### PR TITLE
Add zensical documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/.venv/
 docs/site/
 docs/zensical-public-docs.*
 docs/.zensical-build.*
+.kata.local.toml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 /.roborev/
 /.superpowers/
 /docbank
+
+# docs build
+docs/.venv/
+docs/site/
+docs/zensical-public-docs.*
+docs/.zensical-build.*

--- a/.kata.toml
+++ b/.kata.toml
@@ -1,0 +1,4 @@
+version = 1
+
+[project]
+name = "docbank"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+<!-- BEGIN KATA (managed by `kata init --with-agents`) -->
+## kata issue tracker
+
+This project uses [kata](https://github.com/kenn-io/kata) as its shared issue
+ledger. Run `kata quickstart` at the start of each session for the full agent
+contract. The short version:
+
+- Search before creating: `kata search "<keywords>" --agent`.
+- Prefer updating existing issues over duplicates (`kata comment`, `kata label add`, `kata edit`).
+- Default to `--agent` for ordinary reads and mutations; use `--json` only when a script needs structured data.
+- Close only verified work: `kata close <ref> --done --message "<scope + verification>" --commit <sha>`.
+- If work is incomplete, label `needs-review` and comment what remains rather than closing.
+- Never `kata delete` or `kata purge` without explicit user authorization.
+<!-- END KATA -->

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DEFAULT_GOLANGCI_LINT_CACHE := $(shell git rev-parse --path-format=absolute --gi
 GOLANGCI_LINT_CACHE ?= $(DEFAULT_GOLANGCI_LINT_CACHE)
 export GOLANGCI_LINT_CACHE
 
-.PHONY: build install clean test test-v fmt lint lint-ci tidy install-hooks help
+.PHONY: build install clean test test-v fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve help
 
 build:
 	CGO_ENABLED=1 go build -tags "$(BUILD_TAGS)" -ldflags="$(LDFLAGS)" -o docbank ./cmd/docbank
@@ -60,5 +60,14 @@ install-hooks:
 	fi
 	prek install
 
+docs-install:
+	cd docs && uv sync --frozen
+
+docs-build:
+	cd docs && ./zensical-docs.sh build
+
+docs-serve:
+	cd docs && ./zensical-docs.sh serve
+
 help:
-	@echo "Targets: build install clean test test-v fmt lint lint-ci tidy install-hooks"
+	@echo "Targets: build install clean test test-v fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@
 
 .DEFAULT_GOAL := help
 
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# Tag names are attacker-controlled in CI and VERSION is interpolated into
+# the shell command line of build/install: strip anything outside a strict
+# allowlist rather than trusting git metadata.
+VERSION := $(shell (git describe --tags --always --dirty 2>/dev/null || echo dev) | tr -cd 'A-Za-z0-9._+-')
+ifeq ($(VERSION),)
+VERSION := dev
+endif
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 LDFLAGS := -X go.kenn.io/docbank/cmd/docbank/cmd.Version=$(VERSION) \

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# docbank documentation
+
+This directory holds the [zensical](https://zensical.org) documentation site
+plus internal design material.
+
+## Layout
+
+- `*.md`, `usage/`, `architecture/` — published site content
+- `superpowers/` — internal specs and implementation plans (never published)
+- `zensical.toml` — site configuration
+- `zensical-docs.sh` — build wrapper; copies publishable content into a
+  temporary tree so internal material can't leak into the site
+
+## Building
+
+```bash
+cd docs
+uv sync --frozen          # one-time: installs zensical into docs/.venv
+./zensical-docs.sh serve  # live-reload preview
+./zensical-docs.sh build  # strict production build into docs/site/
+```
+
+Or from the repository root: `make docs-install`, `make docs-serve`,
+`make docs-build`.
+
+## Conventions
+
+- User-facing pages document only what the current binary does. Planned
+  behavior lives in the Design section and is labeled with a
+  `!!! info "Planned — Phase N"` admonition. Do not document flags or
+  endpoints that do not exist yet outside those admonitions.
+- The Design pages are the digested, maintained form of the superpowers
+  specs. When a design decision changes, update the Design page in the same
+  PR; the superpowers documents are point-in-time records and are not
+  edited retroactively.

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -1,0 +1,55 @@
+---
+title: Backup
+description: Verifiable, incremental backups via the shared kit engine.
+---
+
+# Backup
+
+!!! info "Planned — Phase 4"
+    The backup engine itself exists and is battle-tested — it's
+    msgvault's, extracted into `go.kenn.io/kit` precisely so docbank
+    could reuse it — but docbank's wiring (`internal/backupapp` and the
+    `docbank backup` commands) is not yet implemented.
+
+## The engine
+
+docbank reuses `kit/backup` and `kit/pack`: page-diffed SQLite snapshots
+plus only-new content files packed into sealed, verifiable packs.
+Incremental by construction — a snapshot after adding ten documents
+captures ten blobs and the changed database pages, nothing else. The
+repository format, manifest discipline, and verification model are
+documented in msgvault's
+[backup format specification](https://msgvault.io/architecture/backup-format/);
+docbank inherits them wholesale.
+
+The engine is generalized around an application seam (`backup.App`):
+docbank provides freeze (WAL-checkpoint + pinned read transaction),
+content enumeration (every row in `blobs`), stats for the fidelity
+proof (node/blob/tag counts and date range), and exclusions (`logs/`,
+`blobs/tmp/`). Restore materializes `docbank.db` + `blobs/` and proves
+the restored stats byte-match the manifest.
+
+## Commands
+
+Mirroring msgvault:
+
+```
+docbank backup init <repo-path>
+docbank backup create
+docbank backup list
+docbank backup verify [--snapshot <id>]
+docbank backup restore <snapshot> <dest>
+```
+
+A NAS-mounted directory is the expected repo target; any path works.
+
+## Backup reachability ≠ GC reachability
+
+Deliberately, backup captures **every** `blobs` row — including blobs
+that are already GC candidates (for example, after `trash empty` but
+before `gc --run`). A backup taken mid-deletion-pipeline preserves the
+regret window; candidates age out of new snapshots only after GC
+actually reclaims them. The rule composes with
+[editing](editing-and-versions.md) the obvious way: prior versions are
+reachable rows, so backups always include the full edit history that
+exists at snapshot time.

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -1,0 +1,121 @@
+---
+title: Editing & Versions
+description: How docbank supports mutable documents over an immutable blob store — the design that separates it from msgvault.
+---
+
+# Editing & Versions
+
+docbank's defining difference from msgvault is that **documents are
+editable**. A message archive preserves a fixed historical record; a
+document vault manages files you're still working on — the tax
+spreadsheet you update, the contract that goes through drafts, the scan
+you annotate. docbank must let you edit a document in place *without*
+giving up the archive guarantees that justify trusting it with the only
+copy.
+
+The design squares that circle by keeping mutability out of the byte
+layer entirely.
+
+## The model: mutable documents, immutable contents
+
+A document (a file node) is a **named pointer into the content-addressed
+store**. Editing never rewrites bytes; it re-points the node:
+
+1. The new content is ingested like any import: hashed, written durably
+   to `blobs/<aa>/<sha256>`, deduplicated if it already exists.
+2. One transaction records the node's current `(blob_hash, size)` in
+   `node_versions` with a `replaced_at` timestamp, points the node at
+   the new blob, updates `size`/`mime_type`/`modified_at`, and bumps the
+   node's `revision`.
+
+```mermaid
+flowchart LR
+    subgraph node ["node: /taxes/2026/worksheet.xlsx"]
+        HEAD["blob_hash → v3"]
+    end
+    subgraph versions ["node_versions"]
+        V2["v2, replaced 2026-07-01"]
+        V1["v1, replaced 2026-06-14"]
+    end
+    HEAD -.-> B3[("blob c9d2…")]
+    V2 -.-> B2[("blob 81aa…")]
+    V1 -.-> B1[("blob 4f07…")]
+```
+
+Consequences, all inherited rather than engineered:
+
+- **Every edit is a version.** History is nearly free in a CAS — a
+  version costs one metadata row, and unchanged bytes are shared. Ten
+  drafts of a contract that each change one page store ten full blobs
+  only if all ten differ; identical saves deduplicate to nothing.
+- **No torn writes.** The new content is durable before the swap
+  commits, and the swap is atomic. A crash mid-edit leaves the document
+  at the old version with, at worst, an orphan blob for `gc`.
+- **History is protected from GC.** Reachability already includes
+  `node_versions`, so prior contents survive `gc --run` until their
+  version records are explicitly pruned.
+- **Concurrent edits are detectable.** The revision bump is the
+  `If-Match` precondition token in the HTTP API — two agents editing the
+  same document get a `412`, not a lost update.
+
+What versioning is **not**: a diff engine. Versions are whole-content
+snapshots; v1 exposes listing and retrieving them, nothing more. And
+version history is linear per node — restoring an old version creates a
+*new* head version rather than rewinding, so history only grows until
+you prune it.
+
+## Editing surfaces
+
+!!! info "Planned — Phase 2"
+    The version machinery (schema, GC reachability) shipped in Phase 1,
+    but no user-facing editing surface exists yet. The surfaces below
+    are the design commitment; exact flags and shapes land in the CLI
+    reference and OpenAPI spec when they ship.
+
+**CLI.**
+
+```
+docbank versions <path|id>              # list: version, size, replaced_at
+docbank cat <path> --version <n>        # retrieve a prior content
+docbank put <src-file> <path|id>        # replace content from a local file
+docbank revert <path|id> --version <n>  # old content becomes the new head
+docbank edit <path|id>                  # materialize → $EDITOR → save back
+```
+
+`edit` is the ergonomic core: materialize the blob to a temp file, open
+the user's editor (or, with `--app`, the platform default application),
+and on exit re-ingest if the bytes changed. It must handle the
+disciplined case (editor exits after save) and warn on the undisciplined
+one (file unchanged at exit — many GUI apps detach; `put` is the
+fallback).
+
+**HTTP.** `PUT /nodes/{id}/content` with a required
+`If-Match: <revision>` precondition replaces content;
+`GET /nodes/{id}/versions` lists history;
+`GET /nodes/{id}/versions/{n}/content` retrieves it. Agents edit
+documents through exactly the read-modify-write loop the
+[HTTP API](http-api.md) concurrency model is built for.
+
+**TUI (Phase 3).** "Open for editing" — materialize, hand to the default
+app, watch for changes, re-ingest — plus a version list per document.
+
+## Retention
+
+Version history grows monotonically until pruned. v1 keeps everything —
+document edits are low-frequency, human-scale events, and disk is
+cheaper than a lost draft. The design reserves explicit pruning
+(`docbank versions prune --keep <n>` / `--older-than <age>`), which
+deletes `node_versions` rows and thereby releases those blobs to `gc`.
+Automatic retention policy, if it ever exists, will be configuration,
+never a default.
+
+## Why not edit blobs in place?
+
+Rejected because it would forfeit every guarantee at once: dedup breaks
+(the blob's name would no longer be its hash), crash-safety breaks
+(partial in-place writes), history breaks (the old bytes are gone), and
+concurrent readers break (a `cat` streaming during an edit would see a
+tear). The CAS stays append-only; documents mutate one metadata pointer
+at a time. This is also what keeps docbank compatible with the shared
+`kit` backup engine, whose incremental model assumes content files never
+change under it.

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -1,0 +1,95 @@
+---
+title: HTTP API
+description: The agent-first HTTP API design — filesystem-shaped endpoints, revision preconditions, and batch reorganization.
+---
+
+# HTTP API
+
+!!! info "Planned — Phase 2"
+    This page is the design contract for `docbank serve`; none of it is
+    implemented yet. It exists now because the API's ergonomics are a
+    first-class requirement — the design test below is a commitment the
+    implementation will be reviewed against, and the endpoint shapes
+    here become the OpenAPI spec.
+
+**Design test: an agent must be able to do everything the TUI can,
+through the API alone.** Agents are not a secondary interface bolted
+onto a human tool; browsing, retrieving, filing, editing, and
+reorganizing the entire tree must work for a client that only speaks
+HTTP.
+
+## Shape
+
+Served by `docbank serve`, following msgvault's daemon patterns:
+[Huma v2](https://huma.rocks) with a typed OpenAPI contract from day
+one, API-key auth, and a generated client. Endpoints are
+filesystem-shaped:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /nodes/{id}` · `GET /path/{path}` | stat — both return the node with its ID |
+| `GET /nodes/{id}/children` | list a directory, paginated |
+| `GET /nodes/{id}/content` | document bytes |
+| `GET /nodes/{id}/versions` · `GET /nodes/{id}/versions/{n}/content` | edit history |
+| `GET /search?q=…` | FTS + filters (tag, MIME, date, path prefix), paginated |
+| `POST /nodes` | mkdir / multipart upload |
+| `PUT /nodes/{id}/content` | replace content (versioned edit), requires `If-Match` |
+| `PATCH /nodes/{id}` | rename / move / retag, requires `If-Match` |
+| `POST /nodes/{id}/trash` · `POST /nodes/{id}/restore` | soft delete / recover, requires `If-Match` |
+| `POST /batch/move` | bulk reorganization with `dry_run` |
+| `GET /tags` + tag CRUD | tag management |
+
+IDs are canonical everywhere: every response carries them, and mutating
+endpoints address nodes by ID so a rename can't strand a concurrent
+client's reference.
+
+## Concurrency: per-node revisions, `If-Match`
+
+Every node carries a `revision` that bumps on each mutation (directories
+bump when their contents change). All mutating endpoints require
+`If-Match: <revision>`; a stale revision gets `412 Precondition Failed`,
+telling the agent to re-read and retry.
+
+The granularity is deliberate. A global tree ETag would invalidate every
+agent's in-flight work whenever anything anywhere changed; per-node
+revisions scope conflicts to actual contention. SQLite already
+serializes the writes — preconditions exist to catch **lost updates
+across an agent's read-modify-write turns**, not to lock. This is the
+same mechanism that makes concurrent document *editing* safe
+([Editing & Versions](editing-and-versions.md)).
+
+## Batch reorganization
+
+Agent-driven filing is the marquee use case: "reorganize these 400
+inbox scans into the tree." Doing that one `PATCH` at a time is slow and
+can strand a half-applied plan. `POST /batch/move` takes a list of
+`{node_id, new_parent_id, new_name?}` operations and:
+
+- **`dry_run: true`** validates the entire batch — collisions, cycles,
+  missing IDs, stale revisions — and reports per-operation outcomes
+  without applying anything. The agent iterates on its plan against
+  reality before touching the tree.
+- **Execution is all-or-nothing** in one transaction. A batch either
+  fully applies or fully doesn't; there is no partially filed state to
+  reason about.
+
+## Error mapping
+
+The store's typed errors map onto status codes so agents can branch on
+semantics rather than parse messages:
+
+| Store error | HTTP |
+|-------------|------|
+| `ErrNotFound` | 404 |
+| `ErrExists` (name collision) | 409 |
+| `ErrCycle` (move under own descendant) | 409 |
+| `ErrNotDir` / `ErrNotFile` / `ErrInvalidName` | 422 |
+| stale `If-Match` revision | 412 |
+
+## Non-goals
+
+- No server-side rendering or web UI (the API serves programs).
+- No multi-user model: one vault, one key set. Sharing is out of scope
+  for v1.
+- No MCP server in Phase 2 — but the OpenAPI contract is designed to
+  make wrapping one mechanical, post-v1.

--- a/docs/architecture/locking.md
+++ b/docs/architecture/locking.md
@@ -1,0 +1,76 @@
+---
+title: Concurrency & Locking
+description: How concurrent docbank processes coordinate — SQLite for data, an advisory flock for cross-layer operations.
+---
+
+# Concurrency & Locking
+
+Two layers coordinate concurrent access: SQLite serializes all metadata
+writes, and an advisory file lock serializes the few operations that
+span the database *and* the blob directory.
+
+## What SQLite handles
+
+Every tree mutation is one transaction; the store opens the database in
+WAL mode with `BEGIN IMMEDIATE` write transactions and a busy timeout.
+Concurrent imports, moves, and trash operations from multiple processes
+interleave safely — invariants are enforced by the schema, and losers of
+a name race get a typed `name already exists` error, not corruption.
+
+## What SQLite can't handle
+
+Garbage collection reads the database ("which blobs are unreachable?"),
+then deletes files from `blobs/`. Between those two steps, a concurrent
+import could ingest the same content, observe the blob file still
+present, deduplicate against it — and then GC deletes the file out from
+under a freshly committed reference. No database transaction can close
+that window, because half of it lives on the filesystem.
+
+The same shape recurs at startup: clearing stale `blobs/tmp/` files must
+not delete a temp file another process is actively writing.
+
+## The vault lock
+
+`~/.docbank/vault.lock` is an advisory `flock(2)`:
+
+| Holder | Mode | Held for |
+|--------|------|----------|
+| Every normal command | **shared** | the life of the command |
+| `docbank gc` | **exclusive** | the whole collection |
+| startup tmp cleanup | momentary **exclusive** (non-blocking attempt) | the cleanup only |
+
+Normal commands coexist; `gc` waits for them to finish and blocks new
+ones while it runs, which makes its query-then-delete sequence
+atomic *with respect to other docbank processes*. Startup cleanup tries
+a non-blocking upgrade to exclusive: success proves this is the only
+live process, so stale temp files can be removed; failure (any other
+holder) skips cleanup and lets a later sole process or `gc` handle it.
+
+Two implementation details worth recording:
+
+- **Failed upgrades must reacquire.** On Linux, flock lock conversion is
+  release-then-acquire, so a failed non-blocking upgrade can silently
+  drop the shared lock. The lock wrapper reacquires shared before
+  reporting failure — otherwise a command would keep running convinced
+  it holds the vault while holding nothing.
+- **Unix only, explicitly.** The lock is the one platform-specific piece
+  of docbank. It's compiled under a `unix` build tag with a stub
+  elsewhere that fails at vault open with a clear unsupported-platform
+  error, rather than an undefined-symbol build break.
+
+## First-open bootstrap
+
+Creating a fresh vault has its own race: SQLite's WAL-mode conversion
+and autocommit DDL both acquire locks in ways that can fail immediately
+*without* consulting the busy handler when two processes race first
+contact. The store applies the schema and creates the root inside one
+`BEGIN IMMEDIATE` transaction and retries `SQLITE_BUSY` with a bounded
+backoff; every statement is idempotent, so whichever process wins, both
+converge on the same initialized vault.
+
+## Guidance for other layers
+
+The daemon (Phase 2) is just another vault-lock participant: API
+mutations take the shared lock like CLI commands, and scheduled GC takes
+exclusive. Nothing about the model assumes a single resident process —
+which is precisely why a CLI invoked while the daemon runs stays safe.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,93 @@
+---
+title: Design Overview
+description: The virtual tree over content-addressed storage, and how the components fit together.
+---
+
+# Design Overview
+
+docbank separates **what a document is** from **where it lives and what
+it's called**. Bytes go into an immutable content-addressed store;
+identity, naming, hierarchy, versions, and history live in SQLite. Every
+higher layer — CLI today; daemon, HTTP API, and TUI later — goes through
+the same store package, so no surface has privileged operations.
+
+```mermaid
+flowchart TD
+    CLI["CLI (Phase 1)"] --> STORE
+    API["HTTP API (Phase 2)"] --> STORE
+    TUI["TUI (Phase 3)"] --> STORE
+    subgraph vault ["~/.docbank"]
+        STORE["store: SQLite virtual tree<br/>nodes · versions · provenance · FTS"]
+        BLOBS["blob store: blobs/&lt;aa&gt;/&lt;sha256&gt;<br/>immutable, deduplicated"]
+    end
+    STORE -. "references by hash" .-> BLOBS
+    INGEST["ingest pipeline"] --> STORE
+    INGEST --> BLOBS
+    CLI --> INGEST
+    API --> INGEST
+```
+
+## The two-layer split
+
+**Blobs are immutable.** A blob's name is the SHA-256 of its content;
+two ingested copies of the same file are one blob. Blobs are written
+durably (temp file → fsync → rename → directory fsync) *before* any
+database row references them, so a committed reference always points at
+real bytes. Blobs are never modified — "editing" a document means
+writing a new blob (see
+[Editing & Versions](editing-and-versions.md)).
+
+**The tree is mutable, transactionally.** Nodes (directories and files)
+form the hierarchy users see. Moves, renames, trash, restore, and
+content replacement are single SQLite transactions over metadata. The
+store enforces the tree invariants — single root, live-sibling name
+uniqueness, no cycles, validated NFC-normalized names — mostly *in the
+schema itself* (partial unique indexes, CHECK constraints), so they hold
+against every future writer, not just today's code paths.
+
+This split is what makes docbank cheap to reorganize (moving a folder of
+scans is a metadata transaction) and safe to deduplicate (identity is
+content, so re-imports converge instead of duplicating).
+
+## Contrast with msgvault
+
+msgvault archives an immutable historical record: a message, once
+synced, never changes. docbank manages **living documents** — the whole
+point is that you keep renaming, refiling, and editing them. The designs
+share the storage discipline (content-addressed bytes, SQLite metadata,
+the same durability rules, and the same backup engine from
+`go.kenn.io/kit`), but they diverge on mutability:
+
+| | msgvault | docbank |
+|---|---|---|
+| Content contract | Immutable once archived | Editable; every edit is versioned |
+| Organizing structure | Fixed (accounts, folders, threads from source) | Free-form virtual tree, user- and agent-reorganized |
+| Deletion | Staged deletion *from the source* (Gmail) | Trash → empty → GC pipeline inside the vault |
+| History | The archive *is* the history | `node_versions` chain per document |
+
+## Component responsibilities
+
+- **`internal/store`** — SQLite schema and every tree operation. Typed
+  sentinel errors (`ErrNotFound`, `ErrExists`, `ErrCycle`, …) that the
+  CLI prints and the future API maps to HTTP status codes.
+- **`internal/blob`** — content-addressed file store with the fsync
+  discipline; knows nothing about the tree.
+- **`internal/ingest`** — the single import pipeline all entry points
+  share (CLI now; watcher and HTTP upload later): hash → durable blob →
+  one metadata transaction per file.
+- **`internal/home`** — vault directory layout and the inter-process
+  advisory lock ([Concurrency & Locking](locking.md)).
+- **`cmd/docbank`** — thin cobra commands; no business logic.
+
+## Build phases
+
+Each phase ships independently useful software; the
+[Roadmap](../roadmap.md) tracks status.
+
+0. **Extraction** — msgvault's pack/backup engine generalized into
+   `go.kenn.io/kit` (shared with docbank). Done, pending final merge.
+1. **Core** — store, ingest, full CLI. **Implemented.**
+2. **Daemon + API** — `serve`, HTTP API, watched inboxes, text
+   extraction, editing commands.
+3. **TUI** — Bubble Tea file browser over the same store.
+4. **Backup** — the kit backup engine wired to docbank's schema.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,0 +1,115 @@
+---
+title: Storage
+description: The SQLite schema, blob store layout, durability discipline, and enforced invariants.
+---
+
+# Storage
+
+Everything lives under `~/.docbank/`: one SQLite database and one blob
+directory. The pair is the archive — copy both and you've moved the
+vault; `docbank verify` proves the copy is intact.
+
+## Blob store
+
+```
+blobs/
+├── tmp/                      # in-flight writes
+└── <aa>/<sha256>             # aa = first two hex chars of the hash
+```
+
+One file per unique content, named by its SHA-256, sharded by the first
+byte to keep directories small. Blobs are immutable and deduplicated by
+construction: writing content that already exists is a no-op success.
+
+**Durability discipline.** Every write streams to `blobs/tmp/`, fsyncs
+the file, renames it into place, then fsyncs the shard directory (using
+`go.kenn.io/kit/pack`'s synced-directory helpers) — including on the
+deduplication fast path, so a reference is never handed out for a
+directory entry that could vanish on power loss. The database
+transaction that references a blob commits only after the blob is
+durable. A crash between the two leaves an *orphan blob*: harmless,
+invisible, reclaimed by `gc`.
+
+Stale `tmp/` files from interrupted writes are cleaned at startup — but
+only when no other docbank process holds the vault (see
+[Concurrency & Locking](locking.md)).
+
+## Database schema
+
+Core tables (`internal/store/schema.sql`):
+
+```sql
+nodes (
+    id            INTEGER PRIMARY KEY,
+    parent_id     INTEGER REFERENCES nodes(id) ON DELETE CASCADE,
+    name          TEXT NOT NULL,
+    kind          TEXT NOT NULL,          -- 'dir' | 'file'
+    blob_hash     TEXT REFERENCES blobs(hash),   -- files only
+    size          INTEGER,
+    mime_type     TEXT,
+    revision      INTEGER NOT NULL DEFAULT 1,
+    created_at    TEXT NOT NULL,
+    modified_at   TEXT NOT NULL,
+    trashed_at    TEXT,                   -- NULL = live
+    trash_parent  INTEGER,                -- original location, for restore
+    trash_name    TEXT
+)
+blobs          (hash PRIMARY KEY, size, created_at)
+node_versions  (node_id, blob_hash, size, replaced_at)   -- prior contents
+ingests        (id, started_at, source_kind, source_desc)
+provenance     (node_id, ingest_id, original_path, original_mtime)
+tags           (id, name UNIQUE)          -- schema present; surfaces later
+node_tags      (node_id, tag_id)
+extracted_text (blob_hash, extractor, extractor_version, status,
+                error, attempts, text, extracted_at)      -- Phase 2 workers
+nodes_fts      -- FTS5 external-content index over live node names
+```
+
+## Invariants enforced in the schema
+
+The important rules hold at the SQL layer, so they bind every writer:
+
+- **Exactly one root.** SQLite treats NULLs as distinct in unique
+  indexes, so a partial unique index on a constant expression does it:
+  `CREATE UNIQUE INDEX one_root ON nodes((1)) WHERE parent_id IS NULL`.
+- **Live-sibling name uniqueness.**
+  `UNIQUE(parent_id, name) WHERE trashed_at IS NULL` — trashed nodes
+  never block a name.
+- **Kind/content consistency.** A CHECK constraint ties
+  `kind = 'file'` to `blob_hash IS NOT NULL` and directories to NULL.
+- **Referential integrity.** `blob_hash` references `blobs`; a blob row
+  can't be deleted while anything points at it, which is what makes GC's
+  reachability query trustworthy.
+
+The store layer adds the rules SQL can't express: name validation
+(reject empty, `.`, `..`, `/`, NUL) with Unicode NFC normalization,
+cycle prevention on moves (ancestry walk inside the move transaction),
+revision bumps on every mutation, and size consistency between a node
+and its blob row.
+
+## Timestamps and identity
+
+- All timestamps are UTC RFC 3339 text.
+- **Node IDs are canonical**; paths are derived for display. Every CLI
+  listing includes IDs, and ID-based operations (`restore`) survive any
+  amount of renaming.
+
+## Trash representation
+
+Trashing stamps `trashed_at` on the whole subtree in one transaction and
+records `trash_parent`/`trash_name` on the trash root so restore can put
+it back. The trash root is reparented under `/` at trash time: since
+`parent_id` cascades on delete, this keeps an independently-trashed
+subtree alive even if its original parent is later permanently deleted.
+All nodes trashed in one operation share the same `trashed_at` stamp,
+which is how `trash list` distinguishes trash roots from members of a
+trashed subtree.
+
+## Concurrent first-open
+
+The schema is applied and the root node created inside a single
+`BEGIN IMMEDIATE` transaction with a bounded busy-retry. Two processes
+racing to create the same fresh vault serialize instead of tripping over
+SQLite's WAL-conversion and DDL lock upgrades, and both arrive at the
+same single root (the root insert is an atomic
+`INSERT ... SELECT ... WHERE NOT EXISTS`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,20 @@
+---
+title: Changelog
+description: Release history.
+---
+
+# Changelog
+
+docbank is pre-release; nothing has been versioned or announced yet.
+
+## Unreleased
+
+Phase 1 (Core) complete:
+
+- Virtual tree store (SQLite, FTS5) with schema-enforced invariants
+- Content-addressed blob store with durable write discipline
+- Idempotent recursive import with collision suffixing and provenance
+- Full core CLI: `add`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`,
+  `search`, `trash list|empty`, `gc`, `verify`
+- Trash → empty → GC deletion pipeline with `verify` integrity checking
+- Inter-process vault locking (shared for commands, exclusive for `gc`)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,212 @@
+---
+title: CLI Reference
+description: Every docbank command, flag, output format, and error behavior.
+---
+
+# CLI Reference
+
+All commands operate on the vault at `~/.docbank` (override with
+`DOCBANK_HOME`; see [Configuration](configuration.md)). Errors go to
+stderr and produce a non-zero exit code. Virtual paths are absolute,
+`/`-separated, and case-sensitive.
+
+Commands hold a shared inter-process lock while running, so concurrent
+docbank invocations are safe; `gc` takes the lock exclusively and briefly
+blocks other commands. See
+[Concurrency & Locking](architecture/locking.md).
+
+## docbank add
+
+```
+docbank add <path>... [--dest <virtual-dir>]
+```
+
+Imports files or directory trees into the vault. Sources are copied,
+never modified or deleted.
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--dest` | `/inbox` | Virtual destination directory; created (with parents) if missing |
+
+- A directory argument imports recursively: its basename becomes a
+  directory under `--dest` and relative structure is preserved.
+- Symlinks and other non-regular files are skipped and reported as
+  failures; they do not abort the run.
+- Name collisions with different content auto-suffix:
+  `report.pdf` → `report (2).pdf`.
+- Re-running an import converges: a file whose content already exists
+  under any candidate name in the destination is skipped, so an
+  interrupted bulk import can simply be re-run. See
+  [Importing Documents](usage/importing.md).
+
+Output is a one-line summary plus one stderr line per failed file:
+
+```
+added: 12  skipped: 3  failed: 1
+failed: /src/broken.pdf: opening /src/broken.pdf: permission denied
+```
+
+Exit is non-zero if any file failed. A missing or unreadable top-level
+source argument aborts the run with an error (per-file failures inside a
+directory tree do not).
+
+## docbank ls
+
+```
+docbank ls [path]
+```
+
+Lists a virtual directory (default `/`). Columns: `ID`, `KIND`
+(`dir`/`file`), `SIZE` (bytes; 0 for directories), `MODIFIED` (UTC,
+RFC 3339), `NAME`. Fails with `not a directory` when the path names a
+file.
+
+## docbank tree
+
+```
+docbank tree [path]
+```
+
+Prints the subtree rooted at `path` (default `/`), two-space indented,
+each entry suffixed with its node ID in brackets. Fails without output if
+`path` names a file.
+
+## docbank cat
+
+```
+docbank cat <path>
+```
+
+Streams the file's stored bytes to stdout. Fails with `not a file` for
+directories.
+
+## docbank mv
+
+```
+docbank mv <src-path> <dest-path>
+```
+
+Moves or renames a node. Metadata only — bytes never move. The
+destination is interpreted like POSIX `mv`:
+
+- If `dest-path` names an existing directory, the source moves **into**
+  it, keeping its name.
+- Otherwise `dest-path`'s parent must exist, and its basename becomes
+  the new name (rename, or move-and-rename).
+- If `dest-path` names an existing **file**, the move fails with
+  `name already exists` — docbank never overwrites.
+
+Directory moves carry the whole subtree. A move that would place a
+directory under its own descendant fails with `move would create a
+cycle`. On success prints `moved [<id>] <new-path>`.
+
+## docbank rm
+
+```
+docbank rm <path>
+```
+
+Soft-deletes: moves the node — and, for a directory, its entire subtree —
+to the trash. Nothing is permanently removed and no bytes are reclaimed.
+The freed name is immediately reusable. Prints:
+
+```
+trashed [15] /taxes/2024/return.pdf (restore with: docbank restore 15)
+```
+
+## docbank restore
+
+```
+docbank restore <id>
+```
+
+Returns a trashed node (by ID — see `docbank trash list`) to its original
+location, re-suffixing its name if a live node now occupies it. If the
+original parent directory was itself permanently deleted, the node is
+restored under `/`. Prints `restored [<id>] <path>`.
+
+## docbank search
+
+```
+docbank search <query>...
+```
+
+Full-text search over live node names (FTS5). Every whitespace-separated
+term is matched as a prefix; FTS operator syntax in the query is escaped,
+not interpreted. Results are ranked best-first (BM25, ties broken by
+name) and capped at 50. Output columns are `ID` and `PATH`; no matches
+prints `no matches`.
+
+!!! info "Planned — Phase 2"
+    Search currently covers node names only. Extracted document text
+    (PDF text layers, office formats) joins the index when the extraction
+    workers land. See [Searching](usage/searching.md).
+
+## docbank trash
+
+```
+docbank trash list
+docbank trash empty [--older-than <age>]
+```
+
+`list` shows restorable trashed nodes: `ID`, `TRASHED AT`, `NAME`. Only
+trash roots are listed — trashing a directory produces one entry, and
+restoring it brings the whole subtree back.
+
+`empty` permanently deletes trashed nodes; their blobs become `gc`
+candidates unless referenced elsewhere. `--older-than` accepts Go
+durations (`12h`, `30m`) plus a day suffix (`30d`); negative ages are
+rejected. Without the flag, everything in the trash is deleted. Prints
+`deleted <n> trashed node(s)`.
+
+## docbank gc
+
+```
+docbank gc [--run]
+```
+
+Garbage-collects unreachable blobs — content referenced by no live node,
+no trashed node, and no recorded prior version. Dry-run by default:
+
+```
+3 candidate blob(s), 1204882 byte(s) reclaimable
+dry run — pass --run to delete
+```
+
+With `--run`, blob files are deleted first, then their metadata rows;
+prints `reclaimed <n> blob(s), <bytes> byte(s)`. A crash mid-GC leaves
+rows without files, which the next `gc --run` reconciles and `verify`
+reports in the meantime. `gc` holds the vault lock exclusively, so it
+never races a concurrent import.
+
+## docbank verify
+
+```
+docbank verify
+```
+
+Re-hashes every stored blob against its recorded SHA-256. Reports one
+line per problem — `missing: <hash>` (row without file),
+`corrupt: <hash>` (hash mismatch), or `unreadable: <hash>` (I/O error) —
+then a summary `<n> blob(s) ok, <n> problem(s)`. Exits non-zero if any
+problem was found.
+
+## docbank version
+
+```
+docbank --version
+```
+
+Prints the build version and commit (`dev (unknown)` for untagged local
+builds; release builds inject both via `-ldflags`).
+
+## Planned commands
+
+!!! info "Planned — later phases"
+    The following are designed but not yet implemented; they will appear
+    here with exact semantics when they ship. `docbank edit` and
+    `docbank versions` (Phase 2, [Editing & Versions](architecture/editing-and-versions.md));
+    `docbank serve` and `docbank extract` (Phase 2,
+    [HTTP API](architecture/http-api.md)); `docbank tui` (Phase 3);
+    `docbank backup init|create|list|verify|restore` (Phase 4,
+    [Backup](architecture/backup.md)).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,48 @@
+---
+title: Configuration
+description: Vault location, data layout, and environment variables.
+---
+
+# Configuration
+
+Phase 1 needs no configuration file. The only knob is where the vault
+lives.
+
+## Vault location
+
+All data defaults to `~/.docbank/`. Override with the `DOCBANK_HOME`
+environment variable:
+
+```bash
+export DOCBANK_HOME=/Volumes/Archive/docbank
+```
+
+The directory layout is created on first use:
+
+```
+~/.docbank/
+├── docbank.db           # SQLite: virtual tree, metadata, FTS index
+├── blobs/
+│   ├── <aa>/<sha256>    # content-addressed document bytes
+│   └── tmp/             # staging for in-flight writes
+├── logs/                # reserved for the daemon (Phase 2)
+└── vault.lock           # advisory inter-process lock
+```
+
+`docbank.db` and `blobs/` together are the archive; back up both. The
+database references blobs by hash, so restoring a copied
+`docbank.db` + `blobs/` pair onto any machine yields a working vault —
+`docbank verify` proves the pair is consistent.
+
+!!! warning
+    Don't edit or prune `blobs/` by hand. Blob files are referenced by
+    the database (including as prior document versions); use
+    `docbank trash empty` and `docbank gc --run` to reclaim space, and
+    `docbank verify` to check integrity.
+
+## Planned configuration
+
+!!! info "Planned — Phase 2"
+    The daemon introduces `~/.docbank/config.toml` for watched-inbox
+    directories, the API listen address and keys, and extraction worker
+    settings. The file is optional; the CLI keeps working without it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,69 @@
+---
+title: docbank
+description: Personal document archive with a virtual tree over content-addressed storage, full-text search, trash and recovery, versioned editing, and an agent-first HTTP API.
+---
+
+# docbank
+
+Own the documents that accumulate over a lifetime — PDFs, scans, text
+files, spreadsheets, images — in one durable, searchable, reorganizable
+vault.
+
+docbank is the third member of a family of personal data tools alongside
+[msgvault](https://msgvault.io) (communications archive) and fotobank
+(photo/video archive). Where msgvault preserves an immutable historical
+record of your messages, docbank manages **living documents**: files you
+still rename, refile, and edit.
+
+## How it works
+
+The vault owns the bytes. Documents are ingested into content-addressed
+storage (one blob per unique content, named by its SHA-256), and the
+organizing structure is a **virtual tree stored in SQLite**. Moves,
+renames, and reorganization are metadata transactions that never touch
+bytes. Editing a document writes a new blob and keeps the old one as a
+prior version — contents are versioned by construction.
+
+```
+docbank add ~/Documents/taxes --dest /taxes   # bulk import, resumable
+docbank tree /taxes                           # browse the virtual tree
+docbank search "insurance"                    # full-text search
+docbank mv "/inbox/scan (2).pdf" /taxes/2026  # reorganize, metadata only
+docbank rm /inbox/junk.pdf                    # trash, recoverable
+docbank gc --run                              # reclaim unreferenced bytes
+docbank verify                                # prove the bytes are intact
+```
+
+## Principles
+
+- **Never lose a byte.** Blob writes are durable (fsync discipline) before
+  the database ever references them. Deletion is soft; nothing is
+  reclaimed except by an explicit `gc --run`. `verify` re-hashes
+  everything on demand.
+- **Ingest never touches sources.** Importing copies; it never deletes or
+  modifies the original files.
+- **IDs are canonical, paths are convenience.** Every listing shows node
+  IDs; trash recovery and (in future) the HTTP API operate on IDs so
+  renames can't strand a reference.
+- **Agents are first-class.** The planned HTTP API exposes everything the
+  CLI and TUI can do, with optimistic-concurrency preconditions designed
+  for agent read-modify-write loops. See [HTTP API](architecture/http-api.md).
+- **Documents are mutable, history is not.** Editing replaces a node's
+  content and records the prior version; old blobs remain retrievable
+  until you garbage-collect them. See
+  [Editing & Versions](architecture/editing-and-versions.md).
+
+## Status
+
+docbank is pre-release. Phase 1 (store, ingest pipeline, and the full
+core CLI) is implemented and tested; the daemon, HTTP API, editing
+commands, TUI, and backup are designed but not yet built. The
+[Roadmap](roadmap.md) tracks what exists versus what is planned, and every
+page in this documentation marks planned behavior explicitly.
+
+## Where to go next
+
+- [Setup](setup.md) — build and install the binary
+- [Quickstart](quickstart.md) — a ten-minute tour of the CLI
+- [CLI Reference](cli-reference.md) — every command, flag, and output format
+- [Design → Overview](architecture/overview.md) — how the pieces fit together

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "docbank-docs"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+  "zensical==0.0.45",
+]
+
+[tool.uv]
+package = false

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,145 @@
+---
+title: Quickstart
+description: A ten-minute tour of the docbank CLI.
+---
+
+# Quickstart
+
+This walkthrough exercises every core command against a scratch vault.
+Point `DOCBANK_HOME` at a temporary directory so you can experiment
+freely:
+
+```bash
+export DOCBANK_HOME=$(mktemp -d)
+```
+
+## Import some documents
+
+`add` copies files into the vault. Sources are never modified or deleted.
+
+```bash
+docbank add ~/Documents/taxes --dest /taxes
+```
+
+```
+added: 214  skipped: 0  failed: 0
+```
+
+Directories import recursively: the directory's own name becomes a
+folder under `--dest`, and the relative structure underneath is
+preserved. Without `--dest`, files land in `/inbox`.
+
+Re-running the same import is safe — already-imported files (matched by
+content, not name) are skipped:
+
+```
+added: 0  skipped: 214  failed: 0
+```
+
+## Browse the tree
+
+```bash
+docbank ls /taxes
+```
+
+```
+ID   KIND  SIZE    MODIFIED                        NAME
+14   dir   0       2026-07-06T21:14:03.2211Z       2024
+102  dir   0       2026-07-06T21:14:05.9871Z       2025
+231  file  48211   2026-07-06T21:14:08.1298Z       checklist.pdf
+```
+
+`tree` prints the whole hierarchy with node IDs:
+
+```bash
+docbank tree /taxes
+```
+
+```
+/taxes
+  2024  [14]
+    return.pdf  [15]
+  2025  [102]
+    return.pdf  [103]
+  checklist.pdf  [231]
+```
+
+`cat` streams a file's bytes to stdout:
+
+```bash
+docbank cat /taxes/checklist.pdf > /tmp/checklist.pdf
+```
+
+## Reorganize
+
+Moves and renames are metadata-only; the stored bytes never move.
+
+```bash
+# Rename in place (destination doesn't exist; its parent does)
+docbank mv /taxes/checklist.pdf /taxes/filing-checklist.pdf
+
+# Move into an existing directory, keeping the name
+docbank mv /taxes/filing-checklist.pdf /taxes/2025
+```
+
+```
+moved [231] /taxes/2025/filing-checklist.pdf
+```
+
+## Search
+
+Names are indexed with SQLite FTS5; every term is a prefix match:
+
+```bash
+docbank search tax check
+```
+
+```
+ID   PATH
+231  /taxes/2025/filing-checklist.pdf
+```
+
+## Trash and recovery
+
+`rm` is soft deletion — the node (and its subtree, for directories) moves
+to the trash and its name becomes reusable:
+
+```bash
+docbank rm /taxes/2024/return.pdf
+```
+
+```
+trashed [15] /taxes/2024/return.pdf (restore with: docbank restore 15)
+```
+
+```bash
+docbank trash list        # what's recoverable
+docbank restore 15        # put it back where it was
+docbank trash empty --older-than 30d   # permanently delete old trash
+```
+
+## Reclaim and verify
+
+Emptying the trash deletes tree entries, but the underlying bytes remain
+until you garbage-collect. `gc` is a dry run by default:
+
+```bash
+docbank gc
+```
+
+```
+3 candidate blob(s), 1204882 byte(s) reclaimable
+dry run — pass --run to delete
+```
+
+```bash
+docbank gc --run
+docbank verify            # re-hash every stored blob
+```
+
+```
+211 blob(s) ok, 0 problem(s)
+```
+
+That's the complete Phase 1 surface. See the
+[CLI Reference](cli-reference.md) for exact semantics of every command.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,65 @@
+---
+title: Roadmap
+description: What is implemented today and what each phase adds.
+---
+
+# Roadmap
+
+docbank ships in phases, each independently useful. This page is the
+authoritative record of what exists versus what is designed — anything
+marked planned appears elsewhere in these docs only under an explicit
+"Planned" admonition.
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| 0 | Extract msgvault's pack/backup engine into `go.kenn.io/kit` | Done; final upstream merge in progress |
+| 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
+| 2 | Daemon: `serve` + HTTP API, watched inboxes, text extraction, editing commands | Designed |
+| 3 | TUI file browser | Designed |
+| 4 | Backup commands over the kit engine | Designed |
+
+## Implemented (Phase 1)
+
+- Virtual tree store with schema-enforced invariants (single root,
+  live-sibling name uniqueness, no cycles, NFC name normalization,
+  revision bumps)
+- Content-addressed blob store with full fsync durability discipline
+- Idempotent, resumable bulk import with collision suffixing and
+  provenance
+- FTS5 name search, ranked and operator-safe
+- Trash / restore / `trash empty` with the three-stage deletion pipeline
+- `gc` (dry-run default) and `verify`
+- Inter-process vault locking (shared/exclusive flock)
+- CLI: `add`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`, `search`,
+  `trash`, `gc`, `verify`
+
+## Phase 2 — Daemon + API + Editing
+
+- `docbank serve`: Huma v2 HTTP API with typed OpenAPI contract,
+  API-key auth, generated client ([design](architecture/http-api.md))
+- Editing surfaces: `PUT` content, `docbank edit`/`put`/`revert`, and
+  `versions` listing ([design](architecture/editing-and-versions.md))
+- Watched inbox directories with a stability window, landing imports
+  under `/inbox/<date>/`
+- Text extraction workers (PDF text layer, plain text/markdown, office
+  formats) feeding content search
+- Tags surfaced in CLI, search filters, and the API
+- `config.toml` for daemon settings
+
+## Phase 3 — TUI
+
+Bubble Tea file manager over the same store: navigate, search, rename,
+move, trash/restore, version list, open-in-default-app. No privileged
+operations — anything the TUI does, the API can do.
+
+## Phase 4 — Backup
+
+`docbank backup init|create|list|verify|restore` against the kit engine
+([design](architecture/backup.md)).
+
+## Deferred beyond v1
+
+OCR of scans, embeddings/AI tagging, a web UI, at-rest encryption of the
+live store (encrypted *backups* come free with the pack layer),
+importing attachments out of msgvault, multi-user/sharing, and an MCP
+server wrapping the API.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,57 @@
+---
+title: Setup
+description: Build docbank from source and initialize the vault.
+---
+
+# Setup
+
+docbank is pre-release: there are no binary releases yet, so you build
+from source.
+
+## Requirements
+
+- Go (latest stable) with CGO enabled — the store uses
+  [mattn/go-sqlite3](https://github.com/mattn/go-sqlite3)
+- A C compiler (Xcode command-line tools on macOS, `gcc`/`clang` on Linux)
+- macOS or Linux. docbank requires a Unix-like OS: vault locking uses
+  `flock(2)`, and there is no Windows port.
+
+## Build and install
+
+```bash
+git clone https://github.com/kenn-io/docbank.git
+cd docbank
+make build      # builds ./docbank
+make install    # installs to ~/.local/bin (or GOPATH/bin)
+```
+
+The SQLite full-text index requires the `fts5` build tag; the Makefile
+targets set it for you. If you invoke `go` directly, pass it yourself:
+
+```bash
+go build -tags fts5 ./cmd/docbank
+go test -tags fts5 ./...
+```
+
+## First run
+
+There is no init step. The first command you run creates the vault layout
+under `~/.docbank/` (database, blob directory, lock file):
+
+```bash
+docbank add ~/Desktop/some-document.pdf
+docbank ls /inbox
+```
+
+Set `DOCBANK_HOME` to keep the vault somewhere else — see
+[Configuration](configuration.md).
+
+## Verifying the toolchain
+
+```bash
+make test    # full test suite
+make lint    # golangci-lint
+```
+
+Both must pass cleanly on a supported platform. If `go test` fails with
+`undefined: ...fts5...` errors, the `fts5` tag is missing.

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -1,0 +1,88 @@
+---
+title: Importing Documents
+description: Bulk import semantics — recursion, idempotency, collision suffixing, and failure handling.
+---
+
+# Importing Documents
+
+`docbank add` is the bulk-migration path for decades of accumulated
+`Documents/`, Dropbox, and old-drive trees. It is designed to be run
+repeatedly against the same sources without ever duplicating a document
+or touching the originals.
+
+## What an import does
+
+For each regular file:
+
+1. The content is hashed (SHA-256, streaming) and written to the blob
+   store — durably, before any database row references it. Content that
+   already exists in the vault is not written twice.
+2. One database transaction creates the tree node, records the blob, and
+   captures provenance: the original filesystem path and modification
+   time survive any later renames or moves.
+
+Directory arguments walk recursively. The directory's basename becomes a
+folder under `--dest`, and everything below keeps its relative structure:
+
+```bash
+docbank add ~/old-laptop/Documents --dest /archive
+# → /archive/Documents/... mirrors the source tree
+```
+
+Trailing slashes and `./`-style paths are normalized; `add docs/` and
+`add ./docs` behave identically to `add docs`.
+
+## Idempotency: safe to re-run
+
+Interrupted a 200,000-file import? Run the same command again. For each
+source file, docbank walks the candidate names in the destination
+directory — `report.pdf`, `report (2).pdf`, `report (3).pdf`, … — and:
+
+- if any live candidate has the **same content**, the file is counted as
+  `skipped` (already imported, even if a prior run imported it under a
+  suffix);
+- if all existing candidates have different content, the next free
+  suffix is used;
+- otherwise the first free candidate name is taken.
+
+Re-runs therefore converge instead of duplicating. Identity is content,
+not filename: the same bytes under two source names import as two nodes
+sharing one stored blob.
+
+## Collisions
+
+Two different files arriving at the same virtual name don't conflict —
+the newcomer is suffixed (`scan.pdf` → `scan (2).pdf`). The provenance
+record preserves where each one actually came from.
+
+## Failures don't abort the batch
+
+Unreadable files, permission errors, and non-regular files (symlinks,
+sockets, devices) are recorded and reported at the end; the rest of the
+import continues. A directory that can't be created in the tree (for
+example, its virtual path collides with an existing file) skips that
+subtree and continues with the next.
+
+```
+added: 4211  skipped: 12  failed: 2
+failed: /src/broken.pdf: opening /src/broken.pdf: permission denied
+failed: /src/link.pdf: not a regular file or directory (symlinks are skipped)
+```
+
+The exit code is non-zero when any file failed, so scripted migrations
+can detect partial imports. One exception: a top-level source argument
+that doesn't exist aborts immediately — that's a typo, not a corrupt
+file.
+
+## Sources are read-only
+
+Import never deletes or modifies source files. Delete originals yourself
+once `docbank verify` and your own spot-checks satisfy you — the same
+archive-first, delete-later posture msgvault takes with mailboxes.
+
+!!! info "Planned — Phase 2"
+    **Watched inboxes**: the daemon will watch configured directories
+    (scanner output, a "To File" folder) and import files automatically
+    once they've been stable for a settle period, landing under
+    `/inbox/<date>/` for later filing. **HTTP upload** arrives with the
+    [HTTP API](../architecture/http-api.md).

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -1,0 +1,67 @@
+---
+title: Organizing the Tree
+description: Browsing, moving, and renaming in the virtual tree.
+---
+
+# Organizing the Tree
+
+The folder structure you see in `ls` and `tree` is virtual — rows in
+SQLite, not directories on disk. That makes reorganization instant and
+transactional no matter how large the files are: moving a 4 GB scan
+archive is one metadata update.
+
+## Browsing
+
+```bash
+docbank ls /taxes          # one directory, with IDs, sizes, timestamps
+docbank tree /taxes        # whole subtree, indented, IDs in brackets
+docbank cat /taxes/w2.pdf  # stream file bytes to stdout
+```
+
+Node IDs appear everywhere deliberately: IDs are the canonical way to
+refer to a document. Paths change when you reorganize; IDs never do.
+Today the CLI uses IDs for trash recovery (`docbank restore <id>`); the
+planned HTTP API is ID-first throughout.
+
+## Moving and renaming
+
+`docbank mv` follows POSIX `mv` intuition:
+
+```bash
+docbank mv /inbox/scan.pdf /taxes/2026          # /taxes/2026 is a dir → move into it
+docbank mv /taxes/2026/scan.pdf /taxes/2026/w2.pdf   # dest doesn't exist → rename
+docbank mv /inbox/receipts /archive             # directories move with their subtree
+```
+
+Rules the store enforces, atomically, per move:
+
+- **No overwrites.** Moving onto an existing live file or directory name
+  fails with `name already exists`. Rename or trash the occupant first.
+- **No cycles.** A directory cannot move under its own descendant.
+- **Names are validated.** Empty, `.`, `..`, and names containing `/` or
+  NUL are rejected. Names are Unicode-normalized (NFC) so visually
+  identical names can't coexist, and compared case-sensitively.
+
+A move bumps the node's revision and both affected directories' — that's
+the change-detection signal the HTTP API's `If-Match` preconditions use.
+
+## Trashed names don't block
+
+Sibling-name uniqueness applies to **live** nodes only. After
+`docbank rm /inbox/draft.pdf` you can immediately import or move a new
+`draft.pdf` into `/inbox`; the trashed one remains restorable (it gets a
+suffix if its old name is occupied at restore time).
+
+## Tips for bulk reorganization
+
+- `tree` output includes IDs, so you can script against stable
+  references while shuffling paths.
+- Every `mv` is its own transaction: a failed move in a scripted batch
+  leaves everything else applied and consistent.
+
+!!! info "Planned — Phase 2"
+    The HTTP API adds `POST /batch/move` with a `dry_run` mode that
+    validates an entire reorganization (collisions, cycles, missing IDs)
+    before applying it all-or-nothing in one transaction — designed for
+    agent-driven filing. Tags (orthogonal to the tree) are in the schema
+    and surface alongside it.

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -1,0 +1,44 @@
+---
+title: Searching
+description: Full-text search over the vault with FTS5.
+---
+
+# Searching
+
+```bash
+docbank search insurance
+docbank search tax 2026
+```
+
+```
+ID   PATH
+231  /taxes/2026/insurance-renewal.pdf
+198  /taxes/2026/car-insurance.pdf
+```
+
+## Semantics
+
+- **Prefix matching.** Every whitespace-separated term matches word
+  prefixes: `insur` finds `insurance-renewal.pdf`. Multiple terms must
+  all match.
+- **Operator-safe.** Query text is escaped before reaching FTS5, so
+  `AND`, `OR`, quotes, and parentheses in a query are searched for
+  literally, never interpreted. Any string is a safe query.
+- **Ranked.** Results are ordered by BM25 relevance, with deterministic
+  name/ID tie-breaks, and capped at 50.
+- **Live nodes only.** Trashed documents don't appear; restore returns
+  them to the index. Renames update the index immediately.
+
+## What's indexed today
+
+Phase 1 indexes **node names** only. That already covers the common
+"where did I file that" lookup, since document filenames tend to carry
+their subject.
+
+!!! info "Planned — Phase 2"
+    Text extraction workers add document **contents** to the same index:
+    PDF text layers, plain text/markdown, and office formats, extracted
+    once per unique blob and per extractor version. Search gains filters
+    (tag, MIME type, date, path prefix) alongside the HTTP `/search`
+    endpoint. Because extraction is keyed by content hash, renaming or
+    moving files never triggers re-extraction.

--- a/docs/usage/trash-and-gc.md
+++ b/docs/usage/trash-and-gc.md
@@ -1,0 +1,90 @@
+---
+title: Trash, GC & Verify
+description: The three-stage deletion model and integrity checking.
+---
+
+# Trash, GC & Verify
+
+Nothing in docbank is deleted in one step. Removal is a three-stage
+pipeline, each stage explicit, so the window for regret is as wide as
+you want it to be:
+
+```mermaid
+flowchart LR
+    A[live node] -- "docbank rm" --> B[trash]
+    B -- "docbank restore" --> A
+    B -- "docbank trash empty" --> C[unreferenced blob]
+    C -- "docbank gc --run" --> D[bytes reclaimed]
+```
+
+## Stage 1: Trash (`rm`, `restore`, `trash list`)
+
+`docbank rm <path>` marks the node — and its whole subtree for
+directories — as trashed. The tree entry disappears from `ls`, `tree`,
+and `search`; the name becomes reusable; the bytes are untouched.
+
+```bash
+docbank trash list
+```
+
+```
+ID   TRASHED AT                     NAME
+15   2026-07-06T21:40:11.0021Z      return.pdf
+88   2026-07-05T09:12:44.8810Z      old-drafts
+```
+
+Only trash *roots* are listed: trashing a directory produces one entry,
+and `docbank restore <id>` brings the entire subtree back to its
+original location. If a live node has since taken the name, the restored
+node is suffixed (`return.pdf` → `return (2).pdf`); if the original
+parent was itself permanently deleted, the node is restored under `/`.
+
+Trashing a subtree stamps every node with the same trash time, so a
+nested directory trashed *before* its parent keeps its own independent
+trash entry — restoring the parent doesn't resurrect things you trashed
+separately.
+
+## Stage 2: Empty the trash
+
+```bash
+docbank trash empty                  # everything
+docbank trash empty --older-than 30d # only items trashed ≥30 days ago
+```
+
+This permanently deletes the tree entries. The document bytes are still
+on disk — they've merely become unreferenced.
+
+## Stage 3: Garbage collection (`gc`)
+
+Blobs are reclaimed only by explicit GC. A blob is *reachable* — and
+therefore never collected — while any of these reference it:
+
+- a live node,
+- a trashed node (trash is always restorable in full), or
+- a recorded prior version of an edited document
+  (see [Editing & Versions](../architecture/editing-and-versions.md)).
+
+```bash
+docbank gc          # dry run: candidate count and reclaimable bytes
+docbank gc --run    # delete files, then metadata rows
+```
+
+`gc --run` holds the vault lock exclusively so a concurrent import can
+never dedup against a blob that's being deleted (see
+[Concurrency & Locking](../architecture/locking.md)). Files are removed
+before their rows: a crash in between leaves rows-without-files, which
+the next `gc --run` reconciles and `verify` flags in the meantime.
+Orphan blobs from interrupted ingests are reclaimed the same way.
+
+## Verify
+
+```bash
+docbank verify
+```
+
+Re-hashes every stored blob against its recorded SHA-256 and reports
+`missing`, `corrupt`, or `unreadable` per problem blob, exiting non-zero
+if anything is wrong. Corruption is something you detect on your
+schedule, not something you discover the day you need the document. Run
+it after moving the vault between disks, before deleting original
+sources, and periodically from cron.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -1,0 +1,271 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "deepmerge"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/78/6e9e20106224083cfb817d2d3c26e80e72258d617b616721a169b87081e0/deepmerge-2.1.0.tar.gz", hash = "sha256:07ca7a7b8935df596c512fa8161877c0487ac61f691c07766e7d71d2b23bdd2f", size = 21449, upload-time = "2026-06-22T05:46:07.669Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/25/2a75b47cb057b1e164c604fb81ab690a6cdb5e2260ce651194eae90f64a3/deepmerge-2.1.0-py3-none-any.whl", hash = "sha256:8f148339a91d680a75ecb74ade235d9e759a93df373a0b04e9d31c8666cfeb75", size = 14345, upload-time = "2026-06-22T05:46:06.742Z" },
+]
+
+[[package]]
+name = "docbank-docs"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "zensical" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "zensical", specifier = "==0.0.45" }]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "zensical"
+version = "0.0.45"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "deepmerge" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "pyyaml" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d1/ecb1889fd2208b2d577e6ff952d9bee201302eec7966b5b61cc64adfd8f5/zensical-0.0.45.tar.gz", hash = "sha256:315bce4ab0470338dd3588add38fb325f840856c375722e6802bd58a06446266", size = 3935947, upload-time = "2026-06-09T11:23:32.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/fd/6b84115e3bbe6b76ebb1265e8ff2161c0bc88dcd6499eaf29c61a66421e9/zensical-0.0.45-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c4cb2e11132f02ae824e246e016e073458e12e9de1eaf86fd39f01890d41204c", size = 12698844, upload-time = "2026-06-09T11:22:56.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/dc/4ddf05d77c1455c32cb26da71f2a19d355927a45a3db5b26fb258a07ce8f/zensical-0.0.45-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:799a01de2102b5f731744ad31bdbc464d0c07d484e67ba148f6923679afa6ce6", size = 12571590, upload-time = "2026-06-09T11:23:00.192Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/53/60c6cc7b2ce8b1a83eb87bff3f7289447995552fd9a30ca76ffba22ca9d5/zensical-0.0.45-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6201e79ea8a64bd3ced3f05ef4b1529da0e675d67b1395987c0ba942e4e10dc4", size = 12939590, upload-time = "2026-06-09T11:23:02.721Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/e9217ed75dba323a6f9a4eee28eb40416eff99932cd0ee6c394bf07b9ead/zensical-0.0.45-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:854aaf500e4a3ce64adea1faa7a1820c7cf9a4f66be1043e4e9ba727fe9cf2b5", size = 12911669, upload-time = "2026-06-09T11:23:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/6fc9fe2334bb4460a8a8d732e23a30d2ddc2ecf63c2eb3487d9e7405e70d/zensical-0.0.45-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a80c57fd50fc60415914388286ac10a7d8b6f70b8ca7235597d09fb12c3171b0", size = 13267643, upload-time = "2026-06-09T11:23:07.915Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f9/5696114af4ede5f1bd01e641a4ff24ee8ca49810bfaa28e5be12d930c0ef/zensical-0.0.45-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58c3510f69e08b6ed8bb9596fc9393e4687f90394aa0ef2d6118b1375ad97be5", size = 12972147, upload-time = "2026-06-09T11:23:12.069Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9e/5c6acde480c43f8c993b13260925df8db31d51ab8a9977618e9efdd98d45/zensical-0.0.45-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:01c484bb2ee85e98e21e24b397ff52ffc31101f7485935eee5d3afa6cca6cc08", size = 13117360, upload-time = "2026-06-09T11:23:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/31/ea21f102049b35a8fe5218c5331857a15eeb60deb1bb21823a4c0701e274/zensical-0.0.45-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:3654b708830303759e866a58a60c483cd2a1c56a44acdaae5bbb341a3f40ebce", size = 13185593, upload-time = "2026-06-09T11:23:18.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/97/6ded39fe27fa8a292d17d9af713b018e4919315233b60fa4b4b0aca737a6/zensical-0.0.45-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c4da1c37eca1474b487def0ef40d7ac2aff31a9d7a029cb7479ef7c354437361", size = 13326882, upload-time = "2026-06-09T11:23:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/79/80/075975032a9e20f319c0134f8ca659d295ee4908f15ab212702a2728247f/zensical-0.0.45-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f8a1966c186feebd3b795f9d420000bfd582e16eefdd9bc7a286d878faabae52", size = 13253961, upload-time = "2026-06-09T11:23:23.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6a/0eab0eb311af6a07cde15ca58d5d720cbfa02cd509e4c7fb5fa20cda0b46/zensical-0.0.45-cp310-abi3-win32.whl", hash = "sha256:a1dd63a5efb8d0e5f2fadf862f02771a279dc5cbe9a982700194650065758f01", size = 12257083, upload-time = "2026-06-09T11:23:26.769Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/cd/b117e749c60b1d1e16b8450db1355f69f38376f783b8c6c8815202988933/zensical-0.0.45-cp310-abi3-win_amd64.whl", hash = "sha256:1f2c0e69839ce4274bde34d18139d3b0d96bbf02b245ada46243590c9eedebc1", size = 12498335, upload-time = "2026-06-09T11:23:29.702Z" },
+]

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:-}"
+if [[ "$command_name" != "build" && "$command_name" != "serve" ]]; then
+  printf 'usage: %s {build|serve} [zensical args...]\n' "$0" >&2
+  exit 2
+fi
+shift || true
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+docs_root="$script_dir"
+site_dir="${DOCBANK_DOCS_SITE_DIR:-site}"
+
+if [[ -n "${VIRTUAL_ENV:-}" && -x "$VIRTUAL_ENV/bin/zensical" ]]; then
+  zensical_bin="$VIRTUAL_ENV/bin/zensical"
+elif [[ -x "$docs_root/.venv/bin/zensical" ]]; then
+  zensical_bin="$docs_root/.venv/bin/zensical"
+elif command -v zensical >/dev/null 2>&1; then
+  zensical_bin="zensical"
+else
+  printf 'zensical not found; install with: cd docs && uv sync --frozen --no-dev\n' >&2
+  exit 127
+fi
+
+tmp_docs=""
+tmp_config_base=""
+tmp_config=""
+
+cleanup() {
+  if [[ -n "$tmp_docs" ]]; then
+    rm -rf "$tmp_docs"
+  fi
+  if [[ -n "$tmp_config" ]]; then
+    rm -f "$tmp_config"
+  fi
+  if [[ -n "$tmp_config_base" ]]; then
+    rm -f "$tmp_config_base"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+tmp_docs_name="$(cd "$docs_root" && mktemp -d zensical-public-docs.XXXXXX)"
+tmp_docs="$docs_root/$tmp_docs_name"
+tmp_config_base_name="$(cd "$docs_root" && mktemp .zensical-build.XXXXXX)"
+tmp_config_base="$docs_root/$tmp_config_base_name"
+tmp_config="$tmp_config_base.toml"
+tmp_config_name="$tmp_config_base_name.toml"
+if [[ -e "$tmp_config" ]]; then
+  printf 'temporary config path already exists: %s\n' "$tmp_config" >&2
+  exit 1
+fi
+mv "$tmp_config_base" "$tmp_config"
+tmp_config_base=""
+
+# The temporary docs tree is the publishing boundary: internal material
+# (superpowers specs/plans, tooling, local env) never reaches the site.
+(
+  cd "$docs_root"
+  tar \
+    --exclude './.venv' \
+    --exclude './.env' \
+    --exclude './.env.*' \
+    --exclude './site' \
+    --exclude './zensical-public-docs.*' \
+    --exclude './.zensical-build.*' \
+    --exclude './superpowers' \
+    --exclude './README.md' \
+    --exclude './pyproject.toml' \
+    --exclude './uv.lock' \
+    --exclude './zensical-docs.sh' \
+    --exclude './zensical.toml' \
+    -cf - .
+) | (cd "$tmp_docs" && tar -xf -)
+
+find "$tmp_docs" -depth -name '.*' -exec rm -rf {} +
+
+awk -v docs_dir="$tmp_docs_name" -v site_dir="$site_dir" '
+  $0 == "docs_dir = \"docs\"" {
+    print "docs_dir = \"" docs_dir "\""
+    next
+  }
+  $0 == "site_dir = \"site\"" {
+    print "site_dir = \"" site_dir "\""
+    next
+  }
+  { print }
+' "$docs_root/zensical.toml" > "$tmp_config"
+
+case "$command_name" in
+  build)
+    (cd "$docs_root" && "$zensical_bin" build --strict --config-file "$tmp_config_name" "$@")
+    ;;
+  serve)
+    (cd "$docs_root" && "$zensical_bin" serve --config-file "$tmp_config_name" "$@")
+    ;;
+esac

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -1,0 +1,82 @@
+[project]
+site_name = "docbank"
+site_description = "Personal document archive: a virtual tree over content-addressed storage, with full-text search, trash and recovery, versioned editing, and an agent-first HTTP API."
+site_author = "Kenn Software LLC"
+copyright = 'Copyright &copy; 2026 <a href="https://kenn.io">Kenn Software LLC</a>.'
+docs_dir = "docs"
+site_dir = "site"
+repo_url = "https://github.com/kenn-io/docbank"
+repo_name = "kenn-io/docbank"
+use_directory_urls = true
+nav = [
+  {"Introduction" = "index.md"},
+  {"Setup" = "setup.md"},
+  {"Quickstart" = "quickstart.md"},
+  {"CLI Reference" = "cli-reference.md"},
+  {"Configuration" = "configuration.md"},
+  {"Usage" = [
+    {"Importing Documents" = "usage/importing.md"},
+    {"Organizing the Tree" = "usage/organizing.md"},
+    {"Searching" = "usage/searching.md"},
+    {"Trash, GC & Verify" = "usage/trash-and-gc.md"},
+  ]},
+  {"Design" = [
+    {"Overview" = "architecture/overview.md"},
+    {"Storage" = "architecture/storage.md"},
+    {"Editing & Versions" = "architecture/editing-and-versions.md"},
+    {"Concurrency & Locking" = "architecture/locking.md"},
+    {"HTTP API" = "architecture/http-api.md"},
+    {"Backup" = "architecture/backup.md"},
+  ]},
+  {"Roadmap" = "roadmap.md"},
+  {"Changelog" = "changelog.md"},
+]
+
+[project.extra]
+homepage = "/"
+
+[project.theme]
+variant = "modern"
+features = [
+  "navigation.instant",
+  "navigation.instant.progress",
+  "navigation.tracking",
+  "navigation.sections",
+  "navigation.path",
+  "content.code.copy",
+]
+
+[project.theme.palette]
+scheme = "slate"
+primary = "custom"
+accent = "custom"
+
+[project.theme.icon]
+repo = "fontawesome/brands/github"
+
+[project.markdown_extensions.admonition]
+
+[project.markdown_extensions.attr_list]
+
+[project.markdown_extensions.md_in_html]
+
+[project.markdown_extensions.pymdownx.details]
+
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+pygments_lang_class = true
+
+[project.markdown_extensions.pymdownx.inlinehilite]
+
+[project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }
+]
+
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+
+[project.markdown_extensions.tables]
+
+[project.markdown_extensions.toc]
+permalink = true

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -103,6 +103,12 @@ func (s *Store) withTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
 	return nil
 }
 
+// timestampLayout is RFC 3339 UTC with fixed-width nanoseconds. Timestamps
+// are compared and sorted as strings in SQL (EmptyTrash, TrashedRoots), so
+// lexicographic order must match chronological order; RFC3339Nano trims
+// trailing zeros and breaks that within a second.
+const timestampLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
 func nowRFC3339() string {
-	return time.Now().UTC().Format(time.RFC3339Nano)
+	return time.Now().UTC().Format(timestampLayout)
 }

--- a/internal/store/trash.go
+++ b/internal/store/trash.go
@@ -181,7 +181,7 @@ func (s *Store) EmptyTrash(ctx context.Context, olderThan time.Duration) (int64,
 			// (clock skew) must not survive an explicit empty-everything.
 			res, err = tx.Exec(`DELETE FROM nodes WHERE trash_name IS NOT NULL`)
 		} else {
-			cutoff := time.Now().UTC().Add(-olderThan).Format(time.RFC3339Nano)
+			cutoff := time.Now().UTC().Add(-olderThan).Format(timestampLayout)
 			res, err = tx.Exec(
 				`DELETE FROM nodes WHERE trash_name IS NOT NULL AND trashed_at <= ?`, cutoff)
 		}

--- a/internal/store/trash_test.go
+++ b/internal/store/trash_test.go
@@ -148,3 +148,23 @@ func TestEmptyTrash(t *testing.T) {
 	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM blobs`).Scan(&blobCount))
 	assert.Equal(t, 1, blobCount)
 }
+
+func TestEmptyTrashWholeSecondTimestamp(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	// trashed_at is compared to the cutoff as a string, so a whole-second
+	// timestamp must sort before a cutoff with fractional digits in the same
+	// second. Under the old variable-width RFC3339Nano format it rendered
+	// without fractional digits ("...:00Z" > "...:00.5Z") and survived.
+	d, err := s.Mkdir(ctx, s.RootID(), "old")
+	require.NoError(t, err)
+	require.NoError(t, s.Trash(ctx, d.ID))
+	stamp := time.Now().UTC().Add(-time.Hour).Truncate(time.Second).Format(timestampLayout)
+	_, err = s.db.Exec(`UPDATE nodes SET trashed_at = ? WHERE id = ?`, stamp, d.ID)
+	require.NoError(t, err)
+
+	n, err := s.EmptyTrash(ctx, time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+}


### PR DESCRIPTION
Zensical documentation for docbank, mirroring msgvault's docs arrangement. Builds with `make docs-install` / `make docs-serve` / `make docs-build` (strict).

## What changed

- **User docs:** introduction, setup, quickstart, full CLI reference (exact flags, output formats, and error behavior of every Phase 1 command), configuration, and usage guides for importing, organizing, searching, and the trash/GC/verify pipeline.
- **Design docs:** overview (virtual tree over CAS, contrast with msgvault), storage (schema + durability discipline), concurrency & locking, HTTP API contract, and backup.
- **Editing & Versions design page:** records the mutability decision — docbank documents are editable, unlike msgvault's immutable archive; edits write a new blob and record the prior version in `node_versions`, with `docbank edit`/`put`/`revert`/`versions` and `PUT /nodes/{id}/content` (If-Match) committed as Phase 2 surfaces.
- Planned behavior is always inside a "Planned — Phase N" admonition; user-facing pages document only what the current binary does. The Roadmap page tracks implemented vs designed.
- `docs/superpowers/` (internal specs/plans) is excluded from the published site by the build script's copy-to-temp boundary.

Based on `phase1-core` since the docs describe its behavior; retarget to `main` after #1 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)