### PR TITLE
Add scripted release preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           else
             : > release-notes.md
           fi
-          if [[ -s release-notes.md ]]; then
+          if grep -q '[^[:space:]]' release-notes.md; then
             echo "has_body=true" >> "${GITHUB_OUTPUT}"
           else
             echo "has_body=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-tags: true
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -36,6 +37,10 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "FATAL: release tag must use vX.Y.Z format" >&2
+            exit 1
+          fi
           COMMIT="$(git rev-parse --short HEAD)"
           LDFLAGS="-X go.kenn.io/docbank/internal/version.Version=${VERSION} \
                    -X go.kenn.io/docbank/internal/version.Commit=${COMMIT}"
@@ -65,6 +70,9 @@ jobs:
     permissions:
       contents: write # gh release create uploads archives and checksums
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: assets
@@ -75,13 +83,39 @@ jobs:
           cd assets
           sha256sum -- *.tar.gz > SHA256SUMS
           cat SHA256SUMS
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Read annotated tag message
+        id: tag_message
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"
+          TAG_TYPE="$(git for-each-ref --format='%(objecttype)' "refs/tags/${TAG}")"
+          if [[ -z "${TAG_TYPE}" ]]; then
+            echo "FATAL: checkout did not fetch ${TAG}" >&2
+            exit 1
+          fi
+          if [[ "${TAG_TYPE}" == "tag" ]]; then
+            git for-each-ref --format='%(contents:body)' "refs/tags/${TAG}" > release-notes.md
+          else
+            : > release-notes.md
+          fi
+          if [[ -s release-notes.md ]]; then
+            echo "has_body=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_body=false" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HAS_TAG_BODY: ${{ steps.tag_message.outputs.has_body }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          NOTES_ARGS=(--generate-notes)
+          if [[ "${HAS_TAG_BODY}" == "true" ]]; then
+            NOTES_ARGS=(--notes-file release-notes.md)
+          fi
           gh release create "${TAG}" assets/* \
             --repo "${GITHUB_REPOSITORY}" \
             --title "${TAG}" \
-            --generate-notes
+            --verify-tag \
+            "${NOTES_ARGS[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,16 @@ Instructions for autonomous coding agents working in this repository.
    job, merging is the user's.
 4. Run `prek run` before committing.
 
+## Releases
+
+- Cut releases only from a clean local `main` that exactly matches
+  `origin/main`.
+- Preview notes with `scripts/changelog.sh <version>`; publish with
+  `scripts/release.sh <version> [extra_instructions]`.
+- The release script creates and pushes an annotated `vX.Y.Z` tag. The release
+  workflow uses the tag body as GitHub release notes and falls back to generated
+  notes only for a lightweight or empty tag.
+
 ## Design Invariants
 
 - Daemon-first: the daemon is the only process that opens the store; CLI

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Generate release notes from commits since the previous release.
+# Usage: ./scripts/changelog.sh [version] [start_tag] [extra_instructions]
+# Set CHANGELOG_AGENT=claude to use Claude instead of Codex (default).
+# If version is omitted, NEXT is used as a placeholder.
+# If start_tag is - or omitted, the previous tag is auto-detected.
+
+set -euo pipefail
+
+VERSION="${1:-NEXT}"
+START_TAG="${2:-}"
+EXTRA_INSTRUCTIONS="${3:-}"
+AGENT="${CHANGELOG_AGENT:-codex}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CHANGELOG_PATHS=(
+    .
+    ':(exclude)docs/**'
+    ':(exclude)AGENTS.md'
+    ':(exclude).roborev.toml'
+)
+
+if [[ -n "$START_TAG" && "$START_TAG" != "-" ]]; then
+    git -C "$REPO_ROOT" rev-parse --verify "${START_TAG}^{commit}" >/dev/null
+    RANGE="${START_TAG}..HEAD"
+    RANGE_LABEL="$START_TAG"
+    echo "Generating changelog from $START_TAG to HEAD..." >&2
+else
+    PREV_TAG="$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || true)"
+    if [[ -z "$PREV_TAG" ]]; then
+        FIRST_COMMIT="$(git -C "$REPO_ROOT" rev-list --max-parents=0 HEAD)"
+        RANGE="${FIRST_COMMIT}..HEAD"
+        RANGE_LABEL="$FIRST_COMMIT"
+        echo "No previous release found. Generating changelog for all commits..." >&2
+    else
+        RANGE="${PREV_TAG}..HEAD"
+        RANGE_LABEL="$PREV_TAG"
+        echo "Generating changelog from $PREV_TAG to HEAD..." >&2
+    fi
+fi
+
+# Documentation-only and reviewer-configuration commits are intentionally
+# excluded from release-note material.
+COMMITS="$(git -C "$REPO_ROOT" log "$RANGE" --pretty=format:'- %s (%h)' --no-merges -- "${CHANGELOG_PATHS[@]}")"
+DIFF_STAT="$(git -C "$REPO_ROOT" diff --stat "$RANGE" -- "${CHANGELOG_PATHS[@]}")"
+
+if [[ -z "$COMMITS" ]]; then
+    echo "No non-documentation commits since $RANGE_LABEL" >&2
+    exit 0
+fi
+
+echo "Using $AGENT to generate changelog..." >&2
+
+OUTPUT_FILE="$(mktemp)"
+PROMPT_FILE="$(mktemp)"
+trap 'rm -f "$OUTPUT_FILE" "$PROMPT_FILE"' EXIT
+
+cat >"$PROMPT_FILE" <<EOF
+You are generating release notes for docbank version $VERSION.
+
+docbank is a local-first personal document archive. A daemon owns its SQLite
+metadata and content-addressed blob vault; the CLI and external applications use
+its authenticated loopback HTTP API to ingest, organize, search, and verify files.
+
+IMPORTANT: Do NOT use tools, run shell commands, search, or read files. Everything
+needed is in the commit list and diff summary below.
+
+Commits since the previous release:
+$COMMITS
+
+Diff summary:
+$DIFF_STAT
+
+Generate concise, user-focused Markdown release notes. Use only the sections that
+have content, choosing from:
+- New Features
+- Improvements
+- Bug Fixes
+
+Focus on user-visible changes. Skip internal refactoring, tests, release plumbing,
+review follow-ups, and documentation-only changes unless they materially change
+installation or operation. Keep each description to one line and use present tense.
+Do not mention bugs introduced and fixed within this same release cycle.
+${EXTRA_INSTRUCTIONS:+
+
+Pay particular attention to these features or improvements when they appear in the
+commit list: $EXTRA_INSTRUCTIONS
+Do not inspect anything outside the supplied commit list and diff summary.}
+Output ONLY the Markdown release-note content, with no preamble.
+EOF
+
+case "$AGENT" in
+    codex)
+        codex exec --skip-git-repo-check --sandbox read-only \
+            -c model_reasoning_effort=high -o "$OUTPUT_FILE" - >/dev/null <"$PROMPT_FILE"
+        ;;
+    claude)
+        claude --print <"$PROMPT_FILE" >"$OUTPUT_FILE"
+        ;;
+    *)
+        echo "Error: unknown CHANGELOG_AGENT '$AGENT' (expected 'codex' or 'claude')" >&2
+        exit 1
+        ;;
+esac
+
+if [[ ! -s "$OUTPUT_FILE" ]]; then
+    echo "Error: $AGENT returned empty release notes" >&2
+    exit 1
+fi
+
+cat "$OUTPUT_FILE"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,7 +42,8 @@ if ! gh auth status >/dev/null 2>&1; then
     exit 1
 fi
 
-git -C "$REPO_ROOT" fetch --quiet origin main --tags
+git -C "$REPO_ROOT" fetch --quiet origin \
+    '+refs/heads/main:refs/remotes/origin/main' --tags
 
 if [[ "$(git -C "$REPO_ROOT" rev-parse HEAD)" != "$(git -C "$REPO_ROOT" rev-parse origin/main)" ]]; then
     echo "Error: local main must exactly match origin/main"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Generate release notes, create an annotated version tag, and push it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VERSION="${1:-}"
+EXTRA_INSTRUCTIONS="${2:-}"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 <version> [extra_instructions]"
+    echo "Example: $0 0.2.0"
+    echo "Example: $0 0.2.0 \"Focus on editing and version history\""
+    exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: version must use X.Y.Z format (for example, 0.2.0)"
+    exit 1
+fi
+
+TAG="v$VERSION"
+
+if [[ "$(git -C "$REPO_ROOT" branch --show-current)" != "main" ]]; then
+    echo "Error: releases must be cut from main"
+    exit 1
+fi
+
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+    echo "Error: the working tree is not clean; commit or stash changes first"
+    exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh CLI is required (https://cli.github.com/)"
+    exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: gh CLI is not authenticated"
+    exit 1
+fi
+
+git -C "$REPO_ROOT" fetch --quiet origin main --tags
+
+if [[ "$(git -C "$REPO_ROOT" rev-parse HEAD)" != "$(git -C "$REPO_ROOT" rev-parse origin/main)" ]]; then
+    echo "Error: local main must exactly match origin/main"
+    exit 1
+fi
+
+if git -C "$REPO_ROOT" rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+    echo "Error: tag $TAG already exists"
+    exit 1
+fi
+
+CHANGELOG_FILE="$(mktemp)"
+trap 'rm -f "$CHANGELOG_FILE"' EXIT
+
+"$SCRIPT_DIR/changelog.sh" "$VERSION" - "$EXTRA_INSTRUCTIONS" >"$CHANGELOG_FILE"
+
+if [[ ! -s "$CHANGELOG_FILE" ]]; then
+    echo "Error: no release-note content was generated"
+    exit 1
+fi
+
+echo
+echo "=========================================="
+echo "PROPOSED RELEASE NOTES FOR $TAG"
+echo "=========================================="
+cat "$CHANGELOG_FILE"
+echo
+echo "=========================================="
+echo
+
+read -r -p "Accept these notes and create release $TAG? [y/N] " REPLY
+if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
+    echo "Release cancelled."
+    exit 0
+fi
+
+echo "Creating annotated tag $TAG..."
+git -C "$REPO_ROOT" tag -a "$TAG" \
+    -m "Release $VERSION" \
+    -m "$(cat "$CHANGELOG_FILE")"
+
+echo "Pushing tag to origin..."
+git -C "$REPO_ROOT" push origin "$TAG"
+
+echo
+echo "Release $TAG tag pushed successfully."
+echo "GitHub Actions will publish the archives, checksums, and tag-message notes."
+echo "https://github.com/kenn-io/docbank/releases/tag/$TAG"


### PR DESCRIPTION
Docbank now has a real release to maintain, so future tags need the same repeatable, reviewable preparation path used by msgvault instead of ad hoc tag commands and GitHub-generated prose. This adds that shared operating model while retaining docbank-specific guards against cutting a release from dirty, divergent, non-main, or malformed-tag state.

The changelog helper feeds only the bounded commit log and diff summary to Codex or Claude, excluding documentation-only and reviewer-configuration changes. The release helper presents those notes for human confirmation, then creates and pushes an annotated semver tag. The publication workflow consumes the annotation body as the GitHub release notes, with generated notes retained only for lightweight or empty tags.

The synchronization check explicitly refreshes the remote-tracking main ref before comparing it to HEAD; this closes the review finding that a named-branch fetch could leave the guard stale.

Validation:

- full `CGO_ENABLED=1 make test`, `make lint`, and strict `make docs-build`
- `bash -n` and `shellcheck` on both scripts
- `actionlint` and zero-finding `zizmor --pedantic`
- real Codex changelog generation over the v0.1 commit range
- invalid version, non-main branch, unknown agent, and empty-output failure paths
- annotated-tag type/body extraction against live `v0.1.0`
- explicit origin/main refspec verified against `git ls-remote`

The initial `v0.1.0` tag was intentionally cut manually from merged commit `5046ff7`; its release workflow and all downloaded checksums passed, the macOS binary reports the expected version/commit, and authenticated `docbank update --check` reports already up to date.