### PR TITLE
Publish Markdown counterparts for documentation routes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ Every rendered directory route also publishes its exact Markdown source at
 the sibling `.md` path: `/setup/` has `/setup.md`, and
 `/usage/importing/` has `/usage/importing.md`. This gives agents and other
 text-first clients a stable representation without scraping rendered HTML.
+Section landing pages use a sibling source such as `usage.md`, not
+`usage/index.md`, so relative links keep the same base at `/usage.md`.
 
 ## Building
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,11 @@ plus internal design material.
   metadata, assets, and publishing boundary; all Python tools run through
   the locked `uv` environment
 
+Every rendered directory route also publishes its exact Markdown source at
+the sibling `.md` path: `/setup/` has `/setup.md`, and
+`/usage/importing/` has `/usage/importing.md`. This gives agents and other
+text-first clients a stable representation without scraping rendered HTML.
+
 ## Building
 
 ```bash

--- a/docs/scripts/check_built_site.py
+++ b/docs/scripts/check_built_site.py
@@ -52,8 +52,6 @@ def markdown_route(site: pathlib.Path, rel: pathlib.Path) -> pathlib.Path:
 
 
 def markdown_output(site: pathlib.Path, rel: pathlib.Path) -> pathlib.Path:
-    if rel.name == "index.md" and rel.parent != pathlib.Path("."):
-        return site / pathlib.Path(f"{rel.parent}.md")
     return site / rel
 
 

--- a/docs/scripts/check_built_site.py
+++ b/docs/scripts/check_built_site.py
@@ -47,6 +47,7 @@ def local_target(
 
 def main() -> None:
     site = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "site").resolve()
+    source = pathlib.Path(sys.argv[2]).resolve() if len(sys.argv) > 2 else None
     errors: list[str] = []
     pages = sorted(site.rglob("*.html"))
     if not pages:
@@ -88,6 +89,42 @@ def main() -> None:
                 and fragment not in parsed_pages[target].anchors
             ):
                 errors.append(f"{rel}: broken local fragment {raw}")
+
+    if source is not None:
+        source_markdown = sorted(source.rglob("*.md"))
+        expected_markdown: set[pathlib.Path] = set()
+        for markdown in source_markdown:
+            rel = markdown.relative_to(source)
+            published = site / rel
+            expected_markdown.add(published.resolve())
+            if not published.is_file():
+                errors.append(f"{rel}: Markdown counterpart was not published")
+            elif published.read_bytes() != markdown.read_bytes():
+                errors.append(f"{rel}: published Markdown differs from its source")
+
+            route = (
+                site / "index.html"
+                if rel == pathlib.Path("index.md")
+                else site / rel.with_suffix("") / "index.html"
+            )
+            if not route.is_file():
+                errors.append(f"{rel}: rendered route does not exist")
+
+        for published in site.rglob("*.md"):
+            if published.resolve() not in expected_markdown:
+                errors.append(f"{published.relative_to(site)}: no matching Markdown source")
+
+        for page in pages:
+            rel = page.relative_to(site)
+            if rel == pathlib.Path("404.html"):
+                continue
+            markdown = (
+                site / "index.md"
+                if rel == pathlib.Path("index.html")
+                else page.parent.with_suffix(".md")
+            )
+            if not markdown.is_file():
+                errors.append(f"{rel}: rendered route has no Markdown counterpart")
 
     if errors:
         print("built documentation validation failed:", file=sys.stderr)

--- a/docs/scripts/check_built_site.py
+++ b/docs/scripts/check_built_site.py
@@ -45,6 +45,18 @@ def local_target(
     return target.resolve(), urllib.parse.unquote(parsed.fragment)
 
 
+def markdown_route(site: pathlib.Path, rel: pathlib.Path) -> pathlib.Path:
+    if rel.name == "index.md":
+        return site / rel.parent / "index.html"
+    return site / rel.with_suffix("") / "index.html"
+
+
+def markdown_output(site: pathlib.Path, rel: pathlib.Path) -> pathlib.Path:
+    if rel.name == "index.md" and rel.parent != pathlib.Path("."):
+        return site / rel.parent.with_suffix(".md")
+    return site / rel
+
+
 def main() -> None:
     site = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "site").resolve()
     source = pathlib.Path(sys.argv[2]).resolve() if len(sys.argv) > 2 else None
@@ -95,18 +107,14 @@ def main() -> None:
         expected_markdown: set[pathlib.Path] = set()
         for markdown in source_markdown:
             rel = markdown.relative_to(source)
-            published = site / rel
+            published = markdown_output(site, rel)
             expected_markdown.add(published.resolve())
             if not published.is_file():
                 errors.append(f"{rel}: Markdown counterpart was not published")
             elif published.read_bytes() != markdown.read_bytes():
                 errors.append(f"{rel}: published Markdown differs from its source")
 
-            route = (
-                site / "index.html"
-                if rel == pathlib.Path("index.md")
-                else site / rel.with_suffix("") / "index.html"
-            )
+            route = markdown_route(site, rel)
             if not route.is_file():
                 errors.append(f"{rel}: rendered route does not exist")
 

--- a/docs/scripts/check_built_site.py
+++ b/docs/scripts/check_built_site.py
@@ -53,7 +53,7 @@ def markdown_route(site: pathlib.Path, rel: pathlib.Path) -> pathlib.Path:
 
 def markdown_output(site: pathlib.Path, rel: pathlib.Path) -> pathlib.Path:
     if rel.name == "index.md" and rel.parent != pathlib.Path("."):
-        return site / rel.parent.with_suffix(".md")
+        return site / pathlib.Path(f"{rel.parent}.md")
     return site / rel
 
 
@@ -129,7 +129,7 @@ def main() -> None:
             markdown = (
                 site / "index.md"
                 if rel == pathlib.Path("index.html")
-                else page.parent.with_suffix(".md")
+                else site / pathlib.Path(f"{rel.parent}.md")
             )
             if not markdown.is_file():
                 errors.append(f"{rel}: rendered route has no Markdown counterpart")

--- a/docs/scripts/check_markdown_sources.py
+++ b/docs/scripts/check_markdown_sources.py
@@ -50,6 +50,12 @@ def main() -> None:
 
     for path in files:
         rel = path.relative_to(ROOT)
+        if rel.name == "index.md" and rel != pathlib.Path("index.md"):
+            section_page = pathlib.Path(f"{rel.parent}.md")
+            errors.append(
+                f"{rel}: nested index pages are unsupported; use {section_page} "
+                "so the rendered and Markdown routes share a URL base"
+            )
         text = path.read_text(encoding="utf-8")
         lines = text.splitlines()
         if len(lines) < 4 or lines[0] != "---":

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -148,7 +148,13 @@ awk -v docs_dir="$tmp_docs_name" -v site_dir="$site_config_dir" '
 case "$command_name" in
   build)
     (cd "$docs_root" && "${uv_run[@]}" zensical build --strict --config-file "$tmp_config_name" "$@")
-    "${uv_run[@]}" python "$docs_root/scripts/check_built_site.py" "$tmp_site"
+    while IFS= read -r -d '' markdown_source; do
+      markdown_rel="${markdown_source#"$tmp_docs/"}"
+      markdown_dest="$tmp_site/$markdown_rel"
+      mkdir -p "$(dirname "$markdown_dest")"
+      cp "$markdown_source" "$markdown_dest"
+    done < <(find "$tmp_docs" -type f -name '*.md' -print0)
+    "${uv_run[@]}" python "$docs_root/scripts/check_built_site.py" "$tmp_site" "$tmp_docs"
     printf '%s\n' "$site_marker_contents" > "$tmp_site/$site_marker"
     mkdir -p "$(dirname "$site_path")"
     if [[ -e "$site_path" || -L "$site_path" ]]; then

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -150,11 +150,7 @@ case "$command_name" in
     (cd "$docs_root" && "${uv_run[@]}" zensical build --strict --config-file "$tmp_config_name" "$@")
     while IFS= read -r -d '' markdown_source; do
       markdown_rel="${markdown_source#"$tmp_docs/"}"
-      if [[ "$markdown_rel" == */index.md ]]; then
-        markdown_dest="$tmp_site/${markdown_rel%/index.md}.md"
-      else
-        markdown_dest="$tmp_site/$markdown_rel"
-      fi
+      markdown_dest="$tmp_site/$markdown_rel"
       mkdir -p "$(dirname "$markdown_dest")"
       cp "$markdown_source" "$markdown_dest"
     done < <(find "$tmp_docs" -type f -name '*.md' -print0)

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -150,7 +150,11 @@ case "$command_name" in
     (cd "$docs_root" && "${uv_run[@]}" zensical build --strict --config-file "$tmp_config_name" "$@")
     while IFS= read -r -d '' markdown_source; do
       markdown_rel="${markdown_source#"$tmp_docs/"}"
-      markdown_dest="$tmp_site/$markdown_rel"
+      if [[ "$markdown_rel" == */index.md ]]; then
+        markdown_dest="$tmp_site/${markdown_rel%/index.md}.md"
+      else
+        markdown_dest="$tmp_site/$markdown_rel"
+      fi
       mkdir -p "$(dirname "$markdown_dest")"
       cp "$markdown_source" "$markdown_dest"
     done < <(find "$tmp_docs" -type f -name '*.md' -print0)


### PR DESCRIPTION
Docbank’s documentation serves two equal audiences: people reading the rendered site and agents or text-first tools that need the maintained source without scraping HTML. A directory route such as `/usage/importing/` currently exposes only the human presentation, even though its canonical Markdown already exists in the repository.

This makes the representation predictable: every content route publishes its exact source at the sibling `.md` path, so `/usage/importing/` and `/usage/importing.md` describe the same page. The Markdown is copied from the same isolated public-source tree used by Zensical, preserving the existing boundary around internal notes and tooling.

The pairing is part of the publication contract rather than a best-effort copy. A build cannot replace the last valid site unless every maintained Markdown source matches its published bytes and rendered route, and every rendered content route has a Markdown counterpart. This gives the upcoming agent documentation a stable retrieval convention it can rely on.