### PR TITLE
Document safe user and agent workflows

### DIFF
--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -72,7 +72,7 @@ Then make an authenticated request. Resolve `/` to obtain the root node and
 its ID:
 
 ```bash
-curl --fail --get \
+curl --fail-with-body --get \
   -H "Authorization: Bearer $DOCBANK_API_KEY" \
   --data-urlencode 'path=/' \
   "$DOCBANK_URL/api/v1/path"
@@ -88,7 +88,7 @@ Directory children are paginated and sorted with directories first, then by
 name. Use `total`, `limit`, and `offset` until the complete page set is read:
 
 ```bash
-curl --fail \
+curl --fail-with-body \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   "$DOCBANK_URL/api/v1/nodes/1/children?limit=500&offset=0"
 ```
@@ -97,7 +97,7 @@ Search is bounded separately. Always inspect `truncated`; increase the limit
 or refine the query rather than assuming the returned array is complete.
 
 ```bash
-curl --fail --get \
+curl --fail-with-body --get \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   --data-urlencode 'q=tax return' \
   --data 'limit=100' \
@@ -120,7 +120,7 @@ revision belongs to the node state the agent evaluated:
 
 ```bash
 # A prior GET returned id=42 and revision=7.
-curl --fail -X PATCH \
+curl --fail-with-body -X PATCH \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'If-Match: "7"' \
   -H 'Content-Type: application/json' \
@@ -150,7 +150,7 @@ agent previously inspected a particular node and wants lost-update protection.
 Create a directory under a known parent ID:
 
 ```bash
-curl --fail -X POST \
+curl --fail-with-body -X POST \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'Content-Type: application/json' \
   --data '{"parent_id": 1, "name": "receipts", "kind": "dir"}' \
@@ -164,7 +164,7 @@ name and verify that it is the directory the workflow intended.
 to loopback callers. It is not a file-upload endpoint:
 
 ```bash
-curl --fail -X POST \
+curl --fail-with-body -X POST \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'Content-Type: application/json' \
   --data '{"paths":["/Users/me/Downloads/receipt.pdf"],"dest":"/receipts"}' \
@@ -186,13 +186,13 @@ Trash empty and GC are dry-run operations when `run` is false. An agent should
 present or evaluate the report before issuing a separate execution request:
 
 ```bash
-curl --fail -X POST \
+curl --fail-with-body -X POST \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'Content-Type: application/json' \
   --data '{"older_than":"30d","run":false}' \
   "$DOCBANK_URL/api/v1/trash/empty"
 
-curl --fail -X POST \
+curl --fail-with-body -X POST \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'Content-Type: application/json' \
   --data '{"run":false}' \

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -1,0 +1,252 @@
+---
+title: Agent Integration Guide
+description: Connect an agent to docbank safely using its OpenAPI contract, authenticated HTTP API, revisions, and dry-run maintenance operations.
+---
+
+# Agent integration guide
+
+Docbank is daemon-first: the CLI, agents, and scripts all use the same HTTP
+API. An integration never opens `docbank.db` or the blob store directly.
+
+## Choose the interface
+
+Use the CLI for human-directed shell work and simple orchestration. Use HTTP
+for structured agent workflows, pagination, machine-readable errors, and
+revision-aware mutations.
+
+The canonical contract is generated from the running route definitions:
+
+```bash
+docbank openapi --json > docbank-openapi.json   # offline; no vault needed
+```
+
+A running daemon also serves `/openapi.json`, `/openapi.yaml`, and interactive
+docs at `/docs`. These contract routes are auth-exempt so a client generator
+can discover them before authentication is configured.
+
+The rendered documentation is available to people at directory routes such as
+`/agents/integration/`. The same maintained source is published for agents at
+the sibling `/agents/integration.md` URL.
+
+## Give an independent client a stable endpoint
+
+The docbank CLI can discover an ephemeral port and per-run key from the
+same-user runtime record. An independent long-lived client should instead use
+an explicit loopback port and a strong API key:
+
+```toml
+# ~/.docbank/config.toml
+[server]
+bind_addr = "127.0.0.1"
+api_port = 7486
+api_key = "replace-with-a-long-random-secret"
+idle_timeout = "0"
+```
+
+Restart after changing config:
+
+```bash
+docbank daemon restart
+```
+
+The daemon rejects non-loopback binds. Remote access is not a separate mode:
+use an SSH tunnel or VPN that terminates at the daemon host's loopback
+listener, and protect the API key as a vault credential.
+
+Examples below assume:
+
+```bash
+export DOCBANK_URL=http://127.0.0.1:7486
+export DOCBANK_API_KEY=replace-with-a-long-random-secret
+```
+
+## Prove reachability and authentication separately
+
+`/health` is intentionally auth-exempt:
+
+```bash
+curl --fail "$DOCBANK_URL/health"
+```
+
+Then make an authenticated request. Resolve `/` to obtain the root node and
+its ID:
+
+```bash
+curl --fail --get \
+  -H "Authorization: Bearer $DOCBANK_API_KEY" \
+  --data-urlencode 'path=/' \
+  "$DOCBANK_URL/api/v1/path"
+```
+
+A node response includes stable `id`, mutable `revision`, `kind`, timestamps,
+and—on single-node responses—its current `path`. IDs survive renames; paths are
+for display and one-shot path operations.
+
+## Read a tree without unbounded responses
+
+Directory children are paginated and sorted with directories first, then by
+name. Use `total`, `limit`, and `offset` until the complete page set is read:
+
+```bash
+curl --fail \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  "$DOCBANK_URL/api/v1/nodes/1/children?limit=500&offset=0"
+```
+
+Search is bounded separately. Always inspect `truncated`; increase the limit
+or refine the query rather than assuming the returned array is complete.
+
+```bash
+curl --fail --get \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  --data-urlencode 'q=tax return' \
+  --data 'limit=100' \
+  "$DOCBANK_URL/api/v1/search"
+```
+
+Retrieve file bytes by ID, not path:
+
+```bash
+curl --fail \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  "$DOCBANK_URL/api/v1/nodes/42/content" \
+  --output document.bin
+```
+
+## Use revisions for read-modify-write
+
+ID-addressed move, trash, and restore operations require `If-Match`. The
+revision belongs to the node state the agent evaluated:
+
+```bash
+# A prior GET returned id=42 and revision=7.
+curl --fail -X PATCH \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'If-Match: "7"' \
+  -H 'Content-Type: application/json' \
+  --data '{"new_parent_id": 18, "new_name": "filed.pdf"}' \
+  "$DOCBANK_URL/api/v1/nodes/42"
+```
+
+If another actor changed the node first, the API returns `412` with
+`code: "stale_revision"`. Do not blindly replay the old decision:
+
+1. Re-read the node by ID.
+2. Re-evaluate the intended move, name, or deletion against its new state.
+3. Retry with the new revision only if the intent still applies.
+4. Bound retries; repeated conflicts require human or higher-level policy.
+
+A missing precondition returns `428 precondition_required`. An invalid header
+returns `400 validation`.
+
+Path mutations are intentionally different. `POST /api/v1/path/move` and
+`POST /api/v1/path/trash` resolve and mutate inside one store transaction, so
+they do not accept `If-Match`. Use them for a one-shot instruction tied to the
+path as it exists when the transaction runs. Use ID plus revision when an
+agent previously inspected a particular node and wants lost-update protection.
+
+## Create and ingest safely
+
+Create a directory under a known parent ID:
+
+```bash
+curl --fail -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{"parent_id": 1, "name": "receipts", "kind": "dir"}' \
+  "$DOCBANK_URL/api/v1/nodes"
+```
+
+A `409 exists` response is not automatically success: resolve the existing
+name and verify that it is the directory the workflow intended.
+
+`POST /api/v1/ingest` reads absolute paths on the daemon host and is restricted
+to loopback callers. It is not a file-upload endpoint:
+
+```bash
+curl --fail -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{"paths":["/Users/me/Downloads/receipt.pdf"],"dest":"/receipts"}' \
+  "$DOCBANK_URL/api/v1/ingest"
+```
+
+Inspect `added`, `skipped`, and every member of `failed`. Repeating the same
+ingest after fixing a partial failure is safe; successful content converges to
+`skipped` rather than another copy.
+
+!!! info "Planned — remote upload"
+    Multipart upload is not implemented. A client on another machine cannot
+    send document bytes through the API yet; `POST /ingest` names paths local
+    to the daemon host.
+
+## Treat destructive maintenance as a two-step decision
+
+Trash empty and GC are dry-run operations when `run` is false. An agent should
+present or evaluate the report before issuing a separate execution request:
+
+```bash
+curl --fail -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{"older_than":"30d","run":false}' \
+  "$DOCBANK_URL/api/v1/trash/empty"
+
+curl --fail -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{"run":false}' \
+  "$DOCBANK_URL/api/v1/gc"
+```
+
+Only send `run: true` when policy explicitly authorizes permanent removal.
+Treat the execution as a new decision: the vault may have changed since the
+preview. Packed bytes reported as pending are logically dead but not yet
+physically reclaimed.
+
+`POST /api/v1/verify` is read-only with respect to archive content but can be
+expensive. Maintenance requests serialize against mutations and may run
+without the ordinary request timeout; agents should expose progress as
+“waiting” rather than assuming a queued request is hung.
+
+## Branch on problem codes
+
+Non-2xx responses use RFC 7807 problem JSON:
+
+```json
+{
+  "title": "Conflict",
+  "status": 409,
+  "detail": "node \"report.pdf\" already exists",
+  "code": "exists"
+}
+```
+
+Branch on `code`, never `detail`. Useful policy groups:
+
+- Re-read and reconsider: `stale_revision`.
+- Correct the request: `validation`, `precondition_required`, `invalid_name`,
+  `not_dir`, `not_file`, `is_root`.
+- Reconcile desired state: `exists`, `cycle`, `not_trashed`, `not_found`.
+- Stop and surface credentials or topology: `unauthorized`, `loopback_only`.
+- Stop automation and preserve evidence: `internal`.
+
+The complete mapping lives in [HTTP API](../architecture/http-api.md) and the
+OpenAPI document.
+
+## A safe filing loop
+
+A robust inbox-filing agent follows this sequence:
+
+1. Resolve `/inbox` and page through its children.
+2. Read metadata or content for candidate files by ID.
+3. Decide a destination; create missing directories deliberately.
+4. Re-read the candidate if the decision took long enough for concurrent work
+   to be plausible.
+5. Move by ID with the revision the decision was based on.
+6. On `412`, re-read and reconsider rather than replaying.
+7. Record the returned ID, path, and revision as the outcome.
+
+Keep planning and mutation separate in logs. Never log the API key, shutdown
+token, or document content by default. Use request IDs from your own workflow
+for correlation; docbank's stable node ID is the durable object identity.

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -78,9 +78,16 @@ curl --fail-with-body --get \
   "$DOCBANK_URL/api/v1/path"
 ```
 
-A node response includes stable `id`, mutable `revision`, `kind`, timestamps,
-and—on single-node responses—its current `path`. IDs survive renames; paths are
-for display and one-shot path operations.
+A node response includes stable `id`, mutable `revision`, `kind`, and
+timestamps. Live single-node responses also include the current `path`. IDs
+survive renames; use a live path only for display or a one-shot path operation.
+
+Trash is the important exception. A successful trash response returns the
+node's **pre-trash path** to explain where a restore would try to put it. That
+path no longer resolves to the trashed node and may later resolve to a different
+node if its name is reused. Retain the response's `id` and `revision` for
+subsequent ID-addressed inspection or restore, and treat every path attached to
+a trashed node as display or recovery context rather than identity.
 
 ## Read a tree without unbounded responses
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -50,8 +50,8 @@ failed: /src/broken.pdf: opening /src/broken.pdf: permission denied
 ```
 
 Exit is non-zero if any file failed. A missing or unreadable top-level
-source argument aborts the run with an error (per-file failures inside a
-directory tree do not).
+source is reported as a failure and the command continues with remaining
+source arguments, just as it does for failures inside a directory tree.
 
 ## docbank ls
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,8 @@ ignore in backups and safe to delete when no daemon is running
 shutdown). The database
 references blobs by hash, so restoring a copied `docbank.db` + `blobs/`
 pair onto any machine yields a working vault — `docbank verify` proves
-the pair is consistent.
+the pair is consistent. Stop the daemon before taking a manual filesystem
+snapshot; see [Vault Lifecycle](usage/lifecycle.md#take-a-coherent-manual-snapshot).
 
 !!! warning
     Don't edit or prune `blobs/` by hand. Blob files are referenced by

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ the tree above them is yours to rename, move, search, trash, and restore.
 <p class="hero-actions">
   <a class="md-button md-button--primary" href="setup/">Set up docbank</a>
   <a class="md-button" href="quickstart/">Take the ten-minute tour</a>
-  <a class="md-button" href="architecture/http-api/">Build an agent integration</a>
+  <a class="md-button" href="agents/integration/">Build an agent integration</a>
 </p>
 
 <div class="signal-grid">
@@ -100,5 +100,8 @@ and self-update) are implemented and tested.
 
 - [Setup](setup.md) — build and install the binary
 - [Quickstart](quickstart.md) — a ten-minute tour of the CLI
+- [Vault Lifecycle](usage/lifecycle.md) — operate, update, snapshot, and recover safely
+- [Agent Integration](agents/integration.md) — build revision-aware automations
+- [Troubleshooting](troubleshooting.md) — diagnose failures without risking the vault
 - [CLI Reference](cli-reference.md) — every command, flag, and output format
 - [Architecture → Overview](architecture/overview.md) — how the pieces fit together

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -150,5 +150,7 @@ docbank verify            # re-hash every stored blob
 211 blob(s) ok, 0 problem(s)
 ```
 
-That's the complete Phase 1 surface. See the
-[CLI Reference](cli-reference.md) for exact semantics of every command.
+That is the core document workflow. Continue with
+[Vault Lifecycle](usage/lifecycle.md) for maintenance, upgrades, snapshots,
+and recovery, or use the [CLI Reference](cli-reference.md) for exact command
+semantics.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -40,7 +40,7 @@ Windows is not published because the vault is Unix-only.
 git clone https://github.com/kenn-io/docbank.git
 cd docbank
 make build      # builds ./docbank
-make install    # installs to ~/.local/bin (or GOPATH/bin)
+make install    # installs to ~/.local/bin
 ```
 
 The SQLite full-text index requires the `fts5` build tag; the Makefile
@@ -63,6 +63,9 @@ docbank ls /inbox
 
 Set `DOCBANK_HOME` to keep the vault somewhere else — see
 [Configuration](configuration.md).
+
+Before importing irreplaceable material, read [Vault Lifecycle](usage/lifecycle.md)
+and decide how the vault will be snapshotted.
 
 ## Verifying the toolchain
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -73,9 +73,10 @@ successful portion.
 docbank add ~/Documents/archive --dest /imports
 ```
 
-A missing or unreadable top-level argument aborts immediately. Symlinks and
-non-regular files are intentionally skipped; import the regular target file
-explicitly if it belongs in the vault.
+A missing or unreadable top-level argument is reported as a failed source, and
+the command continues with any remaining arguments. Symlinks and non-regular
+files are intentionally skipped; import the regular target file explicitly if
+it belongs in the vault.
 
 ## Search cannot find document text
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,169 @@
+---
+title: Troubleshooting
+description: Diagnose docbank startup, daemon, import, integrity, update, and HTTP API failures without risking the vault.
+---
+
+# Troubleshooting
+
+Start with observation, not cleanup. Keep the vault intact until you know
+whether the problem is configuration, daemon lifecycle, source-file access, or
+stored data.
+
+```bash
+docbank daemon status --json
+docbank verify
+```
+
+If a command prints a specific error, preserve it. CLI errors go to stderr and
+return a non-zero status; HTTP errors include a machine-readable `code`.
+
+## The daemon will not start
+
+Run it in the foreground to see the startup error directly:
+
+```bash
+DOCBANK_LOG_LEVEL=debug docbank daemon run
+```
+
+Common causes:
+
+- `config.toml` contains an unknown key, invalid duration, or non-loopback
+  bind address. The daemon rejects these rather than guessing.
+- Another process owns the same vault. Check `docbank daemon status`; do not
+  remove `vault.lock` while a daemon may still be alive.
+- The vault is on Windows. Storage and daemon lifecycle require a Unix-like
+  operating system.
+- The configured port is already in use. Set `api_port = 0` to let the OS
+  choose one, or choose another fixed port.
+
+Background daemon logs are JSON files under `$DOCBANK_HOME/logs/`. A data
+command normally repairs stale runtime records and replaces an incompatible
+daemon automatically; `daemon status` and `daemon stop` intentionally do not
+start anything.
+
+## A command cannot connect
+
+First ask the CLI to converge the daemon explicitly:
+
+```bash
+docbank daemon restart
+docbank daemon status
+```
+
+If restart fails, use foreground mode. If it succeeds but a raw HTTP client
+still fails, confirm that the client uses the daemon's actual address and
+effective API key. With `api_port = 0` or an empty configured key, both change
+when the daemon restarts; the docbank CLI discovers them automatically, but an
+independent client does not.
+
+For a stable integration, configure a fixed loopback port and API key as shown
+in the [Agent Integration Guide](agents/integration.md).
+
+## Import completed with failures
+
+`docbank add` continues past unreadable files inside a directory and reports
+each failure. Its exit status is non-zero if any file failed, even when other
+files were added successfully.
+
+Fix source permissions or availability, then rerun the same command. Already
+imported content is skipped, so a rerun converges instead of duplicating the
+successful portion.
+
+```bash
+docbank add ~/Documents/archive --dest /imports
+```
+
+A missing or unreadable top-level argument aborts immediately. Symlinks and
+non-regular files are intentionally skipped; import the regular target file
+explicitly if it belongs in the vault.
+
+## Search cannot find document text
+
+Search currently indexes live node names, not document contents. Try terms
+from the filename and remember that each term is a prefix match.
+
+```bash
+docbank search insur stat
+```
+
+!!! info "Planned — text extraction"
+    PDF, office-document, and plain-text extraction is designed for Phase 2b
+    but is not implemented. See [Searching](usage/searching.md).
+
+## A move or restore conflicts
+
+The CLI never overwrites a live file. Moving onto an existing file returns
+`name already exists`; choose another destination or move into an existing
+directory to retain the source name.
+
+Restore handles name reuse automatically by adding a numeric suffix. If its
+original parent was permanently removed, it restores at `/`. Use the path
+printed by `docbank restore` rather than assuming the old path returned.
+
+HTTP clients must also distinguish:
+
+- `409 exists` or `cycle`: the requested tree state is invalid; choose a new
+  action.
+- `412 stale_revision`: another mutation won; re-read the node and reconsider
+  the action before retrying.
+- `428 precondition_required`: supply the revision from a fresh node response
+  in `If-Match`.
+
+## Verify reports a problem
+
+`verify` classifies each affected hash:
+
+| Result | Meaning | First response |
+|--------|---------|----------------|
+| `missing` | The catalog references bytes that cannot be found. | Stop maintenance and locate a known-good snapshot. |
+| `corrupt` | Bytes are readable but no longer match their SHA-256 identity. | Preserve the vault and restore that content from a known-good copy. |
+| `unreadable` | The storage layer returned an I/O or permission error. | Check mounts, permissions, and system logs before retrying. |
+
+Do not run `gc --run` as a repair tool. GC removes unreachable data; it does
+not repair referenced content. Preserve the affected vault, record the full
+`verify` output, and restore from a snapshot only after identifying which copy
+is known-good.
+
+## GC reclaimed fewer bytes than expected
+
+Packed blobs are immutable members of pack files. GC can remove their catalog
+authority, but that only makes their stored ranges logically dead; physical
+pack space remains until repacking is available. The report separates
+`pending_packed_bytes` from loose bytes actually reclaimable so logical
+deletion is not presented as disk reclamation.
+
+## Update fails
+
+`docbank update` requires a published release with a matching SHA-256 checksum.
+It refuses unverifiable assets. An install failure attempts to restart the old
+daemon; inspect `docbank daemon status` afterward and use `daemon run` if it is
+not healthy.
+
+`--force` does not bypass checksum verification. It refreshes release metadata
+and permits replacing an unversioned development build.
+
+## HTTP returns 401
+
+Every `/api/v1` request requires an effective API key, even when
+`api_key = ""` in config—the empty setting means “generate a per-run key.” Use
+exactly one of:
+
+```text
+X-Api-Key: <key>
+Authorization: Bearer <key>
+```
+
+The health check, ping, interactive API docs, and OpenAPI documents are
+auth-exempt. A successful `/health` response therefore proves reachability,
+not authenticated access.
+
+## Before asking for help
+
+Capture the version, daemon status, failing command or request, and relevant
+log lines. Remove API keys, shutdown tokens, document contents, and private
+paths before sharing them.
+
+```bash
+docbank --version
+docbank daemon status --json
+```

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -70,9 +70,9 @@ failed: /src/link.pdf: not a regular file or directory (symlinks are skipped)
 ```
 
 The exit code is non-zero when any file failed, so scripted migrations
-can detect partial imports. One exception: a top-level source argument
-that doesn't exist aborts immediately — that's a typo, not a corrupt
-file.
+can detect partial imports. A missing or unreadable top-level source is
+reported the same way, and the command continues with the remaining
+source arguments.
 
 ## Sources are read-only
 

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -1,0 +1,170 @@
+---
+title: Vault Lifecycle
+description: Operate a docbank vault safely from first import through maintenance, upgrades, snapshots, and recovery.
+---
+
+# Vault lifecycle
+
+A docbank vault is deliberately low-maintenance: data commands start the
+daemon when needed, imports never alter their sources, deletion is staged, and
+integrity checks are explicit. This page connects those pieces into an
+operating routine.
+
+## Know what owns the vault
+
+The daemon is the only process that opens `docbank.db` and the blob store.
+Ordinary commands are HTTP clients of it and start a compatible background
+daemon automatically.
+
+```bash
+docbank daemon status
+docbank daemon start       # optional: data commands do this automatically
+docbank daemon stop        # graceful; does not start a stopped daemon
+```
+
+Use `docbank daemon run` when diagnosing startup or configuration problems: it
+stays in the foreground and writes logs to the terminal. Background logs live
+under `$DOCBANK_HOME/logs/`.
+
+## A practical operating rhythm
+
+### As documents arrive
+
+Import into `/inbox`, then file from there. Re-running an interrupted import is
+safe: matching content already present under a destination candidate is
+skipped.
+
+```bash
+docbank add ~/Desktop/scans
+docbank tree /inbox
+docbank mv /inbox/scans/tax-notice.pdf /taxes/2026/
+```
+
+The source files remain untouched. Keep them until your normal backup process
+has captured the vault.
+
+### Before removing anything permanently
+
+Deletion has three separate gates:
+
+1. `rm` moves a node to recoverable trash.
+2. `trash empty` permanently removes old tree entries, but is a dry run unless
+   `--run` is present.
+3. `gc` reclaims unreachable loose bytes, but is also a dry run unless `--run`
+   is present. Packed bytes become logically dead and await repacking; they are
+   not reported as physically reclaimed.
+
+```bash
+docbank rm /inbox/duplicate.pdf
+docbank trash list
+docbank trash empty --older-than 30d
+docbank trash empty --older-than 30d --run
+docbank gc
+docbank gc --run
+```
+
+Read each dry-run count before adding `--run`. If a document should return,
+restore its numeric trash ID before emptying:
+
+```bash
+docbank restore 42
+```
+
+### On a schedule
+
+Run `verify` after moving or restoring the vault, after storage trouble, and on
+a schedule appropriate for the archive. It reads and hashes every cataloged
+blob, so large vaults take time.
+
+```bash
+docbank verify
+```
+
+A clean result proves that each cataloged hash can be read and still matches
+its content. It does not replace a backup: verification can identify missing
+or corrupt bytes, but it cannot recreate them.
+
+## Upgrade without daemon drift
+
+Check first, then install when ready:
+
+```bash
+docbank update --check
+docbank update
+```
+
+An install stops a running daemon, replaces the binary, and starts the new
+daemon. If installation fails, docbank attempts to restart the old daemon.
+`daemon start`, `daemon restart`, and command auto-start also replace a daemon
+whose binary or API protocol is incompatible with the invoking CLI.
+
+For unattended installation, use `docbank update --yes`; do not use `--force`
+as a routine upgrade flag. It exists to bypass cached release metadata and to
+allow replacing an unversioned development build.
+
+## Take a coherent manual snapshot
+
+The current release provides no built-in backup command. For a coherent manual
+snapshot, stop the daemon before copying the vault so the SQLite database and
+blob catalog cannot change during the copy.
+
+```bash
+vault="${DOCBANK_HOME:-$HOME/.docbank}"
+docbank daemon stop
+tar -C "$(dirname "$vault")" -czf "docbank-$(date +%F).tar.gz" "$(basename "$vault")"
+docbank daemon start
+```
+
+The whole directory is the simplest snapshot. The essential archive state is
+`docbank.db` plus `blobs/`; `config.toml` is worth retaining when customized.
+Logs, lock files, and stale runtime records are not archive data.
+
+Protect the snapshot like the vault itself: document contents and a configured
+API key may both be present. Test restoration into a separate
+`DOCBANK_HOME`, then run `docbank verify` there.
+
+```bash
+export DOCBANK_HOME=/tmp/docbank-restore-test
+mkdir -p "$DOCBANK_HOME"
+# Restore the archived vault contents into this directory.
+docbank verify
+docbank tree /
+docbank daemon stop
+```
+
+Never point the restore test at the live vault, and never copy a snapshot over
+a running vault. To replace a damaged vault, stop the daemon, preserve the old
+directory under another name, restore the snapshot, and verify before resuming
+normal use.
+
+!!! info "Planned — built-in backups"
+    `docbank backup init|create|list|verify|restore` will eventually provide
+    encrypted, incremental snapshots with an explicit restore workflow. Those
+    commands do not exist yet. See [Backup](../architecture/backup.md).
+
+## Move a vault
+
+1. Stop the source daemon.
+2. Copy the complete vault directory while it is stopped.
+3. Point `DOCBANK_HOME` at the copy on the destination machine.
+4. Run `docbank verify`, then `docbank tree /`.
+5. Start using the destination only after both checks succeed.
+
+The database refers to content by hash rather than absolute filesystem path,
+so no path rewriting is required. docbank itself still requires macOS or
+Linux; the Windows build contains lifecycle stubs but cannot open a vault.
+
+## When something looks wrong
+
+Stop destructive maintenance, keep the original vault directory intact, and
+collect evidence before changing files by hand:
+
+```bash
+docbank daemon status --json
+docbank verify
+docbank daemon stop
+```
+
+Do not delete blob files, SQLite sidecars, lock files, or runtime records while
+the daemon is running. Continue with [Troubleshooting](../troubleshooting.md)
+for startup, import, integrity, and API failures.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -17,6 +17,7 @@ nav = [
     {"Configuration" = "configuration.md"},
   ]},
   {"User Guide" = [
+    {"Vault Lifecycle" = "usage/lifecycle.md"},
     {"Importing Documents" = "usage/importing.md"},
     {"Organizing the Tree" = "usage/organizing.md"},
     {"Searching" = "usage/searching.md"},
@@ -24,8 +25,12 @@ nav = [
   ]},
   {"Reference" = [
     {"CLI Reference" = "cli-reference.md"},
+  ]},
+  {"For Agents" = [
+    {"Integration Guide" = "agents/integration.md"},
     {"Agent HTTP API" = "architecture/http-api.md"},
   ]},
+  {"Troubleshooting" = "troubleshooting.md"},
   {"Architecture" = [
     {"Overview" = "architecture/overview.md"},
     {"Storage" = "architecture/storage.md"},


### PR DESCRIPTION
Docbank already documents each command and endpoint, but reference coverage alone does not answer the operational questions that prevent data loss and automation mistakes. Operators need a coherent path from first import through deletion, verification, upgrades, snapshots, and recovery. Agents need policy around discovery, pagination, revisions, retries, ingest boundaries, and destructive intent—not just a list of routes.

This PR gives each audience a task-oriented journey while preserving the existing references as the source of exact command and wire semantics. The lifecycle guide makes the daemon ownership model and three-stage deletion process concrete, including a stop-before-copy manual snapshot procedure until built-in backups exist. Troubleshooting begins with evidence preservation and maps startup, import, integrity, update, and HTTP failures to safe next actions.

The agent guide treats the OpenAPI document as canonical and turns it into an operating model: stable loopback authentication for independent clients, bounded reads, ID-plus-revision mutations, deliberate handling of stale revisions, local-only ingest, machine-readable problem codes, and separate preview and execution decisions for permanent maintenance. The navigation now makes this material a first-class audience path rather than leaving it embedded in architecture prose.