### PR TITLE
Expose packed storage inventory

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/store"
 )
@@ -325,6 +327,25 @@ func TestGcReclaimsUnreachableBlobs(t *testing.T) {
 	out, err = runCLI(t, "gc")
 	require.NoError(t, err)
 	assert.Contains(t, out, "0 candidate")
+}
+
+func TestStorageStatusHumanAndJSON(t *testing.T) {
+	_ = setupVaultHome(t)
+	src := writeSourceFile(t, "a.txt", "alpha")
+	_, err := runCLI(t, "add", src, "--dest", "/inbox")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "storage", "status")
+	require.NoError(t, err)
+	assert.Contains(t, out, "loose: 1 blob(s), 5 byte(s)")
+	assert.Contains(t, out, "packed: 0 live blob(s) in 0 pack(s)")
+
+	out, err = runCLI(t, "storage", "status", "--json")
+	require.NoError(t, err)
+	var status api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(out), &status))
+	assert.Equal(t, 1, status.LooseBlobs)
+	assert.Equal(t, int64(5), status.LooseBytes)
 }
 
 func TestVerifyDetectsMissingAndCorrupt(t *testing.T) {

--- a/cmd/docbank/storage.go
+++ b/cmd/docbank/storage.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/client"
+)
+
+var storageCmd = &cobra.Command{
+	Use:   "storage",
+	Short: "Inspect and maintain physical blob storage",
+}
+
+var storageStatusJSON bool
+
+var storageStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Report loose and packed storage usage",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		status, err := c.StorageStatus(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if storageStatusJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(status)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "loose: %d blob(s), %d byte(s)\n",
+			status.LooseBlobs, status.LooseBytes)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"packed: %d live blob(s) in %d pack(s), %d stored byte(s), %d raw byte(s)\n",
+			status.PackedBlobs, status.Packs, status.PackedStoredBytes, status.PackedRawBytes)
+		if status.DeadPackedBytes > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pending repack: %d stored byte(s)\n",
+				status.DeadPackedBytes)
+		}
+		return nil
+	},
+}
+
+func init() {
+	storageStatusCmd.Flags().BoolVar(&storageStatusJSON, "json", false, "machine-readable output")
+	storageCmd.AddCommand(storageStatusCmd)
+	rootCmd.AddCommand(storageCmd)
+}

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -12,10 +12,10 @@ mixed reads, and physical lifecycle coordination. Existing vaults require no
 conversion: ordinary writes still land loose and both representations are
 valid indefinitely.
 
-!!! info "Planned — operator surface"
-    Authenticated daemon operations for status, explicit packing, repacking,
-    and unpacking have not landed yet. Startup never performs an implicit
-    migration, and automatic background maintenance remains a later step.
+`docbank storage status` exposes loose and packed inventory through the
+authenticated daemon API. Explicit packing, repacking, and unpacking remain
+planned. Startup never performs an implicit migration, and automatic
+background maintenance remains a later step.
 
 Large collections of small files are expensive to enumerate, copy, and restore.
 msgvault uses immutable pack files as the steady-state storage format for
@@ -62,6 +62,8 @@ and does not own either application's schema or garbage-collection policy.
    catalog interfaces and migrate msgvault without observable behavior change.
 3. **Complete:** add docbank's SQLite catalog, mixed reader, durable loose
    writer, GC integration, and the Kit catalog conformance suite.
+4. **Complete:** expose read-only loose, live-packed, and dead-packed storage
+   inventory through the authenticated daemon API and CLI.
 
 !!! info "Planned — next adoption steps"
     Daemon-first pack, repack, and unpack operations will expose the existing

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -188,6 +188,17 @@ reports in the meantime. The daemon's maintenance gate holds off
 concurrent mutations while `gc --run` runs, so it never races a
 concurrent import (see [Concurrency & Locking](architecture/locking.md)).
 
+## docbank storage status
+
+```
+docbank storage status [--json]
+```
+
+Reports the daemon's physical storage inventory: loose blob count and bytes,
+live packed blobs and their stored/raw bytes, pack count, and immutable packed
+bytes pending repack. The command is read-only. `--json` emits the same fields
+as the authenticated `GET /api/v1/storage` endpoint.
+
 ## docbank verify
 
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -64,10 +64,10 @@ marked planned appears elsewhere in these docs only under an explicit
   open without conversion, and GC/verify operate through the shared
   physical store
 
-!!! info "Planned — packed-storage operations"
-    Daemon-backed status, pack, repack, and unpack commands are the next
-    delivery. Until then, ordinary ingests continue to publish loose blobs;
-    startup never performs an implicit migration.
+`docbank storage status` now reports loose, live-packed, and dead-packed
+inventory through the daemon. Pack, repack, and unpack commands remain the
+next delivery. Until then, ordinary ingests continue to publish loose blobs;
+startup never performs an implicit migration.
 
 ## Phase 2b — Features (designed)
 

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -16,7 +16,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	doc := string(out)
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
-		"ingest", "listTrash", "emptyTrash", "gc", "verify"} {
+		"storageStatus", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
 	assert.NotContains(t, doc, "/api/daemon/shutdown", "lifecycle plumbing must stay hidden")

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -19,6 +19,23 @@ import (
 )
 
 func registerOpsRoutes(api huma.API, d Deps, g *gate) {
+	type storageStatusOutput struct{ Body StorageStatus }
+	huma.Register(api, huma.Operation{
+		OperationID: "storageStatus", Method: http.MethodGet, Path: "/api/v1/storage",
+		Summary: "Report loose and packed physical storage usage",
+	}, func(ctx context.Context, _ *struct{}) (*storageStatusOutput, error) {
+		stats, err := d.Blobs.Stats(ctx)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return &storageStatusOutput{Body: StorageStatus{
+			LooseBlobs: stats.LooseBlobs, LooseBytes: stats.LooseBytes,
+			Packs: stats.Packs, PackStoredBytes: stats.PackStoredBytes,
+			PackedBlobs: stats.PackedBlobs, PackedRawBytes: stats.PackedRawBytes,
+			PackedStoredBytes: stats.PackedStoredBytes, DeadPackedBytes: stats.DeadPackedBytes,
+		}}, nil
+	})
+
 	type ingestOutput struct{ Body IngestReport }
 	huma.Register(api, huma.Operation{
 		OperationID: "ingest", Method: http.MethodPost, Path: "/api/v1/ingest",

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -130,6 +130,33 @@ func TestTrashListAndEmpty(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 }
 
+func TestStorageStatusReportsLooseAndPackedUsage(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	createFileWithContent(t, ts, s, "/packed.txt", "packed storage status")
+
+	resp, body := get(t, ts, "/api/v1/storage", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var status api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(body), &status))
+	assert.Equal(t, 1, status.LooseBlobs)
+	assert.Equal(t, int64(len("packed storage status")), status.LooseBytes)
+	assert.Zero(t, status.Packs)
+
+	packed, err := s.Blobs.Maintainer().Pack(t.Context(), packstore.PackOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, packed.BlobsPacked)
+	resp, body = get(t, ts, "/api/v1/storage", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	require.NoError(t, json.Unmarshal([]byte(body), &status))
+	assert.Zero(t, status.LooseBlobs)
+	assert.Equal(t, 1, status.Packs)
+	assert.Equal(t, int64(1), status.PackedBlobs)
+	assert.Equal(t, int64(len("packed storage status")), status.PackedRawBytes)
+	assert.Positive(t, status.PackedStoredBytes)
+	assert.Equal(t, status.PackedStoredBytes, status.PackStoredBytes)
+	assert.Zero(t, status.DeadPackedBytes)
+}
+
 func TestGCRevokesPackedBlobAuthority(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	file := createFileWithContent(t, ts, s, "/packed.txt", "packed gc content")
@@ -163,6 +190,13 @@ func TestGCRevokesPackedBlobAuthority(t *testing.T) {
 	records, err := store.NewPackCatalog(s.Store).ListPackRecords(t.Context())
 	require.NoError(t, err)
 	require.Len(t, records, 1, "physical inventory remains until reader-safe retirement")
+	resp, body = get(t, ts, "/api/v1/storage", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var status api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(body), &status))
+	assert.Zero(t, status.PackedBlobs)
+	assert.Positive(t, status.DeadPackedBytes)
+	assert.Equal(t, status.PackStoredBytes, status.DeadPackedBytes)
 
 	repacked, err := s.Blobs.Maintainer().Repack(t.Context(), packstore.RepackOptions{})
 	require.NoError(t, err)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -65,6 +65,19 @@ type GCReport struct {
 	Run                bool  `json:"run"`
 }
 
+// StorageStatus reports physical loose inventory and catalog-authorized pack
+// usage. PackStoredBytes includes both live and logically dead payload bytes.
+type StorageStatus struct {
+	LooseBlobs        int   `json:"loose_blobs"`
+	LooseBytes        int64 `json:"loose_bytes"`
+	Packs             int   `json:"packs"`
+	PackStoredBytes   int64 `json:"pack_stored_bytes"`
+	PackedBlobs       int64 `json:"packed_blobs"`
+	PackedRawBytes    int64 `json:"packed_raw_bytes"`
+	PackedStoredBytes int64 `json:"packed_stored_bytes"`
+	DeadPackedBytes   int64 `json:"dead_packed_bytes"`
+}
+
 // VerifyProblem flags one blob whose content didn't check out.
 type VerifyProblem struct {
 	Hash    string `json:"hash"`

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -23,6 +23,7 @@ var ErrInvalidHash = packstore.ErrInvalidHash
 type Store struct {
 	dir         string
 	layout      packstore.Layout
+	catalog     packstore.Catalog
 	loose       *packstore.LooseStore
 	reader      *packstore.Store
 	maintainer  *packstore.Maintainer
@@ -47,8 +48,49 @@ func New(catalog packstore.Catalog, blobsDir string) (*Store, error) {
 		_ = maintainer.Close()
 		return nil, fmt.Errorf("creating loose blob store: %w", err)
 	}
-	return &Store{dir: blobsDir, layout: layout, loose: loose, reader: maintainer.Store(),
+	return &Store{dir: blobsDir, layout: layout, catalog: catalog, loose: loose, reader: maintainer.Store(),
 		maintainer: maintainer, coordinator: coordinator}, nil
+}
+
+// StorageStats describes the daemon's current physical storage inventory.
+// Packed dead bytes remain inside immutable packs until repack retires them.
+type StorageStats struct {
+	LooseBlobs        int
+	LooseBytes        int64
+	Packs             int
+	PackStoredBytes   int64
+	PackedBlobs       int64
+	PackedRawBytes    int64
+	PackedStoredBytes int64
+	DeadPackedBytes   int64
+}
+
+// Stats reports loose files and catalog-authorized pack usage without opening
+// or rewriting content.
+func (s *Store) Stats(ctx context.Context) (StorageStats, error) {
+	loose, err := s.List()
+	if err != nil {
+		return StorageStats{}, err
+	}
+	usage, err := s.catalog.ListPackUsage(ctx)
+	if err != nil {
+		return StorageStats{}, fmt.Errorf("listing pack usage: %w", err)
+	}
+	stats := StorageStats{LooseBlobs: len(loose), Packs: len(usage)}
+	for _, size := range loose {
+		stats.LooseBytes += size
+	}
+	for _, pack := range usage {
+		stats.PackStoredBytes += pack.StoredBytes
+		stats.PackedBlobs += pack.LiveEntries
+		stats.PackedRawBytes += pack.LiveRawBytes
+		stats.PackedStoredBytes += pack.LiveStoredBytes
+	}
+	if stats.PackedStoredBytes > stats.PackStoredBytes {
+		return StorageStats{}, errors.New("pack usage is inconsistent: live stored bytes exceed pack totals")
+	}
+	stats.DeadPackedBytes = stats.PackStoredBytes - stats.PackedStoredBytes
+	return stats, nil
 }
 
 // newReaderStore constructs a mixed reader without a maintenance catalog. It

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -236,6 +236,12 @@ func (c *Client) GC(ctx context.Context, run bool) (api.GCReport, error) {
 	return rep, err
 }
 
+func (c *Client) StorageStatus(ctx context.Context) (api.StorageStatus, error) {
+	var status api.StorageStatus
+	err := c.do(ctx, http.MethodGet, "/api/v1/storage", nil, nil, &status)
+	return status, err
+}
+
 func (c *Client) Verify(ctx context.Context) (api.VerifyReport, error) {
 	var rep api.VerifyReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/verify", nil, nil, &rep)


### PR DESCRIPTION
Operators need a truthful baseline before docbank exposes commands that rewrite its physical storage. Today the Kit-backed lifecycle exists internally, but there is no supported way to distinguish loose content, live packed payload, and immutable dead payload awaiting repack. That makes future pack and reclamation behavior difficult to observe and risks implying that logically deleted packed bytes have already left disk.

This PR establishes that baseline as a read-only, authenticated daemon capability with both human and machine-readable CLI output. It deliberately lands before pack, repack, and unpack mutations so reviewers can evaluate the accounting contract independently, and so each later operation has observable before-and-after state.

The boundary remains daemon-first: clients consume the HTTP contract, while docbank asks Kit’s catalog and canonical loose layout for physical inventory. No CLI process opens the vault, and startup still performs no implicit conversion.