### PR TITLE
Expose explicit packed-storage maintenance

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -348,6 +348,34 @@ func TestStorageStatusHumanAndJSON(t *testing.T) {
 	assert.Equal(t, int64(5), status.LooseBytes)
 }
 
+func TestStoragePackBudgetAndJSON(t *testing.T) {
+	_ = setupVaultHome(t)
+	for name, content := range map[string]string{"a.txt": "alpha", "b.txt": "bravo"} {
+		src := writeSourceFile(t, name, content)
+		_, err := runCLI(t, "add", src, "--dest", "/inbox")
+		require.NoError(t, err)
+	}
+
+	out, err := runCLI(t, "storage", "pack", "--max-bytes", "1")
+	require.NoError(t, err)
+	assert.Contains(t, out, "packed 1 blob(s)")
+	assert.Contains(t, out, "byte budget exhausted")
+
+	out, err = runCLI(t, "storage", "pack", "--json")
+	require.NoError(t, err)
+	var report api.StoragePackReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, 1, report.BlobsPacked)
+	assert.False(t, report.BudgetExhausted)
+
+	out, err = runCLI(t, "storage", "status", "--json")
+	require.NoError(t, err)
+	var status api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(out), &status))
+	assert.Zero(t, status.LooseBlobs)
+	assert.Equal(t, int64(2), status.PackedBlobs)
+}
+
 func TestVerifyDetectsMissingAndCorrupt(t *testing.T) {
 	home := setupVaultHome(t)
 	srcA := writeSourceFile(t, "a.txt", "alpha")

--- a/cmd/docbank/storage.go
+++ b/cmd/docbank/storage.go
@@ -47,8 +47,66 @@ var storageStatusCmd = &cobra.Command{
 	},
 }
 
+var (
+	storagePackMaxBytes int64
+	storagePackJSON     bool
+)
+
+var storagePackCmd = &cobra.Command{
+	Use:   "pack",
+	Short: "Pack authorized loose blobs into immutable pack files",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		report, err := c.StoragePack(cmd.Context(), storagePackMaxBytes)
+		if err != nil {
+			return err
+		}
+		if storagePackJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(report)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "packed %d blob(s), %d raw byte(s), sealed %d pack(s)\n",
+			report.BlobsPacked, report.BytesPacked, report.PacksSealed)
+		if report.LooseSwept > 0 || report.LooseOrphansRemoved > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"removed %d redundant loose file(s) and %d orphan loose object(s)\n",
+				report.LooseSwept, report.LooseOrphansRemoved)
+		}
+		if report.PacksAdopted+report.PacksRemoved+report.PacksQuarantined+
+			report.PacksUnreadable+report.RecordsDropped > 0 || report.MappingsPruned > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"reconciled packs: %d adopted, %d removed, %d quarantined, %d unreadable; "+
+					"%d record(s) dropped, %d mapping(s) pruned\n",
+				report.PacksAdopted, report.PacksRemoved, report.PacksQuarantined,
+				report.PacksUnreadable, report.RecordsDropped, report.MappingsPruned)
+		}
+		if report.BlobsMissing+report.BlobsCorrupt+report.BlobsDeferredOversized+
+			report.PacksDeferredOversized > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"deferred: %d missing blob(s), %d corrupt blob(s), %d oversized blob(s), %d oversized pack(s)\n",
+				report.BlobsMissing, report.BlobsCorrupt, report.BlobsDeferredOversized,
+				report.PacksDeferredOversized)
+		}
+		if report.LooseOrphanSweepSuppressed {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "orphan loose sweep suppressed: reference inventory was incomplete")
+		}
+		if report.BudgetExhausted {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "byte budget exhausted; run again to continue")
+		}
+		return nil
+	},
+}
+
 func init() {
 	storageStatusCmd.Flags().BoolVar(&storageStatusJSON, "json", false, "machine-readable output")
-	storageCmd.AddCommand(storageStatusCmd)
+	storagePackCmd.Flags().Int64Var(&storagePackMaxBytes, "max-bytes", 0,
+		"soft raw-byte work budget (0 is unlimited)")
+	storagePackCmd.Flags().BoolVar(&storagePackJSON, "json", false, "machine-readable output")
+	storageCmd.AddCommand(storageStatusCmd, storagePackCmd)
 	rootCmd.AddCommand(storageCmd)
 }

--- a/cmd/docbank/storage.go
+++ b/cmd/docbank/storage.go
@@ -96,7 +96,7 @@ var storagePackCmd = &cobra.Command{
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "orphan loose sweep suppressed: reference inventory was incomplete")
 		}
 		if report.BudgetExhausted {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "byte budget exhausted; run again to continue")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "byte budget exhausted; rerun if loose blobs remain")
 		}
 		return nil
 	},

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -216,6 +216,13 @@ expensive. Maintenance requests serialize against mutations and may run
 without the ordinary request timeout; agents should expose progress as
 “waiting” rather than assuming a queued request is hung.
 
+`POST /api/v1/storage/pack` is explicit but non-destructive: it changes the
+physical representation without changing document identity or blob read
+authority. Use `GET /api/v1/storage` before and after when an operator needs an
+auditable result. A positive `max_bytes` bounds raw-byte work softly—the blob
+that crosses the budget is committed—and `budget_exhausted: true` means another
+request is needed to continue.
+
 ## Branch on problem codes
 
 Non-2xx responses use RFC 7807 problem JSON:

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -220,8 +220,9 @@ without the ordinary request timeout; agents should expose progress as
 physical representation without changing document identity or blob read
 authority. Use `GET /api/v1/storage` before and after when an operator needs an
 auditable result. A positive `max_bytes` bounds raw-byte work softly—the blob
-that crosses the budget is committed—and `budget_exhausted: true` means another
-request is needed to continue.
+that crosses the budget is committed. `budget_exhausted: true` describes that
+crossing, not whether eligible loose blobs remain; inspect storage status before
+deciding to issue another request.
 
 ## Branch on problem codes
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -42,6 +42,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /nodes/{id}/trash` · `POST /nodes/{id}/restore` | soft delete / recover | Implemented |
 | `GET /trash` · `POST /trash/empty` `{run, older_than}` | list / report or hard-delete trash roots | Implemented |
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / re-hash all blobs | Implemented |
+| `GET /storage` · `POST /storage/pack` `{max_bytes}` | inspect physical usage / explicitly pack loose blobs | Implemented |
 
 Root-level, outside `/api/v1` and auth-exempt: `GET /health`, `GET
 /api/ping` (daemon discovery), `GET /docs` and the OpenAPI documents,

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -13,9 +13,10 @@ conversion: ordinary writes still land loose and both representations are
 valid indefinitely.
 
 `docbank storage status` exposes loose and packed inventory through the
-authenticated daemon API. Explicit packing, repacking, and unpacking remain
-planned. Startup never performs an implicit migration, and automatic
-background maintenance remains a later step.
+authenticated daemon API, and `docbank storage pack` explicitly moves
+authorized loose content into immutable packs with an optional work budget.
+Repacking and unpacking remain planned. Startup never performs an implicit
+migration, and automatic background maintenance remains a later step.
 
 Large collections of small files are expensive to enumerate, copy, and restore.
 msgvault uses immutable pack files as the steady-state storage format for
@@ -64,9 +65,11 @@ and does not own either application's schema or garbage-collection policy.
    writer, GC integration, and the Kit catalog conformance suite.
 4. **Complete:** expose read-only loose, live-packed, and dead-packed storage
    inventory through the authenticated daemon API and CLI.
+5. **Complete:** expose explicit, optionally budgeted packing through the
+   daemon maintenance gate and Kit coordinator.
 
 !!! info "Planned — next adoption steps"
-    Daemon-first pack, repack, and unpack operations will expose the existing
+    Daemon-first repack and unpack operations will expose the remaining
     mechanics. Built-in backup and external integrations will use the catalog
     and content-hash boundary rather than private pack internals.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -213,9 +213,10 @@ packed storage remains valid after an interruption.
 
 `--max-bytes` is a soft raw-byte work budget. The blob that crosses the budget
 is committed before the operation stops, and output says the budget was
-exhausted; run the command again to continue. Zero (the default) is unlimited.
-`--json` includes packing, repair, deferral, and reconciliation counters from
-the shared Kit lifecycle engine.
+exhausted. Check `storage status` and rerun if loose blobs remain; crossing the
+budget does not itself prove that more eligible work exists. Zero (the default)
+is unlimited. `--json` includes packing, repair, deferral, and reconciliation
+counters from the shared Kit lifecycle engine.
 
 ## docbank verify
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -199,6 +199,24 @@ live packed blobs and their stored/raw bytes, pack count, and immutable packed
 bytes pending repack. The command is read-only. `--json` emits the same fields
 as the authenticated `GET /api/v1/storage` endpoint.
 
+## docbank storage pack
+
+```
+docbank storage pack [--max-bytes <bytes>] [--json]
+```
+
+Explicitly converts authorized loose blobs into immutable Kit pack files. The
+operation runs through the authenticated daemon and holds the vault maintenance
+gate; reads remain available, while imports and other mutations wait. Packing
+does not change document identity or blob read authority, and mixed loose and
+packed storage remains valid after an interruption.
+
+`--max-bytes` is a soft raw-byte work budget. The blob that crosses the budget
+is committed before the operation stops, and output says the budget was
+exhausted; run the command again to continue. Zero (the default) is unlimited.
+`--json` includes packing, repair, deferral, and reconciliation counters from
+the shared Kit lifecycle engine.
+
 ## docbank verify
 
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -64,10 +64,11 @@ marked planned appears elsewhere in these docs only under an explicit
   open without conversion, and GC/verify operate through the shared
   physical store
 
-`docbank storage status` now reports loose, live-packed, and dead-packed
-inventory through the daemon. Pack, repack, and unpack commands remain the
-next delivery. Until then, ordinary ingests continue to publish loose blobs;
-startup never performs an implicit migration.
+`docbank storage status` reports loose, live-packed, and dead-packed inventory,
+and `docbank storage pack` performs explicit optionally budgeted packing through
+the daemon. Repack and unpack commands remain the next delivery. Ordinary
+ingests continue to publish loose blobs; startup never performs an implicit
+migration.
 
 ## Phase 2b — Features (designed)
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -16,7 +16,8 @@ const requestTimeout = 60 * time.Second
 // timeout-exempt: long-running maintenance and bulk ingest.
 func timeoutExempt(path string) bool {
 	switch path {
-	case "/api/v1/ingest", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty":
+	case "/api/v1/ingest", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
+		"/api/v1/storage/pack":
 		return true
 	}
 	return false

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -16,7 +16,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	doc := string(out)
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
-		"storageStatus", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
+		"storageStatus", "storagePack", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
 	assert.NotContains(t, doc, "/api/daemon/shutdown", "lifecycle plumbing must stay hidden")

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/internal/ingest"
 )
@@ -34,6 +35,27 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 			PackedBlobs: stats.PackedBlobs, PackedRawBytes: stats.PackedRawBytes,
 			PackedStoredBytes: stats.PackedStoredBytes, DeadPackedBytes: stats.DeadPackedBytes,
 		}}, nil
+	})
+
+	type storagePackOutput struct{ Body StoragePackReport }
+	huma.Register(api, huma.Operation{
+		OperationID: "storagePack", Method: http.MethodPost, Path: "/api/v1/storage/pack",
+		Summary: "Pack authorized loose blobs into immutable pack files",
+	}, func(ctx context.Context, in *struct {
+		Body struct {
+			MaxBytes int64 `json:"max_bytes,omitempty" minimum:"0"`
+		}
+	}) (*storagePackOutput, error) {
+		out := &storagePackOutput{}
+		err := g.maintain(func() error {
+			stats, err := d.Blobs.Maintainer().Pack(ctx, packstore.PackOptions{MaxBytes: in.Body.MaxBytes})
+			if err != nil {
+				return FromStoreError(err)
+			}
+			out.Body = storagePackReport(stats)
+			return nil
+		})
+		return out, err
 	})
 
 	type ingestOutput struct{ Body IngestReport }
@@ -180,6 +202,21 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		})
 		return out, err
 	})
+}
+
+func storagePackReport(stats packstore.PackStats) StoragePackReport {
+	return StoragePackReport{
+		PacksSealed: stats.PacksSealed, BlobsPacked: stats.BlobsPacked, BytesPacked: stats.BytesPacked,
+		PacksAdopted: stats.PacksAdopted, PacksRemoved: stats.PacksRemoved,
+		PacksQuarantined: stats.PacksQuarantined, PacksUnreadable: stats.PacksUnreadable,
+		RecordsDropped: stats.RecordsDropped, MappingsPruned: stats.MappingsPruned,
+		BlobsMissing: stats.BlobsMissing, BlobsCorrupt: stats.BlobsCorrupt,
+		BlobsDeferredOversized: stats.BlobsDeferredOversized,
+		PacksDeferredOversized: stats.PacksDeferredOversized,
+		LooseSwept:             stats.LooseSwept, LooseOrphansRemoved: stats.LooseOrphansRemoved,
+		LooseOrphanSweepSuppressed: stats.LooseOrphanSweepSuppressed,
+		BudgetExhausted:            stats.BudgetExhausted,
+	}
 }
 
 // runGC ports cmd/gc.go's semantics: candidates from row reachability,

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -157,6 +157,45 @@ func TestStorageStatusReportsLooseAndPackedUsage(t *testing.T) {
 	assert.Zero(t, status.DeadPackedBytes)
 }
 
+func TestStoragePackHonorsBudgetAndConverges(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	createFileWithContent(t, ts, s, "/one.txt", "one")
+	createFileWithContent(t, ts, s, "/two.txt", "two")
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/storage/pack", nil,
+		map[string]any{"max_bytes": 1})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var report api.StoragePackReport
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.Equal(t, 1, report.BlobsPacked)
+	assert.Equal(t, 1, report.PacksSealed)
+	assert.True(t, report.BudgetExhausted)
+
+	statusResp, statusBody := get(t, ts, "/api/v1/storage", nil)
+	require.Equal(t, http.StatusOK, statusResp.StatusCode, statusBody)
+	var status api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(statusBody), &status))
+	assert.Equal(t, 1, status.LooseBlobs)
+	assert.Equal(t, int64(1), status.PackedBlobs)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/storage/pack", nil,
+		map[string]any{"max_bytes": 0})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.Equal(t, 1, report.BlobsPacked)
+	assert.False(t, report.BudgetExhausted)
+
+	statusResp, statusBody = get(t, ts, "/api/v1/storage", nil)
+	require.Equal(t, http.StatusOK, statusResp.StatusCode, statusBody)
+	require.NoError(t, json.Unmarshal([]byte(statusBody), &status))
+	assert.Zero(t, status.LooseBlobs)
+	assert.Equal(t, int64(2), status.PackedBlobs)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/storage/pack", nil,
+		map[string]any{"max_bytes": -1})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+}
+
 func TestGCRevokesPackedBlobAuthority(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	file := createFileWithContent(t, ts, s, "/packed.txt", "packed gc content")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -78,6 +78,27 @@ type StorageStatus struct {
 	DeadPackedBytes   int64 `json:"dead_packed_bytes"`
 }
 
+// StoragePackReport summarizes one explicit Kit packing and repair pass.
+type StoragePackReport struct {
+	PacksSealed                int   `json:"packs_sealed"`
+	BlobsPacked                int   `json:"blobs_packed"`
+	BytesPacked                int64 `json:"bytes_packed"`
+	PacksAdopted               int   `json:"packs_adopted"`
+	PacksRemoved               int   `json:"packs_removed"`
+	PacksQuarantined           int   `json:"packs_quarantined"`
+	PacksUnreadable            int   `json:"packs_unreadable"`
+	RecordsDropped             int   `json:"records_dropped"`
+	MappingsPruned             int64 `json:"mappings_pruned"`
+	BlobsMissing               int   `json:"blobs_missing"`
+	BlobsCorrupt               int   `json:"blobs_corrupt"`
+	BlobsDeferredOversized     int   `json:"blobs_deferred_oversized"`
+	PacksDeferredOversized     int   `json:"packs_deferred_oversized"`
+	LooseSwept                 int   `json:"loose_swept"`
+	LooseOrphansRemoved        int   `json:"loose_orphans_removed"`
+	LooseOrphanSweepSuppressed bool  `json:"loose_orphan_sweep_suppressed"`
+	BudgetExhausted            bool  `json:"budget_exhausted"`
+}
+
 // VerifyProblem flags one blob whose content didn't check out.
 type VerifyProblem struct {
 	Hash    string `json:"hash"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -242,6 +242,13 @@ func (c *Client) StorageStatus(ctx context.Context) (api.StorageStatus, error) {
 	return status, err
 }
 
+func (c *Client) StoragePack(ctx context.Context, maxBytes int64) (api.StoragePackReport, error) {
+	var report api.StoragePackReport
+	err := c.do(ctx, http.MethodPost, "/api/v1/storage/pack", nil,
+		map[string]any{"max_bytes": maxBytes}, &report)
+	return report, err
+}
+
 func (c *Client) Verify(ctx context.Context) (api.VerifyReport, error) {
 	var rep api.VerifyReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/verify", nil, nil, &rep)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -97,6 +97,20 @@ func TestAPIKeySent(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestStoragePackRoundTrip(t *testing.T) {
+	c, _ := newClient(t, serverKey)
+	src := filepath.Join(t.TempDir(), "pack.txt")
+	require.NoError(t, os.WriteFile(src, []byte("pack me"), 0o600))
+	ingested, err := c.Ingest(t.Context(), []string{src}, "/inbox")
+	require.NoError(t, err)
+	require.Equal(t, 1, ingested.Added)
+
+	report, err := c.StoragePack(t.Context(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.BlobsPacked)
+	assert.True(t, report.BudgetExhausted)
+}
+
 // TestWrongAPIKeyIsRejected is the client-side half of the keyless-loopback
 // regression: a client holding the wrong key must get a clearly readable
 // 401, never silent success and never an opaque envelope dump.


### PR DESCRIPTION
Docbank now understands Kit-packed content and can report its physical inventory, but operators still have no supported way to move ordinary loose ingests into that representation. Leaving packing reachable only from internal tests prevents us from treating packed storage as normal live state and blocks the repack, unpack, and backup work that depends on an operator-visible lifecycle.

This PR adds packing as an explicit authenticated daemon operation rather than an implicit startup migration. An optional soft raw-byte budget bounds a maintenance pass while preserving Kit’s atomicity: the blob that crosses the budget is committed, the response reports exhaustion, and another invocation continues safely. Human output emphasizes the primary result and exceptional reconciliation; JSON preserves the complete Kit outcome for automation.

The ordering is intentional: docbank’s API maintenance gate is acquired before Kit’s packstore coordinator. Mutations therefore wait while physical authority changes, reads remain available, and the CLI remains an HTTP client that never opens the vault directly. Repack and unpack remain isolated follow-up PRs.