### PR TITLE
Expose sparse pack reclamation

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -376,6 +376,42 @@ func TestStoragePackBudgetAndJSON(t *testing.T) {
 	assert.Equal(t, int64(2), status.PackedBlobs)
 }
 
+func TestStorageRepackJSON(t *testing.T) {
+	_ = setupVaultHome(t)
+	for name, content := range map[string]string{
+		"keep.txt": "keep", "drop-a.txt": "drop a", "drop-b.txt": "drop b",
+	} {
+		src := writeSourceFile(t, name, content)
+		_, err := runCLI(t, "add", src, "--dest", "/inbox")
+		require.NoError(t, err)
+	}
+	_, err := runCLI(t, "storage", "pack")
+	require.NoError(t, err)
+	for _, path := range []string{"/inbox/drop-a.txt", "/inbox/drop-b.txt"} {
+		_, err = runCLI(t, "rm", path)
+		require.NoError(t, err)
+	}
+	_, err = runCLI(t, "trash", "empty", "--run")
+	require.NoError(t, err)
+	_, err = runCLI(t, "gc", "--run")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "storage", "repack", "--min-age", "1ns",
+		"--min-dead-bytes", "1", "--json")
+	require.NoError(t, err)
+	var report api.StorageRepackReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, 1, report.PacksRewritten)
+	assert.Equal(t, 1, report.PacksRemoved)
+	assert.Equal(t, 1, report.BlobsRepacked)
+
+	out, err = runCLI(t, "storage", "status", "--json")
+	require.NoError(t, err)
+	var status api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(out), &status))
+	assert.Zero(t, status.DeadPackedBytes)
+}
+
 func TestVerifyDetectsMissingAndCorrupt(t *testing.T) {
 	home := setupVaultHome(t)
 	srcA := writeSourceFile(t, "a.txt", "alpha")

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -412,6 +412,22 @@ func TestStorageRepackJSON(t *testing.T) {
 	assert.Zero(t, status.DeadPackedBytes)
 }
 
+func TestDeletionHelpSeparatesTrashGCAndRepack(t *testing.T) {
+	out, err := runCLI(t, "rm", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, out, "rm never permanently deletes metadata or reclaims content")
+
+	out, err = runCLI(t, "trash", "empty", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Content bytes remain")
+	assert.Contains(t, out, "packed space then requires repack")
+
+	out, err = runCLI(t, "gc", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, out, "loose files are reclaimed immediately")
+	assert.Contains(t, out, "requires a separate storage repack")
+}
+
 func TestVerifyDetectsMissingAndCorrupt(t *testing.T) {
 	home := setupVaultHome(t)
 	srcA := writeSourceFile(t, "a.txt", "alpha")

--- a/cmd/docbank/gc.go
+++ b/cmd/docbank/gc.go
@@ -13,7 +13,10 @@ var gcRun bool
 var gcCmd = &cobra.Command{
 	Use:   "gc",
 	Short: "Reclaim unreachable blobs (dry-run unless --run)",
-	Args:  cobra.NoArgs,
+	Long: "Remove authority for blobs with no remaining references. With --run, loose " +
+		"files are reclaimed immediately; packed payload becomes logically dead and " +
+		"requires a separate storage repack to reclaim physical pack space.",
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/cmd/docbank/rm.go
+++ b/cmd/docbank/rm.go
@@ -11,7 +11,10 @@ import (
 var rmCmd = &cobra.Command{
 	Use:   "rm <path>",
 	Short: "Move a node (and its subtree) to the trash",
-	Args:  cobra.ExactArgs(1),
+	Long: "Move a node (and its subtree) to recoverable trash. rm never permanently " +
+		"deletes metadata or reclaims content; use trash empty, gc, and storage repack " +
+		"as separate explicit maintenance steps.",
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/cmd/docbank/storage.go
+++ b/cmd/docbank/storage.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -102,11 +103,60 @@ var storagePackCmd = &cobra.Command{
 	},
 }
 
+var (
+	storageRepackMaxBytes     int64
+	storageRepackMinAge       time.Duration
+	storageRepackMinDeadBytes int64
+	storageRepackJSON         bool
+)
+
+var storageRepackCmd = &cobra.Command{
+	Use:   "repack",
+	Short: "Rewrite sparse packs and retire dead pack files",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		report, err := c.StorageRepack(cmd.Context(), storageRepackMaxBytes,
+			storageRepackMinAge, storageRepackMinDeadBytes)
+		if err != nil {
+			return err
+		}
+		if storageRepackJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(report)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"selected %d pack(s); rewrote %d live blob(s), %d raw byte(s), into %d pack(s)\n",
+			report.PacksSelected, report.BlobsRepacked, report.BytesRepacked, report.PacksSealed)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "retired %d source pack(s); pruned %d stale mapping(s)\n",
+			report.PacksRemoved, report.MappingsPruned)
+		if report.PacksDeferredOversized > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "deferred %d oversized pack(s)\n",
+				report.PacksDeferredOversized)
+		}
+		if report.BudgetExhausted {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "byte budget exhausted; rerun to continue selected work")
+		}
+		return nil
+	},
+}
+
 func init() {
 	storageStatusCmd.Flags().BoolVar(&storageStatusJSON, "json", false, "machine-readable output")
 	storagePackCmd.Flags().Int64Var(&storagePackMaxBytes, "max-bytes", 0,
 		"soft raw-byte work budget (0 is unlimited)")
 	storagePackCmd.Flags().BoolVar(&storagePackJSON, "json", false, "machine-readable output")
-	storageCmd.AddCommand(storageStatusCmd, storagePackCmd)
+	storageRepackCmd.Flags().Int64Var(&storageRepackMaxBytes, "max-bytes", 0,
+		"soft live raw-byte work budget (0 is unlimited and fail-fast)")
+	storageRepackCmd.Flags().DurationVar(&storageRepackMinAge, "min-age", 24*time.Hour,
+		"minimum source pack age")
+	storageRepackCmd.Flags().Int64Var(&storageRepackMinDeadBytes, "min-dead-bytes", 8<<20,
+		"minimum dead stored payload in a sparse pack")
+	storageRepackCmd.Flags().BoolVar(&storageRepackJSON, "json", false, "machine-readable output")
+	storageCmd.AddCommand(storageStatusCmd, storagePackCmd, storageRepackCmd)
 	rootCmd.AddCommand(storageCmd)
 }

--- a/cmd/docbank/trash.go
+++ b/cmd/docbank/trash.go
@@ -49,7 +49,10 @@ var (
 var trashEmptyCmd = &cobra.Command{
 	Use:   "empty",
 	Short: "Report or permanently delete trashed nodes",
-	Args:  cobra.NoArgs,
+	Long: "Report or permanently delete trashed tree metadata. Content bytes remain " +
+		"until they are unreachable and an explicit gc run removes their authority; " +
+		"packed space then requires repack.",
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if _, err := api.ParseAge(trashOlderThan); err != nil {
 			return err

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -224,6 +224,12 @@ that crosses the budget is committed. `budget_exhausted: true` describes that
 crossing, not whether eligible loose blobs remain; inspect storage status before
 deciding to issue another request.
 
+`POST /api/v1/storage/repack` physically retires empty packs and rewrites
+eligible sparse packs without changing logical content authority. Its selection
+thresholds are policy, not a preview guarantee: inspect storage status before
+and after. `bytes_repacked` counts live raw bytes rewritten and must not be
+reported as reclaimed disk space.
+
 ## Branch on problem codes
 
 Non-2xx responses use RFC 7807 problem JSON:

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -42,7 +42,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /nodes/{id}/trash` · `POST /nodes/{id}/restore` | soft delete / recover | Implemented |
 | `GET /trash` · `POST /trash/empty` `{run, older_than}` | list / report or hard-delete trash roots | Implemented |
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / re-hash all blobs | Implemented |
-| `GET /storage` · `POST /storage/pack` `{max_bytes}` | inspect physical usage / explicitly pack loose blobs | Implemented |
+| `GET /storage` · `POST /storage/pack` · `POST /storage/repack` | inspect usage / pack loose blobs / compact sparse packs | Implemented |
 
 Root-level, outside `/api/v1` and auth-exempt: `GET /health`, `GET
 /api/ping` (daemon discovery), `GET /docs` and the OpenAPI documents,

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -15,8 +15,9 @@ valid indefinitely.
 `docbank storage status` exposes loose and packed inventory through the
 authenticated daemon API, and `docbank storage pack` explicitly moves
 authorized loose content into immutable packs with an optional work budget.
-Repacking and unpacking remain planned. Startup never performs an implicit
-migration, and automatic background maintenance remains a later step.
+`docbank storage repack` compacts eligible sparse packs and retires dead pack
+files. Unpacking remains planned. Startup never performs an implicit migration,
+and automatic background maintenance remains a later step.
 
 Large collections of small files are expensive to enumerate, copy, and restore.
 msgvault uses immutable pack files as the steady-state storage format for
@@ -67,10 +68,12 @@ and does not own either application's schema or garbage-collection policy.
    inventory through the authenticated daemon API and CLI.
 5. **Complete:** expose explicit, optionally budgeted packing through the
    daemon maintenance gate and Kit coordinator.
+6. **Complete:** expose policy-selected sparse repacking and reader-safe source
+   retirement through the same ordering.
 
 !!! info "Planned — next adoption steps"
-    Daemon-first repack and unpack operations will expose the remaining
-    mechanics. Built-in backup and external integrations will use the catalog
+    A daemon-first unpack operation will expose the remaining lifecycle
+    mechanic. Built-in backup and external integrations will use the catalog
     and content-hash boundary rather than private pack internals.
 
 ## Consequences for docbank

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -117,6 +117,11 @@ The freed name is immediately reusable. Prints:
 trashed [15] /taxes/2024/return.pdf (restore with: docbank restore 15)
 ```
 
+There is no hard-delete flag. GC cannot collect a trashed document because the
+trash entry remains a restorable reference. Permanent metadata deletion,
+unreachable-content collection, and packed-space reclamation are the separate
+`trash empty --run`, `gc --run`, and `storage repack` operations.
+
 ## docbank restore
 
 ```
@@ -187,6 +192,7 @@ rows without files, which the next `gc --run` reconciles and `verify`
 reports in the meantime. The daemon's maintenance gate holds off
 concurrent mutations while `gc --run` runs, so it never races a
 concurrent import (see [Concurrency & Locking](architecture/locking.md)).
+GC does not invoke repack, and no automatic GC/repack scheduler exists today.
 
 ## docbank storage status
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -218,6 +218,28 @@ budget does not itself prove that more eligible work exists. Zero (the default)
 is unlimited. `--json` includes packing, repair, deferral, and reconciliation
 counters from the shared Kit lifecycle engine.
 
+## docbank storage repack
+
+```
+docbank storage repack [--min-age <duration>] [--min-dead-bytes <bytes>]
+                       [--max-bytes <bytes>] [--json]
+```
+
+Rewrites eligible sparse packs with only their live blobs, atomically changes
+catalog authority, and retires the old immutable pack files after active
+readers release them. Packs with no live mappings are retired regardless of
+age. A partially live pack is eligible when at most half its entries remain and
+it satisfies both selection thresholds. Defaults are `--min-age 24h` and
+`--min-dead-bytes 8388608`; use explicit smaller positive values for immediate
+manual compaction.
+
+`--max-bytes` is a soft live raw-byte budget. Zero is unlimited and makes a
+source-content error fail the operation immediately; a positive budget lets
+Kit continue with independent eligible source packs and return their combined
+errors after committed work. The report's `bytes_repacked` is live raw content
+rewritten, not a claim about filesystem bytes reclaimed. Compare `storage
+status` before and after when exact inventory change matters.
+
 ## docbank verify
 
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,9 @@ snapshot; see [Vault Lifecycle](usage/lifecycle.md#take-a-coherent-manual-snapsh
 !!! warning
     Don't edit or prune `blobs/` by hand. Blob files are referenced by
     the database (including as prior document versions); use
-    `docbank trash empty --run` and `docbank gc --run` to reclaim space, and
-    `docbank verify` to check integrity.
+    `docbank trash empty --run`, `docbank gc --run`, and (for dead packed
+    payload) `docbank storage repack` to reclaim space; use `docbank verify` to
+    check integrity.
 
 ## config.toml
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,9 @@ docbank tree /taxes                           # browse the virtual tree
 docbank search "insurance"                    # full-text search
 docbank mv "/inbox/scan (2).pdf" /taxes/2026  # reorganize, metadata only
 docbank rm /inbox/junk.pdf                    # trash, recoverable
-docbank gc --run                              # reclaim unreferenced bytes
+docbank trash empty --run                     # permanently delete trash metadata
+docbank gc --run                              # reclaim loose; mark packed bytes dead
+docbank storage repack                        # compact eligible sparse packs
 docbank verify                                # prove the bytes are intact
 ```
 
@@ -73,9 +75,9 @@ docbank verify                                # prove the bytes are intact
 </div>
 
 - **Never lose a byte.** Blob writes are durable (fsync discipline) before
-  the database ever references them. Deletion is soft; nothing is
-  reclaimed except by an explicit `gc --run`. `verify` re-hashes
-  everything on demand.
+  the database ever references them. `rm` is always soft; permanent tree
+  deletion, unreachable-content GC, and packed-space reclamation are separate
+  explicit operations. `verify` re-hashes everything on demand.
 - **Ingest never touches sources.** Importing copies; it never deletes or
   modifies the original files.
 - **IDs are canonical, paths are convenience.** Every listing shows node

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -85,7 +85,12 @@ Deletion is deliberately three-stage:
 
 1. Trash stamps a subtree and records original parent/name recovery context.
 2. Trash empty permanently removes eligible tree metadata.
-3. GC removes unreachable blob authority and physical content.
+3. GC removes unreachable blob authority and any loose physical content.
+
+The third stage removes loose files immediately. For packed content it only
+makes the immutable range logically dead; a separate repack maintenance pass
+rewrites live ranges and retires sparse source packs. No removal command folds
+that physical rewrite into logical deletion.
 
 Trashed nodes remain reachable. Permanent node deletion may make a blob row a
 GC candidate, but it does not itself claim disk space. GC must consider live

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -130,19 +130,22 @@ docbank trash empty --older-than 30d --run   # permanently delete old trash
 ## Reclaim and verify
 
 Emptying the trash deletes tree entries, but the underlying bytes remain
-until you garbage-collect. `gc` is a dry run by default:
+until you garbage-collect. `gc` is a dry run by default; it removes loose files
+directly and marks unreachable packed payload as pending repack:
 
 ```bash
 docbank gc
 ```
 
 ```
-3 candidate blob(s), 1204882 byte(s) reclaimable
+3 candidate blob(s), 0 untracked file(s), 1204882 loose byte(s) reclaimable
 dry run — pass --run to delete
 ```
 
 ```bash
 docbank gc --run
+docbank storage status     # shows dead packed payload, if any
+docbank storage repack     # compacts eligible sparse packs
 docbank verify            # re-hash every stored blob
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,9 +66,9 @@ marked planned appears elsewhere in these docs only under an explicit
 
 `docbank storage status` reports loose, live-packed, and dead-packed inventory,
 and `docbank storage pack` performs explicit optionally budgeted packing through
-the daemon. Repack and unpack commands remain the next delivery. Ordinary
-ingests continue to publish loose blobs; startup never performs an implicit
-migration.
+the daemon. `docbank storage repack` compacts eligible sparse packs and retires
+dead source files. Unpack remains the next lifecycle delivery. Ordinary ingests
+continue to publish loose blobs; startup never performs an implicit migration.
 
 ## Phase 2b — Features (designed)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,8 @@ marked planned appears elsewhere in these docs only under an explicit
 - Idempotent, resumable bulk import with collision suffixing and
   provenance
 - FTS5 name search, ranked and operator-safe
-- Trash / restore / `trash empty` with the three-stage deletion pipeline
+- Trash / restore / `trash empty`, explicit unreachable-content GC, and
+  separate packed-space reclamation
 - `gc` (dry-run default) and `verify`
 - Inter-process vault locking (shared/exclusive flock)
 - CLI: `add`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`, `search`,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -129,7 +129,8 @@ is known-good.
 
 Packed blobs are immutable members of pack files. GC can remove their catalog
 authority, but that only makes their stored ranges logically dead; physical
-pack space remains until repacking is available. The report separates
+pack space remains until `docbank storage repack` selects and retires the
+sparse source pack. The report separates
 `pending_packed_bytes` from loose bytes actually reclaimable so logical
 deletion is not presented as disk reclamation.
 

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -45,7 +45,7 @@ has captured the vault.
 
 ### Before removing anything permanently
 
-Deletion has three separate gates:
+Deletion and physical reclamation have separate gates:
 
 1. `rm` moves a node to recoverable trash.
 2. `trash empty` permanently removes old tree entries, but is a dry run unless
@@ -53,6 +53,11 @@ Deletion has three separate gates:
 3. `gc` reclaims unreachable loose bytes, but is also a dry run unless `--run`
    is present. Packed bytes become logically dead and await repacking; they are
    not reported as physically reclaimed.
+4. `storage repack` rewrites eligible sparse packs and retires their old files.
+
+There is no `rm --hard`, and none of these maintenance commands is scheduled
+automatically today. Running `gc --run` immediately after `rm` cannot reclaim
+the document because the recoverable trash entry still references it.
 
 ```bash
 docbank rm /inbox/duplicate.pdf
@@ -61,6 +66,8 @@ docbank trash empty --older-than 30d
 docbank trash empty --older-than 30d --run
 docbank gc
 docbank gc --run
+docbank storage status
+docbank storage repack
 ```
 
 Read each dry-run count before adding `--run`. If a document should return,

--- a/docs/usage/trash-and-gc.md
+++ b/docs/usage/trash-and-gc.md
@@ -1,27 +1,33 @@
 ---
-title: Trash, GC & Verify
-description: The three-stage deletion model and integrity checking.
+title: Trash, GC, Repack & Verify
+description: The explicit deletion and physical-reclamation lifecycle.
 ---
 
-# Trash, GC & Verify
+# Trash, GC, Repack & Verify
 
-Nothing in docbank is deleted in one step. Removal is a three-stage
-pipeline, each stage explicit, so the window for regret is as wide as
-you want it to be:
+`docbank rm` is always a soft deletion. There is no `rm --hard`, and neither GC
+nor repack runs automatically. Permanent deletion and physical reclamation are
+separate operator decisions, so the window for regret is as wide as you want
+it to be:
 
 ```mermaid
 flowchart LR
     A[live node] -- "docbank rm" --> B[trash]
     B -- "docbank restore" --> A
-    B -- "docbank trash empty --run" --> C[unreferenced blob]
-    C -- "docbank gc --run" --> D[authority removed; loose bytes reclaimed]
+    B -- "docbank trash empty --run" --> C[tree metadata gone; blob may be unreachable]
+    C -- "docbank gc --run" --> D[blob authority removed]
+    D -- "loose storage: same GC run" --> E[loose file removed]
+    D -- "packed storage" --> F[dead immutable pack range]
+    F -- "docbank storage repack" --> G[sparse source pack retired]
 ```
 
 ## Stage 1: Trash (`rm`, `restore`, `trash list`)
 
 `docbank rm <path>` marks the node — and its whole subtree for
 directories — as trashed. The tree entry disappears from `ls`, `tree`,
-and `search`; the name becomes reusable; the bytes are untouched.
+and `search`; the name becomes reusable; the bytes are untouched. Running GC
+after `rm` does nothing to that content because trash remains a live,
+restorable reference.
 
 ```bash
 docbank trash list
@@ -54,12 +60,13 @@ docbank trash empty --older-than 30d --run # permanently delete those items
 
 The command is a dry run unless `--run` is present. An executed run
 permanently deletes the selected tree entries. The document bytes are still
-on disk — they've merely become unreferenced.
+on disk and may still be referenced by another node or version. Only content
+with no remaining reference becomes a GC candidate.
 
 ## Stage 3: Garbage collection (`gc`)
 
-Blobs are reclaimed only by explicit GC. A blob is *reachable* — and
-therefore never collected — while any of these reference it:
+Unreachable blob authority is removed only by explicit GC. A blob is
+*reachable* — and therefore never collected — while any of these reference it:
 
 - a live node,
 - a trashed node (trash is always restorable in full), or
@@ -68,7 +75,7 @@ therefore never collected — while any of these reference it:
 
 ```bash
 docbank gc          # dry run: candidate count and reclaimable bytes
-docbank gc --run    # delete files, then metadata rows
+docbank gc --run    # remove unreachable authority and loose files
 ```
 
 For loose blobs, the reported reclaimable count is the number of bytes that GC
@@ -83,6 +90,18 @@ import can never dedup against a blob that's being deleted (see
 before their rows: a crash in between leaves rows-without-files, which
 the next `gc --run` reconciles and `verify` flags in the meantime.
 Orphan blobs from interrupted ingests are reclaimed the same way.
+
+## Stage 4: Repack packed storage (`storage repack`)
+
+GC cannot remove one range from an immutable pack file. After `gc --run`, dead
+packed payload appears in `storage status` as `dead_packed_bytes`. An explicit
+`docbank storage repack` rewrites eligible sparse packs with their live blobs
+and retires the old source packs. Empty packs are retired directly.
+
+Repack is not part of `rm`, `trash empty`, or `gc`, and there is currently no
+background maintenance scheduler. This is intentional: repacking may rewrite
+unrelated live blobs that share the same pack, so its timing and selection
+thresholds remain an independent storage-policy decision.
 
 ## Verify
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -21,7 +21,7 @@ nav = [
     {"Importing Documents" = "usage/importing.md"},
     {"Organizing the Tree" = "usage/organizing.md"},
     {"Searching" = "usage/searching.md"},
-    {"Trash, GC & Verify" = "usage/trash-and-gc.md"},
+    {"Trash, GC, Repack & Verify" = "usage/trash-and-gc.md"},
   ]},
   {"Reference" = [
     {"CLI Reference" = "cli-reference.md"},

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -17,7 +17,7 @@ const requestTimeout = 60 * time.Second
 func timeoutExempt(path string) bool {
 	switch path {
 	case "/api/v1/ingest", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
-		"/api/v1/storage/pack":
+		"/api/v1/storage/pack", "/api/v1/storage/repack":
 		return true
 	}
 	return false

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -16,7 +16,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	doc := string(out)
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
-		"storageStatus", "storagePack", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
+		"storageStatus", "storagePack", "storageRepack", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
 	assert.NotContains(t, doc, "/api/daemon/shutdown", "lifecycle plumbing must stay hidden")

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -37,6 +37,38 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		}}, nil
 	})
 
+	type storageRepackOutput struct{ Body StorageRepackReport }
+	huma.Register(api, huma.Operation{
+		OperationID: "storageRepack", Method: http.MethodPost, Path: "/api/v1/storage/repack",
+		Summary: "Rewrite eligible sparse packs and retire dead pack files",
+	}, func(ctx context.Context, in *struct {
+		Body struct {
+			MaxBytes     int64  `json:"max_bytes,omitempty" minimum:"0"`
+			MinAge       string `json:"min_age,omitempty" example:"24h"`
+			MinDeadBytes int64  `json:"min_dead_bytes,omitempty" minimum:"0"`
+		}
+	}) (*storageRepackOutput, error) {
+		minAge, err := ParseAge(in.Body.MinAge)
+		if err != nil {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+		}
+		out := &storageRepackOutput{}
+		err = g.maintain(func() error {
+			stats, err := d.Blobs.Maintainer().Repack(ctx, packstore.RepackOptions{
+				MaxBytes: in.Body.MaxBytes,
+				Selection: packstore.RepackSelection{
+					MinAge: minAge, MinDeadStored: in.Body.MinDeadBytes,
+				},
+			})
+			if err != nil {
+				return FromStoreError(err)
+			}
+			out.Body = storageRepackReport(stats)
+			return nil
+		})
+		return out, err
+	})
+
 	type storagePackOutput struct{ Body StoragePackReport }
 	huma.Register(api, huma.Operation{
 		OperationID: "storagePack", Method: http.MethodPost, Path: "/api/v1/storage/pack",
@@ -216,6 +248,16 @@ func storagePackReport(stats packstore.PackStats) StoragePackReport {
 		LooseSwept:             stats.LooseSwept, LooseOrphansRemoved: stats.LooseOrphansRemoved,
 		LooseOrphanSweepSuppressed: stats.LooseOrphanSweepSuppressed,
 		BudgetExhausted:            stats.BudgetExhausted,
+	}
+}
+
+func storageRepackReport(stats packstore.RepackStats) StorageRepackReport {
+	return StorageRepackReport{
+		MappingsPruned: stats.MappingsPruned, PacksSelected: stats.PacksSelected,
+		PacksRewritten: stats.PacksRewritten, PacksSealed: stats.PacksSealed,
+		PacksRemoved: stats.PacksRemoved, PacksDeferredOversized: stats.PacksDeferredOversized,
+		BlobsRepacked: stats.BlobsRepacked, BytesRepacked: stats.BytesRepacked,
+		BudgetExhausted: stats.BudgetExhausted,
 	}
 }
 

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -196,6 +196,60 @@ func TestStoragePackHonorsBudgetAndConverges(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
 }
 
+func TestStorageRepackReclaimsSparsePack(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	files := []store.Node{
+		createFileWithContent(t, ts, s, "/one.txt", "one"),
+		createFileWithContent(t, ts, s, "/two.txt", "two"),
+		createFileWithContent(t, ts, s, "/three.txt", "three"),
+	}
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/storage/pack", nil,
+		map[string]any{"max_bytes": 0})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+
+	for _, file := range files[:2] {
+		_, etag := etagOf(t, ts, file.ID)
+		resp, body = do(t, ts, http.MethodPost, fmt.Sprintf("/api/v1/nodes/%d/trash", file.ID),
+			map[string]string{"If-Match": etag}, nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	}
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/trash/empty", nil,
+		map[string]any{"run": true})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/gc", nil, map[string]any{"run": true})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+
+	statusResp, statusBody := get(t, ts, "/api/v1/storage", nil)
+	require.Equal(t, http.StatusOK, statusResp.StatusCode, statusBody)
+	var before api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(statusBody), &before))
+	assert.Positive(t, before.DeadPackedBytes)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/storage/repack", nil,
+		map[string]any{"min_age": "1ns", "min_dead_bytes": 1, "max_bytes": 0})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var report api.StorageRepackReport
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.Equal(t, 1, report.PacksSelected)
+	assert.Equal(t, 1, report.PacksRewritten)
+	assert.Equal(t, 1, report.PacksRemoved)
+	assert.Equal(t, 1, report.BlobsRepacked)
+	assert.Equal(t, int64(len("three")), report.BytesRepacked)
+
+	statusResp, statusBody = get(t, ts, "/api/v1/storage", nil)
+	require.Equal(t, http.StatusOK, statusResp.StatusCode, statusBody)
+	require.NoError(t, json.Unmarshal([]byte(statusBody), &before))
+	assert.Zero(t, before.DeadPackedBytes)
+	assert.Equal(t, int64(1), before.PackedBlobs)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/storage/repack", nil,
+		map[string]any{"min_age": "-1h", "min_dead_bytes": 1})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/storage/repack", nil,
+		map[string]any{"min_age": "1ns", "min_dead_bytes": -1})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+}
+
 func TestGCRevokesPackedBlobAuthority(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	file := createFileWithContent(t, ts, s, "/packed.txt", "packed gc content")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -99,6 +99,21 @@ type StoragePackReport struct {
 	BudgetExhausted            bool  `json:"budget_exhausted"`
 }
 
+// StorageRepackReport summarizes sparse-pack selection, rewriting, and
+// reader-safe retirement. BytesRepacked is live raw content rewritten, not a
+// measurement of filesystem bytes reclaimed.
+type StorageRepackReport struct {
+	MappingsPruned         int64 `json:"mappings_pruned"`
+	PacksSelected          int   `json:"packs_selected"`
+	PacksRewritten         int   `json:"packs_rewritten"`
+	PacksSealed            int   `json:"packs_sealed"`
+	PacksRemoved           int   `json:"packs_removed"`
+	PacksDeferredOversized int   `json:"packs_deferred_oversized"`
+	BlobsRepacked          int   `json:"blobs_repacked"`
+	BytesRepacked          int64 `json:"bytes_repacked"`
+	BudgetExhausted        bool  `json:"budget_exhausted"`
+}
+
 // VerifyProblem flags one blob whose content didn't check out.
 type VerifyProblem struct {
 	Hash    string `json:"hash"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -249,6 +249,15 @@ func (c *Client) StoragePack(ctx context.Context, maxBytes int64) (api.StoragePa
 	return report, err
 }
 
+func (c *Client) StorageRepack(ctx context.Context, maxBytes int64, minAge time.Duration,
+	minDeadBytes int64) (api.StorageRepackReport, error) {
+	var report api.StorageRepackReport
+	err := c.do(ctx, http.MethodPost, "/api/v1/storage/repack", nil, map[string]any{
+		"max_bytes": maxBytes, "min_age": minAge.String(), "min_dead_bytes": minDeadBytes,
+	}, &report)
+	return report, err
+}
+
 func (c *Client) Verify(ctx context.Context) (api.VerifyReport, error) {
 	var rep api.VerifyReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/verify", nil, nil, &rep)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,6 +110,36 @@ func TestStoragePackRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, report.BlobsPacked)
 	assert.True(t, report.BudgetExhausted)
+}
+
+func TestStorageRepackRoundTrip(t *testing.T) {
+	c, _ := newClient(t, serverKey)
+	for name, content := range map[string]string{
+		"keep.txt": "keep", "drop-a.txt": "drop a", "drop-b.txt": "drop b",
+	} {
+		src := filepath.Join(t.TempDir(), name)
+		require.NoError(t, os.WriteFile(src, []byte(content), 0o600))
+		ingested, err := c.Ingest(t.Context(), []string{src}, "/inbox")
+		require.NoError(t, err)
+		require.Equal(t, 1, ingested.Added)
+	}
+	_, err := c.StoragePack(t.Context(), 0)
+	require.NoError(t, err)
+	for _, path := range []string{"/inbox/drop-a.txt", "/inbox/drop-b.txt"} {
+		drop, statErr := c.Stat(t.Context(), path)
+		require.NoError(t, statErr)
+		_, err = c.Trash(t.Context(), drop.ID, drop.Revision)
+		require.NoError(t, err)
+	}
+	_, err = c.TrashEmpty(t.Context(), "", true)
+	require.NoError(t, err)
+	_, err = c.GC(t.Context(), true)
+	require.NoError(t, err)
+
+	report, err := c.StorageRepack(t.Context(), 0, time.Nanosecond, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.PacksRewritten)
+	assert.Equal(t, 1, report.PacksRemoved)
 }
 
 // TestWrongAPIKeyIsRejected is the client-side half of the keyless-loopback


### PR DESCRIPTION
Packed GC intentionally separates logical deletion from physical reclamation: removing a blob’s catalog authority makes its immutable range dead, but cannot shrink the source pack. Without an operator-visible repack operation, dead packed payload can accumulate and storage status can only describe a condition docbank cannot resolve.

This PR exposes Kit’s existing sparse rewrite and reader-safe source retirement through the authenticated daemon. Docbank supplies policy—minimum source age, minimum dead stored payload, and an optional live raw-byte work budget—while Kit remains the sole owner of selection, preflight, compare-and-swap replacement, and physical retirement. Conservative defaults avoid rewriting young or insignificantly sparse packs; explicit smaller positive thresholds support deliberate immediate compaction.

The operator lifecycle is explicit: `rm` always moves content to recoverable trash; `trash empty --run` removes selected tree metadata; `gc --run` removes content authority only after no references remain and immediately unlinks loose files; `storage repack` separately retires eligible dead packed space. There is no `rm --hard`, GC does not invoke repack, and neither operation runs on an automatic schedule today.

The reporting boundary is equally deliberate. `bytes_repacked` means live raw content rewritten, not disk space reclaimed. Operators and agents compare storage inventory before and after when the physical change matters, while pack counts describe selection, replacement, and retirement directly. The API maintenance gate is acquired before Kit’s coordinator so logical mutations cannot race catalog replacement.

Unpack remains a separate final lifecycle PR.