### PR TITLE
Expose all-loose storage recovery

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -428,6 +428,32 @@ func TestDeletionHelpSeparatesTrashGCAndRepack(t *testing.T) {
 	assert.Contains(t, out, "requires a separate storage repack")
 }
 
+func TestStorageUnpackJSON(t *testing.T) {
+	_ = setupVaultHome(t)
+	for name, content := range map[string]string{"a.txt": "alpha", "b.txt": "bravo"} {
+		src := writeSourceFile(t, name, content)
+		_, err := runCLI(t, "add", src, "--dest", "/inbox")
+		require.NoError(t, err)
+	}
+	_, err := runCLI(t, "storage", "pack")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "storage", "unpack", "--json")
+	require.NoError(t, err)
+	var report api.StorageUnpackReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, 1, report.PacksUnpacked)
+	assert.Equal(t, 2, report.BlobsRestored)
+	assert.Equal(t, int64(len("alpha")+len("bravo")), report.BytesRestored)
+
+	out, err = runCLI(t, "storage", "status", "--json")
+	require.NoError(t, err)
+	var status api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(out), &status))
+	assert.Equal(t, 2, status.LooseBlobs)
+	assert.Zero(t, status.Packs)
+}
+
 func TestVerifyDetectsMissingAndCorrupt(t *testing.T) {
 	home := setupVaultHome(t)
 	srcA := writeSourceFile(t, "a.txt", "alpha")

--- a/cmd/docbank/storage.go
+++ b/cmd/docbank/storage.go
@@ -145,6 +145,34 @@ var storageRepackCmd = &cobra.Command{
 	},
 }
 
+var storageUnpackJSON bool
+
+var storageUnpackCmd = &cobra.Command{
+	Use:   "unpack",
+	Short: "Materialize packed blobs loose and retire all pack files",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		report, err := c.StorageUnpack(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if storageUnpackJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(report)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "restored %d blob(s), %d byte(s), to loose storage\n",
+			report.BlobsRestored, report.BytesRestored)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "retired %d pack(s); pruned %d stale mapping(s)\n",
+			report.PacksUnpacked, report.MappingsPruned)
+		return nil
+	},
+}
+
 func init() {
 	storageStatusCmd.Flags().BoolVar(&storageStatusJSON, "json", false, "machine-readable output")
 	storagePackCmd.Flags().Int64Var(&storagePackMaxBytes, "max-bytes", 0,
@@ -157,6 +185,7 @@ func init() {
 	storageRepackCmd.Flags().Int64Var(&storageRepackMinDeadBytes, "min-dead-bytes", 8<<20,
 		"minimum dead stored payload in a sparse pack")
 	storageRepackCmd.Flags().BoolVar(&storageRepackJSON, "json", false, "machine-readable output")
-	storageCmd.AddCommand(storageStatusCmd, storagePackCmd, storageRepackCmd)
+	storageUnpackCmd.Flags().BoolVar(&storageUnpackJSON, "json", false, "machine-readable output")
+	storageCmd.AddCommand(storageStatusCmd, storagePackCmd, storageRepackCmd, storageUnpackCmd)
 	rootCmd.AddCommand(storageCmd)
 }

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -230,6 +230,11 @@ thresholds are policy, not a preview guarantee: inspect storage status before
 and after. `bytes_repacked` counts live raw bytes rewritten and must not be
 reported as reclaimed disk space.
 
+`POST /api/v1/storage/unpack` is the explicit all-loose recovery path. It
+preflights every source before writing, but may temporarily need space for both
+packs and live raw loose content. Treat `bytes_restored` as materialized raw
+content, not net disk growth, and compare storage status before and after.
+
 ## Branch on problem codes
 
 Non-2xx responses use RFC 7807 problem JSON:

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -42,7 +42,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /nodes/{id}/trash` · `POST /nodes/{id}/restore` | soft delete / recover | Implemented |
 | `GET /trash` · `POST /trash/empty` `{run, older_than}` | list / report or hard-delete trash roots | Implemented |
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / re-hash all blobs | Implemented |
-| `GET /storage` · `POST /storage/pack` · `POST /storage/repack` | inspect usage / pack loose blobs / compact sparse packs | Implemented |
+| `GET /storage` · `POST /storage/{pack,repack,unpack}` | inspect usage / change physical blob representation | Implemented |
 
 Root-level, outside `/api/v1` and auth-exempt: `GET /health`, `GET
 /api/ping` (daemon discovery), `GET /docs` and the OpenAPI documents,

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -16,8 +16,9 @@ valid indefinitely.
 authenticated daemon API, and `docbank storage pack` explicitly moves
 authorized loose content into immutable packs with an optional work budget.
 `docbank storage repack` compacts eligible sparse packs and retires dead pack
-files. Unpacking remains planned. Startup never performs an implicit migration,
-and automatic background maintenance remains a later step.
+files. `docbank storage unpack` durably materializes all live content loose and
+retires every pack. Startup never performs an implicit migration, and automatic
+background maintenance remains a later step.
 
 Large collections of small files are expensive to enumerate, copy, and restore.
 msgvault uses immutable pack files as the steady-state storage format for
@@ -70,11 +71,13 @@ and does not own either application's schema or garbage-collection policy.
    daemon maintenance gate and Kit coordinator.
 6. **Complete:** expose policy-selected sparse repacking and reader-safe source
    retirement through the same ordering.
+7. **Complete:** expose preflighted all-pack unpacking as the recovery path back
+   to canonical loose storage.
 
 !!! info "Planned — next adoption steps"
-    A daemon-first unpack operation will expose the remaining lifecycle
-    mechanic. Built-in backup and external integrations will use the catalog
-    and content-hash boundary rather than private pack internals.
+    Built-in backup and external integrations will use the catalog and
+    content-hash boundary rather than private pack internals. Automatic storage
+    maintenance remains deferred until watched-inbox policy lands.
 
 ## Consequences for docbank
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -246,6 +246,25 @@ errors after committed work. The report's `bytes_repacked` is live raw content
 rewritten, not a claim about filesystem bytes reclaimed. Compare `storage
 status` before and after when exact inventory change matters.
 
+## docbank storage unpack
+
+```
+docbank storage unpack [--json]
+```
+
+Converts every live packed blob back to durable canonical loose storage and
+retires all pack files. Kit preflights every source pack and footer before the
+first loose write, then materializes and verifies every live blob before
+atomically clearing packed catalog authority. Source packs are retired only
+after loose authority is established and active readers release them.
+
+Unpack is an explicit representation change, not a logical content operation:
+node IDs, paths, blob hashes, and readable bytes remain unchanged. It may
+temporarily require enough disk space for both the existing packs and all live
+raw loose content. Use `storage status` before and after; repeated unpack runs
+converge to a zero-work report. `--json` reports restored blobs/bytes, retired
+packs, and stale mappings pruned during preflight.
+
 ## docbank verify
 
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,8 +68,9 @@ marked planned appears elsewhere in these docs only under an explicit
 `docbank storage status` reports loose, live-packed, and dead-packed inventory,
 and `docbank storage pack` performs explicit optionally budgeted packing through
 the daemon. `docbank storage repack` compacts eligible sparse packs and retires
-dead source files. Unpack remains the next lifecycle delivery. Ordinary ingests
-continue to publish loose blobs; startup never performs an implicit migration.
+dead source files, while `docbank storage unpack` provides a preflighted return
+to all-loose storage. Ordinary ingests continue to publish loose blobs; startup
+never performs an implicit migration.
 
 ## Phase 2b — Features (designed)
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -17,7 +17,7 @@ const requestTimeout = 60 * time.Second
 func timeoutExempt(path string) bool {
 	switch path {
 	case "/api/v1/ingest", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
-		"/api/v1/storage/pack", "/api/v1/storage/repack":
+		"/api/v1/storage/pack", "/api/v1/storage/repack", "/api/v1/storage/unpack":
 		return true
 	}
 	return false

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -16,7 +16,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	doc := string(out)
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
-		"storageStatus", "storagePack", "storageRepack", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
+		"storageStatus", "storagePack", "storageRepack", "storageUnpack", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
 	assert.NotContains(t, doc, "/api/daemon/shutdown", "lifecycle plumbing must stay hidden")

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -37,6 +37,23 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		}}, nil
 	})
 
+	type storageUnpackOutput struct{ Body StorageUnpackReport }
+	huma.Register(api, huma.Operation{
+		OperationID: "storageUnpack", Method: http.MethodPost, Path: "/api/v1/storage/unpack",
+		Summary: "Materialize live packed blobs loose and retire all pack files",
+	}, func(ctx context.Context, _ *struct{}) (*storageUnpackOutput, error) {
+		out := &storageUnpackOutput{}
+		err := g.maintain(func() error {
+			stats, err := d.Blobs.Maintainer().Unpack(ctx)
+			if err != nil {
+				return FromStoreError(err)
+			}
+			out.Body = storageUnpackReport(stats)
+			return nil
+		})
+		return out, err
+	})
+
 	type storageRepackOutput struct{ Body StorageRepackReport }
 	huma.Register(api, huma.Operation{
 		OperationID: "storageRepack", Method: http.MethodPost, Path: "/api/v1/storage/repack",
@@ -258,6 +275,13 @@ func storageRepackReport(stats packstore.RepackStats) StorageRepackReport {
 		PacksRemoved: stats.PacksRemoved, PacksDeferredOversized: stats.PacksDeferredOversized,
 		BlobsRepacked: stats.BlobsRepacked, BytesRepacked: stats.BytesRepacked,
 		BudgetExhausted: stats.BudgetExhausted,
+	}
+}
+
+func storageUnpackReport(stats packstore.UnpackStats) StorageUnpackReport {
+	return StorageUnpackReport{
+		PacksUnpacked: stats.PacksUnpacked, BlobsRestored: stats.BlobsRestored,
+		BytesRestored: stats.BytesRestored, MappingsPruned: stats.MappingsPruned,
 	}
 }
 

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -250,6 +250,44 @@ func TestStorageRepackReclaimsSparsePack(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
 }
 
+func TestStorageUnpackMaterializesLooseAndConverges(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	files := []store.Node{
+		createFileWithContent(t, ts, s, "/one.txt", "one"),
+		createFileWithContent(t, ts, s, "/two.txt", "two"),
+	}
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/storage/pack", nil,
+		map[string]any{"max_bytes": 0})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/storage/unpack", nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var report api.StorageUnpackReport
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.Equal(t, 1, report.PacksUnpacked)
+	assert.Equal(t, 2, report.BlobsRestored)
+	assert.Equal(t, int64(len("one")+len("two")), report.BytesRestored)
+
+	statusResp, statusBody := get(t, ts, "/api/v1/storage", nil)
+	require.Equal(t, http.StatusOK, statusResp.StatusCode, statusBody)
+	var status api.StorageStatus
+	require.NoError(t, json.Unmarshal([]byte(statusBody), &status))
+	assert.Equal(t, 2, status.LooseBlobs)
+	assert.Zero(t, status.Packs)
+	assert.Zero(t, status.PackedBlobs)
+	for _, file := range files {
+		contentResp, content := get(t, ts, fmt.Sprintf("/api/v1/nodes/%d/content", file.ID), nil)
+		require.Equal(t, http.StatusOK, contentResp.StatusCode, content)
+		assert.Equal(t, file.Size, int64(len(content)))
+	}
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/storage/unpack", nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.Zero(t, report.PacksUnpacked)
+	assert.Zero(t, report.BlobsRestored)
+}
+
 func TestGCRevokesPackedBlobAuthority(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	file := createFileWithContent(t, ts, s, "/packed.txt", "packed gc content")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -114,6 +114,15 @@ type StorageRepackReport struct {
 	BudgetExhausted        bool  `json:"budget_exhausted"`
 }
 
+// StorageUnpackReport summarizes durable loose materialization and packed
+// authority retirement.
+type StorageUnpackReport struct {
+	PacksUnpacked  int   `json:"packs_unpacked"`
+	BlobsRestored  int   `json:"blobs_restored"`
+	BytesRestored  int64 `json:"bytes_restored"`
+	MappingsPruned int64 `json:"mappings_pruned"`
+}
+
 // VerifyProblem flags one blob whose content didn't check out.
 type VerifyProblem struct {
 	Hash    string `json:"hash"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -258,6 +258,12 @@ func (c *Client) StorageRepack(ctx context.Context, maxBytes int64, minAge time.
 	return report, err
 }
 
+func (c *Client) StorageUnpack(ctx context.Context) (api.StorageUnpackReport, error) {
+	var report api.StorageUnpackReport
+	err := c.do(ctx, http.MethodPost, "/api/v1/storage/unpack", nil, nil, &report)
+	return report, err
+}
+
 func (c *Client) Verify(ctx context.Context) (api.VerifyReport, error) {
 	var rep api.VerifyReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/verify", nil, nil, &rep)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -142,6 +142,23 @@ func TestStorageRepackRoundTrip(t *testing.T) {
 	assert.Equal(t, 1, report.PacksRemoved)
 }
 
+func TestStorageUnpackRoundTrip(t *testing.T) {
+	c, _ := newClient(t, serverKey)
+	src := filepath.Join(t.TempDir(), "unpack.txt")
+	require.NoError(t, os.WriteFile(src, []byte("unpack me"), 0o600))
+	ingested, err := c.Ingest(t.Context(), []string{src}, "/inbox")
+	require.NoError(t, err)
+	require.Equal(t, 1, ingested.Added)
+	_, err = c.StoragePack(t.Context(), 0)
+	require.NoError(t, err)
+
+	report, err := c.StorageUnpack(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.PacksUnpacked)
+	assert.Equal(t, 1, report.BlobsRestored)
+	assert.Equal(t, int64(len("unpack me")), report.BytesRestored)
+}
+
 // TestWrongAPIKeyIsRejected is the client-side half of the keyless-loopback
 // regression: a client holding the wrong key must get a clearly readable
 // 401, never silent success and never an opaque envelope dump.


### PR DESCRIPTION
Packed storage needs a supported exit path as well as packing and compaction. Returning to canonical loose files is useful for recovery, direct inspection, or a deliberate storage-policy change, but the transition is unsafe if catalog authority moves before every live blob has been durably materialized and verified.

This PR exposes Kit’s existing all-pack preflight and unpack lifecycle through the authenticated daemon. Kit validates every source pack and footer before the first loose write, materializes and verifies all live content, atomically clears packed catalog authority, and only then retires source packs after active readers release them. Docbank contributes the API maintenance gate and product reporting; it does not recreate the physical transition.

Unpack changes representation only. Node IDs, paths, blob hashes, and readable content remain stable. The report names raw bytes restored and packs retired without presenting that value as net disk growth, since the operation may temporarily hold both representations. Repeated runs converge to zero work.

This completes the explicit status, pack, repack, and unpack operator lifecycle on the Kit packstore foundation.