### PR TITLE
Keep packed representation managed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ Instructions for autonomous coding agents working in this repository.
   open the vault directly from a command.
 - The daemon always enforces an API key (ephemeral per-run when none is
   configured, published via the runtime record). Binds are loopback-only.
+- Packed storage is managed, not a user-selected format. The ordinary operator
+  surface is status, pack, and repack. Do not expose Kit's unpack primitive as
+  a general API or CLI command; reserve it for tests, migrations, or a
+  purpose-built emergency recovery workflow with a demonstrated need.
 - User-facing docs describe only what exists; planned behavior sits under
   `!!! info "Planned"` admonitions.
 

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -16,8 +16,9 @@ valid indefinitely.
 authenticated daemon API, and `docbank storage pack` explicitly moves
 authorized loose content into immutable packs with an optional work budget.
 `docbank storage repack` compacts eligible sparse packs and retires dead pack
-files. Unpacking remains planned. Startup never performs an implicit migration,
-and automatic background maintenance remains a later step.
+files. These commands are the complete ordinary representation-management
+surface. Startup never performs an implicit migration, and automatic background
+maintenance remains a later step.
 
 Large collections of small files are expensive to enumerate, copy, and restore.
 msgvault uses immutable pack files as the steady-state storage format for
@@ -72,9 +73,9 @@ and does not own either application's schema or garbage-collection policy.
    retirement through the same ordering.
 
 !!! info "Planned — next adoption steps"
-    A daemon-first unpack operation will expose the remaining lifecycle
-    mechanic. Built-in backup and external integrations will use the catalog
-    and content-hash boundary rather than private pack internals.
+    Built-in backup and external integrations will use the catalog and
+    content-hash boundary rather than private pack internals. Automatic storage
+    maintenance remains deferred until watched-inbox policy lands.
 
 ## Consequences for docbank
 
@@ -85,6 +86,20 @@ and the representation for blobs above the bounded maintenance limit.
 
 The `blobs` membership boundary also lets logical features evolve without
 changing physical pack authority.
+
+## Why unpack is not an operator command
+
+Kit retains an unpack primitive because shared storage tests, migrations, and a
+future purpose-built recovery tool may need to materialize packed content
+loose. Docbank intentionally does not expose that primitive as a normal API or
+CLI operation.
+
+Packing exists to avoid the enumeration, backup, and restore cost of thousands
+of small files. A general unpack command would recreate that problem, could
+temporarily require space for both representations, and would make users manage
+an implementation format that docbank should own. Recovery belongs in verified
+backup/restore or a concrete repair workflow; the existence of a low-level Kit
+operation is not by itself a product use case.
 
 !!! info "Planned — external reachability"
     Editing and versions, generalized provenance, and external references must

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -128,6 +128,14 @@ reader or lifecycle mechanics in docbank. A physical-storage bug shared by
 msgvault belongs in Kit; a decision about whether a docbank reference keeps a
 blob alive belongs here.
 
+Kit owning a mechanic does not imply that docbank exposes it. In particular,
+`packstore.Maintainer.Unpack` remains available for conformance tests,
+migrations, and a purpose-built emergency recovery path, but is not part of the
+ordinary daemon API or CLI. A public unpack operation would reverse the
+small-file benefit, require transient duplicate disk capacity, and leak
+physical-format selection into the product. Do not add one without a concrete
+recovery workflow that cannot be served by verified backup/restore.
+
 ## Schema compatibility
 
 Store startup runs the embedded idempotent schema in one immediate transaction
@@ -148,5 +156,5 @@ failure rollback behavior, and a documented backup-before-migrate contract.
   pin blob authority, or allow dangling-reference detection in the referrer.
 - Version writers must preserve bytes-before-reference ordering and add their
   rows to reachability atomically with pointer replacement.
-- Pack maintenance commands must remain daemon/API operations; no CLI path may
-  open the physical store directly.
+- Pack and repack maintenance commands must remain daemon/API operations; no
+  CLI path may open the physical store directly.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,8 +68,10 @@ marked planned appears elsewhere in these docs only under an explicit
 `docbank storage status` reports loose, live-packed, and dead-packed inventory,
 and `docbank storage pack` performs explicit optionally budgeted packing through
 the daemon. `docbank storage repack` compacts eligible sparse packs and retires
-dead source files. Unpack remains the next lifecycle delivery. Ordinary ingests
-continue to publish loose blobs; startup never performs an implicit migration.
+dead source files. This is the complete ordinary storage-maintenance surface;
+Kit unpack remains internal to tests, migrations, or a future purpose-built
+recovery workflow rather than a planned user command. Ordinary ingests continue
+to publish loose blobs; startup never performs an implicit migration.
 
 ## Phase 2b — Features (designed)
 


### PR DESCRIPTION
Kit exposes unpack because a shared storage engine needs it for conformance tests, migrations, and possible emergency recovery. That does not mean docbank should make physical-format selection an ordinary user concern. A general unpack command would recreate the small-file enumeration and backup cost that packing exists to solve, could require transient space for both representations, and would add a high-amplification operation without a demonstrated product workflow.

This PR defines status, pack, and repack as docbank’s complete ordinary storage-maintenance surface. Public architecture explains why unpack is not a user command; the internal storage design preserves the engineering boundary; the roadmap no longer schedules it; and the agent contract prevents future implementation work from inferring product requirements from every available Kit primitive.

Unpack remains where it belongs: available inside Kit for tests, migrations, or a future purpose-built emergency recovery path whose need cannot be served by verified backup and restore.