### PR TITLE
Define docbank backup authority

### DIFF
--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -26,11 +26,11 @@ choose a different representation without changing the archive.
 Snapshots taken from a packed vault retain source pack metadata in their
 captured database. Docbank therefore fails closed if such a snapshot is sent
 through Kit's loose-only restore path: loose files plus stale pack authority
-would make the restored vault unreadable. The paired packed-restore adapter
-instead publishes verified repository packs into the target and atomically
-replaces all captured pack records and mappings before the staged vault becomes
-visible. Integration coverage opens every restored blob through the same mixed
-store used by a live vault.
+would make the restored vault unreadable. Docbank's restore wrapper inseparably
+owns the application adapter and packed target: it publishes verified repository
+packs into the target and atomically replaces all captured pack records and
+mappings before the staged vault becomes visible. Integration coverage opens
+every restored blob through the same mixed store used by a live vault.
 
 !!! info "Planned — Phase 4"
     Command/API orchestration has not landed. The completed capture and restore

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -23,10 +23,19 @@ tests prove loose create/verify/restore and capture directly from a packed live
 store. Physical pack tables are excluded from fidelity stats so a restore may
 choose a different representation without changing the archive.
 
+Snapshots taken from a packed vault retain source pack metadata in their
+captured database. Docbank therefore fails closed if such a snapshot is sent
+through Kit's loose-only restore path: loose files plus stale pack authority
+would make the restored vault unreadable. The paired packed-restore adapter
+instead publishes verified repository packs into the target and atomically
+replaces all captured pack records and mappings before the staged vault becomes
+visible. Integration coverage opens every restored blob through the same mixed
+store used by a live vault.
+
 !!! info "Planned — Phase 4"
-    Command/API orchestration and packed catalog publication on restore have
-    not landed. The completed adapter is internal and does not make any
-    `docbank backup` command available yet.
+    Command/API orchestration has not landed. The completed capture and restore
+    adapters are internal and do not make any `docbank backup` command
+    available yet.
 
     The planned command family is `docbank backup init|create|list|verify|restore`.
     Exact flags will enter the CLI reference only when implemented.

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -1,6 +1,6 @@
 ---
 title: Backup
-description: Current manual snapshot requirements and the planned Kit-backed backup integration.
+description: Current manual snapshots and the staged Kit-backed backup integration.
 ---
 
 # Backup
@@ -14,18 +14,19 @@ The essential archive is the database plus `blobs/`. Configuration is useful
 to retain when customized; logs, locks, and runtime records are not archive
 state. A restored copy is not trusted until `docbank verify` succeeds.
 
-## Planned Kit integration
+## Kit integration status
+
+The internal `backupapp` adapter now supplies Kit with docbank's frozen logical
+view: every authoritative `blobs` row, representation-neutral fidelity stats,
+canonical restore paths, and mixed loose/packed content reads. Integration
+tests prove loose create/verify/restore and capture directly from a packed live
+store. Physical pack tables are excluded from fidelity stats so a restore may
+choose a different representation without changing the archive.
 
 !!! info "Planned — Phase 4"
-    Docbank will integrate `go.kenn.io/kit/backup`, the shared engine already
-    used by msgvault. The application adapter will own WAL checkpointing and a
-    pinned read transaction, content enumeration from docbank's `blobs` rows,
-    fidelity statistics, and exclusions for logs and staging files.
-
-    Snapshots will contain page-diffed SQLite state plus only-new content in
-    sealed, verifiable packs. Restore will materialize `docbank.db` and
-    `blobs/`, then compare application statistics with the manifest before the
-    result is accepted.
+    Command/API orchestration and packed catalog publication on restore have
+    not landed. The completed adapter is internal and does not make any
+    `docbank backup` command available yet.
 
     The planned command family is `docbank backup init|create|list|verify|restore`.
     Exact flags will enter the CLI reference only when implemented.

--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -9,7 +9,7 @@ developers update the right layer and preserve cross-layer contracts.
 |------|------|--------------|
 | `internal/store` | schema, transactions, tree identity, reachability queries, typed domain errors | HTTP, CLI formatting, physical pack lifecycle |
 | `internal/blob` | docbank adapter around Kit physical storage | virtual paths or node policy |
-| `internal/backupapp` | frozen logical enumeration, fidelity stats, restore paths, mixed backup reads | repository orchestration or CLI policy |
+| `internal/backupapp` | frozen logical enumeration, fidelity stats, restore paths, mixed backup reads, packed restore policy | repository orchestration or CLI policy |
 | `internal/ingest` | source traversal and bytes-before-reference pipeline | daemon discovery or UI behavior |
 | `internal/api` | wire contract, auth, middleware, gate classification, error mapping | direct CLI output policy |
 | `internal/client` | typed HTTP calls and daemon convergence | opening SQLite or blobs |

--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -9,6 +9,7 @@ developers update the right layer and preserve cross-layer contracts.
 |------|------|--------------|
 | `internal/store` | schema, transactions, tree identity, reachability queries, typed domain errors | HTTP, CLI formatting, physical pack lifecycle |
 | `internal/blob` | docbank adapter around Kit physical storage | virtual paths or node policy |
+| `internal/backupapp` | frozen logical enumeration, fidelity stats, restore paths, mixed backup reads | repository orchestration or CLI policy |
 | `internal/ingest` | source traversal and bytes-before-reference pipeline | daemon discovery or UI behavior |
 | `internal/api` | wire contract, auth, middleware, gate classification, error mapping | direct CLI output policy |
 | `internal/client` | typed HTTP calls and daemon convergence | opening SQLite or blobs |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,8 +106,8 @@ operations — anything the TUI does, the API can do.
 `docbank backup init|create|list|verify|restore` against the kit engine
 ([design](architecture/backup.md)).
 
-The internal Kit application adapter and loose/packed capture proof are
-implemented. Command/API orchestration and packed restore publication remain.
+The internal Kit application adapter, loose/packed capture proof, and atomic
+packed restore publication are implemented. Command/API orchestration remains.
 
 ## Deferred beyond v1
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,6 +106,9 @@ operations — anything the TUI does, the API can do.
 `docbank backup init|create|list|verify|restore` against the kit engine
 ([design](architecture/backup.md)).
 
+The internal Kit application adapter and loose/packed capture proof are
+implemented. Command/API orchestration and packed restore publication remain.
+
 ## Deferred beyond v1
 
 OCR of scans, embeddings/AI tagging, a web UI, at-rest encryption of the

--- a/internal/backupapp/app.go
+++ b/internal/backupapp/app.go
@@ -67,22 +67,11 @@ func computeStats(ctx context.Context, q rowQuerier) (Stats, error) {
 }
 
 // App implements backup.App for docbank.
-type App struct {
-	version            string
-	allowPackedRestore bool
-}
+type App struct{ version string }
 
 var _ backup.App = (*App)(nil)
 
 func New(version string) *App { return &App{version: version} }
-
-// NewPackedRestore returns the application adapter and packed-content target
-// that must be passed together to backup.Restore. The paired adapter permits
-// the snapshot's physical pack metadata to remain in the unpublished database
-// until Kit atomically replaces it with the packs published into the target.
-func NewPackedRestore(version string) (*App, *PackedRestoreTarget) {
-	return &App{version: version, allowPackedRestore: true}, newPackedRestoreTarget()
-}
 
 func (a *App) FrozenView(session *backup.FrozenSession) backup.FrozenView {
 	return &frozenView{tx: session.Tx()}
@@ -133,7 +122,11 @@ func (v *frozenView) Stats(ctx context.Context) (json.RawMessage, error) {
 }
 
 func (a *App) RestoredContentPaths(ctx context.Context, db *sql.DB) (map[string][]string, error) {
-	if !a.allowPackedRestore {
+	return restoredContentPaths(ctx, db, false)
+}
+
+func restoredContentPaths(ctx context.Context, db *sql.DB, allowPackedRestore bool) (map[string][]string, error) {
+	if !allowPackedRestore {
 		var packed bool
 		if err := db.QueryRowContext(ctx, `
 			SELECT EXISTS(SELECT 1 FROM blob_pack_index)
@@ -141,7 +134,7 @@ func (a *App) RestoredContentPaths(ctx context.Context, db *sql.DB) (map[string]
 			return nil, fmt.Errorf("backupapp: checking restored pack authority: %w", err)
 		}
 		if packed {
-			return nil, errors.New("backupapp: snapshot contains packed blob authority; use NewPackedRestore with its packed-content target")
+			return nil, errors.New("backupapp: snapshot contains packed blob authority; use backupapp.Restore")
 		}
 	}
 	rows, err := db.QueryContext(ctx, `SELECT hash FROM blobs ORDER BY hash`)

--- a/internal/backupapp/app.go
+++ b/internal/backupapp/app.go
@@ -67,11 +67,22 @@ func computeStats(ctx context.Context, q rowQuerier) (Stats, error) {
 }
 
 // App implements backup.App for docbank.
-type App struct{ version string }
+type App struct {
+	version            string
+	allowPackedRestore bool
+}
 
 var _ backup.App = (*App)(nil)
 
 func New(version string) *App { return &App{version: version} }
+
+// NewPackedRestore returns the application adapter and packed-content target
+// that must be passed together to backup.Restore. The paired adapter permits
+// the snapshot's physical pack metadata to remain in the unpublished database
+// until Kit atomically replaces it with the packs published into the target.
+func NewPackedRestore(version string) (*App, *PackedRestoreTarget) {
+	return &App{version: version, allowPackedRestore: true}, newPackedRestoreTarget()
+}
 
 func (a *App) FrozenView(session *backup.FrozenSession) backup.FrozenView {
 	return &frozenView{tx: session.Tx()}
@@ -122,6 +133,17 @@ func (v *frozenView) Stats(ctx context.Context) (json.RawMessage, error) {
 }
 
 func (a *App) RestoredContentPaths(ctx context.Context, db *sql.DB) (map[string][]string, error) {
+	if !a.allowPackedRestore {
+		var packed bool
+		if err := db.QueryRowContext(ctx, `
+			SELECT EXISTS(SELECT 1 FROM blob_pack_index)
+			    OR EXISTS(SELECT 1 FROM blob_packs)`).Scan(&packed); err != nil {
+			return nil, fmt.Errorf("backupapp: checking restored pack authority: %w", err)
+		}
+		if packed {
+			return nil, errors.New("backupapp: snapshot contains packed blob authority; use NewPackedRestore with its packed-content target")
+		}
+	}
 	rows, err := db.QueryContext(ctx, `SELECT hash FROM blobs ORDER BY hash`)
 	if err != nil {
 		return nil, fmt.Errorf("backupapp: listing restored blobs: %w", err)

--- a/internal/backupapp/app.go
+++ b/internal/backupapp/app.go
@@ -1,0 +1,206 @@
+// Package backupapp adapts docbank's logical schema and mixed blob store to
+// Kit's application-neutral backup engine.
+package backupapp
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"go.kenn.io/kit/backup"
+	"go.kenn.io/kit/packstore"
+)
+
+// Stats is the representation-neutral fidelity payload recorded in each
+// snapshot. Physical pack rows are deliberately excluded: restore may choose a
+// different loose/packed representation while preserving the same archive.
+type Stats struct {
+	Nodes         int64 `json:"nodes"`
+	Files         int64 `json:"files"`
+	Directories   int64 `json:"directories"`
+	TrashedNodes  int64 `json:"trashed_nodes"`
+	Blobs         int64 `json:"blobs"`
+	BlobBytes     int64 `json:"blob_bytes"`
+	NodeVersions  int64 `json:"node_versions"`
+	Ingests       int64 `json:"ingests"`
+	Provenance    int64 `json:"provenance"`
+	Tags          int64 `json:"tags"`
+	NodeTags      int64 `json:"node_tags"`
+	ExtractedText int64 `json:"extracted_text"`
+}
+
+type rowQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func computeStats(ctx context.Context, q rowQuerier) (Stats, error) {
+	var stats Stats
+	counts := []struct {
+		dst   *int64
+		query string
+	}{
+		{&stats.Nodes, `SELECT COUNT(*) FROM nodes`},
+		{&stats.Files, `SELECT COUNT(*) FROM nodes WHERE kind = 'file'`},
+		{&stats.Directories, `SELECT COUNT(*) FROM nodes WHERE kind = 'dir'`},
+		{&stats.TrashedNodes, `SELECT COUNT(*) FROM nodes WHERE trashed_at IS NOT NULL`},
+		{&stats.NodeVersions, `SELECT COUNT(*) FROM node_versions`},
+		{&stats.Ingests, `SELECT COUNT(*) FROM ingests`},
+		{&stats.Provenance, `SELECT COUNT(*) FROM provenance`},
+		{&stats.Tags, `SELECT COUNT(*) FROM tags`},
+		{&stats.NodeTags, `SELECT COUNT(*) FROM node_tags`},
+		{&stats.ExtractedText, `SELECT COUNT(*) FROM extracted_text`},
+	}
+	for _, count := range counts {
+		if err := q.QueryRowContext(ctx, count.query).Scan(count.dst); err != nil {
+			return Stats{}, fmt.Errorf("backupapp: stats query %q: %w", count.query, err)
+		}
+	}
+	if err := q.QueryRowContext(ctx,
+		`SELECT COUNT(*), COALESCE(SUM(size), 0) FROM blobs`,
+	).Scan(&stats.Blobs, &stats.BlobBytes); err != nil {
+		return Stats{}, fmt.Errorf("backupapp: blob stats: %w", err)
+	}
+	return stats, nil
+}
+
+// App implements backup.App for docbank.
+type App struct{ version string }
+
+var _ backup.App = (*App)(nil)
+
+func New(version string) *App { return &App{version: version} }
+
+func (a *App) FrozenView(session *backup.FrozenSession) backup.FrozenView {
+	return &frozenView{tx: session.Tx()}
+}
+
+func (a *App) DBFileName() string        { return "docbank.db" }
+func (a *App) ContentDirName() string    { return "blobs" }
+func (a *App) PackFileExtension() string { return packstore.PackExt }
+func (a *App) Version() string           { return a.version }
+func (a *App) ExcludedPaths() []string {
+	return []string{"config.toml", "logs/", "vault.lock", "launch.lock", "daemon.*.json", "blobs/tmp/"}
+}
+
+type frozenView struct{ tx *sql.Tx }
+
+func (v *frozenView) ContentInfo(ctx context.Context) (*backup.ContentInfo, error) {
+	rows, err := v.tx.QueryContext(ctx, `SELECT hash, size FROM blobs ORDER BY hash`)
+	if err != nil {
+		return nil, fmt.Errorf("backupapp: listing frozen blobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var refs []backup.ContentRef
+	for rows.Next() {
+		var ref backup.ContentRef
+		if err := rows.Scan(&ref.Hash, &ref.Size); err != nil {
+			return nil, fmt.Errorf("backupapp: scanning frozen blob: %w", err)
+		}
+		if _, err := packstore.ParseHash(ref.Hash); err != nil {
+			return nil, fmt.Errorf("backupapp: frozen blob hash %q: %w", ref.Hash, err)
+		}
+		if ref.Size < 0 {
+			return nil, fmt.Errorf("backupapp: frozen blob %s has negative size %d", ref.Hash, ref.Size)
+		}
+		refs = append(refs, ref)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("backupapp: frozen blob rows: %w", err)
+	}
+	return &backup.ContentInfo{Refs: refs, Rows: int64(len(refs))}, nil
+}
+
+func (v *frozenView) Stats(ctx context.Context) (json.RawMessage, error) {
+	stats, err := computeStats(ctx, v.tx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(stats)
+}
+
+func (a *App) RestoredContentPaths(ctx context.Context, db *sql.DB) (map[string][]string, error) {
+	rows, err := db.QueryContext(ctx, `SELECT hash FROM blobs ORDER BY hash`)
+	if err != nil {
+		return nil, fmt.Errorf("backupapp: listing restored blobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	paths := make(map[string][]string)
+	for rows.Next() {
+		var hash string
+		if err := rows.Scan(&hash); err != nil {
+			return nil, fmt.Errorf("backupapp: scanning restored blob: %w", err)
+		}
+		parsed, err := packstore.ParseHash(hash)
+		if err != nil {
+			return nil, fmt.Errorf("backupapp: restored blob hash %q: %w", hash, err)
+		}
+		paths[hash] = []string{parsed.String()[:2] + "/" + parsed.String()}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("backupapp: restored blob rows: %w", err)
+	}
+	return paths, nil
+}
+
+func (a *App) RestoredStats(ctx context.Context, db *sql.DB) (json.RawMessage, error) {
+	stats, err := computeStats(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(stats)
+}
+
+func (a *App) CheckManifest(manifest *backup.Manifest) []string {
+	stats, err := ParseStats(manifest.Stats)
+	if err != nil {
+		return []string{fmt.Sprintf("manifest stats unreadable: %v", err)}
+	}
+	var problems []string
+	if stats.Blobs != manifest.Attachments.Blobs {
+		problems = append(problems, fmt.Sprintf("stats.blobs %d != attachments.blobs %d",
+			stats.Blobs, manifest.Attachments.Blobs))
+	}
+	if stats.BlobBytes != manifest.Attachments.BlobBytes {
+		problems = append(problems, fmt.Sprintf("stats.blob_bytes %d != attachments.blob_bytes %d",
+			stats.BlobBytes, manifest.Attachments.BlobBytes))
+	}
+	if stats.Blobs != manifest.Attachments.Rows {
+		problems = append(problems, fmt.Sprintf("stats.blobs %d != attachments.rows %d",
+			stats.Blobs, manifest.Attachments.Rows))
+	}
+	return problems
+}
+
+func ParseStats(raw json.RawMessage) (Stats, error) {
+	var stats Stats
+	if err := json.Unmarshal(raw, &stats); err != nil {
+		return Stats{}, fmt.Errorf("backupapp: parsing manifest stats: %w", err)
+	}
+	return stats, nil
+}
+
+// BlobOpener is the mixed loose/packed read surface backup capture needs.
+type BlobOpener interface {
+	OpenContext(ctx context.Context, hash string) (io.ReadSeekCloser, error)
+}
+
+// ContentSource adapts docbank's catalog-authorized mixed store to backup.
+type ContentSource struct{ blobs BlobOpener }
+
+var _ backup.ContentSource = (*ContentSource)(nil)
+
+func NewContentSource(blobs BlobOpener) *ContentSource { return &ContentSource{blobs: blobs} }
+
+func (s *ContentSource) Open(ctx context.Context, ref backup.ContentRef) (io.ReadCloser, error) {
+	if s == nil || s.blobs == nil {
+		return nil, errors.New("backupapp: content source has no blob store")
+	}
+	reader, err := s.blobs.OpenContext(ctx, ref.Hash)
+	if err != nil {
+		return nil, fmt.Errorf("backupapp: opening content %s: %w", ref.Hash, err)
+	}
+	return reader, nil
+}

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -110,7 +110,7 @@ func TestLooseSnapshotVerifyAndRestore(t *testing.T) {
 	require.NoError(t, restoredStore.Close())
 }
 
-func TestPackedContentSourceCreatesVerifiableSnapshot(t *testing.T) {
+func TestPackedSnapshotRequiresAndUsesPackedRestoreTarget(t *testing.T) {
 	fixture := newArchiveFixture(t)
 	packed, err := fixture.blobs.Maintainer().Pack(t.Context(), packstore.PackOptions{})
 	require.NoError(t, err)
@@ -131,4 +131,44 @@ func TestPackedContentSourceCreatesVerifiableSnapshot(t *testing.T) {
 	verified, err := backup.Verify(t.Context(), repo, app, backup.VerifyOptions{Jobs: 2})
 	require.NoError(t, err)
 	assert.Empty(t, verified.Problems)
+
+	unsafeTarget := filepath.Join(t.TempDir(), "unsafe-restored")
+	_, err = backup.Restore(t.Context(), repo, app, backup.RestoreOptions{
+		TargetDir: unsafeTarget, Jobs: 2,
+	})
+	require.ErrorContains(t, err, "snapshot contains packed blob authority")
+
+	restoreApp, packedTarget := backupapp.NewPackedRestore("test-version")
+	target := filepath.Join(t.TempDir(), "restored")
+	restored, err := backup.Restore(t.Context(), repo, restoreApp, backup.RestoreOptions{
+		TargetDir: target, Jobs: 2, PackedContent: packedTarget,
+	})
+	require.NoError(t, err)
+	assert.Zero(t, restored.LooseAttachmentBlobs)
+	assert.Equal(t, int64(2), restored.PackedAttachmentBlobs)
+	assert.Positive(t, restored.AttachmentPacks)
+
+	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	restoredCatalog := store.NewPackCatalog(restoredStore)
+	records, err := restoredCatalog.ListPackRecords(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, records)
+	entries, err := restoredCatalog.ListIndexed(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+	restoredBlobs, err := blob.New(restoredCatalog, filepath.Join(target, "blobs"))
+	require.NoError(t, err)
+	for name, want := range fixture.content {
+		node, nodeErr := restoredStore.NodeByPath(t.Context(), "/"+name)
+		require.NoError(t, nodeErr)
+		reader, openErr := restoredBlobs.OpenContext(t.Context(), node.BlobHash)
+		require.NoError(t, openErr)
+		got, readErr := io.ReadAll(reader)
+		require.NoError(t, readErr)
+		require.NoError(t, reader.Close())
+		assert.Equal(t, want, string(got))
+	}
+	require.NoError(t, restoredBlobs.Close())
+	require.NoError(t, restoredStore.Close())
 }

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -138,10 +138,9 @@ func TestPackedSnapshotRequiresAndUsesPackedRestoreTarget(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "snapshot contains packed blob authority")
 
-	restoreApp, packedTarget := backupapp.NewPackedRestore("test-version")
 	target := filepath.Join(t.TempDir(), "restored")
-	restored, err := backup.Restore(t.Context(), repo, restoreApp, backup.RestoreOptions{
-		TargetDir: target, Jobs: 2, PackedContent: packedTarget,
+	restored, err := backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{
+		TargetDir: target, Jobs: 2,
 	})
 	require.NoError(t, err)
 	assert.Zero(t, restored.LooseAttachmentBlobs)

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -1,0 +1,134 @@
+package backupapp_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/backup"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/backupapp"
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/store"
+)
+
+type archiveFixture struct {
+	root     string
+	metadata *store.Store
+	blobs    *blob.Store
+	content  map[string]string
+}
+
+func newArchiveFixture(t *testing.T) *archiveFixture {
+	t.Helper()
+	root := t.TempDir()
+	metadata, err := store.Open(filepath.Join(root, "docbank.db"))
+	require.NoError(t, err)
+	blobsDir := filepath.Join(root, "blobs")
+	require.NoError(t, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
+	blobs, err := blob.New(store.NewPackCatalog(metadata), blobsDir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, blobs.Close())
+		require.NoError(t, metadata.Close())
+	})
+	fixture := &archiveFixture{
+		root: root, metadata: metadata, blobs: blobs,
+		content: map[string]string{"alpha.txt": "alpha backup", "bravo.txt": "bravo backup"},
+	}
+	require.NoError(t, blobs.WithMutation(t.Context(), func() error {
+		for name, content := range fixture.content {
+			hash, size, writeErr := blobs.WriteContext(t.Context(), strings.NewReader(content))
+			if writeErr != nil {
+				return writeErr
+			}
+			if _, createErr := metadata.CreateFile(t.Context(), metadata.RootID(), name,
+				hash, size, "text/plain"); createErr != nil {
+				return createErr
+			}
+		}
+		return nil
+	}))
+	return fixture
+}
+
+func TestLooseSnapshotVerifyAndRestore(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	app := backupapp.New("test-version")
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+
+	manifest, err := backup.Create(t.Context(), repo, app, backup.CreateOptions{
+		DBPath:        filepath.Join(fixture.root, "docbank.db"),
+		ContentSource: backupapp.NewContentSource(fixture.blobs),
+		Jobs:          2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), manifest.Attachments.Rows)
+	assert.Equal(t, int64(2), manifest.Attachments.Blobs)
+	assert.Equal(t, int64(len("alpha backup")+len("bravo backup")), manifest.Attachments.BlobBytes)
+	stats, err := backupapp.ParseStats(manifest.Stats)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.Nodes, "root plus two files")
+	assert.Equal(t, int64(2), stats.Files)
+	assert.Equal(t, manifest.Attachments.BlobBytes, stats.BlobBytes)
+
+	verified, err := backup.Verify(t.Context(), repo, app, backup.VerifyOptions{Jobs: 2})
+	require.NoError(t, err)
+	assert.Empty(t, verified.Problems)
+	assert.Equal(t, []string{manifest.SnapshotID}, verified.Snapshots)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	restored, err := backup.Restore(t.Context(), repo, app, backup.RestoreOptions{
+		TargetDir: target, Jobs: 2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), restored.AttachmentBlobs)
+	assert.Equal(t, int64(2), restored.LooseAttachmentBlobs)
+
+	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	restoredBlobs, err := blob.New(store.NewPackCatalog(restoredStore), filepath.Join(target, "blobs"))
+	require.NoError(t, err)
+	for name, want := range fixture.content {
+		node, nodeErr := restoredStore.NodeByPath(t.Context(), "/"+name)
+		require.NoError(t, nodeErr)
+		reader, openErr := restoredBlobs.OpenContext(t.Context(), node.BlobHash)
+		require.NoError(t, openErr)
+		got, readErr := io.ReadAll(reader)
+		require.NoError(t, readErr)
+		require.NoError(t, reader.Close())
+		assert.Equal(t, want, string(got))
+	}
+	require.NoError(t, restoredBlobs.Close())
+	require.NoError(t, restoredStore.Close())
+}
+
+func TestPackedContentSourceCreatesVerifiableSnapshot(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	packed, err := fixture.blobs.Maintainer().Pack(t.Context(), packstore.PackOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 2, packed.BlobsPacked)
+	require.Equal(t, 1, packed.PacksSealed)
+
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	app := backupapp.New("test-version")
+	manifest, err := backup.Create(context.Background(), repo, app, backup.CreateOptions{
+		DBPath:        filepath.Join(fixture.root, "docbank.db"),
+		ContentSource: backupapp.NewContentSource(fixture.blobs),
+		Jobs:          2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), manifest.Attachments.Blobs)
+
+	verified, err := backup.Verify(t.Context(), repo, app, backup.VerifyOptions{Jobs: 2})
+	require.NoError(t, err)
+	assert.Empty(t, verified.Problems)
+}

--- a/internal/backupapp/restore.go
+++ b/internal/backupapp/restore.go
@@ -3,6 +3,7 @@ package backupapp
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"go.kenn.io/kit/backup"
@@ -11,25 +12,54 @@ import (
 	"go.kenn.io/docbank/internal/store"
 )
 
-// PackedRestoreTarget supplies docbank's storage policy and catalog adapter to
+// packedRestoreTarget supplies docbank's storage policy and catalog adapter to
 // Kit while it restores into an unpublished target database.
-type PackedRestoreTarget struct {
+type packedRestoreTarget struct {
 	coordinator *packstore.Coordinator
 	limits      packstore.Limits
 }
 
-var _ backup.PackedContentTarget = (*PackedRestoreTarget)(nil)
+var _ backup.PackedContentTarget = (*packedRestoreTarget)(nil)
 
-func newPackedRestoreTarget() *PackedRestoreTarget {
-	return &PackedRestoreTarget{
+type packedRestoreApp struct{ *App }
+
+var _ backup.App = (*packedRestoreApp)(nil)
+
+func (a *packedRestoreApp) RestoredContentPaths(
+	ctx context.Context, db *sql.DB,
+) (map[string][]string, error) {
+	return restoredContentPaths(ctx, db, true)
+}
+
+func newPackedRestoreTarget() *packedRestoreTarget {
+	return &packedRestoreTarget{
 		coordinator: packstore.NewCoordinator(),
 		limits:      packstore.DefaultLimits(),
 	}
 }
 
-func (t *PackedRestoreTarget) Limits() packstore.Limits { return t.limits }
+// Restore restores a snapshot with docbank's packed-storage policy. It owns the
+// application adapter and packed target as one operation so callers cannot
+// accidentally authorize captured pack metadata while omitting catalog
+// replacement from Kit's restore options.
+func Restore(
+	ctx context.Context, repo *backup.Repo, version string, opts backup.RestoreOptions,
+) (*backup.RestoreResult, error) {
+	if opts.PackedContent != nil {
+		return nil, errors.New("backupapp: restore options must not supply packed content policy")
+	}
+	opts.PackedContent = newPackedRestoreTarget()
+	app := &packedRestoreApp{App: New(version)}
+	result, err := backup.Restore(ctx, repo, app, opts)
+	if err != nil {
+		return nil, fmt.Errorf("backupapp: restoring snapshot: %w", err)
+	}
+	return result, nil
+}
 
-func (t *PackedRestoreTarget) AcquireRestoreLease(ctx context.Context) (*packstore.Lease, error) {
+func (t *packedRestoreTarget) Limits() packstore.Limits { return t.limits }
+
+func (t *packedRestoreTarget) AcquireRestoreLease(ctx context.Context) (*packstore.Lease, error) {
 	lease, err := t.coordinator.AcquireMutation(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("backupapp: acquiring packed restore lease: %w", err)
@@ -37,7 +67,7 @@ func (t *PackedRestoreTarget) AcquireRestoreLease(ctx context.Context) (*packsto
 	return lease, nil
 }
 
-func (t *PackedRestoreTarget) OpenRestoreCatalog(
+func (t *packedRestoreTarget) OpenRestoreCatalog(
 	_ context.Context, db *sql.DB,
 ) (packstore.RestoreCatalog, error) {
 	return store.NewPackRestoreCatalog(db), nil

--- a/internal/backupapp/restore.go
+++ b/internal/backupapp/restore.go
@@ -1,0 +1,44 @@
+package backupapp
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"go.kenn.io/kit/backup"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+// PackedRestoreTarget supplies docbank's storage policy and catalog adapter to
+// Kit while it restores into an unpublished target database.
+type PackedRestoreTarget struct {
+	coordinator *packstore.Coordinator
+	limits      packstore.Limits
+}
+
+var _ backup.PackedContentTarget = (*PackedRestoreTarget)(nil)
+
+func newPackedRestoreTarget() *PackedRestoreTarget {
+	return &PackedRestoreTarget{
+		coordinator: packstore.NewCoordinator(),
+		limits:      packstore.DefaultLimits(),
+	}
+}
+
+func (t *PackedRestoreTarget) Limits() packstore.Limits { return t.limits }
+
+func (t *PackedRestoreTarget) AcquireRestoreLease(ctx context.Context) (*packstore.Lease, error) {
+	lease, err := t.coordinator.AcquireMutation(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("backupapp: acquiring packed restore lease: %w", err)
+	}
+	return lease, nil
+}
+
+func (t *PackedRestoreTarget) OpenRestoreCatalog(
+	_ context.Context, db *sql.DB,
+) (packstore.RestoreCatalog, error) {
+	return store.NewPackRestoreCatalog(db), nil
+}

--- a/internal/store/pack_catalog.go
+++ b/internal/store/pack_catalog.go
@@ -23,6 +23,77 @@ func NewPackCatalog(s *Store) *PackCatalog { return &PackCatalog{store: s} }
 
 var _ packstore.Catalog = (*PackCatalog)(nil)
 
+// PackRestoreCatalog grants packed authority in an unpublished restored
+// database. It deliberately accepts a *sql.DB rather than a Store because Kit
+// owns the staged database lifecycle until restore publication.
+type PackRestoreCatalog struct{ db *sql.DB }
+
+// NewPackRestoreCatalog constructs a restore-only packed catalog over db.
+func NewPackRestoreCatalog(db *sql.DB) *PackRestoreCatalog { return &PackRestoreCatalog{db: db} }
+
+var _ packstore.RestoreCatalog = (*PackRestoreCatalog)(nil)
+
+// ReplaceRestoredPacks atomically discards pack metadata captured from the
+// source vault and grants authority only to packs Kit published and verified
+// in the restore target.
+func (c *PackRestoreCatalog) ReplaceRestoredPacks(
+	ctx context.Context, records []packstore.PackRecord, adoptions []packstore.Adoption,
+) error {
+	packIDs := make(map[string]struct{}, len(records))
+	for _, record := range records {
+		if err := record.Validate(); err != nil {
+			return fmt.Errorf("validating restored blob pack %s: %w", record.PackID, err)
+		}
+		if _, duplicate := packIDs[record.PackID]; duplicate {
+			return fmt.Errorf("duplicate restored blob pack %s", record.PackID)
+		}
+		packIDs[record.PackID] = struct{}{}
+	}
+	hashes := make(map[packstore.Hash]struct{}, len(adoptions))
+	for _, adoption := range adoptions {
+		if err := adoption.Entry.Validate(); err != nil {
+			return fmt.Errorf("validating restored packed blob %s: %w", adoption.Entry.Hash, err)
+		}
+		if _, ok := packIDs[adoption.Entry.PackID]; !ok {
+			return fmt.Errorf("restored packed blob %s names unknown pack %s",
+				adoption.Entry.Hash, adoption.Entry.PackID)
+		}
+		if _, duplicate := hashes[adoption.Entry.Hash]; duplicate {
+			return fmt.Errorf("duplicate restored packed blob %s", adoption.Entry.Hash)
+		}
+		hashes[adoption.Entry.Hash] = struct{}{}
+	}
+
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning restored pack catalog replacement: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM blob_pack_index`); err != nil {
+		return fmt.Errorf("clearing restored packed blob mappings: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM blob_packs`); err != nil {
+		return fmt.Errorf("clearing restored blob pack records: %w", err)
+	}
+	for _, record := range records {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO blob_packs (pack_id, entry_count, stored_bytes, created_at)
+			VALUES (?, ?, ?, ?)`, record.PackID, record.EntryCount, record.StoredBytes,
+			record.CreatedAt.UTC().Format(timestampLayout)); err != nil {
+			return fmt.Errorf("recording restored blob pack %s: %w", record.PackID, err)
+		}
+	}
+	for _, adoption := range adoptions {
+		if err := writeAdoption(ctx, tx, adoption.Entry, false); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing restored pack catalog replacement: %w", err)
+	}
+	return nil
+}
+
 func (c *PackCatalog) Resolve(ctx context.Context, hash packstore.Hash) (packstore.Location, error) {
 	row := c.store.db.QueryRowContext(ctx, `
 		SELECT i.pack_id, i.pack_offset, i.stored_len, i.raw_len, i.flags, i.crc32c


### PR DESCRIPTION
Kit’s snapshot engine needs an application-owned definition of archive membership and restore fidelity before docbank can safely expose backup commands. That definition cannot follow the current loose or packed layout: physical maintenance is allowed to change representation without changing which content belongs to the archive.

This PR adds the internal docbank backup adapter. Every authoritative blobs row is captured through the mixed store, including content that has become a GC candidate but has not been collected. Fidelity statistics cover logical archive state while deliberately excluding pack records and offsets. Canonical restore paths are derived from the restored database rather than copied from live filesystem assumptions.

Restore preserves that representation-neutral contract without trusting physical metadata captured from the source vault. A packed snapshot fails closed if routed through the loose-only adapter. The paired packed restore path lets Kit publish and verify repository packs, then atomically replaces every source pack record and mapping in the unpublished target database before publication. The integration proof restores a packed fixture and reads every blob through Docbank’s normal mixed store.

No user-facing backup command is introduced here. Command/API orchestration remains a separate reviewable child of the backup umbrella.