### PR TITLE
Expose verifiable HTTP content identity

### DIFF
--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -79,8 +79,10 @@ curl --fail-with-body --get \
 ```
 
 A node response includes stable `id`, mutable `revision`, `kind`, and
-timestamps. Live single-node responses also include the current `path`. IDs
-survive renames; use a live path only for display or a one-shot path operation.
+timestamps. File nodes also include their immutable SHA-256 `blob_hash` and
+raw `size`; directories omit the hash. Live single-node responses include the
+current `path`. IDs survive renames; use a live path only for display or a
+one-shot path operation.
 
 Trash is the important exception. A successful trash response returns the
 node's **pre-trash path** to explain where a restore would try to put it. That
@@ -119,6 +121,31 @@ curl --fail \
   "$DOCBANK_URL/api/v1/nodes/42/content" \
   --output document.bin
 ```
+
+The content response sends `X-Docbank-Blob-Hash` and
+`X-Docbank-Blob-Size` before the body. After the body it sends an
+[RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html) `Content-Digest`
+trailer computed from the bytes actually streamed. A client
+that needs independent transfer proof hashes `document.bin` itself and compares
+that digest, the trailer, and the file node's `blob_hash`. Do not treat the
+catalog header alone as a fresh physical verification.
+
+For a bounded server-side check, send the revision from the node response:
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'If-Match: "7"' \
+  "$DOCBANK_URL/api/v1/nodes/42/verify"
+```
+
+A successful proof returns `blob_hash`, `computed_hash`, `size`,
+`computed_size`, and `verified: true`, bound to `node_id` and `revision`.
+Missing or damaged content returns HTTP 200 with `verified: false` and
+`problem: "missing"`, `"corrupt"`, or `"unreadable"`; those are completed
+checks with negative evidence, not request failures. A `412 stale_revision`
+means the node changed during or since inspection—read it again before deciding
+what content to verify.
 
 ## Use revisions for read-modify-write
 
@@ -215,6 +242,10 @@ physically reclaimed.
 expensive. Maintenance requests serialize against mutations and may run
 without the ordinary request timeout; agents should expose progress as
 “waiting” rather than assuming a queued request is hung.
+
+Use `POST /api/v1/nodes/{id}/verify` when the decision concerns one inspected
+file. Unlike the vault-wide operation it requires `If-Match`, stays bounded to
+one blob, and returns the recorded and freshly computed identities directly.
 
 `POST /api/v1/storage/pack` is explicit but non-destructive: it changes the
 physical representation without changing document identity or blob read

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -33,7 +33,8 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /nodes/{id}` | stat by id (live or trashed) | Implemented |
 | `GET /path?path=/a/b` | stat by virtual path | Implemented |
 | `GET /nodes/{id}/children` | list a directory, paginated (`limit`/`offset`) | Implemented |
-| `GET /nodes/{id}/content` | stream document bytes | Implemented |
+| `GET /nodes/{id}/content` | stream document bytes with catalog identity and a computed digest trailer | Implemented |
+| `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
 | `POST /ingest` | import server-side paths — see [addendum](#addendum-post-ingest) | Implemented |
@@ -92,6 +93,7 @@ and maintenance are explicit exceptions:
 | `PATCH /nodes/{id}` | required — target node's revision |
 | `POST /nodes/{id}/trash` | required — target node's revision |
 | `POST /nodes/{id}/restore` | required — target node's revision |
+| `POST /nodes/{id}/verify` | required — binds the evidence to the exact node state the caller inspected |
 | `POST /path/move`, `POST /path/trash` | none — the path is resolved and mutated inside one store transaction, so there is no separate read for a revision to guard |
 | `POST /nodes` (create dir) | none — creation has no prior revision; a name collision is `409` |
 | `POST /ingest` | none — long-running bulk operation with per-path partial success; the destination directory may legitimately change while it runs |
@@ -101,6 +103,41 @@ A stale revision gets `412 Precondition Failed`, telling the caller to
 re-read and retry. A required `If-Match` that's missing gets `428
 Precondition Required`. Both carry the problem-JSON error envelope
 below explaining the rule.
+
+## Content identity and verification evidence
+
+Every file-node representation includes `blob_hash`, docbank's canonical
+lowercase SHA-256 content identity, together with its raw `size`. Directories
+omit `blob_hash`. The hash is stable across moves and renames; a future content
+replacement will retain the node ID but change its hash and revision.
+
+`GET /nodes/{id}/content` exposes the catalog identity before streaming in
+`X-Docbank-Blob-Hash` and `X-Docbank-Blob-Size`. It then hashes the bytes while
+they pass through the response and emits the result as the
+[RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html) `Content-Digest`
+trailer. The response deliberately omits standard
+`Content-Length`: HTTP/1.1 cannot carry a trailer on a fixed-length message,
+and pre-reading a large loose or packed blob solely to populate a header would
+double physical I/O. Clients that need independent transfer proof hash the
+body themselves and compare both their digest and the trailer with the node's
+`blob_hash`.
+
+`POST /nodes/{id}/verify` is the bounded server-side proof. It requires
+`If-Match` from a prior node response, reopens the blob through the same mixed
+loose/packed store used for downloads, and returns the recorded and computed
+hashes and sizes. Missing, corrupt, and unreadable content are successful
+reports with `verified: false` and a `problem`; transport, validation, and
+stale-node failures remain non-2xx responses. The route checks the revision
+again after reading, so a concurrent rename, trash, or future content
+replacement yields `412` instead of ambiguous evidence.
+
+The single-node route is exempt from the ordinary request timeout. It is
+bounded in scope, not necessarily short in duration: hashing one very large
+blob may legitimately take longer than a minute.
+
+These are integrity receipts from the authenticated daemon, not
+non-repudiable attestations against a malicious server. Signed receipts or a
+transparency log are outside docbank's current trust model.
 
 ## Addendum: `POST /ingest`
 

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -38,7 +38,7 @@ user's privileges. Consequently:
 | A deleted blob stays deleted | `blob.Remove` | shard dir fsync before gc deletes the metadata row, including on the already-missing retry path |
 | A stored object is what its name claims *structurally* | `blob.Write` dedup check | Kit performs a no-follow identity check; a wrong-sized object, symlink, or special file fails closed and is left unchanged for explicit recovery |
 | Reads serve only stored blobs | `blob.Open` / `blob.Exists` | no-follow open + regular-file check on the blob itself; the vault's own directory structure above it is trusted per the boundary above (a symlinked shard dir is user-privileged relocation or tampering, not an attack docbank can meaningfully resist) |
-| Content matches its hash *byte-for-byte* | `docbank verify` | full re-hash of every blob, on demand |
+| Content matches its hash *byte-for-byte* | `docbank verify`; `POST /nodes/{id}/verify` | full-vault re-hash on demand, or a revision-bound fresh read of one file through the mixed store |
 | No orphan blob file survives | `docbank gc` | reachability query for rows **plus** a directory scan for files that never gained (or lost) their row |
 | Imports read the file they classified | ingest | `O_NOFOLLOW` + fstat at open, not the earlier `Lstat`/`WalkDir` classification |
 | Mutations act on the node the caller named | store | id-addressed mutations (`Move`, `Trash`, `Restore`) require an `If-Match` revision precondition; path-addressed mutations (`MovePath`, `TrashPath`, backing `POST /path/move` and `/path/trash`) resolve and mutate inside one store transaction — either way, no path-race window between resolving a name and acting on it |

--- a/docs/internal/daemon-api-design.md
+++ b/docs/internal/daemon-api-design.md
@@ -70,6 +70,22 @@ Do not add a path mutation that resolves through a separate preflight query.
 Use an ID plus revision for read-modify-write or add a transactional store
 operation for one-shot path intent.
 
+File-node wire representations expose the catalog's lowercase SHA-256
+`blob_hash`; stable node identity and immutable content identity are separate
+on purpose. A content response sends that expected identity before the body
+and computes an RFC 9530 `Content-Digest` trailer while streaming actual bytes.
+Do not substitute the catalog value directly into `Content-Digest`: corruption
+would turn an integrity field into a false assertion.
+
+Single-node verification requires `If-Match`, reads through the mixed store,
+and checks the node revision again afterward. The second check is essential:
+ordinary mutations may run concurrently, and evidence must never silently
+change meaning if the node is renamed, trashed, or eventually pointed at a new
+content version during a long read. Physical pack maintenance remains safe
+through Kit's reader lifecycle and does not change blob identity.
+Because one blob may still be very large, this route is timeout-exempt like the
+vault-wide verifier; cancellation still propagates from the client connection.
+
 ## Request concurrency and maintenance
 
 SQLite serializes metadata writes and schema/store invariants choose the winner

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,6 +75,11 @@ to publish loose blobs; startup never performs an implicit migration.
 
 ## Phase 2b — Features (designed)
 
+Implemented foundation: file-node API responses expose immutable SHA-256
+identity, content streams carry catalog identity plus a freshly computed digest
+trailer, and a revision-bound single-node endpoint verifies stored bytes. This
+is the evidence contract future remote writers build on.
+
 - Editing surfaces: `PUT` content, `docbank edit`/`put`/`revert`, and
   `versions` listing ([design](architecture/editing-and-versions.md))
 - Tags surfaced in CLI, search filters, and the API; `POST /batch/move`

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -13,14 +13,14 @@ import (
 
 const requestTimeout = 60 * time.Second
 
-// timeout-exempt: long-running maintenance and bulk ingest.
+// timeout-exempt: long-running maintenance, integrity reads, and bulk ingest.
 func timeoutExempt(path string) bool {
 	switch path {
 	case "/api/v1/ingest", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
 		"/api/v1/storage/pack", "/api/v1/storage/repack":
 		return true
 	}
-	return false
+	return strings.HasPrefix(path, "/api/v1/nodes/") && strings.HasSuffix(path, "/verify")
 }
 
 // auth-exempt: discovery, docs, and the static placeholder carry no vault

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -14,12 +14,15 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	out, err := api.OpenAPIYAML()
 	require.NoError(t, err)
 	doc := string(out)
-	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent",
+	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent", "verifyNodeContent",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
 		"storageStatus", "storagePack", "storageRepack", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
 	assert.NotContains(t, doc, "/api/daemon/shutdown", "lifecycle plumbing must stay hidden")
+	assert.Contains(t, doc, "X-Docbank-Blob-Hash")
+	assert.Contains(t, doc, "Content-Digest")
+	assert.Contains(t, doc, "computed_hash")
 }
 
 func TestOpenAPIDeclaresSecurity(t *testing.T) {

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -2,8 +2,13 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"strconv"
 	"strings"
@@ -16,6 +21,15 @@ import (
 type nodeOutput struct {
 	ETag string `header:"ETag"`
 	Body Node
+}
+
+func contentDigest(hash []byte) string {
+	return "sha-256=:" + base64.StdEncoding.EncodeToString(hash) + ":"
+}
+
+func staleRevisionError(id, expected, actual int64) error {
+	return FromStoreError(fmt.Errorf("node %d revision is %d, expected %d: %w",
+		id, actual, expected, store.ErrStaleRevision))
 }
 
 // nodeOutputAt builds the single-node response with a caller-supplied
@@ -103,6 +117,26 @@ func registerReadRoutes(api huma.API, d Deps) {
 	huma.Register(api, huma.Operation{
 		OperationID: "getNodeContent", Method: http.MethodGet, Path: "/api/v1/nodes/{id}/content",
 		Summary: "Stream a file's bytes",
+		Description: "X-Docbank-Blob-Hash and X-Docbank-Blob-Size carry catalog identity " +
+			"before the body. Content-Digest is an RFC 9530 trailer computed from the bytes " +
+			"actually streamed; the standard Content-Length header is omitted so HTTP/1.1 " +
+			"can transmit that trailer without a second physical read.",
+		Responses: map[string]*huma.Response{
+			"200": {
+				Description: "Document bytes with expected identity headers and a computed digest trailer",
+				Headers: map[string]*huma.Param{
+					BlobHashHeader: {Description: "Catalog SHA-256 identity (lowercase hex)",
+						Schema: &huma.Schema{Type: "string", Pattern: "^[0-9a-f]{64}$"}},
+					BlobSizeHeader: {Description: "Catalog raw byte length",
+						Schema: &huma.Schema{Type: "string", Pattern: "^[0-9]+$"}},
+					"Content-Digest": {Description: "RFC 9530 SHA-256 of bytes actually streamed; delivered as an HTTP trailer",
+						Schema: &huma.Schema{Type: "string"}},
+				},
+				Content: map[string]*huma.MediaType{
+					"application/octet-stream": {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				},
+			},
+		},
 	}, func(ctx context.Context, in *struct {
 		ID int64 `path:"id"`
 	}) (*huma.StreamResponse, error) {
@@ -126,9 +160,79 @@ func registerReadRoutes(api huma.API, d Deps) {
 		return &huma.StreamResponse{Body: func(hctx huma.Context) {
 			defer func() { _ = f.Close() }()
 			hctx.SetHeader("Content-Type", ct)
-			hctx.SetHeader("Content-Length", strconv.FormatInt(n.Size, 10))
-			_, _ = io.Copy(hctx.BodyWriter(), f)
+			hctx.SetHeader(BlobHashHeader, n.BlobHash)
+			hctx.SetHeader(BlobSizeHeader, strconv.FormatInt(n.Size, 10))
+			hctx.SetHeader("Trailer", "Content-Digest")
+			hash := sha256.New()
+			if _, err := io.Copy(hctx.BodyWriter(), io.TeeReader(f, hash)); err == nil {
+				hctx.SetHeader("Content-Digest", contentDigest(hash.Sum(nil)))
+			}
 		}}, nil
+	})
+
+	type verifyNodeOutput struct{ Body ContentVerification }
+	huma.Register(api, huma.Operation{
+		OperationID: "verifyNodeContent", Method: http.MethodPost, Path: "/api/v1/nodes/{id}/verify",
+		Summary: "Re-hash one file and bind the evidence to its node revision",
+		Description: "Requires If-Match from a prior node response. Returns catalog identity and " +
+			"a fresh read through the mixed loose/packed store; a concurrent node change returns 412.",
+	}, func(ctx context.Context, in *struct {
+		ID      int64  `path:"id"`
+		IfMatch string `header:"If-Match"`
+	}) (*verifyNodeOutput, error) {
+		revision, err := parseIfMatch(in.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+		n, err := d.Store.NodeByID(ctx, in.ID)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		if n.IsDir() {
+			return nil, NewError(http.StatusUnprocessableEntity, "not_file",
+				fmt.Sprintf("node %d is a directory", n.ID))
+		}
+		if n.Revision != revision {
+			return nil, staleRevisionError(n.ID, revision, n.Revision)
+		}
+
+		report := ContentVerification{
+			NodeID: n.ID, Revision: n.Revision, BlobHash: n.BlobHash, Size: n.Size,
+		}
+		f, openErr := d.Blobs.OpenContext(ctx, n.BlobHash)
+		if openErr != nil {
+			if errors.Is(openErr, fs.ErrNotExist) {
+				report.Problem = "missing"
+			} else {
+				report.Problem = "unreadable"
+			}
+		} else {
+			hash := sha256.New()
+			report.ComputedSize, err = io.Copy(hash, f)
+			closeErr := f.Close()
+			if err != nil || closeErr != nil {
+				report.Problem = "unreadable"
+			} else {
+				report.ComputedHash = hex.EncodeToString(hash.Sum(nil))
+				report.Verified = report.ComputedHash == n.BlobHash && report.ComputedSize == n.Size
+				if !report.Verified {
+					report.Problem = "corrupt"
+				}
+			}
+		}
+
+		current, err := d.Store.NodeByID(ctx, in.ID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, FromStoreError(fmt.Errorf(
+					"node %d disappeared during verification: %w", in.ID, store.ErrStaleRevision))
+			}
+			return nil, FromStoreError(err)
+		}
+		if current.Revision != revision || current.BlobHash != n.BlobHash {
+			return nil, staleRevisionError(n.ID, revision, current.Revision)
+		}
+		return &verifyNodeOutput{Body: report}, nil
 	})
 
 	type searchOutput struct{ Body SearchReport }

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -2,9 +2,13 @@
 package api_test
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -25,6 +29,7 @@ func TestStatByIDAndPath(t *testing.T) {
 	var n api.Node
 	require.NoError(t, json.Unmarshal([]byte(body), &n))
 	assert.Equal(t, d.ID, n.ID)
+	assert.Empty(t, n.BlobHash)
 	assert.Equal(t, "/docs", n.Path)
 	assert.Equal(t, fmt.Sprintf("%q", strconv.FormatInt(d.Revision, 10)), resp.Header.Get("ETag"))
 
@@ -70,6 +75,82 @@ func TestContentStreamsBlob(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "hello world", body)
 	assert.Contains(t, resp.Header.Get("Content-Type"), "text/plain")
+	assert.Equal(t, n.BlobHash, resp.Header.Get(api.BlobHashHeader))
+	assert.Equal(t, strconv.FormatInt(n.Size, 10), resp.Header.Get(api.BlobSizeHeader))
+	assert.Empty(t, resp.Header.Get("Content-Length"), "fixed length would suppress the digest trailer on HTTP/1.1")
+	sum := sha256.Sum256([]byte("hello world"))
+	assert.Equal(t, "sha-256=:"+base64.StdEncoding.EncodeToString(sum[:])+":",
+		resp.Trailer.Get("Content-Digest"))
+}
+
+func TestFileNodeExposesBlobIdentity(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	n := createFileWithContent(t, ts, s, "/identity.txt", "identity")
+	resp, body := get(t, ts, fmt.Sprintf("/api/v1/nodes/%d", n.ID), nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var got api.Node
+	require.NoError(t, json.Unmarshal([]byte(body), &got))
+	assert.Equal(t, n.BlobHash, got.BlobHash)
+	assert.Equal(t, n.Size, got.Size)
+}
+
+func TestVerifyNodeContentBindsRevisionAndReadsStoredBytes(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	n := createFileWithContent(t, ts, s, "/evidence.txt", "evidence")
+	_, etag := etagOf(t, ts, n.ID)
+	path := fmt.Sprintf("/api/v1/nodes/%d/verify", n.ID)
+
+	resp, body := do(t, ts, http.MethodPost, path, map[string]string{"If-Match": etag}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var report api.ContentVerification
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.Equal(t, n.ID, report.NodeID)
+	assert.Equal(t, n.Revision, report.Revision)
+	assert.Equal(t, n.BlobHash, report.BlobHash)
+	assert.Equal(t, n.BlobHash, report.ComputedHash)
+	assert.Equal(t, n.Size, report.Size)
+	assert.Equal(t, n.Size, report.ComputedSize)
+	assert.True(t, report.Verified)
+	assert.Empty(t, report.Problem)
+
+	resp, body = do(t, ts, http.MethodPost, path, nil, nil)
+	assert.Equal(t, http.StatusPreconditionRequired, resp.StatusCode)
+	assert.Contains(t, body, `"code":"precondition_required"`)
+	resp, body = do(t, ts, http.MethodPost, path,
+		map[string]string{"If-Match": `"999"`}, nil)
+	assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	assert.Contains(t, body, `"code":"stale_revision"`)
+
+	corrupt := []byte("damaged!")
+	require.Len(t, corrupt, int(n.Size))
+	require.NoError(t, os.WriteFile(filepath.Join(s.BlobsDir, n.BlobHash[:2], n.BlobHash), corrupt, 0o600))
+	resp, body = do(t, ts, http.MethodPost, path, map[string]string{"If-Match": etag}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	report = api.ContentVerification{}
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.False(t, report.Verified)
+	assert.Equal(t, "corrupt", report.Problem)
+	assert.NotEqual(t, report.BlobHash, report.ComputedHash)
+	assert.Equal(t, report.Size, report.ComputedSize)
+
+	require.NoError(t, s.Blobs.Remove(n.BlobHash))
+	resp, body = do(t, ts, http.MethodPost, path, map[string]string{"If-Match": etag}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	report = api.ContentVerification{}
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.False(t, report.Verified)
+	assert.Equal(t, "missing", report.Problem)
+}
+
+func TestVerifyNodeContentRejectsDirectory(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	d, err := s.Mkdir(t.Context(), s.RootID(), "directory")
+	require.NoError(t, err)
+	_, etag := etagOf(t, ts, d.ID)
+	resp, body := do(t, ts, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/verify", d.ID), map[string]string{"If-Match": etag}, nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	assert.Contains(t, body, `"code":"not_file"`)
 }
 
 func TestContentOnDirIs422(t *testing.T) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -29,7 +29,8 @@ import (
 type testStore struct {
 	*store.Store
 
-	Blobs *blob.Store
+	Blobs    *blob.Store
+	BlobsDir string
 }
 
 // testAPIKey is the default key newTestServer configures: production always
@@ -65,7 +66,7 @@ func newTestServer(t *testing.T, mutate func(*api.Deps)) (*httptest.Server, *tes
 	ts := httptest.NewServer(api.NewServer(d).Handler())
 	t.Cleanup(ts.Close)
 	ts.Client().Transport = &apiKeyTransport{key: d.Cfg.Server.APIKey, next: ts.Client().Transport}
-	return ts, &testStore{Store: s, Blobs: blobs}
+	return ts, &testStore{Store: s, Blobs: blobs, BlobsDir: blobsDir}
 }
 
 // apiKeyTransport injects key as X-Api-Key on any request that doesn't

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -2,6 +2,15 @@ package api
 
 import "go.kenn.io/docbank/internal/store"
 
+const (
+	// BlobHashHeader carries docbank's canonical lowercase SHA-256 identity.
+	BlobHashHeader = "X-Docbank-Blob-Hash"
+	// BlobSizeHeader carries the catalog's expected raw byte length. Content
+	// streams use it instead of Content-Length so HTTP/1.1 can carry a digest
+	// trailer computed while streaming without a second physical read.
+	BlobSizeHeader = "X-Docbank-Blob-Size"
+)
+
 // Node is the wire representation of a store.Node. Path is only populated on
 // single-node responses; list responses omit it.
 type Node struct {
@@ -9,6 +18,7 @@ type Node struct {
 	ParentID   *int64 `json:"parent_id,omitempty"`
 	Name       string `json:"name"`
 	Kind       string `json:"kind" enum:"dir,file"`
+	BlobHash   string `json:"blob_hash,omitempty" pattern:"^[0-9a-f]{64}$"`
 	Size       int64  `json:"size"`
 	MimeType   string `json:"mime_type,omitempty"`
 	Revision   int64  `json:"revision"`
@@ -16,6 +26,20 @@ type Node struct {
 	ModifiedAt string `json:"modified_at"`
 	TrashedAt  string `json:"trashed_at,omitempty"`
 	Path       string `json:"path,omitempty"` // set on single-node responses only
+}
+
+// ContentVerification binds a fresh physical read to the exact node revision
+// the caller inspected. BlobHash and Size are catalog identity; ComputedHash
+// and ComputedSize describe the bytes read through the mixed store.
+type ContentVerification struct {
+	NodeID       int64  `json:"node_id"`
+	Revision     int64  `json:"revision"`
+	BlobHash     string `json:"blob_hash" pattern:"^[0-9a-f]{64}$"`
+	Size         int64  `json:"size"`
+	ComputedHash string `json:"computed_hash,omitempty" pattern:"^[0-9a-f]{64}$"`
+	ComputedSize int64  `json:"computed_size"`
+	Verified     bool   `json:"verified"`
+	Problem      string `json:"problem,omitempty" enum:"missing,corrupt,unreadable"`
 }
 
 // SearchHit pairs a matched node with its display path.
@@ -129,7 +153,7 @@ type VerifyReport struct {
 func fromStoreNode(n store.Node) Node {
 	out := Node{
 		ID: n.ID, ParentID: n.ParentID, Name: n.Name, Kind: n.Kind,
-		Size: n.Size, MimeType: n.MimeType, Revision: n.Revision,
+		BlobHash: n.BlobHash, Size: n.Size, MimeType: n.MimeType, Revision: n.Revision,
 		CreatedAt: n.CreatedAt, ModifiedAt: n.ModifiedAt,
 	}
 	if n.TrashedAt != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,8 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,6 +24,27 @@ type Client struct {
 	base string
 	key  string
 	hc   *http.Client
+}
+
+// ContentStream exposes the catalog identity available before a download and
+// the RFC 9530 digest trailer available after Body reaches EOF. Callers prove
+// the transfer by comparing ContentDigest with the SHA-256 they compute while
+// reading; BlobHash is the vault's expected immutable identity.
+type ContentStream struct {
+	io.ReadCloser
+
+	BlobHash string
+	Size     int64
+	trailer  http.Header
+}
+
+// ContentDigest returns the digest of bytes actually streamed. HTTP trailers
+// are populated only after the response body has been read to EOF.
+func (s *ContentStream) ContentDigest() string {
+	if s == nil {
+		return ""
+	}
+	return s.trailer.Get("Content-Digest")
 }
 
 func New(baseURL, apiKey string) *Client {
@@ -136,7 +159,7 @@ func (c *Client) Children(ctx context.Context, id int64) ([]api.Node, error) {
 	}
 }
 
-func (c *Client) Content(ctx context.Context, id int64) (io.ReadCloser, error) {
+func (c *Client) Content(ctx context.Context, id int64) (*ContentStream, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/api/v1/nodes/%d/content", c.base, id), nil)
 	if err != nil {
@@ -153,7 +176,26 @@ func (c *Client) Content(ctx context.Context, id int64) (io.ReadCloser, error) {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, decodeError(resp)
 	}
-	return resp.Body, nil
+	size, err := strconv.ParseInt(resp.Header.Get(api.BlobSizeHeader), 10, 64)
+	if err != nil || size < 0 {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("content of node %d returned invalid %s %q",
+			id, api.BlobSizeHeader, resp.Header.Get(api.BlobSizeHeader))
+	}
+	hash := resp.Header.Get(api.BlobHashHeader)
+	decoded, decodeErr := hex.DecodeString(hash)
+	if decodeErr != nil || len(decoded) != sha256.Size || hex.EncodeToString(decoded) != hash {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("content of node %d returned invalid %s %q", id, api.BlobHashHeader, hash)
+	}
+	return &ContentStream{ReadCloser: resp.Body, BlobHash: hash, Size: size, trailer: resp.Trailer}, nil
+}
+
+func (c *Client) VerifyNodeContent(ctx context.Context, id, revision int64) (api.ContentVerification, error) {
+	var report api.ContentVerification
+	err := c.do(ctx, http.MethodPost, fmt.Sprintf("/api/v1/nodes/%d/verify", id),
+		ifMatch(revision), nil, &report)
+	return report, err
 }
 
 func (c *Client) Search(ctx context.Context, query string, limit int) (api.SearchReport, error) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,6 +1,10 @@
 package client_test
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"io"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -110,6 +114,45 @@ func TestStoragePackRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, report.BlobsPacked)
 	assert.True(t, report.BudgetExhausted)
+}
+
+func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {
+	c, _ := newClient(t, serverKey)
+	content := []byte("remote writer evidence")
+	src := filepath.Join(t.TempDir(), "evidence.txt")
+	require.NoError(t, os.WriteFile(src, content, 0o600))
+	report, err := c.Ingest(t.Context(), []string{src}, "/inbox")
+	require.NoError(t, err)
+	require.Equal(t, 1, report.Added)
+
+	node, err := c.Stat(t.Context(), "/inbox/evidence.txt")
+	require.NoError(t, err)
+	sum := sha256.Sum256(content)
+	wantHash := hex.EncodeToString(sum[:])
+	assert.Equal(t, wantHash, node.BlobHash)
+
+	stream, err := c.Content(t.Context(), node.ID)
+	require.NoError(t, err)
+	assert.Equal(t, wantHash, stream.BlobHash)
+	assert.Equal(t, int64(len(content)), stream.Size)
+	got, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.NoError(t, stream.Close())
+	assert.Equal(t, content, got)
+	assert.Equal(t, "sha-256=:"+base64.StdEncoding.EncodeToString(sum[:])+":", stream.ContentDigest())
+
+	verified, err := c.VerifyNodeContent(t.Context(), node.ID, node.Revision)
+	require.NoError(t, err)
+	assert.True(t, verified.Verified)
+	assert.Equal(t, wantHash, verified.ComputedHash)
+
+	packed, err := c.StoragePack(t.Context(), 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, packed.BlobsPacked)
+	verified, err = c.VerifyNodeContent(t.Context(), node.ID, node.Revision)
+	require.NoError(t, err)
+	assert.True(t, verified.Verified, "the same evidence contract reads packed authority")
+	assert.Equal(t, wantHash, verified.ComputedHash)
 }
 
 func TestStorageRepackRoundTrip(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "2"
+	daemonProtocolVersion = "3"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Remote writers need a stable way to prove that the bytes Docbank identifies, stores, and later serves are the bytes the writer intended. The existing API hid the file node’s content hash and offered only a vault-wide verifier, so a successful write or download could not produce bounded evidence tied to one inspected node state.

This PR separates three meanings that must not be conflated. File-node responses expose the catalog’s immutable SHA-256 identity. Content downloads advertise that expected identity before the body and emit an RFC 9530 digest computed from the bytes actually streamed afterward. A new single-node verification operation reopens content through the normal loose/packed store and returns recorded versus computed hashes and sizes, while If-Match plus a post-read revision check prevents a concurrent node change from making the receipt ambiguous.

The streamed digest is deliberately a trailer and the response uses an explicit Docbank size header instead of Content-Length. That preserves one-pass reads for large loose or packed blobs while ensuring the HTTP integrity field describes actual transmitted bytes rather than blindly repeating catalog metadata. Negative verification results are structured evidence—missing, corrupt, or unreadable—rather than transport failures.

This is the reusable integrity foundation for the next digest-checked remote-upload PR. It does not claim non-repudiation against a malicious server; signed attestations remain outside Docbank’s single-user trust model.