### PR TITLE
Accept digest-checked remote uploads

### DIFF
--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -209,10 +209,40 @@ Inspect `added`, `skipped`, and every member of `failed`. Repeating the same
 ingest after fixing a partial failure is safe; successful content converges to
 `skipped` rather than another copy.
 
-!!! info "Planned — remote upload"
-    Multipart upload is not implemented. A client on another machine cannot
-    send document bytes through the API yet; `POST /ingest` names paths local
-    to the daemon host.
+Remote writers use a file-granular multipart request. Compute the expected
+identity before sending bytes, and address the destination by stable directory
+ID:
+
+```bash
+FILE=receipt.pdf
+HASH=$(shasum -a 256 "$FILE" | awk '{print $1}')
+SIZE=$(wc -c < "$FILE" | tr -d ' ')
+
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H "X-Docbank-Blob-Hash: $HASH" \
+  -H "X-Docbank-Blob-Size: $SIZE" \
+  -F 'file=@receipt.pdf;filename=receipt.pdf;type=application/pdf' \
+  "$DOCBANK_URL/api/v1/uploads?parent_id=18&name=receipt.pdf"
+```
+
+Clients must percent-encode a nontrivial `name` query value. The request has
+exactly one part named `file`, and its multipart filename must equal `name`.
+The hash and size headers describe that file payload; top-level
+`Content-Digest` would instead describe the multipart envelope and is therefore
+not the write precondition.
+
+On `201`, require `status: "added"`; an idempotent retry returns `200` with
+`status: "skipped"` and the same stable node. In both cases compare
+`computed_hash` and `computed_size` with the locally calculated values, then
+retain `node.id`, `node.revision`, and `node.blob_hash`. A
+`digest_mismatch` or `size_mismatch` is a failed write with no new node/blob
+authority. Upload many files as independent requests so each result is
+unambiguous and independently retryable.
+
+The receipt proves receive-time agreement. Use the revision-bound single-node
+verification endpoint later when policy requires evidence about bytes currently
+stored in the vault.
 
 ## Treat destructive maintenance as a two-step decision
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -10,7 +10,7 @@ description: The agent-first HTTP API — filesystem-shaped endpoints, revision 
     today and back the CLI's data commands — the CLI is an HTTP client
     of exactly this surface, with no other path into the vault. Rows
     under the "Planned" admonitions further down (versioned editing,
-    tags, batch move, multipart upload) are designed but not built; see
+    tags, batch move) are designed but not built; see
     [Roadmap](../roadmap.md).
 
 **Design test: an agent must be able to do everything the CLI can,
@@ -38,6 +38,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
 | `POST /ingest` | import server-side paths — see [addendum](#addendum-post-ingest) | Implemented |
+| `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |
 | `PATCH /nodes/{id}` | move and/or rename | Implemented |
 | `POST /path/move` · `POST /path/trash` | move / trash by virtual path, resolved and mutated in one store transaction | Implemented |
 | `POST /nodes/{id}/trash` · `POST /nodes/{id}/restore` | soft delete / recover | Implemented |
@@ -55,10 +56,8 @@ its own shutdown token.
 !!! info "Planned"
     Not yet implemented: `PUT /nodes/{id}/content` (versioned edit) and
     `GET /nodes/{id}/versions` ([Editing & Versions](editing-and-versions.md));
-    tags (`GET /tags` + CRUD, tag filters on search); `POST /batch/move`
-    bulk reorganization with `dry_run`; multipart file upload (`POST
-    /nodes` with `kind: "file"`) as the remote counterpart to `POST
-    /ingest`.
+    tags (`GET /tags` + CRUD, tag filters on search); and
+    `POST /batch/move` bulk reorganization with `dry_run`.
 
 IDs are canonical everywhere: every response carries them, and mutating
 endpoints address nodes by ID so a rename can't strand a concurrent
@@ -97,6 +96,7 @@ and maintenance are explicit exceptions:
 | `POST /path/move`, `POST /path/trash` | none — the path is resolved and mutated inside one store transaction, so there is no separate read for a revision to guard |
 | `POST /nodes` (create dir) | none — creation has no prior revision; a name collision is `409` |
 | `POST /ingest` | none — long-running bulk operation with per-path partial success; the destination directory may legitimately change while it runs |
+| `POST /uploads` | none — creates or idempotently resolves one file under the stable `parent_id`; name/content collision policy is transactional |
 | `POST /trash/empty`, `POST /gc`, `POST /verify` | none — vault-wide maintenance, serialized by the maintenance gate |
 
 A stale revision gets `412 Precondition Failed`, telling the caller to
@@ -154,7 +154,47 @@ Because it grants "read any daemon-readable local path," `POST /ingest`
 is checked per-request against `RemoteAddr` and **restricted to
 loopback callers** regardless of bind address or API key — a
 non-loopback client gets `403` (`loopback_only`). There is no remote file-upload
-endpoint in the current API.
+capability on this route: remote bytes use `POST /uploads`, while remote access
+to the loopback-bound daemon still terminates through the configured SSH/VPN
+tunnel.
+
+## Addendum: `POST /uploads`
+
+`POST /uploads?parent_id=<id>&name=<filename>` accepts exactly one
+`multipart/form-data` file field named `file`. The query uses a stable
+destination directory ID rather than a mutable path. The multipart filename
+must equal the normalized `name` query value, preventing the envelope and
+requested tree entry from describing different files.
+
+Two request headers declare the expected identity of the **file part**, not the
+multipart envelope:
+
+- `X-Docbank-Blob-Hash`: canonical lowercase hexadecimal SHA-256;
+- `X-Docbank-Blob-Size`: raw byte length, bounded by Kit's blob limit.
+
+The server streams the file once through Kit's durable writer and independently
+computes both values. Only after they match, the closing multipart boundary has
+been validated, and no extra parts remain does one metadata transaction grant
+blob authority and create the node. `201` with `status: "added"` identifies a
+new node. Repeating the same name, hash, and parent converges to that stable node
+with `200` and `status: "skipped"`. The receipt always includes the server's
+`computed_hash`, `computed_size`, and the node's ID and revision; clients compare
+the values themselves.
+
+Uploads are intentionally file-granular. A caller sending many files issues
+independent requests (concurrently when useful), so one failure never makes the
+success of another file ambiguous and each item can be retried on its own.
+Different content under the same requested name follows normal ingest suffixing
+rather than overwriting an existing document.
+
+Digest or size disagreement returns `422 digest_mismatch` or
+`422 size_mismatch` and grants no new `blobs` row or node authority. Because
+physical bytes are published before metadata by design, a rejected stream may
+leave an authority-free loose object; the normal GC untracked-file scan removes
+it. Malformed envelopes and extra parts are also rejected before authority.
+Request bodies are capped at the declared size plus bounded multipart overhead,
+and the route is exempt from the ordinary timeout so a legitimate large upload
+is governed by client cancellation rather than a one-minute deadline.
 
 !!! info "Planned"
     Ingest provenance today is filesystem-shaped: each import records
@@ -216,9 +256,11 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `cycle` | 409 | `store.ErrCycle` (move under own descendant) |
 | `stale_revision` | 412 | `store.ErrStaleRevision` — `If-Match` didn't match the current revision |
 | `not_dir` / `not_file` / `invalid_name` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrNotTrashed` / `ErrIsRoot` |
-| `validation` | 400 or 422 | malformed request (bad `If-Match`, non-absolute `?path=` or ingest path, huma request validation) |
+| `validation` | 400, 415, or 422 | malformed request (bad `If-Match`, paths, media type, multipart envelope, or generated validation) |
 | `precondition_required` | 428 | required `If-Match` header missing |
 | `loopback_only` | 403 | `POST /ingest` called by a non-loopback peer |
+| `digest_mismatch` / `size_mismatch` | 422 | uploaded file bytes disagree with the required declaration; no node/blob authority committed |
+| `too_large` | 413 | upload exceeded its declared size plus bounded multipart overhead |
 | `unauthorized` | 401 | missing or invalid API key; bad shutdown token |
 | `internal` | 500 | unmapped error (still surfaced with a message — this is a single-user local daemon, not a hardened multi-tenant service) |
 

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -41,6 +41,7 @@ user's privileges. Consequently:
 | Content matches its hash *byte-for-byte* | `docbank verify`; `POST /nodes/{id}/verify` | full-vault re-hash on demand, or a revision-bound fresh read of one file through the mixed store |
 | No orphan blob file survives | `docbank gc` | reachability query for rows **plus** a directory scan for files that never gained (or lost) their row |
 | Imports read the file they classified | ingest | `O_NOFOLLOW` + fstat at open, not the earlier `Lstat`/`WalkDir` classification |
+| Remote writes match the writer's bytes | `POST /uploads` | required SHA-256/size declarations are compared with Kit's streamed result before any blob row or node authority commits |
 | Mutations act on the node the caller named | store | id-addressed mutations (`Move`, `Trash`, `Restore`) require an `If-Match` revision precondition; path-addressed mutations (`MovePath`, `TrashPath`, backing `POST /path/move` and `/path/trash`) resolve and mutate inside one store transaction — either way, no path-race window between resolving a name and acting on it |
 | Node identity is permanent | schema | `AUTOINCREMENT` ids plus `trash_parent ... ON DELETE SET NULL` — a dangling origin becomes NULL, never a reused id |
 | Vault contents are private to the user | `home.Ensure` | the 0700 boundary is enforced on every open, not assumed: layout directories are tightened to 0700, the database file to 0600 (WAL/SHM inherit its mode), and blob files are written 0600 |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -97,7 +97,8 @@ metadata, durability rules, and physical storage primitives from
   discipline; knows nothing about the tree.
 - **`internal/ingest`** — the single import pipeline all entry points
   share: hash → durable blob → one metadata transaction per file. The
-  daemon is its caller (`POST /ingest`, backing `docbank add`).
+  daemon is its caller (`POST /ingest`, backing `docbank add`, and
+  digest-checked `POST /uploads` for remote writers).
 - **`internal/home`** — vault directory layout and the vault lock the
   daemon holds exclusively ([Concurrency & Locking](locking.md)).
 - **`internal/config`** — optional `config.toml` loading and the

--- a/docs/internal/daemon-api-design.md
+++ b/docs/internal/daemon-api-design.md
@@ -137,6 +137,27 @@ The CLI resolves user arguments to absolute paths before sending the request,
 preserving shell-relative ergonomics. Partial source failures are returned in
 the report while other sources continue.
 
+`POST /uploads` is the remote counterpart, but it is deliberately one file per
+request. `parent_id` and normalized `name` identify the destination; required
+hash/size headers describe the sole multipart `file` part. File granularity
+makes success, failure, and retry atomic rather than embedding partially
+successful application work inside one transport result.
+
+The raw handler streams directly from `multipart.Reader` instead of using
+Huma's decoded multipart input, which pre-parses the complete request into
+memory or temporary files before invoking application code. Its OpenAPI
+operation is registered manually against the same Huma document. Keep the raw
+handler and schema synchronized in one registration function.
+
+The operation holds the application mutation gate before Kit's mutation lease.
+Kit durably publishes and hashes bytes first. A prepared upload exposes no
+application authority, allowing the handler to validate the closing boundary
+and absence of extra parts before its metadata transaction inserts the blob and
+node. Digest/size mismatch or malformed trailing multipart data can leave an
+untracked physical object, never a readable blob row; GC owns that ordinary
+crash/rejection residue. Successful retries return the existing node, so the
+receipt always carries stable identity.
+
 ## Change constraints
 
 - New data commands must be HTTP clients, never direct store callers.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,12 +78,14 @@ to publish loose blobs; startup never performs an implicit migration.
 Implemented foundation: file-node API responses expose immutable SHA-256
 identity, content streams carry catalog identity plus a freshly computed digest
 trailer, and a revision-bound single-node endpoint verifies stored bytes. This
-is the evidence contract future remote writers build on.
+evidence contract now backs file-granular multipart upload: remote writers must
+declare SHA-256 and size, and receive the stable node plus server-computed
+identity only after both match.
 
 - Editing surfaces: `PUT` content, `docbank edit`/`put`/`revert`, and
   `versions` listing ([design](architecture/editing-and-versions.md))
 - Tags surfaced in CLI, search filters, and the API; `POST /batch/move`
-  bulk reorganization; multipart file upload
+  bulk reorganization
 - Watched inbox directories with a stability window, landing imports
   under `/inbox/<date>/`
 - Text extraction workers (PDF text layer, plain text/markdown, office

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -80,10 +80,16 @@ Import never deletes or modifies source files. Delete originals yourself
 once `docbank verify` and your own spot-checks satisfy you — the same
 archive-first, delete-later posture msgvault takes with mailboxes.
 
-!!! info "Planned — Phase 2b"
-    **Watched inboxes**: the daemon will watch configured directories
-    (scanner output, a "To File" folder) and import files automatically
-    once they've been stable for a settle period, landing under
-    `/inbox/<date>/` for later filing. **Multipart upload** joins the
-    [HTTP API](../architecture/http-api.md) as the remote counterpart
-    to today's loopback-only, server-side-path `POST /ingest`.
+## Remote API imports
+
+Authenticated integrations can send one digest-checked file at a time through
+`POST /api/v1/uploads`. The server requires the writer's SHA-256 and byte length,
+computes both independently while streaming, and creates no node or blob
+authority when either differs. See the [HTTP API](../architecture/http-api.md#addendum-post-uploads)
+and [Agent Integration Guide](../agents/integration.md#create-and-ingest-safely)
+for the exact contract.
+
+!!! info "Planned — watched inboxes"
+    The daemon will watch configured directories (scanner output, a "To File"
+    folder) and import files automatically once they've been stable for a
+    settle period, landing under `/inbox/<date>/` for later filing.

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -73,7 +73,7 @@ func loopbackMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/ingest" && !isLoopbackRemote(r.RemoteAddr) {
 			writeError(w, NewError(http.StatusForbidden, "loopback_only",
-				"ingest by server-side path is loopback-only; remote clients need multipart upload (planned)"))
+				"ingest by server-side path is loopback-only; remote clients use POST /api/v1/uploads"))
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -17,7 +17,7 @@ const requestTimeout = 60 * time.Second
 func timeoutExempt(path string) bool {
 	switch path {
 	case "/api/v1/ingest", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
-		"/api/v1/storage/pack", "/api/v1/storage/repack":
+		"/api/v1/storage/pack", "/api/v1/storage/repack", "/api/v1/uploads":
 		return true
 	}
 	return strings.HasPrefix(path, "/api/v1/nodes/") && strings.HasSuffix(path, "/verify")

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -16,7 +16,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	doc := string(out)
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent", "verifyNodeContent",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
-		"storageStatus", "storagePack", "storageRepack", "ingest", "listTrash", "emptyTrash", "gc", "verify"} {
+		"storageStatus", "storagePack", "storageRepack", "ingest", "uploadFile", "listTrash", "emptyTrash", "gc", "verify"} {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
 	assert.NotContains(t, doc, "/api/daemon/shutdown", "lifecycle plumbing must stay hidden")
@@ -35,4 +35,25 @@ func TestOpenAPIDeclaresSecurity(t *testing.T) {
 	assert.Contains(t, doc, "X-Api-Key")
 	assert.Contains(t, doc, "scheme: bearer")
 	assert.Contains(t, doc, "security:", "document-level security requirement missing")
+}
+
+func TestOpenAPIDeclaresDigestCheckedUpload(t *testing.T) {
+	doc := api.NewOfflineServer().API().OpenAPI()
+	op := doc.Paths["/api/v1/uploads"].Post
+	require.NotNil(t, op)
+	assert.Equal(t, "uploadFile", op.OperationID)
+	form := op.RequestBody.Content["multipart/form-data"]
+	require.NotNil(t, form)
+	assert.Equal(t, "binary", form.Schema.Properties["file"].Format)
+	assert.Contains(t, form.Schema.Required, "file")
+
+	required := map[string]bool{}
+	for _, param := range op.Parameters {
+		required[param.Name] = param.Required
+	}
+	for _, name := range []string{"parent_id", "name", api.BlobHashHeader, api.BlobSizeHeader} {
+		assert.True(t, required[name], "%s must be required", name)
+	}
+	assert.NotNil(t, op.Responses["200"])
+	assert.NotNil(t, op.Responses["201"])
 }

--- a/internal/api/routes_mutate.go
+++ b/internal/api/routes_mutate.go
@@ -40,7 +40,7 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 		OperationID: "createNode", Method: http.MethodPost, Path: "/api/v1/nodes",
 		Summary: "Create a directory", DefaultStatus: http.StatusCreated,
 		Description: "kind must be \"dir\"; file creation is POST /api/v1/ingest " +
-			"(server-side paths) today, multipart upload later.",
+			"for server-side paths or digest-checked POST /api/v1/uploads for remote bytes.",
 	}, func(ctx context.Context, in *struct {
 		Body struct {
 			ParentID int64  `json:"parent_id"`
@@ -50,7 +50,7 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 	}) (*nodeOutput, error) {
 		if in.Body.Kind != "dir" {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation",
-				"kind \"file\" is not supported here: use POST /api/v1/ingest (multipart upload is planned)")
+				"kind \"file\" is not supported here: use POST /api/v1/ingest or POST /api/v1/uploads")
 		}
 		var out *nodeOutput
 		err := g.mutate(func() error {

--- a/internal/api/routes_mutate_test.go
+++ b/internal/api/routes_mutate_test.go
@@ -22,7 +22,7 @@ func TestCreateDirectory(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(body), &n))
 	assert.Equal(t, "/taxes", n.Path)
 
-	// Name collision → 409 exists; kind=file → 422 (multipart is planned).
+	// Name collision → 409 exists; kind=file uses the dedicated upload route.
 	resp, body = do(t, ts, http.MethodPost, "/api/v1/nodes", nil,
 		map[string]any{"parent_id": s.RootID(), "name": "taxes", "kind": "dir"})
 	assert.Equal(t, http.StatusConflict, resp.StatusCode)

--- a/internal/api/routes_upload.go
+++ b/internal/api/routes_upload.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"reflect"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/ingest"
+	"go.kenn.io/docbank/internal/store"
+)
+
+const uploadMultipartOverhead = int64(1 << 20)
+
+var errInvalidUploadEnvelope = errors.New("invalid upload multipart envelope")
+
+func registerUploadRoute(mux *http.ServeMux, api huma.API, d Deps, g *gate) {
+	registerUploadOpenAPI(api)
+	mux.HandleFunc("POST /api/v1/uploads", func(w http.ResponseWriter, r *http.Request) {
+		handleUpload(w, r, d, g)
+	})
+}
+
+func registerUploadOpenAPI(api huma.API) {
+	registry := api.OpenAPI().Components.Schemas
+	receiptSchema := huma.SchemaFromType(registry, reflect.TypeFor[UploadReceipt]())
+	errorSchema := huma.SchemaFromType(registry, reflect.TypeFor[Error]())
+	response := func(description string) *huma.Response {
+		return &huma.Response{Description: description, Content: map[string]*huma.MediaType{
+			"application/json": {Schema: receiptSchema},
+		}}
+	}
+	api.OpenAPI().AddOperation(&huma.Operation{
+		OperationID: "uploadFile", Method: http.MethodPost, Path: "/api/v1/uploads",
+		Summary: "Upload one digest-checked file",
+		Description: "Streams exactly one multipart field named `file`. " +
+			"X-Docbank-Blob-Hash and X-Docbank-Blob-Size are required declarations for the file payload, " +
+			"not the multipart envelope. Success grants node/blob authority only after both match.",
+		Parameters: []*huma.Param{
+			{Name: "parent_id", In: "query", Required: true,
+				Description: "Stable destination directory node ID", Schema: &huma.Schema{Type: "integer", Format: "int64"}},
+			{Name: "name", In: "query", Required: true,
+				Description: "Virtual filename; must equal the multipart filename", Schema: &huma.Schema{Type: "string", MinLength: new(1)}},
+			{Name: BlobHashHeader, In: "header", Required: true,
+				Description: "Expected lowercase hexadecimal SHA-256 of the file payload",
+				Schema:      &huma.Schema{Type: "string", Pattern: "^[0-9a-f]{64}$"}},
+			{Name: BlobSizeHeader, In: "header", Required: true,
+				Description: "Expected raw file byte length",
+				Schema:      &huma.Schema{Type: "integer", Format: "int64", Minimum: new(float64(0))}},
+		},
+		RequestBody: &huma.RequestBody{Required: true, Content: map[string]*huma.MediaType{
+			"multipart/form-data": {
+				Schema: &huma.Schema{Type: "object", Properties: map[string]*huma.Schema{
+					"file": {Type: "string", Format: "binary"},
+				}, Required: []string{"file"}},
+				Encoding: map[string]*huma.Encoding{"file": {ContentType: "*/*"}},
+			},
+		}},
+		Responses: map[string]*huma.Response{
+			"200": response("Idempotent retry converged on the existing node"),
+			"201": response("New file node created"),
+			"default": {Description: "Error", Content: map[string]*huma.MediaType{
+				"application/problem+json": {Schema: errorSchema},
+			}},
+		},
+	})
+}
+
+func handleUpload(w http.ResponseWriter, r *http.Request, d Deps, g *gate) {
+	parentID, name, expectedHash, expectedSize, identityErr := parseUploadIdentity(r)
+	if identityErr != nil {
+		writeError(w, identityErr)
+		return
+	}
+	maxBody := expectedSize + uploadMultipartOverhead
+	r.Body = http.MaxBytesReader(w, r.Body, maxBody)
+	multipartReader, readErr := r.MultipartReader()
+	if readErr != nil {
+		writeError(w, NewError(http.StatusUnsupportedMediaType, "validation",
+			"upload requires multipart/form-data: "+readErr.Error()))
+		return
+	}
+	part, readErr := multipartReader.NextPart()
+	if readErr != nil {
+		writeError(w, uploadMultipartReadError(readErr, "upload requires exactly one file part"))
+		return
+	}
+	defer func() { _ = part.Close() }()
+	if part.FormName() != "file" || part.FileName() == "" {
+		writeError(w, NewError(http.StatusUnprocessableEntity, "validation",
+			"first multipart part must be a file field named \"file\""))
+		return
+	}
+	partName, normalizeErr := store.NormalizeName(part.FileName())
+	if normalizeErr != nil || partName != name {
+		writeError(w, NewError(http.StatusUnprocessableEntity, "validation",
+			fmt.Sprintf("multipart filename %q must equal requested name %q", part.FileName(), name)))
+		return
+	}
+	mimeType, mimeErr := uploadMediaType(part.Header.Get("Content-Type"))
+	if mimeErr != nil {
+		writeError(w, NewError(http.StatusUnprocessableEntity, "validation", mimeErr.Error()))
+		return
+	}
+
+	var result ingest.UploadResult
+	opErr := g.mutate(func() error {
+		return d.Blobs.WithMutation(r.Context(), func() error {
+			limited := &io.LimitedReader{R: part, N: expectedSize + 1}
+			ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
+			prepared, prepareErr := ing.PrepareUpload(r.Context(), parentID, name, mimeType,
+				limited, expectedHash, expectedSize)
+			if prepareErr != nil {
+				return prepareErr
+			}
+			next, nextErr := multipartReader.NextPart()
+			if next != nil {
+				_ = next.Close()
+			}
+			if !errors.Is(nextErr, io.EOF) {
+				if nextErr == nil {
+					return fmt.Errorf("%w: upload contains more than one multipart part",
+						errInvalidUploadEnvelope)
+				}
+				var maxBytesErr *http.MaxBytesError
+				if errors.As(nextErr, &maxBytesErr) {
+					return fmt.Errorf("upload multipart body exceeded limit: %w", nextErr)
+				}
+				return fmt.Errorf("%w: reading end of multipart body: %w",
+					errInvalidUploadEnvelope, nextErr)
+			}
+			result, prepareErr = prepared.Commit(r.Context())
+			return prepareErr
+		})
+	})
+	if opErr != nil {
+		writeError(w, uploadError(opErr))
+		return
+	}
+	status := "skipped"
+	httpStatus := http.StatusOK
+	if result.Added {
+		status = "added"
+		httpStatus = http.StatusCreated
+	}
+	writeJSON(w, httpStatus, UploadReceipt{
+		Status: status, Node: fromStoreNode(result.Node),
+		ComputedHash: result.ComputedHash, ComputedSize: result.ComputedSize,
+	})
+}
+
+func uploadMultipartReadError(err error, detail string) *Error {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		return NewError(http.StatusRequestEntityTooLarge, "too_large", detail+": "+err.Error())
+	}
+	return NewError(http.StatusUnprocessableEntity, "validation", detail+": "+err.Error())
+}
+
+func parseUploadIdentity(r *http.Request) (int64, string, string, int64, *Error) {
+	parentID, err := strconv.ParseInt(r.URL.Query().Get("parent_id"), 10, 64)
+	if err != nil || parentID <= 0 {
+		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "validation",
+			"parent_id must be a positive node ID")
+	}
+	name, err := store.NormalizeName(r.URL.Query().Get("name"))
+	if err != nil {
+		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "invalid_name", err.Error())
+	}
+	expectedHash := r.Header.Get(BlobHashHeader)
+	parsed, err := packstore.ParseHash(expectedHash)
+	if err != nil || parsed.String() != expectedHash {
+		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "validation",
+			BlobHashHeader+" must be canonical lowercase SHA-256")
+	}
+	expectedSize, err := strconv.ParseInt(r.Header.Get(BlobSizeHeader), 10, 64)
+	limits := packstore.DefaultLimits()
+	if err != nil || expectedSize < 0 || expectedSize > limits.BlobBytes {
+		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "validation",
+			fmt.Sprintf("%s must be between 0 and %d", BlobSizeHeader, limits.BlobBytes))
+	}
+	return parentID, name, expectedHash, expectedSize, nil
+}
+
+func uploadMediaType(value string) (string, error) {
+	if value == "" {
+		return "application/octet-stream", nil
+	}
+	mediaType, params, err := mime.ParseMediaType(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid file Content-Type %q: %w", value, err)
+	}
+	return mime.FormatMediaType(mediaType, params), nil
+}
+
+func uploadError(err error) *Error {
+	var maxBytesErr *http.MaxBytesError
+	switch {
+	case errors.Is(err, ingest.ErrUploadDigestMismatch):
+		return NewError(http.StatusUnprocessableEntity, "digest_mismatch", err.Error())
+	case errors.Is(err, ingest.ErrUploadSizeMismatch):
+		return NewError(http.StatusUnprocessableEntity, "size_mismatch", err.Error())
+	case errors.As(err, &maxBytesErr):
+		return NewError(http.StatusRequestEntityTooLarge, "too_large", err.Error())
+	case errors.Is(err, errInvalidUploadEnvelope):
+		return NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+	default:
+		mapped := &Error{}
+		if errors.As(FromStoreError(err), &mapped) {
+			return mapped
+		}
+		return NewError(http.StatusInternalServerError, "internal", err.Error())
+	}
+}

--- a/internal/api/routes_upload.go
+++ b/internal/api/routes_upload.go
@@ -208,6 +208,9 @@ func uploadError(err error) *Error {
 		return NewError(http.StatusUnprocessableEntity, "size_mismatch", err.Error())
 	case errors.As(err, &maxBytesErr):
 		return NewError(http.StatusRequestEntityTooLarge, "too_large", err.Error())
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return NewError(http.StatusUnprocessableEntity, "validation",
+			"invalid upload multipart envelope: "+err.Error())
 	case errors.Is(err, errInvalidUploadEnvelope):
 		return NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 	default:

--- a/internal/api/routes_upload_test.go
+++ b/internal/api/routes_upload_test.go
@@ -171,3 +171,30 @@ func TestUploadRejectsNonDirectoryBeforeReadingContent(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
 	assert.Contains(t, body, `"code":"not_dir"`)
 }
+
+func TestUploadRejectsTruncatedMultipartAsValidation(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	content := "truncated"
+	boundary := "missing-closing-boundary"
+	body := fmt.Sprintf("--%s\r\nContent-Disposition: form-data; name=\"file\"; filename=\"bad.txt\"\r\n"+
+		"Content-Type: text/plain\r\n\r\n%s", boundary, content)
+	query := url.Values{"parent_id": {strconv.FormatInt(s.RootID(), 10)}, "name": {"bad.txt"}}
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/uploads?"+query.Encode(), bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.Header.Set(api.BlobHashHeader, uploadIdentity([]byte(content)))
+	req.Header.Set(api.BlobSizeHeader, strconv.Itoa(len(content)))
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	var response bytes.Buffer
+	_, err = response.ReadFrom(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, response.String())
+	assert.Contains(t, response.String(), `"code":"validation"`)
+	_, err = s.NodeByPath(t.Context(), "/bad.txt")
+	require.ErrorIs(t, err, store.ErrNotFound)
+	blobs, err := s.AllBlobs(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, blobs)
+}

--- a/internal/api/routes_upload_test.go
+++ b/internal/api/routes_upload_test.go
@@ -1,0 +1,173 @@
+package api_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/store"
+)
+
+type uploadRequest struct {
+	name         string
+	filename     string
+	content      []byte
+	expectedHash string
+	expectedSize int64
+	extraPart    bool
+}
+
+func sendUpload(
+	t *testing.T, tsURL string, client *http.Client, parentID int64, in uploadRequest,
+) (*http.Response, string) {
+	t.Helper()
+	if in.filename == "" {
+		in.filename = in.name
+	}
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", multipart.FileContentDisposition("file", in.filename))
+	header.Set("Content-Type", "text/plain; charset=utf-8")
+	part, err := writer.CreatePart(header)
+	require.NoError(t, err)
+	_, err = part.Write(in.content)
+	require.NoError(t, err)
+	if in.extraPart {
+		require.NoError(t, writer.WriteField("extra", "not allowed"))
+	}
+	require.NoError(t, writer.Close())
+
+	query := url.Values{"parent_id": {strconv.FormatInt(parentID, 10)}, "name": {in.name}}
+	req, err := http.NewRequest(http.MethodPost, tsURL+"/api/v1/uploads?"+query.Encode(), &body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set(api.BlobHashHeader, in.expectedHash)
+	req.Header.Set(api.BlobSizeHeader, strconv.FormatInt(in.expectedSize, 10))
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	var response bytes.Buffer
+	_, err = response.ReadFrom(resp.Body)
+	require.NoError(t, err)
+	return resp, response.String()
+}
+
+func uploadIdentity(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestUploadCreatesReceiptAndIdempotentRetry(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	content := []byte("remote upload")
+	in := uploadRequest{
+		name: "report.txt", content: content,
+		expectedHash: uploadIdentity(content), expectedSize: int64(len(content)),
+	}
+
+	resp, body := sendUpload(t, ts.URL, ts.Client(), s.RootID(), in)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	var added api.UploadReceipt
+	require.NoError(t, json.Unmarshal([]byte(body), &added))
+	assert.Equal(t, "added", added.Status)
+	assert.Equal(t, in.expectedHash, added.ComputedHash)
+	assert.Equal(t, in.expectedSize, added.ComputedSize)
+	assert.Equal(t, in.expectedHash, added.Node.BlobHash)
+	assert.Equal(t, "text/plain; charset=utf-8", added.Node.MimeType)
+
+	stored, err := s.NodeByPath(t.Context(), "/report.txt")
+	require.NoError(t, err)
+	assert.Equal(t, added.Node.ID, stored.ID)
+
+	resp, body = sendUpload(t, ts.URL, ts.Client(), s.RootID(), in)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var skipped api.UploadReceipt
+	require.NoError(t, json.Unmarshal([]byte(body), &skipped))
+	assert.Equal(t, "skipped", skipped.Status)
+	assert.Equal(t, added.Node.ID, skipped.Node.ID)
+	assert.Equal(t, added.Node.Revision, skipped.Node.Revision)
+
+	changed := []byte("changed content")
+	in.content = changed
+	in.expectedHash = uploadIdentity(changed)
+	in.expectedSize = int64(len(changed))
+	resp, body = sendUpload(t, ts.URL, ts.Client(), s.RootID(), in)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	var suffixed api.UploadReceipt
+	require.NoError(t, json.Unmarshal([]byte(body), &suffixed))
+	assert.Equal(t, "report (2).txt", suffixed.Node.Name)
+}
+
+func TestUploadAcceptsEmptyFile(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	content := []byte{}
+	in := uploadRequest{name: "empty.txt", content: content,
+		expectedHash: uploadIdentity(content), expectedSize: 0}
+	resp, body := sendUpload(t, ts.URL, ts.Client(), s.RootID(), in)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	var receipt api.UploadReceipt
+	require.NoError(t, json.Unmarshal([]byte(body), &receipt))
+	assert.Zero(t, receipt.ComputedSize)
+	assert.Equal(t, in.expectedHash, receipt.ComputedHash)
+}
+
+func TestUploadRejectsMismatchedEvidenceWithoutAuthority(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*uploadRequest)
+		wantCode   string
+		wantStatus int
+	}{
+		{name: "digest", mutate: func(in *uploadRequest) { in.expectedHash = uploadIdentity([]byte("other")) },
+			wantCode: "digest_mismatch", wantStatus: http.StatusUnprocessableEntity},
+		{name: "short size", mutate: func(in *uploadRequest) { in.expectedSize-- },
+			wantCode: "size_mismatch", wantStatus: http.StatusUnprocessableEntity},
+		{name: "long size", mutate: func(in *uploadRequest) { in.expectedSize++ },
+			wantCode: "size_mismatch", wantStatus: http.StatusUnprocessableEntity},
+		{name: "extra part", mutate: func(in *uploadRequest) { in.extraPart = true },
+			wantCode: "validation", wantStatus: http.StatusUnprocessableEntity},
+		{name: "different filename", mutate: func(in *uploadRequest) { in.filename = "other.txt" },
+			wantCode: "validation", wantStatus: http.StatusUnprocessableEntity},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, s := newTestServer(t, nil)
+			content := []byte("remote upload")
+			in := uploadRequest{name: "rejected.txt", content: content,
+				expectedHash: uploadIdentity(content), expectedSize: int64(len(content))}
+			tt.mutate(&in)
+			resp, body := sendUpload(t, ts.URL, ts.Client(), s.RootID(), in)
+			assert.Equal(t, tt.wantStatus, resp.StatusCode, body)
+			assert.Contains(t, body, fmt.Sprintf(`"code":%q`, tt.wantCode))
+			_, err := s.NodeByPath(t.Context(), "/rejected.txt")
+			require.ErrorIs(t, err, store.ErrNotFound)
+			blobs, err := s.AllBlobs(t.Context())
+			require.NoError(t, err)
+			assert.Empty(t, blobs, "failed upload must grant no blob authority")
+		})
+	}
+}
+
+func TestUploadRejectsNonDirectoryBeforeReadingContent(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	parent := createFileWithContent(t, ts, s, "/not-a-dir", "existing")
+	content := []byte("remote upload")
+	in := uploadRequest{name: "child.txt", content: content,
+		expectedHash: uploadIdentity(content), expectedSize: int64(len(content))}
+	resp, body := sendUpload(t, ts.URL, ts.Client(), parent.ID, in)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"not_dir"`)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -79,6 +79,7 @@ func NewServer(d Deps) *Server {
 	registerReadRoutes(humaAPI, d)      // Task 5 (stat-by-id lands in this task)
 	registerMutateRoutes(humaAPI, d, g) // Task 6
 	registerOpsRoutes(humaAPI, d, g)    // Task 7
+	registerUploadRoute(mux, humaAPI, d, g)
 	s.registerHealth(mux)
 	mux.Handle("GET "+kitPingPath, kitdaemon.NewPingHandler(kitdaemon.PingHandlerOptions{
 		Service: "docbank", Version: version.Version, PID: os.Getpid(),

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -42,6 +42,16 @@ type ContentVerification struct {
 	Problem      string `json:"problem,omitempty" enum:"missing,corrupt,unreadable"`
 }
 
+// UploadReceipt proves which bytes the daemon computed and which stable node
+// now names them. Status is "added" for a new node and "skipped" for an
+// idempotent retry that converged on an existing node.
+type UploadReceipt struct {
+	Status       string `json:"status" enum:"added,skipped"`
+	Node         Node   `json:"node"`
+	ComputedHash string `json:"computed_hash" pattern:"^[0-9a-f]{64}$"`
+	ComputedSize int64  `json:"computed_size"`
+}
+
 // SearchHit pairs a matched node with its display path.
 type SearchHit struct {
 	Node Node   `json:"node"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,9 +9,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strconv"
 	"time"
@@ -183,12 +187,16 @@ func (c *Client) Content(ctx context.Context, id int64) (*ContentStream, error) 
 			id, api.BlobSizeHeader, resp.Header.Get(api.BlobSizeHeader))
 	}
 	hash := resp.Header.Get(api.BlobHashHeader)
-	decoded, decodeErr := hex.DecodeString(hash)
-	if decodeErr != nil || len(decoded) != sha256.Size || hex.EncodeToString(decoded) != hash {
+	if !validSHA256Hex(hash) {
 		_ = resp.Body.Close()
 		return nil, fmt.Errorf("content of node %d returned invalid %s %q", id, api.BlobHashHeader, hash)
 	}
 	return &ContentStream{ReadCloser: resp.Body, BlobHash: hash, Size: size, trailer: resp.Trailer}, nil
+}
+
+func validSHA256Hex(hash string) bool {
+	decoded, err := hex.DecodeString(hash)
+	return err == nil && len(decoded) == sha256.Size && hex.EncodeToString(decoded) == hash
 }
 
 func (c *Client) VerifyNodeContent(ctx context.Context, id, revision int64) (api.ContentVerification, error) {
@@ -217,6 +225,96 @@ func (c *Client) Ingest(ctx context.Context, paths []string, dest string) (api.I
 	err := c.do(ctx, http.MethodPost, "/api/v1/ingest", nil,
 		map[string]any{"paths": paths, "dest": dest}, &rep)
 	return rep, err
+}
+
+// Upload streams one remote file as a digest-checked multipart request. The
+// reader is consumed once; callers retain responsibility for closing it when
+// it also implements io.Closer.
+func (c *Client) Upload(
+	ctx context.Context, parentID int64, name, mimeType, expectedHash string,
+	expectedSize int64, content io.Reader,
+) (api.UploadReceipt, error) {
+	var receipt api.UploadReceipt
+	if parentID <= 0 {
+		return receipt, errors.New("upload parent ID must be positive")
+	}
+	if _, err := store.NormalizeName(name); err != nil {
+		return receipt, fmt.Errorf("upload name: %w", err)
+	}
+	if !validSHA256Hex(expectedHash) {
+		return receipt, errors.New("upload hash must be canonical lowercase SHA-256")
+	}
+	if expectedSize < 0 {
+		return receipt, errors.New("upload size must not be negative")
+	}
+	if content == nil {
+		return receipt, errors.New("upload content reader is nil")
+	}
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	} else {
+		mediaType, params, err := mime.ParseMediaType(mimeType)
+		if err != nil {
+			return receipt, fmt.Errorf("upload media type %q: %w", mimeType, err)
+		}
+		mimeType = mime.FormatMediaType(mediaType, params)
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	multipartWriter := multipart.NewWriter(pipeWriter)
+	writeDone := make(chan error, 1)
+	go func() {
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", multipart.FileContentDisposition("file", name))
+		header.Set("Content-Type", mimeType)
+		part, err := multipartWriter.CreatePart(header)
+		if err == nil {
+			_, err = io.Copy(part, content)
+		}
+		if err == nil {
+			err = multipartWriter.Close()
+		}
+		if err != nil {
+			_ = pipeWriter.CloseWithError(err)
+		} else {
+			err = pipeWriter.Close()
+		}
+		writeDone <- err
+	}()
+
+	query := url.Values{"parent_id": {strconv.FormatInt(parentID, 10)}, "name": {name}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.base+"/api/v1/uploads?"+query.Encode(), pipeReader)
+	if err != nil {
+		_ = pipeReader.Close()
+		return receipt, fmt.Errorf("building upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	req.Header.Set(api.BlobHashHeader, expectedHash)
+	req.Header.Set(api.BlobSizeHeader, strconv.FormatInt(expectedSize, 10))
+	if c.key != "" {
+		req.Header.Set("X-Api-Key", c.key)
+	}
+	resp, callErr := c.hc.Do(req)
+	if callErr != nil {
+		_ = pipeReader.CloseWithError(callErr)
+		<-writeDone
+		return receipt, fmt.Errorf("uploading %q: %w", name, callErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		_ = pipeReader.Close()
+		<-writeDone
+		return receipt, decodeError(resp)
+	}
+	writerErr := <-writeDone
+	if writerErr != nil {
+		return receipt, fmt.Errorf("streaming upload %q: %w", name, writerErr)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&receipt); err != nil {
+		return receipt, fmt.Errorf("decoding upload response: %w", err)
+	}
+	return receipt, nil
 }
 
 func (c *Client) Move(ctx context.Context, id, rev int64, newParentID *int64, newName *string) (api.Node, error) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -153,6 +154,32 @@ func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, verified.Verified, "the same evidence contract reads packed authority")
 	assert.Equal(t, wantHash, verified.ComputedHash)
+}
+
+func TestDigestCheckedUploadRoundTrip(t *testing.T) {
+	c, s := newClient(t, serverKey)
+	content := "client upload"
+	sum := sha256.Sum256([]byte(content))
+	hash := hex.EncodeToString(sum[:])
+
+	added, err := c.Upload(t.Context(), s.RootID(), "upload.txt", "text/plain",
+		hash, int64(len(content)), strings.NewReader(content))
+	require.NoError(t, err)
+	assert.Equal(t, "added", added.Status)
+	assert.Equal(t, hash, added.ComputedHash)
+	assert.Equal(t, hash, added.Node.BlobHash)
+
+	skipped, err := c.Upload(t.Context(), s.RootID(), "upload.txt", "text/plain",
+		hash, int64(len(content)), strings.NewReader(content))
+	require.NoError(t, err)
+	assert.Equal(t, "skipped", skipped.Status)
+	assert.Equal(t, added.Node.ID, skipped.Node.ID)
+
+	wrong := sha256.Sum256([]byte("wrong"))
+	_, err = c.Upload(t.Context(), s.RootID(), "rejected.txt", "text/plain",
+		hex.EncodeToString(wrong[:]), int64(len(content)), strings.NewReader(content))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "digest_mismatch")
 }
 
 func TestStorageRepackRoundTrip(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "3"
+	daemonProtocolVersion = "4"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -16,6 +16,15 @@ import (
 	"go.kenn.io/docbank/internal/store"
 )
 
+var (
+	// ErrUploadDigestMismatch reports bytes that do not match the identity the
+	// remote writer declared. The physical write may leave an authority-free
+	// object for GC, but no blobs row or node is committed.
+	ErrUploadDigestMismatch = errors.New("upload digest mismatch")
+	// ErrUploadSizeMismatch is the corresponding declared-length failure.
+	ErrUploadSizeMismatch = errors.New("upload size mismatch")
+)
+
 // Ingester wires the metadata store to the blob store.
 type Ingester struct {
 	Store *store.Store
@@ -33,6 +42,83 @@ type Report struct {
 	Added   int
 	Skipped int
 	Failed  []FileError
+}
+
+// UploadResult is the server's independently computed receipt for one remote
+// file. Node is populated for both a new import and an idempotent retry.
+type UploadResult struct {
+	Node         store.Node
+	Added        bool
+	ComputedHash string
+	ComputedSize int64
+}
+
+// PreparedUpload is a verified, authority-free remote write. The caller may
+// validate the remainder of its transport envelope before Commit grants blob
+// and node authority.
+type PreparedUpload struct {
+	ing      *Ingester
+	parentID int64
+	name     string
+	mimeType string
+	result   UploadResult
+}
+
+// PrepareUpload streams one remote file through Kit's durable writer and
+// checks the independently declared identity. It intentionally stops before
+// inserting application metadata so callers can reject a malformed trailing
+// multipart envelope without partially accepting the request.
+func (ing *Ingester) PrepareUpload(
+	ctx context.Context, parentID int64, name, mimeType string, r io.Reader,
+	expectedHash string, expectedSize int64,
+) (*PreparedUpload, error) {
+	var result UploadResult
+	name, err := store.NormalizeName(name)
+	if err != nil {
+		return nil, err
+	}
+	parent, err := ing.Store.NodeByID(ctx, parentID)
+	if err != nil {
+		return nil, err
+	}
+	if parent.TrashedAt != nil {
+		return nil, store.ErrNotFound
+	}
+	if !parent.IsDir() {
+		return nil, store.ErrNotDir
+	}
+
+	result.ComputedHash, result.ComputedSize, err = ing.Blobs.WriteContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	if result.ComputedSize != expectedSize {
+		return nil, fmt.Errorf("declared %d bytes, received %d: %w",
+			expectedSize, result.ComputedSize, ErrUploadSizeMismatch)
+	}
+	if result.ComputedHash != expectedHash {
+		return nil, fmt.Errorf("declared SHA-256 %s, computed %s: %w",
+			expectedHash, result.ComputedHash, ErrUploadDigestMismatch)
+	}
+	return &PreparedUpload{
+		ing: ing, parentID: parentID, name: name, mimeType: mimeType, result: result,
+	}, nil
+}
+
+// Commit grants application authority to a prepared upload and returns the
+// stable node for either a new import or an idempotent retry.
+func (p *PreparedUpload) Commit(ctx context.Context) (UploadResult, error) {
+	result := p.result
+	ingestID, err := p.ing.Store.BeginIngest(ctx, "upload", p.name)
+	if err != nil {
+		return result, err
+	}
+	result.Node, result.Added, err = p.ing.Store.IngestFile(ctx, ingestID, p.parentID,
+		p.name, result.ComputedHash, result.ComputedSize, p.mimeType, p.name, "")
+	if err != nil {
+		return result, err
+	}
+	return result, nil
 }
 
 // AddPaths ingests files and directory trees under the virtual destPath.

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -30,13 +30,13 @@ func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) 
 // auto-suffixed copy ("report (2).pdf" next to an identical "report.pdf")
 // is a distinct file, not a re-import. Otherwise returns the smallest free
 // candidate name.
-func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (string, bool, error) {
+func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (string, int64, bool, error) {
 	base, ext := splitSuffix(name)
 	rows, err := tx.Query(
 		`SELECT id, name, COALESCE(blob_hash, '') FROM nodes
 		 WHERE parent_id = ? AND trashed_at IS NULL AND kind = 'file'`, parentID)
 	if err != nil {
-		return "", false, fmt.Errorf("listing siblings for %q: %w", name, err)
+		return "", 0, false, fmt.Errorf("listing siblings for %q: %w", name, err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -46,7 +46,7 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 		var sibID int64
 		var sibName, sibHash string
 		if err := rows.Scan(&sibID, &sibName, &sibHash); err != nil {
-			return "", false, fmt.Errorf("scanning sibling: %w", err)
+			return "", 0, false, fmt.Errorf("scanning sibling: %w", err)
 		}
 		n, ok := parseSuffix(sibName, base, ext)
 		if !ok {
@@ -58,15 +58,15 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 		taken[n] = true
 	}
 	if err := rows.Err(); err != nil {
-		return "", false, fmt.Errorf("listing siblings for %q: %w", name, err)
+		return "", 0, false, fmt.Errorf("listing siblings for %q: %w", name, err)
 	}
 	for _, sibID := range sameHash {
 		imported, err := sameOriginTx(tx, sibID, name)
 		if err != nil {
-			return "", false, err
+			return "", 0, false, err
 		}
 		if imported {
-			return "", true, nil // already imported (possibly under a suffix)
+			return "", sibID, true, nil // already imported (possibly under a suffix)
 		}
 	}
 	// Directories can occupy candidate names too; they don't carry content,
@@ -81,10 +81,10 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 				`SELECT 1 FROM nodes WHERE parent_id = ? AND name = ? AND trashed_at IS NULL`,
 				parentID, candidate).Scan(&one)
 			if errors.Is(err, sql.ErrNoRows) {
-				return candidate, false, nil
+				return candidate, 0, false, nil
 			}
 			if err != nil {
-				return "", false, fmt.Errorf("probing name %q: %w", candidate, err)
+				return "", 0, false, fmt.Errorf("probing name %q: %w", candidate, err)
 			}
 		}
 		n++
@@ -138,11 +138,15 @@ func (s *Store) IngestFile(ctx context.Context, ingestID, parentID int64, name, 
 		added   bool
 	)
 	err = s.withTx(ctx, func(tx *sql.Tx) error {
-		finalName, skip, err := resolveIngestNameTx(tx, parentID, name, blobHash)
+		finalName, existingID, skip, err := resolveIngestNameTx(tx, parentID, name, blobHash)
 		if err != nil {
 			return err
 		}
 		if skip {
+			created, err = scanNode(tx.QueryRow(`SELECT `+nodeCols+` FROM nodes WHERE id = ?`, existingID))
+			if err != nil {
+				return fmt.Errorf("reading idempotent ingest node %d: %w", existingID, err)
+			}
 			return nil
 		}
 		created, err = s.createFileTx(tx, parentID, finalName, blobHash, size, mimeType)

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -22,10 +22,11 @@ func TestIngestFileIdempotency(t *testing.T) {
 	assert.Equal(t, "report.pdf", n1.Name)
 
 	// Same content, same name: skipped.
-	_, added, err = s.IngestFile(ctx, ing, s.RootID(),
+	skipped, added, err := s.IngestFile(ctx, ing, s.RootID(),
 		"report.pdf", fakeHash("a1"), 10, "application/pdf", "/src/docs/report.pdf", "")
 	require.NoError(t, err)
 	assert.False(t, added)
+	assert.Equal(t, n1.ID, skipped.ID)
 
 	// Different content, same name: suffixed.
 	n2, added, err := s.IngestFile(ctx, ing, s.RootID(),
@@ -35,10 +36,11 @@ func TestIngestFileIdempotency(t *testing.T) {
 	assert.Equal(t, "report (2).pdf", n2.Name)
 
 	// Re-run of the suffixed one: skipped even though names differ.
-	_, added, err = s.IngestFile(ctx, ing, s.RootID(),
+	skipped, added, err = s.IngestFile(ctx, ing, s.RootID(),
 		"report.pdf", fakeHash("b2"), 11, "application/pdf", "/other/report.pdf", "")
 	require.NoError(t, err)
 	assert.False(t, added)
+	assert.Equal(t, n2.ID, skipped.ID)
 
 	// Third distinct content takes the next free ordinal.
 	n3, added, err := s.IngestFile(ctx, ing, s.RootID(),


### PR DESCRIPTION
External writers need to send document bytes without exposing their filesystem to the daemon, and they need a receipt that proves Docbank committed the identity they intended. The existing server-path ingest route cannot serve that trust boundary: it names files on the daemon host, is deliberately loopback-only, and returns batch counts rather than per-file computed evidence.

This PR makes remote upload file-granular and evidence-first. A request names a stable destination directory ID, carries exactly one multipart file, and declares the file’s expected SHA-256 and raw length independently of the multipart envelope. Docbank streams the part directly through Kit and grants blob/node authority only after the server-computed values, normalized filename, and complete envelope all agree. The response returns computed identity plus the stable node and distinguishes a new node from an idempotent retry.

One file per request is a deliberate atomicity boundary. Multi-file writers can run requests concurrently, but one failure never makes another file’s result ambiguous and each item can be retried independently. Different content under the same name follows normal suffixing rather than overwriting. Digest or length disagreement yields a specific machine-readable error and no new application authority.

The bytes-before-reference invariant still permits a rejected or interrupted stream to leave an untracked physical object. That is safer than deleting a hash another concurrent writer may be authorizing, and it remains invisible until the existing GC orphan scan removes it. The raw streaming handler also avoids Huma’s decoded-multipart path, which would pre-parse entire uploads into memory or temporary files before application validation.