### PR TITLE
Make Docbank streaming policy explicit

### DIFF
--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -170,7 +170,8 @@ Two request headers declare the expected identity of the **file part**, not the
 multipart envelope:
 
 - `X-Docbank-Blob-Hash`: canonical lowercase hexadecimal SHA-256;
-- `X-Docbank-Blob-Size`: raw byte length, bounded by Kit's blob limit.
+- `X-Docbank-Blob-Size`: raw byte length, bounded by docbank's explicit 64 MiB
+  object policy.
 
 The server streams the file once through Kit's durable writer and independently
 computes both values. Only after they match, the closing multipart boundary has

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -27,10 +27,11 @@ index, reader cache, recovery state machine, and repacker.
 
 `kit/packstore` sits above the low-level `kit/pack` format. It provides a mixed
 loose-and-packed content-addressed store, so migration can be gradual and
-interrupted work remains recoverable. Docbank explicitly caps one content
-object at 64 MiB across ingest, upload, reads, maintenance, backup, and restore.
-That is application policy rather than an inherited Kit default, so upgrading
-the shared engine cannot silently raise it.
+interrupted work remains recoverable. Docbank explicitly caps new content
+objects and pack maintenance at 64 MiB. That is application policy rather than
+an inherited Kit default, so upgrading the shared engine cannot silently raise
+it. Oversized loose objects accepted by an earlier release remain readable and
+eligible for backup, but maintenance leaves them loose.
 
 ## Ownership boundary
 

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -27,9 +27,10 @@ index, reader cache, recovery state machine, and repacker.
 
 `kit/packstore` sits above the low-level `kit/pack` format. It provides a mixed
 loose-and-packed content-addressed store, so migration can be gradual and
-interrupted work remains recoverable. Its default maintenance limit is 64 MiB
-per blob; larger documents remain loose and readable rather than forcing an
-unbounded in-memory pack operation.
+interrupted work remains recoverable. Docbank explicitly caps one content
+object at 64 MiB across ingest, upload, reads, maintenance, backup, and restore.
+That is application policy rather than an inherited Kit default, so upgrading
+the shared engine cannot silently raise it.
 
 ## Ownership boundary
 
@@ -82,7 +83,15 @@ and does not own either application's schema or garbage-collection policy.
 Docbank owns only its catalog adapter, daemon wiring, migration policy, and
 end-to-end verification. It does not fork Kit's reader cache, reconciliation,
 or repacker. The existing loose representation remains both the recovery path
-and the representation for blobs above the bounded maintenance limit.
+and the staging representation before packing.
+
+Raising the 64 MiB ceiling is a separate policy decision. It requires
+representative measurements of memory, temporary space, descriptors,
+throughput, cancellation, and restore behavior. Streaming removes
+whole-object heap allocation, but pack preparation can still require roughly
+2.004 times the raw object size in scratch space per concurrent preparation,
+and active streams can temporarily exceed the idle reader-cache descriptor
+count.
 
 The `blobs` membership boundary also lets logical features evolve without
 changing physical pack authority.

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -124,6 +124,13 @@ vault-wide verification, and backup capture must therefore consume through
 that terminal boundary; existence probes retain the buffered open-and-close
 path because they ask about catalog authority, not fresh byte evidence.
 
+Docbank sets `BlobBytes` explicitly to 64 MiB for loose writes, mixed reads,
+maintenance, remote uploads, and packed restore. Never replace that shared
+policy with an ambient Kit default. A larger ceiling needs downstream
+measurements first: pack preparation can use about 2.004 times raw size in
+scratch per concurrent object, and active stream leases can temporarily raise
+open descriptors above the idle reader-cache bound.
+
 Docbank owns:
 
 - the SQLite schema and catalog adapter;

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -124,9 +124,11 @@ vault-wide verification, and backup capture must therefore consume through
 that terminal boundary; existence probes retain the buffered open-and-close
 path because they ask about catalog authority, not fresh byte evidence.
 
-Docbank sets `BlobBytes` explicitly to 64 MiB for loose writes, mixed reads,
-maintenance, remote uploads, and packed restore. Never replace that shared
-policy with an ambient Kit default. A larger ceiling needs downstream
+Docbank sets `BlobBytes` explicitly to 64 MiB for new loose writes, maintenance,
+remote uploads, and packed restore. Never replace that shared policy with an
+ambient Kit default. Catalog-authorized oversized loose objects created before
+write enforcement are grandfathered for verified reads and backup; they are
+not eligible for packing. A larger ceiling for new content needs downstream
 measurements first: pack preparation can use about 2.004 times raw size in
 scratch per concurrent object, and active stream leases can temporarily raise
 open descriptors above the idle reader-cache bound.

--- a/internal/api/routes_upload.go
+++ b/internal/api/routes_upload.go
@@ -12,6 +12,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"go.kenn.io/kit/packstore"
 
+	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/ingest"
 	"go.kenn.io/docbank/internal/store"
 )
@@ -180,10 +181,9 @@ func parseUploadIdentity(r *http.Request) (int64, string, string, int64, *Error)
 			BlobHashHeader+" must be canonical lowercase SHA-256")
 	}
 	expectedSize, err := strconv.ParseInt(r.Header.Get(BlobSizeHeader), 10, 64)
-	limits := packstore.DefaultLimits()
-	if err != nil || expectedSize < 0 || expectedSize > limits.BlobBytes {
+	if err != nil || expectedSize < 0 || expectedSize > blob.MaxBlobBytes {
 		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "validation",
-			fmt.Sprintf("%s must be between 0 and %d", BlobSizeHeader, limits.BlobBytes))
+			fmt.Sprintf("%s must be between 0 and %d", BlobSizeHeader, blob.MaxBlobBytes))
 	}
 	return parentID, name, expectedHash, expectedSize, nil
 }

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -2,6 +2,8 @@ package backupapp_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"os"
 	"path/filepath"
@@ -23,6 +25,13 @@ type archiveFixture struct {
 	metadata *store.Store
 	blobs    *blob.Store
 	content  map[string]string
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }
 
 func newArchiveFixture(t *testing.T) *archiveFixture {
@@ -108,6 +117,55 @@ func TestLooseSnapshotVerifyAndRestore(t *testing.T) {
 	}
 	require.NoError(t, restoredBlobs.Close())
 	require.NoError(t, restoredStore.Close())
+}
+
+func TestOversizedLegacyLooseSnapshotVerifyAndRestore(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	size := blob.MaxBlobBytes + 1
+	digest := sha256.New()
+	_, err := io.CopyN(digest, zeroReader{}, size)
+	require.NoError(t, err)
+	hash := hex.EncodeToString(digest.Sum(nil))
+	path := filepath.Join(fixture.root, "blobs", hash[:2], hash)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	_, err = io.CopyN(f, zeroReader{}, size)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	_, err = fixture.metadata.CreateFile(t.Context(), fixture.metadata.RootID(), "legacy-large.bin",
+		hash, size, "application/octet-stream")
+	require.NoError(t, err)
+
+	app := backupapp.New("test-version")
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	manifest, err := backup.Create(t.Context(), repo, app, backup.CreateOptions{
+		DBPath: filepath.Join(fixture.root, "docbank.db"), ContentSource: backupapp.NewContentSource(fixture.blobs),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), manifest.Attachments.Blobs)
+	verified, err := backup.Verify(t.Context(), repo, app, backup.VerifyOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, verified.Problems)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	_, err = backup.Restore(t.Context(), repo, app, backup.RestoreOptions{TargetDir: target})
+	require.NoError(t, err)
+	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restoredStore.Close()) })
+	restoredBlobs, err := blob.New(store.NewPackCatalog(restoredStore), filepath.Join(target, "blobs"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restoredBlobs.Close()) })
+	stream, restoredSize, err := restoredBlobs.OpenStreamContext(t.Context(), hash)
+	require.NoError(t, err)
+	assert.Equal(t, size, restoredSize)
+	written, err := io.Copy(io.Discard, stream)
+	require.NoError(t, err)
+	assert.Equal(t, size, written)
+	assert.True(t, stream.Verified())
+	require.NoError(t, stream.Close())
 }
 
 func TestPackedSnapshotRequiresAndUsesPackedRestoreTarget(t *testing.T) {

--- a/internal/backupapp/restore.go
+++ b/internal/backupapp/restore.go
@@ -9,6 +9,7 @@ import (
 	"go.kenn.io/kit/backup"
 	"go.kenn.io/kit/packstore"
 
+	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -34,7 +35,7 @@ func (a *packedRestoreApp) RestoredContentPaths(
 func newPackedRestoreTarget() *packedRestoreTarget {
 	return &packedRestoreTarget{
 		coordinator: packstore.NewCoordinator(),
-		limits:      packstore.DefaultLimits(),
+		limits:      blob.StorageLimits(),
 	}
 }
 

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -35,6 +35,7 @@ func StorageLimits() packstore.Limits {
 type Store struct {
 	dir         string
 	layout      packstore.Layout
+	resolver    packstore.Resolver
 	catalog     packstore.Catalog
 	loose       *packstore.LooseStore
 	reader      *packstore.Store
@@ -61,7 +62,8 @@ func New(catalog packstore.Catalog, blobsDir string) (*Store, error) {
 		_ = maintainer.Close()
 		return nil, fmt.Errorf("creating loose blob store: %w", err)
 	}
-	return &Store{dir: blobsDir, layout: layout, catalog: catalog, loose: loose, reader: maintainer.Store(),
+	return &Store{dir: blobsDir, layout: layout, resolver: catalog, catalog: catalog, loose: loose,
+		reader:     maintainer.Store(),
 		maintainer: maintainer, coordinator: coordinator}, nil
 }
 
@@ -121,7 +123,7 @@ func newReaderStore(resolver packstore.Resolver, blobsDir string) (*Store, error
 	if err != nil {
 		return nil, fmt.Errorf("creating test mixed blob reader: %w", err)
 	}
-	return &Store{dir: blobsDir, layout: layout, loose: loose, reader: reader}, nil
+	return &Store{dir: blobsDir, layout: layout, resolver: resolver, loose: loose, reader: reader}, nil
 }
 
 func newLayout(blobsDir string) (packstore.Layout, error) {
@@ -222,10 +224,25 @@ func (s *Store) OpenStreamContext(
 		return nil, 0, fmt.Errorf("blob hash %q: %w", hash, ErrInvalidHash)
 	}
 	reader, size, err := s.reader.OpenStream(ctx, parsed)
-	if err != nil {
+	if err == nil {
+		return reader, size, nil
+	}
+	var limitErr *packstore.LimitError
+	if !errors.As(err, &limitErr) || limitErr.Dimension != packstore.LimitBlobRawBytes {
 		return nil, 0, fmt.Errorf("opening blob stream %s: %w", hash, err)
 	}
-	return reader, size, nil
+	location, resolveErr := s.resolver.Resolve(ctx, parsed)
+	if resolveErr != nil {
+		return nil, 0, fmt.Errorf("resolving oversized blob %s: %w", hash, resolveErr)
+	}
+	if !location.Member || location.Pack != nil {
+		return nil, 0, fmt.Errorf("opening blob stream %s: %w", hash, err)
+	}
+	compat, size, openErr := s.reader.Open(ctx, parsed)
+	if openErr != nil {
+		return nil, 0, fmt.Errorf("opening oversized loose blob %s: %w", hash, openErr)
+	}
+	return newVerifiedLooseCompatibilityStream(ctx, compat, parsed, size), size, nil
 }
 
 // Exists reports whether catalog-authorized content can be opened.

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -17,6 +17,18 @@ import (
 // ErrInvalidHash reports a value that is not canonical lowercase SHA-256.
 var ErrInvalidHash = packstore.ErrInvalidHash
 
+// MaxBlobBytes is docbank's application policy for one content object. Keep
+// this explicit: a future change to Kit's conservative defaults must not
+// silently expand docbank's upload, read, maintenance, or restore limits.
+const MaxBlobBytes int64 = 64 << 20
+
+// StorageLimits returns the shared Kit limits with docbank's object policy.
+func StorageLimits() packstore.Limits {
+	limits := packstore.DefaultLimits()
+	limits.BlobBytes = MaxBlobBytes
+	return limits
+}
+
 // Store owns docbank's durable loose writer and daemon-shared mixed reader.
 // The maintainer and coordinator are exposed to the daemon integration, but
 // physical maintenance remains unavailable to CLI processes directly.
@@ -39,6 +51,7 @@ func New(catalog packstore.Catalog, blobsDir string) (*Store, error) {
 	coordinator := packstore.NewCoordinator()
 	maintainer, err := packstore.NewMaintainer(catalog, layout, packstore.MaintainerOptions{
 		Coordinator: coordinator,
+		Limits:      StorageLimits(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating blob maintainer: %w", err)
@@ -104,7 +117,7 @@ func newReaderStore(resolver packstore.Resolver, blobsDir string) (*Store, error
 	if err != nil {
 		return nil, fmt.Errorf("creating test loose blob store: %w", err)
 	}
-	reader, err := packstore.NewStore(resolver, layout, packstore.StoreOptions{})
+	reader, err := packstore.NewStore(resolver, layout, packstore.StoreOptions{Limits: StorageLimits()})
 	if err != nil {
 		return nil, fmt.Errorf("creating test mixed blob reader: %w", err)
 	}
@@ -165,6 +178,7 @@ func (s *Store) WriteContext(ctx context.Context, r io.Reader) (string, int64, e
 	result, err := s.loose.Write(ctx, r, packstore.WriteOptions{
 		Durability: packstore.DurablePublication,
 		Dedup:      packstore.VerifyTypeAndSize,
+		MaxBytes:   MaxBlobBytes,
 	})
 	if err != nil {
 		return "", 0, fmt.Errorf("writing blob: %w", err)

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -1,6 +1,7 @@
 package blob
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -40,6 +41,48 @@ func TestWriteEnforcesBlobLimit(t *testing.T) {
 	assert.Zero(t, size)
 }
 
+func TestOpenStreamGrandfathersOversizedLooseBlob(t *testing.T) {
+	bs := newTestBlobStore(t)
+	size := MaxBlobBytes + 1
+	digest := sha256.New()
+	_, err := io.CopyN(digest, zeroReader{}, size)
+	require.NoError(t, err)
+	hash := hex.EncodeToString(digest.Sum(nil))
+	path := bs.path(hash)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	_, err = io.CopyN(f, zeroReader{}, size)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	stream, gotSize, err := bs.OpenStream(hash)
+	require.NoError(t, err)
+	assert.Equal(t, size, gotSize)
+	written, err := io.Copy(io.Discard, stream)
+	require.NoError(t, err)
+	assert.Equal(t, size, written)
+	assert.True(t, stream.Verified())
+	require.NoError(t, stream.Close())
+}
+
+func TestOversizedLooseCompatibilityStreamStillRequiresVerification(t *testing.T) {
+	content := []byte("compatibility content")
+	sum := sha256.Sum256(content)
+	expected, err := packstore.ParseHash(hex.EncodeToString(sum[:]))
+	require.NoError(t, err)
+
+	partial := newVerifiedLooseCompatibilityStream(t.Context(), &readSeekCloser{bytes.NewReader(content)},
+		expected, int64(len(content)))
+	_, err = partial.Read(make([]byte, 1))
+	require.NoError(t, err)
+	require.ErrorIs(t, partial.Close(), pack.ErrVerificationIncomplete)
+
+	corrupt := newVerifiedLooseCompatibilityStream(t.Context(),
+		&readSeekCloser{bytes.NewReader([]byte("corrupted content!!"))}, expected, int64(len(content)))
+	require.ErrorIs(t, corrupt.Verify(), packstore.ErrContentMismatch)
+}
+
 type alwaysMemberResolver struct{}
 
 func (alwaysMemberResolver) Resolve(_ context.Context, _ packstore.Hash) (packstore.Location, error) {
@@ -52,6 +95,10 @@ func (zeroReader) Read(p []byte) (int, error) {
 	clear(p)
 	return len(p), nil
 }
+
+type readSeekCloser struct{ *bytes.Reader }
+
+func (*readSeekCloser) Close() error { return nil }
 
 func TestWriteAndReadBack(t *testing.T) {
 	bs := newTestBlobStore(t)

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -27,10 +27,30 @@ func newTestBlobStore(t *testing.T) *Store {
 	return store
 }
 
+func TestStoragePolicyKeepsBlobLimitExplicit(t *testing.T) {
+	assert.Equal(t, MaxBlobBytes, int64(64<<20))
+	assert.Equal(t, MaxBlobBytes, StorageLimits().BlobBytes)
+}
+
+func TestWriteEnforcesBlobLimit(t *testing.T) {
+	bs := newTestBlobStore(t)
+	hash, size, err := bs.Write(io.LimitReader(zeroReader{}, MaxBlobBytes+1))
+	require.ErrorIs(t, err, packstore.ErrContentMismatch)
+	assert.Empty(t, hash)
+	assert.Zero(t, size)
+}
+
 type alwaysMemberResolver struct{}
 
 func (alwaysMemberResolver) Resolve(_ context.Context, _ packstore.Hash) (packstore.Location, error) {
 	return packstore.Location{Member: true}, nil
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }
 
 func TestWriteAndReadBack(t *testing.T) {

--- a/internal/blob/compat_stream.go
+++ b/internal/blob/compat_stream.go
@@ -1,0 +1,127 @@
+package blob
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+
+	"go.kenn.io/kit/pack"
+	"go.kenn.io/kit/packstore"
+)
+
+// verifiedLooseCompatibilityStream preserves reads of oversized loose objects
+// accepted before docbank enforced MaxBlobBytes at write time. It is created
+// only after catalog resolution confirms there is no packed authority.
+type verifiedLooseCompatibilityStream struct {
+	ctx          context.Context
+	reader       io.ReadSeekCloser
+	expectedHash packstore.Hash
+	expectedSize int64
+	digest       hash.Hash
+	read         int64
+	terminal     error
+	closeErr     error
+	closed       bool
+	verified     bool
+}
+
+func newVerifiedLooseCompatibilityStream(
+	ctx context.Context, reader io.ReadSeekCloser, expectedHash packstore.Hash, expectedSize int64,
+) packstore.VerifiedReadCloser {
+	return &verifiedLooseCompatibilityStream{
+		ctx: ctx, reader: reader, expectedHash: expectedHash, expectedSize: expectedSize, digest: sha256.New(),
+	}
+}
+
+func (s *verifiedLooseCompatibilityStream) Read(p []byte) (int, error) {
+	if s.closed {
+		if s.terminal != nil {
+			return 0, s.terminal
+		}
+		if s.verified {
+			return 0, io.EOF
+		}
+		return 0, os.ErrClosed
+	}
+	if err := s.ctx.Err(); err != nil {
+		return 0, s.fail(err)
+	}
+	n, err := s.reader.Read(p)
+	if n > 0 {
+		_, _ = s.digest.Write(p[:n])
+		s.read += int64(n)
+		if s.read > s.expectedSize {
+			return n, s.fail(packstore.ErrContentMismatch)
+		}
+	}
+	if errors.Is(err, io.EOF) {
+		return n, s.finish()
+	}
+	if err != nil {
+		return n, s.fail(err)
+	}
+	return n, nil
+}
+
+func (s *verifiedLooseCompatibilityStream) finish() error {
+	if err := s.ctx.Err(); err != nil {
+		return s.fail(err)
+	}
+	if s.read != s.expectedSize || hex.EncodeToString(s.digest.Sum(nil)) != s.expectedHash.String() {
+		return s.fail(fmt.Errorf("%w: oversized loose blob identity changed", packstore.ErrContentMismatch))
+	}
+	s.closeErr = s.reader.Close()
+	s.closed = true
+	if s.closeErr != nil {
+		s.terminal = s.closeErr
+		return s.terminal
+	}
+	s.verified = true
+	return io.EOF
+}
+
+func (s *verifiedLooseCompatibilityStream) fail(err error) error {
+	if s.terminal == nil {
+		s.closeErr = s.reader.Close()
+		s.closed = true
+		s.terminal = errors.Join(err, s.closeErr)
+	}
+	return s.terminal
+}
+
+func (s *verifiedLooseCompatibilityStream) Verify() error {
+	if s.verified {
+		return nil
+	}
+	if s.terminal != nil {
+		return s.terminal
+	}
+	buf := make([]byte, 64<<10)
+	for {
+		_, err := s.Read(buf)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (s *verifiedLooseCompatibilityStream) Verified() bool { return s.verified }
+
+func (s *verifiedLooseCompatibilityStream) Close() error {
+	if !s.closed {
+		s.closeErr = s.reader.Close()
+		s.closed = true
+	}
+	if s.verified {
+		return s.closeErr
+	}
+	return errors.Join(s.terminal, s.closeErr, pack.ErrVerificationIncomplete)
+}

--- a/internal/blob/packed_integration_test.go
+++ b/internal/blob/packed_integration_test.go
@@ -1,7 +1,9 @@
 package blob_test
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -119,6 +121,134 @@ func TestMixedStoreLifecyclePreservesMembershipAndBytes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, records)
 	assertBlobContent(t, physical, fixtures[2].hash, fixtures[2].data)
+}
+
+func TestMaintainerSharesDocbankMutationCoordinator(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	root := t.TempDir()
+	metadata, err := store.Open(filepath.Join(root, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, metadata.Close()) })
+	blobsDir := filepath.Join(root, "blobs")
+	require.NoError(t, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
+	physical, err := blob.New(store.NewPackCatalog(metadata), blobsDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, physical.Close()) })
+
+	require.NoError(t, physical.WithMutation(ctx, func() error {
+		hash, size, writeErr := physical.WriteContext(ctx, strings.NewReader("coordinated content"))
+		if writeErr != nil {
+			return writeErr
+		}
+		_, createErr := metadata.CreateFile(ctx, metadata.RootID(), "coordinated.txt",
+			hash, size, "text/plain")
+		return createErr
+	}))
+
+	lease, err := physical.Coordinator().AcquireMutation(ctx)
+	require.NoError(t, err)
+	waitCtx, cancel := context.WithTimeout(ctx, 25*time.Millisecond)
+	_, err = physical.Maintainer().Pack(waitCtx, packstore.PackOptions{})
+	cancel()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NoError(t, lease.Release())
+
+	packed, err := physical.Maintainer().Pack(ctx, packstore.PackOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, packed.BlobsPacked)
+}
+
+func TestActiveStreamSurvivesRepackRetirementAndStoreClose(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	root := t.TempDir()
+	metadata, err := store.Open(filepath.Join(root, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, metadata.Close()) })
+	blobsDir := filepath.Join(root, "blobs")
+	require.NoError(t, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
+	physical, err := blob.New(store.NewPackCatalog(metadata), blobsDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, physical.Close()) })
+
+	liveContent := bytes.Repeat([]byte("leased packed content "), 8192)
+	var liveHash string
+	var dead []store.Node
+	require.NoError(t, physical.WithMutation(ctx, func() error {
+		var writeErr error
+		liveHash, _, writeErr = physical.WriteContext(ctx, bytes.NewReader(liveContent))
+		if writeErr != nil {
+			return writeErr
+		}
+		_, createErr := metadata.CreateFile(ctx, metadata.RootID(), "live.bin",
+			liveHash, int64(len(liveContent)), "application/octet-stream")
+		if createErr != nil {
+			return createErr
+		}
+		for i, content := range []string{"first dead content", "second dead content"} {
+			deadHash, deadSize, err := physical.WriteContext(ctx, strings.NewReader(content))
+			if err != nil {
+				return err
+			}
+			node, err := metadata.CreateFile(ctx, metadata.RootID(),
+				fmt.Sprintf("dead-%d.txt", i), deadHash, deadSize, "text/plain")
+			if err != nil {
+				return err
+			}
+			dead = append(dead, node)
+		}
+		return nil
+	}))
+
+	packed, err := physical.Maintainer().Pack(ctx, packstore.PackOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, packed.PacksSealed)
+	records, err := store.NewPackCatalog(metadata).ListPackRecords(ctx)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	oldPackPath := filepath.Join(blobsDir, "packs", records[0].PackID[:2],
+		records[0].PackID+packstore.PackExt)
+
+	stream, size, err := physical.OpenStreamContext(ctx, liveHash)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(liveContent)), size)
+	prefix := make([]byte, 97)
+	_, err = io.ReadFull(stream, prefix)
+	require.NoError(t, err)
+	assert.False(t, stream.Verified())
+
+	require.NoError(t, physical.WithMutation(ctx, func() error {
+		for _, node := range dead {
+			if _, _, trashErr := metadata.Trash(ctx, node.ID, -1); trashErr != nil {
+				return trashErr
+			}
+		}
+		if _, emptyErr := metadata.TrashEmpty(ctx, 0, true); emptyErr != nil {
+			return emptyErr
+		}
+		return metadata.DeleteBlobRows(ctx, []string{dead[0].BlobHash, dead[1].BlobHash})
+	}))
+	repacked, err := physical.Maintainer().Repack(ctx, packstore.RepackOptions{
+		Now: time.Now().UTC().Add(48 * time.Hour),
+		Selection: packstore.RepackSelection{
+			MinAge: time.Nanosecond, MinDeadStored: 1,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, repacked.PacksRewritten)
+	assert.Equal(t, 1, repacked.PacksRemoved)
+	assert.NoFileExists(t, oldPackPath)
+	require.NoError(t, physical.Close())
+
+	rest, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	got := make([]byte, 0, len(prefix)+len(rest))
+	got = append(got, prefix...)
+	got = append(got, rest...)
+	assert.Equal(t, liveContent, got)
+	assert.True(t, stream.Verified())
+	require.NoError(t, stream.Close())
 }
 
 func assertBlobContent(t *testing.T, physical *blob.Store, hash, want string) {


### PR DESCRIPTION
Kit deliberately keeps conservative defaults, but those defaults are not an application contract. Docbank’s 64 MiB ceiling was previously indirect, and local ingest did not apply it at write time. A future Kit default change could therefore alter application behavior—or allow Docbank to authorize a loose object its maintenance paths cannot safely process.

This makes 64 MiB explicit for new local and remote writes, pack maintenance, and packed restore. It does not revoke content accepted by an earlier build: resolver-confirmed oversized loose objects remain readable and backup-eligible through a bounded-memory SHA-256-verifying compatibility stream. The exception cannot bypass the ceiling for packed content, and it preserves terminal-EOF, cancellation, corruption, and early-close verification semantics. An end-to-end regression fixture snapshots, verifies, restores, and rereads a 64 MiB+1 legacy loose object.

The change also tests the lifecycle assumptions behind the integration against Docbank’s real SQLite catalog. The maintainer must wait behind the same Coordinator used by application mutations, and an active verified stream must survive source repack, pack retirement, and store closure before completing with authoritative EOF.

Raising the new-object ceiling remains a separate decision requiring representative memory, scratch-space, descriptor, throughput, cancellation, and restore measurements; bounded-memory streaming does not erase those resource costs.