### PR TITLE
Define deferred pack retirement recovery

### DIFF
--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -317,6 +317,9 @@ Branch on `code`, never `detail`. Useful policy groups:
   `not_dir`, `not_file`, `is_root`.
 - Reconcile desired state: `exists`, `cycle`, `not_trashed`, `not_found`.
 - Stop and surface credentials or topology: `unauthorized`, `loopback_only`.
+- Release external file locks, then run `storage pack` reconciliation:
+  `pack_retirement_deferred`. The preceding repack catalog change already
+  committed; never restore the retired mapping or assume rollback.
 - Stop automation and preserve evidence: `internal`.
 
 The complete mapping lives in [HTTP API](../architecture/http-api.md) and the

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -262,6 +262,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `loopback_only` | 403 | `POST /ingest` called by a non-loopback peer |
 | `digest_mismatch` / `size_mismatch` | 422 | uploaded file bytes disagree with the required declaration; no node/blob authority committed |
 | `too_large` | 413 | upload exceeded its declared size plus bounded multipart overhead |
+| `pack_retirement_deferred` | 503 | repack authority committed but an old source pack remains physically locked; release the lock, then run `storage pack` reconciliation |
 | `unauthorized` | 401 | missing or invalid API key; bad shutdown token |
 | `internal` | 500 | unmapped error (still surfaced with a message — this is a single-user local daemon, not a hardened multi-tenant service) |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -246,6 +246,13 @@ errors after committed work. The report's `bytes_repacked` is live raw content
 rewritten, not a claim about filesystem bytes reclaimed. Compare `storage
 status` before and after when exact inventory change matters.
 
+Pack retirement can be deferred when another process holds a source pack open,
+most commonly through a Windows handle that does not permit deletion. The
+repack response then uses `pack_retirement_deferred`: replacement catalog
+authority has already committed, so do not restore the old mapping or assume
+the rewrite rolled back. Release the external file lock and run `docbank
+storage pack`; its reconciliation pass removes the orphaned source pack.
+
 ## docbank verify
 
 ```

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -133,6 +133,13 @@ measurements first: pack preparation can use about 2.004 times raw size in
 scratch per concurrent object, and active stream leases can temporarily raise
 open descriptors above the idle reader-cache bound.
 
+Repack commits replacement mappings before retiring an old immutable pack. If
+Kit returns `ErrPackRetirementDeferred`, the catalog change must not be rolled
+back: the old pack is now an untrusted physical orphan, not authority. Docbank
+reports the condition as retryable cleanup. After external readers or Windows
+file locks release it, the operator runs `storage pack`; Kit's orphan
+reconciliation verifies current authority and removes the redundant source.
+
 Docbank owns:
 
 - the SQLite schema and catalog adapter;

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/internal/store"
 )
@@ -82,4 +84,16 @@ func FromStoreError(err error) error {
 		}
 	}
 	return NewError(http.StatusInternalServerError, "internal", err.Error())
+}
+
+// FromMaintenanceError preserves the commit boundary of a deferred physical
+// pack retirement. Repack catalog changes are already authoritative; a later
+// pack pass reconciles the now-orphaned source file after external locks clear.
+func FromMaintenanceError(err error) error {
+	if errors.Is(err, packstore.ErrPackRetirementDeferred) {
+		return NewError(http.StatusServiceUnavailable, "pack_retirement_deferred", fmt.Sprintf(
+			"pack replacement committed, but source-file cleanup was deferred; release external file locks, "+
+				"then run docbank storage pack to reconcile orphan packs: %v", err))
+	}
+	return FromStoreError(err)
 }

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/packstore"
+)
+
+func TestFromMaintenanceErrorPreservesCommittedRetirementBoundary(t *testing.T) {
+	err := &packstore.PackRetirementError{PackID: "01kxbz5s5z6b3m8v8m8p0m6h4y", Err: errors.New("sharing violation")}
+	mapped := &Error{}
+	ok := errors.As(FromMaintenanceError(err), &mapped)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusServiceUnavailable, mapped.Status)
+	assert.Equal(t, "pack_retirement_deferred", mapped.Code)
+	assert.Contains(t, mapped.Detail, "pack replacement committed")
+	assert.Contains(t, mapped.Detail, "docbank storage pack")
+}

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -61,7 +61,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 				},
 			})
 			if err != nil {
-				return FromStoreError(err)
+				return FromMaintenanceError(err)
 			}
 			out.Body = storageRepackReport(stats)
 			return nil
@@ -82,7 +82,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		err := g.maintain(func() error {
 			stats, err := d.Blobs.Maintainer().Pack(ctx, packstore.PackOptions{MaxBytes: in.Body.MaxBytes})
 			if err != nil {
-				return FromStoreError(err)
+				return FromMaintenanceError(err)
 			}
 			out.Body = storagePackReport(stats)
 			return nil

--- a/internal/blob/packed_integration_test.go
+++ b/internal/blob/packed_integration_test.go
@@ -3,6 +3,7 @@ package blob_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,49 @@ import (
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/store"
 )
+
+type deferredRetirementCatalog struct {
+	packstore.Catalog
+
+	blobsDir string
+	heldPath string
+	packPath string
+}
+
+func (c *deferredRetirementCatalog) CommitRepack(
+	ctx context.Context, sourceIDs []string, records []packstore.PackRecord, moves []packstore.RepackMove,
+) error {
+	if err := c.Catalog.CommitRepack(ctx, sourceIDs, records, moves); err != nil {
+		return fmt.Errorf("committing test repack: %w", err)
+	}
+	if len(sourceIDs) != 1 {
+		return fmt.Errorf("test retirement hook expected one source pack, got %d", len(sourceIDs))
+	}
+	c.packPath = filepath.Join(c.blobsDir, "packs", sourceIDs[0][:2], sourceIDs[0]+packstore.PackExt)
+	c.heldPath = c.packPath + ".held"
+	if err := os.Rename(c.packPath, c.heldPath); err != nil {
+		return fmt.Errorf("holding retired source pack: %w", err)
+	}
+	if err := os.Mkdir(c.packPath, 0o700); err != nil {
+		return fmt.Errorf("blocking retired source path: %w", err)
+	}
+	return os.WriteFile(filepath.Join(c.packPath, "lock"), []byte("held"), 0o600)
+}
+
+func (c *deferredRetirementCatalog) release() error {
+	if c.heldPath == "" {
+		return nil
+	}
+	if _, err := os.Stat(c.heldPath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(c.packPath); err != nil {
+		return err
+	}
+	return os.Rename(c.heldPath, c.packPath)
+}
 
 func TestMixedStoreLifecyclePreservesMembershipAndBytes(t *testing.T) {
 	t.Parallel()
@@ -249,6 +293,79 @@ func TestActiveStreamSurvivesRepackRetirementAndStoreClose(t *testing.T) {
 	assert.Equal(t, liveContent, got)
 	assert.True(t, stream.Verified())
 	require.NoError(t, stream.Close())
+}
+
+func TestDeferredRetirementCommitsAuthorityAndPackReconcilesOrphan(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	root := t.TempDir()
+	metadata, err := store.Open(filepath.Join(root, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, metadata.Close()) })
+	blobsDir := filepath.Join(root, "blobs")
+	require.NoError(t, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
+	baseCatalog := store.NewPackCatalog(metadata)
+	catalog := &deferredRetirementCatalog{Catalog: baseCatalog, blobsDir: blobsDir}
+	physical, err := blob.New(catalog, blobsDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, physical.Close()) })
+	t.Cleanup(func() { require.NoError(t, catalog.release()) })
+
+	var nodes []store.Node
+	require.NoError(t, physical.WithMutation(ctx, func() error {
+		for i, content := range []string{"live after deferred retirement", "dead one", "dead two"} {
+			hash, size, writeErr := physical.WriteContext(ctx, strings.NewReader(content))
+			if writeErr != nil {
+				return writeErr
+			}
+			node, createErr := metadata.CreateFile(ctx, metadata.RootID(), fmt.Sprintf("item-%d.txt", i),
+				hash, size, "text/plain")
+			if createErr != nil {
+				return createErr
+			}
+			nodes = append(nodes, node)
+		}
+		return nil
+	}))
+	packed, err := physical.Maintainer().Pack(ctx, packstore.PackOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, packed.PacksSealed)
+	records, err := baseCatalog.ListPackRecords(ctx)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	sourceID := records[0].PackID
+
+	require.NoError(t, physical.WithMutation(ctx, func() error {
+		for _, node := range nodes[1:] {
+			if _, _, trashErr := metadata.Trash(ctx, node.ID, -1); trashErr != nil {
+				return trashErr
+			}
+		}
+		if _, emptyErr := metadata.TrashEmpty(ctx, 0, true); emptyErr != nil {
+			return emptyErr
+		}
+		return metadata.DeleteBlobRows(ctx, []string{nodes[1].BlobHash, nodes[2].BlobHash})
+	}))
+	repacked, err := physical.Maintainer().Repack(ctx, packstore.RepackOptions{
+		Now: time.Now().UTC().Add(48 * time.Hour),
+		Selection: packstore.RepackSelection{
+			MinAge: time.Nanosecond, MinDeadStored: 1,
+		},
+	})
+	require.ErrorIs(t, err, packstore.ErrPackRetirementDeferred)
+	assert.Equal(t, 1, repacked.PacksRewritten)
+	assert.Zero(t, repacked.PacksRemoved)
+	hasSource, err := baseCatalog.HasPackRecord(ctx, sourceID)
+	require.NoError(t, err)
+	assert.False(t, hasSource, "the committed replacement must not be rolled back")
+	assertBlobContent(t, physical, nodes[0].BlobHash, "live after deferred retirement")
+
+	require.NoError(t, catalog.release())
+	reconciled, err := physical.Maintainer().Pack(ctx, packstore.PackOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, reconciled.PacksRemoved)
+	assert.NoFileExists(t, catalog.packPath)
+	assertBlobContent(t, physical, nodes[0].BlobHash, "live after deferred retirement")
 }
 
 func assertBlobContent(t *testing.T, physical *blob.Store, hash, want string) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"time"
 
+	"go.kenn.io/kit/packstore"
+
 	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/store"
 )
@@ -55,17 +57,19 @@ func New(baseURL, apiKey string) *Client {
 	return &Client{base: baseURL, key: apiKey, hc: &http.Client{Timeout: 0}}
 }
 
-// codeToStoreErr is the inverse of the server's FromStoreError mapping.
-var codeToStoreErr = map[string]error{
-	"not_found":      store.ErrNotFound,
-	"exists":         store.ErrExists,
-	"cycle":          store.ErrCycle,
-	"stale_revision": store.ErrStaleRevision,
-	"not_dir":        store.ErrNotDir,
-	"not_file":       store.ErrNotFile,
-	"invalid_name":   store.ErrInvalidName,
-	"not_trashed":    store.ErrNotTrashed,
-	"is_root":        store.ErrIsRoot,
+// codeToTypedErr preserves server problem codes that have a stable local
+// sentinel for callers using errors.Is.
+var codeToTypedErr = map[string]error{
+	"not_found":                store.ErrNotFound,
+	"exists":                   store.ErrExists,
+	"cycle":                    store.ErrCycle,
+	"stale_revision":           store.ErrStaleRevision,
+	"not_dir":                  store.ErrNotDir,
+	"not_file":                 store.ErrNotFile,
+	"invalid_name":             store.ErrInvalidName,
+	"not_trashed":              store.ErrNotTrashed,
+	"is_root":                  store.ErrIsRoot,
+	"pack_retirement_deferred": packstore.ErrPackRetirementDeferred,
 }
 
 func decodeError(resp *http.Response) error {
@@ -74,7 +78,7 @@ func decodeError(resp *http.Response) error {
 	if err := json.Unmarshal(body, &e); err != nil || e.Status == 0 {
 		return fmt.Errorf("daemon returned %s: %s", resp.Status, string(body))
 	}
-	if target, ok := codeToStoreErr[e.Code]; ok {
+	if target, ok := codeToTypedErr[e.Code]; ok {
 		return fmt.Errorf("%s: %w", e.Detail, target)
 	}
 	return fmt.Errorf("daemon error (%d %s): %s", e.Status, e.Code, e.Detail)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/blob"
@@ -94,6 +97,23 @@ func TestErrorMapping(t *testing.T) {
 
 	_, err = c.Move(ctx, d.ID, d.Revision+99, nil, new("x"))
 	require.ErrorIs(t, err, store.ErrStaleRevision)
+}
+
+func TestDeferredRetirementProblemKeepsTypedClientError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if err := json.NewEncoder(w).Encode(api.Error{
+			Title: http.StatusText(http.StatusServiceUnavailable), Status: http.StatusServiceUnavailable,
+			Code: "pack_retirement_deferred", Detail: "replacement committed; run storage pack",
+		}); err != nil {
+			t.Errorf("encoding problem response: %v", err)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	c := client.New(ts.URL, "key")
+	_, err := c.StorageRepack(t.Context(), 0, 0, 0)
+	require.ErrorIs(t, err, packstore.ErrPackRetirementDeferred)
 }
 
 func TestAPIKeySent(t *testing.T) {


### PR DESCRIPTION
Repack has a split commit boundary: replacement catalog authority can commit successfully even when an external file handle prevents Kit from deleting the retired source pack. Treating that outcome as an opaque internal failure is dangerous. An operator cannot tell whether the rewrite rolled back, and a well-intentioned recovery could restore stale authority or repeat the wrong maintenance operation.

This gives the condition a truthful contract. The daemon returns `503 pack_retirement_deferred`, explicitly states that replacement authority committed, and directs the operator to release external file locks and run `docbank storage pack`. That later pack pass uses Kit’s orphan reconciliation to remove the redundant physical source; it does not restore the retired mapping. Typed clients preserve `errors.Is(err, packstore.ErrPackRetirementDeferred)` so automation can branch on the code rather than parse prose.

A real Docbank SQLite-catalog lifecycle forces retirement failure after the replacement transaction, proves the live blob remains readable from new authority and the old record stays retired, then releases the simulated lock and proves `storage pack` removes the orphan. The same tests run under the Windows CI leg, while Kit’s native Windows gate supplies the underlying sharing-violation classification.