### PR TITLE
Baseline Docbank's streaming resource envelope

### DIFF
--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -141,7 +141,7 @@ reports the condition as retryable cleanup. After external readers or Windows
 file locks release it, the operator runs `storage pack`; Kit's orphan
 reconciliation verifies current authority and removes the redundant source.
 
-## Current 64 MiB resource envelope
+## Current resource envelope
 
 `internal/backupapp/resource_benchmark_test.go` is the reproducible downstream
 gate for the real SQLite catalog and Docbank adapters:
@@ -152,19 +152,26 @@ go test -tags fts5 ./internal/backupapp -run '^$' \
 ```
 
 The current darwin/arm64 baseline on an Apple M4 Max with Go 1.26.4 and Kit
-commit `7335149` is:
+v0.8.0 is:
 
 | Workload | Throughput | Heap allocated per operation | Additional stream descriptors |
 | --- | ---: | ---: | ---: |
-| verified loose read, 64 MiB | 2,607 MB/s | 15,584 bytes | 1 |
-| verified packed read, 64 MiB | 2,115 MB/s | 18,584 bytes | 1 |
-| write + pack + sparse repack, 64 MiB total | 147 MB/s | 75,593,880 bytes cumulative | — |
-| snapshot + verify + loose restore, 64 MiB, one job | 672 MB/s | 71,132,216 bytes cumulative | — |
+| verified loose read, 64 MiB | 2,589 MB/s | 15,584 bytes | 1 |
+| verified packed read, 64 MiB | 2,135 MB/s | 18,584 bytes | 1 |
+| write + pack + sparse repack, 64 MiB total | 147 MB/s | 75,600,088 bytes cumulative | — |
+| snapshot + verify + loose restore, 64 MiB, one job | 678 MB/s | 71,134,816 bytes cumulative | — |
+| candidate durable loose write, 1 GiB | 293 MB/s | 116,328 bytes | — |
+| candidate verified loose read, 1 GiB | 2,644 MB/s | 15,600 bytes | 1 |
+| candidate snapshot + verify + loose restore, 1 GiB, one job | 953 MB/s | 49,985,904 bytes cumulative | — |
 
-A prebuilt benchmark binary running all four workloads sequentially peaked at
-80,478,208 bytes (76.8 MiB) resident. `B/op` for the compound maintenance and
-backup rows is cumulative allocation across several streaming stages, not peak
-live heap; the external RSS measurement is the process envelope.
+A prebuilt benchmark binary running all seven workloads sequentially peaked at
+111,706,112 bytes (106.5 MiB) resident. Running only the three 1 GiB loose
+candidate workloads peaked at 49,168,384 bytes (46.9 MiB) resident. The full
+suite retains allocator and codec high-water state from prior maintenance, so
+the larger number is the appropriate whole-process capacity baseline. `B/op`
+for compound maintenance and backup rows is cumulative allocation across
+several streaming stages, not peak live heap; the external RSS measurements
+are the process envelopes.
 
 Resource policy still needs capacity beyond RSS. Incompressible preparation at
 the 64 MiB ceiling can require about 128.256 MiB of scratch for one object.
@@ -175,10 +182,18 @@ and each concurrent loose or packed stream can add one descriptor until EOF or
 `Close`. Cancellation and early-close cleanup remain mandatory race-tested
 gates, not benchmark outcomes.
 
-These numbers are evidence for retaining the current ceiling, not performance
-guarantees. Any proposal to raise `MaxBlobBytes`, maintenance limits, reader
-slots, or backup concurrency must rerun this suite on representative target
-hardware and revise this envelope.
+The 1 GiB candidate benchmarks bypass only Docbank's current admission check;
+they use Kit's durable loose writer, Docbank's mutation and SQLite authority
+boundary, native verified `OpenStream`, and the real backup adapters. They do
+not admit the object to packing. This is evidence that a 1 GiB loose-ingestion
+policy can remain bounded while packed maintenance stays at 64 MiB, not a
+performance guarantee or a policy change by itself. Such an object still needs
+roughly its raw size for live storage, repository storage, and a simultaneous
+restore target in the incompressible case.
+
+Any proposal to change admission or maintenance limits, reader slots, or
+backup concurrency must rerun this suite on representative target hardware and
+revise this envelope.
 
 Docbank owns:
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -141,6 +141,45 @@ reports the condition as retryable cleanup. After external readers or Windows
 file locks release it, the operator runs `storage pack`; Kit's orphan
 reconciliation verifies current authority and removes the redundant source.
 
+## Current 64 MiB resource envelope
+
+`internal/backupapp/resource_benchmark_test.go` is the reproducible downstream
+gate for the real SQLite catalog and Docbank adapters:
+
+```bash
+go test -tags fts5 ./internal/backupapp -run '^$' \
+  -bench '^BenchmarkDocbank' -benchtime=1x -benchmem -count=1
+```
+
+The current darwin/arm64 baseline on an Apple M4 Max with Go 1.26.4 and Kit
+commit `7335149` is:
+
+| Workload | Throughput | Heap allocated per operation | Additional stream descriptors |
+| --- | ---: | ---: | ---: |
+| verified loose read, 64 MiB | 2,607 MB/s | 15,584 bytes | 1 |
+| verified packed read, 64 MiB | 2,115 MB/s | 18,584 bytes | 1 |
+| write + pack + sparse repack, 64 MiB total | 147 MB/s | 75,593,880 bytes cumulative | — |
+| snapshot + verify + loose restore, 64 MiB, one job | 672 MB/s | 71,132,216 bytes cumulative | — |
+
+A prebuilt benchmark binary running all four workloads sequentially peaked at
+80,478,208 bytes (76.8 MiB) resident. `B/op` for the compound maintenance and
+backup rows is cumulative allocation across several streaming stages, not peak
+live heap; the external RSS measurement is the process envelope.
+
+Resource policy still needs capacity beyond RSS. Incompressible preparation at
+the 64 MiB ceiling can require about 128.256 MiB of scratch for one object.
+Docbank serializes maintenance, so pack/repack currently has one preparation in
+flight; future backup concurrency must multiply scratch and codec windows by
+its explicit job count. The mixed reader keeps at most 16 idle pack descriptors,
+and each concurrent loose or packed stream can add one descriptor until EOF or
+`Close`. Cancellation and early-close cleanup remain mandatory race-tested
+gates, not benchmark outcomes.
+
+These numbers are evidence for retaining the current ceiling, not performance
+guarantees. Any proposal to raise `MaxBlobBytes`, maintenance limits, reader
+slots, or backup concurrency must rerun this suite on representative target
+hardware and revise this envelope.
+
 Docbank owns:
 
 - the SQLite schema and catalog adapter;

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -151,22 +151,37 @@ go test -tags fts5 ./internal/backupapp -run '^$' \
   -bench '^BenchmarkDocbank' -benchtime=1x -benchmem -count=1
 ```
 
+The peak-RSS figures use a prebuilt test binary so compilation is outside the
+measurement. On macOS, reproduce the full and candidate-only runs with:
+
+```bash
+go test -c -tags fts5 -o /tmp/docbank-resource.test ./internal/backupapp
+/usr/bin/time -l /tmp/docbank-resource.test -test.run '^$' \
+  -test.bench '^BenchmarkDocbank' -test.benchtime=1x -test.benchmem -test.count=1
+/usr/bin/time -l /tmp/docbank-resource.test -test.run '^$' \
+  -test.bench '^BenchmarkDocbankCandidateLoose' \
+  -test.benchtime=1x -test.benchmem -test.count=1
+```
+
+Record `maximum resident set size`; other operating systems need their
+equivalent external process measurement rather than Go's cumulative `B/op`.
+
 The current darwin/arm64 baseline on an Apple M4 Max with Go 1.26.4 and Kit
 v0.8.0 is:
 
 | Workload | Throughput | Heap allocated per operation | Additional stream descriptors |
 | --- | ---: | ---: | ---: |
-| verified loose read, 64 MiB | 2,589 MB/s | 15,584 bytes | 1 |
-| verified packed read, 64 MiB | 2,135 MB/s | 18,584 bytes | 1 |
-| write + pack + sparse repack, 64 MiB total | 147 MB/s | 75,600,088 bytes cumulative | — |
-| snapshot + verify + loose restore, 64 MiB, one job | 678 MB/s | 71,134,816 bytes cumulative | — |
-| candidate durable loose write, 1 GiB | 293 MB/s | 116,328 bytes | — |
-| candidate verified loose read, 1 GiB | 2,644 MB/s | 15,600 bytes | 1 |
-| candidate snapshot + verify + loose restore, 1 GiB, one job | 953 MB/s | 49,985,904 bytes cumulative | — |
+| verified loose read, 64 MiB | 2,622 MB/s | 12,944 bytes | 1 |
+| verified packed read, 64 MiB | 2,132 MB/s | 15,928 bytes | 1 |
+| write + pack + sparse repack, 64 MiB total | 148 MB/s | 75,620,568 bytes cumulative | — |
+| snapshot + verify + loose restore, 64 MiB, one job | 652 MB/s | 71,135,648 bytes cumulative | — |
+| candidate durable loose write, 1 GiB | 294 MB/s | 48,872 bytes | — |
+| candidate verified loose read, 1 GiB | 2,635 MB/s | 12,944 bytes | 1 |
+| candidate snapshot + verify + loose restore, 1 GiB, one job | 954 MB/s | 71,138,880 bytes cumulative | — |
 
 A prebuilt benchmark binary running all seven workloads sequentially peaked at
-111,706,112 bytes (106.5 MiB) resident. Running only the three 1 GiB loose
-candidate workloads peaked at 49,168,384 bytes (46.9 MiB) resident. The full
+110,706,688 bytes (105.6 MiB) resident. Running only the three 1 GiB loose
+candidate workloads peaked at 49,659,904 bytes (47.4 MiB) resident. The full
 suite retains allocator and codec high-water state from prior maintenance, so
 the larger number is the appropriate whole-process capacity baseline. `B/op`
 for compound maintenance and backup rows is cumulative allocation across

--- a/internal/backupapp/resource_benchmark_test.go
+++ b/internal/backupapp/resource_benchmark_test.go
@@ -19,6 +19,8 @@ import (
 	"go.kenn.io/docbank/internal/store"
 )
 
+const candidateLooseBytes = int64(1 << 30)
+
 type resourceNoiseReader struct{ state uint32 }
 
 func (r *resourceNoiseReader) Read(p []byte) (int, error) {
@@ -49,23 +51,15 @@ func (f *resourceFixture) Close() error {
 
 func newResourceFixture(b *testing.B, sizes ...int64) *resourceFixture {
 	b.Helper()
-	root := b.TempDir()
-	metadata, err := store.Open(filepath.Join(root, "docbank.db"))
-	require.NoError(b, err)
-	blobsDir := filepath.Join(root, "blobs")
-	require.NoError(b, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
-	blobs, err := blob.New(store.NewPackCatalog(metadata), blobsDir)
-	require.NoError(b, err)
-	fixture := &resourceFixture{root: root, metadata: metadata, blobs: blobs}
-	b.Cleanup(func() { require.NoError(b, fixture.Close()) })
-	require.NoError(b, blobs.WithMutation(context.Background(), func() error {
+	fixture := newEmptyResourceFixture(b)
+	require.NoError(b, fixture.blobs.WithMutation(context.Background(), func() error {
 		for i, size := range sizes {
-			hash, written, writeErr := blobs.WriteContext(context.Background(),
+			hash, written, writeErr := fixture.blobs.WriteContext(context.Background(),
 				io.LimitReader(&resourceNoiseReader{state: uint32(i + 1)}, size))
 			if writeErr != nil {
 				return writeErr
 			}
-			node, createErr := metadata.CreateFile(context.Background(), metadata.RootID(),
+			node, createErr := fixture.metadata.CreateFile(context.Background(), fixture.metadata.RootID(),
 				fmt.Sprintf("resource-%d.bin", i), hash, written, "application/octet-stream")
 			if createErr != nil {
 				return createErr
@@ -75,6 +69,57 @@ func newResourceFixture(b *testing.B, sizes ...int64) *resourceFixture {
 		return nil
 	}))
 	return fixture
+}
+
+func newEmptyResourceFixture(b *testing.B) *resourceFixture {
+	b.Helper()
+	root := b.TempDir()
+	metadata, err := store.Open(filepath.Join(root, "docbank.db"))
+	require.NoError(b, err)
+	blobsDir := filepath.Join(root, "blobs")
+	require.NoError(b, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
+	blobs, err := blob.New(store.NewPackCatalog(metadata), blobsDir)
+	require.NoError(b, err)
+	fixture := &resourceFixture{root: root, metadata: metadata, blobs: blobs}
+	b.Cleanup(func() { require.NoError(b, fixture.Close()) })
+	return fixture
+}
+
+// addCandidateLoose models a higher admission ceiling without changing the
+// production MaxBlobBytes policy. It uses the same Kit durable loose write and
+// Docbank mutation/catalog boundary that WriteContext wraps.
+func (f *resourceFixture) addCandidateLoose(ctx context.Context, size int64) error {
+	layout, err := packstore.NewLayout(filepath.Join(f.root, "blobs"), packstore.LayoutOptions{
+		Staging: packstore.StagingStoreDirectory, StagingDir: "tmp",
+	})
+	if err != nil {
+		return fmt.Errorf("creating candidate layout: %w", err)
+	}
+	loose, err := packstore.NewLooseStore(layout)
+	if err != nil {
+		return fmt.Errorf("creating candidate loose store: %w", err)
+	}
+	if err := f.blobs.WithMutation(ctx, func() error {
+		result, writeErr := loose.Write(ctx,
+			io.LimitReader(&resourceNoiseReader{state: 1}, size), packstore.WriteOptions{
+				Durability: packstore.DurablePublication,
+				Dedup:      packstore.VerifyTypeAndSize,
+				MaxBytes:   size,
+			})
+		if writeErr != nil {
+			return fmt.Errorf("writing candidate loose object: %w", writeErr)
+		}
+		node, createErr := f.metadata.CreateFile(ctx, f.metadata.RootID(), "candidate-large.bin",
+			result.Hash.String(), result.Size, "application/octet-stream")
+		if createErr != nil {
+			return fmt.Errorf("authorizing candidate loose object: %w", createErr)
+		}
+		f.nodes = append(f.nodes, node)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("writing candidate through mutation boundary: %w", err)
+	}
+	return nil
 }
 
 func BenchmarkDocbankVerifiedRead64MiB(b *testing.B) {
@@ -151,10 +196,59 @@ func BenchmarkDocbankWritePackRepack64MiB(b *testing.B) {
 
 func BenchmarkDocbankBackupRoundTrip64MiB(b *testing.B) {
 	fixture := newResourceFixture(b, blob.MaxBlobBytes)
+	benchmarkBackupRoundTrip(b, fixture, blob.MaxBlobBytes)
+}
+
+func BenchmarkDocbankCandidateLooseWrite1GiB(b *testing.B) {
+	b.ReportAllocs()
+	b.SetBytes(candidateLooseBytes)
+	for range b.N {
+		fixture := newEmptyResourceFixture(b)
+		require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes))
+		require.NoError(b, fixture.Close())
+	}
+}
+
+func BenchmarkDocbankCandidateLooseRead1GiB(b *testing.B) {
+	fixture := newEmptyResourceFixture(b)
+	require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes))
+	b.ReportAllocs()
+	b.SetBytes(candidateLooseBytes)
+	baselineFDs := 0
+	if entries, err := filepath.Glob("/dev/fd/*"); err == nil {
+		baselineFDs = len(entries)
+	}
+	b.ResetTimer()
+	peakFDs := baselineFDs
+	for range b.N {
+		stream, size, err := fixture.blobs.OpenStream(fixture.nodes[0].BlobHash)
+		require.NoError(b, err)
+		require.Equal(b, candidateLooseBytes, size)
+		if entries, readErr := filepath.Glob("/dev/fd/*"); readErr == nil {
+			peakFDs = max(peakFDs, len(entries))
+		}
+		_, copyErr := io.Copy(io.Discard, stream)
+		require.NoError(b, copyErr)
+		require.True(b, stream.Verified())
+		require.NoError(b, stream.Close())
+	}
+	if baselineFDs > 0 {
+		b.ReportMetric(float64(peakFDs-baselineFDs), "stream-fds")
+	}
+}
+
+func BenchmarkDocbankCandidateLooseBackupRoundTrip1GiB(b *testing.B) {
+	fixture := newEmptyResourceFixture(b)
+	require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes))
+	benchmarkBackupRoundTrip(b, fixture, candidateLooseBytes)
+}
+
+func benchmarkBackupRoundTrip(b *testing.B, fixture *resourceFixture, size int64) {
+	b.Helper()
 	app := backupapp.New("benchmark-version")
 	root := b.TempDir()
 	b.ReportAllocs()
-	b.SetBytes(3 * blob.MaxBlobBytes)
+	b.SetBytes(3 * size)
 	b.ResetTimer()
 	for i := range b.N {
 		repo, err := backup.Init(filepath.Join(root, fmt.Sprintf("repo-%d", i)))

--- a/internal/backupapp/resource_benchmark_test.go
+++ b/internal/backupapp/resource_benchmark_test.go
@@ -1,0 +1,175 @@
+package backupapp_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/backup"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/backupapp"
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/store"
+)
+
+type resourceNoiseReader struct{ state uint32 }
+
+func (r *resourceNoiseReader) Read(p []byte) (int, error) {
+	for i := range p {
+		r.state ^= r.state << 13
+		r.state ^= r.state >> 17
+		r.state ^= r.state << 5
+		p[i] = byte(r.state)
+	}
+	return len(p), nil
+}
+
+type resourceFixture struct {
+	root     string
+	metadata *store.Store
+	blobs    *blob.Store
+	nodes    []store.Node
+	closed   bool
+}
+
+func (f *resourceFixture) Close() error {
+	if f.closed {
+		return nil
+	}
+	f.closed = true
+	return errors.Join(f.blobs.Close(), f.metadata.Close())
+}
+
+func newResourceFixture(b *testing.B, sizes ...int64) *resourceFixture {
+	b.Helper()
+	root := b.TempDir()
+	metadata, err := store.Open(filepath.Join(root, "docbank.db"))
+	require.NoError(b, err)
+	blobsDir := filepath.Join(root, "blobs")
+	require.NoError(b, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
+	blobs, err := blob.New(store.NewPackCatalog(metadata), blobsDir)
+	require.NoError(b, err)
+	fixture := &resourceFixture{root: root, metadata: metadata, blobs: blobs}
+	b.Cleanup(func() { require.NoError(b, fixture.Close()) })
+	require.NoError(b, blobs.WithMutation(context.Background(), func() error {
+		for i, size := range sizes {
+			hash, written, writeErr := blobs.WriteContext(context.Background(),
+				io.LimitReader(&resourceNoiseReader{state: uint32(i + 1)}, size))
+			if writeErr != nil {
+				return writeErr
+			}
+			node, createErr := metadata.CreateFile(context.Background(), metadata.RootID(),
+				fmt.Sprintf("resource-%d.bin", i), hash, written, "application/octet-stream")
+			if createErr != nil {
+				return createErr
+			}
+			fixture.nodes = append(fixture.nodes, node)
+		}
+		return nil
+	}))
+	return fixture
+}
+
+func BenchmarkDocbankVerifiedRead64MiB(b *testing.B) {
+	for _, packed := range []bool{false, true} {
+		name := "loose"
+		if packed {
+			name = "packed"
+		}
+		b.Run(name, func(b *testing.B) {
+			fixture := newResourceFixture(b, blob.MaxBlobBytes)
+			if packed {
+				stats, err := fixture.blobs.Maintainer().Pack(context.Background(), packstore.PackOptions{})
+				require.NoError(b, err)
+				require.Equal(b, 1, stats.BlobsPacked)
+			}
+			b.ReportAllocs()
+			b.SetBytes(blob.MaxBlobBytes)
+			baselineFDs := 0
+			if entries, readErr := filepath.Glob("/dev/fd/*"); readErr == nil {
+				baselineFDs = len(entries)
+			}
+			b.ResetTimer()
+			peakFDs := baselineFDs
+			for range b.N {
+				stream, size, err := fixture.blobs.OpenStream(fixture.nodes[0].BlobHash)
+				require.NoError(b, err)
+				if entries, readErr := filepath.Glob("/dev/fd/*"); readErr == nil {
+					peakFDs = max(peakFDs, len(entries))
+				}
+				require.Equal(b, blob.MaxBlobBytes, size)
+				_, copyErr := io.Copy(io.Discard, stream)
+				require.NoError(b, copyErr)
+				require.True(b, stream.Verified())
+				require.NoError(b, stream.Close())
+			}
+			if baselineFDs > 0 {
+				b.ReportMetric(float64(peakFDs-baselineFDs), "stream-fds")
+			}
+		})
+	}
+}
+
+func BenchmarkDocbankWritePackRepack64MiB(b *testing.B) {
+	part := blob.MaxBlobBytes / 3
+	b.ReportAllocs()
+	b.SetBytes(blob.MaxBlobBytes)
+	for range b.N {
+		fixture := newResourceFixture(b, part, part, blob.MaxBlobBytes-2*part)
+		_, err := fixture.blobs.Maintainer().Pack(context.Background(), packstore.PackOptions{TargetSize: 128 << 20})
+		require.NoError(b, err)
+		require.NoError(b, fixture.blobs.WithMutation(context.Background(), func() error {
+			for _, node := range fixture.nodes[1:] {
+				if _, _, trashErr := fixture.metadata.Trash(context.Background(), node.ID, -1); trashErr != nil {
+					return trashErr
+				}
+			}
+			if _, emptyErr := fixture.metadata.TrashEmpty(context.Background(), 0, true); emptyErr != nil {
+				return emptyErr
+			}
+			return fixture.metadata.DeleteBlobRows(context.Background(),
+				[]string{fixture.nodes[1].BlobHash, fixture.nodes[2].BlobHash})
+		}))
+		stats, err := fixture.blobs.Maintainer().Repack(context.Background(), packstore.RepackOptions{
+			Now: time.Now().UTC().Add(48 * time.Hour),
+			Selection: packstore.RepackSelection{
+				MinAge: time.Nanosecond, MinDeadStored: 1,
+			},
+		})
+		require.NoError(b, err)
+		require.Equal(b, 1, stats.PacksRewritten)
+		require.NoError(b, fixture.Close())
+	}
+}
+
+func BenchmarkDocbankBackupRoundTrip64MiB(b *testing.B) {
+	fixture := newResourceFixture(b, blob.MaxBlobBytes)
+	app := backupapp.New("benchmark-version")
+	root := b.TempDir()
+	b.ReportAllocs()
+	b.SetBytes(3 * blob.MaxBlobBytes)
+	b.ResetTimer()
+	for i := range b.N {
+		repo, err := backup.Init(filepath.Join(root, fmt.Sprintf("repo-%d", i)))
+		require.NoError(b, err)
+		_, err = backup.Create(context.Background(), repo, app, backup.CreateOptions{
+			DBPath:        filepath.Join(fixture.root, "docbank.db"),
+			ContentSource: backupapp.NewContentSource(fixture.blobs), Jobs: 1,
+		})
+		require.NoError(b, err)
+		verified, err := backup.Verify(context.Background(), repo, app, backup.VerifyOptions{Jobs: 1})
+		require.NoError(b, err)
+		require.Empty(b, verified.Problems)
+		_, err = backup.Restore(context.Background(), repo, app, backup.RestoreOptions{
+			TargetDir: filepath.Join(root, fmt.Sprintf("restore-%d", i)), Jobs: 1,
+		})
+		require.NoError(b, err)
+	}
+}

--- a/internal/backupapp/resource_benchmark_test.go
+++ b/internal/backupapp/resource_benchmark_test.go
@@ -88,7 +88,7 @@ func newEmptyResourceFixture(b *testing.B) *resourceFixture {
 // addCandidateLoose models a higher admission ceiling without changing the
 // production MaxBlobBytes policy. It uses the same Kit durable loose write and
 // Docbank mutation/catalog boundary that WriteContext wraps.
-func (f *resourceFixture) addCandidateLoose(ctx context.Context, size int64) error {
+func (f *resourceFixture) addCandidateLoose(ctx context.Context, size int64, index int) error {
 	layout, err := packstore.NewLayout(filepath.Join(f.root, "blobs"), packstore.LayoutOptions{
 		Staging: packstore.StagingStoreDirectory, StagingDir: "tmp",
 	})
@@ -101,7 +101,7 @@ func (f *resourceFixture) addCandidateLoose(ctx context.Context, size int64) err
 	}
 	if err := f.blobs.WithMutation(ctx, func() error {
 		result, writeErr := loose.Write(ctx,
-			io.LimitReader(&resourceNoiseReader{state: 1}, size), packstore.WriteOptions{
+			io.LimitReader(&resourceNoiseReader{state: uint32(index + 1)}, size), packstore.WriteOptions{
 				Durability: packstore.DurablePublication,
 				Dedup:      packstore.VerifyTypeAndSize,
 				MaxBytes:   size,
@@ -109,7 +109,8 @@ func (f *resourceFixture) addCandidateLoose(ctx context.Context, size int64) err
 		if writeErr != nil {
 			return fmt.Errorf("writing candidate loose object: %w", writeErr)
 		}
-		node, createErr := f.metadata.CreateFile(ctx, f.metadata.RootID(), "candidate-large.bin",
+		node, createErr := f.metadata.CreateFile(ctx, f.metadata.RootID(),
+			fmt.Sprintf("candidate-large-%d.bin", index),
 			result.Hash.String(), result.Size, "application/octet-stream")
 		if createErr != nil {
 			return fmt.Errorf("authorizing candidate loose object: %w", createErr)
@@ -145,16 +146,29 @@ func BenchmarkDocbankVerifiedRead64MiB(b *testing.B) {
 			peakFDs := baselineFDs
 			for range b.N {
 				stream, size, err := fixture.blobs.OpenStream(fixture.nodes[0].BlobHash)
-				require.NoError(b, err)
+				if err != nil {
+					b.Fatalf("opening verified stream: %v", err)
+				}
+				b.StopTimer()
 				if entries, readErr := filepath.Glob("/dev/fd/*"); readErr == nil {
 					peakFDs = max(peakFDs, len(entries))
 				}
-				require.Equal(b, blob.MaxBlobBytes, size)
+				b.StartTimer()
+				if size != blob.MaxBlobBytes {
+					b.Fatalf("stream size %d, want %d", size, blob.MaxBlobBytes)
+				}
 				_, copyErr := io.Copy(io.Discard, stream)
-				require.NoError(b, copyErr)
-				require.True(b, stream.Verified())
-				require.NoError(b, stream.Close())
+				if copyErr != nil {
+					b.Fatalf("copying verified stream: %v", copyErr)
+				}
+				if !stream.Verified() {
+					b.Fatal("stream did not verify at EOF")
+				}
+				if closeErr := stream.Close(); closeErr != nil {
+					b.Fatalf("closing verified stream: %v", closeErr)
+				}
 			}
+			b.StopTimer()
 			if baselineFDs > 0 {
 				b.ReportMetric(float64(peakFDs-baselineFDs), "stream-fds")
 			}
@@ -200,18 +214,20 @@ func BenchmarkDocbankBackupRoundTrip64MiB(b *testing.B) {
 }
 
 func BenchmarkDocbankCandidateLooseWrite1GiB(b *testing.B) {
+	fixture := newEmptyResourceFixture(b)
 	b.ReportAllocs()
 	b.SetBytes(candidateLooseBytes)
-	for range b.N {
-		fixture := newEmptyResourceFixture(b)
-		require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes))
-		require.NoError(b, fixture.Close())
+	b.ResetTimer()
+	for i := range b.N {
+		if err := fixture.addCandidateLoose(context.Background(), candidateLooseBytes, i); err != nil {
+			b.Fatalf("writing candidate loose object: %v", err)
+		}
 	}
 }
 
 func BenchmarkDocbankCandidateLooseRead1GiB(b *testing.B) {
 	fixture := newEmptyResourceFixture(b)
-	require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes))
+	require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes, 0))
 	b.ReportAllocs()
 	b.SetBytes(candidateLooseBytes)
 	baselineFDs := 0
@@ -222,16 +238,29 @@ func BenchmarkDocbankCandidateLooseRead1GiB(b *testing.B) {
 	peakFDs := baselineFDs
 	for range b.N {
 		stream, size, err := fixture.blobs.OpenStream(fixture.nodes[0].BlobHash)
-		require.NoError(b, err)
-		require.Equal(b, candidateLooseBytes, size)
+		if err != nil {
+			b.Fatalf("opening candidate stream: %v", err)
+		}
+		b.StopTimer()
 		if entries, readErr := filepath.Glob("/dev/fd/*"); readErr == nil {
 			peakFDs = max(peakFDs, len(entries))
 		}
+		b.StartTimer()
+		if size != candidateLooseBytes {
+			b.Fatalf("stream size %d, want %d", size, candidateLooseBytes)
+		}
 		_, copyErr := io.Copy(io.Discard, stream)
-		require.NoError(b, copyErr)
-		require.True(b, stream.Verified())
-		require.NoError(b, stream.Close())
+		if copyErr != nil {
+			b.Fatalf("copying candidate stream: %v", copyErr)
+		}
+		if !stream.Verified() {
+			b.Fatal("candidate stream did not verify at EOF")
+		}
+		if closeErr := stream.Close(); closeErr != nil {
+			b.Fatalf("closing candidate stream: %v", closeErr)
+		}
 	}
+	b.StopTimer()
 	if baselineFDs > 0 {
 		b.ReportMetric(float64(peakFDs-baselineFDs), "stream-fds")
 	}
@@ -239,7 +268,7 @@ func BenchmarkDocbankCandidateLooseRead1GiB(b *testing.B) {
 
 func BenchmarkDocbankCandidateLooseBackupRoundTrip1GiB(b *testing.B) {
 	fixture := newEmptyResourceFixture(b)
-	require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes))
+	require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes, 0))
 	benchmarkBackupRoundTrip(b, fixture, candidateLooseBytes)
 }
 


### PR DESCRIPTION
Docbank’s storage limits should be application decisions backed by downstream evidence, not inherited from Kit defaults. Kit v0.8 separates authorized loose streaming from packed-read and maintenance limits, which lets us evaluate a larger ingestion ceiling without making large objects packable. The real application still adds SQLite catalog work, mutation ordering, verified-read adaptation, backup orchestration, disk demand, and descriptor concurrency that Kit’s isolated benchmarks cannot quantify for us.

This adds a reproducible real-catalog resource suite for the current 64 MiB packed policy and a proposed 1 GiB loose-only admission policy. The candidate path bypasses only Docbank’s current admission check; it uses Kit’s durable loose writer, Docbank’s mutation and SQLite authority boundary, native verified `OpenStream`, and snapshot/verify/restore adapters. It does not admit the object to packing or change production behavior.

On the current Apple M4 Max / Go 1.26.4 / Kit v0.8.0 baseline, the corrected 1 GiB candidate writes at roughly 294 MB/s with about 49 KiB cumulative allocation, verifies at roughly 2.64 GB/s with about 13 KiB allocation and one descriptor, and completes snapshot/verify/restore at roughly 954 MB/s effective three-pass throughput. Candidate-only peak RSS is 47.4 MiB; the full mixed maintenance and candidate suite peaks at 105.6 MiB after retaining allocator and codec high-water state. The benchmark excludes descriptor sampling and success-assertion overhead, and the living design provides exact prebuilt-binary RSS commands.

Large loose objects avoid pack-preparation scratch, but an incompressible 1 GiB object can require roughly 1 GiB each for live storage, repository storage, and a simultaneous restore target. These results support discussing a split 1 GiB ingestion / 64 MiB packing policy while keeping the actual policy change in a separate PR.