### PR TITLE
Adopt split loose and packed object limits

### DIFF
--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -170,8 +170,8 @@ Two request headers declare the expected identity of the **file part**, not the
 multipart envelope:
 
 - `X-Docbank-Blob-Hash`: canonical lowercase hexadecimal SHA-256;
-- `X-Docbank-Blob-Size`: raw byte length, bounded by docbank's explicit 1 GiB
-  loose-ingestion policy.
+- `X-Docbank-Blob-Size`: raw byte length, bounded by docbank's explicit 4 GiB
+  format-v1 backup ceiling.
 
 The server streams the file once through Kit's durable writer and independently
 computes both values. Only after they match, the closing multipart boundary has
@@ -190,7 +190,7 @@ rather than overwriting an existing document.
 
 Objects through 64 MiB are eligible for packing. Larger accepted objects remain
 loose, but use the same content-hash authority, verified streaming, backup, and
-restore contracts. The 1 GiB admission limit therefore does not imply that a
+restore contracts. The 4 GiB admission limit therefore does not imply that a
 single object will be moved into a pack.
 
 Digest or size disagreement returns `422 digest_mismatch` or

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -170,8 +170,8 @@ Two request headers declare the expected identity of the **file part**, not the
 multipart envelope:
 
 - `X-Docbank-Blob-Hash`: canonical lowercase hexadecimal SHA-256;
-- `X-Docbank-Blob-Size`: raw byte length, bounded by docbank's explicit 64 MiB
-  object policy.
+- `X-Docbank-Blob-Size`: raw byte length, bounded by docbank's explicit 1 GiB
+  loose-ingestion policy.
 
 The server streams the file once through Kit's durable writer and independently
 computes both values. Only after they match, the closing multipart boundary has
@@ -187,6 +187,11 @@ independent requests (concurrently when useful), so one failure never makes the
 success of another file ambiguous and each item can be retried on its own.
 Different content under the same requested name follows normal ingest suffixing
 rather than overwriting an existing document.
+
+Objects through 64 MiB are eligible for packing. Larger accepted objects remain
+loose, but use the same content-hash authority, verified streaming, backup, and
+restore contracts. The 1 GiB admission limit therefore does not imply that a
+single object will be moved into a pack.
 
 Digest or size disagreement returns `422 digest_mismatch` or
 `422 size_mismatch` and grants no new `blobs` row or node authority. Because

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -28,7 +28,7 @@ index, reader cache, recovery state machine, and repacker.
 `kit/packstore` sits above the low-level `kit/pack` format. It provides a mixed
 loose-and-packed content-addressed store, so migration can be gradual and
 interrupted work remains recoverable. Docbank explicitly caps new loose-object
-admission at 1 GiB while keeping packing, packed reads, and packed restore at
+admission at 4 GiB while keeping packing, packed reads, and packed restore at
 64 MiB. These are application policies rather than inherited Kit defaults, so
 upgrading the shared engine cannot silently raise either one. An admitted object
 above 64 MiB remains loose, readable, and eligible for backup; pack maintenance
@@ -87,18 +87,20 @@ end-to-end verification. It does not fork Kit's reader cache, reconciliation,
 or repacker. The existing loose representation remains both the recovery path
 and the staging representation before packing.
 
-The separate limits are deliberate. Verified loose streaming and backup keep a
-1 GiB object within the measured memory envelope, while a 1 GiB pack candidate
-could require about 2.004 GiB of scratch for preparation before frame overhead.
+The separate limits are deliberate. The 4 GiB admission ceiling matches Kit's
+format-v1 raw-object ceiling, preserving backup eligibility for every admitted
+object. Verified loose streaming and backup keep the measured 1 GiB workload
+within the recorded memory envelope, while even a 1 GiB pack candidate could
+require about 2.004 GiB of scratch for preparation before frame overhead.
 Raising the 64 MiB packed-content limit therefore remains a separate decision
 that requires representative measurements of temporary space, descriptors,
 throughput, cancellation, and restore behavior. Active streams can also
 temporarily exceed the idle reader-cache descriptor count.
 
 Large loose objects retain the filesystem tradeoff that packing solves for
-small-object collections. In the incompressible case, operating with one 1 GiB
-object can require roughly 1 GiB in the live vault, another 1 GiB in the backup
-repository, and another 1 GiB in a simultaneous restore target.
+small-object collections. In the incompressible case, one large object can
+require roughly its raw size in the live vault, again in the backup repository,
+and again in a simultaneous restore target.
 
 The `blobs` membership boundary also lets logical features evolve without
 changing physical pack authority.

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -27,11 +27,12 @@ index, reader cache, recovery state machine, and repacker.
 
 `kit/packstore` sits above the low-level `kit/pack` format. It provides a mixed
 loose-and-packed content-addressed store, so migration can be gradual and
-interrupted work remains recoverable. Docbank explicitly caps new content
-objects and pack maintenance at 64 MiB. That is application policy rather than
-an inherited Kit default, so upgrading the shared engine cannot silently raise
-it. Oversized loose objects accepted by an earlier release remain readable and
-eligible for backup, but maintenance leaves them loose.
+interrupted work remains recoverable. Docbank explicitly caps new loose-object
+admission at 1 GiB while keeping packing, packed reads, and packed restore at
+64 MiB. These are application policies rather than inherited Kit defaults, so
+upgrading the shared engine cannot silently raise either one. An admitted object
+above 64 MiB remains loose, readable, and eligible for backup; pack maintenance
+reports it as deferred instead of attempting to prepare it.
 
 ## Ownership boundary
 
@@ -86,13 +87,18 @@ end-to-end verification. It does not fork Kit's reader cache, reconciliation,
 or repacker. The existing loose representation remains both the recovery path
 and the staging representation before packing.
 
-Raising the 64 MiB ceiling is a separate policy decision. It requires
-representative measurements of memory, temporary space, descriptors,
-throughput, cancellation, and restore behavior. Streaming removes
-whole-object heap allocation, but pack preparation can still require roughly
-2.004 times the raw object size in scratch space per concurrent preparation,
-and active streams can temporarily exceed the idle reader-cache descriptor
-count.
+The separate limits are deliberate. Verified loose streaming and backup keep a
+1 GiB object within the measured memory envelope, while a 1 GiB pack candidate
+could require about 2.004 GiB of scratch for preparation before frame overhead.
+Raising the 64 MiB packed-content limit therefore remains a separate decision
+that requires representative measurements of temporary space, descriptors,
+throughput, cancellation, and restore behavior. Active streams can also
+temporarily exceed the idle reader-cache descriptor count.
+
+Large loose objects retain the filesystem tradeoff that packing solves for
+small-object collections. In the incompressible case, operating with one 1 GiB
+object can require roughly 1 GiB in the live vault, another 1 GiB in the backup
+repository, and another 1 GiB in a simultaneous restore target.
 
 The `blobs` membership boundary also lets logical features evolve without
 changing physical pack authority.

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -124,15 +124,16 @@ vault-wide verification, and backup capture must therefore consume through
 that terminal boundary; existence probes retain the buffered open-and-close
 path because they ask about catalog authority, not fresh byte evidence.
 
-Docbank currently uses 64 MiB for two distinct policies: new local and remote
-writes, and Kit's packed-read, maintenance, and packed-restore `BlobBytes`
-limit. Kit v0.8 keeps catalog-authorized oversized loose objects available
-through the same verified `OpenStream`; they remain eligible for backup but not
-packing. Do not add a second Docbank loose-stream adapter or mistake the packed
-limit for a read-availability boundary. Raising either application policy needs
-downstream measurements first: pack preparation can use about 2.004 times raw
-size in scratch per concurrent object, and active stream leases can temporarily
-raise open descriptors above the idle reader-cache bound.
+Docbank deliberately separates two policies. New local and remote writes may
+admit one loose object through 1 GiB. Kit's packed-read, maintenance, and
+packed-restore `BlobBytes` limit remains 64 MiB. Kit v0.8 keeps
+catalog-authorized larger loose objects available through the same verified
+`OpenStream`; they remain eligible for backup but not packing. Do not add a
+second Docbank loose-stream adapter or mistake the packed limit for a
+read-availability boundary. Raising either application policy needs downstream
+measurements first: pack preparation can use about 2.004 times raw size in
+scratch per concurrent object, and active stream leases can temporarily raise
+open descriptors above the idle reader-cache bound.
 
 Repack commits replacement mappings before retiring an old immutable pack. If
 Kit returns `ErrPackRetirementDeferred`, the catalog change must not be rolled
@@ -152,14 +153,14 @@ go test -tags fts5 ./internal/backupapp -run '^$' \
 ```
 
 The peak-RSS figures use a prebuilt test binary so compilation is outside the
-measurement. On macOS, reproduce the full and candidate-only runs with:
+measurement. On macOS, reproduce the full and 1 GiB loose-only runs with:
 
 ```bash
 go test -c -tags fts5 -o /tmp/docbank-resource.test ./internal/backupapp
 /usr/bin/time -l /tmp/docbank-resource.test -test.run '^$' \
   -test.bench '^BenchmarkDocbank' -test.benchtime=1x -test.benchmem -test.count=1
 /usr/bin/time -l /tmp/docbank-resource.test -test.run '^$' \
-  -test.bench '^BenchmarkDocbankCandidateLoose' \
+  -test.bench '^BenchmarkDocbankLoose' \
   -test.benchtime=1x -test.benchmem -test.count=1
 ```
 
@@ -171,17 +172,17 @@ v0.8.0 is:
 
 | Workload | Throughput | Heap allocated per operation | Additional stream descriptors |
 | --- | ---: | ---: | ---: |
-| verified loose read, 64 MiB | 2,622 MB/s | 12,944 bytes | 1 |
-| verified packed read, 64 MiB | 2,132 MB/s | 15,928 bytes | 1 |
-| write + pack + sparse repack, 64 MiB total | 148 MB/s | 75,620,568 bytes cumulative | — |
-| snapshot + verify + loose restore, 64 MiB, one job | 652 MB/s | 71,135,648 bytes cumulative | — |
-| candidate durable loose write, 1 GiB | 294 MB/s | 48,872 bytes | — |
-| candidate verified loose read, 1 GiB | 2,635 MB/s | 12,944 bytes | 1 |
-| candidate snapshot + verify + loose restore, 1 GiB, one job | 954 MB/s | 71,138,880 bytes cumulative | — |
+| verified loose read, 64 MiB | 2,570 MB/s | 12,944 bytes | 1 |
+| verified packed read, 64 MiB | 2,159 MB/s | 15,928 bytes | 1 |
+| write + pack + sparse repack, 64 MiB total | 145 MB/s | 75,589,880 bytes cumulative | — |
+| snapshot + verify + loose restore, 64 MiB, one job | 633 MB/s | 71,131,056 bytes cumulative | — |
+| durable loose write, 1 GiB | 295 MB/s | 49,624 bytes | — |
+| verified loose read, 1 GiB | 2,639 MB/s | 12,944 bytes | 1 |
+| snapshot + verify + loose restore, 1 GiB, one job | 950 MB/s | 49,987,056 bytes cumulative | — |
 
 A prebuilt benchmark binary running all seven workloads sequentially peaked at
-110,706,688 bytes (105.6 MiB) resident. Running only the three 1 GiB loose
-candidate workloads peaked at 49,659,904 bytes (47.4 MiB) resident. The full
+109,953,024 bytes (104.9 MiB) resident. Running only the three 1 GiB loose
+workloads peaked at 49,348,608 bytes (47.1 MiB) resident. The full
 suite retains allocator and codec high-water state from prior maintenance, so
 the larger number is the appropriate whole-process capacity baseline. `B/op`
 for compound maintenance and backup rows is cumulative allocation across
@@ -197,14 +198,14 @@ and each concurrent loose or packed stream can add one descriptor until EOF or
 `Close`. Cancellation and early-close cleanup remain mandatory race-tested
 gates, not benchmark outcomes.
 
-The 1 GiB candidate benchmarks bypass only Docbank's current admission check;
-they use Kit's durable loose writer, Docbank's mutation and SQLite authority
-boundary, native verified `OpenStream`, and the real backup adapters. They do
-not admit the object to packing. This is evidence that a 1 GiB loose-ingestion
-policy can remain bounded while packed maintenance stays at 64 MiB, not a
-performance guarantee or a policy change by itself. Such an object still needs
-roughly its raw size for live storage, repository storage, and a simultaneous
-restore target in the incompressible case.
+The 1 GiB benchmarks exercise Docbank's production admission path, Kit's
+durable loose writer, the mutation and SQLite authority boundary, native
+verified `OpenStream`, and the real backup adapters. They do not admit the
+object to packing. They are the resource evidence for the current 1 GiB
+loose-ingestion policy while packed maintenance stays at 64 MiB, not a
+performance guarantee. Such an object still needs roughly its raw size for
+live storage, repository storage, and a simultaneous restore target in the
+incompressible case.
 
 Any proposal to change admission or maintenance limits, reader slots, or
 backup concurrency must rerun this suite on representative target hardware and

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -125,8 +125,9 @@ that terminal boundary; existence probes retain the buffered open-and-close
 path because they ask about catalog authority, not fresh byte evidence.
 
 Docbank deliberately separates two policies. New local and remote writes may
-admit one loose object through 1 GiB. Kit's packed-read, maintenance, and
-packed-restore `BlobBytes` limit remains 64 MiB. Kit v0.8 keeps
+admit one loose object through 4 GiB, matching the format-v1 backup ceiling.
+Kit's packed-read, maintenance, and packed-restore `BlobBytes` limit remains
+64 MiB. Kit v0.8 keeps
 catalog-authorized larger loose objects available through the same verified
 `OpenStream`; they remain eligible for backup but not packing. Do not add a
 second Docbank loose-stream adapter or mistake the packed limit for a
@@ -198,14 +199,15 @@ and each concurrent loose or packed stream can add one descriptor until EOF or
 `Close`. Cancellation and early-close cleanup remain mandatory race-tested
 gates, not benchmark outcomes.
 
-The 1 GiB benchmarks exercise Docbank's production admission path, Kit's
-durable loose writer, the mutation and SQLite authority boundary, native
+The 1 GiB benchmarks exercise a representative large object through Docbank's
+production admission path, Kit's durable loose writer, the mutation and SQLite
+authority boundary, native
 verified `OpenStream`, and the real backup adapters. They do not admit the
-object to packing. They are the resource evidence for the current 1 GiB
-loose-ingestion policy while packed maintenance stays at 64 MiB, not a
-performance guarantee. Such an object still needs roughly its raw size for
-live storage, repository storage, and a simultaneous restore target in the
-incompressible case.
+object to packing. They are bounded-memory evidence supporting the current
+4 GiB loose-ingestion ceiling while packed maintenance stays at 64 MiB, not a
+measurement of the ceiling itself or a performance guarantee. A large object
+still needs roughly its raw size for live storage, repository storage, and a
+simultaneous restore target in the incompressible case.
 
 Any proposal to change admission or maintenance limits, reader slots, or
 backup concurrency must rerun this suite on representative target hardware and

--- a/internal/api/routes_upload.go
+++ b/internal/api/routes_upload.go
@@ -181,9 +181,9 @@ func parseUploadIdentity(r *http.Request) (int64, string, string, int64, *Error)
 			BlobHashHeader+" must be canonical lowercase SHA-256")
 	}
 	expectedSize, err := strconv.ParseInt(r.Header.Get(BlobSizeHeader), 10, 64)
-	if err != nil || expectedSize < 0 || expectedSize > blob.MaxBlobBytes {
+	if err != nil || expectedSize < 0 || expectedSize > blob.MaxIngestBytes {
 		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "validation",
-			fmt.Sprintf("%s must be between 0 and %d", BlobSizeHeader, blob.MaxBlobBytes))
+			fmt.Sprintf("%s must be between 0 and %d", BlobSizeHeader, blob.MaxIngestBytes))
 	}
 	return parentID, name, expectedHash, expectedSize, nil
 }

--- a/internal/api/routes_upload_test.go
+++ b/internal/api/routes_upload_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -122,6 +123,18 @@ func TestUploadAcceptsEmptyFile(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(body), &receipt))
 	assert.Zero(t, receipt.ComputedSize)
 	assert.Equal(t, in.expectedHash, receipt.ComputedHash)
+}
+
+func TestUploadRejectsDeclaredSizeAboveIngestLimit(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	content := []byte("small envelope")
+	in := uploadRequest{name: "too-large.bin", content: content,
+		expectedHash: uploadIdentity(content), expectedSize: blob.MaxIngestBytes + 1}
+	resp, body := sendUpload(t, ts.URL, ts.Client(), s.RootID(), in)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, strconv.FormatInt(blob.MaxIngestBytes, 10))
+	_, err := s.NodeByPath(t.Context(), "/too-large.bin")
+	require.ErrorIs(t, err, store.ErrNotFound)
 }
 
 func TestUploadRejectsMismatchedEvidenceWithoutAuthority(t *testing.T) {

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -2,8 +2,6 @@ package backupapp_test
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"io"
 	"os"
 	"path/filepath"
@@ -119,23 +117,20 @@ func TestLooseSnapshotVerifyAndRestore(t *testing.T) {
 	require.NoError(t, restoredStore.Close())
 }
 
-func TestOversizedLegacyLooseSnapshotVerifyAndRestore(t *testing.T) {
+func TestLooseAbovePackingLimitSnapshotVerifyAndRestore(t *testing.T) {
 	fixture := newArchiveFixture(t)
-	size := blob.MaxBlobBytes + 1
-	digest := sha256.New()
-	_, err := io.CopyN(digest, zeroReader{}, size)
-	require.NoError(t, err)
-	hash := hex.EncodeToString(digest.Sum(nil))
-	path := filepath.Join(fixture.root, "blobs", hash[:2], hash)
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
-	f, err := os.Create(path)
-	require.NoError(t, err)
-	_, err = io.CopyN(f, zeroReader{}, size)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-	_, err = fixture.metadata.CreateFile(t.Context(), fixture.metadata.RootID(), "legacy-large.bin",
-		hash, size, "application/octet-stream")
-	require.NoError(t, err)
+	size := blob.MaxPackedBlobBytes + 1
+	var hash string
+	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
+		var err error
+		hash, _, err = fixture.blobs.WriteContext(t.Context(), io.LimitReader(zeroReader{}, size))
+		if err != nil {
+			return err
+		}
+		_, err = fixture.metadata.CreateFile(t.Context(), fixture.metadata.RootID(), "large-loose.bin",
+			hash, size, "application/octet-stream")
+		return err
+	}))
 
 	app := backupapp.New("test-version")
 	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))

--- a/internal/backupapp/resource_benchmark_test.go
+++ b/internal/backupapp/resource_benchmark_test.go
@@ -19,8 +19,6 @@ import (
 	"go.kenn.io/docbank/internal/store"
 )
 
-const candidateLooseBytes = int64(1 << 30)
-
 type resourceNoiseReader struct{ state uint32 }
 
 func (r *resourceNoiseReader) Read(p []byte) (int, error) {
@@ -52,22 +50,9 @@ func (f *resourceFixture) Close() error {
 func newResourceFixture(b *testing.B, sizes ...int64) *resourceFixture {
 	b.Helper()
 	fixture := newEmptyResourceFixture(b)
-	require.NoError(b, fixture.blobs.WithMutation(context.Background(), func() error {
-		for i, size := range sizes {
-			hash, written, writeErr := fixture.blobs.WriteContext(context.Background(),
-				io.LimitReader(&resourceNoiseReader{state: uint32(i + 1)}, size))
-			if writeErr != nil {
-				return writeErr
-			}
-			node, createErr := fixture.metadata.CreateFile(context.Background(), fixture.metadata.RootID(),
-				fmt.Sprintf("resource-%d.bin", i), hash, written, "application/octet-stream")
-			if createErr != nil {
-				return createErr
-			}
-			fixture.nodes = append(fixture.nodes, node)
-		}
-		return nil
-	}))
+	for i, size := range sizes {
+		require.NoError(b, fixture.addLoose(context.Background(), size, i))
+	}
 	return fixture
 }
 
@@ -85,40 +70,22 @@ func newEmptyResourceFixture(b *testing.B) *resourceFixture {
 	return fixture
 }
 
-// addCandidateLoose models a higher admission ceiling without changing the
-// production MaxBlobBytes policy. It uses the same Kit durable loose write and
-// Docbank mutation/catalog boundary that WriteContext wraps.
-func (f *resourceFixture) addCandidateLoose(ctx context.Context, size int64, index int) error {
-	layout, err := packstore.NewLayout(filepath.Join(f.root, "blobs"), packstore.LayoutOptions{
-		Staging: packstore.StagingStoreDirectory, StagingDir: "tmp",
-	})
-	if err != nil {
-		return fmt.Errorf("creating candidate layout: %w", err)
-	}
-	loose, err := packstore.NewLooseStore(layout)
-	if err != nil {
-		return fmt.Errorf("creating candidate loose store: %w", err)
-	}
+func (f *resourceFixture) addLoose(ctx context.Context, size int64, index int) error {
 	if err := f.blobs.WithMutation(ctx, func() error {
-		result, writeErr := loose.Write(ctx,
-			io.LimitReader(&resourceNoiseReader{state: uint32(index + 1)}, size), packstore.WriteOptions{
-				Durability: packstore.DurablePublication,
-				Dedup:      packstore.VerifyTypeAndSize,
-				MaxBytes:   size,
-			})
+		hash, written, writeErr := f.blobs.WriteContext(ctx,
+			io.LimitReader(&resourceNoiseReader{state: uint32(index + 1)}, size))
 		if writeErr != nil {
-			return fmt.Errorf("writing candidate loose object: %w", writeErr)
+			return fmt.Errorf("writing loose object: %w", writeErr)
 		}
 		node, createErr := f.metadata.CreateFile(ctx, f.metadata.RootID(),
-			fmt.Sprintf("candidate-large-%d.bin", index),
-			result.Hash.String(), result.Size, "application/octet-stream")
+			fmt.Sprintf("resource-%d.bin", index), hash, written, "application/octet-stream")
 		if createErr != nil {
-			return fmt.Errorf("authorizing candidate loose object: %w", createErr)
+			return fmt.Errorf("authorizing loose object: %w", createErr)
 		}
 		f.nodes = append(f.nodes, node)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("writing candidate through mutation boundary: %w", err)
+		return fmt.Errorf("writing through mutation boundary: %w", err)
 	}
 	return nil
 }
@@ -130,14 +97,14 @@ func BenchmarkDocbankVerifiedRead64MiB(b *testing.B) {
 			name = "packed"
 		}
 		b.Run(name, func(b *testing.B) {
-			fixture := newResourceFixture(b, blob.MaxBlobBytes)
+			fixture := newResourceFixture(b, blob.MaxPackedBlobBytes)
 			if packed {
 				stats, err := fixture.blobs.Maintainer().Pack(context.Background(), packstore.PackOptions{})
 				require.NoError(b, err)
 				require.Equal(b, 1, stats.BlobsPacked)
 			}
 			b.ReportAllocs()
-			b.SetBytes(blob.MaxBlobBytes)
+			b.SetBytes(blob.MaxPackedBlobBytes)
 			baselineFDs := 0
 			if entries, readErr := filepath.Glob("/dev/fd/*"); readErr == nil {
 				baselineFDs = len(entries)
@@ -154,8 +121,8 @@ func BenchmarkDocbankVerifiedRead64MiB(b *testing.B) {
 					peakFDs = max(peakFDs, len(entries))
 				}
 				b.StartTimer()
-				if size != blob.MaxBlobBytes {
-					b.Fatalf("stream size %d, want %d", size, blob.MaxBlobBytes)
+				if size != blob.MaxPackedBlobBytes {
+					b.Fatalf("stream size %d, want %d", size, blob.MaxPackedBlobBytes)
 				}
 				_, copyErr := io.Copy(io.Discard, stream)
 				if copyErr != nil {
@@ -177,11 +144,11 @@ func BenchmarkDocbankVerifiedRead64MiB(b *testing.B) {
 }
 
 func BenchmarkDocbankWritePackRepack64MiB(b *testing.B) {
-	part := blob.MaxBlobBytes / 3
+	part := blob.MaxPackedBlobBytes / 3
 	b.ReportAllocs()
-	b.SetBytes(blob.MaxBlobBytes)
+	b.SetBytes(blob.MaxPackedBlobBytes)
 	for range b.N {
-		fixture := newResourceFixture(b, part, part, blob.MaxBlobBytes-2*part)
+		fixture := newResourceFixture(b, part, part, blob.MaxPackedBlobBytes-2*part)
 		_, err := fixture.blobs.Maintainer().Pack(context.Background(), packstore.PackOptions{TargetSize: 128 << 20})
 		require.NoError(b, err)
 		require.NoError(b, fixture.blobs.WithMutation(context.Background(), func() error {
@@ -209,27 +176,27 @@ func BenchmarkDocbankWritePackRepack64MiB(b *testing.B) {
 }
 
 func BenchmarkDocbankBackupRoundTrip64MiB(b *testing.B) {
-	fixture := newResourceFixture(b, blob.MaxBlobBytes)
-	benchmarkBackupRoundTrip(b, fixture, blob.MaxBlobBytes)
+	fixture := newResourceFixture(b, blob.MaxPackedBlobBytes)
+	benchmarkBackupRoundTrip(b, fixture, blob.MaxPackedBlobBytes)
 }
 
-func BenchmarkDocbankCandidateLooseWrite1GiB(b *testing.B) {
+func BenchmarkDocbankLooseWrite1GiB(b *testing.B) {
 	fixture := newEmptyResourceFixture(b)
 	b.ReportAllocs()
-	b.SetBytes(candidateLooseBytes)
+	b.SetBytes(blob.MaxIngestBytes)
 	b.ResetTimer()
 	for i := range b.N {
-		if err := fixture.addCandidateLoose(context.Background(), candidateLooseBytes, i); err != nil {
-			b.Fatalf("writing candidate loose object: %v", err)
+		if err := fixture.addLoose(context.Background(), blob.MaxIngestBytes, i); err != nil {
+			b.Fatalf("writing loose object: %v", err)
 		}
 	}
 }
 
-func BenchmarkDocbankCandidateLooseRead1GiB(b *testing.B) {
+func BenchmarkDocbankLooseRead1GiB(b *testing.B) {
 	fixture := newEmptyResourceFixture(b)
-	require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes, 0))
+	require.NoError(b, fixture.addLoose(context.Background(), blob.MaxIngestBytes, 0))
 	b.ReportAllocs()
-	b.SetBytes(candidateLooseBytes)
+	b.SetBytes(blob.MaxIngestBytes)
 	baselineFDs := 0
 	if entries, err := filepath.Glob("/dev/fd/*"); err == nil {
 		baselineFDs = len(entries)
@@ -239,25 +206,25 @@ func BenchmarkDocbankCandidateLooseRead1GiB(b *testing.B) {
 	for range b.N {
 		stream, size, err := fixture.blobs.OpenStream(fixture.nodes[0].BlobHash)
 		if err != nil {
-			b.Fatalf("opening candidate stream: %v", err)
+			b.Fatalf("opening loose stream: %v", err)
 		}
 		b.StopTimer()
 		if entries, readErr := filepath.Glob("/dev/fd/*"); readErr == nil {
 			peakFDs = max(peakFDs, len(entries))
 		}
 		b.StartTimer()
-		if size != candidateLooseBytes {
-			b.Fatalf("stream size %d, want %d", size, candidateLooseBytes)
+		if size != blob.MaxIngestBytes {
+			b.Fatalf("stream size %d, want %d", size, blob.MaxIngestBytes)
 		}
 		_, copyErr := io.Copy(io.Discard, stream)
 		if copyErr != nil {
-			b.Fatalf("copying candidate stream: %v", copyErr)
+			b.Fatalf("copying loose stream: %v", copyErr)
 		}
 		if !stream.Verified() {
-			b.Fatal("candidate stream did not verify at EOF")
+			b.Fatal("loose stream did not verify at EOF")
 		}
 		if closeErr := stream.Close(); closeErr != nil {
-			b.Fatalf("closing candidate stream: %v", closeErr)
+			b.Fatalf("closing loose stream: %v", closeErr)
 		}
 	}
 	b.StopTimer()
@@ -266,10 +233,10 @@ func BenchmarkDocbankCandidateLooseRead1GiB(b *testing.B) {
 	}
 }
 
-func BenchmarkDocbankCandidateLooseBackupRoundTrip1GiB(b *testing.B) {
+func BenchmarkDocbankLooseBackupRoundTrip1GiB(b *testing.B) {
 	fixture := newEmptyResourceFixture(b)
-	require.NoError(b, fixture.addCandidateLoose(context.Background(), candidateLooseBytes, 0))
-	benchmarkBackupRoundTrip(b, fixture, candidateLooseBytes)
+	require.NoError(b, fixture.addLoose(context.Background(), blob.MaxIngestBytes, 0))
+	benchmarkBackupRoundTrip(b, fixture, blob.MaxIngestBytes)
 }
 
 func benchmarkBackupRoundTrip(b *testing.B, fixture *resourceFixture, size int64) {

--- a/internal/backupapp/resource_benchmark_test.go
+++ b/internal/backupapp/resource_benchmark_test.go
@@ -19,6 +19,8 @@ import (
 	"go.kenn.io/docbank/internal/store"
 )
 
+const measuredLargeLooseBytes int64 = 1 << 30
+
 type resourceNoiseReader struct{ state uint32 }
 
 func (r *resourceNoiseReader) Read(p []byte) (int, error) {
@@ -183,10 +185,10 @@ func BenchmarkDocbankBackupRoundTrip64MiB(b *testing.B) {
 func BenchmarkDocbankLooseWrite1GiB(b *testing.B) {
 	fixture := newEmptyResourceFixture(b)
 	b.ReportAllocs()
-	b.SetBytes(blob.MaxIngestBytes)
+	b.SetBytes(measuredLargeLooseBytes)
 	b.ResetTimer()
 	for i := range b.N {
-		if err := fixture.addLoose(context.Background(), blob.MaxIngestBytes, i); err != nil {
+		if err := fixture.addLoose(context.Background(), measuredLargeLooseBytes, i); err != nil {
 			b.Fatalf("writing loose object: %v", err)
 		}
 	}
@@ -194,9 +196,9 @@ func BenchmarkDocbankLooseWrite1GiB(b *testing.B) {
 
 func BenchmarkDocbankLooseRead1GiB(b *testing.B) {
 	fixture := newEmptyResourceFixture(b)
-	require.NoError(b, fixture.addLoose(context.Background(), blob.MaxIngestBytes, 0))
+	require.NoError(b, fixture.addLoose(context.Background(), measuredLargeLooseBytes, 0))
 	b.ReportAllocs()
-	b.SetBytes(blob.MaxIngestBytes)
+	b.SetBytes(measuredLargeLooseBytes)
 	baselineFDs := 0
 	if entries, err := filepath.Glob("/dev/fd/*"); err == nil {
 		baselineFDs = len(entries)
@@ -213,8 +215,8 @@ func BenchmarkDocbankLooseRead1GiB(b *testing.B) {
 			peakFDs = max(peakFDs, len(entries))
 		}
 		b.StartTimer()
-		if size != blob.MaxIngestBytes {
-			b.Fatalf("stream size %d, want %d", size, blob.MaxIngestBytes)
+		if size != measuredLargeLooseBytes {
+			b.Fatalf("stream size %d, want %d", size, measuredLargeLooseBytes)
 		}
 		_, copyErr := io.Copy(io.Discard, stream)
 		if copyErr != nil {
@@ -235,8 +237,8 @@ func BenchmarkDocbankLooseRead1GiB(b *testing.B) {
 
 func BenchmarkDocbankLooseBackupRoundTrip1GiB(b *testing.B) {
 	fixture := newEmptyResourceFixture(b)
-	require.NoError(b, fixture.addLoose(context.Background(), blob.MaxIngestBytes, 0))
-	benchmarkBackupRoundTrip(b, fixture, blob.MaxIngestBytes)
+	require.NoError(b, fixture.addLoose(context.Background(), measuredLargeLooseBytes, 0))
+	benchmarkBackupRoundTrip(b, fixture, measuredLargeLooseBytes)
 }
 
 func benchmarkBackupRoundTrip(b *testing.B, fixture *resourceFixture, size int64) {

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"go.kenn.io/kit/pack"
 	"go.kenn.io/kit/packstore"
 )
 
@@ -18,8 +19,10 @@ import (
 var ErrInvalidHash = packstore.ErrInvalidHash
 
 const (
-	// MaxIngestBytes is docbank's admission policy for a new loose object.
-	MaxIngestBytes int64 = 1 << 30
+	// MaxIngestBytes is docbank's admission policy for a new loose object. It
+	// matches the format-v1 raw-object ceiling so every admitted object remains
+	// eligible for backup.
+	MaxIngestBytes int64 = int64(pack.MaxRawLen)
 
 	// MaxPackedBlobBytes is docbank's policy for packing, packed reads, and
 	// packed restore. Larger admitted objects remain authoritative loose blobs.

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -17,16 +17,20 @@ import (
 // ErrInvalidHash reports a value that is not canonical lowercase SHA-256.
 var ErrInvalidHash = packstore.ErrInvalidHash
 
-// MaxBlobBytes is docbank's current admission and packed-content policy for one
-// object. Keep it explicit: a future Kit default must not silently change
-// docbank writes, packed reads, maintenance, or packed restore.
-const MaxBlobBytes int64 = 64 << 20
+const (
+	// MaxIngestBytes is docbank's admission policy for a new loose object.
+	MaxIngestBytes int64 = 1 << 30
+
+	// MaxPackedBlobBytes is docbank's policy for packing, packed reads, and
+	// packed restore. Larger admitted objects remain authoritative loose blobs.
+	MaxPackedBlobBytes int64 = 64 << 20
+)
 
 // StorageLimits returns Kit's packed-read and maintenance limits with
 // docbank's current packed-object policy.
 func StorageLimits() packstore.Limits {
 	limits := packstore.DefaultLimits()
-	limits.BlobBytes = MaxBlobBytes
+	limits.BlobBytes = MaxPackedBlobBytes
 	return limits
 }
 
@@ -180,7 +184,7 @@ func (s *Store) WriteContext(ctx context.Context, r io.Reader) (string, int64, e
 	result, err := s.loose.Write(ctx, r, packstore.WriteOptions{
 		Durability: packstore.DurablePublication,
 		Dedup:      packstore.VerifyTypeAndSize,
-		MaxBytes:   MaxBlobBytes,
+		MaxBytes:   MaxIngestBytes,
 	})
 	if err != nil {
 		return "", 0, fmt.Errorf("writing blob: %w", err)

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -28,7 +28,7 @@ func newTestBlobStore(t *testing.T) *Store {
 }
 
 func TestStoragePolicyKeepsBlobLimitExplicit(t *testing.T) {
-	assert.Equal(t, MaxIngestBytes, int64(1<<30))
+	assert.Equal(t, MaxIngestBytes, int64(1<<32))
 	assert.Equal(t, MaxPackedBlobBytes, int64(64<<20))
 	assert.Equal(t, MaxPackedBlobBytes, StorageLimits().BlobBytes)
 }

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -28,39 +28,24 @@ func newTestBlobStore(t *testing.T) *Store {
 }
 
 func TestStoragePolicyKeepsBlobLimitExplicit(t *testing.T) {
-	assert.Equal(t, MaxBlobBytes, int64(64<<20))
-	assert.Equal(t, MaxBlobBytes, StorageLimits().BlobBytes)
+	assert.Equal(t, MaxIngestBytes, int64(1<<30))
+	assert.Equal(t, MaxPackedBlobBytes, int64(64<<20))
+	assert.Equal(t, MaxPackedBlobBytes, StorageLimits().BlobBytes)
 }
 
-func TestWriteEnforcesBlobLimit(t *testing.T) {
+func TestWriteAcceptsLooseBlobAbovePackingLimit(t *testing.T) {
 	bs := newTestBlobStore(t)
-	hash, size, err := bs.Write(io.LimitReader(zeroReader{}, MaxBlobBytes+1))
-	require.ErrorIs(t, err, packstore.ErrContentMismatch)
-	assert.Empty(t, hash)
-	assert.Zero(t, size)
-}
-
-func TestOpenStreamReadsLooseBlobAbovePackingLimit(t *testing.T) {
-	bs := newTestBlobStore(t)
-	size := MaxBlobBytes + 1
-	digest := sha256.New()
-	_, err := io.CopyN(digest, zeroReader{}, size)
+	wantSize := MaxPackedBlobBytes + 1
+	hash, size, err := bs.Write(io.LimitReader(zeroReader{}, wantSize))
 	require.NoError(t, err)
-	hash := hex.EncodeToString(digest.Sum(nil))
-	path := bs.path(hash)
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
-	f, err := os.Create(path)
-	require.NoError(t, err)
-	_, err = io.CopyN(f, zeroReader{}, size)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
+	assert.Equal(t, wantSize, size)
 
 	stream, gotSize, err := bs.OpenStream(hash)
 	require.NoError(t, err)
-	assert.Equal(t, size, gotSize)
+	assert.Equal(t, wantSize, gotSize)
 	written, err := io.Copy(io.Discard, stream)
 	require.NoError(t, err)
-	assert.Equal(t, size, written)
+	assert.Equal(t, wantSize, written)
 	assert.True(t, stream.Verified())
 	require.NoError(t, stream.Close())
 }


### PR DESCRIPTION
Kit v0.8 lets Docbank separate whether a loose object remains readable from whether it is safe to prepare and maintain inside a pack. Keeping one 64 MiB ceiling rejects useful large documents without buying additional read-memory safety; raising that same ceiling everywhere would expose routine maintenance to multi-gigabyte scratch demand.

This adopts the structural middle ground: local and remote ingestion accept loose objects through Kit format v1’s 4 GiB raw-object ceiling, so every authoritative object remains backup-eligible. Packing, packed reads, and packed restore retain the explicit 64 MiB policy. Objects above that threshold remain verified, authoritative, and backup-eligible, but maintenance defers them instead of packing them. The resource suite measures a representative 1 GiB object through the actual production writer rather than presenting the benchmark size as product policy.

The full test suite, lint, vet, pre-commit hooks, and strict documentation build pass. A one-operation production-path resource run measured roughly 295 MB/s for 1 GiB durable writes, 2.64 GB/s for verified reads, and 104.9 MiB peak RSS across the complete seven-workload benchmark process.