### PR TITLE
Define logical JSONL metadata round trips

### DIFF
--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -31,7 +31,9 @@ FTS rows and physical pack mappings: search indexes are rebuilt by importing
 nodes, while restore grants physical authority only after content has been
 verified and published. Import targets must be fresh current-schema databases;
 a malformed or referentially incomplete stream leaves the pristine target
-unchanged.
+unchanged. The header also preserves the node-ID allocation high-water mark,
+including IDs whose rows were later deleted, so restore never reuses a value
+that an external reference may remember.
 
 Capture reads loose and packed blobs through Kit's bounded-memory stream. The
 archive may grant authority to copied bytes only after terminal EOF verifies

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -23,6 +23,16 @@ tests prove loose create/verify/restore and capture directly from a packed live
 store. Physical pack tables are excluded from fidelity stats so a restore may
 choose a different representation without changing the archive.
 
+Docbank also has a deterministic, versioned JSONL representation of its logical
+metadata. It contains the complete virtual directory tree and file records,
+including stable IDs, content hashes, timestamps, trash coordinates, prior
+versions, ingest provenance, tags, and extracted text. It intentionally omits
+FTS rows and physical pack mappings: search indexes are rebuilt by importing
+nodes, while restore grants physical authority only after content has been
+verified and published. Import targets must be fresh current-schema databases;
+a malformed or referentially incomplete stream leaves the pristine target
+unchanged.
+
 Capture reads loose and packed blobs through Kit's bounded-memory stream. The
 archive may grant authority to copied bytes only after terminal EOF verifies
 their stored framing, decoded length, and SHA-256 identity; opening a stream or
@@ -41,6 +51,12 @@ every restored blob through the same mixed store used by a live vault.
     Command/API orchestration has not landed. The completed capture and restore
     adapters are internal and do not make any `docbank backup` command
     available yet.
+
+    Kit currently captures the frozen SQLite database as its metadata artifact.
+    The next integration step is to make the logical JSONL stream the archive's
+    application metadata and rebuild a fresh current-schema database during
+    restore. Until that lands, the JSONL codec alone does not change the bytes
+    in a Kit snapshot.
 
     The planned command family is `docbank backup init|create|list|verify|restore`.
     Exact flags will enter the CLI reference only when implemented.

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -254,7 +254,10 @@ saved `trash_parent` may be absent when the original directory was hard-deleted;
 `trash_name` remains authoritative and restore then falls back to the tree root.
 When a saved parent is present, import proves it is neither the trash root nor
 one of its descendants, so restore cannot create a cycle from hostile or
-corrupted coordinates.
+corrupted coordinates. Every trashed node must belong to exactly one such root,
+and every member of that subtree must be trashed under the root's exact
+operation timestamp. This mirrors restore's timestamp-scoped update and rejects
+both permanently hidden orphans and live nodes nested beneath trash.
 Explicit node IDs advance SQLite's `AUTOINCREMENT` sequence, preserving the
 invariant that a deleted historical ID is never silently reused.
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -245,7 +245,9 @@ with deferred foreign-key checks. Unknown format versions, unknown record types
 or fields, uniqueness failures, orphaned extraction rows, and dangling
 references abort the transaction. Timestamps must use Docbank's canonical UTC
 representation because retention queries compare their fixed-width strings
-lexicographically.
+lexicographically. The exception is provenance `original_mtime`: it records an
+external filesystem value using canonical UTC `RFC3339Nano`, matching ordinary
+ingestion, and is never used as a retention cutoff.
 Explicit node IDs advance SQLite's `AUTOINCREMENT` sequence, preserving the
 invariant that a deleted historical ID is never silently reused.
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -230,6 +230,9 @@ format version. Records are emitted in dependency-stable order and deterministic
 key order: blobs, nodes, ingests, node versions, provenance, tags, node tags,
 and extracted text. Nodes carry parent IDs, so directory structure, trash
 restore coordinates, and stable external node references survive a roundtrip.
+The header carries SQLite's node `AUTOINCREMENT` high-water mark separately
+from the live rows; import restores it only after proving it is at least the
+maximum surviving node ID.
 
 The stream excludes `nodes_fts`, `blob_packs`, and `blob_pack_index`. FTS is a
 derived index rebuilt by the node insert triggers. Pack tables describe one
@@ -239,7 +242,10 @@ chosen loose or packed representation before installing fresh catalog mappings.
 
 Import runs only against a pristine current-schema database, in one transaction
 with deferred foreign-key checks. Unknown format versions, unknown record types
-or fields, uniqueness failures, and dangling references abort the transaction.
+or fields, uniqueness failures, orphaned extraction rows, and dangling
+references abort the transaction. Timestamps must use Docbank's canonical UTC
+representation because retention queries compare their fixed-width strings
+lexicographically.
 Explicit node IDs advance SQLite's `AUTOINCREMENT` sequence, preserving the
 invariant that a deleted historical ID is never silently reused.
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -248,6 +248,13 @@ representation because retention queries compare their fixed-width strings
 lexicographically. The exception is provenance `original_mtime`: it records an
 external filesystem value using canonical UTC `RFC3339Nano`, matching ordinary
 ingestion, and is never used as a retention cutoff.
+
+Trash roots remain detached beneath the tree root in portable metadata. Their
+saved `trash_parent` may be absent when the original directory was hard-deleted;
+`trash_name` remains authoritative and restore then falls back to the tree root.
+When a saved parent is present, import proves it is neither the trash root nor
+one of its descendants, so restore cannot create a cycle from hostile or
+corrupted coordinates.
 Explicit node IDs advance SQLite's `AUTOINCREMENT` sequence, preserving the
 invariant that a deleted historical ID is never silently reused.
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -221,6 +221,36 @@ Docbank owns:
 - trash, version, provenance, and future external-reference semantics;
 - daemon commands, scheduling, logging, and product output.
 
+## Logical metadata portability
+
+SQLite is Docbank's runtime query and transaction engine, but its historical
+page layout is not the intended long-lived backup contract. The logical
+boundary is deterministic JSONL headed by `docbank-metadata` and an integer
+format version. Records are emitted in dependency-stable order and deterministic
+key order: blobs, nodes, ingests, node versions, provenance, tags, node tags,
+and extracted text. Nodes carry parent IDs, so directory structure, trash
+restore coordinates, and stable external node references survive a roundtrip.
+
+The stream excludes `nodes_fts`, `blob_packs`, and `blob_pack_index`. FTS is a
+derived index rebuilt by the node insert triggers. Pack tables describe one
+physical representation and must never regain authority merely because an old
+metadata snapshot mentioned offsets; Kit restore verifies and publishes the
+chosen loose or packed representation before installing fresh catalog mappings.
+
+Import runs only against a pristine current-schema database, in one transaction
+with deferred foreign-key checks. Unknown format versions, unknown record types
+or fields, uniqueness failures, and dangling references abort the transaction.
+Explicit node IDs advance SQLite's `AUTOINCREMENT` sequence, preserving the
+invariant that a deleted historical ID is never silently reused.
+
+This boundary replaces in-place schema evolution with export → construct a
+fresh current-schema database → import → verify → atomic replacement. It does
+not make compatibility work disappear: each supported JSONL version needs an
+explicit decoder, and a live cutover must carry current physical pack authority
+through a separately verified path. The current codec establishes version 1;
+automatic database replacement and Kit metadata-artifact integration remain
+follow-up work.
+
 Do not move docbank SQL or reachability policy into Kit. Do not reimplement Kit
 reader or lifecycle mechanics in docbank. A physical-storage bug shared by
 msgvault belongs in Kit; a decision about whether a docbank reference keeps a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,7 +114,11 @@ operations — anything the TUI does, the API can do.
 ([design](architecture/backup.md)).
 
 The internal Kit application adapter, loose/packed capture proof, and atomic
-packed restore publication are implemented. Command/API orchestration remains.
+packed restore publication are implemented. Docbank's deterministic logical
+JSONL codec also round-trips directory structure, stable node IDs, content
+membership, trash state, versions, provenance, tags, and extraction state into
+a fresh current-schema database. Kit metadata-artifact integration and
+command/API orchestration remain.
 
 ## Deferred beyond v1
 

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -1,0 +1,694 @@
+package store
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"go.kenn.io/kit/packstore"
+)
+
+const metadataFormatVersion = 1
+
+type metadataHeader struct {
+	Type    string `json:"type"`
+	Format  string `json:"format"`
+	Version int    `json:"version"`
+}
+
+type metadataBlob struct {
+	Type      string `json:"type"`
+	Hash      string `json:"hash"`
+	Size      int64  `json:"size"`
+	CreatedAt string `json:"created_at"`
+}
+
+type metadataNode struct {
+	Type        string  `json:"type"`
+	ID          int64   `json:"id"`
+	ParentID    *int64  `json:"parent_id"`
+	Name        string  `json:"name"`
+	Kind        string  `json:"kind"`
+	BlobHash    *string `json:"blob_hash"`
+	Size        *int64  `json:"size"`
+	MIMEType    *string `json:"mime_type"`
+	Revision    int64   `json:"revision"`
+	CreatedAt   string  `json:"created_at"`
+	ModifiedAt  string  `json:"modified_at"`
+	TrashedAt   *string `json:"trashed_at"`
+	TrashParent *int64  `json:"trash_parent"`
+	TrashName   *string `json:"trash_name"`
+}
+
+type metadataNodeVersion struct {
+	Type       string `json:"type"`
+	NodeID     int64  `json:"node_id"`
+	BlobHash   string `json:"blob_hash"`
+	Size       int64  `json:"size"`
+	ReplacedAt string `json:"replaced_at"`
+}
+
+type metadataIngest struct {
+	Type       string `json:"type"`
+	ID         int64  `json:"id"`
+	StartedAt  string `json:"started_at"`
+	SourceKind string `json:"source_kind"`
+	SourceDesc string `json:"source_desc"`
+}
+
+type metadataProvenance struct {
+	Type          string  `json:"type"`
+	NodeID        int64   `json:"node_id"`
+	IngestID      int64   `json:"ingest_id"`
+	OriginalPath  string  `json:"original_path"`
+	OriginalMTime *string `json:"original_mtime"`
+}
+
+type metadataTag struct {
+	Type string `json:"type"`
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type metadataNodeTag struct {
+	Type   string `json:"type"`
+	NodeID int64  `json:"node_id"`
+	TagID  int64  `json:"tag_id"`
+}
+
+type metadataExtractedText struct {
+	Type             string  `json:"type"`
+	BlobHash         string  `json:"blob_hash"`
+	Extractor        string  `json:"extractor"`
+	ExtractorVersion int64   `json:"extractor_version"`
+	Status           string  `json:"status"`
+	Error            *string `json:"error"`
+	Attempts         int64   `json:"attempts"`
+	Text             *string `json:"text"`
+	ExtractedAt      string  `json:"extracted_at"`
+}
+
+// ExportMetadata writes a deterministic JSONL description of Docbank's
+// logical state. Rebuildable FTS data and physical pack authority are omitted.
+func (s *Store) ExportMetadata(ctx context.Context, w io.Writer) error {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return fmt.Errorf("beginning metadata snapshot: %w", err)
+	}
+	if err := ExportMetadataTx(ctx, tx, w); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing metadata snapshot: %w", err)
+	}
+	return nil
+}
+
+// ExportMetadataTx writes metadata from an already pinned SQLite snapshot.
+// Backup capture uses this entry point so metadata and blob membership come
+// from the same frozen transaction.
+func ExportMetadataTx(ctx context.Context, tx *sql.Tx, w io.Writer) error {
+	if tx == nil {
+		return errors.New("exporting metadata: nil transaction")
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	write := func(v any) error {
+		if err := enc.Encode(v); err != nil {
+			return fmt.Errorf("encoding metadata: %w", err)
+		}
+		return nil
+	}
+	if err := write(metadataHeader{Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion}); err != nil {
+		return err
+	}
+	if err := exportBlobs(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportNodes(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportIngests(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportNodeVersions(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportProvenance(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportTags(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportNodeTags(ctx, tx, write); err != nil {
+		return err
+	}
+	return exportExtractedText(ctx, tx, write)
+}
+
+type metadataWrite func(any) error
+
+func exportBlobs(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT hash, size, created_at FROM blobs ORDER BY hash`)
+	if err != nil {
+		return fmt.Errorf("exporting blobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		r := metadataBlob{Type: "blob"}
+		if err := rows.Scan(&r.Hash, &r.Size, &r.CreatedAt); err != nil {
+			return fmt.Errorf("scanning blob metadata: %w", err)
+		}
+		if err := write(r); err != nil {
+			return err
+		}
+	}
+	return rowsError("blob", rows)
+}
+
+func exportNodes(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, parent_id, name, kind, blob_hash, size, mime_type, revision,
+		       created_at, modified_at, trashed_at, trash_parent, trash_name
+		FROM nodes ORDER BY id`)
+	if err != nil {
+		return fmt.Errorf("exporting nodes: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		r := metadataNode{Type: "node"}
+		var parent, size, trashParent sql.NullInt64
+		var blobHash, mimeType, trashedAt, trashName sql.NullString
+		if err := rows.Scan(&r.ID, &parent, &r.Name, &r.Kind, &blobHash, &size, &mimeType,
+			&r.Revision, &r.CreatedAt, &r.ModifiedAt, &trashedAt, &trashParent, &trashName); err != nil {
+			return fmt.Errorf("scanning node metadata: %w", err)
+		}
+		r.ParentID, r.Size, r.TrashParent = int64Ptr(parent), int64Ptr(size), int64Ptr(trashParent)
+		r.BlobHash, r.MIMEType = stringPtr(blobHash), stringPtr(mimeType)
+		r.TrashedAt, r.TrashName = stringPtr(trashedAt), stringPtr(trashName)
+		if err := write(r); err != nil {
+			return err
+		}
+	}
+	return rowsError("node", rows)
+}
+
+func exportNodeVersions(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT node_id, blob_hash, size, replaced_at FROM node_versions
+		ORDER BY node_id, replaced_at, blob_hash, size`)
+	if err != nil {
+		return fmt.Errorf("exporting node versions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		r := metadataNodeVersion{Type: "node_version"}
+		if err := rows.Scan(&r.NodeID, &r.BlobHash, &r.Size, &r.ReplacedAt); err != nil {
+			return fmt.Errorf("scanning node version metadata: %w", err)
+		}
+		if err := write(r); err != nil {
+			return err
+		}
+	}
+	return rowsError("node version", rows)
+}
+
+func exportIngests(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT id, started_at, source_kind, source_desc FROM ingests ORDER BY id`)
+	if err != nil {
+		return fmt.Errorf("exporting ingests: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		r := metadataIngest{Type: "ingest"}
+		if err := rows.Scan(&r.ID, &r.StartedAt, &r.SourceKind, &r.SourceDesc); err != nil {
+			return fmt.Errorf("scanning ingest metadata: %w", err)
+		}
+		if err := write(r); err != nil {
+			return err
+		}
+	}
+	return rowsError("ingest", rows)
+}
+
+func exportProvenance(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT node_id, ingest_id, original_path, original_mtime FROM provenance
+		ORDER BY node_id, ingest_id, original_path, original_mtime`)
+	if err != nil {
+		return fmt.Errorf("exporting provenance: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		r := metadataProvenance{Type: "provenance"}
+		var mtime sql.NullString
+		if err := rows.Scan(&r.NodeID, &r.IngestID, &r.OriginalPath, &mtime); err != nil {
+			return fmt.Errorf("scanning provenance metadata: %w", err)
+		}
+		r.OriginalMTime = stringPtr(mtime)
+		if err := write(r); err != nil {
+			return err
+		}
+	}
+	return rowsError("provenance", rows)
+}
+
+func exportTags(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT id, name FROM tags ORDER BY id`)
+	if err != nil {
+		return fmt.Errorf("exporting tags: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		r := metadataTag{Type: "tag"}
+		if err := rows.Scan(&r.ID, &r.Name); err != nil {
+			return fmt.Errorf("scanning tag metadata: %w", err)
+		}
+		if err := write(r); err != nil {
+			return err
+		}
+	}
+	return rowsError("tag", rows)
+}
+
+func exportNodeTags(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT node_id, tag_id FROM node_tags ORDER BY node_id, tag_id`)
+	if err != nil {
+		return fmt.Errorf("exporting node tags: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		r := metadataNodeTag{Type: "node_tag"}
+		if err := rows.Scan(&r.NodeID, &r.TagID); err != nil {
+			return fmt.Errorf("scanning node tag metadata: %w", err)
+		}
+		if err := write(r); err != nil {
+			return err
+		}
+	}
+	return rowsError("node tag", rows)
+}
+
+func exportExtractedText(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT blob_hash, extractor, extractor_version, status, error, attempts, text, extracted_at
+		FROM extracted_text ORDER BY blob_hash, extractor`)
+	if err != nil {
+		return fmt.Errorf("exporting extracted text: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		r := metadataExtractedText{Type: "extracted_text"}
+		var extractErr, text sql.NullString
+		if err := rows.Scan(&r.BlobHash, &r.Extractor, &r.ExtractorVersion, &r.Status,
+			&extractErr, &r.Attempts, &text, &r.ExtractedAt); err != nil {
+			return fmt.Errorf("scanning extracted text metadata: %w", err)
+		}
+		r.Error, r.Text = stringPtr(extractErr), stringPtr(text)
+		if err := write(r); err != nil {
+			return err
+		}
+	}
+	return rowsError("extracted text", rows)
+}
+
+func rowsError(kind string, rows *sql.Rows) error {
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating %s metadata: %w", kind, err)
+	}
+	return nil
+}
+
+func int64Ptr(v sql.NullInt64) *int64 {
+	if !v.Valid {
+		return nil
+	}
+	return &v.Int64
+}
+
+func stringPtr(v sql.NullString) *string {
+	if !v.Valid {
+		return nil
+	}
+	return &v.String
+}
+
+// ImportMetadata replaces the pristine root in a newly created store with a
+// logical JSONL snapshot. It refuses a store containing user or pack state.
+func (s *Store) ImportMetadata(ctx context.Context, r io.Reader) error {
+	rootID := int64(0)
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := requirePristineMetadataTarget(ctx, tx); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM nodes`); err != nil {
+			return fmt.Errorf("removing bootstrap root: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `PRAGMA defer_foreign_keys = ON`); err != nil {
+			return fmt.Errorf("deferring metadata foreign keys: %w", err)
+		}
+		if err := importMetadataLines(ctx, tx, r); err != nil {
+			return err
+		}
+		if err := validateImportedMetadata(ctx, tx); err != nil {
+			return err
+		}
+		if err := tx.QueryRowContext(ctx, `SELECT id FROM nodes WHERE parent_id IS NULL`).Scan(&rootID); err != nil {
+			return fmt.Errorf("finding imported root: %w", err)
+		}
+		rows, err := tx.QueryContext(ctx, `PRAGMA foreign_key_check`)
+		if err != nil {
+			return fmt.Errorf("checking imported foreign keys: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		if rows.Next() {
+			var table string
+			var rowID, parent any
+			var fk int64
+			if err := rows.Scan(&table, &rowID, &parent, &fk); err != nil {
+				return fmt.Errorf("reading imported foreign-key failure: %w", err)
+			}
+			return fmt.Errorf("imported metadata violates foreign key %s[%v] constraint %d", table, rowID, fk)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return err
+	}
+	s.rootID = rootID
+	return nil
+}
+
+func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
+	var nodes, other, packs int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT
+		  (SELECT COUNT(*) FROM nodes),
+		  (SELECT COUNT(*) FROM blobs) + (SELECT COUNT(*) FROM node_versions)
+		    + (SELECT COUNT(*) FROM ingests) + (SELECT COUNT(*) FROM provenance)
+		    + (SELECT COUNT(*) FROM tags) + (SELECT COUNT(*) FROM node_tags)
+		    + (SELECT COUNT(*) FROM extracted_text),
+		  (SELECT COUNT(*) FROM blob_packs) + (SELECT COUNT(*) FROM blob_pack_index)
+	`).Scan(&nodes, &other, &packs); err != nil {
+		return fmt.Errorf("checking metadata import target: %w", err)
+	}
+	if nodes != 1 || other != 0 || packs != 0 {
+		return fmt.Errorf("metadata import target is not pristine: nodes=%d logical_rows=%d pack_rows=%d",
+			nodes, other, packs)
+	}
+	return nil
+}
+
+func importMetadataLines(ctx context.Context, tx *sql.Tx, r io.Reader) error {
+	dec := json.NewDecoder(bufio.NewReader(r))
+	dec.DisallowUnknownFields()
+	var header metadataHeader
+	if err := dec.Decode(&header); err != nil {
+		return fmt.Errorf("decoding metadata header: %w", err)
+	}
+	if header != (metadataHeader{Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion}) {
+		return fmt.Errorf("unsupported metadata header: type=%q format=%q version=%d",
+			header.Type, header.Format, header.Version)
+	}
+	for record := 2; ; record++ {
+		var raw json.RawMessage
+		err := dec.Decode(&raw)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("decoding metadata record %d: %w", record, err)
+		}
+		var kind struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(raw, &kind); err != nil {
+			return fmt.Errorf("decoding metadata record %d type: %w", record, err)
+		}
+		if err := importMetadataRecord(ctx, tx, kind.Type, raw); err != nil {
+			return fmt.Errorf("importing metadata record %d (%s): %w", record, kind.Type, err)
+		}
+	}
+}
+
+func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json.RawMessage) error {
+	required, ok := metadataRequiredFields[kind]
+	if !ok {
+		return fmt.Errorf("unknown record type %q", kind)
+	}
+	if err := requireMetadataFields(raw, required); err != nil {
+		return err
+	}
+	decode := func(dst any) error {
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.DisallowUnknownFields()
+		return dec.Decode(dst)
+	}
+	switch kind {
+	case "blob":
+		var v metadataBlob
+		if err := decode(&v); err != nil {
+			return err
+		}
+		if err := validateBlobRecord(v); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO blobs(hash,size,created_at) VALUES(?,?,?)`, v.Hash, v.Size, v.CreatedAt)
+		return err
+	case "node":
+		var v metadataNode
+		if err := decode(&v); err != nil {
+			return err
+		}
+		if err := validateNodeRecord(v); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO nodes(id,parent_id,name,kind,blob_hash,size,mime_type,revision,created_at,modified_at,trashed_at,trash_parent,trash_name) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			v.ID, v.ParentID, v.Name, v.Kind, v.BlobHash, v.Size, v.MIMEType, v.Revision, v.CreatedAt, v.ModifiedAt, v.TrashedAt, v.TrashParent, v.TrashName)
+		return err
+	case "node_version":
+		var v metadataNodeVersion
+		if err := decode(&v); err != nil {
+			return err
+		}
+		if err := validateNodeVersionRecord(v); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO node_versions(node_id,blob_hash,size,replaced_at) VALUES(?,?,?,?)`, v.NodeID, v.BlobHash, v.Size, v.ReplacedAt)
+		return err
+	case "ingest":
+		var v metadataIngest
+		if err := decode(&v); err != nil {
+			return err
+		}
+		if v.Type != kind || v.ID <= 0 || v.SourceKind == "" || v.SourceDesc == "" {
+			return errors.New("invalid ingest record")
+		}
+		if err := validateMetadataTime("ingest started_at", v.StartedAt); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO ingests(id,started_at,source_kind,source_desc) VALUES(?,?,?,?)`, v.ID, v.StartedAt, v.SourceKind, v.SourceDesc)
+		return err
+	case "provenance":
+		var v metadataProvenance
+		if err := decode(&v); err != nil {
+			return err
+		}
+		if v.Type != kind || v.NodeID <= 0 || v.IngestID <= 0 || v.OriginalPath == "" {
+			return errors.New("invalid provenance record")
+		}
+		if v.OriginalMTime != nil {
+			if err := validateMetadataTime("provenance original_mtime", *v.OriginalMTime); err != nil {
+				return err
+			}
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO provenance(node_id,ingest_id,original_path,original_mtime) VALUES(?,?,?,?)`, v.NodeID, v.IngestID, v.OriginalPath, v.OriginalMTime)
+		return err
+	case "tag":
+		var v metadataTag
+		if err := decode(&v); err != nil {
+			return err
+		}
+		if v.Type != kind || v.ID <= 0 || v.Name == "" {
+			return errors.New("invalid tag record")
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO tags(id,name) VALUES(?,?)`, v.ID, v.Name)
+		return err
+	case "node_tag":
+		var v metadataNodeTag
+		if err := decode(&v); err != nil {
+			return err
+		}
+		if v.Type != kind || v.NodeID <= 0 || v.TagID <= 0 {
+			return errors.New("invalid node tag record")
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO node_tags(node_id,tag_id) VALUES(?,?)`, v.NodeID, v.TagID)
+		return err
+	case "extracted_text":
+		var v metadataExtractedText
+		if err := decode(&v); err != nil {
+			return err
+		}
+		if err := validateExtractedTextRecord(v); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO extracted_text(blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at) VALUES(?,?,?,?,?,?,?,?)`,
+			v.BlobHash, v.Extractor, v.ExtractorVersion, v.Status, v.Error, v.Attempts, v.Text, v.ExtractedAt)
+		return err
+	default:
+		return fmt.Errorf("unknown record type %q", kind)
+	}
+}
+
+var metadataRequiredFields = map[string][]string{
+	"blob":           {"type", "hash", "size", "created_at"},
+	"node":           {"type", "id", "parent_id", "name", "kind", "blob_hash", "size", "mime_type", "revision", "created_at", "modified_at", "trashed_at", "trash_parent", "trash_name"},
+	"node_version":   {"type", "node_id", "blob_hash", "size", "replaced_at"},
+	"ingest":         {"type", "id", "started_at", "source_kind", "source_desc"},
+	"provenance":     {"type", "node_id", "ingest_id", "original_path", "original_mtime"},
+	"tag":            {"type", "id", "name"},
+	"node_tag":       {"type", "node_id", "tag_id"},
+	"extracted_text": {"type", "blob_hash", "extractor", "extractor_version", "status", "error", "attempts", "text", "extracted_at"},
+}
+
+func requireMetadataFields(raw json.RawMessage, required []string) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return fmt.Errorf("decoding metadata fields: %w", err)
+	}
+	for _, field := range required {
+		if _, ok := fields[field]; !ok {
+			return fmt.Errorf("metadata record lacks required field %q", field)
+		}
+	}
+	return nil
+}
+
+func validateBlobRecord(v metadataBlob) error {
+	if v.Type != "blob" || v.Size < 0 {
+		return errors.New("invalid blob record")
+	}
+	if _, err := packstore.ParseHash(v.Hash); err != nil {
+		return fmt.Errorf("invalid blob hash: %w", err)
+	}
+	return validateMetadataTime("blob created_at", v.CreatedAt)
+}
+
+func validateNodeRecord(v metadataNode) error {
+	if v.Type != "node" || v.ID <= 0 || v.Revision <= 0 {
+		return errors.New("invalid node record")
+	}
+	if err := validateMetadataTime("node created_at", v.CreatedAt); err != nil {
+		return err
+	}
+	if err := validateMetadataTime("node modified_at", v.ModifiedAt); err != nil {
+		return err
+	}
+	if v.TrashedAt != nil {
+		if err := validateMetadataTime("node trashed_at", *v.TrashedAt); err != nil {
+			return err
+		}
+	}
+	if v.ParentID == nil {
+		if v.Name != "" || v.Kind != "dir" || v.BlobHash != nil || v.Size != nil || v.TrashedAt != nil ||
+			v.TrashParent != nil || v.TrashName != nil {
+			return errors.New("invalid root node record")
+		}
+		return nil
+	}
+	if *v.ParentID <= 0 {
+		return errors.New("invalid node parent_id")
+	}
+	normalized, err := NormalizeName(v.Name)
+	if err != nil || normalized != v.Name {
+		return fmt.Errorf("invalid node name %q", v.Name)
+	}
+	switch v.Kind {
+	case "dir":
+		if v.BlobHash != nil || v.Size != nil || v.MIMEType != nil {
+			return errors.New("directory record carries file content")
+		}
+	case "file":
+		if v.BlobHash == nil || v.Size == nil || *v.Size < 0 {
+			return errors.New("file record lacks valid content identity")
+		}
+		if _, err := packstore.ParseHash(*v.BlobHash); err != nil {
+			return fmt.Errorf("invalid node blob hash: %w", err)
+		}
+	default:
+		return fmt.Errorf("invalid node kind %q", v.Kind)
+	}
+	if (v.TrashParent == nil) != (v.TrashName == nil) || (v.TrashParent != nil && v.TrashedAt == nil) {
+		return errors.New("incomplete node trash coordinates")
+	}
+	return nil
+}
+
+func validateNodeVersionRecord(v metadataNodeVersion) error {
+	if v.Type != "node_version" || v.NodeID <= 0 || v.Size < 0 {
+		return errors.New("invalid node version record")
+	}
+	if _, err := packstore.ParseHash(v.BlobHash); err != nil {
+		return fmt.Errorf("invalid node version blob hash: %w", err)
+	}
+	return validateMetadataTime("node version replaced_at", v.ReplacedAt)
+}
+
+func validateExtractedTextRecord(v metadataExtractedText) error {
+	if v.Type != "extracted_text" || v.Extractor == "" || v.ExtractorVersion < 0 || v.Attempts < 0 {
+		return errors.New("invalid extracted text record")
+	}
+	if v.Status != "ok" && v.Status != "failed" {
+		return fmt.Errorf("invalid extraction status %q", v.Status)
+	}
+	if _, err := packstore.ParseHash(v.BlobHash); err != nil {
+		return fmt.Errorf("invalid extracted text blob hash: %w", err)
+	}
+	return validateMetadataTime("extracted text extracted_at", v.ExtractedAt)
+}
+
+func validateMetadataTime(field, value string) error {
+	if _, err := time.Parse(timestampLayout, value); err != nil {
+		return fmt.Errorf("invalid %s: %w", field, err)
+	}
+	return nil
+}
+
+func validateImportedMetadata(ctx context.Context, tx *sql.Tx) error {
+	checks := []struct {
+		name  string
+		query string
+	}{
+		{"tree contains unreachable nodes", `
+			WITH RECURSIVE reachable(id) AS (
+			  SELECT id FROM nodes WHERE parent_id IS NULL
+			  UNION SELECT n.id FROM nodes n JOIN reachable r ON n.parent_id = r.id
+			)
+			SELECT (SELECT COUNT(*) FROM reachable) != (SELECT COUNT(*) FROM nodes)`},
+		{"node parent is not a directory", `
+			SELECT EXISTS(SELECT 1 FROM nodes n JOIN nodes p ON p.id=n.parent_id WHERE p.kind != 'dir')`},
+		{"trash parent is not a directory", `
+			SELECT EXISTS(SELECT 1 FROM nodes n JOIN nodes p ON p.id=n.trash_parent WHERE p.kind != 'dir')`},
+		{"node size differs from blob authority", `
+			SELECT EXISTS(SELECT 1 FROM nodes n JOIN blobs b ON b.hash=n.blob_hash WHERE n.size != b.size)`},
+		{"node version size differs from blob authority", `
+			SELECT EXISTS(SELECT 1 FROM node_versions v JOIN blobs b ON b.hash=v.blob_hash WHERE v.size != b.size)`},
+	}
+	for _, check := range checks {
+		var failed bool
+		if err := tx.QueryRowContext(ctx, check.query).Scan(&failed); err != nil {
+			return fmt.Errorf("validating imported metadata (%s): %w", check.name, err)
+		}
+		if failed {
+			return errors.New(check.name)
+		}
+	}
+	return nil
+}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -524,7 +524,7 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 			return errors.New("invalid provenance record")
 		}
 		if v.OriginalMTime != nil {
-			if err := validateMetadataTime("provenance original_mtime", *v.OriginalMTime); err != nil {
+			if err := validateProvenanceTime(*v.OriginalMTime); err != nil {
 				return err
 			}
 		}
@@ -680,6 +680,17 @@ func validateMetadataTime(field, value string) error {
 	}
 	if value != parsed.UTC().Format(timestampLayout) {
 		return fmt.Errorf("invalid %s: timestamp is not canonical UTC", field)
+	}
+	return nil
+}
+
+func validateProvenanceTime(value string) error {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return fmt.Errorf("invalid provenance original_mtime: %w", err)
+	}
+	if value != parsed.UTC().Format(time.RFC3339Nano) {
+		return errors.New("invalid provenance original_mtime: timestamp is not canonical UTC RFC3339Nano")
 	}
 	return nil
 }

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -738,6 +738,31 @@ func validateImportedMetadata(ctx context.Context, tx *sql.Tx) error {
 			    ON s.trash_root = root.id AND s.id = root.trash_parent
 			  WHERE root.trash_parent IS NOT NULL
 			)`},
+		{"trashed node does not belong to exactly one trash root", `
+			WITH RECURSIVE trash_subtree(trash_root, id) AS (
+			  SELECT id, id FROM nodes WHERE trash_name IS NOT NULL
+			  UNION ALL
+			  SELECT s.trash_root, n.id
+			  FROM trash_subtree s JOIN nodes n ON n.parent_id = s.id
+			)
+			SELECT EXISTS(
+			  SELECT 1 FROM nodes n
+			  LEFT JOIN trash_subtree s ON s.id = n.id
+			  WHERE n.trashed_at IS NOT NULL
+			  GROUP BY n.id
+			  HAVING COUNT(s.trash_root) != 1
+			)`},
+		{"trash subtree contains live node or mismatched timestamp", `
+			WITH RECURSIVE trash_subtree(trash_root, root_stamp, id) AS (
+			  SELECT id, trashed_at, id FROM nodes WHERE trash_name IS NOT NULL
+			  UNION ALL
+			  SELECT s.trash_root, s.root_stamp, n.id
+			  FROM trash_subtree s JOIN nodes n ON n.parent_id = s.id
+			)
+			SELECT EXISTS(
+			  SELECT 1 FROM trash_subtree s JOIN nodes n ON n.id = s.id
+			  WHERE n.trashed_at IS NULL OR n.trashed_at != s.root_stamp
+			)`},
 		{"node size differs from blob authority", `
 			SELECT EXISTS(SELECT 1 FROM nodes n JOIN blobs b ON b.hash=n.blob_hash WHERE n.size != b.size)`},
 		{"node version size differs from blob authority", `

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -644,8 +644,17 @@ func validateNodeRecord(v metadataNode) error {
 	default:
 		return fmt.Errorf("invalid node kind %q", v.Kind)
 	}
-	if (v.TrashParent == nil) != (v.TrashName == nil) || (v.TrashParent != nil && v.TrashedAt == nil) {
+	if v.TrashParent != nil && v.TrashName == nil {
 		return errors.New("incomplete node trash coordinates")
+	}
+	if (v.TrashParent != nil || v.TrashName != nil) && v.TrashedAt == nil {
+		return errors.New("incomplete node trash coordinates")
+	}
+	if v.TrashName != nil {
+		normalizedTrashName, err := NormalizeName(*v.TrashName)
+		if err != nil || normalizedTrashName != *v.TrashName {
+			return fmt.Errorf("invalid node trash_name %q", *v.TrashName)
+		}
 	}
 	return nil
 }
@@ -710,6 +719,25 @@ func validateImportedMetadata(ctx context.Context, tx *sql.Tx) error {
 			SELECT EXISTS(SELECT 1 FROM nodes n JOIN nodes p ON p.id=n.parent_id WHERE p.kind != 'dir')`},
 		{"trash parent is not a directory", `
 			SELECT EXISTS(SELECT 1 FROM nodes n JOIN nodes p ON p.id=n.trash_parent WHERE p.kind != 'dir')`},
+		{"trash root is not detached beneath the tree root", `
+			SELECT EXISTS(
+			  SELECT 1 FROM nodes n
+			  WHERE n.trash_name IS NOT NULL
+			    AND n.parent_id != (SELECT id FROM nodes WHERE parent_id IS NULL)
+			)`},
+		{"trash parent points inside its subtree", `
+			WITH RECURSIVE trash_subtree(trash_root, id) AS (
+			  SELECT id, id FROM nodes WHERE trash_name IS NOT NULL
+			  UNION
+			  SELECT s.trash_root, n.id
+			  FROM trash_subtree s JOIN nodes n ON n.parent_id = s.id
+			)
+			SELECT EXISTS(
+			  SELECT 1 FROM nodes root
+			  JOIN trash_subtree s
+			    ON s.trash_root = root.id AND s.id = root.trash_parent
+			  WHERE root.trash_parent IS NOT NULL
+			)`},
 		{"node size differs from blob authority", `
 			SELECT EXISTS(SELECT 1 FROM nodes n JOIN blobs b ON b.hash=n.blob_hash WHERE n.size != b.size)`},
 		{"node version size differs from blob authority", `

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -17,9 +17,10 @@ import (
 const metadataFormatVersion = 1
 
 type metadataHeader struct {
-	Type    string `json:"type"`
-	Format  string `json:"format"`
-	Version int    `json:"version"`
+	Type         string `json:"type"`
+	Format       string `json:"format"`
+	Version      int    `json:"version"`
+	NodeSequence int64  `json:"node_sequence"`
 }
 
 type metadataBlob struct {
@@ -126,7 +127,13 @@ func ExportMetadataTx(ctx context.Context, tx *sql.Tx, w io.Writer) error {
 		}
 		return nil
 	}
-	if err := write(metadataHeader{Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion}); err != nil {
+	var nodeSequence int64
+	if err := tx.QueryRowContext(ctx, `SELECT seq FROM sqlite_sequence WHERE name = 'nodes'`).Scan(&nodeSequence); err != nil {
+		return fmt.Errorf("reading node ID high-water mark: %w", err)
+	}
+	if err := write(metadataHeader{
+		Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion, NodeSequence: nodeSequence,
+	}); err != nil {
 		return err
 	}
 	if err := exportBlobs(ctx, tx, write); err != nil {
@@ -354,11 +361,22 @@ func (s *Store) ImportMetadata(ctx context.Context, r io.Reader) error {
 		if _, err := tx.ExecContext(ctx, `PRAGMA defer_foreign_keys = ON`); err != nil {
 			return fmt.Errorf("deferring metadata foreign keys: %w", err)
 		}
-		if err := importMetadataLines(ctx, tx, r); err != nil {
+		nodeSequence, err := importMetadataLines(ctx, tx, r)
+		if err != nil {
 			return err
 		}
 		if err := validateImportedMetadata(ctx, tx); err != nil {
 			return err
+		}
+		var maxNodeID int64
+		if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM nodes`).Scan(&maxNodeID); err != nil {
+			return fmt.Errorf("reading imported maximum node ID: %w", err)
+		}
+		if nodeSequence < maxNodeID {
+			return fmt.Errorf("node ID high-water mark %d is below imported maximum %d", nodeSequence, maxNodeID)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE sqlite_sequence SET seq = ? WHERE name = 'nodes'`, nodeSequence); err != nil {
+			return fmt.Errorf("restoring node ID high-water mark: %w", err)
 		}
 		if err := tx.QueryRowContext(ctx, `SELECT id FROM nodes WHERE parent_id IS NULL`).Scan(&rootID); err != nil {
 			return fmt.Errorf("finding imported root: %w", err)
@@ -406,34 +424,35 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 	return nil
 }
 
-func importMetadataLines(ctx context.Context, tx *sql.Tx, r io.Reader) error {
+func importMetadataLines(ctx context.Context, tx *sql.Tx, r io.Reader) (int64, error) {
 	dec := json.NewDecoder(bufio.NewReader(r))
 	dec.DisallowUnknownFields()
 	var header metadataHeader
 	if err := dec.Decode(&header); err != nil {
-		return fmt.Errorf("decoding metadata header: %w", err)
+		return 0, fmt.Errorf("decoding metadata header: %w", err)
 	}
-	if header != (metadataHeader{Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion}) {
-		return fmt.Errorf("unsupported metadata header: type=%q format=%q version=%d",
-			header.Type, header.Format, header.Version)
+	if header.Type != "meta" || header.Format != "docbank-metadata" ||
+		header.Version != metadataFormatVersion || header.NodeSequence <= 0 {
+		return 0, fmt.Errorf("unsupported metadata header: type=%q format=%q version=%d node_sequence=%d",
+			header.Type, header.Format, header.Version, header.NodeSequence)
 	}
 	for record := 2; ; record++ {
 		var raw json.RawMessage
 		err := dec.Decode(&raw)
 		if errors.Is(err, io.EOF) {
-			return nil
+			return header.NodeSequence, nil
 		}
 		if err != nil {
-			return fmt.Errorf("decoding metadata record %d: %w", record, err)
+			return 0, fmt.Errorf("decoding metadata record %d: %w", record, err)
 		}
 		var kind struct {
 			Type string `json:"type"`
 		}
 		if err := json.Unmarshal(raw, &kind); err != nil {
-			return fmt.Errorf("decoding metadata record %d type: %w", record, err)
+			return 0, fmt.Errorf("decoding metadata record %d type: %w", record, err)
 		}
 		if err := importMetadataRecord(ctx, tx, kind.Type, raw); err != nil {
-			return fmt.Errorf("importing metadata record %d (%s): %w", record, kind.Type, err)
+			return 0, fmt.Errorf("importing metadata record %d (%s): %w", record, kind.Type, err)
 		}
 	}
 }
@@ -655,8 +674,12 @@ func validateExtractedTextRecord(v metadataExtractedText) error {
 }
 
 func validateMetadataTime(field, value string) error {
-	if _, err := time.Parse(timestampLayout, value); err != nil {
+	parsed, err := time.Parse(timestampLayout, value)
+	if err != nil {
 		return fmt.Errorf("invalid %s: %w", field, err)
+	}
+	if value != parsed.UTC().Format(timestampLayout) {
+		return fmt.Errorf("invalid %s: timestamp is not canonical UTC", field)
 	}
 	return nil
 }
@@ -680,6 +703,8 @@ func validateImportedMetadata(ctx context.Context, tx *sql.Tx) error {
 			SELECT EXISTS(SELECT 1 FROM nodes n JOIN blobs b ON b.hash=n.blob_hash WHERE n.size != b.size)`},
 		{"node version size differs from blob authority", `
 			SELECT EXISTS(SELECT 1 FROM node_versions v JOIN blobs b ON b.hash=v.blob_hash WHERE v.size != b.size)`},
+		{"extracted text references missing blob authority", `
+			SELECT EXISTS(SELECT 1 FROM extracted_text e LEFT JOIN blobs b ON b.hash=e.blob_hash WHERE b.hash IS NULL)`},
 	}
 	for _, check := range checks {
 		var failed bool

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -34,6 +34,17 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 		"text/plain", "/source/filesystem-time.txt", filesystemMTime)
 	require.NoError(t, err)
 	require.True(t, added)
+	lostParent, err := source.Mkdir(ctx, source.RootID(), "deleted-parent")
+	require.NoError(t, err)
+	lostFile, err := source.CreateFile(ctx, lostParent.ID, "lost.txt",
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 6, "text/plain")
+	require.NoError(t, err)
+	_, _, err = source.Trash(ctx, lostFile.ID, UnconditionalRev)
+	require.NoError(t, err)
+	_, _, err = source.Trash(ctx, lostParent.ID, UnconditionalRev)
+	require.NoError(t, err)
+	_, err = source.db.ExecContext(ctx, `DELETE FROM nodes WHERE id = ?`, lostParent.ID)
+	require.NoError(t, err)
 	require.NoError(t, source.withTx(ctx, func(tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, `INSERT INTO nodes(id,parent_id,name,kind,created_at,modified_at)
 			VALUES(100,1,'later-deleted','dir','2026-02-04T00:00:00.000000000Z','2026-02-04T00:00:00.000000000Z')`); err != nil {
@@ -62,6 +73,14 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	require.NoError(t, target.ExportMetadata(ctx, &restored))
 	assert.Equal(t, first.Bytes(), restored.Bytes())
 	assert.Equal(t, int64(1), target.RootID())
+	var importedTrashParent sql.NullInt64
+	var importedTrashName sql.NullString
+	require.NoError(t, target.db.QueryRowContext(ctx,
+		`SELECT trash_parent, trash_name FROM nodes WHERE id = ?`, lostFile.ID).
+		Scan(&importedTrashParent, &importedTrashName))
+	assert.False(t, importedTrashParent.Valid)
+	require.True(t, importedTrashName.Valid)
+	assert.Equal(t, "lost.txt", importedTrashName.String)
 
 	node, err := target.NodeByPath(ctx, "/Projects/report.txt")
 	require.NoError(t, err)
@@ -80,6 +99,11 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	require.NoError(t, target.db.QueryRowContext(ctx,
 		`SELECT (SELECT COUNT(*) FROM blob_packs) + (SELECT COUNT(*) FROM blob_pack_index)`).Scan(&packRows))
 	assert.Zero(t, packRows, "physical pack authority is reconstructed separately")
+	restoredLostFile, err := target.Restore(ctx, lostFile.ID, UnconditionalRev)
+	require.NoError(t, err)
+	restoredLostPath, err := target.Path(ctx, restoredLostFile.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "/lost.txt", restoredLostPath)
 
 	created, err := target.Mkdir(ctx, target.RootID(), "after-restore")
 	require.NoError(t, err)
@@ -144,6 +168,49 @@ func TestImportMetadataRejectsDisconnectedCycle(t *testing.T) {
 	var nodes int64
 	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
 	assert.Equal(t, int64(1), nodes)
+}
+
+func TestImportMetadataRejectsUnsafeTrashTopology(t *testing.T) {
+	stamp := "2026-01-01T00:00:00.000000000Z"
+	root := `{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":1,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":null,"trash_parent":null,"trash_name":null}`
+	tests := []struct {
+		name    string
+		records []string
+		want    string
+	}{
+		{
+			name: "restore parent inside subtree",
+			records: []string{
+				`{"type":"node","id":2,"parent_id":1,"name":"A","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":3,"trash_name":"A"}`,
+				`{"type":"node","id":3,"parent_id":2,"name":"B","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":null,"trash_name":null}`,
+			},
+			want: "trash parent points inside its subtree",
+		},
+		{
+			name: "trash root not detached",
+			records: []string{
+				`{"type":"node","id":3,"parent_id":1,"name":"container","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":1,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":null,"trash_parent":null,"trash_name":null}`,
+				`{"type":"node","id":2,"parent_id":3,"name":"A","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":1,"trash_name":"A"}`,
+			},
+			want: "trash root is not detached",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, target.Close()) })
+			lines := append([]string{
+				`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":3}`,
+				root,
+			}, tt.records...)
+			err = target.ImportMetadata(context.Background(), strings.NewReader(strings.Join(lines, "\n")+"\n"))
+			require.ErrorContains(t, err, tt.want)
+			var nodes int64
+			require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
+			assert.Equal(t, int64(1), nodes)
+		})
+	}
 }
 
 func TestImportMetadataRejectsNodeSequenceBelowSurvivingIDs(t *testing.T) {
@@ -219,7 +286,7 @@ func seedMetadataRoundTrip(t *testing.T, s *Store) {
 			 VALUES(10,7,'report.txt','file','` + metadataHashCurrent + `',12,'text/plain',3,
 			 '2026-01-08T00:00:00.000000000Z','2026-01-09T00:00:00.000000000Z')`,
 			`INSERT INTO nodes(id,parent_id,name,kind,blob_hash,size,mime_type,revision,created_at,modified_at,trashed_at,trash_parent,trash_name)
-			 VALUES(11,7,'old.bin','file','` + metadataHashTrashed + `',5,'application/octet-stream',2,
+			 VALUES(11,1,'old.bin','file','` + metadataHashTrashed + `',5,'application/octet-stream',2,
 			 '2026-01-10T00:00:00.000000000Z','2026-01-11T00:00:00.000000000Z',
 			 '2026-01-12T00:00:00.000000000Z',7,'old.bin')`,
 			`INSERT INTO node_versions(node_id,blob_hash,size,replaced_at)

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -1,0 +1,185 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	metadataHashCurrent = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	metadataHashTrashed = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	metadataHashVersion = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)
+
+func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
+	ctx := context.Background()
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+
+	var first, second bytes.Buffer
+	require.NoError(t, source.ExportMetadata(ctx, &first))
+	require.NoError(t, source.ExportMetadata(ctx, &second))
+	assert.Equal(t, first.Bytes(), second.Bytes(), "unchanged metadata must export byte-identically")
+	assert.Contains(t, first.String(), `{"type":"node","id":7,"parent_id":1,"name":"Projects","kind":"dir"`)
+	assert.NotContains(t, first.String(), "blob_pack_index")
+	assert.NotContains(t, first.String(), "metadata-pack")
+
+	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	require.NoError(t, target.ImportMetadata(ctx, bytes.NewReader(first.Bytes())))
+
+	var restored bytes.Buffer
+	require.NoError(t, target.ExportMetadata(ctx, &restored))
+	assert.Equal(t, first.Bytes(), restored.Bytes())
+	assert.Equal(t, int64(1), target.RootID())
+
+	node, err := target.NodeByPath(ctx, "/Projects/report.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), node.ID)
+	assert.Equal(t, metadataHashCurrent, node.BlobHash)
+	_, err = target.NodeByPath(ctx, "/Empty")
+	require.NoError(t, err, "empty directories are logical backup records")
+
+	results, truncated, err := target.SearchPage(ctx, "report", 10)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, results, 1, "FTS must be rebuilt by logical node import")
+	assert.Equal(t, node.ID, results[0].Node.ID)
+
+	var packRows int64
+	require.NoError(t, target.db.QueryRowContext(ctx,
+		`SELECT (SELECT COUNT(*) FROM blob_packs) + (SELECT COUNT(*) FROM blob_pack_index)`).Scan(&packRows))
+	assert.Zero(t, packRows, "physical pack authority is reconstructed separately")
+
+	created, err := target.Mkdir(ctx, target.RootID(), "after-restore")
+	require.NoError(t, err)
+	assert.Greater(t, created.ID, int64(12), "AUTOINCREMENT must not reuse imported stable IDs")
+}
+
+func TestImportMetadataRejectsDanglingContentAndRollsBack(t *testing.T) {
+	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+
+	input := strings.Join([]string{
+		`{"type":"meta","format":"docbank-metadata","version":1}`,
+		`{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
+		`{"type":"node","id":2,"parent_id":1,"name":"missing.bin","kind":"file","blob_hash":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","size":1,"mime_type":"application/octet-stream","revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
+	}, "\n") + "\n"
+	err = target.ImportMetadata(context.Background(), strings.NewReader(input))
+	require.ErrorContains(t, err, "foreign key")
+	assert.Equal(t, int64(1), target.RootID())
+	var nodes int64
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
+	assert.Equal(t, int64(1), nodes, "failed import must leave the pristine target intact")
+}
+
+func TestImportMetadataRejectsDisconnectedCycle(t *testing.T) {
+	ctx := context.Background()
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(ctx, &exported))
+	cyclic := strings.Replace(exported.String(),
+		`"id":7,"parent_id":1`, `"id":7,"parent_id":12`, 1)
+	cyclic = strings.Replace(cyclic,
+		`"id":12,"parent_id":1`, `"id":12,"parent_id":7`, 1)
+
+	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	err = target.ImportMetadata(ctx, strings.NewReader(cyclic))
+	require.ErrorContains(t, err, "unreachable")
+	var nodes int64
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
+	assert.Equal(t, int64(1), nodes)
+}
+
+func TestImportMetadataRejectsNonPristineTarget(t *testing.T) {
+	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	_, err = target.Mkdir(context.Background(), target.RootID(), "existing")
+	require.NoError(t, err)
+
+	input := `{"type":"meta","format":"docbank-metadata","version":1}` + "\n"
+	err = target.ImportMetadata(context.Background(), strings.NewReader(input))
+	require.ErrorContains(t, err, "not pristine")
+	_, err = target.NodeByPath(context.Background(), "/existing")
+	require.NoError(t, err)
+}
+
+func TestImportMetadataRejectsUnknownVersionAndFields(t *testing.T) {
+	for _, input := range []string{
+		`{"type":"meta","format":"docbank-metadata","version":2}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"surprise":true}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1}` + "\n" +
+			`{"type":"future_record","value":1}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1}` + "\n" +
+			`{"type":"blob","hash":"` + metadataHashCurrent + `","size":12}` + "\n",
+	} {
+		t.Run(input, func(t *testing.T) {
+			target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, target.Close()) })
+			require.Error(t, target.ImportMetadata(context.Background(), strings.NewReader(input)))
+		})
+	}
+}
+
+func seedMetadataRoundTrip(t *testing.T, s *Store) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, s.withTx(ctx, func(tx *sql.Tx) error {
+		statements := []string{
+			`UPDATE nodes SET created_at='2026-01-01T00:00:00.000000000Z', modified_at='2026-01-02T00:00:00.000000000Z' WHERE id=1`,
+			`INSERT INTO blobs(hash,size,created_at) VALUES
+			 ('` + metadataHashCurrent + `',12,'2026-01-03T00:00:00.000000000Z'),
+			 ('` + metadataHashTrashed + `',5,'2026-01-04T00:00:00.000000000Z'),
+			 ('` + metadataHashVersion + `',9,'2026-01-05T00:00:00.000000000Z')`,
+			`INSERT INTO nodes(id,parent_id,name,kind,created_at,modified_at) VALUES
+			 (7,1,'Projects','dir','2026-01-06T00:00:00.000000000Z','2026-01-07T00:00:00.000000000Z')`,
+			`INSERT INTO nodes(id,parent_id,name,kind,created_at,modified_at) VALUES
+			 (12,1,'Empty','dir','2026-01-06T00:00:00.000000000Z','2026-01-07T00:00:00.000000000Z')`,
+			`INSERT INTO nodes(id,parent_id,name,kind,blob_hash,size,mime_type,revision,created_at,modified_at)
+			 VALUES(10,7,'report.txt','file','` + metadataHashCurrent + `',12,'text/plain',3,
+			 '2026-01-08T00:00:00.000000000Z','2026-01-09T00:00:00.000000000Z')`,
+			`INSERT INTO nodes(id,parent_id,name,kind,blob_hash,size,mime_type,revision,created_at,modified_at,trashed_at,trash_parent,trash_name)
+			 VALUES(11,7,'old.bin','file','` + metadataHashTrashed + `',5,'application/octet-stream',2,
+			 '2026-01-10T00:00:00.000000000Z','2026-01-11T00:00:00.000000000Z',
+			 '2026-01-12T00:00:00.000000000Z',7,'old.bin')`,
+			`INSERT INTO node_versions(node_id,blob_hash,size,replaced_at)
+			 VALUES(10,'` + metadataHashVersion + `',9,'2026-01-09T00:00:00.000000000Z')`,
+			`INSERT INTO ingests(id,started_at,source_kind,source_desc)
+			 VALUES(4,'2026-01-08T00:00:00.000000000Z','filesystem','dropbox')`,
+			`INSERT INTO provenance(node_id,ingest_id,original_path,original_mtime)
+			 VALUES(10,4,'/source/report.txt','2025-12-31T23:00:00.000000000Z')`,
+			`INSERT INTO tags(id,name) VALUES(8,'important')`,
+			`INSERT INTO node_tags(node_id,tag_id) VALUES(10,8)`,
+			`INSERT INTO extracted_text(blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at)
+			 VALUES('` + metadataHashCurrent + `','plain',2,'ok',NULL,1,'line one\nline two','2026-01-13T00:00:00.000000000Z')`,
+			`INSERT INTO blob_packs(pack_id,entry_count,stored_bytes,created_at)
+			 VALUES('metadata-pack',1,12,'2026-01-14T00:00:00.000000000Z')`,
+			`INSERT INTO blob_pack_index(blob_hash,pack_id,pack_offset,stored_len,raw_len,flags,crc32c)
+			 VALUES('` + metadataHashCurrent + `','metadata-pack',16,12,12,0,42)`,
+		}
+		for _, statement := range statements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+}

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -172,6 +172,7 @@ func TestImportMetadataRejectsDisconnectedCycle(t *testing.T) {
 
 func TestImportMetadataRejectsUnsafeTrashTopology(t *testing.T) {
 	stamp := "2026-01-01T00:00:00.000000000Z"
+	otherStamp := "2026-01-02T00:00:00.000000000Z"
 	root := `{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":1,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":null,"trash_parent":null,"trash_name":null}`
 	tests := []struct {
 		name    string
@@ -193,6 +194,29 @@ func TestImportMetadataRejectsUnsafeTrashTopology(t *testing.T) {
 				`{"type":"node","id":2,"parent_id":3,"name":"A","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":1,"trash_name":"A"}`,
 			},
 			want: "trash root is not detached",
+		},
+		{
+			name: "trashed node without trash root",
+			records: []string{
+				`{"type":"node","id":2,"parent_id":1,"name":"orphan","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":null,"trash_name":null}`,
+			},
+			want: "does not belong to exactly one trash root",
+		},
+		{
+			name: "trash descendant timestamp differs",
+			records: []string{
+				`{"type":"node","id":2,"parent_id":1,"name":"A","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":1,"trash_name":"A"}`,
+				`{"type":"node","id":3,"parent_id":2,"name":"B","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + otherStamp + `","trash_parent":null,"trash_name":null}`,
+			},
+			want: "live node or mismatched timestamp",
+		},
+		{
+			name: "live descendant beneath trash root",
+			records: []string{
+				`{"type":"node","id":2,"parent_id":1,"name":"A","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":1,"trash_name":"A"}`,
+				`{"type":"node","id":3,"parent_id":2,"name":"B","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":1,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":null,"trash_parent":null,"trash_name":null}`,
+			},
+			want: "live node or mismatched timestamp",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -29,6 +29,7 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	require.NoError(t, source.ExportMetadata(ctx, &first))
 	require.NoError(t, source.ExportMetadata(ctx, &second))
 	assert.Equal(t, first.Bytes(), second.Bytes(), "unchanged metadata must export byte-identically")
+	assert.Contains(t, first.String(), `{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":50}`)
 	assert.Contains(t, first.String(), `{"type":"node","id":7,"parent_id":1,"name":"Projects","kind":"dir"`)
 	assert.NotContains(t, first.String(), "blob_pack_index")
 	assert.NotContains(t, first.String(), "metadata-pack")
@@ -63,7 +64,7 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 
 	created, err := target.Mkdir(ctx, target.RootID(), "after-restore")
 	require.NoError(t, err)
-	assert.Greater(t, created.ID, int64(12), "AUTOINCREMENT must not reuse imported stable IDs")
+	assert.Greater(t, created.ID, int64(50), "AUTOINCREMENT must not reuse any historically allocated ID")
 }
 
 func TestImportMetadataRejectsDanglingContentAndRollsBack(t *testing.T) {
@@ -72,7 +73,7 @@ func TestImportMetadataRejectsDanglingContentAndRollsBack(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, target.Close()) })
 
 	input := strings.Join([]string{
-		`{"type":"meta","format":"docbank-metadata","version":1}`,
+		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":2}`,
 		`{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
 		`{"type":"node","id":2,"parent_id":1,"name":"missing.bin","kind":"file","blob_hash":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","size":1,"mime_type":"application/octet-stream","revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
 	}, "\n") + "\n"
@@ -82,6 +83,25 @@ func TestImportMetadataRejectsDanglingContentAndRollsBack(t *testing.T) {
 	var nodes int64
 	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
 	assert.Equal(t, int64(1), nodes, "failed import must leave the pristine target intact")
+}
+
+func TestImportMetadataRejectsOrphanedExtractionAndRollsBack(t *testing.T) {
+	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+
+	input := strings.Join([]string{
+		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}`,
+		`{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","blob_hash":null,"size":null,"mime_type":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
+		`{"type":"extracted_text","blob_hash":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","extractor":"plain","extractor_version":1,"status":"ok","error":null,"attempts":1,"text":"orphan","extracted_at":"2026-01-01T00:00:00.000000000Z"}`,
+	}, "\n") + "\n"
+	err = target.ImportMetadata(context.Background(), strings.NewReader(input))
+	require.ErrorContains(t, err, "extracted text references missing blob authority")
+	var nodes, extracted int64
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM extracted_text`).Scan(&extracted))
+	assert.Equal(t, int64(1), nodes)
+	assert.Zero(t, extracted)
 }
 
 func TestImportMetadataRejectsDisconnectedCycle(t *testing.T) {
@@ -107,6 +127,26 @@ func TestImportMetadataRejectsDisconnectedCycle(t *testing.T) {
 	assert.Equal(t, int64(1), nodes)
 }
 
+func TestImportMetadataRejectsNodeSequenceBelowSurvivingIDs(t *testing.T) {
+	ctx := context.Background()
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(ctx, &exported))
+	badSequence := strings.Replace(exported.String(), `"node_sequence":50`, `"node_sequence":10`, 1)
+
+	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	err = target.ImportMetadata(ctx, strings.NewReader(badSequence))
+	require.ErrorContains(t, err, "below imported maximum")
+	var nodes int64
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
+	assert.Equal(t, int64(1), nodes)
+}
+
 func TestImportMetadataRejectsNonPristineTarget(t *testing.T) {
 	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
 	require.NoError(t, err)
@@ -114,7 +154,7 @@ func TestImportMetadataRejectsNonPristineTarget(t *testing.T) {
 	_, err = target.Mkdir(context.Background(), target.RootID(), "existing")
 	require.NoError(t, err)
 
-	input := `{"type":"meta","format":"docbank-metadata","version":1}` + "\n"
+	input := `{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n"
 	err = target.ImportMetadata(context.Background(), strings.NewReader(input))
 	require.ErrorContains(t, err, "not pristine")
 	_, err = target.NodeByPath(context.Background(), "/existing")
@@ -123,12 +163,15 @@ func TestImportMetadataRejectsNonPristineTarget(t *testing.T) {
 
 func TestImportMetadataRejectsUnknownVersionAndFields(t *testing.T) {
 	for _, input := range []string{
-		`{"type":"meta","format":"docbank-metadata","version":2}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1,"surprise":true}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1}` + "\n" +
+		`{"type":"meta","format":"docbank-metadata","version":2,"node_sequence":1}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1,"surprise":true}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n" +
 			`{"type":"future_record","value":1}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1}` + "\n" +
+		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n" +
 			`{"type":"blob","hash":"` + metadataHashCurrent + `","size":12}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n" +
+			`{"type":"blob","hash":"` + metadataHashCurrent + `","size":12,"created_at":"2026-01-01T00:00:00.000000000+00:00"}` + "\n",
 	} {
 		t.Run(input, func(t *testing.T) {
 			target, err := Open(filepath.Join(t.TempDir(), "target.db"))
@@ -174,6 +217,9 @@ func seedMetadataRoundTrip(t *testing.T, s *Store) {
 			 VALUES('metadata-pack',1,12,'2026-01-14T00:00:00.000000000Z')`,
 			`INSERT INTO blob_pack_index(blob_hash,pack_id,pack_offset,stored_len,raw_len,flags,crc32c)
 			 VALUES('` + metadataHashCurrent + `','metadata-pack',16,12,12,0,42)`,
+			`INSERT INTO nodes(id,parent_id,name,kind,created_at,modified_at)
+			 VALUES(50,1,'historical-high-water','dir','2026-01-15T00:00:00.000000000Z','2026-01-15T00:00:00.000000000Z')`,
+			`DELETE FROM nodes WHERE id=50`,
 		}
 		for _, statement := range statements {
 			if _, err := tx.ExecContext(ctx, statement); err != nil {

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,12 +25,30 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, source.Close()) })
 	seedMetadataRoundTrip(t, source)
+	filesystemMTime := time.Date(2026, time.February, 3, 4, 5, 6, 120_000_000, time.UTC).
+		Format(time.RFC3339Nano)
+	ingestID, err := source.BeginIngest(ctx, "cli", "actual filesystem timestamp")
+	require.NoError(t, err)
+	_, added, err := source.IngestFile(ctx, ingestID, source.RootID(), "filesystem-time.txt",
+		"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", 4,
+		"text/plain", "/source/filesystem-time.txt", filesystemMTime)
+	require.NoError(t, err)
+	require.True(t, added)
+	require.NoError(t, source.withTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO nodes(id,parent_id,name,kind,created_at,modified_at)
+			VALUES(100,1,'later-deleted','dir','2026-02-04T00:00:00.000000000Z','2026-02-04T00:00:00.000000000Z')`); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `DELETE FROM nodes WHERE id=100`)
+		return err
+	}))
 
 	var first, second bytes.Buffer
 	require.NoError(t, source.ExportMetadata(ctx, &first))
 	require.NoError(t, source.ExportMetadata(ctx, &second))
 	assert.Equal(t, first.Bytes(), second.Bytes(), "unchanged metadata must export byte-identically")
-	assert.Contains(t, first.String(), `{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":50}`)
+	assert.Contains(t, first.String(), `{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":100}`)
+	assert.Contains(t, first.String(), `"original_mtime":"2026-02-03T04:05:06.12Z"`)
 	assert.Contains(t, first.String(), `{"type":"node","id":7,"parent_id":1,"name":"Projects","kind":"dir"`)
 	assert.NotContains(t, first.String(), "blob_pack_index")
 	assert.NotContains(t, first.String(), "metadata-pack")
@@ -64,7 +83,7 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 
 	created, err := target.Mkdir(ctx, target.RootID(), "after-restore")
 	require.NoError(t, err)
-	assert.Greater(t, created.ID, int64(50), "AUTOINCREMENT must not reuse any historically allocated ID")
+	assert.Greater(t, created.ID, int64(100), "AUTOINCREMENT must not reuse any historically allocated ID")
 }
 
 func TestImportMetadataRejectsDanglingContentAndRollsBack(t *testing.T) {
@@ -208,7 +227,7 @@ func seedMetadataRoundTrip(t *testing.T, s *Store) {
 			`INSERT INTO ingests(id,started_at,source_kind,source_desc)
 			 VALUES(4,'2026-01-08T00:00:00.000000000Z','filesystem','dropbox')`,
 			`INSERT INTO provenance(node_id,ingest_id,original_path,original_mtime)
-			 VALUES(10,4,'/source/report.txt','2025-12-31T23:00:00.000000000Z')`,
+			 VALUES(10,4,'/source/report.txt','2025-12-31T23:00:00.12Z')`,
 			`INSERT INTO tags(id,name) VALUES(8,'important')`,
 			`INSERT INTO node_tags(node_id,tag_id) VALUES(10,8)`,
 			`INSERT INTO extracted_text(blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at)


### PR DESCRIPTION
SQLite remains the right runtime transaction and query engine for Docbank, but preserving its historical page and table layouts as the only backup contract would make every future schema change an increasingly delicate migration exercise. It would also leave the virtual directory tree opaque in an otherwise content-addressed archive.

This establishes a deterministic, versioned JSONL authority for logical metadata before public backup commands are exposed. The stream preserves stable node IDs, directories and files, content membership, timestamps and trash coordinates, prior versions, ingest provenance, tags, and extraction state. It deliberately excludes FTS and physical pack mappings: search is rebuilt from nodes, while restore must grant loose or packed authority only after content has been verified and published.

Import is restricted to a pristine current-schema database and is transactional. The roundtrip proof covers byte-stable export, empty directories, trashed state, all logical tables, FTS reconstruction, monotonic node IDs, and exclusion of source pack authority; malformed versions and fields, dangling hashes, disconnected cycles, and non-pristine targets fail without changing the target. The full repository tests, focused race test, lint, vet, pre-commit hooks, and strict documentation build pass.

This PR defines the application artifact only. Kit still snapshots SQLite today; consuming JSONL during Kit capture and rebuilding SQLite during restore is intentionally the next reviewable integration.