### PR TITLE
Make JSONL authoritative for backup restore

### DIFF
--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -1,6 +1,6 @@
 ---
 title: Backup
-description: Current manual snapshots and the staged Kit-backed backup integration.
+description: Current manual snapshots and Docbank's JSONL-native Kit backup engine.
 ---
 
 # Backup
@@ -16,49 +16,54 @@ state. A restored copy is not trusted until `docbank verify` succeeds.
 
 ## Kit integration status
 
-The internal `backupapp` adapter now supplies Kit with docbank's frozen logical
+The internal `backupapp` adapter supplies Kit v0.9.0 with Docbank's frozen logical
 view: every authoritative `blobs` row, representation-neutral fidelity stats,
-canonical restore paths, and mixed loose/packed content reads. Integration
-tests prove loose create/verify/restore and capture directly from a packed live
-store. Physical pack tables are excluded from fidelity stats so a restore may
-choose a different representation without changing the archive.
+and mixed loose/packed content reads. A short daemon freeze opens and pins one
+deferred SQLite read transaction; the freeze then ends, writers resume into the
+WAL, and metadata, content membership, and fidelity statistics continue to see
+the same point-in-time state.
 
 Docbank also has a deterministic, versioned JSONL representation of its logical
-metadata. It contains the complete virtual directory tree and file records,
+metadata, identified in manifests as `docbank-metadata-jsonl-v1`. It contains
+the complete virtual directory tree and file records,
 including stable IDs, content hashes, timestamps, trash coordinates, prior
 versions, ingest provenance, tags, and extracted text. It intentionally omits
 FTS rows and physical pack mappings: search indexes are rebuilt by importing
 nodes, while restore grants physical authority only after content has been
 verified and published. Import targets must be fresh current-schema databases;
 a malformed or referentially incomplete stream leaves the pristine target
-unchanged. The header also preserves the node-ID allocation high-water mark,
-including IDs whose rows were later deleted, so restore never reuses a value
-that an external reference may remember.
+unchanged. Capture makes two deterministic passes over the same pinned
+transaction: the first establishes the exact artifact size and the second
+streams the bytes into Kit without materializing a second database or a JSONL
+temporary file. The header also preserves the node-ID allocation high-water
+mark, including IDs whose rows were later deleted, so restore never reuses a
+value that an external reference may remember.
 
 Capture reads loose and packed blobs through Kit's bounded-memory stream. The
 archive may grant authority to copied bytes only after terminal EOF verifies
 their stored framing, decoded length, and SHA-256 identity; opening a stream or
 closing it early is not a successful copy.
 
-Snapshots taken from a packed vault retain source pack metadata in their
-captured database. Docbank therefore fails closed if such a snapshot is sent
-through Kit's loose-only restore path: loose files plus stale pack authority
-would make the restored vault unreadable. Docbank's restore wrapper inseparably
-owns the application adapter and packed target: it publishes verified repository
-packs into the target and atomically replaces all captured pack records and
-mappings before the staged vault becomes visible. Integration coverage opens
-every restored blob through the same mixed store used by a live vault.
+Restore constructs a fresh current-schema database from the verified JSONL
+artifact inside Kit's private staging area. It then checkpoints the database,
+publishes verified content, grants fresh catalog authority to the chosen loose
+or packed representation, reproduces the recorded fidelity statistics, and
+only then publishes the staged vault. Source pack rows never enter the JSONL
+artifact. Docbank's restore wrapper owns both the metadata restorer and packed
+target so callers cannot accidentally separate those policies. Integration
+coverage proves logical JSONL equality, loose and packed source capture,
+packed publication, large loose-object fallback, and reads every restored blob
+through the same mixed store used by a live vault.
+
+Snapshots created before this cutover used Kit's SQLite page-map metadata.
+They remain restorable through the same wrapper. New captures always use JSONL;
+the legacy path is a reader compatibility boundary, not an alternative format
+for new snapshots.
 
 !!! info "Planned — Phase 4"
     Command/API orchestration has not landed. The completed capture and restore
     adapters are internal and do not make any `docbank backup` command
     available yet.
-
-    Kit currently captures the frozen SQLite database as its metadata artifact.
-    The next integration step is to make the logical JSONL stream the archive's
-    application metadata and rebuild a fresh current-schema database during
-    restore. Until that lands, the JSONL codec alone does not change the bytes
-    in a Kit snapshot.
 
     The planned command family is `docbank backup init|create|list|verify|restore`.
     Exact flags will enter the CLI reference only when implemented.

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -261,13 +261,14 @@ both permanently hidden orphans and live nodes nested beneath trash.
 Explicit node IDs advance SQLite's `AUTOINCREMENT` sequence, preserving the
 invariant that a deleted historical ID is never silently reused.
 
-This boundary replaces in-place schema evolution with export → construct a
-fresh current-schema database → import → verify → atomic replacement. It does
-not make compatibility work disappear: each supported JSONL version needs an
-explicit decoder, and a live cutover must carry current physical pack authority
-through a separately verified path. The current codec establishes version 1;
-automatic database replacement and Kit metadata-artifact integration remain
-follow-up work.
+The Kit v0.9.0 backup adapter now uses this boundary for every new snapshot:
+export → verified metadata artifact → construct a fresh current-schema
+database → import → checkpoint → publish verified content and fresh pack
+authority → prove fidelity → atomic replacement. Historical SQLite page-map
+snapshots remain restorable, but new captures cannot select that legacy path.
+This does not make compatibility work disappear: each supported JSONL version
+needs an explicit decoder, and physical pack authority must always travel
+through Kit's separately verified publication path.
 
 Do not move docbank SQL or reachability policy into Kit. Do not reimplement Kit
 reader or lifecycle mechanics in docbank. A physical-storage bug shared by

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,11 +114,12 @@ operations — anything the TUI does, the API can do.
 ([design](architecture/backup.md)).
 
 The internal Kit application adapter, loose/packed capture proof, and atomic
-packed restore publication are implemented. Docbank's deterministic logical
-JSONL codec also round-trips directory structure, stable node IDs, content
-membership, trash state, versions, provenance, tags, and extraction state into
-a fresh current-schema database. Kit metadata-artifact integration and
-command/API orchestration remain.
+packed restore publication are implemented. Every new internal capture uses
+Docbank's deterministic logical JSONL artifact, which round-trips directory
+structure, stable node IDs, content membership, trash state, versions,
+provenance, tags, and extraction state into a fresh current-schema database.
+Historical SQLite page-map snapshots remain restorable. Command/API
+orchestration remains.
 
 ## Deferred beyond v1
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	go.kenn.io/kit v0.8.0
+	go.kenn.io/kit v0.9.0
 	golang.org/x/text v0.38.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.kenn.io/kit v0.8.0 h1:CkfFD3KCBAUte2fKBno9J1ew8PW5V+SHl6p3uwdztRk=
 go.kenn.io/kit v0.8.0/go.mod h1:dComZhFNb4LR+Tj4ZD0slEDMkPJk0gGd8q/HEHXTGSM=
+go.kenn.io/kit v0.9.0 h1:Y1oARFf7zRg4aXQ3//aqzTPj/6xc0B738MsenhmV/Ys=
+go.kenn.io/kit v0.9.0/go.mod h1:dComZhFNb4LR+Tj4ZD0slEDMkPJk0gGd8q/HEHXTGSM=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/internal/backupapp/app.go
+++ b/internal/backupapp/app.go
@@ -12,6 +12,8 @@ import (
 
 	"go.kenn.io/kit/backup"
 	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/store"
 )
 
 // Stats is the representation-neutral fidelity payload recorded in each
@@ -33,6 +35,7 @@ type Stats struct {
 }
 
 type rowQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
@@ -73,6 +76,29 @@ var _ backup.App = (*App)(nil)
 
 func New(version string) *App { return &App{version: version} }
 
+// Create captures Docbank's logical JSONL metadata and catalog-authorized blob
+// streams. The wrapper owns both adapters so ordinary callers cannot
+// accidentally fall back to SQLite page capture or loose-path reads.
+func Create(
+	ctx context.Context,
+	repo *backup.Repo,
+	version string,
+	metadata *store.Store,
+	blobs BlobStreamer,
+	opts backup.CreateOptions,
+) (*backup.Manifest, error) {
+	if opts.MetadataSource != nil || opts.ContentSource != nil || opts.DBPath != "" {
+		return nil, errors.New("backupapp: create options must not supply metadata or content sources")
+	}
+	opts.MetadataSource = NewMetadataSource(metadata)
+	opts.ContentSource = NewContentSource(blobs)
+	manifest, err := backup.Create(ctx, repo, New(version), opts)
+	if err != nil {
+		return nil, fmt.Errorf("backupapp: creating snapshot: %w", err)
+	}
+	return manifest, nil
+}
+
 func (a *App) FrozenView(session *backup.FrozenSession) backup.FrozenView {
 	return &frozenView{tx: session.Tx()}
 }
@@ -85,7 +111,7 @@ func (a *App) ExcludedPaths() []string {
 	return []string{"config.toml", "logs/", "vault.lock", "launch.lock", "daemon.*.json", "blobs/tmp/"}
 }
 
-type frozenView struct{ tx *sql.Tx }
+type frozenView struct{ tx rowQuerier }
 
 func (v *frozenView) ContentInfo(ctx context.Context) (*backup.ContentInfo, error) {
 	rows, err := v.tx.QueryContext(ctx, `SELECT hash, size FROM blobs ORDER BY hash`)

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -1,7 +1,9 @@
 package backupapp_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -26,6 +28,39 @@ type archiveFixture struct {
 }
 
 type zeroReader struct{}
+
+type freezeCoordinator struct {
+	end func(context.Context) error
+}
+
+func (freezeCoordinator) Begin(context.Context) error { return nil }
+
+func (f freezeCoordinator) End(ctx context.Context) error { return f.end(ctx) }
+
+type malformedMetadataSource struct{}
+
+func (malformedMetadataSource) Format() string { return backupapp.MetadataFormat }
+
+func (malformedMetadataSource) OpenSnapshot(context.Context) (backup.MetadataSnapshot, error) {
+	return malformedMetadataSnapshot{}, nil
+}
+
+type malformedMetadataSnapshot struct{}
+
+func (malformedMetadataSnapshot) OpenMetadata(context.Context) (io.ReadCloser, int64, error) {
+	const metadata = "{malformed\n"
+	return io.NopCloser(strings.NewReader(metadata)), int64(len(metadata)), nil
+}
+
+func (malformedMetadataSnapshot) ContentInfo(context.Context) (*backup.ContentInfo, error) {
+	return &backup.ContentInfo{}, nil
+}
+
+func (malformedMetadataSnapshot) Stats(context.Context) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}
+
+func (malformedMetadataSnapshot) Close() error { return nil }
 
 func (zeroReader) Read(p []byte) (int, error) {
 	clear(p)
@@ -65,18 +100,28 @@ func newArchiveFixture(t *testing.T) *archiveFixture {
 	return fixture
 }
 
-func TestLooseSnapshotVerifyAndRestore(t *testing.T) {
+func exportMetadata(t *testing.T, metadata *store.Store) []byte {
+	t.Helper()
+	var dst bytes.Buffer
+	require.NoError(t, metadata.ExportMetadata(t.Context(), &dst))
+	return dst.Bytes()
+}
+
+func TestJSONLLooseSnapshotVerifyAndRestore(t *testing.T) {
 	fixture := newArchiveFixture(t)
+	wantMetadata := exportMetadata(t, fixture.metadata)
 	app := backupapp.New("test-version")
 	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
 	require.NoError(t, err)
 
-	manifest, err := backup.Create(t.Context(), repo, app, backup.CreateOptions{
-		DBPath:        filepath.Join(fixture.root, "docbank.db"),
-		ContentSource: backupapp.NewContentSource(fixture.blobs),
-		Jobs:          2,
-	})
+	manifest, err := backupapp.Create(
+		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs, backup.CreateOptions{
+			Jobs: 2,
+		})
 	require.NoError(t, err)
+	require.NotNil(t, manifest.Metadata)
+	assert.Equal(t, backupapp.MetadataFormat, manifest.Metadata.Format)
+	assert.Empty(t, manifest.DB.Engine)
 	assert.Equal(t, int64(2), manifest.Attachments.Rows)
 	assert.Equal(t, int64(2), manifest.Attachments.Blobs)
 	assert.Equal(t, int64(len("alpha backup")+len("bravo backup")), manifest.Attachments.BlobBytes)
@@ -92,12 +137,59 @@ func TestLooseSnapshotVerifyAndRestore(t *testing.T) {
 	assert.Equal(t, []string{manifest.SnapshotID}, verified.Snapshots)
 
 	target := filepath.Join(t.TempDir(), "restored")
-	restored, err := backup.Restore(t.Context(), repo, app, backup.RestoreOptions{
+	_, err = backup.Restore(t.Context(), repo, app, backup.RestoreOptions{
+		TargetDir: filepath.Join(t.TempDir(), "missing-metadata-restorer"), Jobs: 2,
+	})
+	require.ErrorContains(t, err, "requires a MetadataRestorer")
+
+	restored, err := backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{
 		TargetDir: target, Jobs: 2,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), restored.AttachmentBlobs)
-	assert.Equal(t, int64(2), restored.LooseAttachmentBlobs)
+	assert.Equal(t, int64(2), restored.PackedAttachmentBlobs)
+	assert.Zero(t, restored.LooseAttachmentBlobs)
+
+	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	assert.Equal(t, string(wantMetadata), string(exportMetadata(t, restoredStore)))
+	restoredBlobs, err := blob.New(store.NewPackCatalog(restoredStore), filepath.Join(target, "blobs"))
+	require.NoError(t, err)
+	for name, want := range fixture.content {
+		node, nodeErr := restoredStore.NodeByPath(t.Context(), "/"+name)
+		require.NoError(t, nodeErr)
+		reader, openErr := restoredBlobs.OpenContext(t.Context(), node.BlobHash)
+		require.NoError(t, openErr)
+		got, readErr := io.ReadAll(reader)
+		require.NoError(t, readErr)
+		require.NoError(t, reader.Close())
+		assert.Equal(t, want, string(got))
+	}
+	require.NoError(t, restoredBlobs.Close())
+	require.NoError(t, restoredStore.Close())
+}
+
+func TestRestoreSupportsLegacySQLitePageSnapshots(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	app := backupapp.New("legacy-version")
+	manifest, err := backup.Create(t.Context(), repo, app, backup.CreateOptions{
+		DBPath:        filepath.Join(fixture.root, "docbank.db"),
+		ContentSource: backupapp.NewContentSource(fixture.blobs),
+		Jobs:          2,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, manifest.Metadata)
+	assert.NotEmpty(t, manifest.DB.Engine)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	result, err := backupapp.Restore(t.Context(), repo, "current-version", backup.RestoreOptions{
+		TargetDir: target,
+		Jobs:      2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.AttachmentBlobs)
 
 	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
 	require.NoError(t, err)
@@ -115,6 +207,52 @@ func TestLooseSnapshotVerifyAndRestore(t *testing.T) {
 	}
 	require.NoError(t, restoredBlobs.Close())
 	require.NoError(t, restoredStore.Close())
+}
+
+func TestJSONLSnapshotRemainsStableAfterFreezeEnds(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	freezer := freezeCoordinator{end: func(ctx context.Context) error {
+		_, mkdirErr := fixture.metadata.Mkdir(ctx, fixture.metadata.RootID(), "created-after-snapshot")
+		return mkdirErr
+	}}
+
+	manifest, err := backupapp.Create(
+		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs,
+		backup.CreateOptions{Freezer: freezer, Jobs: 2})
+	require.NoError(t, err)
+	stats, err := backupapp.ParseStats(manifest.Stats)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.Nodes)
+	_, err = fixture.metadata.NodeByPath(t.Context(), "/created-after-snapshot")
+	require.NoError(t, err)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	_, err = backupapp.Restore(
+		t.Context(), repo, "test-version", backup.RestoreOptions{TargetDir: target, Jobs: 2})
+	require.NoError(t, err)
+	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	_, err = restoredStore.NodeByPath(t.Context(), "/created-after-snapshot")
+	require.Error(t, err)
+	require.NoError(t, restoredStore.Close())
+}
+
+func TestMalformedJSONLRestoreLeavesNoPublishedDatabase(t *testing.T) {
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	_, err = backup.Create(t.Context(), repo, backupapp.New("test-version"), backup.CreateOptions{
+		MetadataSource: malformedMetadataSource{},
+	})
+	require.NoError(t, err)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	_, err = backupapp.Restore(
+		t.Context(), repo, "test-version", backup.RestoreOptions{TargetDir: target})
+	require.ErrorContains(t, err, "importing metadata JSONL")
+	_, statErr := os.Stat(filepath.Join(target, "docbank.db"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
 func TestLooseAbovePackingLimitSnapshotVerifyAndRestore(t *testing.T) {
@@ -135,9 +273,8 @@ func TestLooseAbovePackingLimitSnapshotVerifyAndRestore(t *testing.T) {
 	app := backupapp.New("test-version")
 	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
 	require.NoError(t, err)
-	manifest, err := backup.Create(t.Context(), repo, app, backup.CreateOptions{
-		DBPath: filepath.Join(fixture.root, "docbank.db"), ContentSource: backupapp.NewContentSource(fixture.blobs),
-	})
+	manifest, err := backupapp.Create(
+		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs, backup.CreateOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), manifest.Attachments.Blobs)
 	verified, err := backup.Verify(t.Context(), repo, app, backup.VerifyOptions{})
@@ -145,7 +282,8 @@ func TestLooseAbovePackingLimitSnapshotVerifyAndRestore(t *testing.T) {
 	assert.Empty(t, verified.Problems)
 
 	target := filepath.Join(t.TempDir(), "restored")
-	_, err = backup.Restore(t.Context(), repo, app, backup.RestoreOptions{TargetDir: target})
+	_, err = backupapp.Restore(
+		t.Context(), repo, "test-version", backup.RestoreOptions{TargetDir: target})
 	require.NoError(t, err)
 	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
 	require.NoError(t, err)
@@ -173,11 +311,10 @@ func TestPackedSnapshotRequiresAndUsesPackedRestoreTarget(t *testing.T) {
 	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
 	require.NoError(t, err)
 	app := backupapp.New("test-version")
-	manifest, err := backup.Create(context.Background(), repo, app, backup.CreateOptions{
-		DBPath:        filepath.Join(fixture.root, "docbank.db"),
-		ContentSource: backupapp.NewContentSource(fixture.blobs),
-		Jobs:          2,
-	})
+	manifest, err := backupapp.Create(
+		context.Background(), repo, "test-version", fixture.metadata, fixture.blobs, backup.CreateOptions{
+			Jobs: 2,
+		})
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), manifest.Attachments.Blobs)
 
@@ -189,7 +326,7 @@ func TestPackedSnapshotRequiresAndUsesPackedRestoreTarget(t *testing.T) {
 	_, err = backup.Restore(t.Context(), repo, app, backup.RestoreOptions{
 		TargetDir: unsafeTarget, Jobs: 2,
 	})
-	require.ErrorContains(t, err, "snapshot contains packed blob authority")
+	require.ErrorContains(t, err, "requires a MetadataRestorer")
 
 	target := filepath.Join(t.TempDir(), "restored")
 	restored, err := backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{

--- a/internal/backupapp/metadata.go
+++ b/internal/backupapp/metadata.go
@@ -1,0 +1,152 @@
+package backupapp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+
+	"go.kenn.io/kit/backup"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+// MetadataFormat is the stable Kit manifest identifier for Docbank's
+// deterministic logical metadata stream.
+const MetadataFormat = "docbank-metadata-jsonl-v1"
+
+// MetadataSource pins one Docbank transaction for JSONL, content membership,
+// and fidelity statistics. OpenMetadata performs a counting pass and then
+// streams a second deterministic pass without materializing the JSONL.
+type MetadataSource struct{ metadata *store.Store }
+
+var _ backup.MetadataSource = (*MetadataSource)(nil)
+
+func NewMetadataSource(metadata *store.Store) *MetadataSource {
+	return &MetadataSource{metadata: metadata}
+}
+
+func (*MetadataSource) Format() string { return MetadataFormat }
+
+func (s *MetadataSource) OpenSnapshot(ctx context.Context) (backup.MetadataSnapshot, error) {
+	if s == nil || s.metadata == nil {
+		return nil, errors.New("backupapp: metadata source has no store")
+	}
+	tx, err := s.metadata.BeginMetadataSnapshot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("backupapp: opening metadata snapshot: %w", err)
+	}
+	return &metadataSnapshot{tx: tx}, nil
+}
+
+type metadataSnapshot struct {
+	tx         *store.MetadataSnapshot
+	reader     *io.PipeReader
+	exportDone chan error
+	opened     bool
+	closed     bool
+}
+
+var _ backup.MetadataSnapshot = (*metadataSnapshot)(nil)
+
+func (s *metadataSnapshot) OpenMetadata(ctx context.Context) (io.ReadCloser, int64, error) {
+	if s.closed {
+		return nil, 0, errors.New("backupapp: metadata snapshot is closed")
+	}
+	if s.opened {
+		return nil, 0, errors.New("backupapp: metadata stream already opened")
+	}
+	s.opened = true
+	var count byteCounter
+	if err := s.tx.Export(ctx, &count); err != nil {
+		return nil, 0, fmt.Errorf("backupapp: sizing metadata JSONL: %w", err)
+	}
+	reader, writer := io.Pipe()
+	s.reader = reader
+	s.exportDone = make(chan error, 1)
+	go func() {
+		exportErr := s.tx.Export(ctx, writer)
+		closeErr := writer.CloseWithError(exportErr)
+		s.exportDone <- errors.Join(exportErr, closeErr)
+	}()
+	return reader, count.n, nil
+}
+
+func (s *metadataSnapshot) ContentInfo(ctx context.Context) (*backup.ContentInfo, error) {
+	if s.closed {
+		return nil, errors.New("backupapp: metadata snapshot is closed")
+	}
+	return (&frozenView{tx: s.tx}).ContentInfo(ctx)
+}
+
+func (s *metadataSnapshot) Stats(ctx context.Context) (json.RawMessage, error) {
+	if s.closed {
+		return nil, errors.New("backupapp: metadata snapshot is closed")
+	}
+	return (&frozenView{tx: s.tx}).Stats(ctx)
+}
+
+func (s *metadataSnapshot) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	var exportErr error
+	if s.reader != nil {
+		_ = s.reader.Close()
+		exportErr = <-s.exportDone
+	}
+	return errors.Join(exportErr, s.tx.Close())
+}
+
+type byteCounter struct{ n int64 }
+
+func (w *byteCounter) Write(p []byte) (int, error) {
+	if int64(len(p)) > math.MaxInt64-w.n {
+		return 0, errors.New("backupapp: metadata JSONL size exceeds int64")
+	}
+	w.n += int64(len(p))
+	return len(p), nil
+}
+
+type metadataRestorer struct{}
+
+var _ backup.MetadataRestorer = metadataRestorer{}
+
+func (metadataRestorer) RestoreMetadata(
+	ctx context.Context, format string, metadata io.Reader, targetPath string,
+) (resultErr error) {
+	if format != MetadataFormat {
+		return fmt.Errorf("backupapp: unsupported metadata format %q", format)
+	}
+	target, err := store.Open(targetPath)
+	if err != nil {
+		return fmt.Errorf("backupapp: creating restored metadata store: %w", err)
+	}
+	open := true
+	defer func() {
+		if open {
+			resultErr = errors.Join(resultErr, target.Close())
+		}
+	}()
+	if err := target.ImportMetadata(ctx, metadata); err != nil {
+		return fmt.Errorf("backupapp: importing metadata JSONL: %w", err)
+	}
+	if err := target.Checkpoint(ctx); err != nil {
+		return fmt.Errorf("backupapp: checkpointing restored metadata: %w", err)
+	}
+	closeErr := target.Close()
+	open = false
+	if closeErr != nil {
+		return fmt.Errorf("backupapp: closing restored metadata store: %w", closeErr)
+	}
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		if err := os.Remove(targetPath + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("backupapp: removing restored metadata sidecar %s: %w", suffix, err)
+		}
+	}
+	return nil
+}

--- a/internal/backupapp/resource_benchmark_test.go
+++ b/internal/backupapp/resource_benchmark_test.go
@@ -243,23 +243,22 @@ func BenchmarkDocbankLooseBackupRoundTrip1GiB(b *testing.B) {
 
 func benchmarkBackupRoundTrip(b *testing.B, fixture *resourceFixture, size int64) {
 	b.Helper()
-	app := backupapp.New("benchmark-version")
 	root := b.TempDir()
+	app := backupapp.New("benchmark-version")
 	b.ReportAllocs()
 	b.SetBytes(3 * size)
 	b.ResetTimer()
 	for i := range b.N {
 		repo, err := backup.Init(filepath.Join(root, fmt.Sprintf("repo-%d", i)))
 		require.NoError(b, err)
-		_, err = backup.Create(context.Background(), repo, app, backup.CreateOptions{
-			DBPath:        filepath.Join(fixture.root, "docbank.db"),
-			ContentSource: backupapp.NewContentSource(fixture.blobs), Jobs: 1,
-		})
+		_, err = backupapp.Create(
+			context.Background(), repo, "benchmark-version", fixture.metadata, fixture.blobs,
+			backup.CreateOptions{Jobs: 1})
 		require.NoError(b, err)
 		verified, err := backup.Verify(context.Background(), repo, app, backup.VerifyOptions{Jobs: 1})
 		require.NoError(b, err)
 		require.Empty(b, verified.Problems)
-		_, err = backup.Restore(context.Background(), repo, app, backup.RestoreOptions{
+		_, err = backupapp.Restore(context.Background(), repo, "benchmark-version", backup.RestoreOptions{
 			TargetDir: filepath.Join(root, fmt.Sprintf("restore-%d", i)), Jobs: 1,
 		})
 		require.NoError(b, err)

--- a/internal/backupapp/restore.go
+++ b/internal/backupapp/restore.go
@@ -49,7 +49,11 @@ func Restore(
 	if opts.PackedContent != nil {
 		return nil, errors.New("backupapp: restore options must not supply packed content policy")
 	}
+	if opts.MetadataRestorer != nil {
+		return nil, errors.New("backupapp: restore options must not supply a metadata restorer")
+	}
 	opts.PackedContent = newPackedRestoreTarget()
+	opts.MetadataRestorer = metadataRestorer{}
 	app := &packedRestoreApp{App: New(version)}
 	result, err := backup.Restore(ctx, repo, app, opts)
 	if err != nil {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -16,6 +16,62 @@ import (
 
 const metadataFormatVersion = 1
 
+// MetadataSnapshot owns a dedicated deferred read transaction. Store's normal
+// connections use BEGIN IMMEDIATE for mutations; using that pool here would
+// hold the writer lock for the full backup instead of only pinning a WAL view.
+type MetadataSnapshot struct {
+	db *sql.DB
+	tx *sql.Tx
+}
+
+func (s *MetadataSnapshot) QueryContext(
+	ctx context.Context, query string, args ...any,
+) (*sql.Rows, error) {
+	return s.tx.QueryContext(ctx, query, args...)
+}
+
+func (s *MetadataSnapshot) QueryRowContext(
+	ctx context.Context, query string, args ...any,
+) *sql.Row {
+	return s.tx.QueryRowContext(ctx, query, args...)
+}
+
+func (s *MetadataSnapshot) Close() error {
+	rollbackErr := s.tx.Rollback()
+	if errors.Is(rollbackErr, sql.ErrTxDone) {
+		rollbackErr = nil
+	}
+	return errors.Join(rollbackErr, s.db.Close())
+}
+
+// Export writes the deterministic logical metadata held by this snapshot.
+func (s *MetadataSnapshot) Export(ctx context.Context, w io.Writer) error {
+	return exportMetadataSnapshot(ctx, s, w)
+}
+
+// BeginMetadataSnapshot establishes a pinned read transaction for logical
+// backup capture. The initial read is required: BeginTx alone is lazy in
+// SQLite and would not pin a snapshot before Kit releases the mutation gate.
+func (s *Store) BeginMetadataSnapshot(ctx context.Context) (*MetadataSnapshot, error) {
+	db, err := sql.Open("sqlite3",
+		s.path+"?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=5000&_txlock=deferred")
+	if err != nil {
+		return nil, fmt.Errorf("beginning metadata snapshot: %w", err)
+	}
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("beginning metadata snapshot: %w", err)
+	}
+	var schemaVersion int64
+	if err := tx.QueryRowContext(ctx, `PRAGMA schema_version`).Scan(&schemaVersion); err != nil {
+		_ = tx.Rollback()
+		_ = db.Close()
+		return nil, fmt.Errorf("pinning metadata snapshot: %w", err)
+	}
+	return &MetadataSnapshot{db: db, tx: tx}, nil
+}
+
 type metadataHeader struct {
 	Type         string `json:"type"`
 	Format       string `json:"format"`
@@ -98,24 +154,29 @@ type metadataExtractedText struct {
 // ExportMetadata writes a deterministic JSONL description of Docbank's
 // logical state. Rebuildable FTS data and physical pack authority are omitted.
 func (s *Store) ExportMetadata(ctx context.Context, w io.Writer) error {
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	tx, err := s.BeginMetadataSnapshot(ctx)
 	if err != nil {
-		return fmt.Errorf("beginning metadata snapshot: %w", err)
-	}
-	if err := ExportMetadataTx(ctx, tx, w); err != nil {
-		_ = tx.Rollback()
 		return err
 	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("committing metadata snapshot: %w", err)
+	if err := tx.Export(ctx, w); err != nil {
+		_ = tx.Close()
+		return err
+	}
+	if err := tx.Close(); err != nil {
+		return fmt.Errorf("closing metadata snapshot: %w", err)
 	}
 	return nil
 }
 
-// ExportMetadataTx writes metadata from an already pinned SQLite snapshot.
+type metadataQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// exportMetadataSnapshot writes metadata from an already pinned SQLite snapshot.
 // Backup capture uses this entry point so metadata and blob membership come
 // from the same frozen transaction.
-func ExportMetadataTx(ctx context.Context, tx *sql.Tx, w io.Writer) error {
+func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer) error {
 	if tx == nil {
 		return errors.New("exporting metadata: nil transaction")
 	}
@@ -162,7 +223,7 @@ func ExportMetadataTx(ctx context.Context, tx *sql.Tx, w io.Writer) error {
 
 type metadataWrite func(any) error
 
-func exportBlobs(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+func exportBlobs(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `SELECT hash, size, created_at FROM blobs ORDER BY hash`)
 	if err != nil {
 		return fmt.Errorf("exporting blobs: %w", err)
@@ -180,7 +241,7 @@ func exportBlobs(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
 	return rowsError("blob", rows)
 }
 
-func exportNodes(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+func exportNodes(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `
 		SELECT id, parent_id, name, kind, blob_hash, size, mime_type, revision,
 		       created_at, modified_at, trashed_at, trash_parent, trash_name
@@ -207,7 +268,7 @@ func exportNodes(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
 	return rowsError("node", rows)
 }
 
-func exportNodeVersions(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+func exportNodeVersions(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `
 		SELECT node_id, blob_hash, size, replaced_at FROM node_versions
 		ORDER BY node_id, replaced_at, blob_hash, size`)
@@ -227,7 +288,7 @@ func exportNodeVersions(ctx context.Context, tx *sql.Tx, write metadataWrite) er
 	return rowsError("node version", rows)
 }
 
-func exportIngests(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+func exportIngests(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `SELECT id, started_at, source_kind, source_desc FROM ingests ORDER BY id`)
 	if err != nil {
 		return fmt.Errorf("exporting ingests: %w", err)
@@ -245,7 +306,7 @@ func exportIngests(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
 	return rowsError("ingest", rows)
 }
 
-func exportProvenance(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+func exportProvenance(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `
 		SELECT node_id, ingest_id, original_path, original_mtime FROM provenance
 		ORDER BY node_id, ingest_id, original_path, original_mtime`)
@@ -267,7 +328,7 @@ func exportProvenance(ctx context.Context, tx *sql.Tx, write metadataWrite) erro
 	return rowsError("provenance", rows)
 }
 
-func exportTags(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+func exportTags(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `SELECT id, name FROM tags ORDER BY id`)
 	if err != nil {
 		return fmt.Errorf("exporting tags: %w", err)
@@ -285,7 +346,7 @@ func exportTags(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
 	return rowsError("tag", rows)
 }
 
-func exportNodeTags(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+func exportNodeTags(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `SELECT node_id, tag_id FROM node_tags ORDER BY node_id, tag_id`)
 	if err != nil {
 		return fmt.Errorf("exporting node tags: %w", err)
@@ -303,7 +364,7 @@ func exportNodeTags(ctx context.Context, tx *sql.Tx, write metadataWrite) error 
 	return rowsError("node tag", rows)
 }
 
-func exportExtractedText(ctx context.Context, tx *sql.Tx, write metadataWrite) error {
+func exportExtractedText(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `
 		SELECT blob_hash, extractor, extractor_version, status, error, attempts, text, extracted_at
 		FROM extracted_text ORDER BY blob_hash, extractor`)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,7 @@ var schemaSQL string
 // Store is the single access path to the docbank database.
 type Store struct {
 	db     *sql.DB
+	path   string
 	rootID int64
 }
 
@@ -28,7 +29,7 @@ func Open(path string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening database %s: %w", path, err)
 	}
-	s := &Store{db: db}
+	s := &Store{db: db, path: path}
 	if err := s.bootstrap(); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -83,6 +84,23 @@ func (s *Store) RootID() int64 { return s.rootID }
 
 // Close closes the underlying database.
 func (s *Store) Close() error { return s.db.Close() }
+
+// Checkpoint truncates the WAL after all application writes have completed.
+// Portable restore uses it before closing a freshly imported database so the
+// main file is self-contained and no sidecar is required for publication.
+func (s *Store) Checkpoint(ctx context.Context) error {
+	var busy, logFrames, checkpointed int64
+	if err := s.db.QueryRowContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`).Scan(
+		&busy, &logFrames, &checkpointed); err != nil {
+		return fmt.Errorf("checkpointing database: %w", err)
+	}
+	if busy != 0 || logFrames != 0 {
+		return fmt.Errorf(
+			"checkpointing database: WAL remains busy=%d log=%d checkpointed=%d",
+			busy, logFrames, checkpointed)
+	}
+	return nil
+}
 
 // withTx runs fn inside a transaction, committing on nil and rolling back
 // on error. Used by later packages (Task 4+) for transactional operations.


### PR DESCRIPTION
SQLite should remain Docbank’s live query engine without making its historical page layout the permanent backup compatibility contract. Kit v0.9.0 now exposes the portable metadata lifecycle needed to archive Docbank’s logical state directly and reconstruct the current runtime schema during restore.

This makes deterministic `docbank-metadata-jsonl-v1` the only path for new internal captures. The snapshot uses a dedicated deferred transaction so the daemon can release its short freeze and resume writers into the WAL while metadata, content membership, and fidelity statistics remain pinned to one point in time. Restore builds and checkpoints a fresh database in Kit-owned staging, then lets Kit publish verified content and fresh packed authority before the vault becomes visible. Historical SQLite page-map snapshots remain readable so repositories created during the foundation work are not stranded.

The main review boundary is authority ordering: source pack rows never enter JSONL, malformed imports never publish a database, and ordinary callers cannot replace either the metadata or packed-restore policy. Integration coverage exercises stable post-freeze capture, byte-identical logical round trips, packed and oversized-loose content, malformed metadata cleanup, and legacy snapshot restore. The full repository, race-sensitive storage/backup, lint, vet, pre-commit, and strict documentation checks pass.