### PR TITLE
Expose backup repository verification

### DIFF
--- a/cmd/docbank/backup.go
+++ b/cmd/docbank/backup.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -139,6 +140,68 @@ var backupListCmd = &cobra.Command{
 	},
 }
 
+var (
+	backupVerifyRepo        string
+	backupVerifyAll         bool
+	backupVerifyQuick       bool
+	backupVerifyJobs        int
+	backupVerifyForceUnlock bool
+	backupVerifyJSON        bool
+	backupVerifyProgress    string
+)
+
+var backupVerifyCmd = &cobra.Command{
+	Use:   "verify [SNAPSHOT]",
+	Short: "Verify backup repository integrity",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if backupVerifyAll && len(args) > 0 {
+			return errors.New("backup verify: SNAPSHOT and --all are mutually exclusive")
+		}
+		repo, err := absoluteBackupRepo(backupVerifyRepo)
+		if err != nil {
+			return err
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		opts := client.BackupVerifyOptions{
+			Repo: repo, All: backupVerifyAll, Quick: backupVerifyQuick,
+			Jobs: backupVerifyJobs, ForceUnlock: backupVerifyForceUnlock,
+		}
+		if len(args) == 1 {
+			opts.SnapshotID = args[0]
+		}
+		var report api.BackupVerifyReport
+		if backupVerifyJSON {
+			report, err = c.BackupVerify(cmd.Context(), opts)
+		} else {
+			mode, modeErr := backupProgressModeFromFlag(backupVerifyProgress)
+			if modeErr != nil {
+				return modeErr
+			}
+			renderer := newBackupProgressRenderer(cmd.ErrOrStderr(), mode)
+			defer renderer.finish()
+			report, err = c.BackupVerifyStream(cmd.Context(), opts, renderer.handle)
+		}
+		if err != nil {
+			return err
+		}
+		if backupVerifyJSON {
+			if err := writeBackupJSON(cmd.OutOrStdout(), report); err != nil {
+				return err
+			}
+		} else if err := writeBackupVerifyReport(cmd.OutOrStdout(), report); err != nil {
+			return err
+		}
+		if len(report.Problems) > 0 {
+			return fmt.Errorf("backup verify: found %d problem(s)", len(report.Problems))
+		}
+		return nil
+	},
+}
+
 func absoluteBackupRepo(repo string) (string, error) {
 	if repo == "" {
 		return "", nil
@@ -188,6 +251,22 @@ func writeBackupList(w io.Writer, snapshots []api.BackupSnapshot) error {
 	return nil
 }
 
+func writeBackupVerifyReport(w io.Writer, report api.BackupVerifyReport) error {
+	for _, problem := range report.Problems {
+		if _, err := fmt.Fprintf(w, "problem: snapshot %s: %s\n",
+			problem.SnapshotID, problem.Detail); err != nil {
+			return fmt.Errorf("writing backup verification problem: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintf(w,
+		"verified %d snapshot(s), %d blob(s), %s read; %d problem(s)\n",
+		len(report.Snapshots), report.BlobsChecked, formatBackupBytes(report.BytesRead),
+		len(report.Problems)); err != nil {
+		return fmt.Errorf("writing backup verification summary: %w", err)
+	}
+	return nil
+}
+
 func init() {
 	backupInitCmd.Flags().StringVar(&backupInitRepo, "repo", "", "backup repository directory")
 	backupInitCmd.Flags().BoolVar(&backupInitJSON, "json", false, "machine-readable output")
@@ -202,6 +281,17 @@ func init() {
 		"progress output mode: auto, bar, or plain (suppressed by --json)")
 	backupListCmd.Flags().StringVar(&backupListRepo, "repo", "", "backup repository directory")
 	backupListCmd.Flags().BoolVar(&backupListJSON, "json", false, "machine-readable output")
-	backupCmd.AddCommand(backupInitCmd, backupCreateCmd, backupListCmd)
+	backupVerifyCmd.Flags().StringVar(&backupVerifyRepo, "repo", "", "backup repository directory")
+	backupVerifyCmd.Flags().BoolVar(&backupVerifyAll, "all", false, "verify every snapshot")
+	backupVerifyCmd.Flags().BoolVar(&backupVerifyQuick, "quick", false,
+		"check repository structure without reading content bytes")
+	backupVerifyCmd.Flags().IntVar(&backupVerifyJobs, "jobs", 0,
+		"concurrent blob readers (0 uses one per CPU; use 1 for spinning disks or NAS shares)")
+	backupVerifyCmd.Flags().BoolVar(&backupVerifyForceUnlock, "force-unlock", false,
+		"break a fresh repository lock only when its owner is known to be gone")
+	backupVerifyCmd.Flags().BoolVar(&backupVerifyJSON, "json", false, "machine-readable output")
+	backupVerifyCmd.Flags().StringVar(&backupVerifyProgress, "progress", "auto",
+		"progress output mode: auto, bar, or plain (suppressed by --json)")
+	backupCmd.AddCommand(backupInitCmd, backupCreateCmd, backupListCmd, backupVerifyCmd)
 	rootCmd.AddCommand(backupCmd)
 }

--- a/cmd/docbank/backup_progress.go
+++ b/cmd/docbank/backup_progress.go
@@ -61,7 +61,7 @@ func backupProgressModeFromFlag(value string) (backupProgressMode, error) {
 		return backupProgressPlain, nil
 	default:
 		return backupProgressAuto, fmt.Errorf(
-			"backup create: invalid --progress value %q (want auto, bar, or plain)", value)
+			"backup: invalid --progress value %q (want auto, bar, or plain)", value)
 	}
 }
 

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/backup"
+	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/backupapp"
@@ -350,7 +351,7 @@ func TestStorageStatusHumanAndJSON(t *testing.T) {
 	assert.Equal(t, int64(5), status.LooseBytes)
 }
 
-func TestBackupInitCreateListCLI(t *testing.T) {
+func TestBackupInitCreateListVerifyCLI(t *testing.T) {
 	home := t.TempDir()
 	repoPath := filepath.Join(t.TempDir(), "repo")
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
@@ -390,11 +391,47 @@ func TestBackupInitCreateListCLI(t *testing.T) {
 	require.Len(t, listed.Items, 2)
 	assert.Equal(t, backupapp.MetadataFormat, listed.Items[0].MetadataFormat)
 
+	out, err = runCLI(t, "backup", "verify", "--all", "--jobs", "1", "--progress", "plain")
+	require.NoError(t, err)
+	assert.Contains(t, out, "verify:")
+	assert.Contains(t, out, "verified 2 snapshot(s)")
+	assert.Contains(t, out, "0 problem(s)")
+
+	out, err = runCLI(t, "backup", "verify", created.ID, "--quick", "--json")
+	require.NoError(t, err)
+	var verification api.BackupVerifyReport
+	require.NoError(t, json.Unmarshal([]byte(out), &verification),
+		"--json must contain no progress lines")
+	assert.Equal(t, []string{created.ID}, verification.Snapshots)
+	assert.Positive(t, verification.BytesRead, "quick verification still reads metadata")
+
+	_, err = runCLI(t, "backup", "verify", created.ID, "--all")
+	require.ErrorContains(t, err, "mutually exclusive")
+
 	repo, err := backup.Open(repoPath)
 	require.NoError(t, err)
 	verified, err := backup.Verify(t.Context(), repo, backupapp.New("test"), backup.VerifyOptions{})
 	require.NoError(t, err)
 	assert.Empty(t, verified.Problems)
+
+	manifests, err := repo.ListSnapshots()
+	require.NoError(t, err)
+	require.Len(t, manifests, 2)
+	manifest := manifests[0]
+	require.NotEmpty(t, manifest.NewPacks)
+	packID := manifest.NewPacks[0]
+	packPath := repo.Path("packs", packID[:2], packID+packstore.PackExt)
+	packBytes, err := os.ReadFile(packPath)
+	require.NoError(t, err)
+	packBytes[len(packBytes)/3] ^= 1
+	require.NoError(t, os.WriteFile(packPath, packBytes, 0o600))
+
+	out, err = runCLI(t, "backup", "verify", manifest.SnapshotID, "--jobs", "1", "--json")
+	require.ErrorContains(t, err, "found")
+	require.NoError(t, json.Unmarshal([]byte(out), &verification),
+		"failed JSON proof must remain one machine-readable report")
+	assert.NotEmpty(t, verification.Problems)
+	assert.Equal(t, manifest.SnapshotID, verification.Problems[0].SnapshotID)
 }
 
 func TestStoragePackBudgetAndJSON(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -139,7 +139,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "5", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "6", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -77,10 +77,20 @@ reporting success. The human CLI renders the same events as terminal bars or
 plain log lines. Machine-readable CLI output uses the non-streaming endpoint so
 stdout remains one JSON document.
 
-!!! info "Planned — remaining Phase 4 commands"
-    `docbank backup verify` and `docbank backup restore` have not landed. The
-    restore adapter described above is internal until the recovery CLI/API
-    defines target confinement, overwrite behavior, and operator output.
+Repository verification is daemon-mediated even though it reads the backup
+repository rather than the live vault. The authenticated JSON endpoint returns
+one complete typed report; the NDJSON endpoint carries Kit's verification
+progress followed by exactly one terminal report or error. Quick mode proves
+structure and references without reading document content. Full mode reads and
+hash-verifies referenced content, deduplicating shared objects across selected
+snapshots, and returns every finding rather than stopping at the first damaged
+object. Kit's shared repository lock permits concurrent verifies and restores
+while excluding repository writers.
+
+!!! info "Planned — remaining Phase 4 command"
+    `docbank backup restore` has not landed. The restore adapter described above
+    is internal until the recovery CLI/API defines target confinement,
+    overwrite behavior, and operator output.
 
 Backup reachability is intentionally broader than GC reachability: every
 `blobs` row is captured, including a row that has become a GC candidate but has

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -126,7 +126,7 @@ metadata, durability rules, and physical storage primitives from
 
 !!! info "Planned — later clients and features"
     Versioned editing, tags, watched inboxes, text extraction, the TUI, and
-    built-in backup verification and restore are designed but not implemented.
-    Backup initialization, creation, and listing already use the daemon
+    built-in backup restore is designed but not implemented. Backup
+    initialization, creation, listing, and repository verification use the daemon
     boundary above. Later features must not introduce a privileged path around
     the daemon or mutable blob bytes. See the [Roadmap](../roadmap.md).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -272,22 +272,27 @@ docbank backup init [--repo <dir>] [--json]
 docbank backup create [--repo <dir>] [--tag <label>] [--jobs <n>]
                       [--force-unlock] [--progress auto|bar|plain] [--json]
 docbank backup list [--repo <dir>] [--json]
+docbank backup verify [snapshot] [--repo <dir>] [--all] [--quick] [--jobs <n>]
+                      [--force-unlock] [--progress auto|bar|plain] [--json]
 ```
 
 Initializes an immutable Kit repository, captures a verified JSONL-native
-snapshot through the daemon, and lists snapshot history. `--repo` overrides
+snapshot through the daemon, lists snapshot history, and independently proves
+repository integrity. `--repo` overrides
 `[backup] repo`; one of them is required. `create` briefly quiesces mutations
 only while pinning its logical view, then streams loose or packed content while
 normal daemon work resumes. `--jobs 1` serializes repository readers;
 `--force-unlock` is only for a repository lock whose owner is known to be gone.
-`create` draws per-stage progress bars on a terminal and durable progress lines
-when redirected; `--progress` can force either form. Every subcommand supports
-typed `--json` output; create suppresses progress in that mode. See
+`create` and `verify` draw per-stage progress bars on a terminal and durable
+progress lines when redirected; `--progress` can force either form. `verify`
+checks the latest snapshot by default, one named snapshot positionally, or all
+snapshots with `--all`; `--quick` skips content reads. Every subcommand supports
+typed `--json` output; long-running operations suppress progress in that mode. See
 [Backup](usage/backup.md).
 
 !!! info "Planned"
-    `docbank backup verify` and `docbank backup restore` are the next Phase 4
-    command slice and are not available yet.
+    `docbank backup restore` is the remaining Phase 4 command and is not
+    available yet.
 
 ## docbank daemon
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -119,8 +119,8 @@ Docbank's deterministic logical JSONL artifact, which round-trips directory
 structure, stable node IDs, content membership, trash state, versions,
 provenance, tags, and extraction state into a fresh current-schema database.
 Historical SQLite page-map snapshots remain restorable. Authenticated daemon
-API and CLI orchestration for repository initialization, snapshot creation, and
-listing are implemented; verification and restore commands remain.
+API and CLI orchestration for repository initialization, snapshot creation,
+listing, and repository verification are implemented; restore remains.
 
 ## Deferred beyond v1
 

--- a/docs/usage/backup.md
+++ b/docs/usage/backup.md
@@ -10,10 +10,12 @@ checksummed files. A snapshot contains the deterministic JSONL description of
 the virtual tree plus every catalog-authorized document blob, whether its live
 representation is loose or packed. Unchanged metadata and content are reused
 across snapshots, so repeated captures add only new repository objects and a
-new manifest.
+new manifest. Metadata is a complete logical JSONL description per snapshot,
+not a row-level delta: an unchanged description is reused by hash, while any
+logical change stores one new compressed metadata object.
 
-The current command surface initializes repositories, creates snapshots, and
-lists them. Repository verification and user-facing restore are the next
+The current command surface initializes repositories, creates snapshots,
+lists them, and verifies repository integrity. User-facing restore is the next
 backup slice; the underlying verified restore engine is already integrated.
 
 !!! warning "Repositories are not encrypted"
@@ -33,6 +35,9 @@ docbank backup create --repo ~/Backups/docbank --tag before-reorganization
 
 # Inspect the snapshot history
 docbank backup list --repo ~/Backups/docbank
+
+# Prove the latest snapshot, including every referenced content byte
+docbank backup verify --repo ~/Backups/docbank
 ```
 
 Set a default repository to omit `--repo`:
@@ -98,6 +103,31 @@ counts, bytes newly added to the repository, and tag. `--json` returns the same
 typed snapshot summaries as `GET /api/v1/backup/snapshots`, including the
 metadata format and parent snapshot ID.
 
+## Verify repository integrity
+
+```bash
+docbank backup verify [SNAPSHOT] [--repo DIR] [--all] [--quick] [--jobs N]
+                      [--force-unlock] [--progress auto|bar|plain] [--json]
+```
+
+With no snapshot argument, verification proves the latest snapshot. Pass an
+immutable snapshot ID to prove one historical snapshot, or `--all` to prove
+every manifest. A full verification resolves repository indexes and pack
+footers, materializes the snapshot's JSONL metadata, reads and SHA-256 verifies
+every referenced content object, and checks Docbank's recorded logical totals.
+Content shared by several selected snapshots is read only once during one
+verification pass. Every finding is reported with the affected snapshot, and
+the command exits non-zero if any problems were found.
+
+`--quick` checks manifests, indexes, pack structure, metadata, and logical
+references without reading document content. Its `bytes_read` therefore still
+includes metadata bytes. It is useful after each capture,
+but it does not prove the storage medium has retained every content byte; run
+full verification regularly. `--jobs 1` avoids concurrent reads on spinning
+disks and latency-sensitive network storage. The progress and JSON contracts
+match `backup create`: progress is written to stderr, and `--json` suppresses
+progress so stdout contains one typed report.
+
 ## Repository placement
 
 Keep the repository outside `$DOCBANK_HOME`. It is independent archive state,
@@ -106,8 +136,8 @@ repository suitable for `rsync`, `rclone`, cloud-drive sync, filesystem
 snapshots, or removable media. Sync after `backup create` completes; never edit
 repository packs, indexes, manifests, locks, or configuration by hand.
 
-!!! info "Planned — verification and restore commands"
-    `docbank backup verify` and `docbank backup restore` are not exposed yet.
-    Until they land, snapshot creation and listing are usable, but the CLI does
-    not yet provide the complete recovery workflow. Manual filesystem snapshots
+!!! info "Planned — restore command"
+    `docbank backup restore` is not exposed yet. Until it lands, the built-in
+    workflow can capture and independently verify snapshots but cannot
+    materialize one through the user-facing CLI. Manual filesystem snapshots
     remain documented under [Vault Lifecycle](lifecycle.md).

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -111,11 +111,11 @@ allow replacing an unversioned development build.
 
 ## Take a coherent manual snapshot
 
-Docbank provides `backup init`, `backup create`, and `backup list` for
-incremental, verified capture into an immutable Kit repository; see
-[Backup](backup.md). Those repositories are compressed but **not encrypted**,
-and user-facing `backup verify` and `backup restore` commands have not landed
-yet.
+Docbank provides `backup init`, `backup create`, `backup list`, and `backup
+verify` for incremental capture and independent integrity proof in an
+immutable Kit repository; see [Backup](backup.md). Those repositories are
+compressed but **not encrypted**, and user-facing `backup restore` has not
+landed yet.
 
 A stopped-vault copy remains the complete manual recovery path while restore is
 planned. Stop the daemon before copying so the SQLite database and blob catalog
@@ -150,11 +150,10 @@ a running vault. To replace a damaged vault, stop the daemon, preserve the old
 directory under another name, restore the snapshot, and verify before resuming
 normal use.
 
-!!! info "Planned — backup verification and restore"
-    `docbank backup verify` and `docbank backup restore` will complete the
-    built-in recovery workflow. `backup init`, `backup create`, and `backup
-    list` already exist and produce unencrypted incremental snapshots. See
-    [Backup](backup.md).
+!!! info "Planned — backup restore"
+    `docbank backup restore` will complete the built-in recovery workflow.
+    Initialization, incremental capture, listing, and repository verification
+    already exist for unencrypted repositories. See [Backup](backup.md).
 
 ## Move a vault
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -18,7 +18,8 @@ func timeoutExempt(path string) bool {
 	switch path {
 	case "/api/v1/ingest", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
 		"/api/v1/storage/pack", "/api/v1/storage/repack", "/api/v1/uploads",
-		"/api/v1/backup/snapshots", "/api/v1/backup/snapshots/stream":
+		"/api/v1/backup/snapshots", "/api/v1/backup/snapshots/stream",
+		"/api/v1/backup/verify", "/api/v1/backup/verify/stream":
 		return true
 	}
 	return strings.HasPrefix(path, "/api/v1/nodes/") && strings.HasSuffix(path, "/verify")

--- a/internal/api/routes_backup.go
+++ b/internal/api/routes_backup.go
@@ -25,6 +25,15 @@ type backupCreateRequest struct {
 	ForceUnlock bool   `json:"force_unlock,omitempty"`
 }
 
+type backupVerifyRequest struct {
+	Repo        string `json:"repo,omitempty"`
+	SnapshotID  string `json:"snapshot_id,omitempty"`
+	All         bool   `json:"all,omitempty"`
+	Quick       bool   `json:"quick,omitempty"`
+	Jobs        int    `json:"jobs,omitempty" minimum:"0"`
+	ForceUnlock bool   `json:"force_unlock,omitempty"`
+}
+
 func registerBackupRoutes(api huma.API, d Deps, g *gate) {
 	type initOutput struct{ Body BackupRepository }
 	huma.Register(api, huma.Operation{
@@ -92,7 +101,7 @@ func registerBackupRoutes(api huma.API, d Deps, g *gate) {
 			hctx.SetHeader("Cache-Control", "no-store")
 			runCtx, cancel := context.WithCancel(hctx.Context())
 			defer cancel()
-			stream := newBackupEventWriter(hctx.BodyWriter(), cancel)
+			stream := newBackupEventWriter[BackupCreateEvent](hctx.BodyWriter(), cancel)
 			snapshot, createErr := createBackupSnapshot(
 				runCtx, repo, d, g, in.Body,
 				func(event backup.ProgressEvent) {
@@ -140,6 +149,70 @@ func registerBackupRoutes(api huma.API, d Deps, g *gate) {
 		}
 		return out, nil
 	})
+
+	type verifyOutput struct{ Body BackupVerifyReport }
+	huma.Register(api, huma.Operation{
+		OperationID: "verifyBackupRepository", Method: http.MethodPost, Path: "/api/v1/backup/verify",
+		Summary: "Verify backup repository integrity",
+	}, func(ctx context.Context, in *struct {
+		Body backupVerifyRequest
+	}) (*verifyOutput, error) {
+		repo, err := openBackupRepository(d, in.Body.Repo)
+		if err != nil {
+			return nil, err
+		}
+		report, err := verifyBackupRepository(ctx, repo, in.Body, nil)
+		if err != nil {
+			return nil, err
+		}
+		return &verifyOutput{Body: report}, nil
+	})
+
+	verifyStreamSchema := api.OpenAPI().Components.Schemas.Schema(
+		reflect.TypeFor[BackupVerifyEvent](), true, "BackupVerifyEvent")
+	huma.Register(api, huma.Operation{
+		OperationID: "streamBackupRepositoryVerification", Method: http.MethodPost,
+		Path:    "/api/v1/backup/verify/stream",
+		Summary: "Verify a backup repository and stream structured progress",
+		Description: "Returns newline-delimited JSON. Progress events precede exactly one terminal " +
+			"result or error event; an HTTP 200 only means the stream started.",
+		Responses: map[string]*huma.Response{
+			"200": {
+				Description: "Backup verification progress followed by one terminal result or error",
+				Content: map[string]*huma.MediaType{
+					"application/x-ndjson": {Schema: verifyStreamSchema},
+				},
+			},
+		},
+	}, func(_ context.Context, in *struct {
+		Body backupVerifyRequest
+	}) (*huma.StreamResponse, error) {
+		repo, err := openBackupRepository(d, in.Body.Repo)
+		if err != nil {
+			return nil, err
+		}
+		return &huma.StreamResponse{Body: func(hctx huma.Context) {
+			hctx.SetHeader("Content-Type", "application/x-ndjson")
+			hctx.SetHeader("Cache-Control", "no-store")
+			runCtx, cancel := context.WithCancel(hctx.Context())
+			defer cancel()
+			stream := newBackupEventWriter[BackupVerifyEvent](hctx.BodyWriter(), cancel)
+			report, verifyErr := verifyBackupRepository(runCtx, repo, in.Body,
+				func(event backup.ProgressEvent) {
+					stream.send(BackupVerifyEvent{
+						Type: "progress", Progress: backupProgress(event),
+					})
+				})
+			if stream.err() != nil {
+				return
+			}
+			if verifyErr != nil {
+				stream.send(BackupVerifyEvent{Type: "error", Error: backupProblem(verifyErr)})
+				return
+			}
+			stream.send(BackupVerifyEvent{Type: "result", Report: &report})
+		}}, nil
+	})
 }
 
 func openBackupRepository(d Deps, requested string) (*backup.Repo, error) {
@@ -183,6 +256,36 @@ func createBackupSnapshot(
 	return snapshot, nil
 }
 
+func verifyBackupRepository(
+	ctx context.Context,
+	repo *backup.Repo,
+	in backupVerifyRequest,
+	progress func(backup.ProgressEvent),
+) (BackupVerifyReport, error) {
+	if in.All && in.SnapshotID != "" {
+		return BackupVerifyReport{}, NewError(http.StatusUnprocessableEntity, "validation",
+			"snapshot_id and all are mutually exclusive")
+	}
+	result, err := backup.Verify(ctx, repo, backupapp.New(version.Version), backup.VerifyOptions{
+		SnapshotID: in.SnapshotID, All: in.All, Quick: in.Quick, Jobs: in.Jobs,
+		ForceUnlock: in.ForceUnlock, Progress: progress,
+	})
+	if err != nil {
+		return BackupVerifyReport{}, fromBackupError(err)
+	}
+	report := BackupVerifyReport{
+		Snapshots: result.Snapshots, BlobsChecked: result.BlobsChecked,
+		BytesRead: result.BytesRead,
+		Problems:  make([]BackupVerifyProblem, 0, len(result.Problems)),
+	}
+	for _, problem := range result.Problems {
+		report.Problems = append(report.Problems, BackupVerifyProblem{
+			SnapshotID: problem.SnapshotID, Detail: problem.Detail,
+		})
+	}
+	return report, nil
+}
+
 func backupProgress(event backup.ProgressEvent) *BackupProgress {
 	return &BackupProgress{
 		Stage: string(event.Stage), Done: event.Done, Total: event.Total,
@@ -190,7 +293,7 @@ func backupProgress(event backup.ProgressEvent) *BackupProgress {
 	}
 }
 
-type backupEventWriter struct {
+type backupEventWriter[T any] struct {
 	mu       sync.Mutex
 	encoder  *json.Encoder
 	flusher  http.Flusher
@@ -198,13 +301,13 @@ type backupEventWriter struct {
 	writeErr error
 }
 
-func newBackupEventWriter(w io.Writer, cancel context.CancelFunc) *backupEventWriter {
-	return &backupEventWriter{
+func newBackupEventWriter[T any](w io.Writer, cancel context.CancelFunc) *backupEventWriter[T] {
+	return &backupEventWriter[T]{
 		encoder: json.NewEncoder(w), flusher: responseFlusher(w), cancel: cancel,
 	}
 }
 
-func (w *backupEventWriter) send(event BackupCreateEvent) {
+func (w *backupEventWriter[T]) send(event T) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.writeErr != nil {
@@ -220,7 +323,7 @@ func (w *backupEventWriter) send(event BackupCreateEvent) {
 	}
 }
 
-func (w *backupEventWriter) err() error {
+func (w *backupEventWriter[T]) err() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.writeErr

--- a/internal/api/routes_backup_test.go
+++ b/internal/api/routes_backup_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/backup"
+	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/backupapp"
@@ -23,6 +25,21 @@ func decodeBackupEvents(t *testing.T, body string) []api.BackupCreateEvent {
 	var events []api.BackupCreateEvent
 	for {
 		var event api.BackupCreateEvent
+		err := decoder.Decode(&event)
+		if err == io.EOF {
+			return events
+		}
+		require.NoError(t, err)
+		events = append(events, event)
+	}
+}
+
+func decodeBackupVerifyEvents(t *testing.T, body string) []api.BackupVerifyEvent {
+	t.Helper()
+	decoder := json.NewDecoder(strings.NewReader(body))
+	var events []api.BackupVerifyEvent
+	for {
+		var event api.BackupVerifyEvent
 		err := decoder.Decode(&event)
 		if err == io.EOF {
 			return events
@@ -118,6 +135,11 @@ func TestBackupRoutesValidateRepositoryAndReportLock(t *testing.T) {
 	require.NotNil(t, events[0].Error)
 	assert.Equal(t, "error", events[0].Type)
 	assert.Equal(t, "backup_locked", events[0].Error.Code)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/verify", nil,
+		map[string]any{"repo": repoPath})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	assert.Contains(t, body, `"code":"backup_locked"`)
 }
 
 func TestBackupCreateProgressStreamEndsWithResult(t *testing.T) {
@@ -151,4 +173,74 @@ func TestBackupCreateProgressStreamEndsWithResult(t *testing.T) {
 	require.NotNil(t, terminal.Snapshot)
 	assert.Equal(t, "streamed", terminal.Snapshot.Tag)
 	assert.Equal(t, int64(1), terminal.Snapshot.Files)
+}
+
+func TestBackupVerifySelectionAndProgressStream(t *testing.T) {
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	ts, s := newTestServer(t, func(d *api.Deps) { d.Cfg.Backup.Repo = repoPath })
+	createFileWithContent(t, ts, s, "/verified.txt", "read every byte")
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/backup/init", nil, map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/snapshots", nil,
+		map[string]any{"tag": "first", "jobs": 1})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var first api.BackupSnapshot
+	require.NoError(t, json.Unmarshal([]byte(body), &first))
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/snapshots", nil,
+		map[string]any{"tag": "second", "jobs": 1})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/verify", nil,
+		map[string]any{"snapshot_id": first.ID, "jobs": 1})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var report api.BackupVerifyReport
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.Equal(t, []string{first.ID}, report.Snapshots)
+	assert.Positive(t, report.BlobsChecked)
+	assert.Positive(t, report.BytesRead)
+	assert.Empty(t, report.Problems)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/verify/stream", nil,
+		map[string]any{"all": true, "quick": true})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/x-ndjson")
+	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+	events := decodeBackupVerifyEvents(t, body)
+	require.GreaterOrEqual(t, len(events), 2)
+	terminal := events[len(events)-1]
+	assert.Equal(t, "result", terminal.Type)
+	require.NotNil(t, terminal.Report)
+	assert.Len(t, terminal.Report.Snapshots, 2)
+	assert.Positive(t, terminal.Report.BytesRead,
+		"quick verification still reads the authoritative metadata object")
+	assert.Empty(t, terminal.Report.Problems)
+	require.NotNil(t, events[len(events)-2].Progress)
+	assert.True(t, events[len(events)-2].Progress.Final)
+	assert.Equal(t, "verify", events[len(events)-2].Progress.Stage)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/verify", nil,
+		map[string]any{"all": true, "snapshot_id": first.ID})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	assert.Contains(t, body, `"code":"validation"`)
+
+	repo, err := backup.Open(repoPath)
+	require.NoError(t, err)
+	manifest, err := repo.LoadManifest(first.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, manifest.NewPacks)
+	packID := manifest.NewPacks[0]
+	packPath := repo.Path("packs", packID[:2], packID+packstore.PackExt)
+	packBytes, err := os.ReadFile(packPath)
+	require.NoError(t, err)
+	packBytes[len(packBytes)/3] ^= 1
+	require.NoError(t, os.WriteFile(packPath, packBytes, 0o600))
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/verify", nil,
+		map[string]any{"snapshot_id": first.ID, "jobs": 1})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body,
+		"integrity findings belong in the complete report")
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.NotEmpty(t, report.Problems)
+	assert.Equal(t, first.ID, report.Problems[0].SnapshotID)
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -209,6 +209,32 @@ type BackupCreateEvent struct {
 	Error    *Error          `json:"error,omitempty"`
 }
 
+// BackupVerifyProblem identifies one repository-integrity failure and the
+// snapshot whose logical state exposed it.
+type BackupVerifyProblem struct {
+	SnapshotID string `json:"snapshot_id"`
+	Detail     string `json:"detail"`
+}
+
+// BackupVerifyReport summarizes one completed repository verification pass.
+// Problems are findings rather than transport failures, so the API returns the
+// complete report and lets callers decide how to present a failed proof.
+type BackupVerifyReport struct {
+	Snapshots    []string              `json:"snapshots"`
+	BlobsChecked int64                 `json:"blobs_checked"`
+	BytesRead    int64                 `json:"bytes_read"`
+	Problems     []BackupVerifyProblem `json:"problems"`
+}
+
+// BackupVerifyEvent is one line of the backup-verify NDJSON stream. A report
+// or error is terminal; progress may appear zero or more times before it.
+type BackupVerifyEvent struct {
+	Type     string              `json:"type" enum:"progress,result,error"`
+	Progress *BackupProgress     `json:"progress,omitempty"`
+	Report   *BackupVerifyReport `json:"report,omitempty"`
+	Error    *Error              `json:"error,omitempty"`
+}
+
 func fromStoreNode(n store.Node) Node {
 	out := Node{
 		ID: n.ID, ParentID: n.ParentID, Name: n.Name, Kind: n.Kind,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -532,6 +532,109 @@ func (c *Client) BackupList(ctx context.Context, repo string) ([]api.BackupSnaps
 	return out.Items, err
 }
 
+type BackupVerifyOptions struct {
+	Repo        string
+	SnapshotID  string
+	All         bool
+	Quick       bool
+	Jobs        int
+	ForceUnlock bool
+}
+
+func (c *Client) BackupVerify(
+	ctx context.Context, opts BackupVerifyOptions,
+) (api.BackupVerifyReport, error) {
+	var out api.BackupVerifyReport
+	err := c.do(ctx, http.MethodPost, "/api/v1/backup/verify", nil,
+		backupVerifyRequest(opts), &out)
+	return out, err
+}
+
+// BackupVerifyStream verifies a repository while delivering structured
+// progress. A successful HTTP status only starts the stream; the method
+// returns success only after receiving its terminal report event.
+func (c *Client) BackupVerifyStream(
+	ctx context.Context,
+	opts BackupVerifyOptions,
+	progress func(api.BackupProgress),
+) (api.BackupVerifyReport, error) {
+	body, err := json.Marshal(backupVerifyRequest(opts))
+	if err != nil {
+		return api.BackupVerifyReport{}, fmt.Errorf("encoding backup verify request: %w", err)
+	}
+	const path = "/api/v1/backup/verify/stream"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+path, bytes.NewReader(body))
+	if err != nil {
+		return api.BackupVerifyReport{}, fmt.Errorf("building backup verify stream request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	if c.key != "" {
+		req.Header.Set("X-Api-Key", c.key)
+	}
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return api.BackupVerifyReport{}, fmt.Errorf("calling daemon (POST %s): %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return api.BackupVerifyReport{}, decodeError(resp)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	var result *api.BackupVerifyReport
+	for {
+		var event api.BackupVerifyEvent
+		if err := decoder.Decode(&event); err != nil {
+			if errors.Is(err, io.EOF) {
+				if result == nil {
+					return api.BackupVerifyReport{}, errors.New(
+						"backup verify progress stream ended without a result")
+				}
+				return *result, nil
+			}
+			return api.BackupVerifyReport{}, fmt.Errorf("decoding backup verify progress: %w", err)
+		}
+		if result != nil {
+			return api.BackupVerifyReport{}, errors.New(
+				"backup verify progress stream continued after its result")
+		}
+		switch event.Type {
+		case "progress":
+			if event.Progress == nil || event.Report != nil || event.Error != nil {
+				return api.BackupVerifyReport{}, errors.New(
+					"backup verify returned malformed progress event")
+			}
+			if progress != nil {
+				progress(*event.Progress)
+			}
+		case "result":
+			if event.Report == nil || event.Progress != nil || event.Error != nil {
+				return api.BackupVerifyReport{}, errors.New(
+					"backup verify returned malformed result event")
+			}
+			report := *event.Report
+			result = &report
+		case "error":
+			if event.Error == nil || event.Progress != nil || event.Report != nil {
+				return api.BackupVerifyReport{}, errors.New(
+					"backup verify returned malformed error event")
+			}
+			return api.BackupVerifyReport{}, apiProblemError(*event.Error)
+		default:
+			return api.BackupVerifyReport{}, fmt.Errorf(
+				"backup verify returned unknown progress event type %q", event.Type)
+		}
+	}
+}
+
+func backupVerifyRequest(opts BackupVerifyOptions) map[string]any {
+	return map[string]any{
+		"repo": opts.Repo, "snapshot_id": opts.SnapshotID, "all": opts.All,
+		"quick": opts.Quick, "jobs": opts.Jobs, "force_unlock": opts.ForceUnlock,
+	}
+}
+
 func (c *Client) Shutdown(ctx context.Context, token string) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -186,6 +186,27 @@ func TestBackupCreateStreamRoundTripAndTypedError(t *testing.T) {
 	assert.Len(t, snapshots, 1, "a disconnected progress client must not publish a snapshot")
 	_, err = c.BackupCreateStream(t.Context(), client.BackupCreateOptions{Repo: repoPath}, nil)
 	require.ErrorIs(t, err, backup.ErrRepoLocked)
+	require.NoError(t, lock.Release())
+
+	var verifyEvents []api.BackupProgress
+	verified, err := c.BackupVerifyStream(t.Context(), client.BackupVerifyOptions{
+		Repo: repoPath, Jobs: 1,
+	}, func(event api.BackupProgress) { verifyEvents = append(verifyEvents, event) })
+	require.NoError(t, err)
+	assert.Equal(t, []string{snapshot.ID}, verified.Snapshots)
+	assert.Positive(t, verified.BlobsChecked)
+	assert.Positive(t, verified.BytesRead)
+	assert.Empty(t, verified.Problems)
+	require.NotEmpty(t, verifyEvents)
+	assert.Equal(t, "verify", verifyEvents[len(verifyEvents)-1].Stage)
+	assert.True(t, verifyEvents[len(verifyEvents)-1].Final)
+
+	quick, err := c.BackupVerify(t.Context(), client.BackupVerifyOptions{
+		Repo: repoPath, SnapshotID: snapshot.ID, Quick: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{snapshot.ID}, quick.Snapshots)
+	assert.Positive(t, quick.BytesRead, "quick verification still reads metadata")
 }
 
 func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "5"
+	daemonProtocolVersion = "6"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Snapshot creation is not a complete recovery contract until people and automated clients can independently prove repository integrity after capture. Kit already supplies the necessary latest, historical, all-snapshot, quick, and full-content verification semantics; keeping them internal left Docbank repositories operationally unverifiable.

This exposes one authenticated daemon contract through typed JSON and NDJSON APIs plus `docbank backup verify`. Integrity findings are returned as a complete report so all affected snapshots remain visible, while the CLI exits non-zero and keeps `--json` parseable for automation. Human runs receive the same structured progress treatment as snapshot creation. The daemon protocol advances so a stale development daemon cannot silently lack this endpoint.

Restore remains a separate review unit because target confinement, overwrite policy, publication, and recovery proof have a different risk boundary. The standard project checks, strict documentation build, and race-sensitive backup paths pass.