### PR TITLE
Clarify Docbank's human and agent story

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,106 @@
+# docbank
+
+[![Go 1.26+](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go)](https://go.dev)
+[![CI](https://github.com/kenn-io/docbank/actions/workflows/ci.yml/badge.svg)](https://github.com/kenn-io/docbank/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/kenn-io/docbank?include_prereleases)](https://github.com/kenn-io/docbank/releases)
+
+> **Alpha software.** Docbank is pre-1.0. Keep independent copies of
+> irreplaceable material and verify backups before relying on them.
+
+Keep the documents. Change the filing system.
+
+Docbank is a local-first document archive for PDFs, scans, notes,
+spreadsheets, images, and other files. It stores immutable, deduplicated bytes
+by SHA-256 and gives them a virtual directory tree that can be reorganized
+without moving the underlying content.
+
+It is designed to be useful both directly and as document infrastructure for
+other software. Humans use the CLI; agents and external applications use the
+same authenticated HTTP API. The daemon is the only process that opens the
+vault, so every client observes one authority for metadata, content, and
+maintenance.
+
+## Why docbank?
+
+- **Organization is not storage.** Rename and move documents through metadata
+  transactions while their content identity remains stable.
+- **Import is safe to repeat.** Recursive ingestion copies rather than modifies
+  sources, records provenance, resumes cleanly, and deduplicates by content.
+- **Deletion is deliberate.** `rm` is recoverable. Emptying trash, collecting
+  unreachable content, and compacting dead packed space are separate steps.
+- **Integrity is visible.** Verify live content by hash, stream bytes with
+  transfer evidence, and create incremental snapshots that can be verified and
+  restored into a separate vault.
+- **Agents get a real contract.** Stable node IDs, revisions, bounded lists,
+  structured errors, dry-run maintenance, OpenAPI, and byte-identity proofs
+  support safe automation without direct database access.
+
+## Implemented today
+
+- Virtual folders with listing, tree browsing, rename, move, trash, and restore
+- Resumable bulk import and verified multipart upload
+- FTS5 name search (document-body extraction and search are planned)
+- Mixed loose and packed content storage with explicit pack, GC, and repack
+- Whole-vault integrity verification
+- Incremental backup repositories with create, list, verify, and confined restore
+- Daemon-first CLI, authenticated loopback HTTP API, and offline OpenAPI output
+- Linux amd64/arm64 and macOS arm64 release archives with SHA-256 checksums
+
+Versioned content editing, tags, watched inboxes, text extraction, and the TUI
+are planned rather than implemented. See the [roadmap](docs/roadmap.md) for the
+current boundary.
+
+## Installation
+
+Docbank requires macOS or Linux. Download an archive and `SHA256SUMS` from
+[GitHub Releases](https://github.com/kenn-io/docbank/releases), verify it,
+extract `docbank`, and put the binary on your `PATH`.
+
+To build from source, install Go 1.26+, CGO, and a C compiler:
+
+```bash
+git clone https://github.com/kenn-io/docbank.git
+cd docbank
+make install
+```
+
+The next distribution work will add a checksum-verifying installer, macOS
+amd64 archives, and reproducible package definitions. The
+[setup guide](docs/setup.md) is the installation authority.
+
+## Quick start
+
+There is no initialization command. The first data command creates the local
+vault and starts its daemon:
+
+```bash
+docbank add ~/Documents --dest /archive
+docbank tree /archive
+docbank search "tax return"
+docbank mv /archive/Documents/receipt.pdf /archive/Documents/receipt-2026.pdf
+docbank verify
+```
+
+Create and prove an incremental backup repository:
+
+```bash
+docbank backup init --repo ~/Backups/docbank
+docbank backup create --repo ~/Backups/docbank --tag first-import
+docbank backup verify --repo ~/Backups/docbank
+docbank backup restore --repo ~/Backups/docbank --target ~/Restores/docbank-test
+```
+
+## Documentation
+
+- [Setup](docs/setup.md) and [ten-minute quickstart](docs/quickstart.md)
+- [Using docbank](docs/usage/lifecycle.md), including backup and recovery
+- [Docbank for agents](docs/agents.md) and the detailed
+  [integration guide](docs/agents/integration.md)
+- [CLI reference](docs/cli-reference.md)
+- [Architecture overview](docs/architecture/overview.md)
+- [Internal design map](docs/internal/README.md) for contributors and coding agents
+
+Docbank belongs to the same family of personal data tools as
+[msgvault](https://msgvault.io). Msgvault preserves communications history;
+Docbank provides a durable, reorganizable home for ordinary documents and a
+safe document API for external applications.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,92 @@
+---
+title: Docbank for Agents
+description: Why agents use docbank, which interface to choose, and the safety model for document automation.
+---
+
+# Docbank for agents
+
+Docbank is a document system of record with an agent-ready interface, not a
+database that an automation should open directly. One daemon owns the vault.
+The CLI, agents, scripts, and external applications all use its authenticated
+HTTP contract and therefore share the same validation, concurrency, integrity,
+and maintenance rules.
+
+This makes Docbank useful when an agent needs to file, retrieve, reorganize,
+or verify documents without taking ownership of their physical storage format.
+
+## What the contract gives an agent
+
+<div class="feature-grid">
+  <section>
+    <h3>Stable identity</h3>
+    <p>Node IDs survive renames and moves; immutable SHA-256 identities describe file content.</p>
+  </section>
+  <section>
+    <h3>Conflict evidence</h3>
+    <p>Revisions and <code>If-Match</code> turn stale read-modify-write decisions into explicit HTTP 412 responses.</p>
+  </section>
+  <section>
+    <h3>Byte evidence</h3>
+    <p>Uploads declare hash and size; downloads can be checked against headers, a verified digest trailer, and the node record.</p>
+  </section>
+  <section>
+    <h3>Bounded automation</h3>
+    <p>Pagination, search limits, structured problem codes, dry runs, and NDJSON progress avoid scraping human output.</p>
+  </section>
+</div>
+
+## Choose the right surface
+
+| Surface | Use it for | Contract |
+|---------|------------|----------|
+| CLI | Human-directed work, shell scripts, and inspecting behavior | Readable output; machine modes where documented |
+| HTTP API | Independent applications and long-running agent workflows | Authenticated JSON, revisions, pagination, structured errors |
+| OpenAPI | Client generation and capability discovery | `docbank openapi --json`, `/openapi.json`, `/openapi.yaml` |
+| Markdown docs | Context retrieval without HTML scraping | Every public `/foo/` page is also published at `/foo.md` |
+
+The detailed [Agent Integration Guide](agents/integration.md) covers endpoint
+setup, authentication, upload and download proof, revision-aware mutations,
+backup progress, error handling, and a complete safe filing loop. The
+[HTTP API](architecture/http-api.md) page explains the design contract and
+non-goals.
+
+## The mental model
+
+1. **The daemon is the authority.** Never open `docbank.db`, rewrite pack
+   files, or infer live content from filesystem layout.
+2. **IDs identify nodes; paths describe current placement.** Retain a node ID
+   after inspecting it. Re-resolve paths when the intent is path-specific.
+3. **Content identity is immutable.** A file node names SHA-256 and size.
+   Future edits create versions rather than modifying stored bytes in place.
+4. **A stream is not verified until it finishes.** Read through successful EOF
+   and require the digest evidence before publishing downloaded bytes.
+5. **Destruction has stages.** Trash is recoverable; trash empty removes tree
+   history; GC removes unreachable loose bytes or marks packed payload dead;
+   repack reclaims physical packed space.
+6. **Dry run before policy-changing maintenance.** Preview destructive work,
+   evaluate the result, then make the separate explicit run request.
+
+## Common agent workflows
+
+- **File local material:** use server-path ingest when the daemon can read the
+  source, then inspect every added, skipped, and failed result.
+- **Write from another machine:** upload one file with declared SHA-256, size,
+  name, and destination directory ID; accept success only when the returned
+  server-computed identity matches.
+- **Reorganize after inspection:** read by ID, retain the revision, and mutate
+  with `If-Match`. On `stale_revision`, re-read and reconsider rather than
+  blindly replaying the action.
+- **Retrieve for another system:** stage the response privately, hash while
+  reading, require successful EOF and the digest trailer, then publish.
+- **Protect a workflow boundary:** create a tagged incremental snapshot, follow
+  structured progress to a terminal result, and verify the repository on the
+  schedule appropriate for its storage medium.
+
+## Start integrating
+
+1. Generate the current contract with `docbank openapi --json`.
+2. Configure a stable loopback port and strong API key.
+3. Follow the [integration guide](agents/integration.md) through health,
+   authentication, bounded reads, and a revision-aware filing loop.
+4. Treat the running OpenAPI document and structured problem codes as the wire
+   authority; treat these pages as the maintained operating model.

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -5,8 +5,9 @@ description: Docbank's JSONL-native Kit snapshot and restore architecture.
 
 # Backup
 
-`docbank backup init`, `backup create`, and `backup list` are implemented over
-the authenticated daemon API; see the [Backup user guide](../usage/backup.md).
+`docbank backup init`, `backup create`, `backup list`, `backup verify`, and
+`backup restore` are implemented over the authenticated daemon API; see the
+[Backup user guide](../usage/backup.md).
 A coherent manual filesystem snapshot remains available by stopping the daemon
 before copying the vault; see
 [Vault Lifecycle](../usage/lifecycle.md#take-a-coherent-manual-snapshot).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -378,5 +378,4 @@ background-spawned daemons.
     here with exact semantics when they ship. `docbank edit` and
     `docbank versions` (Phase 2b, [Editing & Versions](architecture/editing-and-versions.md));
     `docbank extract` (Phase 2b, [HTTP API](architecture/http-api.md));
-    `docbank tui` (Phase 3); `docbank backup verify|restore`
-    (Phase 4, [Backup](architecture/backup.md)).
+    and `docbank tui` (Phase 3).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: docbank
-description: Personal document archive with a virtual tree over content-addressed storage, full-text search, trash and recovery, and an agent-first HTTP API.
+description: Local-first document archive with immutable content, flexible organization, verified backup and recovery, and an agent-ready HTTP API.
 ---
 
 <p class="eyebrow">LOCAL-FIRST DOCUMENT ARCHIVE</p>
@@ -14,7 +14,7 @@ the tree above them is yours to rename, move, search, trash, and restore.
 <p class="hero-actions">
   <a class="md-button md-button--primary" href="setup/">Set up docbank</a>
   <a class="md-button" href="quickstart/">Take the ten-minute tour</a>
-  <a class="md-button" href="agents/integration/">Build an agent integration</a>
+  <a class="md-button" href="agents/">Use docbank with agents</a>
 </p>
 
 <div class="signal-grid">
@@ -26,8 +26,21 @@ the tree above them is yours to rename, move, search, trash, and restore.
 docbank belongs to a family of personal data tools alongside
 [msgvault](https://msgvault.io) (communications archive) and fotobank
 (photo/video archive). Where msgvault preserves an immutable historical
-record of your messages, docbank manages **living documents**: files you
-still rename, refile, and edit.
+record of your messages, docbank manages **working documents**: files you
+still organize, retrieve, and build workflows around.
+
+## Why docbank
+
+Ordinary folders make their paths part of their identity. Sync tools copy that
+coupling between machines. Docbank separates the durable document from its
+current filing location: content has a verified SHA-256 identity, while a
+transactional virtual tree supplies names and paths that can change cheaply.
+
+That gives people a recoverable archive instead of another folder to curate,
+and gives agents a bounded interface instead of unrestricted filesystem access.
+Imports are repeatable, deletion proceeds through explicit stages, reads can
+prove the returned bytes, and incremental snapshots can be verified and
+restored before they are trusted.
 
 ## How it works
 
@@ -44,13 +57,15 @@ renames, and reorganization are metadata transactions that never touch bytes.
 ```
 docbank add ~/Documents/taxes --dest /taxes   # bulk import, resumable
 docbank tree /taxes                           # browse the virtual tree
-docbank search "insurance"                    # full-text search
+docbank search "insurance"                    # indexed name search
 docbank mv "/inbox/scan (2).pdf" /taxes/2026  # reorganize, metadata only
 docbank rm /inbox/junk.pdf                    # trash, recoverable
 docbank trash empty --run                     # permanently delete trash metadata
 docbank gc --run                              # reclaim loose; mark packed bytes dead
 docbank storage repack                        # compact eligible sparse packs
 docbank verify                                # prove the bytes are intact
+docbank backup create --repo ~/Backups/docbank
+docbank backup restore --repo ~/Backups/docbank --target ~/Restores/docbank
 ```
 
 ## Principles
@@ -87,17 +102,18 @@ docbank verify                                # prove the bytes are intact
   can do — the CLI is itself an HTTP client of it — with
   optimistic-concurrency preconditions designed for agent
   read-modify-write loops. See [HTTP API](architecture/http-api.md).
+
 ## Status
 
-docbank is pre-release. Phase 1 (store, ingest pipeline, and the full
-core CLI) and Phase 2a (the daemon, the HTTP API, the daemon-first CLI,
-and self-update) are implemented and tested.
+docbank is alpha software with tagged releases. The core store and ingest
+pipeline, virtual-tree CLI, authenticated daemon API, packed storage,
+integrity verification, and incremental backup creation, verification, and
+restore are implemented and tested. Representative-corpus hardening and
+distribution work continue before a stable 1.0 release.
 
 !!! info "Planned — later phases"
-    Editing commands, tags, watched inboxes, text extraction (Phase 2b), the
-    TUI (Phase 3), and backup verification/restore (Phase 4) are designed but
-    not yet built. Snapshot repository initialization, creation, and listing
-    are implemented. The
+    Versioned editing, tags, watched inboxes, content-text extraction and
+    search, and the TUI are designed but not yet built. The
     [Roadmap](roadmap.md) tracks what exists versus what is planned.
 
 ## Where to go next
@@ -105,6 +121,7 @@ and self-update) are implemented and tested.
 - [Setup](setup.md) — build and install the binary
 - [Quickstart](quickstart.md) — a ten-minute tour of the CLI
 - [Vault Lifecycle](usage/lifecycle.md) — operate, update, snapshot, and recover safely
+- [Docbank for Agents](agents.md) — understand the automation contract
 - [Agent Integration](agents/integration.md) — build revision-aware automations
 - [Troubleshooting](troubleshooting.md) — diagnose failures without risking the vault
 - [CLI Reference](cli-reference.md) — every command, flag, and output format

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -153,7 +153,32 @@ docbank verify            # re-hash every stored blob
 211 blob(s) ok, 0 problem(s)
 ```
 
+## Prove recovery
+
+Backup repositories are separate from the live vault. Captures are
+incremental: unchanged content is reused across snapshots. This scratch loop
+creates a repository, captures the vault, verifies the repository, and restores
+the latest snapshot into a different vault:
+
+```bash
+export DOCBANK_BACKUP=$(mktemp -d)
+export DOCBANK_RESTORE=$(mktemp -d)
+
+docbank backup init --repo "$DOCBANK_BACKUP"
+docbank backup create --repo "$DOCBANK_BACKUP"
+docbank backup list --repo "$DOCBANK_BACKUP"
+docbank backup verify --repo "$DOCBANK_BACKUP"
+docbank backup restore --repo "$DOCBANK_BACKUP" --target "$DOCBANK_RESTORE"
+
+DOCBANK_HOME="$DOCBANK_RESTORE" docbank tree /
+DOCBANK_HOME="$DOCBANK_RESTORE" docbank verify
+```
+
+The restored target is independently usable; the running source vault is not
+replaced. See [Backup & Restore](usage/backup.md) for progress modes, snapshot
+selection, overwrite rules, and the exact proof returned by restore.
+
 That is the core document workflow. Continue with
-[Vault Lifecycle](usage/lifecycle.md) for maintenance, upgrades, snapshots,
-and recovery, or use the [CLI Reference](cli-reference.md) for exact command
-semantics.
+[Vault Lifecycle](usage/lifecycle.md) for maintenance and upgrades, explore
+[Docbank for Agents](agents.md) for automation, or use the
+[CLI Reference](cli-reference.md) for exact command semantics.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,12 +12,12 @@ marked planned appears elsewhere in these docs only under an explicit
 
 | Phase | Scope | Status |
 |-------|-------|--------|
-| 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (`kit` v0.7.0) |
+| 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.9.2) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: versioned editing, tags, watched inboxes, text extraction, ingest provenance | Designed |
 | 3 | TUI file browser | Designed |
-| 4 | Backup commands over the kit engine | In progress (`init`, `create`, `list` implemented) |
+| 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
 
@@ -108,7 +108,7 @@ Bubble Tea file manager over the same store: navigate, search, rename,
 move, trash/restore, version list, open-in-default-app. No privileged
 operations — anything the TUI does, the API can do.
 
-## Phase 4 — Backup
+## Phase 4 — Backup (implemented)
 
 `docbank backup init|create|list|verify|restore` against the kit engine
 ([design](architecture/backup.md)).

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "docbank"
-site_description = "Personal document archive: a virtual tree over content-addressed storage, with full-text search, trash and recovery, and an agent-first HTTP API."
+site_description = "Local-first document archive with immutable content, flexible organization, verified backup and recovery, and an agent-ready HTTP API."
 site_author = "Kenn Software LLC"
 copyright = 'Copyright &copy; 2026 <a href="https://kenn.io">Kenn Software LLC</a>.'
 docs_dir = "docs"
@@ -10,29 +10,32 @@ repo_name = "kenn-io/docbank"
 extra_css = ["stylesheets/extra.css"]
 use_directory_urls = true
 nav = [
-  {"Introduction" = "index.md"},
-  {"Getting Started" = [
+  {"Overview" = "index.md"},
+  {"Start Here" = [
     {"Setup" = "setup.md"},
     {"Quickstart" = "quickstart.md"},
     {"Configuration" = "configuration.md"},
   ]},
-  {"User Guide" = [
-    {"Vault Lifecycle" = "usage/lifecycle.md"},
+  {"Work with Documents" = [
     {"Importing Documents" = "usage/importing.md"},
     {"Organizing the Tree" = "usage/organizing.md"},
-    {"Searching" = "usage/searching.md"},
+    {"Finding Documents" = "usage/searching.md"},
+  ]},
+  {"Protect & Operate" = [
+    {"Vault Lifecycle" = "usage/lifecycle.md"},
     {"Trash, GC, Repack & Verify" = "usage/trash-and-gc.md"},
-    {"Backup" = "usage/backup.md"},
+    {"Backup & Restore" = "usage/backup.md"},
+  ]},
+  {"Automate & Integrate" = [
+    {"Docbank for Agents" = "agents.md"},
+    {"Integration Guide" = "agents/integration.md"},
+    {"HTTP API Contract" = "architecture/http-api.md"},
   ]},
   {"Reference" = [
     {"CLI Reference" = "cli-reference.md"},
+    {"Troubleshooting" = "troubleshooting.md"},
   ]},
-  {"For Agents" = [
-    {"Integration Guide" = "agents/integration.md"},
-    {"Agent HTTP API" = "architecture/http-api.md"},
-  ]},
-  {"Troubleshooting" = "troubleshooting.md"},
-  {"Architecture" = [
+  {"How It Works" = [
     {"Overview" = "architecture/overview.md"},
     {"Storage" = "architecture/storage.md"},
     {"Packed Storage Foundation" = "architecture/packed-storage.md"},
@@ -42,8 +45,10 @@ nav = [
     {"Daemon" = "architecture/daemon.md"},
     {"Backup" = "architecture/backup.md"},
   ]},
-  {"Roadmap" = "roadmap.md"},
-  {"Changelog" = "changelog.md"},
+  {"Project" = [
+    {"Roadmap" = "roadmap.md"},
+    {"Changelog" = "changelog.md"},
+  ]},
 ]
 
 [project.extra]


### PR DESCRIPTION
Docbank now has a useful storage, integrity, and recovery foundation, but its public entry points still read like an internal build log. The repository had no README, the site mixed several audiences in one navigation tree, and prominent pages still described shipped recovery commands as future work. A prospective user or collaborator therefore had to reconstruct both the value proposition and the actual capability boundary from architecture notes.

This gives humans a direct path from the durable-content/mutable-organization idea into an executable document and recovery workflow. It gives agents a separate landing page centered on stable identity, revision evidence, verified transfers, structured errors, and staged destruction before sending implementers into the detailed protocol guide. The site hierarchy now distinguishes learning, document work, operations, integrations, reference, and implementation detail.

Claims are deliberately limited to what exists today: name search is not presented as document-body search, backup verification and confined restore are current capabilities, and editing, extraction, tags, watched inboxes, and the TUI remain explicitly planned. Installer and package gaps are called out as follow-on distribution work so they can be reviewed independently.

The strict documentation build and the repository checks pass.