### PR TITLE
Publish six-platform release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Check Unix installer
+        run: sh -n scripts/install.sh
+
       - name: Vet
         run: go vet -tags fts5 ./...
 
@@ -74,6 +77,13 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Check PowerShell installer
+        if: matrix.goarch == 'amd64'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          [scriptblock]::Create((Get-Content -Raw scripts/install.ps1)) | Out-Null
 
       - name: Set up ARM64 C compiler
         if: matrix.goarch == 'arm64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,11 +263,6 @@ jobs:
               *darwin_amd64*) grep -Eq 'x86-64|x86_64' <<<"${binary_info}" ;;
               *darwin_arm64*) grep -Eqi 'aarch64|arm64' <<<"${binary_info}" ;;
             esac
-            if [[ "${archive}" == *linux_amd64* ]]; then
-              SMOKE_OUT="$("${tmpdir}/docbank" --version 2>&1)"
-              echo "${SMOKE_OUT}"
-              grep -Fq "docbank version ${VERSION}" <<<"${SMOKE_OUT}"
-            fi
             rm -rf "${tmpdir}"
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { runner: ubuntu-latest, goarch: amd64, go-archive-arch: amd64 }
-          - { runner: ubuntu-24.04-arm, goarch: arm64, go-archive-arch: arm64 }
+          - { runner: ubuntu-latest, goarch: amd64 }
+          - { runner: ubuntu-24.04-arm, goarch: arm64 }
     runs-on: ${{ matrix.runner }}
     container:
       image: ubuntu:22.04
@@ -33,21 +33,17 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends ca-certificates curl file gcc git gzip tar
+          apt-get install -y --no-install-recommends ca-certificates file gcc git gzip tar
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Install Go
-        run: |
-          set -euo pipefail
-          GO_VERSION="$(awk '$1 == "go" { print $2; exit }' go.mod)"
-          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${{ matrix.go-archive-arch }}.tar.gz" -o go.tar.gz
-          tar -C /usr/local -xzf go.tar.gz
-          rm go.tar.gz
-          echo "/usr/local/go/bin" >> "${GITHUB_PATH}"
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
 
       - name: Build and package
         env:
@@ -56,7 +52,6 @@ jobs:
           GOOS: linux
         run: |
           set -euo pipefail
-          export PATH="/usr/local/go/bin:${PATH}"
           VERSION="${GITHUB_REF#refs/tags/v}"
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "FATAL: release tag must use vX.Y.Z format" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ubuntu:22.04
+    defaults:
+      run:
+        shell: bash
     timeout-minutes: 20
     steps:
       - name: Install build tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,28 +12,94 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+  build-linux:
+    name: Build linux/${{ matrix.goarch }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - { runner: ubuntu-latest,     goos: linux,  goarch: amd64 }
-          - { runner: ubuntu-24.04-arm,  goos: linux,  goarch: arm64 }
-          - { runner: macos-latest,      goos: darwin, goarch: arm64 }
+          - { runner: ubuntu-latest, goarch: amd64, go-archive-arch: amd64 }
+          - { runner: ubuntu-24.04-arm, goarch: arm64, go-archive-arch: arm64 }
     runs-on: ${{ matrix.runner }}
+    container:
+      image: ubuntu:22.04
+    timeout-minutes: 20
+    steps:
+      - name: Install build tools
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates curl file gcc git gzip tar
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Install Go
+        run: |
+          set -euo pipefail
+          GO_VERSION="$(awk '$1 == "go" { print $2; exit }' go.mod)"
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${{ matrix.go-archive-arch }}.tar.gz" -o go.tar.gz
+          tar -C /usr/local -xzf go.tar.gz
+          rm go.tar.gz
+          echo "/usr/local/go/bin" >> "${GITHUB_PATH}"
+
+      - name: Build and package
+        env:
+          CGO_ENABLED: "1"
+          GOARCH: ${{ matrix.goarch }}
+          GOOS: linux
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/go/bin:${PATH}"
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "FATAL: release tag must use vX.Y.Z format" >&2
+            exit 1
+          fi
+          COMMIT="$(printf '%s' "${GITHUB_SHA}" | cut -c1-8)"
+          LDFLAGS="-s -w -X go.kenn.io/docbank/internal/version.Version=${VERSION} -X go.kenn.io/docbank/internal/version.Commit=${COMMIT}"
+          go build -tags fts5 -trimpath -buildvcs=false -ldflags "${LDFLAGS}" -o dist/docbank ./cmd/docbank
+          file dist/docbank
+          SMOKE_OUT="$(dist/docbank --version 2>&1)"
+          echo "${SMOKE_OUT}"
+          grep -Fq "docbank version ${VERSION} (${COMMIT})" <<<"${SMOKE_OUT}"
+          cd dist
+          tar -czf "docbank_${VERSION}_linux_${GOARCH}.tar.gz" docbank
+          rm docbank
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docbank-linux-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  build-darwin:
+    name: Build darwin/${{ matrix.goarch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        goarch: [amd64, arm64]
+    runs-on: macos-15
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-tags: true
           persist-credentials: false
+
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: false
-      - name: Build
+
+      - name: Build and package
         env:
           CGO_ENABLED: "1"
+          GOARCH: ${{ matrix.goarch }}
+          GOOS: darwin
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF#refs/tags/v}"
@@ -41,30 +107,106 @@ jobs:
             echo "FATAL: release tag must use vX.Y.Z format" >&2
             exit 1
           fi
-          COMMIT="$(git rev-parse --short HEAD)"
-          LDFLAGS="-X go.kenn.io/docbank/internal/version.Version=${VERSION} \
-                   -X go.kenn.io/docbank/internal/version.Commit=${COMMIT}"
-          go build -tags fts5 -trimpath -ldflags "${LDFLAGS}" -o dist/docbank ./cmd/docbank
-          ./dist/docbank --version
-      - name: Package
+          COMMIT="$(printf '%s' "${GITHUB_SHA}" | cut -c1-8)"
+          LDFLAGS="-s -w -X go.kenn.io/docbank/internal/version.Version=${VERSION} -X go.kenn.io/docbank/internal/version.Commit=${COMMIT}"
+          go build -tags fts5 -trimpath -buildvcs=false -ldflags "${LDFLAGS}" -o dist/docbank ./cmd/docbank
+          file dist/docbank
+          otool -L dist/docbank
+          if [[ "${GOARCH}" == "arm64" ]]; then
+            SMOKE_OUT="$(dist/docbank --version 2>&1)"
+            echo "${SMOKE_OUT}"
+            grep -Fq "docbank version ${VERSION} (${COMMIT})" <<<"${SMOKE_OUT}"
+          fi
+          cd dist
+          tar -czf "docbank_${VERSION}_darwin_${GOARCH}.tar.gz" docbank
+          rm docbank
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docbank-darwin-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  build-windows:
+    name: Build windows/${{ matrix.goarch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: windows-latest, goarch: amd64 }
+          - { runner: windows-11-arm, goarch: arm64 }
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-tags: true
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Set up ARM64 C compiler
+        if: matrix.goarch == 'arm64'
+        shell: pwsh
         env:
+          LLVM_MINGW_VERSION: "20260602"
+          LLVM_MINGW_NAME: llvm-mingw-20260602-ucrt-aarch64
+          LLVM_MINGW_SHA256: cb5c20fbe1808e31ada5cbe4efd9daa2fee19c91dac6ec5ca1ac46a9c7247e37
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $zip = Join-Path $env:RUNNER_TEMP 'llvm-mingw.zip'
+          $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$env:LLVM_MINGW_VERSION/$env:LLVM_MINGW_NAME.zip"
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $env:LLVM_MINGW_SHA256) {
+            throw "Checksum mismatch for $url`n  expected $env:LLVM_MINGW_SHA256`n  actual   $actual"
+          }
+          7z x $zip -o"$env:RUNNER_TEMP" | Out-Null
+          $cc = Join-Path $env:RUNNER_TEMP "$env:LLVM_MINGW_NAME\bin\aarch64-w64-mingw32-clang.exe"
+          if (-not (Test-Path $cc)) { throw "CC not found at $cc" }
+          Add-Content -Path $env:GITHUB_ENV -Value "CC=$cc"
+
+      - name: Build and package
+        env:
+          CGO_ENABLED: "1"
           GOARCH: ${{ matrix.goarch }}
-          GOOS: ${{ matrix.goos }}
+          GOOS: windows
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF#refs/tags/v}"
-          ARCHIVE="docbank_${VERSION}_${GOOS}_${GOARCH}.tar.gz"
-          tar -C dist -czf "${ARCHIVE}" docbank
-          mkdir -p out && mv "${ARCHIVE}" out/
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "FATAL: release tag must use vX.Y.Z format" >&2
+            exit 1
+          fi
+          COMMIT="$(printf '%s' "${GITHUB_SHA}" | cut -c1-8)"
+          LDFLAGS="-s -w -X go.kenn.io/docbank/internal/version.Version=${VERSION} -X go.kenn.io/docbank/internal/version.Commit=${COMMIT}"
+          go build -tags fts5 -trimpath -buildvcs=false -ldflags "${LDFLAGS}" -o dist/docbank.exe ./cmd/docbank
+          SMOKE_OUT="$(dist/docbank.exe --version 2>&1)"
+          echo "${SMOKE_OUT}"
+          grep -Fq "docbank version ${VERSION} (${COMMIT})" <<<"${SMOKE_OUT}"
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $version = $env:GITHUB_REF -replace '^refs/tags/v', ''
+          Compress-Archive -Path dist/docbank.exe -DestinationPath "dist/docbank_${version}_windows_${{ matrix.goarch }}.zip"
+          Remove-Item dist/docbank.exe
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: docbank-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: out/*.tar.gz
+          name: docbank-windows-${{ matrix.goarch }}
+          path: dist/*.zip
           if-no-files-found: error
 
   publish:
     name: Publish GitHub release
-    needs: build
+    needs: [build-linux, build-darwin, build-windows]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -72,17 +214,81 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-tags: true
           persist-credentials: false
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: assets
           merge-multiple: true
-      - name: Checksums
+
+      - name: Validate artifacts and generate checksums
         run: |
           set -euo pipefail
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          EXPECTED=(
+            "docbank_${VERSION}_linux_amd64.tar.gz"
+            "docbank_${VERSION}_linux_arm64.tar.gz"
+            "docbank_${VERSION}_darwin_amd64.tar.gz"
+            "docbank_${VERSION}_darwin_arm64.tar.gz"
+            "docbank_${VERSION}_windows_amd64.zip"
+            "docbank_${VERSION}_windows_arm64.zip"
+          )
+          mapfile -t ACTUAL < <(find assets -maxdepth 1 -type f -printf '%f\n' | sort)
+          mapfile -t WANTED < <(printf '%s\n' "${EXPECTED[@]}" | sort)
+          if [[ "$(printf '%s\n' "${ACTUAL[@]}")" != "$(printf '%s\n' "${WANTED[@]}")" ]]; then
+            echo "FATAL: release artifact set differs from the six supported targets" >&2
+            printf 'expected: %s\n' "${WANTED[*]}" >&2
+            printf 'actual:   %s\n' "${ACTUAL[*]}" >&2
+            exit 1
+          fi
+
+          for archive in assets/*.tar.gz; do
+            tmpdir="$(mktemp -d)"
+            entries="$(tar -tzf "${archive}")"
+            if [[ "${entries}" != "docbank" ]]; then
+              echo "FATAL: ${archive} must contain only docbank at its root" >&2
+              exit 1
+            fi
+            tar -xzf "${archive}" -C "${tmpdir}"
+            test -x "${tmpdir}/docbank"
+            binary_info="$(file "${tmpdir}/docbank")"
+            echo "${binary_info}"
+            case "${archive}" in
+              *linux_amd64*) grep -Eq 'x86-64|x86_64' <<<"${binary_info}" ;;
+              *linux_arm64*) grep -Eqi 'aarch64|arm64' <<<"${binary_info}" ;;
+              *darwin_amd64*) grep -Eq 'x86-64|x86_64' <<<"${binary_info}" ;;
+              *darwin_arm64*) grep -Eqi 'aarch64|arm64' <<<"${binary_info}" ;;
+            esac
+            if [[ "${archive}" == *linux_amd64* ]]; then
+              SMOKE_OUT="$("${tmpdir}/docbank" --version 2>&1)"
+              echo "${SMOKE_OUT}"
+              grep -Fq "docbank version ${VERSION}" <<<"${SMOKE_OUT}"
+            fi
+            rm -rf "${tmpdir}"
+          done
+
+          for archive in assets/*.zip; do
+            tmpdir="$(mktemp -d)"
+            mapfile -t entries < <(zipinfo -1 "${archive}")
+            if [[ "${#entries[@]}" -ne 1 || "${entries[0]}" != "docbank.exe" ]]; then
+              echo "FATAL: ${archive} must contain only docbank.exe at its root" >&2
+              exit 1
+            fi
+            unzip -q "${archive}" -d "${tmpdir}"
+            binary_info="$(file "${tmpdir}/docbank.exe")"
+            echo "${binary_info}"
+            case "${archive}" in
+              *windows_amd64*) grep -Eq 'x86-64|x86_64' <<<"${binary_info}" ;;
+              *windows_arm64*) grep -Eqi 'aarch64|arm64' <<<"${binary_info}" ;;
+            esac
+            rm -rf "${tmpdir}"
+          done
+
           cd assets
-          sha256sum -- *.tar.gz > SHA256SUMS
+          sha256sum -- "${EXPECTED[@]}" > SHA256SUMS
           cat SHA256SUMS
+
       - name: Read annotated tag message
         id: tag_message
         run: |
@@ -103,6 +309,7 @@ jobs:
           else
             echo "has_body=false" >> "${GITHUB_OUTPUT}"
           fi
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ maintenance.
 - Whole-vault integrity verification
 - Incremental backup repositories with create, list, verify, and confined restore
 - Daemon-first CLI, authenticated loopback HTTP API, and offline OpenAPI output
-- Release archives for Linux, macOS, and Windows on amd64 and arm64, with
+- A release pipeline for Linux, macOS, and Windows on amd64 and arm64, with
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows
 
@@ -56,6 +56,11 @@ current boundary.
 
 Docbank supports Linux, macOS, and 64-bit Windows on amd64 and arm64. On Linux
 or macOS, install the latest release with:
+
+> **Current release:** v0.1.0 predates the complete distribution pipeline. Its
+> archives cover Linux amd64/arm64 and macOS arm64 only. Windows and macOS
+> amd64 users must build from source until the next release is published; the
+> installers fail rather than substitute an incompatible archive.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kenn-io/docbank/main/scripts/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ maintenance.
 - Whole-vault integrity verification
 - Incremental backup repositories with create, list, verify, and confined restore
 - Daemon-first CLI, authenticated loopback HTTP API, and offline OpenAPI output
-- Linux amd64/arm64 and macOS arm64 release archives with SHA-256 checksums
+- Release archives for Linux, macOS, and Windows on amd64 and arm64, with
+  SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows
 
 Versioned content editing, tags, watched inboxes, text extraction, and the TUI
@@ -53,10 +54,23 @@ current boundary.
 
 ## Installation
 
-Docbank supports Linux, macOS, and 64-bit Windows. Download an archive and
-`SHA256SUMS` from
-[GitHub Releases](https://github.com/kenn-io/docbank/releases), verify it,
-extract `docbank`, and put the binary on your `PATH`.
+Docbank supports Linux, macOS, and 64-bit Windows on amd64 and arm64. On Linux
+or macOS, install the latest release with:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kenn-io/docbank/main/scripts/install.sh | sh
+```
+
+On Windows, run this in PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/kenn-io/docbank/main/scripts/install.ps1 | iex
+```
+
+Both installers select the native archive and refuse to install it unless its
+SHA-256 digest matches the release's `SHA256SUMS`. You can instead download and
+verify an archive manually from
+[GitHub Releases](https://github.com/kenn-io/docbank/releases).
 
 To build from source, install Go 1.26+, CGO, and a C compiler:
 
@@ -69,11 +83,7 @@ make install
 On Windows, build `docbank.exe` with
 `go build -tags fts5 -o docbank.exe ./cmd/docbank`; the
 [setup guide](docs/setup.md) covers the platform toolchain.
-
-The current release predates Windows runtime support. The next distribution
-release will add Windows amd64/arm64, macOS amd64, and checksum-verifying
-installers. The
-[setup guide](docs/setup.md) is the installation authority.
+The [setup guide](docs/setup.md) is the installation authority.
 
 ## Quick start
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,8 +14,9 @@ docbank is pre-1.0; interfaces and storage migrations may still evolve.
   ingest, overlapping vault/restore exclusion, backup, restore, and self-update
   use native Windows primitives.
 - Windows CI runs the complete CLI and internal suite on amd64 and arm64.
-- Six-platform release archives and checksum-verifying installers follow in the
-  distribution release work.
+- Releases publish Linux, macOS, and Windows archives for amd64 and arm64. The
+  shell and PowerShell installers select the native archive, verify it against
+  `SHA256SUMS`, and reject missing, ambiguous, or invalid checksums.
 
 ## v0.1.0
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,6 +22,12 @@ additionally requires:
 
 ## Install a release
 
+!!! info "Current tagged release"
+    v0.1.0 predates the complete distribution pipeline. It includes Linux
+    amd64/arm64 and macOS arm64 archives only. Windows and macOS amd64 users
+    must build from source until the next release is published; the installers
+    fail rather than substitute an incompatible archive.
+
 On Linux or macOS, the installer selects the native archive and installs
 `docbank` to `~/.local/bin` by default:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,13 +1,12 @@
 ---
 title: Setup
-description: Build docbank from source and initialize the vault.
+description: Install docbank on Linux, macOS, or Windows and create the vault.
 ---
 
 # Setup
 
-docbank is pre-1.0. Linux, macOS, and 64-bit Windows are supported. The current
-tagged release provides Linux amd64/arm64 and macOS arm64 archives; the next
-distribution release adds the other supported targets and installers.
+docbank is pre-1.0. Linux, macOS, and 64-bit Windows are supported on amd64 and
+arm64.
 
 ## Requirements
 
@@ -23,6 +22,34 @@ additionally requires:
 
 ## Install a release
 
+On Linux or macOS, the installer selects the native archive and installs
+`docbank` to `~/.local/bin` by default:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kenn-io/docbank/main/scripts/install.sh | sh
+```
+
+Set `DOCBANK_INSTALL_DIR` to choose another destination. Set
+`DOCBANK_VERSION=vX.Y.Z` to install a specific release rather than the latest.
+
+On Windows, run the PowerShell installer:
+
+```powershell
+irm https://raw.githubusercontent.com/kenn-io/docbank/main/scripts/install.ps1 | iex
+```
+
+It installs to `%LOCALAPPDATA%\Programs\docbank\bin` and adds that directory
+to the user `PATH`. `DOCBANK_INSTALL_DIR` and `DOCBANK_VERSION` provide the
+same overrides as on Unix; set `DOCBANK_NO_MODIFY_PATH=1` to leave `PATH`
+unchanged.
+
+The installers fail closed: the archive is not extracted or installed unless
+`SHA256SUMS` is available, contains exactly one matching entry, and verifies.
+They also reject an archive that contains anything other than the expected
+top-level executable.
+
+### Manual installation
+
 For a published release, download the archive for your platform and
 `SHA256SUMS` from the
 [GitHub Releases](https://github.com/kenn-io/docbank/releases) page. Verify
@@ -34,10 +61,10 @@ docbank_<version>_<goos>_<goarch>.tar.gz  # Linux and macOS
 docbank_<version>_windows_<goarch>.zip    # Windows
 ```
 
-!!! info "Current release assets"
-    The first release predates the Windows port and macOS amd64 build. Until
-    the next release is published, those users must build this branch from
-    source. Never install an archive for a different OS or architecture.
+Releases produced by the current distribution workflow publish all six
+archives. Earlier tags may contain fewer targets; an installer fails instead
+of substituting another platform. Never install an archive for a different OS
+or architecture.
 
 ## Build and install from source
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -108,6 +108,18 @@ function Get-ExpectedChecksum([string]$Path, [string]$ArchiveName) {
     return $checksumMatches[0].ToLowerInvariant()
 }
 
+function Get-Sha256([string]$Path) {
+    $stream = [IO.File]::OpenRead($Path)
+    $algorithm = [Security.Cryptography.SHA256]::Create()
+    try {
+        $digest = $algorithm.ComputeHash($stream)
+        return [BitConverter]::ToString($digest).Replace('-', '').ToLowerInvariant()
+    } finally {
+        $algorithm.Dispose()
+        $stream.Dispose()
+    }
+}
+
 function Assert-ZipLayout([string]$Path) {
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
@@ -151,7 +163,7 @@ function Install-Docbank {
         Invoke-WebRequestCompat -Uri "$baseUrl/SHA256SUMS" -OutFile $checksums | Out-Null
 
         $expected = Get-ExpectedChecksum -Path $checksums -ArchiveName $archiveName
-        $actual = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        $actual = Get-Sha256 -Path $archive
         if ($actual -ne $expected) {
             throw "checksum mismatch for $archiveName (expected $expected, got $actual)"
         }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,188 @@
+# Install the latest docbank release on 64-bit Windows.
+# Usage: irm https://raw.githubusercontent.com/kenn-io/docbank/main/scripts/install.ps1 | iex
+
+$ErrorActionPreference = 'Stop'
+
+$repo = 'kenn-io/docbank'
+$binaryName = 'docbank.exe'
+
+function Write-Info([string]$Message) { Write-Host $Message -ForegroundColor Green }
+function Write-WarningMessage([string]$Message) { Write-Host $Message -ForegroundColor Yellow }
+
+function Test-EnvBool([string]$Name) {
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    return $value -match '^(1|true|yes)$'
+}
+
+function Get-Architecture {
+    try {
+        $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        switch ($architecture) {
+            'X64' { return 'amd64' }
+            'Arm64' { return 'arm64' }
+            default { throw "unsupported Windows architecture: $architecture" }
+        }
+    } catch {
+        $architecture = if ($env:PROCESSOR_ARCHITEW6432) {
+            $env:PROCESSOR_ARCHITEW6432
+        } else {
+            $env:PROCESSOR_ARCHITECTURE
+        }
+        switch ($architecture) {
+            'AMD64' { return 'amd64' }
+            'ARM64' { return 'arm64' }
+            default { throw "unsupported Windows architecture: $architecture" }
+        }
+    }
+}
+
+function Invoke-WebRequestCompat {
+    param([Parameter(Mandatory)][string]$Uri, [string]$OutFile, [string]$Method = 'Get')
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    }
+    $parameters = @{ Uri = $Uri; Method = $Method; ErrorAction = 'Stop' }
+    if ($OutFile) { $parameters.OutFile = $OutFile }
+    if ($PSVersionTable.PSVersion.Major -lt 6) { $parameters.UseBasicParsing = $true }
+    return Invoke-WebRequest @parameters
+}
+
+function Get-FinalUrl($Response) {
+    if ($Response.BaseResponse.ResponseUri) {
+        return $Response.BaseResponse.ResponseUri.AbsoluteUri
+    }
+    if ($Response.BaseResponse.RequestMessage.RequestUri) {
+        return $Response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+    }
+    return $null
+}
+
+function Get-LatestVersion {
+    if ($env:DOCBANK_VERSION) { return $env:DOCBANK_VERSION }
+
+    $latestUrl = "https://github.com/$repo/releases/latest"
+    $response = Invoke-WebRequestCompat -Uri $latestUrl -Method Head
+    $finalUrl = Get-FinalUrl $response
+    if (-not $finalUrl -or $finalUrl -notmatch '/releases/tag/([^/]+)/?$') {
+        throw "could not resolve the latest release tag from $latestUrl"
+    }
+    return $Matches[1]
+}
+
+function Get-InstallDirectory {
+    if ($env:DOCBANK_INSTALL_DIR) { return $env:DOCBANK_INSTALL_DIR }
+    if ($env:LOCALAPPDATA) { return Join-Path $env:LOCALAPPDATA 'Programs\docbank\bin' }
+    return Join-Path $env:USERPROFILE '.local\bin'
+}
+
+function Add-ToUserPath([string]$Directory) {
+    $currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $normalized = $Directory.TrimEnd('\', '/')
+    $present = $currentPath -split ';' | Where-Object {
+        $_.TrimEnd('\', '/') -ieq $normalized
+    }
+    if ($present) { return $false }
+
+    $newPath = if ($currentPath) { "$currentPath;$Directory" } else { $Directory }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    $env:Path = "$env:Path;$Directory"
+    return $true
+}
+
+function Get-ExpectedChecksum([string]$Path, [string]$ArchiveName) {
+    $matches = @()
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ($line -match '^\s*$') { continue }
+        $parts = $line -split '\s+', 2
+        if ($parts.Count -ne 2) { continue }
+        $name = $parts[1] -replace '^\*', '' -replace '^\.\\', '' -replace '^\./', ''
+        if ($name -eq $ArchiveName) { $matches += $parts[0] }
+    }
+    if ($matches.Count -ne 1) {
+        throw "SHA256SUMS must contain exactly one entry for $ArchiveName"
+    }
+    if ($matches[0] -notmatch '^[0-9a-fA-F]{64}$') {
+        throw "invalid SHA-256 value for $ArchiveName"
+    }
+    return $matches[0].ToLowerInvariant()
+}
+
+function Assert-ZipLayout([string]$Path) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        if ($zip.Entries.Count -ne 1 -or $zip.Entries[0].FullName -ne $binaryName) {
+            throw "release archive must contain only $binaryName at its root"
+        }
+    } finally {
+        $zip.Dispose()
+    }
+}
+
+function Install-Docbank {
+    if ($PSVersionTable.PSVersion.Major -lt 5) {
+        throw 'PowerShell 5.0 or later is required'
+    }
+
+    $architecture = Get-Architecture
+    $version = Get-LatestVersion
+    if ($version -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') {
+        throw "release tag is not vX.Y.Z: $version"
+    }
+    $versionNumber = $version.Substring(1)
+    $archiveName = "docbank_${versionNumber}_windows_${architecture}.zip"
+    $baseUrl = "https://github.com/$repo/releases/download/$version"
+    $installDirectory = Get-InstallDirectory
+    New-Item -ItemType Directory -Path $installDirectory -Force | Out-Null
+
+    $temporaryDirectory = Join-Path ([IO.Path]::GetTempPath()) "docbank-install-$([guid]::NewGuid())"
+    New-Item -ItemType Directory -Path $temporaryDirectory | Out-Null
+    $staged = $null
+    try {
+        $archive = Join-Path $temporaryDirectory $archiveName
+        $checksums = Join-Path $temporaryDirectory 'SHA256SUMS'
+        Write-Info "Installing docbank $version for windows/$architecture..."
+        Invoke-WebRequestCompat -Uri "$baseUrl/$archiveName" -OutFile $archive | Out-Null
+        Invoke-WebRequestCompat -Uri "$baseUrl/SHA256SUMS" -OutFile $checksums | Out-Null
+
+        $expected = Get-ExpectedChecksum -Path $checksums -ArchiveName $archiveName
+        $actual = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actual -ne $expected) {
+            throw "checksum mismatch for $archiveName (expected $expected, got $actual)"
+        }
+        Write-Info 'Checksum verified.'
+
+        Assert-ZipLayout -Path $archive
+        Expand-Archive -LiteralPath $archive -DestinationPath $temporaryDirectory
+        $source = Join-Path $temporaryDirectory $binaryName
+        if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+            throw "release archive does not contain $binaryName"
+        }
+
+        $destination = Join-Path $installDirectory $binaryName
+        $staged = Join-Path $installDirectory ".docbank-install-$([guid]::NewGuid()).exe"
+        Copy-Item -LiteralPath $source -Destination $staged
+        try {
+            Move-Item -LiteralPath $staged -Destination $destination -Force
+        } catch {
+            throw "could not replace $destination; stop any running Docbank daemon and retry: $_"
+        }
+        $staged = $null
+
+        Write-Info "Installed $destination"
+        if (-not (Test-EnvBool 'DOCBANK_NO_MODIFY_PATH')) {
+            if (Add-ToUserPath $installDirectory) {
+                Write-WarningMessage "Added $installDirectory to PATH; restart your terminal to use it."
+            }
+        }
+        Write-Info 'Get started: docbank add ~/Documents --dest /archive'
+    } finally {
+        if ($staged -and (Test-Path -LiteralPath $staged)) {
+            Remove-Item -LiteralPath $staged -Force -ErrorAction SilentlyContinue
+        }
+        Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Install-Docbank

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -91,21 +91,21 @@ function Add-ToUserPath([string]$Directory) {
 }
 
 function Get-ExpectedChecksum([string]$Path, [string]$ArchiveName) {
-    $matches = @()
+    $checksumMatches = @()
     foreach ($line in Get-Content -LiteralPath $Path) {
         if ($line -match '^\s*$') { continue }
         $parts = $line -split '\s+', 2
         if ($parts.Count -ne 2) { continue }
         $name = $parts[1] -replace '^\*', '' -replace '^\.\\', '' -replace '^\./', ''
-        if ($name -eq $ArchiveName) { $matches += $parts[0] }
+        if ($name -eq $ArchiveName) { $checksumMatches += $parts[0] }
     }
-    if ($matches.Count -ne 1) {
+    if ($checksumMatches.Count -ne 1) {
         throw "SHA256SUMS must contain exactly one entry for $ArchiveName"
     }
-    if ($matches[0] -notmatch '^[0-9a-fA-F]{64}$') {
+    if ($checksumMatches[0] -notmatch '^[0-9a-fA-F]{64}$') {
         throw "invalid SHA-256 value for $ArchiveName"
     }
-    return $matches[0].ToLowerInvariant()
+    return $checksumMatches[0].ToLowerInvariant()
 }
 
 function Assert-ZipLayout([string]$Path) {
@@ -132,7 +132,11 @@ function Install-Docbank {
     }
     $versionNumber = $version.Substring(1)
     $archiveName = "docbank_${versionNumber}_windows_${architecture}.zip"
-    $baseUrl = "https://github.com/$repo/releases/download/$version"
+    $baseUrl = if ($env:DOCBANK_RELEASE_BASE_URL) {
+        $env:DOCBANK_RELEASE_BASE_URL.TrimEnd('/')
+    } else {
+        "https://github.com/$repo/releases/download/$version"
+    }
     $installDirectory = Get-InstallDirectory
     New-Item -ItemType Directory -Path $installDirectory -Force | Out-Null
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+# Install the latest docbank release on Linux or macOS.
+# Usage: curl -fsSL https://raw.githubusercontent.com/kenn-io/docbank/main/scripts/install.sh | sh
+
+set -eu
+
+repo="kenn-io/docbank"
+binary_name="docbank"
+
+info() { printf '%s\n' "$1"; }
+fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) printf 'darwin\n' ;;
+        Linux) printf 'linux\n' ;;
+        *) fail "unsupported operating system: $(uname -s)" ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64) printf 'amd64\n' ;;
+        aarch64|arm64) printf 'arm64\n' ;;
+        *) fail "unsupported architecture: $(uname -m)" ;;
+    esac
+}
+
+download() {
+    url=$1
+    output=$2
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$output"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q "$url" -O "$output"
+    else
+        fail "curl or wget is required"
+    fi
+}
+
+latest_version() {
+    if [ -n "${DOCBANK_VERSION:-}" ]; then
+        printf '%s\n' "$DOCBANK_VERSION"
+        return
+    fi
+
+    latest_url="https://github.com/${repo}/releases/latest"
+    if command -v curl >/dev/null 2>&1; then
+        final_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url") || return 1
+    elif command -v wget >/dev/null 2>&1; then
+        final_url=$(wget --spider -S "$latest_url" 2>&1 \
+            | awk 'tolower($1) == "location:" { print $2 }' \
+            | tail -1 \
+            | tr -d '\r\n') || return 1
+    else
+        fail "curl or wget is required"
+    fi
+    case "$final_url" in
+        */releases/tag/*) printf '%s\n' "${final_url##*/releases/tag/}" ;;
+        *) return 1 ;;
+    esac
+}
+
+checksum_for() {
+    checksums=$1
+    filename=$2
+    awk -v wanted="$filename" '
+        NF >= 2 {
+            name = $2
+            sub(/^\*/, "", name)
+            sub(/^\.\//, "", name)
+            if (name == wanted) {
+                count++
+                hash = $1
+            }
+        }
+        END {
+            if (count != 1) exit 1
+            print hash
+        }
+    ' "$checksums"
+}
+
+verify_checksum() {
+    archive=$1
+    checksums=$2
+    filename=$3
+
+    expected=$(checksum_for "$checksums" "$filename") || \
+        fail "SHA256SUMS must contain exactly one entry for ${filename}"
+    case "$expected" in
+        *[!0-9a-fA-F]*|'') fail "invalid SHA-256 value for ${filename}" ;;
+    esac
+    [ "${#expected}" -eq 64 ] || fail "invalid SHA-256 value for ${filename}"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$archive" | awk '{ print $1 }')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$archive" | awk '{ print $1 }')
+    else
+        fail "sha256sum or shasum is required; refusing an unverified install"
+    fi
+    expected=$(printf '%s' "$expected" | tr 'A-F' 'a-f')
+    actual=$(printf '%s' "$actual" | tr 'A-F' 'a-f')
+    [ "$actual" = "$expected" ] || \
+        fail "checksum mismatch for ${filename} (expected ${expected}, got ${actual})"
+    info "Checksum verified."
+}
+
+install_docbank() {
+    os=$(detect_os)
+    arch=$(detect_arch)
+    version=$(latest_version) || fail "could not resolve the latest GitHub release"
+    printf '%s\n' "$version" | awk '/^v[0-9]+\.[0-9]+\.[0-9]+$/ { valid = 1 } END { exit !valid }' || \
+        fail "release tag is not vX.Y.Z: ${version}"
+
+    version_number=${version#v}
+    filename="docbank_${version_number}_${os}_${arch}.tar.gz"
+    base_url="https://github.com/${repo}/releases/download/${version}"
+    install_dir=${DOCBANK_INSTALL_DIR:-"$HOME/.local/bin"}
+    mkdir -p "$install_dir"
+    [ -d "$install_dir" ] || fail "install destination is not a directory: ${install_dir}"
+    [ -w "$install_dir" ] || fail "install destination is not writable: ${install_dir}"
+
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/docbank-install.XXXXXX") || \
+        fail "could not create a temporary directory"
+    trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+    archive="$tmpdir/$filename"
+    checksums="$tmpdir/SHA256SUMS"
+    info "Installing docbank ${version} for ${os}/${arch}..."
+    download "${base_url}/${filename}" "$archive" || fail "could not download ${filename}"
+    download "${base_url}/SHA256SUMS" "$checksums" || \
+        fail "could not download SHA256SUMS; refusing an unverified install"
+    verify_checksum "$archive" "$checksums" "$filename"
+
+    entries=$(tar -tzf "$archive") || fail "could not read ${filename}"
+    [ "$entries" = "$binary_name" ] || \
+        fail "release archive must contain only ${binary_name} at its root"
+    tar -xzf "$archive" -C "$tmpdir"
+    [ -f "$tmpdir/$binary_name" ] || fail "release archive does not contain ${binary_name}"
+
+    staged="$install_dir/.docbank-install-$$"
+    trap 'rm -rf "$tmpdir"; rm -f "$staged"' EXIT HUP INT TERM
+    cp "$tmpdir/$binary_name" "$staged"
+    chmod 0755 "$staged"
+    mv -f "$staged" "$install_dir/$binary_name"
+
+    if [ "$os" = "darwin" ] && command -v codesign >/dev/null 2>&1; then
+        codesign -s - "$install_dir/$binary_name" >/dev/null 2>&1 || true
+    fi
+
+    info "Installed ${install_dir}/${binary_name}"
+    case ":$PATH:" in
+        *":$install_dir:"*) ;;
+        *) info "Add ${install_dir} to PATH: export PATH=\"${install_dir}:\$PATH\"" ;;
+    esac
+    info "Get started: docbank add ~/Documents --dest /archive"
+}
+
+install_docbank

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,7 +116,8 @@ install_docbank() {
 
     version_number=${version#v}
     filename="docbank_${version_number}_${os}_${arch}.tar.gz"
-    base_url="https://github.com/${repo}/releases/download/${version}"
+    base_url=${DOCBANK_RELEASE_BASE_URL:-"https://github.com/${repo}/releases/download/${version}"}
+    base_url=${base_url%/}
     install_dir=${DOCBANK_INSTALL_DIR:-"$HOME/.local/bin"}
     mkdir -p "$install_dir"
     [ -d "$install_dir" ] || fail "install destination is not a directory: ${install_dir}"

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -1,0 +1,216 @@
+package scripts
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type installerFixture struct {
+	mu        sync.RWMutex
+	archive   []byte
+	checksums string
+}
+
+func (f *installerFixture) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	switch path.Base(r.URL.Path) {
+	case "SHA256SUMS":
+		_, _ = fmt.Fprint(w, f.checksums)
+	default:
+		if strings.HasSuffix(r.URL.Path, ".tar.gz") || strings.HasSuffix(r.URL.Path, ".zip") {
+			_, _ = w.Write(f.archive)
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+func (f *installerFixture) set(archive []byte, checksums string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.archive = archive
+	f.checksums = checksums
+}
+
+func TestInstallerVerifiesBeforeReplacingBinary(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" && runtime.GOOS != "windows" {
+		t.Skip("no installer for this platform")
+	}
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		t.Skip("no installer for this architecture")
+	}
+
+	const version = "9.9.9"
+	extension := ".tar.gz"
+	binaryName := "docbank"
+	if runtime.GOOS == "windows" {
+		extension = ".zip"
+		binaryName += ".exe"
+	}
+	archiveName := fmt.Sprintf("docbank_%s_%s_%s%s", version, runtime.GOOS, runtime.GOARCH, extension)
+	installDir := t.TempDir()
+	destination := filepath.Join(installDir, binaryName)
+
+	fixture := &installerFixture{}
+	server := httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
+	t.Cleanup(server.Close)
+
+	goodArchive := installerArchive(t, binaryName, []byte("new docbank\n"), false)
+	goodHash := fmt.Sprintf("%x", sha256.Sum256(goodArchive))
+	fixture.set(goodArchive, fmt.Sprintf("%s  %s\n", goodHash, archiveName))
+	writeExisting(t, destination)
+	output, err := runInstaller(t, server.URL, installDir)
+	if err != nil {
+		t.Fatalf("installing verified fixture: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "Checksum verified") {
+		t.Fatalf("installer did not report checksum verification:\n%s", output)
+	}
+	assertContent(t, destination, "new docbank\n")
+
+	tests := []struct {
+		name      string
+		archive   []byte
+		checksums string
+		wantError string
+	}{
+		{
+			name:      "checksum mismatch",
+			archive:   goodArchive,
+			checksums: fmt.Sprintf("%064d  %s\n", 0, archiveName),
+			wantError: "checksum mismatch",
+		},
+		{
+			name:      "duplicate checksum",
+			archive:   goodArchive,
+			checksums: fmt.Sprintf("%s  %s\n%s  %s\n", goodHash, archiveName, goodHash, archiveName),
+			wantError: "exactly one entry",
+		},
+		{
+			name:      "unexpected archive entry",
+			archive:   installerArchive(t, binaryName, []byte("new docbank\n"), true),
+			wantError: "only",
+		},
+	}
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			test := tests[i]
+			if test.checksums == "" {
+				hash := fmt.Sprintf("%x", sha256.Sum256(test.archive))
+				test.checksums = fmt.Sprintf("%s  %s\n", hash, archiveName)
+			}
+			fixture.set(test.archive, test.checksums)
+			writeExisting(t, destination)
+			output, err := runInstaller(t, server.URL, installDir)
+			if err == nil {
+				t.Fatalf("installer accepted invalid release:\n%s", output)
+			}
+			if !strings.Contains(strings.ToLower(output), strings.ToLower(test.wantError)) {
+				t.Fatalf("error does not explain %q:\n%s", test.wantError, output)
+			}
+			assertContent(t, destination, "old docbank\n")
+		})
+	}
+}
+
+func runInstaller(t *testing.T, baseURL, installDir string) (string, error) {
+	t.Helper()
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "install.ps1")
+	} else {
+		cmd = exec.Command("sh", "install.sh")
+	}
+	cmd.Env = append(os.Environ(),
+		"DOCBANK_VERSION=v9.9.9",
+		"DOCBANK_RELEASE_BASE_URL="+baseURL,
+		"DOCBANK_INSTALL_DIR="+installDir,
+		"DOCBANK_NO_MODIFY_PATH=1",
+	)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func writeExisting(t *testing.T, destination string) {
+	t.Helper()
+	if err := os.WriteFile(destination, []byte("old docbank\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertContent(t *testing.T, destination, want string) {
+	t.Helper()
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("installed content = %q, want %q", got, want)
+	}
+}
+
+func installerArchive(t *testing.T, binaryName string, content []byte, extra bool) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if runtime.GOOS == "windows" {
+		zw := zip.NewWriter(&buf)
+		writeZipEntry(t, zw, binaryName, content)
+		if extra {
+			writeZipEntry(t, zw, "unexpected.txt", []byte("unexpected\n"))
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	writeTarEntry(t, tw, binaryName, content)
+	if extra {
+		writeTarEntry(t, tw, "unexpected.txt", []byte("unexpected\n"))
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func writeZipEntry(t *testing.T, zw *zip.Writer, name string, content []byte) {
+	t.Helper()
+	w, err := zw.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(content); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTarEntry(t *testing.T, tw *tar.Writer, name string, content []byte) {
+	t.Helper()
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(content))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Docbank now supports the full vault lifecycle on Linux, macOS, and Windows, but its release pipeline still publishes only three of the six supported OS/architecture combinations. That makes Windows support and macOS on Intel source-build-only despite the runtime contract now being complete.

This makes distribution match the product boundary:

- build Linux, macOS, and Windows archives for amd64 and arm64, using native Linux/Windows runners and CGO-enabled macOS cross-compilation;
- block release publication unless the exact six artifacts contain the expected executable, target architecture, embedded release version, and generated checksum entry;
- add shell and PowerShell installers that refuse missing, duplicate, malformed, or mismatched checksums and reject unexpected archive contents before publishing a binary; and
- document the supported installer, manual archive, destination, version-selection, and PATH behavior without adding Nix packaging.

The normal platform suites execute the actual shell installer on Unix and the actual PowerShell installer on Windows against generated release fixtures. They prove that a verified archive replaces the binary while checksum mismatches, duplicate entries, and unexpected payloads fail without changing an existing installation. The native runners also exposed and removed an optional Windows cmdlet dependency, leaving the PowerShell 5/7 path on framework cryptography primitives.
