### PR TITLE
Validate release builders before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: release
 on:
   push:
     tags: ["v*"]
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+      - go.mod
+      - go.sum
 
 permissions:
   contents: read
@@ -33,7 +38,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends ca-certificates file gcc git gzip tar
+          apt-get install -y --no-install-recommends build-essential ca-certificates file git gzip tar
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -52,7 +57,11 @@ jobs:
           GOOS: linux
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION="0.0.0"
+          fi
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "FATAL: release tag must use vX.Y.Z format" >&2
             exit 1
@@ -100,7 +109,11 @@ jobs:
           GOOS: darwin
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION="0.0.0"
+          fi
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "FATAL: release tag must use vX.Y.Z format" >&2
             exit 1
@@ -177,7 +190,11 @@ jobs:
           GOOS: windows
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION="0.0.0"
+          fi
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "FATAL: release tag must use vX.Y.Z format" >&2
             exit 1
@@ -205,6 +222,7 @@ jobs:
   publish:
     name: Publish GitHub release
     needs: [build-linux, build-darwin, build-windows]
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,7 @@ jobs:
             echo "FATAL: release tag must use vX.Y.Z format" >&2
             exit 1
           fi
+          printf 'RELEASE_VERSION=%s\n' "${VERSION}" >> "${GITHUB_ENV}"
           COMMIT="$(printf '%s' "${GITHUB_SHA}" | cut -c1-8)"
           LDFLAGS="-s -w -X go.kenn.io/docbank/internal/version.Version=${VERSION} -X go.kenn.io/docbank/internal/version.Commit=${COMMIT}"
           go build -tags fts5 -trimpath -buildvcs=false -ldflags "${LDFLAGS}" -o dist/docbank.exe ./cmd/docbank
@@ -209,8 +210,7 @@ jobs:
       - name: Package
         shell: pwsh
         run: |
-          $version = $env:GITHUB_REF -replace '^refs/tags/v', ''
-          Compress-Archive -Path dist/docbank.exe -DestinationPath "dist/docbank_${version}_windows_${{ matrix.goarch }}.zip"
+          Compress-Archive -Path dist/docbank.exe -DestinationPath "dist/docbank_$($env:RELEASE_VERSION)_windows_${{ matrix.goarch }}.zip"
           Remove-Item dist/docbank.exe
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
The first six-platform release reached both Ubuntu 22.04 builders but failed before linking because the minimal container had GCC without the C library development headers required by CGO. That package boundary was not exercised in PR CI, so the defect remained invisible until `v0.2.0` had already been tagged.

This uses Ubuntu’s complete native build toolchain and runs the six release builders when a pull request changes the release workflow or Go toolchain inputs. Review builds use an inert `0.0.0` version and the write-capable publish job remains tag-only, preserving the release authority boundary while proving the actual archives before another tag is cut.

This PR’s own release-workflow checks are the acceptance test for the repaired Linux container and the other five packaging paths.