### PR TITLE
Let recovery releases span unpublished tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,9 @@ Instructions for autonomous coding agents working in this repository.
 - Cut releases only from a clean local `main` that exactly matches
   `origin/main`.
 - Preview notes with `scripts/changelog.sh <version>`; publish with
-  `scripts/release.sh <version> [extra_instructions]`.
+  `scripts/release.sh <version> [extra_instructions] [start_tag]`. Supply the
+  optional start tag only when notes must span an intervening tag that did not
+  publish.
 - The release script creates and pushes an annotated `vX.Y.Z` tag. The release
   workflow uses the tag body as GitHub release notes and falls back to generated
   notes only for a lightweight or empty tag.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Generate release notes, create an annotated version tag, and push it.
+# Usage: ./scripts/release.sh <version> [extra_instructions] [start_tag]
 
 set -euo pipefail
 
@@ -8,11 +9,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 VERSION="${1:-}"
 EXTRA_INSTRUCTIONS="${2:-}"
+START_TAG="${3:--}"
 
 if [[ -z "$VERSION" ]]; then
-    echo "Usage: $0 <version> [extra_instructions]"
+    echo "Usage: $0 <version> [extra_instructions] [start_tag]"
     echo "Example: $0 0.2.0"
     echo "Example: $0 0.2.0 \"Focus on editing and version history\""
+    echo "Example: $0 0.2.1 \"Include the unpublished release features\" v0.1.0"
     exit 1
 fi
 
@@ -58,7 +61,7 @@ fi
 CHANGELOG_FILE="$(mktemp)"
 trap 'rm -f "$CHANGELOG_FILE"' EXIT
 
-"$SCRIPT_DIR/changelog.sh" "$VERSION" - "$EXTRA_INSTRUCTIONS" >"$CHANGELOG_FILE"
+"$SCRIPT_DIR/changelog.sh" "$VERSION" "$START_TAG" "$EXTRA_INSTRUCTIONS" >"$CHANGELOG_FILE"
 
 if [[ ! -s "$CHANGELOG_FILE" ]]; then
     echo "Error: no release-note content was generated"


### PR DESCRIPTION
A Git tag can exist even when its release workflow fails before publication. In that state, the next release currently treats the failed tag as its changelog boundary and silently omits the user-facing work that has never appeared in a downloadable release. That is exactly the state left by the blocked `v0.2.0` run.

This exposes the changelog generator’s existing explicit start boundary through the guarded release wrapper. Normal releases retain automatic tag detection; a caller supplies the third argument only when an intervening tag never published. This lets `v0.2.1` remain an immutable follow-up while accurately describing everything shipped since public `v0.1.0`.

The script passes Bash syntax and shell analysis, and the explicit `v0.1.0` changelog preview produces the intended complete `v0.2.1` notes.