### PR TITLE
Honor explicitly named cloud-storage roots

### DIFF
--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -90,7 +90,12 @@ payoff (importing user-readable files into the user's own vault) does
 not justify platform-specific `openat`/`fstatat` machinery. The
 *accidental* case — a symlink sitting in the tree — is handled: it is
 classified, reported, and skipped, and the final open refuses to
-follow links regardless.
+follow links regardless. The one explicit exception is a source argument whose
+final component is a symlink to a directory, which is common for cloud-storage
+roots. Docbank resolves that link before walking and continues on the resolved
+path, so retargeting the user-facing link after resolution cannot redirect the
+walk. Descendant symlinks are still skipped, while virtual naming and provenance
+retain the spelling the user supplied.
 
 ### Schema compatibility after v0.1.0
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -33,8 +33,10 @@ never modified or deleted.
 
 - A directory argument imports recursively: its basename becomes a
   directory under `--dest` and relative structure is preserved.
-- Symlinks and other non-regular files are skipped and reported as
-  failures; they do not abort the run.
+- An explicitly named symlink to a directory is followed as the import root;
+  its supplied basename and provenance spelling are retained. Symlinks inside
+  that tree, symlinks to files, and other non-regular files are skipped and
+  reported as failures; they do not abort the run.
 - Name collisions with different content auto-suffix:
   `report.pdf` → `report (2).pdf`.
 - Re-running an import converges: a file whose content already exists

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -32,6 +32,13 @@ docbank add ~/old-laptop/Documents --dest /archive
 Trailing slashes and `./`-style paths are normalized; `add docs/` and
 `add ./docs` behave identically to `add docs`.
 
+An explicitly named source may be a symlink to a directory. This supports
+ordinary platform layouts such as `~/Dropbox` on macOS: docbank resolves that
+one root link, retains `Dropbox` as the virtual directory name, and records
+provenance using the path the user supplied. Symlinks encountered *inside* the
+tree remain skipped and reported, and an explicitly named symlink to a file is
+not imported.
+
 ## Idempotency: safe to re-run
 
 Interrupted a 200,000-file import? Run the same command again. For each
@@ -76,7 +83,8 @@ source arguments.
 
 ## Sources are read-only
 
-Import never deletes or modifies source files. Delete originals yourself
+Import never deletes or modifies source files, including a followed root
+directory symlink. Delete originals yourself
 once `docbank verify` and your own spot-checks satisfy you — the same
 archive-first, delete-later posture msgvault takes with mailboxes.
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -144,9 +144,30 @@ func (ing *Ingester) AddPaths(ctx context.Context, sources []string, destPath st
 		}
 		switch {
 		case info.Mode().IsRegular():
-			ing.addOne(ctx, &rep, ingestID, dest.ID, src)
+			ing.addOne(ctx, &rep, ingestID, dest.ID, src, src)
 		case info.IsDir():
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src); err != nil {
+			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, src); err != nil {
+				return rep, err
+			}
+		case info.Mode()&fs.ModeSymlink != 0:
+			walkRoot, err := filepath.EvalSymlinks(src)
+			if err != nil {
+				rep.Failed = append(rep.Failed, FileError{Path: src,
+					Err: fmt.Errorf("resolving explicitly named directory symlink: %w", err)})
+				continue
+			}
+			target, err := os.Stat(walkRoot)
+			if err != nil {
+				rep.Failed = append(rep.Failed, FileError{Path: src,
+					Err: fmt.Errorf("checking explicitly named directory symlink: %w", err)})
+				continue
+			}
+			if !target.IsDir() {
+				rep.Failed = append(rep.Failed, FileError{Path: src,
+					Err: errors.New("explicit symlink source does not resolve to a directory")})
+				continue
+			}
+			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, walkRoot); err != nil {
 				return rep, err
 			}
 		default:
@@ -157,27 +178,39 @@ func (ing *Ingester) AddPaths(ctx context.Context, sources []string, destPath st
 	return rep, nil
 }
 
-// addTree imports srcRoot recursively; its basename becomes a directory
-// under destDirID and relative structure is preserved.
+// addTree imports walkRoot recursively; sourceRoot's basename becomes a
+// directory under destDirID and relative structure is preserved. The roots
+// differ only when the user explicitly supplied a symlink to a directory:
+// traversal uses its resolved target while provenance retains the supplied
+// spelling.
 //
 // Traversal is by path (WalkDir): swapping an already-classified directory
-// for a symlink mid-walk can redirect descent outside srcRoot. That race is
+// for a symlink mid-walk can redirect descent outside walkRoot. That race is
 // accepted — docbank is single-user and imports the user's own trees, so a
 // process able to race the walk already runs as the user; importFile's
 // no-follow open covers the accidental symlink case.
-func (ing *Ingester) addTree(ctx context.Context, rep *Report, ingestID, destDirID int64, srcRoot string) error {
+func (ing *Ingester) addTree(
+	ctx context.Context,
+	rep *Report,
+	ingestID, destDirID int64,
+	sourceRoot, walkRoot string,
+) error {
 	// Absolutize first. WalkDir hands back the root spelled exactly as given
 	// while children come from filepath.Join, which cleans — dirIDs keys must
 	// use one spelling. And a source spelled "." or ".." has no usable
 	// basename: a ".." topName would climb out of the destination when
 	// joined into the virtual path below.
-	srcRoot, err := filepath.Abs(srcRoot)
+	sourceRoot, err := filepath.Abs(sourceRoot)
 	if err != nil {
-		return fmt.Errorf("resolving source %s: %w", srcRoot, err)
+		return fmt.Errorf("resolving source %s: %w", sourceRoot, err)
 	}
-	topName := filepath.Base(srcRoot)
-	if topName == string(filepath.Separator) {
-		return fmt.Errorf("cannot import filesystem root %q", srcRoot)
+	walkRoot, err = filepath.Abs(walkRoot)
+	if err != nil {
+		return fmt.Errorf("resolving traversal root %s: %w", walkRoot, err)
+	}
+	topName := filepath.Base(sourceRoot)
+	if topName == string(filepath.Separator) || filepath.Base(walkRoot) == string(filepath.Separator) {
+		return fmt.Errorf("cannot import filesystem root %q", sourceRoot)
 	}
 
 	// Parentage stays ID-based throughout: every directory is created under
@@ -185,15 +218,16 @@ func (ing *Ingester) addTree(ctx context.Context, rep *Report, ingestID, destDir
 	// destDirID — a concurrent move or trash of the destination would make
 	// that path re-create (even resurrect) a tree somewhere else.
 	dirIDs := map[string]int64{} // source dir path -> virtual dir node id
-	walkErr := filepath.WalkDir(srcRoot, func(p string, d fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(walkRoot, func(p string, d fs.DirEntry, err error) error {
+		sourcePath := sourceTreePath(sourceRoot, walkRoot, p)
 		if err != nil {
-			rep.Failed = append(rep.Failed, FileError{Path: p, Err: err})
+			rep.Failed = append(rep.Failed, FileError{Path: sourcePath, Err: err})
 			return nil //nolint:nilerr // intentional: record error and continue walk
 		}
 		switch {
 		case d.IsDir():
 			parentID, name := destDirID, topName
-			if p != srcRoot {
+			if p != walkRoot {
 				pid, ok := dirIDs[filepath.Dir(p)]
 				if !ok {
 					return fmt.Errorf("internal: no virtual dir recorded for %s", filepath.Dir(p))
@@ -202,7 +236,7 @@ func (ing *Ingester) addTree(ctx context.Context, rep *Report, ingestID, destDir
 			}
 			dir, err := ing.Store.EnsureDir(ctx, parentID, name)
 			if err != nil {
-				rep.Failed = append(rep.Failed, FileError{Path: p,
+				rep.Failed = append(rep.Failed, FileError{Path: sourcePath,
 					Err: fmt.Errorf("creating virtual dir %q under node %d: %w", name, parentID, err)})
 				return fs.SkipDir
 			}
@@ -212,9 +246,9 @@ func (ing *Ingester) addTree(ctx context.Context, rep *Report, ingestID, destDir
 			if !ok {
 				return fmt.Errorf("internal: no virtual dir recorded for %s", filepath.Dir(p))
 			}
-			ing.addOne(ctx, rep, ingestID, parentID, p)
+			ing.addOne(ctx, rep, ingestID, parentID, p, sourcePath)
 		default:
-			rep.Failed = append(rep.Failed, FileError{Path: p,
+			rep.Failed = append(rep.Failed, FileError{Path: sourcePath,
 				Err: errors.New("not a regular file (symlinks are skipped)")})
 		}
 		return nil
@@ -222,12 +256,25 @@ func (ing *Ingester) addTree(ctx context.Context, rep *Report, ingestID, destDir
 	return walkErr
 }
 
+func sourceTreePath(sourceRoot, walkRoot, walkPath string) string {
+	rel, err := filepath.Rel(walkRoot, walkPath)
+	if err != nil || rel == "." {
+		return sourceRoot
+	}
+	return filepath.Join(sourceRoot, rel)
+}
+
 // addOne imports a single regular file; failures land in the report.
-func (ing *Ingester) addOne(ctx context.Context, rep *Report, ingestID, parentID int64, src string) {
-	added, err := ing.importFile(ctx, ingestID, parentID, src)
+func (ing *Ingester) addOne(
+	ctx context.Context,
+	rep *Report,
+	ingestID, parentID int64,
+	openPath, sourcePath string,
+) {
+	added, err := ing.importFile(ctx, ingestID, parentID, openPath, sourcePath)
 	switch {
 	case err != nil:
-		rep.Failed = append(rep.Failed, FileError{Path: src, Err: err})
+		rep.Failed = append(rep.Failed, FileError{Path: sourcePath, Err: err})
 	case added:
 		rep.Added++
 	default:
@@ -235,31 +282,35 @@ func (ing *Ingester) addOne(ctx context.Context, rep *Report, ingestID, parentID
 	}
 }
 
-func (ing *Ingester) importFile(ctx context.Context, ingestID, parentID int64, src string) (bool, error) {
+func (ing *Ingester) importFile(
+	ctx context.Context,
+	ingestID, parentID int64,
+	openPath, sourcePath string,
+) (bool, error) {
 	// No-follow plus fstat, not the earlier Lstat/WalkDir classification:
 	// the file could have been swapped since, and "symlinks are skipped"
 	// must hold for the file actually read, not the one classified.
-	f, err := blob.OpenNoFollow(src)
+	f, err := blob.OpenNoFollow(openPath)
 	if err != nil {
-		return false, fmt.Errorf("opening %s: %w", src, err)
+		return false, fmt.Errorf("opening %s: %w", sourcePath, err)
 	}
 	defer func() { _ = f.Close() }()
 	info, err := f.Stat()
 	if err != nil {
-		return false, fmt.Errorf("checking %s: %w", src, err)
+		return false, fmt.Errorf("checking %s: %w", sourcePath, err)
 	}
 	if !info.Mode().IsRegular() {
-		return false, fmt.Errorf("%s: not a regular file", src)
+		return false, fmt.Errorf("%s: not a regular file", sourcePath)
 	}
 
 	head := make([]byte, 512)
 	n, err := io.ReadFull(f, head)
 	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
-		return false, fmt.Errorf("reading %s: %w", src, err)
+		return false, fmt.Errorf("reading %s: %w", sourcePath, err)
 	}
 	head = head[:n]
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return false, fmt.Errorf("rewinding %s: %w", src, err)
+		return false, fmt.Errorf("rewinding %s: %w", sourcePath, err)
 	}
 
 	// Blob first: the node row must never commit before its bytes are
@@ -268,14 +319,14 @@ func (ing *Ingester) importFile(ctx context.Context, ingestID, parentID int64, s
 	// scan.
 	hash, size, err := ing.Blobs.WriteContext(ctx, f)
 	if err != nil {
-		return false, fmt.Errorf("storing content of %s: %w", src, err)
+		return false, fmt.Errorf("storing content of %s: %w", sourcePath, err)
 	}
 
 	mtime := info.ModTime().UTC().Format(time.RFC3339Nano)
 	_, added, err := ing.Store.IngestFile(ctx, ingestID, parentID,
-		filepath.Base(src), hash, size, detectMime(src, head), src, mtime)
+		filepath.Base(sourcePath), hash, size, detectMime(sourcePath, head), sourcePath, mtime)
 	if err != nil {
-		return false, fmt.Errorf("recording %s: %w", src, err)
+		return false, fmt.Errorf("recording %s: %w", sourcePath, err)
 	}
 	return added, nil
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -239,7 +239,7 @@ func TestAddTreeStaleDestinationIsNotResurrected(t *testing.T) {
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
 	var rep Report
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src))
+	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 

--- a/internal/ingest/ingest_unix_test.go
+++ b/internal/ingest/ingest_unix_test.go
@@ -3,10 +3,14 @@
 package ingest
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,6 +25,64 @@ func TestImportRefusesSymlinkAtOpen(t *testing.T) {
 	// are skipped" has to hold at the point the file is opened for reading.
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
-	_, err = ing.importFile(ctx, ingestID, ing.Store.RootID(), link)
+	_, err = ing.importFile(ctx, ingestID, ing.Store.RootID(), link, link)
 	require.Error(t, err)
+}
+
+func TestAddExplicitDirectorySymlinkPreservesSourceSpelling(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	target := writeTree(t, map[string]string{"nested/notes.txt": "hello"})
+	alias := filepath.Join(t.TempDir(), "Dropbox")
+	require.NoError(t, os.Symlink(target, alias))
+	require.NoError(t, os.Symlink(
+		filepath.Join(target, "nested", "notes.txt"),
+		filepath.Join(target, "nested", "linked-notes.txt"),
+	))
+
+	rep, err := ing.AddPaths(ctx, []string{alias}, "/archive")
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Added)
+	assert.Zero(t, rep.Skipped)
+	require.Len(t, rep.Failed, 1)
+	assert.Equal(t, filepath.Join(alias, "nested", "linked-notes.txt"), rep.Failed[0].Path)
+
+	node, err := ing.Store.NodeByPath(ctx, "/archive/Dropbox/nested/notes.txt")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(alias, "nested", "notes.txt"), provenancePath(t, ing, node.ID))
+
+	// Re-running through the same user-facing spelling converges, and neither
+	// the root link nor a nested link is replaced or followed as file content.
+	rep, err = ing.AddPaths(ctx, []string{alias}, "/archive")
+	require.NoError(t, err)
+	assert.Zero(t, rep.Added)
+	assert.Equal(t, 1, rep.Skipped)
+	require.Len(t, rep.Failed, 1)
+	rootInfo, err := os.Lstat(alias)
+	require.NoError(t, err)
+	assert.NotZero(t, rootInfo.Mode()&os.ModeSymlink)
+	nestedInfo, err := os.Lstat(filepath.Join(target, "nested", "linked-notes.txt"))
+	require.NoError(t, err)
+	assert.NotZero(t, nestedInfo.Mode()&os.ModeSymlink)
+}
+
+func provenancePath(t *testing.T, ing *Ingester, nodeID int64) string {
+	t.Helper()
+	var metadata bytes.Buffer
+	require.NoError(t, ing.Store.ExportMetadata(t.Context(), &metadata))
+	scanner := bufio.NewScanner(&metadata)
+	for scanner.Scan() {
+		var record struct {
+			Type         string `json:"type"`
+			NodeID       int64  `json:"node_id"`
+			OriginalPath string `json:"original_path"`
+		}
+		require.NoError(t, json.Unmarshal(scanner.Bytes(), &record))
+		if record.Type == "provenance" && record.NodeID == nodeID {
+			return record.OriginalPath
+		}
+	}
+	require.NoError(t, scanner.Err())
+	t.Fatalf("no provenance for node %d", nodeID)
+	return ""
 }


### PR DESCRIPTION
On current macOS Dropbox installations, `~/Dropbox` is a final symlink into `~/Library/CloudStorage`. Docbank rejects that natural source spelling before traversal, forcing people to know the provider’s physical implementation path before they can archive their own documents. The newly synchronized corpus exposed this immediately, before any source content was ingested.

This treats an explicitly named symlink to a directory as user intent to import that root. The walk stays on the resolved target, so later retargeting of the visible link cannot redirect it; the virtual root and provenance retain the path the user actually supplied. Links encountered below that root and links to files remain reported failures, and the importer never writes to the source tree.

A synthetic cloud-root regression proves preserved structure and provenance, nested-link refusal, unchanged links, and convergence on rerun. The complete repository and strict documentation checks are green.