### PR TITLE
Preflight large imports without touching content

### DIFF
--- a/cmd/docbank/add.go
+++ b/cmd/docbank/add.go
@@ -77,7 +77,7 @@ var addCmd = &cobra.Command{
 
 func init() {
 	addCmd.Flags().StringVar(&addDest, "dest", "/inbox", "virtual destination directory")
-	addCmd.Flags().StringSliceVar(&addExclude, "exclude", nil,
+	addCmd.Flags().StringArrayVar(&addExclude, "exclude", nil,
 		"exclude an entry name anywhere or a relative path within each source (repeatable)")
 	addCmd.Flags().BoolVar(&addPreflight, "preflight", false,
 		"inventory sources without opening content or changing the vault")

--- a/cmd/docbank/add.go
+++ b/cmd/docbank/add.go
@@ -1,21 +1,32 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
 )
 
-var addDest string
+var (
+	addDest      string
+	addExclude   []string
+	addPreflight bool
+	addJSON      bool
+)
 
 var addCmd = &cobra.Command{
 	Use:   "add <path>...",
 	Short: "Import files or directory trees into the vault",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if addJSON && !addPreflight {
+			return errors.New("--json requires --preflight")
+		}
 		abs := make([]string, len(args))
 		for i, a := range args {
 			p, err := filepath.Abs(a)
@@ -28,12 +39,32 @@ var addCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		rep, err := c.Ingest(cmd.Context(), abs, addDest)
+		if addPreflight {
+			rep, err := c.PreflightIngest(cmd.Context(), abs, addExclude)
+			if err != nil {
+				return err
+			}
+			if addJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(rep); err != nil {
+					return fmt.Errorf("encoding preflight report: %w", err)
+				}
+			} else {
+				printIngestPreflight(cmd, rep)
+			}
+			if rep.Errors > 0 || rep.Rejected.Files > 0 {
+				return fmt.Errorf("preflight found %d error(s) and %d file(s) above the ingest limit",
+					rep.Errors, rep.Rejected.Files)
+			}
+			return nil
+		}
+		rep, err := c.IngestWithOptions(cmd.Context(), abs, addDest, addExclude)
 		if err != nil {
 			return err
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "added: %d  skipped: %d  failed: %d\n",
-			rep.Added, rep.Skipped, len(rep.Failed))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "added: %d  skipped: %d  excluded: %d  failed: %d\n",
+			rep.Added, rep.Skipped, rep.Excluded, len(rep.Failed))
 		for _, f := range rep.Failed {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "failed: %s: %s\n", f.Path, f.Error)
 		}
@@ -46,5 +77,47 @@ var addCmd = &cobra.Command{
 
 func init() {
 	addCmd.Flags().StringVar(&addDest, "dest", "/inbox", "virtual destination directory")
+	addCmd.Flags().StringSliceVar(&addExclude, "exclude", nil,
+		"exclude an entry name anywhere or a relative path within each source (repeatable)")
+	addCmd.Flags().BoolVar(&addPreflight, "preflight", false,
+		"inventory sources without opening content or changing the vault")
+	addCmd.Flags().BoolVar(&addJSON, "json", false, "machine-readable preflight report")
 	rootCmd.AddCommand(addCmd)
+}
+
+func printIngestPreflight(cmd *cobra.Command, rep api.IngestPreflightReport) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "files: %d  directories: %d  logical size: %s\n",
+		rep.Files, rep.Directories, formatBackupBytes(rep.LogicalBytes))
+	_, _ = fmt.Fprintf(out, "pack eligible: %d file(s), %s\n",
+		rep.PackEligible.Files, formatBackupBytes(rep.PackEligible.Bytes))
+	_, _ = fmt.Fprintf(out, "loose only: %d file(s), %s\n",
+		rep.LooseOnly.Files, formatBackupBytes(rep.LooseOnly.Bytes))
+	_, _ = fmt.Fprintf(out, "rejected: %d file(s), %s\n",
+		rep.Rejected.Files, formatBackupBytes(rep.Rejected.Bytes))
+	_, _ = fmt.Fprintf(out, "excluded: %d  skipped non-regular: %d  errors: %d\n",
+		rep.Excluded, rep.Skipped, rep.Errors)
+
+	if len(rep.FileTypes) > 0 {
+		_, _ = fmt.Fprintln(out, "largest file types:")
+		limit := min(len(rep.FileTypes), 12)
+		for _, fileType := range rep.FileTypes[:limit] {
+			name := fileType.Extension
+			if name == "" {
+				name = "(no extension)"
+			}
+			_, _ = fmt.Fprintf(out, "  %-16s %8d file(s)  %s\n",
+				name, fileType.Files, formatBackupBytes(fileType.Bytes))
+		}
+		if len(rep.FileTypes) > limit || rep.FileTypesTruncated {
+			_, _ = fmt.Fprintln(out, "  ... use --json for the full bounded summary")
+		}
+	}
+	for _, finding := range rep.Findings {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s: %s: %s\n",
+			finding.Kind, finding.Path, finding.Detail)
+	}
+	if rep.FindingsTruncated {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "additional findings omitted; counts above are complete")
+	}
 }

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -50,7 +50,11 @@ func runCLI(t *testing.T, args ...string) (string, error) {
 func resetFlags(c *cobra.Command) {
 	c.Flags().VisitAll(func(f *pflag.Flag) {
 		if f.Changed {
-			_ = f.Value.Set(f.DefValue)
+			if values, ok := f.Value.(pflag.SliceValue); ok && f.DefValue == "[]" {
+				_ = values.Replace(nil)
+			} else {
+				_ = f.Value.Set(f.DefValue)
+			}
 			f.Changed = false
 		}
 	})
@@ -161,6 +165,32 @@ func TestAddPreflightReportsWithoutImporting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out, "session.jsonl")
 	assert.NotContains(t, out, ".git")
+}
+
+func TestAddExcludeCommaIsLiteral(t *testing.T) {
+	_ = setupVaultHome(t)
+	src := t.TempDir()
+	for _, rel := range []string{"cache,tmp/ignored.txt", "cache/kept.txt", "tmp/kept.txt"} {
+		path := filepath.Join(src, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte(rel), 0o600))
+	}
+
+	out, err := runCLI(t, "add", src, "--preflight", "--exclude", "cache,tmp", "--json")
+	require.NoError(t, err)
+	var report api.IngestPreflightReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, int64(2), report.Files,
+		"comma-containing entry must be one literal rule; cache and tmp remain selected")
+	assert.Equal(t, int64(1), report.Excluded)
+
+	// The literal array flag appends repeated occurrences in production, but
+	// in-process CLI executions must still reset it between invocations.
+	out, err = runCLI(t, "add", src, "--preflight", "--json")
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, int64(3), report.Files)
+	assert.Zero(t, report.Excluded)
 }
 
 func TestAddMissingSourceFails(t *testing.T) {

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -129,6 +129,40 @@ func TestAddRerunReportsSkips(t *testing.T) {
 	assert.Contains(t, out, "skipped: 1")
 }
 
+func TestAddPreflightReportsWithoutImporting(t *testing.T) {
+	_ = setupVaultHome(t)
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "session.jsonl"), []byte("{\"ok\":true}\n"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, ".git"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(src, ".git", "config"), []byte("ignored"), 0o600))
+
+	out, err := runCLI(t, "add", src, "--preflight", "--exclude", ".git")
+	require.NoError(t, err)
+	assert.Contains(t, out, "files: 1")
+	assert.Contains(t, out, "excluded: 1")
+	assert.Contains(t, out, ".jsonl")
+
+	_, err = runCLI(t, "ls", "/inbox")
+	require.Error(t, err, "preflight must not create the destination")
+
+	out, err = runCLI(t, "add", src, "--preflight", "--exclude", ".git", "--json")
+	require.NoError(t, err)
+	var report api.IngestPreflightReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, int64(1), report.Files)
+	assert.Equal(t, int64(1), report.Excluded)
+
+	out, err = runCLI(t, "add", src, "--exclude", ".git")
+	require.NoError(t, err)
+	assert.Contains(t, out, "added: 1")
+	assert.Contains(t, out, "excluded: 1")
+
+	out, err = runCLI(t, "tree", "/inbox")
+	require.NoError(t, err)
+	assert.Contains(t, out, "session.jsonl")
+	assert.NotContains(t, out, ".git")
+}
+
 func TestAddMissingSourceFails(t *testing.T) {
 	_ = setupVaultHome(t)
 

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -149,6 +149,28 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	assert.Contains(t, out, "already running")
 	assert.Equal(t, oldPID, parsePID(t, out))
 
+	// A same-version daemon from before ingest preflight/exclusions existed
+	// must be replaced before the CLI issues the new request. Otherwise
+	// preflight returns 404 and a real ingest can silently ignore exclusions.
+	src := filepath.Join(t.TempDir(), "preflight.txt")
+	require.NoError(t, os.WriteFile(src, []byte("preview"), 0o600))
+	recs, err := client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.Equal(t, "8", recs[0].Metadata["protocol_version"])
+	recs[0].Metadata["protocol_version"] = "7"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+
+	out, err = run(oldBin, "add", src, "--preflight")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "files: 1")
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	preflightPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, oldPID, preflightPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -160,10 +182,10 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	// Simulate the immediately preceding same-version dev protocol. Data
 	// commands share daemon start's convergence path, so backup create must
 	// replace it instead of reaching the old daemon and failing with 404.
-	recs, err := client.RuntimeStore(dir).List()
+	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "7", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "8", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -176,7 +198,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, oldPID, protocolPID)
+	assert.NotEqual(t, preflightPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -68,8 +68,9 @@ non-goals.
 
 ## Common agent workflows
 
-- **File local material:** use server-path ingest when the daemon can read the
-  source, then inspect every added, skipped, and failed result.
+- **File local material:** preflight large server-side trees with the intended
+  exclusions, require no errors or over-limit files, then ingest with the same
+  selection and inspect every added, skipped, excluded, and failed result.
 - **Write from another machine:** upload one file with declared SHA-256, size,
   name, and destination directory ID; accept success only when the returned
   server-computed identity matches.

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -223,15 +223,31 @@ name and verify that it is the directory the workflow intended.
 `POST /api/v1/ingest` reads absolute paths on the daemon host and is restricted
 to loopback callers. It is not a file-upload endpoint:
 
+For a large tree, inventory the exact selection first. This request reads
+filesystem metadata but does not open file content or mutate the vault:
+
 ```bash
 curl --fail-with-body -X POST \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'Content-Type: application/json' \
-  --data '{"paths":["/Users/me/Downloads/receipt.pdf"],"dest":"/receipts"}' \
+  --data '{"paths":["/Users/me/Dropbox"],"exclude":[".git",".Trash"]}' \
+  "$DOCBANK_URL/api/v1/ingest/preflight"
+```
+
+Require `errors == 0` and `rejected.files == 0`, inspect every returned
+finding, and retain the exact exclusion list for ingest. Findings and extension
+groups are bounded; their count and truncation fields say when the detailed
+arrays are samples rather than complete lists.
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{"paths":["/Users/me/Downloads/receipt.pdf"],"dest":"/receipts","exclude":[]}' \
   "$DOCBANK_URL/api/v1/ingest"
 ```
 
-Inspect `added`, `skipped`, and every member of `failed`. Repeating the same
+Inspect `added`, `skipped`, `excluded`, and every member of `failed`. Repeating the same
 ingest after fixing a partial failure is safe; successful content converges to
 `skipped` rather than another copy.
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -37,7 +37,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
-| `POST /ingest` | import server-side paths — see [addendum](#addendum-post-ingest) | Implemented |
+| `POST /ingest` · `POST /ingest/preflight` | import or inventory server-side paths — see [addendum](#addendum-post-ingest-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |
 | `PATCH /nodes/{id}` | move and/or rename | Implemented |
 | `POST /path/move` · `POST /path/trash` | move / trash by virtual path, resolved and mutated in one store transaction | Implemented |
@@ -164,10 +164,20 @@ These are integrity receipts from the authenticated daemon, not
 non-repudiable attestations against a malicious server. Signed receipts or a
 transparency log are outside docbank's current trust model.
 
-## Addendum: `POST /ingest`
+## Addendum: `POST /ingest` and `POST /ingest/preflight`
+
+`POST /ingest/preflight` takes `{paths: [...], exclude: [...]}` and performs a
+metadata-only source inventory. It opens no regular-file content and writes no
+vault metadata or blobs. Its report includes file/directory/logical-byte totals,
+pack-eligible, loose-only, and rejected size classes, exclusion/skip/error
+counts, bounded findings, and extension summaries. The route uses the same
+absolute-path validation, explicit root-directory-symlink behavior, exclusion
+rules, loopback fence, and timeout exemption as the real ingest. Findings are
+observations rather than a snapshot lock: sources can still change before
+ingest, and metadata-only scanning cannot prove later content readability.
 
 `POST /ingest` takes **server-side local paths** — `{paths: [...],
-dest: "/inbox"}` — and returns an `IngestReport` (`added`, `skipped`,
+dest: "/inbox", exclude: [...]}` — and returns an `IngestReport` (`added`, `skipped`, `excluded`,
 per-path `failed` entries), backing `docbank add`. Paths must be
 **absolute**: the long-lived daemon's working directory is meaningless,
 so a relative path is rejected with `422`. The CLI resolves `docbank
@@ -182,6 +192,11 @@ non-loopback client gets `403` (`loopback_only`). There is no remote file-upload
 capability on this route: remote bytes use `POST /uploads`, while remote access
 to the loopback-bound daemon still terminates through the configured SSH/VPN
 tunnel.
+
+Each exclusion is either a bare entry name, matched at any depth, or a relative
+path containing `/`, matched within every supplied source. Matching a directory
+prunes its subtree. The preflight and ingest implementations share this matcher
+so reviewed selection and actual selection cannot drift.
 
 ## Addendum: `POST /uploads`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -21,7 +21,8 @@ daemon status` and `docbank daemon stop` never auto-start. See
 ## docbank add
 
 ```
-docbank add <path>... [--dest <virtual-dir>]
+docbank add <path>... [--dest <virtual-dir>] [--exclude <rule>]...
+docbank add <path>... --preflight [--exclude <rule>]... [--json]
 ```
 
 Imports files or directory trees into the vault. Sources are copied,
@@ -30,6 +31,9 @@ never modified or deleted.
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `--dest` | `/inbox` | Virtual destination directory; created (with parents) if missing |
+| `--exclude` | none | Prune a matching entry name anywhere, or a relative path within each source; repeatable |
+| `--preflight` | false | Inventory source metadata without opening file content or changing the vault |
+| `--json` | false | Emit the preflight report as JSON; requires `--preflight` |
 
 - A directory argument imports recursively: its basename becomes a
   directory under `--dest` and relative structure is preserved.
@@ -44,10 +48,24 @@ never modified or deleted.
   interrupted bulk import can simply be re-run. See
   [Importing Documents](usage/importing.md).
 
+Run `--preflight` before a large import. It reports regular-file and directory
+counts, logical bytes, pack-eligible files, larger loose-only files, files over
+the ingest ceiling, exclusions, skipped non-regular entries, filesystem errors,
+and the largest extension groups. The scan reads filesystem metadata only: it
+does not open cloud placeholders, create the destination, record an ingest, or
+write blobs. `--json` retains a bounded set of detailed findings and file-type
+groups for agents and scripts.
+
+Exclusion rules are deliberately simple and shared by preflight and import. A
+bare entry name such as `.git` or `node_modules` matches at any depth. A path
+containing `/`, such as `project/cache`, matches that relative path and its
+descendants within every supplied source. Rules are not shell globs and must be
+relative; absolute paths and `..` escapes are rejected.
+
 Output is a one-line summary plus one stderr line per failed file:
 
 ```
-added: 12  skipped: 3  failed: 1
+added: 12  skipped: 3  excluded: 2  failed: 1
 failed: /src/broken.pdf: opening /src/broken.pdf: permission denied
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,7 +62,8 @@ containing `/`, such as `project/cache`, matches that relative path and its
 descendants within every supplied source. Rules are not shell globs and must be
 relative; absolute paths and `..` escapes are rejected. Rule form is preserved:
 `cache` is a name at any depth, while `cache/` and `./cache` mean only the
-root-relative `cache` entry.
+root-relative `cache` entry. Each `--exclude` value is literal and commas are
+ordinary filename characters; repeat the flag to supply multiple rules.
 
 Output is a one-line summary plus one stderr line per failed file:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -60,7 +60,9 @@ Exclusion rules are deliberately simple and shared by preflight and import. A
 bare entry name such as `.git` or `node_modules` matches at any depth. A path
 containing `/`, such as `project/cache`, matches that relative path and its
 descendants within every supplied source. Rules are not shell globs and must be
-relative; absolute paths and `..` escapes are rejected.
+relative; absolute paths and `..` escapes are rejected. Rule form is preserved:
+`cache` is a name at any depth, while `cache/` and `./cache` mean only the
+root-relative `cache` entry.
 
 Output is a one-line summary plus one stderr line per failed file:
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -79,6 +79,14 @@ problems converges without discarding prior progress. The destination directory
 is ID-based once resolved so a concurrent move cannot cause later files to
 recreate an old path.
 
+Preflight and import share one exclusion matcher and explicit-root-symlink
+model. Preflight stops at filesystem metadata: it never opens a regular file,
+hydrates cloud content, creates a destination, records an ingest, or writes a
+blob. It therefore predicts selection and size-policy outcomes, not future
+readability. Detailed findings and extension groups are bounded while their
+aggregate counts remain complete, preventing an adversarial tree from creating
+an unbounded API response.
+
 ## Trash, permanent deletion, and GC
 
 Deletion is deliberately three-stage:

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -39,6 +39,36 @@ provenance using the path the user supplied. Symlinks encountered *inside* the
 tree remain skipped and reported, and an explicitly named symlink to a file is
 not imported.
 
+## Preflight a large tree
+
+Inventory a source before Docbank opens any file content or changes the vault:
+
+```bash
+docbank add ~/Dropbox --preflight \
+  --exclude .git \
+  --exclude .Trash \
+  --exclude project/cache
+```
+
+The report separates files currently eligible for packing (through 64 MiB),
+larger files that will remain authoritative loose objects, and files above the
+current format-v1 ingest ceiling. It also reports logical bytes, directory
+count, skipped non-regular entries, filesystem errors, and the largest groups
+by lowercase filename extension. Use `--json` for a structured, bounded report.
+
+Preflight is metadata-only. In particular, it does not open cloud-provider
+placeholder content merely to estimate the import. That avoids an inventory
+silently hydrating an entire cloud tree, but it also means successful preflight
+cannot promise that every file will remain readable when the later import
+opens it. Re-run preflight after changing exclusions, then pass the exact same
+`--exclude` flags to the real `docbank add` command.
+
+A bare exclusion such as `.git` prunes that entry name wherever it occurs. A
+relative path such as `project/cache` prunes that path and its descendants
+within each supplied source. Exclusions do not use glob syntax. A pruned
+directory counts as one excluded entry because Docbank deliberately does not
+walk it to count hidden descendants.
+
 ## Idempotency: safe to re-run
 
 Interrupted a 200,000-file import? Run the same command again. For each

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -69,7 +69,9 @@ within each supplied source. Exclusions do not use glob syntax. A pruned
 directory counts as one excluded entry because Docbank deliberately does not
 walk it to count hidden descendants. A trailing slash or leading `./` keeps a
 single-component rule path-shaped: `cache` matches that name anywhere, whereas
-`cache/` and `./cache` match only the source root's `cache` entry.
+`cache/` and `./cache` match only the source root's `cache` entry. Commas are
+literal filename characters, not rule separators; pass `--exclude` repeatedly
+for multiple rules.
 
 ## Idempotency: safe to re-run
 

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -67,7 +67,9 @@ A bare exclusion such as `.git` prunes that entry name wherever it occurs. A
 relative path such as `project/cache` prunes that path and its descendants
 within each supplied source. Exclusions do not use glob syntax. A pruned
 directory counts as one excluded entry because Docbank deliberately does not
-walk it to count hidden descendants.
+walk it to count hidden descendants. A trailing slash or leading `./` keeps a
+single-component rule path-shaped: `cache` matches that name anywhere, whereas
+`cache/` and `./cache` match only the source root's `cache` entry.
 
 ## Idempotency: safe to re-run
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -16,7 +16,7 @@ const requestTimeout = 60 * time.Second
 // timeout-exempt: long-running maintenance, integrity reads, and bulk ingest.
 func timeoutExempt(path string) bool {
 	switch path {
-	case "/api/v1/ingest", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
+	case "/api/v1/ingest", "/api/v1/ingest/preflight", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
 		"/api/v1/storage/pack", "/api/v1/storage/repack", "/api/v1/uploads",
 		"/api/v1/backup/snapshots", "/api/v1/backup/snapshots/stream",
 		"/api/v1/backup/verify", "/api/v1/backup/verify/stream",
@@ -70,17 +70,21 @@ func authMiddleware(next http.Handler, key string) http.Handler {
 }
 
 // loopbackMiddleware fences endpoints that grant local-filesystem
-// capability (POST /api/v1/ingest) to loopback peers, regardless of bind
+// capability (POST /api/v1/ingest and its preflight) to loopback peers, regardless of bind
 // address or key. See the spec's ingest addendum.
 func loopbackMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/ingest" && !isLoopbackRemote(r.RemoteAddr) {
+		if r.Method == http.MethodPost && isServerPathIngestRoute(r.URL.Path) && !isLoopbackRemote(r.RemoteAddr) {
 			writeError(w, NewError(http.StatusForbidden, "loopback_only",
-				"ingest by server-side path is loopback-only; remote clients use POST /api/v1/uploads"))
+				"server-side path ingest is loopback-only; remote clients use POST /api/v1/uploads"))
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func isServerPathIngestRoute(path string) bool {
+	return path == "/api/v1/ingest" || path == "/api/v1/ingest/preflight"
 }
 
 func isLoopbackRemote(remoteAddr string) bool {

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -91,20 +91,46 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 	})
 
 	type ingestOutput struct{ Body IngestReport }
+	type ingestPreflightOutput struct{ Body IngestPreflightReport }
+	huma.Register(api, huma.Operation{
+		OperationID: "preflightIngest", Method: http.MethodPost, Path: "/api/v1/ingest/preflight",
+		Summary: "Inventory server-side files without opening content or mutating the vault",
+	}, func(ctx context.Context, in *struct {
+		Body struct {
+			Paths   []string `json:"paths" minItems:"1"`
+			Exclude []string `json:"exclude,omitempty"`
+		}
+	}) (*ingestPreflightOutput, error) {
+		if err := validateIngestPaths(in.Body.Paths); err != nil {
+			return nil, err
+		}
+		opts := ingest.Options{Exclude: in.Body.Exclude}
+		if err := ingest.ValidateOptions(opts); err != nil {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+		}
+		report, err := ingest.Preflight(ctx, in.Body.Paths, opts)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return &ingestPreflightOutput{Body: ingestPreflightReport(report)}, nil
+	})
+
 	huma.Register(api, huma.Operation{
 		OperationID: "ingest", Method: http.MethodPost, Path: "/api/v1/ingest",
 		Summary: "Import server-side files or directory trees (loopback callers only)",
 	}, func(ctx context.Context, in *struct {
 		Body struct {
-			Paths []string `json:"paths" minItems:"1"`
-			Dest  string   `json:"dest" default:"/inbox"`
+			Paths   []string `json:"paths" minItems:"1"`
+			Dest    string   `json:"dest" default:"/inbox"`
+			Exclude []string `json:"exclude,omitempty"`
 		}
 	}) (*ingestOutput, error) {
-		for _, p := range in.Body.Paths {
-			if !filepath.IsAbs(p) {
-				return nil, NewError(http.StatusUnprocessableEntity, "validation",
-					fmt.Sprintf("path %q must be absolute: the daemon has no meaningful working directory", p))
-			}
+		if err := validateIngestPaths(in.Body.Paths); err != nil {
+			return nil, err
+		}
+		opts := ingest.Options{Exclude: in.Body.Exclude}
+		if err := ingest.ValidateOptions(opts); err != nil {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 		}
 		// The schema default covers an absent dest, not an explicit ""
 		// (which MkdirAll would treat as the vault root).
@@ -120,11 +146,11 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		err := g.mutate(func() error {
 			return d.Blobs.WithMutation(ctx, func() error {
 				ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
-				rep, err := ing.AddPaths(ctx, in.Body.Paths, dest)
+				rep, err := ing.AddPathsWithOptions(ctx, in.Body.Paths, dest, opts)
 				if err != nil {
 					return FromStoreError(err)
 				}
-				out.Body = IngestReport{Added: rep.Added, Skipped: rep.Skipped}
+				out.Body = IngestReport{Added: rep.Added, Skipped: rep.Skipped, Excluded: rep.Excluded}
 				for _, f := range rep.Failed {
 					out.Body.Failed = append(out.Body.Failed, IngestFailure{Path: f.Path, Error: f.Err.Error()})
 				}
@@ -234,6 +260,45 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		})
 		return out, err
 	})
+}
+
+func validateIngestPaths(paths []string) error {
+	for _, path := range paths {
+		if !filepath.IsAbs(path) {
+			return NewError(http.StatusUnprocessableEntity, "validation",
+				fmt.Sprintf("path %q must be absolute: the daemon has no meaningful working directory", path))
+		}
+	}
+	return nil
+}
+
+func ingestPreflightReport(report ingest.PreflightReport) IngestPreflightReport {
+	out := IngestPreflightReport{
+		Files: report.Files, Directories: report.Directories, LogicalBytes: report.LogicalBytes,
+		PackEligible: ingestSizeClass(report.PackEligible),
+		LooseOnly:    ingestSizeClass(report.LooseOnly),
+		Rejected:     ingestSizeClass(report.Rejected),
+		Excluded:     report.Excluded, Skipped: report.Skipped, Errors: report.Errors,
+		OtherFileTypes:     ingestSizeClass(report.OtherFileTypes),
+		FileTypesTruncated: report.FileTypesTruncated, FindingsTruncated: report.FindingsTruncated,
+		FileTypes: make([]IngestFileType, 0, len(report.FileTypes)),
+		Findings:  make([]IngestPreflightFinding, 0, len(report.Findings)),
+	}
+	for _, fileType := range report.FileTypes {
+		out.FileTypes = append(out.FileTypes, IngestFileType{
+			Extension: fileType.Extension, Files: fileType.Files, Bytes: fileType.Bytes,
+		})
+	}
+	for _, finding := range report.Findings {
+		out.Findings = append(out.Findings, IngestPreflightFinding{
+			Path: finding.Path, Kind: finding.Kind, Detail: finding.Detail,
+		})
+	}
+	return out
+}
+
+func ingestSizeClass(class ingest.SizeClass) IngestSizeClass {
+	return IngestSizeClass{Files: class.Files, Bytes: class.Bytes}
 }
 
 func storagePackReport(stats packstore.PackStats) StoragePackReport {

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -64,6 +64,43 @@ func TestIngestEndpoint(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode, body)
 }
 
+func TestIngestPreflightIsReadOnlyAndSharesExclusions(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "keep.jsonl"), []byte("{\"ok\":true}\n"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, ".git"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(src, ".git", "config"), []byte("ignored"), 0o600))
+
+	request := map[string]any{"paths": []string{src}, "exclude": []string{".git"}}
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/ingest/preflight", nil, request)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var report api.IngestPreflightReport
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	assert.Equal(t, int64(1), report.Files)
+	assert.Equal(t, int64(1), report.Excluded)
+	assert.Equal(t, int64(len("{\"ok\":true}\n")), report.LogicalBytes)
+	assert.Equal(t, int64(1), report.PackEligible.Files)
+	assert.Zero(t, report.Errors)
+	require.Len(t, report.FileTypes, 1)
+	assert.Equal(t, ".jsonl", report.FileTypes[0].Extension)
+
+	resp, body = get(t, ts, "/api/v1/path?path=/inbox", nil)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, body)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/ingest", nil,
+		map[string]any{"paths": []string{src}, "dest": "/inbox", "exclude": []string{".git"}})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var ingested api.IngestReport
+	require.NoError(t, json.Unmarshal([]byte(body), &ingested))
+	assert.Equal(t, 1, ingested.Added)
+	assert.Equal(t, 1, ingested.Excluded)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/ingest/preflight", nil,
+		map[string]any{"paths": []string{src}, "exclude": []string{"../outside"}})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"validation"`)
+}
+
 func TestIngestRejectsNonLoopback(t *testing.T) {
 	// httptest.NewRequest-style direct handler invocation with a non-loopback
 	// RemoteAddr proves the middleware fence without real remote networking.
@@ -82,14 +119,18 @@ func TestIngestRejectsNonLoopback(t *testing.T) {
 	cfg := config.Default()
 	cfg.Server.APIKey = "test-key"
 	srv := api.NewServer(api.Deps{Store: s, Blobs: blobs, VaultRoot: dir, Cfg: cfg})
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest", strings.NewReader(`{"paths":["/x"],"dest":"/inbox"}`))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Api-Key", "test-key")
-	req.RemoteAddr = "192.0.2.1:4444"
-	rec := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusForbidden, rec.Code)
-	assert.Contains(t, rec.Body.String(), `"code":"loopback_only"`)
+	for _, path := range []string{"/api/v1/ingest", "/api/v1/ingest/preflight"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"paths":["/x"],"dest":"/inbox"}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Api-Key", "test-key")
+			req.RemoteAddr = "192.0.2.1:4444"
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusForbidden, rec.Code)
+			assert.Contains(t, rec.Body.String(), `"code":"loopback_only"`)
+		})
+	}
 }
 
 func TestTrashListAndEmpty(t *testing.T) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -73,9 +73,53 @@ type IngestFailure struct {
 
 // IngestReport summarizes an ingest run.
 type IngestReport struct {
-	Added   int             `json:"added"`
-	Skipped int             `json:"skipped"`
-	Failed  []IngestFailure `json:"failed,omitempty"`
+	Added    int             `json:"added"`
+	Skipped  int             `json:"skipped"`
+	Excluded int             `json:"excluded"`
+	Failed   []IngestFailure `json:"failed,omitempty"`
+}
+
+// IngestSizeClass summarizes files in one storage-policy outcome.
+type IngestSizeClass struct {
+	Files int64 `json:"files"`
+	Bytes int64 `json:"bytes"`
+}
+
+// IngestFileType summarizes regular files by lowercase extension. Extension
+// is empty for names without an extension.
+type IngestFileType struct {
+	Extension string `json:"extension"`
+	Files     int64  `json:"files"`
+	Bytes     int64  `json:"bytes"`
+}
+
+// IngestPreflightFinding is one bounded sample from a source scan.
+type IngestPreflightFinding struct {
+	Path   string `json:"path"`
+	Kind   string `json:"kind" enum:"excluded,skipped,error"`
+	Detail string `json:"detail"`
+}
+
+// IngestPreflightReport inventories a prospective server-side import without
+// opening file content or mutating the vault.
+type IngestPreflightReport struct {
+	Files        int64 `json:"files"`
+	Directories  int64 `json:"directories"`
+	LogicalBytes int64 `json:"logical_bytes"`
+
+	PackEligible IngestSizeClass `json:"pack_eligible"`
+	LooseOnly    IngestSizeClass `json:"loose_only"`
+	Rejected     IngestSizeClass `json:"rejected"`
+
+	Excluded int64 `json:"excluded"`
+	Skipped  int64 `json:"skipped"`
+	Errors   int64 `json:"errors"`
+
+	FileTypes          []IngestFileType         `json:"file_types"`
+	OtherFileTypes     IngestSizeClass          `json:"other_file_types"`
+	FileTypesTruncated bool                     `json:"file_types_truncated"`
+	Findings           []IngestPreflightFinding `json:"findings"`
+	FindingsTruncated  bool                     `json:"findings_truncated"`
 }
 
 // TrashEmptyReport summarizes a trash-empty dry run or execution.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -231,9 +231,33 @@ func (c *Client) Mkdir(ctx context.Context, parentID int64, name string) (api.No
 }
 
 func (c *Client) Ingest(ctx context.Context, paths []string, dest string) (api.IngestReport, error) {
+	return c.IngestWithOptions(ctx, paths, dest, nil)
+}
+
+// IngestWithOptions imports server-side paths with the same exclusion rules
+// accepted by PreflightIngest.
+func (c *Client) IngestWithOptions(
+	ctx context.Context,
+	paths []string,
+	dest string,
+	exclude []string,
+) (api.IngestReport, error) {
 	var rep api.IngestReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/ingest", nil,
-		map[string]any{"paths": paths, "dest": dest}, &rep)
+		map[string]any{"paths": paths, "dest": dest, "exclude": exclude}, &rep)
+	return rep, err
+}
+
+// PreflightIngest inventories server-side paths without opening file content
+// or mutating the vault.
+func (c *Client) PreflightIngest(
+	ctx context.Context,
+	paths []string,
+	exclude []string,
+) (api.IngestPreflightReport, error) {
+	var rep api.IngestPreflightReport
+	err := c.do(ctx, http.MethodPost, "/api/v1/ingest/preflight", nil,
+		map[string]any{"paths": paths, "exclude": exclude}, &rep)
 	return rep, err
 }
 

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "7"
+	daemonProtocolVersion = "8"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -39,9 +39,10 @@ type FileError struct {
 
 // Report summarizes an ingest run.
 type Report struct {
-	Added   int
-	Skipped int
-	Failed  []FileError
+	Added    int
+	Skipped  int
+	Excluded int
+	Failed   []FileError
 }
 
 // UploadResult is the server's independently computed receipt for one remote
@@ -124,7 +125,22 @@ func (p *PreparedUpload) Commit(ctx context.Context) (UploadResult, error) {
 // AddPaths ingests files and directory trees under the virtual destPath.
 // Per-file failures are collected in the report; the run continues.
 func (ing *Ingester) AddPaths(ctx context.Context, sources []string, destPath string) (Report, error) {
+	return ing.AddPathsWithOptions(ctx, sources, destPath, Options{})
+}
+
+// AddPathsWithOptions ingests the selected parts of files and directory trees
+// under the virtual destPath. Exclusions have the same semantics as Preflight.
+func (ing *Ingester) AddPathsWithOptions(
+	ctx context.Context,
+	sources []string,
+	destPath string,
+	opts Options,
+) (Report, error) {
 	var rep Report
+	excludes, err := compileExclusions(opts.Exclude)
+	if err != nil {
+		return rep, err
+	}
 	dest, err := ing.Store.MkdirAll(ctx, destPath)
 	if err != nil {
 		return rep, fmt.Errorf("resolving destination %q: %w", destPath, err)
@@ -142,11 +158,15 @@ func (ing *Ingester) AddPaths(ctx context.Context, sources []string, destPath st
 			rep.Failed = append(rep.Failed, FileError{Path: src, Err: err})
 			continue
 		}
+		if excludes.match(src, src) {
+			rep.Excluded++
+			continue
+		}
 		switch {
 		case info.Mode().IsRegular():
 			ing.addOne(ctx, &rep, ingestID, dest.ID, src, src)
 		case info.IsDir():
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, src); err != nil {
+			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, excludes); err != nil {
 				return rep, err
 			}
 		case info.Mode()&fs.ModeSymlink != 0:
@@ -167,7 +187,7 @@ func (ing *Ingester) AddPaths(ctx context.Context, sources []string, destPath st
 					Err: errors.New("explicit symlink source does not resolve to a directory")})
 				continue
 			}
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, walkRoot); err != nil {
+			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, walkRoot, excludes); err != nil {
 				return rep, err
 			}
 		default:
@@ -194,6 +214,7 @@ func (ing *Ingester) addTree(
 	rep *Report,
 	ingestID, destDirID int64,
 	sourceRoot, walkRoot string,
+	excludes exclusions,
 ) error {
 	// Absolutize first. WalkDir hands back the root spelled exactly as given
 	// while children come from filepath.Join, which cleans — dirIDs keys must
@@ -223,6 +244,13 @@ func (ing *Ingester) addTree(
 		if err != nil {
 			rep.Failed = append(rep.Failed, FileError{Path: sourcePath, Err: err})
 			return nil //nolint:nilerr // intentional: record error and continue walk
+		}
+		if excludes.match(sourceRoot, sourcePath) {
+			rep.Excluded++
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
 		}
 		switch {
 		case d.IsDir():

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -150,7 +150,8 @@ func (ing *Ingester) AddPathsWithOptions(
 		return rep, err
 	}
 
-	for _, src := range sources {
+	for _, rawSource := range sources {
+		src := filepath.Clean(rawSource)
 		info, err := os.Lstat(src)
 		if err != nil {
 			// Per-file failure like any other: aborting here would leave

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -239,12 +239,94 @@ func TestAddTreeStaleDestinationIsNotResurrected(t *testing.T) {
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
 	var rep Report
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src))
+	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, exclusions{}))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 
 	_, err = ing.Store.NodeByPath(ctx, "/inbox")
 	assert.ErrorIs(t, err, store.ErrNotFound, "trashed destination must stay trashed")
+}
+
+func TestPreflightInventoriesWithoutMutatingVault(t *testing.T) {
+	ing := newTestIngester(t)
+	src := writeTree(t, map[string]string{
+		"keep/report.PDF":        "report",
+		"keep/readme":            "read me",
+		".git/config":            "secret-ish metadata",
+		"project/cache/data.bin": "cache",
+		"project/data.jsonl":     "{\"ok\":true}\n",
+	})
+
+	report, err := Preflight(t.Context(), []string{src}, Options{
+		Exclude: []string{".git", "project/cache"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), report.Files)
+	assert.Equal(t, int64(len("report")+len("read me")+len("{\"ok\":true}\n")), report.LogicalBytes)
+	assert.Equal(t, int64(3), report.PackEligible.Files)
+	assert.Zero(t, report.LooseOnly.Files)
+	assert.Zero(t, report.Rejected.Files)
+	assert.Equal(t, int64(2), report.Excluded)
+	assert.Zero(t, report.Errors)
+	require.Len(t, report.FileTypes, 3)
+	assert.Equal(t, ".jsonl", report.FileTypes[0].Extension)
+	assert.Empty(t, report.FileTypes[1].Extension)
+	assert.Equal(t, ".pdf", report.FileTypes[2].Extension)
+
+	_, err = ing.Store.NodeByPath(t.Context(), "/inbox")
+	require.ErrorIs(t, err, store.ErrNotFound, "preflight must not create a destination or ingest rows")
+}
+
+func TestPreflightSizePolicyBoundaries(t *testing.T) {
+	var report PreflightReport
+	types := make(map[string]FileType)
+	report.addFile("packed.bin", blob.MaxPackedBlobBytes, types)
+	report.addFile("loose.bin", blob.MaxPackedBlobBytes+1, types)
+	report.addFile("limit.bin", blob.MaxIngestBytes, types)
+	report.addFile("rejected.bin", blob.MaxIngestBytes+1, types)
+
+	assert.Equal(t, int64(1), report.PackEligible.Files)
+	assert.Equal(t, int64(2), report.LooseOnly.Files)
+	assert.Equal(t, int64(1), report.Rejected.Files)
+}
+
+func TestAddPathsHonorsPreflightExclusions(t *testing.T) {
+	ing := newTestIngester(t)
+	src := writeTree(t, map[string]string{
+		"keep.txt":               "keep",
+		".git/config":            "exclude",
+		"project/cache/data.bin": "exclude",
+		"project/session.jsonl":  "keep",
+	})
+
+	report, err := ing.AddPathsWithOptions(t.Context(), []string{src}, "/inbox", Options{
+		Exclude: []string{".git", "project/cache"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, report.Added)
+	assert.Equal(t, 2, report.Excluded)
+	assert.Empty(t, report.Failed)
+
+	top := "/inbox/" + filepath.Base(src)
+	_, err = ing.Store.NodeByPath(t.Context(), top+"/keep.txt")
+	require.NoError(t, err)
+	_, err = ing.Store.NodeByPath(t.Context(), top+"/project/session.jsonl")
+	require.NoError(t, err)
+	_, err = ing.Store.NodeByPath(t.Context(), top+"/.git")
+	require.ErrorIs(t, err, store.ErrNotFound)
+	_, err = ing.Store.NodeByPath(t.Context(), top+"/project/cache")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestPreflightRejectsUnsafeExclusionRules(t *testing.T) {
+	for _, rule := range []string{
+		"", ".", "..", "../outside", "inside/../other", string(filepath.Separator) + "absolute",
+	} {
+		t.Run(rule, func(t *testing.T) {
+			_, err := Preflight(t.Context(), nil, Options{Exclude: []string{rule}})
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestAddMissingSourceIsReportedNotFatal(t *testing.T) {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -329,6 +329,25 @@ func TestPreflightRejectsUnsafeExclusionRules(t *testing.T) {
 	}
 }
 
+func TestPreflightPreservesPathFormExclusions(t *testing.T) {
+	src := writeTree(t, map[string]string{
+		"cache/root.bin":           "root cache",
+		"project/cache/nested.bin": "nested cache",
+		"keep.bin":                 "keep",
+	})
+	for _, rule := range []string{"cache/", "./cache"} {
+		t.Run(rule, func(t *testing.T) {
+			report, err := Preflight(t.Context(), []string{src}, Options{Exclude: []string{rule}})
+			require.NoError(t, err)
+			assert.Equal(t, int64(2), report.Files,
+				"path-form rule must not become a basename match at every depth")
+			assert.Equal(t, int64(1), report.Excluded)
+			require.Len(t, report.Findings, 1)
+			assert.Equal(t, filepath.Join(src, "cache"), report.Findings[0].Path)
+		})
+	}
+}
+
 func TestAddMissingSourceIsReportedNotFatal(t *testing.T) {
 	ing := newTestIngester(t)
 	ctx := t.Context()

--- a/internal/ingest/ingest_unix_test.go
+++ b/internal/ingest/ingest_unix_test.go
@@ -66,6 +66,47 @@ func TestAddExplicitDirectorySymlinkPreservesSourceSpelling(t *testing.T) {
 	assert.NotZero(t, nestedInfo.Mode()&os.ModeSymlink)
 }
 
+func TestExplicitDirectorySymlinkWithTrailingSeparator(t *testing.T) {
+	ing := newTestIngester(t)
+	target := writeTree(t, map[string]string{"notes.txt": "hello"})
+	alias := filepath.Join(t.TempDir(), "Dropbox")
+	require.NoError(t, os.Symlink(target, alias))
+	spelled := alias + string(filepath.Separator)
+
+	report, err := Preflight(t.Context(), []string{spelled}, Options{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), report.Files)
+	assert.Equal(t, int64(1), report.Directories)
+	assert.Zero(t, report.Skipped)
+	assert.Zero(t, report.Errors)
+
+	rep, err := ing.AddPaths(t.Context(), []string{spelled}, "/archive")
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Added)
+	assert.Empty(t, rep.Failed)
+	_, err = ing.Store.NodeByPath(t.Context(), "/archive/Dropbox/notes.txt")
+	require.NoError(t, err)
+}
+
+func TestExcludedBrokenRootSymlinkDoesNotResolve(t *testing.T) {
+	ing := newTestIngester(t)
+	alias := filepath.Join(t.TempDir(), "excluded")
+	require.NoError(t, os.Symlink(filepath.Join(t.TempDir(), "missing"), alias))
+	opts := Options{Exclude: []string{"excluded"}}
+
+	report, err := Preflight(t.Context(), []string{alias}, opts)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), report.Excluded)
+	assert.Zero(t, report.Errors)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, "excluded", report.Findings[0].Kind)
+
+	rep, err := ing.AddPathsWithOptions(t.Context(), []string{alias}, "/archive", opts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Excluded)
+	assert.Empty(t, rep.Failed)
+}
+
 func TestPreflightExplicitDirectorySymlinkUsesAliasAndSkipsNestedLinks(t *testing.T) {
 	target := writeTree(t, map[string]string{"nested/session.jsonl": "{\"ok\":true}\n"})
 	alias := filepath.Join(t.TempDir(), "Agent Sessions")

--- a/internal/ingest/ingest_unix_test.go
+++ b/internal/ingest/ingest_unix_test.go
@@ -66,6 +66,23 @@ func TestAddExplicitDirectorySymlinkPreservesSourceSpelling(t *testing.T) {
 	assert.NotZero(t, nestedInfo.Mode()&os.ModeSymlink)
 }
 
+func TestPreflightExplicitDirectorySymlinkUsesAliasAndSkipsNestedLinks(t *testing.T) {
+	target := writeTree(t, map[string]string{"nested/session.jsonl": "{\"ok\":true}\n"})
+	alias := filepath.Join(t.TempDir(), "Agent Sessions")
+	require.NoError(t, os.Symlink(target, alias))
+	nestedLink := filepath.Join(target, "nested", "latest.jsonl")
+	require.NoError(t, os.Symlink(filepath.Join(target, "nested", "session.jsonl"), nestedLink))
+
+	report, err := Preflight(t.Context(), []string{alias}, Options{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), report.Files)
+	assert.Equal(t, int64(2), report.Directories)
+	assert.Equal(t, int64(1), report.Skipped)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, filepath.Join(alias, "nested", "latest.jsonl"), report.Findings[0].Path)
+	assert.Equal(t, "skipped", report.Findings[0].Kind)
+}
+
 func provenancePath(t *testing.T, ing *Ingester, nodeID int64) string {
 	t.Helper()
 	var metadata bytes.Buffer

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -93,12 +93,13 @@ func compileExclusions(values []string) (exclusions, error) {
 		if slices.Contains(strings.Split(converted, string(filepath.Separator)), "..") {
 			return exclusions{}, fmt.Errorf("exclude rule %q must not contain parent traversal", raw)
 		}
+		pathForm := strings.ContainsRune(converted, filepath.Separator)
 		clean := filepath.Clean(converted)
 		if clean == "." {
 			return exclusions{}, fmt.Errorf("exclude rule %q must name an entry within each source", raw)
 		}
 		rule := exclusionRule{}
-		if strings.ContainsRune(clean, filepath.Separator) {
+		if pathForm {
 			rule.path = clean
 		} else {
 			rule.name = clean

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -89,10 +90,8 @@ func compileExclusions(values []string) (exclusions, error) {
 		if filepath.IsAbs(converted) || filepath.VolumeName(converted) != "" {
 			return exclusions{}, fmt.Errorf("exclude rule %q must be relative", raw)
 		}
-		for _, component := range strings.Split(converted, string(filepath.Separator)) {
-			if component == ".." {
-				return exclusions{}, fmt.Errorf("exclude rule %q must not contain parent traversal", raw)
-			}
+		if slices.Contains(strings.Split(converted, string(filepath.Separator)), "..") {
+			return exclusions{}, fmt.Errorf("exclude rule %q must not contain parent traversal", raw)
 		}
 		clean := filepath.Clean(converted)
 		if clean == "." {

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -87,7 +87,7 @@ func compileExclusions(values []string) (exclusions, error) {
 			return exclusions{}, errors.New("exclude rule must not be empty")
 		}
 		converted := filepath.FromSlash(raw)
-		if filepath.IsAbs(converted) || filepath.VolumeName(converted) != "" {
+		if !filepath.IsLocal(converted) {
 			return exclusions{}, fmt.Errorf("exclude rule %q must be relative", raw)
 		}
 		if slices.Contains(strings.Split(converted, string(filepath.Separator)), "..") {

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -143,13 +143,18 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 		return report, err
 	}
 	types := make(map[string]FileType)
-	for _, source := range sources {
+	for _, rawSource := range sources {
+		source := filepath.Clean(rawSource)
 		if err := ctx.Err(); err != nil {
 			return report, err
 		}
 		info, err := os.Lstat(source)
 		if err != nil {
 			report.addFinding(source, "error", err.Error())
+			continue
+		}
+		if excludes.match(source, source) {
+			report.addFinding(source, "excluded", "matched an exclusion rule")
 			continue
 		}
 		walkRoot := source
@@ -170,10 +175,6 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 			}
 		}
 		if info.Mode().IsRegular() {
-			if excludes.match(source, source) {
-				report.addFinding(source, "excluded", "matched an exclusion rule")
-				continue
-			}
 			report.addFile(source, info.Size(), types)
 			continue
 		}

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -1,0 +1,304 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"go.kenn.io/docbank/internal/blob"
+)
+
+const (
+	maxPreflightFindings  = 100
+	maxPreflightFileTypes = 50
+)
+
+// Options controls source selection for both preflight and the real import.
+// A rule without a slash matches that entry name anywhere. A relative path
+// rule matches that entry and its descendants within each supplied source.
+type Options struct {
+	Exclude []string
+}
+
+// SizeClass summarizes one physical-policy outcome.
+type SizeClass struct {
+	Files int64
+	Bytes int64
+}
+
+// FileType summarizes regular files by lowercase extension. Extension is
+// empty for names without an extension.
+type FileType struct {
+	Extension string
+	Files     int64
+	Bytes     int64
+}
+
+// PreflightFinding is a bounded sample of an exclusion, skipped non-regular
+// entry, or filesystem error. Counts in PreflightReport remain authoritative
+// when more than maxPreflightFindings findings exist.
+type PreflightFinding struct {
+	Path   string
+	Kind   string
+	Detail string
+}
+
+// PreflightReport is a metadata-only inventory. It never opens regular-file
+// content and never touches the vault store.
+type PreflightReport struct {
+	Files        int64
+	Directories  int64
+	LogicalBytes int64
+
+	PackEligible SizeClass
+	LooseOnly    SizeClass
+	Rejected     SizeClass
+
+	Excluded int64
+	Skipped  int64
+	Errors   int64
+
+	FileTypes          []FileType
+	OtherFileTypes     SizeClass
+	FileTypesTruncated bool
+	Findings           []PreflightFinding
+	FindingsTruncated  bool
+}
+
+type exclusionRule struct {
+	name string
+	path string
+}
+
+type exclusions struct {
+	rules []exclusionRule
+}
+
+func compileExclusions(values []string) (exclusions, error) {
+	result := exclusions{rules: make([]exclusionRule, 0, len(values))}
+	for _, raw := range values {
+		if raw == "" {
+			return exclusions{}, errors.New("exclude rule must not be empty")
+		}
+		converted := filepath.FromSlash(raw)
+		if filepath.IsAbs(converted) || filepath.VolumeName(converted) != "" {
+			return exclusions{}, fmt.Errorf("exclude rule %q must be relative", raw)
+		}
+		for _, component := range strings.Split(converted, string(filepath.Separator)) {
+			if component == ".." {
+				return exclusions{}, fmt.Errorf("exclude rule %q must not contain parent traversal", raw)
+			}
+		}
+		clean := filepath.Clean(converted)
+		if clean == "." {
+			return exclusions{}, fmt.Errorf("exclude rule %q must name an entry within each source", raw)
+		}
+		rule := exclusionRule{}
+		if strings.ContainsRune(clean, filepath.Separator) {
+			rule.path = clean
+		} else {
+			rule.name = clean
+		}
+		result.rules = append(result.rules, rule)
+	}
+	return result, nil
+}
+
+func (e exclusions) match(sourceRoot, sourcePath string) bool {
+	rel, err := filepath.Rel(sourceRoot, sourcePath)
+	if err != nil {
+		return false
+	}
+	name := filepath.Base(sourcePath)
+	for _, rule := range e.rules {
+		if rule.name != "" && name == rule.name {
+			return true
+		}
+		if rule.path != "" && (rel == rule.path || strings.HasPrefix(rel, rule.path+string(filepath.Separator))) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateOptions checks source-selection rules without touching the
+// filesystem. API handlers use it to return a validation error before work.
+func ValidateOptions(opts Options) error {
+	_, err := compileExclusions(opts.Exclude)
+	return err
+}
+
+// Preflight inventories sources using the same root-symlink and exclusion
+// semantics as AddPathsWithOptions. It uses directory metadata only: cloud
+// placeholders are not opened or hydrated merely to estimate an import.
+func Preflight(ctx context.Context, sources []string, opts Options) (PreflightReport, error) {
+	var report PreflightReport
+	excludes, err := compileExclusions(opts.Exclude)
+	if err != nil {
+		return report, err
+	}
+	types := make(map[string]FileType)
+	for _, source := range sources {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+		info, err := os.Lstat(source)
+		if err != nil {
+			report.addFinding(source, "error", err.Error())
+			continue
+		}
+		walkRoot := source
+		if info.Mode()&fs.ModeSymlink != 0 {
+			walkRoot, err = filepath.EvalSymlinks(source)
+			if err != nil {
+				report.addFinding(source, "error", "resolving explicitly named directory symlink: "+err.Error())
+				continue
+			}
+			info, err = os.Stat(walkRoot)
+			if err != nil {
+				report.addFinding(source, "error", "checking explicitly named directory symlink: "+err.Error())
+				continue
+			}
+			if !info.IsDir() {
+				report.addFinding(source, "skipped", "explicit symlink source does not resolve to a directory")
+				continue
+			}
+		}
+		if info.Mode().IsRegular() {
+			if excludes.match(source, source) {
+				report.addFinding(source, "excluded", "matched an exclusion rule")
+				continue
+			}
+			report.addFile(source, info.Size(), types)
+			continue
+		}
+		if !info.IsDir() {
+			report.addFinding(source, "skipped", "not a regular file or directory")
+			continue
+		}
+		if err := preflightTree(ctx, &report, types, excludes, source, walkRoot); err != nil {
+			return report, err
+		}
+	}
+	report.FileTypes, report.OtherFileTypes, report.FileTypesTruncated = sortedFileTypes(types)
+	return report, nil
+}
+
+func preflightTree(
+	ctx context.Context,
+	report *PreflightReport,
+	types map[string]FileType,
+	excludes exclusions,
+	sourceRoot, walkRoot string,
+) error {
+	sourceRoot, err := filepath.Abs(sourceRoot)
+	if err != nil {
+		return fmt.Errorf("resolving source %s: %w", sourceRoot, err)
+	}
+	walkRoot, err = filepath.Abs(walkRoot)
+	if err != nil {
+		return fmt.Errorf("resolving traversal root %s: %w", walkRoot, err)
+	}
+	if filepath.Base(sourceRoot) == string(filepath.Separator) || filepath.Base(walkRoot) == string(filepath.Separator) {
+		return fmt.Errorf("cannot scan filesystem root %q", sourceRoot)
+	}
+	return filepath.WalkDir(walkRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		sourcePath := sourceTreePath(sourceRoot, walkRoot, path)
+		if walkErr != nil {
+			report.addFinding(sourcePath, "error", walkErr.Error())
+			return nil
+		}
+		if excludes.match(sourceRoot, sourcePath) {
+			report.addFinding(sourcePath, "excluded", "matched an exclusion rule")
+			if entry.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		switch {
+		case entry.IsDir():
+			report.Directories++
+		case entry.Type().IsRegular():
+			info, err := entry.Info()
+			if err != nil {
+				report.addFinding(sourcePath, "error", err.Error())
+				return nil
+			}
+			report.addFile(sourcePath, info.Size(), types)
+		default:
+			report.addFinding(sourcePath, "skipped", "not a regular file (symlinks are skipped)")
+		}
+		return nil
+	})
+}
+
+func (r *PreflightReport) addFile(path string, size int64, types map[string]FileType) {
+	r.Files++
+	r.LogicalBytes += size
+	switch {
+	case size <= blob.MaxPackedBlobBytes:
+		r.PackEligible.Files++
+		r.PackEligible.Bytes += size
+	case size <= blob.MaxIngestBytes:
+		r.LooseOnly.Files++
+		r.LooseOnly.Bytes += size
+	default:
+		r.Rejected.Files++
+		r.Rejected.Bytes += size
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	item := types[ext]
+	item.Extension = ext
+	item.Files++
+	item.Bytes += size
+	types[ext] = item
+}
+
+func (r *PreflightReport) addFinding(path, kind, detail string) {
+	switch kind {
+	case "excluded":
+		r.Excluded++
+	case "skipped":
+		r.Skipped++
+	case "error":
+		r.Errors++
+	}
+	if len(r.Findings) < maxPreflightFindings {
+		r.Findings = append(r.Findings, PreflightFinding{Path: path, Kind: kind, Detail: detail})
+	} else {
+		r.FindingsTruncated = true
+	}
+}
+
+func sortedFileTypes(types map[string]FileType) ([]FileType, SizeClass, bool) {
+	result := make([]FileType, 0, len(types))
+	for _, item := range types {
+		result = append(result, item)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Bytes != result[j].Bytes {
+			return result[i].Bytes > result[j].Bytes
+		}
+		if result[i].Files != result[j].Files {
+			return result[i].Files > result[j].Files
+		}
+		return result[i].Extension < result[j].Extension
+	})
+	if len(result) <= maxPreflightFileTypes {
+		return result, SizeClass{}, false
+	}
+	var other SizeClass
+	for _, item := range result[maxPreflightFileTypes:] {
+		other.Files += item.Files
+		other.Bytes += item.Bytes
+	}
+	return result[:maxPreflightFileTypes], other, true
+}


### PR DESCRIPTION
Large cloud-backed and archival trees need a trustworthy inventory before Docbank creates a destination or begins copying bytes. Until now, an operator could only discover unexpected material, filesystem errors, and storage-policy limits during the real import.

This adds a daemon-owned metadata-only preflight and makes its deterministic exclusion rules part of the real ingest contract. A bare name prunes that name at any depth; a relative path prunes that subtree within each supplied source. Sharing the matcher matters more than offering a generic dry run: the selection a person or agent reviews is the selection Docbank later imports.

The preview deliberately never opens regular-file content, so inspecting a cloud tree does not cause Docbank to hydrate placeholders. That also defines its limit: it proves selection and size-policy outcomes, not future readability if the source changes. Complete aggregate counts are paired with bounded findings and extension groups so large or adversarial trees cannot create unbounded API responses.

A real metadata-only pass over ~/Dropbox inventoried 2,575 files, 490 directories, and 4,761,047,736 logical bytes with zero errors or rejected files. It classified 2,567 files as pack-eligible and eight as loose-only without writing inside Dropbox.

This PR is stacked on #38 because preflight must share its explicit cloud-storage root-symlink semantics; after #38 lands, this branch can be rebased onto main.