### PR TITLE
Make private-data isolation an agent invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,22 @@ Instructions for autonomous coding agents working in this repository.
   daemon, lock, backup, and restore suite on amd64 and arm64; do not replace
   real platform behavior with compile-only stubs.
 
+## Private Data Boundary
+
+- Never put private developer information in tracked files. Tests, fixtures,
+  golden files, examples, and documentation must use synthetic data—not files,
+  filenames, directory structure, document contents, credentials, session
+  transcripts, hashes, or metadata copied from a developer's home directory or
+  personal corpus.
+- Access a real personal corpus only with explicit authorization for that
+  validation. Keep the source read-only, work in an owner-private isolated
+  directory outside the repository, and emit only aggregate evidence unless
+  the user explicitly requests otherwise.
+- Before handing off a real-corpus validation, stop its processes and remove
+  every temporary vault, backup, restore, binary, report, mismatch list, log,
+  and cache created for the run—even when the validation fails. Confirm the
+  cleanup rather than assuming a deferred cleanup ran.
+
 ## Git Rules
 
 1. Commit every turn that changes tracked files; never amend.


### PR DESCRIPTION
Real-corpus lifecycle testing is essential for Docbank, but it creates copies of exactly the information the project exists to protect. A successful validation is not complete if personal filenames, document metadata, hashes, logs, temporary vaults, or backup repositories survive in tracked artifacts or forgotten local state.

This makes the privacy boundary part of the autonomous-agent contract. Tests and documentation must use synthetic material. Access to a personal corpus requires explicit authorization, a read-only source, owner-private isolation outside the repository, aggregate-only evidence by default, and confirmed cleanup of every process and artifact even when the run fails.

The rule is motivated by the completed Dropbox lifecycle rehearsal: its temporary source vault, backup repository, restored vault, binary, reports, and both daemons were removed and independently confirmed absent before this PR was created.