### PR TITLE
Stream ingest progress to a terminal report

### DIFF
--- a/cmd/docbank/add.go
+++ b/cmd/docbank/add.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -17,6 +17,7 @@ var (
 	addExclude   []string
 	addPreflight bool
 	addJSON      bool
+	addProgress  string
 )
 
 var addCmd = &cobra.Command{
@@ -24,9 +25,6 @@ var addCmd = &cobra.Command{
 	Short: "Import files or directory trees into the vault",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if addJSON && !addPreflight {
-			return errors.New("--json requires --preflight")
-		}
 		abs := make([]string, len(args))
 		for i, a := range args {
 			p, err := filepath.Abs(a)
@@ -59,14 +57,33 @@ var addCmd = &cobra.Command{
 			}
 			return nil
 		}
-		rep, err := c.IngestWithOptions(cmd.Context(), abs, addDest, addExclude)
+		var rep api.IngestReport
+		if addJSON {
+			rep, err = c.IngestWithOptions(cmd.Context(), abs, addDest, addExclude)
+		} else {
+			mode, modeErr := progressModeFromFlag("add", addProgress)
+			if modeErr != nil {
+				return modeErr
+			}
+			renderer := newIngestProgressRenderer(cmd.ErrOrStderr(), mode)
+			defer renderer.finish()
+			rep, err = c.IngestStream(cmd.Context(), abs, addDest, addExclude, renderer.handle)
+		}
 		if err != nil {
 			return err
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "added: %d  skipped: %d  excluded: %d  failed: %d\n",
-			rep.Added, rep.Skipped, rep.Excluded, len(rep.Failed))
-		for _, f := range rep.Failed {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "failed: %s: %s\n", f.Path, f.Error)
+		if addJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(rep); err != nil {
+				return fmt.Errorf("encoding ingest report: %w", err)
+			}
+		} else {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "added: %d  skipped: %d  excluded: %d  failed: %d\n",
+				rep.Added, rep.Skipped, rep.Excluded, len(rep.Failed))
+			for _, f := range rep.Failed {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "failed: %s: %s\n", f.Path, f.Error)
+			}
 		}
 		if len(rep.Failed) > 0 {
 			return fmt.Errorf("%d file(s) failed to import", len(rep.Failed))
@@ -81,8 +98,30 @@ func init() {
 		"exclude an entry name anywhere or a relative path within each source (repeatable)")
 	addCmd.Flags().BoolVar(&addPreflight, "preflight", false,
 		"inventory sources without opening content or changing the vault")
-	addCmd.Flags().BoolVar(&addJSON, "json", false, "machine-readable preflight report")
+	addCmd.Flags().BoolVar(&addJSON, "json", false,
+		"machine-readable terminal report (progress suppressed)")
+	addCmd.Flags().StringVar(&addProgress, "progress", "auto",
+		"progress output mode: auto, bar, or plain (suppressed by --json)")
 	rootCmd.AddCommand(addCmd)
+}
+
+type ingestProgressRenderer struct {
+	base *backupProgressRenderer
+}
+
+func newIngestProgressRenderer(out io.Writer, mode backupProgressMode) *ingestProgressRenderer {
+	return &ingestProgressRenderer{base: newBackupProgressRenderer(out, mode)}
+}
+
+func (r *ingestProgressRenderer) handle(event api.IngestProgress) {
+	r.base.handle(api.BackupProgress{
+		Stage: event.Stage, Done: event.Done, Total: event.Total,
+		BytesDone: event.BytesDone, BytesTotal: event.BytesTotal, Final: event.Final,
+	})
+}
+
+func (r *ingestProgressRenderer) finish() {
+	r.base.finish()
 }
 
 func printIngestPreflight(cmd *cobra.Command, rep api.IngestPreflightReport) {

--- a/cmd/docbank/backup_progress.go
+++ b/cmd/docbank/backup_progress.go
@@ -52,6 +52,10 @@ func newBackupProgressRenderer(out io.Writer, mode backupProgressMode) *backupPr
 }
 
 func backupProgressModeFromFlag(value string) (backupProgressMode, error) {
+	return progressModeFromFlag("backup", value)
+}
+
+func progressModeFromFlag(command, value string) (backupProgressMode, error) {
 	switch value {
 	case "", "auto":
 		return backupProgressAuto, nil
@@ -61,7 +65,7 @@ func backupProgressModeFromFlag(value string) (backupProgressMode, error) {
 		return backupProgressPlain, nil
 	default:
 		return backupProgressAuto, fmt.Errorf(
-			"backup: invalid --progress value %q (want auto, bar, or plain)", value)
+			"%s: invalid --progress value %q (want auto, bar, or plain)", command, value)
 	}
 }
 

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -130,7 +130,22 @@ func TestAddRerunReportsSkips(t *testing.T) {
 	require.NoError(t, err)
 	out, err := runCLI(t, "add", src, "--dest", "/inbox")
 	require.NoError(t, err)
+	assert.Contains(t, out, "scan:")
+	assert.Contains(t, out, "ingest:")
 	assert.Contains(t, out, "skipped: 1")
+}
+
+func TestAddJSONSuppressesProgress(t *testing.T) {
+	_ = setupVaultHome(t)
+	src := writeSourceFile(t, "json.txt", "quiet automation")
+
+	out, err := runCLI(t, "add", src, "--dest", "/inbox", "--json")
+	require.NoError(t, err)
+	var report api.IngestReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report), out)
+	assert.Equal(t, 1, report.Added)
+	assert.NotContains(t, out, "scan:")
+	assert.NotContains(t, out, "ingest:")
 }
 
 func TestAddPreflightReportsWithoutImporting(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -157,7 +157,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "8", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "9", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -170,6 +170,23 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.Len(t, recs, 1)
 	preflightPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, oldPID, preflightPID)
+
+	// Protocol 8 predates the ordinary ingest progress stream. Human-mode add
+	// must replace it before requesting that endpoint rather than fail with a
+	// 404 after the user has already selected a source tree.
+	recs[0].Metadata["protocol_version"] = "8"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "add", src, "--progress", "plain")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "scan:")
+	assert.Contains(t, out, "ingest:")
+	assert.Contains(t, out, "added: 1")
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	ingestPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, preflightPID, ingestPID)
 
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
@@ -185,7 +202,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "8", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "9", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -198,7 +215,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, preflightPID, protocolPID)
+	assert.NotEqual(t, ingestPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -251,6 +251,16 @@ Inspect `added`, `skipped`, `excluded`, and every member of `failed`. Repeating 
 ingest after fixing a partial failure is safe; successful content converges to
 `skipped` rather than another copy.
 
+For an interactive or long-running local integration, send the same body to
+`POST /api/v1/ingest/stream` with `Accept: application/x-ndjson`. Read every
+line through EOF. `progress` events cover the metadata-only `scan` and content
+`ingest` stages; a `result` carrying the final report or an `error` is the
+single terminal event. HTTP 200 means only that streaming started. Treat EOF
+without a terminal event, malformed events, or data after the terminal event
+as failure. Cancelling or disconnecting cancels traversal and the active blob
+write; only files whose individual publication already completed retain
+authority and are safely reported as skipped on a rerun.
+
 Remote writers use a file-granular multipart request. Compute the expected
 identity before sending bytes, and address the destination by stable directory
 ID:

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -37,7 +37,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
-| `POST /ingest` · `POST /ingest/preflight` | import or inventory server-side paths — see [addendum](#addendum-post-ingest-and-post-ingestpreflight) | Implemented |
+| `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |
 | `PATCH /nodes/{id}` | move and/or rename | Implemented |
 | `POST /path/move` · `POST /path/trash` | move / trash by virtual path, resolved and mutated in one store transaction | Implemented |
@@ -119,7 +119,7 @@ and maintenance are explicit exceptions:
 | `POST /nodes/{id}/verify` | required — binds the evidence to the exact node state the caller inspected |
 | `POST /path/move`, `POST /path/trash` | none — the path is resolved and mutated inside one store transaction, so there is no separate read for a revision to guard |
 | `POST /nodes` (create dir) | none — creation has no prior revision; a name collision is `409` |
-| `POST /ingest` | none — long-running bulk operation with per-path partial success; the destination directory may legitimately change while it runs |
+| `POST /ingest` · `POST /ingest/stream` | none — long-running bulk operations with per-path partial success; the destination directory may legitimately change while they run |
 | `POST /uploads` | none — creates or idempotently resolves one file under the stable `parent_id`; name/content collision policy is transactional |
 | `POST /trash/empty`, `POST /gc`, `POST /verify` | none — vault-wide maintenance, serialized by the maintenance gate |
 | `POST /backup/snapshots`, `POST /backup/snapshots/stream` | none — mutations pause only while pinning one logical snapshot; a preservation lease queues maintenance for the full capture, and the repository has its own exclusive lock |
@@ -164,7 +164,7 @@ These are integrity receipts from the authenticated daemon, not
 non-repudiable attestations against a malicious server. Signed receipts or a
 transparency log are outside docbank's current trust model.
 
-## Addendum: `POST /ingest` and `POST /ingest/preflight`
+## Addendum: `POST /ingest`, `POST /ingest/stream`, and `POST /ingest/preflight`
 
 `POST /ingest/preflight` takes `{paths: [...], exclude: [...]}` and performs a
 metadata-only source inventory. It opens no regular-file content and writes no
@@ -185,9 +185,18 @@ add`'s arguments to absolute paths before calling, so the command-line
 UX (relative paths, `cwd`-relative sources) is unchanged from Phase 1.
 Collisions resolve by the same suffixing rules as Phase 1's import.
 
-Because it grants "read any daemon-readable local path," `POST /ingest`
-is checked per-request against `RemoteAddr` and **restricted to
-loopback callers** regardless of bind address or API key — a
+`POST /ingest/stream` accepts the same body and returns
+`application/x-ndjson`. A metadata-only `scan` stage establishes advisory file
+and byte totals, followed by `ingest` progress for bytes read and file outcomes.
+Exactly one `result` carrying `IngestReport` or `error` terminates the stream;
+HTTP 200 alone is not success. A write failure or client disconnect cancels the
+request context used by traversal, blob writing, and metadata transactions.
+Already completed files remain valid and converge on retry, while an
+incomplete blob never receives node authority.
+
+Because they grant "read any daemon-readable local path," `POST /ingest` and
+`POST /ingest/stream` are checked per-request against `RemoteAddr` and
+**restricted to loopback callers** regardless of bind address or API key — a
 non-loopback client gets `403` (`loopback_only`). There is no remote file-upload
 capability on this route: remote bytes use `POST /uploads`, while remote access
 to the loopback-bound daemon still terminates through the configured SSH/VPN
@@ -313,7 +322,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `not_dir` / `not_file` / `invalid_name` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrNotTrashed` / `ErrIsRoot` |
 | `validation` | 400, 415, or 422 | malformed request (bad `If-Match`, paths, media type, multipart envelope, or generated validation) |
 | `precondition_required` | 428 | required `If-Match` header missing |
-| `loopback_only` | 403 | `POST /ingest` called by a non-loopback peer |
+| `loopback_only` | 403 | server-path ingest or preflight called by a non-loopback peer |
 | `digest_mismatch` / `size_mismatch` | 422 | uploaded file bytes disagree with the required declaration; no node/blob authority committed |
 | `too_large` | 413 | upload exceeded its declared size plus bounded multipart overhead |
 | `pack_retirement_deferred` | 503 | repack authority committed but an old source pack remains physically locked; release the lock, then run `storage pack` reconciliation |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -21,7 +21,7 @@ daemon status` and `docbank daemon stop` never auto-start. See
 ## docbank add
 
 ```
-docbank add <path>... [--dest <virtual-dir>] [--exclude <rule>]...
+docbank add <path>... [--dest <virtual-dir>] [--exclude <rule>]... [--progress auto|bar|plain] [--json]
 docbank add <path>... --preflight [--exclude <rule>]... [--json]
 ```
 
@@ -33,7 +33,8 @@ never modified or deleted.
 | `--dest` | `/inbox` | Virtual destination directory; created (with parents) if missing |
 | `--exclude` | none | Prune a matching entry name anywhere, or a relative path within each source; repeatable |
 | `--preflight` | false | Inventory source metadata without opening file content or changing the vault |
-| `--json` | false | Emit the preflight report as JSON; requires `--preflight` |
+| `--json` | false | Emit only the terminal preflight or ingest report as JSON; suppress progress |
+| `--progress` | `auto` | Human ingest progress: `auto`, `bar`, or durable `plain` lines |
 
 - A directory argument imports recursively: its basename becomes a
   directory under `--dest` and relative structure is preserved.
@@ -65,7 +66,12 @@ relative; absolute paths and `..` escapes are rejected. Rule form is preserved:
 root-relative `cache` entry. Each `--exclude` value is literal and commas are
 ordinary filename characters; repeat the flag to supply multiple rules.
 
-Output is a one-line summary plus one stderr line per failed file:
+An ordinary import first scans source metadata for file and byte totals, then
+shows ingest progress on stderr. `auto` uses a redrawable bar on a terminal and
+durable periodic lines when redirected; `--progress plain` forces durable
+lines. The scan is advisory because sources may change before they are opened.
+The command ends with a one-line stdout summary plus one stderr line per failed
+file:
 
 ```
 added: 12  skipped: 3  excluded: 2  failed: 1
@@ -75,6 +81,8 @@ failed: /src/broken.pdf: opening /src/broken.pdf: permission denied
 Exit is non-zero if any file failed. A missing or unreadable top-level
 source is reported as a failure and the command continues with remaining
 source arguments, just as it does for failures inside a directory tree.
+`--json` suppresses progress and returns the same terminal report shape as the
+HTTP JSON endpoint, so stdout remains safe for automation.
 
 ## docbank ls
 

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -73,6 +73,28 @@ single-component rule path-shaped: `cache` matches that name anywhere, whereas
 literal filename characters, not rule separators; pass `--exclude` repeatedly
 for multiple rules.
 
+## Follow a long import
+
+Human-mode `docbank add` performs a metadata-only scan to establish file and
+byte totals, then reports content-read progress while it imports:
+
+```bash
+docbank add ~/Dropbox --dest /archive --progress plain
+```
+
+`auto` (the default) draws a progress bar on a terminal and emits durable
+periodic lines when stderr is redirected. `plain` always emits durable lines;
+`bar` forces the redrawable form. Progress belongs on stderr and the terminal
+summary belongs on stdout. Use `--json` to suppress progress and emit only the
+machine-readable terminal report.
+
+The scan totals are an estimate rather than a filesystem lock: a source may
+change before Docbank opens it. Byte progress counts content actually read,
+while a file counts as done only after its individual blob and metadata
+operation returns. Interrupting the command cancels the daemon request. Files
+that already completed remain authoritative and make a rerun converge; an
+incomplete file never receives node authority.
+
 ## Idempotency: safe to re-run
 
 Interrupted a 200,000-file import? Run the same command again. For each

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -16,7 +16,7 @@ const requestTimeout = 60 * time.Second
 // timeout-exempt: long-running maintenance, integrity reads, and bulk ingest.
 func timeoutExempt(path string) bool {
 	switch path {
-	case "/api/v1/ingest", "/api/v1/ingest/preflight", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
+	case "/api/v1/ingest", "/api/v1/ingest/stream", "/api/v1/ingest/preflight", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
 		"/api/v1/storage/pack", "/api/v1/storage/repack", "/api/v1/uploads",
 		"/api/v1/backup/snapshots", "/api/v1/backup/snapshots/stream",
 		"/api/v1/backup/verify", "/api/v1/backup/verify/stream",
@@ -84,7 +84,7 @@ func loopbackMiddleware(next http.Handler) http.Handler {
 }
 
 func isServerPathIngestRoute(path string) bool {
-	return path == "/api/v1/ingest" || path == "/api/v1/ingest/preflight"
+	return path == "/api/v1/ingest" || path == "/api/v1/ingest/stream" || path == "/api/v1/ingest/preflight"
 }
 
 func isLoopbackRemote(remoteAddr string) bool {

--- a/internal/api/routes_backup.go
+++ b/internal/api/routes_backup.go
@@ -115,7 +115,7 @@ func registerBackupRoutes(api huma.API, d Deps, g *gate) {
 			hctx.SetHeader("Cache-Control", "no-store")
 			runCtx, cancel := context.WithCancel(hctx.Context())
 			defer cancel()
-			stream := newBackupEventWriter[BackupCreateEvent](hctx.BodyWriter(), cancel)
+			stream := newEventStreamWriter[BackupCreateEvent](hctx.BodyWriter(), cancel)
 			snapshot, createErr := createBackupSnapshot(
 				runCtx, repo, d, g, in.Body,
 				func(event backup.ProgressEvent) {
@@ -210,7 +210,7 @@ func registerBackupRoutes(api huma.API, d Deps, g *gate) {
 			hctx.SetHeader("Cache-Control", "no-store")
 			runCtx, cancel := context.WithCancel(hctx.Context())
 			defer cancel()
-			stream := newBackupEventWriter[BackupVerifyEvent](hctx.BodyWriter(), cancel)
+			stream := newEventStreamWriter[BackupVerifyEvent](hctx.BodyWriter(), cancel)
 			report, verifyErr := verifyBackupRepository(runCtx, repo, in.Body,
 				func(event backup.ProgressEvent) {
 					stream.send(BackupVerifyEvent{
@@ -279,7 +279,7 @@ func registerBackupRoutes(api huma.API, d Deps, g *gate) {
 			hctx.SetHeader("Cache-Control", "no-store")
 			runCtx, cancel := context.WithCancel(hctx.Context())
 			defer cancel()
-			stream := newBackupEventWriter[BackupRestoreEvent](hctx.BodyWriter(), cancel)
+			stream := newEventStreamWriter[BackupRestoreEvent](hctx.BodyWriter(), cancel)
 			report, restoreErr := restoreBackupSnapshot(
 				runCtx, repo, target, in.Body, coordinator,
 				func(event backup.ProgressEvent) {
@@ -602,7 +602,7 @@ func backupProgress(event backup.ProgressEvent) *BackupProgress {
 	}
 }
 
-type backupEventWriter[T any] struct {
+type eventStreamWriter[T any] struct {
 	mu       sync.Mutex
 	encoder  *json.Encoder
 	flusher  http.Flusher
@@ -610,13 +610,13 @@ type backupEventWriter[T any] struct {
 	writeErr error
 }
 
-func newBackupEventWriter[T any](w io.Writer, cancel context.CancelFunc) *backupEventWriter[T] {
-	return &backupEventWriter[T]{
+func newEventStreamWriter[T any](w io.Writer, cancel context.CancelFunc) *eventStreamWriter[T] {
+	return &eventStreamWriter[T]{
 		encoder: json.NewEncoder(w), flusher: responseFlusher(w), cancel: cancel,
 	}
 }
 
-func (w *backupEventWriter[T]) send(event T) {
+func (w *eventStreamWriter[T]) send(event T) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.writeErr != nil {
@@ -632,7 +632,7 @@ func (w *backupEventWriter[T]) send(event T) {
 	}
 }
 
-func (w *backupEventWriter[T]) err() error {
+func (w *eventStreamWriter[T]) err() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.writeErr

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"net/http"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -119,45 +120,81 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		OperationID: "ingest", Method: http.MethodPost, Path: "/api/v1/ingest",
 		Summary: "Import server-side files or directory trees (loopback callers only)",
 	}, func(ctx context.Context, in *struct {
-		Body struct {
-			Paths   []string `json:"paths" minItems:"1"`
-			Dest    string   `json:"dest" default:"/inbox"`
-			Exclude []string `json:"exclude,omitempty"`
-		}
+		Body ingestRequest
 	}) (*ingestOutput, error) {
-		if err := validateIngestPaths(in.Body.Paths); err != nil {
+		dest, opts, err := ingestParams(in.Body)
+		if err != nil {
 			return nil, err
 		}
-		opts := ingest.Options{Exclude: in.Body.Exclude}
-		if err := ingest.ValidateOptions(opts); err != nil {
-			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+		report, err := runIngest(ctx, d, g, in.Body.Paths, dest, opts)
+		return &ingestOutput{Body: report}, err
+	})
+
+	ingestStreamSchema := api.OpenAPI().Components.Schemas.Schema(
+		reflect.TypeFor[IngestEvent](), true, "IngestEvent")
+	huma.Register(api, huma.Operation{
+		OperationID: "streamIngest", Method: http.MethodPost, Path: "/api/v1/ingest/stream",
+		Summary: "Import server-side paths while streaming structured progress",
+		Description: "Returns newline-delimited JSON. Scan and ingest progress precede exactly one " +
+			"terminal result or error event; an HTTP 200 only means the stream started.",
+		Responses: map[string]*huma.Response{
+			"200": {
+				Description: "Ingest progress followed by one terminal result or error",
+				Content: map[string]*huma.MediaType{
+					"application/x-ndjson": {Schema: ingestStreamSchema},
+				},
+			},
+		},
+	}, func(_ context.Context, in *struct {
+		Body ingestRequest
+	}) (*huma.StreamResponse, error) {
+		dest, opts, err := ingestParams(in.Body)
+		if err != nil {
+			return nil, err
 		}
-		// The schema default covers an absent dest, not an explicit ""
-		// (which MkdirAll would treat as the vault root).
-		dest := in.Body.Dest
-		if dest == "" {
-			dest = "/inbox"
-		}
-		if !strings.HasPrefix(dest, "/") {
-			return nil, NewError(http.StatusUnprocessableEntity, "validation",
-				fmt.Sprintf("dest %q must be an absolute virtual path (start with /)", dest))
-		}
-		out := &ingestOutput{}
-		err := g.mutate(func() error {
-			return d.Blobs.WithMutation(ctx, func() error {
-				ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
-				rep, err := ing.AddPathsWithOptions(ctx, in.Body.Paths, dest, opts)
-				if err != nil {
-					return FromStoreError(err)
-				}
-				out.Body = IngestReport{Added: rep.Added, Skipped: rep.Skipped, Excluded: rep.Excluded}
-				for _, f := range rep.Failed {
-					out.Body.Failed = append(out.Body.Failed, IngestFailure{Path: f.Path, Error: f.Err.Error()})
-				}
-				return nil
-			})
-		})
-		return out, err
+		return &huma.StreamResponse{Body: func(hctx huma.Context) {
+			hctx.SetHeader("Content-Type", "application/x-ndjson")
+			hctx.SetHeader("Cache-Control", "no-store")
+			runCtx, cancel := context.WithCancel(hctx.Context())
+			defer cancel()
+			stream := newEventStreamWriter[IngestEvent](hctx.BodyWriter(), cancel)
+			stream.send(IngestEvent{Type: "progress", Progress: &IngestProgress{Stage: "scan"}})
+			preflight, scanErr := ingest.Preflight(runCtx, in.Body.Paths, opts)
+			if stream.err() != nil {
+				return
+			}
+			if scanErr != nil {
+				stream.send(IngestEvent{Type: "error", Error: ingestProblem(scanErr)})
+				return
+			}
+			stream.send(IngestEvent{Type: "progress", Progress: &IngestProgress{
+				Stage: "scan", Done: preflight.Files, Total: preflight.Files,
+				BytesDone: preflight.LogicalBytes, BytesTotal: preflight.LogicalBytes, Final: true,
+			}})
+			stream.send(IngestEvent{Type: "progress", Progress: &IngestProgress{
+				Stage: "ingest", Total: preflight.Files, BytesTotal: preflight.LogicalBytes,
+			}})
+			if stream.err() != nil {
+				return
+			}
+			opts.Progress = func(event ingest.ProgressEvent) {
+				stream.send(IngestEvent{Type: "progress", Progress: &IngestProgress{
+					Stage: "ingest", Done: event.FilesDone, Total: preflight.Files,
+					BytesDone: event.BytesRead, BytesTotal: preflight.LogicalBytes,
+					Added: event.Added, Skipped: event.Skipped, Excluded: event.Excluded,
+					Failed: event.Failed, Final: event.Final,
+				}})
+			}
+			report, ingestErr := runIngest(runCtx, d, g, in.Body.Paths, dest, opts)
+			if stream.err() != nil {
+				return
+			}
+			if ingestErr != nil {
+				stream.send(IngestEvent{Type: "error", Error: ingestProblem(ingestErr)})
+				return
+			}
+			stream.send(IngestEvent{Type: "result", Report: &report})
+		}}, nil
 	})
 
 	type trashListOutput struct {
@@ -260,6 +297,73 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		})
 		return out, err
 	})
+}
+
+type ingestRequest struct {
+	Paths   []string `json:"paths" minItems:"1"`
+	Dest    string   `json:"dest" default:"/inbox"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+func ingestParams(body ingestRequest) (string, ingest.Options, error) {
+	if err := validateIngestPaths(body.Paths); err != nil {
+		return "", ingest.Options{}, err
+	}
+	opts := ingest.Options{Exclude: body.Exclude}
+	if err := ingest.ValidateOptions(opts); err != nil {
+		return "", ingest.Options{}, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+	}
+	// The schema default covers an absent dest, not an explicit ""
+	// (which MkdirAll would treat as the vault root).
+	dest := body.Dest
+	if dest == "" {
+		dest = "/inbox"
+	}
+	if !strings.HasPrefix(dest, "/") {
+		return "", ingest.Options{}, NewError(http.StatusUnprocessableEntity, "validation",
+			fmt.Sprintf("dest %q must be an absolute virtual path (start with /)", dest))
+	}
+	return dest, opts, nil
+}
+
+func runIngest(
+	ctx context.Context,
+	d Deps,
+	g *gate,
+	paths []string,
+	dest string,
+	opts ingest.Options,
+) (IngestReport, error) {
+	var out IngestReport
+	err := g.mutate(func() error {
+		return d.Blobs.WithMutation(ctx, func() error {
+			ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
+			rep, err := ing.AddPathsWithOptions(ctx, paths, dest, opts)
+			if err != nil {
+				return FromStoreError(err)
+			}
+			out = IngestReport{Added: rep.Added, Skipped: rep.Skipped, Excluded: rep.Excluded}
+			for _, failure := range rep.Failed {
+				out.Failed = append(out.Failed, IngestFailure{
+					Path: failure.Path, Error: failure.Err.Error(),
+				})
+			}
+			return nil
+		})
+	})
+	return out, err
+}
+
+func ingestProblem(err error) *Error {
+	var problem *Error
+	if errors.As(err, &problem) {
+		return problem
+	}
+	mapped := FromStoreError(err)
+	if errors.As(mapped, &problem) {
+		return problem
+	}
+	return NewError(http.StatusInternalServerError, "internal", err.Error())
 }
 
 func validateIngestPaths(paths []string) error {

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -64,6 +64,50 @@ func TestIngestEndpoint(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode, body)
 }
 
+func TestIngestProgressStreamEndsWithResult(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	src := filepath.Join(t.TempDir(), "progress.txt")
+	content := []byte("stream this import")
+	require.NoError(t, os.WriteFile(src, content, 0o600))
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/ingest/stream", nil,
+		map[string]any{"paths": []string{src}, "dest": "/inbox"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/x-ndjson")
+
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	require.GreaterOrEqual(t, len(lines), 5)
+	var events []api.IngestEvent
+	for _, line := range lines {
+		var event api.IngestEvent
+		require.NoError(t, json.Unmarshal([]byte(line), &event), line)
+		events = append(events, event)
+	}
+	for i, event := range events[:len(events)-1] {
+		assert.Equal(t, "progress", event.Type, "event %d", i)
+		require.NotNil(t, event.Progress)
+	}
+	terminal := events[len(events)-1]
+	assert.Equal(t, "result", terminal.Type)
+	require.NotNil(t, terminal.Report)
+	assert.Equal(t, 1, terminal.Report.Added)
+	assert.Nil(t, terminal.Progress)
+	assert.Nil(t, terminal.Error)
+
+	finalStages := map[string]api.IngestProgress{}
+	for _, event := range events {
+		if event.Progress != nil && event.Progress.Final {
+			finalStages[event.Progress.Stage] = *event.Progress
+		}
+	}
+	require.Contains(t, finalStages, "scan")
+	require.Contains(t, finalStages, "ingest")
+	assert.Equal(t, int64(1), finalStages["scan"].Total)
+	assert.Equal(t, int64(len(content)), finalStages["scan"].BytesTotal)
+	assert.Equal(t, int64(1), finalStages["ingest"].Done)
+	assert.Equal(t, int64(len(content)), finalStages["ingest"].BytesDone)
+}
+
 func TestIngestPreflightIsReadOnlyAndSharesExclusions(t *testing.T) {
 	ts, _ := newTestServer(t, nil)
 	src := t.TempDir()
@@ -119,7 +163,7 @@ func TestIngestRejectsNonLoopback(t *testing.T) {
 	cfg := config.Default()
 	cfg.Server.APIKey = "test-key"
 	srv := api.NewServer(api.Deps{Store: s, Blobs: blobs, VaultRoot: dir, Cfg: cfg})
-	for _, path := range []string{"/api/v1/ingest", "/api/v1/ingest/preflight"} {
+	for _, path := range []string{"/api/v1/ingest", "/api/v1/ingest/stream", "/api/v1/ingest/preflight"} {
 		t.Run(path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"paths":["/x"],"dest":"/inbox"}`))
 			req.Header.Set("Content-Type", "application/json")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -79,6 +79,31 @@ type IngestReport struct {
 	Failed   []IngestFailure `json:"failed,omitempty"`
 }
 
+// IngestProgress is one structured update from a server-side import. Scan
+// establishes totals without opening content; ingest counts bytes actually
+// read and files whose individual import attempt has completed.
+type IngestProgress struct {
+	Stage      string `json:"stage" enum:"scan,ingest"`
+	Done       int64  `json:"done"`
+	Total      int64  `json:"total"`
+	BytesDone  int64  `json:"bytes_done"`
+	BytesTotal int64  `json:"bytes_total"`
+	Added      int    `json:"added"`
+	Skipped    int    `json:"skipped"`
+	Excluded   int    `json:"excluded"`
+	Failed     int    `json:"failed"`
+	Final      bool   `json:"final"`
+}
+
+// IngestEvent is one line of the ingest NDJSON stream. A report or error is
+// terminal; progress may appear zero or more times before it.
+type IngestEvent struct {
+	Type     string          `json:"type" enum:"progress,result,error"`
+	Progress *IngestProgress `json:"progress,omitempty"`
+	Report   *IngestReport   `json:"report,omitempty"`
+	Error    *Error          `json:"error,omitempty"`
+}
+
 // IngestSizeClass summarizes files in one storage-policy outcome.
 type IngestSizeClass struct {
 	Files int64 `json:"files"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -248,6 +248,83 @@ func (c *Client) IngestWithOptions(
 	return rep, err
 }
 
+// IngestStream imports server-side paths while delivering structured scan and
+// ingest progress. Success requires a terminal report event; an HTTP 200 only
+// means that the stream started.
+func (c *Client) IngestStream(
+	ctx context.Context,
+	paths []string,
+	dest string,
+	exclude []string,
+	progress func(api.IngestProgress),
+) (api.IngestReport, error) {
+	body, err := json.Marshal(map[string]any{
+		"paths": paths, "dest": dest, "exclude": exclude,
+	})
+	if err != nil {
+		return api.IngestReport{}, fmt.Errorf("encoding ingest request: %w", err)
+	}
+	const path = "/api/v1/ingest/stream"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+path, bytes.NewReader(body))
+	if err != nil {
+		return api.IngestReport{}, fmt.Errorf("building ingest stream request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	if c.key != "" {
+		req.Header.Set("X-Api-Key", c.key)
+	}
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return api.IngestReport{}, fmt.Errorf("calling daemon (POST %s): %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return api.IngestReport{}, decodeError(resp)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	var result *api.IngestReport
+	for {
+		var event api.IngestEvent
+		if err := decoder.Decode(&event); err != nil {
+			if errors.Is(err, io.EOF) {
+				if result == nil {
+					return api.IngestReport{}, errors.New("ingest progress stream ended without a result")
+				}
+				return *result, nil
+			}
+			return api.IngestReport{}, fmt.Errorf("decoding ingest progress: %w", err)
+		}
+		if result != nil {
+			return api.IngestReport{}, errors.New("ingest progress stream continued after its result")
+		}
+		switch event.Type {
+		case "progress":
+			if event.Progress == nil || event.Report != nil || event.Error != nil {
+				return api.IngestReport{}, errors.New("ingest returned malformed progress event")
+			}
+			if progress != nil {
+				progress(*event.Progress)
+			}
+		case "result":
+			if event.Report == nil || event.Progress != nil || event.Error != nil {
+				return api.IngestReport{}, errors.New("ingest returned malformed result event")
+			}
+			report := *event.Report
+			result = &report
+		case "error":
+			if event.Error == nil || event.Progress != nil || event.Report != nil {
+				return api.IngestReport{}, errors.New("ingest returned malformed error event")
+			}
+			return api.IngestReport{}, apiProblemError(*event.Error)
+		default:
+			return api.IngestReport{}, fmt.Errorf(
+				"ingest returned unknown progress event type %q", event.Type)
+		}
+	}
+}
+
 // PreflightIngest inventories server-side paths without opening file content
 // or mutating the vault.
 func (c *Client) PreflightIngest(

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -139,6 +139,32 @@ func TestStoragePackRoundTrip(t *testing.T) {
 	assert.True(t, report.BudgetExhausted)
 }
 
+func TestIngestStreamRoundTrip(t *testing.T) {
+	c, _ := newClient(t, serverKey)
+	src := filepath.Join(t.TempDir(), "stream.txt")
+	content := []byte("stream this ingest")
+	require.NoError(t, os.WriteFile(src, content, 0o600))
+
+	var events []api.IngestProgress
+	report, err := c.IngestStream(t.Context(), []string{src}, "/inbox", nil,
+		func(event api.IngestProgress) { events = append(events, event) })
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Added)
+	assert.Empty(t, report.Failed)
+	require.NotEmpty(t, events)
+
+	finalStages := map[string]api.IngestProgress{}
+	for _, event := range events {
+		if event.Final {
+			finalStages[event.Stage] = event
+		}
+	}
+	require.Contains(t, finalStages, "scan")
+	require.Contains(t, finalStages, "ingest")
+	assert.Equal(t, int64(1), finalStages["ingest"].Done)
+	assert.Equal(t, int64(len(content)), finalStages["ingest"].BytesDone)
+}
+
 func TestBackupCreateStreamRoundTripAndTypedError(t *testing.T) {
 	c, _ := newClient(t, serverKey)
 	repoPath := filepath.Join(t.TempDir(), "repo")

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "8"
+	daemonProtocolVersion = "9"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -355,6 +355,9 @@ func (ing *Ingester) addTree(
 	// that path re-create (even resurrect) a tree somewhere else.
 	dirIDs := map[string]int64{} // source dir path -> virtual dir node id
 	walkErr := filepath.WalkDir(walkRoot, func(p string, d fs.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		sourcePath := sourceTreePath(sourceRoot, walkRoot, p)
 		if err != nil {
 			rep.Failed = append(rep.Failed, FileError{Path: sourcePath, Err: err})
@@ -381,6 +384,9 @@ func (ing *Ingester) addTree(
 			}
 			dir, err := ing.Store.EnsureDir(ctx, parentID, name)
 			if err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
 				rep.Failed = append(rep.Failed, FileError{Path: sourcePath,
 					Err: fmt.Errorf("creating virtual dir %q under node %d: %w", name, parentID, err)})
 				progress.report(*rep, false)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -45,6 +45,103 @@ type Report struct {
 	Failed   []FileError
 }
 
+// ProgressEvent reports bytes read and file outcomes observed so far. A file
+// contributes to FilesDone only after its blob and metadata operation returns;
+// BytesRead may include an incomplete file when the operation is cancelled.
+type ProgressEvent struct {
+	FilesDone int64
+	BytesRead int64
+	Added     int
+	Skipped   int
+	Excluded  int
+	Failed    int
+	Final     bool
+}
+
+const (
+	progressByteInterval = 4 << 20
+	progressFileInterval = 64
+	progressTimeInterval = time.Second
+)
+
+type progressTracker struct {
+	notify               func(ProgressEvent)
+	event                ProgressEvent
+	lastNotifiedBytes    int64
+	lastNotifiedFiles    int64
+	lastNotifiedExcluded int
+	lastNotifiedFailed   int
+	lastNotifiedAt       time.Time
+}
+
+func newProgressTracker(notify func(ProgressEvent)) *progressTracker {
+	if notify == nil {
+		return nil
+	}
+	return &progressTracker{notify: notify}
+}
+
+func (p *progressTracker) addBytes(n int) {
+	if p == nil || n <= 0 {
+		return
+	}
+	p.event.BytesRead += int64(n)
+	if p.event.BytesRead-p.lastNotifiedBytes >= progressByteInterval ||
+		time.Since(p.lastNotifiedAt) >= progressTimeInterval {
+		p.emit(false)
+	}
+}
+
+func (p *progressTracker) report(rep Report, final bool) {
+	if p == nil {
+		return
+	}
+	p.event.FilesDone = int64(rep.Added + rep.Skipped + len(rep.Failed))
+	p.event.Added = rep.Added
+	p.event.Skipped = rep.Skipped
+	p.event.Excluded = rep.Excluded
+	p.event.Failed = len(rep.Failed)
+	if p.lastNotifiedAt.IsZero() || final ||
+		p.event.FilesDone-p.lastNotifiedFiles >= progressFileInterval ||
+		p.event.Excluded-p.lastNotifiedExcluded >= progressFileInterval ||
+		p.event.Failed > p.lastNotifiedFailed ||
+		time.Since(p.lastNotifiedAt) >= progressTimeInterval {
+		p.emit(final)
+	}
+}
+
+func (p *progressTracker) emit(final bool) {
+	if p == nil {
+		return
+	}
+	p.event.Final = final
+	p.lastNotifiedBytes = p.event.BytesRead
+	p.lastNotifiedFiles = p.event.FilesDone
+	p.lastNotifiedExcluded = p.event.Excluded
+	p.lastNotifiedFailed = p.event.Failed
+	p.lastNotifiedAt = time.Now()
+	p.notify(p.event)
+}
+
+type progressReader struct {
+	io.Reader
+
+	ctx     context.Context
+	tracker *progressTracker
+}
+
+func (r progressReader) Read(buf []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := r.Reader.Read(buf)
+	r.tracker.addBytes(n)
+	if err == nil {
+		err = r.ctx.Err()
+	}
+	return n, err
+}
+
 // UploadResult is the server's independently computed receipt for one remote
 // file. Node is populated for both a new import and an idempotent retry.
 type UploadResult struct {
@@ -135,8 +232,12 @@ func (ing *Ingester) AddPathsWithOptions(
 	sources []string,
 	destPath string,
 	opts Options,
-) (Report, error) {
-	var rep Report
+) (rep Report, err error) {
+	progress := newProgressTracker(opts.Progress)
+	progress.report(rep, false)
+	if err := ctx.Err(); err != nil {
+		return rep, err
+	}
 	excludes, err := compileExclusions(opts.Exclude)
 	if err != nil {
 		return rep, err
@@ -151,23 +252,30 @@ func (ing *Ingester) AddPathsWithOptions(
 	}
 
 	for _, rawSource := range sources {
+		if err := ctx.Err(); err != nil {
+			return rep, err
+		}
 		src := filepath.Clean(rawSource)
 		info, err := os.Lstat(src)
 		if err != nil {
 			// Per-file failure like any other: aborting here would leave
 			// already-imported files out of the report entirely.
 			rep.Failed = append(rep.Failed, FileError{Path: src, Err: err})
+			progress.report(rep, false)
 			continue
 		}
 		if excludes.match(src, src) {
 			rep.Excluded++
+			progress.report(rep, false)
 			continue
 		}
 		switch {
 		case info.Mode().IsRegular():
-			ing.addOne(ctx, &rep, ingestID, dest.ID, src, src)
+			if err := ing.addOne(ctx, &rep, ingestID, dest.ID, src, src, progress); err != nil {
+				return rep, err
+			}
 		case info.IsDir():
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, excludes); err != nil {
+			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, excludes, progress); err != nil {
 				return rep, err
 			}
 		case info.Mode()&fs.ModeSymlink != 0:
@@ -175,27 +283,32 @@ func (ing *Ingester) AddPathsWithOptions(
 			if err != nil {
 				rep.Failed = append(rep.Failed, FileError{Path: src,
 					Err: fmt.Errorf("resolving explicitly named directory symlink: %w", err)})
+				progress.report(rep, false)
 				continue
 			}
 			target, err := os.Stat(walkRoot)
 			if err != nil {
 				rep.Failed = append(rep.Failed, FileError{Path: src,
 					Err: fmt.Errorf("checking explicitly named directory symlink: %w", err)})
+				progress.report(rep, false)
 				continue
 			}
 			if !target.IsDir() {
 				rep.Failed = append(rep.Failed, FileError{Path: src,
 					Err: errors.New("explicit symlink source does not resolve to a directory")})
+				progress.report(rep, false)
 				continue
 			}
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, walkRoot, excludes); err != nil {
+			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, walkRoot, excludes, progress); err != nil {
 				return rep, err
 			}
 		default:
 			rep.Failed = append(rep.Failed, FileError{Path: src,
 				Err: errors.New("not a regular file or directory (symlinks are skipped)")})
+			progress.report(rep, false)
 		}
 	}
+	progress.report(rep, true)
 	return rep, nil
 }
 
@@ -216,6 +329,7 @@ func (ing *Ingester) addTree(
 	ingestID, destDirID int64,
 	sourceRoot, walkRoot string,
 	excludes exclusions,
+	progress *progressTracker,
 ) error {
 	// Absolutize first. WalkDir hands back the root spelled exactly as given
 	// while children come from filepath.Join, which cleans — dirIDs keys must
@@ -244,10 +358,12 @@ func (ing *Ingester) addTree(
 		sourcePath := sourceTreePath(sourceRoot, walkRoot, p)
 		if err != nil {
 			rep.Failed = append(rep.Failed, FileError{Path: sourcePath, Err: err})
+			progress.report(*rep, false)
 			return nil //nolint:nilerr // intentional: record error and continue walk
 		}
 		if excludes.match(sourceRoot, sourcePath) {
 			rep.Excluded++
+			progress.report(*rep, false)
 			if d.IsDir() {
 				return fs.SkipDir
 			}
@@ -267,6 +383,7 @@ func (ing *Ingester) addTree(
 			if err != nil {
 				rep.Failed = append(rep.Failed, FileError{Path: sourcePath,
 					Err: fmt.Errorf("creating virtual dir %q under node %d: %w", name, parentID, err)})
+				progress.report(*rep, false)
 				return fs.SkipDir
 			}
 			dirIDs[p] = dir.ID
@@ -275,10 +392,13 @@ func (ing *Ingester) addTree(
 			if !ok {
 				return fmt.Errorf("internal: no virtual dir recorded for %s", filepath.Dir(p))
 			}
-			ing.addOne(ctx, rep, ingestID, parentID, p, sourcePath)
+			if err := ing.addOne(ctx, rep, ingestID, parentID, p, sourcePath, progress); err != nil {
+				return err
+			}
 		default:
 			rep.Failed = append(rep.Failed, FileError{Path: sourcePath,
 				Err: errors.New("not a regular file (symlinks are skipped)")})
+			progress.report(*rep, false)
 		}
 		return nil
 	})
@@ -299,22 +419,29 @@ func (ing *Ingester) addOne(
 	rep *Report,
 	ingestID, parentID int64,
 	openPath, sourcePath string,
-) {
-	added, err := ing.importFile(ctx, ingestID, parentID, openPath, sourcePath)
+	progress *progressTracker,
+) error {
+	added, err := ing.importFile(ctx, ingestID, parentID, openPath, sourcePath, progress)
 	switch {
 	case err != nil:
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		rep.Failed = append(rep.Failed, FileError{Path: sourcePath, Err: err})
 	case added:
 		rep.Added++
 	default:
 		rep.Skipped++
 	}
+	progress.report(*rep, false)
+	return nil
 }
 
 func (ing *Ingester) importFile(
 	ctx context.Context,
 	ingestID, parentID int64,
 	openPath, sourcePath string,
+	progress *progressTracker,
 ) (bool, error) {
 	// No-follow plus fstat, not the earlier Lstat/WalkDir classification:
 	// the file could have been swapped since, and "symlinks are skipped"
@@ -346,7 +473,11 @@ func (ing *Ingester) importFile(
 	// durable. A skip, metadata failure, or crash after this point can
 	// orphan the blob file — harmless, reclaimed by gc's untracked-file
 	// scan.
-	hash, size, err := ing.Blobs.WriteContext(ctx, f)
+	var content io.Reader = f
+	if progress != nil {
+		content = progressReader{Reader: f, ctx: ctx, tracker: progress}
+	}
+	hash, size, err := ing.Blobs.WriteContext(ctx, content)
 	if err != nil {
 		return false, fmt.Errorf("storing content of %s: %w", sourcePath, err)
 	}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -134,6 +134,32 @@ func TestAddProgressBatchesManySmallFiles(t *testing.T) {
 	assert.Equal(t, int64(130), events[len(events)-1].FilesDone)
 }
 
+func TestAddCancellationStopsExcludedDirectoryWalk(t *testing.T) {
+	ing := newTestIngester(t)
+	src := t.TempDir()
+	for i := range 130 {
+		require.NoError(t, os.MkdirAll(
+			filepath.Join(src, fmt.Sprintf("%03d", i), "skip"), 0o700))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var events []ProgressEvent
+	_, err := ing.AddPathsWithOptions(ctx, []string{src}, "/inbox", Options{
+		Exclude: []string{"skip"},
+		Progress: func(event ProgressEvent) {
+			events = append(events, event)
+			if event.Excluded >= progressFileInterval {
+				cancel()
+			}
+		},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotEmpty(t, events)
+	assert.False(t, events[len(events)-1].Final)
+	assert.Less(t, events[len(events)-1].Excluded, 130,
+		"the walk must stop instead of traversing every excluded directory")
+}
+
 func TestAddDirectoryPreservesStructure(t *testing.T) {
 	ing := newTestIngester(t)
 	ctx := t.Context()

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1,6 +1,8 @@
 package ingest
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,6 +63,75 @@ func TestAddSingleFile(t *testing.T) {
 	// Source untouched.
 	_, err = os.Stat(filepath.Join(src, "notes.txt"))
 	require.NoError(t, err)
+}
+
+func TestAddProgressReportsBytesAndFinalOutcome(t *testing.T) {
+	ing := newTestIngester(t)
+	src := writeTree(t, map[string]string{"a.txt": "alpha", "b.txt": "beta"})
+	paths := []string{filepath.Join(src, "a.txt"), filepath.Join(src, "b.txt")}
+	var events []ProgressEvent
+
+	rep, err := ing.AddPathsWithOptions(t.Context(), paths, "/inbox", Options{
+		Progress: func(event ProgressEvent) { events = append(events, event) },
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, rep.Added)
+	require.NotEmpty(t, events)
+	assert.Zero(t, events[0].FilesDone)
+	assert.False(t, events[0].Final)
+	last := events[len(events)-1]
+	assert.True(t, last.Final)
+	assert.Equal(t, int64(2), last.FilesDone)
+	assert.Equal(t, int64(len("alpha")+len("beta")), last.BytesRead)
+	assert.Equal(t, 2, last.Added)
+	assert.Zero(t, last.Failed)
+}
+
+func TestAddCancellationDoesNotAuthorizeIncompleteFile(t *testing.T) {
+	ing := newTestIngester(t)
+	src := filepath.Join(t.TempDir(), "large.bin")
+	f, err := os.Create(src)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(progressByteInterval*2))
+	require.NoError(t, f.Close())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var events []ProgressEvent
+	_, err = ing.AddPathsWithOptions(ctx, []string{src}, "/inbox", Options{
+		Progress: func(event ProgressEvent) {
+			events = append(events, event)
+			if event.BytesRead >= progressByteInterval {
+				cancel()
+			}
+		},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled, err)
+	require.NotEmpty(t, events)
+	assert.False(t, events[len(events)-1].Final)
+	_, err = ing.Store.NodeByPath(t.Context(), "/inbox/large.bin")
+	assert.ErrorIs(t, err, store.ErrNotFound,
+		"cancellation during blob reading must not grant node authority")
+}
+
+func TestAddProgressBatchesManySmallFiles(t *testing.T) {
+	ing := newTestIngester(t)
+	files := make(map[string]string, 130)
+	for i := range 130 {
+		files[fmt.Sprintf("%03d.txt", i)] = "x"
+	}
+	src := writeTree(t, files)
+	var events []ProgressEvent
+
+	rep, err := ing.AddPathsWithOptions(t.Context(), []string{src}, "/inbox", Options{
+		Progress: func(event ProgressEvent) { events = append(events, event) },
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 130, rep.Added)
+	require.GreaterOrEqual(t, len(events), 4, "initial, two batches, and final")
+	assert.Less(t, len(events), 10, "progress must not emit one event per small file")
+	assert.True(t, events[len(events)-1].Final)
+	assert.Equal(t, int64(130), events[len(events)-1].FilesDone)
 }
 
 func TestAddDirectoryPreservesStructure(t *testing.T) {
@@ -239,7 +310,7 @@ func TestAddTreeStaleDestinationIsNotResurrected(t *testing.T) {
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
 	var rep Report
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, exclusions{}))
+	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, exclusions{}, nil))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 

--- a/internal/ingest/ingest_unix_test.go
+++ b/internal/ingest/ingest_unix_test.go
@@ -25,7 +25,7 @@ func TestImportRefusesSymlinkAtOpen(t *testing.T) {
 	// are skipped" has to hold at the point the file is opened for reading.
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
-	_, err = ing.importFile(ctx, ingestID, ing.Store.RootID(), link, link)
+	_, err = ing.importFile(ctx, ingestID, ing.Store.RootID(), link, link, nil)
 	require.Error(t, err)
 }
 

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -24,6 +24,9 @@ const (
 // rule matches that entry and its descendants within each supplied source.
 type Options struct {
 	Exclude []string
+	// Progress receives bounded updates while a real ingest reads and commits
+	// files. Preflight ignores it because it never opens file content.
+	Progress func(ProgressEvent)
 }
 
 // SizeClass summarizes one physical-policy outcome.


### PR DESCRIPTION
A representative 2,575-file import left the operator without feedback for roughly 40 seconds, and even an unchanged rerun stayed silent for 33 seconds. That makes a healthy large import indistinguishable from a stalled request and leaves agents without a structured completion boundary.

This gives human-mode `docbank add` the same terminal-aware progress posture as backup: an advisory metadata scan establishes file and byte totals, then bounded content-read and completed-file updates drive either a TTY bar or durable redirected output. `--json` deliberately stays quiet and emits one report, preserving an automation-safe stdout contract.

The HTTP stream is successful only after exactly one terminal result event; HTTP 200 merely means it started. Disconnects and cancellation reach traversal and blob publication through the operation context. Files whose publication already completed remain valid and converge on retry, while an interrupted file receives no node authority. Protocol revision 9 prevents the CLI from routing this request to a same-version daemon that predates the stream.

The repository suite, race-sensitive ingest/API/client coverage, strict documentation build, lint, vet, and generated OpenAPI inspection pass. Kata: `c18r`.
