### PR TITLE
Supervise daemon background work

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -122,6 +122,19 @@ func TestAddLsTreeCat(t *testing.T) {
 	assert.Equal(t, "hello vault", out)
 }
 
+func TestJobsShowsDaemonStatus(t *testing.T) {
+	_ = setupVaultHome(t)
+	out, err := runCLI(t, "jobs")
+	require.NoError(t, err)
+	assert.Equal(t, "no background jobs\n", out)
+
+	out, err = runCLI(t, "jobs", "--json")
+	require.NoError(t, err)
+	var got api.JobList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Empty(t, got.Items)
+}
+
 func TestAddRerunReportsSkips(t *testing.T) {
 	_ = setupVaultHome(t)
 	src := writeSourceFile(t, "a.txt", "alpha")

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -24,6 +24,7 @@ import (
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/daemonlife"
 	"go.kenn.io/docbank/internal/home"
 	"go.kenn.io/docbank/internal/jobs"
 	"go.kenn.io/docbank/internal/store"
@@ -125,7 +126,8 @@ func runServe(ctx context.Context) (retErr error) {
 	// runtime cleanup so the daemon stays discoverable while jobs drain, and
 	// after store/blob cleanup so their resources remain open until then.
 	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), daemonlife.JobDrainTimeout)
 		defer cancel()
 		if err := jobSupervisor.Shutdown(shutdownCtx); err != nil {
 			retErr = errors.Join(retErr, err)
@@ -169,7 +171,8 @@ func runServe(ctx context.Context) (retErr error) {
 	}
 	logger.Info("docbank daemon shutting down")
 	jobSupervisor.Stop()
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(
+		context.Background(), daemonlife.HTTPDrainTimeout)
 	defer cancel()
 	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
 		// A timed-out drain means handlers may still be running. Force-close

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -48,6 +48,15 @@ func runServe(ctx context.Context) (retErr error) {
 	if err != nil {
 		return err
 	}
+	// This is deliberately the first cleanup registered after acquiring the
+	// vault. LIFO execution removes the runtime record only after supervised
+	// jobs, storage, the lock, and the held root have all finished cleanup.
+	var recPath string
+	defer func() {
+		if recPath != "" {
+			_ = os.Remove(recPath)
+		}
+	}()
 	defer func() { _ = root.Close() }()
 	defer func() { _ = lock.Release() }()
 
@@ -116,15 +125,13 @@ func runServe(ctx context.Context) (retErr error) {
 	cfg.Server.APIKey = apiKey
 
 	rtStore := client.RuntimeStore(layout.Root)
-	recPath, err := rtStore.Write(client.NewRecord(addr, apiKey, shutdownToken))
+	recPath, err = rtStore.Write(client.NewRecord(addr, apiKey, shutdownToken))
 	if err != nil {
 		_ = listener.Close()
 		return fmt.Errorf("writing daemon runtime record: %w", err)
 	}
-	defer func() { _ = os.Remove(recPath) }()
-	// Defers run in reverse registration order. Register the job wait after
-	// runtime cleanup so the daemon stays discoverable while jobs drain, and
-	// after store/blob cleanup so their resources remain open until then.
+	// Register the job wait after store/blob cleanup so their resources remain
+	// open until runners return. The earlier runtime cleanup remains last.
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(
 			context.Background(), daemonlife.JobDrainTimeout)

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -24,6 +25,7 @@ import (
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/config"
 	"go.kenn.io/docbank/internal/home"
+	"go.kenn.io/docbank/internal/jobs"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -36,7 +38,7 @@ var daemonRunCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error { return runServe(cmd.Context()) },
 }
 
-func runServe(ctx context.Context) error {
+func runServe(ctx context.Context) (retErr error) {
 	layout, err := home.Resolve()
 	if err != nil {
 		return err
@@ -64,6 +66,8 @@ func runServe(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	sigCtx, sigCancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer sigCancel()
 
 	s, err := store.Open(layout.DBPath())
 	if err != nil {
@@ -79,6 +83,16 @@ func runServe(ctx context.Context) error {
 	if err := blobs.CleanTmp(); err != nil {
 		return err
 	}
+	jobSupervisor := jobs.New(sigCtx, logger)
+	// Register this after the store/blob defers so jobs always stop before the
+	// resources their runners may use are closed, including early error paths.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := jobSupervisor.Shutdown(shutdownCtx); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
 
 	listener, err := kitdaemon.Listen(ctx, kitdaemon.Endpoint{
 		Network: kitdaemon.NetworkTCP,
@@ -125,6 +139,7 @@ func runServe(ctx context.Context) error {
 	srv := api.NewServer(api.Deps{
 		Store: s, Blobs: blobs, VaultRoot: layout.Root, Cfg: cfg, Logger: logger,
 		StartedAt: time.Now(), ShutdownToken: shutdownToken, Shutdown: stop, Tracker: tracker,
+		Jobs: jobSupervisor,
 	})
 	httpSrv := &http.Server{
 		Handler:           srv.Handler(),
@@ -132,11 +147,13 @@ func runServe(ctx context.Context) error {
 		BaseContext:       func(net.Listener) context.Context { return ctx },
 	}
 
-	sigCtx, sigCancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
-	defer sigCancel()
-
 	if background && cfg.Server.IdleTimeout.Std() > 0 {
-		go idleWatch(sigCtx, tracker, cfg.Server.IdleTimeout.Std(), logger, stop)
+		if err := jobSupervisor.Start("daemon.idle-timeout", func(ctx context.Context) error {
+			idleWatch(ctx, tracker, cfg.Server.IdleTimeout.Std(), logger, stop)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("starting idle-timeout job: %w", err)
+		}
 	}
 
 	errCh := make(chan error, 1)
@@ -150,6 +167,7 @@ func runServe(ctx context.Context) error {
 	case <-stopCh:
 	}
 	logger.Info("docbank daemon shutting down")
+	jobSupervisor.Stop()
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := httpSrv.Shutdown(shutdownCtx); err != nil {

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -84,15 +84,6 @@ func runServe(ctx context.Context) (retErr error) {
 		return err
 	}
 	jobSupervisor := jobs.New(sigCtx, logger)
-	// Register this after the store/blob defers so jobs always stop before the
-	// resources their runners may use are closed, including early error paths.
-	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := jobSupervisor.Shutdown(shutdownCtx); err != nil {
-			retErr = errors.Join(retErr, err)
-		}
-	}()
 
 	listener, err := kitdaemon.Listen(ctx, kitdaemon.Endpoint{
 		Network: kitdaemon.NetworkTCP,
@@ -130,6 +121,16 @@ func runServe(ctx context.Context) (retErr error) {
 		return fmt.Errorf("writing daemon runtime record: %w", err)
 	}
 	defer func() { _ = os.Remove(recPath) }()
+	// Defers run in reverse registration order. Register the job wait after
+	// runtime cleanup so the daemon stays discoverable while jobs drain, and
+	// after store/blob cleanup so their resources remain open until then.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := jobSupervisor.Shutdown(shutdownCtx); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
 
 	var stopOnce sync.Once
 	stopCh := make(chan struct{})

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -149,15 +149,34 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	assert.Contains(t, out, "already running")
 	assert.Equal(t, oldPID, parsePID(t, out))
 
+	// Protocol 9 predates background-job status. Ensure must replace it before
+	// the CLI requests /api/v1/jobs rather than sending the new request to a
+	// same-version daemon that will return 404.
+	recs, err := client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.Equal(t, "10", recs[0].Metadata["protocol_version"])
+	recs[0].Metadata["protocol_version"] = "9"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "jobs", "--json")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, `"items"`)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	jobsPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, oldPID, jobsPID)
+
 	// A same-version daemon from before ingest preflight/exclusions existed
 	// must be replaced before the CLI issues the new request. Otherwise
 	// preflight returns 404 and a real ingest can silently ignore exclusions.
 	src := filepath.Join(t.TempDir(), "preflight.txt")
 	require.NoError(t, os.WriteFile(src, []byte("preview"), 0o600))
-	recs, err := client.RuntimeStore(dir).List()
+	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "9", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "10", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -169,7 +188,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	preflightPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, oldPID, preflightPID)
+	assert.NotEqual(t, jobsPID, preflightPID)
 
 	// Protocol 8 predates the ordinary ingest progress stream. Human-mode add
 	// must replace it before requesting that endpoint rather than fail with a
@@ -202,7 +221,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "9", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "10", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/jobs.go
+++ b/cmd/docbank/jobs.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+var jobsJSON bool
+
+var jobsCmd = &cobra.Command{
+	Use:   "jobs",
+	Short: "Show daemon background-job status",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		items, err := c.Jobs(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if jobsJSON {
+			return writeJobsJSON(cmd.OutOrStdout(), items)
+		}
+		return writeJobs(cmd.OutOrStdout(), items)
+	},
+}
+
+func writeJobsJSON(w io.Writer, items []api.Job) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(api.JobList{Items: items}); err != nil {
+		return fmt.Errorf("writing job status JSON: %w", err)
+	}
+	return nil
+}
+
+func writeJobs(w io.Writer, items []api.Job) error {
+	if len(items) == 0 {
+		if _, err := fmt.Fprintln(w, "no background jobs"); err != nil {
+			return fmt.Errorf("writing empty job list: %w", err)
+		}
+		return nil
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NAME\tSTATUS\tSTARTED\tFINISHED\tERROR"); err != nil {
+		return fmt.Errorf("writing job list header: %w", err)
+	}
+	for _, job := range items {
+		finished, problem := job.FinishedAt, job.Error
+		if finished == "" {
+			finished = "-"
+		}
+		if problem == "" {
+			problem = "-"
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			job.Name, job.Status, job.StartedAt, finished, problem); err != nil {
+			return fmt.Errorf("writing job list row: %w", err)
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("writing job list: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	jobsCmd.Flags().BoolVar(&jobsJSON, "json", false, "emit machine-readable JSON")
+	rootCmd.AddCommand(jobsCmd)
+}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -173,6 +173,23 @@ the stable snapshot summary or `error` with the normal problem fields. Treat
 EOF before that terminal line as failure. In particular, do not interpret HTTP
 200 as snapshot success: it only confirms that streaming began.
 
+## Inspect daemon background work
+
+Before relying on a configured background feature, inspect its task state:
+
+```bash
+curl --fail-with-body \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  "$DOCBANK_URL/api/v1/jobs"
+```
+
+The response is `{items: [...]}`, sorted by stable task name. Branch on
+`status`: `running` is active; `completed`, `failed`, and `cancelled` are
+terminal for this daemon run. Surface a failed task's bounded `error` to the
+operator, but do not parse its prose as a protocol. An absent item is not proof
+that work completed—it can mean the feature is unconfigured or the daemon
+restarted, because status history is intentionally process-local.
+
 ## Use revisions for read-modify-write
 
 ID-addressed move, trash, and restore operations require `If-Match`. The

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -40,8 +40,9 @@ shutdown request.
 process running `daemon run`; `docbank daemon stop` asks it to shut down;
 `docbank daemon restart` stops it (tolerating it not already running) and
 starts it again; `docbank daemon status` reports whether it's running.
-Shutdown is graceful: in-flight requests drain, the store closes, the
-vault lock releases, and the runtime record is removed — in that order,
+Shutdown is graceful: background tasks receive cancellation, in-flight
+requests drain, tasks receive a bounded window to return, the store closes,
+the vault lock releases, and the runtime record is removed — in that order,
 so a stopped daemon leaves no trace for the next `daemon start` or
 auto-start to trip over.
 
@@ -119,6 +120,22 @@ minutes) with no requests, so spawned daemons don't accumulate across
 sessions. `idle_timeout = "0"` disables idle shutdown. A foreground
 `docbank daemon run` never idles out — it runs until signaled or
 stopped.
+
+## Background tasks
+
+Every daemon-owned task runs under one supervisor rooted in the daemon's
+shutdown context. Names are unique and stable for the lifetime of that daemon;
+a task panic is recovered and recorded as a failure rather than crashing the
+process. `docbank jobs` and authenticated `GET /api/v1/jobs` expose running and
+terminal state in deterministic order. Terminal records remain until restart,
+which makes a failed task visible instead of silently disappearing.
+
+The supervisor stops accepting work as soon as shutdown begins, cancels every
+runner, and waits before SQLite and blob storage close. Runners must honor
+their context; the wait is bounded so a defective runner cannot prevent daemon
+exit forever. The background daemon's idle-timeout loop is supervised through
+this same path. Watched inboxes and scheduled maintenance are still planned,
+but must use this lifecycle rather than creating unmanaged goroutines.
 
 ## Logs
 

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -110,13 +110,17 @@ The listener closes before background tasks finish draining. During that
 interval ping-based discovery cannot identify the daemon, but its runtime
 record and process remain live while it still owns the vault lock. Public ping
 fields cannot prove that a listener appearing on the same loopback port still
-belongs to that PID; accepting such a response could send the API key to a
-locally hijacked port. A starter therefore never re-probes a pingless record or
-sends secrets to that endpoint. It requests graceful process termination only
-for the create-time-verified PID, waits for exit, and then starts replacement.
-Runtime records without create-time proof are never trusted for this path.
-This handles shutdown and the rarer uncoordinated slow-start transition without
-spawning into an owned vault or trusting a rebound listener.
+belongs to that PID. Discovery therefore follows ping with a fresh nonce
+challenge whose HMAC requires the per-run shutdown secret in the private
+runtime record; neither that secret nor the API key crosses the socket during
+the proof. Credential-bearing requests remain pinned to that proven TCP
+connection and fail rather than redirecting or reconnecting. A forged or
+pingless endpoint is never sent secrets. The starter instead requests graceful
+process termination only for the create-time-verified PID, waits for exit, and
+then starts replacement. Runtime records without create-time proof are never
+trusted for this path. This handles shutdown and the rarer uncoordinated
+slow-start transition without spawning into an owned vault or trusting a
+rebound listener.
 
 ## Auto-start and idle shutdown
 

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -44,7 +44,10 @@ Shutdown is graceful: background tasks receive cancellation, in-flight
 requests drain, tasks receive a bounded window to return, the store closes,
 the vault lock releases, and the runtime record is removed — in that order,
 so a stopped daemon leaves no trace for the next `daemon start` or
-auto-start to trip over.
+auto-start to trip over. HTTP draining and background-task draining each have
+a ten-second ceiling. Clients preserve a 25-second graceful-exit window before
+forced termination, so scheduling and cleanup do not consume either drain
+budget.
 
 ```bash
 docbank daemon run          # foreground; logs to stderr
@@ -102,6 +105,15 @@ daemon acquires the vault-tree lock. `daemon restart` reuses the same lock for
 the start half of the restart. Bootstrap stderr is captured in a private
 transient file beside that external lock, included in a startup failure, and
 removed when the start attempt finishes.
+
+The listener closes before background tasks finish draining. During that
+interval ping-based discovery cannot identify the daemon, but its runtime
+record and process remain live while it still owns the vault lock. A starter
+therefore treats a create-time-verified live runtime PID as a stopping daemon,
+waits through the complete graceful-exit budget, and only then considers
+forced termination and replacement. Runtime records without create-time proof
+are never trusted for this ping-less path. This prevents a concurrent command
+from spawning into a vault whose previous owner is still cleaning up.
 
 ## Auto-start and idle shutdown
 

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -108,15 +108,15 @@ removed when the start attempt finishes.
 
 The listener closes before background tasks finish draining. During that
 interval ping-based discovery cannot identify the daemon, but its runtime
-record and process remain live while it still owns the vault lock. A starter
-therefore treats a create-time-verified live runtime PID as an unresolved
-transition: it re-probes while waiting, reuses the daemon if it becomes healthy
-and compatible, requests authenticated shutdown if it becomes healthy but
-incompatible, and recognizes a process exit as completed cleanup. Only after
-the complete graceful-exit budget can it consider forced termination and
-replacement. Runtime records without create-time proof are never trusted for
-this ping-less path. This handles both shutdown and slow startup without
-spawning into a vault whose existing owner still holds the lock.
+record and process remain live while it still owns the vault lock. Public ping
+fields cannot prove that a listener appearing on the same loopback port still
+belongs to that PID; accepting such a response could send the API key to a
+locally hijacked port. A starter therefore never re-probes a pingless record or
+sends secrets to that endpoint. It requests graceful process termination only
+for the create-time-verified PID, waits for exit, and then starts replacement.
+Runtime records without create-time proof are never trusted for this path.
+This handles shutdown and the rarer uncoordinated slow-start transition without
+spawning into an owned vault or trusting a rebound listener.
 
 ## Auto-start and idle shutdown
 

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -109,11 +109,14 @@ removed when the start attempt finishes.
 The listener closes before background tasks finish draining. During that
 interval ping-based discovery cannot identify the daemon, but its runtime
 record and process remain live while it still owns the vault lock. A starter
-therefore treats a create-time-verified live runtime PID as a stopping daemon,
-waits through the complete graceful-exit budget, and only then considers
-forced termination and replacement. Runtime records without create-time proof
-are never trusted for this ping-less path. This prevents a concurrent command
-from spawning into a vault whose previous owner is still cleaning up.
+therefore treats a create-time-verified live runtime PID as an unresolved
+transition: it re-probes while waiting, reuses the daemon if it becomes healthy
+and compatible, requests authenticated shutdown if it becomes healthy but
+incompatible, and recognizes a process exit as completed cleanup. Only after
+the complete graceful-exit budget can it consider forced termination and
+replacement. Runtime records without create-time proof are never trusted for
+this ping-less path. This handles both shutdown and slow startup without
+spawning into a vault whose existing owner still holds the lock.
 
 ## Auto-start and idle shutdown
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -45,6 +45,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /trash` · `POST /trash/empty` `{run, older_than}` | list / report or hard-delete trash roots | Implemented |
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / re-hash all blobs | Implemented |
 | `GET /storage` · `POST /storage/pack` · `POST /storage/repack` | inspect usage / pack loose blobs / compact sparse packs | Implemented |
+| `GET /jobs` | inspect daemon-owned background tasks and terminal failures | Implemented |
 | `POST /backup/init` · `POST /backup/snapshots` · `POST /backup/snapshots/stream` · `GET /backup/snapshots` | initialize a repository / create with JSON or streamed progress / list snapshots | Implemented |
 
 Root-level, outside `/api/v1` and auth-exempt: `GET /health`, `GET
@@ -86,6 +87,15 @@ Explicit repository paths are server filesystem paths and must be absolute.
 The CLI resolves a relative `--repo` against its own working directory before
 sending it. API clients over an SSH tunnel must reason about the daemon host's
 filesystem, not the caller's. Every endpoint requires the daemon API key.
+
+### Background-job status
+
+`GET /jobs` returns `{items: [...]}` in stable job-name order. Each item carries
+`name`, `status` (`running`, `completed`, `failed`, or `cancelled`), and a UTC
+`started_at`; terminal jobs add `finished_at`, and failures add a bounded
+`error`. Records describe this daemon run only and disappear when it restarts.
+The endpoint is observation, not control: stopping a task requires stopping or
+reconfiguring the daemon feature that owns it.
 
 ### Path resolution: a query parameter, not a URL segment
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -103,6 +103,8 @@ metadata, durability rules, and physical storage primitives from
   daemon holds exclusively ([Concurrency & Locking](locking.md)).
 - **`internal/config`** — optional `config.toml` loading and the
   bind/key validation ([Configuration](../configuration.md)).
+- **`internal/jobs`** — daemon-owned background-task supervision, cancellation,
+  bounded shutdown, panic/error capture, and deterministic status snapshots.
 - **`internal/api`** — the huma v2 HTTP surface: routes, middleware,
   auth, the maintenance gate ([HTTP API](http-api.md)).
 - **`internal/client`** — the typed HTTP client plus daemon
@@ -120,6 +122,8 @@ metadata, durability rules, and physical storage primitives from
 - Kit owns application-neutral loose/packed storage mechanics; docbank owns
   catalog authority and garbage-collection policy.
 - The HTTP API is the sole data contract for clients, including the CLI.
+- Background work is daemon-owned, observable through the API, and stopped
+  before storage resources close.
 - Stable node IDs identify objects; paths are mutable addressing conveniences.
 - Trash, permanent metadata deletion, and physical byte reclamation are
   separate decisions.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,7 +11,7 @@ stderr and produce a non-zero exit code. Virtual paths are absolute,
 `/`-separated, and case-sensitive.
 
 Every data command below (`add`, `ls`, `tree`, `cat`, `mv`, `rm`,
-`restore`, `search`, `trash`, `gc`, `verify`) talks to the `docbank`
+`restore`, `search`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
 daemon over its HTTP API rather than opening the vault itself; if none
 is running, the command auto-starts one in the background. `docbank
 daemon status` and `docbank daemon stop` never auto-start. See
@@ -357,6 +357,19 @@ API protocol does not match the invoking binary is stopped and replaced
 (printed as `replaced daemon <old> (pid N) with <new>: ...`), so after
 any of them succeeds, the one running daemon is current. See
 [Daemon](architecture/daemon.md).
+
+## docbank jobs
+
+```
+docbank jobs [--json]
+```
+
+Shows daemon-owned background tasks in stable name order, including status,
+start and finish timestamps, and the bounded error recorded for a failed task.
+Running tasks have no finish timestamp; terminal task records remain visible
+until the daemon restarts. `--json` emits `{"items": [...]}` for automation.
+An empty list is normal when no configured feature has registered background
+work. See [Daemon](architecture/daemon.md).
 
 ## docbank update
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,6 +46,10 @@ marked planned appears elsewhere in these docs only under an explicit
   gc, and verify — the CLI's data commands are HTTP clients of this
   surface, with no other path into the vault
   ([design](architecture/http-api.md))
+- Daemon background-task supervision with shared cancellation, bounded
+  shutdown before storage closes, failure capture, and observable
+  `docbank jobs` / `GET /api/v1/jobs` status. Watched inbox behavior remains
+  Phase 2b work on top of this implemented lifecycle.
 - The vault lock becomes a single exclusive holder (the daemon) instead
   of Phase 1's per-command shared/exclusive split; an in-daemon
   maintenance gate replaces `gc`'s own exclusive acquisition
@@ -56,8 +60,8 @@ marked planned appears elsewhere in these docs only under an explicit
   `kit/selfupdate`, coordinating daemon stop/replace/restart
 - `docbank openapi`: offline OpenAPI document for agents and client
   generation
-- Tag-driven release pipeline building archives plus `SHA256SUMS` for
-  Linux (amd64/arm64) and macOS (arm64)
+- Tag-driven release pipeline building archives plus `SHA256SUMS` for Linux,
+  macOS, and Windows on amd64 and arm64
 - A handwritten placeholder web page at `/`, naming the vault and
   linking to `/docs`
 - Internal mixed loose/packed blob storage on `kit/packstore`: docbank's

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"go.kenn.io/docbank/internal/daemonauth"
 )
 
 const requestTimeout = 60 * time.Second
@@ -26,12 +28,12 @@ func timeoutExempt(path string) bool {
 	return strings.HasPrefix(path, "/api/v1/nodes/") && strings.HasSuffix(path, "/verify")
 }
 
-// auth-exempt: discovery, docs, and the static placeholder carry no vault
-// data. Everything else requires the key — the daemon always has one; see
-// NewServer.
+// auth-exempt: discovery, credential-free ownership proof, docs, and the
+// static placeholder carry no vault data. Everything else requires the key —
+// the daemon always has one; see NewServer.
 func authExempt(path string) bool {
 	switch path {
-	case "/", "/health", kitPingPath:
+	case "/", "/health", kitPingPath, daemonauth.ChallengePath:
 		return true
 	}
 	return strings.HasPrefix(path, "/docs") ||

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -17,7 +17,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent", "verifyNodeContent",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
 		"storageStatus", "storagePack", "storageRepack", "ingest", "uploadFile", "listTrash", "emptyTrash", "gc", "verify",
-		"initBackupRepository", "createBackupSnapshot", "listBackupSnapshots"} {
+		"initBackupRepository", "createBackupSnapshot", "listBackupSnapshots", "listJobs"} {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
 	assert.NotContains(t, doc, "/api/daemon/shutdown", "lifecycle plumbing must stay hidden")

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -21,6 +21,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
 	assert.NotContains(t, doc, "/api/daemon/shutdown", "lifecycle plumbing must stay hidden")
+	assert.NotContains(t, doc, "/api/daemon/challenge", "lifecycle plumbing must stay hidden")
 	assert.Contains(t, doc, "X-Docbank-Blob-Hash")
 	assert.Contains(t, doc, "Content-Digest")
 	assert.Contains(t, doc, "computed_hash")

--- a/internal/api/routes_jobs.go
+++ b/internal/api/routes_jobs.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+func registerJobRoutes(api huma.API, d Deps) {
+	type output struct {
+		Body JobList
+	}
+	huma.Register(api, huma.Operation{
+		OperationID: "listJobs", Method: http.MethodGet, Path: "/api/v1/jobs",
+		Summary: "List daemon background jobs and their current status",
+	}, func(_ context.Context, _ *struct{}) (*output, error) {
+		out := &output{Body: JobList{Items: []Job{}}}
+		if d.Jobs == nil {
+			return out, nil
+		}
+		for _, snapshot := range d.Jobs.Snapshot() {
+			job := Job{
+				Name: snapshot.Name, Status: string(snapshot.Status),
+				StartedAt: snapshot.StartedAt.Format(time.RFC3339Nano), Error: snapshot.Error,
+			}
+			if snapshot.FinishedAt != nil {
+				job.FinishedAt = snapshot.FinishedAt.Format(time.RFC3339Nano)
+			}
+			out.Body.Items = append(out.Body.Items, job)
+		}
+		return out, nil
+	})
+}

--- a/internal/api/routes_jobs_test.go
+++ b/internal/api/routes_jobs_test.go
@@ -1,0 +1,67 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/jobs"
+)
+
+func TestListJobsReturnsStableObservableState(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	supervisor := jobs.New(ctx, slog.New(slog.DiscardHandler))
+	t.Cleanup(func() { require.NoError(t, supervisor.Shutdown(context.Background())) })
+	running := make(chan struct{})
+	release := make(chan struct{})
+	require.NoError(t, supervisor.Start("watch:inbox", func(ctx context.Context) error {
+		close(running)
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}))
+	<-running
+	require.NoError(t, supervisor.Start("maintenance.failed", func(context.Context) error {
+		return errors.New("disk unavailable")
+	}))
+	require.Eventually(t, func() bool {
+		items := supervisor.Snapshot()
+		return len(items) == 2 && items[0].Status == jobs.StatusFailed
+	}, time.Second, time.Millisecond)
+
+	ts, _ := newTestServer(t, func(d *api.Deps) { d.Jobs = supervisor })
+	resp, body := get(t, ts, "/api/v1/jobs", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var got api.JobList
+	require.NoError(t, json.Unmarshal([]byte(body), &got))
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, "maintenance.failed", got.Items[0].Name)
+	assert.Equal(t, "failed", got.Items[0].Status)
+	assert.Equal(t, "disk unavailable", got.Items[0].Error)
+	assert.NotEmpty(t, got.Items[0].FinishedAt)
+	assert.Equal(t, "watch:inbox", got.Items[1].Name)
+	assert.Equal(t, "running", got.Items[1].Status)
+	assert.Empty(t, got.Items[1].FinishedAt)
+	close(release)
+}
+
+func TestListJobsWithoutSupervisorReturnsEmptyObject(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := get(t, ts, "/api/v1/jobs", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var got api.JobList
+	require.NoError(t, json.Unmarshal([]byte(body), &got))
+	assert.Empty(t, got.Items)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/daemonauth"
 	"go.kenn.io/docbank/internal/jobs"
 	"go.kenn.io/docbank/internal/store"
 	"go.kenn.io/docbank/internal/version"
@@ -92,6 +94,7 @@ func NewServer(d Deps) *Server {
 	mux.Handle("GET "+kitPingPath, kitdaemon.NewPingHandler(kitdaemon.PingHandlerOptions{
 		Service: "docbank", Version: version.Version, PID: os.Getpid(),
 	}))
+	s.registerChallenge(mux)
 	s.registerShutdown(mux)
 	registerWeb(mux, d.Cfg.Web.Enabled)
 
@@ -120,6 +123,26 @@ func (s *Server) registerHealth(mux *http.ServeMux) {
 			Status: "ok", Version: version.Version,
 			UptimeSeconds: int64(time.Since(s.deps.StartedAt).Seconds()),
 		})
+	})
+}
+
+// registerChallenge proves that the process answering public ping owns the
+// owner-private runtime record. The token never crosses the socket: the client
+// supplies a fresh nonce and verifies this HMAC before sending API credentials.
+func (s *Server) registerChallenge(mux *http.ServeMux) {
+	if s.deps.ShutdownToken == "" {
+		return
+	}
+	mux.HandleFunc("GET "+daemonauth.ChallengePath, func(w http.ResponseWriter, r *http.Request) {
+		nonce, err := hex.DecodeString(r.URL.Query().Get("nonce"))
+		if err != nil || len(nonce) != daemonauth.NonceBytes {
+			writeError(w, NewError(http.StatusBadRequest, "invalid_challenge",
+				"nonce must be 32 bytes encoded as hexadecimal"))
+			return
+		}
+		writeJSON(w, http.StatusOK, struct {
+			Proof string `json:"proof"`
+		}{Proof: daemonauth.Proof(s.deps.ShutdownToken, nonce)})
 	})
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/jobs"
 	"go.kenn.io/docbank/internal/store"
 	"go.kenn.io/docbank/internal/version"
 )
@@ -31,6 +32,7 @@ type Deps struct {
 	ShutdownToken string           // "" disables the shutdown route
 	Shutdown      func()           // called (async) by the shutdown route
 	Tracker       *ActivityTracker // nil → no idle tracking
+	Jobs          *jobs.Supervisor // nil → no registered background jobs
 }
 
 // Server is docbank's HTTP API: a huma-described /api/v1 surface plus a
@@ -84,6 +86,7 @@ func NewServer(d Deps) *Server {
 	registerMutateRoutes(humaAPI, d, g) // Task 6
 	registerOpsRoutes(humaAPI, d, g)    // Task 7
 	registerBackupRoutes(humaAPI, d, g)
+	registerJobRoutes(humaAPI, d)
 	registerUploadRoute(mux, humaAPI, d, g)
 	s.registerHealth(mux)
 	mux.Handle("GET "+kitPingPath, kitdaemon.NewPingHandler(kitdaemon.PingHandlerOptions{

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -20,6 +20,7 @@ import (
 	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/daemonauth"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -214,6 +215,26 @@ func TestHealthAndPing(t *testing.T) {
 	resp, body = get(t, ts, "/api/ping", nil)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, body, `"docbank"`)
+}
+
+func TestDaemonOwnershipChallengeDoesNotRequireOrRevealCredentials(t *testing.T) {
+	const token = "per-run-shutdown-secret"
+	ts, _ := newTestServer(t, func(d *api.Deps) { d.ShutdownToken = token })
+	nonce := bytes.Repeat([]byte{0x42}, daemonauth.NonceBytes)
+	path := daemonauth.ChallengePath + "?nonce=" + hex.EncodeToString(nonce)
+
+	resp, body := get(t, ts, path, map[string]string{"X-Api-Key": ""})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result struct {
+		Proof string `json:"proof"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &result))
+	assert.True(t, daemonauth.Verify(token, nonce, result.Proof))
+	assert.NotContains(t, body, token)
+
+	resp, _ = get(t, ts, daemonauth.ChallengePath+"?nonce=short",
+		map[string]string{"X-Api-Key": ""})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestAuthRequiredWhenKeySet(t *testing.T) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -229,6 +229,22 @@ type VerifyReport struct {
 	Problems []VerifyProblem `json:"problems,omitempty"`
 }
 
+// Job is the observable state of one daemon-owned background task. Names are
+// stable within a daemon run and terminal records remain visible until restart.
+type Job struct {
+	Name       string `json:"name"`
+	Status     string `json:"status" enum:"running,completed,failed,cancelled"`
+	StartedAt  string `json:"started_at"`
+	FinishedAt string `json:"finished_at,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+// JobList is returned as an object so the contract can gain aggregate state
+// without changing a top-level JSON array.
+type JobList struct {
+	Items []Job `json:"items"`
+}
+
 // BackupRepository identifies an initialized Kit snapshot repository.
 type BackupRepository struct {
 	ID   string `json:"id"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -633,6 +633,13 @@ func (c *Client) BackupList(ctx context.Context, repo string) ([]api.BackupSnaps
 	return out.Items, err
 }
 
+// Jobs returns the stable, name-sorted snapshot of daemon background work.
+func (c *Client) Jobs(ctx context.Context) ([]api.Job, error) {
+	var out api.JobList
+	err := c.do(ctx, http.MethodGet, "/api/v1/jobs", nil, nil, &out)
+	return out.Items, err
+}
+
 type BackupVerifyOptions struct {
 	Repo        string
 	SnapshotID  string

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -33,6 +33,24 @@ type Client struct {
 	hc   *http.Client
 }
 
+// responseError distinguishes an HTTP response from transport failure while
+// preserving the existing typed API error through Unwrap.
+type responseError struct {
+	status int
+	err    error
+}
+
+func (e *responseError) Error() string { return e.err.Error() }
+func (e *responseError) Unwrap() error { return e.err }
+
+func responseStatus(err error) (int, bool) {
+	var response *responseError
+	if !errors.As(err, &response) {
+		return 0, false
+	}
+	return response.status, true
+}
+
 // ContentStream exposes the catalog identity available before a download and
 // the RFC 9530 digest trailer available after Body reaches EOF. Callers prove
 // the transfer by comparing ContentDigest with the SHA-256 they compute while
@@ -78,9 +96,10 @@ func decodeError(resp *http.Response) error {
 	var e api.Error
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err := json.Unmarshal(body, &e); err != nil || e.Status == 0 {
-		return fmt.Errorf("daemon returned %s: %s", resp.Status, string(body))
+		return &responseError{status: resp.StatusCode,
+			err: fmt.Errorf("daemon returned %s: %s", resp.Status, string(body))}
 	}
-	return apiProblemError(e)
+	return &responseError{status: resp.StatusCode, err: apiProblemError(e)}
 }
 
 func apiProblemError(e api.Error) error {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -125,6 +125,13 @@ func TestAPIKeySent(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestJobsRoundTrip(t *testing.T) {
+	c, _ := newClient(t, serverKey)
+	items, err := c.Jobs(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
 func TestStoragePackRoundTrip(t *testing.T) {
 	c, _ := newClient(t, serverKey)
 	src := filepath.Join(t.TempDir(), "pack.txt")

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -108,6 +108,14 @@ func Ensure(ctx context.Context) (*Client, error) {
 // auto-start all share this path, so there is a single replacement policy and
 // no command ever leaves a stale daemon behind.
 func EnsureDaemon(ctx context.Context, root string) (EnsureResult, error) {
+	return ensureDaemon(ctx, root, Start)
+}
+
+func ensureDaemon(
+	ctx context.Context,
+	root string,
+	startFn func(context.Context, string) (kitdaemon.RuntimeRecord, error),
+) (EnsureResult, error) {
 	var res EnsureResult
 	root, err := home.CanonicalRoot(root)
 	if err != nil {
@@ -154,26 +162,20 @@ func EnsureDaemon(ctx context.Context, root string) (EnsureResult, error) {
 				return liveErr
 			}
 			if live {
-				info, responsive, waitErr := waitForRuntimeTransition(ctx, stopping)
-				if waitErr != nil {
-					return fmt.Errorf("waiting for stopping daemon (pid %d): %w",
-						stopping.PID, waitErr)
+				// A pingless endpoint is not authenticated ownership evidence: once
+				// the recorded listener closes, another local process can claim its
+				// port and forge the public ping fields. Stop only the identity-checked
+				// recorded PID, then replace it after exit; never send its API key to a
+				// listener that appeared during this transition.
+				if err := signalStopRecord(ctx, stopping); err != nil {
+					return fmt.Errorf("stopping pingless daemon (pid %d): %w",
+						stopping.PID, err)
 				}
-				if responsive {
-					if discoverOptions(true).Accept(stopping, info) {
-						res.Record = stopping
-						return nil
-					}
-					if err := stopRecord(ctx, stopping); err != nil {
-						return fmt.Errorf("stopping incompatible daemon (pid %d, %s): %w",
-							stopping.PID, stopping.Version, err)
-					}
-					res.Replaced = &stopping
-				}
+				res.Replaced = &stopping
 			}
 		}
 
-		res.Record, err = Start(ctx, root)
+		res.Record, err = startFn(ctx, root)
 		res.Started = err == nil
 		return err
 	})
@@ -312,11 +314,9 @@ func Stop(ctx context.Context, root string) (bool, error) {
 	if err != nil || !ok {
 		return false, err
 	}
-	_, responsive, err := waitForRuntimeTransition(ctx, rec)
-	if err != nil || !responsive {
-		return true, err
-	}
-	return true, stopRecord(ctx, rec)
+	// Do not probe or send secrets to a listener that may have been rebound
+	// after the recorded daemon stopped answering. Signal only the verified PID.
+	return true, signalStopRecord(ctx, rec)
 }
 
 func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
@@ -377,44 +377,6 @@ func forceStopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 		return fmt.Errorf("daemon pid %d did not exit after forced termination", rec.PID)
 	}
 	return nil
-}
-
-// waitForRuntimeTransition resolves the ambiguous pingless-record state. The
-// process may be draining, still starting, or briefly unable to answer. It
-// returns a verified ping as soon as one appears, returns responsive=false
-// when the process exits, and force-terminates only after the full grace.
-func waitForRuntimeTransition(
-	ctx context.Context, rec kitdaemon.RuntimeRecord,
-) (kitdaemon.PingInfo, bool, error) {
-	const transitionProbeTimeout = 500 * time.Millisecond
-	deadline := time.Now().Add(daemonlife.GracefulExitTimeout)
-	for time.Now().Before(deadline) {
-		if !kitdaemon.ProcessAlive(rec.PID) {
-			return kitdaemon.PingInfo{}, false, nil
-		}
-		if !createTimeMatches(rec) {
-			return kitdaemon.PingInfo{}, false,
-				errors.New("daemon PID no longer matches its recorded create time")
-		}
-		probeCtx, cancel := context.WithTimeout(ctx, transitionProbeTimeout)
-		info, err := kitdaemon.Probe(probeCtx, rec.Endpoint(), probeOptions())
-		cancel()
-		if err == nil && info.PID == rec.PID {
-			return info, true, nil
-		}
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return kitdaemon.PingInfo{}, false, ctxErr
-		}
-		select {
-		case <-ctx.Done():
-			return kitdaemon.PingInfo{}, false, ctx.Err()
-		case <-time.After(100 * time.Millisecond):
-		}
-	}
-	if err := forceStopRecord(ctx, rec); err != nil {
-		return kitdaemon.PingInfo{}, false, err
-	}
-	return kitdaemon.PingInfo{}, false, nil
 }
 
 func verifyRecordProcess(rec kitdaemon.RuntimeRecord) error {

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -317,6 +317,23 @@ func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 		if dead {
 			return nil
 		}
+		return forceStopRecord(ctx, rec)
+	}
+	// Older records without a token need the platform's graceful signal first.
+	// Current Windows records always carry a token; its fallback has no console
+	// signal equivalent and terminates through the native process handle.
+	if err := verifyRecordProcess(rec); err != nil {
+		return err
+	}
+	if err := requestProcessStop(rec.PID); err != nil {
+		return fmt.Errorf("requesting daemon pid %d stop: %w", rec.PID, err)
+	}
+	dead, err := waitDead(ctx, rec, daemonlife.GracefulExitTimeout)
+	if err != nil {
+		return fmt.Errorf("waiting for signaled daemon shutdown: %w", err)
+	}
+	if dead {
+		return nil
 	}
 	return forceStopRecord(ctx, rec)
 }
@@ -333,12 +350,11 @@ func waitForStoppingRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) err
 }
 
 func forceStopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
-	// Signal fallback only when the PID is provably still our daemon.
-	if !createTimeMatches(rec) {
-		return errors.New("daemon PID no longer matches its recorded create time; not signaling")
+	if err := verifyRecordProcess(rec); err != nil {
+		return err
 	}
-	if err := terminateProcess(rec.PID); err != nil {
-		return fmt.Errorf("signaling daemon pid %d: %w", rec.PID, err)
+	if err := forceTerminateProcess(rec.PID); err != nil {
+		return fmt.Errorf("forcibly terminating daemon pid %d: %w", rec.PID, err)
 	}
 	dead, err := waitDead(ctx, rec, daemonlife.ForcedExitTimeout)
 	if err != nil {
@@ -346,6 +362,13 @@ func forceStopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 	}
 	if !dead {
 		return fmt.Errorf("daemon pid %d did not exit after forced termination", rec.PID)
+	}
+	return nil
+}
+
+func verifyRecordProcess(rec kitdaemon.RuntimeRecord) error {
+	if !createTimeMatches(rec) {
+		return errors.New("daemon PID no longer matches its recorded create time; not signaling")
 	}
 	return nil
 }

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -2,16 +2,24 @@ package client
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	kitdaemon "go.kenn.io/kit/daemon"
 
+	"go.kenn.io/docbank/internal/daemonauth"
 	"go.kenn.io/docbank/internal/daemonlife"
 	"go.kenn.io/docbank/internal/home"
 	"go.kenn.io/docbank/internal/version"
@@ -55,13 +63,63 @@ func Find(ctx context.Context, root string) (kitdaemon.RuntimeRecord, kitdaemon.
 	return rec, info, ok, nil
 }
 
-// newClientFor authenticates with the key the daemon itself published in
+// newProvenClientFor authenticates with the key the daemon itself published in
 // its runtime record (configured or ephemeral) rather than re-reading
-// config.toml: the record's key is the one the running daemon actually
-// enforces, which matters when a background daemon was started under an
-// older config than the one on disk now.
-func newClientFor(rec kitdaemon.RuntimeRecord) *Client {
-	return New("http://"+rec.Address, rec.Metadata[metaAPIKey])
+// config.toml. Before the key can cross the socket, the endpoint must prove it
+// owns that private record, and every later request stays on the proven socket.
+func newProvenClientFor(ctx context.Context, rec kitdaemon.RuntimeRecord) (*Client, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, probeOptions().Timeout)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(probeCtx, kitdaemon.NetworkTCP, rec.Address)
+	if err != nil {
+		return nil, fmt.Errorf("dialing daemon for ownership proof: %w", err)
+	}
+	dialer := &singleConnDialer{conn: conn}
+	transport := &http.Transport{
+		Proxy:               nil,
+		DialContext:         dialer.DialContext,
+		MaxConnsPerHost:     1,
+		MaxIdleConnsPerHost: 1,
+	}
+	hc := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errors.New("daemon requests must not redirect")
+		},
+	}
+	owned, proofErr := proveOwnershipWithClient(ctx, rec, hc)
+	if proofErr != nil || !owned {
+		transport.CloseIdleConnections()
+		_ = conn.Close()
+		if proofErr != nil {
+			return nil, proofErr
+		}
+		return nil, errors.New("daemon endpoint failed ownership proof")
+	}
+	c := New("http://"+rec.Address, rec.Metadata[metaAPIKey])
+	c.hc = hc
+	return c, nil
+}
+
+// singleConnDialer gives the HTTP transport exactly the socket that completed
+// ownership proof. If that connection closes, requests fail rather than
+// reconnecting to a process that captured the loopback port.
+type singleConnDialer struct {
+	mu   sync.Mutex
+	conn net.Conn
+}
+
+func (d *singleConnDialer) DialContext(
+	_ context.Context, _, _ string,
+) (net.Conn, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.conn == nil {
+		return nil, errors.New("proven daemon connection is closed; refusing to redial")
+	}
+	conn := d.conn
+	d.conn = nil
+	return conn, nil
 }
 
 // WithLaunchLock serializes daemon auto-start with update's stop/install/
@@ -98,7 +156,7 @@ func Ensure(ctx context.Context) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newClientFor(res.Record), nil
+	return newProvenClientFor(ctx, res.Record)
 }
 
 // EnsureDaemon converges the vault on exactly one version- and
@@ -290,7 +348,69 @@ func discoverWithOptions(
 	if err != nil {
 		return rec, ping, ok, fmt.Errorf("scanning daemon runtime records: %w", err)
 	}
+	if ok {
+		owned, proofErr := proveEndpointOwnership(ctx, rec)
+		if proofErr != nil {
+			return rec, ping, false, proofErr
+		}
+		if !owned {
+			return rec, ping, false, nil
+		}
+	}
 	return rec, ping, ok, nil
+}
+
+// proveEndpointOwnership binds public ping to the owner-private runtime record
+// without transmitting its API key or shutdown token. A listener that captured
+// the port during teardown can copy ping fields but cannot forge this response.
+func proveEndpointOwnership(ctx context.Context, rec kitdaemon.RuntimeRecord) (bool, error) {
+	challengeClient := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errors.New("daemon ownership challenge must not redirect")
+		},
+	}
+	return proveOwnershipWithClient(ctx, rec, challengeClient)
+}
+
+func proveOwnershipWithClient(
+	ctx context.Context, rec kitdaemon.RuntimeRecord, challengeClient *http.Client,
+) (bool, error) {
+	token := rec.Metadata[metaShutdownToken]
+	if token == "" {
+		return false, nil
+	}
+	nonce := make([]byte, daemonauth.NonceBytes)
+	if _, err := rand.Read(nonce); err != nil {
+		return false, fmt.Errorf("generating daemon ownership challenge: %w", err)
+	}
+	u := url.URL{Scheme: "http", Host: rec.Address, Path: daemonauth.ChallengePath}
+	query := u.Query()
+	query.Set("nonce", hex.EncodeToString(nonce))
+	u.RawQuery = query.Encode()
+	probeCtx, cancel := context.WithTimeout(ctx, probeOptions().Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return false, fmt.Errorf("building daemon ownership challenge: %w", err)
+	}
+	resp, err := challengeClient.Do(req)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+		return false, nil
+	}
+	var result struct {
+		Proof string `json:"proof"`
+	}
+	limited := io.LimitReader(resp.Body, 4<<10)
+	if err := json.NewDecoder(limited).Decode(&result); err != nil {
+		return false, nil
+	}
+	_, _ = io.Copy(io.Discard, limited)
+	return daemonauth.Verify(token, nonce, result.Proof), nil
 }
 
 // Stop gracefully stops the discovered daemon: token endpoint first,
@@ -320,7 +440,12 @@ func Stop(ctx context.Context, root string) (bool, error) {
 }
 
 func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
-	c := newClientFor(rec)
+	c, proofErr := newProvenClientFor(ctx, rec)
+	if proofErr != nil {
+		// Endpoint ownership could not be proven without exposing credentials.
+		// Signal only the create-time-verified process recorded in private state.
+		return signalStopRecord(ctx, rec)
+	}
 	if token := rec.Metadata[metaShutdownToken]; token != "" {
 		// A transport failure can mean another caller already closed the listener,
 		// so preserve the drain budget. A completed HTTP rejection proves this
@@ -343,9 +468,9 @@ func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 
 func signalStopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 	// Older records without a token, and definitive HTTP rejections, need the
-	// platform's graceful signal. Current Windows records always carry a token;
-	// its fallback has no console signal equivalent and terminates through the
-	// native process handle.
+	// platform's graceful signal. Windows has no process-scoped equivalent for a
+	// detached daemon, so its request is a no-op and the complete grace window
+	// elapses before force termination.
 	if err := verifyRecordProcess(rec); err != nil {
 		return err
 	}

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -12,6 +12,7 @@ import (
 
 	kitdaemon "go.kenn.io/kit/daemon"
 
+	"go.kenn.io/docbank/internal/daemonlife"
 	"go.kenn.io/docbank/internal/home"
 	"go.kenn.io/docbank/internal/version"
 )
@@ -143,6 +144,21 @@ func EnsureDaemon(ctx context.Context, root string) (EnsureResult, error) {
 					old.PID, old.Version, err)
 			}
 			res.Replaced = &old
+		} else {
+			// Shutdown closes the listener before background jobs finish. During
+			// that window ping-based discovery returns no daemon even though the
+			// verified runtime PID still owns the vault. Wait for that owner (and
+			// only force it after the complete graceful budget) before spawning.
+			stopping, live, liveErr := liveRuntimeRecord(root)
+			if liveErr != nil {
+				return liveErr
+			}
+			if live {
+				if err := waitForStoppingRecord(ctx, stopping); err != nil {
+					return fmt.Errorf("waiting for stopping daemon (pid %d): %w",
+						stopping.PID, err)
+				}
+			}
 		}
 
 		res.Record, err = Start(ctx, root)
@@ -267,22 +283,56 @@ func discoverWithOptions(
 // SIGTERM only when create_time still matches the recorded PID. Returns
 // false when no daemon was running.
 func Stop(ctx context.Context, root string) (bool, error) {
+	root, err := home.CanonicalRoot(root)
+	if err != nil {
+		return false, err
+	}
 	rec, _, ok, err := Find(ctx, root)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		return true, stopRecord(ctx, rec)
+	}
+	// A daemon that already closed its listener can still be draining jobs.
+	// Recognize only a create-time-verified runtime PID without ping evidence.
+	rec, ok, err = liveRuntimeRecord(root)
 	if err != nil || !ok {
 		return false, err
 	}
-	return true, stopRecord(ctx, rec)
+	return true, waitForStoppingRecord(ctx, rec)
 }
 
 func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 	c := newClientFor(rec)
 	if token := rec.Metadata[metaShutdownToken]; token != "" {
-		if err := c.Shutdown(ctx, token); err == nil {
-			if waitDead(ctx, rec, 10*time.Second) {
-				return nil
-			}
+		// Even a failed request can mean the listener closed because another
+		// caller already initiated shutdown. In either case, preserve the full
+		// daemon drain budget before considering forced termination.
+		_ = c.Shutdown(ctx, token)
+		dead, err := waitDead(ctx, rec, daemonlife.GracefulExitTimeout)
+		if err != nil {
+			return fmt.Errorf("waiting for graceful daemon shutdown: %w", err)
+		}
+		if dead {
+			return nil
 		}
 	}
+	return forceStopRecord(ctx, rec)
+}
+
+func waitForStoppingRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
+	dead, err := waitDead(ctx, rec, daemonlife.GracefulExitTimeout)
+	if err != nil {
+		return fmt.Errorf("waiting for graceful daemon shutdown: %w", err)
+	}
+	if dead {
+		return nil
+	}
+	return forceStopRecord(ctx, rec)
+}
+
+func forceStopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 	// Signal fallback only when the PID is provably still our daemon.
 	if !createTimeMatches(rec) {
 		return errors.New("daemon PID no longer matches its recorded create time; not signaling")
@@ -290,23 +340,60 @@ func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 	if err := terminateProcess(rec.PID); err != nil {
 		return fmt.Errorf("signaling daemon pid %d: %w", rec.PID, err)
 	}
-	if !waitDead(ctx, rec, 10*time.Second) {
-		return fmt.Errorf("daemon pid %d did not exit after SIGTERM", rec.PID)
+	dead, err := waitDead(ctx, rec, daemonlife.ForcedExitTimeout)
+	if err != nil {
+		return fmt.Errorf("waiting for daemon after forced termination: %w", err)
+	}
+	if !dead {
+		return fmt.Errorf("daemon pid %d did not exit after forced termination", rec.PID)
 	}
 	return nil
 }
 
-func waitDead(ctx context.Context, rec kitdaemon.RuntimeRecord, timeout time.Duration) bool {
+// liveRuntimeRecord finds a non-responsive daemon only when its owner-private
+// record carries a create time that still matches a live process. Ping-less
+// records without that proof are never trusted for waiting or signaling.
+func liveRuntimeRecord(root string) (kitdaemon.RuntimeRecord, bool, error) {
+	info, err := os.Stat(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return kitdaemon.RuntimeRecord{}, false, nil
+	}
+	if err != nil {
+		return kitdaemon.RuntimeRecord{}, false,
+			fmt.Errorf("checking daemon runtime directory: %w", err)
+	}
+	if !info.IsDir() {
+		return kitdaemon.RuntimeRecord{}, false,
+			fmt.Errorf("daemon runtime path %s is not a directory", root)
+	}
+	records, err := RuntimeStore(root).List()
+	if err != nil {
+		return kitdaemon.RuntimeRecord{}, false,
+			fmt.Errorf("listing daemon runtime records: %w", err)
+	}
+	for _, rec := range records {
+		if rec.Service != Service || rec.Metadata[metaCreateTime] == "" ||
+			!kitdaemon.ProcessAlive(rec.PID) || !createTimeMatches(rec) {
+			continue
+		}
+		return rec, true, nil
+	}
+	return kitdaemon.RuntimeRecord{}, false, nil
+}
+
+func waitDead(
+	ctx context.Context, rec kitdaemon.RuntimeRecord, timeout time.Duration,
+) (bool, error) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if !kitdaemon.ProcessAlive(rec.PID) {
-			return true
+			return true, nil
 		}
 		select {
 		case <-ctx.Done():
-			return false
+			return false, ctx.Err()
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
-	return !kitdaemon.ProcessAlive(rec.PID)
+	return !kitdaemon.ProcessAlive(rec.PID), nil
 }

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -154,9 +154,21 @@ func EnsureDaemon(ctx context.Context, root string) (EnsureResult, error) {
 				return liveErr
 			}
 			if live {
-				if err := waitForStoppingRecord(ctx, stopping); err != nil {
+				info, responsive, waitErr := waitForRuntimeTransition(ctx, stopping)
+				if waitErr != nil {
 					return fmt.Errorf("waiting for stopping daemon (pid %d): %w",
-						stopping.PID, err)
+						stopping.PID, waitErr)
+				}
+				if responsive {
+					if discoverOptions(true).Accept(stopping, info) {
+						res.Record = stopping
+						return nil
+					}
+					if err := stopRecord(ctx, stopping); err != nil {
+						return fmt.Errorf("stopping incompatible daemon (pid %d, %s): %w",
+							stopping.PID, stopping.Version, err)
+					}
+					res.Replaced = &stopping
 				}
 			}
 		}
@@ -300,16 +312,23 @@ func Stop(ctx context.Context, root string) (bool, error) {
 	if err != nil || !ok {
 		return false, err
 	}
-	return true, waitForStoppingRecord(ctx, rec)
+	_, responsive, err := waitForRuntimeTransition(ctx, rec)
+	if err != nil || !responsive {
+		return true, err
+	}
+	return true, stopRecord(ctx, rec)
 }
 
 func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 	c := newClientFor(rec)
 	if token := rec.Metadata[metaShutdownToken]; token != "" {
-		// Even a failed request can mean the listener closed because another
-		// caller already initiated shutdown. In either case, preserve the full
-		// daemon drain budget before considering forced termination.
-		_ = c.Shutdown(ctx, token)
+		// A transport failure can mean another caller already closed the listener,
+		// so preserve the drain budget. A completed HTTP rejection proves this
+		// request did not initiate shutdown and uses the process-signal fallback.
+		shutdownErr := c.Shutdown(ctx, token)
+		if _, rejected := responseStatus(shutdownErr); rejected {
+			return signalStopRecord(ctx, rec)
+		}
 		dead, err := waitDead(ctx, rec, daemonlife.GracefulExitTimeout)
 		if err != nil {
 			return fmt.Errorf("waiting for graceful daemon shutdown: %w", err)
@@ -319,9 +338,14 @@ func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 		}
 		return forceStopRecord(ctx, rec)
 	}
-	// Older records without a token need the platform's graceful signal first.
-	// Current Windows records always carry a token; its fallback has no console
-	// signal equivalent and terminates through the native process handle.
+	return signalStopRecord(ctx, rec)
+}
+
+func signalStopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
+	// Older records without a token, and definitive HTTP rejections, need the
+	// platform's graceful signal. Current Windows records always carry a token;
+	// its fallback has no console signal equivalent and terminates through the
+	// native process handle.
 	if err := verifyRecordProcess(rec); err != nil {
 		return err
 	}
@@ -331,17 +355,6 @@ func stopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 	dead, err := waitDead(ctx, rec, daemonlife.GracefulExitTimeout)
 	if err != nil {
 		return fmt.Errorf("waiting for signaled daemon shutdown: %w", err)
-	}
-	if dead {
-		return nil
-	}
-	return forceStopRecord(ctx, rec)
-}
-
-func waitForStoppingRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
-	dead, err := waitDead(ctx, rec, daemonlife.GracefulExitTimeout)
-	if err != nil {
-		return fmt.Errorf("waiting for graceful daemon shutdown: %w", err)
 	}
 	if dead {
 		return nil
@@ -364,6 +377,44 @@ func forceStopRecord(ctx context.Context, rec kitdaemon.RuntimeRecord) error {
 		return fmt.Errorf("daemon pid %d did not exit after forced termination", rec.PID)
 	}
 	return nil
+}
+
+// waitForRuntimeTransition resolves the ambiguous pingless-record state. The
+// process may be draining, still starting, or briefly unable to answer. It
+// returns a verified ping as soon as one appears, returns responsive=false
+// when the process exits, and force-terminates only after the full grace.
+func waitForRuntimeTransition(
+	ctx context.Context, rec kitdaemon.RuntimeRecord,
+) (kitdaemon.PingInfo, bool, error) {
+	const transitionProbeTimeout = 500 * time.Millisecond
+	deadline := time.Now().Add(daemonlife.GracefulExitTimeout)
+	for time.Now().Before(deadline) {
+		if !kitdaemon.ProcessAlive(rec.PID) {
+			return kitdaemon.PingInfo{}, false, nil
+		}
+		if !createTimeMatches(rec) {
+			return kitdaemon.PingInfo{}, false,
+				errors.New("daemon PID no longer matches its recorded create time")
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, transitionProbeTimeout)
+		info, err := kitdaemon.Probe(probeCtx, rec.Endpoint(), probeOptions())
+		cancel()
+		if err == nil && info.PID == rec.PID {
+			return info, true, nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return kitdaemon.PingInfo{}, false, ctxErr
+		}
+		select {
+		case <-ctx.Done():
+			return kitdaemon.PingInfo{}, false, ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	if err := forceStopRecord(ctx, rec); err != nil {
+		return kitdaemon.PingInfo{}, false, err
+	}
+	return kitdaemon.PingInfo{}, false, nil
 }
 
 func verifyRecordProcess(rec kitdaemon.RuntimeRecord) error {

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -1,9 +1,13 @@
 package client
 
 import (
+	"context"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,4 +66,85 @@ func TestEnsureDiscoveryRejectsProtocolMismatch(t *testing.T) {
 	rec.Metadata[metaProtocolVersion] = "0"
 	assert.False(t, discoverOptions(true).Accept(rec, info),
 		"same-version record with a mismatched protocol revision must be replaced")
+}
+
+// TestEnsureWaitsForLiveUnresponsiveRuntime models the interval after a
+// daemon closes its listener but before a blocked background job lets the
+// process exit. A concurrent command must wait for that verified owner rather
+// than spawning a replacement that will collide with its vault lock.
+func TestEnsureWaitsForLiveUnresponsiveRuntime(t *testing.T) {
+	root, rec := startUnresponsiveRuntime(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err := EnsureDaemon(ctx, root)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.GreaterOrEqual(t, time.Since(started), 200*time.Millisecond)
+	assert.True(t, kitdaemon.ProcessAlive(rec.PID),
+		"context cancellation must not force-kill the draining daemon")
+	records, err := RuntimeStore(root).List()
+	require.NoError(t, err)
+	assert.Len(t, records, 1, "no replacement runtime record should be published")
+}
+
+func TestStopContextDoesNotKillDrainingDaemon(t *testing.T) {
+	root, rec := startUnresponsiveRuntime(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	defer cancel()
+	stopped, err := Stop(ctx, root)
+	assert.True(t, stopped, "the live runtime PID must be recognized as stopping")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.True(t, kitdaemon.ProcessAlive(rec.PID),
+		"an interrupted client wait must not force-kill valid cleanup")
+}
+
+func TestStopMissingDaemonDoesNotCreateVault(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	stopped, err := Stop(t.Context(), root)
+	require.NoError(t, err)
+	assert.False(t, stopped)
+	_, err = os.Stat(root)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func startUnresponsiveRuntime(t *testing.T) (string, kitdaemon.RuntimeRecord) {
+	t.Helper()
+	// The exact current test executable is intentional: the selected helper
+	// provides a portable child PID on Unix and Windows without a shell.
+	//nolint:gosec // os.Args[0] is not user-controlled command text in this test.
+	cmd := exec.Command(os.Args[0], "-test.run=^TestUnresponsiveDaemonHelper$")
+	cmd.Env = append(os.Environ(), "DOCBANK_UNRESPONSIVE_HELPER=1")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	var created int64
+	require.Eventually(t, func() bool {
+		var ok bool
+		created, ok = processCreateTimeMillis(cmd.Process.Pid)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond)
+
+	root := t.TempDir()
+	rec := kitdaemon.NewRuntimeRecord(Service, version.Version, kitdaemon.Endpoint{
+		Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:1",
+	})
+	rec.PID = cmd.Process.Pid
+	rec.Metadata = map[string]string{
+		metaCreateTime: strconv.FormatInt(created, 10),
+		metaAPIKey:     "key", metaProtocolVersion: daemonProtocolVersion,
+	}
+	_, err := RuntimeStore(root).Write(rec)
+	require.NoError(t, err)
+	return root, rec
+}
+
+func TestUnresponsiveDaemonHelper(_ *testing.T) {
+	if os.Getenv("DOCBANK_UNRESPONSIVE_HELPER") != "1" {
+		return
+	}
+	time.Sleep(30 * time.Second)
 }

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -21,6 +21,7 @@ import (
 	kitdaemon "go.kenn.io/kit/daemon"
 
 	"go.kenn.io/docbank/internal/daemonauth"
+	"go.kenn.io/docbank/internal/daemonlife"
 	"go.kenn.io/docbank/internal/version"
 )
 
@@ -202,8 +203,14 @@ func TestShutdownHTTPRejectionUsesProcessStop(t *testing.T) {
 
 	started := time.Now()
 	require.NoError(t, stopRecord(t.Context(), rec))
-	assert.Less(t, time.Since(started), 5*time.Second,
-		"a definitive rejection must not consume the already-stopping grace window")
+	elapsed := time.Since(started)
+	if runtime.GOOS == "windows" {
+		assert.GreaterOrEqual(t, elapsed, daemonlife.GracefulExitTimeout-time.Second,
+			"Windows must preserve graceful draining before native termination")
+	} else {
+		assert.Less(t, elapsed, 5*time.Second,
+			"a definitive rejection must take the graceful process-signal path immediately")
+	}
 	assert.False(t, kitdaemon.ProcessAlive(rec.PID))
 }
 

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,66 +71,35 @@ func TestEnsureDiscoveryRejectsProtocolMismatch(t *testing.T) {
 		"same-version record with a mismatched protocol revision must be replaced")
 }
 
-// TestEnsureWaitsForLiveUnresponsiveRuntime models the interval after a
-// daemon closes its listener but before a blocked background job lets the
-// process exit. A concurrent command must wait for that verified owner rather
-// than spawning a replacement that will collide with its vault lock.
-func TestEnsureWaitsForLiveUnresponsiveRuntime(t *testing.T) {
+// TestEnsureStopsPinglessRuntimeBeforeReplacement models both a daemon whose
+// listener closed during job draining and a startup that published its record
+// before answering. Public ping fields cannot authenticate a rebound port, so
+// Ensure signals only the verified PID and starts replacement after it exits.
+func TestEnsureStopsPinglessRuntimeBeforeReplacement(t *testing.T) {
 	root, rec := startUnresponsiveRuntime(t)
-
-	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
-	defer cancel()
-	started := time.Now()
-	_, err := EnsureDaemon(ctx, root)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.GreaterOrEqual(t, time.Since(started), 200*time.Millisecond)
-	assert.True(t, kitdaemon.ProcessAlive(rec.PID),
-		"context cancellation must not force-kill the draining daemon")
-	records, err := RuntimeStore(root).List()
+	canonicalRoot, err := filepath.EvalSymlinks(root)
 	require.NoError(t, err)
-	assert.Len(t, records, 1, "no replacement runtime record should be published")
+	started := false
+	result, err := ensureDaemon(t.Context(), root,
+		func(_ context.Context, gotRoot string) (kitdaemon.RuntimeRecord, error) {
+			started = true
+			assert.Equal(t, canonicalRoot, gotRoot)
+			assert.False(t, kitdaemon.ProcessAlive(rec.PID),
+				"replacement must wait for the recorded owner to exit")
+			return NewRecord("127.0.0.1:2", "new-key", "new-token"), nil
+		})
+	require.NoError(t, err)
+	assert.True(t, started)
+	require.NotNil(t, result.Replaced)
+	assert.Equal(t, rec.PID, result.Replaced.PID)
 }
 
-func TestStopContextDoesNotKillDrainingDaemon(t *testing.T) {
+func TestStopSignalsPinglessDaemonWithoutSendingSecrets(t *testing.T) {
 	root, rec := startUnresponsiveRuntime(t)
-	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
-	defer cancel()
-	stopped, err := Stop(ctx, root)
+	stopped, err := Stop(t.Context(), root)
 	assert.True(t, stopped, "the live runtime PID must be recognized as stopping")
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.True(t, kitdaemon.ProcessAlive(rec.PID),
-		"an interrupted client wait must not force-kill valid cleanup")
-}
-
-func TestEnsureReusesPinglessDaemonThatBecomesReady(t *testing.T) {
-	root, rec := startUnresponsiveRuntime(t)
-	var probes atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Ensure probes once before and twice inside launch coordination. Model a
-		// slow startup that becomes healthy only during transition waiting.
-		if probes.Add(1) <= 3 {
-			http.Error(w, "starting", http.StatusServiceUnavailable)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(kitdaemon.PingInfo{
-			OK: true, Service: Service, Version: version.Version, PID: rec.PID,
-		}); err != nil {
-			t.Errorf("encoding ping: %v", err)
-		}
-	}))
-	t.Cleanup(ts.Close)
-	rec.Address = strings.TrimPrefix(ts.URL, "http://")
-	_, err := RuntimeStore(root).Write(rec)
 	require.NoError(t, err)
-
-	result, err := EnsureDaemon(t.Context(), root)
-	require.NoError(t, err)
-	assert.False(t, result.Started)
-	assert.Nil(t, result.Replaced)
-	assert.Equal(t, rec.PID, result.Record.PID)
-	assert.True(t, kitdaemon.ProcessAlive(rec.PID),
-		"a compatible daemon that finishes startup must be reused")
+	assert.False(t, kitdaemon.ProcessAlive(rec.PID))
 }
 
 func TestShutdownHTTPRejectionUsesProcessStop(t *testing.T) {

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -2,10 +2,15 @@ package client
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -99,6 +104,55 @@ func TestStopContextDoesNotKillDrainingDaemon(t *testing.T) {
 		"an interrupted client wait must not force-kill valid cleanup")
 }
 
+func TestEnsureReusesPinglessDaemonThatBecomesReady(t *testing.T) {
+	root, rec := startUnresponsiveRuntime(t)
+	var probes atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Ensure probes once before and twice inside launch coordination. Model a
+		// slow startup that becomes healthy only during transition waiting.
+		if probes.Add(1) <= 3 {
+			http.Error(w, "starting", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(kitdaemon.PingInfo{
+			OK: true, Service: Service, Version: version.Version, PID: rec.PID,
+		}); err != nil {
+			t.Errorf("encoding ping: %v", err)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	rec.Address = strings.TrimPrefix(ts.URL, "http://")
+	_, err := RuntimeStore(root).Write(rec)
+	require.NoError(t, err)
+
+	result, err := EnsureDaemon(t.Context(), root)
+	require.NoError(t, err)
+	assert.False(t, result.Started)
+	assert.Nil(t, result.Replaced)
+	assert.Equal(t, rec.PID, result.Record.PID)
+	assert.True(t, kitdaemon.ProcessAlive(rec.PID),
+		"a compatible daemon that finishes startup must be reused")
+}
+
+func TestShutdownHTTPRejectionUsesProcessStop(t *testing.T) {
+	_, rec := startUnresponsiveRuntime(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"title":"Unauthorized","status":401,"code":"unauthorized"}`))
+	}))
+	t.Cleanup(ts.Close)
+	rec.Address = strings.TrimPrefix(ts.URL, "http://")
+	rec.Metadata[metaShutdownToken] = "rejected-token"
+
+	started := time.Now()
+	require.NoError(t, stopRecord(t.Context(), rec))
+	assert.Less(t, time.Since(started), 5*time.Second,
+		"a definitive rejection must not consume the already-stopping grace window")
+	assert.False(t, kitdaemon.ProcessAlive(rec.PID))
+}
+
 func TestStopMissingDaemonDoesNotCreateVault(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "missing")
 	stopped, err := Stop(t.Context(), root)
@@ -116,9 +170,18 @@ func startUnresponsiveRuntime(t *testing.T) (string, kitdaemon.RuntimeRecord) {
 	cmd := exec.Command(os.Args[0], "-test.run=^TestUnresponsiveDaemonHelper$")
 	cmd.Env = append(os.Environ(), "DOCBANK_UNRESPONSIVE_HELPER=1")
 	require.NoError(t, cmd.Start())
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
 	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("helper process did not exit")
+		}
 	})
 
 	var created int64

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -2,13 +2,17 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	kitdaemon "go.kenn.io/kit/daemon"
 
+	"go.kenn.io/docbank/internal/daemonauth"
 	"go.kenn.io/docbank/internal/version"
 )
 
@@ -94,6 +99,77 @@ func TestEnsureStopsPinglessRuntimeBeforeReplacement(t *testing.T) {
 	assert.Equal(t, rec.PID, result.Replaced.PID)
 }
 
+func TestEnsureRejectsForgedPingWithoutSendingRuntimeSecrets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows intentionally consumes the full graceful wait before force termination")
+	}
+	root, rec := startUnresponsiveRuntime(t)
+	var leaked atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != "" ||
+			r.Header.Get("X-Docbank-Daemon-Token") != "" {
+			leaked.Store(true)
+		}
+		switch r.URL.Path {
+		case kitdaemon.DefaultPingPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(kitdaemon.PingInfo{
+				OK: true, Service: Service, Version: version.Version, PID: rec.PID,
+			})
+		case daemonauth.ChallengePath:
+			_ = json.NewEncoder(w).Encode(map[string]string{"proof": "forged"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	rec.Address = strings.TrimPrefix(ts.URL, "http://")
+	_, err := RuntimeStore(root).Write(rec)
+	require.NoError(t, err)
+
+	result, err := ensureDaemon(t.Context(), root,
+		func(_ context.Context, _ string) (kitdaemon.RuntimeRecord, error) {
+			assert.False(t, kitdaemon.ProcessAlive(rec.PID))
+			return NewRecord("127.0.0.1:2", "new-key", "new-token"), nil
+		})
+	require.NoError(t, err)
+	require.NotNil(t, result.Replaced)
+	assert.Equal(t, rec.PID, result.Replaced.PID)
+	assert.False(t, leaked.Load(), "forged endpoint must receive no runtime secret")
+}
+
+func TestProvenClientRefusesRedialAfterChallengeConnectionCloses(t *testing.T) {
+	const token = "connection-proof-token"
+	var leaked atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != "" ||
+			r.Header.Get("X-Docbank-Daemon-Token") != "" {
+			leaked.Store(true)
+		}
+		if r.URL.Path != daemonauth.ChallengePath {
+			http.NotFound(w, r)
+			return
+		}
+		nonce, err := hex.DecodeString(r.URL.Query().Get("nonce"))
+		if err != nil {
+			http.Error(w, "bad nonce", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Connection", "close")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"proof": daemonauth.Proof(token, nonce),
+		})
+	}))
+	t.Cleanup(ts.Close)
+	rec := NewRecord(strings.TrimPrefix(ts.URL, "http://"), "private-api-key", token)
+
+	c, err := newProvenClientFor(t.Context(), rec)
+	require.NoError(t, err)
+	require.Error(t, c.Health(t.Context()),
+		"a closed proven connection must fail instead of redialing")
+	assert.False(t, leaked.Load(), "redial target must receive no runtime secret")
+}
+
 func TestStopSignalsPinglessDaemonWithoutSendingSecrets(t *testing.T) {
 	root, rec := startUnresponsiveRuntime(t)
 	stopped, err := Stop(t.Context(), root)
@@ -104,14 +180,25 @@ func TestStopSignalsPinglessDaemonWithoutSendingSecrets(t *testing.T) {
 
 func TestShutdownHTTPRejectionUsesProcessStop(t *testing.T) {
 	_, rec := startUnresponsiveRuntime(t)
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	rec.Metadata[metaShutdownToken] = "rejected-token"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == daemonauth.ChallengePath {
+			nonce, err := hex.DecodeString(r.URL.Query().Get("nonce"))
+			if err != nil {
+				http.Error(w, "bad nonce", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"proof": daemonauth.Proof(rec.Metadata[metaShutdownToken], nonce),
+			})
+			return
+		}
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"title":"Unauthorized","status":401,"code":"unauthorized"}`))
 	}))
 	t.Cleanup(ts.Close)
 	rec.Address = strings.TrimPrefix(ts.URL, "http://")
-	rec.Metadata[metaShutdownToken] = "rejected-token"
 
 	started := time.Now()
 	require.NoError(t, stopRecord(t.Context(), rec))
@@ -166,6 +253,7 @@ func startUnresponsiveRuntime(t *testing.T) (string, kitdaemon.RuntimeRecord) {
 	rec.Metadata = map[string]string{
 		metaCreateTime: strconv.FormatInt(created, 10),
 		metaAPIKey:     "key", metaProtocolVersion: daemonProtocolVersion,
+		metaShutdownToken: "token",
 	}
 	_, err := RuntimeStore(root).Write(rec)
 	require.NoError(t, err)

--- a/internal/client/process_unix.go
+++ b/internal/client/process_unix.go
@@ -8,13 +8,24 @@ import (
 	"syscall"
 )
 
-func terminateProcess(pid int) error {
+func requestProcessStop(pid int) error {
 	err := syscall.Kill(pid, syscall.SIGTERM)
 	if errors.Is(err, syscall.ESRCH) {
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("sending SIGTERM: %w", err)
+	}
+	return nil
+}
+
+func forceTerminateProcess(pid int) error {
+	err := syscall.Kill(pid, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("sending SIGKILL: %w", err)
 	}
 	return nil
 }

--- a/internal/client/process_unix_test.go
+++ b/internal/client/process_unix_test.go
@@ -1,0 +1,58 @@
+//go:build !windows
+
+package client
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitdaemon "go.kenn.io/kit/daemon"
+)
+
+func TestForceTerminateKillsProcessIgnoringTerm(t *testing.T) {
+	ready := filepath.Join(t.TempDir(), "ready")
+	//nolint:gosec // exact current test executable, no shell or user command text.
+	cmd := exec.Command(os.Args[0], "-test.run=^TestIgnoreTermHelper$")
+	cmd.Env = append(os.Environ(),
+		"DOCBANK_IGNORE_TERM_HELPER=1", "DOCBANK_HELPER_READY="+ready)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(ready)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, requestProcessStop(cmd.Process.Pid))
+	time.Sleep(100 * time.Millisecond)
+	assert.True(t, kitdaemon.ProcessAlive(cmd.Process.Pid), "helper must ignore SIGTERM")
+	require.NoError(t, forceTerminateProcess(cmd.Process.Pid))
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		require.Error(t, err, "SIGKILL should produce a non-success exit")
+	case <-time.After(5 * time.Second):
+		t.Fatal("helper did not exit after SIGKILL")
+	}
+}
+
+func TestIgnoreTermHelper(_ *testing.T) {
+	if os.Getenv("DOCBANK_IGNORE_TERM_HELPER") != "1" {
+		return
+	}
+	signal.Ignore(syscall.SIGTERM)
+	if err := os.WriteFile(os.Getenv("DOCBANK_HELPER_READY"), []byte("ready"), 0o600); err != nil {
+		os.Exit(2)
+	}
+	select {}
+}

--- a/internal/client/process_windows.go
+++ b/internal/client/process_windows.go
@@ -10,8 +10,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func requestProcessStop(pid int) error {
-	return killProcess(pid)
+func requestProcessStop(_ int) error {
+	// Windows has no process-scoped equivalent of SIGTERM for a detached
+	// daemon. Treat the graceful request as unsupported so the caller waits for
+	// an already-draining process through the full grace window before killing.
+	return nil
 }
 
 func forceTerminateProcess(pid int) error {

--- a/internal/client/process_windows.go
+++ b/internal/client/process_windows.go
@@ -10,7 +10,15 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func terminateProcess(pid int) error {
+func requestProcessStop(pid int) error {
+	return killProcess(pid)
+}
+
+func forceTerminateProcess(pid int) error {
+	return killProcess(pid)
+}
+
+func killProcess(pid int) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {

--- a/internal/client/process_windows_test.go
+++ b/internal/client/process_windows_test.go
@@ -4,12 +4,50 @@ package client
 
 import (
 	"math"
+	"os"
+	"os/exec"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	kitdaemon "go.kenn.io/kit/daemon"
 )
 
 func TestProcessTerminationTreatsMissingProcessAsStopped(t *testing.T) {
 	require.NoError(t, requestProcessStop(math.MaxInt32))
 	require.NoError(t, forceTerminateProcess(math.MaxInt32))
+}
+
+func TestGracefulStopDoesNotKillWindowsProcess(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWindowsGracefulStopHelper$")
+	cmd.Env = append(os.Environ(), "DOCBANK_WINDOWS_STOP_HELPER=1")
+	require.NoError(t, cmd.Start())
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("helper process did not exit")
+		}
+	})
+	require.Eventually(t, func() bool {
+		return kitdaemon.ProcessAlive(cmd.Process.Pid)
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, requestProcessStop(cmd.Process.Pid))
+	time.Sleep(100 * time.Millisecond)
+	assert.True(t, kitdaemon.ProcessAlive(cmd.Process.Pid),
+		"graceful Windows fallback must wait rather than terminate")
+}
+
+func TestWindowsGracefulStopHelper(_ *testing.T) {
+	if os.Getenv("DOCBANK_WINDOWS_STOP_HELPER") == "1" {
+		time.Sleep(30 * time.Second)
+	}
 }

--- a/internal/client/process_windows_test.go
+++ b/internal/client/process_windows_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTerminateProcessTreatsMissingProcessAsStopped(t *testing.T) {
-	require.NoError(t, terminateProcess(math.MaxInt32))
+func TestProcessTerminationTreatsMissingProcessAsStopped(t *testing.T) {
+	require.NoError(t, requestProcessStop(math.MaxInt32))
+	require.NoError(t, forceTerminateProcess(math.MaxInt32))
 }

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "9"
+	daemonProtocolVersion = "10"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/daemonauth/challenge.go
+++ b/internal/daemonauth/challenge.go
@@ -1,0 +1,37 @@
+// Package daemonauth implements proof that a discovered loopback endpoint
+// owns the private runtime record without sending either runtime secret to it.
+package daemonauth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+const (
+	// ChallengePath is lifecycle plumbing and intentionally absent from OpenAPI.
+	ChallengePath = "/api/daemon/challenge"
+	// NonceBytes keeps every ownership challenge fresh and replay-resistant.
+	NonceBytes  = 32
+	proofDomain = "docbank-daemon-ownership-v1\x00"
+)
+
+// Proof returns the domain-separated HMAC for nonce using the per-run daemon
+// token held in the owner-private runtime record.
+func Proof(token string, nonce []byte) string {
+	mac := hmac.New(sha256.New, []byte(token))
+	_, _ = mac.Write([]byte(proofDomain))
+	_, _ = mac.Write(nonce)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify reports whether proof is the expected HMAC without leaking comparison
+// timing. Malformed hexadecimal is rejected.
+func Verify(token string, nonce []byte, proof string) bool {
+	got, err := hex.DecodeString(proof)
+	if err != nil {
+		return false
+	}
+	want, err := hex.DecodeString(Proof(token, nonce))
+	return err == nil && hmac.Equal(got, want)
+}

--- a/internal/daemonauth/challenge_test.go
+++ b/internal/daemonauth/challenge_test.go
@@ -1,0 +1,18 @@
+package daemonauth
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProofVerification(t *testing.T) {
+	nonce := bytes.Repeat([]byte{0x42}, NonceBytes)
+	proof := Proof("runtime-secret", nonce)
+
+	assert.True(t, Verify("runtime-secret", nonce, proof))
+	assert.False(t, Verify("wrong-secret", nonce, proof))
+	assert.False(t, Verify("runtime-secret", append([]byte{0x00}, nonce...), proof))
+	assert.False(t, Verify("runtime-secret", nonce, "not-hex"))
+}

--- a/internal/daemonlife/timeouts.go
+++ b/internal/daemonlife/timeouts.go
@@ -1,0 +1,16 @@
+// Package daemonlife defines lifecycle budgets shared by the daemon and the
+// clients that wait for it to stop.
+package daemonlife
+
+import "time"
+
+const (
+	HTTPDrainTimeout = 10 * time.Second
+	JobDrainTimeout  = 10 * time.Second
+
+	// GracefulExitTimeout must exceed the daemon's consecutive HTTP and job
+	// drain windows. The margin covers scheduling and cleanup defers before the
+	// process exits; clients must not force termination inside this window.
+	GracefulExitTimeout = HTTPDrainTimeout + JobDrainTimeout + 5*time.Second
+	ForcedExitTimeout   = 10 * time.Second
+)

--- a/internal/daemonlife/timeouts_test.go
+++ b/internal/daemonlife/timeouts_test.go
@@ -1,0 +1,10 @@
+package daemonlife
+
+import "testing"
+
+func TestClientGraceExceedsCompleteDaemonDrainBudget(t *testing.T) {
+	if GracefulExitTimeout <= HTTPDrainTimeout+JobDrainTimeout {
+		t.Fatalf("graceful exit wait %s must exceed daemon drain budget %s",
+			GracefulExitTimeout, HTTPDrainTimeout+JobDrainTimeout)
+	}
+}

--- a/internal/jobs/supervisor.go
+++ b/internal/jobs/supervisor.go
@@ -1,0 +1,204 @@
+// Package jobs supervises daemon-owned background work.
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+var (
+	ErrClosed    = errors.New("background job supervisor is stopping")
+	ErrDuplicate = errors.New("background job name is already registered")
+	ErrInvalid   = errors.New("invalid background job")
+)
+
+// Status is the current terminal or non-terminal state of one named job.
+type Status string
+
+const (
+	StatusRunning   Status = "running"
+	StatusCompleted Status = "completed"
+	StatusFailed    Status = "failed"
+	StatusCancelled Status = "cancelled"
+)
+
+// Snapshot is a stable copy of one job's observable state.
+type Snapshot struct {
+	Name       string
+	Status     Status
+	StartedAt  time.Time
+	FinishedAt *time.Time
+	Error      string
+}
+
+type state struct {
+	Snapshot
+}
+
+// Supervisor owns a fixed set of uniquely named goroutines. Stop prevents new
+// jobs and cancels the shared root; Shutdown additionally waits for every job
+// to return before the daemon closes resources they may use.
+type Supervisor struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	logger *slog.Logger
+
+	mu       sync.Mutex
+	jobs     map[string]*state
+	active   int
+	stopping bool
+	done     chan struct{}
+	doneOnce sync.Once
+}
+
+func New(parent context.Context, logger *slog.Logger) *Supervisor {
+	if parent == nil {
+		panic("jobs: nil parent context")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	return &Supervisor{
+		ctx: ctx, cancel: cancel, logger: logger, jobs: make(map[string]*state), done: make(chan struct{}),
+	}
+}
+
+// Start registers and launches one job. Names remain reserved after a job
+// finishes so status does not silently switch to a different run.
+func (s *Supervisor) Start(name string, run func(context.Context) error) error {
+	if err := validate(name, run); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopping || s.ctx.Err() != nil {
+		return ErrClosed
+	}
+	if _, exists := s.jobs[name]; exists {
+		return fmt.Errorf("job %q: %w", name, ErrDuplicate)
+	}
+	job := &state{Snapshot: Snapshot{
+		Name: name, Status: StatusRunning, StartedAt: time.Now().UTC(),
+	}}
+	s.jobs[name] = job
+	s.active++
+	go s.run(job, run)
+	return nil
+}
+
+func (s *Supervisor) run(job *state, run func(context.Context) error) {
+	var runErr error
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			runErr = fmt.Errorf("panic: %v", recovered)
+			s.logger.Error("background job panicked", "job", job.Name,
+				"panic", recovered, "stack", string(debug.Stack()))
+		}
+		s.finish(job, runErr)
+	}()
+	runErr = run(s.ctx)
+}
+
+func (s *Supervisor) finish(job *state, runErr error) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job.FinishedAt = &now
+	switch {
+	case runErr == nil && s.ctx.Err() == nil:
+		job.Status = StatusCompleted
+	case runErr == nil || errors.Is(runErr, context.Canceled):
+		job.Status = StatusCancelled
+	default:
+		job.Status = StatusFailed
+		job.Error = boundedError(runErr)
+		s.logger.Error("background job failed", "job", job.Name, "error", runErr)
+	}
+	s.active--
+	if s.stopping && s.active == 0 {
+		s.doneOnce.Do(func() { close(s.done) })
+	}
+}
+
+// Stop requests cancellation without waiting.
+func (s *Supervisor) Stop() {
+	s.mu.Lock()
+	if !s.stopping {
+		s.stopping = true
+		s.cancel()
+	}
+	if s.active == 0 {
+		s.doneOnce.Do(func() { close(s.done) })
+	}
+	s.mu.Unlock()
+}
+
+// Shutdown stops the supervisor and waits for every registered job.
+func (s *Supervisor) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("jobs: nil shutdown context")
+	}
+	s.Stop()
+	select {
+	case <-s.done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for background jobs: %w", ctx.Err())
+	}
+}
+
+// Snapshot returns every registered job sorted by stable name.
+func (s *Supervisor) Snapshot() []Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Snapshot, 0, len(s.jobs))
+	for _, job := range s.jobs {
+		snapshot := job.Snapshot
+		if job.FinishedAt != nil {
+			finished := *job.FinishedAt
+			snapshot.FinishedAt = &finished
+		}
+		out = append(out, snapshot)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func validate(name string, run func(context.Context) error) error {
+	if run == nil {
+		return fmt.Errorf("job %q has no runner: %w", name, ErrInvalid)
+	}
+	if name == "" || len(name) > 128 {
+		return fmt.Errorf("job name must contain 1-128 characters: %w", ErrInvalid)
+	}
+	for _, char := range name {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') ||
+			strings.ContainsRune("-_.:/", char) {
+			continue
+		}
+		return fmt.Errorf("job name %q contains unsupported characters: %w", name, ErrInvalid)
+	}
+	return nil
+}
+
+func boundedError(err error) string {
+	const maxBytes = 4096
+	message := strings.ToValidUTF8(err.Error(), "\uFFFD")
+	if len(message) <= maxBytes {
+		return message
+	}
+	prefix := message[:maxBytes-3]
+	for !utf8.ValidString(prefix) {
+		prefix = prefix[:len(prefix)-1]
+	}
+	return prefix + "..."
+}

--- a/internal/jobs/supervisor_test.go
+++ b/internal/jobs/supervisor_test.go
@@ -1,0 +1,94 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupervisorTracksDeterministicTerminalStates(t *testing.T) {
+	s := New(t.Context(), discardLogger())
+	blocked := make(chan struct{})
+	require.NoError(t, s.Start("z-running", func(ctx context.Context) error {
+		close(blocked)
+		<-ctx.Done()
+		return ctx.Err()
+	}))
+	<-blocked
+	require.NoError(t, s.Start("a-complete", func(context.Context) error { return nil }))
+	require.NoError(t, s.Start("m-failed", func(context.Context) error { return errors.New("broken") }))
+
+	require.Eventually(t, func() bool {
+		jobs := s.Snapshot()
+		return len(jobs) == 3 && jobs[0].Status == StatusCompleted && jobs[1].Status == StatusFailed
+	}, time.Second, time.Millisecond)
+	jobs := s.Snapshot()
+	assert.Equal(t, []string{"a-complete", "m-failed", "z-running"},
+		[]string{jobs[0].Name, jobs[1].Name, jobs[2].Name})
+	assert.Equal(t, "broken", jobs[1].Error)
+	assert.Nil(t, jobs[2].FinishedAt)
+
+	require.NoError(t, s.Shutdown(t.Context()))
+	jobs = s.Snapshot()
+	assert.Equal(t, StatusCancelled, jobs[2].Status)
+	assert.NotNil(t, jobs[2].FinishedAt)
+}
+
+func TestSupervisorRejectsDuplicateInvalidAndPostStopJobs(t *testing.T) {
+	s := New(t.Context(), discardLogger())
+	require.ErrorIs(t, s.Start("Bad Name", func(context.Context) error { return nil }), ErrInvalid)
+	require.ErrorIs(t, s.Start("missing", nil), ErrInvalid)
+	require.NoError(t, s.Start("watch:inbox", func(context.Context) error { return nil }))
+	require.ErrorIs(t, s.Start("watch:inbox", func(context.Context) error { return nil }), ErrDuplicate)
+	require.NoError(t, s.Shutdown(t.Context()))
+	require.ErrorIs(t, s.Start("late", func(context.Context) error { return nil }), ErrClosed)
+}
+
+func TestSupervisorCapturesPanicsAndBoundsErrors(t *testing.T) {
+	s := New(t.Context(), discardLogger())
+	require.NoError(t, s.Start("panic", func(context.Context) error { panic("boom") }))
+	require.NoError(t, s.Start("long-error", func(context.Context) error {
+		return errors.New(strings.Repeat("x", 5000))
+	}))
+	require.Eventually(t, func() bool {
+		jobs := s.Snapshot()
+		return len(jobs) == 2 && jobs[0].Status == StatusFailed && jobs[1].Status == StatusFailed
+	}, time.Second, time.Millisecond)
+	jobs := s.Snapshot()
+	assert.Equal(t, "long-error", jobs[0].Name)
+	assert.Len(t, jobs[0].Error, 4096)
+	assert.Equal(t, "panic: boom", jobs[1].Error)
+	require.NoError(t, s.Shutdown(t.Context()))
+}
+
+func TestSupervisorShutdownHonorsDeadline(t *testing.T) {
+	s := New(t.Context(), discardLogger())
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	require.NoError(t, s.Start("stuck", func(context.Context) error {
+		<-release
+		return nil
+	}))
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, s.Shutdown(ctx), context.DeadlineExceeded)
+	close(release)
+	released = true
+	require.NoError(t, s.Shutdown(t.Context()))
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}


### PR DESCRIPTION
Watched inboxes and later scheduled maintenance need a safe daemon lifecycle before either feature starts doing work. The daemon previously had no common owner for long-lived tasks, so a watcher added now could fail silently or outlive the SQLite and blob resources it uses during shutdown.

This establishes one process-local supervisor with shared cancellation, bounded draining, panic and error capture, and stable task snapshots. Operators and agents can inspect those snapshots through `docbank jobs` or authenticated `GET /api/v1/jobs`; history intentionally lasts only for the current daemon run. The existing idle-timeout loop now uses the same supervision path.

The protocol revision advances so a new CLI replaces a same-version daemon that predates the status endpoint. This PR deliberately stops at lifecycle and observability: watched-inbox selection, stability policy, and ingestion behavior remain separate reviewable work on top.

The repository's required checks pass. Kata: `asvk`.