### PR TITLE
Add verified versioned content replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ maintenance.
 
 - Virtual folders with listing, tree browsing, rename, move, trash, and restore
 - Resumable bulk import and verified multipart upload
-- Stable content-version UUIDs with bounded history listing and ID-addressed
-  retrieval
+- Stable content-version UUIDs, verified content replacement, bounded history
+  listing, and ID-addressed retrieval
 - FTS5 name search (document-body extraction and search are planned)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification
@@ -50,10 +50,10 @@ maintenance.
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows
 
-Versioned content editing, permanent tamper-evident audited history, tags,
-watched inboxes, text extraction, the kit-ui web portal, and the focused TUI
-are planned rather than implemented. See the [roadmap](docs/roadmap.md) for
-the current boundary.
+Reversion and interactive editing, permanent tamper-evident audited history,
+tags, watched inboxes, text extraction, the kit-ui web portal, and the focused
+TUI are planned rather than implemented. See the [roadmap](docs/roadmap.md)
+for the current boundary.
 
 ## Installation
 
@@ -103,6 +103,7 @@ docbank add ~/Documents --dest /archive
 docbank tree /archive
 docbank search "tax return"
 docbank versions /archive/Documents/receipt.pdf
+docbank put revised-receipt.pdf /archive/Documents/receipt.pdf
 docbank mv /archive/Documents/receipt.pdf /archive/Documents/receipt-2026.pdf
 docbank verify
 ```

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -140,6 +140,51 @@ func TestAddLsTreeCat(t *testing.T) {
 	assert.Equal(t, "hello vault", out)
 }
 
+func TestPutReplacesContentAndRetainsHistory(t *testing.T) {
+	_ = setupVaultHome(t)
+	initial := writeSourceFile(t, "document.txt", "initial content")
+	_, err := runCLI(t, "add", initial, "--dest", "/inbox")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "versions", "/inbox/document.txt", "--json")
+	require.NoError(t, err)
+	var initialPage api.ContentVersionPage
+	require.NoError(t, json.Unmarshal([]byte(out), &initialPage))
+	require.Len(t, initialPage.Items, 1)
+	initialVersion := initialPage.Items[0].ID
+
+	replacement := writeSourceFile(t, "replacement.bin", "replacement content")
+	out, err = runCLI(t, "put", replacement, "/inbox/document.txt",
+		"--mime-type", "text/plain", "--progress", "plain")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "hash:")
+	assert.Contains(t, out, "upload:")
+	assert.Contains(t, out, "updated /inbox/document.txt to version")
+
+	out, err = runCLI(t, "cat", "/inbox/document.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "replacement content", out)
+	out, err = runCLI(t, "version", initialVersion, "--content")
+	require.NoError(t, err)
+	assert.Equal(t, "initial content", out, "put must retain the prior immutable bytes")
+	out, err = runCLI(t, "versions", "/inbox/document.txt")
+	require.NoError(t, err)
+	assert.Contains(t, out, "content_replace")
+	assert.Contains(t, out, "content_create")
+
+	again := writeSourceFile(t, "again.bin", "third version")
+	out, err = runCLI(t, "put", again, "/inbox/document.txt",
+		"--mime-type", "application/octet-stream", "--json")
+	require.NoError(t, err, out)
+	assert.NotContains(t, out, "hash:", "JSON output must not contain progress lines")
+	assert.NotContains(t, out, "upload:", "JSON output must not contain progress lines")
+	var receipt api.ContentReplacementReceipt
+	require.NoError(t, json.Unmarshal([]byte(out), &receipt))
+	assert.Equal(t, "content_replace", receipt.Version.TransitionKind)
+	assert.Equal(t, int64(3), receipt.Node.Revision)
+	assert.Equal(t, "application/octet-stream", receipt.Node.MimeType)
+}
+
 func TestJobsShowsDaemonStatus(t *testing.T) {
 	_ = setupVaultHome(t)
 	out, err := runCLI(t, "jobs")

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -155,7 +155,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "12", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "13", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "12", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "13", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -238,6 +238,23 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	metadataPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, versionsPID, metadataPID)
 
+	// Protocol 12 predates versioned content replacement. Replace it before
+	// put starts its two-pass transfer so the CLI cannot hash a large source
+	// only to receive a 404 from a same-version stale daemon.
+	replacementSrc := filepath.Join(t.TempDir(), "replacement.txt")
+	require.NoError(t, os.WriteFile(replacementSrc, []byte("replacement content"), 0o600))
+	recs[0].Metadata["protocol_version"] = "12"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "put", replacementSrc, "/inbox/preflight.txt", "--progress", "plain")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "updated /inbox/preflight.txt")
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	putPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, metadataPID, putPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -252,7 +269,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "12", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "13", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -265,7 +282,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, metadataPID, protocolPID)
+	assert.NotEqual(t, putPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/cmd/docbank/put.go
+++ b/cmd/docbank/put.go
@@ -43,18 +43,6 @@ var putCmd = &cobra.Command{
 		}
 		defer func() { _ = source.Close() }()
 
-		c, err := client.Ensure(cmd.Context())
-		if err != nil {
-			return err
-		}
-		target, err := c.Stat(cmd.Context(), args[1])
-		if err != nil {
-			return fmt.Errorf("resolving %q: %w", args[1], err)
-		}
-		if target.Kind != "file" {
-			return fmt.Errorf("%q: %w", args[1], store.ErrNotFile)
-		}
-
 		mimeType, err := putSourceMIME(source, sourcePath, putMIMEType)
 		if err != nil {
 			return err
@@ -81,6 +69,21 @@ var putCmd = &cobra.Command{
 		hashReader.finish()
 		if _, err := source.Seek(0, io.SeekStart); err != nil {
 			return fmt.Errorf("rewinding %s: %w", sourcePath, err)
+		}
+
+		// Keep the potentially long local pass outside the daemon lifecycle.
+		// Inspect the target only when the upload is ready to begin so an idle
+		// daemon cannot disappear while the source is being hashed.
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		target, err := c.Stat(cmd.Context(), args[1])
+		if err != nil {
+			return fmt.Errorf("resolving %q: %w", args[1], err)
+		}
+		if target.Kind != "file" {
+			return fmt.Errorf("%q: %w", args[1], store.ErrNotFile)
 		}
 
 		uploadReader := newPutProgressReader(cmd.Context(), source, size, "upload", renderer, putJSON)

--- a/cmd/docbank/put.go
+++ b/cmd/docbank/put.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/store"
+)
+
+const putProgressByteInterval = 4 << 20
+
+var (
+	putJSON     bool
+	putProgress string
+	putMIMEType string
+)
+
+var putCmd = &cobra.Command{
+	Use:   "put <source-file> <vault-path>",
+	Short: "Replace a file's content while retaining its immutable history",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		source, sourcePath, size, err := openPutSource(args[0])
+		if err != nil {
+			return err
+		}
+		defer func() { _ = source.Close() }()
+
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		target, err := c.Stat(cmd.Context(), args[1])
+		if err != nil {
+			return fmt.Errorf("resolving %q: %w", args[1], err)
+		}
+		if target.Kind != "file" {
+			return fmt.Errorf("%q: %w", args[1], store.ErrNotFile)
+		}
+
+		mimeType, err := putSourceMIME(source, sourcePath, putMIMEType)
+		if err != nil {
+			return err
+		}
+		mode := backupProgressAuto
+		if !putJSON {
+			mode, err = progressModeFromFlag("put", putProgress)
+			if err != nil {
+				return err
+			}
+		}
+		renderer := newBackupProgressRenderer(cmd.ErrOrStderr(), mode)
+		defer renderer.finish()
+
+		hash := sha256.New()
+		hashReader := newPutProgressReader(cmd.Context(), source, size, "hash", renderer, putJSON)
+		read, err := io.Copy(hash, hashReader)
+		if err != nil {
+			return fmt.Errorf("hashing %s: %w", sourcePath, err)
+		}
+		if read != size {
+			return fmt.Errorf("hashing %s: source size changed from %d to %d bytes", sourcePath, size, read)
+		}
+		hashReader.finish()
+		if _, err := source.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("rewinding %s: %w", sourcePath, err)
+		}
+
+		uploadReader := newPutProgressReader(cmd.Context(), source, size, "upload", renderer, putJSON)
+		receipt, err := c.ReplaceContent(cmd.Context(), target.ID, target.Revision, mimeType,
+			hex.EncodeToString(hash.Sum(nil)), size, uploadReader)
+		if err != nil {
+			return fmt.Errorf("replacing %q: %w", args[1], err)
+		}
+		uploadReader.finish()
+		if putJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetEscapeHTML(false)
+			if err := enc.Encode(receipt); err != nil {
+				return fmt.Errorf("writing replacement receipt: %w", err)
+			}
+			return nil
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(),
+			"updated %s to version %s (revision %d, %s, sha256 %s)\n",
+			args[1], receipt.Version.ID, receipt.Node.Revision,
+			formatBackupBytes(receipt.ComputedSize), receipt.ComputedHash)
+		if err != nil {
+			return fmt.Errorf("writing replacement receipt: %w", err)
+		}
+		return nil
+	},
+}
+
+func openPutSource(raw string) (*os.File, string, int64, error) {
+	if !utf8.ValidString(raw) {
+		return nil, "", 0, fmt.Errorf("replacement source path %s is not valid UTF-8",
+			strconv.QuoteToASCII(raw))
+	}
+	path, err := filepath.Abs(raw)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("resolving %q: %w", raw, err)
+	}
+	file, err := blob.OpenNoFollow(path)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("opening %s: %w", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, "", 0, fmt.Errorf("checking %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, "", 0, fmt.Errorf("%s: not a regular file", path)
+	}
+	if info.Size() > blob.MaxIngestBytes {
+		_ = file.Close()
+		return nil, "", 0, fmt.Errorf("%s is %d bytes; maximum replacement size is %d",
+			path, info.Size(), blob.MaxIngestBytes)
+	}
+	return file, path, info.Size(), nil
+}
+
+func putSourceMIME(source io.ReadSeeker, path, override string) (string, error) {
+	if override != "" {
+		mediaType, params, err := mime.ParseMediaType(override)
+		if err != nil {
+			return "", fmt.Errorf("invalid --mime-type %q: %w", override, err)
+		}
+		return mime.FormatMediaType(mediaType, params), nil
+	}
+	head := make([]byte, 512)
+	n, err := io.ReadFull(source, head)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return "", fmt.Errorf("reading %s for media type: %w", path, err)
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return "", fmt.Errorf("rewinding %s after media-type detection: %w", path, err)
+	}
+	if byExtension := mime.TypeByExtension(filepath.Ext(path)); byExtension != "" {
+		return byExtension, nil
+	}
+	return http.DetectContentType(head[:n]), nil
+}
+
+type putProgressReader struct {
+	ctx          context.Context
+	reader       io.Reader
+	total        int64
+	stage        string
+	renderer     *backupProgressRenderer
+	suppressed   bool
+	done         int64
+	lastRendered int64
+	lastAt       time.Time
+}
+
+func newPutProgressReader(
+	ctx context.Context, reader io.Reader, total int64, stage string,
+	renderer *backupProgressRenderer, suppressed bool,
+) *putProgressReader {
+	p := &putProgressReader{ctx: ctx, reader: reader, total: total, stage: stage,
+		renderer: renderer, suppressed: suppressed}
+	p.render(false)
+	return p
+}
+
+func (p *putProgressReader) Read(buf []byte) (int, error) {
+	if err := p.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := p.reader.Read(buf)
+	p.done += int64(n)
+	if !p.suppressed && (p.done-p.lastRendered >= putProgressByteInterval ||
+		(!p.lastAt.IsZero() && time.Since(p.lastAt) >= time.Second)) {
+		p.render(false)
+	}
+	if err == nil {
+		err = p.ctx.Err()
+	}
+	return n, err
+}
+
+func (p *putProgressReader) finish() { p.render(true) }
+
+func (p *putProgressReader) render(final bool) {
+	if p.suppressed {
+		return
+	}
+	done := int64(0)
+	if final {
+		done = 1
+	}
+	p.renderer.handle(api.BackupProgress{
+		Stage: p.stage, Done: done, Total: 1,
+		BytesDone: p.done, BytesTotal: p.total, Final: final,
+	})
+	p.lastRendered = p.done
+	p.lastAt = time.Now()
+}
+
+func init() {
+	putCmd.Flags().BoolVar(&putJSON, "json", false,
+		"emit a machine-readable replacement receipt (progress suppressed)")
+	putCmd.Flags().StringVar(&putProgress, "progress", "auto",
+		"progress output mode: auto, bar, or plain (suppressed by --json)")
+	putCmd.Flags().StringVar(&putMIMEType, "mime-type", "",
+		"override the media type detected from the source file")
+	rootCmd.AddCommand(putCmd)
+}

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -57,8 +57,8 @@ non-goals.
 2. **IDs identify nodes; paths describe current placement.** Retain a node ID
    after inspecting it. Re-resolve paths when the intent is path-specific.
 3. **Content identity is immutable.** A file node names a stable current-version
-   UUID plus SHA-256 and size. List or retrieve versions by stable ID; future
-   edits add versions rather than modifying stored bytes in place.
+   UUID plus SHA-256 and size. List or retrieve versions by stable ID; `put`
+   adds a verified immutable head rather than modifying stored bytes in place.
 4. **A stream is not verified until it finishes.** Read through successful EOF
    and require the digest evidence before publishing downloaded bytes.
 5. **Destruction has stages.** Trash is recoverable; trash empty removes tree
@@ -90,6 +90,9 @@ non-goals.
 - **Write from another machine:** upload one file with declared SHA-256, size,
   name, and destination directory ID; accept success only when the returned
   server-computed identity matches.
+- **Replace an inspected file:** retain its node ID and revision, send raw bytes
+  with declared SHA-256 and size, and require the returned node, new version,
+  computed identity, and ETag to agree before accepting success.
 - **Reorganize after inspection:** read by ID, retain the revision, and mutate
   with `If-Match`. On `stale_revision`, re-read and reconsider rather than
   blindly replaying the action.

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -243,6 +243,29 @@ If another actor changed the node first, the API returns `412` with
 A missing precondition returns `428 precondition_required`. An invalid header
 returns `400 validation`.
 
+Content replacement follows the same read-decide-write rule and adds byte
+evidence. Compute the local file's SHA-256 and size, retain the revision from
+the node response, then send raw bytes:
+
+```bash
+curl --fail-with-body -X PUT \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'If-Match: "7"' \
+  -H "X-Docbank-Blob-Hash: $SHA256" \
+  -H "X-Docbank-Blob-Size: $SIZE" \
+  -H 'Content-Type: application/pdf' \
+  --data-binary @revised.pdf \
+  "$DOCBANK_URL/api/v1/nodes/42/content"
+```
+
+Do not accept HTTP 200 alone. Require the receipt's `computed_hash` and
+`computed_size` to equal the local values; require its node and version to both
+name node 42; require `content_replace`, the next node revision, matching blob
+identity, and `node.current_version_id == version.id`; and require the response
+ETag to encode that resulting revision. The old version remains addressable.
+A `412` means the decision is stale—re-read and decide again rather than
+blindly retrying with a fresh revision.
+
 Path mutations are intentionally different. `POST /api/v1/path/move` and
 `POST /api/v1/path/trash` resolve and mutate inside one store transaction, so
 they do not accept `If-Match`. Use them for a one-shot instruction tied to the

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -6,10 +6,11 @@ description: The planned permanent, tamper-evident history contract for protecte
 # Audited history
 
 !!! info "Planned — not yet implemented"
-    Docbank does not yet record content replacements or audited history. This
-    page is the definitive contract the Phase 2b implementation will follow.
-    Current commands retain only the current file content and the metadata
-    described elsewhere in these docs.
+    Docbank records immutable `content_create` and `content_replace` versions,
+    but does not yet implement audit scopes, mutation chains, or permanent
+    protected retention. This page is the definitive contract that work will
+    follow; the current ordinary version behavior is described in
+    [Editing & Versions](editing-and-versions.md).
 
 Full audit is an opt-in promise for records whose history matters more than
 easy reclamation: tax documents, contracts, regulated work, or an external

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -79,11 +79,13 @@ docbank put revised.pdf /taxes/2025/return.pdf
 ```
 
 `put` opens a regular source without following a final symlink, detects or
-accepts its media type, hashes it, and uploads it with the target node revision
-the CLI inspected. Hashing and upload have separate progress stages because the
-daemon requires the expected SHA-256 and size before granting authority. The
-client uses `Expect: 100-continue`, allowing the daemon to reject a stale or
-invalid target before the large body is transmitted.
+accepts its media type, and hashes it before starting or contacting the daemon.
+It then inspects the target and uploads with that node revision. Keeping the
+local pass outside the daemon lifecycle avoids idle shutdown during a slow read
+and shortens the optimistic-concurrency window. Hashing and upload have separate
+progress stages because the daemon requires the expected SHA-256 and size before
+granting authority. The client uses `Expect: 100-continue`, allowing the daemon
+to reject a stale or invalid target before the large body is transmitted.
 
 The corresponding `PUT /api/v1/nodes/{id}/content` body is the raw file bytes.
 It requires `If-Match`, `X-Docbank-Blob-Hash`, and

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -10,10 +10,10 @@ is document identity; the version identifies one immutable set of bytes. Users
 and agents can list versions, inspect one by UUID, and retrieve its bytes even
 after the node moves or is renamed.
 
-Content replacement and reversion are not implemented yet, so a newly created
-file currently has exactly one version. Establishing the identity and read
-contract at ingest means later editing can add history without redefining
-existing files or backups.
+Content replacement is implemented by `docbank put` and the raw HTTP content
+write. Reversion and interactive editing are planned. Establishing one identity
+and read contract across ingest and replacement lets those later operations add
+history without redefining existing files or backups.
 
 ## Version contract
 
@@ -72,33 +72,46 @@ version IDs across loose or packed physical representations. Import rejects
 dangling current pointers, cross-node pointers, size disagreement, invalid UUIDs,
 and malformed JSON records transactionally.
 
+## Replacing content
+
+```bash
+docbank put revised.pdf /taxes/2025/return.pdf
+```
+
+`put` opens a regular source without following a final symlink, detects or
+accepts its media type, hashes it, and uploads it with the target node revision
+the CLI inspected. Hashing and upload have separate progress stages because the
+daemon requires the expected SHA-256 and size before granting authority. The
+client uses `Expect: 100-continue`, allowing the daemon to reject a stale or
+invalid target before the large body is transmitted.
+
+The corresponding `PUT /api/v1/nodes/{id}/content` body is the raw file bytes.
+It requires `If-Match`, `X-Docbank-Blob-Hash`, and
+`X-Docbank-Blob-Size`; `Content-Type` becomes version metadata. The daemon
+durably writes and independently hashes the body first. Only an exact match
+allows one transaction to create the `content_replace` record, advance
+`current_version_id`, update metadata, and bump the node revision. The response
+returns the new node and version plus the computed identity and resulting ETag.
+
+A stale revision fails with `412`; a size or digest mismatch fails with `422`.
+Neither grants new metadata or blob authority. A crash or rejection after the
+durable write may leave an authority-free loose object for ordinary GC. The old
+head remains readable throughout. Even a replacement with identical bytes
+creates a distinct version and operation while content storage deduplicates the
+shared blob.
+
 ## Planned editing model
 
 !!! info "Planned — Phase 2b"
-    A document node remains stable while its content pointer changes. Replacing
-    content will:
-
-    1. hash and durably publish the new bytes;
-    2. create an immutable content-version record for the new head, including
-       its blob hash, size, media type, introducing operation, transition kind,
-       and resulting node revision; and
-    3. point the node at that version, update metadata, and bump its revision in
-       the same SQLite transaction.
-
-    Initial ingest already creates revision-one `content_create`. Replacement
-    will create `content_replace`. Reversion will create a new `content_revert` head that names
+    Reversion will create a new `content_revert` head that names
     the older source version; it never rewinds or deletes later history. A
     metadata transaction creates at most one version for a node, enforced by
     unique `(node_id, node_revision)` and `(node_id,
     introduced_operation_id)` constraints.
 
-    Versions are whole-content snapshots, not diffs. Identical bytes still
-    deduplicate. A crash before the metadata transaction commits leaves the old
-    head intact with at most an orphan blob for GC.
-
-    Planned write surfaces are `put`, `revert`, and `edit` plus
-    `PUT /nodes/{id}/content`. ID-addressed replacement requires `If-Match` so
-    concurrent edits fail with 412 rather than losing an update.
+    Planned write surfaces are `revert` and interactive `edit`; both build on
+    the implemented immutable replacement transaction and require optimistic
+    concurrency rather than overwriting another actor's head.
 
     Version pruning is explicit and releases blob reachability only when its
     metadata row is removed. No automatic retention policy is the default. A

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -9,7 +9,7 @@ description: The agent-first HTTP API — filesystem-shaped endpoints, revision 
     The endpoints below marked **Implemented** exist in `docbank daemon run`
     today and back the CLI's data commands — the CLI is an HTTP client
     of exactly this surface, with no other path into the vault. Rows
-    under the "Planned" admonitions further down (versioned editing,
+    under the "Planned" admonitions further down (reversion,
     tags, batch move) are designed but not built; see
     [Roadmap](../roadmap.md).
 
@@ -34,6 +34,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /path?path=/a/b` | stat by virtual path | Implemented |
 | `GET /nodes/{id}/children` | list a directory, paginated (`limit`/`offset`) | Implemented |
 | `GET /nodes/{id}/content` | stream document bytes with catalog identity and a computed digest trailer | Implemented |
+| `PUT /nodes/{id}/content` | replace raw content under revision, size, and digest preconditions — see [addendum](#addendum-put-nodesidcontent) | Implemented |
 | `GET /nodes/{id}/versions` | list immutable content versions newest-first, paginated (`limit`/`offset`) | Implemented |
 | `GET /versions/{version_id}` · `GET /versions/{version_id}/content` | inspect or stream one immutable version by stable UUID | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
@@ -58,8 +59,8 @@ daemon stop`; it isn't auth-exempt, so it requires both the API key and
 its own shutdown token.
 
 !!! info "Planned"
-    Not yet implemented: `PUT /nodes/{id}/content` (versioned edit), revert,
-    and version pruning ([Editing & Versions](editing-and-versions.md));
+    Not yet implemented: revert, interactive edit, and version pruning
+    ([Editing & Versions](editing-and-versions.md));
     tags (`GET /tags` + CRUD, tag filters on search), whose IDs are opaque
     non-reusable UUIDv4 values independent of mutable names; and
     `POST /batch/move` bulk reorganization with `dry_run`.
@@ -127,6 +128,7 @@ and maintenance are explicit exceptions:
 | Endpoint | Precondition |
 |----------|--------------|
 | `PATCH /nodes/{id}` | required — target node's revision |
+| `PUT /nodes/{id}/content` | required — prevents a replacement from overwriting a head the caller did not inspect |
 | `POST /nodes/{id}/trash` | required — target node's revision |
 | `POST /nodes/{id}/restore` | required — target node's revision |
 | `POST /nodes/{id}/verify` | required — binds the evidence to the exact node state the caller inspected |
@@ -147,8 +149,9 @@ below explaining the rule.
 Every file-node representation includes a stable `current_version_id` plus
 `blob_hash`, docbank's canonical lowercase SHA-256 content identity, and raw
 `size`. Directories omit content identity. Node and version IDs are stable
-across moves and renames; a future content replacement will retain the node ID,
-create a version, and change its current pointer, hash, and revision.
+across moves and renames. Content replacement retains the node ID, creates an
+immutable version, and changes its current pointer, hash, media type, and
+revision.
 
 `GET /nodes/{id}/content` exposes the catalog identity before streaming in
 `X-Docbank-Content-Version`, `X-Docbank-Blob-Hash`, and
@@ -174,8 +177,8 @@ loose/packed store used for downloads, and returns the recorded and computed
 version ID, hashes, and sizes. Missing, corrupt, and unreadable content are successful
 reports with `verified: false` and a `problem`; transport, validation, and
 stale-node failures remain non-2xx responses. The route checks the revision
-again after reading, so a concurrent rename, trash, or future content
-replacement yields `412` instead of ambiguous evidence.
+again after reading, so a concurrent rename, trash, or content replacement
+yields `412` instead of ambiguous evidence.
 
 The single-node route is exempt from the ordinary request timeout. It is
 bounded in scope, not necessarily short in duration: hashing one very large
@@ -272,6 +275,36 @@ it. Malformed envelopes and extra parts are also rejected before authority.
 Request bodies are capped at the declared size plus bounded multipart overhead,
 and the route is exempt from the ordinary timeout so a legitimate large upload
 is governed by client cancellation rather than a one-minute deadline.
+
+## Addendum: `PUT /nodes/{id}/content`
+
+Content replacement accepts raw bytes rather than multipart. A caller first
+reads the file node and sends its revision in `If-Match`, then declares the raw
+body's canonical SHA-256 and byte count in `X-Docbank-Blob-Hash` and
+`X-Docbank-Blob-Size`. `Content-Type` is normalized and stored on the new
+version; an omitted value becomes `application/octet-stream`.
+
+The daemon streams the body into durable authority-free storage and computes
+the identity independently. Only exact agreement permits one metadata
+transaction to create a `content_replace` version, advance the node's current
+pointer, and bump its revision. The old head remains an immutable GC root. A
+successful response includes the resulting ETag plus a receipt containing the
+node, new version, `computed_hash`, and `computed_size`; clients compare every
+field with the request before accepting success.
+
+Clients should send `Expect: 100-continue` for large writes. The daemon checks
+the target kind and revision before its first body read, then repeats those
+checks in the committing metadata transaction. The early check avoids wasting
+bandwidth; only the transactional check grants authority.
+
+Stale revisions return `412 stale_revision`; missing preconditions return
+`428 precondition_required`; identity disagreements return
+`422 digest_mismatch` or `422 size_mismatch`. A failed operation grants no new
+catalog authority, although a completely written loose object can remain
+authority-free until GC. Because the body may be binary, this route is an
+explicit exception to the raw JSON text validator; its byte count and digest
+are the lossless boundary instead. Cancellation propagates through physical
+writing and prevents the metadata transaction.
 
 !!! info "Planned"
     Ingest provenance today is filesystem-shaped: each import records

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -83,9 +83,10 @@ metadata, durability rules, and physical storage primitives from
 
 Every imported file starts with a stable content-version UUID. Version listing,
 metadata lookup, and byte retrieval are implemented independently of the node's
-mutable path. Content replacement and reversion remain planned; they will add
-immutable versions and move the node's current pointer rather than rewriting a
-blob. See [Editing & Versions](editing-and-versions.md).
+mutable path. Content replacement adds an immutable version and moves the
+node's current pointer under a revision precondition rather than rewriting a
+blob. Reversion remains planned. See
+[Editing & Versions](editing-and-versions.md).
 
 !!! info "Planned — full audit"
     Selected directory scopes will be able to retain every authoritative
@@ -136,9 +137,9 @@ blob. See [Editing & Versions](editing-and-versions.md).
   separate decisions.
 
 !!! info "Planned — later clients and features"
-    Versioned editing, full audit, tags, watched inboxes, text extraction, the
-    kit-ui web portal, and the focused TUI remain planned. Later clients must
-    not bypass the implemented backup and restore API.
+    Reversion, interactive editing, full audit, tags, watched inboxes, text
+    extraction, the kit-ui web portal, and the focused TUI remain planned.
+    Later clients must not bypass the implemented backup and restore API.
     Backup initialization, creation, listing, verification, and restore use the
     daemon boundary above. Later features must not introduce a privileged path
     around the daemon or mutable blob bytes. See the [Roadmap](../roadmap.md).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -131,14 +131,16 @@ redirected lines, and `plain` always emits durable lines. `--json` suppresses
 progress and returns the new node, immutable version, and server-computed hash
 and size. `--mime-type` overrides extension/content detection.
 
-The command resolves the target to a stable node ID and revision before
-hashing. The raw `PUT` carries that revision as `If-Match`; if another actor
-moves, trashes, or replaces the node first, the operation fails with
-`stale_revision` rather than losing the concurrent update. A successful put
-bumps the node revision, creates a `content_replace` version, and leaves the
-older bytes reachable through `docbank version <id> --content`. Replacing with
-identical bytes still records an explicit versioned operation while the blob
-itself deduplicates.
+The command completes its local hash before starting or contacting the daemon,
+then resolves the target to a stable node ID and revision immediately before
+upload. This keeps a slow local read outside the daemon's idle lifetime and
+shortens the optimistic-concurrency window. The raw `PUT` carries the inspected
+revision as `If-Match`; if another actor moves, trashes, or replaces the node
+afterward, the operation fails with `stale_revision` rather than losing the
+concurrent update. A successful put bumps the node revision, creates a
+`content_replace` version, and leaves the older bytes reachable through
+`docbank version <id> --content`. Replacing with identical bytes still records
+an explicit versioned operation while the blob itself deduplicates.
 
 ## docbank versions
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,7 @@ All commands operate on the vault at `~/.docbank` (override with
 stderr and produce a non-zero exit code. Virtual paths are absolute,
 `/`-separated, and case-sensitive.
 
-Every data command below (`add`, `ls`, `tree`, `cat`, `mv`, `rm`,
+Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `versions`, `version`, `mv`, `rm`,
 `restore`, `search`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
 daemon over its HTTP API rather than opening the vault itself; if none
 is running, the command auto-starts one in the background. `docbank
@@ -114,6 +114,32 @@ docbank cat <path>
 Streams the file's stored bytes to stdout. Fails with `not a file` for
 directories.
 
+## docbank put
+
+```text
+docbank put <source-file> <vault-path> [--mime-type <type>] [--progress auto|bar|plain] [--json]
+```
+
+Replaces one existing file's current content while retaining every prior
+immutable version. The source must be a regular file and is opened without
+following a final symlink. It is never modified.
+
+`put` reads the source twice: first to compute the SHA-256 and exact size the
+daemon must independently verify, then to upload the bytes. Human mode shows
+separate `hash` and `upload` progress; `auto` uses a terminal bar or durable
+redirected lines, and `plain` always emits durable lines. `--json` suppresses
+progress and returns the new node, immutable version, and server-computed hash
+and size. `--mime-type` overrides extension/content detection.
+
+The command resolves the target to a stable node ID and revision before
+hashing. The raw `PUT` carries that revision as `If-Match`; if another actor
+moves, trashes, or replaces the node first, the operation fails with
+`stale_revision` rather than losing the concurrent update. A successful put
+bumps the node revision, creates a `content_replace` version, and leaves the
+older bytes reachable through `docbank version <id> --content`. Replacing with
+identical bytes still records an explicit versioned operation while the blob
+itself deduplicates.
+
 ## docbank versions
 
 ```text
@@ -126,9 +152,8 @@ Human output marks the node's current version. `--json` emits
 `{"items": [...], "total", "limit", "offset"}` so callers can distinguish a
 complete page from a prefix.
 
-Every newly imported file has one revision-one `content_create` version.
-Replacement and reversion are not implemented yet, so more than one row appears
-only after those write surfaces ship.
+Every newly imported file has one revision-one `content_create` version. Each
+successful `put` adds a `content_replace` row. Reversion is not implemented yet.
 
 ## docbank version
 
@@ -451,7 +476,7 @@ background-spawned daemons.
 
 !!! info "Planned — later phases"
     The following are designed but not yet implemented; they will appear
-    here with exact semantics when they ship. `docbank edit`, `put`, and
+    here with exact semantics when they ship. `docbank edit` and
     `revert` (Phase 2b, [Editing & Versions](architecture/editing-and-versions.md));
     `docbank audit enable`, `audit status`, `audit history`, and `audit verify`
     (Phase 2b, [Audited History](architecture/audited-history.md));

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,9 @@ storage (one blob per unique content, named by its SHA-256), and the
 organizing structure is a **virtual tree stored in SQLite**. Moves,
 renames, and reorganization are metadata transactions that never touch bytes.
 
-Every imported file starts with a stable content-version UUID. Versions can be
-listed and retrieved independently of mutable paths; planned editing will add
-new immutable heads rather than rewrite bytes. See
+Every imported file starts with a stable content-version UUID. `docbank put`
+adds a verified immutable head without rewriting or discarding prior bytes;
+versions can be listed and retrieved independently of mutable paths. See
 [Editing & Versions](architecture/editing-and-versions.md).
 
 !!! info "Planned — full audit"
@@ -65,6 +65,7 @@ docbank add ~/Documents/taxes --dest /taxes   # bulk import, resumable
 docbank tree /taxes                           # browse the virtual tree
 docbank search "insurance"                    # indexed name search
 docbank versions /taxes/2026/return.pdf       # inspect stable content identity
+docbank put revised.pdf /taxes/2026/return.pdf # retain the prior version
 docbank mv "/inbox/scan (2).pdf" /taxes/2026  # reorganize, metadata only
 docbank rm /inbox/junk.pdf                    # trash, recoverable
 docbank trash empty --run                     # permanently delete trash metadata
@@ -116,12 +117,13 @@ docbank is alpha software with tagged releases. The core store and ingest
 pipeline, virtual-tree CLI, authenticated daemon API, packed storage,
 integrity verification, and incremental backup creation, verification, and
 restore are implemented and tested. Stable content-version listing and
-ID-addressed retrieval work through loose/packed storage and backup restore.
+ID-addressed retrieval and verified replacement work through loose/packed
+storage and backup restore.
 Representative-corpus hardening and
 distribution work continue before a stable 1.0 release.
 
 !!! info "Planned — later phases"
-    Versioned editing, full audited history, tags, watched inboxes,
+    Reversion and interactive editing, full audited history, tags, watched inboxes,
     content-text extraction and search, the kit-ui web portal, and the focused
     TUI are designed but not yet built. The
     [Roadmap](roadmap.md) tracks what exists versus what is planned.

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -135,7 +135,7 @@ share a blob without sharing document identity.
 Canonical blobs are immutable SHA-256 objects. Rewriting bytes in place would
 make the path lie about content identity, surprise every deduplicated reader,
 and lose crash-safe history. All logical mutation therefore happens in SQLite:
-moves, renames, trash, restore, and future content-pointer replacement.
+moves, renames, trash, restore, and content-pointer replacement.
 
 The schema enforces the invariants that every writer must obey:
 
@@ -176,6 +176,14 @@ eligible. It does not rehash same-sized bytes on every duplicate ingest because
 that doubles common-path I/O without systematically protecting existing
 references. Full content validation belongs to `verify`, which covers every
 authorized blob.
+
+Content replacement uses the same ordering. A cheap node/revision check occurs
+before reading a potentially large request, but it is only an optimization.
+After durable publication, the metadata transaction repeats the target and
+revision checks, authorizes the blob, inserts one `content_replace` version,
+advances the current pointer, and bumps the node revision. A race or failed
+precondition may leave an untracked physical object, never a half-installed
+head.
 
 ## Ingest convergence
 
@@ -443,7 +451,8 @@ actual released formats and fixtures rather than speculative migration work.
 
 - External references need a liveness policy before their schema exists:
   pin blob authority, or allow dangling-reference detection in the referrer.
-- Version writers must preserve bytes-before-reference ordering and add their
-  rows to reachability atomically with pointer replacement.
+- Revert and future version writers must preserve the implemented
+  bytes-before-reference ordering and add rows to reachability atomically with
+  pointer replacement.
 - Pack and repack maintenance commands must remain daemon/API operations; no
   CLI path may open the physical store directly.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,11 +94,12 @@ docbank put ~/Documents/revised-checklist.pdf /taxes/checklist.pdf
 docbank versions /taxes/checklist.pdf
 ```
 
-`put` hashes the source and then uploads it, showing separate progress for both
-passes. It requires the target revision observed before hashing, so a concurrent
-change fails instead of being overwritten. The prior version remains available
-through `docbank version <old-version-id> --content`. Reversion is planned; it
-will create another immutable head rather than rewind history.
+`put` hashes the source before contacting the daemon, then inspects the target
+and uploads it, showing separate progress for both file passes. The upload
+requires that freshly observed target revision, so a concurrent change fails
+instead of being overwritten. The prior version remains available through
+`docbank version <old-version-id> --content`. Reversion is planned; it will
+create another immutable head rather than rewind history.
 
 ## Reorganize
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -86,8 +86,19 @@ docbank version <version-id> --json
 docbank version <version-id> --content > /tmp/checklist-version.pdf
 ```
 
-The version ID survives node renames and moves. New files currently have one
-`content_create` version; editing and reversion will add history later.
+The version ID survives node renames and moves. Replace the current content
+without changing the stable file node:
+
+```bash
+docbank put ~/Documents/revised-checklist.pdf /taxes/checklist.pdf
+docbank versions /taxes/checklist.pdf
+```
+
+`put` hashes the source and then uploads it, showing separate progress for both
+passes. It requires the target revision observed before hashing, so a concurrent
+change fails instead of being overwritten. The prior version remains available
+through `docbank version <old-version-id> --content`. Reversion is planned; it
+will create another immutable head rather than rewind history.
 
 ## Reorganize
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,7 @@ marked planned appears elsewhere in these docs only under an explicit
 | 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.9.2) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
-| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: version identity and reads implemented; remaining work designed |
+| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: version identity, reads, and verified replacement implemented; remaining work designed |
 | 3 | Primary kit-ui web portal and focused operator TUI | Designed |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
@@ -87,9 +87,11 @@ identity through loose and packed storage. File-node responses expose current
 version plus immutable SHA-256 identity; content streams carry both catalog
 identities plus a freshly computed digest trailer. Remote writers must declare
 SHA-256 and size, and receive the stable node/version plus server-computed
-identity only after both match.
+identity only after both match. `docbank put` and raw
+`PUT /nodes/{id}/content` now add a digest-checked `content_replace` head under
+an optimistic revision precondition while retaining every prior version.
 
-- Remaining editing surfaces: `PUT` content and `docbank edit`/`put`/`revert`
+- Remaining editing surfaces: `docbank edit` and `docbank revert`
   ([design](architecture/editing-and-versions.md))
 - Full-audit directory scopes with sticky membership, complete authoritative
   change and content-version retention, tamper-evident history, maintenance

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -28,7 +28,11 @@ func timeoutExempt(path string) bool {
 		"/api/v1/backup/restore", "/api/v1/backup/restore/stream":
 		return true
 	}
-	return strings.HasPrefix(path, "/api/v1/nodes/") && strings.HasSuffix(path, "/verify")
+	if strings.HasPrefix(path, "/api/v1/nodes/") &&
+		(strings.HasSuffix(path, "/verify") || strings.HasSuffix(path, "/content")) {
+		return true
+	}
+	return strings.HasPrefix(path, "/api/v1/versions/") && strings.HasSuffix(path, "/content")
 }
 
 // auth-exempt: discovery, credential-free ownership proof, docs, and the
@@ -98,11 +102,11 @@ func isServerPathIngestRoute(path string) bool {
 // byte-for-byte or a mutation could target a different, replacement-character
 // node. Every mutating request is text-validated regardless of Content-Type:
 // Huma accepts an omitted Content-Type for body-bound operations, and malformed
-// headers must not bypass the boundary. The upload route is the daemon's sole
-// opaque-body mutation and validates its multipart envelope separately.
+// headers must not bypass the boundary. Explicit content-write routes carry
+// opaque bytes and validate their own size, digest, and transport envelope.
 func jsonBodyTextMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Body == nil || !mutationMethod(r.Method) || r.URL.Path == "/api/v1/uploads" {
+		if r.Body == nil || !mutationMethod(r.Method) || isOpaqueBodyMutation(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -119,6 +123,15 @@ func jsonBodyTextMiddleware(next http.Handler) http.Handler {
 		r.Body = io.NopCloser(bytes.NewReader(body))
 		next.ServeHTTP(w, r)
 	})
+}
+
+func isOpaqueBodyMutation(r *http.Request) bool {
+	if r.Method == http.MethodPost && r.URL.Path == "/api/v1/uploads" {
+		return true
+	}
+	return r.Method == http.MethodPut &&
+		strings.HasPrefix(r.URL.Path, "/api/v1/nodes/") &&
+		strings.HasSuffix(r.URL.Path, "/content")
 }
 
 func mutationMethod(method string) bool {

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -60,4 +60,10 @@ func TestOpenAPIDeclaresDigestCheckedUpload(t *testing.T) {
 	}
 	assert.NotNil(t, op.Responses["200"])
 	assert.NotNil(t, op.Responses["201"])
+
+	replace := doc.Paths["/api/v1/nodes/{id}/content"].Put
+	require.NotNil(t, replace)
+	require.NotNil(t, replace.RequestBody)
+	assert.Contains(t, replace.RequestBody.Content, "*/*")
+	assert.NotNil(t, replace.Responses["200"])
 }

--- a/internal/api/routes_content_write.go
+++ b/internal/api/routes_content_write.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/docbank/internal/ingest"
+)
+
+func registerContentWriteRoute(mux *http.ServeMux, api huma.API, d Deps, g *gate) {
+	registerContentWriteOpenAPI(api)
+	mux.HandleFunc("PUT /api/v1/nodes/{id}/content", func(w http.ResponseWriter, r *http.Request) {
+		handleContentWrite(w, r, d, g)
+	})
+}
+
+func registerContentWriteOpenAPI(api huma.API) {
+	registry := api.OpenAPI().Components.Schemas
+	receiptSchema := huma.SchemaFromType(registry, reflect.TypeFor[ContentReplacementReceipt]())
+	errorSchema := huma.SchemaFromType(registry, reflect.TypeFor[Error]())
+	api.OpenAPI().AddOperation(&huma.Operation{
+		OperationID: "replaceNodeContent", Method: http.MethodPut,
+		Path: "/api/v1/nodes/{id}/content", Summary: "Replace a file's content with a new immutable head",
+		Description: "Streams raw content under an If-Match node revision. The daemon grants " +
+			"metadata authority only after independently computing the declared SHA-256 and size.",
+		Parameters: []*huma.Param{
+			{Name: "id", In: "path", Required: true, Description: "Stable file node ID",
+				Schema: &huma.Schema{Type: "integer", Format: "int64"}},
+			{Name: "If-Match", In: "header", Required: true, Description: "Quoted or bare current node revision",
+				Schema: &huma.Schema{Type: openAPIStringType}},
+			{Name: BlobHashHeader, In: "header", Required: true,
+				Description: "Expected lowercase hexadecimal SHA-256 of the request body",
+				Schema:      &huma.Schema{Type: openAPIStringType, Pattern: "^[0-9a-f]{64}$"}},
+			{Name: BlobSizeHeader, In: "header", Required: true,
+				Description: "Expected raw request-body byte length",
+				Schema:      &huma.Schema{Type: "integer", Format: "int64", Minimum: new(float64(0))}},
+		},
+		RequestBody: &huma.RequestBody{Required: true, Content: map[string]*huma.MediaType{
+			"*/*": {Schema: &huma.Schema{Type: openAPIStringType, Format: "binary"}},
+		}},
+		Responses: map[string]*huma.Response{
+			"200": {Description: "Replacement committed", Headers: map[string]*huma.Param{
+				"ETag": {Description: "Quoted resulting node revision", Schema: &huma.Schema{Type: openAPIStringType}},
+			}, Content: map[string]*huma.MediaType{"application/json": {Schema: receiptSchema}}},
+			"default": {Description: "Error", Content: map[string]*huma.MediaType{
+				"application/problem+json": {Schema: errorSchema},
+			}},
+		},
+	})
+}
+
+func handleContentWrite(w http.ResponseWriter, r *http.Request, d Deps, g *gate) {
+	nodeID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || nodeID <= 0 {
+		writeError(w, NewError(http.StatusUnprocessableEntity, "validation",
+			"node id must be a positive integer"))
+		return
+	}
+	ifRev, matchErr := parseIfMatch(r.Header.Get("If-Match"))
+	if matchErr != nil {
+		apiErr := &Error{}
+		ok := errors.As(matchErr, &apiErr)
+		if !ok {
+			apiErr = NewError(http.StatusInternalServerError, "internal", matchErr.Error())
+		}
+		writeError(w, apiErr)
+		return
+	}
+	expectedHash, expectedSize, identityErr := parseExpectedBlobIdentity(r)
+	if identityErr != nil {
+		writeError(w, identityErr)
+		return
+	}
+	if r.ContentLength >= 0 && r.ContentLength != expectedSize {
+		writeError(w, NewError(http.StatusUnprocessableEntity, "size_mismatch", fmt.Sprintf(
+			"declared %d bytes, HTTP body reports %d", expectedSize, r.ContentLength)))
+		return
+	}
+	mimeType, mimeErr := uploadMediaType(r.Header.Get("Content-Type"))
+	if mimeErr != nil {
+		writeError(w, NewError(http.StatusUnprocessableEntity, "validation", mimeErr.Error()))
+		return
+	}
+
+	var result ingest.ReplacementResult
+	opErr := g.mutate(func() error {
+		return d.Blobs.WithMutation(r.Context(), func() error {
+			limited := &io.LimitedReader{R: r.Body, N: expectedSize + 1}
+			ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
+			var replaceErr error
+			result, replaceErr = ing.ReplaceContent(r.Context(), nodeID, ifRev, mimeType,
+				limited, expectedHash, expectedSize)
+			return replaceErr
+		})
+	})
+	if opErr != nil {
+		writeError(w, uploadError(opErr))
+		return
+	}
+	w.Header().Set("ETag", fmt.Sprintf("%q", strconv.FormatInt(result.Node.Revision, 10)))
+	writeJSON(w, http.StatusOK, ContentReplacementReceipt{
+		Node: fromStoreNode(result.Node), Version: fromStoreContentVersion(result.Version),
+		ComputedHash: result.ComputedHash, ComputedSize: result.ComputedSize,
+	})
+}

--- a/internal/api/routes_content_write_test.go
+++ b/internal/api/routes_content_write_test.go
@@ -1,0 +1,167 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func sendContentReplacement(
+	t *testing.T, tsURL string, client *http.Client, nodeID, revision int64,
+	content []byte, expectedHash string, expectedSize int64, contentType string,
+) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut,
+		fmt.Sprintf("%s/api/v1/nodes/%d/content", tsURL, nodeID), bytes.NewReader(content))
+	require.NoError(t, err)
+	req.Header.Set("If-Match", fmt.Sprintf("%q", strconv.FormatInt(revision, 10)))
+	req.Header.Set(api.BlobHashHeader, expectedHash)
+	req.Header.Set(api.BlobSizeHeader, strconv.FormatInt(expectedSize, 10))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, body
+}
+
+func TestContentReplacementCreatesVerifiedImmutableHead(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	created := createFileWithContent(t, ts, s, "/report.bin", "old content")
+	oldVersion := created.CurrentVersionID
+	content := []byte{0x00, 0xff, 0x10, 0x80, 'n', 'e', 'w'}
+	hash := uploadIdentity(content)
+
+	resp, body := sendContentReplacement(t, ts.URL, ts.Client(), created.ID, created.Revision,
+		content, hash, int64(len(content)), "application/octet-stream")
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	assert.Equal(t, `"2"`, resp.Header.Get("ETag"))
+	var receipt api.ContentReplacementReceipt
+	require.NoError(t, json.Unmarshal(body, &receipt))
+	assert.Equal(t, created.ID, receipt.Node.ID)
+	assert.Equal(t, created.Revision+1, receipt.Node.Revision)
+	assert.Equal(t, receipt.Version.ID, receipt.Node.CurrentVersionID)
+	assert.Equal(t, "content_replace", receipt.Version.TransitionKind)
+	assert.Equal(t, hash, receipt.ComputedHash)
+	assert.Equal(t, int64(len(content)), receipt.ComputedSize)
+	assert.Equal(t, hash, receipt.Version.BlobHash)
+	assert.Equal(t, "application/octet-stream", receipt.Version.MimeType)
+
+	contentResp, err := ts.Client().Get(fmt.Sprintf("%s/api/v1/nodes/%d/content", ts.URL, created.ID))
+	require.NoError(t, err)
+	currentBody, err := io.ReadAll(contentResp.Body)
+	require.NoError(t, err)
+	require.NoError(t, contentResp.Body.Close())
+	assert.Equal(t, http.StatusOK, contentResp.StatusCode)
+	assert.Equal(t, content, currentBody, "opaque binary bytes must bypass JSON text validation unchanged")
+	assert.Equal(t, receipt.Version.ID, contentResp.Header.Get(api.ContentVersionHeader))
+
+	oldResp, err := ts.Client().Get(ts.URL + "/api/v1/versions/" + oldVersion + "/content")
+	require.NoError(t, err)
+	oldBody, err := io.ReadAll(oldResp.Body)
+	require.NoError(t, err)
+	require.NoError(t, oldResp.Body.Close())
+	assert.Equal(t, http.StatusOK, oldResp.StatusCode)
+	assert.Equal(t, []byte("old content"), oldBody)
+
+	versions, total, err := s.ContentVersions(t.Context(), created.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, versions, 2)
+	assert.Equal(t, receipt.Version.ID, versions[0].ID)
+	assert.Equal(t, oldVersion, versions[1].ID)
+}
+
+func TestContentReplacementRejectsMismatchWithoutChangingAuthority(t *testing.T) {
+	tests := []struct {
+		name         string
+		revision     func(store.Node) int64
+		expectedHash func([]byte) string
+		expectedSize func([]byte) int64
+		wantStatus   int
+		wantCode     string
+	}{
+		{name: "stale revision", revision: func(n store.Node) int64 { return n.Revision + 1 },
+			wantStatus: http.StatusPreconditionFailed, wantCode: "stale_revision"},
+		{name: "digest mismatch", expectedHash: func([]byte) string { return uploadIdentity([]byte("other")) },
+			wantStatus: http.StatusUnprocessableEntity, wantCode: "digest_mismatch"},
+		{name: "short declaration", expectedSize: func(body []byte) int64 { return int64(len(body) - 1) },
+			wantStatus: http.StatusUnprocessableEntity, wantCode: "size_mismatch"},
+		{name: "long declaration", expectedSize: func(body []byte) int64 { return int64(len(body) + 1) },
+			wantStatus: http.StatusUnprocessableEntity, wantCode: "size_mismatch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, s := newTestServer(t, nil)
+			created := createFileWithContent(t, ts, s, "/report.txt", "old content")
+			content := []byte("replacement")
+			revision := created.Revision
+			if tt.revision != nil {
+				revision = tt.revision(created)
+			}
+			hash := uploadIdentity(content)
+			if tt.expectedHash != nil {
+				hash = tt.expectedHash(content)
+			}
+			size := int64(len(content))
+			if tt.expectedSize != nil {
+				size = tt.expectedSize(content)
+			}
+			resp, body := sendContentReplacement(t, ts.URL, ts.Client(), created.ID, revision,
+				content, hash, size, "text/plain")
+			assert.Equal(t, tt.wantStatus, resp.StatusCode, string(body))
+			assert.Contains(t, string(body), fmt.Sprintf(`"code":%q`, tt.wantCode))
+
+			unchanged, err := s.NodeByID(t.Context(), created.ID)
+			require.NoError(t, err)
+			assert.Equal(t, created.Revision, unchanged.Revision)
+			assert.Equal(t, created.CurrentVersionID, unchanged.CurrentVersionID)
+			versions, total, err := s.ContentVersions(t.Context(), created.ID, 10, 0)
+			require.NoError(t, err)
+			assert.Equal(t, 1, total)
+			require.Len(t, versions, 1)
+		})
+	}
+}
+
+func TestContentReplacementRequiresPreconditionAndFileTarget(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	content := []byte("replacement")
+	hash := uploadIdentity(content)
+
+	req, err := http.NewRequest(http.MethodPut,
+		fmt.Sprintf("%s/api/v1/nodes/%d/content", ts.URL, s.RootID()), bytes.NewReader(content))
+	require.NoError(t, err)
+	req.Header.Set(api.BlobHashHeader, hash)
+	req.Header.Set(api.BlobSizeHeader, strconv.Itoa(len(content)))
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusPreconditionRequired, resp.StatusCode, string(body))
+	assert.Contains(t, string(body), `"code":"precondition_required"`)
+
+	root, err := s.NodeByID(t.Context(), s.RootID())
+	require.NoError(t, err)
+	resp, body = sendContentReplacement(t, ts.URL, ts.Client(), root.ID, root.Revision,
+		content, hash, int64(len(content)), "")
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, string(body))
+	assert.Contains(t, string(body), `"code":"not_file"`)
+	blobs, err := s.AllBlobs(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, blobs, "a failed replacement must not grant blob authority")
+}

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -71,16 +71,16 @@ func contentResponses() map[string]*huma.Response {
 			Description: "Document bytes with expected version and blob identity plus a computed digest trailer",
 			Headers: map[string]*huma.Param{
 				ContentVersionHeader: {Description: "Stable content-version UUID",
-					Schema: &huma.Schema{Type: "string", Format: "uuid"}},
+					Schema: &huma.Schema{Type: openAPIStringType, Format: "uuid"}},
 				BlobHashHeader: {Description: "Catalog SHA-256 identity (lowercase hex)",
-					Schema: &huma.Schema{Type: "string", Pattern: "^[0-9a-f]{64}$"}},
+					Schema: &huma.Schema{Type: openAPIStringType, Pattern: "^[0-9a-f]{64}$"}},
 				BlobSizeHeader: {Description: "Catalog raw byte length",
-					Schema: &huma.Schema{Type: "string", Pattern: "^[0-9]+$"}},
+					Schema: &huma.Schema{Type: openAPIStringType, Pattern: "^[0-9]+$"}},
 				"Content-Digest": {Description: "RFC 9530 SHA-256 of bytes actually streamed; delivered as an HTTP trailer",
-					Schema: &huma.Schema{Type: "string"}},
+					Schema: &huma.Schema{Type: openAPIStringType}},
 			},
 			Content: map[string]*huma.MediaType{
-				"application/octet-stream": {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"application/octet-stream": {Schema: &huma.Schema{Type: openAPIStringType, Format: "binary"}},
 			},
 		},
 	}

--- a/internal/api/routes_upload.go
+++ b/internal/api/routes_upload.go
@@ -47,10 +47,10 @@ func registerUploadOpenAPI(api huma.API) {
 			{Name: "parent_id", In: "query", Required: true,
 				Description: "Stable destination directory node ID", Schema: &huma.Schema{Type: "integer", Format: "int64"}},
 			{Name: "name", In: "query", Required: true,
-				Description: "Virtual filename; must equal the multipart filename", Schema: &huma.Schema{Type: "string", MinLength: new(1)}},
+				Description: "Virtual filename; must equal the multipart filename", Schema: &huma.Schema{Type: openAPIStringType, MinLength: new(1)}},
 			{Name: BlobHashHeader, In: "header", Required: true,
 				Description: "Expected lowercase hexadecimal SHA-256 of the file payload",
-				Schema:      &huma.Schema{Type: "string", Pattern: "^[0-9a-f]{64}$"}},
+				Schema:      &huma.Schema{Type: openAPIStringType, Pattern: "^[0-9a-f]{64}$"}},
 			{Name: BlobSizeHeader, In: "header", Required: true,
 				Description: "Expected raw file byte length",
 				Schema:      &huma.Schema{Type: "integer", Format: "int64", Minimum: new(float64(0))}},
@@ -58,7 +58,7 @@ func registerUploadOpenAPI(api huma.API) {
 		RequestBody: &huma.RequestBody{Required: true, Content: map[string]*huma.MediaType{
 			"multipart/form-data": {
 				Schema: &huma.Schema{Type: "object", Properties: map[string]*huma.Schema{
-					"file": {Type: "string", Format: "binary"},
+					"file": {Type: openAPIStringType, Format: "binary"},
 				}, Required: []string{"file"}},
 				Encoding: map[string]*huma.Encoding{"file": {ContentType: "*/*"}},
 			},
@@ -174,18 +174,26 @@ func parseUploadIdentity(r *http.Request) (int64, string, string, int64, *Error)
 	if err != nil {
 		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "invalid_name", err.Error())
 	}
+	expectedHash, expectedSize, identityErr := parseExpectedBlobIdentity(r)
+	if identityErr != nil {
+		return 0, "", "", 0, identityErr
+	}
+	return parentID, name, expectedHash, expectedSize, nil
+}
+
+func parseExpectedBlobIdentity(r *http.Request) (string, int64, *Error) {
 	expectedHash := r.Header.Get(BlobHashHeader)
 	parsed, err := packstore.ParseHash(expectedHash)
 	if err != nil || parsed.String() != expectedHash {
-		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "validation",
+		return "", 0, NewError(http.StatusUnprocessableEntity, "validation",
 			BlobHashHeader+" must be canonical lowercase SHA-256")
 	}
 	expectedSize, err := strconv.ParseInt(r.Header.Get(BlobSizeHeader), 10, 64)
 	if err != nil || expectedSize < 0 || expectedSize > blob.MaxIngestBytes {
-		return 0, "", "", 0, NewError(http.StatusUnprocessableEntity, "validation",
+		return "", 0, NewError(http.StatusUnprocessableEntity, "validation",
 			fmt.Sprintf("%s must be between 0 and %d", BlobSizeHeader, blob.MaxIngestBytes))
 	}
-	return parentID, name, expectedHash, expectedSize, nil
+	return expectedHash, expectedSize, nil
 }
 
 func uploadMediaType(value string) (string, error) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -90,6 +90,7 @@ func NewServer(d Deps) *Server {
 	registerBackupRoutes(humaAPI, d, g)
 	registerJobRoutes(humaAPI, d)
 	registerUploadRoute(mux, humaAPI, d, g)
+	registerContentWriteRoute(mux, humaAPI, d, g)
 	s.registerHealth(mux)
 	mux.Handle("GET "+kitPingPath, kitdaemon.NewPingHandler(kitdaemon.PingHandlerOptions{
 		Service: "docbank", Version: version.Version, PID: os.Getpid(),

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -2,6 +2,8 @@ package api
 
 import "go.kenn.io/docbank/internal/store"
 
+const openAPIStringType = "string"
+
 const (
 	// BlobHashHeader carries docbank's canonical lowercase SHA-256 identity.
 	BlobHashHeader = "X-Docbank-Blob-Hash"
@@ -77,6 +79,15 @@ type UploadReceipt struct {
 	Node         Node   `json:"node"`
 	ComputedHash string `json:"computed_hash" pattern:"^[0-9a-f]{64}$"`
 	ComputedSize int64  `json:"computed_size"`
+}
+
+// ContentReplacementReceipt proves which bytes the daemon received and which
+// immutable head the optimistic replacement installed.
+type ContentReplacementReceipt struct {
+	Node         Node           `json:"node"`
+	Version      ContentVersion `json:"version"`
+	ComputedHash string         `json:"computed_hash" pattern:"^[0-9a-f]{64}$"`
+	ComputedSize int64          `json:"computed_size" minimum:"0"`
 }
 
 // SearchHit pairs a matched node with its display path.

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -413,3 +413,72 @@ func TestPackedSnapshotRequiresAndUsesPackedRestoreTarget(t *testing.T) {
 	require.NoError(t, restoredBlobs.Close())
 	require.NoError(t, restoredStore.Close())
 }
+
+func TestVersionedReplacementRoundTripsPackedPriorContent(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	alpha, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")
+	require.NoError(t, err)
+	priorVersionID := alpha.CurrentVersionID
+	packed, err := fixture.blobs.Maintainer().Pack(t.Context(), packstore.PackOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 2, packed.BlobsPacked)
+
+	const replacement = "alpha replacement"
+	var replaced store.Node
+	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
+		hash, size, writeErr := fixture.blobs.WriteContext(t.Context(), strings.NewReader(replacement))
+		if writeErr != nil {
+			return writeErr
+		}
+		replaced, _, writeErr = fixture.metadata.ReplaceContent(
+			t.Context(), alpha.ID, alpha.Revision, hash, size, "text/plain",
+		)
+		return writeErr
+	}))
+	wantMetadata := exportMetadata(t, fixture.metadata)
+
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	manifest, err := backupapp.Create(
+		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs,
+		backup.CreateOptions{Jobs: 2})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), manifest.Attachments.Blobs,
+		"backup must include both heads plus the other file")
+	stats, err := backupapp.ParseStats(manifest.Stats)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.ContentVersions)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	_, err = backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{
+		TargetDir: target, Jobs: 2,
+	})
+	require.NoError(t, err)
+	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	assert.Equal(t, string(wantMetadata), string(exportMetadata(t, restoredStore)),
+		"JSONL restore must preserve the complete replacement history byte-for-byte")
+	restoredBlobs, err := blob.New(store.NewPackCatalog(restoredStore), filepath.Join(target, "blobs"))
+	require.NoError(t, err)
+
+	restoredNode, err := restoredStore.NodeByID(t.Context(), alpha.ID)
+	require.NoError(t, err)
+	assert.Equal(t, replaced.CurrentVersionID, restoredNode.CurrentVersionID)
+	assert.Equal(t, int64(2), restoredNode.Revision)
+	for versionID, want := range map[string]string{
+		priorVersionID:                "alpha backup",
+		restoredNode.CurrentVersionID: replacement,
+	} {
+		version, versionErr := restoredStore.ContentVersionByID(t.Context(), versionID)
+		require.NoError(t, versionErr)
+		stream, _, openErr := restoredBlobs.OpenStreamContext(t.Context(), version.BlobHash)
+		require.NoError(t, openErr)
+		got, readErr := io.ReadAll(stream)
+		require.NoError(t, readErr)
+		assert.True(t, stream.Verified())
+		require.NoError(t, stream.Close())
+		assert.Equal(t, want, string(got))
+	}
+	require.NoError(t, restoredBlobs.Close())
+	require.NoError(t, restoredStore.Close())
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -564,6 +564,110 @@ func (c *Client) Upload(
 	return receipt, nil
 }
 
+// ReplaceContent streams raw bytes into a new immutable head under an
+// optimistic node-revision precondition. Success requires the daemon's receipt
+// and ETag to agree with the caller-declared byte identity and the requested
+// node; callers retain responsibility for closing content when applicable.
+func (c *Client) ReplaceContent(
+	ctx context.Context, nodeID, revision int64, mimeType, expectedHash string,
+	expectedSize int64, content io.Reader,
+) (api.ContentReplacementReceipt, error) {
+	var receipt api.ContentReplacementReceipt
+	if nodeID <= 0 {
+		return receipt, errors.New("replacement node ID must be positive")
+	}
+	if revision < 0 {
+		return receipt, errors.New("replacement revision must not be negative")
+	}
+	if !validSHA256Hex(expectedHash) {
+		return receipt, errors.New("replacement hash must be canonical lowercase SHA-256")
+	}
+	if expectedSize < 0 {
+		return receipt, errors.New("replacement size must not be negative")
+	}
+	if content == nil {
+		return receipt, errors.New("replacement content reader is nil")
+	}
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	} else {
+		mediaType, params, err := mime.ParseMediaType(mimeType)
+		if err != nil {
+			return receipt, fmt.Errorf("replacement media type %q: %w", mimeType, err)
+		}
+		mimeType = mime.FormatMediaType(mediaType, params)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		fmt.Sprintf("%s/api/v1/nodes/%d/content", c.base, nodeID), io.NopCloser(content))
+	if err != nil {
+		return receipt, fmt.Errorf("building replacement request: %w", err)
+	}
+	req.ContentLength = expectedSize
+	req.Header.Set("Content-Type", mimeType)
+	req.Header.Set("Expect", "100-continue")
+	req.Header.Set("If-Match", fmt.Sprintf("%q", strconv.FormatInt(revision, 10)))
+	req.Header.Set(api.BlobHashHeader, expectedHash)
+	req.Header.Set(api.BlobSizeHeader, strconv.FormatInt(expectedSize, 10))
+	if c.key != "" {
+		req.Header.Set("X-Api-Key", c.key)
+	}
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return receipt, fmt.Errorf("replacing content of node %d: %w", nodeID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return receipt, decodeError(resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&receipt); err != nil {
+		return receipt, fmt.Errorf("decoding content replacement response: %w", err)
+	}
+	if err := validateReplacementReceipt(
+		receipt, resp.Header.Get("ETag"), nodeID, revision, mimeType, expectedHash, expectedSize,
+	); err != nil {
+		return api.ContentReplacementReceipt{}, err
+	}
+	return receipt, nil
+}
+
+func validateReplacementReceipt(
+	receipt api.ContentReplacementReceipt, etag string, nodeID, revision int64,
+	mimeType, expectedHash string, expectedSize int64,
+) error {
+	if receipt.ComputedHash != expectedHash || receipt.ComputedSize != expectedSize {
+		return fmt.Errorf("content replacement receipt computed identity %s/%d, expected %s/%d",
+			receipt.ComputedHash, receipt.ComputedSize, expectedHash, expectedSize)
+	}
+	if receipt.Node.ID != nodeID || receipt.Version.NodeID != nodeID {
+		return fmt.Errorf("content replacement receipt targets node %d/%d, expected %d",
+			receipt.Node.ID, receipt.Version.NodeID, nodeID)
+	}
+	if receipt.Node.Revision != revision+1 || receipt.Version.NodeRevision != receipt.Node.Revision {
+		return fmt.Errorf("content replacement receipt revision %d/%d, expected %d",
+			receipt.Node.Revision, receipt.Version.NodeRevision, revision+1)
+	}
+	if receipt.Version.ID == "" || receipt.Node.CurrentVersionID != receipt.Version.ID {
+		return errors.New("content replacement receipt does not install its returned version as current")
+	}
+	if receipt.Version.TransitionKind != "content_replace" || receipt.Version.SourceVersionID != nil {
+		return errors.New("content replacement receipt does not describe a content_replace head")
+	}
+	if receipt.Node.BlobHash != expectedHash || receipt.Node.Size != expectedSize ||
+		receipt.Version.BlobHash != expectedHash || receipt.Version.Size != expectedSize {
+		return errors.New("content replacement receipt authority disagrees with declared bytes")
+	}
+	if receipt.Node.MimeType != mimeType || receipt.Version.MimeType != mimeType {
+		return fmt.Errorf("content replacement receipt media type %q/%q, expected %q",
+			receipt.Node.MimeType, receipt.Version.MimeType, mimeType)
+	}
+	expectedETag := fmt.Sprintf("%q", strconv.FormatInt(receipt.Node.Revision, 10))
+	if etag != expectedETag {
+		return fmt.Errorf("content replacement response ETag %q, expected %q", etag, expectedETag)
+	}
+	return nil
+}
+
 func (c *Client) Move(ctx context.Context, id, rev int64, newParentID *int64, newName *string) (api.Node, error) {
 	var n api.Node
 	body := map[string]any{}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -35,6 +35,17 @@ import (
 // NewServer's refusal of an empty one), so the fake server must too.
 const serverKey = "server-key"
 
+type countedReader struct {
+	reader io.Reader
+	read   *atomic.Int64
+}
+
+func (r countedReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.read.Add(int64(n))
+	return n, err
+}
+
 // newClient builds a real server keyed with serverKey and a client keyed
 // with clientKey (which may differ from serverKey, to exercise the
 // mismatched-key path — see TestWrongAPIKeyIsRejected).
@@ -478,6 +489,72 @@ func TestDigestCheckedUploadRoundTrip(t *testing.T) {
 		hex.EncodeToString(wrong[:]), int64(len(content)), strings.NewReader(content))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "digest_mismatch")
+}
+
+func TestContentReplacementRoundTrip(t *testing.T) {
+	c, s := newClient(t, serverKey)
+	initial := "initial content"
+	initialSum := sha256.Sum256([]byte(initial))
+	created, err := c.Upload(t.Context(), s.RootID(), "versioned.txt", "text/plain",
+		hex.EncodeToString(initialSum[:]), int64(len(initial)), strings.NewReader(initial))
+	require.NoError(t, err)
+
+	replacement := []byte{0x00, 0xff, 'n', 'e', 'w'}
+	replacementSum := sha256.Sum256(replacement)
+	receipt, err := c.ReplaceContent(t.Context(), created.Node.ID, created.Node.Revision,
+		"application/octet-stream", hex.EncodeToString(replacementSum[:]),
+		int64(len(replacement)), bytes.NewReader(replacement))
+	require.NoError(t, err)
+	assert.Equal(t, created.Node.Revision+1, receipt.Node.Revision)
+	assert.Equal(t, receipt.Version.ID, receipt.Node.CurrentVersionID)
+	assert.Equal(t, "content_replace", receipt.Version.TransitionKind)
+	assert.Equal(t, hex.EncodeToString(replacementSum[:]), receipt.ComputedHash)
+
+	var staleBytesRead atomic.Int64
+	_, err = c.ReplaceContent(t.Context(), created.Node.ID, created.Node.Revision,
+		"application/octet-stream", hex.EncodeToString(replacementSum[:]),
+		int64(len(replacement)), countedReader{
+			reader: bytes.NewReader(replacement), read: &staleBytesRead,
+		})
+	require.ErrorIs(t, err, store.ErrStaleRevision)
+	assert.Zero(t, staleBytesRead.Load(), "Expect: 100-continue must avoid sending a known-stale body")
+	versions, err := c.Versions(t.Context(), created.Node.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, versions.Total)
+}
+
+func TestContentReplacementRejectsUnprovenReceipt(t *testing.T) {
+	content := []byte("replacement")
+	hash := sha256.Sum256(content)
+	expectedHash := hex.EncodeToString(hash[:])
+	base := api.ContentReplacementReceipt{
+		Node: api.Node{ID: 7, Revision: 4, CurrentVersionID: "11111111-1111-4111-8111-111111111111",
+			BlobHash: expectedHash, Size: int64(len(content)), MimeType: "text/plain"},
+		Version: api.ContentVersion{ID: "11111111-1111-4111-8111-111111111111", NodeID: 7,
+			NodeRevision: 4, BlobHash: expectedHash, Size: int64(len(content)), MimeType: "text/plain",
+			TransitionKind: "content_replace"},
+		ComputedHash: expectedHash, ComputedSize: int64(len(content)),
+	}
+	tests := map[string]func(*api.ContentReplacementReceipt){
+		"computed hash": func(r *api.ContentReplacementReceipt) { r.ComputedHash = strings.Repeat("0", 64) },
+		"node":          func(r *api.ContentReplacementReceipt) { r.Node.ID++ },
+		"version":       func(r *api.ContentReplacementReceipt) { r.Node.CurrentVersionID = "other" },
+		"authority":     func(r *api.ContentReplacementReceipt) { r.Version.Size++ },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			receipt := base
+			mutate(&receipt)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("ETag", `"4"`)
+				_ = json.NewEncoder(w).Encode(receipt)
+			}))
+			t.Cleanup(ts.Close)
+			_, err := client.New(ts.URL, "key").ReplaceContent(t.Context(), 7, 3, "text/plain",
+				expectedHash, int64(len(content)), bytes.NewReader(content))
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestStorageRepackRoundTrip(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "12"
+	daemonProtocolVersion = "13"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -176,6 +176,15 @@ type UploadResult struct {
 	ComputedSize int64
 }
 
+// ReplacementResult is the independently verified byte identity and the new
+// immutable content authority installed for an existing file.
+type ReplacementResult struct {
+	Node         store.Node
+	Version      store.ContentVersion
+	ComputedHash string
+	ComputedSize int64
+}
+
 // PreparedUpload is a verified, authority-free remote write. The caller may
 // validate the remainder of its transport envelope before Commit grants blob
 // and node authority.
@@ -245,6 +254,39 @@ func (p *PreparedUpload) Commit(ctx context.Context) (UploadResult, error) {
 		return result, err
 	}
 	return result, nil
+}
+
+// ReplaceContent streams a remote body into durable authority-free storage,
+// verifies its declared identity, then atomically installs a content_replace
+// head under the caller's node-revision precondition.
+func (ing *Ingester) ReplaceContent(
+	ctx context.Context, nodeID, ifRev int64, mimeType string, r io.Reader,
+	expectedHash string, expectedSize int64,
+) (ReplacementResult, error) {
+	var result ReplacementResult
+	if !utf8.ValidString(mimeType) {
+		return result, errors.New("MIME type is not valid UTF-8")
+	}
+	if err := ing.Store.CheckContentReplacementTarget(ctx, nodeID, ifRev); err != nil {
+		return result, err
+	}
+	var err error
+	result.ComputedHash, result.ComputedSize, err = ing.Blobs.WriteContext(ctx, r)
+	if err != nil {
+		return result, err
+	}
+	if result.ComputedSize != expectedSize {
+		return result, fmt.Errorf("declared %d bytes, received %d: %w",
+			expectedSize, result.ComputedSize, ErrUploadSizeMismatch)
+	}
+	if result.ComputedHash != expectedHash {
+		return result, fmt.Errorf("declared SHA-256 %s, computed %s: %w",
+			expectedHash, result.ComputedHash, ErrUploadDigestMismatch)
+	}
+	result.Node, result.Version, err = ing.Store.ReplaceContent(
+		ctx, nodeID, ifRev, result.ComputedHash, result.ComputedSize, mimeType,
+	)
+	return result, err
 }
 
 // AddPaths ingests files and directory trees under the virtual destPath.

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -139,6 +139,52 @@ func TestAddCancellationDoesNotAuthorizeIncompleteFile(t *testing.T) {
 		"cancellation during blob reading must not grant node authority")
 }
 
+type cancelingContentReader struct {
+	cancel context.CancelFunc
+	sent   bool
+}
+
+func (r *cancelingContentReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.sent {
+		return 0, context.Canceled
+	}
+	r.sent = true
+	p[0] = 'x'
+	r.cancel()
+	return 1, nil
+}
+
+func TestReplaceContentCancellationLeavesCurrentAuthorityUntouched(t *testing.T) {
+	ing := newTestIngester(t)
+	var created store.Node
+	require.NoError(t, ing.Blobs.WithMutation(t.Context(), func() error {
+		hash, size, err := ing.Blobs.WriteContext(t.Context(), strings.NewReader("current"))
+		if err != nil {
+			return err
+		}
+		created, err = ing.Store.CreateFile(
+			t.Context(), ing.Store.RootID(), "current.txt", hash, size, "text/plain",
+		)
+		return err
+	}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	_, err := ing.ReplaceContent(ctx, created.ID, created.Revision, "text/plain",
+		&cancelingContentReader{cancel: cancel}, strings.Repeat("0", 64), 2)
+	require.ErrorIs(t, err, context.Canceled)
+	unchanged, err := ing.Store.NodeByID(t.Context(), created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.Revision, unchanged.Revision)
+	assert.Equal(t, created.CurrentVersionID, unchanged.CurrentVersionID)
+	versions, total, err := ing.Store.ContentVersions(t.Context(), created.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, versions, 1)
+}
+
 func TestAddProgressBatchesManySmallFiles(t *testing.T) {
 	ing := newTestIngester(t)
 	files := make(map[string]string, 130)

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -5,11 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 )
 
 // ContentVersion is one immutable byte identity recorded for a stable file
-// node. Initial ingest currently creates content_create records; later editing
-// operations can add new heads without changing this read contract.
+// node. Initial ingest creates content_create records and verified replacement
+// adds content_replace heads without changing this read contract.
 type ContentVersion struct {
 	ID                    string
 	NodeID                int64
@@ -120,4 +121,101 @@ func (s *Store) ContentVersions(
 		return nil, 0, fmt.Errorf("node %d: %w", nodeID, ErrNotFound)
 	}
 	return versions, total, nil
+}
+
+// ReplaceContent installs one already-durable blob as a file's new immutable
+// head. Unless ifRev is UnconditionalRev, the node must still be at ifRev;
+// version creation, pointer replacement, and the node revision bump commit as
+// one transaction.
+func (s *Store) ReplaceContent(
+	ctx context.Context, nodeID, ifRev int64, blobHash string, size int64, mimeType string,
+) (Node, ContentVersion, error) {
+	if size < 0 {
+		return Node{}, ContentVersion{}, errors.New("content size must not be negative")
+	}
+	if err := validateUTF8Field("content MIME type", mimeType); err != nil {
+		return Node{}, ContentVersion{}, err
+	}
+	var (
+		updated Node
+		version ContentVersion
+	)
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		n, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		if err := validateContentReplacementTarget(n, ifRev); err != nil {
+			return err
+		}
+		if err := s.EnsureBlobTx(tx, blobHash, size); err != nil {
+			return err
+		}
+		versionID, err := newUUIDv4()
+		if err != nil {
+			return err
+		}
+		operationID, err := newUUIDv4()
+		if err != nil {
+			return err
+		}
+		now := nowRFC3339()
+		newRevision := n.Revision + 1
+		var storedMime any
+		if mimeType != "" {
+			storedMime = mimeType
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO content_versions (
+				version_id, node_id, blob_hash, size, mime_type, recorded_at,
+				node_revision, introduced_operation_id, transition_kind, source_version_id
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'content_replace', NULL)`,
+			versionID, nodeID, blobHash, size, storedMime, now, newRevision, operationID); err != nil {
+			return fmt.Errorf("recording replacement content version for node %d: %w", nodeID, err)
+		}
+		if _, err := tx.Exec(
+			`UPDATE nodes SET current_version_id = ?, revision = ?, modified_at = ? WHERE id = ?`,
+			versionID, newRevision, now, nodeID); err != nil {
+			return fmt.Errorf("installing replacement content version for node %d: %w", nodeID, err)
+		}
+		updated, err = nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		version, err = scanContentVersion(tx.QueryRow(
+			`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`, versionID))
+		return err
+	})
+	if err != nil {
+		return Node{}, ContentVersion{}, err
+	}
+	return updated, version, nil
+}
+
+// CheckContentReplacementTarget performs the cheap target and revision checks
+// before a caller streams bytes. ReplaceContent repeats them transactionally,
+// because this preflight is an optimization rather than mutation authority.
+func (s *Store) CheckContentReplacementTarget(ctx context.Context, nodeID, ifRev int64) error {
+	n, err := s.NodeByID(ctx, nodeID)
+	if err != nil {
+		return err
+	}
+	return validateContentReplacementTarget(n, ifRev)
+}
+
+func validateContentReplacementTarget(n Node, ifRev int64) error {
+	if n.TrashedAt != nil {
+		return fmt.Errorf("node %d is trashed: %w", n.ID, ErrNotFound)
+	}
+	if n.IsDir() {
+		return fmt.Errorf("node %d: %w", n.ID, ErrNotFile)
+	}
+	if ifRev != UnconditionalRev && n.Revision != ifRev {
+		return fmt.Errorf("node %d at revision %d, expected %d: %w",
+			n.ID, n.Revision, ifRev, ErrStaleRevision)
+	}
+	if n.Revision == math.MaxInt64 {
+		return fmt.Errorf("node %d revision cannot advance beyond %d", n.ID, n.Revision)
+	}
+	return nil
 }

--- a/internal/store/write_test.go
+++ b/internal/store/write_test.go
@@ -99,6 +99,79 @@ func TestCurrentVersionMustBelongToItsNode(t *testing.T) {
 	assert.Equal(t, first.CurrentVersionID, unchanged.CurrentVersionID)
 }
 
+func TestReplaceContentCreatesImmutableHead(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	created, err := s.CreateFile(ctx, s.RootID(), "report.txt", fakeHash("a1"), 3, "text/plain")
+	require.NoError(t, err)
+
+	updated, replacement, err := s.ReplaceContent(
+		ctx, created.ID, created.Revision, fakeHash("b2"), 4, "text/markdown",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, updated.ID)
+	assert.Equal(t, created.Revision+1, updated.Revision)
+	assert.Equal(t, replacement.ID, updated.CurrentVersionID)
+	assert.Equal(t, fakeHash("b2"), updated.BlobHash)
+	assert.Equal(t, int64(4), updated.Size)
+	assert.Equal(t, "text/markdown", updated.MimeType)
+	assert.Equal(t, updated.Revision, replacement.NodeRevision)
+	assert.Equal(t, "content_replace", replacement.TransitionKind)
+	assert.Nil(t, replacement.SourceVersionID)
+	require.NoError(t, validateUUIDv4(replacement.ID))
+	require.NoError(t, validateUUIDv4(replacement.IntroducedOperationID))
+
+	versions, total, err := s.ContentVersions(ctx, created.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, versions, 2)
+	assert.Equal(t, replacement.ID, versions[0].ID)
+	assert.Equal(t, created.CurrentVersionID, versions[1].ID)
+	assert.Equal(t, fakeHash("a1"), versions[1].BlobHash,
+		"replacement must retain the prior immutable version")
+
+	// Replacing with the same bytes is still an explicit versioned mutation;
+	// storage deduplicates the blob while history records the operation.
+	sameBytes, sameVersion, err := s.ReplaceContent(
+		ctx, updated.ID, updated.Revision, updated.BlobHash, updated.Size, updated.MimeType,
+	)
+	require.NoError(t, err)
+	assert.NotEqual(t, replacement.ID, sameVersion.ID)
+	assert.Equal(t, replacement.BlobHash, sameVersion.BlobHash)
+	assert.Equal(t, updated.Revision+1, sameBytes.Revision)
+	var blobCount int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM blobs`).Scan(&blobCount))
+	assert.Equal(t, 2, blobCount)
+}
+
+func TestReplaceContentRejectsInvalidTargetAndStaleRevision(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	file, err := s.CreateFile(ctx, s.RootID(), "report.txt", fakeHash("a1"), 3, "text/plain")
+	require.NoError(t, err)
+	dir, err := s.Mkdir(ctx, s.RootID(), "folder")
+	require.NoError(t, err)
+
+	_, _, err = s.ReplaceContent(ctx, file.ID, file.Revision+1, fakeHash("b2"), 4, "text/plain")
+	require.ErrorIs(t, err, ErrStaleRevision)
+	_, _, err = s.ReplaceContent(ctx, dir.ID, dir.Revision, fakeHash("b2"), 4, "text/plain")
+	require.ErrorIs(t, err, ErrNotFile)
+	trashed, _, err := s.Trash(ctx, file.ID, file.Revision)
+	require.NoError(t, err)
+	_, _, err = s.ReplaceContent(ctx, trashed.ID, trashed.Revision, fakeHash("b2"), 4, "text/plain")
+	require.ErrorIs(t, err, ErrNotFound)
+
+	versions, total, err := s.ContentVersions(ctx, file.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, versions, 1)
+	assert.Equal(t, file.CurrentVersionID, versions[0].ID)
+	var candidateBlobs int
+	require.NoError(t, s.db.QueryRow(
+		`SELECT COUNT(*) FROM blobs WHERE hash = ?`, fakeHash("b2")).Scan(&candidateBlobs))
+	assert.Zero(t, candidateBlobs, "failed replacements must not grant blob authority")
+}
+
 func TestContentVersionsRequiresBoundedPage(t *testing.T) {
 	s := newTestStore(t)
 	file, err := s.CreateFile(t.Context(), s.RootID(), "bounded.txt", fakeHash("a1"), 1, "text/plain")


### PR DESCRIPTION
Stable version identity needs a real write path: until now every document could expose its initial immutable version, but people and agents had no supported way to replace the current bytes without creating a different node or stepping outside Docbank. That left the most basic editing workflow disconnected from the version and backup contracts we just established.

This PR makes replacement one proved optimistic operation. `docbank put` hashes a regular local source, shows separate hash and upload progress, and sends the inspected node revision with declared SHA-256 and size. The daemon independently writes and verifies those bytes before atomically installing a `content_replace` head; stale writes fail before the body is sent, and the client accepts success only when the ETag, node, version, size, and hash all agree.

The old head remains immutable and readable, including when it was already packed. Portable JSONL backup and restore preserve both versions and their byte authority. The daemon protocol advances so a current CLI cannot route this contract to an older same-version daemon. Revert, interactive edit, pruning, and audit policy remain deliberately outside this slice.

The repository gates and race-enabled replacement lifecycle coverage are green. Kata: `mh8t`.