### PR TITLE
Add immutable content reversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ maintenance.
 
 - Virtual folders with listing, tree browsing, rename, move, trash, and restore
 - Resumable bulk import and verified multipart upload
-- Stable content-version UUIDs, verified content replacement, bounded history
-  listing, and ID-addressed retrieval
+- Stable content-version UUIDs, verified replacement and reversion, bounded
+  history listing, and ID-addressed retrieval
 - FTS5 name search (document-body extraction and search are planned)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification
@@ -50,10 +50,10 @@ maintenance.
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows
 
-Reversion and interactive editing, permanent tamper-evident audited history,
-tags, watched inboxes, text extraction, the kit-ui web portal, and the focused
-TUI are planned rather than implemented. See the [roadmap](docs/roadmap.md)
-for the current boundary.
+Interactive editing, permanent tamper-evident audited history, tags, watched
+inboxes, text extraction, the kit-ui web portal, and the focused TUI are planned
+rather than implemented. See the [roadmap](docs/roadmap.md) for the current
+boundary.
 
 ## Installation
 
@@ -104,6 +104,7 @@ docbank tree /archive
 docbank search "tax return"
 docbank versions /archive/Documents/receipt.pdf
 docbank put revised-receipt.pdf /archive/Documents/receipt.pdf
+docbank revert /archive/Documents/receipt.pdf <prior-version-id>
 docbank mv /archive/Documents/receipt.pdf /archive/Documents/receipt-2026.pdf
 docbank verify
 ```

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -183,6 +183,26 @@ func TestPutReplacesContentAndRetainsHistory(t *testing.T) {
 	assert.Equal(t, "content_replace", receipt.Version.TransitionKind)
 	assert.Equal(t, int64(3), receipt.Node.Revision)
 	assert.Equal(t, "application/octet-stream", receipt.Node.MimeType)
+
+	out, err = runCLI(t, "revert", "/inbox/document.txt", initialVersion)
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "reverted /inbox/document.txt to source version "+initialVersion)
+	out, err = runCLI(t, "cat", "/inbox/document.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "initial content", out)
+
+	// Selecting the same historical source again records another deliberate
+	// revert rather than mutating or reusing the current history row.
+	out, err = runCLI(t, "revert", "/inbox/document.txt", initialVersion, "--json")
+	require.NoError(t, err, out)
+	var reverted api.ContentReversionReceipt
+	require.NoError(t, json.Unmarshal([]byte(out), &reverted))
+	assert.Equal(t, initialVersion, reverted.SourceVersion.ID)
+	assert.Equal(t, "content_revert", reverted.Version.TransitionKind)
+	assert.Equal(t, int64(5), reverted.Node.Revision)
+	out, err = runCLI(t, "version", reverted.Version.ID)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Source version:  "+initialVersion)
 }
 
 func TestJobsShowsDaemonStatus(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/home"
 )
@@ -155,7 +157,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "13", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "14", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -176,7 +178,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "13", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "14", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -255,6 +257,27 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	putPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, metadataPID, putPID)
 
+	// Protocol 13 predates content reversion. Replace it before the CLI sends
+	// the mutation so an older same-version daemon cannot return 404 after the
+	// operator has selected a historical source.
+	out, err = run(oldBin, "versions", "/inbox/preflight.txt", "--json")
+	require.NoError(t, err, out)
+	var versionPage api.ContentVersionPage
+	require.NoError(t, json.Unmarshal([]byte(out), &versionPage))
+	require.Len(t, versionPage.Items, 2)
+	sourceVersionID := versionPage.Items[1].ID
+	recs[0].Metadata["protocol_version"] = "13"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "revert", "/inbox/preflight.txt", sourceVersionID, "--json")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, `"transition_kind":"content_revert"`)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	revertPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, putPID, revertPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -269,7 +292,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "13", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "14", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -282,7 +305,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, putPID, protocolPID)
+	assert.NotEqual(t, revertPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/cmd/docbank/revert.go
+++ b/cmd/docbank/revert.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/store"
+)
+
+var revertJSON bool
+
+var revertCmd = &cobra.Command{
+	Use:   "revert <vault-path> <version-id>",
+	Short: "Create a new current version from an immutable prior version",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		target, err := c.Stat(cmd.Context(), args[0])
+		if err != nil {
+			return fmt.Errorf("resolving %q: %w", args[0], err)
+		}
+		if target.Kind != "file" {
+			return fmt.Errorf("%q: %w", args[0], store.ErrNotFile)
+		}
+		receipt, err := c.RevertContent(
+			cmd.Context(), target.ID, target.Revision, args[1],
+		)
+		if err != nil {
+			return fmt.Errorf("reverting %q: %w", args[0], err)
+		}
+		if revertJSON {
+			return writeVersionJSON(cmd.OutOrStdout(), receipt)
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(),
+			"reverted %s to source version %s as new version %s (revision %d, %s, sha256 %s)\n",
+			args[0], receipt.SourceVersion.ID, receipt.Version.ID, receipt.Node.Revision,
+			formatBackupBytes(receipt.Version.Size), receipt.Version.BlobHash)
+		if err != nil {
+			return fmt.Errorf("writing reversion receipt: %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	revertCmd.Flags().BoolVar(&revertJSON, "json", false, "emit a machine-readable reversion receipt")
+	rootCmd.AddCommand(revertCmd)
+}

--- a/cmd/docbank/versions.go
+++ b/cmd/docbank/versions.go
@@ -112,6 +112,9 @@ var versionCmd = &cobra.Command{
 		if version.MimeType != "" {
 			_, _ = fmt.Fprintf(w, "Media type:\t%s\n", version.MimeType)
 		}
+		if version.SourceVersionID != nil {
+			_, _ = fmt.Fprintf(w, "Source version:\t%s\n", *version.SourceVersionID)
+		}
 		return w.Flush()
 	},
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -58,7 +58,8 @@ non-goals.
    after inspecting it. Re-resolve paths when the intent is path-specific.
 3. **Content identity is immutable.** A file node names a stable current-version
    UUID plus SHA-256 and size. List or retrieve versions by stable ID; `put`
-   adds a verified immutable head rather than modifying stored bytes in place.
+   adds verified bytes and `revert` adds a new head from a prior version rather
+   than modifying stored history in place.
 4. **A stream is not verified until it finishes.** Read through successful EOF
    and require the digest evidence before publishing downloaded bytes.
 5. **Destruction has stages.** Trash is recoverable; trash empty removes tree
@@ -93,6 +94,9 @@ non-goals.
 - **Replace an inspected file:** retain its node ID and revision, send raw bytes
   with declared SHA-256 and size, and require the returned node, new version,
   computed identity, and ETag to agree before accepting success.
+- **Adopt a prior version:** retain the target node ID and revision, select a
+  version belonging to it, and require the reversion receipt's node, source,
+  new head, content authority, and ETag to agree. No byte transfer is involved.
 - **Reorganize after inspection:** read by ID, retain the revision, and mutate
   with `If-Match`. On `stale_revision`, re-read and reconsider rather than
   blindly replaying the action.

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -266,6 +266,26 @@ ETag to encode that resulting revision. The old version remains addressable.
 A `412` means the decision is stale—re-read and decide again rather than
 blindly retrying with a fresh revision.
 
+Reversion applies the same concurrency rule without uploading bytes. Select a
+prior version belonging to the inspected node and send:
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'If-Match: "8"' \
+  -H 'Content-Type: application/json' \
+  --data '{"source_version_id":"11111111-1111-4111-8111-111111111111"}' \
+  "$DOCBANK_URL/api/v1/nodes/42/revert"
+```
+
+Require `source_version.id` to equal the requested ID and all three records to
+name node 42. Require the new version to be `content_revert`, to name that source,
+and to reproduce its hash, size, and media type exactly. The node must install
+the new version at revision 9 and the ETag must agree. Reversion is metadata-only,
+so it has no computed digest receipt; it relies on already-authoritative source
+bytes and does not copy them. Use the ordinary content verification surface when
+a fresh physical proof is part of the workflow.
+
 Path mutations are intentionally different. `POST /api/v1/path/move` and
 `POST /api/v1/path/trash` resolve and mutate inside one store transaction, so
 they do not accept `If-Match`. Use them for a one-shot instruction tied to the

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -1,6 +1,6 @@
 ---
 title: Editing & Versions
-description: Stable content-version identity, retrieval, retention, and the planned editing model over immutable content.
+description: Stable content-version identity, retrieval, replacement, reversion, and retention over immutable content.
 ---
 
 # Editing and versions
@@ -10,10 +10,9 @@ is document identity; the version identifies one immutable set of bytes. Users
 and agents can list versions, inspect one by UUID, and retrieve its bytes even
 after the node moves or is renamed.
 
-Content replacement is implemented by `docbank put` and the raw HTTP content
-write. Reversion and interactive editing are planned. Establishing one identity
-and read contract across ingest and replacement lets those later operations add
-history without redefining existing files or backups.
+Content replacement is implemented by `docbank put`, and reversion by
+`docbank revert`. Both add immutable history instead of rewriting an existing
+version. Interactive editing remains planned on top of the same write contract.
 
 ## Version contract
 
@@ -102,18 +101,37 @@ head remains readable throughout. Even a replacement with identical bytes
 creates a distinct version and operation while content storage deduplicates the
 shared blob.
 
-## Planned editing model
+## Reverting content
+
+```bash
+docbank revert /taxes/2025/return.pdf <prior-version-id>
+```
+
+Reversion is a metadata-only content transition. The selected version must
+belong to the target file and must not already be its current head. Under the
+target's inspected revision, one transaction creates a new `content_revert`
+version with the source's exact blob hash, size, and media type; records the
+source version ID; advances `current_version_id`; and bumps the node revision.
+No loose or packed bytes are read, copied, or rewritten.
+
+The source and every intervening version remain immutable and addressable. A
+later repeat of the same historical choice creates another explicit revert
+operation rather than reusing the earlier history row. Because no content is
+destroyed, reversion needs no destructive confirmation. A stale node fails with
+`412`; a source from another node and an already-current source fail with
+structured `422` errors.
+
+`POST /api/v1/nodes/{id}/revert` accepts `source_version_id` with `If-Match`.
+Its receipt returns the resulting node, the new reversion row, the complete
+source version, and the resulting ETag. Clients accept success only when all
+node, revision, source, and content-authority fields agree.
+
+## Planned editing and retention
 
 !!! info "Planned — Phase 2b"
-    Reversion will create a new `content_revert` head that names
-    the older source version; it never rewinds or deletes later history. A
-    metadata transaction creates at most one version for a node, enforced by
-    unique `(node_id, node_revision)` and `(node_id,
-    introduced_operation_id)` constraints.
-
-    Planned write surfaces are `revert` and interactive `edit`; both build on
-    the implemented immutable replacement transaction and require optimistic
-    concurrency rather than overwriting another actor's head.
+    Interactive `edit` will use private staging and the implemented replacement
+    transaction. It must require optimistic concurrency rather than overwriting
+    another actor's head.
 
     Version pruning is explicit and releases blob reachability only when its
     metadata row is removed. No automatic retention policy is the default. A

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -9,7 +9,7 @@ description: The agent-first HTTP API — filesystem-shaped endpoints, revision 
     The endpoints below marked **Implemented** exist in `docbank daemon run`
     today and back the CLI's data commands — the CLI is an HTTP client
     of exactly this surface, with no other path into the vault. Rows
-    under the "Planned" admonitions further down (reversion,
+    under the "Planned" admonitions further down (interactive editing,
     tags, batch move) are designed but not built; see
     [Roadmap](../roadmap.md).
 
@@ -35,6 +35,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /nodes/{id}/children` | list a directory, paginated (`limit`/`offset`) | Implemented |
 | `GET /nodes/{id}/content` | stream document bytes with catalog identity and a computed digest trailer | Implemented |
 | `PUT /nodes/{id}/content` | replace raw content under revision, size, and digest preconditions — see [addendum](#addendum-put-nodesidcontent) | Implemented |
+| `POST /nodes/{id}/revert` | create a new head from a prior version of the same file | Implemented |
 | `GET /nodes/{id}/versions` | list immutable content versions newest-first, paginated (`limit`/`offset`) | Implemented |
 | `GET /versions/{version_id}` · `GET /versions/{version_id}/content` | inspect or stream one immutable version by stable UUID | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
@@ -59,7 +60,7 @@ daemon stop`; it isn't auth-exempt, so it requires both the API key and
 its own shutdown token.
 
 !!! info "Planned"
-    Not yet implemented: revert, interactive edit, and version pruning
+    Not yet implemented: interactive edit and version pruning
     ([Editing & Versions](editing-and-versions.md));
     tags (`GET /tags` + CRUD, tag filters on search), whose IDs are opaque
     non-reusable UUIDv4 values independent of mutable names; and
@@ -129,6 +130,7 @@ and maintenance are explicit exceptions:
 |----------|--------------|
 | `PATCH /nodes/{id}` | required — target node's revision |
 | `PUT /nodes/{id}/content` | required — prevents a replacement from overwriting a head the caller did not inspect |
+| `POST /nodes/{id}/revert` | required — binds the selected source to the current head the caller inspected |
 | `POST /nodes/{id}/trash` | required — target node's revision |
 | `POST /nodes/{id}/restore` | required — target node's revision |
 | `POST /nodes/{id}/verify` | required — binds the evidence to the exact node state the caller inspected |
@@ -305,6 +307,25 @@ authority-free until GC. Because the body may be binary, this route is an
 explicit exception to the raw JSON text validator; its byte count and digest
 are the lossless boundary instead. Cancellation propagates through physical
 writing and prevents the metadata transaction.
+
+## Addendum: `POST /nodes/{id}/revert`
+
+Reversion accepts JSON `{"source_version_id":"<uuid>"}` and requires the
+target node's revision in `If-Match`. The source must be an immutable version of
+that same node and cannot be its current version. A successful transaction
+creates a distinct `content_revert` row, copies the source's blob hash, size,
+and media type into it, records `source_version_id`, advances the current
+pointer, and bumps the node revision.
+
+This operation is metadata-only: it neither streams nor copies the source blob,
+whether loose or packed. Every existing version remains a reachability root.
+The receipt contains `node`, the new `version`, and `source_version`, while the
+ETag carries the resulting revision. Clients cross-check all four authorities;
+HTTP 200 alone is not sufficient evidence.
+
+A stale target returns `412 stale_revision`. A source from another node returns
+`422 version_node_mismatch`, selecting the current head returns
+`422 version_already_current`, and an unknown source returns `404 not_found`.
 
 !!! info "Planned"
     Ingest provenance today is filesystem-shaped: each import records

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -83,9 +83,9 @@ metadata, durability rules, and physical storage primitives from
 
 Every imported file starts with a stable content-version UUID. Version listing,
 metadata lookup, and byte retrieval are implemented independently of the node's
-mutable path. Content replacement adds an immutable version and moves the
-node's current pointer under a revision precondition rather than rewriting a
-blob. Reversion remains planned. See
+mutable path. Content replacement and reversion add immutable versions and move
+the node's current pointer under a revision precondition rather than rewriting
+a blob. See
 [Editing & Versions](editing-and-versions.md).
 
 !!! info "Planned — full audit"
@@ -137,8 +137,8 @@ blob. Reversion remains planned. See
   separate decisions.
 
 !!! info "Planned — later clients and features"
-    Reversion, interactive editing, full audit, tags, watched inboxes, text
-    extraction, the kit-ui web portal, and the focused TUI remain planned.
+    Interactive editing, full audit, tags, watched inboxes, text extraction,
+    the kit-ui web portal, and the focused TUI remain planned.
     Later clients must not bypass the implemented backup and restore API.
     Backup initialization, creation, listing, verification, and restore use the
     daemon boundary above. Later features must not introduce a privileged path

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,7 @@ All commands operate on the vault at `~/.docbank` (override with
 stderr and produce a non-zero exit code. Virtual paths are absolute,
 `/`-separated, and case-sensitive.
 
-Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `versions`, `version`, `mv`, `rm`,
+Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `versions`, `version`, `revert`, `mv`, `rm`,
 `restore`, `search`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
 daemon over its HTTP API rather than opening the vault itself; if none
 is running, the command auto-starts one in the background. `docbank
@@ -155,7 +155,8 @@ Human output marks the node's current version. `--json` emits
 complete page from a prefix.
 
 Every newly imported file has one revision-one `content_create` version. Each
-successful `put` adds a `content_replace` row. Reversion is not implemented yet.
+successful `put` adds a `content_replace` row and each `revert` adds a
+`content_revert` row naming its immutable source.
 
 ## docbank version
 
@@ -166,12 +167,31 @@ docbank version <version-id> --content
 
 Inspects one immutable version by stable UUID, independent of the file's current
 path. The human view prints node and node-revision identity, recording time,
-transition kind, blob hash, size, and media type; `--json` emits the typed record.
+transition kind, blob hash, size, media type, and any reversion source;
+`--json` emits the typed record.
 `--content` writes that exact version's bytes to stdout and cannot be combined
 with `--json`. It exits successfully only after the response version ID, byte
 count, SHA-256 identity, and terminal `Content-Digest` all agree. Output may
 already have reached stdout when verification fails, so scripts publishing a
 file should write privately and rename it only after a successful exit.
+
+## docbank revert
+
+```text
+docbank revert <vault-path> <version-id> [--json]
+```
+
+Makes a prior version current by creating a new immutable `content_revert`
+history row. It never deletes or rewinds the current or intervening versions,
+and it does not read or copy the source blob. The selected source must belong to
+the target file and must not already be its current version.
+
+The command inspects the target's stable node ID and revision, then sends both
+with the source version ID. A concurrent move, trash, replacement, or reversion
+fails with `stale_revision`. Human output identifies the source, new version,
+resulting revision, size, and hash; `--json` returns the node, new version, and
+complete source-version receipt. Repeating the same historical choice later is
+valid and records another explicit operation.
 
 ## docbank mv
 
@@ -478,8 +498,8 @@ background-spawned daemons.
 
 !!! info "Planned — later phases"
     The following are designed but not yet implemented; they will appear
-    here with exact semantics when they ship. `docbank edit` and
-    `revert` (Phase 2b, [Editing & Versions](architecture/editing-and-versions.md));
+    here with exact semantics when they ship. `docbank edit`
+    (Phase 2b, [Editing & Versions](architecture/editing-and-versions.md));
     `docbank audit enable`, `audit status`, `audit history`, and `audit verify`
     (Phase 2b, [Audited History](architecture/audited-history.md));
     `docbank extract` (Phase 2b, [HTTP API](architecture/http-api.md));

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,9 @@ organizing structure is a **virtual tree stored in SQLite**. Moves,
 renames, and reorganization are metadata transactions that never touch bytes.
 
 Every imported file starts with a stable content-version UUID. `docbank put`
-adds a verified immutable head without rewriting or discarding prior bytes;
-versions can be listed and retrieved independently of mutable paths. See
+adds verified bytes as an immutable head and `docbank revert` adopts a prior
+version through a new history row; neither discards earlier versions. Versions
+can be listed and retrieved independently of mutable paths. See
 [Editing & Versions](architecture/editing-and-versions.md).
 
 !!! info "Planned — full audit"
@@ -117,13 +118,13 @@ docbank is alpha software with tagged releases. The core store and ingest
 pipeline, virtual-tree CLI, authenticated daemon API, packed storage,
 integrity verification, and incremental backup creation, verification, and
 restore are implemented and tested. Stable content-version listing and
-ID-addressed retrieval and verified replacement work through loose/packed
-storage and backup restore.
+ID-addressed retrieval, verified replacement, and reversion work through
+loose/packed storage and backup restore.
 Representative-corpus hardening and
 distribution work continue before a stable 1.0 release.
 
 !!! info "Planned — later phases"
-    Reversion and interactive editing, full audited history, tags, watched inboxes,
+    Interactive editing, full audited history, tags, watched inboxes,
     content-text extraction and search, the kit-ui web portal, and the focused
     TUI are designed but not yet built. The
     [Roadmap](roadmap.md) tracks what exists versus what is planned.

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -451,8 +451,9 @@ actual released formats and fixtures rather than speculative migration work.
 
 - External references need a liveness policy before their schema exists:
   pin blob authority, or allow dangling-reference detection in the referrer.
-- Revert and future version writers must preserve the implemented
-  bytes-before-reference ordering and add rows to reachability atomically with
-  pointer replacement.
+- Future version writers must preserve the implemented bytes-before-reference
+  ordering and add rows to reachability atomically with pointer replacement.
+  Reversion is the metadata-only exception: it reuses already-authoritative
+  source bytes and atomically adds a new reachability row and pointer.
 - Pack and repack maintenance commands must remain daemon/API operations; no
   CLI path may open the physical store directly.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,8 +98,16 @@ docbank versions /taxes/checklist.pdf
 and uploads it, showing separate progress for both file passes. The upload
 requires that freshly observed target revision, so a concurrent change fails
 instead of being overwritten. The prior version remains available through
-`docbank version <old-version-id> --content`. Reversion is planned; it will
-create another immutable head rather than rewind history.
+`docbank version <old-version-id> --content`. Adopt it as current without
+erasing the replacement:
+
+```bash
+docbank revert /taxes/checklist.pdf <old-version-id>
+```
+
+Reversion creates another immutable head that records its source. It does not
+copy the source blob or rewind history, so both the replacement and the original
+remain addressable.
 
 ## Reorganize
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,7 @@ marked planned appears elsewhere in these docs only under an explicit
 | 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.9.2) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
-| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: version identity, reads, and verified replacement implemented; remaining work designed |
+| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: version identity, reads, verified replacement, and reversion implemented; remaining work designed |
 | 3 | Primary kit-ui web portal and focused operator TUI | Designed |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
@@ -90,8 +90,11 @@ SHA-256 and size, and receive the stable node/version plus server-computed
 identity only after both match. `docbank put` and raw
 `PUT /nodes/{id}/content` now add a digest-checked `content_replace` head under
 an optimistic revision precondition while retaining every prior version.
+`docbank revert` and `POST /nodes/{id}/revert` add a metadata-only
+`content_revert` head from one prior version without copying its loose or packed
+blob.
 
-- Remaining editing surfaces: `docbank edit` and `docbank revert`
+- Remaining editing surface: `docbank edit`
   ([design](architecture/editing-and-versions.md))
 - Full-audit directory scopes with sticky membership, complete authoritative
   change and content-version retention, tamper-evident history, maintenance

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -69,6 +69,8 @@ var storeErrCodes = []struct {
 	{store.ErrInvalidName, http.StatusUnprocessableEntity, "invalid_name"},
 	{store.ErrNotTrashed, http.StatusUnprocessableEntity, "not_trashed"},
 	{store.ErrIsRoot, http.StatusUnprocessableEntity, "is_root"},
+	{store.ErrVersionNodeMismatch, http.StatusUnprocessableEntity, "version_node_mismatch"},
+	{store.ErrVersionAlreadyCurrent, http.StatusUnprocessableEntity, "version_already_current"},
 }
 
 // FromStoreError maps the store's typed errors onto the wire envelope; an

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -66,4 +66,10 @@ func TestOpenAPIDeclaresDigestCheckedUpload(t *testing.T) {
 	require.NotNil(t, replace.RequestBody)
 	assert.Contains(t, replace.RequestBody.Content, "*/*")
 	assert.NotNil(t, replace.Responses["200"])
+
+	revert := doc.Paths["/api/v1/nodes/{id}/revert"].Post
+	require.NotNil(t, revert)
+	require.NotNil(t, revert.RequestBody)
+	assert.Contains(t, revert.RequestBody.Content, "application/json")
+	assert.NotNil(t, revert.Responses["200"])
 }

--- a/internal/api/routes_content_revert.go
+++ b/internal/api/routes_content_revert.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type contentReversionOutput struct {
+	ETag string `header:"ETag"`
+	Body ContentReversionReceipt
+}
+
+func registerContentRevertRoute(api huma.API, d Deps, g *gate) {
+	huma.Register(api, huma.Operation{
+		OperationID: "revertNodeContent", Method: http.MethodPost,
+		Path:    "/api/v1/nodes/{id}/revert",
+		Summary: "Create a new head from one of the file's prior immutable versions",
+		Description: "Reversion is metadata-only: it adopts the source version's existing " +
+			"blob authority and records a new content_revert history row under If-Match.",
+	}, func(ctx context.Context, in *struct {
+		ID      int64  `path:"id" minimum:"1"`
+		IfMatch string `header:"If-Match"`
+		Body    struct {
+			SourceVersionID string `json:"source_version_id" format:"uuid" minLength:"36" maxLength:"36"`
+		}
+	}) (*contentReversionOutput, error) {
+		revision, err := parseIfMatch(in.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+		var out *contentReversionOutput
+		err = g.mutate(func() error {
+			node, version, source, revertErr := d.Store.RevertContent(
+				ctx, in.ID, revision, in.Body.SourceVersionID,
+			)
+			if revertErr != nil {
+				return FromStoreError(revertErr)
+			}
+			out = &contentReversionOutput{
+				ETag: fmt.Sprintf("%q", strconv.FormatInt(node.Revision, 10)),
+				Body: ContentReversionReceipt{
+					Node:          fromStoreNode(node),
+					Version:       fromStoreContentVersion(version),
+					SourceVersion: fromStoreContentVersion(source),
+				},
+			}
+			return nil
+		})
+		return out, err
+	})
+}

--- a/internal/api/routes_content_revert_test.go
+++ b/internal/api/routes_content_revert_test.go
@@ -1,0 +1,134 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func postContentRevert(
+	t *testing.T, tsURL string, client *http.Client, nodeID, revision int64, sourceVersionID string,
+) (*http.Response, []byte) {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"source_version_id": sourceVersionID})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/api/v1/nodes/%d/revert", tsURL, nodeID), bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if revision >= 0 {
+		req.Header.Set("If-Match", fmt.Sprintf("%q", strconv.FormatInt(revision, 10)))
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, responseBody
+}
+
+func TestContentRevertAdoptsPackedPriorVersionWithoutCopyingBlob(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	blobs := s.Blobs
+	created := createFileWithContent(t, ts, s, "/report.txt", "original")
+	packed, err := blobs.Maintainer().Pack(t.Context(), packstore.PackOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, packed.BlobsPacked)
+
+	replacement := []byte("replacement")
+	replacementHash := uploadIdentity(replacement)
+	resp, body := sendContentReplacement(t, ts.URL, ts.Client(), created.ID, created.Revision,
+		replacement, replacementHash, int64(len(replacement)), "text/markdown")
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var replaced api.ContentReplacementReceipt
+	require.NoError(t, json.Unmarshal(body, &replaced))
+	beforeStats, err := blobs.Stats(t.Context())
+	require.NoError(t, err)
+
+	resp, body = postContentRevert(t, ts.URL, ts.Client(), created.ID, replaced.Node.Revision,
+		created.CurrentVersionID)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	assert.Equal(t, `"3"`, resp.Header.Get("ETag"))
+	var receipt api.ContentReversionReceipt
+	require.NoError(t, json.Unmarshal(body, &receipt))
+	assert.Equal(t, created.CurrentVersionID, receipt.SourceVersion.ID)
+	assert.Equal(t, created.BlobHash, receipt.Version.BlobHash)
+	assert.Equal(t, created.MimeType, receipt.Version.MimeType)
+	assert.Equal(t, "content_revert", receipt.Version.TransitionKind)
+	require.NotNil(t, receipt.Version.SourceVersionID)
+	assert.Equal(t, receipt.SourceVersion.ID, *receipt.Version.SourceVersionID)
+	assert.Equal(t, receipt.Version.ID, receipt.Node.CurrentVersionID)
+	afterStats, err := blobs.Stats(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, beforeStats, afterStats, "reversion must not copy loose or packed bytes")
+
+	currentResp, err := ts.Client().Get(fmt.Sprintf("%s/api/v1/nodes/%d/content", ts.URL, created.ID))
+	require.NoError(t, err)
+	current, err := io.ReadAll(currentResp.Body)
+	require.NoError(t, err)
+	require.NoError(t, currentResp.Body.Close())
+	assert.Equal(t, http.StatusOK, currentResp.StatusCode)
+	assert.Equal(t, "original", string(current))
+	assert.Equal(t, receipt.Version.ID, currentResp.Header.Get(api.ContentVersionHeader))
+}
+
+func TestContentRevertRejectsStaleAndInvalidSources(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	first := createFileWithContent(t, ts, s, "/first.txt", "first")
+	second := createFileWithContent(t, ts, s, "/second.txt", "second")
+	replacement := []byte("new first")
+	replacementHash := uploadIdentity(replacement)
+	resp, body := sendContentReplacement(t, ts.URL, ts.Client(), first.ID, first.Revision,
+		replacement, replacementHash, int64(len(replacement)), "text/plain")
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var replaced api.ContentReplacementReceipt
+	require.NoError(t, json.Unmarshal(body, &replaced))
+
+	tests := []struct {
+		name       string
+		revision   int64
+		source     string
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "missing precondition", revision: -1, source: first.CurrentVersionID,
+			wantStatus: http.StatusPreconditionRequired, wantCode: "precondition_required"},
+		{name: "stale", revision: first.Revision, source: first.CurrentVersionID,
+			wantStatus: http.StatusPreconditionFailed, wantCode: "stale_revision"},
+		{name: "other node", revision: replaced.Node.Revision, source: second.CurrentVersionID,
+			wantStatus: http.StatusUnprocessableEntity, wantCode: "version_node_mismatch"},
+		{name: "current", revision: replaced.Node.Revision, source: replaced.Version.ID,
+			wantStatus: http.StatusUnprocessableEntity, wantCode: "version_already_current"},
+		{name: "missing", revision: replaced.Node.Revision,
+			source:     "11111111-1111-4111-8111-111111111111",
+			wantStatus: http.StatusNotFound, wantCode: "not_found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, responseBody := postContentRevert(
+				t, ts.URL, ts.Client(), first.ID, tt.revision, tt.source,
+			)
+			assert.Equal(t, tt.wantStatus, resp.StatusCode, string(responseBody))
+			assert.Contains(t, string(responseBody), fmt.Sprintf(`"code":%q`, tt.wantCode))
+		})
+	}
+
+	unchanged, err := s.NodeByID(t.Context(), first.ID)
+	require.NoError(t, err)
+	assert.Equal(t, replaced.Node.Revision, unchanged.Revision)
+	versions, total, err := s.ContentVersions(t.Context(), first.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, versions, 2)
+	assert.Equal(t, "content_replace", versions[0].TransitionKind)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -91,6 +91,7 @@ func NewServer(d Deps) *Server {
 	registerJobRoutes(humaAPI, d)
 	registerUploadRoute(mux, humaAPI, d, g)
 	registerContentWriteRoute(mux, humaAPI, d, g)
+	registerContentRevertRoute(humaAPI, d, g)
 	s.registerHealth(mux)
 	mux.Handle("GET "+kitPingPath, kitdaemon.NewPingHandler(kitdaemon.PingHandlerOptions{
 		Service: "docbank", Version: version.Version, PID: os.Getpid(),

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -90,6 +90,14 @@ type ContentReplacementReceipt struct {
 	ComputedSize int64          `json:"computed_size" minimum:"0"`
 }
 
+// ContentReversionReceipt proves which immutable source authority was adopted
+// and which new history row became the node's current head.
+type ContentReversionReceipt struct {
+	Node          Node           `json:"node"`
+	Version       ContentVersion `json:"version"`
+	SourceVersion ContentVersion `json:"source_version"`
+}
+
 // SearchHit pairs a matched node with its display path.
 type SearchHit struct {
 	Node Node   `json:"node"`

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -414,7 +414,7 @@ func TestPackedSnapshotRequiresAndUsesPackedRestoreTarget(t *testing.T) {
 	require.NoError(t, restoredStore.Close())
 }
 
-func TestVersionedReplacementRoundTripsPackedPriorContent(t *testing.T) {
+func TestVersionedEditingRoundTripsPackedRevertSource(t *testing.T) {
 	fixture := newArchiveFixture(t)
 	alpha, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")
 	require.NoError(t, err)
@@ -435,6 +435,10 @@ func TestVersionedReplacementRoundTripsPackedPriorContent(t *testing.T) {
 		)
 		return writeErr
 	}))
+	reverted, revertVersion, _, err := fixture.metadata.RevertContent(
+		t.Context(), alpha.ID, replaced.Revision, priorVersionID,
+	)
+	require.NoError(t, err)
 	wantMetadata := exportMetadata(t, fixture.metadata)
 
 	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
@@ -447,7 +451,7 @@ func TestVersionedReplacementRoundTripsPackedPriorContent(t *testing.T) {
 		"backup must include both heads plus the other file")
 	stats, err := backupapp.ParseStats(manifest.Stats)
 	require.NoError(t, err)
-	assert.Equal(t, int64(3), stats.ContentVersions)
+	assert.Equal(t, int64(4), stats.ContentVersions)
 
 	target := filepath.Join(t.TempDir(), "restored")
 	_, err = backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{
@@ -463,11 +467,12 @@ func TestVersionedReplacementRoundTripsPackedPriorContent(t *testing.T) {
 
 	restoredNode, err := restoredStore.NodeByID(t.Context(), alpha.ID)
 	require.NoError(t, err)
-	assert.Equal(t, replaced.CurrentVersionID, restoredNode.CurrentVersionID)
-	assert.Equal(t, int64(2), restoredNode.Revision)
+	assert.Equal(t, reverted.CurrentVersionID, restoredNode.CurrentVersionID)
+	assert.Equal(t, int64(3), restoredNode.Revision)
 	for versionID, want := range map[string]string{
 		priorVersionID:                "alpha backup",
-		restoredNode.CurrentVersionID: replacement,
+		replaced.CurrentVersionID:     replacement,
+		restoredNode.CurrentVersionID: "alpha backup",
 	} {
 		version, versionErr := restoredStore.ContentVersionByID(t.Context(), versionID)
 		require.NoError(t, versionErr)
@@ -479,6 +484,10 @@ func TestVersionedReplacementRoundTripsPackedPriorContent(t *testing.T) {
 		require.NoError(t, stream.Close())
 		assert.Equal(t, want, string(got))
 	}
+	restoredRevert, err := restoredStore.ContentVersionByID(t.Context(), revertVersion.ID)
+	require.NoError(t, err)
+	require.NotNil(t, restoredRevert.SourceVersionID)
+	assert.Equal(t, priorVersionID, *restoredRevert.SourceVersionID)
 	require.NoError(t, restoredBlobs.Close())
 	require.NoError(t, restoredStore.Close())
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -126,6 +126,8 @@ var codeToTypedErr = map[string]error{
 	"invalid_name":             store.ErrInvalidName,
 	"not_trashed":              store.ErrNotTrashed,
 	"is_root":                  store.ErrIsRoot,
+	"version_node_mismatch":    store.ErrVersionNodeMismatch,
+	"version_already_current":  store.ErrVersionAlreadyCurrent,
 	"backup_locked":            backup.ErrRepoLocked,
 	"pack_retirement_deferred": packstore.ErrPackRetirementDeferred,
 }
@@ -664,6 +666,101 @@ func validateReplacementReceipt(
 	expectedETag := fmt.Sprintf("%q", strconv.FormatInt(receipt.Node.Revision, 10))
 	if etag != expectedETag {
 		return fmt.Errorf("content replacement response ETag %q, expected %q", etag, expectedETag)
+	}
+	return nil
+}
+
+// RevertContent creates a new immutable head from one prior version under an
+// optimistic node-revision precondition. The response must bind the requested
+// source, new history row, current node authority, and resulting ETag.
+func (c *Client) RevertContent(
+	ctx context.Context, nodeID, revision int64, sourceVersionID string,
+) (api.ContentReversionReceipt, error) {
+	var receipt api.ContentReversionReceipt
+	if nodeID <= 0 {
+		return receipt, errors.New("reversion node ID must be positive")
+	}
+	if revision < 0 {
+		return receipt, errors.New("reversion revision must not be negative")
+	}
+	if !validUUIDv4(sourceVersionID) {
+		return receipt, errors.New("reversion source must be a canonical UUIDv4")
+	}
+	headers := ifMatch(revision)
+	body, err := marshalJSONRequest(map[string]string{"source_version_id": sourceVersionID})
+	if err != nil {
+		return receipt, fmt.Errorf("encoding content reversion request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/nodes/%d/revert", c.base, nodeID), bytes.NewReader(body))
+	if err != nil {
+		return receipt, fmt.Errorf("building content reversion request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	if c.key != "" {
+		req.Header.Set("X-Api-Key", c.key)
+	}
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return receipt, fmt.Errorf("reverting content of node %d: %w", nodeID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return receipt, decodeError(resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&receipt); err != nil {
+		return receipt, fmt.Errorf("decoding content reversion response: %w", err)
+	}
+	if err := validateReversionReceipt(
+		receipt, resp.Header.Get("ETag"), nodeID, revision, sourceVersionID,
+	); err != nil {
+		return api.ContentReversionReceipt{}, err
+	}
+	return receipt, nil
+}
+
+func validateReversionReceipt(
+	receipt api.ContentReversionReceipt, etag string, nodeID, revision int64, sourceVersionID string,
+) error {
+	if receipt.Node.ID != nodeID || receipt.Version.NodeID != nodeID ||
+		receipt.SourceVersion.NodeID != nodeID {
+		return fmt.Errorf("content reversion receipt targets node %d/%d/%d, expected %d",
+			receipt.Node.ID, receipt.Version.NodeID, receipt.SourceVersion.NodeID, nodeID)
+	}
+	if receipt.Node.Revision != revision+1 || receipt.Version.NodeRevision != receipt.Node.Revision {
+		return fmt.Errorf("content reversion receipt revision %d/%d, expected %d",
+			receipt.Node.Revision, receipt.Version.NodeRevision, revision+1)
+	}
+	if !validUUIDv4(receipt.Version.ID) || receipt.Version.ID == sourceVersionID ||
+		receipt.Node.CurrentVersionID != receipt.Version.ID {
+		return errors.New("content reversion receipt does not install a valid returned version as current")
+	}
+	if receipt.SourceVersion.ID != sourceVersionID || !validUUIDv4(receipt.SourceVersion.ID) {
+		return fmt.Errorf("content reversion receipt source %q, expected %q",
+			receipt.SourceVersion.ID, sourceVersionID)
+	}
+	if receipt.Version.TransitionKind != "content_revert" ||
+		receipt.Version.SourceVersionID == nil ||
+		*receipt.Version.SourceVersionID != sourceVersionID {
+		return errors.New("content reversion receipt does not bind its content_revert source")
+	}
+	if receipt.SourceVersion.NodeRevision >= receipt.Version.NodeRevision {
+		return errors.New("content reversion receipt source is not older than its new head")
+	}
+	if receipt.Node.BlobHash != receipt.SourceVersion.BlobHash ||
+		receipt.Node.Size != receipt.SourceVersion.Size ||
+		receipt.Node.MimeType != receipt.SourceVersion.MimeType ||
+		receipt.Version.BlobHash != receipt.SourceVersion.BlobHash ||
+		receipt.Version.Size != receipt.SourceVersion.Size ||
+		receipt.Version.MimeType != receipt.SourceVersion.MimeType {
+		return errors.New("content reversion receipt authority disagrees with its source version")
+	}
+	expectedETag := fmt.Sprintf("%q", strconv.FormatInt(receipt.Node.Revision, 10))
+	if etag != expectedETag {
+		return fmt.Errorf("content reversion response ETag %q, expected %q", etag, expectedETag)
 	}
 	return nil
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -557,6 +557,91 @@ func TestContentReplacementRejectsUnprovenReceipt(t *testing.T) {
 	}
 }
 
+func TestContentReversionRoundTrip(t *testing.T) {
+	c, s := newClient(t, serverKey)
+	initial := "initial content"
+	initialSum := sha256.Sum256([]byte(initial))
+	created, err := c.Upload(t.Context(), s.RootID(), "versioned.txt", "text/plain",
+		hex.EncodeToString(initialSum[:]), int64(len(initial)), strings.NewReader(initial))
+	require.NoError(t, err)
+	replacement := "replacement"
+	replacementSum := sha256.Sum256([]byte(replacement))
+	replaced, err := c.ReplaceContent(t.Context(), created.Node.ID, created.Node.Revision,
+		"text/markdown", hex.EncodeToString(replacementSum[:]), int64(len(replacement)),
+		strings.NewReader(replacement))
+	require.NoError(t, err)
+
+	receipt, err := c.RevertContent(t.Context(), created.Node.ID, replaced.Node.Revision,
+		created.Node.CurrentVersionID)
+	require.NoError(t, err)
+	assert.Equal(t, created.Node.CurrentVersionID, receipt.SourceVersion.ID)
+	assert.Equal(t, "content_revert", receipt.Version.TransitionKind)
+	assert.Equal(t, created.Node.BlobHash, receipt.Node.BlobHash)
+	assert.Equal(t, "text/plain", receipt.Node.MimeType)
+
+	_, err = c.RevertContent(t.Context(), created.Node.ID, replaced.Node.Revision,
+		created.Node.CurrentVersionID)
+	require.ErrorIs(t, err, store.ErrStaleRevision)
+	_, err = c.RevertContent(t.Context(), created.Node.ID, receipt.Node.Revision, receipt.Version.ID)
+	require.ErrorIs(t, err, store.ErrVersionAlreadyCurrent)
+	other := "other content"
+	otherSum := sha256.Sum256([]byte(other))
+	otherNode, err := c.Upload(t.Context(), s.RootID(), "other.txt", "text/plain",
+		hex.EncodeToString(otherSum[:]), int64(len(other)), strings.NewReader(other))
+	require.NoError(t, err)
+	_, err = c.RevertContent(t.Context(), created.Node.ID, receipt.Node.Revision,
+		otherNode.Node.CurrentVersionID)
+	require.ErrorIs(t, err, store.ErrVersionNodeMismatch)
+}
+
+func TestContentReversionRejectsUnprovenReceipt(t *testing.T) {
+	const (
+		sourceID = "11111111-1111-4111-8111-111111111111"
+		newID    = "22222222-2222-4222-8222-222222222222"
+	)
+	hash := strings.Repeat("a", 64)
+	base := api.ContentReversionReceipt{
+		Node: api.Node{ID: 7, Revision: 4, CurrentVersionID: newID,
+			BlobHash: hash, Size: 12, MimeType: "text/plain"},
+		Version: api.ContentVersion{ID: newID, NodeID: 7, NodeRevision: 4,
+			BlobHash: hash, Size: 12, MimeType: "text/plain", TransitionKind: "content_revert",
+			SourceVersionID: new(string)},
+		SourceVersion: api.ContentVersion{ID: sourceID, NodeID: 7, NodeRevision: 1,
+			BlobHash: hash, Size: 12, MimeType: "text/plain", TransitionKind: "content_create"},
+	}
+	*base.Version.SourceVersionID = sourceID
+	tests := map[string]func(*api.ContentReversionReceipt){
+		"node":       func(r *api.ContentReversionReceipt) { r.Node.ID++ },
+		"revision":   func(r *api.ContentReversionReceipt) { r.Version.NodeRevision++ },
+		"new head":   func(r *api.ContentReversionReceipt) { r.Node.CurrentVersionID = sourceID },
+		"source":     func(r *api.ContentReversionReceipt) { r.SourceVersion.ID = newID },
+		"transition": func(r *api.ContentReversionReceipt) { r.Version.TransitionKind = "content_replace" },
+		"binding": func(r *api.ContentReversionReceipt) {
+			other := newID
+			r.Version.SourceVersionID = &other
+		},
+		"authority": func(r *api.ContentReversionReceipt) { r.Version.Size++ },
+		"etag":      func(_ *api.ContentReversionReceipt) {},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			receipt := base
+			source := sourceID
+			receipt.Version.SourceVersionID = &source
+			mutate(&receipt)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if name != "etag" {
+					w.Header().Set("ETag", `"4"`)
+				}
+				_ = json.NewEncoder(w).Encode(receipt)
+			}))
+			t.Cleanup(ts.Close)
+			_, err := client.New(ts.URL, "key").RevertContent(t.Context(), 7, 3, sourceID)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestStorageRepackRoundTrip(t *testing.T) {
 	c, _ := newClient(t, serverKey)
 	for name, content := range map[string]string{

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "13"
+	daemonProtocolVersion = "14"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -22,6 +22,12 @@ var (
 	// ErrStaleRevision means a mutation's expected revision no longer
 	// matches the node (lost-update guard for If-Match).
 	ErrStaleRevision = errors.New("revision mismatch")
+	// ErrVersionNodeMismatch means a requested source version belongs to a
+	// different stable file node.
+	ErrVersionNodeMismatch = errors.New("content version belongs to another node")
+	// ErrVersionAlreadyCurrent means a revert selected the node's current head,
+	// which is not a historical transition.
+	ErrVersionAlreadyCurrent = errors.New("content version is already current")
 )
 
 // UnconditionalRev is the only ifRev value that skips the revision

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -9,8 +9,9 @@ import (
 )
 
 // ContentVersion is one immutable byte identity recorded for a stable file
-// node. Initial ingest creates content_create records and verified replacement
-// adds content_replace heads without changing this read contract.
+// node. Initial ingest creates content_create records, verified replacement
+// adds content_replace heads, and reversion adds content_revert heads that
+// retain their source identity.
 type ContentVersion struct {
 	ID                    string
 	NodeID                int64
@@ -151,41 +152,117 @@ func (s *Store) ReplaceContent(
 		if err := s.EnsureBlobTx(tx, blobHash, size); err != nil {
 			return err
 		}
-		versionID, err := newUUIDv4()
-		if err != nil {
-			return err
-		}
-		operationID, err := newUUIDv4()
-		if err != nil {
-			return err
-		}
-		now := nowRFC3339()
-		newRevision := n.Revision + 1
-		var storedMime any
-		if mimeType != "" {
-			storedMime = mimeType
-		}
-		if _, err := tx.Exec(
-			`INSERT INTO content_versions (
-				version_id, node_id, blob_hash, size, mime_type, recorded_at,
-				node_revision, introduced_operation_id, transition_kind, source_version_id
-			 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'content_replace', NULL)`,
-			versionID, nodeID, blobHash, size, storedMime, now, newRevision, operationID); err != nil {
-			return fmt.Errorf("recording replacement content version for node %d: %w", nodeID, err)
-		}
-		if _, err := tx.Exec(
-			`UPDATE nodes SET current_version_id = ?, revision = ?, modified_at = ? WHERE id = ?`,
-			versionID, newRevision, now, nodeID); err != nil {
-			return fmt.Errorf("installing replacement content version for node %d: %w", nodeID, err)
-		}
-		updated, err = nodeByIDTx(tx, nodeID)
-		if err != nil {
-			return err
-		}
-		version, err = scanContentVersion(tx.QueryRow(
-			`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`, versionID))
+		updated, version, err = installContentVersionTx(
+			tx, n, blobHash, size, mimeType, "content_replace", nil,
+		)
 		return err
 	})
+	if err != nil {
+		return Node{}, ContentVersion{}, err
+	}
+	return updated, version, nil
+}
+
+// RevertContent creates a new immutable head with the exact content authority
+// and media type of sourceVersionID. It records the source identity rather than
+// rewinding the node or changing any historical row.
+func (s *Store) RevertContent(
+	ctx context.Context, nodeID, ifRev int64, sourceVersionID string,
+) (Node, ContentVersion, ContentVersion, error) {
+	if err := validateUUIDv4(sourceVersionID); err != nil {
+		return Node{}, ContentVersion{}, ContentVersion{},
+			fmt.Errorf("content version %q: %w", sourceVersionID, ErrNotFound)
+	}
+	var (
+		updated Node
+		version ContentVersion
+		source  ContentVersion
+	)
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		n, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		if err := validateContentReplacementTarget(n, ifRev); err != nil {
+			return err
+		}
+		source, err = scanContentVersion(tx.QueryRow(
+			`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`, sourceVersionID))
+		if err != nil {
+			return fmt.Errorf("content version %q: %w", sourceVersionID, err)
+		}
+		if source.NodeID != nodeID {
+			return fmt.Errorf("content version %s belongs to node %d, not node %d: %w",
+				source.ID, source.NodeID, nodeID, ErrVersionNodeMismatch)
+		}
+		if source.ID == n.CurrentVersionID {
+			return fmt.Errorf("content version %s is the current head of node %d: %w",
+				source.ID, nodeID, ErrVersionAlreadyCurrent)
+		}
+		if source.NodeRevision >= n.Revision+1 {
+			return fmt.Errorf("source version %s revision %d is not older than node %d next revision %d",
+				source.ID, source.NodeRevision, nodeID, n.Revision+1)
+		}
+		var catalogSize int64
+		if err := tx.QueryRow(`SELECT size FROM blobs WHERE hash = ?`, source.BlobHash).
+			Scan(&catalogSize); err != nil {
+			return fmt.Errorf("checking source blob %s: %w", source.BlobHash, err)
+		}
+		if catalogSize != source.Size {
+			return fmt.Errorf("source version %s records %d bytes but blob %s records %d",
+				source.ID, source.Size, source.BlobHash, catalogSize)
+		}
+		updated, version, err = installContentVersionTx(
+			tx, n, source.BlobHash, source.Size, source.MimeType, "content_revert", &source.ID,
+		)
+		return err
+	})
+	if err != nil {
+		return Node{}, ContentVersion{}, ContentVersion{}, err
+	}
+	return updated, version, source, nil
+}
+
+func installContentVersionTx(
+	tx *sql.Tx, n Node, blobHash string, size int64, mimeType, transitionKind string,
+	sourceVersionID *string,
+) (Node, ContentVersion, error) {
+	versionID, err := newUUIDv4()
+	if err != nil {
+		return Node{}, ContentVersion{}, err
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return Node{}, ContentVersion{}, err
+	}
+	now := nowRFC3339()
+	newRevision := n.Revision + 1
+	var storedMime any
+	if mimeType != "" {
+		storedMime = mimeType
+	}
+	if _, err := tx.Exec(
+		`INSERT INTO content_versions (
+			version_id, node_id, blob_hash, size, mime_type, recorded_at,
+			node_revision, introduced_operation_id, transition_kind, source_version_id
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		versionID, n.ID, blobHash, size, storedMime, now, newRevision, operationID,
+		transitionKind, sourceVersionID); err != nil {
+		return Node{}, ContentVersion{}, fmt.Errorf(
+			"recording %s content version for node %d: %w", transitionKind, n.ID, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE nodes SET current_version_id = ?, revision = ?, modified_at = ? WHERE id = ?`,
+		versionID, newRevision, now, n.ID); err != nil {
+		return Node{}, ContentVersion{}, fmt.Errorf(
+			"installing %s content version for node %d: %w", transitionKind, n.ID, err)
+	}
+	updated, err := nodeByIDTx(tx, n.ID)
+	if err != nil {
+		return Node{}, ContentVersion{}, err
+	}
+	version, err := scanContentVersion(tx.QueryRow(
+		`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`, versionID))
 	if err != nil {
 		return Node{}, ContentVersion{}, err
 	}

--- a/internal/store/write_test.go
+++ b/internal/store/write_test.go
@@ -172,6 +172,104 @@ func TestReplaceContentRejectsInvalidTargetAndStaleRevision(t *testing.T) {
 	assert.Zero(t, candidateBlobs, "failed replacements must not grant blob authority")
 }
 
+func TestRevertContentCreatesNewHeadFromPriorAuthority(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	created, err := s.CreateFile(ctx, s.RootID(), "report.txt", fakeHash("a1"), 3, "text/plain")
+	require.NoError(t, err)
+	replaced, replacement, err := s.ReplaceContent(
+		ctx, created.ID, created.Revision, fakeHash("b2"), 4, "text/markdown",
+	)
+	require.NoError(t, err)
+
+	reverted, revertVersion, source, err := s.RevertContent(
+		ctx, created.ID, replaced.Revision, created.CurrentVersionID,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, created.CurrentVersionID, source.ID)
+	assert.Equal(t, created.BlobHash, revertVersion.BlobHash)
+	assert.Equal(t, created.Size, revertVersion.Size)
+	assert.Equal(t, created.MimeType, revertVersion.MimeType)
+	assert.Equal(t, "content_revert", revertVersion.TransitionKind)
+	require.NotNil(t, revertVersion.SourceVersionID)
+	assert.Equal(t, source.ID, *revertVersion.SourceVersionID)
+	assert.Equal(t, revertVersion.ID, reverted.CurrentVersionID)
+	assert.Equal(t, replaced.Revision+1, reverted.Revision)
+
+	// Repeating the same historical choice is another explicit operation. The
+	// current reversion row is distinct from its immutable source identity.
+	repeated, repeatedVersion, _, err := s.RevertContent(
+		ctx, created.ID, reverted.Revision, created.CurrentVersionID,
+	)
+	require.NoError(t, err)
+	assert.NotEqual(t, revertVersion.ID, repeatedVersion.ID)
+	assert.Equal(t, created.BlobHash, repeatedVersion.BlobHash)
+	assert.Equal(t, reverted.Revision+1, repeated.Revision)
+
+	versions, total, err := s.ContentVersions(ctx, created.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 4, total)
+	require.Len(t, versions, 4)
+	assert.Equal(t, repeatedVersion.ID, versions[0].ID)
+	assert.Equal(t, revertVersion.ID, versions[1].ID)
+	assert.Equal(t, replacement.ID, versions[2].ID)
+	assert.Equal(t, created.CurrentVersionID, versions[3].ID)
+	var blobCount int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM blobs`).Scan(&blobCount))
+	assert.Equal(t, 2, blobCount, "reversion must not create or copy a blob")
+}
+
+func TestRevertContentRejectsInvalidSourceAndTarget(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	first, err := s.CreateFile(ctx, s.RootID(), "first.txt", fakeHash("a1"), 3, "text/plain")
+	require.NoError(t, err)
+	second, err := s.CreateFile(ctx, s.RootID(), "second.txt", fakeHash("b2"), 4, "text/plain")
+	require.NoError(t, err)
+	dir, err := s.Mkdir(ctx, s.RootID(), "folder")
+	require.NoError(t, err)
+
+	rejectedNode, rejectedVersion, rejectedSource, err := s.RevertContent(
+		ctx, first.ID, first.Revision, first.CurrentVersionID,
+	)
+	require.ErrorIs(t, err, ErrVersionAlreadyCurrent)
+	assert.Equal(t, Node{}, rejectedNode)
+	assert.Equal(t, ContentVersion{}, rejectedVersion)
+	assert.Equal(t, ContentVersion{}, rejectedSource)
+	wrongNode, wrongVersion, wrongSource, err := s.RevertContent(
+		ctx, first.ID, first.Revision, second.CurrentVersionID,
+	)
+	require.ErrorIs(t, err, ErrVersionNodeMismatch)
+	assert.Equal(t, Node{}, wrongNode)
+	assert.Equal(t, ContentVersion{}, wrongVersion)
+	assert.Equal(t, ContentVersion{}, wrongSource)
+	staleNode, staleVersion, staleSource, err := s.RevertContent(
+		ctx, first.ID, first.Revision+1, second.CurrentVersionID,
+	)
+	require.ErrorIs(t, err, ErrStaleRevision)
+	assert.Equal(t, Node{}, staleNode)
+	assert.Equal(t, ContentVersion{}, staleVersion)
+	assert.Equal(t, ContentVersion{}, staleSource)
+	dirNode, dirVersion, dirSource, err := s.RevertContent(
+		ctx, dir.ID, dir.Revision, first.CurrentVersionID,
+	)
+	require.ErrorIs(t, err, ErrNotFile)
+	assert.Equal(t, Node{}, dirNode)
+	assert.Equal(t, ContentVersion{}, dirVersion)
+	assert.Equal(t, ContentVersion{}, dirSource)
+	missingNode, missingVersion, missingSource, err := s.RevertContent(ctx, first.ID, first.Revision,
+		"11111111-1111-4111-8111-111111111111")
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Equal(t, Node{}, missingNode)
+	assert.Equal(t, ContentVersion{}, missingVersion)
+	assert.Equal(t, ContentVersion{}, missingSource)
+
+	versions, total, err := s.ContentVersions(ctx, first.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, versions, 1)
+}
+
 func TestContentVersionsRequiresBoundedPage(t *testing.T) {
 	s := newTestStore(t)
 	file, err := s.CreateFile(t.Context(), s.RootID(), "bounded.txt", fakeHash("a1"), 1, "text/plain")


### PR DESCRIPTION
Version history should be directly usable, not merely inspectable. Before this change, restoring an earlier document state meant downloading its bytes and sending them back through `put`, adding unnecessary I/O and obscuring the fact that the new choice came from a specific immutable version already owned by Docbank.

This PR makes reversion a first-class optimistic metadata transition. `docbank revert <vault-path> <version-id>` and `POST /api/v1/nodes/{id}/revert` create a new `content_revert` head that names the selected source and reproduces its hash, size, and media type exactly. The source must belong to the same file and cannot already be current; stale decisions fail without changing history. The typed client accepts success only when the node, source, new version, resulting revision, and ETag all agree.

No blob is read, copied, or rewritten, so an old packed version becomes current without storage churn. Every prior and intervening version remains addressable, repeated historical choices remain explicit operations, and deterministic JSONL backup/restore preserves the source link and current bytes. Interactive editing and pruning remain separate slices.

The repository gates and race-enabled store, API, client, backup, and CLI lifecycle coverage are green. Kata: `y6fv`.