### PR TITLE
Keep documentation capability-focused

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,13 @@ Instructions for autonomous coding agents working in this repository.
   surface is status, pack, and repack. Do not expose Kit's unpack primitive as
   a general API or CLI command; reserve it for tests, migrations, or a
   purpose-built emergency recovery workflow with a demonstrated need.
-- User-facing docs describe only what exists; planned behavior sits under
-  `!!! info "Planned"` admonitions.
+- Documentation is not the implementation tracker. User- and agent-facing
+  pages describe shipped capabilities and current limitations. Architecture
+  and internal pages may preserve durable future design under explicit
+  `!!! info "Planned"` admonitions, but must not carry task breakdowns,
+  sequencing, ownership, or completion criteria. `docs/roadmap.md` is the one
+  high-level public product-status view; kata is the sole source of truth for
+  actionable work and its status.
 - No storage compatibility boundary exists before the first public release.
   Keep the live schema and deterministic JSONL authority at format v1, make
   breaking pre-release changes directly, and treat vaults created by earlier

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,6 @@ plus internal design material.
 - `stylesheets/` — published visual theme
 - `scripts/` — source and built-site validation (never published)
 - `internal/` — living agent/developer design documentation (never published)
-- `superpowers/` — transient working specs and implementation plans for
-  in-flight development (never published; exists only while a project
-  is being executed)
 - `zensical.toml` — site configuration
 - `zensical-docs.sh` — build wrapper; validates sources, copies publishable
   content into a temporary tree, and checks the generated site's links,
@@ -37,17 +34,18 @@ uv sync --frozen          # one-time: installs zensical into docs/.venv
 Or from the repository root: `make docs-install`, `make docs-serve`,
 `make docs-build`.
 
-## Conventions
+## Documentation boundary
 
-- User-facing pages document only what the current binary does. Planned
-  behavior lives in the Architecture section and is labeled with a
-  `!!! info "Planned — Phase N"` admonition. Do not document flags or
-  endpoints that do not exist yet outside those admonitions.
-- The Architecture pages are the digested, maintained form of the superpowers
-  specs. When a design decision changes, update the Architecture page in the
-  same PR. Once a project ships and its design content is digested into
-  the site, delete its spec and plan — git history keeps the
-  point-in-time record; the working tree carries only maintained docs.
+- User- and agent-facing pages explain shipped capabilities, exact contracts,
+  and current limitations. They do not inventory future commands or endpoints.
+- Public Architecture pages explain product behavior and durable boundaries.
+  A future contract belongs there only when it materially explains design
+  intent, and is always isolated under an explicit `!!! info "Planned"`
+  admonition.
 - `internal/` is the definitive developer description of how the system works
   and why. Update it in place with implementation changes; revise the matching
   public Architecture page when user-visible behavior or boundaries change.
+- `roadmap.md` is the one high-level public view of product direction and
+  status. It is not an execution ledger.
+- Kata is the sole source of truth for actionable work, sequencing, ownership,
+  blockers, and completion state. Do not copy that state into documentation.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -68,21 +68,6 @@ non-goals.
 6. **Dry run before policy-changing maintenance.** Preview destructive work,
    evaluate the result, then make the separate explicit run request.
 
-!!! info "Planned — audited scopes"
-    A full-audit scope will make membership sticky and retain every successful
-    authoritative mutation and content version. Ordinary trash remains
-    reversible; trash empty will loudly exclude protected roots while removing
-    eligible ordinary trash, and version pruning and GC cannot remove protected
-    history. Refused protected mutations return every blocking scope. Agents
-    must inspect the preview's structured `vault_metadata_retention` inventory
-    as well as its scope baseline. The irreversible enable operation requires
-    both the server-issued preview token and
-    `acknowledge_vault_metadata_retention: true`; an agent must not supply that
-    acknowledgment unless its caller explicitly approved permanent metadata
-    retention outside the selected scope. Agents can inspect and verify history,
-    but no normal agent surface will destroy it. See
-    [Audited History](architecture/audited-history.md).
-
 ## Common agent workflows
 
 - **File local material:** preflight large server-side trees with the intended

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -114,52 +114,12 @@ Backup reachability is intentionally broader than GC reachability: every
 not yet been reclaimed. This preserves the deletion pipeline's regret window
 inside the snapshot.
 
-!!! info "Planned — editing and audited-history authority"
-    Before the first public release, `docbank-metadata-jsonl-v1` will directly
-    adopt the stable vault ID, node-ID allocator
-    high-water mark, content versions and current references, and non-reusable
-    tag identities plus every retained ingest record without audit genesis or
-    lineage. Enabling the first audit scope will extend that same v1
-    authority with scopes, sticky memberships, shared enrollment-baseline
-    batches and digests, mutation records, a complete vault-topology genesis
-    snapshot, canonical unknown-origin records, baseline
-    ancestor-spine witness generations, witness-change lists, atomic topology
-    deltas, independently replayable net path-effect commitments, per-scope
-    chain entries/heads, a stable vault ID, both allocator high-water marks, a
-    vault-wide allocation lineage, and authoritative tag/provenance attachments
-    with their referenced records.
-    Every protected historical blob becomes snapshot content. Audit snapshots
-    also carry the vault-wide topology tombstones and tag/ingest/provenance
-    lineage required for replay, including metadata for unaudited nodes; this
-    does not by itself retain their content bytes. Import,
-    verification, and restore must recompute baseline digests from immutable
-    enrollment snapshots, replay the complete vault topology from its genesis,
-    derive every enrollment's exact trash-origin closure, and derive every
-    topology delta's net affected member and witness sets from the prior
-    projections. They reconcile attached metadata, verify later mutations and
-    allocation lineage separately, restore the allocators at the verified
-    lineage tail, and reject an internally missing, malformed, reordered,
-    truncated, or hash-inconsistent stream before publishing the database. Each
-    canonical mutation is bound to exactly one allocation-lineage entry by
-    operation ID and mutation hash;
-    every post-audit topology delta is likewise bound by operation ID and delta
-    digest even when it has no scoped audit effect; witness-change counts and
-    digests are bound the same way.
-    Snapshot manifests carry an evidence bundle containing the stable vault ID,
-    every scope count/head, and allocation-lineage count/head. When independently
-    trusted, that manifest or bundle is rollback evidence; a fresh import without
-    such an external reference cannot detect a coherently rewritten set of
-    chains.
-
-    Before overwriting an existing audited target, restore inspects it under
-    the target lock. The snapshot must have the same vault ID and prove every
-    existing scope head and the vault-wide allocation-lineage head as prefixes
-    at their existing counts; missing, shorter, divergent, pre-audit, or
-    unrelated history is refused before cleanup. Because every authoritative
-    operation carries a random operation ID in that lineage, independently
-    mutated copies cannot pass merely by consuming equal numeric allocator
-    values. The complete contract is in
-    [Audited History](audited-history.md).
+The current JSONL authority round-trips the node allocator high-water mark,
+blobs, tree and trash state, content versions and current pointers, ingests,
+provenance, tags, and extraction records. Its relational validation runs before
+a restored database is published. Audit scopes do not exist in the current
+store; their separate planned backup contract is maintained in
+[Audited History](audited-history.md).
 
 ## Boundary with packed storage
 

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -20,10 +20,9 @@ is no separate code path that opens the store directly — the CLI's own
 commands are the design test that the agent-facing API is sufficient,
 because the CLI has no other way to reach the vault.
 
-This replaces Phase 1's model, where every command opened the store and
-coordinated through the vault lock directly ([Concurrency &
-Locking](locking.md) covers the daemon's single-lock-holder model that
-results).
+Earlier development builds let every command open the store and coordinate
+through the vault lock directly. The current single-lock-holder model is
+described in [Concurrency & Locking](locking.md).
 
 ## Lifecycle
 

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -126,17 +126,13 @@ Its receipt returns the resulting node, the new reversion row, the complete
 source version, and the resulting ETag. Clients accept success only when all
 node, revision, source, and content-authority fields agree.
 
-## Planned editing and retention
+## Current retention behavior
 
-!!! info "Planned — Phase 2b"
-    Interactive `edit` will use private staging and the implemented replacement
-    transaction. It must require optimistic concurrency rather than overwriting
-    another actor's head.
-
-    Version pruning is explicit and releases blob reachability only when its
-    metadata row is removed. No automatic retention policy is the default. A
-    version protected by a [full-audit scope](audited-history.md) is never
-    eligible for ordinary pruning.
+`put` and `revert` retain every prior content version. Docbank currently has no
+interactive `edit` command, version-pruning command, or automatic retention
+policy, so recorded versions remain reachability roots. The planned
+[full-audit contract](audited-history.md) defines a stronger permanent-retention
+mode separately from this current behavior.
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -5,13 +5,9 @@ description: The agent-first HTTP API — filesystem-shaped endpoints, revision 
 
 # HTTP API
 
-!!! info "Implemented, with exceptions"
-    The endpoints below marked **Implemented** exist in `docbank daemon run`
-    today and back the CLI's data commands — the CLI is an HTTP client
-    of exactly this surface, with no other path into the vault. Rows
-    under the "Planned" admonitions further down (interactive editing,
-    tags, batch move) are designed but not built; see
-    [Roadmap](../roadmap.md).
+The endpoints below exist in `docbank daemon run` and back the CLI's data
+commands — the CLI is an HTTP client of exactly this surface, with no other
+path into the vault.
 
 **Design test: an agent must be able to do everything the CLI can,
 through the API alone.** Agents are not a secondary interface bolted
@@ -58,13 +54,6 @@ and `/` (the placeholder web UI, when `[web] enabled`). A hidden `POST
 /api/daemon/shutdown` (not in the OpenAPI document) backs `docbank
 daemon stop`; it isn't auth-exempt, so it requires both the API key and
 its own shutdown token.
-
-!!! info "Planned"
-    Not yet implemented: interactive edit and version pruning
-    ([Editing & Versions](editing-and-versions.md));
-    tags (`GET /tags` + CRUD, tag filters on search), whose IDs are opaque
-    non-reusable UUIDv4 values independent of mutable names; and
-    `POST /batch/move` bulk reorganization with `dry_run`.
 
 IDs are canonical everywhere: every response carries them, and mutating
 endpoints address nodes by ID so a rename can't strand a concurrent
@@ -208,8 +197,8 @@ per-path `failed` entries), backing `docbank add`. Paths must be
 **absolute**: the long-lived daemon's working directory is meaningless,
 so a relative path is rejected with `422`. The CLI resolves `docbank
 add`'s arguments to absolute paths before calling, so the command-line
-UX (relative paths, `cwd`-relative sources) is unchanged from Phase 1.
-Collisions resolve by the same suffixing rules as Phase 1's import.
+UX still accepts relative and `cwd`-relative sources. Collisions resolve by the
+same suffixing rules as other imports.
 
 `POST /ingest/stream` accepts the same body and returns
 `application/x-ndjson`. A metadata-only `scan` stage establishes advisory file
@@ -327,15 +316,10 @@ A stale target returns `412 stale_revision`. A source from another node returns
 `422 version_node_mismatch`, selecting the current head returns
 `422 version_already_current`, and an unknown source returns `404 not_found`.
 
-!!! info "Planned"
-    Ingest provenance today is filesystem-shaped: each import records
-    the source's original path and mtime in the store's `provenance`
-    table (the path is a record, never identity). Generalizing it —
-    `source_kind` / `source_ref` / `source_meta` fields for non-file
-    origins — and node lookup by content hash are planned so external
-    applications can trace a node to its origin and deduplicate against
-    the vault; see the
-    [roadmap](../roadmap.md#phase-2b-features-designed).
+Ingest provenance is currently filesystem-shaped: each import records the
+source's original path and mtime in the store's `provenance` table. The path is
+a record, never node identity. Non-file origin fields and lookup by content
+hash are not part of the current API.
 
 ## Maintenance gate
 
@@ -404,32 +388,6 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `pack_retirement_deferred` | 503 | repack authority committed but an old source pack remains physically locked; release the lock, then run `storage pack` reconciliation |
 | `unauthorized` | 401 | missing or invalid API key; bad shutdown token |
 | `internal` | 500 | unmapped error (still surfaced with a message — this is a single-user local daemon, not a hardened multi-tenant service) |
-
-!!! info "Planned — audited-history API"
-    One bounded, cursor-paginated model will expose audit scope status, sticky
-    membership, canonical mutation events, content versions, comparison
-    metadata, and chain verification to CLI, agent, TUI, and web clients. Status
-    and terminal verification responses will expose one rollback-evidence
-    bundle: stable vault ID, every scope count/head, and allocation-lineage
-    count/head. Expected-state verification checks all of those fields, including
-    lineage advances caused only by unaudited operations. Mutation events expose
-    a unique per-transaction `operation_id` and an optional `grouping_id` for a
-    command or job spanning several transactions; grouping never implies atomic
-    commit. Scope preview returns a short-lived token bound to the baseline and
-    vault preview generation plus `vault_metadata_retention`: whether the
-    vault-wide lineage is newly activated or already active, genesis record
-    counts by kind, estimated serialized bytes, the retained metadata classes,
-    and `unaudited_content_retained: false`. Enablement requires both that token
-    and `acknowledge_vault_metadata_retention: true`; omitting or falsifying the
-    acknowledgment is a validation error, never implicit consent.
-    `audit_not_enrolled` (409) means
-    a requested node timeline has no audit authority. `audit_protected` (409)
-    refuses an incompatible mutation and carries a `blocking_scopes` array;
-    overlapping scopes are never collapsed to one. `audit_preview_stale` (409)
-    means the one-use preview token expired, the daemon restarted, another
-    execution consumed it, or authoritative state advanced. Credentialed
-    clients will not receive an ordinary audit-destruction operation. See
-    [Audited History](audited-history.md).
 
 ## Non-goals
 

--- a/docs/architecture/locking.md
+++ b/docs/architecture/locking.md
@@ -39,8 +39,8 @@ not delete a temp file another process is actively writing.
 daemon run` takes exclusively (`TryLockExclusive`) at startup and releases
 only on shutdown. Unix uses `flock(2)` and Windows uses `LockFileEx`. Because
 it's a single long-lived process rather than one lock
-acquisition per command, the shared/exclusive split from Phase 1 is
-gone: with all access funneled through one process, the daemon *is* the
+acquisition per command, no per-command shared/exclusive split remains:
+with all access funneled through one process, the daemon *is* the
 serialization point, and a second daemon on the same vault is impossible
 by construction.
 
@@ -109,13 +109,13 @@ Windows.
 ## The maintenance gate: serializing inside the daemon
 
 With one process holding the vault lock for its whole run, `gc --run`,
-`trash empty`, and `verify` can no longer take the *vault* lock
-exclusively the way Phase 1's CLI did — the daemon already holds it.
+`trash empty`, and `verify` cannot take the *vault* lock exclusively per
+command — the daemon already holds it.
 Instead, an in-process `sync.RWMutex`-shaped gate serializes maintenance
 against regular mutations: ordinary mutating API handlers take the read
 side (concurrent with each other), and `gc --run`/`trash empty`/`verify`
 take the write side, giving them the same "observe a quiescent vault"
-guarantee the exclusive vault lock gave Phase 1's `gc`. Requests queue rather
+guarantee as an exclusive per-command lock. Requests queue rather
 than fail. See [HTTP API: maintenance gate](http-api.md#maintenance-gate)
 for the request-handling detail.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -43,9 +43,9 @@ flowchart TD
 | What contract do the CLI and agents share? | [HTTP API](http-api.md) |
 | Which failures and adversaries are in scope? | [Integrity & Threat Model](integrity.md) |
 
-The [Roadmap](../roadmap.md) is the authority for planned features. These
-architecture pages describe implemented boundaries first and isolate future
-behavior in explicit planned callouts.
+The [Roadmap](../roadmap.md) gives high-level product direction. These
+architecture pages describe implemented boundaries and durable design intent;
+kata remains the authority for implementation work and status.
 
 ## The two-layer split
 
@@ -88,13 +88,6 @@ the node's current pointer under a revision precondition rather than rewriting
 a blob. See
 [Editing & Versions](editing-and-versions.md).
 
-!!! info "Planned — full audit"
-    Selected directory scopes will be able to retain every authoritative
-    mutation and content version with sticky membership, tamper-evident event
-    chains, and complete JSONL backup/restore fidelity. Ordinary deletion and
-    GC will be unable to erase protected history. See
-    [Audited History](audited-history.md).
-
 ## Component responsibilities
 
 - **`internal/store`** — SQLite schema and every tree operation. Typed
@@ -136,10 +129,7 @@ a blob. See
 - Trash, permanent metadata deletion, and physical byte reclamation are
   separate decisions.
 
-!!! info "Planned — later clients and features"
-    Interactive editing, full audit, tags, watched inboxes, text extraction,
-    the kit-ui web portal, and the focused TUI remain planned.
-    Later clients must not bypass the implemented backup and restore API.
-    Backup initialization, creation, listing, verification, and restore use the
-    daemon boundary above. Later features must not introduce a privileged path
-    around the daemon or mutable blob bytes. See the [Roadmap](../roadmap.md).
+Any future client or feature remains subject to these boundaries: it uses the
+daemon API, immutable blob bytes, and the implemented backup/restore surface.
+The [Audited History](audited-history.md) page records the separate planned
+retention contract where that future design matters.

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -60,26 +60,6 @@ Current GC keeps that row while any live node, trashed node, or recorded prior
 version refers to it. Kit therefore accepts an application-supplied catalog
 and does not own either application's schema or garbage-collection policy.
 
-## Adoption sequence
-
-1. **Complete:** prove msgvault's pack, logical-delete, repack, reader-retirement,
-   backup-overlap, unpack, and crash-recovery lifecycle.
-2. **Complete:** extract that lifecycle into Kit behind application-neutral
-   catalog interfaces and migrate msgvault without observable behavior change.
-3. **Complete:** add docbank's SQLite catalog, mixed reader, durable loose
-   writer, GC integration, and the Kit catalog conformance suite.
-4. **Complete:** expose read-only loose, live-packed, and dead-packed storage
-   inventory through the authenticated daemon API and CLI.
-5. **Complete:** expose explicit, optionally budgeted packing through the
-   daemon maintenance gate and Kit coordinator.
-6. **Complete:** expose policy-selected sparse repacking and reader-safe source
-   retirement through the same ordering.
-
-!!! info "Planned — next adoption steps"
-    Built-in backup and external integrations will use the catalog and
-    content-hash boundary rather than private pack internals. Automatic storage
-    maintenance remains deferred until watched-inbox policy lands.
-
 ## Consequences for docbank
 
 Docbank owns only its catalog adapter, daemon wiring, migration policy, and
@@ -119,8 +99,6 @@ an implementation format that docbank should own. Recovery belongs in verified
 backup/restore or a concrete repair workflow; the existence of a low-level Kit
 operation is not by itself a product use case.
 
-!!! info "Planned — external reachability"
-    Editing and versions, generalized provenance, and external references must
-    define their liveness policy at the docbank catalog boundary. Whether an
-    external reference pins content or merely detects a dangling reference is
-    intentionally unresolved and must be decided before that schema lands.
+Automatic storage maintenance and external content references are not current
+operator capabilities. Backup, replacement, reversion, and maintenance already
+use the catalog and content-hash boundary rather than private pack internals.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -79,40 +79,10 @@ UUIDv4 values. `(node_id, node_revision)` and
 [Editing & Versions](editing-and-versions.md) for the read and retention
 contract.
 
-!!! info "Planned — full-audit schema"
-    Audit scopes, sticky memberships, mutation records, and chain state will be
-    current-schema metadata included in deterministic JSONL rather than
-    inferred from paths or pack layout. The one JSONL format remains version 1
-    with or without audit scopes.
-    Audited trash origins will retain immutable parent IDs and names
-    outside nullable live foreign-key semantics, so deleting an unaudited origin
-    cannot rewrite protected history. The existing `trash_parent` becomes a
-    non-authoritative locator excluded from audit hashing and reconciliation.
-    Audit baselines and replay also cover `node_tags` with their `tags` records
-    and `provenance` with referenced `ingests`; FTS and `extracted_text` remain
-    rebuildable derived data outside audit authority. Ingest and provenance
-    records become immutable facts, with database guards preventing ordinary
-    update or deletion when an audited member roots them.
-    Tag IDs likewise become canonical non-reusable UUIDv4 values; tag names may
-    change or be recreated without retargeting historical assignments. Once any
-    scope exists, node insertion/deletion and parent/name/trash changes require a
-    guarded audit transaction whose precomputed membership, baseline,
-    descendant-event, lineage, and scope-head effects must match exactly before
-    commit. Direct and cascading deletion must publish exact topology tombstones.
-    Enrollment storage uses one shared baseline batch per scope, normalized
-    subtree target, and operation. Every newly acquired membership references
-    exactly one batch; existing memberships are never re-baselined. Baselines
-    also preserve the minimal ancestor-spine topology needed to derive audited
-    paths and a canonical unknown-origin record for root-scope legacy trash. A
-    complete vault-topology genesis snapshot plus every later lineage-bound
-    delta provides the independent authority for deriving each adopted closure.
-    Later multi-change topology mutations commit one atomic sorted delta and a
-    canonical net path-effect set that import derives from the previous replayed
-    projection before accepting descendant events. Allocation lineage commits
-    every post-audit topology-delta digest, including operations whose derived
-    audit effect is empty. Active ancestor witnesses are retired and re-created
-    deterministically as path dependencies change, and each sorted witness-change
-    count/digest is committed by both mutation and allocation lineage.
+The current schema has no audit-scope authority. The planned storage contract
+for sticky membership, mutation chains, and JSONL fidelity is maintained in
+[Audited History](audited-history.md), rather than duplicated in this current
+schema reference.
 
 ## Invariants enforced in the schema
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -257,10 +257,8 @@ matches exist, the command says that the result is truncated rather than
 silently implying completeness. Output columns are `ID` and `PATH`; no
 matches prints `no matches`.
 
-!!! info "Planned — Phase 2b"
-    Search currently covers node names only. Extracted document text
-    (PDF text layers, office formats) joins the index when the extraction
-    workers land. See [Searching](usage/searching.md).
+Search currently covers node names only; document-body extraction and content
+search are not available. See [Searching](usage/searching.md).
 
 ## docbank trash
 
@@ -493,14 +491,3 @@ builds; release builds inject both via `-ldflags`).
 `DOCBANK_LOG_LEVEL` sets the daemon's log level (`debug`, `info`,
 `warn`, `error`; default `info`) for both `docbank daemon run` and
 background-spawned daemons.
-
-## Planned commands
-
-!!! info "Planned — later phases"
-    The following are designed but not yet implemented; they will appear
-    here with exact semantics when they ship. `docbank edit`
-    (Phase 2b, [Editing & Versions](architecture/editing-and-versions.md));
-    `docbank audit enable`, `audit status`, `audit history`, and `audit verify`
-    (Phase 2b, [Audited History](architecture/audited-history.md));
-    `docbank extract` (Phase 2b, [HTTP API](architecture/http-api.md));
-    and `docbank tui` (Phase 3).

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,12 +55,6 @@ version through a new history row; neither discards earlier versions. Versions
 can be listed and retrieved independently of mutable paths. See
 [Editing & Versions](architecture/editing-and-versions.md).
 
-!!! info "Planned — full audit"
-    Selected directory scopes will retain every authoritative change and
-    content version with sticky membership, tamper-evident history, and
-    complete backup/restore fidelity. See
-    [Audited History](architecture/audited-history.md).
-
 ```
 docbank add ~/Documents/taxes --dest /taxes   # bulk import, resumable
 docbank tree /taxes                           # browse the virtual tree
@@ -120,14 +114,9 @@ integrity verification, and incremental backup creation, verification, and
 restore are implemented and tested. Stable content-version listing and
 ID-addressed retrieval, verified replacement, and reversion work through
 loose/packed storage and backup restore.
-Representative-corpus hardening and
-distribution work continue before a stable 1.0 release.
-
-!!! info "Planned — later phases"
-    Interactive editing, full audited history, tags, watched inboxes,
-    content-text extraction and search, the kit-ui web portal, and the focused
-    TUI are designed but not yet built. The
-    [Roadmap](roadmap.md) tracks what exists versus what is planned.
+Docbank is not yet a stable 1.0 release. The [Roadmap](roadmap.md) gives the
+high-level product direction without duplicating the project's kata work
+ledger.
 
 ## Where to go next
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -23,14 +23,17 @@ constraints, and implementation seams.
 
 ## Documentation boundary
 
-- **Public architecture:** what exists, the user-visible model, and planned
-  behavior only inside explicit planned callouts.
+- **User and agent guides:** shipped capabilities, exact contracts, and current
+  limitations.
+- **Public architecture:** the user-visible model and durable design intent;
+  future contracts appear only inside explicit planned callouts.
 - **Internal design:** current mechanics and rationale for agents and
   developers, including consequences and constraints.
-- **Transient specs/plans:** execution scaffolding under `docs/superpowers/`.
-  Digest useful content into the two maintained surfaces and remove the
-  transient file when the work ships.
+- **Roadmap:** one high-level public product-status view.
+- **Kata:** the sole home for work items, ordering, ownership, blockers, and
+  completion state.
 
 There is no separate decision ledger. If the design changes, revise the
 relevant living page so a new contributor can learn the current system without
-replaying historical records. Git history preserves the older state.
+replaying historical records. Git history preserves the older state. These
+pages must not become a second task ledger.

--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -68,12 +68,11 @@ For every material design change:
 2. Update public architecture when the user-visible model or boundary changes.
 3. Update CLI/API references and examples when a contract changes.
 4. Keep planned public behavior inside explicit planned callouts.
-5. Remove completed transient specs/plans after their durable content is
-   digested.
 
 Do not add a historical decision ledger. Git records prior versions; the
 working tree should let a new contributor understand the current system without
-replaying them.
+replaying them. Track work, ordering, blockers, and acceptance state in kata;
+documentation carries the resulting capability and durable rationale.
 
 ## Verification contract
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -432,11 +432,11 @@ Store startup runs the embedded idempotent schema in one immediate transaction
 and ensures the root exists. This safely creates missing compatible tables and
 indexes, but it is not a general migration system.
 
-Implement the metadata-v1 identity model as vertical changes to the live store,
-ingest, reachability, and backup/restore paths. Do not land a parallel schema or
-codec that production code does not consume; shared metadata helpers should be
-extracted only when the live paths use them. Follow-on work replaces the
-development runtime shape directly rather than translating or upgrading it.
+Metadata-v1 identity changes are vertical changes to the live store, ingest,
+reachability, and backup/restore paths. A parallel schema or codec that
+production code does not consume has no authority; shared metadata helpers
+belong here only when live paths use them. Pre-release development replaces the
+runtime shape directly rather than translating or upgrading it.
 
 Until the first public release, incompatible schema work is allowed and the
 format identifier remains v1. Earlier development vaults and JSONL streams are
@@ -447,12 +447,12 @@ The first public release establishes the compatibility boundary. From that
 point onward, incompatible changes require an explicit policy grounded in
 actual released formats and fixtures rather than speculative migration work.
 
-## Open design constraints
+## Extension constraints
 
-- External references need a liveness policy before their schema exists:
-  pin blob authority, or allow dangling-reference detection in the referrer.
-- Future version writers must preserve the implemented bytes-before-reference
-  ordering and add rows to reachability atomically with pointer replacement.
+- An external-reference schema must define its liveness policy: either pin blob
+  authority or make dangling-reference detection the referrer's responsibility.
+- Every version writer preserves the implemented bytes-before-reference
+  ordering and adds reachability atomically with pointer replacement.
   Reversion is the metadata-only exception: it reuses already-authoritative
   source bytes and atomically adds a new reachability row and pointer.
 - Pack and repack maintenance commands must remain daemon/API operations; no

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,10 +5,12 @@ description: What is implemented today and what each phase adds.
 
 # Roadmap
 
-docbank ships in phases, each independently useful. This page is the
-authoritative record of what exists versus what is designed — anything
-marked planned appears elsewhere in these docs only under an explicit
-"Planned" admonition.
+docbank ships in independently useful increments. This page is a high-level
+public view of current capability and product direction, not an execution
+ledger. The repository's kata ledger is the source of truth for actionable
+work, ordering, blockers, and completion state. Durable future contracts appear
+elsewhere only when they materially explain the design and are marked
+"Planned."
 
 | Phase | Scope | Status |
 |-------|-------|--------|

--- a/docs/scripts/check_markdown_sources.py
+++ b/docs/scripts/check_markdown_sources.py
@@ -10,6 +10,16 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 EXCLUDED = {".cache", ".venv", "internal", "scripts", "site", "superpowers"}
 FORBIDDEN = ("@astrojs/starlight", "<Card", "<Aside", "<Tabs", ":::")
 ADMONITION = re.compile(r'!!!\s+[A-Za-z][\w-]*(?:\s+"(?:[^"\\]|\\.)*")?')
+TRACKER_ALLOWLIST = {pathlib.Path("changelog.md"), pathlib.Path("roadmap.md")}
+TRACKER_PATTERNS = (
+    (re.compile(r"(?im)^\s*(?:[-*]\s+)?\[[ xX]\]\s+"), "task checkbox"),
+    (re.compile(r"(?i)\bTODO\b"), "TODO marker"),
+    (re.compile(r"(?i)\bPhase\s+[0-9]+[a-z]?\b"), "phase tracking"),
+    (re.compile(r"(?i)\bimplementation plans?\b"), "implementation planning"),
+    (re.compile(r"(?i)\bremaining work\b"), "remaining-work tracking"),
+    (re.compile(r"(?i)\bfollow-on work\b"), "follow-on work tracking"),
+    (re.compile(r"(?i)docs/superpowers/"), "transient plan path"),
+)
 
 
 def public_markdown() -> list[pathlib.Path]:
@@ -19,6 +29,18 @@ def public_markdown() -> list[pathlib.Path]:
         if path.name != "README.md"
         and not any(
             part in EXCLUDED or part.startswith("zensical-public-docs.")
+            for part in path.relative_to(ROOT).parts
+        )
+    )
+
+
+def maintained_markdown() -> list[pathlib.Path]:
+    return sorted(
+        path
+        for path in ROOT.rglob("*.md")
+        if not any(
+            part in {".cache", ".venv", "site"}
+            or part.startswith("zensical-public-docs.")
             for part in path.relative_to(ROOT).parts
         )
     )
@@ -47,6 +69,19 @@ def main() -> None:
         errors.append(f"{missing}: public page is missing from navigation")
     for missing in sorted(configured - public):
         errors.append(f"{missing}: navigation target does not exist")
+
+    for path in maintained_markdown():
+        rel = path.relative_to(ROOT)
+        if rel in TRACKER_ALLOWLIST:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for pattern, label in TRACKER_PATTERNS:
+            match = pattern.search(text)
+            if match is not None:
+                line = text.count("\n", 0, match.start()) + 1
+                errors.append(
+                    f"{rel}:{line}: {label} belongs in kata, not documentation"
+                )
 
     for path in files:
         rel = path.relative_to(ROOT)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,9 +85,8 @@ from the filename and remember that each term is a prefix match.
 docbank search insur stat
 ```
 
-!!! info "Planned — text extraction"
-    PDF, office-document, and plain-text extraction is designed for Phase 2b
-    but is not implemented. See [Searching](usage/searching.md).
+PDF, office-document, and plain-text extraction are not available. See
+[Searching](usage/searching.md) for the current name-search contract.
 
 ## A move or restore conflicts
 

--- a/docs/usage/backup.md
+++ b/docs/usage/backup.md
@@ -130,52 +130,9 @@ disks and latency-sensitive network storage. The progress and JSON contracts
 match `backup create`: progress is written to stderr, and `--json` suppresses
 progress so stdout contains one typed report.
 
-!!! info "Planned — editing and audited-history fidelity"
-    Before the first public release, `docbank-metadata-jsonl-v1` will directly
-    adopt the
-    stable vault ID, node-ID allocator high-water mark, content versions and
-    current references, and non-reusable tag identities plus every retained
-    ingest record without audit genesis or lineage. Enabling the first audit
-    scope will extend that same v1 authority with audit scopes,
-    sticky memberships, shared enrollment-baseline batches and digests,
-    mutation records, per-scope chain heads, a complete vault-topology genesis
-    snapshot, canonical
-    unknown-origin records, baseline ancestor-spine witness generations,
-    witness-change lists, atomic topology deltas, net path-effect commitments, a
-    stable vault ID, both allocator high-water marks, a vault-wide allocation
-    lineage, and authoritative
-    tag/provenance attachments with the tag and ingest records they reference.
-    Capture will include every protected historical blob. Snapshot metadata will
-    also include the vault-wide topology tombstones and tag/ingest/provenance
-    lineage needed for replay, including values from unaudited nodes; audit does
-    not retain those nodes' content bytes solely for that reason. Verify and
-    restore
-    will recompute baseline digests from frozen enrollment records, replay and
-    reconcile attached metadata, replay the vault topology from genesis, derive
-    each enrollment's exact trash-origin closure, and derive each topology
-    delta's net descendant and witness sets from the prior projections. They
-    verify later mutations and allocation lineage separately, restore the
-    allocators at the verified lineage tail, and reject internally missing,
-    reordered, truncated, or hash-invalid authority rather than restoring only
-    the current tree.
-    Canonical mutations and allocation entries will be cross-bound by operation
-    ID and mutation hash. Every post-audit topology delta will also be bound to
-    its allocation entry by operation ID and delta digest, including deltas with
-    no scoped effect; witness-change lists will be bound by count and digest.
-    Each snapshot manifest will carry the stable vault ID, every scope
-    count/head, and allocation-lineage count/head as one evidence bundle.
-    Rollback detection requires that complete bundle from a trusted
-    prior snapshot or external record; a fresh import cannot identify a
-    coherently rewritten set of chains.
-
-    Overwriting an existing audited target is forward-only: under the target
-    lock, the snapshot must prove the same vault ID and preserve or extend every
-    existing scope chain and the vault-wide allocation lineage. Independently
-    mutated copies diverge in that lineage even when they consume the same node
-    IDs or operation sequences. Older, pre-audit, divergent, or unrelated
-    snapshots can restore to a fresh directory but cannot replace the audited
-    target through the normal command. See the
-    [Audited History](../architecture/audited-history.md) contract.
+Snapshots include the current virtual tree, trash state, stable content
+versions, ingest/provenance metadata, tags, and extraction records. Restoring
+rebuilds and validates that logical authority before publishing the target.
 
 ## Restore and prove a snapshot
 

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -158,7 +158,5 @@ authority when either differs. See the [HTTP API](../architecture/http-api.md#ad
 and [Agent Integration Guide](../agents/integration.md#create-and-ingest-safely)
 for the exact contract.
 
-!!! info "Planned — watched inboxes"
-    The daemon will watch configured directories (scanner output, a "To File"
-    folder) and import files automatically once they've been stable for a
-    settle period, landing under `/inbox/<date>/` for later filing.
+Docbank does not currently watch source directories or ingest changed files
+automatically; every import is an explicit CLI or API operation.

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -59,13 +59,5 @@ suffix if its old name is occupied at restore time).
 - Every `mv` is its own transaction: a failed move in a scripted batch
   leaves everything else applied and consistent.
 
-!!! info "Planned — Phase 2b"
-    `POST /batch/move` joins the HTTP API with a `dry_run` mode that
-    validates an entire reorganization (collisions, cycles, missing IDs)
-    before applying it all-or-nothing in one transaction — designed for
-    agent-driven filing. All entries are evaluated from one pre-state to one
-    final post-state rather than in request order; duplicate changes to one
-    node and invalid final graphs are rejected, while valid nested moves produce
-    one canonical atomic delta and net path changes. Tags (orthogonal to the
-    tree) are in the schema
-    and surface alongside it.
+Bulk all-or-nothing moves and user-facing tags are not available. Scripts must
+therefore treat each current `mv` as an independently committed operation.

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -33,14 +33,9 @@ ID   PATH
 
 ## What's indexed today
 
-Phase 1 indexes **node names** only. That already covers the common
+Docbank indexes **node names** only. That already covers the common
 "where did I file that" lookup, since document filenames tend to carry
 their subject.
 
-!!! info "Planned — Phase 2b"
-    Text extraction workers add document **contents** to the same index:
-    PDF text layers, plain text/markdown, and office formats, extracted
-    once per unique blob and per extractor version. Search gains filters
-    (tag, MIME type, date, path prefix) in both the CLI and the HTTP
-    `/search` endpoint. Because extraction is keyed by content hash,
-    renaming or moving files never triggers re-extraction.
+Document-body extraction, content search, and tag/MIME/date/path filters are
+not available in the current CLI or HTTP API.

--- a/docs/usage/trash-and-gc.md
+++ b/docs/usage/trash-and-gc.md
@@ -63,17 +63,6 @@ permanently deletes the selected tree entries. The document bytes are still
 on disk and may still be referenced by another node or version. Only content
 with no remaining reference becomes a GC candidate.
 
-!!! info "Planned — full-audit protection"
-    Any trash root containing an audited node is explicitly outside the
-    eligible deletion set. Dry-run and execution reports list eligible roots
-    separately from protected roots and identify every protecting scope.
-    Execution deletes the eligible roots and leaves protected roots intact, so
-    one audited item never wedges cleanup of unrelated trash. Trashing and
-    restoring audited nodes remain allowed and become history events. Their
-    original parent ID/name remain protected even if an unrelated origin
-    directory is later emptied; restore falls back to `/` without erasing that
-    evidence. See [Audited History](../architecture/audited-history.md).
-
 ## Stage 3: Garbage collection (`gc`)
 
 Unreachable blob authority is removed only by explicit GC. A blob is
@@ -83,12 +72,6 @@ Unreachable blob authority is removed only by explicit GC. A blob is
 - a trashed node (trash is always restorable in full), or
 - a recorded prior version of an edited document
   (see [Editing & Versions](../architecture/editing-and-versions.md)).
-
-!!! info "Planned — full-audit reachability"
-    Full-audit membership makes every protected historical version a permanent
-    reachability root for ordinary maintenance. Repack may change where those
-    bytes are physically stored, but only after verified replacement
-    publication; it cannot revoke their logical authority.
 
 ```bash
 docbank gc          # dry run: candidate count and reclaimable bytes


### PR DESCRIPTION
Kata is already Docbank’s authoritative work ledger, but the documentation had accumulated phase labels, future command and endpoint inventories, completed adoption sequences, and repeated pre-implementation backup/audit details. That made user-facing pages read like an internal queue and created a second source of status that could drift from the actual project.

This establishes a firmer boundary: user and agent references describe shipped capabilities and current limitations; public and internal architecture preserve durable how/why; the roadmap remains the one high-level public direction view; and kata alone owns actionable work, ordering, blockers, and completion state. The definitive audited-history contract remains intact, while duplicated projections of it are removed from capability pages.

The documentation source check now prevents phase tracking, task checkboxes, TODO markers, and stale plan-ledger language from returning outside the roadmap and changelog.