### PR TITLE
Add authoritative content hash lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ maintenance.
 - Virtual folders with listing, tree browsing, rename, move, trash, and restore
 - Resumable bulk import and verified multipart upload
 - Stable content-version UUIDs, verified replacement and reversion, bounded
-  history listing, and ID-addressed retrieval
+  history listing, ID-addressed retrieval, and lookup by content hash
 - FTS5 name search (document-body extraction and search are planned)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification
@@ -50,10 +50,8 @@ maintenance.
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows
 
-Interactive editing, permanent tamper-evident audited history, tags, watched
-inboxes, text extraction, the kit-ui web portal, and the focused TUI are planned
-rather than implemented. See the [roadmap](docs/roadmap.md) for the current
-boundary.
+See the [roadmap](docs/roadmap.md) for high-level product direction beyond the
+capabilities listed here.
 
 ## Installation
 
@@ -103,6 +101,7 @@ docbank add ~/Documents --dest /archive
 docbank tree /archive
 docbank search "tax return"
 docbank versions /archive/Documents/receipt.pdf
+docbank refs <receipt-sha256>
 docbank put revised-receipt.pdf /archive/Documents/receipt.pdf
 docbank revert /archive/Documents/receipt.pdf <prior-version-id>
 docbank mv /archive/Documents/receipt.pdf /archive/Documents/receipt-2026.pdf

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -203,6 +204,51 @@ func TestPutReplacesContentAndRetainsHistory(t *testing.T) {
 	out, err = runCLI(t, "version", reverted.Version.ID)
 	require.NoError(t, err)
 	assert.Contains(t, out, "Source version:  "+initialVersion)
+}
+
+func TestRefsFindsCurrentHistoricalAndTrashedContent(t *testing.T) {
+	_ = setupVaultHome(t)
+	initialBytes := []byte("stable lookup content")
+	initial := writeSourceFile(t, "lookup.txt", string(initialBytes))
+	_, err := runCLI(t, "add", initial, "--dest", "/inbox")
+	require.NoError(t, err)
+	sum := sha256.Sum256(initialBytes)
+	hash := hex.EncodeToString(sum[:])
+
+	out, err := runCLI(t, "refs", hash)
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "CURRENT")
+	assert.Contains(t, out, "yes")
+	assert.Contains(t, out, "live")
+	assert.Contains(t, out, "/inbox/lookup.txt")
+
+	replacement := writeSourceFile(t, "replacement.txt", "different bytes")
+	_, err = runCLI(t, "put", replacement, "/inbox/lookup.txt", "--progress", "plain")
+	require.NoError(t, err)
+	out, err = runCLI(t, "refs", hash)
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "no")
+	assert.Contains(t, out, "/inbox/lookup.txt")
+
+	_, err = runCLI(t, "rm", "/inbox/lookup.txt")
+	require.NoError(t, err)
+	out, err = runCLI(t, "refs", hash, "--json")
+	require.NoError(t, err, out)
+	var page api.ContentReferencePage
+	require.NoError(t, json.Unmarshal([]byte(out), &page))
+	assert.Equal(t, 1, page.Total)
+	require.Len(t, page.Items, 1)
+	assert.False(t, page.Items[0].IsCurrent)
+	assert.NotEmpty(t, page.Items[0].Node.TrashedAt)
+	assert.Empty(t, page.Items[0].Path)
+
+	out, err = runCLI(t, "refs", strings.Repeat("f", 64))
+	require.NoError(t, err, out)
+	assert.Equal(t, "no authoritative references\n", out)
+	_, err = runCLI(t, "refs", "ABC")
+	require.ErrorContains(t, err, "canonical lowercase SHA-256")
+	_, err = runCLI(t, "refs", hash, "--limit", "0")
+	require.ErrorContains(t, err, "--limit must be between 1 and 1000")
 }
 
 func TestJobsShowsDaemonStatus(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -157,7 +157,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "14", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "15", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "14", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "15", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -292,7 +292,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "14", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "15", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/refs.go
+++ b/cmd/docbank/refs.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/client"
+)
+
+const maxReferencesLimit = 1000
+
+var (
+	referencesLimit  int
+	referencesOffset int
+	referencesJSON   bool
+)
+
+var referencesCmd = &cobra.Command{
+	Use:   "refs <sha256>",
+	Short: "Find document versions that retain a content hash",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := packstore.ParseHash(args[0]); err != nil {
+			return errors.New("content hash must be canonical lowercase SHA-256")
+		}
+		if referencesLimit < 1 || referencesLimit > maxReferencesLimit {
+			return fmt.Errorf("--limit must be between 1 and %d", maxReferencesLimit)
+		}
+		if referencesOffset < 0 {
+			return errors.New("--offset must not be negative")
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		page, err := c.ContentReferences(
+			cmd.Context(), args[0], referencesLimit, referencesOffset,
+		)
+		if err != nil {
+			return err
+		}
+		if referencesJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetEscapeHTML(false)
+			if err := enc.Encode(page); err != nil {
+				return fmt.Errorf("writing content-reference JSON: %w", err)
+			}
+			return nil
+		}
+		if len(page.Items) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no authoritative references")
+			return nil
+		}
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "VERSION\tNODE\tNODE REV\tCURRENT\tSTATE\tSIZE\tRECORDED\tPATH")
+		for _, ref := range page.Items {
+			current := "no"
+			if ref.IsCurrent {
+				current = "yes"
+			}
+			state, path := "live", ref.Path
+			if ref.Node.TrashedAt != "" {
+				state, path = "trashed", "-"
+			}
+			_, _ = fmt.Fprintf(w, "%s\t%d\t%d\t%s\t%s\t%d\t%s\t%s\n",
+				ref.Version.ID, ref.Node.ID, ref.Version.NodeRevision, current,
+				state, ref.Version.Size, ref.Version.RecordedAt, path)
+		}
+		if err := w.Flush(); err != nil {
+			return fmt.Errorf("writing content references: %w", err)
+		}
+		if referencesOffset+len(page.Items) < page.Total {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"showing %d-%d of %d (use --offset to continue)\n",
+				referencesOffset+1, referencesOffset+len(page.Items), page.Total)
+		}
+		return nil
+	},
+}
+
+func init() {
+	referencesCmd.Flags().IntVar(&referencesLimit, "limit", 100,
+		"maximum references to return (1-1000)")
+	referencesCmd.Flags().IntVar(&referencesOffset, "offset", 0,
+		"number of references to skip")
+	referencesCmd.Flags().BoolVar(&referencesJSON, "json", false,
+		"emit machine-readable JSON")
+	rootCmd.AddCommand(referencesCmd)
+}

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -76,6 +76,9 @@ non-goals.
 - **Write from another machine:** upload one file with declared SHA-256, size,
   name, and destination directory ID; accept success only when the returned
   server-computed identity matches.
+- **Resolve known bytes:** query content references by canonical SHA-256 before
+  uploading; inspect every bounded result because the same bytes may be current
+  or historical on several live or trashed nodes.
 - **Replace an inspected file:** retain its node ID and revision, send raw bytes
   with declared SHA-256 and size, and require the returned node, new version,
   computed identity, and ETag to agree before accepting success.

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -156,6 +156,23 @@ recording time, transition kind, and introducing operation UUID. Version-byte
 responses use the same headers and terminal digest contract as current-node
 content.
 
+Resolve known bytes to every authoritative node/version reference without
+guessing from paths or physical storage:
+
+```bash
+curl --fail-with-body --get \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  --data-urlencode "sha256=$SHA256" \
+  --data 'limit=100' \
+  --data 'offset=0' \
+  "$DOCBANK_URL/api/v1/content-references"
+```
+
+The response is a bounded page ordered with live current references first,
+then live prior versions, then trash. A result's path is present only for a
+live node. No result means no logical content version currently retains the
+hash, even if unreferenced physical bytes have not yet been swept by GC.
+
 Read the response through successful EOF and require the trailer. A readable
 prefix is not verified content: if the request is cancelled, the body ends in
 error, or the trailer is absent, discard any staged output rather than

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -40,17 +40,21 @@ also creates no version.
 docbank versions /taxes/2025/return.pdf
 docbank version <version-id> --json
 docbank version <version-id> --content > return.pdf
+docbank refs <sha256>
 ```
 
 `versions` is newest-first and bounded by `--limit` and `--offset`; `--json`
 returns the complete page envelope including `total`. `version` addresses
 metadata or bytes by UUID, independent of the node's current path.
+`refs` performs the inverse lookup: one content hash to every stable
+node/version pair that retains it, including prior versions and trash.
 
 The HTTP equivalents are:
 
 - `GET /api/v1/nodes/{id}/versions?limit=&offset=`;
 - `GET /api/v1/versions/{version_id}`; and
-- `GET /api/v1/versions/{version_id}/content`.
+- `GET /api/v1/versions/{version_id}/content`; and
+- `GET /api/v1/content-references?sha256=&limit=&offset=`.
 
 Current-node and ID-addressed version streams both send
 `X-Docbank-Content-Version`, `X-Docbank-Blob-Hash`, and

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -34,6 +34,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /nodes/{id}/revert` | create a new head from a prior version of the same file | Implemented |
 | `GET /nodes/{id}/versions` | list immutable content versions newest-first, paginated (`limit`/`offset`) | Implemented |
 | `GET /versions/{version_id}` · `GET /versions/{version_id}/content` | inspect or stream one immutable version by stable UUID | Implemented |
+| `GET /content-references?sha256=&limit=&offset=` | find every stable node/version pair retaining a content hash | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
@@ -161,6 +162,14 @@ body themselves and compare both their digest and the trailer with the node's
 metadata globally, and its `/content` child streams that version with the same
 identity headers and digest contract. A path rename cannot strand a retained
 version reference.
+
+`GET /content-references` is the inverse identity lookup. It accepts one
+canonical lowercase SHA-256 and returns only logical `content_versions`
+references backed by blob-catalog authority; it never infers a match from a
+loose file or pack entry alone. Each item contains the complete immutable
+version, its current node projection, whether that version is the node's
+current head, and a path only while the node is live. Results are bounded and
+deterministic: live current references, live history, then trashed references.
 
 `POST /nodes/{id}/verify` is the bounded server-side proof. It requires
 `If-Match` from a prior node response, reopens the blob through the same mixed

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,7 @@ All commands operate on the vault at `~/.docbank` (override with
 stderr and produce a non-zero exit code. Virtual paths are absolute,
 `/`-separated, and case-sensitive.
 
-Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `versions`, `version`, `revert`, `mv`, `rm`,
+Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `versions`, `version`, `refs`, `revert`, `mv`, `rm`,
 `restore`, `search`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
 daemon over its HTTP API rather than opening the vault itself; if none
 is running, the command auto-starts one in the background. `docbank
@@ -174,6 +174,23 @@ with `--json`. It exits successfully only after the response version ID, byte
 count, SHA-256 identity, and terminal `Content-Digest` all agree. Output may
 already have reached stdout when verification fails, so scripts publishing a
 file should write privately and rename it only after a successful exit.
+
+## docbank refs
+
+```text
+docbank refs <sha256> [--limit <n>] [--offset <n>] [--json]
+```
+
+Finds every immutable content version that retains the canonical lowercase
+SHA-256 identity. Live current references sort first, followed by live prior
+versions and trashed references. Each result carries the stable version and
+node IDs, node revision, current/history state, size, recording time, and the
+node's current path when it is live. Trashed nodes have no resolvable path.
+
+The default limit is 100; `--limit` accepts 1–1000 and `--offset` continues a
+bounded result. `--json` emits the page envelope with `items`, `total`, `limit`,
+and `offset`. A cataloged physical blob with no retained content version is not
+a match; the command reports `no authoritative references`.
 
 ## docbank revert
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ docbank add ~/Documents/taxes --dest /taxes   # bulk import, resumable
 docbank tree /taxes                           # browse the virtual tree
 docbank search "insurance"                    # indexed name search
 docbank versions /taxes/2026/return.pdf       # inspect stable content identity
+docbank refs <sha256>                         # find every retaining node/version
 docbank put revised.pdf /taxes/2026/return.pdf # retain the prior version
 docbank mv "/inbox/scan (2).pdf" /taxes/2026  # reorganize, metadata only
 docbank rm /inbox/junk.pdf                    # trash, recoverable

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,7 +94,8 @@ identity only after both match. `docbank put` and raw
 an optimistic revision precondition while retaining every prior version.
 `docbank revert` and `POST /nodes/{id}/revert` add a metadata-only
 `content_revert` head from one prior version without copying its loose or packed
-blob.
+blob. `docbank refs` and `GET /content-references` resolve a SHA-256 identity to
+every retaining current, historical, or trashed node/version pair.
 
 - Remaining editing surface: `docbank edit`
   ([design](architecture/editing-and-versions.md))
@@ -112,10 +113,8 @@ blob.
   today's `provenance` table records the original filesystem path and
   mtime; `source_kind` / `source_ref` / `source_meta` fields extend it
   to non-file origins (a watched inbox, another application's archive)
-  as generic fields, never application-specific tables; and node lookup
-  by content hash, so an external system of record holding
-  `node_id` + hash references can ask "is this already in the vault?" in
-  one call. To settle before the refs schema exists: whether external
+  as generic fields, never application-specific tables. To settle before an
+  external-reference schema exists: whether external
   references pin nodes against `trash empty`/`gc`, or dangling-ref
   detection stays the referrer's job (docbank guarantees only that node
   ids are never reused)

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -16,6 +16,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	doc := string(out)
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent", "verifyNodeContent",
 		"listContentVersions", "getContentVersion", "getContentVersionBytes",
+		"lookupContentReferences",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
 		"storageStatus", "storagePack", "storageRepack", "ingest", "uploadFile", "listTrash", "emptyTrash", "gc", "verify",
 		"initBackupRepository", "createBackupSnapshot", "listBackupSnapshots", "listJobs"} {

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -177,6 +177,33 @@ func registerReadRoutes(api huma.API, d Deps) {
 		return streamContentVersion(ctx, d, version)
 	})
 
+	type contentReferencesOutput struct{ Body ContentReferencePage }
+	huma.Register(api, huma.Operation{
+		OperationID: "lookupContentReferences", Method: http.MethodGet,
+		Path:    "/api/v1/content-references",
+		Summary: "Find stable document versions that retain a SHA-256 identity",
+		Description: "Results are logical content-version references, not physical loose or pack entries. " +
+			"Live current references sort first, followed by live history and trashed references.",
+	}, func(ctx context.Context, in *struct {
+		SHA256 string `query:"sha256" required:"true" pattern:"^[0-9a-f]{64}$"`
+		Limit  int    `query:"limit" default:"100" minimum:"1" maximum:"1000"`
+		Offset int    `query:"offset" default:"0" minimum:"0"`
+	}) (*contentReferencesOutput, error) {
+		references, total, err := d.Store.ContentReferencesByHash(
+			ctx, in.SHA256, in.Limit, in.Offset,
+		)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		out := &contentReferencesOutput{Body: ContentReferencePage{
+			Items: []ContentReference{}, Total: total, Limit: in.Limit, Offset: in.Offset,
+		}}
+		for _, ref := range references {
+			out.Body.Items = append(out.Body.Items, fromStoreContentReference(ref))
+		}
+		return out, nil
+	})
+
 	huma.Register(api, huma.Operation{
 		OperationID: "resolvePath", Method: http.MethodGet, Path: "/api/v1/path",
 		Summary: "Resolve an absolute virtual path to its node",

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -136,6 +137,70 @@ func TestContentVersionListMetadataAndPackedBytes(t *testing.T) {
 	resp, body = get(t, ts, "/api/v1/nodes/"+strconv.FormatInt(s.RootID(), 10)+"/versions", nil)
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	assert.Contains(t, body, `"code":"not_file"`)
+}
+
+func TestContentReferenceLookupIsLogicalPaginatedAndRepresentationNeutral(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	ctx := t.Context()
+	wantedHash, wantedSize, err := s.Blobs.Write(strings.NewReader("shared content"))
+	require.NoError(t, err)
+	replacementHash, replacementSize, err := s.Blobs.Write(strings.NewReader("replacement"))
+	require.NoError(t, err)
+
+	historical, err := s.CreateFile(
+		ctx, s.RootID(), "historical.txt", wantedHash, wantedSize, "text/plain",
+	)
+	require.NoError(t, err)
+	historicalVersion := historical.CurrentVersionID
+	historical, _, err = s.ReplaceContent(ctx, historical.ID, historical.Revision,
+		replacementHash, replacementSize, "text/plain")
+	require.NoError(t, err)
+	current, err := s.CreateFile(ctx, s.RootID(), "current.txt", wantedHash, wantedSize, "text/plain")
+	require.NoError(t, err)
+	trashed, err := s.CreateFile(ctx, s.RootID(), "trashed.txt", wantedHash, wantedSize, "text/plain")
+	require.NoError(t, err)
+	_, _, err = s.Trash(ctx, trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+
+	lookup := "/api/v1/content-references?sha256=" + wantedHash + "&limit=10&offset=0"
+	resp, body := get(t, ts, lookup, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var loose api.ContentReferencePage
+	require.NoError(t, json.Unmarshal([]byte(body), &loose))
+	assert.Equal(t, 3, loose.Total)
+	require.Len(t, loose.Items, 3)
+	assert.Equal(t, current.ID, loose.Items[0].Node.ID)
+	assert.True(t, loose.Items[0].IsCurrent)
+	assert.Equal(t, "/current.txt", loose.Items[0].Path)
+	assert.Equal(t, historical.ID, loose.Items[1].Node.ID)
+	assert.Equal(t, historicalVersion, loose.Items[1].Version.ID)
+	assert.False(t, loose.Items[1].IsCurrent)
+	assert.Equal(t, replacementHash, loose.Items[1].Node.BlobHash)
+	assert.Equal(t, trashed.ID, loose.Items[2].Node.ID)
+	assert.NotEmpty(t, loose.Items[2].Node.TrashedAt)
+	assert.Empty(t, loose.Items[2].Path)
+
+	resp, body = get(t, ts,
+		"/api/v1/content-references?sha256="+wantedHash+"&limit=1&offset=1", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var page api.ContentReferencePage
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+	assert.Equal(t, 3, page.Total)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, historicalVersion, page.Items[0].Version.ID)
+
+	packed, err := s.Blobs.Maintainer().Pack(ctx, packstore.PackOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, packed.BlobsPacked)
+	resp, body = get(t, ts, lookup, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var afterPack api.ContentReferencePage
+	require.NoError(t, json.Unmarshal([]byte(body), &afterPack))
+	assert.Equal(t, loose, afterPack, "physical representation cannot change logical lookup")
+
+	resp, body = get(t, ts, "/api/v1/content-references?sha256=ABC", nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	assert.Contains(t, body, `"code":"validation"`)
 }
 
 func TestVerifyNodeContentBindsRevisionAndReadsStoredBytes(t *testing.T) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -56,6 +56,23 @@ type ContentVersionPage struct {
 	Offset int              `json:"offset"`
 }
 
+// ContentReference identifies one stable node/version pair that retains a
+// requested content hash. Path is present only while the node is live.
+type ContentReference struct {
+	Version   ContentVersion `json:"version"`
+	Node      Node           `json:"node"`
+	Path      string         `json:"path,omitempty"`
+	IsCurrent bool           `json:"is_current"`
+}
+
+// ContentReferencePage is one bounded content-hash lookup page.
+type ContentReferencePage struct {
+	Items  []ContentReference `json:"items"`
+	Total  int                `json:"total"`
+	Limit  int                `json:"limit"`
+	Offset int                `json:"offset"`
+}
+
 // ContentVerification binds a fresh physical read to the exact node revision
 // the caller inspected. BlobHash and Size are catalog identity; ComputedHash
 // and ComputedSize describe the bytes read through the mixed store.
@@ -426,5 +443,12 @@ func fromStoreContentVersion(v store.ContentVersion) ContentVersion {
 		MimeType: v.MimeType, RecordedAt: v.RecordedAt, NodeRevision: v.NodeRevision,
 		IntroducedOperationID: v.IntroducedOperationID,
 		TransitionKind:        v.TransitionKind, SourceVersionID: v.SourceVersionID,
+	}
+}
+
+func fromStoreContentReference(ref store.ContentReference) ContentReference {
+	return ContentReference{
+		Version: fromStoreContentVersion(ref.Version), Node: fromStoreNode(ref.Node),
+		Path: ref.Path, IsCurrent: ref.IsCurrent,
 	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -340,7 +340,8 @@ func validateContentReferencePage(page api.ContentReferencePage, hash string, li
 			ref.Node.MimeType != ref.Version.MimeType) {
 			return fmt.Errorf("content-reference response item %d has inconsistent current authority", i)
 		}
-		if (ref.Node.TrashedAt == "") != strings.HasPrefix(ref.Path, "/") {
+		if (ref.Node.TrashedAt != "" && ref.Path != "") ||
+			(ref.Node.TrashedAt == "" && !strings.HasPrefix(ref.Path, "/")) {
 			return fmt.Errorf("content-reference response item %d has inconsistent path state", i)
 		}
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -286,6 +286,67 @@ func (c *Client) VersionContent(ctx context.Context, id string) (*ContentStream,
 	return stream, nil
 }
 
+// ContentReferences returns one bounded page of logical version references to
+// canonical SHA-256 content. It never infers authority from physical files.
+func (c *Client) ContentReferences(
+	ctx context.Context, hash string, limit, offset int,
+) (api.ContentReferencePage, error) {
+	var page api.ContentReferencePage
+	if !validSHA256Hex(hash) {
+		return page, errors.New("content hash must be canonical lowercase SHA-256")
+	}
+	if limit < 1 || limit > 1000 {
+		return page, errors.New("content-reference limit must be between 1 and 1000")
+	}
+	if offset < 0 {
+		return page, errors.New("content-reference offset must not be negative")
+	}
+	path := fmt.Sprintf("/api/v1/content-references?sha256=%s&limit=%d&offset=%d",
+		url.QueryEscape(hash), limit, offset)
+	if err := c.do(ctx, http.MethodGet, path, nil, nil, &page); err != nil {
+		return page, err
+	}
+	if err := validateContentReferencePage(page, hash, limit, offset); err != nil {
+		return api.ContentReferencePage{}, err
+	}
+	return page, nil
+}
+
+func validateContentReferencePage(page api.ContentReferencePage, hash string, limit, offset int) error {
+	if page.Limit != limit || page.Offset != offset || page.Total < 0 ||
+		len(page.Items) > limit ||
+		(len(page.Items) == 0 && offset < page.Total) ||
+		(len(page.Items) > 0 && offset+len(page.Items) > page.Total) {
+		return errors.New("content-reference response has inconsistent pagination")
+	}
+	seen := make(map[string]struct{}, len(page.Items))
+	for i, ref := range page.Items {
+		if !validUUIDv4(ref.Version.ID) || !validUUIDv4(ref.Version.IntroducedOperationID) ||
+			!validUUIDv4(ref.Node.CurrentVersionID) || ref.Node.Kind != "file" ||
+			ref.Version.NodeID != ref.Node.ID || ref.Version.BlobHash != hash ||
+			!validSHA256Hex(ref.Node.BlobHash) || ref.Version.Size < 0 || ref.Node.Size < 0 {
+			return fmt.Errorf("content-reference response item %d has inconsistent identity", i)
+		}
+		_, duplicate := seen[ref.Version.ID]
+		if duplicate {
+			return fmt.Errorf("content-reference response repeats version %s", ref.Version.ID)
+		}
+		seen[ref.Version.ID] = struct{}{}
+		current := ref.Version.ID == ref.Node.CurrentVersionID
+		if ref.IsCurrent != current {
+			return fmt.Errorf("content-reference response item %d has inconsistent current state", i)
+		}
+		if current && (ref.Node.BlobHash != hash || ref.Node.Size != ref.Version.Size ||
+			ref.Node.MimeType != ref.Version.MimeType) {
+			return fmt.Errorf("content-reference response item %d has inconsistent current authority", i)
+		}
+		if (ref.Node.TrashedAt == "") != strings.HasPrefix(ref.Path, "/") {
+			return fmt.Errorf("content-reference response item %d has inconsistent path state", i)
+		}
+	}
+	return nil
+}
+
 func (c *Client) content(ctx context.Context, path, identity string) (*ContentStream, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 		c.base+path, nil)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -457,7 +457,11 @@ func TestContentReferencesRejectsInconsistentResponses(t *testing.T) {
 		"current state":     func(page *api.ContentReferencePage) { page.Items[0].IsCurrent = false },
 		"current authority": func(page *api.ContentReferencePage) { page.Items[0].Node.Size++ },
 		"path state":        func(page *api.ContentReferencePage) { page.Items[0].Path = "" },
-		"pagination":        func(page *api.ContentReferencePage) { page.Total = 0 },
+		"trashed path": func(page *api.ContentReferencePage) {
+			page.Items[0].Node.TrashedAt = "2026-07-15T12:00:00.000000000Z"
+			page.Items[0].Path = "doc.txt"
+		},
+		"pagination": func(page *api.ContentReferencePage) { page.Total = 0 },
 		"missing page": func(page *api.ContentReferencePage) {
 			page.Total = 2
 			page.Items = nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -374,6 +374,18 @@ func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {
 	version, err := c.Version(t.Context(), node.CurrentVersionID)
 	require.NoError(t, err)
 	assert.Equal(t, page.Items[0], version)
+	looseRefs, err := c.ContentReferences(t.Context(), wantHash, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, looseRefs.Total)
+	require.Len(t, looseRefs.Items, 1)
+	assert.Equal(t, node.ID, looseRefs.Items[0].Node.ID)
+	assert.Equal(t, node.CurrentVersionID, looseRefs.Items[0].Version.ID)
+	assert.True(t, looseRefs.Items[0].IsCurrent)
+	assert.Equal(t, "/inbox/evidence.txt", looseRefs.Items[0].Path)
+	exhaustedRefs, err := c.ContentReferences(t.Context(), wantHash, 1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, exhaustedRefs.Total)
+	assert.Empty(t, exhaustedRefs.Items)
 
 	stream, err := c.Content(t.Context(), node.ID)
 	require.NoError(t, err)
@@ -395,6 +407,9 @@ func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {
 	packed, err := c.StoragePack(t.Context(), 0)
 	require.NoError(t, err)
 	require.Equal(t, 1, packed.BlobsPacked)
+	packedRefs, err := c.ContentReferences(t.Context(), wantHash, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, looseRefs, packedRefs)
 	versionStream, err := c.VersionContent(t.Context(), node.CurrentVersionID)
 	require.NoError(t, err)
 	assert.Equal(t, node.CurrentVersionID, versionStream.VersionID)
@@ -409,6 +424,61 @@ func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, verified.Verified, "the same evidence contract reads packed authority")
 	assert.Equal(t, wantHash, verified.ComputedHash)
+	_, err = c.ContentReferences(t.Context(), "ABC", 10, 0)
+	require.ErrorContains(t, err, "canonical lowercase SHA-256")
+	_, err = c.ContentReferences(t.Context(), wantHash, 0, 0)
+	require.ErrorContains(t, err, "between 1 and 1000")
+	_, err = c.ContentReferences(t.Context(), wantHash, 1, -1)
+	require.ErrorContains(t, err, "must not be negative")
+}
+
+func TestContentReferencesRejectsInconsistentResponses(t *testing.T) {
+	const (
+		versionID   = "11111111-1111-4111-8111-111111111111"
+		operationID = "22222222-2222-4222-8222-222222222222"
+	)
+	hash := strings.Repeat("a", 64)
+	base := api.ContentReferencePage{
+		Items: []api.ContentReference{{
+			Version: api.ContentVersion{ID: versionID, NodeID: 7, BlobHash: hash,
+				Size: 3, MimeType: "text/plain", NodeRevision: 1,
+				IntroducedOperationID: operationID, TransitionKind: "content_create"},
+			Node: api.Node{ID: 7, Name: "doc.txt", Kind: "file", CurrentVersionID: versionID,
+				BlobHash: hash, Size: 3, MimeType: "text/plain", Revision: 1},
+			Path: "/doc.txt", IsCurrent: true,
+		}},
+		Total: 1, Limit: 10, Offset: 0,
+	}
+	tests := map[string]func(*api.ContentReferencePage){
+		"requested hash": func(page *api.ContentReferencePage) {
+			page.Items[0].Version.BlobHash = strings.Repeat("b", 64)
+		},
+		"node identity":     func(page *api.ContentReferencePage) { page.Items[0].Node.ID++ },
+		"current state":     func(page *api.ContentReferencePage) { page.Items[0].IsCurrent = false },
+		"current authority": func(page *api.ContentReferencePage) { page.Items[0].Node.Size++ },
+		"path state":        func(page *api.ContentReferencePage) { page.Items[0].Path = "" },
+		"pagination":        func(page *api.ContentReferencePage) { page.Total = 0 },
+		"missing page": func(page *api.ContentReferencePage) {
+			page.Total = 2
+			page.Items = nil
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			page := base
+			page.Items = append([]api.ContentReference(nil), base.Items...)
+			mutate(&page)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(page); err != nil {
+					t.Errorf("encoding response: %v", err)
+				}
+			}))
+			t.Cleanup(ts.Close)
+			_, err := client.New(ts.URL, "").ContentReferences(t.Context(), hash, 10, 0)
+			require.ErrorContains(t, err, "content-reference response")
+		})
+	}
 }
 
 func TestVersionContentRejectsUnprovenResponses(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "14"
+	daemonProtocolVersion = "15"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/content_reference.go
+++ b/internal/store/content_reference.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/kit/packstore"
+)
+
+// ContentReference joins one immutable content version to the stable node that
+// retains it. Path is populated only for a live node; trashed nodes deliberately
+// have no resolvable virtual path.
+type ContentReference struct {
+	Version   ContentVersion
+	Node      Node
+	Path      string
+	IsCurrent bool
+}
+
+// ContentReferencesByHash returns one bounded, deterministic page of logical
+// references to canonical SHA-256 content. A physical blob with no retained
+// content version is not a match. Live current references sort first, followed
+// by live history and then trashed references.
+func (s *Store) ContentReferencesByHash(
+	ctx context.Context, hash string, limit, offset int,
+) ([]ContentReference, int, error) {
+	if _, err := packstore.ParseHash(hash); err != nil {
+		return nil, 0, errors.New("content hash must be canonical lowercase SHA-256")
+	}
+	if limit < 1 || limit > 1000 {
+		return nil, 0, errors.New("content-reference limit must be between 1 and 1000")
+	}
+	if offset < 0 {
+		return nil, 0, errors.New("content-reference offset must not be negative")
+	}
+
+	// Totals and page are one statement so concurrent replacement, trash, or
+	// trash-empty is observed entirely before or after the mutation. The
+	// recursive path projection runs only for live nodes in the selected page.
+	rows, err := s.db.QueryContext(ctx, `
+		WITH RECURSIVE matching AS (
+			SELECT v.version_id, v.node_id, v.blob_hash, v.size, v.mime_type,
+			       v.recorded_at, v.node_revision, v.introduced_operation_id,
+			       v.transition_kind, v.source_version_id,
+			       n.parent_id, n.name, n.kind, n.current_version_id,
+			       current.blob_hash AS current_blob_hash,
+			       current.size AS current_size, current.mime_type AS current_mime_type,
+			       n.revision, n.created_at, n.modified_at, n.trashed_at,
+			       n.trashed_at IS NOT NULL AS trashed_sort,
+			       v.version_id != n.current_version_id AS historical_sort
+			FROM content_versions v
+			JOIN blobs b ON b.hash = v.blob_hash AND b.size = v.size
+			JOIN nodes n ON n.id = v.node_id
+			LEFT JOIN content_versions current
+			  ON current.node_id = n.id AND current.version_id = n.current_version_id
+			WHERE v.blob_hash = ?
+		), page AS (
+			SELECT * FROM matching
+			ORDER BY trashed_sort, historical_sort, node_id, node_revision DESC, version_id
+			LIMIT ? OFFSET ?
+		), totals AS (
+			SELECT COUNT(*) AS total FROM matching
+		), ancestry(version_id, id, parent_id, path) AS (
+			SELECT version_id, node_id, parent_id, name
+			FROM page WHERE trashed_at IS NULL
+			UNION ALL
+			SELECT a.version_id, n.id, n.parent_id,
+			       CASE WHEN n.name = '' THEN '/' || a.path ELSE n.name || '/' || a.path END
+			FROM nodes n JOIN ancestry a ON n.id = a.parent_id
+			WHERE n.trashed_at IS NULL
+		), paths AS (
+			SELECT version_id, path FROM ancestry WHERE parent_id IS NULL
+		)
+		SELECT totals.total,
+		       COALESCE(page.version_id, ''), COALESCE(page.node_id, 0),
+		       COALESCE(page.blob_hash, ''), COALESCE(page.size, 0),
+		       COALESCE(page.mime_type, ''), COALESCE(page.recorded_at, ''),
+		       COALESCE(page.node_revision, 0),
+		       COALESCE(page.introduced_operation_id, ''),
+		       COALESCE(page.transition_kind, ''), page.source_version_id,
+		       COALESCE(page.node_id, 0), page.parent_id, COALESCE(page.name, ''),
+		       COALESCE(page.kind, ''), COALESCE(page.current_version_id, ''),
+		       COALESCE(page.current_blob_hash, ''), COALESCE(page.current_size, 0),
+		       COALESCE(page.current_mime_type, ''), COALESCE(page.revision, 0),
+		       COALESCE(page.created_at, ''), COALESCE(page.modified_at, ''),
+		       page.trashed_at, COALESCE(paths.path, ''),
+		       COALESCE(page.historical_sort = 0, false)
+		FROM totals LEFT JOIN page ON true
+		LEFT JOIN paths ON paths.version_id = page.version_id
+		ORDER BY page.trashed_sort, page.historical_sort, page.node_id,
+		         page.node_revision DESC, page.version_id`, hash, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("looking up content hash %s: %w", hash, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	references := make([]ContentReference, 0)
+	var total int
+	for rows.Next() {
+		var ref ContentReference
+		if err := rows.Scan(
+			&total,
+			&ref.Version.ID, &ref.Version.NodeID, &ref.Version.BlobHash,
+			&ref.Version.Size, &ref.Version.MimeType, &ref.Version.RecordedAt,
+			&ref.Version.NodeRevision, &ref.Version.IntroducedOperationID,
+			&ref.Version.TransitionKind, &ref.Version.SourceVersionID,
+			&ref.Node.ID, &ref.Node.ParentID, &ref.Node.Name, &ref.Node.Kind,
+			&ref.Node.CurrentVersionID, &ref.Node.BlobHash, &ref.Node.Size,
+			&ref.Node.MimeType, &ref.Node.Revision, &ref.Node.CreatedAt,
+			&ref.Node.ModifiedAt, &ref.Node.TrashedAt, &ref.Path, &ref.IsCurrent,
+		); err != nil {
+			return nil, 0, fmt.Errorf("looking up content hash %s: scanning page: %w", hash, err)
+		}
+		if ref.Version.ID != "" {
+			references = append(references, ref)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("looking up content hash %s: %w", hash, err)
+	}
+	return references, total, nil
+}

--- a/internal/store/content_reference_test.go
+++ b/internal/store/content_reference_test.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContentReferencesByHashIncludesCurrentHistoricalAndTrash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	wanted := fakeHash("a1")
+	replacement := fakeHash("b2")
+
+	historical, err := s.CreateFile(ctx, s.RootID(), "historical.txt", wanted, 10, "text/plain")
+	require.NoError(t, err)
+	historicalVersion := historical.CurrentVersionID
+	historical, _, err = s.ReplaceContent(
+		ctx, historical.ID, historical.Revision, replacement, 11, "text/plain",
+	)
+	require.NoError(t, err)
+
+	current, err := s.CreateFile(ctx, s.RootID(), "current.txt", wanted, 10, "text/plain")
+	require.NoError(t, err)
+	trashed, err := s.CreateFile(ctx, s.RootID(), "trashed.txt", wanted, 10, "text/plain")
+	require.NoError(t, err)
+	trashed, _, err = s.Trash(ctx, trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+
+	refs, total, err := s.ContentReferencesByHash(ctx, wanted, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	require.Len(t, refs, 3)
+
+	assert.Equal(t, current.ID, refs[0].Node.ID, "live current references sort first")
+	assert.Equal(t, current.CurrentVersionID, refs[0].Version.ID)
+	assert.True(t, refs[0].IsCurrent)
+	assert.Equal(t, "/current.txt", refs[0].Path)
+	assert.Nil(t, refs[0].Node.TrashedAt)
+
+	assert.Equal(t, historical.ID, refs[1].Node.ID, "live history follows live current references")
+	assert.Equal(t, historicalVersion, refs[1].Version.ID)
+	assert.False(t, refs[1].IsCurrent)
+	assert.Equal(t, replacement, refs[1].Node.BlobHash,
+		"the node projection describes its current authority")
+	assert.Equal(t, "/historical.txt", refs[1].Path)
+
+	assert.Equal(t, trashed.ID, refs[2].Node.ID, "trashed references sort last")
+	assert.True(t, refs[2].IsCurrent)
+	assert.NotNil(t, refs[2].Node.TrashedAt)
+	assert.Empty(t, refs[2].Path, "trashed nodes have no resolvable current path")
+
+	page, pageTotal, err := s.ContentReferencesByHash(ctx, wanted, 1, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 3, pageTotal)
+	require.Len(t, page, 1)
+	assert.Equal(t, historicalVersion, page[0].Version.ID)
+
+	exhausted, exhaustedTotal, err := s.ContentReferencesByHash(ctx, wanted, 1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 3, exhaustedTotal)
+	assert.Empty(t, exhausted)
+}
+
+func TestContentReferencesByHashRequiresLogicalAuthorityAndBoundedInput(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	orphan := fakeHash("c3")
+
+	// A catalog row without a content version is physical authority only and
+	// must not be presented as a document reference.
+	require.NoError(t, s.withTx(ctx, func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, orphan, 7)
+	}))
+	refs, total, err := s.ContentReferencesByHash(ctx, orphan, 10, 0)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Empty(t, refs)
+
+	_, _, err = s.ContentReferencesByHash(ctx, "ABC", 10, 0)
+	require.ErrorContains(t, err, "canonical lowercase SHA-256")
+	_, _, err = s.ContentReferencesByHash(ctx, orphan, 0, 0)
+	require.ErrorContains(t, err, "between 1 and 1000")
+	_, _, err = s.ContentReferencesByHash(ctx, orphan, 1001, 0)
+	require.ErrorContains(t, err, "between 1 and 1000")
+	_, _, err = s.ContentReferencesByHash(ctx, orphan, 1, -1)
+	require.ErrorContains(t, err, "must not be negative")
+}


### PR DESCRIPTION
External applications often begin with bytes and a SHA-256, not a Docbank path or node ID. Today they cannot ask whether Docbank already retains those bytes without attempting another write or maintaining a separate index, which weakens the intended system-of-record integration model.

This adds one bounded inverse identity query across the store, authenticated HTTP API, typed client, and `docbank refs`. Results identify every retained immutable version and its stable node, distinguish current from historical authority, include trashed records without pretending they still have a resolvable path, and remain identical whether content is loose or packed. Physical blob rows without a logical content version are deliberately excluded.

The daemon protocol advances because an older same-version daemon cannot answer this contract. Capability documentation now presents the lookup as shipped behavior, while kata remains the implementation ledger. Coverage exercises current, historical, trashed, paginated, packed, malformed, and internally inconsistent responses.