### PR TITLE
Give every vault a stable identity

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -67,6 +67,11 @@ version while preserving the node ID. Supply `PutOptions.Expected` when the
 caller already knows the SHA-256 and byte count and wants Docbank to reject a
 mismatched stream before granting metadata authority.
 
+`vault.ID()` returns the archive's stable UUID. JSONL backup and restore
+preserve that identity even when the restored vault has a different filesystem
+root; applications can therefore distinguish logical archives without treating
+paths as identity.
+
 An `OpenContent` stream is not authoritative until it reaches terminal `io.EOF`
 or `Verify` succeeds. Early `Close` does not drain the stream. `Vault.Close`
 waits for active operations and streams, closes storage, and releases the vault

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -81,6 +81,7 @@ type metadataHeader struct {
 	Type         string `json:"type"`
 	Format       string `json:"format"`
 	Version      int    `json:"version"`
+	VaultID      string `json:"vault_id"`
 	NodeSequence int64  `json:"node_sequence"`
 }
 
@@ -189,6 +190,12 @@ func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer
 	if tx == nil {
 		return errors.New("exporting metadata: nil transaction")
 	}
+	var vaultID string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT vault_id FROM vault_metadata WHERE singleton = 1`,
+	).Scan(&vaultID); err != nil {
+		return fmt.Errorf("reading vault identity: %w", err)
+	}
 	var nodeSequence int64
 	if err := tx.QueryRowContext(ctx, `SELECT seq FROM sqlite_sequence WHERE name = 'nodes'`).Scan(&nodeSequence); err != nil {
 		return fmt.Errorf("reading node ID high-water mark: %w", err)
@@ -205,7 +212,8 @@ func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer
 		return nil
 	}
 	if err := write(metadataHeader{
-		Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion, NodeSequence: nodeSequence,
+		Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion,
+		VaultID: vaultID, NodeSequence: nodeSequence,
 	}); err != nil {
 		return err
 	}
@@ -453,6 +461,7 @@ func stringPtr(v sql.NullString) *string {
 // logical JSONL snapshot. It refuses a store containing user or pack state.
 func (s *Store) ImportMetadata(ctx context.Context, r io.Reader) error {
 	rootID := int64(0)
+	vaultID := ""
 	err := s.withTx(ctx, func(tx *sql.Tx) error {
 		if err := requirePristineMetadataTarget(ctx, tx); err != nil {
 			return err
@@ -463,25 +472,32 @@ func (s *Store) ImportMetadata(ctx context.Context, r io.Reader) error {
 		if _, err := tx.ExecContext(ctx, `PRAGMA defer_foreign_keys = ON`); err != nil {
 			return fmt.Errorf("deferring metadata foreign keys: %w", err)
 		}
-		nodeSequence, err := importMetadataLines(ctx, tx, r)
+		header, err := importMetadataLines(ctx, tx, r)
 		if err != nil {
 			return err
 		}
-		if err := validateMetadataState(ctx, tx, nodeSequence); err != nil {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE vault_metadata SET vault_id = ? WHERE singleton = 1`, header.VaultID,
+		); err != nil {
+			return fmt.Errorf("restoring vault identity: %w", err)
+		}
+		if err := validateMetadataState(ctx, tx, header.NodeSequence); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx, `UPDATE sqlite_sequence SET seq = ? WHERE name = 'nodes'`, nodeSequence); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE sqlite_sequence SET seq = ? WHERE name = 'nodes'`, header.NodeSequence); err != nil {
 			return fmt.Errorf("restoring node ID high-water mark: %w", err)
 		}
 		if err := tx.QueryRowContext(ctx, `SELECT id FROM nodes WHERE parent_id IS NULL`).Scan(&rootID); err != nil {
 			return fmt.Errorf("finding imported root: %w", err)
 		}
+		vaultID = header.VaultID
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 	s.rootID = rootID
+	s.vaultID = vaultID
 	return nil
 }
 
@@ -505,47 +521,50 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 	return nil
 }
 
-func importMetadataLines(ctx context.Context, tx *sql.Tx, r io.Reader) (int64, error) {
+func importMetadataLines(ctx context.Context, tx *sql.Tx, r io.Reader) (metadataHeader, error) {
 	dec := json.NewDecoder(bufio.NewReader(r))
 	var rawHeader json.RawMessage
 	if err := dec.Decode(&rawHeader); err != nil {
-		return 0, fmt.Errorf("decoding metadata header: %w", err)
+		return metadataHeader{}, fmt.Errorf("decoding metadata header: %w", err)
 	}
 	if err := validateMetadataJSON(rawHeader); err != nil {
-		return 0, fmt.Errorf("decoding metadata header: %w", err)
+		return metadataHeader{}, fmt.Errorf("decoding metadata header: %w", err)
 	}
 	if err := requireMetadataFields(rawHeader, metadataHeaderFields, nil); err != nil {
-		return 0, fmt.Errorf("decoding metadata header: %w", err)
+		return metadataHeader{}, fmt.Errorf("decoding metadata header: %w", err)
 	}
 	var header metadataHeader
 	if err := decodeMetadataRecord(rawHeader, &header); err != nil {
-		return 0, fmt.Errorf("decoding metadata header: %w", err)
+		return metadataHeader{}, fmt.Errorf("decoding metadata header: %w", err)
 	}
 	if header.Type != "meta" || header.Format != "docbank-metadata" ||
 		header.Version != metadataFormatVersion || header.NodeSequence <= 0 {
-		return 0, fmt.Errorf("unsupported metadata header: type=%q format=%q version=%d node_sequence=%d",
+		return metadataHeader{}, fmt.Errorf("unsupported metadata header: type=%q format=%q version=%d node_sequence=%d",
 			header.Type, header.Format, header.Version, header.NodeSequence)
+	}
+	if err := validateUUIDv4(header.VaultID); err != nil {
+		return metadataHeader{}, fmt.Errorf("invalid metadata vault_id: %w", err)
 	}
 	for record := 2; ; record++ {
 		var raw json.RawMessage
 		err := dec.Decode(&raw)
 		if errors.Is(err, io.EOF) {
-			return header.NodeSequence, nil
+			return header, nil
 		}
 		if err != nil {
-			return 0, fmt.Errorf("decoding metadata record %d: %w", record, err)
+			return metadataHeader{}, fmt.Errorf("decoding metadata record %d: %w", record, err)
 		}
 		if err := validateMetadataJSON(raw); err != nil {
-			return 0, fmt.Errorf("decoding metadata record %d: %w", record, err)
+			return metadataHeader{}, fmt.Errorf("decoding metadata record %d: %w", record, err)
 		}
 		var kind struct {
 			Type string `json:"type"`
 		}
 		if err := json.Unmarshal(raw, &kind); err != nil {
-			return 0, fmt.Errorf("decoding metadata record %d type: %w", record, err)
+			return metadataHeader{}, fmt.Errorf("decoding metadata record %d type: %w", record, err)
 		}
 		if err := importMetadataRecord(ctx, tx, kind.Type, raw); err != nil {
-			return 0, fmt.Errorf("importing metadata record %d (%s): %w", record, kind.Type, err)
+			return metadataHeader{}, fmt.Errorf("importing metadata record %d (%s): %w", record, kind.Type, err)
 		}
 	}
 }
@@ -653,7 +672,7 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 
 const metadataTypeField = "type"
 
-var metadataHeaderFields = []string{metadataTypeField, "format", "version", "node_sequence"}
+var metadataHeaderFields = []string{metadataTypeField, "format", "version", "vault_id", "node_sequence"}
 
 var metadataRequiredFields = map[string][]string{
 	"blob":            {metadataTypeField, "hash", "size", "created_at"},
@@ -963,6 +982,15 @@ func validateProvenanceTime(value string) error {
 }
 
 func validateMetadataState(ctx context.Context, tx metadataQuerier, nodeSequence int64) error {
+	var vaultID string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT vault_id FROM vault_metadata WHERE singleton = 1`,
+	).Scan(&vaultID); err != nil {
+		return fmt.Errorf("reading vault identity: %w", err)
+	}
+	if err := validateUUIDv4(vaultID); err != nil {
+		return fmt.Errorf("invalid vault identity: %w", err)
+	}
 	if err := validateMetadataRelations(ctx, tx); err != nil {
 		return err
 	}

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -28,6 +28,8 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	sourceVaultID := source.VaultID()
+	require.NoError(t, validateUUIDv4(sourceVaultID))
 	seedMetadataRoundTrip(t, source)
 	filesystemMTime := time.Date(2026, time.February, 3, 4, 5, 6, 120_000_000, time.UTC).
 		Format(time.RFC3339Nano)
@@ -62,7 +64,8 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	require.NoError(t, source.ExportMetadata(ctx, &first))
 	require.NoError(t, source.ExportMetadata(ctx, &second))
 	assert.Equal(t, first.Bytes(), second.Bytes(), "unchanged metadata must export byte-identically")
-	assert.Contains(t, first.String(), `{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":100}`)
+	assert.Contains(t, first.String(), `{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"`+
+		sourceVaultID+`","node_sequence":100}`)
 	assert.Contains(t, first.String(), `"original_mtime":"2026-02-03T04:05:06.12Z"`)
 	assert.Contains(t, first.String(), `{"type":"node","id":7,"parent_id":1,"name":"Projects","kind":"dir"`)
 	assert.NotContains(t, first.String(), "blob_pack_index")
@@ -72,6 +75,7 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, target.Close()) })
 	require.NoError(t, target.ImportMetadata(ctx, bytes.NewReader(first.Bytes())))
+	assert.Equal(t, sourceVaultID, target.VaultID())
 
 	var restored bytes.Buffer
 	require.NoError(t, target.ExportMetadata(ctx, &restored))
@@ -125,9 +129,10 @@ func TestImportMetadataRejectsDanglingContentAndRollsBack(t *testing.T) {
 	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	targetVaultID := target.VaultID()
 
 	input := strings.Join([]string{
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":2}`,
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":2}`,
 		`{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","current_version_id":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
 		`{"type":"node","id":2,"parent_id":1,"name":"missing.bin","kind":"file","current_version_id":"44444444-4444-4444-8444-444444444444","revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
 	}, "\n") + "\n"
@@ -137,11 +142,17 @@ func TestImportMetadataRejectsDanglingContentAndRollsBack(t *testing.T) {
 	var nodes int64
 	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
 	assert.Equal(t, int64(1), nodes, "failed import must leave the pristine target intact")
+	assert.Equal(t, targetVaultID, target.VaultID())
+	var storedVaultID string
+	require.NoError(t, target.db.QueryRow(
+		`SELECT vault_id FROM vault_metadata WHERE singleton = 1`,
+	).Scan(&storedVaultID))
+	assert.Equal(t, targetVaultID, storedVaultID)
 }
 
 func TestImportMetadataRejectsInvalidUTF8AndRollsBack(t *testing.T) {
 	const (
-		header = `{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n"
+		header = `{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n"
 		root   = `{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","current_version_id":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}` + "\n"
 	)
 	withInvalidByte := func(prefix, suffix string) []byte {
@@ -154,7 +165,7 @@ func TestImportMetadataRejectsInvalidUTF8AndRollsBack(t *testing.T) {
 	}{
 		"header string": {
 			input: withInvalidByte(
-				`{"type":"meta","format":"docbank-`, `","version":1,"node_sequence":1}`+"\n"),
+				`{"type":"meta","format":"docbank-`, `","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}`+"\n"),
 			want: "metadata JSON is not valid UTF-8",
 		},
 		"record string": {
@@ -189,7 +200,7 @@ func TestImportMetadataRejectsInvalidUTF8AndRollsBack(t *testing.T) {
 
 func TestImportMetadataAcceptsValidSurrogatePair(t *testing.T) {
 	input := strings.Join([]string{
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}`,
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}`,
 		`{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","current_version_id":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
 		`{"type":"tag","id":1,"name":"archive \ud83d\ude00"}`,
 	}, "\n") + "\n"
@@ -477,7 +488,7 @@ func TestImportMetadataRejectsOrphanedExtractionAndRollsBack(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, target.Close()) })
 
 	input := strings.Join([]string{
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}`,
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}`,
 		`{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","current_version_id":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
 		`{"type":"extracted_text","blob_hash":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","extractor":"plain","extractor_version":1,"status":"ok","error":null,"attempts":1,"text":"orphan","extracted_at":"2026-01-01T00:00:00.000000000Z"}`,
 	}, "\n") + "\n"
@@ -568,7 +579,7 @@ func TestImportMetadataRejectsUnsafeTrashTopology(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, target.Close()) })
 			lines := append([]string{
-				`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":3}`,
+				`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":3}`,
 				root,
 			}, tt.records...)
 			err = target.ImportMetadata(context.Background(), strings.NewReader(strings.Join(lines, "\n")+"\n"))
@@ -607,7 +618,7 @@ func TestImportMetadataRejectsNonPristineTarget(t *testing.T) {
 	_, err = target.Mkdir(context.Background(), target.RootID(), "existing")
 	require.NoError(t, err)
 
-	input := `{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n"
+	input := `{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n"
 	err = target.ImportMetadata(context.Background(), strings.NewReader(input))
 	require.ErrorContains(t, err, "not pristine")
 	_, err = target.NodeByPath(context.Background(), "/existing")
@@ -616,19 +627,22 @@ func TestImportMetadataRejectsNonPristineTarget(t *testing.T) {
 
 func TestImportMetadataRejectsUnknownVersionAndFields(t *testing.T) {
 	for _, input := range []string{
-		`{"type":"meta","format":"docbank-metadata","version":2,"node_sequence":1}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1,"version":1,"node_sequence":1}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1,"surprise":true}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":2,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"not-a-uuid","node_sequence":1}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":null,"node_sequence":1}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","vault_id":"eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee","node_sequence":1}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n",
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1,"surprise":true}` + "\n",
 		`{"type":"meta","format":"docbank-metadata","version":1}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n" +
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n" +
 			`{"type":"future_record","value":1}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n" +
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n" +
 			`{"type":"blob","hash":"` + metadataHashCurrent + `","size":12}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n" +
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n" +
 			`{"type":"blob","hash":"` + metadataHashCurrent + `","size":null,"created_at":"2026-01-01T00:00:00.000000000Z"}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n" +
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n" +
 			`{"type":"blob","hash":"` + metadataHashCurrent + `","Size":12,"created_at":"2026-01-01T00:00:00.000000000Z"}` + "\n",
-		`{"type":"meta","format":"docbank-metadata","version":1,"node_sequence":1}` + "\n" +
+		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n" +
 			`{"type":"blob","hash":"` + metadataHashCurrent + `","size":12,"created_at":"2026-01-01T00:00:00.000000000+00:00"}` + "\n",
 	} {
 		t.Run(input, func(t *testing.T) {
@@ -638,6 +652,17 @@ func TestImportMetadataRejectsUnknownVersionAndFields(t *testing.T) {
 			require.Error(t, target.ImportMetadata(context.Background(), strings.NewReader(input)))
 		})
 	}
+}
+
+func TestExportMetadataRejectsMalformedVaultIdentity(t *testing.T) {
+	source := newTestStore(t)
+	_, err := source.db.Exec(`UPDATE vault_metadata SET vault_id = 'not-a-uuid' WHERE singleton = 1`)
+	require.NoError(t, err)
+
+	var exported bytes.Buffer
+	err = source.ExportMetadata(t.Context(), &exported)
+	require.ErrorContains(t, err, "invalid vault identity")
+	assert.Empty(t, exported.Bytes())
 }
 
 func seedMetadataRoundTrip(t *testing.T, s *Store) {

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -1,5 +1,12 @@
 -- docbank core schema. Idempotent: applied on every Open.
 
+-- One stable logical identity follows the vault through JSONL backup and
+-- restore. Filesystem location is deliberately not identity.
+CREATE TABLE IF NOT EXISTS vault_metadata (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    vault_id  TEXT NOT NULL UNIQUE
+);
+
 -- AUTOINCREMENT: node ids are stored as origins (trash_parent) and will be
 -- handed to agents over the HTTP API; a reused rowid would silently retarget
 -- those references at an unrelated node.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,10 +17,11 @@ var schemaSQL string
 
 // Store is the single access path to the docbank database.
 type Store struct {
-	db     *sql.DB
-	path   string
-	rootID int64
-	driver docsqlite.Driver
+	db      *sql.DB
+	path    string
+	rootID  int64
+	vaultID string
+	driver  docsqlite.Driver
 }
 
 // DefaultSQLiteDriver returns the build's standalone-compatible adapter: CGO
@@ -81,6 +82,25 @@ func (s *Store) bootstrapTx() error {
 		if _, err := tx.Exec(schemaSQL); err != nil {
 			return fmt.Errorf("applying schema: %w", err)
 		}
+		if err := tx.QueryRow(`SELECT vault_id FROM vault_metadata WHERE singleton = 1`).Scan(
+			&s.vaultID,
+		); errors.Is(err, sql.ErrNoRows) {
+			vaultID, idErr := newUUIDv4()
+			if idErr != nil {
+				return fmt.Errorf("creating vault identity: %w", idErr)
+			}
+			if _, idErr = tx.Exec(
+				`INSERT INTO vault_metadata(singleton, vault_id) VALUES(1, ?)`, vaultID,
+			); idErr != nil {
+				return fmt.Errorf("creating vault identity: %w", idErr)
+			}
+			s.vaultID = vaultID
+		} else if err != nil {
+			return fmt.Errorf("looking up vault identity: %w", err)
+		}
+		if err := validateUUIDv4(s.vaultID); err != nil {
+			return fmt.Errorf("validating vault identity: %w", err)
+		}
 		now := nowRFC3339()
 		if _, err := tx.Exec(
 			`INSERT INTO nodes (parent_id, name, kind, created_at, modified_at)
@@ -99,6 +119,10 @@ func (s *Store) bootstrapTx() error {
 
 // RootID returns the id of the tree root.
 func (s *Store) RootID() int64 { return s.rootID }
+
+// VaultID returns the stable logical identity preserved by metadata export,
+// backup, and restore. Moving or restoring a vault does not change it.
+func (s *Store) VaultID() string { return s.vaultID }
 
 // SQLiteDriver returns the exact adapter used by this store. Backup snapshots
 // and embedded lifecycle helpers reuse it for every auxiliary connection.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -23,6 +23,8 @@ func TestOpenBootstrapsRoot(t *testing.T) {
 	require.NoError(t, err)
 	rootID := s.RootID()
 	assert.Positive(t, rootID)
+	vaultID := s.VaultID()
+	require.NoError(t, validateUUIDv4(vaultID))
 	require.NoError(t, s.Close())
 
 	// Reopen: same root, no duplicate.
@@ -30,6 +32,7 @@ func TestOpenBootstrapsRoot(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, s2.Close()) }()
 	assert.Equal(t, rootID, s2.RootID())
+	assert.Equal(t, vaultID, s2.VaultID())
 
 	var count int
 	require.NoError(t, s2.db.QueryRow(
@@ -55,6 +58,7 @@ func TestOpenConcurrentBootstrap(t *testing.T) {
 
 	for i := range n {
 		require.NoError(t, errs[i])
+		assert.Equal(t, stores[0].VaultID(), stores[i].VaultID())
 	}
 	defer func() {
 		for i := range n {

--- a/pkg/docbank.go
+++ b/pkg/docbank.go
@@ -143,6 +143,15 @@ func (v *Vault) SQLiteDriver() string {
 	return v.metadata.SQLiteDriver().Name()
 }
 
+// ID reports the stable logical vault identity preserved by metadata export,
+// backup, and restore. It is independent of the vault's filesystem root.
+func (v *Vault) ID() string {
+	if v == nil || v.metadata == nil {
+		return ""
+	}
+	return v.metadata.VaultID()
+}
+
 // Stat resolves a live virtual path to its stable node projection.
 func (v *Vault) Stat(ctx context.Context, virtualPath string) (Node, error) {
 	if err := v.begin(); err != nil {

--- a/pkg/docbank_test.go
+++ b/pkg/docbank_test.go
@@ -106,6 +106,8 @@ func testEmbeddedVaultLifecycle(t *testing.T, driver docsqlite.Driver) {
 	root := t.TempDir()
 	vault, err := Open(t.Context(), OpenOptions{Root: root, SQLite: driver})
 	require.NoError(err)
+	vaultID := vault.ID()
+	require.NotEmpty(vaultID)
 
 	first, err := vault.Put(t.Context(), "/sessions/one.jsonl", strings.NewReader("first\n"),
 		PutOptions{MediaType: "application/x-ndjson"})
@@ -140,6 +142,7 @@ func testEmbeddedVaultLifecycle(t *testing.T, driver docsqlite.Driver) {
 	reopened, err := Open(t.Context(), OpenOptions{Root: root, SQLite: driver})
 	require.NoError(err)
 	t.Cleanup(func() { require.NoError(reopened.Close()) })
+	require.Equal(vaultID, reopened.ID())
 	node, err := reopened.Stat(t.Context(), "/sessions/one.jsonl")
 	require.NoError(err)
 	require.Equal(second.Node.ID, node.ID)


### PR DESCRIPTION
Full-audit hashes and restore lineage need a durable logical archive identity; a filesystem root cannot serve that role because backup restores and embedded deployments legitimately move vaults. Metadata v1 currently preserves nodes and versions but generates no identity that can domain-separate the later authority.

This gives every new or opened vault one canonical UUIDv4, carries it through deterministic JSONL import/export as part of the existing format-v1 header, and exposes it to embedded applications as `vault.ID()`. Import replaces a pristine target's bootstrap identity only inside the successful metadata transaction, so malformed or inconsistent streams cannot partially retarget a vault.

This is deliberately the zero-scope prerequisite only. Audit scopes, mutation chains, retention enforcement, and backup evidence remain in the dependent full-audit slices.