### PR TITLE
Use stable identities for ingest and tag authority

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -401,7 +401,8 @@ func (ing *Ingester) AddPathsWithOptions(
 func (ing *Ingester) addTree(
 	ctx context.Context,
 	rep *Report,
-	ingestID, destDirID int64,
+	ingestID string,
+	destDirID int64,
 	sourceRoot, walkRoot string,
 	excludes exclusions,
 	progress *progressTracker,
@@ -506,7 +507,8 @@ func sourceTreePath(sourceRoot, walkRoot, walkPath string) string {
 func (ing *Ingester) addOne(
 	ctx context.Context,
 	rep *Report,
-	ingestID, parentID int64,
+	ingestID string,
+	parentID int64,
 	openPath, sourcePath string,
 	progress *progressTracker,
 ) error {
@@ -528,7 +530,8 @@ func (ing *Ingester) addOne(
 
 func (ing *Ingester) importFile(
 	ctx context.Context,
-	ingestID, parentID int64,
+	ingestID string,
+	parentID int64,
 	openPath, sourcePath string,
 	progress *progressTracker,
 ) (bool, error) {

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 )
 
-// newUUIDv4 returns a canonical lowercase random UUID. Version identities are
-// intentionally independent of SQLite allocators, content hashes, and clocks.
+// newUUIDv4 returns a canonical lowercase random UUID. Persistent identities
+// are intentionally independent of SQLite allocators, content hashes, and clocks.
 func newUUIDv4() (string, error) {
 	var raw [16]byte
 	if _, err := rand.Read(raw[:]); err != nil {

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -8,23 +8,23 @@ import (
 	"path/filepath"
 )
 
-// BeginIngest records the start of an ingest run and returns its id.
-func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) (int64, error) {
+// BeginIngest records the start of an ingest run and returns its ID.
+func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) (string, error) {
+	id, err := newUUIDv4()
+	if err != nil {
+		return "", fmt.Errorf("allocating ingest id: %w", err)
+	}
 	startedAt := nowRFC3339()
 	if err := validateIngestRecord(metadataIngest{
-		Type: "ingest", ID: 1, StartedAt: startedAt, SourceKind: sourceKind, SourceDesc: sourceDesc,
+		Type: "ingest", ID: id, StartedAt: startedAt, SourceKind: sourceKind, SourceDesc: sourceDesc,
 	}); err != nil {
-		return 0, fmt.Errorf("validating ingest start: %w", err)
+		return "", fmt.Errorf("validating ingest start: %w", err)
 	}
-	res, err := s.db.ExecContext(ctx,
-		`INSERT INTO ingests (started_at, source_kind, source_desc) VALUES (?, ?, ?)`,
-		startedAt, sourceKind, sourceDesc)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO ingests (id, started_at, source_kind, source_desc) VALUES (?, ?, ?, ?)`,
+		id, startedAt, sourceKind, sourceDesc)
 	if err != nil {
-		return 0, fmt.Errorf("recording ingest start: %w", err)
-	}
-	id, err := res.LastInsertId()
-	if err != nil {
-		return 0, fmt.Errorf("reading ingest id: %w", err)
+		return "", fmt.Errorf("recording ingest start: %w", err)
 	}
 	return id, nil
 }
@@ -135,7 +135,7 @@ func sameOriginTx(tx *sql.Tx, nodeID int64, name string) (bool, error) {
 // IngestFile imports one already-durable blob as a node under parentID,
 // applying the idempotency rule and recording provenance. Returns
 // added=false when the content is already present under a candidate name.
-func (s *Store) IngestFile(ctx context.Context, ingestID, parentID int64, name, blobHash string, size int64, mimeType, originalPath, originalMtime string) (Node, bool, error) {
+func (s *Store) IngestFile(ctx context.Context, ingestID string, parentID int64, name, blobHash string, size int64, mimeType, originalPath, originalMtime string) (Node, bool, error) {
 	name, err := NormalizeName(name)
 	if err != nil {
 		return Node{}, false, err

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -87,6 +87,7 @@ func TestIngestFileRecordsProvenance(t *testing.T) {
 
 	ing, err := s.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
+	require.NoError(t, validateUUIDv4(ing))
 	n, added, err := s.IngestFile(ctx, ing, s.RootID(),
 		"a.txt", fakeHash("a1"), 1, "text/plain", "/orig/a.txt", "2026-01-02T03:04:05Z")
 	require.NoError(t, err)
@@ -98,6 +99,23 @@ func TestIngestFileRecordsProvenance(t *testing.T) {
 		n.ID).Scan(&origPath, &origMtime))
 	assert.Equal(t, "/orig/a.txt", origPath)
 	assert.Equal(t, "2026-01-02T03:04:05Z", origMtime)
+	var storedIngestID string
+	require.NoError(t, s.db.QueryRow(
+		`SELECT ingest_id FROM provenance WHERE node_id = ?`, n.ID,
+	).Scan(&storedIngestID))
+	assert.Equal(t, ing, storedIngestID)
+}
+
+func TestBeginIngestAllocatesDistinctUUIDs(t *testing.T) {
+	s := newTestStore(t)
+	first, err := s.BeginIngest(t.Context(), "cli", "first")
+	require.NoError(t, err)
+	second, err := s.BeginIngest(t.Context(), "cli", "second")
+	require.NoError(t, err)
+
+	require.NoError(t, validateUUIDv4(first))
+	require.NoError(t, validateUUIDv4(second))
+	assert.NotEqual(t, first, second)
 }
 
 func TestIngestRejectsNonUTF8MetadataBeforeCommit(t *testing.T) {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -123,7 +123,7 @@ type metadataContentVersion struct {
 
 type metadataIngest struct {
 	Type       string `json:"type"`
-	ID         int64  `json:"id"`
+	ID         string `json:"ingest_id"`
 	StartedAt  string `json:"started_at"`
 	SourceKind string `json:"source_kind"`
 	SourceDesc string `json:"source_desc"`
@@ -132,21 +132,21 @@ type metadataIngest struct {
 type metadataProvenance struct {
 	Type          string  `json:"type"`
 	NodeID        int64   `json:"node_id"`
-	IngestID      int64   `json:"ingest_id"`
+	IngestID      string  `json:"ingest_id"`
 	OriginalPath  string  `json:"original_path"`
 	OriginalMTime *string `json:"original_mtime"`
 }
 
 type metadataTag struct {
 	Type string `json:"type"`
-	ID   int64  `json:"id"`
+	ID   string `json:"tag_id"`
 	Name string `json:"name"`
 }
 
 type metadataNodeTag struct {
 	Type   string `json:"type"`
 	NodeID int64  `json:"node_id"`
-	TagID  int64  `json:"tag_id"`
+	TagID  string `json:"tag_id"`
 }
 
 type metadataExtractedText struct {
@@ -678,9 +678,9 @@ var metadataRequiredFields = map[string][]string{
 	"blob":            {metadataTypeField, "hash", "size", "created_at"},
 	"node":            {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", "created_at", "modified_at", "trashed_at", "trash_parent", "trash_name"},
 	"content_version": {metadataTypeField, "version_id", "node_id", "blob_hash", "size", "mime_type", "recorded_at", "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
-	"ingest":          {metadataTypeField, "id", "started_at", "source_kind", "source_desc"},
+	"ingest":          {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
 	"provenance":      {metadataTypeField, "node_id", "ingest_id", "original_path", "original_mtime"},
-	"tag":             {metadataTypeField, "id", "name"},
+	"tag":             {metadataTypeField, "tag_id", "name"},
 	"node_tag":        {metadataTypeField, "node_id", "tag_id"},
 	"extracted_text":  {metadataTypeField, "blob_hash", "extractor", "extractor_version", "status", "error", "attempts", "text", "extracted_at"},
 }
@@ -894,8 +894,11 @@ func validateContentVersionRecord(v metadataContentVersion) error {
 }
 
 func validateIngestRecord(v metadataIngest) error {
-	if v.Type != "ingest" || v.ID <= 0 || v.SourceKind == "" || v.SourceDesc == "" {
+	if v.Type != "ingest" || v.SourceKind == "" || v.SourceDesc == "" {
 		return errors.New("invalid ingest record")
+	}
+	if err := validateUUIDv4(v.ID); err != nil {
+		return fmt.Errorf("invalid ingest ID: %w", err)
 	}
 	if err := validateUTF8Field("ingest source_kind", v.SourceKind); err != nil {
 		return err
@@ -907,8 +910,11 @@ func validateIngestRecord(v metadataIngest) error {
 }
 
 func validateProvenanceRecord(v metadataProvenance) error {
-	if v.Type != "provenance" || v.NodeID <= 0 || v.IngestID <= 0 || v.OriginalPath == "" {
+	if v.Type != "provenance" || v.NodeID <= 0 || v.OriginalPath == "" {
 		return errors.New("invalid provenance record")
+	}
+	if err := validateUUIDv4(v.IngestID); err != nil {
+		return fmt.Errorf("invalid provenance ingest ID: %w", err)
 	}
 	if err := validateUTF8Field("provenance original_path", v.OriginalPath); err != nil {
 		return err
@@ -920,15 +926,21 @@ func validateProvenanceRecord(v metadataProvenance) error {
 }
 
 func validateTagRecord(v metadataTag) error {
-	if v.Type != "tag" || v.ID <= 0 || v.Name == "" {
+	if v.Type != "tag" || v.Name == "" {
 		return errors.New("invalid tag record")
+	}
+	if err := validateUUIDv4(v.ID); err != nil {
+		return fmt.Errorf("invalid tag ID: %w", err)
 	}
 	return validateUTF8Field("tag name", v.Name)
 }
 
 func validateNodeTagRecord(v metadataNodeTag) error {
-	if v.Type != "node_tag" || v.NodeID <= 0 || v.TagID <= 0 {
+	if v.Type != "node_tag" || v.NodeID <= 0 {
 		return errors.New("invalid node tag record")
+	}
+	if err := validateUUIDv4(v.TagID); err != nil {
+		return fmt.Errorf("invalid node tag tag ID: %w", err)
 	}
 	return nil
 }

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -21,6 +21,8 @@ const (
 	metadataVersionCurrent = "11111111-1111-4111-8111-111111111111"
 	metadataVersionOld     = "22222222-2222-4222-8222-222222222222"
 	metadataVersionTrashed = "33333333-3333-4333-8333-333333333333"
+	metadataIngestID       = "44444444-4444-4444-8444-444444444444"
+	metadataTagID          = "55555555-5555-4555-8555-555555555555"
 )
 
 func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
@@ -170,15 +172,15 @@ func TestImportMetadataRejectsInvalidUTF8AndRollsBack(t *testing.T) {
 		},
 		"record string": {
 			input: withInvalidByte(
-				header+root+`{"type":"tag","id":1,"name":"invalid`, `"}`+"\n"),
+				header+root+`{"type":"tag","tag_id":"`+metadataTagID+`","name":"invalid`, `"}`+"\n"),
 			want: "metadata JSON is not valid UTF-8",
 		},
 		"lone high surrogate": {
-			input: []byte(header + root + `{"type":"tag","id":1,"name":"invalid\ud800"}` + "\n"),
+			input: []byte(header + root + `{"type":"tag","tag_id":"` + metadataTagID + `","name":"invalid\ud800"}` + "\n"),
 			want:  "unpaired UTF-16 surrogate escape",
 		},
 		"lone low surrogate": {
-			input: []byte(header + root + `{"type":"tag","id":1,"name":"invalid\udc00"}` + "\n"),
+			input: []byte(header + root + `{"type":"tag","tag_id":"` + metadataTagID + `","name":"invalid\udc00"}` + "\n"),
 			want:  "unpaired UTF-16 surrogate escape",
 		},
 	}
@@ -202,14 +204,14 @@ func TestImportMetadataAcceptsValidSurrogatePair(t *testing.T) {
 	input := strings.Join([]string{
 		`{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}`,
 		`{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","current_version_id":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}`,
-		`{"type":"tag","id":1,"name":"archive \ud83d\ude00"}`,
+		`{"type":"tag","tag_id":"` + metadataTagID + `","name":"archive \ud83d\ude00"}`,
 	}, "\n") + "\n"
 	target, err := Open(filepath.Join(t.TempDir(), "target.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, target.Close()) })
 	require.NoError(t, target.ImportMetadata(t.Context(), strings.NewReader(input)))
 	var name string
-	require.NoError(t, target.db.QueryRow(`SELECT name FROM tags WHERE id=1`).Scan(&name))
+	require.NoError(t, target.db.QueryRow(`SELECT name FROM tags WHERE id=?`, metadataTagID).Scan(&name))
 	assert.Equal(t, "archive 😀", name)
 }
 
@@ -665,6 +667,66 @@ func TestExportMetadataRejectsMalformedVaultIdentity(t *testing.T) {
 	assert.Empty(t, exported.Bytes())
 }
 
+func TestMetadataRejectsMalformedStableRecordIDs(t *testing.T) {
+	t.Run("import", func(t *testing.T) {
+		header := `{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n"
+		root := `{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","current_version_id":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}` + "\n"
+		for name, record := range map[string]string{
+			"ingest": `{"type":"ingest","ingest_id":"not-a-uuid","started_at":"2026-01-01T00:00:00.000000000Z","source_kind":"cli","source_desc":"source"}`,
+			"tag":    `{"type":"tag","tag_id":"not-a-uuid","name":"archive"}`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, target.Close()) })
+				err = target.ImportMetadata(t.Context(), strings.NewReader(header+root+record+"\n"))
+				require.ErrorContains(t, err, "canonical UUIDv4")
+			})
+		}
+	})
+
+	t.Run("export", func(t *testing.T) {
+		for name, insert := range map[string]string{
+			"ingest": `INSERT INTO ingests(id,started_at,source_kind,source_desc)
+				VALUES('not-a-uuid','2026-01-01T00:00:00.000000000Z','cli','source')`,
+			"tag": `INSERT INTO tags(id,name) VALUES('not-a-uuid','archive')`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				source := newTestStore(t)
+				_, err := source.db.Exec(insert)
+				require.NoError(t, err)
+				var exported bytes.Buffer
+				err = source.ExportMetadata(t.Context(), &exported)
+				require.ErrorContains(t, err, "canonical UUIDv4")
+			})
+		}
+	})
+}
+
+func TestImportMetadataRejectsDuplicateStableRecordIDsTransactionally(t *testing.T) {
+	header := `{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","node_sequence":1}` + "\n"
+	root := `{"type":"node","id":1,"parent_id":null,"name":"","kind":"dir","current_version_id":null,"revision":1,"created_at":"2026-01-01T00:00:00.000000000Z","modified_at":"2026-01-01T00:00:00.000000000Z","trashed_at":null,"trash_parent":null,"trash_name":null}` + "\n"
+	for name, record := range map[string]string{
+		"ingest": `{"type":"ingest","ingest_id":"` + metadataIngestID + `","started_at":"2026-01-01T00:00:00.000000000Z","source_kind":"cli","source_desc":"source"}`,
+		"tag":    `{"type":"tag","tag_id":"` + metadataTagID + `","name":"archive"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			target, err := Open(filepath.Join(t.TempDir(), "target.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, target.Close()) })
+
+			err = target.ImportMetadata(t.Context(), strings.NewReader(header+root+record+"\n"+record+"\n"))
+			require.Error(t, err)
+
+			var recordCount int64
+			require.NoError(t, target.db.QueryRow(
+				`SELECT (SELECT COUNT(*) FROM ingests) + (SELECT COUNT(*) FROM tags)`,
+			).Scan(&recordCount))
+			assert.Zero(t, recordCount)
+		})
+	}
+}
+
 func seedMetadataRoundTrip(t *testing.T, s *Store) {
 	t.Helper()
 	ctx := context.Background()
@@ -697,11 +759,11 @@ func seedMetadataRoundTrip(t *testing.T, s *Store) {
 			 ('` + metadataVersionTrashed + `',11,'` + metadataHashTrashed + `',5,'application/octet-stream',
 			  '2026-01-10T00:00:00.000000000Z',1,'cccccccc-cccc-4ccc-8ccc-cccccccccccc','content_create',NULL)`,
 			`INSERT INTO ingests(id,started_at,source_kind,source_desc)
-			 VALUES(4,'2026-01-08T00:00:00.000000000Z','filesystem','dropbox')`,
+				 VALUES('` + metadataIngestID + `','2026-01-08T00:00:00.000000000Z','filesystem','dropbox')`,
 			`INSERT INTO provenance(node_id,ingest_id,original_path,original_mtime)
-			 VALUES(10,4,'/source/report.txt','2025-12-31T23:00:00.12Z')`,
-			`INSERT INTO tags(id,name) VALUES(8,'important')`,
-			`INSERT INTO node_tags(node_id,tag_id) VALUES(10,8)`,
+				 VALUES(10,'` + metadataIngestID + `','/source/report.txt','2025-12-31T23:00:00.12Z')`,
+			`INSERT INTO tags(id,name) VALUES('` + metadataTagID + `','important')`,
+			`INSERT INTO node_tags(node_id,tag_id) VALUES(10,'` + metadataTagID + `')`,
 			`INSERT INTO extracted_text(blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at)
 			 VALUES('` + metadataHashCurrent + `','plain',2,'ok',NULL,1,'line one\nline two','2026-01-13T00:00:00.000000000Z')`,
 			`INSERT INTO blob_packs(pack_id,entry_count,stored_bytes,created_at)

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -97,7 +97,7 @@ CREATE INDEX IF NOT EXISTS content_versions_node
 CREATE INDEX IF NOT EXISTS content_versions_blob ON content_versions(blob_hash);
 
 CREATE TABLE IF NOT EXISTS ingests (
-    id          INTEGER PRIMARY KEY,
+    id          TEXT PRIMARY KEY NOT NULL,
     started_at  TEXT NOT NULL,
     source_kind TEXT NOT NULL,
     source_desc TEXT NOT NULL
@@ -105,7 +105,7 @@ CREATE TABLE IF NOT EXISTS ingests (
 
 CREATE TABLE IF NOT EXISTS provenance (
     node_id       INTEGER NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
-    ingest_id     INTEGER NOT NULL REFERENCES ingests(id),
+    ingest_id     TEXT NOT NULL REFERENCES ingests(id),
     original_path TEXT NOT NULL,
     original_mtime TEXT
 );
@@ -113,13 +113,13 @@ CREATE TABLE IF NOT EXISTS provenance (
 CREATE INDEX IF NOT EXISTS provenance_node ON provenance(node_id);
 
 CREATE TABLE IF NOT EXISTS tags (
-    id   INTEGER PRIMARY KEY,
+    id   TEXT PRIMARY KEY NOT NULL,
     name TEXT NOT NULL UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS node_tags (
     node_id INTEGER NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
-    tag_id  INTEGER NOT NULL REFERENCES tags(id),
+    tag_id  TEXT NOT NULL REFERENCES tags(id),
     PRIMARY KEY (node_id, tag_id)
 );
 


### PR DESCRIPTION
Allocator-derived ingest and tag IDs are unsafe durable identities: a JSONL round trip or independently restored vault can reuse them and silently retarget provenance, tag assignments, or future audit records. Full-audit authority needs these attached records to remain unambiguous before scopes and mutation chains are persisted.

This makes Docbank allocate canonical UUIDv4 identities for each ingest and tag, carries them through provenance and deterministic metadata-v1 JSONL, and rejects malformed or duplicate identities transactionally. Because Docbank has no public release compatibility boundary, this directly replaces the v1 schema instead of adding migration or dual-format machinery.

The complete CGO and pure-Go suites pass after rebasing directly onto current main; affected race, lint, documentation, and hook checks also pass. Kata: `wscp`.