### PR TITLE
Expose packing and bounded children to embedded vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ metadata, content, and maintenance authority.
 - Whole-vault integrity verification
 - Incremental backup repositories with create, list, verify, and confined restore
 - Daemon-first CLI, authenticated loopback HTTP API, and offline OpenAPI output
-- An embedded Go API with independently locked vaults and selectable CGO or
-  pure-Go SQLite
+- An embedded Go API with independently locked vaults, bounded tree listing,
+  explicit packing, and selectable CGO or pure-Go SQLite
 - A release pipeline for Linux, macOS, and Windows on amd64 and arm64, with
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -15,10 +15,11 @@ valid indefinitely.
 `docbank storage status` exposes loose and packed inventory through the
 authenticated daemon API, and `docbank storage pack` explicitly moves
 authorized loose content into immutable packs with an optional work budget.
-`docbank storage repack` compacts eligible sparse packs and retires dead pack
-files. These commands are the complete ordinary representation-management
-surface. Startup never performs an implicit migration, and automatic background
-maintenance remains a later step.
+An application that exclusively owns an embedded vault can invoke the same
+packing and reconciliation pass through `Vault.Pack`; it cannot bypass the
+catalog or Kit's maintenance coordinator. `docbank storage repack` compacts
+eligible sparse packs and retires dead pack files. Startup never performs an
+implicit migration, and automatic background maintenance remains a later step.
 
 Large collections of small files are expensive to enumerate, copy, and restore.
 msgvault uses immutable pack files as the steady-state storage format for

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -77,6 +77,63 @@ or `Verify` succeeds. Early `Close` does not drain the stream. `Vault.Close`
 waits for active operations and streams, closes storage, and releases the vault
 lock.
 
+## List and pack content
+
+`Children` exposes the live virtual tree without materializing an unbounded
+directory. Resolve a directory with `Stat`, then advance through its direct
+children with `Limit` and `Offset`:
+
+```go
+manifests, err := vault.Stat(ctx, "/manifests")
+if err != nil {
+    return err
+}
+for offset := 0; ; {
+    page, err := vault.Children(ctx, manifests.ID, docbank.ChildrenOptions{
+        Limit:  500,
+        Offset: offset,
+    })
+    if err != nil {
+        return err
+    }
+    for _, child := range page.Items {
+        // Inspect this bounded page.
+        _ = child
+    }
+    offset += len(page.Items)
+    if offset >= page.Total || len(page.Items) == 0 {
+        break
+    }
+}
+```
+
+Pages contain directories first and files second, name-sorted within each
+kind. A zero limit uses `DefaultChildrenLimit`; one call cannot exceed
+`MaxChildrenLimit`. The total and page come from one metadata snapshot, but a
+caller that needs a complete stable traversal must avoid concurrent tree
+mutations between page calls.
+
+Ordinary `Put` calls publish loose content. Call `Pack` explicitly when the
+embedded owner is ready to move authorized loose blobs into managed immutable
+packs:
+
+```go
+report, err := vault.Pack(ctx, docbank.PackOptions{MaxBytes: 256 << 20})
+if err != nil {
+    return err
+}
+if report.BudgetExhausted {
+    // Run another bounded pass when scheduling allows.
+}
+```
+
+`MaxBytes` is a soft committed raw-byte budget: the pass finishes the blob that
+crosses the budget, seals its pack, and stops. Zero is unlimited. The report
+includes packing, reconciliation, missing/corrupt content, and orphan cleanup
+outcomes; embedded applications should surface those fields rather than
+treating a nil error alone as a complete health report. Packing changes only
+physical representation. `OpenContent` keeps the same verified read contract.
+
 ## Choose SQLite
 
 The build default preserves performance where CGO is available:

--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -16,6 +16,7 @@ developers update the right layer and preserve cross-layer contracts.
 | `internal/home` | vault layout, privacy, and portable vault/tree locking | data operations |
 | `internal/config` | strict config parsing and security validation | runtime discovery |
 | `cmd/docbank` | Cobra ergonomics and human output | store business logic |
+| `pkg` | lifecycle and bounded public operations for one exclusively owned embedded vault | standalone CLI paths or a second storage implementation |
 
 ## Common change paths
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -455,5 +455,7 @@ actual released formats and fixtures rather than speculative migration work.
   ordering and adds reachability atomically with pointer replacement.
   Reversion is the metadata-only exception: it reuses already-authoritative
   source bytes and atomically adds a new reachability row and pointer.
-- Pack and repack maintenance commands must remain daemon/API operations; no
-  CLI path may open the physical store directly.
+- Standalone pack and repack commands remain daemon/API operations; no CLI path
+  may open the physical store directly. An application that exclusively owns
+  an embedded vault may enter the same coordinated pack maintenance through
+  `pkg.Vault.Pack`.

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -240,15 +240,15 @@ func registerReadRoutes(api huma.API, d Deps) {
 		Limit  int   `query:"limit" default:"500" minimum:"1" maximum:"5000"`
 		Offset int   `query:"offset" default:"0" minimum:"0"`
 	}) (*childrenPage, error) {
-		kids, err := d.Store.Children(ctx, in.ID)
+		kids, total, err := d.Store.ChildrenPage(ctx, in.ID, in.Limit, in.Offset)
 		if err != nil {
 			return nil, FromStoreError(err)
 		}
 		out := &childrenPage{}
-		out.Body.Total, out.Body.Limit, out.Body.Offset = len(kids), in.Limit, in.Offset
+		out.Body.Total, out.Body.Limit, out.Body.Offset = total, in.Limit, in.Offset
 		out.Body.Items = []Node{}
-		for i := in.Offset; i < len(kids) && i < in.Offset+in.Limit; i++ {
-			out.Body.Items = append(out.Body.Items, fromStoreNode(kids[i]))
+		for _, child := range kids {
+			out.Body.Items = append(out.Body.Items, fromStoreNode(child))
 		}
 		return out, nil
 	})

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -137,6 +137,83 @@ func (s *Store) Children(ctx context.Context, dirID int64) ([]Node, error) {
 	return kids, nil
 }
 
+// ChildrenPage lists one bounded page of a directory's live children, dirs
+// first and name-sorted, and returns the complete child count. Target kind,
+// total, and page come from one statement so callers never observe a mixture
+// across concurrent tree mutations.
+func (s *Store) ChildrenPage(
+	ctx context.Context, dirID int64, limit, offset int,
+) ([]Node, int, error) {
+	if limit < 1 || limit > 5000 {
+		return nil, 0, errors.New("children limit must be between 1 and 5000")
+	}
+	if offset < 0 {
+		return nil, 0, errors.New("children offset must not be negative")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		WITH target AS (
+		  SELECT kind FROM nodes WHERE id = ?
+		), totals AS (
+		  SELECT COUNT(*) AS total
+		  FROM nodes
+		  WHERE parent_id = ? AND trashed_at IS NULL
+		), page AS (
+		  SELECT n.id, n.parent_id, n.name, n.kind,
+		         COALESCE(n.current_version_id, '') AS current_version_id,
+		         COALESCE(cv.blob_hash, '') AS blob_hash,
+		         COALESCE(cv.size, 0) AS size,
+		         COALESCE(cv.mime_type, '') AS mime_type,
+		         n.revision, n.created_at, n.modified_at, n.trashed_at
+		  FROM `+nodeFrom+`
+		  WHERE n.parent_id = ? AND n.trashed_at IS NULL
+		  ORDER BY n.kind = 'file', n.name
+		  LIMIT ? OFFSET ?
+		)
+		SELECT target.kind, totals.total,
+		       COALESCE(page.id, 0), page.parent_id, COALESCE(page.name, ''),
+		       COALESCE(page.kind, ''), COALESCE(page.current_version_id, ''),
+		       COALESCE(page.blob_hash, ''), COALESCE(page.size, 0),
+		       COALESCE(page.mime_type, ''), COALESCE(page.revision, 0),
+		       COALESCE(page.created_at, ''), COALESCE(page.modified_at, ''),
+		       page.trashed_at
+		FROM target CROSS JOIN totals LEFT JOIN page ON true
+		ORDER BY page.kind = 'file', page.name`, dirID, dirID, dirID, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing children of %d: %w", dirID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	children := make([]Node, 0)
+	var total int
+	found := false
+	for rows.Next() {
+		found = true
+		var targetKind string
+		var child Node
+		if err := rows.Scan(
+			&targetKind, &total, &child.ID, &child.ParentID, &child.Name,
+			&child.Kind, &child.CurrentVersionID, &child.BlobHash, &child.Size,
+			&child.MimeType, &child.Revision, &child.CreatedAt, &child.ModifiedAt,
+			&child.TrashedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("listing children of %d: scanning page: %w", dirID, err)
+		}
+		if targetKind != "dir" {
+			return nil, 0, fmt.Errorf("node %d: %w", dirID, ErrNotDir)
+		}
+		if child.ID != 0 {
+			children = append(children, child)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("listing children of %d: %w", dirID, err)
+	}
+	if !found {
+		return nil, 0, fmt.Errorf("node %d: %w", dirID, ErrNotFound)
+	}
+	return children, total, nil
+}
+
 // Path returns the display path of a node ("/" for the root).
 func (s *Store) Path(ctx context.Context, id int64) (string, error) {
 	if _, err := s.NodeByID(ctx, id); err != nil {

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -134,4 +135,46 @@ func TestChildrenSortedDirsFirst(t *testing.T) {
 
 	_, err = s.Children(ctx, kids[0].ID)
 	require.NoError(t, err)
+}
+
+func TestChildrenPageBoundsResultsAndPreservesTotal(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	_, err := s.Mkdir(ctx, s.RootID(), "zdir")
+	require.NoError(t, err)
+	_, err = s.Mkdir(ctx, s.RootID(), "adir")
+	require.NoError(t, err)
+	for _, name := range []string{"bravo.txt", "alpha.txt"} {
+		_, err = s.CreateFile(ctx, s.RootID(), name, strings.Repeat("a", 64), 1, "text/plain")
+		require.NoError(t, err)
+	}
+
+	first, total, err := s.ChildrenPage(ctx, s.RootID(), 3, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 4, total)
+	require.Len(t, first, 3)
+	assert.Equal(t, []string{"adir", "zdir", "alpha.txt"}, []string{
+		first[0].Name, first[1].Name, first[2].Name,
+	})
+
+	last, total, err := s.ChildrenPage(ctx, s.RootID(), 3, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 4, total)
+	require.Len(t, last, 1)
+	assert.Equal(t, "bravo.txt", last[0].Name)
+
+	empty, total, err := s.ChildrenPage(ctx, s.RootID(), 3, 4)
+	require.NoError(t, err)
+	assert.Equal(t, 4, total)
+	assert.Empty(t, empty)
+
+	_, _, err = s.ChildrenPage(ctx, first[2].ID, 3, 0)
+	require.ErrorIs(t, err, ErrNotDir)
+	_, _, err = s.ChildrenPage(ctx, 1<<62, 3, 0)
+	require.ErrorIs(t, err, ErrNotFound)
+	_, _, err = s.ChildrenPage(ctx, s.RootID(), 0, 0)
+	require.Error(t, err)
+	_, _, err = s.ChildrenPage(ctx, s.RootID(), 3, -1)
+	require.Error(t, err)
 }

--- a/pkg/docbank.go
+++ b/pkg/docbank.go
@@ -41,6 +41,13 @@ var (
 	ErrStaleRevision = store.ErrStaleRevision
 )
 
+const (
+	// DefaultChildrenLimit is the page size used when ChildrenOptions.Limit is zero.
+	DefaultChildrenLimit = 500
+	// MaxChildrenLimit is the largest child page one embedded call may materialize.
+	MaxChildrenLimit = 5000
+)
+
 // OpenOptions selects one private vault root and, optionally, its SQLite
 // implementation. Nil SQLite uses mattn/go-sqlite3 in CGO builds and
 // modernc.org/sqlite when CGO is disabled.
@@ -163,6 +170,32 @@ func (v *Vault) Stat(ctx context.Context, virtualPath string) (Node, error) {
 		return Node{}, err
 	}
 	return fromStoreNode(node), nil
+}
+
+// Children lists one bounded page of a directory's live children, directories
+// first and then files, name-sorted within each kind.
+func (v *Vault) Children(
+	ctx context.Context, directoryID int64, opts ChildrenOptions,
+) (ChildrenPage, error) {
+	if err := v.begin(); err != nil {
+		return ChildrenPage{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	limit := opts.Limit
+	if limit == 0 {
+		limit = DefaultChildrenLimit
+	}
+	children, total, err := v.metadata.ChildrenPage(ctx, directoryID, limit, opts.Offset)
+	if err != nil {
+		return ChildrenPage{}, err
+	}
+	page := ChildrenPage{
+		Items: make([]Node, 0, len(children)), Total: total, Limit: limit, Offset: opts.Offset,
+	}
+	for _, child := range children {
+		page.Items = append(page.Items, fromStoreNode(child))
+	}
+	return page, nil
 }
 
 // PutOptions controls one embedded content write. Expected is optional; when
@@ -325,6 +358,18 @@ func (v *Vault) OpenContent(ctx context.Context, virtualPath string) (*Content, 
 		Node:   fromStoreNode(node),
 		Reader: &leasedReader{VerifiedReadCloser: reader, release: v.lifecycle.RUnlock},
 	}, nil
+}
+
+// Pack explicitly moves authorized loose content into managed immutable packs.
+// It also performs the same reconciliation and repair pass as the standalone
+// storage pack operation. Ordinary Put calls remain loose until Pack is called.
+func (v *Vault) Pack(ctx context.Context, opts PackOptions) (PackReport, error) {
+	if err := v.begin(); err != nil {
+		return PackReport{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	stats, err := v.blobs.Maintainer().Pack(ctx, packstore.PackOptions{MaxBytes: opts.MaxBytes})
+	return fromPackStats(stats), err
 }
 
 func (v *Vault) begin() error {

--- a/pkg/docbank_test.go
+++ b/pkg/docbank_test.go
@@ -84,6 +84,137 @@ func TestPutMetadataFailureRemovesOnlyUnrecordedLooseBlob(t *testing.T) {
 	require.Equal(map[string]int64{kept.Computed.SHA256: kept.Computed.Size}, loose)
 }
 
+func TestChildrenReturnsBoundedStablePages(t *testing.T) {
+	require := require.New(t)
+	vault, err := Open(t.Context(), OpenOptions{Root: t.TempDir()})
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(vault.Close()) })
+
+	for path, content := range map[string]string{
+		"/manifests/zulu.json":         "zulu\n",
+		"/manifests/alpha.json":        "alpha\n",
+		"/manifests/nested/child.json": "nested\n",
+	} {
+		_, err := vault.Put(t.Context(), path, strings.NewReader(content), PutOptions{})
+		require.NoError(err)
+	}
+	dir, err := vault.Stat(t.Context(), "/manifests")
+	require.NoError(err)
+
+	first, err := vault.Children(t.Context(), dir.ID, ChildrenOptions{Limit: 2})
+	require.NoError(err)
+	require.Len(first.Items, 2)
+	require.Equal(3, first.Total)
+	require.Equal(2, first.Limit)
+	require.Zero(first.Offset)
+	require.Equal([]string{"nested", "alpha.json"}, nodeNames(first.Items))
+	require.Equal([]string{"dir", "file"}, []string{first.Items[0].Kind, first.Items[1].Kind})
+	require.Zero(first.Items[0].Size)
+	require.Equal(int64(6), first.Items[1].Size)
+	require.NotEmpty(first.Items[1].CurrentVersionID)
+	require.NotEmpty(first.Items[1].BlobHash)
+
+	second, err := vault.Children(t.Context(), dir.ID, ChildrenOptions{Limit: 2, Offset: 2})
+	require.NoError(err)
+	require.Equal(3, second.Total)
+	require.Equal(2, second.Limit)
+	require.Equal(2, second.Offset)
+	require.Equal([]string{"zulu.json"}, nodeNames(second.Items))
+
+	empty, err := vault.Children(t.Context(), dir.ID, ChildrenOptions{Limit: 2, Offset: 3})
+	require.NoError(err)
+	require.Empty(empty.Items)
+	require.Equal(3, empty.Total)
+	require.Equal(3, empty.Offset)
+
+	defaultPage, err := vault.Children(t.Context(), dir.ID, ChildrenOptions{})
+	require.NoError(err)
+	require.Equal(DefaultChildrenLimit, defaultPage.Limit)
+	require.Equal([]string{"nested", "alpha.json", "zulu.json"}, nodeNames(defaultPage.Items))
+
+	file, err := vault.Stat(t.Context(), "/manifests/alpha.json")
+	require.NoError(err)
+	_, err = vault.Children(t.Context(), file.ID, ChildrenOptions{})
+	require.ErrorIs(err, ErrNotDirectory)
+	_, err = vault.Children(t.Context(), 1<<62, ChildrenOptions{})
+	require.ErrorIs(err, ErrNotFound)
+	_, err = vault.Children(t.Context(), dir.ID, ChildrenOptions{Limit: MaxChildrenLimit + 1})
+	require.Error(err)
+	_, err = vault.Children(t.Context(), dir.ID, ChildrenOptions{Offset: -1})
+	require.Error(err)
+}
+
+func TestPackBoundsWorkAndPreservesVerifiedContent(t *testing.T) {
+	require := require.New(t)
+	vault, err := Open(t.Context(), OpenOptions{Root: t.TempDir()})
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(vault.Close()) })
+
+	contents := map[string]string{
+		"/sessions/one.jsonl": strings.Repeat("first session line\n", 512),
+		"/sessions/two.jsonl": strings.Repeat("second session line\n", 512),
+	}
+	for path, content := range contents {
+		_, err := vault.Put(t.Context(), path, strings.NewReader(content), PutOptions{})
+		require.NoError(err)
+	}
+
+	first, err := vault.Pack(t.Context(), PackOptions{MaxBytes: 1})
+	require.NoError(err)
+	require.Equal(1, first.PacksSealed)
+	require.Equal(1, first.BlobsPacked)
+	require.True(first.BudgetExhausted)
+
+	second, err := vault.Pack(t.Context(), PackOptions{})
+	require.NoError(err)
+	require.Equal(1, second.PacksSealed)
+	require.Equal(1, second.BlobsPacked)
+	require.False(second.BudgetExhausted)
+	loose, err := vault.blobs.List()
+	require.NoError(err)
+	require.Empty(loose)
+
+	idle, err := vault.Pack(t.Context(), PackOptions{})
+	require.NoError(err)
+	require.Zero(idle.PacksSealed)
+	require.Zero(idle.BlobsPacked)
+
+	for path, want := range contents {
+		content, err := vault.OpenContent(t.Context(), path)
+		require.NoError(err)
+		got, err := io.ReadAll(content.Reader)
+		require.NoError(err)
+		require.NoError(content.Reader.Verify())
+		require.NoError(content.Reader.Close())
+		require.Equal(want, string(got))
+	}
+
+	_, err = vault.Pack(t.Context(), PackOptions{MaxBytes: -1})
+	require.Error(err)
+}
+
+func TestChildrenAndPackRejectClosedVault(t *testing.T) {
+	require := require.New(t)
+	vault, err := Open(t.Context(), OpenOptions{Root: t.TempDir()})
+	require.NoError(err)
+	root, err := vault.Stat(t.Context(), "/")
+	require.NoError(err)
+	require.NoError(vault.Close())
+
+	_, err = vault.Children(t.Context(), root.ID, ChildrenOptions{})
+	require.ErrorIs(err, ErrClosed)
+	_, err = vault.Pack(t.Context(), PackOptions{})
+	require.ErrorIs(err, ErrClosed)
+}
+
+func nodeNames(nodes []Node) []string {
+	names := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		names = append(names, node.Name)
+	}
+	return names
+}
+
 func TestEmbeddedVaultLifecycle(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -3,6 +3,8 @@ package docbank
 import (
 	"io"
 
+	"go.kenn.io/kit/packstore"
+
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -51,6 +53,49 @@ type PutReceipt struct {
 	Replaced bool            `json:"replaced"`
 }
 
+// ChildrenOptions selects one bounded page of a directory's live children.
+// A zero Limit uses DefaultChildrenLimit. Offset must not be negative.
+type ChildrenOptions struct {
+	Limit  int
+	Offset int
+}
+
+// ChildrenPage is one bounded dirs-first, name-sorted child listing.
+type ChildrenPage struct {
+	Items  []Node `json:"items"`
+	Total  int    `json:"total"`
+	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
+}
+
+// PackOptions bounds one explicit embedded packing pass. MaxBytes is a soft
+// committed raw-byte budget; zero is unlimited and negative values are
+// rejected.
+type PackOptions struct {
+	MaxBytes int64
+}
+
+// PackReport summarizes one explicit packing and repair pass.
+type PackReport struct {
+	PacksSealed                int   `json:"packs_sealed"`
+	BlobsPacked                int   `json:"blobs_packed"`
+	BytesPacked                int64 `json:"bytes_packed"`
+	PacksAdopted               int   `json:"packs_adopted"`
+	PacksRemoved               int   `json:"packs_removed"`
+	PacksQuarantined           int   `json:"packs_quarantined"`
+	PacksUnreadable            int   `json:"packs_unreadable"`
+	RecordsDropped             int   `json:"records_dropped"`
+	MappingsPruned             int64 `json:"mappings_pruned"`
+	BlobsMissing               int   `json:"blobs_missing"`
+	BlobsCorrupt               int   `json:"blobs_corrupt"`
+	BlobsDeferredOversized     int   `json:"blobs_deferred_oversized"`
+	PacksDeferredOversized     int   `json:"packs_deferred_oversized"`
+	LooseSwept                 int   `json:"loose_swept"`
+	LooseOrphansRemoved        int   `json:"loose_orphans_removed"`
+	LooseOrphanSweepSuppressed bool  `json:"loose_orphan_sweep_suppressed"`
+	BudgetExhausted            bool  `json:"budget_exhausted"`
+}
+
 // VerifiedReadCloser is a bounded-memory content reader. A caller must reach
 // terminal io.EOF or call Verify successfully before treating bytes as valid;
 // an early Close reports incomplete verification and never drains implicitly.
@@ -81,5 +126,20 @@ func fromStoreVersion(version store.ContentVersion) ContentVersion {
 		NodeRevision:          version.NodeRevision,
 		IntroducedOperationID: version.IntroducedOperationID,
 		TransitionKind:        version.TransitionKind, SourceVersionID: version.SourceVersionID,
+	}
+}
+
+func fromPackStats(stats packstore.PackStats) PackReport {
+	return PackReport{
+		PacksSealed: stats.PacksSealed, BlobsPacked: stats.BlobsPacked,
+		BytesPacked: stats.BytesPacked, PacksAdopted: stats.PacksAdopted,
+		PacksRemoved: stats.PacksRemoved, PacksQuarantined: stats.PacksQuarantined,
+		PacksUnreadable: stats.PacksUnreadable, RecordsDropped: stats.RecordsDropped,
+		MappingsPruned: stats.MappingsPruned, BlobsMissing: stats.BlobsMissing,
+		BlobsCorrupt: stats.BlobsCorrupt, BlobsDeferredOversized: stats.BlobsDeferredOversized,
+		PacksDeferredOversized: stats.PacksDeferredOversized, LooseSwept: stats.LooseSwept,
+		LooseOrphansRemoved:        stats.LooseOrphansRemoved,
+		LooseOrphanSweepSuppressed: stats.LooseOrphanSweepSuppressed,
+		BudgetExhausted:            stats.BudgetExhausted,
 	}
 }


### PR DESCRIPTION
Embedded applications can own a vault and put or read verified content, but
they cannot currently move loose content into managed packs or enumerate a
large directory through the public package. That leaves consumers reaching
through internal boundaries or retaining an unnecessary daemon integration.

This adds `Vault.Pack` with the same optional soft byte budget and complete
maintenance report as the daemon operation. It also adds paginated
`Vault.Children` and moves the existing HTTP children route onto the same
bounded SQL query, so neither ownership mode materializes a whole directory
before slicing it.

Ordinary puts remain loose until an owner explicitly schedules packing.
Standalone CLI commands remain daemon-first, while embedded applications enter
the same catalog-authorized Kit maintenance coordinator. Offset pages preserve
the existing dirs-first, name-sorted contract; callers that need a stable
multi-page traversal must avoid concurrent tree mutations between calls.
