### PR TITLE
Add explicit version pruning

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -228,6 +228,8 @@ func TestVersionsPruneIsPreviewFirstAndKeepsCurrentContent(t *testing.T) {
 		"--version", before.Items[1].ID+","+before.Items[2].ID)
 	require.ErrorContains(t, err, "canonical UUIDv4",
 		"repeatable --version values must treat commas literally")
+	_, err = runCLI(t, "versions", "prune", "/inbox/document.txt", "--keep-newest", "0")
+	require.ErrorContains(t, err, "--keep-newest must be at least 1")
 
 	out, err = runCLI(t, "versions", "prune", "/inbox/document.txt", "--keep-newest", "1")
 	require.NoError(t, err, out)
@@ -250,6 +252,9 @@ func TestVersionsPruneIsPreviewFirstAndKeepsCurrentContent(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(out), &afterRun))
 	require.Len(t, afterRun.Items, 1)
 	assert.Equal(t, before.Items[0].ID, afterRun.Items[0].ID)
+	out, err = runCLI(t, "versions", "prune", "/inbox/document.txt", "--all-prior", "--run")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "pruned 0 version(s); nothing to do")
 	out, err = runCLI(t, "cat", "/inbox/document.txt")
 	require.NoError(t, err)
 	assert.Equal(t, "current content", out)

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -206,6 +206,55 @@ func TestPutReplacesContentAndRetainsHistory(t *testing.T) {
 	assert.Contains(t, out, "Source version:  "+initialVersion)
 }
 
+func TestVersionsPruneIsPreviewFirstAndKeepsCurrentContent(t *testing.T) {
+	_ = setupVaultHome(t)
+	initial := writeSourceFile(t, "document.txt", "initial content")
+	_, err := runCLI(t, "add", initial, "--dest", "/inbox")
+	require.NoError(t, err)
+
+	second := writeSourceFile(t, "second.txt", "second content")
+	_, err = runCLI(t, "put", second, "/inbox/document.txt", "--progress", "plain")
+	require.NoError(t, err)
+	third := writeSourceFile(t, "third.txt", "current content")
+	_, err = runCLI(t, "put", third, "/inbox/document.txt", "--progress", "plain")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "versions", "/inbox/document.txt", "--json")
+	require.NoError(t, err)
+	var before api.ContentVersionPage
+	require.NoError(t, json.Unmarshal([]byte(out), &before))
+	require.Len(t, before.Items, 3)
+	_, err = runCLI(t, "versions", "prune", "/inbox/document.txt",
+		"--version", before.Items[1].ID+","+before.Items[2].ID)
+	require.ErrorContains(t, err, "canonical UUIDv4",
+		"repeatable --version values must treat commas literally")
+
+	out, err = runCLI(t, "versions", "prune", "/inbox/document.txt", "--keep-newest", "1")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "2 version(s) selected")
+	assert.Contains(t, out, "dry run")
+	assert.Contains(t, out, "pending gc")
+	out, err = runCLI(t, "versions", "/inbox/document.txt", "--json")
+	require.NoError(t, err)
+	var afterPreview api.ContentVersionPage
+	require.NoError(t, json.Unmarshal([]byte(out), &afterPreview))
+	assert.Equal(t, 3, afterPreview.Total, "preview must retain history")
+
+	out, err = runCLI(t, "versions", "prune", "/inbox/document.txt",
+		"--keep-newest", "1", "--run")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "pruned 2 version(s)")
+	out, err = runCLI(t, "versions", "/inbox/document.txt", "--json")
+	require.NoError(t, err)
+	var afterRun api.ContentVersionPage
+	require.NoError(t, json.Unmarshal([]byte(out), &afterRun))
+	require.Len(t, afterRun.Items, 1)
+	assert.Equal(t, before.Items[0].ID, afterRun.Items[0].ID)
+	out, err = runCLI(t, "cat", "/inbox/document.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "current content", out)
+}
+
 func TestTagCLIOrganizesNodesByNameOrStableID(t *testing.T) {
 	_ = setupVaultHome(t)
 	source := writeSourceFile(t, "return.pdf", "tax return")

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -157,7 +157,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "16", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "17", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "16", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "17", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -292,6 +292,21 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	tagPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, revertPID, tagPID)
 
+	// Protocol 16 predates explicit version pruning. Replace it before a dry
+	// run reaches a same-version daemon that would return 404 instead of a
+	// trustworthy history inventory.
+	recs[0].Metadata["protocol_version"] = "16"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "versions", "prune", "/inbox/preflight.txt", "--all-prior", "--json")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, `"checkpoint_required":true`)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	prunePID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, tagPID, prunePID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -306,7 +321,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "16", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "17", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -319,7 +334,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, tagPID, protocolPID)
+	assert.NotEqual(t, prunePID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/cmd/docbank/versions.go
+++ b/cmd/docbank/versions.go
@@ -138,7 +138,10 @@ var versionsPruneCmd = &cobra.Command{
 			VersionIDs: pruneVersionIDs, KeepNewest: pruneKeepNewest,
 			OlderThan: pruneOlderThan, AllPrior: pruneAllPrior, Run: pruneRun,
 		}
-		if err := validatePruneFlags(request); err != nil {
+		if cmd.Flags().Changed("keep-newest") && pruneKeepNewest < 1 {
+			return errors.New("--keep-newest must be at least 1")
+		}
+		if _, err := api.ParseVersionPruneRequest(request); err != nil {
 			return err
 		}
 		c, err := client.Ensure(cmd.Context())
@@ -163,40 +166,13 @@ var versionsPruneCmd = &cobra.Command{
 	},
 }
 
-func validatePruneFlags(request api.VersionPruneRequest) error {
-	if request.KeepNewest < 0 {
-		return errors.New("--keep-newest must be positive")
-	}
-	modes := 0
-	if len(request.VersionIDs) > 0 {
-		modes++
-	}
-	if request.KeepNewest > 0 {
-		modes++
-	}
-	if request.OlderThan != "" {
-		modes++
-		age, err := api.ParseAge(request.OlderThan)
-		if err != nil {
-			return err
-		}
-		if age == 0 {
-			return errors.New("--older-than must be greater than zero")
-		}
-	}
-	if request.AllPrior {
-		modes++
-	}
-	if modes != 1 {
-		return errors.New("choose exactly one of --version, --keep-newest, --older-than, or --all-prior")
-	}
-	return nil
-}
-
 func writeVersionPruneReport(cmd *cobra.Command, report api.VersionPruneReport) {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 		"%d version(s) selected, %d logical byte(s), %d unique blob(s)\n",
 		len(report.Candidates), report.LogicalBytes, report.UniqueBlobs)
+	if report.Cutoff != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "age cutoff: %s\n", report.Cutoff)
+	}
 	if len(report.DependencyRetained) > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 			"retained %d selected source version(s) required by remaining reverts\n",
@@ -228,7 +204,9 @@ func writeVersionPruneReport(cmd *cobra.Command, report api.VersionPruneReport) 
 	if report.Changed {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pruned %d version(s); node revision is now %d\n",
 			report.DeletedVersions, report.Node.Revision)
+		return
 	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "pruned 0 version(s); nothing to do")
 }
 
 func writeVersionJSON(w io.Writer, value any) error {

--- a/cmd/docbank/versions.go
+++ b/cmd/docbank/versions.go
@@ -9,17 +9,24 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
 )
 
 const maxVersionsLimit = 1000
 
 var (
-	versionsLimit  int
-	versionsOffset int
-	versionsJSON   bool
-	versionJSON    bool
-	versionContent bool
+	versionsLimit   int
+	versionsOffset  int
+	versionsJSON    bool
+	versionJSON     bool
+	versionContent  bool
+	pruneVersionIDs []string
+	pruneKeepNewest int
+	pruneOlderThan  string
+	pruneAllPrior   bool
+	pruneRun        bool
+	pruneJSON       bool
 )
 
 var versionsCmd = &cobra.Command{
@@ -119,6 +126,111 @@ var versionCmd = &cobra.Command{
 	},
 }
 
+var versionsPruneCmd = &cobra.Command{
+	Use:   "prune <path>",
+	Short: "Preview or release selected version history",
+	Long: "Release selected immutable history while retaining the current content. " +
+		"This changes logical reachability only: run gc for loose bytes and storage repack " +
+		"for dead packed space. The default is a dry run.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		request := api.VersionPruneRequest{
+			VersionIDs: pruneVersionIDs, KeepNewest: pruneKeepNewest,
+			OlderThan: pruneOlderThan, AllPrior: pruneAllPrior, Run: pruneRun,
+		}
+		if err := validatePruneFlags(request); err != nil {
+			return err
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		node, err := c.Stat(cmd.Context(), args[0])
+		if err != nil {
+			return fmt.Errorf("resolving %q: %w", args[0], err)
+		}
+		report, err := c.PruneContentVersions(
+			cmd.Context(), node.ID, node.Revision, request,
+		)
+		if err != nil {
+			return fmt.Errorf("pruning versions of %q: %w", args[0], err)
+		}
+		if pruneJSON {
+			return writeVersionJSON(cmd.OutOrStdout(), report)
+		}
+		writeVersionPruneReport(cmd, report)
+		return nil
+	},
+}
+
+func validatePruneFlags(request api.VersionPruneRequest) error {
+	if request.KeepNewest < 0 {
+		return errors.New("--keep-newest must be positive")
+	}
+	modes := 0
+	if len(request.VersionIDs) > 0 {
+		modes++
+	}
+	if request.KeepNewest > 0 {
+		modes++
+	}
+	if request.OlderThan != "" {
+		modes++
+		age, err := api.ParseAge(request.OlderThan)
+		if err != nil {
+			return err
+		}
+		if age == 0 {
+			return errors.New("--older-than must be greater than zero")
+		}
+	}
+	if request.AllPrior {
+		modes++
+	}
+	if modes != 1 {
+		return errors.New("choose exactly one of --version, --keep-newest, --older-than, or --all-prior")
+	}
+	return nil
+}
+
+func writeVersionPruneReport(cmd *cobra.Command, report api.VersionPruneReport) {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"%d version(s) selected, %d logical byte(s), %d unique blob(s)\n",
+		len(report.Candidates), report.LogicalBytes, report.UniqueBlobs)
+	if len(report.DependencyRetained) > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"retained %d selected source version(s) required by remaining reverts\n",
+			len(report.DependencyRetained))
+	}
+	if report.CheckpointRequired {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(),
+			"the current revert will be replaced by a same-byte checkpoint before pruning")
+	}
+	if report.ReleasableBlobs > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"%d blob(s), %d byte(s) become eligible for later physical maintenance\n",
+			report.ReleasableBlobs, report.ReleasableBytes)
+	}
+	if report.LooseBlobsPendingGC > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d loose blob(s), %d byte(s) pending gc\n",
+			report.LooseBlobsPendingGC, report.LooseBytesPendingGC)
+	}
+	if report.PackedBlobsPendingRepack > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d packed blob(s), %d stored byte(s) pending gc then repack\n",
+			report.PackedBlobsPendingRepack, report.PackedBytesPendingRepack)
+	}
+	if !report.Run {
+		if len(report.Candidates) > 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "dry run — pass --run to prune")
+		}
+		return
+	}
+	if report.Changed {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pruned %d version(s); node revision is now %d\n",
+			report.DeletedVersions, report.Node.Revision)
+	}
+}
+
 func writeVersionJSON(w io.Writer, value any) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
@@ -134,5 +246,17 @@ func init() {
 	versionsCmd.Flags().BoolVar(&versionsJSON, "json", false, "emit machine-readable JSON")
 	versionCmd.Flags().BoolVar(&versionJSON, "json", false, "emit machine-readable JSON")
 	versionCmd.Flags().BoolVar(&versionContent, "content", false, "write this version's bytes to stdout")
+	versionsPruneCmd.Flags().StringArrayVar(&pruneVersionIDs, "version", nil,
+		"select one version UUID (repeatable; commas are literal)")
+	versionsPruneCmd.Flags().IntVar(&pruneKeepNewest, "keep-newest", 0,
+		"retain at least this many newest versions")
+	versionsPruneCmd.Flags().StringVar(&pruneOlderThan, "older-than", "",
+		"select versions at least this old (e.g. 90d or 12h)")
+	versionsPruneCmd.Flags().BoolVar(&pruneAllPrior, "all-prior", false,
+		"remove the complete prior history while retaining current content")
+	versionsPruneCmd.Flags().BoolVar(&pruneRun, "run", false,
+		"actually prune (default is dry-run)")
+	versionsPruneCmd.Flags().BoolVar(&pruneJSON, "json", false, "emit a machine-readable report")
+	versionsCmd.AddCommand(versionsPruneCmd)
 	rootCmd.AddCommand(versionsCmd, versionCmd)
 }

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -364,6 +364,14 @@ loose/packed maintenance consequences, repeat with `"run":true` and the same
 inspected revision. Do not blindly replace a stale `If-Match`: re-read the node
 and re-evaluate the selection.
 
+`older_than` is evaluated against the `cutoff` returned by each request. Time
+can move versions across that boundary without changing the node ETag, so a
+later age-based run can contain additional candidates. If execution must match
+the preview exactly, send its candidate IDs through `version_ids` instead of
+repeating the age selector. Explicit-ID requests accept at most 1,000 IDs; for
+larger sets, execute batches and inspect the advanced node revision before
+sending each next batch.
+
 For a dry run, require the response node and ETag to match the inspected node
 and revision, `changed:false`, `deleted_versions:0`, and no checkpoint. For an
 executed change, require `deleted_versions` to equal the candidate count,

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -345,6 +345,35 @@ so it has no computed digest receipt; it relies on already-authoritative source
 bytes and does not copy them. Use the ordinary content verification surface when
 a fresh physical proof is part of the workflow.
 
+Version retention is unlimited by default. To release unwanted non-current
+history, preview exactly one selector through the authenticated pruning route:
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'If-Match: "9"' \
+  -H 'Content-Type: application/json' \
+  --data '{"keep_newest":3}' \
+  "$DOCBANK_URL/api/v1/nodes/42/versions/prune"
+```
+
+The other request selectors are `version_ids`, `older_than`, and `all_prior`;
+exactly one is allowed. Omitted or false `run` is a dry run. After evaluating
+the returned candidate IDs, logical bytes, retained revert dependencies, and
+loose/packed maintenance consequences, repeat with `"run":true` and the same
+inspected revision. Do not blindly replace a stale `If-Match`: re-read the node
+and re-evaluate the selection.
+
+For a dry run, require the response node and ETag to match the inspected node
+and revision, `changed:false`, `deleted_versions:0`, and no checkpoint. For an
+executed change, require `deleted_versions` to equal the candidate count,
+`changed:true`, and exactly one revision advance. When
+`checkpoint_required:true`, execution must return a source-free
+`content_replace` checkpoint installed as the current version. Blob counts must
+partition into shared versus releasable, and releasable into loose pending GC
+versus packed pending repack. These are future maintenance candidates, not
+bytes reclaimed by pruning.
+
 Path mutations are intentionally different. `POST /api/v1/path/move` and
 `POST /api/v1/path/trash` resolve and mutate inside one store transaction, so
 they do not accept `If-Match`. Use them for a one-shot instruction tied to the

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -52,8 +52,8 @@ node/version pair that retains it, including prior versions and trash.
 The HTTP equivalents are:
 
 - `GET /api/v1/nodes/{id}/versions?limit=&offset=`;
-- `GET /api/v1/versions/{version_id}`; and
-- `GET /api/v1/versions/{version_id}/content`; and
+- `GET /api/v1/versions/{version_id}`;
+- `GET /api/v1/versions/{version_id}/content`;
 - `GET /api/v1/content-references?sha256=&limit=&offset=`.
 
 Current-node and ID-addressed version streams both send
@@ -64,16 +64,20 @@ compare the trailer before publishing them.
 
 ## Retention and backup
 
-Every content-version row is a GC reachability root, whether or not it is the
-current head. Deleting a file's tree metadata through trash empty removes its
-versions; only then can unreferenced blobs become GC candidates. Repack may
-change physical placement but not version identity.
+Every retained content-version row is a GC reachability root, whether or not it
+is the current head. Explicit version pruning or deletion of a file's tree
+metadata through trash empty can release those references; only then can an
+unreferenced blob become a GC candidate. Repack may change physical placement
+but not version identity.
 
 Deterministic metadata JSONL includes every version and every node's current
 pointer. Backup capture, verification, and restore therefore preserve stable
 version IDs across loose or packed physical representations. Import rejects
 dangling current pointers, cross-node pointers, size disagreement, invalid UUIDs,
-and malformed JSON records transactionally.
+and malformed JSON records transactionally. A backup captured after pruning
+preserves the retained graph and does not resurrect deleted version rows.
+Earlier snapshots remain independent historical records and can still restore
+the state they captured.
 
 ## Replacing content
 
@@ -158,13 +162,35 @@ Its receipt returns the resulting node, the new reversion row, the complete
 source version, and the resulting ETag. Clients accept success only when all
 node, revision, source, and content-authority fields agree.
 
-## Current retention behavior
+## Choosing retention
 
-`put`, changed `edit` sessions, and `revert` retain every prior content version.
-Docbank currently has no version-pruning command or automatic retention policy,
-so recorded versions remain reachability roots. The planned
-[full-audit contract](audited-history.md) defines a stronger permanent-retention
-mode separately from this current behavior.
+`put`, changed `edit` sessions, and `revert` retain every prior content version
+by default. Docbank does not choose an age or history limit for the operator.
+When a file's old versions are no longer wanted, pruning is explicit and
+preview-first:
+
+```bash
+docbank versions prune /taxes/2025/return.pdf --keep-newest 3
+docbank versions prune /taxes/2025/return.pdf --older-than 365d
+docbank versions prune /taxes/2025/return.pdf --version <version-id>
+docbank versions prune /taxes/2025/return.pdf --all-prior
+```
+
+Exactly one selector is accepted. Nothing changes without `--run`, and an
+executed selection is bound to the node ID and revision inspected by the
+client. The current content is always retained. Ordinary selectors never
+select the current row and also retain any source version still required by a
+remaining `content_revert` record, reporting that dependency rather than
+producing a dangling history graph. `--all-prior` can release the complete
+older graph; when the current head is itself a revert, the transaction first
+installs a same-byte, source-free `content_replace` checkpoint and then removes
+the old graph, including the superseded revert head.
+
+Pruning deletes version authority, not bytes. Its report distinguishes logical
+bytes, shared blobs that remain reachable, loose blobs that become eligible for
+`gc`, and packed payload that needs `gc` followed by `storage repack`. A run
+that deletes versions advances the node revision exactly once; an empty
+selection is a no-op. There is no automatic retention policy.
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -176,15 +176,24 @@ docbank versions prune /taxes/2025/return.pdf --version <version-id>
 docbank versions prune /taxes/2025/return.pdf --all-prior
 ```
 
-Exactly one selector is accepted. Nothing changes without `--run`, and an
-executed selection is bound to the node ID and revision inspected by the
-client. The current content is always retained. Ordinary selectors never
-select the current row and also retain any source version still required by a
-remaining `content_revert` record, reporting that dependency rather than
-producing a dangling history graph. `--all-prior` can release the complete
-older graph; when the current head is itself a revert, the transaction first
-installs a same-byte, source-free `content_replace` checkpoint and then removes
-the old graph, including the superseded revert head.
+Exactly one selector is accepted. Nothing changes without `--run`, and every
+request is bound to the node ID and revision inspected by the client. The
+current content is always retained. Ordinary selectors never select the
+current row and also retain any source version still required by a remaining
+`content_revert` record, reporting that dependency rather than producing a
+dangling history graph. `--all-prior` can release the complete older graph;
+when the current head is itself a revert, the transaction first installs a
+same-byte, source-free `content_replace` checkpoint and then removes the old
+graph, including the superseded revert head.
+
+An age selection is evaluated against the wall-clock cutoff reported in that
+request. Time can advance without changing a node revision, so a later
+`--older-than ... --run` request may include additional versions that crossed
+the boundary after the preview. This never selects a version younger than the
+requested age. When exact replay of a preview matters, execute its returned
+candidate IDs with repeated `--version` selectors instead. Explicit-ID requests
+are bounded to 1,000 IDs; larger selections can be applied in batches, reading
+the advanced node revision before each subsequent batch.
 
 Pruning deletes version authority, not bytes. Its report distinguishes logical
 bytes, shared blobs that remain reachable, loose blobs that become eligible for

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -296,7 +296,8 @@ version; an omitted value becomes `application/octet-stream`.
 The daemon streams the body into durable authority-free storage and computes
 the identity independently. Only exact agreement permits one metadata
 transaction to create a `content_replace` version, advance the node's current
-pointer, and bump its revision. The old head remains an immutable GC root. A
+pointer, and bump its revision. The old head remains an immutable history and
+GC root until the operator explicitly prunes that version. A
 successful response includes the resulting ETag plus a receipt containing the
 node, new version, `computed_hash`, and `computed_size`; clients compare every
 field with the request before accepting success.
@@ -325,7 +326,8 @@ and media type into it, records `source_version_id`, advances the current
 pointer, and bumps the node revision.
 
 This operation is metadata-only: it neither streams nor copies the source blob,
-whether loose or packed. Every existing version remains a reachability root.
+whether loose or packed. Every existing version remains a reachability root
+until explicitly selected by version pruning.
 The receipt contains `node`, the new `version`, and `source_version`, while the
 ETag carries the resulting revision. Clients cross-check all four authorities;
 HTTP 200 alone is not sufficient evidence.
@@ -333,6 +335,33 @@ HTTP 200 alone is not sufficient evidence.
 A stale target returns `412 stale_revision`. A source from another node returns
 `422 version_node_mismatch`, selecting the current head returns
 `422 version_already_current`, and an unknown source returns `404 not_found`.
+
+## Addendum: `POST /nodes/{id}/versions/prune`
+
+Version pruning releases selected non-current history without changing current
+content. Every request requires the inspected node revision in `If-Match` and
+chooses exactly one selector: `version_ids` (at most 1,000 canonical UUIDs),
+`keep_newest`, `older_than`, or `all_prior`. The default is a dry run;
+`"run":true` performs the reported class of operation under the same node
+revision precondition.
+
+Ordinary selectors retain revert-source dependencies and report them
+separately. `all_prior` may first install a same-byte, source-free checkpoint
+when the current head is a revert, allowing the complete older graph to be
+removed safely. A successful run advances the node revision once when it
+deletes history and does not advance it for an empty selection. Deleted version
+IDs stop resolving.
+
+An `older_than` selector computes and returns its cutoff for each request. The
+node ETag protects content-graph changes, but wall-clock aging does not advance
+the revision; a later run can therefore include versions that crossed the age
+boundary after a preview. Callers needing an exact replay execute the preview's
+candidate IDs through `version_ids`.
+
+The receipt separates logical history bytes from physical consequences. Shared
+blobs remain reachable, authority-free loose blobs await GC, and dead packed
+payload awaits GC followed by repack. Pruning itself does not claim physical
+space reclamation.
 
 ## Addendum: tags
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -208,6 +208,13 @@ previous graph, including that superseded revert row, can be released safely.
 Execution uses the node ID and revision inspected immediately beforehand; a
 concurrent change fails with `stale_revision`.
 
+Age previews report their evaluated cutoff. Wall-clock aging does not advance a
+node revision, so a later `--older-than ... --run` can also select versions that
+crossed the same age boundary after the preview. To execute the exact previewed
+set, pass its candidate IDs back through repeated `--version` flags.
+Explicit-ID requests accept at most 1,000 IDs; re-read the node revision between
+batches when applying a larger exact set.
+
 Human and JSON reports separate selected versions and logical bytes from
 physical consequences: shared blobs remain reachable, loose unreferenced blobs
 wait for `docbank gc --run`, and dead packed payload waits for GC followed by

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -185,6 +185,36 @@ Every newly imported file has one revision-one `content_create` version. Each
 successful `put` adds a `content_replace` row and each `revert` adds a
 `content_revert` row naming its immutable source.
 
+### docbank versions prune
+
+```text
+docbank versions prune <path> --version <version-id> [--version <version-id>...] [--run] [--json]
+docbank versions prune <path> --keep-newest <n> [--run] [--json]
+docbank versions prune <path> --older-than <age> [--run] [--json]
+docbank versions prune <path> --all-prior [--run] [--json]
+```
+
+Selects unwanted non-current history for one file. Exactly one selector is
+required. `--version` is repeatable and literal, `--keep-newest` retains at
+least that many newest rows including the current head, `--older-than` accepts
+Go durations plus whole days such as `90d`, and `--all-prior` selects the
+complete old graph. The command is a dry run unless `--run` is present.
+
+The current content is always retained. Ordinary selectors cannot select the
+current row. If one includes a source still required by a retained reversion,
+the report identifies and retains that source. `--all-prior` can replace a
+current reversion with a same-byte source-free checkpoint so the complete
+previous graph, including that superseded revert row, can be released safely.
+Execution uses the node ID and revision inspected immediately beforehand; a
+concurrent change fails with `stale_revision`.
+
+Human and JSON reports separate selected versions and logical bytes from
+physical consequences: shared blobs remain reachable, loose unreferenced blobs
+wait for `docbank gc --run`, and dead packed payload waits for GC followed by
+`docbank storage repack`. Pruning itself never claims to reclaim disk space.
+Deleted version IDs stop resolving. Backups made afterward preserve that
+result, while snapshots made before pruning still contain their earlier state.
+
 ## docbank version
 
 ```text

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,7 +94,10 @@ identity only after both match. `docbank put`, `docbank edit`, and raw
 an optimistic revision precondition while retaining every prior version.
 `docbank revert` and `POST /nodes/{id}/revert` add a metadata-only
 `content_revert` head from one prior version without copying its loose or packed
-blob. `docbank refs` and `GET /content-references` resolve a SHA-256 identity to
+blob. `docbank versions prune` and `POST /nodes/{id}/versions/prune` provide
+preview-first individual, age, count, and complete-prior-history selection,
+with revert dependency handling and honest GC/repack consequences. `docbank
+refs` and `GET /content-references` resolve a SHA-256 identity to
 every retaining current, historical, or trashed node/version pair. Stable tags
 are available across the CLI, authenticated API, typed client, OpenAPI, and
 metadata-v1 backup/restore authority, including bounded forward and reverse

--- a/docs/usage/trash-and-gc.md
+++ b/docs/usage/trash-and-gc.md
@@ -70,8 +70,9 @@ Unreachable blob authority is removed only by explicit GC. A blob is
 
 - a live node,
 - a trashed node (trash is always restorable in full), or
-- a recorded prior version of an edited document
-  (see [Editing & Versions](../architecture/editing-and-versions.md)).
+- a retained prior version of an edited document. Explicit, preview-first
+  [version pruning](../architecture/editing-and-versions.md#choosing-retention)
+  can release that reference without deleting the current file.
 
 ```bash
 docbank gc          # dry run: candidate count and reclaimable bytes

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -72,6 +72,7 @@ var storeErrCodes = []struct {
 	{store.ErrIsRoot, http.StatusUnprocessableEntity, "is_root"},
 	{store.ErrVersionNodeMismatch, http.StatusUnprocessableEntity, "version_node_mismatch"},
 	{store.ErrVersionAlreadyCurrent, http.StatusUnprocessableEntity, "version_already_current"},
+	{store.ErrInvalidVersionPrune, http.StatusUnprocessableEntity, "invalid_version_prune"},
 }
 
 // FromStoreError maps the store's typed errors onto the wire envelope; an

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -81,6 +81,19 @@ func TestOpenAPIDeclaresDigestCheckedUpload(t *testing.T) {
 
 func TestOpenAPIDeclaresMutationPreconditions(t *testing.T) {
 	doc := api.NewOfflineServer().API().OpenAPI()
+	pruneRequest := doc.Components.Schemas.Map()["VersionPruneRequest"]
+	require.NotNil(t, pruneRequest)
+	versionIDs := pruneRequest.Properties["version_ids"]
+	require.NotNil(t, versionIDs)
+	require.NotNil(t, versionIDs.MaxItems)
+	assert.Equal(t, 1000, *versionIDs.MaxItems)
+	assert.True(t, versionIDs.UniqueItems)
+	require.NotNil(t, versionIDs.Items)
+	assert.Equal(t, "uuid", versionIDs.Items.Format)
+	keepNewest := pruneRequest.Properties["keep_newest"]
+	require.NotNil(t, keepNewest)
+	require.NotNil(t, keepNewest.Minimum)
+	assert.InDelta(t, 1, *keepNewest.Minimum, 0)
 	for _, operation := range []*huma.Operation{
 		doc.Paths["/api/v1/nodes/{id}"].Patch,
 		doc.Paths["/api/v1/nodes/{id}/trash"].Post,

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -16,7 +16,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	require.NoError(t, err)
 	doc := string(out)
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent", "verifyNodeContent",
-		"listContentVersions", "getContentVersion", "getContentVersionBytes",
+		"listContentVersions", "getContentVersion", "getContentVersionBytes", "pruneNodeContentVersions",
 		"lookupContentReferences",
 		"listTags", "resolveTagByName", "getTag", "listTagNodes", "listNodeTags",
 		"createTag", "renameTag", "deleteTag", "assignTag", "unassignTag",
@@ -87,6 +87,7 @@ func TestOpenAPIDeclaresMutationPreconditions(t *testing.T) {
 		doc.Paths["/api/v1/nodes/{id}/restore"].Post,
 		doc.Paths["/api/v1/nodes/{id}/verify"].Post,
 		doc.Paths["/api/v1/nodes/{id}/revert"].Post,
+		doc.Paths["/api/v1/nodes/{id}/versions/prune"].Post,
 		doc.Paths["/api/v1/nodes/{id}/tags/{tag_id}"].Put,
 		doc.Paths["/api/v1/nodes/{id}/tags/{tag_id}"].Delete,
 		doc.Paths["/api/v1/tags/{tag_id}"].Patch,

--- a/internal/api/routes_content_prune.go
+++ b/internal/api/routes_content_prune.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+func registerContentPruneRoute(api huma.API, d Deps, g *gate) {
+	type pruneOutput struct {
+		ETag string `header:"ETag"`
+		Body VersionPruneReport
+	}
+	huma.Register(api, huma.Operation{
+		OperationID: "pruneNodeContentVersions", Method: http.MethodPost,
+		Path:    "/api/v1/nodes/{id}/versions/prune",
+		Summary: "Preview or prune selected non-current content versions",
+		Description: "Dry-run by default. Execution requires If-Match and releases only logical " +
+			"history authority; GC and repack remain separate physical maintenance operations.",
+	}, func(ctx context.Context, in *struct {
+		ID      int64  `path:"id"`
+		IfMatch string `header:"If-Match"`
+		Body    VersionPruneRequest
+	}) (*pruneOutput, error) {
+		revision, err := parseIfMatch(in.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+		age, err := ParseAge(in.Body.OlderThan)
+		if err != nil {
+			return nil, NewError(http.StatusUnprocessableEntity, "invalid_version_prune", err.Error())
+		}
+		selector := store.VersionPruneSelector{
+			VersionIDs: in.Body.VersionIDs, KeepNewest: in.Body.KeepNewest,
+			OlderThan: age, AllPrior: in.Body.AllPrior,
+		}
+		var report VersionPruneReport
+		err = g.mutate(func() error {
+			result, pruneErr := d.Store.PruneContentVersions(
+				ctx, in.ID, revision, selector, in.Body.Run,
+			)
+			if pruneErr != nil {
+				return FromStoreError(pruneErr)
+			}
+			report = fromStoreVersionPruneResult(result)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &pruneOutput{
+			ETag: strconv.Quote(strconv.FormatInt(report.Node.Revision, 10)),
+			Body: report,
+		}, nil
+	})
+}

--- a/internal/api/routes_content_prune.go
+++ b/internal/api/routes_content_prune.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 
 	"github.com/danielgtaylor/huma/v2"
-
-	"go.kenn.io/docbank/internal/store"
 )
 
 func registerContentPruneRoute(api huma.API, d Deps, g *gate) {
@@ -19,7 +17,7 @@ func registerContentPruneRoute(api huma.API, d Deps, g *gate) {
 		OperationID: "pruneNodeContentVersions", Method: http.MethodPost,
 		Path:    "/api/v1/nodes/{id}/versions/prune",
 		Summary: "Preview or prune selected non-current content versions",
-		Description: "Dry-run by default. Execution requires If-Match and releases only logical " +
+		Description: "Requires If-Match for preview and execution; dry-run by default. Execution releases only logical " +
 			"history authority; GC and repack remain separate physical maintenance operations.",
 	}, func(ctx context.Context, in *struct {
 		ID      int64  `path:"id"`
@@ -30,13 +28,9 @@ func registerContentPruneRoute(api huma.API, d Deps, g *gate) {
 		if err != nil {
 			return nil, err
 		}
-		age, err := ParseAge(in.Body.OlderThan)
+		selector, err := ParseVersionPruneRequest(in.Body)
 		if err != nil {
 			return nil, NewError(http.StatusUnprocessableEntity, "invalid_version_prune", err.Error())
-		}
-		selector := store.VersionPruneSelector{
-			VersionIDs: in.Body.VersionIDs, KeepNewest: in.Body.KeepNewest,
-			OlderThan: age, AllPrior: in.Body.AllPrior,
 		}
 		var report VersionPruneReport
 		err = g.mutate(func() error {

--- a/internal/api/routes_content_prune_test.go
+++ b/internal/api/routes_content_prune_test.go
@@ -103,6 +103,19 @@ func TestContentVersionPruneRequiresRevisionAndOneSelector(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, string(body))
 	assert.Contains(t, string(body), `"code":"invalid_version_prune"`)
 
+	resp, body = postContentPrune(t, ts.URL, ts.Client(), created.ID, &revision,
+		map[string]any{"older_than": "0h", "all_prior": true, "run": true})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, string(body))
+	assert.Contains(t, string(body), `"code":"invalid_version_prune"`)
+
+	resp, body = postContentPrune(t, ts.URL, ts.Client(), created.ID, &revision,
+		map[string]any{"version_ids": []string{"not-a-uuid"}})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, string(body))
+
+	_, total, err := s.ContentVersions(t.Context(), created.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "invalid execution must not alter history")
+
 	stale := revision + 1
 	resp, body = postContentPrune(t, ts.URL, ts.Client(), created.ID, &stale,
 		map[string]any{"all_prior": true, "run": true})

--- a/internal/api/routes_content_prune_test.go
+++ b/internal/api/routes_content_prune_test.go
@@ -1,0 +1,111 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func postContentPrune(
+	t *testing.T, tsURL string, client *http.Client, nodeID int64, revision *int64, body any,
+) (*http.Response, []byte) {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/api/v1/nodes/%d/versions/prune", tsURL, nodeID), bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if revision != nil {
+		req.Header.Set("If-Match", strconv.Quote(strconv.FormatInt(*revision, 10)))
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, responseBody
+}
+
+func TestContentVersionPrunePreviewsThenReleasesHistory(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	created := createFileWithContent(t, ts, s, "/report.txt", "old content")
+	oldVersionID := created.CurrentVersionID
+	oldHash := created.BlobHash
+	replacement := []byte("current content")
+	resp, body := sendContentReplacement(t, ts.URL, ts.Client(), created.ID, created.Revision,
+		replacement, uploadIdentity(replacement), int64(len(replacement)), "text/plain")
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var replaced api.ContentReplacementReceipt
+	require.NoError(t, json.Unmarshal(body, &replaced))
+
+	revision := replaced.Node.Revision
+	resp, body = postContentPrune(t, ts.URL, ts.Client(), created.ID, &revision,
+		map[string]any{"keep_newest": 1})
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	assert.Equal(t, strconv.Quote(strconv.FormatInt(revision, 10)), resp.Header.Get("ETag"))
+	var preview api.VersionPruneReport
+	require.NoError(t, json.Unmarshal(body, &preview))
+	assert.False(t, preview.Run)
+	assert.False(t, preview.Changed)
+	assert.Equal(t, 1, preview.UniqueBlobs)
+	assert.Equal(t, 1, preview.ReleasableBlobs)
+	assert.Equal(t, int64(len("old content")), preview.LooseBytesPendingGC)
+	require.Len(t, preview.Candidates, 1)
+	assert.Equal(t, oldVersionID, preview.Candidates[0].ID)
+	_, err := s.ContentVersionByID(t.Context(), oldVersionID)
+	require.NoError(t, err, "preview must not alter history")
+
+	resp, body = postContentPrune(t, ts.URL, ts.Client(), created.ID, &revision,
+		map[string]any{"keep_newest": 1, "run": true})
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	assert.Equal(t, strconv.Quote(strconv.FormatInt(revision+1, 10)), resp.Header.Get("ETag"))
+	var receipt api.VersionPruneReport
+	require.NoError(t, json.Unmarshal(body, &receipt))
+	assert.True(t, receipt.Run)
+	assert.True(t, receipt.Changed)
+	assert.Equal(t, 1, receipt.DeletedVersions)
+	assert.Equal(t, revision+1, receipt.Node.Revision)
+	assert.Equal(t, replaced.Version.ID, receipt.Node.CurrentVersionID)
+
+	oldResp, err := ts.Client().Get(ts.URL + "/api/v1/versions/" + oldVersionID)
+	require.NoError(t, err)
+	require.NoError(t, oldResp.Body.Close())
+	assert.Equal(t, http.StatusNotFound, oldResp.StatusCode)
+	unreachable, err := s.UnreachableBlobs(t.Context())
+	require.NoError(t, err)
+	require.Len(t, unreachable, 1)
+	assert.Equal(t, oldHash, unreachable[0].Hash,
+		"pruning releases authority but leaves physical reclamation to GC")
+}
+
+func TestContentVersionPruneRequiresRevisionAndOneSelector(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	created := createFileWithContent(t, ts, s, "/report.txt", "content")
+
+	resp, body := postContentPrune(t, ts.URL, ts.Client(), created.ID, nil,
+		map[string]any{"all_prior": true})
+	assert.Equal(t, http.StatusPreconditionRequired, resp.StatusCode, string(body))
+	assert.Contains(t, string(body), `"code":"precondition_required"`)
+
+	revision := created.Revision
+	resp, body = postContentPrune(t, ts.URL, ts.Client(), created.ID, &revision,
+		map[string]any{"keep_newest": 1, "all_prior": true})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, string(body))
+	assert.Contains(t, string(body), `"code":"invalid_version_prune"`)
+
+	stale := revision + 1
+	resp, body = postContentPrune(t, ts.URL, ts.Client(), created.ID, &stale,
+		map[string]any{"all_prior": true, "run": true})
+	assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode, string(body))
+	assert.Contains(t, string(body), `"code":"stale_revision"`)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -92,6 +92,7 @@ func NewServer(d Deps) *Server {
 	registerUploadRoute(mux, humaAPI, d, g)
 	registerContentWriteRoute(mux, humaAPI, d, g)
 	registerContentRevertRoute(humaAPI, d, g)
+	registerContentPruneRoute(humaAPI, d, g)
 	registerTagRoutes(humaAPI, d, g)
 	markRevisionPreconditionsRequired(humaAPI)
 	s.registerHealth(mux)
@@ -130,6 +131,7 @@ func markRevisionPreconditionsRequired(api huma.API) {
 		{"/api/v1/nodes/{id}/restore", http.MethodPost},
 		{"/api/v1/nodes/{id}/verify", http.MethodPost},
 		{"/api/v1/nodes/{id}/revert", http.MethodPost},
+		{"/api/v1/nodes/{id}/versions/prune", http.MethodPost},
 		{"/api/v1/nodes/{id}/tags/{tag_id}", http.MethodPut},
 		{"/api/v1/nodes/{id}/tags/{tag_id}", http.MethodDelete},
 		{"/api/v1/tags/{tag_id}", http.MethodPatch},

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -59,8 +59,8 @@ type ContentVersionPage struct {
 // VersionPruneRequest selects one explicit history-pruning policy. Exactly one
 // of VersionIDs, KeepNewest, OlderThan, or AllPrior must be set.
 type VersionPruneRequest struct {
-	VersionIDs []string `json:"version_ids,omitempty"`
-	KeepNewest int      `json:"keep_newest,omitempty" minimum:"0"`
+	VersionIDs []string `json:"version_ids,omitempty" format:"uuid" minItems:"1" maxItems:"1000" uniqueItems:"true"`
+	KeepNewest int      `json:"keep_newest,omitempty" minimum:"1"`
 	OlderThan  string   `json:"older_than,omitempty" example:"90d"`
 	AllPrior   bool     `json:"all_prior,omitempty"`
 	Run        bool     `json:"run,omitempty" default:"false"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -56,6 +56,39 @@ type ContentVersionPage struct {
 	Offset int              `json:"offset"`
 }
 
+// VersionPruneRequest selects one explicit history-pruning policy. Exactly one
+// of VersionIDs, KeepNewest, OlderThan, or AllPrior must be set.
+type VersionPruneRequest struct {
+	VersionIDs []string `json:"version_ids,omitempty"`
+	KeepNewest int      `json:"keep_newest,omitempty" minimum:"0"`
+	OlderThan  string   `json:"older_than,omitempty" example:"90d"`
+	AllPrior   bool     `json:"all_prior,omitempty"`
+	Run        bool     `json:"run,omitempty" default:"false"`
+}
+
+// VersionPruneReport distinguishes released logical history from physical
+// bytes that only a later GC/repack can reclaim.
+type VersionPruneReport struct {
+	Node                     Node             `json:"node"`
+	Candidates               []ContentVersion `json:"candidates"`
+	DependencyRetained       []ContentVersion `json:"dependency_retained"`
+	Checkpoint               *ContentVersion  `json:"checkpoint,omitempty"`
+	Cutoff                   string           `json:"cutoff,omitempty"`
+	LogicalBytes             int64            `json:"logical_bytes" minimum:"0"`
+	UniqueBlobs              int              `json:"unique_blobs" minimum:"0"`
+	SharedBlobs              int              `json:"shared_blobs" minimum:"0"`
+	ReleasableBlobs          int              `json:"releasable_blobs" minimum:"0"`
+	ReleasableBytes          int64            `json:"releasable_bytes" minimum:"0"`
+	LooseBlobsPendingGC      int              `json:"loose_blobs_pending_gc" minimum:"0"`
+	LooseBytesPendingGC      int64            `json:"loose_bytes_pending_gc" minimum:"0"`
+	PackedBlobsPendingRepack int              `json:"packed_blobs_pending_repack" minimum:"0"`
+	PackedBytesPendingRepack int64            `json:"packed_bytes_pending_repack" minimum:"0"`
+	DeletedVersions          int              `json:"deleted_versions" minimum:"0"`
+	CheckpointRequired       bool             `json:"checkpoint_required"`
+	Changed                  bool             `json:"changed"`
+	Run                      bool             `json:"run"`
+}
+
 // ContentReference identifies one stable node/version pair that retains a
 // requested content hash. Path is present only while the node is live.
 type ContentReference struct {
@@ -489,6 +522,36 @@ func fromStoreContentVersion(v store.ContentVersion) ContentVersion {
 		IntroducedOperationID: v.IntroducedOperationID,
 		TransitionKind:        v.TransitionKind, SourceVersionID: v.SourceVersionID,
 	}
+}
+
+func fromStoreVersionPruneResult(result store.VersionPruneResult) VersionPruneReport {
+	report := VersionPruneReport{
+		Node: fromStoreNode(result.Node), Candidates: []ContentVersion{},
+		DependencyRetained: []ContentVersion{}, Cutoff: result.Cutoff,
+		LogicalBytes: result.LogicalBytes, UniqueBlobs: result.UniqueBlobs,
+		SharedBlobs: result.SharedBlobs, ReleasableBlobs: result.ReleasableBlobs,
+		ReleasableBytes:          result.ReleasableBytes,
+		LooseBlobsPendingGC:      result.LooseBlobsPendingGC,
+		LooseBytesPendingGC:      result.LooseBytesPendingGC,
+		PackedBlobsPendingRepack: result.PackedBlobsPendingRepack,
+		PackedBytesPendingRepack: result.PackedBytesPendingRepack,
+		DeletedVersions:          result.DeletedVersions,
+		CheckpointRequired:       result.CheckpointRequired,
+		Changed:                  result.Changed, Run: result.Run,
+	}
+	for _, version := range result.Candidates {
+		report.Candidates = append(report.Candidates, fromStoreContentVersion(version))
+	}
+	for _, version := range result.DependencyRetained {
+		report.DependencyRetained = append(
+			report.DependencyRetained, fromStoreContentVersion(version),
+		)
+	}
+	if result.Checkpoint != nil {
+		checkpoint := fromStoreContentVersion(*result.Checkpoint)
+		report.Checkpoint = &checkpoint
+	}
+	return report
 }
 
 func fromStoreContentReference(ref store.ContentReference) ContentReference {

--- a/internal/api/version_prune.go
+++ b/internal/api/version_prune.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"fmt"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+// ParseVersionPruneRequest converts the wire selector into the store's
+// authoritative selector type. It also preserves the distinction between an
+// omitted age and a supplied zero age, which time.Duration alone cannot carry.
+func ParseVersionPruneRequest(request VersionPruneRequest) (store.VersionPruneSelector, error) {
+	age, err := ParseAge(request.OlderThan)
+	if err != nil {
+		return store.VersionPruneSelector{}, fmt.Errorf(
+			"invalid version-prune age %q: %w", request.OlderThan, err,
+		)
+	}
+	if request.OlderThan != "" && age == 0 {
+		return store.VersionPruneSelector{}, fmt.Errorf(
+			"version-prune age must be greater than zero: %w", store.ErrInvalidVersionPrune,
+		)
+	}
+	selector := store.VersionPruneSelector{
+		VersionIDs: request.VersionIDs,
+		KeepNewest: request.KeepNewest,
+		OlderThan:  age,
+		AllPrior:   request.AllPrior,
+	}
+	if err := store.ValidateVersionPruneSelector(selector); err != nil {
+		return store.VersionPruneSelector{}, err
+	}
+	return selector, nil
+}

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -497,3 +497,58 @@ func TestVersionedEditingRoundTripsPackedRevertSource(t *testing.T) {
 	require.NoError(t, restoredBlobs.Close())
 	require.NoError(t, restoredStore.Close())
 }
+
+func TestPrunedVersionHistoryRoundTripsWithoutResurrection(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	alpha, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")
+	require.NoError(t, err)
+	prunedVersionID := alpha.CurrentVersionID
+	const replacement = "retained replacement"
+	var replaced store.Node
+	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
+		hash, size, writeErr := fixture.blobs.WriteContext(t.Context(), strings.NewReader(replacement))
+		if writeErr != nil {
+			return writeErr
+		}
+		replaced, _, writeErr = fixture.metadata.ReplaceContent(
+			t.Context(), alpha.ID, alpha.Revision, hash, size, "text/plain",
+		)
+		return writeErr
+	}))
+	pruned, err := fixture.metadata.PruneContentVersions(t.Context(), alpha.ID, replaced.Revision,
+		store.VersionPruneSelector{AllPrior: true}, true)
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned.DeletedVersions)
+	wantMetadata := exportMetadata(t, fixture.metadata)
+
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	manifest, err := backupapp.Create(
+		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs,
+		backup.CreateOptions{Jobs: 2})
+	require.NoError(t, err)
+	stats, err := backupapp.ParseStats(manifest.Stats)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), stats.ContentVersions,
+		"backup metadata must contain only the retained heads")
+
+	target := filepath.Join(t.TempDir(), "restored")
+	_, err = backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{
+		TargetDir: target, Jobs: 2,
+	})
+	require.NoError(t, err)
+	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, restoredStore.Close()) }()
+	assert.Equal(t, string(wantMetadata), string(exportMetadata(t, restoredStore)))
+	_, err = restoredStore.ContentVersionByID(t.Context(), prunedVersionID)
+	require.ErrorIs(t, err, store.ErrNotFound,
+		"backup and restore must not resurrect released history")
+	restoredAlpha, err := restoredStore.NodeByPath(t.Context(), "/alpha.txt")
+	require.NoError(t, err)
+	versions, total, err := restoredStore.ContentVersions(t.Context(), restoredAlpha.ID, 10, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, versions, 1)
+	assert.Equal(t, replaced.CurrentVersionID, versions[0].ID)
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -308,7 +308,7 @@ func (c *Client) PruneContentVersions(
 	if revision < 1 {
 		return report, errors.New("version-prune revision must be positive")
 	}
-	if err := validateVersionPruneRequest(request); err != nil {
+	if _, err := api.ParseVersionPruneRequest(request); err != nil {
 		return report, err
 	}
 	headers, err := c.doWithHeaders(ctx, http.MethodPost,
@@ -322,44 +322,22 @@ func (c *Client) PruneContentVersions(
 	return report, nil
 }
 
-func validateVersionPruneRequest(request api.VersionPruneRequest) error {
-	if request.KeepNewest < 0 {
-		return errors.New("versions to keep must not be negative")
+func validateVersionPruneReport(
+	report api.VersionPruneReport, etag string, nodeID, revision int64, run bool,
+) error {
+	if err := validateVersionPruneBinding(report, etag, nodeID, revision, run); err != nil {
+		return err
 	}
-	modes := 0
-	if len(request.VersionIDs) > 0 {
-		modes++
+	if err := validateVersionPruneCounts(report, run); err != nil {
+		return err
 	}
-	if request.KeepNewest > 0 {
-		modes++
+	if err := validateVersionPruneVersions(report, nodeID, run); err != nil {
+		return err
 	}
-	if request.OlderThan != "" {
-		modes++
-		age, err := api.ParseAge(request.OlderThan)
-		if err != nil || age == 0 {
-			return fmt.Errorf("invalid version-prune age %q", request.OlderThan)
-		}
-	}
-	if request.AllPrior {
-		modes++
-	}
-	if modes != 1 {
-		return errors.New("version pruning requires exactly one selector")
-	}
-	seen := make(map[string]bool, len(request.VersionIDs))
-	for _, id := range request.VersionIDs {
-		if !validUUIDv4(id) {
-			return fmt.Errorf("version-prune ID %q must be a canonical UUIDv4", id)
-		}
-		if seen[id] {
-			return fmt.Errorf("version-prune ID %s appears more than once", id)
-		}
-		seen[id] = true
-	}
-	return nil
+	return validateVersionPruneCheckpoint(report, nodeID, run)
 }
 
-func validateVersionPruneReport(
+func validateVersionPruneBinding(
 	report api.VersionPruneReport, etag string, nodeID, revision int64, run bool,
 ) error {
 	if report.Node.ID != nodeID || report.Run != run {
@@ -379,7 +357,11 @@ func validateVersionPruneReport(
 		return fmt.Errorf("version-prune response ETag %q disagrees with node revision %d",
 			etag, report.Node.Revision)
 	}
-	if !run && (report.Changed || report.DeletedVersions != 0 || report.Checkpoint != nil) {
+	return nil
+}
+
+func validateVersionPruneCounts(report api.VersionPruneReport, run bool) error {
+	if !run && (report.DeletedVersions != 0 || report.Checkpoint != nil) {
 		return errors.New("version-prune dry run reports a mutation")
 	}
 	if run && report.DeletedVersions != len(report.Candidates) {
@@ -399,30 +381,33 @@ func validateVersionPruneReport(
 		report.ReleasableBlobs != report.LooseBlobsPendingGC+report.PackedBlobsPendingRepack {
 		return errors.New("version-prune receipt has inconsistent blob counts")
 	}
+	return nil
+}
+
+func validateVersionPruneVersions(report api.VersionPruneReport, nodeID int64, run bool) error {
 	logicalBytes := int64(0)
 	uniqueBlobs := make(map[string]bool, len(report.Candidates))
 	seenVersions := make(map[string]bool, len(report.Candidates)+len(report.DependencyRetained))
 	checkpointPreviewIncludesCurrent := false
-	for index, version := range append(append([]api.ContentVersion{}, report.Candidates...), report.DependencyRetained...) {
-		if version.NodeID != nodeID || !validVersionPruneVersion(version) {
-			return errors.New("version-prune receipt contains an invalid version")
+	for _, version := range report.Candidates {
+		if err := validateVersionPruneReceiptVersion(version, nodeID, seenVersions); err != nil {
+			return err
 		}
-		if seenVersions[version.ID] {
-			return errors.New("version-prune receipt repeats a version")
+		currentCheckpointPreview := !run && report.CheckpointRequired &&
+			version.ID == report.Node.CurrentVersionID
+		checkpointPreviewIncludesCurrent = checkpointPreviewIncludesCurrent || currentCheckpointPreview
+		if version.ID == report.Node.CurrentVersionID && !currentCheckpointPreview {
+			return errors.New("version-prune receipt selects invalid current history")
 		}
-		seenVersions[version.ID] = true
-		if index < len(report.Candidates) {
-			currentCheckpointPreview := !run && report.CheckpointRequired &&
-				version.ID == report.Node.CurrentVersionID
-			checkpointPreviewIncludesCurrent = checkpointPreviewIncludesCurrent || currentCheckpointPreview
-			if (version.ID == report.Node.CurrentVersionID && !currentCheckpointPreview) || version.Size < 0 {
-				return errors.New("version-prune receipt selects invalid current history")
-			}
-			if version.Size > math.MaxInt64-logicalBytes {
-				return errors.New("version-prune receipt logical size overflows")
-			}
-			logicalBytes += version.Size
-			uniqueBlobs[version.BlobHash] = true
+		if version.Size > math.MaxInt64-logicalBytes {
+			return errors.New("version-prune receipt logical size overflows")
+		}
+		logicalBytes += version.Size
+		uniqueBlobs[version.BlobHash] = true
+	}
+	for _, version := range report.DependencyRetained {
+		if err := validateVersionPruneReceiptVersion(version, nodeID, seenVersions); err != nil {
+			return err
 		}
 	}
 	if report.LogicalBytes != logicalBytes || report.UniqueBlobs != len(uniqueBlobs) {
@@ -431,6 +416,23 @@ func validateVersionPruneReport(
 	if !run && report.CheckpointRequired && !checkpointPreviewIncludesCurrent {
 		return errors.New("version-prune preview omits its checkpointed current version")
 	}
+	return nil
+}
+
+func validateVersionPruneReceiptVersion(
+	version api.ContentVersion, nodeID int64, seen map[string]bool,
+) error {
+	if version.NodeID != nodeID || !validVersionPruneVersion(version) {
+		return errors.New("version-prune receipt contains an invalid version")
+	}
+	if seen[version.ID] {
+		return errors.New("version-prune receipt repeats a version")
+	}
+	seen[version.ID] = true
+	return nil
+}
+
+func validateVersionPruneCheckpoint(report api.VersionPruneReport, nodeID int64, run bool) error {
 	if report.Checkpoint != nil {
 		if !run || !report.Changed || !report.CheckpointRequired ||
 			report.Checkpoint.NodeID != nodeID || report.Node.CurrentVersionID != report.Checkpoint.ID ||

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -129,6 +130,7 @@ var codeToTypedErr = map[string]error{
 	"is_root":                  store.ErrIsRoot,
 	"version_node_mismatch":    store.ErrVersionNodeMismatch,
 	"version_already_current":  store.ErrVersionAlreadyCurrent,
+	"invalid_version_prune":    store.ErrInvalidVersionPrune,
 	"backup_locked":            backup.ErrRepoLocked,
 	"pack_retirement_deferred": packstore.ErrPackRetirementDeferred,
 }
@@ -292,6 +294,172 @@ func (c *Client) VersionContent(ctx context.Context, id string) (*ContentStream,
 		return nil, fmt.Errorf("content version %s returned version identity %s", id, stream.VersionID)
 	}
 	return stream, nil
+}
+
+// PruneContentVersions previews or executes one explicit version-history
+// selector under an optimistic node-revision precondition.
+func (c *Client) PruneContentVersions(
+	ctx context.Context, nodeID, revision int64, request api.VersionPruneRequest,
+) (api.VersionPruneReport, error) {
+	var report api.VersionPruneReport
+	if nodeID <= 0 {
+		return report, errors.New("version-prune node ID must be positive")
+	}
+	if revision < 1 {
+		return report, errors.New("version-prune revision must be positive")
+	}
+	if err := validateVersionPruneRequest(request); err != nil {
+		return report, err
+	}
+	headers, err := c.doWithHeaders(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/versions/prune", nodeID), ifMatch(revision), request, &report)
+	if err != nil {
+		return api.VersionPruneReport{}, err
+	}
+	if err := validateVersionPruneReport(report, headers.Get("ETag"), nodeID, revision, request.Run); err != nil {
+		return api.VersionPruneReport{}, err
+	}
+	return report, nil
+}
+
+func validateVersionPruneRequest(request api.VersionPruneRequest) error {
+	if request.KeepNewest < 0 {
+		return errors.New("versions to keep must not be negative")
+	}
+	modes := 0
+	if len(request.VersionIDs) > 0 {
+		modes++
+	}
+	if request.KeepNewest > 0 {
+		modes++
+	}
+	if request.OlderThan != "" {
+		modes++
+		age, err := api.ParseAge(request.OlderThan)
+		if err != nil || age == 0 {
+			return fmt.Errorf("invalid version-prune age %q", request.OlderThan)
+		}
+	}
+	if request.AllPrior {
+		modes++
+	}
+	if modes != 1 {
+		return errors.New("version pruning requires exactly one selector")
+	}
+	seen := make(map[string]bool, len(request.VersionIDs))
+	for _, id := range request.VersionIDs {
+		if !validUUIDv4(id) {
+			return fmt.Errorf("version-prune ID %q must be a canonical UUIDv4", id)
+		}
+		if seen[id] {
+			return fmt.Errorf("version-prune ID %s appears more than once", id)
+		}
+		seen[id] = true
+	}
+	return nil
+}
+
+func validateVersionPruneReport(
+	report api.VersionPruneReport, etag string, nodeID, revision int64, run bool,
+) error {
+	if report.Node.ID != nodeID || report.Run != run {
+		return errors.New("version-prune receipt does not bind its request")
+	}
+	wantRevision := revision
+	if report.Changed {
+		if !run {
+			return errors.New("version-prune dry run reports a mutation")
+		}
+		wantRevision++
+	}
+	if report.Node.Revision != wantRevision {
+		return fmt.Errorf("version-prune node revision %d, expected %d", report.Node.Revision, wantRevision)
+	}
+	if etag != strconv.Quote(strconv.FormatInt(report.Node.Revision, 10)) {
+		return fmt.Errorf("version-prune response ETag %q disagrees with node revision %d",
+			etag, report.Node.Revision)
+	}
+	if !run && (report.Changed || report.DeletedVersions != 0 || report.Checkpoint != nil) {
+		return errors.New("version-prune dry run reports a mutation")
+	}
+	if run && report.DeletedVersions != len(report.Candidates) {
+		return errors.New("version-prune receipt has inconsistent deletion counts")
+	}
+	if report.Changed != (report.DeletedVersions > 0) {
+		return errors.New("version-prune receipt has inconsistent changed state")
+	}
+	if report.LogicalBytes < 0 || report.UniqueBlobs < 0 || report.SharedBlobs < 0 ||
+		report.ReleasableBlobs < 0 || report.ReleasableBytes < 0 ||
+		report.LooseBlobsPendingGC < 0 || report.LooseBytesPendingGC < 0 ||
+		report.PackedBlobsPendingRepack < 0 || report.PackedBytesPendingRepack < 0 ||
+		report.DeletedVersions < 0 {
+		return errors.New("version-prune receipt contains negative counts")
+	}
+	if report.UniqueBlobs != report.SharedBlobs+report.ReleasableBlobs ||
+		report.ReleasableBlobs != report.LooseBlobsPendingGC+report.PackedBlobsPendingRepack {
+		return errors.New("version-prune receipt has inconsistent blob counts")
+	}
+	logicalBytes := int64(0)
+	uniqueBlobs := make(map[string]bool, len(report.Candidates))
+	seenVersions := make(map[string]bool, len(report.Candidates)+len(report.DependencyRetained))
+	checkpointPreviewIncludesCurrent := false
+	for index, version := range append(append([]api.ContentVersion{}, report.Candidates...), report.DependencyRetained...) {
+		if version.NodeID != nodeID || !validVersionPruneVersion(version) {
+			return errors.New("version-prune receipt contains an invalid version")
+		}
+		if seenVersions[version.ID] {
+			return errors.New("version-prune receipt repeats a version")
+		}
+		seenVersions[version.ID] = true
+		if index < len(report.Candidates) {
+			currentCheckpointPreview := !run && report.CheckpointRequired &&
+				version.ID == report.Node.CurrentVersionID
+			checkpointPreviewIncludesCurrent = checkpointPreviewIncludesCurrent || currentCheckpointPreview
+			if (version.ID == report.Node.CurrentVersionID && !currentCheckpointPreview) || version.Size < 0 {
+				return errors.New("version-prune receipt selects invalid current history")
+			}
+			if version.Size > math.MaxInt64-logicalBytes {
+				return errors.New("version-prune receipt logical size overflows")
+			}
+			logicalBytes += version.Size
+			uniqueBlobs[version.BlobHash] = true
+		}
+	}
+	if report.LogicalBytes != logicalBytes || report.UniqueBlobs != len(uniqueBlobs) {
+		return errors.New("version-prune receipt has inconsistent logical inventory")
+	}
+	if !run && report.CheckpointRequired && !checkpointPreviewIncludesCurrent {
+		return errors.New("version-prune preview omits its checkpointed current version")
+	}
+	if report.Checkpoint != nil {
+		if !run || !report.Changed || !report.CheckpointRequired ||
+			report.Checkpoint.NodeID != nodeID || report.Node.CurrentVersionID != report.Checkpoint.ID ||
+			report.Checkpoint.NodeRevision != report.Node.Revision ||
+			report.Checkpoint.BlobHash != report.Node.BlobHash ||
+			report.Checkpoint.Size != report.Node.Size || report.Checkpoint.MimeType != report.Node.MimeType ||
+			report.Checkpoint.TransitionKind != "content_replace" || report.Checkpoint.SourceVersionID != nil ||
+			!validVersionPruneVersion(*report.Checkpoint) {
+			return errors.New("version-prune receipt contains an invalid checkpoint")
+		}
+	} else if run && report.Changed && report.CheckpointRequired {
+		return errors.New("version-prune receipt omits its required checkpoint")
+	}
+	return nil
+}
+
+func validVersionPruneVersion(version api.ContentVersion) bool {
+	if !validUUIDv4(version.ID) || !validUUIDv4(version.IntroducedOperationID) ||
+		!validSHA256Hex(version.BlobHash) || version.Size < 0 || version.NodeRevision < 1 {
+		return false
+	}
+	switch version.TransitionKind {
+	case "content_create", "content_replace":
+		return version.SourceVersionID == nil
+	case "content_revert":
+		return version.SourceVersionID != nil && validUUIDv4(*version.SourceVersionID)
+	default:
+		return false
+	}
 }
 
 // ContentReferences returns one bounded page of logical version references to

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -783,6 +783,132 @@ func TestContentReversionRejectsUnprovenReceipt(t *testing.T) {
 	}
 }
 
+func TestContentVersionPruneRoundTrip(t *testing.T) {
+	c, s := newClient(t, serverKey)
+	initial := "initial content"
+	initialSum := sha256.Sum256([]byte(initial))
+	created, err := c.Upload(t.Context(), s.RootID(), "versioned.txt", "text/plain",
+		hex.EncodeToString(initialSum[:]), int64(len(initial)), strings.NewReader(initial))
+	require.NoError(t, err)
+	replacement := "replacement content"
+	replacementSum := sha256.Sum256([]byte(replacement))
+	replaced, err := c.ReplaceContent(t.Context(), created.Node.ID, created.Node.Revision,
+		"text/plain", hex.EncodeToString(replacementSum[:]), int64(len(replacement)),
+		strings.NewReader(replacement))
+	require.NoError(t, err)
+
+	request := api.VersionPruneRequest{KeepNewest: 1}
+	preview, err := c.PruneContentVersions(
+		t.Context(), created.Node.ID, replaced.Node.Revision, request,
+	)
+	require.NoError(t, err)
+	assert.False(t, preview.Changed)
+	require.Len(t, preview.Candidates, 1)
+	assert.Equal(t, created.Node.CurrentVersionID, preview.Candidates[0].ID)
+
+	request.Run = true
+	receipt, err := c.PruneContentVersions(
+		t.Context(), created.Node.ID, replaced.Node.Revision, request,
+	)
+	require.NoError(t, err)
+	assert.True(t, receipt.Changed)
+	assert.Equal(t, 1, receipt.DeletedVersions)
+	assert.Equal(t, replaced.Node.Revision+1, receipt.Node.Revision)
+	versions, err := c.Versions(t.Context(), created.Node.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, versions.Total)
+	_, err = c.PruneContentVersions(t.Context(), created.Node.ID, replaced.Node.Revision, request)
+	require.ErrorIs(t, err, store.ErrStaleRevision)
+}
+
+func TestContentVersionPruneAllPriorCheckpointsCurrentRevert(t *testing.T) {
+	c, s := newClient(t, serverKey)
+	initial := "initial content"
+	initialSum := sha256.Sum256([]byte(initial))
+	created, err := c.Upload(t.Context(), s.RootID(), "reverted.txt", "text/plain",
+		hex.EncodeToString(initialSum[:]), int64(len(initial)), strings.NewReader(initial))
+	require.NoError(t, err)
+	replacement := "replacement content"
+	replacementSum := sha256.Sum256([]byte(replacement))
+	replaced, err := c.ReplaceContent(t.Context(), created.Node.ID, created.Node.Revision,
+		"text/plain", hex.EncodeToString(replacementSum[:]), int64(len(replacement)),
+		strings.NewReader(replacement))
+	require.NoError(t, err)
+	reverted, err := c.RevertContent(t.Context(), created.Node.ID, replaced.Node.Revision,
+		created.Node.CurrentVersionID)
+	require.NoError(t, err)
+
+	request := api.VersionPruneRequest{AllPrior: true}
+	preview, err := c.PruneContentVersions(
+		t.Context(), created.Node.ID, reverted.Node.Revision, request,
+	)
+	require.NoError(t, err)
+	assert.True(t, preview.CheckpointRequired)
+	assert.Nil(t, preview.Checkpoint)
+	require.Len(t, preview.Candidates, 3)
+
+	request.Run = true
+	receipt, err := c.PruneContentVersions(
+		t.Context(), created.Node.ID, reverted.Node.Revision, request,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, receipt.Checkpoint)
+	assert.Equal(t, "content_replace", receipt.Checkpoint.TransitionKind)
+	assert.Nil(t, receipt.Checkpoint.SourceVersionID)
+	assert.Equal(t, receipt.Checkpoint.ID, receipt.Node.CurrentVersionID)
+	assert.Equal(t, created.Node.BlobHash, receipt.Node.BlobHash)
+	versions, err := c.Versions(t.Context(), created.Node.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, versions.Items, 1)
+	assert.Equal(t, receipt.Checkpoint.ID, versions.Items[0].ID)
+}
+
+func TestContentVersionPruneRejectsUnprovenReceipt(t *testing.T) {
+	const (
+		currentID = "11111111-1111-4111-8111-111111111111"
+		oldID     = "22222222-2222-4222-8222-222222222222"
+	)
+	base := api.VersionPruneReport{
+		Node: api.Node{ID: 7, Revision: 4, CurrentVersionID: currentID},
+		Candidates: []api.ContentVersion{{
+			ID: oldID, NodeID: 7, BlobHash: strings.Repeat("a", 64), Size: 12,
+			NodeRevision: 2, IntroducedOperationID: "33333333-3333-4333-8333-333333333333",
+			TransitionKind: "content_replace",
+		}},
+		DependencyRetained: []api.ContentVersion{},
+		LogicalBytes:       12, UniqueBlobs: 1, ReleasableBlobs: 1,
+		ReleasableBytes: 12, LooseBlobsPendingGC: 1, LooseBytesPendingGC: 12,
+	}
+	tests := map[string]func(*api.VersionPruneReport){
+		"node":      func(r *api.VersionPruneReport) { r.Node.ID++ },
+		"revision":  func(r *api.VersionPruneReport) { r.Node.Revision++ },
+		"current":   func(r *api.VersionPruneReport) { r.Node.CurrentVersionID = oldID },
+		"logical":   func(r *api.VersionPruneReport) { r.LogicalBytes++ },
+		"unique":    func(r *api.VersionPruneReport) { r.UniqueBlobs++ },
+		"negative":  func(r *api.VersionPruneReport) { r.ReleasableBytes = -1 },
+		"duplicate": func(r *api.VersionPruneReport) { r.DependencyRetained = r.Candidates },
+		"etag":      func(_ *api.VersionPruneReport) {},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			report := base
+			report.Candidates = append([]api.ContentVersion(nil), base.Candidates...)
+			mutate(&report)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if name != "etag" {
+					w.Header().Set("ETag", `"4"`)
+				}
+				_ = json.NewEncoder(w).Encode(report)
+			}))
+			t.Cleanup(ts.Close)
+			_, err := client.New(ts.URL, "key").PruneContentVersions(
+				t.Context(), 7, 4, api.VersionPruneRequest{AllPrior: true},
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestStorageRepackRoundTrip(t *testing.T) {
 	c, _ := newClient(t, serverKey)
 	for name, content := range map[string]string{

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "16"
+	daemonProtocolVersion = "17"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -30,6 +30,9 @@ var (
 	// ErrVersionAlreadyCurrent means a revert selected the node's current head,
 	// which is not a historical transition.
 	ErrVersionAlreadyCurrent = errors.New("content version is already current")
+	// ErrInvalidVersionPrune means a history-pruning selector is absent,
+	// contradictory, or otherwise unsafe to execute.
+	ErrInvalidVersionPrune = errors.New("invalid version-prune selector")
 )
 
 // UnconditionalRev is the only ifRev value that skips the revision

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -1129,12 +1129,9 @@ func validateMetadataRelations(ctx context.Context, tx metadataQuerier) error {
 			)`},
 		{"content version size differs from blob authority", `
 			SELECT EXISTS(SELECT 1 FROM content_versions v JOIN blobs b ON b.hash=v.blob_hash WHERE v.size != b.size)`},
-		{"content history lacks exactly one revision-one create", `
-			SELECT EXISTS(
-			  SELECT n.id FROM nodes n LEFT JOIN content_versions v
-			    ON v.node_id=n.id AND v.node_revision=1 AND v.transition_kind='content_create'
-			  WHERE n.kind='file' GROUP BY n.id HAVING COUNT(v.version_id) != 1
-			)`},
+		// Explicit version pruning may remove the revision-one create. UUID
+		// identities are never reused and the node allocator/revision remain at
+		// their high-water marks, so retained history may begin at any revision.
 		{"content_create time differs from node creation", `
 			SELECT EXISTS(
 			  SELECT 1 FROM content_versions v JOIN nodes n ON n.id=v.node_id

--- a/internal/store/version_prune.go
+++ b/internal/store/version_prune.go
@@ -6,8 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"time"
 )
+
+// MaxVersionPruneIDs bounds explicit point selections. Larger history cleanup
+// should use an age, count, or all-prior selector instead of holding a write
+// transaction for an unbounded request body.
+const MaxVersionPruneIDs = 1000
 
 // VersionPruneSelector chooses historical content versions. Exactly one mode
 // must be set. The current head is never removable; AllPrior may replace a
@@ -59,7 +65,7 @@ type pruneBlobStats struct {
 func (s *Store) PruneContentVersions(
 	ctx context.Context, nodeID, ifRev int64, selector VersionPruneSelector, run bool,
 ) (VersionPruneResult, error) {
-	if err := validateVersionPruneSelector(selector); err != nil {
+	if err := ValidateVersionPruneSelector(selector); err != nil {
 		return VersionPruneResult{}, err
 	}
 	result := VersionPruneResult{Run: run}
@@ -105,9 +111,6 @@ func (s *Store) PruneContentVersions(
 		if !run || len(candidateSet) == 0 {
 			return nil
 		}
-		if node.Revision == math.MaxInt64 {
-			return fmt.Errorf("node %d revision cannot advance beyond %d", node.ID, node.Revision)
-		}
 		if checkpointRequired {
 			updated, checkpoint, err := installContentVersionTx(
 				tx, node, versions[0].BlobHash, versions[0].Size, versions[0].MimeType,
@@ -120,15 +123,11 @@ func (s *Store) PruneContentVersions(
 			result.Checkpoint = &checkpoint
 		} else {
 			now := nowRFC3339()
-			if _, err := tx.Exec(
-				`UPDATE nodes SET revision = revision + 1, modified_at = ? WHERE id = ?`, now, node.ID,
-			); err != nil {
-				return fmt.Errorf("advancing node %d after version pruning: %w", node.ID, err)
-			}
-			result.Node, err = nodeByIDTx(tx, node.ID)
-			if err != nil {
+			if err := bumpRevisionTx(tx, node.ID, now); err != nil {
 				return err
 			}
+			result.Node.Revision++
+			result.Node.ModifiedAt = now
 		}
 		for _, version := range result.Candidates {
 			if _, err := tx.Exec(`DELETE FROM content_versions WHERE version_id = ?`, version.ID); err != nil {
@@ -151,7 +150,14 @@ func (s *Store) PruneContentVersions(
 	return result, nil
 }
 
-func validateVersionPruneSelector(selector VersionPruneSelector) error {
+// ValidateVersionPruneSelector applies the authoritative store-level selector
+// rules. HTTP and CLI adapters translate their inputs into this type and reuse
+// the same validation before opening a transaction.
+func ValidateVersionPruneSelector(selector VersionPruneSelector) error {
+	if len(selector.VersionIDs) > MaxVersionPruneIDs {
+		return fmt.Errorf("at most %d explicit version IDs may be pruned at once: %w",
+			MaxVersionPruneIDs, ErrInvalidVersionPrune)
+	}
 	modes := 0
 	if len(selector.VersionIDs) > 0 {
 		modes++
@@ -178,7 +184,8 @@ func validateVersionPruneSelector(selector VersionPruneSelector) error {
 	seen := make(map[string]bool, len(selector.VersionIDs))
 	for _, id := range selector.VersionIDs {
 		if err := validateUUIDv4(id); err != nil {
-			return fmt.Errorf("content version %q: %w", id, ErrNotFound)
+			return fmt.Errorf("content version %q must be a canonical UUIDv4: %w",
+				id, ErrInvalidVersionPrune)
 		}
 		if seen[id] {
 			return fmt.Errorf("content version %s is selected more than once: %w", id, ErrInvalidVersionPrune)
@@ -219,25 +226,38 @@ func selectVersionPruneCandidates(
 	checkpointRequired := selector.AllPrior && versions[0].TransitionKind == "content_revert"
 	switch {
 	case len(selector.VersionIDs) > 0:
+		byID := make(map[string]ContentVersion, len(versions))
+		for _, version := range versions {
+			byID[version.ID] = version
+		}
+		missing := make([]string, 0)
 		for _, id := range selector.VersionIDs {
-			version, err := scanContentVersion(tx.QueryRow(
-				`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`, id))
-			if err != nil {
-				return nil, nil, "", false, fmt.Errorf("content version %q: %w", id, err)
+			_, ok := byID[id]
+			if !ok {
+				missing = append(missing, id)
+				continue
 			}
-			if version.NodeID != node.ID {
-				return nil, nil, "", false, fmt.Errorf(
-					"content version %s belongs to node %d, not node %d: %w",
-					version.ID, version.NodeID, node.ID, ErrVersionNodeMismatch,
-				)
-			}
-			if version.ID == node.CurrentVersionID {
+			if id == node.CurrentVersionID {
 				return nil, nil, "", false, fmt.Errorf(
 					"content version %s is the current head of node %d: %w",
-					version.ID, node.ID, ErrVersionAlreadyCurrent,
+					id, node.ID, ErrVersionAlreadyCurrent,
 				)
 			}
 			candidates[id] = true
+		}
+		if len(missing) > 0 {
+			owners, err := contentVersionOwnersTx(tx, missing)
+			if err != nil {
+				return nil, nil, "", false, err
+			}
+			id := missing[0]
+			if owner, ok := owners[id]; ok {
+				return nil, nil, "", false, fmt.Errorf(
+					"content version %s belongs to node %d, not node %d: %w",
+					id, owner, node.ID, ErrVersionNodeMismatch,
+				)
+			}
+			return nil, nil, "", false, fmt.Errorf("content version %q: %w", id, ErrNotFound)
 		}
 	case selector.KeepNewest > 0:
 		for index := selector.KeepNewest; index < len(versions); index++ {
@@ -281,6 +301,32 @@ func selectVersionPruneCandidates(
 	return candidates, dependencyRetained, cutoff, checkpointRequired, nil
 }
 
+func contentVersionOwnersTx(tx *sql.Tx, versionIDs []string) (map[string]int64, error) {
+	args := make([]any, len(versionIDs))
+	for index, id := range versionIDs {
+		args[index] = id
+	}
+	rows, err := tx.Query(`SELECT version_id, node_id FROM content_versions
+		WHERE version_id IN (`+placeholders(len(versionIDs))+`)`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving selected content versions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	owners := make(map[string]int64, len(versionIDs))
+	for rows.Next() {
+		var id string
+		var nodeID int64
+		if err := rows.Scan(&id, &nodeID); err != nil {
+			return nil, fmt.Errorf("resolving selected content versions: %w", err)
+		}
+		owners[id] = nodeID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("resolving selected content versions: %w", err)
+	}
+	return owners, nil
+}
+
 func populateVersionPruneBlobStats(
 	tx *sql.Tx, result *VersionPruneResult, checkpointRequired bool,
 ) error {
@@ -292,29 +338,14 @@ func populateVersionPruneBlobStats(
 	if len(selectedByHash) == 0 {
 		return nil
 	}
-	rows, err := tx.Query(`
-		SELECT v.blob_hash, COUNT(*), b.size,
-		       CASE WHEN p.blob_hash IS NULL THEN 0 ELSE 1 END,
-		       COALESCE(p.stored_len, 0)
-		FROM content_versions v
-		JOIN blobs b ON b.hash = v.blob_hash
-		LEFT JOIN blob_pack_index p ON p.blob_hash = v.blob_hash
-		GROUP BY v.blob_hash, b.size, p.blob_hash, p.stored_len`)
+	hashes := make([]string, 0, len(selectedByHash))
+	for hash := range selectedByHash {
+		hashes = append(hashes, hash)
+	}
+	sort.Strings(hashes)
+	stats, err := versionPruneBlobStatsTx(tx, hashes)
 	if err != nil {
-		return fmt.Errorf("inventorying version-prune blobs: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-	stats := make(map[string]pruneBlobStats, len(selectedByHash))
-	for rows.Next() {
-		var hash string
-		var item pruneBlobStats
-		if err := rows.Scan(&hash, &item.refs, &item.size, &item.packed, &item.storedLen); err != nil {
-			return fmt.Errorf("inventorying version-prune blobs: %w", err)
-		}
-		stats[hash] = item
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("inventorying version-prune blobs: %w", err)
+		return err
 	}
 	for hash, selected := range selectedByHash {
 		item, ok := stats[hash]
@@ -347,6 +378,52 @@ func populateVersionPruneBlobStats(
 			}
 			result.LooseBytesPendingGC += item.size
 		}
+	}
+	return nil
+}
+
+func versionPruneBlobStatsTx(tx *sql.Tx, hashes []string) (map[string]pruneBlobStats, error) {
+	const batchSize = 500
+	stats := make(map[string]pruneBlobStats, len(hashes))
+	for start := 0; start < len(hashes); start += batchSize {
+		end := min(start+batchSize, len(hashes))
+		if err := versionPruneBlobStatsBatchTx(tx, hashes[start:end], stats); err != nil {
+			return nil, err
+		}
+	}
+	return stats, nil
+}
+
+func versionPruneBlobStatsBatchTx(
+	tx *sql.Tx, hashes []string, stats map[string]pruneBlobStats,
+) error {
+	args := make([]any, len(hashes))
+	for index, hash := range hashes {
+		args[index] = hash
+	}
+	rows, err := tx.Query(`
+			SELECT v.blob_hash, COUNT(*), b.size,
+			       CASE WHEN p.blob_hash IS NULL THEN 0 ELSE 1 END,
+			       COALESCE(p.stored_len, 0)
+			FROM content_versions v
+			JOIN blobs b ON b.hash = v.blob_hash
+			LEFT JOIN blob_pack_index p ON p.blob_hash = v.blob_hash
+			WHERE v.blob_hash IN (`+placeholders(len(hashes))+`)
+			GROUP BY v.blob_hash, b.size, p.blob_hash, p.stored_len`, args...)
+	if err != nil {
+		return fmt.Errorf("inventorying version-prune blobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var hash string
+		var item pruneBlobStats
+		if err := rows.Scan(&hash, &item.refs, &item.size, &item.packed, &item.storedLen); err != nil {
+			return fmt.Errorf("inventorying version-prune blobs: %w", err)
+		}
+		stats[hash] = item
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("inventorying version-prune blobs: %w", err)
 	}
 	return nil
 }

--- a/internal/store/version_prune.go
+++ b/internal/store/version_prune.go
@@ -1,0 +1,352 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+)
+
+// VersionPruneSelector chooses historical content versions. Exactly one mode
+// must be set. The current head is never removable; AllPrior may replace a
+// current revert with a same-byte checkpoint so its complete source graph can
+// be released.
+type VersionPruneSelector struct {
+	VersionIDs []string
+	KeepNewest int
+	OlderThan  time.Duration
+	AllPrior   bool
+}
+
+// VersionPruneResult is the complete dry-run inventory or execution receipt.
+// LogicalBytes counts version references and may count a deduplicated blob
+// more than once. ReleasableBytes counts unique blobs that become eligible for
+// a later GC; pruning itself never reports physical bytes as reclaimed.
+type VersionPruneResult struct {
+	Node                     Node
+	Candidates               []ContentVersion
+	DependencyRetained       []ContentVersion
+	Checkpoint               *ContentVersion
+	Cutoff                   string
+	LogicalBytes             int64
+	UniqueBlobs              int
+	SharedBlobs              int
+	ReleasableBlobs          int
+	ReleasableBytes          int64
+	LooseBlobsPendingGC      int
+	LooseBytesPendingGC      int64
+	PackedBlobsPendingRepack int
+	PackedBytesPendingRepack int64
+	DeletedVersions          int
+	CheckpointRequired       bool
+	Changed                  bool
+	Run                      bool
+}
+
+type pruneBlobStats struct {
+	refs      int
+	size      int64
+	packed    bool
+	storedLen int64
+}
+
+// PruneContentVersions previews or removes selected non-current history under
+// an optimistic node revision. A run that changes history advances the node
+// revision once. Revert-source dependencies remain retained unless AllPrior
+// creates a new source-free checkpoint head in the same transaction.
+func (s *Store) PruneContentVersions(
+	ctx context.Context, nodeID, ifRev int64, selector VersionPruneSelector, run bool,
+) (VersionPruneResult, error) {
+	if err := validateVersionPruneSelector(selector); err != nil {
+		return VersionPruneResult{}, err
+	}
+	result := VersionPruneResult{Run: run}
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		if err := validateContentReplacementTarget(node, ifRev); err != nil {
+			return err
+		}
+		versions, err := contentVersionsForNodeTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		if len(versions) == 0 || versions[0].ID != node.CurrentVersionID {
+			return fmt.Errorf("node %d current content version is not its newest history row", nodeID)
+		}
+
+		candidateSet, retainedSet, cutoff, checkpointRequired, err :=
+			selectVersionPruneCandidates(tx, node, versions, selector)
+		if err != nil {
+			return err
+		}
+		result.Node = node
+		result.Cutoff = cutoff
+		result.CheckpointRequired = checkpointRequired
+		for _, version := range versions {
+			if candidateSet[version.ID] {
+				result.Candidates = append(result.Candidates, version)
+				if version.Size > math.MaxInt64-result.LogicalBytes {
+					return errors.New("selected content-version bytes exceed the reportable range")
+				}
+				result.LogicalBytes += version.Size
+			}
+			if retainedSet[version.ID] {
+				result.DependencyRetained = append(result.DependencyRetained, version)
+			}
+		}
+		if err := populateVersionPruneBlobStats(tx, &result, checkpointRequired); err != nil {
+			return err
+		}
+		if !run || len(candidateSet) == 0 {
+			return nil
+		}
+		if node.Revision == math.MaxInt64 {
+			return fmt.Errorf("node %d revision cannot advance beyond %d", node.ID, node.Revision)
+		}
+		if checkpointRequired {
+			updated, checkpoint, err := installContentVersionTx(
+				tx, node, versions[0].BlobHash, versions[0].Size, versions[0].MimeType,
+				"content_replace", nil,
+			)
+			if err != nil {
+				return fmt.Errorf("checkpointing node %d before pruning: %w", node.ID, err)
+			}
+			result.Node = updated
+			result.Checkpoint = &checkpoint
+		} else {
+			now := nowRFC3339()
+			if _, err := tx.Exec(
+				`UPDATE nodes SET revision = revision + 1, modified_at = ? WHERE id = ?`, now, node.ID,
+			); err != nil {
+				return fmt.Errorf("advancing node %d after version pruning: %w", node.ID, err)
+			}
+			result.Node, err = nodeByIDTx(tx, node.ID)
+			if err != nil {
+				return err
+			}
+		}
+		for _, version := range result.Candidates {
+			if _, err := tx.Exec(`DELETE FROM content_versions WHERE version_id = ?`, version.ID); err != nil {
+				return fmt.Errorf("pruning content version %s: %w", version.ID, err)
+			}
+		}
+		result.DeletedVersions = len(result.Candidates)
+		result.Changed = true
+		return nil
+	})
+	if err != nil {
+		return VersionPruneResult{}, err
+	}
+	if result.Candidates == nil {
+		result.Candidates = []ContentVersion{}
+	}
+	if result.DependencyRetained == nil {
+		result.DependencyRetained = []ContentVersion{}
+	}
+	return result, nil
+}
+
+func validateVersionPruneSelector(selector VersionPruneSelector) error {
+	modes := 0
+	if len(selector.VersionIDs) > 0 {
+		modes++
+	}
+	if selector.KeepNewest != 0 {
+		modes++
+	}
+	if selector.OlderThan != 0 {
+		modes++
+	}
+	if selector.AllPrior {
+		modes++
+	}
+	if modes != 1 {
+		return fmt.Errorf("version pruning requires exactly one selector: version IDs, keep newest, older than, or all prior: %w",
+			ErrInvalidVersionPrune)
+	}
+	if selector.KeepNewest < 0 {
+		return fmt.Errorf("versions to keep must be positive: %w", ErrInvalidVersionPrune)
+	}
+	if selector.OlderThan < 0 {
+		return fmt.Errorf("version age must not be negative: %w", ErrInvalidVersionPrune)
+	}
+	seen := make(map[string]bool, len(selector.VersionIDs))
+	for _, id := range selector.VersionIDs {
+		if err := validateUUIDv4(id); err != nil {
+			return fmt.Errorf("content version %q: %w", id, ErrNotFound)
+		}
+		if seen[id] {
+			return fmt.Errorf("content version %s is selected more than once: %w", id, ErrInvalidVersionPrune)
+		}
+		seen[id] = true
+	}
+	return nil
+}
+
+func contentVersionsForNodeTx(tx *sql.Tx, nodeID int64) ([]ContentVersion, error) {
+	rows, err := tx.Query(
+		`SELECT `+contentVersionCols+` FROM content_versions
+		 WHERE node_id = ? ORDER BY node_revision DESC, version_id`, nodeID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing content versions of node %d for pruning: %w", nodeID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var versions []ContentVersion
+	for rows.Next() {
+		version, err := scanContentVersion(rows)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, version)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing content versions of node %d for pruning: %w", nodeID, err)
+	}
+	return versions, nil
+}
+
+func selectVersionPruneCandidates(
+	tx *sql.Tx, node Node, versions []ContentVersion, selector VersionPruneSelector,
+) (map[string]bool, map[string]bool, string, bool, error) {
+	candidates := make(map[string]bool)
+	cutoff := ""
+	checkpointRequired := selector.AllPrior && versions[0].TransitionKind == "content_revert"
+	switch {
+	case len(selector.VersionIDs) > 0:
+		for _, id := range selector.VersionIDs {
+			version, err := scanContentVersion(tx.QueryRow(
+				`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`, id))
+			if err != nil {
+				return nil, nil, "", false, fmt.Errorf("content version %q: %w", id, err)
+			}
+			if version.NodeID != node.ID {
+				return nil, nil, "", false, fmt.Errorf(
+					"content version %s belongs to node %d, not node %d: %w",
+					version.ID, version.NodeID, node.ID, ErrVersionNodeMismatch,
+				)
+			}
+			if version.ID == node.CurrentVersionID {
+				return nil, nil, "", false, fmt.Errorf(
+					"content version %s is the current head of node %d: %w",
+					version.ID, node.ID, ErrVersionAlreadyCurrent,
+				)
+			}
+			candidates[id] = true
+		}
+	case selector.KeepNewest > 0:
+		for index := selector.KeepNewest; index < len(versions); index++ {
+			candidates[versions[index].ID] = true
+		}
+	case selector.OlderThan > 0:
+		cutoff = time.Now().UTC().Add(-selector.OlderThan).Format(timestampLayout)
+		for _, version := range versions[1:] {
+			if version.RecordedAt <= cutoff {
+				candidates[version.ID] = true
+			}
+		}
+	case selector.AllPrior:
+		start := 1
+		if checkpointRequired {
+			start = 0
+		}
+		for _, version := range versions[start:] {
+			candidates[version.ID] = true
+		}
+	}
+
+	dependencyRetained := make(map[string]bool)
+	if !checkpointRequired {
+		changed := true
+		for changed {
+			changed = false
+			for _, version := range versions {
+				if candidates[version.ID] || version.SourceVersionID == nil {
+					continue
+				}
+				sourceID := *version.SourceVersionID
+				if candidates[sourceID] {
+					delete(candidates, sourceID)
+					dependencyRetained[sourceID] = true
+					changed = true
+				}
+			}
+		}
+	}
+	return candidates, dependencyRetained, cutoff, checkpointRequired, nil
+}
+
+func populateVersionPruneBlobStats(
+	tx *sql.Tx, result *VersionPruneResult, checkpointRequired bool,
+) error {
+	selectedByHash := make(map[string]int)
+	for _, version := range result.Candidates {
+		selectedByHash[version.BlobHash]++
+	}
+	result.UniqueBlobs = len(selectedByHash)
+	if len(selectedByHash) == 0 {
+		return nil
+	}
+	rows, err := tx.Query(`
+		SELECT v.blob_hash, COUNT(*), b.size,
+		       CASE WHEN p.blob_hash IS NULL THEN 0 ELSE 1 END,
+		       COALESCE(p.stored_len, 0)
+		FROM content_versions v
+		JOIN blobs b ON b.hash = v.blob_hash
+		LEFT JOIN blob_pack_index p ON p.blob_hash = v.blob_hash
+		GROUP BY v.blob_hash, b.size, p.blob_hash, p.stored_len`)
+	if err != nil {
+		return fmt.Errorf("inventorying version-prune blobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	stats := make(map[string]pruneBlobStats, len(selectedByHash))
+	for rows.Next() {
+		var hash string
+		var item pruneBlobStats
+		if err := rows.Scan(&hash, &item.refs, &item.size, &item.packed, &item.storedLen); err != nil {
+			return fmt.Errorf("inventorying version-prune blobs: %w", err)
+		}
+		stats[hash] = item
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("inventorying version-prune blobs: %w", err)
+	}
+	for hash, selected := range selectedByHash {
+		item, ok := stats[hash]
+		if !ok {
+			return fmt.Errorf("candidate content blob %s lacks catalog authority", hash)
+		}
+		retained := item.refs - selected
+		if checkpointRequired && hash == result.Node.BlobHash {
+			retained++
+		}
+		if retained > 0 {
+			result.SharedBlobs++
+			continue
+		}
+		result.ReleasableBlobs++
+		if item.size > math.MaxInt64-result.ReleasableBytes {
+			return errors.New("releasable content-version bytes exceed the reportable range")
+		}
+		result.ReleasableBytes += item.size
+		if item.packed {
+			result.PackedBlobsPendingRepack++
+			if item.storedLen > math.MaxInt64-result.PackedBytesPendingRepack {
+				return errors.New("packed content-version bytes exceed the reportable range")
+			}
+			result.PackedBytesPendingRepack += item.storedLen
+		} else {
+			result.LooseBlobsPendingGC++
+			if item.size > math.MaxInt64-result.LooseBytesPendingGC {
+				return errors.New("loose content-version bytes exceed the reportable range")
+			}
+			result.LooseBytesPendingGC += item.size
+		}
+	}
+	return nil
+}

--- a/internal/store/version_prune_test.go
+++ b/internal/store/version_prune_test.go
@@ -2,12 +2,27 @@ package store
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestVersionPruneBlobStatsBatchesCandidateHashes(t *testing.T) {
+	s := newTestStore(t)
+	tx, err := s.db.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	hashes := make([]string, 501)
+	for index := range hashes {
+		hashes[index] = fmt.Sprintf("%064x", index+1)
+	}
+	stats, err := versionPruneBlobStatsTx(tx, hashes)
+	require.NoError(t, err)
+	assert.Empty(t, stats)
+}
 
 func TestPruneContentVersionsPreviewRunAndMetadataRoundTrip(t *testing.T) {
 	s := newTestStore(t)
@@ -189,6 +204,7 @@ func TestPruneContentVersionsValidatesSelectorsAndTargets(t *testing.T) {
 		"several":    {KeepNewest: 1, AllPrior: true},
 		"zero age":   {OlderThan: 0},
 		"negative":   {KeepNewest: -1},
+		"too many":   {VersionIDs: make([]string, MaxVersionPruneIDs+1)},
 		"duplicate":  {VersionIDs: []string{second.CurrentVersionID, second.CurrentVersionID}},
 		"invalid id": {VersionIDs: []string{"not-a-uuid"}},
 	} {

--- a/internal/store/version_prune_test.go
+++ b/internal/store/version_prune_test.go
@@ -1,0 +1,224 @@
+package store
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPruneContentVersionsPreviewRunAndMetadataRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	created, err := s.CreateFile(ctx, s.RootID(), "history.txt", fakeHash("a1"), 10, "text/plain")
+	require.NoError(t, err)
+	replaced, second, err := s.ReplaceContent(
+		ctx, created.ID, created.Revision, fakeHash("b2"), 20, "text/plain",
+	)
+	require.NoError(t, err)
+	replaced, current, err := s.ReplaceContent(
+		ctx, created.ID, replaced.Revision, fakeHash("c3"), 30, "text/plain",
+	)
+	require.NoError(t, err)
+
+	preview, err := s.PruneContentVersions(ctx, created.ID, replaced.Revision,
+		VersionPruneSelector{KeepNewest: 2}, false)
+	require.NoError(t, err)
+	assert.False(t, preview.Run)
+	assert.False(t, preview.Changed)
+	assert.Equal(t, int64(10), preview.LogicalBytes)
+	assert.Equal(t, 1, preview.UniqueBlobs)
+	assert.Equal(t, 1, preview.ReleasableBlobs)
+	assert.Equal(t, int64(10), preview.ReleasableBytes)
+	assert.Equal(t, 1, preview.LooseBlobsPendingGC)
+	require.Len(t, preview.Candidates, 1)
+	assert.Equal(t, created.CurrentVersionID, preview.Candidates[0].ID)
+
+	_, err = s.PruneContentVersions(ctx, created.ID, created.Revision,
+		VersionPruneSelector{KeepNewest: 2}, true)
+	require.ErrorIs(t, err, ErrStaleRevision)
+
+	receipt, err := s.PruneContentVersions(ctx, created.ID, replaced.Revision,
+		VersionPruneSelector{KeepNewest: 2}, true)
+	require.NoError(t, err)
+	assert.True(t, receipt.Run)
+	assert.True(t, receipt.Changed)
+	assert.Equal(t, 1, receipt.DeletedVersions)
+	assert.Equal(t, replaced.Revision+1, receipt.Node.Revision)
+	assert.Equal(t, current.ID, receipt.Node.CurrentVersionID)
+	_, err = s.ContentVersionByID(ctx, created.CurrentVersionID)
+	require.ErrorIs(t, err, ErrNotFound)
+	versions, total, err := s.ContentVersions(ctx, created.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, versions, 2)
+	assert.Equal(t, current.ID, versions[0].ID)
+	assert.Equal(t, second.ID, versions[1].ID)
+
+	unreachable, err := s.UnreachableBlobs(ctx)
+	require.NoError(t, err)
+	require.Len(t, unreachable, 1)
+	assert.Equal(t, fakeHash("a1"), unreachable[0].Hash)
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(ctx, &exported))
+	restored := newTestStore(t)
+	require.NoError(t, restored.ImportMetadata(ctx, bytes.NewReader(exported.Bytes())))
+	restoredNode, err := restored.NodeByPath(ctx, "/history.txt")
+	require.NoError(t, err)
+	assert.Equal(t, receipt.Node.Revision, restoredNode.Revision)
+	restoredVersions, restoredTotal, err := restored.ContentVersions(ctx, restoredNode.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, restoredTotal)
+	assert.Equal(t, []string{current.ID, second.ID},
+		[]string{restoredVersions[0].ID, restoredVersions[1].ID})
+}
+
+func TestPruneContentVersionsRetainsDependenciesAndCheckpointsAllPrior(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	created, err := s.CreateFile(ctx, s.RootID(), "reverted.txt", fakeHash("d4"), 40, "text/plain")
+	require.NoError(t, err)
+	replaced, replacement, err := s.ReplaceContent(
+		ctx, created.ID, created.Revision, fakeHash("e5"), 50, "text/markdown",
+	)
+	require.NoError(t, err)
+	reverted, revertVersion, _, err := s.RevertContent(
+		ctx, created.ID, replaced.Revision, created.CurrentVersionID,
+	)
+	require.NoError(t, err)
+
+	protected, err := s.PruneContentVersions(ctx, created.ID, reverted.Revision,
+		VersionPruneSelector{VersionIDs: []string{created.CurrentVersionID}}, false)
+	require.NoError(t, err)
+	assert.Empty(t, protected.Candidates)
+	require.Len(t, protected.DependencyRetained, 1)
+	assert.Equal(t, created.CurrentVersionID, protected.DependencyRetained[0].ID)
+	unchanged, err := s.PruneContentVersions(ctx, created.ID, reverted.Revision,
+		VersionPruneSelector{VersionIDs: []string{created.CurrentVersionID}}, true)
+	require.NoError(t, err)
+	assert.False(t, unchanged.Changed)
+	assert.Equal(t, reverted.Revision, unchanged.Node.Revision)
+
+	preview, err := s.PruneContentVersions(ctx, created.ID, reverted.Revision,
+		VersionPruneSelector{AllPrior: true}, false)
+	require.NoError(t, err)
+	assert.True(t, preview.CheckpointRequired)
+	assert.Len(t, preview.Candidates, 3)
+	assert.Equal(t, int64(130), preview.LogicalBytes)
+	assert.Equal(t, 2, preview.UniqueBlobs)
+	assert.Equal(t, 1, preview.SharedBlobs,
+		"the checkpoint keeps the current/reverted blob reachable")
+	assert.Equal(t, 1, preview.ReleasableBlobs)
+	assert.Equal(t, int64(50), preview.LooseBytesPendingGC)
+
+	receipt, err := s.PruneContentVersions(ctx, created.ID, reverted.Revision,
+		VersionPruneSelector{AllPrior: true}, true)
+	require.NoError(t, err)
+	assert.True(t, receipt.Changed)
+	assert.Equal(t, 3, receipt.DeletedVersions)
+	require.NotNil(t, receipt.Checkpoint)
+	assert.Equal(t, "content_replace", receipt.Checkpoint.TransitionKind)
+	assert.Nil(t, receipt.Checkpoint.SourceVersionID)
+	assert.Equal(t, created.BlobHash, receipt.Checkpoint.BlobHash)
+	assert.Equal(t, reverted.Revision+1, receipt.Node.Revision)
+	assert.Equal(t, receipt.Checkpoint.ID, receipt.Node.CurrentVersionID)
+
+	versions, total, err := s.ContentVersions(ctx, created.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, versions, 1)
+	assert.Equal(t, receipt.Checkpoint.ID, versions[0].ID)
+	for _, id := range []string{created.CurrentVersionID, replacement.ID, revertVersion.ID} {
+		_, err = s.ContentVersionByID(ctx, id)
+		require.ErrorIs(t, err, ErrNotFound)
+	}
+	unreachable, err := s.UnreachableBlobs(ctx)
+	require.NoError(t, err)
+	require.Len(t, unreachable, 1)
+	assert.Equal(t, replacement.BlobHash, unreachable[0].Hash)
+}
+
+func TestPruneContentVersionsReportsPackedAndSharedConsequences(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	created, err := s.CreateFile(ctx, s.RootID(), "packed.txt", fakeHash("f6"), 60, "text/plain")
+	require.NoError(t, err)
+	replaced, packedVersion, err := s.ReplaceContent(
+		ctx, created.ID, created.Revision, fakeHash("a7"), 70, "text/plain",
+	)
+	require.NoError(t, err)
+	replaced, _, err = s.ReplaceContent(
+		ctx, created.ID, replaced.Revision, fakeHash("b8"), 80, "text/plain",
+	)
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, s.RootID(), "shared.txt", created.BlobHash, created.Size, "text/plain")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`INSERT INTO blob_packs(pack_id,entry_count,stored_bytes,created_at)
+		VALUES('pack-test',1,17,?)`, nowRFC3339())
+	require.NoError(t, err)
+	_, err = s.db.Exec(`INSERT INTO blob_pack_index(
+		blob_hash,pack_id,pack_offset,stored_len,raw_len,flags,crc32c
+	) VALUES(?, 'pack-test', 0, 17, ?, 0, 0)`, packedVersion.BlobHash, packedVersion.Size)
+	require.NoError(t, err)
+
+	preview, err := s.PruneContentVersions(ctx, created.ID, replaced.Revision,
+		VersionPruneSelector{KeepNewest: 1}, false)
+	require.NoError(t, err)
+	assert.Len(t, preview.Candidates, 2)
+	assert.Equal(t, 2, preview.UniqueBlobs)
+	assert.Equal(t, 1, preview.SharedBlobs)
+	assert.Equal(t, 1, preview.ReleasableBlobs)
+	assert.Equal(t, 1, preview.PackedBlobsPendingRepack)
+	assert.Equal(t, int64(17), preview.PackedBytesPendingRepack)
+	assert.Zero(t, preview.LooseBytesPendingGC)
+}
+
+func TestPruneContentVersionsValidatesSelectorsAndTargets(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	first, err := s.CreateFile(ctx, s.RootID(), "first.txt", fakeHash("c9"), 90, "text/plain")
+	require.NoError(t, err)
+	second, err := s.CreateFile(ctx, s.RootID(), "second.txt", fakeHash("da"), 100, "text/plain")
+	require.NoError(t, err)
+
+	for name, selector := range map[string]VersionPruneSelector{
+		"none":       {},
+		"several":    {KeepNewest: 1, AllPrior: true},
+		"zero age":   {OlderThan: 0},
+		"negative":   {KeepNewest: -1},
+		"duplicate":  {VersionIDs: []string{second.CurrentVersionID, second.CurrentVersionID}},
+		"invalid id": {VersionIDs: []string{"not-a-uuid"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, pruneErr := s.PruneContentVersions(ctx, second.ID, second.Revision, selector, false)
+			require.Error(t, pruneErr)
+		})
+	}
+	_, err = s.PruneContentVersions(ctx, second.ID, second.Revision,
+		VersionPruneSelector{VersionIDs: []string{second.CurrentVersionID}}, false)
+	require.ErrorIs(t, err, ErrVersionAlreadyCurrent)
+	_, err = s.PruneContentVersions(ctx, second.ID, second.Revision,
+		VersionPruneSelector{VersionIDs: []string{first.CurrentVersionID}}, false)
+	require.ErrorIs(t, err, ErrVersionNodeMismatch)
+	_, err = s.PruneContentVersions(ctx, second.ID, second.Revision,
+		VersionPruneSelector{OlderThan: time.Hour}, false)
+	require.NoError(t, err)
+
+	replaced, _, err := s.ReplaceContent(
+		ctx, second.ID, second.Revision, fakeHash("eb"), 110, "text/plain",
+	)
+	require.NoError(t, err)
+	old := time.Now().UTC().Add(-2 * time.Hour).Format(timestampLayout)
+	_, err = s.db.Exec(`UPDATE content_versions SET recorded_at = ? WHERE version_id = ?`,
+		old, second.CurrentVersionID)
+	require.NoError(t, err)
+	preview, err := s.PruneContentVersions(ctx, second.ID, replaced.Revision,
+		VersionPruneSelector{OlderThan: time.Hour}, false)
+	require.NoError(t, err)
+	require.Len(t, preview.Candidates, 1)
+	assert.Equal(t, second.CurrentVersionID, preview.Candidates[0].ID)
+	assert.NotEmpty(t, preview.Cutoff)
+}


### PR DESCRIPTION
Docbank deliberately retains every document version by default, but that neutral posture needs an equally deliberate escape hatch: large edited files should not consume storage forever when an operator or agent has decided their old history is no longer valuable. Database surgery is not an acceptable substitute because it can strand revert dependencies, race a concurrent writer, and misstate when disk space is actually recovered.

This adds one preview-first retention surface for individual version IDs, age cutoffs, newest-count limits, and complete prior-history removal. Execution is bound to the inspected stable node and revision. The current content always survives; ordinary selections preserve sources required by retained reverts, while complete-history removal replaces a current revert with a same-byte source-free checkpoint before releasing its graph.

The resulting report intentionally distinguishes logical history from physical storage. Shared blobs remain authoritative, loose orphaned bytes require GC, and packed dead bytes require GC followed by repack. Deterministic JSONL backup and restore preserve the pruned graph without resurrecting released version identities, while snapshots captured before pruning remain independent historical records.

The behavior is exercised across store, HTTP/OpenAPI, typed client, CLI and daemon replacement, both SQLite modes, race checks, backup/restore, strict documentation, and Windows compilation. Kata: `sf33`.