### PR TITLE
Enforce canonical audit record shapes

### DIFF
--- a/internal/audit/encoding.go
+++ b/internal/audit/encoding.go
@@ -144,6 +144,13 @@ func Nested(record Record) Value {
 
 // Encode returns the canonical audit-encoding bytes for a record.
 func Encode(record Record) ([]byte, error) {
+	if err := Validate(record); err != nil {
+		return nil, err
+	}
+	return encodeCanonical(record)
+}
+
+func encodeCanonical(record Record) ([]byte, error) {
 	encoded := make([]byte, 0, 256)
 	if err := appendRecord(&encoded, record, 0); err != nil {
 		return nil, err
@@ -154,6 +161,14 @@ func Encode(record Record) ([]byte, error) {
 // Hash returns SHA-256 over the canonical audit-encoding bytes.
 func Hash(record Record) ([sha256.Size]byte, error) {
 	encoded, err := Encode(record)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256(encoded), nil
+}
+
+func hashCanonical(record Record) ([sha256.Size]byte, error) {
+	encoded, err := encodeCanonical(record)
 	if err != nil {
 		return [sha256.Size]byte{}, err
 	}

--- a/internal/audit/encoding_test.go
+++ b/internal/audit/encoding_test.go
@@ -36,7 +36,7 @@ func TestAuditEncodingBoundaryGoldenHashes(t *testing.T) {
 	}
 	for name, value := range vectors {
 		t.Run(name, func(t *testing.T) {
-			digest, err := Hash(Record{Kind: "vector", Fields: []Field{{Name: "value", Value: value}}})
+			digest, err := hashCanonical(Record{Kind: "vector", Fields: []Field{{Name: "value", Value: value}}})
 			require.NoError(t, err)
 			actual := hex.EncodeToString(digest[:])
 			if actual != expected[name] {
@@ -68,14 +68,14 @@ func TestAuditEncodingGoldenRecord(t *testing.T) {
 		{Name: "b_true", Value: Bool(true)},
 		{Name: "a_false", Value: Bool(false)},
 	}}
-	encoded, err := Encode(record)
+	encoded, err := encodeCanonical(record)
 	require.NoError(t, err)
 	actual := hex.EncodeToString(encoded)
 	const expected = "000000000000000d646f6362616e6b2d61756469740000000000000001000000000000000d676f6c64656e5f7265636f7264000000000000000c0000000000000007615f66616c7365010000000000000006625f7472756502000000000000000a635f756e7369676e65640301020304050607080000000000000008645f7369676e656404fffffffffffffffe0000000000000007655f627974657305000000000000000200ff0000000000000006665f7465787406000000000000000368c3a9000000000000000b675f74696d657374616d7007000000000000001e323032362d30372d31365431323a33343a35362e3132333435363738395a0000000000000006685f757569640800112233445546778899aabbccddeeff0000000000000008695f64696765737409d1e815eb101fa389ebba332f74729f1aca88a97e8f814d007c63541fd241e5b800000000000000066a5f6c6973740a0000000000000003000300000000000000090600000000000000017800000000000000086b5f6e65737465640b0000000000000040000000000000000d646f6362616e6b2d6175646974000000000000000100000000000000056368696c640000000000000001000000000000000576616c75650200000000000000087a5f616273656e7400"
 	if actual != expected {
 		t.Fatalf("audit encoding golden bytes = %s", actual)
 	}
-	digestValue, err := Hash(record)
+	digestValue, err := hashCanonical(record)
 	require.NoError(t, err)
 	assert.Equal(t, "5c851f9926b68c6689637d82cbe8d541c2703aa6ded1f04e5bb1650cbbfbc4cc",
 		hex.EncodeToString(digestValue[:]))
@@ -83,13 +83,13 @@ func TestAuditEncodingGoldenRecord(t *testing.T) {
 
 func TestAuditEncodingSortsFieldsAndDistinguishesAbsentFromEmpty(t *testing.T) {
 	emptyText := mustText(t, "")
-	left, err := Encode(Record{Kind: "sample", Fields: []Field{
+	left, err := encodeCanonical(Record{Kind: "sample", Fields: []Field{
 		{Name: "z", Value: Bytes(nil)},
 		{Name: "a", Value: Absent()},
 		{Name: "m", Value: emptyText},
 	}})
 	require.NoError(t, err)
-	right, err := Encode(Record{Kind: "sample", Fields: []Field{
+	right, err := encodeCanonical(Record{Kind: "sample", Fields: []Field{
 		{Name: "m", Value: emptyText},
 		{Name: "z", Value: Bytes([]byte{})},
 		{Name: "a", Value: Absent()},
@@ -97,9 +97,9 @@ func TestAuditEncodingSortsFieldsAndDistinguishesAbsentFromEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, left, right)
 
-	absent, err := Encode(Record{Kind: "sample", Fields: []Field{{Name: "a", Value: Absent()}}})
+	absent, err := encodeCanonical(Record{Kind: "sample", Fields: []Field{{Name: "a", Value: Absent()}}})
 	require.NoError(t, err)
-	empty, err := Encode(Record{Kind: "sample", Fields: []Field{{Name: "a", Value: Bytes(nil)}}})
+	empty, err := encodeCanonical(Record{Kind: "sample", Fields: []Field{{Name: "a", Value: Bytes(nil)}}})
 	require.NoError(t, err)
 	assert.NotEqual(t, absent, empty)
 }
@@ -108,7 +108,7 @@ func TestAuditEncodingValuesOwnInputBytes(t *testing.T) {
 	input := []byte("before")
 	value := Bytes(input)
 	input[0] = 'x'
-	encoded, err := Encode(Record{Kind: "sample", Fields: []Field{{Name: "value", Value: value}}})
+	encoded, err := encodeCanonical(Record{Kind: "sample", Fields: []Field{{Name: "value", Value: value}}})
 	require.NoError(t, err)
 	assert.Contains(t, string(encoded), "before")
 	assert.NotContains(t, string(encoded), "xefore")
@@ -116,7 +116,7 @@ func TestAuditEncodingValuesOwnInputBytes(t *testing.T) {
 	nested := Record{Kind: "child", Fields: []Field{{Name: "value", Value: Bytes([]byte("before"))}}}
 	nestedValue := Nested(nested)
 	nested.Fields[0].Value = Bytes([]byte("after"))
-	encoded, err = Encode(Record{Kind: "sample", Fields: []Field{{Name: "child", Value: nestedValue}}})
+	encoded, err = encodeCanonical(Record{Kind: "sample", Fields: []Field{{Name: "child", Value: nestedValue}}})
 	require.NoError(t, err)
 	assert.Contains(t, string(encoded), "before")
 	assert.NotContains(t, string(encoded), "after")
@@ -162,7 +162,7 @@ func TestAuditEncodingRejectsInvalidRecordShape(t *testing.T) {
 		}},
 	} {
 		t.Run(name, func(t *testing.T) {
-			_, err := Encode(record)
+			_, err := encodeCanonical(record)
 			require.Error(t, err)
 		})
 	}
@@ -173,7 +173,7 @@ func TestAuditEncodingBoundsRecursiveValues(t *testing.T) {
 	for range maxValueDepth + 2 {
 		value = List(value)
 	}
-	_, err := Encode(Record{Kind: "deep", Fields: []Field{{Name: "value", Value: value}}})
+	_, err := encodeCanonical(Record{Kind: "deep", Fields: []Field{{Name: "value", Value: value}}})
 	require.ErrorContains(t, err, "nesting exceeds")
 }
 

--- a/internal/audit/registry.go
+++ b/internal/audit/registry.go
@@ -1,0 +1,486 @@
+package audit
+
+import (
+	"fmt"
+	"slices"
+)
+
+type schemaType byte
+
+const (
+	typeAbsent schemaType = iota
+	typeBool
+	typeUnsigned
+	typeSigned
+	typeBytes
+	typeText
+	typeTimestamp
+	typeUUID
+	typeDigest
+	typeList
+	typeRecord
+)
+
+type valueRule struct {
+	typeOf      schemaType
+	optional    bool
+	textValues  []string
+	recordKinds []string
+	listElement *valueRule
+}
+
+type fieldRule struct {
+	name string
+	rule valueRule
+}
+
+type recordSchema struct {
+	fields []fieldRule
+}
+
+var (
+	absentRule    = valueRule{typeOf: typeAbsent}
+	boolRule      = valueRule{typeOf: typeBool}
+	unsignedRule  = valueRule{typeOf: typeUnsigned}
+	bytesRule     = valueRule{typeOf: typeBytes}
+	textRule      = valueRule{typeOf: typeText}
+	timestampRule = valueRule{typeOf: typeTimestamp}
+	uuidRule      = valueRule{typeOf: typeUUID}
+	digestRule    = valueRule{typeOf: typeDigest}
+
+	optionalUnsigned  = optional(unsignedRule)
+	optionalBytes     = optional(bytesRule)
+	optionalText      = optional(textRule)
+	optionalTimestamp = optional(timestampRule)
+	optionalUUID      = optional(uuidRule)
+	optionalDigest    = optional(digestRule)
+)
+
+var recordSchemas = map[string]recordSchema{
+	"unknown_origin": schema(
+		field("node_id", unsignedRule),
+		field("parent_id", absentRule),
+		field("name", optionalBytes),
+	),
+	"known_origin": schema(
+		field("node_id", unsignedRule),
+		field("parent_id", unsignedRule),
+		field("name", bytesRule),
+	),
+	"topology_node": schema(
+		field("node_id", unsignedRule),
+		field("parent_id", optionalUnsigned),
+		field("name", bytesRule),
+		field("node_kind", textEnum("file", "dir")),
+		field("state", textEnum("live", "trash", "tombstone")),
+		field("origin", optional(recordOf("known_origin", "unknown_origin"))),
+		field("created_at", timestampRule),
+		field("modified_at", timestampRule),
+		field("trashed_at", optionalTimestamp),
+	),
+	"content_version": schema(
+		field("version_id", uuidRule),
+		field("node_id", unsignedRule),
+		field("blob_hash", digestRule),
+		field("size", unsignedRule),
+		field("media_type", optionalText),
+		field("recorded_at", timestampRule),
+		field("node_revision", unsignedRule),
+		field("introduced_operation_id", uuidRule),
+		field("transition_kind", textEnum("content_create", "content_replace", "content_revert")),
+		field("source_version_id", optionalUUID),
+	),
+	"tag_definition": schema(
+		field("tag_id", uuidRule),
+		field("name", textRule),
+	),
+	"tag_assignment": schema(
+		field("tag_id", uuidRule),
+		field("node_id", unsignedRule),
+	),
+	"ingest": schema(
+		field("ingest_id", uuidRule),
+		field("started_at", timestampRule),
+		field("source_kind", textRule),
+		field("source_desc", bytesRule),
+	),
+	"provenance_identity": schema(
+		field("node_id", unsignedRule),
+		field("ingest_id", uuidRule),
+		field("original_path", optionalBytes),
+		field("original_mtime", optionalTimestamp),
+		field("supersedes", optionalDigest),
+	),
+	"provenance": schema(
+		field("identity", digestRule),
+		field("node_id", unsignedRule),
+		field("ingest_id", uuidRule),
+		field("original_path", optionalBytes),
+		field("original_mtime", optionalTimestamp),
+		field("supersedes", optionalDigest),
+	),
+	"tag_definition_identity": schema(field("tag_id", uuidRule)),
+	"tag_assignment_identity": schema(
+		field("tag_id", uuidRule),
+		field("node_id", unsignedRule),
+	),
+	"ingest_identity":         schema(field("ingest_id", uuidRule)),
+	"provenance_identity_ref": schema(field("identity", digestRule)),
+	"event_identity": schema(
+		field("operation_id", uuidRule),
+		field("event_ordinal", unsignedRule),
+	),
+	"member_state": schema(
+		field("node_id", unsignedRule),
+		field("node_revision", unsignedRule),
+		field("current_version_id", optionalUUID),
+	),
+	"member_state_change": schema(
+		field("node_id", unsignedRule),
+		field("prior_revision", unsignedRule),
+		field("resulting_revision", unsignedRule),
+		field("prior_current_version_id", optionalUUID),
+		field("resulting_current_version_id", optionalUUID),
+	),
+	"witnessed_state": schema(field("node", recordOf("topology_node"))),
+	"witness": schema(
+		field("node_id", unsignedRule),
+		field("generation_operation_id", uuidRule),
+		field("state_digest", digestRule),
+	),
+	"baseline_binding": schema(
+		field("scope_id", uuidRule),
+		field("target_node_id", unsignedRule),
+		field("baseline_digest", digestRule),
+	),
+	"topology_change": schema(
+		field("node_id", unsignedRule),
+		field("pre", optional(recordOf("topology_node"))),
+		field("post", optional(recordOf("topology_node"))),
+	),
+	"path_state": schema(
+		field("path", bytesRule),
+		field("state", textEnum("live", "trash", "tombstone")),
+	),
+	"path_effect": schema(
+		field("scope_id", uuidRule),
+		field("member_node_id", unsignedRule),
+		field("old", recordOf("path_state")),
+		field("new", recordOf("path_state")),
+	),
+	"witness_change": schema(
+		field("node_id", unsignedRule),
+		field("generation_operation_id", uuidRule),
+		field("action", textEnum("create", "retire")),
+		field("state_digest", optionalDigest),
+	),
+	"attached_metadata_change": schema(
+		field("record_kind", attachedRecordKindRule()),
+		field("stable_identity", attachedIdentityRule()),
+		field("pre", optional(attachedRecordRule())),
+		field("post", optional(attachedRecordRule())),
+	),
+	"audit_event": schema(
+		field("event_id", digestRule),
+		field("operation_id", uuidRule),
+		field("node_id", unsignedRule),
+		field("event_kind", eventKindRule()),
+		field("scope_id", uuidRule),
+		field("target_node_id", optionalUnsigned),
+		field("attachment_kind", optional(textEnum("provenance", "tag"))),
+		field("attachment_identity", optional(eventAttachmentIdentityRule())),
+		field("source_version_id", optionalUUID),
+		field("event_ordinal", unsignedRule),
+		field("recorded_at", timestampRule),
+		field("prior_node_revision", unsignedRule),
+		field("resulting_node_revision", unsignedRule),
+		field("prior_current_version_id", optionalUUID),
+		field("resulting_current_version_id", optionalUUID),
+		field("origin", originRule()),
+		field("agent_label", optionalText),
+		field("pre", optional(eventPayloadRule())),
+		field("post", optional(eventPayloadRule())),
+		field("topology_delta", optionalDigest),
+		field("baseline_digest", optionalDigest),
+	),
+	"enrollment_baseline": schema(
+		field("vault_id", uuidRule),
+		field("scope_id", uuidRule),
+		field("target_node_id", unsignedRule),
+		field("operation_id", uuidRule),
+		field("cause", textRule),
+		field("members", listOf(unsignedRule)),
+		field("member_states", listOf(recordOf("member_state"))),
+		field("nodes", listOf(recordOf("topology_node"))),
+		field("versions", listOf(recordOf("content_version"))),
+		field("attachments", listOf(attachedRecordRule())),
+		field("witnesses", listOf(recordOf("witness"))),
+	),
+	"topology_genesis": schema(
+		field("vault_id", uuidRule),
+		field("lineage_id", uuidRule),
+		field("nodes", listOf(recordOf("topology_node"))),
+	),
+	"attached_metadata_genesis": schema(
+		field("vault_id", uuidRule),
+		field("lineage_id", uuidRule),
+		field("records", listOf(attachedRecordRule())),
+	),
+	"topology_delta": schema(
+		field("operation_id", uuidRule),
+		field("changes", listOf(recordOf("topology_change"))),
+	),
+	"path_effect_list": schema(
+		field("operation_id", uuidRule),
+		field("topology_delta", digestRule),
+		field("effects", listOf(recordOf("path_effect"))),
+	),
+	"witness_change_list": schema(
+		field("operation_id", uuidRule),
+		field("changes", listOf(recordOf("witness_change"))),
+	),
+	"attached_metadata_delta": schema(
+		field("operation_id", uuidRule),
+		field("changes", listOf(recordOf("attached_metadata_change"))),
+	),
+	"event": schema(field("event", recordOf("audit_event"))),
+	"canonical_mutation": schema(
+		field("vault_id", uuidRule),
+		field("operation_sequence", unsignedRule),
+		field("operation_id", uuidRule),
+		field("grouping_id", optionalUUID),
+		field("recorded_at", timestampRule),
+		field("origin", originRule()),
+		field("agent_label", optionalText),
+		field("events", listOf(recordOf("audit_event"))),
+		field("member_state_changes", listOf(recordOf("member_state_change"))),
+		field("baselines", listOf(recordOf("baseline_binding"))),
+		field("topology_delta", optionalDigest),
+		field("path_effect_count", unsignedRule),
+		field("path_effect_digest", optionalDigest),
+		field("witness_change_count", unsignedRule),
+		field("witness_change_digest", optionalDigest),
+		field("attached_metadata_change_count", unsignedRule),
+		field("attached_metadata_change_digest", optionalDigest),
+	),
+	"scope_chain_entry": schema(
+		field("vault_id", uuidRule),
+		field("scope_id", uuidRule),
+		field("entry_count", unsignedRule),
+		field("previous_head", optionalDigest),
+		field("mutation_hash", digestRule),
+	),
+	"allocation_genesis": schema(
+		field("vault_id", uuidRule),
+		field("lineage_id", uuidRule),
+		field("previous_head", optionalDigest),
+		field("node_id_high_water", unsignedRule),
+		field("operation_sequence_high_water", unsignedRule),
+		field("topology_count", unsignedRule),
+		field("topology_digest", digestRule),
+		field("attached_metadata_count", unsignedRule),
+		field("attached_metadata_digest", digestRule),
+	),
+	"allocation_entry": schema(
+		field("vault_id", uuidRule),
+		field("lineage_id", uuidRule),
+		field("previous_head", digestRule),
+		field("operation_sequence", unsignedRule),
+		field("operation_id", uuidRule),
+		field("allocated_node_ids", listOf(unsignedRule)),
+		field("node_id_high_water", unsignedRule),
+		field("operation_sequence_high_water", unsignedRule),
+		field("has_audited_mutation", boolRule),
+		field("mutation_hash", optionalDigest),
+		field("has_topology_change", boolRule),
+		field("topology_delta", optionalDigest),
+		field("has_witness_change", boolRule),
+		field("witness_change_count", unsignedRule),
+		field("witness_change_digest", optionalDigest),
+		field("has_attached_metadata_change", boolRule),
+		field("attached_metadata_change_count", unsignedRule),
+		field("attached_metadata_change_digest", optionalDigest),
+	),
+	"preview_token": schema(
+		field("secret", bytesRule),
+		field("vault_id", uuidRule),
+		field("scope_id", uuidRule),
+		field("target_node_id", unsignedRule),
+		field("baseline_digest", digestRule),
+		field("preview_generation", unsignedRule),
+		field("operation_id", uuidRule),
+		field("lineage_id", uuidRule),
+		field("topology_genesis_digest", optionalDigest),
+		field("attached_metadata_genesis_digest", optionalDigest),
+	),
+}
+
+// Validate checks that a record belongs to the metadata-v1 registry and has
+// its exact recursively registered shape.
+func Validate(record Record) error {
+	return validateRecord(record, 0)
+}
+
+func validateRecord(record Record, depth int) error {
+	if depth > maxValueDepth {
+		return fmt.Errorf("audit record nesting exceeds %d levels", maxValueDepth)
+	}
+	schema, ok := recordSchemas[record.Kind]
+	if !ok {
+		return fmt.Errorf("unknown metadata-v1 audit record kind %q", record.Kind)
+	}
+	provided := make(map[string]Value, len(record.Fields))
+	for _, actual := range record.Fields {
+		if !validToken(actual.Name) {
+			return fmt.Errorf("invalid field name %q in audit record %s", actual.Name, record.Kind)
+		}
+		if _, exists := provided[actual.Name]; exists {
+			return fmt.Errorf("duplicate field %q in audit record %s", actual.Name, record.Kind)
+		}
+		provided[actual.Name] = actual.Value
+	}
+	for _, expected := range schema.fields {
+		actual, exists := provided[expected.name]
+		if !exists {
+			return fmt.Errorf("missing field %s.%s", record.Kind, expected.name)
+		}
+		if err := validateValue(actual, expected.rule, record.Kind+"."+expected.name, depth); err != nil {
+			return err
+		}
+		delete(provided, expected.name)
+	}
+	if len(provided) != 0 {
+		extra := make([]string, 0, len(provided))
+		for name := range provided {
+			extra = append(extra, name)
+		}
+		slices.Sort(extra)
+		return fmt.Errorf("unexpected field %s.%s", record.Kind, extra[0])
+	}
+	return nil
+}
+
+func validateValue(value Value, rule valueRule, path string, depth int) error {
+	if depth > maxValueDepth {
+		return fmt.Errorf("audit record nesting exceeds %d levels", maxValueDepth)
+	}
+	if value.kind == kindAbsent {
+		if rule.optional || rule.typeOf == typeAbsent {
+			return nil
+		}
+		return fmt.Errorf("field %s must be %s, not absent", path, rule.describe())
+	}
+	if rule.typeOf == typeAbsent {
+		return fmt.Errorf("field %s must be absent", path)
+	}
+	if !rule.acceptsKind(value.kind) {
+		return fmt.Errorf("field %s must be %s", path, rule.describe())
+	}
+	if rule.typeOf == typeText && len(rule.textValues) != 0 &&
+		!slices.Contains(rule.textValues, string(value.data)) {
+		return fmt.Errorf("field %s contains unknown metadata-v1 code %q", path, value.data)
+	}
+	switch rule.typeOf {
+	case typeAbsent, typeBool, typeUnsigned, typeSigned, typeBytes, typeText, typeTimestamp, typeUUID, typeDigest:
+	case typeList:
+		for index, item := range value.items {
+			if err := validateValue(item, *rule.listElement, fmt.Sprintf("%s[%d]", path, index), depth+1); err != nil {
+				return err
+			}
+		}
+	case typeRecord:
+		if value.record == nil {
+			return fmt.Errorf("field %s contains a nil audit record", path)
+		}
+		if !slices.Contains(rule.recordKinds, value.record.Kind) {
+			return fmt.Errorf("field %s contains disallowed audit record kind %q", path, value.record.Kind)
+		}
+		if err := validateRecord(*value.record, depth+1); err != nil {
+			return fmt.Errorf("field %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func (rule valueRule) acceptsKind(kind valueKind) bool {
+	switch rule.typeOf {
+	case typeBool:
+		return kind == kindFalse || kind == kindTrue
+	case typeUnsigned:
+		return kind == kindUnsigned
+	case typeSigned:
+		return kind == kindSigned
+	case typeBytes:
+		return kind == kindBytes
+	case typeText:
+		return kind == kindText
+	case typeTimestamp:
+		return kind == kindTimestamp
+	case typeUUID:
+		return kind == kindUUID
+	case typeDigest:
+		return kind == kindDigest
+	case typeList:
+		return kind == kindList
+	case typeRecord:
+		return kind == kindRecord
+	default:
+		return kind == kindAbsent
+	}
+}
+
+func (rule valueRule) describe() string {
+	names := [...]string{"absent", "boolean", "unsigned integer", "signed integer", "bytes", "text", "timestamp", "UUID", "digest", "list", "nested record"}
+	return names[rule.typeOf]
+}
+
+func schema(fields ...fieldRule) recordSchema { return recordSchema{fields: fields} }
+
+func field(name string, rule valueRule) fieldRule { return fieldRule{name: name, rule: rule} }
+
+func optional(rule valueRule) valueRule {
+	rule.optional = true
+	return rule
+}
+
+func textEnum(values ...string) valueRule {
+	return valueRule{typeOf: typeText, textValues: values}
+}
+
+func recordOf(kinds ...string) valueRule {
+	return valueRule{typeOf: typeRecord, recordKinds: kinds}
+}
+
+func listOf(element valueRule) valueRule {
+	return valueRule{typeOf: typeList, listElement: &element}
+}
+
+func attachedRecordRule() valueRule {
+	return recordOf("ingest", "provenance", "tag_assignment", "tag_definition")
+}
+
+func attachedIdentityRule() valueRule {
+	return recordOf("ingest_identity", "provenance_identity_ref", "tag_assignment_identity", "tag_definition_identity")
+}
+
+func eventAttachmentIdentityRule() valueRule {
+	return recordOf("provenance_identity_ref", "tag_assignment_identity", "tag_definition_identity")
+}
+
+func attachedRecordKindRule() valueRule {
+	return textEnum("ingest", "provenance", "tag_assignment", "tag_definition")
+}
+
+func eventPayloadRule() valueRule {
+	return recordOf("content_version", "path_state", "provenance", "tag_assignment", "tag_definition", "topology_node")
+}
+
+func eventKindRule() valueRule {
+	return textEnum(
+		"audit_enroll", "audit_inherit", "content_create", "content_replace", "content_revert",
+		"node_create", "node_path", "provenance_add", "provenance_supersede", "tag_assign",
+		"tag_define", "tag_delete", "tag_rename", "tag_unassign",
+	)
+}
+
+func originRule() valueRule { return textEnum("api", "cli", "import", "job") }

--- a/internal/audit/registry_test.go
+++ b/internal/audit/registry_test.go
@@ -1,0 +1,271 @@
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditRegistryCoversFrozenMetadataV1Kinds(t *testing.T) {
+	expected := []string{
+		"allocation_entry", "allocation_genesis", "attached_metadata_change", "attached_metadata_delta",
+		"attached_metadata_genesis", "audit_event", "baseline_binding", "canonical_mutation",
+		"content_version", "enrollment_baseline", "event", "event_identity", "ingest", "ingest_identity",
+		"known_origin", "member_state", "member_state_change", "path_effect", "path_effect_list", "path_state",
+		"preview_token", "provenance", "provenance_identity", "provenance_identity_ref", "scope_chain_entry",
+		"tag_assignment", "tag_assignment_identity", "tag_definition", "tag_definition_identity",
+		"topology_change", "topology_delta", "topology_genesis", "topology_node", "unknown_origin",
+		"witness", "witness_change", "witness_change_list", "witnessed_state",
+	}
+	actual := make([]string, 0, len(recordSchemas))
+	for kind := range recordSchemas {
+		actual = append(actual, kind)
+	}
+	slices.Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestAuditRegistryAcceptsEveryRegisteredShape(t *testing.T) {
+	for kind := range recordSchemas {
+		t.Run(kind, func(t *testing.T) {
+			record := exampleRecord(t, kind)
+			require.NoError(t, Validate(record))
+			_, err := Encode(record)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAuditRegistryAcceptsEveryRegisteredEnumAndNestedKind(t *testing.T) {
+	for kind, registered := range recordSchemas {
+		for _, registeredField := range registered.fields {
+			for _, code := range registeredField.rule.textValues {
+				t.Run(kind+"/"+registeredField.name+"/"+code, func(t *testing.T) {
+					record := replaceField(exampleRecord(t, kind), registeredField.name, mustText(t, code))
+					require.NoError(t, Validate(record))
+				})
+			}
+			for _, nestedKind := range nestedKindVariants(registeredField.rule) {
+				t.Run(kind+"/"+registeredField.name+"/"+nestedKind, func(t *testing.T) {
+					value := Nested(exampleRecord(t, nestedKind))
+					if registeredField.rule.typeOf == typeList {
+						value = List(value)
+					}
+					record := replaceField(exampleRecord(t, kind), registeredField.name, value)
+					require.NoError(t, Validate(record))
+				})
+			}
+		}
+	}
+}
+
+func TestAuditRegistryRejectsUnknownAndInexactShapes(t *testing.T) {
+	valid := exampleRecord(t, "tag_definition")
+	tests := map[string]Record{
+		"unknown record": {Kind: "future_record"},
+		"missing field": {
+			Kind:   valid.Kind,
+			Fields: valid.Fields[:1],
+		},
+		"extra field": {
+			Kind:   valid.Kind,
+			Fields: append(slices.Clone(valid.Fields), Field{Name: "future", Value: Unsigned(1)}),
+		},
+		"duplicate field": {
+			Kind:   valid.Kind,
+			Fields: append(slices.Clone(valid.Fields), valid.Fields[0]),
+		},
+		"wrong type":      replaceField(valid, "tag_id", Unsigned(1)),
+		"required absent": replaceField(valid, "name", Absent()),
+	}
+	for name, record := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, Validate(record))
+			_, err := Encode(record)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestAuditRegistryEnforcesStaticTextCodes(t *testing.T) {
+	tests := []struct {
+		kind  string
+		field string
+	}{
+		{kind: "allocation_entry", field: "has_audited_mutation"},
+		{kind: "attached_metadata_change", field: "record_kind"},
+		{kind: "audit_event", field: "event_kind"},
+		{kind: "audit_event", field: "origin"},
+		{kind: "content_version", field: "transition_kind"},
+		{kind: "path_state", field: "state"},
+		{kind: "topology_node", field: "node_kind"},
+		{kind: "topology_node", field: "state"},
+		{kind: "witness_change", field: "action"},
+	}
+	for _, test := range tests {
+		t.Run(test.kind+"/"+test.field, func(t *testing.T) {
+			record := exampleRecord(t, test.kind)
+			if test.field == "has_audited_mutation" {
+				require.Error(t, Validate(replaceField(record, test.field, mustText(t, "true"))))
+				return
+			}
+			require.Error(t, Validate(replaceField(record, test.field, mustText(t, "future_code"))))
+		})
+	}
+}
+
+func TestAuditRegistryValidatesOptionalAndNestedFields(t *testing.T) {
+	for kind, registered := range recordSchemas {
+		for _, registeredField := range registered.fields {
+			if !registeredField.rule.optional {
+				continue
+			}
+			t.Run(kind+"/"+registeredField.name, func(t *testing.T) {
+				record := exampleRecord(t, kind)
+				require.NoError(t, Validate(record))
+				presentRule := registeredField.rule
+				presentRule.optional = false
+				record = replaceField(record, registeredField.name, exampleValue(t, presentRule))
+				require.NoError(t, Validate(record))
+			})
+		}
+	}
+
+	witness := exampleRecord(t, "witnessed_state")
+	witness = replaceField(witness, "node", Nested(exampleRecord(t, "known_origin")))
+	require.ErrorContains(t, Validate(witness), "disallowed")
+
+	malformedNode := exampleRecord(t, "topology_node")
+	malformedNode.Fields = malformedNode.Fields[:1]
+	witness = replaceField(exampleRecord(t, "witnessed_state"), "node", Nested(malformedNode))
+	require.ErrorContains(t, Validate(witness), "missing field")
+
+	event := replaceField(exampleRecord(t, "audit_event"), "attachment_identity",
+		Nested(exampleRecord(t, "ingest_identity")))
+	require.ErrorContains(t, Validate(event), "disallowed")
+}
+
+func TestAuditRegistryRegisteredGoldenHashes(t *testing.T) {
+	expected := map[string]string{
+		"allocation_entry":          "ad35cdd67f7cbdca45ec9c7557c32d4493f0e4df8357b7bc0a50a4513eef3c55",
+		"allocation_genesis":        "5e9d1f128e743cd3ee0df3448b57356e9d4a35c2292eaedf2850846229aebe80",
+		"attached_metadata_change":  "5b889936862fcf242e37260eb53ac40f26618d5fc8019a1ecebfc22a0afcd13e",
+		"attached_metadata_delta":   "15477e3808f187bd2ee752bd48619b49649b22d01c008eb766e9bae8b9f7738b",
+		"attached_metadata_genesis": "87a79f8c58ea993892e97db2d65b26107381de6211781fb23c1c06128011d354",
+		"audit_event":               "d94906b15e34b4fa51344e843d45c5e5d584f5db7252e4f1a4c6aaaf41e01885",
+		"baseline_binding":          "e6a91c8a8446946727344f568e2ce5a3acbf01887ea4acc582c406557d478e14",
+		"canonical_mutation":        "ba90467069c4477c40aa308252fee4fc5915a22f62a4b4d5768941814150c3b1",
+		"content_version":           "a26828acdb01d692e69ce1f2f49e6cab9dfdbe9e9c4270293ee4c47fb70c961d",
+		"enrollment_baseline":       "c25b754ff40dce7c87379e5b17ae3c8bca387c6823888049cce8a0898fd87b30",
+		"event":                     "1b90a08f1b177924abb4c73b6766080013dd099f4795e21cfad806b19e72ad4b",
+		"event_identity":            "5ee82a22ac305d21961a6646836cad10e73d1dd19e72d607566d0ea0685e70a5",
+		"ingest":                    "68d5f41b0353d9e3d965c2a645a1733b4b43e89b347ba6eb09e02f8a9903e82e",
+		"ingest_identity":           "b36f958aa06ee224f413ee8d20ac58860507c78b89b807602cecb16ab97dbb9d",
+		"known_origin":              "4ef50f1b9cc97af64788bb76bbe678ed2513e90077a9453b6223b0d9cb0a39c1",
+		"member_state":              "8d82845e3a5b381440a6853b883a7e3b75bcd184342a08dd4fb69db3dbdf751f",
+		"member_state_change":       "c57d08354146220824e0517be4c021829b2691b78aa906ca2223ba0a85ce0b4b",
+		"path_effect":               "e3a3edd499f4b82a44b52c1470172ae8b36ec452eebb8069b6f600bdc7b30997",
+		"path_effect_list":          "d6a0e010be748988dffe32e19e031b3a56b0f216aae114b38d00350667b0c3b4",
+		"path_state":                "bb358f2812f633c0139c639d0d9e1990a859bbb261f7825c30f00a42c5c10eda",
+		"preview_token":             "914b97b5a1f21c7c9336c35abd9e9ae4e3829b1e7c487e3fb2622bcd650c3372",
+		"provenance":                "a6ce16f925767af1cb677963002b7403dd0a3ed419f68252c210cd3d68d00c54",
+		"provenance_identity":       "90f92e5ea3e1b173414d4380f76114ff78431f3075e29cec20746465a2d48a72",
+		"provenance_identity_ref":   "05cc34a929455b3c8909c311ef2ae7d0ef5302c63a402708b40e0a855324b4d9",
+		"scope_chain_entry":         "e5eb564cf6632e574720f1a72ff4c8ed1717acf98acc0cb79b778ba6cc6c4a2b",
+		"tag_assignment":            "a28d9b6237cec86632df1241cfc6abeb98fc54084827b7f56ba7c5e7ef4d6805",
+		"tag_assignment_identity":   "afa085f52694144504b355e4927407171843228873f46700552fc4667c5016e4",
+		"tag_definition":            "24fa83c5e4344d70b43c5478af58f292e17340e7d0ebe5852320ebd809641db2",
+		"tag_definition_identity":   "e32925ac70e10a1154c275477c587d5f9994aa44386ecd09ca7a23aef9b6cce1",
+		"topology_change":           "c268193d2565130a5d2808f868561c97c8b2b5a20592bde7ee33815dc4d13b58",
+		"topology_delta":            "098688d0a0306900d33e1487a97349444347bf438ff82d2929c6d8ebdc07d899",
+		"topology_genesis":          "da96cc19d880e1f29ce729842389036193816cbf9f86e3341d41b2cc520792a1",
+		"topology_node":             "7b4f04dffd8225a6035f8c90eb07f71aa439c162e766a0823bf46d8d4556fefc",
+		"unknown_origin":            "d8fbfcf127bdca2cb544572e7f769001466363b385e46ea47edd37469c2e8e08",
+		"witness":                   "de552ab7b3738eb1cd3630bdd94ebba8d87a29f458f212e404362b6309e2e97f",
+		"witness_change":            "9d5d48e12013fe0176cde8bf643f72c93869566755763e9ef266d7a55f8b202b",
+		"witness_change_list":       "9434b863354252dd98311ff0cfda38a57061d08fbad6eda3b10a70e029c1a951",
+		"witnessed_state":           "f70fbacc0d76f39df805ca4d46b88aa2b05332b3cd86fe494042cb70e3de5487",
+	}
+	for kind := range recordSchemas {
+		digest, err := Hash(exampleRecord(t, kind))
+		require.NoError(t, err)
+		actual := hex.EncodeToString(digest[:])
+		assert.Equal(t, expected[kind], actual, kind)
+	}
+}
+
+func exampleRecord(t *testing.T, kind string) Record {
+	t.Helper()
+	registered, ok := recordSchemas[kind]
+	require.True(t, ok, kind)
+	record := Record{Kind: kind, Fields: make([]Field, 0, len(registered.fields))}
+	for _, registeredField := range registered.fields {
+		record.Fields = append(record.Fields, Field{
+			Name:  registeredField.name,
+			Value: exampleValue(t, registeredField.rule),
+		})
+	}
+	return record
+}
+
+func exampleValue(t *testing.T, rule valueRule) Value {
+	t.Helper()
+	if rule.optional || rule.typeOf == typeAbsent {
+		return Absent()
+	}
+	switch rule.typeOf {
+	case typeBool:
+		return Bool(true)
+	case typeUnsigned:
+		return Unsigned(1)
+	case typeSigned:
+		return Signed(-1)
+	case typeBytes:
+		return Bytes([]byte{0x00, 0xff})
+	case typeText:
+		if len(rule.textValues) != 0 {
+			return mustText(t, rule.textValues[0])
+		}
+		return mustText(t, "sample")
+	case typeTimestamp:
+		return mustTimestamp(t, "2026-07-16T12:34:56.123456789Z")
+	case typeUUID:
+		return mustUUID(t, "00112233-4455-4677-8899-aabbccddeeff")
+	case typeDigest:
+		return Digest(sha256.Sum256([]byte("sample")))
+	case typeList:
+		return List(exampleValue(t, *rule.listElement))
+	case typeRecord:
+		require.NotEmpty(t, rule.recordKinds)
+		return Nested(exampleRecord(t, rule.recordKinds[0]))
+	default:
+		require.FailNow(t, fmt.Sprintf("unsupported example rule %d", rule.typeOf))
+		return Value{}
+	}
+}
+
+func replaceField(record Record, name string, value Value) Record {
+	record = cloneRecord(record)
+	for index := range record.Fields {
+		if record.Fields[index].Name == name {
+			record.Fields[index].Value = value
+			return record
+		}
+	}
+	panic("field not found: " + name)
+}
+
+func nestedKindVariants(rule valueRule) []string {
+	if rule.typeOf == typeRecord {
+		return rule.recordKinds
+	}
+	if rule.typeOf == typeList && rule.listElement.typeOf == typeRecord {
+		return rule.listElement.recordKinds
+	}
+	return nil
+}


### PR DESCRIPTION
The canonical encoder previously accepted any syntactically valid record, leaving future audit callers able to hash shapes outside the frozen metadata-v1 contract. This change makes the contract executable before audit state begins depending on it.

The exported encoding and hashing path now requires one of the 38 registered v1 record kinds with its exact fields, optionality, scalar types, fixed text codes, and permitted nested record families. The generic primitive encoder remains private for boundary testing. Stable golden hashes cover every registered kind, alongside rejection coverage for unknown, incomplete, mistyped, and recursively malformed records.

This is deliberately only the structural gate. List ordering, relational semantics, persistence, and guarded mutations remain separate kata children so each change stays reviewable.