### PR TITLE
Enforce canonical audit collection order

### DIFF
--- a/internal/audit/ordering.go
+++ b/internal/audit/ordering.go
@@ -1,0 +1,505 @@
+package audit
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+type collectionPolicy byte
+
+const (
+	collectionNone collectionPolicy = iota
+	collectionUnsigned
+	collectionAllocatedNodeID
+	collectionNodeID
+	collectionVersion
+	collectionAttachedRecord
+	collectionWitness
+	collectionTopologyChange
+	collectionPathEffect
+	collectionWitnessChange
+	collectionAttachedChange
+	collectionEvent
+	collectionBaselineBinding
+)
+
+type orderPartKind byte
+
+const (
+	orderUnsigned orderPartKind = iota
+	orderBytes
+)
+
+type orderPart struct {
+	kind     orderPartKind
+	present  bool
+	unsigned uint64
+	data     []byte
+}
+
+type collectionKey struct {
+	sort   []orderPart
+	unique []orderPart
+}
+
+func validateCollection(items []Value, policy collectionPolicy, path string) error {
+	if policy == collectionNone {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(items))
+	var previous []orderPart
+	for index, item := range items {
+		key, err := collectionKeyFor(policy, item)
+		if err != nil {
+			return fmt.Errorf("field %s[%d]: %w", path, index, err)
+		}
+		unique := key.unique
+		if unique == nil {
+			unique = key.sort
+		}
+		encodedUnique := encodeOrderKey(unique)
+		if _, exists := seen[encodedUnique]; exists {
+			return fmt.Errorf("field %s contains duplicate canonical collection key at index %d", path, index)
+		}
+		seen[encodedUnique] = struct{}{}
+		if key.sort != nil && previous != nil && compareOrderKey(previous, key.sort) > 0 {
+			return fmt.Errorf("field %s is not in canonical order at index %d", path, index)
+		}
+		previous = key.sort
+	}
+	return nil
+}
+
+func collectionKeyFor(policy collectionPolicy, item Value) (collectionKey, error) {
+	switch policy {
+	case collectionUnsigned:
+		part := unsignedPart(item)
+		return collectionKey{sort: []orderPart{part}}, nil
+	case collectionAllocatedNodeID:
+		return collectionKey{unique: []orderPart{unsignedPart(item)}}, nil
+	case collectionNodeID:
+		record, err := collectionRecord(item)
+		if err != nil {
+			return collectionKey{}, err
+		}
+		part, err := recordUnsignedPart(record, "node_id")
+		return collectionKey{sort: []orderPart{part}}, err
+	case collectionVersion:
+		return versionCollectionKey(item)
+	case collectionAttachedRecord:
+		return attachedRecordCollectionKey(item)
+	case collectionWitness:
+		return witnessCollectionKey(item)
+	case collectionTopologyChange:
+		return topologyChangeCollectionKey(item)
+	case collectionPathEffect:
+		return pathEffectCollectionKey(item)
+	case collectionWitnessChange:
+		return witnessChangeCollectionKey(item)
+	case collectionAttachedChange:
+		return attachedChangeCollectionKey(item)
+	case collectionEvent:
+		return eventCollectionKey(item)
+	case collectionBaselineBinding:
+		return baselineBindingCollectionKey(item)
+	case collectionNone:
+		return collectionKey{}, nil
+	default:
+		return collectionKey{}, fmt.Errorf("unknown canonical collection policy %d", policy)
+	}
+}
+
+func versionCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	nodeID, err := recordUnsignedPart(record, "node_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	versionID, err := recordDataPart(record, "version_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{sort: []orderPart{nodeID, versionID}}, nil
+}
+
+func attachedRecordCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	identity, err := attachedRecordIdentity(record)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{sort: []orderPart{dataPart([]byte(record.Kind)), dataPart(identity)}}, nil
+}
+
+func witnessCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	nodeID, err := recordUnsignedPart(record, "node_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	generation, err := recordDataPart(record, "generation_operation_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{sort: []orderPart{nodeID, generation}}, nil
+}
+
+func topologyChangeCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	nodeID, err := recordUnsignedPart(record, "node_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	pre, err := recordNestedPart(record, "pre")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	post, err := recordNestedPart(record, "post")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{
+		sort:   []orderPart{nodeID, pre, post},
+		unique: []orderPart{nodeID},
+	}, nil
+}
+
+func pathEffectCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	scopeID, err := recordDataPart(record, "scope_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	memberID, err := recordUnsignedPart(record, "member_node_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	oldState, err := recordNested(record, "old")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	newState, err := recordNested(record, "new")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	oldPath, err := recordDataPart(oldState, "path")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	newPath, err := recordDataPart(newState, "path")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	oldCode, err := recordDataPart(oldState, "state")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	newCode, err := recordDataPart(newState, "state")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{
+		sort:   []orderPart{scopeID, memberID, oldPath, newPath, oldCode, newCode},
+		unique: []orderPart{scopeID, memberID},
+	}, nil
+}
+
+func witnessChangeCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	nodeID, err := recordUnsignedPart(record, "node_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	generation, err := recordDataPart(record, "generation_operation_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	action, err := recordDataPart(record, "action")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{sort: []orderPart{nodeID, generation, action}}, nil
+}
+
+func attachedChangeCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	recordKind, err := recordDataPart(record, "record_kind")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	identity, err := recordNestedPart(record, "stable_identity")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{sort: []orderPart{recordKind, identity}}, nil
+}
+
+func eventCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	nodeID, err := recordUnsignedPart(record, "node_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	eventKind, err := recordDataPart(record, "event_kind")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	scopeID, err := recordDataPart(record, "scope_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	targetID, err := recordOptionalUnsignedPart(record, "target_node_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	attachmentKind, err := recordOptionalDataPart(record, "attachment_kind")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	attachmentIdentity, err := recordNestedPart(record, "attachment_identity")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{sort: []orderPart{
+		nodeID, eventKind, scopeID, targetID, attachmentKind, attachmentIdentity,
+	}}, nil
+}
+
+func baselineBindingCollectionKey(item Value) (collectionKey, error) {
+	record, err := collectionRecord(item)
+	if err != nil {
+		return collectionKey{}, err
+	}
+	scopeID, err := recordDataPart(record, "scope_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	targetID, err := recordUnsignedPart(record, "target_node_id")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	digest, err := recordDataPart(record, "baseline_digest")
+	if err != nil {
+		return collectionKey{}, err
+	}
+	return collectionKey{sort: []orderPart{scopeID, targetID, digest}}, nil
+}
+
+func attachedRecordIdentity(record *Record) ([]byte, error) {
+	var identity Record
+	switch record.Kind {
+	case "ingest":
+		ingestID, err := recordField(record, "ingest_id")
+		if err != nil {
+			return nil, err
+		}
+		identity = Record{Kind: "ingest_identity", Fields: []Field{{Name: "ingest_id", Value: ingestID}}}
+	case "provenance":
+		value, err := recordField(record, "identity")
+		if err != nil {
+			return nil, err
+		}
+		identity = Record{Kind: "provenance_identity_ref", Fields: []Field{{Name: "identity", Value: value}}}
+	case "tag_assignment":
+		tagID, err := recordField(record, "tag_id")
+		if err != nil {
+			return nil, err
+		}
+		nodeID, err := recordField(record, "node_id")
+		if err != nil {
+			return nil, err
+		}
+		identity = Record{Kind: "tag_assignment_identity", Fields: []Field{
+			{Name: "tag_id", Value: tagID},
+			{Name: "node_id", Value: nodeID},
+		}}
+	case "tag_definition":
+		tagID, err := recordField(record, "tag_id")
+		if err != nil {
+			return nil, err
+		}
+		identity = Record{Kind: "tag_definition_identity", Fields: []Field{{Name: "tag_id", Value: tagID}}}
+	default:
+		return nil, fmt.Errorf("record kind %q has no attached-metadata identity", record.Kind)
+	}
+	return encodeCanonical(identity)
+}
+
+func collectionRecord(value Value) (*Record, error) {
+	if value.kind != kindRecord || value.record == nil {
+		return nil, errors.New("canonical collection item is not a nested record")
+	}
+	return value.record, nil
+}
+
+func recordNested(record *Record, name string) (*Record, error) {
+	value, err := recordField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	return collectionRecord(value)
+}
+
+func recordField(record *Record, name string) (Value, error) {
+	for _, field := range record.Fields {
+		if field.Name == name {
+			return field.Value, nil
+		}
+	}
+	return Value{}, fmt.Errorf("audit record %s lacks field %s", record.Kind, name)
+}
+
+func recordUnsignedPart(record *Record, name string) (orderPart, error) {
+	value, err := recordField(record, name)
+	if err != nil {
+		return orderPart{}, err
+	}
+	if value.kind != kindUnsigned {
+		return orderPart{}, fmt.Errorf("audit record %s.%s is not unsigned", record.Kind, name)
+	}
+	return unsignedPart(value), nil
+}
+
+func recordOptionalUnsignedPart(record *Record, name string) (orderPart, error) {
+	value, err := recordField(record, name)
+	if err != nil {
+		return orderPart{}, err
+	}
+	if value.kind == kindAbsent {
+		return absentPart(orderUnsigned), nil
+	}
+	if value.kind != kindUnsigned {
+		return orderPart{}, fmt.Errorf("audit record %s.%s is not optional unsigned", record.Kind, name)
+	}
+	return unsignedPart(value), nil
+}
+
+func recordDataPart(record *Record, name string) (orderPart, error) {
+	value, err := recordField(record, name)
+	if err != nil {
+		return orderPart{}, err
+	}
+	if value.kind != kindBytes && value.kind != kindText && value.kind != kindUUID && value.kind != kindDigest {
+		return orderPart{}, fmt.Errorf("audit record %s.%s is not byte-comparable", record.Kind, name)
+	}
+	return dataPart(value.data), nil
+}
+
+func recordOptionalDataPart(record *Record, name string) (orderPart, error) {
+	value, err := recordField(record, name)
+	if err != nil {
+		return orderPart{}, err
+	}
+	if value.kind == kindAbsent {
+		return absentPart(orderBytes), nil
+	}
+	if value.kind != kindBytes && value.kind != kindText && value.kind != kindUUID && value.kind != kindDigest {
+		return orderPart{}, fmt.Errorf("audit record %s.%s is not optional byte-comparable", record.Kind, name)
+	}
+	return dataPart(value.data), nil
+}
+
+func recordNestedPart(record *Record, name string) (orderPart, error) {
+	value, err := recordField(record, name)
+	if err != nil {
+		return orderPart{}, err
+	}
+	if value.kind == kindAbsent {
+		return absentPart(orderBytes), nil
+	}
+	nested, err := collectionRecord(value)
+	if err != nil {
+		return orderPart{}, err
+	}
+	encoded, err := encodeCanonical(*nested)
+	if err != nil {
+		return orderPart{}, err
+	}
+	return dataPart(encoded), nil
+}
+
+func unsignedPart(value Value) orderPart {
+	return orderPart{kind: orderUnsigned, present: true, unsigned: value.unsigned}
+}
+
+func dataPart(value []byte) orderPart {
+	return orderPart{kind: orderBytes, present: true, data: value}
+}
+
+func absentPart(kind orderPartKind) orderPart {
+	return orderPart{kind: kind}
+}
+
+func compareOrderKey(left, right []orderPart) int {
+	for index := range left {
+		if result := compareOrderPart(left[index], right[index]); result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareOrderPart(left, right orderPart) int {
+	if left.present != right.present {
+		if left.present {
+			return 1
+		}
+		return -1
+	}
+	if !left.present {
+		return 0
+	}
+	if left.kind == orderUnsigned {
+		if left.unsigned < right.unsigned {
+			return -1
+		}
+		if left.unsigned > right.unsigned {
+			return 1
+		}
+		return 0
+	}
+	return bytes.Compare(left.data, right.data)
+}
+
+func encodeOrderKey(parts []orderPart) string {
+	encoded := make([]byte, 0, len(parts)*10)
+	for _, part := range parts {
+		encoded = append(encoded, byte(part.kind))
+		if !part.present {
+			encoded = append(encoded, 0)
+			continue
+		}
+		encoded = append(encoded, 1)
+		if part.kind == orderUnsigned {
+			appendUint64(&encoded, part.unsigned)
+		} else {
+			appendFrame(&encoded, part.data)
+		}
+	}
+	return string(encoded)
+}

--- a/internal/audit/ordering_test.go
+++ b/internal/audit/ordering_test.go
@@ -1,0 +1,229 @@
+package audit
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditRegistryAssignsEveryCollectionPolicy(t *testing.T) {
+	expected := map[string]collectionPolicy{
+		"allocation_entry.allocated_node_ids":     collectionAllocatedNodeID,
+		"attached_metadata_delta.changes":         collectionAttachedChange,
+		"attached_metadata_genesis.records":       collectionAttachedRecord,
+		"canonical_mutation.baselines":            collectionBaselineBinding,
+		"canonical_mutation.events":               collectionEvent,
+		"canonical_mutation.member_state_changes": collectionNodeID,
+		"enrollment_baseline.attachments":         collectionAttachedRecord,
+		"enrollment_baseline.member_states":       collectionNodeID,
+		"enrollment_baseline.members":             collectionUnsigned,
+		"enrollment_baseline.nodes":               collectionNodeID,
+		"enrollment_baseline.versions":            collectionVersion,
+		"enrollment_baseline.witnesses":           collectionWitness,
+		"path_effect_list.effects":                collectionPathEffect,
+		"topology_delta.changes":                  collectionTopologyChange,
+		"topology_genesis.nodes":                  collectionNodeID,
+		"witness_change_list.changes":             collectionWitnessChange,
+	}
+	actual := make(map[string]collectionPolicy)
+	for kind, registered := range recordSchemas {
+		for _, registeredField := range registered.fields {
+			if registeredField.rule.typeOf != typeList {
+				continue
+			}
+			actual[kind+"."+registeredField.name] = registeredField.rule.listPolicy
+		}
+	}
+	assert.Equal(t, expected, actual)
+	for path, policy := range actual {
+		assert.NotEqual(t, collectionNone, policy, path)
+	}
+}
+
+func TestAuditCollectionPoliciesRejectReversalAndDuplicates(t *testing.T) {
+	idA := mustUUID(t, "00112233-4455-4677-8899-aabbccddee00")
+	idB := mustUUID(t, "00112233-4455-4677-8899-aabbccddee01")
+	digestA := Digest([sha256.Size]byte{})
+	digestBytes := [sha256.Size]byte{}
+	digestBytes[sha256.Size-1] = 1
+	digestB := Digest(digestBytes)
+
+	tagA := replaceField(exampleRecord(t, "tag_definition"), "tag_id", idA)
+	tagB := replaceField(exampleRecord(t, "tag_definition"), "tag_id", idB)
+	identityA := replaceField(exampleRecord(t, "tag_definition_identity"), "tag_id", idA)
+	identityB := replaceField(exampleRecord(t, "tag_definition_identity"), "tag_id", idB)
+
+	tests := []struct {
+		name   string
+		policy collectionPolicy
+		left   Value
+		right  Value
+	}{
+		{name: "unsigned", policy: collectionUnsigned, left: Unsigned(1), right: Unsigned(2)},
+		{
+			name:   "node ID",
+			policy: collectionNodeID,
+			left:   nestedWith(t, "member_state", "node_id", Unsigned(1)),
+			right:  nestedWith(t, "member_state", "node_id", Unsigned(2)),
+		},
+		{
+			name:   "version UUID",
+			policy: collectionVersion,
+			left:   nestedWith(t, "content_version", "version_id", idA),
+			right:  nestedWith(t, "content_version", "version_id", idB),
+		},
+		{name: "attached identity", policy: collectionAttachedRecord, left: Nested(tagA), right: Nested(tagB)},
+		{
+			name:   "witness generation",
+			policy: collectionWitness,
+			left:   nestedWith(t, "witness", "generation_operation_id", idA),
+			right:  nestedWith(t, "witness", "generation_operation_id", idB),
+		},
+		{
+			name:   "topology node",
+			policy: collectionTopologyChange,
+			left:   nestedWith(t, "topology_change", "node_id", Unsigned(1)),
+			right:  nestedWith(t, "topology_change", "node_id", Unsigned(2)),
+		},
+		{
+			name:   "path effect scope",
+			policy: collectionPathEffect,
+			left:   nestedWith(t, "path_effect", "scope_id", idA),
+			right:  nestedWith(t, "path_effect", "scope_id", idB),
+		},
+		{
+			name:   "witness action",
+			policy: collectionWitnessChange,
+			left:   nestedWith(t, "witness_change", "action", mustText(t, "create")),
+			right:  nestedWith(t, "witness_change", "action", mustText(t, "retire")),
+		},
+		{
+			name:   "attached change identity",
+			policy: collectionAttachedChange,
+			left: nestedWith(t, "attached_metadata_change", "stable_identity",
+				Nested(identityA)),
+			right: nestedWith(t, "attached_metadata_change", "stable_identity",
+				Nested(identityB)),
+		},
+		{
+			name:   "event attachment identity",
+			policy: collectionEvent,
+			left: nestedWith(t, "audit_event", "attachment_identity",
+				Nested(identityA)),
+			right: nestedWith(t, "audit_event", "attachment_identity",
+				Nested(identityB)),
+		},
+		{
+			name:   "baseline digest",
+			policy: collectionBaselineBinding,
+			left:   nestedWith(t, "baseline_binding", "baseline_digest", digestA),
+			right:  nestedWith(t, "baseline_binding", "baseline_digest", digestB),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, validateCollection([]Value{test.left, test.right}, test.policy, "test.items"))
+			require.ErrorContains(t,
+				validateCollection([]Value{test.right, test.left}, test.policy, "test.items"),
+				"canonical order",
+			)
+			require.ErrorContains(t,
+				validateCollection([]Value{test.left, test.left}, test.policy, "test.items"),
+				"duplicate canonical collection key",
+			)
+		})
+	}
+}
+
+func TestAuditCollectionPreservesIntrinsicAllocationOrder(t *testing.T) {
+	require.NoError(t, validateCollection(
+		[]Value{Unsigned(9), Unsigned(2), Unsigned(7)},
+		collectionAllocatedNodeID,
+		"allocation_entry.allocated_node_ids",
+	))
+	require.ErrorContains(t, validateCollection(
+		[]Value{Unsigned(9), Unsigned(2), Unsigned(9)},
+		collectionAllocatedNodeID,
+		"allocation_entry.allocated_node_ids",
+	), "duplicate canonical collection key")
+}
+
+func TestAuditEncodingRejectsNoncanonicalRegisteredCollection(t *testing.T) {
+	baseline := replaceField(exampleRecord(t, "enrollment_baseline"), "members",
+		List(Unsigned(2), Unsigned(1)))
+	require.ErrorContains(t, Validate(baseline), "canonical order")
+	_, err := Encode(baseline)
+	require.ErrorContains(t, err, "canonical order")
+}
+
+func TestAuditEventCollectionSortsAbsentSentinelsFirst(t *testing.T) {
+	absentTarget := Nested(exampleRecord(t, "audit_event"))
+	presentTarget := nestedWith(t, "audit_event", "target_node_id", Unsigned(1))
+	require.NoError(t, validateCollection(
+		[]Value{absentTarget, presentTarget}, collectionEvent, "canonical_mutation.events",
+	))
+	require.ErrorContains(t, validateCollection(
+		[]Value{presentTarget, absentTarget}, collectionEvent, "canonical_mutation.events",
+	), "canonical order")
+
+	identity := Nested(exampleRecord(t, "tag_definition_identity"))
+	absentIdentity := nestedWith(t, "audit_event", "attachment_kind", mustText(t, "tag"))
+	presentIdentity := nestedWithFields(t, "audit_event",
+		fieldValue{name: "attachment_kind", value: mustText(t, "tag")},
+		fieldValue{name: "attachment_identity", value: identity},
+	)
+	require.NoError(t, validateCollection(
+		[]Value{absentIdentity, presentIdentity}, collectionEvent, "canonical_mutation.events",
+	))
+	require.ErrorContains(t, validateCollection(
+		[]Value{presentIdentity, absentIdentity}, collectionEvent, "canonical_mutation.events",
+	), "canonical order")
+}
+
+func TestAuditCollectionsRejectDuplicateSemanticIdentities(t *testing.T) {
+	tag := exampleRecord(t, "tag_definition")
+	renamed := replaceField(tag, "name", mustText(t, "renamed"))
+	require.ErrorContains(t, validateCollection(
+		[]Value{Nested(tag), Nested(renamed)},
+		collectionAttachedRecord,
+		"enrollment_baseline.attachments",
+	), "duplicate canonical collection key")
+
+	firstChange := exampleRecord(t, "topology_change")
+	secondChange := replaceField(firstChange, "post", Nested(exampleRecord(t, "topology_node")))
+	require.ErrorContains(t, validateCollection(
+		[]Value{Nested(firstChange), Nested(secondChange)},
+		collectionTopologyChange,
+		"topology_delta.changes",
+	), "duplicate canonical collection key")
+
+	firstEffect := exampleRecord(t, "path_effect")
+	newPath := replaceField(exampleRecord(t, "path_state"), "path", Bytes([]byte("new")))
+	secondEffect := replaceField(firstEffect, "new", Nested(newPath))
+	require.ErrorContains(t, validateCollection(
+		[]Value{Nested(firstEffect), Nested(secondEffect)},
+		collectionPathEffect,
+		"path_effect_list.effects",
+	), "duplicate canonical collection key")
+}
+
+type fieldValue struct {
+	name  string
+	value Value
+}
+
+func nestedWith(t *testing.T, kind, name string, value Value) Value {
+	t.Helper()
+	return nestedWithFields(t, kind, fieldValue{name: name, value: value})
+}
+
+func nestedWithFields(t *testing.T, kind string, fields ...fieldValue) Value {
+	t.Helper()
+	record := exampleRecord(t, kind)
+	for _, field := range fields {
+		record = replaceField(record, field.name, field.value)
+	}
+	return Nested(record)
+}

--- a/internal/audit/registry.go
+++ b/internal/audit/registry.go
@@ -27,6 +27,7 @@ type valueRule struct {
 	textValues  []string
 	recordKinds []string
 	listElement *valueRule
+	listPolicy  collectionPolicy
 }
 
 type fieldRule struct {
@@ -209,39 +210,39 @@ var recordSchemas = map[string]recordSchema{
 		field("target_node_id", unsignedRule),
 		field("operation_id", uuidRule),
 		field("cause", textRule),
-		field("members", listOf(unsignedRule)),
-		field("member_states", listOf(recordOf("member_state"))),
-		field("nodes", listOf(recordOf("topology_node"))),
-		field("versions", listOf(recordOf("content_version"))),
-		field("attachments", listOf(attachedRecordRule())),
-		field("witnesses", listOf(recordOf("witness"))),
+		field("members", orderedListOf(unsignedRule, collectionUnsigned)),
+		field("member_states", orderedListOf(recordOf("member_state"), collectionNodeID)),
+		field("nodes", orderedListOf(recordOf("topology_node"), collectionNodeID)),
+		field("versions", orderedListOf(recordOf("content_version"), collectionVersion)),
+		field("attachments", orderedListOf(attachedRecordRule(), collectionAttachedRecord)),
+		field("witnesses", orderedListOf(recordOf("witness"), collectionWitness)),
 	),
 	"topology_genesis": schema(
 		field("vault_id", uuidRule),
 		field("lineage_id", uuidRule),
-		field("nodes", listOf(recordOf("topology_node"))),
+		field("nodes", orderedListOf(recordOf("topology_node"), collectionNodeID)),
 	),
 	"attached_metadata_genesis": schema(
 		field("vault_id", uuidRule),
 		field("lineage_id", uuidRule),
-		field("records", listOf(attachedRecordRule())),
+		field("records", orderedListOf(attachedRecordRule(), collectionAttachedRecord)),
 	),
 	"topology_delta": schema(
 		field("operation_id", uuidRule),
-		field("changes", listOf(recordOf("topology_change"))),
+		field("changes", orderedListOf(recordOf("topology_change"), collectionTopologyChange)),
 	),
 	"path_effect_list": schema(
 		field("operation_id", uuidRule),
 		field("topology_delta", digestRule),
-		field("effects", listOf(recordOf("path_effect"))),
+		field("effects", orderedListOf(recordOf("path_effect"), collectionPathEffect)),
 	),
 	"witness_change_list": schema(
 		field("operation_id", uuidRule),
-		field("changes", listOf(recordOf("witness_change"))),
+		field("changes", orderedListOf(recordOf("witness_change"), collectionWitnessChange)),
 	),
 	"attached_metadata_delta": schema(
 		field("operation_id", uuidRule),
-		field("changes", listOf(recordOf("attached_metadata_change"))),
+		field("changes", orderedListOf(recordOf("attached_metadata_change"), collectionAttachedChange)),
 	),
 	"event": schema(field("event", recordOf("audit_event"))),
 	"canonical_mutation": schema(
@@ -252,9 +253,9 @@ var recordSchemas = map[string]recordSchema{
 		field("recorded_at", timestampRule),
 		field("origin", originRule()),
 		field("agent_label", optionalText),
-		field("events", listOf(recordOf("audit_event"))),
-		field("member_state_changes", listOf(recordOf("member_state_change"))),
-		field("baselines", listOf(recordOf("baseline_binding"))),
+		field("events", orderedListOf(recordOf("audit_event"), collectionEvent)),
+		field("member_state_changes", orderedListOf(recordOf("member_state_change"), collectionNodeID)),
+		field("baselines", orderedListOf(recordOf("baseline_binding"), collectionBaselineBinding)),
 		field("topology_delta", optionalDigest),
 		field("path_effect_count", unsignedRule),
 		field("path_effect_digest", optionalDigest),
@@ -287,7 +288,7 @@ var recordSchemas = map[string]recordSchema{
 		field("previous_head", digestRule),
 		field("operation_sequence", unsignedRule),
 		field("operation_id", uuidRule),
-		field("allocated_node_ids", listOf(unsignedRule)),
+		field("allocated_node_ids", orderedListOf(unsignedRule, collectionAllocatedNodeID)),
 		field("node_id_high_water", unsignedRule),
 		field("operation_sequence_high_water", unsignedRule),
 		field("has_audited_mutation", boolRule),
@@ -388,6 +389,9 @@ func validateValue(value Value, rule valueRule, path string, depth int) error {
 				return err
 			}
 		}
+		if err := validateCollection(value.items, rule.listPolicy, path); err != nil {
+			return err
+		}
 	case typeRecord:
 		if value.record == nil {
 			return fmt.Errorf("field %s contains a nil audit record", path)
@@ -453,6 +457,12 @@ func recordOf(kinds ...string) valueRule {
 
 func listOf(element valueRule) valueRule {
 	return valueRule{typeOf: typeList, listElement: &element}
+}
+
+func orderedListOf(element valueRule, policy collectionPolicy) valueRule {
+	rule := listOf(element)
+	rule.listPolicy = policy
+	return rule
 }
 
 func attachedRecordRule() valueRule {


### PR DESCRIPTION
The metadata-v1 encoder now knows every legal record shape, but its set-like lists could still preserve filesystem, SQL, or map discovery order. Two honest implementations could therefore hash equivalent audit authority differently, while repeated semantic identities could enter a baseline or mutation unnoticed.

This makes collection policy part of the closed registry and rejects noncanonical or duplicate inputs before encoding. Numeric IDs sort numerically; UUIDs, digests, opaque paths, optional sentinels, and complete event tuples follow the frozen contract; attached metadata is keyed through its typed stable-identity encoding. Allocated node IDs remain intrinsically ordered, because sorting them would erase allocation lineage, while duplicate allocation is still rejected.

The encoder deliberately validates rather than silently sorting so callers cannot mistake a rewritten record for the authority they supplied. Event ordinals, count/digest relationships, relational replay, persistence, and mutation guards remain separate kata children.