### PR TITLE
Make provenance stable audit authority

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -65,7 +65,8 @@ content_versions(version_id UUID PRIMARY KEY, node_id, blob_hash, size,
                  mime_type, recorded_at, node_revision,
                  introduced_operation_id, transition_kind, source_version_id)
 ingests        (id, started_at, source_kind, source_desc)
-provenance     (node_id, ingest_id, original_path, original_mtime)
+provenance     (identity SHA-256 PRIMARY KEY, node_id, ingest_id,
+                original_path, original_mtime, supersedes)
 tags           (id UUID PRIMARY KEY, name UNIQUE, revision)
 node_tags      (node_id, tag_id)
 extracted_text (blob_hash, extractor, extractor_version, status,
@@ -80,6 +81,12 @@ UUIDv4 values. `(node_id, node_revision)` and
 `(node_id, introduced_operation_id)` are unique. See
 [Editing & Versions](editing-and-versions.md) for the read and retention
 contract.
+
+Each provenance fact has a SHA-256 identity derived from its immutable node,
+ingest, original-path, mtime, and optional predecessor fields. Current ingest
+creates an unsuperseded fact; SQL prevents rewriting ingest or provenance rows.
+JSONL preserves the identity and optional `supersedes` edge and rejects a
+dangling, cross-node, branching, or cyclic graph during import.
 
 The current schema has no audit-scope authority. The planned storage contract
 for sticky membership, mutation chains, and JSONL fidelity is maintained in
@@ -97,10 +104,10 @@ The important rules hold at the SQL layer, so they bind every writer:
   `UNIQUE(parent_id, name) WHERE trashed_at IS NULL` — trashed nodes
   never block a name.
 - **Kind/content consistency.** A CHECK constraint ties
-  `kind = 'file'` to `blob_hash IS NOT NULL` and directories to NULL.
-- **Referential integrity.** `blob_hash` references `blobs`; a blob row
-  can't be deleted while anything points at it, which is what makes GC's
-  reachability query trustworthy.
+  `kind = 'file'` to `current_version_id IS NOT NULL` and directories to NULL.
+- **Referential integrity.** Content-version `blob_hash` values reference
+  `blobs`; a blob row can't be deleted while any retained version points at it,
+  which is what makes GC's reachability query trustworthy.
 
 The store layer adds the rules SQL can't express: name validation
 (reject empty, `.`, `..`, `/`, NUL) with Unicode NFC normalization,

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -144,10 +144,11 @@ func (s *Store) IngestFile(ctx context.Context, ingestID string, parentID int64,
 	if originalMtime != "" {
 		recordedMtime = &originalMtime
 	}
-	if err := validateProvenanceRecord(metadataProvenance{
-		Type: "provenance", NodeID: 1, IngestID: ingestID,
+	provenance := metadataProvenance{
+		Type: metadataProvenanceType, NodeID: 1, IngestID: ingestID,
 		OriginalPath: originalPath, OriginalMTime: recordedMtime,
-	}); err != nil {
+	}
+	if err := validateProvenanceFields(provenance); err != nil {
 		return Node{}, false, fmt.Errorf("validating ingest provenance: %w", err)
 	}
 	var (
@@ -171,10 +172,20 @@ func (s *Store) IngestFile(ctx context.Context, ingestID string, parentID int64,
 		if err != nil {
 			return err
 		}
+		provenance.NodeID = created.ID
+		provenance.Identity, err = provenanceIdentity(provenance)
+		if err != nil {
+			return fmt.Errorf("identifying provenance for %q: %w", finalName, err)
+		}
+		if err := validateProvenanceRecord(provenance); err != nil {
+			return fmt.Errorf("validating provenance for %q: %w", finalName, err)
+		}
 		if _, err := tx.Exec(
-			`INSERT INTO provenance (node_id, ingest_id, original_path, original_mtime)
-			 VALUES (?, ?, ?, ?)`,
-			created.ID, ingestID, originalPath, recordedMtime); err != nil {
+			`INSERT INTO provenance (
+				identity, node_id, ingest_id, original_path, original_mtime, supersedes
+			 ) VALUES (?, ?, ?, ?, ?, ?)`,
+			provenance.Identity, provenance.NodeID, provenance.IngestID,
+			provenance.OriginalPath, provenance.OriginalMTime, provenance.Supersedes); err != nil {
 			return fmt.Errorf("recording provenance for %q: %w", finalName, err)
 		}
 		added = true

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -98,13 +98,19 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 	}
 }
 
-// sameOriginTx reports whether node nodeID was imported from a source whose
-// basename (normalized) equals name — i.e. the incoming file is a re-import
-// of the same logical file, not a distinct source that merely shares
-// content. A node with no provenance rows matches unconditionally: its
+// sameOriginTx reports whether node nodeID's active provenance leaf has a
+// source basename (normalized) equal to name — i.e. the incoming file is a
+// re-import of the same logical file, not a distinct source that merely
+// shares content. A node with no provenance matches unconditionally: its
 // origin is unknown, and skipping preserves the old idempotent behavior.
 func sameOriginTx(tx *sql.Tx, nodeID int64, name string) (bool, error) {
-	rows, err := tx.Query(`SELECT original_path FROM provenance WHERE node_id = ?`, nodeID)
+	rows, err := tx.Query(`
+		SELECT p.original_path
+		FROM provenance AS p
+		WHERE p.node_id = ?
+		  AND NOT EXISTS (
+			SELECT 1 FROM provenance AS successor WHERE successor.supersedes = p.identity
+		  )`, nodeID)
 	if err != nil {
 		return false, fmt.Errorf("reading provenance of node %d: %w", nodeID, err)
 	}

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -55,12 +55,12 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 		if err := rows.Scan(&sibID, &sibName, &sibHash); err != nil {
 			return "", 0, false, fmt.Errorf("scanning sibling: %w", err)
 		}
+		if sibHash == blobHash {
+			sameHash = append(sameHash, sibID)
+		}
 		n, ok := parseSuffix(sibName, base, ext)
 		if !ok {
 			continue
-		}
-		if sibHash == blobHash {
-			sameHash = append(sameHash, sibID)
 		}
 		taken[n] = true
 	}

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -47,7 +47,11 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 	}
 	defer func() { _ = rows.Close() }()
 
-	var sameHash []int64
+	type hashCandidate struct {
+		nodeID       int64
+		inNameFamily bool
+	}
+	var sameHash []hashCandidate
 	taken := map[int]bool{}
 	for rows.Next() {
 		var sibID int64
@@ -55,11 +59,11 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 		if err := rows.Scan(&sibID, &sibName, &sibHash); err != nil {
 			return "", 0, false, fmt.Errorf("scanning sibling: %w", err)
 		}
+		n, inNameFamily := parseSuffix(sibName, base, ext)
 		if sibHash == blobHash {
-			sameHash = append(sameHash, sibID)
+			sameHash = append(sameHash, hashCandidate{nodeID: sibID, inNameFamily: inNameFamily})
 		}
-		n, ok := parseSuffix(sibName, base, ext)
-		if !ok {
+		if !inNameFamily {
 			continue
 		}
 		taken[n] = true
@@ -67,13 +71,13 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 	if err := rows.Err(); err != nil {
 		return "", 0, false, fmt.Errorf("listing siblings for %q: %w", name, err)
 	}
-	for _, sibID := range sameHash {
-		imported, err := sameOriginTx(tx, sibID, name)
+	for _, candidate := range sameHash {
+		imported, err := sameOriginTx(tx, candidate.nodeID, name, candidate.inNameFamily)
 		if err != nil {
 			return "", 0, false, err
 		}
 		if imported {
-			return "", sibID, true, nil // already imported (possibly under a suffix)
+			return "", candidate.nodeID, true, nil // already imported (possibly under a suffix)
 		}
 	}
 	// Directories can occupy candidate names too; they don't carry content,
@@ -101,9 +105,10 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 // sameOriginTx reports whether node nodeID's active provenance leaf has a
 // source basename (normalized) equal to name — i.e. the incoming file is a
 // re-import of the same logical file, not a distinct source that merely
-// shares content. A node with no provenance matches unconditionally: its
-// origin is unknown, and skipping preserves the old idempotent behavior.
-func sameOriginTx(tx *sql.Tx, nodeID int64, name string) (bool, error) {
+// shares content. A node with no provenance matches only when its virtual name
+// belongs to the incoming suffix family: its origin is unknown, so the legacy
+// idempotent fallback must not suppress an unrelated same-content file.
+func sameOriginTx(tx *sql.Tx, nodeID int64, name string, allowUnknown bool) (bool, error) {
 	rows, err := tx.Query(`
 		SELECT p.original_path
 		FROM provenance AS p
@@ -135,7 +140,7 @@ func sameOriginTx(tx *sql.Tx, nodeID int64, name string) (bool, error) {
 	if err := rows.Err(); err != nil {
 		return false, fmt.Errorf("reading provenance of node %d: %w", nodeID, err)
 	}
-	return match || !sawProvenance, nil
+	return match || (!sawProvenance && allowUnknown), nil
 }
 
 // IngestFile imports one already-durable blob as a node under parentID,

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -163,6 +163,14 @@ func TestIngestIdempotencyUsesActiveProvenanceLeaf(t *testing.T) {
 		corrected.OriginalPath, corrected.OriginalMTime, corrected.Supersedes)
 	require.NoError(t, err)
 
+	// The active origin identifies the existing node even though its current
+	// virtual name belongs to a different suffix family.
+	skipped, added, err := s.IngestFile(ctx, ingestID, s.RootID(),
+		"renamed.pdf", fakeHash("a1"), 1, "application/pdf", "/corrected/renamed.pdf", "")
+	require.NoError(t, err)
+	require.False(t, added)
+	assert.Equal(t, node.ID, skipped.ID)
+
 	// The obsolete origin no longer identifies this node. An identical file
 	// imported from that basename is a distinct source and must not be skipped.
 	imported, added, err := s.IngestFile(ctx, ingestID, s.RootID(),

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,17 +94,47 @@ func TestIngestFileRecordsProvenance(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 
-	var origPath, origMtime string
+	var identity, origPath, origMtime string
+	var supersedes sql.NullString
 	require.NoError(t, s.db.QueryRow(
-		`SELECT original_path, original_mtime FROM provenance WHERE node_id = ?`,
-		n.ID).Scan(&origPath, &origMtime))
+		`SELECT identity, original_path, original_mtime, supersedes
+		 FROM provenance WHERE node_id = ?`,
+		n.ID).Scan(&identity, &origPath, &origMtime, &supersedes))
 	assert.Equal(t, "/orig/a.txt", origPath)
 	assert.Equal(t, "2026-01-02T03:04:05Z", origMtime)
+	assert.False(t, supersedes.Valid)
 	var storedIngestID string
 	require.NoError(t, s.db.QueryRow(
 		`SELECT ingest_id FROM provenance WHERE node_id = ?`, n.ID,
 	).Scan(&storedIngestID))
 	assert.Equal(t, ing, storedIngestID)
+	wantIdentity, err := provenanceIdentity(metadataProvenance{
+		Type: metadataProvenanceType, NodeID: n.ID, IngestID: ing,
+		OriginalPath: origPath, OriginalMTime: &origMtime,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, wantIdentity, identity)
+}
+
+func TestIngestAndProvenanceFactsAreImmutable(t *testing.T) {
+	s := newTestStore(t)
+	ingestID, err := s.BeginIngest(t.Context(), "cli", "source")
+	require.NoError(t, err)
+	node, added, err := s.IngestFile(t.Context(), ingestID, s.RootID(),
+		"a.txt", fakeHash("a1"), 1, "text/plain", "/source/a.txt", "")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	_, err = s.db.Exec(`UPDATE ingests SET source_desc='rewritten' WHERE id=?`, ingestID)
+	require.ErrorContains(t, err, "ingest records are immutable")
+	_, err = s.db.Exec(`UPDATE provenance SET original_path='/rewritten' WHERE node_id=?`, node.ID)
+	require.ErrorContains(t, err, "provenance records are immutable")
+
+	var sourceDesc, originalPath string
+	require.NoError(t, s.db.QueryRow(`SELECT source_desc FROM ingests WHERE id=?`, ingestID).Scan(&sourceDesc))
+	require.NoError(t, s.db.QueryRow(`SELECT original_path FROM provenance WHERE node_id=?`, node.ID).Scan(&originalPath))
+	assert.Equal(t, "source", sourceDesc)
+	assert.Equal(t, "/source/a.txt", originalPath)
 }
 
 func TestBeginIngestAllocatesDistinctUUIDs(t *testing.T) {

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -137,6 +137,42 @@ func TestIngestAndProvenanceFactsAreImmutable(t *testing.T) {
 	assert.Equal(t, "/source/a.txt", originalPath)
 }
 
+func TestIngestIdempotencyUsesActiveProvenanceLeaf(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	ingestID, err := s.BeginIngest(ctx, "cli", "source")
+	require.NoError(t, err)
+	node, added, err := s.IngestFile(ctx, ingestID, s.RootID(),
+		"report.pdf", fakeHash("a1"), 1, "application/pdf", "/obsolete/report.pdf", "")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	var priorIdentity string
+	require.NoError(t, s.db.QueryRow(
+		`SELECT identity FROM provenance WHERE node_id=?`, node.ID,
+	).Scan(&priorIdentity))
+	corrected := metadataProvenance{
+		Type: metadataProvenanceType, NodeID: node.ID, IngestID: ingestID,
+		OriginalPath: "/corrected/renamed.pdf", Supersedes: &priorIdentity,
+	}
+	corrected.Identity, err = provenanceIdentity(corrected)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`INSERT INTO provenance(
+		identity,node_id,ingest_id,original_path,original_mtime,supersedes
+	) VALUES(?,?,?,?,?,?)`, corrected.Identity, corrected.NodeID, corrected.IngestID,
+		corrected.OriginalPath, corrected.OriginalMTime, corrected.Supersedes)
+	require.NoError(t, err)
+
+	// The obsolete origin no longer identifies this node. An identical file
+	// imported from that basename is a distinct source and must not be skipped.
+	imported, added, err := s.IngestFile(ctx, ingestID, s.RootID(),
+		"report.pdf", fakeHash("a1"), 1, "application/pdf", "/other/report.pdf", "")
+	require.NoError(t, err)
+	require.True(t, added)
+	assert.NotEqual(t, node.ID, imported.ID)
+	assert.Equal(t, "report (2).pdf", imported.Name)
+}
+
 func TestBeginIngestAllocatesDistinctUUIDs(t *testing.T) {
 	s := newTestStore(t)
 	first, err := s.BeginIngest(t.Context(), "cli", "first")

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -243,3 +243,20 @@ func TestIngestFileDistinctSourceNamedLikeSuffix(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, added)
 }
+
+func TestIngestFileDoesNotMatchUnknownOriginOutsideNameFamily(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	manual, err := s.CreateFile(ctx, s.RootID(), "other.bin", fakeHash("a1"), 1, "application/octet-stream")
+	require.NoError(t, err)
+	ingestID, err := s.BeginIngest(ctx, "cli", "source")
+	require.NoError(t, err)
+
+	imported, added, err := s.IngestFile(ctx, ingestID, s.RootID(),
+		"report.pdf", fakeHash("a1"), 1, "application/pdf", "/source/report.pdf", "")
+	require.NoError(t, err)
+	require.True(t, added)
+	assert.NotEqual(t, manual.ID, imported.ID)
+	assert.Equal(t, "report.pdf", imported.Name)
+}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -131,10 +131,12 @@ type metadataIngest struct {
 
 type metadataProvenance struct {
 	Type          string  `json:"type"`
+	Identity      string  `json:"identity"`
 	NodeID        int64   `json:"node_id"`
 	IngestID      string  `json:"ingest_id"`
 	OriginalPath  string  `json:"original_path"`
 	OriginalMTime *string `json:"original_mtime"`
+	Supersedes    *string `json:"supersedes"`
 }
 
 type metadataTag struct {
@@ -346,19 +348,20 @@ func exportIngests(ctx context.Context, tx metadataQuerier, write metadataWrite)
 
 func exportProvenance(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT node_id, ingest_id, original_path, original_mtime FROM provenance
-		ORDER BY node_id, ingest_id, original_path, original_mtime`)
+		SELECT identity, node_id, ingest_id, original_path, original_mtime, supersedes
+		FROM provenance ORDER BY identity`)
 	if err != nil {
 		return fmt.Errorf("exporting provenance: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
-		r := metadataProvenance{Type: "provenance"}
-		var mtime sql.NullString
-		if err := rows.Scan(&r.NodeID, &r.IngestID, &r.OriginalPath, &mtime); err != nil {
+		r := metadataProvenance{Type: metadataProvenanceType}
+		var mtime, supersedes sql.NullString
+		if err := rows.Scan(&r.Identity, &r.NodeID, &r.IngestID, &r.OriginalPath, &mtime, &supersedes); err != nil {
 			return fmt.Errorf("scanning provenance metadata: %w", err)
 		}
 		r.OriginalMTime = stringPtr(mtime)
+		r.Supersedes = stringPtr(supersedes)
 		if err := validateProvenanceRecord(r); err != nil {
 			return fmt.Errorf("validating provenance metadata for export: %w", err)
 		}
@@ -366,7 +369,7 @@ func exportProvenance(ctx context.Context, tx metadataQuerier, write metadataWri
 			return err
 		}
 	}
-	return rowsError("provenance", rows)
+	return rowsError(metadataProvenanceType, rows)
 }
 
 func exportTags(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
@@ -625,7 +628,7 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		}
 		_, err := tx.ExecContext(ctx, `INSERT INTO ingests(id,started_at,source_kind,source_desc) VALUES(?,?,?,?)`, v.ID, v.StartedAt, v.SourceKind, v.SourceDesc)
 		return err
-	case "provenance":
+	case metadataProvenanceType:
 		var v metadataProvenance
 		if err := decodeMetadataRecord(raw, &v); err != nil {
 			return err
@@ -633,7 +636,10 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		if err := validateProvenanceRecord(v); err != nil {
 			return err
 		}
-		_, err := tx.ExecContext(ctx, `INSERT INTO provenance(node_id,ingest_id,original_path,original_mtime) VALUES(?,?,?,?)`, v.NodeID, v.IngestID, v.OriginalPath, v.OriginalMTime)
+		_, err := tx.ExecContext(ctx, `INSERT INTO provenance(
+			identity,node_id,ingest_id,original_path,original_mtime,supersedes
+		) VALUES(?,?,?,?,?,?)`, v.Identity, v.NodeID, v.IngestID, v.OriginalPath,
+			v.OriginalMTime, v.Supersedes)
 		return err
 	case "tag":
 		var v metadataTag
@@ -672,19 +678,22 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 	}
 }
 
-const metadataTypeField = "type"
+const (
+	metadataTypeField      = "type"
+	metadataProvenanceType = "provenance"
+)
 
 var metadataHeaderFields = []string{metadataTypeField, "format", "version", "vault_id", "node_sequence"}
 
 var metadataRequiredFields = map[string][]string{
-	"blob":            {metadataTypeField, "hash", "size", "created_at"},
-	"node":            {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", "created_at", "modified_at", "trashed_at", "trash_parent", "trash_name"},
-	"content_version": {metadataTypeField, "version_id", "node_id", "blob_hash", "size", "mime_type", "recorded_at", "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
-	"ingest":          {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
-	"provenance":      {metadataTypeField, "node_id", "ingest_id", "original_path", "original_mtime"},
-	"tag":             {metadataTypeField, "tag_id", "name", "revision"},
-	"node_tag":        {metadataTypeField, "node_id", "tag_id"},
-	"extracted_text":  {metadataTypeField, "blob_hash", "extractor", "extractor_version", "status", "error", "attempts", "text", "extracted_at"},
+	"blob":                 {metadataTypeField, "hash", "size", "created_at"},
+	"node":                 {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", "created_at", "modified_at", "trashed_at", "trash_parent", "trash_name"},
+	"content_version":      {metadataTypeField, "version_id", "node_id", "blob_hash", "size", "mime_type", "recorded_at", "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
+	"ingest":               {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
+	metadataProvenanceType: {metadataTypeField, "identity", "node_id", "ingest_id", "original_path", "original_mtime", "supersedes"},
+	"tag":                  {metadataTypeField, "tag_id", "name", "revision"},
+	"node_tag":             {metadataTypeField, "node_id", "tag_id"},
+	"extracted_text":       {metadataTypeField, "blob_hash", "extractor", "extractor_version", "status", "error", "attempts", "text", "extracted_at"},
 }
 
 var metadataNullableFields = map[string]map[string]bool{
@@ -692,9 +701,9 @@ var metadataNullableFields = map[string]map[string]bool{
 		"parent_id": true, "current_version_id": true, "trashed_at": true,
 		"trash_parent": true, "trash_name": true,
 	},
-	"content_version": {"mime_type": true, "source_version_id": true},
-	"provenance":      {"original_mtime": true},
-	"extracted_text":  {"error": true, "text": true},
+	"content_version":      {"mime_type": true, "source_version_id": true},
+	metadataProvenanceType: {"original_mtime": true, "supersedes": true},
+	"extracted_text":       {"error": true, "text": true},
 }
 
 func decodeMetadataRecord(raw json.RawMessage, dst any) error {
@@ -912,7 +921,27 @@ func validateIngestRecord(v metadataIngest) error {
 }
 
 func validateProvenanceRecord(v metadataProvenance) error {
-	if v.Type != "provenance" || v.NodeID <= 0 || v.OriginalPath == "" {
+	if v.Identity == "" {
+		return errors.New("invalid provenance record")
+	}
+	if err := validateProvenanceFields(v); err != nil {
+		return err
+	}
+	if _, err := packstore.ParseHash(v.Identity); err != nil {
+		return fmt.Errorf("invalid provenance identity: %w", err)
+	}
+	want, err := provenanceIdentity(v)
+	if err != nil {
+		return fmt.Errorf("computing provenance identity: %w", err)
+	}
+	if v.Identity != want {
+		return errors.New("provenance identity does not match its immutable fields")
+	}
+	return nil
+}
+
+func validateProvenanceFields(v metadataProvenance) error {
+	if v.Type != metadataProvenanceType || v.NodeID <= 0 || v.OriginalPath == "" {
 		return errors.New("invalid provenance record")
 	}
 	if err := validateUUIDv4(v.IngestID); err != nil {
@@ -922,7 +951,14 @@ func validateProvenanceRecord(v metadataProvenance) error {
 		return err
 	}
 	if v.OriginalMTime != nil {
-		return validateProvenanceTime(*v.OriginalMTime)
+		if err := validateProvenanceTime(*v.OriginalMTime); err != nil {
+			return err
+		}
+	}
+	if v.Supersedes != nil {
+		if _, err := packstore.ParseHash(*v.Supersedes); err != nil {
+			return fmt.Errorf("invalid superseded provenance identity: %w", err)
+		}
 	}
 	return nil
 }
@@ -1145,6 +1181,23 @@ func validateMetadataRelations(ctx context.Context, tx metadataQuerier) error {
 			)`},
 		{"extracted text references missing blob authority", `
 			SELECT EXISTS(SELECT 1 FROM extracted_text e LEFT JOIN blobs b ON b.hash=e.blob_hash WHERE b.hash IS NULL)`},
+		{"provenance supersedes a missing fact", `
+			SELECT EXISTS(
+			  SELECT 1 FROM provenance p LEFT JOIN provenance prior ON prior.identity=p.supersedes
+			  WHERE p.supersedes IS NOT NULL AND prior.identity IS NULL
+			)`},
+		{"provenance supersedes a fact on another node", `
+			SELECT EXISTS(
+			  SELECT 1 FROM provenance p JOIN provenance prior ON prior.identity=p.supersedes
+			  WHERE prior.node_id != p.node_id
+			)`},
+		{"provenance supersession graph contains a cycle", `
+			WITH RECURSIVE reachable(identity) AS (
+			  SELECT identity FROM provenance WHERE supersedes IS NULL
+			  UNION ALL
+			  SELECT p.identity FROM provenance p JOIN reachable r ON p.supersedes=r.identity
+			)
+			SELECT (SELECT COUNT(*) FROM reachable) != (SELECT COUNT(*) FROM provenance)`},
 	}
 	for _, check := range checks {
 		var failed bool

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -69,6 +69,8 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	assert.Contains(t, first.String(), `{"type":"meta","format":"docbank-metadata","version":1,"vault_id":"`+
 		sourceVaultID+`","node_sequence":100}`)
 	assert.Contains(t, first.String(), `"original_mtime":"2026-02-03T04:05:06.12Z"`)
+	assert.Contains(t, first.String(), `"type":"provenance","identity":"`)
+	assert.Contains(t, first.String(), `"supersedes":null`)
 	assert.Contains(t, first.String(), `{"type":"node","id":7,"parent_id":1,"name":"Projects","kind":"dir"`)
 	assert.NotContains(t, first.String(), "blob_pack_index")
 	assert.NotContains(t, first.String(), "metadata-pack")
@@ -128,6 +130,104 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	created, err := target.Mkdir(ctx, target.RootID(), "after-restore")
 	require.NoError(t, err)
 	assert.Greater(t, created.ID, int64(100), "AUTOINCREMENT must not reuse any historically allocated ID")
+}
+
+func TestImportMetadataRejectsInvalidProvenanceAuthorityAndRollsBack(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	prior := firstProvenanceRecord(t, exported.Bytes())
+
+	dangling := strings.Repeat("d", 64)
+	crossNode := metadataProvenance{
+		Type: metadataProvenanceType, NodeID: 11, IngestID: prior.IngestID,
+		OriginalPath: "/source/cross-node.txt", Supersedes: &prior.Identity,
+	}
+	crossNode.Identity, err = provenanceIdentity(crossNode)
+	require.NoError(t, err)
+	firstSuccessor := metadataProvenance{
+		Type: metadataProvenanceType, NodeID: prior.NodeID, IngestID: prior.IngestID,
+		OriginalPath: "/source/corrected-one.txt", Supersedes: &prior.Identity,
+	}
+	firstSuccessor.Identity, err = provenanceIdentity(firstSuccessor)
+	require.NoError(t, err)
+	secondSuccessor := metadataProvenance{
+		Type: metadataProvenanceType, NodeID: prior.NodeID, IngestID: prior.IngestID,
+		OriginalPath: "/source/corrected-two.txt", Supersedes: &prior.Identity,
+	}
+	secondSuccessor.Identity, err = provenanceIdentity(secondSuccessor)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{
+			name: "identity mismatch",
+			input: mutateFirstProvenanceRecord(t, exported.Bytes(), false, func(record *metadataProvenance) {
+				record.OriginalPath = "/source/altered.txt"
+			}),
+			want: "provenance identity does not match",
+		},
+		{
+			name: "dangling predecessor",
+			input: mutateFirstProvenanceRecord(t, exported.Bytes(), true, func(record *metadataProvenance) {
+				record.Supersedes = &dangling
+			}),
+			want: "provenance supersedes a missing fact",
+		},
+		{
+			name:  "cross-node predecessor",
+			input: appendMetadataRecords(t, exported.Bytes(), crossNode),
+			want:  "provenance supersession must stay on one node",
+		},
+		{
+			name:  "two direct successors",
+			input: appendMetadataRecords(t, exported.Bytes(), firstSuccessor, secondSuccessor),
+			want:  "UNIQUE constraint failed",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target, openErr := Open(filepath.Join(t.TempDir(), "target.db"))
+			require.NoError(t, openErr)
+			t.Cleanup(func() { require.NoError(t, target.Close()) })
+			targetVaultID := target.VaultID()
+			importErr := target.ImportMetadata(t.Context(), bytes.NewReader(test.input))
+			require.ErrorContains(t, importErr, test.want)
+			assert.Equal(t, targetVaultID, target.VaultID())
+			var nodes, provenanceRows int64
+			require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
+			require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM provenance`).Scan(&provenanceRows))
+			assert.Equal(t, int64(1), nodes)
+			assert.Zero(t, provenanceRows)
+		})
+	}
+}
+
+func TestMetadataRelationsRejectProvenanceCycle(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	firstIdentity := strings.Repeat("d", 64)
+	secondIdentity := strings.Repeat("e", 64)
+	_, err = source.db.Exec(`INSERT INTO provenance(
+		identity,node_id,ingest_id,original_path,original_mtime,supersedes
+	) VALUES
+		(?,10,?,'/cycle/one',NULL,?),
+		(?,10,?,'/cycle/two',NULL,?)`,
+		firstIdentity, metadataIngestID, secondIdentity,
+		secondIdentity, metadataIngestID, firstIdentity)
+	require.NoError(t, err)
+	require.ErrorContains(t,
+		validateMetadataRelations(t.Context(), source.db),
+		"provenance supersession graph contains a cycle",
+	)
 }
 
 func TestImportMetadataRejectsDanglingContentAndRollsBack(t *testing.T) {
@@ -787,6 +887,12 @@ func TestImportMetadataRejectsDuplicateStableRecordIDsTransactionally(t *testing
 func seedMetadataRoundTrip(t *testing.T, s *Store) {
 	t.Helper()
 	ctx := context.Background()
+	originalMTime := "2025-12-31T23:00:00.12Z"
+	provenanceID, err := provenanceIdentity(metadataProvenance{
+		Type: metadataProvenanceType, NodeID: 10, IngestID: metadataIngestID,
+		OriginalPath: "/source/report.txt", OriginalMTime: &originalMTime,
+	})
+	require.NoError(t, err)
 	require.NoError(t, s.withTx(ctx, func(tx *sql.Tx) error {
 		statements := []string{
 			`UPDATE nodes SET created_at='2026-01-01T00:00:00.000000000Z', modified_at='2026-01-02T00:00:00.000000000Z' WHERE id=1`,
@@ -817,8 +923,8 @@ func seedMetadataRoundTrip(t *testing.T, s *Store) {
 			  '2026-01-10T00:00:00.000000000Z',1,'cccccccc-cccc-4ccc-8ccc-cccccccccccc','content_create',NULL)`,
 			`INSERT INTO ingests(id,started_at,source_kind,source_desc)
 				 VALUES('` + metadataIngestID + `','2026-01-08T00:00:00.000000000Z','filesystem','dropbox')`,
-			`INSERT INTO provenance(node_id,ingest_id,original_path,original_mtime)
-				 VALUES(10,'` + metadataIngestID + `','/source/report.txt','2025-12-31T23:00:00.12Z')`,
+			`INSERT INTO provenance(identity,node_id,ingest_id,original_path,original_mtime,supersedes)
+				 VALUES('` + provenanceID + `',10,'` + metadataIngestID + `','/source/report.txt','` + originalMTime + `',NULL)`,
 			`INSERT INTO tags(id,name,revision) VALUES('` + metadataTagID + `','important',7)`,
 			`INSERT INTO node_tags(node_id,tag_id) VALUES(10,'` + metadataTagID + `')`,
 			`INSERT INTO extracted_text(blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at)
@@ -838,4 +944,67 @@ func seedMetadataRoundTrip(t *testing.T, s *Store) {
 		}
 		return nil
 	}))
+}
+
+func firstProvenanceRecord(t *testing.T, input []byte) metadataProvenance {
+	t.Helper()
+	for line := range bytes.SplitSeq(bytes.TrimSpace(input), []byte{'\n'}) {
+		var kind struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &kind))
+		if kind.Type != metadataProvenanceType {
+			continue
+		}
+		var record metadataProvenance
+		require.NoError(t, json.Unmarshal(line, &record))
+		return record
+	}
+	require.FailNow(t, "metadata lacks provenance record")
+	return metadataProvenance{}
+}
+
+func mutateFirstProvenanceRecord(
+	t *testing.T,
+	input []byte,
+	recomputeIdentity bool,
+	mutate func(*metadataProvenance),
+) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	for index, line := range lines {
+		var kind struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &kind))
+		if kind.Type != metadataProvenanceType {
+			continue
+		}
+		var record metadataProvenance
+		require.NoError(t, json.Unmarshal(line, &record))
+		mutate(&record)
+		if recomputeIdentity {
+			var err error
+			record.Identity, err = provenanceIdentity(record)
+			require.NoError(t, err)
+		}
+		var err error
+		lines[index], err = json.Marshal(record)
+		require.NoError(t, err)
+		return append(bytes.Join(lines, []byte{'\n'}), '\n')
+	}
+	require.FailNow(t, "metadata lacks provenance record")
+	return nil
+}
+
+func appendMetadataRecords(t *testing.T, input []byte, records ...any) []byte {
+	t.Helper()
+	result := bytes.Clone(input)
+	for _, record := range records {
+		encoded, err := json.Marshal(record)
+		require.NoError(t, err)
+		result = append(result, encoded...)
+		result = append(result, '\n')
+	}
+	return result
 }

--- a/internal/store/provenance.go
+++ b/internal/store/provenance.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func provenanceIdentity(value metadataProvenance) (string, error) {
+	if value.NodeID <= 0 {
+		return "", fmt.Errorf("invalid provenance node ID %d", value.NodeID)
+	}
+	nodeID := uint64(value.NodeID)
+	ingestID, err := audit.UUID(value.IngestID)
+	if err != nil {
+		return "", err
+	}
+	originalMTime := audit.Absent()
+	if value.OriginalMTime != nil {
+		parsed, parseErr := time.Parse(time.RFC3339Nano, *value.OriginalMTime)
+		if parseErr != nil {
+			return "", fmt.Errorf("parsing original mtime: %w", parseErr)
+		}
+		originalMTime, err = audit.Timestamp(parsed.UTC().Format(timestampLayout))
+		if err != nil {
+			return "", err
+		}
+	}
+	supersedes := audit.Absent()
+	if value.Supersedes != nil {
+		supersedes, err = audit.DigestHex(*value.Supersedes)
+		if err != nil {
+			return "", err
+		}
+	}
+	digest, err := audit.Hash(audit.Record{Kind: "provenance_identity", Fields: []audit.Field{
+		{Name: "node_id", Value: audit.Unsigned(nodeID)},
+		{Name: "ingest_id", Value: ingestID},
+		{Name: "original_path", Value: audit.Bytes([]byte(value.OriginalPath))},
+		{Name: "original_mtime", Value: originalMTime},
+		{Name: "supersedes", Value: supersedes},
+	}})
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/internal/store/provenance_test.go
+++ b/internal/store/provenance_test.go
@@ -1,0 +1,20 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvenanceIdentityGolden(t *testing.T) {
+	originalMTime := "2026-01-02T03:04:05.12Z"
+	identity, err := provenanceIdentity(metadataProvenance{
+		Type:          metadataProvenanceType,
+		NodeID:        42,
+		IngestID:      "00112233-4455-4677-8899-aabbccddeeff",
+		OriginalPath:  "/source/report.txt",
+		OriginalMTime: &originalMTime,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "2d6ccdf760691482e62a95cb57623282c919aaba7a69808ff6da2e2c7af95516", identity)
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -104,13 +104,39 @@ CREATE TABLE IF NOT EXISTS ingests (
 );
 
 CREATE TABLE IF NOT EXISTS provenance (
-    node_id       INTEGER NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
-    ingest_id     TEXT NOT NULL REFERENCES ingests(id),
-    original_path TEXT NOT NULL,
-    original_mtime TEXT
+    identity       TEXT PRIMARY KEY NOT NULL,
+    node_id        INTEGER NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    ingest_id      TEXT NOT NULL REFERENCES ingests(id),
+    original_path  TEXT NOT NULL,
+    original_mtime TEXT,
+    supersedes     TEXT REFERENCES provenance(identity)
+        DEFERRABLE INITIALLY DEFERRED
 );
 
 CREATE INDEX IF NOT EXISTS provenance_node ON provenance(node_id);
+CREATE UNIQUE INDEX IF NOT EXISTS provenance_direct_successor
+    ON provenance(supersedes) WHERE supersedes IS NOT NULL;
+
+-- Ingest and provenance facts are append-only authority. Corrections add a
+-- new provenance fact linked through supersedes; they never rewrite history.
+CREATE TRIGGER IF NOT EXISTS ingests_immutable_update
+BEFORE UPDATE ON ingests BEGIN
+    SELECT RAISE(ABORT, 'ingest records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS provenance_immutable_update
+BEFORE UPDATE ON provenance BEGIN
+    SELECT RAISE(ABORT, 'provenance records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS provenance_same_node_insert
+BEFORE INSERT ON provenance
+WHEN NEW.supersedes IS NOT NULL AND EXISTS (
+    SELECT 1 FROM provenance prior
+    WHERE prior.identity = NEW.supersedes AND prior.node_id != NEW.node_id
+) BEGIN
+    SELECT RAISE(ABORT, 'provenance supersession must stay on one node');
+END;
 
 CREATE TABLE IF NOT EXISTS tags (
     id       TEXT PRIMARY KEY NOT NULL,


### PR DESCRIPTION
Audit enrollment needs provenance facts that can be named, hashed, retained, and restored without ambiguity. The existing provenance rows were anonymous and mutable, so an audit baseline could not safely bind attached source history.

This change gives each provenance fact a deterministic SHA-256 identity derived with the canonical audit encoder, makes ingest and provenance facts append-only, and supports an optional immutable supersession edge. Metadata JSONL now preserves that authority and transactionally rejects identity mismatches plus dangling, cross-node, branching, or cyclic supersession graphs. Initial filesystem ingest creates an unsuperseded fact.

The schema changes directly because Docbank remains pre-public-release and does not carry compatibility migrations. The scope intentionally stops at the authority the audit model already requires: correction APIs, generalized source metadata, external pins, audit scopes/events, and new public surfaces remain separate work.