### PR TITLE
Expose verified embedded content history

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ docbank is pre-1.0; interfaces and storage migrations may still evolve.
 
 ## Unreleased
 
+- Embedded Go applications can page immutable content history with `Versions`
+  and open any historical version through the verified read contract with
+  `OpenVersionContent`.
 - Windows is a supported vault platform rather than a compile-only target:
   daemon discovery and detached startup, owner-private vaults, no-follow
   ingest, overlapping vault/restore exclusion, backup, restore, and self-update

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -67,6 +67,13 @@ version while preserving the node ID. Supply `PutOptions.Expected` when the
 caller already knows the SHA-256 and byte count and wants Docbank to reject a
 mismatched stream before granting metadata authority.
 
+`Put` is an idempotent content write, not an integrity repair primitive. Kit's
+structural dedup can reuse an existing canonical representation without hashing
+it, and packed catalog authority can remain selected over a loose copy.
+Consumers repairing a corrupt current version must publish different bytes or
+use Docbank verify/restore; they must verify the resulting head before treating
+its bytes as authoritative.
+
 `vault.ID()` returns the archive's stable UUID. JSONL backup and restore
 preserve that identity even when the restored vault has a different filesystem
 root; applications can therefore distinguish logical archives without treating

--- a/pkg/docbank.go
+++ b/pkg/docbank.go
@@ -198,6 +198,28 @@ func (v *Vault) Children(
 	return page, nil
 }
 
+func (v *Vault) Versions(
+	ctx context.Context, nodeID int64, opts VersionsOptions,
+) (VersionsPage, error) {
+	if err := v.begin(); err != nil {
+		return VersionsPage{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	limit := opts.Limit
+	if limit == 0 {
+		limit = DefaultVersionsLimit
+	}
+	versions, total, err := v.metadata.ContentVersions(ctx, nodeID, limit, opts.Offset)
+	if err != nil {
+		return VersionsPage{}, err
+	}
+	page := VersionsPage{Items: make([]ContentVersion, 0, len(versions)), Total: total, Limit: limit, Offset: opts.Offset}
+	for _, version := range versions {
+		page.Items = append(page.Items, fromStoreVersion(version))
+	}
+	return page, nil
+}
+
 // PutOptions controls one embedded content write. Expected is optional; when
 // present, no node or version authority is granted unless both fields match
 // the independently computed durable bytes.

--- a/pkg/docbank.go
+++ b/pkg/docbank.go
@@ -382,6 +382,34 @@ func (v *Vault) OpenContent(ctx context.Context, virtualPath string) (*Content, 
 	}, nil
 }
 
+// OpenVersionContent opens the catalog-authorized bytes for one immutable
+// content version. The reader holds a vault lease and uses the same verified
+// read contract as OpenContent.
+func (v *Vault) OpenVersionContent(ctx context.Context, versionID string) (*VersionContent, error) {
+	if err := v.begin(); err != nil {
+		return nil, err
+	}
+	version, err := v.metadata.ContentVersionByID(ctx, versionID)
+	if err != nil {
+		v.lifecycle.RUnlock()
+		return nil, err
+	}
+	reader, size, err := v.blobs.OpenStreamContext(ctx, version.BlobHash)
+	if err != nil {
+		v.lifecycle.RUnlock()
+		return nil, err
+	}
+	if size != version.Size {
+		closeErr := reader.Close()
+		v.lifecycle.RUnlock()
+		return nil, errors.Join(fmt.Errorf("catalog size %d does not match version size %d", size, version.Size), closeErr)
+	}
+	return &VersionContent{
+		Version: fromStoreVersion(version),
+		Reader:  &leasedReader{VerifiedReadCloser: reader, release: v.lifecycle.RUnlock},
+	}, nil
+}
+
 // Pack explicitly moves authorized loose content into managed immutable packs.
 // It also performs the same reconciliation and repair pass as the standalone
 // storage pack operation. Ordinary Put calls remain loose until Pack is called.

--- a/pkg/docbank_test.go
+++ b/pkg/docbank_test.go
@@ -144,6 +144,76 @@ func TestChildrenReturnsBoundedStablePages(t *testing.T) {
 	require.Error(err)
 }
 
+func TestEmbeddedVersions(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver docsqlite.Driver
+	}{
+		{name: "build default"},
+		{name: "pure Go", driver: modernc.Driver{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			testEmbeddedVersions(t, test.driver)
+		})
+	}
+}
+
+func testEmbeddedVersions(t *testing.T, driver docsqlite.Driver) {
+	t.Helper()
+	require := require.New(t)
+	ctx := t.Context()
+	vault, err := Open(ctx, OpenOptions{Root: t.TempDir(), SQLite: driver})
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(vault.Close()) })
+
+	receipt, err := vault.Put(ctx, "/notes/entry.md", strings.NewReader("first\n"), PutOptions{})
+	require.NoError(err)
+	second, err := vault.Put(ctx, "/notes/entry.md", strings.NewReader("second\n"), PutOptions{})
+	require.NoError(err)
+	third, err := vault.Put(ctx, "/notes/entry.md", strings.NewReader("third\n"), PutOptions{})
+	require.NoError(err)
+
+	page, err := vault.Versions(ctx, receipt.Node.ID, VersionsOptions{Limit: 2})
+	require.NoError(err)
+	require.Equal(3, page.Total)
+	require.Equal(2, page.Limit)
+	require.Zero(page.Offset)
+	require.Len(page.Items, 2)
+	require.Equal([]string{third.Version.ID, second.Version.ID}, []string{
+		page.Items[0].ID, page.Items[1].ID,
+	})
+
+	secondPage, err := vault.Versions(ctx, receipt.Node.ID, VersionsOptions{Limit: 2, Offset: 2})
+	require.NoError(err)
+	require.Equal(3, secondPage.Total)
+	require.Equal(2, secondPage.Limit)
+	require.Equal(2, secondPage.Offset)
+	require.Len(secondPage.Items, 1)
+	require.Equal([]string{receipt.Version.ID}, []string{secondPage.Items[0].ID})
+
+	defaultPage, err := vault.Versions(ctx, receipt.Node.ID, VersionsOptions{})
+	require.NoError(err)
+	require.Equal(DefaultVersionsLimit, defaultPage.Limit)
+	require.Len(defaultPage.Items, 3)
+
+	directory, err := vault.Stat(ctx, "/notes")
+	require.NoError(err)
+	_, err = vault.Versions(ctx, directory.ID, VersionsOptions{})
+	require.ErrorIs(err, ErrNotFile)
+	_, err = vault.Versions(ctx, 1<<62, VersionsOptions{})
+	require.ErrorIs(err, ErrNotFound)
+	_, err = vault.Versions(ctx, receipt.Node.ID, VersionsOptions{Limit: MaxVersionsLimit + 1})
+	require.Error(err)
+	_, err = vault.Versions(ctx, receipt.Node.ID, VersionsOptions{Offset: -1})
+	require.Error(err)
+
+	require.NoError(vault.Close())
+	_, err = vault.Versions(ctx, receipt.Node.ID, VersionsOptions{})
+	require.ErrorIs(err, ErrClosed)
+}
+
 func TestPackBoundsWorkAndPreservesVerifiedContent(t *testing.T) {
 	require := require.New(t)
 	vault, err := Open(t.Context(), OpenOptions{Root: t.TempDir()})

--- a/pkg/docbank_test.go
+++ b/pkg/docbank_test.go
@@ -5,10 +5,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/packstore"
 
 	docsqlite "go.kenn.io/docbank/pkg/sqlite"
 	"go.kenn.io/docbank/pkg/sqlite/modernc"
@@ -212,6 +215,93 @@ func testEmbeddedVersions(t *testing.T, driver docsqlite.Driver) {
 	require.NoError(vault.Close())
 	_, err = vault.Versions(ctx, receipt.Node.ID, VersionsOptions{})
 	require.ErrorIs(err, ErrClosed)
+}
+
+func TestEmbeddedVersionContent(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver docsqlite.Driver
+	}{
+		{name: "build default"},
+		{name: "pure Go", driver: modernc.Driver{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			testEmbeddedVersionContent(t, test.driver)
+		})
+	}
+}
+
+func testEmbeddedVersionContent(t *testing.T, driver docsqlite.Driver) {
+	t.Helper()
+	require := require.New(t)
+	ctx := t.Context()
+	vault, err := Open(ctx, OpenOptions{Root: t.TempDir(), SQLite: driver})
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(vault.Close()) })
+
+	first, err := vault.Put(ctx, "/notes/entry.md", strings.NewReader("first\n"), PutOptions{})
+	require.NoError(err)
+	_, err = vault.Put(ctx, "/notes/entry.md", strings.NewReader("second\n"), PutOptions{})
+	require.NoError(err)
+
+	content, err := vault.OpenVersionContent(ctx, first.Version.ID)
+	require.NoError(err)
+	got, err := io.ReadAll(content.Reader)
+	require.NoError(err)
+	require.NoError(content.Reader.Verify())
+	require.NoError(content.Reader.Close())
+	require.Equal([]byte("first\n"), got)
+	require.Equal(first.Version.ID, content.Version.ID)
+
+	_, err = vault.OpenVersionContent(ctx, "00000000-0000-4000-8000-000000000000")
+	require.ErrorIs(err, ErrNotFound)
+
+	require.NoError(vault.Close())
+	_, err = vault.OpenVersionContent(ctx, first.Version.ID)
+	require.ErrorIs(err, ErrClosed)
+}
+
+func TestEmbeddedVersionContentRejectsSizeMismatch(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	vault, err := Open(t.Context(), OpenOptions{Root: root})
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(vault.Close()) })
+
+	first, err := vault.Put(
+		t.Context(), "/notes/entry.md", strings.NewReader("first\n"), PutOptions{})
+	require.NoError(err)
+	blobPath := filepath.Join(root, "blobs", first.Version.BlobHash[:2], first.Version.BlobHash)
+	require.NoError(os.WriteFile(blobPath, []byte("short"), 0o600))
+
+	_, err = vault.OpenVersionContent(t.Context(), first.Version.ID)
+	require.ErrorContains(err, "catalog size 5 does not match version size 6")
+}
+
+func TestEmbeddedVersionContentRejectsSameSizeCorruption(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	vault, err := Open(t.Context(), OpenOptions{Root: root})
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(vault.Close()) })
+
+	first, err := vault.Put(
+		t.Context(), "/notes/entry.md", strings.NewReader("first\n"), PutOptions{})
+	require.NoError(err)
+	blobPath := filepath.Join(root, "blobs", first.Version.BlobHash[:2], first.Version.BlobHash)
+	corrupt := []byte("wrong\n")
+	require.Len(corrupt, int(first.Version.Size))
+	require.NoError(os.WriteFile(blobPath, corrupt, 0o600))
+
+	content, err := vault.OpenVersionContent(t.Context(), first.Version.ID)
+	require.NoError(err)
+	got, err := io.ReadAll(content.Reader)
+	require.ErrorIs(err, packstore.ErrContentMismatch)
+	require.Equal(corrupt, got)
+	require.ErrorIs(content.Reader.Verify(), packstore.ErrContentMismatch)
+	require.Error(content.Reader.Close())
 }
 
 func TestPackBoundsWorkAndPreservesVerifiedContent(t *testing.T) {

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -68,6 +68,23 @@ type ChildrenPage struct {
 	Offset int    `json:"offset"`
 }
 
+const (
+	DefaultVersionsLimit = 100
+	MaxVersionsLimit     = 1000
+)
+
+type VersionsOptions struct {
+	Limit  int
+	Offset int
+}
+
+type VersionsPage struct {
+	Items  []ContentVersion `json:"items"`
+	Total  int              `json:"total"`
+	Limit  int              `json:"limit"`
+	Offset int              `json:"offset"`
+}
+
 // PackOptions bounds one explicit embedded packing pass. MaxBytes is a soft
 // committed raw-byte budget; zero is unlimited and negative values are
 // rejected.

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -127,6 +127,12 @@ type Content struct {
 	Reader VerifiedReadCloser
 }
 
+// VersionContent binds a verified byte stream to one immutable content version.
+type VersionContent struct {
+	Version ContentVersion
+	Reader  VerifiedReadCloser
+}
+
 func fromStoreNode(node store.Node) Node {
 	return Node{
 		ID: node.ID, ParentID: node.ParentID, Name: node.Name, Kind: node.Kind,


### PR DESCRIPTION
Embedded applications need a bounded way to inspect immutable content history and reopen prior versions without reaching into internal storage APIs. The previous embedded surface exposed only current content, which forced consumers to bypass Docbank's lifecycle and verification guarantees for historical reads.

This adds newest-first paged history and verified access to a selected immutable version while retaining vault leases and catalog size checks. `Put` remains an idempotent content write; it is not promised as a repair mechanism for already-corrupt canonical content, so consumers must use verify/restore or publish different bytes and verify the resulting head.