### PR TITLE
Persist first audit enrollment authority

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -69,6 +69,12 @@ provenance     (identity SHA-256 PRIMARY KEY, node_id, ingest_id,
                 original_path, original_mtime, supersedes)
 tags           (id UUID PRIMARY KEY, name UNIQUE, revision)
 node_tags      (node_id, tag_id)
+audit_records  (digest PRIMARY KEY, kind, operation indexes, record_json)
+audit_authority(lineage_id, operation high-water, allocation count/head)
+audit_write_guard(derived singleton installed after complete validation)
+audit_scopes   (scope_id, target_node_id, enable operation, count/head)
+audit_baselines(digest, scope_id, target_node_id, operation_id)
+audit_memberships(scope_id, node_id, baseline_digest)
 extracted_text (blob_hash, extractor, extractor_version, status,
                 error, attempts, text, extracted_at)      -- reserved; no workers yet
 nodes_fts      -- FTS5 external-content index over live node names
@@ -88,10 +94,16 @@ creates an unsuperseded fact; SQL prevents rewriting ingest or provenance rows.
 JSONL preserves the identity and optional `supersedes` edge and rejects a
 dangling, cross-node, branching, or cyclic graph during import.
 
-The current schema has no audit-scope authority. The planned storage contract
-for sticky membership, mutation chains, and JSONL fidelity is maintained in
-[Audited History](audited-history.md), rather than duplicated in this current
-schema reference.
+The schema and metadata-v1 codec can persist one complete first audit
+enrollment: topology and attached-metadata genesis, a shared baseline, sticky
+membership, an enrollment event, scope chain, and allocation lineage. Import
+recomputes every canonical digest and reconciles the protected closure with the
+restored current state before accepting it. No command or HTTP route can create
+a scope yet, so this authority remains dormant in ordinary vaults. A restored
+authority is read-only at the logical metadata layer until guarded mutation
+recording is implemented; pack layout and backup reads remain maintainable. The
+planned mutation and maintenance contract is maintained in
+[Audited History](audited-history.md).
 
 ## Invariants enforced in the schema
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -365,18 +365,30 @@ page layout is not the intended long-lived backup contract. The logical
 boundary is deterministic JSONL headed by `docbank-metadata` and an integer
 format version. Records are emitted in dependency-stable order and deterministic
 key order: blobs, nodes, ingests, node versions, provenance, tags, node tags,
-and extracted text. Nodes carry parent IDs, so directory structure, trash
+extracted text, and any audit authority. Audit projection rows precede their
+canonical records; import defers their foreign keys and validates the complete
+graph before commit. Nodes carry parent IDs, so directory structure, trash
 restore coordinates, and stable external node references survive a roundtrip.
 The header carries SQLite's node `AUTOINCREMENT` high-water mark separately
 from the live rows; import restores it only after proving it is at least the
 maximum surviving node ID.
 
-!!! info "Planned — editing and audited metadata v1"
-    Before the first public release this boundary will adopt stable content,
-    vault, tag, ingest, and provenance identities directly while remaining
-    `docbank-metadata` version 1 and `docbank-metadata-jsonl-v1`. Enabling the
-    first scope adds complete audit authority to the same format. Earlier
-    development shapes are disposable and receive no compatibility decoder.
+Stable content, vault, tag, ingest, and provenance identities are native
+metadata-v1 fields. A zero-scope stream contains no audit rows. The codec also
+persists and validates the closed first-enrollment record set: topology and
+attached-metadata genesis, allocation genesis and first entry, one shared
+baseline and its memberships, one enrollment event and canonical mutation, and
+the first scope-chain entry. This is persistence infrastructure, not an
+enablement surface; ordinary vaults still export the compact zero-scope form.
+If this authority is restored, schema guards freeze logical metadata so its
+verified state cannot diverge before guarded mutation recording ships. Physical
+pack maintenance and read-only backup/export remain available.
+
+!!! info "Planned — audited mutations"
+    Audit enablement, subsequent guarded mutations, maintenance protection, and
+    verification/status APIs will extend this same metadata-v1 authority before
+    the first public release. Earlier development shapes are disposable and
+    receive no compatibility decoder.
 
 The stream excludes `nodes_fts`, `blob_packs`, and `blob_pack_index`. FTS is a
 derived index rebuilt by the node insert triggers. Pack tables describe one

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -366,8 +366,9 @@ boundary is deterministic JSONL headed by `docbank-metadata` and an integer
 format version. Records are emitted in dependency-stable order and deterministic
 key order: blobs, nodes, ingests, node versions, provenance, tags, node tags,
 extracted text, and any audit authority. Audit projection rows precede their
-canonical records; import defers their foreign keys and validates the complete
-graph before commit. Nodes carry parent IDs, so directory structure, trash
+canonical records; import defers all foreign-key enforcement transaction-wide
+and validates the complete graph before commit. Nodes carry parent IDs, so
+directory structure, trash
 restore coordinates, and stable external node references survive a roundtrip.
 The header carries SQLite's node `AUTOINCREMENT` high-water mark separately
 from the live rows; import restores it only after proving it is at least the

--- a/internal/audit/access.go
+++ b/internal/audit/access.go
@@ -1,0 +1,87 @@
+package audit
+
+import (
+	"bytes"
+	"encoding/hex"
+)
+
+// FieldValue returns a cloned field value from record.
+func FieldValue(record Record, name string) (Value, bool) {
+	for _, field := range record.Fields {
+		if field.Name == name {
+			return cloneValue(field.Value), true
+		}
+	}
+	return Value{}, false
+}
+
+// IsAbsent reports whether value is the canonical absent value.
+func (value Value) IsAbsent() bool { return value.kind == kindAbsent }
+
+// BoolValue returns a canonical boolean value.
+func (value Value) BoolValue() (bool, bool) {
+	switch value.kind {
+	case kindFalse:
+		return false, true
+	case kindTrue:
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+// UnsignedValue returns a canonical unsigned integer value.
+func (value Value) UnsignedValue() (uint64, bool) {
+	return value.unsigned, value.kind == kindUnsigned
+}
+
+// BytesValue returns a copy of a canonical byte-string value.
+func (value Value) BytesValue() ([]byte, bool) {
+	return bytes.Clone(value.data), value.kind == kindBytes
+}
+
+// TextValue returns a canonical text value.
+func (value Value) TextValue() (string, bool) {
+	return string(value.data), value.kind == kindText
+}
+
+// TimestampValue returns a canonical timestamp value.
+func (value Value) TimestampValue() (string, bool) {
+	return string(value.data), value.kind == kindTimestamp
+}
+
+// UUIDValue returns a canonical lowercase UUIDv4 value.
+func (value Value) UUIDValue() (string, bool) {
+	if value.kind != kindUUID || len(value.data) != 16 {
+		return "", false
+	}
+	return formatUUID(value.data), true
+}
+
+// DigestValue returns a canonical lowercase SHA-256 value.
+func (value Value) DigestValue() (string, bool) {
+	if value.kind != kindDigest || len(value.data) != 32 {
+		return "", false
+	}
+	return hex.EncodeToString(value.data), true
+}
+
+// ListValue returns a deep copy of a canonical list value.
+func (value Value) ListValue() ([]Value, bool) {
+	if value.kind != kindList {
+		return nil, false
+	}
+	items := make([]Value, len(value.items))
+	for index := range value.items {
+		items[index] = cloneValue(value.items[index])
+	}
+	return items, true
+}
+
+// RecordValue returns a deep copy of a canonical nested record value.
+func (value Value) RecordValue() (Record, bool) {
+	if value.kind != kindRecord || value.record == nil {
+		return Record{}, false
+	}
+	return cloneRecord(*value.record), true
+}

--- a/internal/store/audit_baseline_projection.go
+++ b/internal/store/audit_baseline_projection.go
@@ -16,6 +16,9 @@ func deriveInitialAuditMembers(
 	if err != nil {
 		return nil, err
 	}
+	if err := validateAuditTrashOrigins(rows); err != nil {
+		return nil, err
+	}
 	target, ok := rows[targetNodeID]
 	if !ok || target.kind != "dir" || target.trashedAt.Valid {
 		return nil, fmt.Errorf("audit enrollment target %d must be a live directory", targetNodeID)
@@ -56,7 +59,58 @@ func deriveInitialAuditMembers(
 			}
 		}
 	}
+	if !target.parentID.Valid && len(members) != len(rows) {
+		return nil, fmt.Errorf(
+			"root audit enrollment covers %d extant nodes, want %d", len(members), len(rows),
+		)
+	}
 	return sortedAuditMembers(members), nil
+}
+
+// validateAuditTrashOrigins follows the historical origin edge for detached
+// trash roots and the live parent edge everywhere else. Every chain must end
+// at the tree root or at an explicit unknown-origin trash anchor.
+func validateAuditTrashOrigins(rows map[uint64]auditTopologyRow) error {
+	roots := make(map[uint64]bool)
+	for id, row := range rows {
+		if row.trashName.Valid {
+			roots[id] = true
+		}
+	}
+	for _, start := range sortedAuditMembers(roots) {
+		seen := make(map[uint64]bool)
+		current := start
+		for {
+			if seen[current] {
+				return fmt.Errorf("audit trash-origin topology contains a cycle at node %d", current)
+			}
+			seen[current] = true
+			row, ok := rows[current]
+			if !ok {
+				return fmt.Errorf("audit trash-origin topology references missing node %d", current)
+			}
+			if row.trashName.Valid {
+				if !row.trashParent.Valid {
+					break
+				}
+				next, err := positiveAuditNodeID(row.trashParent.Int64)
+				if err != nil {
+					return err
+				}
+				current = next
+				continue
+			}
+			if !row.parentID.Valid {
+				break
+			}
+			next, err := positiveAuditNodeID(row.parentID.Int64)
+			if err != nil {
+				return err
+			}
+			current = next
+		}
+	}
+	return nil
 }
 
 func loadAuditTopologyRows(ctx context.Context, tx metadataQuerier) (map[uint64]auditTopologyRow, error) {

--- a/internal/store/audit_baseline_projection.go
+++ b/internal/store/audit_baseline_projection.go
@@ -1,0 +1,357 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func deriveInitialAuditMembers(
+	ctx context.Context, tx metadataQuerier, targetNodeID uint64,
+) ([]uint64, error) {
+	rows, err := loadAuditTopologyRows(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	target, ok := rows[targetNodeID]
+	if !ok || target.kind != "dir" || target.trashedAt.Valid {
+		return nil, fmt.Errorf("audit enrollment target %d must be a live directory", targetNodeID)
+	}
+	children := make(map[uint64][]uint64)
+	for id, row := range rows {
+		if row.parentID.Valid {
+			parentID, err := positiveAuditNodeID(row.parentID.Int64)
+			if err != nil {
+				return nil, err
+			}
+			children[parentID] = append(children[parentID], id)
+		}
+	}
+	members := map[uint64]bool{targetNodeID: true}
+	addDescendants(targetNodeID, rows, children, members, true)
+	for changed := true; changed; {
+		changed = false
+		for id, row := range rows {
+			if !row.trashName.Valid || members[id] {
+				continue
+			}
+			adopt := false
+			if row.trashParent.Valid {
+				parentID, err := positiveAuditNodeID(row.trashParent.Int64)
+				if err != nil {
+					return nil, err
+				}
+				adopt = members[parentID]
+			}
+			if !row.trashParent.Valid && !target.parentID.Valid {
+				adopt = true
+			}
+			if adopt {
+				members[id] = true
+				addDescendants(id, rows, children, members, false)
+				changed = true
+			}
+		}
+	}
+	return sortedAuditMembers(members), nil
+}
+
+func loadAuditTopologyRows(ctx context.Context, tx metadataQuerier) (map[uint64]auditTopologyRow, error) {
+	queryRows, err := tx.QueryContext(ctx, `SELECT id,parent_id,name,kind,created_at,modified_at,
+		trashed_at,trash_parent,trash_name FROM nodes ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("reading audit topology rows: %w", err)
+	}
+	defer func() { _ = queryRows.Close() }()
+	result := make(map[uint64]auditTopologyRow)
+	for queryRows.Next() {
+		var row auditTopologyRow
+		if err := queryRows.Scan(&row.id, &row.parentID, &row.name, &row.kind,
+			&row.createdAt, &row.modifiedAt, &row.trashedAt, &row.trashParent,
+			&row.trashName); err != nil {
+			return nil, fmt.Errorf("scanning audit topology row: %w", err)
+		}
+		id, err := positiveAuditNodeID(row.id)
+		if err != nil {
+			return nil, err
+		}
+		result[id] = row
+	}
+	if err := queryRows.Err(); err != nil {
+		return nil, fmt.Errorf("reading audit topology rows: %w", err)
+	}
+	return result, nil
+}
+
+func positiveAuditNodeID(value int64) (uint64, error) {
+	if value <= 0 {
+		return 0, fmt.Errorf("audit topology contains invalid node ID %d", value)
+	}
+	return uint64(value), nil
+}
+
+func addDescendants(
+	root uint64, rows map[uint64]auditTopologyRow, children map[uint64][]uint64,
+	members map[uint64]bool, liveOnly bool,
+) {
+	for _, child := range children[root] {
+		if members[child] || (liveOnly && rows[child].trashedAt.Valid) {
+			continue
+		}
+		members[child] = true
+		addDescendants(child, rows, children, members, liveOnly)
+	}
+}
+
+func currentAuditMemberStates(
+	ctx context.Context, tx metadataQuerier, members []uint64,
+) ([]audit.Record, error) {
+	memberSet := auditMemberSet(members)
+	rows, err := tx.QueryContext(ctx, `SELECT id,revision,current_version_id FROM nodes ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("reading audit member states: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make([]audit.Record, 0, len(members))
+	for rows.Next() {
+		var id, revision int64
+		var current sql.NullString
+		if err := rows.Scan(&id, &revision, &current); err != nil {
+			return nil, fmt.Errorf("scanning audit member state: %w", err)
+		}
+		nodeID, err := positiveAuditNodeID(id)
+		if err != nil {
+			return nil, err
+		}
+		if !memberSet[nodeID] {
+			continue
+		}
+		if revision <= 0 {
+			return nil, fmt.Errorf("audit member %d has invalid revision %d", id, revision)
+		}
+		currentValue := audit.Absent()
+		if current.Valid {
+			currentValue, err = audit.UUID(current.String)
+			if err != nil {
+				return nil, err
+			}
+		}
+		result = append(result, audit.Record{Kind: "member_state", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+			// The positivity check above makes this conversion lossless.
+			{Name: "node_revision", Value: audit.Unsigned(uint64(revision))},
+			{Name: "current_version_id", Value: currentValue},
+		}})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading audit member states: %w", err)
+	}
+	if len(result) != len(members) {
+		return nil, fmt.Errorf("audit member state cardinality is %d, want %d", len(result), len(members))
+	}
+	return result, nil
+}
+
+func currentAuditVersions(
+	ctx context.Context, tx metadataQuerier, members []uint64,
+) ([]audit.Record, error) {
+	memberSet := auditMemberSet(members)
+	rows, err := tx.QueryContext(ctx, `SELECT version_id,node_id,blob_hash,size,mime_type,
+		recorded_at,node_revision,introduced_operation_id,transition_kind,source_version_id
+		FROM content_versions ORDER BY node_id,version_id`)
+	if err != nil {
+		return nil, fmt.Errorf("reading audited content versions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var result []audit.Record
+	for rows.Next() {
+		var versionID, blobHash, recordedAt, operationID, transition string
+		var nodeID, size, revision int64
+		var mediaType, source sql.NullString
+		if err := rows.Scan(&versionID, &nodeID, &blobHash, &size, &mediaType,
+			&recordedAt, &revision, &operationID, &transition, &source); err != nil {
+			return nil, fmt.Errorf("scanning audited content version: %w", err)
+		}
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		if !memberSet[auditNodeID] {
+			continue
+		}
+		if size < 0 || revision <= 0 {
+			return nil, fmt.Errorf("audited content version %s has invalid size or revision", versionID)
+		}
+		// The range checks above make both conversions lossless.
+		auditSize := uint64(size)
+		auditRevision := uint64(revision)
+		record, err := contentVersionAuditRecord(versionID, blobHash, recordedAt,
+			operationID, transition, auditNodeID, auditSize, auditRevision, mediaType, source)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading audited content versions: %w", err)
+	}
+	return result, nil
+}
+
+func contentVersionAuditRecord(
+	versionID, blobHash, recordedAt, operationID, transition string,
+	nodeID, size, revision uint64, mediaType, source sql.NullString,
+) (audit.Record, error) {
+	versionValue, err := audit.UUID(versionID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	blobValue, err := audit.DigestHex(blobHash)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	recordedValue, err := audit.Timestamp(recordedAt)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	operationValue, err := audit.UUID(operationID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	transitionValue, err := audit.Text(transition)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	mediaValue := audit.Absent()
+	if mediaType.Valid {
+		mediaValue, err = audit.Text(mediaType.String)
+		if err != nil {
+			return audit.Record{}, err
+		}
+	}
+	sourceValue := audit.Absent()
+	if source.Valid {
+		sourceValue, err = audit.UUID(source.String)
+		if err != nil {
+			return audit.Record{}, err
+		}
+	}
+	return audit.Record{Kind: "content_version", Fields: []audit.Field{
+		{Name: "version_id", Value: versionValue},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "blob_hash", Value: blobValue},
+		{Name: "size", Value: audit.Unsigned(size)},
+		{Name: "media_type", Value: mediaValue},
+		{Name: "recorded_at", Value: recordedValue},
+		{Name: "node_revision", Value: audit.Unsigned(revision)},
+		{Name: "introduced_operation_id", Value: operationValue},
+		{Name: "transition_kind", Value: transitionValue},
+		{Name: "source_version_id", Value: sourceValue},
+	}}, nil
+}
+
+func initialBaselineTopology(
+	topology []audit.Record, members []uint64, generationOperationID string,
+) ([]audit.Record, []audit.Record, error) {
+	byID := make(map[uint64]audit.Record, len(topology))
+	parents := make(map[uint64]*uint64, len(topology))
+	originParents := make(map[uint64]*uint64)
+	for _, record := range topology {
+		id, err := auditUnsignedField(record, metadataNodeIDField)
+		if err != nil {
+			return nil, nil, err
+		}
+		byID[id] = record
+		parent, err := auditOptionalUnsignedField(record, "parent_id")
+		if err != nil {
+			return nil, nil, err
+		}
+		parents[id] = parent
+		originValue, err := auditField(record, "origin")
+		if err != nil {
+			return nil, nil, err
+		}
+		if originValue.IsAbsent() {
+			continue
+		}
+		origin, ok := originValue.RecordValue()
+		if !ok {
+			return nil, nil, fmt.Errorf("topology node %d has invalid origin", id)
+		}
+		if origin.Kind == "known_origin" {
+			originParent, err := auditUnsignedField(origin, "parent_id")
+			if err != nil {
+				return nil, nil, err
+			}
+			originParents[id] = &originParent
+		}
+	}
+	closure := auditMemberSet(members)
+	for _, member := range members {
+		addAuditAncestors(member, parents, closure)
+		if parent := originParents[member]; parent != nil {
+			closure[*parent] = true
+			addAuditAncestors(*parent, parents, closure)
+		}
+	}
+	ids := sortedAuditMembers(closure)
+	nodes := make([]audit.Record, 0, len(ids))
+	memberSet := auditMemberSet(members)
+	var witnesses []audit.Record
+	generation, err := audit.UUID(generationOperationID)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, id := range ids {
+		node, ok := byID[id]
+		if !ok {
+			return nil, nil, fmt.Errorf("baseline topology dependency node %d is missing", id)
+		}
+		nodes = append(nodes, node)
+		if memberSet[id] {
+			continue
+		}
+		stateDigest, err := audit.Hash(audit.Record{Kind: "witnessed_state", Fields: []audit.Field{
+			{Name: "node", Value: audit.Nested(node)},
+		}})
+		if err != nil {
+			return nil, nil, err
+		}
+		witnesses = append(witnesses, audit.Record{Kind: "witness", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(id)},
+			{Name: "generation_operation_id", Value: generation},
+			{Name: "state_digest", Value: audit.Digest(stateDigest)},
+		}})
+	}
+	return nodes, witnesses, nil
+}
+
+func addAuditAncestors(id uint64, parents map[uint64]*uint64, closure map[uint64]bool) {
+	seen := make(map[uint64]bool)
+	for parent := parents[id]; parent != nil && !seen[*parent]; parent = parents[*parent] {
+		seen[*parent] = true
+		closure[*parent] = true
+	}
+}
+
+func auditOptionalUnsignedField(record audit.Record, name string) (*uint64, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent optional integer.
+	}
+	result, ok := value.UnsignedValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not optional unsigned", record.Kind, name)
+	}
+	return &result, nil
+}
+
+func equalAuditRecordLists(left, right []audit.Record) bool {
+	return len(left) == len(right) && slices.EqualFunc(left, right, auditRecordEqual)
+}

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -292,7 +292,10 @@ func validateInitialBaseline(
 		return err
 	}
 	storedStates, err := auditRecordListField(baseline.record, "member_states")
-	if err != nil || !equalAuditRecordLists(storedStates, states) {
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(storedStates, states) {
 		return errors.New("audit enrollment member states do not match current nodes")
 	}
 	versions, err := currentAuditVersions(ctx, tx, members)
@@ -300,7 +303,10 @@ func validateInitialBaseline(
 		return err
 	}
 	storedVersions, err := auditRecordListField(baseline.record, "versions")
-	if err != nil || !equalAuditRecordLists(storedVersions, versions) {
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(storedVersions, versions) {
 		return errors.New("audit enrollment versions do not match retained content")
 	}
 	allAttachments, err := currentAuditAttachments(ctx, tx)
@@ -312,7 +318,10 @@ func validateInitialBaseline(
 		return err
 	}
 	storedAttachments, err := auditRecordListField(baseline.record, "attachments")
-	if err != nil || !equalAuditRecordLists(storedAttachments, expectedAttachments) {
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(storedAttachments, expectedAttachments) {
 		return errors.New("audit enrollment attachments do not match current metadata")
 	}
 	return validateInitialBaselineTopology(ctx, tx, baseline.record, members, scope.operationID)
@@ -331,11 +340,17 @@ func validateInitialBaselineTopology(
 		return err
 	}
 	storedNodes, err := auditRecordListField(baseline, "nodes")
-	if err != nil || !equalAuditRecordLists(storedNodes, expectedNodes) {
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(storedNodes, expectedNodes) {
 		return errors.New("audit enrollment topology does not match current dependencies")
 	}
 	storedWitnesses, err := auditRecordListField(baseline, "witnesses")
-	if err != nil || !equalAuditRecordLists(storedWitnesses, expectedWitnesses) {
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(storedWitnesses, expectedWitnesses) {
 		return errors.New("audit enrollment witnesses do not match topology dependencies")
 	}
 	return nil
@@ -408,15 +423,24 @@ func validateInitialMutation(
 		return err
 	}
 	events, err := auditRecordListField(mutation.record, "events")
-	if err != nil || len(events) != 1 || !auditRecordEqual(events[0], event) {
+	if err != nil {
+		return err
+	}
+	if len(events) != 1 || !auditRecordEqual(events[0], event) {
 		return errors.New("initial audit mutation does not bind its enrollment event")
 	}
 	changes, err := auditRecordListField(mutation.record, "member_state_changes")
-	if err != nil || len(changes) != 0 {
+	if err != nil {
+		return err
+	}
+	if len(changes) != 0 {
 		return errors.New("initial audit enrollment must not contain member-state changes")
 	}
 	bindings, err := auditRecordListField(mutation.record, "baselines")
-	if err != nil || len(bindings) != 1 {
+	if err != nil {
+		return err
+	}
+	if len(bindings) != 1 {
 		return errors.New("initial audit mutation must bind one enrollment baseline")
 	}
 	if err := validateInitialBaselineBinding(bindings[0], scope, baseline.digest); err != nil {
@@ -532,7 +556,7 @@ func requireMatchingEventEnvelope(mutation, event audit.Record) error {
 		if err != nil {
 			return err
 		}
-		if !auditValueEqual(left, right) {
+		if !equalAuditEnvelopeValue(left, right) {
 			return fmt.Errorf("initial audit mutation and event disagree on %s", field)
 		}
 	}
@@ -588,7 +612,10 @@ func validateInitialAllocation(
 		return err
 	}
 	allocated, err := auditUnsignedListField(entry.record, "allocated_node_ids")
-	if err != nil || len(allocated) != 0 {
+	if err != nil {
+		return err
+	}
+	if len(allocated) != 0 {
 		return errors.New("initial audit enrollment must not allocate node IDs")
 	}
 	for field, want := range map[string]uint64{
@@ -720,7 +747,9 @@ func requireAuditAbsentFields(record audit.Record, fields ...string) error {
 	return nil
 }
 
-func auditValueEqual(left, right audit.Value) bool {
+// equalAuditEnvelopeValue compares the optional text and timestamp field types
+// shared by canonical mutations and their events.
+func equalAuditEnvelopeValue(left, right audit.Value) bool {
 	if left.IsAbsent() || right.IsAbsent() {
 		return left.IsAbsent() && right.IsAbsent()
 	}

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -1,0 +1,736 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type initialAuditAuthority struct {
+	lineageID       string
+	sequence        int64
+	genesisDigest   string
+	allocationCount int64
+	allocationHead  string
+}
+
+type initialAuditScope struct {
+	scopeID      string
+	targetNodeID uint64
+	operationID  string
+	entryCount   int64
+	chainHead    string
+}
+
+func validateInitialAuditAuthority(
+	ctx context.Context, tx metadataQuerier, vaultID string, nodeSequence int64,
+) error {
+	counts, err := auditAuthorityCounts(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if counts[1] == 0 {
+		for index, count := range counts {
+			if count != 0 {
+				return fmt.Errorf("dormant audit authority has %d row(s) in relation %d", count, index)
+			}
+		}
+		return nil
+	}
+	if counts[0] != 1 || counts[1] != 1 || counts[2] != 1 ||
+		counts[3] == 0 || counts[4] != int64(len(initialAuditRecordKinds)) || counts[5] != 1 {
+		return fmt.Errorf("initial audit authority must contain one authority, scope, baseline, and complete record set: counts=%v", counts)
+	}
+	authority, scope, err := loadInitialAuditProjection(ctx, tx)
+	if err != nil {
+		return err
+	}
+	records, err := loadInitialAuditRecords(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if err := requireInitialAuditRecordCardinality(records); err != nil {
+		return err
+	}
+	return validateInitialAuditRecords(ctx, tx, vaultID, nodeSequence, authority, scope, records)
+}
+
+func auditAuthorityCounts(ctx context.Context, tx metadataQuerier) ([6]int64, error) {
+	var counts [6]int64
+	err := tx.QueryRowContext(ctx, `SELECT
+		(SELECT COUNT(*) FROM audit_authority),
+		(SELECT COUNT(*) FROM audit_scopes),
+		(SELECT COUNT(*) FROM audit_baselines),
+		(SELECT COUNT(*) FROM audit_memberships),
+		(SELECT COUNT(*) FROM audit_records),
+		(SELECT COUNT(*) FROM audit_write_guard)`).Scan(
+		&counts[0], &counts[1], &counts[2], &counts[3], &counts[4], &counts[5])
+	if err != nil {
+		return counts, fmt.Errorf("counting audit authority: %w", err)
+	}
+	return counts, nil
+}
+
+func loadInitialAuditProjection(
+	ctx context.Context, tx metadataQuerier,
+) (initialAuditAuthority, initialAuditScope, error) {
+	var authority initialAuditAuthority
+	err := tx.QueryRowContext(ctx, `SELECT lineage_id,operation_sequence_high_water,
+		allocation_genesis_digest,allocation_entry_count,allocation_head
+		FROM audit_authority WHERE singleton=1`).Scan(
+		&authority.lineageID, &authority.sequence, &authority.genesisDigest,
+		&authority.allocationCount, &authority.allocationHead)
+	if err != nil {
+		return authority, initialAuditScope{}, fmt.Errorf("reading initial audit authority: %w", err)
+	}
+	var scope initialAuditScope
+	err = tx.QueryRowContext(ctx, `SELECT scope_id,target_node_id,enable_operation_id,
+		entry_count,chain_head FROM audit_scopes`).Scan(
+		&scope.scopeID, &scope.targetNodeID, &scope.operationID,
+		&scope.entryCount, &scope.chainHead)
+	if err != nil {
+		return authority, scope, fmt.Errorf("reading initial audit scope: %w", err)
+	}
+	return authority, scope, nil
+}
+
+func loadInitialAuditRecords(
+	ctx context.Context, tx metadataQuerier,
+) (map[string][]storedAuditRecord, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT digest,kind,operation_id,operation_sequence,
+		scope_id,entry_count,event_id,event_ordinal,record_json FROM audit_records`)
+	if err != nil {
+		return nil, fmt.Errorf("reading initial audit records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make(map[string][]storedAuditRecord)
+	for rows.Next() {
+		var digest, kind, recordJSON string
+		var operationID, scopeID, eventID sql.NullString
+		var sequence, entryCount, ordinal sql.NullInt64
+		if err := rows.Scan(&digest, &kind, &operationID, &sequence, &scopeID,
+			&entryCount, &eventID, &ordinal, &recordJSON); err != nil {
+			return nil, fmt.Errorf("scanning initial audit record: %w", err)
+		}
+		record, index, canonical, err := validateAuditRecord(metadataAuditRecord{
+			Type: metadataAuditRecordType, Digest: digest, Record: []byte(recordJSON),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if kind != record.Kind || recordJSON != string(canonical) ||
+			!sameNullString(operationID, index.operationID) ||
+			!sameNullInt64(sequence, index.operationSequence) ||
+			!sameNullString(scopeID, index.scopeID) ||
+			!sameNullInt64(entryCount, index.entryCount) ||
+			!sameNullString(eventID, index.eventID) ||
+			!sameNullInt64(ordinal, index.eventOrdinal) {
+			return nil, fmt.Errorf("audit record %s relational index does not match canonical fields", digest)
+		}
+		result[kind] = append(result[kind], storedAuditRecord{
+			digest: digest, record: record, index: index,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading initial audit records: %w", err)
+	}
+	return result, nil
+}
+
+func sameNullString(value sql.NullString, expected *string) bool {
+	return value.Valid == (expected != nil) && (!value.Valid || value.String == *expected)
+}
+
+func sameNullInt64(value sql.NullInt64, expected *int64) bool {
+	return value.Valid == (expected != nil) && (!value.Valid || value.Int64 == *expected)
+}
+
+func requireInitialAuditRecordCardinality(records map[string][]storedAuditRecord) error {
+	if len(records) != len(initialAuditRecordKinds) {
+		return fmt.Errorf("initial audit authority has %d record kinds, want %d", len(records), len(initialAuditRecordKinds))
+	}
+	for kind := range initialAuditRecordKinds {
+		if len(records[kind]) != 1 {
+			return fmt.Errorf("initial audit authority has %d %s records, want 1", len(records[kind]), kind)
+		}
+	}
+	return nil
+}
+
+func validateInitialAuditRecords(
+	ctx context.Context, tx metadataQuerier, vaultID string, nodeSequence int64,
+	authority initialAuditAuthority, scope initialAuditScope,
+	records map[string][]storedAuditRecord,
+) error {
+	topology := records["topology_genesis"][0]
+	attachments := records["attached_metadata_genesis"][0]
+	allocationGenesis := records["allocation_genesis"][0]
+	baseline := records["enrollment_baseline"][0]
+	event := records["event"][0]
+	mutation := records["canonical_mutation"][0]
+	scopeEntry := records["scope_chain_entry"][0]
+	allocationEntry := records["allocation_entry"][0]
+	if err := validateInitialGenesis(ctx, tx, vaultID, nodeSequence, authority,
+		topology, attachments, allocationGenesis); err != nil {
+		return err
+	}
+	if err := validateInitialBaseline(ctx, tx, vaultID, scope, baseline); err != nil {
+		return err
+	}
+	if err := validateInitialMutation(vaultID, scope, baseline, event, mutation); err != nil {
+		return err
+	}
+	if err := validateInitialScopeChain(vaultID, scope, mutation, scopeEntry); err != nil {
+		return err
+	}
+	return validateInitialAllocation(vaultID, nodeSequence, authority, scope,
+		allocationGenesis, mutation, allocationEntry)
+}
+
+func validateInitialGenesis(
+	ctx context.Context, tx metadataQuerier, vaultID string, nodeSequence int64,
+	authority initialAuditAuthority, topology, attachments, allocation storedAuditRecord,
+) error {
+	nodeHighWater, err := positiveAuditNodeID(nodeSequence)
+	if err != nil {
+		return err
+	}
+	currentTopology, err := currentAuditTopology(ctx, tx)
+	if err != nil {
+		return err
+	}
+	storedTopology, err := auditRecordListField(topology.record, "nodes")
+	if err != nil {
+		return err
+	}
+	currentAttachments, err := currentAuditAttachments(ctx, tx)
+	if err != nil {
+		return err
+	}
+	storedAttachments, err := auditRecordListField(attachments.record, "records")
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(storedTopology, currentTopology) {
+		return errors.New("audit topology genesis does not match current topology")
+	}
+	if !equalAuditRecordLists(storedAttachments, currentAttachments) {
+		return errors.New("audit attached-metadata genesis does not match current metadata")
+	}
+	for _, record := range []audit.Record{topology.record, attachments.record, allocation.record} {
+		if err := requireAuditUUID(record, "vault_id", vaultID); err != nil {
+			return err
+		}
+		if err := requireAuditUUID(record, "lineage_id", authority.lineageID); err != nil {
+			return err
+		}
+	}
+	if allocation.digest != authority.genesisDigest {
+		return errors.New("audit allocation genesis pointer does not match its record")
+	}
+	if err := requireAuditAbsent(allocation.record, "previous_head"); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(allocation.record, "node_id_high_water", nodeHighWater); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(allocation.record, "operation_sequence_high_water", 0); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(allocation.record, "topology_count", uint64(len(currentTopology))); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(allocation.record, "topology_digest", topology.digest); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(allocation.record, "attached_metadata_count", uint64(len(currentAttachments))); err != nil {
+		return err
+	}
+	return requireAuditDigest(allocation.record, "attached_metadata_digest", attachments.digest)
+}
+
+func validateInitialBaseline(
+	ctx context.Context, tx metadataQuerier, vaultID string, scope initialAuditScope,
+	baseline storedAuditRecord,
+) error {
+	if err := requireAuditUUID(baseline.record, "vault_id", vaultID); err != nil {
+		return err
+	}
+	if err := requireAuditUUID(baseline.record, "scope_id", scope.scopeID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(baseline.record, "target_node_id", scope.targetNodeID); err != nil {
+		return err
+	}
+	if err := requireAuditUUID(baseline.record, "operation_id", scope.operationID); err != nil {
+		return err
+	}
+	if err := requireAuditText(baseline.record, "cause", "explicit"); err != nil {
+		return err
+	}
+	members, err := auditUnsignedListField(baseline.record, "members")
+	if err != nil {
+		return err
+	}
+	expectedMembers, err := deriveInitialAuditMembers(ctx, tx, scope.targetNodeID)
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(members, expectedMembers) {
+		return errors.New("audit enrollment members do not match the protected closure")
+	}
+	if err := validateInitialMembershipRows(ctx, tx, scope, baseline.digest, members); err != nil {
+		return err
+	}
+	states, err := currentAuditMemberStates(ctx, tx, members)
+	if err != nil {
+		return err
+	}
+	storedStates, err := auditRecordListField(baseline.record, "member_states")
+	if err != nil || !equalAuditRecordLists(storedStates, states) {
+		return errors.New("audit enrollment member states do not match current nodes")
+	}
+	versions, err := currentAuditVersions(ctx, tx, members)
+	if err != nil {
+		return err
+	}
+	storedVersions, err := auditRecordListField(baseline.record, "versions")
+	if err != nil || !equalAuditRecordLists(storedVersions, versions) {
+		return errors.New("audit enrollment versions do not match retained content")
+	}
+	allAttachments, err := currentAuditAttachments(ctx, tx)
+	if err != nil {
+		return err
+	}
+	expectedAttachments, err := auditRecordsForNodes(allAttachments, auditMemberSet(members))
+	if err != nil {
+		return err
+	}
+	storedAttachments, err := auditRecordListField(baseline.record, "attachments")
+	if err != nil || !equalAuditRecordLists(storedAttachments, expectedAttachments) {
+		return errors.New("audit enrollment attachments do not match current metadata")
+	}
+	return validateInitialBaselineTopology(ctx, tx, baseline.record, members, scope.operationID)
+}
+
+func validateInitialBaselineTopology(
+	ctx context.Context, tx metadataQuerier, baseline audit.Record, members []uint64,
+	operationID string,
+) error {
+	topology, err := currentAuditTopology(ctx, tx)
+	if err != nil {
+		return err
+	}
+	expectedNodes, expectedWitnesses, err := initialBaselineTopology(topology, members, operationID)
+	if err != nil {
+		return err
+	}
+	storedNodes, err := auditRecordListField(baseline, "nodes")
+	if err != nil || !equalAuditRecordLists(storedNodes, expectedNodes) {
+		return errors.New("audit enrollment topology does not match current dependencies")
+	}
+	storedWitnesses, err := auditRecordListField(baseline, "witnesses")
+	if err != nil || !equalAuditRecordLists(storedWitnesses, expectedWitnesses) {
+		return errors.New("audit enrollment witnesses do not match topology dependencies")
+	}
+	return nil
+}
+
+func validateInitialMembershipRows(
+	ctx context.Context, tx metadataQuerier, scope initialAuditScope,
+	baselineDigest string, members []uint64,
+) error {
+	var relationScope, relationOperation string
+	var targetID uint64
+	err := tx.QueryRowContext(ctx, `SELECT scope_id,target_node_id,operation_id
+		FROM audit_baselines WHERE digest=?`, baselineDigest).Scan(
+		&relationScope, &targetID, &relationOperation)
+	if err != nil {
+		return fmt.Errorf("reading audit baseline relation: %w", err)
+	}
+	if relationScope != scope.scopeID || targetID != scope.targetNodeID ||
+		relationOperation != scope.operationID {
+		return errors.New("audit baseline relation does not match its scope and operation")
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT node_id,baseline_digest FROM audit_memberships
+		WHERE scope_id=? ORDER BY node_id`, scope.scopeID)
+	if err != nil {
+		return fmt.Errorf("reading audit membership projection: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var projected []uint64
+	for rows.Next() {
+		var nodeID uint64
+		var digest string
+		if err := rows.Scan(&nodeID, &digest); err != nil {
+			return fmt.Errorf("scanning audit membership projection: %w", err)
+		}
+		if digest != baselineDigest {
+			return errors.New("audit membership points to the wrong baseline")
+		}
+		projected = append(projected, nodeID)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("reading audit membership projection: %w", err)
+	}
+	if !slices.Equal(projected, members) {
+		return errors.New("audit membership projection does not match the baseline")
+	}
+	return nil
+}
+
+func validateInitialMutation(
+	vaultID string, scope initialAuditScope, baseline, eventWrapper,
+	mutation storedAuditRecord,
+) error {
+	event, err := auditNestedField(eventWrapper.record, "event")
+	if err != nil {
+		return err
+	}
+	if err := validateInitialEvent(scope, baseline, event); err != nil {
+		return err
+	}
+	if err := requireAuditUUID(mutation.record, "vault_id", vaultID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(mutation.record, "operation_sequence", 1); err != nil {
+		return err
+	}
+	if err := requireAuditUUID(mutation.record, "operation_id", scope.operationID); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
+		return err
+	}
+	events, err := auditRecordListField(mutation.record, "events")
+	if err != nil || len(events) != 1 || !auditRecordEqual(events[0], event) {
+		return errors.New("initial audit mutation does not bind its enrollment event")
+	}
+	changes, err := auditRecordListField(mutation.record, "member_state_changes")
+	if err != nil || len(changes) != 0 {
+		return errors.New("initial audit enrollment must not contain member-state changes")
+	}
+	bindings, err := auditRecordListField(mutation.record, "baselines")
+	if err != nil || len(bindings) != 1 {
+		return errors.New("initial audit mutation must bind one enrollment baseline")
+	}
+	if err := validateInitialBaselineBinding(bindings[0], scope, baseline.digest); err != nil {
+		return err
+	}
+	if err := requireNoChangeMutationFields(mutation.record); err != nil {
+		return err
+	}
+	return requireMatchingEventEnvelope(mutation.record, event)
+}
+
+func validateInitialEvent(scope initialAuditScope, baseline storedAuditRecord, event audit.Record) error {
+	identityOperation, err := audit.UUID(scope.operationID)
+	if err != nil {
+		return err
+	}
+	identityDigest, err := audit.Hash(audit.Record{Kind: "event_identity", Fields: []audit.Field{
+		{Name: "operation_id", Value: identityOperation},
+		{Name: "event_ordinal", Value: audit.Unsigned(0)},
+	}})
+	if err != nil {
+		return err
+	}
+	checks := []func() error{
+		func() error { return requireAuditDigest(event, "event_id", hex.EncodeToString(identityDigest[:])) },
+		func() error { return requireAuditUUID(event, "operation_id", scope.operationID) },
+		func() error { return requireAuditUnsigned(event, metadataNodeIDField, scope.targetNodeID) },
+		func() error { return requireAuditText(event, "event_kind", "audit_enroll") },
+		func() error { return requireAuditUUID(event, "scope_id", scope.scopeID) },
+		func() error { return requireAuditUnsigned(event, "target_node_id", scope.targetNodeID) },
+		func() error { return requireAuditUnsigned(event, "event_ordinal", 0) },
+		func() error { return requireAuditDigest(event, "baseline_digest", baseline.digest) },
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	states, err := auditRecordListField(baseline.record, "member_states")
+	if err != nil {
+		return err
+	}
+	if err := validateInitialEventState(event, scope.targetNodeID, states); err != nil {
+		return err
+	}
+	return requireAuditAbsentFields(event, "attachment_kind", "attachment_identity",
+		"source_version_id", "pre", "post", "topology_delta")
+}
+
+func validateInitialEventState(event audit.Record, targetNodeID uint64, states []audit.Record) error {
+	for _, state := range states {
+		nodeID, err := auditUnsignedField(state, metadataNodeIDField)
+		if err != nil {
+			return err
+		}
+		if nodeID != targetNodeID {
+			continue
+		}
+		revision, err := auditUnsignedField(state, "node_revision")
+		if err != nil {
+			return err
+		}
+		if err := requireAuditUnsigned(event, "prior_node_revision", revision); err != nil {
+			return err
+		}
+		if err := requireAuditUnsigned(event, "resulting_node_revision", revision); err != nil {
+			return err
+		}
+		current, err := auditOptionalUUIDField(state, "current_version_id")
+		if err != nil {
+			return err
+		}
+		if err := requireAuditOptionalUUID(event, "prior_current_version_id", current); err != nil {
+			return err
+		}
+		return requireAuditOptionalUUID(event, "resulting_current_version_id", current)
+	}
+	return errors.New("initial audit event target has no baseline member state")
+}
+
+func validateInitialBaselineBinding(record audit.Record, scope initialAuditScope, digest string) error {
+	if err := requireAuditUUID(record, "scope_id", scope.scopeID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(record, "target_node_id", scope.targetNodeID); err != nil {
+		return err
+	}
+	return requireAuditDigest(record, "baseline_digest", digest)
+}
+
+func requireNoChangeMutationFields(record audit.Record) error {
+	if err := requireAuditAbsentFields(record, "topology_delta", "path_effect_digest",
+		"witness_change_digest", "attached_metadata_change_digest"); err != nil {
+		return err
+	}
+	for _, field := range []string{
+		"path_effect_count", "witness_change_count", "attached_metadata_change_count",
+	} {
+		if err := requireAuditUnsigned(record, field, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireMatchingEventEnvelope(mutation, event audit.Record) error {
+	for _, field := range []string{"recorded_at", "origin", "agent_label"} {
+		left, err := auditField(mutation, field)
+		if err != nil {
+			return err
+		}
+		right, err := auditField(event, field)
+		if err != nil {
+			return err
+		}
+		if !auditValueEqual(left, right) {
+			return fmt.Errorf("initial audit mutation and event disagree on %s", field)
+		}
+	}
+	return nil
+}
+
+func validateInitialScopeChain(
+	vaultID string, scope initialAuditScope, mutation, entry storedAuditRecord,
+) error {
+	if scope.entryCount != 1 || scope.chainHead != entry.digest {
+		return errors.New("initial audit scope projection does not match its first chain entry")
+	}
+	if err := requireAuditUUID(entry.record, "vault_id", vaultID); err != nil {
+		return err
+	}
+	if err := requireAuditUUID(entry.record, "scope_id", scope.scopeID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(entry.record, "entry_count", 1); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(entry.record, "previous_head"); err != nil {
+		return err
+	}
+	return requireAuditDigest(entry.record, "mutation_hash", mutation.digest)
+}
+
+func validateInitialAllocation(
+	vaultID string, nodeSequence int64, authority initialAuditAuthority,
+	scope initialAuditScope, genesis, mutation, entry storedAuditRecord,
+) error {
+	nodeHighWater, err := positiveAuditNodeID(nodeSequence)
+	if err != nil {
+		return err
+	}
+	if authority.sequence != 1 || authority.allocationCount != 1 ||
+		authority.allocationHead != entry.digest {
+		return errors.New("initial allocation authority does not match its first entry")
+	}
+	if err := requireAuditUUID(entry.record, "vault_id", vaultID); err != nil {
+		return err
+	}
+	if err := requireAuditUUID(entry.record, "lineage_id", authority.lineageID); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(entry.record, "previous_head", genesis.digest); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(entry.record, "operation_sequence", 1); err != nil {
+		return err
+	}
+	if err := requireAuditUUID(entry.record, "operation_id", scope.operationID); err != nil {
+		return err
+	}
+	allocated, err := auditUnsignedListField(entry.record, "allocated_node_ids")
+	if err != nil || len(allocated) != 0 {
+		return errors.New("initial audit enrollment must not allocate node IDs")
+	}
+	for field, want := range map[string]uint64{
+		"node_id_high_water":             nodeHighWater,
+		"operation_sequence_high_water":  1,
+		"witness_change_count":           0,
+		"attached_metadata_change_count": 0,
+	} {
+		if err := requireAuditUnsigned(entry.record, field, want); err != nil {
+			return err
+		}
+	}
+	if err := requireAuditBool(entry.record, "has_audited_mutation", true); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(entry.record, "mutation_hash", mutation.digest); err != nil {
+		return err
+	}
+	for _, field := range []string{
+		"has_topology_change", "has_witness_change", "has_attached_metadata_change",
+	} {
+		if err := requireAuditBool(entry.record, field, false); err != nil {
+			return err
+		}
+	}
+	return requireAuditAbsentFields(entry.record, "topology_delta", "witness_change_digest",
+		"attached_metadata_change_digest")
+}
+
+func auditRecordListField(record audit.Record, name string) ([]audit.Record, error) {
+	values, err := auditListField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	return auditRecordList(values)
+}
+
+func auditUnsignedListField(record audit.Record, name string) ([]uint64, error) {
+	values, err := auditListField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	return auditUnsignedList(values)
+}
+
+func requireAuditUUID(record audit.Record, name, want string) error {
+	got, err := auditUUIDField(record, name)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("audit field %s.%s is %q, want %q", record.Kind, name, got, want)
+	}
+	return nil
+}
+
+func requireAuditDigest(record audit.Record, name, want string) error {
+	got, err := auditDigestField(record, name)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("audit field %s.%s does not match", record.Kind, name)
+	}
+	return nil
+}
+
+func requireAuditUnsigned(record audit.Record, name string, want uint64) error {
+	got, err := auditUnsignedField(record, name)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("audit field %s.%s is %d, want %d", record.Kind, name, got, want)
+	}
+	return nil
+}
+
+func requireAuditText(record audit.Record, name, want string) error {
+	got, err := auditTextField(record, name)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("audit field %s.%s is %q, want %q", record.Kind, name, got, want)
+	}
+	return nil
+}
+
+func requireAuditBool(record audit.Record, name string, want bool) error {
+	got, err := auditBoolField(record, name)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("audit field %s.%s has the wrong boolean value", record.Kind, name)
+	}
+	return nil
+}
+
+func requireAuditOptionalUUID(record audit.Record, name string, want *string) error {
+	got, err := auditOptionalUUIDField(record, name)
+	if err != nil {
+		return err
+	}
+	if (got == nil) != (want == nil) || (got != nil && *got != *want) {
+		return fmt.Errorf("audit field %s.%s does not match", record.Kind, name)
+	}
+	return nil
+}
+
+func requireAuditAbsent(record audit.Record, name string) error {
+	value, err := auditField(record, name)
+	if err != nil {
+		return err
+	}
+	if !value.IsAbsent() {
+		return fmt.Errorf("audit field %s.%s must be absent", record.Kind, name)
+	}
+	return nil
+}
+
+func requireAuditAbsentFields(record audit.Record, fields ...string) error {
+	for _, field := range fields {
+		if err := requireAuditAbsent(record, field); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func auditValueEqual(left, right audit.Value) bool {
+	if left.IsAbsent() || right.IsAbsent() {
+		return left.IsAbsent() && right.IsAbsent()
+	}
+	if leftText, ok := left.TextValue(); ok {
+		rightText, rightOK := right.TextValue()
+		return rightOK && leftText == rightText
+	}
+	if leftTime, ok := left.TimestampValue(); ok {
+		rightTime, rightOK := right.TimestampValue()
+		return rightOK && leftTime == rightTime
+	}
+	return false
+}

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -1,0 +1,530 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+var initialAuditRecordKinds = map[string]bool{
+	"enrollment_baseline":       true,
+	"topology_genesis":          true,
+	"attached_metadata_genesis": true,
+	"event":                     true,
+	"canonical_mutation":        true,
+	"scope_chain_entry":         true,
+	"allocation_genesis":        true,
+	"allocation_entry":          true,
+}
+
+type auditRecordIndex struct {
+	operationID       *string
+	operationSequence *int64
+	scopeID           *string
+	entryCount        *int64
+	eventID           *string
+	eventOrdinal      *int64
+}
+
+type storedAuditRecord struct {
+	digest string
+	record audit.Record
+	index  auditRecordIndex
+}
+
+func exportAuditMetadata(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	var authority metadataAuditAuthority
+	err := tx.QueryRowContext(ctx, `SELECT lineage_id,operation_sequence_high_water,
+		allocation_genesis_digest,allocation_entry_count,allocation_head
+		FROM audit_authority WHERE singleton=1`).Scan(
+		&authority.LineageID, &authority.OperationSequenceHighWater,
+		&authority.AllocationGenesisDigest, &authority.AllocationEntryCount,
+		&authority.AllocationHead)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("exporting audit authority: %w", err)
+	}
+	authority.Type = metadataAuditAuthorityType
+	if err := write(authority); err != nil {
+		return err
+	}
+	if err := exportAuditScopes(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportAuditMemberships(ctx, tx, write); err != nil {
+		return err
+	}
+	return exportAuditRecords(ctx, tx, write)
+}
+
+func exportAuditScopes(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT scope_id,target_node_id,enable_operation_id,
+		entry_count,chain_head FROM audit_scopes ORDER BY scope_id`)
+	if err != nil {
+		return fmt.Errorf("exporting audit scopes: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataAuditScope{Type: metadataAuditScopeType}
+		if err := rows.Scan(&value.ScopeID, &value.TargetNodeID, &value.EnableOperationID,
+			&value.EntryCount, &value.ChainHead); err != nil {
+			return fmt.Errorf("scanning audit scope: %w", err)
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("audit scopes", rows)
+}
+
+func exportAuditMemberships(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT scope_id,node_id,baseline_digest
+		FROM audit_memberships ORDER BY scope_id,node_id`)
+	if err != nil {
+		return fmt.Errorf("exporting audit memberships: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataAuditMembership{Type: metadataAuditMembershipType}
+		if err := rows.Scan(&value.ScopeID, &value.NodeID, &value.BaselineDigest); err != nil {
+			return fmt.Errorf("scanning audit membership: %w", err)
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("audit memberships", rows)
+}
+
+func exportAuditRecords(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT digest,record_json FROM audit_records
+		ORDER BY CASE kind
+		  WHEN 'topology_genesis' THEN 1
+		  WHEN 'attached_metadata_genesis' THEN 2
+		  WHEN 'allocation_genesis' THEN 3
+		  WHEN 'enrollment_baseline' THEN 4
+		  WHEN 'event' THEN 5
+		  WHEN 'canonical_mutation' THEN 6
+		  WHEN 'scope_chain_entry' THEN 7
+		  WHEN 'allocation_entry' THEN 8
+		  ELSE 99 END,
+		COALESCE(operation_sequence,0),COALESCE(scope_id,''),
+		COALESCE(entry_count,0),COALESCE(event_ordinal,0),digest`)
+	if err != nil {
+		return fmt.Errorf("exporting audit records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataAuditRecord{Type: metadataAuditRecordType}
+		var recordJSON string
+		if err := rows.Scan(&value.Digest, &recordJSON); err != nil {
+			return fmt.Errorf("scanning audit record: %w", err)
+		}
+		value.Record = json.RawMessage(recordJSON)
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("audit records", rows)
+}
+
+func importAuditAuthority(ctx context.Context, tx *sql.Tx, value metadataAuditAuthority) error {
+	if err := validateAuditAuthorityRecord(value); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `INSERT INTO audit_authority(
+		singleton,lineage_id,operation_sequence_high_water,allocation_genesis_digest,
+		allocation_entry_count,allocation_head) VALUES(1,?,?,?,?,?)`, value.LineageID,
+		value.OperationSequenceHighWater, value.AllocationGenesisDigest,
+		value.AllocationEntryCount, value.AllocationHead)
+	return err
+}
+
+func importAuditScope(ctx context.Context, tx *sql.Tx, value metadataAuditScope) error {
+	if err := validateAuditScopeRecord(value); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `INSERT INTO audit_scopes(
+		scope_id,target_node_id,enable_operation_id,entry_count,chain_head)
+		VALUES(?,?,?,?,?)`, value.ScopeID, value.TargetNodeID, value.EnableOperationID,
+		value.EntryCount, value.ChainHead)
+	return err
+}
+
+func importAuditMembership(ctx context.Context, tx *sql.Tx, value metadataAuditMembership) error {
+	if err := validateAuditMembershipRecord(value); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `INSERT INTO audit_memberships(
+		scope_id,node_id,baseline_digest) VALUES(?,?,?)`,
+		value.ScopeID, value.NodeID, value.BaselineDigest)
+	return err
+}
+
+func importAuditRecord(ctx context.Context, tx *sql.Tx, value metadataAuditRecord) error {
+	record, index, canonical, err := validateAuditRecord(value)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO audit_records(
+		digest,kind,operation_id,operation_sequence,scope_id,entry_count,
+		event_id,event_ordinal,record_json) VALUES(?,?,?,?,?,?,?,?,?)`,
+		value.Digest, record.Kind, index.operationID, index.operationSequence,
+		index.scopeID, index.entryCount, index.eventID, index.eventOrdinal, string(canonical))
+	if err != nil || record.Kind != "enrollment_baseline" {
+		return err
+	}
+	scopeID, err := auditUUIDField(record, "scope_id")
+	if err != nil {
+		return err
+	}
+	targetNodeID, err := auditUnsignedField(record, "target_node_id")
+	if err != nil {
+		return err
+	}
+	operationID, err := auditUUIDField(record, "operation_id")
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO audit_baselines(
+		digest,scope_id,target_node_id,operation_id) VALUES(?,?,?,?)`,
+		value.Digest, scopeID, targetNodeID, operationID)
+	return err
+}
+
+func validateAuditAuthorityRecord(value metadataAuditAuthority) error {
+	if value.Type != metadataAuditAuthorityType || value.OperationSequenceHighWater == 0 ||
+		value.OperationSequenceHighWater > math.MaxInt64 || value.AllocationEntryCount == 0 ||
+		value.AllocationEntryCount > math.MaxInt64 {
+		return errors.New("invalid audit authority record")
+	}
+	if err := validateUUIDv4(value.LineageID); err != nil {
+		return fmt.Errorf("invalid audit lineage ID: %w", err)
+	}
+	if err := validateAuditDigest("allocation genesis", value.AllocationGenesisDigest); err != nil {
+		return err
+	}
+	return validateAuditDigest("allocation head", value.AllocationHead)
+}
+
+func validateAuditScopeRecord(value metadataAuditScope) error {
+	if value.Type != metadataAuditScopeType || value.TargetNodeID == 0 ||
+		value.TargetNodeID > math.MaxInt64 || value.EntryCount == 0 || value.EntryCount > math.MaxInt64 {
+		return errors.New("invalid audit scope record")
+	}
+	if err := validateUUIDv4(value.ScopeID); err != nil {
+		return fmt.Errorf("invalid audit scope ID: %w", err)
+	}
+	if err := validateUUIDv4(value.EnableOperationID); err != nil {
+		return fmt.Errorf("invalid audit enable operation ID: %w", err)
+	}
+	return validateAuditDigest("scope chain head", value.ChainHead)
+}
+
+func validateAuditMembershipRecord(value metadataAuditMembership) error {
+	if value.Type != metadataAuditMembershipType || value.NodeID == 0 || value.NodeID > math.MaxInt64 {
+		return errors.New("invalid audit membership record")
+	}
+	if err := validateUUIDv4(value.ScopeID); err != nil {
+		return fmt.Errorf("invalid audit membership scope ID: %w", err)
+	}
+	return validateAuditDigest("membership baseline", value.BaselineDigest)
+}
+
+func validateAuditRecord(value metadataAuditRecord) (audit.Record, auditRecordIndex, []byte, error) {
+	if value.Type != metadataAuditRecordType {
+		return audit.Record{}, auditRecordIndex{}, nil, errors.New("invalid audit record wrapper")
+	}
+	if err := validateAuditDigest("record", value.Digest); err != nil {
+		return audit.Record{}, auditRecordIndex{}, nil, err
+	}
+	record, err := audit.UnmarshalJSONRecord(value.Record)
+	if err != nil {
+		return audit.Record{}, auditRecordIndex{}, nil,
+			fmt.Errorf("decoding canonical audit record: %w", err)
+	}
+	if !initialAuditRecordKinds[record.Kind] {
+		return audit.Record{}, auditRecordIndex{}, nil,
+			fmt.Errorf("audit record kind %q is not valid before mutation enforcement", record.Kind)
+	}
+	digest, err := audit.Hash(record)
+	if err != nil {
+		return audit.Record{}, auditRecordIndex{}, nil, err
+	}
+	if hex.EncodeToString(digest[:]) != value.Digest {
+		return audit.Record{}, auditRecordIndex{}, nil,
+			errors.New("audit record digest does not match its canonical fields")
+	}
+	canonical, err := audit.MarshalJSONRecord(record)
+	if err != nil {
+		return audit.Record{}, auditRecordIndex{}, nil, err
+	}
+	index, err := indexAuditRecord(record)
+	if err != nil {
+		return audit.Record{}, auditRecordIndex{}, nil, err
+	}
+	return record, index, canonical, nil
+}
+
+func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
+	var index auditRecordIndex
+	switch record.Kind {
+	case "enrollment_baseline":
+		operationID, err := auditUUIDField(record, "operation_id")
+		if err != nil {
+			return index, err
+		}
+		scopeID, err := auditUUIDField(record, "scope_id")
+		if err != nil {
+			return index, err
+		}
+		index.operationID, index.scopeID = &operationID, &scopeID
+	case "event":
+		event, err := auditNestedField(record, "event")
+		if err != nil {
+			return index, err
+		}
+		operationID, err := auditUUIDField(event, "operation_id")
+		if err != nil {
+			return index, err
+		}
+		scopeID, err := auditUUIDField(event, "scope_id")
+		if err != nil {
+			return index, err
+		}
+		eventID, err := auditDigestField(event, "event_id")
+		if err != nil {
+			return index, err
+		}
+		ordinal, err := auditInt64UnsignedField(event, "event_ordinal")
+		if err != nil {
+			return index, err
+		}
+		index.operationID, index.scopeID = &operationID, &scopeID
+		index.eventID, index.eventOrdinal = &eventID, &ordinal
+	case "canonical_mutation", "allocation_entry":
+		operationID, err := auditUUIDField(record, "operation_id")
+		if err != nil {
+			return index, err
+		}
+		sequence, err := auditInt64UnsignedField(record, "operation_sequence")
+		if err != nil {
+			return index, err
+		}
+		index.operationID, index.operationSequence = &operationID, &sequence
+	case "scope_chain_entry":
+		scopeID, err := auditUUIDField(record, "scope_id")
+		if err != nil {
+			return index, err
+		}
+		entryCount, err := auditInt64UnsignedField(record, "entry_count")
+		if err != nil {
+			return index, err
+		}
+		index.scopeID, index.entryCount = &scopeID, &entryCount
+	case "topology_genesis", "attached_metadata_genesis", "allocation_genesis":
+	default:
+		return index, fmt.Errorf("unsupported initial audit record kind %q", record.Kind)
+	}
+	return index, nil
+}
+
+func validateAuditDigest(subject, value string) error {
+	if _, err := audit.DigestHex(value); err != nil {
+		return fmt.Errorf("invalid audit %s digest: %w", subject, err)
+	}
+	return nil
+}
+
+func auditField(record audit.Record, name string) (audit.Value, error) {
+	value, ok := audit.FieldValue(record, name)
+	if !ok {
+		return audit.Value{}, fmt.Errorf("audit record %s lacks field %q", record.Kind, name)
+	}
+	return value, nil
+}
+
+func auditUUIDField(record audit.Record, name string) (string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return "", err
+	}
+	result, ok := value.UUIDValue()
+	if !ok {
+		return "", fmt.Errorf("audit field %s.%s is not a UUID", record.Kind, name)
+	}
+	return result, nil
+}
+
+func auditDigestField(record audit.Record, name string) (string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return "", err
+	}
+	result, ok := value.DigestValue()
+	if !ok {
+		return "", fmt.Errorf("audit field %s.%s is not a digest", record.Kind, name)
+	}
+	return result, nil
+}
+
+func auditTextField(record audit.Record, name string) (string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return "", err
+	}
+	result, ok := value.TextValue()
+	if !ok {
+		return "", fmt.Errorf("audit field %s.%s is not text", record.Kind, name)
+	}
+	return result, nil
+}
+
+func auditBoolField(record audit.Record, name string) (bool, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return false, err
+	}
+	result, ok := value.BoolValue()
+	if !ok {
+		return false, fmt.Errorf("audit field %s.%s is not boolean", record.Kind, name)
+	}
+	return result, nil
+}
+
+func auditOptionalUUIDField(record audit.Record, name string) (*string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent optional UUID.
+	}
+	result, ok := value.UUIDValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not an optional UUID", record.Kind, name)
+	}
+	return &result, nil
+}
+
+func auditUnsignedField(record audit.Record, name string) (uint64, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return 0, err
+	}
+	result, ok := value.UnsignedValue()
+	if !ok {
+		return 0, fmt.Errorf("audit field %s.%s is not unsigned", record.Kind, name)
+	}
+	return result, nil
+}
+
+func auditInt64UnsignedField(record audit.Record, name string) (int64, error) {
+	value, err := auditUnsignedField(record, name)
+	if err != nil {
+		return 0, err
+	}
+	if value > math.MaxInt64 {
+		return 0, fmt.Errorf("audit field %s.%s exceeds SQLite integer range", record.Kind, name)
+	}
+	return int64(value), nil
+}
+
+func auditNestedField(record audit.Record, name string) (audit.Record, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	result, ok := value.RecordValue()
+	if !ok {
+		return audit.Record{}, fmt.Errorf("audit field %s.%s is not a nested record", record.Kind, name)
+	}
+	return result, nil
+}
+
+func auditListField(record audit.Record, name string) ([]audit.Value, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	result, ok := value.ListValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not a list", record.Kind, name)
+	}
+	return result, nil
+}
+
+func auditRecordList(values []audit.Value) ([]audit.Record, error) {
+	result := make([]audit.Record, len(values))
+	for index, value := range values {
+		record, ok := value.RecordValue()
+		if !ok {
+			return nil, fmt.Errorf("audit list item %d is not a nested record", index)
+		}
+		result[index] = record
+	}
+	return result, nil
+}
+
+func auditUnsignedList(values []audit.Value) ([]uint64, error) {
+	result := make([]uint64, len(values))
+	for index, value := range values {
+		item, ok := value.UnsignedValue()
+		if !ok {
+			return nil, fmt.Errorf("audit list item %d is not unsigned", index)
+		}
+		result[index] = item
+	}
+	return result, nil
+}
+
+func auditRecordEqual(left, right audit.Record) bool {
+	leftBytes, leftErr := audit.Encode(left)
+	rightBytes, rightErr := audit.Encode(right)
+	return leftErr == nil && rightErr == nil && bytes.Equal(leftBytes, rightBytes)
+}
+
+func sortAuditRecordsByCanonicalIdentity(
+	records []audit.Record, identity func(audit.Record) (audit.Record, error),
+) error {
+	type keyed struct {
+		record audit.Record
+		kind   string
+		key    []byte
+	}
+	items := make([]keyed, len(records))
+	for index, record := range records {
+		identityRecord, err := identity(record)
+		if err != nil {
+			return err
+		}
+		key, err := audit.Encode(identityRecord)
+		if err != nil {
+			return err
+		}
+		items[index] = keyed{record: record, kind: record.Kind, key: key}
+	}
+	slices.SortFunc(items, func(left, right keyed) int {
+		if left.kind < right.kind {
+			return -1
+		}
+		if left.kind > right.kind {
+			return 1
+		}
+		return bytes.Compare(left.key, right.key)
+	})
+	for index := range items {
+		records[index] = items[index].record
+	}
+	return nil
+}

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -245,6 +245,12 @@ func TestInitialAuditAuthorityFreezesLogicalMetadata(t *testing.T) {
 	seedInitialAuditAuthority(t, s, target.ID)
 
 	statements := []string{
+		`UPDATE vault_metadata SET vault_id=vault_id WHERE singleton=1`,
+		`DELETE FROM vault_metadata WHERE singleton=1`,
+		`INSERT INTO audit_records(digest,kind,record_json) VALUES('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee','event','{}')`,
+		`INSERT INTO audit_scopes(scope_id,target_node_id,enable_operation_id,entry_count,chain_head) VALUES('99999999-9999-4999-8999-999999999999',1,'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',1,'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')`,
+		`INSERT INTO audit_baselines(digest,scope_id,target_node_id,operation_id) VALUES('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee','66666666-6666-4666-8666-666666666666',7,'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')`,
+		`INSERT INTO audit_memberships(scope_id,node_id,baseline_digest) SELECT scope_id,1,digest FROM audit_scopes JOIN audit_baselines USING(scope_id)`,
 		`UPDATE nodes SET name=name WHERE id=1`,
 		`UPDATE content_versions SET mime_type=mime_type WHERE node_id=10`,
 		`INSERT INTO blobs(hash,size,created_at) VALUES('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',1,'2026-07-17T00:00:00.000000000Z')`,

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -1,0 +1,626 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+const (
+	testAuditScopeID     = "66666666-6666-4666-8666-666666666666"
+	testAuditOperationID = "77777777-7777-4777-8777-777777777777"
+	testAuditLineageID   = "88888888-8888-4888-8888-888888888888"
+	testAuditTimestamp   = "2026-07-17T12:34:56.123456789Z"
+)
+
+func TestInitialAuditAuthorityMetadataRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	target, err := source.NodeByPath(ctx, "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, source, target.ID)
+
+	var first, second bytes.Buffer
+	require.NoError(t, source.ExportMetadata(ctx, &first))
+	require.NoError(t, source.ExportMetadata(ctx, &second))
+	assert.Equal(t, first.Bytes(), second.Bytes())
+	assert.Contains(t, first.String(), `"type":"audit_authority"`)
+	assert.Contains(t, first.String(), `"type":"audit_scope"`)
+	assert.Contains(t, first.String(), `"kind":"allocation_entry"`)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(ctx, bytes.NewReader(first.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(ctx, &roundTrip))
+	assert.Equal(t, first.Bytes(), roundTrip.Bytes())
+
+	var scopes, memberships, records int64
+	require.NoError(t, restored.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM audit_scopes),
+		(SELECT COUNT(*) FROM audit_memberships),
+		(SELECT COUNT(*) FROM audit_records)`).Scan(&scopes, &memberships, &records))
+	assert.Equal(t, int64(1), scopes)
+	assert.Equal(t, int64(3), memberships, "scope adopts live descendants and retained origin trash")
+	assert.Equal(t, int64(8), records)
+}
+
+func TestInitialAuditAuthorityImportRejectsCorruptionAndRollsBack(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	target, err := source.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, source, target.ID)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+
+	corrupt := mutateAuditMetadataRecord(t, exported.Bytes(), metadataAuditAuthorityType, func(raw []byte) []byte {
+		var authority metadataAuditAuthority
+		require.NoError(t, json.Unmarshal(raw, &authority))
+		authority.AllocationHead = metadataHashTrashed
+		result, marshalErr := json.Marshal(authority)
+		require.NoError(t, marshalErr)
+		return result
+	})
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	originalVaultID := restored.VaultID()
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(corrupt))
+	require.ErrorContains(t, err, "initial allocation authority does not match")
+	assert.Equal(t, originalVaultID, restored.VaultID())
+	var nodes, auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&nodes))
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&auditRows))
+	assert.Equal(t, int64(1), nodes)
+	assert.Zero(t, auditRows)
+}
+
+func TestInitialAuditAuthorityImportRejectsIncompleteMembership(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	target, err := source.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, source, target.ID)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+
+	incomplete := removeFirstAuditMetadataRecord(t, exported.Bytes(), metadataAuditMembershipType)
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(incomplete))
+	require.ErrorContains(t, err, "membership projection does not match")
+	var records int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&records))
+	assert.Zero(t, records)
+}
+
+func TestInitialAuditAuthorityImportActivatesAfterWholeStream(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	target, err := source.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, source, target.ID)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+
+	reordered := moveFirstMetadataRecordAfterHeader(t, exported.Bytes(), metadataAuditAuthorityType)
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(reordered)))
+	require.NoError(t, restored.ExportMetadata(t.Context(), &bytes.Buffer{}))
+}
+
+func TestInitialAuditRootEnrollmentAdoptsUnknownOriginTrash(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	_, err = source.db.Exec(`UPDATE nodes SET trash_parent=NULL WHERE id=11`)
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, source, source.RootID())
+
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var memberships int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_memberships`).Scan(&memberships))
+	assert.Equal(t, int64(5), memberships, "root scope adopts live nodes and unresolved retained trash")
+}
+
+func TestImportMetadataRejectsOrphanAuditRecord(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	record := audit.Record{Kind: "scope_chain_entry", Fields: []audit.Field{
+		{Name: "vault_id", Value: mustAuditUUID(t, source.VaultID())},
+		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
+		{Name: "entry_count", Value: audit.Unsigned(1)},
+		{Name: "previous_head", Value: audit.Absent()},
+		{Name: "mutation_hash", Value: mustAuditDigest(t, metadataHashCurrent)},
+	}}
+	recordJSON, err := audit.MarshalJSONRecord(record)
+	require.NoError(t, err)
+	input := appendMetadataRecords(t, exported.Bytes(), metadataAuditRecord{
+		Type: metadataAuditRecordType, Digest: mustAuditRecordDigest(t, record), Record: recordJSON,
+	})
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(input))
+	require.ErrorContains(t, err, "dormant audit authority")
+	var records int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&records))
+	assert.Zero(t, records)
+}
+
+func TestImportMetadataRejectsAuditRecordDigestMismatch(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	target, err := source.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, source, target.ID)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	corrupt := mutateAuditMetadataRecord(t, exported.Bytes(), metadataAuditRecordType, func(raw []byte) []byte {
+		var wrapper metadataAuditRecord
+		require.NoError(t, json.Unmarshal(raw, &wrapper))
+		var record map[string]any
+		require.NoError(t, json.Unmarshal(wrapper.Record, &record))
+		fields, ok := record["fields"].(map[string]any)
+		require.True(t, ok)
+		fields["lineage_id"] = "99999999-9999-4999-8999-999999999999"
+		wrapper.Record, err = json.Marshal(record)
+		require.NoError(t, err)
+		result, err := json.Marshal(wrapper)
+		require.NoError(t, err)
+		return result
+	})
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(corrupt))
+	require.ErrorContains(t, err, "digest does not match")
+	var records int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&records))
+	assert.Zero(t, records)
+}
+
+func TestInitialAuditAuthorityBlocksPartialAndMutableState(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, target.ID)
+
+	_, err = s.db.Exec(`UPDATE audit_records SET record_json='{}'`)
+	require.ErrorContains(t, err, "audit records are immutable")
+	_, err = s.db.Exec(`DELETE FROM audit_memberships`)
+	require.ErrorContains(t, err, "audit memberships are immutable")
+	var wrongHead string
+	require.NoError(t, s.db.QueryRow(
+		`SELECT digest FROM audit_records WHERE kind='allocation_entry'`).Scan(&wrongHead))
+	_, err = s.db.Exec(`UPDATE audit_scopes SET chain_head=?`, wrongHead)
+	require.ErrorContains(t, err, "audited metadata is read-only")
+	require.NoError(t, s.ExportMetadata(t.Context(), &bytes.Buffer{}))
+}
+
+func TestInitialAuditAuthorityFreezesLogicalMetadata(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, target.ID)
+
+	statements := []string{
+		`UPDATE nodes SET name=name WHERE id=1`,
+		`UPDATE content_versions SET mime_type=mime_type WHERE node_id=10`,
+		`INSERT INTO blobs(hash,size,created_at) VALUES('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',1,'2026-07-17T00:00:00.000000000Z')`,
+		`INSERT INTO ingests(id,started_at,source_kind,source_desc) VALUES('99999999-9999-4999-8999-999999999999','2026-07-17T00:00:00.000000000Z','cli','blocked')`,
+		`INSERT INTO provenance(identity,node_id,ingest_id,original_path) VALUES('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',10,'44444444-4444-4444-8444-444444444444','/blocked')`,
+		`INSERT INTO tags(id,name) VALUES('99999999-9999-4999-8999-999999999999','blocked')`,
+		`INSERT INTO node_tags(node_id,tag_id) VALUES(7,'55555555-5555-4555-8555-555555555555')`,
+		`UPDATE node_tags SET node_id=7 WHERE node_id=10`,
+	}
+	for _, statement := range statements {
+		_, err := s.db.Exec(statement)
+		require.ErrorContains(t, err, "audited metadata is read-only", statement)
+	}
+
+	_, err = s.Mkdir(t.Context(), s.RootID(), "blocked")
+	require.ErrorContains(t, err, "audited metadata is read-only")
+	_, err = s.CreateTag(t.Context(), "blocked")
+	require.ErrorContains(t, err, "audited metadata is read-only")
+	_, err = s.BeginIngest(t.Context(), "cli", "blocked")
+	require.ErrorContains(t, err, "audited metadata is read-only")
+	_, err = s.TrashEmpty(t.Context(), 0, true)
+	require.ErrorContains(t, err, "audited metadata is read-only")
+}
+
+func TestInitialAuditAuthorityReopens(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault.db")
+	s, err := Open(path)
+	require.NoError(t, err)
+	seedMetadataRoundTrip(t, s)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, target.ID)
+	require.NoError(t, s.Close())
+
+	reopened, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+	require.NoError(t, reopened.ExportMetadata(t.Context(), &bytes.Buffer{}))
+}
+
+func seedInitialAuditAuthority(t *testing.T, s *Store, targetNodeID int64) {
+	t.Helper()
+	ctx := context.Background()
+	topology, err := currentAuditTopology(ctx, s.db)
+	require.NoError(t, err)
+	attachments, err := currentAuditAttachments(ctx, s.db)
+	require.NoError(t, err)
+	var nodeSequence int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT seq FROM sqlite_sequence WHERE name='nodes'`).Scan(&nodeSequence))
+
+	topologyGenesis := audit.Record{Kind: "topology_genesis", Fields: []audit.Field{
+		{Name: "vault_id", Value: mustAuditUUID(t, s.VaultID())},
+		{Name: "lineage_id", Value: mustAuditUUID(t, testAuditLineageID)},
+		{Name: "nodes", Value: audit.List(auditNestedValues(topology)...)},
+	}}
+	attachmentGenesis := audit.Record{Kind: "attached_metadata_genesis", Fields: []audit.Field{
+		{Name: "vault_id", Value: mustAuditUUID(t, s.VaultID())},
+		{Name: "lineage_id", Value: mustAuditUUID(t, testAuditLineageID)},
+		{Name: "records", Value: audit.List(auditNestedValues(attachments)...)},
+	}}
+	topologyDigest := mustAuditRecordDigest(t, topologyGenesis)
+	attachmentDigest := mustAuditRecordDigest(t, attachmentGenesis)
+	allocationGenesis := audit.Record{Kind: "allocation_genesis", Fields: []audit.Field{
+		{Name: "vault_id", Value: mustAuditUUID(t, s.VaultID())},
+		{Name: "lineage_id", Value: mustAuditUUID(t, testAuditLineageID)},
+		{Name: "previous_head", Value: audit.Absent()},
+		{Name: "node_id_high_water", Value: audit.Unsigned(uint64(nodeSequence))},
+		{Name: "operation_sequence_high_water", Value: audit.Unsigned(0)},
+		{Name: "topology_count", Value: audit.Unsigned(uint64(len(topology)))},
+		{Name: "topology_digest", Value: mustAuditDigest(t, topologyDigest)},
+		{Name: "attached_metadata_count", Value: audit.Unsigned(uint64(len(attachments)))},
+		{Name: "attached_metadata_digest", Value: mustAuditDigest(t, attachmentDigest)},
+	}}
+	allocationGenesisDigest := mustAuditRecordDigest(t, allocationGenesis)
+
+	members, err := deriveInitialAuditMembers(ctx, s.db, uint64(targetNodeID))
+	require.NoError(t, err)
+	states, err := currentAuditMemberStates(ctx, s.db, members)
+	require.NoError(t, err)
+	versions, err := currentAuditVersions(ctx, s.db, members)
+	require.NoError(t, err)
+	baselineAttachments, err := auditRecordsForNodes(attachments, auditMemberSet(members))
+	require.NoError(t, err)
+	baselineNodes, witnesses, err := initialBaselineTopology(topology, members, testAuditOperationID)
+	require.NoError(t, err)
+	baseline := makeAuditEnrollmentBaseline(t, s.VaultID(), targetNodeID, members,
+		states, versions, baselineAttachments, baselineNodes, witnesses)
+	baselineDigest := mustAuditRecordDigest(t, baseline)
+	event := makeInitialAuditEvent(t, targetNodeID, baselineDigest, states)
+	eventWrapper := audit.Record{Kind: "event", Fields: []audit.Field{
+		{Name: "event", Value: audit.Nested(event)},
+	}}
+	mutation := makeInitialAuditMutation(t, s.VaultID(), targetNodeID, baselineDigest, event)
+	mutationDigest := mustAuditRecordDigest(t, mutation)
+	scopeEntry := audit.Record{Kind: "scope_chain_entry", Fields: []audit.Field{
+		{Name: "vault_id", Value: mustAuditUUID(t, s.VaultID())},
+		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
+		{Name: "entry_count", Value: audit.Unsigned(1)},
+		{Name: "previous_head", Value: audit.Absent()},
+		{Name: "mutation_hash", Value: mustAuditDigest(t, mutationDigest)},
+	}}
+	allocationEntry := makeInitialAllocationEntry(t, s.VaultID(), nodeSequence,
+		allocationGenesisDigest, mutationDigest)
+
+	records := []audit.Record{topologyGenesis, attachmentGenesis, allocationGenesis,
+		baseline, eventWrapper, mutation, scopeEntry, allocationEntry}
+	require.NoError(t, s.withTx(ctx, func(tx *sql.Tx) error {
+		for _, record := range records {
+			if err := insertAuditRecordFixture(tx, record); err != nil {
+				return err
+			}
+		}
+		scopeHead := mustAuditRecordDigest(t, scopeEntry)
+		allocationHead := mustAuditRecordDigest(t, allocationEntry)
+		if _, err := tx.Exec(`INSERT INTO audit_authority VALUES(1,?,?,?,1,?)`,
+			testAuditLineageID, 1, allocationGenesisDigest, allocationHead); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`INSERT INTO audit_scopes VALUES(?,?,?,1,?)`,
+			testAuditScopeID, targetNodeID, testAuditOperationID, scopeHead); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`INSERT INTO audit_baselines VALUES(?,?,?,?)`,
+			baselineDigest, testAuditScopeID, targetNodeID, testAuditOperationID); err != nil {
+			return err
+		}
+		for _, member := range members {
+			if _, err := tx.Exec(`INSERT INTO audit_memberships VALUES(?,?,?)`,
+				testAuditScopeID, member, baselineDigest); err != nil {
+				return err
+			}
+		}
+		_, err := tx.Exec(`INSERT INTO audit_write_guard VALUES(1)`)
+		return err
+	}))
+}
+
+func makeAuditEnrollmentBaseline(
+	t *testing.T, vaultID string, targetNodeID int64, members []uint64,
+	states, versions, attachments, nodes, witnesses []audit.Record,
+) audit.Record {
+	t.Helper()
+	memberValues := make([]audit.Value, len(members))
+	for index, member := range members {
+		memberValues[index] = audit.Unsigned(member)
+	}
+	return audit.Record{Kind: "enrollment_baseline", Fields: []audit.Field{
+		{Name: "vault_id", Value: mustAuditUUID(t, vaultID)},
+		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
+		{Name: "target_node_id", Value: audit.Unsigned(uint64(targetNodeID))},
+		{Name: "operation_id", Value: mustAuditUUID(t, testAuditOperationID)},
+		{Name: "cause", Value: mustAuditText(t, "explicit")},
+		{Name: "members", Value: audit.List(memberValues...)},
+		{Name: "member_states", Value: audit.List(auditNestedValues(states)...)},
+		{Name: "nodes", Value: audit.List(auditNestedValues(nodes)...)},
+		{Name: "versions", Value: audit.List(auditNestedValues(versions)...)},
+		{Name: "attachments", Value: audit.List(auditNestedValues(attachments)...)},
+		{Name: "witnesses", Value: audit.List(auditNestedValues(witnesses)...)},
+	}}
+}
+
+func makeInitialAuditEvent(
+	t *testing.T, targetNodeID int64, baselineDigest string, states []audit.Record,
+) audit.Record {
+	t.Helper()
+	operation := mustAuditUUID(t, testAuditOperationID)
+	eventIdentity := audit.Record{Kind: "event_identity", Fields: []audit.Field{
+		{Name: "operation_id", Value: operation},
+		{Name: "event_ordinal", Value: audit.Unsigned(0)},
+	}}
+	identityDigest := mustAuditRecordDigest(t, eventIdentity)
+	var targetState audit.Record
+	for _, state := range states {
+		id, err := auditUnsignedField(state, metadataNodeIDField)
+		require.NoError(t, err)
+		if id == uint64(targetNodeID) {
+			targetState = state
+		}
+	}
+	require.NotEmpty(t, targetState.Kind)
+	revision, err := auditUnsignedField(targetState, "node_revision")
+	require.NoError(t, err)
+	current, err := auditField(targetState, "current_version_id")
+	require.NoError(t, err)
+	return audit.Record{Kind: "audit_event", Fields: []audit.Field{
+		{Name: "event_id", Value: mustAuditDigest(t, identityDigest)},
+		{Name: "operation_id", Value: operation},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(uint64(targetNodeID))},
+		{Name: "event_kind", Value: mustAuditText(t, "audit_enroll")},
+		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
+		{Name: "target_node_id", Value: audit.Unsigned(uint64(targetNodeID))},
+		{Name: "attachment_kind", Value: audit.Absent()},
+		{Name: "attachment_identity", Value: audit.Absent()},
+		{Name: "source_version_id", Value: audit.Absent()},
+		{Name: "event_ordinal", Value: audit.Unsigned(0)},
+		{Name: "recorded_at", Value: mustAuditTimestamp(t, testAuditTimestamp)},
+		{Name: "prior_node_revision", Value: audit.Unsigned(revision)},
+		{Name: "resulting_node_revision", Value: audit.Unsigned(revision)},
+		{Name: "prior_current_version_id", Value: current},
+		{Name: "resulting_current_version_id", Value: current},
+		{Name: "origin", Value: mustAuditText(t, "cli")},
+		{Name: "agent_label", Value: audit.Absent()},
+		{Name: "pre", Value: audit.Absent()},
+		{Name: "post", Value: audit.Absent()},
+		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: "baseline_digest", Value: mustAuditDigest(t, baselineDigest)},
+	}}
+}
+
+func makeInitialAuditMutation(
+	t *testing.T, vaultID string, targetNodeID int64, baselineDigest string,
+	event audit.Record,
+) audit.Record {
+	t.Helper()
+	binding := audit.Record{Kind: "baseline_binding", Fields: []audit.Field{
+		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
+		{Name: "target_node_id", Value: audit.Unsigned(uint64(targetNodeID))},
+		{Name: "baseline_digest", Value: mustAuditDigest(t, baselineDigest)},
+	}}
+	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
+		{Name: "vault_id", Value: mustAuditUUID(t, vaultID)},
+		{Name: "operation_sequence", Value: audit.Unsigned(1)},
+		{Name: "operation_id", Value: mustAuditUUID(t, testAuditOperationID)},
+		{Name: "grouping_id", Value: audit.Absent()},
+		{Name: "recorded_at", Value: mustAuditTimestamp(t, testAuditTimestamp)},
+		{Name: "origin", Value: mustAuditText(t, "cli")},
+		{Name: "agent_label", Value: audit.Absent()},
+		{Name: "events", Value: audit.List(audit.Nested(event))},
+		{Name: "member_state_changes", Value: audit.List()},
+		{Name: "baselines", Value: audit.List(audit.Nested(binding))},
+		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: "path_effect_count", Value: audit.Unsigned(0)},
+		{Name: "path_effect_digest", Value: audit.Absent()},
+		{Name: "witness_change_count", Value: audit.Unsigned(0)},
+		{Name: "witness_change_digest", Value: audit.Absent()},
+		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
+		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+	}}
+}
+
+func makeInitialAllocationEntry(
+	t *testing.T, vaultID string, nodeSequence int64, genesisDigest, mutationDigest string,
+) audit.Record {
+	t.Helper()
+	return audit.Record{Kind: "allocation_entry", Fields: []audit.Field{
+		{Name: "vault_id", Value: mustAuditUUID(t, vaultID)},
+		{Name: "lineage_id", Value: mustAuditUUID(t, testAuditLineageID)},
+		{Name: "previous_head", Value: mustAuditDigest(t, genesisDigest)},
+		{Name: "operation_sequence", Value: audit.Unsigned(1)},
+		{Name: "operation_id", Value: mustAuditUUID(t, testAuditOperationID)},
+		{Name: "allocated_node_ids", Value: audit.List()},
+		{Name: "node_id_high_water", Value: audit.Unsigned(uint64(nodeSequence))},
+		{Name: "operation_sequence_high_water", Value: audit.Unsigned(1)},
+		{Name: "has_audited_mutation", Value: audit.Bool(true)},
+		{Name: "mutation_hash", Value: mustAuditDigest(t, mutationDigest)},
+		{Name: "has_topology_change", Value: audit.Bool(false)},
+		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: "has_witness_change", Value: audit.Bool(false)},
+		{Name: "witness_change_count", Value: audit.Unsigned(0)},
+		{Name: "witness_change_digest", Value: audit.Absent()},
+		{Name: "has_attached_metadata_change", Value: audit.Bool(false)},
+		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
+		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+	}}
+}
+
+func insertAuditRecordFixture(tx *sql.Tx, record audit.Record) error {
+	digestValue, err := audit.Hash(record)
+	if err != nil {
+		return err
+	}
+	digest := hex.EncodeToString(digestValue[:])
+	recordJSON, err := audit.MarshalJSONRecord(record)
+	if err != nil {
+		return err
+	}
+	index, err := indexAuditRecord(record)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(`INSERT INTO audit_records(digest,kind,operation_id,operation_sequence,
+		scope_id,entry_count,event_id,event_ordinal,record_json) VALUES(?,?,?,?,?,?,?,?,?)`,
+		digest, record.Kind, index.operationID, index.operationSequence, index.scopeID,
+		index.entryCount, index.eventID, index.eventOrdinal, string(recordJSON))
+	return err
+}
+
+func mustAuditRecordDigest(t *testing.T, record audit.Record) string {
+	t.Helper()
+	digest, err := audit.Hash(record)
+	require.NoError(t, err)
+	return hex.EncodeToString(digest[:])
+}
+
+func mustAuditUUID(t *testing.T, value string) audit.Value {
+	t.Helper()
+	result, err := audit.UUID(value)
+	require.NoError(t, err)
+	return result
+}
+
+func mustAuditDigest(t *testing.T, value string) audit.Value {
+	t.Helper()
+	result, err := audit.DigestHex(value)
+	require.NoError(t, err)
+	return result
+}
+
+func mustAuditText(t *testing.T, value string) audit.Value {
+	t.Helper()
+	result, err := audit.Text(value)
+	require.NoError(t, err)
+	return result
+}
+
+func mustAuditTimestamp(t *testing.T, value string) audit.Value {
+	t.Helper()
+	result, err := audit.Timestamp(value)
+	require.NoError(t, err)
+	return result
+}
+
+func mutateAuditMetadataRecord(
+	t *testing.T, input []byte, kind string, mutate func([]byte) []byte,
+) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	for index, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type == kind {
+			lines[index] = mutate(line)
+			return append(bytes.Join(lines, []byte{'\n'}), '\n')
+		}
+	}
+	require.FailNow(t, "metadata record not found", kind)
+	return nil
+}
+
+func removeFirstAuditMetadataRecord(t *testing.T, input []byte, kind string) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	for index, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type == kind {
+			lines = append(lines[:index], lines[index+1:]...)
+			return append(bytes.Join(lines, []byte{'\n'}), '\n')
+		}
+	}
+	require.FailNow(t, "metadata record not found", kind)
+	return nil
+}
+
+func moveFirstMetadataRecordAfterHeader(t *testing.T, input []byte, kind string) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	for index, line := range lines[1:] {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type == kind {
+			index++
+			result := make([][]byte, 0, len(lines))
+			result = append(result, lines[0], lines[index])
+			result = append(result, lines[1:index]...)
+			result = append(result, lines[index+1:]...)
+			return append(bytes.Join(result, []byte{'\n'}), '\n')
+		}
+	}
+	require.FailNow(t, "metadata record not found", kind)
+	return nil
+}

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -269,6 +269,36 @@ func TestInitialAuditAuthorityFreezesLogicalMetadata(t *testing.T) {
 	require.ErrorContains(t, err, "audited metadata is read-only")
 }
 
+func TestInitialAuditAuthorityAllowsUnreferencedBlobGC(t *testing.T) {
+	const orphanHash = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	_, err = s.db.Exec(`INSERT INTO blobs(hash,size,created_at)
+		VALUES(?,4,'2026-07-17T00:00:00.000000000Z')`, orphanHash)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`INSERT INTO extracted_text(
+		blob_hash,extractor,extractor_version,status,attempts,extracted_at)
+		VALUES(?,'synthetic',1,'ok',1,'2026-07-17T00:00:00.000000000Z')`, orphanHash)
+	require.NoError(t, err)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, target.ID)
+
+	unreachable, err := s.UnreachableBlobs(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []BlobInfo{{Hash: orphanHash, Size: 4}}, unreachable)
+	require.NoError(t, s.DeleteBlobRows(t.Context(), []string{orphanHash}))
+
+	var rows int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM blobs WHERE hash=?) +
+		(SELECT COUNT(*) FROM extracted_text WHERE blob_hash=?)`, orphanHash, orphanHash).Scan(&rows))
+	assert.Zero(t, rows)
+	require.NoError(t, s.ExportMetadata(t.Context(), &bytes.Buffer{}))
+}
+
 func TestInitialAuditAuthorityReopens(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "vault.db")
 	s, err := Open(path)

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -247,6 +247,10 @@ func TestInitialAuditAuthorityFreezesLogicalMetadata(t *testing.T) {
 	statements := []string{
 		`UPDATE vault_metadata SET vault_id=vault_id WHERE singleton=1`,
 		`DELETE FROM vault_metadata WHERE singleton=1`,
+		`INSERT OR REPLACE INTO vault_metadata(singleton,vault_id) VALUES(1,'99999999-9999-4999-8999-999999999999')`,
+		`INSERT OR REPLACE INTO audit_authority(singleton,lineage_id,operation_sequence_high_water,allocation_genesis_digest,allocation_entry_count,allocation_head)
+		 SELECT singleton,lineage_id,operation_sequence_high_water,allocation_genesis_digest,allocation_entry_count,allocation_head
+		 FROM audit_authority WHERE singleton=1`,
 		`INSERT INTO audit_records(digest,kind,record_json) VALUES('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee','event','{}')`,
 		`INSERT INTO audit_scopes(scope_id,target_node_id,enable_operation_id,entry_count,chain_head) VALUES('99999999-9999-4999-8999-999999999999',1,'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',1,'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')`,
 		`INSERT INTO audit_baselines(digest,scope_id,target_node_id,operation_id) VALUES('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee','66666666-6666-4666-8666-666666666666',7,'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')`,

--- a/internal/store/audit_projection.go
+++ b/internal/store/audit_projection.go
@@ -1,0 +1,408 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+	"time"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type auditTopologyRow struct {
+	id          int64
+	parentID    sql.NullInt64
+	name        string
+	kind        string
+	createdAt   string
+	modifiedAt  string
+	trashedAt   sql.NullString
+	trashParent sql.NullInt64
+	trashName   sql.NullString
+}
+
+func currentAuditTopology(ctx context.Context, tx metadataQuerier) ([]audit.Record, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT id,parent_id,name,kind,created_at,modified_at,
+		trashed_at,trash_parent,trash_name FROM nodes ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("reading current audit topology: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var records []audit.Record
+	for rows.Next() {
+		var row auditTopologyRow
+		if err := rows.Scan(&row.id, &row.parentID, &row.name, &row.kind, &row.createdAt,
+			&row.modifiedAt, &row.trashedAt, &row.trashParent, &row.trashName); err != nil {
+			return nil, fmt.Errorf("scanning current audit topology: %w", err)
+		}
+		record, err := topologyRecord(row)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading current audit topology: %w", err)
+	}
+	return records, nil
+}
+
+func topologyRecord(row auditTopologyRow) (audit.Record, error) {
+	nodeID, err := positiveAuditNodeID(row.id)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	parent := audit.Absent()
+	if row.parentID.Valid {
+		parentID, idErr := positiveAuditNodeID(row.parentID.Int64)
+		if idErr != nil {
+			return audit.Record{}, idErr
+		}
+		parent = audit.Unsigned(parentID)
+	}
+	createdAt, err := audit.Timestamp(row.createdAt)
+	if err != nil {
+		return audit.Record{}, fmt.Errorf("encoding topology node %d creation time: %w", row.id, err)
+	}
+	modifiedAt, err := audit.Timestamp(row.modifiedAt)
+	if err != nil {
+		return audit.Record{}, fmt.Errorf("encoding topology node %d modification time: %w", row.id, err)
+	}
+	trashedAt := audit.Absent()
+	state := "live"
+	if row.trashedAt.Valid {
+		state = "trash"
+		trashedAt, err = audit.Timestamp(row.trashedAt.String)
+		if err != nil {
+			return audit.Record{}, fmt.Errorf("encoding topology node %d trash time: %w", row.id, err)
+		}
+	}
+	origin, err := topologyOrigin(row, nodeID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	kindValue, err := audit.Text(row.kind)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	stateValue, err := audit.Text(state)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "topology_node", Fields: []audit.Field{
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "parent_id", Value: parent},
+		{Name: "name", Value: audit.Bytes([]byte(row.name))},
+		{Name: "node_kind", Value: kindValue},
+		{Name: "state", Value: stateValue},
+		{Name: "origin", Value: origin},
+		{Name: "created_at", Value: createdAt},
+		{Name: "modified_at", Value: modifiedAt},
+		{Name: "trashed_at", Value: trashedAt},
+	}}, nil
+}
+
+func topologyOrigin(row auditTopologyRow, nodeID uint64) (audit.Value, error) {
+	if !row.trashName.Valid {
+		return audit.Absent(), nil
+	}
+	if row.trashParent.Valid {
+		parentID, err := positiveAuditNodeID(row.trashParent.Int64)
+		if err != nil {
+			return audit.Value{}, err
+		}
+		return audit.Nested(audit.Record{Kind: "known_origin", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+			{Name: "parent_id", Value: audit.Unsigned(parentID)},
+			{Name: "name", Value: audit.Bytes([]byte(row.trashName.String))},
+		}}), nil
+	}
+	return audit.Nested(audit.Record{Kind: "unknown_origin", Fields: []audit.Field{
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "parent_id", Value: audit.Absent()},
+		{Name: "name", Value: audit.Bytes([]byte(row.trashName.String))},
+	}}), nil
+}
+
+func currentAuditAttachments(ctx context.Context, tx metadataQuerier) ([]audit.Record, error) {
+	var records []audit.Record
+	appenders := []func(context.Context, metadataQuerier, *[]audit.Record) error{
+		appendAuditIngests, appendAuditProvenance, appendAuditTagAssignments, appendAuditTagDefinitions,
+	}
+	for _, appendRecords := range appenders {
+		if err := appendRecords(ctx, tx, &records); err != nil {
+			return nil, err
+		}
+	}
+	if err := sortAuditRecordsByCanonicalIdentity(records, attachedAuditIdentity); err != nil {
+		return nil, fmt.Errorf("sorting current attached metadata: %w", err)
+	}
+	return records, nil
+}
+
+func appendAuditIngests(ctx context.Context, tx metadataQuerier, records *[]audit.Record) error {
+	rows, err := tx.QueryContext(ctx, `SELECT id,started_at,source_kind,source_desc FROM ingests`)
+	if err != nil {
+		return fmt.Errorf("reading audit ingests: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id, startedAt, sourceKind, sourceDesc string
+		if err := rows.Scan(&id, &startedAt, &sourceKind, &sourceDesc); err != nil {
+			return fmt.Errorf("scanning audit ingest: %w", err)
+		}
+		idValue, err := audit.UUID(id)
+		if err != nil {
+			return err
+		}
+		startedValue, err := audit.Timestamp(startedAt)
+		if err != nil {
+			return err
+		}
+		kindValue, err := audit.Text(sourceKind)
+		if err != nil {
+			return err
+		}
+		*records = append(*records, audit.Record{Kind: metadataIngestType, Fields: []audit.Field{
+			{Name: "ingest_id", Value: idValue},
+			{Name: "started_at", Value: startedValue},
+			{Name: "source_kind", Value: kindValue},
+			{Name: "source_desc", Value: audit.Bytes([]byte(sourceDesc))},
+		}})
+	}
+	return rowsError("audit ingests", rows)
+}
+
+func appendAuditProvenance(ctx context.Context, tx metadataQuerier, records *[]audit.Record) error {
+	rows, err := tx.QueryContext(ctx, `SELECT identity,node_id,ingest_id,original_path,
+		original_mtime,supersedes FROM provenance`)
+	if err != nil {
+		return fmt.Errorf("reading audit provenance: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var identity, ingestID, originalPath string
+		var nodeID int64
+		var originalMTime, supersedes sql.NullString
+		if err := rows.Scan(&identity, &nodeID, &ingestID, &originalPath,
+			&originalMTime, &supersedes); err != nil {
+			return fmt.Errorf("scanning audit provenance: %w", err)
+		}
+		record, err := provenanceAuditRecord(identity, nodeID, ingestID, originalPath,
+			originalMTime, supersedes)
+		if err != nil {
+			return err
+		}
+		*records = append(*records, record)
+	}
+	return rowsError("audit provenance", rows)
+}
+
+func provenanceAuditRecord(
+	identity string, nodeID int64, ingestID, originalPath string,
+	originalMTime, supersedes sql.NullString,
+) (audit.Record, error) {
+	auditNodeID, err := positiveAuditNodeID(nodeID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	identityValue, err := audit.DigestHex(identity)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	ingestValue, err := audit.UUID(ingestID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	mtimeValue := audit.Absent()
+	if originalMTime.Valid {
+		parsed, parseErr := time.Parse(time.RFC3339Nano, originalMTime.String)
+		if parseErr != nil {
+			return audit.Record{}, fmt.Errorf("parsing provenance mtime: %w", parseErr)
+		}
+		mtimeValue, err = audit.Timestamp(parsed.UTC().Format(timestampLayout))
+		if err != nil {
+			return audit.Record{}, err
+		}
+	}
+	supersedesValue := audit.Absent()
+	if supersedes.Valid {
+		supersedesValue, err = audit.DigestHex(supersedes.String)
+		if err != nil {
+			return audit.Record{}, err
+		}
+	}
+	return audit.Record{Kind: "provenance", Fields: []audit.Field{
+		{Name: "identity", Value: identityValue},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
+		{Name: "ingest_id", Value: ingestValue},
+		{Name: "original_path", Value: audit.Bytes([]byte(originalPath))},
+		{Name: "original_mtime", Value: mtimeValue},
+		{Name: "supersedes", Value: supersedesValue},
+	}}, nil
+}
+
+func appendAuditTagAssignments(ctx context.Context, tx metadataQuerier, records *[]audit.Record) error {
+	rows, err := tx.QueryContext(ctx, `SELECT tag_id,node_id FROM node_tags`)
+	if err != nil {
+		return fmt.Errorf("reading audit tag assignments: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var tagID string
+		var nodeID int64
+		if err := rows.Scan(&tagID, &nodeID); err != nil {
+			return fmt.Errorf("scanning audit tag assignment: %w", err)
+		}
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return err
+		}
+		tagValue, err := audit.UUID(tagID)
+		if err != nil {
+			return err
+		}
+		*records = append(*records, audit.Record{Kind: "tag_assignment", Fields: []audit.Field{
+			{Name: "tag_id", Value: tagValue},
+			{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
+		}})
+	}
+	return rowsError("audit tag assignments", rows)
+}
+
+func appendAuditTagDefinitions(ctx context.Context, tx metadataQuerier, records *[]audit.Record) error {
+	rows, err := tx.QueryContext(ctx, `SELECT id,name FROM tags`)
+	if err != nil {
+		return fmt.Errorf("reading audit tag definitions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var tagID, name string
+		if err := rows.Scan(&tagID, &name); err != nil {
+			return fmt.Errorf("scanning audit tag definition: %w", err)
+		}
+		tagValue, err := audit.UUID(tagID)
+		if err != nil {
+			return err
+		}
+		nameValue, err := audit.Text(name)
+		if err != nil {
+			return err
+		}
+		*records = append(*records, audit.Record{Kind: "tag_definition", Fields: []audit.Field{
+			{Name: "tag_id", Value: tagValue}, {Name: "name", Value: nameValue},
+		}})
+	}
+	return rowsError("audit tag definitions", rows)
+}
+
+func attachedAuditIdentity(record audit.Record) (audit.Record, error) {
+	switch record.Kind {
+	case metadataIngestType:
+		value, err := auditField(record, "ingest_id")
+		return audit.Record{Kind: "ingest_identity", Fields: []audit.Field{{Name: "ingest_id", Value: value}}}, err
+	case "provenance":
+		value, err := auditField(record, "identity")
+		return audit.Record{Kind: "provenance_identity_ref", Fields: []audit.Field{{Name: "identity", Value: value}}}, err
+	case "tag_assignment":
+		tagID, err := auditField(record, "tag_id")
+		if err != nil {
+			return audit.Record{}, err
+		}
+		nodeID, err := auditField(record, metadataNodeIDField)
+		return audit.Record{Kind: "tag_assignment_identity", Fields: []audit.Field{
+			{Name: "tag_id", Value: tagID}, {Name: metadataNodeIDField, Value: nodeID},
+		}}, err
+	case "tag_definition":
+		value, err := auditField(record, "tag_id")
+		return audit.Record{Kind: "tag_definition_identity", Fields: []audit.Field{{Name: "tag_id", Value: value}}}, err
+	default:
+		return audit.Record{}, fmt.Errorf("record kind %q has no attached-metadata identity", record.Kind)
+	}
+}
+
+func auditRecordsForNodes(records []audit.Record, members map[uint64]bool) ([]audit.Record, error) {
+	selected := make([]audit.Record, 0)
+	ingests := make(map[string]bool)
+	tags := make(map[string]bool)
+	for _, record := range records {
+		switch record.Kind {
+		case "provenance":
+			nodeID, err := auditUnsignedField(record, metadataNodeIDField)
+			if err != nil {
+				return nil, err
+			}
+			if members[nodeID] {
+				selected = append(selected, record)
+				ingestID, err := auditUUIDField(record, "ingest_id")
+				if err != nil {
+					return nil, err
+				}
+				ingests[ingestID] = true
+			}
+		case "tag_assignment":
+			nodeID, err := auditUnsignedField(record, metadataNodeIDField)
+			if err != nil {
+				return nil, err
+			}
+			if members[nodeID] {
+				selected = append(selected, record)
+				tagID, err := auditUUIDField(record, "tag_id")
+				if err != nil {
+					return nil, err
+				}
+				tags[tagID] = true
+			}
+		}
+	}
+	for _, record := range records {
+		switch record.Kind {
+		case metadataIngestType:
+			id, err := auditUUIDField(record, "ingest_id")
+			if err != nil {
+				return nil, err
+			}
+			if ingests[id] {
+				selected = append(selected, record)
+			}
+		case "tag_definition":
+			id, err := auditUUIDField(record, "tag_id")
+			if err != nil {
+				return nil, err
+			}
+			if tags[id] {
+				selected = append(selected, record)
+			}
+		}
+	}
+	if err := sortAuditRecordsByCanonicalIdentity(selected, attachedAuditIdentity); err != nil {
+		return nil, err
+	}
+	return selected, nil
+}
+
+func auditNestedValues(records []audit.Record) []audit.Value {
+	values := make([]audit.Value, len(records))
+	for index := range records {
+		values[index] = audit.Nested(records[index])
+	}
+	return values
+}
+
+func auditMemberSet(values []uint64) map[uint64]bool {
+	result := make(map[uint64]bool, len(values))
+	for _, value := range values {
+		result[value] = true
+	}
+	return result
+}
+
+func sortedAuditMembers(members map[uint64]bool) []uint64 {
+	result := make([]uint64, 0, len(members))
+	for id := range members {
+		result = append(result, id)
+	}
+	slices.Sort(result)
+	return result
+}

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -16,7 +16,8 @@ func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) 
 	}
 	startedAt := nowRFC3339()
 	if err := validateIngestRecord(metadataIngest{
-		Type: "ingest", ID: id, StartedAt: startedAt, SourceKind: sourceKind, SourceDesc: sourceDesc,
+		Type: metadataIngestType, ID: id, StartedAt: startedAt,
+		SourceKind: sourceKind, SourceDesc: sourceDesc,
 	}); err != nil {
 		return "", fmt.Errorf("validating ingest start: %w", err)
 	}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -1129,6 +1129,13 @@ func validateMetadataState(ctx context.Context, tx metadataQuerier, nodeSequence
 	if err := validateMetadataRelations(ctx, tx); err != nil {
 		return err
 	}
+	topology, err := loadAuditTopologyRows(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if err := validateAuditTrashOrigins(topology); err != nil {
+		return err
+	}
 	if err := validateInitialAuditAuthority(ctx, tx, vaultID, nodeSequence); err != nil {
 		return err
 	}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -164,6 +164,37 @@ type metadataExtractedText struct {
 	ExtractedAt      string  `json:"extracted_at"`
 }
 
+type metadataAuditRecord struct {
+	Type   string          `json:"type"`
+	Digest string          `json:"digest"`
+	Record json.RawMessage `json:"record"`
+}
+
+type metadataAuditAuthority struct {
+	Type                       string `json:"type"`
+	LineageID                  string `json:"lineage_id"`
+	OperationSequenceHighWater uint64 `json:"operation_sequence_high_water"`
+	AllocationGenesisDigest    string `json:"allocation_genesis_digest"`
+	AllocationEntryCount       uint64 `json:"allocation_entry_count"`
+	AllocationHead             string `json:"allocation_head"`
+}
+
+type metadataAuditScope struct {
+	Type              string `json:"type"`
+	ScopeID           string `json:"scope_id"`
+	TargetNodeID      uint64 `json:"target_node_id"`
+	EnableOperationID string `json:"enable_operation_id"`
+	EntryCount        uint64 `json:"entry_count"`
+	ChainHead         string `json:"chain_head"`
+}
+
+type metadataAuditMembership struct {
+	Type           string `json:"type"`
+	ScopeID        string `json:"scope_id"`
+	NodeID         uint64 `json:"node_id"`
+	BaselineDigest string `json:"baseline_digest"`
+}
+
 // ExportMetadata writes a deterministic JSONL description of Docbank's
 // logical state. Rebuildable FTS data and physical pack authority are omitted.
 func (s *Store) ExportMetadata(ctx context.Context, w io.Writer) error {
@@ -241,7 +272,10 @@ func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer
 	if err := exportNodeTags(ctx, tx, write); err != nil {
 		return err
 	}
-	return exportExtractedText(ctx, tx, write)
+	if err := exportExtractedText(ctx, tx, write); err != nil {
+		return err
+	}
+	return exportAuditMetadata(ctx, tx, write)
 }
 
 type metadataWrite func(any) error
@@ -332,7 +366,7 @@ func exportIngests(ctx context.Context, tx metadataQuerier, write metadataWrite)
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
-		r := metadataIngest{Type: "ingest"}
+		r := metadataIngest{Type: metadataIngestType}
 		if err := rows.Scan(&r.ID, &r.StartedAt, &r.SourceKind, &r.SourceDesc); err != nil {
 			return fmt.Errorf("scanning ingest metadata: %w", err)
 		}
@@ -343,7 +377,7 @@ func exportIngests(ctx context.Context, tx metadataQuerier, write metadataWrite)
 			return err
 		}
 	}
-	return rowsError("ingest", rows)
+	return rowsError(metadataIngestType, rows)
 }
 
 func exportProvenance(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
@@ -485,6 +519,10 @@ func (s *Store) ImportMetadata(ctx context.Context, r io.Reader) error {
 		); err != nil {
 			return fmt.Errorf("restoring vault identity: %w", err)
 		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO audit_write_guard(singleton)
+			SELECT 1 WHERE EXISTS (SELECT 1 FROM audit_authority)`); err != nil {
+			return fmt.Errorf("activating restored audit authority: %w", err)
+		}
 		if err := validateMetadataState(ctx, tx, header.NodeSequence); err != nil {
 			return err
 		}
@@ -513,7 +551,13 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		  (SELECT COUNT(*) FROM blobs) + (SELECT COUNT(*) FROM content_versions)
 		    + (SELECT COUNT(*) FROM ingests) + (SELECT COUNT(*) FROM provenance)
 		    + (SELECT COUNT(*) FROM tags) + (SELECT COUNT(*) FROM node_tags)
-		    + (SELECT COUNT(*) FROM extracted_text),
+		    + (SELECT COUNT(*) FROM extracted_text)
+		    + (SELECT COUNT(*) FROM audit_records)
+		    + (SELECT COUNT(*) FROM audit_authority)
+		    + (SELECT COUNT(*) FROM audit_scopes)
+		    + (SELECT COUNT(*) FROM audit_baselines)
+		    + (SELECT COUNT(*) FROM audit_memberships)
+		    + (SELECT COUNT(*) FROM audit_write_guard),
 		  (SELECT COUNT(*) FROM blob_packs) + (SELECT COUNT(*) FROM blob_pack_index)
 	`).Scan(&nodes, &other, &packs); err != nil {
 		return fmt.Errorf("checking metadata import target: %w", err)
@@ -618,7 +662,7 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 			v.MIMEType, v.RecordedAt, v.NodeRevision, v.IntroducedOperationID,
 			v.TransitionKind, v.SourceVersionID)
 		return err
-	case "ingest":
+	case metadataIngestType:
 		var v metadataIngest
 		if err := decodeMetadataRecord(raw, &v); err != nil {
 			return err
@@ -673,27 +717,61 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		_, err := tx.ExecContext(ctx, `INSERT INTO extracted_text(blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at) VALUES(?,?,?,?,?,?,?,?)`,
 			v.BlobHash, v.Extractor, v.ExtractorVersion, v.Status, v.Error, v.Attempts, v.Text, v.ExtractedAt)
 		return err
+	case metadataAuditAuthorityType:
+		var v metadataAuditAuthority
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		return importAuditAuthority(ctx, tx, v)
+	case metadataAuditScopeType:
+		var v metadataAuditScope
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		return importAuditScope(ctx, tx, v)
+	case metadataAuditMembershipType:
+		var v metadataAuditMembership
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		return importAuditMembership(ctx, tx, v)
+	case metadataAuditRecordType:
+		var v metadataAuditRecord
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		return importAuditRecord(ctx, tx, v)
 	default:
 		return fmt.Errorf("unknown record type %q", kind)
 	}
 }
 
 const (
-	metadataTypeField      = "type"
-	metadataProvenanceType = "provenance"
+	metadataTypeField           = "type"
+	metadataNodeIDField         = "node_id"
+	metadataIngestType          = "ingest"
+	metadataProvenanceType      = "provenance"
+	metadataAuditAuthorityType  = "audit_authority"
+	metadataAuditScopeType      = "audit_scope"
+	metadataAuditMembershipType = "audit_membership"
+	metadataAuditRecordType     = "audit_record"
 )
 
 var metadataHeaderFields = []string{metadataTypeField, "format", "version", "vault_id", "node_sequence"}
 
 var metadataRequiredFields = map[string][]string{
-	"blob":                 {metadataTypeField, "hash", "size", "created_at"},
-	"node":                 {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", "created_at", "modified_at", "trashed_at", "trash_parent", "trash_name"},
-	"content_version":      {metadataTypeField, "version_id", "node_id", "blob_hash", "size", "mime_type", "recorded_at", "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
-	"ingest":               {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
-	metadataProvenanceType: {metadataTypeField, "identity", "node_id", "ingest_id", "original_path", "original_mtime", "supersedes"},
-	"tag":                  {metadataTypeField, "tag_id", "name", "revision"},
-	"node_tag":             {metadataTypeField, "node_id", "tag_id"},
-	"extracted_text":       {metadataTypeField, "blob_hash", "extractor", "extractor_version", "status", "error", "attempts", "text", "extracted_at"},
+	"blob":                      {metadataTypeField, "hash", "size", "created_at"},
+	"node":                      {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", "created_at", "modified_at", "trashed_at", "trash_parent", "trash_name"},
+	"content_version":           {metadataTypeField, "version_id", metadataNodeIDField, "blob_hash", "size", "mime_type", "recorded_at", "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
+	metadataIngestType:          {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
+	metadataProvenanceType:      {metadataTypeField, "identity", metadataNodeIDField, "ingest_id", "original_path", "original_mtime", "supersedes"},
+	"tag":                       {metadataTypeField, "tag_id", "name", "revision"},
+	"node_tag":                  {metadataTypeField, metadataNodeIDField, "tag_id"},
+	"extracted_text":            {metadataTypeField, "blob_hash", "extractor", "extractor_version", "status", "error", "attempts", "text", "extracted_at"},
+	metadataAuditAuthorityType:  {metadataTypeField, "lineage_id", "operation_sequence_high_water", "allocation_genesis_digest", "allocation_entry_count", "allocation_head"},
+	metadataAuditScopeType:      {metadataTypeField, "scope_id", "target_node_id", "enable_operation_id", "entry_count", "chain_head"},
+	metadataAuditMembershipType: {metadataTypeField, "scope_id", metadataNodeIDField, "baseline_digest"},
+	metadataAuditRecordType:     {metadataTypeField, "digest", "record"},
 }
 
 var metadataNullableFields = map[string]map[string]bool{
@@ -905,7 +983,7 @@ func validateContentVersionRecord(v metadataContentVersion) error {
 }
 
 func validateIngestRecord(v metadataIngest) error {
-	if v.Type != "ingest" || v.SourceKind == "" || v.SourceDesc == "" {
+	if v.Type != metadataIngestType || v.SourceKind == "" || v.SourceDesc == "" {
 		return errors.New("invalid ingest record")
 	}
 	if err := validateUUIDv4(v.ID); err != nil {
@@ -1049,6 +1127,9 @@ func validateMetadataState(ctx context.Context, tx metadataQuerier, nodeSequence
 		return fmt.Errorf("invalid vault identity: %w", err)
 	}
 	if err := validateMetadataRelations(ctx, tx); err != nil {
+		return err
+	}
+	if err := validateInitialAuditAuthority(ctx, tx, vaultID, nodeSequence); err != nil {
 		return err
 	}
 	var maxNodeID int64

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -647,6 +647,14 @@ func TestImportMetadataRejectsUnsafeTrashTopology(t *testing.T) {
 			want: "trash parent points inside its subtree",
 		},
 		{
+			name: "trash origin cycle",
+			records: []string{
+				`{"type":"node","id":2,"parent_id":1,"name":"A","kind":"dir","current_version_id":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":3,"trash_name":"A"}`,
+				`{"type":"node","id":3,"parent_id":1,"name":"B","kind":"dir","current_version_id":null,"revision":2,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":"` + stamp + `","trash_parent":2,"trash_name":"B"}`,
+			},
+			want: "trash-origin topology contains a cycle",
+		},
+		{
 			name: "trash root not detached",
 			records: []string{
 				`{"type":"node","id":3,"parent_id":1,"name":"container","kind":"dir","current_version_id":null,"revision":1,"created_at":"` + stamp + `","modified_at":"` + stamp + `","trashed_at":null,"trash_parent":null,"trash_name":null}`,

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -314,8 +314,20 @@ WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
     SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
 END;
 
+CREATE TRIGGER IF NOT EXISTS audited_vault_metadata_frozen_insert
+BEFORE INSERT ON vault_metadata
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
 CREATE TRIGGER IF NOT EXISTS audited_vault_metadata_frozen_delete
 BEFORE DELETE ON vault_metadata
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_authority_frozen_insert
+BEFORE INSERT ON audit_authority
 WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
     SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
 END;

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -152,6 +152,270 @@ CREATE TABLE IF NOT EXISTS node_tags (
 
 CREATE INDEX IF NOT EXISTS node_tags_tag ON node_tags(tag_id);
 
+-- Canonical full-audit records are immutable content-addressed authority. The
+-- digest is over Docbank's typed canonical audit encoding, never the JSON
+-- spelling retained here for deterministic metadata-v1 transport.
+CREATE TABLE IF NOT EXISTS audit_records (
+    digest             TEXT PRIMARY KEY NOT NULL,
+    kind               TEXT NOT NULL CHECK (kind IN (
+        'enrollment_baseline', 'topology_genesis',
+        'attached_metadata_genesis', 'event', 'canonical_mutation',
+        'scope_chain_entry', 'allocation_genesis', 'allocation_entry'
+    )),
+    operation_id       TEXT,
+    operation_sequence INTEGER CHECK (operation_sequence IS NULL OR operation_sequence > 0),
+    scope_id           TEXT,
+    entry_count        INTEGER CHECK (entry_count IS NULL OR entry_count > 0),
+    event_id           TEXT,
+    event_ordinal      INTEGER CHECK (event_ordinal IS NULL OR event_ordinal >= 0),
+    record_json        TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS audit_record_event
+    ON audit_records(event_id) WHERE event_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS audit_record_mutation_operation
+    ON audit_records(operation_id) WHERE kind = 'canonical_mutation';
+CREATE UNIQUE INDEX IF NOT EXISTS audit_record_mutation_sequence
+    ON audit_records(operation_sequence) WHERE kind = 'canonical_mutation';
+CREATE UNIQUE INDEX IF NOT EXISTS audit_record_scope_entry
+    ON audit_records(scope_id, entry_count) WHERE kind = 'scope_chain_entry';
+CREATE UNIQUE INDEX IF NOT EXISTS audit_record_allocation_operation
+    ON audit_records(operation_id) WHERE kind = 'allocation_entry';
+CREATE UNIQUE INDEX IF NOT EXISTS audit_record_allocation_sequence
+    ON audit_records(operation_sequence) WHERE kind = 'allocation_entry';
+CREATE UNIQUE INDEX IF NOT EXISTS audit_record_single_genesis
+    ON audit_records(kind) WHERE kind IN (
+        'topology_genesis', 'attached_metadata_genesis', 'allocation_genesis'
+    );
+
+CREATE TABLE IF NOT EXISTS audit_authority (
+    singleton                       INTEGER PRIMARY KEY CHECK (singleton = 1),
+    lineage_id                      TEXT NOT NULL UNIQUE,
+    operation_sequence_high_water   INTEGER NOT NULL CHECK (operation_sequence_high_water > 0),
+    allocation_genesis_digest       TEXT NOT NULL UNIQUE REFERENCES audit_records(digest)
+        DEFERRABLE INITIALLY DEFERRED,
+    allocation_entry_count          INTEGER NOT NULL CHECK (allocation_entry_count > 0),
+    allocation_head                 TEXT NOT NULL REFERENCES audit_records(digest)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+-- Derived activation marker installed only after the closed first-enrollment
+-- set has been staged in one transaction. Keeping it out of JSONL lets import
+-- accept records in any order without enabling write guards halfway through
+-- the stream.
+CREATE TABLE IF NOT EXISTS audit_write_guard (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1)
+        REFERENCES audit_authority(singleton) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS audit_scopes (
+    scope_id             TEXT PRIMARY KEY NOT NULL,
+    target_node_id       INTEGER NOT NULL REFERENCES nodes(id),
+    enable_operation_id  TEXT NOT NULL UNIQUE,
+    entry_count          INTEGER NOT NULL CHECK (entry_count > 0),
+    chain_head           TEXT NOT NULL REFERENCES audit_records(digest)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS audit_baselines (
+    digest          TEXT PRIMARY KEY NOT NULL REFERENCES audit_records(digest)
+        DEFERRABLE INITIALLY DEFERRED,
+    scope_id        TEXT NOT NULL REFERENCES audit_scopes(scope_id)
+        DEFERRABLE INITIALLY DEFERRED,
+    target_node_id  INTEGER NOT NULL REFERENCES nodes(id),
+    operation_id    TEXT NOT NULL,
+    UNIQUE (scope_id, target_node_id, operation_id)
+);
+
+CREATE TABLE IF NOT EXISTS audit_memberships (
+    scope_id         TEXT NOT NULL REFERENCES audit_scopes(scope_id)
+        DEFERRABLE INITIALLY DEFERRED,
+    node_id          INTEGER NOT NULL REFERENCES nodes(id),
+    baseline_digest  TEXT NOT NULL REFERENCES audit_baselines(digest)
+        DEFERRABLE INITIALLY DEFERRED,
+    PRIMARY KEY (scope_id, node_id)
+);
+
+CREATE INDEX IF NOT EXISTS audit_membership_node ON audit_memberships(node_id);
+
+CREATE TRIGGER IF NOT EXISTS audit_records_immutable_update
+BEFORE UPDATE ON audit_records BEGIN
+    SELECT RAISE(ABORT, 'audit records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_records_immutable_delete
+BEFORE DELETE ON audit_records BEGIN
+    SELECT RAISE(ABORT, 'audit records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_memberships_immutable_update
+BEFORE UPDATE ON audit_memberships BEGIN
+    SELECT RAISE(ABORT, 'audit memberships are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_memberships_immutable_delete
+BEFORE DELETE ON audit_memberships BEGIN
+    SELECT RAISE(ABORT, 'audit memberships are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_scope_identity_immutable
+BEFORE UPDATE OF scope_id, target_node_id, enable_operation_id ON audit_scopes BEGIN
+    SELECT RAISE(ABORT, 'audit scope identity is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_scopes_immutable_delete
+BEFORE DELETE ON audit_scopes BEGIN
+    SELECT RAISE(ABORT, 'audit scopes are permanent');
+END;
+
+-- Until guarded mutation recording is enabled, a restored first-enrollment
+-- authority is fail-closed. Physical blob/pack maintenance remains available,
+-- but no logical metadata may diverge from the imported audit state. These
+-- triggers will be replaced by guarded operation-context checks when audited
+-- mutations are implemented.
+CREATE TRIGGER IF NOT EXISTS audit_authority_frozen_update
+BEFORE UPDATE ON audit_authority BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_authority_frozen_delete
+BEFORE DELETE ON audit_authority BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_scope_state_frozen
+BEFORE UPDATE OF entry_count, chain_head ON audit_scopes BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_baselines_immutable_update
+BEFORE UPDATE ON audit_baselines BEGIN
+    SELECT RAISE(ABORT, 'audit baselines are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_baselines_immutable_delete
+BEFORE DELETE ON audit_baselines BEGIN
+    SELECT RAISE(ABORT, 'audit baselines are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_write_guard_immutable_update
+BEFORE UPDATE ON audit_write_guard BEGIN
+    SELECT RAISE(ABORT, 'audit write guard is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_write_guard_immutable_delete
+BEFORE DELETE ON audit_write_guard BEGIN
+    SELECT RAISE(ABORT, 'audit write guard is permanent');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_nodes_frozen_insert
+BEFORE INSERT ON nodes
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_nodes_frozen_update
+BEFORE UPDATE ON nodes
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_nodes_frozen_delete
+BEFORE DELETE ON nodes
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_versions_frozen_insert
+BEFORE INSERT ON content_versions
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_versions_frozen_update
+BEFORE UPDATE ON content_versions
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_versions_frozen_delete
+BEFORE DELETE ON content_versions
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_blobs_frozen_insert
+BEFORE INSERT ON blobs
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_blobs_frozen_update
+BEFORE UPDATE ON blobs
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_ingests_frozen_insert
+BEFORE INSERT ON ingests
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_ingests_frozen_delete
+BEFORE DELETE ON ingests
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_provenance_frozen_insert
+BEFORE INSERT ON provenance
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_provenance_frozen_delete
+BEFORE DELETE ON provenance
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_tags_frozen_insert
+BEFORE INSERT ON tags
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_tags_frozen_update
+BEFORE UPDATE ON tags
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_tags_frozen_delete
+BEFORE DELETE ON tags
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_node_tags_frozen_insert
+BEFORE INSERT ON node_tags
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_node_tags_frozen_update
+BEFORE UPDATE ON node_tags
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_node_tags_frozen_delete
+BEFORE DELETE ON node_tags
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
 CREATE TABLE IF NOT EXISTS extracted_text (
     blob_hash         TEXT NOT NULL,
     extractor         TEXT NOT NULL,

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -308,6 +308,42 @@ BEFORE DELETE ON audit_write_guard BEGIN
     SELECT RAISE(ABORT, 'audit write guard is permanent');
 END;
 
+CREATE TRIGGER IF NOT EXISTS audited_vault_metadata_frozen_update
+BEFORE UPDATE ON vault_metadata
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_vault_metadata_frozen_delete
+BEFORE DELETE ON vault_metadata
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_records_frozen_insert
+BEFORE INSERT ON audit_records
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_scopes_frozen_insert
+BEFORE INSERT ON audit_scopes
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_baselines_frozen_insert
+BEFORE INSERT ON audit_baselines
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audited_memberships_frozen_insert
+BEFORE INSERT ON audit_memberships
+WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
+    SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
+END;
+
 CREATE TRIGGER IF NOT EXISTS audited_nodes_frozen_insert
 BEFORE INSERT ON nodes
 WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -344,6 +344,10 @@ WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN
     SELECT RAISE(ABORT, 'audited metadata is read-only until mutation enforcement is available');
 END;
 
+-- Blob deletion deliberately remains available for unreachable-blob GC: a
+-- referenced blob is protected by content_versions' foreign key. Extracted
+-- text is derived and remains replaceable, while ingest and provenance updates
+-- are already forbidden by their unconditional immutability triggers above.
 CREATE TRIGGER IF NOT EXISTS audited_blobs_frozen_insert
 BEFORE INSERT ON blobs
 WHEN EXISTS (SELECT 1 FROM audit_write_guard) BEGIN


### PR DESCRIPTION
Canonical audit encoding is not enough to make full-audit history durable: metadata backup and restore need one closed first-enrollment authority whose scope membership, protected versions, attached metadata, chain heads, and allocator lineage can be reconstructed without trusting stored JSON. Accepting partial ledger fragments would make a restored vault look authoritative while leaving its protection boundary ambiguous.

This establishes that first complete persistence boundary in metadata v1. Import and export independently recompute canonical digests, the protected topology and trash-origin closure, referenced metadata, the enrollment event and mutation binding, scope-chain state, and allocation lineage before accepting the state. Ordinary zero-scope vaults keep their compact representation.

Guarded mutation recording remains later work. Until it lands, a restored audited vault fails closed for logical metadata writes while read-only backup/export and physical pack maintenance remain available; existing unaudited paths therefore cannot silently invalidate an accepted chain. No preview/enable API or unfinished user surface is introduced here.

Repository checks pass. Kata: gckj, 07wr.