### PR TITLE
Create audit authority through production enrollment

### DIFF
--- a/internal/store/audit_enrollment.go
+++ b/internal/store/audit_enrollment.go
@@ -94,7 +94,7 @@ func (s *Store) initializeAuditAuthorityWithInput(
 		if err := persistInitialAuditEnrollment(ctx, tx, set); err != nil {
 			return err
 		}
-		if err := validateInitialAuditAuthority(ctx, tx, s.vaultID, set.nodeSequence); err != nil {
+		if err := validateMetadataState(ctx, tx, set.nodeSequence); err != nil {
 			return fmt.Errorf("validating created audit authority: %w", err)
 		}
 		result = initialAuditEnrollmentResult{

--- a/internal/store/audit_enrollment.go
+++ b/internal/store/audit_enrollment.go
@@ -1,0 +1,504 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type initialAuditEnrollmentInput struct {
+	targetNodeID int64
+	scopeID      string
+	operationID  string
+	lineageID    string
+	recordedAt   string
+	origin       string
+	agentLabel   *string
+}
+
+type initialAuditEnrollmentResult struct {
+	scopeID        string
+	operationID    string
+	baselineDigest string
+	memberCount    int
+}
+
+type initialAuditEnrollmentSet struct {
+	input                   initialAuditEnrollmentInput
+	nodeSequence            int64
+	members                 []uint64
+	records                 []audit.Record
+	allocationGenesisDigest string
+	baselineDigest          string
+	scopeHead               string
+	allocationHead          string
+}
+
+type initialAuditValues struct {
+	vaultID, scopeID, operationID, lineageID audit.Value
+	recordedAt, origin, agentLabel           audit.Value
+	cause, eventKind                         audit.Value
+}
+
+// initializeAuditAuthority creates the first audit authority. It remains
+// internal until every logical mutation can extend that authority; exposing
+// enablement sooner would leave a vault intentionally frozen after enrollment.
+func (s *Store) initializeAuditAuthority(
+	ctx context.Context, targetNodeID int64, origin string, agentLabel *string,
+) (initialAuditEnrollmentResult, error) {
+	scopeID, err := newUUIDv4()
+	if err != nil {
+		return initialAuditEnrollmentResult{}, err
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return initialAuditEnrollmentResult{}, err
+	}
+	lineageID, err := newUUIDv4()
+	if err != nil {
+		return initialAuditEnrollmentResult{}, err
+	}
+	return s.initializeAuditAuthorityWithInput(ctx, initialAuditEnrollmentInput{
+		targetNodeID: targetNodeID,
+		scopeID:      scopeID,
+		operationID:  operationID,
+		lineageID:    lineageID,
+		recordedAt:   nowRFC3339(),
+		origin:       origin,
+		agentLabel:   agentLabel,
+	})
+}
+
+func (s *Store) initializeAuditAuthorityWithInput(
+	ctx context.Context, input initialAuditEnrollmentInput,
+) (initialAuditEnrollmentResult, error) {
+	var result initialAuditEnrollmentResult
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		counts, err := auditAuthorityCounts(ctx, tx)
+		if err != nil {
+			return err
+		}
+		for _, count := range counts {
+			if count != 0 {
+				return errors.New("audit authority is already initialized or incomplete")
+			}
+		}
+		set, err := buildInitialAuditEnrollment(ctx, tx, s.vaultID, input)
+		if err != nil {
+			return err
+		}
+		if err := persistInitialAuditEnrollment(ctx, tx, set); err != nil {
+			return err
+		}
+		if err := validateInitialAuditAuthority(ctx, tx, s.vaultID, set.nodeSequence); err != nil {
+			return fmt.Errorf("validating created audit authority: %w", err)
+		}
+		result = initialAuditEnrollmentResult{
+			scopeID:        input.scopeID,
+			operationID:    input.operationID,
+			baselineDigest: set.baselineDigest,
+			memberCount:    len(set.members),
+		}
+		return nil
+	})
+	return result, err
+}
+
+func buildInitialAuditEnrollment(
+	ctx context.Context, tx metadataQuerier, vaultID string, input initialAuditEnrollmentInput,
+) (initialAuditEnrollmentSet, error) {
+	values, err := makeInitialAuditValues(vaultID, input)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	if input.targetNodeID <= 0 {
+		return initialAuditEnrollmentSet{}, fmt.Errorf(
+			"audit enrollment target %d must be positive", input.targetNodeID,
+		)
+	}
+	var nodeSequence int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT seq FROM sqlite_sequence WHERE name='nodes'`,
+	).Scan(&nodeSequence); err != nil {
+		return initialAuditEnrollmentSet{}, fmt.Errorf("reading node ID high-water mark: %w", err)
+	}
+	if nodeSequence <= 0 {
+		return initialAuditEnrollmentSet{}, fmt.Errorf("invalid node ID high-water mark %d", nodeSequence)
+	}
+	// The positivity checks above make these conversions lossless.
+	auditTargetNodeID := uint64(input.targetNodeID)
+	auditNodeSequence := uint64(nodeSequence)
+	topology, err := currentAuditTopology(ctx, tx)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	attachments, err := currentAuditAttachments(ctx, tx)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	topologyGenesis := audit.Record{Kind: "topology_genesis", Fields: []audit.Field{
+		{Name: "vault_id", Value: values.vaultID},
+		{Name: "lineage_id", Value: values.lineageID},
+		{Name: "nodes", Value: audit.List(auditNestedValues(topology)...)},
+	}}
+	attachmentGenesis := audit.Record{Kind: "attached_metadata_genesis", Fields: []audit.Field{
+		{Name: "vault_id", Value: values.vaultID},
+		{Name: "lineage_id", Value: values.lineageID},
+		{Name: "records", Value: audit.List(auditNestedValues(attachments)...)},
+	}}
+	topologyDigest, err := hashAuditRecord(topologyGenesis)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	attachmentDigest, err := hashAuditRecord(attachmentGenesis)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	allocationGenesis := makeInitialAllocationGenesis(
+		values, auditNodeSequence, topology, topologyDigest, attachments, attachmentDigest,
+	)
+	allocationGenesisDigest, err := hashAuditRecord(allocationGenesis)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+
+	members, err := deriveInitialAuditMembers(ctx, tx, auditTargetNodeID)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	states, err := currentAuditMemberStates(ctx, tx, members)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	versions, err := currentAuditVersions(ctx, tx, members)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	baselineAttachments, err := auditRecordsForNodes(attachments, auditMemberSet(members))
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	baselineNodes, witnesses, err := initialBaselineTopology(topology, members, input.operationID)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	baseline := makeInitialAuditBaseline(values, auditTargetNodeID, members,
+		states, versions, baselineAttachments, baselineNodes, witnesses)
+	baselineDigest, err := hashAuditRecord(baseline)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	event, err := makeInitialAuditEnrollmentEvent(values, auditTargetNodeID, baselineDigest, states)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	eventWrapper := audit.Record{Kind: "event", Fields: []audit.Field{
+		{Name: "event", Value: audit.Nested(event)},
+	}}
+	mutation := makeInitialAuditMutation(values, auditTargetNodeID, baselineDigest, event)
+	mutationDigest, err := hashAuditRecord(mutation)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	scopeEntry := audit.Record{Kind: "scope_chain_entry", Fields: []audit.Field{
+		{Name: "vault_id", Value: values.vaultID},
+		{Name: "scope_id", Value: values.scopeID},
+		{Name: "entry_count", Value: audit.Unsigned(1)},
+		{Name: "previous_head", Value: audit.Absent()},
+		{Name: "mutation_hash", Value: mutationDigest.value},
+	}}
+	scopeHead, err := hashAuditRecord(scopeEntry)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	allocationEntry := makeInitialAllocationEntry(
+		values, auditNodeSequence, allocationGenesisDigest.value, mutationDigest.value,
+	)
+	allocationHead, err := hashAuditRecord(allocationEntry)
+	if err != nil {
+		return initialAuditEnrollmentSet{}, err
+	}
+	return initialAuditEnrollmentSet{
+		input:        input,
+		nodeSequence: nodeSequence,
+		members:      members,
+		records: []audit.Record{
+			topologyGenesis, attachmentGenesis, allocationGenesis, baseline,
+			eventWrapper, mutation, scopeEntry, allocationEntry,
+		},
+		allocationGenesisDigest: allocationGenesisDigest.text,
+		baselineDigest:          baselineDigest.text,
+		scopeHead:               scopeHead.text,
+		allocationHead:          allocationHead.text,
+	}, nil
+}
+
+type auditRecordHash struct {
+	text  string
+	value audit.Value
+}
+
+func hashAuditRecord(record audit.Record) (auditRecordHash, error) {
+	digest, err := audit.Hash(record)
+	if err != nil {
+		return auditRecordHash{}, fmt.Errorf("hashing %s audit record: %w", record.Kind, err)
+	}
+	return auditRecordHash{text: hex.EncodeToString(digest[:]), value: audit.Digest(digest)}, nil
+}
+
+func makeInitialAuditValues(vaultID string, input initialAuditEnrollmentInput) (initialAuditValues, error) {
+	values := initialAuditValues{}
+	constructors := []struct {
+		name  string
+		value string
+		make  func(string) (audit.Value, error)
+		out   *audit.Value
+	}{
+		{"vault ID", vaultID, audit.UUID, &values.vaultID},
+		{"scope ID", input.scopeID, audit.UUID, &values.scopeID},
+		{"operation ID", input.operationID, audit.UUID, &values.operationID},
+		{"lineage ID", input.lineageID, audit.UUID, &values.lineageID},
+		{"recorded time", input.recordedAt, audit.Timestamp, &values.recordedAt},
+		{"origin", input.origin, audit.Text, &values.origin},
+		{"enrollment cause", "explicit", audit.Text, &values.cause},
+		{"enrollment event kind", "audit_enroll", audit.Text, &values.eventKind},
+	}
+	for _, item := range constructors {
+		value, err := item.make(item.value)
+		if err != nil {
+			return initialAuditValues{}, fmt.Errorf("encoding audit enrollment %s: %w", item.name, err)
+		}
+		*item.out = value
+	}
+	values.agentLabel = audit.Absent()
+	if input.agentLabel != nil {
+		label, err := audit.Text(*input.agentLabel)
+		if err != nil {
+			return initialAuditValues{}, fmt.Errorf("encoding audit enrollment agent label: %w", err)
+		}
+		values.agentLabel = label
+	}
+	return values, nil
+}
+
+func makeInitialAllocationGenesis(
+	values initialAuditValues, nodeSequence uint64,
+	topology []audit.Record, topologyDigest auditRecordHash,
+	attachments []audit.Record, attachmentDigest auditRecordHash,
+) audit.Record {
+	return audit.Record{Kind: "allocation_genesis", Fields: []audit.Field{
+		{Name: "vault_id", Value: values.vaultID},
+		{Name: "lineage_id", Value: values.lineageID},
+		{Name: "previous_head", Value: audit.Absent()},
+		{Name: "node_id_high_water", Value: audit.Unsigned(nodeSequence)},
+		{Name: "operation_sequence_high_water", Value: audit.Unsigned(0)},
+		{Name: "topology_count", Value: audit.Unsigned(uint64(len(topology)))},
+		{Name: "topology_digest", Value: topologyDigest.value},
+		{Name: "attached_metadata_count", Value: audit.Unsigned(uint64(len(attachments)))},
+		{Name: "attached_metadata_digest", Value: attachmentDigest.value},
+	}}
+}
+
+func makeInitialAuditBaseline(
+	values initialAuditValues, targetNodeID uint64, members []uint64,
+	states, versions, attachments, nodes, witnesses []audit.Record,
+) audit.Record {
+	memberValues := make([]audit.Value, len(members))
+	for index, member := range members {
+		memberValues[index] = audit.Unsigned(member)
+	}
+	return audit.Record{Kind: "enrollment_baseline", Fields: []audit.Field{
+		{Name: "vault_id", Value: values.vaultID},
+		{Name: "scope_id", Value: values.scopeID},
+		{Name: "target_node_id", Value: audit.Unsigned(targetNodeID)},
+		{Name: "operation_id", Value: values.operationID},
+		{Name: "cause", Value: values.cause},
+		{Name: "members", Value: audit.List(memberValues...)},
+		{Name: "member_states", Value: audit.List(auditNestedValues(states)...)},
+		{Name: "nodes", Value: audit.List(auditNestedValues(nodes)...)},
+		{Name: "versions", Value: audit.List(auditNestedValues(versions)...)},
+		{Name: "attachments", Value: audit.List(auditNestedValues(attachments)...)},
+		{Name: "witnesses", Value: audit.List(auditNestedValues(witnesses)...)},
+	}}
+}
+
+func makeInitialAuditEnrollmentEvent(
+	values initialAuditValues, targetNodeID uint64, baselineDigest auditRecordHash,
+	states []audit.Record,
+) (audit.Record, error) {
+	identityDigest, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
+		{Name: "operation_id", Value: values.operationID},
+		{Name: "event_ordinal", Value: audit.Unsigned(0)},
+	}})
+	if err != nil {
+		return audit.Record{}, err
+	}
+	var targetState audit.Record
+	for _, state := range states {
+		id, err := auditUnsignedField(state, metadataNodeIDField)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		if id == targetNodeID {
+			targetState = state
+			break
+		}
+	}
+	if targetState.Kind == "" {
+		return audit.Record{}, fmt.Errorf("audit enrollment target %d lacks member state", targetNodeID)
+	}
+	revision, err := auditUnsignedField(targetState, "node_revision")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	current, err := auditField(targetState, "current_version_id")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "audit_event", Fields: []audit.Field{
+		{Name: "event_id", Value: identityDigest.value},
+		{Name: "operation_id", Value: values.operationID},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(targetNodeID)},
+		{Name: "event_kind", Value: values.eventKind},
+		{Name: "scope_id", Value: values.scopeID},
+		{Name: "target_node_id", Value: audit.Unsigned(targetNodeID)},
+		{Name: "attachment_kind", Value: audit.Absent()},
+		{Name: "attachment_identity", Value: audit.Absent()},
+		{Name: "source_version_id", Value: audit.Absent()},
+		{Name: "event_ordinal", Value: audit.Unsigned(0)},
+		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: "prior_node_revision", Value: audit.Unsigned(revision)},
+		{Name: "resulting_node_revision", Value: audit.Unsigned(revision)},
+		{Name: "prior_current_version_id", Value: current},
+		{Name: "resulting_current_version_id", Value: current},
+		{Name: "origin", Value: values.origin},
+		{Name: "agent_label", Value: values.agentLabel},
+		{Name: "pre", Value: audit.Absent()},
+		{Name: "post", Value: audit.Absent()},
+		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: "baseline_digest", Value: baselineDigest.value},
+	}}, nil
+}
+
+func makeInitialAuditMutation(
+	values initialAuditValues, targetNodeID uint64, baselineDigest auditRecordHash,
+	event audit.Record,
+) audit.Record {
+	binding := audit.Record{Kind: "baseline_binding", Fields: []audit.Field{
+		{Name: "scope_id", Value: values.scopeID},
+		{Name: "target_node_id", Value: audit.Unsigned(targetNodeID)},
+		{Name: "baseline_digest", Value: baselineDigest.value},
+	}}
+	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
+		{Name: "vault_id", Value: values.vaultID},
+		{Name: "operation_sequence", Value: audit.Unsigned(1)},
+		{Name: "operation_id", Value: values.operationID},
+		{Name: "grouping_id", Value: audit.Absent()},
+		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: "origin", Value: values.origin},
+		{Name: "agent_label", Value: values.agentLabel},
+		{Name: "events", Value: audit.List(audit.Nested(event))},
+		{Name: "member_state_changes", Value: audit.List()},
+		{Name: "baselines", Value: audit.List(audit.Nested(binding))},
+		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: "path_effect_count", Value: audit.Unsigned(0)},
+		{Name: "path_effect_digest", Value: audit.Absent()},
+		{Name: "witness_change_count", Value: audit.Unsigned(0)},
+		{Name: "witness_change_digest", Value: audit.Absent()},
+		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
+		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+	}}
+}
+
+func makeInitialAllocationEntry(
+	values initialAuditValues, nodeSequence uint64,
+	genesisDigest, mutationDigest audit.Value,
+) audit.Record {
+	return audit.Record{Kind: "allocation_entry", Fields: []audit.Field{
+		{Name: "vault_id", Value: values.vaultID},
+		{Name: "lineage_id", Value: values.lineageID},
+		{Name: "previous_head", Value: genesisDigest},
+		{Name: "operation_sequence", Value: audit.Unsigned(1)},
+		{Name: "operation_id", Value: values.operationID},
+		{Name: "allocated_node_ids", Value: audit.List()},
+		{Name: "node_id_high_water", Value: audit.Unsigned(nodeSequence)},
+		{Name: "operation_sequence_high_water", Value: audit.Unsigned(1)},
+		{Name: "has_audited_mutation", Value: audit.Bool(true)},
+		{Name: "mutation_hash", Value: mutationDigest},
+		{Name: "has_topology_change", Value: audit.Bool(false)},
+		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: "has_witness_change", Value: audit.Bool(false)},
+		{Name: "witness_change_count", Value: audit.Unsigned(0)},
+		{Name: "witness_change_digest", Value: audit.Absent()},
+		{Name: "has_attached_metadata_change", Value: audit.Bool(false)},
+		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
+		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+	}}
+}
+
+func persistInitialAuditEnrollment(
+	ctx context.Context, tx *sql.Tx, set initialAuditEnrollmentSet,
+) error {
+	for _, record := range set.records {
+		if err := insertInitialAuditRecord(ctx, tx, record); err != nil {
+			return err
+		}
+	}
+	input := set.input
+	if _, err := tx.ExecContext(ctx, `INSERT INTO audit_authority(
+		singleton,lineage_id,operation_sequence_high_water,allocation_genesis_digest,
+		allocation_entry_count,allocation_head) VALUES(1,?,1,?,1,?)`,
+		input.lineageID, set.allocationGenesisDigest, set.allocationHead); err != nil {
+		return fmt.Errorf("creating audit authority: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO audit_scopes(
+		scope_id,target_node_id,enable_operation_id,entry_count,chain_head)
+		VALUES(?,?,?,1,?)`, input.scopeID, input.targetNodeID,
+		input.operationID, set.scopeHead); err != nil {
+		return fmt.Errorf("creating audit scope: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO audit_baselines(
+		digest,scope_id,target_node_id,operation_id) VALUES(?,?,?,?)`,
+		set.baselineDigest, input.scopeID, input.targetNodeID, input.operationID); err != nil {
+		return fmt.Errorf("creating audit baseline projection: %w", err)
+	}
+	for _, member := range set.members {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO audit_memberships(
+			scope_id,node_id,baseline_digest) VALUES(?,?,?)`,
+			input.scopeID, member, set.baselineDigest); err != nil {
+			return fmt.Errorf("creating audit membership for node %d: %w", member, err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO audit_write_guard(singleton) VALUES(1)`); err != nil {
+		return fmt.Errorf("activating audit write guard: %w", err)
+	}
+	return nil
+}
+
+func insertInitialAuditRecord(ctx context.Context, tx *sql.Tx, record audit.Record) error {
+	digest, err := hashAuditRecord(record)
+	if err != nil {
+		return err
+	}
+	recordJSON, err := audit.MarshalJSONRecord(record)
+	if err != nil {
+		return fmt.Errorf("encoding %s audit record: %w", record.Kind, err)
+	}
+	index, err := indexAuditRecord(record)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO audit_records(
+		digest,kind,operation_id,operation_sequence,scope_id,entry_count,
+		event_id,event_ordinal,record_json) VALUES(?,?,?,?,?,?,?,?,?)`,
+		digest.text, record.Kind, index.operationID, index.operationSequence,
+		index.scopeID, index.entryCount, index.eventID, index.eventOrdinal, string(recordJSON))
+	if err != nil {
+		return fmt.Errorf("storing %s audit record: %w", record.Kind, err)
+	}
+	return nil
+}

--- a/internal/store/audit_enrollment_test.go
+++ b/internal/store/audit_enrollment_test.go
@@ -83,3 +83,20 @@ func TestInitializeAuditAuthorityRejectsInvalidTargetsWithoutAuthority(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, [6]int64{}, counts)
 }
+
+func TestInitializeAuditAuthorityRejectsInvalidMetadataAndRollsBack(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`UPDATE sqlite_sequence SET seq=5 WHERE name='nodes'`)
+	require.NoError(t, err)
+
+	_, err = s.initializeAuditAuthority(t.Context(), target.ID, "cli", nil)
+	require.ErrorContains(t, err, "node ID high-water mark 5 is below maximum node ID 12")
+	counts, err := auditAuthorityCounts(t.Context(), s.db)
+	require.NoError(t, err)
+	assert.Equal(t, [6]int64{}, counts)
+}

--- a/internal/store/audit_enrollment_test.go
+++ b/internal/store/audit_enrollment_test.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestInitializeAuditAuthorityCreatesValidatedClosedSet(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	agentLabel := "archive-agent"
+
+	result, err := s.initializeAuditAuthority(t.Context(), target.ID, "api", &agentLabel)
+	require.NoError(t, err)
+	require.NoError(t, validateUUIDv4(result.scopeID))
+	require.NoError(t, validateUUIDv4(result.operationID))
+	assert.Len(t, result.baselineDigest, 64)
+	assert.Equal(t, 3, result.memberCount,
+		"the project scope adopts its live descendants and retained origin trash")
+
+	counts, err := auditAuthorityCounts(t.Context(), s.db)
+	require.NoError(t, err)
+	assert.Equal(t, [6]int64{1, 1, 1, 3, 8, 1}, counts)
+
+	var raw string
+	require.NoError(t, s.db.QueryRow(
+		`SELECT record_json FROM audit_records WHERE kind='canonical_mutation'`,
+	).Scan(&raw))
+	mutation, err := audit.UnmarshalJSONRecord([]byte(raw))
+	require.NoError(t, err)
+	origin, err := auditTextField(mutation, "origin")
+	require.NoError(t, err)
+	assert.Equal(t, "api", origin)
+	label, err := auditField(mutation, "agent_label")
+	require.NoError(t, err)
+	labelText, ok := label.TextValue()
+	require.True(t, ok)
+	assert.Equal(t, agentLabel, labelText)
+
+	_, err = s.initializeAuditAuthority(t.Context(), target.ID, "api", nil)
+	require.ErrorContains(t, err, "already initialized")
+}
+
+func TestInitializeAuditAuthorityRollsBackPartialWrite(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_audit_membership
+		BEFORE INSERT ON audit_memberships BEGIN
+		SELECT RAISE(ABORT, 'forced enrollment failure'); END`)
+	require.NoError(t, err)
+
+	_, err = s.initializeAuditAuthority(t.Context(), target.ID, "cli", nil)
+	require.ErrorContains(t, err, "forced enrollment failure")
+	counts, err := auditAuthorityCounts(t.Context(), s.db)
+	require.NoError(t, err)
+	assert.Equal(t, [6]int64{}, counts)
+}
+
+func TestInitializeAuditAuthorityRejectsInvalidTargetsWithoutAuthority(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+
+	for _, targetNodeID := range []int64{10, 11, 999} {
+		_, err := s.initializeAuditAuthority(t.Context(), targetNodeID, "cli", nil)
+		require.ErrorContains(t, err, "must be a live directory")
+	}
+	counts, err := auditAuthorityCounts(t.Context(), s.db)
+	require.NoError(t, err)
+	assert.Equal(t, [6]int64{}, counts)
+}

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"path/filepath"
@@ -327,250 +326,16 @@ func TestInitialAuditAuthorityReopens(t *testing.T) {
 
 func seedInitialAuditAuthority(t *testing.T, s *Store, targetNodeID int64) {
 	t.Helper()
-	ctx := context.Background()
-	topology, err := currentAuditTopology(ctx, s.db)
+	result, err := s.initializeAuditAuthorityWithInput(context.Background(), initialAuditEnrollmentInput{
+		targetNodeID: targetNodeID,
+		scopeID:      testAuditScopeID,
+		operationID:  testAuditOperationID,
+		lineageID:    testAuditLineageID,
+		recordedAt:   testAuditTimestamp,
+		origin:       "cli",
+	})
 	require.NoError(t, err)
-	attachments, err := currentAuditAttachments(ctx, s.db)
-	require.NoError(t, err)
-	var nodeSequence int64
-	require.NoError(t, s.db.QueryRow(
-		`SELECT seq FROM sqlite_sequence WHERE name='nodes'`).Scan(&nodeSequence))
-
-	topologyGenesis := audit.Record{Kind: "topology_genesis", Fields: []audit.Field{
-		{Name: "vault_id", Value: mustAuditUUID(t, s.VaultID())},
-		{Name: "lineage_id", Value: mustAuditUUID(t, testAuditLineageID)},
-		{Name: "nodes", Value: audit.List(auditNestedValues(topology)...)},
-	}}
-	attachmentGenesis := audit.Record{Kind: "attached_metadata_genesis", Fields: []audit.Field{
-		{Name: "vault_id", Value: mustAuditUUID(t, s.VaultID())},
-		{Name: "lineage_id", Value: mustAuditUUID(t, testAuditLineageID)},
-		{Name: "records", Value: audit.List(auditNestedValues(attachments)...)},
-	}}
-	topologyDigest := mustAuditRecordDigest(t, topologyGenesis)
-	attachmentDigest := mustAuditRecordDigest(t, attachmentGenesis)
-	allocationGenesis := audit.Record{Kind: "allocation_genesis", Fields: []audit.Field{
-		{Name: "vault_id", Value: mustAuditUUID(t, s.VaultID())},
-		{Name: "lineage_id", Value: mustAuditUUID(t, testAuditLineageID)},
-		{Name: "previous_head", Value: audit.Absent()},
-		{Name: "node_id_high_water", Value: audit.Unsigned(uint64(nodeSequence))},
-		{Name: "operation_sequence_high_water", Value: audit.Unsigned(0)},
-		{Name: "topology_count", Value: audit.Unsigned(uint64(len(topology)))},
-		{Name: "topology_digest", Value: mustAuditDigest(t, topologyDigest)},
-		{Name: "attached_metadata_count", Value: audit.Unsigned(uint64(len(attachments)))},
-		{Name: "attached_metadata_digest", Value: mustAuditDigest(t, attachmentDigest)},
-	}}
-	allocationGenesisDigest := mustAuditRecordDigest(t, allocationGenesis)
-
-	members, err := deriveInitialAuditMembers(ctx, s.db, uint64(targetNodeID))
-	require.NoError(t, err)
-	states, err := currentAuditMemberStates(ctx, s.db, members)
-	require.NoError(t, err)
-	versions, err := currentAuditVersions(ctx, s.db, members)
-	require.NoError(t, err)
-	baselineAttachments, err := auditRecordsForNodes(attachments, auditMemberSet(members))
-	require.NoError(t, err)
-	baselineNodes, witnesses, err := initialBaselineTopology(topology, members, testAuditOperationID)
-	require.NoError(t, err)
-	baseline := makeAuditEnrollmentBaseline(t, s.VaultID(), targetNodeID, members,
-		states, versions, baselineAttachments, baselineNodes, witnesses)
-	baselineDigest := mustAuditRecordDigest(t, baseline)
-	event := makeInitialAuditEvent(t, targetNodeID, baselineDigest, states)
-	eventWrapper := audit.Record{Kind: "event", Fields: []audit.Field{
-		{Name: "event", Value: audit.Nested(event)},
-	}}
-	mutation := makeInitialAuditMutation(t, s.VaultID(), targetNodeID, baselineDigest, event)
-	mutationDigest := mustAuditRecordDigest(t, mutation)
-	scopeEntry := audit.Record{Kind: "scope_chain_entry", Fields: []audit.Field{
-		{Name: "vault_id", Value: mustAuditUUID(t, s.VaultID())},
-		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
-		{Name: "entry_count", Value: audit.Unsigned(1)},
-		{Name: "previous_head", Value: audit.Absent()},
-		{Name: "mutation_hash", Value: mustAuditDigest(t, mutationDigest)},
-	}}
-	allocationEntry := makeInitialAllocationEntry(t, s.VaultID(), nodeSequence,
-		allocationGenesisDigest, mutationDigest)
-
-	records := []audit.Record{topologyGenesis, attachmentGenesis, allocationGenesis,
-		baseline, eventWrapper, mutation, scopeEntry, allocationEntry}
-	require.NoError(t, s.withTx(ctx, func(tx *sql.Tx) error {
-		for _, record := range records {
-			if err := insertAuditRecordFixture(tx, record); err != nil {
-				return err
-			}
-		}
-		scopeHead := mustAuditRecordDigest(t, scopeEntry)
-		allocationHead := mustAuditRecordDigest(t, allocationEntry)
-		if _, err := tx.Exec(`INSERT INTO audit_authority VALUES(1,?,?,?,1,?)`,
-			testAuditLineageID, 1, allocationGenesisDigest, allocationHead); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`INSERT INTO audit_scopes VALUES(?,?,?,1,?)`,
-			testAuditScopeID, targetNodeID, testAuditOperationID, scopeHead); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`INSERT INTO audit_baselines VALUES(?,?,?,?)`,
-			baselineDigest, testAuditScopeID, targetNodeID, testAuditOperationID); err != nil {
-			return err
-		}
-		for _, member := range members {
-			if _, err := tx.Exec(`INSERT INTO audit_memberships VALUES(?,?,?)`,
-				testAuditScopeID, member, baselineDigest); err != nil {
-				return err
-			}
-		}
-		_, err := tx.Exec(`INSERT INTO audit_write_guard VALUES(1)`)
-		return err
-	}))
-}
-
-func makeAuditEnrollmentBaseline(
-	t *testing.T, vaultID string, targetNodeID int64, members []uint64,
-	states, versions, attachments, nodes, witnesses []audit.Record,
-) audit.Record {
-	t.Helper()
-	memberValues := make([]audit.Value, len(members))
-	for index, member := range members {
-		memberValues[index] = audit.Unsigned(member)
-	}
-	return audit.Record{Kind: "enrollment_baseline", Fields: []audit.Field{
-		{Name: "vault_id", Value: mustAuditUUID(t, vaultID)},
-		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
-		{Name: "target_node_id", Value: audit.Unsigned(uint64(targetNodeID))},
-		{Name: "operation_id", Value: mustAuditUUID(t, testAuditOperationID)},
-		{Name: "cause", Value: mustAuditText(t, "explicit")},
-		{Name: "members", Value: audit.List(memberValues...)},
-		{Name: "member_states", Value: audit.List(auditNestedValues(states)...)},
-		{Name: "nodes", Value: audit.List(auditNestedValues(nodes)...)},
-		{Name: "versions", Value: audit.List(auditNestedValues(versions)...)},
-		{Name: "attachments", Value: audit.List(auditNestedValues(attachments)...)},
-		{Name: "witnesses", Value: audit.List(auditNestedValues(witnesses)...)},
-	}}
-}
-
-func makeInitialAuditEvent(
-	t *testing.T, targetNodeID int64, baselineDigest string, states []audit.Record,
-) audit.Record {
-	t.Helper()
-	operation := mustAuditUUID(t, testAuditOperationID)
-	eventIdentity := audit.Record{Kind: "event_identity", Fields: []audit.Field{
-		{Name: "operation_id", Value: operation},
-		{Name: "event_ordinal", Value: audit.Unsigned(0)},
-	}}
-	identityDigest := mustAuditRecordDigest(t, eventIdentity)
-	var targetState audit.Record
-	for _, state := range states {
-		id, err := auditUnsignedField(state, metadataNodeIDField)
-		require.NoError(t, err)
-		if id == uint64(targetNodeID) {
-			targetState = state
-		}
-	}
-	require.NotEmpty(t, targetState.Kind)
-	revision, err := auditUnsignedField(targetState, "node_revision")
-	require.NoError(t, err)
-	current, err := auditField(targetState, "current_version_id")
-	require.NoError(t, err)
-	return audit.Record{Kind: "audit_event", Fields: []audit.Field{
-		{Name: "event_id", Value: mustAuditDigest(t, identityDigest)},
-		{Name: "operation_id", Value: operation},
-		{Name: metadataNodeIDField, Value: audit.Unsigned(uint64(targetNodeID))},
-		{Name: "event_kind", Value: mustAuditText(t, "audit_enroll")},
-		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
-		{Name: "target_node_id", Value: audit.Unsigned(uint64(targetNodeID))},
-		{Name: "attachment_kind", Value: audit.Absent()},
-		{Name: "attachment_identity", Value: audit.Absent()},
-		{Name: "source_version_id", Value: audit.Absent()},
-		{Name: "event_ordinal", Value: audit.Unsigned(0)},
-		{Name: "recorded_at", Value: mustAuditTimestamp(t, testAuditTimestamp)},
-		{Name: "prior_node_revision", Value: audit.Unsigned(revision)},
-		{Name: "resulting_node_revision", Value: audit.Unsigned(revision)},
-		{Name: "prior_current_version_id", Value: current},
-		{Name: "resulting_current_version_id", Value: current},
-		{Name: "origin", Value: mustAuditText(t, "cli")},
-		{Name: "agent_label", Value: audit.Absent()},
-		{Name: "pre", Value: audit.Absent()},
-		{Name: "post", Value: audit.Absent()},
-		{Name: "topology_delta", Value: audit.Absent()},
-		{Name: "baseline_digest", Value: mustAuditDigest(t, baselineDigest)},
-	}}
-}
-
-func makeInitialAuditMutation(
-	t *testing.T, vaultID string, targetNodeID int64, baselineDigest string,
-	event audit.Record,
-) audit.Record {
-	t.Helper()
-	binding := audit.Record{Kind: "baseline_binding", Fields: []audit.Field{
-		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
-		{Name: "target_node_id", Value: audit.Unsigned(uint64(targetNodeID))},
-		{Name: "baseline_digest", Value: mustAuditDigest(t, baselineDigest)},
-	}}
-	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
-		{Name: "vault_id", Value: mustAuditUUID(t, vaultID)},
-		{Name: "operation_sequence", Value: audit.Unsigned(1)},
-		{Name: "operation_id", Value: mustAuditUUID(t, testAuditOperationID)},
-		{Name: "grouping_id", Value: audit.Absent()},
-		{Name: "recorded_at", Value: mustAuditTimestamp(t, testAuditTimestamp)},
-		{Name: "origin", Value: mustAuditText(t, "cli")},
-		{Name: "agent_label", Value: audit.Absent()},
-		{Name: "events", Value: audit.List(audit.Nested(event))},
-		{Name: "member_state_changes", Value: audit.List()},
-		{Name: "baselines", Value: audit.List(audit.Nested(binding))},
-		{Name: "topology_delta", Value: audit.Absent()},
-		{Name: "path_effect_count", Value: audit.Unsigned(0)},
-		{Name: "path_effect_digest", Value: audit.Absent()},
-		{Name: "witness_change_count", Value: audit.Unsigned(0)},
-		{Name: "witness_change_digest", Value: audit.Absent()},
-		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
-		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
-	}}
-}
-
-func makeInitialAllocationEntry(
-	t *testing.T, vaultID string, nodeSequence int64, genesisDigest, mutationDigest string,
-) audit.Record {
-	t.Helper()
-	return audit.Record{Kind: "allocation_entry", Fields: []audit.Field{
-		{Name: "vault_id", Value: mustAuditUUID(t, vaultID)},
-		{Name: "lineage_id", Value: mustAuditUUID(t, testAuditLineageID)},
-		{Name: "previous_head", Value: mustAuditDigest(t, genesisDigest)},
-		{Name: "operation_sequence", Value: audit.Unsigned(1)},
-		{Name: "operation_id", Value: mustAuditUUID(t, testAuditOperationID)},
-		{Name: "allocated_node_ids", Value: audit.List()},
-		{Name: "node_id_high_water", Value: audit.Unsigned(uint64(nodeSequence))},
-		{Name: "operation_sequence_high_water", Value: audit.Unsigned(1)},
-		{Name: "has_audited_mutation", Value: audit.Bool(true)},
-		{Name: "mutation_hash", Value: mustAuditDigest(t, mutationDigest)},
-		{Name: "has_topology_change", Value: audit.Bool(false)},
-		{Name: "topology_delta", Value: audit.Absent()},
-		{Name: "has_witness_change", Value: audit.Bool(false)},
-		{Name: "witness_change_count", Value: audit.Unsigned(0)},
-		{Name: "witness_change_digest", Value: audit.Absent()},
-		{Name: "has_attached_metadata_change", Value: audit.Bool(false)},
-		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
-		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
-	}}
-}
-
-func insertAuditRecordFixture(tx *sql.Tx, record audit.Record) error {
-	digestValue, err := audit.Hash(record)
-	if err != nil {
-		return err
-	}
-	digest := hex.EncodeToString(digestValue[:])
-	recordJSON, err := audit.MarshalJSONRecord(record)
-	if err != nil {
-		return err
-	}
-	index, err := indexAuditRecord(record)
-	if err != nil {
-		return err
-	}
-	_, err = tx.Exec(`INSERT INTO audit_records(digest,kind,operation_id,operation_sequence,
-		scope_id,entry_count,event_id,event_ordinal,record_json) VALUES(?,?,?,?,?,?,?,?,?)`,
-		digest, record.Kind, index.operationID, index.operationSequence, index.scopeID,
-		index.entryCount, index.eventID, index.eventOrdinal, string(recordJSON))
-	return err
+	require.NotEmpty(t, result.baselineDigest)
 }
 
 func mustAuditRecordDigest(t *testing.T, record audit.Record) string {
@@ -590,20 +355,6 @@ func mustAuditUUID(t *testing.T, value string) audit.Value {
 func mustAuditDigest(t *testing.T, value string) audit.Value {
 	t.Helper()
 	result, err := audit.DigestHex(value)
-	require.NoError(t, err)
-	return result
-}
-
-func mustAuditText(t *testing.T, value string) audit.Value {
-	t.Helper()
-	result, err := audit.Text(value)
-	require.NoError(t, err)
-	return result
-}
-
-func mustAuditTimestamp(t *testing.T, value string) audit.Value {
-	t.Helper()
-	result, err := audit.Timestamp(value)
 	require.NoError(t, err)
 	return result
 }


### PR DESCRIPTION
PR #65 made one first-enrollment authority portable and independently verifiable, but its only producer was a test fixture that hand-built the canonical records. Carrying that fixture forward beside a real writer would give the audit contract multiple implementations and make guarded mutations harder to reason about.

This moves the closed first-enrollment construction into one production transaction and makes the existing round-trip and adversarial import suite consume it. The transaction refuses non-dormant authority, derives the complete scope closure, persists all records and projections, activates the write guard last, and runs the independent authority validator before commit; a forced mid-write failure proves the entire set rolls back.

The entry point intentionally remains internal. Enabling audit publicly before ordinary mutations can advance its chains would create a vault that immediately becomes read-only, so HTTP, CLI, and embedded enablement remain with the guarded-mutation work rather than leaking a half-usable feature now. Kata: qmec.
