### PR TITLE
Record inherited audited node creation

### DIFF
--- a/internal/store/audit_baseline_projection.go
+++ b/internal/store/audit_baseline_projection.go
@@ -324,7 +324,7 @@ func initialBaselineTopology(
 			return nil, nil, err
 		}
 		parents[id] = parent
-		originValue, err := auditField(record, "origin")
+		originValue, err := auditField(record, auditOriginField)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/store/audit_content_replace.go
+++ b/internal/store/audit_content_replace.go
@@ -175,8 +175,8 @@ func persistAuditedContentReplacement(
 		return err
 	}
 	for _, event := range events {
-		if err := insertAuditRecord(ctx, tx, audit.Record{Kind: "event", Fields: []audit.Field{
-			{Name: "event", Value: audit.Nested(event)},
+		if err := insertAuditRecord(ctx, tx, audit.Record{Kind: auditEventField, Fields: []audit.Field{
+			{Name: auditEventField, Value: audit.Nested(event)},
 		}}); err != nil {
 			return err
 		}

--- a/internal/store/audit_content_replace.go
+++ b/internal/store/audit_content_replace.go
@@ -37,7 +37,7 @@ func replaceAuditedContentTx(
 	ctx context.Context, tx *sql.Tx, store *Store, node Node,
 	blobHash string, size int64, mimeType string,
 ) (Node, ContentVersion, error) {
-	authority, scopes, nodeSequence, err := loadAuditedReplacementAuthority(ctx, tx, node.ID)
+	authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, node.ID)
 	if err != nil {
 		return Node{}, ContentVersion{}, err
 	}
@@ -70,7 +70,7 @@ func replaceAuditedContentTx(
 	return updated, version, nil
 }
 
-func loadAuditedReplacementAuthority(
+func loadAuditedNodeAuthority(
 	ctx context.Context, tx *sql.Tx, nodeID int64,
 ) (auditAuthorityState, []auditScopeState, int64, error) {
 	var authority auditAuthorityState
@@ -104,7 +104,7 @@ func loadAuditedReplacementAuthority(
 		return authority, nil, 0, fmt.Errorf("reading audit memberships for node %d: %w", nodeID, err)
 	}
 	if len(scopes) == 0 {
-		return authority, nil, 0, unsupportedAuditedContentReplacement(nodeID)
+		return authority, nil, 0, unsupportedAuditedNodeMutation(nodeID)
 	}
 	var nodeSequence int64
 	if err := tx.QueryRowContext(ctx,
@@ -115,7 +115,7 @@ func loadAuditedReplacementAuthority(
 	return authority, scopes, nodeSequence, nil
 }
 
-func unsupportedAuditedContentReplacement(nodeID int64) error {
+func unsupportedAuditedNodeMutation(nodeID int64) error {
 	return fmt.Errorf("node %d is not in an audit scope: %w", nodeID, ErrAuditMutationUnsupported)
 }
 
@@ -135,7 +135,7 @@ func persistAuditedContentReplacement(
 	if err != nil {
 		return err
 	}
-	values, err := makeAuditedContentReplacementValues(
+	values, err := makeAuditedMutationValues(
 		vaultID, authority.lineageID, resultingVersion.IntroducedOperationID,
 		resultingVersion.RecordedAt,
 	)
@@ -234,15 +234,15 @@ func persistAuditedContentReplacement(
 	return nil
 }
 
-type auditedContentReplacementValues struct {
+type auditedMutationValues struct {
 	vaultID, lineageID, operationID audit.Value
 	recordedAt, origin              audit.Value
 }
 
-func makeAuditedContentReplacementValues(
+func makeAuditedMutationValues(
 	vaultID, lineageID, operationID, recordedAt string,
-) (auditedContentReplacementValues, error) {
-	var values auditedContentReplacementValues
+) (auditedMutationValues, error) {
+	var values auditedMutationValues
 	constructors := []struct {
 		name  string
 		value string
@@ -253,7 +253,7 @@ func makeAuditedContentReplacementValues(
 		{"lineage ID", lineageID, audit.UUID, &values.lineageID},
 		{"operation ID", operationID, audit.UUID, &values.operationID},
 		{"recorded time", recordedAt, audit.Timestamp, &values.recordedAt},
-		{"origin", "api", audit.Text, &values.origin},
+		{auditOriginField, "api", audit.Text, &values.origin},
 	}
 	for _, item := range constructors {
 		value, err := item.make(item.value)
@@ -283,7 +283,7 @@ func auditRecordForContentVersion(version ContentVersion) (audit.Record, error) 
 }
 
 func makeAuditedContentReplacementEvent(
-	values auditedContentReplacementValues, scopeID string, ordinal uint64,
+	values auditedMutationValues, scopeID string, ordinal uint64,
 	priorNode, resultingNode Node, priorVersion, resultingVersion audit.Record,
 ) (audit.Record, error) {
 	nodeID, err := positiveAuditNodeID(priorNode.ID)
@@ -326,7 +326,7 @@ func makeAuditedContentReplacementEvent(
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
 		{Name: "event_kind", Value: eventKind},
-		{Name: "scope_id", Value: scopeValue},
+		{Name: auditScopeIDField, Value: scopeValue},
 		{Name: "target_node_id", Value: audit.Absent()},
 		{Name: "attachment_kind", Value: audit.Absent()},
 		{Name: "attachment_identity", Value: audit.Absent()},
@@ -337,11 +337,11 @@ func makeAuditedContentReplacementEvent(
 		{Name: "resulting_node_revision", Value: audit.Unsigned(resultingRevision)},
 		{Name: "prior_current_version_id", Value: priorVersionID},
 		{Name: "resulting_current_version_id", Value: resultingVersionID},
-		{Name: "origin", Value: values.origin},
+		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: audit.Absent()},
 		{Name: "pre", Value: audit.Nested(priorVersion)},
 		{Name: "post", Value: audit.Nested(resultingVersion)},
-		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
 		{Name: "baseline_digest", Value: audit.Absent()},
 	}}, nil
 }
@@ -359,11 +359,11 @@ func makeAuditMemberStateChange(prior, resulting Node) (audit.Record, error) {
 	if err != nil || resultingRevision != priorRevision+1 {
 		return audit.Record{}, errors.New("audited member-state change has an invalid revision transition")
 	}
-	priorVersion, err := audit.UUID(prior.CurrentVersionID)
+	priorVersion, err := auditNodeCurrentVersion(prior)
 	if err != nil {
 		return audit.Record{}, err
 	}
-	resultingVersion, err := audit.UUID(resulting.CurrentVersionID)
+	resultingVersion, err := auditNodeCurrentVersion(resulting)
 	if err != nil {
 		return audit.Record{}, err
 	}
@@ -376,12 +376,19 @@ func makeAuditMemberStateChange(prior, resulting Node) (audit.Record, error) {
 	}}, nil
 }
 
+func auditNodeCurrentVersion(node Node) (audit.Value, error) {
+	if node.CurrentVersionID == "" {
+		return audit.Absent(), nil
+	}
+	return audit.UUID(node.CurrentVersionID)
+}
+
 func positiveAuditRevision(value int64) (uint64, error) {
 	return positiveAuditInteger("content revision", value)
 }
 
 func makeAuditedContentReplacementMutation(
-	values auditedContentReplacementValues, sequence int64,
+	values auditedMutationValues, sequence int64,
 	events []audit.Record, change audit.Record,
 ) (audit.Record, error) {
 	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
@@ -398,23 +405,23 @@ func makeAuditedContentReplacementMutation(
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: "grouping_id", Value: audit.Absent()},
 		{Name: "recorded_at", Value: values.recordedAt},
-		{Name: "origin", Value: values.origin},
+		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: audit.Absent()},
 		{Name: "events", Value: audit.List(eventValues...)},
 		{Name: "member_state_changes", Value: audit.List(audit.Nested(change))},
 		{Name: "baselines", Value: audit.List()},
-		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
 		{Name: "path_effect_count", Value: audit.Unsigned(0)},
 		{Name: "path_effect_digest", Value: audit.Absent()},
-		{Name: "witness_change_count", Value: audit.Unsigned(0)},
+		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "witness_change_digest", Value: audit.Absent()},
-		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
 	}}, nil
 }
 
 func makeAuditScopeChainEntry(
-	values auditedContentReplacementValues, scopeID string, entryCount int64,
+	values auditedMutationValues, scopeID string, entryCount int64,
 	previousHead string, mutationHash audit.Value,
 ) (audit.Record, error) {
 	auditEntryCount, err := positiveAuditInteger("scope entry count", entryCount)
@@ -431,7 +438,7 @@ func makeAuditScopeChainEntry(
 	}
 	return audit.Record{Kind: "scope_chain_entry", Fields: []audit.Field{
 		{Name: auditVaultIDField, Value: values.vaultID},
-		{Name: "scope_id", Value: scopeValue},
+		{Name: auditScopeIDField, Value: scopeValue},
 		{Name: "entry_count", Value: audit.Unsigned(auditEntryCount)},
 		{Name: "previous_head", Value: previousValue},
 		{Name: "mutation_hash", Value: mutationHash},
@@ -439,7 +446,7 @@ func makeAuditScopeChainEntry(
 }
 
 func makeAuditedContentAllocationEntry(
-	values auditedContentReplacementValues, sequence, nodeSequence int64,
+	values auditedMutationValues, sequence, nodeSequence int64,
 	previousHead string, mutationHash audit.Value,
 ) (audit.Record, error) {
 	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
@@ -466,12 +473,12 @@ func makeAuditedContentAllocationEntry(
 		{Name: "has_audited_mutation", Value: audit.Bool(true)},
 		{Name: "mutation_hash", Value: mutationHash},
 		{Name: "has_topology_change", Value: audit.Bool(false)},
-		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
 		{Name: "has_witness_change", Value: audit.Bool(false)},
-		{Name: "witness_change_count", Value: audit.Unsigned(0)},
+		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "witness_change_digest", Value: audit.Absent()},
 		{Name: "has_attached_metadata_change", Value: audit.Bool(false)},
-		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
 	}}, nil
 }

--- a/internal/store/audit_enrollment.go
+++ b/internal/store/audit_enrollment.go
@@ -196,8 +196,8 @@ func buildInitialAuditEnrollment(
 	if err != nil {
 		return initialAuditEnrollmentSet{}, err
 	}
-	eventWrapper := audit.Record{Kind: "event", Fields: []audit.Field{
-		{Name: "event", Value: audit.Nested(event)},
+	eventWrapper := audit.Record{Kind: auditEventField, Fields: []audit.Field{
+		{Name: auditEventField, Value: audit.Nested(event)},
 	}}
 	mutation := makeInitialAuditMutation(values, auditTargetNodeID, baselineDigest, event)
 	mutationDigest, err := hashAuditRecord(mutation)

--- a/internal/store/audit_enrollment.go
+++ b/internal/store/audit_enrollment.go
@@ -206,7 +206,7 @@ func buildInitialAuditEnrollment(
 	}
 	scopeEntry := audit.Record{Kind: "scope_chain_entry", Fields: []audit.Field{
 		{Name: auditVaultIDField, Value: values.vaultID},
-		{Name: "scope_id", Value: values.scopeID},
+		{Name: auditScopeIDField, Value: values.scopeID},
 		{Name: "entry_count", Value: audit.Unsigned(1)},
 		{Name: "previous_head", Value: audit.Absent()},
 		{Name: "mutation_hash", Value: mutationDigest.value},
@@ -263,7 +263,7 @@ func makeInitialAuditValues(vaultID string, input initialAuditEnrollmentInput) (
 		{"operation ID", input.operationID, audit.UUID, &values.operationID},
 		{"lineage ID", input.lineageID, audit.UUID, &values.lineageID},
 		{"recorded time", input.recordedAt, audit.Timestamp, &values.recordedAt},
-		{"origin", input.origin, audit.Text, &values.origin},
+		{auditOriginField, input.origin, audit.Text, &values.origin},
 		{"enrollment cause", "explicit", audit.Text, &values.cause},
 		{"enrollment event kind", "audit_enroll", audit.Text, &values.eventKind},
 	}
@@ -313,7 +313,7 @@ func makeInitialAuditBaseline(
 	}
 	return audit.Record{Kind: "enrollment_baseline", Fields: []audit.Field{
 		{Name: auditVaultIDField, Value: values.vaultID},
-		{Name: "scope_id", Value: values.scopeID},
+		{Name: auditScopeIDField, Value: values.scopeID},
 		{Name: "target_node_id", Value: audit.Unsigned(targetNodeID)},
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: "cause", Value: values.cause},
@@ -364,7 +364,7 @@ func makeInitialAuditEnrollmentEvent(
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: metadataNodeIDField, Value: audit.Unsigned(targetNodeID)},
 		{Name: "event_kind", Value: values.eventKind},
-		{Name: "scope_id", Value: values.scopeID},
+		{Name: auditScopeIDField, Value: values.scopeID},
 		{Name: "target_node_id", Value: audit.Unsigned(targetNodeID)},
 		{Name: "attachment_kind", Value: audit.Absent()},
 		{Name: "attachment_identity", Value: audit.Absent()},
@@ -375,11 +375,11 @@ func makeInitialAuditEnrollmentEvent(
 		{Name: "resulting_node_revision", Value: audit.Unsigned(revision)},
 		{Name: "prior_current_version_id", Value: current},
 		{Name: "resulting_current_version_id", Value: current},
-		{Name: "origin", Value: values.origin},
+		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: values.agentLabel},
 		{Name: "pre", Value: audit.Absent()},
 		{Name: "post", Value: audit.Absent()},
-		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
 		{Name: "baseline_digest", Value: baselineDigest.value},
 	}}, nil
 }
@@ -389,7 +389,7 @@ func makeInitialAuditMutation(
 	event audit.Record,
 ) audit.Record {
 	binding := audit.Record{Kind: "baseline_binding", Fields: []audit.Field{
-		{Name: "scope_id", Value: values.scopeID},
+		{Name: auditScopeIDField, Value: values.scopeID},
 		{Name: "target_node_id", Value: audit.Unsigned(targetNodeID)},
 		{Name: "baseline_digest", Value: baselineDigest.value},
 	}}
@@ -399,17 +399,17 @@ func makeInitialAuditMutation(
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: "grouping_id", Value: audit.Absent()},
 		{Name: "recorded_at", Value: values.recordedAt},
-		{Name: "origin", Value: values.origin},
+		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: values.agentLabel},
 		{Name: "events", Value: audit.List(audit.Nested(event))},
 		{Name: "member_state_changes", Value: audit.List()},
 		{Name: "baselines", Value: audit.List(audit.Nested(binding))},
-		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
 		{Name: "path_effect_count", Value: audit.Unsigned(0)},
 		{Name: "path_effect_digest", Value: audit.Absent()},
-		{Name: "witness_change_count", Value: audit.Unsigned(0)},
+		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "witness_change_digest", Value: audit.Absent()},
-		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
 	}}
 }
@@ -430,12 +430,12 @@ func makeInitialAllocationEntry(
 		{Name: "has_audited_mutation", Value: audit.Bool(true)},
 		{Name: "mutation_hash", Value: mutationDigest},
 		{Name: "has_topology_change", Value: audit.Bool(false)},
-		{Name: "topology_delta", Value: audit.Absent()},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
 		{Name: "has_witness_change", Value: audit.Bool(false)},
-		{Name: "witness_change_count", Value: audit.Unsigned(0)},
+		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "witness_change_digest", Value: audit.Absent()},
 		{Name: "has_attached_metadata_change", Value: audit.Bool(false)},
-		{Name: "attached_metadata_change_count", Value: audit.Unsigned(0)},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
 	}}
 }

--- a/internal/store/audit_enrollment_test.go
+++ b/internal/store/audit_enrollment_test.go
@@ -37,7 +37,7 @@ func TestInitializeAuditAuthorityCreatesValidatedClosedSet(t *testing.T) {
 	).Scan(&raw))
 	mutation, err := audit.UnmarshalJSONRecord([]byte(raw))
 	require.NoError(t, err)
-	origin, err := auditTextField(mutation, "origin")
+	origin, err := auditTextField(mutation, auditOriginField)
 	require.NoError(t, err)
 	assert.Equal(t, "api", origin)
 	label, err := auditField(mutation, "agent_label")

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -239,7 +239,7 @@ func validateAuditedHistory(
 	if err != nil {
 		return err
 	}
-	events, err := auditEventRecordsByID(records["event"])
+	events, err := auditEventRecordsByID(records[auditEventField])
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func validateAuditedHistory(
 			return fmt.Errorf("validating audit operation %d: %w", sequence, err)
 		}
 	}
-	initialEventID := *initial["event"][0].index.eventID
+	initialEventID := *initial[auditEventField][0].index.eventID
 	usedEvents[initialEventID] = true
 	if len(usedEvents) != len(events) {
 		return errors.New("audit history contains an unbound event record")
@@ -520,7 +520,7 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 	if !ok || usedEvents[eventID] {
 		return 0, audit.Record{}, errors.New("content replacement lacks one unique event wrapper")
 	}
-	wrapped, err := auditNestedField(wrapper.record, "event")
+	wrapped, err := auditNestedField(wrapper.record, auditEventField)
 	if err != nil || !auditRecordEqual(wrapped, event) {
 		return 0, audit.Record{}, errors.New("content replacement event wrapper does not match mutation")
 	}

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -82,7 +82,7 @@ func replayAuditTopology(topology []audit.Record) (map[uint64]replayAuditTopolog
 		if err != nil {
 			return nil, err
 		}
-		originValue, err := auditField(record, "origin")
+		originValue, err := auditField(record, auditOriginField)
 		if err != nil {
 			return nil, err
 		}
@@ -205,9 +205,17 @@ type auditedHistoryReplay struct {
 	scopeEntryCount int64
 	allocationHead  string
 	allocationCount int64
+	nodeHighWater   uint64
+	baselines       map[string]auditBaselineProjection
+	memberBaselines map[uint64]string
 }
 
-func validateAuditedContentReplacementHistory(
+type auditBaselineProjection struct {
+	scopeID, operationID string
+	targetNodeID         uint64
+}
+
+func validateAuditedHistory(
 	ctx context.Context, tx metadataQuerier, vaultID string, nodeSequence int64,
 	authority initialAuditAuthority, scope initialAuditScope,
 	records, initial map[string][]storedAuditRecord,
@@ -236,11 +244,28 @@ func validateAuditedContentReplacementHistory(
 		return err
 	}
 	usedEvents := map[string]bool{}
+	baselines := auditRecordsByDigest(records["enrollment_baseline"])
+	topologyDeltas := auditRecordsByDigest(records[auditTopologyDeltaField])
+	usedBaselines := map[string]bool{initial["enrollment_baseline"][0].digest: true}
+	usedTopologyDeltas := map[string]bool{}
 	for sequence := int64(2); sequence <= authority.sequence; sequence++ {
-		if err := replay.applyContentReplacement(
-			vaultID, nodeSequence, mutations[sequence], allocations[sequence],
-			entries[sequence], events, usedEvents,
-		); err != nil {
+		mutation := mutations[sequence]
+		bindings, bindingErr := auditRecordListField(mutation.record, "baselines")
+		if bindingErr != nil {
+			return fmt.Errorf("validating audit operation %d: %w", sequence, bindingErr)
+		}
+		if len(bindings) == 0 {
+			err = replay.applyContentReplacement(
+				vaultID, mutation, allocations[sequence], entries[sequence], events, usedEvents,
+			)
+		} else {
+			err = replay.applyNodeCreation(
+				vaultID, mutation, allocations[sequence], entries[sequence],
+				baselines, topologyDeltas, events, usedBaselines,
+				usedTopologyDeltas, usedEvents,
+			)
+		}
+		if err != nil {
 			return fmt.Errorf("validating audit operation %d: %w", sequence, err)
 		}
 	}
@@ -249,13 +274,34 @@ func validateAuditedContentReplacementHistory(
 	if len(usedEvents) != len(events) {
 		return errors.New("audit history contains an unbound event record")
 	}
+	if len(usedBaselines) != len(baselines) {
+		return errors.New("audit history contains an unbound enrollment baseline")
+	}
+	if len(usedTopologyDeltas) != len(topologyDeltas) {
+		return errors.New("audit history contains an unbound topology delta")
+	}
 	if authority.sequence != replay.allocationCount || authority.allocationHead != replay.allocationHead {
 		return errors.New("audit allocation authority does not match replayed history")
 	}
 	if scope.entryCount != replay.scopeEntryCount || scope.chainHead != replay.scopeHead {
 		return errors.New("audit scope authority does not match replayed history")
 	}
+	finalNodeHighWater, err := positiveAuditNodeID(nodeSequence)
+	if err != nil {
+		return err
+	}
+	if finalNodeHighWater != replay.nodeHighWater {
+		return errors.New("audit node allocation high-water mark does not match replayed history")
+	}
 	return replay.reconcileCurrentState(ctx, tx, initial)
+}
+
+func auditRecordsByDigest(records []storedAuditRecord) map[string]storedAuditRecord {
+	result := make(map[string]storedAuditRecord, len(records))
+	for _, record := range records {
+		result[record.digest] = record
+	}
+	return result
 }
 
 func validateStoredAuditRecordSchemas(records map[string][]storedAuditRecord) error {
@@ -296,6 +342,11 @@ func newAuditedHistoryReplay(
 	if err != nil {
 		return nil, err
 	}
+	nodeHighWater, err := auditUnsignedField(initial["allocation_genesis"][0].record, "node_id_high_water")
+	if err != nil {
+		return nil, err
+	}
+	initialBaseline := initial["enrollment_baseline"][0]
 	replay := &auditedHistoryReplay{
 		scopeID:         scope.scopeID,
 		lineageID:       authority.lineageID,
@@ -309,6 +360,17 @@ func newAuditedHistoryReplay(
 		scopeEntryCount: 1,
 		allocationHead:  initial["allocation_entry"][0].digest,
 		allocationCount: 1,
+		nodeHighWater:   nodeHighWater,
+		baselines: map[string]auditBaselineProjection{
+			initialBaseline.digest: {
+				scopeID: scope.scopeID, operationID: scope.operationID,
+				targetNodeID: scope.targetNodeID,
+			},
+		},
+		memberBaselines: make(map[uint64]string, len(members)),
+	}
+	for _, member := range members {
+		replay.memberBaselines[member] = initialBaseline.digest
 	}
 	for _, state := range states {
 		nodeID, err := auditUnsignedField(state, metadataNodeIDField)
@@ -388,7 +450,7 @@ func auditEventRecordsByID(records []storedAuditRecord) (map[string]storedAuditR
 }
 
 func (replay *auditedHistoryReplay) applyContentReplacement(
-	vaultID string, nodeSequence int64, mutation, allocation, scopeEntry storedAuditRecord,
+	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
 	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
 ) error {
 	sequence := *mutation.index.operationSequence
@@ -439,7 +501,7 @@ func (replay *auditedHistoryReplay) applyContentReplacement(
 		return err
 	}
 	if err := replay.advanceAllocation(
-		vaultID, nodeSequence, operationID, mutation, allocation,
+		vaultID, operationID, mutation, allocation,
 	); err != nil {
 		return err
 	}
@@ -484,7 +546,7 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 	checks := []func() error{
 		func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
 		func() error { return requireAuditText(event, "event_kind", "content_replace") },
-		func() error { return requireAuditUUID(event, "scope_id", replay.scopeID) },
+		func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
 		func() error { return requireAuditUnsigned(event, "event_ordinal", 0) },
 	}
 	for _, check := range checks {
@@ -493,7 +555,7 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 		}
 	}
 	if err := requireAuditAbsentFields(event, "target_node_id", "attachment_kind",
-		"attachment_identity", "source_version_id", "topology_delta", "baseline_digest"); err != nil {
+		"attachment_identity", "source_version_id", auditTopologyDeltaField, "baseline_digest"); err != nil {
 		return 0, audit.Record{}, err
 	}
 	if err := requireMatchingEventEnvelope(mutation, event); err != nil {
@@ -610,7 +672,7 @@ func (replay *auditedHistoryReplay) advanceScope(
 	if err := requireAuditUUID(entry.record, auditVaultIDField, vaultID); err != nil {
 		return err
 	}
-	if err := requireAuditUUID(entry.record, "scope_id", replay.scopeID); err != nil {
+	if err := requireAuditUUID(entry.record, auditScopeIDField, replay.scopeID); err != nil {
 		return err
 	}
 	if err := requireAuditDigest(entry.record, "previous_head", replay.scopeHead); err != nil {
@@ -628,15 +690,11 @@ func (replay *auditedHistoryReplay) advanceScope(
 }
 
 func (replay *auditedHistoryReplay) advanceAllocation(
-	vaultID string, nodeSequence int64, operationID string,
+	vaultID string, operationID string,
 	mutation, entry storedAuditRecord,
 ) error {
 	nextCount := replay.allocationCount + 1
 	auditCount, err := positiveAuditInteger("allocation entry count", nextCount)
-	if err != nil {
-		return err
-	}
-	auditNodeSequence, err := positiveAuditInteger("node ID high-water mark", nodeSequence)
 	if err != nil {
 		return err
 	}
@@ -652,7 +710,7 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 		func() error {
 			return requireAuditUnsigned(entry.record, "operation_sequence_high_water", auditCount)
 		},
-		func() error { return requireAuditUnsigned(entry.record, "node_id_high_water", auditNodeSequence) },
+		func() error { return requireAuditUnsigned(entry.record, "node_id_high_water", replay.nodeHighWater) },
 		func() error { return requireAuditBool(entry.record, "has_audited_mutation", true) },
 	}
 	for _, check := range checks {
@@ -681,12 +739,12 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 			return err
 		}
 	}
-	for _, field := range []string{"witness_change_count", "attached_metadata_change_count"} {
+	for _, field := range []string{auditWitnessChangeCountField, auditAttachedMetadataChangeCountField} {
 		if err := requireAuditUnsigned(entry.record, field, 0); err != nil {
 			return err
 		}
 	}
-	if err := requireAuditAbsentFields(entry.record, "topology_delta",
+	if err := requireAuditAbsentFields(entry.record, auditTopologyDeltaField,
 		"witness_change_digest", "attached_metadata_change_digest"); err != nil {
 		return err
 	}
@@ -744,6 +802,9 @@ func replaceAuditRecordField(record audit.Record, name string, value audit.Value
 func (replay *auditedHistoryReplay) reconcileCurrentState(
 	ctx context.Context, tx metadataQuerier, initial map[string][]storedAuditRecord,
 ) error {
+	if err := replay.reconcileMembershipProjection(ctx, tx); err != nil {
+		return err
+	}
 	currentStates, err := currentAuditMemberStates(ctx, tx, replay.members)
 	if err != nil {
 		return err
@@ -785,6 +846,62 @@ func (replay *auditedHistoryReplay) reconcileCurrentState(
 	}
 	if !equalAuditRecordLists(genesisAttachments, currentAttachments) {
 		return errors.New("replayed audit attachments do not match current metadata")
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) reconcileMembershipProjection(
+	ctx context.Context, tx metadataQuerier,
+) error {
+	rows, err := tx.QueryContext(ctx, `SELECT node_id,baseline_digest FROM audit_memberships
+		WHERE scope_id=? ORDER BY node_id`, replay.scopeID)
+	if err != nil {
+		return fmt.Errorf("reading replayed audit memberships: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var members []uint64
+	for rows.Next() {
+		var nodeID uint64
+		var baseline string
+		if err := rows.Scan(&nodeID, &baseline); err != nil {
+			return fmt.Errorf("scanning replayed audit membership: %w", err)
+		}
+		if replay.memberBaselines[nodeID] != baseline {
+			return fmt.Errorf("audit membership for node %d does not match replayed baseline", nodeID)
+		}
+		members = append(members, nodeID)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("reading replayed audit memberships: %w", err)
+	}
+	if !slices.Equal(members, replay.members) {
+		return errors.New("audit membership projection does not match replayed history")
+	}
+	baselineRows, err := tx.QueryContext(ctx, `SELECT digest,scope_id,target_node_id,operation_id
+		FROM audit_baselines ORDER BY digest`)
+	if err != nil {
+		return fmt.Errorf("reading replayed audit baselines: %w", err)
+	}
+	defer func() { _ = baselineRows.Close() }()
+	seen := make(map[string]bool, len(replay.baselines))
+	for baselineRows.Next() {
+		var digest, scopeID, operationID string
+		var targetNodeID uint64
+		if err := baselineRows.Scan(&digest, &scopeID, &targetNodeID, &operationID); err != nil {
+			return fmt.Errorf("scanning replayed audit baseline: %w", err)
+		}
+		want, ok := replay.baselines[digest]
+		if !ok || seen[digest] || want.scopeID != scopeID ||
+			want.targetNodeID != targetNodeID || want.operationID != operationID {
+			return errors.New("audit baseline projection does not match replayed history")
+		}
+		seen[digest] = true
+	}
+	if err := baselineRows.Err(); err != nil {
+		return fmt.Errorf("reading replayed audit baselines: %w", err)
+	}
+	if len(seen) != len(replay.baselines) {
+		return errors.New("audit baseline projection is incomplete")
 	}
 	return nil
 }

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -42,8 +42,8 @@ func validateAuditAuthority(
 		}
 		return nil
 	}
-	if counts[0] != 1 || counts[1] != 1 || counts[2] != 1 || counts[3] == 0 {
-		return fmt.Errorf("audit authority must contain one authority, scope, and baseline: counts=%v", counts)
+	if counts[0] != 1 || counts[1] != 1 || counts[2] < 1 || counts[3] == 0 {
+		return fmt.Errorf("audit authority must contain one authority and scope with baselines: counts=%v", counts)
 	}
 	authority, scope, err := loadInitialAuditProjection(ctx, tx)
 	if err != nil {
@@ -58,11 +58,11 @@ func validateAuditAuthority(
 		return err
 	}
 	if err := validateInitialAuditRecords(
-		ctx, tx, vaultID, nodeSequence, authority, scope, initial,
+		ctx, tx, vaultID, authority, scope, initial,
 	); err != nil {
 		return err
 	}
-	return validateAuditedContentReplacementHistory(
+	return validateAuditedHistory(
 		ctx, tx, vaultID, nodeSequence, authority, scope, records, initial,
 	)
 }
@@ -160,12 +160,8 @@ func selectInitialAuditRecords(
 	authority initialAuditAuthority, scope initialAuditScope,
 	records map[string][]storedAuditRecord,
 ) (map[string][]storedAuditRecord, error) {
-	if len(records) != len(auditRecordKinds) {
-		return nil, fmt.Errorf("audit authority has %d record kinds, want %d", len(records), len(auditRecordKinds))
-	}
 	for _, kind := range []string{
 		"topology_genesis", "attached_metadata_genesis", "allocation_genesis",
-		"enrollment_baseline",
 	} {
 		if len(records[kind]) != 1 {
 			return nil, fmt.Errorf("audit authority has %d %s records, want 1", len(records[kind]), kind)
@@ -183,7 +179,19 @@ func selectInitialAuditRecords(
 		"topology_genesis":          records["topology_genesis"],
 		"attached_metadata_genesis": records["attached_metadata_genesis"],
 		"allocation_genesis":        records["allocation_genesis"],
-		"enrollment_baseline":       records["enrollment_baseline"],
+	}
+	for _, record := range records["enrollment_baseline"] {
+		operationID, err := auditUUIDField(record.record, auditOperationIDField)
+		if err != nil {
+			return nil, err
+		}
+		if operationID == scope.operationID {
+			result["enrollment_baseline"] = append(result["enrollment_baseline"], record)
+		}
+	}
+	if len(result["enrollment_baseline"]) != 1 {
+		return nil, fmt.Errorf("audit authority has %d initial enrollment baselines, want 1",
+			len(result["enrollment_baseline"]))
 	}
 	selectors := []struct {
 		kind  string
@@ -219,7 +227,7 @@ func selectInitialAuditRecords(
 }
 
 func validateInitialAuditRecords(
-	ctx context.Context, tx metadataQuerier, vaultID string, nodeSequence int64,
+	ctx context.Context, tx metadataQuerier, vaultID string,
 	authority initialAuditAuthority, scope initialAuditScope,
 	records map[string][]storedAuditRecord,
 ) error {
@@ -231,7 +239,7 @@ func validateInitialAuditRecords(
 	mutation := records["canonical_mutation"][0]
 	scopeEntry := records["scope_chain_entry"][0]
 	allocationEntry := records["allocation_entry"][0]
-	if err := validateInitialGenesis(vaultID, nodeSequence, authority,
+	if err := validateInitialGenesis(vaultID, authority,
 		topology, attachments, allocationGenesis); err != nil {
 		return err
 	}
@@ -246,18 +254,18 @@ func validateInitialAuditRecords(
 	if err := validateInitialScopeChain(vaultID, scope, mutation, scopeEntry); err != nil {
 		return err
 	}
-	return validateInitialAllocation(vaultID, nodeSequence, authority, scope,
+	genesisHighWater, err := auditUnsignedField(allocationGenesis.record, "node_id_high_water")
+	if err != nil {
+		return err
+	}
+	return validateInitialAllocation(vaultID, genesisHighWater, authority, scope,
 		allocationGenesis, mutation, allocationEntry)
 }
 
 func validateInitialGenesis(
-	vaultID string, nodeSequence int64,
+	vaultID string,
 	authority initialAuditAuthority, topology, attachments, allocation storedAuditRecord,
 ) error {
-	nodeHighWater, err := positiveAuditNodeID(nodeSequence)
-	if err != nil {
-		return err
-	}
 	storedTopology, err := auditRecordListField(topology.record, "nodes")
 	if err != nil {
 		return err
@@ -279,6 +287,21 @@ func validateInitialGenesis(
 	}
 	if err := requireAuditAbsent(allocation.record, "previous_head"); err != nil {
 		return err
+	}
+	nodeHighWater, err := auditUnsignedField(allocation.record, "node_id_high_water")
+	if err != nil || nodeHighWater == 0 {
+		return errors.New("audit allocation genesis has an invalid node high-water mark")
+	}
+	var topologyHighWater uint64
+	for _, node := range storedTopology {
+		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
+		if err != nil {
+			return err
+		}
+		topologyHighWater = max(topologyHighWater, nodeID)
+	}
+	if nodeHighWater < topologyHighWater {
+		return errors.New("audit allocation genesis is below its topology high-water mark")
 	}
 	if err := requireAuditUnsigned(allocation.record, "node_id_high_water", nodeHighWater); err != nil {
 		return err
@@ -305,7 +328,7 @@ func validateInitialBaseline(
 	if err := requireAuditUUID(baseline.record, auditVaultIDField, vaultID); err != nil {
 		return err
 	}
-	if err := requireAuditUUID(baseline.record, "scope_id", scope.scopeID); err != nil {
+	if err := requireAuditUUID(baseline.record, auditScopeIDField, scope.scopeID); err != nil {
 		return err
 	}
 	if err := requireAuditUnsigned(baseline.record, "target_node_id", scope.targetNodeID); err != nil {
@@ -413,7 +436,7 @@ func validateInitialMembershipRows(
 		return errors.New("audit baseline relation does not match its scope and operation")
 	}
 	rows, err := tx.QueryContext(ctx, `SELECT node_id,baseline_digest FROM audit_memberships
-		WHERE scope_id=? ORDER BY node_id`, scope.scopeID)
+		WHERE scope_id=? AND baseline_digest=? ORDER BY node_id`, scope.scopeID, baselineDigest)
 	if err != nil {
 		return fmt.Errorf("reading audit membership projection: %w", err)
 	}
@@ -509,7 +532,7 @@ func validateInitialEvent(scope initialAuditScope, baseline storedAuditRecord, e
 		func() error { return requireAuditUUID(event, auditOperationIDField, scope.operationID) },
 		func() error { return requireAuditUnsigned(event, metadataNodeIDField, scope.targetNodeID) },
 		func() error { return requireAuditText(event, "event_kind", "audit_enroll") },
-		func() error { return requireAuditUUID(event, "scope_id", scope.scopeID) },
+		func() error { return requireAuditUUID(event, auditScopeIDField, scope.scopeID) },
 		func() error { return requireAuditUnsigned(event, "target_node_id", scope.targetNodeID) },
 		func() error { return requireAuditUnsigned(event, "event_ordinal", 0) },
 		func() error { return requireAuditDigest(event, "baseline_digest", baseline.digest) },
@@ -527,7 +550,7 @@ func validateInitialEvent(scope initialAuditScope, baseline storedAuditRecord, e
 		return err
 	}
 	return requireAuditAbsentFields(event, "attachment_kind", "attachment_identity",
-		"source_version_id", "pre", "post", "topology_delta")
+		"source_version_id", "pre", "post", auditTopologyDeltaField)
 }
 
 func validateInitialEventState(event audit.Record, targetNodeID uint64, states []audit.Record) error {
@@ -562,7 +585,7 @@ func validateInitialEventState(event audit.Record, targetNodeID uint64, states [
 }
 
 func validateInitialBaselineBinding(record audit.Record, scope initialAuditScope, digest string) error {
-	if err := requireAuditUUID(record, "scope_id", scope.scopeID); err != nil {
+	if err := requireAuditUUID(record, auditScopeIDField, scope.scopeID); err != nil {
 		return err
 	}
 	if err := requireAuditUnsigned(record, "target_node_id", scope.targetNodeID); err != nil {
@@ -572,12 +595,12 @@ func validateInitialBaselineBinding(record audit.Record, scope initialAuditScope
 }
 
 func requireNoChangeMutationFields(record audit.Record) error {
-	if err := requireAuditAbsentFields(record, "topology_delta", "path_effect_digest",
+	if err := requireAuditAbsentFields(record, auditTopologyDeltaField, "path_effect_digest",
 		"witness_change_digest", "attached_metadata_change_digest"); err != nil {
 		return err
 	}
 	for _, field := range []string{
-		"path_effect_count", "witness_change_count", "attached_metadata_change_count",
+		"path_effect_count", auditWitnessChangeCountField, auditAttachedMetadataChangeCountField,
 	} {
 		if err := requireAuditUnsigned(record, field, 0); err != nil {
 			return err
@@ -587,7 +610,7 @@ func requireNoChangeMutationFields(record audit.Record) error {
 }
 
 func requireMatchingEventEnvelope(mutation, event audit.Record) error {
-	for _, field := range []string{"recorded_at", "origin", "agent_label"} {
+	for _, field := range []string{"recorded_at", auditOriginField, "agent_label"} {
 		left, err := auditField(mutation, field)
 		if err != nil {
 			return err
@@ -609,7 +632,7 @@ func validateInitialScopeChain(
 	if err := requireAuditUUID(entry.record, auditVaultIDField, vaultID); err != nil {
 		return err
 	}
-	if err := requireAuditUUID(entry.record, "scope_id", scope.scopeID); err != nil {
+	if err := requireAuditUUID(entry.record, auditScopeIDField, scope.scopeID); err != nil {
 		return err
 	}
 	if err := requireAuditUnsigned(entry.record, "entry_count", 1); err != nil {
@@ -622,13 +645,9 @@ func validateInitialScopeChain(
 }
 
 func validateInitialAllocation(
-	vaultID string, nodeSequence int64, authority initialAuditAuthority,
+	vaultID string, nodeHighWater uint64, authority initialAuditAuthority,
 	scope initialAuditScope, genesis, mutation, entry storedAuditRecord,
 ) error {
-	nodeHighWater, err := positiveAuditNodeID(nodeSequence)
-	if err != nil {
-		return err
-	}
 	if err := requireAuditUUID(entry.record, auditVaultIDField, vaultID); err != nil {
 		return err
 	}
@@ -652,10 +671,10 @@ func validateInitialAllocation(
 		return errors.New("initial audit enrollment must not allocate node IDs")
 	}
 	for field, want := range map[string]uint64{
-		"node_id_high_water":             nodeHighWater,
-		"operation_sequence_high_water":  1,
-		"witness_change_count":           0,
-		"attached_metadata_change_count": 0,
+		"node_id_high_water":                  nodeHighWater,
+		"operation_sequence_high_water":       1,
+		auditWitnessChangeCountField:          0,
+		auditAttachedMetadataChangeCountField: 0,
 	} {
 		if err := requireAuditUnsigned(entry.record, field, want); err != nil {
 			return err
@@ -674,7 +693,7 @@ func validateInitialAllocation(
 			return err
 		}
 	}
-	return requireAuditAbsentFields(entry.record, "topology_delta", "witness_change_digest",
+	return requireAuditAbsentFields(entry.record, auditTopologyDeltaField, "witness_change_digest",
 		"attached_metadata_change_digest")
 }
 

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -289,7 +289,10 @@ func validateInitialGenesis(
 		return err
 	}
 	nodeHighWater, err := auditUnsignedField(allocation.record, "node_id_high_water")
-	if err != nil || nodeHighWater == 0 {
+	if err != nil {
+		return fmt.Errorf("reading audit allocation genesis node high-water mark: %w", err)
+	}
+	if nodeHighWater == 0 {
 		return errors.New("audit allocation genesis has an invalid node high-water mark")
 	}
 	var topologyHighWater uint64
@@ -305,9 +308,6 @@ func validateInitialGenesis(
 			"node ID high-water mark %d is below maximum node ID %d",
 			nodeHighWater, topologyHighWater,
 		)
-	}
-	if err := requireAuditUnsigned(allocation.record, "node_id_high_water", nodeHighWater); err != nil {
-		return err
 	}
 	if err := requireAuditUnsigned(allocation.record, "operation_sequence_high_water", 0); err != nil {
 		return err

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -207,7 +207,7 @@ func selectInitialAuditRecords(
 			return record.index.scopeID != nil && *record.index.scopeID == scope.scopeID &&
 				record.index.entryCount != nil && *record.index.entryCount == 1
 		}},
-		{"event", func(record storedAuditRecord) bool {
+		{auditEventField, func(record storedAuditRecord) bool {
 			return record.index.operationID != nil && *record.index.operationID == scope.operationID &&
 				record.index.eventOrdinal != nil && *record.index.eventOrdinal == 0
 		}},
@@ -235,7 +235,7 @@ func validateInitialAuditRecords(
 	attachments := records["attached_metadata_genesis"][0]
 	allocationGenesis := records["allocation_genesis"][0]
 	baseline := records["enrollment_baseline"][0]
-	event := records["event"][0]
+	event := records[auditEventField][0]
 	mutation := records["canonical_mutation"][0]
 	scopeEntry := records["scope_chain_entry"][0]
 	allocationEntry := records["allocation_entry"][0]
@@ -469,7 +469,7 @@ func validateInitialMutation(
 	vaultID string, scope initialAuditScope, baseline, eventWrapper,
 	mutation storedAuditRecord,
 ) error {
-	event, err := auditNestedField(eventWrapper.record, "event")
+	event, err := auditNestedField(eventWrapper.record, auditEventField)
 	if err != nil {
 		return err
 	}

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -301,7 +301,10 @@ func validateInitialGenesis(
 		topologyHighWater = max(topologyHighWater, nodeID)
 	}
 	if nodeHighWater < topologyHighWater {
-		return errors.New("audit allocation genesis is below its topology high-water mark")
+		return fmt.Errorf(
+			"node ID high-water mark %d is below maximum node ID %d",
+			nodeHighWater, topologyHighWater,
+		)
 	}
 	if err := requireAuditUnsigned(allocation.record, "node_id_high_water", nodeHighWater); err != nil {
 		return err

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -18,7 +18,7 @@ var auditRecordKinds = map[string]bool{
 	"enrollment_baseline":       true,
 	"topology_genesis":          true,
 	"attached_metadata_genesis": true,
-	"event":                     true,
+	auditEventField:             true,
 	"canonical_mutation":        true,
 	"scope_chain_entry":         true,
 	"allocation_genesis":        true,
@@ -290,8 +290,8 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 			return index, err
 		}
 		index.operationID, index.scopeID = &operationID, &scopeID
-	case "event":
-		event, err := auditNestedField(record, "event")
+	case auditEventField:
+		event, err := auditNestedField(record, auditEventField)
 		if err != nil {
 			return index, err
 		}

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -23,6 +23,7 @@ var auditRecordKinds = map[string]bool{
 	"scope_chain_entry":         true,
 	"allocation_genesis":        true,
 	"allocation_entry":          true,
+	auditTopologyDeltaField:     true,
 }
 
 type auditRecordIndex struct {
@@ -184,7 +185,7 @@ func importAuditRecord(ctx context.Context, tx *sql.Tx, value metadataAuditRecor
 	if err != nil || record.Kind != "enrollment_baseline" {
 		return err
 	}
-	scopeID, err := auditUUIDField(record, "scope_id")
+	scopeID, err := auditUUIDField(record, auditScopeIDField)
 	if err != nil {
 		return err
 	}
@@ -284,7 +285,7 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 		if err != nil {
 			return index, err
 		}
-		scopeID, err := auditUUIDField(record, "scope_id")
+		scopeID, err := auditUUIDField(record, auditScopeIDField)
 		if err != nil {
 			return index, err
 		}
@@ -298,7 +299,7 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 		if err != nil {
 			return index, err
 		}
-		scopeID, err := auditUUIDField(event, "scope_id")
+		scopeID, err := auditUUIDField(event, auditScopeIDField)
 		if err != nil {
 			return index, err
 		}
@@ -323,7 +324,7 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 		}
 		index.operationID, index.operationSequence = &operationID, &sequence
 	case "scope_chain_entry":
-		scopeID, err := auditUUIDField(record, "scope_id")
+		scopeID, err := auditUUIDField(record, auditScopeIDField)
 		if err != nil {
 			return index, err
 		}
@@ -332,7 +333,7 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 			return index, err
 		}
 		index.scopeID, index.entryCount = &scopeID, &entryCount
-	case "topology_genesis", "attached_metadata_genesis", "allocation_genesis":
+	case "topology_genesis", "attached_metadata_genesis", "allocation_genesis", auditTopologyDeltaField:
 	default:
 		return index, fmt.Errorf("unsupported initial audit record kind %q", record.Kind)
 	}

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -159,7 +159,7 @@ func TestImportMetadataRejectsOrphanAuditRecord(t *testing.T) {
 	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
 	record := audit.Record{Kind: "scope_chain_entry", Fields: []audit.Field{
 		{Name: "vault_id", Value: mustAuditUUID(t, source.VaultID())},
-		{Name: "scope_id", Value: mustAuditUUID(t, testAuditScopeID)},
+		{Name: auditScopeIDField, Value: mustAuditUUID(t, testAuditScopeID)},
 		{Name: "entry_count", Value: audit.Unsigned(1)},
 		{Name: "previous_head", Value: audit.Absent()},
 		{Name: "mutation_hash", Value: mustAuditDigest(t, metadataHashCurrent)},

--- a/internal/store/audit_node_create.go
+++ b/internal/store/audit_node_create.go
@@ -1,0 +1,585 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type auditedCreationBaseline struct {
+	scope    auditScopeState
+	record   audit.Record
+	digest   auditRecordHash
+	binding  audit.Record
+	members  []uint64
+	nodeID   uint64
+	scopeID  audit.Value
+	version  *audit.Record
+	topology audit.Record
+}
+
+func persistAuditedNodeCreation(
+	ctx context.Context, tx *sql.Tx, vaultID string,
+	authority auditAuthorityState, scopes []auditScopeState,
+	priorParent, resultingParent, created Node, version ContentVersion,
+	operationID, recordedAt string,
+) error {
+	if len(scopes) != 1 {
+		return unsupportedAuditedNodeMutation(priorParent.ID)
+	}
+	operationSequence, err := nextAuditInteger("operation sequence", authority.sequence)
+	if err != nil {
+		return err
+	}
+	values, err := makeAuditedMutationValues(
+		vaultID, authority.lineageID, operationID, recordedAt,
+	)
+	if err != nil {
+		return err
+	}
+	priorParentTopology, err := auditTopologyForLiveNode(priorParent)
+	if err != nil {
+		return err
+	}
+	resultingParentTopology, err := auditTopologyForLiveNode(resultingParent)
+	if err != nil {
+		return err
+	}
+	createdTopology, err := auditTopologyForLiveNode(created)
+	if err != nil {
+		return err
+	}
+	topologyDelta, err := makeAuditedCreationTopologyDelta(
+		values.operationID, priorParentTopology, resultingParentTopology, createdTopology,
+	)
+	if err != nil {
+		return err
+	}
+	topologyDigest, err := hashAuditRecord(topologyDelta)
+	if err != nil {
+		return err
+	}
+	baselines, err := buildAuditedCreationBaselines(
+		tx, values, scopes, created, version, createdTopology,
+	)
+	if err != nil {
+		return err
+	}
+	events, err := makeAuditedCreationEvents(values, baselines, created, topologyDigest)
+	if err != nil {
+		return err
+	}
+	parentChange, err := makeAuditMemberStateChange(priorParent, resultingParent)
+	if err != nil {
+		return err
+	}
+	auditOperationSequence, err := positiveAuditInteger("operation sequence", operationSequence)
+	if err != nil {
+		return err
+	}
+	mutation := makeAuditedCreationMutation(
+		values, auditOperationSequence, events, parentChange, baselines, topologyDigest,
+	)
+	mutationDigest, err := hashAuditRecord(mutation)
+	if err != nil {
+		return err
+	}
+	if err := persistAuditedCreationRecords(
+		ctx, tx, baselines, topologyDelta, events, mutation,
+	); err != nil {
+		return err
+	}
+	if err := advanceAuditedCreationScopes(
+		ctx, tx, values, baselines, mutationDigest,
+	); err != nil {
+		return err
+	}
+	nodeSequence, err := auditNodeSequence(ctx, tx)
+	if err != nil {
+		return err
+	}
+	allocation, err := makeAuditedCreationAllocationEntry(
+		values, operationSequence, nodeSequence, created.ID,
+		authority.allocationHead, mutationDigest.value, topologyDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	allocationHead, err := hashAuditRecord(allocation)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, allocation); err != nil {
+		return err
+	}
+	allocationCount, err := nextAuditInteger("allocation entry count", authority.allocationCount)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE audit_authority
+		SET operation_sequence_high_water=?,allocation_entry_count=?,allocation_head=?
+		WHERE singleton=1`, operationSequence, allocationCount, allocationHead.text); err != nil {
+		return fmt.Errorf("advancing audit allocation authority: %w", err)
+	}
+	return nil
+}
+
+func auditNodeSequence(ctx context.Context, tx *sql.Tx) (int64, error) {
+	var sequence int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT seq FROM sqlite_sequence WHERE name='nodes'`,
+	).Scan(&sequence); err != nil {
+		return 0, fmt.Errorf("reading node ID high-water mark: %w", err)
+	}
+	return sequence, nil
+}
+
+func auditTopologyForLiveNode(node Node) (audit.Record, error) {
+	if node.ID <= 0 || node.TrashedAt != nil {
+		return audit.Record{}, fmt.Errorf("node %d is not live audit topology", node.ID)
+	}
+	row := auditTopologyRow{
+		id: node.ID, name: node.Name, kind: node.Kind,
+		createdAt: node.CreatedAt, modifiedAt: node.ModifiedAt,
+	}
+	if node.ParentID != nil {
+		row.parentID = sql.NullInt64{Int64: *node.ParentID, Valid: true}
+	}
+	return topologyRecord(row)
+}
+
+func makeAuditedCreationTopologyDelta(
+	operationID audit.Value, priorParent, resultingParent, created audit.Record,
+) (audit.Record, error) {
+	parentID, err := auditUnsignedField(priorParent, metadataNodeIDField)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	createdID, err := auditUnsignedField(created, metadataNodeIDField)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	changes := []audit.Record{
+		{Kind: "topology_change", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(parentID)},
+			{Name: "pre", Value: audit.Nested(priorParent)},
+			{Name: "post", Value: audit.Nested(resultingParent)},
+		}},
+		{Kind: "topology_change", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(createdID)},
+			{Name: "pre", Value: audit.Absent()},
+			{Name: "post", Value: audit.Nested(created)},
+		}},
+	}
+	if err := sortAuditTopologyRecords(changes); err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: auditTopologyDeltaField, Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: operationID},
+		{Name: "changes", Value: audit.List(auditNestedValues(changes)...)},
+	}}, nil
+}
+
+func sortAuditTopologyRecords(records []audit.Record) error {
+	type keyedRecord struct {
+		id     uint64
+		record audit.Record
+	}
+	keyed := make([]keyedRecord, len(records))
+	for index, record := range records {
+		id, err := auditUnsignedField(record, metadataNodeIDField)
+		if err != nil {
+			return err
+		}
+		keyed[index] = keyedRecord{id: id, record: record}
+	}
+	slices.SortFunc(keyed, func(left, right keyedRecord) int {
+		return cmpAuditNodeID(left.id, right.id)
+	})
+	for index := range keyed {
+		records[index] = keyed[index].record
+	}
+	return nil
+}
+
+func cmpAuditNodeID(left, right uint64) int {
+	if left < right {
+		return -1
+	}
+	if left > right {
+		return 1
+	}
+	return 0
+}
+
+func buildAuditedCreationBaselines(
+	tx *sql.Tx, values auditedMutationValues,
+	scopes []auditScopeState, created Node, version ContentVersion,
+	createdTopology audit.Record,
+) ([]auditedCreationBaseline, error) {
+	nodeID, err := positiveAuditNodeID(created.ID)
+	if err != nil {
+		return nil, err
+	}
+	state, err := auditMemberStateForNode(created)
+	if err != nil {
+		return nil, err
+	}
+	var versions []audit.Record
+	var versionRecord *audit.Record
+	if !created.IsDir() {
+		record, err := auditRecordForContentVersion(version)
+		if err != nil {
+			return nil, err
+		}
+		versions = []audit.Record{record}
+		versionRecord = &versions[0]
+	}
+	nodes, witnesses, err := auditCreationBaselineTopology(tx, created.ID, values.operationID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]auditedCreationBaseline, len(scopes))
+	for index, scope := range scopes {
+		scopeID, err := audit.UUID(scope.scopeID)
+		if err != nil {
+			return nil, err
+		}
+		cause, err := audit.Text("node_create")
+		if err != nil {
+			return nil, err
+		}
+		eventKind, err := audit.Text("audit_inherit")
+		if err != nil {
+			return nil, err
+		}
+		initialValues := initialAuditValues{
+			vaultID: values.vaultID, scopeID: scopeID, operationID: values.operationID,
+			recordedAt: values.recordedAt, origin: values.origin, agentLabel: audit.Absent(),
+			cause: cause, eventKind: eventKind,
+		}
+		record := makeInitialAuditBaseline(
+			initialValues, nodeID, []uint64{nodeID}, []audit.Record{state},
+			versions, nil, nodes, witnesses,
+		)
+		digest, err := hashAuditRecord(record)
+		if err != nil {
+			return nil, err
+		}
+		binding := audit.Record{Kind: "baseline_binding", Fields: []audit.Field{
+			{Name: auditScopeIDField, Value: scopeID},
+			{Name: "target_node_id", Value: audit.Unsigned(nodeID)},
+			{Name: "baseline_digest", Value: digest.value},
+		}}
+		result[index] = auditedCreationBaseline{
+			scope: scope, record: record, digest: digest, binding: binding,
+			members: []uint64{nodeID}, nodeID: nodeID, scopeID: scopeID,
+			version: versionRecord, topology: createdTopology,
+		}
+	}
+	return result, nil
+}
+
+func auditMemberStateForNode(node Node) (audit.Record, error) {
+	nodeID, err := positiveAuditNodeID(node.ID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	revision, err := positiveAuditRevision(node.Revision)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	current, err := auditNodeCurrentVersion(node)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "member_state", Fields: []audit.Field{
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "node_revision", Value: audit.Unsigned(revision)},
+		{Name: "current_version_id", Value: current},
+	}}, nil
+}
+
+func auditCreationBaselineTopology(
+	tx *sql.Tx, nodeID int64, operationID audit.Value,
+) ([]audit.Record, []audit.Record, error) {
+	var nodes []audit.Record
+	current := nodeID
+	for {
+		node, err := nodeByIDTx(tx, current)
+		if err != nil {
+			return nil, nil, err
+		}
+		record, err := auditTopologyForLiveNode(node)
+		if err != nil {
+			return nil, nil, err
+		}
+		nodes = append(nodes, record)
+		if node.ParentID == nil {
+			break
+		}
+		current = *node.ParentID
+	}
+	if err := sortAuditTopologyRecords(nodes); err != nil {
+		return nil, nil, err
+	}
+	witnesses := make([]audit.Record, 0, len(nodes)-1)
+	createdID, err := positiveAuditNodeID(nodeID)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, node := range nodes {
+		id, err := auditUnsignedField(node, metadataNodeIDField)
+		if err != nil {
+			return nil, nil, err
+		}
+		if id == createdID {
+			continue
+		}
+		stateDigest, err := audit.Hash(audit.Record{Kind: "witnessed_state", Fields: []audit.Field{
+			{Name: "node", Value: audit.Nested(node)},
+		}})
+		if err != nil {
+			return nil, nil, err
+		}
+		witnesses = append(witnesses, audit.Record{Kind: "witness", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(id)},
+			{Name: "generation_operation_id", Value: operationID},
+			{Name: "state_digest", Value: audit.Digest(stateDigest)},
+		}})
+	}
+	return nodes, witnesses, nil
+}
+
+func makeAuditedCreationEvents(
+	values auditedMutationValues, baselines []auditedCreationBaseline,
+	created Node, topologyDigest auditRecordHash,
+) ([]audit.Record, error) {
+	eventCount := len(baselines) * 2
+	if !created.IsDir() {
+		eventCount += len(baselines)
+	}
+	events := make([]audit.Record, 0, eventCount)
+	for _, kind := range []string{"audit_inherit", "content_create", "node_create"} {
+		if kind == "content_create" && created.IsDir() {
+			continue
+		}
+		for _, baseline := range baselines {
+			event, err := makeAuditedCreationEvent(
+				values, baseline, kind, uint64(len(events)), created, topologyDigest,
+			)
+			if err != nil {
+				return nil, err
+			}
+			events = append(events, event)
+		}
+	}
+	return events, nil
+}
+
+func makeAuditedCreationEvent(
+	values auditedMutationValues, baseline auditedCreationBaseline, kind string,
+	ordinal uint64, created Node, topologyDigest auditRecordHash,
+) (audit.Record, error) {
+	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
+	}})
+	if err != nil {
+		return audit.Record{}, err
+	}
+	kindValue, err := audit.Text(kind)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	current, err := auditNodeCurrentVersion(created)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	target, pre, post := audit.Absent(), audit.Absent(), audit.Absent()
+	topology, baselineDigest := audit.Absent(), audit.Absent()
+	switch kind {
+	case "audit_inherit":
+		target, baselineDigest = audit.Unsigned(baseline.nodeID), baseline.digest.value
+	case "content_create":
+		if baseline.version == nil {
+			return audit.Record{}, errors.New("content-create audit event lacks a version")
+		}
+		post = audit.Nested(*baseline.version)
+	case "node_create":
+		post, topology = audit.Nested(baseline.topology), topologyDigest.value
+	default:
+		return audit.Record{}, fmt.Errorf("unsupported creation event kind %q", kind)
+	}
+	return audit.Record{Kind: "audit_event", Fields: []audit.Field{
+		{Name: "event_id", Value: identity.value},
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(baseline.nodeID)},
+		{Name: "event_kind", Value: kindValue},
+		{Name: auditScopeIDField, Value: baseline.scopeID},
+		{Name: "target_node_id", Value: target},
+		{Name: "attachment_kind", Value: audit.Absent()},
+		{Name: "attachment_identity", Value: audit.Absent()},
+		{Name: "source_version_id", Value: audit.Absent()},
+		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
+		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: "prior_node_revision", Value: audit.Unsigned(0)},
+		{Name: "resulting_node_revision", Value: audit.Unsigned(1)},
+		{Name: "prior_current_version_id", Value: audit.Absent()},
+		{Name: "resulting_current_version_id", Value: current},
+		{Name: auditOriginField, Value: values.origin},
+		{Name: "agent_label", Value: audit.Absent()},
+		{Name: "pre", Value: pre},
+		{Name: "post", Value: post},
+		{Name: auditTopologyDeltaField, Value: topology},
+		{Name: "baseline_digest", Value: baselineDigest},
+	}}, nil
+}
+
+func makeAuditedCreationMutation(
+	values auditedMutationValues, sequence uint64, events []audit.Record,
+	parentChange audit.Record, baselines []auditedCreationBaseline,
+	topologyDigest auditRecordHash,
+) audit.Record {
+	bindings := make([]audit.Record, len(baselines))
+	for index := range baselines {
+		bindings[index] = baselines[index].binding
+	}
+	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
+		{Name: auditVaultIDField, Value: values.vaultID},
+		{Name: "operation_sequence", Value: audit.Unsigned(sequence)},
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: "grouping_id", Value: audit.Absent()},
+		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: auditOriginField, Value: values.origin},
+		{Name: "agent_label", Value: audit.Absent()},
+		{Name: "events", Value: audit.List(auditNestedValues(events)...)},
+		{Name: "member_state_changes", Value: audit.List(audit.Nested(parentChange))},
+		{Name: "baselines", Value: audit.List(auditNestedValues(bindings)...)},
+		{Name: auditTopologyDeltaField, Value: topologyDigest.value},
+		{Name: "path_effect_count", Value: audit.Unsigned(0)},
+		{Name: "path_effect_digest", Value: audit.Absent()},
+		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
+		{Name: "witness_change_digest", Value: audit.Absent()},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
+		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+	}}
+}
+
+func persistAuditedCreationRecords(
+	ctx context.Context, tx *sql.Tx, baselines []auditedCreationBaseline,
+	topologyDelta audit.Record, events []audit.Record, mutation audit.Record,
+) error {
+	operationID, err := auditUUIDField(mutation, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	for _, baseline := range baselines {
+		if err := insertAuditRecord(ctx, tx, baseline.record); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO audit_baselines(
+			digest,scope_id,target_node_id,operation_id) VALUES(?,?,?,?)`,
+			baseline.digest.text, baseline.scope.scopeID, baseline.nodeID,
+			operationID); err != nil {
+			return fmt.Errorf("creating inherited audit baseline: %w", err)
+		}
+		for _, member := range baseline.members {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO audit_memberships(
+				scope_id,node_id,baseline_digest) VALUES(?,?,?)`,
+				baseline.scope.scopeID, member, baseline.digest.text); err != nil {
+				return fmt.Errorf("creating inherited audit membership for node %d: %w", member, err)
+			}
+		}
+	}
+	if err := insertAuditRecord(ctx, tx, topologyDelta); err != nil {
+		return err
+	}
+	for _, event := range events {
+		wrapper := audit.Record{Kind: "event", Fields: []audit.Field{
+			{Name: "event", Value: audit.Nested(event)},
+		}}
+		if err := insertAuditRecord(ctx, tx, wrapper); err != nil {
+			return err
+		}
+	}
+	return insertAuditRecord(ctx, tx, mutation)
+}
+
+func advanceAuditedCreationScopes(
+	ctx context.Context, tx *sql.Tx, values auditedMutationValues,
+	baselines []auditedCreationBaseline, mutationDigest auditRecordHash,
+) error {
+	for _, baseline := range baselines {
+		entryCount, err := nextAuditInteger("scope entry count", baseline.scope.entryCount)
+		if err != nil {
+			return err
+		}
+		entry, err := makeAuditScopeChainEntry(
+			values, baseline.scope.scopeID, entryCount,
+			baseline.scope.chainHead, mutationDigest.value,
+		)
+		if err != nil {
+			return err
+		}
+		head, err := hashAuditRecord(entry)
+		if err != nil {
+			return err
+		}
+		if err := insertAuditRecord(ctx, tx, entry); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE audit_scopes
+			SET entry_count=?,chain_head=? WHERE scope_id=?`,
+			entryCount, head.text, baseline.scope.scopeID); err != nil {
+			return fmt.Errorf("advancing audit scope %s: %w", baseline.scope.scopeID, err)
+		}
+	}
+	return nil
+}
+
+func makeAuditedCreationAllocationEntry(
+	values auditedMutationValues, sequence, nodeSequence, allocatedNodeID int64,
+	previousHead string, mutationHash, topologyDigest audit.Value,
+) (audit.Record, error) {
+	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	auditNodeSequence, err := positiveAuditInteger("node ID high-water mark", nodeSequence)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	auditAllocatedID, err := positiveAuditInteger("allocated node ID", allocatedNodeID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	previousValue, err := audit.DigestHex(previousHead)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "allocation_entry", Fields: []audit.Field{
+		{Name: auditVaultIDField, Value: values.vaultID},
+		{Name: "lineage_id", Value: values.lineageID},
+		{Name: "previous_head", Value: previousValue},
+		{Name: "operation_sequence", Value: audit.Unsigned(auditSequence)},
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: "allocated_node_ids", Value: audit.List(audit.Unsigned(auditAllocatedID))},
+		{Name: "node_id_high_water", Value: audit.Unsigned(auditNodeSequence)},
+		{Name: "operation_sequence_high_water", Value: audit.Unsigned(auditSequence)},
+		{Name: "has_audited_mutation", Value: audit.Bool(true)},
+		{Name: "mutation_hash", Value: mutationHash},
+		{Name: "has_topology_change", Value: audit.Bool(true)},
+		{Name: auditTopologyDeltaField, Value: topologyDigest},
+		{Name: "has_witness_change", Value: audit.Bool(false)},
+		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
+		{Name: "witness_change_digest", Value: audit.Absent()},
+		{Name: "has_attached_metadata_change", Value: audit.Bool(false)},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
+		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+	}}, nil
+}

--- a/internal/store/audit_node_create.go
+++ b/internal/store/audit_node_create.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"errors"
@@ -15,7 +16,6 @@ type auditedCreationBaseline struct {
 	record   audit.Record
 	digest   auditRecordHash
 	binding  audit.Record
-	members  []uint64
 	nodeID   uint64
 	scopeID  audit.Value
 	version  *audit.Record
@@ -63,13 +63,13 @@ func persistAuditedNodeCreation(
 	if err != nil {
 		return err
 	}
-	baselines, err := buildAuditedCreationBaselines(
-		tx, values, scopes, created, version, createdTopology,
+	baseline, err := buildAuditedCreationBaseline(
+		tx, values, scopes[0], created, version, createdTopology,
 	)
 	if err != nil {
 		return err
 	}
-	events, err := makeAuditedCreationEvents(values, baselines, created, topologyDigest)
+	events, err := makeAuditedCreationEvents(values, baseline, created, topologyDigest)
 	if err != nil {
 		return err
 	}
@@ -82,19 +82,19 @@ func persistAuditedNodeCreation(
 		return err
 	}
 	mutation := makeAuditedCreationMutation(
-		values, auditOperationSequence, events, parentChange, baselines, topologyDigest,
+		values, auditOperationSequence, events, parentChange, baseline, topologyDigest,
 	)
 	mutationDigest, err := hashAuditRecord(mutation)
 	if err != nil {
 		return err
 	}
 	if err := persistAuditedCreationRecords(
-		ctx, tx, baselines, topologyDelta, events, mutation,
+		ctx, tx, baseline, topologyDelta, events, mutation,
 	); err != nil {
 		return err
 	}
-	if err := advanceAuditedCreationScopes(
-		ctx, tx, values, baselines, mutationDigest,
+	if err := advanceAuditedCreationScope(
+		ctx, tx, values, baseline, mutationDigest,
 	); err != nil {
 		return err
 	}
@@ -197,91 +197,75 @@ func sortAuditTopologyRecords(records []audit.Record) error {
 		}
 		keyed[index] = keyedRecord{id: id, record: record}
 	}
-	slices.SortFunc(keyed, func(left, right keyedRecord) int {
-		return cmpAuditNodeID(left.id, right.id)
-	})
+	slices.SortFunc(keyed, func(left, right keyedRecord) int { return cmp.Compare(left.id, right.id) })
 	for index := range keyed {
 		records[index] = keyed[index].record
 	}
 	return nil
 }
 
-func cmpAuditNodeID(left, right uint64) int {
-	if left < right {
-		return -1
-	}
-	if left > right {
-		return 1
-	}
-	return 0
-}
-
-func buildAuditedCreationBaselines(
+func buildAuditedCreationBaseline(
 	tx *sql.Tx, values auditedMutationValues,
-	scopes []auditScopeState, created Node, version ContentVersion,
+	scope auditScopeState, created Node, version ContentVersion,
 	createdTopology audit.Record,
-) ([]auditedCreationBaseline, error) {
+) (auditedCreationBaseline, error) {
 	nodeID, err := positiveAuditNodeID(created.ID)
 	if err != nil {
-		return nil, err
+		return auditedCreationBaseline{}, err
 	}
 	state, err := auditMemberStateForNode(created)
 	if err != nil {
-		return nil, err
+		return auditedCreationBaseline{}, err
 	}
 	var versions []audit.Record
 	var versionRecord *audit.Record
 	if !created.IsDir() {
 		record, err := auditRecordForContentVersion(version)
 		if err != nil {
-			return nil, err
+			return auditedCreationBaseline{}, err
 		}
 		versions = []audit.Record{record}
 		versionRecord = &versions[0]
 	}
 	nodes, witnesses, err := auditCreationBaselineTopology(tx, created.ID, values.operationID)
 	if err != nil {
-		return nil, err
+		return auditedCreationBaseline{}, err
 	}
-	result := make([]auditedCreationBaseline, len(scopes))
-	for index, scope := range scopes {
-		scopeID, err := audit.UUID(scope.scopeID)
-		if err != nil {
-			return nil, err
-		}
-		cause, err := audit.Text("node_create")
-		if err != nil {
-			return nil, err
-		}
-		eventKind, err := audit.Text("audit_inherit")
-		if err != nil {
-			return nil, err
-		}
-		initialValues := initialAuditValues{
-			vaultID: values.vaultID, scopeID: scopeID, operationID: values.operationID,
-			recordedAt: values.recordedAt, origin: values.origin, agentLabel: audit.Absent(),
-			cause: cause, eventKind: eventKind,
-		}
-		record := makeInitialAuditBaseline(
-			initialValues, nodeID, []uint64{nodeID}, []audit.Record{state},
-			versions, nil, nodes, witnesses,
-		)
-		digest, err := hashAuditRecord(record)
-		if err != nil {
-			return nil, err
-		}
-		binding := audit.Record{Kind: "baseline_binding", Fields: []audit.Field{
-			{Name: auditScopeIDField, Value: scopeID},
-			{Name: "target_node_id", Value: audit.Unsigned(nodeID)},
-			{Name: "baseline_digest", Value: digest.value},
-		}}
-		result[index] = auditedCreationBaseline{
-			scope: scope, record: record, digest: digest, binding: binding,
-			members: []uint64{nodeID}, nodeID: nodeID, scopeID: scopeID,
-			version: versionRecord, topology: createdTopology,
-		}
+	scopeID, err := audit.UUID(scope.scopeID)
+	if err != nil {
+		return auditedCreationBaseline{}, err
 	}
-	return result, nil
+	cause, err := audit.Text("node_create")
+	if err != nil {
+		return auditedCreationBaseline{}, err
+	}
+	eventKind, err := audit.Text("audit_inherit")
+	if err != nil {
+		return auditedCreationBaseline{}, err
+	}
+	initialValues := initialAuditValues{
+		vaultID: values.vaultID, scopeID: scopeID, operationID: values.operationID,
+		recordedAt: values.recordedAt, origin: values.origin, agentLabel: audit.Absent(),
+		cause: cause, eventKind: eventKind,
+	}
+	record := makeInitialAuditBaseline(
+		initialValues, nodeID, []uint64{nodeID}, []audit.Record{state},
+		versions, nil, nodes, witnesses,
+	)
+	digest, err := hashAuditRecord(record)
+	if err != nil {
+		return auditedCreationBaseline{}, err
+	}
+	binding := audit.Record{Kind: "baseline_binding", Fields: []audit.Field{
+		{Name: auditScopeIDField, Value: scopeID},
+		{Name: "target_node_id", Value: audit.Unsigned(nodeID)},
+		{Name: "baseline_digest", Value: digest.value},
+	}}
+	return auditedCreationBaseline{
+		scope: scope, record: record, digest: digest, binding: binding,
+		nodeID: nodeID, scopeID: scopeID,
+		version: versionRecord, topology: createdTopology,
+	}, nil
 }
 
 func auditMemberStateForNode(node Node) (audit.Record, error) {
@@ -356,27 +340,25 @@ func auditCreationBaselineTopology(
 }
 
 func makeAuditedCreationEvents(
-	values auditedMutationValues, baselines []auditedCreationBaseline,
+	values auditedMutationValues, baseline auditedCreationBaseline,
 	created Node, topologyDigest auditRecordHash,
 ) ([]audit.Record, error) {
-	eventCount := len(baselines) * 2
+	eventCount := 2
 	if !created.IsDir() {
-		eventCount += len(baselines)
+		eventCount++
 	}
 	events := make([]audit.Record, 0, eventCount)
 	for _, kind := range []string{"audit_inherit", "content_create", "node_create"} {
 		if kind == "content_create" && created.IsDir() {
 			continue
 		}
-		for _, baseline := range baselines {
-			event, err := makeAuditedCreationEvent(
-				values, baseline, kind, uint64(len(events)), created, topologyDigest,
-			)
-			if err != nil {
-				return nil, err
-			}
-			events = append(events, event)
+		event, err := makeAuditedCreationEvent(
+			values, baseline, kind, uint64(len(events)), created, topologyDigest,
+		)
+		if err != nil {
+			return nil, err
 		}
+		events = append(events, event)
 	}
 	return events, nil
 }
@@ -442,13 +424,9 @@ func makeAuditedCreationEvent(
 
 func makeAuditedCreationMutation(
 	values auditedMutationValues, sequence uint64, events []audit.Record,
-	parentChange audit.Record, baselines []auditedCreationBaseline,
+	parentChange audit.Record, baseline auditedCreationBaseline,
 	topologyDigest auditRecordHash,
 ) audit.Record {
-	bindings := make([]audit.Record, len(baselines))
-	for index := range baselines {
-		bindings[index] = baselines[index].binding
-	}
 	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
 		{Name: auditVaultIDField, Value: values.vaultID},
 		{Name: "operation_sequence", Value: audit.Unsigned(sequence)},
@@ -459,7 +437,7 @@ func makeAuditedCreationMutation(
 		{Name: "agent_label", Value: audit.Absent()},
 		{Name: "events", Value: audit.List(auditNestedValues(events)...)},
 		{Name: "member_state_changes", Value: audit.List(audit.Nested(parentChange))},
-		{Name: "baselines", Value: audit.List(auditNestedValues(bindings)...)},
+		{Name: "baselines", Value: audit.List(audit.Nested(baseline.binding))},
 		{Name: auditTopologyDeltaField, Value: topologyDigest.value},
 		{Name: "path_effect_count", Value: audit.Unsigned(0)},
 		{Name: "path_effect_digest", Value: audit.Absent()},
@@ -471,30 +449,26 @@ func makeAuditedCreationMutation(
 }
 
 func persistAuditedCreationRecords(
-	ctx context.Context, tx *sql.Tx, baselines []auditedCreationBaseline,
+	ctx context.Context, tx *sql.Tx, baseline auditedCreationBaseline,
 	topologyDelta audit.Record, events []audit.Record, mutation audit.Record,
 ) error {
 	operationID, err := auditUUIDField(mutation, auditOperationIDField)
 	if err != nil {
 		return err
 	}
-	for _, baseline := range baselines {
-		if err := insertAuditRecord(ctx, tx, baseline.record); err != nil {
-			return err
-		}
-		if _, err := tx.ExecContext(ctx, `INSERT INTO audit_baselines(
-			digest,scope_id,target_node_id,operation_id) VALUES(?,?,?,?)`,
-			baseline.digest.text, baseline.scope.scopeID, baseline.nodeID,
-			operationID); err != nil {
-			return fmt.Errorf("creating inherited audit baseline: %w", err)
-		}
-		for _, member := range baseline.members {
-			if _, err := tx.ExecContext(ctx, `INSERT INTO audit_memberships(
-				scope_id,node_id,baseline_digest) VALUES(?,?,?)`,
-				baseline.scope.scopeID, member, baseline.digest.text); err != nil {
-				return fmt.Errorf("creating inherited audit membership for node %d: %w", member, err)
-			}
-		}
+	if err := insertAuditRecord(ctx, tx, baseline.record); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO audit_baselines(
+		digest,scope_id,target_node_id,operation_id) VALUES(?,?,?,?)`,
+		baseline.digest.text, baseline.scope.scopeID, baseline.nodeID,
+		operationID); err != nil {
+		return fmt.Errorf("creating inherited audit baseline: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO audit_memberships(
+		scope_id,node_id,baseline_digest) VALUES(?,?,?)`,
+		baseline.scope.scopeID, baseline.nodeID, baseline.digest.text); err != nil {
+		return fmt.Errorf("creating inherited audit membership for node %d: %w", baseline.nodeID, err)
 	}
 	if err := insertAuditRecord(ctx, tx, topologyDelta); err != nil {
 		return err
@@ -510,34 +484,32 @@ func persistAuditedCreationRecords(
 	return insertAuditRecord(ctx, tx, mutation)
 }
 
-func advanceAuditedCreationScopes(
+func advanceAuditedCreationScope(
 	ctx context.Context, tx *sql.Tx, values auditedMutationValues,
-	baselines []auditedCreationBaseline, mutationDigest auditRecordHash,
+	baseline auditedCreationBaseline, mutationDigest auditRecordHash,
 ) error {
-	for _, baseline := range baselines {
-		entryCount, err := nextAuditInteger("scope entry count", baseline.scope.entryCount)
-		if err != nil {
-			return err
-		}
-		entry, err := makeAuditScopeChainEntry(
-			values, baseline.scope.scopeID, entryCount,
-			baseline.scope.chainHead, mutationDigest.value,
-		)
-		if err != nil {
-			return err
-		}
-		head, err := hashAuditRecord(entry)
-		if err != nil {
-			return err
-		}
-		if err := insertAuditRecord(ctx, tx, entry); err != nil {
-			return err
-		}
-		if _, err := tx.ExecContext(ctx, `UPDATE audit_scopes
-			SET entry_count=?,chain_head=? WHERE scope_id=?`,
-			entryCount, head.text, baseline.scope.scopeID); err != nil {
-			return fmt.Errorf("advancing audit scope %s: %w", baseline.scope.scopeID, err)
-		}
+	entryCount, err := nextAuditInteger("scope entry count", baseline.scope.entryCount)
+	if err != nil {
+		return err
+	}
+	entry, err := makeAuditScopeChainEntry(
+		values, baseline.scope.scopeID, entryCount,
+		baseline.scope.chainHead, mutationDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	head, err := hashAuditRecord(entry)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, entry); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE audit_scopes
+		SET entry_count=?,chain_head=? WHERE scope_id=?`,
+		entryCount, head.text, baseline.scope.scopeID); err != nil {
+		return fmt.Errorf("advancing audit scope %s: %w", baseline.scope.scopeID, err)
 	}
 	return nil
 }

--- a/internal/store/audit_node_create.go
+++ b/internal/store/audit_node_create.go
@@ -474,8 +474,8 @@ func persistAuditedCreationRecords(
 		return err
 	}
 	for _, event := range events {
-		wrapper := audit.Record{Kind: "event", Fields: []audit.Field{
-			{Name: "event", Value: audit.Nested(event)},
+		wrapper := audit.Record{Kind: auditEventField, Fields: []audit.Field{
+			{Name: auditEventField, Value: audit.Nested(event)},
 		}}
 		if err := insertAuditRecord(ctx, tx, wrapper); err != nil {
 			return err

--- a/internal/store/audit_node_create_test.go
+++ b/internal/store/audit_node_create_test.go
@@ -1,0 +1,152 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditedNodeCreationInheritsMembershipAndRoundTrips(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+
+	directory, err := s.Mkdir(t.Context(), scope.ID, "2026")
+	require.NoError(t, err)
+	file, err := s.CreateFile(
+		t.Context(), directory.ID, "return.txt", fakeHash("ac1"), 31, "text/plain",
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	var sequence, allocationCount, scopeCount, baselineCount int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT allocation_entry_count FROM audit_authority),
+		(SELECT entry_count FROM audit_scopes),
+		(SELECT COUNT(*) FROM audit_baselines)`).Scan(
+		&sequence, &allocationCount, &scopeCount, &baselineCount,
+	))
+	assert.Equal(t, int64(3), sequence)
+	assert.Equal(t, sequence, allocationCount)
+	assert.Equal(t, sequence, scopeCount)
+	assert.Equal(t, int64(3), baselineCount)
+
+	rows, err := s.db.Query(`SELECT node_id FROM audit_memberships
+		WHERE node_id IN (?,?) ORDER BY node_id`, directory.ID, file.ID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	var inherited []int64
+	for rows.Next() {
+		var nodeID int64
+		require.NoError(t, rows.Scan(&nodeID))
+		inherited = append(inherited, nodeID)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []int64{directory.ID, file.ID}, inherited)
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+	restoredFile, err := restored.NodeByPath(t.Context(), "/Projects/2026/return.txt")
+	require.NoError(t, err)
+	assert.Equal(t, file.ID, restoredFile.ID)
+	assert.Equal(t, file.CurrentVersionID, restoredFile.CurrentVersionID)
+}
+
+func TestAuditedNodeCreationImportRejectsMembershipRetarget(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	created, err := s.Mkdir(t.Context(), scope.ID, "retargeted")
+	require.NoError(t, err)
+	var initialBaseline string
+	require.NoError(t, s.db.QueryRow(
+		`SELECT digest FROM audit_baselines WHERE operation_id=?`, testAuditOperationID,
+	).Scan(&initialBaseline))
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := retargetAuditMembership(
+		t, exported.Bytes(), uint64(created.ID), initialBaseline,
+	)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "membership")
+	var auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&auditRows))
+	assert.Zero(t, auditRows)
+}
+
+func TestAuditedNodeCreationRollsBackWholeOperation(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_creation_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audited creation failure'); END`)
+	require.NoError(t, err)
+
+	_, err = s.CreateFile(
+		t.Context(), scope.ID, "rollback.txt", fakeHash("ac2"), 19, "text/plain",
+	)
+	require.ErrorContains(t, err, "forced audited creation failure")
+	_, err = s.NodeByPath(t.Context(), "/Projects/rollback.txt")
+	require.ErrorIs(t, err, ErrNotFound)
+	var blobRows, baselineRows, recordRows int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM blobs WHERE hash=?),
+		(SELECT COUNT(*) FROM audit_baselines),
+		(SELECT COUNT(*) FROM audit_records)`, fakeHash("ac2")).Scan(
+		&blobRows, &baselineRows, &recordRows,
+	))
+	assert.Zero(t, blobRows)
+	assert.Equal(t, int64(1), baselineRows)
+	assert.Equal(t, int64(8), recordRows)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func retargetAuditMembership(
+	t *testing.T, input []byte, nodeID uint64, baselineDigest string,
+) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	for index, line := range lines {
+		var membership metadataAuditMembership
+		if err := json.Unmarshal(line, &membership); err != nil ||
+			membership.Type != metadataAuditMembershipType || membership.NodeID != nodeID {
+			continue
+		}
+		membership.BaselineDigest = baselineDigest
+		var err error
+		lines[index], err = json.Marshal(membership)
+		require.NoError(t, err)
+		return append(bytes.Join(lines, []byte{'\n'}), '\n')
+	}
+	require.FailNow(t, "audit membership not found", nodeID)
+	return nil
+}

--- a/internal/store/audit_node_create_test.go
+++ b/internal/store/audit_node_create_test.go
@@ -125,6 +125,35 @@ func TestAuditedNodeCreationImportRejectsCrossVaultBaseline(t *testing.T) {
 	assert.Zero(t, auditRows)
 }
 
+func TestAuditedNodeCreationImportRejectsProtectedVersionReuse(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	created, err := s.CreateFile(
+		t.Context(), scope.ID, "collision.txt", fakeHash("ac3"), 23, "text/plain",
+	)
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := rewriteCreatedVersionCollision(
+		t, exported.Bytes(), created.ID, created.CurrentVersionID,
+		metadataVersionOld, metadataHashVersion,
+	)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "reuses protected content version "+metadataVersionOld)
+	var auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&auditRows))
+	assert.Zero(t, auditRows)
+}
+
 func TestAuditedNodeCreationRollsBackWholeOperation(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
 	require.NoError(t, err)
@@ -185,6 +214,97 @@ type auditRecordRewriteFixture struct {
 
 func rewriteCreatedBaselineVault(t *testing.T, input []byte, vaultID string) []byte {
 	t.Helper()
+	return rewriteCreatedOperation(t, input, createdOperationRewrite{
+		baseline: func(record audit.Record) audit.Record {
+			return mustReplaceAuditRecordField(
+				t, record, auditVaultIDField, mustAuditUUID(t, vaultID),
+			)
+		},
+	})
+}
+
+func rewriteCreatedVersionCollision(
+	t *testing.T, input []byte, nodeID int64,
+	createdVersionID, protectedVersionID, protectedBlobHash string,
+) []byte {
+	t.Helper()
+	protectedVersion := mustAuditUUID(t, protectedVersionID)
+	return rewriteCreatedOperation(t, input, createdOperationRewrite{
+		baseline: func(record audit.Record) audit.Record {
+			states, err := auditRecordListField(record, "member_states")
+			require.NoError(t, err)
+			require.Len(t, states, 1)
+			states[0] = mustReplaceAuditRecordField(
+				t, states[0], "current_version_id", protectedVersion,
+			)
+			versions, err := auditRecordListField(record, "versions")
+			require.NoError(t, err)
+			require.Len(t, versions, 1)
+			versions[0] = mustReplaceAuditRecordField(
+				t, versions[0], "version_id", protectedVersion,
+			)
+			record = mustReplaceAuditRecordField(
+				t, record, "member_states", audit.List(audit.Nested(states[0])),
+			)
+			return mustReplaceAuditRecordField(
+				t, record, "versions", audit.List(audit.Nested(versions[0])),
+			)
+		},
+		event: func(record audit.Record) audit.Record {
+			record = mustReplaceAuditRecordField(
+				t, record, "resulting_current_version_id", protectedVersion,
+			)
+			kind, err := auditTextField(record, "event_kind")
+			require.NoError(t, err)
+			if kind != "content_create" {
+				return record
+			}
+			post, err := auditNestedField(record, "post")
+			require.NoError(t, err)
+			post = mustReplaceAuditRecordField(t, post, "version_id", protectedVersion)
+			return mustReplaceAuditRecordField(t, record, "post", audit.Nested(post))
+		},
+		metadata: func(kind string, raw []byte) []byte {
+			switch kind {
+			case "blob":
+				var blob metadataBlob
+				require.NoError(t, json.Unmarshal(raw, &blob))
+				if blob.Hash == protectedBlobHash {
+					return nil
+				}
+			case "content_version":
+				var version metadataContentVersion
+				require.NoError(t, json.Unmarshal(raw, &version))
+				switch version.VersionID {
+				case protectedVersionID:
+					return nil
+				case createdVersionID:
+					version.VersionID = protectedVersionID
+					return mustMarshalJSON(t, version)
+				}
+			case "node":
+				var node metadataNode
+				require.NoError(t, json.Unmarshal(raw, &node))
+				if node.ID == nodeID {
+					node.CurrentVersionID = &protectedVersionID
+					return mustMarshalJSON(t, node)
+				}
+			}
+			return raw
+		},
+	})
+}
+
+type createdOperationRewrite struct {
+	baseline func(audit.Record) audit.Record
+	event    func(audit.Record) audit.Record
+	metadata func(string, []byte) []byte
+}
+
+func rewriteCreatedOperation(
+	t *testing.T, input []byte, plan createdOperationRewrite,
+) []byte {
+	t.Helper()
 	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
 	records := make(map[string]auditRecordRewriteFixture)
 	for _, line := range lines {
@@ -219,36 +339,44 @@ func rewriteCreatedBaselineVault(t *testing.T, input []byte, vaultID string) []b
 		cause, err := auditTextField(record, "cause")
 		return err == nil && cause == "node_create"
 	})
-	baseline, err := replaceAuditRecordField(baseline, auditVaultIDField, mustAuditUUID(t, vaultID))
-	require.NoError(t, err)
+	if plan.baseline != nil {
+		baseline = plan.baseline(baseline)
+	}
 	newBaseline := rewrite(oldBaseline, baseline)
 
-	oldEventWrapper, eventWrapper := findAuditRecord(t, records, func(record audit.Record) bool {
-		if record.Kind != auditEventField {
-			return false
-		}
-		event, err := auditNestedField(record, auditEventField)
-		if err != nil {
-			return false
-		}
-		kind, err := auditTextField(event, "event_kind")
-		if err != nil || kind != "audit_inherit" {
-			return false
-		}
-		digest, err := auditDigestField(event, "baseline_digest")
-		return err == nil && digest == oldBaseline
-	})
-	inheritedEvent, err := auditNestedField(eventWrapper, auditEventField)
+	operationID, err := auditUUIDField(baseline, auditOperationIDField)
 	require.NoError(t, err)
-	inheritedEvent, err = replaceAuditRecordField(
-		inheritedEvent, "baseline_digest", mustAuditDigest(t, newBaseline),
-	)
-	require.NoError(t, err)
-	eventWrapper, err = replaceAuditRecordField(
-		eventWrapper, auditEventField, audit.Nested(inheritedEvent),
-	)
-	require.NoError(t, err)
-	rewrite(oldEventWrapper, eventWrapper)
+	rewrittenEvents := make(map[string]audit.Record)
+	for digest, fixture := range records {
+		if fixture.record.Kind != auditEventField {
+			continue
+		}
+		event, eventErr := auditNestedField(fixture.record, auditEventField)
+		require.NoError(t, eventErr)
+		eventOperationID, eventErr := auditUUIDField(event, auditOperationIDField)
+		require.NoError(t, eventErr)
+		if eventOperationID != operationID {
+			continue
+		}
+		baselineValue, eventErr := auditField(event, "baseline_digest")
+		require.NoError(t, eventErr)
+		if eventBaseline, ok := baselineValue.DigestValue(); ok && eventBaseline == oldBaseline {
+			event = mustReplaceAuditRecordField(
+				t, event, "baseline_digest", mustAuditDigest(t, newBaseline),
+			)
+		}
+		if plan.event != nil {
+			event = plan.event(event)
+		}
+		wrapper := mustReplaceAuditRecordField(
+			t, fixture.record, auditEventField, audit.Nested(event),
+		)
+		rewrite(digest, wrapper)
+		eventID, eventErr := auditDigestField(event, "event_id")
+		require.NoError(t, eventErr)
+		rewrittenEvents[eventID] = event
+	}
+	require.NotEmpty(t, rewrittenEvents)
 
 	oldMutation, mutation := findAuditRecord(t, records, func(record audit.Record) bool {
 		if record.Kind != "canonical_mutation" {
@@ -273,12 +401,11 @@ func rewriteCreatedBaselineVault(t *testing.T, input []byte, vaultID string) []b
 	require.NoError(t, err)
 	events, err := auditRecordListField(mutation, "events")
 	require.NoError(t, err)
-	wantEventID, err := auditDigestField(inheritedEvent, "event_id")
-	require.NoError(t, err)
 	for index := range events {
 		eventID, eventErr := auditDigestField(events[index], "event_id")
-		if eventErr == nil && eventID == wantEventID {
-			events[index] = inheritedEvent
+		require.NoError(t, eventErr)
+		if replacement, ok := rewrittenEvents[eventID]; ok {
+			events[index] = replacement
 		}
 	}
 	mutation, err = replaceAuditRecordField(
@@ -351,8 +478,33 @@ func rewriteCreatedBaselineVault(t *testing.T, input []byte, vaultID string) []b
 				require.NoError(t, err)
 			}
 		}
+		if plan.metadata != nil {
+			lines[index] = plan.metadata(header.Type, lines[index])
+		}
 	}
-	return append(bytes.Join(lines, []byte{'\n'}), '\n')
+	kept := lines[:0]
+	for _, line := range lines {
+		if line != nil {
+			kept = append(kept, line)
+		}
+	}
+	return append(bytes.Join(kept, []byte{'\n'}), '\n')
+}
+
+func mustReplaceAuditRecordField(
+	t *testing.T, record audit.Record, name string, value audit.Value,
+) audit.Record {
+	t.Helper()
+	result, err := replaceAuditRecordField(record, name, value)
+	require.NoError(t, err)
+	return result
+}
+
+func mustMarshalJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	result, err := json.Marshal(value)
+	require.NoError(t, err)
+	return result
 }
 
 func findAuditRecord(

--- a/internal/store/audit_node_create_test.go
+++ b/internal/store/audit_node_create_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
 )
 
 func TestAuditedNodeCreationInheritsMembershipAndRoundTrips(t *testing.T) {
@@ -98,6 +99,32 @@ func TestAuditedNodeCreationImportRejectsMembershipRetarget(t *testing.T) {
 	assert.Zero(t, auditRows)
 }
 
+func TestAuditedNodeCreationImportRejectsCrossVaultBaseline(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	_, err = s.Mkdir(t.Context(), scope.ID, "cross-vault")
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := rewriteCreatedBaselineVault(
+		t, exported.Bytes(), "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+	)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "enrollment_baseline.vault_id")
+	var auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&auditRows))
+	assert.Zero(t, auditRows)
+}
+
 func TestAuditedNodeCreationRollsBackWholeOperation(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
 	require.NoError(t, err)
@@ -149,4 +176,195 @@ func retargetAuditMembership(
 	}
 	require.FailNow(t, "audit membership not found", nodeID)
 	return nil
+}
+
+type auditRecordRewriteFixture struct {
+	wrapper metadataAuditRecord
+	record  audit.Record
+}
+
+func rewriteCreatedBaselineVault(t *testing.T, input []byte, vaultID string) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	records := make(map[string]auditRecordRewriteFixture)
+	for _, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type != metadataAuditRecordType {
+			continue
+		}
+		var wrapper metadataAuditRecord
+		require.NoError(t, json.Unmarshal(line, &wrapper))
+		record, err := audit.UnmarshalJSONRecord(wrapper.Record)
+		require.NoError(t, err)
+		records[wrapper.Digest] = auditRecordRewriteFixture{wrapper: wrapper, record: record}
+	}
+
+	rewrites := make(map[string]metadataAuditRecord)
+	rewrite := func(oldDigest string, record audit.Record) string {
+		raw, err := audit.MarshalJSONRecord(record)
+		require.NoError(t, err)
+		wrapper := records[oldDigest].wrapper
+		wrapper.Digest, wrapper.Record = mustAuditRecordDigest(t, record), raw
+		rewrites[oldDigest] = wrapper
+		return wrapper.Digest
+	}
+
+	oldBaseline, baseline := findAuditRecord(t, records, func(record audit.Record) bool {
+		if record.Kind != "enrollment_baseline" {
+			return false
+		}
+		cause, err := auditTextField(record, "cause")
+		return err == nil && cause == "node_create"
+	})
+	baseline, err := replaceAuditRecordField(baseline, auditVaultIDField, mustAuditUUID(t, vaultID))
+	require.NoError(t, err)
+	newBaseline := rewrite(oldBaseline, baseline)
+
+	oldEventWrapper, eventWrapper := findAuditRecord(t, records, func(record audit.Record) bool {
+		if record.Kind != auditEventField {
+			return false
+		}
+		event, err := auditNestedField(record, auditEventField)
+		if err != nil {
+			return false
+		}
+		kind, err := auditTextField(event, "event_kind")
+		if err != nil || kind != "audit_inherit" {
+			return false
+		}
+		digest, err := auditDigestField(event, "baseline_digest")
+		return err == nil && digest == oldBaseline
+	})
+	inheritedEvent, err := auditNestedField(eventWrapper, auditEventField)
+	require.NoError(t, err)
+	inheritedEvent, err = replaceAuditRecordField(
+		inheritedEvent, "baseline_digest", mustAuditDigest(t, newBaseline),
+	)
+	require.NoError(t, err)
+	eventWrapper, err = replaceAuditRecordField(
+		eventWrapper, auditEventField, audit.Nested(inheritedEvent),
+	)
+	require.NoError(t, err)
+	rewrite(oldEventWrapper, eventWrapper)
+
+	oldMutation, mutation := findAuditRecord(t, records, func(record audit.Record) bool {
+		if record.Kind != "canonical_mutation" {
+			return false
+		}
+		bindings, err := auditRecordListField(record, "baselines")
+		if err != nil || len(bindings) != 1 {
+			return false
+		}
+		digest, err := auditDigestField(bindings[0], "baseline_digest")
+		return err == nil && digest == oldBaseline
+	})
+	bindings, err := auditRecordListField(mutation, "baselines")
+	require.NoError(t, err)
+	bindings[0], err = replaceAuditRecordField(
+		bindings[0], "baseline_digest", mustAuditDigest(t, newBaseline),
+	)
+	require.NoError(t, err)
+	mutation, err = replaceAuditRecordField(
+		mutation, "baselines", audit.List(audit.Nested(bindings[0])),
+	)
+	require.NoError(t, err)
+	events, err := auditRecordListField(mutation, "events")
+	require.NoError(t, err)
+	wantEventID, err := auditDigestField(inheritedEvent, "event_id")
+	require.NoError(t, err)
+	for index := range events {
+		eventID, eventErr := auditDigestField(events[index], "event_id")
+		if eventErr == nil && eventID == wantEventID {
+			events[index] = inheritedEvent
+		}
+	}
+	mutation, err = replaceAuditRecordField(
+		mutation, "events", audit.List(auditNestedValues(events)...),
+	)
+	require.NoError(t, err)
+	newMutation := rewrite(oldMutation, mutation)
+
+	oldScopeEntry, scopeEntry := findAuditRecord(t, records, func(record audit.Record) bool {
+		if record.Kind != "scope_chain_entry" {
+			return false
+		}
+		digest, err := auditDigestField(record, "mutation_hash")
+		return err == nil && digest == oldMutation
+	})
+	scopeEntry, err = replaceAuditRecordField(
+		scopeEntry, "mutation_hash", mustAuditDigest(t, newMutation),
+	)
+	require.NoError(t, err)
+	newScopeEntry := rewrite(oldScopeEntry, scopeEntry)
+
+	oldAllocation, allocation := findAuditRecord(t, records, func(record audit.Record) bool {
+		if record.Kind != "allocation_entry" {
+			return false
+		}
+		digest, err := auditDigestField(record, "mutation_hash")
+		return err == nil && digest == oldMutation
+	})
+	allocation, err = replaceAuditRecordField(
+		allocation, "mutation_hash", mustAuditDigest(t, newMutation),
+	)
+	require.NoError(t, err)
+	newAllocation := rewrite(oldAllocation, allocation)
+
+	for index, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		switch header.Type {
+		case metadataAuditRecordType:
+			var wrapper metadataAuditRecord
+			require.NoError(t, json.Unmarshal(line, &wrapper))
+			if replacement, ok := rewrites[wrapper.Digest]; ok {
+				lines[index], err = json.Marshal(replacement)
+				require.NoError(t, err)
+			}
+		case metadataAuditMembershipType:
+			var membership metadataAuditMembership
+			require.NoError(t, json.Unmarshal(line, &membership))
+			if membership.BaselineDigest == oldBaseline {
+				membership.BaselineDigest = newBaseline
+				lines[index], err = json.Marshal(membership)
+				require.NoError(t, err)
+			}
+		case metadataAuditScopeType:
+			var scope metadataAuditScope
+			require.NoError(t, json.Unmarshal(line, &scope))
+			if scope.ChainHead == oldScopeEntry {
+				scope.ChainHead = newScopeEntry
+				lines[index], err = json.Marshal(scope)
+				require.NoError(t, err)
+			}
+		case metadataAuditAuthorityType:
+			var authority metadataAuditAuthority
+			require.NoError(t, json.Unmarshal(line, &authority))
+			if authority.AllocationHead == oldAllocation {
+				authority.AllocationHead = newAllocation
+				lines[index], err = json.Marshal(authority)
+				require.NoError(t, err)
+			}
+		}
+	}
+	return append(bytes.Join(lines, []byte{'\n'}), '\n')
+}
+
+func findAuditRecord(
+	t *testing.T, records map[string]auditRecordRewriteFixture,
+	match func(audit.Record) bool,
+) (string, audit.Record) {
+	t.Helper()
+	for digest, fixture := range records {
+		if match(fixture.record) {
+			return digest, fixture.record
+		}
+	}
+	require.FailNow(t, "matching audit record not found")
+	return "", audit.Record{}
 }

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -1,0 +1,682 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type replayedNodeCreation struct {
+	childID, parentID uint64
+	childTopology     audit.Record
+	postTopology      []audit.Record
+	childState        audit.Record
+	version           *audit.Record
+	baselineDigest    string
+	topologyDigest    string
+	baseline          storedAuditRecord
+}
+
+func (replay *auditedHistoryReplay) applyNodeCreation(
+	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	baselineRecords, topologyRecords, eventRecords map[string]storedAuditRecord,
+	usedBaselines, usedTopology, usedEvents map[string]bool,
+) error {
+	sequence := *mutation.index.operationSequence
+	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
+	if err != nil {
+		return err
+	}
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUUID(mutation.record, auditVaultIDField, vaultID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(mutation.record, "operation_sequence", auditSequence); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
+		return err
+	}
+	creation, err := replay.validateNodeCreationAuthority(
+		mutation.record, operationID, baselineRecords, topologyRecords,
+		usedBaselines, usedTopology,
+	)
+	if err != nil {
+		return err
+	}
+	if err := replay.validateNodeCreationEvents(
+		mutation.record, operationID, creation, eventRecords, usedEvents,
+	); err != nil {
+		return err
+	}
+	if err := replay.validateNodeCreationParentChange(mutation.record, creation.parentID); err != nil {
+		return err
+	}
+	if err := validateNodeCreationMutationDigests(mutation.record, creation); err != nil {
+		return err
+	}
+	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+		return err
+	}
+	if err := replay.advanceNodeCreationAllocation(
+		vaultID, operationID, mutation, allocation, creation,
+	); err != nil {
+		return err
+	}
+	return replay.applyNodeCreationState(operationID, creation)
+}
+
+func (replay *auditedHistoryReplay) validateNodeCreationAuthority(
+	mutation audit.Record, operationID string,
+	baselineRecords, topologyRecords map[string]storedAuditRecord,
+	usedBaselines, usedTopology map[string]bool,
+) (replayedNodeCreation, error) {
+	bindings, err := auditRecordListField(mutation, "baselines")
+	if err != nil {
+		return replayedNodeCreation{}, err
+	}
+	if len(bindings) != 1 {
+		return replayedNodeCreation{}, errors.New("node creation must bind one inherited baseline")
+	}
+	binding := bindings[0]
+	if err := requireAuditUUID(binding, auditScopeIDField, replay.scopeID); err != nil {
+		return replayedNodeCreation{}, err
+	}
+	childID, err := auditUnsignedField(binding, "target_node_id")
+	if err != nil {
+		return replayedNodeCreation{}, err
+	}
+	if replay.memberSet[childID] {
+		return replayedNodeCreation{}, fmt.Errorf("node creation re-enrolls audited node %d", childID)
+	}
+	baselineDigest, err := auditDigestField(binding, "baseline_digest")
+	if err != nil {
+		return replayedNodeCreation{}, err
+	}
+	baseline, ok := baselineRecords[baselineDigest]
+	if !ok || usedBaselines[baselineDigest] {
+		return replayedNodeCreation{}, errors.New("node creation lacks one unique enrollment baseline")
+	}
+	topologyDigest, err := auditDigestField(mutation, auditTopologyDeltaField)
+	if err != nil {
+		return replayedNodeCreation{}, err
+	}
+	topology, ok := topologyRecords[topologyDigest]
+	if !ok || usedTopology[topologyDigest] {
+		return replayedNodeCreation{}, errors.New("node creation lacks one unique topology delta")
+	}
+	creation, err := replay.validateNodeCreationTopology(
+		mutation, operationID, childID, topology.record,
+	)
+	if err != nil {
+		return replayedNodeCreation{}, err
+	}
+	creation.baselineDigest, creation.baseline = baselineDigest, baseline
+	creation.topologyDigest = topologyDigest
+	if err := replay.validateNodeCreationBaseline(
+		mutation, operationID, &creation,
+	); err != nil {
+		return replayedNodeCreation{}, err
+	}
+	usedBaselines[baselineDigest], usedTopology[topologyDigest] = true, true
+	return creation, nil
+}
+
+func (replay *auditedHistoryReplay) validateNodeCreationTopology(
+	mutation audit.Record, operationID string, childID uint64, delta audit.Record,
+) (replayedNodeCreation, error) {
+	if err := requireAuditUUID(delta, auditOperationIDField, operationID); err != nil {
+		return replayedNodeCreation{}, err
+	}
+	changes, err := auditRecordListField(delta, "changes")
+	if err != nil {
+		return replayedNodeCreation{}, err
+	}
+	if len(changes) != 2 {
+		return replayedNodeCreation{}, errors.New("node creation topology must contain parent and child changes")
+	}
+	var childPost, parentPre, parentPost audit.Record
+	var parentID uint64
+	for _, change := range changes {
+		nodeID, err := auditUnsignedField(change, metadataNodeIDField)
+		if err != nil {
+			return replayedNodeCreation{}, err
+		}
+		pre, preErr := optionalAuditNestedField(change, "pre")
+		post, postErr := optionalAuditNestedField(change, "post")
+		if preErr != nil || postErr != nil {
+			return replayedNodeCreation{}, errors.Join(preErr, postErr)
+		}
+		if nodeID == childID {
+			if pre != nil || post == nil {
+				return replayedNodeCreation{}, errors.New("created node topology must have absent pre-state")
+			}
+			childPost = *post
+			continue
+		}
+		if pre == nil || post == nil || parentPre.Kind != "" {
+			return replayedNodeCreation{}, errors.New("node creation has an invalid parent topology change")
+		}
+		parentID, parentPre, parentPost = nodeID, *pre, *post
+	}
+	if childPost.Kind == "" || parentPre.Kind == "" {
+		return replayedNodeCreation{}, errors.New("node creation topology is incomplete")
+	}
+	if !replay.memberSet[parentID] {
+		return replayedNodeCreation{}, fmt.Errorf("created node parent %d is not audited", parentID)
+	}
+	parentIndex, ok := replay.topologyIndex[parentID]
+	if !ok || !auditRecordEqual(replay.topology[parentIndex], parentPre) {
+		return replayedNodeCreation{}, errors.New("node creation parent pre-state does not match replayed topology")
+	}
+	modifiedAt, err := auditField(mutation, "recorded_at")
+	if err != nil {
+		return replayedNodeCreation{}, err
+	}
+	expectedParentPost, err := replaceAuditRecordField(parentPre, "modified_at", modifiedAt)
+	if err != nil {
+		return replayedNodeCreation{}, err
+	}
+	if !auditRecordEqual(expectedParentPost, parentPost) {
+		return replayedNodeCreation{}, errors.New("node creation parent post-state is not an exact timestamp touch")
+	}
+	if _, exists := replay.topologyIndex[childID]; exists {
+		return replayedNodeCreation{}, fmt.Errorf("created node %d already exists in replayed topology", childID)
+	}
+	if err := validateCreatedTopologyNode(childPost, childID, parentID, modifiedAt); err != nil {
+		return replayedNodeCreation{}, err
+	}
+	postTopology := slices.Clone(replay.topology)
+	postTopology[parentIndex] = parentPost
+	postTopology = append(postTopology, childPost)
+	if err := sortAuditTopologyRecords(postTopology); err != nil {
+		return replayedNodeCreation{}, err
+	}
+	return replayedNodeCreation{
+		childID: childID, parentID: parentID, childTopology: childPost,
+		postTopology: postTopology,
+	}, nil
+}
+
+func optionalAuditNestedField(record audit.Record, name string) (*audit.Record, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // nil is the canonical absent optional record.
+	}
+	nested, ok := value.RecordValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not an optional record", record.Kind, name)
+	}
+	return &nested, nil
+}
+
+func validateCreatedTopologyNode(
+	node audit.Record, childID, parentID uint64, recordedAt audit.Value,
+) error {
+	checks := []func() error{
+		func() error { return requireAuditUnsigned(node, metadataNodeIDField, childID) },
+		func() error { return requireAuditUnsigned(node, "parent_id", parentID) },
+		func() error { return requireAuditText(node, "state", "live") },
+		func() error { return requireAuditAbsent(node, auditOriginField) },
+		func() error { return requireAuditAbsent(node, "trashed_at") },
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	for _, field := range []string{"created_at", "modified_at"} {
+		value, err := auditField(node, field)
+		if err != nil {
+			return err
+		}
+		if !equalAuditEnvelopeValue(value, recordedAt) {
+			return fmt.Errorf("created node %s does not match its operation time", field)
+		}
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) validateNodeCreationBaseline(
+	mutation audit.Record, operationID string, creation *replayedNodeCreation,
+) error {
+	baseline := creation.baseline.record
+	checks := []func() error{
+		func() error { return requireAuditUUID(baseline, auditScopeIDField, replay.scopeID) },
+		func() error { return requireAuditUnsigned(baseline, "target_node_id", creation.childID) },
+		func() error { return requireAuditUUID(baseline, auditOperationIDField, operationID) },
+		func() error { return requireAuditText(baseline, "cause", "node_create") },
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	members, err := auditUnsignedListField(baseline, "members")
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(members, []uint64{creation.childID}) {
+		return errors.New("node creation baseline has an invalid member set")
+	}
+	states, err := auditRecordListField(baseline, "member_states")
+	if err != nil {
+		return err
+	}
+	if len(states) != 1 {
+		return errors.New("node creation baseline must contain one member state")
+	}
+	state := states[0]
+	if err := requireAuditUnsigned(state, metadataNodeIDField, creation.childID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(state, "node_revision", 1); err != nil {
+		return err
+	}
+	kind, err := auditTextField(creation.childTopology, "node_kind")
+	if err != nil {
+		return err
+	}
+	versions, err := auditRecordListField(baseline, "versions")
+	if err != nil {
+		return err
+	}
+	current, err := auditOptionalUUIDField(state, "current_version_id")
+	if err != nil {
+		return err
+	}
+	switch kind {
+	case "dir":
+		if current != nil || len(versions) != 0 {
+			return errors.New("created directory baseline contains content")
+		}
+	case "file":
+		if current == nil || len(versions) != 1 {
+			return errors.New("created file baseline lacks its initial content")
+		}
+		if err := validateCreatedContentVersion(
+			versions[0], creation.childID, *current, operationID, mutation,
+		); err != nil {
+			return err
+		}
+		creation.version = &versions[0]
+	default:
+		return fmt.Errorf("created node has invalid kind %q", kind)
+	}
+	attachments, err := auditRecordListField(baseline, "attachments")
+	if err != nil {
+		return err
+	}
+	if len(attachments) != 0 {
+		return errors.New("direct node creation baseline cannot contain attached metadata")
+	}
+	expectedNodes, expectedWitnesses, err := initialBaselineTopology(
+		creation.postTopology, []uint64{creation.childID}, operationID,
+	)
+	if err != nil {
+		return err
+	}
+	nodes, err := auditRecordListField(baseline, "nodes")
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(nodes, expectedNodes) {
+		return errors.New("node creation baseline topology does not match replayed post-state")
+	}
+	witnesses, err := auditRecordListField(baseline, "witnesses")
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(witnesses, expectedWitnesses) {
+		return errors.New("node creation baseline witnesses do not match replayed post-state")
+	}
+	creation.childState = state
+	return nil
+}
+
+func validateCreatedContentVersion(
+	version audit.Record, nodeID uint64, versionID, operationID string, mutation audit.Record,
+) error {
+	checks := []func() error{
+		func() error { return requireAuditUUID(version, "version_id", versionID) },
+		func() error { return requireAuditUnsigned(version, metadataNodeIDField, nodeID) },
+		func() error { return requireAuditUnsigned(version, "node_revision", 1) },
+		func() error { return requireAuditUUID(version, "introduced_operation_id", operationID) },
+		func() error { return requireAuditText(version, "transition_kind", "content_create") },
+		func() error { return requireAuditAbsent(version, "source_version_id") },
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	recordedAt, err := auditField(version, "recorded_at")
+	if err != nil {
+		return err
+	}
+	mutationTime, err := auditField(mutation, "recorded_at")
+	if err != nil {
+		return err
+	}
+	if !equalAuditEnvelopeValue(recordedAt, mutationTime) {
+		return errors.New("created content version time does not match its mutation")
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) validateNodeCreationEvents(
+	mutation audit.Record, operationID string, creation replayedNodeCreation,
+	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
+) error {
+	events, err := auditRecordListField(mutation, "events")
+	if err != nil {
+		return err
+	}
+	expectedKinds := []string{"audit_inherit", "node_create"}
+	if creation.version != nil {
+		expectedKinds = []string{"audit_inherit", "content_create", "node_create"}
+	}
+	if len(events) != len(expectedKinds) {
+		return errors.New("node creation has an invalid event set")
+	}
+	current, err := auditOptionalUUIDField(creation.childState, "current_version_id")
+	if err != nil {
+		return err
+	}
+	topologyDigest, err := auditDigestField(mutation, auditTopologyDeltaField)
+	if err != nil {
+		return err
+	}
+	ordinal := uint64(0)
+	for index, event := range events {
+		if err := validateCreationEventWrapper(
+			operationID, ordinal, event, eventRecords, usedEvents,
+		); err != nil {
+			return err
+		}
+		checks := []func() error{
+			func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
+			func() error { return requireAuditUnsigned(event, metadataNodeIDField, creation.childID) },
+			func() error { return requireAuditText(event, "event_kind", expectedKinds[index]) },
+			func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
+			func() error { return requireAuditUnsigned(event, "event_ordinal", ordinal) },
+			func() error { return requireAuditUnsigned(event, "prior_node_revision", 0) },
+			func() error { return requireAuditUnsigned(event, "resulting_node_revision", 1) },
+			func() error { return requireAuditAbsent(event, "prior_current_version_id") },
+			func() error { return requireAuditOptionalUUID(event, "resulting_current_version_id", current) },
+		}
+		for _, check := range checks {
+			if err := check(); err != nil {
+				return err
+			}
+		}
+		if err := requireMatchingEventEnvelope(mutation, event); err != nil {
+			return err
+		}
+		if err := validateCreationEventPayload(
+			event, expectedKinds[index], creation, topologyDigest,
+		); err != nil {
+			return err
+		}
+		ordinal++
+	}
+	return nil
+}
+
+func validateCreationEventWrapper(
+	operationID string, ordinal uint64, event audit.Record,
+	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
+) error {
+	eventID, err := auditDigestField(event, "event_id")
+	if err != nil {
+		return err
+	}
+	wrapper, ok := eventRecords[eventID]
+	if !ok || usedEvents[eventID] {
+		return errors.New("node creation lacks one unique event wrapper")
+	}
+	wrapped, err := auditNestedField(wrapper.record, "event")
+	if err != nil {
+		return err
+	}
+	if !auditRecordEqual(wrapped, event) {
+		return errors.New("node creation event wrapper does not match mutation")
+	}
+	operationValue, err := audit.UUID(operationID)
+	if err != nil {
+		return err
+	}
+	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: operationValue},
+		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
+	}})
+	if err != nil {
+		return err
+	}
+	if identity.text != eventID {
+		return errors.New("node creation event identity does not match its operation")
+	}
+	usedEvents[eventID] = true
+	return nil
+}
+
+func validateCreationEventPayload(
+	event audit.Record, kind string, creation replayedNodeCreation, topologyDigest string,
+) error {
+	if err := requireAuditAbsentFields(event,
+		"attachment_kind", "attachment_identity", "source_version_id"); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(event, "pre"); err != nil {
+		return err
+	}
+	switch kind {
+	case "audit_inherit":
+		if err := requireAuditUnsigned(event, "target_node_id", creation.childID); err != nil {
+			return err
+		}
+		if err := requireAuditDigest(event, "baseline_digest", creation.baselineDigest); err != nil {
+			return err
+		}
+		return requireAuditAbsentFields(event, "post", auditTopologyDeltaField)
+	case "content_create":
+		post, err := auditNestedField(event, "post")
+		if err != nil {
+			return err
+		}
+		if creation.version == nil || !auditRecordEqual(post, *creation.version) {
+			return errors.New("content-create event does not match its inherited baseline")
+		}
+		return requireAuditAbsentFields(event, "target_node_id", auditTopologyDeltaField, "baseline_digest")
+	case "node_create":
+		post, err := auditNestedField(event, "post")
+		if err != nil {
+			return err
+		}
+		if !auditRecordEqual(post, creation.childTopology) {
+			return errors.New("node-create event does not match its inherited baseline")
+		}
+		if err := requireAuditDigest(event, auditTopologyDeltaField, topologyDigest); err != nil {
+			return err
+		}
+		return requireAuditAbsentFields(event, "target_node_id", "baseline_digest")
+	default:
+		return fmt.Errorf("invalid node creation event kind %q", kind)
+	}
+}
+
+func (replay *auditedHistoryReplay) validateNodeCreationParentChange(
+	mutation audit.Record, parentID uint64,
+) error {
+	changes, err := auditRecordListField(mutation, "member_state_changes")
+	if err != nil {
+		return err
+	}
+	if len(changes) != 1 {
+		return errors.New("node creation must contain one parent member-state change")
+	}
+	state, ok := replay.states[parentID]
+	if !ok {
+		return fmt.Errorf("node creation parent %d lacks replayed member state", parentID)
+	}
+	priorRevision, err := auditUnsignedField(state, "node_revision")
+	if err != nil {
+		return err
+	}
+	current, err := auditOptionalUUIDField(state, "current_version_id")
+	if err != nil {
+		return err
+	}
+	change := changes[0]
+	checks := []func() error{
+		func() error { return requireAuditUnsigned(change, metadataNodeIDField, parentID) },
+		func() error { return requireAuditUnsigned(change, "prior_revision", priorRevision) },
+		func() error { return requireAuditUnsigned(change, "resulting_revision", priorRevision+1) },
+		func() error { return requireAuditOptionalUUID(change, "prior_current_version_id", current) },
+		func() error { return requireAuditOptionalUUID(change, "resulting_current_version_id", current) },
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNodeCreationMutationDigests(
+	mutation audit.Record, creation replayedNodeCreation,
+) error {
+	if err := requireAuditDigest(mutation, auditTopologyDeltaField, creation.topologyDigest); err != nil {
+		return err
+	}
+	if err := requireAuditAbsentFields(mutation, "path_effect_digest",
+		"witness_change_digest", "attached_metadata_change_digest"); err != nil {
+		return err
+	}
+	for _, field := range []string{
+		"path_effect_count", auditWitnessChangeCountField, auditAttachedMetadataChangeCountField,
+	} {
+		if err := requireAuditUnsigned(mutation, field, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) advanceNodeCreationAllocation(
+	vaultID, operationID string, mutation, entry storedAuditRecord,
+	creation replayedNodeCreation,
+) error {
+	nextCount := replay.allocationCount + 1
+	auditCount, err := positiveAuditInteger("allocation entry count", nextCount)
+	if err != nil {
+		return err
+	}
+	if creation.childID != replay.nodeHighWater+1 {
+		return fmt.Errorf("created node ID %d does not follow allocation high-water %d",
+			creation.childID, replay.nodeHighWater)
+	}
+	checks := []func() error{
+		func() error { return requireAuditUUID(entry.record, auditVaultIDField, vaultID) },
+		func() error { return requireAuditUUID(entry.record, "lineage_id", replay.lineageID) },
+		func() error { return requireAuditUUID(entry.record, auditOperationIDField, operationID) },
+		func() error { return requireAuditDigest(entry.record, "previous_head", replay.allocationHead) },
+		func() error { return requireAuditUnsigned(entry.record, "operation_sequence", auditCount) },
+		func() error { return requireAuditUnsigned(entry.record, "operation_sequence_high_water", auditCount) },
+		func() error { return requireAuditUnsigned(entry.record, "node_id_high_water", creation.childID) },
+		func() error { return requireAuditBool(entry.record, "has_audited_mutation", true) },
+		func() error { return requireAuditBool(entry.record, "has_topology_change", true) },
+		func() error { return requireAuditBool(entry.record, "has_witness_change", false) },
+		func() error { return requireAuditBool(entry.record, "has_attached_metadata_change", false) },
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	allocated, err := auditUnsignedListField(entry.record, "allocated_node_ids")
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(allocated, []uint64{creation.childID}) {
+		return errors.New("node creation allocation does not name the created node")
+	}
+	mutationDigest, err := hashAuditRecord(mutation.record)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditDigest(entry.record, "mutation_hash", mutationDigest.text); err != nil {
+		return err
+	}
+	topologyDigest, err := auditDigestField(mutation.record, auditTopologyDeltaField)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditDigest(entry.record, auditTopologyDeltaField, topologyDigest); err != nil {
+		return err
+	}
+	for _, field := range []string{auditWitnessChangeCountField, auditAttachedMetadataChangeCountField} {
+		if err := requireAuditUnsigned(entry.record, field, 0); err != nil {
+			return err
+		}
+	}
+	if err := requireAuditAbsentFields(entry.record,
+		"witness_change_digest", "attached_metadata_change_digest"); err != nil {
+		return err
+	}
+	replay.allocationCount, replay.allocationHead = nextCount, entry.digest
+	return nil
+}
+
+func (replay *auditedHistoryReplay) applyNodeCreationState(
+	operationID string, creation replayedNodeCreation,
+) error {
+	parentState := replay.states[creation.parentID]
+	priorRevision, err := auditUnsignedField(parentState, "node_revision")
+	if err != nil {
+		return err
+	}
+	current, err := auditField(parentState, "current_version_id")
+	if err != nil {
+		return err
+	}
+	replay.states[creation.parentID] = audit.Record{Kind: "member_state", Fields: []audit.Field{
+		{Name: metadataNodeIDField, Value: audit.Unsigned(creation.parentID)},
+		{Name: "node_revision", Value: audit.Unsigned(priorRevision + 1)},
+		{Name: "current_version_id", Value: current},
+	}}
+	replay.members = append(replay.members, creation.childID)
+	slices.Sort(replay.members)
+	replay.memberSet[creation.childID] = true
+	replay.states[creation.childID] = creation.childState
+	replay.memberBaselines[creation.childID] = creation.baselineDigest
+	replay.baselines[creation.baselineDigest] = auditBaselineProjection{
+		scopeID: replay.scopeID, operationID: operationID, targetNodeID: creation.childID,
+	}
+	if creation.version != nil {
+		versionID, err := auditUUIDField(*creation.version, "version_id")
+		if err != nil {
+			return err
+		}
+		replay.versions[versionID] = *creation.version
+	}
+	replay.topology = creation.postTopology
+	replay.topologyIndex = make(map[uint64]int, len(replay.topology))
+	for index, node := range replay.topology {
+		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
+		if err != nil {
+			return err
+		}
+		replay.topologyIndex[nodeID] = index
+	}
+	replay.nodeHighWater = creation.childID
+	return nil
+}

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -303,6 +303,9 @@ func (replay *auditedHistoryReplay) validateNodeCreationBaseline(
 		if current == nil || len(versions) != 1 {
 			return errors.New("created file baseline lacks its initial content")
 		}
+		if _, exists := replay.versions[*current]; exists {
+			return fmt.Errorf("created file reuses protected content version %s", *current)
+		}
 		if err := validateCreatedContentVersion(
 			versions[0], creation.childID, *current, operationID, mutation,
 		); err != nil {
@@ -666,6 +669,9 @@ func (replay *auditedHistoryReplay) applyNodeCreationState(
 		versionID, err := auditUUIDField(*creation.version, "version_id")
 		if err != nil {
 			return err
+		}
+		if _, exists := replay.versions[versionID]; exists {
+			return fmt.Errorf("created file reuses protected content version %s", versionID)
 		}
 		replay.versions[versionID] = *creation.version
 	}

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -43,7 +43,7 @@ func (replay *auditedHistoryReplay) applyNodeCreation(
 		return err
 	}
 	creation, err := replay.validateNodeCreationAuthority(
-		mutation.record, operationID, baselineRecords, topologyRecords,
+		vaultID, mutation.record, operationID, baselineRecords, topologyRecords,
 		usedBaselines, usedTopology,
 	)
 	if err != nil {
@@ -72,7 +72,7 @@ func (replay *auditedHistoryReplay) applyNodeCreation(
 }
 
 func (replay *auditedHistoryReplay) validateNodeCreationAuthority(
-	mutation audit.Record, operationID string,
+	vaultID string, mutation audit.Record, operationID string,
 	baselineRecords, topologyRecords map[string]storedAuditRecord,
 	usedBaselines, usedTopology map[string]bool,
 ) (replayedNodeCreation, error) {
@@ -119,7 +119,7 @@ func (replay *auditedHistoryReplay) validateNodeCreationAuthority(
 	creation.baselineDigest, creation.baseline = baselineDigest, baseline
 	creation.topologyDigest = topologyDigest
 	if err := replay.validateNodeCreationBaseline(
-		mutation, operationID, &creation,
+		vaultID, mutation, operationID, &creation,
 	); err != nil {
 		return replayedNodeCreation{}, err
 	}
@@ -246,10 +246,11 @@ func validateCreatedTopologyNode(
 }
 
 func (replay *auditedHistoryReplay) validateNodeCreationBaseline(
-	mutation audit.Record, operationID string, creation *replayedNodeCreation,
+	vaultID string, mutation audit.Record, operationID string, creation *replayedNodeCreation,
 ) error {
 	baseline := creation.baseline.record
 	checks := []func() error{
+		func() error { return requireAuditUUID(baseline, auditVaultIDField, vaultID) },
 		func() error { return requireAuditUUID(baseline, auditScopeIDField, replay.scopeID) },
 		func() error { return requireAuditUnsigned(baseline, "target_node_id", creation.childID) },
 		func() error { return requireAuditUUID(baseline, auditOperationIDField, operationID) },
@@ -443,7 +444,7 @@ func validateCreationEventWrapper(
 	if !ok || usedEvents[eventID] {
 		return errors.New("node creation lacks one unique event wrapper")
 	}
-	wrapped, err := auditNestedField(wrapper.record, "event")
+	wrapped, err := auditNestedField(wrapper.record, auditEventField)
 	if err != nil {
 		return err
 	}

--- a/internal/store/audit_projection.go
+++ b/internal/store/audit_projection.go
@@ -96,7 +96,7 @@ func topologyRecord(row auditTopologyRow) (audit.Record, error) {
 		{Name: "name", Value: audit.Bytes([]byte(row.name))},
 		{Name: "node_kind", Value: kindValue},
 		{Name: "state", Value: stateValue},
-		{Name: "origin", Value: origin},
+		{Name: auditOriginField, Value: origin},
 		{Name: "created_at", Value: createdAt},
 		{Name: "modified_at", Value: modifiedAt},
 		{Name: "trashed_at", Value: trashedAt},

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -767,6 +767,7 @@ const (
 	auditTopologyDeltaField               = "topology_delta"
 	auditWitnessChangeCountField          = "witness_change_count"
 	auditAttachedMetadataChangeCountField = "attached_metadata_change_count"
+	auditEventField                       = "event"
 	metadataIngestType                    = "ingest"
 	metadataProvenanceType                = "provenance"
 	metadataAuditAuthorityType            = "audit_authority"

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -758,16 +758,21 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 }
 
 const (
-	metadataTypeField           = "type"
-	metadataNodeIDField         = "node_id"
-	auditVaultIDField           = "vault_id"
-	auditOperationIDField       = "operation_id"
-	metadataIngestType          = "ingest"
-	metadataProvenanceType      = "provenance"
-	metadataAuditAuthorityType  = "audit_authority"
-	metadataAuditScopeType      = "audit_scope"
-	metadataAuditMembershipType = "audit_membership"
-	metadataAuditRecordType     = "audit_record"
+	metadataTypeField                     = "type"
+	metadataNodeIDField                   = "node_id"
+	auditVaultIDField                     = "vault_id"
+	auditOperationIDField                 = "operation_id"
+	auditScopeIDField                     = "scope_id"
+	auditOriginField                      = "origin"
+	auditTopologyDeltaField               = "topology_delta"
+	auditWitnessChangeCountField          = "witness_change_count"
+	auditAttachedMetadataChangeCountField = "attached_metadata_change_count"
+	metadataIngestType                    = "ingest"
+	metadataProvenanceType                = "provenance"
+	metadataAuditAuthorityType            = "audit_authority"
+	metadataAuditScopeType                = "audit_scope"
+	metadataAuditMembershipType           = "audit_membership"
+	metadataAuditRecordType               = "audit_record"
 )
 
 var metadataHeaderFields = []string{metadataTypeField, "format", "version", auditVaultIDField, "node_sequence"}
@@ -782,8 +787,8 @@ var metadataRequiredFields = map[string][]string{
 	"node_tag":                  {metadataTypeField, metadataNodeIDField, "tag_id"},
 	"extracted_text":            {metadataTypeField, "blob_hash", "extractor", "extractor_version", "status", "error", "attempts", "text", "extracted_at"},
 	metadataAuditAuthorityType:  {metadataTypeField, "lineage_id", "operation_sequence_high_water", "allocation_genesis_digest", "allocation_entry_count", "allocation_head"},
-	metadataAuditScopeType:      {metadataTypeField, "scope_id", "target_node_id", "enable_operation_id", "entry_count", "chain_head"},
-	metadataAuditMembershipType: {metadataTypeField, "scope_id", metadataNodeIDField, "baseline_digest"},
+	metadataAuditScopeType:      {metadataTypeField, auditScopeIDField, "target_node_id", "enable_operation_id", "entry_count", "chain_head"},
+	metadataAuditMembershipType: {metadataTypeField, auditScopeIDField, metadataNodeIDField, "baseline_digest"},
 	metadataAuditRecordType:     {metadataTypeField, "digest", "record"},
 }
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -160,7 +160,8 @@ CREATE TABLE IF NOT EXISTS audit_records (
     kind               TEXT NOT NULL CHECK (kind IN (
         'enrollment_baseline', 'topology_genesis',
         'attached_metadata_genesis', 'event', 'canonical_mutation',
-        'scope_chain_entry', 'allocation_genesis', 'allocation_entry'
+        'scope_chain_entry', 'allocation_genesis', 'allocation_entry',
+        'topology_delta'
     )),
     operation_id       TEXT,
     operation_sequence INTEGER CHECK (operation_sequence IS NULL OR operation_sequence > 0),

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -327,7 +327,7 @@ func (s *Store) CheckContentReplacementTarget(ctx context.Context, nodeID, ifRev
 			return fmt.Errorf("checking audit membership for node %d: %w", nodeID, err)
 		}
 		if !member {
-			return unsupportedAuditedContentReplacement(nodeID)
+			return unsupportedAuditedNodeMutation(nodeID)
 		}
 		return nil
 	})

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -26,8 +26,6 @@ func bumpRevisionTx(tx *sql.Tx, id int64, now string) error {
 }
 
 // liveDirTx loads id and errors unless it is a live directory.
-//
-//nolint:unparam // Node result is part of the shared tx-helper contract; later tasks consume it.
 func liveDirTx(tx *sql.Tx, id int64) (Node, error) {
 	n, err := nodeByIDTx(tx, id)
 	if err != nil {
@@ -49,34 +47,68 @@ func (s *Store) Mkdir(ctx context.Context, parentID int64, name string) (Node, e
 		return Node{}, err
 	}
 	var created Node
-	err = s.withLogicalTx(ctx, func(tx *sql.Tx) error {
-		if _, err := liveDirTx(tx, parentID); err != nil {
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
 			return err
 		}
-		now := nowRFC3339()
-		res, err := tx.Exec(
-			`INSERT INTO nodes (parent_id, name, kind, created_at, modified_at)
-			 VALUES (?, ?, 'dir', ?, ?)`, parentID, name, now, now)
-		if s.driver.IsUniqueViolation(err) {
-			return fmt.Errorf("mkdir %q under node %d: %w", name, parentID, ErrExists)
-		}
-		if err != nil {
-			return fmt.Errorf("mkdir %q under node %d: %w", name, parentID, err)
-		}
-		id, err := res.LastInsertId()
-		if err != nil {
-			return fmt.Errorf("mkdir %q: reading id: %w", name, err)
-		}
-		if err := bumpRevisionTx(tx, parentID, now); err != nil {
+		if !active {
+			created, err = s.mkdirTx(tx, parentID, name, nowRFC3339())
 			return err
 		}
-		created, err = nodeByIDTx(tx, id)
-		return err
+		priorParent, err := liveDirTx(tx, parentID)
+		if err != nil {
+			return err
+		}
+		authority, scopes, _, err := loadAuditedNodeAuthority(ctx, tx, parentID)
+		if err != nil {
+			return err
+		}
+		operationID, err := newUUIDv4()
+		if err != nil {
+			return err
+		}
+		recordedAt := nowRFC3339()
+		created, err = s.mkdirTx(tx, parentID, name, recordedAt)
+		if err != nil {
+			return err
+		}
+		resultingParent, err := nodeByIDTx(tx, parentID)
+		if err != nil {
+			return err
+		}
+		return persistAuditedNodeCreation(ctx, tx, s.vaultID, authority, scopes,
+			priorParent, resultingParent, created, ContentVersion{}, operationID, recordedAt)
 	})
 	if err != nil {
 		return Node{}, err
 	}
 	return created, nil
+}
+
+func (s *Store) mkdirTx(
+	tx *sql.Tx, parentID int64, name, recordedAt string,
+) (Node, error) {
+	if _, err := liveDirTx(tx, parentID); err != nil {
+		return Node{}, err
+	}
+	res, err := tx.Exec(
+		`INSERT INTO nodes (parent_id, name, kind, created_at, modified_at)
+		 VALUES (?, ?, 'dir', ?, ?)`, parentID, name, recordedAt, recordedAt)
+	if s.driver.IsUniqueViolation(err) {
+		return Node{}, fmt.Errorf("mkdir %q under node %d: %w", name, parentID, ErrExists)
+	}
+	if err != nil {
+		return Node{}, fmt.Errorf("mkdir %q under node %d: %w", name, parentID, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Node{}, fmt.Errorf("mkdir %q: reading id: %w", name, err)
+	}
+	if err := bumpRevisionTx(tx, parentID, recordedAt); err != nil {
+		return Node{}, err
+	}
+	return nodeByIDTx(tx, id)
 }
 
 // childByName returns the live child of dirID named name (name must already
@@ -161,37 +193,44 @@ func (s *Store) EnsureBlobTx(tx *sql.Tx, hash string, size int64) error {
 }
 
 func (s *Store) createFileTx(tx *sql.Tx, parentID int64, name, blobHash string, size int64, mimeType string) (Node, error) {
-	if err := validateUTF8Field("content MIME type", mimeType); err != nil {
+	operation, err := newContentVersionOperation()
+	if err != nil {
 		return Node{}, err
+	}
+	created, _, err := s.createFileWithOperationTx(
+		tx, parentID, name, blobHash, size, mimeType, operation,
+	)
+	return created, err
+}
+
+func (s *Store) createFileWithOperationTx(
+	tx *sql.Tx, parentID int64, name, blobHash string, size int64, mimeType string,
+	operation contentVersionOperation,
+) (Node, ContentVersion, error) {
+	if err := validateUTF8Field("content MIME type", mimeType); err != nil {
+		return Node{}, ContentVersion{}, err
 	}
 	if _, err := liveDirTx(tx, parentID); err != nil {
-		return Node{}, err
+		return Node{}, ContentVersion{}, err
 	}
 	if err := s.EnsureBlobTx(tx, blobHash, size); err != nil {
-		return Node{}, err
+		return Node{}, ContentVersion{}, err
 	}
-	versionID, err := newUUIDv4()
-	if err != nil {
-		return Node{}, err
-	}
-	operationID, err := newUUIDv4()
-	if err != nil {
-		return Node{}, err
-	}
-	now := nowRFC3339()
 	res, err := tx.Exec(
 		`INSERT INTO nodes (parent_id, name, kind, current_version_id, created_at, modified_at)
 		 VALUES (?, ?, 'file', ?, ?, ?)`,
-		parentID, name, versionID, now, now)
+		parentID, name, operation.versionID, operation.recordedAt, operation.recordedAt)
 	if s.driver.IsUniqueViolation(err) {
-		return Node{}, fmt.Errorf("creating file %q under node %d: %w", name, parentID, ErrExists)
+		return Node{}, ContentVersion{}, fmt.Errorf(
+			"creating file %q under node %d: %w", name, parentID, ErrExists)
 	}
 	if err != nil {
-		return Node{}, fmt.Errorf("creating file %q under node %d: %w", name, parentID, err)
+		return Node{}, ContentVersion{}, fmt.Errorf(
+			"creating file %q under node %d: %w", name, parentID, err)
 	}
 	id, err := res.LastInsertId()
 	if err != nil {
-		return Node{}, fmt.Errorf("creating file %q: reading id: %w", name, err)
+		return Node{}, ContentVersion{}, fmt.Errorf("creating file %q: reading id: %w", name, err)
 	}
 	var storedMime any
 	if mimeType != "" {
@@ -202,13 +241,25 @@ func (s *Store) createFileTx(tx *sql.Tx, parentID int64, name, blobHash string, 
 			version_id, node_id, blob_hash, size, mime_type, recorded_at,
 			node_revision, introduced_operation_id, transition_kind, source_version_id
 		 ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, 'content_create', NULL)`,
-		versionID, id, blobHash, size, storedMime, now, operationID); err != nil {
-		return Node{}, fmt.Errorf("recording initial content version for node %d: %w", id, err)
+		operation.versionID, id, blobHash, size, storedMime, operation.recordedAt,
+		operation.operationID); err != nil {
+		return Node{}, ContentVersion{}, fmt.Errorf(
+			"recording initial content version for node %d: %w", id, err)
 	}
-	if err := bumpRevisionTx(tx, parentID, now); err != nil {
-		return Node{}, err
+	if err := bumpRevisionTx(tx, parentID, operation.recordedAt); err != nil {
+		return Node{}, ContentVersion{}, err
 	}
-	return nodeByIDTx(tx, id)
+	created, err := nodeByIDTx(tx, id)
+	if err != nil {
+		return Node{}, ContentVersion{}, err
+	}
+	version, err := scanContentVersion(tx.QueryRow(
+		`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id=?`, operation.versionID,
+	))
+	if err != nil {
+		return Node{}, ContentVersion{}, err
+	}
+	return created, version, nil
 }
 
 // CreateFile creates a file node pointing at an already-durable blob.
@@ -218,9 +269,41 @@ func (s *Store) CreateFile(ctx context.Context, parentID int64, name, blobHash s
 		return Node{}, err
 	}
 	var created Node
-	err = s.withLogicalTx(ctx, func(tx *sql.Tx) error {
-		created, err = s.createFileTx(tx, parentID, name, blobHash, size, mimeType)
-		return err
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if !active {
+			created, err = s.createFileTx(tx, parentID, name, blobHash, size, mimeType)
+			return err
+		}
+		priorParent, err := liveDirTx(tx, parentID)
+		if err != nil {
+			return err
+		}
+		authority, scopes, _, err := loadAuditedNodeAuthority(ctx, tx, parentID)
+		if err != nil {
+			return err
+		}
+		operation, err := newContentVersionOperation()
+		if err != nil {
+			return err
+		}
+		var version ContentVersion
+		created, version, err = s.createFileWithOperationTx(
+			tx, parentID, name, blobHash, size, mimeType, operation,
+		)
+		if err != nil {
+			return err
+		}
+		resultingParent, err := nodeByIDTx(tx, parentID)
+		if err != nil {
+			return err
+		}
+		return persistAuditedNodeCreation(ctx, tx, s.vaultID, authority, scopes,
+			priorParent, resultingParent, created, version, operation.operationID,
+			operation.recordedAt)
 	})
 	if err != nil {
 		return Node{}, err


### PR DESCRIPTION
An audited directory cannot safely accept new children unless membership inheritance and history recording happen in the same transaction. Otherwise creation is either permanently unavailable after enrollment or becomes a retention escape that leaves the new node purgeable.

This adds the smallest direct-creation slice: directory and file creation beneath an audited member now bind the child, its initial content when applicable, the parent revision change, topology transition, inherited baseline, scope chain, and allocator lineage as one Go-owned mutation. JSONL import and verification independently replay that mutation and reconcile the resulting projections instead of trusting the writer’s stored records.

The boundary is intentional. This covers Store.Mkdir, Store.CreateFile, and the embedded Put path. Filesystem ingest remains fail-closed because provenance is attached metadata and must be recorded atomically in its own focused follow-up; this PR does not add a partial ingest contract or speculative public audit surface.

Rollback, inherited directory/file creation, deterministic metadata round-trip, and adversarial membership-retarget coverage exercise the new authority path, and the repository’s CGO, pure-Go, race, lint, vet, and documentation gates are green.

Kata: qd6q.