### PR TITLE
Classify unavailable embedded content

### DIFF
--- a/content_unavailable_test.go
+++ b/content_unavailable_test.go
@@ -1,0 +1,133 @@
+package docbank_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	docbank "go.kenn.io/docbank"
+)
+
+func TestOpenContentClassifiesPhysicalContentFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		corrupt func(*testing.T, string)
+	}{
+		{
+			name: "missing blob",
+			corrupt: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.Remove(path))
+			},
+		},
+		{
+			name: "physical size mismatch",
+			corrupt: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(path, []byte("short"), 0o600))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			vault, err := docbank.New(t.Context(), docbank.Config{Root: root})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+			receipt, err := vault.Put(
+				t.Context(), "/notes/current.md", strings.NewReader("current bytes\n"), docbank.PutOptions{},
+			)
+			require.NoError(t, err)
+			test.corrupt(t, looseBlobPath(root, receipt.Computed.SHA256))
+
+			_, err = vault.OpenContent(t.Context(), "/notes/current.md")
+			require.ErrorIs(t, err, docbank.ErrContentUnavailable)
+		})
+	}
+}
+
+func TestOpenVersionContentClassifiesPhysicalContentFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		corrupt func(*testing.T, string)
+	}{
+		{
+			name: "missing blob",
+			corrupt: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.Remove(path))
+			},
+		},
+		{
+			name: "physical size mismatch",
+			corrupt: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(path, []byte("short"), 0o600))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			vault, err := docbank.New(t.Context(), docbank.Config{Root: root})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+			first, err := vault.Put(
+				t.Context(), "/notes/history.md", strings.NewReader("historical bytes\n"), docbank.PutOptions{},
+			)
+			require.NoError(t, err)
+			_, err = vault.Put(
+				t.Context(), "/notes/history.md", strings.NewReader("current bytes\n"), docbank.PutOptions{},
+			)
+			require.NoError(t, err)
+			test.corrupt(t, looseBlobPath(root, first.Computed.SHA256))
+
+			_, err = vault.OpenVersionContent(t.Context(), first.Version.ID)
+			require.ErrorIs(t, err, docbank.ErrContentUnavailable)
+		})
+	}
+}
+
+func TestContentMetadataErrorsRemainDistinctFromPhysicalUnavailability(t *testing.T) {
+	root := t.TempDir()
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: root})
+	require.NoError(t, err)
+
+	receipt, err := vault.Put(
+		t.Context(), "/notes/entry.md", strings.NewReader("entry\n"), docbank.PutOptions{},
+	)
+	require.NoError(t, err)
+
+	_, err = vault.OpenContent(t.Context(), "/missing.md")
+	require.ErrorIs(t, err, docbank.ErrNotFound)
+	require.NotErrorIs(t, err, docbank.ErrContentUnavailable)
+
+	_, err = vault.OpenContent(t.Context(), "/notes")
+	require.ErrorIs(t, err, docbank.ErrNotFile)
+	require.NotErrorIs(t, err, docbank.ErrContentUnavailable)
+
+	_, err = vault.OpenVersionContent(t.Context(), "00000000-0000-4000-8000-000000000000")
+	require.ErrorIs(t, err, docbank.ErrNotFound)
+	require.NotErrorIs(t, err, docbank.ErrContentUnavailable)
+
+	require.NoError(t, vault.Close())
+
+	_, err = vault.OpenContent(t.Context(), "/notes/entry.md")
+	require.ErrorIs(t, err, docbank.ErrClosed)
+	require.NotErrorIs(t, err, docbank.ErrContentUnavailable)
+
+	_, err = vault.OpenVersionContent(t.Context(), receipt.Version.ID)
+	require.ErrorIs(t, err, docbank.ErrClosed)
+	require.NotErrorIs(t, err, docbank.ErrContentUnavailable)
+}
+
+func looseBlobPath(root, hash string) string {
+	return filepath.Join(root, "blobs", hash[:2], hash)
+}

--- a/docbank.go
+++ b/docbank.go
@@ -27,6 +27,9 @@ import (
 var (
 	// ErrClosed means an operation targeted a closed embedded vault.
 	ErrClosed = errors.New("docbank vault is closed")
+	// ErrContentUnavailable means catalog-authorized content could not be
+	// opened or its physical size disagreed with the metadata authority.
+	ErrContentUnavailable = errors.New("docbank content is unavailable")
 	// ErrDigestMismatch means the durable bytes did not match the caller's
 	// optional expected SHA-256 identity.
 	ErrDigestMismatch = errors.New("docbank content digest mismatch")
@@ -367,14 +370,20 @@ func (v *Vault) OpenContent(ctx context.Context, virtualPath string) (*Content, 
 	}
 	reader, size, err := v.blobs.OpenStreamContext(ctx, node.BlobHash)
 	if err != nil {
+		closeErr := closeContentReader(reader)
 		v.lifecycle.RUnlock()
-		return nil, err
+		return nil, errors.Join(fmt.Errorf(
+			"opening content for virtual path %q: %w: %w",
+			virtualPath, ErrContentUnavailable, err,
+		), closeErr)
 	}
 	if size != node.Size {
 		closeErr := reader.Close()
 		v.lifecycle.RUnlock()
 		return nil, errors.Join(fmt.Errorf(
-			"catalog size %d does not match node size %d", size, node.Size), closeErr)
+			"catalog size %d does not match node size %d: %w",
+			size, node.Size, ErrContentUnavailable,
+		), closeErr)
 	}
 	return &Content{
 		Node:   fromStoreNode(node),
@@ -396,18 +405,32 @@ func (v *Vault) OpenVersionContent(ctx context.Context, versionID string) (*Vers
 	}
 	reader, size, err := v.blobs.OpenStreamContext(ctx, version.BlobHash)
 	if err != nil {
+		closeErr := closeContentReader(reader)
 		v.lifecycle.RUnlock()
-		return nil, err
+		return nil, errors.Join(fmt.Errorf(
+			"opening content version %q: %w: %w",
+			versionID, ErrContentUnavailable, err,
+		), closeErr)
 	}
 	if size != version.Size {
 		closeErr := reader.Close()
 		v.lifecycle.RUnlock()
-		return nil, errors.Join(fmt.Errorf("catalog size %d does not match version size %d", size, version.Size), closeErr)
+		return nil, errors.Join(fmt.Errorf(
+			"catalog size %d does not match version size %d: %w",
+			size, version.Size, ErrContentUnavailable,
+		), closeErr)
 	}
 	return &VersionContent{
 		Version: fromStoreVersion(version),
 		Reader:  &leasedReader{VerifiedReadCloser: reader, release: v.lifecycle.RUnlock},
 	}, nil
+}
+
+func closeContentReader(reader packstore.VerifiedReadCloser) error {
+	if reader == nil {
+		return nil
+	}
+	return reader.Close()
 }
 
 // Pack explicitly moves authorized loose content into managed immutable packs.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,8 @@ docbank is pre-1.0; interfaces and storage migrations may still evolve.
 
 ## Unreleased
 
+- Embedded content opens classify missing or physically size-mismatched bytes
+  with `ErrContentUnavailable` without conflating metadata lookup failures.
 - Embedded Go applications can page immutable content history with `Versions`
   and open any historical version through the verified read contract with
   `OpenVersionContent`.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -84,6 +84,13 @@ or `Verify` succeeds. Early `Close` does not drain the stream. `Vault.Close`
 waits for active operations and streams, closes storage, and releases the vault
 lock.
 
+`OpenContent` and `OpenVersionContent` wrap `ErrContentUnavailable` when the
+catalog-authorized physical content cannot be opened or its physical size
+disagrees with metadata. Metadata lookup failures retain their existing
+`ErrNotFound`, `ErrNotFile`, or `ErrClosed` classification instead. A canceled
+physical open can match both `context.Canceled` and `ErrContentUnavailable`, so
+callers that distinguish cancellation should check the context error first.
+
 ## List and pack content
 
 `Children` exposes the live virtual tree without materializing an unbounded


### PR DESCRIPTION
Embedded consumers need to distinguish physical content loss from metadata or lifecycle failures so one damaged blob does not unnecessarily take an entire service offline. The prior API returned several pre-reader storage failures without a stable classification, forcing consumers either to parse error strings or misclassify database errors as corruption.

This adds an errors.Is-compatible boundary for physical open and size failures while retaining existing underlying causes and keeping not-found, not-file, closed, and cancellation semantics independently observable. That lets consumers degrade only the affected document without weakening metadata readiness failures.