### PR TITLE
Record audited filesystem ingest

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -401,7 +401,7 @@ func (ing *Ingester) AddPathsWithOptions(
 func (ing *Ingester) addTree(
 	ctx context.Context,
 	rep *Report,
-	ingestID string,
+	ingestRun store.IngestRun,
 	destDirID int64,
 	sourceRoot, walkRoot string,
 	excludes exclusions,
@@ -482,7 +482,7 @@ func (ing *Ingester) addTree(
 			if !ok {
 				return fmt.Errorf("internal: no virtual dir recorded for %s", filepath.Dir(p))
 			}
-			if err := ing.addOne(ctx, rep, ingestID, parentID, p, sourcePath, progress); err != nil {
+			if err := ing.addOne(ctx, rep, ingestRun, parentID, p, sourcePath, progress); err != nil {
 				return err
 			}
 		default:
@@ -507,12 +507,12 @@ func sourceTreePath(sourceRoot, walkRoot, walkPath string) string {
 func (ing *Ingester) addOne(
 	ctx context.Context,
 	rep *Report,
-	ingestID string,
+	ingestRun store.IngestRun,
 	parentID int64,
 	openPath, sourcePath string,
 	progress *progressTracker,
 ) error {
-	added, err := ing.importFile(ctx, ingestID, parentID, openPath, sourcePath, progress)
+	added, err := ing.importFile(ctx, ingestRun, parentID, openPath, sourcePath, progress)
 	switch {
 	case err != nil:
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -530,7 +530,7 @@ func (ing *Ingester) addOne(
 
 func (ing *Ingester) importFile(
 	ctx context.Context,
-	ingestID string,
+	ingestRun store.IngestRun,
 	parentID int64,
 	openPath, sourcePath string,
 	progress *progressTracker,
@@ -578,7 +578,7 @@ func (ing *Ingester) importFile(
 	}
 
 	mtime := info.ModTime().UTC().Format(time.RFC3339Nano)
-	_, added, err := ing.Store.IngestFile(ctx, ingestID, parentID,
+	_, added, err := ing.Store.IngestFile(ctx, ingestRun, parentID,
 		filepath.Base(sourcePath), hash, size, detectMime(sourcePath, head), sourcePath, mtime)
 	if err != nil {
 		return false, fmt.Errorf("recording %s: %w", sourcePath, err)

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -199,6 +199,7 @@ type auditedHistoryReplay struct {
 	memberSet       map[uint64]bool
 	states          map[uint64]audit.Record
 	versions        map[string]audit.Record
+	attachments     map[string]audit.Record
 	topology        []audit.Record
 	topologyIndex   map[uint64]int
 	scopeHead       string
@@ -246,8 +247,10 @@ func validateAuditedHistory(
 	usedEvents := map[string]bool{}
 	baselines := auditRecordsByDigest(records["enrollment_baseline"])
 	topologyDeltas := auditRecordsByDigest(records[auditTopologyDeltaField])
+	attachmentDeltas := auditRecordsByDigest(records["attached_metadata_delta"])
 	usedBaselines := map[string]bool{initial["enrollment_baseline"][0].digest: true}
 	usedTopologyDeltas := map[string]bool{}
+	usedAttachmentDeltas := map[string]bool{}
 	for sequence := int64(2); sequence <= authority.sequence; sequence++ {
 		mutation := mutations[sequence]
 		bindings, bindingErr := auditRecordListField(mutation.record, "baselines")
@@ -261,8 +264,8 @@ func validateAuditedHistory(
 		} else {
 			err = replay.applyNodeCreation(
 				vaultID, mutation, allocations[sequence], entries[sequence],
-				baselines, topologyDeltas, events, usedBaselines,
-				usedTopologyDeltas, usedEvents,
+				baselines, topologyDeltas, attachmentDeltas, events, usedBaselines,
+				usedTopologyDeltas, usedAttachmentDeltas, usedEvents,
 			)
 		}
 		if err != nil {
@@ -280,6 +283,9 @@ func validateAuditedHistory(
 	if len(usedTopologyDeltas) != len(topologyDeltas) {
 		return errors.New("audit history contains an unbound topology delta")
 	}
+	if len(usedAttachmentDeltas) != len(attachmentDeltas) {
+		return errors.New("audit history contains an unbound attached-metadata delta")
+	}
 	if authority.sequence != replay.allocationCount || authority.allocationHead != replay.allocationHead {
 		return errors.New("audit allocation authority does not match replayed history")
 	}
@@ -293,7 +299,7 @@ func validateAuditedHistory(
 	if finalNodeHighWater != replay.nodeHighWater {
 		return errors.New("audit node allocation high-water mark does not match replayed history")
 	}
-	return replay.reconcileCurrentState(ctx, tx, initial)
+	return replay.reconcileCurrentState(ctx, tx)
 }
 
 func auditRecordsByDigest(records []storedAuditRecord) map[string]storedAuditRecord {
@@ -338,6 +344,12 @@ func newAuditedHistoryReplay(
 	if err != nil {
 		return nil, err
 	}
+	attachments, err := auditRecordListField(
+		initial["attached_metadata_genesis"][0].record, "records",
+	)
+	if err != nil {
+		return nil, err
+	}
 	topology, err := auditRecordListField(initial["topology_genesis"][0].record, "nodes")
 	if err != nil {
 		return nil, err
@@ -354,6 +366,7 @@ func newAuditedHistoryReplay(
 		memberSet:       auditMemberSet(members),
 		states:          make(map[uint64]audit.Record, len(states)),
 		versions:        make(map[string]audit.Record, len(versions)),
+		attachments:     make(map[string]audit.Record, len(attachments)),
 		topology:        slices.Clone(topology),
 		topologyIndex:   make(map[uint64]int, len(topology)),
 		scopeHead:       initial["scope_chain_entry"][0].digest,
@@ -385,6 +398,16 @@ func newAuditedHistoryReplay(
 			return nil, err
 		}
 		replay.versions[versionID] = version
+	}
+	for _, attachment := range attachments {
+		key, err := attachedAuditKey(attachment)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := replay.attachments[key]; exists {
+			return nil, errors.New("audit attachment genesis repeats an identity")
+		}
+		replay.attachments[key] = attachment
 	}
 	for index, node := range topology {
 		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
@@ -800,7 +823,7 @@ func replaceAuditRecordField(record audit.Record, name string, value audit.Value
 }
 
 func (replay *auditedHistoryReplay) reconcileCurrentState(
-	ctx context.Context, tx metadataQuerier, initial map[string][]storedAuditRecord,
+	ctx context.Context, tx metadataQuerier,
 ) error {
 	if err := replay.reconcileMembershipProjection(ctx, tx); err != nil {
 		return err
@@ -838,13 +861,11 @@ func (replay *auditedHistoryReplay) reconcileCurrentState(
 	if err != nil {
 		return err
 	}
-	genesisAttachments, err := auditRecordListField(
-		initial["attached_metadata_genesis"][0].record, "records",
-	)
-	if err != nil {
-		return err
+	expectedAttachments := make([]audit.Record, 0, len(replay.attachments))
+	for _, record := range replay.attachments {
+		expectedAttachments = append(expectedAttachments, record)
 	}
-	if !equalAuditRecordLists(genesisAttachments, currentAttachments) {
+	if !equalAuditRecordSets(expectedAttachments, currentAttachments) {
 		return errors.New("replayed audit attachments do not match current metadata")
 	}
 	return nil

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -350,6 +350,9 @@ func newAuditedHistoryReplay(
 	if err != nil {
 		return nil, err
 	}
+	if err := validateGenesisProvenanceIngests(attachments); err != nil {
+		return nil, err
+	}
 	topology, err := auditRecordListField(initial["topology_genesis"][0].record, "nodes")
 	if err != nil {
 		return nil, err
@@ -417,6 +420,33 @@ func newAuditedHistoryReplay(
 		replay.topologyIndex[nodeID] = index
 	}
 	return replay, nil
+}
+
+func validateGenesisProvenanceIngests(attachments []audit.Record) error {
+	ingests := make(map[string]bool)
+	for _, record := range attachments {
+		if record.Kind != metadataIngestType {
+			continue
+		}
+		ingestID, err := auditUUIDField(record, "ingest_id")
+		if err != nil {
+			return fmt.Errorf("reading genesis ingest identity: %w", err)
+		}
+		ingests[ingestID] = true
+	}
+	for _, record := range attachments {
+		if record.Kind != metadataProvenanceType {
+			continue
+		}
+		ingestID, err := auditUUIDField(record, "ingest_id")
+		if err != nil {
+			return fmt.Errorf("reading genesis provenance ingest: %w", err)
+		}
+		if !ingests[ingestID] {
+			return fmt.Errorf("audit attachment genesis provenance references missing ingest %s", ingestID)
+		}
+	}
+	return nil
 }
 
 func auditRecordsBySequence(

--- a/internal/store/audit_ingest.go
+++ b/internal/store/audit_ingest.go
@@ -1,0 +1,127 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+// auditedCreationMetadata is the attached authority introduced by an audited
+// file creation. A filesystem ingest adds one provenance fact and may also
+// publish the ingest run that fact references.
+type auditedCreationMetadata struct {
+	groupingID      audit.Value
+	baselineRecords []audit.Record
+	changes         []audit.Record
+	delta           audit.Record
+	deltaDigest     auditRecordHash
+	provenance      audit.Record
+}
+
+func auditedCreationBaselineAttachments(metadata *auditedCreationMetadata) []audit.Record {
+	if metadata == nil {
+		return nil
+	}
+	return metadata.baselineRecords
+}
+
+func makeAuditedIngestCreationMetadata(
+	ingest metadataIngest, provenance metadataProvenance, ingestAdded bool,
+	operationID string,
+) (auditedCreationMetadata, error) {
+	ingestRecord, err := ingestAuditRecord(ingest)
+	if err != nil {
+		return auditedCreationMetadata{}, err
+	}
+	provenanceRecord, err := provenanceAuditRecord(
+		provenance.Identity, provenance.NodeID, provenance.IngestID,
+		provenance.OriginalPath,
+		nullString(provenance.OriginalMTime), nullString(provenance.Supersedes),
+	)
+	if err != nil {
+		return auditedCreationMetadata{}, err
+	}
+	baseline := []audit.Record{ingestRecord, provenanceRecord}
+	if err := sortAuditRecordsByCanonicalIdentity(baseline, attachedAuditIdentity); err != nil {
+		return auditedCreationMetadata{}, fmt.Errorf("sorting audited ingest baseline metadata: %w", err)
+	}
+	changes := make([]audit.Record, 0, 2)
+	if ingestAdded {
+		change, err := makeAttachedMetadataAddition(ingestRecord)
+		if err != nil {
+			return auditedCreationMetadata{}, err
+		}
+		changes = append(changes, change)
+	}
+	provenanceChange, err := makeAttachedMetadataAddition(provenanceRecord)
+	if err != nil {
+		return auditedCreationMetadata{}, err
+	}
+	changes = append(changes, provenanceChange)
+	operationValue, err := audit.UUID(operationID)
+	if err != nil {
+		return auditedCreationMetadata{}, err
+	}
+	delta := audit.Record{Kind: "attached_metadata_delta", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: operationValue},
+		{Name: "changes", Value: audit.List(auditNestedValues(changes)...)},
+	}}
+	digest, err := hashAuditRecord(delta)
+	if err != nil {
+		return auditedCreationMetadata{}, err
+	}
+	groupingID, err := audit.UUID(ingest.ID)
+	if err != nil {
+		return auditedCreationMetadata{}, err
+	}
+	return auditedCreationMetadata{
+		groupingID: groupingID, baselineRecords: baseline, changes: changes,
+		delta: delta, deltaDigest: digest, provenance: provenanceRecord,
+	}, nil
+}
+
+func ingestAuditRecord(ingest metadataIngest) (audit.Record, error) {
+	id, err := audit.UUID(ingest.ID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	startedAt, err := audit.Timestamp(ingest.StartedAt)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	sourceKind, err := audit.Text(ingest.SourceKind)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: metadataIngestType, Fields: []audit.Field{
+		{Name: "ingest_id", Value: id},
+		{Name: "started_at", Value: startedAt},
+		{Name: "source_kind", Value: sourceKind},
+		{Name: "source_desc", Value: audit.Bytes([]byte(ingest.SourceDesc))},
+	}}, nil
+}
+
+func makeAttachedMetadataAddition(record audit.Record) (audit.Record, error) {
+	kind, err := audit.Text(record.Kind)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	identity, err := attachedAuditIdentity(record)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "attached_metadata_change", Fields: []audit.Field{
+		{Name: "record_kind", Value: kind},
+		{Name: "stable_identity", Value: audit.Nested(identity)},
+		{Name: "pre", Value: audit.Absent()},
+		{Name: "post", Value: audit.Nested(record)},
+	}}, nil
+}
+
+func nullString(value *string) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *value, Valid: true}
+}

--- a/internal/store/audit_ingest_test.go
+++ b/internal/store/audit_ingest_test.go
@@ -1,0 +1,181 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedIngestRecordsProvenanceAndRoundTrips(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+
+	run, err := s.BeginIngest(t.Context(), "cli", "/source/reports")
+	require.NoError(t, err)
+	var runRows int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT COUNT(*) FROM ingests WHERE id=?`, run.ID(),
+	).Scan(&runRows))
+	assert.Zero(t, runRows, "preparing a run must not publish metadata authority")
+
+	first, added, err := s.IngestFile(
+		t.Context(), run, scope.ID, "first.txt", fakeHash("ad1"), 11,
+		"text/plain", "/source/reports/first.txt", "2026-07-17T12:00:00Z",
+	)
+	require.NoError(t, err)
+	require.True(t, added)
+	second, added, err := s.IngestFile(
+		t.Context(), run, scope.ID, "second.txt", fakeHash("ad2"), 12,
+		"text/plain", "/source/reports/second.txt", "2026-07-17T12:00:01Z",
+	)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	skipped, added, err := s.IngestFile(
+		t.Context(), run, scope.ID, "second.txt", fakeHash("ad2"), 12,
+		"text/plain", "/source/reports/second.txt", "2026-07-17T12:00:01Z",
+	)
+	require.NoError(t, err)
+	assert.False(t, added)
+	assert.Equal(t, second.ID, skipped.ID)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	var ingests, provenance, sequence, membership int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM ingests WHERE id=?),
+		(SELECT COUNT(*) FROM provenance WHERE ingest_id=?),
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM audit_memberships WHERE node_id IN (?,?))`,
+		run.ID(), run.ID(), first.ID, second.ID,
+	).Scan(&ingests, &provenance, &sequence, &membership))
+	assert.Equal(t, int64(1), ingests)
+	assert.Equal(t, int64(2), provenance)
+	assert.Equal(t, int64(3), sequence)
+	assert.Equal(t, int64(2), membership)
+
+	rows, err := s.db.Query(`SELECT record_json FROM audit_records
+		WHERE kind='canonical_mutation' AND operation_sequence>1 ORDER BY operation_sequence`)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	var attachmentCounts []uint64
+	for rows.Next() {
+		var raw []byte
+		require.NoError(t, rows.Scan(&raw))
+		record, err := audit.UnmarshalJSONRecord(raw)
+		require.NoError(t, err)
+		groupingID, err := auditUUIDField(record, "grouping_id")
+		require.NoError(t, err)
+		assert.Equal(t, run.ID(), groupingID)
+		count, err := auditUnsignedField(record, auditAttachedMetadataChangeCountField)
+		require.NoError(t, err)
+		attachmentCounts = append(attachmentCounts, count)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []uint64{2, 1}, attachmentCounts)
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+}
+
+func TestAuditedIngestRollsBackFileAndAttachments(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	run, err := s.BeginIngest(t.Context(), "cli", "/source")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_ingest_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audited ingest failure'); END`)
+	require.NoError(t, err)
+
+	_, _, err = s.IngestFile(
+		t.Context(), run, scope.ID, "rollback.txt", fakeHash("ad3"), 7,
+		"text/plain", "/source/rollback.txt", "",
+	)
+	require.ErrorContains(t, err, "forced audited ingest failure")
+	_, err = s.NodeByPath(t.Context(), "/Projects/rollback.txt")
+	require.ErrorIs(t, err, ErrNotFound)
+	var ingestRows, provenanceRows int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM ingests WHERE id=?),
+		(SELECT COUNT(*) FROM provenance WHERE ingest_id=?)`,
+		run.ID(), run.ID(),
+	).Scan(&ingestRows, &provenanceRows))
+	assert.Zero(t, ingestRows)
+	assert.Zero(t, provenanceRows)
+}
+
+func TestAuditedIngestImportRejectsOmittedProvenance(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	run, err := s.BeginIngest(t.Context(), "cli", "/source")
+	require.NoError(t, err)
+	created, added, err := s.IngestFile(
+		t.Context(), run, scope.ID, "missing.txt", fakeHash("ad4"), 9,
+		"text/plain", "/source/missing.txt", "",
+	)
+	require.NoError(t, err)
+	require.True(t, added)
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := omitMetadataProvenance(t, exported.Bytes(), created.ID)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "replayed audit attachments do not match current metadata")
+	var auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&auditRows))
+	assert.Zero(t, auditRows)
+}
+
+func omitMetadataProvenance(t *testing.T, input []byte, nodeID int64) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	kept := lines[:0]
+	found := false
+	for _, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type == metadataProvenanceType {
+			var provenance metadataProvenance
+			require.NoError(t, json.Unmarshal(line, &provenance))
+			if provenance.NodeID == nodeID {
+				found = true
+				continue
+			}
+		}
+		kept = append(kept, line)
+	}
+	require.True(t, found)
+	return append(bytes.Join(kept, []byte{'\n'}), '\n')
+}

--- a/internal/store/audit_ingest_test.go
+++ b/internal/store/audit_ingest_test.go
@@ -156,6 +156,55 @@ func TestAuditedIngestImportRejectsOmittedProvenance(t *testing.T) {
 	assert.Zero(t, auditRows)
 }
 
+func TestAuditReplayRejectsGenesisProvenanceFromLaterIngest(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scopeNode, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scopeNode.ID)
+	run, err := s.BeginIngest(t.Context(), "cli", "/later")
+	require.NoError(t, err)
+	_, added, err := s.IngestFile(
+		t.Context(), run, scopeNode.ID, "later.txt", fakeHash("ad5"), 10,
+		"text/plain", "/later/later.txt", "",
+	)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	deltaChanges, err := auditRecordListField(records["attached_metadata_delta"][0].record, "changes")
+	require.NoError(t, err)
+	var laterProvenance audit.Record
+	for _, change := range deltaChanges {
+		post, postErr := auditNestedField(change, "post")
+		require.NoError(t, postErr)
+		if post.Kind == metadataProvenanceType {
+			laterProvenance = post
+		}
+	}
+	require.Equal(t, metadataProvenanceType, laterProvenance.Kind)
+
+	genesis := initial["attached_metadata_genesis"][0]
+	genesisAttachments, err := auditRecordListField(genesis.record, "records")
+	require.NoError(t, err)
+	genesisAttachments = append(genesisAttachments, laterProvenance)
+	genesis.record, err = replaceAuditRecordField(
+		genesis.record, "records", audit.List(auditNestedValues(genesisAttachments)...),
+	)
+	require.NoError(t, err)
+	initial["attached_metadata_genesis"][0] = genesis
+
+	_, err = newAuditedHistoryReplay(authority, scope, initial)
+	require.ErrorContains(t, err, "genesis provenance references missing ingest "+run.ID())
+}
+
 func omitMetadataProvenance(t *testing.T, input []byte, nodeID int64) []byte {
 	t.Helper()
 	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})

--- a/internal/store/audit_ingest_validate.go
+++ b/internal/store/audit_ingest_validate.go
@@ -1,0 +1,165 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func (replay *auditedHistoryReplay) validateNodeCreationAttachedMetadata(
+	mutation audit.Record, operationID string, creation *replayedNodeCreation,
+	deltaRecords map[string]storedAuditRecord, usedDeltas map[string]bool,
+) error {
+	count, err := auditUnsignedField(mutation, auditAttachedMetadataChangeCountField)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		if err := requireAuditAbsentFields(
+			mutation, "grouping_id", "attached_metadata_change_digest",
+		); err != nil {
+			return err
+		}
+		if len(creation.baselineAttachments) != 0 {
+			return errors.New("direct node creation baseline cannot contain attached metadata")
+		}
+		return nil
+	}
+	if creation.version == nil || count > 2 {
+		return errors.New("audited ingest has an invalid attached-metadata change count")
+	}
+	ingestID, err := auditUUIDField(mutation, "grouping_id")
+	if err != nil {
+		return fmt.Errorf("reading audited ingest grouping ID: %w", err)
+	}
+	digest, err := auditDigestField(mutation, "attached_metadata_change_digest")
+	if err != nil {
+		return err
+	}
+	delta, ok := deltaRecords[digest]
+	if !ok || usedDeltas[digest] {
+		return errors.New("audited ingest lacks one unique attached-metadata delta")
+	}
+	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
+		return err
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return err
+	}
+	if uint64(len(changes)) != count {
+		return errors.New("audited ingest attachment count does not match its delta")
+	}
+	var ingestRecord, provenanceRecord *audit.Record
+	for index := range changes {
+		post, err := validateAuditedIngestAddition(changes[index])
+		if err != nil {
+			return err
+		}
+		key, err := attachedAuditKey(post)
+		if err != nil {
+			return err
+		}
+		if _, exists := replay.attachments[key]; exists {
+			return fmt.Errorf("audited ingest reuses attached metadata identity %s", post.Kind)
+		}
+		switch post.Kind {
+		case metadataIngestType:
+			if ingestRecord != nil {
+				return errors.New("audited ingest adds more than one ingest record")
+			}
+			ingestRecord = &post
+		case metadataProvenanceType:
+			if provenanceRecord != nil {
+				return errors.New("audited ingest adds more than one provenance record")
+			}
+			provenanceRecord = &post
+		default:
+			return fmt.Errorf("audited ingest adds unsupported %s metadata", post.Kind)
+		}
+	}
+	if provenanceRecord == nil {
+		return errors.New("audited ingest lacks its provenance addition")
+	}
+	if err := validateAuditedIngestProvenance(*provenanceRecord, creation.childID, ingestID); err != nil {
+		return err
+	}
+	if ingestRecord == nil {
+		existing, err := replay.ingestAttachment(ingestID)
+		if err != nil {
+			return err
+		}
+		ingestRecord = &existing
+	} else if err := requireAuditUUID(*ingestRecord, "ingest_id", ingestID); err != nil {
+		return err
+	}
+	expectedBaseline := []audit.Record{*ingestRecord, *provenanceRecord}
+	if err := sortAuditRecordsByCanonicalIdentity(expectedBaseline, attachedAuditIdentity); err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(expectedBaseline, creation.baselineAttachments) {
+		return errors.New("audited ingest baseline does not match its attached metadata")
+	}
+	creation.attachmentChanges = changes
+	creation.attachmentDigest = digest
+	creation.provenance = provenanceRecord
+	creation.ingestID = ingestID
+	usedDeltas[digest] = true
+	return nil
+}
+
+func validateAuditedIngestAddition(change audit.Record) (audit.Record, error) {
+	if err := requireAuditAbsent(change, "pre"); err != nil {
+		return audit.Record{}, errors.New("audited ingest attachment change is not an addition")
+	}
+	post, err := auditNestedField(change, "post")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	kind, err := auditTextField(change, "record_kind")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	if kind != post.Kind {
+		return audit.Record{}, errors.New("audited ingest attachment kind does not match its post record")
+	}
+	identity, err := auditNestedField(change, "stable_identity")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	wantIdentity, err := attachedAuditIdentity(post)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	if !auditRecordEqual(identity, wantIdentity) {
+		return audit.Record{}, errors.New("audited ingest attachment identity does not match its post record")
+	}
+	return post, nil
+}
+
+func validateAuditedIngestProvenance(record audit.Record, nodeID uint64, ingestID string) error {
+	if err := requireAuditUnsigned(record, metadataNodeIDField, nodeID); err != nil {
+		return err
+	}
+	if err := requireAuditUUID(record, "ingest_id", ingestID); err != nil {
+		return err
+	}
+	return requireAuditAbsent(record, "supersedes")
+}
+
+func (replay *auditedHistoryReplay) ingestAttachment(ingestID string) (audit.Record, error) {
+	for _, record := range replay.attachments {
+		if record.Kind != metadataIngestType {
+			continue
+		}
+		id, err := auditUUIDField(record, "ingest_id")
+		if err != nil {
+			return audit.Record{}, err
+		}
+		if id == ingestID {
+			return record, nil
+		}
+	}
+	return audit.Record{}, fmt.Errorf("audited ingest references missing run %s", ingestID)
+}

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -24,6 +24,7 @@ var auditRecordKinds = map[string]bool{
 	"allocation_genesis":        true,
 	"allocation_entry":          true,
 	auditTopologyDeltaField:     true,
+	"attached_metadata_delta":   true,
 }
 
 type auditRecordIndex struct {
@@ -333,7 +334,8 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 			return index, err
 		}
 		index.scopeID, index.entryCount = &scopeID, &entryCount
-	case "topology_genesis", "attached_metadata_genesis", "allocation_genesis", auditTopologyDeltaField:
+	case "topology_genesis", "attached_metadata_genesis", "allocation_genesis",
+		auditTopologyDeltaField, "attached_metadata_delta":
 	default:
 		return index, fmt.Errorf("unsupported initial audit record kind %q", record.Kind)
 	}

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -281,7 +281,12 @@ func TestInitialAuditAuthorityRejectsUnsupportedLogicalMutations(t *testing.T) {
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
 	_, err = s.CreateTag(t.Context(), "blocked")
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
-	_, err = s.BeginIngest(t.Context(), "cli", "blocked")
+	run, err := s.BeginIngest(t.Context(), "cli", "blocked")
+	require.NoError(t, err)
+	_, _, err = s.IngestFile(
+		t.Context(), run, s.RootID(), "blocked.txt", fakeHash("blocked"), 1,
+		"text/plain", "/blocked.txt", "",
+	)
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
 	_, err = s.TrashEmpty(t.Context(), 0, true)
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)

--- a/internal/store/audit_node_create.go
+++ b/internal/store/audit_node_create.go
@@ -26,7 +26,7 @@ func persistAuditedNodeCreation(
 	ctx context.Context, tx *sql.Tx, vaultID string,
 	authority auditAuthorityState, scopes []auditScopeState,
 	priorParent, resultingParent, created Node, version ContentVersion,
-	operationID, recordedAt string,
+	operationID, recordedAt string, metadata *auditedCreationMetadata,
 ) error {
 	if len(scopes) != 1 {
 		return unsupportedAuditedNodeMutation(priorParent.ID)
@@ -64,12 +64,14 @@ func persistAuditedNodeCreation(
 		return err
 	}
 	baseline, err := buildAuditedCreationBaseline(
-		tx, values, scopes[0], created, version, createdTopology,
+		tx, values, scopes[0], created, version, createdTopology, metadata,
 	)
 	if err != nil {
 		return err
 	}
-	events, err := makeAuditedCreationEvents(values, baseline, created, topologyDigest)
+	events, err := makeAuditedCreationEvents(
+		values, baseline, created, topologyDigest, metadata,
+	)
 	if err != nil {
 		return err
 	}
@@ -82,14 +84,14 @@ func persistAuditedNodeCreation(
 		return err
 	}
 	mutation := makeAuditedCreationMutation(
-		values, auditOperationSequence, events, parentChange, baseline, topologyDigest,
+		values, auditOperationSequence, events, parentChange, baseline, topologyDigest, metadata,
 	)
 	mutationDigest, err := hashAuditRecord(mutation)
 	if err != nil {
 		return err
 	}
 	if err := persistAuditedCreationRecords(
-		ctx, tx, baseline, topologyDelta, events, mutation,
+		ctx, tx, baseline, topologyDelta, events, mutation, metadata,
 	); err != nil {
 		return err
 	}
@@ -104,7 +106,7 @@ func persistAuditedNodeCreation(
 	}
 	allocation, err := makeAuditedCreationAllocationEntry(
 		values, operationSequence, nodeSequence, created.ID,
-		authority.allocationHead, mutationDigest.value, topologyDigest.value,
+		authority.allocationHead, mutationDigest.value, topologyDigest.value, metadata,
 	)
 	if err != nil {
 		return err
@@ -207,7 +209,7 @@ func sortAuditTopologyRecords(records []audit.Record) error {
 func buildAuditedCreationBaseline(
 	tx *sql.Tx, values auditedMutationValues,
 	scope auditScopeState, created Node, version ContentVersion,
-	createdTopology audit.Record,
+	createdTopology audit.Record, metadata *auditedCreationMetadata,
 ) (auditedCreationBaseline, error) {
 	nodeID, err := positiveAuditNodeID(created.ID)
 	if err != nil {
@@ -250,7 +252,7 @@ func buildAuditedCreationBaseline(
 	}
 	record := makeInitialAuditBaseline(
 		initialValues, nodeID, []uint64{nodeID}, []audit.Record{state},
-		versions, nil, nodes, witnesses,
+		versions, auditedCreationBaselineAttachments(metadata), nodes, witnesses,
 	)
 	digest, err := hashAuditRecord(record)
 	if err != nil {
@@ -341,19 +343,25 @@ func auditCreationBaselineTopology(
 
 func makeAuditedCreationEvents(
 	values auditedMutationValues, baseline auditedCreationBaseline,
-	created Node, topologyDigest auditRecordHash,
+	created Node, topologyDigest auditRecordHash, metadata *auditedCreationMetadata,
 ) ([]audit.Record, error) {
 	eventCount := 2
 	if !created.IsDir() {
 		eventCount++
 	}
+	if metadata != nil {
+		eventCount++
+	}
 	events := make([]audit.Record, 0, eventCount)
-	for _, kind := range []string{"audit_inherit", "content_create", "node_create"} {
+	for _, kind := range []string{"audit_inherit", "content_create", "node_create", "provenance_add"} {
 		if kind == "content_create" && created.IsDir() {
 			continue
 		}
+		if kind == "provenance_add" && metadata == nil {
+			continue
+		}
 		event, err := makeAuditedCreationEvent(
-			values, baseline, kind, uint64(len(events)), created, topologyDigest,
+			values, baseline, kind, uint64(len(events)), created, topologyDigest, metadata,
 		)
 		if err != nil {
 			return nil, err
@@ -366,6 +374,7 @@ func makeAuditedCreationEvents(
 func makeAuditedCreationEvent(
 	values auditedMutationValues, baseline auditedCreationBaseline, kind string,
 	ordinal uint64, created Node, topologyDigest auditRecordHash,
+	metadata *auditedCreationMetadata,
 ) (audit.Record, error) {
 	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: values.operationID},
@@ -384,6 +393,7 @@ func makeAuditedCreationEvent(
 	}
 	target, pre, post := audit.Absent(), audit.Absent(), audit.Absent()
 	topology, baselineDigest := audit.Absent(), audit.Absent()
+	attachmentKind, attachmentIdentity := audit.Absent(), audit.Absent()
 	switch kind {
 	case "audit_inherit":
 		target, baselineDigest = audit.Unsigned(baseline.nodeID), baseline.digest.value
@@ -394,6 +404,19 @@ func makeAuditedCreationEvent(
 		post = audit.Nested(*baseline.version)
 	case "node_create":
 		post, topology = audit.Nested(baseline.topology), topologyDigest.value
+	case "provenance_add":
+		if metadata == nil {
+			return audit.Record{}, errors.New("provenance-add event lacks attached metadata")
+		}
+		attachmentKind, err = audit.Text(metadata.provenance.Kind)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		identity, identityErr := attachedAuditIdentity(metadata.provenance)
+		if identityErr != nil {
+			return audit.Record{}, identityErr
+		}
+		attachmentIdentity, post = audit.Nested(identity), audit.Nested(metadata.provenance)
 	default:
 		return audit.Record{}, fmt.Errorf("unsupported creation event kind %q", kind)
 	}
@@ -404,8 +427,8 @@ func makeAuditedCreationEvent(
 		{Name: "event_kind", Value: kindValue},
 		{Name: auditScopeIDField, Value: baseline.scopeID},
 		{Name: "target_node_id", Value: target},
-		{Name: "attachment_kind", Value: audit.Absent()},
-		{Name: "attachment_identity", Value: audit.Absent()},
+		{Name: "attachment_kind", Value: attachmentKind},
+		{Name: "attachment_identity", Value: attachmentIdentity},
 		{Name: "source_version_id", Value: audit.Absent()},
 		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
 		{Name: "recorded_at", Value: values.recordedAt},
@@ -425,13 +448,20 @@ func makeAuditedCreationEvent(
 func makeAuditedCreationMutation(
 	values auditedMutationValues, sequence uint64, events []audit.Record,
 	parentChange audit.Record, baseline auditedCreationBaseline,
-	topologyDigest auditRecordHash,
+	topologyDigest auditRecordHash, metadata *auditedCreationMetadata,
 ) audit.Record {
+	groupingID, attachedDigest := audit.Absent(), audit.Absent()
+	var attachedCount uint64
+	if metadata != nil {
+		groupingID = metadata.groupingID
+		attachedCount = uint64(len(metadata.changes))
+		attachedDigest = metadata.deltaDigest.value
+	}
 	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
 		{Name: auditVaultIDField, Value: values.vaultID},
 		{Name: "operation_sequence", Value: audit.Unsigned(sequence)},
 		{Name: auditOperationIDField, Value: values.operationID},
-		{Name: "grouping_id", Value: audit.Absent()},
+		{Name: "grouping_id", Value: groupingID},
 		{Name: "recorded_at", Value: values.recordedAt},
 		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: audit.Absent()},
@@ -443,14 +473,15 @@ func makeAuditedCreationMutation(
 		{Name: "path_effect_digest", Value: audit.Absent()},
 		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "witness_change_digest", Value: audit.Absent()},
-		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
-		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(attachedCount)},
+		{Name: "attached_metadata_change_digest", Value: attachedDigest},
 	}}
 }
 
 func persistAuditedCreationRecords(
 	ctx context.Context, tx *sql.Tx, baseline auditedCreationBaseline,
 	topologyDelta audit.Record, events []audit.Record, mutation audit.Record,
+	metadata *auditedCreationMetadata,
 ) error {
 	operationID, err := auditUUIDField(mutation, auditOperationIDField)
 	if err != nil {
@@ -472,6 +503,11 @@ func persistAuditedCreationRecords(
 	}
 	if err := insertAuditRecord(ctx, tx, topologyDelta); err != nil {
 		return err
+	}
+	if metadata != nil {
+		if err := insertAuditRecord(ctx, tx, metadata.delta); err != nil {
+			return err
+		}
 	}
 	for _, event := range events {
 		wrapper := audit.Record{Kind: auditEventField, Fields: []audit.Field{
@@ -517,6 +553,7 @@ func advanceAuditedCreationScope(
 func makeAuditedCreationAllocationEntry(
 	values auditedMutationValues, sequence, nodeSequence, allocatedNodeID int64,
 	previousHead string, mutationHash, topologyDigest audit.Value,
+	metadata *auditedCreationMetadata,
 ) (audit.Record, error) {
 	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
 	if err != nil {
@@ -534,6 +571,12 @@ func makeAuditedCreationAllocationEntry(
 	if err != nil {
 		return audit.Record{}, err
 	}
+	attachedDigest := audit.Absent()
+	var attachedCount uint64
+	if metadata != nil {
+		attachedDigest = metadata.deltaDigest.value
+		attachedCount = uint64(len(metadata.changes))
+	}
 	return audit.Record{Kind: "allocation_entry", Fields: []audit.Field{
 		{Name: auditVaultIDField, Value: values.vaultID},
 		{Name: "lineage_id", Value: values.lineageID},
@@ -550,8 +593,8 @@ func makeAuditedCreationAllocationEntry(
 		{Name: "has_witness_change", Value: audit.Bool(false)},
 		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "witness_change_digest", Value: audit.Absent()},
-		{Name: "has_attached_metadata_change", Value: audit.Bool(false)},
-		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
-		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+		{Name: "has_attached_metadata_change", Value: audit.Bool(metadata != nil)},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(attachedCount)},
+		{Name: "attached_metadata_change_digest", Value: attachedDigest},
 	}}, nil
 }

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -9,20 +9,26 @@ import (
 )
 
 type replayedNodeCreation struct {
-	childID, parentID uint64
-	childTopology     audit.Record
-	postTopology      []audit.Record
-	childState        audit.Record
-	version           *audit.Record
-	baselineDigest    string
-	topologyDigest    string
-	baseline          storedAuditRecord
+	childID, parentID   uint64
+	childTopology       audit.Record
+	postTopology        []audit.Record
+	childState          audit.Record
+	version             *audit.Record
+	baselineAttachments []audit.Record
+	attachmentChanges   []audit.Record
+	attachmentDigest    string
+	provenance          *audit.Record
+	ingestID            string
+	baselineDigest      string
+	topologyDigest      string
+	baseline            storedAuditRecord
 }
 
 func (replay *auditedHistoryReplay) applyNodeCreation(
 	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
-	baselineRecords, topologyRecords, eventRecords map[string]storedAuditRecord,
-	usedBaselines, usedTopology, usedEvents map[string]bool,
+	baselineRecords, topologyRecords, attachmentRecords,
+	eventRecords map[string]storedAuditRecord,
+	usedBaselines, usedTopology, usedAttachments, usedEvents map[string]bool,
 ) error {
 	sequence := *mutation.index.operationSequence
 	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
@@ -39,14 +45,16 @@ func (replay *auditedHistoryReplay) applyNodeCreation(
 	if err := requireAuditUnsigned(mutation.record, "operation_sequence", auditSequence); err != nil {
 		return err
 	}
-	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
-		return err
-	}
 	creation, err := replay.validateNodeCreationAuthority(
 		vaultID, mutation.record, operationID, baselineRecords, topologyRecords,
 		usedBaselines, usedTopology,
 	)
 	if err != nil {
+		return err
+	}
+	if err := replay.validateNodeCreationAttachedMetadata(
+		mutation.record, operationID, &creation, attachmentRecords, usedAttachments,
+	); err != nil {
 		return err
 	}
 	if err := replay.validateNodeCreationEvents(
@@ -319,9 +327,7 @@ func (replay *auditedHistoryReplay) validateNodeCreationBaseline(
 	if err != nil {
 		return err
 	}
-	if len(attachments) != 0 {
-		return errors.New("direct node creation baseline cannot contain attached metadata")
-	}
+	creation.baselineAttachments = attachments
 	expectedNodes, expectedWitnesses, err := initialBaselineTopology(
 		creation.postTopology, []uint64{creation.childID}, operationID,
 	)
@@ -387,6 +393,9 @@ func (replay *auditedHistoryReplay) validateNodeCreationEvents(
 	expectedKinds := []string{"audit_inherit", "node_create"}
 	if creation.version != nil {
 		expectedKinds = []string{"audit_inherit", "content_create", "node_create"}
+	}
+	if creation.provenance != nil {
+		expectedKinds = append(expectedKinds, "provenance_add")
 	}
 	if len(events) != len(expectedKinds) {
 		return errors.New("node creation has an invalid event set")
@@ -475,12 +484,16 @@ func validateCreationEventWrapper(
 func validateCreationEventPayload(
 	event audit.Record, kind string, creation replayedNodeCreation, topologyDigest string,
 ) error {
-	if err := requireAuditAbsentFields(event,
-		"attachment_kind", "attachment_identity", "source_version_id"); err != nil {
+	if err := requireAuditAbsent(event, "source_version_id"); err != nil {
 		return err
 	}
 	if err := requireAuditAbsent(event, "pre"); err != nil {
 		return err
+	}
+	if kind != "provenance_add" {
+		if err := requireAuditAbsentFields(event, "attachment_kind", "attachment_identity"); err != nil {
+			return err
+		}
 	}
 	switch kind {
 	case "audit_inherit":
@@ -512,6 +525,34 @@ func validateCreationEventPayload(
 			return err
 		}
 		return requireAuditAbsentFields(event, "target_node_id", "baseline_digest")
+	case "provenance_add":
+		if creation.provenance == nil {
+			return errors.New("provenance-add event has no replayed provenance")
+		}
+		post, err := auditNestedField(event, "post")
+		if err != nil {
+			return err
+		}
+		if !auditRecordEqual(post, *creation.provenance) {
+			return errors.New("provenance-add event does not match its attached-metadata delta")
+		}
+		if err := requireAuditText(event, "attachment_kind", metadataProvenanceType); err != nil {
+			return err
+		}
+		identity, err := attachedAuditIdentity(*creation.provenance)
+		if err != nil {
+			return err
+		}
+		storedIdentity, err := auditNestedField(event, "attachment_identity")
+		if err != nil {
+			return err
+		}
+		if !auditRecordEqual(identity, storedIdentity) {
+			return errors.New("provenance-add event identity does not match its post record")
+		}
+		return requireAuditAbsentFields(
+			event, "target_node_id", auditTopologyDeltaField, "baseline_digest",
+		)
 	default:
 		return fmt.Errorf("invalid node creation event kind %q", kind)
 	}
@@ -561,16 +602,36 @@ func validateNodeCreationMutationDigests(
 	if err := requireAuditDigest(mutation, auditTopologyDeltaField, creation.topologyDigest); err != nil {
 		return err
 	}
-	if err := requireAuditAbsentFields(mutation, "path_effect_digest",
-		"witness_change_digest", "attached_metadata_change_digest"); err != nil {
+	if err := requireAuditAbsentFields(
+		mutation, "path_effect_digest", "witness_change_digest",
+	); err != nil {
 		return err
 	}
-	for _, field := range []string{
-		"path_effect_count", auditWitnessChangeCountField, auditAttachedMetadataChangeCountField,
-	} {
+	for _, field := range []string{"path_effect_count", auditWitnessChangeCountField} {
 		if err := requireAuditUnsigned(mutation, field, 0); err != nil {
 			return err
 		}
+	}
+	if creation.provenance == nil {
+		if err := requireAuditAbsentFields(
+			mutation, "grouping_id", "attached_metadata_change_digest",
+		); err != nil {
+			return err
+		}
+		return requireAuditUnsigned(mutation, auditAttachedMetadataChangeCountField, 0)
+	}
+	if err := requireAuditUUID(mutation, "grouping_id", creation.ingestID); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(
+		mutation, "attached_metadata_change_digest", creation.attachmentDigest,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(
+		mutation, auditAttachedMetadataChangeCountField, uint64(len(creation.attachmentChanges)),
+	); err != nil {
+		return err
 	}
 	return nil
 }
@@ -599,7 +660,11 @@ func (replay *auditedHistoryReplay) advanceNodeCreationAllocation(
 		func() error { return requireAuditBool(entry.record, "has_audited_mutation", true) },
 		func() error { return requireAuditBool(entry.record, "has_topology_change", true) },
 		func() error { return requireAuditBool(entry.record, "has_witness_change", false) },
-		func() error { return requireAuditBool(entry.record, "has_attached_metadata_change", false) },
+		func() error {
+			return requireAuditBool(
+				entry.record, "has_attached_metadata_change", creation.provenance != nil,
+			)
+		},
 	}
 	for _, check := range checks {
 		if err := check(); err != nil {
@@ -627,14 +692,31 @@ func (replay *auditedHistoryReplay) advanceNodeCreationAllocation(
 	if err := requireAuditDigest(entry.record, auditTopologyDeltaField, topologyDigest); err != nil {
 		return err
 	}
-	for _, field := range []string{auditWitnessChangeCountField, auditAttachedMetadataChangeCountField} {
-		if err := requireAuditUnsigned(entry.record, field, 0); err != nil {
+	if err := requireAuditUnsigned(entry.record, auditWitnessChangeCountField, 0); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(entry.record, "witness_change_digest"); err != nil {
+		return err
+	}
+	if creation.provenance == nil {
+		if err := requireAuditUnsigned(entry.record, auditAttachedMetadataChangeCountField, 0); err != nil {
 			return err
 		}
-	}
-	if err := requireAuditAbsentFields(entry.record,
-		"witness_change_digest", "attached_metadata_change_digest"); err != nil {
-		return err
+		if err := requireAuditAbsent(entry.record, "attached_metadata_change_digest"); err != nil {
+			return err
+		}
+	} else {
+		if err := requireAuditUnsigned(
+			entry.record, auditAttachedMetadataChangeCountField,
+			uint64(len(creation.attachmentChanges)),
+		); err != nil {
+			return err
+		}
+		if err := requireAuditDigest(
+			entry.record, "attached_metadata_change_digest", creation.attachmentDigest,
+		); err != nil {
+			return err
+		}
 	}
 	replay.allocationCount, replay.allocationHead = nextCount, entry.digest
 	return nil
@@ -674,6 +756,20 @@ func (replay *auditedHistoryReplay) applyNodeCreationState(
 			return fmt.Errorf("created file reuses protected content version %s", versionID)
 		}
 		replay.versions[versionID] = *creation.version
+	}
+	for _, change := range creation.attachmentChanges {
+		post, err := validateAuditedIngestAddition(change)
+		if err != nil {
+			return err
+		}
+		key, err := attachedAuditKey(post)
+		if err != nil {
+			return err
+		}
+		if _, exists := replay.attachments[key]; exists {
+			return fmt.Errorf("audited ingest reuses attached metadata identity %s", post.Kind)
+		}
+		replay.attachments[key] = post
 	}
 	replay.topology = creation.postTopology
 	replay.topologyIndex = make(map[uint64]int, len(replay.topology))

--- a/internal/store/audit_projection.go
+++ b/internal/store/audit_projection.go
@@ -152,24 +152,14 @@ func appendAuditIngests(ctx context.Context, tx metadataQuerier, records *[]audi
 		if err := rows.Scan(&id, &startedAt, &sourceKind, &sourceDesc); err != nil {
 			return fmt.Errorf("scanning audit ingest: %w", err)
 		}
-		idValue, err := audit.UUID(id)
+		record, err := ingestAuditRecord(metadataIngest{
+			Type: metadataIngestType, ID: id, StartedAt: startedAt,
+			SourceKind: sourceKind, SourceDesc: sourceDesc,
+		})
 		if err != nil {
 			return err
 		}
-		startedValue, err := audit.Timestamp(startedAt)
-		if err != nil {
-			return err
-		}
-		kindValue, err := audit.Text(sourceKind)
-		if err != nil {
-			return err
-		}
-		*records = append(*records, audit.Record{Kind: metadataIngestType, Fields: []audit.Field{
-			{Name: "ingest_id", Value: idValue},
-			{Name: "started_at", Value: startedValue},
-			{Name: "source_kind", Value: kindValue},
-			{Name: "source_desc", Value: audit.Bytes([]byte(sourceDesc))},
-		}})
+		*records = append(*records, record)
 	}
 	return rowsError("audit ingests", rows)
 }
@@ -320,6 +310,18 @@ func attachedAuditIdentity(record audit.Record) (audit.Record, error) {
 	default:
 		return audit.Record{}, fmt.Errorf("record kind %q has no attached-metadata identity", record.Kind)
 	}
+}
+
+func attachedAuditKey(record audit.Record) (string, error) {
+	identity, err := attachedAuditIdentity(record)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := audit.Encode(identity)
+	if err != nil {
+		return "", err
+	}
+	return record.Kind + "\x00" + string(encoded), nil
 }
 
 func auditRecordsForNodes(records []audit.Record, members map[uint64]bool) ([]audit.Record, error) {

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -8,29 +8,68 @@ import (
 	"path/filepath"
 )
 
-// BeginIngest records the start of an ingest run and returns its ID.
-func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) (string, error) {
+// IngestRun identifies one logical import and carries the immutable metadata
+// that is published with its first imported file. Holding a run grants no
+// metadata authority by itself.
+type IngestRun struct {
+	record metadataIngest
+}
+
+// ID returns the stable ingest identity.
+func (r IngestRun) ID() string { return r.record.ID }
+
+// BeginIngest prepares an authority-free ingest run. Its metadata is inserted
+// atomically with the first file that actually imports, so audited vaults never
+// contain a run whose provenance was committed in a separate transaction.
+func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) (IngestRun, error) {
+	if err := ctx.Err(); err != nil {
+		return IngestRun{}, err
+	}
 	id, err := newUUIDv4()
 	if err != nil {
-		return "", fmt.Errorf("allocating ingest id: %w", err)
+		return IngestRun{}, fmt.Errorf("allocating ingest id: %w", err)
 	}
-	startedAt := nowRFC3339()
-	if err := validateIngestRecord(metadataIngest{
-		Type: metadataIngestType, ID: id, StartedAt: startedAt,
+	record := metadataIngest{
+		Type: metadataIngestType, ID: id, StartedAt: nowRFC3339(),
 		SourceKind: sourceKind, SourceDesc: sourceDesc,
-	}); err != nil {
-		return "", fmt.Errorf("validating ingest start: %w", err)
 	}
-	err = s.withLogicalTx(ctx, func(tx *sql.Tx) error {
-		_, execErr := tx.ExecContext(ctx,
-			`INSERT INTO ingests (id, started_at, source_kind, source_desc) VALUES (?, ?, ?, ?)`,
-			id, startedAt, sourceKind, sourceDesc)
-		return execErr
-	})
+	if err := validateIngestRecord(record); err != nil {
+		return IngestRun{}, fmt.Errorf("validating ingest start: %w", err)
+	}
+	return IngestRun{record: record}, nil
+}
+
+// ensureIngestRunTx publishes run once and rejects any identity collision with
+// different immutable fields. The returned boolean reports whether this
+// transaction inserted the record.
+func ensureIngestRunTx(ctx context.Context, tx *sql.Tx, run IngestRun) (bool, error) {
+	if err := validateIngestRecord(run.record); err != nil {
+		return false, fmt.Errorf("validating ingest run: %w", err)
+	}
+	result, err := tx.ExecContext(ctx,
+		`INSERT OR IGNORE INTO ingests (id, started_at, source_kind, source_desc)
+		 VALUES (?, ?, ?, ?)`,
+		run.record.ID, run.record.StartedAt, run.record.SourceKind, run.record.SourceDesc)
 	if err != nil {
-		return "", fmt.Errorf("recording ingest start: %w", err)
+		return false, fmt.Errorf("recording ingest run: %w", err)
 	}
-	return id, nil
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("checking ingest run insertion: %w", err)
+	}
+	stored := metadataIngest{Type: metadataIngestType}
+	if err := tx.QueryRowContext(ctx,
+		`SELECT id,started_at,source_kind,source_desc FROM ingests WHERE id=?`,
+		run.record.ID).Scan(
+		&stored.ID, &stored.StartedAt, &stored.SourceKind, &stored.SourceDesc,
+	); err != nil {
+		return false, fmt.Errorf("reading ingest run %s: %w", run.record.ID, err)
+	}
+	if stored.ID != run.record.ID || stored.StartedAt != run.record.StartedAt ||
+		stored.SourceKind != run.record.SourceKind || stored.SourceDesc != run.record.SourceDesc {
+		return false, fmt.Errorf("ingest identity %s names different immutable metadata", run.record.ID)
+	}
+	return inserted == 1, nil
 }
 
 // resolveIngestNameTx applies the import idempotency rule: a live suffix
@@ -150,17 +189,20 @@ func sameOriginTx(tx *sql.Tx, nodeID int64, name string, allowUnknown bool) (boo
 // IngestFile imports one already-durable blob as a node under parentID,
 // applying the idempotency rule and recording provenance. Returns
 // added=false when the content is already present under a candidate name.
-func (s *Store) IngestFile(ctx context.Context, ingestID string, parentID int64, name, blobHash string, size int64, mimeType, originalPath, originalMtime string) (Node, bool, error) {
+func (s *Store) IngestFile(ctx context.Context, run IngestRun, parentID int64, name, blobHash string, size int64, mimeType, originalPath, originalMtime string) (Node, bool, error) {
 	name, err := NormalizeName(name)
 	if err != nil {
 		return Node{}, false, err
+	}
+	if err := validateIngestRecord(run.record); err != nil {
+		return Node{}, false, fmt.Errorf("validating ingest run: %w", err)
 	}
 	var recordedMtime *string
 	if originalMtime != "" {
 		recordedMtime = &originalMtime
 	}
 	provenance := metadataProvenance{
-		Type: metadataProvenanceType, NodeID: 1, IngestID: ingestID,
+		Type: metadataProvenanceType, NodeID: 1, IngestID: run.record.ID,
 		OriginalPath: originalPath, OriginalMTime: recordedMtime,
 	}
 	if err := validateProvenanceFields(provenance); err != nil {
@@ -170,7 +212,7 @@ func (s *Store) IngestFile(ctx context.Context, ingestID string, parentID int64,
 		created Node
 		added   bool
 	)
-	err = s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		finalName, existingID, skip, err := resolveIngestNameTx(tx, parentID, name, blobHash)
 		if err != nil {
 			return err
@@ -183,7 +225,37 @@ func (s *Store) IngestFile(ctx context.Context, ingestID string, parentID int64,
 			}
 			return nil
 		}
-		created, err = s.createFileTx(tx, parentID, finalName, blobHash, size, mimeType)
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		var (
+			authority auditAuthorityState
+			scopes    []auditScopeState
+			prior     Node
+		)
+		if active {
+			prior, err = liveDirTx(tx, parentID)
+			if err != nil {
+				return err
+			}
+			authority, scopes, _, err = loadAuditedNodeAuthority(ctx, tx, parentID)
+			if err != nil {
+				return err
+			}
+		}
+		ingestAdded, err := ensureIngestRunTx(ctx, tx, run)
+		if err != nil {
+			return err
+		}
+		operation, err := newContentVersionOperation()
+		if err != nil {
+			return err
+		}
+		var version ContentVersion
+		created, version, err = s.createFileWithOperationTx(
+			tx, parentID, finalName, blobHash, size, mimeType, operation,
+		)
 		if err != nil {
 			return err
 		}
@@ -202,6 +274,24 @@ func (s *Store) IngestFile(ctx context.Context, ingestID string, parentID int64,
 			provenance.Identity, provenance.NodeID, provenance.IngestID,
 			provenance.OriginalPath, provenance.OriginalMTime, provenance.Supersedes); err != nil {
 			return fmt.Errorf("recording provenance for %q: %w", finalName, err)
+		}
+		if active {
+			resultingParent, err := nodeByIDTx(tx, parentID)
+			if err != nil {
+				return err
+			}
+			metadata, err := makeAuditedIngestCreationMetadata(
+				run.record, provenance, ingestAdded, operation.operationID,
+			)
+			if err != nil {
+				return err
+			}
+			if err := persistAuditedNodeCreation(
+				ctx, tx, s.vaultID, authority, scopes, prior, resultingParent,
+				created, version, operation.operationID, operation.recordedAt, &metadata,
+			); err != nil {
+				return err
+			}
 		}
 		added = true
 		return nil

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -88,7 +88,7 @@ func TestIngestFileRecordsProvenance(t *testing.T) {
 
 	ing, err := s.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
-	require.NoError(t, validateUUIDv4(ing))
+	require.NoError(t, validateUUIDv4(ing.ID()))
 	n, added, err := s.IngestFile(ctx, ing, s.RootID(),
 		"a.txt", fakeHash("a1"), 1, "text/plain", "/orig/a.txt", "2026-01-02T03:04:05Z")
 	require.NoError(t, err)
@@ -107,9 +107,9 @@ func TestIngestFileRecordsProvenance(t *testing.T) {
 	require.NoError(t, s.db.QueryRow(
 		`SELECT ingest_id FROM provenance WHERE node_id = ?`, n.ID,
 	).Scan(&storedIngestID))
-	assert.Equal(t, ing, storedIngestID)
+	assert.Equal(t, ing.ID(), storedIngestID)
 	wantIdentity, err := provenanceIdentity(metadataProvenance{
-		Type: metadataProvenanceType, NodeID: n.ID, IngestID: ing,
+		Type: metadataProvenanceType, NodeID: n.ID, IngestID: ing.ID(),
 		OriginalPath: origPath, OriginalMTime: &origMtime,
 	})
 	require.NoError(t, err)
@@ -125,13 +125,13 @@ func TestIngestAndProvenanceFactsAreImmutable(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 
-	_, err = s.db.Exec(`UPDATE ingests SET source_desc='rewritten' WHERE id=?`, ingestID)
+	_, err = s.db.Exec(`UPDATE ingests SET source_desc='rewritten' WHERE id=?`, ingestID.ID())
 	require.ErrorContains(t, err, "ingest records are immutable")
 	_, err = s.db.Exec(`UPDATE provenance SET original_path='/rewritten' WHERE node_id=?`, node.ID)
 	require.ErrorContains(t, err, "provenance records are immutable")
 
 	var sourceDesc, originalPath string
-	require.NoError(t, s.db.QueryRow(`SELECT source_desc FROM ingests WHERE id=?`, ingestID).Scan(&sourceDesc))
+	require.NoError(t, s.db.QueryRow(`SELECT source_desc FROM ingests WHERE id=?`, ingestID.ID()).Scan(&sourceDesc))
 	require.NoError(t, s.db.QueryRow(`SELECT original_path FROM provenance WHERE node_id=?`, node.ID).Scan(&originalPath))
 	assert.Equal(t, "source", sourceDesc)
 	assert.Equal(t, "/source/a.txt", originalPath)
@@ -152,7 +152,7 @@ func TestIngestIdempotencyUsesActiveProvenanceLeaf(t *testing.T) {
 		`SELECT identity FROM provenance WHERE node_id=?`, node.ID,
 	).Scan(&priorIdentity))
 	corrected := metadataProvenance{
-		Type: metadataProvenanceType, NodeID: node.ID, IngestID: ingestID,
+		Type: metadataProvenanceType, NodeID: node.ID, IngestID: ingestID.ID(),
 		OriginalPath: "/corrected/renamed.pdf", Supersedes: &priorIdentity,
 	}
 	corrected.Identity, err = provenanceIdentity(corrected)
@@ -188,9 +188,9 @@ func TestBeginIngestAllocatesDistinctUUIDs(t *testing.T) {
 	second, err := s.BeginIngest(t.Context(), "cli", "second")
 	require.NoError(t, err)
 
-	require.NoError(t, validateUUIDv4(first))
-	require.NoError(t, validateUUIDv4(second))
-	assert.NotEqual(t, first, second)
+	require.NoError(t, validateUUIDv4(first.ID()))
+	require.NoError(t, validateUUIDv4(second.ID()))
+	assert.NotEqual(t, first.ID(), second.ID())
 }
 
 func TestIngestRejectsNonUTF8MetadataBeforeCommit(t *testing.T) {

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -161,7 +161,7 @@ CREATE TABLE IF NOT EXISTS audit_records (
         'enrollment_baseline', 'topology_genesis',
         'attached_metadata_genesis', 'event', 'canonical_mutation',
         'scope_chain_entry', 'allocation_genesis', 'allocation_entry',
-        'topology_delta'
+        'topology_delta', 'attached_metadata_delta'
     )),
     operation_id       TEXT,
     operation_sequence INTEGER CHECK (operation_sequence IS NULL OR operation_sequence > 0),

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -78,7 +78,7 @@ func (s *Store) Mkdir(ctx context.Context, parentID int64, name string) (Node, e
 			return err
 		}
 		return persistAuditedNodeCreation(ctx, tx, s.vaultID, authority, scopes,
-			priorParent, resultingParent, created, ContentVersion{}, operationID, recordedAt)
+			priorParent, resultingParent, created, ContentVersion{}, operationID, recordedAt, nil)
 	})
 	if err != nil {
 		return Node{}, err
@@ -303,7 +303,7 @@ func (s *Store) CreateFile(ctx context.Context, parentID int64, name, blobHash s
 		}
 		return persistAuditedNodeCreation(ctx, tx, s.vaultID, authority, scopes,
 			priorParent, resultingParent, created, version, operation.operationID,
-			operation.recordedAt)
+			operation.recordedAt, nil)
 	})
 	if err != nil {
 		return Node{}, err


### PR DESCRIPTION
Audited vaults can record direct child creation, but their primary filesystem import path still had to fail closed because ingest identity, file creation, and provenance were separate metadata mutations. Accepting that split would make protected history unable to prove the source fact that introduced a document.

This keeps an ingest run authority-free until a file actually imports, then commits the file, initial version, sticky membership, immutable ingest/provenance facts, and canonical attached-metadata delta as one Go-owned transaction. Independent replay reconstructs the attached facts during JSONL import and verification rather than trusting the writer’s projections. Idempotent repeats remain non-mutating, and a failed audit advance rolls back the file and its source metadata together.

The change extends the existing audited node-creation writer instead of introducing a parallel record builder. It does not expose unfinished audit controls or advertise internal capability in the user documentation. The CGO and pure-Go suites, focused race coverage, lint, and strict documentation build are green.

Kata: 9j5e.