### PR TITLE
Record audited content reverts

### DIFF
--- a/internal/store/audit_content_replace.go
+++ b/internal/store/audit_content_replace.go
@@ -33,10 +33,20 @@ func auditAuthorityActiveTx(ctx context.Context, tx *sql.Tx) (bool, error) {
 	return active, nil
 }
 
-func replaceAuditedContentTx(
+func installAuditedContentVersionTx(
 	ctx context.Context, tx *sql.Tx, store *Store, node Node,
-	blobHash string, size int64, mimeType string,
+	blobHash string, size int64, mimeType, transitionKind string, sourceVersionID *string,
 ) (Node, ContentVersion, error) {
+	if transitionKind != "content_replace" && transitionKind != "content_revert" {
+		return Node{}, ContentVersion{}, fmt.Errorf(
+			"unsupported audited content transition %q", transitionKind,
+		)
+	}
+	if (transitionKind == "content_revert") != (sourceVersionID != nil) {
+		return Node{}, ContentVersion{}, fmt.Errorf(
+			"audited %s has inconsistent source-version authority", transitionKind,
+		)
+	}
 	authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, node.ID)
 	if err != nil {
 		return Node{}, ContentVersion{}, err
@@ -56,12 +66,12 @@ func replaceAuditedContentTx(
 		return Node{}, ContentVersion{}, fmt.Errorf("reading audited prior content: %w", err)
 	}
 	updated, version, err := installContentVersionWithOperationTx(
-		tx, node, blobHash, size, mimeType, "content_replace", nil, operation,
+		tx, node, blobHash, size, mimeType, transitionKind, sourceVersionID, operation,
 	)
 	if err != nil {
 		return Node{}, ContentVersion{}, err
 	}
-	if err := persistAuditedContentReplacement(
+	if err := persistAuditedContentTransition(
 		ctx, tx, store.vaultID, nodeSequence, authority, scopes,
 		node, updated, prior, version,
 	); err != nil {
@@ -126,7 +136,7 @@ func nextAuditInteger(name string, value int64) (int64, error) {
 	return value + 1, nil
 }
 
-func persistAuditedContentReplacement(
+func persistAuditedContentTransition(
 	ctx context.Context, tx *sql.Tx, vaultID string, nodeSequence int64,
 	authority auditAuthorityState, scopes []auditScopeState,
 	priorNode, resultingNode Node, priorVersion, resultingVersion ContentVersion,
@@ -152,7 +162,7 @@ func persistAuditedContentReplacement(
 	}
 	events := make([]audit.Record, len(scopes))
 	for index, scope := range scopes {
-		events[index], err = makeAuditedContentReplacementEvent(
+		events[index], err = makeAuditedContentTransitionEvent(
 			values, scope.scopeID, uint64(index), priorNode, resultingNode,
 			priorRecord, resultingRecord,
 		)
@@ -164,7 +174,7 @@ func persistAuditedContentReplacement(
 	if err != nil {
 		return err
 	}
-	mutation, err := makeAuditedContentReplacementMutation(
+	mutation, err := makeAuditedContentTransitionMutation(
 		values, operationSequence, events, change,
 	)
 	if err != nil {
@@ -258,7 +268,7 @@ func makeAuditedMutationValues(
 	for _, item := range constructors {
 		value, err := item.make(item.value)
 		if err != nil {
-			return values, fmt.Errorf("encoding audited content replacement %s: %w", item.name, err)
+			return values, fmt.Errorf("encoding audited content transition %s: %w", item.name, err)
 		}
 		*item.out = value
 	}
@@ -282,13 +292,13 @@ func auditRecordForContentVersion(version ContentVersion) (audit.Record, error) 
 	)
 }
 
-func makeAuditedContentReplacementEvent(
+func makeAuditedContentTransitionEvent(
 	values auditedMutationValues, scopeID string, ordinal uint64,
 	priorNode, resultingNode Node, priorVersion, resultingVersion audit.Record,
 ) (audit.Record, error) {
 	nodeID, err := positiveAuditNodeID(priorNode.ID)
 	if err != nil || resultingNode.ID != priorNode.ID {
-		return audit.Record{}, errors.New("audited content replacement changes node identity")
+		return audit.Record{}, errors.New("audited content transition changes node identity")
 	}
 	priorRevision, err := positiveAuditRevision(priorNode.Revision)
 	if err != nil {
@@ -296,15 +306,36 @@ func makeAuditedContentReplacementEvent(
 	}
 	resultingRevision, err := positiveAuditRevision(resultingNode.Revision)
 	if err != nil || resultingRevision != priorRevision+1 {
-		return audit.Record{}, errors.New("audited content replacement has an invalid revision transition")
+		return audit.Record{}, errors.New("audited content operation has an invalid revision transition")
 	}
 	scopeValue, err := audit.UUID(scopeID)
 	if err != nil {
 		return audit.Record{}, err
 	}
-	eventKind, err := audit.Text("content_replace")
+	transitionKind, err := auditTextField(resultingVersion, "transition_kind")
 	if err != nil {
 		return audit.Record{}, err
+	}
+	sourceVersionID, err := auditOptionalUUIDField(resultingVersion, "source_version_id")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	if (transitionKind == "content_revert") != (sourceVersionID != nil) ||
+		(transitionKind != "content_replace" && transitionKind != "content_revert") {
+		return audit.Record{}, fmt.Errorf(
+			"audited %s has inconsistent source-version authority", transitionKind,
+		)
+	}
+	eventKind, err := audit.Text(transitionKind)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	sourceVersion := audit.Absent()
+	if sourceVersionID != nil {
+		sourceVersion, err = audit.UUID(*sourceVersionID)
+		if err != nil {
+			return audit.Record{}, err
+		}
 	}
 	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: values.operationID},
@@ -330,7 +361,7 @@ func makeAuditedContentReplacementEvent(
 		{Name: "target_node_id", Value: audit.Absent()},
 		{Name: "attachment_kind", Value: audit.Absent()},
 		{Name: "attachment_identity", Value: audit.Absent()},
-		{Name: "source_version_id", Value: audit.Absent()},
+		{Name: "source_version_id", Value: sourceVersion},
 		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
 		{Name: "recorded_at", Value: values.recordedAt},
 		{Name: "prior_node_revision", Value: audit.Unsigned(priorRevision)},
@@ -387,7 +418,7 @@ func positiveAuditRevision(value int64) (uint64, error) {
 	return positiveAuditInteger("content revision", value)
 }
 
-func makeAuditedContentReplacementMutation(
+func makeAuditedContentTransitionMutation(
 	values auditedMutationValues, sequence int64,
 	events []audit.Record, change audit.Record,
 ) (audit.Record, error) {

--- a/internal/store/audit_content_replace_test.go
+++ b/internal/store/audit_content_replace_test.go
@@ -62,7 +62,140 @@ func TestAuditedContentReplacementAdvancesPortableAuthority(t *testing.T) {
 	assert.Equal(t, version.ID, versions[0].ID)
 }
 
-func TestAuditedContentReplacementChainsMultipleOperations(t *testing.T) {
+func TestAuditedContentRevertAdvancesPortableAuthority(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	scope, err := source.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, source, scope.ID)
+	file, err := source.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+
+	updated, version, revertedFrom, err := source.RevertContent(
+		t.Context(), file.ID, file.Revision, metadataVersionOld,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, file.Revision+1, updated.Revision)
+	assert.Equal(t, version.ID, updated.CurrentVersionID)
+	assert.Equal(t, "content_revert", version.TransitionKind)
+	require.NotNil(t, version.SourceVersionID)
+	assert.Equal(t, metadataVersionOld, *version.SourceVersionID)
+	assert.Equal(t, metadataVersionOld, revertedFrom.ID)
+	assert.Equal(t, revertedFrom.BlobHash, version.BlobHash)
+	assert.Equal(t, revertedFrom.Size, version.Size)
+	assert.Equal(t, revertedFrom.MimeType, version.MimeType)
+
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+
+	authority, auditScope, err := loadInitialAuditProjection(t.Context(), source.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), source.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, auditScope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, auditScope, initial)
+	require.NoError(t, err)
+	mutations, err := auditRecordsBySequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	events, err := auditRecordListField(mutations[2].record, "events")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	post, err := auditNestedField(events[0], "post")
+	require.NoError(t, err)
+	nodeID, err := auditUnsignedField(events[0], metadataNodeIDField)
+	require.NoError(t, err)
+	priorRevision, err := auditUnsignedField(replay.states[nodeID], "node_revision")
+	require.NoError(t, err)
+	priorVersionID, err := auditUUIDField(replay.versions[metadataVersionCurrent], "version_id")
+	require.NoError(t, err)
+	require.NoError(t, replay.validateContentTransitionSource(
+		events[0], post, "content_revert", nodeID, priorVersionID, priorRevision,
+	))
+	tamperedPost, err := replaceAuditRecordField(
+		post, "blob_hash", mustAuditDigest(t, fakeHash("deadbeef")),
+	)
+	require.NoError(t, err)
+	require.ErrorContains(t, replay.validateContentTransitionSource(
+		events[0], tamperedPost, "content_revert", nodeID, priorVersionID, priorRevision,
+	), "bytes do not match")
+}
+
+func TestAuditedVaultRejectsRevertOutsideScope(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	outside, err := s.CreateFile(
+		t.Context(), empty.ID, "outside.txt", fakeHash("aa11"), 11, "text/plain",
+	)
+	require.NoError(t, err)
+	priorVersionID := outside.CurrentVersionID
+	outside, _, err = s.ReplaceContent(
+		t.Context(), outside.ID, outside.Revision, fakeHash("bb22"), 12, "text/plain",
+	)
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+
+	revertedNode, revertedVersion, revertedSource, err := s.RevertContent(
+		t.Context(), outside.ID, outside.Revision, priorVersionID,
+	)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	assert.Zero(t, revertedNode)
+	assert.Zero(t, revertedVersion)
+	assert.Zero(t, revertedSource)
+	unchanged, err := s.NodeByID(t.Context(), outside.ID)
+	require.NoError(t, err)
+	assert.Equal(t, outside, unchanged)
+}
+
+func TestAuditedContentRevertRollsBackWholeOperation(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	file, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_audit_revert_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audit revert failure'); END`)
+	require.NoError(t, err)
+
+	revertedNode, revertedVersion, revertedSource, err := s.RevertContent(
+		t.Context(), file.ID, file.Revision, metadataVersionOld,
+	)
+	require.ErrorContains(t, err, "forced audit revert failure")
+	assert.Zero(t, revertedNode)
+	assert.Zero(t, revertedVersion)
+	assert.Zero(t, revertedSource)
+	unchanged, err := s.NodeByID(t.Context(), file.ID)
+	require.NoError(t, err)
+	assert.Equal(t, file, unchanged)
+	var versions, records int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM content_versions WHERE node_id=?),
+		(SELECT COUNT(*) FROM audit_records)`, file.ID).Scan(&versions, &records))
+	assert.Equal(t, int64(2), versions)
+	assert.Equal(t, int64(8), records)
+}
+
+func TestAuditedContentTransitionsChainMultipleOperations(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
@@ -73,6 +206,7 @@ func TestAuditedContentReplacementChainsMultipleOperations(t *testing.T) {
 	file, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
 	require.NoError(t, err)
 
+	var firstReplacementID string
 	for index, replacement := range []struct {
 		hash string
 		size int64
@@ -81,19 +215,31 @@ func TestAuditedContentReplacementChainsMultipleOperations(t *testing.T) {
 		{fakeHash("d4"), 14, "text/markdown"},
 		{fakeHash("e5"), 23, "application/pdf"},
 	} {
-		file, _, err = s.ReplaceContent(
+		var version ContentVersion
+		file, version, err = s.ReplaceContent(
 			t.Context(), file.ID, file.Revision,
 			replacement.hash, replacement.size, replacement.mime,
 		)
 		require.NoError(t, err, index)
+		if index == 0 {
+			firstReplacementID = version.ID
+		}
 	}
+	file, reverted, source, err := s.RevertContent(
+		t.Context(), file.ID, file.Revision, firstReplacementID,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, firstReplacementID, source.ID)
+	require.NotNil(t, reverted.SourceVersionID)
+	assert.Equal(t, firstReplacementID, *reverted.SourceVersionID)
+	assert.Equal(t, reverted.ID, file.CurrentVersionID)
 
 	var sequence, records int64
 	require.NoError(t, s.db.QueryRow(`SELECT
 		(SELECT operation_sequence_high_water FROM audit_authority),
 		(SELECT COUNT(*) FROM audit_records)`).Scan(&sequence, &records))
-	assert.Equal(t, int64(3), sequence)
-	assert.Equal(t, int64(16), records)
+	assert.Equal(t, int64(4), sequence)
+	assert.Equal(t, int64(20), records)
 	require.NoError(t, s.ExportMetadata(t.Context(), &bytes.Buffer{}))
 }
 

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -258,7 +258,7 @@ func validateAuditedHistory(
 			return fmt.Errorf("validating audit operation %d: %w", sequence, bindingErr)
 		}
 		if len(bindings) == 0 {
-			err = replay.applyContentReplacement(
+			err = replay.applyContentTransition(
 				vaultID, mutation, allocations[sequence], entries[sequence], events, usedEvents,
 			)
 		} else {
@@ -502,7 +502,7 @@ func auditEventRecordsByID(records []storedAuditRecord) (map[string]storedAuditR
 	return result, nil
 }
 
-func (replay *auditedHistoryReplay) applyContentReplacement(
+func (replay *auditedHistoryReplay) applyContentTransition(
 	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
 	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
 ) error {
@@ -529,15 +529,15 @@ func (replay *auditedHistoryReplay) applyContentReplacement(
 		return err
 	}
 	if len(events) != 1 {
-		return errors.New("content-replacement mutation must contain one scope event")
+		return errors.New("content mutation must contain one scope event")
 	}
-	nodeID, postVersion, err := replay.validateContentReplacementEvent(
+	nodeID, postVersion, err := replay.validateContentTransitionEvent(
 		operationID, mutation.record, events[0], eventRecords, usedEvents,
 	)
 	if err != nil {
 		return err
 	}
-	if err := replay.validateContentReplacementStateChange(mutation.record, nodeID, postVersion); err != nil {
+	if err := replay.validateContentTransitionStateChange(mutation.record, nodeID, postVersion); err != nil {
 		return err
 	}
 	baselines, err := auditRecordListField(mutation.record, "baselines")
@@ -545,7 +545,7 @@ func (replay *auditedHistoryReplay) applyContentReplacement(
 		return err
 	}
 	if len(baselines) != 0 {
-		return errors.New("content replacement cannot bind an enrollment baseline")
+		return errors.New("content mutation cannot bind an enrollment baseline")
 	}
 	if err := requireNoChangeMutationFields(mutation.record); err != nil {
 		return err
@@ -558,10 +558,10 @@ func (replay *auditedHistoryReplay) applyContentReplacement(
 	); err != nil {
 		return err
 	}
-	return replay.applyContentReplacementState(nodeID, postVersion, mutation.record)
+	return replay.applyContentTransitionState(nodeID, postVersion, mutation.record)
 }
 
-func (replay *auditedHistoryReplay) validateContentReplacementEvent(
+func (replay *auditedHistoryReplay) validateContentTransitionEvent(
 	operationID string, mutation, event audit.Record,
 	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
 ) (uint64, audit.Record, error) {
@@ -571,11 +571,11 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 	}
 	wrapper, ok := eventRecords[eventID]
 	if !ok || usedEvents[eventID] {
-		return 0, audit.Record{}, errors.New("content replacement lacks one unique event wrapper")
+		return 0, audit.Record{}, errors.New("content mutation lacks one unique event wrapper")
 	}
 	wrapped, err := auditNestedField(wrapper.record, auditEventField)
 	if err != nil || !auditRecordEqual(wrapped, event) {
-		return 0, audit.Record{}, errors.New("content replacement event wrapper does not match mutation")
+		return 0, audit.Record{}, errors.New("content event wrapper does not match mutation")
 	}
 	usedEvents[eventID] = true
 	identityOperation, err := audit.UUID(operationID)
@@ -590,15 +590,21 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 		return 0, audit.Record{}, err
 	}
 	if eventID != identity.text {
-		return 0, audit.Record{}, errors.New("content replacement event identity does not match its operation")
+		return 0, audit.Record{}, errors.New("content event identity does not match its operation")
 	}
 	nodeID, err := auditUnsignedField(event, metadataNodeIDField)
 	if err != nil || !replay.memberSet[nodeID] {
-		return 0, audit.Record{}, fmt.Errorf("content replacement targets unaudited node %d", nodeID)
+		return 0, audit.Record{}, fmt.Errorf("content mutation targets unaudited node %d", nodeID)
+	}
+	eventKind, err := auditTextField(event, "event_kind")
+	if err != nil {
+		return 0, audit.Record{}, err
+	}
+	if eventKind != "content_replace" && eventKind != "content_revert" {
+		return 0, audit.Record{}, fmt.Errorf("unsupported audited content event %q", eventKind)
 	}
 	checks := []func() error{
 		func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
-		func() error { return requireAuditText(event, "event_kind", "content_replace") },
 		func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
 		func() error { return requireAuditUnsigned(event, "event_ordinal", 0) },
 	}
@@ -608,7 +614,7 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 		}
 	}
 	if err := requireAuditAbsentFields(event, "target_node_id", "attachment_kind",
-		"attachment_identity", "source_version_id", auditTopologyDeltaField, "baseline_digest"); err != nil {
+		"attachment_identity", auditTopologyDeltaField, "baseline_digest"); err != nil {
 		return 0, audit.Record{}, err
 	}
 	if err := requireMatchingEventEnvelope(mutation, event); err != nil {
@@ -634,7 +640,7 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 	}
 	pre, err := auditNestedField(event, "pre")
 	if err != nil || !auditRecordEqual(pre, replay.versions[*priorVersionID]) {
-		return 0, audit.Record{}, errors.New("content replacement pre-version does not match replayed head")
+		return 0, audit.Record{}, errors.New("content pre-version does not match replayed head")
 	}
 	post, err := auditNestedField(event, "post")
 	if err != nil {
@@ -645,7 +651,7 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 		return 0, audit.Record{}, err
 	}
 	if _, exists := replay.versions[postVersionID]; exists {
-		return 0, audit.Record{}, errors.New("content replacement reuses a version identity")
+		return 0, audit.Record{}, errors.New("content mutation reuses a version identity")
 	}
 	if err := requireAuditUnsigned(post, metadataNodeIDField, nodeID); err != nil {
 		return 0, audit.Record{}, err
@@ -656,10 +662,12 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 	if err := requireAuditUUID(post, "introduced_operation_id", operationID); err != nil {
 		return 0, audit.Record{}, err
 	}
-	if err := requireAuditText(post, "transition_kind", "content_replace"); err != nil {
+	if err := requireAuditText(post, "transition_kind", eventKind); err != nil {
 		return 0, audit.Record{}, err
 	}
-	if err := requireAuditAbsent(post, "source_version_id"); err != nil {
+	if err := replay.validateContentTransitionSource(
+		event, post, eventKind, nodeID, *priorVersionID, priorRevision,
+	); err != nil {
 		return 0, audit.Record{}, err
 	}
 	postTime, err := auditField(post, "recorded_at")
@@ -668,7 +676,7 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 	}
 	mutationTime, err := auditField(mutation, "recorded_at")
 	if err != nil || !equalAuditEnvelopeValue(postTime, mutationTime) {
-		return 0, audit.Record{}, errors.New("content replacement version time does not match its mutation")
+		return 0, audit.Record{}, errors.New("content version time does not match its mutation")
 	}
 	if err := requireAuditOptionalUUID(event, "resulting_current_version_id", &postVersionID); err != nil {
 		return 0, audit.Record{}, err
@@ -676,7 +684,73 @@ func (replay *auditedHistoryReplay) validateContentReplacementEvent(
 	return nodeID, post, nil
 }
 
-func (replay *auditedHistoryReplay) validateContentReplacementStateChange(
+func (replay *auditedHistoryReplay) validateContentTransitionSource(
+	event, post audit.Record, eventKind string,
+	nodeID uint64, priorVersionID string, priorRevision uint64,
+) error {
+	eventSourceID, err := auditOptionalUUIDField(event, "source_version_id")
+	if err != nil {
+		return err
+	}
+	postSourceID, err := auditOptionalUUIDField(post, "source_version_id")
+	if err != nil {
+		return err
+	}
+	if eventKind == "content_replace" {
+		if eventSourceID != nil || postSourceID != nil {
+			return errors.New("content replacement carries a revert source")
+		}
+		return nil
+	}
+	if eventSourceID == nil || postSourceID == nil || *eventSourceID != *postSourceID {
+		return errors.New("content revert event and version do not share one source")
+	}
+	if *eventSourceID == priorVersionID {
+		return errors.New("content revert source is already the current head")
+	}
+	source, ok := replay.versions[*eventSourceID]
+	if !ok {
+		return fmt.Errorf("content revert references missing source version %s", *eventSourceID)
+	}
+	if err := requireAuditUnsigned(source, metadataNodeIDField, nodeID); err != nil {
+		return errors.New("content revert source belongs to another node")
+	}
+	sourceRevision, err := auditUnsignedField(source, "node_revision")
+	if err != nil {
+		return err
+	}
+	if sourceRevision >= priorRevision+1 {
+		return errors.New("content revert source is not older than the resulting revision")
+	}
+	sourceHash, err := auditDigestField(source, "blob_hash")
+	if err != nil {
+		return err
+	}
+	if err := requireAuditDigest(post, "blob_hash", sourceHash); err != nil {
+		return errors.New("content revert bytes do not match its source")
+	}
+	sourceSize, err := auditUnsignedField(source, "size")
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(post, "size", sourceSize); err != nil {
+		return errors.New("content revert size does not match its source")
+	}
+	sourceMIME, err := auditField(source, "media_type")
+	if err != nil {
+		return err
+	}
+	postMIME, err := auditField(post, "media_type")
+	if err != nil {
+		return err
+	}
+	if !equalAuditEnvelopeValue(sourceMIME, postMIME) {
+		return errors.New("content revert MIME type does not match its source")
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) validateContentTransitionStateChange(
 	mutation audit.Record, nodeID uint64, postVersion audit.Record,
 ) error {
 	changes, err := auditRecordListField(mutation, "member_state_changes")
@@ -684,7 +758,7 @@ func (replay *auditedHistoryReplay) validateContentReplacementStateChange(
 		return err
 	}
 	if len(changes) != 1 {
-		return errors.New("content replacement must contain one member-state change")
+		return errors.New("content mutation must contain one member-state change")
 	}
 	state := replay.states[nodeID]
 	priorRevision, err := auditUnsignedField(state, "node_revision")
@@ -720,7 +794,7 @@ func (replay *auditedHistoryReplay) advanceScope(
 ) error {
 	nextCount := replay.scopeEntryCount + 1
 	if entry.index.entryCount == nil || *entry.index.entryCount != nextCount {
-		return errors.New("content replacement scope entry is out of order")
+		return errors.New("content mutation scope entry is out of order")
 	}
 	if err := requireAuditUUID(entry.record, auditVaultIDField, vaultID); err != nil {
 		return err
@@ -752,7 +826,7 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 		return err
 	}
 	if entry.index.operationSequence == nil || *entry.index.operationSequence != nextCount {
-		return errors.New("content replacement allocation entry is out of order")
+		return errors.New("content mutation allocation entry is out of order")
 	}
 	checks := []func() error{
 		func() error { return requireAuditUUID(entry.record, auditVaultIDField, vaultID) },
@@ -776,7 +850,7 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 		return err
 	}
 	if len(allocated) != 0 {
-		return errors.New("content replacement allocation cannot allocate node IDs")
+		return errors.New("content mutation allocation cannot allocate node IDs")
 	}
 	mutationDigest, err := hashAuditRecord(mutation.record)
 	if err != nil {
@@ -805,7 +879,7 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 	return nil
 }
 
-func (replay *auditedHistoryReplay) applyContentReplacementState(
+func (replay *auditedHistoryReplay) applyContentTransitionState(
 	nodeID uint64, postVersion, mutation audit.Record,
 ) error {
 	state := replay.states[nodeID]

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -154,8 +154,8 @@ func (s *Store) ReplaceContent(
 			return err
 		}
 		if audited {
-			updated, version, err = replaceAuditedContentTx(
-				ctx, tx, s, n, blobHash, size, mimeType,
+			updated, version, err = installAuditedContentVersionTx(
+				ctx, tx, s, n, blobHash, size, mimeType, "content_replace", nil,
 			)
 			return err
 		}
@@ -188,7 +188,7 @@ func (s *Store) RevertContent(
 		version ContentVersion
 		source  ContentVersion
 	)
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		n, err := nodeByIDTx(tx, nodeID)
 		if err != nil {
 			return err
@@ -221,6 +221,17 @@ func (s *Store) RevertContent(
 		if catalogSize != source.Size {
 			return fmt.Errorf("source version %s records %d bytes but blob %s records %d",
 				source.ID, source.Size, source.BlobHash, catalogSize)
+		}
+		audited, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if audited {
+			updated, version, err = installAuditedContentVersionTx(
+				ctx, tx, s, n, source.BlobHash, source.Size, source.MimeType,
+				"content_revert", &source.ID,
+			)
+			return err
 		}
 		updated, version, err = installContentVersionTx(
 			tx, n, source.BlobHash, source.Size, source.MimeType, "content_revert", &source.ID,


### PR DESCRIPTION
An audited file can already accept replacement content, but the existing version-revert operation still fails closed after enrollment. That leaves a basic version-management workflow incompatible with full retention, even though the canonical audit contract already defines `content_revert`.

This routes revert through the existing Go-owned audited content transaction. The new immutable head and event bind the selected historical source, and replay independently requires that source to predate the operation, belong to the same node, be non-current, and match the restored bytes, size, and media type exactly. Sources introduced by earlier audited replacements are supported as well as genesis versions.

Out-of-scope reverts remain refused, forced audit failures roll back the new version and node head together, and deterministic JSONL export/import reproduces the resulting authority. The repository’s CGO and pure-Go suites, focused race coverage, lint, and strict documentation build are green. No unfinished audit controls are exposed or advertised.

Kata: bk5p.