### PR TITLE
Record audited in-scope moves and renames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,12 +40,17 @@ Instructions for autonomous coding agents working in this repository.
 3. Do not merge pull requests; opening and reporting them is the agent's
    job, merging is the user's.
 4. Run `prek run` before committing.
-5. Keep pull request descriptions rationale-first. Do not add routine
-   `Validation`, `Testing`, or checklist sections for `make test`, lint, docs,
-   vet, `prek`, CI, or ordinary conformance suites; report those results in the
-   handoff instead. Include validation in the PR body only when it is novel
-   evidence that materially informs review, such as a migration rehearsal,
-   benchmark, real-vault hardening run, or compatibility experiment.
+5. Write pull request descriptions for humans. Lead with the user-visible
+   outcome in plain language and, when useful, one concrete example. Explain
+   the important safety boundary or tradeoff without making the reader decode
+   internal types, record names, endpoints, or implementation chronology.
+   Keep the rationale, but avoid robotic implementation inventories.
+6. Do not add routine `Validation`, `Testing`, or checklist sections for
+   `make test`, lint, docs, vet, `prek`, CI, or ordinary conformance suites;
+   report those results in the handoff instead. Include validation in the PR
+   body only when it is novel evidence that materially informs review, such as
+   a migration rehearsal, benchmark, real-vault hardening run, or compatibility
+   experiment.
 
 ## Releases
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -933,8 +933,14 @@ func TestStorageRepackRoundTrip(t *testing.T) {
 	_, err = c.GC(t.Context(), true)
 	require.NoError(t, err)
 
-	report, err := c.StorageRepack(t.Context(), 0, time.Nanosecond, 1)
-	require.NoError(t, err)
+	var report api.StorageRepackReport
+	var repackErr error
+	require.Eventually(t, func() bool {
+		report, repackErr = c.StorageRepack(t.Context(), 0, time.Nanosecond, 1)
+		return repackErr == nil && report.PacksRewritten == 1
+	}, time.Second, 10*time.Millisecond,
+		"pack should become eligible after the platform clock advances")
+	require.NoError(t, repackErr)
 	assert.Equal(t, 1, report.PacksRewritten)
 	assert.Equal(t, 1, report.PacksRemoved)
 }

--- a/internal/store/audit_baseline_projection.go
+++ b/internal/store/audit_baseline_projection.go
@@ -299,7 +299,7 @@ func contentVersionAuditRecord(
 		{Name: "blob_hash", Value: blobValue},
 		{Name: "size", Value: audit.Unsigned(size)},
 		{Name: "media_type", Value: mediaValue},
-		{Name: "recorded_at", Value: recordedValue},
+		{Name: auditRecordedAtField, Value: recordedValue},
 		{Name: "node_revision", Value: audit.Unsigned(revision)},
 		{Name: "introduced_operation_id", Value: operationValue},
 		{Name: "transition_kind", Value: transitionValue},
@@ -319,7 +319,7 @@ func initialBaselineTopology(
 			return nil, nil, err
 		}
 		byID[id] = record
-		parent, err := auditOptionalUnsignedField(record, "parent_id")
+		parent, err := auditOptionalParentIDField(record)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -391,8 +391,8 @@ func addAuditAncestors(id uint64, parents map[uint64]*uint64, closure map[uint64
 	}
 }
 
-func auditOptionalUnsignedField(record audit.Record, name string) (*uint64, error) {
-	value, err := auditField(record, name)
+func auditOptionalParentIDField(record audit.Record) (*uint64, error) {
+	value, err := auditField(record, auditParentIDField)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,9 @@ func auditOptionalUnsignedField(record audit.Record, name string) (*uint64, erro
 	}
 	result, ok := value.UnsignedValue()
 	if !ok {
-		return nil, fmt.Errorf("audit field %s.%s is not optional unsigned", record.Kind, name)
+		return nil, fmt.Errorf(
+			"audit field %s.%s is not optional unsigned", record.Kind, auditParentIDField,
+		)
 	}
 	return &result, nil
 }

--- a/internal/store/audit_baseline_projection.go
+++ b/internal/store/audit_baseline_projection.go
@@ -20,7 +20,7 @@ func deriveInitialAuditMembers(
 		return nil, err
 	}
 	target, ok := rows[targetNodeID]
-	if !ok || target.kind != "dir" || target.trashedAt.Valid {
+	if !ok || target.kind != nodeKindDir || target.trashedAt.Valid {
 		return nil, fmt.Errorf("audit enrollment target %d must be a live directory", targetNodeID)
 	}
 	children := make(map[uint64][]uint64)

--- a/internal/store/audit_content_replace.go
+++ b/internal/store/audit_content_replace.go
@@ -339,7 +339,7 @@ func makeAuditedContentTransitionEvent(
 	}
 	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: values.operationID},
-		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
 	}})
 	if err != nil {
 		return audit.Record{}, err
@@ -362,8 +362,8 @@ func makeAuditedContentTransitionEvent(
 		{Name: "attachment_kind", Value: audit.Absent()},
 		{Name: "attachment_identity", Value: audit.Absent()},
 		{Name: "source_version_id", Value: sourceVersion},
-		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
-		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
 		{Name: "prior_node_revision", Value: audit.Unsigned(priorRevision)},
 		{Name: "resulting_node_revision", Value: audit.Unsigned(resultingRevision)},
 		{Name: "prior_current_version_id", Value: priorVersionID},
@@ -435,7 +435,7 @@ func makeAuditedContentTransitionMutation(
 		{Name: "operation_sequence", Value: audit.Unsigned(auditSequence)},
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: "grouping_id", Value: audit.Absent()},
-		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
 		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: audit.Absent()},
 		{Name: "events", Value: audit.List(eventValues...)},

--- a/internal/store/audit_enrollment.go
+++ b/internal/store/audit_enrollment.go
@@ -332,7 +332,7 @@ func makeInitialAuditEnrollmentEvent(
 ) (audit.Record, error) {
 	identityDigest, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: values.operationID},
-		{Name: "event_ordinal", Value: audit.Unsigned(0)},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(0)},
 	}})
 	if err != nil {
 		return audit.Record{}, err
@@ -369,8 +369,8 @@ func makeInitialAuditEnrollmentEvent(
 		{Name: "attachment_kind", Value: audit.Absent()},
 		{Name: "attachment_identity", Value: audit.Absent()},
 		{Name: "source_version_id", Value: audit.Absent()},
-		{Name: "event_ordinal", Value: audit.Unsigned(0)},
-		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(0)},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
 		{Name: "prior_node_revision", Value: audit.Unsigned(revision)},
 		{Name: "resulting_node_revision", Value: audit.Unsigned(revision)},
 		{Name: "prior_current_version_id", Value: current},
@@ -398,7 +398,7 @@ func makeInitialAuditMutation(
 		{Name: "operation_sequence", Value: audit.Unsigned(1)},
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: "grouping_id", Value: audit.Absent()},
-		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
 		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: values.agentLabel},
 		{Name: "events", Value: audit.List(audit.Nested(event))},

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -25,7 +25,7 @@ func deriveInitialAuditMembersFromRecords(
 		return nil, err
 	}
 	target, ok := nodes[targetNodeID]
-	if !ok || target.kind != "dir" || target.state != "live" {
+	if !ok || target.kind != nodeKindDir || target.state != "live" {
 		return nil, fmt.Errorf("audit enrollment target %d must be a live directory", targetNodeID)
 	}
 	children := make(map[uint64][]uint64)
@@ -107,6 +107,56 @@ func replayAuditTopology(topology []audit.Record) (map[uint64]replayAuditTopolog
 	return result, nil
 }
 
+func validateReplayedAuditTopology(topology []audit.Record) error {
+	nodes, err := replayAuditTopology(topology)
+	if err != nil {
+		return err
+	}
+	type liveSibling struct {
+		parentID uint64
+		name     string
+	}
+	liveNames := make(map[liveSibling]uint64)
+	var rootID uint64
+	for nodeID, node := range nodes {
+		nameBytes, err := auditNameBytesField(node.record)
+		if err != nil {
+			return err
+		}
+		if node.parentID == nil {
+			if rootID != 0 || len(nameBytes) != 0 || node.kind != nodeKindDir || node.state != "live" {
+				return errors.New("audit topology has an invalid vault root")
+			}
+			rootID = nodeID
+			continue
+		}
+		name := string(nameBytes)
+		normalized, err := NormalizeName(name)
+		if err != nil || normalized != name {
+			return fmt.Errorf("audit topology node %d has invalid canonical name", nodeID)
+		}
+		if node.state != "live" {
+			continue
+		}
+		parent, ok := nodes[*node.parentID]
+		if !ok || parent.state != "live" || parent.kind != nodeKindDir {
+			return fmt.Errorf("live audit topology node %d has an invalid parent", nodeID)
+		}
+		key := liveSibling{parentID: *node.parentID, name: name}
+		if siblingID, exists := liveNames[key]; exists {
+			return fmt.Errorf(
+				"live audit topology nodes %d and %d have the same parent and name",
+				siblingID, nodeID,
+			)
+		}
+		liveNames[key] = nodeID
+	}
+	if rootID == 0 {
+		return errors.New("audit topology lacks a vault root")
+	}
+	return nil
+}
+
 func addReplayAuditDescendants(
 	root uint64, nodes map[uint64]replayAuditTopologyNode,
 	children map[uint64][]uint64, members map[uint64]bool, liveOnly bool,
@@ -172,7 +222,7 @@ func validateInitialAuditMemberProjection(
 		if !exists {
 			return fmt.Errorf("audit member %d is absent from topology genesis", nodeID)
 		}
-		if node.kind == "dir" {
+		if node.kind == nodeKindDir {
 			if current != nil || latestRevision[nodeID] != 0 {
 				return fmt.Errorf("audited directory %d carries content authority", nodeID)
 			}

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -70,7 +70,7 @@ func replayAuditTopology(topology []audit.Record) (map[uint64]replayAuditTopolog
 		if _, exists := result[nodeID]; exists {
 			return nil, fmt.Errorf("audit topology repeats node %d", nodeID)
 		}
-		parentID, err := auditOptionalUnsignedField(record, "parent_id")
+		parentID, err := auditOptionalParentIDField(record)
 		if err != nil {
 			return nil, err
 		}
@@ -93,7 +93,7 @@ func replayAuditTopology(topology []audit.Record) (map[uint64]replayAuditTopolog
 				return nil, fmt.Errorf("audit topology node %d has invalid origin", nodeID)
 			}
 			if origin.Kind == "known_origin" {
-				originParent, err = auditOptionalUnsignedField(origin, "parent_id")
+				originParent, err = auditOptionalParentIDField(origin)
 				if err != nil || originParent == nil {
 					return nil, fmt.Errorf("audit topology node %d has invalid known origin", nodeID)
 				}
@@ -247,9 +247,11 @@ func validateAuditedHistory(
 	usedEvents := map[string]bool{}
 	baselines := auditRecordsByDigest(records["enrollment_baseline"])
 	topologyDeltas := auditRecordsByDigest(records[auditTopologyDeltaField])
+	pathEffectLists := auditRecordsByDigest(records["path_effect_list"])
 	attachmentDeltas := auditRecordsByDigest(records["attached_metadata_delta"])
 	usedBaselines := map[string]bool{initial["enrollment_baseline"][0].digest: true}
 	usedTopologyDeltas := map[string]bool{}
+	usedPathEffectLists := map[string]bool{}
 	usedAttachmentDeltas := map[string]bool{}
 	for sequence := int64(2); sequence <= authority.sequence; sequence++ {
 		mutation := mutations[sequence]
@@ -257,15 +259,25 @@ func validateAuditedHistory(
 		if bindingErr != nil {
 			return fmt.Errorf("validating audit operation %d: %w", sequence, bindingErr)
 		}
-		if len(bindings) == 0 {
+		topologyValue, topologyErr := auditField(mutation.record, auditTopologyDeltaField)
+		if topologyErr != nil {
+			return fmt.Errorf("validating audit operation %d: %w", sequence, topologyErr)
+		}
+		if len(bindings) == 0 && topologyValue.IsAbsent() {
 			err = replay.applyContentTransition(
 				vaultID, mutation, allocations[sequence], entries[sequence], events, usedEvents,
 			)
-		} else {
+		} else if len(bindings) != 0 {
 			err = replay.applyNodeCreation(
 				vaultID, mutation, allocations[sequence], entries[sequence],
 				baselines, topologyDeltas, attachmentDeltas, events, usedBaselines,
 				usedTopologyDeltas, usedAttachmentDeltas, usedEvents,
+			)
+		} else {
+			err = replay.applyNodeMove(
+				vaultID, mutation, allocations[sequence], entries[sequence],
+				topologyDeltas, pathEffectLists, events,
+				usedTopologyDeltas, usedPathEffectLists, usedEvents,
 			)
 		}
 		if err != nil {
@@ -282,6 +294,9 @@ func validateAuditedHistory(
 	}
 	if len(usedTopologyDeltas) != len(topologyDeltas) {
 		return errors.New("audit history contains an unbound topology delta")
+	}
+	if len(usedPathEffectLists) != len(pathEffectLists) {
+		return errors.New("audit history contains an unbound path-effect list")
 	}
 	if len(usedAttachmentDeltas) != len(attachmentDeltas) {
 		return errors.New("audit history contains an unbound attached-metadata delta")
@@ -584,7 +599,7 @@ func (replay *auditedHistoryReplay) validateContentTransitionEvent(
 	}
 	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: identityOperation},
-		{Name: "event_ordinal", Value: audit.Unsigned(0)},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(0)},
 	}})
 	if err != nil {
 		return 0, audit.Record{}, err
@@ -606,7 +621,7 @@ func (replay *auditedHistoryReplay) validateContentTransitionEvent(
 	checks := []func() error{
 		func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
 		func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
-		func() error { return requireAuditUnsigned(event, "event_ordinal", 0) },
+		func() error { return requireAuditUnsigned(event, auditEventOrdinalField, 0) },
 	}
 	for _, check := range checks {
 		if err := check(); err != nil {
@@ -670,11 +685,11 @@ func (replay *auditedHistoryReplay) validateContentTransitionEvent(
 	); err != nil {
 		return 0, audit.Record{}, err
 	}
-	postTime, err := auditField(post, "recorded_at")
+	postTime, err := auditField(post, auditRecordedAtField)
 	if err != nil {
 		return 0, audit.Record{}, err
 	}
-	mutationTime, err := auditField(mutation, "recorded_at")
+	mutationTime, err := auditField(mutation, auditRecordedAtField)
 	if err != nil || !equalAuditEnvelopeValue(postTime, mutationTime) {
 		return 0, audit.Record{}, errors.New("content version time does not match its mutation")
 	}
@@ -905,7 +920,7 @@ func (replay *auditedHistoryReplay) applyContentTransitionState(
 	if !ok {
 		return fmt.Errorf("audited node %d is absent from topology replay", nodeID)
 	}
-	modifiedAt, err := auditField(mutation, "recorded_at")
+	modifiedAt, err := auditField(mutation, auditRecordedAtField)
 	if err != nil {
 		return err
 	}

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -525,7 +525,7 @@ func validateInitialEvent(scope initialAuditScope, baseline storedAuditRecord, e
 	}
 	identityDigest, err := audit.Hash(audit.Record{Kind: "event_identity", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: identityOperation},
-		{Name: "event_ordinal", Value: audit.Unsigned(0)},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(0)},
 	}})
 	if err != nil {
 		return err
@@ -537,7 +537,7 @@ func validateInitialEvent(scope initialAuditScope, baseline storedAuditRecord, e
 		func() error { return requireAuditText(event, "event_kind", "audit_enroll") },
 		func() error { return requireAuditUUID(event, auditScopeIDField, scope.scopeID) },
 		func() error { return requireAuditUnsigned(event, "target_node_id", scope.targetNodeID) },
-		func() error { return requireAuditUnsigned(event, "event_ordinal", 0) },
+		func() error { return requireAuditUnsigned(event, auditEventOrdinalField, 0) },
 		func() error { return requireAuditDigest(event, "baseline_digest", baseline.digest) },
 	}
 	for _, check := range checks {
@@ -613,7 +613,7 @@ func requireNoChangeMutationFields(record audit.Record) error {
 }
 
 func requireMatchingEventEnvelope(mutation, event audit.Record) error {
-	for _, field := range []string{"recorded_at", auditOriginField, "agent_label"} {
+	for _, field := range []string{auditRecordedAtField, auditOriginField, "agent_label"} {
 		left, err := auditField(mutation, field)
 		if err != nil {
 			return err

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -270,6 +270,9 @@ func validateInitialGenesis(
 	if err != nil {
 		return err
 	}
+	if err := validateReplayedAuditTopology(storedTopology); err != nil {
+		return fmt.Errorf("validating audit topology genesis: %w", err)
+	}
 	storedAttachments, err := auditRecordListField(attachments.record, "records")
 	if err != nil {
 		return err

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -14,6 +14,12 @@ import (
 	"go.kenn.io/docbank/internal/audit"
 )
 
+const (
+	auditEventOrdinalField = "event_ordinal"
+	auditParentIDField     = "parent_id"
+	auditRecordedAtField   = "recorded_at"
+)
+
 var auditRecordKinds = map[string]bool{
 	"enrollment_baseline":       true,
 	"topology_genesis":          true,
@@ -24,6 +30,7 @@ var auditRecordKinds = map[string]bool{
 	"allocation_genesis":        true,
 	"allocation_entry":          true,
 	auditTopologyDeltaField:     true,
+	"path_effect_list":          true,
 	"attached_metadata_delta":   true,
 }
 
@@ -308,7 +315,7 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 		if err != nil {
 			return index, err
 		}
-		ordinal, err := auditInt64UnsignedField(event, "event_ordinal")
+		ordinal, err := auditInt64UnsignedField(event, auditEventOrdinalField)
 		if err != nil {
 			return index, err
 		}
@@ -335,7 +342,7 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 		}
 		index.scopeID, index.entryCount = &scopeID, &entryCount
 	case "topology_genesis", "attached_metadata_genesis", "allocation_genesis",
-		auditTopologyDeltaField, "attached_metadata_delta":
+		auditTopologyDeltaField, "path_effect_list", "attached_metadata_delta":
 	default:
 		return index, fmt.Errorf("unsupported initial audit record kind %q", record.Kind)
 	}

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -57,6 +57,49 @@ func TestInitialAuditAuthorityMetadataRoundTrip(t *testing.T) {
 	assert.Equal(t, int64(8), records)
 }
 
+func TestInitialAuditGenesisRejectsLiveSiblingCollision(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	other, err := s.CreateFile(
+		t.Context(), projects.ID, "other.txt", fakeHash("a724"), 10, "text/plain",
+	)
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	topology := initial["topology_genesis"][0]
+	nodes, err := auditRecordListField(topology.record, "nodes")
+	require.NoError(t, err)
+	for index, node := range nodes {
+		if mustAuditUnsignedField(t, node, metadataNodeIDField) != uint64(report.ID) {
+			continue
+		}
+		nodes[index] = mustReplaceAuditRecordField(
+			t, node, "name", audit.Bytes([]byte(other.Name)),
+		)
+	}
+	topology.record = mustReplaceAuditRecordField(
+		t, topology.record, "nodes", audit.List(auditNestedValues(nodes)...),
+	)
+
+	err = validateInitialGenesis(
+		s.VaultID(), authority, topology,
+		initial["attached_metadata_genesis"][0], initial["allocation_genesis"][0],
+	)
+	require.ErrorContains(t, err, "same parent and name")
+}
+
 func TestInitialAuditAuthorityImportRejectsCorruptionAndRollsBack(t *testing.T) {
 	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
 	require.NoError(t, err)

--- a/internal/store/audit_node_create.go
+++ b/internal/store/audit_node_create.go
@@ -378,7 +378,7 @@ func makeAuditedCreationEvent(
 ) (audit.Record, error) {
 	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: values.operationID},
-		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
 	}})
 	if err != nil {
 		return audit.Record{}, err
@@ -430,8 +430,8 @@ func makeAuditedCreationEvent(
 		{Name: "attachment_kind", Value: attachmentKind},
 		{Name: "attachment_identity", Value: attachmentIdentity},
 		{Name: "source_version_id", Value: audit.Absent()},
-		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
-		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
 		{Name: "prior_node_revision", Value: audit.Unsigned(0)},
 		{Name: "resulting_node_revision", Value: audit.Unsigned(1)},
 		{Name: "prior_current_version_id", Value: audit.Absent()},
@@ -462,7 +462,7 @@ func makeAuditedCreationMutation(
 		{Name: "operation_sequence", Value: audit.Unsigned(sequence)},
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: "grouping_id", Value: groupingID},
-		{Name: "recorded_at", Value: values.recordedAt},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
 		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: audit.Absent()},
 		{Name: "events", Value: audit.List(auditNestedValues(events)...)},

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -205,6 +205,9 @@ func (replay *auditedHistoryReplay) validateNodeCreationTopology(
 	if err := sortAuditTopologyRecords(postTopology); err != nil {
 		return replayedNodeCreation{}, err
 	}
+	if err := validateReplayedAuditTopology(postTopology); err != nil {
+		return replayedNodeCreation{}, fmt.Errorf("validating node creation topology: %w", err)
+	}
 	return replayedNodeCreation{
 		childID: childID, parentID: parentID, childTopology: childPost,
 		postTopology: postTopology,
@@ -303,7 +306,7 @@ func (replay *auditedHistoryReplay) validateNodeCreationBaseline(
 		return err
 	}
 	switch kind {
-	case "dir":
+	case nodeKindDir:
 		if current != nil || len(versions) != 0 {
 			return errors.New("created directory baseline contains content")
 		}

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -182,7 +182,7 @@ func (replay *auditedHistoryReplay) validateNodeCreationTopology(
 	if !ok || !auditRecordEqual(replay.topology[parentIndex], parentPre) {
 		return replayedNodeCreation{}, errors.New("node creation parent pre-state does not match replayed topology")
 	}
-	modifiedAt, err := auditField(mutation, "recorded_at")
+	modifiedAt, err := auditField(mutation, auditRecordedAtField)
 	if err != nil {
 		return replayedNodeCreation{}, err
 	}
@@ -368,11 +368,11 @@ func validateCreatedContentVersion(
 			return err
 		}
 	}
-	recordedAt, err := auditField(version, "recorded_at")
+	recordedAt, err := auditField(version, auditRecordedAtField)
 	if err != nil {
 		return err
 	}
-	mutationTime, err := auditField(mutation, "recorded_at")
+	mutationTime, err := auditField(mutation, auditRecordedAtField)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func (replay *auditedHistoryReplay) validateNodeCreationEvents(
 			func() error { return requireAuditUnsigned(event, metadataNodeIDField, creation.childID) },
 			func() error { return requireAuditText(event, "event_kind", expectedKinds[index]) },
 			func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
-			func() error { return requireAuditUnsigned(event, "event_ordinal", ordinal) },
+			func() error { return requireAuditUnsigned(event, auditEventOrdinalField, ordinal) },
 			func() error { return requireAuditUnsigned(event, "prior_node_revision", 0) },
 			func() error { return requireAuditUnsigned(event, "resulting_node_revision", 1) },
 			func() error { return requireAuditAbsent(event, "prior_current_version_id") },
@@ -469,7 +469,7 @@ func validateCreationEventWrapper(
 	}
 	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: operationValue},
-		{Name: "event_ordinal", Value: audit.Unsigned(ordinal)},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
 	}})
 	if err != nil {
 		return err

--- a/internal/store/audit_node_move.go
+++ b/internal/store/audit_node_move.go
@@ -1,0 +1,571 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type auditedMoveSnapshot struct {
+	authority                auditAuthorityState
+	scope                    auditScopeState
+	nodeSequence             int64
+	operationID, recordedAt  string
+	priorNodes, priorSubtree map[int64]Node
+	priorPaths               map[int64]string
+	subtreeIDs               []int64
+}
+
+func (s *Store) moveAuditedTx(
+	ctx context.Context, tx *sql.Tx, id, newParentID int64, newName string, ifRev int64,
+) (Node, error) {
+	snapshot, normalizedName, noChange, err := s.prepareAuditedMove(
+		ctx, tx, id, newParentID, newName, ifRev,
+	)
+	if err != nil {
+		return Node{}, err
+	}
+	if noChange {
+		return snapshot.priorSubtree[id], nil
+	}
+	moved, err := s.moveAtTx(
+		tx, id, newParentID, normalizedName, ifRev, snapshot.recordedAt,
+	)
+	if err != nil {
+		return Node{}, err
+	}
+	resultingNodes := make(map[int64]Node, len(snapshot.priorNodes))
+	for nodeID := range snapshot.priorNodes {
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return Node{}, err
+		}
+		resultingNodes[nodeID] = node
+	}
+	resultingSubtree := make(map[int64]Node, len(snapshot.subtreeIDs))
+	resultingPaths := make(map[int64]string, len(snapshot.subtreeIDs))
+	for _, nodeID := range snapshot.subtreeIDs {
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return Node{}, err
+		}
+		path, err := pathOf(ctx, tx, nodeID)
+		if err != nil {
+			return Node{}, err
+		}
+		resultingSubtree[nodeID], resultingPaths[nodeID] = node, path
+	}
+	if err := persistAuditedMove(
+		ctx, tx, s.vaultID, snapshot, resultingNodes, resultingSubtree, resultingPaths,
+	); err != nil {
+		return Node{}, err
+	}
+	return moved, nil
+}
+
+func (s *Store) prepareAuditedMove(
+	ctx context.Context, tx *sql.Tx, id, newParentID int64, newName string, ifRev int64,
+) (auditedMoveSnapshot, string, bool, error) {
+	var snapshot auditedMoveSnapshot
+	if id == s.rootID {
+		return snapshot, "", false, ErrIsRoot
+	}
+	normalizedName, err := NormalizeName(newName)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	moved, err := nodeByIDTx(tx, id)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	if moved.TrashedAt != nil {
+		return snapshot, "", false, fmt.Errorf("node %d is trashed: %w", id, ErrNotFound)
+	}
+	if ifRev != UnconditionalRev && moved.Revision != ifRev {
+		return snapshot, "", false, fmt.Errorf(
+			"node %d at revision %d, expected %d: %w", id, moved.Revision, ifRev, ErrStaleRevision,
+		)
+	}
+	if _, err := liveDirTx(tx, newParentID); err != nil {
+		return snapshot, "", false, err
+	}
+	inCycle, err := isAncestorTx(tx, id, newParentID)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	if inCycle {
+		return snapshot, "", false, fmt.Errorf("moving node %d under %d: %w", id, newParentID, ErrCycle)
+	}
+	authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, id)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	if len(scopes) != 1 {
+		return snapshot, "", false, unsupportedAuditedNodeMutation(id)
+	}
+	oldParentID := *moved.ParentID
+	for _, parentID := range []int64{oldParentID, newParentID} {
+		member, err := nodeInAuditScopeTx(ctx, tx, parentID, scopes[0].scopeID)
+		if err != nil {
+			return snapshot, "", false, err
+		}
+		if !member {
+			return snapshot, "", false, unsupportedAuditedNodeMutation(parentID)
+		}
+	}
+	subtreeIDs, err := liveSubtreeIDsTx(ctx, tx, id)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	priorSubtree := make(map[int64]Node, len(subtreeIDs))
+	priorPaths := make(map[int64]string, len(subtreeIDs))
+	for _, nodeID := range subtreeIDs {
+		member, err := nodeInAuditScopeTx(ctx, tx, nodeID, scopes[0].scopeID)
+		if err != nil {
+			return snapshot, "", false, err
+		}
+		if !member {
+			return snapshot, "", false, unsupportedAuditedNodeMutation(nodeID)
+		}
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return snapshot, "", false, err
+		}
+		path, err := pathOf(ctx, tx, nodeID)
+		if err != nil {
+			return snapshot, "", false, err
+		}
+		priorSubtree[nodeID], priorPaths[nodeID] = node, path
+	}
+	directIDs := []int64{id, oldParentID}
+	if newParentID != oldParentID {
+		directIDs = append(directIDs, newParentID)
+	}
+	slices.Sort(directIDs)
+	priorNodes := make(map[int64]Node, len(directIDs))
+	for _, nodeID := range directIDs {
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return snapshot, "", false, err
+		}
+		priorNodes[nodeID] = node
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	snapshot = auditedMoveSnapshot{
+		authority: authority, scope: scopes[0], nodeSequence: nodeSequence,
+		operationID: operationID, recordedAt: nowRFC3339(),
+		priorNodes: priorNodes, priorSubtree: priorSubtree,
+		priorPaths: priorPaths, subtreeIDs: subtreeIDs,
+	}
+	return snapshot, normalizedName,
+		oldParentID == newParentID && moved.Name == normalizedName, nil
+}
+
+func nodeInAuditScopeTx(
+	ctx context.Context, tx *sql.Tx, nodeID int64, scopeID string,
+) (bool, error) {
+	var member bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM audit_memberships WHERE scope_id=? AND node_id=?
+	)`, scopeID, nodeID).Scan(&member); err != nil {
+		return false, fmt.Errorf("checking audit membership for node %d: %w", nodeID, err)
+	}
+	return member, nil
+}
+
+func liveSubtreeIDsTx(ctx context.Context, tx *sql.Tx, rootID int64) ([]int64, error) {
+	rows, err := tx.QueryContext(ctx, `WITH RECURSIVE subtree(id) AS (
+		SELECT id FROM nodes WHERE id=? AND trashed_at IS NULL
+		UNION ALL
+		SELECT node.id FROM nodes node JOIN subtree ON node.parent_id=subtree.id
+		WHERE node.trashed_at IS NULL
+	) SELECT id FROM subtree ORDER BY id`, rootID)
+	if err != nil {
+		return nil, fmt.Errorf("listing live subtree of node %d: %w", rootID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var result []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning live subtree of node %d: %w", rootID, err)
+		}
+		result = append(result, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing live subtree of node %d: %w", rootID, err)
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("node %d: %w", rootID, ErrNotFound)
+	}
+	return result, nil
+}
+
+func persistAuditedMove(
+	ctx context.Context, tx *sql.Tx, vaultID string, snapshot auditedMoveSnapshot,
+	resultingNodes, resultingSubtree map[int64]Node, resultingPaths map[int64]string,
+) error {
+	values, err := makeAuditedMutationValues(
+		vaultID, snapshot.authority.lineageID, snapshot.operationID, snapshot.recordedAt,
+	)
+	if err != nil {
+		return err
+	}
+	topology, err := makeAuditedMoveTopologyDelta(
+		values.operationID, snapshot.priorNodes, resultingNodes,
+	)
+	if err != nil {
+		return err
+	}
+	topologyDigest, err := hashAuditRecord(topology)
+	if err != nil {
+		return err
+	}
+	effects, effectList, effectDigest, err := makeAuditedMovePathEffects(
+		values, snapshot, resultingPaths, topologyDigest,
+	)
+	if err != nil {
+		return err
+	}
+	stateChanges, err := makeAuditedMoveStateChanges(snapshot.priorNodes, resultingNodes)
+	if err != nil {
+		return err
+	}
+	events, err := makeAuditedMoveEvents(
+		values, snapshot.scope.scopeID, snapshot, resultingSubtree, effects, topologyDigest,
+	)
+	if err != nil {
+		return err
+	}
+	mutation, err := makeAuditedMoveMutation(
+		values, snapshot.authority.sequence+1, events, stateChanges,
+		topologyDigest, uint64(len(effects)), effectDigest,
+	)
+	if err != nil {
+		return err
+	}
+	mutationDigest, err := hashAuditRecord(mutation)
+	if err != nil {
+		return err
+	}
+	for _, record := range []audit.Record{topology, effectList} {
+		if err := insertAuditRecord(ctx, tx, record); err != nil {
+			return err
+		}
+	}
+	for _, event := range events {
+		if err := insertAuditRecord(ctx, tx, audit.Record{Kind: auditEventField, Fields: []audit.Field{
+			{Name: auditEventField, Value: audit.Nested(event)},
+		}}); err != nil {
+			return err
+		}
+	}
+	if err := insertAuditRecord(ctx, tx, mutation); err != nil {
+		return err
+	}
+	entryCount, err := nextAuditInteger("scope entry count", snapshot.scope.entryCount)
+	if err != nil {
+		return err
+	}
+	entry, err := makeAuditScopeChainEntry(
+		values, snapshot.scope.scopeID, entryCount, snapshot.scope.chainHead, mutationDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	scopeHead, err := hashAuditRecord(entry)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, entry); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE audit_scopes SET entry_count=?,chain_head=? WHERE scope_id=?`,
+		entryCount, scopeHead.text, snapshot.scope.scopeID); err != nil {
+		return fmt.Errorf("advancing audit scope %s: %w", snapshot.scope.scopeID, err)
+	}
+	allocation, err := makeAuditedMoveAllocationEntry(
+		values, snapshot.authority.sequence+1, snapshot.nodeSequence,
+		snapshot.authority.allocationHead, mutationDigest.value, topologyDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	allocationHead, err := hashAuditRecord(allocation)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, allocation); err != nil {
+		return err
+	}
+	allocationCount, err := nextAuditInteger(
+		"allocation entry count", snapshot.authority.allocationCount,
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE audit_authority
+		SET operation_sequence_high_water=?,allocation_entry_count=?,allocation_head=?
+		WHERE singleton=1`, snapshot.authority.sequence+1, allocationCount, allocationHead.text); err != nil {
+		return fmt.Errorf("advancing audit allocation authority: %w", err)
+	}
+	return nil
+}
+
+func makeAuditedMoveTopologyDelta(
+	operationID audit.Value, prior, resulting map[int64]Node,
+) (audit.Record, error) {
+	changes := make([]audit.Record, 0, len(prior))
+	for nodeID, priorNode := range prior {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		resultingNode, ok := resulting[nodeID]
+		if !ok {
+			return audit.Record{}, fmt.Errorf("audited move lacks resulting node %d", nodeID)
+		}
+		pre, err := auditTopologyForLiveNode(priorNode)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		post, err := auditTopologyForLiveNode(resultingNode)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		changes = append(changes, audit.Record{Kind: "topology_change", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
+			{Name: "pre", Value: audit.Nested(pre)},
+			{Name: "post", Value: audit.Nested(post)},
+		}})
+	}
+	if err := sortAuditTopologyRecords(changes); err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: auditTopologyDeltaField, Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: operationID},
+		{Name: "changes", Value: audit.List(auditNestedValues(changes)...)},
+	}}, nil
+}
+
+func makeAuditedMovePathEffects(
+	values auditedMutationValues, snapshot auditedMoveSnapshot,
+	resultingPaths map[int64]string, topologyDigest auditRecordHash,
+) ([]audit.Record, audit.Record, auditRecordHash, error) {
+	scopeID, err := audit.UUID(snapshot.scope.scopeID)
+	if err != nil {
+		return nil, audit.Record{}, auditRecordHash{}, err
+	}
+	live, err := audit.Text("live")
+	if err != nil {
+		return nil, audit.Record{}, auditRecordHash{}, err
+	}
+	effects := make([]audit.Record, 0, len(snapshot.subtreeIDs))
+	for _, nodeID := range snapshot.subtreeIDs {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return nil, audit.Record{}, auditRecordHash{}, err
+		}
+		priorPath, resultingPath := snapshot.priorPaths[nodeID], resultingPaths[nodeID]
+		if priorPath == resultingPath {
+			return nil, audit.Record{}, auditRecordHash{}, fmt.Errorf(
+				"audited move did not change path of subtree node %d", nodeID,
+			)
+		}
+		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
+			{Name: auditScopeIDField, Value: scopeID},
+			{Name: "member_node_id", Value: audit.Unsigned(auditNodeID)},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
+				{Name: "path", Value: audit.Bytes([]byte(priorPath))},
+				{Name: "state", Value: live},
+			}})},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
+				{Name: "path", Value: audit.Bytes([]byte(resultingPath))},
+				{Name: "state", Value: live},
+			}})},
+		}})
+	}
+	list := audit.Record{Kind: "path_effect_list", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: auditTopologyDeltaField, Value: topologyDigest.value},
+		{Name: "effects", Value: audit.List(auditNestedValues(effects)...)},
+	}}
+	digest, err := hashAuditRecord(list)
+	return effects, list, digest, err
+}
+
+func makeAuditedMoveStateChanges(
+	prior, resulting map[int64]Node,
+) ([]audit.Record, error) {
+	changes := make([]audit.Record, 0, len(prior))
+	for nodeID, priorNode := range prior {
+		resultingNode, ok := resulting[nodeID]
+		if !ok {
+			return nil, fmt.Errorf("audited move lacks resulting member %d", nodeID)
+		}
+		change, err := makeAuditMemberStateChange(priorNode, resultingNode)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, change)
+	}
+	if err := sortAuditTopologyRecords(changes); err != nil {
+		return nil, err
+	}
+	return changes, nil
+}
+
+func makeAuditedMoveEvents(
+	values auditedMutationValues, scopeID string, snapshot auditedMoveSnapshot,
+	resultingSubtree map[int64]Node, effects []audit.Record, topologyDigest auditRecordHash,
+) ([]audit.Record, error) {
+	if len(effects) != len(snapshot.subtreeIDs) {
+		return nil, errors.New("audited move path effects do not match its subtree")
+	}
+	events := make([]audit.Record, len(effects))
+	ordinal := uint64(0)
+	for index, effect := range effects {
+		nodeID := snapshot.subtreeIDs[index]
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		if err := requireAuditUnsigned(effect, "member_node_id", auditNodeID); err != nil {
+			return nil, err
+		}
+		events[index], err = makeAuditedMoveEvent(
+			values, scopeID, ordinal, snapshot.priorSubtree[nodeID],
+			resultingSubtree[nodeID], effect, topologyDigest,
+		)
+		if err != nil {
+			return nil, err
+		}
+		ordinal++
+	}
+	return events, nil
+}
+
+func makeAuditedMoveEvent(
+	values auditedMutationValues, scopeID string, ordinal uint64,
+	prior, resulting Node, effect audit.Record, topologyDigest auditRecordHash,
+) (audit.Record, error) {
+	nodeID, err := positiveAuditNodeID(prior.ID)
+	if err != nil || resulting.ID != prior.ID {
+		return audit.Record{}, errors.New("audited move changes affected node identity")
+	}
+	scopeValue, err := audit.UUID(scopeID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	kind, err := audit.Text("node_path")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	identity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+	}})
+	if err != nil {
+		return audit.Record{}, err
+	}
+	pre, err := auditNestedField(effect, "old")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	post, err := auditNestedField(effect, "new")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	priorVersion, err := auditNodeCurrentVersion(prior)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	resultingVersion, err := auditNodeCurrentVersion(resulting)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	priorRevision, err := positiveAuditRevision(prior.Revision)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	resultingRevision, err := positiveAuditRevision(resulting.Revision)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "audit_event", Fields: []audit.Field{
+		{Name: "event_id", Value: identity.value},
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "event_kind", Value: kind},
+		{Name: auditScopeIDField, Value: scopeValue},
+		{Name: "target_node_id", Value: audit.Absent()},
+		{Name: "attachment_kind", Value: audit.Absent()},
+		{Name: "attachment_identity", Value: audit.Absent()},
+		{Name: "source_version_id", Value: audit.Absent()},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
+		{Name: "prior_node_revision", Value: audit.Unsigned(priorRevision)},
+		{Name: "resulting_node_revision", Value: audit.Unsigned(resultingRevision)},
+		{Name: "prior_current_version_id", Value: priorVersion},
+		{Name: "resulting_current_version_id", Value: resultingVersion},
+		{Name: auditOriginField, Value: values.origin},
+		{Name: "agent_label", Value: audit.Absent()},
+		{Name: "pre", Value: audit.Nested(pre)},
+		{Name: "post", Value: audit.Nested(post)},
+		{Name: auditTopologyDeltaField, Value: topologyDigest.value},
+		{Name: "baseline_digest", Value: audit.Absent()},
+	}}, nil
+}
+
+func makeAuditedMoveMutation(
+	values auditedMutationValues, sequence int64, events, changes []audit.Record,
+	topologyDigest auditRecordHash, effectCount uint64, effectDigest auditRecordHash,
+) (audit.Record, error) {
+	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
+		{Name: auditVaultIDField, Value: values.vaultID},
+		{Name: "operation_sequence", Value: audit.Unsigned(auditSequence)},
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: "grouping_id", Value: audit.Absent()},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
+		{Name: auditOriginField, Value: values.origin},
+		{Name: "agent_label", Value: audit.Absent()},
+		{Name: "events", Value: audit.List(auditNestedValues(events)...)},
+		{Name: "member_state_changes", Value: audit.List(auditNestedValues(changes)...)},
+		{Name: "baselines", Value: audit.List()},
+		{Name: auditTopologyDeltaField, Value: topologyDigest.value},
+		{Name: "path_effect_count", Value: audit.Unsigned(effectCount)},
+		{Name: "path_effect_digest", Value: effectDigest.value},
+		{Name: auditWitnessChangeCountField, Value: audit.Unsigned(0)},
+		{Name: "witness_change_digest", Value: audit.Absent()},
+		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
+		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
+	}}, nil
+}
+
+func makeAuditedMoveAllocationEntry(
+	values auditedMutationValues, sequence, nodeSequence int64,
+	previousHead string, mutationHash, topologyDigest audit.Value,
+) (audit.Record, error) {
+	entry, err := makeAuditedContentAllocationEntry(
+		values, sequence, nodeSequence, previousHead, mutationHash,
+	)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	entry, err = replaceAuditRecordField(entry, "has_topology_change", audit.Bool(true))
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return replaceAuditRecordField(entry, auditTopologyDeltaField, topologyDigest)
+}

--- a/internal/store/audit_node_move.go
+++ b/internal/store/audit_node_move.go
@@ -108,6 +108,34 @@ func (s *Store) prepareAuditedMove(
 		return snapshot, "", false, unsupportedAuditedNodeMutation(id)
 	}
 	oldParentID := *moved.ParentID
+	if oldParentID == newParentID && moved.Name == normalizedName {
+		snapshot.priorSubtree = map[int64]Node{id: moved}
+		return snapshot, normalizedName, true, nil
+	}
+	scopeMembers, err := auditScopeMemberSetTx(ctx, tx, scopes[0].scopeID)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	topology, err := currentAuditTopology(ctx, tx)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	auditNodeID, err := positiveAuditNodeID(id)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	affectsTrashOrigin, err := auditMoveAffectsTrashOrigin(
+		topology, scopeMembers, auditNodeID,
+	)
+	if err != nil {
+		return snapshot, "", false, err
+	}
+	if affectsTrashOrigin {
+		return snapshot, "", false, fmt.Errorf(
+			"moving node %d would change retained trash-origin paths: %w",
+			id, ErrAuditMutationUnsupported,
+		)
+	}
 	for _, parentID := range []int64{oldParentID, newParentID} {
 		member, err := nodeInAuditScopeTx(ctx, tx, parentID, scopes[0].scopeID)
 		if err != nil {
@@ -164,8 +192,7 @@ func (s *Store) prepareAuditedMove(
 		priorNodes: priorNodes, priorSubtree: priorSubtree,
 		priorPaths: priorPaths, subtreeIDs: subtreeIDs,
 	}
-	return snapshot, normalizedName,
-		oldParentID == newParentID && moved.Name == normalizedName, nil
+	return snapshot, normalizedName, false, nil
 }
 
 func nodeInAuditScopeTx(
@@ -178,6 +205,33 @@ func nodeInAuditScopeTx(
 		return false, fmt.Errorf("checking audit membership for node %d: %w", nodeID, err)
 	}
 	return member, nil
+}
+
+func auditScopeMemberSetTx(
+	ctx context.Context, tx *sql.Tx, scopeID string,
+) (map[uint64]bool, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT node_id FROM audit_memberships WHERE scope_id=? ORDER BY node_id`, scopeID)
+	if err != nil {
+		return nil, fmt.Errorf("listing audit scope %s members: %w", scopeID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make(map[uint64]bool)
+	for rows.Next() {
+		var rawID int64
+		if err := rows.Scan(&rawID); err != nil {
+			return nil, fmt.Errorf("scanning audit scope %s member: %w", scopeID, err)
+		}
+		nodeID, err := positiveAuditNodeID(rawID)
+		if err != nil {
+			return nil, err
+		}
+		result[nodeID] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing audit scope %s members: %w", scopeID, err)
+	}
+	return result, nil
 }
 
 func liveSubtreeIDsTx(ctx context.Context, tx *sql.Tx, rootID int64) ([]int64, error) {

--- a/internal/store/audit_node_move_test.go
+++ b/internal/store/audit_node_move_test.go
@@ -95,18 +95,79 @@ func TestAuditedRootScopeRenameHandlesRootTimestampTouch(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	seedMetadataRoundTrip(t, s)
-	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
 	require.NoError(t, err)
 	seedInitialAuditAuthority(t, s, s.RootID())
 
 	renamed, err := s.Move(
-		t.Context(), projects.ID, s.RootID(), "RenamedProjects", projects.Revision,
+		t.Context(), empty.ID, s.RootID(), "RenamedEmpty", empty.Revision,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "RenamedProjects", renamed.Name)
+	assert.Equal(t, "RenamedEmpty", renamed.Name)
 	require.NoError(t, s.ValidateMetadata(t.Context()))
-	_, err = s.NodeByPath(t.Context(), "/RenamedProjects/report.txt")
+	_, err = s.NodeByPath(t.Context(), "/RenamedEmpty")
 	require.NoError(t, err)
+}
+
+func TestAuditedMoveRejectsRetainedTrashOriginPathChange(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	projects, err := s.Mkdir(t.Context(), s.RootID(), "Projects")
+	require.NoError(t, err)
+	file, err := s.CreateFile(
+		t.Context(), projects.ID, "old.txt", fakeHash("a723"), 9, "text/plain",
+	)
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), file.ID, file.Revision)
+	require.NoError(t, err)
+	projects, err = s.NodeByID(t.Context(), projects.ID)
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, s.RootID())
+
+	_, err = s.Move(
+		t.Context(), projects.ID, s.RootID(), "RenamedProjects", projects.Revision,
+	)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	require.ErrorContains(t, err, "trash-origin paths")
+	_, err = s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	var sequence int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&sequence))
+	assert.Equal(t, int64(1), sequence)
+}
+
+func TestReplayedAuditTopologyRejectsImpossibleIntermediateState(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	topology, err := currentAuditTopology(t.Context(), s.db)
+	require.NoError(t, err)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		name    string
+		message string
+	}{
+		"invalid canonical name": {name: "..", message: "invalid canonical name"},
+		"live sibling collision": {name: "Archive", message: "same parent and name"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := append([]audit.Record(nil), topology...)
+			for index, record := range candidate {
+				if mustAuditUnsignedField(t, record, metadataNodeIDField) != uint64(report.ID) {
+					continue
+				}
+				candidate[index] = mustReplaceAuditRecordField(
+					t, record, "name", audit.Bytes([]byte(test.name)),
+				)
+			}
+			err := validateReplayedAuditTopology(candidate)
+			require.ErrorContains(t, err, test.message)
+		})
+	}
 }
 
 func TestAuditedMoveRefusesMembershipAndWitnessBoundaryCrossings(t *testing.T) {

--- a/internal/store/audit_node_move_test.go
+++ b/internal/store/audit_node_move_test.go
@@ -1,0 +1,193 @@
+package store
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedInScopeMoveRecordsDescendantPathsAndRoundTrips(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	archive, err := s.NodeByPath(t.Context(), "/Projects/Archive")
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+
+	moved, err := s.Move(
+		t.Context(), work.ID, archive.ID, "Renamed", work.Revision,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, archive.ID, *moved.ParentID)
+	assert.Equal(t, "Renamed", moved.Name)
+	assert.Equal(t, work.Revision+1, moved.Revision)
+	_, err = s.NodeByPath(t.Context(), "/Projects/Work")
+	require.ErrorIs(t, err, ErrNotFound)
+	resolvedChild, err := s.NodeByPath(t.Context(), "/Projects/Archive/Renamed/child.txt")
+	require.NoError(t, err)
+	assert.Equal(t, child.ID, resolvedChild.ID)
+	assert.Equal(t, child.Revision, resolvedChild.Revision)
+	updatedProjects, err := s.NodeByID(t.Context(), projects.ID)
+	require.NoError(t, err)
+	updatedArchive, err := s.NodeByID(t.Context(), archive.ID)
+	require.NoError(t, err)
+	assert.Equal(t, projects.Revision+1, updatedProjects.Revision)
+	assert.Equal(t, archive.Revision+1, updatedArchive.Revision)
+
+	var sequence, records int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM audit_records)`).Scan(&sequence, &records))
+	assert.Equal(t, int64(2), sequence)
+	assert.Equal(t, int64(15), records)
+	var raw []byte
+	require.NoError(t, s.db.QueryRow(
+		`SELECT record_json FROM audit_records WHERE kind='path_effect_list'`,
+	).Scan(&raw))
+	effectList, err := audit.UnmarshalJSONRecord(raw)
+	require.NoError(t, err)
+	effects, err := auditRecordListField(effectList, "effects")
+	require.NoError(t, err)
+	require.Len(t, effects, 2)
+	assert.Equal(t, uint64(work.ID), mustAuditUnsignedField(t, effects[0], "member_node_id"))
+	assert.Equal(t, uint64(child.ID), mustAuditUnsignedField(t, effects[1], "member_node_id"))
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+	_, err = restored.NodeByPath(t.Context(), "/Projects/Archive/Renamed/child.txt")
+	require.NoError(t, err)
+}
+
+func TestAuditedInScopeRenameRecordsOnePathEffect(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	file, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	parent, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+
+	renamed, err := s.Move(t.Context(), file.ID, parent.ID, "renamed.txt", file.Revision)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed.txt", renamed.Name)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	var effects int64
+	require.NoError(t, s.db.QueryRow(`SELECT json_array_length(
+		json_extract(record_json, '$.fields.effects'))
+		FROM audit_records WHERE kind='path_effect_list'`).Scan(&effects))
+	assert.Equal(t, int64(1), effects)
+}
+
+func TestAuditedRootScopeRenameHandlesRootTimestampTouch(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, s.RootID())
+
+	renamed, err := s.Move(
+		t.Context(), projects.ID, s.RootID(), "RenamedProjects", projects.Revision,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "RenamedProjects", renamed.Name)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	_, err = s.NodeByPath(t.Context(), "/RenamedProjects/report.txt")
+	require.NoError(t, err)
+}
+
+func TestAuditedMoveRefusesMembershipAndWitnessBoundaryCrossings(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+
+	_, err = s.Move(t.Context(), report.ID, empty.ID, report.Name, report.Revision)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	unchanged, err := s.NodeByID(t.Context(), report.ID)
+	require.NoError(t, err)
+	assert.Equal(t, report, unchanged)
+
+	outside, err := s.NodeByPath(t.Context(), "/Empty/outside.txt")
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	movedOutside, err := s.Move(
+		t.Context(), outside.ID, projects.ID, outside.Name, outside.Revision,
+	)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	assert.Zero(t, movedOutside)
+}
+
+func TestAuditedMoveRollsBackTreeAndHistory(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	archive, err := s.NodeByPath(t.Context(), "/Projects/Archive")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_audit_move_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audit move failure'); END`)
+	require.NoError(t, err)
+
+	moved, err := s.Move(t.Context(), work.ID, archive.ID, "failed", work.Revision)
+	require.ErrorContains(t, err, "forced audit move failure")
+	assert.Zero(t, moved)
+	unchanged, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	assert.Equal(t, work.ID, *unchanged.ParentID)
+	var sequence, records int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM audit_records)`).Scan(&sequence, &records))
+	assert.Equal(t, int64(1), sequence)
+	assert.Equal(t, int64(8), records)
+}
+
+func newAuditedMoveStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	archive, err := s.Mkdir(t.Context(), projects.ID, "Archive")
+	require.NoError(t, err)
+	assert.NotZero(t, archive.ID)
+	work, err := s.Mkdir(t.Context(), projects.ID, "Work")
+	require.NoError(t, err)
+	_, err = s.CreateFile(
+		t.Context(), work.ID, "child.txt", fakeHash("a722"), 8, "text/plain",
+	)
+	require.NoError(t, err)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	_, err = s.CreateFile(
+		t.Context(), empty.ID, "outside.txt", fakeHash("a721"), 7, "text/plain",
+	)
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+	return s
+}
+
+func mustAuditUnsignedField(t *testing.T, record audit.Record, name string) uint64 {
+	t.Helper()
+	value, err := auditUnsignedField(record, name)
+	require.NoError(t, err)
+	return value
+}

--- a/internal/store/audit_node_move_validate.go
+++ b/internal/store/audit_node_move_validate.go
@@ -163,10 +163,88 @@ func (replay *auditedHistoryReplay) validateNodeMoveTopology(
 	if err := requireLiveDirectoryTopology(postTopology, newParentID); err != nil {
 		return replayedNodeMove{}, err
 	}
+	affectsTrashOrigin, err := auditMoveAffectsTrashOrigin(
+		replay.topology, replay.memberSet, movedID,
+	)
+	if err != nil {
+		return replayedNodeMove{}, err
+	}
+	if affectsTrashOrigin {
+		return replayedNodeMove{}, errors.New(
+			"node move changes a retained trash-origin path without recording trash effects",
+		)
+	}
+	if err := validateReplayedAuditTopology(postTopology); err != nil {
+		return replayedNodeMove{}, fmt.Errorf("validating node move topology: %w", err)
+	}
 	usedTopology[digest] = true
 	return replayedNodeMove{
 		topologyDigest: digest, postTopology: postTopology, changedIDs: changedIDs,
 	}, nil
+}
+
+func auditMoveAffectsTrashOrigin(
+	topology []audit.Record, memberSet map[uint64]bool, movedID uint64,
+) (bool, error) {
+	nodes, err := replayAuditTopology(topology)
+	if err != nil {
+		return false, err
+	}
+	for nodeID, node := range nodes {
+		if !memberSet[nodeID] || node.originParent == nil {
+			continue
+		}
+		current := *node.originParent
+		seen := make(map[uint64]bool)
+		for {
+			if current == movedID {
+				return true, nil
+			}
+			if seen[current] {
+				return false, errors.New("audit trash-origin topology contains a cycle")
+			}
+			seen[current] = true
+			parent, ok := nodes[current]
+			if !ok {
+				return false, fmt.Errorf("audit trash origin references missing node %d", current)
+			}
+			next, err := auditHistoricalParent(parent)
+			if err != nil {
+				return false, err
+			}
+			if next == nil {
+				break
+			}
+			current = *next
+		}
+	}
+	return false, nil
+}
+
+func auditHistoricalParent(node replayAuditTopologyNode) (*uint64, error) {
+	originValue, err := auditField(node.record, auditOriginField)
+	if err != nil {
+		return nil, err
+	}
+	if originValue.IsAbsent() {
+		return node.parentID, nil
+	}
+	origin, ok := originValue.RecordValue()
+	if !ok {
+		return nil, errors.New("audit topology contains an invalid trash origin")
+	}
+	switch origin.Kind {
+	case "unknown_origin":
+		return nil, nil //nolint:nilnil // Unknown origin deliberately terminates the historical path.
+	case "known_origin":
+		parentID, err := auditUnsignedField(origin, auditParentIDField)
+		if err != nil {
+			return nil, err
+		}
+		return &parentID, nil
+	default:
+		return nil, fmt.Errorf("audit topology contains unsupported origin %q", origin.Kind)
+	}
 }
 
 func validateNodeMoveTopologyChange(
@@ -187,11 +265,11 @@ func validateNodeMoveTopologyChange(
 	if err != nil {
 		return false, 0, 0, err
 	}
-	preName, err := auditBytesField(pre, "name")
+	preName, err := auditNameBytesField(pre)
 	if err != nil {
 		return false, 0, 0, err
 	}
-	postName, err := auditBytesField(post, "name")
+	postName, err := auditNameBytesField(post)
 	if err != nil {
 		return false, 0, 0, err
 	}
@@ -228,14 +306,14 @@ func validateNodeMoveTopologyChange(
 	return true, *preParent, *postParent, nil
 }
 
-func auditBytesField(record audit.Record, name string) ([]byte, error) {
-	value, err := auditField(record, name)
+func auditNameBytesField(record audit.Record) ([]byte, error) {
+	value, err := auditField(record, "name")
 	if err != nil {
 		return nil, err
 	}
 	result, ok := value.BytesValue()
 	if !ok {
-		return nil, fmt.Errorf("audit field %s.%s is not bytes", record.Kind, name)
+		return nil, fmt.Errorf("audit field %s.name is not bytes", record.Kind)
 	}
 	return result, nil
 }
@@ -249,7 +327,7 @@ func requireLiveDirectoryTopology(topology []audit.Record, nodeID uint64) error 
 		if id != nodeID {
 			continue
 		}
-		if err := requireAuditText(node, "node_kind", "dir"); err != nil {
+		if err := requireAuditText(node, "node_kind", nodeKindDir); err != nil {
 			return err
 		}
 		return requireAuditText(node, "state", "live")
@@ -375,7 +453,7 @@ func auditLivePath(topology []audit.Record, nodeID uint64) ([]byte, bool, error)
 		if parentID == nil {
 			break
 		}
-		name, err := auditBytesField(current, "name")
+		name, err := auditNameBytesField(current)
 		if err != nil {
 			return nil, false, err
 		}

--- a/internal/store/audit_node_move_validate.go
+++ b/internal/store/audit_node_move_validate.go
@@ -1,0 +1,594 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type replayedNodeMove struct {
+	topologyDigest, pathEffectDigest string
+	postTopology                     []audit.Record
+	effects                          []audit.Record
+	changedIDs                       []uint64
+}
+
+func (replay *auditedHistoryReplay) applyNodeMove(
+	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	topologyRecords, pathEffectRecords, eventRecords map[string]storedAuditRecord,
+	usedTopology, usedPathEffects, usedEvents map[string]bool,
+) error {
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUUID(mutation.record, auditVaultIDField, vaultID); err != nil {
+		return err
+	}
+	nextSequence, err := positiveAuditInteger(
+		"operation sequence", replay.allocationCount+1,
+	)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(
+		mutation.record, "operation_sequence", nextSequence,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
+		return err
+	}
+	bindings, err := auditRecordListField(mutation.record, "baselines")
+	if err != nil {
+		return err
+	}
+	if len(bindings) != 0 {
+		return errors.New("in-scope move cannot bind an enrollment baseline")
+	}
+	move, err := replay.validateNodeMoveTopology(
+		mutation.record, operationID, topologyRecords, usedTopology,
+	)
+	if err != nil {
+		return err
+	}
+	if err := replay.validateNodeMovePathEffects(
+		mutation.record, operationID, &move, pathEffectRecords, usedPathEffects,
+	); err != nil {
+		return err
+	}
+	if err := replay.validateNodeMoveStateChanges(mutation.record, move.changedIDs); err != nil {
+		return err
+	}
+	if err := replay.validateNodeMoveEvents(
+		mutation.record, operationID, move, eventRecords, usedEvents,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditAbsentFields(
+		mutation.record, "witness_change_digest", "attached_metadata_change_digest",
+	); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(mutation.record, auditWitnessChangeCountField, 0); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(mutation.record, auditAttachedMetadataChangeCountField, 0); err != nil {
+		return err
+	}
+	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+		return err
+	}
+	if err := replay.advanceNodeMoveAllocation(
+		vaultID, operationID, mutation, allocation, move,
+	); err != nil {
+		return err
+	}
+	return replay.applyNodeMoveState(move)
+}
+
+func (replay *auditedHistoryReplay) validateNodeMoveTopology(
+	mutation audit.Record, operationID string,
+	topologyRecords map[string]storedAuditRecord, usedTopology map[string]bool,
+) (replayedNodeMove, error) {
+	digest, err := auditDigestField(mutation, auditTopologyDeltaField)
+	if err != nil {
+		return replayedNodeMove{}, err
+	}
+	delta, ok := topologyRecords[digest]
+	if !ok || usedTopology[digest] {
+		return replayedNodeMove{}, errors.New("node move lacks one unique topology delta")
+	}
+	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
+		return replayedNodeMove{}, err
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return replayedNodeMove{}, err
+	}
+	if len(changes) < 2 || len(changes) > 3 {
+		return replayedNodeMove{}, errors.New("in-scope move topology must change two or three nodes")
+	}
+	postTopology := slices.Clone(replay.topology)
+	changedIDs := make([]uint64, 0, len(changes))
+	var movedID, oldParentID, newParentID uint64
+	for _, change := range changes {
+		nodeID, err := auditUnsignedField(change, metadataNodeIDField)
+		if err != nil {
+			return replayedNodeMove{}, err
+		}
+		if !replay.memberSet[nodeID] {
+			return replayedNodeMove{}, fmt.Errorf("in-scope move changes unaudited node %d", nodeID)
+		}
+		pre, preErr := optionalAuditNestedField(change, "pre")
+		post, postErr := optionalAuditNestedField(change, "post")
+		if preErr != nil || postErr != nil || pre == nil || post == nil {
+			return replayedNodeMove{}, errors.New("in-scope move requires complete topology sides")
+		}
+		index, ok := replay.topologyIndex[nodeID]
+		if !ok || !auditRecordEqual(replay.topology[index], *pre) {
+			return replayedNodeMove{}, fmt.Errorf("node move pre-state for %d does not match replay", nodeID)
+		}
+		pathChanged, priorParent, resultingParent, err := validateNodeMoveTopologyChange(
+			mutation, *pre, *post,
+		)
+		if err != nil {
+			return replayedNodeMove{}, err
+		}
+		if pathChanged {
+			if movedID != 0 {
+				return replayedNodeMove{}, errors.New("node move topology changes multiple paths directly")
+			}
+			movedID, oldParentID, newParentID = nodeID, priorParent, resultingParent
+		}
+		postTopology[index] = *post
+		changedIDs = append(changedIDs, nodeID)
+	}
+	if movedID == 0 || !slices.Contains(changedIDs, oldParentID) ||
+		!slices.Contains(changedIDs, newParentID) {
+		return replayedNodeMove{}, errors.New("node move topology lacks its changed parent state")
+	}
+	wantChanges := 2
+	if oldParentID != newParentID {
+		wantChanges = 3
+	}
+	if len(changes) != wantChanges {
+		return replayedNodeMove{}, errors.New("node move topology has an unexpected changed-node set")
+	}
+	if err := requireLiveDirectoryTopology(postTopology, oldParentID); err != nil {
+		return replayedNodeMove{}, err
+	}
+	if err := requireLiveDirectoryTopology(postTopology, newParentID); err != nil {
+		return replayedNodeMove{}, err
+	}
+	usedTopology[digest] = true
+	return replayedNodeMove{
+		topologyDigest: digest, postTopology: postTopology, changedIDs: changedIDs,
+	}, nil
+}
+
+func validateNodeMoveTopologyChange(
+	mutation, pre, post audit.Record,
+) (bool, uint64, uint64, error) {
+	preID, err := auditUnsignedField(pre, metadataNodeIDField)
+	if err != nil {
+		return false, 0, 0, err
+	}
+	if err := requireAuditUnsigned(post, metadataNodeIDField, preID); err != nil {
+		return false, 0, 0, err
+	}
+	preParent, err := auditOptionalParentIDField(pre)
+	if err != nil {
+		return false, 0, 0, err
+	}
+	postParent, err := auditOptionalParentIDField(post)
+	if err != nil {
+		return false, 0, 0, err
+	}
+	preName, err := auditBytesField(pre, "name")
+	if err != nil {
+		return false, 0, 0, err
+	}
+	postName, err := auditBytesField(post, "name")
+	if err != nil {
+		return false, 0, 0, err
+	}
+	parentsEqual := (preParent == nil) == (postParent == nil) &&
+		(preParent == nil || *preParent == *postParent)
+	pathChanged := !parentsEqual || !slices.Equal(preName, postName)
+	if pathChanged && (preParent == nil || postParent == nil) {
+		return false, 0, 0, errors.New("node move cannot add or remove the vault root")
+	}
+	modifiedAt, err := auditField(mutation, auditRecordedAtField)
+	if err != nil {
+		return false, 0, 0, err
+	}
+	expected, err := replaceAuditRecordField(pre, "modified_at", modifiedAt)
+	if err != nil {
+		return false, 0, 0, err
+	}
+	if pathChanged {
+		expected, err = replaceAuditRecordField(expected, "parent_id", audit.Unsigned(*postParent))
+		if err != nil {
+			return false, 0, 0, err
+		}
+		expected, err = replaceAuditRecordField(expected, "name", audit.Bytes(postName))
+		if err != nil {
+			return false, 0, 0, err
+		}
+	}
+	if !auditRecordEqual(expected, post) {
+		return false, 0, 0, fmt.Errorf("node move post-state for %d has unsupported changes", preID)
+	}
+	if !pathChanged {
+		return false, 0, 0, nil
+	}
+	return true, *preParent, *postParent, nil
+}
+
+func auditBytesField(record audit.Record, name string) ([]byte, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	result, ok := value.BytesValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not bytes", record.Kind, name)
+	}
+	return result, nil
+}
+
+func requireLiveDirectoryTopology(topology []audit.Record, nodeID uint64) error {
+	for _, node := range topology {
+		id, err := auditUnsignedField(node, metadataNodeIDField)
+		if err != nil {
+			return err
+		}
+		if id != nodeID {
+			continue
+		}
+		if err := requireAuditText(node, "node_kind", "dir"); err != nil {
+			return err
+		}
+		return requireAuditText(node, "state", "live")
+	}
+	return fmt.Errorf("node move parent %d is absent from topology", nodeID)
+}
+
+func (replay *auditedHistoryReplay) validateNodeMovePathEffects(
+	mutation audit.Record, operationID string, move *replayedNodeMove,
+	pathEffectRecords map[string]storedAuditRecord, usedPathEffects map[string]bool,
+) error {
+	digest, err := auditDigestField(mutation, "path_effect_digest")
+	if err != nil {
+		return err
+	}
+	list, ok := pathEffectRecords[digest]
+	if !ok || usedPathEffects[digest] {
+		return errors.New("node move lacks one unique path-effect list")
+	}
+	if err := requireAuditUUID(list.record, auditOperationIDField, operationID); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(list.record, auditTopologyDeltaField, move.topologyDigest); err != nil {
+		return err
+	}
+	stored, err := auditRecordListField(list.record, "effects")
+	if err != nil {
+		return err
+	}
+	expected, err := replay.deriveNodeMovePathEffects(move.postTopology)
+	if err != nil {
+		return err
+	}
+	if len(expected) == 0 || !equalAuditRecordLists(stored, expected) {
+		return errors.New("node move path effects do not match replayed topology")
+	}
+	if err := requireAuditUnsigned(mutation, "path_effect_count", uint64(len(expected))); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(mutation, "path_effect_digest", digest); err != nil {
+		return err
+	}
+	move.pathEffectDigest, move.effects = digest, expected
+	usedPathEffects[digest] = true
+	return nil
+}
+
+func (replay *auditedHistoryReplay) deriveNodeMovePathEffects(
+	postTopology []audit.Record,
+) ([]audit.Record, error) {
+	scopeID, err := audit.UUID(replay.scopeID)
+	if err != nil {
+		return nil, err
+	}
+	live, err := audit.Text("live")
+	if err != nil {
+		return nil, err
+	}
+	memberIDs := slices.Clone(replay.members)
+	slices.Sort(memberIDs)
+	var effects []audit.Record
+	for _, nodeID := range memberIDs {
+		priorPath, priorLive, err := auditLivePath(replay.topology, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		postPath, postLive, err := auditLivePath(postTopology, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		if !priorLive || !postLive || slices.Equal(priorPath, postPath) {
+			continue
+		}
+		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
+			{Name: auditScopeIDField, Value: scopeID},
+			{Name: "member_node_id", Value: audit.Unsigned(nodeID)},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
+				{Name: "path", Value: audit.Bytes(priorPath)}, {Name: "state", Value: live},
+			}})},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
+				{Name: "path", Value: audit.Bytes(postPath)}, {Name: "state", Value: live},
+			}})},
+		}})
+	}
+	return effects, nil
+}
+
+func auditLivePath(topology []audit.Record, nodeID uint64) ([]byte, bool, error) {
+	byID := make(map[uint64]audit.Record, len(topology))
+	for _, node := range topology {
+		id, err := auditUnsignedField(node, metadataNodeIDField)
+		if err != nil {
+			return nil, false, err
+		}
+		byID[id] = node
+	}
+	current, ok := byID[nodeID]
+	if !ok {
+		return nil, false, fmt.Errorf("audit topology lacks node %d", nodeID)
+	}
+	state, err := auditTextField(current, "state")
+	if err != nil {
+		return nil, false, err
+	}
+	if state != "live" {
+		return nil, false, nil
+	}
+	visited := make(map[uint64]bool)
+	var components [][]byte
+	for {
+		id, err := auditUnsignedField(current, metadataNodeIDField)
+		if err != nil {
+			return nil, false, err
+		}
+		if visited[id] {
+			return nil, false, errors.New("audit topology contains a live-parent cycle")
+		}
+		visited[id] = true
+		parentID, err := auditOptionalParentIDField(current)
+		if err != nil {
+			return nil, false, err
+		}
+		if parentID == nil {
+			break
+		}
+		name, err := auditBytesField(current, "name")
+		if err != nil {
+			return nil, false, err
+		}
+		components = append(components, name)
+		parent, exists := byID[*parentID]
+		if !exists {
+			return nil, false, fmt.Errorf("audit topology node %d has missing live parent %d", id, *parentID)
+		}
+		if err := requireAuditText(parent, "state", "live"); err != nil {
+			return nil, false, err
+		}
+		current = parent
+	}
+	result := []byte{'/'}
+	for _, v := range slices.Backward(components) {
+		if len(result) > 1 {
+			result = append(result, '/')
+		}
+		result = append(result, v...)
+	}
+	return result, true, nil
+}
+
+func (replay *auditedHistoryReplay) validateNodeMoveStateChanges(
+	mutation audit.Record, changedIDs []uint64,
+) error {
+	changes, err := auditRecordListField(mutation, "member_state_changes")
+	if err != nil {
+		return err
+	}
+	if len(changes) != len(changedIDs) {
+		return errors.New("node move member-state changes do not match changed topology")
+	}
+	for index, nodeID := range changedIDs {
+		state := replay.states[nodeID]
+		priorRevision, err := auditUnsignedField(state, "node_revision")
+		if err != nil {
+			return err
+		}
+		current, err := auditOptionalUUIDField(state, "current_version_id")
+		if err != nil {
+			return err
+		}
+		change := changes[index]
+		checks := []func() error{
+			func() error { return requireAuditUnsigned(change, metadataNodeIDField, nodeID) },
+			func() error { return requireAuditUnsigned(change, "prior_revision", priorRevision) },
+			func() error { return requireAuditUnsigned(change, "resulting_revision", priorRevision+1) },
+			func() error { return requireAuditOptionalUUID(change, "prior_current_version_id", current) },
+			func() error { return requireAuditOptionalUUID(change, "resulting_current_version_id", current) },
+		}
+		for _, check := range checks {
+			if err := check(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) validateNodeMoveEvents(
+	mutation audit.Record, operationID string, move replayedNodeMove,
+	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
+) error {
+	events, err := auditRecordListField(mutation, "events")
+	if err != nil {
+		return err
+	}
+	if len(events) != len(move.effects) {
+		return errors.New("node move event set does not match its path effects")
+	}
+	changed := make(map[uint64]bool, len(move.changedIDs))
+	for _, id := range move.changedIDs {
+		changed[id] = true
+	}
+	ordinal := uint64(0)
+	for index, event := range events {
+		effect := move.effects[index]
+		nodeID, err := auditUnsignedField(effect, "member_node_id")
+		if err != nil {
+			return err
+		}
+		if err := validateCreationEventWrapper(
+			operationID, ordinal, event, eventRecords, usedEvents,
+		); err != nil {
+			return err
+		}
+		state := replay.states[nodeID]
+		priorRevision, err := auditUnsignedField(state, "node_revision")
+		if err != nil {
+			return err
+		}
+		resultingRevision := priorRevision
+		if changed[nodeID] {
+			resultingRevision++
+		}
+		current, err := auditOptionalUUIDField(state, "current_version_id")
+		if err != nil {
+			return err
+		}
+		pre, err := auditNestedField(effect, "old")
+		if err != nil {
+			return err
+		}
+		post, err := auditNestedField(effect, "new")
+		if err != nil {
+			return err
+		}
+		checks := []func() error{
+			func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
+			func() error { return requireAuditUnsigned(event, metadataNodeIDField, nodeID) },
+			func() error { return requireAuditText(event, "event_kind", "node_path") },
+			func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
+			func() error { return requireAuditUnsigned(event, auditEventOrdinalField, ordinal) },
+			func() error { return requireAuditUnsigned(event, "prior_node_revision", priorRevision) },
+			func() error { return requireAuditUnsigned(event, "resulting_node_revision", resultingRevision) },
+			func() error { return requireAuditOptionalUUID(event, "prior_current_version_id", current) },
+			func() error { return requireAuditOptionalUUID(event, "resulting_current_version_id", current) },
+			func() error { return requireAuditDigest(event, auditTopologyDeltaField, move.topologyDigest) },
+		}
+		for _, check := range checks {
+			if err := check(); err != nil {
+				return err
+			}
+		}
+		if err := requireMatchingEventEnvelope(mutation, event); err != nil {
+			return err
+		}
+		ordinal++
+		if err := requireAuditAbsentFields(
+			event, "target_node_id", "attachment_kind", "attachment_identity",
+			"source_version_id", "baseline_digest",
+		); err != nil {
+			return err
+		}
+		eventPre, err := auditNestedField(event, "pre")
+		if err != nil || !auditRecordEqual(eventPre, pre) {
+			return errors.New("node move event pre-state does not match its path effect")
+		}
+		eventPost, err := auditNestedField(event, "post")
+		if err != nil || !auditRecordEqual(eventPost, post) {
+			return errors.New("node move event post-state does not match its path effect")
+		}
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) advanceNodeMoveAllocation(
+	vaultID, operationID string, mutation, entry storedAuditRecord, move replayedNodeMove,
+) error {
+	nextCount := replay.allocationCount + 1
+	auditCount, err := positiveAuditInteger("allocation entry count", nextCount)
+	if err != nil {
+		return err
+	}
+	checks := []func() error{
+		func() error { return requireAuditUUID(entry.record, auditVaultIDField, vaultID) },
+		func() error { return requireAuditUUID(entry.record, "lineage_id", replay.lineageID) },
+		func() error { return requireAuditUUID(entry.record, auditOperationIDField, operationID) },
+		func() error { return requireAuditDigest(entry.record, "previous_head", replay.allocationHead) },
+		func() error { return requireAuditUnsigned(entry.record, "operation_sequence", auditCount) },
+		func() error { return requireAuditUnsigned(entry.record, "operation_sequence_high_water", auditCount) },
+		func() error { return requireAuditUnsigned(entry.record, "node_id_high_water", replay.nodeHighWater) },
+		func() error { return requireAuditBool(entry.record, "has_audited_mutation", true) },
+		func() error { return requireAuditBool(entry.record, "has_topology_change", true) },
+		func() error { return requireAuditDigest(entry.record, auditTopologyDeltaField, move.topologyDigest) },
+		func() error { return requireAuditBool(entry.record, "has_witness_change", false) },
+		func() error { return requireAuditUnsigned(entry.record, auditWitnessChangeCountField, 0) },
+		func() error { return requireAuditAbsent(entry.record, "witness_change_digest") },
+		func() error { return requireAuditBool(entry.record, "has_attached_metadata_change", false) },
+		func() error { return requireAuditUnsigned(entry.record, auditAttachedMetadataChangeCountField, 0) },
+		func() error { return requireAuditAbsent(entry.record, "attached_metadata_change_digest") },
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	allocated, err := auditUnsignedListField(entry.record, "allocated_node_ids")
+	if err != nil {
+		return err
+	}
+	if len(allocated) != 0 {
+		return errors.New("node move allocation cannot allocate node IDs")
+	}
+	mutationDigest, err := hashAuditRecord(mutation.record)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditDigest(entry.record, "mutation_hash", mutationDigest.text); err != nil {
+		return err
+	}
+	replay.allocationCount, replay.allocationHead = nextCount, entry.digest
+	return nil
+}
+
+func (replay *auditedHistoryReplay) applyNodeMoveState(move replayedNodeMove) error {
+	for _, nodeID := range move.changedIDs {
+		state := replay.states[nodeID]
+		revision, err := auditUnsignedField(state, "node_revision")
+		if err != nil {
+			return err
+		}
+		current, err := auditField(state, "current_version_id")
+		if err != nil {
+			return err
+		}
+		replay.states[nodeID] = audit.Record{Kind: "member_state", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+			{Name: "node_revision", Value: audit.Unsigned(revision + 1)},
+			{Name: "current_version_id", Value: current},
+		}}
+	}
+	replay.topology = move.postTopology
+	return nil
+}

--- a/internal/store/audit_node_move_validate.go
+++ b/internal/store/audit_node_move_validate.go
@@ -390,11 +390,15 @@ func (replay *auditedHistoryReplay) deriveNodeMovePathEffects(
 	slices.Sort(memberIDs)
 	var effects []audit.Record
 	for _, nodeID := range memberIDs {
-		priorPath, priorLive, err := auditLivePath(replay.topology, nodeID)
+		priorPath, priorLive, err := auditLivePath(
+			replay.topology, replay.topologyIndex, nodeID,
+		)
 		if err != nil {
 			return nil, err
 		}
-		postPath, postLive, err := auditLivePath(postTopology, nodeID)
+		postPath, postLive, err := auditLivePath(
+			postTopology, replay.topologyIndex, nodeID,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -415,19 +419,14 @@ func (replay *auditedHistoryReplay) deriveNodeMovePathEffects(
 	return effects, nil
 }
 
-func auditLivePath(topology []audit.Record, nodeID uint64) ([]byte, bool, error) {
-	byID := make(map[uint64]audit.Record, len(topology))
-	for _, node := range topology {
-		id, err := auditUnsignedField(node, metadataNodeIDField)
-		if err != nil {
-			return nil, false, err
-		}
-		byID[id] = node
-	}
-	current, ok := byID[nodeID]
+func auditLivePath(
+	topology []audit.Record, topologyIndex map[uint64]int, nodeID uint64,
+) ([]byte, bool, error) {
+	index, ok := topologyIndex[nodeID]
 	if !ok {
 		return nil, false, fmt.Errorf("audit topology lacks node %d", nodeID)
 	}
+	current := topology[index]
 	state, err := auditTextField(current, "state")
 	if err != nil {
 		return nil, false, err
@@ -458,10 +457,11 @@ func auditLivePath(topology []audit.Record, nodeID uint64) ([]byte, bool, error)
 			return nil, false, err
 		}
 		components = append(components, name)
-		parent, exists := byID[*parentID]
+		parentIndex, exists := topologyIndex[*parentID]
 		if !exists {
 			return nil, false, fmt.Errorf("audit topology node %d has missing live parent %d", id, *parentID)
 		}
+		parent := topology[parentIndex]
 		if err := requireAuditText(parent, "state", "live"); err != nil {
 			return nil, false, err
 		}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -781,7 +781,7 @@ var metadataHeaderFields = []string{metadataTypeField, "format", "version", audi
 var metadataRequiredFields = map[string][]string{
 	"blob":                      {metadataTypeField, "hash", "size", "created_at"},
 	"node":                      {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", "created_at", "modified_at", "trashed_at", "trash_parent", "trash_name"},
-	"content_version":           {metadataTypeField, "version_id", metadataNodeIDField, "blob_hash", "size", "mime_type", "recorded_at", "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
+	"content_version":           {metadataTypeField, "version_id", metadataNodeIDField, "blob_hash", "size", "mime_type", auditRecordedAtField, "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
 	metadataIngestType:          {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
 	metadataProvenanceType:      {metadataTypeField, "identity", metadataNodeIDField, "ingest_id", "original_path", "original_mtime", "supersedes"},
 	"tag":                       {metadataTypeField, "tag_id", "name", "revision"},

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -916,7 +916,7 @@ func validateNodeRecord(v metadataNode) error {
 		}
 	}
 	if v.ParentID == nil {
-		if v.Name != "" || v.Kind != "dir" || v.CurrentVersionID != nil || v.TrashedAt != nil ||
+		if v.Name != "" || v.Kind != nodeKindDir || v.CurrentVersionID != nil || v.TrashedAt != nil ||
 			v.TrashParent != nil || v.TrashName != nil {
 			return errors.New("invalid root node record")
 		}
@@ -930,7 +930,7 @@ func validateNodeRecord(v metadataNode) error {
 		return fmt.Errorf("invalid node name %q", v.Name)
 	}
 	switch v.Kind {
-	case "dir":
+	case nodeKindDir:
 		if v.CurrentVersionID != nil {
 			return errors.New("directory record carries file content")
 		}

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const nodeKindDir = "dir"
+
 // Node is a row of the virtual tree. IDs are canonical; paths are display.
 type Node struct {
 	ID               int64
@@ -25,7 +27,7 @@ type Node struct {
 }
 
 // IsDir reports whether the node is a directory.
-func (n Node) IsDir() bool { return n.Kind == "dir" }
+func (n Node) IsDir() bool { return n.Kind == nodeKindDir }
 
 const nodeFrom = `nodes AS n
 	LEFT JOIN content_versions AS cv
@@ -198,7 +200,7 @@ func (s *Store) ChildrenPage(
 		); err != nil {
 			return nil, 0, fmt.Errorf("listing children of %d: scanning page: %w", dirID, err)
 		}
-		if targetKind != "dir" {
+		if targetKind != nodeKindDir {
 			return nil, 0, fmt.Errorf("node %d: %w", dirID, ErrNotDir)
 		}
 		if child.ID != 0 {

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -161,7 +161,7 @@ CREATE TABLE IF NOT EXISTS audit_records (
         'enrollment_baseline', 'topology_genesis',
         'attached_metadata_genesis', 'event', 'canonical_mutation',
         'scope_chain_entry', 'allocation_genesis', 'allocation_entry',
-        'topology_delta', 'attached_metadata_delta'
+        'topology_delta', 'path_effect_list', 'attached_metadata_delta'
     )),
     operation_id       TEXT,
     operation_sequence INTEGER CHECK (operation_sequence IS NULL OR operation_sequence > 0),

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -336,8 +336,16 @@ func isAncestorTx(tx *sql.Tx, maybeAncestor, candidate int64) (bool, error) {
 // unless ifRev matches the node's current revision.
 func (s *Store) Move(ctx context.Context, id, newParentID int64, newName string, ifRev int64) (Node, error) {
 	var moved Node
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		var err error
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if active {
+			moved, err = s.moveAuditedTx(ctx, tx, id, newParentID, newName, ifRev)
+			return err
+		}
 		moved, err = s.moveTx(tx, id, newParentID, newName, ifRev)
 		return err
 	})
@@ -354,7 +362,7 @@ func (s *Store) Move(ctx context.Context, id, newParentID int64, newName string,
 // the new name.
 func (s *Store) MovePath(ctx context.Context, srcPath, destPath string) (Node, error) {
 	var moved Node
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		src, err := nodeByPath(ctx, tx, s.rootID, srcPath)
 		if err != nil {
 			return fmt.Errorf("resolving %q: %w", srcPath, err)
@@ -364,6 +372,16 @@ func (s *Store) MovePath(ctx context.Context, srcPath, destPath string) (Node, e
 		}
 		newParentID, newName, err := s.resolveMoveTargetTx(ctx, tx, destPath, src.Name)
 		if err != nil {
+			return err
+		}
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if active {
+			moved, err = s.moveAuditedTx(
+				ctx, tx, src.ID, newParentID, newName, UnconditionalRev,
+			)
 			return err
 		}
 		moved, err = s.moveTx(tx, src.ID, newParentID, newName, UnconditionalRev)
@@ -410,6 +428,12 @@ func (s *Store) resolveMoveTargetTx(
 }
 
 func (s *Store) moveTx(tx *sql.Tx, id, newParentID int64, newName string, ifRev int64) (Node, error) {
+	return s.moveAtTx(tx, id, newParentID, newName, ifRev, nowRFC3339())
+}
+
+func (s *Store) moveAtTx(
+	tx *sql.Tx, id, newParentID int64, newName string, ifRev int64, recordedAt string,
+) (Node, error) {
 	if id == s.rootID {
 		return Node{}, ErrIsRoot
 	}
@@ -431,6 +455,9 @@ func (s *Store) moveTx(tx *sql.Tx, id, newParentID int64, newName string, ifRev 
 	if _, err := liveDirTx(tx, newParentID); err != nil {
 		return Node{}, err
 	}
+	if *n.ParentID == newParentID && n.Name == newName {
+		return n, nil
+	}
 	// The destination may not be the node itself or any of its
 	// descendants (equivalently: id may not be an ancestor of dest).
 	inCycle, err := isAncestorTx(tx, id, newParentID)
@@ -440,11 +467,10 @@ func (s *Store) moveTx(tx *sql.Tx, id, newParentID int64, newName string, ifRev 
 	if inCycle {
 		return Node{}, fmt.Errorf("moving node %d under %d: %w", id, newParentID, ErrCycle)
 	}
-	now := nowRFC3339()
 	_, err = tx.Exec(
 		`UPDATE nodes SET parent_id = ?, name = ?, revision = revision + 1,
 		        modified_at = ? WHERE id = ?`,
-		newParentID, newName, now, id)
+		newParentID, newName, recordedAt, id)
 	if s.driver.IsUniqueViolation(err) {
 		return Node{}, fmt.Errorf("moving node %d to %q: %w", id, newName, ErrExists)
 	}
@@ -452,11 +478,11 @@ func (s *Store) moveTx(tx *sql.Tx, id, newParentID int64, newName string, ifRev 
 		return Node{}, fmt.Errorf("moving node %d: %w", id, err)
 	}
 	oldParent := *n.ParentID
-	if err := bumpRevisionTx(tx, oldParent, now); err != nil {
+	if err := bumpRevisionTx(tx, oldParent, recordedAt); err != nil {
 		return Node{}, err
 	}
 	if newParentID != oldParent {
-		if err := bumpRevisionTx(tx, newParentID, now); err != nil {
+		if err := bumpRevisionTx(tx, newParentID, recordedAt); err != nil {
 			return Node{}, err
 		}
 	}


### PR DESCRIPTION
Once a folder is under full audit, people still need to reorganize it without breaking permanent history. For example, moving `/Taxes/Unsorted/2025` to `/Taxes/Filed/2025` changes the visible path of every document beneath it even though those documents keep their stable identities. Before this change, Docbank refused that ordinary move.

This PR records the directory move and every resulting descendant path change as one operation. A receipt moved indirectly with its parent remains the same document, while its old and new paths become part of the retained history. If recording the history fails, the move is rolled back too.

Backup restore does not simply trust the recorded list. It reconstructs the audited tree before and after each move and verifies that every affected document was included. It also checks each intermediate tree for valid names and sibling conflicts, so a backup cannot hide an impossible temporary state that happens to look valid at the end.

There are two deliberate limits for now. A move cannot cross an audit boundary or change protected membership. It is also blocked when a trashed document remembers an origin beneath the directory being moved, because that remembered trash path would change too; support for that case should arrive only when Docbank can record the trash-path effect explicitly.

The rules live in Go so future metadata backends can enforce the same behavior. SQLite only stores the additional canonical record kind.

Kata: 2dsm.