### PR TITLE
Record reversible audited trash transitions

### DIFF
--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -25,7 +25,7 @@ func deriveInitialAuditMembersFromRecords(
 		return nil, err
 	}
 	target, ok := nodes[targetNodeID]
-	if !ok || target.kind != nodeKindDir || target.state != "live" {
+	if !ok || target.kind != nodeKindDir || target.state != auditNodeStateLive {
 		return nil, fmt.Errorf("audit enrollment target %d must be a live directory", targetNodeID)
 	}
 	children := make(map[uint64][]uint64)
@@ -39,7 +39,7 @@ func deriveInitialAuditMembersFromRecords(
 	for changed := true; changed; {
 		changed = false
 		for nodeID, node := range nodes {
-			if node.state != "trash" || members[nodeID] {
+			if node.state != auditNodeStateTrash || members[nodeID] {
 				continue
 			}
 			adopt := node.originParent != nil && members[*node.originParent]
@@ -124,7 +124,8 @@ func validateReplayedAuditTopology(topology []audit.Record) error {
 			return err
 		}
 		if node.parentID == nil {
-			if rootID != 0 || len(nameBytes) != 0 || node.kind != nodeKindDir || node.state != "live" {
+			if rootID != 0 || len(nameBytes) != 0 || node.kind != nodeKindDir ||
+				node.state != auditNodeStateLive {
 				return errors.New("audit topology has an invalid vault root")
 			}
 			rootID = nodeID
@@ -135,11 +136,11 @@ func validateReplayedAuditTopology(topology []audit.Record) error {
 		if err != nil || normalized != name {
 			return fmt.Errorf("audit topology node %d has invalid canonical name", nodeID)
 		}
-		if node.state != "live" {
+		if node.state != auditNodeStateLive {
 			continue
 		}
 		parent, ok := nodes[*node.parentID]
-		if !ok || parent.state != "live" || parent.kind != nodeKindDir {
+		if !ok || parent.state != auditNodeStateLive || parent.kind != nodeKindDir {
 			return fmt.Errorf("live audit topology node %d has an invalid parent", nodeID)
 		}
 		key := liveSibling{parentID: *node.parentID, name: name}
@@ -162,7 +163,7 @@ func addReplayAuditDescendants(
 	children map[uint64][]uint64, members map[uint64]bool, liveOnly bool,
 ) {
 	for _, child := range children[root] {
-		if members[child] || (liveOnly && nodes[child].state != "live") {
+		if members[child] || (liveOnly && nodes[child].state != auditNodeStateLive) {
 			continue
 		}
 		members[child] = true
@@ -324,11 +325,22 @@ func validateAuditedHistory(
 				usedTopologyDeltas, usedAttachmentDeltas, usedEvents,
 			)
 		} else {
-			err = replay.applyNodeMove(
-				vaultID, mutation, allocations[sequence], entries[sequence],
-				topologyDeltas, pathEffectLists, events,
-				usedTopologyDeltas, usedPathEffectLists, usedEvents,
-			)
+			kind, kindErr := classifyAuditedTopologyMutation(mutation.record, topologyDeltas)
+			if kindErr != nil {
+				err = kindErr
+			} else if kind == auditedTopologyTrash {
+				err = replay.applyNodeTrash(
+					vaultID, mutation, allocations[sequence], entries[sequence],
+					topologyDeltas, pathEffectLists, events,
+					usedTopologyDeltas, usedPathEffectLists, usedEvents,
+				)
+			} else {
+				err = replay.applyNodeMove(
+					vaultID, mutation, allocations[sequence], entries[sequence],
+					topologyDeltas, pathEffectLists, events,
+					usedTopologyDeltas, usedPathEffectLists, usedEvents,
+				)
+			}
 		}
 		if err != nil {
 			return fmt.Errorf("validating audit operation %d: %w", sequence, err)
@@ -365,6 +377,54 @@ func validateAuditedHistory(
 		return errors.New("audit node allocation high-water mark does not match replayed history")
 	}
 	return replay.reconcileCurrentState(ctx, tx)
+}
+
+const (
+	auditedTopologyMove  = "move"
+	auditedTopologyTrash = "trash"
+)
+
+func classifyAuditedTopologyMutation(
+	mutation audit.Record, topologyRecords map[string]storedAuditRecord,
+) (string, error) {
+	digest, err := auditDigestField(mutation, auditTopologyDeltaField)
+	if err != nil {
+		return "", err
+	}
+	delta, ok := topologyRecords[digest]
+	if !ok {
+		return "", errors.New("topology mutation lacks its topology delta")
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return "", err
+	}
+	kind := auditedTopologyMove
+	for _, change := range changes {
+		pre, preErr := auditNestedField(change, "pre")
+		post, postErr := auditNestedField(change, "post")
+		if preErr != nil || postErr != nil {
+			return "", errors.New("topology mutation requires complete pre/post states")
+		}
+		preState, err := auditTextField(pre, "state")
+		if err != nil {
+			return "", err
+		}
+		postState, err := auditTextField(post, "state")
+		if err != nil {
+			return "", err
+		}
+		switch {
+		case preState == auditNodeStateLive && postState == auditNodeStateLive:
+		case preState == auditNodeStateLive && postState == auditNodeStateTrash:
+			kind = auditedTopologyTrash
+		default:
+			return "", fmt.Errorf(
+				"unsupported audited topology state transition %s to %s", preState, postState,
+			)
+		}
+	}
+	return kind, nil
 }
 
 func auditRecordsByDigest(records []storedAuditRecord) map[string]storedAuditRecord {

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -235,7 +235,7 @@ func validateCreatedTopologyNode(
 	checks := []func() error{
 		func() error { return requireAuditUnsigned(node, metadataNodeIDField, childID) },
 		func() error { return requireAuditUnsigned(node, "parent_id", parentID) },
-		func() error { return requireAuditText(node, "state", "live") },
+		func() error { return requireAuditText(node, "state", auditNodeStateLive) },
 		func() error { return requireAuditAbsent(node, auditOriginField) },
 		func() error { return requireAuditAbsent(node, "trashed_at") },
 	}

--- a/internal/store/audit_node_move.go
+++ b/internal/store/audit_node_move.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 
 	"go.kenn.io/docbank/internal/audit"
@@ -278,99 +279,15 @@ func persistAuditedMove(
 	if err != nil {
 		return err
 	}
-	topologyDigest, err := hashAuditRecord(topology)
+	effects, err := makeAuditedMovePathEffects(snapshot, resultingPaths)
 	if err != nil {
 		return err
 	}
-	effects, effectList, effectDigest, err := makeAuditedMovePathEffects(
-		values, snapshot, resultingPaths, topologyDigest,
+	return persistAuditedTopologyMutation(
+		ctx, tx, values, snapshot.authority, snapshot.scope, snapshot.nodeSequence,
+		topology, effects, snapshot.priorNodes, resultingNodes,
+		snapshot.priorSubtree, resultingSubtree,
 	)
-	if err != nil {
-		return err
-	}
-	stateChanges, err := makeAuditedMoveStateChanges(snapshot.priorNodes, resultingNodes)
-	if err != nil {
-		return err
-	}
-	events, err := makeAuditedMoveEvents(
-		values, snapshot.scope.scopeID, snapshot, resultingSubtree, effects, topologyDigest,
-	)
-	if err != nil {
-		return err
-	}
-	mutation, err := makeAuditedMoveMutation(
-		values, snapshot.authority.sequence+1, events, stateChanges,
-		topologyDigest, uint64(len(effects)), effectDigest,
-	)
-	if err != nil {
-		return err
-	}
-	mutationDigest, err := hashAuditRecord(mutation)
-	if err != nil {
-		return err
-	}
-	for _, record := range []audit.Record{topology, effectList} {
-		if err := insertAuditRecord(ctx, tx, record); err != nil {
-			return err
-		}
-	}
-	for _, event := range events {
-		if err := insertAuditRecord(ctx, tx, audit.Record{Kind: auditEventField, Fields: []audit.Field{
-			{Name: auditEventField, Value: audit.Nested(event)},
-		}}); err != nil {
-			return err
-		}
-	}
-	if err := insertAuditRecord(ctx, tx, mutation); err != nil {
-		return err
-	}
-	entryCount, err := nextAuditInteger("scope entry count", snapshot.scope.entryCount)
-	if err != nil {
-		return err
-	}
-	entry, err := makeAuditScopeChainEntry(
-		values, snapshot.scope.scopeID, entryCount, snapshot.scope.chainHead, mutationDigest.value,
-	)
-	if err != nil {
-		return err
-	}
-	scopeHead, err := hashAuditRecord(entry)
-	if err != nil {
-		return err
-	}
-	if err := insertAuditRecord(ctx, tx, entry); err != nil {
-		return err
-	}
-	if _, err := tx.ExecContext(ctx, `UPDATE audit_scopes SET entry_count=?,chain_head=? WHERE scope_id=?`,
-		entryCount, scopeHead.text, snapshot.scope.scopeID); err != nil {
-		return fmt.Errorf("advancing audit scope %s: %w", snapshot.scope.scopeID, err)
-	}
-	allocation, err := makeAuditedMoveAllocationEntry(
-		values, snapshot.authority.sequence+1, snapshot.nodeSequence,
-		snapshot.authority.allocationHead, mutationDigest.value, topologyDigest.value,
-	)
-	if err != nil {
-		return err
-	}
-	allocationHead, err := hashAuditRecord(allocation)
-	if err != nil {
-		return err
-	}
-	if err := insertAuditRecord(ctx, tx, allocation); err != nil {
-		return err
-	}
-	allocationCount, err := nextAuditInteger(
-		"allocation entry count", snapshot.authority.allocationCount,
-	)
-	if err != nil {
-		return err
-	}
-	if _, err := tx.ExecContext(ctx, `UPDATE audit_authority
-		SET operation_sequence_high_water=?,allocation_entry_count=?,allocation_head=?
-		WHERE singleton=1`, snapshot.authority.sequence+1, allocationCount, allocationHead.text); err != nil {
-		return fmt.Errorf("advancing audit allocation authority: %w", err)
-	}
-	return nil
 }
 
 func makeAuditedMoveTopologyDelta(
@@ -403,33 +320,36 @@ func makeAuditedMoveTopologyDelta(
 	if err := sortAuditTopologyRecords(changes); err != nil {
 		return audit.Record{}, err
 	}
+	return makeAuditedTopologyDelta(operationID, changes), nil
+}
+
+func makeAuditedTopologyDelta(operationID audit.Value, changes []audit.Record) audit.Record {
 	return audit.Record{Kind: auditTopologyDeltaField, Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: operationID},
 		{Name: "changes", Value: audit.List(auditNestedValues(changes)...)},
-	}}, nil
+	}}
 }
 
 func makeAuditedMovePathEffects(
-	values auditedMutationValues, snapshot auditedMoveSnapshot,
-	resultingPaths map[int64]string, topologyDigest auditRecordHash,
-) ([]audit.Record, audit.Record, auditRecordHash, error) {
+	snapshot auditedMoveSnapshot, resultingPaths map[int64]string,
+) ([]audit.Record, error) {
 	scopeID, err := audit.UUID(snapshot.scope.scopeID)
 	if err != nil {
-		return nil, audit.Record{}, auditRecordHash{}, err
+		return nil, err
 	}
-	live, err := audit.Text("live")
+	live, err := audit.Text(auditNodeStateLive)
 	if err != nil {
-		return nil, audit.Record{}, auditRecordHash{}, err
+		return nil, err
 	}
 	effects := make([]audit.Record, 0, len(snapshot.subtreeIDs))
 	for _, nodeID := range snapshot.subtreeIDs {
 		auditNodeID, err := positiveAuditNodeID(nodeID)
 		if err != nil {
-			return nil, audit.Record{}, auditRecordHash{}, err
+			return nil, err
 		}
 		priorPath, resultingPath := snapshot.priorPaths[nodeID], resultingPaths[nodeID]
 		if priorPath == resultingPath {
-			return nil, audit.Record{}, auditRecordHash{}, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"audited move did not change path of subtree node %d", nodeID,
 			)
 		}
@@ -446,16 +366,10 @@ func makeAuditedMovePathEffects(
 			}})},
 		}})
 	}
-	list := audit.Record{Kind: "path_effect_list", Fields: []audit.Field{
-		{Name: auditOperationIDField, Value: values.operationID},
-		{Name: auditTopologyDeltaField, Value: topologyDigest.value},
-		{Name: "effects", Value: audit.List(auditNestedValues(effects)...)},
-	}}
-	digest, err := hashAuditRecord(list)
-	return effects, list, digest, err
+	return effects, nil
 }
 
-func makeAuditedMoveStateChanges(
+func makeAuditedTopologyStateChanges(
 	prior, resulting map[int64]Node,
 ) ([]audit.Record, error) {
 	changes := make([]audit.Record, 0, len(prior))
@@ -476,27 +390,28 @@ func makeAuditedMoveStateChanges(
 	return changes, nil
 }
 
-func makeAuditedMoveEvents(
-	values auditedMutationValues, scopeID string, snapshot auditedMoveSnapshot,
-	resultingSubtree map[int64]Node, effects []audit.Record, topologyDigest auditRecordHash,
+func makeAuditedPathEvents(
+	values auditedMutationValues, scopeID string, prior, resulting map[int64]Node,
+	effects []audit.Record, topologyDigest auditRecordHash,
 ) ([]audit.Record, error) {
-	if len(effects) != len(snapshot.subtreeIDs) {
-		return nil, errors.New("audited move path effects do not match its subtree")
-	}
 	events := make([]audit.Record, len(effects))
 	ordinal := uint64(0)
 	for index, effect := range effects {
-		nodeID := snapshot.subtreeIDs[index]
-		auditNodeID, err := positiveAuditNodeID(nodeID)
+		auditNodeID, err := auditUnsignedField(effect, "member_node_id")
 		if err != nil {
 			return nil, err
 		}
-		if err := requireAuditUnsigned(effect, "member_node_id", auditNodeID); err != nil {
-			return nil, err
+		if auditNodeID > math.MaxInt64 {
+			return nil, fmt.Errorf("audited path effect node %d exceeds signed node range", auditNodeID)
 		}
-		events[index], err = makeAuditedMoveEvent(
-			values, scopeID, ordinal, snapshot.priorSubtree[nodeID],
-			resultingSubtree[nodeID], effect, topologyDigest,
+		nodeID := int64(auditNodeID)
+		priorNode, priorOK := prior[nodeID]
+		resultingNode, resultingOK := resulting[nodeID]
+		if !priorOK || !resultingOK {
+			return nil, fmt.Errorf("audited path effect lacks node state for %d", nodeID)
+		}
+		events[index], err = makeAuditedPathEvent(
+			values, scopeID, ordinal, priorNode, resultingNode, effect, topologyDigest,
 		)
 		if err != nil {
 			return nil, err
@@ -506,7 +421,7 @@ func makeAuditedMoveEvents(
 	return events, nil
 }
 
-func makeAuditedMoveEvent(
+func makeAuditedPathEvent(
 	values auditedMutationValues, scopeID string, ordinal uint64,
 	prior, resulting Node, effect audit.Record, topologyDigest auditRecordHash,
 ) (audit.Record, error) {
@@ -578,7 +493,7 @@ func makeAuditedMoveEvent(
 	}}, nil
 }
 
-func makeAuditedMoveMutation(
+func makeAuditedTopologyMutation(
 	values auditedMutationValues, sequence int64, events, changes []audit.Record,
 	topologyDigest auditRecordHash, effectCount uint64, effectDigest auditRecordHash,
 ) (audit.Record, error) {
@@ -607,7 +522,7 @@ func makeAuditedMoveMutation(
 	}}, nil
 }
 
-func makeAuditedMoveAllocationEntry(
+func makeAuditedTopologyAllocationEntry(
 	values auditedMutationValues, sequence, nodeSequence int64,
 	previousHead string, mutationHash, topologyDigest audit.Value,
 ) (audit.Record, error) {

--- a/internal/store/audit_node_move_validate.go
+++ b/internal/store/audit_node_move_validate.go
@@ -8,7 +8,7 @@ import (
 	"go.kenn.io/docbank/internal/audit"
 )
 
-type replayedNodeMove struct {
+type replayedTopologyMutation struct {
 	topologyDigest, pathEffectDigest string
 	postTopology                     []audit.Record
 	effects                          []audit.Record
@@ -54,15 +54,20 @@ func (replay *auditedHistoryReplay) applyNodeMove(
 	if err != nil {
 		return err
 	}
-	if err := replay.validateNodeMovePathEffects(
-		mutation.record, operationID, &move, pathEffectRecords, usedPathEffects,
+	expectedEffects, err := replay.deriveNodeMovePathEffects(move.postTopology)
+	if err != nil {
+		return err
+	}
+	if err := replay.validateTopologyPathEffects(
+		mutation.record, operationID, &move, expectedEffects,
+		pathEffectRecords, usedPathEffects,
 	); err != nil {
 		return err
 	}
-	if err := replay.validateNodeMoveStateChanges(mutation.record, move.changedIDs); err != nil {
+	if err := replay.validateTopologyStateChanges(mutation.record, move.changedIDs); err != nil {
 		return err
 	}
-	if err := replay.validateNodeMoveEvents(
+	if err := replay.validateTopologyEvents(
 		mutation.record, operationID, move, eventRecords, usedEvents,
 	); err != nil {
 		return err
@@ -81,35 +86,35 @@ func (replay *auditedHistoryReplay) applyNodeMove(
 	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
 		return err
 	}
-	if err := replay.advanceNodeMoveAllocation(
+	if err := replay.advanceTopologyAllocation(
 		vaultID, operationID, mutation, allocation, move,
 	); err != nil {
 		return err
 	}
-	return replay.applyNodeMoveState(move)
+	return replay.applyTopologyState(move)
 }
 
 func (replay *auditedHistoryReplay) validateNodeMoveTopology(
 	mutation audit.Record, operationID string,
 	topologyRecords map[string]storedAuditRecord, usedTopology map[string]bool,
-) (replayedNodeMove, error) {
+) (replayedTopologyMutation, error) {
 	digest, err := auditDigestField(mutation, auditTopologyDeltaField)
 	if err != nil {
-		return replayedNodeMove{}, err
+		return replayedTopologyMutation{}, err
 	}
 	delta, ok := topologyRecords[digest]
 	if !ok || usedTopology[digest] {
-		return replayedNodeMove{}, errors.New("node move lacks one unique topology delta")
+		return replayedTopologyMutation{}, errors.New("node move lacks one unique topology delta")
 	}
 	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
-		return replayedNodeMove{}, err
+		return replayedTopologyMutation{}, err
 	}
 	changes, err := auditRecordListField(delta.record, "changes")
 	if err != nil {
-		return replayedNodeMove{}, err
+		return replayedTopologyMutation{}, err
 	}
 	if len(changes) < 2 || len(changes) > 3 {
-		return replayedNodeMove{}, errors.New("in-scope move topology must change two or three nodes")
+		return replayedTopologyMutation{}, errors.New("in-scope move topology must change two or three nodes")
 	}
 	postTopology := slices.Clone(replay.topology)
 	changedIDs := make([]uint64, 0, len(changes))
@@ -117,68 +122,73 @@ func (replay *auditedHistoryReplay) validateNodeMoveTopology(
 	for _, change := range changes {
 		nodeID, err := auditUnsignedField(change, metadataNodeIDField)
 		if err != nil {
-			return replayedNodeMove{}, err
+			return replayedTopologyMutation{}, err
 		}
 		if !replay.memberSet[nodeID] {
-			return replayedNodeMove{}, fmt.Errorf("in-scope move changes unaudited node %d", nodeID)
+			return replayedTopologyMutation{}, fmt.Errorf("in-scope move changes unaudited node %d", nodeID)
 		}
 		pre, preErr := optionalAuditNestedField(change, "pre")
 		post, postErr := optionalAuditNestedField(change, "post")
 		if preErr != nil || postErr != nil || pre == nil || post == nil {
-			return replayedNodeMove{}, errors.New("in-scope move requires complete topology sides")
+			return replayedTopologyMutation{}, errors.New("in-scope move requires complete topology sides")
 		}
 		index, ok := replay.topologyIndex[nodeID]
 		if !ok || !auditRecordEqual(replay.topology[index], *pre) {
-			return replayedNodeMove{}, fmt.Errorf("node move pre-state for %d does not match replay", nodeID)
+			return replayedTopologyMutation{}, fmt.Errorf("node move pre-state for %d does not match replay", nodeID)
 		}
 		pathChanged, priorParent, resultingParent, err := validateNodeMoveTopologyChange(
 			mutation, *pre, *post,
 		)
 		if err != nil {
-			return replayedNodeMove{}, err
+			return replayedTopologyMutation{}, err
 		}
 		if pathChanged {
 			if movedID != 0 {
-				return replayedNodeMove{}, errors.New("node move topology changes multiple paths directly")
+				return replayedTopologyMutation{}, errors.New("node move topology changes multiple paths directly")
 			}
 			movedID, oldParentID, newParentID = nodeID, priorParent, resultingParent
 		}
 		postTopology[index] = *post
 		changedIDs = append(changedIDs, nodeID)
 	}
+	if !slices.IsSorted(changedIDs) {
+		return replayedTopologyMutation{}, errors.New(
+			"node move topology changes are not in canonical node order",
+		)
+	}
 	if movedID == 0 || !slices.Contains(changedIDs, oldParentID) ||
 		!slices.Contains(changedIDs, newParentID) {
-		return replayedNodeMove{}, errors.New("node move topology lacks its changed parent state")
+		return replayedTopologyMutation{}, errors.New("node move topology lacks its changed parent state")
 	}
 	wantChanges := 2
 	if oldParentID != newParentID {
 		wantChanges = 3
 	}
 	if len(changes) != wantChanges {
-		return replayedNodeMove{}, errors.New("node move topology has an unexpected changed-node set")
+		return replayedTopologyMutation{}, errors.New("node move topology has an unexpected changed-node set")
 	}
 	if err := requireLiveDirectoryTopology(postTopology, oldParentID); err != nil {
-		return replayedNodeMove{}, err
+		return replayedTopologyMutation{}, err
 	}
 	if err := requireLiveDirectoryTopology(postTopology, newParentID); err != nil {
-		return replayedNodeMove{}, err
+		return replayedTopologyMutation{}, err
 	}
 	affectsTrashOrigin, err := auditMoveAffectsTrashOrigin(
 		replay.topology, replay.memberSet, movedID,
 	)
 	if err != nil {
-		return replayedNodeMove{}, err
+		return replayedTopologyMutation{}, err
 	}
 	if affectsTrashOrigin {
-		return replayedNodeMove{}, errors.New(
+		return replayedTopologyMutation{}, errors.New(
 			"node move changes a retained trash-origin path without recording trash effects",
 		)
 	}
 	if err := validateReplayedAuditTopology(postTopology); err != nil {
-		return replayedNodeMove{}, fmt.Errorf("validating node move topology: %w", err)
+		return replayedTopologyMutation{}, fmt.Errorf("validating node move topology: %w", err)
 	}
 	usedTopology[digest] = true
-	return replayedNodeMove{
+	return replayedTopologyMutation{
 		topologyDigest: digest, postTopology: postTopology, changedIDs: changedIDs,
 	}, nil
 }
@@ -330,14 +340,15 @@ func requireLiveDirectoryTopology(topology []audit.Record, nodeID uint64) error 
 		if err := requireAuditText(node, "node_kind", nodeKindDir); err != nil {
 			return err
 		}
-		return requireAuditText(node, "state", "live")
+		return requireAuditText(node, "state", auditNodeStateLive)
 	}
 	return fmt.Errorf("node move parent %d is absent from topology", nodeID)
 }
 
-func (replay *auditedHistoryReplay) validateNodeMovePathEffects(
-	mutation audit.Record, operationID string, move *replayedNodeMove,
-	pathEffectRecords map[string]storedAuditRecord, usedPathEffects map[string]bool,
+func (replay *auditedHistoryReplay) validateTopologyPathEffects(
+	mutation audit.Record, operationID string, transition *replayedTopologyMutation,
+	expected []audit.Record, pathEffectRecords map[string]storedAuditRecord,
+	usedPathEffects map[string]bool,
 ) error {
 	digest, err := auditDigestField(mutation, "path_effect_digest")
 	if err != nil {
@@ -345,24 +356,22 @@ func (replay *auditedHistoryReplay) validateNodeMovePathEffects(
 	}
 	list, ok := pathEffectRecords[digest]
 	if !ok || usedPathEffects[digest] {
-		return errors.New("node move lacks one unique path-effect list")
+		return errors.New("topology mutation lacks one unique path-effect list")
 	}
 	if err := requireAuditUUID(list.record, auditOperationIDField, operationID); err != nil {
 		return err
 	}
-	if err := requireAuditDigest(list.record, auditTopologyDeltaField, move.topologyDigest); err != nil {
+	if err := requireAuditDigest(
+		list.record, auditTopologyDeltaField, transition.topologyDigest,
+	); err != nil {
 		return err
 	}
 	stored, err := auditRecordListField(list.record, "effects")
 	if err != nil {
 		return err
 	}
-	expected, err := replay.deriveNodeMovePathEffects(move.postTopology)
-	if err != nil {
-		return err
-	}
 	if len(expected) == 0 || !equalAuditRecordLists(stored, expected) {
-		return errors.New("node move path effects do not match replayed topology")
+		return errors.New("topology path effects do not match replayed topology")
 	}
 	if err := requireAuditUnsigned(mutation, "path_effect_count", uint64(len(expected))); err != nil {
 		return err
@@ -370,7 +379,7 @@ func (replay *auditedHistoryReplay) validateNodeMovePathEffects(
 	if err := requireAuditDigest(mutation, "path_effect_digest", digest); err != nil {
 		return err
 	}
-	move.pathEffectDigest, move.effects = digest, expected
+	transition.pathEffectDigest, transition.effects = digest, expected
 	usedPathEffects[digest] = true
 	return nil
 }
@@ -382,7 +391,7 @@ func (replay *auditedHistoryReplay) deriveNodeMovePathEffects(
 	if err != nil {
 		return nil, err
 	}
-	live, err := audit.Text("live")
+	live, err := audit.Text(auditNodeStateLive)
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +440,7 @@ func auditLivePath(
 	if err != nil {
 		return nil, false, err
 	}
-	if state != "live" {
+	if state != auditNodeStateLive {
 		return nil, false, nil
 	}
 	visited := make(map[uint64]bool)
@@ -462,7 +471,7 @@ func auditLivePath(
 			return nil, false, fmt.Errorf("audit topology node %d has missing live parent %d", id, *parentID)
 		}
 		parent := topology[parentIndex]
-		if err := requireAuditText(parent, "state", "live"); err != nil {
+		if err := requireAuditText(parent, "state", auditNodeStateLive); err != nil {
 			return nil, false, err
 		}
 		current = parent
@@ -477,7 +486,7 @@ func auditLivePath(
 	return result, true, nil
 }
 
-func (replay *auditedHistoryReplay) validateNodeMoveStateChanges(
+func (replay *auditedHistoryReplay) validateTopologyStateChanges(
 	mutation audit.Record, changedIDs []uint64,
 ) error {
 	changes, err := auditRecordListField(mutation, "member_state_changes")
@@ -485,7 +494,7 @@ func (replay *auditedHistoryReplay) validateNodeMoveStateChanges(
 		return err
 	}
 	if len(changes) != len(changedIDs) {
-		return errors.New("node move member-state changes do not match changed topology")
+		return errors.New("topology member-state changes do not match changed topology")
 	}
 	for index, nodeID := range changedIDs {
 		state := replay.states[nodeID]
@@ -514,24 +523,24 @@ func (replay *auditedHistoryReplay) validateNodeMoveStateChanges(
 	return nil
 }
 
-func (replay *auditedHistoryReplay) validateNodeMoveEvents(
-	mutation audit.Record, operationID string, move replayedNodeMove,
+func (replay *auditedHistoryReplay) validateTopologyEvents(
+	mutation audit.Record, operationID string, transition replayedTopologyMutation,
 	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
 ) error {
 	events, err := auditRecordListField(mutation, "events")
 	if err != nil {
 		return err
 	}
-	if len(events) != len(move.effects) {
-		return errors.New("node move event set does not match its path effects")
+	if len(events) != len(transition.effects) {
+		return errors.New("topology event set does not match its path effects")
 	}
-	changed := make(map[uint64]bool, len(move.changedIDs))
-	for _, id := range move.changedIDs {
+	changed := make(map[uint64]bool, len(transition.changedIDs))
+	for _, id := range transition.changedIDs {
 		changed[id] = true
 	}
 	ordinal := uint64(0)
 	for index, event := range events {
-		effect := move.effects[index]
+		effect := transition.effects[index]
 		nodeID, err := auditUnsignedField(effect, "member_node_id")
 		if err != nil {
 			return err
@@ -572,7 +581,11 @@ func (replay *auditedHistoryReplay) validateNodeMoveEvents(
 			func() error { return requireAuditUnsigned(event, "resulting_node_revision", resultingRevision) },
 			func() error { return requireAuditOptionalUUID(event, "prior_current_version_id", current) },
 			func() error { return requireAuditOptionalUUID(event, "resulting_current_version_id", current) },
-			func() error { return requireAuditDigest(event, auditTopologyDeltaField, move.topologyDigest) },
+			func() error {
+				return requireAuditDigest(
+					event, auditTopologyDeltaField, transition.topologyDigest,
+				)
+			},
 		}
 		for _, check := range checks {
 			if err := check(); err != nil {
@@ -591,18 +604,19 @@ func (replay *auditedHistoryReplay) validateNodeMoveEvents(
 		}
 		eventPre, err := auditNestedField(event, "pre")
 		if err != nil || !auditRecordEqual(eventPre, pre) {
-			return errors.New("node move event pre-state does not match its path effect")
+			return errors.New("topology event pre-state does not match its path effect")
 		}
 		eventPost, err := auditNestedField(event, "post")
 		if err != nil || !auditRecordEqual(eventPost, post) {
-			return errors.New("node move event post-state does not match its path effect")
+			return errors.New("topology event post-state does not match its path effect")
 		}
 	}
 	return nil
 }
 
-func (replay *auditedHistoryReplay) advanceNodeMoveAllocation(
-	vaultID, operationID string, mutation, entry storedAuditRecord, move replayedNodeMove,
+func (replay *auditedHistoryReplay) advanceTopologyAllocation(
+	vaultID, operationID string, mutation, entry storedAuditRecord,
+	transition replayedTopologyMutation,
 ) error {
 	nextCount := replay.allocationCount + 1
 	auditCount, err := positiveAuditInteger("allocation entry count", nextCount)
@@ -619,7 +633,11 @@ func (replay *auditedHistoryReplay) advanceNodeMoveAllocation(
 		func() error { return requireAuditUnsigned(entry.record, "node_id_high_water", replay.nodeHighWater) },
 		func() error { return requireAuditBool(entry.record, "has_audited_mutation", true) },
 		func() error { return requireAuditBool(entry.record, "has_topology_change", true) },
-		func() error { return requireAuditDigest(entry.record, auditTopologyDeltaField, move.topologyDigest) },
+		func() error {
+			return requireAuditDigest(
+				entry.record, auditTopologyDeltaField, transition.topologyDigest,
+			)
+		},
 		func() error { return requireAuditBool(entry.record, "has_witness_change", false) },
 		func() error { return requireAuditUnsigned(entry.record, auditWitnessChangeCountField, 0) },
 		func() error { return requireAuditAbsent(entry.record, "witness_change_digest") },
@@ -637,7 +655,7 @@ func (replay *auditedHistoryReplay) advanceNodeMoveAllocation(
 		return err
 	}
 	if len(allocated) != 0 {
-		return errors.New("node move allocation cannot allocate node IDs")
+		return errors.New("topology mutation allocation cannot allocate node IDs")
 	}
 	mutationDigest, err := hashAuditRecord(mutation.record)
 	if err != nil {
@@ -650,8 +668,10 @@ func (replay *auditedHistoryReplay) advanceNodeMoveAllocation(
 	return nil
 }
 
-func (replay *auditedHistoryReplay) applyNodeMoveState(move replayedNodeMove) error {
-	for _, nodeID := range move.changedIDs {
+func (replay *auditedHistoryReplay) applyTopologyState(
+	transition replayedTopologyMutation,
+) error {
+	for _, nodeID := range transition.changedIDs {
 		state := replay.states[nodeID]
 		revision, err := auditUnsignedField(state, "node_revision")
 		if err != nil {
@@ -667,6 +687,6 @@ func (replay *auditedHistoryReplay) applyNodeMoveState(move replayedNodeMove) er
 			{Name: "current_version_id", Value: current},
 		}}
 	}
-	replay.topology = move.postTopology
+	replay.topology = transition.postTopology
 	return nil
 }

--- a/internal/store/audit_node_trash.go
+++ b/internal/store/audit_node_trash.go
@@ -1,0 +1,222 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type auditedTrashSnapshot struct {
+	authority                auditAuthorityState
+	scope                    auditScopeState
+	nodeSequence             int64
+	operationID, recordedAt  string
+	priorNodes, priorSubtree map[int64]Node
+	priorPaths               map[int64]string
+	subtreeIDs               []int64
+}
+
+func (s *Store) trashAuditedTx(
+	ctx context.Context, tx *sql.Tx, node Node, ifRev int64,
+) (Node, string, error) {
+	snapshot, err := s.prepareAuditedTrash(ctx, tx, node, ifRev)
+	if err != nil {
+		return Node{}, "", err
+	}
+	if err := s.trashNodeTx(tx, node, snapshot.recordedAt); err != nil {
+		return Node{}, "", err
+	}
+	resultingNodes := make(map[int64]Node, len(snapshot.priorNodes))
+	resultingTopology := make(map[int64]audit.Record, len(snapshot.priorNodes))
+	for nodeID := range snapshot.priorNodes {
+		resulting, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return Node{}, "", err
+		}
+		topology, err := auditTopologyForNodeTx(ctx, tx, nodeID)
+		if err != nil {
+			return Node{}, "", err
+		}
+		resultingNodes[nodeID], resultingTopology[nodeID] = resulting, topology
+	}
+	resultingSubtree := make(map[int64]Node, len(snapshot.subtreeIDs))
+	for _, nodeID := range snapshot.subtreeIDs {
+		resultingSubtree[nodeID] = resultingNodes[nodeID]
+	}
+	values, err := makeAuditedMutationValues(
+		s.vaultID, snapshot.authority.lineageID, snapshot.operationID, snapshot.recordedAt,
+	)
+	if err != nil {
+		return Node{}, "", err
+	}
+	topology, err := makeAuditedTrashTopologyDelta(
+		values.operationID, snapshot.priorNodes, resultingTopology,
+	)
+	if err != nil {
+		return Node{}, "", err
+	}
+	effects, err := makeAuditedTrashPathEffects(snapshot)
+	if err != nil {
+		return Node{}, "", err
+	}
+	if err := persistAuditedTopologyMutation(
+		ctx, tx, values, snapshot.authority, snapshot.scope, snapshot.nodeSequence,
+		topology, effects, snapshot.priorNodes, resultingNodes,
+		snapshot.priorSubtree, resultingSubtree,
+	); err != nil {
+		return Node{}, "", err
+	}
+	return resultingSubtree[node.ID], snapshot.priorPaths[node.ID], nil
+}
+
+func (s *Store) prepareAuditedTrash(
+	ctx context.Context, tx *sql.Tx, node Node, ifRev int64,
+) (auditedTrashSnapshot, error) {
+	var snapshot auditedTrashSnapshot
+	if node.ID == s.rootID {
+		return snapshot, ErrIsRoot
+	}
+	if node.TrashedAt != nil {
+		return snapshot, fmt.Errorf("node %d already trashed: %w", node.ID, ErrNotFound)
+	}
+	if ifRev != UnconditionalRev && node.Revision != ifRev {
+		return snapshot, fmt.Errorf(
+			"node %d at revision %d, expected %d: %w",
+			node.ID, node.Revision, ifRev, ErrStaleRevision,
+		)
+	}
+	if node.ParentID == nil {
+		return snapshot, ErrIsRoot
+	}
+	authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, node.ID)
+	if err != nil {
+		return snapshot, err
+	}
+	if len(scopes) != 1 {
+		return snapshot, unsupportedAuditedNodeMutation(node.ID)
+	}
+	scope := scopes[0]
+	parentMember, err := nodeInAuditScopeTx(ctx, tx, *node.ParentID, scope.scopeID)
+	if err != nil {
+		return snapshot, err
+	}
+	if !parentMember {
+		return snapshot, unsupportedAuditedNodeMutation(*node.ParentID)
+	}
+	subtreeIDs, err := liveSubtreeIDsTx(ctx, tx, node.ID)
+	if err != nil {
+		return snapshot, err
+	}
+	priorSubtree := make(map[int64]Node, len(subtreeIDs))
+	priorPaths := make(map[int64]string, len(subtreeIDs))
+	for _, nodeID := range subtreeIDs {
+		member, err := nodeInAuditScopeTx(ctx, tx, nodeID, scope.scopeID)
+		if err != nil {
+			return snapshot, err
+		}
+		if !member {
+			return snapshot, unsupportedAuditedNodeMutation(nodeID)
+		}
+		prior, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return snapshot, err
+		}
+		path, err := pathOf(ctx, tx, nodeID)
+		if err != nil {
+			return snapshot, err
+		}
+		priorSubtree[nodeID], priorPaths[nodeID] = prior, path
+	}
+	changedIDs := append(slices.Clone(subtreeIDs), *node.ParentID)
+	slices.Sort(changedIDs)
+	priorNodes := make(map[int64]Node, len(changedIDs))
+	for _, nodeID := range changedIDs {
+		prior, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return snapshot, err
+		}
+		priorNodes[nodeID] = prior
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return snapshot, err
+	}
+	snapshot = auditedTrashSnapshot{
+		authority: authority, scope: scope, nodeSequence: nodeSequence,
+		operationID: operationID, recordedAt: nowRFC3339(),
+		priorNodes: priorNodes, priorSubtree: priorSubtree,
+		priorPaths: priorPaths, subtreeIDs: subtreeIDs,
+	}
+	return snapshot, nil
+}
+
+func makeAuditedTrashTopologyDelta(
+	operationID audit.Value, prior map[int64]Node, resulting map[int64]audit.Record,
+) (audit.Record, error) {
+	changes := make([]audit.Record, 0, len(prior))
+	for nodeID, priorNode := range prior {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		post, ok := resulting[nodeID]
+		if !ok {
+			return audit.Record{}, fmt.Errorf("audited trash lacks resulting node %d", nodeID)
+		}
+		pre, err := auditTopologyForLiveNode(priorNode)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		changes = append(changes, audit.Record{Kind: "topology_change", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
+			{Name: "pre", Value: audit.Nested(pre)},
+			{Name: "post", Value: audit.Nested(post)},
+		}})
+	}
+	if err := sortAuditTopologyRecords(changes); err != nil {
+		return audit.Record{}, err
+	}
+	return makeAuditedTopologyDelta(operationID, changes), nil
+}
+
+func makeAuditedTrashPathEffects(snapshot auditedTrashSnapshot) ([]audit.Record, error) {
+	scopeID, err := audit.UUID(snapshot.scope.scopeID)
+	if err != nil {
+		return nil, err
+	}
+	live, err := audit.Text(auditNodeStateLive)
+	if err != nil {
+		return nil, err
+	}
+	trash, err := audit.Text(auditNodeStateTrash)
+	if err != nil {
+		return nil, err
+	}
+	effects := make([]audit.Record, 0, len(snapshot.subtreeIDs))
+	for _, nodeID := range snapshot.subtreeIDs {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		priorPath := snapshot.priorPaths[nodeID]
+		if len(priorPath) == 0 || priorPath[0] != '/' {
+			return nil, errors.New("audited trash lacks a canonical prior path")
+		}
+		trashPath := append([]byte("@trash/known"), []byte(priorPath)...)
+		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
+			{Name: auditScopeIDField, Value: scopeID},
+			{Name: "member_node_id", Value: audit.Unsigned(auditNodeID)},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
+				{Name: "path", Value: audit.Bytes([]byte(priorPath))}, {Name: "state", Value: live},
+			}})},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
+				{Name: "path", Value: audit.Bytes(trashPath)}, {Name: "state", Value: trash},
+			}})},
+		}})
+	}
+	return effects, nil
+}

--- a/internal/store/audit_node_trash_test.go
+++ b/internal/store/audit_node_trash_test.go
@@ -1,0 +1,205 @@
+package store
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedTrashRecordsSubtreeAndRoundTrips(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+
+	trashed, priorPath, err := s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+	assert.Equal(t, "/Projects/Work", priorPath)
+	assert.NotNil(t, trashed.TrashedAt)
+	assert.Equal(t, work.Revision+1, trashed.Revision)
+	trashedChild, err := s.NodeByID(t.Context(), child.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, trashedChild.TrashedAt)
+	assert.Equal(t, child.Revision+1, trashedChild.Revision)
+	updatedProjects, err := s.NodeByID(t.Context(), projects.ID)
+	require.NoError(t, err)
+	assert.Equal(t, projects.Revision+1, updatedProjects.Revision)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	var raw []byte
+	require.NoError(t, s.db.QueryRow(
+		`SELECT record_json FROM audit_records WHERE kind='path_effect_list'`,
+	).Scan(&raw))
+	effectList, err := audit.UnmarshalJSONRecord(raw)
+	require.NoError(t, err)
+	effects, err := auditRecordListField(effectList, "effects")
+	require.NoError(t, err)
+	require.Len(t, effects, 2)
+	assert.Equal(t, uint64(work.ID), mustAuditUnsignedField(t, effects[0], "member_node_id"))
+	assert.Equal(t, uint64(child.ID), mustAuditUnsignedField(t, effects[1], "member_node_id"))
+	assertAuditPathState(t, effects[0], "old", "/Projects/Work", "live")
+	assertAuditPathState(t, effects[0], "new", "@trash/known/Projects/Work", "trash")
+	assertAuditPathState(t, effects[1], "old", "/Projects/Work/child.txt", "live")
+	assertAuditPathState(
+		t, effects[1], "new", "@trash/known/Projects/Work/child.txt", "trash",
+	)
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+	restoredTrash, err := restored.TrashedRoots(t.Context())
+	require.NoError(t, err)
+	var found bool
+	for _, node := range restoredTrash {
+		found = found || node.ID == work.ID
+	}
+	assert.True(t, found, "restored metadata should retain the audited trash root")
+}
+
+func TestAuditedTrashPathUsesSameTransaction(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+
+	trashed, priorPath, err := s.TrashPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	assert.Equal(t, report.ID, trashed.ID)
+	assert.Equal(t, "/Projects/report.txt", priorPath)
+	assert.NotNil(t, trashed.TrashedAt)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedRootScopeTrashRecordsRootParentTouch(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	root, err := s.NodeByID(t.Context(), s.RootID())
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, s.RootID())
+
+	trashed, priorPath, err := s.Trash(t.Context(), empty.ID, empty.Revision)
+	require.NoError(t, err)
+	assert.Equal(t, "/Empty", priorPath)
+	assert.NotNil(t, trashed.TrashedAt)
+	updatedRoot, err := s.NodeByID(t.Context(), s.RootID())
+	require.NoError(t, err)
+	assert.Equal(t, root.Revision+1, updatedRoot.Revision)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTrashRefusesScopeBoundaryWitnessChange(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+
+	trashed, _, err := s.Trash(t.Context(), projects.ID, projects.Revision)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	assert.Zero(t, trashed)
+	unchanged, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	assert.Equal(t, projects, unchanged)
+}
+
+func TestAuditedTrashRollsBackTreeAndHistory(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_audit_trash_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audit trash failure'); END`)
+	require.NoError(t, err)
+
+	trashed, _, err := s.Trash(t.Context(), work.ID, work.Revision)
+	require.ErrorContains(t, err, "forced audit trash failure")
+	assert.Zero(t, trashed)
+	unchanged, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	assert.Equal(t, work.ID, *unchanged.ParentID)
+	var sequence, records int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM audit_records)`).Scan(&sequence, &records))
+	assert.Equal(t, int64(1), sequence)
+	assert.Equal(t, int64(8), records)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTrashReplayRejectsOmittedDescendant(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, scope, initial)
+	require.NoError(t, err)
+	mutations, err := auditRecordsBySequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	mutation := mutations[2]
+	digest, err := auditDigestField(mutation.record, auditTopologyDeltaField)
+	require.NoError(t, err)
+	topologyRecords := auditRecordsByDigest(records[auditTopologyDeltaField])
+	delta := topologyRecords[digest]
+	changes, err := auditRecordListField(delta.record, "changes")
+	require.NoError(t, err)
+	filtered := changes[:0]
+	for _, change := range changes {
+		if mustAuditUnsignedField(t, change, metadataNodeIDField) != uint64(child.ID) {
+			filtered = append(filtered, change)
+		}
+	}
+	delta.record = mustReplaceAuditRecordField(
+		t, delta.record, "changes", audit.List(auditNestedValues(filtered)...),
+	)
+	topologyRecords[digest] = delta
+	_, _, err = replay.validateNodeTrashTopology(
+		mutation.record, mustAuditUUIDField(t, mutation.record, auditOperationIDField),
+		topologyRecords, map[string]bool{},
+	)
+	require.ErrorContains(t, err, "complete live subtree")
+}
+
+func assertAuditPathState(
+	t *testing.T, effect audit.Record, field, path, state string,
+) {
+	t.Helper()
+	value, err := auditNestedField(effect, field)
+	require.NoError(t, err)
+	pathValue, err := auditField(value, "path")
+	require.NoError(t, err)
+	pathBytes, ok := pathValue.BytesValue()
+	require.True(t, ok)
+	assert.Equal(t, path, string(pathBytes))
+	require.NoError(t, requireAuditText(value, "state", state))
+}
+
+func mustAuditUUIDField(t *testing.T, record audit.Record, name string) string {
+	t.Helper()
+	value, err := auditUUIDField(record, name)
+	require.NoError(t, err)
+	return value
+}

--- a/internal/store/audit_node_trash_validate.go
+++ b/internal/store/audit_node_trash_validate.go
@@ -1,0 +1,511 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func (replay *auditedHistoryReplay) applyNodeTrash(
+	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	topologyRecords, pathEffectRecords, eventRecords map[string]storedAuditRecord,
+	usedTopology, usedPathEffects, usedEvents map[string]bool,
+) error {
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUUID(mutation.record, auditVaultIDField, vaultID); err != nil {
+		return err
+	}
+	nextSequence, err := positiveAuditInteger(
+		"operation sequence", replay.allocationCount+1,
+	)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(
+		mutation.record, "operation_sequence", nextSequence,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
+		return err
+	}
+	bindings, err := auditRecordListField(mutation.record, "baselines")
+	if err != nil {
+		return err
+	}
+	if len(bindings) != 0 {
+		return errors.New("in-scope trash cannot bind an enrollment baseline")
+	}
+	transition, trashIDs, err := replay.validateNodeTrashTopology(
+		mutation.record, operationID, topologyRecords, usedTopology,
+	)
+	if err != nil {
+		return err
+	}
+	expectedEffects, err := replay.deriveNodeTrashPathEffects(
+		transition.postTopology, trashIDs,
+	)
+	if err != nil {
+		return err
+	}
+	if err := replay.validateTopologyPathEffects(
+		mutation.record, operationID, &transition, expectedEffects,
+		pathEffectRecords, usedPathEffects,
+	); err != nil {
+		return err
+	}
+	if err := replay.validateTopologyStateChanges(
+		mutation.record, transition.changedIDs,
+	); err != nil {
+		return err
+	}
+	if err := replay.validateTopologyEvents(
+		mutation.record, operationID, transition, eventRecords, usedEvents,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditAbsentFields(
+		mutation.record, "witness_change_digest", "attached_metadata_change_digest",
+	); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(mutation.record, auditWitnessChangeCountField, 0); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(
+		mutation.record, auditAttachedMetadataChangeCountField, 0,
+	); err != nil {
+		return err
+	}
+	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+		return err
+	}
+	if err := replay.advanceTopologyAllocation(
+		vaultID, operationID, mutation, allocation, transition,
+	); err != nil {
+		return err
+	}
+	return replay.applyTopologyState(transition)
+}
+
+func (replay *auditedHistoryReplay) validateNodeTrashTopology(
+	mutation audit.Record, operationID string,
+	topologyRecords map[string]storedAuditRecord, usedTopology map[string]bool,
+) (replayedTopologyMutation, []uint64, error) {
+	digest, err := auditDigestField(mutation, auditTopologyDeltaField)
+	if err != nil {
+		return replayedTopologyMutation{}, nil, err
+	}
+	delta, ok := topologyRecords[digest]
+	if !ok || usedTopology[digest] {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"node trash lacks one unique topology delta",
+		)
+	}
+	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
+		return replayedTopologyMutation{}, nil, err
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return replayedTopologyMutation{}, nil, err
+	}
+	if len(changes) < 2 {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"in-scope trash topology must change a subtree and its origin parent",
+		)
+	}
+	changeByID := make(map[uint64]audit.Record, len(changes))
+	trashSet := make(map[uint64]bool, len(changes)-1)
+	storedIDs := make([]uint64, 0, len(changes))
+	for _, change := range changes {
+		nodeID, err := auditUnsignedField(change, metadataNodeIDField)
+		if err != nil {
+			return replayedTopologyMutation{}, nil, err
+		}
+		if _, exists := changeByID[nodeID]; exists {
+			return replayedTopologyMutation{}, nil, fmt.Errorf(
+				"node trash repeats topology change for %d", nodeID,
+			)
+		}
+		pre, preErr := auditNestedField(change, "pre")
+		post, postErr := auditNestedField(change, "post")
+		if preErr != nil || postErr != nil {
+			return replayedTopologyMutation{}, nil, errors.New(
+				"in-scope trash requires complete topology sides",
+			)
+		}
+		preState, err := auditTextField(pre, "state")
+		if err != nil {
+			return replayedTopologyMutation{}, nil, err
+		}
+		postState, err := auditTextField(post, "state")
+		if err != nil {
+			return replayedTopologyMutation{}, nil, err
+		}
+		if preState == auditNodeStateLive && postState == auditNodeStateTrash {
+			trashSet[nodeID] = true
+		} else if preState != auditNodeStateLive || postState != auditNodeStateLive {
+			return replayedTopologyMutation{}, nil, errors.New(
+				"node trash contains an unsupported topology state transition",
+			)
+		}
+		changeByID[nodeID] = change
+		storedIDs = append(storedIDs, nodeID)
+	}
+	if !slices.IsSorted(storedIDs) {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"node trash topology changes are not in canonical node order",
+		)
+	}
+	trashRoot, err := replay.deriveNodeTrashRoot(trashSet)
+	if err != nil {
+		return replayedTopologyMutation{}, nil, err
+	}
+	trashIDs, err := replay.liveTopologySubtree(trashRoot)
+	if err != nil {
+		return replayedTopologyMutation{}, nil, err
+	}
+	if len(trashIDs) != len(trashSet) {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"node trash transition does not cover its complete live subtree",
+		)
+	}
+	for _, nodeID := range trashIDs {
+		if !trashSet[nodeID] {
+			return replayedTopologyMutation{}, nil, fmt.Errorf(
+				"node trash omits live subtree node %d", nodeID,
+			)
+		}
+	}
+	rootPre, err := auditNestedField(changeByID[trashRoot], "pre")
+	if err != nil {
+		return replayedTopologyMutation{}, nil, err
+	}
+	originParent, err := auditOptionalParentIDField(rootPre)
+	if err != nil || originParent == nil {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"node trash root lacks its live origin parent",
+		)
+	}
+	if trashSet[*originParent] || len(changeByID) != len(trashIDs)+1 {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"node trash changed-node set does not match its subtree and origin parent",
+		)
+	}
+	if _, ok := changeByID[*originParent]; !ok {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"node trash lacks its origin-parent topology change",
+		)
+	}
+	changedIDs := make([]uint64, 0, len(changeByID))
+	for nodeID := range changeByID {
+		if !replay.memberSet[nodeID] {
+			return replayedTopologyMutation{}, nil, fmt.Errorf(
+				"in-scope trash changes unaudited node %d", nodeID,
+			)
+		}
+		changedIDs = append(changedIDs, nodeID)
+	}
+	slices.Sort(changedIDs)
+	rootID, err := auditTopologyRootID(replay.topology)
+	if err != nil {
+		return replayedTopologyMutation{}, nil, err
+	}
+	recordedAt, err := auditField(mutation, auditRecordedAtField)
+	if err != nil {
+		return replayedTopologyMutation{}, nil, err
+	}
+	postTopology := slices.Clone(replay.topology)
+	for _, nodeID := range changedIDs {
+		change := changeByID[nodeID]
+		pre, err := auditNestedField(change, "pre")
+		if err != nil {
+			return replayedTopologyMutation{}, nil, err
+		}
+		post, err := auditNestedField(change, "post")
+		if err != nil {
+			return replayedTopologyMutation{}, nil, err
+		}
+		index, ok := replay.topologyIndex[nodeID]
+		if !ok || !auditRecordEqual(replay.topology[index], pre) {
+			return replayedTopologyMutation{}, nil, fmt.Errorf(
+				"node trash pre-state for %d does not match replay", nodeID,
+			)
+		}
+		expected, err := expectedNodeTrashPost(
+			pre, nodeID, trashRoot, rootID, *originParent, trashSet[nodeID], recordedAt,
+		)
+		if err != nil {
+			return replayedTopologyMutation{}, nil, err
+		}
+		if !auditRecordEqual(expected, post) {
+			return replayedTopologyMutation{}, nil, fmt.Errorf(
+				"node trash post-state for %d does not match its transition", nodeID,
+			)
+		}
+		postTopology[index] = post
+	}
+	if err := validateReplayedAuditTopology(postTopology); err != nil {
+		return replayedTopologyMutation{}, nil, fmt.Errorf(
+			"validating node trash topology: %w", err,
+		)
+	}
+	usedTopology[digest] = true
+	return replayedTopologyMutation{
+		topologyDigest: digest, postTopology: postTopology, changedIDs: changedIDs,
+	}, trashIDs, nil
+}
+
+func (replay *auditedHistoryReplay) deriveNodeTrashRoot(
+	trashSet map[uint64]bool,
+) (uint64, error) {
+	var root uint64
+	for nodeID := range trashSet {
+		index, ok := replay.topologyIndex[nodeID]
+		if !ok {
+			return 0, fmt.Errorf("node trash references missing topology node %d", nodeID)
+		}
+		parentID, err := auditOptionalParentIDField(replay.topology[index])
+		if err != nil {
+			return 0, err
+		}
+		if parentID == nil || trashSet[*parentID] {
+			continue
+		}
+		if root != 0 {
+			return 0, errors.New("node trash transition has multiple subtree roots")
+		}
+		root = nodeID
+	}
+	if root == 0 {
+		return 0, errors.New("node trash transition lacks one subtree root")
+	}
+	return root, nil
+}
+
+func (replay *auditedHistoryReplay) liveTopologySubtree(root uint64) ([]uint64, error) {
+	children := make(map[uint64][]uint64)
+	for _, node := range replay.topology {
+		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
+		if err != nil {
+			return nil, err
+		}
+		state, err := auditTextField(node, "state")
+		if err != nil {
+			return nil, err
+		}
+		parentID, err := auditOptionalParentIDField(node)
+		if err != nil {
+			return nil, err
+		}
+		if state == auditNodeStateLive && parentID != nil {
+			children[*parentID] = append(children[*parentID], nodeID)
+		}
+	}
+	var result []uint64
+	var add func(uint64)
+	add = func(nodeID uint64) {
+		result = append(result, nodeID)
+		slices.Sort(children[nodeID])
+		for _, child := range children[nodeID] {
+			add(child)
+		}
+	}
+	add(root)
+	slices.Sort(result)
+	return result, nil
+}
+
+func expectedNodeTrashPost(
+	pre audit.Record, nodeID, trashRoot, vaultRoot, originParent uint64,
+	trashed bool, recordedAt audit.Value,
+) (audit.Record, error) {
+	expected, err := replaceAuditRecordField(pre, "modified_at", recordedAt)
+	if err != nil || !trashed {
+		return expected, err
+	}
+	trashState, err := audit.Text(auditNodeStateTrash)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	expected, err = replaceAuditRecordField(expected, "state", trashState)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	expected, err = replaceAuditRecordField(expected, "trashed_at", recordedAt)
+	if err != nil || nodeID != trashRoot {
+		return expected, err
+	}
+	name, err := auditNameBytesField(pre)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	origin := audit.Record{Kind: "known_origin", Fields: []audit.Field{
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "parent_id", Value: audit.Unsigned(originParent)},
+		{Name: "name", Value: audit.Bytes(name)},
+	}}
+	expected, err = replaceAuditRecordField(expected, "parent_id", audit.Unsigned(vaultRoot))
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return replaceAuditRecordField(expected, auditOriginField, audit.Nested(origin))
+}
+
+func auditTopologyRootID(topology []audit.Record) (uint64, error) {
+	var root uint64
+	for _, node := range topology {
+		parentID, err := auditOptionalParentIDField(node)
+		if err != nil {
+			return 0, err
+		}
+		if parentID != nil {
+			continue
+		}
+		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
+		if err != nil {
+			return 0, err
+		}
+		if root != 0 {
+			return 0, errors.New("audit topology has multiple vault roots")
+		}
+		root = nodeID
+	}
+	if root == 0 {
+		return 0, errors.New("audit topology lacks its vault root")
+	}
+	return root, nil
+}
+
+func (replay *auditedHistoryReplay) deriveNodeTrashPathEffects(
+	postTopology []audit.Record, trashIDs []uint64,
+) ([]audit.Record, error) {
+	scopeID, err := audit.UUID(replay.scopeID)
+	if err != nil {
+		return nil, err
+	}
+	live, err := audit.Text(auditNodeStateLive)
+	if err != nil {
+		return nil, err
+	}
+	trash, err := audit.Text(auditNodeStateTrash)
+	if err != nil {
+		return nil, err
+	}
+	effects := make([]audit.Record, 0, len(trashIDs))
+	for _, nodeID := range trashIDs {
+		priorPath, priorLive, err := auditLivePath(
+			replay.topology, replay.topologyIndex, nodeID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if !priorLive {
+			return nil, fmt.Errorf("node trash source %d is not live", nodeID)
+		}
+		postPath, err := auditKnownTrashPath(
+			postTopology, replay.topologyIndex, nodeID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
+			{Name: auditScopeIDField, Value: scopeID},
+			{Name: "member_node_id", Value: audit.Unsigned(nodeID)},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
+				{Name: "path", Value: audit.Bytes(priorPath)}, {Name: "state", Value: live},
+			}})},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
+				{Name: "path", Value: audit.Bytes(postPath)}, {Name: "state", Value: trash},
+			}})},
+		}})
+	}
+	return effects, nil
+}
+
+func auditKnownTrashPath(
+	topology []audit.Record, topologyIndex map[uint64]int, nodeID uint64,
+) ([]byte, error) {
+	index, ok := topologyIndex[nodeID]
+	if !ok {
+		return nil, fmt.Errorf("audit topology lacks node %d", nodeID)
+	}
+	current := topology[index]
+	if err := requireAuditText(current, "state", auditNodeStateTrash); err != nil {
+		return nil, err
+	}
+	visited := make(map[uint64]bool)
+	var descendants [][]byte
+	for {
+		currentID, err := auditUnsignedField(current, metadataNodeIDField)
+		if err != nil {
+			return nil, err
+		}
+		if visited[currentID] {
+			return nil, errors.New("audit topology contains a trash-parent cycle")
+		}
+		visited[currentID] = true
+		originValue, err := auditField(current, auditOriginField)
+		if err != nil {
+			return nil, err
+		}
+		if !originValue.IsAbsent() {
+			origin, ok := originValue.RecordValue()
+			if !ok || origin.Kind != "known_origin" {
+				return nil, errors.New("audited trash transition lacks a known origin")
+			}
+			if err := requireAuditUnsigned(origin, metadataNodeIDField, currentID); err != nil {
+				return nil, err
+			}
+			originParent, err := auditUnsignedField(origin, "parent_id")
+			if err != nil {
+				return nil, err
+			}
+			originName, err := auditNameBytesField(origin)
+			if err != nil {
+				return nil, err
+			}
+			parentPath, liveParent, err := auditLivePath(
+				topology, topologyIndex, originParent,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if !liveParent {
+				return nil, errors.New("audited trash origin parent is not live")
+			}
+			result := append([]byte("@trash/known"), parentPath...)
+			if result[len(result)-1] != '/' {
+				result = append(result, '/')
+			}
+			result = append(result, originName...)
+			for _, name := range slices.Backward(descendants) {
+				result = append(result, '/')
+				result = append(result, name...)
+			}
+			return result, nil
+		}
+		name, err := auditNameBytesField(current)
+		if err != nil {
+			return nil, err
+		}
+		descendants = append(descendants, name)
+		parentID, err := auditOptionalParentIDField(current)
+		if err != nil || parentID == nil {
+			return nil, errors.New("trash descendant lacks its parent")
+		}
+		parentIndex, ok := topologyIndex[*parentID]
+		if !ok {
+			return nil, fmt.Errorf("trash descendant references missing parent %d", *parentID)
+		}
+		current = topology[parentIndex]
+		if err := requireAuditText(current, "state", auditNodeStateTrash); err != nil {
+			return nil, err
+		}
+	}
+}

--- a/internal/store/audit_projection.go
+++ b/internal/store/audit_projection.go
@@ -22,6 +22,11 @@ type auditTopologyRow struct {
 	trashName   sql.NullString
 }
 
+const (
+	auditNodeStateLive  = "live"
+	auditNodeStateTrash = "trash"
+)
+
 func currentAuditTopology(ctx context.Context, tx metadataQuerier) ([]audit.Record, error) {
 	rows, err := tx.QueryContext(ctx, `SELECT id,parent_id,name,kind,created_at,modified_at,
 		trashed_at,trash_parent,trash_name FROM nodes ORDER BY id`)
@@ -48,6 +53,21 @@ func currentAuditTopology(ctx context.Context, tx metadataQuerier) ([]audit.Reco
 	return records, nil
 }
 
+func auditTopologyForNodeTx(
+	ctx context.Context, tx metadataQuerier, nodeID int64,
+) (audit.Record, error) {
+	var row auditTopologyRow
+	err := tx.QueryRowContext(ctx, `SELECT id,parent_id,name,kind,created_at,modified_at,
+		trashed_at,trash_parent,trash_name FROM nodes WHERE id=?`, nodeID).Scan(
+		&row.id, &row.parentID, &row.name, &row.kind, &row.createdAt,
+		&row.modifiedAt, &row.trashedAt, &row.trashParent, &row.trashName,
+	)
+	if err != nil {
+		return audit.Record{}, fmt.Errorf("reading audit topology for node %d: %w", nodeID, err)
+	}
+	return topologyRecord(row)
+}
+
 func topologyRecord(row auditTopologyRow) (audit.Record, error) {
 	nodeID, err := positiveAuditNodeID(row.id)
 	if err != nil {
@@ -70,9 +90,9 @@ func topologyRecord(row auditTopologyRow) (audit.Record, error) {
 		return audit.Record{}, fmt.Errorf("encoding topology node %d modification time: %w", row.id, err)
 	}
 	trashedAt := audit.Absent()
-	state := "live"
+	state := auditNodeStateLive
 	if row.trashedAt.Valid {
-		state = "trash"
+		state = auditNodeStateTrash
 		trashedAt, err = audit.Timestamp(row.trashedAt.String)
 		if err != nil {
 			return audit.Record{}, fmt.Errorf("encoding topology node %d trash time: %w", row.id, err)

--- a/internal/store/audit_topology_mutation.go
+++ b/internal/store/audit_topology_mutation.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+// persistAuditedTopologyMutation commits the record envelope shared by
+// topology changes that affect one existing audit scope. Callers remain
+// responsible for deriving the operation-specific topology and path effects.
+func persistAuditedTopologyMutation(
+	ctx context.Context,
+	tx *sql.Tx,
+	values auditedMutationValues,
+	authority auditAuthorityState,
+	scope auditScopeState,
+	nodeSequence int64,
+	topology audit.Record,
+	effects []audit.Record,
+	priorNodes, resultingNodes, priorEventNodes, resultingEventNodes map[int64]Node,
+) error {
+	topologyDigest, err := hashAuditRecord(topology)
+	if err != nil {
+		return err
+	}
+	effectList := audit.Record{Kind: "path_effect_list", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: auditTopologyDeltaField, Value: topologyDigest.value},
+		{Name: "effects", Value: audit.List(auditNestedValues(effects)...)},
+	}}
+	effectDigest, err := hashAuditRecord(effectList)
+	if err != nil {
+		return err
+	}
+	stateChanges, err := makeAuditedTopologyStateChanges(priorNodes, resultingNodes)
+	if err != nil {
+		return err
+	}
+	events, err := makeAuditedPathEvents(
+		values, scope.scopeID, priorEventNodes, resultingEventNodes, effects, topologyDigest,
+	)
+	if err != nil {
+		return err
+	}
+	mutation, err := makeAuditedTopologyMutation(
+		values, authority.sequence+1, events, stateChanges,
+		topologyDigest, uint64(len(effects)), effectDigest,
+	)
+	if err != nil {
+		return err
+	}
+	mutationDigest, err := hashAuditRecord(mutation)
+	if err != nil {
+		return err
+	}
+	for _, record := range []audit.Record{topology, effectList} {
+		if err := insertAuditRecord(ctx, tx, record); err != nil {
+			return err
+		}
+	}
+	for _, event := range events {
+		if err := insertAuditRecord(ctx, tx, audit.Record{Kind: auditEventField, Fields: []audit.Field{
+			{Name: auditEventField, Value: audit.Nested(event)},
+		}}); err != nil {
+			return err
+		}
+	}
+	if err := insertAuditRecord(ctx, tx, mutation); err != nil {
+		return err
+	}
+	entryCount, err := nextAuditInteger("scope entry count", scope.entryCount)
+	if err != nil {
+		return err
+	}
+	entry, err := makeAuditScopeChainEntry(
+		values, scope.scopeID, entryCount, scope.chainHead, mutationDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	scopeHead, err := hashAuditRecord(entry)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, entry); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE audit_scopes SET entry_count=?,chain_head=? WHERE scope_id=?`,
+		entryCount, scopeHead.text, scope.scopeID,
+	); err != nil {
+		return fmt.Errorf("advancing audit scope %s: %w", scope.scopeID, err)
+	}
+	allocation, err := makeAuditedTopologyAllocationEntry(
+		values, authority.sequence+1, nodeSequence,
+		authority.allocationHead, mutationDigest.value, topologyDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	allocationHead, err := hashAuditRecord(allocation)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, allocation); err != nil {
+		return err
+	}
+	allocationCount, err := nextAuditInteger(
+		"allocation entry count", authority.allocationCount,
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE audit_authority
+		SET operation_sequence_high_water=?,allocation_entry_count=?,allocation_head=?
+		WHERE singleton=1`, authority.sequence+1, allocationCount, allocationHead.text); err != nil {
+		return fmt.Errorf("advancing audit allocation authority: %w", err)
+	}
+	return nil
+}

--- a/internal/store/trash.go
+++ b/internal/store/trash.go
@@ -22,9 +22,17 @@ func (s *Store) Trash(ctx context.Context, id, ifRev int64) (Node, string, error
 	}
 	var trashed Node
 	var origPath string
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		n, err := nodeByIDTx(tx, id)
 		if err != nil {
+			return err
+		}
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if active {
+			trashed, origPath, err = s.trashAuditedTx(ctx, tx, n, ifRev)
 			return err
 		}
 		if n.TrashedAt != nil {
@@ -37,7 +45,7 @@ func (s *Store) Trash(ctx context.Context, id, ifRev int64) (Node, string, error
 		if origPath, err = pathOf(ctx, tx, id); err != nil {
 			return err
 		}
-		if err := s.trashNodeTx(tx, n); err != nil {
+		if err := s.trashNodeTx(tx, n, nowRFC3339()); err != nil {
 			return err
 		}
 		trashed, err = nodeByIDTx(tx, id)
@@ -56,7 +64,7 @@ func (s *Store) Trash(ctx context.Context, id, ifRev int64) (Node, string, error
 func (s *Store) TrashPath(ctx context.Context, path string) (Node, string, error) {
 	var trashed Node
 	var origPath string
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		n, err := nodeByPath(ctx, tx, s.rootID, path)
 		if err != nil {
 			return fmt.Errorf("resolving %q: %w", path, err)
@@ -64,10 +72,20 @@ func (s *Store) TrashPath(ctx context.Context, path string) (Node, string, error
 		if n.ID == s.rootID {
 			return ErrIsRoot
 		}
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if active {
+			trashed, origPath, err = s.trashAuditedTx(
+				ctx, tx, n, UnconditionalRev,
+			)
+			return err
+		}
 		if origPath, err = pathOf(ctx, tx, n.ID); err != nil {
 			return err
 		}
-		if err := s.trashNodeTx(tx, n); err != nil {
+		if err := s.trashNodeTx(tx, n, nowRFC3339()); err != nil {
 			return err
 		}
 		trashed, err = nodeByIDTx(tx, n.ID)
@@ -81,9 +99,8 @@ func (s *Store) TrashPath(ctx context.Context, path string) (Node, string, error
 
 // trashNodeTx trashes a live node n (pre-checked by the caller) and its live
 // subtree within the caller's transaction.
-func (s *Store) trashNodeTx(tx *sql.Tx, n Node) error {
+func (s *Store) trashNodeTx(tx *sql.Tx, n Node, now string) error {
 	id := n.ID
-	now := nowRFC3339()
 	if _, err := tx.Exec(`
 			WITH RECURSIVE subtree(id) AS (
 				SELECT id FROM nodes WHERE id = ?


### PR DESCRIPTION
Once a directory is under full audit, `docbank rm` should still behave like a reversible move to trash. For example, removing `/Projects/Work` should take it out of the live tree while preserving the identity, versions, original location, and path history of `Work` and every document beneath it. Before this change, audit activation refused that ordinary operation.

This PR records the whole live-to-trash transition as one operation. The audited subtree receives retained trash paths such as `@trash/known/Projects/Work/child.txt`, while the original live paths remain in history. If the history cannot be recorded, the soft deletion rolls back with it. JSONL import and backup restore independently reconstruct the pre-trash tree, derive the complete subtree, and reject a record that omits a descendant or changes its origin.

The boundary is deliberately narrow and reviewable. The trashed subtree and its origin parent must already belong to the same audit scope. Trashing across a scope boundary still fails closed because that requires witness and membership changes. Restore and permanent trash deletion are also unchanged and will be handled as separate lifecycle operations.

The shared topology envelope now serves both moves and trash, but the trash closure and path derivation are independently checked in Go. No audit policy was moved into SQL and no unfinished public audit control is exposed.

Kata: 0c7b.