### PR TITLE
Record reversible audited restore transitions

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -200,7 +200,7 @@ func TestAddProgressBatchesManySmallFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 130, rep.Added)
 	require.GreaterOrEqual(t, len(events), 4, "initial, two batches, and final")
-	assert.Less(t, len(events), 10, "progress must not emit one event per small file")
+	assert.Less(t, len(events), rep.Added, "progress must not emit one event per small file")
 	assert.True(t, events[len(events)-1].Final)
 	assert.Equal(t, int64(130), events[len(events)-1].FilesDone)
 }

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -78,7 +78,7 @@ func replayAuditTopology(topology []audit.Record) (map[uint64]replayAuditTopolog
 		if err != nil {
 			return nil, err
 		}
-		state, err := auditTextField(record, "state")
+		state, err := auditTextField(record, auditStateField)
 		if err != nil {
 			return nil, err
 		}
@@ -334,6 +334,12 @@ func validateAuditedHistory(
 					topologyDeltas, pathEffectLists, events,
 					usedTopologyDeltas, usedPathEffectLists, usedEvents,
 				)
+			} else if kind == auditedTopologyRestore {
+				err = replay.applyNodeRestore(
+					vaultID, mutation, allocations[sequence], entries[sequence],
+					topologyDeltas, pathEffectLists, events,
+					usedTopologyDeltas, usedPathEffectLists, usedEvents,
+				)
 			} else {
 				err = replay.applyNodeMove(
 					vaultID, mutation, allocations[sequence], entries[sequence],
@@ -380,8 +386,9 @@ func validateAuditedHistory(
 }
 
 const (
-	auditedTopologyMove  = "move"
-	auditedTopologyTrash = "trash"
+	auditedTopologyMove    = "move"
+	auditedTopologyTrash   = "trash"
+	auditedTopologyRestore = "restore"
 )
 
 func classifyAuditedTopologyMutation(
@@ -399,32 +406,43 @@ func classifyAuditedTopologyMutation(
 	if err != nil {
 		return "", err
 	}
-	kind := auditedTopologyMove
+	var sawTrash, sawRestore bool
 	for _, change := range changes {
 		pre, preErr := auditNestedField(change, "pre")
 		post, postErr := auditNestedField(change, "post")
 		if preErr != nil || postErr != nil {
 			return "", errors.New("topology mutation requires complete pre/post states")
 		}
-		preState, err := auditTextField(pre, "state")
+		preState, err := auditTextField(pre, auditStateField)
 		if err != nil {
 			return "", err
 		}
-		postState, err := auditTextField(post, "state")
+		postState, err := auditTextField(post, auditStateField)
 		if err != nil {
 			return "", err
 		}
 		switch {
 		case preState == auditNodeStateLive && postState == auditNodeStateLive:
 		case preState == auditNodeStateLive && postState == auditNodeStateTrash:
-			kind = auditedTopologyTrash
+			sawTrash = true
+		case preState == auditNodeStateTrash && postState == auditNodeStateLive:
+			sawRestore = true
 		default:
 			return "", fmt.Errorf(
 				"unsupported audited topology state transition %s to %s", preState, postState,
 			)
 		}
 	}
-	return kind, nil
+	if sawTrash && sawRestore {
+		return "", errors.New("audited topology mutation mixes trash and restore transitions")
+	}
+	if sawTrash {
+		return auditedTopologyTrash, nil
+	}
+	if sawRestore {
+		return auditedTopologyRestore, nil
+	}
+	return auditedTopologyMove, nil
 }
 
 func auditRecordsByDigest(records []storedAuditRecord) map[string]storedAuditRecord {

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -235,7 +235,7 @@ func validateCreatedTopologyNode(
 	checks := []func() error{
 		func() error { return requireAuditUnsigned(node, metadataNodeIDField, childID) },
 		func() error { return requireAuditUnsigned(node, "parent_id", parentID) },
-		func() error { return requireAuditText(node, "state", auditNodeStateLive) },
+		func() error { return requireAuditText(node, auditStateField, auditNodeStateLive) },
 		func() error { return requireAuditAbsent(node, auditOriginField) },
 		func() error { return requireAuditAbsent(node, "trashed_at") },
 	}

--- a/internal/store/audit_node_move.go
+++ b/internal/store/audit_node_move.go
@@ -293,12 +293,9 @@ func persistAuditedMove(
 func makeAuditedMoveTopologyDelta(
 	operationID audit.Value, prior, resulting map[int64]Node,
 ) (audit.Record, error) {
-	changes := make([]audit.Record, 0, len(prior))
+	priorRecords := make(map[int64]audit.Record, len(prior))
+	resultingRecords := make(map[int64]audit.Record, len(resulting))
 	for nodeID, priorNode := range prior {
-		auditNodeID, err := positiveAuditNodeID(nodeID)
-		if err != nil {
-			return audit.Record{}, err
-		}
 		resultingNode, ok := resulting[nodeID]
 		if !ok {
 			return audit.Record{}, fmt.Errorf("audited move lacks resulting node %d", nodeID)
@@ -311,16 +308,9 @@ func makeAuditedMoveTopologyDelta(
 		if err != nil {
 			return audit.Record{}, err
 		}
-		changes = append(changes, audit.Record{Kind: "topology_change", Fields: []audit.Field{
-			{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
-			{Name: "pre", Value: audit.Nested(pre)},
-			{Name: "post", Value: audit.Nested(post)},
-		}})
+		priorRecords[nodeID], resultingRecords[nodeID] = pre, post
 	}
-	if err := sortAuditTopologyRecords(changes); err != nil {
-		return audit.Record{}, err
-	}
-	return makeAuditedTopologyDelta(operationID, changes), nil
+	return makeAuditedTopologyRecordDelta(operationID, priorRecords, resultingRecords)
 }
 
 func makeAuditedTopologyDelta(operationID audit.Value, changes []audit.Record) audit.Record {
@@ -356,13 +346,13 @@ func makeAuditedMovePathEffects(
 		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
 			{Name: auditScopeIDField, Value: scopeID},
 			{Name: "member_node_id", Value: audit.Unsigned(auditNodeID)},
-			{Name: "old", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
-				{Name: "path", Value: audit.Bytes([]byte(priorPath))},
-				{Name: "state", Value: live},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes([]byte(priorPath))},
+				{Name: auditStateField, Value: live},
 			}})},
-			{Name: "new", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
-				{Name: "path", Value: audit.Bytes([]byte(resultingPath))},
-				{Name: "state", Value: live},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes([]byte(resultingPath))},
+				{Name: auditStateField, Value: live},
 			}})},
 		}})
 	}

--- a/internal/store/audit_node_move_validate.go
+++ b/internal/store/audit_node_move_validate.go
@@ -340,7 +340,7 @@ func requireLiveDirectoryTopology(topology []audit.Record, nodeID uint64) error 
 		if err := requireAuditText(node, "node_kind", nodeKindDir); err != nil {
 			return err
 		}
-		return requireAuditText(node, "state", auditNodeStateLive)
+		return requireAuditText(node, auditStateField, auditNodeStateLive)
 	}
 	return fmt.Errorf("node move parent %d is absent from topology", nodeID)
 }
@@ -417,11 +417,11 @@ func (replay *auditedHistoryReplay) deriveNodeMovePathEffects(
 		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
 			{Name: auditScopeIDField, Value: scopeID},
 			{Name: "member_node_id", Value: audit.Unsigned(nodeID)},
-			{Name: "old", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
-				{Name: "path", Value: audit.Bytes(priorPath)}, {Name: "state", Value: live},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes(priorPath)}, {Name: auditStateField, Value: live},
 			}})},
-			{Name: "new", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
-				{Name: "path", Value: audit.Bytes(postPath)}, {Name: "state", Value: live},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes(postPath)}, {Name: auditStateField, Value: live},
 			}})},
 		}})
 	}
@@ -436,7 +436,7 @@ func auditLivePath(
 		return nil, false, fmt.Errorf("audit topology lacks node %d", nodeID)
 	}
 	current := topology[index]
-	state, err := auditTextField(current, "state")
+	state, err := auditTextField(current, auditStateField)
 	if err != nil {
 		return nil, false, err
 	}
@@ -471,7 +471,7 @@ func auditLivePath(
 			return nil, false, fmt.Errorf("audit topology node %d has missing live parent %d", id, *parentID)
 		}
 		parent := topology[parentIndex]
-		if err := requireAuditText(parent, "state", auditNodeStateLive); err != nil {
+		if err := requireAuditText(parent, auditStateField, auditNodeStateLive); err != nil {
 			return nil, false, err
 		}
 		current = parent

--- a/internal/store/audit_node_restore.go
+++ b/internal/store/audit_node_restore.go
@@ -112,6 +112,32 @@ func (s *Store) prepareAuditedRestore(
 		return snapshot, unsupportedAuditedNodeMutation(node.ID)
 	}
 	scope := scopes[0]
+	if target.finalName != target.originalName {
+		scopeMembers, err := auditScopeMemberSetTx(ctx, tx, scope.scopeID)
+		if err != nil {
+			return snapshot, err
+		}
+		topology, err := currentAuditTopology(ctx, tx)
+		if err != nil {
+			return snapshot, err
+		}
+		auditNodeID, err := positiveAuditNodeID(node.ID)
+		if err != nil {
+			return snapshot, err
+		}
+		affectsTrashOrigin, err := auditMoveAffectsTrashOrigin(
+			topology, scopeMembers, auditNodeID,
+		)
+		if err != nil {
+			return snapshot, err
+		}
+		if affectsTrashOrigin {
+			return snapshot, fmt.Errorf(
+				"restoring node %d under a conflict suffix would change retained trash-origin paths: %w",
+				node.ID, ErrAuditMutationUnsupported,
+			)
+		}
+	}
 	destinationMember, err := nodeInAuditScopeTx(ctx, tx, target.destID, scope.scopeID)
 	if err != nil {
 		return snapshot, err

--- a/internal/store/audit_node_restore.go
+++ b/internal/store/audit_node_restore.go
@@ -1,0 +1,305 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type auditedRestoreSnapshot struct {
+	authority                auditAuthorityState
+	scope                    auditScopeState
+	nodeSequence             int64
+	operationID, recordedAt  string
+	target                   restoreTarget
+	priorNodes, priorSubtree map[int64]Node
+	priorTopology            map[int64]audit.Record
+	priorPaths               map[int64]string
+	subtreeIDs               []int64
+}
+
+func (s *Store) restoreAuditedTx(
+	ctx context.Context, tx *sql.Tx, node Node, ifRev int64,
+) (Node, error) {
+	snapshot, err := s.prepareAuditedRestore(ctx, tx, node, ifRev)
+	if err != nil {
+		return Node{}, err
+	}
+	restored, err := s.restoreNodeTx(tx, node, snapshot.target, snapshot.recordedAt)
+	if err != nil {
+		return Node{}, err
+	}
+	resultingNodes := make(map[int64]Node, len(snapshot.priorNodes))
+	resultingTopology := make(map[int64]audit.Record, len(snapshot.priorNodes))
+	for nodeID := range snapshot.priorNodes {
+		resulting, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return Node{}, err
+		}
+		topology, err := auditTopologyForNodeTx(ctx, tx, nodeID)
+		if err != nil {
+			return Node{}, err
+		}
+		resultingNodes[nodeID], resultingTopology[nodeID] = resulting, topology
+	}
+	resultingSubtree := make(map[int64]Node, len(snapshot.subtreeIDs))
+	resultingPaths := make(map[int64]string, len(snapshot.subtreeIDs))
+	for _, nodeID := range snapshot.subtreeIDs {
+		path, err := pathOf(ctx, tx, nodeID)
+		if err != nil {
+			return Node{}, err
+		}
+		resultingSubtree[nodeID], resultingPaths[nodeID] = resultingNodes[nodeID], path
+	}
+	values, err := makeAuditedMutationValues(
+		s.vaultID, snapshot.authority.lineageID, snapshot.operationID, snapshot.recordedAt,
+	)
+	if err != nil {
+		return Node{}, err
+	}
+	topology, err := makeAuditedTopologyRecordDelta(
+		values.operationID, snapshot.priorTopology, resultingTopology,
+	)
+	if err != nil {
+		return Node{}, err
+	}
+	effects, err := makeAuditedRestorePathEffects(snapshot, resultingPaths)
+	if err != nil {
+		return Node{}, err
+	}
+	if err := persistAuditedTopologyMutation(
+		ctx, tx, values, snapshot.authority, snapshot.scope, snapshot.nodeSequence,
+		topology, effects, snapshot.priorNodes, resultingNodes,
+		snapshot.priorSubtree, resultingSubtree,
+	); err != nil {
+		return Node{}, err
+	}
+	return restored, nil
+}
+
+func (s *Store) prepareAuditedRestore(
+	ctx context.Context, tx *sql.Tx, node Node, ifRev int64,
+) (auditedRestoreSnapshot, error) {
+	var snapshot auditedRestoreSnapshot
+	if node.TrashedAt == nil {
+		return snapshot, fmt.Errorf("node %d: %w", node.ID, ErrNotTrashed)
+	}
+	if ifRev != UnconditionalRev && node.Revision != ifRev {
+		return snapshot, fmt.Errorf(
+			"node %d at revision %d, expected %d: %w",
+			node.ID, node.Revision, ifRev, ErrStaleRevision,
+		)
+	}
+	target, err := s.restoreTargetTx(tx, node)
+	if err != nil {
+		return snapshot, err
+	}
+	if target.originParentID == nil || target.destID != *target.originParentID {
+		return snapshot, fmt.Errorf(
+			"restoring node %d requires a scope-boundary fallback: %w",
+			node.ID, ErrAuditMutationUnsupported,
+		)
+	}
+	authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, node.ID)
+	if err != nil {
+		return snapshot, err
+	}
+	if len(scopes) != 1 {
+		return snapshot, unsupportedAuditedNodeMutation(node.ID)
+	}
+	scope := scopes[0]
+	destinationMember, err := nodeInAuditScopeTx(ctx, tx, target.destID, scope.scopeID)
+	if err != nil {
+		return snapshot, err
+	}
+	if !destinationMember {
+		return snapshot, unsupportedAuditedNodeMutation(target.destID)
+	}
+	subtreeIDs, err := trashedSubtreeIDsTx(ctx, tx, node.ID, *node.TrashedAt)
+	if err != nil {
+		return snapshot, err
+	}
+	priorSubtree := make(map[int64]Node, len(subtreeIDs))
+	for _, nodeID := range subtreeIDs {
+		member, err := nodeInAuditScopeTx(ctx, tx, nodeID, scope.scopeID)
+		if err != nil {
+			return snapshot, err
+		}
+		if !member {
+			return snapshot, unsupportedAuditedNodeMutation(nodeID)
+		}
+		prior, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return snapshot, err
+		}
+		priorSubtree[nodeID] = prior
+	}
+	originParentPath, err := pathOf(ctx, tx, target.destID)
+	if err != nil {
+		return snapshot, err
+	}
+	rootTrashPath := append([]byte("@trash/known"), []byte(originParentPath)...)
+	if rootTrashPath[len(rootTrashPath)-1] != '/' {
+		rootTrashPath = append(rootTrashPath, '/')
+	}
+	rootTrashPath = append(rootTrashPath, []byte(target.originalName)...)
+	priorPaths := make(map[int64]string, len(subtreeIDs))
+	for _, nodeID := range subtreeIDs {
+		path, err := auditedTrashSubtreePath(
+			priorSubtree, node.ID, nodeID, string(rootTrashPath),
+		)
+		if err != nil {
+			return snapshot, err
+		}
+		priorPaths[nodeID] = path
+	}
+	changedIDs := append(slices.Clone(subtreeIDs), target.destID)
+	slices.Sort(changedIDs)
+	priorNodes := make(map[int64]Node, len(changedIDs))
+	priorTopology := make(map[int64]audit.Record, len(changedIDs))
+	for _, nodeID := range changedIDs {
+		prior, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return snapshot, err
+		}
+		topology, err := auditTopologyForNodeTx(ctx, tx, nodeID)
+		if err != nil {
+			return snapshot, err
+		}
+		priorNodes[nodeID], priorTopology[nodeID] = prior, topology
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return snapshot, err
+	}
+	return auditedRestoreSnapshot{
+		authority: authority, scope: scope, nodeSequence: nodeSequence,
+		operationID: operationID, recordedAt: nowRFC3339(), target: target,
+		priorNodes: priorNodes, priorSubtree: priorSubtree, priorTopology: priorTopology,
+		priorPaths: priorPaths, subtreeIDs: subtreeIDs,
+	}, nil
+}
+
+func trashedSubtreeIDsTx(
+	ctx context.Context, tx *sql.Tx, rootID int64, trashedAt string,
+) ([]int64, error) {
+	rows, err := tx.QueryContext(
+		ctx, `SELECT id,parent_id FROM nodes WHERE trashed_at=? ORDER BY id`, trashedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing trashed subtree of node %d: %w", rootID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	children := make(map[int64][]int64)
+	foundRoot := false
+	for rows.Next() {
+		var id int64
+		var parentID sql.NullInt64
+		if err := rows.Scan(&id, &parentID); err != nil {
+			return nil, fmt.Errorf("scanning trashed subtree of node %d: %w", rootID, err)
+		}
+		foundRoot = foundRoot || id == rootID
+		if parentID.Valid {
+			children[parentID.Int64] = append(children[parentID.Int64], id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing trashed subtree of node %d: %w", rootID, err)
+	}
+	if !foundRoot {
+		return nil, fmt.Errorf("node %d is not a restorable trash root: %w", rootID, ErrNotTrashed)
+	}
+	visited := make(map[int64]bool)
+	var result []int64
+	var visit func(int64) error
+	visit = func(nodeID int64) error {
+		if visited[nodeID] {
+			return errors.New("trashed subtree contains a parent cycle")
+		}
+		visited[nodeID] = true
+		result = append(result, nodeID)
+		for _, childID := range children[nodeID] {
+			if err := visit(childID); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := visit(rootID); err != nil {
+		return nil, err
+	}
+	slices.Sort(result)
+	return result, nil
+}
+
+func auditedTrashSubtreePath(
+	nodes map[int64]Node, rootID, nodeID int64, rootPath string,
+) (string, error) {
+	if nodeID == rootID {
+		return rootPath, nil
+	}
+	visited := make(map[int64]bool)
+	var names []string
+	currentID := nodeID
+	for currentID != rootID {
+		if visited[currentID] {
+			return "", errors.New("audited trash subtree contains a parent cycle")
+		}
+		visited[currentID] = true
+		current, ok := nodes[currentID]
+		if !ok || current.ParentID == nil {
+			return "", fmt.Errorf("audited trash subtree node %d lacks its parent", currentID)
+		}
+		names = append(names, current.Name)
+		currentID = *current.ParentID
+	}
+	result := []byte(rootPath)
+	for _, name := range slices.Backward(names) {
+		result = append(result, '/')
+		result = append(result, name...)
+	}
+	return string(result), nil
+}
+
+func makeAuditedRestorePathEffects(
+	snapshot auditedRestoreSnapshot, resultingPaths map[int64]string,
+) ([]audit.Record, error) {
+	scopeID, err := audit.UUID(snapshot.scope.scopeID)
+	if err != nil {
+		return nil, err
+	}
+	trash, err := audit.Text(auditNodeStateTrash)
+	if err != nil {
+		return nil, err
+	}
+	live, err := audit.Text(auditNodeStateLive)
+	if err != nil {
+		return nil, err
+	}
+	effects := make([]audit.Record, 0, len(snapshot.subtreeIDs))
+	for _, nodeID := range snapshot.subtreeIDs {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		priorPath, resultingPath := snapshot.priorPaths[nodeID], resultingPaths[nodeID]
+		if priorPath == "" || resultingPath == "" {
+			return nil, fmt.Errorf("audited restore lacks a path for node %d", nodeID)
+		}
+		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
+			{Name: auditScopeIDField, Value: scopeID},
+			{Name: "member_node_id", Value: audit.Unsigned(auditNodeID)},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes([]byte(priorPath))}, {Name: auditStateField, Value: trash},
+			}})},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes([]byte(resultingPath))}, {Name: auditStateField, Value: live},
+			}})},
+		}})
+	}
+	return effects, nil
+}

--- a/internal/store/audit_node_restore_test.go
+++ b/internal/store/audit_node_restore_test.go
@@ -1,0 +1,242 @@
+package store
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedRestoreRecordsSubtreeAndRoundTrips(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	trashed, _, err := s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+
+	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	assert.Nil(t, restored.TrashedAt)
+	assert.Equal(t, work.Revision+2, restored.Revision)
+	restoredChild, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	assert.Equal(t, child.ID, restoredChild.ID)
+	assert.Nil(t, restoredChild.TrashedAt)
+	assert.Equal(t, child.Revision+2, restoredChild.Revision)
+	updatedProjects, err := s.NodeByID(t.Context(), projects.ID)
+	require.NoError(t, err)
+	assert.Equal(t, projects.Revision+2, updatedProjects.Revision)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	effects := auditPathEffectsForSequence(t, s, 3)
+	require.Len(t, effects, 2)
+	assertAuditPathState(t, effects[0], "old", "@trash/known/Projects/Work", "trash")
+	assertAuditPathState(t, effects[0], "new", "/Projects/Work", "live")
+	assertAuditPathState(
+		t, effects[1], "old", "@trash/known/Projects/Work/child.txt", "trash",
+	)
+	assertAuditPathState(t, effects[1], "new", "/Projects/Work/child.txt", "live")
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	roundTrip, err := Open(filepath.Join(t.TempDir(), "round-trip.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, roundTrip.Close()) })
+	require.NoError(t, roundTrip.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var restoredExport bytes.Buffer
+	require.NoError(t, roundTrip.ExportMetadata(t.Context(), &restoredExport))
+	assert.Equal(t, exported.Bytes(), restoredExport.Bytes())
+	_, err = roundTrip.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+}
+
+func TestAuditedRestoreUsesCanonicalConflictSuffix(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	trashed, _, err := s.Trash(t.Context(), report.ID, report.Revision)
+	require.NoError(t, err)
+	replacement, err := s.CreateFile(
+		t.Context(), projects.ID, "report.txt", fakeHash("cafe"), 18, "text/plain",
+	)
+	require.NoError(t, err)
+
+	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	assert.Equal(t, "report (2).txt", restored.Name)
+	stillReplacement, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	assert.Equal(t, replacement.ID, stillReplacement.ID)
+	resolved, err := s.NodeByPath(t.Context(), "/Projects/report (2).txt")
+	require.NoError(t, err)
+	assert.Equal(t, report.ID, resolved.ID)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedRootScopeRestoreRecordsRootParentTouch(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, s.RootID())
+	trashed, _, err := s.Trash(t.Context(), empty.ID, empty.Revision)
+	require.NoError(t, err)
+	rootAfterTrash, err := s.NodeByID(t.Context(), s.RootID())
+	require.NoError(t, err)
+
+	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	assert.Equal(t, "/Empty", mustNodePath(t, s, restored.ID))
+	rootAfterRestore, err := s.NodeByID(t.Context(), s.RootID())
+	require.NoError(t, err)
+	assert.Equal(t, rootAfterTrash.Revision+1, rootAfterRestore.Revision)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedRestoreRefusesFallbackFromTrashedOrigin(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	empty, err := s.Mkdir(t.Context(), s.RootID(), "Empty")
+	require.NoError(t, err)
+	file, err := s.CreateFile(
+		t.Context(), empty.ID, "file.txt", fakeHash("fa11bac"), 8, "text/plain",
+	)
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, s.RootID())
+	trashedFile, _, err := s.Trash(t.Context(), file.ID, file.Revision)
+	require.NoError(t, err)
+	empty, err = s.NodeByID(t.Context(), empty.ID)
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), empty.ID, empty.Revision)
+	require.NoError(t, err)
+
+	restored, err := s.Restore(t.Context(), trashedFile.ID, trashedFile.Revision)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	assert.Zero(t, restored)
+	stillTrashed, err := s.NodeByID(t.Context(), file.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, stillTrashed.TrashedAt)
+}
+
+func TestAuditedRestoreRollsBackTreeAndHistory(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	trashed, _, err := s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_audit_restore_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audit restore failure'); END`)
+	require.NoError(t, err)
+
+	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	require.ErrorContains(t, err, "forced audit restore failure")
+	assert.Zero(t, restored)
+	stillTrashed, err := s.NodeByID(t.Context(), work.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, stillTrashed.TrashedAt)
+	_, err = s.NodeByPath(t.Context(), "/Projects/Work")
+	require.ErrorIs(t, err, ErrNotFound)
+	var sequence int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&sequence))
+	assert.Equal(t, int64(2), sequence)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedRestoreReplayRejectsOmittedDescendant(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	trashed, _, err := s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+	_, err = s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, scope, initial)
+	require.NoError(t, err)
+	mutations, err := auditRecordsBySequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	allocations, err := auditRecordsBySequence(records["allocation_entry"], authority.sequence)
+	require.NoError(t, err)
+	entries, err := auditScopeRecordsByCount(records["scope_chain_entry"], scope)
+	require.NoError(t, err)
+	topologyRecords := auditRecordsByDigest(records[auditTopologyDeltaField])
+	pathEffectRecords := auditRecordsByDigest(records["path_effect_list"])
+	eventRecords, err := auditEventRecordsByID(records[auditEventField])
+	require.NoError(t, err)
+	usedTopology := map[string]bool{}
+	usedPathEffects := map[string]bool{}
+	usedEvents := map[string]bool{}
+	require.NoError(t, replay.applyNodeTrash(
+		s.VaultID(), mutations[2], allocations[2], entries[2],
+		topologyRecords, pathEffectRecords, eventRecords,
+		usedTopology, usedPathEffects, usedEvents,
+	))
+
+	mutation := mutations[3]
+	digest, err := auditDigestField(mutation.record, auditTopologyDeltaField)
+	require.NoError(t, err)
+	delta := topologyRecords[digest]
+	changes, err := auditRecordListField(delta.record, "changes")
+	require.NoError(t, err)
+	filtered := changes[:0]
+	for _, change := range changes {
+		if mustAuditUnsignedField(t, change, metadataNodeIDField) != uint64(child.ID) {
+			filtered = append(filtered, change)
+		}
+	}
+	delta.record = mustReplaceAuditRecordField(
+		t, delta.record, "changes", audit.List(auditNestedValues(filtered)...),
+	)
+	topologyRecords[digest] = delta
+	_, _, err = replay.validateNodeRestoreTopology(
+		mutation.record, mustAuditUUIDField(t, mutation.record, auditOperationIDField),
+		topologyRecords, usedTopology,
+	)
+	require.ErrorContains(t, err, "complete trash subtree")
+}
+
+func auditPathEffectsForSequence(
+	t *testing.T, s *Store, sequence int64,
+) []audit.Record {
+	t.Helper()
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	mutations, err := auditRecordsBySequence(records["canonical_mutation"], sequence)
+	require.NoError(t, err)
+	digest, err := auditDigestField(mutations[sequence].record, "path_effect_digest")
+	require.NoError(t, err)
+	lists := auditRecordsByDigest(records["path_effect_list"])
+	effects, err := auditRecordListField(lists[digest].record, "effects")
+	require.NoError(t, err)
+	return effects
+}
+
+func mustNodePath(t *testing.T, s *Store, nodeID int64) string {
+	t.Helper()
+	path, err := s.Path(t.Context(), nodeID)
+	require.NoError(t, err)
+	return path
+}

--- a/internal/store/audit_node_restore_test.go
+++ b/internal/store/audit_node_restore_test.go
@@ -82,6 +82,51 @@ func TestAuditedRestoreUsesCanonicalConflictSuffix(t *testing.T) {
 	require.NoError(t, s.ValidateMetadata(t.Context()))
 }
 
+func TestAuditedRestoreAllowsUnchangedRetainedTrashOriginPath(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), child.ID, child.Revision)
+	require.NoError(t, err)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	trashedWork, _, err := s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+
+	restored, err := s.Restore(t.Context(), trashedWork.ID, trashedWork.Revision)
+	require.NoError(t, err)
+	assert.Equal(t, "/Projects/Work", mustNodePath(t, s, restored.ID))
+	stillTrashed, err := s.NodeByID(t.Context(), child.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, stillTrashed.TrashedAt)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedRestoreRejectsConflictThatRetargetsTrashOrigin(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), child.ID, child.Revision)
+	require.NoError(t, err)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	trashedWork, _, err := s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	_, err = s.Mkdir(t.Context(), projects.ID, "Work")
+	require.NoError(t, err)
+
+	restored, err := s.Restore(t.Context(), trashedWork.ID, trashedWork.Revision)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	require.ErrorContains(t, err, "retained trash-origin paths")
+	assert.Zero(t, restored)
+	stillTrashed, err := s.NodeByID(t.Context(), work.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, stillTrashed.TrashedAt)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
 func TestAuditedRootScopeRestoreRecordsRootParentTouch(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
 	require.NoError(t, err)
@@ -216,6 +261,31 @@ func TestAuditedRestoreReplayRejectsOmittedDescendant(t *testing.T) {
 		topologyRecords, usedTopology,
 	)
 	require.ErrorContains(t, err, "complete trash subtree")
+}
+
+func TestAuditedRestoreReplayRejectsTrashSubtreeCycle(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+	topology, err := currentAuditTopology(t.Context(), s.db)
+	require.NoError(t, err)
+	index := make(map[uint64]int, len(topology))
+	for i, node := range topology {
+		nodeID := mustAuditUnsignedField(t, node, metadataNodeIDField)
+		index[nodeID] = i
+	}
+	rootID, childID := uint64(work.ID), uint64(child.ID)
+	topology[index[rootID]] = mustReplaceAuditRecordField(
+		t, topology[index[rootID]], auditParentIDField, audit.Unsigned(childID),
+	)
+	replay := auditedHistoryReplay{topology: topology, topologyIndex: index}
+
+	_, err = replay.trashedTopologySubtree(rootID)
+	require.ErrorContains(t, err, "contains a cycle")
 }
 
 func auditPathEffectsForSequence(

--- a/internal/store/audit_node_restore_validate.go
+++ b/internal/store/audit_node_restore_validate.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"slices"
@@ -199,6 +200,19 @@ func (replay *auditedHistoryReplay) validateNodeRestoreTopology(
 	if err != nil {
 		return replayedTopologyMutation{}, nil, err
 	}
+	if !bytes.Equal(finalName, originName) {
+		affectsTrashOrigin, err := auditMoveAffectsTrashOrigin(
+			replay.topology, replay.memberSet, restoreRoot,
+		)
+		if err != nil {
+			return replayedTopologyMutation{}, nil, err
+		}
+		if affectsTrashOrigin {
+			return replayedTopologyMutation{}, nil, errors.New(
+				"node restore changes a retained trash-origin path without recording trash effects",
+			)
+		}
+	}
 	changedIDs := make([]uint64, 0, len(changeByID))
 	for nodeID := range changeByID {
 		if !replay.memberSet[nodeID] {
@@ -339,15 +353,21 @@ func (replay *auditedHistoryReplay) trashedTopologySubtree(root uint64) ([]uint6
 		}
 	}
 	var result []uint64
-	var add func(uint64)
-	add = func(nodeID uint64) {
+	visited := make(map[uint64]bool)
+	pending := []uint64{root}
+	for len(pending) != 0 {
+		nodeID := pending[len(pending)-1]
+		pending = pending[:len(pending)-1]
+		if visited[nodeID] {
+			return nil, fmt.Errorf("audit trash subtree contains a cycle at node %d", nodeID)
+		}
+		visited[nodeID] = true
 		result = append(result, nodeID)
 		slices.Sort(children[nodeID])
-		for _, child := range children[nodeID] {
-			add(child)
+		for _, child := range slices.Backward(children[nodeID]) {
+			pending = append(pending, child)
 		}
 	}
-	add(root)
 	slices.Sort(result)
 	return result, nil
 }

--- a/internal/store/audit_node_restore_validate.go
+++ b/internal/store/audit_node_restore_validate.go
@@ -8,7 +8,7 @@ import (
 	"go.kenn.io/docbank/internal/audit"
 )
 
-func (replay *auditedHistoryReplay) applyNodeTrash(
+func (replay *auditedHistoryReplay) applyNodeRestore(
 	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
 	topologyRecords, pathEffectRecords, eventRecords map[string]storedAuditRecord,
 	usedTopology, usedPathEffects, usedEvents map[string]bool,
@@ -39,16 +39,16 @@ func (replay *auditedHistoryReplay) applyNodeTrash(
 		return err
 	}
 	if len(bindings) != 0 {
-		return errors.New("in-scope trash cannot bind an enrollment baseline")
+		return errors.New("in-scope restore cannot bind an enrollment baseline")
 	}
-	transition, trashIDs, err := replay.validateNodeTrashTopology(
+	transition, restoredIDs, err := replay.validateNodeRestoreTopology(
 		mutation.record, operationID, topologyRecords, usedTopology,
 	)
 	if err != nil {
 		return err
 	}
-	expectedEffects, err := replay.deriveNodeTrashPathEffects(
-		transition.postTopology, trashIDs,
+	expectedEffects, err := replay.deriveNodeRestorePathEffects(
+		transition.postTopology, restoredIDs,
 	)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func (replay *auditedHistoryReplay) applyNodeTrash(
 	return replay.applyTopologyState(transition)
 }
 
-func (replay *auditedHistoryReplay) validateNodeTrashTopology(
+func (replay *auditedHistoryReplay) validateNodeRestoreTopology(
 	mutation audit.Record, operationID string,
 	topologyRecords map[string]storedAuditRecord, usedTopology map[string]bool,
 ) (replayedTopologyMutation, []uint64, error) {
@@ -104,7 +104,7 @@ func (replay *auditedHistoryReplay) validateNodeTrashTopology(
 	delta, ok := topologyRecords[digest]
 	if !ok || usedTopology[digest] {
 		return replayedTopologyMutation{}, nil, errors.New(
-			"node trash lacks one unique topology delta",
+			"node restore lacks one unique topology delta",
 		)
 	}
 	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
@@ -116,11 +116,11 @@ func (replay *auditedHistoryReplay) validateNodeTrashTopology(
 	}
 	if len(changes) < 2 {
 		return replayedTopologyMutation{}, nil, errors.New(
-			"in-scope trash topology must change a subtree and its origin parent",
+			"in-scope restore topology must change a subtree and its destination parent",
 		)
 	}
 	changeByID := make(map[uint64]audit.Record, len(changes))
-	trashSet := make(map[uint64]bool, len(changes)-1)
+	restoredSet := make(map[uint64]bool, len(changes)-1)
 	storedIDs := make([]uint64, 0, len(changes))
 	for _, change := range changes {
 		nodeID, err := auditUnsignedField(change, metadataNodeIDField)
@@ -129,14 +129,14 @@ func (replay *auditedHistoryReplay) validateNodeTrashTopology(
 		}
 		if _, exists := changeByID[nodeID]; exists {
 			return replayedTopologyMutation{}, nil, fmt.Errorf(
-				"node trash repeats topology change for %d", nodeID,
+				"node restore repeats topology change for %d", nodeID,
 			)
 		}
 		pre, preErr := auditNestedField(change, "pre")
 		post, postErr := auditNestedField(change, "post")
 		if preErr != nil || postErr != nil {
 			return replayedTopologyMutation{}, nil, errors.New(
-				"in-scope trash requires complete topology sides",
+				"in-scope restore requires complete topology sides",
 			)
 		}
 		preState, err := auditTextField(pre, auditStateField)
@@ -147,11 +147,11 @@ func (replay *auditedHistoryReplay) validateNodeTrashTopology(
 		if err != nil {
 			return replayedTopologyMutation{}, nil, err
 		}
-		if preState == auditNodeStateLive && postState == auditNodeStateTrash {
-			trashSet[nodeID] = true
+		if preState == auditNodeStateTrash && postState == auditNodeStateLive {
+			restoredSet[nodeID] = true
 		} else if preState != auditNodeStateLive || postState != auditNodeStateLive {
 			return replayedTopologyMutation{}, nil, errors.New(
-				"node trash contains an unsupported topology state transition",
+				"node restore contains an unsupported topology state transition",
 			)
 		}
 		changeByID[nodeID] = change
@@ -159,63 +159,56 @@ func (replay *auditedHistoryReplay) validateNodeTrashTopology(
 	}
 	if !slices.IsSorted(storedIDs) {
 		return replayedTopologyMutation{}, nil, errors.New(
-			"node trash topology changes are not in canonical node order",
+			"node restore topology changes are not in canonical node order",
 		)
 	}
-	trashRoot, err := replay.deriveNodeTrashRoot(trashSet)
+	restoreRoot, originParent, originName, err := replay.deriveNodeRestoreRoot(restoredSet)
 	if err != nil {
 		return replayedTopologyMutation{}, nil, err
 	}
-	trashIDs, err := replay.liveTopologySubtree(trashRoot)
+	restoredIDs, err := replay.trashedTopologySubtree(restoreRoot)
 	if err != nil {
 		return replayedTopologyMutation{}, nil, err
 	}
-	if len(trashIDs) != len(trashSet) {
+	if len(restoredIDs) != len(restoredSet) {
 		return replayedTopologyMutation{}, nil, errors.New(
-			"node trash transition does not cover its complete live subtree",
+			"node restore transition does not cover its complete trash subtree",
 		)
 	}
-	for _, nodeID := range trashIDs {
-		if !trashSet[nodeID] {
+	for _, nodeID := range restoredIDs {
+		if !restoredSet[nodeID] {
 			return replayedTopologyMutation{}, nil, fmt.Errorf(
-				"node trash omits live subtree node %d", nodeID,
+				"node restore omits trash subtree node %d", nodeID,
 			)
 		}
 	}
-	rootPre, err := auditNestedField(changeByID[trashRoot], "pre")
-	if err != nil {
+	if restoredSet[originParent] || len(changeByID) != len(restoredIDs)+1 {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"node restore changed-node set does not match its subtree and destination parent",
+		)
+	}
+	if _, ok := changeByID[originParent]; !ok {
+		return replayedTopologyMutation{}, nil, errors.New(
+			"node restore lacks its destination-parent topology change",
+		)
+	}
+	if err := requireLiveDirectoryTopology(replay.topology, originParent); err != nil {
 		return replayedTopologyMutation{}, nil, err
 	}
-	originParent, err := auditOptionalParentIDField(rootPre)
-	if err != nil || originParent == nil {
-		return replayedTopologyMutation{}, nil, errors.New(
-			"node trash root lacks its live origin parent",
-		)
-	}
-	if trashSet[*originParent] || len(changeByID) != len(trashIDs)+1 {
-		return replayedTopologyMutation{}, nil, errors.New(
-			"node trash changed-node set does not match its subtree and origin parent",
-		)
-	}
-	if _, ok := changeByID[*originParent]; !ok {
-		return replayedTopologyMutation{}, nil, errors.New(
-			"node trash lacks its origin-parent topology change",
-		)
+	finalName, err := replay.nextFreeTopologyName(originParent, originName)
+	if err != nil {
+		return replayedTopologyMutation{}, nil, err
 	}
 	changedIDs := make([]uint64, 0, len(changeByID))
 	for nodeID := range changeByID {
 		if !replay.memberSet[nodeID] {
 			return replayedTopologyMutation{}, nil, fmt.Errorf(
-				"in-scope trash changes unaudited node %d", nodeID,
+				"in-scope restore changes unaudited node %d", nodeID,
 			)
 		}
 		changedIDs = append(changedIDs, nodeID)
 	}
 	slices.Sort(changedIDs)
-	rootID, err := auditTopologyRootID(replay.topology)
-	if err != nil {
-		return replayedTopologyMutation{}, nil, err
-	}
 	recordedAt, err := auditField(mutation, auditRecordedAtField)
 	if err != nil {
 		return replayedTopologyMutation{}, nil, err
@@ -234,61 +227,94 @@ func (replay *auditedHistoryReplay) validateNodeTrashTopology(
 		index, ok := replay.topologyIndex[nodeID]
 		if !ok || !auditRecordEqual(replay.topology[index], pre) {
 			return replayedTopologyMutation{}, nil, fmt.Errorf(
-				"node trash pre-state for %d does not match replay", nodeID,
+				"node restore pre-state for %d does not match replay", nodeID,
 			)
 		}
-		expected, err := expectedNodeTrashPost(
-			pre, nodeID, trashRoot, rootID, *originParent, trashSet[nodeID], recordedAt,
+		expected, err := expectedNodeRestorePost(
+			pre, nodeID, restoreRoot, originParent, finalName,
+			restoredSet[nodeID], recordedAt,
 		)
 		if err != nil {
 			return replayedTopologyMutation{}, nil, err
 		}
 		if !auditRecordEqual(expected, post) {
 			return replayedTopologyMutation{}, nil, fmt.Errorf(
-				"node trash post-state for %d does not match its transition", nodeID,
+				"node restore post-state for %d does not match its transition", nodeID,
 			)
 		}
 		postTopology[index] = post
 	}
 	if err := validateReplayedAuditTopology(postTopology); err != nil {
 		return replayedTopologyMutation{}, nil, fmt.Errorf(
-			"validating node trash topology: %w", err,
+			"validating node restore topology: %w", err,
 		)
 	}
 	usedTopology[digest] = true
 	return replayedTopologyMutation{
 		topologyDigest: digest, postTopology: postTopology, changedIDs: changedIDs,
-	}, trashIDs, nil
+	}, restoredIDs, nil
 }
 
-func (replay *auditedHistoryReplay) deriveNodeTrashRoot(
-	trashSet map[uint64]bool,
-) (uint64, error) {
-	var root uint64
-	for nodeID := range trashSet {
+func (replay *auditedHistoryReplay) deriveNodeRestoreRoot(
+	restoredSet map[uint64]bool,
+) (uint64, uint64, []byte, error) {
+	var root, originParent uint64
+	var originName []byte
+	for nodeID := range restoredSet {
 		index, ok := replay.topologyIndex[nodeID]
 		if !ok {
-			return 0, fmt.Errorf("node trash references missing topology node %d", nodeID)
+			return 0, 0, nil, fmt.Errorf(
+				"node restore references missing topology node %d", nodeID,
+			)
 		}
-		parentID, err := auditOptionalParentIDField(replay.topology[index])
+		originValue, err := auditField(replay.topology[index], auditOriginField)
 		if err != nil {
-			return 0, err
+			return 0, 0, nil, err
 		}
-		if parentID == nil || trashSet[*parentID] {
+		if originValue.IsAbsent() {
 			continue
 		}
 		if root != 0 {
-			return 0, errors.New("node trash transition has multiple subtree roots")
+			return 0, 0, nil, errors.New("node restore transition has multiple trash roots")
+		}
+		origin, ok := originValue.RecordValue()
+		if !ok || origin.Kind != "known_origin" {
+			return 0, 0, nil, errors.New(
+				"in-scope restore requires one known trash origin",
+			)
+		}
+		if err := requireAuditUnsigned(origin, metadataNodeIDField, nodeID); err != nil {
+			return 0, 0, nil, err
+		}
+		originParent, err = auditUnsignedField(origin, "parent_id")
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		originName, err = auditNameBytesField(origin)
+		if err != nil {
+			return 0, 0, nil, err
 		}
 		root = nodeID
 	}
 	if root == 0 {
-		return 0, errors.New("node trash transition lacks one subtree root")
+		return 0, 0, nil, errors.New("node restore transition lacks one trash root")
 	}
-	return root, nil
+	return root, originParent, originName, nil
 }
 
-func (replay *auditedHistoryReplay) liveTopologySubtree(root uint64) ([]uint64, error) {
+func (replay *auditedHistoryReplay) trashedTopologySubtree(root uint64) ([]uint64, error) {
+	rootIndex, ok := replay.topologyIndex[root]
+	if !ok {
+		return nil, fmt.Errorf("audit topology lacks trash root %d", root)
+	}
+	rootStamp, err := auditField(replay.topology[rootIndex], "trashed_at")
+	if err != nil {
+		return nil, err
+	}
+	rootTime, ok := rootStamp.TimestampValue()
+	if !ok {
+		return nil, errors.New("audit trash root lacks its trash timestamp")
+	}
 	children := make(map[uint64][]uint64)
 	for _, node := range replay.topology {
 		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
@@ -303,7 +329,12 @@ func (replay *auditedHistoryReplay) liveTopologySubtree(root uint64) ([]uint64, 
 		if err != nil {
 			return nil, err
 		}
-		if state == auditNodeStateLive && parentID != nil {
+		stamp, err := auditField(node, "trashed_at")
+		if err != nil {
+			return nil, err
+		}
+		stampTime, hasStamp := stamp.TimestampValue()
+		if state == auditNodeStateTrash && hasStamp && stampTime == rootTime && parentID != nil {
 			children[*parentID] = append(children[*parentID], nodeID)
 		}
 	}
@@ -321,75 +352,75 @@ func (replay *auditedHistoryReplay) liveTopologySubtree(root uint64) ([]uint64, 
 	return result, nil
 }
 
-func expectedNodeTrashPost(
-	pre audit.Record, nodeID, trashRoot, vaultRoot, originParent uint64,
-	trashed bool, recordedAt audit.Value,
-) (audit.Record, error) {
-	expected, err := replaceAuditRecordField(pre, "modified_at", recordedAt)
-	if err != nil || !trashed {
-		return expected, err
-	}
-	trashState, err := audit.Text(auditNodeStateTrash)
-	if err != nil {
-		return audit.Record{}, err
-	}
-	expected, err = replaceAuditRecordField(expected, auditStateField, trashState)
-	if err != nil {
-		return audit.Record{}, err
-	}
-	expected, err = replaceAuditRecordField(expected, "trashed_at", recordedAt)
-	if err != nil || nodeID != trashRoot {
-		return expected, err
-	}
-	name, err := auditNameBytesField(pre)
-	if err != nil {
-		return audit.Record{}, err
-	}
-	origin := audit.Record{Kind: "known_origin", Fields: []audit.Field{
-		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
-		{Name: "parent_id", Value: audit.Unsigned(originParent)},
-		{Name: "name", Value: audit.Bytes(name)},
-	}}
-	expected, err = replaceAuditRecordField(expected, "parent_id", audit.Unsigned(vaultRoot))
-	if err != nil {
-		return audit.Record{}, err
-	}
-	return replaceAuditRecordField(expected, auditOriginField, audit.Nested(origin))
-}
-
-func auditTopologyRootID(topology []audit.Record) (uint64, error) {
-	var root uint64
-	for _, node := range topology {
-		parentID, err := auditOptionalParentIDField(node)
+func (replay *auditedHistoryReplay) nextFreeTopologyName(
+	parentID uint64, name []byte,
+) ([]byte, error) {
+	base, ext := splitSuffix(string(name))
+	occupied := make(map[string]bool)
+	for _, node := range replay.topology {
+		state, err := auditTextField(node, auditStateField)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
-		if parentID != nil {
+		if state != auditNodeStateLive {
 			continue
 		}
-		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
+		candidateParent, err := auditOptionalParentIDField(node)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
-		if root != 0 {
-			return 0, errors.New("audit topology has multiple vault roots")
+		if candidateParent == nil || *candidateParent != parentID {
+			continue
 		}
-		root = nodeID
+		candidateName, err := auditNameBytesField(node)
+		if err != nil {
+			return nil, err
+		}
+		occupied[string(candidateName)] = true
 	}
-	if root == 0 {
-		return 0, errors.New("audit topology lacks its vault root")
+	for suffix := 1; ; suffix++ {
+		candidate := suffixedName(base, ext, suffix)
+		if !occupied[candidate] {
+			return []byte(candidate), nil
+		}
 	}
-	return root, nil
 }
 
-func (replay *auditedHistoryReplay) deriveNodeTrashPathEffects(
-	postTopology []audit.Record, trashIDs []uint64,
+func expectedNodeRestorePost(
+	pre audit.Record, nodeID, restoreRoot, originParent uint64, finalName []byte,
+	restored bool, recordedAt audit.Value,
+) (audit.Record, error) {
+	expected, err := replaceAuditRecordField(pre, "modified_at", recordedAt)
+	if err != nil || !restored {
+		return expected, err
+	}
+	liveState, err := audit.Text(auditNodeStateLive)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	expected, err = replaceAuditRecordField(expected, auditStateField, liveState)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	expected, err = replaceAuditRecordField(expected, "trashed_at", audit.Absent())
+	if err != nil {
+		return audit.Record{}, err
+	}
+	expected, err = replaceAuditRecordField(expected, auditOriginField, audit.Absent())
+	if err != nil || nodeID != restoreRoot {
+		return expected, err
+	}
+	expected, err = replaceAuditRecordField(expected, "parent_id", audit.Unsigned(originParent))
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return replaceAuditRecordField(expected, "name", audit.Bytes(finalName))
+}
+
+func (replay *auditedHistoryReplay) deriveNodeRestorePathEffects(
+	postTopology []audit.Record, restoredIDs []uint64,
 ) ([]audit.Record, error) {
 	scopeID, err := audit.UUID(replay.scopeID)
-	if err != nil {
-		return nil, err
-	}
-	live, err := audit.Text(auditNodeStateLive)
 	if err != nil {
 		return nil, err
 	}
@@ -397,115 +428,37 @@ func (replay *auditedHistoryReplay) deriveNodeTrashPathEffects(
 	if err != nil {
 		return nil, err
 	}
-	effects := make([]audit.Record, 0, len(trashIDs))
-	for _, nodeID := range trashIDs {
-		priorPath, priorLive, err := auditLivePath(
+	live, err := audit.Text(auditNodeStateLive)
+	if err != nil {
+		return nil, err
+	}
+	effects := make([]audit.Record, 0, len(restoredIDs))
+	for _, nodeID := range restoredIDs {
+		priorPath, err := auditKnownTrashPath(
 			replay.topology, replay.topologyIndex, nodeID,
 		)
 		if err != nil {
 			return nil, err
 		}
-		if !priorLive {
-			return nil, fmt.Errorf("node trash source %d is not live", nodeID)
-		}
-		postPath, err := auditKnownTrashPath(
+		postPath, postLive, err := auditLivePath(
 			postTopology, replay.topologyIndex, nodeID,
 		)
 		if err != nil {
 			return nil, err
 		}
+		if !postLive {
+			return nil, fmt.Errorf("node restore result %d is not live", nodeID)
+		}
 		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
 			{Name: auditScopeIDField, Value: scopeID},
 			{Name: "member_node_id", Value: audit.Unsigned(nodeID)},
 			{Name: "old", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
-				{Name: auditPathField, Value: audit.Bytes(priorPath)}, {Name: auditStateField, Value: live},
+				{Name: auditPathField, Value: audit.Bytes(priorPath)}, {Name: auditStateField, Value: trash},
 			}})},
 			{Name: "new", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
-				{Name: auditPathField, Value: audit.Bytes(postPath)}, {Name: auditStateField, Value: trash},
+				{Name: auditPathField, Value: audit.Bytes(postPath)}, {Name: auditStateField, Value: live},
 			}})},
 		}})
 	}
 	return effects, nil
-}
-
-func auditKnownTrashPath(
-	topology []audit.Record, topologyIndex map[uint64]int, nodeID uint64,
-) ([]byte, error) {
-	index, ok := topologyIndex[nodeID]
-	if !ok {
-		return nil, fmt.Errorf("audit topology lacks node %d", nodeID)
-	}
-	current := topology[index]
-	if err := requireAuditText(current, auditStateField, auditNodeStateTrash); err != nil {
-		return nil, err
-	}
-	visited := make(map[uint64]bool)
-	var descendants [][]byte
-	for {
-		currentID, err := auditUnsignedField(current, metadataNodeIDField)
-		if err != nil {
-			return nil, err
-		}
-		if visited[currentID] {
-			return nil, errors.New("audit topology contains a trash-parent cycle")
-		}
-		visited[currentID] = true
-		originValue, err := auditField(current, auditOriginField)
-		if err != nil {
-			return nil, err
-		}
-		if !originValue.IsAbsent() {
-			origin, ok := originValue.RecordValue()
-			if !ok || origin.Kind != "known_origin" {
-				return nil, errors.New("audited trash transition lacks a known origin")
-			}
-			if err := requireAuditUnsigned(origin, metadataNodeIDField, currentID); err != nil {
-				return nil, err
-			}
-			originParent, err := auditUnsignedField(origin, "parent_id")
-			if err != nil {
-				return nil, err
-			}
-			originName, err := auditNameBytesField(origin)
-			if err != nil {
-				return nil, err
-			}
-			parentPath, liveParent, err := auditLivePath(
-				topology, topologyIndex, originParent,
-			)
-			if err != nil {
-				return nil, err
-			}
-			if !liveParent {
-				return nil, errors.New("audited trash origin parent is not live")
-			}
-			result := append([]byte("@trash/known"), parentPath...)
-			if result[len(result)-1] != '/' {
-				result = append(result, '/')
-			}
-			result = append(result, originName...)
-			for _, name := range slices.Backward(descendants) {
-				result = append(result, '/')
-				result = append(result, name...)
-			}
-			return result, nil
-		}
-		name, err := auditNameBytesField(current)
-		if err != nil {
-			return nil, err
-		}
-		descendants = append(descendants, name)
-		parentID, err := auditOptionalParentIDField(current)
-		if err != nil || parentID == nil {
-			return nil, errors.New("trash descendant lacks its parent")
-		}
-		parentIndex, ok := topologyIndex[*parentID]
-		if !ok {
-			return nil, fmt.Errorf("trash descendant references missing parent %d", *parentID)
-		}
-		current = topology[parentIndex]
-		if err := requireAuditText(current, auditStateField, auditNodeStateTrash); err != nil {
-			return nil, err
-		}
-	}
 }

--- a/internal/store/audit_node_trash.go
+++ b/internal/store/audit_node_trash.go
@@ -157,30 +157,15 @@ func (s *Store) prepareAuditedTrash(
 func makeAuditedTrashTopologyDelta(
 	operationID audit.Value, prior map[int64]Node, resulting map[int64]audit.Record,
 ) (audit.Record, error) {
-	changes := make([]audit.Record, 0, len(prior))
+	priorRecords := make(map[int64]audit.Record, len(prior))
 	for nodeID, priorNode := range prior {
-		auditNodeID, err := positiveAuditNodeID(nodeID)
-		if err != nil {
-			return audit.Record{}, err
-		}
-		post, ok := resulting[nodeID]
-		if !ok {
-			return audit.Record{}, fmt.Errorf("audited trash lacks resulting node %d", nodeID)
-		}
 		pre, err := auditTopologyForLiveNode(priorNode)
 		if err != nil {
 			return audit.Record{}, err
 		}
-		changes = append(changes, audit.Record{Kind: "topology_change", Fields: []audit.Field{
-			{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
-			{Name: "pre", Value: audit.Nested(pre)},
-			{Name: "post", Value: audit.Nested(post)},
-		}})
+		priorRecords[nodeID] = pre
 	}
-	if err := sortAuditTopologyRecords(changes); err != nil {
-		return audit.Record{}, err
-	}
-	return makeAuditedTopologyDelta(operationID, changes), nil
+	return makeAuditedTopologyRecordDelta(operationID, priorRecords, resulting)
 }
 
 func makeAuditedTrashPathEffects(snapshot auditedTrashSnapshot) ([]audit.Record, error) {
@@ -210,11 +195,11 @@ func makeAuditedTrashPathEffects(snapshot auditedTrashSnapshot) ([]audit.Record,
 		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
 			{Name: auditScopeIDField, Value: scopeID},
 			{Name: "member_node_id", Value: audit.Unsigned(auditNodeID)},
-			{Name: "old", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
-				{Name: "path", Value: audit.Bytes([]byte(priorPath))}, {Name: "state", Value: live},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes([]byte(priorPath))}, {Name: auditStateField, Value: live},
 			}})},
-			{Name: "new", Value: audit.Nested(audit.Record{Kind: "path_state", Fields: []audit.Field{
-				{Name: "path", Value: audit.Bytes(trashPath)}, {Name: "state", Value: trash},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes(trashPath)}, {Name: auditStateField, Value: trash},
 			}})},
 		}})
 	}

--- a/internal/store/audit_projection.go
+++ b/internal/store/audit_projection.go
@@ -25,6 +25,9 @@ type auditTopologyRow struct {
 const (
 	auditNodeStateLive  = "live"
 	auditNodeStateTrash = "trash"
+	auditPathStateKind  = "path_state"
+	auditPathField      = "path"
+	auditStateField     = "state"
 )
 
 func currentAuditTopology(ctx context.Context, tx metadataQuerier) ([]audit.Record, error) {
@@ -115,7 +118,7 @@ func topologyRecord(row auditTopologyRow) (audit.Record, error) {
 		{Name: "parent_id", Value: parent},
 		{Name: "name", Value: audit.Bytes([]byte(row.name))},
 		{Name: "node_kind", Value: kindValue},
-		{Name: "state", Value: stateValue},
+		{Name: auditStateField, Value: stateValue},
 		{Name: auditOriginField, Value: origin},
 		{Name: "created_at", Value: createdAt},
 		{Name: "modified_at", Value: modifiedAt},

--- a/internal/store/audit_topology_mutation.go
+++ b/internal/store/audit_topology_mutation.go
@@ -8,6 +8,39 @@ import (
 	"go.kenn.io/docbank/internal/audit"
 )
 
+func makeAuditedTopologyRecordDelta(
+	operationID audit.Value, prior, resulting map[int64]audit.Record,
+) (audit.Record, error) {
+	if len(prior) != len(resulting) {
+		return audit.Record{}, fmt.Errorf(
+			"audited topology transition has %d prior nodes and %d resulting nodes",
+			len(prior), len(resulting),
+		)
+	}
+	changes := make([]audit.Record, 0, len(prior))
+	for nodeID, pre := range prior {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		post, ok := resulting[nodeID]
+		if !ok {
+			return audit.Record{}, fmt.Errorf(
+				"audited topology transition lacks resulting node %d", nodeID,
+			)
+		}
+		changes = append(changes, audit.Record{Kind: "topology_change", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
+			{Name: "pre", Value: audit.Nested(pre)},
+			{Name: "post", Value: audit.Nested(post)},
+		}})
+	}
+	if err := sortAuditTopologyRecords(changes); err != nil {
+		return audit.Record{}, err
+	}
+	return makeAuditedTopologyDelta(operationID, changes), nil
+}
+
 // persistAuditedTopologyMutation commits the record envelope shared by
 // topology changes that affect one existing audit scope. Callers remain
 // responsible for deriving the operation-specific topology and path effects.

--- a/internal/store/trash.go
+++ b/internal/store/trash.go
@@ -152,9 +152,17 @@ func nextFreeNameTx(tx *sql.Tx, parentID int64, name string) (string, error) {
 // matches the node's current revision.
 func (s *Store) Restore(ctx context.Context, id, ifRev int64) (Node, error) {
 	var restored Node
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		n, err := nodeByIDTx(tx, id)
 		if err != nil {
+			return err
+		}
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if active {
+			restored, err = s.restoreAuditedTx(ctx, tx, n, ifRev)
 			return err
 		}
 		if n.TrashedAt == nil {
@@ -164,67 +172,89 @@ func (s *Store) Restore(ctx context.Context, id, ifRev int64) (Node, error) {
 			return fmt.Errorf("node %d at revision %d, expected %d: %w",
 				id, n.Revision, ifRev, ErrStaleRevision)
 		}
-		var trashParent sql.NullInt64
-		var trashName sql.NullString
-		if err := tx.QueryRow(
-			`SELECT trash_parent, trash_name FROM nodes WHERE id = ?`, id).
-			Scan(&trashParent, &trashName); err != nil {
-			return fmt.Errorf("reading trash origin of node %d: %w", id, err)
-		}
-		if !trashName.Valid {
-			return fmt.Errorf("node %d is not a trash root: %w", id, ErrNotTrashed)
-		}
-
-		destID := s.rootID
-		if trashParent.Valid {
-			if _, err := liveDirTx(tx, trashParent.Int64); err == nil {
-				destID = trashParent.Int64
-			} else if !errors.Is(err, ErrNotFound) && !errors.Is(err, ErrNotDir) {
-				return err
-			}
-		}
-		finalName, err := nextFreeNameTx(tx, destID, trashName.String)
+		target, err := s.restoreTargetTx(tx, n)
 		if err != nil {
 			return err
 		}
-		now := nowRFC3339()
-		// Reattach the top node FIRST — parent, final (possibly re-suffixed)
-		// name, and liveness in one statement. Un-trashing before renaming
-		// would trip the live-sibling unique index whenever the original
-		// name was reused while this node sat in the trash.
-		if _, err := tx.Exec(
-			`UPDATE nodes SET parent_id = ?, name = ?, trashed_at = NULL,
-			        trash_parent = NULL, trash_name = NULL,
-			        revision = revision + 1, modified_at = ? WHERE id = ?`,
-			destID, finalName, now, id); err != nil {
-			return fmt.Errorf("reattaching node %d: %w", id, err)
-		}
-		// Then un-trash the descendants that share this operation's stamp.
-		// Their (parent, name) pairs cannot conflict: nothing could be
-		// created under a trashed directory in the interim.
-		if _, err := tx.Exec(`
-			WITH RECURSIVE subtree(id) AS (
-				SELECT id FROM nodes WHERE id = ?
-				UNION ALL
-				SELECT n.id FROM nodes n
-				JOIN subtree st ON n.parent_id = st.id
-				WHERE n.trashed_at = ?
-			)
-			UPDATE nodes SET trashed_at = NULL, revision = revision + 1, modified_at = ?
-			WHERE id IN (SELECT id FROM subtree) AND trashed_at = ?`,
-			id, *n.TrashedAt, now, *n.TrashedAt); err != nil {
-			return fmt.Errorf("restoring subtree of node %d: %w", id, err)
-		}
-		if err := bumpRevisionTx(tx, destID, now); err != nil {
-			return err
-		}
-		restored, err = nodeByIDTx(tx, id)
+		restored, err = s.restoreNodeTx(tx, n, target, nowRFC3339())
 		return err
 	})
 	if err != nil {
 		return Node{}, err
 	}
 	return restored, nil
+}
+
+type restoreTarget struct {
+	destID         int64
+	originParentID *int64
+	originalName   string
+	finalName      string
+}
+
+func (s *Store) restoreTargetTx(tx *sql.Tx, node Node) (restoreTarget, error) {
+	var trashParent sql.NullInt64
+	var trashName sql.NullString
+	if err := tx.QueryRow(
+		`SELECT trash_parent, trash_name FROM nodes WHERE id = ?`, node.ID,
+	).Scan(&trashParent, &trashName); err != nil {
+		return restoreTarget{}, fmt.Errorf("reading trash origin of node %d: %w", node.ID, err)
+	}
+	if !trashName.Valid {
+		return restoreTarget{}, fmt.Errorf("node %d is not a trash root: %w", node.ID, ErrNotTrashed)
+	}
+	target := restoreTarget{destID: s.rootID, originalName: trashName.String}
+	if trashParent.Valid {
+		originParentID := trashParent.Int64
+		target.originParentID = &originParentID
+		if _, err := liveDirTx(tx, originParentID); err == nil {
+			target.destID = originParentID
+		} else if !errors.Is(err, ErrNotFound) && !errors.Is(err, ErrNotDir) {
+			return restoreTarget{}, err
+		}
+	}
+	finalName, err := nextFreeNameTx(tx, target.destID, target.originalName)
+	if err != nil {
+		return restoreTarget{}, err
+	}
+	target.finalName = finalName
+	return target, nil
+}
+
+func (s *Store) restoreNodeTx(
+	tx *sql.Tx, node Node, target restoreTarget, now string,
+) (Node, error) {
+	// Reattach the top node FIRST — parent, final (possibly re-suffixed)
+	// name, and liveness in one statement. Un-trashing before renaming
+	// would trip the live-sibling unique index whenever the original
+	// name was reused while this node sat in the trash.
+	if _, err := tx.Exec(
+		`UPDATE nodes SET parent_id = ?, name = ?, trashed_at = NULL,
+		        trash_parent = NULL, trash_name = NULL,
+		        revision = revision + 1, modified_at = ? WHERE id = ?`,
+		target.destID, target.finalName, now, node.ID); err != nil {
+		return Node{}, fmt.Errorf("reattaching node %d: %w", node.ID, err)
+	}
+	// Then un-trash the descendants that share this operation's stamp.
+	// Their (parent, name) pairs cannot conflict: nothing could be
+	// created under a trashed directory in the interim.
+	if _, err := tx.Exec(`
+		WITH RECURSIVE subtree(id) AS (
+			SELECT id FROM nodes WHERE id = ?
+			UNION ALL
+			SELECT n.id FROM nodes n
+			JOIN subtree st ON n.parent_id = st.id
+			WHERE n.trashed_at = ?
+		)
+		UPDATE nodes SET trashed_at = NULL, revision = revision + 1, modified_at = ?
+		WHERE id IN (SELECT id FROM subtree) AND trashed_at = ?`,
+		node.ID, *node.TrashedAt, now, *node.TrashedAt); err != nil {
+		return Node{}, fmt.Errorf("restoring subtree of node %d: %w", node.ID, err)
+	}
+	if err := bumpRevisionTx(tx, target.destID, now); err != nil {
+		return Node{}, err
+	}
+	return nodeByIDTx(tx, node.ID)
 }
 
 // TrashedRoots lists restorable trash roots, newest first.


### PR DESCRIPTION
After `docbank rm` moves a protected folder into trash, a person should be able to restore it without breaking the permanent history that full audit promises. Until now, audit activation still refused that ordinary recovery step.

This makes the common case work end to end. Restoring `/Projects/Work` returns the same folder and documents to their recorded live parent and preserves both their trash paths and restored paths in history. The tree change and the audit record commit together, so a recording failure leaves the folder safely in trash.

Backup restore and JSONL import do not take that record on faith. They rebuild the complete trash subtree, independently derive the destination and any conflict suffix, reject omitted descendants or impossible intermediate trees, and terminate safely when malformed history contains a topology cycle.

The boundary is intentionally small. The original parent must still be a live member of the same audit scope. A normal name conflict is resolved as `report (2).txt`; however, if that suffix would also retarget the remembered path of a different detached item, restore fails closed until Docbank can record that indirect path effect. Unknown origins and fallback-to-`/` restores remain blocked for the same reason. Permanent deletion and public audit controls remain separate work. The policy stays in Go; this adds no schema machinery.

The audit cases and both SQLite driver suites are green. The unrelated Windows CI failure was a timing-sensitive test assertion: slow runners may emit periodic progress updates while still batching files, and the test now checks the actual no-per-file-emission guarantee.

Kata: m1sr.