### PR TITLE
Record audited tag assignments

### DIFF
--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -1110,7 +1110,8 @@ codes are:
 `content_revert`, `node_create`, `node_path`,
 `provenance_add`, `provenance_supersede`, `tag_assign`, `tag_define`,
 `tag_delete`, `tag_rename`, and `tag_unassign`; attachment codes are
-`provenance` and `tag`. Canonical bytewise token order determines sorting. A
+`provenance`, `tag_assignment`, and `tag_definition`. Canonical bytewise token
+order determines sorting. A
 later format may add codes but never remaps an existing token, and import rejects
 an unknown or non-canonical code for the declared format version.
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -387,14 +387,16 @@ Once this authority exists, the Go store's logical-mutation boundary rejects
 mutation classes that do not have an audit-recording implementation. SQL retains
 only relational constraints; append-only semantics, canonical mutation
 construction, chain advancement, and independent replay remain backend-neutral
-Go logic. Content replacement is the first supported audited transition.
-Physical pack maintenance and read-only backup/export remain available.
+Go logic. Implemented guarded transitions cover content replacement and revert,
+inherited node creation, move, trash, restore, and assignment or removal of an
+existing tag. Physical pack maintenance and read-only backup/export remain
+available.
 
 !!! info "Planned — audited mutations"
-    Audit enablement, subsequent guarded mutations, maintenance protection, and
-    verification/status APIs will extend this same metadata-v1 authority before
-    the first public release. Earlier development shapes are disposable and
-    receive no compatibility decoder.
+    Public audit enablement, the remaining guarded mutation classes,
+    maintenance protection, and verification/status APIs will extend this same
+    metadata-v1 authority before the first public release. Earlier development
+    shapes are disposable and receive no compatibility decoder.
 
 The stream excludes `nodes_fts`, `blob_packs`, and `blob_pack_index`. FTS is a
 derived index rebuilt by the node insert triggers. Pack tables describe one

--- a/internal/audit/ordering_test.go
+++ b/internal/audit/ordering_test.go
@@ -169,9 +169,9 @@ func TestAuditEventCollectionSortsAbsentSentinelsFirst(t *testing.T) {
 	), "canonical order")
 
 	identity := Nested(exampleRecord(t, "tag_definition_identity"))
-	absentIdentity := nestedWith(t, "audit_event", "attachment_kind", mustText(t, "tag"))
+	absentIdentity := nestedWith(t, "audit_event", "attachment_kind", mustText(t, "tag_assignment"))
 	presentIdentity := nestedWithFields(t, "audit_event",
-		fieldValue{name: "attachment_kind", value: mustText(t, "tag")},
+		fieldValue{name: "attachment_kind", value: mustText(t, "tag_assignment")},
 		fieldValue{name: "attachment_identity", value: identity},
 	)
 	require.NoError(t, validateCollection(

--- a/internal/audit/registry.go
+++ b/internal/audit/registry.go
@@ -188,7 +188,9 @@ var recordSchemas = map[string]recordSchema{
 		field("event_kind", eventKindRule()),
 		field("scope_id", uuidRule),
 		field("target_node_id", optionalUnsigned),
-		field("attachment_kind", optional(textEnum("provenance", "tag"))),
+		field("attachment_kind", optional(textEnum(
+			"provenance", "tag_assignment", "tag_definition",
+		))),
 		field("attachment_identity", optional(eventAttachmentIdentityRule())),
 		field("source_version_id", optionalUUID),
 		field("event_ordinal", unsignedRule),

--- a/internal/store/audit_content_replace.go
+++ b/internal/store/audit_content_replace.go
@@ -174,7 +174,7 @@ func persistAuditedContentTransition(
 	if err != nil {
 		return err
 	}
-	mutation, err := makeAuditedContentTransitionMutation(
+	mutation, err := makeAuditedMemberStateMutation(
 		values, operationSequence, events, change,
 	)
 	if err != nil {
@@ -194,13 +194,34 @@ func persistAuditedContentTransition(
 	if err := insertAuditRecord(ctx, tx, mutation); err != nil {
 		return err
 	}
+	if err := advanceAuditedMutationScopes(
+		ctx, tx, values, scopes, mutationDigest.value,
+	); err != nil {
+		return err
+	}
+	allocation, err := makeAuditedMutationAllocationEntry(
+		values, operationSequence, nodeSequence, authority.allocationHead,
+		mutationDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	return advanceAuditedMutationAuthority(
+		ctx, tx, authority, operationSequence, allocation,
+	)
+}
+
+func advanceAuditedMutationScopes(
+	ctx context.Context, tx *sql.Tx, values auditedMutationValues,
+	scopes []auditScopeState, mutationHash audit.Value,
+) error {
 	for _, scope := range scopes {
 		entryCount, err := nextAuditInteger("scope entry count", scope.entryCount)
 		if err != nil {
 			return err
 		}
 		entry, err := makeAuditScopeChainEntry(
-			values, scope.scopeID, entryCount, scope.chainHead, mutationDigest.value,
+			values, scope.scopeID, entryCount, scope.chainHead, mutationHash,
 		)
 		if err != nil {
 			return err
@@ -218,13 +239,13 @@ func persistAuditedContentTransition(
 			return fmt.Errorf("advancing audit scope %s: %w", scope.scopeID, err)
 		}
 	}
-	allocation, err := makeAuditedContentAllocationEntry(
-		values, operationSequence, nodeSequence, authority.allocationHead,
-		mutationDigest.value,
-	)
-	if err != nil {
-		return err
-	}
+	return nil
+}
+
+func advanceAuditedMutationAuthority(
+	ctx context.Context, tx *sql.Tx, authority auditAuthorityState,
+	operationSequence int64, allocation audit.Record,
+) error {
 	allocationHead, err := hashAuditRecord(allocation)
 	if err != nil {
 		return err
@@ -418,7 +439,7 @@ func positiveAuditRevision(value int64) (uint64, error) {
 	return positiveAuditInteger("content revision", value)
 }
 
-func makeAuditedContentTransitionMutation(
+func makeAuditedMemberStateMutation(
 	values auditedMutationValues, sequence int64,
 	events []audit.Record, change audit.Record,
 ) (audit.Record, error) {
@@ -476,7 +497,7 @@ func makeAuditScopeChainEntry(
 	}}, nil
 }
 
-func makeAuditedContentAllocationEntry(
+func makeAuditedMutationAllocationEntry(
 	values auditedMutationValues, sequence, nodeSequence int64,
 	previousHead string, mutationHash audit.Value,
 ) (audit.Record, error) {

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -315,9 +315,21 @@ func validateAuditedHistory(
 			return fmt.Errorf("validating audit operation %d: %w", sequence, topologyErr)
 		}
 		if len(bindings) == 0 && topologyValue.IsAbsent() {
-			err = replay.applyContentTransition(
-				vaultID, mutation, allocations[sequence], entries[sequence], events, usedEvents,
+			attachedCount, attachedErr := auditUnsignedField(
+				mutation.record, auditAttachedMetadataChangeCountField,
 			)
+			if attachedErr != nil {
+				err = attachedErr
+			} else if attachedCount != 0 {
+				err = replay.applyTagAssignment(
+					vaultID, mutation, allocations[sequence], entries[sequence],
+					attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
+				)
+			} else {
+				err = replay.applyContentTransition(
+					vaultID, mutation, allocations[sequence], entries[sequence], events, usedEvents,
+				)
+			}
 		} else if len(bindings) != 0 {
 			err = replay.applyNodeCreation(
 				vaultID, mutation, allocations[sequence], entries[sequence],
@@ -697,7 +709,7 @@ func (replay *auditedHistoryReplay) applyContentTransition(
 		return err
 	}
 	if err := replay.advanceAllocation(
-		vaultID, operationID, mutation, allocation,
+		vaultID, operationID, mutation, allocation, "",
 	); err != nil {
 		return err
 	}
@@ -961,7 +973,7 @@ func (replay *auditedHistoryReplay) advanceScope(
 
 func (replay *auditedHistoryReplay) advanceAllocation(
 	vaultID string, operationID string,
-	mutation, entry storedAuditRecord,
+	mutation, entry storedAuditRecord, attachedDigest string,
 ) error {
 	nextCount := replay.allocationCount + 1
 	auditCount, err := positiveAuditInteger("allocation entry count", nextCount)
@@ -969,7 +981,7 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 		return err
 	}
 	if entry.index.operationSequence == nil || *entry.index.operationSequence != nextCount {
-		return errors.New("content mutation allocation entry is out of order")
+		return errors.New("audited mutation allocation entry is out of order")
 	}
 	checks := []func() error{
 		func() error { return requireAuditUUID(entry.record, auditVaultIDField, vaultID) },
@@ -993,7 +1005,7 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 		return err
 	}
 	if len(allocated) != 0 {
-		return errors.New("content mutation allocation cannot allocate node IDs")
+		return errors.New("audited mutation allocation cannot allocate node IDs")
 	}
 	mutationDigest, err := hashAuditRecord(mutation.record)
 	if err != nil {
@@ -1002,21 +1014,45 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 	if err := requireAuditDigest(entry.record, "mutation_hash", mutationDigest.text); err != nil {
 		return err
 	}
-	for _, field := range []string{
-		"has_topology_change", "has_witness_change", "has_attached_metadata_change",
-	} {
+	for _, field := range []string{"has_topology_change", "has_witness_change"} {
 		if err := requireAuditBool(entry.record, field, false); err != nil {
 			return err
 		}
 	}
-	for _, field := range []string{auditWitnessChangeCountField, auditAttachedMetadataChangeCountField} {
-		if err := requireAuditUnsigned(entry.record, field, 0); err != nil {
+	if err := requireAuditUnsigned(entry.record, auditWitnessChangeCountField, 0); err != nil {
+		return err
+	}
+	if err := requireAuditAbsentFields(
+		entry.record, auditTopologyDeltaField, "witness_change_digest",
+	); err != nil {
+		return err
+	}
+	if attachedDigest == "" {
+		if err := requireAuditBool(entry.record, "has_attached_metadata_change", false); err != nil {
 			return err
 		}
-	}
-	if err := requireAuditAbsentFields(entry.record, auditTopologyDeltaField,
-		"witness_change_digest", "attached_metadata_change_digest"); err != nil {
-		return err
+		if err := requireAuditUnsigned(
+			entry.record, auditAttachedMetadataChangeCountField, 0,
+		); err != nil {
+			return err
+		}
+		if err := requireAuditAbsent(entry.record, "attached_metadata_change_digest"); err != nil {
+			return err
+		}
+	} else {
+		if err := requireAuditBool(entry.record, "has_attached_metadata_change", true); err != nil {
+			return err
+		}
+		if err := requireAuditUnsigned(
+			entry.record, auditAttachedMetadataChangeCountField, 1,
+		); err != nil {
+			return err
+		}
+		if err := requireAuditDigest(
+			entry.record, "attached_metadata_change_digest", attachedDigest,
+		); err != nil {
+			return err
+		}
 	}
 	replay.allocationCount, replay.allocationHead = nextCount, entry.digest
 	return nil

--- a/internal/store/audit_ingest.go
+++ b/internal/store/audit_ingest.go
@@ -103,6 +103,12 @@ func ingestAuditRecord(ingest metadataIngest) (audit.Record, error) {
 }
 
 func makeAttachedMetadataAddition(record audit.Record) (audit.Record, error) {
+	return makeAttachedMetadataPresenceChange(record, true)
+}
+
+func makeAttachedMetadataPresenceChange(
+	record audit.Record, add bool,
+) (audit.Record, error) {
 	kind, err := audit.Text(record.Kind)
 	if err != nil {
 		return audit.Record{}, err
@@ -111,11 +117,15 @@ func makeAttachedMetadataAddition(record audit.Record) (audit.Record, error) {
 	if err != nil {
 		return audit.Record{}, err
 	}
+	pre, post := audit.Absent(), audit.Nested(record)
+	if !add {
+		pre, post = post, pre
+	}
 	return audit.Record{Kind: "attached_metadata_change", Fields: []audit.Field{
 		{Name: "record_kind", Value: kind},
 		{Name: "stable_identity", Value: audit.Nested(identity)},
-		{Name: "pre", Value: audit.Absent()},
-		{Name: "post", Value: audit.Nested(record)},
+		{Name: auditPreField, Value: pre},
+		{Name: auditPostField, Value: post},
 	}}, nil
 }
 

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -15,8 +15,11 @@ import (
 )
 
 const (
+	auditAgentLabelField   = "agent_label"
 	auditEventOrdinalField = "event_ordinal"
 	auditParentIDField     = "parent_id"
+	auditPostField         = "post"
+	auditPreField          = "pre"
 	auditRecordedAtField   = "recorded_at"
 )
 

--- a/internal/store/audit_node_create_validate.go
+++ b/internal/store/audit_node_create_validate.go
@@ -413,7 +413,7 @@ func (replay *auditedHistoryReplay) validateNodeCreationEvents(
 	}
 	ordinal := uint64(0)
 	for index, event := range events {
-		if err := validateCreationEventWrapper(
+		if err := validateAuditEventWrapper(
 			operationID, ordinal, event, eventRecords, usedEvents,
 		); err != nil {
 			return err
@@ -447,7 +447,7 @@ func (replay *auditedHistoryReplay) validateNodeCreationEvents(
 	return nil
 }
 
-func validateCreationEventWrapper(
+func validateAuditEventWrapper(
 	operationID string, ordinal uint64, event audit.Record,
 	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
 ) error {
@@ -457,14 +457,14 @@ func validateCreationEventWrapper(
 	}
 	wrapper, ok := eventRecords[eventID]
 	if !ok || usedEvents[eventID] {
-		return errors.New("node creation lacks one unique event wrapper")
+		return errors.New("audited mutation lacks one unique event wrapper")
 	}
 	wrapped, err := auditNestedField(wrapper.record, auditEventField)
 	if err != nil {
 		return err
 	}
 	if !auditRecordEqual(wrapped, event) {
-		return errors.New("node creation event wrapper does not match mutation")
+		return errors.New("audit event wrapper does not match mutation")
 	}
 	operationValue, err := audit.UUID(operationID)
 	if err != nil {
@@ -478,7 +478,7 @@ func validateCreationEventWrapper(
 		return err
 	}
 	if identity.text != eventID {
-		return errors.New("node creation event identity does not match its operation")
+		return errors.New("audit event identity does not match its operation")
 	}
 	usedEvents[eventID] = true
 	return nil

--- a/internal/store/audit_node_move.go
+++ b/internal/store/audit_node_move.go
@@ -516,7 +516,7 @@ func makeAuditedTopologyAllocationEntry(
 	values auditedMutationValues, sequence, nodeSequence int64,
 	previousHead string, mutationHash, topologyDigest audit.Value,
 ) (audit.Record, error) {
-	entry, err := makeAuditedContentAllocationEntry(
+	entry, err := makeAuditedMutationAllocationEntry(
 		values, sequence, nodeSequence, previousHead, mutationHash,
 	)
 	if err != nil {

--- a/internal/store/audit_node_move_validate.go
+++ b/internal/store/audit_node_move_validate.go
@@ -64,7 +64,7 @@ func (replay *auditedHistoryReplay) applyNodeMove(
 	); err != nil {
 		return err
 	}
-	if err := replay.validateTopologyStateChanges(mutation.record, move.changedIDs); err != nil {
+	if err := replay.validateMemberStateChanges(mutation.record, move.changedIDs); err != nil {
 		return err
 	}
 	if err := replay.validateTopologyEvents(
@@ -486,7 +486,7 @@ func auditLivePath(
 	return result, true, nil
 }
 
-func (replay *auditedHistoryReplay) validateTopologyStateChanges(
+func (replay *auditedHistoryReplay) validateMemberStateChanges(
 	mutation audit.Record, changedIDs []uint64,
 ) error {
 	changes, err := auditRecordListField(mutation, "member_state_changes")
@@ -494,7 +494,7 @@ func (replay *auditedHistoryReplay) validateTopologyStateChanges(
 		return err
 	}
 	if len(changes) != len(changedIDs) {
-		return errors.New("topology member-state changes do not match changed topology")
+		return errors.New("member-state changes do not match changed nodes")
 	}
 	for index, nodeID := range changedIDs {
 		state := replay.states[nodeID]
@@ -545,7 +545,7 @@ func (replay *auditedHistoryReplay) validateTopologyEvents(
 		if err != nil {
 			return err
 		}
-		if err := validateCreationEventWrapper(
+		if err := validateAuditEventWrapper(
 			operationID, ordinal, event, eventRecords, usedEvents,
 		); err != nil {
 			return err

--- a/internal/store/audit_node_restore_validate.go
+++ b/internal/store/audit_node_restore_validate.go
@@ -60,7 +60,7 @@ func (replay *auditedHistoryReplay) applyNodeRestore(
 	); err != nil {
 		return err
 	}
-	if err := replay.validateTopologyStateChanges(
+	if err := replay.validateMemberStateChanges(
 		mutation.record, transition.changedIDs,
 	); err != nil {
 		return err

--- a/internal/store/audit_node_trash_validate.go
+++ b/internal/store/audit_node_trash_validate.go
@@ -59,7 +59,7 @@ func (replay *auditedHistoryReplay) applyNodeTrash(
 	); err != nil {
 		return err
 	}
-	if err := replay.validateTopologyStateChanges(
+	if err := replay.validateMemberStateChanges(
 		mutation.record, transition.changedIDs,
 	); err != nil {
 		return err

--- a/internal/store/audit_tag_assignment.go
+++ b/internal/store/audit_tag_assignment.go
@@ -1,0 +1,245 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func (s *Store) changeAuditedTagAssignmentTx(
+	ctx context.Context, tx *sql.Tx, tagID string, prior Node, ifRev int64, assign bool,
+) (TagAssignmentChange, error) {
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return TagAssignmentChange{}, fmt.Errorf("allocating audited tag operation: %w", err)
+	}
+	recordedAt := nowRFC3339()
+	result, err := changeTagAssignmentTx(
+		ctx, tx, tagID, prior, ifRev, assign, recordedAt,
+	)
+	if err != nil || !result.Changed {
+		return result, err
+	}
+	authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, prior.ID)
+	if err != nil {
+		return TagAssignmentChange{}, err
+	}
+	if err := persistAuditedTagAssignment(
+		ctx, tx, s.vaultID, operationID, recordedAt, nodeSequence,
+		authority, scopes, prior, result.Node, tagID, assign,
+	); err != nil {
+		return TagAssignmentChange{}, err
+	}
+	return result, nil
+}
+
+func persistAuditedTagAssignment(
+	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
+	nodeSequence int64, authority auditAuthorityState, scopes []auditScopeState,
+	priorNode, resultingNode Node, tagID string, assign bool,
+) error {
+	sequence, err := nextAuditInteger("operation sequence", authority.sequence)
+	if err != nil {
+		return err
+	}
+	values, err := makeAuditedMutationValues(
+		vaultID, authority.lineageID, operationID, recordedAt,
+	)
+	if err != nil {
+		return err
+	}
+	assignment, err := auditTagAssignmentRecord(tagID, priorNode.ID)
+	if err != nil {
+		return err
+	}
+	change, err := makeAttachedMetadataPresenceChange(assignment, assign)
+	if err != nil {
+		return err
+	}
+	delta := audit.Record{Kind: "attached_metadata_delta", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: "changes", Value: audit.List(audit.Nested(change))},
+	}}
+	deltaDigest, err := hashAuditRecord(delta)
+	if err != nil {
+		return err
+	}
+	events := make([]audit.Record, len(scopes))
+	for index, scope := range scopes {
+		events[index], err = makeAuditedTagAssignmentEvent(
+			values, scope.scopeID, uint64(index), priorNode, resultingNode,
+			assignment, assign,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	stateChange, err := makeAuditMemberStateChange(priorNode, resultingNode)
+	if err != nil {
+		return err
+	}
+	mutation, err := makeAuditedMemberStateMutation(
+		values, sequence, events, stateChange,
+	)
+	if err != nil {
+		return err
+	}
+	mutation, err = replaceAuditRecordField(
+		mutation, auditAttachedMetadataChangeCountField, audit.Unsigned(1),
+	)
+	if err != nil {
+		return err
+	}
+	mutation, err = replaceAuditRecordField(
+		mutation, "attached_metadata_change_digest", deltaDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	mutationDigest, err := hashAuditRecord(mutation)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, delta); err != nil {
+		return err
+	}
+	for _, event := range events {
+		if err := insertAuditRecord(ctx, tx, audit.Record{
+			Kind:   auditEventField,
+			Fields: []audit.Field{{Name: auditEventField, Value: audit.Nested(event)}},
+		}); err != nil {
+			return err
+		}
+	}
+	if err := insertAuditRecord(ctx, tx, mutation); err != nil {
+		return err
+	}
+	if err := advanceAuditedMutationScopes(
+		ctx, tx, values, scopes, mutationDigest.value,
+	); err != nil {
+		return err
+	}
+	allocation, err := makeAuditedMutationAllocationEntry(
+		values, sequence, nodeSequence, authority.allocationHead, mutationDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	allocation, err = replaceAuditRecordField(
+		allocation, "has_attached_metadata_change", audit.Bool(true),
+	)
+	if err != nil {
+		return err
+	}
+	allocation, err = replaceAuditRecordField(
+		allocation, auditAttachedMetadataChangeCountField, audit.Unsigned(1),
+	)
+	if err != nil {
+		return err
+	}
+	allocation, err = replaceAuditRecordField(
+		allocation, "attached_metadata_change_digest", deltaDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	return advanceAuditedMutationAuthority(ctx, tx, authority, sequence, allocation)
+}
+
+func auditTagAssignmentRecord(tagID string, nodeID int64) (audit.Record, error) {
+	tagValue, err := audit.UUID(tagID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	auditNodeID, err := positiveAuditNodeID(nodeID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "tag_assignment", Fields: []audit.Field{
+		{Name: "tag_id", Value: tagValue},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
+	}}, nil
+}
+
+func makeAuditedTagAssignmentEvent(
+	values auditedMutationValues, scopeID string, ordinal uint64,
+	priorNode, resultingNode Node, assignment audit.Record, assign bool,
+) (audit.Record, error) {
+	if priorNode.ID != resultingNode.ID {
+		return audit.Record{}, errors.New("audited tag assignment changes node identity")
+	}
+	nodeID, err := positiveAuditNodeID(priorNode.ID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	priorRevision, err := positiveAuditRevision(priorNode.Revision)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	resultingRevision, err := positiveAuditRevision(resultingNode.Revision)
+	if err != nil || resultingRevision != priorRevision+1 {
+		return audit.Record{}, errors.New("audited tag assignment has an invalid revision transition")
+	}
+	scopeValue, err := audit.UUID(scopeID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	identity, err := attachedAuditIdentity(assignment)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	eventIdentity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+	}})
+	if err != nil {
+		return audit.Record{}, err
+	}
+	eventKind := "tag_assign"
+	pre, post := audit.Absent(), audit.Nested(assignment)
+	if !assign {
+		eventKind, pre, post = "tag_unassign", post, pre
+	}
+	eventKindValue, err := audit.Text(eventKind)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	attachmentKind, err := audit.Text(assignment.Kind)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	priorVersion, err := auditNodeCurrentVersion(priorNode)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	resultingVersion, err := auditNodeCurrentVersion(resultingNode)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "audit_event", Fields: []audit.Field{
+		{Name: "event_id", Value: eventIdentity.value},
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "event_kind", Value: eventKindValue},
+		{Name: auditScopeIDField, Value: scopeValue},
+		{Name: "target_node_id", Value: audit.Absent()},
+		{Name: "attachment_kind", Value: attachmentKind},
+		{Name: "attachment_identity", Value: audit.Nested(identity)},
+		{Name: "source_version_id", Value: audit.Absent()},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
+		{Name: "prior_node_revision", Value: audit.Unsigned(priorRevision)},
+		{Name: "resulting_node_revision", Value: audit.Unsigned(resultingRevision)},
+		{Name: "prior_current_version_id", Value: priorVersion},
+		{Name: "resulting_current_version_id", Value: resultingVersion},
+		{Name: auditOriginField, Value: values.origin},
+		{Name: auditAgentLabelField, Value: audit.Absent()},
+		{Name: auditPreField, Value: pre},
+		{Name: auditPostField, Value: post},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
+		{Name: "baseline_digest", Value: audit.Absent()},
+	}}, nil
+}

--- a/internal/store/audit_tag_assignment_test.go
+++ b/internal/store/audit_tag_assignment_test.go
@@ -1,0 +1,225 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedTagAssignmentRoundTrips(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	assigned, err := s.AssignTagPath(t.Context(), tag.ID, "/Projects/report.txt")
+	require.NoError(t, err)
+	assert.True(t, assigned.Changed)
+	assert.Equal(t, report.Revision+1, assigned.Node.Revision)
+	assert.Equal(t, tag.Revision+1, assigned.Tag.Revision)
+	assert.Equal(t, 1, assigned.Tag.AssignmentCount)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assert.Equal(t, "tag_assign", auditEventKindForSequence(t, s, 2))
+
+	unassigned, err := s.UnassignTag(
+		t.Context(), tag.ID, assigned.Node.ID, assigned.Node.Revision,
+	)
+	require.NoError(t, err)
+	assert.True(t, unassigned.Changed)
+	assert.Equal(t, assigned.Node.Revision+1, unassigned.Node.Revision)
+	assert.Equal(t, assigned.Tag.Revision+1, unassigned.Tag.Revision)
+	assert.Zero(t, unassigned.Tag.AssignmentCount)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assert.Equal(t, "tag_unassign", auditEventKindForSequence(t, s, 3))
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+}
+
+func TestAuditedTagAssignmentNoOpDoesNotAdvanceHistory(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	assigned, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+	var before int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&before))
+
+	repeated, err := s.AssignTag(
+		t.Context(), tag.ID, report.ID, assigned.Node.Revision,
+	)
+	require.NoError(t, err)
+	assert.False(t, repeated.Changed)
+	assert.Equal(t, assigned.Node.Revision, repeated.Node.Revision)
+	var after int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&after))
+	assert.Equal(t, before, after)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTagAssignmentOutsideScopeRollsBack(t *testing.T) {
+	s, tag, _ := newAuditedTagStore(t)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+
+	changed, err := s.AssignTag(t.Context(), tag.ID, empty.ID, empty.Revision)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	assert.Zero(t, changed)
+	unchanged, err := s.NodeByID(t.Context(), empty.ID)
+	require.NoError(t, err)
+	assert.Equal(t, empty.Revision, unchanged.Revision)
+	currentTag, err := s.TagByID(t.Context(), tag.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tag.Revision, currentTag.Revision)
+	assert.Zero(t, currentTag.AssignmentCount)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTagAssignmentRollsBackWithHistory(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	_, err := s.db.Exec(`CREATE TRIGGER reject_audit_tag_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audit tag failure'); END`)
+	require.NoError(t, err)
+
+	changed, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.ErrorContains(t, err, "forced audit tag failure")
+	assert.Zero(t, changed)
+	unchanged, err := s.NodeByID(t.Context(), report.ID)
+	require.NoError(t, err)
+	assert.Equal(t, report.Revision, unchanged.Revision)
+	currentTag, err := s.TagByID(t.Context(), tag.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tag.Revision, currentTag.Revision)
+	assert.Zero(t, currentTag.AssignmentCount)
+	var sequence int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&sequence))
+	assert.Equal(t, int64(1), sequence)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTagAssignmentReplayRejectsRetargetedNode(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	_, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, scope, initial)
+	require.NoError(t, err)
+	mutations, err := auditRecordsBySequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	mutation := mutations[2]
+	digest, err := auditDigestField(mutation.record, "attached_metadata_change_digest")
+	require.NoError(t, err)
+	deltas := auditRecordsByDigest(records["attached_metadata_delta"])
+	delta := deltas[digest]
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	retargeted, err := auditTagAssignmentRecord(tag.ID, empty.ID)
+	require.NoError(t, err)
+	change, err := makeAttachedMetadataPresenceChange(retargeted, true)
+	require.NoError(t, err)
+	delta.record = mustReplaceAuditRecordField(
+		t, delta.record, "changes", audit.List(audit.Nested(change)),
+	)
+	deltas[digest] = delta
+
+	_, err = replay.validateTagAssignmentDelta(
+		mutation.record, mustAuditUUIDField(t, mutation.record, auditOperationIDField),
+		deltas, map[string]bool{},
+	)
+	require.ErrorContains(t, err, "unaudited node")
+}
+
+func TestAuditedTagAssignmentImportRejectsMissingCurrentAssignment(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	_, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := omitMetadataTagAssignment(t, exported.Bytes(), tag.ID, report.ID)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "replayed audit attachments do not match current metadata")
+	var assignmentRows, auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM node_tags),
+		(SELECT COUNT(*) FROM audit_records)`).Scan(&assignmentRows, &auditRows))
+	assert.Zero(t, assignmentRows)
+	assert.Zero(t, auditRows)
+}
+
+func newAuditedTagStore(t *testing.T) (*Store, Tag, Node) {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	tag, err := s.CreateTag(t.Context(), "reviewed")
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+	return s, tag, report
+}
+
+func auditEventKindForSequence(t *testing.T, s *Store, sequence int64) string {
+	t.Helper()
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	mutations, err := auditRecordsBySequence(records["canonical_mutation"], sequence)
+	require.NoError(t, err)
+	events, err := auditRecordListField(mutations[sequence].record, "events")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	kind, err := auditTextField(events[0], "event_kind")
+	require.NoError(t, err)
+	return kind
+}
+
+func omitMetadataTagAssignment(
+	t *testing.T, input []byte, tagID string, nodeID int64,
+) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	kept := lines[:0]
+	found := false
+	for _, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type == "node_tag" {
+			var assignment metadataNodeTag
+			require.NoError(t, json.Unmarshal(line, &assignment))
+			if assignment.TagID == tagID && assignment.NodeID == nodeID {
+				found = true
+				continue
+			}
+		}
+		kept = append(kept, line)
+	}
+	require.True(t, found)
+	return append(bytes.Join(kept, []byte{'\n'}), '\n')
+}

--- a/internal/store/audit_tag_assignment_validate.go
+++ b/internal/store/audit_tag_assignment_validate.go
@@ -1,0 +1,356 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type replayedTagAssignment struct {
+	nodeID     uint64
+	assignment audit.Record
+	change     audit.Record
+	digest     string
+	assign     bool
+}
+
+func (replay *auditedHistoryReplay) applyTagAssignment(
+	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	deltaRecords, eventRecords map[string]storedAuditRecord,
+	usedDeltas, usedEvents map[string]bool,
+) error {
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	nextSequence := replay.allocationCount + 1
+	auditSequence, err := positiveAuditInteger("operation sequence", nextSequence)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUUID(mutation.record, auditVaultIDField, vaultID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(
+		mutation.record, "operation_sequence", auditSequence,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
+		return err
+	}
+	transition, err := replay.validateTagAssignmentDelta(
+		mutation.record, operationID, deltaRecords, usedDeltas,
+	)
+	if err != nil {
+		return err
+	}
+	if err := replay.validateTagAssignmentEvent(
+		mutation.record, operationID, transition, eventRecords, usedEvents,
+	); err != nil {
+		return err
+	}
+	if err := replay.validateMemberStateChanges(
+		mutation.record, []uint64{transition.nodeID},
+	); err != nil {
+		return err
+	}
+	bindings, err := auditRecordListField(mutation.record, "baselines")
+	if err != nil {
+		return err
+	}
+	if len(bindings) != 0 {
+		return errors.New("tag assignment cannot bind an enrollment baseline")
+	}
+	if err := requireAuditAbsentFields(
+		mutation.record, auditTopologyDeltaField, "path_effect_digest",
+		"witness_change_digest",
+	); err != nil {
+		return err
+	}
+	for _, field := range []string{"path_effect_count", auditWitnessChangeCountField} {
+		if err := requireAuditUnsigned(mutation.record, field, 0); err != nil {
+			return err
+		}
+	}
+	if err := requireAuditUnsigned(
+		mutation.record, auditAttachedMetadataChangeCountField, 1,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(
+		mutation.record, "attached_metadata_change_digest", transition.digest,
+	); err != nil {
+		return err
+	}
+	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+		return err
+	}
+	if err := replay.advanceAllocation(
+		vaultID, operationID, mutation, allocation, transition.digest,
+	); err != nil {
+		return err
+	}
+	return replay.applyTagAssignmentState(transition, mutation.record)
+}
+
+func (replay *auditedHistoryReplay) validateTagAssignmentDelta(
+	mutation audit.Record, operationID string,
+	deltaRecords map[string]storedAuditRecord, usedDeltas map[string]bool,
+) (replayedTagAssignment, error) {
+	digest, err := auditDigestField(mutation, "attached_metadata_change_digest")
+	if err != nil {
+		return replayedTagAssignment{}, err
+	}
+	delta, ok := deltaRecords[digest]
+	if !ok || usedDeltas[digest] {
+		return replayedTagAssignment{}, errors.New(
+			"tag assignment lacks one unique attached-metadata delta",
+		)
+	}
+	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
+		return replayedTagAssignment{}, err
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return replayedTagAssignment{}, err
+	}
+	if len(changes) != 1 {
+		return replayedTagAssignment{}, errors.New(
+			"tag assignment must contain exactly one attached-metadata change",
+		)
+	}
+	change := changes[0]
+	if err := requireAuditText(change, "record_kind", "tag_assignment"); err != nil {
+		return replayedTagAssignment{}, err
+	}
+	pre, hasPre, preErr := optionalNestedAuditRecord(change, auditPreField)
+	post, hasPost, postErr := optionalNestedAuditRecord(change, auditPostField)
+	if preErr != nil {
+		return replayedTagAssignment{}, preErr
+	}
+	if postErr != nil {
+		return replayedTagAssignment{}, postErr
+	}
+	assign := !hasPre && hasPost
+	if !assign && (!hasPre || hasPost) {
+		return replayedTagAssignment{}, errors.New(
+			"tag assignment delta is neither an assignment nor an unassignment",
+		)
+	}
+	assignment := post
+	if !hasPost {
+		assignment = pre
+	}
+	if assignment.Kind != "tag_assignment" {
+		return replayedTagAssignment{}, errors.New(
+			"tag assignment delta carries the wrong record kind",
+		)
+	}
+	identity, err := attachedAuditIdentity(assignment)
+	if err != nil {
+		return replayedTagAssignment{}, err
+	}
+	storedIdentity, err := auditNestedField(change, "stable_identity")
+	if err != nil || !auditRecordEqual(storedIdentity, identity) {
+		return replayedTagAssignment{}, errors.New(
+			"tag assignment delta identity does not match its record",
+		)
+	}
+	nodeID, err := auditUnsignedField(assignment, metadataNodeIDField)
+	if err != nil || !replay.memberSet[nodeID] {
+		return replayedTagAssignment{}, fmt.Errorf(
+			"tag assignment targets unaudited node %d", nodeID,
+		)
+	}
+	tagID, err := auditUUIDField(assignment, "tag_id")
+	if err != nil {
+		return replayedTagAssignment{}, err
+	}
+	hasDefinition, err := replay.hasTagDefinition(tagID)
+	if err != nil {
+		return replayedTagAssignment{}, err
+	}
+	if !hasDefinition {
+		return replayedTagAssignment{}, fmt.Errorf(
+			"tag assignment references missing tag %s", tagID,
+		)
+	}
+	key, err := attachedAuditKey(assignment)
+	if err != nil {
+		return replayedTagAssignment{}, err
+	}
+	current, exists := replay.attachments[key]
+	if assign && exists {
+		return replayedTagAssignment{}, errors.New("tag assignment already exists in replay")
+	}
+	if !assign && (!exists || !auditRecordEqual(current, assignment)) {
+		return replayedTagAssignment{}, errors.New(
+			"tag unassignment does not match replayed metadata",
+		)
+	}
+	usedDeltas[digest] = true
+	return replayedTagAssignment{
+		nodeID: nodeID, assignment: assignment, change: change,
+		digest: digest, assign: assign,
+	}, nil
+}
+
+func optionalNestedAuditRecord(record audit.Record, field string) (audit.Record, bool, error) {
+	value, err := auditField(record, field)
+	if err != nil {
+		return audit.Record{}, false, err
+	}
+	if value.IsAbsent() {
+		return audit.Record{}, false, nil
+	}
+	nested, ok := value.RecordValue()
+	if !ok {
+		return audit.Record{}, false, fmt.Errorf(
+			"audit field %s.%s must be a record", record.Kind, field,
+		)
+	}
+	return nested, true, nil
+}
+
+func (replay *auditedHistoryReplay) hasTagDefinition(tagID string) (bool, error) {
+	for _, record := range replay.attachments {
+		if record.Kind != "tag_definition" {
+			continue
+		}
+		id, err := auditUUIDField(record, "tag_id")
+		if err != nil {
+			return false, err
+		}
+		if id == tagID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (replay *auditedHistoryReplay) validateTagAssignmentEvent(
+	mutation audit.Record, operationID string, transition replayedTagAssignment,
+	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
+) error {
+	events, err := auditRecordListField(mutation, "events")
+	if err != nil {
+		return err
+	}
+	if len(events) != 1 {
+		return errors.New("tag assignment mutation must contain one scope event")
+	}
+	event := events[0]
+	if err := validateAuditEventWrapper(
+		operationID, 0, event, eventRecords, usedEvents,
+	); err != nil {
+		return err
+	}
+	kind := "tag_assign"
+	if !transition.assign {
+		kind = "tag_unassign"
+	}
+	identity, err := attachedAuditIdentity(transition.assignment)
+	if err != nil {
+		return err
+	}
+	storedIdentity, err := auditNestedField(event, "attachment_identity")
+	if err != nil || !auditRecordEqual(storedIdentity, identity) {
+		return errors.New("tag assignment event identity does not match its attachment")
+	}
+	state := replay.states[transition.nodeID]
+	revision, err := auditUnsignedField(state, "node_revision")
+	if err != nil {
+		return err
+	}
+	current, err := auditOptionalUUIDField(state, "current_version_id")
+	if err != nil {
+		return err
+	}
+	checks := []func() error{
+		func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
+		func() error { return requireAuditUnsigned(event, metadataNodeIDField, transition.nodeID) },
+		func() error { return requireAuditText(event, "event_kind", kind) },
+		func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
+		func() error { return requireAuditText(event, "attachment_kind", "tag_assignment") },
+		func() error { return requireAuditUnsigned(event, auditEventOrdinalField, 0) },
+		func() error { return requireAuditUnsigned(event, "prior_node_revision", revision) },
+		func() error { return requireAuditUnsigned(event, "resulting_node_revision", revision+1) },
+		func() error { return requireAuditOptionalUUID(event, "prior_current_version_id", current) },
+		func() error { return requireAuditOptionalUUID(event, "resulting_current_version_id", current) },
+		func() error { return requireMatchingEventEnvelope(mutation, event) },
+		func() error {
+			return requireAuditAbsentFields(
+				event, "target_node_id", "source_version_id", auditTopologyDeltaField, "baseline_digest",
+			)
+		},
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	for _, field := range []string{auditPreField, auditPostField} {
+		want, err := auditField(transition.change, field)
+		if err != nil {
+			return err
+		}
+		got, err := auditField(event, field)
+		if err != nil {
+			return err
+		}
+		if want.IsAbsent() != got.IsAbsent() {
+			return fmt.Errorf("tag assignment event %s side does not match its delta", field)
+		}
+		if want.IsAbsent() {
+			continue
+		}
+		wantRecord, wantOK := want.RecordValue()
+		gotRecord, gotOK := got.RecordValue()
+		if !wantOK || !gotOK || !auditRecordEqual(wantRecord, gotRecord) {
+			return fmt.Errorf("tag assignment event %s side does not match its delta", field)
+		}
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) applyTagAssignmentState(
+	transition replayedTagAssignment, mutation audit.Record,
+) error {
+	key, err := attachedAuditKey(transition.assignment)
+	if err != nil {
+		return err
+	}
+	if transition.assign {
+		replay.attachments[key] = transition.assignment
+	} else {
+		delete(replay.attachments, key)
+	}
+	state := replay.states[transition.nodeID]
+	revision, err := auditUnsignedField(state, "node_revision")
+	if err != nil {
+		return err
+	}
+	current, err := auditField(state, "current_version_id")
+	if err != nil {
+		return err
+	}
+	replay.states[transition.nodeID] = audit.Record{Kind: "member_state", Fields: []audit.Field{
+		{Name: metadataNodeIDField, Value: audit.Unsigned(transition.nodeID)},
+		{Name: "node_revision", Value: audit.Unsigned(revision + 1)},
+		{Name: "current_version_id", Value: current},
+	}}
+	index, ok := replay.topologyIndex[transition.nodeID]
+	if !ok {
+		return fmt.Errorf("tagged audited node %d is absent from topology", transition.nodeID)
+	}
+	modifiedAt, err := auditField(mutation, auditRecordedAtField)
+	if err != nil {
+		return err
+	}
+	replay.topology[index], err = replaceAuditRecordField(
+		replay.topology[index], "modified_at", modifiedAt,
+	)
+	return err
+}

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -267,12 +267,24 @@ func (s *Store) changeTagAssignment(
 	ctx context.Context, tagID string, nodeID, ifRev int64, assign bool,
 ) (TagAssignmentChange, error) {
 	var result TagAssignmentChange
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		node, err := nodeByIDTx(tx, nodeID)
 		if err != nil {
 			return err
 		}
-		result, err = changeTagAssignmentTx(ctx, tx, tagID, node, ifRev, assign)
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if active {
+			result, err = s.changeAuditedTagAssignmentTx(
+				ctx, tx, tagID, node, ifRev, assign,
+			)
+			return err
+		}
+		result, err = changeTagAssignmentTx(
+			ctx, tx, tagID, node, ifRev, assign, nowRFC3339(),
+		)
 		return err
 	})
 	if err != nil {
@@ -285,13 +297,23 @@ func (s *Store) changeTagAssignmentPath(
 	ctx context.Context, tagID, path string, assign bool,
 ) (TagAssignmentChange, error) {
 	var result TagAssignmentChange
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		node, err := nodeByPath(ctx, tx, s.rootID, path)
 		if err != nil {
 			return err
 		}
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if active {
+			result, err = s.changeAuditedTagAssignmentTx(
+				ctx, tx, tagID, node, UnconditionalRev, assign,
+			)
+			return err
+		}
 		result, err = changeTagAssignmentTx(
-			ctx, tx, tagID, node, UnconditionalRev, assign,
+			ctx, tx, tagID, node, UnconditionalRev, assign, nowRFC3339(),
 		)
 		return err
 	})
@@ -308,6 +330,7 @@ func changeTagAssignmentTx(
 	node Node,
 	ifRev int64,
 	assign bool,
+	recordedAt string,
 ) (TagAssignmentChange, error) {
 	tag, err := tagByIDTx(tx, tagID)
 	if err != nil {
@@ -356,7 +379,7 @@ func changeTagAssignmentTx(
 		result.Tag.Revision++
 		if _, err := tx.Exec(
 			`UPDATE nodes SET revision = revision + 1, modified_at = ? WHERE id = ?`,
-			nowRFC3339(), node.ID,
+			recordedAt, node.ID,
 		); err != nil {
 			return TagAssignmentChange{}, fmt.Errorf(
 				"advancing node %d after tag assignment change: %w", node.ID, err,


### PR DESCRIPTION
Once a folder is under full audit, people should still be able to organize its documents with tags. Until now, assigning or removing a tag after enrollment was refused, even when the tag already existed.

This makes that ordinary workflow work without weakening the history. A real assignment changes the node and tag and records the same transition in the audit chain as one transaction. If recording fails, the tag change rolls back too. Backup restore and JSONL import independently check that the tag existed, the target belonged to the audit scope, the assignment really changed from absent to present (or back), and the final metadata matches the replayed history.

Repeated assignment or removal remains an idempotent no-op and does not fabricate history. Assignment outside the protected scope still fails closed.

The boundary is deliberately small: this covers assigning and removing existing tags. Creating, renaming, and deleting tag definitions remain blocked in audited vaults because those operations can affect many audited documents and need their own focused fan-out implementation. The shared mutation and chain builders stay in Go; this adds no SQL policy or new schema tables.

Kata: w4vy.
