### PR TITLE
Record tag creation after audit activation

### DIFF
--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -388,9 +388,9 @@ mutation classes that do not have an audit-recording implementation. SQL retains
 only relational constraints; append-only semantics, canonical mutation
 construction, chain advancement, and independent replay remain backend-neutral
 Go logic. Implemented guarded transitions cover content replacement and revert,
-inherited node creation, move, trash, restore, and assignment or removal of an
-existing tag. Physical pack maintenance and read-only backup/export remain
-available.
+inherited node creation, move, trash, restore, creation of an unassigned tag,
+and assignment or removal of an existing tag. Physical pack maintenance and
+read-only backup/export remain available.
 
 !!! info "Planned — audited mutations"
     Public audit enablement, the remaining guarded mutation classes,

--- a/internal/store/audit_content_replace.go
+++ b/internal/store/audit_content_replace.go
@@ -83,17 +83,9 @@ func installAuditedContentVersionTx(
 func loadAuditedNodeAuthority(
 	ctx context.Context, tx *sql.Tx, nodeID int64,
 ) (auditAuthorityState, []auditScopeState, int64, error) {
-	var authority auditAuthorityState
-	err := tx.QueryRowContext(ctx, `SELECT lineage_id,operation_sequence_high_water,
-		allocation_entry_count,allocation_head FROM audit_authority WHERE singleton=1`).Scan(
-		&authority.lineageID, &authority.sequence,
-		&authority.allocationCount, &authority.allocationHead,
-	)
+	authority, nodeSequence, err := loadAuditAuthorityTx(ctx, tx)
 	if err != nil {
-		return authority, nil, 0, fmt.Errorf("reading audit authority: %w", err)
-	}
-	if authority.sequence != authority.allocationCount {
-		return authority, nil, 0, errors.New("audit allocation count disagrees with operation sequence")
+		return authority, nil, 0, err
 	}
 	rows, err := tx.QueryContext(ctx, `SELECT scope.scope_id,scope.entry_count,scope.chain_head
 		FROM audit_scopes scope JOIN audit_memberships membership USING(scope_id)
@@ -116,13 +108,31 @@ func loadAuditedNodeAuthority(
 	if len(scopes) == 0 {
 		return authority, nil, 0, unsupportedAuditedNodeMutation(nodeID)
 	}
+	return authority, scopes, nodeSequence, nil
+}
+
+func loadAuditAuthorityTx(
+	ctx context.Context, tx *sql.Tx,
+) (auditAuthorityState, int64, error) {
+	var authority auditAuthorityState
+	err := tx.QueryRowContext(ctx, `SELECT lineage_id,operation_sequence_high_water,
+		allocation_entry_count,allocation_head FROM audit_authority WHERE singleton=1`).Scan(
+		&authority.lineageID, &authority.sequence,
+		&authority.allocationCount, &authority.allocationHead,
+	)
+	if err != nil {
+		return authority, 0, fmt.Errorf("reading audit authority: %w", err)
+	}
+	if authority.sequence != authority.allocationCount {
+		return authority, 0, errors.New("audit allocation count disagrees with operation sequence")
+	}
 	var nodeSequence int64
 	if err := tx.QueryRowContext(ctx,
 		`SELECT seq FROM sqlite_sequence WHERE name='nodes'`,
 	).Scan(&nodeSequence); err != nil {
-		return authority, nil, 0, fmt.Errorf("reading node ID high-water mark: %w", err)
+		return authority, 0, fmt.Errorf("reading node ID high-water mark: %w", err)
 	}
-	return authority, scopes, nodeSequence, nil
+	return authority, nodeSequence, nil
 }
 
 func unsupportedAuditedNodeMutation(nodeID int64) error {
@@ -199,14 +209,14 @@ func persistAuditedContentTransition(
 	); err != nil {
 		return err
 	}
-	allocation, err := makeAuditedMutationAllocationEntry(
+	allocation, err := makeAuditAllocationEntry(
 		values, operationSequence, nodeSequence, authority.allocationHead,
 		mutationDigest.value,
 	)
 	if err != nil {
 		return err
 	}
-	return advanceAuditedMutationAuthority(
+	return advanceAuditAuthority(
 		ctx, tx, authority, operationSequence, allocation,
 	)
 }
@@ -242,7 +252,7 @@ func advanceAuditedMutationScopes(
 	return nil
 }
 
-func advanceAuditedMutationAuthority(
+func advanceAuditAuthority(
 	ctx context.Context, tx *sql.Tx, authority auditAuthorityState,
 	operationSequence int64, allocation audit.Record,
 ) error {
@@ -497,7 +507,7 @@ func makeAuditScopeChainEntry(
 	}}, nil
 }
 
-func makeAuditedMutationAllocationEntry(
+func makeAuditAllocationEntry(
 	values auditedMutationValues, sequence, nodeSequence int64,
 	previousHead string, mutationHash audit.Value,
 ) (audit.Record, error) {
@@ -522,7 +532,7 @@ func makeAuditedMutationAllocationEntry(
 		{Name: "allocated_node_ids", Value: audit.List()},
 		{Name: "node_id_high_water", Value: audit.Unsigned(auditNodeSequence)},
 		{Name: "operation_sequence_high_water", Value: audit.Unsigned(auditSequence)},
-		{Name: "has_audited_mutation", Value: audit.Bool(true)},
+		{Name: "has_audited_mutation", Value: audit.Bool(!mutationHash.IsAbsent())},
 		{Name: "mutation_hash", Value: mutationHash},
 		{Name: "has_topology_change", Value: audit.Bool(false)},
 		{Name: auditTopologyDeltaField, Value: audit.Absent()},
@@ -533,6 +543,25 @@ func makeAuditedMutationAllocationEntry(
 		{Name: auditAttachedMetadataChangeCountField, Value: audit.Unsigned(0)},
 		{Name: "attached_metadata_change_digest", Value: audit.Absent()},
 	}}, nil
+}
+
+func addAttachedMetadataToAllocation(
+	entry audit.Record, count uint64, digest audit.Value,
+) (audit.Record, error) {
+	var err error
+	entry, err = replaceAuditRecordField(
+		entry, "has_attached_metadata_change", audit.Bool(true),
+	)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	entry, err = replaceAuditRecordField(
+		entry, auditAttachedMetadataChangeCountField, audit.Unsigned(count),
+	)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return replaceAuditRecordField(entry, "attached_metadata_change_digest", digest)
 }
 
 func positiveAuditInteger(name string, value int64) (uint64, error) {

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -279,7 +279,9 @@ func validateAuditedHistory(
 	if err != nil {
 		return err
 	}
-	mutations, err := auditRecordsBySequence(records["canonical_mutation"], authority.sequence)
+	mutations, err := auditRecordsByOptionalSequence(
+		records["canonical_mutation"], authority.sequence,
+	)
 	if err != nil {
 		return err
 	}
@@ -305,7 +307,21 @@ func validateAuditedHistory(
 	usedPathEffectLists := map[string]bool{}
 	usedAttachmentDeltas := map[string]bool{}
 	for sequence := int64(2); sequence <= authority.sequence; sequence++ {
-		mutation := mutations[sequence]
+		allocation := allocations[sequence]
+		mutation, hasMutation := mutations[sequence]
+		if !hasMutation {
+			err = replay.applyUnauditedTagCreation(
+				vaultID, allocation, attachmentDeltas, usedAttachmentDeltas,
+			)
+			if err != nil {
+				return fmt.Errorf("validating audit operation %d: %w", sequence, err)
+			}
+			continue
+		}
+		scopeEntry, ok := entries[replay.scopeEntryCount+1]
+		if !ok {
+			return fmt.Errorf("validating audit operation %d: audit scope chain is incomplete", sequence)
+		}
 		bindings, bindingErr := auditRecordListField(mutation.record, "baselines")
 		if bindingErr != nil {
 			return fmt.Errorf("validating audit operation %d: %w", sequence, bindingErr)
@@ -322,17 +338,17 @@ func validateAuditedHistory(
 				err = attachedErr
 			} else if attachedCount != 0 {
 				err = replay.applyTagAssignment(
-					vaultID, mutation, allocations[sequence], entries[sequence],
+					vaultID, mutation, allocation, scopeEntry,
 					attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
 				)
 			} else {
 				err = replay.applyContentTransition(
-					vaultID, mutation, allocations[sequence], entries[sequence], events, usedEvents,
+					vaultID, mutation, allocation, scopeEntry, events, usedEvents,
 				)
 			}
 		} else if len(bindings) != 0 {
 			err = replay.applyNodeCreation(
-				vaultID, mutation, allocations[sequence], entries[sequence],
+				vaultID, mutation, allocation, scopeEntry,
 				baselines, topologyDeltas, attachmentDeltas, events, usedBaselines,
 				usedTopologyDeltas, usedAttachmentDeltas, usedEvents,
 			)
@@ -342,19 +358,19 @@ func validateAuditedHistory(
 				err = kindErr
 			} else if kind == auditedTopologyTrash {
 				err = replay.applyNodeTrash(
-					vaultID, mutation, allocations[sequence], entries[sequence],
+					vaultID, mutation, allocation, scopeEntry,
 					topologyDeltas, pathEffectLists, events,
 					usedTopologyDeltas, usedPathEffectLists, usedEvents,
 				)
 			} else if kind == auditedTopologyRestore {
 				err = replay.applyNodeRestore(
-					vaultID, mutation, allocations[sequence], entries[sequence],
+					vaultID, mutation, allocation, scopeEntry,
 					topologyDeltas, pathEffectLists, events,
 					usedTopologyDeltas, usedPathEffectLists, usedEvents,
 				)
 			} else {
 				err = replay.applyNodeMove(
-					vaultID, mutation, allocations[sequence], entries[sequence],
+					vaultID, mutation, allocation, scopeEntry,
 					topologyDeltas, pathEffectLists, events,
 					usedTopologyDeltas, usedPathEffectLists, usedEvents,
 				)
@@ -607,6 +623,23 @@ func validateGenesisProvenanceIngests(attachments []audit.Record) error {
 func auditRecordsBySequence(
 	records []storedAuditRecord, highWater int64,
 ) (map[int64]storedAuditRecord, error) {
+	result, err := auditRecordsByOptionalSequence(records, highWater)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(result)) != highWater {
+		kind := "record"
+		if len(records) != 0 {
+			kind = records[0].record.Kind
+		}
+		return nil, fmt.Errorf("audit %s sequence is incomplete", kind)
+	}
+	return result, nil
+}
+
+func auditRecordsByOptionalSequence(
+	records []storedAuditRecord, highWater int64,
+) (map[int64]storedAuditRecord, error) {
 	result := make(map[int64]storedAuditRecord, len(records))
 	for _, record := range records {
 		if record.index.operationSequence == nil {
@@ -618,9 +651,6 @@ func auditRecordsBySequence(
 				record.record.Kind, sequence)
 		}
 		result[sequence] = record
-	}
-	if int64(len(result)) != highWater {
-		return nil, fmt.Errorf("audit %s sequence is incomplete", records[0].record.Kind)
 	}
 	return result, nil
 }
@@ -949,7 +979,7 @@ func (replay *auditedHistoryReplay) advanceScope(
 ) error {
 	nextCount := replay.scopeEntryCount + 1
 	if entry.index.entryCount == nil || *entry.index.entryCount != nextCount {
-		return errors.New("content mutation scope entry is out of order")
+		return errors.New("audited mutation scope entry is out of order")
 	}
 	if err := requireAuditUUID(entry.record, auditVaultIDField, vaultID); err != nil {
 		return err
@@ -975,56 +1005,18 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 	vaultID string, operationID string,
 	mutation, entry storedAuditRecord, attachedDigest string,
 ) error {
-	nextCount := replay.allocationCount + 1
-	auditCount, err := positiveAuditInteger("allocation entry count", nextCount)
+	nextCount, err := replay.validateAllocationBase(vaultID, operationID, entry)
 	if err != nil {
 		return err
 	}
-	if entry.index.operationSequence == nil || *entry.index.operationSequence != nextCount {
-		return errors.New("audited mutation allocation entry is out of order")
-	}
-	checks := []func() error{
-		func() error { return requireAuditUUID(entry.record, auditVaultIDField, vaultID) },
-		func() error { return requireAuditUUID(entry.record, "lineage_id", replay.lineageID) },
-		func() error { return requireAuditUUID(entry.record, auditOperationIDField, operationID) },
-		func() error { return requireAuditDigest(entry.record, "previous_head", replay.allocationHead) },
-		func() error { return requireAuditUnsigned(entry.record, "operation_sequence", auditCount) },
-		func() error {
-			return requireAuditUnsigned(entry.record, "operation_sequence_high_water", auditCount)
-		},
-		func() error { return requireAuditUnsigned(entry.record, "node_id_high_water", replay.nodeHighWater) },
-		func() error { return requireAuditBool(entry.record, "has_audited_mutation", true) },
-	}
-	for _, check := range checks {
-		if err := check(); err != nil {
-			return err
-		}
-	}
-	allocated, err := auditUnsignedListField(entry.record, "allocated_node_ids")
-	if err != nil {
+	if err := requireAuditBool(entry.record, "has_audited_mutation", true); err != nil {
 		return err
-	}
-	if len(allocated) != 0 {
-		return errors.New("audited mutation allocation cannot allocate node IDs")
 	}
 	mutationDigest, err := hashAuditRecord(mutation.record)
 	if err != nil {
 		return err
 	}
 	if err := requireAuditDigest(entry.record, "mutation_hash", mutationDigest.text); err != nil {
-		return err
-	}
-	for _, field := range []string{"has_topology_change", "has_witness_change"} {
-		if err := requireAuditBool(entry.record, field, false); err != nil {
-			return err
-		}
-	}
-	if err := requireAuditUnsigned(entry.record, auditWitnessChangeCountField, 0); err != nil {
-		return err
-	}
-	if err := requireAuditAbsentFields(
-		entry.record, auditTopologyDeltaField, "witness_change_digest",
-	); err != nil {
 		return err
 	}
 	if attachedDigest == "" {
@@ -1056,6 +1048,51 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 	}
 	replay.allocationCount, replay.allocationHead = nextCount, entry.digest
 	return nil
+}
+
+func (replay *auditedHistoryReplay) validateAllocationBase(
+	vaultID, operationID string, entry storedAuditRecord,
+) (int64, error) {
+	nextCount := replay.allocationCount + 1
+	auditCount, err := positiveAuditInteger("allocation entry count", nextCount)
+	if err != nil {
+		return 0, err
+	}
+	if entry.index.operationSequence == nil || *entry.index.operationSequence != nextCount {
+		return 0, errors.New("audit allocation entry is out of order")
+	}
+	checks := []func() error{
+		func() error { return requireAuditUUID(entry.record, auditVaultIDField, vaultID) },
+		func() error { return requireAuditUUID(entry.record, "lineage_id", replay.lineageID) },
+		func() error { return requireAuditUUID(entry.record, auditOperationIDField, operationID) },
+		func() error { return requireAuditDigest(entry.record, "previous_head", replay.allocationHead) },
+		func() error { return requireAuditUnsigned(entry.record, "operation_sequence", auditCount) },
+		func() error {
+			return requireAuditUnsigned(entry.record, "operation_sequence_high_water", auditCount)
+		},
+		func() error { return requireAuditUnsigned(entry.record, "node_id_high_water", replay.nodeHighWater) },
+		func() error { return requireAuditBool(entry.record, "has_topology_change", false) },
+		func() error { return requireAuditBool(entry.record, "has_witness_change", false) },
+		func() error { return requireAuditUnsigned(entry.record, auditWitnessChangeCountField, 0) },
+		func() error {
+			return requireAuditAbsentFields(
+				entry.record, auditTopologyDeltaField, "witness_change_digest",
+			)
+		},
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return 0, err
+		}
+	}
+	allocated, err := auditUnsignedListField(entry.record, "allocated_node_ids")
+	if err != nil {
+		return 0, err
+	}
+	if len(allocated) != 0 {
+		return 0, errors.New("audit allocation cannot allocate node IDs")
+	}
+	return nextCount, nil
 }
 
 func (replay *auditedHistoryReplay) applyContentTransitionState(

--- a/internal/store/audit_ingest.go
+++ b/internal/store/audit_ingest.go
@@ -63,11 +63,7 @@ func makeAuditedIngestCreationMetadata(
 	if err != nil {
 		return auditedCreationMetadata{}, err
 	}
-	delta := audit.Record{Kind: "attached_metadata_delta", Fields: []audit.Field{
-		{Name: auditOperationIDField, Value: operationValue},
-		{Name: "changes", Value: audit.List(auditNestedValues(changes)...)},
-	}}
-	digest, err := hashAuditRecord(delta)
+	delta, digest, err := makeAttachedMetadataDelta(operationValue, changes)
 	if err != nil {
 		return auditedCreationMetadata{}, err
 	}
@@ -79,6 +75,17 @@ func makeAuditedIngestCreationMetadata(
 		groupingID: groupingID, baselineRecords: baseline, changes: changes,
 		delta: delta, deltaDigest: digest, provenance: provenanceRecord,
 	}, nil
+}
+
+func makeAttachedMetadataDelta(
+	operationID audit.Value, changes []audit.Record,
+) (audit.Record, auditRecordHash, error) {
+	delta := audit.Record{Kind: "attached_metadata_delta", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: operationID},
+		{Name: "changes", Value: audit.List(auditNestedValues(changes)...)},
+	}}
+	digest, err := hashAuditRecord(delta)
+	return delta, digest, err
 }
 
 func ingestAuditRecord(ingest metadataIngest) (audit.Record, error) {

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -168,7 +168,7 @@ func selectInitialAuditRecords(
 		}
 	}
 	if authority.sequence < 1 || authority.allocationCount != authority.sequence ||
-		int64(len(records["canonical_mutation"])) != authority.sequence ||
+		int64(len(records["canonical_mutation"])) > authority.sequence ||
 		int64(len(records["allocation_entry"])) != authority.allocationCount {
 		return nil, errors.New("audit allocation projection does not match its operation records")
 	}

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -322,8 +322,6 @@ func TestInitialAuditAuthorityRejectsUnsupportedLogicalMutations(t *testing.T) {
 
 	_, err = s.Mkdir(t.Context(), s.RootID(), "blocked")
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
-	_, err = s.CreateTag(t.Context(), "blocked")
-	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
 	run, err := s.BeginIngest(t.Context(), "cli", "blocked")
 	require.NoError(t, err)
 	_, _, err = s.IngestFile(

--- a/internal/store/audit_node_move.go
+++ b/internal/store/audit_node_move.go
@@ -516,7 +516,7 @@ func makeAuditedTopologyAllocationEntry(
 	values auditedMutationValues, sequence, nodeSequence int64,
 	previousHead string, mutationHash, topologyDigest audit.Value,
 ) (audit.Record, error) {
-	entry, err := makeAuditedMutationAllocationEntry(
+	entry, err := makeAuditAllocationEntry(
 		values, sequence, nodeSequence, previousHead, mutationHash,
 	)
 	if err != nil {

--- a/internal/store/audit_node_restore_test.go
+++ b/internal/store/audit_node_restore_test.go
@@ -257,7 +257,7 @@ func TestAuditedRestoreReplayRejectsOmittedDescendant(t *testing.T) {
 	)
 	topologyRecords[digest] = delta
 	_, _, err = replay.validateNodeRestoreTopology(
-		mutation.record, mustAuditUUIDField(t, mutation.record, auditOperationIDField),
+		mutation.record, mustAuditOperationID(t, mutation.record),
 		topologyRecords, usedTopology,
 	)
 	require.ErrorContains(t, err, "complete trash subtree")

--- a/internal/store/audit_node_trash_test.go
+++ b/internal/store/audit_node_trash_test.go
@@ -177,7 +177,7 @@ func TestAuditedTrashReplayRejectsOmittedDescendant(t *testing.T) {
 	)
 	topologyRecords[digest] = delta
 	_, _, err = replay.validateNodeTrashTopology(
-		mutation.record, mustAuditUUIDField(t, mutation.record, auditOperationIDField),
+		mutation.record, mustAuditOperationID(t, mutation.record),
 		topologyRecords, map[string]bool{},
 	)
 	require.ErrorContains(t, err, "complete live subtree")
@@ -197,9 +197,9 @@ func assertAuditPathState(
 	require.NoError(t, requireAuditText(value, "state", state))
 }
 
-func mustAuditUUIDField(t *testing.T, record audit.Record, name string) string {
+func mustAuditOperationID(t *testing.T, record audit.Record) string {
 	t.Helper()
-	value, err := auditUUIDField(record, name)
+	value, err := auditUUIDField(record, auditOperationIDField)
 	require.NoError(t, err)
 	return value
 }

--- a/internal/store/audit_projection.go
+++ b/internal/store/audit_projection.go
@@ -295,19 +295,27 @@ func appendAuditTagDefinitions(ctx context.Context, tx metadataQuerier, records 
 		if err := rows.Scan(&tagID, &name); err != nil {
 			return fmt.Errorf("scanning audit tag definition: %w", err)
 		}
-		tagValue, err := audit.UUID(tagID)
+		record, err := tagDefinitionAuditRecord(Tag{ID: tagID, Name: name})
 		if err != nil {
 			return err
 		}
-		nameValue, err := audit.Text(name)
-		if err != nil {
-			return err
-		}
-		*records = append(*records, audit.Record{Kind: "tag_definition", Fields: []audit.Field{
-			{Name: "tag_id", Value: tagValue}, {Name: "name", Value: nameValue},
-		}})
+		*records = append(*records, record)
 	}
 	return rowsError("audit tag definitions", rows)
+}
+
+func tagDefinitionAuditRecord(tag Tag) (audit.Record, error) {
+	tagValue, err := audit.UUID(tag.ID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	nameValue, err := audit.Text(tag.Name)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "tag_definition", Fields: []audit.Field{
+		{Name: "tag_id", Value: tagValue}, {Name: "name", Value: nameValue},
+	}}, nil
 }
 
 func attachedAuditIdentity(record audit.Record) (audit.Record, error) {

--- a/internal/store/audit_tag_assignment.go
+++ b/internal/store/audit_tag_assignment.go
@@ -59,11 +59,9 @@ func persistAuditedTagAssignment(
 	if err != nil {
 		return err
 	}
-	delta := audit.Record{Kind: "attached_metadata_delta", Fields: []audit.Field{
-		{Name: auditOperationIDField, Value: values.operationID},
-		{Name: "changes", Value: audit.List(audit.Nested(change))},
-	}}
-	deltaDigest, err := hashAuditRecord(delta)
+	delta, deltaDigest, err := makeAttachedMetadataDelta(
+		values.operationID, []audit.Record{change},
+	)
 	if err != nil {
 		return err
 	}
@@ -122,31 +120,17 @@ func persistAuditedTagAssignment(
 	); err != nil {
 		return err
 	}
-	allocation, err := makeAuditedMutationAllocationEntry(
+	allocation, err := makeAuditAllocationEntry(
 		values, sequence, nodeSequence, authority.allocationHead, mutationDigest.value,
 	)
 	if err != nil {
 		return err
 	}
-	allocation, err = replaceAuditRecordField(
-		allocation, "has_attached_metadata_change", audit.Bool(true),
-	)
+	allocation, err = addAttachedMetadataToAllocation(allocation, 1, deltaDigest.value)
 	if err != nil {
 		return err
 	}
-	allocation, err = replaceAuditRecordField(
-		allocation, auditAttachedMetadataChangeCountField, audit.Unsigned(1),
-	)
-	if err != nil {
-		return err
-	}
-	allocation, err = replaceAuditRecordField(
-		allocation, "attached_metadata_change_digest", deltaDigest.value,
-	)
-	if err != nil {
-		return err
-	}
-	return advanceAuditedMutationAuthority(ctx, tx, authority, sequence, allocation)
+	return advanceAuditAuthority(ctx, tx, authority, sequence, allocation)
 }
 
 func auditTagAssignmentRecord(tagID string, nodeID int64) (audit.Record, error) {

--- a/internal/store/audit_tag_assignment_test.go
+++ b/internal/store/audit_tag_assignment_test.go
@@ -141,7 +141,7 @@ func TestAuditedTagAssignmentReplayRejectsRetargetedNode(t *testing.T) {
 	deltas[digest] = delta
 
 	_, err = replay.validateTagAssignmentDelta(
-		mutation.record, mustAuditUUIDField(t, mutation.record, auditOperationIDField),
+		mutation.record, mustAuditOperationID(t, mutation.record),
 		deltas, map[string]bool{},
 	)
 	require.ErrorContains(t, err, "unaudited node")
@@ -188,7 +188,7 @@ func auditEventKindForSequence(t *testing.T, s *Store, sequence int64) string {
 	t.Helper()
 	records, err := loadInitialAuditRecords(t.Context(), s.db)
 	require.NoError(t, err)
-	mutations, err := auditRecordsBySequence(records["canonical_mutation"], sequence)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], sequence)
 	require.NoError(t, err)
 	events, err := auditRecordListField(mutations[sequence].record, "events")
 	require.NoError(t, err)

--- a/internal/store/audit_tag_definition.go
+++ b/internal/store/audit_tag_definition.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func (s *Store) persistAuditedTagCreation(
+	ctx context.Context, tx *sql.Tx, tag Tag,
+) error {
+	authority, nodeSequence, err := loadAuditAuthorityTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return fmt.Errorf("allocating audited tag-creation operation: %w", err)
+	}
+	values, err := makeAuditedMutationValues(
+		s.vaultID, authority.lineageID, operationID, nowRFC3339(),
+	)
+	if err != nil {
+		return err
+	}
+	definition, err := tagDefinitionAuditRecord(tag)
+	if err != nil {
+		return err
+	}
+	change, err := makeAttachedMetadataPresenceChange(definition, true)
+	if err != nil {
+		return err
+	}
+	delta, deltaDigest, err := makeAttachedMetadataDelta(
+		values.operationID, []audit.Record{change},
+	)
+	if err != nil {
+		return err
+	}
+	sequence, err := nextAuditInteger("operation sequence", authority.sequence)
+	if err != nil {
+		return err
+	}
+	allocation, err := makeAuditAllocationEntry(
+		values, sequence, nodeSequence, authority.allocationHead, audit.Absent(),
+	)
+	if err != nil {
+		return err
+	}
+	allocation, err = addAttachedMetadataToAllocation(
+		allocation, 1, deltaDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, delta); err != nil {
+		return err
+	}
+	return advanceAuditAuthority(ctx, tx, authority, sequence, allocation)
+}

--- a/internal/store/audit_tag_definition_test.go
+++ b/internal/store/audit_tag_definition_test.go
@@ -1,0 +1,168 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedTagCreationRoundTripsBeforeAssignment(t *testing.T) {
+	s, _, report := newAuditedTagStore(t)
+	created, err := s.CreateTag(t.Context(), "post-enrollment")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), created.Revision)
+	assert.Zero(t, created.AssignmentCount)
+
+	assigned, err := s.AssignTag(
+		t.Context(), created.ID, report.ID, report.Revision,
+	)
+	require.NoError(t, err)
+	assert.True(t, assigned.Changed)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assert.Equal(t, "tag_assign", auditEventKindForSequence(t, s, 3))
+
+	var sequence, allocations, scopeEntries, mutations, deltas int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT allocation_entry_count FROM audit_authority),
+		(SELECT entry_count FROM audit_scopes),
+		(SELECT COUNT(*) FROM audit_records WHERE kind='canonical_mutation'),
+		(SELECT COUNT(*) FROM audit_records WHERE kind='attached_metadata_delta')`,
+	).Scan(&sequence, &allocations, &scopeEntries, &mutations, &deltas))
+	assert.Equal(t, int64(3), sequence)
+	assert.Equal(t, int64(3), allocations)
+	assert.Equal(t, int64(2), scopeEntries)
+	assert.Equal(t, int64(2), mutations)
+	assert.Equal(t, int64(2), deltas)
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+}
+
+func TestAuditedTagCreationNameConflictDoesNotAdvanceLineage(t *testing.T) {
+	s, existing, _ := newAuditedTagStore(t)
+	_, err := s.CreateTag(t.Context(), existing.Name)
+	require.ErrorIs(t, err, ErrExists)
+
+	var sequence, deltas int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM audit_records WHERE kind='attached_metadata_delta')`,
+	).Scan(&sequence, &deltas))
+	assert.Equal(t, int64(1), sequence)
+	assert.Zero(t, deltas)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTagCreationRollsBackWithLineage(t *testing.T) {
+	s, _, _ := newAuditedTagStore(t)
+	_, err := s.db.Exec(`CREATE TRIGGER reject_tag_creation_authority_advance
+		BEFORE UPDATE ON audit_authority BEGIN
+		SELECT RAISE(ABORT, 'forced tag-creation failure'); END`)
+	require.NoError(t, err)
+
+	_, err = s.CreateTag(t.Context(), "rollback")
+	require.ErrorContains(t, err, "forced tag-creation failure")
+	_, err = s.TagByName(t.Context(), "rollback")
+	require.ErrorIs(t, err, ErrNotFound)
+	var sequence, deltas int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM audit_records WHERE kind='attached_metadata_delta')`,
+	).Scan(&sequence, &deltas))
+	assert.Equal(t, int64(1), sequence)
+	assert.Zero(t, deltas)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTagCreationImportRejectsMissingCurrentDefinition(t *testing.T) {
+	s, _, _ := newAuditedTagStore(t)
+	created, err := s.CreateTag(t.Context(), "missing")
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := omitMetadataTagDefinition(t, exported.Bytes(), created.ID)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "replayed audit attachments do not match current metadata")
+	var tagRows, auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM tags),
+		(SELECT COUNT(*) FROM audit_records)`).Scan(&tagRows, &auditRows))
+	assert.Zero(t, tagRows)
+	assert.Zero(t, auditRows)
+}
+
+func TestAuditedTagCreationReplayRejectsReusedIdentity(t *testing.T) {
+	s, existing, _ := newAuditedTagStore(t)
+	_, err := s.CreateTag(t.Context(), "new")
+	require.NoError(t, err)
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, scope, initial)
+	require.NoError(t, err)
+	allocations, err := auditRecordsBySequence(records["allocation_entry"], authority.sequence)
+	require.NoError(t, err)
+	allocation := allocations[2]
+	digest, err := auditDigestField(allocation.record, "attached_metadata_change_digest")
+	require.NoError(t, err)
+	deltas := auditRecordsByDigest(records["attached_metadata_delta"])
+	delta := deltas[digest]
+	existingDefinition, err := tagDefinitionAuditRecord(existing)
+	require.NoError(t, err)
+	change, err := makeAttachedMetadataPresenceChange(existingDefinition, true)
+	require.NoError(t, err)
+	delta.record = mustReplaceAuditRecordField(
+		t, delta.record, "changes", audit.List(audit.Nested(change)),
+	)
+	deltas[digest] = delta
+
+	_, err = replay.validateTagCreationDelta(
+		mustAuditOperationID(t, allocation.record),
+		digest, deltas, map[string]bool{},
+	)
+	require.ErrorContains(t, err, "reuses definition identity")
+}
+
+func omitMetadataTagDefinition(t *testing.T, input []byte, tagID string) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	kept := lines[:0]
+	found := false
+	for _, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type == "tag" {
+			var definition metadataTag
+			require.NoError(t, json.Unmarshal(line, &definition))
+			if definition.ID == tagID {
+				found = true
+				continue
+			}
+		}
+		kept = append(kept, line)
+	}
+	require.True(t, found)
+	return append(bytes.Join(kept, []byte{'\n'}), '\n')
+}

--- a/internal/store/audit_tag_definition_validate.go
+++ b/internal/store/audit_tag_definition_validate.go
@@ -1,0 +1,128 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func (replay *auditedHistoryReplay) applyUnauditedTagCreation(
+	vaultID string, allocation storedAuditRecord,
+	deltaRecords map[string]storedAuditRecord, usedDeltas map[string]bool,
+) error {
+	operationID, err := auditUUIDField(allocation.record, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	nextCount, err := replay.validateAllocationBase(vaultID, operationID, allocation)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditBool(allocation.record, "has_audited_mutation", false); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(allocation.record, "mutation_hash"); err != nil {
+		return err
+	}
+	if err := requireAuditBool(
+		allocation.record, "has_attached_metadata_change", true,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(
+		allocation.record, auditAttachedMetadataChangeCountField, 1,
+	); err != nil {
+		return err
+	}
+	digest, err := auditDigestField(allocation.record, "attached_metadata_change_digest")
+	if err != nil {
+		return err
+	}
+	definition, err := replay.validateTagCreationDelta(
+		operationID, digest, deltaRecords, usedDeltas,
+	)
+	if err != nil {
+		return err
+	}
+	key, err := attachedAuditKey(definition)
+	if err != nil {
+		return err
+	}
+	replay.attachments[key] = definition
+	replay.allocationCount, replay.allocationHead = nextCount, allocation.digest
+	return nil
+}
+
+func (replay *auditedHistoryReplay) validateTagCreationDelta(
+	operationID, digest string, deltaRecords map[string]storedAuditRecord,
+	usedDeltas map[string]bool,
+) (audit.Record, error) {
+	delta, ok := deltaRecords[digest]
+	if !ok || usedDeltas[digest] {
+		return audit.Record{}, errors.New(
+			"tag creation lacks one unique attached-metadata delta",
+		)
+	}
+	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
+		return audit.Record{}, err
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	if len(changes) != 1 {
+		return audit.Record{}, errors.New(
+			"tag creation must contain exactly one attached-metadata change",
+		)
+	}
+	change := changes[0]
+	if err := requireAuditText(change, "record_kind", "tag_definition"); err != nil {
+		return audit.Record{}, err
+	}
+	if err := requireAuditAbsent(change, auditPreField); err != nil {
+		return audit.Record{}, errors.New("tag creation pre-state must be absent")
+	}
+	definition, err := auditNestedField(change, auditPostField)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	if definition.Kind != "tag_definition" {
+		return audit.Record{}, errors.New("tag creation post-state is not a tag definition")
+	}
+	identity, err := attachedAuditIdentity(definition)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	storedIdentity, err := auditNestedField(change, "stable_identity")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	if !auditRecordEqual(storedIdentity, identity) {
+		return audit.Record{}, errors.New("tag creation identity does not match its definition")
+	}
+	tagID, err := auditUUIDField(definition, "tag_id")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	name, err := auditTextField(definition, "name")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	normalized, err := NormalizeTagName(name)
+	if err != nil {
+		return audit.Record{}, fmt.Errorf("tag %s has an invalid name: %w", tagID, err)
+	}
+	if normalized != name {
+		return audit.Record{}, fmt.Errorf("tag %s has an invalid canonical name", tagID)
+	}
+	key, err := attachedAuditKey(definition)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	if _, exists := replay.attachments[key]; exists {
+		return audit.Record{}, fmt.Errorf("tag creation reuses definition identity %s", tagID)
+	}
+	usedDeltas[digest] = true
+	return definition, nil
+}

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -77,17 +77,27 @@ func (s *Store) CreateTag(ctx context.Context, name string) (Tag, error) {
 	if err != nil {
 		return Tag{}, fmt.Errorf("allocating tag ID: %w", err)
 	}
-	err = s.withLogicalTx(ctx, func(tx *sql.Tx) error {
-		_, execErr := tx.ExecContext(ctx, `INSERT INTO tags(id, name) VALUES(?, ?)`, id, name)
-		return execErr
+	created := Tag{ID: id, Name: name, Revision: 1}
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO tags(id, name) VALUES(?, ?)`, id, name); err != nil {
+			if s.driver.IsUniqueViolation(err) {
+				return fmt.Errorf("tag %q: %w", name, ErrExists)
+			}
+			return fmt.Errorf("creating tag %q: %w", name, err)
+		}
+		if !active {
+			return nil
+		}
+		return s.persistAuditedTagCreation(ctx, tx, created)
 	})
 	if err != nil {
-		if s.driver.IsUniqueViolation(err) {
-			return Tag{}, fmt.Errorf("tag %q: %w", name, ErrExists)
-		}
-		return Tag{}, fmt.Errorf("creating tag %q: %w", name, err)
+		return Tag{}, err
 	}
-	return Tag{ID: id, Name: name, Revision: 1}, nil
+	return created, nil
 }
 
 // TagByID returns one tag by stable identity.


### PR DESCRIPTION
Once audit has been activated, people can now create a new tag and then assign it to a protected document. Previously the assignment itself worked, but every useful tag had to exist before enrollment.

Tag creation is different from assignment: an unassigned definition does not change any audited document. Docbank therefore records it in the vault-wide lineage without inventing a document event or advancing the scope chain. When that tag is later assigned, the document receives the normal audited assignment event and the two histories remain correctly linked.

Backup restore and JSONL import replay the definition change rather than trusting the final tag table. They reject a missing definition, a reused stable tag identity, a false claim that the operation changed an audited document, or an allocation record that does not continue the vault lineage. The tag row and lineage record also roll back together if either side fails.

This intentionally covers only creating an unassigned tag. Rename and delete can affect every audited document carrying a tag, so their fan-out remains separate work. The lineage and replay rules stay in Go; this adds no SQL policy or schema tables.

Kata: crq8.
