### PR TITLE
Record audited tag definition renames

### DIFF
--- a/internal/store/audit_content_replace.go
+++ b/internal/store/audit_content_replace.go
@@ -453,6 +453,13 @@ func makeAuditedMemberStateMutation(
 	values auditedMutationValues, sequence int64,
 	events []audit.Record, change audit.Record,
 ) (audit.Record, error) {
+	return makeAuditedMemberStatesMutation(values, sequence, events, []audit.Record{change})
+}
+
+func makeAuditedMemberStatesMutation(
+	values auditedMutationValues, sequence int64,
+	events, changes []audit.Record,
+) (audit.Record, error) {
 	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
 	if err != nil {
 		return audit.Record{}, err
@@ -460,6 +467,10 @@ func makeAuditedMemberStateMutation(
 	eventValues := make([]audit.Value, len(events))
 	for index := range events {
 		eventValues[index] = audit.Nested(events[index])
+	}
+	changeValues := make([]audit.Value, len(changes))
+	for index := range changes {
+		changeValues[index] = audit.Nested(changes[index])
 	}
 	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
 		{Name: auditVaultIDField, Value: values.vaultID},
@@ -470,7 +481,7 @@ func makeAuditedMemberStateMutation(
 		{Name: auditOriginField, Value: values.origin},
 		{Name: "agent_label", Value: audit.Absent()},
 		{Name: "events", Value: audit.List(eventValues...)},
-		{Name: "member_state_changes", Value: audit.List(audit.Nested(change))},
+		{Name: "member_state_changes", Value: audit.List(changeValues...)},
 		{Name: "baselines", Value: audit.List()},
 		{Name: auditTopologyDeltaField, Value: audit.Absent()},
 		{Name: "path_effect_count", Value: audit.Unsigned(0)},

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -310,7 +310,7 @@ func validateAuditedHistory(
 		allocation := allocations[sequence]
 		mutation, hasMutation := mutations[sequence]
 		if !hasMutation {
-			err = replay.applyUnauditedTagCreation(
+			err = replay.applyUnscopedTagDefinitionChange(
 				vaultID, allocation, attachmentDeltas, usedAttachmentDeltas,
 			)
 			if err != nil {
@@ -337,10 +337,20 @@ func validateAuditedHistory(
 			if attachedErr != nil {
 				err = attachedErr
 			} else if attachedCount != 0 {
-				err = replay.applyTagAssignment(
-					vaultID, mutation, allocation, scopeEntry,
-					attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
-				)
+				kind, kindErr := attachedMutationRecordKind(mutation.record, attachmentDeltas)
+				if kindErr != nil {
+					err = kindErr
+				} else if kind == "tag_definition" {
+					err = replay.applyTagDefinitionRename(
+						vaultID, mutation, allocation, scopeEntry,
+						attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
+					)
+				} else {
+					err = replay.applyTagAssignment(
+						vaultID, mutation, allocation, scopeEntry,
+						attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
+					)
+				}
 			} else {
 				err = replay.applyContentTransition(
 					vaultID, mutation, allocation, scopeEntry, events, usedEvents,

--- a/internal/store/audit_ingest.go
+++ b/internal/store/audit_ingest.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"go.kenn.io/docbank/internal/audit"
@@ -116,6 +117,21 @@ func makeAttachedMetadataAddition(record audit.Record) (audit.Record, error) {
 func makeAttachedMetadataPresenceChange(
 	record audit.Record, add bool,
 ) (audit.Record, error) {
+	pre, post := audit.Record{}, record
+	if !add {
+		pre, post = post, pre
+	}
+	return makeAttachedMetadataChange(pre, post)
+}
+
+func makeAttachedMetadataChange(pre, post audit.Record) (audit.Record, error) {
+	record := post
+	if record.Kind == "" {
+		record = pre
+	}
+	if record.Kind == "" || (pre.Kind != "" && post.Kind != "" && pre.Kind != post.Kind) {
+		return audit.Record{}, errors.New("attached metadata change has inconsistent record kinds")
+	}
 	kind, err := audit.Text(record.Kind)
 	if err != nil {
 		return audit.Record{}, err
@@ -124,15 +140,32 @@ func makeAttachedMetadataPresenceChange(
 	if err != nil {
 		return audit.Record{}, err
 	}
-	pre, post := audit.Absent(), audit.Nested(record)
-	if !add {
-		pre, post = post, pre
+	preValue, postValue := audit.Absent(), audit.Absent()
+	if pre.Kind != "" {
+		preIdentity, err := attachedAuditIdentity(pre)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		if !auditRecordEqual(preIdentity, identity) {
+			return audit.Record{}, errors.New("attached metadata change alters stable identity")
+		}
+		preValue = audit.Nested(pre)
+	}
+	if post.Kind != "" {
+		postIdentity, err := attachedAuditIdentity(post)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		if !auditRecordEqual(postIdentity, identity) {
+			return audit.Record{}, errors.New("attached metadata change alters stable identity")
+		}
+		postValue = audit.Nested(post)
 	}
 	return audit.Record{Kind: "attached_metadata_change", Fields: []audit.Field{
 		{Name: "record_kind", Value: kind},
 		{Name: "stable_identity", Value: audit.Nested(identity)},
-		{Name: auditPreField, Value: pre},
-		{Name: auditPostField, Value: post},
+		{Name: auditPreField, Value: preValue},
+		{Name: auditPostField, Value: postValue},
 	}}, nil
 }
 

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -21,6 +21,7 @@ const (
 	auditPostField         = "post"
 	auditPreField          = "pre"
 	auditRecordedAtField   = "recorded_at"
+	auditTargetNodeIDField = "target_node_id"
 )
 
 var auditRecordKinds = map[string]bool{

--- a/internal/store/audit_tag_definition_test.go
+++ b/internal/store/audit_tag_definition_test.go
@@ -136,7 +136,7 @@ func TestAuditedTagCreationReplayRejectsReusedIdentity(t *testing.T) {
 	)
 	deltas[digest] = delta
 
-	_, err = replay.validateTagCreationDelta(
+	_, err = replay.validateTagDefinitionDelta(
 		mustAuditOperationID(t, allocation.record),
 		digest, deltas, map[string]bool{},
 	)

--- a/internal/store/audit_tag_definition_validate.go
+++ b/internal/store/audit_tag_definition_validate.go
@@ -3,11 +3,48 @@ package store
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.kenn.io/docbank/internal/audit"
 )
 
-func (replay *auditedHistoryReplay) applyUnauditedTagCreation(
+const (
+	tagDefinitionCreate = "create"
+	tagDefinitionRename = "rename"
+)
+
+type replayedTagDefinitionChange struct {
+	tagID      string
+	kind       string
+	pre        audit.Record
+	post       audit.Record
+	change     audit.Record
+	digest     string
+	candidates []uint64
+}
+
+func attachedMutationRecordKind(
+	mutation audit.Record, deltaRecords map[string]storedAuditRecord,
+) (string, error) {
+	digest, err := auditDigestField(mutation, "attached_metadata_change_digest")
+	if err != nil {
+		return "", err
+	}
+	delta, ok := deltaRecords[digest]
+	if !ok {
+		return "", errors.New("attached-metadata mutation lacks its delta")
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return "", err
+	}
+	if len(changes) != 1 {
+		return "", errors.New("attached-metadata mutation must contain exactly one change")
+	}
+	return auditTextField(changes[0], "record_kind")
+}
+
+func (replay *auditedHistoryReplay) applyUnscopedTagDefinitionChange(
 	vaultID string, allocation storedAuditRecord,
 	deltaRecords map[string]storedAuditRecord, usedDeltas map[string]bool,
 ) error {
@@ -39,90 +76,415 @@ func (replay *auditedHistoryReplay) applyUnauditedTagCreation(
 	if err != nil {
 		return err
 	}
-	definition, err := replay.validateTagCreationDelta(
+	transition, err := replay.validateTagDefinitionDelta(
 		operationID, digest, deltaRecords, usedDeltas,
 	)
 	if err != nil {
 		return err
 	}
-	key, err := attachedAuditKey(definition)
+	if transition.kind != tagDefinitionCreate && transition.kind != tagDefinitionRename {
+		return errors.New("unscoped tag-definition operation has an unsupported transition")
+	}
+	transition.candidates, err = replay.auditedTagDefinitionCandidates(transition.tagID)
 	if err != nil {
 		return err
 	}
-	replay.attachments[key] = definition
+	if len(transition.candidates) != 0 {
+		return errors.New("tag definition change omits required audited effects")
+	}
+	if err := replay.applyTagDefinitionState(transition, nil); err != nil {
+		return err
+	}
 	replay.allocationCount, replay.allocationHead = nextCount, allocation.digest
 	return nil
 }
 
-func (replay *auditedHistoryReplay) validateTagCreationDelta(
+func (replay *auditedHistoryReplay) validateTagDefinitionDelta(
 	operationID, digest string, deltaRecords map[string]storedAuditRecord,
 	usedDeltas map[string]bool,
-) (audit.Record, error) {
+) (replayedTagDefinitionChange, error) {
 	delta, ok := deltaRecords[digest]
 	if !ok || usedDeltas[digest] {
-		return audit.Record{}, errors.New(
-			"tag creation lacks one unique attached-metadata delta",
+		return replayedTagDefinitionChange{}, errors.New(
+			"tag definition change lacks one unique attached-metadata delta",
 		)
 	}
 	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
-		return audit.Record{}, err
+		return replayedTagDefinitionChange{}, err
 	}
 	changes, err := auditRecordListField(delta.record, "changes")
 	if err != nil {
-		return audit.Record{}, err
+		return replayedTagDefinitionChange{}, err
 	}
 	if len(changes) != 1 {
-		return audit.Record{}, errors.New(
-			"tag creation must contain exactly one attached-metadata change",
+		return replayedTagDefinitionChange{}, errors.New(
+			"tag definition change must contain exactly one attached-metadata change",
 		)
 	}
 	change := changes[0]
 	if err := requireAuditText(change, "record_kind", "tag_definition"); err != nil {
-		return audit.Record{}, err
+		return replayedTagDefinitionChange{}, err
 	}
-	if err := requireAuditAbsent(change, auditPreField); err != nil {
-		return audit.Record{}, errors.New("tag creation pre-state must be absent")
-	}
-	definition, err := auditNestedField(change, auditPostField)
+	pre, hasPre, err := optionalNestedAuditRecord(change, auditPreField)
 	if err != nil {
-		return audit.Record{}, err
+		return replayedTagDefinitionChange{}, err
 	}
-	if definition.Kind != "tag_definition" {
-		return audit.Record{}, errors.New("tag creation post-state is not a tag definition")
-	}
-	identity, err := attachedAuditIdentity(definition)
+	post, hasPost, err := optionalNestedAuditRecord(change, auditPostField)
 	if err != nil {
-		return audit.Record{}, err
+		return replayedTagDefinitionChange{}, err
+	}
+	transition := replayedTagDefinitionChange{change: change, digest: digest, pre: pre, post: post}
+	switch {
+	case !hasPre && hasPost:
+		transition.kind = tagDefinitionCreate
+	case hasPre && hasPost:
+		transition.kind = tagDefinitionRename
+	default:
+		return replayedTagDefinitionChange{}, errors.New(
+			"tag definition delta is neither a creation nor rename",
+		)
+	}
+	record := post
+	if err := validateReplayedTagDefinition(record); err != nil {
+		return replayedTagDefinitionChange{}, err
+	}
+	identity, err := attachedAuditIdentity(record)
+	if err != nil {
+		return replayedTagDefinitionChange{}, err
 	}
 	storedIdentity, err := auditNestedField(change, "stable_identity")
-	if err != nil {
-		return audit.Record{}, err
+	if err != nil || !auditRecordEqual(storedIdentity, identity) {
+		return replayedTagDefinitionChange{}, errors.New(
+			"tag definition identity does not match its record",
+		)
 	}
-	if !auditRecordEqual(storedIdentity, identity) {
-		return audit.Record{}, errors.New("tag creation identity does not match its definition")
+	transition.tagID, err = auditUUIDField(record, "tag_id")
+	if err != nil {
+		return replayedTagDefinitionChange{}, err
+	}
+	if err := replay.validateTagDefinitionNameAvailable(record, transition.tagID); err != nil {
+		return replayedTagDefinitionChange{}, err
+	}
+	key, err := attachedAuditKey(record)
+	if err != nil {
+		return replayedTagDefinitionChange{}, err
+	}
+	current, exists := replay.attachments[key]
+	if transition.kind == tagDefinitionCreate {
+		if exists {
+			return replayedTagDefinitionChange{}, fmt.Errorf(
+				"tag creation reuses definition identity %s", transition.tagID,
+			)
+		}
+	} else {
+		if err := validateReplayedTagDefinition(pre); err != nil {
+			return replayedTagDefinitionChange{}, err
+		}
+		preIdentity, err := attachedAuditIdentity(pre)
+		if err != nil || !auditRecordEqual(preIdentity, identity) {
+			return replayedTagDefinitionChange{}, errors.New("tag rename changes stable identity")
+		}
+		if !exists || !auditRecordEqual(current, pre) {
+			return replayedTagDefinitionChange{}, errors.New(
+				"tag rename pre-state does not match replayed metadata",
+			)
+		}
+		if auditRecordEqual(pre, post) {
+			return replayedTagDefinitionChange{}, errors.New("tag rename does not change its definition")
+		}
+	}
+	usedDeltas[digest] = true
+	return transition, nil
+}
+
+func (replay *auditedHistoryReplay) validateTagDefinitionNameAvailable(
+	definition audit.Record, tagID string,
+) error {
+	name, err := auditTextField(definition, "name")
+	if err != nil {
+		return err
+	}
+	for _, current := range replay.attachments {
+		if current.Kind != "tag_definition" {
+			continue
+		}
+		currentID, err := auditUUIDField(current, "tag_id")
+		if err != nil {
+			return err
+		}
+		if currentID == tagID {
+			continue
+		}
+		currentName, err := auditTextField(current, "name")
+		if err != nil {
+			return err
+		}
+		if currentName == name {
+			return fmt.Errorf("tag definition name %q already exists in replay", name)
+		}
+	}
+	return nil
+}
+
+func validateReplayedTagDefinition(definition audit.Record) error {
+	if definition.Kind != "tag_definition" {
+		return errors.New("tag definition change carries the wrong record kind")
 	}
 	tagID, err := auditUUIDField(definition, "tag_id")
 	if err != nil {
-		return audit.Record{}, err
+		return err
 	}
 	name, err := auditTextField(definition, "name")
 	if err != nil {
-		return audit.Record{}, err
+		return err
 	}
 	normalized, err := NormalizeTagName(name)
 	if err != nil {
-		return audit.Record{}, fmt.Errorf("tag %s has an invalid name: %w", tagID, err)
+		return fmt.Errorf("tag %s has an invalid name: %w", tagID, err)
 	}
 	if normalized != name {
-		return audit.Record{}, fmt.Errorf("tag %s has an invalid canonical name", tagID)
+		return fmt.Errorf("tag %s has an invalid canonical name", tagID)
 	}
-	key, err := attachedAuditKey(definition)
+	return nil
+}
+
+func (replay *auditedHistoryReplay) auditedTagDefinitionCandidates(
+	tagID string,
+) ([]uint64, error) {
+	seen := make(map[uint64]bool)
+	for _, record := range replay.attachments {
+		if record.Kind != "tag_assignment" {
+			continue
+		}
+		candidateTagID, err := auditUUIDField(record, "tag_id")
+		if err != nil {
+			return nil, err
+		}
+		if candidateTagID != tagID {
+			continue
+		}
+		nodeID, err := auditUnsignedField(record, metadataNodeIDField)
+		if err != nil {
+			return nil, err
+		}
+		if replay.memberSet[nodeID] {
+			seen[nodeID] = true
+		}
+	}
+	result := make([]uint64, 0, len(seen))
+	for nodeID := range seen {
+		result = append(result, nodeID)
+	}
+	slices.Sort(result)
+	return result, nil
+}
+
+func (replay *auditedHistoryReplay) applyTagDefinitionRename(
+	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	deltaRecords, eventRecords map[string]storedAuditRecord,
+	usedDeltas, usedEvents map[string]bool,
+) error {
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
 	if err != nil {
-		return audit.Record{}, err
+		return err
 	}
-	if _, exists := replay.attachments[key]; exists {
-		return audit.Record{}, fmt.Errorf("tag creation reuses definition identity %s", tagID)
+	auditSequence, err := positiveAuditInteger("operation sequence", replay.allocationCount+1)
+	if err != nil {
+		return err
 	}
-	usedDeltas[digest] = true
-	return definition, nil
+	if err := requireAuditUUID(mutation.record, auditVaultIDField, vaultID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(mutation.record, "operation_sequence", auditSequence); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
+		return err
+	}
+	digest, err := auditDigestField(mutation.record, "attached_metadata_change_digest")
+	if err != nil {
+		return err
+	}
+	transition, err := replay.validateTagDefinitionDelta(
+		operationID, digest, deltaRecords, usedDeltas,
+	)
+	if err != nil {
+		return err
+	}
+	if transition.kind != tagDefinitionRename {
+		return errors.New("audited tag-definition mutation is not a rename")
+	}
+	transition.candidates, err = replay.auditedTagDefinitionCandidates(transition.tagID)
+	if err != nil {
+		return err
+	}
+	if len(transition.candidates) == 0 {
+		return errors.New("tag rename fabricates an audited mutation without affected members")
+	}
+	if err := replay.validateTagRenameEvents(
+		mutation.record, operationID, transition, eventRecords, usedEvents,
+	); err != nil {
+		return err
+	}
+	if err := replay.validateMemberStateChanges(mutation.record, transition.candidates); err != nil {
+		return err
+	}
+	bindings, err := auditRecordListField(mutation.record, "baselines")
+	if err != nil {
+		return err
+	}
+	if len(bindings) != 0 {
+		return errors.New("tag rename cannot bind an enrollment baseline")
+	}
+	if err := requireAuditAbsentFields(
+		mutation.record, auditTopologyDeltaField, "path_effect_digest", "witness_change_digest",
+	); err != nil {
+		return err
+	}
+	for _, field := range []string{"path_effect_count", auditWitnessChangeCountField} {
+		if err := requireAuditUnsigned(mutation.record, field, 0); err != nil {
+			return err
+		}
+	}
+	if err := requireAuditUnsigned(
+		mutation.record, auditAttachedMetadataChangeCountField, 1,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(
+		mutation.record, "attached_metadata_change_digest", transition.digest,
+	); err != nil {
+		return err
+	}
+	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+		return err
+	}
+	if err := replay.advanceAllocation(
+		vaultID, operationID, mutation, allocation, transition.digest,
+	); err != nil {
+		return err
+	}
+	return replay.applyTagDefinitionState(transition, &mutation.record)
+}
+
+func (replay *auditedHistoryReplay) validateTagRenameEvents(
+	mutation audit.Record, operationID string, transition replayedTagDefinitionChange,
+	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
+) error {
+	events, err := auditRecordListField(mutation, "events")
+	if err != nil {
+		return err
+	}
+	if len(events) != len(transition.candidates) {
+		return errors.New("tag rename event set does not match assigned audited nodes")
+	}
+	identity, err := attachedAuditIdentity(transition.pre)
+	if err != nil {
+		return err
+	}
+	ordinal := uint64(0)
+	for index, nodeID := range transition.candidates {
+		event := events[index]
+		if err := validateAuditEventWrapper(
+			operationID, ordinal, event, eventRecords, usedEvents,
+		); err != nil {
+			return err
+		}
+		state := replay.states[nodeID]
+		revision, err := auditUnsignedField(state, "node_revision")
+		if err != nil {
+			return err
+		}
+		current, err := auditOptionalUUIDField(state, "current_version_id")
+		if err != nil {
+			return err
+		}
+		storedIdentity, err := auditNestedField(event, "attachment_identity")
+		if err != nil || !auditRecordEqual(storedIdentity, identity) {
+			return errors.New("tag rename event identity does not match its definition")
+		}
+		checks := []func() error{
+			func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
+			func() error { return requireAuditUnsigned(event, metadataNodeIDField, nodeID) },
+			func() error { return requireAuditText(event, "event_kind", "tag_rename") },
+			func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
+			func() error { return requireAuditText(event, "attachment_kind", "tag_definition") },
+			func() error { return requireAuditUnsigned(event, auditEventOrdinalField, ordinal) },
+			func() error { return requireAuditUnsigned(event, "prior_node_revision", revision) },
+			func() error { return requireAuditUnsigned(event, "resulting_node_revision", revision+1) },
+			func() error { return requireAuditOptionalUUID(event, "prior_current_version_id", current) },
+			func() error { return requireAuditOptionalUUID(event, "resulting_current_version_id", current) },
+			func() error { return requireMatchingEventEnvelope(mutation, event) },
+			func() error {
+				return requireAuditAbsentFields(
+					event, auditTargetNodeIDField, "source_version_id", auditTopologyDeltaField,
+					"baseline_digest",
+				)
+			},
+		}
+		for _, check := range checks {
+			if err := check(); err != nil {
+				return err
+			}
+		}
+		for _, side := range []struct {
+			name string
+			want audit.Record
+		}{{auditPreField, transition.pre}, {auditPostField, transition.post}} {
+			got, err := auditNestedField(event, side.name)
+			if err != nil || !auditRecordEqual(got, side.want) {
+				return fmt.Errorf("tag rename event %s does not match its delta", side.name)
+			}
+		}
+		ordinal++
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) applyTagDefinitionState(
+	transition replayedTagDefinitionChange, mutation *audit.Record,
+) error {
+	record := transition.post
+	key, err := attachedAuditKey(record)
+	if err != nil {
+		return err
+	}
+	replay.attachments[key] = record
+	if len(transition.candidates) == 0 {
+		return nil
+	}
+	if mutation == nil {
+		return errors.New("scoped tag-definition change lacks its mutation")
+	}
+	modifiedAt, err := auditField(*mutation, auditRecordedAtField)
+	if err != nil {
+		return err
+	}
+	for _, nodeID := range transition.candidates {
+		state := replay.states[nodeID]
+		revision, err := auditUnsignedField(state, "node_revision")
+		if err != nil {
+			return err
+		}
+		current, err := auditField(state, "current_version_id")
+		if err != nil {
+			return err
+		}
+		replay.states[nodeID] = audit.Record{Kind: "member_state", Fields: []audit.Field{
+			{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+			{Name: "node_revision", Value: audit.Unsigned(revision + 1)},
+			{Name: "current_version_id", Value: current},
+		}}
+		index, ok := replay.topologyIndex[nodeID]
+		if !ok {
+			return fmt.Errorf("tagged audited node %d is absent from topology", nodeID)
+		}
+		replay.topology[index], err = replaceAuditRecordField(
+			replay.topology[index], "modified_at", modifiedAt,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/store/audit_tag_rename.go
+++ b/internal/store/audit_tag_rename.go
@@ -1,0 +1,302 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func (s *Store) renameAuditedTagTx(
+	ctx context.Context, tx *sql.Tx, current Tag, name string,
+) (Tag, error) {
+	priorNodes, scope, err := auditedTaggedNodesTx(ctx, tx, current.ID)
+	if err != nil {
+		return Tag{}, err
+	}
+	authority, nodeSequence, err := loadAuditAuthorityTx(ctx, tx)
+	if err != nil {
+		return Tag{}, err
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return Tag{}, fmt.Errorf("allocating audited tag-rename operation: %w", err)
+	}
+	recordedAt := nowRFC3339()
+	renamed, err := s.renameTagDefinitionTx(tx, current, name)
+	if err != nil {
+		return Tag{}, err
+	}
+	if err := touchAuditedTagRenameNodesTx(tx, current.ID, priorNodes, recordedAt); err != nil {
+		return Tag{}, err
+	}
+	resultingNodes := make([]Node, len(priorNodes))
+	for index, prior := range priorNodes {
+		resultingNodes[index], err = nodeByIDTx(tx, prior.ID)
+		if err != nil {
+			return Tag{}, err
+		}
+	}
+	if err := persistAuditedTagRename(
+		ctx, tx, s.vaultID, operationID, recordedAt, nodeSequence,
+		authority, scope, current, renamed, priorNodes, resultingNodes,
+	); err != nil {
+		return Tag{}, err
+	}
+	return renamed, nil
+}
+
+func touchAuditedTagRenameNodesTx(
+	tx *sql.Tx, tagID string, audited []Node, recordedAt string,
+) error {
+	// Revisions cover every assigned node. modified_at is changed only where the
+	// scoped mutation commits the operation timestamp; the allocation-only form
+	// deliberately has no timestamp from which replay could derive that field.
+	if _, err := tx.Exec(`UPDATE nodes SET revision=revision+1
+		WHERE id IN (SELECT node_id FROM node_tags WHERE tag_id=?)`, tagID); err != nil {
+		return fmt.Errorf("advancing nodes assigned tag %s: %w", tagID, err)
+	}
+	for _, node := range audited {
+		if _, err := tx.Exec(
+			`UPDATE nodes SET modified_at=? WHERE id=?`, recordedAt, node.ID,
+		); err != nil {
+			return fmt.Errorf("recording audited tag rename on node %d: %w", node.ID, err)
+		}
+	}
+	return nil
+}
+
+func auditedTaggedNodesTx(
+	ctx context.Context, tx *sql.Tx, tagID string,
+) ([]Node, *auditScopeState, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT membership.node_id,scope.scope_id,
+		scope.entry_count,scope.chain_head
+		FROM node_tags assignment
+		JOIN audit_memberships membership ON membership.node_id=assignment.node_id
+		JOIN audit_scopes scope ON scope.scope_id=membership.scope_id
+		WHERE assignment.tag_id=? ORDER BY membership.node_id,scope.scope_id`, tagID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing audited nodes assigned tag %s: %w", tagID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var (
+		nodeIDs []int64
+		scope   *auditScopeState
+	)
+	for rows.Next() {
+		var nodeID int64
+		var current auditScopeState
+		if err := rows.Scan(
+			&nodeID, &current.scopeID, &current.entryCount, &current.chainHead,
+		); err != nil {
+			_ = rows.Close()
+			return nil, nil, fmt.Errorf("scanning audited tag assignment: %w", err)
+		}
+		if scope != nil && scope.scopeID != current.scopeID {
+			_ = rows.Close()
+			return nil, nil, errors.New("tag rename across multiple audit scopes is not supported")
+		}
+		if scope == nil {
+			scope = &current
+		}
+		if len(nodeIDs) == 0 || nodeIDs[len(nodeIDs)-1] != nodeID {
+			nodeIDs = append(nodeIDs, nodeID)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, nil, fmt.Errorf("listing audited nodes assigned tag %s: %w", tagID, err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, nil, fmt.Errorf("closing audited tag assignment rows: %w", err)
+	}
+	nodes := make([]Node, len(nodeIDs))
+	for index, nodeID := range nodeIDs {
+		nodes[index], err = nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return nodes, scope, nil
+}
+
+func persistAuditedTagRename(
+	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
+	nodeSequence int64, authority auditAuthorityState, scope *auditScopeState,
+	priorTag, resultingTag Tag, priorNodes, resultingNodes []Node,
+) error {
+	if len(priorNodes) != len(resultingNodes) || (len(priorNodes) != 0) != (scope != nil) {
+		return errors.New("audited tag rename has inconsistent affected-node authority")
+	}
+	sequence, err := nextAuditInteger("operation sequence", authority.sequence)
+	if err != nil {
+		return err
+	}
+	values, err := makeAuditedMutationValues(vaultID, authority.lineageID, operationID, recordedAt)
+	if err != nil {
+		return err
+	}
+	priorDefinition, err := tagDefinitionAuditRecord(priorTag)
+	if err != nil {
+		return err
+	}
+	resultingDefinition, err := tagDefinitionAuditRecord(resultingTag)
+	if err != nil {
+		return err
+	}
+	change, err := makeAttachedMetadataChange(priorDefinition, resultingDefinition)
+	if err != nil {
+		return err
+	}
+	delta, deltaDigest, err := makeAttachedMetadataDelta(values.operationID, []audit.Record{change})
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, delta); err != nil {
+		return err
+	}
+	mutationHash := audit.Absent()
+	if len(priorNodes) != 0 {
+		events := make([]audit.Record, len(priorNodes))
+		stateChanges := make([]audit.Record, len(priorNodes))
+		for index := range priorNodes {
+			events[index], err = makeAuditedTagRenameEvent(
+				values, scope.scopeID, uint64(index), priorNodes[index], resultingNodes[index],
+				priorDefinition, resultingDefinition,
+			)
+			if err != nil {
+				return err
+			}
+			stateChanges[index], err = makeAuditMemberStateChange(
+				priorNodes[index], resultingNodes[index],
+			)
+			if err != nil {
+				return err
+			}
+		}
+		mutation, err := makeAuditedMemberStatesMutation(values, sequence, events, stateChanges)
+		if err != nil {
+			return err
+		}
+		mutation, err = replaceAuditRecordField(
+			mutation, auditAttachedMetadataChangeCountField, audit.Unsigned(1),
+		)
+		if err != nil {
+			return err
+		}
+		mutation, err = replaceAuditRecordField(
+			mutation, "attached_metadata_change_digest", deltaDigest.value,
+		)
+		if err != nil {
+			return err
+		}
+		mutationDigest, err := hashAuditRecord(mutation)
+		if err != nil {
+			return err
+		}
+		for _, event := range events {
+			if err := insertAuditRecord(ctx, tx, audit.Record{Kind: auditEventField, Fields: []audit.Field{
+				{Name: auditEventField, Value: audit.Nested(event)},
+			}}); err != nil {
+				return err
+			}
+		}
+		if err := insertAuditRecord(ctx, tx, mutation); err != nil {
+			return err
+		}
+		if err := advanceAuditedMutationScopes(
+			ctx, tx, values, []auditScopeState{*scope}, mutationDigest.value,
+		); err != nil {
+			return err
+		}
+		mutationHash = mutationDigest.value
+	}
+	allocation, err := makeAuditAllocationEntry(
+		values, sequence, nodeSequence, authority.allocationHead, mutationHash,
+	)
+	if err != nil {
+		return err
+	}
+	allocation, err = addAttachedMetadataToAllocation(allocation, 1, deltaDigest.value)
+	if err != nil {
+		return err
+	}
+	return advanceAuditAuthority(ctx, tx, authority, sequence, allocation)
+}
+
+func makeAuditedTagRenameEvent(
+	values auditedMutationValues, scopeID string, ordinal uint64,
+	priorNode, resultingNode Node, priorDefinition, resultingDefinition audit.Record,
+) (audit.Record, error) {
+	if priorNode.ID != resultingNode.ID {
+		return audit.Record{}, errors.New("audited tag rename changes node identity")
+	}
+	nodeID, err := positiveAuditNodeID(priorNode.ID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	priorRevision, err := positiveAuditRevision(priorNode.Revision)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	resultingRevision, err := positiveAuditRevision(resultingNode.Revision)
+	if err != nil || resultingRevision != priorRevision+1 {
+		return audit.Record{}, errors.New("audited tag rename has an invalid revision transition")
+	}
+	scopeValue, err := audit.UUID(scopeID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	identity, err := attachedAuditIdentity(priorDefinition)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	eventIdentity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+	}})
+	if err != nil {
+		return audit.Record{}, err
+	}
+	kind, err := audit.Text("tag_rename")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	attachmentKind, err := audit.Text("tag_definition")
+	if err != nil {
+		return audit.Record{}, err
+	}
+	priorVersion, err := auditNodeCurrentVersion(priorNode)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	resultingVersion, err := auditNodeCurrentVersion(resultingNode)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	return audit.Record{Kind: "audit_event", Fields: []audit.Field{
+		{Name: "event_id", Value: eventIdentity.value},
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "event_kind", Value: kind},
+		{Name: auditScopeIDField, Value: scopeValue},
+		{Name: auditTargetNodeIDField, Value: audit.Absent()},
+		{Name: "attachment_kind", Value: attachmentKind},
+		{Name: "attachment_identity", Value: audit.Nested(identity)},
+		{Name: "source_version_id", Value: audit.Absent()},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
+		{Name: "prior_node_revision", Value: audit.Unsigned(priorRevision)},
+		{Name: "resulting_node_revision", Value: audit.Unsigned(resultingRevision)},
+		{Name: "prior_current_version_id", Value: priorVersion},
+		{Name: "resulting_current_version_id", Value: resultingVersion},
+		{Name: auditOriginField, Value: values.origin},
+		{Name: auditAgentLabelField, Value: audit.Absent()},
+		{Name: auditPreField, Value: audit.Nested(priorDefinition)},
+		{Name: auditPostField, Value: audit.Nested(resultingDefinition)},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
+		{Name: "baseline_digest", Value: audit.Absent()},
+	}}, nil
+}

--- a/internal/store/audit_tag_rename_test.go
+++ b/internal/store/audit_tag_rename_test.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedTagRenameRoundTripsAssignedDefinition(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	assigned, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+
+	renamed, err := s.RenameTag(t.Context(), tag.ID, assigned.Tag.Revision, "needs review")
+	require.NoError(t, err)
+	assert.Equal(t, "needs review", renamed.Name)
+	assert.Equal(t, assigned.Tag.Revision+1, renamed.Revision)
+	current, err := s.NodeByID(t.Context(), report.ID)
+	require.NoError(t, err)
+	assert.Equal(t, assigned.Node.Revision+1, current.Revision)
+	assert.Equal(t, "tag_rename", auditEventKindForSequence(t, s, 3))
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	assertAuditMetadataRoundTrip(t, s)
+}
+
+func TestAuditedTagRenameWithoutAuditedAssignmentsAdvancesOnlyAllocation(t *testing.T) {
+	s, tag, _ := newAuditedTagStore(t)
+	renamed, err := s.RenameTag(t.Context(), tag.ID, tag.Revision, "renamed")
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", renamed.Name)
+
+	var sequence, allocations, scopeEntries, mutations, deltas int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT allocation_entry_count FROM audit_authority),
+		(SELECT entry_count FROM audit_scopes),
+		(SELECT COUNT(*) FROM audit_records WHERE kind='canonical_mutation'),
+		(SELECT COUNT(*) FROM audit_records WHERE kind='attached_metadata_delta')`,
+	).Scan(&sequence, &allocations, &scopeEntries, &mutations, &deltas))
+	assert.Equal(t, int64(2), sequence)
+	assert.Equal(t, int64(2), allocations)
+	assert.Equal(t, int64(1), scopeEntries)
+	assert.Equal(t, int64(1), mutations)
+	assert.Equal(t, int64(1), deltas)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assertAuditMetadataRoundTrip(t, s)
+}
+
+func TestAuditedTagRenamePreservesUnscopedTopology(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	tag, err := s.CreateTag(t.Context(), "reviewed")
+	require.NoError(t, err)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	assigned, err := s.AssignTag(t.Context(), tag.ID, empty.ID, empty.Revision)
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+
+	_, err = s.RenameTag(t.Context(), tag.ID, assigned.Tag.Revision, "renamed")
+	require.NoError(t, err)
+	current, err := s.NodeByID(t.Context(), empty.ID)
+	require.NoError(t, err)
+	assert.Equal(t, assigned.Node.Revision+1, current.Revision)
+	assert.Equal(t, assigned.Node.ModifiedAt, current.ModifiedAt)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assertAuditMetadataRoundTrip(t, s)
+}
+
+func TestAuditedTagRenameNoOpDoesNotAdvanceHistory(t *testing.T) {
+	s, tag, _ := newAuditedTagStore(t)
+	unchanged, err := s.RenameTag(t.Context(), tag.ID, tag.Revision, tag.Name)
+	require.NoError(t, err)
+	assert.Equal(t, tag, unchanged)
+
+	var sequence int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&sequence))
+	assert.Equal(t, int64(1), sequence)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTagRenameRollsBackDefinitionNodesAndHistory(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	assigned, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_audit_tag_rename_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audit tag rename failure'); END`)
+	require.NoError(t, err)
+
+	_, err = s.RenameTag(t.Context(), tag.ID, assigned.Tag.Revision, "rollback")
+	require.ErrorContains(t, err, "forced audit tag rename failure")
+	currentTag, err := s.TagByID(t.Context(), tag.ID)
+	require.NoError(t, err)
+	assert.Equal(t, assigned.Tag, currentTag)
+	currentNode, err := s.NodeByID(t.Context(), report.ID)
+	require.NoError(t, err)
+	assert.Equal(t, assigned.Node.Revision, currentNode.Revision)
+	var sequence int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&sequence))
+	assert.Equal(t, int64(2), sequence)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTagRenameImportRejectsMismatchedCurrentDefinition(t *testing.T) {
+	s, tag, _ := newAuditedTagStore(t)
+	_, err := s.RenameTag(t.Context(), tag.ID, tag.Revision, "renamed")
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := rewriteMetadataTagName(t, exported.Bytes(), tag.ID, tag.Name)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "replayed audit attachments do not match current metadata")
+	var tagRows, auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM tags),
+		(SELECT COUNT(*) FROM audit_records)`).Scan(&tagRows, &auditRows))
+	assert.Zero(t, tagRows)
+	assert.Zero(t, auditRows)
+}
+
+func TestAuditedTagRenameReplayRejectsOmittedMemberEffect(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	assigned, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+	_, err = s.RenameTag(t.Context(), tag.ID, assigned.Tag.Revision, "renamed")
+	require.NoError(t, err)
+
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, scope, initial)
+	require.NoError(t, err)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	allocations, err := auditRecordsBySequence(records["allocation_entry"], authority.sequence)
+	require.NoError(t, err)
+	entries, err := auditScopeRecordsByCount(records["scope_chain_entry"], scope)
+	require.NoError(t, err)
+	deltas := auditRecordsByDigest(records["attached_metadata_delta"])
+	events, err := auditEventRecordsByID(records[auditEventField])
+	require.NoError(t, err)
+	usedDeltas, usedEvents := map[string]bool{}, map[string]bool{}
+	require.NoError(t, replay.applyTagAssignment(
+		s.vaultID, mutations[2], allocations[2], entries[2],
+		deltas, events, usedDeltas, usedEvents,
+	))
+	malformed := mutations[3]
+	malformed.record = mustReplaceAuditRecordField(
+		t, malformed.record, "events", audit.List(),
+	)
+
+	err = replay.applyTagDefinitionRename(
+		s.vaultID, malformed, allocations[3], entries[3],
+		deltas, events, usedDeltas, usedEvents,
+	)
+	require.ErrorContains(t, err, "event set does not match assigned audited nodes")
+}
+
+func assertAuditMetadataRoundTrip(t *testing.T, s *Store) {
+	t.Helper()
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+}
+
+func rewriteMetadataTagName(t *testing.T, input []byte, tagID, name string) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	found := false
+	for index, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type != "tag" {
+			continue
+		}
+		var definition metadataTag
+		require.NoError(t, json.Unmarshal(line, &definition))
+		if definition.ID != tagID {
+			continue
+		}
+		definition.Name = name
+		encoded, err := json.Marshal(definition)
+		require.NoError(t, err)
+		lines[index] = encoded
+		found = true
+	}
+	require.True(t, found)
+	return append(bytes.Join(lines, []byte{'\n'}), '\n')
+}

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -180,7 +180,7 @@ func (s *Store) RenameTag(ctx context.Context, id string, ifRev int64, name stri
 		return Tag{}, err
 	}
 	var renamed Tag
-	err = s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		current, err := tagByIDTx(tx, id)
 		if err != nil {
 			return err
@@ -192,25 +192,48 @@ func (s *Store) RenameTag(ctx context.Context, id string, ifRev int64, name stri
 			renamed = current
 			return nil
 		}
-		if _, err := tx.Exec(
-			`UPDATE tags SET name = ?, revision = revision + 1 WHERE id = ?`, name, id,
-		); err != nil {
-			if s.driver.IsUniqueViolation(err) {
-				return fmt.Errorf("tag %q: %w", name, ErrExists)
-			}
-			return fmt.Errorf("renaming tag %s: %w", id, err)
-		}
-		if err := touchTaggedNodesTx(tx, id, nowRFC3339()); err != nil {
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
 			return err
 		}
-		renamed = current
-		renamed.Name = name
-		renamed.Revision++
-		return nil
+		if active {
+			renamed, err = s.renameAuditedTagTx(ctx, tx, current, name)
+			return err
+		}
+		renamed, err = s.renameTagTx(tx, current, name, nowRFC3339())
+		return err
 	})
 	if err != nil {
 		return Tag{}, err
 	}
+	return renamed, nil
+}
+
+func (s *Store) renameTagTx(
+	tx *sql.Tx, current Tag, name, recordedAt string,
+) (Tag, error) {
+	renamed, err := s.renameTagDefinitionTx(tx, current, name)
+	if err != nil {
+		return Tag{}, err
+	}
+	if err := touchTaggedNodesTx(tx, current.ID, recordedAt); err != nil {
+		return Tag{}, err
+	}
+	return renamed, nil
+}
+
+func (s *Store) renameTagDefinitionTx(tx *sql.Tx, current Tag, name string) (Tag, error) {
+	if _, err := tx.Exec(
+		`UPDATE tags SET name = ?, revision = revision + 1 WHERE id = ?`, name, current.ID,
+	); err != nil {
+		if s.driver.IsUniqueViolation(err) {
+			return Tag{}, fmt.Errorf("tag %q: %w", name, ErrExists)
+		}
+		return Tag{}, fmt.Errorf("renaming tag %s: %w", current.ID, err)
+	}
+	renamed := current
+	renamed.Name = name
+	renamed.Revision++
 	return renamed, nil
 }
 


### PR DESCRIPTION
Once a folder is under full audit, people should still be able to rename the tags they use to organize it. Until now, `docbank tag rename` was refused after audit activation even though the tag identity and all of its assignments remain unchanged.

This makes rename work as one atomic operation. Every protected document carrying the tag receives a `tag_rename` history entry and a new concurrency revision, so its timeline explains the metadata change. A tag that is unused—or used only outside the protected scope—still records its old and new definition in the vault lineage, but does not fabricate document history or enroll unrelated files. If the history cannot be recorded, the rename and node revisions roll back together.

Backup restore and JSONL import independently start from the pre-rename assignment set, derive exactly which protected documents should have been affected, and reject missing or extra events, reused identities, impossible intermediate name conflicts, or a final tag table that disagrees with replay. They do not trust the writer’s stored fan-out.

The boundary remains deliberately narrow. Cascading tag deletion is still blocked and will be handled separately because it removes both the definition and every assignment. This change adds no schema or SQL policy; the fan-out and replay rules remain ordinary Go code.

The repository’s full local verification is green.

Kata: 19p1.