### PR TITLE
Record audited tag deletion

### DIFF
--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -244,22 +244,23 @@ func validateInitialAuditMemberProjection(
 }
 
 type auditedHistoryReplay struct {
-	scopeID         string
-	lineageID       string
-	members         []uint64
-	memberSet       map[uint64]bool
-	states          map[uint64]audit.Record
-	versions        map[string]audit.Record
-	attachments     map[string]audit.Record
-	topology        []audit.Record
-	topologyIndex   map[uint64]int
-	scopeHead       string
-	scopeEntryCount int64
-	allocationHead  string
-	allocationCount int64
-	nodeHighWater   uint64
-	baselines       map[string]auditBaselineProjection
-	memberBaselines map[uint64]string
+	scopeID          string
+	lineageID        string
+	members          []uint64
+	memberSet        map[uint64]bool
+	states           map[uint64]audit.Record
+	versions         map[string]audit.Record
+	attachments      map[string]audit.Record
+	tagDefinitionIDs map[string]bool
+	topology         []audit.Record
+	topologyIndex    map[uint64]int
+	scopeHead        string
+	scopeEntryCount  int64
+	allocationHead   string
+	allocationCount  int64
+	nodeHighWater    uint64
+	baselines        map[string]auditBaselineProjection
+	memberBaselines  map[uint64]string
 }
 
 type auditBaselineProjection struct {
@@ -337,11 +338,16 @@ func validateAuditedHistory(
 			if attachedErr != nil {
 				err = attachedErr
 			} else if attachedCount != 0 {
-				kind, kindErr := attachedMutationRecordKind(mutation.record, attachmentDeltas)
+				kind, kindErr := attachedMutationKind(mutation.record, attachmentDeltas)
 				if kindErr != nil {
 					err = kindErr
-				} else if kind == "tag_definition" {
+				} else if kind == "tag_rename" {
 					err = replay.applyTagDefinitionRename(
+						vaultID, mutation, allocation, scopeEntry,
+						attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
+					)
+				} else if kind == "tag_delete" {
+					err = replay.applyTagDefinitionDelete(
 						vaultID, mutation, allocation, scopeEntry,
 						attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
 					)
@@ -544,20 +550,21 @@ func newAuditedHistoryReplay(
 	}
 	initialBaseline := initial["enrollment_baseline"][0]
 	replay := &auditedHistoryReplay{
-		scopeID:         scope.scopeID,
-		lineageID:       authority.lineageID,
-		members:         members,
-		memberSet:       auditMemberSet(members),
-		states:          make(map[uint64]audit.Record, len(states)),
-		versions:        make(map[string]audit.Record, len(versions)),
-		attachments:     make(map[string]audit.Record, len(attachments)),
-		topology:        slices.Clone(topology),
-		topologyIndex:   make(map[uint64]int, len(topology)),
-		scopeHead:       initial["scope_chain_entry"][0].digest,
-		scopeEntryCount: 1,
-		allocationHead:  initial["allocation_entry"][0].digest,
-		allocationCount: 1,
-		nodeHighWater:   nodeHighWater,
+		scopeID:          scope.scopeID,
+		lineageID:        authority.lineageID,
+		members:          members,
+		memberSet:        auditMemberSet(members),
+		states:           make(map[uint64]audit.Record, len(states)),
+		versions:         make(map[string]audit.Record, len(versions)),
+		attachments:      make(map[string]audit.Record, len(attachments)),
+		tagDefinitionIDs: make(map[string]bool),
+		topology:         slices.Clone(topology),
+		topologyIndex:    make(map[uint64]int, len(topology)),
+		scopeHead:        initial["scope_chain_entry"][0].digest,
+		scopeEntryCount:  1,
+		allocationHead:   initial["allocation_entry"][0].digest,
+		allocationCount:  1,
+		nodeHighWater:    nodeHighWater,
 		baselines: map[string]auditBaselineProjection{
 			initialBaseline.digest: {
 				scopeID: scope.scopeID, operationID: scope.operationID,
@@ -592,6 +599,13 @@ func newAuditedHistoryReplay(
 			return nil, errors.New("audit attachment genesis repeats an identity")
 		}
 		replay.attachments[key] = attachment
+		if attachment.Kind == "tag_definition" {
+			tagID, err := auditUUIDField(attachment, "tag_id")
+			if err != nil {
+				return nil, err
+			}
+			replay.tagDefinitionIDs[tagID] = true
+		}
 	}
 	for index, node := range topology {
 		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
@@ -749,7 +763,7 @@ func (replay *auditedHistoryReplay) applyContentTransition(
 		return err
 	}
 	if err := replay.advanceAllocation(
-		vaultID, operationID, mutation, allocation, "",
+		vaultID, operationID, mutation, allocation, "", 0,
 	); err != nil {
 		return err
 	}
@@ -1013,7 +1027,7 @@ func (replay *auditedHistoryReplay) advanceScope(
 
 func (replay *auditedHistoryReplay) advanceAllocation(
 	vaultID string, operationID string,
-	mutation, entry storedAuditRecord, attachedDigest string,
+	mutation, entry storedAuditRecord, attachedDigest string, attachedCount uint64,
 ) error {
 	nextCount, err := replay.validateAllocationBase(vaultID, operationID, entry)
 	if err != nil {
@@ -1042,11 +1056,14 @@ func (replay *auditedHistoryReplay) advanceAllocation(
 			return err
 		}
 	} else {
+		if attachedCount == 0 {
+			return errors.New("audit allocation has a digest without attached-metadata changes")
+		}
 		if err := requireAuditBool(entry.record, "has_attached_metadata_change", true); err != nil {
 			return err
 		}
 		if err := requireAuditUnsigned(
-			entry.record, auditAttachedMetadataChangeCountField, 1,
+			entry.record, auditAttachedMetadataChangeCountField, attachedCount,
 		); err != nil {
 			return err
 		}

--- a/internal/store/audit_ingest.go
+++ b/internal/store/audit_ingest.go
@@ -1,9 +1,11 @@
 package store
 
 import (
+	"bytes"
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.kenn.io/docbank/internal/audit"
 )
@@ -81,6 +83,40 @@ func makeAuditedIngestCreationMetadata(
 func makeAttachedMetadataDelta(
 	operationID audit.Value, changes []audit.Record,
 ) (audit.Record, auditRecordHash, error) {
+	type keyedChange struct {
+		record   audit.Record
+		kind     string
+		identity []byte
+	}
+	items := make([]keyedChange, len(changes))
+	for index, change := range changes {
+		kind, err := auditTextField(change, "record_kind")
+		if err != nil {
+			return audit.Record{}, auditRecordHash{}, err
+		}
+		identity, err := auditNestedField(change, "stable_identity")
+		if err != nil {
+			return audit.Record{}, auditRecordHash{}, err
+		}
+		encoded, err := audit.Encode(identity)
+		if err != nil {
+			return audit.Record{}, auditRecordHash{}, err
+		}
+		items[index] = keyedChange{record: change, kind: kind, identity: encoded}
+	}
+	slices.SortFunc(items, func(left, right keyedChange) int {
+		if left.kind < right.kind {
+			return -1
+		}
+		if left.kind > right.kind {
+			return 1
+		}
+		return bytes.Compare(left.identity, right.identity)
+	})
+	changes = make([]audit.Record, len(items))
+	for index := range items {
+		changes[index] = items[index].record
+	}
 	delta := audit.Record{Kind: "attached_metadata_delta", Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: operationID},
 		{Name: "changes", Value: audit.List(auditNestedValues(changes)...)},

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -15,13 +15,17 @@ import (
 )
 
 const (
-	auditAgentLabelField   = "agent_label"
-	auditEventOrdinalField = "event_ordinal"
-	auditParentIDField     = "parent_id"
-	auditPostField         = "post"
-	auditPreField          = "pre"
-	auditRecordedAtField   = "recorded_at"
-	auditTargetNodeIDField = "target_node_id"
+	auditAgentLabelField      = "agent_label"
+	auditBaselineDigestField  = "baseline_digest"
+	auditEventIdentityKind    = "event_identity"
+	auditEventOrdinalField    = "event_ordinal"
+	auditParentIDField        = "parent_id"
+	auditPostField            = "post"
+	auditPreField             = "pre"
+	auditRecordedAtField      = "recorded_at"
+	auditSourceVersionIDField = "source_version_id"
+	auditTagDefinitionKind    = "tag_definition"
+	auditTargetNodeIDField    = "target_node_id"
 )
 
 var auditRecordKinds = map[string]bool{

--- a/internal/store/audit_tag_assignment_validate.go
+++ b/internal/store/audit_tag_assignment_validate.go
@@ -88,7 +88,7 @@ func (replay *auditedHistoryReplay) applyTagAssignment(
 		return err
 	}
 	if err := replay.advanceAllocation(
-		vaultID, operationID, mutation, allocation, transition.digest,
+		vaultID, operationID, mutation, allocation, transition.digest, 1,
 	); err != nil {
 		return err
 	}

--- a/internal/store/audit_tag_definition_validate.go
+++ b/internal/store/audit_tag_definition_validate.go
@@ -23,7 +23,7 @@ type replayedTagDefinitionChange struct {
 	candidates []uint64
 }
 
-func attachedMutationRecordKind(
+func attachedMutationKind(
 	mutation audit.Record, deltaRecords map[string]storedAuditRecord,
 ) (string, error) {
 	digest, err := auditDigestField(mutation, "attached_metadata_change_digest")
@@ -38,10 +38,38 @@ func attachedMutationRecordKind(
 	if err != nil {
 		return "", err
 	}
-	if len(changes) != 1 {
-		return "", errors.New("attached-metadata mutation must contain exactly one change")
+	if len(changes) == 0 {
+		return "", errors.New("attached-metadata mutation has no changes")
 	}
-	return auditTextField(changes[0], "record_kind")
+	for _, change := range changes {
+		kind, err := auditTextField(change, "record_kind")
+		if err != nil {
+			return "", err
+		}
+		if kind != "tag_definition" {
+			continue
+		}
+		_, hasPre, err := optionalNestedAuditRecord(change, auditPreField)
+		if err != nil {
+			return "", err
+		}
+		_, hasPost, err := optionalNestedAuditRecord(change, auditPostField)
+		if err != nil {
+			return "", err
+		}
+		switch {
+		case hasPre && !hasPost:
+			return "tag_delete", nil
+		case hasPre && hasPost:
+			return "tag_rename", nil
+		default:
+			return "", errors.New("audited tag definition has an unsupported transition")
+		}
+	}
+	if len(changes) == 1 {
+		return auditTextField(changes[0], "record_kind")
+	}
+	return "", errors.New("attached-metadata mutation has unsupported mixed changes")
 }
 
 func (replay *auditedHistoryReplay) applyUnscopedTagDefinitionChange(
@@ -67,13 +95,38 @@ func (replay *auditedHistoryReplay) applyUnscopedTagDefinitionChange(
 	); err != nil {
 		return err
 	}
+	digest, err := auditDigestField(allocation.record, "attached_metadata_change_digest")
+	if err != nil {
+		return err
+	}
+	deletion, err := attachedDeltaContainsTagDelete(digest, deltaRecords)
+	if err != nil {
+		return err
+	}
+	if deletion {
+		transition, err := replay.validateTagDeletionDelta(
+			operationID, digest, deltaRecords, usedDeltas,
+		)
+		if err != nil {
+			return err
+		}
+		if len(transition.candidates) != 0 {
+			return errors.New("tag deletion omits required audited effects")
+		}
+		if err := requireAuditUnsigned(
+			allocation.record, auditAttachedMetadataChangeCountField, transition.changeCount,
+		); err != nil {
+			return err
+		}
+		if err := replay.applyTagDeletionState(transition, nil); err != nil {
+			return err
+		}
+		replay.allocationCount, replay.allocationHead = nextCount, allocation.digest
+		return nil
+	}
 	if err := requireAuditUnsigned(
 		allocation.record, auditAttachedMetadataChangeCountField, 1,
 	); err != nil {
-		return err
-	}
-	digest, err := auditDigestField(allocation.record, "attached_metadata_change_digest")
-	if err != nil {
 		return err
 	}
 	transition, err := replay.validateTagDefinitionDelta(
@@ -171,7 +224,7 @@ func (replay *auditedHistoryReplay) validateTagDefinitionDelta(
 	}
 	current, exists := replay.attachments[key]
 	if transition.kind == tagDefinitionCreate {
-		if exists {
+		if replay.tagDefinitionIDs[transition.tagID] {
 			return replayedTagDefinitionChange{}, fmt.Errorf(
 				"tag creation reuses definition identity %s", transition.tagID,
 			)
@@ -360,7 +413,7 @@ func (replay *auditedHistoryReplay) applyTagDefinitionRename(
 		return err
 	}
 	if err := replay.advanceAllocation(
-		vaultID, operationID, mutation, allocation, transition.digest,
+		vaultID, operationID, mutation, allocation, transition.digest, 1,
 	); err != nil {
 		return err
 	}
@@ -450,7 +503,14 @@ func (replay *auditedHistoryReplay) applyTagDefinitionState(
 		return err
 	}
 	replay.attachments[key] = record
-	if len(transition.candidates) == 0 {
+	replay.tagDefinitionIDs[transition.tagID] = true
+	return replay.applyTagAffectedNodeState(transition.candidates, mutation)
+}
+
+func (replay *auditedHistoryReplay) applyTagAffectedNodeState(
+	candidates []uint64, mutation *audit.Record,
+) error {
+	if len(candidates) == 0 {
 		return nil
 	}
 	if mutation == nil {
@@ -460,7 +520,7 @@ func (replay *auditedHistoryReplay) applyTagDefinitionState(
 	if err != nil {
 		return err
 	}
-	for _, nodeID := range transition.candidates {
+	for _, nodeID := range candidates {
 		state := replay.states[nodeID]
 		revision, err := auditUnsignedField(state, "node_revision")
 		if err != nil {

--- a/internal/store/audit_tag_delete.go
+++ b/internal/store/audit_tag_delete.go
@@ -9,9 +9,13 @@ import (
 	"go.kenn.io/docbank/internal/audit"
 )
 
-func (s *Store) renameAuditedTagTx(
-	ctx context.Context, tx *sql.Tx, current Tag, name string,
+func (s *Store) deleteAuditedTagTx(
+	ctx context.Context, tx *sql.Tx, current Tag,
 ) (Tag, error) {
+	assignmentNodeIDs, err := tagAssignmentNodeIDsTx(ctx, tx, current.ID)
+	if err != nil {
+		return Tag{}, err
+	}
 	priorNodes, scope, err := auditedTaggedNodesTx(ctx, tx, current.ID)
 	if err != nil {
 		return Tag{}, err
@@ -22,14 +26,15 @@ func (s *Store) renameAuditedTagTx(
 	}
 	operationID, err := newUUIDv4()
 	if err != nil {
-		return Tag{}, fmt.Errorf("allocating audited tag-rename operation: %w", err)
+		return Tag{}, fmt.Errorf("allocating audited tag-delete operation: %w", err)
 	}
 	recordedAt := nowRFC3339()
-	renamed, err := s.renameTagDefinitionTx(tx, current, name)
-	if err != nil {
+	if err := touchAuditedTagDefinitionNodesTx(
+		tx, current.ID, priorNodes, recordedAt,
+	); err != nil {
 		return Tag{}, err
 	}
-	if err := touchAuditedTagDefinitionNodesTx(tx, current.ID, priorNodes, recordedAt); err != nil {
+	if err := deleteTagDefinitionTx(tx, current.ID); err != nil {
 		return Tag{}, err
 	}
 	resultingNodes := make([]Node, len(priorNodes))
@@ -39,96 +44,46 @@ func (s *Store) renameAuditedTagTx(
 			return Tag{}, err
 		}
 	}
-	if err := persistAuditedTagRename(
+	if err := persistAuditedTagDelete(
 		ctx, tx, s.vaultID, operationID, recordedAt, nodeSequence,
-		authority, scope, current, renamed, priorNodes, resultingNodes,
+		authority, scope, current, assignmentNodeIDs, priorNodes, resultingNodes,
 	); err != nil {
 		return Tag{}, err
 	}
-	return renamed, nil
+	return current, nil
 }
 
-func touchAuditedTagDefinitionNodesTx(
-	tx *sql.Tx, tagID string, audited []Node, recordedAt string,
-) error {
-	// Revisions cover every assigned node. modified_at is changed only where the
-	// scoped mutation commits the operation timestamp; the allocation-only form
-	// deliberately has no timestamp from which replay could derive that field.
-	if _, err := tx.Exec(`UPDATE nodes SET revision=revision+1
-		WHERE id IN (SELECT node_id FROM node_tags WHERE tag_id=?)`, tagID); err != nil {
-		return fmt.Errorf("advancing nodes assigned tag %s: %w", tagID, err)
-	}
-	for _, node := range audited {
-		if _, err := tx.Exec(
-			`UPDATE nodes SET modified_at=? WHERE id=?`, recordedAt, node.ID,
-		); err != nil {
-			return fmt.Errorf("recording audited tag rename on node %d: %w", node.ID, err)
-		}
-	}
-	return nil
-}
-
-func auditedTaggedNodesTx(
+func tagAssignmentNodeIDsTx(
 	ctx context.Context, tx *sql.Tx, tagID string,
-) ([]Node, *auditScopeState, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT membership.node_id,scope.scope_id,
-		scope.entry_count,scope.chain_head
-		FROM node_tags assignment
-		JOIN audit_memberships membership ON membership.node_id=assignment.node_id
-		JOIN audit_scopes scope ON scope.scope_id=membership.scope_id
-		WHERE assignment.tag_id=? ORDER BY membership.node_id,scope.scope_id`, tagID)
+) ([]int64, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT node_id FROM node_tags WHERE tag_id=? ORDER BY node_id`, tagID,
+	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("listing audited nodes assigned tag %s: %w", tagID, err)
+		return nil, fmt.Errorf("listing assignments for tag %s: %w", tagID, err)
 	}
 	defer func() { _ = rows.Close() }()
-	var (
-		nodeIDs []int64
-		scope   *auditScopeState
-	)
+	var nodeIDs []int64
 	for rows.Next() {
 		var nodeID int64
-		var current auditScopeState
-		if err := rows.Scan(
-			&nodeID, &current.scopeID, &current.entryCount, &current.chainHead,
-		); err != nil {
-			_ = rows.Close()
-			return nil, nil, fmt.Errorf("scanning audited tag assignment: %w", err)
+		if err := rows.Scan(&nodeID); err != nil {
+			return nil, fmt.Errorf("scanning tag %s assignment: %w", tagID, err)
 		}
-		if scope != nil && scope.scopeID != current.scopeID {
-			_ = rows.Close()
-			return nil, nil, errors.New("tag rename across multiple audit scopes is not supported")
-		}
-		if scope == nil {
-			scope = &current
-		}
-		if len(nodeIDs) == 0 || nodeIDs[len(nodeIDs)-1] != nodeID {
-			nodeIDs = append(nodeIDs, nodeID)
-		}
+		nodeIDs = append(nodeIDs, nodeID)
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, nil, fmt.Errorf("listing audited nodes assigned tag %s: %w", tagID, err)
+		return nil, fmt.Errorf("listing assignments for tag %s: %w", tagID, err)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, nil, fmt.Errorf("closing audited tag assignment rows: %w", err)
-	}
-	nodes := make([]Node, len(nodeIDs))
-	for index, nodeID := range nodeIDs {
-		nodes[index], err = nodeByIDTx(tx, nodeID)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	return nodes, scope, nil
+	return nodeIDs, nil
 }
 
-func persistAuditedTagRename(
+func persistAuditedTagDelete(
 	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
 	nodeSequence int64, authority auditAuthorityState, scope *auditScopeState,
-	priorTag, resultingTag Tag, priorNodes, resultingNodes []Node,
+	deletedTag Tag, assignmentNodeIDs []int64, priorNodes, resultingNodes []Node,
 ) error {
 	if len(priorNodes) != len(resultingNodes) || (len(priorNodes) != 0) != (scope != nil) {
-		return errors.New("audited tag rename has inconsistent affected-node authority")
+		return errors.New("audited tag delete has inconsistent affected-node authority")
 	}
 	sequence, err := nextAuditInteger("operation sequence", authority.sequence)
 	if err != nil {
@@ -138,37 +93,64 @@ func persistAuditedTagRename(
 	if err != nil {
 		return err
 	}
-	priorDefinition, err := tagDefinitionAuditRecord(priorTag)
+	definition, err := tagDefinitionAuditRecord(deletedTag)
 	if err != nil {
 		return err
 	}
-	resultingDefinition, err := tagDefinitionAuditRecord(resultingTag)
+	definitionChange, err := makeAttachedMetadataPresenceChange(definition, false)
 	if err != nil {
 		return err
 	}
-	change, err := makeAttachedMetadataChange(priorDefinition, resultingDefinition)
-	if err != nil {
-		return err
+	changes := make([]audit.Record, 0, len(assignmentNodeIDs)+1)
+	assignments := make(map[int64]audit.Record, len(assignmentNodeIDs))
+	for _, nodeID := range assignmentNodeIDs {
+		assignment, err := auditTagAssignmentRecord(deletedTag.ID, nodeID)
+		if err != nil {
+			return err
+		}
+		change, err := makeAttachedMetadataPresenceChange(assignment, false)
+		if err != nil {
+			return err
+		}
+		assignments[nodeID] = assignment
+		changes = append(changes, change)
 	}
-	delta, deltaDigest, err := makeAttachedMetadataDelta(values.operationID, []audit.Record{change})
+	changes = append(changes, definitionChange)
+	delta, deltaDigest, err := makeAttachedMetadataDelta(values.operationID, changes)
 	if err != nil {
 		return err
 	}
 	if err := insertAuditRecord(ctx, tx, delta); err != nil {
 		return err
 	}
+	changeCount := uint64(1)
+	for range assignmentNodeIDs {
+		changeCount++
+	}
 	mutationHash := audit.Absent()
 	if len(priorNodes) != 0 {
-		events := make([]audit.Record, len(priorNodes))
+		events := make([]audit.Record, 0, len(priorNodes)*2)
 		stateChanges := make([]audit.Record, len(priorNodes))
+		ordinal := uint64(0)
 		for index := range priorNodes {
-			events[index], err = makeAuditedTagRenameEvent(
-				values, scope.scopeID, uint64(index), priorNodes[index], resultingNodes[index],
-				priorDefinition, resultingDefinition,
+			definitionEvent, err := makeAuditedTagDeleteEvent(
+				values, scope.scopeID, ordinal, priorNodes[index], resultingNodes[index], definition,
 			)
 			if err != nil {
 				return err
 			}
+			events = append(events, definitionEvent)
+			ordinal++
+			assignment := assignments[priorNodes[index].ID]
+			unassignEvent, err := makeAuditedTagAssignmentEvent(
+				values, scope.scopeID, ordinal, priorNodes[index], resultingNodes[index],
+				assignment, false,
+			)
+			if err != nil {
+				return err
+			}
+			events = append(events, unassignEvent)
+			ordinal++
 			stateChanges[index], err = makeAuditMemberStateChange(
 				priorNodes[index], resultingNodes[index],
 			)
@@ -181,7 +163,7 @@ func persistAuditedTagRename(
 			return err
 		}
 		mutation, err = replaceAuditRecordField(
-			mutation, auditAttachedMetadataChangeCountField, audit.Unsigned(1),
+			mutation, auditAttachedMetadataChangeCountField, audit.Unsigned(changeCount),
 		)
 		if err != nil {
 			return err
@@ -219,19 +201,21 @@ func persistAuditedTagRename(
 	if err != nil {
 		return err
 	}
-	allocation, err = addAttachedMetadataToAllocation(allocation, 1, deltaDigest.value)
+	allocation, err = addAttachedMetadataToAllocation(
+		allocation, changeCount, deltaDigest.value,
+	)
 	if err != nil {
 		return err
 	}
 	return advanceAuditAuthority(ctx, tx, authority, sequence, allocation)
 }
 
-func makeAuditedTagRenameEvent(
+func makeAuditedTagDeleteEvent(
 	values auditedMutationValues, scopeID string, ordinal uint64,
-	priorNode, resultingNode Node, priorDefinition, resultingDefinition audit.Record,
+	priorNode, resultingNode Node, definition audit.Record,
 ) (audit.Record, error) {
 	if priorNode.ID != resultingNode.ID {
-		return audit.Record{}, errors.New("audited tag rename changes node identity")
+		return audit.Record{}, errors.New("audited tag delete changes node identity")
 	}
 	nodeID, err := positiveAuditNodeID(priorNode.ID)
 	if err != nil {
@@ -243,28 +227,28 @@ func makeAuditedTagRenameEvent(
 	}
 	resultingRevision, err := positiveAuditRevision(resultingNode.Revision)
 	if err != nil || resultingRevision != priorRevision+1 {
-		return audit.Record{}, errors.New("audited tag rename has an invalid revision transition")
+		return audit.Record{}, errors.New("audited tag delete has an invalid revision transition")
 	}
 	scopeValue, err := audit.UUID(scopeID)
 	if err != nil {
 		return audit.Record{}, err
 	}
-	identity, err := attachedAuditIdentity(priorDefinition)
+	identity, err := attachedAuditIdentity(definition)
 	if err != nil {
 		return audit.Record{}, err
 	}
-	eventIdentity, err := hashAuditRecord(audit.Record{Kind: "event_identity", Fields: []audit.Field{
+	eventIdentity, err := hashAuditRecord(audit.Record{Kind: auditEventIdentityKind, Fields: []audit.Field{
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
 	}})
 	if err != nil {
 		return audit.Record{}, err
 	}
-	kind, err := audit.Text("tag_rename")
+	kind, err := audit.Text("tag_delete")
 	if err != nil {
 		return audit.Record{}, err
 	}
-	attachmentKind, err := audit.Text("tag_definition")
+	attachmentKind, err := audit.Text(auditTagDefinitionKind)
 	if err != nil {
 		return audit.Record{}, err
 	}
@@ -285,7 +269,7 @@ func makeAuditedTagRenameEvent(
 		{Name: auditTargetNodeIDField, Value: audit.Absent()},
 		{Name: "attachment_kind", Value: attachmentKind},
 		{Name: "attachment_identity", Value: audit.Nested(identity)},
-		{Name: "source_version_id", Value: audit.Absent()},
+		{Name: auditSourceVersionIDField, Value: audit.Absent()},
 		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
 		{Name: auditRecordedAtField, Value: values.recordedAt},
 		{Name: "prior_node_revision", Value: audit.Unsigned(priorRevision)},
@@ -294,9 +278,9 @@ func makeAuditedTagRenameEvent(
 		{Name: "resulting_current_version_id", Value: resultingVersion},
 		{Name: auditOriginField, Value: values.origin},
 		{Name: auditAgentLabelField, Value: audit.Absent()},
-		{Name: auditPreField, Value: audit.Nested(priorDefinition)},
-		{Name: auditPostField, Value: audit.Nested(resultingDefinition)},
+		{Name: auditPreField, Value: audit.Nested(definition)},
+		{Name: auditPostField, Value: audit.Absent()},
 		{Name: auditTopologyDeltaField, Value: audit.Absent()},
-		{Name: "baseline_digest", Value: audit.Absent()},
+		{Name: auditBaselineDigestField, Value: audit.Absent()},
 	}}, nil
 }

--- a/internal/store/audit_tag_delete_test.go
+++ b/internal/store/audit_tag_delete_test.go
@@ -1,0 +1,288 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedTagDeleteRoundTripsCompleteFanout(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	reportAssignment, err := s.AssignTag(
+		t.Context(), tag.ID, report.ID, report.Revision,
+	)
+	require.NoError(t, err)
+	projectsAssignment, err := s.AssignTag(
+		t.Context(), tag.ID, projects.ID, projects.Revision,
+	)
+	require.NoError(t, err)
+
+	deleted, err := s.DeleteTag(t.Context(), tag.ID, projectsAssignment.Tag.Revision)
+	require.NoError(t, err)
+	assert.Equal(t, 2, deleted.AssignmentCount)
+	_, err = s.TagByID(t.Context(), tag.ID)
+	require.ErrorIs(t, err, ErrNotFound)
+	currentReport, err := s.NodeByID(t.Context(), report.ID)
+	require.NoError(t, err)
+	assert.Equal(t, reportAssignment.Node.Revision+1, currentReport.Revision)
+	currentProjects, err := s.NodeByID(t.Context(), projects.ID)
+	require.NoError(t, err)
+	assert.Equal(t, projectsAssignment.Node.Revision+1, currentProjects.Revision)
+	events := auditEventsForSequence(t, s, 4)
+	require.Len(t, events, 4)
+	assert.Equal(t, []string{
+		"tag_delete", "tag_unassign", "tag_delete", "tag_unassign",
+	}, auditEventKinds(t, events))
+	assert.Equal(t, []uint64{
+		uint64(projects.ID), uint64(projects.ID), uint64(report.ID), uint64(report.ID),
+	}, auditEventNodeIDs(t, events))
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assertAuditMetadataRoundTrip(t, s)
+}
+
+func TestAuditedTagDeleteOutsideScopeAdvancesOnlyAllocation(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	tag, err := s.CreateTag(t.Context(), "reviewed")
+	require.NoError(t, err)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	assigned, err := s.AssignTag(t.Context(), tag.ID, empty.ID, empty.Revision)
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+
+	_, err = s.DeleteTag(t.Context(), tag.ID, assigned.Tag.Revision)
+	require.NoError(t, err)
+	current, err := s.NodeByID(t.Context(), empty.ID)
+	require.NoError(t, err)
+	assert.Equal(t, assigned.Node.Revision+1, current.Revision)
+	assert.Equal(t, assigned.Node.ModifiedAt, current.ModifiedAt)
+	var sequence, scopeEntries, mutations int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT entry_count FROM audit_scopes),
+		(SELECT COUNT(*) FROM audit_records WHERE kind='canonical_mutation')`,
+	).Scan(&sequence, &scopeEntries, &mutations))
+	assert.Equal(t, int64(2), sequence)
+	assert.Equal(t, int64(1), scopeEntries)
+	assert.Equal(t, int64(1), mutations)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	allocations, err := auditRecordsBySequence(records["allocation_entry"], sequence)
+	require.NoError(t, err)
+	changes, err := auditUnsignedField(
+		allocations[2].record, auditAttachedMetadataChangeCountField,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), changes)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assertAuditMetadataRoundTrip(t, s)
+}
+
+func TestAuditedTagDeleteRollsBackDefinitionNodesAndHistory(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	assigned, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`CREATE TRIGGER reject_audit_tag_delete_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audit tag delete failure'); END`)
+	require.NoError(t, err)
+
+	_, err = s.DeleteTag(t.Context(), tag.ID, assigned.Tag.Revision)
+	require.ErrorContains(t, err, "forced audit tag delete failure")
+	currentTag, err := s.TagByID(t.Context(), tag.ID)
+	require.NoError(t, err)
+	assert.Equal(t, assigned.Tag, currentTag)
+	currentNode, err := s.NodeByID(t.Context(), report.ID)
+	require.NoError(t, err)
+	assert.Equal(t, assigned.Node.Revision, currentNode.Revision)
+	var sequence int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&sequence))
+	assert.Equal(t, int64(2), sequence)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedTagDeleteImportRejectsReappearingDefinition(t *testing.T) {
+	s, tag, _ := newAuditedTagStore(t)
+	_, err := s.DeleteTag(t.Context(), tag.ID, tag.Revision)
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := appendMetadataTag(t, exported.Bytes(), tag)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "replayed audit attachments do not match current metadata")
+	var tagRows, auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM tags),
+		(SELECT COUNT(*) FROM audit_records)`).Scan(&tagRows, &auditRows))
+	assert.Zero(t, tagRows)
+	assert.Zero(t, auditRows)
+}
+
+func TestAuditedTagDeleteReplayRejectsOmittedAssignmentTombstone(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	assigned, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+	_, err = s.DeleteTag(t.Context(), tag.ID, assigned.Tag.Revision)
+	require.NoError(t, err)
+	replay, records, authority, scope := loadAuditReplayFixture(t, s)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	allocations, err := auditRecordsBySequence(records["allocation_entry"], authority.sequence)
+	require.NoError(t, err)
+	entries, err := auditScopeRecordsByCount(records["scope_chain_entry"], scope)
+	require.NoError(t, err)
+	deltas := auditRecordsByDigest(records["attached_metadata_delta"])
+	events, err := auditEventRecordsByID(records[auditEventField])
+	require.NoError(t, err)
+	usedDeltas, usedEvents := map[string]bool{}, map[string]bool{}
+	require.NoError(t, replay.applyTagAssignment(
+		s.vaultID, mutations[2], allocations[2], entries[2],
+		deltas, events, usedDeltas, usedEvents,
+	))
+	deleteDigest, err := auditDigestField(
+		mutations[3].record, "attached_metadata_change_digest",
+	)
+	require.NoError(t, err)
+	malformed := deltas[deleteDigest]
+	changes, err := auditRecordListField(malformed.record, "changes")
+	require.NoError(t, err)
+	filtered := changes[:0]
+	for _, change := range changes {
+		kind, err := auditTextField(change, "record_kind")
+		require.NoError(t, err)
+		if kind != "tag_assignment" {
+			filtered = append(filtered, change)
+		}
+	}
+	malformed.record = mustReplaceAuditRecordField(
+		t, malformed.record, "changes", audit.List(auditNestedValues(filtered)...),
+	)
+	deltas[deleteDigest] = malformed
+
+	err = replay.applyTagDefinitionDelete(
+		s.vaultID, mutations[3], allocations[3], entries[3],
+		deltas, events, usedDeltas, usedEvents,
+	)
+	require.ErrorContains(t, err, "complete assignment set")
+}
+
+func TestAuditedTagDeleteReplayRetainsUsedDefinitionIdentity(t *testing.T) {
+	s, tag, _ := newAuditedTagStore(t)
+	_, err := s.DeleteTag(t.Context(), tag.ID, tag.Revision)
+	require.NoError(t, err)
+	replay, records, authority, _ := loadAuditReplayFixture(t, s)
+	allocations, err := auditRecordsBySequence(records["allocation_entry"], authority.sequence)
+	require.NoError(t, err)
+	deltas := auditRecordsByDigest(records["attached_metadata_delta"])
+	require.NoError(t, replay.applyUnscopedTagDefinitionChange(
+		s.vaultID, allocations[2], deltas, map[string]bool{},
+	))
+	reused := tag
+	reused.Name = "reused"
+	definition, err := tagDefinitionAuditRecord(reused)
+	require.NoError(t, err)
+	change, err := makeAttachedMetadataPresenceChange(definition, true)
+	require.NoError(t, err)
+	operationID := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	operationValue, err := audit.UUID(operationID)
+	require.NoError(t, err)
+	delta, digest, err := makeAttachedMetadataDelta(operationValue, []audit.Record{change})
+	require.NoError(t, err)
+
+	_, err = replay.validateTagDefinitionDelta(
+		operationID, digest.text,
+		map[string]storedAuditRecord{digest.text: {digest: digest.text, record: delta}},
+		map[string]bool{},
+	)
+	require.ErrorContains(t, err, "reuses definition identity")
+}
+
+func loadAuditReplayFixture(
+	t *testing.T, s *Store,
+) (*auditedHistoryReplay, map[string][]storedAuditRecord, initialAuditAuthority, initialAuditScope) {
+	t.Helper()
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, scope, initial)
+	require.NoError(t, err)
+	return replay, records, authority, scope
+}
+
+func auditEventsForSequence(t *testing.T, s *Store, sequence int64) []audit.Record {
+	t.Helper()
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], sequence)
+	require.NoError(t, err)
+	events, err := auditRecordListField(mutations[sequence].record, "events")
+	require.NoError(t, err)
+	return events
+}
+
+func auditEventKinds(t *testing.T, events []audit.Record) []string {
+	t.Helper()
+	result := make([]string, len(events))
+	for index, event := range events {
+		var err error
+		result[index], err = auditTextField(event, "event_kind")
+		require.NoError(t, err)
+	}
+	return result
+}
+
+func auditEventNodeIDs(t *testing.T, events []audit.Record) []uint64 {
+	t.Helper()
+	result := make([]uint64, len(events))
+	for index, event := range events {
+		var err error
+		result[index], err = auditUnsignedField(event, metadataNodeIDField)
+		require.NoError(t, err)
+	}
+	return result
+}
+
+func appendMetadataTag(t *testing.T, input []byte, tag Tag) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(metadataTag{
+		Type: metadataTagRecordType, ID: tag.ID, Name: tag.Name, Revision: tag.Revision,
+	})
+	require.NoError(t, err)
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	for index, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type != metadataAuditAuthorityType {
+			continue
+		}
+		lines = append(lines, nil)
+		copy(lines[index+1:], lines[index:])
+		lines[index] = encoded
+		return append(bytes.Join(lines, []byte{'\n'}), '\n')
+	}
+	t.Fatal("metadata export lacks audit authority")
+	return nil
+}

--- a/internal/store/audit_tag_delete_validate.go
+++ b/internal/store/audit_tag_delete_validate.go
@@ -1,0 +1,382 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type replayedTagDeletion struct {
+	tagID       string
+	definition  audit.Record
+	assignments map[uint64]audit.Record
+	allNodes    []uint64
+	candidates  []uint64
+	digest      string
+	changeCount uint64
+}
+
+func attachedDeltaContainsTagDelete(
+	digest string, deltaRecords map[string]storedAuditRecord,
+) (bool, error) {
+	delta, ok := deltaRecords[digest]
+	if !ok {
+		return false, errors.New("tag definition change lacks its attached-metadata delta")
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return false, err
+	}
+	for _, change := range changes {
+		kind, err := auditTextField(change, "record_kind")
+		if err != nil {
+			return false, err
+		}
+		if kind != auditTagDefinitionKind {
+			continue
+		}
+		_, hasPre, err := optionalNestedAuditRecord(change, auditPreField)
+		if err != nil {
+			return false, err
+		}
+		_, hasPost, err := optionalNestedAuditRecord(change, auditPostField)
+		if err != nil {
+			return false, err
+		}
+		return hasPre && !hasPost, nil
+	}
+	return false, nil
+}
+
+func (replay *auditedHistoryReplay) validateTagDeletionDelta(
+	operationID, digest string, deltaRecords map[string]storedAuditRecord,
+	usedDeltas map[string]bool,
+) (replayedTagDeletion, error) {
+	delta, ok := deltaRecords[digest]
+	if !ok || usedDeltas[digest] {
+		return replayedTagDeletion{}, errors.New(
+			"tag deletion lacks one unique attached-metadata delta",
+		)
+	}
+	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
+		return replayedTagDeletion{}, err
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil {
+		return replayedTagDeletion{}, err
+	}
+	if len(changes) == 0 {
+		return replayedTagDeletion{}, errors.New("tag deletion has no attached-metadata changes")
+	}
+	transition := replayedTagDeletion{
+		assignments: make(map[uint64]audit.Record), digest: digest,
+	}
+	for _, change := range changes {
+		transition.changeCount++
+		if err := requireAuditAbsent(change, auditPostField); err != nil {
+			return replayedTagDeletion{}, errors.New("tag deletion change post-state must be absent")
+		}
+		pre, err := auditNestedField(change, auditPreField)
+		if err != nil {
+			return replayedTagDeletion{}, err
+		}
+		kind, err := auditTextField(change, "record_kind")
+		if err != nil || kind != pre.Kind {
+			return replayedTagDeletion{}, errors.New("tag deletion change has inconsistent record kind")
+		}
+		identity, err := attachedAuditIdentity(pre)
+		if err != nil {
+			return replayedTagDeletion{}, err
+		}
+		storedIdentity, err := auditNestedField(change, "stable_identity")
+		if err != nil || !auditRecordEqual(storedIdentity, identity) {
+			return replayedTagDeletion{}, errors.New(
+				"tag deletion change identity does not match its record",
+			)
+		}
+		key, err := attachedAuditKey(pre)
+		if err != nil {
+			return replayedTagDeletion{}, err
+		}
+		current, exists := replay.attachments[key]
+		if !exists || !auditRecordEqual(current, pre) {
+			return replayedTagDeletion{}, errors.New(
+				"tag deletion pre-state does not match replayed metadata",
+			)
+		}
+		switch pre.Kind {
+		case auditTagDefinitionKind:
+			if transition.definition.Kind != "" {
+				return replayedTagDeletion{}, errors.New("tag deletion repeats its definition tombstone")
+			}
+			if err := validateReplayedTagDefinition(pre); err != nil {
+				return replayedTagDeletion{}, err
+			}
+			transition.definition = pre
+			transition.tagID, err = auditUUIDField(pre, "tag_id")
+			if err != nil {
+				return replayedTagDeletion{}, err
+			}
+		case "tag_assignment":
+			nodeID, err := auditUnsignedField(pre, metadataNodeIDField)
+			if err != nil {
+				return replayedTagDeletion{}, err
+			}
+			if _, exists := transition.assignments[nodeID]; exists {
+				return replayedTagDeletion{}, fmt.Errorf(
+					"tag deletion repeats assignment for node %d", nodeID,
+				)
+			}
+			transition.assignments[nodeID] = pre
+			transition.allNodes = append(transition.allNodes, nodeID)
+		default:
+			return replayedTagDeletion{}, fmt.Errorf(
+				"tag deletion contains unsupported %s tombstone", pre.Kind,
+			)
+		}
+	}
+	if transition.definition.Kind == "" {
+		return replayedTagDeletion{}, errors.New("tag deletion lacks its definition tombstone")
+	}
+	slices.Sort(transition.allNodes)
+	for _, nodeID := range transition.allNodes {
+		assignmentTagID, err := auditUUIDField(transition.assignments[nodeID], "tag_id")
+		if err != nil {
+			return replayedTagDeletion{}, err
+		}
+		if assignmentTagID != transition.tagID {
+			return replayedTagDeletion{}, errors.New(
+				"tag deletion includes an assignment for another definition",
+			)
+		}
+		if replay.memberSet[nodeID] {
+			transition.candidates = append(transition.candidates, nodeID)
+		}
+	}
+	expectedNodes, err := replay.tagAssignmentNodes(transition.tagID)
+	if err != nil {
+		return replayedTagDeletion{}, err
+	}
+	if !slices.Equal(transition.allNodes, expectedNodes) {
+		return replayedTagDeletion{}, errors.New(
+			"tag deletion tombstones do not match the complete assignment set",
+		)
+	}
+	usedDeltas[digest] = true
+	return transition, nil
+}
+
+func (replay *auditedHistoryReplay) tagAssignmentNodes(tagID string) ([]uint64, error) {
+	var result []uint64
+	for _, record := range replay.attachments {
+		if record.Kind != "tag_assignment" {
+			continue
+		}
+		currentTagID, err := auditUUIDField(record, "tag_id")
+		if err != nil {
+			return nil, err
+		}
+		if currentTagID != tagID {
+			continue
+		}
+		nodeID, err := auditUnsignedField(record, metadataNodeIDField)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, nodeID)
+	}
+	slices.Sort(result)
+	return result, nil
+}
+
+func (replay *auditedHistoryReplay) applyTagDefinitionDelete(
+	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	deltaRecords, eventRecords map[string]storedAuditRecord,
+	usedDeltas, usedEvents map[string]bool,
+) error {
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	auditSequence, err := positiveAuditInteger("operation sequence", replay.allocationCount+1)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUUID(mutation.record, auditVaultIDField, vaultID); err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(mutation.record, "operation_sequence", auditSequence); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
+		return err
+	}
+	digest, err := auditDigestField(mutation.record, "attached_metadata_change_digest")
+	if err != nil {
+		return err
+	}
+	transition, err := replay.validateTagDeletionDelta(
+		operationID, digest, deltaRecords, usedDeltas,
+	)
+	if err != nil {
+		return err
+	}
+	if len(transition.candidates) == 0 {
+		return errors.New("tag deletion fabricates an audited mutation without affected members")
+	}
+	if err := replay.validateTagDeleteEvents(
+		mutation.record, operationID, transition, eventRecords, usedEvents,
+	); err != nil {
+		return err
+	}
+	if err := replay.validateMemberStateChanges(mutation.record, transition.candidates); err != nil {
+		return err
+	}
+	bindings, err := auditRecordListField(mutation.record, "baselines")
+	if err != nil {
+		return err
+	}
+	if len(bindings) != 0 {
+		return errors.New("tag deletion cannot bind an enrollment baseline")
+	}
+	if err := requireAuditAbsentFields(
+		mutation.record, auditTopologyDeltaField, "path_effect_digest", "witness_change_digest",
+	); err != nil {
+		return err
+	}
+	for _, field := range []string{"path_effect_count", auditWitnessChangeCountField} {
+		if err := requireAuditUnsigned(mutation.record, field, 0); err != nil {
+			return err
+		}
+	}
+	if err := requireAuditUnsigned(
+		mutation.record, auditAttachedMetadataChangeCountField, transition.changeCount,
+	); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(
+		mutation.record, "attached_metadata_change_digest", transition.digest,
+	); err != nil {
+		return err
+	}
+	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+		return err
+	}
+	if err := replay.advanceAllocation(
+		vaultID, operationID, mutation, allocation, transition.digest, transition.changeCount,
+	); err != nil {
+		return err
+	}
+	return replay.applyTagDeletionState(transition, &mutation.record)
+}
+
+func (replay *auditedHistoryReplay) validateTagDeleteEvents(
+	mutation audit.Record, operationID string, transition replayedTagDeletion,
+	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
+) error {
+	events, err := auditRecordListField(mutation, "events")
+	if err != nil {
+		return err
+	}
+	if len(events) != len(transition.candidates)*2 {
+		return errors.New("tag deletion event set does not match assigned audited nodes")
+	}
+	ordinal := uint64(0)
+	for _, nodeID := range transition.candidates {
+		state := replay.states[nodeID]
+		revision, err := auditUnsignedField(state, "node_revision")
+		if err != nil {
+			return err
+		}
+		current, err := auditOptionalUUIDField(state, "current_version_id")
+		if err != nil {
+			return err
+		}
+		expected := []struct {
+			kind       string
+			attachment audit.Record
+		}{
+			{"tag_delete", transition.definition},
+			{"tag_unassign", transition.assignments[nodeID]},
+		}
+		for _, item := range expected {
+			event := events[ordinal]
+			if err := validateAuditEventWrapper(
+				operationID, ordinal, event, eventRecords, usedEvents,
+			); err != nil {
+				return err
+			}
+			if err := validateTagDeleteEvent(
+				mutation, event, operationID, ordinal, nodeID, revision, current,
+				replay.scopeID, item.kind, item.attachment,
+			); err != nil {
+				return err
+			}
+			ordinal++
+		}
+	}
+	return nil
+}
+
+func validateTagDeleteEvent(
+	mutation, event audit.Record, operationID string, ordinal, nodeID, revision uint64,
+	current *string, scopeID, kind string, attachment audit.Record,
+) error {
+	identity, err := attachedAuditIdentity(attachment)
+	if err != nil {
+		return err
+	}
+	storedIdentity, err := auditNestedField(event, "attachment_identity")
+	if err != nil || !auditRecordEqual(storedIdentity, identity) {
+		return fmt.Errorf("%s event identity does not match its attachment", kind)
+	}
+	checks := []func() error{
+		func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
+		func() error { return requireAuditUnsigned(event, metadataNodeIDField, nodeID) },
+		func() error { return requireAuditText(event, "event_kind", kind) },
+		func() error { return requireAuditUUID(event, auditScopeIDField, scopeID) },
+		func() error { return requireAuditText(event, "attachment_kind", attachment.Kind) },
+		func() error { return requireAuditUnsigned(event, auditEventOrdinalField, ordinal) },
+		func() error { return requireAuditUnsigned(event, "prior_node_revision", revision) },
+		func() error { return requireAuditUnsigned(event, "resulting_node_revision", revision+1) },
+		func() error { return requireAuditOptionalUUID(event, "prior_current_version_id", current) },
+		func() error { return requireAuditOptionalUUID(event, "resulting_current_version_id", current) },
+		func() error { return requireMatchingEventEnvelope(mutation, event) },
+		func() error {
+			return requireAuditAbsentFields(
+				event, auditTargetNodeIDField, auditSourceVersionIDField, auditTopologyDeltaField,
+				auditBaselineDigestField, auditPostField,
+			)
+		},
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	pre, err := auditNestedField(event, auditPreField)
+	if err != nil || !auditRecordEqual(pre, attachment) {
+		return fmt.Errorf("%s event pre-state does not match its delta", kind)
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) applyTagDeletionState(
+	transition replayedTagDeletion, mutation *audit.Record,
+) error {
+	definitionKey, err := attachedAuditKey(transition.definition)
+	if err != nil {
+		return err
+	}
+	delete(replay.attachments, definitionKey)
+	for _, assignment := range transition.assignments {
+		key, err := attachedAuditKey(assignment)
+		if err != nil {
+			return err
+		}
+		delete(replay.attachments, key)
+	}
+	return replay.applyTagAffectedNodeState(transition.candidates, mutation)
+}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -770,6 +770,7 @@ const (
 	auditEventField                       = "event"
 	metadataIngestType                    = "ingest"
 	metadataProvenanceType                = "provenance"
+	metadataTagRecordType                 = "tag"
 	metadataAuditAuthorityType            = "audit_authority"
 	metadataAuditScopeType                = "audit_scope"
 	metadataAuditMembershipType           = "audit_membership"

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -241,7 +241,7 @@ func (s *Store) renameTagDefinitionTx(tx *sql.Tx, current Tag, name string) (Tag
 // formerly assigned node's metadata revision exactly once.
 func (s *Store) DeleteTag(ctx context.Context, id string, ifRev int64) (Tag, error) {
 	var deleted Tag
-	err := s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		current, err := tagByIDTx(tx, id)
 		if err != nil {
 			return err
@@ -249,19 +249,38 @@ func (s *Store) DeleteTag(ctx context.Context, id string, ifRev int64) (Tag, err
 		if err := checkTagRevision(current, ifRev); err != nil {
 			return err
 		}
-		if err := touchTaggedNodesTx(tx, id, nowRFC3339()); err != nil {
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
 			return err
 		}
-		if _, err := tx.Exec(`DELETE FROM tags WHERE id = ?`, id); err != nil {
-			return fmt.Errorf("deleting tag %s: %w", id, err)
+		if active {
+			deleted, err = s.deleteAuditedTagTx(ctx, tx, current)
+			return err
 		}
-		deleted = current
-		return nil
+		deleted, err = deleteTagTx(tx, current, nowRFC3339())
+		return err
 	})
 	if err != nil {
 		return Tag{}, err
 	}
 	return deleted, nil
+}
+
+func deleteTagTx(tx *sql.Tx, current Tag, recordedAt string) (Tag, error) {
+	if err := touchTaggedNodesTx(tx, current.ID, recordedAt); err != nil {
+		return Tag{}, err
+	}
+	if err := deleteTagDefinitionTx(tx, current.ID); err != nil {
+		return Tag{}, err
+	}
+	return current, nil
+}
+
+func deleteTagDefinitionTx(tx *sql.Tx, tagID string) error {
+	if _, err := tx.Exec(`DELETE FROM tags WHERE id = ?`, tagID); err != nil {
+		return fmt.Errorf("deleting tag %s: %w", tagID, err)
+	}
+	return nil
 }
 
 // AssignTag attaches a tag to a node under an optimistic revision check.


### PR DESCRIPTION
Once full audit is enabled, people should still be able to retire a tag they no longer use. Until now, deletion was the last ordinary tag operation that Docbank refused because it removes both the tag definition and every assignment at once.

This makes deletion one atomic history operation. Every protected document carrying the tag records that its assignment disappeared and that the definition was deleted, while its node revision advances only once. Documents outside the protected scope still receive the normal concurrency revision change, but Docbank does not invent audit events for them. If any part of history recording fails, the definition, assignments, revisions, and audit records all roll back together.

Backup restore and JSONL import independently derive the tag’s complete assignment set before applying the deletion. They reject a history that omits an assignment, invents an affected protected document, restores a deleted definition, or later reuses its stable tag identity. This means the final tag table is accepted only when it agrees with replayed history.

The policy remains ordinary Go code; this adds no schema machinery or SQL business rules. Public audit enrollment and history controls remain a separate, user-facing follow-up.

The full local verification matrix is green.

Kata: nyx4.