### PR TITLE
Expose permanent audit enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ metadata, content, and maintenance authority.
   history listing, ID-addressed retrieval, and lookup by content hash
 - Stable tags with define, rename, assign, unassign, delete, and bounded
   node/tag listings
+- Preview-first permanent audit enrollment for one directory scope, with
+  sticky retention, recorded supported mutations, status evidence, and
+  backup/restore fidelity
 - FTS5 name search (document-body extraction and search are planned)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification
@@ -61,11 +64,6 @@ capabilities listed here.
 
 Docbank supports Linux, macOS, and 64-bit Windows on amd64 and arm64. On Linux
 or macOS, install the latest release with:
-
-> **Current release:** v0.1.0 predates the complete distribution pipeline. Its
-> archives cover Linux amd64/arm64 and macOS arm64 only. Windows and macOS
-> amd64 users must build from source until the next release is published; the
-> installers fail rather than substitute an incompatible archive.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kenn-io/docbank/main/scripts/install.sh | sh

--- a/cmd/docbank/audit.go
+++ b/cmd/docbank/audit.go
@@ -127,9 +127,9 @@ func writeAuditPreview(w io.Writer, preview api.AuditEnrollmentPreview) error {
 		fmt.Sprintf("Retained versions: %d version(s), %d logical byte(s), %d unique blob(s), %d unique byte(s)",
 			preview.VersionCount, preview.LogicalVersionBytes,
 			preview.UniqueBlobs, preview.UniqueBlobBytes),
-		fmt.Sprintf("Vault-wide evidence: %d topology node(s), %d attached metadata record(s)",
+		fmt.Sprintf("Vault-wide permanent metadata: %d topology node(s), %d attached metadata record(s)",
 			preview.VaultTopologyNodes, preview.VaultAttachmentRecords),
-		fmt.Sprintf("Audit metadata estimate: %d JSONL byte(s)", preview.AuthorityJSONBytes),
+		fmt.Sprintf("Projected audit JSONL growth: %d byte(s)", preview.AuthorityJSONBytes),
 		"Baseline digest: " + preview.BaselineDigest,
 	}
 	if preview.UnresolvedTrashOrigins > 0 {
@@ -137,7 +137,8 @@ func writeAuditPreview(w io.Writer, preview api.AuditEnrollmentPreview) error {
 			preview.UnresolvedTrashOrigins))
 	}
 	lines = append(lines,
-		"This commitment is permanent: ordinary commands cannot disable it or purge protected history.",
+		"This commitment permanently retains protected history plus names, topology, tags, and provenance across the entire vault, including outside the selected scope.",
+		"Ordinary commands cannot disable audit or purge that retained authority.",
 		"Preview expires: "+preview.ExpiresAt,
 		"To enable exactly this reviewed scope:",
 		fmt.Sprintf("  docbank audit enable --run --token %s --acknowledge-permanent-retention",
@@ -237,7 +238,7 @@ func init() {
 		"one-use token returned by a fresh preview")
 	auditEnableCmd.Flags().BoolVar(&auditEnableAcknowledge,
 		"acknowledge-permanent-retention", false,
-		"confirm that ordinary commands cannot disable audit or purge protected history")
+		"confirm permanent protected history and vault-wide metadata, including names, topology, tags, and provenance outside the selected scope")
 	auditEnableCmd.Flags().BoolVar(&auditEnableJSON, "json", false, "machine-readable output")
 	auditStatusCmd.Flags().Int64Var(&auditStatusNodeID, "node-id", 0,
 		"inspect one stable node ID (alternative to path)")

--- a/cmd/docbank/audit.go
+++ b/cmd/docbank/audit.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -120,7 +121,7 @@ func writeAuditPreview(w io.Writer, preview api.AuditEnrollmentPreview) error {
 		return fmt.Errorf("writing audit preview: %w", err)
 	}
 	lines := []string{
-		fmt.Sprintf("Target: %s (node %d)", preview.TargetPath, preview.TargetNodeID),
+		fmt.Sprintf("Target: %s (node %d)", auditDisplayPath(preview.TargetPath), preview.TargetNodeID),
 		"Permanent scope: " + preview.ScopeID,
 		fmt.Sprintf("Protected tree: %d node(s) — %d directories, %d file(s)",
 			preview.MemberCount, preview.DirectoryCount, preview.FileCount),
@@ -157,7 +158,7 @@ func writeAuditEnabled(w io.Writer, status api.AuditStatus) error {
 		return errors.New("enabled audit status does not contain exactly one first scope")
 	}
 	scope := status.Scopes[0]
-	path := scope.TargetPath
+	path := auditDisplayPath(scope.TargetPath)
 	if scope.TargetTrashed {
 		path = "(target is in trash)"
 	}
@@ -186,7 +187,7 @@ func writeAuditStatus(w io.Writer, status api.AuditStatus) error {
 			return fmt.Errorf("writing audit status: %w", err)
 		}
 		for _, scope := range status.Scopes {
-			path := scope.TargetPath
+			path := auditDisplayPath(scope.TargetPath)
 			if scope.TargetTrashed {
 				path = "(target is in trash)"
 			}
@@ -201,7 +202,7 @@ func writeAuditStatus(w io.Writer, status api.AuditStatus) error {
 	}
 	if status.Membership != nil {
 		member := status.Membership
-		coordinate := member.Path
+		coordinate := auditDisplayPath(member.Path)
 		if member.Trashed {
 			coordinate = fmt.Sprintf("node %d in trash", member.NodeID)
 		}
@@ -216,6 +217,10 @@ func writeAuditStatus(w io.Writer, status api.AuditStatus) error {
 		}
 	}
 	return nil
+}
+
+func auditDisplayPath(path string) string {
+	return strconv.QuoteToASCII(path)
 }
 
 func writeAuditJSON(w io.Writer, value any) error {

--- a/cmd/docbank/audit.go
+++ b/cmd/docbank/audit.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Protect permanent document history and inspect its evidence",
+}
+
+var (
+	auditEnableNodeID      int64
+	auditEnableAgentLabel  string
+	auditEnableRun         bool
+	auditEnableToken       string
+	auditEnableAcknowledge bool
+	auditEnableJSON        bool
+)
+
+var auditEnableCmd = &cobra.Command{
+	Use:   "enable [path]",
+	Short: "Preview permanent retention, then explicitly enable the reviewed scope",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if auditEnableRun {
+			if len(args) != 0 || auditEnableNodeID != 0 || auditEnableAgentLabel != "" {
+				return errors.New("audit enable --run uses only the reviewed preview token")
+			}
+			if auditEnableToken == "" {
+				return errors.New("audit enable --run requires --token from a fresh preview")
+			}
+			if !auditEnableAcknowledge {
+				return errors.New(
+					"audit enable --run requires --acknowledge-permanent-retention",
+				)
+			}
+			c, err := client.Ensure(cmd.Context())
+			if err != nil {
+				return err
+			}
+			status, err := c.EnableAudit(cmd.Context(), auditEnableToken, true)
+			if err != nil {
+				return err
+			}
+			if auditEnableJSON {
+				return writeAuditJSON(cmd.OutOrStdout(), status)
+			}
+			return writeAuditEnabled(cmd.OutOrStdout(), status)
+		}
+		if auditEnableToken != "" || auditEnableAcknowledge {
+			return errors.New("--token and --acknowledge-permanent-retention require --run")
+		}
+		if (len(args) == 0) == (auditEnableNodeID == 0) {
+			return errors.New("audit enable preview requires exactly one path or --node-id")
+		}
+		opts := client.AuditPreviewOptions{
+			NodeID: auditEnableNodeID, AgentLabel: auditEnableAgentLabel,
+		}
+		if len(args) == 1 {
+			opts.Path = args[0]
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		preview, err := c.PreviewAudit(cmd.Context(), opts)
+		if err != nil {
+			return err
+		}
+		if auditEnableJSON {
+			return writeAuditJSON(cmd.OutOrStdout(), preview)
+		}
+		return writeAuditPreview(cmd.OutOrStdout(), preview)
+	},
+}
+
+var (
+	auditStatusNodeID int64
+	auditStatusJSON   bool
+)
+
+var auditStatusCmd = &cobra.Command{
+	Use:   "status [path]",
+	Short: "Inspect vault audit authority and optional node protection",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 && auditStatusNodeID != 0 {
+			return errors.New("audit status accepts either a path or --node-id, not both")
+		}
+		path := ""
+		if len(args) == 1 {
+			path = args[0]
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		status, err := c.AuditStatus(cmd.Context(), path, auditStatusNodeID)
+		if err != nil {
+			return err
+		}
+		if auditStatusJSON {
+			return writeAuditJSON(cmd.OutOrStdout(), status)
+		}
+		return writeAuditStatus(cmd.OutOrStdout(), status)
+	},
+}
+
+func writeAuditPreview(w io.Writer, preview api.AuditEnrollmentPreview) error {
+	if _, err := fmt.Fprintln(w, "Audit enrollment preview — no changes made"); err != nil {
+		return fmt.Errorf("writing audit preview: %w", err)
+	}
+	lines := []string{
+		fmt.Sprintf("Target: %s (node %d)", preview.TargetPath, preview.TargetNodeID),
+		"Permanent scope: " + preview.ScopeID,
+		fmt.Sprintf("Protected tree: %d node(s) — %d directories, %d file(s)",
+			preview.MemberCount, preview.DirectoryCount, preview.FileCount),
+		fmt.Sprintf("Retained versions: %d version(s), %d logical byte(s), %d unique blob(s), %d unique byte(s)",
+			preview.VersionCount, preview.LogicalVersionBytes,
+			preview.UniqueBlobs, preview.UniqueBlobBytes),
+		fmt.Sprintf("Vault-wide evidence: %d topology node(s), %d attached metadata record(s)",
+			preview.VaultTopologyNodes, preview.VaultAttachmentRecords),
+		fmt.Sprintf("Audit metadata estimate: %d JSONL byte(s)", preview.AuthorityJSONBytes),
+		"Baseline digest: " + preview.BaselineDigest,
+	}
+	if preview.UnresolvedTrashOrigins > 0 {
+		lines = append(lines, fmt.Sprintf("Unresolved retained trash origins: %d",
+			preview.UnresolvedTrashOrigins))
+	}
+	lines = append(lines,
+		"This commitment is permanent: ordinary commands cannot disable it or purge protected history.",
+		"Preview expires: "+preview.ExpiresAt,
+		"To enable exactly this reviewed scope:",
+		fmt.Sprintf("  docbank audit enable --run --token %s --acknowledge-permanent-retention",
+			preview.PreviewToken),
+	)
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("writing audit preview: %w", err)
+		}
+	}
+	return nil
+}
+
+func writeAuditEnabled(w io.Writer, status api.AuditStatus) error {
+	if len(status.Scopes) != 1 {
+		return errors.New("enabled audit status does not contain exactly one first scope")
+	}
+	scope := status.Scopes[0]
+	path := scope.TargetPath
+	if scope.TargetTrashed {
+		path = "(target is in trash)"
+	}
+	_, err := fmt.Fprintf(w,
+		"enabled permanent audit scope %s for %s (node %d); protecting %d node(s)\n",
+		scope.ID, path, scope.TargetNodeID, scope.MemberCount)
+	if err != nil {
+		return fmt.Errorf("writing audit result: %w", err)
+	}
+	return nil
+}
+
+func writeAuditStatus(w io.Writer, status api.AuditStatus) error {
+	if !status.Enabled {
+		if _, err := fmt.Fprintln(w, "audit is not enabled for this vault"); err != nil {
+			return fmt.Errorf("writing audit status: %w", err)
+		}
+	} else {
+		if _, err := fmt.Fprintf(w,
+			"audit enabled; lineage %s, operation %d, allocation entry %d\n",
+			status.LineageID, status.OperationSequenceHighWater,
+			status.AllocationEntryCount); err != nil {
+			return fmt.Errorf("writing audit status: %w", err)
+		}
+		if _, err := fmt.Fprintf(w, "allocation head: %s\n", status.AllocationHead); err != nil {
+			return fmt.Errorf("writing audit status: %w", err)
+		}
+		for _, scope := range status.Scopes {
+			path := scope.TargetPath
+			if scope.TargetTrashed {
+				path = "(target is in trash)"
+			}
+			if _, err := fmt.Fprintf(w,
+				"scope %s: %s (node %d), %d member(s), chain entry %d\n"+
+					"  baseline: %s\n  chain head: %s\n",
+				scope.ID, path, scope.TargetNodeID, scope.MemberCount, scope.EntryCount,
+				scope.BaselineDigest, scope.ChainHead); err != nil {
+				return fmt.Errorf("writing audit status: %w", err)
+			}
+		}
+	}
+	if status.Membership != nil {
+		member := status.Membership
+		coordinate := member.Path
+		if member.Trashed {
+			coordinate = fmt.Sprintf("node %d in trash", member.NodeID)
+		}
+		if member.Protected {
+			_, err := fmt.Fprintf(w, "%s is permanently protected by %d scope(s): %v\n",
+				coordinate, len(member.ScopeIDs), member.ScopeIDs)
+			if err != nil {
+				return fmt.Errorf("writing audit membership: %w", err)
+			}
+		} else if _, err := fmt.Fprintf(w, "%s is not in an audit scope\n", coordinate); err != nil {
+			return fmt.Errorf("writing audit membership: %w", err)
+		}
+	}
+	return nil
+}
+
+func writeAuditJSON(w io.Writer, value any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("writing audit JSON: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	auditEnableCmd.Flags().Int64Var(&auditEnableNodeID, "node-id", 0,
+		"stable live directory ID (alternative to path)")
+	auditEnableCmd.Flags().StringVar(&auditEnableAgentLabel, "agent-label", "",
+		"optional actor label retained in the enrollment event")
+	auditEnableCmd.Flags().BoolVar(&auditEnableRun, "run", false,
+		"permanently enable the reviewed preview")
+	auditEnableCmd.Flags().StringVar(&auditEnableToken, "token", "",
+		"one-use token returned by a fresh preview")
+	auditEnableCmd.Flags().BoolVar(&auditEnableAcknowledge,
+		"acknowledge-permanent-retention", false,
+		"confirm that ordinary commands cannot disable audit or purge protected history")
+	auditEnableCmd.Flags().BoolVar(&auditEnableJSON, "json", false, "machine-readable output")
+	auditStatusCmd.Flags().Int64Var(&auditStatusNodeID, "node-id", 0,
+		"inspect one stable node ID (alternative to path)")
+	auditStatusCmd.Flags().BoolVar(&auditStatusJSON, "json", false, "machine-readable output")
+	auditCmd.AddCommand(auditEnableCmd, auditStatusCmd)
+	rootCmd.AddCommand(auditCmd)
+}

--- a/cmd/docbank/audit.go
+++ b/cmd/docbank/audit.go
@@ -138,7 +138,7 @@ func writeAuditPreview(w io.Writer, preview api.AuditEnrollmentPreview) error {
 			preview.UnresolvedTrashOrigins))
 	}
 	lines = append(lines,
-		"This commitment permanently retains protected history plus names, topology, tags, and provenance across the entire vault, including outside the selected scope.",
+		"This commitment permanently retains protected history plus names, topology, tags, assignments, ingests, and provenance across the entire vault, including outside the selected scope.",
 		"Ordinary commands cannot disable audit or purge that retained authority.",
 		"Preview expires: "+preview.ExpiresAt,
 		"To enable exactly this reviewed scope:",
@@ -243,7 +243,7 @@ func init() {
 		"one-use token returned by a fresh preview")
 	auditEnableCmd.Flags().BoolVar(&auditEnableAcknowledge,
 		"acknowledge-permanent-retention", false,
-		"confirm permanent protected history and vault-wide metadata, including names, topology, tags, and provenance outside the selected scope")
+		"confirm permanent protected history and vault-wide metadata, including names, topology, tags, assignments, ingests, and provenance outside the selected scope")
 	auditEnableCmd.Flags().BoolVar(&auditEnableJSON, "json", false, "machine-readable output")
 	auditStatusCmd.Flags().Int64Var(&auditStatusNodeID, "node-id", 0,
 		"inspect one stable node ID (alternative to path)")

--- a/cmd/docbank/audit_test.go
+++ b/cmd/docbank/audit_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestHumanAuditOutputQuotesPaths(t *testing.T) {
+	const unsafePath = "/Taxes/\n\x1b[31mFORGED"
+	want := strconv.QuoteToASCII(unsafePath)
+	tests := []struct {
+		name  string
+		write func(io.Writer) error
+	}{
+		{
+			name: "preview",
+			write: func(w io.Writer) error {
+				return writeAuditPreview(w, api.AuditEnrollmentPreview{TargetPath: unsafePath})
+			},
+		},
+		{
+			name: "enabled",
+			write: func(w io.Writer) error {
+				return writeAuditEnabled(w, api.AuditStatus{Scopes: []api.AuditScopeStatus{{
+					TargetPath: unsafePath,
+				}}})
+			},
+		},
+		{
+			name: "status",
+			write: func(w io.Writer) error {
+				return writeAuditStatus(w, api.AuditStatus{
+					Enabled: true,
+					Scopes:  []api.AuditScopeStatus{{TargetPath: unsafePath}},
+					Membership: &api.AuditMembershipStatus{
+						Path: unsafePath,
+					},
+				})
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			require.NoError(t, test.write(&output))
+			assert.Contains(t, output.String(), want)
+			assert.NotContains(t, output.String(), unsafePath)
+		})
+	}
+}

--- a/cmd/docbank/audit_test.go
+++ b/cmd/docbank/audit_test.go
@@ -55,3 +55,14 @@ func TestHumanAuditOutputQuotesPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestAuditRetentionDisclosureNamesEveryMetadataClass(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, writeAuditPreview(&output, api.AuditEnrollmentPreview{}))
+	help := auditEnableCmd.Flags().Lookup("acknowledge-permanent-retention").Usage
+	for _, text := range []string{output.String(), help} {
+		for _, class := range []string{"names", "topology", "tags", "assignments", "ingests", "provenance"} {
+			assert.Contains(t, text, class)
+		}
+	}
+}

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -141,6 +141,51 @@ func TestAddLsTreeCat(t *testing.T) {
 	assert.Equal(t, "hello vault", out)
 }
 
+func TestAuditEnableIsPreviewFirstAndReportsProtection(t *testing.T) {
+	_ = setupVaultHome(t)
+	source := writeSourceFile(t, "return.txt", "tax return")
+	_, err := runCLI(t, "add", source, "--dest", "/Taxes")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "audit", "status", "--json")
+	require.NoError(t, err, out)
+	var dormant api.AuditStatus
+	require.NoError(t, json.Unmarshal([]byte(out), &dormant))
+	assert.False(t, dormant.Enabled)
+
+	out, err = runCLI(t, "audit", "enable", "/Taxes", "--json")
+	require.NoError(t, err, out)
+	var preview api.AuditEnrollmentPreview
+	require.NoError(t, json.Unmarshal([]byte(out), &preview))
+	assert.Equal(t, "/Taxes", preview.TargetPath)
+	assert.Equal(t, 2, preview.MemberCount)
+	assert.NotEmpty(t, preview.PreviewToken)
+
+	_, err = runCLI(t, "audit", "enable", "--run", "--token", preview.PreviewToken)
+	require.ErrorContains(t, err, "--acknowledge-permanent-retention")
+
+	out, err = runCLI(t, "audit", "enable", "--run", "--token", preview.PreviewToken,
+		"--acknowledge-permanent-retention", "--json")
+	require.NoError(t, err, out)
+	var status api.AuditStatus
+	require.NoError(t, json.Unmarshal([]byte(out), &status))
+	assert.True(t, status.Enabled)
+	require.Len(t, status.Scopes, 1)
+	assert.Equal(t, preview.ScopeID, status.Scopes[0].ID)
+
+	out, err = runCLI(t, "audit", "status", "/Taxes/return.txt")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "/Taxes/return.txt is permanently protected")
+
+	replacement := writeSourceFile(t, "replacement.txt", "amended return")
+	_, err = runCLI(t, "put", replacement, "/Taxes/return.txt", "--progress", "plain")
+	require.NoError(t, err)
+
+	_, err = runCLI(t, "audit", "enable", "--run", "--token", preview.PreviewToken,
+		"--acknowledge-permanent-retention")
+	require.ErrorIs(t, err, store.ErrAuditPreviewStale)
+}
+
 func TestPutReplacesContentAndRetainsHistory(t *testing.T) {
 	_ = setupVaultHome(t)
 	initial := writeSourceFile(t, "document.txt", "initial content")

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -160,6 +160,10 @@ func TestAuditEnableIsPreviewFirstAndReportsProtection(t *testing.T) {
 	assert.Equal(t, "/Taxes", preview.TargetPath)
 	assert.Equal(t, 2, preview.MemberCount)
 	assert.NotEmpty(t, preview.PreviewToken)
+	humanPreview, err := runCLI(t, "audit", "enable", "/Taxes")
+	require.NoError(t, err, humanPreview)
+	assert.Contains(t, humanPreview, "Vault-wide permanent metadata:")
+	assert.Contains(t, humanPreview, "including outside the selected scope")
 
 	_, err = runCLI(t, "audit", "enable", "--run", "--token", preview.PreviewToken)
 	require.ErrorContains(t, err, "--acknowledge-permanent-retention")

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -179,7 +179,7 @@ func TestAuditEnableIsPreviewFirstAndReportsProtection(t *testing.T) {
 
 	out, err = runCLI(t, "audit", "status", "/Taxes/return.txt")
 	require.NoError(t, err, out)
-	assert.Contains(t, out, "/Taxes/return.txt is permanently protected")
+	assert.Contains(t, out, `"/Taxes/return.txt" is permanently protected`)
 
 	replacement := writeSourceFile(t, "replacement.txt", "amended return")
 	_, err = runCLI(t, "put", replacement, "/Taxes/return.txt", "--progress", "plain")

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -157,7 +157,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "17", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "18", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "17", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "18", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -307,6 +307,20 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	prunePID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, tagPID, prunePID)
 
+	// Protocol 17 predates permanent audit enrollment and status. Replace it
+	// before the CLI reaches a same-version daemon without the audit contract.
+	recs[0].Metadata["protocol_version"] = "17"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "audit", "status", "--json")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, `"enabled": false`)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	auditPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, prunePID, auditPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -321,7 +335,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "17", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "18", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -334,7 +348,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, prunePID, protocolPID)
+	assert.NotEqual(t, auditPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -494,8 +494,12 @@ curl --fail-with-body -X POST \
 ```
 
 Present or evaluate the returned protected node/version counts, logical and
-unique bytes, vault-wide evidence counts, and `baseline_digest`. Only after
-that review may a client execute the exact daemon-held plan:
+unique bytes, vault-wide evidence counts, and `baseline_digest`. First
+activation permanently retains enrollment-time names, topology, tags,
+assignments, ingests, and provenance across the vault, including outside the
+selected scope. Unrelated content versions do not become scope members, but the
+metadata snapshot remains evidence. Only after that review may a client execute
+the exact daemon-held plan:
 
 ```bash
 curl --fail-with-body -X POST \

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -480,6 +480,37 @@ The receipt proves receive-time agreement. Use the revision-bound single-node
 verification endpoint later when policy requires evidence about bytes currently
 stored in the vault.
 
+## Enroll permanent history only after an exact preview
+
+Audit enrollment is irreversible. An agent must first preview one live
+directory by path or stable node ID:
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{"path":"/taxes","agent_label":"records policy"}' \
+  "$DOCBANK_URL/api/v1/audit/preview"
+```
+
+Present or evaluate the returned protected node/version counts, logical and
+unique bytes, vault-wide evidence counts, and `baseline_digest`. Only after
+that review may a client execute the exact daemon-held plan:
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{"preview_token":"<one-use-token>","acknowledge_permanent_retention":true}' \
+  "$DOCBANK_URL/api/v1/audit/enable"
+```
+
+The token expires after ten minutes, is consumed by one attempt, and does not
+survive daemon restart. On `audit_preview_stale`, preview again; never retry the
+same execution blindly. `GET /api/v1/audit/status` reports vault-wide evidence.
+Add either `?path=/taxes/file.pdf` or `?node_id=57` to inspect sticky membership.
+The current public boundary permits one permanent scope per vault.
+
 ## Treat destructive maintenance as a two-step decision
 
 Trash empty and GC are dry-run operations when `run` is false. An agent should

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -222,8 +222,8 @@ For first activation, preview preallocates the random operation and lineage IDs,
 operation sequence, event timestamp, and other non-derivable inputs used by its
 baseline digest. It constructs the complete genesis projections, computes their
 registered digests, and keeps those inputs in the server-side token state. The
-displayed retention counts and serialized-byte estimates are deterministically
-derived from those exact projections. Execution recomputes the baseline,
+displayed retention counts and exact projected JSONL audit growth are
+deterministically derived from those exact projections. Execution recomputes the baseline,
 genesis digests, and disclosure under the mutation gate before accepting the
 token. Expiration before execution discards the unused identities. Accepted
 execution uses those exact values in the one SQLite enrollment transaction and
@@ -538,13 +538,13 @@ metadata values from JSONL exports or backups. Full audit does **not** retain an
 unaudited file's content bytes or versions solely for this reason, but its
 vault-wide metadata trail persists with the audit authority.
 
-Every enablement preview states this distinction in plain language and reports
-whether vault-wide lineage is newly activated or already active. On first
-activation it inventories the topology and attached-metadata genesis by record
-kind and estimated serialized bytes; confirmation explicitly accepts permanent
-metadata retention outside the selected scope. CLI/agent JSON exposes the same
-structured counts and acknowledgment requirement, and TUI/web clients may not
-hide it behind a generic confirmation dialog.
+Every enablement preview states this distinction in plain language. On first
+activation it reports topology and attached-metadata counts plus the exact
+projected JSONL growth of the authority, scope, memberships, and canonical
+record envelopes. Confirmation explicitly accepts permanent metadata retention
+outside the selected scope. CLI/agent JSON exposes the same structured counts
+and acknowledgment requirement, and TUI/web clients may not hide it behind a
+generic confirmation dialog.
 
 An external application or pseudo-folder uses the same model: an integration
 projects its collection onto a stable Docbank directory/scope reference. The

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -1,16 +1,17 @@
 ---
 title: Audited History
-description: The planned permanent, tamper-evident history contract for protected directory scopes, content versions, backup, agents, the TUI, and the web portal.
+description: The permanent, tamper-evident history model for protected directory scopes, content versions, backup, agents, and future interactive clients.
 ---
 
 # Audited history
 
-!!! info "Planned — not yet implemented"
-    Docbank records immutable `content_create` and `content_replace` versions,
-    but does not yet implement audit scopes, mutation chains, or permanent
-    protected retention. This page is the definitive contract that work will
-    follow; the current ordinary version behavior is described in
-    [Editing & Versions](editing-and-versions.md).
+!!! info "Current implementation boundary"
+    Docbank implements permanent first-scope enrollment, sticky membership,
+    mutation and allocation chains for the supported changes described below,
+    JSONL backup/restore fidelity, and status inspection. Additional scopes,
+    bounded history browsing, independent verification commands, and TUI/web
+    projections remain planned. See [Permanent Audited History](../usage/audited-history.md)
+    for the current operator workflow.
 
 Full audit is an opt-in promise for records whose history matters more than
 easy reclamation: tax documents, contracts, regulated work, or an external
@@ -192,19 +193,19 @@ clients and agents, TUI, and web — requires the same two-step shape. Preview
 returns the baseline inventory, storage impact, unresolved trash origins, and
 a **vault-wide metadata-retention disclosure** described below, plus a
 short-lived server-issued token bound to the scope ID, baseline digest, vault
-preview generation, and—on first activation—the exact topology- and
+identity, and—on first activation—the exact topology- and
 attached-metadata-genesis digests behind that disclosure. Enablement requires
 that token and an explicit acknowledgment of both the scope promise and
 vault-wide disclosure; it fails if the token is expired, belongs to another
 scope, or the baseline or either genesis projection changed. A client therefore
 cannot bypass review by calling the execution operation directly.
 
-Preview tokens are one-use and held by the issuing daemon. Any intervening
+Preview tokens are one-use and held by the issuing daemon. Execution recomputes
+the complete baseline and allocation-genesis digests; any intervening
 authoritative mutation, successful enablement, or pre-activation change to a
-genesis input advances the vault preview generation and invalidates every
-outstanding token, even for a disjoint scope. Genesis inputs include repairable
-trash locators: although a later locator clear is non-authoritative, before
-genesis it can change the origin edge or unknown-origin record retained
+genesis input therefore makes the reviewed plan stale. Genesis inputs include
+repairable trash locators: although a later locator clear is non-authoritative,
+before genesis it can change the origin edge or unknown-origin record retained
 permanently. This deliberately favors a simple exact review boundary over
 concurrent enablement. Of concurrent executions, only the first matching token
 can commit.
@@ -212,14 +213,10 @@ Expiration or daemon restart discards tokens without changing the vault, and
 the client must preview again after `audit_preview_stale`.
 
 The wire token is the unpadded base64url encoding of a cryptographically random
-32-byte secret. Its stored digest is SHA-256 over the registered canonical
-`preview_token` record containing that secret and the exact scope, target,
-vault ID, baseline digest, preview generation, operation ID, lineage ID, and
-optional topology- and attached-metadata-genesis digests. Both genesis digests
-are present for first activation and both are absent after lineage already
-exists; mixed presence is invalid. Token validation decodes the secret,
-reconstructs that record from server-held state, and compares the digest; the
-raw secret never enters JSONL or a backup.
+32-byte secret. The daemon retains only its SHA-256 digest, mapped to the exact
+opaque enrollment plan and expiration. Token validation decodes and hashes the
+secret, then atomically removes the matching plan before execution. Neither the
+raw secret nor its daemon-local plan enters JSONL or a backup.
 
 For first activation, preview preallocates the random operation and lineage IDs,
 operation sequence, event timestamp, and other non-derivable inputs used by its
@@ -1030,7 +1027,6 @@ Hashed top-level record schemas are:
 | `scope_chain_entry` | `vault_id:uuid`, `scope_id:uuid`, `entry_count:u64`, `previous_head:?digest`, `mutation_hash:digest` |
 | `allocation_genesis` | `vault_id:uuid`, `lineage_id:uuid`, `previous_head:?digest`, `node_id_high_water:u64`, `operation_sequence_high_water:u64`, `topology_count:u64`, `topology_digest:digest`, `attached_metadata_count:u64`, `attached_metadata_digest:digest` |
 | `allocation_entry` | `vault_id:uuid`, `lineage_id:uuid`, `previous_head:digest`, `operation_sequence:u64`, `operation_id:uuid`, `allocated_node_ids:[u64]`, `node_id_high_water:u64`, `operation_sequence_high_water:u64`, `has_audited_mutation:bool`, `mutation_hash:?digest`, `has_topology_change:bool`, `topology_delta:?digest`, `has_witness_change:bool`, `witness_change_count:u64`, `witness_change_digest:?digest`, `has_attached_metadata_change:bool`, `attached_metadata_change_count:u64`, `attached_metadata_change_digest:?digest` |
-| `preview_token` | `secret:bytes`, `vault_id:uuid`, `scope_id:uuid`, `target_node_id:u64`, `baseline_digest:digest`, `preview_generation:u64`, `operation_id:uuid`, `lineage_id:uuid`, `topology_genesis_digest:?digest`, `attached_metadata_genesis_digest:?digest` |
 
 The four `has_*` booleans are the normative allocation-entry no-change markers.
 `false` requires the paired digest absent and count zero where a count exists;
@@ -1460,20 +1456,20 @@ download/open actions; richer format-aware comparison can be added later.
 
 ### CLI and agents
 
-Planned CLI concepts are `audit enable`, `audit status`, `audit history`,
-`audit verify`, and the general `versions` command. `audit enable` previews its
-baseline inventory plus structured vault-wide metadata-retention counts and
-returns a server-issued preview token by default; a separate execution supplies
-that token and the explicit disclosure acknowledgment because enrollment is
-permanent.
-Machine output uses stable scope, node, event, and version IDs and explicit
-protection state. `audit status --json` and `audit verify --json` include the
-complete evidence bundle rather than reporting only per-scope heads. The
-`audit history` command and node-timeline API return
-`audit_not_enrolled` for a node outside every audit scope rather than presenting
-an empty timeline as complete. A refused protected mutation returns
-`audit_protected` with a list of every blocking scope rather than relying on
-prose parsing.
+`audit enable` previews its baseline inventory plus structured vault-wide
+metadata-retention counts and returns a server-issued preview token by default;
+a separate execution supplies that token and the explicit disclosure
+acknowledgment because enrollment is permanent. `audit status` reports the
+vault authority and can inspect one node's sticky membership. Machine output
+uses stable scope, node, operation, lineage, and baseline identities rather
+than asking agents to parse prose.
+
+!!! info "Planned"
+    Bounded `audit history` and independent `audit verify` commands will expose
+    event timelines and terminal verification evidence. A history lookup for a
+    node outside every scope will return `audit_not_enrolled`, and refused
+    protected destruction will identify every blocking scope in structured
+    output.
 
 ### TUI
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -37,6 +37,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /content-references?sha256=&limit=&offset=` | find every stable node/version pair retaining a content hash | Implemented |
 | `GET\|POST /tags` · `GET /tags/by-name` · `GET\|PATCH\|DELETE /tags/{tag_id}` | list, resolve, create, rename, or delete stable tag definitions | Implemented |
 | `GET /nodes/{id}/tags` · `GET /tags/{tag_id}/nodes` · `PUT\|DELETE /nodes/{id}/tags/{tag_id}` · `PUT\|DELETE /path/tags/{tag_id}` | inspect and change tag assignments | Implemented |
+| `POST /audit/preview` · `POST /audit/enable` · `GET /audit/status` | review permanent first-scope retention, enable the exact reviewed plan, and inspect authority or membership | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
@@ -451,6 +452,9 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `exists` | 409 | `store.ErrExists` (name collision) |
 | `cycle` | 409 | `store.ErrCycle` (move under own descendant) |
 | `audit_mutation_unsupported` | 409 | the audited vault does not yet record this logical mutation class |
+| `audit_already_enabled` | 409 | this vault already has its first permanent audit scope |
+| `audit_preview_stale` | 409 | the one-use enrollment preview expired, was consumed, came from another daemon, or no longer matches the vault |
+| `audit_acknowledgment_required` | 422 | enrollment execution omitted the explicit permanent-retention acknowledgment |
 | `stale_revision` | 412 | `store.ErrStaleRevision` — `If-Match` didn't match the current revision |
 | `not_dir` / `not_file` / `invalid_name` / `invalid_tag` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrInvalidTag` / `ErrNotTrashed` / `ErrIsRoot` |
 | `validation` | 400, 415, or 422 | malformed request (bad `If-Match`, paths, media type, multipart envelope, or generated validation) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,7 @@ All commands operate on the vault at `~/.docbank` (override with
 stderr and produce a non-zero exit code. Virtual paths are absolute,
 `/`-separated, and case-sensitive.
 
-Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `edit`, `versions`, `version`, `refs`, `revert`, `tag`, `mv`, `rm`,
+Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `edit`, `versions`, `version`, `refs`, `revert`, `tag`, `audit`, `mv`, `rm`,
 `restore`, `search`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
 daemon over its HTTP API rather than opening the vault itself; if none
 is running, the command auto-starts one in the background. `docbank
@@ -312,6 +312,36 @@ assignment change advances both the node and tag revisions. `tag nodes`
 includes live and trashed nodes, but omits a path for trash because it has no
 resolvable live coordinate. List commands return at most 1000 results per page
 and JSON output includes `total`, `limit`, and `offset`.
+
+## docbank audit
+
+```text
+docbank audit enable <path> [--agent-label <label>] [--json]
+docbank audit enable --node-id <id> [--agent-label <label>] [--json]
+docbank audit enable --run --token <preview-token> --acknowledge-permanent-retention [--json]
+docbank audit status [path] [--json]
+docbank audit status --node-id <id> [--json]
+```
+
+`audit enable` permanently protects a directory scope and all retained content
+versions beneath it. Enrollment cannot be disabled. The default invocation is
+a read-only preview that reports the exact protected set, storage impact,
+baseline digest, vault-wide evidence, and a one-use token. Execution is a
+separate command that accepts only that token and the explicit permanent-
+retention acknowledgment; target selectors are deliberately absent from the
+execution command.
+
+The token expires after ten minutes, is consumed by one execution attempt, and
+does not survive daemon restart. The daemon recomputes the reviewed authority
+inside the mutation boundary. If metadata or allocator state changed, it
+returns `audit_preview_stale` without enabling the scope; run a new preview.
+
+`audit status` without a selector reports vault and scope evidence. A path or
+stable node ID additionally reports whether that node has sticky audit
+membership. The current public boundary supports the first scope in a vault;
+a later `audit enable` returns `audit_already_enabled`. See
+[Permanent Audited History](usage/audited-history.md) for supported mutations
+and maintenance behavior.
 
 ## docbank mv
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -326,10 +326,13 @@ docbank audit status --node-id <id> [--json]
 `audit enable` permanently protects a directory scope and all retained content
 versions beneath it. Enrollment cannot be disabled. The default invocation is
 a read-only preview that reports the exact protected set, storage impact,
-baseline digest, vault-wide evidence, and a one-use token. Execution is a
-separate command that accepts only that token and the explicit permanent-
-retention acknowledgment; target selectors are deliberately absent from the
-execution command.
+baseline digest, vault-wide permanent metadata, and a one-use token. The first
+scope permanently retains enrollment-time names, topology, tags, assignments,
+ingests, and provenance across the vault, including outside the selected scope;
+unrelated content does not become a scope member. Execution is a separate
+command that accepts only that token and the explicit permanent-retention
+acknowledgment; target selectors are deliberately absent from the execution
+command.
 
 The token expires after ten minutes, is consumed by one execution attempt, and
 does not survive daemon restart. The daemon recomputes the reviewed authority

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ elsewhere only when they materially explain the design and are marked
 | 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.10.0) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
-| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: version identity, reads, verified replacement, and reversion implemented; remaining work designed |
+| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, provenance, and first-scope audit authority implemented; watched inboxes and extraction remain |
 | 3 | Primary kit-ui web portal and focused operator TUI | Designed |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
@@ -79,7 +79,7 @@ Kit unpack remains internal to tests, migrations, or a future purpose-built
 recovery workflow rather than a planned user command. Ordinary ingests continue
 to publish loose blobs; startup never performs an implicit migration.
 
-## Phase 2b — Features (designed)
+## Phase 2b — Features (in progress)
 
 Implemented foundation: every initial ingest/upload creates a stable UUIDv4
 content version and current node pointer. `docbank versions`, `docbank version`,
@@ -101,12 +101,15 @@ refs` and `GET /content-references` resolve a SHA-256 identity to
 every retaining current, historical, or trashed node/version pair. Stable tags
 are available across the CLI, authenticated API, typed client, OpenAPI, and
 metadata-v1 backup/restore authority, including bounded forward and reverse
-listings.
+listings. Permanent first-scope audit enrollment is preview-first across the
+CLI and API. Sticky membership, supported logical mutations, allocation and
+scope chains, status evidence, and JSONL backup/restore validation are
+implemented.
 
-- Full-audit directory scopes with sticky membership, complete authoritative
-  change and content-version retention, tamper-evident history, maintenance
-  refusal, and portable JSONL fidelity
-  ([design](architecture/audited-history.md))
+- Additional and overlapping audit scopes, bounded history browsing, and a
+  dedicated independent verification command
+  ([current workflow](usage/audited-history.md),
+  [model](architecture/audited-history.md))
 - Tag/MIME/date/path search filters; `POST /batch/move` bulk reorganization
 - Watched inbox directories with a stability window, landing imports
   under `/inbox/<date>/`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,12 +22,6 @@ additionally requires:
 
 ## Install a release
 
-!!! info "Current tagged release"
-    v0.1.0 predates the complete distribution pipeline. It includes Linux
-    amd64/arm64 and macOS arm64 archives only. Windows and macOS amd64 users
-    must build from source until the next release is published; the installers
-    fail rather than substitute an incompatible archive.
-
 On Linux or macOS, the installer selects the native archive and installs
 `docbank` to `~/.local/bin` by default:
 

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -1,0 +1,121 @@
+---
+title: Permanent Audited History
+description: Permanently retain every version and recorded change beneath a reviewed directory scope.
+---
+
+# Permanent audited history
+
+Full audit is for directories whose history matters more than reclaiming their
+old bytes: tax records, contracts, long-lived agent archives, or an
+application-owned collection. Enabling it makes a permanent promise:
+
+- every node and retained content version in the reviewed scope becomes
+  protected;
+- new children inherit that protection;
+- moving or trashing a protected node does not shed it;
+- supported content, tree, provenance, and tag changes are appended to a
+  tamper-evident history; and
+- ordinary version pruning and permanent trash deletion cannot erase that
+  authority.
+
+This is stronger than ordinary version history. An unaudited file keeps all
+versions by default, but `versions prune` may deliberately release old ones.
+An audited version is a permanent reachability root. Docbank has no `audit
+disable` command.
+
+## Review before enabling
+
+Enrollment is always a separate preview and execution. Preview does not change
+the vault:
+
+```bash
+docbank audit enable /taxes
+```
+
+It reports:
+
+- the stable target node and proposed scope identities;
+- directories, files, and existing versions that will become protected;
+- logical and unique blob bytes retained by those versions;
+- unresolved retained trash origins, if any;
+- the vault-wide topology and attached metadata committed as audit evidence;
+- the baseline digest and estimated JSONL authority size; and
+- a one-use token with a ten-minute expiration.
+
+The vault-wide evidence counts matter even when `/taxes` is a small subtree.
+The allocation lineage commits the surrounding topology and attached metadata
+needed to prove identities and detect rollback; it does not enroll unrelated
+documents into the scope.
+
+Read the preview before executing the command it prints:
+
+```bash
+docbank audit enable \
+  --run \
+  --token <preview-token> \
+  --acknowledge-permanent-retention
+```
+
+The daemon recomputes the complete enrollment while holding the mutation gate.
+If any document, path, version, tag, provenance fact, or allocator state changed
+after preview, execution returns `audit_preview_stale` and changes nothing.
+Preview again rather than retrying the old token. Tokens are consumed by one
+execution attempt and disappear when the daemon restarts.
+
+For automation, add `--json`. A caller may preview by stable directory ID
+instead of path:
+
+```bash
+docbank audit enable --node-id 42 --json
+```
+
+## Inspect protection
+
+Vault-wide status identifies the lineage, allocation head, scope target,
+baseline, membership count, and current scope-chain head:
+
+```bash
+docbank audit status
+docbank audit status --json
+```
+
+Supply a live path or stable node ID to inspect sticky membership:
+
+```bash
+docbank audit status /taxes/2026/return.pdf
+docbank audit status --node-id 57 --json
+```
+
+An empty timeline is not proof that a node is protected; use `audit status` and
+require `protected: true` plus its scope and baseline identities.
+
+## What remains usable
+
+Protected documents remain working documents. Docbank records direct creation
+and filesystem ingest, verified content replacement and reversion, in-scope
+moves and renames, reversible trash and restore, and tag creation, assignment,
+rename, and deletion. These operations commit their metadata and history
+together; a history failure rolls the visible change back.
+
+`rm` remains a soft delete. The protected node stays in recoverable trash and
+can be restored. Physical pack and repack maintenance also remains available
+because it changes representation without removing logical authority, and GC
+can remove only blobs that no content version retains.
+
+Execution of `trash empty --run` and `versions prune --run` is currently
+refused once audit authority exists. Their dry runs remain useful for impact
+inspection. There is deliberately no exceptional audit-destruction command.
+
+## Current boundary
+
+The current public workflow enables the first audit scope in a vault. A second
+`audit enable` returns `audit_already_enabled`; adding overlapping scopes is not
+yet exposed. Status, mutation recording, JSONL export/import, and backup capture
+all preserve the first scope's authority.
+
+!!! info "Planned"
+    Bounded `audit history` and independent `audit verify` commands, additional
+    scope enrollment, and rich TUI/web history views are not implemented yet.
+    Until those arrive, `docbank verify` still validates the stored metadata
+    relations and every blob, while backup restore revalidates the portable
+    JSONL authority before publishing a vault.

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -23,6 +23,12 @@ versions by default, but `versions prune` may deliberately release old ones.
 An audited version is a permanent reachability root. Docbank has no `audit
 disable` command.
 
+First activation also permanently retains one vault-wide metadata snapshot:
+node names and topology plus tag, assignment, ingest, and provenance records,
+including records outside the selected directory. Those unrelated documents
+do not become audit members and their content versions are not protected by
+the scope, but the enrollment-time metadata remains part of the evidence.
+
 ## Review before enabling
 
 Enrollment is always a separate preview and execution. Preview does not change
@@ -38,14 +44,16 @@ It reports:
 - directories, files, and existing versions that will become protected;
 - logical and unique blob bytes retained by those versions;
 - unresolved retained trash origins, if any;
-- the vault-wide topology and attached metadata committed as audit evidence;
-- the baseline digest and estimated JSONL authority size; and
+- the vault-wide topology and attached metadata, including records outside the
+  selected scope, that will be permanently retained as audit evidence;
+- the baseline digest and exact projected JSONL audit growth; and
 - a one-use token with a ten-minute expiration.
 
 The vault-wide evidence counts matter even when `/taxes` is a small subtree.
 The allocation lineage commits the surrounding topology and attached metadata
 needed to prove identities and detect rollback; it does not enroll unrelated
-documents into the scope.
+documents into the scope, but that enrollment-time metadata snapshot remains
+permanent.
 
 Read the preview before executing the command it prints:
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -23,6 +23,7 @@ nav = [
   ]},
   {"Protect & Operate" = [
     {"Vault Lifecycle" = "usage/lifecycle.md"},
+    {"Permanent Audited History" = "usage/audited-history.md"},
     {"Trash, GC, Repack & Verify" = "usage/trash-and-gc.md"},
     {"Backup & Restore" = "usage/backup.md"},
   ]},
@@ -45,7 +46,7 @@ nav = [
     {"Daemon & Process Model" = "architecture/daemon.md"},
     {"Backup & Recovery" = "architecture/backup.md"},
     {"Integrity & Trust" = "architecture/integrity.md"},
-    {"Planned: Audited History" = "architecture/audited-history.md"},
+    {"Audited History Model" = "architecture/audited-history.md"},
   ]},
   {"Project" = [
     {"Roadmap" = "roadmap.md"},

--- a/internal/api/audit_previews.go
+++ b/internal/api/audit_previews.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+const (
+	auditPreviewTTL      = 10 * time.Minute
+	maxAuditPreviewPlans = 64
+)
+
+var errAuditPreviewUnavailable = errors.New("audit enrollment preview is expired, used, or from another daemon")
+
+type auditPreviewEntry struct {
+	plan      *store.AuditEnrollmentPlan
+	expiresAt time.Time
+}
+
+// auditPreviewRegistry keeps irreversible enrollment plans daemon-local,
+// bounded, short-lived, and one-use. Only a SHA-256 key for the random wire
+// secret is retained; restart intentionally invalidates every preview.
+type auditPreviewRegistry struct {
+	mu      sync.Mutex
+	entries map[[sha256.Size]byte]auditPreviewEntry
+	now     func() time.Time
+	ttl     time.Duration
+}
+
+func newAuditPreviewRegistry() *auditPreviewRegistry {
+	return &auditPreviewRegistry{
+		entries: make(map[[sha256.Size]byte]auditPreviewEntry),
+		now:     time.Now,
+		ttl:     auditPreviewTTL,
+	}
+}
+
+func (registry *auditPreviewRegistry) issue(
+	plan *store.AuditEnrollmentPlan,
+) (string, time.Time, error) {
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return "", time.Time{}, fmt.Errorf("generating audit preview secret: %w", err)
+	}
+	key := sha256.Sum256(secret)
+	now := registry.now()
+	expiresAt := now.Add(registry.ttl)
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	registry.removeExpiredLocked(now)
+	if len(registry.entries) >= maxAuditPreviewPlans {
+		var oldestKey [sha256.Size]byte
+		var oldestTime time.Time
+		for candidate, entry := range registry.entries {
+			if oldestTime.IsZero() || entry.expiresAt.Before(oldestTime) {
+				oldestKey, oldestTime = candidate, entry.expiresAt
+			}
+		}
+		delete(registry.entries, oldestKey)
+	}
+	registry.entries[key] = auditPreviewEntry{plan: plan, expiresAt: expiresAt}
+	return base64.RawURLEncoding.EncodeToString(secret), expiresAt, nil
+}
+
+func (registry *auditPreviewRegistry) take(token string) (*store.AuditEnrollmentPlan, error) {
+	secret, err := base64.RawURLEncoding.Strict().DecodeString(token)
+	if err != nil || len(secret) != 32 {
+		return nil, errAuditPreviewUnavailable
+	}
+	key := sha256.Sum256(secret)
+	now := registry.now()
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	registry.removeExpiredLocked(now)
+	entry, ok := registry.entries[key]
+	if !ok {
+		return nil, errAuditPreviewUnavailable
+	}
+	delete(registry.entries, key)
+	return entry.plan, nil
+}
+
+func (registry *auditPreviewRegistry) removeExpiredLocked(now time.Time) {
+	for key, entry := range registry.entries {
+		if !entry.expiresAt.After(now) {
+			delete(registry.entries, key)
+		}
+	}
+}

--- a/internal/api/audit_previews_test.go
+++ b/internal/api/audit_previews_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestAuditPreviewRegistryExpiresPlans(t *testing.T) {
+	registry := newAuditPreviewRegistry()
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	registry.now = func() time.Time { return now }
+	registry.ttl = time.Minute
+
+	plan := new(store.AuditEnrollmentPlan)
+	token, expiresAt, err := registry.issue(plan)
+	require.NoError(t, err)
+	require.Equal(t, now.Add(time.Minute), expiresAt)
+
+	now = expiresAt
+	_, err = registry.take(token)
+	require.ErrorIs(t, err, errAuditPreviewUnavailable)
+	require.Empty(t, registry.entries)
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -74,6 +74,8 @@ var storeErrCodes = []struct {
 	{store.ErrVersionAlreadyCurrent, http.StatusUnprocessableEntity, "version_already_current"},
 	{store.ErrInvalidVersionPrune, http.StatusUnprocessableEntity, "invalid_version_prune"},
 	{store.ErrAuditMutationUnsupported, http.StatusConflict, "audit_mutation_unsupported"},
+	{store.ErrAuditAlreadyEnabled, http.StatusConflict, "audit_already_enabled"},
+	{store.ErrAuditPreviewStale, http.StatusConflict, "audit_preview_stale"},
 }
 
 // FromStoreError maps the store's typed errors onto the wire envelope; an

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -47,6 +47,15 @@ func TestOpenAPIDeclaresSecurity(t *testing.T) {
 	assert.Contains(t, doc, "security:", "document-level security requirement missing")
 }
 
+func TestOpenAPIAuditEnableDisclosesCompleteRetention(t *testing.T) {
+	doc := api.NewOfflineServer().API().OpenAPI()
+	op := doc.Paths["/api/v1/audit/enable"].Post
+	require.NotNil(t, op)
+	for _, class := range []string{"names", "topology", "tags", "assignments", "ingests", "provenance"} {
+		assert.Contains(t, op.Description, class)
+	}
+}
+
 func TestOpenAPIDeclaresDigestCheckedUpload(t *testing.T) {
 	doc := api.NewOfflineServer().API().OpenAPI()
 	op := doc.Paths["/api/v1/uploads"].Post

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -21,6 +21,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 		"listTags", "resolveTagByName", "getTag", "listTagNodes", "listNodeTags",
 		"createTag", "renameTag", "deleteTag", "assignTag", "unassignTag",
 		"assignTagPath", "unassignTagPath",
+		"previewAuditEnrollment", "enableAudit", "auditStatus",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
 		"storageStatus", "storagePack", "storageRepack", "ingest", "uploadFile", "listTrash", "emptyTrash", "gc", "verify",
 		"initBackupRepository", "createBackupSnapshot", "listBackupSnapshots", "listJobs"} {

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+type auditPreviewOutput struct{ Body AuditEnrollmentPreview }
+type auditStatusOutput struct{ Body AuditStatus }
+
+func registerAuditRoutes(
+	api huma.API, d Deps, g *gate, previews *auditPreviewRegistry,
+) {
+	huma.Register(api, huma.Operation{
+		OperationID: "previewAuditEnrollment", Method: http.MethodPost,
+		Path:    "/api/v1/audit/preview",
+		Summary: "Preview the permanent first audit scope without changing the vault",
+	}, func(ctx context.Context, in *struct {
+		Body struct {
+			Path       string `json:"path,omitempty"`
+			NodeID     int64  `json:"node_id,omitempty" minimum:"1"`
+			AgentLabel string `json:"agent_label,omitempty" maxLength:"200"`
+		}
+	}) (*auditPreviewOutput, error) {
+		if (in.Body.Path == "") == (in.Body.NodeID == 0) {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation",
+				"audit preview requires exactly one of path or node_id")
+		}
+		var label *string
+		if in.Body.AgentLabel != "" {
+			label = &in.Body.AgentLabel
+		}
+		var out *auditPreviewOutput
+		err := g.mutate(func() error {
+			var plan *store.AuditEnrollmentPlan
+			var err error
+			if in.Body.Path != "" {
+				plan, err = d.Store.PreviewInitialAuditPath(ctx, in.Body.Path, "api", label)
+			} else {
+				plan, err = d.Store.PreviewInitialAudit(ctx, in.Body.NodeID, "api", label)
+			}
+			if err != nil {
+				return FromStoreError(err)
+			}
+			token, expiresAt, err := previews.issue(plan)
+			if err != nil {
+				return NewError(http.StatusInternalServerError, "internal",
+					fmt.Sprintf("issuing audit preview token: %v", err))
+			}
+			out = &auditPreviewOutput{Body: auditEnrollmentPreview(
+				plan.Preview(), token, expiresAt,
+			)}
+			return nil
+		})
+		return out, err
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "enableAudit", Method: http.MethodPost, Path: "/api/v1/audit/enable",
+		Summary: "Permanently enable the exact reviewed first audit scope",
+		Description: "Consumes a one-use preview token. The irreversible retention " +
+			"acknowledgment must be explicit; preview again after any stale-token response.",
+	}, func(ctx context.Context, in *struct {
+		Body struct {
+			PreviewToken                  string `json:"preview_token" minLength:"43" maxLength:"43"`
+			AcknowledgePermanentRetention bool   `json:"acknowledge_permanent_retention"`
+		}
+	}) (*auditStatusOutput, error) {
+		if !in.Body.AcknowledgePermanentRetention {
+			return nil, NewError(http.StatusUnprocessableEntity,
+				"audit_acknowledgment_required",
+				"audit enrollment is permanent; acknowledge permanent retention explicitly")
+		}
+		var out *auditStatusOutput
+		err := g.mutate(func() error {
+			plan, err := previews.take(in.Body.PreviewToken)
+			if err != nil {
+				return NewError(http.StatusConflict, "audit_preview_stale", err.Error())
+			}
+			status, err := d.Store.EnableInitialAudit(ctx, plan)
+			if err != nil {
+				return FromStoreError(err)
+			}
+			out = &auditStatusOutput{Body: auditStatus(status)}
+			return nil
+		})
+		return out, err
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "auditStatus", Method: http.MethodGet, Path: "/api/v1/audit/status",
+		Summary: "Inspect audit authority and optional node protection",
+	}, func(ctx context.Context, in *struct {
+		Path   string `query:"path"`
+		NodeID int64  `query:"node_id" minimum:"1"`
+	}) (*auditStatusOutput, error) {
+		if in.Path != "" && in.NodeID != 0 {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation",
+				"audit status accepts at most one of path or node_id")
+		}
+		var status store.AuditStatus
+		var err error
+		switch {
+		case in.Path != "":
+			status, err = d.Store.AuditStatusPath(ctx, in.Path)
+		case in.NodeID != 0:
+			status, err = d.Store.AuditStatus(ctx, &in.NodeID)
+		default:
+			status, err = d.Store.AuditStatus(ctx, nil)
+		}
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return &auditStatusOutput{Body: auditStatus(status)}, nil
+	})
+}
+
+func auditEnrollmentPreview(
+	preview store.AuditEnrollmentPreview, token string, expiresAt time.Time,
+) AuditEnrollmentPreview {
+	return AuditEnrollmentPreview{
+		VaultID: preview.VaultID, ScopeID: preview.ScopeID,
+		OperationID: preview.OperationID, TargetNodeID: preview.TargetNodeID,
+		TargetPath: preview.TargetPath, BaselineDigest: preview.BaselineDigest,
+		MemberCount: preview.MemberCount, FileCount: preview.FileCount,
+		DirectoryCount: preview.DirectoryCount, VersionCount: preview.VersionCount,
+		LogicalVersionBytes: preview.LogicalVersionBytes,
+		UniqueBlobs:         preview.UniqueBlobs, UniqueBlobBytes: preview.UniqueBlobBytes,
+		UnresolvedTrashOrigins: preview.UnresolvedTrashOrigins,
+		VaultTopologyNodes:     preview.VaultTopologyNodes,
+		VaultAttachmentRecords: preview.VaultAttachmentRecords,
+		AuthorityJSONBytes:     preview.AuthorityJSONBytes,
+		PreviewToken:           token, ExpiresAt: expiresAt.UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func auditStatus(status store.AuditStatus) AuditStatus {
+	out := AuditStatus{
+		Enabled: status.Enabled, VaultID: status.VaultID, LineageID: status.LineageID,
+		OperationSequenceHighWater: status.OperationSequenceHighWater,
+		AllocationEntryCount:       status.AllocationEntryCount,
+		AllocationHead:             status.AllocationHead, Scopes: []AuditScopeStatus{},
+	}
+	for _, scope := range status.Scopes {
+		out.Scopes = append(out.Scopes, AuditScopeStatus{
+			ID: scope.ID, TargetNodeID: scope.TargetNodeID, TargetPath: scope.TargetPath,
+			TargetTrashed: scope.TargetTrashed, EnableOperationID: scope.EnableOperationID,
+			BaselineDigest: scope.BaselineDigest, MemberCount: scope.MemberCount,
+			EntryCount: scope.EntryCount, ChainHead: scope.ChainHead,
+		})
+	}
+	if status.Membership != nil {
+		out.Membership = &AuditMembershipStatus{
+			NodeID: status.Membership.NodeID, Path: status.Membership.Path,
+			Trashed: status.Membership.Trashed, Protected: status.Membership.Protected,
+			ScopeIDs:        status.Membership.ScopeIDs,
+			BaselineDigests: status.Membership.BaselineDigests,
+		}
+	}
+	return out
+}

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -31,6 +32,10 @@ func registerAuditRoutes(
 		if (in.Body.Path == "") == (in.Body.NodeID == 0) {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation",
 				"audit preview requires exactly one of path or node_id")
+		}
+		if in.Body.Path != "" && !strings.HasPrefix(in.Body.Path, "/") {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation",
+				fmt.Sprintf("path %q must be absolute (start with /)", in.Body.Path))
 		}
 		var label *string
 		if in.Body.AgentLabel != "" {
@@ -106,6 +111,10 @@ func registerAuditRoutes(
 		if in.Path != "" && in.NodeID != 0 {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation",
 				"audit status accepts at most one of path or node_id")
+		}
+		if in.Path != "" && !strings.HasPrefix(in.Path, "/") {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation",
+				fmt.Sprintf("path %q must be absolute (start with /)", in.Path))
 		}
 		var status store.AuditStatus
 		var err error

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -64,8 +64,10 @@ func registerAuditRoutes(
 	huma.Register(api, huma.Operation{
 		OperationID: "enableAudit", Method: http.MethodPost, Path: "/api/v1/audit/enable",
 		Summary: "Permanently enable the exact reviewed first audit scope",
-		Description: "Consumes a one-use preview token. The irreversible retention " +
-			"acknowledgment must be explicit; preview again after any stale-token response.",
+		Description: "Consumes a one-use preview token. The acknowledgment explicitly " +
+			"accepts permanent protected history plus names, topology, tags, and provenance " +
+			"across the vault, including outside the selected scope; preview again after " +
+			"any stale-token response.",
 	}, func(ctx context.Context, in *struct {
 		Body struct {
 			PreviewToken                  string `json:"preview_token" minLength:"43" maxLength:"43"`
@@ -75,7 +77,7 @@ func registerAuditRoutes(
 		if !in.Body.AcknowledgePermanentRetention {
 			return nil, NewError(http.StatusUnprocessableEntity,
 				"audit_acknowledgment_required",
-				"audit enrollment is permanent; acknowledge permanent retention explicitly")
+				"acknowledge permanent protected history and vault-wide metadata retention")
 		}
 		var out *auditStatusOutput
 		err := g.mutate(func() error {

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -65,7 +65,8 @@ func registerAuditRoutes(
 		OperationID: "enableAudit", Method: http.MethodPost, Path: "/api/v1/audit/enable",
 		Summary: "Permanently enable the exact reviewed first audit scope",
 		Description: "Consumes a one-use preview token. The acknowledgment explicitly " +
-			"accepts permanent protected history plus names, topology, tags, and provenance " +
+			"accepts permanent protected history plus names, topology, tags, assignments, " +
+			"ingests, and provenance " +
 			"across the vault, including outside the selected scope; preview again after " +
 			"any stale-token response.",
 	}, func(ctx context.Context, in *struct {

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -58,6 +58,17 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	assert.True(t, status.Membership.Protected)
 	assert.Equal(t, []string{preview.ScopeID}, status.Membership.ScopeIDs)
 
+	inherited, err := s.Mkdir(t.Context(), taxes.ID, "2027")
+	require.NoError(t, err)
+	status, err = c.AuditStatus(t.Context(), "", inherited.ID)
+	require.NoError(t, err)
+	require.NotNil(t, status.Membership)
+	assert.True(t, status.Membership.Protected)
+	assert.Equal(t, []string{preview.ScopeID}, status.Membership.ScopeIDs)
+	require.Len(t, status.Membership.BaselineDigests, 1)
+	assert.NotEqual(t, preview.BaselineDigest, status.Membership.BaselineDigests[0],
+		"an inherited node binds to its creation baseline, not the scope enrollment baseline")
+
 	_, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
 	require.ErrorIs(t, err, store.ErrAuditPreviewStale)
 	require.NoError(t, s.ValidateMetadata(t.Context()))

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -51,6 +51,10 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	require.Len(t, status.Scopes, 1)
 	assert.Equal(t, preview.ScopeID, status.Scopes[0].ID)
 	assert.Equal(t, preview.BaselineDigest, status.Scopes[0].BaselineDigest)
+	status, err = c.AuditStatus(t.Context(), "", taxes.ID)
+	require.NoError(t, err)
+	require.NotNil(t, status.Membership)
+	assert.Equal(t, []string{preview.BaselineDigest}, status.Membership.BaselineDigests)
 
 	status, err = c.AuditStatus(t.Context(), "/Taxes/return.txt", 0)
 	require.NoError(t, err)

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -136,6 +136,37 @@ func TestAuditPreviewRequiresOneTarget(t *testing.T) {
 	}
 }
 
+func TestAuditPreviewRejectsMissingAndNonDirectoryTargets(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	file, err := s.CreateFile(t.Context(), s.RootID(), "return.txt", testHash("return"), 6, "text/plain")
+	require.NoError(t, err)
+	trashed, err := s.Mkdir(t.Context(), s.RootID(), "Old Taxes")
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		body   map[string]any
+		status int
+		code   string
+	}{
+		{name: "missing ID", body: map[string]any{"node_id": int64(999_999)}, status: http.StatusNotFound, code: "not_found"},
+		{name: "trashed ID", body: map[string]any{"node_id": trashed.ID}, status: http.StatusNotFound, code: "not_found"},
+		{name: "file ID", body: map[string]any{"node_id": file.ID}, status: http.StatusUnprocessableEntity, code: "not_dir"},
+		{name: "file path", body: map[string]any{"path": "/return.txt"}, status: http.StatusUnprocessableEntity, code: "not_dir"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp, raw := do(t, ts, http.MethodPost, "/api/v1/audit/preview", nil, test.body)
+			assert.Equal(t, test.status, resp.StatusCode)
+			var problem api.Error
+			require.NoError(t, json.Unmarshal([]byte(raw), &problem))
+			assert.Equal(t, test.code, problem.Code)
+		})
+	}
+}
+
 func TestAuditPreviewTokenIsDaemonLocal(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -140,6 +140,34 @@ func TestAuditPreviewRequiresOneTarget(t *testing.T) {
 	}
 }
 
+func TestAuditRoutesRejectRelativePaths(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{
+			name: "preview", method: http.MethodPost, path: "/api/v1/audit/preview",
+			body: map[string]any{"path": "Taxes"},
+		},
+		{
+			name: "status", method: http.MethodGet, path: "/api/v1/audit/status?path=Taxes",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp, raw := do(t, ts, test.method, test.path, nil, test.body)
+			assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+			var problem api.Error
+			require.NoError(t, json.Unmarshal([]byte(raw), &problem))
+			assert.Equal(t, "validation", problem.Code)
+			assert.Contains(t, problem.Detail, "must be absolute")
+		})
+	}
+}
+
 func TestAuditPreviewRejectsMissingAndNonDirectoryTargets(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	file, err := s.CreateFile(t.Context(), s.RootID(), "return.txt", testHash("return"), 6, "text/plain")

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -1,0 +1,121 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	_, err = s.CreateFile(t.Context(), taxes.ID, "return.txt", testHash("return"), 6, "text/plain")
+	require.NoError(t, err)
+	c := client.New(ts.URL, testAPIKey)
+
+	status, err := c.AuditStatus(t.Context(), "/Taxes/return.txt", 0)
+	require.NoError(t, err)
+	assert.False(t, status.Enabled)
+	require.NotNil(t, status.Membership)
+	assert.False(t, status.Membership.Protected)
+
+	preview, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{Path: "/Taxes"})
+	require.NoError(t, err)
+	assert.Equal(t, taxes.ID, preview.TargetNodeID)
+	assert.Equal(t, 2, preview.MemberCount)
+	assert.Equal(t, 1, preview.VersionCount)
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/audit/enable", nil, map[string]any{
+		"preview_token":                   preview.PreviewToken,
+		"acknowledge_permanent_retention": false,
+	})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	var problem api.Error
+	require.NoError(t, json.Unmarshal([]byte(body), &problem))
+	assert.Equal(t, "audit_acknowledgment_required", problem.Code)
+
+	status, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
+	require.NoError(t, err)
+	assert.True(t, status.Enabled)
+	require.Len(t, status.Scopes, 1)
+	assert.Equal(t, preview.ScopeID, status.Scopes[0].ID)
+	assert.Equal(t, preview.BaselineDigest, status.Scopes[0].BaselineDigest)
+
+	status, err = c.AuditStatus(t.Context(), "/Taxes/return.txt", 0)
+	require.NoError(t, err)
+	require.NotNil(t, status.Membership)
+	assert.True(t, status.Membership.Protected)
+	assert.Equal(t, []string{preview.ScopeID}, status.Membership.ScopeIDs)
+
+	_, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
+	require.ErrorIs(t, err, store.ErrAuditPreviewStale)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditEnableRejectsPreviewAfterVaultMutation(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	c := client.New(ts.URL, testAPIKey)
+	preview, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: taxes.ID})
+	require.NoError(t, err)
+
+	_, err = s.Mkdir(t.Context(), s.RootID(), "Changed after review")
+	require.NoError(t, err)
+	_, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
+	require.ErrorIs(t, err, store.ErrAuditPreviewStale)
+
+	_, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
+	require.ErrorIs(t, err, store.ErrAuditPreviewStale, "failed execution consumes the token")
+	status, err := c.AuditStatus(t.Context(), "", 0)
+	require.NoError(t, err)
+	assert.False(t, status.Enabled)
+}
+
+func TestAuditPreviewRequiresOneTarget(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	for _, body := range []map[string]any{
+		{},
+		{"path": "/", "node_id": 1},
+	} {
+		resp, raw := do(t, ts, http.MethodPost, "/api/v1/audit/preview", nil, body)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+		var problem api.Error
+		require.NoError(t, json.Unmarshal([]byte(raw), &problem))
+		assert.Equal(t, "validation", problem.Code)
+	}
+}
+
+func TestAuditPreviewTokenIsDaemonLocal(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	c := client.New(ts.URL, testAPIKey)
+	preview, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: taxes.ID})
+	require.NoError(t, err)
+
+	// A fresh server over the same store models daemon restart: no preview
+	// registry is restored from disk or metadata backup.
+	cfg := config.Default()
+	cfg.Server.APIKey = testAPIKey
+	restarted := api.NewServer(api.Deps{
+		Store: s.Store, Blobs: s.Blobs, VaultRoot: filepath.Dir(s.DBPath),
+		Cfg: cfg,
+	})
+	restartServer := httptest.NewServer(restarted.Handler())
+	t.Cleanup(restartServer.Close)
+	restartClient := client.New(restartServer.URL, testAPIKey)
+	_, err = restartClient.EnableAudit(t.Context(), preview.PreviewToken, true)
+	require.ErrorIs(t, err, store.ErrAuditPreviewStale)
+}

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -83,6 +83,34 @@ func TestAuditEnableRejectsPreviewAfterVaultMutation(t *testing.T) {
 	assert.False(t, status.Enabled)
 }
 
+func TestAuditEnableReportsStaleWhenTargetIsTrashedOrDeleted(t *testing.T) {
+	for _, hardDelete := range []bool{false, true} {
+		name := "trashed"
+		if hardDelete {
+			name = "deleted"
+		}
+		t.Run(name, func(t *testing.T) {
+			ts, s := newTestServer(t, nil)
+			taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+			require.NoError(t, err)
+			c := client.New(ts.URL, testAPIKey)
+			preview, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{
+				NodeID: taxes.ID,
+			})
+			require.NoError(t, err)
+
+			_, _, err = s.Trash(t.Context(), taxes.ID, taxes.Revision)
+			require.NoError(t, err)
+			if hardDelete {
+				_, err = s.TrashEmpty(t.Context(), 0, true)
+				require.NoError(t, err)
+			}
+			_, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
+			require.ErrorIs(t, err, store.ErrAuditPreviewStale)
+		})
+	}
+}
+
 func TestAuditPreviewRequiresOneTarget(t *testing.T) {
 	ts, _ := newTestServer(t, nil)
 	for _, body := range []map[string]any{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -40,9 +40,10 @@ type Deps struct {
 // Server is docbank's HTTP API: a huma-described /api/v1 surface plus a
 // handful of plain http.Handler routes (health, ping, shutdown, web).
 type Server struct {
-	deps    Deps
-	handler http.Handler
-	api     huma.API
+	deps          Deps
+	handler       http.Handler
+	api           huma.API
+	auditPreviews *auditPreviewRegistry
 }
 
 // NewServer wires all routes and middleware onto a fresh mux. The handler
@@ -81,7 +82,7 @@ func NewServer(d Deps) *Server {
 	}
 	cfg.Security = []map[string][]string{{"apiKey": {}}, {"bearer": {}}}
 	humaAPI := humago.New(mux, cfg)
-	s := &Server{deps: d, api: humaAPI}
+	s := &Server{deps: d, api: humaAPI, auditPreviews: newAuditPreviewRegistry()}
 	g := &gate{}
 
 	registerReadRoutes(humaAPI, d)      // Task 5 (stat-by-id lands in this task)
@@ -94,6 +95,7 @@ func NewServer(d Deps) *Server {
 	registerContentRevertRoute(humaAPI, d, g)
 	registerContentPruneRoute(humaAPI, d, g)
 	registerTagRoutes(humaAPI, d, g)
+	registerAuditRoutes(humaAPI, d, g, s.auditPreviews)
 	markRevisionPreconditionsRequired(humaAPI)
 	s.registerHealth(mux)
 	mux.Handle("GET "+kitPingPath, kitdaemon.NewPingHandler(kitdaemon.PingHandlerOptions{

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -151,6 +151,68 @@ type TagDeletionReceipt struct {
 	RemovedAssignments int `json:"removed_assignments" minimum:"0"`
 }
 
+// AuditEnrollmentPreview is the exact permanent-retention boundary reviewed
+// before first activation. PreviewToken is daemon-local, short-lived, and
+// consumed by one enable attempt.
+type AuditEnrollmentPreview struct {
+	VaultID                string `json:"vault_id" format:"uuid"`
+	ScopeID                string `json:"scope_id" format:"uuid"`
+	OperationID            string `json:"operation_id" format:"uuid"`
+	TargetNodeID           int64  `json:"target_node_id" minimum:"1"`
+	TargetPath             string `json:"target_path"`
+	BaselineDigest         string `json:"baseline_digest" pattern:"^[0-9a-f]{64}$"`
+	MemberCount            int    `json:"member_count" minimum:"1"`
+	FileCount              int    `json:"file_count" minimum:"0"`
+	DirectoryCount         int    `json:"directory_count" minimum:"1"`
+	VersionCount           int    `json:"version_count" minimum:"0"`
+	LogicalVersionBytes    int64  `json:"logical_version_bytes" minimum:"0"`
+	UniqueBlobs            int    `json:"unique_blobs" minimum:"0"`
+	UniqueBlobBytes        int64  `json:"unique_blob_bytes" minimum:"0"`
+	UnresolvedTrashOrigins int    `json:"unresolved_trash_origins" minimum:"0"`
+	VaultTopologyNodes     int    `json:"vault_topology_nodes" minimum:"1"`
+	VaultAttachmentRecords int    `json:"vault_attachment_records" minimum:"0"`
+	AuthorityJSONBytes     int64  `json:"authority_json_bytes" minimum:"1"`
+	PreviewToken           string `json:"preview_token" minLength:"43" maxLength:"43"`
+	ExpiresAt              string `json:"expires_at" format:"date-time"`
+}
+
+// AuditScopeStatus is one permanent scope and the evidence needed to identify
+// its target, enrollment boundary, and current chain head.
+type AuditScopeStatus struct {
+	ID                string `json:"id" format:"uuid"`
+	TargetNodeID      int64  `json:"target_node_id" minimum:"1"`
+	TargetPath        string `json:"target_path,omitempty"`
+	TargetTrashed     bool   `json:"target_trashed"`
+	EnableOperationID string `json:"enable_operation_id" format:"uuid"`
+	BaselineDigest    string `json:"baseline_digest" pattern:"^[0-9a-f]{64}$"`
+	MemberCount       int    `json:"member_count" minimum:"1"`
+	EntryCount        int64  `json:"entry_count" minimum:"1"`
+	ChainHead         string `json:"chain_head" pattern:"^[0-9a-f]{64}$"`
+}
+
+// AuditMembershipStatus describes one inspected node's sticky scope bindings.
+type AuditMembershipStatus struct {
+	NodeID          int64    `json:"node_id" minimum:"1"`
+	Path            string   `json:"path,omitempty"`
+	Trashed         bool     `json:"trashed"`
+	Protected       bool     `json:"protected"`
+	ScopeIDs        []string `json:"scope_ids" format:"uuid"`
+	BaselineDigests []string `json:"baseline_digests" pattern:"^[0-9a-f]{64}$"`
+}
+
+// AuditStatus reports dormant or active vault authority and optional node
+// membership. Scopes is always a JSON array, including for a dormant vault.
+type AuditStatus struct {
+	Enabled                    bool                   `json:"enabled"`
+	VaultID                    string                 `json:"vault_id" format:"uuid"`
+	LineageID                  string                 `json:"lineage_id,omitempty" format:"uuid"`
+	OperationSequenceHighWater int64                  `json:"operation_sequence_high_water" minimum:"0"`
+	AllocationEntryCount       int64                  `json:"allocation_entry_count" minimum:"0"`
+	AllocationHead             string                 `json:"allocation_head,omitempty" pattern:"^[0-9a-f]{64}$"`
+	Scopes                     []AuditScopeStatus     `json:"scopes"`
+	Membership                 *AuditMembershipStatus `json:"membership,omitempty"`
+}
+
 // ContentVerification binds a fresh physical read to the exact node revision
 // the caller inspected. BlobHash and Size are catalog identity; ComputedHash
 // and ComputedSize describe the bytes read through the mixed store.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -751,7 +751,7 @@ func validateAuditStatus(status api.AuditStatus) error {
 		len(status.Scopes) == 0 {
 		return errors.New("active audit status lacks complete authority")
 	}
-	seen := make(map[string]string, len(status.Scopes))
+	seen := make(map[string]bool, len(status.Scopes))
 	previousScopeID := ""
 	for index, scope := range status.Scopes {
 		_, duplicate := seen[scope.ID]
@@ -763,7 +763,7 @@ func validateAuditStatus(status api.AuditStatus) error {
 			scope.MemberCount < 1 || scope.EntryCount < 1 || !validSHA256Hex(scope.ChainHead) {
 			return fmt.Errorf("audit status scope %d has invalid authority", index)
 		}
-		seen[scope.ID] = scope.BaselineDigest
+		seen[scope.ID] = true
 		previousScopeID = scope.ID
 	}
 	if status.Membership != nil {
@@ -777,9 +777,9 @@ func validateAuditStatus(status api.AuditStatus) error {
 		previousScopeID = ""
 		for index, scopeID := range member.ScopeIDs {
 			digest := member.BaselineDigests[index]
-			expectedDigest, knownScope := seen[scopeID]
+			knownScope := seen[scopeID]
 			if !validUUIDv4(scopeID) || !validSHA256Hex(digest) ||
-				!knownScope || expectedDigest != digest ||
+				!knownScope ||
 				(previousScopeID != "" && scopeID <= previousScopeID) {
 				return errors.New("audit status has invalid node membership binding")
 			}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -751,7 +751,11 @@ func validateAuditStatus(status api.AuditStatus) error {
 		len(status.Scopes) == 0 {
 		return errors.New("active audit status lacks complete authority")
 	}
-	seen := make(map[string]bool, len(status.Scopes))
+	type scopeMembershipAuthority struct {
+		targetNodeID   int64
+		baselineDigest string
+	}
+	seen := make(map[string]scopeMembershipAuthority, len(status.Scopes))
 	previousScopeID := ""
 	for index, scope := range status.Scopes {
 		_, duplicate := seen[scope.ID]
@@ -763,7 +767,9 @@ func validateAuditStatus(status api.AuditStatus) error {
 			scope.MemberCount < 1 || scope.EntryCount < 1 || !validSHA256Hex(scope.ChainHead) {
 			return fmt.Errorf("audit status scope %d has invalid authority", index)
 		}
-		seen[scope.ID] = true
+		seen[scope.ID] = scopeMembershipAuthority{
+			targetNodeID: scope.TargetNodeID, baselineDigest: scope.BaselineDigest,
+		}
 		previousScopeID = scope.ID
 	}
 	if status.Membership != nil {
@@ -777,9 +783,10 @@ func validateAuditStatus(status api.AuditStatus) error {
 		previousScopeID = ""
 		for index, scopeID := range member.ScopeIDs {
 			digest := member.BaselineDigests[index]
-			knownScope := seen[scopeID]
+			scope, knownScope := seen[scopeID]
 			if !validUUIDv4(scopeID) || !validSHA256Hex(digest) ||
 				!knownScope ||
+				(member.NodeID == scope.targetNodeID && digest != scope.baselineDigest) ||
 				(previousScopeID != "" && scopeID <= previousScopeID) {
 				return errors.New("audit status has invalid node membership binding")
 			}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -131,6 +131,8 @@ var codeToTypedErr = map[string]error{
 	"version_node_mismatch":    store.ErrVersionNodeMismatch,
 	"version_already_current":  store.ErrVersionAlreadyCurrent,
 	"invalid_version_prune":    store.ErrInvalidVersionPrune,
+	"audit_already_enabled":    store.ErrAuditAlreadyEnabled,
+	"audit_preview_stale":      store.ErrAuditPreviewStale,
 	"backup_locked":            backup.ErrRepoLocked,
 	"pack_retirement_deferred": packstore.ErrPackRetirementDeferred,
 }
@@ -606,6 +608,185 @@ func (c *Client) Search(ctx context.Context, query string, limit int) (api.Searc
 	p := fmt.Sprintf("/api/v1/search?q=%s&limit=%d", url.QueryEscape(query), limit)
 	err := c.do(ctx, http.MethodGet, p, nil, nil, &out)
 	return out, err
+}
+
+// AuditPreviewOptions selects one live directory for permanent first-scope
+// enrollment. Exactly one of Path or NodeID must be supplied.
+type AuditPreviewOptions struct {
+	Path       string
+	NodeID     int64
+	AgentLabel string
+}
+
+// PreviewAudit derives the exact permanent-retention boundary without
+// changing the vault and returns a short-lived, daemon-local execution token.
+func (c *Client) PreviewAudit(
+	ctx context.Context, opts AuditPreviewOptions,
+) (api.AuditEnrollmentPreview, error) {
+	var preview api.AuditEnrollmentPreview
+	if (opts.Path == "") == (opts.NodeID == 0) {
+		return preview, errors.New("audit preview requires exactly one path or node ID")
+	}
+	if opts.Path != "" && !strings.HasPrefix(opts.Path, "/") {
+		return preview, errors.New("audit preview path must be absolute")
+	}
+	if opts.NodeID < 0 {
+		return preview, errors.New("audit preview node ID must be positive")
+	}
+	body := map[string]any{}
+	if opts.Path != "" {
+		body["path"] = opts.Path
+	} else {
+		body["node_id"] = opts.NodeID
+	}
+	if opts.AgentLabel != "" {
+		body["agent_label"] = opts.AgentLabel
+	}
+	err := c.do(ctx, http.MethodPost, "/api/v1/audit/preview", nil, body, &preview)
+	if err != nil {
+		return preview, err
+	}
+	if err := validateAuditPreview(preview); err != nil {
+		return api.AuditEnrollmentPreview{}, err
+	}
+	return preview, nil
+}
+
+// EnableAudit consumes one preview after the caller has explicitly accepted
+// permanent retention. A token is one-use even when execution rolls back.
+func (c *Client) EnableAudit(
+	ctx context.Context, previewToken string, acknowledgePermanentRetention bool,
+) (api.AuditStatus, error) {
+	var status api.AuditStatus
+	if previewToken == "" {
+		return status, errors.New("audit enable requires a preview token")
+	}
+	if !acknowledgePermanentRetention {
+		return status, errors.New("audit enable requires permanent-retention acknowledgment")
+	}
+	err := c.do(ctx, http.MethodPost, "/api/v1/audit/enable", nil, map[string]any{
+		"preview_token":                   previewToken,
+		"acknowledge_permanent_retention": acknowledgePermanentRetention,
+	}, &status)
+	if err != nil {
+		return status, err
+	}
+	if err := validateAuditStatus(status); err != nil {
+		return api.AuditStatus{}, err
+	}
+	if !status.Enabled {
+		return api.AuditStatus{}, errors.New("audit enable response reports dormant authority")
+	}
+	return status, nil
+}
+
+// AuditStatus returns vault-wide authority and, when selected, one node's
+// sticky protection bindings. At most one of path and nodeID may be supplied.
+func (c *Client) AuditStatus(
+	ctx context.Context, path string, nodeID int64,
+) (api.AuditStatus, error) {
+	var status api.AuditStatus
+	if path != "" && nodeID != 0 {
+		return status, errors.New("audit status accepts at most one path or node ID")
+	}
+	if path != "" && !strings.HasPrefix(path, "/") {
+		return status, errors.New("audit status path must be absolute")
+	}
+	if nodeID < 0 {
+		return status, errors.New("audit status node ID must be positive")
+	}
+	query := url.Values{}
+	if path != "" {
+		query.Set("path", path)
+	}
+	if nodeID != 0 {
+		query.Set("node_id", strconv.FormatInt(nodeID, 10))
+	}
+	requestPath := "/api/v1/audit/status"
+	if encoded := query.Encode(); encoded != "" {
+		requestPath += "?" + encoded
+	}
+	if err := c.do(ctx, http.MethodGet, requestPath, nil, nil, &status); err != nil {
+		return status, err
+	}
+	if err := validateAuditStatus(status); err != nil {
+		return api.AuditStatus{}, err
+	}
+	return status, nil
+}
+
+func validateAuditPreview(preview api.AuditEnrollmentPreview) error {
+	secret, tokenErr := base64.RawURLEncoding.Strict().DecodeString(preview.PreviewToken)
+	expiresAt, timeErr := time.Parse(time.RFC3339Nano, preview.ExpiresAt)
+	if !validUUIDv4(preview.VaultID) || !validUUIDv4(preview.ScopeID) ||
+		!validUUIDv4(preview.OperationID) || preview.TargetNodeID < 1 ||
+		!strings.HasPrefix(preview.TargetPath, "/") || !validSHA256Hex(preview.BaselineDigest) ||
+		preview.MemberCount < 1 || preview.FileCount < 0 || preview.DirectoryCount < 1 ||
+		preview.FileCount+preview.DirectoryCount != preview.MemberCount ||
+		preview.VersionCount < 0 || preview.LogicalVersionBytes < 0 ||
+		preview.VersionCount < preview.FileCount ||
+		preview.UniqueBlobs < 0 || preview.UniqueBlobs > preview.VersionCount ||
+		preview.UniqueBlobBytes < 0 || preview.UniqueBlobBytes > preview.LogicalVersionBytes ||
+		preview.UnresolvedTrashOrigins < 0 || preview.UnresolvedTrashOrigins > preview.MemberCount ||
+		preview.VaultTopologyNodes < preview.MemberCount || preview.VaultAttachmentRecords < 0 ||
+		preview.AuthorityJSONBytes < 1 || tokenErr != nil || len(secret) != 32 ||
+		timeErr != nil || expiresAt.Location() != time.UTC {
+		return errors.New("audit preview response has inconsistent authority or inventory")
+	}
+	return nil
+}
+
+func validateAuditStatus(status api.AuditStatus) error {
+	if !validUUIDv4(status.VaultID) || status.OperationSequenceHighWater < 0 ||
+		status.AllocationEntryCount < 0 {
+		return errors.New("audit status has invalid vault identity or counters")
+	}
+	if !status.Enabled {
+		if status.LineageID != "" || status.OperationSequenceHighWater != 0 ||
+			status.AllocationEntryCount != 0 || status.AllocationHead != "" || len(status.Scopes) != 0 {
+			return errors.New("dormant audit status contains active authority")
+		}
+	} else if !validUUIDv4(status.LineageID) || status.OperationSequenceHighWater < 1 ||
+		status.AllocationEntryCount < 1 || !validSHA256Hex(status.AllocationHead) ||
+		len(status.Scopes) == 0 {
+		return errors.New("active audit status lacks complete authority")
+	}
+	seen := make(map[string]string, len(status.Scopes))
+	previousScopeID := ""
+	for index, scope := range status.Scopes {
+		_, duplicate := seen[scope.ID]
+		if !validUUIDv4(scope.ID) || duplicate ||
+			(previousScopeID != "" && scope.ID <= previousScopeID) || scope.TargetNodeID < 1 ||
+			(!scope.TargetTrashed && !strings.HasPrefix(scope.TargetPath, "/")) ||
+			(scope.TargetTrashed && scope.TargetPath != "") ||
+			!validUUIDv4(scope.EnableOperationID) || !validSHA256Hex(scope.BaselineDigest) ||
+			scope.MemberCount < 1 || scope.EntryCount < 1 || !validSHA256Hex(scope.ChainHead) {
+			return fmt.Errorf("audit status scope %d has invalid authority", index)
+		}
+		seen[scope.ID] = scope.BaselineDigest
+		previousScopeID = scope.ID
+	}
+	if status.Membership != nil {
+		member := status.Membership
+		if member.NodeID < 1 || (!member.Trashed && !strings.HasPrefix(member.Path, "/")) ||
+			(member.Trashed && member.Path != "") || member.Protected != (len(member.ScopeIDs) != 0) ||
+			(member.Protected && !status.Enabled) ||
+			len(member.ScopeIDs) != len(member.BaselineDigests) {
+			return errors.New("audit status has invalid node membership")
+		}
+		previousScopeID = ""
+		for index, scopeID := range member.ScopeIDs {
+			digest := member.BaselineDigests[index]
+			expectedDigest, knownScope := seen[scopeID]
+			if !validUUIDv4(scopeID) || !validSHA256Hex(digest) ||
+				!knownScope || expectedDigest != digest ||
+				(previousScopeID != "" && scopeID <= previousScopeID) {
+				return errors.New("audit status has invalid node membership binding")
+			}
+			previousScopeID = scopeID
+		}
+	}
+	return nil
 }
 
 // Tags returns one bounded name-sorted page of tag definitions.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -99,6 +99,57 @@ func TestRoundTrip(t *testing.T) {
 	assert.Equal(t, "/docs", restored.Path)
 }
 
+func TestAuditStatusBindsOnlyScopeTargetToEnrollmentBaseline(t *testing.T) {
+	const (
+		vaultID     = "11111111-1111-4111-8111-111111111111"
+		lineageID   = "22222222-2222-4222-8222-222222222222"
+		scopeID     = "33333333-3333-4333-8333-333333333333"
+		operationID = "44444444-4444-4444-8444-444444444444"
+	)
+	enrollmentDigest := strings.Repeat("a", 64)
+	inheritedDigest := strings.Repeat("b", 64)
+	base := api.AuditStatus{
+		Enabled: true, VaultID: vaultID, LineageID: lineageID,
+		OperationSequenceHighWater: 2, AllocationEntryCount: 2,
+		AllocationHead: strings.Repeat("c", 64),
+		Scopes: []api.AuditScopeStatus{{
+			ID: scopeID, TargetNodeID: 7, TargetPath: "/Taxes",
+			EnableOperationID: operationID, BaselineDigest: enrollmentDigest,
+			MemberCount: 2, EntryCount: 2, ChainHead: strings.Repeat("d", 64),
+		}},
+	}
+	tests := []struct {
+		name    string
+		nodeID  int64
+		path    string
+		digest  string
+		wantErr bool
+	}{
+		{name: "scope target", nodeID: 7, path: "/Taxes", digest: enrollmentDigest},
+		{name: "inherited node", nodeID: 8, path: "/Taxes/2027", digest: inheritedDigest},
+		{name: "mismatched scope target", nodeID: 7, path: "/Taxes", digest: inheritedDigest, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status := base
+			status.Membership = &api.AuditMembershipStatus{
+				NodeID: test.nodeID, Path: test.path, Protected: true,
+				ScopeIDs: []string{scopeID}, BaselineDigests: []string{test.digest},
+			}
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(status)
+			}))
+			t.Cleanup(ts.Close)
+			_, err := client.New(ts.URL, "key").AuditStatus(t.Context(), "", test.nodeID)
+			if test.wantErr {
+				require.ErrorContains(t, err, "invalid node membership binding")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestTagRoundTrip(t *testing.T) {
 	c, s := newClient(t, serverKey)
 	ctx := t.Context()

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "17"
+	daemonProtocolVersion = "18"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/audit_enrollment.go
+++ b/internal/store/audit_enrollment.go
@@ -44,33 +44,16 @@ type initialAuditValues struct {
 	cause, eventKind                         audit.Value
 }
 
-// initializeAuditAuthority creates the first audit authority. It remains
-// internal until ordinary logical mutations either extend that authority or
-// fail through the shared Go mutation boundary with useful operator guidance.
+// initializeAuditAuthority creates the first authority in one store call.
+// Public callers use the preview-bound path in audit_public.go instead.
 func (s *Store) initializeAuditAuthority(
 	ctx context.Context, targetNodeID int64, origin string, agentLabel *string,
 ) (initialAuditEnrollmentResult, error) {
-	scopeID, err := newUUIDv4()
+	input, err := newInitialAuditEnrollmentInput(targetNodeID, origin, agentLabel)
 	if err != nil {
 		return initialAuditEnrollmentResult{}, err
 	}
-	operationID, err := newUUIDv4()
-	if err != nil {
-		return initialAuditEnrollmentResult{}, err
-	}
-	lineageID, err := newUUIDv4()
-	if err != nil {
-		return initialAuditEnrollmentResult{}, err
-	}
-	return s.initializeAuditAuthorityWithInput(ctx, initialAuditEnrollmentInput{
-		targetNodeID: targetNodeID,
-		scopeID:      scopeID,
-		operationID:  operationID,
-		lineageID:    lineageID,
-		recordedAt:   nowRFC3339(),
-		origin:       origin,
-		agentLabel:   agentLabel,
-	})
+	return s.initializeAuditAuthorityWithInput(ctx, input)
 }
 
 func (s *Store) initializeAuditAuthorityWithInput(

--- a/internal/store/audit_public.go
+++ b/internal/store/audit_public.go
@@ -120,6 +120,9 @@ func (s *Store) previewInitialAudit(
 		if err != nil {
 			return err
 		}
+		if err := validateLiveAuditEnrollmentTarget(tx, targetNodeID); err != nil {
+			return err
+		}
 		input, err := newInitialAuditEnrollmentInput(targetNodeID, origin, agentLabel)
 		if err != nil {
 			return err
@@ -182,15 +185,23 @@ func (s *Store) EnableInitialAudit(
 }
 
 func requireLiveAuditPreviewTarget(tx *sql.Tx, targetNodeID int64) error {
+	err := validateLiveAuditEnrollmentTarget(tx, targetNodeID)
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrNotDir) {
+		return ErrAuditPreviewStale
+	}
+	return err
+}
+
+func validateLiveAuditEnrollmentTarget(tx *sql.Tx, targetNodeID int64) error {
 	target, err := nodeByIDTx(tx, targetNodeID)
-	if errors.Is(err, ErrNotFound) {
-		return ErrAuditPreviewStale
-	}
 	if err != nil {
-		return err
+		return fmt.Errorf("audit enrollment target %d: %w", targetNodeID, err)
 	}
-	if target.TrashedAt != nil || !target.IsDir() {
-		return ErrAuditPreviewStale
+	if target.TrashedAt != nil {
+		return fmt.Errorf("audit enrollment target %d is trashed: %w", targetNodeID, ErrNotFound)
+	}
+	if !target.IsDir() {
+		return fmt.Errorf("audit enrollment target %d: %w", targetNodeID, ErrNotDir)
 	}
 	return nil
 }
@@ -385,7 +396,10 @@ func initialAuditMetadataJSONBytes(set initialAuditEnrollmentSet) (int64, error)
 	counter := new(metadataByteCounter)
 	write := newMetadataJSONWriter(counter)
 	input := set.input
-	targetNodeID := uint64(input.targetNodeID) //nolint:gosec // positivity is checked above
+	targetNodeID, err := positiveAuditNodeID(input.targetNodeID)
+	if err != nil {
+		return 0, err
+	}
 	if err := write(metadataAuditAuthority{
 		Type: metadataAuditAuthorityType, LineageID: input.lineageID,
 		OperationSequenceHighWater: 1,

--- a/internal/store/audit_public.go
+++ b/internal/store/audit_public.go
@@ -158,6 +158,9 @@ func (s *Store) EnableInitialAudit(
 		if err := requireDormantAuditAuthority(ctx, tx); err != nil {
 			return err
 		}
+		if err := requireLiveAuditPreviewTarget(tx, plan.input.targetNodeID); err != nil {
+			return err
+		}
 		set, err := buildInitialAuditEnrollment(ctx, tx, s.vaultID, plan.input)
 		if err != nil {
 			return err
@@ -176,6 +179,20 @@ func (s *Store) EnableInitialAudit(
 		return err
 	})
 	return status, err
+}
+
+func requireLiveAuditPreviewTarget(tx *sql.Tx, targetNodeID int64) error {
+	target, err := nodeByIDTx(tx, targetNodeID)
+	if errors.Is(err, ErrNotFound) {
+		return ErrAuditPreviewStale
+	}
+	if err != nil {
+		return err
+	}
+	if target.TrashedAt != nil || !target.IsDir() {
+		return ErrAuditPreviewStale
+	}
+	return nil
 }
 
 // AuditStatus reports current authority and optionally the sticky membership

--- a/internal/store/audit_public.go
+++ b/internal/store/audit_public.go
@@ -1,0 +1,479 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+// AuditEnrollmentPreview is the exact retention boundary a caller reviews
+// before permanently enabling the first audit scope in a vault.
+type AuditEnrollmentPreview struct {
+	VaultID                string
+	ScopeID                string
+	OperationID            string
+	TargetNodeID           int64
+	TargetPath             string
+	BaselineDigest         string
+	MemberCount            int
+	FileCount              int
+	DirectoryCount         int
+	VersionCount           int
+	LogicalVersionBytes    int64
+	UniqueBlobs            int
+	UniqueBlobBytes        int64
+	UnresolvedTrashOrigins int
+	VaultTopologyNodes     int
+	VaultAttachmentRecords int
+	AuthorityJSONBytes     int64
+}
+
+// AuditEnrollmentPlan carries the server-private, non-derivable inputs behind
+// a preview. Its fields are intentionally opaque outside this package: callers
+// may present the summary, but only Store can execute the exact plan.
+type AuditEnrollmentPlan struct {
+	preview                 AuditEnrollmentPreview
+	input                   initialAuditEnrollmentInput
+	allocationGenesisDigest string
+}
+
+// Preview returns a copy of the plan's public retention inventory.
+func (plan *AuditEnrollmentPlan) Preview() AuditEnrollmentPreview {
+	if plan == nil {
+		return AuditEnrollmentPreview{}
+	}
+	return plan.preview
+}
+
+// AuditScopeStatus is one permanent scope and its current chain evidence.
+type AuditScopeStatus struct {
+	ID                string
+	TargetNodeID      int64
+	TargetPath        string
+	TargetTrashed     bool
+	EnableOperationID string
+	BaselineDigest    string
+	MemberCount       int
+	EntryCount        int64
+	ChainHead         string
+}
+
+// AuditMembershipStatus explains whether one inspected node is protected and
+// which permanent scope/baseline bindings provide that protection.
+type AuditMembershipStatus struct {
+	NodeID          int64
+	Path            string
+	Trashed         bool
+	Protected       bool
+	ScopeIDs        []string
+	BaselineDigests []string
+}
+
+// AuditStatus is the vault-wide audit authority plus optional node membership.
+type AuditStatus struct {
+	Enabled                    bool
+	VaultID                    string
+	LineageID                  string
+	OperationSequenceHighWater int64
+	AllocationEntryCount       int64
+	AllocationHead             string
+	Scopes                     []AuditScopeStatus
+	Membership                 *AuditMembershipStatus
+}
+
+// PreviewInitialAudit derives the exact first-scope authority without writing
+// it. The returned plan is useful only for EnableInitialAudit on this vault.
+func (s *Store) PreviewInitialAudit(
+	ctx context.Context, targetNodeID int64, origin string, agentLabel *string,
+) (*AuditEnrollmentPlan, error) {
+	return s.previewInitialAudit(ctx, origin, agentLabel, func(_ *sql.Tx) (int64, error) {
+		return targetNodeID, nil
+	})
+}
+
+// PreviewInitialAuditPath resolves a live path and derives its exact first
+// enrollment boundary in the same database snapshot.
+func (s *Store) PreviewInitialAuditPath(
+	ctx context.Context, path, origin string, agentLabel *string,
+) (*AuditEnrollmentPlan, error) {
+	return s.previewInitialAudit(ctx, origin, agentLabel, func(tx *sql.Tx) (int64, error) {
+		node, err := nodeByPath(ctx, tx, s.rootID, path)
+		return node.ID, err
+	})
+}
+
+func (s *Store) previewInitialAudit(
+	ctx context.Context, origin string, agentLabel *string,
+	resolveTarget func(*sql.Tx) (int64, error),
+) (*AuditEnrollmentPlan, error) {
+	var plan *AuditEnrollmentPlan
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if err := requireDormantAuditAuthority(ctx, tx); err != nil {
+			return err
+		}
+		targetNodeID, err := resolveTarget(tx)
+		if err != nil {
+			return err
+		}
+		input, err := newInitialAuditEnrollmentInput(targetNodeID, origin, agentLabel)
+		if err != nil {
+			return err
+		}
+		set, err := buildInitialAuditEnrollment(ctx, tx, s.vaultID, input)
+		if err != nil {
+			return err
+		}
+		targetPath, err := pathOf(ctx, tx, targetNodeID)
+		if err != nil {
+			return err
+		}
+		preview, err := summarizeInitialAuditEnrollment(s.vaultID, set, targetPath)
+		if err != nil {
+			return err
+		}
+		plan = &AuditEnrollmentPlan{
+			preview: preview, input: input,
+			allocationGenesisDigest: set.allocationGenesisDigest,
+		}
+		return nil
+	})
+	return plan, err
+}
+
+// EnableInitialAudit commits a previously reviewed first-scope plan only when
+// its baseline and vault-wide genesis still exactly match current metadata.
+func (s *Store) EnableInitialAudit(
+	ctx context.Context, plan *AuditEnrollmentPlan,
+) (AuditStatus, error) {
+	if plan == nil || plan.preview.VaultID != s.vaultID || plan.input.targetNodeID <= 0 {
+		return AuditStatus{}, fmt.Errorf("invalid audit enrollment plan: %w", ErrAuditPreviewStale)
+	}
+	var status AuditStatus
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if err := requireDormantAuditAuthority(ctx, tx); err != nil {
+			return err
+		}
+		set, err := buildInitialAuditEnrollment(ctx, tx, s.vaultID, plan.input)
+		if err != nil {
+			return err
+		}
+		if set.baselineDigest != plan.preview.BaselineDigest ||
+			set.allocationGenesisDigest != plan.allocationGenesisDigest {
+			return ErrAuditPreviewStale
+		}
+		if err := persistInitialAuditEnrollment(ctx, tx, set); err != nil {
+			return err
+		}
+		if err := validateMetadataState(ctx, tx, set.nodeSequence); err != nil {
+			return fmt.Errorf("validating created audit authority: %w", err)
+		}
+		status, err = auditStatusTx(ctx, tx, s.vaultID, nil)
+		return err
+	})
+	return status, err
+}
+
+// AuditStatus reports current authority and optionally the sticky membership
+// of one stable node from one consistent database snapshot.
+func (s *Store) AuditStatus(ctx context.Context, nodeID *int64) (AuditStatus, error) {
+	return s.auditStatusSnapshot(ctx, func(_ *sql.Tx) (*int64, error) { return nodeID, nil })
+}
+
+// AuditStatusPath resolves one live path and its sticky membership in the same
+// read snapshot as the vault-wide authority evidence.
+func (s *Store) AuditStatusPath(ctx context.Context, path string) (AuditStatus, error) {
+	return s.auditStatusSnapshot(ctx, func(tx *sql.Tx) (*int64, error) {
+		node, err := nodeByPath(ctx, tx, s.rootID, path)
+		if err != nil {
+			return nil, err
+		}
+		return &node.ID, nil
+	})
+}
+
+func (s *Store) auditStatusSnapshot(
+	ctx context.Context, resolveNode func(*sql.Tx) (*int64, error),
+) (AuditStatus, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return AuditStatus{}, fmt.Errorf("starting audit-status snapshot: %w", err)
+	}
+	nodeID, err := resolveNode(tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return AuditStatus{}, err
+	}
+	status, statusErr := auditStatusTx(ctx, tx, s.vaultID, nodeID)
+	if statusErr != nil {
+		_ = tx.Rollback()
+		return AuditStatus{}, statusErr
+	}
+	if err := tx.Commit(); err != nil {
+		return AuditStatus{}, fmt.Errorf("closing audit-status snapshot: %w", err)
+	}
+	return status, nil
+}
+
+func newInitialAuditEnrollmentInput(
+	targetNodeID int64, origin string, agentLabel *string,
+) (initialAuditEnrollmentInput, error) {
+	scopeID, err := newUUIDv4()
+	if err != nil {
+		return initialAuditEnrollmentInput{}, err
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return initialAuditEnrollmentInput{}, err
+	}
+	lineageID, err := newUUIDv4()
+	if err != nil {
+		return initialAuditEnrollmentInput{}, err
+	}
+	return initialAuditEnrollmentInput{
+		targetNodeID: targetNodeID, scopeID: scopeID, operationID: operationID,
+		lineageID: lineageID, recordedAt: nowRFC3339(), origin: origin,
+		agentLabel: agentLabel,
+	}, nil
+}
+
+func requireDormantAuditAuthority(ctx context.Context, tx metadataQuerier) error {
+	counts, err := auditAuthorityCounts(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if counts == [5]int64{} {
+		return nil
+	}
+	if counts[0] == 1 && counts[1] > 0 {
+		return ErrAuditAlreadyEnabled
+	}
+	return errors.New("audit authority is incomplete")
+}
+
+func summarizeInitialAuditEnrollment(
+	vaultID string, set initialAuditEnrollmentSet, targetPath string,
+) (AuditEnrollmentPreview, error) {
+	if len(set.records) != 8 {
+		return AuditEnrollmentPreview{}, errors.New("initial audit enrollment has an invalid record set")
+	}
+	baseline := set.records[3]
+	baselineNodes, err := auditRecordListField(baseline, "nodes")
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
+	}
+	versions, err := auditRecordListField(baseline, "versions")
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
+	}
+	topology, err := auditRecordListField(set.records[0], "nodes")
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
+	}
+	attachments, err := auditRecordListField(set.records[1], "records")
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
+	}
+	preview := AuditEnrollmentPreview{
+		VaultID: vaultID, ScopeID: set.input.scopeID,
+		OperationID: set.input.operationID, TargetNodeID: set.input.targetNodeID,
+		TargetPath: targetPath, BaselineDigest: set.baselineDigest,
+		MemberCount: len(set.members), VersionCount: len(versions),
+		VaultTopologyNodes: len(topology), VaultAttachmentRecords: len(attachments),
+	}
+	members := auditMemberSet(set.members)
+	for _, node := range baselineNodes {
+		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
+		if err != nil {
+			return AuditEnrollmentPreview{}, err
+		}
+		if !members[nodeID] {
+			continue
+		}
+		kind, err := auditTextField(node, "node_kind")
+		if err != nil {
+			return AuditEnrollmentPreview{}, err
+		}
+		switch kind {
+		case nodeKindDir:
+			preview.DirectoryCount++
+		case "file":
+			preview.FileCount++
+		default:
+			return AuditEnrollmentPreview{}, fmt.Errorf("audit preview contains node kind %q", kind)
+		}
+		origin, ok := audit.FieldValue(node, auditOriginField)
+		if ok && !origin.IsAbsent() {
+			record, nested := origin.RecordValue()
+			if !nested {
+				return AuditEnrollmentPreview{}, errors.New("audit preview contains invalid trash origin")
+			}
+			if record.Kind == "unknown_origin" {
+				preview.UnresolvedTrashOrigins++
+			}
+		}
+	}
+	unique := make(map[string]int64)
+	for _, version := range versions {
+		size, err := auditUnsignedField(version, "size")
+		if err != nil || size > math.MaxInt64 {
+			return AuditEnrollmentPreview{}, errors.New("audit preview contains invalid version size")
+		}
+		if preview.LogicalVersionBytes > math.MaxInt64-int64(size) {
+			return AuditEnrollmentPreview{}, errors.New("audit preview logical size overflows int64")
+		}
+		preview.LogicalVersionBytes += int64(size)
+		hash, err := auditDigestField(version, "blob_hash")
+		if err != nil {
+			return AuditEnrollmentPreview{}, err
+		}
+		if prior, exists := unique[hash]; exists && prior != int64(size) {
+			return AuditEnrollmentPreview{}, errors.New("audit preview contains inconsistent blob sizes")
+		}
+		unique[hash] = int64(size)
+	}
+	preview.UniqueBlobs = len(unique)
+	for _, size := range unique {
+		if preview.UniqueBlobBytes > math.MaxInt64-size {
+			return AuditEnrollmentPreview{}, errors.New("audit preview unique size overflows int64")
+		}
+		preview.UniqueBlobBytes += size
+	}
+	for _, record := range set.records {
+		encoded, err := audit.MarshalJSONRecord(record)
+		if err != nil {
+			return AuditEnrollmentPreview{}, err
+		}
+		if len(encoded) >= math.MaxInt || preview.AuthorityJSONBytes > math.MaxInt64-int64(len(encoded)+1) {
+			return AuditEnrollmentPreview{}, errors.New("audit preview authority size overflows int64")
+		}
+		preview.AuthorityJSONBytes += int64(len(encoded) + 1)
+	}
+	return preview, nil
+}
+
+func auditStatusTx(
+	ctx context.Context, tx *sql.Tx, vaultID string, nodeID *int64,
+) (AuditStatus, error) {
+	status := AuditStatus{VaultID: vaultID, Scopes: []AuditScopeStatus{}}
+	err := tx.QueryRowContext(ctx, `SELECT lineage_id,operation_sequence_high_water,
+		allocation_entry_count,allocation_head FROM audit_authority WHERE singleton=1`).Scan(
+		&status.LineageID, &status.OperationSequenceHighWater,
+		&status.AllocationEntryCount, &status.AllocationHead,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		if err := requireDormantAuditAuthority(ctx, tx); err != nil {
+			return AuditStatus{}, err
+		}
+		if nodeID != nil {
+			membership, err := auditMembershipStatusTx(ctx, tx, *nodeID)
+			if err != nil {
+				return AuditStatus{}, err
+			}
+			status.Membership = &membership
+		}
+		return status, nil
+	}
+	if err != nil {
+		return AuditStatus{}, fmt.Errorf("reading audit authority status: %w", err)
+	}
+	status.Enabled = true
+	rows, err := tx.QueryContext(ctx, `SELECT s.scope_id,s.target_node_id,
+		s.enable_operation_id,b.digest,s.entry_count,s.chain_head,
+		COUNT(m.node_id)
+		FROM audit_scopes s
+		JOIN audit_baselines b ON b.scope_id=s.scope_id AND b.operation_id=s.enable_operation_id
+		JOIN audit_memberships m ON m.scope_id=s.scope_id
+		GROUP BY s.scope_id,s.target_node_id,s.enable_operation_id,b.digest,
+			s.entry_count,s.chain_head ORDER BY s.scope_id`)
+	if err != nil {
+		return AuditStatus{}, fmt.Errorf("reading audit scope status: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var scope AuditScopeStatus
+		if err := rows.Scan(&scope.ID, &scope.TargetNodeID, &scope.EnableOperationID,
+			&scope.BaselineDigest, &scope.EntryCount, &scope.ChainHead,
+			&scope.MemberCount); err != nil {
+			return AuditStatus{}, fmt.Errorf("scanning audit scope status: %w", err)
+		}
+		status.Scopes = append(status.Scopes, scope)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return AuditStatus{}, fmt.Errorf("reading audit scope status: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return AuditStatus{}, fmt.Errorf("closing audit scope status: %w", err)
+	}
+	if len(status.Scopes) == 0 {
+		return AuditStatus{}, errors.New("audit authority lacks a scope")
+	}
+	for index := range status.Scopes {
+		scope := &status.Scopes[index]
+		target, err := nodeByIDTx(tx, scope.TargetNodeID)
+		if err != nil {
+			return AuditStatus{}, err
+		}
+		scope.TargetTrashed = target.TrashedAt != nil
+		if !scope.TargetTrashed {
+			scope.TargetPath, err = pathOf(ctx, tx, scope.TargetNodeID)
+			if err != nil {
+				return AuditStatus{}, err
+			}
+		}
+	}
+	if nodeID != nil {
+		membership, err := auditMembershipStatusTx(ctx, tx, *nodeID)
+		if err != nil {
+			return AuditStatus{}, err
+		}
+		status.Membership = &membership
+	}
+	return status, nil
+}
+
+func auditMembershipStatusTx(
+	ctx context.Context, tx *sql.Tx, nodeID int64,
+) (AuditMembershipStatus, error) {
+	node, err := nodeByIDTx(tx, nodeID)
+	if err != nil {
+		return AuditMembershipStatus{}, err
+	}
+	status := AuditMembershipStatus{
+		NodeID: nodeID, Trashed: node.TrashedAt != nil,
+		ScopeIDs: []string{}, BaselineDigests: []string{},
+	}
+	if !status.Trashed {
+		status.Path, err = pathOf(ctx, tx, nodeID)
+		if err != nil {
+			return AuditMembershipStatus{}, err
+		}
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT scope_id,baseline_digest
+		FROM audit_memberships WHERE node_id=? ORDER BY scope_id`, nodeID)
+	if err != nil {
+		return AuditMembershipStatus{}, fmt.Errorf("reading node audit membership: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var scopeID, digest string
+		if err := rows.Scan(&scopeID, &digest); err != nil {
+			return AuditMembershipStatus{}, fmt.Errorf("scanning node audit membership: %w", err)
+		}
+		status.ScopeIDs = append(status.ScopeIDs, scopeID)
+		status.BaselineDigests = append(status.BaselineDigests, digest)
+	}
+	if err := rows.Err(); err != nil {
+		return AuditMembershipStatus{}, fmt.Errorf("reading node audit membership: %w", err)
+	}
+	status.Protected = len(status.ScopeIDs) != 0
+	if !slices.IsSorted(status.ScopeIDs) {
+		return AuditMembershipStatus{}, errors.New("audit membership scopes are not ordered")
+	}
+	return status, nil
+}

--- a/internal/store/audit_public.go
+++ b/internal/store/audit_public.go
@@ -343,17 +343,71 @@ func summarizeInitialAuditEnrollment(
 		}
 		preview.UniqueBlobBytes += size
 	}
-	for _, record := range set.records {
-		encoded, err := audit.MarshalJSONRecord(record)
-		if err != nil {
-			return AuditEnrollmentPreview{}, err
-		}
-		if len(encoded) >= math.MaxInt || preview.AuthorityJSONBytes > math.MaxInt64-int64(len(encoded)+1) {
-			return AuditEnrollmentPreview{}, errors.New("audit preview authority size overflows int64")
-		}
-		preview.AuthorityJSONBytes += int64(len(encoded) + 1)
+	preview.AuthorityJSONBytes, err = initialAuditMetadataJSONBytes(set)
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
 	}
 	return preview, nil
+}
+
+type metadataByteCounter struct{ total int64 }
+
+func (counter *metadataByteCounter) Write(p []byte) (int, error) {
+	size := int64(len(p))
+	if counter.total > math.MaxInt64-size {
+		return 0, errors.New("audit preview metadata size overflows int64")
+	}
+	counter.total += size
+	return len(p), nil
+}
+
+func initialAuditMetadataJSONBytes(set initialAuditEnrollmentSet) (int64, error) {
+	if set.input.targetNodeID <= 0 {
+		return 0, errors.New("audit preview target node ID must be positive")
+	}
+	counter := new(metadataByteCounter)
+	write := newMetadataJSONWriter(counter)
+	input := set.input
+	targetNodeID := uint64(input.targetNodeID) //nolint:gosec // positivity is checked above
+	if err := write(metadataAuditAuthority{
+		Type: metadataAuditAuthorityType, LineageID: input.lineageID,
+		OperationSequenceHighWater: 1,
+		AllocationGenesisDigest:    set.allocationGenesisDigest,
+		AllocationEntryCount:       1, AllocationHead: set.allocationHead,
+	}); err != nil {
+		return 0, err
+	}
+	if err := write(metadataAuditScope{
+		Type: metadataAuditScopeType, ScopeID: input.scopeID,
+		TargetNodeID: targetNodeID, EnableOperationID: input.operationID,
+		EntryCount: 1, ChainHead: set.scopeHead,
+	}); err != nil {
+		return 0, err
+	}
+	for _, member := range set.members {
+		if err := write(metadataAuditMembership{
+			Type: metadataAuditMembershipType, ScopeID: input.scopeID,
+			NodeID: member, BaselineDigest: set.baselineDigest,
+		}); err != nil {
+			return 0, err
+		}
+	}
+	for _, record := range set.records {
+		digest, err := hashAuditRecord(record)
+		if err != nil {
+			return 0, err
+		}
+		recordJSON, err := audit.MarshalJSONRecord(record)
+		if err != nil {
+			return 0, fmt.Errorf("encoding projected %s audit record: %w", record.Kind, err)
+		}
+		if err := write(metadataAuditRecord{
+			Type: metadataAuditRecordType, Digest: digest.text, Record: recordJSON,
+		}); err != nil {
+			return 0, err
+		}
+	}
+	return counter.total, nil
 }
 
 func auditStatusTx(

--- a/internal/store/audit_public_test.go
+++ b/internal/store/audit_public_test.go
@@ -81,6 +81,37 @@ func TestAuditEnrollmentPreviewRejectsChangedVaultState(t *testing.T) {
 	assert.Equal(t, [5]int64{}, counts)
 }
 
+func TestAuditEnrollmentPreviewRejectsTrashedOrDeletedTargetAsStale(t *testing.T) {
+	for _, hardDelete := range []bool{false, true} {
+		name := "trashed"
+		if hardDelete {
+			name = "deleted"
+		}
+		t.Run(name, func(t *testing.T) {
+			s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, s.Close()) })
+			seedMetadataRoundTrip(t, s)
+			target, err := s.NodeByPath(t.Context(), "/Projects")
+			require.NoError(t, err)
+			plan, err := s.PreviewInitialAudit(t.Context(), target.ID, "api", nil)
+			require.NoError(t, err)
+
+			_, _, err = s.Trash(t.Context(), target.ID, target.Revision)
+			require.NoError(t, err)
+			if hardDelete {
+				_, err = s.TrashEmpty(t.Context(), 0, true)
+				require.NoError(t, err)
+			}
+			_, err = s.EnableInitialAudit(t.Context(), plan)
+			require.ErrorIs(t, err, ErrAuditPreviewStale)
+			counts, err := auditAuthorityCounts(t.Context(), s.db)
+			require.NoError(t, err)
+			assert.Equal(t, [5]int64{}, counts)
+		})
+	}
+}
+
 func TestAuditEnrollmentPreviewIsVaultBoundAndFirstActivationOnly(t *testing.T) {
 	first, err := Open(filepath.Join(t.TempDir(), "first.db"))
 	require.NoError(t, err)

--- a/internal/store/audit_public_test.go
+++ b/internal/store/audit_public_test.go
@@ -1,0 +1,131 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditEnrollmentPreviewEnablesExactReviewedAuthority(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+
+	plan, err := s.PreviewInitialAudit(t.Context(), target.ID, "api", nil)
+	require.NoError(t, err)
+	preview := plan.Preview()
+	assert.Equal(t, s.VaultID(), preview.VaultID)
+	assert.Equal(t, target.ID, preview.TargetNodeID)
+	assert.Equal(t, "/Projects", preview.TargetPath)
+	assert.Equal(t, 3, preview.MemberCount)
+	assert.Equal(t, 1, preview.DirectoryCount)
+	assert.Equal(t, 2, preview.FileCount)
+	assert.Positive(t, preview.VersionCount)
+	assert.Positive(t, preview.LogicalVersionBytes)
+	assert.Positive(t, preview.UniqueBlobs)
+	assert.Positive(t, preview.UniqueBlobBytes)
+	assert.Positive(t, preview.VaultTopologyNodes)
+	assert.Positive(t, preview.AuthorityJSONBytes)
+	require.NoError(t, validateUUIDv4(preview.ScopeID))
+	require.NoError(t, validateUUIDv4(preview.OperationID))
+	assert.Len(t, preview.BaselineDigest, 64)
+	counts, err := auditAuthorityCounts(t.Context(), s.db)
+	require.NoError(t, err)
+	assert.Equal(t, [5]int64{}, counts, "preview must not install authority")
+
+	status, err := s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+	assert.True(t, status.Enabled)
+	assert.Equal(t, s.VaultID(), status.VaultID)
+	assert.Equal(t, int64(1), status.OperationSequenceHighWater)
+	assert.Equal(t, int64(1), status.AllocationEntryCount)
+	require.Len(t, status.Scopes, 1)
+	assert.Equal(t, preview.ScopeID, status.Scopes[0].ID)
+	assert.Equal(t, preview.OperationID, status.Scopes[0].EnableOperationID)
+	assert.Equal(t, preview.BaselineDigest, status.Scopes[0].BaselineDigest)
+	assert.Equal(t, preview.MemberCount, status.Scopes[0].MemberCount)
+	assert.Equal(t, preview.TargetPath, status.Scopes[0].TargetPath)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assertAuditMetadataRoundTrip(t, s)
+}
+
+func TestAuditEnrollmentPreviewRejectsChangedVaultState(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	target, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	plan, err := s.PreviewInitialAudit(t.Context(), target.ID, "api", nil)
+	require.NoError(t, err)
+
+	_, err = s.Mkdir(t.Context(), s.RootID(), "Changed after preview")
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), plan)
+	require.ErrorIs(t, err, ErrAuditPreviewStale)
+	counts, err := auditAuthorityCounts(t.Context(), s.db)
+	require.NoError(t, err)
+	assert.Equal(t, [5]int64{}, counts)
+}
+
+func TestAuditEnrollmentPreviewIsVaultBoundAndFirstActivationOnly(t *testing.T) {
+	first, err := Open(filepath.Join(t.TempDir(), "first.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, first.Close()) })
+	seedMetadataRoundTrip(t, first)
+	target, err := first.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	plan, err := first.PreviewInitialAudit(t.Context(), target.ID, "api", nil)
+	require.NoError(t, err)
+
+	second, err := Open(filepath.Join(t.TempDir(), "second.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+	_, err = second.EnableInitialAudit(t.Context(), plan)
+	require.ErrorIs(t, err, ErrAuditPreviewStale)
+
+	_, err = first.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+	_, err = first.PreviewInitialAudit(t.Context(), target.ID, "api", nil)
+	require.ErrorIs(t, err, ErrAuditAlreadyEnabled)
+	_, err = first.EnableInitialAudit(t.Context(), plan)
+	require.ErrorIs(t, err, ErrAuditAlreadyEnabled)
+}
+
+func TestAuditStatusExplainsDormantAndProtectedNodes(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+
+	status, err := s.AuditStatus(t.Context(), &report.ID)
+	require.NoError(t, err)
+	assert.False(t, status.Enabled)
+	require.NotNil(t, status.Membership)
+	assert.False(t, status.Membership.Protected)
+	assert.Equal(t, "/Projects/report.txt", status.Membership.Path)
+
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	plan, err := s.PreviewInitialAudit(t.Context(), projects.ID, "api", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+	status, err = s.AuditStatus(t.Context(), &report.ID)
+	require.NoError(t, err)
+	require.NotNil(t, status.Membership)
+	assert.True(t, status.Membership.Protected)
+	assert.Equal(t, []string{plan.Preview().ScopeID}, status.Membership.ScopeIDs)
+	assert.Equal(t, []string{plan.Preview().BaselineDigest}, status.Membership.BaselineDigests)
+
+	missing := int64(99999)
+	_, err = s.AuditStatus(t.Context(), &missing)
+	require.ErrorIs(t, err, ErrNotFound)
+}

--- a/internal/store/audit_public_test.go
+++ b/internal/store/audit_public_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
 
@@ -13,6 +14,8 @@ func TestAuditEnrollmentPreviewEnablesExactReviewedAuthority(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	seedMetadataRoundTrip(t, s)
+	var before bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &before))
 	target, err := s.NodeByPath(t.Context(), "/Projects")
 	require.NoError(t, err)
 
@@ -51,6 +54,11 @@ func TestAuditEnrollmentPreviewEnablesExactReviewedAuthority(t *testing.T) {
 	assert.Equal(t, preview.MemberCount, status.Scopes[0].MemberCount)
 	assert.Equal(t, preview.TargetPath, status.Scopes[0].TargetPath)
 	require.NoError(t, s.ValidateMetadata(t.Context()))
+	var after bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &after))
+	require.Greater(t, after.Len(), before.Len())
+	assert.Equal(t, int64(after.Len()-before.Len()), preview.AuthorityJSONBytes,
+		"preview must count the exact metadata-v1 audit JSONL growth")
 	assertAuditMetadataRoundTrip(t, s)
 }
 

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -36,6 +36,13 @@ var (
 	// ErrAuditMutationUnsupported means an audited vault cannot perform a
 	// logical mutation until that mutation records its audit transition.
 	ErrAuditMutationUnsupported = errors.New("mutation is not supported for an audited vault")
+	// ErrAuditAlreadyEnabled means first-scope enrollment cannot run because
+	// this vault already has audit authority. Later scope enrollment is a
+	// separate operation with different closure semantics.
+	ErrAuditAlreadyEnabled = errors.New("audit is already enabled for this vault")
+	// ErrAuditPreviewStale means enrollment no longer matches the exact
+	// metadata state reviewed by the caller.
+	ErrAuditPreviewStale = errors.New("audit enrollment preview is stale")
 )
 
 // UnconditionalRev is the only ifRev value that skips the revision

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -253,14 +253,7 @@ func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer
 	if err := validateMetadataState(ctx, tx, nodeSequence); err != nil {
 		return fmt.Errorf("validating metadata snapshot: %w", err)
 	}
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	write := func(v any) error {
-		if err := enc.Encode(v); err != nil {
-			return fmt.Errorf("encoding metadata: %w", err)
-		}
-		return nil
-	}
+	write := newMetadataJSONWriter(w)
 	if err := write(metadataHeader{
 		Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion,
 		VaultID: vaultID, NodeSequence: nodeSequence,
@@ -295,6 +288,20 @@ func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer
 }
 
 type metadataWrite func(any) error
+
+// newMetadataJSONWriter is the single JSONL encoding boundary used by exports
+// and exact projected-size calculations. Keeping both on this encoder prevents
+// previews from estimating a different wire representation than backups use.
+func newMetadataJSONWriter(w io.Writer) metadataWrite {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return func(v any) error {
+		if err := enc.Encode(v); err != nil {
+			return fmt.Errorf("encoding metadata: %w", err)
+		}
+		return nil
+	}
+}
 
 func exportBlobs(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `SELECT hash, size, created_at FROM blobs ORDER BY hash`)


### PR DESCRIPTION
Docbank can already preserve and validate audited history, but until now that capability was internal: a person or agent could not safely place a real directory under permanent retention. This PR makes that promise usable without turning an irreversible choice into a one-step footgun.

`docbank audit enable /taxes` is a preview. It explains how many directories, files, versions, and bytes will become permanent and returns a short-lived one-use token. Because first activation also commits the vault-wide evidence needed to prove identity and rollback, the preview explicitly discloses that enrollment-time names, topology, tags, assignments, ingests, and provenance outside `/taxes` remain permanent metadata. Unrelated content versions do not become members. The reported JSONL growth is calculated through the same encoder and complete envelope set used by backup export, so it matches the actual metadata increase rather than counting only raw audit payloads.

Enabling is a separate command with an explicit acknowledgment of both protected history and vault-wide metadata retention. Before committing, the daemon rebuilds the reviewed authority; if the vault changed, it rejects the token and asks for a fresh preview.

Afterward, `docbank audit status` exposes the stable scope, baseline, lineage, and chain evidence. Supplying a path or node ID answers the practical question: “is this document permanently protected, and by which scope?” The same workflow is available through the authenticated HTTP API and typed client, and the daemon protocol advances so an older process can never receive these commands.

This intentionally exposes only the first scope. Additional scopes, event-history browsing, and independent audit verification remain separate work, keeping this review centered on one complete operator workflow. The human and agent documentation now describes the implemented boundary and no longer presents the whole audit model as merely planned.

The behavior is exercised end to end across preview, exact export growth, acknowledgment, stale and reused tokens, daemon restart, status and membership, both SQLite implementations, and stale-daemon replacement.