### PR TITLE
Expose audited node history

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ metadata, content, and maintenance authority.
 - Stable tags with define, rename, assign, unassign, delete, and bounded
   node/tag listings
 - Preview-first permanent audit enrollment for one directory scope, with
-  sticky retention, recorded supported mutations, status evidence, and
-  backup/restore fidelity
+  sticky retention, recorded supported mutations, status evidence, bounded
+  per-node history, and backup/restore fidelity
 - FTS5 name search (document-body extraction and search are planned)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification

--- a/cmd/docbank/audit_history.go
+++ b/cmd/docbank/audit_history.go
@@ -70,7 +70,8 @@ func writeAuditHistory(w io.Writer, page api.AuditEventPage) error {
 		}
 		if event.OldPath != nil && event.NewPath != nil {
 			if _, err := fmt.Fprintf(w, "  path: %s -> %s\n",
-				auditDisplayPath(*event.OldPath), auditDisplayPath(*event.NewPath)); err != nil {
+				auditDisplayPath(event.OldPath.Path),
+				auditDisplayPath(event.NewPath.Path)); err != nil {
 				return fmt.Errorf("writing audit history: %w", err)
 			}
 		}
@@ -86,6 +87,11 @@ func writeAuditHistory(w io.Writer, page api.AuditEventPage) error {
 				return fmt.Errorf("writing audit history: %w", err)
 			}
 		}
+		if event.Attachment != nil {
+			if err := writeAuditAttachment(w, *event.Attachment); err != nil {
+				return err
+			}
+		}
 	}
 	if page.NextCursor != "" {
 		if _, err := fmt.Fprintln(w, "next cursor: "+page.NextCursor); err != nil {
@@ -93,6 +99,53 @@ func writeAuditHistory(w io.Writer, page api.AuditEventPage) error {
 		}
 	}
 	return nil
+}
+
+func writeAuditAttachment(w io.Writer, change api.AuditAttachmentChange) error {
+	var summary string
+	switch change.Kind {
+	case "tag_definition":
+		summary = fmt.Sprintf("tag %s: %s -> %s", change.Identity.TagID,
+			auditTagState(change.Before), auditTagState(change.After))
+	case "tag_assignment":
+		summary = fmt.Sprintf("tag %s on node %d: %s -> %s",
+			change.Identity.TagID, change.Identity.NodeID,
+			auditPresence(change.Before), auditPresence(change.After))
+	case "provenance":
+		summary = fmt.Sprintf("provenance %s: %s -> %s", change.Identity.ProvenanceID,
+			auditProvenanceState(change.Before), auditProvenanceState(change.After))
+	default:
+		return fmt.Errorf("writing audit history: unknown attachment kind %q", change.Kind)
+	}
+	if _, err := fmt.Fprintln(w, "  "+summary); err != nil {
+		return fmt.Errorf("writing audit history: %w", err)
+	}
+	return nil
+}
+
+func auditTagState(state *api.AuditAttachmentState) string {
+	if state == nil {
+		return "(absent)"
+	}
+	return auditDisplayPath(state.TagName)
+}
+
+func auditPresence(state *api.AuditAttachmentState) string {
+	if state == nil {
+		return "absent"
+	}
+	return "present"
+}
+
+func auditProvenanceState(state *api.AuditAttachmentState) string {
+	if state == nil {
+		return "(absent)"
+	}
+	path := "(path absent)"
+	if state.OriginalPath != nil {
+		path = auditDisplayPath(*state.OriginalPath)
+	}
+	return fmt.Sprintf("%s via ingest %s", path, state.IngestID)
 }
 
 func auditOptionalValue(value *string) string {

--- a/cmd/docbank/audit_history.go
+++ b/cmd/docbank/audit_history.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+var (
+	auditHistoryNodeID int64
+	auditHistoryLimit  int
+	auditHistoryCursor string
+	auditHistoryJSON   bool
+)
+
+var auditHistoryCmd = &cobra.Command{
+	Use:   "history [path]",
+	Short: "Read one permanently protected node's canonical event timeline",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if (len(args) == 0) == (auditHistoryNodeID == 0) {
+			return errors.New("audit history requires exactly one path or --node-id")
+		}
+		path := ""
+		if len(args) == 1 {
+			path = args[0]
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		page, err := c.AuditHistory(
+			cmd.Context(), path, auditHistoryNodeID, auditHistoryLimit, auditHistoryCursor,
+		)
+		if err != nil {
+			return err
+		}
+		if auditHistoryJSON {
+			return writeAuditJSON(cmd.OutOrStdout(), page)
+		}
+		return writeAuditHistory(cmd.OutOrStdout(), page)
+	},
+}
+
+func writeAuditHistory(w io.Writer, page api.AuditEventPage) error {
+	coordinate := auditDisplayPath(page.Path)
+	if page.Node.TrashedAt != "" {
+		coordinate = fmt.Sprintf("node %d in trash", page.Node.ID)
+	}
+	if _, err := fmt.Fprintf(w, "audit history for %s (node %d): %d recorded event(s)\n",
+		coordinate, page.Node.ID, page.Total); err != nil {
+		return fmt.Errorf("writing audit history: %w", err)
+	}
+	if len(page.Items) == 0 {
+		if _, err := fmt.Fprintln(w,
+			"no events on this page; the node is still permanently protected"); err != nil {
+			return fmt.Errorf("writing audit history: %w", err)
+		}
+	}
+	for _, event := range page.Items {
+		if _, err := fmt.Fprintf(w, "%s  %s  operation %d.%d  revision %d -> %d\n",
+			event.RecordedAt, event.Kind, event.OperationSequence, event.Ordinal,
+			event.PriorNodeRevision, event.ResultingNodeRevision); err != nil {
+			return fmt.Errorf("writing audit history: %w", err)
+		}
+		if event.OldPath != nil && event.NewPath != nil {
+			if _, err := fmt.Fprintf(w, "  path: %s -> %s\n",
+				auditDisplayPath(*event.OldPath), auditDisplayPath(*event.NewPath)); err != nil {
+				return fmt.Errorf("writing audit history: %w", err)
+			}
+		}
+		if event.PriorCurrentVersionID != nil || event.ResultingCurrentVersionID != nil {
+			if _, err := fmt.Fprintf(w, "  version: %s -> %s\n",
+				auditOptionalValue(event.PriorCurrentVersionID),
+				auditOptionalValue(event.ResultingCurrentVersionID)); err != nil {
+				return fmt.Errorf("writing audit history: %w", err)
+			}
+		}
+		if event.AgentLabel != nil {
+			if _, err := fmt.Fprintf(w, "  agent: %s\n", auditDisplayPath(*event.AgentLabel)); err != nil {
+				return fmt.Errorf("writing audit history: %w", err)
+			}
+		}
+	}
+	if page.NextCursor != "" {
+		if _, err := fmt.Fprintln(w, "next cursor: "+page.NextCursor); err != nil {
+			return fmt.Errorf("writing audit history: %w", err)
+		}
+	}
+	return nil
+}
+
+func auditOptionalValue(value *string) string {
+	if value == nil {
+		return "(none)"
+	}
+	return *value
+}
+
+func init() {
+	auditHistoryCmd.Flags().Int64Var(&auditHistoryNodeID, "node-id", 0,
+		"stable node ID, including a node in trash (alternative to path)")
+	auditHistoryCmd.Flags().IntVar(&auditHistoryLimit, "limit", 50,
+		"maximum events to return (1-500)")
+	auditHistoryCmd.Flags().StringVar(&auditHistoryCursor, "cursor", "",
+		"opaque continuation cursor from the preceding page")
+	auditHistoryCmd.Flags().BoolVar(&auditHistoryJSON, "json", false,
+		"machine-readable output")
+	auditCmd.AddCommand(auditHistoryCmd)
+}

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -184,6 +184,17 @@ func TestAuditEnableIsPreviewFirstAndReportsProtection(t *testing.T) {
 	replacement := writeSourceFile(t, "replacement.txt", "amended return")
 	_, err = runCLI(t, "put", replacement, "/Taxes/return.txt", "--progress", "plain")
 	require.NoError(t, err)
+	out, err = runCLI(t, "audit", "history", "/Taxes/return.txt", "--json")
+	require.NoError(t, err, out)
+	var history api.AuditEventPage
+	require.NoError(t, json.Unmarshal([]byte(out), &history))
+	require.NotEmpty(t, history.Items)
+	assert.Equal(t, "content_replace", history.Items[0].Kind)
+	assert.Equal(t, "/Taxes/return.txt", history.Path)
+	humanHistory, err := runCLI(t, "audit", "history", "/Taxes/return.txt")
+	require.NoError(t, err, humanHistory)
+	assert.Contains(t, humanHistory, "content_replace")
+	assert.Contains(t, humanHistory, `audit history for "/Taxes/return.txt"`)
 
 	_, err = runCLI(t, "audit", "enable", "--run", "--token", preview.PreviewToken,
 		"--acknowledge-permanent-retention")

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -157,7 +157,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "18", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "19", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "18", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "19", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -321,6 +321,20 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	auditPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, prunePID, auditPID)
 
+	// Protocol 18 predates bounded audit-history reads. Replace it before the
+	// CLI reaches a same-version daemon that cannot expose canonical events.
+	recs[0].Metadata["protocol_version"] = "18"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "audit", "history", "/inbox/preflight.txt", "--json")
+	require.Error(t, err)
+	assert.Contains(t, out, "not enrolled in an audit scope")
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	historyPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, auditPID, historyPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -335,7 +349,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "18", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "19", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -348,7 +362,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, auditPID, protocolPID)
+	assert.NotEqual(t, historyPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -522,7 +522,11 @@ curl --fail-with-body \
 ```
 
 Events are newest first and bind stable event, operation, scope, node-revision,
-and optional path/content identities. Follow `next_cursor` to read older events;
+and optional path/content identities. A path state distinguishes `/live/paths`
+from canonical `@trash/known/...` and `@trash/unknown/...` coordinates. Tag and
+provenance events include an `attachment` object with a discriminating `kind`,
+stable `identity`, and typed `before`/`after` states, so clients do not need to
+decode canonical audit internals. Follow `next_cursor` to read older events;
 send it back unchanged and never derive meaning from its encoding. The cursor
 is node-bound and remains stable when newer operations append. Treat
 `audit_not_enrolled` as a valid answer that the node is outside permanent

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -513,6 +513,23 @@ The token expires after ten minutes, is consumed by one attempt, and does not
 survive daemon restart. On `audit_preview_stale`, preview again; never retry the
 same execution blindly. `GET /api/v1/audit/status` reports vault-wide evidence.
 Add either `?path=/taxes/file.pdf` or `?node_id=57` to inspect sticky membership.
+Read that node's canonical timeline with exactly one selector:
+
+```bash
+curl --fail-with-body \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  "$DOCBANK_URL/api/v1/audit/history?node_id=57&limit=50"
+```
+
+Events are newest first and bind stable event, operation, scope, node-revision,
+and optional path/content identities. Follow `next_cursor` to read older events;
+send it back unchanged and never derive meaning from its encoding. The cursor
+is node-bound and remains stable when newer operations append. Treat
+`audit_not_enrolled` as a valid answer that the node is outside permanent
+retention, and `invalid_audit_cursor` as a request error. A protected node may
+have an empty timeline when it was adopted at enrollment and has not changed;
+use status membership, not event count, to decide protection.
+
 The current public boundary permits one permanent scope per vault.
 
 ## Treat destructive maintenance as a two-step decision

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -1469,6 +1469,10 @@ bound to the node and to the last canonical `(operation_sequence,
 event_ordinal, event_id)` position, so later appends do not shift older pages.
 An enrolled baseline member with no later node event returns an empty timeline;
 status membership, rather than event count, remains the protection authority.
+The projection retains the canonical live/trash path-state distinction and
+turns tag/provenance identity and pre/post records into a typed attachment
+change, rather than exposing the internal canonical encoding or dropping the
+metadata that explains the event.
 
 !!! info "Planned"
     Scope-wide history and independent `audit verify` will expose aggregate

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -8,10 +8,11 @@ description: The permanent, tamper-evident history model for protected directory
 !!! info "Current implementation boundary"
     Docbank implements permanent first-scope enrollment, sticky membership,
     mutation and allocation chains for the supported changes described below,
-    JSONL backup/restore fidelity, and status inspection. Additional scopes,
-    bounded history browsing, independent verification commands, and TUI/web
-    projections remain planned. See [Permanent Audited History](../usage/audited-history.md)
-    for the current operator workflow.
+    JSONL backup/restore fidelity, status inspection, and bounded per-node
+    history. Additional scopes, scope-wide browsing, independent verification
+    commands, and TUI/web projections remain planned. See
+    [Permanent Audited History](../usage/audited-history.md) for the current
+    operator workflow.
 
 Full audit is an opt-in promise for records whose history matters more than
 easy reclamation: tax documents, contracts, regulated work, or an external
@@ -1462,14 +1463,17 @@ a separate execution supplies that token and the explicit disclosure
 acknowledgment because enrollment is permanent. `audit status` reports the
 vault authority and can inspect one node's sticky membership. Machine output
 uses stable scope, node, operation, lineage, and baseline identities rather
-than asking agents to parse prose.
+than asking agents to parse prose. `audit history` exposes a bounded newest-first
+node timeline by live path or stable node ID. Its opaque continuation cursor is
+bound to the node and to the last canonical `(operation_sequence,
+event_ordinal, event_id)` position, so later appends do not shift older pages.
+An enrolled baseline member with no later node event returns an empty timeline;
+status membership, rather than event count, remains the protection authority.
 
 !!! info "Planned"
-    Bounded `audit history` and independent `audit verify` commands will expose
-    event timelines and terminal verification evidence. A history lookup for a
-    node outside every scope will return `audit_not_enrolled`, and refused
-    protected destruction will identify every blocking scope in structured
-    output.
+    Scope-wide history and independent `audit verify` will expose aggregate
+    timelines and terminal verification evidence. Refused protected destruction
+    will identify every blocking scope in structured output.
 
 ### TUI
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -38,6 +38,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET\|POST /tags` · `GET /tags/by-name` · `GET\|PATCH\|DELETE /tags/{tag_id}` | list, resolve, create, rename, or delete stable tag definitions | Implemented |
 | `GET /nodes/{id}/tags` · `GET /tags/{tag_id}/nodes` · `PUT\|DELETE /nodes/{id}/tags/{tag_id}` · `PUT\|DELETE /path/tags/{tag_id}` | inspect and change tag assignments | Implemented |
 | `POST /audit/preview` · `POST /audit/enable` · `GET /audit/status` | review permanent first-scope retention, enable the exact reviewed plan, and inspect authority or membership | Implemented |
+| `GET /audit/history?path=&node_id=&limit=&cursor=` | read one audited node's canonical newest-first event timeline with a stable continuation cursor | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
@@ -455,6 +456,8 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `audit_already_enabled` | 409 | this vault already has its first permanent audit scope |
 | `audit_preview_stale` | 409 | the one-use enrollment preview expired, was consumed, came from another daemon, or no longer matches the vault |
 | `audit_acknowledgment_required` | 422 | enrollment execution omitted the explicit permanent-retention acknowledgment |
+| `audit_not_enrolled` | 422 | the selected node exists but is outside every permanent audit scope |
+| `invalid_audit_cursor` | 422 | the history cursor is malformed or belongs to another stable node |
 | `stale_revision` | 412 | `store.ErrStaleRevision` — `If-Match` didn't match the current revision |
 | `not_dir` / `not_file` / `invalid_name` / `invalid_tag` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrInvalidTag` / `ErrNotTrashed` / `ErrIsRoot` |
 | `validation` | 400, 415, or 422 | malformed request (bad `If-Match`, paths, media type, multipart envelope, or generated validation) |

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -69,7 +69,7 @@ provenance     (identity SHA-256 PRIMARY KEY, node_id, ingest_id,
                 original_path, original_mtime, supersedes)
 tags           (id UUID PRIMARY KEY, name UNIQUE, revision)
 node_tags      (node_id, tag_id)
-audit_records  (digest PRIMARY KEY, kind, operation indexes, record_json)
+audit_records  (digest PRIMARY KEY, kind, operation/event/node indexes, record_json)
 audit_authority(lineage_id, operation high-water, allocation count/head)
 audit_scopes   (scope_id, target_node_id, enable operation, count/head)
 audit_baselines(digest, scope_id, target_node_id, operation_id)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -321,6 +321,8 @@ docbank audit enable --node-id <id> [--agent-label <label>] [--json]
 docbank audit enable --run --token <preview-token> --acknowledge-permanent-retention [--json]
 docbank audit status [path] [--json]
 docbank audit status --node-id <id> [--json]
+docbank audit history <path> [--limit <n>] [--cursor <cursor>] [--json]
+docbank audit history --node-id <id> [--limit <n>] [--cursor <cursor>] [--json]
 ```
 
 `audit enable` permanently protects a directory scope and all retained content
@@ -341,8 +343,20 @@ returns `audit_preview_stale` without enabling the scope; run a new preview.
 
 `audit status` without a selector reports vault and scope evidence. A path or
 stable node ID additionally reports whether that node has sticky audit
-membership. The current public boundary supports the first scope in a vault;
-a later `audit enable` returns `audit_already_enabled`. See
+membership.
+
+`audit history` reads canonical events for one protected node, newest first.
+Path events expose their old and new paths; content events expose prior and
+resulting immutable version IDs. The default and maximum page sizes are 50 and
+500. `next_cursor` in JSON, or the `next cursor` line in human output, continues
+through older events without shifting when a newer operation is appended. A
+cursor is opaque and bound to its stable node. Use `--node-id` for a moved or
+trashed node. A protected enrollment-baseline member can legitimately have no
+node-specific events until its first later mutation; use `audit status` for
+membership authority.
+
+The current public boundary supports the first scope in a vault; a later
+`audit enable` returns `audit_already_enabled`. See
 [Permanent Audited History](usage/audited-history.md) for supported mutations
 and maintenance behavior.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -346,9 +346,11 @@ stable node ID additionally reports whether that node has sticky audit
 membership.
 
 `audit history` reads canonical events for one protected node, newest first.
-Path events expose their old and new paths; content events expose prior and
-resulting immutable version IDs. The default and maximum page sizes are 50 and
-500. `next_cursor` in JSON, or the `next cursor` line in human output, continues
+Path events expose old and new coordinates with their live/trash state; content
+events expose prior and resulting immutable version IDs. Tag and provenance
+events expose their stable identity and typed before/after state. The default
+and maximum page sizes are 50 and 500. `next_cursor` in JSON, or the `next
+cursor` line in human output, continues
 through older events without shifting when a newer operation is appended. A
 cursor is opaque and bound to its stable node. Use `--node-id` for a moved or
 trashed node. A protected enrollment-baseline member can legitimately have no

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,9 +104,10 @@ metadata-v1 backup/restore authority, including bounded forward and reverse
 listings. Permanent first-scope audit enrollment is preview-first across the
 CLI and API. Sticky membership, supported logical mutations, allocation and
 scope chains, status evidence, and JSONL backup/restore validation are
-implemented.
+implemented. One-node canonical audit history is available by path or stable ID
+with bounded, append-stable cursor pagination.
 
-- Additional and overlapping audit scopes, bounded history browsing, and a
+- Additional and overlapping audit scopes, scope-wide history browsing, and a
   dedicated independent verification command
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -97,6 +97,43 @@ docbank audit status --node-id 57 --json
 An empty timeline is not proof that a node is protected; use `audit status` and
 require `protected: true` plus its scope and baseline identities.
 
+## Read a node's history
+
+Read canonical events for one protected document or directory by its live path:
+
+```bash
+docbank audit history /taxes/2026/return.pdf
+docbank audit history /taxes/2026/return.pdf --json
+```
+
+Use a stable node ID when a document has moved, or while it is in trash:
+
+```bash
+docbank audit history --node-id 57
+```
+
+Events are newest first. Each one identifies its immutable event and operation,
+scope, recording time, origin, node revision before and after, and the fields
+relevant to that event. Path events include the old and new paths; content
+events include prior and resulting version IDs. Human output summarizes those
+changes. JSON returns the complete typed projection.
+
+The default page contains at most 50 events. Continue an older timeline with
+the opaque cursor printed by human output or returned as `next_cursor` in JSON:
+
+```bash
+docbank audit history --node-id 57 --limit 50 --cursor <next-cursor> --json
+```
+
+The cursor is bound to the stable node and does not shift when newer events are
+recorded. Do not parse or construct it. A cursor from another node returns
+`invalid_audit_cursor`; a node outside every audit scope returns
+`audit_not_enrolled`.
+
+A protected node adopted during first enrollment may have no node-specific
+events until its first later change. That empty timeline does not weaken its
+baseline protection; `audit status` is the membership authority.
+
 ## What remains usable
 
 Protected documents remain working documents. Docbank records direct creation
@@ -122,8 +159,8 @@ yet exposed. Status, mutation recording, JSONL export/import, and backup capture
 all preserve the first scope's authority.
 
 !!! info "Planned"
-    Bounded `audit history` and independent `audit verify` commands, additional
-    scope enrollment, and rich TUI/web history views are not implemented yet.
-    Until those arrive, `docbank verify` still validates the stored metadata
-    relations and every blob, while backup restore revalidates the portable
-    JSONL authority before publishing a vault.
+    Independent `audit verify`, additional scope enrollment, scope-wide history,
+    and rich TUI/web history views are not implemented yet. Until those arrive,
+    `docbank verify` still validates the stored metadata relations and every
+    blob, while backup restore revalidates the portable JSONL authority before
+    publishing a vault.

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -114,9 +114,13 @@ docbank audit history --node-id 57
 
 Events are newest first. Each one identifies its immutable event and operation,
 scope, recording time, origin, node revision before and after, and the fields
-relevant to that event. Path events include the old and new paths; content
-events include prior and resulting version IDs. Human output summarizes those
-changes. JSON returns the complete typed projection.
+relevant to that event. Path events include old and new coordinates plus their
+`live` or `trash` state; trash coordinates use the separate
+`@trash/known/...` or `@trash/unknown/...` domain rather than pretending to be
+live virtual paths. Content events include prior and resulting version IDs.
+Tag and provenance events include their stable attachment identity and complete
+before/after attachment state. Human output summarizes those changes. JSON
+returns the complete typed projection.
 
 The default page contains at most 50 events. Continue an older timeline with
 the opaque cursor printed by human output or returned as `next_cursor` in JSON:

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -76,6 +76,8 @@ var storeErrCodes = []struct {
 	{store.ErrAuditMutationUnsupported, http.StatusConflict, "audit_mutation_unsupported"},
 	{store.ErrAuditAlreadyEnabled, http.StatusConflict, "audit_already_enabled"},
 	{store.ErrAuditPreviewStale, http.StatusConflict, "audit_preview_stale"},
+	{store.ErrAuditNotEnrolled, http.StatusUnprocessableEntity, "audit_not_enrolled"},
+	{store.ErrInvalidAuditCursor, http.StatusUnprocessableEntity, "invalid_audit_cursor"},
 }
 
 // FromStoreError maps the store's typed errors onto the wire envelope; an

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -21,7 +21,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 		"listTags", "resolveTagByName", "getTag", "listTagNodes", "listNodeTags",
 		"createTag", "renameTag", "deleteTag", "assignTag", "unassignTag",
 		"assignTagPath", "unassignTagPath",
-		"previewAuditEnrollment", "enableAudit", "auditStatus",
+		"previewAuditEnrollment", "enableAudit", "auditStatus", "auditNodeHistory",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
 		"storageStatus", "storagePack", "storageRepack", "ingest", "uploadFile", "listTrash", "emptyTrash", "gc", "verify",
 		"initBackupRepository", "createBackupSnapshot", "listBackupSnapshots", "listJobs"} {

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -229,9 +229,43 @@ func auditEventPage(page store.AuditEventPage) AuditEventPage {
 			PriorCurrentVersionID:     event.PriorCurrentVersionID,
 			ResultingCurrentVersionID: event.ResultingCurrentVersionID,
 			SourceVersionID:           event.SourceVersionID, TargetNodeID: event.TargetNodeID,
-			BaselineDigest: event.BaselineDigest, AttachmentKind: event.AttachmentKind,
-			OldPath: event.OldPath, NewPath: event.NewPath,
+			BaselineDigest: event.BaselineDigest,
+			Attachment:     auditAttachmentChange(event.Attachment),
+			OldPath:        auditPathState(event.OldPath), NewPath: auditPathState(event.NewPath),
 		})
 	}
 	return out
+}
+
+func auditPathState(value *store.AuditPathState) *AuditPathState {
+	if value == nil {
+		return nil
+	}
+	return &AuditPathState{Path: value.Path, State: value.State}
+}
+
+func auditAttachmentChange(value *store.AuditAttachmentChange) *AuditAttachmentChange {
+	if value == nil {
+		return nil
+	}
+	return &AuditAttachmentChange{
+		Kind: value.Kind,
+		Identity: AuditAttachmentIdentity{
+			TagID: value.Identity.TagID, NodeID: value.Identity.NodeID,
+			ProvenanceID: value.Identity.ProvenanceID,
+		},
+		Before: auditAttachmentState(value.Before), After: auditAttachmentState(value.After),
+	}
+}
+
+func auditAttachmentState(value *store.AuditAttachmentState) *AuditAttachmentState {
+	if value == nil {
+		return nil
+	}
+	return &AuditAttachmentState{
+		TagID: value.TagID, NodeID: value.NodeID, TagName: value.TagName,
+		ProvenanceID: value.ProvenanceID, IngestID: value.IngestID,
+		OriginalPath: value.OriginalPath, OriginalMTime: value.OriginalMTime,
+		Supersedes: value.Supersedes,
+	}
 }

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -14,6 +14,7 @@ import (
 
 type auditPreviewOutput struct{ Body AuditEnrollmentPreview }
 type auditStatusOutput struct{ Body AuditStatus }
+type auditHistoryOutput struct{ Body AuditEventPage }
 
 func registerAuditRoutes(
 	api huma.API, d Deps, g *gate, previews *auditPreviewRegistry,
@@ -131,6 +132,39 @@ func registerAuditRoutes(
 		}
 		return &auditStatusOutput{Body: auditStatus(status)}, nil
 	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "auditNodeHistory", Method: http.MethodGet,
+		Path:    "/api/v1/audit/history",
+		Summary: "Read one audited node's canonical event timeline",
+		Description: "Returns newest-first canonical events for one stable node. " +
+			"Use next_cursor to continue without shifting when newer events arrive.",
+	}, func(ctx context.Context, in *struct {
+		Path   string `query:"path"`
+		NodeID int64  `query:"node_id" minimum:"1"`
+		Limit  int    `query:"limit" default:"50" minimum:"1" maximum:"500"`
+		Cursor string `query:"cursor" maxLength:"256"`
+	}) (*auditHistoryOutput, error) {
+		if (in.Path == "") == (in.NodeID == 0) {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation",
+				"audit history requires exactly one of path or node_id")
+		}
+		if in.Path != "" && !strings.HasPrefix(in.Path, "/") {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation",
+				fmt.Sprintf("path %q must be absolute (start with /)", in.Path))
+		}
+		var page store.AuditEventPage
+		var err error
+		if in.Path != "" {
+			page, err = d.Store.AuditHistoryPath(ctx, in.Path, in.Limit, in.Cursor)
+		} else {
+			page, err = d.Store.AuditHistory(ctx, in.NodeID, in.Limit, in.Cursor)
+		}
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return &auditHistoryOutput{Body: auditEventPage(page)}, nil
+	})
 }
 
 func auditEnrollmentPreview(
@@ -174,6 +208,30 @@ func auditStatus(status store.AuditStatus) AuditStatus {
 			ScopeIDs:        status.Membership.ScopeIDs,
 			BaselineDigests: status.Membership.BaselineDigests,
 		}
+	}
+	return out
+}
+
+func auditEventPage(page store.AuditEventPage) AuditEventPage {
+	out := AuditEventPage{
+		Node: fromStoreNode(page.Node), Path: page.Path,
+		Items: []AuditEvent{}, Total: page.Total, Limit: page.Limit,
+		Cursor: page.Cursor, NextCursor: page.NextCursor,
+	}
+	for _, event := range page.Items {
+		out.Items = append(out.Items, AuditEvent{
+			ID: event.ID, OperationID: event.OperationID,
+			OperationSequence: event.OperationSequence, Ordinal: event.Ordinal,
+			NodeID: event.NodeID, Kind: event.Kind, ScopeID: event.ScopeID,
+			RecordedAt: event.RecordedAt, Origin: event.Origin, AgentLabel: event.AgentLabel,
+			PriorNodeRevision:         event.PriorNodeRevision,
+			ResultingNodeRevision:     event.ResultingNodeRevision,
+			PriorCurrentVersionID:     event.PriorCurrentVersionID,
+			ResultingCurrentVersionID: event.ResultingCurrentVersionID,
+			SourceVersionID:           event.SourceVersionID, TargetNodeID: event.TargetNodeID,
+			BaselineDigest: event.BaselineDigest, AttachmentKind: event.AttachmentKind,
+			OldPath: event.OldPath, NewPath: event.NewPath,
+		})
 	}
 	return out
 }

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -72,6 +73,31 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	require.Len(t, status.Membership.BaselineDigests, 1)
 	assert.NotEqual(t, preview.BaselineDigest, status.Membership.BaselineDigests[0],
 		"an inherited node binds to its creation baseline, not the scope enrollment baseline")
+
+	firstHistory, err := c.AuditHistory(t.Context(), "", inherited.ID, 1, "")
+	require.NoError(t, err)
+	assert.Equal(t, "/Taxes/2027", firstHistory.Path)
+	assert.Equal(t, 2, firstHistory.Total)
+	require.Len(t, firstHistory.Items, 1)
+	assert.Equal(t, "node_create", firstHistory.Items[0].Kind)
+	require.NotEmpty(t, firstHistory.NextCursor)
+	secondHistory, err := c.AuditHistory(
+		t.Context(), "/Taxes/2027", 0, 1, firstHistory.NextCursor,
+	)
+	require.NoError(t, err)
+	require.Len(t, secondHistory.Items, 1)
+	assert.Equal(t, "audit_inherit", secondHistory.Items[0].Kind)
+	assert.Empty(t, secondHistory.NextCursor)
+	_, err = c.AuditHistory(t.Context(), "", s.RootID(), 10, "")
+	require.ErrorIs(t, err, store.ErrAuditNotEnrolled)
+
+	resp, raw := do(t, ts, http.MethodGet, fmt.Sprintf(
+		"/api/v1/audit/history?node_id=%d&limit=10&cursor=bad", inherited.ID,
+	), nil, nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	var cursorProblem api.Error
+	require.NoError(t, json.Unmarshal([]byte(raw), &cursorProblem))
+	assert.Equal(t, "invalid_audit_cursor", cursorProblem.Code)
 
 	_, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
 	require.ErrorIs(t, err, store.ErrAuditPreviewStale)
@@ -154,6 +180,10 @@ func TestAuditRoutesRejectRelativePaths(t *testing.T) {
 		},
 		{
 			name: "status", method: http.MethodGet, path: "/api/v1/audit/status?path=Taxes",
+		},
+		{
+			name: "history", method: http.MethodGet,
+			path: "/api/v1/audit/history?path=Taxes&limit=10",
 		},
 	}
 	for _, test := range tests {

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -88,6 +88,52 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	require.Len(t, secondHistory.Items, 1)
 	assert.Equal(t, "audit_inherit", secondHistory.Items[0].Kind)
 	assert.Empty(t, secondHistory.NextCursor)
+
+	trashed, _, err := s.Trash(t.Context(), inherited.ID, inherited.Revision)
+	require.NoError(t, err)
+	trashHistory, err := c.AuditHistory(t.Context(), "", inherited.ID, 10, "")
+	require.NoError(t, err)
+	require.NotNil(t, trashHistory.Items[0].NewPath)
+	assert.Equal(t, "trash", trashHistory.Items[0].NewPath.State)
+	assert.Equal(t, "@trash/known/Taxes/2027", trashHistory.Items[0].NewPath.Path)
+	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	restoreHistory, err := c.AuditHistory(t.Context(), "/Taxes/2027", 0, 10, "")
+	require.NoError(t, err)
+	require.NotNil(t, restoreHistory.Items[0].OldPath)
+	assert.Equal(t, "trash", restoreHistory.Items[0].OldPath.State)
+	assert.Equal(t, "@trash/known/Taxes/2027", restoreHistory.Items[0].OldPath.Path)
+
+	tag, err := s.CreateTag(t.Context(), "reviewed")
+	require.NoError(t, err)
+	_, err = s.AssignTag(t.Context(), tag.ID, inherited.ID, restored.Revision)
+	require.NoError(t, err)
+	tagHistory, err := c.AuditHistory(t.Context(), "", inherited.ID, 10, "")
+	require.NoError(t, err)
+	require.NotNil(t, tagHistory.Items[0].Attachment)
+	assert.Equal(t, "tag_assignment", tagHistory.Items[0].Attachment.Kind)
+	assert.Equal(t, tag.ID, tagHistory.Items[0].Attachment.Identity.TagID)
+	require.NotNil(t, tagHistory.Items[0].Attachment.After)
+
+	run, err := s.BeginIngest(t.Context(), "cli", "/source/taxes")
+	require.NoError(t, err)
+	ingested, added, err := s.IngestFile(
+		t.Context(), run, taxes.ID, "receipt.txt", testHash("audit provenance"), 7,
+		"text/plain", "/source/taxes/receipt.txt", "2026-07-18T12:00:00Z",
+	)
+	require.NoError(t, err)
+	require.True(t, added)
+	provenanceHistory, err := c.AuditHistory(t.Context(), "", ingested.ID, 10, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, provenanceHistory.Items)
+	provenanceEvent := provenanceHistory.Items[0]
+	assert.Equal(t, "provenance_add", provenanceEvent.Kind)
+	require.NotNil(t, provenanceEvent.Attachment)
+	assert.Equal(t, "provenance", provenanceEvent.Attachment.Kind)
+	require.NotNil(t, provenanceEvent.Attachment.After)
+	assert.Equal(t, "/source/taxes/receipt.txt",
+		*provenanceEvent.Attachment.After.OriginalPath)
+
 	_, err = c.AuditHistory(t.Context(), "", s.RootID(), 10, "")
 	require.ErrorIs(t, err, store.ErrAuditNotEnrolled)
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -213,6 +213,42 @@ type AuditStatus struct {
 	Membership                 *AuditMembershipStatus `json:"membership,omitempty"`
 }
 
+// AuditEvent is one canonical, immutable event involving an audited node.
+// Optional fields are present only when that event kind carries the relation.
+type AuditEvent struct {
+	ID                        string  `json:"id" pattern:"^[0-9a-f]{64}$"`
+	OperationID               string  `json:"operation_id" format:"uuid"`
+	OperationSequence         int64   `json:"operation_sequence" minimum:"1"`
+	Ordinal                   int64   `json:"ordinal" minimum:"0"`
+	NodeID                    int64   `json:"node_id" minimum:"1"`
+	Kind                      string  `json:"kind"`
+	ScopeID                   string  `json:"scope_id" format:"uuid"`
+	RecordedAt                string  `json:"recorded_at" format:"date-time"`
+	Origin                    string  `json:"origin"`
+	AgentLabel                *string `json:"agent_label,omitempty"`
+	PriorNodeRevision         int64   `json:"prior_node_revision" minimum:"0"`
+	ResultingNodeRevision     int64   `json:"resulting_node_revision" minimum:"0"`
+	PriorCurrentVersionID     *string `json:"prior_current_version_id,omitempty" format:"uuid"`
+	ResultingCurrentVersionID *string `json:"resulting_current_version_id,omitempty" format:"uuid"`
+	SourceVersionID           *string `json:"source_version_id,omitempty" format:"uuid"`
+	TargetNodeID              *int64  `json:"target_node_id,omitempty" minimum:"1"`
+	BaselineDigest            *string `json:"baseline_digest,omitempty" pattern:"^[0-9a-f]{64}$"`
+	AttachmentKind            *string `json:"attachment_kind,omitempty"`
+	OldPath                   *string `json:"old_path,omitempty"`
+	NewPath                   *string `json:"new_path,omitempty"`
+}
+
+// AuditEventPage is a newest-first, cursor-stable timeline for one node.
+type AuditEventPage struct {
+	Node       Node         `json:"node"`
+	Path       string       `json:"path,omitempty"`
+	Items      []AuditEvent `json:"items"`
+	Total      int          `json:"total" minimum:"0"`
+	Limit      int          `json:"limit" minimum:"1" maximum:"500"`
+	Cursor     string       `json:"cursor,omitempty"`
+	NextCursor string       `json:"next_cursor,omitempty"`
+}
+
 // ContentVerification binds a fresh physical read to the exact node revision
 // the caller inspected. BlobHash and Size are catalog identity; ComputedHash
 // and ComputedSize describe the bytes read through the mixed store.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -216,26 +216,61 @@ type AuditStatus struct {
 // AuditEvent is one canonical, immutable event involving an audited node.
 // Optional fields are present only when that event kind carries the relation.
 type AuditEvent struct {
-	ID                        string  `json:"id" pattern:"^[0-9a-f]{64}$"`
-	OperationID               string  `json:"operation_id" format:"uuid"`
-	OperationSequence         int64   `json:"operation_sequence" minimum:"1"`
-	Ordinal                   int64   `json:"ordinal" minimum:"0"`
-	NodeID                    int64   `json:"node_id" minimum:"1"`
-	Kind                      string  `json:"kind"`
-	ScopeID                   string  `json:"scope_id" format:"uuid"`
-	RecordedAt                string  `json:"recorded_at" format:"date-time"`
-	Origin                    string  `json:"origin"`
-	AgentLabel                *string `json:"agent_label,omitempty"`
-	PriorNodeRevision         int64   `json:"prior_node_revision" minimum:"0"`
-	ResultingNodeRevision     int64   `json:"resulting_node_revision" minimum:"0"`
-	PriorCurrentVersionID     *string `json:"prior_current_version_id,omitempty" format:"uuid"`
-	ResultingCurrentVersionID *string `json:"resulting_current_version_id,omitempty" format:"uuid"`
-	SourceVersionID           *string `json:"source_version_id,omitempty" format:"uuid"`
-	TargetNodeID              *int64  `json:"target_node_id,omitempty" minimum:"1"`
-	BaselineDigest            *string `json:"baseline_digest,omitempty" pattern:"^[0-9a-f]{64}$"`
-	AttachmentKind            *string `json:"attachment_kind,omitempty"`
-	OldPath                   *string `json:"old_path,omitempty"`
-	NewPath                   *string `json:"new_path,omitempty"`
+	ID                        string                 `json:"id" pattern:"^[0-9a-f]{64}$"`
+	OperationID               string                 `json:"operation_id" format:"uuid"`
+	OperationSequence         int64                  `json:"operation_sequence" minimum:"1"`
+	Ordinal                   int64                  `json:"ordinal" minimum:"0"`
+	NodeID                    int64                  `json:"node_id" minimum:"1"`
+	Kind                      string                 `json:"kind"`
+	ScopeID                   string                 `json:"scope_id" format:"uuid"`
+	RecordedAt                string                 `json:"recorded_at" format:"date-time"`
+	Origin                    string                 `json:"origin"`
+	AgentLabel                *string                `json:"agent_label,omitempty"`
+	PriorNodeRevision         int64                  `json:"prior_node_revision" minimum:"0"`
+	ResultingNodeRevision     int64                  `json:"resulting_node_revision" minimum:"0"`
+	PriorCurrentVersionID     *string                `json:"prior_current_version_id,omitempty" format:"uuid"`
+	ResultingCurrentVersionID *string                `json:"resulting_current_version_id,omitempty" format:"uuid"`
+	SourceVersionID           *string                `json:"source_version_id,omitempty" format:"uuid"`
+	TargetNodeID              *int64                 `json:"target_node_id,omitempty" minimum:"1"`
+	BaselineDigest            *string                `json:"baseline_digest,omitempty" pattern:"^[0-9a-f]{64}$"`
+	Attachment                *AuditAttachmentChange `json:"attachment,omitempty"`
+	OldPath                   *AuditPathState        `json:"old_path,omitempty"`
+	NewPath                   *AuditPathState        `json:"new_path,omitempty"`
+}
+
+// AuditPathState distinguishes a live virtual path from a retained canonical
+// trash coordinate.
+type AuditPathState struct {
+	Path  string `json:"path"`
+	State string `json:"state" enum:"live,trash"`
+}
+
+// AuditAttachmentIdentity is the stable key of one tag or provenance record.
+type AuditAttachmentIdentity struct {
+	TagID        string `json:"tag_id,omitempty" format:"uuid"`
+	NodeID       int64  `json:"node_id,omitempty" minimum:"1"`
+	ProvenanceID string `json:"provenance_id,omitempty" pattern:"^[0-9a-f]{64}$"`
+}
+
+// AuditAttachmentState is one typed side of a tag or provenance transition.
+type AuditAttachmentState struct {
+	TagID         string  `json:"tag_id,omitempty" format:"uuid"`
+	NodeID        int64   `json:"node_id,omitempty" minimum:"1"`
+	TagName       string  `json:"tag_name,omitempty"`
+	ProvenanceID  string  `json:"provenance_id,omitempty" pattern:"^[0-9a-f]{64}$"`
+	IngestID      string  `json:"ingest_id,omitempty" format:"uuid"`
+	OriginalPath  *string `json:"original_path,omitempty"`
+	OriginalMTime *string `json:"original_mtime,omitempty" format:"date-time"`
+	Supersedes    *string `json:"supersedes,omitempty" pattern:"^[0-9a-f]{64}$"`
+}
+
+// AuditAttachmentChange provides the stable identity and complete before/after
+// payload for one tag or provenance event.
+type AuditAttachmentChange struct {
+	Kind     string                  `json:"kind" enum:"tag_definition,tag_assignment,provenance"`
+	Identity AuditAttachmentIdentity `json:"identity"`
+	Before   *AuditAttachmentState   `json:"before,omitempty"`
+	After    *AuditAttachmentState   `json:"after,omitempty"`
 }
 
 // AuditEventPage is a newest-first, cursor-stable timeline for one node.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -133,6 +133,8 @@ var codeToTypedErr = map[string]error{
 	"invalid_version_prune":    store.ErrInvalidVersionPrune,
 	"audit_already_enabled":    store.ErrAuditAlreadyEnabled,
 	"audit_preview_stale":      store.ErrAuditPreviewStale,
+	"audit_not_enrolled":       store.ErrAuditNotEnrolled,
+	"invalid_audit_cursor":     store.ErrInvalidAuditCursor,
 	"backup_locked":            backup.ErrRepoLocked,
 	"pack_retirement_deferred": packstore.ErrPackRetirementDeferred,
 }
@@ -713,6 +715,108 @@ func (c *Client) AuditStatus(
 		return api.AuditStatus{}, err
 	}
 	return status, nil
+}
+
+// AuditHistory returns one stable newest-first page of canonical events for
+// exactly one audited node selected by live path or stable ID.
+func (c *Client) AuditHistory(
+	ctx context.Context, path string, nodeID int64, limit int, cursor string,
+) (api.AuditEventPage, error) {
+	var page api.AuditEventPage
+	if (path == "") == (nodeID == 0) {
+		return page, errors.New("audit history requires exactly one path or node ID")
+	}
+	if path != "" && !strings.HasPrefix(path, "/") {
+		return page, errors.New("audit history path must be absolute")
+	}
+	if nodeID < 0 {
+		return page, errors.New("audit history node ID must be positive")
+	}
+	if limit < 1 || limit > 500 {
+		return page, errors.New("audit history limit must be between 1 and 500")
+	}
+	if nodeID != 0 {
+		if err := store.ValidateAuditHistoryCursor(cursor, nodeID); err != nil {
+			return page, err
+		}
+	}
+	query := url.Values{}
+	if path != "" {
+		query.Set("path", path)
+	} else {
+		query.Set("node_id", strconv.FormatInt(nodeID, 10))
+	}
+	query.Set("limit", strconv.Itoa(limit))
+	if cursor != "" {
+		query.Set("cursor", cursor)
+	}
+	if err := c.do(ctx, http.MethodGet, "/api/v1/audit/history?"+query.Encode(),
+		nil, nil, &page); err != nil {
+		return page, err
+	}
+	if err := validateAuditEventPage(page, nodeID, limit, cursor); err != nil {
+		return api.AuditEventPage{}, err
+	}
+	return page, nil
+}
+
+func validateAuditEventPage(page api.AuditEventPage, requestedNodeID int64, limit int, cursor string) error {
+	if page.Node.ID < 1 || (requestedNodeID != 0 && page.Node.ID != requestedNodeID) ||
+		page.Limit != limit || page.Cursor != cursor || page.Total < len(page.Items) ||
+		len(page.Items) > limit || (page.Node.TrashedAt == "") != strings.HasPrefix(page.Path, "/") {
+		return errors.New("audit history response has inconsistent node or pagination")
+	}
+	if err := store.ValidateAuditHistoryCursor(cursor, page.Node.ID); err != nil {
+		return err
+	}
+	if err := store.ValidateAuditHistoryCursor(page.NextCursor, page.Node.ID); err != nil {
+		return err
+	}
+	if page.NextCursor != "" && len(page.Items) != limit {
+		return errors.New("audit history response has a premature next cursor")
+	}
+	for i, event := range page.Items {
+		if err := validateAuditEvent(event, page.Node.ID); err != nil {
+			return fmt.Errorf("audit history item %d: %w", i, err)
+		}
+		if i > 0 && !auditEventPrecedes(page.Items[i-1], event) {
+			return errors.New("audit history response is not newest first")
+		}
+	}
+	return nil
+}
+
+func validateAuditEvent(event api.AuditEvent, nodeID int64) error {
+	recordedAt, timeErr := time.Parse(time.RFC3339Nano, event.RecordedAt)
+	if !validSHA256Hex(event.ID) || !validUUIDv4(event.OperationID) ||
+		event.OperationSequence < 1 || event.Ordinal < 0 || event.NodeID != nodeID ||
+		event.Kind == "" || !validUUIDv4(event.ScopeID) || event.Origin == "" ||
+		timeErr != nil || recordedAt.Location() != time.UTC ||
+		event.PriorNodeRevision < 0 || event.ResultingNodeRevision < 0 ||
+		!validOptionalUUID(event.PriorCurrentVersionID) ||
+		!validOptionalUUID(event.ResultingCurrentVersionID) ||
+		!validOptionalUUID(event.SourceVersionID) ||
+		(event.TargetNodeID != nil && *event.TargetNodeID < 1) ||
+		(event.BaselineDigest != nil && !validSHA256Hex(*event.BaselineDigest)) {
+		return errors.New("event has invalid canonical fields")
+	}
+	if event.Kind == "node_path" &&
+		(event.OldPath == nil || event.NewPath == nil ||
+			!strings.HasPrefix(*event.OldPath, "/") || !strings.HasPrefix(*event.NewPath, "/")) {
+		return errors.New("path event lacks absolute old and new paths")
+	}
+	return nil
+}
+
+func validOptionalUUID(value *string) bool {
+	return value == nil || validUUIDv4(*value)
+}
+
+func auditEventPrecedes(newer, older api.AuditEvent) bool {
+	return newer.OperationSequence > older.OperationSequence ||
+		(newer.OperationSequence == older.OperationSequence && newer.Ordinal > older.Ordinal) ||
+		(newer.OperationSequence == older.OperationSequence && newer.Ordinal == older.Ordinal &&
+			newer.ID > older.ID)
 }
 
 func validateAuditPreview(preview api.AuditEnrollmentPreview) error {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -800,12 +800,127 @@ func validateAuditEvent(event api.AuditEvent, nodeID int64) error {
 		(event.BaselineDigest != nil && !validSHA256Hex(*event.BaselineDigest)) {
 		return errors.New("event has invalid canonical fields")
 	}
-	if event.Kind == "node_path" &&
-		(event.OldPath == nil || event.NewPath == nil ||
-			!strings.HasPrefix(*event.OldPath, "/") || !strings.HasPrefix(*event.NewPath, "/")) {
-		return errors.New("path event lacks absolute old and new paths")
+	if event.Kind == "node_path" {
+		if event.OldPath == nil || event.NewPath == nil {
+			return errors.New("path event lacks old and new path states")
+		}
+		if err := store.ValidateAuditPathState(event.OldPath.Path, event.OldPath.State); err != nil {
+			return fmt.Errorf("invalid old path state: %w", err)
+		}
+		if err := store.ValidateAuditPathState(event.NewPath.Path, event.NewPath.State); err != nil {
+			return fmt.Errorf("invalid new path state: %w", err)
+		}
+	} else if event.OldPath != nil || event.NewPath != nil {
+		return errors.New("non-path event contains path states")
 	}
-	return nil
+	return validateAuditAttachment(event.Kind, event.Attachment)
+}
+
+func validateAuditAttachment(eventKind string, change *api.AuditAttachmentChange) error {
+	wantKind := ""
+	switch eventKind {
+	case "tag_define", "tag_rename", "tag_delete":
+		wantKind = "tag_definition"
+	case "tag_assign", "tag_unassign":
+		wantKind = "tag_assignment"
+	case "provenance_add", "provenance_supersede":
+		wantKind = "provenance"
+	}
+	if wantKind == "" {
+		if change != nil {
+			return errors.New("event kind cannot carry an attachment")
+		}
+		return nil
+	}
+	if change == nil || change.Kind != wantKind ||
+		(change.Before == nil && change.After == nil) {
+		return errors.New("attachment event lacks a complete typed change")
+	}
+	if err := validateAuditAttachmentIdentity(change.Kind, change.Identity); err != nil {
+		return err
+	}
+	for _, state := range []*api.AuditAttachmentState{change.Before, change.After} {
+		if state == nil {
+			continue
+		}
+		if err := validateAuditAttachmentState(change.Kind, change.Identity, *state); err != nil {
+			return err
+		}
+	}
+	switch eventKind {
+	case "tag_rename":
+		if change.Before != nil && change.After != nil {
+			return nil
+		}
+	case "tag_delete", "tag_unassign":
+		if change.Before != nil && change.After == nil {
+			return nil
+		}
+	case "tag_define", "tag_assign", "provenance_add":
+		if change.Before == nil && change.After != nil &&
+			(eventKind != "provenance_add" ||
+				change.After.ProvenanceID == change.Identity.ProvenanceID) {
+			return nil
+		}
+	case "provenance_supersede":
+		if change.Before != nil && change.After != nil &&
+			change.After.ProvenanceID == change.Identity.ProvenanceID &&
+			change.After.Supersedes != nil &&
+			*change.After.Supersedes == change.Before.ProvenanceID {
+			return nil
+		}
+	}
+	return errors.New("audit attachment has an invalid transition shape")
+}
+
+func validateAuditAttachmentIdentity(kind string, identity api.AuditAttachmentIdentity) error {
+	switch kind {
+	case "tag_definition":
+		if validUUIDv4(identity.TagID) && identity.NodeID == 0 && identity.ProvenanceID == "" {
+			return nil
+		}
+	case "tag_assignment":
+		if validUUIDv4(identity.TagID) && identity.NodeID > 0 && identity.ProvenanceID == "" {
+			return nil
+		}
+	case "provenance":
+		if identity.TagID == "" && identity.NodeID == 0 && validSHA256Hex(identity.ProvenanceID) {
+			return nil
+		}
+	}
+	return errors.New("audit attachment has an invalid stable identity")
+}
+
+func validateAuditAttachmentState(
+	kind string, identity api.AuditAttachmentIdentity, state api.AuditAttachmentState,
+) error {
+	switch kind {
+	case "tag_definition":
+		if state.TagID == identity.TagID && state.TagName != "" && state.NodeID == 0 &&
+			state.ProvenanceID == "" && state.IngestID == "" && state.OriginalPath == nil &&
+			state.OriginalMTime == nil && state.Supersedes == nil {
+			return nil
+		}
+	case "tag_assignment":
+		if state.TagID == identity.TagID && state.NodeID == identity.NodeID &&
+			state.TagName == "" && state.ProvenanceID == "" && state.IngestID == "" &&
+			state.OriginalPath == nil && state.OriginalMTime == nil && state.Supersedes == nil {
+			return nil
+		}
+	case "provenance":
+		mtimeValid := true
+		if state.OriginalMTime != nil {
+			parsed, err := time.Parse(time.RFC3339Nano, *state.OriginalMTime)
+			mtimeValid = err == nil && parsed.Location() == time.UTC
+		}
+		supersedesValid := state.Supersedes == nil || validSHA256Hex(*state.Supersedes)
+		if state.TagID == "" && state.TagName == "" && state.NodeID > 0 &&
+			validSHA256Hex(state.ProvenanceID) && validUUIDv4(state.IngestID) &&
+			mtimeValid && supersedesValid {
+			return nil
+		}
+	}
+	return errors.New("audit attachment has an invalid before or after state")
 }
 
 func validOptionalUUID(value *string) bool {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "18"
+	daemonProtocolVersion = "19"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/audit_enrollment.go
+++ b/internal/store/audit_enrollment.go
@@ -474,9 +474,10 @@ func insertAuditRecord(ctx context.Context, tx *sql.Tx, record audit.Record) err
 	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO audit_records(
 		digest,kind,operation_id,operation_sequence,scope_id,entry_count,
-		event_id,event_ordinal,record_json) VALUES(?,?,?,?,?,?,?,?,?)`,
+		event_id,event_ordinal,node_id,record_json) VALUES(?,?,?,?,?,?,?,?,?,?)`,
 		digest.text, record.Kind, index.operationID, index.operationSequence,
-		index.scopeID, index.entryCount, index.eventID, index.eventOrdinal, string(recordJSON))
+		index.scopeID, index.entryCount, index.eventID, index.eventOrdinal,
+		index.nodeID, string(recordJSON))
 	if err != nil {
 		return fmt.Errorf("storing %s audit record: %w", record.Kind, err)
 	}

--- a/internal/store/audit_history.go
+++ b/internal/store/audit_history.go
@@ -1,0 +1,374 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+const maxAuditHistoryPage = 500
+
+// AuditEvent is one canonical node event projected for human and agent readers.
+type AuditEvent struct {
+	ID                        string
+	OperationID               string
+	OperationSequence         int64
+	Ordinal                   int64
+	NodeID                    int64
+	Kind                      string
+	ScopeID                   string
+	RecordedAt                string
+	Origin                    string
+	AgentLabel                *string
+	PriorNodeRevision         int64
+	ResultingNodeRevision     int64
+	PriorCurrentVersionID     *string
+	ResultingCurrentVersionID *string
+	SourceVersionID           *string
+	TargetNodeID              *int64
+	BaselineDigest            *string
+	AttachmentKind            *string
+	OldPath                   *string
+	NewPath                   *string
+}
+
+// AuditEventPage is a stable newest-first page for one audited node.
+type AuditEventPage struct {
+	Node       Node
+	Path       string
+	Items      []AuditEvent
+	Total      int
+	Limit      int
+	Cursor     string
+	NextCursor string
+}
+
+type auditHistoryCursor struct {
+	nodeID   int64
+	sequence int64
+	ordinal  int64
+	eventID  string
+}
+
+// AuditHistory returns one bounded page for a stable node ID, including trash.
+func (s *Store) AuditHistory(
+	ctx context.Context, nodeID int64, limit int, cursor string,
+) (AuditEventPage, error) {
+	return s.auditHistorySnapshot(ctx, limit, cursor, func(tx *sql.Tx) (Node, error) {
+		return nodeByIDTx(tx, nodeID)
+	})
+}
+
+// AuditHistoryPath resolves one live path in the same snapshot as its history.
+func (s *Store) AuditHistoryPath(
+	ctx context.Context, path string, limit int, cursor string,
+) (AuditEventPage, error) {
+	return s.auditHistorySnapshot(ctx, limit, cursor, func(tx *sql.Tx) (Node, error) {
+		return nodeByPath(ctx, tx, s.rootID, path)
+	})
+}
+
+func (s *Store) auditHistorySnapshot(
+	ctx context.Context,
+	limit int,
+	cursor string,
+	resolve func(*sql.Tx) (Node, error),
+) (AuditEventPage, error) {
+	if limit < 1 || limit > maxAuditHistoryPage {
+		return AuditEventPage{}, fmt.Errorf(
+			"audit history limit must be between 1 and %d", maxAuditHistoryPage,
+		)
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return AuditEventPage{}, fmt.Errorf("starting audit-history snapshot: %w", err)
+	}
+	node, err := resolve(tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return AuditEventPage{}, err
+	}
+	page, err := auditHistoryPageTx(ctx, tx, node, limit, cursor)
+	if err != nil {
+		_ = tx.Rollback()
+		return AuditEventPage{}, err
+	}
+	if node.TrashedAt == nil {
+		page.Path, err = pathOf(ctx, tx, node.ID)
+		if err != nil {
+			_ = tx.Rollback()
+			return AuditEventPage{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return AuditEventPage{}, fmt.Errorf("closing audit-history snapshot: %w", err)
+	}
+	return page, nil
+}
+
+func auditHistoryPageTx(
+	ctx context.Context, tx *sql.Tx, node Node, limit int, rawCursor string,
+) (AuditEventPage, error) {
+	var memberships int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM audit_memberships WHERE node_id=?`, node.ID,
+	).Scan(&memberships); err != nil {
+		return AuditEventPage{}, fmt.Errorf("checking audit membership for node %d: %w", node.ID, err)
+	}
+	if memberships == 0 {
+		return AuditEventPage{}, fmt.Errorf("node %d: %w", node.ID, ErrAuditNotEnrolled)
+	}
+	cursor, err := decodeAuditHistoryCursor(rawCursor, node.ID)
+	if err != nil {
+		return AuditEventPage{}, err
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT e.record_json,m.operation_sequence
+		FROM audit_records AS e
+		JOIN audit_records AS m
+		  ON m.kind='canonical_mutation' AND m.operation_id=e.operation_id
+		WHERE e.kind='event' AND e.node_id=?
+		ORDER BY m.operation_sequence DESC,e.event_ordinal DESC,e.event_id DESC`, node.ID)
+	if err != nil {
+		return AuditEventPage{}, fmt.Errorf("listing audit history for node %d: %w", node.ID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	page := AuditEventPage{
+		Node: node, Items: make([]AuditEvent, 0, limit), Limit: limit, Cursor: rawCursor,
+	}
+	more := false
+	for rows.Next() {
+		var raw string
+		var sequence int64
+		if err := rows.Scan(&raw, &sequence); err != nil {
+			return AuditEventPage{}, fmt.Errorf("scanning audit history: %w", err)
+		}
+		event, err := projectAuditEvent([]byte(raw), sequence)
+		if err != nil {
+			return AuditEventPage{}, err
+		}
+		page.Total++
+		if !auditEventIsAfterCursor(event, cursor) {
+			continue
+		}
+		if len(page.Items) == limit {
+			more = true
+			continue
+		}
+		page.Items = append(page.Items, event)
+	}
+	if err := rows.Err(); err != nil {
+		return AuditEventPage{}, fmt.Errorf("listing audit history for node %d: %w", node.ID, err)
+	}
+	if more {
+		last := page.Items[len(page.Items)-1]
+		page.NextCursor = encodeAuditHistoryCursor(auditHistoryCursor{
+			nodeID: node.ID, sequence: last.OperationSequence,
+			ordinal: last.Ordinal, eventID: last.ID,
+		})
+	}
+	return page, nil
+}
+
+func projectAuditEvent(raw []byte, sequence int64) (AuditEvent, error) {
+	wrapper, err := audit.UnmarshalJSONRecord(raw)
+	if err != nil {
+		return AuditEvent{}, fmt.Errorf("decoding stored audit event: %w", err)
+	}
+	event, err := auditNestedField(wrapper, auditEventField)
+	if err != nil {
+		return AuditEvent{}, err
+	}
+	result := AuditEvent{OperationSequence: sequence}
+	if result.ID, err = auditDigestField(event, "event_id"); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.OperationID, err = auditUUIDField(event, auditOperationIDField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.Ordinal, err = auditInt64UnsignedField(event, auditEventOrdinalField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.NodeID, err = auditInt64UnsignedField(event, metadataNodeIDField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.Kind, err = auditTextField(event, "event_kind"); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.ScopeID, err = auditUUIDField(event, auditScopeIDField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.RecordedAt, err = auditTimestampField(event, auditRecordedAtField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.Origin, err = auditTextField(event, auditOriginField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.AgentLabel, err = auditOptionalTextField(event, auditAgentLabelField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.PriorNodeRevision, err = auditInt64UnsignedField(event, "prior_node_revision"); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.ResultingNodeRevision, err = auditInt64UnsignedField(event, "resulting_node_revision"); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.PriorCurrentVersionID, err = auditOptionalUUIDField(event, "prior_current_version_id"); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.ResultingCurrentVersionID, err = auditOptionalUUIDField(event, "resulting_current_version_id"); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.SourceVersionID, err = auditOptionalUUIDField(event, auditSourceVersionIDField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.TargetNodeID, err = auditOptionalNodeIDField(event, auditTargetNodeIDField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.BaselineDigest, err = auditOptionalDigestField(event, auditBaselineDigestField); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.AttachmentKind, err = auditOptionalTextField(event, "attachment_kind"); err != nil {
+		return AuditEvent{}, err
+	}
+	if result.Kind == "node_path" {
+		if result.OldPath, err = auditEventPathField(event, auditPreField); err != nil {
+			return AuditEvent{}, err
+		}
+		if result.NewPath, err = auditEventPathField(event, auditPostField); err != nil {
+			return AuditEvent{}, err
+		}
+	}
+	return result, nil
+}
+
+func auditTimestampField(record audit.Record, name string) (string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return "", err
+	}
+	result, ok := value.TimestampValue()
+	if !ok {
+		return "", fmt.Errorf("audit field %s.%s is not a timestamp", record.Kind, name)
+	}
+	return result, nil
+}
+
+func auditOptionalTextField(record audit.Record, name string) (*string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent optional text.
+	}
+	result, ok := value.TextValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not optional text", record.Kind, name)
+	}
+	return &result, nil
+}
+
+func auditOptionalDigestField(record audit.Record, name string) (*string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent optional digest.
+	}
+	result, ok := value.DigestValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not an optional digest", record.Kind, name)
+	}
+	return &result, nil
+}
+
+func auditOptionalNodeIDField(record audit.Record, name string) (*int64, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent optional node ID.
+	}
+	result, ok := value.UnsignedValue()
+	if !ok || result == 0 || result > math.MaxInt64 {
+		return nil, fmt.Errorf("audit field %s.%s is not an optional node ID", record.Kind, name)
+	}
+	signed := int64(result)
+	return &signed, nil
+}
+
+func auditEventPathField(record audit.Record, name string) (*string, error) {
+	state, err := auditNestedField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if state.Kind != auditPathStateKind {
+		return nil, fmt.Errorf("audit field %s.%s is not a path state", record.Kind, name)
+	}
+	value, err := auditField(state, auditPathField)
+	if err != nil {
+		return nil, err
+	}
+	path, ok := value.BytesValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not a byte path", state.Kind, auditPathField)
+	}
+	text := string(path)
+	return &text, nil
+}
+
+// ValidateAuditHistoryCursor checks that an opaque cursor belongs to nodeID.
+func ValidateAuditHistoryCursor(raw string, nodeID int64) error {
+	_, err := decodeAuditHistoryCursor(raw, nodeID)
+	return err
+}
+
+func decodeAuditHistoryCursor(raw string, nodeID int64) (auditHistoryCursor, error) {
+	if raw == "" {
+		return auditHistoryCursor{}, nil
+	}
+	decoded, err := base64.RawURLEncoding.Strict().DecodeString(raw)
+	if err != nil {
+		return auditHistoryCursor{}, fmt.Errorf("%w: malformed encoding", ErrInvalidAuditCursor)
+	}
+	parts := strings.Split(string(decoded), ":")
+	if len(parts) != 4 {
+		return auditHistoryCursor{}, fmt.Errorf("%w: malformed fields", ErrInvalidAuditCursor)
+	}
+	parsedNodeID, nodeErr := strconv.ParseInt(parts[0], 10, 64)
+	sequence, sequenceErr := strconv.ParseInt(parts[1], 10, 64)
+	ordinal, ordinalErr := strconv.ParseInt(parts[2], 10, 64)
+	if nodeErr != nil || sequenceErr != nil || ordinalErr != nil ||
+		parsedNodeID != nodeID || nodeID < 1 || sequence < 1 || ordinal < 0 ||
+		validateAuditDigest("history event", parts[3]) != nil {
+		return auditHistoryCursor{}, fmt.Errorf("%w: invalid or mismatched fields", ErrInvalidAuditCursor)
+	}
+	return auditHistoryCursor{
+		nodeID: parsedNodeID, sequence: sequence, ordinal: ordinal, eventID: parts[3],
+	}, nil
+}
+
+func encodeAuditHistoryCursor(cursor auditHistoryCursor) string {
+	raw := fmt.Sprintf("%d:%d:%d:%s",
+		cursor.nodeID, cursor.sequence, cursor.ordinal, cursor.eventID)
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func auditEventIsAfterCursor(event AuditEvent, cursor auditHistoryCursor) bool {
+	if cursor.nodeID == 0 {
+		return true
+	}
+	return event.OperationSequence < cursor.sequence ||
+		(event.OperationSequence == cursor.sequence && event.Ordinal < cursor.ordinal) ||
+		(event.OperationSequence == cursor.sequence && event.Ordinal == cursor.ordinal &&
+			event.ID < cursor.eventID)
+}

--- a/internal/store/audit_history.go
+++ b/internal/store/audit_history.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"go.kenn.io/docbank/internal/audit"
 )
@@ -33,9 +35,44 @@ type AuditEvent struct {
 	SourceVersionID           *string
 	TargetNodeID              *int64
 	BaselineDigest            *string
-	AttachmentKind            *string
-	OldPath                   *string
-	NewPath                   *string
+	Attachment                *AuditAttachmentChange
+	OldPath                   *AuditPathState
+	NewPath                   *AuditPathState
+}
+
+// AuditPathState preserves both the canonical coordinate and its domain.
+type AuditPathState struct {
+	Path  string
+	State string
+}
+
+// AuditAttachmentIdentity identifies one tag or provenance record without
+// relying on its mutable display fields.
+type AuditAttachmentIdentity struct {
+	TagID        string
+	NodeID       int64
+	ProvenanceID string
+}
+
+// AuditAttachmentState is the typed before/after state of one attached record.
+// The enclosing change Kind determines which fields are present.
+type AuditAttachmentState struct {
+	TagID         string
+	NodeID        int64
+	TagName       string
+	ProvenanceID  string
+	IngestID      string
+	OriginalPath  *string
+	OriginalMTime *string
+	Supersedes    *string
+}
+
+// AuditAttachmentChange makes tag and provenance events self-explanatory.
+type AuditAttachmentChange struct {
+	Kind     string
+	Identity AuditAttachmentIdentity
+	Before   *AuditAttachmentState
+	After    *AuditAttachmentState
 }
 
 // AuditEventPage is a stable newest-first page for one audited node.
@@ -234,7 +271,7 @@ func projectAuditEvent(raw []byte, sequence int64) (AuditEvent, error) {
 	if result.BaselineDigest, err = auditOptionalDigestField(event, auditBaselineDigestField); err != nil {
 		return AuditEvent{}, err
 	}
-	if result.AttachmentKind, err = auditOptionalTextField(event, "attachment_kind"); err != nil {
+	if result.Attachment, err = projectAuditAttachment(event); err != nil {
 		return AuditEvent{}, err
 	}
 	if result.Kind == "node_path" {
@@ -306,7 +343,167 @@ func auditOptionalNodeIDField(record audit.Record, name string) (*int64, error) 
 	return &signed, nil
 }
 
-func auditEventPathField(record audit.Record, name string) (*string, error) {
+func projectAuditAttachment(event audit.Record) (*AuditAttachmentChange, error) {
+	kind, err := auditOptionalTextField(event, "attachment_kind")
+	if err != nil {
+		return nil, err
+	}
+	identity, err := auditOptionalNestedField(event, "attachment_identity")
+	if err != nil {
+		return nil, err
+	}
+	if kind == nil {
+		if identity != nil {
+			return nil, errors.New("audit event has an identity without an attachment kind")
+		}
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent attachment.
+	}
+	if identity == nil {
+		return nil, errors.New("audit attachment lacks its stable identity")
+	}
+	before, err := auditOptionalNestedField(event, auditPreField)
+	if err != nil {
+		return nil, err
+	}
+	after, err := auditOptionalNestedField(event, auditPostField)
+	if err != nil {
+		return nil, err
+	}
+	result := &AuditAttachmentChange{Kind: *kind}
+	if result.Identity, err = projectAuditAttachmentIdentity(*kind, *identity); err != nil {
+		return nil, err
+	}
+	if result.Before, err = projectAuditAttachmentState(*kind, before); err != nil {
+		return nil, err
+	}
+	if result.After, err = projectAuditAttachmentState(*kind, after); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func projectAuditAttachmentIdentity(
+	kind string, record audit.Record,
+) (AuditAttachmentIdentity, error) {
+	var result AuditAttachmentIdentity
+	var err error
+	switch kind {
+	case auditTagDefinitionKind:
+		if record.Kind != "tag_definition_identity" {
+			return result, fmt.Errorf("tag-definition identity has kind %q", record.Kind)
+		}
+		result.TagID, err = auditUUIDField(record, "tag_id")
+	case auditTagAssignmentKind:
+		if record.Kind != "tag_assignment_identity" {
+			return result, fmt.Errorf("tag-assignment identity has kind %q", record.Kind)
+		}
+		if result.TagID, err = auditUUIDField(record, "tag_id"); err == nil {
+			result.NodeID, err = auditInt64UnsignedField(record, metadataNodeIDField)
+		}
+	case "provenance":
+		if record.Kind != "provenance_identity_ref" {
+			return result, fmt.Errorf("provenance identity has kind %q", record.Kind)
+		}
+		result.ProvenanceID, err = auditDigestField(record, "identity")
+	default:
+		return result, fmt.Errorf("unsupported audit attachment kind %q", kind)
+	}
+	return result, err
+}
+
+func projectAuditAttachmentState(
+	kind string, record *audit.Record,
+) (*AuditAttachmentState, error) {
+	if record == nil {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent attachment state.
+	}
+	if record.Kind != kind {
+		return nil, fmt.Errorf("audit %s attachment state has kind %q", kind, record.Kind)
+	}
+	result := &AuditAttachmentState{}
+	var err error
+	switch kind {
+	case auditTagDefinitionKind:
+		if result.TagID, err = auditUUIDField(*record, "tag_id"); err == nil {
+			result.TagName, err = auditTextField(*record, "name")
+		}
+	case auditTagAssignmentKind:
+		if result.TagID, err = auditUUIDField(*record, "tag_id"); err == nil {
+			result.NodeID, err = auditInt64UnsignedField(*record, metadataNodeIDField)
+		}
+	case "provenance":
+		if result.ProvenanceID, err = auditDigestField(*record, "identity"); err != nil {
+			break
+		}
+		if result.NodeID, err = auditInt64UnsignedField(*record, metadataNodeIDField); err != nil {
+			break
+		}
+		if result.IngestID, err = auditUUIDField(*record, "ingest_id"); err != nil {
+			break
+		}
+		if result.OriginalPath, err = auditOptionalBytesField(*record, "original_path"); err != nil {
+			break
+		}
+		if result.OriginalMTime, err = auditOptionalTimestampField(*record, "original_mtime"); err != nil {
+			break
+		}
+		result.Supersedes, err = auditOptionalDigestField(*record, "supersedes")
+	default:
+		return nil, fmt.Errorf("unsupported audit attachment kind %q", kind)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func auditOptionalNestedField(record audit.Record, name string) (*audit.Record, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent nested record.
+	}
+	result, ok := value.RecordValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not an optional record", record.Kind, name)
+	}
+	return &result, nil
+}
+
+func auditOptionalBytesField(record audit.Record, name string) (*string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent byte string.
+	}
+	result, ok := value.BytesValue()
+	if !ok || !utf8.Valid(result) {
+		return nil, fmt.Errorf("audit field %s.%s is not optional UTF-8 bytes", record.Kind, name)
+	}
+	text := string(result)
+	return &text, nil
+}
+
+func auditOptionalTimestampField(record audit.Record, name string) (*string, error) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, err
+	}
+	if value.IsAbsent() {
+		return nil, nil //nolint:nilnil // A nil pointer is the canonical absent timestamp.
+	}
+	result, ok := value.TimestampValue()
+	if !ok {
+		return nil, fmt.Errorf("audit field %s.%s is not an optional timestamp", record.Kind, name)
+	}
+	return &result, nil
+}
+
+func auditEventPathField(record audit.Record, name string) (*AuditPathState, error) {
 	state, err := auditNestedField(record, name)
 	if err != nil {
 		return nil, err
@@ -322,8 +519,75 @@ func auditEventPathField(record audit.Record, name string) (*string, error) {
 	if !ok {
 		return nil, fmt.Errorf("audit field %s.%s is not a byte path", state.Kind, auditPathField)
 	}
-	text := string(path)
-	return &text, nil
+	stateValue, err := auditTextField(state, auditStateField)
+	if err != nil {
+		return nil, err
+	}
+	result := AuditPathState{Path: string(path), State: stateValue}
+	if err := ValidateAuditPathState(result.Path, result.State); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ValidateAuditPathState checks the canonical coordinate domain used by an
+// audit path event. It deliberately does not use host-filesystem path rules.
+func ValidateAuditPathState(path, state string) error {
+	if !utf8.ValidString(path) {
+		return errors.New("audit path is not valid UTF-8")
+	}
+	switch state {
+	case "live":
+		if validAuditLiveCoordinate(path) {
+			return nil
+		}
+	case "trash":
+		if validAuditTrashCoordinate(path) {
+			return nil
+		}
+	}
+	return fmt.Errorf("audit path %q is not canonical for state %q", path, state)
+}
+
+func validAuditLiveCoordinate(path string) bool {
+	if path == "/" {
+		return true
+	}
+	return strings.HasPrefix(path, "/") && validAuditPathComponents(path[1:])
+}
+
+func validAuditTrashCoordinate(path string) bool {
+	const knownPrefix = "@trash/known/"
+	const unknownPrefix = "@trash/unknown/"
+	if after, ok := strings.CutPrefix(path, knownPrefix); ok {
+		return validAuditPathComponents(after)
+	}
+	if !strings.HasPrefix(path, unknownPrefix) {
+		return false
+	}
+	remainder := strings.TrimPrefix(path, unknownPrefix)
+	parts := strings.Split(remainder, "/")
+	if len(parts) == 0 || parts[0] == "" || (len(parts[0]) > 1 && parts[0][0] == '0') {
+		return false
+	}
+	id, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil || id == 0 || id > math.MaxInt64 {
+		return false
+	}
+	return len(parts) == 1 || validAuditPathComponents(strings.Join(parts[1:], "/"))
+}
+
+func validAuditPathComponents(path string) bool {
+	if path == "" || strings.HasSuffix(path, "/") {
+		return false
+	}
+	for component := range strings.SplitSeq(path, "/") {
+		if component == "" || component == "." || component == ".." ||
+			strings.ContainsRune(component, 0) {
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateAuditHistoryCursor checks that an opaque cursor belongs to nodeID.

--- a/internal/store/audit_history_test.go
+++ b/internal/store/audit_history_test.go
@@ -44,8 +44,10 @@ func TestAuditHistoryPagesCanonicalNodeEvents(t *testing.T) {
 	assert.Equal(t, "node_path", first.Items[0].Kind)
 	require.NotNil(t, first.Items[0].OldPath)
 	require.NotNil(t, first.Items[0].NewPath)
-	assert.Equal(t, "/Taxes/return.txt", *first.Items[0].OldPath)
-	assert.Equal(t, "/Taxes/2027/return.txt", *first.Items[0].NewPath)
+	assert.Equal(t, "/Taxes/return.txt", first.Items[0].OldPath.Path)
+	assert.Equal(t, "live", first.Items[0].OldPath.State)
+	assert.Equal(t, "/Taxes/2027/return.txt", first.Items[0].NewPath.Path)
+	assert.Equal(t, "live", first.Items[0].NewPath.State)
 	assert.Equal(t, status.Scopes[0].ID, first.Items[0].ScopeID)
 	assert.Equal(t, moved.Revision, first.Items[0].ResultingNodeRevision)
 	assert.Equal(t, "node_create", first.Items[1].Kind)
@@ -108,4 +110,107 @@ func TestAuditHistoryCursorRemainsStableWhenNewEventsArrive(t *testing.T) {
 		assert.NotEqual(t, firstID, event.ID)
 		assert.LessOrEqual(t, event.OperationSequence, first.Items[0].OperationSequence)
 	}
+}
+
+func TestAuditHistoryPreservesTrashAndRestoreCoordinates(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	work, err := s.NodeByPath(t.Context(), "/Projects/Work")
+	require.NoError(t, err)
+	trashed, _, err := s.Trash(t.Context(), work.ID, work.Revision)
+	require.NoError(t, err)
+
+	page, err := s.AuditHistory(t.Context(), work.ID, 10, "")
+	require.NoError(t, err)
+	trashedPath := findAuditHistoryEvent(t, page.Items, "node_path")
+	require.NotNil(t, trashedPath.OldPath)
+	require.NotNil(t, trashedPath.NewPath)
+	assert.Equal(t, AuditPathState{Path: "/Projects/Work", State: "live"}, *trashedPath.OldPath)
+	assert.Equal(t, AuditPathState{
+		Path: "@trash/known/Projects/Work", State: "trash",
+	}, *trashedPath.NewPath)
+
+	_, err = s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	page, err = s.AuditHistory(t.Context(), work.ID, 10, "")
+	require.NoError(t, err)
+	require.NotNil(t, page.Items[0].OldPath)
+	require.NotNil(t, page.Items[0].NewPath)
+	assert.Equal(t, "@trash/known/Projects/Work", page.Items[0].OldPath.Path)
+	assert.Equal(t, "trash", page.Items[0].OldPath.State)
+	assert.Equal(t, "/Projects/Work", page.Items[0].NewPath.Path)
+	assert.Equal(t, "live", page.Items[0].NewPath.State)
+}
+
+func TestAuditHistoryProjectsTagAndProvenanceChanges(t *testing.T) {
+	t.Run("tag assignment and rename", func(t *testing.T) {
+		s, tag, report := newAuditedTagStore(t)
+		assigned, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+		require.NoError(t, err)
+		_, err = s.RenameTag(t.Context(), tag.ID, assigned.Tag.Revision, "needs review")
+		require.NoError(t, err)
+
+		page, err := s.AuditHistory(t.Context(), report.ID, 10, "")
+		require.NoError(t, err)
+		rename := findAuditHistoryEvent(t, page.Items, "tag_rename")
+		require.NotNil(t, rename.Attachment)
+		assert.Equal(t, "tag_definition", rename.Attachment.Kind)
+		assert.Equal(t, tag.ID, rename.Attachment.Identity.TagID)
+		require.NotNil(t, rename.Attachment.Before)
+		require.NotNil(t, rename.Attachment.After)
+		assert.Equal(t, tag.Name, rename.Attachment.Before.TagName)
+		assert.Equal(t, "needs review", rename.Attachment.After.TagName)
+
+		assignment := findAuditHistoryEvent(t, page.Items, "tag_assign")
+		require.NotNil(t, assignment.Attachment)
+		assert.Equal(t, tag.ID, assignment.Attachment.Identity.TagID)
+		assert.Equal(t, report.ID, assignment.Attachment.Identity.NodeID)
+		assert.Nil(t, assignment.Attachment.Before)
+		require.NotNil(t, assignment.Attachment.After)
+		assert.Equal(t, report.ID, assignment.Attachment.After.NodeID)
+	})
+
+	t.Run("filesystem provenance", func(t *testing.T) {
+		s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, s.Close()) })
+		seedMetadataRoundTrip(t, s)
+		scope, err := s.NodeByPath(t.Context(), "/Projects")
+		require.NoError(t, err)
+		seedInitialAuditAuthority(t, s, scope.ID)
+		run, err := s.BeginIngest(t.Context(), "cli", "/source/reports")
+		require.NoError(t, err)
+		file, added, err := s.IngestFile(
+			t.Context(), run, scope.ID, "history.txt", fakeHash("a713"), 7,
+			"text/plain", "/source/reports/history.txt", "2026-07-18T12:00:00Z",
+		)
+		require.NoError(t, err)
+		require.True(t, added)
+
+		page, err := s.AuditHistory(t.Context(), file.ID, 10, "")
+		require.NoError(t, err)
+		provenance := findAuditHistoryEvent(t, page.Items, "provenance_add")
+		require.NotNil(t, provenance.Attachment)
+		assert.Equal(t, "provenance", provenance.Attachment.Kind)
+		require.NotEmpty(t, provenance.Attachment.Identity.ProvenanceID)
+		assert.Nil(t, provenance.Attachment.Before)
+		require.NotNil(t, provenance.Attachment.After)
+		assert.Equal(t, provenance.Attachment.Identity.ProvenanceID,
+			provenance.Attachment.After.ProvenanceID)
+		assert.Equal(t, file.ID, provenance.Attachment.After.NodeID)
+		assert.Equal(t, run.ID(), provenance.Attachment.After.IngestID)
+		require.NotNil(t, provenance.Attachment.After.OriginalPath)
+		assert.Equal(t, "/source/reports/history.txt",
+			*provenance.Attachment.After.OriginalPath)
+	})
+}
+
+func findAuditHistoryEvent(t *testing.T, events []AuditEvent, kind string) AuditEvent {
+	t.Helper()
+	for _, event := range events {
+		if event.Kind == kind {
+			return event
+		}
+	}
+	require.FailNow(t, "audit event not found", "kind=%s", kind)
+	return AuditEvent{}
 }

--- a/internal/store/audit_history_test.go
+++ b/internal/store/audit_history_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditHistoryPagesCanonicalNodeEvents(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	outside, err := s.Mkdir(t.Context(), s.RootID(), "Outside")
+	require.NoError(t, err)
+	plan, err := s.PreviewInitialAudit(t.Context(), taxes.ID, "cli", nil)
+	require.NoError(t, err)
+	status, err := s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+	require.Len(t, status.Scopes, 1)
+	enrollment, err := s.AuditHistory(t.Context(), taxes.ID, 10, "")
+	require.NoError(t, err)
+	require.Len(t, enrollment.Items, 1)
+	assert.Equal(t, "audit_enroll", enrollment.Items[0].Kind)
+
+	destination, err := s.Mkdir(t.Context(), taxes.ID, "2027")
+	require.NoError(t, err)
+	file, err := s.CreateFile(
+		t.Context(), taxes.ID, "return.txt", fakeHash("a710"), 7, "text/plain",
+	)
+	require.NoError(t, err)
+	moved, err := s.Move(t.Context(), file.ID, destination.ID, file.Name, file.Revision)
+	require.NoError(t, err)
+
+	first, err := s.AuditHistory(t.Context(), file.ID, 2, "")
+	require.NoError(t, err)
+	assert.Equal(t, file.ID, first.Node.ID)
+	assert.Equal(t, "/Taxes/2027/return.txt", first.Path)
+	assert.Equal(t, 4, first.Total)
+	require.Len(t, first.Items, 2)
+	assert.Equal(t, "node_path", first.Items[0].Kind)
+	require.NotNil(t, first.Items[0].OldPath)
+	require.NotNil(t, first.Items[0].NewPath)
+	assert.Equal(t, "/Taxes/return.txt", *first.Items[0].OldPath)
+	assert.Equal(t, "/Taxes/2027/return.txt", *first.Items[0].NewPath)
+	assert.Equal(t, status.Scopes[0].ID, first.Items[0].ScopeID)
+	assert.Equal(t, moved.Revision, first.Items[0].ResultingNodeRevision)
+	assert.Equal(t, "node_create", first.Items[1].Kind)
+	require.NotEmpty(t, first.NextCursor)
+	require.NoError(t, ValidateAuditHistoryCursor(first.NextCursor, file.ID))
+
+	second, err := s.AuditHistory(t.Context(), file.ID, 2, first.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, first.Total, second.Total)
+	require.Len(t, second.Items, 2)
+	assert.Equal(t, "content_create", second.Items[0].Kind)
+	assert.Equal(t, "audit_inherit", second.Items[1].Kind)
+	assert.Empty(t, second.NextCursor)
+
+	byPath, err := s.AuditHistoryPath(
+		t.Context(), "/Taxes/2027/return.txt", 10, "",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, first.Total, byPath.Total)
+	assert.Equal(t, file.ID, byPath.Node.ID)
+
+	_, err = s.AuditHistory(t.Context(), outside.ID, 10, "")
+	require.ErrorIs(t, err, ErrAuditNotEnrolled)
+	_, err = s.AuditHistory(t.Context(), file.ID, 10,
+		encodeAuditHistoryCursor(auditHistoryCursor{
+			nodeID: outside.ID, sequence: 1, ordinal: 0,
+			eventID: fakeHash("a711"),
+		}))
+	require.ErrorIs(t, err, ErrInvalidAuditCursor)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditHistoryCursorRemainsStableWhenNewEventsArrive(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	plan, err := s.PreviewInitialAudit(t.Context(), taxes.ID, "cli", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+	file, err := s.CreateFile(
+		t.Context(), taxes.ID, "return.txt", fakeHash("a712"), 6, "text/plain",
+	)
+	require.NoError(t, err)
+
+	first, err := s.AuditHistory(t.Context(), file.ID, 1, "")
+	require.NoError(t, err)
+	require.Len(t, first.Items, 1)
+	require.NotEmpty(t, first.NextCursor)
+	firstID := first.Items[0].ID
+	_, err = s.Move(t.Context(), file.ID, taxes.ID, "renamed.txt", file.Revision)
+	require.NoError(t, err)
+
+	second, err := s.AuditHistory(t.Context(), file.ID, 10, first.NextCursor)
+	require.NoError(t, err)
+	require.NotEmpty(t, second.Items)
+	for _, event := range second.Items {
+		assert.NotEqual(t, firstID, event.ID)
+		assert.LessOrEqual(t, event.OperationSequence, first.Items[0].OperationSequence)
+	}
+}

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -599,7 +599,7 @@ func newAuditedHistoryReplay(
 			return nil, errors.New("audit attachment genesis repeats an identity")
 		}
 		replay.attachments[key] = attachment
-		if attachment.Kind == "tag_definition" {
+		if attachment.Kind == auditTagDefinitionKind {
 			tagID, err := auditUUIDField(attachment, "tag_id")
 			if err != nil {
 				return nil, err

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -109,7 +109,7 @@ func loadInitialAuditRecords(
 	ctx context.Context, tx metadataQuerier,
 ) (map[string][]storedAuditRecord, error) {
 	rows, err := tx.QueryContext(ctx, `SELECT digest,kind,operation_id,operation_sequence,
-		scope_id,entry_count,event_id,event_ordinal,record_json FROM audit_records`)
+		scope_id,entry_count,event_id,event_ordinal,node_id,record_json FROM audit_records`)
 	if err != nil {
 		return nil, fmt.Errorf("reading initial audit records: %w", err)
 	}
@@ -118,9 +118,9 @@ func loadInitialAuditRecords(
 	for rows.Next() {
 		var digest, kind, recordJSON string
 		var operationID, scopeID, eventID sql.NullString
-		var sequence, entryCount, ordinal sql.NullInt64
+		var sequence, entryCount, ordinal, nodeID sql.NullInt64
 		if err := rows.Scan(&digest, &kind, &operationID, &sequence, &scopeID,
-			&entryCount, &eventID, &ordinal, &recordJSON); err != nil {
+			&entryCount, &eventID, &ordinal, &nodeID, &recordJSON); err != nil {
 			return nil, fmt.Errorf("scanning initial audit record: %w", err)
 		}
 		record, index, canonical, err := validateAuditRecord(metadataAuditRecord{
@@ -135,7 +135,8 @@ func loadInitialAuditRecords(
 			!sameNullString(scopeID, index.scopeID) ||
 			!sameNullInt64(entryCount, index.entryCount) ||
 			!sameNullString(eventID, index.eventID) ||
-			!sameNullInt64(ordinal, index.eventOrdinal) {
+			!sameNullInt64(ordinal, index.eventOrdinal) ||
+			!sameNullInt64(nodeID, index.nodeID) {
 			return nil, fmt.Errorf("audit record %s relational index does not match canonical fields", digest)
 		}
 		result[kind] = append(result[kind], storedAuditRecord{

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -24,6 +24,7 @@ const (
 	auditPreField             = "pre"
 	auditRecordedAtField      = "recorded_at"
 	auditSourceVersionIDField = "source_version_id"
+	auditTagAssignmentKind    = "tag_assignment"
 	auditTagDefinitionKind    = "tag_definition"
 	auditTargetNodeIDField    = "target_node_id"
 )

--- a/internal/store/audit_metadata.go
+++ b/internal/store/audit_metadata.go
@@ -49,6 +49,7 @@ type auditRecordIndex struct {
 	entryCount        *int64
 	eventID           *string
 	eventOrdinal      *int64
+	nodeID            *int64
 }
 
 type storedAuditRecord struct {
@@ -195,9 +196,10 @@ func importAuditRecord(ctx context.Context, tx *sql.Tx, value metadataAuditRecor
 	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO audit_records(
 		digest,kind,operation_id,operation_sequence,scope_id,entry_count,
-		event_id,event_ordinal,record_json) VALUES(?,?,?,?,?,?,?,?,?)`,
+		event_id,event_ordinal,node_id,record_json) VALUES(?,?,?,?,?,?,?,?,?,?)`,
 		value.Digest, record.Kind, index.operationID, index.operationSequence,
-		index.scopeID, index.entryCount, index.eventID, index.eventOrdinal, string(canonical))
+		index.scopeID, index.entryCount, index.eventID, index.eventOrdinal,
+		index.nodeID, string(canonical))
 	if err != nil || record.Kind != "enrollment_baseline" {
 		return err
 	}
@@ -327,8 +329,12 @@ func indexAuditRecord(record audit.Record) (auditRecordIndex, error) {
 		if err != nil {
 			return index, err
 		}
+		nodeID, err := auditInt64UnsignedField(event, metadataNodeIDField)
+		if err != nil {
+			return index, err
+		}
 		index.operationID, index.scopeID = &operationID, &scopeID
-		index.eventID, index.eventOrdinal = &eventID, &ordinal
+		index.eventID, index.eventOrdinal, index.nodeID = &eventID, &ordinal, &nodeID
 	case "canonical_mutation", "allocation_entry":
 		operationID, err := auditUUIDField(record, auditOperationIDField)
 		if err != nil {

--- a/internal/store/audit_projection.go
+++ b/internal/store/audit_projection.go
@@ -276,7 +276,7 @@ func appendAuditTagAssignments(ctx context.Context, tx metadataQuerier, records 
 		if err != nil {
 			return err
 		}
-		*records = append(*records, audit.Record{Kind: "tag_assignment", Fields: []audit.Field{
+		*records = append(*records, audit.Record{Kind: auditTagAssignmentKind, Fields: []audit.Field{
 			{Name: "tag_id", Value: tagValue},
 			{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
 		}})
@@ -313,7 +313,7 @@ func tagDefinitionAuditRecord(tag Tag) (audit.Record, error) {
 	if err != nil {
 		return audit.Record{}, err
 	}
-	return audit.Record{Kind: "tag_definition", Fields: []audit.Field{
+	return audit.Record{Kind: auditTagDefinitionKind, Fields: []audit.Field{
 		{Name: "tag_id", Value: tagValue}, {Name: "name", Value: nameValue},
 	}}, nil
 }
@@ -326,7 +326,7 @@ func attachedAuditIdentity(record audit.Record) (audit.Record, error) {
 	case "provenance":
 		value, err := auditField(record, "identity")
 		return audit.Record{Kind: "provenance_identity_ref", Fields: []audit.Field{{Name: "identity", Value: value}}}, err
-	case "tag_assignment":
+	case auditTagAssignmentKind:
 		tagID, err := auditField(record, "tag_id")
 		if err != nil {
 			return audit.Record{}, err
@@ -335,7 +335,7 @@ func attachedAuditIdentity(record audit.Record) (audit.Record, error) {
 		return audit.Record{Kind: "tag_assignment_identity", Fields: []audit.Field{
 			{Name: "tag_id", Value: tagID}, {Name: metadataNodeIDField, Value: nodeID},
 		}}, err
-	case "tag_definition":
+	case auditTagDefinitionKind:
 		value, err := auditField(record, "tag_id")
 		return audit.Record{Kind: "tag_definition_identity", Fields: []audit.Field{{Name: "tag_id", Value: value}}}, err
 	default:
@@ -374,7 +374,7 @@ func auditRecordsForNodes(records []audit.Record, members map[uint64]bool) ([]au
 				}
 				ingests[ingestID] = true
 			}
-		case "tag_assignment":
+		case auditTagAssignmentKind:
 			nodeID, err := auditUnsignedField(record, metadataNodeIDField)
 			if err != nil {
 				return nil, err
@@ -399,7 +399,7 @@ func auditRecordsForNodes(records []audit.Record, members map[uint64]bool) ([]au
 			if ingests[id] {
 				selected = append(selected, record)
 			}
-		case "tag_definition":
+		case auditTagDefinitionKind:
 			id, err := auditUUIDField(record, "tag_id")
 			if err != nil {
 				return nil, err

--- a/internal/store/audit_tag_assignment.go
+++ b/internal/store/audit_tag_assignment.go
@@ -142,7 +142,7 @@ func auditTagAssignmentRecord(tagID string, nodeID int64) (audit.Record, error) 
 	if err != nil {
 		return audit.Record{}, err
 	}
-	return audit.Record{Kind: "tag_assignment", Fields: []audit.Field{
+	return audit.Record{Kind: auditTagAssignmentKind, Fields: []audit.Field{
 		{Name: "tag_id", Value: tagValue},
 		{Name: metadataNodeIDField, Value: audit.Unsigned(auditNodeID)},
 	}}, nil

--- a/internal/store/audit_tag_assignment_validate.go
+++ b/internal/store/audit_tag_assignment_validate.go
@@ -122,7 +122,7 @@ func (replay *auditedHistoryReplay) validateTagAssignmentDelta(
 		)
 	}
 	change := changes[0]
-	if err := requireAuditText(change, "record_kind", "tag_assignment"); err != nil {
+	if err := requireAuditText(change, "record_kind", auditTagAssignmentKind); err != nil {
 		return replayedTagAssignment{}, err
 	}
 	pre, hasPre, preErr := optionalNestedAuditRecord(change, auditPreField)
@@ -143,7 +143,7 @@ func (replay *auditedHistoryReplay) validateTagAssignmentDelta(
 	if !hasPost {
 		assignment = pre
 	}
-	if assignment.Kind != "tag_assignment" {
+	if assignment.Kind != auditTagAssignmentKind {
 		return replayedTagAssignment{}, errors.New(
 			"tag assignment delta carries the wrong record kind",
 		)
@@ -216,7 +216,7 @@ func optionalNestedAuditRecord(record audit.Record, field string) (audit.Record,
 
 func (replay *auditedHistoryReplay) hasTagDefinition(tagID string) (bool, error) {
 	for _, record := range replay.attachments {
-		if record.Kind != "tag_definition" {
+		if record.Kind != auditTagDefinitionKind {
 			continue
 		}
 		id, err := auditUUIDField(record, "tag_id")
@@ -273,7 +273,7 @@ func (replay *auditedHistoryReplay) validateTagAssignmentEvent(
 		func() error { return requireAuditUnsigned(event, metadataNodeIDField, transition.nodeID) },
 		func() error { return requireAuditText(event, "event_kind", kind) },
 		func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
-		func() error { return requireAuditText(event, "attachment_kind", "tag_assignment") },
+		func() error { return requireAuditText(event, "attachment_kind", auditTagAssignmentKind) },
 		func() error { return requireAuditUnsigned(event, auditEventOrdinalField, 0) },
 		func() error { return requireAuditUnsigned(event, "prior_node_revision", revision) },
 		func() error { return requireAuditUnsigned(event, "resulting_node_revision", revision+1) },

--- a/internal/store/audit_tag_definition_validate.go
+++ b/internal/store/audit_tag_definition_validate.go
@@ -46,7 +46,7 @@ func attachedMutationKind(
 		if err != nil {
 			return "", err
 		}
-		if kind != "tag_definition" {
+		if kind != auditTagDefinitionKind {
 			continue
 		}
 		_, hasPre, err := optionalNestedAuditRecord(change, auditPreField)
@@ -175,7 +175,7 @@ func (replay *auditedHistoryReplay) validateTagDefinitionDelta(
 		)
 	}
 	change := changes[0]
-	if err := requireAuditText(change, "record_kind", "tag_definition"); err != nil {
+	if err := requireAuditText(change, "record_kind", auditTagDefinitionKind); err != nil {
 		return replayedTagDefinitionChange{}, err
 	}
 	pre, hasPre, err := optionalNestedAuditRecord(change, auditPreField)
@@ -258,7 +258,7 @@ func (replay *auditedHistoryReplay) validateTagDefinitionNameAvailable(
 		return err
 	}
 	for _, current := range replay.attachments {
-		if current.Kind != "tag_definition" {
+		if current.Kind != auditTagDefinitionKind {
 			continue
 		}
 		currentID, err := auditUUIDField(current, "tag_id")
@@ -280,7 +280,7 @@ func (replay *auditedHistoryReplay) validateTagDefinitionNameAvailable(
 }
 
 func validateReplayedTagDefinition(definition audit.Record) error {
-	if definition.Kind != "tag_definition" {
+	if definition.Kind != auditTagDefinitionKind {
 		return errors.New("tag definition change carries the wrong record kind")
 	}
 	tagID, err := auditUUIDField(definition, "tag_id")
@@ -306,7 +306,7 @@ func (replay *auditedHistoryReplay) auditedTagDefinitionCandidates(
 ) ([]uint64, error) {
 	seen := make(map[uint64]bool)
 	for _, record := range replay.attachments {
-		if record.Kind != "tag_assignment" {
+		if record.Kind != auditTagAssignmentKind {
 			continue
 		}
 		candidateTagID, err := auditUUIDField(record, "tag_id")
@@ -461,7 +461,7 @@ func (replay *auditedHistoryReplay) validateTagRenameEvents(
 			func() error { return requireAuditUnsigned(event, metadataNodeIDField, nodeID) },
 			func() error { return requireAuditText(event, "event_kind", "tag_rename") },
 			func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
-			func() error { return requireAuditText(event, "attachment_kind", "tag_definition") },
+			func() error { return requireAuditText(event, "attachment_kind", auditTagDefinitionKind) },
 			func() error { return requireAuditUnsigned(event, auditEventOrdinalField, ordinal) },
 			func() error { return requireAuditUnsigned(event, "prior_node_revision", revision) },
 			func() error { return requireAuditUnsigned(event, "resulting_node_revision", revision+1) },

--- a/internal/store/audit_tag_delete_validate.go
+++ b/internal/store/audit_tag_delete_validate.go
@@ -119,7 +119,7 @@ func (replay *auditedHistoryReplay) validateTagDeletionDelta(
 			if err != nil {
 				return replayedTagDeletion{}, err
 			}
-		case "tag_assignment":
+		case auditTagAssignmentKind:
 			nodeID, err := auditUnsignedField(pre, metadataNodeIDField)
 			if err != nil {
 				return replayedTagDeletion{}, err
@@ -171,7 +171,7 @@ func (replay *auditedHistoryReplay) validateTagDeletionDelta(
 func (replay *auditedHistoryReplay) tagAssignmentNodes(tagID string) ([]uint64, error) {
 	var result []uint64
 	for _, record := range replay.attachments {
-		if record.Kind != "tag_assignment" {
+		if record.Kind != auditTagAssignmentKind {
 			continue
 		}
 		currentTagID, err := auditUUIDField(record, "tag_id")

--- a/internal/store/audit_tag_rename.go
+++ b/internal/store/audit_tag_rename.go
@@ -264,7 +264,7 @@ func makeAuditedTagRenameEvent(
 	if err != nil {
 		return audit.Record{}, err
 	}
-	attachmentKind, err := audit.Text("tag_definition")
+	attachmentKind, err := audit.Text(auditTagDefinitionKind)
 	if err != nil {
 		return audit.Record{}, err
 	}

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -43,6 +43,11 @@ var (
 	// ErrAuditPreviewStale means enrollment no longer matches the exact
 	// metadata state reviewed by the caller.
 	ErrAuditPreviewStale = errors.New("audit enrollment preview is stale")
+	// ErrAuditNotEnrolled means a node exists but has no sticky audit membership.
+	ErrAuditNotEnrolled = errors.New("node is not enrolled in an audit scope")
+	// ErrInvalidAuditCursor means an audit-history cursor is malformed or belongs
+	// to a different stable node.
+	ErrInvalidAuditCursor = errors.New("invalid audit history cursor")
 )
 
 // UnconditionalRev is the only ifRev value that skips the revision

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -169,11 +169,14 @@ CREATE TABLE IF NOT EXISTS audit_records (
     entry_count        INTEGER CHECK (entry_count IS NULL OR entry_count > 0),
     event_id           TEXT,
     event_ordinal      INTEGER CHECK (event_ordinal IS NULL OR event_ordinal >= 0),
+    node_id            INTEGER CHECK (node_id IS NULL OR node_id > 0),
     record_json        TEXT NOT NULL
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS audit_record_event
     ON audit_records(event_id) WHERE event_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS audit_record_event_node
+    ON audit_records(node_id) WHERE kind = 'event';
 CREATE UNIQUE INDEX IF NOT EXISTS audit_record_mutation_operation
     ON audit_records(operation_id) WHERE kind = 'canonical_mutation';
 CREATE UNIQUE INDEX IF NOT EXISTS audit_record_mutation_sequence


### PR DESCRIPTION
Docbank can already make a permanent retention promise and record supported changes. Until this PR, a person or agent could confirm that a document was protected but could not answer the basic question: what happened to it?

`docbank audit history /taxes/return.pdf` now shows that document timeline newest first. Content events identify the prior and resulting immutable versions. Move, trash, and restore events show both ends of the transition and distinguish live virtual paths from retained trash coordinates such as `@trash/known/Taxes/return.pdf`. `--node-id` follows the same document after moves and while it remains in trash.

Tag and provenance events are understandable without decoding Docbank audit internals. JSON includes the stable tag or provenance identity and its typed before/after state, including tag names, assignment targets, and filesystem-origin details. Human output gives a concise summary of the same change.

Pagination uses an opaque cursor bound to the stable node and last event position. Appending newer operations does not shift older pages an agent is already reading. A node outside permanent retention returns `audit_not_enrolled`; a protected baseline member with no later event returns an honest empty timeline because membership, not event count, proves protection.

Canonical audit records remain authoritative. A small indexed projection only narrows candidate rows; Go decodes and validates the complete event, canonical path domain, and typed attachment state. This keeps business behavior out of SQL and leaves the read model portable to a future metadata backend. The daemon protocol advances so an older process cannot silently receive the new command.

This deliberately stops at one-node history. Scope-wide browsing, rich content comparison, and independent audit verification remain separate work.

Kata: gb9r.
