### PR TITLE
Expose independent audit verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ metadata, content, and maintenance authority.
   node/tag listings
 - Preview-first permanent audit enrollment for one directory scope, with
   sticky retention, recorded supported mutations, status evidence, bounded
-  per-node history, and backup/restore fidelity
+  per-node history, independent chain/protected-byte verification, and
+  backup/restore fidelity
 - FTS5 name search (document-body extraction and search are planned)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification

--- a/cmd/docbank/audit_verify.go
+++ b/cmd/docbank/audit_verify.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+var auditVerifyJSON bool
+
+var auditVerifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Replay audit authority and verify every protected blob",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		report, err := c.VerifyAudit(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if auditVerifyJSON {
+			err = writeAuditJSON(cmd.OutOrStdout(), report)
+		} else {
+			err = writeAuditVerification(cmd.OutOrStdout(), report)
+		}
+		if err != nil {
+			return err
+		}
+		problems := len(report.MetadataProblems) + len(report.Problems)
+		if problems != 0 {
+			return fmt.Errorf("audit verification found %d problem(s)", problems)
+		}
+		return nil
+	},
+}
+
+func writeAuditVerification(w io.Writer, report api.AuditVerifyReport) error {
+	for _, problem := range report.MetadataProblems {
+		if _, err := fmt.Fprintln(w, "metadata: "+problem); err != nil {
+			return fmt.Errorf("writing audit verification: %w", err)
+		}
+	}
+	for _, problem := range report.Problems {
+		if _, err := fmt.Fprintf(w, "%s: %s\n", problem.Problem, problem.Hash); err != nil {
+			return fmt.Errorf("writing audit verification: %w", err)
+		}
+	}
+	if len(report.MetadataProblems) != 0 {
+		return nil
+	}
+	if !report.Enabled {
+		if _, err := fmt.Fprintln(w, "audit is not enabled; no audit authority to verify"); err != nil {
+			return fmt.Errorf("writing audit verification: %w", err)
+		}
+		return nil
+	}
+	if report.Evidence == nil {
+		return errors.New("audit verification lacks terminal evidence")
+	}
+	evidence := report.Evidence
+	lines := []string{
+		"audit authority verified",
+		"vault: " + evidence.VaultID,
+		fmt.Sprintf("allocation lineage %s: entry %d, operation %d",
+			evidence.LineageID, evidence.AllocationEntryCount,
+			evidence.OperationSequenceHighWater),
+		"allocation head: " + evidence.AllocationHead,
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("writing audit verification: %w", err)
+		}
+	}
+	for _, scope := range evidence.Scopes {
+		if _, err := fmt.Fprintf(w, "scope %s: entry %d, chain head %s\n",
+			scope.ID, scope.EntryCount, scope.ChainHead); err != nil {
+			return fmt.Errorf("writing audit verification: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintf(w, "%d of %d protected blob(s) verified, %d unique byte(s)\n",
+		report.VerifiedBlobs, report.ProtectedBlobs, report.ProtectedBytes); err != nil {
+		return fmt.Errorf("writing audit verification: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	auditVerifyCmd.Flags().BoolVar(&auditVerifyJSON, "json", false, "machine-readable output")
+	auditCmd.AddCommand(auditVerifyCmd)
+}

--- a/cmd/docbank/audit_verify_test.go
+++ b/cmd/docbank/audit_verify_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestWriteAuditVerificationExplainsEvidenceAndProblems(t *testing.T) {
+	evidence := &api.AuditEvidence{
+		VaultID:                    "11111111-1111-4111-8111-111111111111",
+		LineageID:                  "22222222-2222-4222-8222-222222222222",
+		OperationSequenceHighWater: 4, AllocationEntryCount: 4,
+		AllocationHead: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Scopes: []api.AuditScopeEvidence{{
+			ID: "33333333-3333-4333-8333-333333333333", EntryCount: 3,
+			ChainHead: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}},
+	}
+	var out bytes.Buffer
+	require.NoError(t, writeAuditVerification(&out, api.AuditVerifyReport{
+		Enabled: true, Evidence: evidence, ProtectedBlobs: 2,
+		ProtectedBytes: 42, VerifiedBlobs: 1,
+		Problems: []api.VerifyProblem{{
+			Hash:    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			Problem: "missing",
+		}},
+	}))
+	assert.Contains(t, out.String(), "audit authority verified")
+	assert.Contains(t, out.String(), "allocation lineage 22222222-2222-4222-8222-222222222222")
+	assert.Contains(t, out.String(), "scope 33333333-3333-4333-8333-333333333333: entry 3")
+	assert.Contains(t, out.String(), "1 of 2 protected blob(s) verified, 42 unique byte(s)")
+	assert.Contains(t, out.String(), "missing: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+}
+
+func TestWriteAuditVerificationExplainsDormantVault(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, writeAuditVerification(&out, api.AuditVerifyReport{}))
+	assert.Equal(t, "audit is not enabled; no audit authority to verify\n", out.String())
+}

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -157,7 +157,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "19", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "20", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "19", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "20", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -335,6 +335,20 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	historyPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, auditPID, historyPID)
 
+	// Protocol 19 predates independent audit verification evidence. Replace it
+	// before the CLI asks for the new read-only verification workflow.
+	recs[0].Metadata["protocol_version"] = "19"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "audit", "verify", "--json")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, `"enabled": false`)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	verifyPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, historyPID, verifyPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -349,7 +363,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "19", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "20", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -362,7 +376,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, historyPID, protocolPID)
+	assert.NotEqual(t, verifyPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -534,6 +534,22 @@ retention, and `invalid_audit_cursor` as a request error. A protected node may
 have an empty timeline when it was adopted at enrollment and has not changed;
 use status membership, not event count, to decide protection.
 
+Independently replay the authority and hash every protected blob with:
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  "$DOCBANK_URL/api/v1/audit/verify"
+```
+
+A successful HTTP response can still report failed verification. Require empty
+`metadata_problems` and `problems`, `verified_blobs == protected_blobs`, and a
+non-null `evidence` object when `enabled` is true. Record that stable evidence
+outside the vault when rollback detection matters: it contains vault and
+allocation-lineage identities, allocation count/head, the operation high-water
+mark, and every scope count/head. This endpoint hashes protected content only;
+the top-level `/api/v1/verify` also covers unaudited blobs.
+
 The current public boundary permits one permanent scope per vault.
 
 ## Treat destructive maintenance as a two-step decision

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -9,8 +9,9 @@ description: The permanent, tamper-evident history model for protected directory
     Docbank implements permanent first-scope enrollment, sticky membership,
     mutation and allocation chains for the supported changes described below,
     JSONL backup/restore fidelity, status inspection, and bounded per-node
-    history. Additional scopes, scope-wide browsing, independent verification
-    commands, and TUI/web projections remain planned. See
+    history. Independent audit verification returns stable terminal evidence
+    and checks every protected blob. Additional scopes, scope-wide browsing,
+    expected-evidence prefix checks, and TUI/web projections remain planned. See
     [Permanent Audited History](../usage/audited-history.md) for the current
     operator workflow.
 
@@ -1474,10 +1475,19 @@ turns tag/provenance identity and pre/post records into a typed attachment
 change, rather than exposing the internal canonical encoding or dropping the
 metadata that explains the event.
 
+`audit verify` pins one metadata snapshot, exports it through the deterministic
+metadata-v1 validation boundary, and therefore independently replays every
+canonical operation before it reports evidence. While the daemon maintenance
+gate keeps that snapshot and its physical reads coherent, it derives the
+distinct blob set from sticky memberships and retained versions and re-hashes
+each object through catalog authority. The returned evidence deliberately
+contains stable identities and terminal counts/heads, not mutable paths.
+
 !!! info "Planned"
-    Scope-wide history and independent `audit verify` will expose aggregate
-    timelines and terminal verification evidence. Refused protected destruction
-    will identify every blocking scope in structured output.
+    Scope-wide history will expose aggregate timelines. Expected-evidence
+    prefix checks will prove that current terminal heads extend an externally
+    recorded bundle rather than merely differing from it. Refused protected
+    destruction will identify every blocking scope in structured output.
 
 ### TUI
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -39,6 +39,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /nodes/{id}/tags` · `GET /tags/{tag_id}/nodes` · `PUT\|DELETE /nodes/{id}/tags/{tag_id}` · `PUT\|DELETE /path/tags/{tag_id}` | inspect and change tag assignments | Implemented |
 | `POST /audit/preview` · `POST /audit/enable` · `GET /audit/status` | review permanent first-scope retention, enable the exact reviewed plan, and inspect authority or membership | Implemented |
 | `GET /audit/history?path=&node_id=&limit=&cursor=` | read one audited node's canonical newest-first event timeline with a stable continuation cursor | Implemented |
+| `POST /audit/verify` | independently replay audit authority, return stable terminal evidence, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -39,6 +39,7 @@ user's privileges. Consequently:
 | A stored object is what its name claims *structurally* | `blob.Write` dedup check | Kit performs a no-follow identity check; a wrong-sized object, symlink, or special file fails closed and is left unchanged for explicit recovery |
 | Reads serve only stored blobs | `blob.Open` / `blob.Exists` | no-follow open + regular-file check on the blob itself; the vault's own directory structure above it is trusted per the boundary above (a symlinked shard dir is user-privileged relocation or tampering, not an attack docbank can meaningfully resist) |
 | Metadata and audit authority are internally consistent | `docbank verify` | relational validation plus independent replay and reconciliation of canonical audit history |
+| Permanent audit evidence and retained bytes agree | `docbank audit verify` | the same independent replay plus stable lineage/scope terminal evidence and a re-hash of every unique protected blob |
 | Content matches its hash *byte-for-byte* | `docbank verify`; `POST /nodes/{id}/verify` | full-vault re-hash on demand, or a revision-bound fresh read of one file through the mixed store |
 | No orphan blob file survives | `docbank gc` | reachability query for rows **plus** a directory scan for files that never gained (or lost) their row |
 | Imports read the file they classified | ingest | `O_NOFOLLOW` + fstat at open, not the earlier `Lstat`/`WalkDir` classification |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -215,7 +215,7 @@ and which threats require independent evidence.
 | Incremental snapshots and safe publication on restore | [Backup & Recovery](backup.md) |
 | The contract shared by the CLI and agents | [HTTP API](http-api.md) |
 | What integrity checks do and do not establish | [Integrity & Trust](integrity.md) |
-| The planned permanent-retention model | [Audited History](audited-history.md) |
+| Permanent retention, history, and verification | [Audited History](audited-history.md) |
 
 The [Roadmap](../roadmap.md) gives high-level product direction. These pages
 explain implemented behavior and durable design intent; planned behavior is

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -323,6 +323,7 @@ docbank audit status [path] [--json]
 docbank audit status --node-id <id> [--json]
 docbank audit history <path> [--limit <n>] [--cursor <cursor>] [--json]
 docbank audit history --node-id <id> [--limit <n>] [--cursor <cursor>] [--json]
+docbank audit verify [--json]
 ```
 
 `audit enable` permanently protects a directory scope and all retained content
@@ -356,6 +357,15 @@ cursor is opaque and bound to its stable node. Use `--node-id` for a moved or
 trashed node. A protected enrollment-baseline member can legitimately have no
 node-specific events until its first later mutation; use `audit status` for
 membership authority.
+
+`audit verify` independently replays canonical history against current
+metadata, then re-hashes every unique blob retained by protected versions. Its
+terminal evidence contains the stable vault and allocation-lineage identities,
+allocation count/head, operation high-water mark, and every scope count/head.
+Human output reports the same evidence and protected-byte totals; JSON is
+suitable for external recording. Missing, corrupt, unreadable, or inconsistent
+authority exits non-zero. Use the top-level `docbank verify` when the decision
+requires every blob in the vault rather than only permanent audit content.
 
 The current public boundary supports the first scope in a vault; a later
 `audit enable` returns `audit_already_enabled`. See

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ docbank backup create --repo ~/Backups/docbank # incremental snapshot
   </section>
   <section>
     <h3>Audited history</h3>
-    <p>Opt a directory into permanent, tamper-evident history, independently replayed by <code>verify</code>.</p>
+    <p>Opt a directory into permanent, tamper-evident history, with stable evidence from <code>audit verify</code>.</p>
   </section>
 </div>
 
@@ -110,7 +110,8 @@ docbank backup create --repo ~/Backups/docbank # incremental snapshot
   backup is proven before it is trusted.
 - **Audited history.** Opt a directory into permanent, tamper-evident
   history: every change — ingest, replacement, reversion, moves, trash and
-  restore, tag changes — is recorded and `verify` independently replays it.
+  restore, tag changes — is recorded and `audit verify` independently replays
+  it and checks every protected blob.
   Enroll a vault's first audit scope with `docbank audit enable` (newer
   than the v0.5.0 release; build from source to use it today); see
   [Permanent Audited History](usage/audited-history.md).
@@ -136,11 +137,12 @@ and checksum-enforcing installers for Linux, macOS, and Windows on amd64
 and arm64. Implemented and tested today: the core store and ingest
 pipeline, the virtual-tree CLI, the authenticated daemon API, stable
 content versions with verified replacement, reversion, pruning, and
-lookup by content hash (`refs`), tags, loose and packed storage with
+lookup by content hash (`refs`), tags, permanent audit enrollment and node
+history with protected-content evidence, loose and packed storage with
 explicit maintenance, whole-vault integrity verification, incremental
-backup create/verify/restore, and the embedded Go API. Permanent audit
-enrollment is newer than v0.5.0 and not yet in a tagged release; it is
-available from a source build. docbank is not yet a stable 1.0; the
+backup create/verify/restore, and the embedded Go API. The public audit
+workflow is newer than v0.5.0 and not yet in a tagged release; it is available
+from a source build. docbank is not yet a stable 1.0; the
 [Roadmap](roadmap.md) gives the product direction.
 
 docbank belongs to a family of personal data tools alongside

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,8 +107,8 @@ scope chains, status evidence, and JSONL backup/restore validation are
 implemented. One-node canonical audit history is available by path or stable ID
 with bounded, append-stable cursor pagination.
 
-- Additional and overlapping audit scopes, scope-wide history browsing, and a
-  dedicated independent verification command
+- Additional and overlapping audit scopes, scope-wide history browsing, and
+  expected-evidence prefix checks over the implemented independent verifier
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
 - Tag/MIME/date/path search filters; `POST /batch/move` bulk reorganization

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -138,6 +138,34 @@ A protected node adopted during first enrollment may have no node-specific
 events until its first later change. That empty timeline does not weaken its
 baseline protection; `audit status` is the membership authority.
 
+## Verify the permanent evidence
+
+Run the audit-specific verifier when you need a compact proof of the permanent
+promise rather than a scan of unrelated vault content:
+
+```bash
+docbank audit verify
+docbank audit verify --json
+```
+
+The command independently replays canonical history against the current node,
+version, membership, topology, tag, and provenance projections. It then reads
+every unique blob retained by protected history through catalog authority and
+recomputes its SHA-256. Missing, corrupt, or unreadable protected bytes make the
+command fail.
+
+On success, the report contains the stable vault and allocation-lineage IDs,
+the allocation entry count and head, the current operation high-water mark,
+and every scope's entry count and chain head. The JSON `evidence` object is a
+compact terminal bundle suitable for recording outside the vault. A later
+bundle that unexpectedly moves backward or changes vault/lineage identity is a
+rollback or replacement signal; keep older evidence and the corresponding
+verified backups while investigating.
+
+`docbank audit verify` hashes protected content only. `docbank verify` remains
+the broader whole-vault check: it performs the same metadata and audit replay,
+then hashes every cataloged blob, including content outside audit membership.
+
 ## What remains usable
 
 Protected documents remain working documents. Docbank records direct creation
@@ -163,8 +191,7 @@ yet exposed. Status, mutation recording, JSONL export/import, and backup capture
 all preserve the first scope's authority.
 
 !!! info "Planned"
-    Independent `audit verify`, additional scope enrollment, scope-wide history,
-    and rich TUI/web history views are not implemented yet. Until those arrive,
-    `docbank verify` still validates the stored metadata relations and every
-    blob, while backup restore revalidates the portable JSONL authority before
-    publishing a vault.
+    Additional scope enrollment, scope-wide history, expected-evidence prefix
+    checks, and rich TUI/web history views are not implemented yet. Backup
+    restore already revalidates the portable JSONL authority before publishing
+    a vault.

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -21,7 +21,7 @@ const requestTimeout = 60 * time.Second
 // timeout-exempt: long-running maintenance, integrity reads, and bulk ingest.
 func timeoutExempt(path string) bool {
 	switch path {
-	case "/api/v1/ingest", "/api/v1/ingest/stream", "/api/v1/ingest/preflight", "/api/v1/gc", "/api/v1/verify", "/api/v1/trash/empty",
+	case "/api/v1/ingest", "/api/v1/ingest/stream", "/api/v1/ingest/preflight", "/api/v1/gc", "/api/v1/verify", "/api/v1/audit/verify", "/api/v1/trash/empty",
 		"/api/v1/storage/pack", "/api/v1/storage/repack", "/api/v1/uploads",
 		"/api/v1/backup/snapshots", "/api/v1/backup/snapshots/stream",
 		"/api/v1/backup/verify", "/api/v1/backup/verify/stream",

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -21,7 +21,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 		"listTags", "resolveTagByName", "getTag", "listTagNodes", "listNodeTags",
 		"createTag", "renameTag", "deleteTag", "assignTag", "unassignTag",
 		"assignTagPath", "unassignTagPath",
-		"previewAuditEnrollment", "enableAudit", "auditStatus", "auditNodeHistory",
+		"previewAuditEnrollment", "enableAudit", "auditStatus", "auditNodeHistory", "verifyAudit",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
 		"storageStatus", "storagePack", "storageRepack", "ingest", "uploadFile", "listTrash", "emptyTrash", "gc", "verify",
 		"initBackupRepository", "createBackupSnapshot", "listBackupSnapshots", "listJobs"} {

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -15,6 +15,7 @@ import (
 type auditPreviewOutput struct{ Body AuditEnrollmentPreview }
 type auditStatusOutput struct{ Body AuditStatus }
 type auditHistoryOutput struct{ Body AuditEventPage }
+type auditVerifyOutput struct{ Body AuditVerifyReport }
 
 func registerAuditRoutes(
 	api huma.API, d Deps, g *gate, previews *auditPreviewRegistry,
@@ -134,6 +135,49 @@ func registerAuditRoutes(
 	})
 
 	huma.Register(api, huma.Operation{
+		OperationID: "verifyAudit", Method: http.MethodPost, Path: "/api/v1/audit/verify",
+		Summary: "Replay audit authority and verify every protected blob",
+		Description: "Returns stable vault, allocation-lineage, and scope-chain " +
+			"evidence after independently replaying canonical history against current " +
+			"metadata and re-hashing every unique blob retained by protected history.",
+	}, func(ctx context.Context, _ *struct{}) (*auditVerifyOutput, error) {
+		out := &auditVerifyOutput{}
+		err := g.maintain(func() error {
+			verification, err := d.Store.VerifyAudit(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return NewError(http.StatusInternalServerError, "internal",
+						fmt.Sprintf("audit verification interrupted: %v", ctx.Err()))
+				}
+				out.Body.MetadataProblems = append(out.Body.MetadataProblems, err.Error())
+				return nil
+			}
+			out.Body.Enabled = verification.Evidence.Enabled
+			if !verification.Evidence.Enabled {
+				return nil
+			}
+			out.Body.Evidence = auditEvidence(verification.Evidence)
+			out.Body.ProtectedBlobs = len(verification.ProtectedBlobs)
+			out.Body.ProtectedBytes = verification.ProtectedBytes
+			for _, blob := range verification.ProtectedBlobs {
+				if err := ctx.Err(); err != nil {
+					return NewError(http.StatusInternalServerError, "internal",
+						fmt.Sprintf("audit verification interrupted: %v", err))
+				}
+				if problem := checkBlob(ctx, d, blob.Hash); problem == "" {
+					out.Body.VerifiedBlobs++
+				} else {
+					out.Body.Problems = append(out.Body.Problems, VerifyProblem{
+						Hash: blob.Hash, Problem: problem,
+					})
+				}
+			}
+			return nil
+		})
+		return out, err
+	})
+
+	huma.Register(api, huma.Operation{
 		OperationID: "auditNodeHistory", Method: http.MethodGet,
 		Path:    "/api/v1/audit/history",
 		Summary: "Read one audited node's canonical event timeline",
@@ -165,6 +209,22 @@ func registerAuditRoutes(
 		}
 		return &auditHistoryOutput{Body: auditEventPage(page)}, nil
 	})
+}
+
+func auditEvidence(evidence store.AuditEvidence) *AuditEvidence {
+	out := &AuditEvidence{
+		VaultID: evidence.VaultID, LineageID: evidence.LineageID,
+		OperationSequenceHighWater: evidence.OperationSequenceHighWater,
+		AllocationEntryCount:       evidence.AllocationEntryCount,
+		AllocationHead:             evidence.AllocationHead,
+		Scopes:                     make([]AuditScopeEvidence, 0, len(evidence.Scopes)),
+	}
+	for _, scope := range evidence.Scopes {
+		out.Scopes = append(out.Scopes, AuditScopeEvidence{
+			ID: scope.ID, EntryCount: scope.EntryCount, ChainHead: scope.ChainHead,
+		})
+	}
+	return out
 }
 
 func auditEnrollmentPreview(

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -150,6 +150,45 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	require.NoError(t, s.ValidateMetadata(t.Context()))
 }
 
+func TestAuditVerifyReturnsStableEvidenceAndChecksProtectedBytes(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	c := client.New(ts.URL, testAPIKey)
+
+	dormant, err := c.VerifyAudit(t.Context())
+	require.NoError(t, err)
+	assert.False(t, dormant.Enabled)
+	assert.Nil(t, dormant.Evidence)
+
+	file := createFileWithContent(t, ts, s, "/record.txt", "protected content")
+	preview, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: s.RootID()})
+	require.NoError(t, err)
+	status, err := c.EnableAudit(t.Context(), preview.PreviewToken, true)
+	require.NoError(t, err)
+
+	report, err := c.VerifyAudit(t.Context())
+	require.NoError(t, err)
+	assert.True(t, report.Enabled)
+	require.NotNil(t, report.Evidence)
+	assert.Equal(t, status.VaultID, report.Evidence.VaultID)
+	assert.Equal(t, status.LineageID, report.Evidence.LineageID)
+	assert.Equal(t, status.AllocationHead, report.Evidence.AllocationHead)
+	require.Len(t, report.Evidence.Scopes, 1)
+	assert.Equal(t, status.Scopes[0].ChainHead, report.Evidence.Scopes[0].ChainHead)
+	assert.Equal(t, 1, report.ProtectedBlobs)
+	assert.Equal(t, int64(len("protected content")), report.ProtectedBytes)
+	assert.Equal(t, 1, report.VerifiedBlobs)
+	assert.Empty(t, report.Problems)
+	assert.Empty(t, report.MetadataProblems)
+
+	require.NoError(t, s.Blobs.Remove(file.BlobHash))
+	report, err = c.VerifyAudit(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.VerifiedBlobs)
+	require.Len(t, report.Problems, 1)
+	assert.Equal(t, file.BlobHash, report.Problems[0].Hash)
+	assert.Equal(t, "missing", report.Problems[0].Problem)
+}
+
 func TestAuditEnableRejectsPreviewAfterVaultMutation(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -213,6 +213,37 @@ type AuditStatus struct {
 	Membership                 *AuditMembershipStatus `json:"membership,omitempty"`
 }
 
+// AuditScopeEvidence is the terminal count and head of one independently
+// replayed permanent scope chain.
+type AuditScopeEvidence struct {
+	ID         string `json:"id" format:"uuid"`
+	EntryCount int64  `json:"entry_count" minimum:"1"`
+	ChainHead  string `json:"chain_head" pattern:"^[0-9a-f]{64}$"`
+}
+
+// AuditEvidence is the stable authority bundle an operator can record outside
+// the vault and compare with later verification results.
+type AuditEvidence struct {
+	VaultID                    string               `json:"vault_id" format:"uuid"`
+	LineageID                  string               `json:"lineage_id" format:"uuid"`
+	OperationSequenceHighWater int64                `json:"operation_sequence_high_water" minimum:"1"`
+	AllocationEntryCount       int64                `json:"allocation_entry_count" minimum:"1"`
+	AllocationHead             string               `json:"allocation_head" pattern:"^[0-9a-f]{64}$"`
+	Scopes                     []AuditScopeEvidence `json:"scopes" minItems:"1"`
+}
+
+// AuditVerifyReport reports independently replayed authority evidence and
+// physical verification of every unique blob retained by protected history.
+type AuditVerifyReport struct {
+	Enabled          bool            `json:"enabled"`
+	Evidence         *AuditEvidence  `json:"evidence,omitempty"`
+	ProtectedBlobs   int             `json:"protected_blobs" minimum:"0"`
+	ProtectedBytes   int64           `json:"protected_bytes" minimum:"0"` // unique raw bytes
+	VerifiedBlobs    int             `json:"verified_blobs" minimum:"0"`
+	Problems         []VerifyProblem `json:"problems,omitempty"`
+	MetadataProblems []string        `json:"metadata_problems,omitempty"`
+}
+
 // AuditEvent is one canonical, immutable event involving an audited node.
 // Optional fields are present only when that event kind carries the relation.
 type AuditEvent struct {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -717,6 +717,19 @@ func (c *Client) AuditStatus(
 	return status, nil
 }
 
+// VerifyAudit independently replays audit authority and verifies every unique
+// blob retained by protected history.
+func (c *Client) VerifyAudit(ctx context.Context) (api.AuditVerifyReport, error) {
+	var report api.AuditVerifyReport
+	if err := c.do(ctx, http.MethodPost, "/api/v1/audit/verify", nil, nil, &report); err != nil {
+		return report, err
+	}
+	if err := validateAuditVerifyReport(report); err != nil {
+		return api.AuditVerifyReport{}, err
+	}
+	return report, nil
+}
+
 // AuditHistory returns one stable newest-first page of canonical events for
 // exactly one audited node selected by live path or stable ID.
 func (c *Client) AuditHistory(
@@ -1011,6 +1024,62 @@ func validateAuditStatus(status api.AuditStatus) error {
 			}
 			previousScopeID = scopeID
 		}
+	}
+	return nil
+}
+
+func validateAuditVerifyReport(report api.AuditVerifyReport) error {
+	if report.ProtectedBlobs < 0 || report.ProtectedBytes < 0 || report.VerifiedBlobs < 0 ||
+		report.VerifiedBlobs+len(report.Problems) != report.ProtectedBlobs {
+		return errors.New("audit verification has inconsistent blob totals")
+	}
+	for index, problem := range report.MetadataProblems {
+		if problem == "" {
+			return fmt.Errorf("audit verification metadata problem %d is empty", index)
+		}
+	}
+	previousHash := ""
+	for index, problem := range report.Problems {
+		if !validSHA256Hex(problem.Hash) ||
+			(problem.Problem != "missing" && problem.Problem != "corrupt" &&
+				problem.Problem != "unreadable") ||
+			(previousHash != "" && problem.Hash <= previousHash) {
+			return fmt.Errorf("audit verification blob problem %d is invalid", index)
+		}
+		previousHash = problem.Hash
+	}
+	if len(report.MetadataProblems) != 0 {
+		if report.Enabled || report.Evidence != nil || report.ProtectedBlobs != 0 ||
+			report.ProtectedBytes != 0 || report.VerifiedBlobs != 0 || len(report.Problems) != 0 {
+			return errors.New("failed audit metadata verification contains trusted evidence")
+		}
+		return nil
+	}
+	if !report.Enabled {
+		if report.Evidence != nil || report.ProtectedBlobs != 0 || report.ProtectedBytes != 0 {
+			return errors.New("dormant audit verification contains active evidence")
+		}
+		return nil
+	}
+	if report.Evidence == nil {
+		return errors.New("active audit verification lacks terminal evidence")
+	}
+	return validateAuditEvidence(*report.Evidence)
+}
+
+func validateAuditEvidence(evidence api.AuditEvidence) error {
+	if !validUUIDv4(evidence.VaultID) || !validUUIDv4(evidence.LineageID) ||
+		evidence.OperationSequenceHighWater < 1 || evidence.AllocationEntryCount < 1 ||
+		!validSHA256Hex(evidence.AllocationHead) || len(evidence.Scopes) == 0 {
+		return errors.New("audit evidence lacks complete allocation authority")
+	}
+	previousScopeID := ""
+	for index, scope := range evidence.Scopes {
+		if !validUUIDv4(scope.ID) || scope.EntryCount < 1 || !validSHA256Hex(scope.ChainHead) ||
+			(previousScopeID != "" && scope.ID <= previousScopeID) {
+			return fmt.Errorf("audit evidence scope %d is invalid", index)
+		}
+		previousScopeID = scope.ID
 	}
 	return nil
 }

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "19"
+	daemonProtocolVersion = "20"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/audit_verify.go
+++ b/internal/store/audit_verify.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+)
+
+// AuditScopeEvidence is one verified scope-chain terminal.
+type AuditScopeEvidence struct {
+	ID         string
+	EntryCount int64
+	ChainHead  string
+}
+
+// AuditEvidence is the stable authority bundle produced after replay.
+type AuditEvidence struct {
+	Enabled                    bool
+	VaultID                    string
+	LineageID                  string
+	OperationSequenceHighWater int64
+	AllocationEntryCount       int64
+	AllocationHead             string
+	Scopes                     []AuditScopeEvidence
+}
+
+// AuditVerification is one independently replayed audit snapshot plus the
+// unique blobs whose bytes permanent history requires.
+type AuditVerification struct {
+	Evidence       AuditEvidence
+	ProtectedBlobs []BlobInfo
+	ProtectedBytes int64 // unique raw bytes across ProtectedBlobs
+}
+
+// VerifyAudit independently replays canonical audit history against the
+// current projections and returns externally recordable terminal evidence.
+// Blob bytes are verified by the daemon through physical catalog authority
+// after this metadata snapshot succeeds.
+func (s *Store) VerifyAudit(ctx context.Context) (result AuditVerification, err error) {
+	snapshot, err := s.BeginMetadataSnapshot(ctx)
+	if err != nil {
+		return result, err
+	}
+	defer func() { err = errors.Join(err, snapshot.Close()) }()
+	if err := snapshot.Export(ctx, io.Discard); err != nil {
+		return result, fmt.Errorf("replaying audit metadata: %w", err)
+	}
+	result.Evidence, err = auditEvidenceSnapshot(ctx, snapshot, s.vaultID)
+	if err != nil {
+		return result, err
+	}
+	result.ProtectedBlobs = []BlobInfo{}
+	if !result.Evidence.Enabled {
+		return result, nil
+	}
+	rows, err := snapshot.QueryContext(ctx, `
+		SELECT DISTINCT b.hash,b.size
+		FROM audit_memberships m
+		JOIN content_versions v ON v.node_id=m.node_id
+		JOIN blobs b ON b.hash=v.blob_hash
+		ORDER BY b.hash`)
+	if err != nil {
+		return result, fmt.Errorf("listing audit-protected blobs: %w", err)
+	}
+	result.ProtectedBlobs, err = scanBlobInfos(rows, "listing audit-protected blobs")
+	if err != nil {
+		return result, err
+	}
+	for _, blob := range result.ProtectedBlobs {
+		if blob.Size > math.MaxInt64-result.ProtectedBytes {
+			return result, errors.New("audit-protected byte total overflows int64")
+		}
+		result.ProtectedBytes += blob.Size
+	}
+	return result, nil
+}
+
+func auditEvidenceSnapshot(
+	ctx context.Context, snapshot *MetadataSnapshot, vaultID string,
+) (AuditEvidence, error) {
+	evidence := AuditEvidence{VaultID: vaultID, Scopes: []AuditScopeEvidence{}}
+	err := snapshot.QueryRowContext(ctx, `SELECT lineage_id,operation_sequence_high_water,
+		allocation_entry_count,allocation_head FROM audit_authority WHERE singleton=1`).Scan(
+		&evidence.LineageID, &evidence.OperationSequenceHighWater,
+		&evidence.AllocationEntryCount, &evidence.AllocationHead,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return evidence, nil
+	}
+	if err != nil {
+		return AuditEvidence{}, fmt.Errorf("reading verified audit authority: %w", err)
+	}
+	evidence.Enabled = true
+	rows, err := snapshot.QueryContext(ctx,
+		`SELECT scope_id,entry_count,chain_head FROM audit_scopes ORDER BY scope_id`)
+	if err != nil {
+		return AuditEvidence{}, fmt.Errorf("reading verified audit scopes: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var scope AuditScopeEvidence
+		if err := rows.Scan(&scope.ID, &scope.EntryCount, &scope.ChainHead); err != nil {
+			return AuditEvidence{}, fmt.Errorf("scanning verified audit scope: %w", err)
+		}
+		evidence.Scopes = append(evidence.Scopes, scope)
+	}
+	if err := rows.Err(); err != nil {
+		return AuditEvidence{}, fmt.Errorf("reading verified audit scopes: %w", err)
+	}
+	return evidence, nil
+}

--- a/internal/store/audit_verify_test.go
+++ b/internal/store/audit_verify_test.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyAuditReturnsReplayedEvidenceAndProtectedBlobs(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+
+	dormant, err := s.VerifyAudit(t.Context())
+	require.NoError(t, err)
+	assert.False(t, dormant.Evidence.Enabled)
+	assert.Empty(t, dormant.ProtectedBlobs)
+	assert.Zero(t, dormant.ProtectedBytes)
+
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	plan, err := s.PreviewInitialAudit(t.Context(), projects.ID, "api", nil)
+	require.NoError(t, err)
+	enabled, err := s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+
+	verified, err := s.VerifyAudit(t.Context())
+	require.NoError(t, err)
+	assert.True(t, verified.Evidence.Enabled)
+	assert.Equal(t, enabled.VaultID, verified.Evidence.VaultID)
+	assert.Equal(t, enabled.LineageID, verified.Evidence.LineageID)
+	assert.Equal(t, enabled.OperationSequenceHighWater,
+		verified.Evidence.OperationSequenceHighWater)
+	assert.Equal(t, enabled.AllocationEntryCount, verified.Evidence.AllocationEntryCount)
+	assert.Equal(t, enabled.AllocationHead, verified.Evidence.AllocationHead)
+	require.Len(t, verified.Evidence.Scopes, 1)
+	assert.Equal(t, enabled.Scopes[0].ID, verified.Evidence.Scopes[0].ID)
+	assert.Equal(t, enabled.Scopes[0].EntryCount, verified.Evidence.Scopes[0].EntryCount)
+	assert.Equal(t, enabled.Scopes[0].ChainHead, verified.Evidence.Scopes[0].ChainHead)
+	assert.Equal(t, []BlobInfo{
+		{Hash: metadataHashCurrent, Size: 12},
+		{Hash: metadataHashTrashed, Size: 5},
+		{Hash: metadataHashVersion, Size: 9},
+	}, verified.ProtectedBlobs)
+	assert.Equal(t, int64(26), verified.ProtectedBytes)
+}
+
+func TestVerifyAuditRejectsAuthorityThatDoesNotMatchReplay(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+
+	_, err = s.db.ExecContext(t.Context(), `UPDATE audit_scopes SET chain_head=(
+		SELECT digest FROM audit_records WHERE kind='enrollment_baseline' LIMIT 1
+	)`)
+	require.NoError(t, err)
+	_, err = s.VerifyAudit(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audit scope authority does not match replayed history")
+}


### PR DESCRIPTION
Docbank can now retain and show permanent history, but people still lacked a compact answer to two practical questions: does the stored authority replay cleanly, and are all the bytes it promises still present?

`docbank audit verify` pins one coherent metadata view, independently replays canonical history against the current nodes, versions, memberships, topology, tags, and provenance, then streams and hashes every unique blob retained by protected versions. Missing, corrupt, or unreadable content is reported and the command exits nonzero. The authenticated API and typed Go client expose the same result.

A successful active report includes a stable evidence bundle: vault and allocation-lineage identities, the allocation count and head, the operation high-water mark, and every scope count and head. Mutable paths are deliberately absent, so the JSON can be recorded outside the vault without ordinary reorganization rewriting the proof.

This does not replace `docbank verify`: that remains the whole-vault integrity command and checks unaudited content too. It also does not add new scopes, scope-wide browsing, expected-evidence prefix checking, or destruction controls. No schema changed; SQLite only projects the small protected-blob set while replay and policy remain Go code.

The coverage exercises dormant and active vaults, independent replay rejection, protected-byte loss, CLI reporting, both SQLite implementations, and stale-daemon replacement. The human, agent, CLI, HTTP, integrity, architecture, and roadmap documentation now describe the same implemented boundary.

Kata: c84b.