### PR TITLE
Verify recorded audit evidence ancestry

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ metadata, content, and maintenance authority.
   node/tag listings
 - Preview-first permanent audit enrollment for one directory scope, with
   sticky retention, recorded supported mutations, status evidence, bounded
-  per-node history, independent chain/protected-byte verification, and
-  backup/restore fidelity
+  per-node history, independent chain/protected-byte verification, exact-prefix
+  checks against externally recorded evidence, and backup/restore fidelity
 - FTS5 name search (document-body extraction and search are planned)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification

--- a/cmd/docbank/audit_verify.go
+++ b/cmd/docbank/audit_verify.go
@@ -1,28 +1,43 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/jsontext"
 )
 
 var auditVerifyJSON bool
+var auditVerifyExpected string
+
+const maxAuditEvidenceFileBytes = 1 << 20
 
 var auditVerifyCmd = &cobra.Command{
 	Use:   "verify",
 	Short: "Replay audit authority and verify every protected blob",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		var expected *api.AuditEvidence
+		if auditVerifyExpected != "" {
+			var err error
+			expected, err = readExpectedAuditEvidence(auditVerifyExpected)
+			if err != nil {
+				return err
+			}
+		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
 			return err
 		}
-		report, err := c.VerifyAudit(cmd.Context())
+		report, err := c.VerifyAudit(cmd.Context(), expected)
 		if err != nil {
 			return err
 		}
@@ -35,6 +50,9 @@ var auditVerifyCmd = &cobra.Command{
 			return err
 		}
 		problems := len(report.MetadataProblems) + len(report.Problems)
+		if report.EvidenceCheck != nil {
+			problems += len(report.EvidenceCheck.Problems)
+		}
 		if problems != 0 {
 			return fmt.Errorf("audit verification found %d problem(s)", problems)
 		}
@@ -51,6 +69,13 @@ func writeAuditVerification(w io.Writer, report api.AuditVerifyReport) error {
 	for _, problem := range report.Problems {
 		if _, err := fmt.Fprintf(w, "%s: %s\n", problem.Problem, problem.Hash); err != nil {
 			return fmt.Errorf("writing audit verification: %w", err)
+		}
+	}
+	if report.EvidenceCheck != nil {
+		for _, problem := range report.EvidenceCheck.Problems {
+			if _, err := fmt.Fprintf(w, "evidence %s: %s\n", problem.Code, problem.Message); err != nil {
+				return fmt.Errorf("writing audit verification: %w", err)
+			}
 		}
 	}
 	if len(report.MetadataProblems) != 0 {
@@ -85,6 +110,12 @@ func writeAuditVerification(w io.Writer, report api.AuditVerifyReport) error {
 			return fmt.Errorf("writing audit verification: %w", err)
 		}
 	}
+	if report.EvidenceCheck != nil && report.EvidenceCheck.Extends {
+		if _, err := fmt.Fprintln(w,
+			"recorded evidence is an exact prefix of current authority"); err != nil {
+			return fmt.Errorf("writing audit verification: %w", err)
+		}
+	}
 	if _, err := fmt.Fprintf(w, "%d of %d protected blob(s) verified, %d unique byte(s)\n",
 		report.VerifiedBlobs, report.ProtectedBlobs, report.ProtectedBytes); err != nil {
 		return fmt.Errorf("writing audit verification: %w", err)
@@ -92,7 +123,59 @@ func writeAuditVerification(w io.Writer, report api.AuditVerifyReport) error {
 	return nil
 }
 
+func readExpectedAuditEvidence(path string) (*api.AuditEvidence, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening expected audit report: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(f, maxAuditEvidenceFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading expected audit report: %w", err)
+	}
+	if len(raw) > maxAuditEvidenceFileBytes {
+		return nil, fmt.Errorf("expected audit report exceeds %d bytes", maxAuditEvidenceFileBytes)
+	}
+	if err := jsontext.Validate(raw, "expected audit report"); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var report api.AuditVerifyReport
+	if err := decoder.Decode(&report); err != nil {
+		return nil, fmt.Errorf("decoding expected audit report: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return nil, fmt.Errorf("decoding expected audit report: %w", err)
+	}
+	if !report.Enabled || report.Evidence == nil || len(report.MetadataProblems) != 0 ||
+		len(report.Problems) != 0 || report.VerifiedBlobs != report.ProtectedBlobs ||
+		report.ProtectedBlobs < 0 || report.ProtectedBytes < 0 ||
+		(report.EvidenceCheck != nil &&
+			(!report.EvidenceCheck.Extends || len(report.EvidenceCheck.Problems) != 0)) {
+		return nil, errors.New("expected audit report was not a successful active verification")
+	}
+	if err := client.ValidateAuditEvidence(*report.Evidence); err != nil {
+		return nil, fmt.Errorf("invalid evidence in expected audit report: %w", err)
+	}
+	return report.Evidence, nil
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	err := decoder.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("multiple JSON values are not allowed")
+	}
+	return err
+}
+
 func init() {
 	auditVerifyCmd.Flags().BoolVar(&auditVerifyJSON, "json", false, "machine-readable output")
+	auditVerifyCmd.Flags().StringVar(&auditVerifyExpected, "expected", "",
+		"successful prior --json report to prove as an exact prefix")
 	auditCmd.AddCommand(auditVerifyCmd)
 }

--- a/cmd/docbank/audit_verify_test.go
+++ b/cmd/docbank/audit_verify_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +28,7 @@ func TestWriteAuditVerificationExplainsEvidenceAndProblems(t *testing.T) {
 	require.NoError(t, writeAuditVerification(&out, api.AuditVerifyReport{
 		Enabled: true, Evidence: evidence, ProtectedBlobs: 2,
 		ProtectedBytes: 42, VerifiedBlobs: 1,
+		EvidenceCheck: &api.AuditEvidenceCheck{Extends: true},
 		Problems: []api.VerifyProblem{{
 			Hash:    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 			Problem: "missing",
@@ -34,7 +38,42 @@ func TestWriteAuditVerificationExplainsEvidenceAndProblems(t *testing.T) {
 	assert.Contains(t, out.String(), "allocation lineage 22222222-2222-4222-8222-222222222222")
 	assert.Contains(t, out.String(), "scope 33333333-3333-4333-8333-333333333333: entry 3")
 	assert.Contains(t, out.String(), "1 of 2 protected blob(s) verified, 42 unique byte(s)")
+	assert.Contains(t, out.String(), "recorded evidence is an exact prefix")
 	assert.Contains(t, out.String(), "missing: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+}
+
+func TestReadExpectedAuditEvidenceRequiresSuccessfulReport(t *testing.T) {
+	evidence := &api.AuditEvidence{
+		VaultID:                    "11111111-1111-4111-8111-111111111111",
+		LineageID:                  "22222222-2222-4222-8222-222222222222",
+		OperationSequenceHighWater: 1, AllocationEntryCount: 1,
+		AllocationHead: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Scopes: []api.AuditScopeEvidence{{
+			ID: "33333333-3333-4333-8333-333333333333", EntryCount: 1,
+			ChainHead: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}},
+	}
+	path := filepath.Join(t.TempDir(), "audit-evidence.json")
+	raw, err := json.Marshal(api.AuditVerifyReport{
+		Enabled: true, Evidence: evidence, ProtectedBlobs: 1, VerifiedBlobs: 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	got, err := readExpectedAuditEvidence(path)
+	require.NoError(t, err)
+	assert.Equal(t, evidence, got)
+
+	raw, err = json.Marshal(api.AuditVerifyReport{
+		Enabled: true, Evidence: evidence, ProtectedBlobs: 1,
+		Problems: []api.VerifyProblem{{
+			Hash:    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			Problem: "missing",
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	_, err = readExpectedAuditEvidence(path)
+	require.ErrorContains(t, err, "not a successful active verification")
 }
 
 func TestWriteAuditVerificationExplainsDormantVault(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -157,7 +157,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "20", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "21", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "20", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "21", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -335,9 +335,9 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	historyPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, auditPID, historyPID)
 
-	// Protocol 19 predates independent audit verification evidence. Replace it
-	// before the CLI asks for the new read-only verification workflow.
-	recs[0].Metadata["protocol_version"] = "19"
+	// Protocol 20 predates exact-prefix checks against externally recorded
+	// audit evidence. Replace it before any expected evidence can be ignored.
+	recs[0].Metadata["protocol_version"] = "20"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
 	out, err = run(oldBin, "audit", "verify", "--json")
@@ -363,7 +363,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "20", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "21", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -550,6 +550,26 @@ allocation-lineage identities, allocation count/head, the operation high-water
 mark, and every scope count/head. This endpoint hashes protected content only;
 the top-level `/api/v1/verify` also covers unaudited blobs.
 
+To check a later vault against that trusted record, send the prior successful
+report's `evidence` object as `expected`:
+
+```bash
+jq -c '{expected: .evidence}' audit-evidence.json > audit-expected-request.json
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data-binary @audit-expected-request.json \
+  "$DOCBANK_URL/api/v1/audit/verify"
+```
+
+Require `evidence_check.extends: true` as well as clean metadata and blob
+results. Equal chains and valid extensions pass. Stable problem codes
+are `audit_not_enabled`, `vault_mismatch`, `lineage_mismatch`,
+`allocation_shorter`, `allocation_diverged`, `scope_missing`, `scope_shorter`,
+and `scope_diverged`. Evidence mismatch is reported in the body rather than as
+an HTTP transport error so agents can inspect the current verified evidence and
+byte state before escalating.
+
 The current public boundary permits one permanent scope per vault.
 
 ## Treat destructive maintenance as a two-step decision

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -10,8 +10,9 @@ description: The permanent, tamper-evident history model for protected directory
     mutation and allocation chains for the supported changes described below,
     JSONL backup/restore fidelity, status inspection, and bounded per-node
     history. Independent audit verification returns stable terminal evidence
-    and checks every protected blob. Additional scopes, scope-wide browsing,
-    expected-evidence prefix checks, and TUI/web projections remain planned. See
+    and checks every protected blob; supplied external evidence is proved as an
+    exact prefix of current allocation and scope chains. Additional scopes,
+    scope-wide browsing, and TUI/web projections remain planned. See
     [Permanent Audited History](../usage/audited-history.md) for the current
     operator workflow.
 
@@ -1483,10 +1484,17 @@ distinct blob set from sticky memberships and retained versions and re-hashes
 each object through catalog authority. The returned evidence deliberately
 contains stable identities and terminal counts/heads, not mutable paths.
 
+When a client supplies a previously successful report, verification uses the
+same pinned snapshot to prove exact ancestry. Vault and allocation-lineage IDs
+must match; the allocation record at the expected count must have the expected
+head; and the scope record at each expected count must have that scope's
+expected head. Current chains may be equal or longer, and future additional
+scopes do not invalidate older evidence. A missing, shorter, or divergent
+prefix is a structured verification problem, not metadata corruption, so the
+report still includes current terminal evidence and protected-byte results.
+
 !!! info "Planned"
-    Scope-wide history will expose aggregate timelines. Expected-evidence
-    prefix checks will prove that current terminal heads extend an externally
-    recorded bundle rather than merely differing from it. Refused protected
+    Scope-wide history will expose aggregate timelines. Refused protected
     destruction will identify every blocking scope in structured output.
 
 ### TUI

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -39,7 +39,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /nodes/{id}/tags` · `GET /tags/{tag_id}/nodes` · `PUT\|DELETE /nodes/{id}/tags/{tag_id}` · `PUT\|DELETE /path/tags/{tag_id}` | inspect and change tag assignments | Implemented |
 | `POST /audit/preview` · `POST /audit/enable` · `GET /audit/status` | review permanent first-scope retention, enable the exact reviewed plan, and inspect authority or membership | Implemented |
 | `GET /audit/history?path=&node_id=&limit=&cursor=` | read one audited node's canonical newest-first event timeline with a stable continuation cursor | Implemented |
-| `POST /audit/verify` | independently replay audit authority, return stable terminal evidence, and re-hash every protected blob | Implemented |
+| `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
@@ -87,6 +87,24 @@ Explicit repository paths are server filesystem paths and must be absolute.
 The CLI resolves a relative `--repo` against its own working directory before
 sending it. API clients over an SSH tunnel must reason about the daemon host's
 filesystem, not the caller's. Every endpoint requires the daemon API key.
+
+### Audit expected-evidence verification
+
+`POST /audit/verify` accepts an empty body for a fresh proof. To prove ancestry,
+send the `evidence` object from a previously successful report:
+
+```json
+{"expected":{"vault_id":"...","lineage_id":"...","operation_sequence_high_water":12,"allocation_entry_count":12,"allocation_head":"...","scopes":[{"id":"...","entry_count":9,"chain_head":"..."}]}}
+```
+
+The current vault is independently replayed before comparison. A successful
+prefix proof returns `evidence_check: {"extends":true}`. Evidence disagreement
+remains an HTTP 200 verification report so clients can inspect current terminal
+evidence and protected-byte problems together; `evidence_check.problems` uses
+the stable codes `audit_not_enabled`, `vault_mismatch`, `lineage_mismatch`,
+`allocation_shorter`, `allocation_diverged`, `scope_missing`, `scope_shorter`,
+and `scope_diverged`. Malformed expected evidence is a `422 validation` request
+error.
 
 ### Background-job status
 

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -39,7 +39,7 @@ user's privileges. Consequently:
 | A stored object is what its name claims *structurally* | `blob.Write` dedup check | Kit performs a no-follow identity check; a wrong-sized object, symlink, or special file fails closed and is left unchanged for explicit recovery |
 | Reads serve only stored blobs | `blob.Open` / `blob.Exists` | no-follow open + regular-file check on the blob itself; the vault's own directory structure above it is trusted per the boundary above (a symlinked shard dir is user-privileged relocation or tampering, not an attack docbank can meaningfully resist) |
 | Metadata and audit authority are internally consistent | `docbank verify` | relational validation plus independent replay and reconciliation of canonical audit history |
-| Permanent audit evidence and retained bytes agree | `docbank audit verify` | the same independent replay plus stable lineage/scope terminal evidence and a re-hash of every unique protected blob |
+| Permanent audit evidence and retained bytes agree | `docbank audit verify` | independent replay, an optional exact-prefix proof against externally recorded lineage/scope evidence, and a re-hash of every unique protected blob |
 | Content matches its hash *byte-for-byte* | `docbank verify`; `POST /nodes/{id}/verify` | full-vault re-hash on demand, or a revision-bound fresh read of one file through the mixed store |
 | No orphan blob file survives | `docbank gc` | reachability query for rows **plus** a directory scan for files that never gained (or lost) their row |
 | Imports read the file they classified | ingest | `O_NOFOLLOW` + fstat at open, not the earlier `Lstat`/`WalkDir` classification |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,11 +11,15 @@ docbank is pre-1.0; interfaces and storage migrations may still evolve.
 
 - The store extends audited recording to filesystem ingest, content
   reversion, in-scope moves and renames, reversible trash and restore, and
-  tag creation, assignment, and rename; backup restore and JSONL import
+  tag creation, assignment, rename, and deletion; backup restore and JSONL import
   independently replay and validate that history.
 - Enrollment of a vault's first audit scope is available through
   `docbank audit enable` and `docbank audit status`, with a preview-first,
   token-acknowledged workflow; additional scopes remain unavailable.
+- Bounded per-node audit history exposes canonical path, content, tag, and
+  provenance changes, while `docbank audit verify` independently replays the
+  authority, checks protected bytes, and proves current chains extend a
+  separately recorded evidence report.
 
 ## v0.5.0 (2026-07-17)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -323,7 +323,7 @@ docbank audit status [path] [--json]
 docbank audit status --node-id <id> [--json]
 docbank audit history <path> [--limit <n>] [--cursor <cursor>] [--json]
 docbank audit history --node-id <id> [--limit <n>] [--cursor <cursor>] [--json]
-docbank audit verify [--json]
+docbank audit verify [--expected <prior-json-report>] [--json]
 ```
 
 `audit enable` permanently protects a directory scope and all retained content
@@ -366,6 +366,12 @@ Human output reports the same evidence and protected-byte totals; JSON is
 suitable for external recording. Missing, corrupt, unreadable, or inconsistent
 authority exits non-zero. Use the top-level `docbank verify` when the decision
 requires every blob in the vault rather than only permanent audit content.
+
+Save a successful active JSON report outside the vault, then pass it back with
+`--expected`. Verification proves that its allocation head and every recorded
+scope head remain exact prefixes of current authority. Equal or validly extended
+chains pass; a different vault/lineage, missing scope, shorter chain, or
+divergent head is reported with a stable problem code and exits non-zero.
 
 The current public boundary supports the first scope in a vault; a later
 `audit enable` returns `audit_already_enabled`. See

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ docbank backup create --repo ~/Backups/docbank # incremental snapshot
   </section>
   <section>
     <h3>Audited history</h3>
-    <p>Opt a directory into permanent, tamper-evident history, with stable evidence from <code>audit verify</code>.</p>
+    <p>Opt a directory into permanent, tamper-evident history, then prove current authority extends evidence you recorded earlier.</p>
   </section>
 </div>
 
@@ -111,7 +111,8 @@ docbank backup create --repo ~/Backups/docbank # incremental snapshot
 - **Audited history.** Opt a directory into permanent, tamper-evident
   history: every change — ingest, replacement, reversion, moves, trash and
   restore, tag changes — is recorded and `audit verify` independently replays
-  it and checks every protected blob.
+  it, checks every protected blob, and proves current authority extends a
+  previously recorded evidence bundle.
   Enroll a vault's first audit scope with `docbank audit enable` (newer
   than the v0.5.0 release; build from source to use it today); see
   [Permanent Audited History](usage/audited-history.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -105,10 +105,11 @@ listings. Permanent first-scope audit enrollment is preview-first across the
 CLI and API. Sticky membership, supported logical mutations, allocation and
 scope chains, status evidence, and JSONL backup/restore validation are
 implemented. One-node canonical audit history is available by path or stable ID
-with bounded, append-stable cursor pagination.
+with bounded, append-stable cursor pagination. Independent verification returns
+stable terminal evidence, checks every protected blob, and can prove that
+current allocation and scope chains extend an externally recorded bundle.
 
-- Additional and overlapping audit scopes, scope-wide history browsing, and
-  expected-evidence prefix checks over the implemented independent verifier
+- Additional and overlapping audit scopes and scope-wide history browsing
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
 - Tag/MIME/date/path search filters; `POST /batch/move` bulk reorganization

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -146,6 +146,8 @@ promise rather than a scan of unrelated vault content:
 ```bash
 docbank audit verify
 docbank audit verify --json
+docbank audit verify --json > audit-evidence.json
+docbank audit verify --expected audit-evidence.json
 ```
 
 The command independently replays canonical history against the current node,
@@ -158,9 +160,19 @@ On success, the report contains the stable vault and allocation-lineage IDs,
 the allocation entry count and head, the current operation high-water mark,
 and every scope's entry count and chain head. The JSON `evidence` object is a
 compact terminal bundle suitable for recording outside the vault. A later
-bundle that unexpectedly moves backward or changes vault/lineage identity is a
-rollback or replacement signal; keep older evidence and the corresponding
-verified backups while investigating.
+verification can prove that exact bundle is a prefix of the current authority:
+the vault and allocation-lineage identities must match, the recorded allocation
+head must still exist at its recorded count, and every recorded scope head must
+still exist at its recorded count. Equal chains pass, and chains with valid
+later operations also pass. A missing, shorter, or divergent chain makes the
+command fail with a structured evidence problem while still reporting current
+metadata and protected-byte results.
+
+`--expected` reads a successful active `audit verify --json` report, not an
+unverified hand-written head. Keep that report outside the vault and retain the
+corresponding verified backups. The proof cannot detect an attacker who can
+replace both the vault and your separately recorded evidence; the external copy
+is the trust anchor.
 
 `docbank audit verify` hashes protected content only. `docbank verify` remains
 the broader whole-vault check: it performs the same metadata and audit replay,
@@ -191,7 +203,6 @@ yet exposed. Status, mutation recording, JSONL export/import, and backup capture
 all preserve the first scope's authority.
 
 !!! info "Planned"
-    Additional scope enrollment, scope-wide history, expected-evidence prefix
-    checks, and rich TUI/web history views are not implemented yet. Backup
-    restore already revalidates the portable JSONL authority before publishing
-    a vault.
+    Additional scope enrollment, scope-wide history, and rich TUI/web history
+    views are not implemented yet. Backup restore already revalidates the
+    portable JSONL authority before publishing a vault.

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -139,11 +139,23 @@ func registerAuditRoutes(
 		Summary: "Replay audit authority and verify every protected blob",
 		Description: "Returns stable vault, allocation-lineage, and scope-chain " +
 			"evidence after independently replaying canonical history against current " +
-			"metadata and re-hashing every unique blob retained by protected history.",
-	}, func(ctx context.Context, _ *struct{}) (*auditVerifyOutput, error) {
+			"metadata and re-hashing every unique blob retained by protected history. " +
+			"Optional expected evidence is proved as an exact prefix of current authority.",
+	}, func(ctx context.Context, in *struct {
+		Body *AuditVerifyRequest
+	}) (*auditVerifyOutput, error) {
+		var expected *store.AuditEvidence
+		if in.Body != nil && in.Body.Expected != nil {
+			converted := storeAuditEvidence(*in.Body.Expected)
+			if err := store.ValidateAuditEvidence(converted); err != nil {
+				return nil, NewError(http.StatusUnprocessableEntity, "validation",
+					fmt.Sprintf("invalid expected audit evidence: %v", err))
+			}
+			expected = &converted
+		}
 		out := &auditVerifyOutput{}
 		err := g.maintain(func() error {
-			verification, err := d.Store.VerifyAudit(ctx)
+			verification, err := d.Store.VerifyAudit(ctx, expected)
 			if err != nil {
 				if ctx.Err() != nil {
 					return NewError(http.StatusInternalServerError, "internal",
@@ -153,6 +165,9 @@ func registerAuditRoutes(
 				return nil
 			}
 			out.Body.Enabled = verification.Evidence.Enabled
+			if verification.EvidenceCheck != nil {
+				out.Body.EvidenceCheck = auditEvidenceCheck(*verification.EvidenceCheck)
+			}
 			if !verification.Evidence.Enabled {
 				return nil
 			}
@@ -209,6 +224,34 @@ func registerAuditRoutes(
 		}
 		return &auditHistoryOutput{Body: auditEventPage(page)}, nil
 	})
+}
+
+func storeAuditEvidence(evidence AuditEvidence) store.AuditEvidence {
+	out := store.AuditEvidence{
+		Enabled: true, VaultID: evidence.VaultID, LineageID: evidence.LineageID,
+		OperationSequenceHighWater: evidence.OperationSequenceHighWater,
+		AllocationEntryCount:       evidence.AllocationEntryCount,
+		AllocationHead:             evidence.AllocationHead,
+		Scopes:                     make([]store.AuditScopeEvidence, 0, len(evidence.Scopes)),
+	}
+	for _, scope := range evidence.Scopes {
+		out.Scopes = append(out.Scopes, store.AuditScopeEvidence{
+			ID: scope.ID, EntryCount: scope.EntryCount, ChainHead: scope.ChainHead,
+		})
+	}
+	return out
+}
+
+func auditEvidenceCheck(check store.AuditEvidenceCheck) *AuditEvidenceCheck {
+	out := &AuditEvidenceCheck{
+		Extends: check.Extends, Problems: make([]AuditEvidenceProblem, 0, len(check.Problems)),
+	}
+	for _, problem := range check.Problems {
+		out.Problems = append(out.Problems, AuditEvidenceProblem{
+			Code: problem.Code, ScopeID: problem.ScopeID, Message: problem.Message,
+		})
+	}
+	return out
 }
 
 func auditEvidence(evidence store.AuditEvidence) *AuditEvidence {

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -153,8 +154,16 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 func TestAuditVerifyReturnsStableEvidenceAndChecksProtectedBytes(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	c := client.New(ts.URL, testAPIKey)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/api/v1/audit/verify", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Api-Key", testAPIKey)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
 
-	dormant, err := c.VerifyAudit(t.Context())
+	dormant, err := c.VerifyAudit(t.Context(), nil)
 	require.NoError(t, err)
 	assert.False(t, dormant.Enabled)
 	assert.Nil(t, dormant.Evidence)
@@ -165,7 +174,7 @@ func TestAuditVerifyReturnsStableEvidenceAndChecksProtectedBytes(t *testing.T) {
 	status, err := c.EnableAudit(t.Context(), preview.PreviewToken, true)
 	require.NoError(t, err)
 
-	report, err := c.VerifyAudit(t.Context())
+	report, err := c.VerifyAudit(t.Context(), nil)
 	require.NoError(t, err)
 	assert.True(t, report.Enabled)
 	require.NotNil(t, report.Evidence)
@@ -179,10 +188,44 @@ func TestAuditVerifyReturnsStableEvidenceAndChecksProtectedBytes(t *testing.T) {
 	assert.Equal(t, 1, report.VerifiedBlobs)
 	assert.Empty(t, report.Problems)
 	assert.Empty(t, report.MetadataProblems)
+	recorded := *report.Evidence
+	invalid := recorded
+	invalid.AllocationEntryCount++
+	raw, err := json.Marshal(api.AuditVerifyRequest{Expected: &invalid})
+	require.NoError(t, err)
+	req, err = http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/api/v1/audit/verify", bytes.NewReader(raw))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", testAPIKey)
+	resp, err = ts.Client().Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	_, err = s.Mkdir(t.Context(), s.RootID(), "after-evidence")
+	require.NoError(t, err)
+	report, err = c.VerifyAudit(t.Context(), &recorded)
+	require.NoError(t, err)
+	require.NotNil(t, report.EvidenceCheck)
+	assert.True(t, report.EvidenceCheck.Extends)
+	assert.Empty(t, report.EvidenceCheck.Problems)
+
+	divergent := recorded
+	divergent.AllocationHead = testHash("divergent allocation")
+	report, err = c.VerifyAudit(t.Context(), &divergent)
+	require.NoError(t, err)
+	require.NotNil(t, report.EvidenceCheck)
+	assert.False(t, report.EvidenceCheck.Extends)
+	require.Len(t, report.EvidenceCheck.Problems, 1)
+	assert.Equal(t, "allocation_diverged", report.EvidenceCheck.Problems[0].Code)
 
 	require.NoError(t, s.Blobs.Remove(file.BlobHash))
-	report, err = c.VerifyAudit(t.Context())
+	report, err = c.VerifyAudit(t.Context(), &divergent)
 	require.NoError(t, err)
+	require.NotNil(t, report.EvidenceCheck)
+	require.Len(t, report.EvidenceCheck.Problems, 1)
+	assert.Equal(t, "allocation_diverged", report.EvidenceCheck.Problems[0].Code)
 	assert.Equal(t, 0, report.VerifiedBlobs)
 	require.Len(t, report.Problems, 1)
 	assert.Equal(t, file.BlobHash, report.Problems[0].Hash)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -229,19 +229,40 @@ type AuditEvidence struct {
 	OperationSequenceHighWater int64                `json:"operation_sequence_high_water" minimum:"1"`
 	AllocationEntryCount       int64                `json:"allocation_entry_count" minimum:"1"`
 	AllocationHead             string               `json:"allocation_head" pattern:"^[0-9a-f]{64}$"`
-	Scopes                     []AuditScopeEvidence `json:"scopes" minItems:"1"`
+	Scopes                     []AuditScopeEvidence `json:"scopes" minItems:"1" maxItems:"1000"`
+}
+
+// AuditVerifyRequest optionally asks verification to prove that current
+// authority extends an externally recorded evidence bundle.
+type AuditVerifyRequest struct {
+	Expected *AuditEvidence `json:"expected,omitempty"`
+}
+
+// AuditEvidenceProblem is one stable reason current authority does not extend
+// externally recorded evidence.
+type AuditEvidenceProblem struct {
+	Code    string `json:"code" enum:"audit_not_enabled,vault_mismatch,lineage_mismatch,allocation_shorter,allocation_diverged,scope_missing,scope_shorter,scope_diverged"`
+	ScopeID string `json:"scope_id,omitempty" format:"uuid"`
+	Message string `json:"message"`
+}
+
+// AuditEvidenceCheck reports the exact-prefix proof requested by the caller.
+type AuditEvidenceCheck struct {
+	Extends  bool                   `json:"extends"`
+	Problems []AuditEvidenceProblem `json:"problems,omitempty"`
 }
 
 // AuditVerifyReport reports independently replayed authority evidence and
 // physical verification of every unique blob retained by protected history.
 type AuditVerifyReport struct {
-	Enabled          bool            `json:"enabled"`
-	Evidence         *AuditEvidence  `json:"evidence,omitempty"`
-	ProtectedBlobs   int             `json:"protected_blobs" minimum:"0"`
-	ProtectedBytes   int64           `json:"protected_bytes" minimum:"0"` // unique raw bytes
-	VerifiedBlobs    int             `json:"verified_blobs" minimum:"0"`
-	Problems         []VerifyProblem `json:"problems,omitempty"`
-	MetadataProblems []string        `json:"metadata_problems,omitempty"`
+	Enabled          bool                `json:"enabled"`
+	Evidence         *AuditEvidence      `json:"evidence,omitempty"`
+	EvidenceCheck    *AuditEvidenceCheck `json:"evidence_check,omitempty"`
+	ProtectedBlobs   int                 `json:"protected_blobs" minimum:"0"`
+	ProtectedBytes   int64               `json:"protected_bytes" minimum:"0"` // unique raw bytes
+	VerifiedBlobs    int                 `json:"verified_blobs" minimum:"0"`
+	Problems         []VerifyProblem     `json:"problems,omitempty"`
+	MetadataProblems []string            `json:"metadata_problems,omitempty"`
 }
 
 // AuditEvent is one canonical, immutable event involving an audited node.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -718,14 +718,29 @@ func (c *Client) AuditStatus(
 }
 
 // VerifyAudit independently replays audit authority and verifies every unique
-// blob retained by protected history.
-func (c *Client) VerifyAudit(ctx context.Context) (api.AuditVerifyReport, error) {
+// blob retained by protected history. When expected is non-nil, the report
+// also proves whether current authority extends that exact recorded prefix.
+func (c *Client) VerifyAudit(
+	ctx context.Context, expected *api.AuditEvidence,
+) (api.AuditVerifyReport, error) {
 	var report api.AuditVerifyReport
-	if err := c.do(ctx, http.MethodPost, "/api/v1/audit/verify", nil, nil, &report); err != nil {
+	if expected != nil {
+		if err := ValidateAuditEvidence(*expected); err != nil {
+			return report, fmt.Errorf("invalid expected audit evidence: %w", err)
+		}
+	}
+	request := api.AuditVerifyRequest{Expected: expected}
+	if err := c.do(ctx, http.MethodPost, "/api/v1/audit/verify", nil, request, &report); err != nil {
 		return report, err
 	}
 	if err := validateAuditVerifyReport(report); err != nil {
 		return api.AuditVerifyReport{}, err
+	}
+	if len(report.MetadataProblems) == 0 &&
+		(expected != nil) != (report.EvidenceCheck != nil) {
+		return api.AuditVerifyReport{}, errors.New(
+			"audit verification response omitted or invented the expected-evidence check",
+		)
 	}
 	return report, nil
 }
@@ -1048,9 +1063,15 @@ func validateAuditVerifyReport(report api.AuditVerifyReport) error {
 		}
 		previousHash = problem.Hash
 	}
+	if report.EvidenceCheck != nil {
+		if err := validateAuditEvidenceCheck(*report.EvidenceCheck); err != nil {
+			return err
+		}
+	}
 	if len(report.MetadataProblems) != 0 {
 		if report.Enabled || report.Evidence != nil || report.ProtectedBlobs != 0 ||
-			report.ProtectedBytes != 0 || report.VerifiedBlobs != 0 || len(report.Problems) != 0 {
+			report.ProtectedBytes != 0 || report.VerifiedBlobs != 0 || len(report.Problems) != 0 ||
+			report.EvidenceCheck != nil {
 			return errors.New("failed audit metadata verification contains trusted evidence")
 		}
 		return nil
@@ -1064,22 +1085,45 @@ func validateAuditVerifyReport(report api.AuditVerifyReport) error {
 	if report.Evidence == nil {
 		return errors.New("active audit verification lacks terminal evidence")
 	}
-	return validateAuditEvidence(*report.Evidence)
+	return ValidateAuditEvidence(*report.Evidence)
 }
 
-func validateAuditEvidence(evidence api.AuditEvidence) error {
+// ValidateAuditEvidence validates one externally recordable terminal bundle.
+func ValidateAuditEvidence(evidence api.AuditEvidence) error {
 	if !validUUIDv4(evidence.VaultID) || !validUUIDv4(evidence.LineageID) ||
-		evidence.OperationSequenceHighWater < 1 || evidence.AllocationEntryCount < 1 ||
-		!validSHA256Hex(evidence.AllocationHead) || len(evidence.Scopes) == 0 {
+		evidence.OperationSequenceHighWater < 1 ||
+		evidence.AllocationEntryCount != evidence.OperationSequenceHighWater ||
+		!validSHA256Hex(evidence.AllocationHead) || len(evidence.Scopes) == 0 ||
+		len(evidence.Scopes) > store.MaxAuditEvidenceScopes {
 		return errors.New("audit evidence lacks complete allocation authority")
 	}
 	previousScopeID := ""
 	for index, scope := range evidence.Scopes {
-		if !validUUIDv4(scope.ID) || scope.EntryCount < 1 || !validSHA256Hex(scope.ChainHead) ||
+		if !validUUIDv4(scope.ID) || scope.EntryCount < 1 ||
+			scope.EntryCount > evidence.AllocationEntryCount || !validSHA256Hex(scope.ChainHead) ||
 			(previousScopeID != "" && scope.ID <= previousScopeID) {
 			return fmt.Errorf("audit evidence scope %d is invalid", index)
 		}
 		previousScopeID = scope.ID
+	}
+	return nil
+}
+
+func validateAuditEvidenceCheck(check api.AuditEvidenceCheck) error {
+	if check.Extends != (len(check.Problems) == 0) {
+		return errors.New("audit evidence check has an inconsistent result")
+	}
+	for index, problem := range check.Problems {
+		scopeProblem := problem.Code == "scope_missing" || problem.Code == "scope_shorter" ||
+			problem.Code == "scope_diverged"
+		validCode := problem.Code == "audit_not_enabled" || problem.Code == "vault_mismatch" ||
+			problem.Code == "lineage_mismatch" || problem.Code == "allocation_shorter" ||
+			problem.Code == "allocation_diverged" || scopeProblem
+		if !validCode || problem.Message == "" ||
+			(scopeProblem && !validUUIDv4(problem.ScopeID)) ||
+			(!scopeProblem && problem.ScopeID != "") {
+			return fmt.Errorf("audit evidence problem %d is invalid", index)
+		}
 	}
 	return nil
 }

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "20"
+	daemonProtocolVersion = "21"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/audit_verify.go
+++ b/internal/store/audit_verify.go
@@ -7,7 +7,14 @@ import (
 	"fmt"
 	"io"
 	"math"
+
+	"go.kenn.io/docbank/internal/audit"
 )
+
+// MaxAuditEvidenceScopes bounds caller-supplied prefix work independently of
+// the HTTP body limit. Current vaults expose one scope; the bound leaves room
+// for the planned multi-scope model without allowing unbounded point lookups.
+const MaxAuditEvidenceScopes = 1000
 
 // AuditScopeEvidence is one verified scope-chain terminal.
 type AuditScopeEvidence struct {
@@ -27,10 +34,26 @@ type AuditEvidence struct {
 	Scopes                     []AuditScopeEvidence
 }
 
+// AuditEvidenceProblem explains why current authority does not extend one
+// externally recorded evidence bundle.
+type AuditEvidenceProblem struct {
+	Code    string
+	ScopeID string
+	Message string
+}
+
+// AuditEvidenceCheck is the exact-prefix proof for externally recorded audit
+// evidence. Extends is true exactly when Problems is empty.
+type AuditEvidenceCheck struct {
+	Extends  bool
+	Problems []AuditEvidenceProblem
+}
+
 // AuditVerification is one independently replayed audit snapshot plus the
 // unique blobs whose bytes permanent history requires.
 type AuditVerification struct {
 	Evidence       AuditEvidence
+	EvidenceCheck  *AuditEvidenceCheck
 	ProtectedBlobs []BlobInfo
 	ProtectedBytes int64 // unique raw bytes across ProtectedBlobs
 }
@@ -39,7 +62,14 @@ type AuditVerification struct {
 // current projections and returns externally recordable terminal evidence.
 // Blob bytes are verified by the daemon through physical catalog authority
 // after this metadata snapshot succeeds.
-func (s *Store) VerifyAudit(ctx context.Context) (result AuditVerification, err error) {
+func (s *Store) VerifyAudit(
+	ctx context.Context, expected *AuditEvidence,
+) (result AuditVerification, err error) {
+	if expected != nil {
+		if err := ValidateAuditEvidence(*expected); err != nil {
+			return result, fmt.Errorf("invalid expected audit evidence: %w", err)
+		}
+	}
 	snapshot, err := s.BeginMetadataSnapshot(ctx)
 	if err != nil {
 		return result, err
@@ -51,6 +81,13 @@ func (s *Store) VerifyAudit(ctx context.Context) (result AuditVerification, err 
 	result.Evidence, err = auditEvidenceSnapshot(ctx, snapshot, s.vaultID)
 	if err != nil {
 		return result, err
+	}
+	if expected != nil {
+		check, err := checkAuditEvidencePrefix(ctx, snapshot, result.Evidence, *expected)
+		if err != nil {
+			return result, err
+		}
+		result.EvidenceCheck = &check
 	}
 	result.ProtectedBlobs = []BlobInfo{}
 	if !result.Evidence.Enabled {
@@ -76,6 +113,143 @@ func (s *Store) VerifyAudit(ctx context.Context) (result AuditVerification, err 
 		result.ProtectedBytes += blob.Size
 	}
 	return result, nil
+}
+
+// ValidateAuditEvidence rejects evidence that cannot represent a terminal
+// allocation lineage plus a stable, sorted set of scope terminals.
+func ValidateAuditEvidence(evidence AuditEvidence) error {
+	if err := validateUUIDv4(evidence.VaultID); err != nil {
+		return fmt.Errorf("vault ID: %w", err)
+	}
+	if err := validateUUIDv4(evidence.LineageID); err != nil {
+		return fmt.Errorf("lineage ID: %w", err)
+	}
+	if evidence.OperationSequenceHighWater < 1 ||
+		evidence.OperationSequenceHighWater != evidence.AllocationEntryCount {
+		return errors.New("allocation count must equal the positive operation high-water mark")
+	}
+	if _, err := audit.DigestHex(evidence.AllocationHead); err != nil {
+		return fmt.Errorf("allocation head: %w", err)
+	}
+	if len(evidence.Scopes) == 0 || len(evidence.Scopes) > MaxAuditEvidenceScopes {
+		return fmt.Errorf("audit evidence must contain between 1 and %d scopes",
+			MaxAuditEvidenceScopes)
+	}
+	previousScopeID := ""
+	for index, scope := range evidence.Scopes {
+		if err := validateUUIDv4(scope.ID); err != nil {
+			return fmt.Errorf("scope %d ID: %w", index, err)
+		}
+		if scope.EntryCount < 1 || scope.EntryCount > evidence.AllocationEntryCount {
+			return fmt.Errorf("scope %s entry count must be positive and no greater than allocation count",
+				scope.ID)
+		}
+		if _, err := audit.DigestHex(scope.ChainHead); err != nil {
+			return fmt.Errorf("scope %s chain head: %w", scope.ID, err)
+		}
+		if previousScopeID != "" && scope.ID <= previousScopeID {
+			return errors.New("audit evidence scopes must be uniquely sorted by ID")
+		}
+		previousScopeID = scope.ID
+	}
+	return nil
+}
+
+func checkAuditEvidencePrefix(
+	ctx context.Context, snapshot *MetadataSnapshot, current, expected AuditEvidence,
+) (AuditEvidenceCheck, error) {
+	check := AuditEvidenceCheck{Extends: true, Problems: []AuditEvidenceProblem{}}
+	add := func(code, scopeID, message string) {
+		check.Extends = false
+		check.Problems = append(check.Problems, AuditEvidenceProblem{
+			Code: code, ScopeID: scopeID, Message: message,
+		})
+	}
+	if !current.Enabled {
+		add("audit_not_enabled", "", "current vault has no audit authority")
+		return check, nil
+	}
+	if current.VaultID != expected.VaultID {
+		add("vault_mismatch", "", fmt.Sprintf(
+			"expected vault %s, current vault is %s", expected.VaultID, current.VaultID,
+		))
+		return check, nil
+	}
+	if current.LineageID != expected.LineageID {
+		add("lineage_mismatch", "", fmt.Sprintf(
+			"expected allocation lineage %s, current lineage is %s",
+			expected.LineageID, current.LineageID,
+		))
+		return check, nil
+	}
+	if current.AllocationEntryCount < expected.AllocationEntryCount {
+		add("allocation_shorter", "", fmt.Sprintf(
+			"expected allocation entry %d, current lineage ends at %d",
+			expected.AllocationEntryCount, current.AllocationEntryCount,
+		))
+	} else {
+		digest, err := auditRecordDigestAt(ctx, snapshot, "allocation_entry", "", expected.AllocationEntryCount)
+		if err != nil {
+			return AuditEvidenceCheck{}, err
+		}
+		if digest != expected.AllocationHead {
+			add("allocation_diverged", "", fmt.Sprintf(
+				"allocation entry %d has head %s, expected %s",
+				expected.AllocationEntryCount, digest, expected.AllocationHead,
+			))
+		}
+	}
+	currentScopes := make(map[string]AuditScopeEvidence, len(current.Scopes))
+	for _, scope := range current.Scopes {
+		currentScopes[scope.ID] = scope
+	}
+	for _, expectedScope := range expected.Scopes {
+		currentScope, ok := currentScopes[expectedScope.ID]
+		if !ok {
+			add("scope_missing", expectedScope.ID,
+				fmt.Sprintf("expected audit scope %s is missing", expectedScope.ID))
+			continue
+		}
+		if currentScope.EntryCount < expectedScope.EntryCount {
+			add("scope_shorter", expectedScope.ID, fmt.Sprintf(
+				"scope %s expected entry %d, current chain ends at %d",
+				expectedScope.ID, expectedScope.EntryCount, currentScope.EntryCount,
+			))
+			continue
+		}
+		digest, err := auditRecordDigestAt(
+			ctx, snapshot, "scope_chain_entry", expectedScope.ID, expectedScope.EntryCount,
+		)
+		if err != nil {
+			return AuditEvidenceCheck{}, err
+		}
+		if digest != expectedScope.ChainHead {
+			add("scope_diverged", expectedScope.ID, fmt.Sprintf(
+				"scope %s entry %d has head %s, expected %s", expectedScope.ID,
+				expectedScope.EntryCount, digest, expectedScope.ChainHead,
+			))
+		}
+	}
+	return check, nil
+}
+
+func auditRecordDigestAt(
+	ctx context.Context, snapshot *MetadataSnapshot, kind, scopeID string, count int64,
+) (string, error) {
+	var digest string
+	var err error
+	if kind == "allocation_entry" {
+		err = snapshot.QueryRowContext(ctx, `SELECT digest FROM audit_records
+			WHERE kind='allocation_entry' AND operation_sequence=?`, count).Scan(&digest)
+	} else {
+		err = snapshot.QueryRowContext(ctx, `SELECT digest FROM audit_records
+			WHERE kind='scope_chain_entry' AND scope_id=? AND entry_count=?`,
+			scopeID, count).Scan(&digest)
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading verified %s prefix entry %d: %w", kind, count, err)
+	}
+	return digest, nil
 }
 
 func auditEvidenceSnapshot(

--- a/internal/store/audit_verify_test.go
+++ b/internal/store/audit_verify_test.go
@@ -14,7 +14,7 @@ func TestVerifyAuditReturnsReplayedEvidenceAndProtectedBlobs(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	seedMetadataRoundTrip(t, s)
 
-	dormant, err := s.VerifyAudit(t.Context())
+	dormant, err := s.VerifyAudit(t.Context(), nil)
 	require.NoError(t, err)
 	assert.False(t, dormant.Evidence.Enabled)
 	assert.Empty(t, dormant.ProtectedBlobs)
@@ -27,7 +27,7 @@ func TestVerifyAuditReturnsReplayedEvidenceAndProtectedBlobs(t *testing.T) {
 	enabled, err := s.EnableInitialAudit(t.Context(), plan)
 	require.NoError(t, err)
 
-	verified, err := s.VerifyAudit(t.Context())
+	verified, err := s.VerifyAudit(t.Context(), nil)
 	require.NoError(t, err)
 	assert.True(t, verified.Evidence.Enabled)
 	assert.Equal(t, enabled.VaultID, verified.Evidence.VaultID)
@@ -61,7 +61,65 @@ func TestVerifyAuditRejectsAuthorityThatDoesNotMatchReplay(t *testing.T) {
 		SELECT digest FROM audit_records WHERE kind='enrollment_baseline' LIMIT 1
 	)`)
 	require.NoError(t, err)
-	_, err = s.VerifyAudit(t.Context())
+	_, err = s.VerifyAudit(t.Context(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "audit scope authority does not match replayed history")
+}
+
+func TestVerifyAuditProvesRecordedEvidenceIsAnExactPrefix(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+
+	recorded, err := s.VerifyAudit(t.Context(), nil)
+	require.NoError(t, err)
+	_, err = s.Mkdir(t.Context(), projects.ID, "Later")
+	require.NoError(t, err)
+
+	current, err := s.VerifyAudit(t.Context(), &recorded.Evidence)
+	require.NoError(t, err)
+	require.NotNil(t, current.EvidenceCheck)
+	assert.True(t, current.EvidenceCheck.Extends)
+	assert.Empty(t, current.EvidenceCheck.Problems)
+	assert.Greater(t, current.Evidence.AllocationEntryCount,
+		recorded.Evidence.AllocationEntryCount)
+	assert.Greater(t, current.Evidence.Scopes[0].EntryCount,
+		recorded.Evidence.Scopes[0].EntryCount)
+}
+
+func TestVerifyAuditReportsExpectedEvidenceDivergence(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, projects.ID)
+
+	recorded, err := s.VerifyAudit(t.Context(), nil)
+	require.NoError(t, err)
+	recorded.Evidence.AllocationHead = fakeHash("deadbeef")
+	recorded.Evidence.Scopes[0].ChainHead = fakeHash("cafebabe")
+	verification, err := s.VerifyAudit(t.Context(), &recorded.Evidence)
+	require.NoError(t, err)
+	require.NotNil(t, verification.EvidenceCheck)
+	assert.False(t, verification.EvidenceCheck.Extends)
+	require.Len(t, verification.EvidenceCheck.Problems, 2)
+	assert.Equal(t, "allocation_diverged", verification.EvidenceCheck.Problems[0].Code)
+	assert.Equal(t, "scope_diverged", verification.EvidenceCheck.Problems[1].Code)
+	assert.Equal(t, recorded.Evidence.Scopes[0].ID,
+		verification.EvidenceCheck.Problems[1].ScopeID)
+}
+
+func TestVerifyAuditRejectsMalformedExpectedEvidence(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	_, err = s.VerifyAudit(t.Context(), &AuditEvidence{})
+	require.ErrorContains(t, err, "invalid expected audit evidence")
 }


### PR DESCRIPTION
PR #85 made audit evidence recordable, but it did not yet make that record actionable. A later terminal head normally changes as valid work continues, so equality would raise false alarms; checking only that counts increased would miss a divergent history. People and agents need a direct answer to: does this vault still contain the exact authority I verified earlier?

The workflow is now:

```
docbank audit verify --json > audit-evidence.json
docbank audit verify --expected audit-evidence.json
```

The second command independently replays the current metadata first, then proves the recorded allocation entry and every recorded scope entry remain exact prefixes under the same vault and allocation-lineage identities. Equal chains pass, valid later operations pass, and future additional scopes will not invalidate older evidence.

A disagreement is a verification result rather than an HTTP transport failure. Stable codes distinguish an inactive or different vault, allocation-lineage replacement, shorter or divergent allocation history, and missing, shorter, or divergent scope history. Current terminal evidence and protected-byte checks are still returned, so an operator can see the present state before deciding whether this is rollback, the wrong vault, or damaged content.

The saved report must remain outside the vault: it is the trust anchor, and no local mechanism can detect an attacker who replaces both the vault and the expected evidence. This PR does not change schema, mutation behavior, backup overwrite policy, or the one-scope enrollment boundary.

The capability is covered through store replay, authenticated HTTP, typed-client validation, CLI report parsing/output, both SQLite modes, and stale-daemon replacement. The user, agent, CLI, HTTP, integrity, architecture, changelog, landing, and roadmap documentation all describe the same record-now/check-later contract.

Kata: n8td.