### PR TITLE
Add structured output to legacy read commands

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -141,6 +141,69 @@ func TestAddLsTreeCat(t *testing.T) {
 	assert.Equal(t, "hello vault", out)
 }
 
+func TestLegacyReadCommandsJSON(t *testing.T) {
+	_ = setupVaultHome(t)
+
+	out, err := runCLI(t, "ls", "/", "--json")
+	require.NoError(t, err)
+	var listed directoryListing
+	require.NoError(t, json.Unmarshal([]byte(out), &listed))
+	assert.Equal(t, "/", listed.Directory.Path)
+	assert.Empty(t, listed.Items)
+	assert.Contains(t, out, `"items":[]`)
+
+	out, err = runCLI(t, "tree", "/", "--json")
+	require.NoError(t, err)
+	var tree treeListing
+	require.NoError(t, json.Unmarshal([]byte(out), &tree))
+	assert.Equal(t, "/", tree.Root.Path)
+	assert.Empty(t, tree.Items)
+	assert.Contains(t, out, `"items":[]`)
+
+	src := writeSourceFile(t, "notes.txt", "searchable notes")
+	_, err = runCLI(t, "add", src, "--dest", "/inbox")
+	require.NoError(t, err)
+
+	out, err = runCLI(t, "ls", "/inbox", "--json")
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(out), &listed))
+	require.Len(t, listed.Items, 1)
+	assert.Equal(t, "notes.txt", listed.Items[0].Name)
+
+	out, err = runCLI(t, "tree", "/", "--json")
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(out), &tree))
+	require.Len(t, tree.Items, 2)
+	assert.Equal(t, "/inbox", tree.Items[0].Path)
+	assert.Equal(t, 1, tree.Items[0].Depth)
+	assert.Equal(t, "/inbox/notes.txt", tree.Items[1].Path)
+	assert.Equal(t, 2, tree.Items[1].Depth)
+
+	out, err = runCLI(t, "search", "notes", "--json")
+	require.NoError(t, err)
+	var search api.SearchReport
+	require.NoError(t, json.Unmarshal([]byte(out), &search))
+	require.Len(t, search.Hits, 1)
+	assert.Equal(t, "/inbox/notes.txt", search.Hits[0].Path)
+
+	_, err = runCLI(t, "rm", "/inbox/notes.txt")
+	require.NoError(t, err)
+	out, err = runCLI(t, "trash", "list", "--json")
+	require.NoError(t, err)
+	var trash trashListing
+	require.NoError(t, json.Unmarshal([]byte(out), &trash))
+	require.Len(t, trash.Items, 1)
+	assert.Equal(t, "notes.txt", trash.Items[0].Name)
+
+	out, err = runCLI(t, "trash", "empty", "--json")
+	require.NoError(t, err)
+	var empty api.TrashEmptyReport
+	require.NoError(t, json.Unmarshal([]byte(out), &empty))
+	assert.EqualValues(t, 1, empty.CandidateRoots)
+	assert.False(t, empty.Run)
+	assert.NotContains(t, out, "dry run")
+}
+
 func TestAuditEnableIsPreviewFirstAndReportsProtection(t *testing.T) {
 	_ = setupVaultHome(t)
 	source := writeSourceFile(t, "return.txt", "tax return")

--- a/cmd/docbank/json.go
+++ b/cmd/docbank/json.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+func writeCLIJSON(w io.Writer, value any) error {
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		return fmt.Errorf("writing JSON output: %w", err)
+	}
+	return nil
+}

--- a/cmd/docbank/ls.go
+++ b/cmd/docbank/ls.go
@@ -6,8 +6,16 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
 )
+
+var lsJSON bool
+
+type directoryListing struct {
+	Directory api.Node   `json:"directory"`
+	Items     []api.Node `json:"items"`
+}
 
 var lsCmd = &cobra.Command{
 	Use:   "ls [path]",
@@ -30,6 +38,12 @@ var lsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if lsJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), directoryListing{
+				Directory: dir,
+				Items:     kids,
+			})
+		}
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 		_, _ = fmt.Fprintln(w, "ID\tKIND\tSIZE\tMODIFIED\tNAME")
 		for _, k := range kids {
@@ -39,4 +53,7 @@ var lsCmd = &cobra.Command{
 	},
 }
 
-func init() { rootCmd.AddCommand(lsCmd) }
+func init() {
+	lsCmd.Flags().BoolVar(&lsJSON, "json", false, "emit machine-readable JSON")
+	rootCmd.AddCommand(lsCmd)
+}

--- a/cmd/docbank/search.go
+++ b/cmd/docbank/search.go
@@ -15,7 +15,10 @@ const (
 	maxSearchLimit     = 1000
 )
 
-var searchLimit int
+var (
+	searchLimit int
+	searchJSON  bool
+)
 
 var searchCmd = &cobra.Command{
 	Use:   "search <query>...",
@@ -32,6 +35,9 @@ var searchCmd = &cobra.Command{
 		rep, err := c.Search(cmd.Context(), strings.Join(args, " "), searchLimit)
 		if err != nil {
 			return err
+		}
+		if searchJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), rep)
 		}
 		if len(rep.Hits) == 0 {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no matches")
@@ -61,5 +67,6 @@ var searchCmd = &cobra.Command{
 func init() {
 	searchCmd.Flags().IntVar(&searchLimit, "limit", defaultSearchLimit,
 		"maximum results to return (1-1000)")
+	searchCmd.Flags().BoolVar(&searchJSON, "json", false, "emit machine-readable JSON")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cmd/docbank/trash.go
+++ b/cmd/docbank/trash.go
@@ -10,6 +10,12 @@ import (
 	"go.kenn.io/docbank/internal/client"
 )
 
+var trashListJSON bool
+
+type trashListing struct {
+	Items []api.Node `json:"items"`
+}
+
 var trashCmd = &cobra.Command{
 	Use:   "trash",
 	Short: "Inspect and empty the trash",
@@ -28,6 +34,9 @@ var trashListCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if trashListJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), trashListing{Items: roots})
+		}
 		if len(roots) == 0 {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "trash is empty")
 			return nil
@@ -44,6 +53,7 @@ var trashListCmd = &cobra.Command{
 var (
 	trashOlderThan string
 	trashRun       bool
+	trashEmptyJSON bool
 )
 
 var trashEmptyCmd = &cobra.Command{
@@ -65,6 +75,9 @@ var trashEmptyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if trashEmptyJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), rep)
+		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d trashed root(s) eligible for permanent deletion\n",
 			rep.CandidateRoots)
 		if !rep.Run {
@@ -79,10 +92,14 @@ var trashEmptyCmd = &cobra.Command{
 }
 
 func init() {
+	trashListCmd.Flags().BoolVar(&trashListJSON, "json", false,
+		"emit machine-readable JSON")
 	trashEmptyCmd.Flags().StringVar(&trashOlderThan, "older-than", "",
 		"select only items trashed at least this long ago (e.g. 30d)")
 	trashEmptyCmd.Flags().BoolVar(&trashRun, "run", false,
 		"actually delete (default is dry-run)")
+	trashEmptyCmd.Flags().BoolVar(&trashEmptyJSON, "json", false,
+		"emit a machine-readable report")
 	trashCmd.AddCommand(trashListCmd, trashEmptyCmd)
 	rootCmd.AddCommand(trashCmd)
 }

--- a/cmd/docbank/tree.go
+++ b/cmd/docbank/tree.go
@@ -4,13 +4,28 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/store"
 )
+
+var treeJSON bool
+
+type treeEntry struct {
+	Node  api.Node `json:"node"`
+	Path  string   `json:"path"`
+	Depth int      `json:"depth"`
+}
+
+type treeListing struct {
+	Root  api.Node    `json:"root"`
+	Items []treeEntry `json:"items"`
+}
 
 var treeCmd = &cobra.Command{
 	Use:   "tree [path]",
@@ -33,9 +48,40 @@ var treeCmd = &cobra.Command{
 		if root.Kind != "dir" {
 			return fmt.Errorf("%s: %w", path, store.ErrNotDir)
 		}
+		if treeJSON {
+			items := []treeEntry{}
+			if err := collectTree(ctx, c, root.Path, root.ID, 1, &items); err != nil {
+				return err
+			}
+			return writeCLIJSON(cmd.OutOrStdout(), treeListing{Root: root, Items: items})
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), path)
 		return printTree(ctx, cmd.OutOrStdout(), c, root.ID, 1)
 	},
+}
+
+func collectTree(
+	ctx context.Context,
+	c *client.Client,
+	parentPath string,
+	dirID int64,
+	depth int,
+	items *[]treeEntry,
+) error {
+	kids, err := c.Children(ctx, dirID)
+	if err != nil {
+		return err
+	}
+	for _, kid := range kids {
+		kidPath := path.Join(parentPath, kid.Name)
+		*items = append(*items, treeEntry{Node: kid, Path: kidPath, Depth: depth})
+		if kid.Kind == "dir" {
+			if err := collectTree(ctx, c, kidPath, kid.ID, depth+1, items); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func printTree(ctx context.Context, w io.Writer, c *client.Client, dirID int64, depth int) error {
@@ -54,4 +100,7 @@ func printTree(ctx context.Context, w io.Writer, c *client.Client, dirID int64, 
 	return nil
 }
 
-func init() { rootCmd.AddCommand(treeCmd) }
+func init() {
+	treeCmd.Flags().BoolVar(&treeJSON, "json", false, "emit machine-readable JSON")
+	rootCmd.AddCommand(treeCmd)
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -87,7 +87,7 @@ HTTP JSON endpoint, so stdout remains safe for automation.
 ## docbank ls
 
 ```
-docbank ls [path]
+docbank ls [path] [--json]
 ```
 
 Lists a virtual directory (default `/`). Columns: `ID`, `KIND`
@@ -95,15 +95,22 @@ Lists a virtual directory (default `/`). Columns: `ID`, `KIND`
 RFC 3339), `NAME`. Fails with `not a directory` when the path names a
 file.
 
+`--json` returns the resolved directory under `directory` and its complete,
+ordered child list under `items`. Empty directories produce `"items": []`.
+
 ## docbank tree
 
 ```
-docbank tree [path]
+docbank tree [path] [--json]
 ```
 
 Prints the subtree rooted at `path` (default `/`), two-space indented,
 each entry suffixed with its node ID in brackets. Fails without output if
 `path` names a file.
+
+`--json` returns the resolved root and a deterministic, pre-order `items`
+array. Each item contains the node, its absolute virtual `path`, and its
+`depth` beneath the root (direct children have depth 1).
 
 ## docbank cat
 
@@ -431,7 +438,7 @@ restored under `/`. Prints `restored [<id>] <path>`.
 ## docbank search
 
 ```
-docbank search <query>... [--limit <n>]
+docbank search <query>... [--limit <n>] [--json]
 ```
 
 Full-text search over live node names (FTS5). Every whitespace-separated
@@ -442,14 +449,17 @@ matches exist, the command says that the result is truncated rather than
 silently implying completeness. Output columns are `ID` and `PATH`; no
 matches prints `no matches`.
 
+`--json` emits the typed search report with `hits`, the applied `limit`, and
+an explicit `truncated` boolean. An empty result uses `"hits": []`.
+
 Search currently covers node names only; document-body extraction and content
 search are not available. See [Searching](usage/searching.md).
 
 ## docbank trash
 
 ```
-docbank trash list
-docbank trash empty [--older-than <age>] [--run]
+docbank trash list [--json]
+docbank trash empty [--older-than <age>] [--run] [--json]
 ```
 
 `list` shows restorable trashed nodes: `ID`, `TRASHED AT`, `NAME`. Only
@@ -461,6 +471,11 @@ default. Pass `--run` to permanently delete them; their blobs then become
 `gc` candidates unless referenced elsewhere. `--older-than` accepts Go
 durations (`12h`, `30m`) plus a day suffix (`30d`); negative ages are
 rejected. Without that filter, every trash root is eligible.
+
+`list --json` emits `{"items": [...]}`. `empty --json` emits the same typed
+dry-run or execution report as the HTTP API: `candidate_roots`, `deleted`,
+and `run`. Human status lines are suppressed so stdout contains one JSON
+document.
 
 ## docbank gc
 

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -18,6 +18,11 @@ docbank tree /taxes        # whole subtree, indented, IDs in brackets
 docbank cat /taxes/w2.pdf  # stream file bytes to stdout
 ```
 
+Use `ls --json` for a directory envelope containing the resolved directory
+and its ordered children. `tree --json` returns the root plus a flat,
+deterministic pre-order list whose entries carry absolute paths and depths;
+this avoids parsing indentation when a script needs to walk a subtree.
+
 Node IDs appear everywhere deliberately: IDs are the canonical way to
 refer to a document. Paths change when you reorganize; IDs never do.
 The CLI uses IDs for trash recovery (`docbank restore <id>`), and the
@@ -89,8 +94,8 @@ those assignments are removed.
 
 ## Tips for bulk reorganization
 
-- `tree` output includes IDs, so you can script against stable
-  references while shuffling paths.
+- `tree` output includes IDs, and `tree --json` exposes them with paths and
+  depths, so scripts can retain stable references while shuffling paths.
 - Every `mv` is its own transaction: a failed move in a scripted batch
   leaves everything else applied and consistent.
 

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -9,6 +9,7 @@ description: Ranked, prefix-matching search over document names with FTS5; docum
 docbank search insurance
 docbank search tax 2026
 docbank search report --limit 200
+docbank search report --json
 ```
 
 ```
@@ -30,6 +31,9 @@ ID   PATH
   accepts 1–1000, and truncation is always reported.
 - **Live nodes only.** Trashed documents don't appear; restore returns
   them to the index. Renames update the index immediately.
+
+For scripts, `--json` returns `hits`, `limit`, and `truncated` without table
+formatting. `hits` is always an array, including when nothing matches.
 
 ## What's indexed today
 

--- a/docs/usage/trash-and-gc.md
+++ b/docs/usage/trash-and-gc.md
@@ -31,6 +31,7 @@ restorable reference.
 
 ```bash
 docbank trash list
+docbank trash list --json
 ```
 
 ```
@@ -49,6 +50,10 @@ Trashing a subtree stamps every node with the same trash time, so a
 nested directory trashed *before* its parent keeps its own independent
 trash entry — restoring the parent doesn't resurrect things you trashed
 separately.
+
+`trash list --json` returns the roots under `items`. For maintenance
+automation, `trash empty --json` returns `candidate_roots`, `deleted`, and
+`run`; it remains a dry run unless `--run` is present.
 
 ## Stage 2: Empty the trash
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -247,7 +247,7 @@ func (c *Client) Stat(ctx context.Context, path string) (api.Node, error) {
 // a real consumer appears (YAGNI).
 func (c *Client) Children(ctx context.Context, id int64) ([]api.Node, error) {
 	const pageSize = 1000
-	var all []api.Node
+	all := []api.Node{}
 	for offset := 0; ; offset += pageSize {
 		var page struct {
 			Items []api.Node `json:"items"`


### PR DESCRIPTION
Docbank’s newer CLI surfaces are straightforward to automate, but its oldest browsing commands still make people, shell scripts, and local agents interpret tables, indentation, and status sentences. That is especially brittle for empty results and deep trees.

This gives `ls`, `tree`, `search`, `trash list`, and the preview-first `trash empty` flow a typed `--json` form while leaving their human output unchanged. Directory listings identify the directory being listed as well as its ordered children. Tree output is a flat deterministic pre-order sequence with an absolute virtual path and depth for every node, so a consumer never has to reverse-engineer indentation. Search retains its explicit truncation signal, and trash preview reports whether deletion actually ran. Successful empty collections are always arrays rather than `null`.

This is deliberately the read-only and maintenance-preview slice of the broader CLI automation work. Mutation receipts and stable process exit semantics remain separate reviewable changes. It changes no daemon protocol, HTTP endpoint, storage schema, or vault behavior.

The behavior is exercised end to end against an actual daemon for empty and populated vaults, including search and trash transitions, and the same code passes with both SQLite implementations and Windows compilation.

Kata: yhdd.