### PR TITLE
Define stable CLI process exit codes

### DIFF
--- a/cmd/docbank/add.go
+++ b/cmd/docbank/add.go
@@ -33,7 +33,8 @@ var addCmd = &cobra.Command{
 			// replace invalid source bytes with U+FFFD. Reject before any OS path
 			// normalization so the CLI cannot silently target another filename.
 			if !utf8.ValidString(a) {
-				return fmt.Errorf("ingest source path %s is not valid UTF-8", strconv.QuoteToASCII(a))
+				return usageError(fmt.Errorf(
+					"ingest source path %s is not valid UTF-8", strconv.QuoteToASCII(a)))
 			}
 			p, err := filepath.Abs(a)
 			if err != nil {

--- a/cmd/docbank/audit.go
+++ b/cmd/docbank/audit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -34,15 +35,17 @@ var auditEnableCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if auditEnableRun {
 			if len(args) != 0 || auditEnableNodeID != 0 || auditEnableAgentLabel != "" {
-				return errors.New("audit enable --run uses only the reviewed preview token")
+				return usageError(errors.New(
+					"audit enable --run uses only the reviewed preview token"))
 			}
 			if auditEnableToken == "" {
-				return errors.New("audit enable --run requires --token from a fresh preview")
+				return usageError(errors.New(
+					"audit enable --run requires --token from a fresh preview"))
 			}
 			if !auditEnableAcknowledge {
-				return errors.New(
+				return usageError(errors.New(
 					"audit enable --run requires --acknowledge-permanent-retention",
-				)
+				))
 			}
 			c, err := client.Ensure(cmd.Context())
 			if err != nil {
@@ -58,10 +61,18 @@ var auditEnableCmd = &cobra.Command{
 			return writeAuditEnabled(cmd.OutOrStdout(), status)
 		}
 		if auditEnableToken != "" || auditEnableAcknowledge {
-			return errors.New("--token and --acknowledge-permanent-retention require --run")
+			return usageError(errors.New(
+				"--token and --acknowledge-permanent-retention require --run"))
 		}
 		if (len(args) == 0) == (auditEnableNodeID == 0) {
-			return errors.New("audit enable preview requires exactly one path or --node-id")
+			return usageError(errors.New(
+				"audit enable preview requires exactly one path or --node-id"))
+		}
+		if auditEnableNodeID < 0 {
+			return usageError(errors.New("audit enable --node-id must be positive"))
+		}
+		if len(args) == 1 && !strings.HasPrefix(args[0], "/") {
+			return usageError(errors.New("audit enable path must be absolute"))
 		}
 		opts := client.AuditPreviewOptions{
 			NodeID: auditEnableNodeID, AgentLabel: auditEnableAgentLabel,
@@ -95,11 +106,18 @@ var auditStatusCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 1 && auditStatusNodeID != 0 {
-			return errors.New("audit status accepts either a path or --node-id, not both")
+			return usageError(errors.New(
+				"audit status accepts either a path or --node-id, not both"))
 		}
 		path := ""
 		if len(args) == 1 {
 			path = args[0]
+		}
+		if auditStatusNodeID < 0 {
+			return usageError(errors.New("audit status --node-id must be positive"))
+		}
+		if path != "" && !strings.HasPrefix(path, "/") {
+			return usageError(errors.New("audit status path must be absolute"))
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/cmd/docbank/audit.go
+++ b/cmd/docbank/audit.go
@@ -33,8 +33,9 @@ var auditEnableCmd = &cobra.Command{
 	Short: "Preview permanent retention, then explicitly enable the reviewed scope",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		nodeIDSet := cmd.Flags().Changed("node-id")
 		if auditEnableRun {
-			if len(args) != 0 || auditEnableNodeID != 0 || auditEnableAgentLabel != "" {
+			if len(args) != 0 || nodeIDSet || auditEnableAgentLabel != "" {
 				return usageError(errors.New(
 					"audit enable --run uses only the reviewed preview token"))
 			}
@@ -64,11 +65,11 @@ var auditEnableCmd = &cobra.Command{
 			return usageError(errors.New(
 				"--token and --acknowledge-permanent-retention require --run"))
 		}
-		if (len(args) == 0) == (auditEnableNodeID == 0) {
+		if (len(args) == 1) == nodeIDSet {
 			return usageError(errors.New(
 				"audit enable preview requires exactly one path or --node-id"))
 		}
-		if auditEnableNodeID < 0 {
+		if nodeIDSet && auditEnableNodeID < 1 {
 			return usageError(errors.New("audit enable --node-id must be positive"))
 		}
 		if len(args) == 1 && !strings.HasPrefix(args[0], "/") {
@@ -105,7 +106,8 @@ var auditStatusCmd = &cobra.Command{
 	Short: "Inspect vault audit authority and optional node protection",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 1 && auditStatusNodeID != 0 {
+		nodeIDSet := cmd.Flags().Changed("node-id")
+		if len(args) == 1 && nodeIDSet {
 			return usageError(errors.New(
 				"audit status accepts either a path or --node-id, not both"))
 		}
@@ -113,7 +115,7 @@ var auditStatusCmd = &cobra.Command{
 		if len(args) == 1 {
 			path = args[0]
 		}
-		if auditStatusNodeID < 0 {
+		if nodeIDSet && auditStatusNodeID < 1 {
 			return usageError(errors.New("audit status --node-id must be positive"))
 		}
 		if path != "" && !strings.HasPrefix(path, "/") {

--- a/cmd/docbank/audit_history.go
+++ b/cmd/docbank/audit_history.go
@@ -24,7 +24,8 @@ var auditHistoryCmd = &cobra.Command{
 	Short: "Read one permanently protected node's canonical event timeline",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if (len(args) == 0) == (auditHistoryNodeID == 0) {
+		nodeIDSet := cmd.Flags().Changed("node-id")
+		if (len(args) == 1) == nodeIDSet {
 			return usageError(errors.New(
 				"audit history requires exactly one path or --node-id"))
 		}
@@ -35,7 +36,7 @@ var auditHistoryCmd = &cobra.Command{
 		if len(args) == 1 {
 			path = args[0]
 		}
-		if auditHistoryNodeID < 0 {
+		if nodeIDSet && auditHistoryNodeID < 1 {
 			return usageError(errors.New("audit history --node-id must be positive"))
 		}
 		if path != "" && !strings.HasPrefix(path, "/") {

--- a/cmd/docbank/audit_history.go
+++ b/cmd/docbank/audit_history.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -24,11 +25,21 @@ var auditHistoryCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if (len(args) == 0) == (auditHistoryNodeID == 0) {
-			return errors.New("audit history requires exactly one path or --node-id")
+			return usageError(errors.New(
+				"audit history requires exactly one path or --node-id"))
+		}
+		if auditHistoryLimit < 1 || auditHistoryLimit > 500 {
+			return usageError(errors.New("audit history --limit must be between 1 and 500"))
 		}
 		path := ""
 		if len(args) == 1 {
 			path = args[0]
+		}
+		if auditHistoryNodeID < 0 {
+			return usageError(errors.New("audit history --node-id must be positive"))
+		}
+		if path != "" && !strings.HasPrefix(path, "/") {
+			return usageError(errors.New("audit history path must be absolute"))
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/cmd/docbank/audit_verify.go
+++ b/cmd/docbank/audit_verify.go
@@ -54,7 +54,7 @@ var auditVerifyCmd = &cobra.Command{
 			problems += len(report.EvidenceCheck.Problems)
 		}
 		if problems != 0 {
-			return fmt.Errorf("audit verification found %d problem(s)", problems)
+			return integrityError(fmt.Errorf("audit verification found %d problem(s)", problems))
 		}
 		return nil
 	},

--- a/cmd/docbank/backup.go
+++ b/cmd/docbank/backup.go
@@ -218,7 +218,15 @@ var (
 var backupRestoreCmd = &cobra.Command{
 	Use:   "restore [SNAPSHOT]",
 	Short: "Restore and prove a snapshot in a separate vault directory",
-	Args:  cobra.MaximumNArgs(1),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+			return err
+		}
+		if backupRestoreTarget == "" {
+			return errors.New("backup restore: --target is required")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, err := absoluteBackupRepo(backupRestoreRepo)
 		if err != nil {
@@ -394,7 +402,6 @@ func init() {
 		"progress output mode: auto, bar, or plain (suppressed by --json)")
 	backupRestoreCmd.Flags().StringVar(&backupRestoreRepo, "repo", "", "backup repository directory")
 	backupRestoreCmd.Flags().StringVar(&backupRestoreTarget, "target", "", "directory to restore into (required)")
-	_ = backupRestoreCmd.MarkFlagRequired("target")
 	backupRestoreCmd.Flags().BoolVar(&backupRestoreOverwrite, "overwrite", false,
 		"allow restoring into a non-empty target directory")
 	backupRestoreCmd.Flags().IntVar(&backupRestoreJobs, "jobs", 0,

--- a/cmd/docbank/backup.go
+++ b/cmd/docbank/backup.go
@@ -157,7 +157,8 @@ var backupVerifyCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if backupVerifyAll && len(args) > 0 {
-			return errors.New("backup verify: SNAPSHOT and --all are mutually exclusive")
+			return usageError(errors.New(
+				"backup verify: SNAPSHOT and --all are mutually exclusive"))
 		}
 		repo, err := absoluteBackupRepo(backupVerifyRepo)
 		if err != nil {
@@ -197,7 +198,8 @@ var backupVerifyCmd = &cobra.Command{
 			return err
 		}
 		if len(report.Problems) > 0 {
-			return fmt.Errorf("backup verify: found %d problem(s)", len(report.Problems))
+			return integrityError(fmt.Errorf(
+				"backup verify: found %d problem(s)", len(report.Problems)))
 		}
 		return nil
 	},

--- a/cmd/docbank/backup_progress.go
+++ b/cmd/docbank/backup_progress.go
@@ -64,8 +64,8 @@ func progressModeFromFlag(command, value string) (backupProgressMode, error) {
 	case "plain":
 		return backupProgressPlain, nil
 	default:
-		return backupProgressAuto, fmt.Errorf(
-			"%s: invalid --progress value %q (want auto, bar, or plain)", command, value)
+		return backupProgressAuto, usageError(fmt.Errorf(
+			"%s: invalid --progress value %q (want auto, bar, or plain)", command, value))
 	}
 }
 

--- a/cmd/docbank/cat.go
+++ b/cmd/docbank/cat.go
@@ -25,16 +25,14 @@ var catCmd = &cobra.Command{
 		if n.Kind == "dir" {
 			return fmt.Errorf("%q: %w", args[0], store.ErrNotFile)
 		}
-		rc, err := c.Content(cmd.Context(), n.ID)
+		// Read the immutable version selected by Stat. A concurrent replacement
+		// may advance the node, but it cannot make this stream silently switch
+		// to different bytes.
+		rc, err := c.VersionContent(cmd.Context(), n.CurrentVersionID)
 		if err != nil {
 			return err
 		}
 		defer func() { _ = rc.Close() }()
-		if rc.VersionID != n.CurrentVersionID {
-			return integrityError(fmt.Errorf(
-				"streaming %q: received content version %s, expected %s",
-				args[0], rc.VersionID, n.CurrentVersionID))
-		}
 		if _, err := rc.CopyVerified(cmd.OutOrStdout()); err != nil {
 			return fmt.Errorf("streaming %q: %w", args[0], err)
 		}

--- a/cmd/docbank/cat.go
+++ b/cmd/docbank/cat.go
@@ -31,8 +31,9 @@ var catCmd = &cobra.Command{
 		}
 		defer func() { _ = rc.Close() }()
 		if rc.VersionID != n.CurrentVersionID {
-			return fmt.Errorf("streaming %q: received content version %s, expected %s",
-				args[0], rc.VersionID, n.CurrentVersionID)
+			return integrityError(fmt.Errorf(
+				"streaming %q: received content version %s, expected %s",
+				args[0], rc.VersionID, n.CurrentVersionID))
 		}
 		if _, err := rc.CopyVerified(cmd.OutOrStdout()); err != nil {
 			return fmt.Errorf("streaming %q: %w", args[0], err)

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -1099,6 +1099,12 @@ func TestVerifyDetectsMissingAndCorrupt(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, out, "corrupt: "+alphaHash)
 	assert.Contains(t, out, "missing: "+betaHash)
+
+	var stdout, stderr bytes.Buffer
+	code := runProcess([]string{"verify"}, &stdout, &stderr)
+	assert.Equal(t, exitIntegrity, code)
+	assert.Contains(t, stdout.String(), "2 problem(s)")
+	assert.Contains(t, stderr.String(), "verify found 2 problem(s)")
 }
 
 // A validation failure exits before RunE, so nothing command-side can reset

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -36,7 +36,13 @@ var daemonRunCmd = &cobra.Command{
 	Long: "Run the daemon in the foreground. Usually invoked by `docbank daemon start`\n" +
 		"in the background; useful directly for debugging.",
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, _ []string) error { return runServe(cmd.Context()) },
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		err := runServe(cmd.Context())
+		if err != nil && os.Getenv(client.EnvBackgroundDaemon) == "1" {
+			_ = client.WriteDaemonStartProblem(cmd.ErrOrStderr(), err)
+		}
+		return err
+	},
 }
 
 func runServe(ctx context.Context) (retErr error) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -120,6 +120,9 @@ func TestDaemonStartDoesNotInitializeRestoreOwnedMissingTarget(t *testing.T) {
 	cmd.Env = append(os.Environ(), "DOCBANK_HOME="+target)
 	out, err := cmd.CombinedOutput()
 	require.Error(t, err, string(out))
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, exitBusy, exitErr.ExitCode(), string(out))
 	assert.Contains(t, string(out), "vault is locked",
 		"the external bootstrap capture must preserve the child startup error")
 	_, err = os.Lstat(target)

--- a/cmd/docbank/edit.go
+++ b/cmd/docbank/edit.go
@@ -39,6 +39,9 @@ var editCmd = &cobra.Command{
 func runEdit(cmd *cobra.Command, vaultPath string) (retErr error) {
 	editor, err := editorCommand(editEditor)
 	if err != nil {
+		if cmd.Flags().Changed("editor") {
+			return usageError(err)
+		}
 		return err
 	}
 	mimeOverride, err := normalizedMIMEOverride(editMIMEType)

--- a/cmd/docbank/edit.go
+++ b/cmd/docbank/edit.go
@@ -43,7 +43,7 @@ func runEdit(cmd *cobra.Command, vaultPath string) (retErr error) {
 	}
 	mimeOverride, err := normalizedMIMEOverride(editMIMEType)
 	if err != nil {
-		return err
+		return usageError(err)
 	}
 	progressMode, err := progressModeFromFlag("edit", editProgress)
 	if err != nil {

--- a/cmd/docbank/edit.go
+++ b/cmd/docbank/edit.go
@@ -242,9 +242,8 @@ func stageCurrentVersion(
 			retErr = errors.Join(retErr, fmt.Errorf("closing content stream: %w", closeErr))
 		}
 	}()
-	if stream.BlobHash != node.BlobHash || stream.Size != node.Size {
-		return "", fmt.Errorf("version authority %s/%d disagrees with node authority %s/%d",
-			stream.BlobHash, stream.Size, node.BlobHash, node.Size)
+	if err := validateEditStreamAuthority(stream, node); err != nil {
+		return "", err
 	}
 
 	file, path, err := staging.createFile(node.Name)
@@ -271,6 +270,16 @@ func stageCurrentVersion(
 	}
 	file = nil
 	return path, nil
+}
+
+func validateEditStreamAuthority(stream *client.ContentStream, node api.Node) error {
+	if stream.BlobHash == node.BlobHash && stream.Size == node.Size {
+		return nil
+	}
+	return integrityError(fmt.Errorf(
+		"version authority %s/%d disagrees with node authority %s/%d",
+		stream.BlobHash, stream.Size, node.BlobHash, node.Size,
+	))
 }
 
 func editStagePattern(name string) string {

--- a/cmd/docbank/edit_test.go
+++ b/cmd/docbank/edit_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,6 +106,17 @@ func TestEditStagePatternUsesOnlySafeBoundedExtensions(t *testing.T) {
 			assert.Equal(t, expected, editStagePattern(name))
 		})
 	}
+}
+
+func TestEditAuthorityMismatchIsIntegrityFailure(t *testing.T) {
+	node := api.Node{BlobHash: strings.Repeat("a", 64), Size: 12}
+	stream := &client.ContentStream{BlobHash: strings.Repeat("b", 64), Size: node.Size}
+	err := validateEditStreamAuthority(stream, node)
+	require.Error(t, err)
+	assert.Equal(t, exitIntegrity, commandExitCode(err, true))
+
+	stream.BlobHash = node.BlobHash
+	require.NoError(t, validateEditStreamAuthority(stream, node))
 }
 
 func TestEditFailureAndConcurrentReplacementDoNotOverwrite(t *testing.T) {

--- a/cmd/docbank/editor_command_unix_test.go
+++ b/cmd/docbank/editor_command_unix_test.go
@@ -3,12 +3,26 @@
 package main
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnixEditorCommandRejectsUnterminatedQuote(t *testing.T) {
 	_, err := splitEditorCommand(`"unterminated`)
 	require.Error(t, err)
+}
+
+func TestExplicitMalformedEditorIsUsageError(t *testing.T) {
+	resetFlags(rootCmd)
+	t.Cleanup(func() { resetFlags(rootCmd) })
+	var stdout, stderr bytes.Buffer
+	code := runProcess(
+		[]string{"edit", "/document", "--editor", `"unterminated`},
+		&stdout, &stderr,
+	)
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "parsing editor command")
 }

--- a/cmd/docbank/exit.go
+++ b/cmd/docbank/exit.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"errors"
+
+	"go.kenn.io/kit/backup"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/home"
+	"go.kenn.io/docbank/internal/store"
+)
+
+const (
+	exitSuccess   = 0
+	exitGeneral   = 1
+	exitUsage     = 2
+	exitNotFound  = 3
+	exitStale     = 4
+	exitBusy      = 5
+	exitIntegrity = 6
+)
+
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+func (e *exitError) Unwrap() error { return e.err }
+
+func usageError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &exitError{code: exitUsage, err: err}
+}
+
+func integrityError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &exitError{code: exitIntegrity, err: err}
+}
+
+func commandExitCode(err error, started bool) int {
+	if err == nil {
+		return exitSuccess
+	}
+	var classified *exitError
+	if errors.As(err, &classified) {
+		return classified.code
+	}
+	if errors.Is(err, client.ErrIntegrity) {
+		return exitIntegrity
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		return exitNotFound
+	}
+	if errors.Is(err, store.ErrStaleRevision) || errors.Is(err, store.ErrAuditPreviewStale) {
+		return exitStale
+	}
+	if errors.Is(err, home.ErrVaultLocked) || errors.Is(err, backup.ErrRepoLocked) ||
+		errors.Is(err, packstore.ErrPackRetirementDeferred) {
+		return exitBusy
+	}
+	if errors.Is(err, store.ErrInvalidName) || errors.Is(err, store.ErrInvalidTag) ||
+		errors.Is(err, store.ErrInvalidVersionPrune) ||
+		errors.Is(err, store.ErrInvalidAuditCursor) {
+		return exitUsage
+	}
+	if code, ok := client.ProblemCode(err); ok &&
+		(code == "validation" || code == "audit_acknowledgment_required") {
+		return exitUsage
+	}
+	if !started {
+		return exitUsage
+	}
+	return exitGeneral
+}

--- a/cmd/docbank/exit_test.go
+++ b/cmd/docbank/exit_test.go
@@ -66,6 +66,30 @@ func TestRunProcessDistinguishesUsageAndMissingNodes(t *testing.T) {
 	assert.Equal(t, exitNotFound, code)
 	assert.Contains(t, stderr.String(), "not found")
 
+	code = run("backup", "restore")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "--target is required")
+
+	code = run("audit", "status", "/", "--node-id", "0")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "either a path or --node-id")
+
+	code = run("audit", "status", "--node-id", "0")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "--node-id must be positive")
+
+	code = run("audit", "enable", "--node-id", "0")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "--node-id must be positive")
+
+	code = run("audit", "enable", "--run", "--node-id", "0")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "uses only the reviewed preview token")
+
+	code = run("audit", "history", "--node-id", "0")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "--node-id must be positive")
+
 	code = run("--not-a-real-flag")
 	require.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "unknown flag")

--- a/cmd/docbank/exit_test.go
+++ b/cmd/docbank/exit_test.go
@@ -90,6 +90,19 @@ func TestRunProcessDistinguishesUsageAndMissingNodes(t *testing.T) {
 	assert.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "--node-id must be positive")
 
+	code = run("tag", "assign", "work", "relative/path")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "tag assignment path must be absolute")
+
+	code = run("revert", "/document", "not-a-version-id")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "must be a canonical UUIDv4")
+
+	invalidSource := string([]byte{'b', 'a', 'd', 0xff})
+	code = run("put", invalidSource, "/document")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "is not valid UTF-8")
+
 	code = run("--not-a-real-flag")
 	require.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "unknown flag")

--- a/cmd/docbank/exit_test.go
+++ b/cmd/docbank/exit_test.go
@@ -98,6 +98,14 @@ func TestRunProcessDistinguishesUsageAndMissingNodes(t *testing.T) {
 	assert.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "must be a canonical UUIDv4")
 
+	code = run("version", "not-a-version-id")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "must be a canonical UUIDv4")
+
+	code = run("version", "not-a-version-id", "--content")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "must be a canonical UUIDv4")
+
 	invalidSource := string([]byte{'b', 'a', 'd', 0xff})
 	code = run("put", invalidSource, "/document")
 	assert.Equal(t, exitUsage, code)

--- a/cmd/docbank/exit_test.go
+++ b/cmd/docbank/exit_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/backup"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/home"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestCommandExitCode(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		started bool
+		want    int
+	}{
+		{name: "success", want: exitSuccess},
+		{name: "general", err: errors.New("failed"), started: true, want: exitGeneral},
+		{name: "cobra usage", err: errors.New("unknown flag"), want: exitUsage},
+		{name: "semantic usage", err: usageError(errors.New("bad limit")), started: true, want: exitUsage},
+		{name: "not found", err: fmt.Errorf("lookup: %w", store.ErrNotFound), started: true, want: exitNotFound},
+		{name: "stale revision", err: store.ErrStaleRevision, started: true, want: exitStale},
+		{name: "stale preview", err: store.ErrAuditPreviewStale, started: true, want: exitStale},
+		{name: "vault busy", err: home.ErrVaultLocked, started: true, want: exitBusy},
+		{name: "repository busy", err: backup.ErrRepoLocked, started: true, want: exitBusy},
+		{name: "retirement busy", err: packstore.ErrPackRetirementDeferred, started: true, want: exitBusy},
+		{name: "content integrity", err: client.ErrIntegrity, started: true, want: exitIntegrity},
+		{name: "reported integrity", err: integrityError(errors.New("problems")), started: true, want: exitIntegrity},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, commandExitCode(tt.err, tt.started))
+		})
+	}
+}
+
+func TestRunProcessDistinguishesUsageAndMissingNodes(t *testing.T) {
+	_ = setupVaultHome(t)
+
+	var stdout, stderr bytes.Buffer
+	run := func(args ...string) int {
+		resetFlags(rootCmd)
+		stdout.Reset()
+		stderr.Reset()
+		return runProcess(args, &stdout, &stderr)
+	}
+
+	code := run("search", "term", "--limit", "0")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "--limit must be between")
+
+	code = run("storage", "pack", "--max-bytes", "-1")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "validation")
+
+	code = run("ls", "/missing")
+	assert.Equal(t, exitNotFound, code)
+	assert.Contains(t, stderr.String(), "not found")
+
+	code = run("--not-a-real-flag")
+	require.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "unknown flag")
+}

--- a/cmd/docbank/main.go
+++ b/cmd/docbank/main.go
@@ -2,12 +2,21 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
 func main() {
+	os.Exit(runProcess(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func runProcess(args []string, stdout, stderr io.Writer) int {
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
 	if err := Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, "error:", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintln(stderr, "error:", err)
+		return commandExitCode(err, commandStarted)
 	}
+	return exitSuccess
 }

--- a/cmd/docbank/put.go
+++ b/cmd/docbank/put.go
@@ -37,6 +37,9 @@ var putCmd = &cobra.Command{
 	Short: "Replace a file's content while retaining its immutable history",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validatePutSourcePath(args[0]); err != nil {
+			return usageError(err)
+		}
 		source, sourcePath, size, err := openPutSource(args[0])
 		if err != nil {
 			return err
@@ -116,9 +119,8 @@ var putCmd = &cobra.Command{
 }
 
 func openPutSource(raw string) (*os.File, string, int64, error) {
-	if !utf8.ValidString(raw) {
-		return nil, "", 0, fmt.Errorf("replacement source path %s is not valid UTF-8",
-			strconv.QuoteToASCII(raw))
+	if err := validatePutSourcePath(raw); err != nil {
+		return nil, "", 0, err
 	}
 	path, err := filepath.Abs(raw)
 	if err != nil {
@@ -143,6 +145,14 @@ func openPutSource(raw string) (*os.File, string, int64, error) {
 			path, info.Size(), blob.MaxIngestBytes)
 	}
 	return file, path, info.Size(), nil
+}
+
+func validatePutSourcePath(raw string) error {
+	if utf8.ValidString(raw) {
+		return nil
+	}
+	return fmt.Errorf("replacement source path %s is not valid UTF-8",
+		strconv.QuoteToASCII(raw))
 }
 
 func putSourceMIME(source io.ReadSeeker, path, override string) (string, error) {

--- a/cmd/docbank/put.go
+++ b/cmd/docbank/put.go
@@ -45,6 +45,9 @@ var putCmd = &cobra.Command{
 
 		mimeType, err := putSourceMIME(source, sourcePath, putMIMEType)
 		if err != nil {
+			if putMIMEType != "" {
+				return usageError(err)
+			}
 			return err
 		}
 		mode := backupProgressAuto

--- a/cmd/docbank/refs.go
+++ b/cmd/docbank/refs.go
@@ -26,13 +26,13 @@ var referencesCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if _, err := packstore.ParseHash(args[0]); err != nil {
-			return errors.New("content hash must be canonical lowercase SHA-256")
+			return usageError(errors.New("content hash must be canonical lowercase SHA-256"))
 		}
 		if referencesLimit < 1 || referencesLimit > maxReferencesLimit {
-			return fmt.Errorf("--limit must be between 1 and %d", maxReferencesLimit)
+			return usageError(fmt.Errorf("--limit must be between 1 and %d", maxReferencesLimit))
 		}
 		if referencesOffset < 0 {
-			return errors.New("--offset must not be negative")
+			return usageError(errors.New("--offset must not be negative"))
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/cmd/docbank/restore.go
+++ b/cmd/docbank/restore.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -15,8 +16,11 @@ var restoreCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id, err := strconv.ParseInt(args[0], 10, 64)
-		if err != nil {
-			return fmt.Errorf("invalid node id %q: %w", args[0], err)
+		if err != nil || id < 1 {
+			if err == nil {
+				err = errors.New("node ID must be positive")
+			}
+			return usageError(fmt.Errorf("invalid node id %q: %w", args[0], err))
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/cmd/docbank/revert.go
+++ b/cmd/docbank/revert.go
@@ -16,6 +16,10 @@ var revertCmd = &cobra.Command{
 	Short: "Create a new current version from an immutable prior version",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !client.IsCanonicalUUIDv4(args[1]) {
+			return usageError(fmt.Errorf(
+				"reversion source %q must be a canonical UUIDv4", args[1]))
+		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
 			return err

--- a/cmd/docbank/root.go
+++ b/cmd/docbank/root.go
@@ -13,8 +13,21 @@ var rootCmd = &cobra.Command{
 	Version:       fmt.Sprintf("%s (%s)", version.Version, version.Commit),
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	// Cobra runs this only after flag parsing and positional validation, which
+	// lets the process boundary distinguish command syntax from RunE failures.
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		commandStarted = true
+	},
 }
 
+var commandStarted bool
+
 func Execute() error {
+	commandStarted = false
 	return rootCmd.Execute() //nolint:wrapcheck // error is user-facing CLI output; wrapping adds noise
+}
+
+func init() {
+	// Keep the root marker active if a child later adds its own persistent hook.
+	cobra.EnableTraverseRunHooks = true
 }

--- a/cmd/docbank/search.go
+++ b/cmd/docbank/search.go
@@ -26,7 +26,7 @@ var searchCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if searchLimit < 1 || searchLimit > maxSearchLimit {
-			return fmt.Errorf("--limit must be between 1 and %d", maxSearchLimit)
+			return usageError(fmt.Errorf("--limit must be between 1 and %d", maxSearchLimit))
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/cmd/docbank/tag.go
+++ b/cmd/docbank/tag.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -242,6 +243,9 @@ var tagNodesCmd = &cobra.Command{
 func changeTagAssignmentCLI(
 	cmd *cobra.Command, selector, path string, assign, jsonOutput bool,
 ) error {
+	if !strings.HasPrefix(path, "/") {
+		return usageError(errors.New("tag assignment path must be absolute"))
+	}
 	c, err := client.Ensure(cmd.Context())
 	if err != nil {
 		return err

--- a/cmd/docbank/tag.go
+++ b/cmd/docbank/tag.go
@@ -296,10 +296,10 @@ func resolveTag(cmd *cobra.Command, c *client.Client, selector string) (api.Tag,
 
 func validateTagPagination(limit, offset int) error {
 	if limit < 1 || limit > maxTagLimit {
-		return fmt.Errorf("--limit must be between 1 and %d", maxTagLimit)
+		return usageError(fmt.Errorf("--limit must be between 1 and %d", maxTagLimit))
 	}
 	if offset < 0 {
-		return errors.New("--offset must not be negative")
+		return usageError(errors.New("--offset must not be negative"))
 	}
 	return nil
 }

--- a/cmd/docbank/trash.go
+++ b/cmd/docbank/trash.go
@@ -65,7 +65,7 @@ var trashEmptyCmd = &cobra.Command{
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if _, err := api.ParseAge(trashOlderThan); err != nil {
-			return err
+			return usageError(err)
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/cmd/docbank/verify.go
+++ b/cmd/docbank/verify.go
@@ -31,7 +31,7 @@ var verifyCmd = &cobra.Command{
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d blob(s) ok, %d problem(s)\n",
 			rep.OK, problemCount)
 		if problemCount > 0 {
-			return fmt.Errorf("verify found %d problem(s)", problemCount)
+			return integrityError(fmt.Errorf("verify found %d problem(s)", problemCount))
 		}
 		return nil
 	},

--- a/cmd/docbank/versions.go
+++ b/cmd/docbank/versions.go
@@ -86,6 +86,10 @@ var versionCmd = &cobra.Command{
 		if versionJSON && versionContent {
 			return usageError(errors.New("--json and --content cannot be combined"))
 		}
+		if !client.IsCanonicalUUIDv4(args[0]) {
+			return usageError(fmt.Errorf(
+				"version ID %q must be a canonical UUIDv4", args[0]))
+		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
 			return err

--- a/cmd/docbank/versions.go
+++ b/cmd/docbank/versions.go
@@ -35,10 +35,10 @@ var versionsCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if versionsLimit < 1 || versionsLimit > maxVersionsLimit {
-			return fmt.Errorf("--limit must be between 1 and %d", maxVersionsLimit)
+			return usageError(fmt.Errorf("--limit must be between 1 and %d", maxVersionsLimit))
 		}
 		if versionsOffset < 0 {
-			return errors.New("--offset must not be negative")
+			return usageError(errors.New("--offset must not be negative"))
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
@@ -84,7 +84,7 @@ var versionCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if versionJSON && versionContent {
-			return errors.New("--json and --content cannot be combined")
+			return usageError(errors.New("--json and --content cannot be combined"))
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
@@ -139,10 +139,10 @@ var versionsPruneCmd = &cobra.Command{
 			OlderThan: pruneOlderThan, AllPrior: pruneAllPrior, Run: pruneRun,
 		}
 		if cmd.Flags().Changed("keep-newest") && pruneKeepNewest < 1 {
-			return errors.New("--keep-newest must be at least 1")
+			return usageError(errors.New("--keep-newest must be at least 1"))
 		}
 		if _, err := api.ParseVersionPruneRequest(request); err != nil {
-			return err
+			return usageError(err)
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -16,6 +16,14 @@ Use the CLI for human-directed shell work and simple orchestration. Use HTTP
 for structured agent workflows, pagination, machine-readable errors, and
 revision-aware mutations.
 
+For simple shell orchestration, CLI exit codes distinguish invalid usage (`2`),
+missing vault objects (`3`), stale state (`4`), busy resources (`5`), and
+integrity findings (`6`) from general failures (`1`). Verification may emit a
+complete report before exiting `6`; never infer success merely because stdout
+contains JSON. The [CLI reference](../cli-reference.md#process-exit-codes)
+defines the full contract. Independent integrations should use the richer HTTP
+problem `code` values below.
+
 The canonical contract is generated from the running route definitions:
 
 ```bash

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ docbank is pre-1.0; interfaces and storage migrations may still evolve.
   provenance changes, while `docbank audit verify` independently replays the
   authority, checks protected bytes, and proves current chains extend a
   separately recorded evidence report.
+- Legacy browsing and trash commands expose typed JSON, and CLI processes use
+  stable exit codes for usage, missing objects, stale state, busy resources,
+  and integrity findings.
 
 ## v0.5.0 (2026-07-17)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,6 +18,27 @@ daemon status` and `docbank daemon stop` never auto-start. See
 [Daemon](architecture/daemon.md) and
 [Ownership & Concurrency](architecture/locking.md).
 
+## Process exit codes
+
+CLI process codes are stable so shell automation can branch without parsing
+stderr. Human error text remains explanatory and may change.
+
+| Code | Meaning | Typical action |
+|------|---------|----------------|
+| `0` | Success, including an empty result or a dry run that found nothing | Continue |
+| `1` | General operational failure, such as local I/O, transport, daemon, or an otherwise unclassified conflict | Report or inspect stderr |
+| `2` | Invalid command usage, arguments, flag combinations, values, or request validation | Correct the invocation |
+| `3` | The daemon returned `not_found` for the requested vault object | Refresh names or identities |
+| `4` | Stale optimistic state: a revision or audit enrollment preview no longer matches | Re-read, reconsider, and retry deliberately |
+| `5` | A vault, backup repository, or physical pack resource is busy or locked | Wait or release the known owner; do not blindly force-unlock |
+| `6` | A completed verification reported integrity findings, or a content stream failed terminal size/hash/digest proof | Do not trust or publish the affected bytes |
+
+Integrity commands may write their complete human or JSON report before
+exiting `6`; the report is evidence, not a success indication. Failures that
+prevent verification from completing at all—such as an unreachable daemon—use
+`1`. HTTP clients should continue to branch on the API's problem `code` rather
+than translating process exits back into HTTP status.
+
 ## docbank add
 
 ```

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -27,6 +27,7 @@ import (
 	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/home"
 	"go.kenn.io/docbank/internal/jsontext"
 	"go.kenn.io/docbank/internal/store"
 )
@@ -53,6 +54,36 @@ func responseStatus(err error) (int, bool) {
 		return 0, false
 	}
 	return response.status, true
+}
+
+type problemError struct {
+	code string
+	err  error
+}
+
+func (e *problemError) Error() string { return e.err.Error() }
+func (e *problemError) Unwrap() error { return e.err }
+
+// ProblemCode returns the daemon's stable RFC 7807 extension code when err
+// came from a decoded HTTP response or progress-stream error event.
+func ProblemCode(err error) (string, bool) {
+	var problem *problemError
+	if !errors.As(err, &problem) || problem.code == "" {
+		return "", false
+	}
+	return problem.code, true
+}
+
+// ErrIntegrity marks content that failed terminal size, hash, or digest proof.
+var ErrIntegrity = errors.New("content integrity verification failed")
+
+type integrityError struct{ message string }
+
+func (e *integrityError) Error() string        { return e.message }
+func (e *integrityError) Is(target error) bool { return target == ErrIntegrity }
+
+func integrityErrorf(format string, args ...any) error {
+	return &integrityError{message: fmt.Sprintf(format, args...)}
 }
 
 // ContentStream exposes the catalog identity available before a download and
@@ -92,20 +123,21 @@ func (s *ContentStream) CopyVerified(w io.Writer) (int64, error) {
 		return written, fmt.Errorf("copying content: %w", err)
 	}
 	if written != s.Size {
-		return written, fmt.Errorf("verifying content: received %d bytes, expected %d", written, s.Size)
+		return written, integrityErrorf("verifying content: received %d bytes, expected %d",
+			written, s.Size)
 	}
 	computedHash := hex.EncodeToString(hash.Sum(nil))
 	if computedHash != s.BlobHash {
-		return written, fmt.Errorf("verifying content: computed SHA-256 %s, expected %s",
+		return written, integrityErrorf("verifying content: computed SHA-256 %s, expected %s",
 			computedHash, s.BlobHash)
 	}
 	wantDigest := "sha-256=:" + base64.StdEncoding.EncodeToString(hash.Sum(nil)) + ":"
 	gotDigest := s.ContentDigest()
 	if gotDigest == "" {
-		return written, errors.New("verifying content: response lacks terminal Content-Digest")
+		return written, integrityErrorf("verifying content: response lacks terminal Content-Digest")
 	}
 	if gotDigest != wantDigest {
-		return written, fmt.Errorf("verifying content: terminal Content-Digest %q, expected %q",
+		return written, integrityErrorf("verifying content: terminal Content-Digest %q, expected %q",
 			gotDigest, wantDigest)
 	}
 	return written, nil
@@ -118,25 +150,26 @@ func New(baseURL, apiKey string) *Client {
 // codeToTypedErr preserves server problem codes that have a stable local
 // sentinel for callers using errors.Is.
 var codeToTypedErr = map[string]error{
-	"not_found":                store.ErrNotFound,
-	"exists":                   store.ErrExists,
-	"cycle":                    store.ErrCycle,
-	"stale_revision":           store.ErrStaleRevision,
-	"not_dir":                  store.ErrNotDir,
-	"not_file":                 store.ErrNotFile,
-	"invalid_name":             store.ErrInvalidName,
-	"invalid_tag":              store.ErrInvalidTag,
-	"not_trashed":              store.ErrNotTrashed,
-	"is_root":                  store.ErrIsRoot,
-	"version_node_mismatch":    store.ErrVersionNodeMismatch,
-	"version_already_current":  store.ErrVersionAlreadyCurrent,
-	"invalid_version_prune":    store.ErrInvalidVersionPrune,
-	"audit_already_enabled":    store.ErrAuditAlreadyEnabled,
-	"audit_preview_stale":      store.ErrAuditPreviewStale,
-	"audit_not_enrolled":       store.ErrAuditNotEnrolled,
-	"invalid_audit_cursor":     store.ErrInvalidAuditCursor,
-	"backup_locked":            backup.ErrRepoLocked,
-	"pack_retirement_deferred": packstore.ErrPackRetirementDeferred,
+	"not_found":                    store.ErrNotFound,
+	"exists":                       store.ErrExists,
+	"cycle":                        store.ErrCycle,
+	"stale_revision":               store.ErrStaleRevision,
+	"not_dir":                      store.ErrNotDir,
+	"not_file":                     store.ErrNotFile,
+	"invalid_name":                 store.ErrInvalidName,
+	"invalid_tag":                  store.ErrInvalidTag,
+	"not_trashed":                  store.ErrNotTrashed,
+	"is_root":                      store.ErrIsRoot,
+	"version_node_mismatch":        store.ErrVersionNodeMismatch,
+	"version_already_current":      store.ErrVersionAlreadyCurrent,
+	"invalid_version_prune":        store.ErrInvalidVersionPrune,
+	"audit_already_enabled":        store.ErrAuditAlreadyEnabled,
+	"audit_preview_stale":          store.ErrAuditPreviewStale,
+	"audit_not_enrolled":           store.ErrAuditNotEnrolled,
+	"invalid_audit_cursor":         store.ErrInvalidAuditCursor,
+	"backup_locked":                backup.ErrRepoLocked,
+	"backup_restore_target_active": home.ErrVaultLocked,
+	"pack_retirement_deferred":     packstore.ErrPackRetirementDeferred,
 }
 
 func decodeError(resp *http.Response) error {
@@ -150,10 +183,13 @@ func decodeError(resp *http.Response) error {
 }
 
 func apiProblemError(e api.Error) error {
+	var cause error
 	if target, ok := codeToTypedErr[e.Code]; ok {
-		return fmt.Errorf("%s: %w", e.Detail, target)
+		cause = fmt.Errorf("%s: %w", e.Detail, target)
+	} else {
+		cause = fmt.Errorf("daemon error (%d %s): %s", e.Status, e.Code, e.Detail)
 	}
-	return fmt.Errorf("daemon error (%d %s): %s", e.Status, e.Code, e.Detail)
+	return &problemError{code: e.Code, err: cause}
 }
 
 // do issues one JSON round-trip. Non-nil out must be a pointer; a non-2xx
@@ -295,7 +331,7 @@ func (c *Client) VersionContent(ctx context.Context, id string) (*ContentStream,
 	}
 	if stream.VersionID != id {
 		_ = stream.Close()
-		return nil, fmt.Errorf("content version %s returned version identity %s", id, stream.VersionID)
+		return nil, integrityErrorf("content version %s returned version identity %s", id, stream.VersionID)
 	}
 	return stream, nil
 }
@@ -550,18 +586,19 @@ func (c *Client) content(ctx context.Context, path, identity string) (*ContentSt
 	size, err := strconv.ParseInt(resp.Header.Get(api.BlobSizeHeader), 10, 64)
 	if err != nil || size < 0 {
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("%s returned invalid %s %q",
+		return nil, integrityErrorf("%s returned invalid %s %q",
 			identity, api.BlobSizeHeader, resp.Header.Get(api.BlobSizeHeader))
 	}
 	hash := resp.Header.Get(api.BlobHashHeader)
 	if !validSHA256Hex(hash) {
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("%s returned invalid %s %q", identity, api.BlobHashHeader, hash)
+		return nil, integrityErrorf("%s returned invalid %s %q", identity, api.BlobHashHeader, hash)
 	}
 	versionID := resp.Header.Get(api.ContentVersionHeader)
 	if !validUUIDv4(versionID) {
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("%s returned invalid %s %q", identity, api.ContentVersionHeader, versionID)
+		return nil, integrityErrorf("%s returned invalid %s %q",
+			identity, api.ContentVersionHeader, versionID)
 	}
 	return &ContentStream{ReadCloser: resp.Body, VersionID: versionID,
 		BlobHash: hash, Size: size, trailer: resp.Trailer}, nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -27,6 +27,7 @@ import (
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/home"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -302,6 +303,24 @@ func TestIngestStreamRoundTrip(t *testing.T) {
 	require.Contains(t, finalStages, "ingest")
 	assert.Equal(t, int64(1), finalStages["ingest"].Done)
 	assert.Equal(t, int64(len(content)), finalStages["ingest"].BytesDone)
+}
+
+func TestProgressStreamPreservesProblemCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_ = json.NewEncoder(w).Encode(api.IngestEvent{Type: "error", Error: &api.Error{
+			Title: "Validation failed", Status: http.StatusUnprocessableEntity,
+			Code: "validation", Detail: "invalid ingest request",
+		}})
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := client.New(ts.URL, "key").IngestStream(
+		t.Context(), []string{"/source"}, "/inbox", nil, nil)
+	require.Error(t, err)
+	code, ok := client.ProblemCode(err)
+	assert.True(t, ok)
+	assert.Equal(t, "validation", code)
 }
 
 func TestJSONMethodsRejectInvalidUTF8BeforeRequest(t *testing.T) {
@@ -648,11 +667,13 @@ func TestVersionContentRejectsUnprovenResponses(t *testing.T) {
 			stream, err := client.New(ts.URL, "key").VersionContent(t.Context(), requestedVersion)
 			if err != nil {
 				require.ErrorContains(t, err, tt.wantError)
+				assert.ErrorIs(t, err, client.ErrIntegrity)
 				return
 			}
 			defer func() { _ = stream.Close() }()
 			_, err = stream.CopyVerified(io.Discard)
 			require.ErrorContains(t, err, tt.wantError)
+			assert.ErrorIs(t, err, client.ErrIntegrity)
 		})
 	}
 }
@@ -1005,4 +1026,26 @@ func TestWrongAPIKeyIsRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "401")
 	assert.Contains(t, err.Error(), "unauthorized")
+	code, ok := client.ProblemCode(err)
+	assert.True(t, ok)
+	assert.Equal(t, "unauthorized", code)
+}
+
+func TestRestoreTargetContentionRemainsTyped(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(api.Error{
+			Title: "Conflict", Status: http.StatusConflict,
+			Code: "backup_restore_target_active", Detail: "restore target is active",
+		})
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := client.New(ts.URL, "key").TrashList(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, home.ErrVaultLocked)
+	code, ok := client.ProblemCode(err)
+	assert.True(t, ok)
+	assert.Equal(t, "backup_restore_target_active", code)
 }

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -27,6 +27,33 @@ import (
 
 const ensureTimeout = 30 * time.Second
 
+const (
+	daemonStartProblemPrefix      = "DOCBANK_DAEMON_START_PROBLEM="
+	daemonStartProblemVaultLocked = "vault_locked"
+)
+
+type daemonStartError struct {
+	message string
+	cause   error
+}
+
+func (e *daemonStartError) Error() string { return e.message }
+func (e *daemonStartError) Unwrap() error { return e.cause }
+
+// WriteDaemonStartProblem records a machine-readable cause in the launcher's
+// private bootstrap output. The detached child cannot return Go error identity
+// across a process boundary, so the launcher restores the small stable subset
+// needed by callers before it returns the human error.
+func WriteDaemonStartProblem(w io.Writer, err error) error {
+	if !errors.Is(err, home.ErrVaultLocked) {
+		return nil
+	}
+	if _, err := fmt.Fprintln(w, daemonStartProblemPrefix+daemonStartProblemVaultLocked); err != nil {
+		return fmt.Errorf("writing daemon startup problem: %w", err)
+	}
+	return nil
+}
+
 func probeOptions() kitdaemon.ProbeOptions {
 	return kitdaemon.ProbeOptions{ExpectedService: Service, Timeout: 2 * time.Second}
 }
@@ -313,10 +340,30 @@ func daemonStartFailure(output *os.File, summary string) error {
 	if err != nil {
 		return fmt.Errorf("%s (reading bootstrap output: %w)", summary, err)
 	}
-	if detail := strings.TrimSpace(string(data)); detail != "" {
-		return fmt.Errorf("%s: %s", summary, detail)
+	detail, cause := parseDaemonStartOutput(string(data))
+	message := summary
+	if detail != "" {
+		message += ": " + detail
 	}
-	return errors.New(summary)
+	if cause != nil {
+		return &daemonStartError{message: message, cause: cause}
+	}
+	return errors.New(message)
+}
+
+func parseDaemonStartOutput(output string) (string, error) {
+	lines := strings.Split(output, "\n")
+	kept := lines[:0]
+	var cause error
+	for _, line := range lines {
+		switch strings.TrimSpace(line) {
+		case daemonStartProblemPrefix + daemonStartProblemVaultLocked:
+			cause = home.ErrVaultLocked
+		default:
+			kept = append(kept, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n")), cause
 }
 
 func discover(


### PR DESCRIPTION
Docbank’s JSON output is becoming useful for shell scripts and local agents, but every failure still exits with code 1. A caller therefore has to parse human error text to tell a typo from a missing document, a stale revision, a locked vault, or damaged content.

This PR gives the command-line process a small stable vocabulary: 0 for success, 1 for an operational failure, 2 for invalid usage, 3 for a missing vault object, 4 for stale optimistic state, 5 for a busy resource, and 6 for integrity findings. Existing human messages are unchanged. Verification commands still print their complete report before returning 6, so the report remains usable evidence rather than being hidden behind the failure.

The classification follows errors already carried through the typed client. Daemon problem codes now also survive NDJSON progress streams, which keeps streamed backup and ingest commands consistent with ordinary HTTP responses. This does not change HTTP status codes, storage behavior, daemon protocol, or schema; integrations using the HTTP API should continue using its more specific problem codes.

The behavior is exercised through the real command boundary and through ordinary and streamed client failures. The repository remains green with both SQLite implementations, strict documentation and lint checks, and Windows amd64/arm64 compilation.

Kata: 0r1d.
