### PR TITLE
Expose structured tree mutation receipts

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -704,6 +705,39 @@ func TestRmRestoreRoundTrip(t *testing.T) {
 	out, err = runCLI(t, "ls", "/inbox")
 	require.NoError(t, err)
 	assert.Contains(t, out, "a.txt")
+}
+
+func TestTreeMutationJSONReceipts(t *testing.T) {
+	setupVaultHome(t)
+	src := writeSourceFile(t, "a.txt", "alpha")
+	_, err := runCLI(t, "add", src, "--dest", "/inbox")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "mv", "/inbox/a.txt", "/inbox/b.txt", "--json")
+	require.NoError(t, err, out)
+	var moved api.Node
+	require.NoError(t, json.Unmarshal([]byte(out), &moved))
+	assert.Equal(t, "/inbox/b.txt", moved.Path)
+	assert.Equal(t, "b.txt", moved.Name)
+	assert.Empty(t, moved.TrashedAt)
+
+	out, err = runCLI(t, "rm", "/inbox/b.txt", "--json")
+	require.NoError(t, err, out)
+	var trashed api.Node
+	require.NoError(t, json.Unmarshal([]byte(out), &trashed))
+	assert.Equal(t, moved.ID, trashed.ID)
+	assert.Equal(t, "/inbox/b.txt", trashed.Path, "trash receipt retains the pre-trash path")
+	assert.NotEmpty(t, trashed.TrashedAt)
+	assert.Greater(t, trashed.Revision, moved.Revision)
+
+	out, err = runCLI(t, "restore", strconv.FormatInt(trashed.ID, 10), "--json")
+	require.NoError(t, err, out)
+	var restored api.Node
+	require.NoError(t, json.Unmarshal([]byte(out), &restored))
+	assert.Equal(t, moved.ID, restored.ID)
+	assert.Equal(t, "/inbox/b.txt", restored.Path)
+	assert.Empty(t, restored.TrashedAt)
+	assert.Greater(t, restored.Revision, trashed.Revision)
 }
 
 func TestSearchCLI(t *testing.T) {

--- a/cmd/docbank/mv.go
+++ b/cmd/docbank/mv.go
@@ -8,6 +8,8 @@ import (
 	"go.kenn.io/docbank/internal/client"
 )
 
+var mvJSON bool
+
 var mvCmd = &cobra.Command{
 	Use:   "mv <src-path> <dest-path>",
 	Short: "Move or rename a node (metadata only; bytes never move)",
@@ -21,9 +23,15 @@ var mvCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if mvJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), moved)
+		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "moved [%d] %s\n", moved.ID, moved.Path)
 		return nil
 	},
 }
 
-func init() { rootCmd.AddCommand(mvCmd) }
+func init() {
+	mvCmd.Flags().BoolVar(&mvJSON, "json", false, "emit a machine-readable node receipt")
+	rootCmd.AddCommand(mvCmd)
+}

--- a/cmd/docbank/restore.go
+++ b/cmd/docbank/restore.go
@@ -10,6 +10,8 @@ import (
 	"go.kenn.io/docbank/internal/client"
 )
 
+var restoreJSON bool
+
 var restoreCmd = &cobra.Command{
 	Use:   "restore <id>",
 	Short: "Restore a trashed node to its original location",
@@ -34,9 +36,16 @@ var restoreCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if restoreJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), restored)
+		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "restored [%d] %s\n", restored.ID, restored.Path)
 		return nil
 	},
 }
 
-func init() { rootCmd.AddCommand(restoreCmd) }
+func init() {
+	restoreCmd.Flags().BoolVar(&restoreJSON, "json", false,
+		"emit a machine-readable node receipt")
+	rootCmd.AddCommand(restoreCmd)
+}

--- a/cmd/docbank/rm.go
+++ b/cmd/docbank/rm.go
@@ -8,6 +8,8 @@ import (
 	"go.kenn.io/docbank/internal/client"
 )
 
+var rmJSON bool
+
 var rmCmd = &cobra.Command{
 	Use:   "rm <path>",
 	Short: "Move a node (and its subtree) to the trash",
@@ -24,10 +26,16 @@ var rmCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if rmJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), n)
+		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 			"trashed [%d] %s (restore with: docbank restore %d)\n", n.ID, args[0], n.ID)
 		return nil
 	},
 }
 
-func init() { rootCmd.AddCommand(rmCmd) }
+func init() {
+	rmCmd.Flags().BoolVar(&rmJSON, "json", false, "emit a machine-readable node receipt")
+	rootCmd.AddCommand(rmCmd)
+}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -24,6 +24,11 @@ contains JSON. The [CLI reference](../cli-reference.md#process-exit-codes)
 defines the full contract. Independent integrations should use the richer HTTP
 problem `code` values below.
 
+For a small shell workflow, `mv`, `rm`, and `restore` accept `--json` and
+return the daemon's complete resulting node receipt. A trash receipt's `path`
+is only its pre-trash recovery context; carry the stable `id` and `revision`
+forward instead.
+
 The canonical contract is generated from the running route definitions:
 
 ```bash

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,9 +20,9 @@ docbank is pre-1.0; interfaces and storage migrations may still evolve.
   provenance changes, while `docbank audit verify` independently replays the
   authority, checks protected bytes, and proves current chains extend a
   separately recorded evidence report.
-- Legacy browsing and trash commands expose typed JSON, and CLI processes use
-  stable exit codes for usage, missing objects, stale state, busy resources,
-  and integrity findings.
+- Legacy browsing, trash, and virtual-tree mutation commands expose typed JSON,
+  and CLI processes use stable exit codes for usage, missing objects, stale
+  state, busy resources, and integrity findings.
 
 ## v0.5.0 (2026-07-17)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -409,7 +409,7 @@ and maintenance behavior.
 ## docbank mv
 
 ```
-docbank mv <src-path> <dest-path>
+docbank mv <src-path> <dest-path> [--json]
 ```
 
 Moves or renames a node. Metadata only — bytes never move. The
@@ -424,12 +424,14 @@ destination is interpreted like POSIX `mv`:
 
 Directory moves carry the whole subtree. A move that would place a
 directory under its own descendant fails with `move would create a
-cycle`. On success prints `moved [<id>] <new-path>`.
+cycle`. On success human output prints `moved [<id>] <new-path>`; `--json`
+returns the complete resulting node, including its stable ID, revision, and
+new path.
 
 ## docbank rm
 
 ```
-docbank rm <path>
+docbank rm <path> [--json]
 ```
 
 Soft-deletes: moves the node — and, for a directory, its entire subtree —
@@ -440,6 +442,10 @@ The freed name is immediately reusable. Prints:
 trashed [15] /taxes/2024/return.pdf (restore with: docbank restore 15)
 ```
 
+`--json` returns the trashed node receipt. Its `path` is the pre-trash path
+shown for recovery context; it no longer resolves to that node. Retain the
+stable `id` and `revision` as authority.
+
 There is no hard-delete flag. GC cannot collect a trashed document because the
 trash entry remains a restorable reference. Permanent metadata deletion,
 unreachable-content collection, and packed-space reclamation are the separate
@@ -448,13 +454,14 @@ unreachable-content collection, and packed-space reclamation are the separate
 ## docbank restore
 
 ```
-docbank restore <id>
+docbank restore <id> [--json]
 ```
 
 Returns a trashed node (by ID — see `docbank trash list`) to its original
 location, re-suffixing its name if a live node now occupies it. If the
 original parent directory was itself permanently deleted, the node is
-restored under `/`. Prints `restored [<id>] <path>`.
+restored under `/`. Human output prints `restored [<id>] <path>`; `--json`
+returns the complete restored node with its resulting path and revision.
 
 ## docbank search
 

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -97,7 +97,7 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	require.NotNil(t, trashHistory.Items[0].NewPath)
 	assert.Equal(t, "trash", trashHistory.Items[0].NewPath.State)
 	assert.Equal(t, "@trash/known/Taxes/2027", trashHistory.Items[0].NewPath.Path)
-	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	restored, _, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
 	require.NoError(t, err)
 	restoreHistory, err := c.AuditHistory(t.Context(), "/Taxes/2027", 0, 10, "")
 	require.NoError(t, err)

--- a/internal/api/routes_mutate.go
+++ b/internal/api/routes_mutate.go
@@ -102,12 +102,12 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 			if parent == nil {
 				return FromStoreError(fmt.Errorf("node %d: %w", in.ID, store.ErrIsRoot))
 			}
-			n, err := d.Store.Move(ctx, in.ID, *parent, name, rev)
+			n, path, err := d.Store.Move(ctx, in.ID, *parent, name, rev)
 			if err != nil {
 				return FromStoreError(err)
 			}
-			out, err = nodeWithPath(ctx, d, n.ID)
-			return err
+			out = nodeOutputAt(n, path)
+			return nil
 		})
 		return out, err
 	})
@@ -132,12 +132,12 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 		}
 		var out *nodeOutput
 		err := g.mutate(func() error {
-			n, err := d.Store.MovePath(ctx, in.Body.SrcPath, in.Body.DestPath)
+			n, path, err := d.Store.MovePath(ctx, in.Body.SrcPath, in.Body.DestPath)
 			if err != nil {
 				return FromStoreError(err)
 			}
-			out, err = nodeWithPath(ctx, d, n.ID)
-			return err
+			out = nodeOutputAt(n, path)
+			return nil
 		})
 		return out, err
 	})
@@ -218,12 +218,12 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 		}
 		var out *nodeOutput
 		err = g.mutate(func() error {
-			n, err := d.Store.Restore(ctx, in.ID, rev)
+			n, path, err := d.Store.Restore(ctx, in.ID, rev)
 			if err != nil {
 				return FromStoreError(err)
 			}
-			out, err = nodeWithPath(ctx, d, n.ID)
-			return err
+			out = nodeOutputAt(n, path)
+			return nil
 		})
 		return out, err
 	})

--- a/internal/api/routes_mutate_test.go
+++ b/internal/api/routes_mutate_test.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,9 +94,9 @@ func TestMovePathAndTrashPath(t *testing.T) {
 	_, err = s.Mkdir(t.Context(), s.RootID(), "filed")
 	require.NoError(t, err)
 	f := createFileWithContent(t, ts, s, "/a.txt", "x")
-	_, err = s.Move(t.Context(), f.ID, s.RootID(), "a.txt", store.UnconditionalRev)
+	_, _, err = s.Move(t.Context(), f.ID, s.RootID(), "a.txt", store.UnconditionalRev)
 	require.NoError(t, err)
-	_, err = s.MovePath(t.Context(), "/a.txt", "/docs")
+	_, _, err = s.MovePath(t.Context(), "/a.txt", "/docs")
 	require.NoError(t, err)
 
 	resp, body := do(t, ts, http.MethodPost, "/api/v1/path/move", nil,
@@ -177,7 +180,7 @@ func TestTrashAndRestoreRoundTripHTTP(t *testing.T) {
 	_, err := s.Mkdir(t.Context(), s.RootID(), "inbox")
 	require.NoError(t, err)
 	f := createFileWithContent(t, ts, s, "/doc.txt", "x")
-	_, err = s.MovePath(t.Context(), "/doc.txt", "/inbox")
+	_, _, err = s.MovePath(t.Context(), "/doc.txt", "/inbox")
 	require.NoError(t, err)
 
 	_, etag := etagOf(t, ts, f.ID)
@@ -202,4 +205,129 @@ func TestTrashAndRestoreRoundTripHTTP(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(body), &restored))
 	assert.Empty(t, restored.TrashedAt)
 	assert.Equal(t, "/inbox/doc.txt", restored.Path)
+}
+
+func TestMutationReceiptsRemainBoundDuringCompetingMutation(t *testing.T) {
+	t.Run("move", func(t *testing.T) {
+		ts, s := newTestServer(t, nil)
+		left, err := s.Mkdir(t.Context(), s.RootID(), "left")
+		require.NoError(t, err)
+		right, err := s.Mkdir(t.Context(), s.RootID(), "right")
+		require.NoError(t, err)
+		file := createFileWithContent(t, ts, s, "/item.txt", "x")
+		file, _, err = s.Move(
+			t.Context(), file.ID, left.ID, file.Name, store.UnconditionalRev,
+		)
+		require.NoError(t, err)
+		revision := file.Revision
+
+		for range 20 {
+			attempted := make(chan struct{})
+			competing := make(chan mutationRequestResult, 1)
+			go func(revision int64) {
+				competing <- retryMoveRequest(
+					t, ts, file.ID, revision, left.ID, attempted,
+					map[int]bool{http.StatusPreconditionFailed: true},
+				)
+			}(revision + 1)
+			<-attempted
+
+			resp, body := do(t, ts, http.MethodPatch,
+				fmt.Sprintf("/api/v1/nodes/%d", file.ID),
+				map[string]string{"If-Match": strconv.FormatInt(revision, 10)},
+				map[string]any{"new_parent_id": right.ID})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			var moved api.Node
+			require.NoError(t, json.Unmarshal([]byte(body), &moved))
+			assert.Equal(t, right.ID, *moved.ParentID)
+			assert.Equal(t, "/right/item.txt", moved.Path)
+
+			result := <-competing
+			require.NoError(t, result.err)
+			require.Equal(t, http.StatusOK, result.status, result.body)
+			var returned api.Node
+			require.NoError(t, json.Unmarshal([]byte(result.body), &returned))
+			assert.Equal(t, left.ID, *returned.ParentID)
+			assert.Equal(t, "/left/item.txt", returned.Path)
+			revision = returned.Revision
+		}
+	})
+
+	t.Run("restore", func(t *testing.T) {
+		ts, s := newTestServer(t, nil)
+		left, err := s.Mkdir(t.Context(), s.RootID(), "left")
+		require.NoError(t, err)
+		right, err := s.Mkdir(t.Context(), s.RootID(), "right")
+		require.NoError(t, err)
+		file := createFileWithContent(t, ts, s, "/item.txt", "x")
+		file, _, err = s.Move(
+			t.Context(), file.ID, left.ID, file.Name, store.UnconditionalRev,
+		)
+		require.NoError(t, err)
+		trashed, _, err := s.Trash(t.Context(), file.ID, file.Revision)
+		require.NoError(t, err)
+
+		attempted := make(chan struct{})
+		competing := make(chan mutationRequestResult, 1)
+		go func() {
+			competing <- retryMoveRequest(
+				t, ts, file.ID, trashed.Revision+1, right.ID, attempted,
+				map[int]bool{http.StatusNotFound: true, http.StatusPreconditionFailed: true},
+			)
+		}()
+		<-attempted
+
+		resp, body := do(t, ts, http.MethodPost,
+			fmt.Sprintf("/api/v1/nodes/%d/restore", file.ID),
+			map[string]string{"If-Match": strconv.FormatInt(trashed.Revision, 10)}, nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode, body)
+		var restored api.Node
+		require.NoError(t, json.Unmarshal([]byte(body), &restored))
+		assert.Equal(t, left.ID, *restored.ParentID)
+		assert.Equal(t, "/left/item.txt", restored.Path)
+
+		result := <-competing
+		require.NoError(t, result.err)
+		require.Equal(t, http.StatusOK, result.status, result.body)
+		var moved api.Node
+		require.NoError(t, json.Unmarshal([]byte(result.body), &moved))
+		assert.Equal(t, right.ID, *moved.ParentID)
+		assert.Equal(t, "/right/item.txt", moved.Path)
+	})
+}
+
+type mutationRequestResult struct {
+	status int
+	body   string
+	err    error
+}
+
+func retryMoveRequest(
+	t *testing.T,
+	ts *httptest.Server,
+	nodeID, revision, parentID int64,
+	attempted chan<- struct{},
+	retryable map[int]bool,
+) mutationRequestResult {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	first := true
+	for time.Now().Before(deadline) {
+		resp, body, err := try(t, ts, http.MethodPatch,
+			fmt.Sprintf("/api/v1/nodes/%d", nodeID),
+			map[string]string{"If-Match": strconv.FormatInt(revision, 10)},
+			map[string]any{"new_parent_id": parentID})
+		if first {
+			close(attempted)
+			first = false
+		}
+		if err != nil {
+			return mutationRequestResult{err: err}
+		}
+		if resp.StatusCode == http.StatusOK || !retryable[resp.StatusCode] {
+			return mutationRequestResult{status: resp.StatusCode, body: body}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return mutationRequestResult{err: fmt.Errorf("timed out waiting to move node %d", nodeID)}
 }

--- a/internal/api/routes_tags_test.go
+++ b/internal/api/routes_tags_test.go
@@ -177,7 +177,7 @@ func TestTagPathAssignmentUsesCurrentTopology(t *testing.T) {
 	require.NoError(t, err)
 	left, err = s.NodeByID(t.Context(), left.ID)
 	require.NoError(t, err)
-	_, err = s.Move(t.Context(), left.ID, right.ID, "moved", left.Revision)
+	_, _, err = s.Move(t.Context(), left.ID, right.ID, "moved", left.Revision)
 	require.NoError(t, err)
 
 	path := "/api/v1/path/tags/" + tag.ID

--- a/internal/store/audit_history_test.go
+++ b/internal/store/audit_history_test.go
@@ -32,7 +32,7 @@ func TestAuditHistoryPagesCanonicalNodeEvents(t *testing.T) {
 		t.Context(), taxes.ID, "return.txt", fakeHash("a710"), 7, "text/plain",
 	)
 	require.NoError(t, err)
-	moved, err := s.Move(t.Context(), file.ID, destination.ID, file.Name, file.Revision)
+	moved, _, err := s.Move(t.Context(), file.ID, destination.ID, file.Name, file.Revision)
 	require.NoError(t, err)
 
 	first, err := s.AuditHistory(t.Context(), file.ID, 2, "")
@@ -100,7 +100,7 @@ func TestAuditHistoryCursorRemainsStableWhenNewEventsArrive(t *testing.T) {
 	require.Len(t, first.Items, 1)
 	require.NotEmpty(t, first.NextCursor)
 	firstID := first.Items[0].ID
-	_, err = s.Move(t.Context(), file.ID, taxes.ID, "renamed.txt", file.Revision)
+	_, _, err = s.Move(t.Context(), file.ID, taxes.ID, "renamed.txt", file.Revision)
 	require.NoError(t, err)
 
 	second, err := s.AuditHistory(t.Context(), file.ID, 10, first.NextCursor)
@@ -129,7 +129,7 @@ func TestAuditHistoryPreservesTrashAndRestoreCoordinates(t *testing.T) {
 		Path: "@trash/known/Projects/Work", State: "trash",
 	}, *trashedPath.NewPath)
 
-	_, err = s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	_, _, err = s.Restore(t.Context(), trashed.ID, trashed.Revision)
 	require.NoError(t, err)
 	page, err = s.AuditHistory(t.Context(), work.ID, 10, "")
 	require.NoError(t, err)

--- a/internal/store/audit_node_move_test.go
+++ b/internal/store/audit_node_move_test.go
@@ -21,10 +21,11 @@ func TestAuditedInScopeMoveRecordsDescendantPathsAndRoundTrips(t *testing.T) {
 	projects, err := s.NodeByPath(t.Context(), "/Projects")
 	require.NoError(t, err)
 
-	moved, err := s.Move(
+	moved, movedPath, err := s.Move(
 		t.Context(), work.ID, archive.ID, "Renamed", work.Revision,
 	)
 	require.NoError(t, err)
+	assert.Equal(t, "/Projects/Archive/Renamed", movedPath)
 	assert.Equal(t, archive.ID, *moved.ParentID)
 	assert.Equal(t, "Renamed", moved.Name)
 	assert.Equal(t, work.Revision+1, moved.Revision)
@@ -79,7 +80,7 @@ func TestAuditedInScopeRenameRecordsOnePathEffect(t *testing.T) {
 	parent, err := s.NodeByPath(t.Context(), "/Projects")
 	require.NoError(t, err)
 
-	renamed, err := s.Move(t.Context(), file.ID, parent.ID, "renamed.txt", file.Revision)
+	renamed, _, err := s.Move(t.Context(), file.ID, parent.ID, "renamed.txt", file.Revision)
 	require.NoError(t, err)
 	assert.Equal(t, "renamed.txt", renamed.Name)
 	require.NoError(t, s.ValidateMetadata(t.Context()))
@@ -99,7 +100,7 @@ func TestAuditedRootScopeRenameHandlesRootTimestampTouch(t *testing.T) {
 	require.NoError(t, err)
 	seedInitialAuditAuthority(t, s, s.RootID())
 
-	renamed, err := s.Move(
+	renamed, _, err := s.Move(
 		t.Context(), empty.ID, s.RootID(), "RenamedEmpty", empty.Revision,
 	)
 	require.NoError(t, err)
@@ -125,7 +126,7 @@ func TestAuditedMoveRejectsRetainedTrashOriginPathChange(t *testing.T) {
 	require.NoError(t, err)
 	seedInitialAuditAuthority(t, s, s.RootID())
 
-	_, err = s.Move(
+	_, _, err = s.Move(
 		t.Context(), projects.ID, s.RootID(), "RenamedProjects", projects.Revision,
 	)
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
@@ -177,7 +178,7 @@ func TestAuditedMoveRefusesMembershipAndWitnessBoundaryCrossings(t *testing.T) {
 	empty, err := s.NodeByPath(t.Context(), "/Empty")
 	require.NoError(t, err)
 
-	_, err = s.Move(t.Context(), report.ID, empty.ID, report.Name, report.Revision)
+	_, _, err = s.Move(t.Context(), report.ID, empty.ID, report.Name, report.Revision)
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
 	unchanged, err := s.NodeByID(t.Context(), report.ID)
 	require.NoError(t, err)
@@ -187,7 +188,7 @@ func TestAuditedMoveRefusesMembershipAndWitnessBoundaryCrossings(t *testing.T) {
 	require.NoError(t, err)
 	projects, err := s.NodeByPath(t.Context(), "/Projects")
 	require.NoError(t, err)
-	movedOutside, err := s.Move(
+	movedOutside, _, err := s.Move(
 		t.Context(), outside.ID, projects.ID, outside.Name, outside.Revision,
 	)
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
@@ -205,7 +206,7 @@ func TestAuditedMoveRollsBackTreeAndHistory(t *testing.T) {
 		SELECT RAISE(ABORT, 'forced audit move failure'); END`)
 	require.NoError(t, err)
 
-	moved, err := s.Move(t.Context(), work.ID, archive.ID, "failed", work.Revision)
+	moved, _, err := s.Move(t.Context(), work.ID, archive.ID, "failed", work.Revision)
 	require.ErrorContains(t, err, "forced audit move failure")
 	assert.Zero(t, moved)
 	unchanged, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")

--- a/internal/store/audit_node_restore_test.go
+++ b/internal/store/audit_node_restore_test.go
@@ -21,8 +21,9 @@ func TestAuditedRestoreRecordsSubtreeAndRoundTrips(t *testing.T) {
 	trashed, _, err := s.Trash(t.Context(), work.ID, work.Revision)
 	require.NoError(t, err)
 
-	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	restored, restoredPath, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
 	require.NoError(t, err)
+	assert.Equal(t, "/Projects/Work", restoredPath)
 	assert.Nil(t, restored.TrashedAt)
 	assert.Equal(t, work.Revision+2, restored.Revision)
 	restoredChild, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
@@ -70,7 +71,7 @@ func TestAuditedRestoreUsesCanonicalConflictSuffix(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	restored, _, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
 	require.NoError(t, err)
 	assert.Equal(t, "report (2).txt", restored.Name)
 	stillReplacement, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
@@ -93,7 +94,7 @@ func TestAuditedRestoreAllowsUnchangedRetainedTrashOriginPath(t *testing.T) {
 	trashedWork, _, err := s.Trash(t.Context(), work.ID, work.Revision)
 	require.NoError(t, err)
 
-	restored, err := s.Restore(t.Context(), trashedWork.ID, trashedWork.Revision)
+	restored, _, err := s.Restore(t.Context(), trashedWork.ID, trashedWork.Revision)
 	require.NoError(t, err)
 	assert.Equal(t, "/Projects/Work", mustNodePath(t, s, restored.ID))
 	stillTrashed, err := s.NodeByID(t.Context(), child.ID)
@@ -117,7 +118,7 @@ func TestAuditedRestoreRejectsConflictThatRetargetsTrashOrigin(t *testing.T) {
 	_, err = s.Mkdir(t.Context(), projects.ID, "Work")
 	require.NoError(t, err)
 
-	restored, err := s.Restore(t.Context(), trashedWork.ID, trashedWork.Revision)
+	restored, _, err := s.Restore(t.Context(), trashedWork.ID, trashedWork.Revision)
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
 	require.ErrorContains(t, err, "retained trash-origin paths")
 	assert.Zero(t, restored)
@@ -140,7 +141,7 @@ func TestAuditedRootScopeRestoreRecordsRootParentTouch(t *testing.T) {
 	rootAfterTrash, err := s.NodeByID(t.Context(), s.RootID())
 	require.NoError(t, err)
 
-	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	restored, _, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
 	require.NoError(t, err)
 	assert.Equal(t, "/Empty", mustNodePath(t, s, restored.ID))
 	rootAfterRestore, err := s.NodeByID(t.Context(), s.RootID())
@@ -167,7 +168,7 @@ func TestAuditedRestoreRefusesFallbackFromTrashedOrigin(t *testing.T) {
 	_, _, err = s.Trash(t.Context(), empty.ID, empty.Revision)
 	require.NoError(t, err)
 
-	restored, err := s.Restore(t.Context(), trashedFile.ID, trashedFile.Revision)
+	restored, _, err := s.Restore(t.Context(), trashedFile.ID, trashedFile.Revision)
 	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
 	assert.Zero(t, restored)
 	stillTrashed, err := s.NodeByID(t.Context(), file.ID)
@@ -186,7 +187,7 @@ func TestAuditedRestoreRollsBackTreeAndHistory(t *testing.T) {
 		SELECT RAISE(ABORT, 'forced audit restore failure'); END`)
 	require.NoError(t, err)
 
-	restored, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	restored, _, err := s.Restore(t.Context(), trashed.ID, trashed.Revision)
 	require.ErrorContains(t, err, "forced audit restore failure")
 	assert.Zero(t, restored)
 	stillTrashed, err := s.NodeByID(t.Context(), work.ID)
@@ -210,7 +211,7 @@ func TestAuditedRestoreReplayRejectsOmittedDescendant(t *testing.T) {
 	require.NoError(t, err)
 	trashed, _, err := s.Trash(t.Context(), work.ID, work.Revision)
 	require.NoError(t, err)
-	_, err = s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	_, _, err = s.Restore(t.Context(), trashed.ID, trashed.Revision)
 	require.NoError(t, err)
 
 	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -121,7 +121,7 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	require.NoError(t, target.db.QueryRowContext(ctx,
 		`SELECT (SELECT COUNT(*) FROM blob_packs) + (SELECT COUNT(*) FROM blob_pack_index)`).Scan(&packRows))
 	assert.Zero(t, packRows, "physical pack authority is reconstructed separately")
-	restoredLostFile, err := target.Restore(ctx, lostFile.ID, UnconditionalRev)
+	restoredLostFile, _, err := target.Restore(ctx, lostFile.ID, UnconditionalRev)
 	require.NoError(t, err)
 	restoredLostPath, err := target.Path(ctx, restoredLostFile.ID)
 	require.NoError(t, err)

--- a/internal/store/move_test.go
+++ b/internal/store/move_test.go
@@ -17,17 +17,16 @@ func TestMoveRename(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pure rename.
-	renamed, err := s.Move(ctx, f.ID, docs.ID, "b.txt", -1)
+	renamed, renamedPath, err := s.Move(ctx, f.ID, docs.ID, "b.txt", -1)
 	require.NoError(t, err)
 	assert.Equal(t, "b.txt", renamed.Name)
 	assert.Equal(t, f.Revision+1, renamed.Revision)
+	assert.Equal(t, "/docs/b.txt", renamedPath)
 
 	// Reparent to root.
-	moved, err := s.Move(ctx, f.ID, s.RootID(), "b.txt", -1)
+	_, movedPath, err := s.Move(ctx, f.ID, s.RootID(), "b.txt", -1)
 	require.NoError(t, err)
-	p, err := s.Path(ctx, moved.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "/b.txt", p)
+	assert.Equal(t, "/b.txt", movedPath)
 }
 
 func TestMoveBumpsBothParents(t *testing.T) {
@@ -46,7 +45,7 @@ func TestMoveBumpsBothParents(t *testing.T) {
 	dstBefore, err := s.NodeByID(ctx, dst.ID)
 	require.NoError(t, err)
 
-	_, err = s.Move(ctx, f.ID, dst.ID, "a.txt", -1)
+	_, _, err = s.Move(ctx, f.ID, dst.ID, "a.txt", -1)
 	require.NoError(t, err)
 
 	srcAfter, err := s.NodeByID(ctx, src.ID)
@@ -67,25 +66,25 @@ func TestMoveRejectsCycleCollisionRoot(t *testing.T) {
 	require.NoError(t, err)
 
 	// Cycle: a under its own child b; and a under itself.
-	_, err = s.Move(ctx, a.ID, b.ID, "a", -1)
+	_, _, err = s.Move(ctx, a.ID, b.ID, "a", -1)
 	require.ErrorIs(t, err, ErrCycle)
-	_, err = s.Move(ctx, a.ID, a.ID, "a", -1)
+	_, _, err = s.Move(ctx, a.ID, a.ID, "a", -1)
 	require.ErrorIs(t, err, ErrCycle)
 
 	// Collision at destination.
 	_, err = s.Mkdir(ctx, s.RootID(), "b")
 	require.NoError(t, err)
-	_, err = s.Move(ctx, b.ID, s.RootID(), "b", -1)
+	_, _, err = s.Move(ctx, b.ID, s.RootID(), "b", -1)
 	require.ErrorIs(t, err, ErrExists)
 
 	// Root cannot move.
-	_, err = s.Move(ctx, s.RootID(), a.ID, "root", -1)
+	_, _, err = s.Move(ctx, s.RootID(), a.ID, "root", -1)
 	require.ErrorIs(t, err, ErrIsRoot)
 
 	// Destination must be a live dir.
 	f, err := s.CreateFile(ctx, s.RootID(), "f.txt", fakeHash("a1"), 1, "text/plain")
 	require.NoError(t, err)
-	_, err = s.Move(ctx, b.ID, f.ID, "b", -1)
+	_, _, err = s.Move(ctx, b.ID, f.ID, "b", -1)
 	assert.ErrorIs(t, err, ErrNotDir)
 }
 
@@ -94,7 +93,7 @@ func TestMoveRejectsMissingOrTrashedSource(t *testing.T) {
 	ctx := t.Context()
 
 	// Nonexistent node id.
-	_, err := s.Move(ctx, 999999, s.RootID(), "nope", -1)
+	_, _, err := s.Move(ctx, 999999, s.RootID(), "nope", -1)
 	require.ErrorIs(t, err, ErrNotFound)
 
 	// Trashed source node.
@@ -102,7 +101,7 @@ func TestMoveRejectsMissingOrTrashedSource(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = s.Trash(ctx, f.ID, -1)
 	require.NoError(t, err)
-	_, err = s.Move(ctx, f.ID, s.RootID(), "b.txt", -1)
+	_, _, err = s.Move(ctx, f.ID, s.RootID(), "b.txt", -1)
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
@@ -118,34 +117,33 @@ func TestMovePath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Non-existing dest path: parent + basename = rename.
-	moved, err := s.MovePath(ctx, "/docs/a.txt", "/docs/b.txt")
+	moved, movedPath, err := s.MovePath(ctx, "/docs/a.txt", "/docs/b.txt")
 	require.NoError(t, err)
 	assert.Equal(t, f.ID, moved.ID)
 	assert.Equal(t, "b.txt", moved.Name)
+	assert.Equal(t, "/docs/b.txt", movedPath)
 
 	// Dest is an existing dir: move into, keep name.
-	moved, err = s.MovePath(ctx, "/docs/b.txt", "/filed")
+	_, movedPath, err = s.MovePath(ctx, "/docs/b.txt", "/filed")
 	require.NoError(t, err)
-	p, err := s.Path(ctx, moved.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "/filed/b.txt", p)
+	assert.Equal(t, "/filed/b.txt", movedPath)
 
 	// Dest exists and is a file: refused.
 	_, err = s.CreateFile(ctx, docs.ID, "c.txt", fakeHash("c1"), 1, "text/plain")
 	require.NoError(t, err)
-	_, err = s.MovePath(ctx, "/filed/b.txt", "/docs/c.txt")
+	_, _, err = s.MovePath(ctx, "/filed/b.txt", "/docs/c.txt")
 	require.ErrorIs(t, err, ErrExists)
 
 	// Missing source, missing dest parent, root source, cycle.
-	_, err = s.MovePath(ctx, "/nope", "/docs/x")
+	_, _, err = s.MovePath(ctx, "/nope", "/docs/x")
 	require.ErrorIs(t, err, ErrNotFound)
-	_, err = s.MovePath(ctx, "/filed/b.txt", "/nope/x")
+	_, _, err = s.MovePath(ctx, "/filed/b.txt", "/nope/x")
 	require.ErrorIs(t, err, ErrNotFound)
-	_, err = s.MovePath(ctx, "/", "/docs")
+	_, _, err = s.MovePath(ctx, "/", "/docs")
 	require.ErrorIs(t, err, ErrIsRoot)
 	_, err = s.Mkdir(ctx, docs.ID, "sub")
 	require.NoError(t, err)
-	_, err = s.MovePath(ctx, "/docs", "/docs/sub")
+	_, _, err = s.MovePath(ctx, "/docs", "/docs/sub")
 	assert.ErrorIs(t, err, ErrCycle)
 }
 
@@ -161,14 +159,14 @@ func TestMovePathRejectsDotSegments(t *testing.T) {
 	// path.Dir semantics would Clean "/missing/../renamed" into a rename at
 	// the root; virtual paths have no dot segments, so this must be
 	// rejected outright and nothing may land at /renamed.
-	_, err = s.MovePath(ctx, "/docs/a.txt", "/missing/../renamed")
+	_, _, err = s.MovePath(ctx, "/docs/a.txt", "/missing/../renamed")
 	require.ErrorIs(t, err, ErrInvalidName)
 	_, err = s.NodeByPath(ctx, "/renamed")
 	require.ErrorIs(t, err, ErrNotFound)
 
-	_, err = s.MovePath(ctx, "/docs/a.txt", "/docs/..")
+	_, _, err = s.MovePath(ctx, "/docs/a.txt", "/docs/..")
 	require.ErrorIs(t, err, ErrInvalidName)
-	_, err = s.MovePath(ctx, "/docs/a.txt", "/docs/.")
+	_, _, err = s.MovePath(ctx, "/docs/a.txt", "/docs/.")
 	require.ErrorIs(t, err, ErrInvalidName)
 
 	// The file never moved.

--- a/internal/store/revision_test.go
+++ b/internal/store/revision_test.go
@@ -15,7 +15,7 @@ func TestStaleRevisionRejected(t *testing.T) {
 	f, err := s.CreateFile(ctx, s.RootID(), "f.txt", fakeHash("a1"), 1, "text/plain")
 	require.NoError(t, err)
 
-	_, err = s.Move(ctx, f.ID, d.ID, "f.txt", f.Revision+1)
+	_, _, err = s.Move(ctx, f.ID, d.ID, "f.txt", f.Revision+1)
 	require.ErrorIs(t, err, ErrStaleRevision)
 	_, _, err = s.Trash(ctx, f.ID, f.Revision+1)
 	require.ErrorIs(t, err, ErrStaleRevision)
@@ -28,9 +28,9 @@ func TestStaleRevisionRejected(t *testing.T) {
 	trashed, _, err := s.Trash(ctx, f.ID, f.Revision)
 	require.NoError(t, err)
 	assert.NotNil(t, trashed.TrashedAt)
-	_, err = s.Restore(ctx, f.ID, trashed.Revision+1)
+	_, _, err = s.Restore(ctx, f.ID, trashed.Revision+1)
 	require.ErrorIs(t, err, ErrStaleRevision)
-	_, err = s.Restore(ctx, f.ID, trashed.Revision)
+	_, _, err = s.Restore(ctx, f.ID, trashed.Revision)
 	require.NoError(t, err)
 }
 
@@ -39,7 +39,7 @@ func TestNegativeRevisionSkipsCheck(t *testing.T) {
 	ctx := t.Context()
 	f, err := s.CreateFile(ctx, s.RootID(), "f.txt", fakeHash("a1"), 1, "text/plain")
 	require.NoError(t, err)
-	_, err = s.Move(ctx, f.ID, s.RootID(), "g.txt", UnconditionalRev)
+	_, _, err = s.Move(ctx, f.ID, s.RootID(), "g.txt", UnconditionalRev)
 	require.NoError(t, err)
 }
 
@@ -52,7 +52,7 @@ func TestBelowSentinelRevisionFailsStale(t *testing.T) {
 	f, err := s.CreateFile(ctx, s.RootID(), "f.txt", fakeHash("a1"), 1, "text/plain")
 	require.NoError(t, err)
 
-	_, err = s.Move(ctx, f.ID, s.RootID(), "g.txt", -2)
+	_, _, err = s.Move(ctx, f.ID, s.RootID(), "g.txt", -2)
 	require.ErrorIs(t, err, ErrStaleRevision)
 	_, _, err = s.Trash(ctx, f.ID, -2)
 	require.ErrorIs(t, err, ErrStaleRevision)
@@ -63,8 +63,8 @@ func TestBelowSentinelRevisionFailsStale(t *testing.T) {
 
 	trashed, _, err := s.Trash(ctx, f.ID, f.Revision)
 	require.NoError(t, err)
-	_, err = s.Restore(ctx, f.ID, -2)
+	_, _, err = s.Restore(ctx, f.ID, -2)
 	require.ErrorIs(t, err, ErrStaleRevision)
-	_, err = s.Restore(ctx, f.ID, trashed.Revision)
+	_, _, err = s.Restore(ctx, f.ID, trashed.Revision)
 	require.NoError(t, err)
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -39,7 +39,7 @@ func TestSearchPrefixAndRename(t *testing.T) {
 	require.Len(t, hits, 1)
 
 	// Rename must update the index (FTS triggers).
-	_, err = s.Move(ctx, f.ID, s.RootID(), "car-policy.pdf", -1)
+	_, _, err = s.Move(ctx, f.ID, s.RootID(), "car-policy.pdf", -1)
 	require.NoError(t, err)
 	hits, _, err = s.SearchPage(ctx, "insur", 0)
 	require.NoError(t, err)

--- a/internal/store/tag_test.go
+++ b/internal/store/tag_test.go
@@ -196,7 +196,7 @@ func TestTagAssignmentPathUsesCurrentTopology(t *testing.T) {
 
 	left, err = s.NodeByID(ctx, left.ID)
 	require.NoError(t, err)
-	_, err = s.Move(ctx, left.ID, right.ID, "moved", left.Revision)
+	_, _, err = s.Move(ctx, left.ID, right.ID, "moved", left.Revision)
 	require.NoError(t, err)
 	unchangedLeaf, err := s.NodeByID(ctx, leaf.ID)
 	require.NoError(t, err)

--- a/internal/store/trash.go
+++ b/internal/store/trash.go
@@ -149,9 +149,11 @@ func nextFreeNameTx(tx *sql.Tx, parentID int64, name string) (string, error) {
 // that location is gone), re-suffixing on conflict. Descendants trashed in
 // earlier separate operations stay trashed. Unless ifRev is
 // UnconditionalRev, the mutation fails with ErrStaleRevision unless ifRev
-// matches the node's current revision.
-func (s *Store) Restore(ctx context.Context, id, ifRev int64) (Node, error) {
+// matches the node's current revision. The returned canonical path is captured
+// in the restore transaction with the returned node.
+func (s *Store) Restore(ctx context.Context, id, ifRev int64) (Node, string, error) {
 	var restored Node
+	var restoredPath string
 	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		n, err := nodeByIDTx(tx, id)
 		if err != nil {
@@ -163,26 +165,29 @@ func (s *Store) Restore(ctx context.Context, id, ifRev int64) (Node, error) {
 		}
 		if active {
 			restored, err = s.restoreAuditedTx(ctx, tx, n, ifRev)
-			return err
+		} else {
+			if n.TrashedAt == nil {
+				return fmt.Errorf("node %d: %w", id, ErrNotTrashed)
+			}
+			if ifRev != UnconditionalRev && n.Revision != ifRev {
+				return fmt.Errorf("node %d at revision %d, expected %d: %w",
+					id, n.Revision, ifRev, ErrStaleRevision)
+			}
+			target, targetErr := s.restoreTargetTx(tx, n)
+			if targetErr != nil {
+				return targetErr
+			}
+			restored, err = s.restoreNodeTx(tx, n, target, nowRFC3339())
 		}
-		if n.TrashedAt == nil {
-			return fmt.Errorf("node %d: %w", id, ErrNotTrashed)
+		if err == nil {
+			restoredPath, err = pathOf(ctx, tx, restored.ID)
 		}
-		if ifRev != UnconditionalRev && n.Revision != ifRev {
-			return fmt.Errorf("node %d at revision %d, expected %d: %w",
-				id, n.Revision, ifRev, ErrStaleRevision)
-		}
-		target, err := s.restoreTargetTx(tx, n)
-		if err != nil {
-			return err
-		}
-		restored, err = s.restoreNodeTx(tx, n, target, nowRFC3339())
 		return err
 	})
 	if err != nil {
-		return Node{}, err
+		return Node{}, "", err
 	}
-	return restored, nil
+	return restored, restoredPath, nil
 }
 
 type restoreTarget struct {

--- a/internal/store/trash_test.go
+++ b/internal/store/trash_test.go
@@ -33,8 +33,9 @@ func TestTrashAndRestoreRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Restore re-suffixes because /docs is taken again.
-	restored, err := s.Restore(ctx, docs.ID, -1)
+	restored, restoredPath, err := s.Restore(ctx, docs.ID, -1)
 	require.NoError(t, err)
+	assert.Equal(t, "/docs (2)", restoredPath)
 	assert.Equal(t, "docs (2)", restored.Name)
 	assert.Nil(t, restored.TrashedAt)
 
@@ -59,13 +60,13 @@ func TestNestedTrashRestoreKeepsEarlierTrash(t *testing.T) {
 	require.NoError(t, err)
 
 	// Restoring docs must NOT resurrect inner.
-	_, err = s.Restore(ctx, docs.ID, -1)
+	_, _, err = s.Restore(ctx, docs.ID, -1)
 	require.NoError(t, err)
 	_, err = s.NodeByPath(ctx, "/docs/inner")
 	require.ErrorIs(t, err, ErrNotFound)
 
 	// inner is still restorable on its own.
-	_, err = s.Restore(ctx, inner.ID, -1)
+	_, _, err = s.Restore(ctx, inner.ID, -1)
 	require.NoError(t, err)
 	_, err = s.NodeByPath(ctx, "/docs/inner")
 	require.NoError(t, err)
@@ -95,7 +96,7 @@ func TestRestoreFallsBackToRootWhenParentGone(t *testing.T) {
 	require.NoError(t, err)
 	deleteTrashRoot(t, s, docs.ID)
 
-	restored, err := s.Restore(ctx, f.ID, -1)
+	restored, _, err := s.Restore(ctx, f.ID, -1)
 	require.NoError(t, err)
 	p, err := s.Path(ctx, restored.ID)
 	require.NoError(t, err)
@@ -123,7 +124,7 @@ func TestTrashGuards(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = s.Trash(ctx, inner.ID, -1)
 	require.NoError(t, err)
-	_, err = s.Restore(ctx, leaf.ID, -1)
+	_, _, err = s.Restore(ctx, leaf.ID, -1)
 	assert.ErrorIs(t, err, ErrNotTrashed)
 }
 
@@ -281,7 +282,7 @@ func TestRestoreAfterParentHardDeleteNeverRetargets(t *testing.T) {
 	require.NoError(t, err)
 	d, err := s.Mkdir(ctx, s.RootID(), "D")
 	require.NoError(t, err)
-	_, err = s.Move(ctx, f.ID, d.ID, "f.txt", -1)
+	_, _, err = s.Move(ctx, f.ID, d.ID, "f.txt", -1)
 	require.NoError(t, err)
 
 	_, _, err = s.Trash(ctx, f.ID, -1) // records trash_parent = D
@@ -296,7 +297,7 @@ func TestRestoreAfterParentHardDeleteNeverRetargets(t *testing.T) {
 
 	// The original parent is gone: restore must fall back to the root, not
 	// land inside an unrelated directory occupying a reused id.
-	restored, err := s.Restore(ctx, f.ID, -1)
+	restored, _, err := s.Restore(ctx, f.ID, -1)
 	require.NoError(t, err)
 	p, err := s.Path(ctx, restored.ID)
 	require.NoError(t, err)

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -333,9 +333,13 @@ func isAncestorTx(tx *sql.Tx, maybeAncestor, candidate int64) (bool, error) {
 
 // Move renames and/or reparents a live node in one transaction. Unless
 // ifRev is UnconditionalRev, the mutation fails with ErrStaleRevision
-// unless ifRev matches the node's current revision.
-func (s *Store) Move(ctx context.Context, id, newParentID int64, newName string, ifRev int64) (Node, error) {
+// unless ifRev matches the node's current revision. The returned canonical
+// path is captured in the mutation transaction with the returned node.
+func (s *Store) Move(
+	ctx context.Context, id, newParentID int64, newName string, ifRev int64,
+) (Node, string, error) {
 	var moved Node
+	var movedPath string
 	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		var err error
 		active, err := auditAuthorityActiveTx(ctx, tx)
@@ -344,24 +348,29 @@ func (s *Store) Move(ctx context.Context, id, newParentID int64, newName string,
 		}
 		if active {
 			moved, err = s.moveAuditedTx(ctx, tx, id, newParentID, newName, ifRev)
-			return err
+		} else {
+			moved, err = s.moveTx(tx, id, newParentID, newName, ifRev)
 		}
-		moved, err = s.moveTx(tx, id, newParentID, newName, ifRev)
+		if err == nil {
+			movedPath, err = pathOf(ctx, tx, moved.ID)
+		}
 		return err
 	})
 	if err != nil {
-		return Node{}, err
+		return Node{}, "", err
 	}
-	return moved, nil
+	return moved, movedPath, nil
 }
 
 // MovePath resolves srcPath and destPath and moves inside one transaction,
 // so a concurrent operation cannot relocate either path between resolution
 // and mutation. A destPath naming an existing live directory means "move
 // into, keep name"; otherwise its parent must exist and its basename becomes
-// the new name.
-func (s *Store) MovePath(ctx context.Context, srcPath, destPath string) (Node, error) {
+// the new name. The returned canonical path is captured in the mutation
+// transaction with the returned node.
+func (s *Store) MovePath(ctx context.Context, srcPath, destPath string) (Node, string, error) {
 	var moved Node
+	var movedPath string
 	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		src, err := nodeByPath(ctx, tx, s.rootID, srcPath)
 		if err != nil {
@@ -382,15 +391,18 @@ func (s *Store) MovePath(ctx context.Context, srcPath, destPath string) (Node, e
 			moved, err = s.moveAuditedTx(
 				ctx, tx, src.ID, newParentID, newName, UnconditionalRev,
 			)
-			return err
+		} else {
+			moved, err = s.moveTx(tx, src.ID, newParentID, newName, UnconditionalRev)
 		}
-		moved, err = s.moveTx(tx, src.ID, newParentID, newName, UnconditionalRev)
+		if err == nil {
+			movedPath, err = pathOf(ctx, tx, moved.ID)
+		}
 		return err
 	})
 	if err != nil {
-		return Node{}, err
+		return Node{}, "", err
 	}
-	return moved, nil
+	return moved, movedPath, nil
 }
 
 func (s *Store) resolveMoveTargetTx(


### PR DESCRIPTION
Docbank’s older tree commands now have structured reads and stable exit codes, but a shell workflow still loses that structure as soon as it changes the tree. Moving, trashing, or restoring a document returns only prose, forcing callers to scrape out the stable node ID or perform another lookup for the resulting revision and path.

This PR adds `--json` to `mv`, `rm`, and `restore`. Each command returns the complete `api.Node` receipt it already receives from the daemon, while its existing human output remains unchanged. A script can therefore carry one stable identity and revision through the full lifecycle without a second request or a new receipt format.

Those receipts are bound to the mutation that produced them. Move and restore now capture the resulting node and canonical path together inside the committing store transaction, so a concurrent follow-up move cannot make the earlier command report a later revision or combine a node and path from different states.

Trash has an important boundary: its receipt includes the pre-trash path to explain where restoration will try to place the node, but that path stops resolving as soon as the trash operation commits. The CLI and agent documentation explicitly direct callers to treat that path as recovery context and retain the node ID and revision as authority.

The HTTP contract, daemon protocol, and storage schema are unchanged. End-to-end coverage follows one stable node through rename, trash, and restore, including competing mutations at the commit boundary.

Kata: cp86.
