### PR TITLE
Lead with Docbank's agent-ready contract

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: docbank
+title: Keep the documents. Change the filing system.
 description: Local-first document system of record for people and agents, with stable identities, verified bytes, revision-safe automation, and proven recovery.
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ Docbank makes those questions part of the product contract.
   </section>
   <section>
     <h3>Operations made for automation</h3>
-    <p>OpenAPI, JSON output, bounded reads, structured errors, dry runs, progress events, audit evidence, and verified backups replace prose scraping.</p>
+    <p>OpenAPI, JSON output, bounded reads, structured errors, dry runs, progress events, and verified backups replace prose scraping.</p>
   </section>
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,58 @@
 ---
 title: docbank
-description: Local-first document archive with immutable content, flexible organization, verified backup and recovery, and an agent-ready HTTP API.
+description: Local-first document system of record for people and agents, with stable identities, verified bytes, revision-safe automation, and proven recovery.
 ---
 
-<p class="eyebrow">LOCAL-FIRST DOCUMENT ARCHIVE</p>
+<p class="eyebrow">LOCAL-FIRST DOCUMENT SYSTEM OF RECORD</p>
 
 # Keep the documents. Change the filing system.
 
-A permanent, verifiable home for the PDFs, scans, notes, spreadsheets, and
-records you keep for life — on your own machine, in a layout you can
-inspect and prove. Content is immutable and deduplicated; the tree above it
-is yours to reshape. Use docbank as a daily archive, or embed it as the
-document store inside your own Go systems.
+Docbank gives people and agents one trustworthy place to work with documents.
+People get a permanent, verifiable home for the PDFs, scans, notes,
+spreadsheets, and records they keep for life. Agents get an authenticated
+contract with stable identities, verified bytes, conflict-safe mutations, and
+explicit lifecycle controls — without opening SQLite or interpreting a storage
+directory. Content is immutable and deduplicated; the virtual tree above it is
+yours to reshape. Run a personal archive, connect an agent over HTTP, or embed
+independently rooted vaults inside a Go system.
 
 <p class="hero-actions">
   <a class="md-button md-button--primary" href="setup/">Start your archive</a>
-  <a class="md-button" href="embedding/">Embed in your system</a>
-  <a class="md-button" href="agents/">For agents</a>
+  <a class="md-button" href="agents/">Build agent workflows</a>
+  <a class="md-button" href="embedding/">Embed in Go</a>
 </p>
+
+## Built for people. Ready for agents.
+
+An agent needs more than permission to read and write a folder. It needs to
+know which document it acted on, whether the bytes are exact, whether its view
+became stale, and what a destructive operation would do before it runs.
+Docbank makes those questions part of the product contract.
+
+<div class="feature-grid">
+  <section>
+    <h3>Identity that survives reorganization</h3>
+    <p>Stable node IDs survive moves and renames. Every immutable content version has its own UUID, SHA-256 identity, and size.</p>
+  </section>
+  <section>
+    <h3>Bytes proven, not assumed</h3>
+    <p>Remote writes declare hash and size. Reads carry recorded content authority plus a digest computed while streaming.</p>
+  </section>
+  <section>
+    <h3>Mutations that detect stale decisions</h3>
+    <p>Revisions and <code>If-Match</code> turn conflicting read-modify-write work into an explicit response instead of a silent overwrite.</p>
+  </section>
+  <section>
+    <h3>Operations made for automation</h3>
+    <p>OpenAPI, JSON output, bounded reads, structured errors, dry runs, progress events, audit evidence, and verified backups replace prose scraping.</p>
+  </section>
+</div>
+
+The CLI is a client of the same authenticated loopback API exposed to agents;
+it has no privileged shortcut into the vault. Generate the live contract with
+`docbank openapi --json`, read [Docbank for Agents](agents.md), or follow the
+[Agent Integration Guide](agents/integration.md) through a complete verified
+filing workflow.
 
 Install with one command (Linux and macOS; see [Setup](setup.md) for
 Windows and source builds):

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,11 +1,11 @@
 # docbank
 
-> Local-first document archive with immutable content, flexible organization, verified backup and recovery, and an agent-ready HTTP API.
+> Local-first document system of record for people and agents, with stable identities, verified bytes, revision-safe automation, and proven recovery.
 
 Every documentation page is also published as raw Markdown at the same path with a `.md` suffix; the links below point at those Markdown routes.
 
 ## Overview
-- [docbank](https://docbank.ai/index.md): Local-first document archive with immutable content, flexible organization, verified backup and recovery, and an agent-ready HTTP API.
+- [docbank](https://docbank.ai/index.md): Local-first document system of record for people and agents, with stable identities, verified bytes, revision-safe automation, and proven recovery.
 
 ## Start Here
 - [Setup](https://docbank.ai/setup.md): Install docbank on Linux, macOS, or Windows and create the vault.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,7 +5,7 @@
 Every documentation page is also published as raw Markdown at the same path with a `.md` suffix; the links below point at those Markdown routes.
 
 ## Overview
-- [docbank](https://docbank.ai/index.md): Local-first document system of record for people and agents, with stable identities, verified bytes, revision-safe automation, and proven recovery.
+- [Keep the documents. Change the filing system.](https://docbank.ai/index.md): Local-first document system of record for people and agents, with stable identities, verified bytes, revision-safe automation, and proven recovery.
 
 ## Start Here
 - [Setup](https://docbank.ai/setup.md): Install docbank on Linux, macOS, or Windows and create the vault.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "docbank"
-site_description = "Local-first document archive with immutable content, flexible organization, verified backup and recovery, and an agent-ready HTTP API."
+site_description = "Local-first document system of record for people and agents, with stable identities, verified bytes, revision-safe automation, and proven recovery."
 site_author = "Kenn Software LLC"
 copyright = 'Copyright &copy; 2026 <a href="https://kenn.io">Kenn Software LLC</a>.'
 docs_dir = "docs"


### PR DESCRIPTION
The homepage says Docbank has an agent-ready API, but until now it made a visitor infer why that matters from a button and material much farther down the page. That makes a foundational product capability look like an integration added after the archive was designed.

This change leads with Docbank as one trustworthy document authority for people and agents. It names the concrete guarantees an automated collaborator can rely on: identities that survive reorganization, bytes that are verified rather than assumed, revisions that expose stale decisions, and structured operations with explicit lifecycle controls. It also makes clear that the CLI uses the same authenticated API instead of a privileged database shortcut.

The human ownership and permanent-archive story remains intact, and standalone HTTP use and embedded Go use remain equally visible. Site metadata and the machine-readable documentation index now carry the same positioning. The homepage headline is also its page title, so browser tabs and link previews say “Keep the documents. Change the filing system. — docbank” instead of the accidental “docbank — docbank.”

The generated site passes its strict source and output validation, and the repository checks remain green.

Kata: ghcf.