### PR TITLE
Put agents in Docbank's first sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@
 > **Alpha software.** Docbank is pre-1.0. Keep independent copies of
 > irreplaceable material and verify backups before relying on them.
 
-**Keep the documents. Change the filing system.**
+**Your documents. Your agents. One system.**
 
-Docbank is a local-first archive for the PDFs, scans, notes, spreadsheets,
-and records you keep for life. Content is immutable and deduplicated under
-one logical SHA-256 identity, stored loose or in managed packs; above it, a
-virtual tree in SQLite supplies names and paths that can be reorganized
-without rewriting content. Documentation lives at
-[docbank.ai](https://docbank.ai).
+Docbank gives you and your agents one authoritative place to file, find,
+organize, version, and verify the PDFs, scans, notes, spreadsheets, and records
+you depend on. You keep the authority: the vault and its history live on your
+own machine rather than inside a provider account. Content is immutable and
+deduplicated under one logical SHA-256 identity, while stable document IDs and
+a virtual tree let people and agents reorganize the archive without losing
+track of anything. Documentation lives at [docbank.ai](https://docbank.ai).
 
 ## Why docbank?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,20 @@
 ---
-title: Your documents. Your system.
-description: Docbank is a self-sovereign document system for people and agents, with indexed retrieval, stable identity, verifiable content, incremental recovery, and audited history.
+title: Your documents. Your agents. One system.
+description: Docbank is a self-sovereign document storage system for you and your agents, with indexed retrieval, stable identity, verifiable content, incremental recovery, and audited history.
 ---
 
-<p class="eyebrow">A SELF-SOVEREIGN DOCUMENT SYSTEM</p>
+<p class="eyebrow">DOCUMENT STORAGE FOR YOU AND YOUR AGENTS</p>
 
-# Your documents. Your system.
+# Your documents. Your agents. One system.
 
-Docbank gives you one authoritative place to file, find, version, verify, and
-automate the documents you depend on. The vault and its history live on your
-own machine rather than inside a provider account. Documents keep stable
-identities as you reorganize them, every stored byte can be checked, and
-incremental backups can be verified before you rely on them. Use it for records
-you keep for decades and for working documents that people and agents organize
-every day, from the CLI, through the authenticated HTTP API, or inside a Go
-application.
+Docbank gives you and your agents one authoritative place to file, find,
+organize, version, and verify the documents you depend on. You keep the
+authority: the vault and its history live on your own machine rather than
+inside a provider account. Stable identities let people and agents reorganize
+documents without losing track of them, every stored byte can be checked, and
+incremental backups can be verified before you rely on them. Work directly
+from the CLI, automate through the authenticated HTTP API, or embed Docbank in
+a Go application.
 
 <p class="hero-actions">
   <a class="md-button md-button--primary" href="setup/">Start your vault</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,7 +5,7 @@
 Every documentation page is also published as raw Markdown at the same path with a `.md` suffix; the links below point at those Markdown routes.
 
 ## Overview
-- [Your documents. Your system.](https://docbank.ai/index.md): Docbank is a self-sovereign document system for people and agents, with indexed retrieval, stable identity, verifiable content, incremental recovery, and audited history.
+- [Your documents. Your agents. One system.](https://docbank.ai/index.md): Docbank is a self-sovereign document storage system for you and your agents, with indexed retrieval, stable identity, verifiable content, incremental recovery, and audited history.
 
 ## Start Here
 - [Setup](https://docbank.ai/setup.md): Install docbank on Linux, macOS, or Windows and create the vault.


### PR DESCRIPTION
Docbank is storage for a person and the agents working with them, but the two most important entry points still made that audience something readers had to infer. The repository opened as a local archive, while the documentation homepage mentioned agents only after its broader system framing.

This gives the README and docbank.ai one shared opening promise: **Your documents. Your agents. One system.** Both now explain immediately that people and agents share one self-owned document authority, with stable identities, verifiable bytes, and recovery that stays under the operator’s control. The existing standalone CLI/API and embedded Go choices remain intact; this changes the presentation, not the product contract.

The machine-readable documentation index carries the same title and description, so humans, agents, search results, and link previews all receive the same account of what Docbank is. The strict documentation build passes.

Kata: `0xq0`.