### PR TITLE
Make social previews use the current homepage message

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if page.meta and page.meta.title %}
+    {% set social_title = page.meta.title %}
+  {% elif page.title %}
+    {% set social_title = page.title | striptags %}
+  {% else %}
+    {% set social_title = config.site_name %}
+  {% endif %}
+  {% if page.meta and page.meta.description %}
+    {% set social_description = page.meta.description %}
+  {% else %}
+    {% set social_description = config.site_description %}
+  {% endif %}
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{ social_title }}">
+  <meta property="og:description" content="{{ social_description }}">
+  {% if page.canonical_url %}
+    <meta property="og:url" content="{{ page.canonical_url }}">
+  {% else %}
+    <meta property="og:url" content="{{ config.site_url }}">
+  {% endif %}
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ social_title }}">
+  <meta name="twitter:description" content="{{ social_description }}">
+{% endblock %}

--- a/docs/scripts/check_built_site.py
+++ b/docs/scripts/check_built_site.py
@@ -12,6 +12,7 @@ class PageParser(html.parser.HTMLParser):
         super().__init__()
         self.title = False
         self.description = False
+        self.metadata: dict[str, str] = {}
         self.urls: list[str] = []
         self.anchors: set[str] = set()
 
@@ -19,8 +20,12 @@ class PageParser(html.parser.HTMLParser):
         values = {key: value or "" for key, value in attrs}
         if tag == "title":
             self.title = True
-        if tag == "meta" and values.get("name") == "description" and values.get("content"):
-            self.description = True
+        if tag == "meta" and values.get("content"):
+            key = values.get("property") or values.get("name")
+            if key:
+                self.metadata[key] = values["content"]
+            if values.get("name") == "description":
+                self.description = True
         if values.get("id"):
             self.anchors.add(values["id"])
         if tag == "a" and values.get("name"):
@@ -70,7 +75,15 @@ def main() -> None:
     pages = sorted(site.rglob("*.html"))
     if not pages:
         errors.append(f"no HTML pages built under {site}")
-    forbidden = {"internal", "superpowers", "scripts", "zensical.toml", "pyproject.toml", "uv.lock"}
+    forbidden = {
+        "internal",
+        "overrides",
+        "superpowers",
+        "scripts",
+        "zensical.toml",
+        "pyproject.toml",
+        "uv.lock",
+    }
     for path in site.rglob("*"):
         if forbidden.intersection(path.relative_to(site).parts):
             errors.append(f"publishing boundary leaked {path.relative_to(site)}")
@@ -88,6 +101,31 @@ def main() -> None:
             errors.append(f"{rel}: missing title")
         if not parser.description:
             errors.append(f"{rel}: missing meta description")
+        for key in (
+            "og:title",
+            "og:description",
+            "og:type",
+            "og:url",
+            "og:site_name",
+            "twitter:card",
+            "twitter:title",
+            "twitter:description",
+        ):
+            if not parser.metadata.get(key):
+                errors.append(f"{rel}: missing {key} metadata")
+        if parser.metadata.get("og:description") != parser.metadata.get("description"):
+            errors.append(f"{rel}: Open Graph description differs from page description")
+        for field in ("title", "description"):
+            if parser.metadata.get(f"twitter:{field}") != parser.metadata.get(
+                f"og:{field}"
+            ):
+                errors.append(f"{rel}: Twitter {field} differs from Open Graph {field}")
+        if (
+            rel == pathlib.Path("index.html")
+            and parser.metadata.get("og:title")
+            != "Your documents. Your agents. One system."
+        ):
+            errors.append("index.html: social title differs from the homepage message")
         for raw in parser.urls:
             local = local_target(site, page, raw)
             if local is None:

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -93,6 +93,7 @@ tar_excludes=(
   --exclude './.env'
   --exclude './.env.*'
   --exclude './internal'
+  --exclude './overrides'
   --exclude './scripts'
   --exclude './site'
   --exclude './zensical-site.*'

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -1,5 +1,6 @@
 [project]
 site_name = "docbank"
+site_url = "https://www.docbank.ai/"
 site_description = "Docbank is a self-sovereign document system for people and agents, with indexed retrieval, stable identity, verifiable content, incremental recovery, and audited history."
 site_author = "Kenn Software LLC"
 copyright = 'Copyright &copy; 2026 <a href="https://kenn.io">Kenn Software LLC</a>.'
@@ -59,6 +60,7 @@ homepage = "/"
 
 [project.theme]
 variant = "modern"
+custom_dir = "overrides"
 features = [
   "navigation.instant",
   "navigation.instant.progress",


### PR DESCRIPTION
Sharing docbank.ai will now present “Your documents. Your agents. One system.” with the same self-sovereign document-system description used by the homepage.

The current Vercel production deployment is healthy and serves the new page title, but its HTML contains no Open Graph or Twitter metadata. Share clients therefore fall back to historical cached titles, including “Keep the documents. Change the filing system.” Explicit social fields give crawlers a canonical current answer instead of relying on that fallback.

Social titles and descriptions are derived from each page’s existing metadata, and the canonical URL follows the production www.docbank.ai redirect. The strict docs build now rejects missing fields, disagreement between Open Graph and Twitter descriptions, or a homepage social title that diverges from the public headline. The generated homepage was inspected locally and emits the intended title, description, and canonical URL.