### PR TITLE
Search verified plain-text document contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Four commitments:
   per-node history, independent chain/protected-byte verification, exact-prefix
   checks against externally recorded evidence, and backup/restore fidelity
 - FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
+  (body search is available from source until the next tagged release)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification
 - Incremental backup repositories with create, list, verify, and confined restore

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Four commitments:
   sticky retention, recorded supported mutations, status evidence, bounded
   per-node history, independent chain/protected-byte verification, exact-prefix
   checks against externally recorded evidence, and backup/restore fidelity
-- FTS5 name search (document-body extraction and search are planned)
+- FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification
 - Incremental backup repositories with create, list, verify, and confined restore

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -538,20 +538,23 @@ func TestJobsShowsDaemonStatus(t *testing.T) {
 	_ = setupVaultHome(t)
 	out, err := runCLI(t, "jobs")
 	require.NoError(t, err)
-	assert.Equal(t, "no background jobs\n", out)
+	assert.Contains(t, out, "extract:plain-text")
+	assert.Contains(t, out, "running")
 
 	out, err = runCLI(t, "jobs", "--json")
 	require.NoError(t, err)
 	var got api.JobList
 	require.NoError(t, json.Unmarshal([]byte(out), &got))
-	assert.Empty(t, got.Items)
+	require.Len(t, got.Items, 1)
+	assert.Equal(t, "extract:plain-text", got.Items[0].Name)
+	assert.Equal(t, "running", got.Items[0].Status)
 }
 
 func TestConfiguredWatchIngestsStableFilesAndRemainsObservable(t *testing.T) {
 	home := t.TempDir()
 	source := t.TempDir()
 	sourcePath := filepath.Join(source, "session.jsonl")
-	record := "{\"kind\":\"assistant-session\"}\n"
+	record := "{\"kind\":\"assistant-session\",\"topic\":\"quasararchive\"}\n"
 	require.NoError(t, os.WriteFile(sourcePath, []byte(record), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
 		"[server]\nidle_timeout = \"30ms\"\n"+
@@ -566,14 +569,25 @@ func TestConfiguredWatchIngestsStableFilesAndRemainsObservable(t *testing.T) {
 		out, err := runCLI(t, "cat", "/agents/session.jsonl")
 		return err == nil && out == record
 	}, 5*time.Second, 25*time.Millisecond)
+	require.Eventually(t, func() bool {
+		out, err := runCLI(t, "search", "quasararchive", "--json")
+		if err != nil {
+			return false
+		}
+		var report api.SearchReport
+		return json.Unmarshal([]byte(out), &report) == nil && len(report.Hits) == 1 &&
+			report.Hits[0].Path == "/agents/session.jsonl" && report.Hits[0].Match == "content"
+	}, 5*time.Second, 25*time.Millisecond)
 
 	out, err := runCLI(t, "jobs", "--json")
 	require.NoError(t, err)
 	var got api.JobList
 	require.NoError(t, json.Unmarshal([]byte(out), &got))
-	require.Len(t, got.Items, 1)
-	assert.Equal(t, "watch:sessions", got.Items[0].Name)
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, "extract:plain-text", got.Items[0].Name)
 	assert.Equal(t, "running", got.Items[0].Status)
+	assert.Equal(t, "watch:sessions", got.Items[1].Name)
+	assert.Equal(t, "running", got.Items[1].Status)
 
 	// A configured watcher keeps a background daemon alive even when the
 	// ordinary request-idle timeout is deliberately tiny.

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -25,6 +25,7 @@ import (
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/config"
 	"go.kenn.io/docbank/internal/daemonlife"
+	"go.kenn.io/docbank/internal/extract"
 	"go.kenn.io/docbank/internal/home"
 	"go.kenn.io/docbank/internal/ingest"
 	"go.kenn.io/docbank/internal/jobs"
@@ -160,6 +161,13 @@ func runServe(ctx context.Context) (retErr error) {
 		if err := jobSupervisor.Start("watch:"+watchConfig.Name, watcher.Run); err != nil {
 			return fmt.Errorf("starting watch %q: %w", watchConfig.Name, err)
 		}
+	}
+	textWorker, err := extract.New(s, blobs, operationGate.Mutate)
+	if err != nil {
+		return fmt.Errorf("configuring text extraction: %w", err)
+	}
+	if err := jobSupervisor.Start("extract:plain-text", textWorker.Run); err != nil {
+		return fmt.Errorf("starting text extraction: %w", err)
 	}
 
 	var stopOnce sync.Once

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "21", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "22", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "21", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "22", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "21", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "22", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/search.go
+++ b/cmd/docbank/search.go
@@ -22,7 +22,7 @@ var (
 
 var searchCmd = &cobra.Command{
 	Use:   "search <query>...",
-	Short: "Full-text search over node names",
+	Short: "Search document names and extracted text",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if searchLimit < 1 || searchLimit > maxSearchLimit {
@@ -44,9 +44,9 @@ var searchCmd = &cobra.Command{
 			return nil
 		}
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
-		_, _ = fmt.Fprintln(w, "ID\tPATH")
+		_, _ = fmt.Fprintln(w, "ID\tMATCH\tPATH")
 		for _, h := range rep.Hits {
-			_, _ = fmt.Fprintf(w, "%d\t%s\n", h.Node.ID, h.Path)
+			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\n", h.Node.ID, h.Match, h.Path)
 		}
 		if err := w.Flush(); err != nil {
 			return fmt.Errorf("writing search results: %w", err)

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -119,6 +119,13 @@ curl --fail-with-body \
 
 Search is bounded separately. Always inspect `truncated`; increase the limit
 or refine the query rather than assuming the returned array is complete.
+Each result's `match` is `name` or `content`. Name matches keep their established
+ranking and always precede content-only matches, so adding content indexing does
+not reorder an agent's filename-based workflow. Content search covers only the
+current version of verified UTF-8 plain text, Markdown, JSON, and JSONL documents
+up to 16 MiB. Extraction runs asynchronously; after a write, inspect
+`docbank jobs` or retry briefly instead of treating an immediate content miss as
+permanent. PDF, Office, image, and OCR text extraction are not implemented.
 
 ```bash
 curl --fail-with-body --get \

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -148,13 +148,19 @@ process. `docbank jobs` and authenticated `GET /api/v1/jobs` expose running and
 terminal state in deterministic order. Terminal records remain until restart,
 which makes a failed task visible instead of silently disappearing.
 
+Every daemon runs `extract:plain-text`, the bounded worker that verifies and
+indexes supported current text content. Configured watched inboxes add one
+`watch:<name>` runner each. Extraction-cache writes share the ordinary mutation
+side of the daemon operation gate, so GC cannot retire a blob while the worker
+is reading and publishing its derived index.
+
 The supervisor stops accepting work as soon as shutdown begins, cancels every
 runner, and waits before SQLite and blob storage close. Runners must honor
 their context; the wait is bounded so a defective runner cannot prevent daemon
 exit forever. The background daemon's idle-timeout loop is supervised through
-this same path. Watched inboxes use this lifecycle; scheduled maintenance
-remains planned, but must use this lifecycle rather than creating unmanaged
-goroutines.
+this same path. Text extraction and watched inboxes use this lifecycle;
+scheduled maintenance remains planned, but must use this lifecycle rather than
+creating unmanaged goroutines.
 
 ## Logs
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -41,7 +41,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /audit/history?path=&node_id=&limit=&cursor=` | read one audited node's canonical newest-first event timeline with a stable continuation cursor | Implemented |
 | `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
-| `GET /search?q=&limit=` | bounded name search (FTS5), with explicit `truncated` status | Implemented |
+| `GET /search?q=&limit=` | bounded name and extracted-content search (FTS5), with match source and explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
 | `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -77,7 +77,7 @@ audit_baselines(digest, scope_id, target_node_id, operation_id)
 audit_memberships(scope_id, node_id, baseline_digest)
 extracted_text (blob_hash, extractor, extractor_version, status,
                 error, attempts, text, extracted_at)      -- versioned derived cache
-text_extraction_queue (blob_hash)                          -- derived daemon work
+text_extraction_queue (blob_hash, next_attempt_at)         -- derived daemon work
 text_searchable_versions (version_id)                      -- Go-derived MIME eligibility
 content_fts    -- derived FTS5 index over successful extraction rows
 nodes_fts      -- FTS5 external-content index over live node names

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -76,7 +76,9 @@ audit_scopes   (scope_id, target_node_id, enable operation, count/head)
 audit_baselines(digest, scope_id, target_node_id, operation_id)
 audit_memberships(scope_id, node_id, baseline_digest)
 extracted_text (blob_hash, extractor, extractor_version, status,
-                error, attempts, text, extracted_at)      -- reserved; no workers yet
+                error, attempts, text, extracted_at)      -- versioned derived cache
+text_extraction_queue (blob_hash, mime_type)               -- derived daemon work
+content_fts    -- derived FTS5 index over successful extraction rows
 nodes_fts      -- FTS5 external-content index over live node names
 ```
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -77,7 +77,8 @@ audit_baselines(digest, scope_id, target_node_id, operation_id)
 audit_memberships(scope_id, node_id, baseline_digest)
 extracted_text (blob_hash, extractor, extractor_version, status,
                 error, attempts, text, extracted_at)      -- versioned derived cache
-text_extraction_queue (blob_hash, mime_type)               -- derived daemon work
+text_extraction_queue (blob_hash)                          -- derived daemon work
+text_searchable_versions (version_id)                      -- Go-derived MIME eligibility
 content_fts    -- derived FTS5 index over successful extraction rows
 nodes_fts      -- FTS5 external-content index over live node names
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ docbank is pre-1.0; interfaces and storage migrations may still evolve.
 
 ## Unreleased
 
+- Search covers live document names and verified UTF-8 plain text, Markdown,
+  JSON, and JSONL content. Name matches keep their established ranking and
+  precede content-only matches, while `docbank jobs` exposes the bounded
+  asynchronous extraction worker.
 - Daemon-owned watched inboxes import stable regular files without touching
   their sources, preserve portable source identity, and append later changes
   as versions of the same Docbank node; their lifecycle and failures are

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -489,19 +489,21 @@ returns the complete restored node with its resulting path and revision.
 docbank search <query>... [--limit <n>] [--json]
 ```
 
-Full-text search over live node names (FTS5). Every whitespace-separated
-term is matched as a prefix; FTS operator syntax in the query is escaped,
-not interpreted. Results are ranked best-first (BM25, ties broken by
-name). The default limit is 50 and `--limit` accepts 1–1000. When more
-matches exist, the command says that the result is truncated rather than
-silently implying completeness. Output columns are `ID` and `PATH`; no
-matches prints `no matches`.
+Full-text search over live node names and verified extracted text (FTS5).
+Every whitespace-separated term is matched as a prefix; FTS operator syntax
+in the query is escaped, not interpreted. Name matches retain their existing
+BM25 order and appear before content-only matches, whose ranking is independent.
+The default limit is 50 and `--limit` accepts 1–1000. When more matches exist,
+the command says that the result is truncated rather than silently implying
+completeness. Output columns are `ID`, `MATCH`, and `PATH`; no matches prints
+`no matches`.
 
 `--json` emits the typed search report with `hits`, the applied `limit`, and
 an explicit `truncated` boolean. An empty result uses `"hits": []`.
 
-Search currently covers node names only; document-body extraction and content
-search are not available. See [Searching](usage/searching.md).
+The daemon indexes current UTF-8 `text/*`, JSON, and JSONL blobs up to 16 MiB
+after a terminally verified read. PDF, Office, and OCR extraction are not yet
+available. See [Searching](usage/searching.md).
 
 ## docbank trash
 
@@ -694,8 +696,8 @@ Shows daemon-owned background tasks in stable name order, including status,
 start and finish timestamps, and the bounded error recorded for a failed task.
 Running tasks have no finish timestamp; terminal task records remain visible
 until the daemon restarts. `--json` emits `{"items": [...]}` for automation.
-An empty list is normal when no configured feature has registered background
-work. See [Daemon](architecture/daemon.md).
+Every daemon registers `extract:plain-text`; configured watched inboxes add
+`watch:<name>` tasks. See [Daemon](architecture/daemon.md).
 
 ## docbank update
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,18 +50,12 @@ Windows and source builds):
 curl -fsSL https://docbank.ai/install.sh | sh
 ```
 
-!!! info "New version-command vocabulary"
-
-    `docbank version` and the explicit `docbank versions list|show|cat`
-    commands shown below are newer than v0.7.0. Build from source to use them
-    until the next release is published.
-
 The ordinary workflow stays direct:
 
 ```bash
 docbank add ~/Documents/taxes --dest /taxes    # import a folder; sources untouched
 docbank tree /taxes                            # browse the virtual tree
-docbank search "insurance"                     # ranked document-name search
+docbank search "insurance"                     # ranked document search
 docbank put revised.pdf /taxes/2026/return.pdf # add a new immutable version
 docbank versions list /taxes/2026/return.pdf   # inspect retained history
 docbank rm /inbox/junk.pdf                     # move to recoverable trash

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,12 +50,18 @@ Windows and source builds):
 curl -fsSL https://docbank.ai/install.sh | sh
 ```
 
+!!! info "Content-search availability"
+
+    The current v0.8.1 installer searches document names. Verified UTF-8 body
+    search is available in source builds and will enter the installer with the
+    next tagged release.
+
 The ordinary workflow stays direct:
 
 ```bash
 docbank add ~/Documents/taxes --dest /taxes    # import a folder; sources untouched
 docbank tree /taxes                            # browse the virtual tree
-docbank search "insurance"                     # ranked document search
+docbank search "insurance"                     # ranked name search; source builds also search text
 docbank put revised.pdf /taxes/2026/return.pdf # add a new immutable version
 docbank versions list /taxes/2026/return.pdf   # inspect retained history
 docbank rm /inbox/junk.pdf                     # move to recoverable trash

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,7 +14,7 @@ Every documentation page is also published as raw Markdown at the same path with
 ## Work with Documents
 - [Importing Documents](https://docbank.ai/usage/importing.md): Bulk import semantics — recursion, idempotency, collision suffixing, and failure handling.
 - [Organizing & Tagging](https://docbank.ai/usage/organizing.md): Browsing, moving, renaming, and tagging in the virtual tree.
-- [Searching](https://docbank.ai/usage/searching.md): Ranked, prefix-matching search over document names with FTS5; document-body search is not available.
+- [Searching](https://docbank.ai/usage/searching.md): Ranked, prefix-matching search over document names and verified text content.
 
 ## Protect & Operate
 - [Vault Lifecycle](https://docbank.ai/usage/lifecycle.md): Operate a docbank vault safely from first import through maintenance, upgrades, snapshots, and recovery.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ elsewhere only when they materially explain the design and are marked
 | 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.10.0) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
-| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, provenance, watched inboxes, and first-scope audit authority implemented; extraction remains |
+| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, provenance, watched inboxes, first-scope audit authority, and bounded plain-text extraction implemented; PDF/Office extraction remains |
 | 3 | Primary kit-ui web portal and focused operator TUI | Designed |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
@@ -29,7 +29,7 @@ elsewhere only when they materially explain the design and are marked
 - Content-addressed blob store with full fsync durability discipline
 - Idempotent, resumable bulk import with collision suffixing and
   provenance
-- FTS5 name search, ranked and operator-safe
+- FTS5 search over names and verified UTF-8 text content, ranked and operator-safe
 - Trash / restore / `trash empty`, explicit unreachable-content GC, and
   separate packed-space reclamation
 - `gc` (dry-run default) and `verify`
@@ -50,8 +50,8 @@ elsewhere only when they materially explain the design and are marked
   ([design](architecture/http-api.md))
 - Daemon background-task supervision with shared cancellation, bounded
   shutdown before storage closes, failure capture, and observable
-  `docbank jobs` / `GET /api/v1/jobs` status. Watched inbox behavior remains
-  Phase 2b work on top of this implemented lifecycle.
+  `docbank jobs` / `GET /api/v1/jobs` status. Watched inboxes and bounded text
+  extraction now run through this implemented lifecycle.
 - The vault lock becomes a single exclusive holder (the daemon) instead
   of Phase 1's per-command shared/exclusive split; an in-daemon
   maintenance gate replaces `gc`'s own exclusive acquisition
@@ -116,8 +116,8 @@ and append later changes to the same stable node without touching source files.
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
 - Tag/MIME/date/path search filters; `POST /batch/move` bulk reorganization
-- Text extraction workers (PDF text layer, plain text/markdown, office
-  formats) feeding content search
+- Additional text extraction workers for PDF text layers and office formats;
+  bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
 - External integration surface: generalized ingest provenance —
   today's `provenance` table records the original filesystem path and
   mtime; `source_kind` / `source_ref` / `source_meta` fields extend it

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -78,15 +78,19 @@ it belongs in the vault.
 
 ## Search cannot find document text
 
-Search currently indexes live node names, not document contents. Try terms
-from the filename and remember that each term is a prefix match.
+Search indexes live node names and current supported text contents. Remember
+that each term is a prefix match, and inspect the extractor job:
 
 ```bash
 docbank search insur stat
+docbank jobs
 ```
 
-PDF, office-document, and plain-text extraction are not available. See
-[Searching](usage/searching.md) for the current name-search contract.
+Body indexing currently requires verified UTF-8 `text/*`, JSON, or JSONL no
+larger than 16 MiB. It is asynchronous and may take a few seconds after ingest
+or replacement. PDF, office-document, OCR, invalid-UTF-8, NUL-containing, and
+larger content is not indexed; filename search still works. See
+[Searching](usage/searching.md) for the exact contract.
 
 ## A move or restore conflicts
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,6 +92,10 @@ or replacement. PDF, office-document, OCR, invalid-UTF-8, NUL-containing, and
 larger content is not indexed; filename search still works. See
 [Searching](usage/searching.md) for the exact contract.
 
+Transient blob open, read, and verification failures remain queued and are
+retried by the running extractor. Repair or restore unavailable content, then
+retry search after the worker has completed a verified read.
+
 ## A move or restore conflicts
 
 The CLI never overwrites a live file. Moving onto an existing file returns

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -50,7 +50,9 @@ text becomes searchable only after the complete stream reaches verified EOF.
 Extraction is bounded to 16 MiB per blob. Larger documents, invalid UTF-8, and
 text containing NUL bytes remain stored and readable but are not body-indexed.
 Newly ingested or replaced content may take a few seconds to appear while the
-daemon job reaches it. `docbank jobs` shows whether that worker is running.
+daemon job reaches it. A transient open, read, or verification error leaves the
+item queued and is retried on a bounded delay; it does not become a permanent
+extraction failure. `docbank jobs` shows whether that worker is running.
 
 PDF text layers, office formats, OCR, and tag/MIME/date/path search filters are
 not yet available. Their absence never changes name-search results or document

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -1,6 +1,6 @@
 ---
 title: Searching
-description: Ranked, prefix-matching search over document names with FTS5; document-body search is not available.
+description: Ranked, prefix-matching search over document names and verified text content.
 ---
 
 # Searching
@@ -13,9 +13,9 @@ docbank search report --json
 ```
 
 ```
-ID   PATH
-231  /taxes/2026/insurance-renewal.pdf
-198  /taxes/2026/car-insurance.pdf
+ID   MATCH    PATH
+231  name     /taxes/2026/insurance-renewal.pdf
+198  content  /taxes/2026/car-insurance-notes.md
 ```
 
 ## Semantics
@@ -26,23 +26,35 @@ ID   PATH
 - **Operator-safe.** Query text is escaped before reaching FTS5, so
   `AND`, `OR`, quotes, and parentheses in a query are searched for
   literally, never interpreted. Any string is a safe query.
-- **Ranked and bounded.** Results are ordered by BM25 relevance, with
-  deterministic name/ID tie-breaks. The default limit is 50; `--limit`
-  accepts 1–1000, and truncation is always reported.
+- **Ranked and bounded.** Name matches retain their BM25 order and appear
+  first. Content-only matches follow in their own BM25 order; both groups use
+  deterministic name/ID tie-breaks. The default limit is 50; `--limit` accepts
+  1–1000, and truncation is always reported.
 - **Live nodes only.** Trashed documents don't appear; restore returns
   them to the index. Renames update the index immediately.
+- **Current content only.** Retained prior versions stay available through
+  `docbank versions`, but ordinary search matches the current selected version
+  of each live file.
 
 For scripts, `--json` returns `hits`, `limit`, and `truncated` without table
 formatting. `hits` is always an array, including when nothing matches.
 
-## What's indexed today
+## Text extraction
 
-Docbank indexes **node names** only. That already covers the common
-"where did I file that" lookup, since document filenames tend to carry
-their subject.
+The daemon's `extract:plain-text` background job indexes UTF-8 content whose
+media type is `text/*`, `application/json`, `application/x-ndjson`, or
+`application/jsonl`. This covers plain text, Markdown, CSV, JSON, and JSONL.
+The source blob is read through Docbank's verified loose/packed interface, and
+text becomes searchable only after the complete stream reaches verified EOF.
 
-Document-body extraction, content search, and tag/MIME/date/path filters are
-not available in the current CLI or HTTP API.
+Extraction is bounded to 16 MiB per blob. Larger documents, invalid UTF-8, and
+text containing NUL bytes remain stored and readable but are not body-indexed.
+Newly ingested or replaced content may take a few seconds to appear while the
+daemon job reaches it. `docbank jobs` shows whether that worker is running.
+
+PDF text layers, office formats, OCR, and tag/MIME/date/path search filters are
+not yet available. Their absence never changes name-search results or document
+authority.
 
 Next: organize documents beyond paths with
 [Organizing & Tagging](organizing.md), or see every search flag in the

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -351,7 +351,9 @@ func registerReadRoutes(api huma.API, d Deps) {
 	type searchOutput struct{ Body SearchReport }
 	huma.Register(api, huma.Operation{
 		OperationID: "search", Method: http.MethodGet, Path: "/api/v1/search",
-		Summary: "Full-text search over node names, best rank first",
+		Summary: "Search live document names and extracted text",
+		Description: "Name matches retain their established BM25 order and appear first; " +
+			"content-only matches follow in their own BM25 order. Every hit names its match source.",
 	}, func(ctx context.Context, in *struct {
 		Q     string `query:"q" required:"true"`
 		Limit int    `query:"limit" default:"50" minimum:"1" maximum:"1000"`
@@ -362,7 +364,9 @@ func registerReadRoutes(api huma.API, d Deps) {
 		}
 		out := &searchOutput{Body: SearchReport{Hits: []SearchHit{}, Limit: in.Limit, Truncated: truncated}}
 		for _, h := range hits {
-			out.Body.Hits = append(out.Body.Hits, SearchHit{Node: fromStoreNode(h.Node), Path: h.Path})
+			out.Body.Hits = append(out.Body.Hits, SearchHit{
+				Node: fromStoreNode(h.Node), Path: h.Path, Match: h.Match,
+			})
 		}
 		return out, nil
 	})

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/store"
 )
 
 func TestStatByIDAndPath(t *testing.T) {
@@ -285,4 +286,17 @@ func TestSearch(t *testing.T) {
 	assert.Len(t, rep.Hits, 1)
 	assert.Equal(t, 1, rep.Limit)
 	assert.True(t, rep.Truncated)
+	assert.Equal(t, "name", rep.Hits[0].Match)
+
+	bodyNode := createFileWithContent(t, ts, s, "/notes.txt", "lighthouse archive")
+	require.NoError(t, s.RecordExtraction(t.Context(), store.ExtractionResult{
+		BlobHash: bodyNode.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: store.ExtractionOK, Text: "lighthouse archive",
+	}))
+	resp, body = get(t, ts, "/api/v1/search?q=lighthouse&limit=10", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, json.Unmarshal([]byte(body), &rep))
+	require.Len(t, rep.Hits, 1)
+	assert.Equal(t, bodyNode.ID, rep.Hits[0].Node.ID)
+	assert.Equal(t, "content", rep.Hits[0].Match)
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -380,8 +380,9 @@ type ContentReversionReceipt struct {
 
 // SearchHit pairs a matched node with its display path.
 type SearchHit struct {
-	Node Node   `json:"node"`
-	Path string `json:"path"`
+	Node  Node   `json:"node"`
+	Path  string `json:"path"`
+	Match string `json:"match" enum:"name,content"`
 }
 
 // SearchReport is one bounded search result page.

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "21"
+	daemonProtocolVersion = "22"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/extract/worker.go
+++ b/internal/extract/worker.go
@@ -26,6 +26,7 @@ const (
 	MaxTextBytes    = int64(16 << 20)
 	batchSize       = 64
 	defaultInterval = 2 * time.Second
+	defaultRetry    = 30 * time.Second
 )
 
 var errExtractionRetry = errors.New("text extraction should be retried")
@@ -33,6 +34,7 @@ var errExtractionRetry = errors.New("text extraction should be retried")
 type catalog interface {
 	SeedTextExtractionQueue(ctx context.Context, extractor string, version int64) error
 	PendingTextExtractions(ctx context.Context, limit int) ([]store.ExtractionCandidate, error)
+	DeferTextExtraction(ctx context.Context, blobHash string, notBefore time.Time) error
 	RecordExtraction(ctx context.Context, result store.ExtractionResult) error
 }
 
@@ -50,6 +52,7 @@ type Worker struct {
 	blobs    blobReader
 	mutate   func(func() error) error
 	interval time.Duration
+	retry    time.Duration
 }
 
 func New(catalog catalog, blobs blobReader, mutate func(func() error) error) (*Worker, error) {
@@ -59,7 +62,10 @@ func New(catalog catalog, blobs blobReader, mutate func(func() error) error) (*W
 	if mutate == nil {
 		mutate = func(fn func() error) error { return fn() }
 	}
-	return &Worker{catalog: catalog, blobs: blobs, mutate: mutate, interval: defaultInterval}, nil
+	return &Worker{
+		catalog: catalog, blobs: blobs, mutate: mutate,
+		interval: defaultInterval, retry: defaultRetry,
+	}, nil
 }
 
 // Run performs an immediate scan, drains all current work in bounded batches,
@@ -73,12 +79,6 @@ func (w *Worker) Run(ctx context.Context) error {
 	for {
 		processed, err := w.ScanOnce(ctx)
 		if err != nil {
-			if errors.Is(err, errExtractionRetry) {
-				if !w.wait(ctx) {
-					return nil
-				}
-				continue
-			}
 			return err
 		}
 		if processed == batchSize {
@@ -109,23 +109,27 @@ func (w *Worker) ScanOnce(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	var retryErr error
 	for i, item := range items {
 		if err := ctx.Err(); err != nil {
 			return i, err
 		}
-		err := w.mutate(func() error { return w.extractOne(ctx, item) })
+		var extractErr error
+		err := w.mutate(func() error {
+			extractErr = w.extractOne(ctx, item)
+			if !errors.Is(extractErr, errExtractionRetry) {
+				return extractErr
+			}
+			return w.catalog.DeferTextExtraction(
+				ctx, item.BlobHash, time.Now().UTC().Add(w.retry),
+			)
+		})
 		switch {
 		case err == nil, errors.Is(err, store.ErrNotFound):
-		case errors.Is(err, errExtractionRetry):
-			if retryErr == nil {
-				retryErr = fmt.Errorf("extracting blob %s: %w", item.BlobHash, err)
-			}
 		default:
 			return i, fmt.Errorf("extracting blob %s: %w", item.BlobHash, err)
 		}
 	}
-	return len(items), retryErr
+	return len(items), nil
 }
 
 func (w *Worker) extractOne(ctx context.Context, item store.ExtractionCandidate) error {

--- a/internal/extract/worker.go
+++ b/internal/extract/worker.go
@@ -28,11 +28,11 @@ const (
 	defaultInterval = 2 * time.Second
 )
 
+var errExtractionRetry = errors.New("text extraction should be retried")
+
 type catalog interface {
 	SeedTextExtractionQueue(ctx context.Context, extractor string, version int64) error
-	PendingTextExtractions(
-		ctx context.Context, extractor string, version int64, limit int,
-	) ([]store.ExtractionCandidate, error)
+	PendingTextExtractions(ctx context.Context, limit int) ([]store.ExtractionCandidate, error)
 	RecordExtraction(ctx context.Context, result store.ExtractionResult) error
 }
 
@@ -73,40 +73,59 @@ func (w *Worker) Run(ctx context.Context) error {
 	for {
 		processed, err := w.ScanOnce(ctx)
 		if err != nil {
+			if errors.Is(err, errExtractionRetry) {
+				if !w.wait(ctx) {
+					return nil
+				}
+				continue
+			}
 			return err
 		}
 		if processed == batchSize {
 			continue
 		}
-		timer := time.NewTimer(w.interval)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+		if !w.wait(ctx) {
 			return nil
-		case <-timer.C:
 		}
+	}
+}
+
+func (w *Worker) wait(ctx context.Context) bool {
+	timer := time.NewTimer(w.interval)
+	select {
+	case <-ctx.Done():
+		if !timer.Stop() {
+			<-timer.C
+		}
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 
 // ScanOnce processes one bounded batch and returns the number attempted.
 func (w *Worker) ScanOnce(ctx context.Context) (int, error) {
-	items, err := w.catalog.PendingTextExtractions(
-		ctx, TextExtractorName, TextExtractorVersion, batchSize,
-	)
+	items, err := w.catalog.PendingTextExtractions(ctx, batchSize)
 	if err != nil {
 		return 0, err
 	}
+	var retryErr error
 	for i, item := range items {
 		if err := ctx.Err(); err != nil {
 			return i, err
 		}
-		if err := w.mutate(func() error { return w.extractOne(ctx, item) }); err != nil && !errors.Is(err, store.ErrNotFound) {
+		err := w.mutate(func() error { return w.extractOne(ctx, item) })
+		switch {
+		case err == nil, errors.Is(err, store.ErrNotFound):
+		case errors.Is(err, errExtractionRetry):
+			if retryErr == nil {
+				retryErr = fmt.Errorf("extracting blob %s: %w", item.BlobHash, err)
+			}
+		default:
 			return i, fmt.Errorf("extracting blob %s: %w", item.BlobHash, err)
 		}
 	}
-	return len(items), nil
+	return len(items), retryErr
 }
 
 func (w *Worker) extractOne(ctx context.Context, item store.ExtractionCandidate) error {
@@ -119,7 +138,7 @@ func (w *Worker) extractOne(ctx context.Context, item store.ExtractionCandidate)
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		return w.recordFailure(ctx, item.BlobHash, err.Error())
+		return fmt.Errorf("%w: opening verified content: %w", errExtractionRetry, err)
 	}
 	data, readErr := io.ReadAll(io.LimitReader(stream, MaxTextBytes+1))
 	closeErr := stream.Close()
@@ -127,15 +146,14 @@ func (w *Worker) extractOne(ctx context.Context, item store.ExtractionCandidate)
 		return ctx.Err()
 	}
 	if int64(len(data)) > MaxTextBytes {
-		return w.recordFailure(ctx, item.BlobHash,
-			fmt.Sprintf("text exceeds the %d-byte extraction limit", MaxTextBytes))
+		return fmt.Errorf("%w: stream exceeded its bounded catalog size", errExtractionRetry)
 	}
 	if err := errors.Join(readErr, closeErr); err != nil {
-		return w.recordFailure(ctx, item.BlobHash, err.Error())
+		return fmt.Errorf("%w: reading verified content: %w", errExtractionRetry, err)
 	}
 	if streamSize != item.Size || int64(len(data)) != item.Size {
-		return w.recordFailure(ctx, item.BlobHash, fmt.Sprintf(
-			"catalog size %d, stream size %d, read %d", item.Size, streamSize, len(data)))
+		return fmt.Errorf("%w: catalog size %d, stream size %d, read %d",
+			errExtractionRetry, item.Size, streamSize, len(data))
 	}
 	data = bytes.TrimPrefix(data, []byte{0xef, 0xbb, 0xbf})
 	if !utf8.Valid(data) || bytes.IndexByte(data, 0) >= 0 {

--- a/internal/extract/worker.go
+++ b/internal/extract/worker.go
@@ -1,0 +1,163 @@
+// Package extract runs bounded, daemon-owned document text extraction.
+package extract
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+const (
+	// TextExtractorName and TextExtractorVersion identify the persisted cache.
+	// A behavior change increments the version and naturally queues old rows.
+	TextExtractorName    = "plain-text"
+	TextExtractorVersion = int64(1)
+
+	// MaxTextBytes bounds both memory and SQLite/FTS growth for one document.
+	MaxTextBytes    = int64(16 << 20)
+	batchSize       = 64
+	defaultInterval = 2 * time.Second
+)
+
+type catalog interface {
+	SeedTextExtractionQueue(ctx context.Context, extractor string, version int64) error
+	PendingTextExtractions(
+		ctx context.Context, extractor string, version int64, limit int,
+	) ([]store.ExtractionCandidate, error)
+	RecordExtraction(ctx context.Context, result store.ExtractionResult) error
+}
+
+type blobReader interface {
+	OpenStreamContext(
+		ctx context.Context, hash string,
+	) (packstore.VerifiedReadCloser, int64, error)
+}
+
+// Worker discovers text blobs, verifies each complete stream, and writes only
+// derived cache rows. mutate shares the daemon's mutation/maintenance gate so
+// GC cannot retire a candidate between opening it and recording its result.
+type Worker struct {
+	catalog  catalog
+	blobs    blobReader
+	mutate   func(func() error) error
+	interval time.Duration
+}
+
+func New(catalog catalog, blobs blobReader, mutate func(func() error) error) (*Worker, error) {
+	if catalog == nil || blobs == nil {
+		return nil, errors.New("text extractor requires catalog and blob reader")
+	}
+	if mutate == nil {
+		mutate = func(fn func() error) error { return fn() }
+	}
+	return &Worker{catalog: catalog, blobs: blobs, mutate: mutate, interval: defaultInterval}, nil
+}
+
+// Run performs an immediate scan, drains all current work in bounded batches,
+// and then watches for newly admitted versions until the daemon stops.
+func (w *Worker) Run(ctx context.Context) error {
+	if err := w.catalog.SeedTextExtractionQueue(
+		ctx, TextExtractorName, TextExtractorVersion,
+	); err != nil {
+		return err
+	}
+	for {
+		processed, err := w.ScanOnce(ctx)
+		if err != nil {
+			return err
+		}
+		if processed == batchSize {
+			continue
+		}
+		timer := time.NewTimer(w.interval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil
+		case <-timer.C:
+		}
+	}
+}
+
+// ScanOnce processes one bounded batch and returns the number attempted.
+func (w *Worker) ScanOnce(ctx context.Context) (int, error) {
+	items, err := w.catalog.PendingTextExtractions(
+		ctx, TextExtractorName, TextExtractorVersion, batchSize,
+	)
+	if err != nil {
+		return 0, err
+	}
+	for i, item := range items {
+		if err := ctx.Err(); err != nil {
+			return i, err
+		}
+		if err := w.mutate(func() error { return w.extractOne(ctx, item) }); err != nil && !errors.Is(err, store.ErrNotFound) {
+			return i, fmt.Errorf("extracting blob %s: %w", item.BlobHash, err)
+		}
+	}
+	return len(items), nil
+}
+
+func (w *Worker) extractOne(ctx context.Context, item store.ExtractionCandidate) error {
+	if item.Size > MaxTextBytes {
+		return w.recordFailure(ctx, item.BlobHash,
+			fmt.Sprintf("text exceeds the %d-byte extraction limit", MaxTextBytes))
+	}
+	stream, streamSize, err := w.blobs.OpenStreamContext(ctx, item.BlobHash)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return w.recordFailure(ctx, item.BlobHash, err.Error())
+	}
+	data, readErr := io.ReadAll(io.LimitReader(stream, MaxTextBytes+1))
+	closeErr := stream.Close()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if int64(len(data)) > MaxTextBytes {
+		return w.recordFailure(ctx, item.BlobHash,
+			fmt.Sprintf("text exceeds the %d-byte extraction limit", MaxTextBytes))
+	}
+	if err := errors.Join(readErr, closeErr); err != nil {
+		return w.recordFailure(ctx, item.BlobHash, err.Error())
+	}
+	if streamSize != item.Size || int64(len(data)) != item.Size {
+		return w.recordFailure(ctx, item.BlobHash, fmt.Sprintf(
+			"catalog size %d, stream size %d, read %d", item.Size, streamSize, len(data)))
+	}
+	data = bytes.TrimPrefix(data, []byte{0xef, 0xbb, 0xbf})
+	if !utf8.Valid(data) || bytes.IndexByte(data, 0) >= 0 {
+		return w.recordFailure(ctx, item.BlobHash, "content is not UTF-8 plain text")
+	}
+	return w.catalog.RecordExtraction(ctx, store.ExtractionResult{
+		BlobHash: item.BlobHash, Extractor: TextExtractorName,
+		ExtractorVersion: TextExtractorVersion, Status: store.ExtractionOK, Text: string(data),
+	})
+}
+
+func (w *Worker) recordFailure(ctx context.Context, blobHash, message string) error {
+	message = strings.ToValidUTF8(message, "\uFFFD")
+	const maxErrorBytes = 1024
+	if len(message) > maxErrorBytes {
+		message = message[:maxErrorBytes]
+		for !utf8.ValidString(message) {
+			message = message[:len(message)-1]
+		}
+	}
+	return w.catalog.RecordExtraction(ctx, store.ExtractionResult{
+		BlobHash: blobHash, Extractor: TextExtractorName,
+		ExtractorVersion: TextExtractorVersion, Status: store.ExtractionFailed, Error: message,
+	})
+}

--- a/internal/extract/worker_test.go
+++ b/internal/extract/worker_test.go
@@ -129,6 +129,12 @@ func TestWorkerRetriesTransientOpenFailure(t *testing.T) {
 		return searchErr == nil && len(hits) == 1
 	}, time.Second, 5*time.Millisecond)
 	cancel()
-	require.NoError(t, <-done)
+	runErr := <-done
+	if runErr != nil {
+		// Cancellation can reach either the idle wait (which returns nil) or an
+		// in-flight catalog query. The daemon supervisor treats both outcomes as
+		// a clean cancelled job.
+		require.ErrorIs(t, runErr, context.Canceled)
+	}
 	assert.GreaterOrEqual(t, reader.calls, 2)
 }

--- a/internal/extract/worker_test.go
+++ b/internal/extract/worker_test.go
@@ -119,6 +119,7 @@ func TestWorkerRetriesTransientOpenFailure(t *testing.T) {
 	w, err := New(s, reader, nil)
 	require.NoError(t, err)
 	w.interval = 5 * time.Millisecond
+	w.retry = 10 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)

--- a/internal/extract/worker_test.go
+++ b/internal/extract/worker_test.go
@@ -1,9 +1,12 @@
 package extract
 
 import (
+	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +15,22 @@ import (
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/store"
 )
+
+type transientBlobReader struct {
+	delegate blobReader
+	failures int
+	calls    int
+}
+
+func (r *transientBlobReader) OpenStreamContext(
+	ctx context.Context, hash string,
+) (packstore.VerifiedReadCloser, int64, error) {
+	r.calls++
+	if r.calls <= r.failures {
+		return nil, 0, errors.New("temporary read failure")
+	}
+	return r.delegate.OpenStreamContext(ctx, hash)
+}
 
 func TestWorkerIndexesVerifiedUTF8AndUsesMutationGate(t *testing.T) {
 	dir := t.TempDir()
@@ -77,9 +96,38 @@ func TestWorkerRecordsDeterministicFailuresWithoutOpeningOversizeBlob(t *testing
 	require.NoError(t, err)
 	assert.Equal(t, 1, processed)
 
-	pending, err := s.PendingTextExtractions(
-		t.Context(), TextExtractorName, TextExtractorVersion, 10,
-	)
+	pending, err := s.PendingTextExtractions(t.Context(), 10)
 	require.NoError(t, err)
 	assert.Empty(t, pending)
+}
+
+func TestWorkerRetriesTransientOpenFailure(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(filepath.Join(dir, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	blobs, err := blob.New(store.NewPackCatalog(s), filepath.Join(dir, "blobs"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, blobs.Close()) })
+
+	content := "A recoverable nebula record.\n"
+	hash, size, err := blobs.Write(strings.NewReader(content))
+	require.NoError(t, err)
+	_, err = s.CreateFile(t.Context(), s.RootID(), "notes.txt", hash, size, "text/plain")
+	require.NoError(t, err)
+	reader := &transientBlobReader{delegate: blobs, failures: 1}
+	w, err := New(s, reader, nil)
+	require.NoError(t, err)
+	w.interval = 5 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+	require.Eventually(t, func() bool {
+		hits, _, searchErr := s.SearchPage(t.Context(), "nebula", 10)
+		return searchErr == nil && len(hits) == 1
+	}, time.Second, 5*time.Millisecond)
+	cancel()
+	require.NoError(t, <-done)
+	assert.GreaterOrEqual(t, reader.calls, 2)
 }

--- a/internal/extract/worker_test.go
+++ b/internal/extract/worker_test.go
@@ -1,0 +1,85 @@
+package extract
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestWorkerIndexesVerifiedUTF8AndUsesMutationGate(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(filepath.Join(dir, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	blobs, err := blob.New(store.NewPackCatalog(s), filepath.Join(dir, "blobs"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, blobs.Close()) })
+
+	content := "The lighthouse keeps a verified archive.\n"
+	hash, size, err := blobs.Write(strings.NewReader(content))
+	require.NoError(t, err)
+	node, err := s.CreateFile(
+		t.Context(), s.RootID(), "notes.md", hash, size, "text/markdown; charset=utf-8",
+	)
+	require.NoError(t, err)
+	packed, err := blobs.Maintainer().Pack(t.Context(), packstore.PackOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, packed.BlobsPacked, "extraction must read through packed storage")
+
+	gateCalls := 0
+	w, err := New(s, blobs, func(fn func() error) error {
+		gateCalls++
+		return fn()
+	})
+	require.NoError(t, err)
+	processed, err := w.ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	assert.Equal(t, 1, gateCalls)
+
+	hits, truncated, err := s.SearchPage(t.Context(), "lighthouse", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.False(t, truncated)
+	assert.Equal(t, node.ID, hits[0].Node.ID)
+	assert.Equal(t, store.SearchMatchContent, hits[0].Match)
+
+	processed, err = w.ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, processed)
+	assert.Equal(t, 1, gateCalls)
+}
+
+func TestWorkerRecordsDeterministicFailuresWithoutOpeningOversizeBlob(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(filepath.Join(dir, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	blobs, err := blob.New(store.NewPackCatalog(s), filepath.Join(dir, "blobs"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, blobs.Close()) })
+
+	// Metadata authority is enough for this branch: the size policy rejects it
+	// before opening physical content.
+	_, err = s.CreateFile(t.Context(), s.RootID(), "huge.txt",
+		strings.Repeat("a", 64), MaxTextBytes+1, "text/plain")
+	require.NoError(t, err)
+	w, err := New(s, blobs, nil)
+	require.NoError(t, err)
+	processed, err := w.ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+
+	pending, err := s.PendingTextExtractions(
+		t.Context(), TextExtractorName, TextExtractorVersion, 10,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}

--- a/internal/store/extraction.go
+++ b/internal/store/extraction.go
@@ -22,7 +22,6 @@ const (
 type ExtractionCandidate struct {
 	BlobHash string
 	Size     int64
-	MimeType string
 }
 
 // ExtractionResult is one complete, versioned derived-text attempt. Text is
@@ -46,16 +45,33 @@ func supportsTextExtractionMIME(value string) bool {
 		mediaType == "application/x-ndjson" || mediaType == "application/jsonl"
 }
 
-func queueTextExtractionTx(tx *sql.Tx, blobHash, mimeType string) error {
+func markTextSearchableVersionTx(tx *sql.Tx, versionID, mimeType string) (bool, error) {
 	if !supportsTextExtractionMIME(mimeType) {
-		return nil
+		return false, nil
 	}
 	if _, err := tx.Exec(`
-		INSERT INTO text_extraction_queue(blob_hash,mime_type) VALUES(?,?)
-		ON CONFLICT(blob_hash) DO NOTHING`, blobHash, mimeType); err != nil {
+		INSERT INTO text_searchable_versions(version_id) VALUES(?)
+		ON CONFLICT(version_id) DO NOTHING`, versionID); err != nil {
+		return false, fmt.Errorf("recording text-search eligibility for %s: %w", versionID, err)
+	}
+	return true, nil
+}
+
+func enqueueTextBlobTx(tx *sql.Tx, blobHash string) error {
+	if _, err := tx.Exec(`
+		INSERT INTO text_extraction_queue(blob_hash) VALUES(?)
+		ON CONFLICT(blob_hash) DO NOTHING`, blobHash); err != nil {
 		return fmt.Errorf("queueing text extraction for %s: %w", blobHash, err)
 	}
 	return nil
+}
+
+func queueTextExtractionTx(tx *sql.Tx, versionID, blobHash, mimeType string) error {
+	eligible, err := markTextSearchableVersionTx(tx, versionID, mimeType)
+	if err != nil || !eligible {
+		return err
+	}
+	return enqueueTextBlobTx(tx, blobHash)
 }
 
 // SeedTextExtractionQueue discovers supported retained content once at daemon
@@ -68,29 +84,32 @@ func (s *Store) SeedTextExtractionQueue(
 		return errors.New("extractor name and positive version are required")
 	}
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT v.blob_hash, COALESCE(v.mime_type, '')
+		SELECT v.version_id, v.blob_hash, COALESCE(v.mime_type, ''),
+		       CASE WHEN e.blob_hash IS NULL OR e.extractor_version < ? THEN 1 ELSE 0 END
 		FROM content_versions v
 		JOIN nodes n ON n.current_version_id = v.version_id
 		LEFT JOIN extracted_text e
 		  ON e.blob_hash=v.blob_hash AND e.extractor=?
-		WHERE e.blob_hash IS NULL OR e.extractor_version < ?
-		ORDER BY v.blob_hash, v.mime_type`, extractor, version)
+		ORDER BY v.version_id`, version, extractor)
 	if err != nil {
 		return fmt.Errorf("discovering text extraction work: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	type seed struct{ hash, mimeType string }
+	type seed struct {
+		versionID, hash, mimeType string
+		needsExtraction           bool
+	}
 	var seeds []seed
-	seen := make(map[string]struct{})
 	for rows.Next() {
 		var item seed
-		if err := rows.Scan(&item.hash, &item.mimeType); err != nil {
+		if err := rows.Scan(
+			&item.versionID, &item.hash, &item.mimeType, &item.needsExtraction,
+		); err != nil {
 			return fmt.Errorf("discovering text extraction work: scanning row: %w", err)
 		}
-		if _, exists := seen[item.hash]; exists || !supportsTextExtractionMIME(item.mimeType) {
+		if !supportsTextExtractionMIME(item.mimeType) {
 			continue
 		}
-		seen[item.hash] = struct{}{}
 		seeds = append(seeds, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -100,8 +119,19 @@ func (s *Store) SeedTextExtractionQueue(
 		return fmt.Errorf("discovering text extraction work: %w", err)
 	}
 	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		queued := make(map[string]struct{})
 		for _, item := range seeds {
-			if err := queueTextExtractionTx(tx, item.hash, item.mimeType); err != nil {
+			if _, err := markTextSearchableVersionTx(tx, item.versionID, item.mimeType); err != nil {
+				return err
+			}
+			if !item.needsExtraction {
+				continue
+			}
+			if _, exists := queued[item.hash]; exists {
+				continue
+			}
+			queued[item.hash] = struct{}{}
+			if err := enqueueTextBlobTx(tx, item.hash); err != nil {
 				return err
 			}
 		}
@@ -109,29 +139,22 @@ func (s *Store) SeedTextExtractionQueue(
 	})
 }
 
-// PendingTextExtractions returns a bounded hash-ordered batch of supported
-// text blobs without current results. Logical writes and one startup seed of
-// selected versions fill the derived queue, so steady-state polling never
-// scans the version catalog.
+// PendingTextExtractions returns a bounded hash-ordered batch from the derived
+// work queue. Logical writes and one startup seed of selected versions fill the
+// queue, so steady-state polling never scans the version catalog.
 func (s *Store) PendingTextExtractions(
-	ctx context.Context, extractor string, version int64, limit int,
+	ctx context.Context, limit int,
 ) ([]ExtractionCandidate, error) {
-	if extractor == "" || version < 1 {
-		return nil, errors.New("extractor name and positive version are required")
-	}
 	if limit < 1 || limit > 1000 {
 		return nil, errors.New("extraction batch limit must be between 1 and 1000")
 	}
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT q.blob_hash, b.size, q.mime_type
+		SELECT q.blob_hash, b.size
 		FROM text_extraction_queue q
 		JOIN blobs b ON b.hash=q.blob_hash
-		LEFT JOIN extracted_text e
-		  ON e.blob_hash = q.blob_hash AND e.extractor = ?
-		WHERE (e.blob_hash IS NULL OR e.extractor_version < ?)
-		  AND EXISTS(SELECT 1 FROM content_versions v WHERE v.blob_hash=q.blob_hash)
+		WHERE EXISTS(SELECT 1 FROM content_versions v WHERE v.blob_hash=q.blob_hash)
 		ORDER BY q.blob_hash
-		LIMIT ?`, extractor, version, limit)
+		LIMIT ?`, limit)
 	if err != nil {
 		return nil, fmt.Errorf("listing pending text extractions: %w", err)
 	}
@@ -139,7 +162,7 @@ func (s *Store) PendingTextExtractions(
 	items := make([]ExtractionCandidate, 0)
 	for rows.Next() {
 		var item ExtractionCandidate
-		if err := rows.Scan(&item.BlobHash, &item.Size, &item.MimeType); err != nil {
+		if err := rows.Scan(&item.BlobHash, &item.Size); err != nil {
 			return nil, fmt.Errorf("listing pending text extractions: scanning row: %w", err)
 		}
 		items = append(items, item)

--- a/internal/store/extraction.go
+++ b/internal/store/extraction.go
@@ -76,6 +76,70 @@ func queueTextExtractionTx(tx *sql.Tx, versionID, blobHash, mimeType string) err
 	return enqueueTextBlobTx(tx, blobHash)
 }
 
+// rebuildImportedTextExtractionStateTx reconstructs the derived search
+// eligibility and work queue after every authoritative metadata record has
+// been imported. Historical versions remain available for explicit version
+// reads, but only selected heads can appear in ordinary search and therefore
+// only selected heads need extraction work.
+func rebuildImportedTextExtractionStateTx(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM text_searchable_versions`); err != nil {
+		return fmt.Errorf("clearing imported text-search eligibility: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM text_extraction_queue`); err != nil {
+		return fmt.Errorf("clearing imported text-extraction queue: %w", err)
+	}
+	type seed struct {
+		versionID, hash, mimeType string
+		hasExtraction             bool
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT v.version_id, v.blob_hash, COALESCE(v.mime_type, ''),
+		       EXISTS(SELECT 1 FROM extracted_text e WHERE e.blob_hash=v.blob_hash)
+		FROM content_versions v
+		JOIN nodes n ON n.current_version_id=v.version_id
+		ORDER BY v.version_id`)
+	if err != nil {
+		return fmt.Errorf("discovering imported text extraction work: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var seeds []seed
+	for rows.Next() {
+		var item seed
+		if err := rows.Scan(
+			&item.versionID, &item.hash, &item.mimeType, &item.hasExtraction,
+		); err != nil {
+			return fmt.Errorf("discovering imported text extraction work: scanning row: %w", err)
+		}
+		if supportsTextExtractionMIME(item.mimeType) {
+			seeds = append(seeds, item)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("discovering imported text extraction work: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("discovering imported text extraction work: %w", err)
+	}
+
+	queued := make(map[string]struct{})
+	for _, item := range seeds {
+		if _, err := markTextSearchableVersionTx(tx, item.versionID, item.mimeType); err != nil {
+			return err
+		}
+		if item.hasExtraction {
+			continue
+		}
+		if _, exists := queued[item.hash]; exists {
+			continue
+		}
+		queued[item.hash] = struct{}{}
+		if err := enqueueTextBlobTx(tx, item.hash); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SeedTextExtractionQueue discovers supported selected content once at daemon
 // startup. Discovery and projection writes share one storage transaction, so a
 // concurrent deletion cannot invalidate a selected version between those steps.

--- a/internal/store/extraction.go
+++ b/internal/store/extraction.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"mime"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"go.kenn.io/kit/packstore"
@@ -59,8 +60,9 @@ func markTextSearchableVersionTx(tx *sql.Tx, versionID, mimeType string) (bool, 
 
 func enqueueTextBlobTx(tx *sql.Tx, blobHash string) error {
 	if _, err := tx.Exec(`
-		INSERT INTO text_extraction_queue(blob_hash) VALUES(?)
-		ON CONFLICT(blob_hash) DO NOTHING`, blobHash); err != nil {
+		INSERT INTO text_extraction_queue(blob_hash,next_attempt_at) VALUES(?,?)
+		ON CONFLICT(blob_hash) DO UPDATE SET next_attempt_at=excluded.next_attempt_at`,
+		blobHash, nowRFC3339()); err != nil {
 		return fmt.Errorf("queueing text extraction for %s: %w", blobHash, err)
 	}
 	return nil
@@ -74,51 +76,52 @@ func queueTextExtractionTx(tx *sql.Tx, versionID, blobHash, mimeType string) err
 	return enqueueTextBlobTx(tx, blobHash)
 }
 
-// SeedTextExtractionQueue discovers supported retained content once at daemon
-// startup. Later logical writes enqueue in Go, avoiding repeated full-catalog
-// scans while still covering vaults created by an older binary.
+// SeedTextExtractionQueue discovers supported selected content once at daemon
+// startup. Discovery and projection writes share one storage transaction, so a
+// concurrent deletion cannot invalidate a selected version between those steps.
+// Later logical writes enqueue in Go while existing vaults converge here.
 func (s *Store) SeedTextExtractionQueue(
 	ctx context.Context, extractor string, version int64,
 ) error {
 	if extractor == "" || version < 1 {
 		return errors.New("extractor name and positive version are required")
 	}
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT v.version_id, v.blob_hash, COALESCE(v.mime_type, ''),
-		       CASE WHEN e.blob_hash IS NULL OR e.extractor_version < ? THEN 1 ELSE 0 END
-		FROM content_versions v
-		JOIN nodes n ON n.current_version_id = v.version_id
-		LEFT JOIN extracted_text e
-		  ON e.blob_hash=v.blob_hash AND e.extractor=?
-		ORDER BY v.version_id`, version, extractor)
-	if err != nil {
-		return fmt.Errorf("discovering text extraction work: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
 	type seed struct {
 		versionID, hash, mimeType string
 		needsExtraction           bool
 	}
-	var seeds []seed
-	for rows.Next() {
-		var item seed
-		if err := rows.Scan(
-			&item.versionID, &item.hash, &item.mimeType, &item.needsExtraction,
-		); err != nil {
-			return fmt.Errorf("discovering text extraction work: scanning row: %w", err)
-		}
-		if !supportsTextExtractionMIME(item.mimeType) {
-			continue
-		}
-		seeds = append(seeds, item)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("discovering text extraction work: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return fmt.Errorf("discovering text extraction work: %w", err)
-	}
 	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, `
+			SELECT v.version_id, v.blob_hash, COALESCE(v.mime_type, ''),
+			       CASE WHEN e.blob_hash IS NULL OR e.extractor_version < ? THEN 1 ELSE 0 END
+			FROM content_versions v
+			JOIN nodes n ON n.current_version_id = v.version_id
+			LEFT JOIN extracted_text e
+			  ON e.blob_hash=v.blob_hash AND e.extractor=?
+			ORDER BY v.version_id`, version, extractor)
+		if err != nil {
+			return fmt.Errorf("discovering text extraction work: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		var seeds []seed
+		for rows.Next() {
+			var item seed
+			if err := rows.Scan(
+				&item.versionID, &item.hash, &item.mimeType, &item.needsExtraction,
+			); err != nil {
+				return fmt.Errorf("discovering text extraction work: scanning row: %w", err)
+			}
+			if supportsTextExtractionMIME(item.mimeType) {
+				seeds = append(seeds, item)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("discovering text extraction work: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("discovering text extraction work: %w", err)
+		}
+
 		queued := make(map[string]struct{})
 		for _, item := range seeds {
 			if _, err := markTextSearchableVersionTx(tx, item.versionID, item.mimeType); err != nil {
@@ -153,8 +156,9 @@ func (s *Store) PendingTextExtractions(
 		FROM text_extraction_queue q
 		JOIN blobs b ON b.hash=q.blob_hash
 		WHERE EXISTS(SELECT 1 FROM content_versions v WHERE v.blob_hash=q.blob_hash)
-		ORDER BY q.blob_hash
-		LIMIT ?`, limit)
+		  AND q.next_attempt_at <= ?
+		ORDER BY q.next_attempt_at, q.blob_hash
+		LIMIT ?`, nowRFC3339(), limit)
 	if err != nil {
 		return nil, fmt.Errorf("listing pending text extractions: %w", err)
 	}
@@ -171,6 +175,32 @@ func (s *Store) PendingTextExtractions(
 		return nil, fmt.Errorf("listing pending text extractions: %w", err)
 	}
 	return items, nil
+}
+
+// DeferTextExtraction leaves a retryable item queued but moves it behind work
+// that is ready now. The worker chooses the bounded delay in Go.
+func (s *Store) DeferTextExtraction(
+	ctx context.Context, blobHash string, notBefore time.Time,
+) error {
+	if _, err := packstore.ParseHash(blobHash); err != nil {
+		return fmt.Errorf("invalid deferred blob hash: %w", err)
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		result, err := tx.ExecContext(ctx, `
+			UPDATE text_extraction_queue SET next_attempt_at = ? WHERE blob_hash = ?`,
+			notBefore.UTC().Format(timestampLayout), blobHash)
+		if err != nil {
+			return fmt.Errorf("deferring text extraction for %s: %w", blobHash, err)
+		}
+		updated, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("deferring text extraction for %s: %w", blobHash, err)
+		}
+		if updated == 0 {
+			return fmt.Errorf("text extraction %s: %w", blobHash, ErrNotFound)
+		}
+		return nil
+	})
 }
 
 // RecordExtraction atomically replaces one extractor's derived result and its

--- a/internal/store/extraction.go
+++ b/internal/store/extraction.go
@@ -219,7 +219,13 @@ func (s *Store) PendingTextExtractions(
 		SELECT q.blob_hash, b.size
 		FROM text_extraction_queue q
 		JOIN blobs b ON b.hash=q.blob_hash
-		WHERE EXISTS(SELECT 1 FROM content_versions v WHERE v.blob_hash=q.blob_hash)
+		WHERE EXISTS(
+		  SELECT 1
+		  FROM content_versions v
+		  JOIN nodes n ON n.current_version_id=v.version_id
+		  JOIN text_searchable_versions sv ON sv.version_id=v.version_id
+		  WHERE v.blob_hash=q.blob_hash
+		)
 		  AND q.next_attempt_at <= ?
 		ORDER BY q.next_attempt_at, q.blob_hash
 		LIMIT ?`, nowRFC3339(), limit)

--- a/internal/store/extraction.go
+++ b/internal/store/extraction.go
@@ -1,0 +1,248 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"mime"
+	"strings"
+	"unicode/utf8"
+
+	"go.kenn.io/kit/packstore"
+)
+
+const (
+	ExtractionOK     = "ok"
+	ExtractionFailed = "failed"
+)
+
+// ExtractionCandidate is one catalog-authorized text blob that has not been
+// processed by the current extractor version.
+type ExtractionCandidate struct {
+	BlobHash string
+	Size     int64
+	MimeType string
+}
+
+// ExtractionResult is one complete, versioned derived-text attempt. Text is
+// present only for a successful, terminally verified extraction.
+type ExtractionResult struct {
+	BlobHash         string
+	Extractor        string
+	ExtractorVersion int64
+	Status           string
+	Error            string
+	Text             string
+}
+
+func supportsTextExtractionMIME(value string) bool {
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return false
+	}
+	mediaType = strings.ToLower(mediaType)
+	return strings.HasPrefix(mediaType, "text/") || mediaType == "application/json" ||
+		mediaType == "application/x-ndjson" || mediaType == "application/jsonl"
+}
+
+func queueTextExtractionTx(tx *sql.Tx, blobHash, mimeType string) error {
+	if !supportsTextExtractionMIME(mimeType) {
+		return nil
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO text_extraction_queue(blob_hash,mime_type) VALUES(?,?)
+		ON CONFLICT(blob_hash) DO NOTHING`, blobHash, mimeType); err != nil {
+		return fmt.Errorf("queueing text extraction for %s: %w", blobHash, err)
+	}
+	return nil
+}
+
+// SeedTextExtractionQueue discovers supported retained content once at daemon
+// startup. Later logical writes enqueue in Go, avoiding repeated full-catalog
+// scans while still covering vaults created by an older binary.
+func (s *Store) SeedTextExtractionQueue(
+	ctx context.Context, extractor string, version int64,
+) error {
+	if extractor == "" || version < 1 {
+		return errors.New("extractor name and positive version are required")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT v.blob_hash, COALESCE(v.mime_type, '')
+		FROM content_versions v
+		JOIN nodes n ON n.current_version_id = v.version_id
+		LEFT JOIN extracted_text e
+		  ON e.blob_hash=v.blob_hash AND e.extractor=?
+		WHERE e.blob_hash IS NULL OR e.extractor_version < ?
+		ORDER BY v.blob_hash, v.mime_type`, extractor, version)
+	if err != nil {
+		return fmt.Errorf("discovering text extraction work: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	type seed struct{ hash, mimeType string }
+	var seeds []seed
+	seen := make(map[string]struct{})
+	for rows.Next() {
+		var item seed
+		if err := rows.Scan(&item.hash, &item.mimeType); err != nil {
+			return fmt.Errorf("discovering text extraction work: scanning row: %w", err)
+		}
+		if _, exists := seen[item.hash]; exists || !supportsTextExtractionMIME(item.mimeType) {
+			continue
+		}
+		seen[item.hash] = struct{}{}
+		seeds = append(seeds, item)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("discovering text extraction work: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("discovering text extraction work: %w", err)
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		for _, item := range seeds {
+			if err := queueTextExtractionTx(tx, item.hash, item.mimeType); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// PendingTextExtractions returns a bounded hash-ordered batch of supported
+// text blobs without current results. Logical writes and one startup seed of
+// selected versions fill the derived queue, so steady-state polling never
+// scans the version catalog.
+func (s *Store) PendingTextExtractions(
+	ctx context.Context, extractor string, version int64, limit int,
+) ([]ExtractionCandidate, error) {
+	if extractor == "" || version < 1 {
+		return nil, errors.New("extractor name and positive version are required")
+	}
+	if limit < 1 || limit > 1000 {
+		return nil, errors.New("extraction batch limit must be between 1 and 1000")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT q.blob_hash, b.size, q.mime_type
+		FROM text_extraction_queue q
+		JOIN blobs b ON b.hash=q.blob_hash
+		LEFT JOIN extracted_text e
+		  ON e.blob_hash = q.blob_hash AND e.extractor = ?
+		WHERE (e.blob_hash IS NULL OR e.extractor_version < ?)
+		  AND EXISTS(SELECT 1 FROM content_versions v WHERE v.blob_hash=q.blob_hash)
+		ORDER BY q.blob_hash
+		LIMIT ?`, extractor, version, limit)
+	if err != nil {
+		return nil, fmt.Errorf("listing pending text extractions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	items := make([]ExtractionCandidate, 0)
+	for rows.Next() {
+		var item ExtractionCandidate
+		if err := rows.Scan(&item.BlobHash, &item.Size, &item.MimeType); err != nil {
+			return nil, fmt.Errorf("listing pending text extractions: scanning row: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing pending text extractions: %w", err)
+	}
+	return items, nil
+}
+
+// RecordExtraction atomically replaces one extractor's derived result and its
+// searchable projection. It never changes document, version, or audit state.
+func (s *Store) RecordExtraction(ctx context.Context, result ExtractionResult) error {
+	if _, err := packstore.ParseHash(result.BlobHash); err != nil {
+		return fmt.Errorf("invalid extracted blob hash: %w", err)
+	}
+	if result.Extractor == "" || result.ExtractorVersion < 1 {
+		return errors.New("extractor name and positive version are required")
+	}
+	if !utf8.ValidString(result.Extractor) || !utf8.ValidString(result.Error) ||
+		!utf8.ValidString(result.Text) {
+		return errors.New("extraction result is not valid UTF-8")
+	}
+	switch result.Status {
+	case ExtractionOK:
+		if result.Error != "" {
+			return errors.New("successful extraction must not contain an error")
+		}
+	case ExtractionFailed:
+		if result.Error == "" || result.Text != "" {
+			return errors.New("failed extraction requires an error and no text")
+		}
+	default:
+		return fmt.Errorf("invalid extraction status %q", result.Status)
+	}
+
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		var exists bool
+		if err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM blobs WHERE hash = ?)`, result.BlobHash,
+		).Scan(&exists); err != nil {
+			return fmt.Errorf("checking extracted blob authority: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("blob %s: %w", result.BlobHash, ErrNotFound)
+		}
+		var extractErr, text any
+		if result.Error != "" {
+			extractErr = result.Error
+		}
+		if result.Status == ExtractionOK {
+			text = result.Text
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO extracted_text(
+			  blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at
+			) VALUES(?,?,?,?,?,1,?,?)
+			ON CONFLICT(blob_hash,extractor) DO UPDATE SET
+			  extractor_version=excluded.extractor_version,
+			  status=excluded.status,
+			  error=excluded.error,
+			  attempts=extracted_text.attempts+1,
+			  text=excluded.text,
+			  extracted_at=excluded.extracted_at`,
+			result.BlobHash, result.Extractor, result.ExtractorVersion,
+			result.Status, extractErr, text, nowRFC3339()); err != nil {
+			return fmt.Errorf("recording text extraction: %w", err)
+		}
+		if err := replaceContentFTSTx(ctx, tx, result.BlobHash, result.Extractor, text); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM text_extraction_queue WHERE blob_hash = ?`, result.BlobHash,
+		); err != nil {
+			return fmt.Errorf("finishing text extraction: %w", err)
+		}
+		return nil
+	})
+}
+
+func replaceContentFTSTx(
+	ctx context.Context, tx *sql.Tx, blobHash, extractor string, text any,
+) error {
+	var rowID int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT rowid FROM extracted_text WHERE blob_hash = ? AND extractor = ?`,
+		blobHash, extractor,
+	).Scan(&rowID); err != nil {
+		return fmt.Errorf("resolving extracted-text row: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM content_fts WHERE rowid = ?`, rowID,
+	); err != nil {
+		return fmt.Errorf("removing prior content search row: %w", err)
+	}
+	if text == nil {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO content_fts(rowid,blob_hash,extractor,text) VALUES(?,?,?,?)`,
+		rowID, blobHash, extractor, text,
+	); err != nil {
+		return fmt.Errorf("indexing extracted text: %w", err)
+	}
+	return nil
+}

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -67,6 +67,14 @@ func (s *Store) DeleteBlobRows(ctx context.Context, hashes []string) error {
 			if _, err := tx.Exec(`DELETE FROM blob_pack_index WHERE blob_hash = ?`, h); err != nil {
 				return fmt.Errorf("deleting packed mapping of %s: %w", h, err)
 			}
+			if _, err := tx.Exec(`DELETE FROM text_extraction_queue WHERE blob_hash = ?`, h); err != nil {
+				return fmt.Errorf("deleting extraction queue row of %s: %w", h, err)
+			}
+			if _, err := tx.Exec(`DELETE FROM content_fts WHERE rowid IN (
+				SELECT rowid FROM extracted_text WHERE blob_hash = ?
+			)`, h); err != nil {
+				return fmt.Errorf("deleting content search rows of %s: %w", h, err)
+			}
 			if _, err := tx.Exec(`DELETE FROM extracted_text WHERE blob_hash = ?`, h); err != nil {
 				return fmt.Errorf("deleting extracted text of %s: %w", h, err)
 			}

--- a/internal/store/gc_test.go
+++ b/internal/store/gc_test.go
@@ -68,8 +68,12 @@ func TestDeleteBlobRows(t *testing.T) {
 		fakeHash("a1"), "2026-01-01T00:00:00Z")
 	require.NoError(t, err)
 	_, err = s.db.Exec(
-		`INSERT INTO extracted_text (blob_hash, extractor, extractor_version, status, extracted_at)
-		 VALUES (?, 'pdf', 1, 'ok', ?)`, fakeHash("a1"), "2026-01-01T00:00:00Z")
+		`INSERT INTO extracted_text (blob_hash, extractor, extractor_version, status, attempts, text, extracted_at)
+		 VALUES (?, 'plain-text', 1, 'ok', 1, 'searchable', ?)`,
+		fakeHash("a1"), "2026-01-01T00:00:00Z")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`INSERT INTO content_fts(rowid,blob_hash,extractor,text)
+		SELECT rowid,blob_hash,extractor,text FROM extracted_text WHERE blob_hash=?`, fakeHash("a1"))
 	require.NoError(t, err)
 
 	require.NoError(t, s.DeleteBlobRows(ctx, []string{fakeHash("a1")}))
@@ -78,6 +82,8 @@ func TestDeleteBlobRows(t *testing.T) {
 	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM blobs`).Scan(&n))
 	assert.Equal(t, 0, n)
 	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM extracted_text`).Scan(&n))
+	assert.Equal(t, 0, n)
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&n))
 	assert.Equal(t, 0, n)
 }
 

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -582,6 +582,9 @@ func (s *Store) ImportMetadata(ctx context.Context, r io.Reader) error {
 		if err := validateMetadataState(ctx, tx, header.NodeSequence); err != nil {
 			return err
 		}
+		if err := rebuildImportedTextExtractionStateTx(ctx, tx); err != nil {
+			return err
+		}
 		if _, err := tx.ExecContext(ctx, `UPDATE sqlite_sequence SET seq = ? WHERE name = 'nodes'`, header.NodeSequence); err != nil {
 			return fmt.Errorf("restoring node ID high-water mark: %w", err)
 		}
@@ -714,10 +717,6 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		if err := validateContentVersionRecord(v); err != nil {
 			return err
 		}
-		mimeType := ""
-		if v.MIMEType != nil {
-			mimeType = *v.MIMEType
-		}
 		_, err := tx.ExecContext(ctx, `INSERT INTO content_versions(
 			version_id,node_id,blob_hash,size,mime_type,recorded_at,node_revision,
 			introduced_operation_id,transition_kind,source_version_id
@@ -727,7 +726,7 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		if err != nil {
 			return err
 		}
-		return queueTextExtractionTx(tx, v.VersionID, v.BlobHash, mimeType)
+		return nil
 	case metadataIngestType:
 		var v metadataIngest
 		if err := decodeMetadataRecord(raw, &v); err != nil {
@@ -804,9 +803,7 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		if err := replaceContentFTSTx(ctx, tx, v.BlobHash, v.Extractor, text); err != nil {
 			return err
 		}
-		_, err = tx.ExecContext(ctx,
-			`DELETE FROM text_extraction_queue WHERE blob_hash = ?`, v.BlobHash)
-		return err
+		return nil
 	case metadataAuditAuthorityType:
 		var v metadataAuditAuthority
 		if err := decodeMetadataRecord(raw, &v); err != nil {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -609,6 +609,8 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		    + (SELECT COUNT(*) FROM watch_sources)
 		    + (SELECT COUNT(*) FROM tags) + (SELECT COUNT(*) FROM node_tags)
 		    + (SELECT COUNT(*) FROM extracted_text)
+		    + (SELECT COUNT(*) FROM text_extraction_queue)
+		    + (SELECT COUNT(*) FROM content_fts)
 		    + (SELECT COUNT(*) FROM audit_records)
 		    + (SELECT COUNT(*) FROM audit_authority)
 		    + (SELECT COUNT(*) FROM audit_scopes)
@@ -717,7 +719,14 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		) VALUES(?,?,?,?,?,?,?,?,?,?)`, v.VersionID, v.NodeID, v.BlobHash, v.Size,
 			v.MIMEType, v.RecordedAt, v.NodeRevision, v.IntroducedOperationID,
 			v.TransitionKind, v.SourceVersionID)
-		return err
+		if err != nil {
+			return err
+		}
+		mimeType := ""
+		if v.MIMEType != nil {
+			mimeType = *v.MIMEType
+		}
+		return queueTextExtractionTx(tx, v.BlobHash, mimeType)
 	case metadataIngestType:
 		var v metadataIngest
 		if err := decodeMetadataRecord(raw, &v); err != nil {
@@ -784,6 +793,18 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		}
 		_, err := tx.ExecContext(ctx, `INSERT INTO extracted_text(blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at) VALUES(?,?,?,?,?,?,?,?)`,
 			v.BlobHash, v.Extractor, v.ExtractorVersion, v.Status, v.Error, v.Attempts, v.Text, v.ExtractedAt)
+		if err != nil {
+			return err
+		}
+		var text any
+		if v.Status == ExtractionOK && v.Text != nil {
+			text = *v.Text
+		}
+		if err := replaceContentFTSTx(ctx, tx, v.BlobHash, v.Extractor, text); err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx,
+			`DELETE FROM text_extraction_queue WHERE blob_hash = ?`, v.BlobHash)
 		return err
 	case metadataAuditAuthorityType:
 		var v metadataAuditAuthority
@@ -1177,6 +1198,12 @@ func validateExtractedTextRecord(v metadataExtractedText) error {
 	}
 	if v.Status != "ok" && v.Status != "failed" {
 		return fmt.Errorf("invalid extraction status %q", v.Status)
+	}
+	if v.Status == ExtractionOK && (v.Text == nil || v.Error != nil) {
+		return errors.New("successful extraction requires text and no error")
+	}
+	if v.Status == ExtractionFailed && (v.Error == nil || v.Text != nil) {
+		return errors.New("failed extraction requires an error and no text")
 	}
 	if _, err := packstore.ParseHash(v.BlobHash); err != nil {
 		return fmt.Errorf("invalid extracted text blob hash: %w", err)

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -610,6 +610,7 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		    + (SELECT COUNT(*) FROM tags) + (SELECT COUNT(*) FROM node_tags)
 		    + (SELECT COUNT(*) FROM extracted_text)
 		    + (SELECT COUNT(*) FROM text_extraction_queue)
+		    + (SELECT COUNT(*) FROM text_searchable_versions)
 		    + (SELECT COUNT(*) FROM content_fts)
 		    + (SELECT COUNT(*) FROM audit_records)
 		    + (SELECT COUNT(*) FROM audit_authority)
@@ -713,6 +714,10 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		if err := validateContentVersionRecord(v); err != nil {
 			return err
 		}
+		mimeType := ""
+		if v.MIMEType != nil {
+			mimeType = *v.MIMEType
+		}
 		_, err := tx.ExecContext(ctx, `INSERT INTO content_versions(
 			version_id,node_id,blob_hash,size,mime_type,recorded_at,node_revision,
 			introduced_operation_id,transition_kind,source_version_id
@@ -722,11 +727,7 @@ func importMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw json
 		if err != nil {
 			return err
 		}
-		mimeType := ""
-		if v.MIMEType != nil {
-			mimeType = *v.MIMEType
-		}
-		return queueTextExtractionTx(tx, v.BlobHash, mimeType)
+		return queueTextExtractionTx(tx, v.VersionID, v.BlobHash, mimeType)
 	case metadataIngestType:
 		var v metadataIngest
 		if err := decodeMetadataRecord(raw, &v); err != nil {

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -153,6 +153,44 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	assert.Greater(t, created.ID, int64(100), "AUTOINCREMENT must not reuse any historically allocated ID")
 }
 
+func TestMetadataImportQueuesOnlyCurrentTextVersions(t *testing.T) {
+	ctx := t.Context()
+	source := newTestStore(t)
+	created, err := source.CreateFile(
+		ctx, source.RootID(), "notes.txt", fakeHash("71"), 4, "text/plain",
+	)
+	require.NoError(t, err)
+	current, _, err := source.ReplaceContent(
+		ctx, created.ID, created.Revision, fakeHash("72"), 5, "text/plain",
+	)
+	require.NoError(t, err)
+
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(ctx, &exported))
+	target := newTestStore(t)
+	require.NoError(t, target.ImportMetadata(ctx, bytes.NewReader(exported.Bytes())))
+
+	pending, err := target.PendingTextExtractions(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, current.BlobHash, pending[0].BlobHash)
+	assert.NotEqual(t, created.BlobHash, pending[0].BlobHash,
+		"retained historical versions must not be queued for ordinary search")
+
+	var searchable []string
+	rows, err := target.db.QueryContext(ctx,
+		`SELECT version_id FROM text_searchable_versions ORDER BY version_id`)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	for rows.Next() {
+		var versionID string
+		require.NoError(t, rows.Scan(&versionID))
+		searchable = append(searchable, versionID)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{current.CurrentVersionID}, searchable)
+}
+
 func TestImportMetadataRejectsInvalidProvenanceAuthorityAndRollsBack(t *testing.T) {
 	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
 	require.NoError(t, err)

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -131,6 +131,12 @@ func TestMetadataJSONLRoundTripPreservesLogicalState(t *testing.T) {
 	assert.False(t, truncated)
 	require.Len(t, results, 1, "FTS must be rebuilt by logical node import")
 	assert.Equal(t, node.ID, results[0].Node.ID)
+	results, truncated, err = target.SearchPage(ctx, "line", 10)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, results, 1, "content FTS must be rebuilt from extracted-text metadata")
+	assert.Equal(t, node.ID, results[0].Node.ID)
+	assert.Equal(t, SearchMatchContent, results[0].Match)
 
 	var packRows int64
 	require.NoError(t, target.db.QueryRowContext(ctx,

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -263,7 +263,8 @@ CREATE TABLE IF NOT EXISTS extracted_text (
 -- Derived work queue. Logical writes enqueue supported text in Go; the daemon
 -- drains it after terminally verified reads. It is not portable authority.
 CREATE TABLE IF NOT EXISTS text_extraction_queue (
-    blob_hash TEXT PRIMARY KEY REFERENCES blobs(hash) ON DELETE CASCADE
+    blob_hash       TEXT PRIMARY KEY REFERENCES blobs(hash) ON DELETE CASCADE,
+    next_attempt_at TEXT NOT NULL
 );
 
 -- Per-version search eligibility is derived from MIME policy in Go. Keeping

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -248,6 +248,7 @@ CREATE TABLE IF NOT EXISTS audit_memberships (
 CREATE INDEX IF NOT EXISTS audit_membership_node ON audit_memberships(node_id);
 
 CREATE TABLE IF NOT EXISTS extracted_text (
+    id                INTEGER PRIMARY KEY,
     blob_hash         TEXT NOT NULL,
     extractor         TEXT NOT NULL,
     extractor_version INTEGER NOT NULL,
@@ -256,7 +257,22 @@ CREATE TABLE IF NOT EXISTS extracted_text (
     attempts          INTEGER NOT NULL DEFAULT 0,
     text              TEXT,
     extracted_at      TEXT NOT NULL,
-    PRIMARY KEY (blob_hash, extractor)
+    UNIQUE (blob_hash, extractor)
+);
+
+-- Derived work queue. Logical writes enqueue supported text in Go; the daemon
+-- drains it after terminally verified reads. It is not portable authority.
+CREATE TABLE IF NOT EXISTS text_extraction_queue (
+    blob_hash TEXT PRIMARY KEY REFERENCES blobs(hash) ON DELETE CASCADE,
+    mime_type TEXT NOT NULL
+);
+
+-- Derived full-text cache. This table is rebuilt from extracted_text during
+-- portable import and is never part of document or audit authority.
+CREATE VIRTUAL TABLE IF NOT EXISTS content_fts USING fts5(
+    blob_hash UNINDEXED,
+    extractor UNINDEXED,
+    text
 );
 
 -- FTS over live node names. External-content table kept in sync by triggers;

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -263,8 +263,14 @@ CREATE TABLE IF NOT EXISTS extracted_text (
 -- Derived work queue. Logical writes enqueue supported text in Go; the daemon
 -- drains it after terminally verified reads. It is not portable authority.
 CREATE TABLE IF NOT EXISTS text_extraction_queue (
-    blob_hash TEXT PRIMARY KEY REFERENCES blobs(hash) ON DELETE CASCADE,
-    mime_type TEXT NOT NULL
+    blob_hash TEXT PRIMARY KEY REFERENCES blobs(hash) ON DELETE CASCADE
+);
+
+-- Per-version search eligibility is derived from MIME policy in Go. Keeping
+-- this projection separate lets existing vaults adopt it without altering the
+-- authoritative content-version table.
+CREATE TABLE IF NOT EXISTS text_searchable_versions (
+    version_id TEXT PRIMARY KEY REFERENCES content_versions(version_id) ON DELETE CASCADE
 );
 
 -- Derived full-text cache. This table is rebuilt from extracted_text during

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -78,6 +78,7 @@ func (s *Store) SearchPage(ctx context.Context, query string, limit int) ([]Sear
 		SELECT `+nodeCols+`
 		FROM `+nodeFrom+`
 		JOIN matched_blobs mb ON mb.blob_hash = cv.blob_hash
+		JOIN text_searchable_versions tsv ON tsv.version_id = cv.version_id
 		WHERE n.trashed_at IS NULL
 		ORDER BY mb.best_rank, n.name, n.id
 		LIMIT ?`, fq, remaining+len(nameHits)+1)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -2,15 +2,22 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 )
 
 // SearchHit is a search result with its display path.
 type SearchHit struct {
-	Node Node
-	Path string
+	Node  Node
+	Path  string
+	Match string
 }
+
+const (
+	SearchMatchName    = "name"
+	SearchMatchContent = "content"
+)
 
 // ftsQuery converts free-form user input into a safe FTS5 query: each
 // whitespace-separated term becomes a quoted prefix term. Embedded double
@@ -24,8 +31,10 @@ func ftsQuery(input string) string {
 	return strings.Join(terms, " ")
 }
 
-// SearchPage matches live node names against the query, best rank first, and
-// reports whether at least one additional match exists beyond limit.
+// SearchPage returns live name matches in their established order, followed
+// by content-only matches. Keeping the two ranks separate preserves the
+// deterministic name-search contract: enabling extraction never reorders or
+// hides a filename match that the same limit returned before.
 func (s *Store) SearchPage(ctx context.Context, query string, limit int) ([]SearchHit, bool, error) {
 	if limit <= 0 {
 		limit = 50
@@ -45,29 +54,87 @@ func (s *Store) SearchPage(ctx context.Context, query string, limit int) ([]Sear
 	if err != nil {
 		return nil, false, fmt.Errorf("searching %q: %w", query, err)
 	}
-	defer func() { _ = rows.Close() }()
+	nameHits, err := scanSearchRows(rows, SearchMatchName, query)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(nameHits) > limit {
+		nameHits = nameHits[:limit]
+		if err := s.addSearchPaths(ctx, nameHits); err != nil {
+			return nil, false, err
+		}
+		return nameHits, true, nil
+	}
 
+	// Content may also match a node already returned by name. Over-fetch by
+	// the complete name set so duplicate filtering cannot conceal truncation.
+	remaining := limit - len(nameHits)
+	rows, err = s.db.QueryContext(ctx, `
+		WITH matched_blobs AS (
+		  SELECT blob_hash, MIN(rank) AS best_rank
+		  FROM content_fts WHERE content_fts MATCH ?
+		  GROUP BY blob_hash
+		)
+		SELECT `+nodeCols+`
+		FROM `+nodeFrom+`
+		JOIN matched_blobs mb ON mb.blob_hash = cv.blob_hash
+		WHERE n.trashed_at IS NULL
+		ORDER BY mb.best_rank, n.name, n.id
+		LIMIT ?`, fq, remaining+len(nameHits)+1)
+	if err != nil {
+		return nil, false, fmt.Errorf("searching extracted content for %q: %w", query, err)
+	}
+	contentHits, err := scanSearchRows(rows, SearchMatchContent, query)
+	if err != nil {
+		return nil, false, err
+	}
+	seen := make(map[int64]struct{}, len(nameHits))
+	for _, hit := range nameHits {
+		seen[hit.Node.ID] = struct{}{}
+	}
+	filtered := contentHits[:0]
+	for _, hit := range contentHits {
+		if _, exists := seen[hit.Node.ID]; exists {
+			continue
+		}
+		filtered = append(filtered, hit)
+	}
+	truncated := len(filtered) > remaining
+	if truncated {
+		filtered = filtered[:remaining]
+	}
+	hits := make([]SearchHit, 0, len(nameHits)+len(filtered))
+	hits = append(hits, nameHits...)
+	hits = append(hits, filtered...)
+	if err := s.addSearchPaths(ctx, hits); err != nil {
+		return nil, false, err
+	}
+	return hits, truncated, nil
+}
+
+func scanSearchRows(rows *sql.Rows, match, query string) ([]SearchHit, error) {
+	defer func() { _ = rows.Close() }()
 	var hits []SearchHit
 	for rows.Next() {
 		n, err := scanNode(rows)
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
-		hits = append(hits, SearchHit{Node: n})
+		hits = append(hits, SearchHit{Node: n, Match: match})
 	}
 	if err := rows.Err(); err != nil {
-		return nil, false, fmt.Errorf("searching %q: %w", query, err)
+		return nil, fmt.Errorf("searching %q: %w", query, err)
 	}
-	truncated := len(hits) > limit
-	if truncated {
-		hits = hits[:limit]
-	}
+	return hits, nil
+}
+
+func (s *Store) addSearchPaths(ctx context.Context, hits []SearchHit) error {
 	for i := range hits {
 		p, err := s.Path(ctx, hits[i].Node.ID)
 		if err != nil {
-			return nil, false, err
+			return err
 		}
 		hits[i].Path = p
 	}
-	return hits, truncated, nil
+	return nil
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -136,6 +136,10 @@ func TestSearchContentFollowsStableNameMatches(t *testing.T) {
 		ctx, s.RootID(), "notes.md", fakeHash("b2"), 5, "text/markdown; charset=utf-8",
 	)
 	require.NoError(t, err)
+	unsupported, err := s.CreateFile(
+		ctx, s.RootID(), "scan.pdf", bodyMatch.BlobHash, 5, "application/pdf",
+	)
+	require.NoError(t, err)
 	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
 		BlobHash: nameMatch.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
 		Status: ExtractionOK, Text: "unrelated body",
@@ -153,6 +157,8 @@ func TestSearchContentFollowsStableNameMatches(t *testing.T) {
 	assert.Equal(t, SearchMatchName, hits[0].Match)
 	assert.Equal(t, bodyMatch.ID, hits[1].Node.ID)
 	assert.Equal(t, SearchMatchContent, hits[1].Match)
+	assert.NotEqual(t, unsupported.ID, hits[1].Node.ID,
+		"a shared blob does not make an unsupported current MIME searchable")
 
 	// The same limit still returns the filename match first and truthfully
 	// reports that a content match remains.
@@ -161,6 +167,19 @@ func TestSearchContentFollowsStableNameMatches(t *testing.T) {
 	require.Len(t, hits, 1)
 	assert.Equal(t, nameMatch.ID, hits[0].Node.ID)
 	assert.True(t, truncated)
+
+	// Relabeling the current bytes with an unsupported MIME must revoke the
+	// content match even though the immutable blob's derived text remains.
+	_, _, err = s.ReplaceContent(
+		ctx, bodyMatch.ID, bodyMatch.Revision, bodyMatch.BlobHash, bodyMatch.Size,
+		"application/octet-stream",
+	)
+	require.NoError(t, err)
+	hits, truncated, err = s.SearchPage(ctx, "quarterly", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.False(t, truncated)
+	assert.Equal(t, nameMatch.ID, hits[0].Node.ID)
 }
 
 func TestPendingAndFailedTextExtractions(t *testing.T) {
@@ -184,12 +203,12 @@ func TestPendingAndFailedTextExtractions(t *testing.T) {
 
 	_, err = s.db.Exec(`DELETE FROM text_extraction_queue`)
 	require.NoError(t, err)
-	pending, err := s.PendingTextExtractions(ctx, "plain-text", 1, 10)
+	pending, err := s.PendingTextExtractions(ctx, 10)
 	require.NoError(t, err)
 	assert.Empty(t, pending)
 	require.NoError(t, s.SeedTextExtractionQueue(ctx, "plain-text", 1))
 
-	pending, err = s.PendingTextExtractions(ctx, "plain-text", 1, 10)
+	pending, err = s.PendingTextExtractions(ctx, 10)
 	require.NoError(t, err)
 	require.Len(t, pending, 2)
 	assert.Equal(t, []string{textNode.BlobHash, jsonNode.BlobHash},
@@ -201,14 +220,14 @@ func TestPendingAndFailedTextExtractions(t *testing.T) {
 		BlobHash: textNode.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
 		Status: ExtractionFailed, Error: "not valid UTF-8",
 	}))
-	pending, err = s.PendingTextExtractions(ctx, "plain-text", 1, 10)
+	pending, err = s.PendingTextExtractions(ctx, 10)
 	require.NoError(t, err)
 	require.Len(t, pending, 1)
 	assert.Equal(t, jsonNode.BlobHash, pending[0].BlobHash)
 
 	// A future extractor implementation naturally retries the old result.
 	require.NoError(t, s.SeedTextExtractionQueue(ctx, "plain-text", 2))
-	pending, err = s.PendingTextExtractions(ctx, "plain-text", 2, 10)
+	pending, err = s.PendingTextExtractions(ctx, 10)
 	require.NoError(t, err)
 	assert.Len(t, pending, 2)
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -211,7 +213,7 @@ func TestPendingAndFailedTextExtractions(t *testing.T) {
 	pending, err = s.PendingTextExtractions(ctx, 10)
 	require.NoError(t, err)
 	require.Len(t, pending, 2)
-	assert.Equal(t, []string{textNode.BlobHash, jsonNode.BlobHash},
+	assert.ElementsMatch(t, []string{textNode.BlobHash, jsonNode.BlobHash},
 		[]string{pending[0].BlobHash, pending[1].BlobHash})
 	assert.NotEqual(t, oldTextHash, textNode.BlobHash,
 		"startup discovery should seed selected versions, not retained history")
@@ -230,4 +232,28 @@ func TestPendingAndFailedTextExtractions(t *testing.T) {
 	pending, err = s.PendingTextExtractions(ctx, 10)
 	require.NoError(t, err)
 	assert.Len(t, pending, 2)
+}
+
+func TestTextExtractionQueueDefersFailuresBehindReadyWork(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	hashes := make([]string, 65)
+	for i := range hashes {
+		hashes[i] = fakeHash(fmt.Sprintf("%02x", i+1))
+		_, err := s.CreateFile(
+			ctx, s.RootID(), fmt.Sprintf("item-%02d.txt", i+1),
+			hashes[i], 1, "text/plain",
+		)
+		require.NoError(t, err)
+	}
+	notBefore := time.Now().UTC().Add(time.Hour)
+	for _, hash := range hashes[:64] {
+		require.NoError(t, s.DeferTextExtraction(ctx, hash, notBefore))
+	}
+
+	pending, err := s.PendingTextExtractions(ctx, 64)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, hashes[64], pending[0].BlobHash,
+		"deferred failures must not starve later ready work")
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -234,6 +234,31 @@ func TestPendingAndFailedTextExtractions(t *testing.T) {
 	assert.Len(t, pending, 2)
 }
 
+func TestPendingTextExtractionsSkipsSupersededQueuedContent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	created, err := s.CreateFile(
+		ctx, s.RootID(), "notes.txt", fakeHash("d1"), 10, "text/plain",
+	)
+	require.NoError(t, err)
+	current, _, err := s.ReplaceContent(
+		ctx, created.ID, created.Revision, fakeHash("d2"), 12, "text/plain",
+	)
+	require.NoError(t, err)
+
+	var queued int
+	require.NoError(t, s.db.QueryRow(
+		`SELECT COUNT(*) FROM text_extraction_queue`,
+	).Scan(&queued))
+	assert.Equal(t, 2, queued, "the stale queue hint should exercise dequeue validation")
+
+	pending, err := s.PendingTextExtractions(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, current.BlobHash, pending[0].BlobHash)
+	assert.NotEqual(t, created.BlobHash, pending[0].BlobHash)
+}
+
 func TestTextExtractionQueueDefersFailuresBehindReadyWork(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -25,6 +25,7 @@ func TestSearchFindsLiveNodesOnly(t *testing.T) {
 	require.Len(t, hits, 1)
 	assert.Equal(t, "tax-return-2024.pdf", hits[0].Node.Name)
 	assert.Equal(t, "/docs/tax-return-2024.pdf", hits[0].Path)
+	assert.Equal(t, SearchMatchName, hits[0].Match)
 }
 
 func TestSearchPrefixAndRename(t *testing.T) {
@@ -121,4 +122,93 @@ func TestSearchPageReportsTruncation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, hits, 3)
 	assert.False(t, truncated)
+}
+
+func TestSearchContentFollowsStableNameMatches(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	nameMatch, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-forecast.md", fakeHash("a1"), 5, "text/markdown",
+	)
+	require.NoError(t, err)
+	bodyMatch, err := s.CreateFile(
+		ctx, s.RootID(), "notes.md", fakeHash("b2"), 5, "text/markdown; charset=utf-8",
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: nameMatch.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "unrelated body",
+	}))
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: bodyMatch.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "quarterly forecast assumptions",
+	}))
+
+	hits, truncated, err := s.SearchPage(ctx, "quarterly", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.False(t, truncated)
+	assert.Equal(t, nameMatch.ID, hits[0].Node.ID)
+	assert.Equal(t, SearchMatchName, hits[0].Match)
+	assert.Equal(t, bodyMatch.ID, hits[1].Node.ID)
+	assert.Equal(t, SearchMatchContent, hits[1].Match)
+
+	// The same limit still returns the filename match first and truthfully
+	// reports that a content match remains.
+	hits, truncated, err = s.SearchPage(ctx, "quarterly", 1)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, nameMatch.ID, hits[0].Node.ID)
+	assert.True(t, truncated)
+}
+
+func TestPendingAndFailedTextExtractions(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	textNode, err := s.CreateFile(
+		ctx, s.RootID(), "notes.txt", fakeHash("a1"), 10, "text/plain; charset=utf-8",
+	)
+	require.NoError(t, err)
+	jsonNode, err := s.CreateFile(
+		ctx, s.RootID(), "session.jsonl", fakeHash("b2"), 20, "application/x-ndjson",
+	)
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, s.RootID(), "scan.pdf", fakeHash("c3"), 30, "application/pdf")
+	require.NoError(t, err)
+	oldTextHash := textNode.BlobHash
+	textNode, _, err = s.ReplaceContent(
+		ctx, textNode.ID, textNode.Revision, fakeHash("a0"), 12, "text/plain",
+	)
+	require.NoError(t, err)
+
+	_, err = s.db.Exec(`DELETE FROM text_extraction_queue`)
+	require.NoError(t, err)
+	pending, err := s.PendingTextExtractions(ctx, "plain-text", 1, 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	require.NoError(t, s.SeedTextExtractionQueue(ctx, "plain-text", 1))
+
+	pending, err = s.PendingTextExtractions(ctx, "plain-text", 1, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	assert.Equal(t, []string{textNode.BlobHash, jsonNode.BlobHash},
+		[]string{pending[0].BlobHash, pending[1].BlobHash})
+	assert.NotEqual(t, oldTextHash, textNode.BlobHash,
+		"startup discovery should seed selected versions, not retained history")
+
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: textNode.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionFailed, Error: "not valid UTF-8",
+	}))
+	pending, err = s.PendingTextExtractions(ctx, "plain-text", 1, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, jsonNode.BlobHash, pending[0].BlobHash)
+
+	// A future extractor implementation naturally retries the old result.
+	require.NoError(t, s.SeedTextExtractionQueue(ctx, "plain-text", 2))
+	pending, err = s.PendingTextExtractions(ctx, "plain-text", 2, 10)
+	require.NoError(t, err)
+	assert.Len(t, pending, 2)
 }

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -416,6 +416,9 @@ func installContentVersionWithOperationTx(
 		return Node{}, ContentVersion{}, fmt.Errorf(
 			"recording %s content version for node %d: %w", transitionKind, n.ID, err)
 	}
+	if err := queueTextExtractionTx(tx, blobHash, mimeType); err != nil {
+		return Node{}, ContentVersion{}, err
+	}
 	if _, err := tx.Exec(
 		`UPDATE nodes SET current_version_id = ?, revision = ?, modified_at = ? WHERE id = ?`,
 		operation.versionID, newRevision, operation.recordedAt, n.ID); err != nil {

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -416,7 +416,7 @@ func installContentVersionWithOperationTx(
 		return Node{}, ContentVersion{}, fmt.Errorf(
 			"recording %s content version for node %d: %w", transitionKind, n.ID, err)
 	}
-	if err := queueTextExtractionTx(tx, blobHash, mimeType); err != nil {
+	if err := queueTextExtractionTx(tx, operation.versionID, blobHash, mimeType); err != nil {
 		return Node{}, ContentVersion{}, err
 	}
 	if _, err := tx.Exec(

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -246,6 +246,9 @@ func (s *Store) createFileWithOperationTx(
 		return Node{}, ContentVersion{}, fmt.Errorf(
 			"recording initial content version for node %d: %w", id, err)
 	}
+	if err := queueTextExtractionTx(tx, blobHash, mimeType); err != nil {
+		return Node{}, ContentVersion{}, err
+	}
 	if err := bumpRevisionTx(tx, parentID, operation.recordedAt); err != nil {
 		return Node{}, ContentVersion{}, err
 	}

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -246,7 +246,7 @@ func (s *Store) createFileWithOperationTx(
 		return Node{}, ContentVersion{}, fmt.Errorf(
 			"recording initial content version for node %d: %w", id, err)
 	}
-	if err := queueTextExtractionTx(tx, blobHash, mimeType); err != nil {
+	if err := queueTextExtractionTx(tx, operation.versionID, blobHash, mimeType); err != nil {
 		return Node{}, ContentVersion{}, err
 	}
 	if err := bumpRevisionTx(tx, parentID, operation.recordedAt); err != nil {


### PR DESCRIPTION
Docbank can find filenames today, but the meaning of a note, Markdown record, or agent-session archive often lives only in its body. This adds the first content-extraction worker for formats that are already text: UTF-8 `text/*`, Markdown, JSON, and JSONL documents up to 16 MiB. PDF, Office, image, and OCR extraction remain separate work.

The worker reads loose and packed blobs through Docbank's verified streaming boundary and publishes searchable text only after the complete stream reaches verified EOF. Oversized, binary, or invalid-UTF-8 input remains normal authoritative document content; only its derived extraction attempt fails. Operational open, read, and verification failures stay queued with a persisted bounded retry time. Polling orders work by readiness, so even a full batch of persistent failures moves aside for healthy documents instead of monopolizing the queue.

Search keeps the existing filename contract intact. Name matches retain exactly their established rank and always appear first; content-only matches follow in their own rank order. Human output and JSON identify whether each result matched `name` or `content`, and ordinary search considers only the current selected version of each live document. MIME eligibility is computed in Go and recorded as a rebuildable per-version projection, so shared bytes or a MIME-only replacement cannot make unsupported PDF or octet-stream content searchable.

The worker runs under the existing daemon supervisor and mutation gate, so `docbank jobs` exposes it and GC cannot retire content during extraction. Startup discovery and eligibility publication share one storage transaction, preventing concurrent deletion from invalidating a selected version between those steps. The extractor-versioned cache travels through portable JSONL metadata, rebuilds its FTS and eligibility projections during restore, and is removed with reclaimed blobs.

Coverage exercises packed reads, transient-failure recovery, queue fairness beyond a full failed batch, shared hashes and MIME-only replacement, watched JSONL ingestion through the real daemon, stable ranking and truncation, restore and GC behavior, targeted race detection, both SQLite implementations, and Windows amd64/arm64 compilation. The human, agent, API, storage, troubleshooting, and roadmap documentation describe the same implemented boundary.

Kata: `xsj7` (child of `28h0`).