### PR TITLE
Put installation in the homepage top fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Four commitments:
   per-node history, independent chain/protected-byte verification, exact-prefix
   checks against externally recorded evidence, and backup/restore fidelity
 - FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
-  (body search is available from source until the next tagged release)
 - Mixed loose and packed content storage with explicit pack, GC, and repack
 - Whole-vault integrity verification
 - Incremental backup repositories with create, list, verify, and confined restore

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,14 @@ incremental backups can be verified before you rely on them. Work directly
 from the CLI, automate through the authenticated HTTP API, or embed Docbank in
 a Go application.
 
+Install the latest release on Linux or macOS:
+
+```bash
+curl -fsSL https://docbank.ai/install.sh | sh
+```
+
+[Windows and source-build instructions](setup.md)
+
 <p class="hero-actions">
   <a class="md-button md-button--primary" href="setup/">Start your vault</a>
   <a class="md-button" href="quickstart/">Ten-minute tour</a>
@@ -43,25 +51,12 @@ a Go application.
   </section>
 </div>
 
-Install with one command (Linux and macOS; see [Setup](setup.md) for
-Windows and source builds):
-
-```bash
-curl -fsSL https://docbank.ai/install.sh | sh
-```
-
-!!! info "Content-search availability"
-
-    The current v0.8.1 installer searches document names. Verified UTF-8 body
-    search is available in source builds and will enter the installer with the
-    next tagged release.
-
 The ordinary workflow stays direct:
 
 ```bash
 docbank add ~/Documents/taxes --dest /taxes    # import a folder; sources untouched
 docbank tree /taxes                            # browse the virtual tree
-docbank search "insurance"                     # ranked name search; source builds also search text
+docbank search "insurance"                     # ranked name and verified plain-text search
 docbank put revised.pdf /taxes/2026/return.pdf # add a new immutable version
 docbank versions list /taxes/2026/return.pdf   # inspect retained history
 docbank rm /inbox/junk.pdf                     # move to recoverable trash


### PR DESCRIPTION
A visitor who is ready to try Docbank currently has to scroll past the first feature grid before seeing how to install it. This moves the Linux/macOS command directly beneath the opening explanation, before the homepage buttons and capability cards:

```bash
curl -fsSL https://docbank.ai/install.sh | sh
```

Windows and source-build instructions remain one click away beside the command, so the faster path does not hide the cross-platform story. The page and README also stop describing body search as source-only now that v0.9.0 ships it.

The strict documentation build confirms the revised homepage and raw Markdown publication are valid.

Kata: `hda7`.