### PR TITLE
Bound tree output for humans and agents

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -157,6 +157,73 @@ func TestAddLsTreeCat(t *testing.T) {
 	assert.Equal(t, "hello vault", out)
 }
 
+func TestTreeBoundsAndReportsOmissions(t *testing.T) {
+	_ = setupVaultHome(t)
+	c, err := client.Ensure(context.Background())
+	require.NoError(t, err)
+	root, err := c.Stat(context.Background(), "/")
+	require.NoError(t, err)
+
+	parent := root
+	for _, name := range []string{"one", "two", "three", "four", "five"} {
+		parent, err = c.Mkdir(context.Background(), parent.ID, name)
+		require.NoError(t, err)
+	}
+
+	out, err := runCLI(t, "tree", "/", "--json")
+	require.NoError(t, err)
+	var listing treeListing
+	require.NoError(t, json.Unmarshal([]byte(out), &listing))
+	require.Len(t, listing.Items, defaultTreeDepth)
+	assert.True(t, listing.Truncated)
+	assert.Equal(t, []treeOmission{{
+		Path: "/one/two/three/four", Reason: "depth_limit", DirectChildren: 1,
+	}}, listing.Omissions)
+
+	out, err = runCLI(t, "tree", "/", "--json", "--depth", "2")
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(out), &listing))
+	require.Len(t, listing.Items, 2)
+	assert.Equal(t, "/one/two", listing.Items[1].Path)
+	assert.Equal(t, []treeOmission{{
+		Path: "/one/two", Reason: "depth_limit", DirectChildren: 1,
+	}}, listing.Omissions)
+
+	out, err = runCLI(t, "tree", "/", "--json", "--max-entries", "2")
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(out), &listing))
+	require.Len(t, listing.Items, 2)
+	assert.Equal(t, []treeOmission{{
+		Path: "/one/two", Reason: "entry_limit", DirectChildren: 1,
+	}}, listing.Omissions)
+
+	out, err = runCLI(t, "tree", "/", "--all", "--json")
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(out), &listing))
+	require.Len(t, listing.Items, 5)
+	assert.False(t, listing.Truncated)
+	assert.Empty(t, listing.Omissions)
+	assert.Contains(t, out, `"omissions":[]`)
+
+	out, err = runCLI(t, "tree", "/", "--depth", "2")
+	require.NoError(t, err)
+	assert.Contains(t, out, "... tree truncated at 1 boundary(s):")
+	assert.Contains(t, out, "/one/two: 1 direct entry hidden by depth limit")
+	assert.Contains(t, out, "use --all deliberately")
+
+	for _, args := range [][]string{
+		{"tree", "--depth", "0"},
+		{"tree", "--max-entries", "0"},
+		{"tree", "--all", "--depth", "2"},
+	} {
+		_, err = runCLI(t, args...)
+		require.Error(t, err)
+		var classified *exitError
+		require.ErrorAs(t, err, &classified)
+		assert.Equal(t, exitUsage, classified.code)
+	}
+}
+
 func TestLegacyReadCommandsJSON(t *testing.T) {
 	_ = setupVaultHome(t)
 
@@ -175,6 +242,8 @@ func TestLegacyReadCommandsJSON(t *testing.T) {
 	assert.Equal(t, "/", tree.Root.Path)
 	assert.Empty(t, tree.Items)
 	assert.Contains(t, out, `"items":[]`)
+	assert.False(t, tree.Truncated)
+	assert.Contains(t, out, `"omissions":[]`)
 
 	src := writeSourceFile(t, "notes.txt", "searchable notes")
 	_, err = runCLI(t, "add", src, "--dest", "/inbox")

--- a/cmd/docbank/tree.go
+++ b/cmd/docbank/tree.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -16,6 +17,18 @@ import (
 
 var treeJSON bool
 
+const (
+	defaultTreeDepth      = 4
+	defaultTreeMaxEntries = 1000
+	treePageSize          = 500
+)
+
+var (
+	treeDepth      int
+	treeMaxEntries int
+	treeAll        bool
+)
+
 type treeEntry struct {
 	Node  api.Node `json:"node"`
 	Path  string   `json:"path"`
@@ -23,8 +36,24 @@ type treeEntry struct {
 }
 
 type treeListing struct {
-	Root  api.Node    `json:"root"`
-	Items []treeEntry `json:"items"`
+	Root      api.Node       `json:"root"`
+	Items     []treeEntry    `json:"items"`
+	Truncated bool           `json:"truncated"`
+	Omissions []treeOmission `json:"omissions"`
+}
+
+type treeOmission struct {
+	Path           string `json:"path"`
+	Reason         string `json:"reason" enum:"depth_limit,entry_limit"`
+	DirectChildren int    `json:"direct_children"`
+}
+
+type treeWalker struct {
+	client     *client.Client
+	maxDepth   int
+	maxEntries int
+	items      []treeEntry
+	omissions  []treeOmission
 }
 
 var treeCmd = &cobra.Command{
@@ -32,75 +61,163 @@ var treeCmd = &cobra.Command{
 	Short: "Print the virtual tree",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		path := "/"
+		if treeDepth < 1 {
+			return usageError(errors.New("tree --depth must be at least 1"))
+		}
+		if treeMaxEntries < 1 {
+			return usageError(errors.New("tree --max-entries must be at least 1"))
+		}
+		if treeAll && (cmd.Flags().Changed("depth") || cmd.Flags().Changed("max-entries")) {
+			return usageError(errors.New("tree --all cannot be combined with --depth or --max-entries"))
+		}
+		rootPath := "/"
 		if len(args) == 1 {
-			path = args[0]
+			rootPath = args[0]
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
 			return err
 		}
 		ctx := cmd.Context()
-		root, err := c.Stat(ctx, path)
+		root, err := c.Stat(ctx, rootPath)
 		if err != nil {
-			return fmt.Errorf("resolving %q: %w", path, err)
+			return fmt.Errorf("resolving %q: %w", rootPath, err)
 		}
 		if root.Kind != "dir" {
-			return fmt.Errorf("%s: %w", path, store.ErrNotDir)
+			return fmt.Errorf("%s: %w", rootPath, store.ErrNotDir)
+		}
+		walker := treeWalker{
+			client: c, maxDepth: treeDepth, maxEntries: treeMaxEntries,
+			items: []treeEntry{}, omissions: []treeOmission{},
+		}
+		if treeAll {
+			walker.maxDepth, walker.maxEntries = 0, 0
+		}
+		if err := walker.walk(ctx, root.Path, root.ID, 1); err != nil {
+			return err
+		}
+		listing := treeListing{
+			Root: root, Items: walker.items, Truncated: len(walker.omissions) > 0,
+			Omissions: walker.omissions,
 		}
 		if treeJSON {
-			items := []treeEntry{}
-			if err := collectTree(ctx, c, root.Path, root.ID, 1, &items); err != nil {
-				return err
-			}
-			return writeCLIJSON(cmd.OutOrStdout(), treeListing{Root: root, Items: items})
+			return writeCLIJSON(cmd.OutOrStdout(), listing)
 		}
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), path)
-		return printTree(ctx, cmd.OutOrStdout(), c, root.ID, 1)
+		return writeTree(cmd.OutOrStdout(), listing)
 	},
 }
 
-func collectTree(
-	ctx context.Context,
-	c *client.Client,
-	parentPath string,
-	dirID int64,
-	depth int,
-	items *[]treeEntry,
+func (w *treeWalker) exhausted() bool {
+	return w.maxEntries > 0 && len(w.items) >= w.maxEntries
+}
+
+func (w *treeWalker) walk(ctx context.Context, parentPath string, dirID int64, depth int) error {
+	for offset := 0; ; {
+		limit := treePageSize
+		if w.maxEntries > 0 {
+			limit = min(limit, w.maxEntries-len(w.items))
+		}
+		if limit == 0 {
+			return nil
+		}
+		page, err := w.client.ChildrenPage(ctx, dirID, limit, offset)
+		if err != nil {
+			return err
+		}
+		for i, kid := range page.Items {
+			kidPath := path.Join(parentPath, kid.Name)
+			w.items = append(w.items, treeEntry{Node: kid, Path: kidPath, Depth: depth})
+			if kid.Kind == "dir" {
+				switch {
+				case w.maxDepth > 0 && depth >= w.maxDepth:
+					if err := w.omitChildren(ctx, kidPath, kid.ID, "depth_limit"); err != nil {
+						return err
+					}
+				case w.exhausted():
+					if err := w.omitChildren(ctx, kidPath, kid.ID, "entry_limit"); err != nil {
+						return err
+					}
+				default:
+					if err := w.walk(ctx, kidPath, kid.ID, depth+1); err != nil {
+						return err
+					}
+				}
+			}
+			if w.exhausted() {
+				if remaining := page.Total - (offset + i + 1); remaining > 0 {
+					w.omissions = append(w.omissions, treeOmission{
+						Path: parentPath, Reason: "entry_limit", DirectChildren: remaining,
+					})
+				}
+				return nil
+			}
+		}
+		offset += len(page.Items)
+		if offset >= page.Total {
+			return nil
+		}
+	}
+}
+
+func (w *treeWalker) omitChildren(
+	ctx context.Context, dirPath string, dirID int64, reason string,
 ) error {
-	kids, err := c.Children(ctx, dirID)
+	page, err := w.client.ChildrenPage(ctx, dirID, 1, 0)
 	if err != nil {
 		return err
 	}
-	for _, kid := range kids {
-		kidPath := path.Join(parentPath, kid.Name)
-		*items = append(*items, treeEntry{Node: kid, Path: kidPath, Depth: depth})
-		if kid.Kind == "dir" {
-			if err := collectTree(ctx, c, kidPath, kid.ID, depth+1, items); err != nil {
-				return err
-			}
-		}
+	if page.Total > 0 {
+		w.omissions = append(w.omissions, treeOmission{
+			Path: dirPath, Reason: reason, DirectChildren: page.Total,
+		})
 	}
 	return nil
 }
 
-func printTree(ctx context.Context, w io.Writer, c *client.Client, dirID int64, depth int) error {
-	kids, err := c.Children(ctx, dirID)
-	if err != nil {
-		return err
+func writeTree(w io.Writer, listing treeListing) error {
+	if _, err := fmt.Fprintln(w, listing.Root.Path); err != nil {
+		return fmt.Errorf("writing tree: %w", err)
 	}
-	for _, k := range kids {
-		_, _ = fmt.Fprintf(w, "%s%s  [%d]\n", strings.Repeat("  ", depth), k.Name, k.ID)
-		if k.Kind == "dir" {
-			if err := printTree(ctx, w, c, k.ID, depth+1); err != nil {
-				return err
-			}
+	for _, item := range listing.Items {
+		if _, err := fmt.Fprintf(w, "%s%s  [%d]\n",
+			strings.Repeat("  ", item.Depth), item.Node.Name, item.Node.ID); err != nil {
+			return fmt.Errorf("writing tree: %w", err)
 		}
+	}
+	if !listing.Truncated {
+		return nil
+	}
+	if _, err := fmt.Fprintf(w, "... tree truncated at %d boundary(s):\n", len(listing.Omissions)); err != nil {
+		return fmt.Errorf("writing tree: %w", err)
+	}
+	for _, omission := range listing.Omissions {
+		reason := "depth limit"
+		if omission.Reason == "entry_limit" {
+			reason = "entry limit"
+		}
+		entryWord := "entries"
+		if omission.DirectChildren == 1 {
+			entryWord = "entry"
+		}
+		if _, err := fmt.Fprintf(w, "  %s: %d direct %s hidden by %s\n",
+			omission.Path, omission.DirectChildren, entryWord, reason); err != nil {
+			return fmt.Errorf("writing tree: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintln(w,
+		"narrow the path, raise --depth/--max-entries, or use --all deliberately"); err != nil {
+		return fmt.Errorf("writing tree: %w", err)
 	}
 	return nil
 }
 
 func init() {
 	treeCmd.Flags().BoolVar(&treeJSON, "json", false, "emit machine-readable JSON")
+	treeCmd.Flags().IntVarP(&treeDepth, "depth", "L", defaultTreeDepth,
+		"maximum depth beneath the root")
+	treeCmd.Flags().IntVar(&treeMaxEntries, "max-entries", defaultTreeMaxEntries,
+		"maximum nodes to print")
+	treeCmd.Flags().BoolVar(&treeAll, "all", false,
+		"print the complete subtree without depth or entry limits")
 	rootCmd.AddCommand(treeCmd)
 }

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -108,8 +108,18 @@ a trashed node as display or recovery context rather than identity.
 
 ## Read a tree without unbounded responses
 
-Directory children are paginated and sorted with directories first, then by
-name. Use `total`, `limit`, and `offset` until the complete page set is read:
+The CLI tree view is bounded by default to four levels and 1,000 nodes. Set
+explicit limits for the task and inspect `truncated` plus `omissions` before
+assuming the result is complete:
+
+```bash
+docbank tree /taxes -L 3 --max-entries 500 --json
+```
+
+Use `--all` only when the complete subtree is known to be appropriately sized.
+For finer control, directory children are paginated and sorted with directories
+first, then by name. Use `total`, `limit`, and `offset` until the required page
+set is read:
 
 ```bash
 curl --fail-with-body \

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -122,16 +122,26 @@ ordered child list under `items`. Empty directories produce `"items": []`.
 ## docbank tree
 
 ```
-docbank tree [path] [--json]
+docbank tree [path] [-L <depth>] [--max-entries <count>] [--all] [--json]
 ```
 
-Prints the subtree rooted at `path` (default `/`), two-space indented,
-each entry suffixed with its node ID in brackets. Fails without output if
-`path` names a file.
+Prints the subtree rooted at `path` (default `/`), two-space indented, each
+entry suffixed with its node ID in brackets. Output is bounded by default to
+four levels and 1,000 nodes, so an exploratory command cannot flood a terminal
+or an agent's context. `-L`/`--depth` and `--max-entries` set narrower or wider
+bounds. `--all` deliberately restores an unlimited traversal and cannot be
+combined with either bound. Fails without output if `path` names a file.
+
+When a bound hides entries, human output names every truncation boundary and
+the number of direct children omitted there. Narrow the root path or increase a
+bound before using `--all` on an unfamiliar archive.
 
 `--json` returns the resolved root and a deterministic, pre-order `items`
 array. Each item contains the node, its absolute virtual `path`, and its
-`depth` beneath the root (direct children have depth 1).
+`depth` beneath the root (direct children have depth 1). Always inspect
+`truncated`; when true, `omissions` contains the affected path, the
+`depth_limit` or `entry_limit` reason, and the number of direct children not
+returned at that boundary.
 
 ## docbank cat
 

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -225,12 +225,7 @@ func registerReadRoutes(api huma.API, d Deps) {
 	})
 
 	type childrenPage struct {
-		Body struct {
-			Items  []Node `json:"items"`
-			Total  int    `json:"total"`
-			Limit  int    `json:"limit"`
-			Offset int    `json:"offset"`
-		}
+		Body NodePage
 	}
 	huma.Register(api, huma.Operation{
 		OperationID: "listChildren", Method: http.MethodGet, Path: "/api/v1/nodes/{id}/children",

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -34,6 +34,14 @@ type Node struct {
 	Path             string `json:"path,omitempty"` // set on single-node responses only
 }
 
+// NodePage is one bounded, ordered directory-child listing.
+type NodePage struct {
+	Items  []Node `json:"items"`
+	Total  int    `json:"total"`
+	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
+}
+
 // ContentVersion is the wire representation of an immutable version record.
 type ContentVersion struct {
 	ID                    string  `json:"id" format:"uuid"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -279,25 +279,51 @@ func (c *Client) Stat(ctx context.Context, path string) (api.Node, error) {
 	return n, err
 }
 
-// Children fetches every page. Callers that need streaming can add it when
-// a real consumer appears (YAGNI).
+// Children fetches every page. Callers that need bounded traversal should use
+// ChildrenPage.
 func (c *Client) Children(ctx context.Context, id int64) ([]api.Node, error) {
 	const pageSize = 1000
 	all := []api.Node{}
-	for offset := 0; ; offset += pageSize {
-		var page struct {
-			Items []api.Node `json:"items"`
-			Total int        `json:"total"`
-		}
-		p := fmt.Sprintf("/api/v1/nodes/%d/children?limit=%d&offset=%d", id, pageSize, offset)
-		if err := c.do(ctx, http.MethodGet, p, nil, nil, &page); err != nil {
+	for offset := 0; ; {
+		page, err := c.ChildrenPage(ctx, id, pageSize, offset)
+		if err != nil {
 			return nil, err
 		}
 		all = append(all, page.Items...)
-		if offset+pageSize >= page.Total {
+		if len(all) >= page.Total {
 			return all, nil
 		}
+		offset += len(page.Items)
 	}
+}
+
+// ChildrenPage returns one bounded page of a directory's ordered live
+// children. Recursive consumers should use this method instead of assembling
+// an unbounded sibling list through Children.
+func (c *Client) ChildrenPage(
+	ctx context.Context, id int64, limit, offset int,
+) (api.NodePage, error) {
+	var page api.NodePage
+	if id < 1 {
+		return page, errors.New("directory node ID must be positive")
+	}
+	if limit < 1 || limit > 5000 {
+		return page, errors.New("child-page limit must be between 1 and 5000")
+	}
+	if offset < 0 {
+		return page, errors.New("child-page offset must not be negative")
+	}
+	p := fmt.Sprintf("/api/v1/nodes/%d/children?limit=%d&offset=%d", id, limit, offset)
+	if err := c.do(ctx, http.MethodGet, p, nil, nil, &page); err != nil {
+		return api.NodePage{}, err
+	}
+	if page.Limit != limit || page.Offset != offset || page.Total < 0 ||
+		len(page.Items) > limit ||
+		(len(page.Items) == 0 && offset < page.Total) ||
+		(len(page.Items) > 0 && offset+len(page.Items) > page.Total) {
+		return api.NodePage{}, errors.New("children response has inconsistent pagination")
+	}
+	return page, nil
 }
 
 func (c *Client) Content(ctx context.Context, id int64) (*ContentStream, error) {


### PR DESCRIPTION
Opening an unfamiliar archive should not mean accidentally dumping its entire namespace into a terminal or an agent's context. Until now, `docbank tree /` recursively fetched and printed every descendant with no stopping point.

This makes exploratory tree reads safe by default: `docbank tree` shows at most four levels and 1,000 nodes. If either boundary is reached, human output says where entries were hidden and how many direct children were omitted. JSON callers receive the same evidence through `truncated` and structured `omissions`, so an agent cannot mistake a partial tree for a complete one.

For example, an agent can ask for exactly the view it needs:

```bash
docbank tree /taxes -L 3 --max-entries 500 --json
```

A person or agent can narrow the root or raise either bound after inspecting the result. `--all` remains available for a deliberate complete traversal, but cannot be mixed with bounds. The paginated children API remains unchanged; the typed Go client now exposes one page at a time so bounded recursive consumers do not first assemble an unlimited sibling list.

Kata: `vy5n`.
