### PR TITLE
Build disposable embedding generations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends build-essential ca-certificates file git gzip tar
+          apt-get install -y --no-install-recommends \
+            build-essential ca-certificates file git gzip libsqlite3-dev tar
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -993,6 +995,64 @@ func TestSearchCLIReportsTruncation(t *testing.T) {
 	_, err = runCLI(t, "search", "report", "--limit", "0")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "between 1 and 1000")
+}
+
+func TestEmbeddingsCLIConfiguresBuildsAndListsGeneration(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DOCBANK_HOME", dir)
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/embeddings", r.URL.Path)
+		var request struct {
+			Model string   `json:"model"`
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decoding embedding request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, "test-model", request.Model)
+		assert.Equal(t, []string{"vector substrate example"}, request.Input)
+		items := make([]map[string]any, len(request.Input))
+		for i := range request.Input {
+			items[i] = map[string]any{"index": i, "embedding": []float32{1, 0}}
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{"data": items}); err != nil {
+			t.Errorf("encoding embedding response: %v", err)
+		}
+	}))
+	t.Cleanup(endpoint.Close)
+	configBody := "[embeddings]\nbase_url = " + strconv.Quote(endpoint.URL+"/v1") +
+		"\nmodel = \"test-model\"\ndimensions = 2\nbatch_size = 8\nconcurrency = 1\ntimeout = \"2s\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.toml"), []byte(configBody), 0o600))
+	startTestDaemon(t, dir)
+	source := writeSourceFile(t, "embedding.txt", "vector substrate example")
+	_, err := runCLI(t, "add", source, "--dest", "/inbox")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		out, searchErr := runCLI(t, "search", "substrate", "--json")
+		if searchErr != nil {
+			return false
+		}
+		var report api.SearchReport
+		return json.Unmarshal([]byte(out), &report) == nil && len(report.Hits) == 1
+	}, 5*time.Second, 25*time.Millisecond)
+
+	out, err := runCLI(t, "embeddings", "list")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "no embedding generations")
+	out, err = runCLI(t, "embeddings", "build", "--json")
+	require.NoError(t, err, out)
+	var result api.EmbeddingBuildResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "test-model", result.Model)
+	assert.True(t, result.Activated)
+	assert.Equal(t, 1, result.Embedded)
+	assert.Equal(t, 1, result.Chunks)
+	out, err = runCLI(t, "embeddings", "list")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "test-model")
+	assert.Contains(t, out, "active")
 }
 
 func TestTrashEmpty(t *testing.T) {

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -25,11 +25,13 @@ import (
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/config"
 	"go.kenn.io/docbank/internal/daemonlife"
+	"go.kenn.io/docbank/internal/embedding"
 	"go.kenn.io/docbank/internal/extract"
 	"go.kenn.io/docbank/internal/home"
 	"go.kenn.io/docbank/internal/ingest"
 	"go.kenn.io/docbank/internal/jobs"
 	"go.kenn.io/docbank/internal/store"
+	docvector "go.kenn.io/docbank/internal/vector"
 )
 
 var daemonRunCmd = &cobra.Command{
@@ -169,6 +171,11 @@ func runServe(ctx context.Context) (retErr error) {
 	if err := jobSupervisor.Start("extract:plain-text", textWorker.Run); err != nil {
 		return fmt.Errorf("starting text extraction: %w", err)
 	}
+	embeddings, closeEmbeddings, err := buildEmbeddingsService(sigCtx, layout, cfg, s)
+	if err != nil {
+		return err
+	}
+	defer func() { retErr = errors.Join(retErr, closeEmbeddings()) }()
 
 	var stopOnce sync.Once
 	stopCh := make(chan struct{})
@@ -179,6 +186,7 @@ func runServe(ctx context.Context) (retErr error) {
 		Store: s, Blobs: blobs, VaultRoot: layout.Root, Cfg: cfg, Logger: logger,
 		StartedAt: time.Now(), ShutdownToken: shutdownToken, Shutdown: stop, Tracker: tracker,
 		Jobs: jobSupervisor, Gate: operationGate,
+		Embeddings: embeddings,
 	})
 	httpSrv := &http.Server{
 		Handler:           srv.Handler(),
@@ -218,6 +226,53 @@ func runServe(ctx context.Context) (retErr error) {
 		return fmt.Errorf("draining daemon requests: %w", err)
 	}
 	return nil
+}
+
+func buildEmbeddingsService(
+	ctx context.Context, layout home.Layout, cfg config.Config, metadata *store.Store,
+) (*docvector.Service, func() error, error) {
+	if !cfg.Embeddings.Enabled() {
+		return nil, func() error { return nil }, nil
+	}
+	apiKey := cfg.Embeddings.ResolvedAPIKey()
+	if cfg.Embeddings.APIKeyEnv != "" && apiKey == "" {
+		return nil, func() error { return nil }, fmt.Errorf(
+			"[embeddings] api_key_env %q is unset or empty", cfg.Embeddings.APIKeyEnv)
+	}
+	encoder, err := embedding.New(embedding.Config{
+		BaseURL: cfg.Embeddings.BaseURL, Model: cfg.Embeddings.Model, APIKey: apiKey,
+		FingerprintSalt: cfg.Embeddings.FingerprintSalt,
+		Dimensions:      cfg.Embeddings.Dimensions, BatchSize: cfg.Embeddings.BatchSize,
+		Timeout: cfg.Embeddings.Timeout.Std(),
+	})
+	if err != nil {
+		return nil, func() error { return nil }, err
+	}
+	if err := layout.EnsureVectorsDB(); err != nil {
+		return nil, func() error { return nil }, err
+	}
+	index, err := docvector.Open(ctx, layout.VectorsDBPath())
+	if err != nil {
+		return nil, func() error { return nil }, err
+	}
+	source := func(ctx context.Context, afterBlobHash string, limit int) ([]docvector.Document, error) {
+		items, err := metadata.VectorDocuments(ctx, afterBlobHash, limit)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]docvector.Document, 0, len(items))
+		for _, item := range items {
+			out = append(out, docvector.Document{
+				BlobHash: item.BlobHash, ExtractorVersion: item.ExtractorVersion, Text: item.Text,
+			})
+		}
+		return out, nil
+	}
+	service := &docvector.Service{
+		Index: index, Source: source, Generation: encoder.Generation(), Encode: encoder.EncodeFunc(),
+		BatchSize: cfg.Embeddings.BatchSize, Concurrency: cfg.Embeddings.Concurrency,
+	}
+	return service, index.Close, nil
 }
 
 // idleWatch exits an auto-started daemon after a fully quiet window so

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "23", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "23", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "23", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/embeddings.go
+++ b/cmd/docbank/embeddings.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+var embeddingsCmd = &cobra.Command{
+	Use:   "embeddings",
+	Short: "Build and inspect the derived semantic-search index",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
+}
+
+var (
+	embeddingsBuildJSON     bool
+	embeddingsBuildProgress string
+)
+
+var embeddingsBuildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Mirror verified text and build the configured vector generation",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		var result api.EmbeddingBuildResult
+		if embeddingsBuildJSON {
+			result, err = c.BuildEmbeddings(cmd.Context(), nil)
+		} else {
+			mode, modeErr := progressModeFromFlag("embeddings build", embeddingsBuildProgress)
+			if modeErr != nil {
+				return modeErr
+			}
+			renderer := newBackupProgressRenderer(cmd.ErrOrStderr(), mode)
+			defer renderer.finish()
+			result, err = c.BuildEmbeddings(cmd.Context(), func(progress api.EmbeddingBuildProgress) {
+				renderer.handle(api.BackupProgress{
+					Stage: progress.Phase, Done: int64(progress.Done), Total: int64(progress.Total),
+				})
+			})
+		}
+		if err != nil {
+			return err
+		}
+		if embeddingsBuildJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), result)
+		}
+		state := "built but not activated"
+		if result.Activated {
+			state = "active"
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(),
+			"embedding generation %s %s; embedded %d unique content object(s) into %d chunk(s)\n",
+			shortFingerprint(result.Fingerprint), state, result.Embedded, result.Chunks)
+		if err != nil {
+			return fmt.Errorf("writing embeddings build result: %w", err)
+		}
+		return nil
+	},
+}
+
+var embeddingsListJSON bool
+
+var embeddingsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List embedding generations and current coverage",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		report, err := c.EmbeddingGenerations(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if embeddingsListJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), report)
+		}
+		if !report.Configured {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(),
+				"embeddings are not configured; lexical search remains available")
+			if err != nil {
+				return fmt.Errorf("writing embeddings configuration status: %w", err)
+			}
+			return nil
+		}
+		if len(report.Items) == 0 {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(),
+				"no embedding generations; run `docbank embeddings build`")
+			if err != nil {
+				return fmt.Errorf("writing embedding generations: %w", err)
+			}
+			return nil
+		}
+		writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(writer, "GENERATION\tSTATE\tMODEL\tDIMS\tEMBEDDED\tSKIPPED\tPENDING")
+		for _, item := range report.Items {
+			_, _ = fmt.Fprintf(writer, "%s\t%s\t%s\t%d\t%d\t%d\t%d\n",
+				shortFingerprint(item.Fingerprint), item.State, strconv.QuoteToASCII(item.Model), item.Dimensions,
+				item.Embedded, item.Skipped, item.Pending)
+		}
+		if err := writer.Flush(); err != nil {
+			return fmt.Errorf("writing embedding generations: %w", err)
+		}
+		return nil
+	},
+}
+
+func shortFingerprint(fingerprint string) string {
+	if len(fingerprint) <= 12 {
+		return fingerprint
+	}
+	return fingerprint[:12]
+}
+
+func init() {
+	embeddingsBuildCmd.Flags().BoolVar(&embeddingsBuildJSON, "json", false,
+		"emit a machine-readable terminal report (progress suppressed)")
+	embeddingsBuildCmd.Flags().StringVar(&embeddingsBuildProgress, "progress", "auto",
+		"progress output mode: auto, bar, or plain (suppressed by --json)")
+	embeddingsListCmd.Flags().BoolVar(&embeddingsListJSON, "json", false,
+		"emit machine-readable JSON")
+	embeddingsCmd.AddCommand(embeddingsBuildCmd, embeddingsListCmd)
+	rootCmd.AddCommand(embeddingsCmd)
+}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -158,6 +158,15 @@ curl --fail-with-body --get \
   "$DOCBANK_URL/api/v1/search"
 ```
 
+When the daemon has an embeddings endpoint configured, an agent can inspect
+local generation coverage with `GET /api/v1/embeddings` and explicitly start a
+resumable build with `POST /api/v1/embeddings/build/stream`. The latter is an
+NDJSON stream: progress events are provisional, and exactly one terminal
+`result` or `error` decides the outcome. The configured external endpoint
+receives verified current extracted text, so this action requires the same
+deliberate data-disclosure decision as the human `docbank embeddings build`
+command. Semantic query is not yet part of the search API.
+
 Retrieve file bytes by ID, not path:
 
 ```bash

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -30,9 +30,10 @@ metadata, identified in manifests as `docbank-metadata-jsonl-v1`. It contains
 the complete virtual directory tree and file records,
 including stable IDs, content hashes, timestamps, trash coordinates, prior
 versions, ingest provenance, watched-source cursors, tags, and extracted text.
-It intentionally omits FTS rows and physical pack mappings: search indexes are
-rebuilt by importing nodes, while restore grants physical authority only after
-content has been verified and published. Import targets must be fresh
+It intentionally omits FTS rows, the optional `vectors.db` sidecar, and physical
+pack mappings: lexical indexes are rebuilt by importing nodes, vectors are
+rebuilt explicitly from verified current text, and restore grants physical
+authority only after content has been verified and published. Import targets must be fresh
 current-schema databases;
 a malformed or referentially incomplete stream leaves the pristine target
 unchanged. Capture makes two deterministic passes over the same pinned

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -6,7 +6,7 @@ description: docbank daemon run — the single process that owns the vault, and 
 # Daemon and process model
 
 `docbank daemon run` is the one process that opens the vault. Every data
-command — `add`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`, `search`,
+command — `add`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`, `search`, `embeddings`,
 `trash list`/`empty`, `gc`, `verify` — is an HTTP client of it, over the
 [HTTP API](http-api.md). `docbank openapi` is the one exception:
 it renders the API contract offline, with routes registered but never

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -42,6 +42,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name and extracted-content search (FTS5), with match source and explicit `truncated` status | Implemented |
+| `GET /embeddings` · `POST /embeddings/build/stream` | inspect local generations / mirror verified current text and build one generation with NDJSON progress | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
 | `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -160,6 +160,21 @@ different valid representation under fresh catalog authority. See
 [Loose & Packed Content](packed-storage.md) for limits, maintenance, and the
 boundary between Docbank policy and Kit mechanics.
 
+## Search indexes are derived
+
+Lexical name and verified-text search is reconstructed from authoritative
+metadata during restore. When embeddings are configured, the daemon can also
+mirror current live extracted text into `vectors.db` and build versioned vector
+generations through Kit's SQLite vector substrate. The active generation is
+swapped only after the replacement completely covers that mirror.
+
+Neither extracted search projections nor `vectors.db` grant document
+authority. The vector sidecar is excluded from JSONL and backup snapshots; it
+can be deleted while the daemon is stopped and rebuilt from verified current
+text. Embedded applications do not import this daemon-owned vector layer and
+may continue using the root Go package with pure-Go SQLite and no CGo vector
+dependency. See [Embedding Index](../usage/embeddings.md).
+
 ## One owner, two integration modes
 
 Exactly one process owns an open vault at a time:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,7 +11,7 @@ stderr and produce a non-zero exit code. Virtual paths are absolute,
 `/`-separated, and case-sensitive.
 
 Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `edit`, `versions`, `version`, `refs`, `revert`, `tag`, `audit`, `mv`, `rm`,
-`restore`, `search`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
+`restore`, `search`, `embeddings`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
 daemon over its HTTP API rather than opening the vault itself; if none
 is running, the command auto-starts one in the background. `docbank
 daemon status` and `docbank daemon stop` never auto-start. See
@@ -534,6 +534,31 @@ an explicit `truncated` boolean. An empty result uses `"hits": []`.
 The daemon indexes current UTF-8 `text/*`, JSON, and JSONL blobs up to 16 MiB
 after a terminally verified read. PDF, Office, and OCR extraction are not yet
 available. See [Searching](usage/searching.md).
+
+## docbank embeddings
+
+```text
+docbank embeddings build [--progress auto|bar|plain] [--json]
+docbank embeddings list [--json]
+```
+
+Builds and inspects the optional local vector sidecar. `build` mirrors current,
+live, successfully extracted text, fills the generation selected by
+`[embeddings]` configuration, and activates it only after complete mirror
+coverage. It does not perform or wait for text extraction. If extraction is
+still running, inspect `docbank jobs` and rerun the resumable build later.
+
+Human mode reports progress by unique content digest. Byte-identical documents
+are encoded once. `--progress plain` selects durable
+progress lines; `--json` suppresses progress and emits the terminal report.
+`list` reports each local generation's state, model, dimensions, and embedded,
+skipped, and pending document counts. An unconfigured list succeeds and says
+that lexical search remains available; an unconfigured build returns the
+structured `embeddings_unconfigured` error.
+
+The configured endpoint receives extracted document text. The sidecar is
+derived, excluded from backup, and safe to rebuild. See
+[Embedding Index](usage/embeddings.md) and [Configuration](configuration.md#embeddings).
 
 ## docbank trash
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ description: Vault location, data layout, config.toml, and environment variables
 
 The only required knob is where the vault lives. `config.toml` is optional and
 controls the daemon's listen address, auth, idle behavior, default backup
-repository, and optional watched inboxes. The vault works without the file;
+repository, optional embeddings endpoint, and watched inboxes. The vault works without the file;
 backup commands require either a configured repository or their explicit
 `--repo` flag.
 
@@ -25,6 +25,7 @@ The directory layout is created on first use:
 ```
 ~/.docbank/
 ├── docbank.db           # SQLite: virtual tree, metadata, FTS index
+├── vectors.db           # optional derived embedding index; rebuildable
 ├── blobs/
 │   ├── <aa>/<sha256>    # content-addressed document bytes
 │   └── tmp/             # staging for in-flight writes
@@ -35,6 +36,9 @@ The directory layout is created on first use:
 ```
 
 `docbank.db` and `blobs/` together are the archive; back up both.
+`vectors.db` is a local derived index built from verified current text. It is
+not archive authority, is not included in Docbank snapshots, and may be deleted
+and rebuilt without losing documents or metadata.
 `config.toml` is configuration, not archive data — optional, but back it
 up if you've customized it (it can hold an `api_key`). `vault.lock` and
 `daemon.<pid>.json` are coordination/runtime state, safe to
@@ -85,6 +89,18 @@ enabled = true
 repo = ""           # no implicit repository; set a path or pass --repo
 zstd_level = 0      # 0 = Kit default; otherwise 1-19
 
+# Optional OpenAI-compatible embedding endpoint. When enabled, document text
+# is sent to this endpoint only when `docbank embeddings build` is requested.
+[embeddings]
+base_url = "http://127.0.0.1:11434/v1"
+model = "your-embedding-model"
+api_key_env = "DOCBANK_EMBEDDINGS_API_KEY"
+dimensions = 768
+batch_size = 32
+concurrency = 2
+timeout = "30s"
+# fingerprint_salt = "provider-model-revision"
+
 [[watch]]
 name = "agent-sessions"
 source = "~/agent-sessions"
@@ -119,6 +135,39 @@ exclude = [".DS_Store", "cache/"]
   Keep the repository outside the live vault in normal deployments.
 - **`[backup] zstd_level`** — repository compression level. `0` uses Kit's
   default; explicit values are limited to `1` through `19`.
+
+### Embeddings
+
+The optional `[embeddings]` section enables `docbank embeddings build`. The
+daemon sends the verified extracted text of current, live, supported documents
+to the configured OpenAI-compatible `POST /embeddings` endpoint, then stores
+normalized vectors in the local `vectors.db` sidecar. It never sends original
+binary blobs, historical versions, trashed documents, paths, tags, provenance,
+or audited-history records.
+
+`base_url` and `model` must be set together. Plain HTTP is accepted only for a
+loopback endpoint; remote endpoints require HTTPS. Set either `api_key` or
+`api_key_env`, not both. Environment indirection is preferable because it keeps
+the bearer credential out of `config.toml`. If `api_key_env` names an unset or
+empty variable, daemon startup fails rather than silently making unauthenticated
+requests.
+
+`dimensions` must exactly match the endpoint's vectors. `batch_size` controls
+the number of text chunks per request, while `concurrency` bounds parallel
+encoding work. `fingerprint_salt` distinguishes changed model weights served
+under the same model name; change it when a provider changes that underlying
+vector space without changing `model`.
+
+Configuration alone makes no external request. Build and inspect the derived
+index explicitly:
+
+```bash
+docbank embeddings build
+docbank embeddings list
+```
+
+See [Embedding Index](usage/embeddings.md) for the exact source and lifecycle
+contract.
 
 ### Watched inboxes
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -14,6 +14,12 @@ Use an embedded vault when the application itself should own document
 lifecycle. Use the HTTP API when independent processes need to share one
 standalone vault.
 
+The root package does not import the daemon's optional vector sidecar. An
+application that does not need semantic indexing can build with
+`CGO_ENABLED=0` and the supported pure-Go SQLite adapter without carrying the
+SQLite vector extension. Applications that need embeddings can own a separate
+derived index or use a configured standalone daemon.
+
 ## Create a vault service
 
 Each root is an independent archive. One process may open several non-overlapping

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,6 +15,7 @@ Every documentation page is also published as raw Markdown at the same path with
 - [Importing Documents](https://docbank.ai/usage/importing.md): Bulk import semantics — recursion, idempotency, collision suffixing, and failure handling.
 - [Organizing & Tagging](https://docbank.ai/usage/organizing.md): Browsing, moving, renaming, and tagging in the virtual tree.
 - [Searching](https://docbank.ai/usage/searching.md): Ranked, prefix-matching search over document names and verified text content.
+- [Embedding Index](https://docbank.ai/usage/embeddings.md): Build and inspect a disposable semantic-search index from verified current document text.
 
 ## Protect & Operate
 - [Vault Lifecycle](https://docbank.ai/usage/lifecycle.md): Operate a docbank vault safely from first import through maintenance, upgrades, snapshots, and recovery.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ elsewhere only when they materially explain the design and are marked
 | 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.10.0) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
-| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, provenance, watched inboxes, first-scope audit authority, and bounded plain-text extraction implemented; PDF/Office extraction remains |
+| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance, semantic retrieval | **In progress**: versions, tags, provenance, watched inboxes, first-scope audit authority, bounded plain-text extraction, and the rebuildable embedding-generation substrate are implemented; semantic querying and PDF/Office extraction remain |
 | 3 | Primary kit-ui web portal and focused operator TUI | Designed |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
@@ -118,6 +118,9 @@ and append later changes to the same stable node without touching source files.
 - Tag/MIME/date/path search filters; `POST /batch/move` bulk reorganization
 - Additional text extraction workers for PDF text layers and office formats;
   bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
+- Semantic and hybrid query over the implemented, rebuildable embedding
+  generations; configuration, explicit generation builds, coverage inventory,
+  and safe replacement activation are implemented
 - External integration surface: generalized ingest provenance —
   today's `provenance` table records the original filesystem path and
   mtime; `source_kind` / `source_ref` / `source_meta` fields extend it
@@ -160,6 +163,6 @@ not a missing recovery command.
 
 ## Deferred beyond v1
 
-OCR of scans, embeddings/AI tagging, at-rest encryption of the live store,
+OCR of scans, AI tagging and summarization, at-rest encryption of the live store,
 encryption for backup repositories, importing attachments out of msgvault,
 multi-user/sharing, and an MCP server wrapping the API.

--- a/docs/usage/embeddings.md
+++ b/docs/usage/embeddings.md
@@ -1,0 +1,86 @@
+---
+title: Embedding Index
+description: Build and inspect a disposable semantic-search index from verified current document text.
+---
+
+# Embedding index
+
+!!! info "Release availability"
+
+    The embeddings commands are newer than v0.9.0. Build from source to use
+    them until the next release is published.
+
+Docbank can encode verified current document text through an optional
+OpenAI-compatible endpoint and keep the resulting vectors in a local derived
+sidecar:
+
+```bash
+docbank embeddings build
+docbank embeddings list
+```
+
+This is an explicit operation. Adding `[embeddings]` configuration does not
+upload text or start embedding work by itself.
+
+## What is encoded
+
+The source set is deliberately narrow:
+
+- the node is a live file;
+- the version is that node's current version;
+- the plain-text extraction completed successfully and reached verified EOF;
+- the content type is already eligible for Docbank's bounded text extraction.
+
+Historical versions, trashed documents, unsupported binary formats, failed or
+pending extractions, and text beyond the extraction limit are absent. The
+encoder receives text chunks only. It does not receive paths, node or version
+IDs, tags, provenance, audit records, or original binary blobs.
+
+Text extraction is asynchronous. `embeddings build` mirrors extraction results
+that exist when its scan begins; it does not wait for or perform extraction.
+Use `docbank jobs` to inspect `extract:plain-text`, then rerun the build after
+new text becomes available.
+
+## Generation and activation
+
+A generation identifies one exact vector space: model name, dimensions, the
+Docbank chunking recipe, and optional fingerprint salt. Docbank splits long
+text into bounded overlapping chunks, normalizes every finite nonzero vector,
+and stores it through Kit's SQLite vector substrate. Byte-identical current
+documents share one content digest and are encoded once, avoiding duplicate
+endpoint work.
+
+A build first refreshes the current-document mirror and then fills missing or
+stale vectors. Re-running the same generation resumes and converges rather than
+starting over. When configuration selects a new generation, the prior active
+generation remains active until the replacement covers the complete current
+mirror. Only then does Docbank activate the replacement.
+
+Human builds show unique-content progress. `--progress plain` emits durable
+lines for logs; `--json` suppresses progress and returns only the terminal
+report:
+
+```bash
+docbank embeddings build --progress plain
+docbank embeddings build --json
+docbank embeddings list --json
+```
+
+Only one build may run at a time. A concurrent request fails with the structured
+`embeddings_build_running` conflict rather than racing the sidecar.
+
+## Authority and recovery
+
+`vectors.db` is disposable derived state, not document or metadata authority.
+Docbank's JSONL backup and restore contract excludes it. After restore, configure
+an encoder and run `docbank embeddings build` to reconstruct it from verified
+current text. Deleting a stopped vault's `vectors.db` has the same effect; the
+next configured daemon creates an empty sidecar.
+
+Lexical `docbank search` remains available whether embeddings are configured,
+built, incomplete, or absent. The current command surface builds and
+inventories vector generations; query-time semantic ranking is not yet exposed.
+
+See [Configuration](../configuration.md#embeddings) for endpoint and credential
+settings, and [Searching](searching.md) for the currently queryable lexical
+search contract.

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -58,6 +58,11 @@ PDF text layers, office formats, OCR, and tag/MIME/date/path search filters are
 not yet available. Their absence never changes name-search results or document
 authority.
 
+An optional [Embedding Index](embeddings.md) can encode this same verified
+current text into a disposable local vector sidecar. Building generations does
+not change the lexical results described on this page; semantic query is not
+yet exposed.
+
 Next: organize documents beyond paths with
 [Organizing & Tagging](organizing.md), or see every search flag in the
 [CLI Reference](../cli-reference.md).

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -20,6 +20,7 @@ nav = [
     {"Importing Documents" = "usage/importing.md"},
     {"Organizing & Tagging" = "usage/organizing.md"},
     {"Searching" = "usage/searching.md"},
+    {"Embedding Index" = "usage/embeddings.md"},
   ]},
   {"Protect & Operate" = [
     {"Vault Lifecycle" = "usage/lifecycle.md"},

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	github.com/asg017/sqlite-vec-go-bindings v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/asg017/sqlite-vec-go-bindings v0.1.6 h1:Nx0jAzyS38XpkKznJ9xQjFXz2X9tI7KqjwVxV8RNoww=
+github.com/asg017/sqlite-vec-go-bindings v0.1.6/go.mod h1:A8+cTt/nKFsYCQF6OgzSNpKZrzNo5gQsXBTfsXHXY0Q=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danielgtaylor/huma/v2 v2.38.0 h1:fb0WZCatnaiHLphMQDDWDjygNxfMkX/ENma3QsRl7vY=

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -27,7 +27,8 @@ func timeoutExempt(path string) bool {
 		"/api/v1/storage/pack", "/api/v1/storage/repack", "/api/v1/uploads",
 		"/api/v1/backup/snapshots", "/api/v1/backup/snapshots/stream",
 		"/api/v1/backup/verify", "/api/v1/backup/verify/stream",
-		"/api/v1/backup/restore", "/api/v1/backup/restore/stream":
+		"/api/v1/backup/restore", "/api/v1/backup/restore/stream",
+		"/api/v1/embeddings/build/stream":
 		return true
 	}
 	if strings.HasPrefix(path, "/api/v1/nodes/") &&

--- a/internal/api/routes_embeddings.go
+++ b/internal/api/routes_embeddings.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/docbank/internal/vector"
+)
+
+func registerEmbeddingRoutes(api huma.API, d Deps) {
+	type listOutput struct{ Body EmbeddingGenerationList }
+	huma.Register(api, huma.Operation{
+		OperationID: "listEmbeddingGenerations", Method: http.MethodGet,
+		Path: "/api/v1/embeddings", Summary: "List local embedding generations and coverage",
+	}, func(ctx context.Context, _ *struct{}) (*listOutput, error) {
+		out := &listOutput{Body: EmbeddingGenerationList{
+			Configured: d.Embeddings != nil, Items: []EmbeddingGeneration{},
+		}}
+		if d.Embeddings == nil {
+			return out, nil
+		}
+		items, err := d.Embeddings.Generations(ctx)
+		if err != nil {
+			return nil, embeddingProblem(err)
+		}
+		for _, item := range items {
+			out.Body.Items = append(out.Body.Items, embeddingGeneration(item))
+		}
+		return out, nil
+	})
+
+	streamSchema := api.OpenAPI().Components.Schemas.Schema(
+		reflect.TypeFor[EmbeddingBuildEvent](), true, "EmbeddingBuildEvent")
+	huma.Register(api, huma.Operation{
+		OperationID: "buildEmbeddingGeneration", Method: http.MethodPost,
+		Path:    "/api/v1/embeddings/build/stream",
+		Summary: "Mirror verified text and build the configured embedding generation",
+		Description: "Returns newline-delimited JSON. Progress precedes exactly one terminal " +
+			"result or error event; an HTTP 200 only means the stream started.",
+		Responses: map[string]*huma.Response{
+			"200": {Description: "Embedding progress followed by one terminal result or error",
+				Content: map[string]*huma.MediaType{
+					"application/x-ndjson": {Schema: streamSchema},
+				}},
+		},
+	}, func(_ context.Context, _ *struct{}) (*huma.StreamResponse, error) {
+		if d.Embeddings == nil {
+			return nil, NewError(http.StatusUnprocessableEntity, "embeddings_unconfigured",
+				"embeddings are not configured; add [embeddings] base_url and model to config.toml")
+		}
+		return &huma.StreamResponse{Body: func(hctx huma.Context) {
+			hctx.SetHeader("Content-Type", "application/x-ndjson")
+			hctx.SetHeader("Cache-Control", "no-store")
+			runCtx, cancel := context.WithCancel(hctx.Context())
+			defer cancel()
+			stream := newEventStreamWriter[EmbeddingBuildEvent](hctx.BodyWriter(), cancel)
+			result, err := d.Embeddings.Build(runCtx, func(progress vector.Progress) {
+				stream.send(EmbeddingBuildEvent{Type: "progress", Progress: &EmbeddingBuildProgress{
+					Phase: progress.Phase, Done: progress.Done, Total: progress.Total,
+				}})
+			})
+			if stream.err() != nil {
+				return
+			}
+			if err != nil {
+				stream.send(EmbeddingBuildEvent{Type: "error", Error: embeddingProblem(err)})
+				return
+			}
+			stream.send(EmbeddingBuildEvent{Type: "result", Result: &EmbeddingBuildResult{
+				Fingerprint: result.Fingerprint, Model: result.Model, Dimensions: result.Dimensions,
+				Mirrored: result.Mirrored, Removed: result.Removed, Embedded: result.Embedded,
+				Chunks: result.Chunks, Skipped: result.Skipped, Stale: result.Stale,
+				Activated: result.Activated,
+			}})
+		}}, nil
+	})
+}
+
+func embeddingGeneration(item vector.GenerationInfo) EmbeddingGeneration {
+	return EmbeddingGeneration{
+		Fingerprint: item.Fingerprint, Model: item.Model, Dimensions: item.Dimensions,
+		State: item.State, Embedded: item.Embedded, Skipped: item.Skipped, Pending: item.Pending,
+	}
+}
+
+func embeddingProblem(err error) *Error {
+	if errors.Is(err, vector.ErrBuildRunning) {
+		return NewError(http.StatusConflict, "embeddings_build_running", err.Error())
+	}
+	return NewError(http.StatusInternalServerError, "embeddings_failed", err.Error())
+}

--- a/internal/api/routes_embeddings_test.go
+++ b/internal/api/routes_embeddings_test.go
@@ -1,0 +1,102 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"math"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitvec "go.kenn.io/kit/vector"
+
+	"go.kenn.io/docbank/internal/api"
+	docvector "go.kenn.io/docbank/internal/vector"
+)
+
+func TestEmbeddingRoutesExposeConfigurationAndStreamBuild(t *testing.T) {
+	index, err := docvector.Open(t.Context(), filepath.Join(t.TempDir(), "vectors.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.Close()) })
+	documents := []docvector.Document{
+		{BlobHash: strings.Repeat("a", 64), ExtractorVersion: 1, Text: "alpha"},
+		{BlobHash: strings.Repeat("b", 64), ExtractorVersion: 1, Text: "beta"},
+	}
+	service := &docvector.Service{
+		Index: index,
+		Source: func(_ context.Context, after string, limit int) ([]docvector.Document, error) {
+			var page []docvector.Document
+			for _, item := range documents {
+				if item.BlobHash > after && len(page) < limit {
+					page = append(page, item)
+				}
+			}
+			return page, nil
+		},
+		Generation: kitvec.Generation{Model: "test-model", Dimensions: 2},
+		Encode: func(_ context.Context, texts []string) ([][]float32, error) {
+			vectors := make([][]float32, len(texts))
+			for i, text := range texts {
+				second := float32(len(text)) / 100
+				scale := float32(1 / math.Sqrt(float64(1+second*second)))
+				vectors[i] = []float32{scale, second * scale}
+			}
+			return vectors, nil
+		},
+		BatchSize: 8, Concurrency: 1,
+	}
+	ts, _ := newTestServer(t, func(d *api.Deps) { d.Embeddings = service })
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/embeddings/build/stream", nil, map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/x-ndjson")
+	events := decodeEmbeddingEvents(t, body)
+	require.NotEmpty(t, events)
+	assert.Equal(t, "progress", events[0].Type)
+	terminal := events[len(events)-1]
+	require.Equal(t, "result", terminal.Type)
+	require.NotNil(t, terminal.Result)
+	assert.True(t, terminal.Result.Activated)
+	assert.Equal(t, 2, terminal.Result.Embedded)
+
+	resp, body = get(t, ts, "/api/v1/embeddings", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var listed api.EmbeddingGenerationList
+	require.NoError(t, json.Unmarshal([]byte(body), &listed))
+	assert.True(t, listed.Configured)
+	require.Len(t, listed.Items, 1)
+	assert.Equal(t, "active", listed.Items[0].State)
+	assert.Equal(t, 2, listed.Items[0].Embedded)
+}
+
+func TestEmbeddingRoutesRemainHonestWhenUnconfigured(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := get(t, ts, "/api/v1/embeddings", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var listed api.EmbeddingGenerationList
+	require.NoError(t, json.Unmarshal([]byte(body), &listed))
+	assert.False(t, listed.Configured)
+	assert.Empty(t, listed.Items)
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/embeddings/build/stream", nil, map[string]any{})
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, "embeddings_unconfigured")
+}
+
+func decodeEmbeddingEvents(t *testing.T, body string) []api.EmbeddingBuildEvent {
+	t.Helper()
+	decoder := json.NewDecoder(strings.NewReader(body))
+	var events []api.EmbeddingBuildEvent
+	for {
+		var event api.EmbeddingBuildEvent
+		err := decoder.Decode(&event)
+		if err == io.EOF {
+			return events
+		}
+		require.NoError(t, err)
+		events = append(events, event)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/docbank/internal/daemonauth"
 	"go.kenn.io/docbank/internal/jobs"
 	"go.kenn.io/docbank/internal/store"
+	"go.kenn.io/docbank/internal/vector"
 	"go.kenn.io/docbank/internal/version"
 )
 
@@ -36,6 +37,7 @@ type Deps struct {
 	Tracker       *ActivityTracker // nil → no idle tracking
 	Jobs          *jobs.Supervisor // nil → no registered background jobs
 	Gate          *OperationGate   // nil → a server-private gate
+	Embeddings    *vector.Service  // nil → embeddings are not configured
 }
 
 // Server is docbank's HTTP API: a huma-described /api/v1 surface plus a
@@ -94,6 +96,7 @@ func NewServer(d Deps) *Server {
 	registerOpsRoutes(humaAPI, d, g)    // Task 7
 	registerBackupRoutes(humaAPI, d, g)
 	registerJobRoutes(humaAPI, d)
+	registerEmbeddingRoutes(humaAPI, d)
 	registerUploadRoute(mux, humaAPI, d, g)
 	registerContentWriteRoute(mux, humaAPI, d, g)
 	registerContentRevertRoute(humaAPI, d, g)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -581,6 +581,54 @@ type JobList struct {
 	Items []Job `json:"items"`
 }
 
+// EmbeddingGeneration reports one local, rebuildable vector generation and
+// its coverage of unique content selected by current live files.
+type EmbeddingGeneration struct {
+	Fingerprint string `json:"fingerprint" pattern:"^[0-9a-f]{16}$"`
+	Model       string `json:"model"`
+	Dimensions  int    `json:"dimensions" minimum:"1"`
+	State       string `json:"state" enum:"building,active,retired"`
+	Embedded    int    `json:"embedded" minimum:"0"`
+	Skipped     int    `json:"skipped" minimum:"0"`
+	Pending     int    `json:"pending" minimum:"0"`
+}
+
+// EmbeddingGenerationList is the machine-readable embeddings inventory.
+type EmbeddingGenerationList struct {
+	Configured bool                  `json:"configured"`
+	Items      []EmbeddingGeneration `json:"items"`
+}
+
+// EmbeddingBuildProgress reports unique-content progress for one build.
+type EmbeddingBuildProgress struct {
+	Phase string `json:"phase" enum:"scanning,embedding"`
+	Done  int    `json:"done" minimum:"0"`
+	Total int    `json:"total" minimum:"0"`
+}
+
+// EmbeddingBuildResult reports one successfully completed build.
+type EmbeddingBuildResult struct {
+	Fingerprint string `json:"fingerprint" pattern:"^[0-9a-f]{16}$"`
+	Model       string `json:"model"`
+	Dimensions  int    `json:"dimensions" minimum:"1"`
+	Mirrored    int    `json:"mirrored" minimum:"0"`
+	Removed     int    `json:"removed" minimum:"0"`
+	Embedded    int    `json:"embedded" minimum:"0"`
+	Chunks      int    `json:"chunks" minimum:"0"`
+	Skipped     int    `json:"skipped" minimum:"0"`
+	Stale       int    `json:"stale" minimum:"0"`
+	Activated   bool   `json:"activated"`
+}
+
+// EmbeddingBuildEvent is one NDJSON build-stream event. Exactly one terminal
+// Result or Error follows zero or more Progress events.
+type EmbeddingBuildEvent struct {
+	Type     string                  `json:"type" enum:"progress,result,error"`
+	Progress *EmbeddingBuildProgress `json:"progress,omitempty"`
+	Result   *EmbeddingBuildResult   `json:"result,omitempty"`
+	Error    *Error                  `json:"error,omitempty"`
+}
+
 // BackupRepository identifies an initialized Kit snapshot repository.
 type BackupRepository struct {
 	ID   string `json:"id"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2197,6 +2197,161 @@ func (c *Client) Jobs(ctx context.Context) ([]api.Job, error) {
 	return out.Items, err
 }
 
+// EmbeddingGenerations reports whether embeddings are configured and lists
+// every locally retained generation with current mirror coverage.
+func (c *Client) EmbeddingGenerations(
+	ctx context.Context,
+) (api.EmbeddingGenerationList, error) {
+	var out api.EmbeddingGenerationList
+	if err := c.do(ctx, http.MethodGet, "/api/v1/embeddings", nil, nil, &out); err != nil {
+		return out, err
+	}
+	if err := validateEmbeddingGenerationList(out); err != nil {
+		return api.EmbeddingGenerationList{}, err
+	}
+	return out, nil
+}
+
+// BuildEmbeddings mirrors current verified extracted text and fills the configured
+// generation while delivering structured unique-content progress.
+func (c *Client) BuildEmbeddings(
+	ctx context.Context, progress func(api.EmbeddingBuildProgress),
+) (api.EmbeddingBuildResult, error) {
+	const path = "/api/v1/embeddings/build/stream"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+path,
+		bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return api.EmbeddingBuildResult{}, fmt.Errorf("building embeddings stream request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	if c.key != "" {
+		req.Header.Set("X-Api-Key", c.key)
+	}
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return api.EmbeddingBuildResult{}, fmt.Errorf("calling daemon (POST %s): %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return api.EmbeddingBuildResult{}, decodeError(resp)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	var result *api.EmbeddingBuildResult
+	for {
+		var event api.EmbeddingBuildEvent
+		if err := decoder.Decode(&event); err != nil {
+			if errors.Is(err, io.EOF) {
+				if result == nil {
+					return api.EmbeddingBuildResult{}, errors.New(
+						"embeddings progress stream ended without a result")
+				}
+				return *result, nil
+			}
+			return api.EmbeddingBuildResult{}, fmt.Errorf("decoding embeddings progress: %w", err)
+		}
+		if result != nil {
+			return api.EmbeddingBuildResult{}, errors.New(
+				"embeddings progress stream continued after its result")
+		}
+		switch event.Type {
+		case "progress":
+			if event.Progress == nil || event.Result != nil || event.Error != nil {
+				return api.EmbeddingBuildResult{}, errors.New(
+					"embeddings returned malformed progress event")
+			}
+			if err := validateEmbeddingBuildProgress(*event.Progress); err != nil {
+				return api.EmbeddingBuildResult{}, err
+			}
+			if progress != nil {
+				progress(*event.Progress)
+			}
+		case "result":
+			if event.Result == nil || event.Progress != nil || event.Error != nil {
+				return api.EmbeddingBuildResult{}, errors.New(
+					"embeddings returned malformed result event")
+			}
+			completed := *event.Result
+			if err := validateEmbeddingBuildResult(completed); err != nil {
+				return api.EmbeddingBuildResult{}, err
+			}
+			result = &completed
+		case "error":
+			if event.Error == nil || event.Progress != nil || event.Result != nil {
+				return api.EmbeddingBuildResult{}, errors.New(
+					"embeddings returned malformed error event")
+			}
+			return api.EmbeddingBuildResult{}, apiProblemError(*event.Error)
+		default:
+			return api.EmbeddingBuildResult{}, fmt.Errorf(
+				"embeddings returned unknown progress event type %q", event.Type)
+		}
+	}
+}
+
+func validateEmbeddingGenerationList(report api.EmbeddingGenerationList) error {
+	if !report.Configured && len(report.Items) != 0 {
+		return errors.New("embeddings response lists generations while unconfigured")
+	}
+	active := 0
+	seen := make(map[string]struct{}, len(report.Items))
+	for _, item := range report.Items {
+		if !validGenerationFingerprint(item.Fingerprint) || strings.TrimSpace(item.Model) == "" ||
+			item.Dimensions < 1 || item.Embedded < 0 || item.Skipped < 0 || item.Pending < 0 {
+			return errors.New("embeddings response contains an invalid generation")
+		}
+		if _, duplicate := seen[item.Fingerprint]; duplicate {
+			return errors.New("embeddings response contains a duplicate generation")
+		}
+		seen[item.Fingerprint] = struct{}{}
+		switch item.State {
+		case "building", "retired":
+		case "active":
+			active++
+		default:
+			return errors.New("embeddings response contains an invalid generation state")
+		}
+	}
+	if active > 1 {
+		return errors.New("embeddings response contains multiple active generations")
+	}
+	return nil
+}
+
+func validateEmbeddingBuildProgress(progress api.EmbeddingBuildProgress) error {
+	if progress.Done < 0 || progress.Total < 0 || progress.Done > progress.Total {
+		return errors.New("embeddings response contains invalid progress counts")
+	}
+	switch progress.Phase {
+	case "scanning":
+		if progress.Done != 0 || progress.Total != 0 {
+			return errors.New("embeddings response contains invalid scanning progress")
+		}
+	case "embedding":
+	default:
+		return errors.New("embeddings response contains an invalid progress phase")
+	}
+	return nil
+}
+
+func validateEmbeddingBuildResult(result api.EmbeddingBuildResult) error {
+	if !validGenerationFingerprint(result.Fingerprint) || strings.TrimSpace(result.Model) == "" ||
+		result.Dimensions < 1 || result.Mirrored < 0 || result.Removed < 0 ||
+		result.Embedded < 0 || result.Chunks < 0 || result.Skipped < 0 || result.Stale < 0 {
+		return errors.New("embeddings response contains an invalid build result")
+	}
+	return nil
+}
+
+func validGenerationFingerprint(value string) bool {
+	if len(value) != 16 {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && hex.EncodeToString(decoded) == value
+}
+
 type BackupVerifyOptions struct {
 	Repo        string
 	SnapshotID  string

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -502,6 +502,48 @@ func TestBackupCreateStreamRoundTripAndTypedError(t *testing.T) {
 	assert.True(t, restored.Proof.SQLiteIntegrity)
 }
 
+func TestEmbeddingBuildStreamAndGenerationList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/embeddings":
+			_ = json.NewEncoder(w).Encode(api.EmbeddingGenerationList{
+				Configured: true,
+				Items: []api.EmbeddingGeneration{{
+					Fingerprint: strings.Repeat("a", 16), Model: "model", Dimensions: 2,
+					State: "active", Embedded: 1,
+				}},
+			})
+		case "/api/v1/embeddings/build/stream":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_ = json.NewEncoder(w).Encode(api.EmbeddingBuildEvent{
+				Type: "progress", Progress: &api.EmbeddingBuildProgress{
+					Phase: "embedding", Done: 1, Total: 1,
+				},
+			})
+			_ = json.NewEncoder(w).Encode(api.EmbeddingBuildEvent{
+				Type: "result", Result: &api.EmbeddingBuildResult{
+					Fingerprint: strings.Repeat("a", 16), Model: "model", Dimensions: 2,
+					Embedded: 1, Chunks: 1, Activated: true,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	c := client.New(server.URL, "key")
+	listed, err := c.EmbeddingGenerations(t.Context())
+	require.NoError(t, err)
+	require.Len(t, listed.Items, 1)
+	var progress []api.EmbeddingBuildProgress
+	result, err := c.BuildEmbeddings(t.Context(), func(event api.EmbeddingBuildProgress) {
+		progress = append(progress, event)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Embedded)
+	assert.Equal(t, []api.EmbeddingBuildProgress{{Phase: "embedding", Done: 1, Total: 1}}, progress)
+}
+
 func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {
 	c, _ := newClient(t, serverKey)
 	content := []byte("remote writer evidence")

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "23"
+	daemonProtocolVersion = "24"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,6 +61,40 @@ type BackupConfig struct {
 	ZstdLevel int    `toml:"zstd_level"`
 }
 
+// EmbeddingsConfig configures the optional OpenAI-compatible encoder used to
+// build Docbank's local, derived semantic-search index. An empty BaseURL and
+// Model leave embeddings disabled and ordinary lexical search unchanged.
+type EmbeddingsConfig struct {
+	BaseURL         string   `toml:"base_url"`
+	Model           string   `toml:"model"`
+	APIKey          string   `toml:"api_key"`
+	APIKeyEnv       string   `toml:"api_key_env"`
+	FingerprintSalt string   `toml:"fingerprint_salt"`
+	Dimensions      int      `toml:"dimensions"`
+	BatchSize       int      `toml:"batch_size"`
+	Concurrency     int      `toml:"concurrency"`
+	Timeout         Duration `toml:"timeout"`
+}
+
+// Enabled reports whether an embeddings endpoint is configured. Validate
+// rejects partial configuration, so callers never observe a half-enabled
+// section after successful config loading.
+func (e EmbeddingsConfig) Enabled() bool {
+	return strings.TrimSpace(e.BaseURL) != "" && strings.TrimSpace(e.Model) != ""
+}
+
+// ResolvedAPIKey returns the inline key or the value of APIKeyEnv. Environment
+// indirection keeps bearer credentials out of config.toml when desired.
+func (e EmbeddingsConfig) ResolvedAPIKey() string {
+	if e.APIKey != "" {
+		return e.APIKey
+	}
+	if e.APIKeyEnv != "" {
+		return os.Getenv(strings.TrimSpace(e.APIKeyEnv))
+	}
+	return ""
+}
+
 // WatchConfig describes one daemon-owned local inbox. Name and each relative
 // source path form the stable, portable source identity; Source itself is a
 // machine-local location and is intentionally not archive metadata.
@@ -74,10 +109,11 @@ type WatchConfig struct {
 
 // Config is the full contents of config.toml.
 type Config struct {
-	Server  ServerConfig  `toml:"server"`
-	Web     WebConfig     `toml:"web"`
-	Backup  BackupConfig  `toml:"backup"`
-	Watches []WatchConfig `toml:"watch"`
+	Server     ServerConfig     `toml:"server"`
+	Web        WebConfig        `toml:"web"`
+	Backup     BackupConfig     `toml:"backup"`
+	Embeddings EmbeddingsConfig `toml:"embeddings"`
+	Watches    []WatchConfig    `toml:"watch"`
 }
 
 // Default returns the configuration used when config.toml is absent.
@@ -88,6 +124,10 @@ func Default() Config {
 			IdleTimeout: Duration(30 * time.Minute),
 		},
 		Web: WebConfig{Enabled: true},
+		Embeddings: EmbeddingsConfig{
+			Dimensions: 768, BatchSize: 32, Concurrency: 2,
+			Timeout: Duration(30 * time.Second),
+		},
 	}
 }
 
@@ -220,6 +260,9 @@ func (c Config) Validate() error {
 			return err
 		}
 	}
+	if err := validateEmbeddings(c.Embeddings); err != nil {
+		return err
+	}
 	host := c.Server.BindAddr
 	if isLoopbackHost(host) {
 		return nil
@@ -229,6 +272,47 @@ func (c Config) Validate() error {
 	}
 	return fmt.Errorf("[server] bind_addr %q: the API is plain HTTP, so binds are "+
 		"loopback-only; reach a remote docbank through an SSH tunnel or VPN", host)
+}
+
+func validateEmbeddings(e EmbeddingsConfig) error {
+	hasBase := strings.TrimSpace(e.BaseURL) != ""
+	hasModel := strings.TrimSpace(e.Model) != ""
+	if hasBase != hasModel {
+		return errors.New("[embeddings] base_url and model must both be set or both omitted")
+	}
+	if e.APIKey != "" && strings.TrimSpace(e.APIKeyEnv) != "" {
+		return errors.New("[embeddings] api_key and api_key_env are mutually exclusive")
+	}
+	if !hasBase {
+		if e.APIKey != "" || strings.TrimSpace(e.APIKeyEnv) != "" ||
+			strings.TrimSpace(e.FingerprintSalt) != "" {
+			return errors.New("[embeddings] credentials and fingerprint_salt require base_url and model")
+		}
+		return nil
+	}
+	if e.Dimensions < 1 || e.Dimensions > 8192 {
+		return errors.New("[embeddings] dimensions must be between 1 and 8192")
+	}
+	if e.BatchSize < 1 || e.BatchSize > 1000 {
+		return errors.New("[embeddings] batch_size must be between 1 and 1000")
+	}
+	if e.Concurrency < 1 || e.Concurrency > 64 {
+		return errors.New("[embeddings] concurrency must be between 1 and 64")
+	}
+	if e.Timeout.Std() <= 0 {
+		return errors.New("[embeddings] timeout must be positive")
+	}
+	target, err := url.Parse(e.BaseURL)
+	if err != nil || target.Host == "" || (target.Scheme != "http" && target.Scheme != "https") {
+		return fmt.Errorf("[embeddings] base_url %q must be an absolute HTTP(S) URL", e.BaseURL)
+	}
+	if target.User != nil || target.RawQuery != "" || target.Fragment != "" {
+		return errors.New("[embeddings] base_url must not contain credentials, a query, or a fragment")
+	}
+	if target.Scheme == "http" && !isLoopbackHost(target.Hostname()) {
+		return errors.New("[embeddings] plaintext HTTP is allowed only for a loopback endpoint")
+	}
+	return nil
 }
 
 func validateWatch(watch WatchConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,11 @@ func TestLoadMissingFileReturnsDefaults(t *testing.T) {
 	assert.True(t, c.Web.Enabled)
 	assert.Empty(t, c.Backup.Repo)
 	assert.Zero(t, c.Backup.ZstdLevel)
+	assert.False(t, c.Embeddings.Enabled())
+	assert.Equal(t, 768, c.Embeddings.Dimensions)
+	assert.Equal(t, 32, c.Embeddings.BatchSize)
+	assert.Equal(t, 2, c.Embeddings.Concurrency)
+	assert.Equal(t, 30*time.Second, c.Embeddings.Timeout.Std())
 }
 
 func TestLoadParsesFile(t *testing.T) {
@@ -161,4 +166,36 @@ func TestValidateBackupCompressionLevel(t *testing.T) {
 		c.Backup.ZstdLevel = level
 		require.ErrorContains(t, c.Validate(), "zstd_level")
 	}
+}
+
+func TestValidateEmbeddings(t *testing.T) {
+	valid := Default()
+	valid.Embeddings.BaseURL = "http://127.0.0.1:11434/v1"
+	valid.Embeddings.Model = "nomic-embed-text"
+	require.NoError(t, valid.Validate())
+
+	for _, tc := range []struct {
+		name string
+		edit func(*EmbeddingsConfig)
+		want string
+	}{
+		{"partial", func(e *EmbeddingsConfig) { e.Model = "" }, "both be set"},
+		{"plaintext remote", func(e *EmbeddingsConfig) { e.BaseURL = "http://example.com/v1" }, "loopback"},
+		{"credentials", func(e *EmbeddingsConfig) { e.BaseURL = "https://user@example.com/v1" }, "credentials"},
+		{"key conflict", func(e *EmbeddingsConfig) { e.APIKey, e.APIKeyEnv = "x", "TOKEN" }, "mutually exclusive"},
+		{"zero dimensions", func(e *EmbeddingsConfig) { e.Dimensions = 0 }, "dimensions"},
+		{"excessive dimensions", func(e *EmbeddingsConfig) { e.Dimensions = 8193 }, "dimensions"},
+		{"zero batch", func(e *EmbeddingsConfig) { e.BatchSize = 0 }, "batch_size"},
+		{"zero concurrency", func(e *EmbeddingsConfig) { e.Concurrency = 0 }, "concurrency"},
+		{"zero timeout", func(e *EmbeddingsConfig) { e.Timeout = 0 }, "timeout"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := valid
+			tc.edit(&cfg.Embeddings)
+			require.ErrorContains(t, cfg.Validate(), tc.want)
+		})
+	}
+	disabledWithKey := Default()
+	disabledWithKey.Embeddings.APIKeyEnv = "TOKEN"
+	require.ErrorContains(t, disabledWithKey.Validate(), "require base_url")
 }

--- a/internal/embedding/client.go
+++ b/internal/embedding/client.go
@@ -1,0 +1,218 @@
+// Package embedding calls an OpenAI-compatible embeddings endpoint. It owns
+// no storage; vector generations and persistence live in internal/vector.
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	kitvec "go.kenn.io/kit/vector"
+)
+
+// Config is the resolved endpoint and vector-space identity.
+type Config struct {
+	BaseURL         string
+	Model           string
+	APIKey          string
+	FingerprintSalt string
+	Dimensions      int
+	BatchSize       int
+	Timeout         time.Duration
+}
+
+// Client calls one origin-pinned /embeddings endpoint.
+type Client struct {
+	http       *http.Client
+	baseURL    string
+	model      string
+	apiKey     string
+	salt       string
+	dimensions int
+	batchSize  int
+}
+
+// New validates cfg and constructs a client whose redirects cannot carry
+// document text or bearer credentials to another origin.
+func New(cfg Config) (*Client, error) {
+	if strings.TrimSpace(cfg.BaseURL) == "" || strings.TrimSpace(cfg.Model) == "" {
+		return nil, errors.New("embedding: base URL and model are required")
+	}
+	if cfg.Dimensions < 1 || cfg.BatchSize < 1 || cfg.Timeout <= 0 {
+		return nil, errors.New("embedding: positive dimensions, batch size, and timeout are required")
+	}
+	originURL, err := url.Parse(cfg.BaseURL)
+	if err != nil || originURL.Scheme == "" || originURL.Host == "" {
+		return nil, fmt.Errorf("embedding: invalid base URL %q", cfg.BaseURL)
+	}
+	origin := originURL.Scheme + "://" + originURL.Host
+	hc := &http.Client{
+		Timeout: cfg.Timeout,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if req.URL.Scheme+"://"+req.URL.Host != origin {
+				return errors.New("embedding: refusing redirect away from configured origin")
+			}
+			return nil
+		},
+	}
+	return &Client{
+		http: hc, baseURL: strings.TrimRight(cfg.BaseURL, "/"), model: cfg.Model,
+		apiKey: cfg.APIKey,
+		salt:   cfg.FingerprintSalt, dimensions: cfg.Dimensions, batchSize: cfg.BatchSize,
+	}, nil
+}
+
+// Generation identifies the exact vector space and text recipe. Endpoint
+// location is transport, not identity; FingerprintSalt distinguishes changed
+// weights published under the same model name.
+func (c *Client) Generation() kitvec.Generation {
+	params := map[string]string{}
+	if c.salt != "" {
+		params["salt"] = c.salt
+	}
+	return kitvec.Generation{Model: c.model, Dimensions: c.dimensions, Params: params}
+}
+
+// EncodeFunc adapts the client to Kit's fill and query flows.
+func (c *Client) EncodeFunc() kitvec.EncodeFunc {
+	return func(ctx context.Context, texts []string) (vectors [][]float32, err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				err = fmt.Errorf("embedding: encoder panic: %v", recovered)
+			}
+		}()
+		return c.Embed(ctx, texts)
+	}
+}
+
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embedResponse struct {
+	Data []struct {
+		Index     int             `json:"index"`
+		Embedding embeddingVector `json:"embedding"`
+	} `json:"data"`
+}
+
+type embeddingVector []float32
+
+func (v *embeddingVector) UnmarshalJSON(data []byte) error {
+	var values []*float32
+	if err := json.Unmarshal(data, &values); err != nil {
+		return err
+	}
+	out := make([]float32, len(values))
+	for i, value := range values {
+		if value == nil {
+			return fmt.Errorf("component %d is null", i)
+		}
+		out[i] = *value
+	}
+	*v = out
+	return nil
+}
+
+// Embed returns one normalized, finite vector per input in input order.
+func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+	out := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += c.batchSize {
+		end := min(start+c.batchSize, len(texts))
+		vectors, err := c.embedBatch(ctx, texts[start:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vectors...)
+	}
+	return out, nil
+}
+
+func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	body, err := json.Marshal(embedRequest{Model: c.model, Input: texts})
+	if err != nil {
+		return nil, fmt.Errorf("embedding: encode request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("embedding: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	maxBytes := int64(c.dimensions)*int64(len(texts))*16 + (1 << 20)
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if readErr != nil {
+		return nil, fmt.Errorf("embedding: read response: %w", readErr)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("embedding: response exceeds %d bytes", maxBytes)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("embedding: endpoint returned %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	var decoded embedResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return nil, fmt.Errorf("embedding: decode response: %w", err)
+	}
+	if len(decoded.Data) != len(texts) {
+		return nil, fmt.Errorf("embedding: endpoint returned %d vectors for %d inputs",
+			len(decoded.Data), len(texts))
+	}
+	vectors := make([][]float32, len(texts))
+	seen := make([]bool, len(texts))
+	for _, item := range decoded.Data {
+		if item.Index < 0 || item.Index >= len(texts) || seen[item.Index] {
+			return nil, fmt.Errorf("embedding: invalid or duplicate response index %d", item.Index)
+		}
+		seen[item.Index] = true
+		vector := []float32(item.Embedding)
+		if len(vector) != c.dimensions {
+			return nil, fmt.Errorf("embedding: response vector has %d dimensions, want %d",
+				len(vector), c.dimensions)
+		}
+		if err := normalize(vector); err != nil {
+			return nil, err
+		}
+		vectors[item.Index] = vector
+	}
+	return vectors, nil
+}
+
+func normalize(vector []float32) error {
+	var sum float64
+	for i, value := range vector {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return fmt.Errorf("embedding: component %d is not finite", i)
+		}
+		sum += float64(value) * float64(value)
+	}
+	if sum == 0 {
+		return errors.New("embedding: vector has zero norm")
+	}
+	scale := float32(1 / math.Sqrt(sum))
+	for i := range vector {
+		vector[i] *= scale
+	}
+	return nil
+}

--- a/internal/embedding/client_test.go
+++ b/internal/embedding/client_test.go
@@ -1,0 +1,79 @@
+package embedding
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientBatchesAuthenticatesOrdersAndNormalizes(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		assert.Equal(t, "/v1/embeddings", r.URL.Path)
+		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		var request embedRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decoding embedding request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		data := make([]map[string]any, len(request.Input))
+		for i := range request.Input {
+			data[len(request.Input)-1-i] = map[string]any{
+				"index": i, "embedding": []float32{3, float32(4 + i)},
+			}
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{"data": data}); err != nil {
+			t.Errorf("encoding embedding response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client, err := New(Config{
+		BaseURL: server.URL + "/v1", Model: "model", APIKey: "secret",
+		Dimensions: 2, BatchSize: 2, Timeout: time.Second,
+	})
+	require.NoError(t, err)
+	vectors, err := client.Embed(t.Context(), []string{"a", "b", "c"})
+	require.NoError(t, err)
+	require.Len(t, vectors, 3)
+	assert.Equal(t, 2, requests)
+	for _, vector := range vectors {
+		norm := math.Sqrt(float64(vector[0]*vector[0] + vector[1]*vector[1]))
+		assert.InDelta(t, 1, norm, 1e-6)
+	}
+}
+
+func TestClientRejectsMalformedVectors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"index":0,"embedding":[null,1]}]}`))
+	}))
+	t.Cleanup(server.Close)
+	client, err := New(Config{
+		BaseURL: server.URL, Model: "model", Dimensions: 2, BatchSize: 1, Timeout: time.Second,
+	})
+	require.NoError(t, err)
+	_, err = client.Embed(t.Context(), []string{"a"})
+	assert.ErrorContains(t, err, "component 0 is null")
+}
+
+func TestGenerationFingerprintExcludesEndpointAndIncludesSalt(t *testing.T) {
+	base := Config{BaseURL: "https://one.example/v1", Model: "model",
+		Dimensions: 3, BatchSize: 1, Timeout: time.Second}
+	first, err := New(base)
+	require.NoError(t, err)
+	base.BaseURL = "https://two.example/v1"
+	second, err := New(base)
+	require.NoError(t, err)
+	assert.Equal(t, first.Generation().Fingerprint(), second.Generation().Fingerprint())
+	base.FingerprintSalt = "new weights"
+	third, err := New(base)
+	require.NoError(t, err)
+	assert.NotEqual(t, first.Generation().Fingerprint(), third.Generation().Fingerprint())
+}

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -97,10 +97,11 @@ func rawPathParent(path string) (string, string) {
 	return volume + parentRest, component
 }
 
-func (l Layout) DBPath() string     { return filepath.Join(l.Root, "docbank.db") }
-func (l Layout) BlobsDir() string   { return filepath.Join(l.Root, "blobs") }
-func (l Layout) BlobTmpDir() string { return filepath.Join(l.Root, "blobs", "tmp") }
-func (l Layout) LogsDir() string    { return filepath.Join(l.Root, "logs") }
+func (l Layout) DBPath() string        { return filepath.Join(l.Root, "docbank.db") }
+func (l Layout) VectorsDBPath() string { return filepath.Join(l.Root, "vectors.db") }
+func (l Layout) BlobsDir() string      { return filepath.Join(l.Root, "blobs") }
+func (l Layout) BlobTmpDir() string    { return filepath.Join(l.Root, "blobs", "tmp") }
+func (l Layout) LogsDir() string       { return filepath.Join(l.Root, "logs") }
 
 // Ensure creates the directory layout if missing and enforces the privacy
 // the design documents rather than assuming it: Unix uses 0700 directories
@@ -125,4 +126,20 @@ func (l Layout) Ensure() error {
 		return err
 	}
 	return secureOptionalConfig(filepath.Join(l.Root, "config.toml"))
+}
+
+// EnsureVectorsDB creates the optional derived vector sidecar with the same
+// owner-private boundary as the authoritative database. The daemon calls it
+// only when embeddings are configured, so lexical-only vaults never acquire
+// an unused sidecar.
+func (l Layout) EnsureVectorsDB() error {
+	db, err := os.OpenFile(l.VectorsDBPath(), os.O_CREATE|os.O_RDONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", l.VectorsDBPath(), err)
+	}
+	closeErr := db.Close()
+	if closeErr != nil {
+		return fmt.Errorf("closing %s: %w", l.VectorsDBPath(), closeErr)
+	}
+	return enforceMode(l.VectorsDBPath(), 0o600)
 }

--- a/internal/store/vector.go
+++ b/internal/store/vector.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// VectorDocument is one unique content object currently selected by at least
+// one live, text-searchable file. ExtractorVersion and Text together determine
+// derived embedding freshness.
+type VectorDocument struct {
+	BlobHash         string
+	ExtractorVersion int
+	Text             string
+}
+
+// VectorDocuments returns a stable node-ID page for the rebuildable vector
+// mirror. It exposes no historical or trashed content and relies only on the
+// current extractor's successful FTS projection.
+func (s *Store) VectorDocuments(
+	ctx context.Context, afterBlobHash string, limit int,
+) ([]VectorDocument, error) {
+	if limit < 1 || limit > 5000 {
+		return nil, errors.New("invalid vector document page")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT DISTINCT v.blob_hash, e.extractor_version, e.text
+		FROM nodes n
+		JOIN content_versions v ON v.version_id=n.current_version_id
+		JOIN text_searchable_versions sv ON sv.version_id=v.version_id
+		JOIN extracted_text e ON e.blob_hash=v.blob_hash
+		WHERE v.blob_hash > ? AND n.trashed_at IS NULL
+		  AND n.kind='file' AND e.extractor='plain-text' AND e.status='ok'
+		  AND e.text IS NOT NULL AND e.text<>''
+		ORDER BY v.blob_hash
+		LIMIT ?`, afterBlobHash, limit)
+	if err != nil {
+		return nil, fmt.Errorf("listing vector documents: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	items := make([]VectorDocument, 0)
+	for rows.Next() {
+		var item VectorDocument
+		if err := rows.Scan(&item.BlobHash, &item.ExtractorVersion, &item.Text); err != nil {
+			return nil, fmt.Errorf("listing vector documents: scanning row: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing vector documents: %w", err)
+	}
+	return items, nil
+}

--- a/internal/store/vector_test.go
+++ b/internal/store/vector_test.go
@@ -1,0 +1,46 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVectorDocumentsContainsOnlyCurrentLiveExtractedText(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	live, err := s.CreateFile(ctx, s.RootID(), "live.txt", fakeHash("a1"), 5, "text/plain")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, s.RootID(), "duplicate.txt", fakeHash("a1"), 5, "text/plain")
+	require.NoError(t, err)
+	trashed, err := s.CreateFile(ctx, s.RootID(), "trashed.txt", fakeHash("b2"), 5, "text/plain")
+	require.NoError(t, err)
+	unsupported, err := s.CreateFile(ctx, s.RootID(), "scan.pdf", fakeHash("c3"), 5, "application/pdf")
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: live.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "current live text",
+	}))
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: trashed.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "trashed text",
+	}))
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: unsupported.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "unsupported text",
+	}))
+	_, _, err = s.Trash(ctx, trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+
+	items, err := s.VectorDocuments(ctx, "", 100)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, live.BlobHash, items[0].BlobHash)
+	assert.Equal(t, 1, items[0].ExtractorVersion)
+	assert.Equal(t, "current live text", items[0].Text)
+
+	items, err = s.VectorDocuments(ctx, live.BlobHash, 100)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}

--- a/internal/vector/driver_cgo.go
+++ b/internal/vector/driver_cgo.go
@@ -1,0 +1,21 @@
+//go:build !windows && cgo
+
+package vector
+
+import (
+	"net/url"
+
+	// Register the CGO-backed SQLite driver used by the standalone daemon.
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const sidecarDriver = "sqlite3"
+
+func sidecarDSN(path string) string {
+	query := url.Values{
+		"_journal_mode": {"WAL"},
+		"_busy_timeout": {"5000"},
+		"_synchronous":  {"NORMAL"},
+	}
+	return sidecarURI(path, query)
+}

--- a/internal/vector/driver_modernc.go
+++ b/internal/vector/driver_modernc.go
@@ -1,0 +1,19 @@
+//go:build windows || !cgo
+
+package vector
+
+import (
+	"net/url"
+
+	_ "modernc.org/sqlite"
+)
+
+const sidecarDriver = "sqlite"
+
+func sidecarDSN(path string) string {
+	query := url.Values{}
+	query.Add("_pragma", "journal_mode(WAL)")
+	query.Add("_pragma", "busy_timeout(5000)")
+	query.Add("_pragma", "synchronous(NORMAL)")
+	return sidecarURI(path, query)
+}

--- a/internal/vector/dsn.go
+++ b/internal/vector/dsn.go
@@ -1,0 +1,18 @@
+package vector
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+func sidecarURI(path string, query url.Values) string {
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	path = filepath.ToSlash(path)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return (&url.URL{Scheme: "file", Path: path, RawQuery: query.Encode()}).String()
+}

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -1,0 +1,530 @@
+// Package vector owns Docbank's rebuildable semantic-search sidecar. The
+// authoritative metadata store supplies current extracted text; Kit owns the
+// generation, fill, freshness, and sqlite-vec persistence contracts.
+package vector
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"strconv"
+	"sync"
+
+	kitvec "go.kenn.io/kit/vector"
+	"go.kenn.io/kit/vector/sqlitevec"
+)
+
+const (
+	sidecarSchemaVersion = "1"
+	vectorsPrefix        = "document_vectors"
+	mirrorPageSize       = 500
+	splitMaxRunes        = 2000
+	splitOverlap         = 200
+	documentRecipe       = "1"
+)
+
+var ErrBuildRunning = errors.New("an embeddings build is already running")
+
+// Document is one current live source row for the derived mirror.
+type Document struct {
+	BlobHash         string
+	ExtractorVersion int
+	Text             string
+}
+
+// SourceFunc pages unique current embeddable content in stable digest order.
+type SourceFunc func(ctx context.Context, afterBlobHash string, limit int) ([]Document, error)
+
+// Progress reports unique-content build progress. Phase is "scanning" or
+// "embedding"; Total becomes known once the mirror is current.
+type Progress struct {
+	Phase string
+	Done  int
+	Total int
+}
+
+// BuildResult summarizes one completed unique-content mirror refresh and generation fill.
+type BuildResult struct {
+	Fingerprint string
+	Model       string
+	Dimensions  int
+	Mirrored    int
+	Removed     int
+	Embedded    int
+	Chunks      int
+	Skipped     int
+	Stale       int
+	Activated   bool
+}
+
+// GenerationInfo is one locally retained vector generation and its coverage
+// of the current unique-content mirror.
+type GenerationInfo struct {
+	Fingerprint string
+	Model       string
+	Dimensions  int
+	State       string
+	Embedded    int
+	Skipped     int
+	Pending     int
+}
+
+// Index owns one vectors.db and serializes builds over it.
+type Index struct {
+	db    *sql.DB
+	store *sqlitevec.Store[string, string]
+	path  string
+
+	mu      sync.Mutex
+	running bool
+}
+
+// Open creates or opens the derived sidecar. A sidecar schema mismatch is
+// handled by deleting and rebuilding it; vectors are never archive authority.
+func Open(ctx context.Context, path string) (*Index, error) {
+	if path == "" {
+		return nil, errors.New("vector: sidecar path is required")
+	}
+	db, current, err := openCurrentSidecar(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if !current {
+		_ = db.Close()
+		if err := removeSidecar(path); err != nil {
+			return nil, err
+		}
+		db, current, err = openCurrentSidecar(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+		if !current {
+			_ = db.Close()
+			return nil, errors.New("vector: recreated sidecar has an unexpected schema")
+		}
+	}
+	store, err := sqlitevec.New[string, string](ctx, db, sqlitevec.Schema{
+		DocsTable: "document_mirror", IDColumn: "blob_hash", ContentColumn: "content",
+		EmbedGenColumn: "embed_gen", RevisionColumn: "source_revision",
+		VectorsPrefix: vectorsPrefix,
+	})
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("vector: initialize Kit store: %w", err)
+	}
+	return &Index{db: db, store: store, path: path}, nil
+}
+
+func openCurrentSidecar(ctx context.Context, path string) (*sql.DB, bool, error) {
+	sqlitevec.Register()
+	db, err := sql.Open(sidecarDriver, sidecarDSN(path))
+	if err != nil {
+		return nil, false, fmt.Errorf("vector: open sidecar: %w", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, false, fmt.Errorf("vector: open sidecar: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = db.Close()
+		return nil, false, fmt.Errorf("vector: protect sidecar: %w", err)
+	}
+	var found bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM sqlite_master WHERE type='table' AND name='vector_meta')`).Scan(&found); err != nil {
+		_ = db.Close()
+		return nil, false, fmt.Errorf("vector: inspect sidecar schema: %w", err)
+	}
+	if found {
+		var version string
+		err := db.QueryRowContext(ctx,
+			`SELECT value FROM vector_meta WHERE key='schema_version'`).Scan(&version)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			_ = db.Close()
+			return nil, false, fmt.Errorf("vector: inspect sidecar version: %w", err)
+		}
+		if version != sidecarSchemaVersion {
+			return db, false, nil
+		}
+	}
+	if err := ensureSidecarSchema(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, false, err
+	}
+	return db, true, nil
+}
+
+func ensureSidecarSchema(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS vector_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS document_mirror (
+  blob_hash       TEXT PRIMARY KEY,
+  content         TEXT NOT NULL,
+  source_revision TEXT NOT NULL,
+  embed_gen       TEXT
+);
+CREATE TABLE IF NOT EXISTS embedding_generation_details (
+  fingerprint TEXT PRIMARY KEY,
+  model       TEXT NOT NULL
+);
+INSERT INTO vector_meta(key,value) VALUES('schema_version','`+sidecarSchemaVersion+`')
+ON CONFLICT(key) DO NOTHING;`)
+	if err != nil {
+		return fmt.Errorf("vector: prepare sidecar schema: %w", err)
+	}
+	return nil
+}
+
+func removeSidecar(path string) error {
+	for _, candidate := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Remove(candidate); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("vector: remove stale sidecar %s: %w", candidate, err)
+		}
+	}
+	return nil
+}
+
+// Close releases the sidecar database.
+func (ix *Index) Close() error {
+	if ix == nil || ix.db == nil {
+		return nil
+	}
+	return ix.db.Close()
+}
+
+// Build refreshes the mirror, fills the configured generation, and activates
+// it only after every current mirror row is covered. A failed new-generation
+// build leaves the prior active generation available.
+func (ix *Index) Build(
+	ctx context.Context, source SourceFunc, generation kitvec.Generation,
+	encode kitvec.EncodeFunc, batchSize, concurrency int, progress func(Progress),
+) (BuildResult, error) {
+	if !ix.beginBuild() {
+		return BuildResult{}, ErrBuildRunning
+	}
+	defer ix.endBuild()
+	if source == nil || encode == nil {
+		return BuildResult{}, errors.New("vector: source and encoder are required")
+	}
+	generation = withDocumentRecipe(generation)
+	if progress != nil {
+		progress(Progress{Phase: "scanning"})
+	}
+	written, removed, err := ix.refresh(ctx, source)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	fingerprint := generation.Fingerprint()
+	result := BuildResult{
+		Fingerprint: fingerprint, Model: generation.Model,
+		Dimensions: generation.Dimensions, Mirrored: written, Removed: removed,
+	}
+	if err := ix.ensureGeneration(ctx, fingerprint, generation); err != nil {
+		return result, err
+	}
+	total, err := ix.backlog(ctx, fingerprint)
+	if err != nil {
+		return result, err
+	}
+	if progress != nil {
+		progress(Progress{Phase: "embedding", Total: total})
+	}
+	done := 0
+	flowStore := progressStore{
+		Store: ix.store,
+		afterSave: func() {
+			done++
+			if progress != nil {
+				progress(Progress{Phase: "embedding", Done: done, Total: total})
+			}
+		},
+	}
+	stats, err := kitvec.Fill[string, string](ctx, flowStore, fingerprint, encode,
+		kitvec.FillOptions[string]{
+			Split: kitvec.SplitOptions{MaxRunes: splitMaxRunes, Overlap: splitOverlap},
+			Batch: kitvec.BatchOptions{BatchSize: batchSize}, Concurrency: concurrency,
+		})
+	result.Embedded, result.Chunks = stats.Documents, stats.Chunks
+	result.Skipped, result.Stale = stats.Skipped, stats.Stale
+	if err != nil {
+		return result, fmt.Errorf("vector: build generation: %w", err)
+	}
+	remaining, err := ix.backlog(ctx, fingerprint)
+	if err != nil {
+		return result, err
+	}
+	if remaining == 0 {
+		if err := ix.activate(ctx, fingerprint); err != nil {
+			return result, err
+		}
+		result.Activated = true
+	}
+	return result, nil
+}
+
+func withDocumentRecipe(generation kitvec.Generation) kitvec.Generation {
+	params := make(map[string]string, len(generation.Params)+4)
+	maps.Copy(params, generation.Params)
+	params["docbank_recipe"] = documentRecipe
+	params["source"] = "plain-text"
+	params["split_max_runes"] = strconv.Itoa(splitMaxRunes)
+	params["split_overlap"] = strconv.Itoa(splitOverlap)
+	generation.Params = params
+	return generation
+}
+
+type progressStore struct {
+	kitvec.Store[string, string]
+
+	afterSave func()
+}
+
+func (s progressStore) SaveVectors(
+	ctx context.Context, generation string, document string, revision any,
+	vectors []kitvec.ChunkVector,
+) error {
+	if err := s.Store.SaveVectors(ctx, generation, document, revision, vectors); err != nil {
+		return fmt.Errorf("vector: save progress document: %w", err)
+	}
+	if s.afterSave != nil {
+		s.afterSave()
+	}
+	return nil
+}
+
+func (ix *Index) beginBuild() bool {
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	if ix.running {
+		return false
+	}
+	ix.running = true
+	return true
+}
+
+func (ix *Index) endBuild() {
+	ix.mu.Lock()
+	ix.running = false
+	ix.mu.Unlock()
+}
+
+func (ix *Index) refresh(ctx context.Context, source SourceFunc) (int, int, error) {
+	seen := make(map[string]struct{})
+	written := 0
+	after := ""
+	for {
+		page, err := source(ctx, after, mirrorPageSize)
+		if err != nil {
+			return written, 0, fmt.Errorf("vector: refresh source: %w", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, document := range page {
+			if document.BlobHash <= after || document.ExtractorVersion < 1 {
+				return written, 0, errors.New("vector: source returned an invalid or unordered document page")
+			}
+			after = document.BlobHash
+			seen[document.BlobHash] = struct{}{}
+			revision := sourceRevision(document)
+			result, err := ix.db.ExecContext(ctx, `
+				INSERT INTO document_mirror(blob_hash,content,source_revision)
+				VALUES(?,?,?)
+				ON CONFLICT(blob_hash) DO UPDATE SET
+				  content=excluded.content,
+				  source_revision=excluded.source_revision
+				WHERE document_mirror.source_revision<>excluded.source_revision
+				   OR document_mirror.content<>excluded.content`,
+				document.BlobHash, document.Text, revision)
+			if err != nil {
+				return written, 0, fmt.Errorf("vector: mirror content %s: %w", document.BlobHash, err)
+			}
+			if changed, err := result.RowsAffected(); err == nil {
+				written += int(changed)
+			}
+		}
+	}
+	rows, err := ix.db.QueryContext(ctx, `SELECT blob_hash FROM document_mirror ORDER BY blob_hash`)
+	if err != nil {
+		return written, 0, fmt.Errorf("vector: list mirror nodes: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var stale []string
+	for rows.Next() {
+		var blobHash string
+		if err := rows.Scan(&blobHash); err != nil {
+			_ = rows.Close()
+			return written, 0, fmt.Errorf("vector: list mirror nodes: %w", err)
+		}
+		if _, exists := seen[blobHash]; !exists {
+			stale = append(stale, blobHash)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return written, 0, fmt.Errorf("vector: list mirror nodes: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return written, 0, fmt.Errorf("vector: list mirror nodes: %w", err)
+	}
+	for _, blobHash := range stale {
+		if err := ix.store.DeleteVectors(ctx, blobHash); err != nil {
+			return written, 0, fmt.Errorf("vector: remove content %s vectors: %w", blobHash, err)
+		}
+		if _, err := ix.db.ExecContext(ctx,
+			`DELETE FROM document_mirror WHERE blob_hash=?`, blobHash); err != nil {
+			return written, 0, fmt.Errorf("vector: remove mirror content %s: %w", blobHash, err)
+		}
+	}
+	return written, len(stale), nil
+}
+
+func sourceRevision(document Document) string {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(strconv.Itoa(document.ExtractorVersion)))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(document.Text))
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func (ix *Index) ensureGeneration(
+	ctx context.Context, fingerprint string, generation kitvec.Generation,
+) error {
+	state, err := ix.generationState(ctx, fingerprint)
+	if err != nil {
+		return err
+	}
+	if state != string(sqlitevec.StateActive) {
+		if err := ix.store.EnsureGeneration(
+			ctx, fingerprint, generation, sqlitevec.StateBuilding,
+		); err != nil {
+			return fmt.Errorf("vector: ensure generation: %w", err)
+		}
+	}
+	if _, err := ix.db.ExecContext(ctx, `
+		INSERT INTO embedding_generation_details(fingerprint,model)
+		VALUES(?,?) ON CONFLICT(fingerprint) DO NOTHING`,
+		fingerprint, generation.Model); err != nil {
+		return fmt.Errorf("vector: record generation details: %w", err)
+	}
+	return nil
+}
+
+func (ix *Index) generationState(ctx context.Context, fingerprint string) (string, error) {
+	var state string
+	err := ix.db.QueryRowContext(ctx, `
+		SELECT state FROM document_vectors_generations WHERE gen_key=?`, fingerprint).Scan(&state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("vector: read generation state: %w", err)
+	}
+	return state, nil
+}
+
+func (ix *Index) activate(ctx context.Context, fingerprint string) error {
+	tx, err := ix.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("vector: begin generation activation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(ctx, `
+		UPDATE document_vectors_generations
+		SET state=CASE WHEN gen_key=? THEN 'active' ELSE 'retired' END`, fingerprint)
+	if err != nil {
+		return fmt.Errorf("vector: activate generation: %w", err)
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed == 0 {
+		return fmt.Errorf("vector: generation %s was not found", fingerprint)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("vector: commit generation activation: %w", err)
+	}
+	return nil
+}
+
+func (ix *Index) backlog(ctx context.Context, fingerprint string) (int, error) {
+	var count int
+	err := ix.db.QueryRowContext(ctx, `
+		SELECT count(*) FROM document_mirror m
+		WHERE NOT EXISTS (
+		  SELECT 1 FROM document_vectors_stamps s
+		  JOIN document_vectors_generations g ON g.ordinal=s.ordinal
+		  WHERE g.gen_key=? AND s.doc_key=m.blob_hash
+		    AND s.revision IS m.source_revision
+		)`, fingerprint).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("vector: count generation backlog: %w", err)
+	}
+	return count, nil
+}
+
+// Generations lists local generation coverage newest first.
+func (ix *Index) Generations(ctx context.Context) ([]GenerationInfo, error) {
+	rows, err := ix.db.QueryContext(ctx, `
+		SELECT g.gen_key, d.model, g.dimension, g.state
+		FROM document_vectors_generations g
+		JOIN embedding_generation_details d ON d.fingerprint=g.gen_key
+		ORDER BY g.ordinal DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("vector: list generations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var items []GenerationInfo
+	for rows.Next() {
+		var item GenerationInfo
+		if err := rows.Scan(
+			&item.Fingerprint, &item.Model, &item.Dimensions, &item.State,
+		); err != nil {
+			return nil, fmt.Errorf("vector: list generations: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("vector: list generations: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("vector: list generations: %w", err)
+	}
+	for i := range items {
+		embedded, skipped, pending, err := ix.coverage(ctx, items[i].Fingerprint)
+		if err != nil {
+			return nil, err
+		}
+		items[i].Embedded, items[i].Skipped, items[i].Pending = embedded, skipped, pending
+	}
+	return items, nil
+}
+
+func (ix *Index) coverage(ctx context.Context, fingerprint string) (int, int, int, error) {
+	pending, err := ix.backlog(ctx, fingerprint)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	var total, embedded int
+	if err := ix.db.QueryRowContext(ctx, `SELECT count(*) FROM document_mirror`).Scan(&total); err != nil {
+		return 0, 0, 0, fmt.Errorf("vector: count mirror rows: %w", err)
+	}
+	if err := ix.db.QueryRowContext(ctx, `
+		SELECT count(DISTINCT m.blob_hash)
+		FROM document_mirror m
+		JOIN document_vectors_stamps s ON s.doc_key=m.blob_hash AND s.revision IS m.source_revision
+		JOIN document_vectors_generations g ON g.ordinal=s.ordinal AND g.gen_key=?
+		JOIN document_vectors_chunks c ON c.ordinal=s.ordinal AND c.doc_key=s.doc_key`,
+		fingerprint).Scan(&embedded); err != nil {
+		return 0, 0, 0, fmt.Errorf("vector: count embedded rows: %w", err)
+	}
+	return embedded, max(total-pending-embedded, 0), pending, nil
+}
+
+// Path returns the sidecar path for diagnostics and tests.
+func (ix *Index) Path() string { return ix.path }

--- a/internal/vector/index_test.go
+++ b/internal/vector/index_test.go
@@ -1,0 +1,176 @@
+package vector
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"math"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitvec "go.kenn.io/kit/vector"
+)
+
+func TestBuildRefreshesCurrentDocumentsAndActivatesCompleteGeneration(t *testing.T) {
+	ctx := t.Context()
+	index, err := Open(ctx, filepath.Join(t.TempDir(), "vectors.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.Close()) })
+
+	documents := []Document{
+		{BlobHash: vectorTestHash("a"), ExtractorVersion: 1, Text: "alpha"},
+		{BlobHash: vectorTestHash("b"), ExtractorVersion: 1, Text: "beta"},
+	}
+	source := documentSource(&documents)
+	generation := kitvec.Generation{Model: "test-model", Dimensions: 2,
+		Params: map[string]string{"recipe": "1"}}
+	var progress []Progress
+	result, err := index.Build(ctx, source, generation, testEncoder(2), 8, 2,
+		func(event Progress) { progress = append(progress, event) })
+	require.NoError(t, err)
+	assert.True(t, result.Activated)
+	assert.Equal(t, 2, result.Embedded)
+	assert.Equal(t, 2, result.Chunks)
+	assert.Equal(t, "scanning", progress[0].Phase)
+	assert.Equal(t, Progress{Phase: "embedding", Done: 2, Total: 2}, progress[len(progress)-1])
+
+	items, err := index.Generations(ctx)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "active", items[0].State)
+	assert.Equal(t, 2, items[0].Embedded)
+	assert.Zero(t, items[0].Pending)
+
+	result, err = index.Build(ctx, source, generation, testEncoder(2), 8, 1, nil)
+	require.NoError(t, err)
+	assert.Zero(t, result.Embedded)
+
+	documents = []Document{{
+		BlobHash: vectorTestHash("a"), ExtractorVersion: 2, Text: "changed",
+	}}
+	result, err = index.Build(ctx, source, generation, testEncoder(2), 8, 1, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Embedded)
+	assert.Equal(t, 1, result.Removed)
+	items, err = index.Generations(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, items[0].Embedded)
+	assert.Zero(t, items[0].Pending)
+
+	documents[0].Text = "corrected extraction"
+	result, err = index.Build(ctx, source, generation, testEncoder(2), 8, 1, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Embedded,
+		"corrected text must invalidate vectors even when extractor version is unchanged")
+}
+
+func TestBuildRetiresPriorGenerationOnlyAfterReplacementCompletes(t *testing.T) {
+	ctx := t.Context()
+	index, err := Open(ctx, filepath.Join(t.TempDir(), "vectors.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.Close()) })
+	documents := []Document{{
+		BlobHash: vectorTestHash("a"), ExtractorVersion: 1, Text: "alpha",
+	}}
+	source := documentSource(&documents)
+	first := kitvec.Generation{Model: "first", Dimensions: 2}
+	second := kitvec.Generation{Model: "second", Dimensions: 3}
+
+	_, err = index.Build(ctx, source, first, testEncoder(2), 8, 1, nil)
+	require.NoError(t, err)
+	_, err = index.Build(ctx, source, second,
+		func(context.Context, []string) ([][]float32, error) {
+			return nil, errors.New("encoder unavailable")
+		}, 8, 1, nil)
+	require.ErrorContains(t, err, "encoder unavailable")
+	items, err := index.Generations(ctx)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "building", items[0].State)
+	assert.Equal(t, "active", items[1].State,
+		"a failed replacement must not retire the searchable generation")
+
+	_, err = index.Build(ctx, source, second, testEncoder(3), 8, 1, nil)
+	require.NoError(t, err)
+	items, err = index.Generations(ctx)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "active", items[0].State)
+	assert.Equal(t, "second", items[0].Model)
+	assert.Equal(t, "retired", items[1].State)
+}
+
+func TestBuildRejectsConcurrentRun(t *testing.T) {
+	ctx := t.Context()
+	index, err := Open(ctx, filepath.Join(t.TempDir(), "vectors.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.Close()) })
+	documents := []Document{{
+		BlobHash: vectorTestHash("a"), ExtractorVersion: 1, Text: "alpha",
+	}}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	encoder := func(ctx context.Context, _ []string) ([][]float32, error) {
+		close(started)
+		select {
+		case <-release:
+			return [][]float32{{1, 0}}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	generation := kitvec.Generation{Model: "test", Dimensions: 2}
+	errCh := make(chan error, 1)
+	go func() {
+		_, buildErr := index.Build(ctx, documentSource(&documents), generation, encoder, 8, 1, nil)
+		errCh <- buildErr
+	}()
+	<-started
+	_, err = index.Build(ctx, documentSource(&documents), generation, testEncoder(2), 8, 1, nil)
+	require.ErrorIs(t, err, ErrBuildRunning)
+	close(release)
+	require.NoError(t, <-errCh)
+}
+
+func documentSource(documents *[]Document) SourceFunc {
+	return func(_ context.Context, after string, limit int) ([]Document, error) {
+		items := slices.Clone(*documents)
+		slices.SortFunc(items, func(a, b Document) int { return cmp.Compare(a.BlobHash, b.BlobHash) })
+		page := make([]Document, 0, limit)
+		for _, item := range items {
+			if item.BlobHash > after && len(page) < limit {
+				page = append(page, item)
+			}
+		}
+		return page, nil
+	}
+}
+
+func vectorTestHash(digit string) string { return strings.Repeat(digit, 64) }
+
+func testEncoder(dimensions int) kitvec.EncodeFunc {
+	return func(_ context.Context, texts []string) ([][]float32, error) {
+		vectors := make([][]float32, len(texts))
+		for i, text := range texts {
+			vector := make([]float32, dimensions)
+			vector[0] = 1
+			if dimensions > 1 {
+				vector[1] = float32(len(text)) / 100
+			}
+			var sum float64
+			for _, value := range vector {
+				sum += float64(value * value)
+			}
+			scale := float32(1 / math.Sqrt(sum))
+			for j := range vector {
+				vector[j] *= scale
+			}
+			vectors[i] = vector
+		}
+		return vectors, nil
+	}
+}

--- a/internal/vector/service.go
+++ b/internal/vector/service.go
@@ -1,0 +1,29 @@
+package vector
+
+import (
+	"context"
+
+	kitvec "go.kenn.io/kit/vector"
+)
+
+// Service binds one configured encoder and authoritative source to an Index.
+// It is the narrow daemon-facing embeddings lifecycle surface.
+type Service struct {
+	Index       *Index
+	Source      SourceFunc
+	Generation  kitvec.Generation
+	Encode      kitvec.EncodeFunc
+	BatchSize   int
+	Concurrency int
+}
+
+// Build refreshes and fills the configured generation.
+func (s *Service) Build(ctx context.Context, progress func(Progress)) (BuildResult, error) {
+	return s.Index.Build(ctx, s.Source, s.Generation, s.Encode,
+		s.BatchSize, s.Concurrency, progress)
+}
+
+// Generations reports retained generations and current coverage.
+func (s *Service) Generations(ctx context.Context) ([]GenerationInfo, error) {
+	return s.Index.Generations(ctx)
+}


### PR DESCRIPTION
Docbank can now prepare its verified current text for semantic search without making model output part of the archive. After configuring an OpenAI-compatible encoder, a person or agent can run `docbank embeddings build`, watch progress, and inspect retained generations with `docbank embeddings list`. Byte-identical documents are encoded once.

The disclosure boundary is explicit: configuration alone sends nothing, and a requested build sends only successfully extracted text from current live documents. It does not send paths, tags, provenance, audit records, historical versions, trashed content, or original binary files.

Vectors live in a disposable local `vectors.db`, outside JSONL and backup authority. Builds resume incomplete work, and a replacement model becomes active only after it covers the complete current mirror; a failed replacement leaves the prior complete generation active. Restoring a vault therefore restores documents and metadata, then the vector index can be rebuilt.

This also preserves the embedding boundary for Go applications. The public `go.kenn.io/docbank` package does not import the daemon vector layer, so embedders that do not need semantic indexing can continue using pure-Go SQLite without a CGo vector dependency. The official daemon owns the optional vector backend.

This PR deliberately stops at generation construction and inventory. Semantic and hybrid query will follow as a separate, unstacked change built on this substrate.