### PR TITLE
Make releases a clear human-operated workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DEFAULT_GOLANGCI_LINT_CACHE := $(shell git rev-parse --path-format=absolute --gi
 GOLANGCI_LINT_CACHE ?= $(DEFAULT_GOLANGCI_LINT_CACHE)
 export GOLANGCI_LINT_CACHE
 
-.PHONY: build install clean test test-v fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve docs-link docs-deploy help
+.PHONY: build install clean test test-v release-scripts-test fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve docs-link docs-deploy help
 
 build:
 	CGO_ENABLED=1 go build -tags "$(BUILD_TAGS)" -ldflags="$(LDFLAGS)" -o docbank ./cmd/docbank
@@ -38,6 +38,9 @@ test:
 
 test-v:
 	go test -tags "$(BUILD_TAGS)" -v ./...
+
+release-scripts-test:
+	bash scripts/release_scripts_test.sh
 
 fmt:
 	go fmt ./...
@@ -98,4 +101,4 @@ docs-deploy: docs-build
 	vercel deploy docs/site --prod --yes
 
 help:
-	@echo "Targets: build install clean test test-v fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve docs-link docs-deploy"
+	@echo "Targets: build install clean test test-v release-scripts-test fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve docs-link docs-deploy"

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,110 +1,193 @@
 #!/usr/bin/env bash
 # Generate release notes from commits since the previous release.
 # Usage: ./scripts/changelog.sh [version] [start_tag] [extra_instructions]
-# Set CHANGELOG_AGENT=claude to use Claude instead of Codex (default).
-# If version is omitted, NEXT is used as a placeholder.
-# If start_tag is - or omitted, the previous tag is auto-detected.
+# Set CHANGELOG_AGENT=codex (default), claude, or none.
 
 set -euo pipefail
 
-VERSION="${1:-NEXT}"
-START_TAG="${2:-}"
-EXTRA_INSTRUCTIONS="${3:-}"
-AGENT="${CHANGELOG_AGENT:-codex}"
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-CHANGELOG_PATHS=(
-    .
-    ':(exclude)docs/**'
-    ':(exclude)AGENTS.md'
-    ':(exclude).roborev.toml'
+version="${1:-NEXT}"
+start_tag="${2:-}"
+extra_instructions="${3:-}"
+agent="${CHANGELOG_AGENT:-codex}"
+repo_root="$(git rev-parse --show-toplevel)"
+changelog_paths=(
+  .
+  ':(exclude)docs/**'
+  ':(exclude)AGENTS.md'
+  ':(exclude).roborev.toml'
 )
 
-if [[ -n "$START_TAG" && "$START_TAG" != "-" ]]; then
-    git -C "$REPO_ROOT" rev-parse --verify "${START_TAG}^{commit}" >/dev/null
-    RANGE="${START_TAG}..HEAD"
-    RANGE_LABEL="$START_TAG"
-    echo "Generating changelog from $START_TAG to HEAD..." >&2
-else
-    PREV_TAG="$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || true)"
-    if [[ -z "$PREV_TAG" ]]; then
-        FIRST_COMMIT="$(git -C "$REPO_ROOT" rev-list --max-parents=0 HEAD)"
-        RANGE="${FIRST_COMMIT}..HEAD"
-        RANGE_LABEL="$FIRST_COMMIT"
-        echo "No previous release found. Generating changelog for all commits..." >&2
-    else
-        RANGE="${PREV_TAG}..HEAD"
-        RANGE_LABEL="$PREV_TAG"
-        echo "Generating changelog from $PREV_TAG to HEAD..." >&2
-    fi
+range_spec=""
+range_label="the beginning of the repository"
+if [[ -n "$start_tag" && "$start_tag" != "-" ]]; then
+  git -C "$repo_root" rev-parse --verify "${start_tag}^{commit}" >/dev/null
+  range_spec="${start_tag}..HEAD"
+  range_label="$start_tag"
+elif previous_tag="$(git -C "$repo_root" describe --tags --abbrev=0 2>/dev/null)"; then
+  range_spec="${previous_tag}..HEAD"
+  range_label="$previous_tag"
 fi
 
-# Documentation-only and reviewer-configuration commits are intentionally
-# excluded from release-note material.
-COMMITS="$(git -C "$REPO_ROOT" log "$RANGE" --pretty=format:'- %s (%h)' --no-merges -- "${CHANGELOG_PATHS[@]}")"
-DIFF_STAT="$(git -C "$REPO_ROOT" diff --stat "$RANGE" -- "${CHANGELOG_PATHS[@]}")"
+git_log() {
+  if [[ -n "$range_spec" ]]; then
+    git -C "$repo_root" log --no-merges "$@" "$range_spec" -- "${changelog_paths[@]}"
+  else
+    git -C "$repo_root" log --no-merges "$@" -- "${changelog_paths[@]}"
+  fi
+}
 
-if [[ -z "$COMMITS" ]]; then
-    echo "No non-documentation commits since $RANGE_LABEL" >&2
-    exit 0
+git_diff_stat() {
+  if [[ -n "$range_spec" ]]; then
+    git -C "$repo_root" diff --stat "$range_spec" -- "${changelog_paths[@]}"
+  else
+    local empty_tree
+    empty_tree="$(git -C "$repo_root" hash-object -t tree /dev/null)"
+    git -C "$repo_root" diff --stat "$empty_tree" HEAD -- "${changelog_paths[@]}"
+  fi
+}
+
+fallback_changelog() {
+  local log_output
+  log_output="$(git_log --pretty=format:'%s%x09%h')"
+  if [[ -z "$log_output" ]]; then
+    printf '## Changes\n\n- No commits since %s.\n' "$range_label"
+    return
+  fi
+
+  local features="" improvements="" fixes=""
+  while IFS=$'\t' read -r subject short_hash; do
+    [[ -n "$subject" ]] || continue
+    local entry="- ${subject} (${short_hash})"
+    case "$subject" in
+      feat:*|feat\(*\):*|feature:*|feature\(*\):*)
+        features+="${entry}"$'\n'
+        ;;
+      fix:*|fix\(*\):*|bugfix:*|bugfix\(*\):*)
+        fixes+="${entry}"$'\n'
+        ;;
+      docs:*|docs\(*\):*|doc:*|doc\(*\):*)
+        ;;
+      *)
+        improvements+="${entry}"$'\n'
+        ;;
+    esac
+  done <<<"$log_output"
+
+  local printed=0
+  if [[ -n "$features" ]]; then
+    printf '## New Features\n\n%s' "$features"
+    printed=1
+  fi
+  if [[ -n "$improvements" ]]; then
+    [[ $printed -eq 0 ]] || printf '\n'
+    printf '## Improvements\n\n%s' "$improvements"
+    printed=1
+  fi
+  if [[ -n "$fixes" ]]; then
+    [[ $printed -eq 0 ]] || printf '\n'
+    printf '## Bug Fixes\n\n%s' "$fixes"
+    printed=1
+  fi
+  if [[ $printed -eq 0 ]]; then
+    printf '## Improvements\n\n- No user-facing changes in this commit range.\n'
+  fi
+}
+
+if [[ "$agent" == "none" ]]; then
+  fallback_changelog
+  exit 0
 fi
 
-echo "Using $AGENT to generate changelog..." >&2
+prompt_file="$(mktemp)"
+log_file="$(mktemp)"
+diff_file="$(mktemp)"
+notes_file="$(mktemp)"
+err_file="$(mktemp)"
+trap 'rm -f "$prompt_file" "$log_file" "$diff_file" "$notes_file" "$err_file"' EXIT
 
-OUTPUT_FILE="$(mktemp)"
-PROMPT_FILE="$(mktemp)"
-trap 'rm -f "$OUTPUT_FILE" "$PROMPT_FILE"' EXIT
+git_log --date=short --pretty=format:'%ad%x09%h%x09%s' >"$log_file"
+git_diff_stat >"$diff_file"
 
-cat >"$PROMPT_FILE" <<EOF
-You are generating release notes for docbank version $VERSION.
+if [[ ! -s "$log_file" ]]; then
+  printf 'No non-documentation commits since %s\n' "$range_label" >&2
+  exit 0
+fi
 
-docbank is a local-first personal document archive. A daemon owns its SQLite
-metadata and content-addressed blob vault; the CLI and external applications use
-its authenticated loopback HTTP API to ingest, organize, search, and verify files.
+{
+  printf 'Write concise Markdown release notes for docbank %s.\n\n' "$version"
+  printf 'IMPORTANT: Do not use tools, run shell commands, search, or read files.\n'
+  printf 'All required information is provided below. Analyze only the commit log and diff summary.\n\n'
+  printf 'docbank is local-first document storage for people, agents, and embedded Go applications.\n'
+  printf 'Its daemon owns SQLite metadata and a content-addressed blob vault; clients use an authenticated loopback HTTP API.\n'
+  printf 'Use user-facing language and group changes under these Markdown headings when applicable:\n'
+  printf '%s\n' '- ## New Features' '- ## Improvements' '- ## Bug Fixes'
+  printf 'Use only headings that have entries. Keep every entry to one line and use present tense.\n'
+  printf 'Skip internal refactoring, tests, review follow-ups, and release plumbing.\n'
+  printf 'Skip documentation-only changes unless they materially change installation or operation.\n'
+  printf 'Do not mention bugs introduced and fixed within this same release cycle.\n'
+  printf 'Output only the release notes, with no preamble.\n'
+  if [[ -n "$extra_instructions" ]]; then
+    printf '\nAdditional instructions:\n%s\n' "$extra_instructions"
+  fi
+  printf '\nCommits since %s:\n' "$range_label"
+  cat "$log_file"
+  printf '\n\nDiff summary:\n'
+  cat "$diff_file"
+} >"$prompt_file"
 
-IMPORTANT: Do NOT use tools, run shell commands, search, or read files. Everything
-needed is in the commit list and diff summary below.
-
-Commits since the previous release:
-$COMMITS
-
-Diff summary:
-$DIFF_STAT
-
-Generate concise, user-focused Markdown release notes. Use only the sections that
-have content, choosing from:
-- New Features
-- Improvements
-- Bug Fixes
-
-Focus on user-visible changes. Skip internal refactoring, tests, release plumbing,
-review follow-ups, and documentation-only changes unless they materially change
-installation or operation. Keep each description to one line and use present tense.
-Do not mention bugs introduced and fixed within this same release cycle.
-${EXTRA_INSTRUCTIONS:+
-
-Pay particular attention to these features or improvements when they appear in the
-commit list: $EXTRA_INSTRUCTIONS
-Do not inspect anything outside the supplied commit list and diff summary.}
-Output ONLY the Markdown release-note content, with no preamble.
-EOF
-
-case "$AGENT" in
+run_agent() {
+  case "$agent" in
     codex)
-        codex exec --skip-git-repo-check --sandbox read-only \
-            -c model_reasoning_effort=high -o "$OUTPUT_FILE" - >/dev/null <"$PROMPT_FILE"
-        ;;
+      if ! command -v codex >/dev/null 2>&1; then
+        printf 'codex not found; install it or set CHANGELOG_AGENT=none for deterministic notes\n' >&2
+        return 127
+      fi
+      local codex_rust_log
+      codex_rust_log="${CHANGELOG_CODEX_RUST_LOG:-${RUST_LOG:-error,codex_core::rollout::list=off}}"
+      RUST_LOG="$codex_rust_log" codex exec \
+        --json \
+        --skip-git-repo-check \
+        --sandbox read-only \
+        -c reasoning_effort=high \
+        -o "$notes_file" \
+        - >/dev/null <"$prompt_file" 2>"$err_file"
+      ;;
     claude)
-        claude --print <"$PROMPT_FILE" >"$OUTPUT_FILE"
-        ;;
+      if ! command -v claude >/dev/null 2>&1; then
+        printf 'claude not found; install it or set CHANGELOG_AGENT=none for deterministic notes\n' >&2
+        return 127
+      fi
+      claude --print <"$prompt_file" >"$notes_file" 2>"$err_file"
+      ;;
     *)
-        echo "Error: unknown CHANGELOG_AGENT '$AGENT' (expected 'codex' or 'claude')" >&2
-        exit 1
-        ;;
-esac
+      printf 'unknown CHANGELOG_AGENT %q; expected codex, claude, or none\n' "$agent" >&2
+      return 2
+      ;;
+  esac
+}
 
-if [[ ! -s "$OUTPUT_FILE" ]]; then
-    echo "Error: $AGENT returned empty release notes" >&2
-    exit 1
+agent_status=0
+set +e
+run_agent
+agent_status=$?
+set -e
+
+if [[ $agent_status -ne 0 || ! -s "$notes_file" ]]; then
+  printf '%s failed to generate release notes\n' "$agent" >&2
+  if [[ "${CHANGELOG_DEBUG:-0}" == "1" && -s "$err_file" ]]; then
+    cat "$err_file" >&2
+  elif [[ -s "$err_file" ]]; then
+    filtered_err="$(grep -E -v 'rollout path for thread|failed to record rollout items: failed to queue rollout items: channel closed|^mcp startup: no servers$|^WARNING: proceeding, even though we could not update PATH:' "$err_file" || true)"
+    if [[ -n "$filtered_err" ]]; then
+      printf '%s\n' "$filtered_err" >&2
+    else
+      printf 'Set CHANGELOG_DEBUG=1 to print full agent logs.\n' >&2
+    fi
+  fi
+  exit 1
 fi
 
-cat "$OUTPUT_FILE"
+if [[ "${CHANGELOG_DEBUG:-0}" == "1" && -s "$err_file" ]]; then
+  cat "$err_file" >&2
+fi
+cat "$notes_file"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,97 +1,118 @@
 #!/usr/bin/env bash
-# Generate release notes, create an annotated version tag, and push it.
+# Generate release notes, ask the operator to approve them, then tag and push.
 # Usage: ./scripts/release.sh <version> [extra_instructions] [start_tag]
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-VERSION="${1:-}"
-EXTRA_INSTRUCTIONS="${2:-}"
-START_TAG="${3:--}"
+usage() {
+  printf 'usage: %s <bare-version> [extra changelog instructions] [start tag]\n' "$0" >&2
+  printf 'example: %s 0.11.0\n' "$0" >&2
+}
 
-if [[ -z "$VERSION" ]]; then
-    echo "Usage: $0 <version> [extra_instructions] [start_tag]"
-    echo "Example: $0 0.2.0"
-    echo "Example: $0 0.2.0 \"Focus on editing and version history\""
-    echo "Example: $0 0.2.1 \"Include the unpublished release features\" v0.1.0"
-    exit 1
+version="${1:-}"
+extra_instructions="${2:-}"
+start_tag="${3:--}"
+
+if [[ -z "$version" ]]; then
+  usage
+  exit 2
+fi
+if [[ "$version" == v* ]]; then
+  printf 'version must be bare, such as 0.11.0, not %s\n' "$version" >&2
+  exit 2
+fi
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  printf 'version must use X.Y.Z semver shape\n' >&2
+  exit 2
 fi
 
-if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: version must use X.Y.Z format (for example, 0.2.0)"
-    exit 1
+tag="v${version}"
+changelog_agent="${CHANGELOG_AGENT:-codex}"
+
+if [[ "$(git -C "$repo_root" branch --show-current)" != "main" ]]; then
+  printf 'releases must be cut from main\n' >&2
+  exit 1
 fi
 
-TAG="v$VERSION"
-
-if [[ "$(git -C "$REPO_ROOT" branch --show-current)" != "main" ]]; then
-    echo "Error: releases must be cut from main"
-    exit 1
-fi
-
-if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
-    echo "Error: the working tree is not clean; commit or stash changes first"
-    exit 1
+git -C "$repo_root" update-index -q --refresh
+if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
+  printf 'worktree is dirty; commit or stash changes before releasing\n' >&2
+  exit 1
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
-    echo "Error: gh CLI is required (https://cli.github.com/)"
-    exit 1
+  printf 'gh CLI is required: https://cli.github.com/\n' >&2
+  exit 1
 fi
 if ! gh auth status >/dev/null 2>&1; then
-    echo "Error: gh CLI is not authenticated"
-    exit 1
+  printf 'gh CLI is not authenticated\n' >&2
+  exit 1
 fi
 
-git -C "$REPO_ROOT" fetch --quiet origin \
-    '+refs/heads/main:refs/remotes/origin/main' --tags
+git -C "$repo_root" fetch --quiet origin \
+  '+refs/heads/main:refs/remotes/origin/main' --tags
 
-if [[ "$(git -C "$REPO_ROOT" rev-parse HEAD)" != "$(git -C "$REPO_ROOT" rev-parse origin/main)" ]]; then
-    echo "Error: local main must exactly match origin/main"
-    exit 1
+if [[ "$(git -C "$repo_root" rev-parse HEAD)" != "$(git -C "$repo_root" rev-parse origin/main)" ]]; then
+  printf 'local main must exactly match origin/main\n' >&2
+  exit 1
+fi
+if git -C "$repo_root" rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1; then
+  printf 'tag %s already exists\n' "$tag" >&2
+  exit 1
 fi
 
-if git -C "$REPO_ROOT" rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1; then
-    echo "Error: tag $TAG already exists"
-    exit 1
+case "$changelog_agent" in
+  codex)
+    printf 'Generating %s notes with Codex from the supplied git history.\n' "$tag"
+    ;;
+  claude)
+    printf 'Generating %s notes with Claude from the supplied git history.\n' "$tag"
+    ;;
+  none)
+    printf 'Generating %s notes with the deterministic git-log fallback.\n' "$tag"
+    ;;
+  *)
+    printf 'Generating %s notes with CHANGELOG_AGENT=%s; changelog.sh will validate it.\n' "$tag" "$changelog_agent"
+    ;;
+esac
+
+notes_file="$(mktemp)"
+tag_message="$(mktemp)"
+trap 'rm -f "$notes_file" "$tag_message"' EXIT
+
+"$repo_root/scripts/changelog.sh" "$version" "$start_tag" "$extra_instructions" >"$notes_file"
+if [[ ! -s "$notes_file" ]]; then
+  printf 'no release-note content was generated\n' >&2
+  exit 1
 fi
 
-CHANGELOG_FILE="$(mktemp)"
-trap 'rm -f "$CHANGELOG_FILE"' EXIT
+printf '\n==========================================\n'
+printf 'PROPOSED RELEASE NOTES FOR %s\n' "$tag"
+printf '==========================================\n'
+cat "$notes_file"
+printf '\n==========================================\n\n'
 
-"$SCRIPT_DIR/changelog.sh" "$VERSION" "$START_TAG" "$EXTRA_INSTRUCTIONS" >"$CHANGELOG_FILE"
-
-if [[ ! -s "$CHANGELOG_FILE" ]]; then
-    echo "Error: no release-note content was generated"
-    exit 1
+printf 'Accept these notes and create release %s? [y/N] ' "$tag"
+answer=""
+read -r answer || true
+printf '\n'
+if [[ "$answer" != "y" && "$answer" != "Y" && "$answer" != "yes" && "$answer" != "YES" ]]; then
+  printf 'Release cancelled.\n'
+  exit 0
 fi
 
-echo
-echo "=========================================="
-echo "PROPOSED RELEASE NOTES FOR $TAG"
-echo "=========================================="
-cat "$CHANGELOG_FILE"
-echo
-echo "=========================================="
-echo
+{
+  printf 'Release %s\n\n' "$version"
+  cat "$notes_file"
+} >"$tag_message"
 
-read -r -p "Accept these notes and create release $TAG? [y/N] " REPLY
-if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
-    echo "Release cancelled."
-    exit 0
-fi
+printf 'Creating annotated tag %s...\n' "$tag"
+git -C "$repo_root" tag -a "$tag" -F "$tag_message"
+printf 'Pushing %s to origin...\n' "$tag"
+git -C "$repo_root" push origin "$tag"
 
-echo "Creating annotated tag $TAG..."
-git -C "$REPO_ROOT" tag -a "$TAG" \
-    -m "Release $VERSION" \
-    -m "$(cat "$CHANGELOG_FILE")"
-
-echo "Pushing tag to origin..."
-git -C "$REPO_ROOT" push origin "$TAG"
-
-echo
-echo "Release $TAG tag pushed successfully."
-echo "GitHub Actions will publish the archives, checksums, and tag-message notes."
-echo "https://github.com/kenn-io/docbank/releases/tag/$TAG"
+printf '\nRelease %s tag pushed successfully.\n' "$tag"
+printf 'GitHub Actions will publish archives, checksums, and the approved notes.\n'
+printf 'https://github.com/kenn-io/docbank/releases/tag/%s\n' "$tag"

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" context="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "$context: expected to find [$needle] in [$haystack]"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" context="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    fail "$context: did not expect to find [$needle] in [$haystack]"
+  fi
+}
+
+init_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.name "Example User"
+  git -C "$dir" config user.email "example@example.test"
+  printf 'example archive\n' >"$dir/README.md"
+  git -C "$dir" add README.md
+  git -C "$dir" commit -q -m "feat: add document archive"
+}
+
+install_scripts() {
+  local dir="$1"
+  mkdir -p "$dir/scripts"
+  cp "$repo_root/scripts/changelog.sh" "$repo_root/scripts/release.sh" "$dir/scripts/"
+  chmod +x "$dir/scripts/changelog.sh" "$dir/scripts/release.sh"
+  git -C "$dir" add scripts
+  git -C "$dir" commit -q -m "chore: add release scripts"
+}
+
+run_in_repo() {
+  local dir="$1"
+  shift
+  (
+    cd "$dir"
+    "$@"
+  )
+}
+
+fake_gh() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$dir/gh"
+}
+
+test_release_rejects_missing_version() {
+  local output status
+  set +e
+  output="$("$repo_root/scripts/release.sh" 2>&1)"
+  status=$?
+  set -e
+  [[ $status -eq 2 ]] || fail "release.sh without version should exit 2"
+  assert_contains "$output" "usage:" "missing version"
+}
+
+test_release_rejects_prefixed_and_invalid_versions() {
+  local output status
+  set +e
+  output="$("$repo_root/scripts/release.sh" v0.11.0 2>&1)"
+  status=$?
+  set -e
+  [[ $status -eq 2 ]] || fail "release.sh should reject v-prefixed versions"
+  assert_contains "$output" "must be bare" "v-prefixed version"
+
+  set +e
+  output="$("$repo_root/scripts/release.sh" 0.11 2>&1)"
+  status=$?
+  set -e
+  [[ $status -eq 2 ]] || fail "release.sh should reject incomplete semver"
+  assert_contains "$output" "X.Y.Z" "invalid version"
+}
+
+test_release_refuses_dirty_main() {
+  local repo="$tmp_root/dirty"
+  init_repo "$repo"
+  install_scripts "$repo"
+  printf 'dirty\n' >"$repo/dirty.txt"
+
+  local output status
+  set +e
+  output="$(run_in_repo "$repo" env CHANGELOG_AGENT=none "$repo/scripts/release.sh" 0.11.0 2>&1)"
+  status=$?
+  set -e
+  [[ $status -ne 0 ]] || fail "release.sh should reject dirty worktrees"
+  assert_contains "$output" "worktree is dirty" "dirty worktree"
+  assert_not_contains "$output" "PROPOSED RELEASE NOTES" "dirty worktree"
+}
+
+test_changelog_fallback_includes_first_commit() {
+  local repo="$tmp_root/fallback"
+  init_repo "$repo"
+
+  local output
+  output="$(run_in_repo "$repo" env CHANGELOG_AGENT=none "$repo_root/scripts/changelog.sh" NEXT -)"
+  assert_contains "$output" "## New Features" "fallback heading"
+  assert_contains "$output" "feat: add document archive" "first commit"
+}
+
+test_changelog_fallback_groups_changes() {
+  local repo="$tmp_root/groups"
+  init_repo "$repo"
+  printf 'faster\n' >"$repo/perf.txt"
+  git -C "$repo" add perf.txt
+  git -C "$repo" commit -q -m "perf: speed up archive traversal"
+  printf 'fixed\n' >"$repo/fix.txt"
+  git -C "$repo" add fix.txt
+  git -C "$repo" commit -q -m "fix: retain document names"
+
+  local output
+  output="$(run_in_repo "$repo" env CHANGELOG_AGENT=none "$repo_root/scripts/changelog.sh" NEXT -)"
+  assert_contains "$output" "## New Features" "feature section"
+  assert_contains "$output" "## Improvements" "improvement section"
+  assert_contains "$output" "## Bug Fixes" "bug-fix section"
+}
+
+test_changelog_agent_receives_context() {
+  local repo="$tmp_root/agent"
+  local fake_bin="$tmp_root/agent-bin"
+  init_repo "$repo"
+  mkdir -p "$fake_bin"
+  cat >"$fake_bin/codex" <<'EOF'
+#!/usr/bin/env bash
+out=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    shift
+    out="$1"
+  fi
+  shift || true
+done
+prompt="$(cat)"
+[[ "$prompt" == *"feat: add document archive"* ]] || exit 3
+printf '## New Features\n\n- Summarizes supplied document changes.\n' >"$out"
+EOF
+  chmod +x "$fake_bin/codex"
+
+  local output
+  output="$(run_in_repo "$repo" env PATH="$fake_bin:$PATH" "$repo_root/scripts/changelog.sh" NEXT -)"
+  assert_contains "$output" "Summarizes supplied document changes" "agent output"
+}
+
+test_changelog_rejects_unknown_agent() {
+  local repo="$tmp_root/unknown-agent"
+  init_repo "$repo"
+
+  local output status
+  set +e
+  output="$(run_in_repo "$repo" env CHANGELOG_AGENT=example "$repo_root/scripts/changelog.sh" NEXT - 2>&1)"
+  status=$?
+  set -e
+  [[ $status -ne 0 ]] || fail "changelog.sh should reject unknown agents"
+  assert_contains "$output" "unknown CHANGELOG_AGENT" "unknown agent"
+}
+
+test_release_preview_and_push() {
+  local repo="$tmp_root/release"
+  local remote="$tmp_root/origin.git"
+  local fake_bin="$tmp_root/gh-bin"
+  init_repo "$repo"
+  install_scripts "$repo"
+  git init -q --bare "$remote"
+  git -C "$repo" remote add origin "$remote"
+  git -C "$repo" push -q -u origin main
+  fake_gh "$fake_bin"
+
+  local output
+  output="$(printf 'yes\n' | run_in_repo "$repo" env PATH="$fake_bin:$PATH" CHANGELOG_AGENT=none "$repo/scripts/release.sh" 0.11.0)"
+  assert_contains "$output" "PROPOSED RELEASE NOTES FOR v0.11.0" "release preview"
+  assert_contains "$output" "Release v0.11.0 tag pushed successfully" "release outcome"
+  git -C "$remote" rev-parse -q --verify refs/tags/v0.11.0 >/dev/null || fail "remote tag missing"
+  assert_contains "$(git -C "$repo" tag -l v0.11.0 --format='%(contents)')" "Release 0.11.0" "annotated tag"
+}
+
+test_release_cancellation_creates_no_tag() {
+  local repo="$tmp_root/cancel"
+  local remote="$tmp_root/cancel-origin.git"
+  local fake_bin="$tmp_root/cancel-gh-bin"
+  init_repo "$repo"
+  install_scripts "$repo"
+  git init -q --bare "$remote"
+  git -C "$repo" remote add origin "$remote"
+  git -C "$repo" push -q -u origin main
+  fake_gh "$fake_bin"
+
+  local output
+  output="$(printf 'n\n' | run_in_repo "$repo" env PATH="$fake_bin:$PATH" CHANGELOG_AGENT=none "$repo/scripts/release.sh" 0.11.0)"
+  assert_contains "$output" "Release cancelled." "release cancellation"
+  if git -C "$repo" rev-parse -q --verify refs/tags/v0.11.0 >/dev/null; then
+    fail "cancelled release created a tag"
+  fi
+}
+
+test_release_rejects_missing_version
+test_release_rejects_prefixed_and_invalid_versions
+test_release_refuses_dirty_main
+test_changelog_fallback_includes_first_commit
+test_changelog_fallback_groups_changes
+test_changelog_agent_receives_context
+test_changelog_rejects_unknown_agent
+test_release_preview_and_push
+test_release_cancellation_creates_no_tag
+
+printf 'release script tests passed\n'


### PR DESCRIPTION
Releasing Docbank should be a short, deliberate operator workflow: generate readable notes from the changes since the last tag, inspect exactly what users will see, and publish only after explicit approval.

The existing scripts already enforced the most important safety boundary—releases must come from a clean local `main` that exactly matches `origin/main`. This keeps those safeguards and aligns the interaction with Kata: note generation is quiet, the selected generator is stated up front, `CHANGELOG_AGENT=none` provides a deterministic offline fallback, and cancellation is unambiguously safe. Annotated tag messages are built through a file so the approved Markdown is preserved exactly.

For example, the normal path remains `scripts/release.sh 0.11.0`. It shows the proposed notes and waits for a human `yes`; declining leaves no tag behind. The release-script harness exercises that complete flow against disposable repositories and remotes, including dirty-tree refusal, cancellation, and the pushed annotated tag.