### PR TITLE
Preserve approved Markdown in release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: go vet -tags fts5 ./...
 
       - name: Test
-        run: go test -tags fts5 ./...
+        run: make test
 
   purego:
     name: Pure-Go SQLite

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install:
 clean:
 	rm -f docbank
 
-test:
+test: release-scripts-test
 	go test -tags "$(BUILD_TAGS)" ./...
 
 test-v:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -109,7 +109,7 @@ fi
 } >"$tag_message"
 
 printf 'Creating annotated tag %s...\n' "$tag"
-git -C "$repo_root" tag -a "$tag" -F "$tag_message"
+git -C "$repo_root" tag --cleanup=whitespace -a "$tag" -F "$tag_message"
 printf 'Pushing %s to origin...\n' "$tag"
 git -C "$repo_root" push origin "$tag"
 

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -188,7 +188,10 @@ test_release_preview_and_push() {
   assert_contains "$output" "PROPOSED RELEASE NOTES FOR v0.11.0" "release preview"
   assert_contains "$output" "Release v0.11.0 tag pushed successfully" "release outcome"
   git -C "$remote" rev-parse -q --verify refs/tags/v0.11.0 >/dev/null || fail "remote tag missing"
-  assert_contains "$(git -C "$repo" tag -l v0.11.0 --format='%(contents)')" "Release 0.11.0" "annotated tag"
+  local tag_contents
+  tag_contents="$(git -C "$repo" tag -l v0.11.0 --format='%(contents)')"
+  assert_contains "$tag_contents" "Release 0.11.0" "annotated tag"
+  assert_contains "$tag_contents" "## New Features" "approved Markdown heading"
 }
 
 test_release_cancellation_creates_no_tag() {


### PR DESCRIPTION
The release preview is supposed to show exactly what GitHub will publish. Git’s default annotated-tag cleanup treats Markdown heading lines beginning with `#` as comments, so it silently removed section headings after the operator approved them.

Release tags now use whitespace-only cleanup, preserving the approved headings in the tag body. The disposable release harness verifies that behavior against a real annotated tag and now runs as part of `make test`, keeping the human approval boundary under routine coverage.