### PR TITLE
Make the selected vault visible to people and agents

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -1108,6 +1108,42 @@ func TestStorageStatusHumanAndJSON(t *testing.T) {
 	assert.Equal(t, int64(5), status.LooseBytes)
 }
 
+func TestInfoHumanAndJSON(t *testing.T) {
+	home := setupVaultHome(t)
+	canonicalHome, err := filepath.EvalSymlinks(home)
+	require.NoError(t, err)
+	src := writeSourceFile(t, "identity.txt", "stable vault")
+	_, err = runCLI(t, "add", src, "--dest", "/inbox")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "info")
+	require.NoError(t, err)
+	assert.Contains(t, out, "vault: ")
+	assert.Contains(t, out, "home: "+strconv.Quote(canonicalHome))
+	assert.Contains(t, out, "live: 1 file(s), 1 folder(s)")
+	assert.Contains(t, out, "history: 1 version(s), 12 logical byte(s)")
+	assert.Contains(t, out, "blob storage: 12 stored byte(s)")
+
+	out, err = runCLI(t, "info", "--json")
+	require.NoError(t, err)
+	var info api.VaultInfo
+	require.NoError(t, json.Unmarshal([]byte(out), &info))
+	assert.Equal(t, canonicalHome, info.VaultPath)
+	assert.NotEmpty(t, info.VaultID)
+	assert.Equal(t, int64(1), info.LiveFiles)
+	assert.Equal(t, int64(1), info.LiveDirectories)
+	assert.Equal(t, int64(1), info.ContentVersions)
+	assert.Equal(t, int64(1), info.TrackedBlobs)
+	assert.Equal(t, 1, info.Storage.LooseBlobs)
+}
+
+func TestRootHelpDocumentsVaultSelection(t *testing.T) {
+	out, err := runCLI(t, "--help")
+	require.NoError(t, err)
+	assert.Contains(t, out, "DOCBANK_HOME selects the vault")
+	assert.Contains(t, out, "docbank info")
+}
+
 func TestBackupInitCreateListVerifyCLI(t *testing.T) {
 	home := t.TempDir()
 	repoPath := filepath.Join(t.TempDir(), "repo")

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "23", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "23", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -352,6 +352,20 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	verifyPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, historyPID, verifyPID)
 
+	// Protocol 23 predates vault introspection. Replace it before the CLI asks
+	// the daemon to identify the selected vault and summarize its contents.
+	recs[0].Metadata["protocol_version"] = "23"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "info", "--json")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, `"vault_id"`)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	infoPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, verifyPID, infoPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -366,7 +380,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "23", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -379,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, verifyPID, protocolPID)
+	assert.NotEqual(t, infoPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/cmd/docbank/info.go
+++ b/cmd/docbank/info.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/client"
+)
+
+var infoJSON bool
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Identify the selected vault and summarize its contents",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		info, err := c.Info(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if infoJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(info)
+		}
+
+		physicalBytes := info.Storage.LooseBytes + info.Storage.PackStoredBytes
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "vault: %s\n", info.VaultID)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "home: %q\n", info.VaultPath)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "live: %d file(s), %d folder(s)\n",
+			info.LiveFiles, info.LiveDirectories)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "trash: %d node(s)\n", info.TrashedNodes)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "history: %d version(s), %d logical byte(s)\n",
+			info.ContentVersions, info.LogicalVersionBytes)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "content: %d tracked blob(s), %d raw byte(s)\n",
+			info.TrackedBlobs, info.TrackedBlobBytes)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "blob storage: %d stored byte(s); %d loose blob(s), %d pack(s)\n",
+			physicalBytes, info.Storage.LooseBlobs, info.Storage.Packs)
+		if info.Storage.DeadPackedBytes > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pending repack: %d stored byte(s)\n",
+				info.Storage.DeadPackedBytes)
+		}
+		return nil
+	},
+}
+
+func init() {
+	infoCmd.Flags().BoolVar(&infoJSON, "json", false, "machine-readable output")
+	rootCmd.AddCommand(infoCmd)
+}

--- a/cmd/docbank/root.go
+++ b/cmd/docbank/root.go
@@ -8,8 +8,13 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:           "docbank",
-	Short:         "Personal document archive with a virtual tree over content-addressed storage",
+	Use:   "docbank",
+	Short: "Personal document archive with a virtual tree over content-addressed storage",
+	Long: `Docbank stores documents for you and your agents in a durable virtual tree.
+
+DOCBANK_HOME selects the vault. It defaults to ~/.docbank. Set it per command
+or in the environment to operate on a different vault, then use "docbank info"
+to confirm the selected vault's canonical path and stable identity.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	// Cobra runs this only after flag parsing and positional validation, which

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -29,6 +29,18 @@ return the daemon's complete resulting node receipt. A trash receipt's `path`
 is only its pre-trash recovery context; carry the stable `id` and `revision`
 forward instead.
 
+Before operating on an unfamiliar machine or switching archives, identify the
+selected vault explicitly:
+
+```bash
+docbank info --json
+```
+
+Treat `vault_id` as the durable identity and `vault_path` as machine-local
+placement. `DOCBANK_HOME=/path/to/another/vault docbank info --json` selects
+and confirms another independently owned archive without changing a global
+profile or opening its database directly.
+
 The canonical contract is generated from the running route definitions:
 
 ```bash

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,13 +10,31 @@ All commands operate on the vault at `~/.docbank` (override with
 stderr and produce a non-zero exit code. Virtual paths are absolute,
 `/`-separated, and case-sensitive.
 
-Every data command below (`add`, `ls`, `tree`, `cat`, `put`, `edit`, `versions`, `version`, `refs`, `revert`, `tag`, `audit`, `mv`, `rm`,
+Every data command below (`info`, `add`, `ls`, `tree`, `cat`, `put`, `edit`, `versions`, `version`, `refs`, `revert`, `tag`, `audit`, `mv`, `rm`,
 `restore`, `search`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
 daemon over its HTTP API rather than opening the vault itself; if none
 is running, the command auto-starts one in the background. `docbank
 daemon status` and `docbank daemon stop` never auto-start. See
 [Daemon](architecture/daemon.md) and
 [Ownership & Concurrency](architecture/locking.md).
+
+## docbank info
+
+```
+docbank info [--json]
+```
+
+Identifies the vault selected by `DOCBANK_HOME` and confirms that its daemon is
+reachable. Human output shows the canonical machine-local vault path, stable
+vault ID, live file and directory counts, trash size, retained version count
+and logical bytes, tracked content blobs, and physical loose/packed usage.
+The virtual root itself is not counted as a directory.
+
+`--json` exposes the same values as stable fields. Agents should record
+`vault_id` as identity and use `vault_path` only to confirm local placement:
+restoring or moving a vault changes its path without changing its ID. Tracked
+blob totals can include content awaiting garbage collection; `storage` reports
+the files and packs currently occupying physical storage.
 
 ## Node selectors
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,14 @@ environment variable:
 export DOCBANK_HOME=/Volumes/Archive/docbank
 ```
 
+Run `docbank info` after selecting a vault to see its canonical path and stable
+vault ID. This is especially useful when one machine has several independent
+Docbank archives:
+
+```bash
+DOCBANK_HOME=/Volumes/Archive/docbank docbank info
+```
+
 The directory layout is created on first use:
 
 ```

--- a/internal/api/routes_info.go
+++ b/internal/api/routes_info.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+func registerInfoRoute(api huma.API, d Deps) {
+	type infoOutput struct{ Body VaultInfo }
+	huma.Register(api, huma.Operation{
+		OperationID: "vaultInfo", Method: http.MethodGet, Path: "/api/v1/info",
+		Summary: "Identify the selected vault and summarize its contents",
+	}, func(ctx context.Context, _ *struct{}) (*infoOutput, error) {
+		logical, err := d.Store.Info(ctx)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		physical, err := d.Blobs.Stats(ctx)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return &infoOutput{Body: VaultInfo{
+			VaultID: logical.VaultID, VaultPath: d.VaultRoot,
+			LiveFiles: logical.LiveFiles, LiveDirectories: logical.LiveDirectories,
+			TrashedNodes: logical.TrashedNodes, ContentVersions: logical.ContentVersions,
+			LogicalVersionBytes: logical.LogicalVersionBytes,
+			TrackedBlobs:        logical.TrackedBlobs, TrackedBlobBytes: logical.TrackedBlobBytes,
+			Storage: StorageStatus{
+				LooseBlobs: physical.LooseBlobs, LooseBytes: physical.LooseBytes,
+				Packs: physical.Packs, PackStoredBytes: physical.PackStoredBytes,
+				PackedBlobs: physical.PackedBlobs, PackedRawBytes: physical.PackedRawBytes,
+				PackedStoredBytes: physical.PackedStoredBytes,
+				DeadPackedBytes:   physical.DeadPackedBytes,
+			},
+		}}, nil
+	})
+}

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -351,6 +351,35 @@ func TestStorageStatusReportsLooseAndPackedUsage(t *testing.T) {
 	assert.Zero(t, status.DeadPackedBytes)
 }
 
+func TestVaultInfoIdentifiesRootAndSummarizesContents(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	docs, err := s.Mkdir(t.Context(), s.RootID(), "docs")
+	require.NoError(t, err)
+	content := "vault inventory"
+	hash, size, err := s.Blobs.Write(strings.NewReader(content))
+	require.NoError(t, err)
+	file, err := s.CreateFile(t.Context(), docs.ID, "record.txt", hash, size, "text/plain")
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), file.ID, -1)
+	require.NoError(t, err)
+
+	resp, body := get(t, ts, "/api/v1/info", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var info api.VaultInfo
+	require.NoError(t, json.Unmarshal([]byte(body), &info))
+	assert.Equal(t, s.VaultID(), info.VaultID)
+	assert.Equal(t, filepath.Dir(s.DBPath), info.VaultPath)
+	assert.Zero(t, info.LiveFiles)
+	assert.Equal(t, int64(1), info.LiveDirectories)
+	assert.Equal(t, int64(1), info.TrashedNodes)
+	assert.Equal(t, int64(1), info.ContentVersions)
+	assert.Equal(t, int64(len(content)), info.LogicalVersionBytes)
+	assert.Equal(t, int64(1), info.TrackedBlobs)
+	assert.Equal(t, int64(len(content)), info.TrackedBlobBytes)
+	assert.Equal(t, 1, info.Storage.LooseBlobs)
+	assert.Equal(t, int64(len(content)), info.Storage.LooseBytes)
+}
+
 func TestStoragePackHonorsBudgetAndConverges(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	createFileWithContent(t, ts, s, "/one.txt", "one")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -105,7 +105,8 @@ func NewServer(d Deps) *Server {
 		g = NewOperationGate()
 	}
 
-	registerReadRoutes(humaAPI, d)      // Task 5 (stat-by-id lands in this task)
+	registerReadRoutes(humaAPI, d) // Task 5 (stat-by-id lands in this task)
+	registerInfoRoute(humaAPI, d)
 	registerMutateRoutes(humaAPI, d, g) // Task 6
 	registerOpsRoutes(humaAPI, d, g)    // Task 7
 	registerBackupRoutes(humaAPI, d, g)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -516,6 +516,21 @@ type StorageStatus struct {
 	DeadPackedBytes   int64 `json:"dead_packed_bytes"`
 }
 
+// VaultInfo identifies the selected vault and summarizes its logical and
+// physical contents. VaultPath is machine-local placement, not vault identity.
+type VaultInfo struct {
+	VaultID             string        `json:"vault_id" format:"uuid"`
+	VaultPath           string        `json:"vault_path"`
+	LiveFiles           int64         `json:"live_files"`
+	LiveDirectories     int64         `json:"live_directories"`
+	TrashedNodes        int64         `json:"trashed_nodes"`
+	ContentVersions     int64         `json:"content_versions"`
+	LogicalVersionBytes int64         `json:"logical_version_bytes"`
+	TrackedBlobs        int64         `json:"tracked_blobs"`
+	TrackedBlobBytes    int64         `json:"tracked_blob_bytes"`
+	Storage             StorageStatus `json:"storage"`
+}
+
 // StoragePackReport summarizes one explicit Kit packing and repair pass.
 type StoragePackReport struct {
 	PacksSealed                int   `json:"packs_sealed"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2050,6 +2050,13 @@ func (c *Client) StorageStatus(ctx context.Context) (api.StorageStatus, error) {
 	return status, err
 }
 
+// Info identifies the selected vault and summarizes its logical and physical contents.
+func (c *Client) Info(ctx context.Context) (api.VaultInfo, error) {
+	var info api.VaultInfo
+	err := c.do(ctx, http.MethodGet, "/api/v1/info", nil, nil, &info)
+	return info, err
+}
+
 func (c *Client) StoragePack(ctx context.Context, maxBytes int64) (api.StoragePackReport, error) {
 	var report api.StoragePackReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/storage/pack", nil,

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "23"
+	daemonProtocolVersion = "24"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/info.go
+++ b/internal/store/info.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// VaultInfo summarizes the logical authority held by a vault. Physical loose
+// and packed storage is reported separately by the blob store.
+type VaultInfo struct {
+	VaultID             string
+	LiveFiles           int64
+	LiveDirectories     int64
+	TrashedNodes        int64
+	ContentVersions     int64
+	LogicalVersionBytes int64
+	TrackedBlobs        int64
+	TrackedBlobBytes    int64
+}
+
+// Info returns a point-in-time logical inventory without changing the vault.
+func (s *Store) Info(ctx context.Context) (VaultInfo, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return VaultInfo{}, fmt.Errorf("starting vault inventory: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	info := VaultInfo{VaultID: s.vaultID}
+	if err := tx.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(SUM(CASE WHEN parent_id IS NOT NULL AND trashed_at IS NULL AND kind = 'file'
+				THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN parent_id IS NOT NULL AND trashed_at IS NULL AND kind = 'dir'
+				THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN trashed_at IS NOT NULL THEN 1 ELSE 0 END), 0)
+		FROM nodes`).Scan(&info.LiveFiles, &info.LiveDirectories, &info.TrashedNodes); err != nil {
+		return VaultInfo{}, fmt.Errorf("counting vault nodes: %w", err)
+	}
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(SUM(size), 0) FROM content_versions`).Scan(
+		&info.ContentVersions, &info.LogicalVersionBytes,
+	); err != nil {
+		return VaultInfo{}, fmt.Errorf("counting content versions: %w", err)
+	}
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(SUM(size), 0) FROM blobs`).Scan(
+		&info.TrackedBlobs, &info.TrackedBlobBytes,
+	); err != nil {
+		return VaultInfo{}, fmt.Errorf("counting tracked blobs: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return VaultInfo{}, fmt.Errorf("finishing vault inventory: %w", err)
+	}
+	return info, nil
+}

--- a/internal/store/info_test.go
+++ b/internal/store/info_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoSummarizesLogicalVaultAuthority(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	docs, err := s.Mkdir(ctx, s.RootID(), "docs")
+	require.NoError(t, err)
+	archive, err := s.Mkdir(ctx, docs.ID, "archive")
+	require.NoError(t, err)
+	first, err := s.CreateFile(ctx, docs.ID, "first.txt", fakeHash("shared"), 7, "text/plain")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, archive.ID, "second.txt", fakeHash("shared"), 7, "text/plain")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, docs.ID, "third.txt", fakeHash("unique"), 11, "text/plain")
+	require.NoError(t, err)
+	_, _, err = s.Trash(ctx, first.ID, -1)
+	require.NoError(t, err)
+
+	info, err := s.Info(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, s.VaultID(), info.VaultID)
+	assert.Equal(t, int64(2), info.LiveFiles)
+	assert.Equal(t, int64(2), info.LiveDirectories)
+	assert.Equal(t, int64(1), info.TrashedNodes)
+	assert.Equal(t, int64(3), info.ContentVersions)
+	assert.Equal(t, int64(25), info.LogicalVersionBytes)
+	assert.Equal(t, int64(2), info.TrackedBlobs)
+	assert.Equal(t, int64(18), info.TrackedBlobBytes)
+}
+
+func TestInfoEmptyVaultExcludesVirtualRoot(t *testing.T) {
+	s := newTestStore(t)
+
+	info, err := s.Info(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, info.LiveFiles)
+	assert.Zero(t, info.LiveDirectories)
+	assert.Zero(t, info.TrashedNodes)
+	assert.Zero(t, info.ContentVersions)
+	assert.Zero(t, info.LogicalVersionBytes)
+	assert.Zero(t, info.TrackedBlobs)
+	assert.Zero(t, info.TrackedBlobBytes)
+}


### PR DESCRIPTION
A machine can hold several independent Docbank archives, but until now neither a person nor an agent could ask Docbank which one `DOCBANK_HOME` had selected. That made even a basic connectivity check ambiguous and made multi-vault automation rely on outside knowledge.

`docbank info` now answers that question directly. It reports the canonical local path and the vault’s stable identity, followed by a compact inventory of live documents, trash, retained versions, tracked content, and loose/packed storage. For example, an agent can run `docbank info --json` before a workflow and bind its work to `vault_id`; it can use `vault_path` only to confirm local placement, since a restore or move may change the path without changing the archive’s identity.

The same authenticated response is available through the HTTP API and typed Go client. Root help explains `DOCBANK_HOME` and how to select another vault, while the human, CLI, configuration, and agent documentation all describe the same identity boundary. A protocol revision ensures the new command replaces an older daemon instead of receiving a misleading 404.