### PR TITLE
Make bulk reorganization atomic

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -849,6 +850,54 @@ func TestMvIntoDirAndRename(t *testing.T) {
 	out, err = runCLI(t, "ls", "/inbox")
 	require.NoError(t, err)
 	assert.NotContains(t, out, "b.txt", "moved source must be vacated")
+}
+
+func TestMvBatchAppliesOnePlan(t *testing.T) {
+	setupVaultHome(t)
+	firstSource := writeSourceFile(t, "first.txt", "first")
+	secondSource := writeSourceFile(t, "second.txt", "second")
+	_, err := runCLI(t, "add", firstSource, "--dest", "/left")
+	require.NoError(t, err)
+	_, err = runCLI(t, "add", secondSource, "--dest", "/right")
+	require.NoError(t, err)
+	c, err := client.Ensure(context.Background())
+	require.NoError(t, err)
+	second, err := c.Stat(context.Background(), "/right/second.txt")
+	require.NoError(t, err)
+	plan := filepath.Join(t.TempDir(), "move-plan.json")
+	planBody := fmt.Sprintf(`{"moves":[
+		{"source":"/left/first.txt","destination":"/right/second.txt"},
+		{"source":"id:%d","destination":"/left/first.txt"}
+	]}`, second.ID)
+	require.NoError(t, os.WriteFile(plan, []byte(planBody), 0o600))
+
+	out, err := runCLI(t, "mv", "batch", plan)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"/left/first.txt" -> "/right/second.txt"`)
+	assert.Contains(t, out, `"/right/second.txt" -> "/left/first.txt"`)
+	out, err = runCLI(t, "cat", "/right/second.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "first", out)
+	out, err = runCLI(t, "cat", "/left/first.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "second", out)
+}
+
+func TestMvBatchRejectsUnknownPlanFieldsBeforeDaemonStart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("DOCBANK_HOME", home)
+	plan := filepath.Join(t.TempDir(), "move-plan.json")
+	require.NoError(t, os.WriteFile(plan, []byte(
+		`{"moves":[{"source":"/a","destination":"/b","surprise":true}]}`), 0o600))
+
+	_, err := runCLI(t, "mv", "batch", plan)
+	require.Error(t, err)
+	var classified *exitError
+	require.ErrorAs(t, err, &classified)
+	assert.Equal(t, exitUsage, classified.code)
+	records, listErr := client.RuntimeStore(home).List()
+	require.NoError(t, listErr)
+	assert.Empty(t, records)
 }
 
 func TestMvOntoSelfFails(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "25", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "25", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -366,6 +366,22 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	infoPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, verifyPID, infoPID)
 
+	// Protocol 24 predates transactional batch moves. Replace it before the
+	// CLI submits a plan that an older same-version daemon cannot recognize.
+	batchPlan := filepath.Join(t.TempDir(), "batch-move.json")
+	require.NoError(t, os.WriteFile(batchPlan, []byte(`{"moves":[{"source":"/inbox/preflight.txt","destination":"/inbox/protocol-batch.txt"}]}`), 0o600))
+	recs[0].Metadata["protocol_version"] = "24"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "mv", "batch", batchPlan)
+	require.NoError(t, err, out)
+	assert.Contains(t, out, `"/inbox/preflight.txt" -> "/inbox/protocol-batch.txt"`)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	batchPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, infoPID, batchPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -380,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "24", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "25", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +409,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, infoPID, protocolPID)
+	assert.NotEqual(t, batchPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/cmd/docbank/exit.go
+++ b/cmd/docbank/exit.go
@@ -65,6 +65,7 @@ func commandExitCode(err error, started bool) int {
 		return exitBusy
 	}
 	if errors.Is(err, store.ErrInvalidName) || errors.Is(err, store.ErrInvalidTag) ||
+		errors.Is(err, store.ErrInvalidBatchMove) ||
 		errors.Is(err, store.ErrInvalidVersionPrune) ||
 		errors.Is(err, store.ErrInvalidAuditCursor) {
 		return exitUsage

--- a/cmd/docbank/mv.go
+++ b/cmd/docbank/mv.go
@@ -1,17 +1,34 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/jsontext"
+	"go.kenn.io/docbank/internal/store"
 )
 
 var mvJSON bool
+
+const maxBatchMovePlanBytes = 1 << 20
+
+type batchMovePlanFile struct {
+	Moves []batchMovePlanItem `json:"moves"`
+}
+
+type batchMovePlanItem struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+}
 
 var mvCmd = &cobra.Command{
 	Use:   "mv <source-path-or-id> <dest-path>",
@@ -53,7 +70,107 @@ var mvCmd = &cobra.Command{
 	},
 }
 
+var mvBatchCmd = &cobra.Command{
+	Use:   "batch <plan.json|->",
+	Short: "Apply an all-or-nothing reorganization plan",
+	Long: `Apply one bounded JSON plan as a single metadata transaction.
+
+Each item has "source" (an absolute path or id:<number>) and an absolute
+"destination". A dash reads the plan from standard input. Every destination
+is interpreted against the tree as it existed before the transaction, so a
+plan can safely express swaps and nested reorganizations.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		plan, err := readBatchMovePlan(cmd, args[0])
+		if err != nil {
+			return usageError(err)
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		moves := make([]api.BatchMoveItem, len(plan.Moves))
+		for index, item := range plan.Moves {
+			selector, parseErr := parseNodeSelector(item.Source)
+			if parseErr != nil {
+				return fmt.Errorf("move %d source: %w", index, parseErr)
+			}
+			move := api.BatchMoveItem{DestinationPath: item.Destination}
+			if selector.isID() {
+				node, resolveErr := selector.resolve(cmd.Context(), c)
+				if resolveErr != nil {
+					return resolveErr
+				}
+				move.NodeID, move.Revision = node.ID, node.Revision
+			} else {
+				move.SourcePath = selector.path
+			}
+			moves[index] = move
+		}
+		report, err := c.BatchMove(cmd.Context(), moves)
+		if err != nil {
+			return err
+		}
+		if mvJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), report)
+		}
+		for _, receipt := range report.Items {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "moved [%s] %q -> %q\n",
+				formatNodeSelector(receipt.Node.ID), receipt.FromPath, receipt.Node.Path); err != nil {
+				return fmt.Errorf("writing batch move receipt: %w", err)
+			}
+		}
+		return nil
+	},
+}
+
+func readBatchMovePlan(cmd *cobra.Command, path string) (batchMovePlanFile, error) {
+	var reader = cmd.InOrStdin()
+	var file *os.File
+	if path != "-" {
+		var err error
+		file, err = os.Open(path)
+		if err != nil {
+			return batchMovePlanFile{}, fmt.Errorf("opening batch move plan: %w", err)
+		}
+		defer func() { _ = file.Close() }()
+		reader = file
+	}
+	raw, err := io.ReadAll(io.LimitReader(reader, maxBatchMovePlanBytes+1))
+	if err != nil {
+		return batchMovePlanFile{}, fmt.Errorf("reading batch move plan: %w", err)
+	}
+	if len(raw) > maxBatchMovePlanBytes {
+		return batchMovePlanFile{}, fmt.Errorf("batch move plan exceeds %d bytes", maxBatchMovePlanBytes)
+	}
+	if err := jsontext.Validate(raw, "batch move plan"); err != nil {
+		return batchMovePlanFile{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var plan batchMovePlanFile
+	if err := decoder.Decode(&plan); err != nil {
+		return batchMovePlanFile{}, fmt.Errorf("decoding batch move plan: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return batchMovePlanFile{}, fmt.Errorf("decoding batch move plan: %w", err)
+	}
+	if len(plan.Moves) == 0 || len(plan.Moves) > store.MaxBatchMoves {
+		return batchMovePlanFile{}, fmt.Errorf(
+			"batch move plan requires 1-%d moves", store.MaxBatchMoves)
+	}
+	for index, move := range plan.Moves {
+		if move.Source == "" || !strings.HasPrefix(move.Destination, "/") {
+			return batchMovePlanFile{}, fmt.Errorf(
+				"move %d requires source and an absolute destination", index)
+		}
+	}
+	return plan, nil
+}
+
 func init() {
 	mvCmd.Flags().BoolVar(&mvJSON, "json", false, "emit a machine-readable node receipt")
+	mvBatchCmd.Flags().BoolVar(&mvJSON, "json", false, "emit machine-readable move receipts")
+	mvCmd.AddCommand(mvBatchCmd)
 	rootCmd.AddCommand(mvCmd)
 }

--- a/cmd/docbank/mv.go
+++ b/cmd/docbank/mv.go
@@ -78,9 +78,9 @@ var mvBatchCmd = &cobra.Command{
 Each item has "source" (an absolute path or id:<number>) and an absolute
 "destination". Unlike ordinary mv, each destination is an exact final
 coordinate—even when that coordinate initially holds a directory. A dash reads
-the plan from standard input. Every destination is interpreted against the tree
-as it existed before the transaction, so a plan can safely express file or
-directory swaps and nested reorganizations.`,
+the plan from standard input. Sources resolve in the initial tree; destination
+parents resolve in the planned final tree. This lets one item move beneath a
+directory that another item moves in the same transaction.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		plan, err := readBatchMovePlan(cmd, args[0])

--- a/cmd/docbank/mv.go
+++ b/cmd/docbank/mv.go
@@ -76,9 +76,11 @@ var mvBatchCmd = &cobra.Command{
 	Long: `Apply one bounded JSON plan as a single metadata transaction.
 
 Each item has "source" (an absolute path or id:<number>) and an absolute
-"destination". A dash reads the plan from standard input. Every destination
-is interpreted against the tree as it existed before the transaction, so a
-plan can safely express swaps and nested reorganizations.`,
+"destination". Unlike ordinary mv, each destination is an exact final
+coordinate—even when that coordinate initially holds a directory. A dash reads
+the plan from standard input. Every destination is interpreted against the tree
+as it existed before the transaction, so a plan can safely express file or
+directory swaps and nested reorganizations.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		plan, err := readBatchMovePlan(cmd, args[0])

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -447,9 +447,9 @@ For a reorganization that must not partially apply, send one bounded plan to
 `POST /api/v1/batch/move` or use `docbank mv batch`. Each source is either an
 absolute `source_path`, resolved inside the transaction, or a stable `node_id`
 with the revision the agent inspected. All `destination_path` values are
-exact final coordinates interpreted against the initial tree; an existing
-directory does not invoke ordinary `mv`'s “move into” shorthand. Docbank
-validates the complete final tree before changing it. This permits file and
+exact final coordinates whose parents resolve in the planned final tree; an
+existing directory does not invoke ordinary `mv`'s “move into” shorthand.
+Docbank validates the complete final tree before changing it. This permits file and
 directory swaps without temporary names. Require a receipt for every request
 item, in the same order, and reconcile its stable node ID, prior path, final
 path, and resulting revision. Any error means the entire plan was rejected.

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -443,6 +443,16 @@ they do not accept `If-Match`. Use them for a one-shot instruction tied to the
 path as it exists when the transaction runs. Use ID plus revision when an
 agent previously inspected a particular node and wants lost-update protection.
 
+For a reorganization that must not partially apply, send one bounded plan to
+`POST /api/v1/batch/move` or use `docbank mv batch`. Each source is either an
+absolute `source_path`, resolved inside the transaction, or a stable `node_id`
+with the revision the agent inspected. All `destination_path` values are
+interpreted against the initial tree, and Docbank validates the complete final
+tree before changing it. This permits swaps without temporary names. Require a
+receipt for every request item, in the same order, and reconcile its stable
+node ID, prior path, final path, and resulting revision. Any error means the
+entire plan was rejected.
+
 ## Create and ingest safely
 
 Create a directory under a known parent ID:

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -447,11 +447,12 @@ For a reorganization that must not partially apply, send one bounded plan to
 `POST /api/v1/batch/move` or use `docbank mv batch`. Each source is either an
 absolute `source_path`, resolved inside the transaction, or a stable `node_id`
 with the revision the agent inspected. All `destination_path` values are
-interpreted against the initial tree, and Docbank validates the complete final
-tree before changing it. This permits swaps without temporary names. Require a
-receipt for every request item, in the same order, and reconcile its stable
-node ID, prior path, final path, and resulting revision. Any error means the
-entire plan was rejected.
+exact final coordinates interpreted against the initial tree; an existing
+directory does not invoke ordinary `mv`'s “move into” shorthand. Docbank
+validates the complete final tree before changing it. This permits file and
+directory swaps without temporary names. Require a receipt for every request
+item, in the same order, and reconcile its stable node ID, prior path, final
+path, and resulting revision. Any error means the entire plan was rejected.
 
 ## Create and ingest safely
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -74,11 +74,12 @@ coordinate-oriented form when the source path itself is the intended target.
 
 `POST /batch/move` accepts `{moves:[...]}`. Each item selects its source with
 either `source_path`, or `node_id` plus the revision previously inspected by
-the caller, and supplies `destination_path`. Every selector and destination is
-resolved against one pre-transaction topology. Each destination is an exact
-final coordinate; batch requests do not apply the single-move “move into an
-existing directory” shorthand. Docbank constructs and checks the complete
-final topology in Go before applying it, so file and directory swaps and nested
+the caller, and supplies `destination_path`. Every selector resolves against
+one pre-transaction topology. Each destination is an exact final coordinate,
+and its parent resolves against the planned final topology; batch requests do
+not apply the single-move “move into an existing directory” shorthand. Docbank
+constructs and checks the complete final topology in Go before applying it, so
+file and directory swaps and nested
 reorganizations do not depend on unsafe intermediate names. A failure rejects
 the whole plan. The response preserves request order and returns each node's
 prior path plus its complete final node projection and path.

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -47,6 +47,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |
 | `PATCH /nodes/{id}` | move and/or rename, including resolving an absolute `dest_path` transactionally | Implemented |
 | `POST /path/move` · `POST /path/trash` | move / trash by virtual path, resolved and mutated in one store transaction | Implemented |
+| `POST /batch/move` | validate and apply up to 1,000 moves as one final-state transaction | Implemented |
 | `POST /nodes/{id}/trash` · `POST /nodes/{id}/restore` | soft delete / recover | Implemented |
 | `GET /trash` · `POST /trash/empty` `{run, older_than}` | list / report or hard-delete trash roots | Implemented |
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / validate metadata and re-hash all blobs | Implemented |
@@ -70,6 +71,15 @@ For stable-identity moves, `PATCH /nodes/{id}` accepts either the lower-level
 mutually exclusive. The latter resolves POSIX-style destination semantics and
 checks `If-Match` in the same transaction. `POST /path/move` remains the
 coordinate-oriented form when the source path itself is the intended target.
+
+`POST /batch/move` accepts `{moves:[...]}`. Each item selects its source with
+either `source_path`, or `node_id` plus the revision previously inspected by
+the caller, and supplies `destination_path`. Every selector and destination is
+resolved against one pre-transaction topology. Docbank constructs and checks
+the complete final topology in Go before applying it, so swaps and nested
+reorganizations do not depend on unsafe intermediate names. A failure rejects
+the whole plan. The response preserves request order and returns each node's
+prior path plus its complete final node projection and path.
 
 ### Backup repository endpoints
 
@@ -161,6 +171,7 @@ and maintenance are explicit exceptions:
 | `PATCH /tags/{tag_id}`, `DELETE /tags/{tag_id}` | required — tag definition/assignment-set revision |
 | `PUT\|DELETE /nodes/{id}/tags/{tag_id}` | required — target node revision; the tag revision also advances on a real assignment change |
 | `POST /path/move`, `POST /path/trash` | none — the path is resolved and mutated inside one store transaction, so there is no separate read for a revision to guard |
+| `POST /batch/move` | each path source resolves in the transaction; each stable-ID source carries its own required revision |
 | `POST /nodes` (create dir) | none — creation has no prior revision; a name collision is `409` |
 | `POST /ingest` · `POST /ingest/stream` | none — long-running bulk operations with per-path partial success; the destination directory may legitimately change while they run |
 | `POST /uploads` | none — creates or idempotently resolves one file under the stable `parent_id`; name/content collision policy is transactional |
@@ -483,6 +494,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `audit_acknowledgment_required` | 422 | enrollment execution omitted the explicit permanent-retention acknowledgment |
 | `audit_not_enrolled` | 422 | the selected node exists but is outside every permanent audit scope |
 | `invalid_audit_cursor` | 422 | the history cursor is malformed or belongs to another stable node |
+| `invalid_batch_move` | 422 | a batch has no moves, too many moves, ambiguous selectors, or an invalid final-state plan |
 | `stale_revision` | 412 | `store.ErrStaleRevision` — `If-Match` didn't match the current revision |
 | `not_dir` / `not_file` / `invalid_name` / `invalid_tag` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrInvalidTag` / `ErrNotTrashed` / `ErrIsRoot` |
 | `validation` | 400, 415, or 422 | malformed request (bad `If-Match`, paths, media type, multipart envelope, or generated validation) |

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -75,8 +75,10 @@ coordinate-oriented form when the source path itself is the intended target.
 `POST /batch/move` accepts `{moves:[...]}`. Each item selects its source with
 either `source_path`, or `node_id` plus the revision previously inspected by
 the caller, and supplies `destination_path`. Every selector and destination is
-resolved against one pre-transaction topology. Docbank constructs and checks
-the complete final topology in Go before applying it, so swaps and nested
+resolved against one pre-transaction topology. Each destination is an exact
+final coordinate; batch requests do not apply the single-move “move into an
+existing directory” shorthand. Docbank constructs and checks the complete
+final topology in Go before applying it, so file and directory swaps and nested
 reorganizations do not depend on unsafe intermediate names. A failure rejects
 the whole plan. The response preserves request order and returns each node's
 prior path plus its complete final node projection and path.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -513,10 +513,11 @@ virtual path or `id:<number>`) and an absolute `destination`:
 ]}
 ```
 
-All coordinates are interpreted from the transaction's initial tree. A batch
-destination is always the exact final coordinate: unlike ordinary `mv`, an
-existing directory does not mean “move into this directory.” Name the retained
-basename explicitly when that is the intent. The complete final tree is
+Sources are interpreted from the transaction's initial tree. A batch
+destination is always the exact final coordinate, and its parent is resolved
+in the planned final tree: unlike ordinary `mv`, an existing directory does
+not mean “move into this directory.” Name the retained basename explicitly
+when that is the intent. The complete final tree is
 validated before anything moves, which supports file and directory swaps and
 nested reorganizations without temporary user-visible names. Any missing
 source or parent, stale ID revision, collision, or cycle rejects the entire

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -513,9 +513,12 @@ virtual path or `id:<number>`) and an absolute `destination`:
 ]}
 ```
 
-All coordinates are interpreted from the transaction's initial tree, and the
-complete final tree is validated before anything moves. This supports swaps
-and nested reorganizations without temporary user-visible names. Any missing
+All coordinates are interpreted from the transaction's initial tree. A batch
+destination is always the exact final coordinate: unlike ordinary `mv`, an
+existing directory does not mean “move into this directory.” Name the retained
+basename explicitly when that is the intent. The complete final tree is
+validated before anything moves, which supports file and directory swaps and
+nested reorganizations without temporary user-visible names. Any missing
 source or parent, stale ID revision, collision, or cycle rejects the entire
 plan. Human output reports the stable ID and quoted old/new paths in request
 order; `--json` returns the same bounded receipt set as structured data.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -496,6 +496,30 @@ cycle`. On success human output prints `moved [id:<id>] <new-path>`; `--json`
 returns the complete resulting node, including its stable ID, revision, and
 new path.
 
+### docbank mv batch
+
+```
+docbank mv batch <plan.json|-> [--json]
+```
+
+Applies up to 1,000 moves as one all-or-nothing metadata transaction. A dash
+reads the plan from standard input. Each plan item has `source` (an absolute
+virtual path or `id:<number>`) and an absolute `destination`:
+
+```json
+{"moves":[
+  {"source":"/inbox/a.pdf","destination":"/filed/b.pdf"},
+  {"source":"id:42","destination":"/inbox/a.pdf"}
+]}
+```
+
+All coordinates are interpreted from the transaction's initial tree, and the
+complete final tree is validated before anything moves. This supports swaps
+and nested reorganizations without temporary user-visible names. Any missing
+source or parent, stale ID revision, collision, or cycle rejects the entire
+plan. Human output reports the stable ID and quoted old/new paths in request
+order; `--json` returns the same bounded receipt set as structured data.
+
 ## docbank rm
 
 ```

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -232,9 +232,10 @@ batch.
 Use `BatchMove` for an all-or-nothing reorganization of up to
 `MaxBatchMoves` nodes. Each source is either a path resolved inside the
 transaction or a stable node ID with the revision previously inspected. All
-destinations are interpreted from one initial tree and the complete final tree
-is validated before any change, so embedded applications can express swaps and
-nested moves without temporary names or partial completion.
+destinations are exact final coordinates interpreted from one initial tree; an
+existing directory does not mean “move into.” The complete final tree is
+validated before any change, so embedded applications can express file or
+directory swaps and nested moves without temporary names or partial completion.
 
 ## Maintain physical storage
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -229,6 +229,13 @@ finite number of trash roots: a zero `MaxRoots` uses
 `DefaultTrashEmptyMaxRoots`, and `More` asks the owner to schedule another
 batch.
 
+Use `BatchMove` for an all-or-nothing reorganization of up to
+`MaxBatchMoves` nodes. Each source is either a path resolved inside the
+transaction or a stable node ID with the revision previously inspected. All
+destinations are interpreted from one initial tree and the complete final tree
+is validated before any change, so embedded applications can express swaps and
+nested moves without temporary names or partial completion.
+
 ## Maintain physical storage
 
 Ordinary `Put` calls publish loose content. Call `Pack` explicitly when the

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -232,10 +232,10 @@ batch.
 Use `BatchMove` for an all-or-nothing reorganization of up to
 `MaxBatchMoves` nodes. Each source is either a path resolved inside the
 transaction or a stable node ID with the revision previously inspected. All
-destinations are exact final coordinates interpreted from one initial tree; an
-existing directory does not mean “move into.” The complete final tree is
-validated before any change, so embedded applications can express file or
-directory swaps and nested moves without temporary names or partial completion.
+destinations are exact final coordinates whose parents resolve in the planned
+final tree; an existing directory does not mean “move into.” The complete final
+tree is validated before any change, so embedded applications can express file
+or directory swaps and nested moves without temporary names or partial completion.
 
 ## Maintain physical storage
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,7 +101,9 @@ refs` and `GET /content-references` resolve a SHA-256 identity to
 every retaining current, historical, or trashed node/version pair. Stable tags
 are available across the CLI, authenticated API, typed client, OpenAPI, and
 metadata-v1 backup/restore authority, including bounded forward and reverse
-listings. Permanent first-scope audit enrollment is preview-first across the
+listings. Transactional batch move validates and applies bounded swaps and
+nested reorganizations as one final-state operation across the CLI, API, typed
+client, and audited history. Permanent first-scope audit enrollment is preview-first across the
 CLI and API. Sticky membership, supported logical mutations, allocation and
 scope chains, status evidence, and JSONL backup/restore validation are
 implemented. One-node canonical audit history is available by path or stable ID
@@ -115,7 +117,7 @@ and append later changes to the same stable node without touching source files.
 - Additional and overlapping audit scopes and scope-wide history browsing
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
-- Tag/MIME/date/path search filters; `POST /batch/move` bulk reorganization
+- Tag/MIME/date/path search filters
 - Additional text extraction workers for PDF text layers and office formats;
   bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
 - External integration surface: generalized ingest provenance —

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -107,15 +107,39 @@ assignment commands intentionally address live nodes only. When `trash empty`
 permanently deletes tagged nodes, each affected tag revision advances before
 those assignments are removed.
 
-## Tips for bulk reorganization
+## Atomic bulk reorganization
 
-- `tree` output includes IDs, and `tree --json` exposes them with paths and
-  depths, so scripts can retain stable references while shuffling paths.
-- Every `mv` is its own transaction: a failed move in a scripted batch
-  leaves everything else applied and consistent.
+Use `mv batch` when a reorganization must either happen completely or leave the
+tree untouched. The command reads a bounded JSON plan from a file, or from
+standard input with `-`:
 
-Bulk all-or-nothing moves are not available. Scripts must therefore treat each
-current `mv` as an independently committed operation.
+```json
+{
+  "moves": [
+    {"source": "/inbox/final.pdf", "destination": "/filed/draft.pdf"},
+    {"source": "id:42", "destination": "/inbox/final.pdf"}
+  ]
+}
+```
+
+```bash
+docbank mv batch reorganization.json
+```
+
+Every source and destination is interpreted against the tree as it existed at
+the start of the transaction. The complete final tree is then checked for
+missing parents, duplicate sibling names, and cycles before any row changes.
+This makes swaps and nested reorganizations possible without temporary names.
+If any selector, revision, or final coordinate is invalid, nothing moves.
+
+A path source means “the node at this coordinate when the transaction runs.”
+An `id:N` source means “this exact node”; the CLI resolves it before submission
+and binds the plan to its current revision. Receipts preserve plan order and
+return each node's stable ID, prior path, final path, and resulting revision.
+Plans accept at most 1,000 moves so validation and responses remain bounded.
+
+Ordinary repeated `docbank mv` commands are still independent transactions;
+use `mv batch` when partial completion is not acceptable.
 
 Next: find what you filed with [Searching](searching.md), or manage
 deletion and recovery with [Trash, GC, Repack & Verify](trash-and-gc.md).

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -127,10 +127,13 @@ docbank mv batch reorganization.json
 ```
 
 Every source and destination is interpreted against the tree as it existed at
-the start of the transaction. The complete final tree is then checked for
-missing parents, duplicate sibling names, and cycles before any row changes.
-This makes swaps and nested reorganizations possible without temporary names.
-If any selector, revision, or final coordinate is invalid, nothing moves.
+the start of the transaction. Unlike ordinary `mv`, a batch destination is the
+exact final coordinate; an existing directory is not shorthand for “move into
+this directory.” To move a document into `/filed` while retaining `a.pdf`, name
+`/filed/a.pdf` explicitly. This makes file and directory swaps unambiguous.
+The complete final tree is then checked for missing parents, duplicate sibling
+names, and cycles before any row changes. If any selector, revision, or final
+coordinate is invalid, nothing moves.
 
 A path source means “the node at this coordinate when the transaction runs.”
 An `id:N` source means “this exact node”; the CLI resolves it before submission

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -126,11 +126,13 @@ standard input with `-`:
 docbank mv batch reorganization.json
 ```
 
-Every source and destination is interpreted against the tree as it existed at
-the start of the transaction. Unlike ordinary `mv`, a batch destination is the
-exact final coordinate; an existing directory is not shorthand for “move into
-this directory.” To move a document into `/filed` while retaining `a.pdf`, name
-`/filed/a.pdf` explicitly. This makes file and directory swaps unambiguous.
+Every source is interpreted against the tree as it existed at the start of the
+transaction. A batch destination is the exact final coordinate; an existing
+directory is not shorthand for “move into this directory.” Destination parents
+are resolved in the planned final tree, so one item can move beneath a directory
+that another item moves in the same batch. To move a document into `/filed`
+while retaining `a.pdf`, name `/filed/a.pdf` explicitly. This makes file and
+directory swaps unambiguous.
 The complete final tree is then checked for missing parents, duplicate sibling
 names, and cycles before any row changes. If any selector, revision, or final
 coordinate is invalid, nothing moves.

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -68,6 +68,7 @@ var storeErrCodes = []struct {
 	{store.ErrNotFile, http.StatusUnprocessableEntity, "not_file"},
 	{store.ErrInvalidName, http.StatusUnprocessableEntity, "invalid_name"},
 	{store.ErrInvalidTag, http.StatusUnprocessableEntity, "invalid_tag"},
+	{store.ErrInvalidBatchMove, http.StatusUnprocessableEntity, "invalid_batch_move"},
 	{store.ErrNotTrashed, http.StatusUnprocessableEntity, "not_trashed"},
 	{store.ErrIsRoot, http.StatusUnprocessableEntity, "is_root"},
 	{store.ErrVersionNodeMismatch, http.StatusUnprocessableEntity, "version_node_mismatch"},

--- a/internal/api/routes_mutate.go
+++ b/internal/api/routes_mutate.go
@@ -165,6 +165,7 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 		OperationID: "batchMove", Method: http.MethodPost, Path: "/api/v1/batch/move",
 		Summary: "Apply an all-or-nothing document reorganization",
 		Description: "Every source and destination is resolved against one initial tree. " +
+			"Each destination is an exact final coordinate, including when a directory initially occupies it. " +
 			"The daemon validates the complete final tree before changing anything, so plans may " +
 			"perform swaps and nested reorganizations without exposing intermediate names. " +
 			"A source uses either source_path or node_id plus revision, never both.",

--- a/internal/api/routes_mutate.go
+++ b/internal/api/routes_mutate.go
@@ -164,8 +164,8 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 	huma.Register(api, huma.Operation{
 		OperationID: "batchMove", Method: http.MethodPost, Path: "/api/v1/batch/move",
 		Summary: "Apply an all-or-nothing document reorganization",
-		Description: "Every source and destination is resolved against one initial tree. " +
-			"Each destination is an exact final coordinate, including when a directory initially occupies it. " +
+		Description: "Every source is resolved against one initial tree. " +
+			"Each destination is an exact final coordinate, and its parent is resolved in the planned final tree. " +
 			"The daemon validates the complete final tree before changing anything, so plans may " +
 			"perform swaps and nested reorganizations without exposing intermediate names. " +
 			"A source uses either source_path or node_id plus revision, never both.",

--- a/internal/api/routes_mutate.go
+++ b/internal/api/routes_mutate.go
@@ -160,6 +160,60 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 		return out, err
 	})
 
+	type batchMoveOutput struct{ Body BatchMoveReport }
+	huma.Register(api, huma.Operation{
+		OperationID: "batchMove", Method: http.MethodPost, Path: "/api/v1/batch/move",
+		Summary: "Apply an all-or-nothing document reorganization",
+		Description: "Every source and destination is resolved against one initial tree. " +
+			"The daemon validates the complete final tree before changing anything, so plans may " +
+			"perform swaps and nested reorganizations without exposing intermediate names. " +
+			"A source uses either source_path or node_id plus revision, never both.",
+	}, func(ctx context.Context, in *struct {
+		Body BatchMoveRequest
+	}) (*batchMoveOutput, error) {
+		moves := make([]store.BatchMoveRequest, len(in.Body.Moves))
+		for index, move := range in.Body.Moves {
+			byPath, byID := move.SourcePath != "", move.NodeID != 0
+			if byPath == byID {
+				return nil, NewError(http.StatusUnprocessableEntity, "invalid_batch_move",
+					fmt.Sprintf("move %d source must use exactly one of source_path or node_id", index))
+			}
+			if byPath {
+				if !strings.HasPrefix(move.SourcePath, "/") || move.Revision != 0 {
+					return nil, NewError(http.StatusUnprocessableEntity, "invalid_batch_move",
+						fmt.Sprintf("move %d path source must be absolute and cannot carry revision", index))
+				}
+			} else if move.NodeID < 1 || move.Revision < 1 {
+				return nil, NewError(http.StatusUnprocessableEntity, "invalid_batch_move",
+					fmt.Sprintf("move %d node source requires positive node_id and revision", index))
+			}
+			if !strings.HasPrefix(move.DestinationPath, "/") {
+				return nil, NewError(http.StatusUnprocessableEntity, "invalid_batch_move",
+					fmt.Sprintf("move %d destination_path must be absolute", index))
+			}
+			moves[index] = store.BatchMoveRequest{
+				SourcePath: move.SourcePath, NodeID: move.NodeID, IfRevision: move.Revision,
+				DestinationPath: move.DestinationPath,
+			}
+		}
+		var output *batchMoveOutput
+		err := g.mutate(func() error {
+			results, err := d.Store.BatchMove(ctx, moves)
+			if err != nil {
+				return FromStoreError(err)
+			}
+			report := BatchMoveReport{Items: make([]BatchMoveReceipt, len(results))}
+			for index, result := range results {
+				node := fromStoreNode(result.Node)
+				node.Path = result.Path
+				report.Items[index] = BatchMoveReceipt{FromPath: result.FromPath, Node: node}
+			}
+			output = &batchMoveOutput{Body: report}
+			return nil
+		})
+		return output, err
+	})
+
 	huma.Register(api, huma.Operation{
 		OperationID: "trashNode", Method: http.MethodPost, Path: "/api/v1/nodes/{id}/trash",
 		Summary: "Move a node and its subtree to the trash",

--- a/internal/api/routes_mutate_test.go
+++ b/internal/api/routes_mutate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -136,6 +137,39 @@ func TestMovePathAndTrashPath(t *testing.T) {
 		map[string]any{"src_path": "relative", "dest_path": "/x"})
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	assert.Contains(t, body, `"code":"validation"`)
+}
+
+func TestBatchMoveSwapsCoordinatesThroughTypedClient(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	left, err := s.Mkdir(t.Context(), s.RootID(), "left")
+	require.NoError(t, err)
+	right, err := s.Mkdir(t.Context(), s.RootID(), "right")
+	require.NoError(t, err)
+	first, err := s.CreateFile(t.Context(), left.ID, "first.txt", testHash("first"), 5, "text/plain")
+	require.NoError(t, err)
+	second, err := s.CreateFile(t.Context(), right.ID, "second.txt", testHash("second"), 6, "text/plain")
+	require.NoError(t, err)
+
+	c := client.New(ts.URL, testAPIKey)
+	report, err := c.BatchMove(t.Context(), []api.BatchMoveItem{
+		{SourcePath: "/left/first.txt", DestinationPath: "/right/second.txt"},
+		{NodeID: second.ID, Revision: second.Revision, DestinationPath: "/left/first.txt"},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Items, 2)
+	assert.Equal(t, first.ID, report.Items[0].Node.ID)
+	assert.Equal(t, "/left/first.txt", report.Items[0].FromPath)
+	assert.Equal(t, "/right/second.txt", report.Items[0].Node.Path)
+	assert.Equal(t, second.ID, report.Items[1].Node.ID)
+	assert.Equal(t, "/left/first.txt", report.Items[1].Node.Path)
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/batch/move", nil,
+		map[string]any{"moves": []map[string]any{{
+			"source_path": "/left/first.txt", "node_id": second.ID,
+			"destination_path": "/elsewhere",
+		}}})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"invalid_batch_move"`)
 }
 
 func TestPathMutationsRejectInvalidUTF8BeforeJSONDecoding(t *testing.T) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -42,6 +42,33 @@ type NodePage struct {
 	Offset int    `json:"offset"`
 }
 
+// BatchMoveItem identifies a live source either by absolute virtual path or
+// by stable node identity plus revision. DestinationPath is interpreted
+// against the transaction's initial topology.
+type BatchMoveItem struct {
+	SourcePath      string `json:"source_path,omitempty"`
+	NodeID          int64  `json:"node_id,omitempty" minimum:"1"`
+	Revision        int64  `json:"revision,omitempty" minimum:"1"`
+	DestinationPath string `json:"destination_path" minLength:"1"`
+}
+
+// BatchMoveRequest is one bounded all-or-nothing reorganization plan.
+type BatchMoveRequest struct {
+	Moves []BatchMoveItem `json:"moves" minItems:"1" maxItems:"1000"`
+}
+
+// BatchMoveReceipt reports one requested node's authoritative pre- and
+// post-transaction coordinates. Node.Path is the final canonical path.
+type BatchMoveReceipt struct {
+	FromPath string `json:"from_path"`
+	Node     Node   `json:"node"`
+}
+
+// BatchMoveReport preserves the plan's request order.
+type BatchMoveReport struct {
+	Items []BatchMoveReceipt `json:"items"`
+}
+
 // ContentVersion is the wire representation of an immutable version record.
 type ContentVersion struct {
 	ID                    string  `json:"id" format:"uuid"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -43,8 +43,8 @@ type NodePage struct {
 }
 
 // BatchMoveItem identifies a live source either by absolute virtual path or
-// by stable node identity plus revision. DestinationPath is interpreted
-// against the transaction's initial topology.
+// by stable node identity plus revision. DestinationPath is an exact final
+// coordinate interpreted against the transaction's initial topology.
 type BatchMoveItem struct {
 	SourcePath      string `json:"source_path,omitempty"`
 	NodeID          int64  `json:"node_id,omitempty" minimum:"1"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -44,7 +44,7 @@ type NodePage struct {
 
 // BatchMoveItem identifies a live source either by absolute virtual path or
 // by stable node identity plus revision. DestinationPath is an exact final
-// coordinate interpreted against the transaction's initial topology.
+// coordinate whose parent is resolved in the planned final topology.
 type BatchMoveItem struct {
 	SourcePath      string `json:"source_path,omitempty"`
 	NodeID          int64  `json:"node_id,omitempty" minimum:"1"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.kenn.io/kit/backup"
 	"go.kenn.io/kit/packstore"
@@ -158,6 +159,7 @@ var codeToTypedErr = map[string]error{
 	"not_file":                     store.ErrNotFile,
 	"invalid_name":                 store.ErrInvalidName,
 	"invalid_tag":                  store.ErrInvalidTag,
+	"invalid_batch_move":           store.ErrInvalidBatchMove,
 	"not_trashed":                  store.ErrNotTrashed,
 	"is_root":                      store.ErrIsRoot,
 	"version_node_mismatch":        store.ErrVersionNodeMismatch,
@@ -1983,6 +1985,59 @@ func (c *Client) MovePath(ctx context.Context, srcPath, destPath string) (api.No
 	err := c.do(ctx, http.MethodPost, "/api/v1/path/move", nil,
 		map[string]any{"src_path": srcPath, "dest_path": destPath}, &n)
 	return n, err
+}
+
+// BatchMove applies one bounded all-or-nothing reorganization. Path sources
+// are resolved by the daemon inside the transaction; ID sources require the
+// caller's inspected revision.
+func (c *Client) BatchMove(
+	ctx context.Context, moves []api.BatchMoveItem,
+) (api.BatchMoveReport, error) {
+	var report api.BatchMoveReport
+	if len(moves) == 0 || len(moves) > store.MaxBatchMoves {
+		return report, fmt.Errorf("batch move requires 1-%d items: %w",
+			store.MaxBatchMoves, store.ErrInvalidBatchMove)
+	}
+	for index, move := range moves {
+		byPath, byID := move.SourcePath != "", move.NodeID != 0
+		if byPath == byID {
+			return report, fmt.Errorf("batch move item %d source must use exactly one of path or node ID: %w",
+				index, store.ErrInvalidBatchMove)
+		}
+		if byPath {
+			if !utf8.ValidString(move.SourcePath) || !strings.HasPrefix(move.SourcePath, "/") || move.Revision != 0 {
+				return report, fmt.Errorf("batch move item %d has an invalid path source: %w",
+					index, store.ErrInvalidBatchMove)
+			}
+		} else if move.NodeID < 1 || move.Revision < 1 {
+			return report, fmt.Errorf("batch move item %d requires a positive node ID and revision: %w",
+				index, store.ErrInvalidBatchMove)
+		}
+		if !utf8.ValidString(move.DestinationPath) || !strings.HasPrefix(move.DestinationPath, "/") {
+			return report, fmt.Errorf("batch move item %d destination must be an absolute UTF-8 path: %w",
+				index, store.ErrInvalidBatchMove)
+		}
+	}
+	if err := c.do(ctx, http.MethodPost, "/api/v1/batch/move", nil,
+		api.BatchMoveRequest{Moves: moves}, &report); err != nil {
+		return api.BatchMoveReport{}, err
+	}
+	if len(report.Items) != len(moves) {
+		return api.BatchMoveReport{}, fmt.Errorf(
+			"batch move receipt has %d items, expected %d", len(report.Items), len(moves))
+	}
+	for index, receipt := range report.Items {
+		if receipt.Node.ID < 1 || receipt.Node.Revision < 1 ||
+			receipt.FromPath == "" || receipt.Node.Path == "" {
+			return api.BatchMoveReport{}, fmt.Errorf("batch move receipt item %d is incomplete", index)
+		}
+		if moves[index].NodeID != 0 && receipt.Node.ID != moves[index].NodeID {
+			return api.BatchMoveReport{}, fmt.Errorf(
+				"batch move receipt item %d targets node %d, expected %d",
+				index, receipt.Node.ID, moves[index].NodeID)
+		}
+	}
+	return report, nil
 }
 
 // MoveToPath moves a stable node identity to an absolute virtual destination

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "24"
+	daemonProtocolVersion = "25"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/audit_batch_move.go
+++ b/internal/store/audit_batch_move.go
@@ -1,0 +1,176 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+type auditedBatchMoveSnapshot struct {
+	authority       auditAuthorityState
+	scope           auditScopeState
+	nodeSequence    int64
+	operationID     string
+	recordedAt      string
+	priorNodes      map[int64]Node
+	priorEventNodes map[int64]Node
+	eventNodeIDs    []int64
+}
+
+func (s *Store) prepareAuditedBatchMove(
+	ctx context.Context, tx *sql.Tx, plan *batchMovePlan,
+) (*auditedBatchMoveSnapshot, error) {
+	authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, plan.movedIDs[0])
+	if err != nil {
+		return nil, err
+	}
+	if len(scopes) != 1 {
+		return nil, unsupportedAuditedNodeMutation(plan.movedIDs[0])
+	}
+	members, err := auditScopeMemberSetTx(ctx, tx, scopes[0].scopeID)
+	if err != nil {
+		return nil, err
+	}
+	for _, nodeID := range plan.changedIDs {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		if !members[auditNodeID] {
+			return nil, unsupportedAuditedNodeMutation(nodeID)
+		}
+	}
+	topology, err := currentAuditTopology(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	for _, nodeID := range plan.movedIDs {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		affectsTrashOrigin, err := auditMoveAffectsTrashOrigin(topology, members, auditNodeID)
+		if err != nil {
+			return nil, err
+		}
+		if affectsTrashOrigin {
+			return nil, fmt.Errorf(
+				"moving node %d would change retained trash-origin paths: %w",
+				nodeID, ErrAuditMutationUnsupported,
+			)
+		}
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return nil, err
+	}
+	snapshot := &auditedBatchMoveSnapshot{
+		authority: authority, scope: scopes[0], nodeSequence: nodeSequence,
+		operationID: operationID, recordedAt: plan.recordedAt,
+		priorNodes: make(map[int64]Node, len(plan.changedIDs)),
+	}
+	for _, nodeID := range plan.changedIDs {
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		snapshot.priorNodes[nodeID] = node
+	}
+	snapshot.eventNodeIDs, err = batchMoveChangedPathIDs(*plan, members)
+	if err != nil {
+		return nil, err
+	}
+	if len(snapshot.eventNodeIDs) == 0 {
+		return nil, fmt.Errorf("audited batch move changes no protected path: %w", ErrInvalidBatchMove)
+	}
+	snapshot.priorEventNodes = make(map[int64]Node, len(snapshot.eventNodeIDs))
+	for _, nodeID := range snapshot.eventNodeIDs {
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		snapshot.priorEventNodes[nodeID] = node
+	}
+	return snapshot, nil
+}
+
+func (s *Store) persistAuditedBatchMove(
+	ctx context.Context, tx *sql.Tx, snapshot auditedBatchMoveSnapshot, plan batchMovePlan,
+) error {
+	resultingNodes := make(map[int64]Node, len(snapshot.priorNodes))
+	for nodeID := range snapshot.priorNodes {
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		resultingNodes[nodeID] = node
+	}
+	resultingEventNodes := make(map[int64]Node, len(snapshot.eventNodeIDs))
+	for _, nodeID := range snapshot.eventNodeIDs {
+		node, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		resultingEventNodes[nodeID] = node
+	}
+	values, err := makeAuditedMutationValues(
+		s.vaultID, snapshot.authority.lineageID, snapshot.operationID, snapshot.recordedAt,
+	)
+	if err != nil {
+		return err
+	}
+	topology, err := makeAuditedMoveTopologyDelta(values.operationID, snapshot.priorNodes, resultingNodes)
+	if err != nil {
+		return err
+	}
+	effects, err := makeAuditedBatchMovePathEffects(
+		snapshot.scope.scopeID, snapshot.eventNodeIDs, plan.priorPaths, plan.finalPaths,
+	)
+	if err != nil {
+		return err
+	}
+	return persistAuditedTopologyMutation(
+		ctx, tx, values, snapshot.authority, snapshot.scope, snapshot.nodeSequence,
+		topology, effects, snapshot.priorNodes, resultingNodes,
+		snapshot.priorEventNodes, resultingEventNodes,
+	)
+}
+
+func makeAuditedBatchMovePathEffects(
+	scopeID string, nodeIDs []int64, priorPaths, resultingPaths map[int64]string,
+) ([]audit.Record, error) {
+	scopeValue, err := audit.UUID(scopeID)
+	if err != nil {
+		return nil, err
+	}
+	live, err := audit.Text(auditNodeStateLive)
+	if err != nil {
+		return nil, err
+	}
+	effects := make([]audit.Record, 0, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
+		auditNodeID, err := positiveAuditNodeID(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		priorPath, resultingPath := priorPaths[nodeID], resultingPaths[nodeID]
+		if priorPath == "" || resultingPath == "" || priorPath == resultingPath {
+			return nil, fmt.Errorf("audited batch move has invalid path effect for node %d", nodeID)
+		}
+		effects = append(effects, audit.Record{Kind: "path_effect", Fields: []audit.Field{
+			{Name: auditScopeIDField, Value: scopeValue},
+			{Name: "member_node_id", Value: audit.Unsigned(auditNodeID)},
+			{Name: "old", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes([]byte(priorPath))},
+				{Name: auditStateField, Value: live},
+			}})},
+			{Name: "new", Value: audit.Nested(audit.Record{Kind: auditPathStateKind, Fields: []audit.Field{
+				{Name: auditPathField, Value: audit.Bytes([]byte(resultingPath))},
+				{Name: auditStateField, Value: live},
+			}})},
+		}})
+	}
+	return effects, nil
+}

--- a/internal/store/audit_node_move_test.go
+++ b/internal/store/audit_node_move_test.go
@@ -91,6 +91,45 @@ func TestAuditedInScopeRenameRecordsOnePathEffect(t *testing.T) {
 	assert.Equal(t, int64(1), effects)
 }
 
+func TestAuditedBatchMoveRecordsOneAtomicFinalTopology(t *testing.T) {
+	s := newAuditedMoveStore(t)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	child, err := s.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+
+	results, err := s.BatchMove(t.Context(), []BatchMoveRequest{
+		{NodeID: report.ID, IfRevision: report.Revision, DestinationPath: "/Projects/Work/child.txt"},
+		{NodeID: child.ID, IfRevision: child.Revision, DestinationPath: "/Projects/report.txt"},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "/Projects/Work/child.txt", results[0].Path)
+	assert.Equal(t, "/Projects/report.txt", results[1].Path)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	var sequence, moveMutations int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM audit_records WHERE kind='canonical_mutation')`,
+	).Scan(&sequence, &moveMutations))
+	assert.Equal(t, int64(2), sequence)
+	assert.Equal(t, int64(2), moveMutations, "the complete batch must add one canonical mutation")
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	resolvedReport, err := restored.NodeByPath(t.Context(), "/Projects/Work/child.txt")
+	require.NoError(t, err)
+	assert.Equal(t, report.ID, resolvedReport.ID)
+	resolvedChild, err := restored.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	assert.Equal(t, child.ID, resolvedChild.ID)
+}
+
 func TestAuditedRootScopeRenameHandlesRootTimestampTouch(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
 	require.NoError(t, err)

--- a/internal/store/audit_node_move_validate.go
+++ b/internal/store/audit_node_move_validate.go
@@ -113,12 +113,13 @@ func (replay *auditedHistoryReplay) validateNodeMoveTopology(
 	if err != nil {
 		return replayedTopologyMutation{}, err
 	}
-	if len(changes) < 2 || len(changes) > 3 {
-		return replayedTopologyMutation{}, errors.New("in-scope move topology must change two or three nodes")
+	if len(changes) < 2 {
+		return replayedTopologyMutation{}, errors.New("in-scope move topology must change at least two nodes")
 	}
 	postTopology := slices.Clone(replay.topology)
 	changedIDs := make([]uint64, 0, len(changes))
-	var movedID, oldParentID, newParentID uint64
+	var movedIDs []uint64
+	requiredParents := make(map[uint64]bool)
 	for _, change := range changes {
 		nodeID, err := auditUnsignedField(change, metadataNodeIDField)
 		if err != nil {
@@ -143,10 +144,8 @@ func (replay *auditedHistoryReplay) validateNodeMoveTopology(
 			return replayedTopologyMutation{}, err
 		}
 		if pathChanged {
-			if movedID != 0 {
-				return replayedTopologyMutation{}, errors.New("node move topology changes multiple paths directly")
-			}
-			movedID, oldParentID, newParentID = nodeID, priorParent, resultingParent
+			movedIDs = append(movedIDs, nodeID)
+			requiredParents[priorParent], requiredParents[resultingParent] = true, true
 		}
 		postTopology[index] = *post
 		changedIDs = append(changedIDs, nodeID)
@@ -156,33 +155,37 @@ func (replay *auditedHistoryReplay) validateNodeMoveTopology(
 			"node move topology changes are not in canonical node order",
 		)
 	}
-	if movedID == 0 || !slices.Contains(changedIDs, oldParentID) ||
-		!slices.Contains(changedIDs, newParentID) {
-		return replayedTopologyMutation{}, errors.New("node move topology lacks its changed parent state")
+	if len(movedIDs) == 0 {
+		return replayedTopologyMutation{}, errors.New("node move topology changes no path directly")
 	}
-	wantChanges := 2
-	if oldParentID != newParentID {
-		wantChanges = 3
+	expectedChanges := make(map[uint64]bool, len(movedIDs)+len(requiredParents))
+	for _, nodeID := range movedIDs {
+		expectedChanges[nodeID] = true
 	}
-	if len(changes) != wantChanges {
+	for parentID := range requiredParents {
+		expectedChanges[parentID] = true
+		if !slices.Contains(changedIDs, parentID) {
+			return replayedTopologyMutation{}, errors.New("node move topology lacks a changed parent state")
+		}
+		if err := requireLiveDirectoryTopology(postTopology, parentID); err != nil {
+			return replayedTopologyMutation{}, err
+		}
+	}
+	if len(changes) != len(expectedChanges) {
 		return replayedTopologyMutation{}, errors.New("node move topology has an unexpected changed-node set")
 	}
-	if err := requireLiveDirectoryTopology(postTopology, oldParentID); err != nil {
-		return replayedTopologyMutation{}, err
-	}
-	if err := requireLiveDirectoryTopology(postTopology, newParentID); err != nil {
-		return replayedTopologyMutation{}, err
-	}
-	affectsTrashOrigin, err := auditMoveAffectsTrashOrigin(
-		replay.topology, replay.memberSet, movedID,
-	)
-	if err != nil {
-		return replayedTopologyMutation{}, err
-	}
-	if affectsTrashOrigin {
-		return replayedTopologyMutation{}, errors.New(
-			"node move changes a retained trash-origin path without recording trash effects",
+	for _, movedID := range movedIDs {
+		affectsTrashOrigin, err := auditMoveAffectsTrashOrigin(
+			replay.topology, replay.memberSet, movedID,
 		)
+		if err != nil {
+			return replayedTopologyMutation{}, err
+		}
+		if affectsTrashOrigin {
+			return replayedTopologyMutation{}, errors.New(
+				"node move changes a retained trash-origin path without recording trash effects",
+			)
+		}
 	}
 	if err := validateReplayedAuditTopology(postTopology); err != nil {
 		return replayedTopologyMutation{}, fmt.Errorf("validating node move topology: %w", err)

--- a/internal/store/batch_move.go
+++ b/internal/store/batch_move.go
@@ -1,0 +1,450 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// MaxBatchMoves bounds one atomic reorganization and its response.
+const MaxBatchMoves = 1000
+
+// BatchMoveRequest identifies a live source either by SourcePath or by the
+// stable NodeID plus IfRevision, and gives its absolute final destination.
+type BatchMoveRequest struct {
+	SourcePath      string
+	NodeID          int64
+	IfRevision      int64
+	DestinationPath string
+}
+
+// BatchMoveResult is the transactionally captured receipt for one request.
+type BatchMoveResult struct {
+	Node     Node
+	FromPath string
+	Path     string
+}
+
+type batchMoveNode struct {
+	id       int64
+	parentID *int64
+	name     string
+	kind     string
+	revision int64
+}
+
+type plannedBatchMove struct {
+	requestIndex int
+	nodeID       int64
+	oldParentID  int64
+	newParentID  int64
+	newName      string
+	changed      bool
+}
+
+type batchMovePlan struct {
+	nodes      map[int64]batchMoveNode
+	priorPaths map[int64]string
+	finalPaths map[int64]string
+	moves      []plannedBatchMove
+	changedIDs []int64
+	movedIDs   []int64
+	parentIDs  []int64
+	recordedAt string
+}
+
+// BatchMove applies the requested reorganization as one metadata transaction.
+// Every selector and destination is resolved against the same pre-state; only
+// the final topology is checked for cycles and sibling collisions.
+func (s *Store) BatchMove(ctx context.Context, requests []BatchMoveRequest) ([]BatchMoveResult, error) {
+	if len(requests) == 0 || len(requests) > MaxBatchMoves {
+		return nil, fmt.Errorf("batch move requires 1-%d items: %w", MaxBatchMoves, ErrInvalidBatchMove)
+	}
+	var results []BatchMoveResult
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		plan, err := s.planBatchMove(ctx, tx, requests)
+		if err != nil {
+			return err
+		}
+		if len(plan.movedIDs) == 0 {
+			results, err = s.batchMoveResults(ctx, tx, plan)
+			return err
+		}
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		var audited *auditedBatchMoveSnapshot
+		if active {
+			audited, err = s.prepareAuditedBatchMove(ctx, tx, &plan)
+			if err != nil {
+				return err
+			}
+			plan.recordedAt = audited.recordedAt
+		}
+		if err := s.applyBatchMove(ctx, tx, plan); err != nil {
+			return err
+		}
+		if audited != nil {
+			if err := s.persistAuditedBatchMove(ctx, tx, *audited, plan); err != nil {
+				return err
+			}
+		}
+		results, err = s.batchMoveResults(ctx, tx, plan)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *Store) planBatchMove(
+	ctx context.Context, tx *sql.Tx, requests []BatchMoveRequest,
+) (batchMovePlan, error) {
+	nodes, err := loadBatchMoveTopology(ctx, tx)
+	if err != nil {
+		return batchMovePlan{}, err
+	}
+	priorPaths, err := batchMovePaths(nodes)
+	if err != nil {
+		return batchMovePlan{}, err
+	}
+	pathIDs := make(map[string]int64, len(priorPaths))
+	for id, path := range priorPaths {
+		pathIDs[path] = id
+	}
+	initialNodes := make(map[int64]batchMoveNode, len(nodes))
+	maps.Copy(initialNodes, nodes)
+	plan := batchMovePlan{nodes: nodes, priorPaths: priorPaths, recordedAt: nowRFC3339()}
+	seen := make(map[int64]bool, len(requests))
+	for index, request := range requests {
+		source, err := resolveBatchMoveSource(request, initialNodes, pathIDs)
+		if err != nil {
+			return batchMovePlan{}, fmt.Errorf("batch move item %d: %w", index, err)
+		}
+		if source.id == s.rootID {
+			return batchMovePlan{}, fmt.Errorf("batch move item %d: %w", index, ErrIsRoot)
+		}
+		if seen[source.id] {
+			return batchMovePlan{}, fmt.Errorf(
+				"batch move item %d repeats node %d: %w", index, source.id, ErrInvalidBatchMove,
+			)
+		}
+		seen[source.id] = true
+		newParentID, newName, err := resolveBatchMoveDestination(
+			request.DestinationPath, source.name, initialNodes, pathIDs,
+		)
+		if err != nil {
+			return batchMovePlan{}, fmt.Errorf("batch move item %d: %w", index, err)
+		}
+		move := plannedBatchMove{
+			requestIndex: index, nodeID: source.id, oldParentID: *source.parentID,
+			newParentID: newParentID, newName: newName,
+		}
+		move.changed = move.oldParentID != move.newParentID || source.name != move.newName
+		plan.moves = append(plan.moves, move)
+		if move.changed {
+			updated := nodes[source.id]
+			updated.parentID, updated.name = new(move.newParentID), move.newName
+			nodes[source.id] = updated
+		}
+	}
+	if err := validateBatchMoveTopology(nodes); err != nil {
+		return batchMovePlan{}, err
+	}
+	plan.finalPaths, err = batchMovePaths(nodes)
+	if err != nil {
+		return batchMovePlan{}, err
+	}
+	changed, moved, parents := map[int64]bool{}, map[int64]bool{}, map[int64]bool{}
+	for _, move := range plan.moves {
+		if !move.changed {
+			continue
+		}
+		changed[move.nodeID], moved[move.nodeID] = true, true
+		changed[move.oldParentID], parents[move.oldParentID] = true, true
+		changed[move.newParentID], parents[move.newParentID] = true, true
+	}
+	plan.changedIDs, plan.movedIDs, plan.parentIDs = sortedBatchMoveIDs(changed),
+		sortedBatchMoveIDs(moved), sortedBatchMoveIDs(parents)
+	return plan, nil
+}
+
+func loadBatchMoveTopology(ctx context.Context, tx *sql.Tx) (map[int64]batchMoveNode, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id,parent_id,name,kind,revision FROM nodes WHERE trashed_at IS NULL ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("loading batch move topology: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	nodes := make(map[int64]batchMoveNode)
+	for rows.Next() {
+		var node batchMoveNode
+		var parent sql.NullInt64
+		if err := rows.Scan(&node.id, &parent, &node.name, &node.kind, &node.revision); err != nil {
+			return nil, fmt.Errorf("scanning batch move topology: %w", err)
+		}
+		if parent.Valid {
+			node.parentID = new(parent.Int64)
+		}
+		nodes[node.id] = node
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("loading batch move topology: %w", err)
+	}
+	return nodes, nil
+}
+
+func resolveBatchMoveSource(
+	request BatchMoveRequest, nodes map[int64]batchMoveNode, pathIDs map[string]int64,
+) (batchMoveNode, error) {
+	byPath, byID := request.SourcePath != "", request.NodeID != 0
+	if byPath == byID {
+		return batchMoveNode{}, fmt.Errorf("source must use exactly one of path or node ID: %w", ErrInvalidBatchMove)
+	}
+	var id int64
+	if byPath {
+		if !strings.HasPrefix(request.SourcePath, "/") {
+			return batchMoveNode{}, fmt.Errorf("source path must be absolute: %w", ErrInvalidBatchMove)
+		}
+		canonical, err := canonicalBatchMovePath(request.SourcePath)
+		if err != nil {
+			return batchMoveNode{}, err
+		}
+		id = pathIDs[canonical]
+		if id == 0 {
+			return batchMoveNode{}, fmt.Errorf("source path %q: %w", request.SourcePath, ErrNotFound)
+		}
+		if request.IfRevision != 0 {
+			return batchMoveNode{}, fmt.Errorf("path source cannot carry a revision: %w", ErrInvalidBatchMove)
+		}
+	} else {
+		if request.NodeID < 1 || request.IfRevision < 1 {
+			return batchMoveNode{}, fmt.Errorf("node source requires positive ID and revision: %w", ErrInvalidBatchMove)
+		}
+		id = request.NodeID
+	}
+	node, ok := nodes[id]
+	if !ok {
+		return batchMoveNode{}, fmt.Errorf("node %d: %w", id, ErrNotFound)
+	}
+	if byID && node.revision != request.IfRevision {
+		return batchMoveNode{}, fmt.Errorf(
+			"node %d at revision %d, expected %d: %w",
+			id, node.revision, request.IfRevision, ErrStaleRevision,
+		)
+	}
+	return node, nil
+}
+
+func resolveBatchMoveDestination(
+	destination, keepName string, nodes map[int64]batchMoveNode, pathIDs map[string]int64,
+) (int64, string, error) {
+	if !strings.HasPrefix(destination, "/") {
+		return 0, "", fmt.Errorf("destination path must be absolute: %w", ErrInvalidBatchMove)
+	}
+	canonical, err := canonicalBatchMovePath(destination)
+	if err != nil {
+		return 0, "", fmt.Errorf("destination %q: %w", destination, err)
+	}
+	segments := splitPath(canonical)
+	if id := pathIDs[canonical]; id != 0 {
+		destinationNode := nodes[id]
+		if destinationNode.kind == nodeKindDir {
+			return id, keepName, nil
+		}
+		if destinationNode.parentID == nil {
+			return 0, "", ErrIsRoot
+		}
+		return *destinationNode.parentID, destinationNode.name, nil
+	}
+	if len(segments) == 0 {
+		return 0, "", fmt.Errorf("destination %q: %w", destination, ErrExists)
+	}
+	parentPath := "/" + strings.Join(segments[:len(segments)-1], "/")
+	parentID := pathIDs[parentPath]
+	parent, ok := nodes[parentID]
+	if !ok {
+		return 0, "", fmt.Errorf("destination parent %q: %w", parentPath, ErrNotFound)
+	}
+	if parent.kind != nodeKindDir {
+		return 0, "", fmt.Errorf("destination parent %q: %w", parentPath, ErrNotDir)
+	}
+	return parentID, segments[len(segments)-1], nil
+}
+
+func canonicalBatchMovePath(value string) (string, error) {
+	segments := splitPath(value)
+	for index, segment := range segments {
+		normalized, err := NormalizeName(segment)
+		if err != nil {
+			return "", err
+		}
+		segments[index] = normalized
+	}
+	return "/" + strings.Join(segments, "/"), nil
+}
+
+func validateBatchMoveTopology(nodes map[int64]batchMoveNode) error {
+	siblings := make(map[string]int64, len(nodes))
+	for id, node := range nodes {
+		if node.parentID == nil {
+			continue
+		}
+		parent, ok := nodes[*node.parentID]
+		if !ok {
+			return fmt.Errorf("batch move parent %d: %w", *node.parentID, ErrNotFound)
+		}
+		if parent.kind != nodeKindDir {
+			return fmt.Errorf("batch move parent %d: %w", *node.parentID, ErrNotDir)
+		}
+		key := fmt.Sprintf("%d\x00%s", *node.parentID, node.name)
+		if prior := siblings[key]; prior != 0 && prior != id {
+			return fmt.Errorf("batch move nodes %d and %d collide at %q: %w", prior, id, node.name, ErrExists)
+		}
+		siblings[key] = id
+	}
+	states := make(map[int64]uint8, len(nodes))
+	var visit func(int64) error
+	visit = func(id int64) error {
+		switch states[id] {
+		case 1:
+			return fmt.Errorf("batch move at node %d: %w", id, ErrCycle)
+		case 2:
+			return nil
+		}
+		states[id] = 1
+		if parent := nodes[id].parentID; parent != nil {
+			if err := visit(*parent); err != nil {
+				return err
+			}
+		}
+		states[id] = 2
+		return nil
+	}
+	for id := range nodes {
+		if err := visit(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func batchMovePaths(nodes map[int64]batchMoveNode) (map[int64]string, error) {
+	paths := make(map[int64]string, len(nodes))
+	var pathFor func(int64, map[int64]bool) (string, error)
+	pathFor = func(id int64, visiting map[int64]bool) (string, error) {
+		if path, ok := paths[id]; ok {
+			return path, nil
+		}
+		node, ok := nodes[id]
+		if !ok {
+			return "", fmt.Errorf("batch move path node %d: %w", id, ErrNotFound)
+		}
+		if visiting[id] {
+			return "", ErrCycle
+		}
+		visiting[id] = true
+		defer delete(visiting, id)
+		if node.parentID == nil {
+			paths[id] = "/"
+			return "/", nil
+		}
+		parent, err := pathFor(*node.parentID, visiting)
+		if err != nil {
+			return "", err
+		}
+		paths[id] = strings.TrimSuffix(parent, "/") + "/" + node.name
+		return paths[id], nil
+	}
+	for id := range nodes {
+		if _, err := pathFor(id, make(map[int64]bool)); err != nil {
+			return nil, err
+		}
+	}
+	return paths, nil
+}
+
+func (s *Store) applyBatchMove(ctx context.Context, tx *sql.Tx, plan batchMovePlan) error {
+	for _, id := range plan.movedIDs {
+		temporaryName := fmt.Sprintf("\x00docbank-batch-%d", id)
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE nodes SET name=? WHERE id=?`, temporaryName, id); err != nil {
+			return fmt.Errorf("staging batch move node %d: %w", id, err)
+		}
+	}
+	moved := make(map[int64]bool, len(plan.movedIDs))
+	for _, move := range plan.moves {
+		if !move.changed {
+			continue
+		}
+		moved[move.nodeID] = true
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE nodes SET parent_id=?,name=?,revision=revision+1,modified_at=? WHERE id=?`,
+			move.newParentID, move.newName, plan.recordedAt, move.nodeID); err != nil {
+			return fmt.Errorf("applying batch move node %d: %w", move.nodeID, err)
+		}
+	}
+	for _, id := range plan.parentIDs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if moved[id] {
+			continue
+		}
+		if err := bumpRevisionTx(tx, id, plan.recordedAt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) batchMoveResults(
+	ctx context.Context, tx *sql.Tx, plan batchMovePlan,
+) ([]BatchMoveResult, error) {
+	results := make([]BatchMoveResult, len(plan.moves))
+	for _, move := range plan.moves {
+		node, err := nodeByIDTx(tx, move.nodeID)
+		if err != nil {
+			return nil, err
+		}
+		path, err := pathOf(ctx, tx, move.nodeID)
+		if err != nil {
+			return nil, err
+		}
+		results[move.requestIndex] = BatchMoveResult{
+			Node: node, FromPath: plan.priorPaths[move.nodeID], Path: path,
+		}
+	}
+	return results, nil
+}
+
+func sortedBatchMoveIDs(set map[int64]bool) []int64 {
+	result := make([]int64, 0, len(set))
+	for id := range set {
+		result = append(result, id)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func batchMoveChangedPathIDs(
+	plan batchMovePlan, members map[uint64]bool,
+) ([]int64, error) {
+	var result []int64
+	for id, priorPath := range plan.priorPaths {
+		auditNodeID, err := positiveAuditNodeID(id)
+		if err != nil {
+			return nil, err
+		}
+		if members[auditNodeID] && priorPath != plan.finalPaths[id] {
+			result = append(result, id)
+		}
+	}
+	slices.Sort(result)
+	return result, nil
+}

--- a/internal/store/batch_move.go
+++ b/internal/store/batch_move.go
@@ -136,7 +136,7 @@ func (s *Store) planBatchMove(
 		}
 		seen[source.id] = true
 		newParentID, newName, err := resolveBatchMoveDestination(
-			request.DestinationPath, source.name, initialNodes, pathIDs,
+			request.DestinationPath, initialNodes, pathIDs,
 		)
 		if err != nil {
 			return batchMovePlan{}, fmt.Errorf("batch move item %d: %w", index, err)
@@ -242,7 +242,7 @@ func resolveBatchMoveSource(
 }
 
 func resolveBatchMoveDestination(
-	destination, keepName string, nodes map[int64]batchMoveNode, pathIDs map[string]int64,
+	destination string, nodes map[int64]batchMoveNode, pathIDs map[string]int64,
 ) (int64, string, error) {
 	if !strings.HasPrefix(destination, "/") {
 		return 0, "", fmt.Errorf("destination path must be absolute: %w", ErrInvalidBatchMove)
@@ -254,9 +254,6 @@ func resolveBatchMoveDestination(
 	segments := splitPath(canonical)
 	if id := pathIDs[canonical]; id != 0 {
 		destinationNode := nodes[id]
-		if destinationNode.kind == nodeKindDir {
-			return id, keepName, nil
-		}
 		if destinationNode.parentID == nil {
 			return 0, "", ErrIsRoot
 		}

--- a/internal/store/batch_move.go
+++ b/internal/store/batch_move.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -37,12 +38,13 @@ type batchMoveNode struct {
 }
 
 type plannedBatchMove struct {
-	requestIndex int
-	nodeID       int64
-	oldParentID  int64
-	newParentID  int64
-	newName      string
-	changed      bool
+	requestIndex    int
+	nodeID          int64
+	oldParentID     int64
+	newParentID     int64
+	newName         string
+	destinationPath string
+	changed         bool
 }
 
 type batchMovePlan struct {
@@ -57,8 +59,8 @@ type batchMovePlan struct {
 }
 
 // BatchMove applies the requested reorganization as one metadata transaction.
-// Every selector and destination is resolved against the same pre-state; only
-// the final topology is checked for cycles and sibling collisions.
+// Sources resolve against one pre-state. Exact destination coordinates resolve
+// against the planned final tree, which is checked before any row changes.
 func (s *Store) BatchMove(ctx context.Context, requests []BatchMoveRequest) ([]BatchMoveResult, error) {
 	if len(requests) == 0 || len(requests) > MaxBatchMoves {
 		return nil, fmt.Errorf("batch move requires 1-%d items: %w", MaxBatchMoves, ErrInvalidBatchMove)
@@ -135,22 +137,45 @@ func (s *Store) planBatchMove(
 			)
 		}
 		seen[source.id] = true
-		newParentID, newName, err := resolveBatchMoveDestination(
-			request.DestinationPath, initialNodes, pathIDs,
-		)
+		destinationPath, err := canonicalBatchMoveDestination(request.DestinationPath)
 		if err != nil {
 			return batchMovePlan{}, fmt.Errorf("batch move item %d: %w", index, err)
 		}
 		move := plannedBatchMove{
 			requestIndex: index, nodeID: source.id, oldParentID: *source.parentID,
-			newParentID: newParentID, newName: newName,
+			destinationPath: destinationPath,
 		}
-		move.changed = move.oldParentID != move.newParentID || source.name != move.newName
 		plan.moves = append(plan.moves, move)
+	}
+	plannedPaths, finalPathIDs, err := plannedBatchMovePaths(initialNodes, plan.moves)
+	if err != nil {
+		return batchMovePlan{}, err
+	}
+	for index := range plan.moves {
+		move := &plan.moves[index]
+		segments := splitPath(move.destinationPath)
+		parentPath := "/" + strings.Join(segments[:len(segments)-1], "/")
+		parentID := finalPathIDs[parentPath]
+		parent, ok := initialNodes[parentID]
+		if !ok {
+			return batchMovePlan{}, fmt.Errorf(
+				"batch move item %d destination parent %q: %w",
+				move.requestIndex, parentPath, ErrNotFound,
+			)
+		}
+		if parent.kind != nodeKindDir {
+			return batchMovePlan{}, fmt.Errorf(
+				"batch move item %d destination parent %q: %w",
+				move.requestIndex, parentPath, ErrNotDir,
+			)
+		}
+		move.newParentID, move.newName = parentID, segments[len(segments)-1]
+		source := initialNodes[move.nodeID]
+		move.changed = move.oldParentID != move.newParentID || source.name != move.newName
 		if move.changed {
-			updated := nodes[source.id]
+			updated := nodes[move.nodeID]
 			updated.parentID, updated.name = new(move.newParentID), move.newName
-			nodes[source.id] = updated
+			nodes[move.nodeID] = updated
 		}
 	}
 	if err := validateBatchMoveTopology(nodes); err != nil {
@@ -159,6 +184,9 @@ func (s *Store) planBatchMove(
 	plan.finalPaths, err = batchMovePaths(nodes)
 	if err != nil {
 		return batchMovePlan{}, err
+	}
+	if !maps.Equal(plan.finalPaths, plannedPaths) {
+		return batchMovePlan{}, errors.New("batch move final topology disagrees with exact destinations")
 	}
 	changed, moved, parents := map[int64]bool{}, map[int64]bool{}, map[int64]bool{}
 	for _, move := range plan.moves {
@@ -241,37 +269,71 @@ func resolveBatchMoveSource(
 	return node, nil
 }
 
-func resolveBatchMoveDestination(
-	destination string, nodes map[int64]batchMoveNode, pathIDs map[string]int64,
-) (int64, string, error) {
+func canonicalBatchMoveDestination(destination string) (string, error) {
 	if !strings.HasPrefix(destination, "/") {
-		return 0, "", fmt.Errorf("destination path must be absolute: %w", ErrInvalidBatchMove)
+		return "", fmt.Errorf("destination path must be absolute: %w", ErrInvalidBatchMove)
 	}
 	canonical, err := canonicalBatchMovePath(destination)
 	if err != nil {
-		return 0, "", fmt.Errorf("destination %q: %w", destination, err)
+		return "", fmt.Errorf("destination %q: %w", destination, err)
 	}
-	segments := splitPath(canonical)
-	if id := pathIDs[canonical]; id != 0 {
-		destinationNode := nodes[id]
-		if destinationNode.parentID == nil {
-			return 0, "", ErrIsRoot
+	if canonical == "/" {
+		return "", fmt.Errorf("destination %q: %w", destination, ErrIsRoot)
+	}
+	return canonical, nil
+}
+
+func plannedBatchMovePaths(
+	nodes map[int64]batchMoveNode, moves []plannedBatchMove,
+) (map[int64]string, map[string]int64, error) {
+	destinations := make(map[int64]string, len(moves))
+	for _, move := range moves {
+		destinations[move.nodeID] = move.destinationPath
+	}
+	paths := make(map[int64]string, len(nodes))
+	var pathFor func(int64, map[int64]bool) (string, error)
+	pathFor = func(id int64, visiting map[int64]bool) (string, error) {
+		if path, ok := paths[id]; ok {
+			return path, nil
 		}
-		return *destinationNode.parentID, destinationNode.name, nil
+		if destination, ok := destinations[id]; ok {
+			paths[id] = destination
+			return destination, nil
+		}
+		node, ok := nodes[id]
+		if !ok {
+			return "", fmt.Errorf("batch move path node %d: %w", id, ErrNotFound)
+		}
+		if visiting[id] {
+			return "", ErrCycle
+		}
+		visiting[id] = true
+		defer delete(visiting, id)
+		if node.parentID == nil {
+			paths[id] = "/"
+			return "/", nil
+		}
+		parent, err := pathFor(*node.parentID, visiting)
+		if err != nil {
+			return "", err
+		}
+		paths[id] = strings.TrimSuffix(parent, "/") + "/" + node.name
+		return paths[id], nil
 	}
-	if len(segments) == 0 {
-		return 0, "", fmt.Errorf("destination %q: %w", destination, ErrExists)
+	pathIDs := make(map[string]int64, len(nodes))
+	for id := range nodes {
+		path, err := pathFor(id, make(map[int64]bool))
+		if err != nil {
+			return nil, nil, err
+		}
+		if prior := pathIDs[path]; prior != 0 && prior != id {
+			return nil, nil, fmt.Errorf(
+				"batch move nodes %d and %d collide at %q: %w", prior, id, path, ErrExists,
+			)
+		}
+		pathIDs[path] = id
 	}
-	parentPath := "/" + strings.Join(segments[:len(segments)-1], "/")
-	parentID := pathIDs[parentPath]
-	parent, ok := nodes[parentID]
-	if !ok {
-		return 0, "", fmt.Errorf("destination parent %q: %w", parentPath, ErrNotFound)
-	}
-	if parent.kind != nodeKindDir {
-		return 0, "", fmt.Errorf("destination parent %q: %w", parentPath, ErrNotDir)
-	}
-	return parentID, segments[len(segments)-1], nil
+	return paths, pathIDs, nil
 }
 
 func canonicalBatchMovePath(value string) (string, error) {

--- a/internal/store/batch_move_test.go
+++ b/internal/store/batch_move_test.go
@@ -65,6 +65,59 @@ func TestBatchMoveSupportsNestedNetChanges(t *testing.T) {
 	assert.Equal(t, "/y/b", results[1].Path)
 }
 
+func TestBatchMoveSwapsDirectoryCoordinates(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	left, err := s.Mkdir(ctx, s.RootID(), "left")
+	require.NoError(t, err)
+	right, err := s.Mkdir(ctx, s.RootID(), "right")
+	require.NoError(t, err)
+	leftChild, err := s.CreateFile(ctx, left.ID, "left.txt", fakeHash("left"), 4, "text/plain")
+	require.NoError(t, err)
+	rightChild, err := s.CreateFile(ctx, right.ID, "right.txt", fakeHash("right"), 5, "text/plain")
+	require.NoError(t, err)
+
+	results, err := s.BatchMove(ctx, []BatchMoveRequest{
+		{SourcePath: "/left", DestinationPath: "/right"},
+		{SourcePath: "/right", DestinationPath: "/left"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, left.ID, results[0].Node.ID)
+	assert.Equal(t, "/right", results[0].Path)
+	assert.Equal(t, right.ID, results[1].Node.ID)
+	assert.Equal(t, "/left", results[1].Path)
+	leftResult, err := s.NodeByPath(ctx, "/right/left.txt")
+	require.NoError(t, err)
+	assert.Equal(t, leftChild.ID, leftResult.ID)
+	rightResult, err := s.NodeByPath(ctx, "/left/right.txt")
+	require.NoError(t, err)
+	assert.Equal(t, rightChild.ID, rightResult.ID)
+}
+
+func TestBatchMoveCanOccupyVacatedDirectoryCoordinate(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	archive, err := s.Mkdir(ctx, s.RootID(), "archive")
+	require.NoError(t, err)
+	slot, err := s.Mkdir(ctx, s.RootID(), "slot")
+	require.NoError(t, err)
+	item, err := s.CreateFile(ctx, s.RootID(), "item.txt", fakeHash("item"), 4, "text/plain")
+	require.NoError(t, err)
+
+	_, err = s.BatchMove(ctx, []BatchMoveRequest{
+		{SourcePath: "/slot", DestinationPath: "/archive/slot"},
+		{SourcePath: "/item.txt", DestinationPath: "/slot"},
+	})
+	require.NoError(t, err)
+	finalSlot, err := s.NodeByPath(ctx, "/slot")
+	require.NoError(t, err)
+	assert.Equal(t, item.ID, finalSlot.ID)
+	archived, err := s.NodeByPath(ctx, "/archive/slot")
+	require.NoError(t, err)
+	assert.Equal(t, slot.ID, archived.ID)
+	assert.Equal(t, archive.ID, *archived.ParentID)
+}
+
 func TestBatchMoveFailureRollsBackWholePlan(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/batch_move_test.go
+++ b/internal/store/batch_move_test.go
@@ -65,6 +65,39 @@ func TestBatchMoveSupportsNestedNetChanges(t *testing.T) {
 	assert.Equal(t, "/y/b", results[1].Path)
 }
 
+func TestBatchMoveResolvesDestinationParentsInFinalTree(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	a, err := s.Mkdir(ctx, s.RootID(), "a")
+	require.NoError(t, err)
+	_, err = s.Mkdir(ctx, s.RootID(), "x")
+	require.NoError(t, err)
+	item, err := s.CreateFile(ctx, s.RootID(), "item.txt", fakeHash("item"), 4, "text/plain")
+	require.NoError(t, err)
+
+	_, err = s.BatchMove(ctx, []BatchMoveRequest{
+		{SourcePath: "/a", DestinationPath: "/x/a"},
+		{SourcePath: "/item.txt", DestinationPath: "/a/item.txt"},
+	})
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.NodeByPath(ctx, "/a")
+	require.NoError(t, err)
+	_, err = s.NodeByPath(ctx, "/item.txt")
+	require.NoError(t, err)
+
+	results, err := s.BatchMove(ctx, []BatchMoveRequest{
+		{SourcePath: "/a", DestinationPath: "/x/a"},
+		{SourcePath: "/item.txt", DestinationPath: "/x/a/item.txt"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/x/a", results[0].Path)
+	assert.Equal(t, "/x/a/item.txt", results[1].Path)
+	moved, err := s.NodeByPath(ctx, "/x/a/item.txt")
+	require.NoError(t, err)
+	assert.Equal(t, item.ID, moved.ID)
+	assert.Equal(t, a.ID, *moved.ParentID)
+}
+
 func TestBatchMoveSwapsDirectoryCoordinates(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
@@ -144,7 +177,7 @@ func TestBatchMoveFailureRollsBackWholePlan(t *testing.T) {
 	assert.Empty(t, children)
 }
 
-func TestBatchMoveRejectsDuplicateSourceAndFinalCycle(t *testing.T) {
+func TestBatchMoveRejectsDuplicateSourceAndMissingFinalParent(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
 	a, err := s.Mkdir(ctx, s.RootID(), "a")
@@ -164,5 +197,5 @@ func TestBatchMoveRejectsDuplicateSourceAndFinalCycle(t *testing.T) {
 		{NodeID: a.ID, IfRevision: a.Revision, DestinationPath: "/a/b/a"},
 		{NodeID: b.ID, IfRevision: b.Revision, DestinationPath: "/a/b"},
 	})
-	require.ErrorIs(t, err, ErrCycle)
+	require.ErrorIs(t, err, ErrNotFound)
 }

--- a/internal/store/batch_move_test.go
+++ b/internal/store/batch_move_test.go
@@ -1,0 +1,115 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchMoveAppliesFinalTopologyAtomically(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	left, err := s.Mkdir(ctx, s.RootID(), "left")
+	require.NoError(t, err)
+	right, err := s.Mkdir(ctx, s.RootID(), "right")
+	require.NoError(t, err)
+	first, err := s.CreateFile(ctx, left.ID, "first.txt", fakeHash("first"), 5, "text/plain")
+	require.NoError(t, err)
+	second, err := s.CreateFile(ctx, right.ID, "second.txt", fakeHash("second"), 6, "text/plain")
+	require.NoError(t, err)
+
+	results, err := s.BatchMove(ctx, []BatchMoveRequest{
+		{SourcePath: "/left/first.txt", DestinationPath: "/right/second.txt"},
+		{NodeID: second.ID, IfRevision: second.Revision, DestinationPath: "/left/first.txt"},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, first.ID, results[0].Node.ID)
+	assert.Equal(t, "/left/first.txt", results[0].FromPath)
+	assert.Equal(t, "/right/second.txt", results[0].Path)
+	assert.Equal(t, second.ID, results[1].Node.ID)
+	assert.Equal(t, "/right/second.txt", results[1].FromPath)
+	assert.Equal(t, "/left/first.txt", results[1].Path)
+
+	atRight, err := s.NodeByPath(ctx, "/right/second.txt")
+	require.NoError(t, err)
+	assert.Equal(t, first.ID, atRight.ID)
+	atLeft, err := s.NodeByPath(ctx, "/left/first.txt")
+	require.NoError(t, err)
+	assert.Equal(t, second.ID, atLeft.ID)
+}
+
+func TestBatchMoveSupportsNestedNetChanges(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	a, err := s.Mkdir(ctx, s.RootID(), "a")
+	require.NoError(t, err)
+	b, err := s.Mkdir(ctx, a.ID, "b")
+	require.NoError(t, err)
+	_, err = s.Mkdir(ctx, s.RootID(), "x")
+	require.NoError(t, err)
+	_, err = s.Mkdir(ctx, s.RootID(), "y")
+	require.NoError(t, err)
+	a, err = s.NodeByID(ctx, a.ID)
+	require.NoError(t, err)
+	b, err = s.NodeByID(ctx, b.ID)
+	require.NoError(t, err)
+
+	results, err := s.BatchMove(ctx, []BatchMoveRequest{
+		{NodeID: a.ID, IfRevision: a.Revision, DestinationPath: "/x/a"},
+		{NodeID: b.ID, IfRevision: b.Revision, DestinationPath: "/y/b"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/x/a", results[0].Path)
+	assert.Equal(t, "/y/b", results[1].Path)
+}
+
+func TestBatchMoveFailureRollsBackWholePlan(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	src, err := s.Mkdir(ctx, s.RootID(), "src")
+	require.NoError(t, err)
+	dst, err := s.Mkdir(ctx, s.RootID(), "dst")
+	require.NoError(t, err)
+	first, err := s.CreateFile(ctx, src.ID, "first.txt", fakeHash("first"), 5, "text/plain")
+	require.NoError(t, err)
+	second, err := s.CreateFile(ctx, src.ID, "second.txt", fakeHash("second"), 6, "text/plain")
+	require.NoError(t, err)
+
+	_, err = s.BatchMove(ctx, []BatchMoveRequest{
+		{NodeID: first.ID, IfRevision: first.Revision, DestinationPath: "/dst/first.txt"},
+		{NodeID: second.ID, IfRevision: second.Revision + 1, DestinationPath: "/dst/second.txt"},
+	})
+	require.ErrorIs(t, err, ErrStaleRevision)
+	_, err = s.NodeByPath(ctx, "/src/first.txt")
+	require.NoError(t, err)
+	_, err = s.NodeByPath(ctx, "/src/second.txt")
+	require.NoError(t, err)
+	children, err := s.Children(ctx, dst.ID)
+	require.NoError(t, err)
+	assert.Empty(t, children)
+}
+
+func TestBatchMoveRejectsDuplicateSourceAndFinalCycle(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	a, err := s.Mkdir(ctx, s.RootID(), "a")
+	require.NoError(t, err)
+	b, err := s.Mkdir(ctx, a.ID, "b")
+	require.NoError(t, err)
+	a, err = s.NodeByID(ctx, a.ID)
+	require.NoError(t, err)
+
+	_, err = s.BatchMove(ctx, []BatchMoveRequest{
+		{NodeID: a.ID, IfRevision: a.Revision, DestinationPath: "/renamed"},
+		{SourcePath: "/a", DestinationPath: "/other"},
+	})
+	require.ErrorIs(t, err, ErrInvalidBatchMove)
+
+	_, err = s.BatchMove(ctx, []BatchMoveRequest{
+		{NodeID: a.ID, IfRevision: a.Revision, DestinationPath: "/a/b/a"},
+		{NodeID: b.ID, IfRevision: b.Revision, DestinationPath: "/a/b"},
+	})
+	require.ErrorIs(t, err, ErrCycle)
+}

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -33,6 +33,9 @@ var (
 	// ErrInvalidVersionPrune means a history-pruning selector is absent,
 	// contradictory, or otherwise unsafe to execute.
 	ErrInvalidVersionPrune = errors.New("invalid version-prune selector")
+	// ErrInvalidBatchMove means a batch is empty, oversized, repeats a source,
+	// or does not identify each source in exactly one supported way.
+	ErrInvalidBatchMove = errors.New("invalid batch move")
 	// ErrAuditMutationUnsupported means an audited vault cannot perform a
 	// logical mutation until that mutation records its audit transition.
 	ErrAuditMutationUnsupported = errors.New("mutation is not supported for an audited vault")

--- a/types.go
+++ b/types.go
@@ -78,7 +78,7 @@ type MutationReceipt struct {
 
 // BatchMoveItem identifies one live source either by SourcePath or by stable
 // NodeID plus IfRevision. DestinationPath is an exact final coordinate
-// interpreted from the batch's initial tree.
+// whose parent is resolved in the batch's planned final tree.
 type BatchMoveItem struct {
 	SourcePath      string `json:"source_path,omitempty"`
 	NodeID          int64  `json:"node_id,omitempty"`

--- a/types.go
+++ b/types.go
@@ -77,8 +77,8 @@ type MutationReceipt struct {
 }
 
 // BatchMoveItem identifies one live source either by SourcePath or by stable
-// NodeID plus IfRevision. DestinationPath is interpreted from the batch's
-// initial tree.
+// NodeID plus IfRevision. DestinationPath is an exact final coordinate
+// interpreted from the batch's initial tree.
 type BatchMoveItem struct {
 	SourcePath      string `json:"source_path,omitempty"`
 	NodeID          int64  `json:"node_id,omitempty"`

--- a/types.go
+++ b/types.go
@@ -76,6 +76,28 @@ type MutationReceipt struct {
 	Path string `json:"path"`
 }
 
+// BatchMoveItem identifies one live source either by SourcePath or by stable
+// NodeID plus IfRevision. DestinationPath is interpreted from the batch's
+// initial tree.
+type BatchMoveItem struct {
+	SourcePath      string `json:"source_path,omitempty"`
+	NodeID          int64  `json:"node_id,omitempty"`
+	IfRevision      int64  `json:"if_revision,omitempty"`
+	DestinationPath string `json:"destination_path"`
+}
+
+// BatchMoveReceipt binds one request to its stable node and transactional
+// pre/post coordinates.
+type BatchMoveReceipt struct {
+	Node     Node   `json:"node"`
+	FromPath string `json:"from_path"`
+	Path     string `json:"path"`
+}
+
+// MaxBatchMoves is the largest all-or-nothing reorganization accepted by one
+// embedded or daemon operation.
+const MaxBatchMoves = store.MaxBatchMoves
+
 // TrashEmptyOptions bounds one trash-empty preview or execution. A zero
 // MaxRoots uses DefaultTrashEmptyMaxRoots. DryRun never deletes candidates.
 type TrashEmptyOptions struct {

--- a/vault.go
+++ b/vault.go
@@ -48,6 +48,7 @@ var (
 	ErrStaleRevision            = store.ErrStaleRevision
 	ErrCycle                    = store.ErrCycle
 	ErrInvalidName              = store.ErrInvalidName
+	ErrInvalidBatchMove         = store.ErrInvalidBatchMove
 	ErrNotTrashed               = store.ErrNotTrashed
 	ErrIsRoot                   = store.ErrIsRoot
 	ErrAuditMutationUnsupported = store.ErrAuditMutationUnsupported
@@ -319,6 +320,41 @@ func (v *Vault) MovePath(
 		return MutationReceipt{}, err
 	}
 	return MutationReceipt{Node: fromStoreNode(node), Path: canonicalPath}, nil
+}
+
+// BatchMove validates and applies one final-state reorganization as a single
+// metadata transaction. Results preserve request order. Path sources resolve
+// inside the transaction; stable node sources require a positive revision.
+func (v *Vault) BatchMove(
+	ctx context.Context, moves []BatchMoveItem,
+) ([]BatchMoveReceipt, error) {
+	if err := v.begin(); err != nil {
+		return nil, err
+	}
+	defer v.lifecycle.RUnlock()
+	requests := make([]store.BatchMoveRequest, len(moves))
+	for index, move := range moves {
+		requests[index] = store.BatchMoveRequest{
+			SourcePath: move.SourcePath, NodeID: move.NodeID, IfRevision: move.IfRevision,
+			DestinationPath: move.DestinationPath,
+		}
+	}
+	v.mutation.Lock()
+	defer v.mutation.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	results, err := v.metadata.BatchMove(ctx, requests)
+	if err != nil {
+		return nil, err
+	}
+	receipts := make([]BatchMoveReceipt, len(results))
+	for index, result := range results {
+		receipts[index] = BatchMoveReceipt{
+			Node: fromStoreNode(result.Node), FromPath: result.FromPath, Path: result.Path,
+		}
+	}
+	return receipts, nil
 }
 
 // TrashPath moves one live path and its subtree to trash, returning the

--- a/vault_external_test.go
+++ b/vault_external_test.go
@@ -74,6 +74,28 @@ func TestVaultMoveTrashRestoreExternalAPI(t *testing.T) {
 	require.True(t, report.DryRun)
 }
 
+func TestVaultMoveBatchExternalAPI(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	first, err := vault.Put(t.Context(), "/left/first.txt", strings.NewReader("first\n"), docbank.PutOptions{})
+	require.NoError(t, err)
+	second, err := vault.Put(t.Context(), "/right/second.txt", strings.NewReader("second\n"), docbank.PutOptions{})
+	require.NoError(t, err)
+
+	receipts, err := vault.BatchMove(t.Context(), []docbank.BatchMoveItem{
+		{SourcePath: "/left/first.txt", DestinationPath: "/right/second.txt"},
+		{NodeID: second.Node.ID, IfRevision: second.Node.Revision, DestinationPath: "/left/first.txt"},
+	})
+	require.NoError(t, err)
+	require.Len(t, receipts, 2)
+	require.Equal(t, first.Node.ID, receipts[0].Node.ID)
+	require.Equal(t, "/left/first.txt", receipts[0].FromPath)
+	require.Equal(t, "/right/second.txt", receipts[0].Path)
+	require.Equal(t, second.Node.ID, receipts[1].Node.ID)
+	require.Equal(t, "/left/first.txt", receipts[1].Path)
+}
+
 func TestTreeMutationErrorsAreClassifiableOutsidePackage(t *testing.T) {
 	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
 	require.NoError(t, err)


### PR DESCRIPTION
A person or agent can now reorganize several documents as one decision: either the complete final tree appears, or nothing moves.

For example, two files—or two directories—can exchange coordinates without inventing a temporary path:

```json
{"moves":[
  {"source":"/inbox/final.pdf","destination":"/filed/draft.pdf"},
  {"source":"id:42","destination":"/inbox/final.pdf"}
]}
```

`docbank mv batch plan.json` resolves every source against the starting tree, then resolves each exact destination parent in the planned final tree. That means one item can move beneath a directory relocated by another item, while a coordinate whose parent disappears is rejected. Docbank checks the complete final arrangement for missing parents, duplicate names, and cycles, and only then commits it. This matters because a shell loop around ordinary `mv` commits each step independently and cannot safely express swaps or nested reorganizations.

Batch destinations are exact final coordinates. Unlike ordinary `docbank mv`, an existing directory does not mean “move into this directory.” A plan that wants to retain `a.pdf` while moving it into `/filed` says `/filed/a.pdf`. This makes directory swaps such as `/left → /right` and `/right → /left` unambiguous, and permits a file to occupy a directory coordinate that another move vacates in the same transaction.

The source selector keeps its usual meaning. A path means “the node at this coordinate when the transaction begins.” An `id:N` source means “this exact node,” and is bound to the revision the CLI inspected. Receipts preserve plan order and report each stable node’s quoted prior path, final path, and resulting revision. Plans are capped at 1,000 moves so validation and responses remain bounded.

The same contract is available through the authenticated API, typed client, and `Vault.BatchMove` for embedded applications. If permanent audit retention is active, the entire reorganization becomes one canonical audited operation rather than a misleading sequence of intermediate moves. A daemon protocol bump ensures a new CLI replaces an older process that does not understand the endpoint.
