### PR TITLE
Browse permanent history across an audit scope

### DIFF
--- a/cmd/docbank/audit_history.go
+++ b/cmd/docbank/audit_history.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	auditHistoryNodeID int64
+	auditHistoryScope  string
 	auditHistoryLimit  int
 	auditHistoryCursor string
 	auditHistoryJSON   bool
@@ -20,19 +21,30 @@ var (
 
 var auditHistoryCmd = &cobra.Command{
 	Use:   "history [path-or-id]",
-	Short: "Read one permanently protected node's canonical event timeline",
+	Short: "Read canonical events for one protected node or scope",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		nodeIDSet := cmd.Flags().Changed("node-id")
-		if (len(args) == 1) == nodeIDSet {
+		scopeSet := cmd.Flags().Changed("scope")
+		selectors := len(args)
+		if nodeIDSet {
+			selectors++
+		}
+		if scopeSet {
+			selectors++
+		}
+		if selectors != 1 {
 			return usageError(errors.New(
-				"audit history requires exactly one path or --node-id"))
+				"audit history requires exactly one path, --node-id, or --scope"))
 		}
 		if auditHistoryLimit < 1 || auditHistoryLimit > 500 {
 			return usageError(errors.New("audit history --limit must be between 1 and 500"))
 		}
 		if nodeIDSet && auditHistoryNodeID < 1 {
 			return usageError(errors.New("audit history --node-id must be positive"))
+		}
+		if scopeSet && !client.IsCanonicalUUIDv4(auditHistoryScope) {
+			return usageError(errors.New("audit history --scope must be a canonical UUIDv4"))
 		}
 		path := ""
 		nodeID := auditHistoryNodeID
@@ -50,6 +62,18 @@ var auditHistoryCmd = &cobra.Command{
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
 			return err
+		}
+		if scopeSet {
+			page, err := c.AuditScopeHistory(
+				cmd.Context(), auditHistoryScope, auditHistoryLimit, auditHistoryCursor,
+			)
+			if err != nil {
+				return err
+			}
+			if auditHistoryJSON {
+				return writeAuditJSON(cmd.OutOrStdout(), page)
+			}
+			return writeAuditScopeHistory(cmd.OutOrStdout(), page)
 		}
 		page, err := c.AuditHistory(
 			cmd.Context(), path, nodeID, auditHistoryLimit, auditHistoryCursor,
@@ -79,9 +103,40 @@ func writeAuditHistory(w io.Writer, page api.AuditEventPage) error {
 			return fmt.Errorf("writing audit history: %w", err)
 		}
 	}
-	for _, event := range page.Items {
-		if _, err := fmt.Fprintf(w, "%s  %s  operation %d.%d  revision %d -> %d\n",
-			event.RecordedAt, event.Kind, event.OperationSequence, event.Ordinal,
+	if err := writeAuditEvents(w, page.Items, false); err != nil {
+		return err
+	}
+	return writeAuditNextCursor(w, page.NextCursor)
+}
+
+func writeAuditScopeHistory(w io.Writer, page api.AuditScopeEventPage) error {
+	coordinate := auditDisplayPath(page.Scope.TargetPath)
+	if page.Scope.TargetTrashed {
+		coordinate = formatNodeSelector(page.Scope.TargetNodeID) + " in trash"
+	}
+	if _, err := fmt.Fprintf(w, "audit history for scope %s at %s: %d recorded event(s)\n",
+		page.Scope.ID, coordinate, page.Total); err != nil {
+		return fmt.Errorf("writing audit scope history: %w", err)
+	}
+	if len(page.Items) == 0 {
+		if _, err := fmt.Fprintln(w, "no events on this page; the scope remains permanent"); err != nil {
+			return fmt.Errorf("writing audit scope history: %w", err)
+		}
+	}
+	if err := writeAuditEvents(w, page.Items, true); err != nil {
+		return err
+	}
+	return writeAuditNextCursor(w, page.NextCursor)
+}
+
+func writeAuditEvents(w io.Writer, events []api.AuditEvent, includeNode bool) error {
+	for _, event := range events {
+		node := ""
+		if includeNode {
+			node = "  " + formatNodeSelector(event.NodeID)
+		}
+		if _, err := fmt.Fprintf(w, "%s  %s%s  operation %d.%d  revision %d -> %d\n",
+			event.RecordedAt, event.Kind, node, event.OperationSequence, event.Ordinal,
 			event.PriorNodeRevision, event.ResultingNodeRevision); err != nil {
 			return fmt.Errorf("writing audit history: %w", err)
 		}
@@ -110,8 +165,12 @@ func writeAuditHistory(w io.Writer, page api.AuditEventPage) error {
 			}
 		}
 	}
-	if page.NextCursor != "" {
-		if _, err := fmt.Fprintln(w, "next cursor: "+page.NextCursor); err != nil {
+	return nil
+}
+
+func writeAuditNextCursor(w io.Writer, cursor string) error {
+	if cursor != "" {
+		if _, err := fmt.Fprintln(w, "next cursor: "+cursor); err != nil {
 			return fmt.Errorf("writing audit history: %w", err)
 		}
 	}
@@ -175,6 +234,8 @@ func auditOptionalValue(value *string) string {
 func init() {
 	auditHistoryCmd.Flags().Int64Var(&auditHistoryNodeID, "node-id", 0,
 		"stable node ID, including a node in trash (alternative to path)")
+	auditHistoryCmd.Flags().StringVar(&auditHistoryScope, "scope", "",
+		"stable audit scope ID (alternative to a node path or ID)")
 	auditHistoryCmd.Flags().IntVar(&auditHistoryLimit, "limit", 50,
 		"maximum events to return (1-500)")
 	auditHistoryCmd.Flags().StringVar(&auditHistoryCursor, "cursor", "",

--- a/cmd/docbank/audit_test.go
+++ b/cmd/docbank/audit_test.go
@@ -81,6 +81,21 @@ func TestHumanAuditHistoryUsesCopyableNodeSelectors(t *testing.T) {
 	assert.NotContains(t, output.String(), "node 42")
 }
 
+func TestHumanAuditScopeHistoryQuotesTargetAndNamesEventNodes(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, writeAuditScopeHistory(&output, api.AuditScopeEventPage{
+		Scope: api.AuditScopeStatus{
+			ID:           "33333333-3333-4333-8333-333333333333",
+			TargetNodeID: 7, TargetPath: "/Taxes/\n\x1b[31mFORGED",
+		},
+		Items: []api.AuditEvent{{NodeID: 42, Kind: "content_replace"}},
+		Total: 1,
+	}))
+	assert.Contains(t, output.String(), strconv.QuoteToASCII("/Taxes/\n\x1b[31mFORGED"))
+	assert.Contains(t, output.String(), "id:42")
+	assert.NotContains(t, output.String(), "/Taxes/\n\x1b[31mFORGED")
+}
+
 func TestAuditRetentionDisclosureNamesEveryMetadataClass(t *testing.T) {
 	var output bytes.Buffer
 	require.NoError(t, writeAuditPreview(&output, api.AuditEnrollmentPreview{}))

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -361,6 +361,18 @@ func TestAuditEnableIsPreviewFirstAndReportsProtection(t *testing.T) {
 	assert.Contains(t, humanHistory, "content_replace")
 	assert.Contains(t, humanHistory, `audit history for "/Taxes/return.txt"`)
 
+	out, err = runCLI(t, "audit", "history", "--scope", preview.ScopeID, "--json")
+	require.NoError(t, err, out)
+	var scopeHistory api.AuditScopeEventPage
+	require.NoError(t, json.Unmarshal([]byte(out), &scopeHistory))
+	assert.Equal(t, preview.ScopeID, scopeHistory.Scope.ID)
+	assert.Equal(t, "/Taxes", scopeHistory.Scope.TargetPath)
+	require.NotEmpty(t, scopeHistory.Items)
+	humanScopeHistory, err := runCLI(t, "audit", "history", "--scope", preview.ScopeID)
+	require.NoError(t, err, humanScopeHistory)
+	assert.Contains(t, humanScopeHistory, "audit history for scope "+preview.ScopeID)
+	assert.Contains(t, humanScopeHistory, formatNodeSelector(returnNode.ID))
+
 	_, err = runCLI(t, "audit", "enable", "--run", "--token", preview.PreviewToken,
 		"--acknowledge-permanent-retention")
 	require.ErrorIs(t, err, store.ErrAuditPreviewStale)

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "25", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "26", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "25", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "26", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "25", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "26", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -600,6 +600,20 @@ retention, and `invalid_audit_cursor` as a request error. A protected node may
 have an empty timeline when it was adopted at enrollment and has not changed;
 use status membership, not event count, to decide protection.
 
+To answer “what changed anywhere in this protected scope?”, use the stable
+scope ID returned by audit status:
+
+```bash
+curl --fail-with-body \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  "$DOCBANK_URL/api/v1/audit/scopes/<scope-id>/history?limit=50"
+```
+
+The page includes current scope evidence and events from every protected
+member. Reconcile each event's `scope_id`, retain its `node_id` as the stable
+subject, and follow `next_cursor` unchanged. Scope cursors are bound to that
+scope and remain append-stable when newer events arrive.
+
 Independently replay the authority and hash every protected blob with:
 
 ```bash

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -39,6 +39,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /nodes/{id}/tags` · `GET /tags/{tag_id}/nodes` · `PUT\|DELETE /nodes/{id}/tags/{tag_id}` · `PUT\|DELETE /path/tags/{tag_id}` | inspect and change tag assignments | Implemented |
 | `POST /audit/preview` · `POST /audit/enable` · `GET /audit/status` | review permanent first-scope retention, enable the exact reviewed plan, and inspect authority or membership | Implemented |
 | `GET /audit/history?path=&node_id=&limit=&cursor=` | read one audited node's canonical newest-first event timeline with a stable continuation cursor | Implemented |
+| `GET /audit/scopes/{scope_id}/history?limit=&cursor=` | read canonical newest-first events across every member of one permanent scope | Implemented |
 | `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&limit=` | bounded name and extracted-content search (FTS5), with match source and explicit `truncated` status | Implemented |
@@ -496,7 +497,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `audit_preview_stale` | 409 | the one-use enrollment preview expired, was consumed, came from another daemon, or no longer matches the vault |
 | `audit_acknowledgment_required` | 422 | enrollment execution omitted the explicit permanent-retention acknowledgment |
 | `audit_not_enrolled` | 422 | the selected node exists but is outside every permanent audit scope |
-| `invalid_audit_cursor` | 422 | the history cursor is malformed or belongs to another stable node |
+| `invalid_audit_cursor` | 422 | the history cursor is malformed or belongs to another stable node or scope |
 | `invalid_batch_move` | 422 | a batch has no moves, too many moves, ambiguous selectors, or an invalid final-state plan |
 | `stale_revision` | 412 | `store.ErrStaleRevision` — `If-Match` didn't match the current revision |
 | `not_dir` / `not_file` / `invalid_name` / `invalid_tag` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrInvalidTag` / `ErrNotTrashed` / `ErrIsRoot` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -419,6 +419,7 @@ docbank audit status [path-or-id] [--json]
 docbank audit status --node-id <id> [--json]
 docbank audit history <path-or-id> [--limit <n>] [--cursor <cursor>] [--json]
 docbank audit history --node-id <id> [--limit <n>] [--cursor <cursor>] [--json]
+docbank audit history --scope <scope-id> [--limit <n>] [--cursor <cursor>] [--json]
 docbank audit verify [--expected <prior-json-report>] [--json]
 ```
 
@@ -453,6 +454,11 @@ cursor is opaque and bound to its stable node. Use `--node-id` for a moved or
 trashed node. A protected enrollment-baseline member can legitimately have no
 node-specific events until its first later mutation; use `audit status` for
 membership authority.
+
+`audit history --scope <scope-id>` reads the same canonical events across all
+members of one permanent scope. Human output names each event's copyable node
+selector; JSON includes the complete scope status alongside the page. Its
+cursor is bound to the stable scope rather than one node.
 
 `audit verify` independently replays canonical history against current
 metadata, then re-hashes every unique blob retained by protected versions. Its

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,15 +106,15 @@ nested reorganizations as one final-state operation across the CLI, API, typed
 client, and audited history. Permanent first-scope audit enrollment is preview-first across the
 CLI and API. Sticky membership, supported logical mutations, allocation and
 scope chains, status evidence, and JSONL backup/restore validation are
-implemented. One-node canonical audit history is available by path or stable ID
-with bounded, append-stable cursor pagination. Independent verification returns
+implemented. Canonical audit history is available by node path, stable node ID,
+or stable scope ID with bounded, append-stable cursor pagination. Independent verification returns
 stable terminal evidence, checks every protected blob, and can prove that
 current allocation and scope chains extend an externally recorded bundle.
 Daemon-owned watched inboxes recursively observe configured local directories,
 wait for stable size and modification time, preserve portable source identity,
 and append later changes to the same stable node without touching source files.
 
-- Additional and overlapping audit scopes and scope-wide history browsing
+- Additional and overlapping audit scopes
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
 - Tag/MIME/date/path search filters

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -138,6 +138,26 @@ A protected node adopted during first enrollment may have no node-specific
 events until its first later change. That empty timeline does not weaken its
 baseline protection; `audit status` is the membership authority.
 
+## Read a scope's history
+
+Use the stable scope ID reported by `audit status` to read every canonical
+event across its protected members:
+
+```bash
+docbank audit history --scope <scope-id>
+docbank audit history --scope <scope-id> --limit 100 --json
+```
+
+Scope history answers “what changed anywhere under this permanent promise?”
+without walking each member separately. Each event includes its stable node ID,
+and human output prints that copyable `id:N` selector. The response also carries
+the scope target, baseline, member count, entry count, and current chain head so
+the timeline stays attached to its evidence authority.
+
+Pagination uses the same newest-first ordering as node history. A scope cursor
+is opaque, bound to that stable scope ID, and remains stable when later events
+are appended. Reusing it with another scope returns `invalid_audit_cursor`.
+
 ## Verify the permanent evidence
 
 Run the audit-specific verifier when you need a compact proof of the permanent
@@ -203,6 +223,6 @@ yet exposed. Status, mutation recording, JSONL export/import, and backup capture
 all preserve the first scope's authority.
 
 !!! info "Planned"
-    Additional scope enrollment, scope-wide history, and rich TUI/web history
-    views are not implemented yet. Backup restore already revalidates the
-    portable JSONL authority before publishing a vault.
+    Additional scope enrollment and rich TUI/web history views are not
+    implemented yet. Backup restore already revalidates the portable JSONL
+    authority before publishing a vault.

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -15,6 +15,7 @@ import (
 type auditPreviewOutput struct{ Body AuditEnrollmentPreview }
 type auditStatusOutput struct{ Body AuditStatus }
 type auditHistoryOutput struct{ Body AuditEventPage }
+type auditScopeHistoryOutput struct{ Body AuditScopeEventPage }
 type auditVerifyOutput struct{ Body AuditVerifyReport }
 
 func registerAuditRoutes(
@@ -224,6 +225,28 @@ func registerAuditRoutes(
 		}
 		return &auditHistoryOutput{Body: auditEventPage(page)}, nil
 	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "auditScopeHistory", Method: http.MethodGet,
+		Path:    "/api/v1/audit/scopes/{scope_id}/history",
+		Summary: "Read canonical events across one permanent audit scope",
+		Description: "Returns newest-first canonical events across every member of " +
+			"one stable scope. Use next_cursor to continue without shifting when newer " +
+			"events arrive.",
+	}, func(ctx context.Context, in *struct {
+		ScopeID string `path:"scope_id" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"`
+		Limit   int    `query:"limit" default:"50" minimum:"1" maximum:"500"`
+		Cursor  string `query:"cursor" maxLength:"256"`
+	}) (*auditScopeHistoryOutput, error) {
+		if err := store.ValidateAuditScopeHistoryCursor(in.Cursor, in.ScopeID); err != nil {
+			return nil, FromStoreError(err)
+		}
+		page, err := d.Store.AuditScopeHistory(ctx, in.ScopeID, in.Limit, in.Cursor)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return &auditScopeHistoryOutput{Body: auditScopeEventPage(page)}, nil
+	})
 }
 
 func storeAuditEvidence(evidence AuditEvidence) store.AuditEvidence {
@@ -297,12 +320,7 @@ func auditStatus(status store.AuditStatus) AuditStatus {
 		AllocationHead:             status.AllocationHead, Scopes: []AuditScopeStatus{},
 	}
 	for _, scope := range status.Scopes {
-		out.Scopes = append(out.Scopes, AuditScopeStatus{
-			ID: scope.ID, TargetNodeID: scope.TargetNodeID, TargetPath: scope.TargetPath,
-			TargetTrashed: scope.TargetTrashed, EnableOperationID: scope.EnableOperationID,
-			BaselineDigest: scope.BaselineDigest, MemberCount: scope.MemberCount,
-			EntryCount: scope.EntryCount, ChainHead: scope.ChainHead,
-		})
+		out.Scopes = append(out.Scopes, auditScopeStatus(scope))
 	}
 	if status.Membership != nil {
 		out.Membership = &AuditMembershipStatus{
@@ -318,26 +336,52 @@ func auditStatus(status store.AuditStatus) AuditStatus {
 func auditEventPage(page store.AuditEventPage) AuditEventPage {
 	out := AuditEventPage{
 		Node: fromStoreNode(page.Node), Path: page.Path,
-		Items: []AuditEvent{}, Total: page.Total, Limit: page.Limit,
+		Items: auditEvents(page.Items), Total: page.Total, Limit: page.Limit,
 		Cursor: page.Cursor, NextCursor: page.NextCursor,
 	}
-	for _, event := range page.Items {
-		out.Items = append(out.Items, AuditEvent{
-			ID: event.ID, OperationID: event.OperationID,
-			OperationSequence: event.OperationSequence, Ordinal: event.Ordinal,
-			NodeID: event.NodeID, Kind: event.Kind, ScopeID: event.ScopeID,
-			RecordedAt: event.RecordedAt, Origin: event.Origin, AgentLabel: event.AgentLabel,
-			PriorNodeRevision:         event.PriorNodeRevision,
-			ResultingNodeRevision:     event.ResultingNodeRevision,
-			PriorCurrentVersionID:     event.PriorCurrentVersionID,
-			ResultingCurrentVersionID: event.ResultingCurrentVersionID,
-			SourceVersionID:           event.SourceVersionID, TargetNodeID: event.TargetNodeID,
-			BaselineDigest: event.BaselineDigest,
-			Attachment:     auditAttachmentChange(event.Attachment),
-			OldPath:        auditPathState(event.OldPath), NewPath: auditPathState(event.NewPath),
-		})
+	return out
+}
+
+func auditScopeEventPage(page store.AuditScopeEventPage) AuditScopeEventPage {
+	return AuditScopeEventPage{
+		Scope: auditScopeStatus(page.Scope), Items: auditEvents(page.Items),
+		Total: page.Total, Limit: page.Limit,
+		Cursor: page.Cursor, NextCursor: page.NextCursor,
+	}
+}
+
+func auditScopeStatus(scope store.AuditScopeStatus) AuditScopeStatus {
+	return AuditScopeStatus{
+		ID: scope.ID, TargetNodeID: scope.TargetNodeID, TargetPath: scope.TargetPath,
+		TargetTrashed: scope.TargetTrashed, EnableOperationID: scope.EnableOperationID,
+		BaselineDigest: scope.BaselineDigest, MemberCount: scope.MemberCount,
+		EntryCount: scope.EntryCount, ChainHead: scope.ChainHead,
+	}
+}
+
+func auditEvents(events []store.AuditEvent) []AuditEvent {
+	out := make([]AuditEvent, 0, len(events))
+	for _, event := range events {
+		out = append(out, auditEvent(event))
 	}
 	return out
+}
+
+func auditEvent(event store.AuditEvent) AuditEvent {
+	return AuditEvent{
+		ID: event.ID, OperationID: event.OperationID,
+		OperationSequence: event.OperationSequence, Ordinal: event.Ordinal,
+		NodeID: event.NodeID, Kind: event.Kind, ScopeID: event.ScopeID,
+		RecordedAt: event.RecordedAt, Origin: event.Origin, AgentLabel: event.AgentLabel,
+		PriorNodeRevision:         event.PriorNodeRevision,
+		ResultingNodeRevision:     event.ResultingNodeRevision,
+		PriorCurrentVersionID:     event.PriorCurrentVersionID,
+		ResultingCurrentVersionID: event.ResultingCurrentVersionID,
+		SourceVersionID:           event.SourceVersionID, TargetNodeID: event.TargetNodeID,
+		BaselineDigest: event.BaselineDigest,
+		Attachment:     auditAttachmentChange(event.Attachment),
+		OldPath:        auditPathState(event.OldPath), NewPath: auditPathState(event.NewPath),
+	}
 }
 
 func auditPathState(value *store.AuditPathState) *AuditPathState {

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -135,6 +135,24 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	assert.Equal(t, "/source/taxes/receipt.txt",
 		*provenanceEvent.Attachment.After.OriginalPath)
 
+	scopeHistory, err := c.AuditScopeHistory(t.Context(), preview.ScopeID, 2, "")
+	require.NoError(t, err)
+	assert.Equal(t, preview.ScopeID, scopeHistory.Scope.ID)
+	assert.Equal(t, taxes.ID, scopeHistory.Scope.TargetNodeID)
+	assert.Equal(t, "/Taxes", scopeHistory.Scope.TargetPath)
+	assert.Greater(t, scopeHistory.Total, 2)
+	require.Len(t, scopeHistory.Items, 2)
+	require.NotEmpty(t, scopeHistory.NextCursor)
+	for _, event := range scopeHistory.Items {
+		assert.Equal(t, preview.ScopeID, event.ScopeID)
+	}
+	scopeHistoryNext, err := c.AuditScopeHistory(
+		t.Context(), preview.ScopeID, 2, scopeHistory.NextCursor,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, scopeHistoryNext.Items)
+	assert.Equal(t, scopeHistory.Total, scopeHistoryNext.Total)
+
 	_, err = c.AuditHistory(t.Context(), "", s.RootID(), 10, "")
 	require.ErrorIs(t, err, store.ErrAuditNotEnrolled)
 
@@ -143,6 +161,13 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	), nil, nil)
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	var cursorProblem api.Error
+	require.NoError(t, json.Unmarshal([]byte(raw), &cursorProblem))
+	assert.Equal(t, "invalid_audit_cursor", cursorProblem.Code)
+
+	resp, raw = do(t, ts, http.MethodGet, fmt.Sprintf(
+		"/api/v1/audit/scopes/%s/history?limit=10&cursor=bad", preview.ScopeID,
+	), nil, nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	require.NoError(t, json.Unmarshal([]byte(raw), &cursorProblem))
 	assert.Equal(t, "invalid_audit_cursor", cursorProblem.Code)
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -371,6 +371,17 @@ type AuditEventPage struct {
 	NextCursor string       `json:"next_cursor,omitempty"`
 }
 
+// AuditScopeEventPage is a newest-first, cursor-stable timeline across one
+// permanent scope.
+type AuditScopeEventPage struct {
+	Scope      AuditScopeStatus `json:"scope"`
+	Items      []AuditEvent     `json:"items"`
+	Total      int              `json:"total" minimum:"0"`
+	Limit      int              `json:"limit" minimum:"1" maximum:"500"`
+	Cursor     string           `json:"cursor,omitempty"`
+	NextCursor string           `json:"next_cursor,omitempty"`
+}
+
 // ContentVerification binds a fresh physical read to the exact node revision
 // the caller inspected. BlobHash and Size are catalog identity; ComputedHash
 // and ComputedSize describe the bytes read through the mixed store.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -853,6 +853,37 @@ func (c *Client) AuditHistory(
 	return page, nil
 }
 
+// AuditScopeHistory returns one stable newest-first page across every member
+// of one permanent audit scope.
+func (c *Client) AuditScopeHistory(
+	ctx context.Context, scopeID string, limit int, cursor string,
+) (api.AuditScopeEventPage, error) {
+	var page api.AuditScopeEventPage
+	if !validUUIDv4(scopeID) {
+		return page, errors.New("audit scope history requires a canonical UUIDv4 scope ID")
+	}
+	if limit < 1 || limit > 500 {
+		return page, errors.New("audit scope history limit must be between 1 and 500")
+	}
+	if err := store.ValidateAuditScopeHistoryCursor(cursor, scopeID); err != nil {
+		return page, err
+	}
+	query := url.Values{}
+	query.Set("limit", strconv.Itoa(limit))
+	if cursor != "" {
+		query.Set("cursor", cursor)
+	}
+	requestPath := "/api/v1/audit/scopes/" + url.PathEscape(scopeID) +
+		"/history?" + query.Encode()
+	if err := c.do(ctx, http.MethodGet, requestPath, nil, nil, &page); err != nil {
+		return page, err
+	}
+	if err := validateAuditScopeEventPage(page, scopeID, limit, cursor); err != nil {
+		return api.AuditScopeEventPage{}, err
+	}
+	return page, nil
+}
+
 func validateAuditEventPage(page api.AuditEventPage, requestedNodeID int64, limit int, cursor string) error {
 	if page.Node.ID < 1 || (requestedNodeID != 0 && page.Node.ID != requestedNodeID) ||
 		page.Limit != limit || page.Cursor != cursor || page.Total < len(page.Items) ||
@@ -879,10 +910,43 @@ func validateAuditEventPage(page api.AuditEventPage, requestedNodeID int64, limi
 	return nil
 }
 
+func validateAuditScopeEventPage(
+	page api.AuditScopeEventPage, scopeID string, limit int, cursor string,
+) error {
+	if page.Scope.ID != scopeID || page.Limit != limit || page.Cursor != cursor ||
+		page.Total < len(page.Items) || len(page.Items) > limit {
+		return errors.New("audit scope history response has inconsistent scope or pagination")
+	}
+	if err := validateAuditScopeStatus(page.Scope); err != nil {
+		return fmt.Errorf("audit scope history response: %w", err)
+	}
+	if err := store.ValidateAuditScopeHistoryCursor(cursor, scopeID); err != nil {
+		return err
+	}
+	if err := store.ValidateAuditScopeHistoryCursor(page.NextCursor, scopeID); err != nil {
+		return err
+	}
+	if page.NextCursor != "" && len(page.Items) != limit {
+		return errors.New("audit scope history response has a premature next cursor")
+	}
+	for i, event := range page.Items {
+		if event.ScopeID != scopeID {
+			return fmt.Errorf("audit scope history item %d belongs to another scope", i)
+		}
+		if err := validateAuditEvent(event, event.NodeID); err != nil {
+			return fmt.Errorf("audit scope history item %d: %w", i, err)
+		}
+		if i > 0 && !auditEventPrecedes(page.Items[i-1], event) {
+			return errors.New("audit scope history response is not newest first")
+		}
+	}
+	return nil
+}
+
 func validateAuditEvent(event api.AuditEvent, nodeID int64) error {
 	recordedAt, timeErr := time.Parse(time.RFC3339Nano, event.RecordedAt)
 	if !validSHA256Hex(event.ID) || !validUUIDv4(event.OperationID) ||
-		event.OperationSequence < 1 || event.Ordinal < 0 || event.NodeID != nodeID ||
+		event.OperationSequence < 1 || event.Ordinal < 0 || event.NodeID < 1 || event.NodeID != nodeID ||
 		event.Kind == "" || !validUUIDv4(event.ScopeID) || event.Origin == "" ||
 		timeErr != nil || recordedAt.Location() != time.UTC ||
 		event.PriorNodeRevision < 0 || event.ResultingNodeRevision < 0 ||
@@ -1071,12 +1135,8 @@ func validateAuditStatus(status api.AuditStatus) error {
 	previousScopeID := ""
 	for index, scope := range status.Scopes {
 		_, duplicate := seen[scope.ID]
-		if !validUUIDv4(scope.ID) || duplicate ||
-			(previousScopeID != "" && scope.ID <= previousScopeID) || scope.TargetNodeID < 1 ||
-			(!scope.TargetTrashed && !strings.HasPrefix(scope.TargetPath, "/")) ||
-			(scope.TargetTrashed && scope.TargetPath != "") ||
-			!validUUIDv4(scope.EnableOperationID) || !validSHA256Hex(scope.BaselineDigest) ||
-			scope.MemberCount < 1 || scope.EntryCount < 1 || !validSHA256Hex(scope.ChainHead) {
+		if duplicate || (previousScopeID != "" && scope.ID <= previousScopeID) ||
+			validateAuditScopeStatus(scope) != nil {
 			return fmt.Errorf("audit status scope %d has invalid authority", index)
 		}
 		seen[scope.ID] = scopeMembershipAuthority{
@@ -1104,6 +1164,17 @@ func validateAuditStatus(status api.AuditStatus) error {
 			}
 			previousScopeID = scopeID
 		}
+	}
+	return nil
+}
+
+func validateAuditScopeStatus(scope api.AuditScopeStatus) error {
+	if !validUUIDv4(scope.ID) || scope.TargetNodeID < 1 ||
+		(!scope.TargetTrashed && !strings.HasPrefix(scope.TargetPath, "/")) ||
+		(scope.TargetTrashed && scope.TargetPath != "") ||
+		!validUUIDv4(scope.EnableOperationID) || !validSHA256Hex(scope.BaselineDigest) ||
+		scope.MemberCount < 1 || scope.EntryCount < 1 || !validSHA256Hex(scope.ChainHead) {
+		return errors.New("audit scope has invalid authority")
 	}
 	return nil
 }

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "25"
+	daemonProtocolVersion = "26"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/audit_history.go
+++ b/internal/store/audit_history.go
@@ -86,8 +86,25 @@ type AuditEventPage struct {
 	NextCursor string
 }
 
+// AuditScopeEventPage is a stable newest-first page across one audit scope.
+type AuditScopeEventPage struct {
+	Scope      AuditScopeStatus
+	Items      []AuditEvent
+	Total      int
+	Limit      int
+	Cursor     string
+	NextCursor string
+}
+
 type auditHistoryCursor struct {
 	nodeID   int64
+	sequence int64
+	ordinal  int64
+	eventID  string
+}
+
+type auditScopeHistoryCursor struct {
+	scopeID  string
 	sequence int64
 	ordinal  int64
 	eventID  string
@@ -109,6 +126,131 @@ func (s *Store) AuditHistoryPath(
 	return s.auditHistorySnapshot(ctx, limit, cursor, func(tx *sql.Tx) (Node, error) {
 		return nodeByPath(ctx, tx, s.rootID, path)
 	})
+}
+
+// AuditScopeHistory returns one bounded page across a stable audit scope.
+func (s *Store) AuditScopeHistory(
+	ctx context.Context, scopeID string, limit int, cursor string,
+) (AuditScopeEventPage, error) {
+	if limit < 1 || limit > maxAuditHistoryPage {
+		return AuditScopeEventPage{}, fmt.Errorf(
+			"audit history limit must be between 1 and %d", maxAuditHistoryPage,
+		)
+	}
+	decoded, err := decodeAuditScopeHistoryCursor(cursor, scopeID)
+	if err != nil {
+		return AuditScopeEventPage{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return AuditScopeEventPage{}, fmt.Errorf("starting audit-scope-history snapshot: %w", err)
+	}
+	page, err := auditScopeHistoryPageTx(ctx, tx, scopeID, limit, cursor, decoded)
+	if err != nil {
+		_ = tx.Rollback()
+		return AuditScopeEventPage{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AuditScopeEventPage{}, fmt.Errorf("closing audit-scope-history snapshot: %w", err)
+	}
+	return page, nil
+}
+
+func auditScopeHistoryPageTx(
+	ctx context.Context, tx *sql.Tx, scopeID string, limit int, rawCursor string,
+	cursor auditScopeHistoryCursor,
+) (AuditScopeEventPage, error) {
+	scope, err := auditScopeStatusByIDTx(ctx, tx, scopeID)
+	if err != nil {
+		return AuditScopeEventPage{}, err
+	}
+	page := AuditScopeEventPage{
+		Scope: scope, Items: make([]AuditEvent, 0, limit), Limit: limit, Cursor: rawCursor,
+	}
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM audit_records WHERE kind='event' AND scope_id=?`, scopeID,
+	).Scan(&page.Total); err != nil {
+		return AuditScopeEventPage{}, fmt.Errorf("counting audit scope %s history: %w", scopeID, err)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT e.record_json,m.operation_sequence
+		FROM audit_records AS e
+		JOIN audit_records AS m
+		  ON m.kind='canonical_mutation' AND m.operation_id=e.operation_id
+		WHERE e.kind='event' AND e.scope_id=? AND
+		  (?=0 OR m.operation_sequence<? OR
+		   (m.operation_sequence=? AND e.event_ordinal<?) OR
+		   (m.operation_sequence=? AND e.event_ordinal=? AND e.event_id<?))
+		ORDER BY m.operation_sequence DESC,e.event_ordinal DESC,e.event_id DESC
+		LIMIT ?`, scopeID,
+		cursor.sequence, cursor.sequence,
+		cursor.sequence, cursor.ordinal,
+		cursor.sequence, cursor.ordinal, cursor.eventID,
+		limit+1,
+	)
+	if err != nil {
+		return AuditScopeEventPage{}, fmt.Errorf("listing audit scope %s history: %w", scopeID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var raw string
+		var sequence int64
+		if err := rows.Scan(&raw, &sequence); err != nil {
+			return AuditScopeEventPage{}, fmt.Errorf("scanning audit scope history: %w", err)
+		}
+		event, err := projectAuditEvent([]byte(raw), sequence)
+		if err != nil {
+			return AuditScopeEventPage{}, err
+		}
+		page.Items = append(page.Items, event)
+	}
+	if err := rows.Err(); err != nil {
+		return AuditScopeEventPage{}, fmt.Errorf("listing audit scope %s history: %w", scopeID, err)
+	}
+	if len(page.Items) > limit {
+		page.Items = page.Items[:limit]
+		last := page.Items[len(page.Items)-1]
+		page.NextCursor = encodeAuditScopeHistoryCursor(auditScopeHistoryCursor{
+			scopeID: scopeID, sequence: last.OperationSequence,
+			ordinal: last.Ordinal, eventID: last.ID,
+		})
+	}
+	return page, nil
+}
+
+func auditScopeStatusByIDTx(
+	ctx context.Context, tx *sql.Tx, scopeID string,
+) (AuditScopeStatus, error) {
+	var scope AuditScopeStatus
+	err := tx.QueryRowContext(ctx, `SELECT s.scope_id,s.target_node_id,
+		s.enable_operation_id,b.digest,s.entry_count,s.chain_head,COUNT(m.node_id)
+		FROM audit_scopes s
+		JOIN audit_baselines b ON b.scope_id=s.scope_id AND b.operation_id=s.enable_operation_id
+		JOIN audit_memberships m ON m.scope_id=s.scope_id
+		WHERE s.scope_id=?
+		GROUP BY s.scope_id,s.target_node_id,s.enable_operation_id,b.digest,
+			s.entry_count,s.chain_head`, scopeID).Scan(
+		&scope.ID, &scope.TargetNodeID, &scope.EnableOperationID,
+		&scope.BaselineDigest, &scope.EntryCount, &scope.ChainHead, &scope.MemberCount,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AuditScopeStatus{}, fmt.Errorf("audit scope %s: %w", scopeID, ErrNotFound)
+	}
+	if err != nil {
+		return AuditScopeStatus{}, fmt.Errorf("reading audit scope %s: %w", scopeID, err)
+	}
+	target, err := nodeByIDTx(tx, scope.TargetNodeID)
+	if err != nil {
+		return AuditScopeStatus{}, err
+	}
+	scope.TargetTrashed = target.TrashedAt != nil
+	if !scope.TargetTrashed {
+		scope.TargetPath, err = pathOf(ctx, tx, scope.TargetNodeID)
+		if err != nil {
+			return AuditScopeStatus{}, err
+		}
+	}
+	return scope, nil
 }
 
 func (s *Store) auditHistorySnapshot(
@@ -635,4 +777,42 @@ func auditEventIsAfterCursor(event AuditEvent, cursor auditHistoryCursor) bool {
 		(event.OperationSequence == cursor.sequence && event.Ordinal < cursor.ordinal) ||
 		(event.OperationSequence == cursor.sequence && event.Ordinal == cursor.ordinal &&
 			event.ID < cursor.eventID)
+}
+
+// ValidateAuditScopeHistoryCursor checks that an opaque cursor belongs to scopeID.
+func ValidateAuditScopeHistoryCursor(raw, scopeID string) error {
+	_, err := decodeAuditScopeHistoryCursor(raw, scopeID)
+	return err
+}
+
+func decodeAuditScopeHistoryCursor(raw, scopeID string) (auditScopeHistoryCursor, error) {
+	if err := validateUUIDv4(scopeID); err != nil {
+		return auditScopeHistoryCursor{}, fmt.Errorf("%w: invalid scope ID", ErrInvalidAuditCursor)
+	}
+	if raw == "" {
+		return auditScopeHistoryCursor{}, nil
+	}
+	decoded, err := base64.RawURLEncoding.Strict().DecodeString(raw)
+	if err != nil {
+		return auditScopeHistoryCursor{}, fmt.Errorf("%w: malformed encoding", ErrInvalidAuditCursor)
+	}
+	parts := strings.Split(string(decoded), ":")
+	if len(parts) != 4 {
+		return auditScopeHistoryCursor{}, fmt.Errorf("%w: malformed fields", ErrInvalidAuditCursor)
+	}
+	sequence, sequenceErr := strconv.ParseInt(parts[1], 10, 64)
+	ordinal, ordinalErr := strconv.ParseInt(parts[2], 10, 64)
+	if parts[0] != scopeID || sequenceErr != nil || ordinalErr != nil ||
+		sequence < 1 || ordinal < 0 || validateAuditDigest("history event", parts[3]) != nil {
+		return auditScopeHistoryCursor{}, fmt.Errorf("%w: invalid or mismatched fields", ErrInvalidAuditCursor)
+	}
+	return auditScopeHistoryCursor{
+		scopeID: scopeID, sequence: sequence, ordinal: ordinal, eventID: parts[3],
+	}, nil
+}
+
+func encodeAuditScopeHistoryCursor(cursor auditScopeHistoryCursor) string {
+	raw := fmt.Sprintf("%s:%d:%d:%s",
+		cursor.scopeID, cursor.sequence, cursor.ordinal, cursor.eventID)
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
 }

--- a/internal/store/audit_history_test.go
+++ b/internal/store/audit_history_test.go
@@ -112,6 +112,67 @@ func TestAuditHistoryCursorRemainsStableWhenNewEventsArrive(t *testing.T) {
 	}
 }
 
+func TestAuditScopeHistoryPagesEveryMemberEvent(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	plan, err := s.PreviewInitialAudit(t.Context(), taxes.ID, "cli", nil)
+	require.NoError(t, err)
+	status, err := s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+	require.Len(t, status.Scopes, 1)
+	scopeID := status.Scopes[0].ID
+	destination, err := s.Mkdir(t.Context(), taxes.ID, "2027")
+	require.NoError(t, err)
+	file, err := s.CreateFile(
+		t.Context(), taxes.ID, "return.txt", fakeHash("a719"), 13, "text/plain",
+	)
+	require.NoError(t, err)
+	_, _, err = s.Move(t.Context(), file.ID, destination.ID, file.Name, file.Revision)
+	require.NoError(t, err)
+
+	first, err := s.AuditScopeHistory(t.Context(), scopeID, 5, "")
+	require.NoError(t, err)
+	assert.Equal(t, scopeID, first.Scope.ID)
+	assert.Equal(t, taxes.ID, first.Scope.TargetNodeID)
+	assert.Equal(t, "/Taxes", first.Scope.TargetPath)
+	assert.Greater(t, first.Total, len(first.Items))
+	require.Len(t, first.Items, 5)
+	require.NotEmpty(t, first.NextCursor)
+	require.NoError(t, ValidateAuditScopeHistoryCursor(first.NextCursor, scopeID))
+	for _, event := range first.Items {
+		assert.Equal(t, scopeID, event.ScopeID)
+	}
+	nodeIDs := map[int64]bool{}
+	for _, event := range first.Items {
+		nodeIDs[event.NodeID] = true
+	}
+	assert.GreaterOrEqual(t, len(nodeIDs), 2)
+
+	boundary := first.Items[len(first.Items)-1]
+	_, _, err = s.Move(t.Context(), file.ID, destination.ID, "amended.txt", file.Revision+1)
+	require.NoError(t, err)
+	second, err := s.AuditScopeHistory(t.Context(), scopeID, 500, first.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, first.Total+1, second.Total)
+	for _, event := range second.Items {
+		assert.True(t,
+			event.OperationSequence < boundary.OperationSequence ||
+				(event.OperationSequence == boundary.OperationSequence && event.Ordinal < boundary.Ordinal) ||
+				(event.OperationSequence == boundary.OperationSequence && event.Ordinal == boundary.Ordinal &&
+					event.ID < boundary.ID),
+		)
+	}
+
+	otherScope := "11111111-1111-4111-8111-111111111111"
+	_, err = s.AuditScopeHistory(t.Context(), otherScope, 10, "")
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.AuditScopeHistory(t.Context(), otherScope, 10, first.NextCursor)
+	require.ErrorIs(t, err, ErrInvalidAuditCursor)
+}
+
 func TestAuditHistoryPreservesTrashAndRestoreCoordinates(t *testing.T) {
 	s := newAuditedMoveStore(t)
 	work, err := s.NodeByPath(t.Context(), "/Projects/Work")

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -49,7 +49,7 @@ var (
 	// ErrAuditNotEnrolled means a node exists but has no sticky audit membership.
 	ErrAuditNotEnrolled = errors.New("node is not enrolled in an audit scope")
 	// ErrInvalidAuditCursor means an audit-history cursor is malformed or belongs
-	// to a different stable node.
+	// to a different stable node or scope.
 	ErrInvalidAuditCursor = errors.New("invalid audit history cursor")
 )
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -297,6 +297,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS audit_record_event
     ON audit_records(event_id) WHERE event_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS audit_record_event_node
     ON audit_records(node_id) WHERE kind = 'event';
+CREATE INDEX IF NOT EXISTS audit_record_event_scope
+    ON audit_records(scope_id) WHERE kind = 'event';
 CREATE UNIQUE INDEX IF NOT EXISTS audit_record_mutation_operation
     ON audit_records(operation_id) WHERE kind = 'canonical_mutation';
 CREATE UNIQUE INDEX IF NOT EXISTS audit_record_mutation_sequence


### PR DESCRIPTION
A person or agent can now answer “what changed anywhere under this permanent retention promise?” without querying every protected document one at a time.

For example, audit status returns a stable scope ID. Running:

    docbank audit history --scope <scope-id>

shows the newest canonical events across every member of that scope. Human output identifies each affected document with a reusable id:N selector. JSON includes the complete typed events and the scope’s current baseline, membership count, chain head, and other evidence, so automation can keep the timeline attached to the authority it is inspecting.

Large histories remain bounded: pages default to 50 events, allow at most 500, and use an opaque cursor tied to the stable scope. The cursor remains valid when newer events arrive, while trying to reuse it against another scope is rejected. The same contract is available through the authenticated HTTP API and typed Go client. A daemon protocol bump prevents a new CLI from routing this request to an older process.

Existing per-document history is unchanged. This PR also does not enable additional audit scopes; that follow-up requires the verifier and mutation writers to understand overlapping scopes together, and should be reviewed as that complete contract rather than as a shallow enrollment change.