### PR TITLE
Search within stable tag assignments

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -110,7 +110,11 @@ Key assumptions reviewers MUST account for:
    capability that is not yet in a tagged release must carry a release
    qualifier where users would act on it (homepage, setup). Flagging
    an unqualified unreleased capability is correct; demanding the
-   capability's documentation be removed entirely is not.
+   capability's documentation be removed entirely is not. The public
+   Zensical site is published only after the corresponding release tag
+   exists; do not require source documentation for merged next-release
+   work to be withheld from main merely because that site publication
+   has not happened yet.
 
 Do NOT flag issues that only apply to public-facing, multi-tenant, or
 internet-exposed services. Focus on bugs, logic errors, data corruption

--- a/README.md
+++ b/README.md
@@ -118,9 +118,8 @@ platform's toolchain.
 There is no initialization command. The first data command creates the local
 vault and starts its daemon:
 
-> **Release availability:** `docbank version` and the explicit
-> `docbank versions list|show|cat` commands are newer than v0.7.0. Build from
-> source to use them until the next release is published.
+> **Release availability:** tag-filtered search is newer than v0.10.0. Build
+> from source to use `docbank search --tag` until the next release is tagged.
 
 ```bash
 docbank add ~/Documents --dest /archive

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ docbank versions list /archive/Documents/receipt.pdf
 docbank refs <receipt-sha256>
 docbank tag create taxes
 docbank tag assign taxes /archive/Documents/receipt.pdf
+docbank search receipt --tag taxes
 docbank put revised-receipt.pdf /archive/Documents/receipt.pdf
 docbank edit /archive/Documents/notes.md
 docbank revert /archive/Documents/receipt.pdf <prior-version-id>

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -1031,12 +1031,33 @@ func TestTreeMutationJSONReceipts(t *testing.T) {
 func TestSearchCLI(t *testing.T) {
 	setupVaultHome(t)
 	src := writeSourceFile(t, "insurance-2026.txt", "policy")
-	_, err := runCLI(t, "add", src, "--dest", "/inbox")
+	other := writeSourceFile(t, "insurance-draft.txt", "draft")
+	_, err := runCLI(t, "add", src, other, "--dest", "/inbox")
 	require.NoError(t, err)
 
 	out, err := runCLI(t, "search", "insurance")
 	require.NoError(t, err)
 	assert.Contains(t, out, "/inbox/insurance-2026.txt")
+	assert.Contains(t, out, "/inbox/insurance-draft.txt")
+
+	out, err = runCLI(t, "tag", "create", "renewal", "--json")
+	require.NoError(t, err, out)
+	var tag api.Tag
+	require.NoError(t, json.Unmarshal([]byte(out), &tag))
+	_, err = runCLI(t, "tag", "assign", "renewal", "/inbox/insurance-2026.txt")
+	require.NoError(t, err)
+
+	out, err = runCLI(t, "search", "insurance", "--tag", "renewal")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "/inbox/insurance-2026.txt")
+	assert.NotContains(t, out, "/inbox/insurance-draft.txt")
+	out, err = runCLI(t, "search", "insurance", "--tag", tag.ID, "--json")
+	require.NoError(t, err, out)
+	var report api.SearchReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, tag.ID, report.TagID)
+	require.Len(t, report.Hits, 1)
+	assert.Equal(t, "/inbox/insurance-2026.txt", report.Hits[0].Path)
 }
 
 func TestSearchCLIReportsTruncation(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "26", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "27", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "26", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "27", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "26", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "27", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/search.go
+++ b/cmd/docbank/search.go
@@ -18,6 +18,7 @@ const (
 var (
 	searchLimit int
 	searchJSON  bool
+	searchTag   string
 )
 
 var searchCmd = &cobra.Command{
@@ -32,7 +33,19 @@ var searchCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		rep, err := c.Search(cmd.Context(), strings.Join(args, " "), searchLimit)
+		var opts client.SearchOptions
+		var tagName string
+		if searchTag != "" {
+			tag, resolveErr := resolveTag(cmd, c, searchTag)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			opts.TagID = tag.ID
+			tagName = tag.Name
+		}
+		rep, err := c.SearchWithOptions(
+			cmd.Context(), strings.Join(args, " "), searchLimit, opts,
+		)
 		if err != nil {
 			return err
 		}
@@ -40,7 +53,11 @@ var searchCmd = &cobra.Command{
 			return writeCLIJSON(cmd.OutOrStdout(), rep)
 		}
 		if len(rep.Hits) == 0 {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no matches")
+			if tagName == "" {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no matches")
+			} else {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "no matches with tag %q\n", tagName)
+			}
 			return nil
 		}
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
@@ -68,6 +85,8 @@ var searchCmd = &cobra.Command{
 func init() {
 	searchCmd.Flags().IntVar(&searchLimit, "limit", defaultSearchLimit,
 		"maximum results to return (1-1000)")
+	searchCmd.Flags().StringVar(&searchTag, "tag", "",
+		"require one tag by name or stable ID")
 	searchCmd.Flags().BoolVar(&searchJSON, "json", false, "emit machine-readable JSON")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -161,11 +161,15 @@ current version of verified UTF-8 plain text, Markdown, JSON, and JSONL document
 up to 16 MiB. Extraction runs asynchronously; after a write, inspect
 `docbank jobs` or retry briefly instead of treating an immediate content miss as
 permanent. PDF, Office, image, and OCR text extraction are not implemented.
+To restrict the same ranking to one current tag assignment, send the canonical
+tag UUID as `tag_id`; retain the echoed `tag_id` as the filter authority rather
+than relying on the tag's mutable display name.
 
 ```bash
 curl --fail-with-body --get \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   --data-urlencode 'q=tax return' \
+  --data 'tag_id=<tag-uuid>' \
   --data 'limit=100' \
   "$DOCBANK_URL/api/v1/search"
 ```

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -42,7 +42,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /audit/scopes/{scope_id}/history?limit=&cursor=` | read canonical newest-first events across every member of one permanent scope | Implemented |
 | `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
-| `GET /search?q=&limit=` | bounded name and extracted-content search (FTS5), with match source and explicit `truncated` status | Implemented |
+| `GET /search?q=&tag_id=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity, with match source and explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
 | `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -568,7 +568,7 @@ returns the complete restored node with its resulting path and revision.
 ## docbank search
 
 ```
-docbank search <query>... [--limit <n>] [--json]
+docbank search <query>... [--tag <name-or-id>] [--limit <n>] [--json]
 ```
 
 Full-text search over live node names and verified extracted text (FTS5).
@@ -580,8 +580,13 @@ the command says that the result is truncated rather than silently implying
 completeness. Output columns are `SELECTOR`, `MATCH`, and `PATH`; no matches prints
 `no matches`.
 
+`--tag` requires one current tag assignment. It accepts a tag's exact name or
+stable UUID using the same selector rules as `docbank tag show`; the CLI
+resolves names before searching, so the request is bound to stable identity.
+
 `--json` emits the typed search report with `hits`, the applied `limit`, and
-an explicit `truncated` boolean. An empty result uses `"hits": []`.
+an explicit `truncated` boolean. A filtered report also echoes the stable
+`tag_id`. An empty result uses `"hits": []`.
 
 The daemon indexes current UTF-8 `text/*`, JSON, and JSONL blobs up to 16 MiB
 after a terminally verified read. PDF, Office, and OCR extraction are not yet

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,10 @@ curl -fsSL https://docbank.ai/install.sh | sh
 
 The ordinary workflow stays direct:
 
+!!! note "Release availability"
+    Tag-filtered search is newer than v0.10.0. Build from source to use
+    `docbank search --tag` until the next release is tagged.
+
 ```bash
 docbank add ~/Documents/taxes --dest /taxes    # import a folder; sources untouched
 docbank tree /taxes                            # browse the virtual tree

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ The ordinary workflow stays direct:
 docbank add ~/Documents/taxes --dest /taxes    # import a folder; sources untouched
 docbank tree /taxes                            # browse the virtual tree
 docbank search "insurance"                     # ranked name and verified plain-text search
+docbank search "return" --tag taxes             # narrow the same ranking by stable tag identity
 docbank put revised.pdf /taxes/2026/return.pdf # add a new immutable version
 docbank versions list /taxes/2026/return.pdf   # inspect retained history
 docbank rm /inbox/junk.pdf                     # move to recoverable trash

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,7 +117,7 @@ and append later changes to the same stable node without touching source files.
 - Additional and overlapping audit scopes
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
-- Tag/MIME/date/path search filters
+- MIME/date/path search filters; stable tag filtering is implemented
 - Additional text extraction workers for PDF text layers and office formats;
   bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
 - External integration surface: generalized ingest provenance —

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -8,6 +8,7 @@ description: Ranked, prefix-matching search over document names and verified tex
 ```bash
 docbank search insurance
 docbank search tax 2026
+docbank search return --tag taxes
 docbank search report --limit 200
 docbank search report --json
 ```
@@ -35,6 +36,10 @@ id:198     content  /taxes/2026/car-insurance-notes.md
 - **Current content only.** Retained prior versions stay available through
   `docbank versions`, but ordinary search matches the current selected version
   of each live file.
+- **Stable tag filtering.** `--tag <name-or-id>` requires one current tag
+  assignment without changing name-before-content ranking. The CLI resolves a
+  tag name to its stable UUID before searching; JSON echoes that UUID as
+  `tag_id`, so a later rename cannot change what the request meant.
 
 For scripts, `--json` returns `hits`, `limit`, and `truncated` without table
 formatting. `hits` is always an array, including when nothing matches.
@@ -54,9 +59,8 @@ daemon job reaches it. A transient open, read, or verification error leaves the
 item queued and is retried on a bounded delay; it does not become a permanent
 extraction failure. `docbank jobs` shows whether that worker is running.
 
-PDF text layers, office formats, OCR, and tag/MIME/date/path search filters are
-not yet available. Their absence never changes name-search results or document
-authority.
+PDF text layers, office formats, OCR, and MIME/date/path search filters are not
+yet available. Their absence never changes name-search results or document authority.
 
 Next: organize documents beyond paths with
 [Organizing & Tagging](organizing.md), or see every search flag in the

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -348,16 +348,22 @@ func registerReadRoutes(api huma.API, d Deps) {
 		OperationID: "search", Method: http.MethodGet, Path: "/api/v1/search",
 		Summary: "Search live document names and extracted text",
 		Description: "Name matches retain their established BM25 order and appear first; " +
-			"content-only matches follow in their own BM25 order. Every hit names its match source.",
+			"content-only matches follow in their own BM25 order. Every hit names its match source. " +
+			"An optional stable tag ID requires that assignment for every result.",
 	}, func(ctx context.Context, in *struct {
 		Q     string `query:"q" required:"true"`
 		Limit int    `query:"limit" default:"50" minimum:"1" maximum:"1000"`
+		TagID string `query:"tag_id" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"`
 	}) (*searchOutput, error) {
-		hits, truncated, err := d.Store.SearchPage(ctx, in.Q, in.Limit)
+		hits, truncated, err := d.Store.SearchPageWithOptions(
+			ctx, in.Q, in.Limit, store.SearchOptions{TagID: in.TagID},
+		)
 		if err != nil {
 			return nil, FromStoreError(err)
 		}
-		out := &searchOutput{Body: SearchReport{Hits: []SearchHit{}, Limit: in.Limit, Truncated: truncated}}
+		out := &searchOutput{Body: SearchReport{
+			Hits: []SearchHit{}, Limit: in.Limit, Truncated: truncated, TagID: in.TagID,
+		}}
 		for _, h := range hits {
 			out.Body.Hits = append(out.Body.Hits, SearchHit{
 				Node: fromStoreNode(h.Node), Path: h.Path, Match: h.Match,

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -275,9 +275,11 @@ func TestContentOnDirIs422(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	ts, s := newTestServer(t, nil)
+	var insuranceNodes []store.Node
 	for i, name := range []string{"insurance-a.pdf", "insurance-b.pdf"} {
-		_, err := s.CreateFile(t.Context(), s.RootID(), name, testHash(string(rune('x'+i))), 3, "application/pdf")
+		node, err := s.CreateFile(t.Context(), s.RootID(), name, testHash(string(rune('x'+i))), 3, "application/pdf")
 		require.NoError(t, err)
+		insuranceNodes = append(insuranceNodes, node)
 	}
 	resp, body := get(t, ts, "/api/v1/search?q=insurance&limit=1", nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -287,6 +289,23 @@ func TestSearch(t *testing.T) {
 	assert.Equal(t, 1, rep.Limit)
 	assert.True(t, rep.Truncated)
 	assert.Equal(t, "name", rep.Hits[0].Match)
+
+	tag, err := s.CreateTag(t.Context(), "renewal")
+	require.NoError(t, err)
+	_, err = s.AssignTag(
+		t.Context(), tag.ID, insuranceNodes[1].ID, insuranceNodes[1].Revision,
+	)
+	require.NoError(t, err)
+	resp, body = get(t, ts, "/api/v1/search?q=insurance&limit=10&tag_id="+tag.ID, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, json.Unmarshal([]byte(body), &rep))
+	require.Len(t, rep.Hits, 1)
+	assert.Equal(t, insuranceNodes[1].ID, rep.Hits[0].Node.ID)
+	assert.Equal(t, tag.ID, rep.TagID)
+
+	resp, body = get(t, ts,
+		"/api/v1/search?q=insurance&limit=10&tag_id=11111111-1111-4111-8111-111111111111", nil)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, body)
 
 	bodyNode := createFileWithContent(t, ts, s, "/notes.txt", "lighthouse archive")
 	require.NoError(t, s.RecordExtraction(t.Context(), store.ExtractionResult{

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -436,6 +436,7 @@ type SearchReport struct {
 	Hits      []SearchHit `json:"hits"`
 	Limit     int         `json:"limit"`
 	Truncated bool        `json:"truncated"`
+	TagID     string      `json:"tag_id,omitempty"`
 }
 
 // IngestFailure records one source path that failed to import.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -670,11 +670,36 @@ func (c *Client) VerifyNodeContent(ctx context.Context, id, revision int64) (api
 	return report, err
 }
 
+// SearchOptions narrows ranked search by stable metadata identity.
+type SearchOptions struct {
+	TagID string
+}
+
 func (c *Client) Search(ctx context.Context, query string, limit int) (api.SearchReport, error) {
+	return c.SearchWithOptions(ctx, query, limit, SearchOptions{})
+}
+
+// SearchWithOptions returns one bounded ranked result set.
+func (c *Client) SearchWithOptions(
+	ctx context.Context, query string, limit int, opts SearchOptions,
+) (api.SearchReport, error) {
 	var out api.SearchReport
-	p := fmt.Sprintf("/api/v1/search?q=%s&limit=%d", url.QueryEscape(query), limit)
-	err := c.do(ctx, http.MethodGet, p, nil, nil, &out)
-	return out, err
+	if opts.TagID != "" && !validUUIDv4(opts.TagID) {
+		return out, errors.New("search tag ID must be a canonical UUIDv4")
+	}
+	queryValues := url.Values{}
+	queryValues.Set("q", query)
+	queryValues.Set("limit", strconv.Itoa(limit))
+	if opts.TagID != "" {
+		queryValues.Set("tag_id", opts.TagID)
+	}
+	if err := c.do(ctx, http.MethodGet, "/api/v1/search?"+queryValues.Encode(), nil, nil, &out); err != nil {
+		return out, err
+	}
+	if out.TagID != opts.TagID {
+		return api.SearchReport{}, errors.New("search response has inconsistent tag authority")
+	}
+	return out, nil
 }
 
 // AuditPreviewOptions selects one live directory for permanent first-scope

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -104,6 +104,34 @@ func TestRoundTrip(t *testing.T) {
 	assert.Equal(t, "/filed", restored.Path)
 }
 
+func TestSearchWithOptionsUsesStableTagIdentity(t *testing.T) {
+	c, s := newClient(t, serverKey)
+	ctx := t.Context()
+	tag, err := s.CreateTag(ctx, "renewal")
+	require.NoError(t, err)
+	tagged, err := s.CreateFile(
+		ctx, s.RootID(), "insurance-renewal.pdf", strings.Repeat("a", 64), 1, "application/pdf",
+	)
+	require.NoError(t, err)
+	_, err = s.CreateFile(
+		ctx, s.RootID(), "insurance-draft.pdf", strings.Repeat("b", 64), 1, "application/pdf",
+	)
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, tag.ID, tagged.ID, tagged.Revision)
+	require.NoError(t, err)
+
+	report, err := c.SearchWithOptions(
+		ctx, "insurance", 10, client.SearchOptions{TagID: tag.ID},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, tag.ID, report.TagID)
+	require.Len(t, report.Hits, 1)
+	assert.Equal(t, tagged.ID, report.Hits[0].Node.ID)
+
+	_, err = c.SearchWithOptions(ctx, "insurance", 10, client.SearchOptions{TagID: "bad"})
+	require.ErrorContains(t, err, "canonical UUIDv4")
+}
+
 func TestMoveToPathValidatesRequestBeforeTransport(t *testing.T) {
 	c := client.New("http://127.0.0.1:1", serverKey)
 

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "26"
+	daemonProtocolVersion = "27"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -14,6 +14,12 @@ type SearchHit struct {
 	Match string
 }
 
+// SearchOptions narrows ranked search without changing its name-before-content
+// ordering. TagID is the stable identity of one required tag assignment.
+type SearchOptions struct {
+	TagID string
+}
+
 const (
 	SearchMatchName    = "name"
 	SearchMatchContent = "content"
@@ -36,21 +42,39 @@ func ftsQuery(input string) string {
 // deterministic name-search contract: enabling extraction never reorders or
 // hides a filename match that the same limit returned before.
 func (s *Store) SearchPage(ctx context.Context, query string, limit int) ([]SearchHit, bool, error) {
+	return s.SearchPageWithOptions(ctx, query, limit, SearchOptions{})
+}
+
+// SearchPageWithOptions returns ranked live matches that satisfy every
+// requested filter. Filters apply equally to name and content candidates.
+func (s *Store) SearchPageWithOptions(
+	ctx context.Context, query string, limit int, opts SearchOptions,
+) ([]SearchHit, bool, error) {
 	if limit <= 0 {
 		limit = 50
+	}
+	if opts.TagID != "" {
+		if _, err := s.TagByID(ctx, opts.TagID); err != nil {
+			return nil, false, fmt.Errorf("search tag %q: %w", opts.TagID, err)
+		}
 	}
 	fq := ftsQuery(query)
 	if fq == "" {
 		return nil, false, nil
 	}
+	filterSQL, filterArgs := searchFilterSQL(opts)
+	nameArgs := []any{fq}
+	nameArgs = append(nameArgs, filterArgs...)
+	nameArgs = append(nameArgs, fq, limit+1)
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+nodeCols+`
 		FROM `+nodeFrom+`
 		WHERE n.id IN (SELECT rowid FROM nodes_fts WHERE nodes_fts MATCH ?)
 		  AND n.trashed_at IS NULL
+		  `+filterSQL+`
 		ORDER BY (SELECT rank FROM nodes_fts WHERE rowid = n.id AND nodes_fts MATCH ?),
 		         n.name, n.id
-		LIMIT ?`, fq, fq, limit+1)
+		LIMIT ?`, nameArgs...)
 	if err != nil {
 		return nil, false, fmt.Errorf("searching %q: %w", query, err)
 	}
@@ -69,6 +93,9 @@ func (s *Store) SearchPage(ctx context.Context, query string, limit int) ([]Sear
 	// Content may also match a node already returned by name. Over-fetch by
 	// the complete name set so duplicate filtering cannot conceal truncation.
 	remaining := limit - len(nameHits)
+	contentArgs := []any{fq}
+	contentArgs = append(contentArgs, filterArgs...)
+	contentArgs = append(contentArgs, remaining+len(nameHits)+1)
 	rows, err = s.db.QueryContext(ctx, `
 		WITH matched_blobs AS (
 		  SELECT blob_hash, MIN(rank) AS best_rank
@@ -80,8 +107,9 @@ func (s *Store) SearchPage(ctx context.Context, query string, limit int) ([]Sear
 		JOIN matched_blobs mb ON mb.blob_hash = cv.blob_hash
 		JOIN text_searchable_versions tsv ON tsv.version_id = cv.version_id
 		WHERE n.trashed_at IS NULL
+		  `+filterSQL+`
 		ORDER BY mb.best_rank, n.name, n.id
-		LIMIT ?`, fq, remaining+len(nameHits)+1)
+		LIMIT ?`, contentArgs...)
 	if err != nil {
 		return nil, false, fmt.Errorf("searching extracted content for %q: %w", query, err)
 	}
@@ -111,6 +139,15 @@ func (s *Store) SearchPage(ctx context.Context, query string, limit int) ([]Sear
 		return nil, false, err
 	}
 	return hits, truncated, nil
+}
+
+func searchFilterSQL(opts SearchOptions) (string, []any) {
+	if opts.TagID == "" {
+		return "", nil
+	}
+	return `AND EXISTS (
+		SELECT 1 FROM node_tags nt WHERE nt.node_id=n.id AND nt.tag_id=?
+	)`, []any{opts.TagID}
 }
 
 func scanSearchRows(rows *sql.Rows, match, query string) ([]SearchHit, error) {

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -126,6 +126,59 @@ func TestSearchPageReportsTruncation(t *testing.T) {
 	assert.False(t, truncated)
 }
 
+func TestSearchPageFiltersNameAndContentMatchesByTag(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	tag, err := s.CreateTag(ctx, "taxes")
+	require.NoError(t, err)
+
+	nameMatch, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-return.pdf", fakeHash("a1"), 4, "application/pdf",
+	)
+	require.NoError(t, err)
+	contentMatch, err := s.CreateFile(
+		ctx, s.RootID(), "notes.md", fakeHash("b2"), 4, "text/markdown",
+	)
+	require.NoError(t, err)
+	untagged, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-draft.pdf", fakeHash("c3"), 4, "application/pdf",
+	)
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, tag.ID, nameMatch.ID, nameMatch.Revision)
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, tag.ID, contentMatch.ID, contentMatch.Revision)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: contentMatch.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "quarterly tax notes",
+	}))
+
+	hits, truncated, err := s.SearchPageWithOptions(
+		ctx, "quarterly", 10, SearchOptions{TagID: tag.ID},
+	)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.False(t, truncated)
+	assert.Equal(t, nameMatch.ID, hits[0].Node.ID)
+	assert.Equal(t, SearchMatchName, hits[0].Match)
+	assert.Equal(t, contentMatch.ID, hits[1].Node.ID)
+	assert.Equal(t, SearchMatchContent, hits[1].Match)
+	assert.NotEqual(t, untagged.ID, hits[0].Node.ID)
+	assert.NotEqual(t, untagged.ID, hits[1].Node.ID)
+
+	hits, truncated, err = s.SearchPageWithOptions(
+		ctx, "quarterly", 1, SearchOptions{TagID: tag.ID},
+	)
+	require.NoError(t, err)
+	assert.Len(t, hits, 1)
+	assert.True(t, truncated)
+
+	_, _, err = s.SearchPageWithOptions(ctx, "quarterly", 10, SearchOptions{
+		TagID: "11111111-1111-4111-8111-111111111111",
+	})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestSearchContentFollowsStableNameMatches(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()


### PR DESCRIPTION
Tags can organize documents independently of their current folders, but until now search ignored that organization. A person or agent had to search the entire vault and filter the returned page itself, which could miss relevant documents whenever the bounded result was truncated.

Now the ordinary workflow composes directly:

    docbank search "tax return" --tag taxes

The result keeps Docbank’s existing ranking: filename matches come first, followed by current verified-content matches. The tag is a requirement applied to both groups, and truncation still describes the filtered result rather than the unfiltered vault.

The CLI accepts the same exact tag name or stable UUID used by the other tag commands. It resolves a name before searching and sends the UUID to the daemon, so renaming a tag cannot silently change the identity behind an in-flight request. JSON echoes that UUID as tag_id. Agents and other clients can supply tag_id directly through the authenticated API or typed Go client.

A protocol revision ensures a new CLI replaces an older daemon that would otherwise ignore the unfamiliar filter and return overly broad results. This PR deliberately adds only tag filtering; MIME, path, and date filters still need their own precise semantics rather than being bundled into a search redesign.