### PR TITLE
Expose physical bytes in loose packing backlog

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -129,8 +129,10 @@ encoding and stored size without changing the logical SHA-256 or size.
 An eligible write temporarily needs scratch space for both the raw object and
 its compressed candidate before Docbank chooses one for durable publication.
 `LooseBacklog` reports how much indexed loose content remains eligible for an
-explicit pack pass, split into raw and compressed object counts. It is useful
-for scheduling; it does not make packing automatic.
+explicit pack pass, including both logical and physically stored bytes and a
+split between raw and compressed object counts. Applications can therefore
+schedule packing from physical storage growth without walking loose objects.
+The report does not make packing automatic.
 
 `vault.ID()` returns the archive's stable UUID. JSONL backup and restore
 preserve that identity even when the restored vault has a different filesystem

--- a/internal/blob/packed_integration_test.go
+++ b/internal/blob/packed_integration_test.go
@@ -174,7 +174,8 @@ func TestMixedStoreLifecyclePreservesMembershipAndBytes(t *testing.T) {
 	backlog, err := metadata.LooseBacklog(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, store.LooseBacklog{
-		EligibleObjects: 1, EligibleBytes: int64(len(fixtures[2].data)), RawObjects: 1,
+		EligibleObjects: 1, EligibleBytes: int64(len(fixtures[2].data)),
+		EligibleStoredBytes: int64(len(fixtures[2].data)), RawObjects: 1,
 	}, backlog)
 	repackedAfterUnpack, err := physical.Maintainer().Pack(ctx, packstore.PackOptions{})
 	require.NoError(t, err)

--- a/internal/store/physical_storage.go
+++ b/internal/store/physical_storage.go
@@ -32,10 +32,11 @@ type PhysicalContent struct {
 
 // LooseBacklog summarizes loose content eligible for an explicit pack pass.
 type LooseBacklog struct {
-	EligibleObjects   int64
-	EligibleBytes     int64
-	RawObjects        int64
-	CompressedObjects int64
+	EligibleObjects     int64
+	EligibleBytes       int64
+	EligibleStoredBytes int64
+	RawObjects          int64
+	CompressedObjects   int64
 }
 
 // BlobPhysical is the loose representation published before a metadata
@@ -138,12 +139,12 @@ func (s *Store) PhysicalContent(ctx context.Context, hash string) (PhysicalConte
 func (s *Store) LooseBacklog(ctx context.Context) (LooseBacklog, error) {
 	var backlog LooseBacklog
 	err := s.db.QueryRowContext(ctx, `
-		SELECT COUNT(*), COALESCE(SUM(size), 0),
+		SELECT COUNT(*), COALESCE(SUM(size), 0), COALESCE(SUM(loose_stored_size), 0),
 		       COALESCE(SUM(CASE WHEN loose_encoding = 'raw' THEN 1 ELSE 0 END), 0),
 		       COALESCE(SUM(CASE WHEN loose_encoding = 'zstd' THEN 1 ELSE 0 END), 0)
 		FROM blobs
 		WHERE pack_eligible = 1 AND loose_encoding IS NOT NULL`,
-	).Scan(&backlog.EligibleObjects, &backlog.EligibleBytes,
+	).Scan(&backlog.EligibleObjects, &backlog.EligibleBytes, &backlog.EligibleStoredBytes,
 		&backlog.RawObjects, &backlog.CompressedObjects)
 	if err != nil {
 		return LooseBacklog{}, fmt.Errorf("reading loose backlog: %w", err)

--- a/internal/store/physical_storage_test.go
+++ b/internal/store/physical_storage_test.go
@@ -29,10 +29,11 @@ func TestLooseBacklogUsesIndexedPhysicalState(t *testing.T) {
 	backlog, err := s.LooseBacklog(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, LooseBacklog{
-		EligibleObjects:   2,
-		EligibleBytes:     30,
-		RawObjects:        1,
-		CompressedObjects: 1,
+		EligibleObjects:     2,
+		EligibleBytes:       30,
+		EligibleStoredBytes: 19,
+		RawObjects:          1,
+		CompressedObjects:   1,
 	}, backlog)
 
 	candidates, err := NewPackCatalog(s).ListUnpacked(t.Context())

--- a/types.go
+++ b/types.go
@@ -126,10 +126,11 @@ type PhysicalContent struct {
 
 // LooseBacklog summarizes loose content eligible for explicit packing.
 type LooseBacklog struct {
-	EligibleObjects   int64 `json:"eligible_objects"`
-	EligibleBytes     int64 `json:"eligible_bytes"`
-	RawObjects        int64 `json:"raw_objects"`
-	CompressedObjects int64 `json:"compressed_objects"`
+	EligibleObjects     int64 `json:"eligible_objects"`
+	EligibleBytes       int64 `json:"eligible_bytes"`
+	EligibleStoredBytes int64 `json:"eligible_stored_bytes"`
+	RawObjects          int64 `json:"raw_objects"`
+	CompressedObjects   int64 `json:"compressed_objects"`
 }
 
 // ChildrenOptions selects one bounded page of a directory's live children.
@@ -243,7 +244,8 @@ func fromStorePhysical(physical store.PhysicalContent) PhysicalContent {
 func fromStoreLooseBacklog(backlog store.LooseBacklog) LooseBacklog {
 	return LooseBacklog{
 		EligibleObjects: backlog.EligibleObjects, EligibleBytes: backlog.EligibleBytes,
-		RawObjects: backlog.RawObjects, CompressedObjects: backlog.CompressedObjects,
+		EligibleStoredBytes: backlog.EligibleStoredBytes,
+		RawObjects:          backlog.RawObjects, CompressedObjects: backlog.CompressedObjects,
 	}
 }
 

--- a/vault_test.go
+++ b/vault_test.go
@@ -937,7 +937,8 @@ func TestNewConfiguresLooseCompression(t *testing.T) {
 	backlog, err := vault.LooseBacklog(t.Context())
 	require.NoError(err)
 	require.Equal(LooseBacklog{
-		EligibleObjects: 1, EligibleBytes: int64(len(content)), CompressedObjects: 1,
+		EligibleObjects: 1, EligibleBytes: int64(len(content)),
+		EligibleStoredBytes: receipt.Physical.StoredBytes, CompressedObjects: 1,
 	}, backlog)
 
 	opened, err := vault.OpenContent(t.Context(), "/document.txt")


### PR DESCRIPTION
Embedded applications can now schedule packing from the actual disk footprint of eligible loose objects. `LooseBacklog` previously exposed only logical bytes and counts, so compression could make a physical-byte threshold inaccurate unless the caller walked storage outside Docbank.

The new `EligibleStoredBytes` / `eligible_stored_bytes` value comes from the existing indexed backlog aggregate and uses the same eligibility predicate as the logical totals. Packed objects and pack-ineligible oversized loose objects remain excluded, and existing API fields retain their meaning.