### PR TITLE
Filter search by current media type

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -1058,6 +1058,12 @@ func TestSearchCLI(t *testing.T) {
 	assert.Equal(t, tag.ID, report.TagID)
 	require.Len(t, report.Hits, 1)
 	assert.Equal(t, "/inbox/insurance-2026.txt", report.Hits[0].Path)
+
+	out, err = runCLI(t, "search", "insurance", "--mime-type", "TEXT/PLAIN", "--json")
+	require.NoError(t, err, out)
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, "text/plain", report.MIMEType)
+	require.Len(t, report.Hits, 2)
 }
 
 func TestSearchCLIReportsTruncation(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "27", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "28", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "27", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "28", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "27", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "28", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/exit_test.go
+++ b/cmd/docbank/exit_test.go
@@ -58,6 +58,10 @@ func TestRunProcessDistinguishesUsageAndMissingNodes(t *testing.T) {
 	assert.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "--limit must be between")
 
+	code = run("search", "term", "--mime-type", "text/plain; charset=utf-8")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "must not include parameters")
+
 	code = run("storage", "pack", "--max-bytes", "-1")
 	assert.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "validation")

--- a/cmd/docbank/search.go
+++ b/cmd/docbank/search.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/store"
 )
 
 const (
@@ -19,6 +20,7 @@ var (
 	searchLimit int
 	searchJSON  bool
 	searchTag   string
+	searchMIME  string
 )
 
 var searchCmd = &cobra.Command{
@@ -29,11 +31,15 @@ var searchCmd = &cobra.Command{
 		if searchLimit < 1 || searchLimit > maxSearchLimit {
 			return usageError(fmt.Errorf("--limit must be between 1 and %d", maxSearchLimit))
 		}
+		mimeType, err := store.NormalizeSearchMIMEType(searchMIME)
+		if err != nil {
+			return usageError(err)
+		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
 			return err
 		}
-		var opts client.SearchOptions
+		opts := client.SearchOptions{MIMEType: mimeType}
 		var tagName string
 		if searchTag != "" {
 			tag, resolveErr := resolveTag(cmd, c, searchTag)
@@ -53,10 +59,16 @@ var searchCmd = &cobra.Command{
 			return writeCLIJSON(cmd.OutOrStdout(), rep)
 		}
 		if len(rep.Hits) == 0 {
-			if tagName == "" {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no matches")
-			} else {
+			switch {
+			case tagName != "" && rep.MIMEType != "":
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+					"no matches with tag %q and media type %q\n", tagName, rep.MIMEType)
+			case tagName != "":
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "no matches with tag %q\n", tagName)
+			case rep.MIMEType != "":
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "no matches with media type %q\n", rep.MIMEType)
+			default:
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no matches")
 			}
 			return nil
 		}
@@ -87,6 +99,8 @@ func init() {
 		"maximum results to return (1-1000)")
 	searchCmd.Flags().StringVar(&searchTag, "tag", "",
 		"require one tag by name or stable ID")
+	searchCmd.Flags().StringVar(&searchMIME, "mime-type", "",
+		"require one current parameter-free media type")
 	searchCmd.Flags().BoolVar(&searchJSON, "json", false, "emit machine-readable JSON")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -164,12 +164,17 @@ permanent. PDF, Office, image, and OCR text extraction are not implemented.
 To restrict the same ranking to one current tag assignment, send the canonical
 tag UUID as `tag_id`; retain the echoed `tag_id` as the filter authority rather
 than relying on the tag's mutable display name.
+To restrict results by the current file version's format, send a valid
+parameter-free base type as `mime_type`. The response echoes its normalized
+spelling. For example, `text/plain` includes stored charset parameters but does
+not match a retained historical version or a directory.
 
 ```bash
 curl --fail-with-body --get \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   --data-urlencode 'q=tax return' \
   --data 'tag_id=<tag-uuid>' \
+  --data-urlencode 'mime_type=application/pdf' \
   --data 'limit=100' \
   "$DOCBANK_URL/api/v1/search"
 ```

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -42,7 +42,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /audit/scopes/{scope_id}/history?limit=&cursor=` | read canonical newest-first events across every member of one permanent scope | Implemented |
 | `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
-| `GET /search?q=&tag_id=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity, with match source and explicit `truncated` status | Implemented |
+| `GET /search?q=&tag_id=&mime_type=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity and current base media type, with match source and explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
 | `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -568,7 +568,7 @@ returns the complete restored node with its resulting path and revision.
 ## docbank search
 
 ```
-docbank search <query>... [--tag <name-or-id>] [--limit <n>] [--json]
+docbank search <query>... [--tag <name-or-id>] [--mime-type <type/subtype>] [--limit <n>] [--json]
 ```
 
 Full-text search over live node names and verified extracted text (FTS5).
@@ -583,10 +583,15 @@ completeness. Output columns are `SELECTOR`, `MATCH`, and `PATH`; no matches pri
 `--tag` requires one current tag assignment. It accepts a tag's exact name or
 stable UUID using the same selector rules as `docbank tag show`; the CLI
 resolves names before searching, so the request is bound to stable identity.
+`--mime-type` accepts one valid parameter-free media type and matches the
+current version's base type case-insensitively. Stored parameters do not affect
+the match: `text/plain` includes `text/plain; charset=utf-8`. MIME filtering
+excludes directories and retained non-current versions.
 
 `--json` emits the typed search report with `hits`, the applied `limit`, and
 an explicit `truncated` boolean. A filtered report also echoes the stable
-`tag_id`. An empty result uses `"hits": []`.
+`tag_id` and normalized `mime_type` when supplied. An empty result uses
+`"hits": []`.
 
 The daemon indexes current UTF-8 `text/*`, JSON, and JSONL blobs up to 16 MiB
 after a terminally verified read. PDF, Office, and OCR extraction are not yet

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,7 +117,7 @@ and append later changes to the same stable node without touching source files.
 - Additional and overlapping audit scopes
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
-- MIME/date/path search filters; stable tag filtering is implemented
+- Date/path search filters; stable tag and current MIME filtering are implemented
 - Additional text extraction workers for PDF text layers and office formats;
   bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
 - External integration surface: generalized ingest provenance —

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -9,6 +9,7 @@ description: Ranked, prefix-matching search over document names and verified tex
 docbank search insurance
 docbank search tax 2026
 docbank search return --tag taxes
+docbank search report --mime-type application/pdf
 docbank search report --limit 200
 docbank search report --json
 ```
@@ -40,6 +41,11 @@ id:198     content  /taxes/2026/car-insurance-notes.md
   assignment without changing name-before-content ranking. The CLI resolves a
   tag name to its stable UUID before searching; JSON echoes that UUID as
   `tag_id`, so a later rename cannot change what the request meant.
+- **Current media-type filtering.** `--mime-type <type/subtype>` requires the
+  current file version to have that base media type. The filter is
+  case-insensitive and ignores stored parameters, so `text/plain` also matches
+  `text/plain; charset=utf-8`. The request itself must be parameter-free;
+  directories and historical versions never match it.
 
 For scripts, `--json` returns `hits`, `limit`, and `truncated` without table
 formatting. `hits` is always an array, including when nothing matches.
@@ -59,7 +65,7 @@ daemon job reaches it. A transient open, read, or verification error leaves the
 item queued and is retried on a bounded delay; it does not become a permanent
 extraction failure. `docbank jobs` shows whether that worker is running.
 
-PDF text layers, office formats, OCR, and MIME/date/path search filters are not
+PDF text layers, office formats, OCR, and date/path search filters are not
 yet available. Their absence never changes name-search results or document authority.
 
 Next: organize documents beyond paths with

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -349,20 +349,27 @@ func registerReadRoutes(api huma.API, d Deps) {
 		Summary: "Search live document names and extracted text",
 		Description: "Name matches retain their established BM25 order and appear first; " +
 			"content-only matches follow in their own BM25 order. Every hit names its match source. " +
-			"An optional stable tag ID requires that assignment for every result.",
+			"An optional stable tag ID requires that assignment for every result. An optional " +
+			"parameter-free MIME type matches the current file version with or without parameters.",
 	}, func(ctx context.Context, in *struct {
-		Q     string `query:"q" required:"true"`
-		Limit int    `query:"limit" default:"50" minimum:"1" maximum:"1000"`
-		TagID string `query:"tag_id" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"`
+		Q        string `query:"q" required:"true"`
+		Limit    int    `query:"limit" default:"50" minimum:"1" maximum:"1000"`
+		TagID    string `query:"tag_id" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"`
+		MIMEType string `query:"mime_type" maxLength:"255"`
 	}) (*searchOutput, error) {
+		mimeType, err := store.NormalizeSearchMIMEType(in.MIMEType)
+		if err != nil {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+		}
 		hits, truncated, err := d.Store.SearchPageWithOptions(
-			ctx, in.Q, in.Limit, store.SearchOptions{TagID: in.TagID},
+			ctx, in.Q, in.Limit, store.SearchOptions{TagID: in.TagID, MIMEType: mimeType},
 		)
 		if err != nil {
 			return nil, FromStoreError(err)
 		}
 		out := &searchOutput{Body: SearchReport{
-			Hits: []SearchHit{}, Limit: in.Limit, Truncated: truncated, TagID: in.TagID,
+			Hits: []SearchHit{}, Limit: in.Limit, Truncated: truncated,
+			TagID: in.TagID, MIMEType: mimeType,
 		}}
 		for _, h := range hits {
 			out.Body.Hits = append(out.Body.Hits, SearchHit{

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -318,4 +318,16 @@ func TestSearch(t *testing.T) {
 	require.Len(t, rep.Hits, 1)
 	assert.Equal(t, bodyNode.ID, rep.Hits[0].Node.ID)
 	assert.Equal(t, "content", rep.Hits[0].Match)
+
+	resp, body = get(t, ts, "/api/v1/search?q=lighthouse&limit=10&mime_type=TEXT%2FPLAIN", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	require.NoError(t, json.Unmarshal([]byte(body), &rep))
+	require.Len(t, rep.Hits, 1)
+	assert.Equal(t, bodyNode.ID, rep.Hits[0].Node.ID)
+	assert.Equal(t, "text/plain", rep.MIMEType)
+
+	resp, body = get(t, ts,
+		"/api/v1/search?q=lighthouse&limit=10&mime_type=text%2Fplain%3B%20charset%3Dutf-8", nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"validation"`)
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -437,6 +437,7 @@ type SearchReport struct {
 	Limit     int         `json:"limit"`
 	Truncated bool        `json:"truncated"`
 	TagID     string      `json:"tag_id,omitempty"`
+	MIMEType  string      `json:"mime_type,omitempty"`
 }
 
 // IngestFailure records one source path that failed to import.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -670,9 +670,10 @@ func (c *Client) VerifyNodeContent(ctx context.Context, id, revision int64) (api
 	return report, err
 }
 
-// SearchOptions narrows ranked search by stable metadata identity.
+// SearchOptions narrows ranked search by stable tag and current media type.
 type SearchOptions struct {
-	TagID string
+	TagID    string
+	MIMEType string
 }
 
 func (c *Client) Search(ctx context.Context, query string, limit int) (api.SearchReport, error) {
@@ -687,17 +688,24 @@ func (c *Client) SearchWithOptions(
 	if opts.TagID != "" && !validUUIDv4(opts.TagID) {
 		return out, errors.New("search tag ID must be a canonical UUIDv4")
 	}
+	mimeType, err := store.NormalizeSearchMIMEType(opts.MIMEType)
+	if err != nil {
+		return out, err
+	}
 	queryValues := url.Values{}
 	queryValues.Set("q", query)
 	queryValues.Set("limit", strconv.Itoa(limit))
 	if opts.TagID != "" {
 		queryValues.Set("tag_id", opts.TagID)
 	}
+	if mimeType != "" {
+		queryValues.Set("mime_type", mimeType)
+	}
 	if err := c.do(ctx, http.MethodGet, "/api/v1/search?"+queryValues.Encode(), nil, nil, &out); err != nil {
 		return out, err
 	}
-	if out.TagID != opts.TagID {
-		return api.SearchReport{}, errors.New("search response has inconsistent tag authority")
+	if out.TagID != opts.TagID || out.MIMEType != mimeType {
+		return api.SearchReport{}, errors.New("search response has inconsistent filter authority")
 	}
 	return out, nil
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -121,15 +121,22 @@ func TestSearchWithOptionsUsesStableTagIdentity(t *testing.T) {
 	require.NoError(t, err)
 
 	report, err := c.SearchWithOptions(
-		ctx, "insurance", 10, client.SearchOptions{TagID: tag.ID},
+		ctx, "insurance", 10, client.SearchOptions{
+			TagID: tag.ID, MIMEType: "APPLICATION/PDF",
+		},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, tag.ID, report.TagID)
+	assert.Equal(t, "application/pdf", report.MIMEType)
 	require.Len(t, report.Hits, 1)
 	assert.Equal(t, tagged.ID, report.Hits[0].Node.ID)
 
 	_, err = c.SearchWithOptions(ctx, "insurance", 10, client.SearchOptions{TagID: "bad"})
 	require.ErrorContains(t, err, "canonical UUIDv4")
+	_, err = c.SearchWithOptions(ctx, "insurance", 10, client.SearchOptions{
+		MIMEType: "application/pdf; version=1",
+	})
+	require.ErrorContains(t, err, "must not include parameters")
 }
 
 func TestMoveToPathValidatesRequestBeforeTransport(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "27"
+	daemonProtocolVersion = "28"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"mime"
 	"strings"
 )
 
@@ -15,9 +16,11 @@ type SearchHit struct {
 }
 
 // SearchOptions narrows ranked search without changing its name-before-content
-// ordering. TagID is the stable identity of one required tag assignment.
+// ordering. TagID identifies one required assignment; MIMEType selects the
+// current file version's parameter-free base media type.
 type SearchOptions struct {
-	TagID string
+	TagID    string
+	MIMEType string
 }
 
 const (
@@ -58,6 +61,11 @@ func (s *Store) SearchPageWithOptions(
 			return nil, false, fmt.Errorf("search tag %q: %w", opts.TagID, err)
 		}
 	}
+	normalizedMIME, err := NormalizeSearchMIMEType(opts.MIMEType)
+	if err != nil {
+		return nil, false, err
+	}
+	opts.MIMEType = normalizedMIME
 	fq := ftsQuery(query)
 	if fq == "" {
 		return nil, false, nil
@@ -142,12 +150,46 @@ func (s *Store) SearchPageWithOptions(
 }
 
 func searchFilterSQL(opts SearchOptions) (string, []any) {
-	if opts.TagID == "" {
+	var (
+		clauses []string
+		args    []any
+	)
+	if opts.TagID != "" {
+		clauses = append(clauses, `AND EXISTS (
+			SELECT 1 FROM node_tags nt WHERE nt.node_id=n.id AND nt.tag_id=?
+		)`)
+		args = append(args, opts.TagID)
+	}
+	if opts.MIMEType != "" {
+		clauses = append(clauses, `AND lower(trim(CASE
+			WHEN instr(cv.mime_type, ';')=0 THEN cv.mime_type
+			ELSE substr(cv.mime_type, 1, instr(cv.mime_type, ';')-1)
+		END))=?`)
+		args = append(args, opts.MIMEType)
+	}
+	return strings.Join(clauses, "\n"), args
+}
+
+// NormalizeSearchMIMEType accepts one parameter-free media type and returns
+// its canonical base spelling. Stored parameters do not participate in search
+// filtering because they describe representation details, not the format.
+func NormalizeSearchMIMEType(value string) (string, error) {
+	if value == "" {
 		return "", nil
 	}
-	return `AND EXISTS (
-		SELECT 1 FROM node_tags nt WHERE nt.node_id=n.id AND nt.tag_id=?
-	)`, []any{opts.TagID}
+	mediaType, params, err := mime.ParseMediaType(value)
+	if err != nil {
+		return "", fmt.Errorf("search MIME type %q is invalid: %w", value, err)
+	}
+	if len(params) != 0 {
+		return "", fmt.Errorf(
+			"search MIME type %q must not include parameters; use %q", value, mediaType,
+		)
+	}
+	if strings.Contains(mediaType, "*") {
+		return "", fmt.Errorf("search MIME type %q must not contain wildcards", value)
+	}
+	return mediaType, nil
 }
 
 func scanSearchRows(rows *sql.Rows, match, query string) ([]SearchHit, error) {

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -179,6 +179,71 @@ func TestSearchPageFiltersNameAndContentMatchesByTag(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestSearchPageFiltersCurrentMediaTypeWithParameters(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	tag, err := s.CreateTag(ctx, "reviewed")
+	require.NoError(t, err)
+	nameMatch, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-return.txt", fakeHash("d4"), 4, "text/plain",
+	)
+	require.NoError(t, err)
+	contentMatch, err := s.CreateFile(
+		ctx, s.RootID(), "notes.bin", fakeHash("e5"), 4, "text/plain; charset=utf-8",
+	)
+	require.NoError(t, err)
+	untaggedText, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-draft.txt", fakeHash("f6"), 4, "text/plain; charset=us-ascii",
+	)
+	require.NoError(t, err)
+	_, err = s.CreateFile(
+		ctx, s.RootID(), "quarterly-scan.pdf", fakeHash("a7"), 4, "application/pdf",
+	)
+	require.NoError(t, err)
+	_, err = s.Mkdir(ctx, s.RootID(), "quarterly-folder")
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, tag.ID, nameMatch.ID, nameMatch.Revision)
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, tag.ID, contentMatch.ID, contentMatch.Revision)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: contentMatch.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "quarterly notes",
+	}))
+
+	hits, truncated, err := s.SearchPageWithOptions(
+		ctx, "quarterly", 10, SearchOptions{MIMEType: "TEXT/PLAIN"},
+	)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, hits, 3)
+	assert.Equal(t, untaggedText.ID, hits[0].Node.ID)
+	assert.Equal(t, nameMatch.ID, hits[1].Node.ID)
+	assert.Equal(t, contentMatch.ID, hits[2].Node.ID)
+	assert.Equal(t, SearchMatchContent, hits[2].Match)
+
+	hits, _, err = s.SearchPageWithOptions(ctx, "quarterly", 10, SearchOptions{
+		TagID: tag.ID, MIMEType: "text/plain",
+	})
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.Equal(t, nameMatch.ID, hits[0].Node.ID)
+	assert.Equal(t, contentMatch.ID, hits[1].Node.ID)
+
+	_, _, err = s.SearchPageWithOptions(
+		ctx, "quarterly", 10, SearchOptions{MIMEType: "text/plain; charset=utf-8"},
+	)
+	require.ErrorContains(t, err, "must not include parameters")
+	_, _, err = s.SearchPageWithOptions(
+		ctx, "quarterly", 10, SearchOptions{MIMEType: "not a media type"},
+	)
+	require.ErrorContains(t, err, "is invalid")
+	_, _, err = s.SearchPageWithOptions(
+		ctx, "quarterly", 10, SearchOptions{MIMEType: "text/*"},
+	)
+	require.ErrorContains(t, err, "must not contain wildcards")
+}
+
 func TestSearchContentFollowsStableNameMatches(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()


### PR DESCRIPTION
A person or agent often knows the kind of document it needs even when the filename or folder is uncertain. Searching the whole vault and filtering a bounded response locally is unsafe: unrelated formats can fill the page before the desired documents appear.

Search can now express that intent directly:

    docbank search "annual report" --mime-type application/pdf

The filter applies to both filename and verified-content matches, so ranking stays exactly as before and truncation describes the filtered result. It looks only at each live file’s current version. Directories and retained historical versions do not match.

The request uses one valid base media type. Matching is case-insensitive and ignores parameters stored on the document, so text/plain also finds text/plain; charset=utf-8. Request parameters and wildcards are rejected rather than creating an accidental query language. The MIME filter composes with --tag when both constraints matter.

JSON echoes the normalized mime_type, and the same contract is available through the authenticated HTTP API and typed Go client. A daemon protocol revision prevents an older process from silently ignoring the new filter and returning an overly broad page.

This remains a deliberately narrow search improvement. Path and date filters still need their own reviewed semantics; this PR does not guess at them.