### PR TITLE
Expose physical write receipts and fail-closed vault reset

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -169,6 +169,8 @@ missing physical authority. The zero value disables compression, preserving the
 unchanged raw loose layout, and mixed raw, zstd, and packed content remains
 readable through the same verified API. Receipts report the chosen physical
 encoding and stored size without changing the logical SHA-256 or size.
+`PutReceipt.Created` reports a new logical node, while `PhysicalCreated`
+separately reports that the operation published new final loose authority.
 
 An eligible write temporarily needs scratch space for both the raw object and
 its compressed candidate before Docbank chooses one for durable publication.

--- a/internal/home/lock.go
+++ b/internal/home/lock.go
@@ -27,8 +27,11 @@ type OwnershipTransition struct {
 }
 
 type ownershipTransitionState struct {
-	layout Layout
-	lock   *Lock
+	layout         Layout
+	lock           *Lock
+	parentIdentity string
+	replacement    *Lock
+	parentIndex    int
 }
 
 var errLockWouldBlock = errors.New("file lock would block")
@@ -118,8 +121,9 @@ func (l Layout) TryLockOwnershipTransition() (*OwnershipTransition, error) {
 		return nil, fmt.Errorf("vault transition parent %s changed while locking", parent)
 	}
 	return &OwnershipTransition{state: &ownershipTransitionState{
-		layout: Layout{Root: target},
-		lock:   lock,
+		layout:         Layout{Root: target},
+		lock:           lock,
+		parentIdentity: identities[len(identities)-1],
 	}}, nil
 }
 
@@ -141,14 +145,161 @@ func (t *OwnershipTransition) OpenAndLockExclusive() (*os.Root, *Lock, error) {
 	return t.state.layout.openAndLockExclusive()
 }
 
-// Release drops the hierarchy-wide acquisition barrier.
-func (t *OwnershipTransition) Release() error {
+// OpenExistingForReplacement owns the existing source and promotes its parent
+// identity lock to an exclusive legacy-compatible barrier. The source target
+// lock remains held while the parent lock changes mode, so a competing legacy
+// owner can only make the promotion fail, not enter the source hierarchy. A
+// legacy sibling owner necessarily prevents promotion because its ordinary
+// lifetime lock shares that parent identity; reset then fails before mutation.
+func (t *OwnershipTransition) OpenExistingForReplacement() (*os.Root, error) {
 	if t == nil || t.state == nil || t.state.lock == nil {
+		return nil, errors.New("vault ownership transition is not held")
+	}
+	if t.state.replacement != nil {
+		return nil, errors.New("vault ownership replacement is already active")
+	}
+	root, replacement, err := t.state.layout.openExistingAndLockExclusive()
+	if err != nil {
+		return nil, err
+	}
+	parentIndex := len(replacement.files) - 3
+	if parentIndex < 0 {
+		err = errors.New("vault ownership replacement has no parent hierarchy lock")
+		return nil, errors.Join(err, replacement.Release(), root.Close())
+	}
+	if err := replacement.relockAt(parentIndex, true, t.state.layout.Root); err != nil {
+		return nil, errors.Join(err, replacement.Release(), root.Close())
+	}
+	t.state.replacement = replacement
+	t.state.parentIndex = parentIndex
+	return root, nil
+}
+
+// ReleaseSourceForReplacement drops the old target identity and local vault
+// locks while retaining the promoted parent hierarchy barrier for rename.
+func (t *OwnershipTransition) ReleaseSourceForReplacement() error {
+	if t == nil || t.state == nil || t.state.replacement == nil {
+		return errors.New("vault ownership replacement is not active")
+	}
+	return t.state.replacement.releaseFrom(t.state.parentIndex + 1)
+}
+
+// OpenAndLockReplacement creates or opens the replacement beneath the held
+// parent barrier, takes its target and local locks, then downgrades the parent
+// to the shared mode retained by an ordinary vault owner.
+func (t *OwnershipTransition) OpenAndLockReplacement() (*os.Root, *Lock, error) {
+	if t == nil || t.state == nil || t.state.lock == nil ||
+		t.state.replacement == nil {
+		return nil, nil, errors.New("vault ownership replacement is not active")
+	}
+	replacement := t.state.replacement
+	if len(replacement.files) != t.state.parentIndex+1 {
+		return nil, nil, errors.New("vault ownership replacement source is still held")
+	}
+	target := t.state.layout.Root
+	parent := filepath.Dir(target)
+	component := filepath.Base(target)
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		return nil, nil, t.failReplacement(
+			nil, fmt.Errorf("checking replacement parent identity: %w", err))
+	}
+	parentIdentity, err := directoryIdentity(parentInfo, parent)
+	if err != nil {
+		return nil, nil, t.failReplacement(nil, err)
+	}
+	if parentIdentity != t.state.parentIdentity {
+		return nil, nil, t.failReplacement(
+			nil, fmt.Errorf("vault replacement parent %s changed while held", parent))
+	}
+	parentRoot, err := os.OpenRoot(parent)
+	if err != nil {
+		return nil, nil, t.failReplacement(
+			nil, fmt.Errorf("opening replacement parent: %w", err))
+	}
+	heldParent, err := parentRoot.Stat(".")
+	if err != nil || !os.SameFile(parentInfo, heldParent) {
+		_ = parentRoot.Close()
+		if err != nil {
+			return nil, nil, t.failReplacement(
+				nil, fmt.Errorf("checking held replacement parent: %w", err))
+		}
+		return nil, nil, t.failReplacement(
+			nil, fmt.Errorf("vault replacement parent %s changed while opening", parent))
+	}
+	root, enterErr := enterVaultDir(parentRoot, component)
+	closeParentErr := parentRoot.Close()
+	if err := errors.Join(enterErr, closeParentErr); err != nil {
+		if root != nil {
+			_ = root.Close()
+		}
+		return nil, nil, t.failReplacement(
+			nil, fmt.Errorf("creating replacement vault root: %w", err))
+	}
+	fail := func(cause error) (*os.Root, *Lock, error) {
+		return nil, nil, t.failReplacement(root, cause)
+	}
+	info, err := root.Stat(".")
+	if err != nil {
+		return fail(fmt.Errorf("checking replacement vault root: %w", err))
+	}
+	identity, err := directoryIdentity(info, target)
+	if err != nil {
+		return fail(err)
+	}
+	registry, err := targetLockRegistryDir()
+	if err != nil {
+		return fail(err)
+	}
+	if err := replacement.lockIdentities(
+		registry, []string{identity}, true, target); err != nil {
+		return fail(err)
+	}
+	local, err := openRootLock(root)
+	if err != nil {
+		return fail(err)
+	}
+	if err := lockFile(local, true); err != nil {
+		_ = local.Close()
+		return fail(classifyLockError(err, target))
+	}
+	replacement.files = append(replacement.files, local)
+	if err := verifyLayoutRoot(target, root); err != nil {
+		return fail(err)
+	}
+	if err := replacement.relockAt(t.state.parentIndex, false, target); err != nil {
+		return fail(err)
+	}
+	t.state.replacement = nil
+	return root, replacement, nil
+}
+
+func (t *OwnershipTransition) failReplacement(root *os.Root, cause error) error {
+	if root != nil {
+		cause = errors.Join(cause, root.Close())
+	}
+	if t != nil && t.state != nil && t.state.replacement != nil {
+		cause = errors.Join(cause, t.state.replacement.Release())
+		t.state.replacement = nil
+	}
+	return cause
+}
+
+// Release drops the hierarchy-wide acquisition and replacement barriers.
+func (t *OwnershipTransition) Release() error {
+	if t == nil || t.state == nil {
 		return nil
 	}
-	err := t.state.lock.Release()
-	t.state.lock = nil
-	return err
+	var replacementErr, acquisitionErr error
+	if t.state.replacement != nil {
+		replacementErr = t.state.replacement.Release()
+		t.state.replacement = nil
+	}
+	if t.state.lock != nil {
+		acquisitionErr = t.state.lock.Release()
+		t.state.lock = nil
+	}
+	return errors.Join(replacementErr, acquisitionErr)
 }
 
 // OpenAndLockExclusive opens an existing vault root or creates a missing one
@@ -701,10 +852,30 @@ func classifyLockError(err error, target string) error {
 	return fmt.Errorf("locking vault target tree: %w", err)
 }
 
-// Release drops the lock.
-func (lk *Lock) Release() error {
+func (lk *Lock) relockAt(index int, exclusive bool, target string) error {
+	if lk == nil || index < 0 || index >= len(lk.files) {
+		return errors.New("vault lock hierarchy entry is unavailable")
+	}
+	f := lk.files[index]
+	if err := unlockFile(f); err != nil {
+		return err
+	}
+	if err := lockFile(f, exclusive); err != nil {
+		closeErr := f.Close()
+		lk.files = append(lk.files[:index], lk.files[index+1:]...)
+		return errors.Join(classifyLockError(err, target), closeErr)
+	}
+	return nil
+}
+
+func (lk *Lock) releaseFrom(index int) error {
+	if lk == nil || index < 0 || index > len(lk.files) {
+		return errors.New("vault lock release boundary is invalid")
+	}
+	files := lk.files[index:]
+	lk.files = lk.files[:index]
 	var errs []error
-	for _, f := range slices.Backward(lk.files) {
+	for _, f := range slices.Backward(files) {
 		if err := unlockFile(f); err != nil {
 			errs = append(errs, err)
 		}
@@ -712,9 +883,16 @@ func (lk *Lock) Release() error {
 			errs = append(errs, err)
 		}
 	}
-	lk.files = nil
 	if err := errors.Join(errs...); err != nil {
 		return fmt.Errorf("releasing vault lock: %w", err)
 	}
 	return nil
+}
+
+// Release drops the lock.
+func (lk *Lock) Release() error {
+	if lk == nil {
+		return nil
+	}
+	return lk.releaseFrom(0)
 }

--- a/internal/home/lock.go
+++ b/internal/home/lock.go
@@ -1,15 +1,11 @@
 package home
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
-	"strings"
 
 	"go.kenn.io/kit/safefileio"
 )
@@ -21,6 +17,18 @@ func (l Layout) LockPath() string { return filepath.Join(l.Root, "vault.lock") }
 // Lock is a held advisory lock on the vault.
 type Lock struct {
 	files []*os.File
+}
+
+// OwnershipTransition excludes ordinary owner acquisition through one stable
+// parent directory while a child vault root changes identity. Reset uses it
+// across the release, rename, and fresh-vault acquisition boundary.
+type OwnershipTransition struct {
+	state *ownershipTransitionState
+}
+
+type ownershipTransitionState struct {
+	layout Layout
+	lock   *Lock
 }
 
 var errLockWouldBlock = errors.New("file lock would block")
@@ -43,11 +51,30 @@ func (l Layout) TryLockExclusive() (*Lock, error) {
 // OpenExistingAndLockExclusive opens and exclusively owns an existing vault
 // root without creating any missing path component.
 func (l Layout) OpenExistingAndLockExclusive() (*os.Root, *Lock, error) {
+	acquisition, err := l.tryLockOwnershipAcquisition()
+	if err != nil {
+		return nil, nil, err
+	}
+	root, lock, openErr := l.openExistingAndLockExclusive()
+	releaseErr := acquisition.Release()
+	if releaseErr != nil {
+		if lock != nil {
+			releaseErr = errors.Join(releaseErr, lock.Release())
+		}
+		if root != nil {
+			releaseErr = errors.Join(releaseErr, root.Close())
+		}
+		return nil, nil, errors.Join(openErr, releaseErr)
+	}
+	return root, lock, openErr
+}
+
+func (l Layout) openExistingAndLockExclusive() (*os.Root, *Lock, error) {
 	root, err := os.OpenRoot(l.Root)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening vault root %s: %w", l.Root, err)
 	}
-	lock, err := l.TryLockExclusiveRoot(root)
+	lock, err := l.tryLockExclusiveRoot(root)
 	if err != nil {
 		_ = root.Close()
 		return nil, nil, err
@@ -55,12 +82,20 @@ func (l Layout) OpenExistingAndLockExclusive() (*os.Root, *Lock, error) {
 	return root, lock, nil
 }
 
-// TryLockTargetCoordinate briefly serializes lifecycle transitions for one
-// canonical vault path. Unlike hierarchy locks keyed by a directory identity,
-// this lock remains stable while reset moves the old directory away and
-// creates a new directory at the same path.
-func (l Layout) TryLockTargetCoordinate() (*Lock, error) {
+// TryLockOwnershipTransition exclusively owns the vault root's stable parent
+// identity. Ordinary owners briefly share its ancestors and exclusively claim
+// their deepest existing identity while taking durable hierarchy locks.
+func (l Layout) TryLockOwnershipTransition() (*OwnershipTransition, error) {
 	target, err := CanonicalRoot(l.Root)
+	if err != nil {
+		return nil, err
+	}
+	parent := filepath.Dir(target)
+	before, err := os.Stat(parent)
+	if err != nil {
+		return nil, fmt.Errorf("checking vault transition parent identity: %w", err)
+	}
+	identities, err := directoryIdentityChain(parent)
 	if err != nil {
 		return nil, err
 	}
@@ -68,30 +103,80 @@ func (l Layout) TryLockTargetCoordinate() (*Lock, error) {
 	if err != nil {
 		return nil, err
 	}
-	coordinate := filepath.Clean(target)
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		coordinate = strings.ToLower(coordinate)
-	}
-	digest := sha256.Sum256([]byte(coordinate))
-	name := "target-" + hex.EncodeToString(digest[:]) + ".lock"
-	f, err := openRegistryLock(registry, name)
-	if err != nil {
+	lock := &Lock{}
+	if err := lock.lockAcquisitionIdentities(
+		registry, identities, true, target); err != nil {
+		_ = lock.Release()
 		return nil, err
 	}
-	if err := lockFile(f, true); err != nil {
-		_ = f.Close()
-		return nil, classifyLockError(err, target)
+	after, err := os.Stat(parent)
+	if err != nil || !os.SameFile(before, after) {
+		_ = lock.Release()
+		if err != nil {
+			return nil, fmt.Errorf("rechecking vault transition parent identity: %w", err)
+		}
+		return nil, fmt.Errorf("vault transition parent %s changed while locking", parent)
 	}
-	return &Lock{files: []*os.File{f}}, nil
+	return &OwnershipTransition{state: &ownershipTransitionState{
+		layout: Layout{Root: target},
+		lock:   lock,
+	}}, nil
+}
+
+// OpenExistingAndLockExclusive validates and owns an existing root while this
+// transition keeps competing ownership acquisition excluded.
+func (t *OwnershipTransition) OpenExistingAndLockExclusive() (*os.Root, *Lock, error) {
+	if t == nil || t.state == nil || t.state.lock == nil {
+		return nil, nil, errors.New("vault ownership transition is not held")
+	}
+	return t.state.layout.openExistingAndLockExclusive()
+}
+
+// OpenAndLockExclusive opens or creates a root while this transition keeps
+// competing ownership acquisition excluded.
+func (t *OwnershipTransition) OpenAndLockExclusive() (*os.Root, *Lock, error) {
+	if t == nil || t.state == nil || t.state.lock == nil {
+		return nil, nil, errors.New("vault ownership transition is not held")
+	}
+	return t.state.layout.openAndLockExclusive()
+}
+
+// Release drops the hierarchy-wide acquisition barrier.
+func (t *OwnershipTransition) Release() error {
+	if t == nil || t.state == nil || t.state.lock == nil {
+		return nil
+	}
+	err := t.state.lock.Release()
+	t.state.lock = nil
+	return err
 }
 
 // OpenAndLockExclusive opens an existing vault root or creates a missing one
 // through a held parent while coordinating every existing ancestor. The
 // returned root is the same directory protected by the returned lock.
 func (l Layout) OpenAndLockExclusive() (*os.Root, *Lock, error) {
+	acquisition, err := l.tryLockOwnershipAcquisition()
+	if err != nil {
+		return nil, nil, err
+	}
+	root, lock, openErr := l.openAndLockExclusive()
+	releaseErr := acquisition.Release()
+	if releaseErr != nil {
+		if lock != nil {
+			releaseErr = errors.Join(releaseErr, lock.Release())
+		}
+		if root != nil {
+			releaseErr = errors.Join(releaseErr, root.Close())
+		}
+		return nil, nil, errors.Join(openErr, releaseErr)
+	}
+	return root, lock, openErr
+}
+
+func (l Layout) openAndLockExclusive() (*os.Root, *Lock, error) {
 	root, err := os.OpenRoot(l.Root)
 	if err == nil {
-		lk, lockErr := l.TryLockExclusiveRoot(root)
+		lk, lockErr := l.tryLockExclusiveRoot(root)
 		if lockErr != nil {
 			_ = root.Close()
 			return nil, nil, lockErr
@@ -200,6 +285,22 @@ func (l Layout) OpenLaunchOutput() (*os.File, string, error) {
 // identity make an owner conflict with restores of parent or descendant trees;
 // the target's ordinary vault.lock preserves coordination with older builds.
 func (l Layout) TryLockExclusiveRoot(root *os.Root) (*Lock, error) {
+	acquisition, err := l.tryLockOwnershipAcquisition()
+	if err != nil {
+		return nil, err
+	}
+	lock, lockErr := l.tryLockExclusiveRoot(root)
+	releaseErr := acquisition.Release()
+	if releaseErr != nil {
+		if lock != nil {
+			releaseErr = errors.Join(releaseErr, lock.Release())
+		}
+		return nil, errors.Join(lockErr, releaseErr)
+	}
+	return lock, lockErr
+}
+
+func (l Layout) tryLockExclusiveRoot(root *os.Root) (*Lock, error) {
 	target, err := filepath.Abs(l.Root)
 	if err != nil {
 		return nil, fmt.Errorf("resolving vault root %s: %w", l.Root, err)
@@ -381,6 +482,76 @@ func (lk *Lock) lockIdentities(
 		f, err := openRegistryLock(registry, identity+".lock")
 		if err != nil {
 			return fmt.Errorf("opening target-tree lock: %w", err)
+		}
+		if err := lockFile(f, exclusive); err != nil {
+			_ = f.Close()
+			return classifyLockError(err, target)
+		}
+		lk.files = append(lk.files, f)
+	}
+	return nil
+}
+
+func (l Layout) tryLockOwnershipAcquisition() (*Lock, error) {
+	target, err := CanonicalRoot(l.Root)
+	if err != nil {
+		return nil, err
+	}
+	current := target
+	for {
+		_, err := os.Stat(current)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("checking vault acquisition ancestor: %w", err)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil, fmt.Errorf("vault root has no existing ancestor: %s", target)
+		}
+		current = parent
+	}
+	before, err := os.Stat(current)
+	if err != nil {
+		return nil, fmt.Errorf("checking vault acquisition ancestor identity: %w", err)
+	}
+	identities, err := directoryIdentityChain(current)
+	if err != nil {
+		return nil, err
+	}
+	registry, err := targetLockRegistryDir()
+	if err != nil {
+		return nil, err
+	}
+	lock := &Lock{}
+	if err := lock.lockAcquisitionIdentities(
+		registry, identities, true, target); err != nil {
+		_ = lock.Release()
+		return nil, err
+	}
+	after, err := os.Stat(current)
+	if err != nil || !os.SameFile(before, after) {
+		_ = lock.Release()
+		if err != nil {
+			return nil, fmt.Errorf("rechecking vault acquisition ancestor identity: %w", err)
+		}
+		return nil, fmt.Errorf("vault acquisition ancestor %s changed while locking", current)
+	}
+	return lock, nil
+}
+
+func (lk *Lock) lockAcquisitionIdentities(
+	registry string,
+	identities []string,
+	exclusiveFinal bool,
+	target string,
+) error {
+	for i, identity := range identities {
+		exclusive := exclusiveFinal && i == len(identities)-1
+		f, err := openRegistryLock(registry, "acquisition-"+identity+".lock")
+		if err != nil {
+			return err
 		}
 		if err := lockFile(f, exclusive); err != nil {
 			_ = f.Close()

--- a/internal/home/lock.go
+++ b/internal/home/lock.go
@@ -1,11 +1,15 @@
 package home
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
+	"strings"
 
 	"go.kenn.io/kit/safefileio"
 )
@@ -29,12 +33,56 @@ var ErrVaultLocked = errors.New("vault is locked by another process")
 // single lock holder for the vault's lifetime; a second daemon (or a stale
 // holder) surfaces immediately instead of hanging.
 func (l Layout) TryLockExclusive() (*Lock, error) {
+	root, lock, err := l.OpenExistingAndLockExclusive()
+	if root != nil {
+		_ = root.Close()
+	}
+	return lock, err
+}
+
+// OpenExistingAndLockExclusive opens and exclusively owns an existing vault
+// root without creating any missing path component.
+func (l Layout) OpenExistingAndLockExclusive() (*os.Root, *Lock, error) {
 	root, err := os.OpenRoot(l.Root)
 	if err != nil {
-		return nil, fmt.Errorf("opening vault root %s: %w", l.Root, err)
+		return nil, nil, fmt.Errorf("opening vault root %s: %w", l.Root, err)
 	}
-	defer func() { _ = root.Close() }()
-	return l.TryLockExclusiveRoot(root)
+	lock, err := l.TryLockExclusiveRoot(root)
+	if err != nil {
+		_ = root.Close()
+		return nil, nil, err
+	}
+	return root, lock, nil
+}
+
+// TryLockTargetCoordinate briefly serializes lifecycle transitions for one
+// canonical vault path. Unlike hierarchy locks keyed by a directory identity,
+// this lock remains stable while reset moves the old directory away and
+// creates a new directory at the same path.
+func (l Layout) TryLockTargetCoordinate() (*Lock, error) {
+	target, err := CanonicalRoot(l.Root)
+	if err != nil {
+		return nil, err
+	}
+	registry, err := targetLockRegistryDir()
+	if err != nil {
+		return nil, err
+	}
+	coordinate := filepath.Clean(target)
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		coordinate = strings.ToLower(coordinate)
+	}
+	digest := sha256.Sum256([]byte(coordinate))
+	name := "target-" + hex.EncodeToString(digest[:]) + ".lock"
+	f, err := openRegistryLock(registry, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockFile(f, true); err != nil {
+		_ = f.Close()
+		return nil, classifyLockError(err, target)
+	}
+	return &Lock{files: []*os.File{f}}, nil
 }
 
 // OpenAndLockExclusive opens an existing vault root or creates a missing one

--- a/internal/home/lock.go
+++ b/internal/home/lock.go
@@ -170,6 +170,20 @@ func (t *OwnershipTransition) OpenExistingForReplacement() (*os.Root, error) {
 	if err := replacement.relockAt(parentIndex, true, t.state.layout.Root); err != nil {
 		return nil, errors.Join(err, replacement.Release(), root.Close())
 	}
+	parent := filepath.Dir(t.state.layout.Root)
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		err = fmt.Errorf("checking vault replacement parent identity: %w", err)
+		return nil, errors.Join(err, replacement.Release(), root.Close())
+	}
+	parentIdentity, err := directoryIdentity(parentInfo, parent)
+	if err != nil {
+		return nil, errors.Join(err, replacement.Release(), root.Close())
+	}
+	if parentIdentity != t.state.parentIdentity {
+		err = fmt.Errorf("vault replacement parent %s changed before rename", parent)
+		return nil, errors.Join(err, replacement.Release(), root.Close())
+	}
 	t.state.replacement = replacement
 	t.state.parentIndex = parentIndex
 	return root, nil

--- a/internal/home/lock.go
+++ b/internal/home/lock.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"go.kenn.io/kit/safefileio"
 )
@@ -102,8 +103,14 @@ func (l Layout) TryLockOwnershipTransition() (*OwnershipTransition, error) {
 	if err != nil {
 		return nil, err
 	}
-	registry, err := targetLockRegistryDir()
+	registry, err := targetLockRegistryPath()
 	if err != nil {
+		return nil, err
+	}
+	if err := validateTransitionRootOutsideRegistry(target, registry); err != nil {
+		return nil, err
+	}
+	if err := ensureTargetLockRegistryDir(registry); err != nil {
 		return nil, err
 	}
 	lock := &Lock{}
@@ -125,6 +132,45 @@ func (l Layout) TryLockOwnershipTransition() (*OwnershipTransition, error) {
 		lock:           lock,
 		parentIdentity: identities[len(identities)-1],
 	}}, nil
+}
+
+func validateTransitionRootOutsideRegistry(target, registry string) error {
+	canonicalRegistry, err := CanonicalRoot(registry)
+	if err != nil {
+		return fmt.Errorf("resolving target-lock registry: %w", err)
+	}
+	if pathContains(target, canonicalRegistry) {
+		return fmt.Errorf("vault transition root %s contains the target-lock registry", target)
+	}
+	targetInfo, err := os.Stat(target)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("vault transition root %s no longer exists", target)
+	}
+	if err != nil {
+		return fmt.Errorf("checking vault transition root: %w", err)
+	}
+	current := canonicalRegistry
+	for {
+		info, statErr := os.Stat(current)
+		if statErr == nil && os.SameFile(info, targetInfo) {
+			return fmt.Errorf(
+				"vault transition root %s contains the target-lock registry", target)
+		}
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return fmt.Errorf("checking target-lock registry ancestor %s: %w", current, statErr)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func pathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	return err == nil && (rel == "." ||
+		(rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))))
 }
 
 // OpenExistingAndLockExclusive validates and owns an existing root while this
@@ -804,7 +850,7 @@ func directoryIdentityChain(target string) ([]string, error) {
 // those unit tests must not contend with cmd/docbank's real daemon processes.
 var targetLockRegistryTestBase string
 
-func targetLockRegistryDir() (string, error) {
+func targetLockRegistryPath() (string, error) {
 	dir := targetLockRegistryTestBase
 	if dir == "" {
 		var err error
@@ -813,8 +859,23 @@ func targetLockRegistryDir() (string, error) {
 			return "", err
 		}
 	}
+	return dir, nil
+}
+
+func ensureTargetLockRegistryDir(dir string) error {
 	if err := safefileio.EnsurePrivateDir(dir); err != nil {
-		return "", fmt.Errorf("securing target-lock registry: %w", err)
+		return fmt.Errorf("securing target-lock registry: %w", err)
+	}
+	return nil
+}
+
+func targetLockRegistryDir() (string, error) {
+	dir, err := targetLockRegistryPath()
+	if err != nil {
+		return "", err
+	}
+	if err := ensureTargetLockRegistryDir(dir); err != nil {
+		return "", err
 	}
 	return dir, nil
 }

--- a/internal/home/lock_test.go
+++ b/internal/home/lock_test.go
@@ -8,6 +8,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTryLockTargetCoordinateIsStablePrivateAndPerCanonicalPath(t *testing.T) {
+	isolateTargetLockRegistry(t)
+	base := t.TempDir()
+	firstPath := filepath.Join(base, "customer-visible-vault-name")
+	secondPath := filepath.Join(base, "other-vault")
+	require.NoError(t, os.Mkdir(firstPath, 0o700))
+	require.NoError(t, os.Mkdir(secondPath, 0o700))
+
+	first, err := (Layout{Root: firstPath}).TryLockTargetCoordinate()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, first.Release()) })
+	_, err = (Layout{Root: firstPath}).TryLockTargetCoordinate()
+	require.ErrorIs(t, err, ErrVaultLocked)
+	second, err := (Layout{Root: secondPath}).TryLockTargetCoordinate()
+	require.NoError(t, err, "unrelated canonical targets must not serialize")
+	require.NoError(t, second.Release())
+
+	entries, err := os.ReadDir(targetLockRegistryTestBase)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	for _, entry := range entries {
+		require.NotContains(t, entry.Name(), "customer-visible-vault-name",
+			"registry names must not expose user-selected path components")
+	}
+}
+
 func TestTryLockExclusive(t *testing.T) {
 	l := Layout{Root: t.TempDir()}
 	require.NoError(t, l.Ensure())

--- a/internal/home/lock_test.go
+++ b/internal/home/lock_test.go
@@ -26,10 +26,13 @@ func TestOwnershipTransitionIsPrivateAndHierarchyWide(t *testing.T) {
 		"identity-changing transitions must exclude every ownership acquisition")
 	nestedParent := filepath.Join(firstPath, "nested")
 	require.NoError(t, os.Mkdir(nestedParent, 0o700))
-	_, err = (Layout{Root: filepath.Join(nestedParent, "vault")}).TryLockOwnershipTransition()
+	nestedPath := filepath.Join(nestedParent, "vault")
+	require.NoError(t, os.Mkdir(nestedPath, 0o700))
+	_, err = (Layout{Root: nestedPath}).TryLockOwnershipTransition()
 	require.ErrorIs(t, err, ErrVaultLocked,
 		"overlapping transitions must coordinate through shared ancestors")
 	disjointPath := filepath.Join(t.TempDir(), "disjoint-vault")
+	require.NoError(t, os.Mkdir(disjointPath, 0o700))
 	disjoint, err := (Layout{Root: disjointPath}).TryLockOwnershipTransition()
 	require.NoError(t, err, "disjoint parent hierarchies must remain independent")
 	require.NoError(t, disjoint.Release())
@@ -112,6 +115,43 @@ func TestOwnershipTransitionExcludesOrdinaryAcquisition(t *testing.T) {
 		_ = lock.Release()
 	}
 	require.Error(t, err, "a copied transition must not bypass ownership after release")
+}
+
+func TestOwnershipTransitionRejectsRegistryInsideSource(t *testing.T) {
+	require.Empty(t, targetLockRegistryTestBase,
+		"target-lock registry tests must not run in parallel")
+	source := filepath.Join(t.TempDir(), "vault")
+	require.NoError(t, os.Mkdir(source, 0o700))
+	targetLockRegistryTestBase = filepath.Join(source, "state", "target-locks")
+	t.Cleanup(func() { targetLockRegistryTestBase = "" })
+
+	transition, err := (Layout{Root: source}).TryLockOwnershipTransition()
+	if transition != nil {
+		t.Cleanup(func() { _ = transition.Release() })
+	}
+
+	require.Nil(t, transition)
+	require.ErrorContains(t, err, "lock registry")
+	require.NoDirExists(t, targetLockRegistryTestBase,
+		"rejecting a movable registry must not mutate the source")
+}
+
+func TestOwnershipTransitionRejectsRegistryInsideMissingSource(t *testing.T) {
+	require.Empty(t, targetLockRegistryTestBase,
+		"target-lock registry tests must not run in parallel")
+	source := filepath.Join(t.TempDir(), "missing-vault")
+	targetLockRegistryTestBase = filepath.Join(source, "state", "target-locks")
+	t.Cleanup(func() { targetLockRegistryTestBase = "" })
+
+	transition, err := (Layout{Root: source}).TryLockOwnershipTransition()
+	if transition != nil {
+		t.Cleanup(func() { _ = transition.Release() })
+	}
+
+	require.Nil(t, transition)
+	require.ErrorContains(t, err, "lock registry")
+	require.NoDirExists(t, source,
+		"rejecting a movable registry must not recreate a missing source")
 }
 
 func TestOwnershipReplacementExcludesLegacyAcquisitionThroughRename(t *testing.T) {

--- a/internal/home/lock_test.go
+++ b/internal/home/lock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTryLockTargetCoordinateIsStablePrivateAndPerCanonicalPath(t *testing.T) {
+func TestOwnershipTransitionIsPrivateAndHierarchyWide(t *testing.T) {
 	isolateTargetLockRegistry(t)
 	base := t.TempDir()
 	firstPath := filepath.Join(base, "customer-visible-vault-name")
@@ -16,14 +16,23 @@ func TestTryLockTargetCoordinateIsStablePrivateAndPerCanonicalPath(t *testing.T)
 	require.NoError(t, os.Mkdir(firstPath, 0o700))
 	require.NoError(t, os.Mkdir(secondPath, 0o700))
 
-	first, err := (Layout{Root: firstPath}).TryLockTargetCoordinate()
+	first, err := (Layout{Root: firstPath}).TryLockOwnershipTransition()
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, first.Release()) })
-	_, err = (Layout{Root: firstPath}).TryLockTargetCoordinate()
+	_, err = (Layout{Root: firstPath}).TryLockOwnershipTransition()
 	require.ErrorIs(t, err, ErrVaultLocked)
-	second, err := (Layout{Root: secondPath}).TryLockTargetCoordinate()
-	require.NoError(t, err, "unrelated canonical targets must not serialize")
-	require.NoError(t, second.Release())
+	_, err = (Layout{Root: secondPath}).TryLockOwnershipTransition()
+	require.ErrorIs(t, err, ErrVaultLocked,
+		"identity-changing transitions must exclude every ownership acquisition")
+	nestedParent := filepath.Join(firstPath, "nested")
+	require.NoError(t, os.Mkdir(nestedParent, 0o700))
+	_, err = (Layout{Root: filepath.Join(nestedParent, "vault")}).TryLockOwnershipTransition()
+	require.ErrorIs(t, err, ErrVaultLocked,
+		"overlapping transitions must coordinate through shared ancestors")
+	disjointPath := filepath.Join(t.TempDir(), "disjoint-vault")
+	disjoint, err := (Layout{Root: disjointPath}).TryLockOwnershipTransition()
+	require.NoError(t, err, "disjoint parent hierarchies must remain independent")
+	require.NoError(t, disjoint.Release())
 
 	entries, err := os.ReadDir(targetLockRegistryTestBase)
 	require.NoError(t, err)
@@ -47,6 +56,62 @@ func TestTryLockExclusive(t *testing.T) {
 	lk2, err := l.TryLockExclusive()
 	require.NoError(t, err)
 	require.NoError(t, lk2.Release())
+}
+
+func TestOwnershipTransitionExcludesOrdinaryAcquisition(t *testing.T) {
+	l := Layout{Root: t.TempDir()}
+	require.NoError(t, l.Ensure())
+
+	transition, err := l.TryLockOwnershipTransition()
+	require.NoError(t, err)
+	defer func() { _ = transition.Release() }()
+
+	root, lock, err := l.OpenAndLockExclusive()
+	if root != nil {
+		_ = root.Close()
+	}
+	if lock != nil {
+		_ = lock.Release()
+	}
+	require.ErrorIs(t, err, ErrVaultLocked,
+		"ordinary ownership entry points must honor reset transitions")
+
+	root, lock, err = l.OpenExistingAndLockExclusive()
+	if root != nil {
+		_ = root.Close()
+	}
+	if lock != nil {
+		_ = lock.Release()
+	}
+	require.ErrorIs(t, err, ErrVaultLocked,
+		"existing-root ownership must honor reset transitions")
+
+	heldRoot, err := os.OpenRoot(l.Root)
+	require.NoError(t, err)
+	defer func() { _ = heldRoot.Close() }()
+	lock, err = l.TryLockExclusiveRoot(heldRoot)
+	if lock != nil {
+		_ = lock.Release()
+	}
+	require.ErrorIs(t, err, ErrVaultLocked,
+		"pinned restore ownership must honor reset transitions")
+
+	root, lock, err = transition.OpenExistingAndLockExclusive()
+	require.NoError(t, err,
+		"the transition holder must be able to validate the existing source")
+	require.NoError(t, root.Close())
+	require.NoError(t, lock.Release())
+
+	stale := *transition
+	require.NoError(t, transition.Release())
+	root, lock, err = stale.OpenExistingAndLockExclusive()
+	if root != nil {
+		_ = root.Close()
+	}
+	if lock != nil {
+		_ = lock.Release()
+	}
+	require.Error(t, err, "a copied transition must not bypass ownership after release")
 }
 
 func TestTryLockExclusiveRejectsOverlappingTrees(t *testing.T) {

--- a/internal/home/lock_test.go
+++ b/internal/home/lock_test.go
@@ -114,6 +114,88 @@ func TestOwnershipTransitionExcludesOrdinaryAcquisition(t *testing.T) {
 	require.Error(t, err, "a copied transition must not bypass ownership after release")
 }
 
+func TestOwnershipReplacementExcludesLegacyAcquisitionThroughRename(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset")
+	require.NoError(t, os.Mkdir(source, 0o700))
+	layout := Layout{Root: source}
+
+	transition, err := layout.TryLockOwnershipTransition()
+	require.NoError(t, err)
+	defer func() { _ = transition.Release() }()
+	root, err := transition.OpenExistingForReplacement()
+	require.NoError(t, err)
+	require.NoError(t, root.Close())
+	require.NoError(t, transition.ReleaseSourceForReplacement())
+	require.NoError(t, os.Rename(source, diagnostic))
+
+	for name, contenderPath := range map[string]string{
+		"exact":  source,
+		"parent": base,
+		"child":  filepath.Join(source, "child"),
+	} {
+		legacyRoot, legacyLock, contenderErr :=
+			(Layout{Root: contenderPath}).openAndLockExclusive()
+		if legacyRoot != nil {
+			_ = legacyRoot.Close()
+		}
+		if legacyLock != nil {
+			_ = legacyLock.Release()
+		}
+		require.ErrorIs(t, contenderErr, ErrVaultLocked,
+			"legacy %s acquisition must honor the replacement barrier", name)
+	}
+	disjointLayout := Layout{Root: filepath.Join(t.TempDir(), "vault")}
+	disjointRoot, disjointLock, err := disjointLayout.openAndLockExclusive()
+	require.NoError(t, err, "a legacy disjoint hierarchy must remain independent")
+	require.NoError(t, disjointRoot.Close())
+	require.NoError(t, disjointLock.Release())
+
+	freshRoot, freshLock, err := transition.OpenAndLockReplacement()
+	require.NoError(t, err)
+	require.NoError(t, transition.Release())
+	legacyRoot, legacyLock, err := layout.openAndLockExclusive()
+	if legacyRoot != nil {
+		_ = legacyRoot.Close()
+	}
+	if legacyLock != nil {
+		_ = legacyLock.Release()
+	}
+	require.ErrorIs(t, err, ErrVaultLocked,
+		"fresh ownership must retain the legacy target lock after transition release")
+	require.NoError(t, freshRoot.Close())
+	require.NoError(t, freshLock.Release())
+}
+
+func TestOwnershipReplacementPromotionFailureReleasesSource(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "vault")
+	sibling := filepath.Join(base, "sibling")
+	require.NoError(t, os.Mkdir(source, 0o700))
+	require.NoError(t, os.Mkdir(sibling, 0o700))
+	siblingRoot, siblingLock, err := (Layout{Root: sibling}).openAndLockExclusive()
+	require.NoError(t, err)
+
+	layout := Layout{Root: source}
+	transition, err := layout.TryLockOwnershipTransition()
+	require.NoError(t, err)
+	root, err := transition.OpenExistingForReplacement()
+	if root != nil {
+		_ = root.Close()
+	}
+	require.ErrorIs(t, err, ErrVaultLocked,
+		"a legacy sibling's shared parent lock must fail replacement closed")
+	require.NoError(t, transition.Release())
+	require.NoError(t, siblingRoot.Close())
+	require.NoError(t, siblingLock.Release())
+
+	root, lock, err := layout.openAndLockExclusive()
+	require.NoError(t, err, "failed promotion must release the source target and local locks")
+	require.NoError(t, root.Close())
+	require.NoError(t, lock.Release())
+}
+
 func TestTryLockExclusiveRejectsOverlappingTrees(t *testing.T) {
 	base := t.TempDir()
 	parent := filepath.Join(base, "restore")

--- a/types.go
+++ b/types.go
@@ -94,12 +94,13 @@ type ProvenancePage struct {
 
 // PutReceipt proves the computed identity and resulting logical authority.
 type PutReceipt struct {
-	Node     Node            `json:"node"`
-	Version  ContentVersion  `json:"version"`
-	Computed ContentIdentity `json:"computed"`
-	Physical PhysicalContent `json:"physical"`
-	Created  bool            `json:"created"`
-	Replaced bool            `json:"replaced"`
+	Node            Node            `json:"node"`
+	Version         ContentVersion  `json:"version"`
+	Computed        ContentIdentity `json:"computed"`
+	Physical        PhysicalContent `json:"physical"`
+	Created         bool            `json:"created"`
+	PhysicalCreated bool            `json:"physical_created"`
+	Replaced        bool            `json:"replaced"`
 }
 
 // RepairReceipt proves the replacement bytes and reports the resulting

--- a/vault.go
+++ b/vault.go
@@ -111,19 +111,7 @@ func New(ctx context.Context, config Config) (_ *Vault, retErr error) {
 		return nil, err
 	}
 	layout := home.Layout{Root: config.Root}
-	coordinate, err := layout.TryLockTargetCoordinate()
-	if err != nil {
-		return nil, err
-	}
-	vault, openErr := openVaultWithLayout(config, blobOptions, layout)
-	coordinateErr := coordinate.Release()
-	if openErr != nil || coordinateErr != nil {
-		if vault != nil {
-			coordinateErr = errors.Join(coordinateErr, vault.Close())
-		}
-		return nil, errors.Join(openErr, coordinateErr)
-	}
-	return vault, nil
+	return openVaultWithLayout(config, blobOptions, layout)
 }
 
 func normalizeVaultConfig(
@@ -164,7 +152,17 @@ func openVaultWithLayout(
 	blobOptions blob.Options,
 	layout home.Layout,
 ) (_ *Vault, retErr error) {
-	root, lock, err := layout.OpenAndLockExclusive()
+	return openVaultWithRootOpener(
+		config, blobOptions, layout, layout.OpenAndLockExclusive)
+}
+
+func openVaultWithRootOpener(
+	config Config,
+	blobOptions blob.Options,
+	layout home.Layout,
+	openRoot func() (*os.Root, *home.Lock, error),
+) (_ *Vault, retErr error) {
+	root, lock, err := openRoot()
 	if err != nil {
 		return nil, err
 	}

--- a/vault.go
+++ b/vault.go
@@ -629,6 +629,7 @@ func (v *Vault) write(
 	v.mutation.Lock()
 	defer v.mutation.Unlock()
 	var receipt PutReceipt
+	var physicalCreated bool
 	err = v.blobs.WithMutation(ctx, func() (resultErr error) {
 		written, writeErr := v.blobs.WriteDetailedContext(ctx, content)
 		if writeErr != nil {
@@ -639,6 +640,7 @@ func (v *Vault) write(
 		if physicalErr != nil {
 			return physicalErr
 		}
+		physicalCreated = physical.Created
 		defer func() {
 			if resultErr != nil {
 				resultErr = errors.Join(resultErr, v.removeUnrecordedLoose(hash))
@@ -760,6 +762,7 @@ func (v *Vault) write(
 	if err != nil {
 		return receipt, err
 	}
+	receipt.PhysicalCreated = physicalCreated && receipt.Physical.Kind == "loose"
 	return receipt, nil
 }
 

--- a/vault.go
+++ b/vault.go
@@ -106,18 +106,41 @@ type Vault struct {
 // lock until Close. A standalone daemon or another embedded instance cannot
 // own the same or an overlapping vault concurrently.
 func New(ctx context.Context, config Config) (_ *Vault, retErr error) {
-	if err := ctx.Err(); err != nil {
+	config, blobOptions, err := normalizeVaultConfig(ctx, config)
+	if err != nil {
 		return nil, err
+	}
+	layout := home.Layout{Root: config.Root}
+	coordinate, err := layout.TryLockTargetCoordinate()
+	if err != nil {
+		return nil, err
+	}
+	vault, openErr := openVaultWithLayout(config, blobOptions, layout)
+	coordinateErr := coordinate.Release()
+	if openErr != nil || coordinateErr != nil {
+		if vault != nil {
+			coordinateErr = errors.Join(coordinateErr, vault.Close())
+		}
+		return nil, errors.Join(openErr, coordinateErr)
+	}
+	return vault, nil
+}
+
+func normalizeVaultConfig(
+	ctx context.Context, config Config,
+) (Config, blob.Options, error) {
+	if err := ctx.Err(); err != nil {
+		return Config{}, blob.Options{}, err
 	}
 	driver := config.SQLite
 	if driver == nil {
 		driver = store.DefaultSQLiteDriver()
 	}
 	if err := docsqlite.Validate(driver); err != nil {
-		return nil, err
+		return Config{}, blob.Options{}, err
 	}
 	if config.Root == "" {
-		return nil, errors.New("docbank vault root is required")
+		return Config{}, blob.Options{}, errors.New("docbank vault root is required")
 	}
 	blobOptions := blob.Options{LooseCompression: blob.LooseCompressionOptions{
 		Enabled:           config.LooseCompression.Enabled,
@@ -125,13 +148,22 @@ func New(ctx context.Context, config Config) (_ *Vault, retErr error) {
 		MinSavingsPercent: config.LooseCompression.MinSavingsPercent,
 	}}
 	if err := blob.ValidateOptions(blobOptions); err != nil {
-		return nil, fmt.Errorf("docbank %w", err)
+		return Config{}, blob.Options{}, fmt.Errorf("docbank %w", err)
 	}
 	canonical, err := home.CanonicalRoot(config.Root)
 	if err != nil {
-		return nil, err
+		return Config{}, blob.Options{}, err
 	}
-	layout := home.Layout{Root: canonical}
+	config.Root = canonical
+	config.SQLite = driver
+	return config, blobOptions, nil
+}
+
+func openVaultWithLayout(
+	config Config,
+	blobOptions blob.Options,
+	layout home.Layout,
+) (_ *Vault, retErr error) {
 	root, lock, err := layout.OpenAndLockExclusive()
 	if err != nil {
 		return nil, err
@@ -144,7 +176,7 @@ func New(ctx context.Context, config Config) (_ *Vault, retErr error) {
 	if err := layout.Ensure(); err != nil {
 		return nil, err
 	}
-	metadata, err := store.Open(layout.DBPath(), driver)
+	metadata, err := store.Open(layout.DBPath(), config.SQLite)
 	if err != nil {
 		return nil, err
 	}

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -83,6 +83,10 @@ func ResetVault(
 	if err := validateResetPaths(sourceRoot, diagnosticRoot); err != nil {
 		return nil, err
 	}
+	expectedSourceIdentity, err := os.Stat(sourceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("capturing docbank reset source identity: %w", err)
+	}
 	if opts.ReleaseCurrent != nil {
 		if err := opts.ReleaseCurrent(); err != nil {
 			return nil, fmt.Errorf("releasing current docbank vault before reset: %w", err)
@@ -94,9 +98,13 @@ func ResetVault(
 		return nil, fmt.Errorf("locking existing docbank vault for reset: %w", err)
 	}
 	heldIdentity, identityErr := root.Stat(".")
+	var changedIdentityErr error
+	if identityErr == nil && !os.SameFile(expectedSourceIdentity, heldIdentity) {
+		changedIdentityErr = errors.New("docbank reset source changed while releasing current owner")
+	}
 	sourceErr := validateResetSourcePath(sourceRoot)
 	closeErr := errors.Join(root.Close(), transition.ReleaseSourceForReplacement())
-	if err := errors.Join(identityErr, sourceErr, closeErr); err != nil {
+	if err := errors.Join(identityErr, changedIdentityErr, sourceErr, closeErr); err != nil {
 		return nil, fmt.Errorf("validating existing docbank vault before reset rename: %w", err)
 	}
 	currentIdentity, err := os.Stat(sourceRoot)
@@ -126,6 +134,17 @@ func ResetVault(
 		return nil, fmt.Errorf(
 			"opening fresh docbank vault at %s after moving the original to %s: %w",
 			sourceRoot, diagnosticRoot, err,
+		)
+	}
+	if err := syncResetParentDirectory(filepath.Dir(sourceRoot)); err != nil {
+		closeErr := fresh.Close()
+		fresh = nil
+		return nil, errors.Join(
+			fmt.Errorf(
+				"syncing docbank reset parent after initializing the fresh vault at %s: %w",
+				sourceRoot, err,
+			),
+			closeErr,
 		)
 	}
 	return fresh, nil

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -12,11 +12,11 @@ import (
 )
 
 // ResetOptions defines the explicit move-aside boundary for ResetVault.
-// ReleaseCurrent, when set, is called exactly once after reset owns the stable
-// target coordinate and validates both paths, but before it takes ordinary
-// ownership of the source directory. Embedded applications use it to hand an
-// already-open vault and any surrounding lifecycle state to reset without an
-// ownership gap.
+// ReleaseCurrent, when set, is called exactly once after reset excludes every
+// overlapping hierarchy-owner acquisition and validates both paths, but before
+// it takes ordinary ownership of the source directory. Embedded applications
+// use it to hand an already-open vault and any surrounding lifecycle state to
+// reset without an ownership gap.
 type ResetOptions struct {
 	DiagnosticRoot string
 	ReleaseCurrent func() error
@@ -58,20 +58,13 @@ func ResetVault(
 	}
 
 	sourceLayout := home.Layout{Root: sourceRoot}
-	sourceCoordinate, err := sourceLayout.TryLockTargetCoordinate()
+	transition, err := sourceLayout.TryLockOwnershipTransition()
 	if err != nil {
-		return nil, fmt.Errorf("locking docbank reset source coordinate: %w", err)
-	}
-	diagnosticCoordinate, err := (home.Layout{Root: diagnosticRoot}).TryLockTargetCoordinate()
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("locking docbank reset diagnostic coordinate: %w", err),
-			sourceCoordinate.Release(),
-		)
+		return nil, fmt.Errorf("excluding docbank vault ownership during reset: %w", err)
 	}
 	moved := false
 	defer func() {
-		releaseErr := errors.Join(diagnosticCoordinate.Release(), sourceCoordinate.Release())
+		releaseErr := transition.Release()
 		if releaseErr == nil {
 			return
 		}
@@ -96,7 +89,7 @@ func ResetVault(
 		}
 	}
 
-	root, lock, err := sourceLayout.OpenExistingAndLockExclusive()
+	root, lock, err := transition.OpenExistingAndLockExclusive()
 	if err != nil {
 		return nil, fmt.Errorf("locking existing docbank vault for reset: %w", err)
 	}
@@ -117,7 +110,11 @@ func ResetVault(
 	}
 	moved = true
 
-	fresh, err = openVaultWithLayout(config, blobOptions, sourceLayout)
+	fresh, err = openVaultWithRootOpener(config, blobOptions, sourceLayout, func() (
+		*os.Root, *home.Lock, error,
+	) {
+		return transition.OpenAndLockExclusive()
+	})
 	if err != nil {
 		return nil, fmt.Errorf(
 			"opening fresh docbank vault at %s after moving the original to %s: %w",

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -1,0 +1,146 @@
+package docbank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/docbank/internal/home"
+)
+
+// ResetOptions defines the explicit move-aside boundary for ResetVault.
+// ReleaseCurrent, when set, is called exactly once after reset owns the stable
+// target coordinate and validates both paths, but before it takes ordinary
+// ownership of the source directory. Embedded applications use it to hand an
+// already-open vault and any surrounding lifecycle state to reset without an
+// ownership gap.
+type ResetOptions struct {
+	DiagnosticRoot string
+	ReleaseCurrent func() error
+}
+
+// ResetVault atomically moves an existing vault to an absent diagnostic
+// sibling and creates a fresh vault at the original canonical path. It never
+// opens the source catalog and never deletes the source, diagnostic, or a
+// partially initialized fresh vault. The returned fresh vault retains ordinary
+// exclusive hierarchy ownership until Close.
+func ResetVault(
+	ctx context.Context, config Config, opts ResetOptions,
+) (fresh *Vault, retErr error) {
+	requestedRoot := config.Root
+	config, blobOptions, err := normalizeVaultConfig(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	requestedInfo, err := os.Lstat(requestedRoot)
+	if err == nil && requestedInfo.Mode()&fs.ModeSymlink != 0 {
+		return nil, errors.New("docbank reset source must not be a symlink")
+	}
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("checking requested docbank reset source: %w", err)
+	}
+	if opts.DiagnosticRoot == "" {
+		return nil, errors.New("docbank reset diagnostic root is required")
+	}
+	diagnosticRoot, err := home.CanonicalRoot(opts.DiagnosticRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolving docbank reset diagnostic root: %w", err)
+	}
+	sourceRoot := config.Root
+	if sourceRoot == diagnosticRoot || filepath.Dir(sourceRoot) != filepath.Dir(diagnosticRoot) {
+		return nil, errors.New("docbank reset diagnostic root must be an absent sibling of the vault root")
+	}
+	if err := validateResetPaths(sourceRoot, diagnosticRoot); err != nil {
+		return nil, err
+	}
+
+	sourceLayout := home.Layout{Root: sourceRoot}
+	sourceCoordinate, err := sourceLayout.TryLockTargetCoordinate()
+	if err != nil {
+		return nil, fmt.Errorf("locking docbank reset source coordinate: %w", err)
+	}
+	diagnosticCoordinate, err := (home.Layout{Root: diagnosticRoot}).TryLockTargetCoordinate()
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("locking docbank reset diagnostic coordinate: %w", err),
+			sourceCoordinate.Release(),
+		)
+	}
+	moved := false
+	defer func() {
+		releaseErr := errors.Join(diagnosticCoordinate.Release(), sourceCoordinate.Release())
+		if releaseErr == nil {
+			return
+		}
+		if fresh != nil {
+			releaseErr = errors.Join(releaseErr, fresh.Close())
+			fresh = nil
+		}
+		if moved {
+			releaseErr = fmt.Errorf(
+				"releasing reset coordination for fresh docbank vault at %s after moving the original to %s: %w",
+				sourceRoot, diagnosticRoot, releaseErr,
+			)
+		}
+		retErr = errors.Join(retErr, releaseErr)
+	}()
+	if err := validateResetPaths(sourceRoot, diagnosticRoot); err != nil {
+		return nil, err
+	}
+	if opts.ReleaseCurrent != nil {
+		if err := opts.ReleaseCurrent(); err != nil {
+			return nil, fmt.Errorf("releasing current docbank vault before reset: %w", err)
+		}
+	}
+
+	root, lock, err := sourceLayout.OpenExistingAndLockExclusive()
+	if err != nil {
+		return nil, fmt.Errorf("locking existing docbank vault for reset: %w", err)
+	}
+	heldIdentity, identityErr := root.Stat(".")
+	closeErr := errors.Join(root.Close(), lock.Release())
+	if err := errors.Join(identityErr, closeErr); err != nil {
+		return nil, fmt.Errorf("releasing existing docbank vault before reset rename: %w", err)
+	}
+	currentIdentity, err := os.Stat(sourceRoot)
+	if err != nil || !os.SameFile(heldIdentity, currentIdentity) {
+		if err != nil {
+			return nil, fmt.Errorf("rechecking docbank reset source: %w", err)
+		}
+		return nil, errors.New("docbank reset source changed before rename")
+	}
+	if err := renameVaultNoReplace(sourceRoot, diagnosticRoot); err != nil {
+		return nil, fmt.Errorf("moving docbank vault aside: %w", err)
+	}
+	moved = true
+
+	fresh, err = openVaultWithLayout(config, blobOptions, sourceLayout)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"opening fresh docbank vault at %s after moving the original to %s: %w",
+			sourceRoot, diagnosticRoot, err,
+		)
+	}
+	return fresh, nil
+}
+
+func validateResetPaths(sourceRoot, diagnosticRoot string) error {
+	source, err := os.Lstat(sourceRoot)
+	if err != nil {
+		return fmt.Errorf("checking docbank reset source: %w", err)
+	}
+	if source.Mode()&fs.ModeSymlink != 0 || !source.IsDir() {
+		return errors.New("docbank reset source must be one real existing directory")
+	}
+	_, err = os.Lstat(diagnosticRoot)
+	if err == nil {
+		return fmt.Errorf("docbank reset diagnostic destination already exists: %s", diagnosticRoot)
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("checking docbank reset diagnostic destination: %w", err)
+	}
+	return nil
+}

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -9,7 +9,10 @@ import (
 	"path/filepath"
 
 	"go.kenn.io/docbank/internal/home"
+	"go.kenn.io/kit/pack"
 )
+
+var syncResetParentDirectory = pack.SyncDir
 
 // ResetOptions defines the explicit move-aside boundary for ResetVault.
 // ReleaseCurrent, when set, is called exactly once after reset excludes every
@@ -107,6 +110,12 @@ func ResetVault(
 		return nil, fmt.Errorf("moving docbank vault aside: %w", err)
 	}
 	moved = true
+	if err := syncResetParentDirectory(filepath.Dir(sourceRoot)); err != nil {
+		return nil, fmt.Errorf(
+			"syncing docbank reset parent after moving the original to %s: %w",
+			diagnosticRoot, err,
+		)
+	}
 
 	fresh, err = openVaultWithRootOpener(config, blobOptions, sourceLayout, func() (
 		*os.Root, *home.Lock, error,

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -83,8 +83,13 @@ func ResetVault(
 	if err := validateResetPaths(sourceRoot, diagnosticRoot); err != nil {
 		return nil, err
 	}
-	expectedSourceIdentity, err := os.Stat(sourceRoot)
+	sourceIdentityRoot, err := os.OpenRoot(sourceRoot)
 	if err != nil {
+		return nil, fmt.Errorf("opening docbank reset source to capture its identity: %w", err)
+	}
+	expectedSourceIdentity, identityErr := sourceIdentityRoot.Stat(".")
+	closeIdentityErr := sourceIdentityRoot.Close()
+	if err := errors.Join(identityErr, closeIdentityErr); err != nil {
 		return nil, fmt.Errorf("capturing docbank reset source identity: %w", err)
 	}
 	if opts.ReleaseCurrent != nil {

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -35,10 +35,7 @@ func ResetVault(
 	if err != nil {
 		return nil, err
 	}
-	requestedInfo, err := os.Lstat(requestedRoot)
-	if err == nil && requestedInfo.Mode()&fs.ModeSymlink != 0 {
-		return nil, errors.New("docbank reset source must not be a symlink")
-	}
+	err = validateResetSourcePath(requestedRoot)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, fmt.Errorf("checking requested docbank reset source: %w", err)
 	}
@@ -94,9 +91,10 @@ func ResetVault(
 		return nil, fmt.Errorf("locking existing docbank vault for reset: %w", err)
 	}
 	heldIdentity, identityErr := root.Stat(".")
+	sourceErr := validateResetSourcePath(sourceRoot)
 	closeErr := errors.Join(root.Close(), transition.ReleaseSourceForReplacement())
-	if err := errors.Join(identityErr, closeErr); err != nil {
-		return nil, fmt.Errorf("releasing existing docbank vault before reset rename: %w", err)
+	if err := errors.Join(identityErr, sourceErr, closeErr); err != nil {
+		return nil, fmt.Errorf("validating existing docbank vault before reset rename: %w", err)
 	}
 	currentIdentity, err := os.Stat(sourceRoot)
 	if err != nil || !os.SameFile(heldIdentity, currentIdentity) {
@@ -125,14 +123,10 @@ func ResetVault(
 }
 
 func validateResetPaths(sourceRoot, diagnosticRoot string) error {
-	source, err := os.Lstat(sourceRoot)
-	if err != nil {
+	if err := validateResetSourcePath(sourceRoot); err != nil {
 		return fmt.Errorf("checking docbank reset source: %w", err)
 	}
-	if source.Mode()&fs.ModeSymlink != 0 || !source.IsDir() {
-		return errors.New("docbank reset source must be one real existing directory")
-	}
-	_, err = os.Lstat(diagnosticRoot)
+	_, err := os.Lstat(diagnosticRoot)
 	if err == nil {
 		return fmt.Errorf("docbank reset diagnostic destination already exists: %s", diagnosticRoot)
 	}

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -30,7 +30,7 @@ type ResetOptions struct {
 func ResetVault(
 	ctx context.Context, config Config, opts ResetOptions,
 ) (fresh *Vault, retErr error) {
-	requestedRoot := config.Root
+	requestedRoot := filepath.Clean(config.Root)
 	config, blobOptions, err := normalizeVaultConfig(ctx, config)
 	if err != nil {
 		return nil, err

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -89,12 +89,12 @@ func ResetVault(
 		}
 	}
 
-	root, lock, err := transition.OpenExistingAndLockExclusive()
+	root, err := transition.OpenExistingForReplacement()
 	if err != nil {
 		return nil, fmt.Errorf("locking existing docbank vault for reset: %w", err)
 	}
 	heldIdentity, identityErr := root.Stat(".")
-	closeErr := errors.Join(root.Close(), lock.Release())
+	closeErr := errors.Join(root.Close(), transition.ReleaseSourceForReplacement())
 	if err := errors.Join(identityErr, closeErr); err != nil {
 		return nil, fmt.Errorf("releasing existing docbank vault before reset rename: %w", err)
 	}
@@ -113,7 +113,7 @@ func ResetVault(
 	fresh, err = openVaultWithRootOpener(config, blobOptions, sourceLayout, func() (
 		*os.Root, *home.Lock, error,
 	) {
-		return transition.OpenAndLockExclusive()
+		return transition.OpenAndLockReplacement()
 	})
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/vault_reset.go
+++ b/vault_reset.go
@@ -47,8 +47,8 @@ func ResetVault(
 		return nil, fmt.Errorf("resolving docbank reset diagnostic root: %w", err)
 	}
 	sourceRoot := config.Root
-	if sourceRoot == diagnosticRoot || filepath.Dir(sourceRoot) != filepath.Dir(diagnosticRoot) {
-		return nil, errors.New("docbank reset diagnostic root must be an absent sibling of the vault root")
+	if err := validateResetRootRelationship(sourceRoot, diagnosticRoot); err != nil {
+		return nil, err
 	}
 	if err := validateResetPaths(sourceRoot, diagnosticRoot); err != nil {
 		return nil, err
@@ -120,6 +120,17 @@ func ResetVault(
 		)
 	}
 	return fresh, nil
+}
+
+func validateResetRootRelationship(sourceRoot, diagnosticRoot string) error {
+	sourceParent := filepath.Dir(sourceRoot)
+	if sourceParent == sourceRoot {
+		return errors.New("docbank reset source must not be a filesystem root")
+	}
+	if sourceRoot == diagnosticRoot || sourceParent != filepath.Dir(diagnosticRoot) {
+		return errors.New("docbank reset diagnostic root must be an absent sibling of the vault root")
+	}
+	return nil
 }
 
 func validateResetPaths(sourceRoot, diagnosticRoot string) error {

--- a/vault_reset_alias_unix_test.go
+++ b/vault_reset_alias_unix_test.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package docbank
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/pkg/sqlite/modernc"
+)
+
+func TestResetVaultRevalidatesSourceAliasAfterOwnerRelease(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	parked := filepath.Join(base, "vault.parked")
+	diagnostic := filepath.Join(base, "vault.reset")
+	current, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+
+	fresh, err := ResetVault(
+		t.Context(),
+		Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{
+			DiagnosticRoot: diagnostic,
+			ReleaseCurrent: func() error {
+				if err := current.Close(); err != nil {
+					return err
+				}
+				if err := os.Rename(root, parked); err != nil {
+					return err
+				}
+				return os.Symlink(parked, root)
+			},
+		},
+	)
+	if fresh != nil {
+		t.Cleanup(func() { _ = fresh.Close() })
+	}
+
+	assert.Nil(t, fresh)
+	require.ErrorContains(t, err, "symlink")
+	info, statErr := os.Lstat(root)
+	require.NoError(t, statErr)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
+	assert.DirExists(t, parked)
+	assert.NoDirExists(t, diagnostic)
+}

--- a/vault_reset_rename_darwin.go
+++ b/vault_reset_rename_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package docbank
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func renameVaultNoReplace(source, destination string) error {
+	if err := unix.RenamexNp(source, destination, unix.RENAME_EXCL); err != nil {
+		return &os.LinkError{Op: "renamex_np", Old: source, New: destination, Err: err}
+	}
+	return nil
+}

--- a/vault_reset_rename_linux.go
+++ b/vault_reset_rename_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package docbank
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func renameVaultNoReplace(source, destination string) error {
+	if err := unix.Renameat2(
+		unix.AT_FDCWD, source, unix.AT_FDCWD, destination, unix.RENAME_NOREPLACE,
+	); err != nil {
+		return &os.LinkError{Op: "renameat2", Old: source, New: destination, Err: err}
+	}
+	return nil
+}

--- a/vault_reset_rename_other.go
+++ b/vault_reset_rename_other.go
@@ -1,0 +1,14 @@
+//go:build !darwin && !linux && !windows
+
+package docbank
+
+import (
+	"errors"
+	"os"
+)
+
+func renameVaultNoReplace(source, destination string) error {
+	return &os.LinkError{
+		Op: "rename-noreplace", Old: source, New: destination, Err: errors.ErrUnsupported,
+	}
+}

--- a/vault_reset_rename_windows.go
+++ b/vault_reset_rename_windows.go
@@ -5,19 +5,35 @@ package docbank
 import (
 	"os"
 
+	"go.kenn.io/docbank/internal/winsecurity"
 	"golang.org/x/sys/windows"
 )
 
 func renameVaultNoReplace(source, destination string) error {
-	sourceName, err := windows.UTF16PtrFromString(source)
+	return renameVaultNoReplaceWithMove(source, destination, windows.MoveFile)
+}
+
+func renameVaultNoReplaceWithMove(
+	source, destination string,
+	move func(*uint16, *uint16) error,
+) error {
+	extendedSource, err := winsecurity.ExtendedLengthPath(source)
 	if err != nil {
 		return err
 	}
-	destinationName, err := windows.UTF16PtrFromString(destination)
+	extendedDestination, err := winsecurity.ExtendedLengthPath(destination)
 	if err != nil {
 		return err
 	}
-	if err := windows.MoveFile(sourceName, destinationName); err != nil {
+	sourceName, err := windows.UTF16PtrFromString(extendedSource)
+	if err != nil {
+		return err
+	}
+	destinationName, err := windows.UTF16PtrFromString(extendedDestination)
+	if err != nil {
+		return err
+	}
+	if err := move(sourceName, destinationName); err != nil {
 		return &os.LinkError{Op: "MoveFileW", Old: source, New: destination, Err: err}
 	}
 	return nil

--- a/vault_reset_rename_windows.go
+++ b/vault_reset_rename_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package docbank
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func renameVaultNoReplace(source, destination string) error {
+	sourceName, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationName, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	if err := windows.MoveFile(sourceName, destinationName); err != nil {
+		return &os.LinkError{Op: "MoveFileW", Old: source, New: destination, Err: err}
+	}
+	return nil
+}

--- a/vault_reset_source.go
+++ b/vault_reset_source.go
@@ -1,0 +1,26 @@
+package docbank
+
+import "errors"
+
+type resetSourceAttributes struct {
+	directory bool
+	reparse   bool
+}
+
+func validateResetSourcePath(path string) error {
+	attributes, err := resetSourceAttributesNoFollow(path)
+	if err != nil {
+		return err
+	}
+	return validateResetSourceAttributes(attributes)
+}
+
+func validateResetSourceAttributes(attributes resetSourceAttributes) error {
+	if attributes.reparse {
+		return errors.New("docbank reset source must not be a symlink or reparse point")
+	}
+	if !attributes.directory {
+		return errors.New("docbank reset source must be one real existing directory")
+	}
+	return nil
+}

--- a/vault_reset_source_unix.go
+++ b/vault_reset_source_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package docbank
+
+import (
+	"os"
+)
+
+func resetSourceAttributesNoFollow(path string) (resetSourceAttributes, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return resetSourceAttributes{}, err
+	}
+	return resetSourceAttributes{
+		directory: info.IsDir(),
+		reparse:   info.Mode()&os.ModeSymlink != 0,
+	}, nil
+}

--- a/vault_reset_source_windows.go
+++ b/vault_reset_source_windows.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package docbank
+
+import (
+	"fmt"
+	"os"
+
+	"go.kenn.io/docbank/internal/winsecurity"
+	"golang.org/x/sys/windows"
+)
+
+func resetSourceAttributesNoFollow(path string) (resetSourceAttributes, error) {
+	extended, err := winsecurity.ExtendedLengthPath(path)
+	if err != nil {
+		return resetSourceAttributes{}, fmt.Errorf("resolving reset source path: %w", err)
+	}
+	path16, err := windows.UTF16PtrFromString(extended)
+	if err != nil {
+		return resetSourceAttributes{}, fmt.Errorf("encoding reset source path: %w", err)
+	}
+	handle, err := windows.CreateFile(
+		path16,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return resetSourceAttributes{}, &os.PathError{
+			Op:   "CreateFile",
+			Path: path,
+			Err:  err,
+		}
+	}
+	defer windows.CloseHandle(handle)
+
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return resetSourceAttributes{}, &os.PathError{
+			Op:   "GetFileInformationByHandle",
+			Path: path,
+			Err:  err,
+		}
+	}
+	return resetSourceAttributes{
+		directory: info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0,
+		reparse:   info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0,
+	}, nil
+}

--- a/vault_reset_test.go
+++ b/vault_reset_test.go
@@ -1,0 +1,267 @@
+package docbank
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	docsqlite "go.kenn.io/docbank/pkg/sqlite"
+	"go.kenn.io/docbank/pkg/sqlite/modernc"
+)
+
+func TestResetVaultRecoversCorruptCatalogWithoutDeletingDiagnosticVault(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset-20260722T120000Z")
+	vault, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	_, err = vault.Put(t.Context(), "/kept.txt", bytes.NewBufferString("kept bytes\n"), PutOptions{})
+	require.NoError(t, err)
+	require.NoError(t, vault.Close())
+	corrupt := []byte("not a sqlite catalog")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docbank.db"), corrupt, 0o600))
+
+	fresh, err := ResetVault(t.Context(), Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{DiagnosticRoot: diagnostic})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fresh.Close()) })
+
+	assert.FileExists(t, filepath.Join(root, "docbank.db"))
+	assert.DirExists(t, diagnostic)
+	assert.Equal(t, corrupt, mustReadResetFile(t, filepath.Join(diagnostic, "docbank.db")))
+	digest := contentIdentity([]byte("kept bytes\n")).SHA256
+	assert.Equal(t, []byte("kept bytes\n"),
+		mustReadResetFile(t, filepath.Join(diagnostic, "blobs", digest[:2], digest)))
+	_, err = fresh.Stat(t.Context(), "/kept.txt")
+	require.ErrorIs(t, err, ErrNotFound, "the replacement must be a fresh logical vault")
+	contender, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	if contender != nil {
+		_ = contender.Close()
+	}
+	require.Error(t, err, "the returned fresh vault must retain ordinary ownership")
+}
+
+func TestResetVaultValidatesSourceAndDestinationWithoutMutation(t *testing.T) {
+	t.Run("invalid config before release callback", func(t *testing.T) {
+		called := false
+		fresh, err := ResetVault(t.Context(), Config{
+			Root: filepath.Join(t.TempDir(), "vault"),
+			LooseCompression: LooseCompressionOptions{
+				MinSavingsPercent: 101,
+			},
+		}, ResetOptions{
+			DiagnosticRoot: filepath.Join(t.TempDir(), "vault.reset"),
+			ReleaseCurrent: func() error { called = true; return nil },
+		})
+
+		assert.Nil(t, fresh)
+		require.Error(t, err)
+		assert.False(t, called)
+	})
+
+	t.Run("missing source", func(t *testing.T) {
+		base := t.TempDir()
+		root := filepath.Join(base, "missing")
+		diagnostic := filepath.Join(base, "missing.reset")
+
+		fresh, err := ResetVault(t.Context(), Config{Root: root, SQLite: modernc.Driver{}},
+			ResetOptions{DiagnosticRoot: diagnostic})
+
+		assert.Nil(t, fresh)
+		require.Error(t, err)
+		assert.NoDirExists(t, root)
+		assert.NoDirExists(t, diagnostic)
+	})
+
+	t.Run("non sibling destination", func(t *testing.T) {
+		base := t.TempDir()
+		root := filepath.Join(base, "vault")
+		vault, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+		require.NoError(t, err)
+		require.NoError(t, vault.Close())
+		called := false
+
+		fresh, err := ResetVault(t.Context(), Config{Root: root, SQLite: modernc.Driver{}},
+			ResetOptions{
+				DiagnosticRoot: filepath.Join(t.TempDir(), "vault.reset"),
+				ReleaseCurrent: func() error { called = true; return nil },
+			})
+
+		assert.Nil(t, fresh)
+		require.Error(t, err)
+		assert.False(t, called)
+		assert.DirExists(t, root)
+	})
+
+	t.Run("symlink source", func(t *testing.T) {
+		base := t.TempDir()
+		realRoot := filepath.Join(base, "real-vault")
+		vault, err := New(t.Context(), Config{Root: realRoot, SQLite: modernc.Driver{}})
+		require.NoError(t, err)
+		require.NoError(t, vault.Close())
+		alias := filepath.Join(base, "vault-alias")
+		if err := os.Symlink(realRoot, alias); err != nil {
+			t.Skipf("creating a symlink requires additional platform permission: %v", err)
+		}
+
+		fresh, err := ResetVault(t.Context(), Config{Root: alias, SQLite: modernc.Driver{}},
+			ResetOptions{DiagnosticRoot: filepath.Join(base, "vault.reset")})
+
+		assert.Nil(t, fresh)
+		require.Error(t, err)
+		assert.DirExists(t, realRoot)
+		info, statErr := os.Lstat(alias)
+		require.NoError(t, statErr)
+		assert.NotZero(t, info.Mode()&os.ModeSymlink)
+	})
+
+	t.Run("existing diagnostic destination", func(t *testing.T) {
+		base := t.TempDir()
+		root := filepath.Join(base, "vault")
+		diagnostic := filepath.Join(base, "vault.reset")
+		vault, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+		require.NoError(t, err)
+		require.NoError(t, vault.Close())
+		sourceBefore := mustReadResetFile(t, filepath.Join(root, "docbank.db"))
+		require.NoError(t, os.Mkdir(diagnostic, 0o700))
+		sentinel := filepath.Join(diagnostic, "sentinel")
+		require.NoError(t, os.WriteFile(sentinel, []byte("do not replace"), 0o600))
+
+		fresh, err := ResetVault(t.Context(), Config{Root: root, SQLite: modernc.Driver{}},
+			ResetOptions{DiagnosticRoot: diagnostic})
+
+		assert.Nil(t, fresh)
+		require.Error(t, err)
+		assert.Equal(t, sourceBefore, mustReadResetFile(t, filepath.Join(root, "docbank.db")))
+		assert.Equal(t, []byte("do not replace"), mustReadResetFile(t, sentinel))
+	})
+}
+
+func TestResetVaultCoordinatesReleaseOfCurrentOwnerBeforeRename(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset")
+	current, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	released := make(chan struct{})
+	continueReset := make(chan struct{})
+	result := make(chan struct {
+		vault *Vault
+		err   error
+	}, 1)
+	go func() {
+		fresh, resetErr := ResetVault(t.Context(), Config{Root: root, SQLite: modernc.Driver{}},
+			ResetOptions{
+				DiagnosticRoot: diagnostic,
+				ReleaseCurrent: func() error {
+					err := current.Close()
+					close(released)
+					<-continueReset
+					return err
+				},
+			})
+		result <- struct {
+			vault *Vault
+			err   error
+		}{fresh, resetErr}
+	}()
+	<-released
+
+	contender, contenderErr := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	if contender != nil {
+		_ = contender.Close()
+	}
+	require.Error(t, contenderErr,
+		"target-coordinate ownership must exclude New after current ownership is released")
+	assert.DirExists(t, root, "reset must not rename until ReleaseCurrent returns")
+	assert.NoDirExists(t, diagnostic)
+
+	close(continueReset)
+	reset := <-result
+	require.NoError(t, reset.err)
+	require.NotNil(t, reset.vault)
+	require.NoError(t, reset.vault.Close())
+	assert.DirExists(t, root)
+	assert.DirExists(t, diagnostic)
+}
+
+func TestResetVaultLockConflictLeavesActiveSourceUnmoved(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset")
+	current, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, current.Close()) })
+
+	fresh, err := ResetVault(t.Context(), Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{DiagnosticRoot: diagnostic})
+
+	assert.Nil(t, fresh)
+	require.Error(t, err)
+	assert.DirExists(t, root)
+	assert.NoDirExists(t, diagnostic)
+}
+
+func TestResetVaultReleaseFailureLeavesSourceUnmoved(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset")
+	vault, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	releaseErr := errors.New("close current owner failed")
+
+	fresh, err := ResetVault(t.Context(), Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{DiagnosticRoot: diagnostic, ReleaseCurrent: func() error { return releaseErr }})
+
+	assert.Nil(t, fresh)
+	require.ErrorIs(t, err, releaseErr)
+	assert.DirExists(t, root)
+	assert.NoDirExists(t, diagnostic)
+	require.NoError(t, vault.Close())
+}
+
+func TestResetVaultFreshInitializationFailurePreservesBothPaths(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset")
+	vault, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	require.NoError(t, vault.Close())
+	sourceBefore := mustReadResetFile(t, filepath.Join(root, "docbank.db"))
+	openErr := errors.New("fresh sqlite open failed")
+
+	fresh, err := ResetVault(t.Context(), Config{Root: root, SQLite: failingResetDriver{err: openErr}},
+		ResetOptions{DiagnosticRoot: diagnostic})
+
+	assert.Nil(t, fresh)
+	require.ErrorIs(t, err, openErr)
+	require.ErrorContains(t, err, root)
+	require.ErrorContains(t, err, diagnostic)
+	assert.DirExists(t, root, "failed fresh initialization must not delete its partial vault")
+	assert.DirExists(t, diagnostic)
+	assert.Equal(t, sourceBefore, mustReadResetFile(t, filepath.Join(diagnostic, "docbank.db")))
+}
+
+type failingResetDriver struct{ err error }
+
+func (f failingResetDriver) Name() string { return "failing reset test driver" }
+func (f failingResetDriver) Open(string, docsqlite.OpenOptions) (*sql.DB, error) {
+	return nil, f.err
+}
+func (f failingResetDriver) IsBusy(error) bool            { return false }
+func (f failingResetDriver) IsUniqueViolation(error) bool { return false }
+
+func mustReadResetFile(t *testing.T, path string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return content
+}
+
+var _ docsqlite.Driver = failingResetDriver{}

--- a/vault_reset_test.go
+++ b/vault_reset_test.go
@@ -100,6 +100,27 @@ func TestResetVaultValidatesSourceAndDestinationWithoutMutation(t *testing.T) {
 		assert.DirExists(t, root)
 	})
 
+	t.Run("filesystem root before release callback", func(t *testing.T) {
+		volumeRoot := filepath.VolumeName(t.TempDir()) + string(os.PathSeparator)
+		called := false
+
+		fresh, err := ResetVault(
+			t.Context(),
+			Config{Root: volumeRoot, SQLite: modernc.Driver{}},
+			ResetOptions{
+				DiagnosticRoot: filepath.Join(volumeRoot, ".docbank-reset-test"),
+				ReleaseCurrent: func() error {
+					called = true
+					return nil
+				},
+			},
+		)
+
+		assert.Nil(t, fresh)
+		require.ErrorContains(t, err, "filesystem root")
+		assert.False(t, called)
+	})
+
 	t.Run("symlink source", func(t *testing.T) {
 		for name, suffix := range map[string]string{
 			"direct":             "",
@@ -166,6 +187,57 @@ func TestValidateResetSourceAttributesRejectsDirectoryReparsePoint(t *testing.T)
 	})
 
 	require.ErrorContains(t, err, "reparse point")
+}
+
+func TestValidateResetRootRelationshipRejectsFilesystemRoot(t *testing.T) {
+	volumeRoot := filepath.VolumeName(t.TempDir()) + string(os.PathSeparator)
+
+	err := validateResetRootRelationship(
+		volumeRoot,
+		filepath.Join(volumeRoot, "vault.reset"),
+	)
+
+	require.ErrorContains(t, err, "filesystem root")
+}
+
+func TestResetVaultRejectsChangedParentBeforeRename(t *testing.T) {
+	grandparent := t.TempDir()
+	base := filepath.Join(grandparent, "base")
+	parkedBase := filepath.Join(grandparent, "base.original")
+	require.NoError(t, os.Mkdir(base, 0o700))
+	root := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset")
+	current, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+
+	fresh, err := ResetVault(
+		t.Context(),
+		Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{
+			DiagnosticRoot: diagnostic,
+			ReleaseCurrent: func() error {
+				if err := current.Close(); err != nil {
+					return err
+				}
+				if err := os.Rename(base, parkedBase); err != nil {
+					return err
+				}
+				if err := os.Mkdir(base, 0o700); err != nil {
+					return err
+				}
+				return os.Rename(filepath.Join(parkedBase, "vault"), root)
+			},
+		},
+	)
+	if fresh != nil {
+		t.Cleanup(func() { _ = fresh.Close() })
+	}
+
+	assert.Nil(t, fresh)
+	require.ErrorContains(t, err, "parent")
+	require.ErrorContains(t, err, "changed")
+	assert.DirExists(t, root)
+	assert.NoDirExists(t, diagnostic)
 }
 
 func TestResetVaultCoordinatesReleaseOfCurrentOwnerBeforeRename(t *testing.T) {

--- a/vault_reset_test.go
+++ b/vault_reset_test.go
@@ -159,6 +159,15 @@ func TestResetVaultValidatesSourceAndDestinationWithoutMutation(t *testing.T) {
 	})
 }
 
+func TestValidateResetSourceAttributesRejectsDirectoryReparsePoint(t *testing.T) {
+	err := validateResetSourceAttributes(resetSourceAttributes{
+		directory: true,
+		reparse:   true,
+	})
+
+	require.ErrorContains(t, err, "reparse point")
+}
+
 func TestResetVaultCoordinatesReleaseOfCurrentOwnerBeforeRename(t *testing.T) {
 	grandparent := t.TempDir()
 	base := filepath.Join(grandparent, "base")

--- a/vault_reset_test.go
+++ b/vault_reset_test.go
@@ -240,6 +240,45 @@ func TestResetVaultRejectsChangedParentBeforeRename(t *testing.T) {
 	assert.NoDirExists(t, diagnostic)
 }
 
+func TestResetVaultRejectsSourceReplacementDuringOwnerRelease(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	parkedRoot := filepath.Join(base, "vault.original")
+	diagnostic := filepath.Join(base, "vault.reset")
+	replacementSentinel := filepath.Join(root, "replacement")
+	current, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+
+	fresh, err := ResetVault(
+		t.Context(),
+		Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{
+			DiagnosticRoot: diagnostic,
+			ReleaseCurrent: func() error {
+				if err := current.Close(); err != nil {
+					return err
+				}
+				if err := os.Rename(root, parkedRoot); err != nil {
+					return err
+				}
+				if err := os.Mkdir(root, 0o700); err != nil {
+					return err
+				}
+				return os.WriteFile(replacementSentinel, []byte("replacement"), 0o600)
+			},
+		},
+	)
+	if fresh != nil {
+		t.Cleanup(func() { _ = fresh.Close() })
+	}
+
+	assert.Nil(t, fresh)
+	require.ErrorContains(t, err, "source changed")
+	assert.DirExists(t, parkedRoot, "the original vault must remain where the callback moved it")
+	assert.Equal(t, []byte("replacement"), mustReadResetFile(t, replacementSentinel))
+	assert.NoDirExists(t, diagnostic, "reset must not move a substituted source directory")
+}
+
 func TestResetVaultCoordinatesReleaseOfCurrentOwnerBeforeRename(t *testing.T) {
 	grandparent := t.TempDir()
 	base := filepath.Join(grandparent, "base")
@@ -393,6 +432,47 @@ func TestResetVaultParentSyncFailureStopsBeforeFreshInitialization(t *testing.T)
 	assert.NoDirExists(t, root, "parent sync failure must stop before replacement creation")
 	assert.DirExists(t, diagnostic)
 	assert.Equal(t, sourceBefore, mustReadResetFile(t, filepath.Join(diagnostic, "docbank.db")))
+}
+
+func TestResetVaultFreshParentSyncFailureClosesFreshVault(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset")
+	vault, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	require.NoError(t, vault.Close())
+	canonicalBase, err := home.CanonicalRoot(base)
+	require.NoError(t, err)
+	syncErr := errors.New("fresh parent sync failed")
+	syncCalls := 0
+	originalSync := syncResetParentDirectory
+	syncResetParentDirectory = func(path string) error {
+		assert.Equal(t, canonicalBase, path)
+		syncCalls++
+		if syncCalls == 2 {
+			return syncErr
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncResetParentDirectory = originalSync })
+
+	fresh, err := ResetVault(
+		t.Context(),
+		Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{DiagnosticRoot: diagnostic},
+	)
+	if fresh != nil {
+		t.Cleanup(func() { _ = fresh.Close() })
+	}
+
+	assert.Nil(t, fresh)
+	require.ErrorIs(t, err, syncErr)
+	assert.Equal(t, 2, syncCalls)
+	assert.DirExists(t, root, "a sync failure must not delete the initialized replacement")
+	assert.DirExists(t, diagnostic)
+	reopened, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err, "the fresh vault must be closed before returning the sync error")
+	require.NoError(t, reopened.Close())
 }
 
 func TestResetVaultFreshInitializationFailurePreservesBothPaths(t *testing.T) {

--- a/vault_reset_test.go
+++ b/vault_reset_test.go
@@ -101,25 +101,40 @@ func TestResetVaultValidatesSourceAndDestinationWithoutMutation(t *testing.T) {
 	})
 
 	t.Run("symlink source", func(t *testing.T) {
-		base := t.TempDir()
-		realRoot := filepath.Join(base, "real-vault")
-		vault, err := New(t.Context(), Config{Root: realRoot, SQLite: modernc.Driver{}})
-		require.NoError(t, err)
-		require.NoError(t, vault.Close())
-		alias := filepath.Join(base, "vault-alias")
-		if err := os.Symlink(realRoot, alias); err != nil {
-			t.Skipf("creating a symlink requires additional platform permission: %v", err)
+		for name, suffix := range map[string]string{
+			"direct":             "",
+			"trailing separator": string(os.PathSeparator),
+			"trailing dot":       string(os.PathSeparator) + ".",
+		} {
+			t.Run(name, func(t *testing.T) {
+				base := t.TempDir()
+				realRoot := filepath.Join(base, "real-vault")
+				vault, err := New(
+					t.Context(), Config{Root: realRoot, SQLite: modernc.Driver{}})
+				require.NoError(t, err)
+				require.NoError(t, vault.Close())
+				alias := filepath.Join(base, "vault-alias")
+				if err := os.Symlink(realRoot, alias); err != nil {
+					t.Skipf("creating a symlink requires additional platform permission: %v", err)
+				}
+
+				fresh, err := ResetVault(
+					t.Context(), Config{Root: alias + suffix, SQLite: modernc.Driver{}},
+					ResetOptions{DiagnosticRoot: filepath.Join(base, "vault.reset")})
+				if fresh != nil {
+					t.Cleanup(func() { _ = fresh.Close() })
+				}
+
+				assert.Nil(t, fresh)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "must not be a symlink")
+				assert.DirExists(t, realRoot)
+				info, statErr := os.Lstat(alias)
+				require.NoError(t, statErr)
+				assert.NotZero(t, info.Mode()&os.ModeSymlink)
+				assert.NoDirExists(t, filepath.Join(base, "vault.reset"))
+			})
 		}
-
-		fresh, err := ResetVault(t.Context(), Config{Root: alias, SQLite: modernc.Driver{}},
-			ResetOptions{DiagnosticRoot: filepath.Join(base, "vault.reset")})
-
-		assert.Nil(t, fresh)
-		require.Error(t, err)
-		assert.DirExists(t, realRoot)
-		info, statErr := os.Lstat(alias)
-		require.NoError(t, statErr)
-		assert.NotZero(t, info.Mode()&os.ModeSymlink)
 	})
 
 	t.Run("existing diagnostic destination", func(t *testing.T) {

--- a/vault_reset_test.go
+++ b/vault_reset_test.go
@@ -145,7 +145,9 @@ func TestResetVaultValidatesSourceAndDestinationWithoutMutation(t *testing.T) {
 }
 
 func TestResetVaultCoordinatesReleaseOfCurrentOwnerBeforeRename(t *testing.T) {
-	base := t.TempDir()
+	grandparent := t.TempDir()
+	base := filepath.Join(grandparent, "base")
+	require.NoError(t, os.Mkdir(base, 0o700))
 	root := filepath.Join(base, "vault")
 	diagnostic := filepath.Join(base, "vault.reset")
 	current, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
@@ -174,12 +176,20 @@ func TestResetVaultCoordinatesReleaseOfCurrentOwnerBeforeRename(t *testing.T) {
 	}()
 	<-released
 
-	contender, contenderErr := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
-	if contender != nil {
-		_ = contender.Close()
+	contenderErrors := make(map[string]error)
+	for name, contenderRoot := range map[string]string{
+		"exact":       root,
+		"parent":      base,
+		"grandparent": grandparent,
+		"child":       filepath.Join(root, "child"),
+	} {
+		contender, contenderErr := New(
+			t.Context(), Config{Root: contenderRoot, SQLite: modernc.Driver{}})
+		if contender != nil {
+			_ = contender.Close()
+		}
+		contenderErrors[name] = contenderErr
 	}
-	require.Error(t, contenderErr,
-		"target-coordinate ownership must exclude New after current ownership is released")
 	assert.DirExists(t, root, "reset must not rename until ReleaseCurrent returns")
 	assert.NoDirExists(t, diagnostic)
 
@@ -190,6 +200,37 @@ func TestResetVaultCoordinatesReleaseOfCurrentOwnerBeforeRename(t *testing.T) {
 	require.NoError(t, reset.vault.Close())
 	assert.DirExists(t, root)
 	assert.DirExists(t, diagnostic)
+	for name, contenderErr := range contenderErrors {
+		require.ErrorIs(t, contenderErr, home.ErrVaultLocked,
+			"reset must exclude the %s vault root after current ownership is released", name)
+	}
+}
+
+func TestNewAllowsCaseDistinctVaultRoots(t *testing.T) {
+	base := t.TempDir()
+	upperRoot := filepath.Join(base, "CaseDistinctVault")
+	lowerRoot := filepath.Join(base, "casedistinctvault")
+	require.NoError(t, os.Mkdir(upperRoot, 0o700))
+	if err := os.Mkdir(lowerRoot, 0o700); errors.Is(err, os.ErrExist) {
+		t.Skip("filesystem is case-insensitive")
+	} else {
+		require.NoError(t, err)
+	}
+	upperInfo, err := os.Stat(upperRoot)
+	require.NoError(t, err)
+	lowerInfo, err := os.Stat(lowerRoot)
+	require.NoError(t, err)
+	if os.SameFile(upperInfo, lowerInfo) {
+		t.Skip("filesystem does not provide case-distinct directory identities")
+	}
+
+	upper, err := New(t.Context(), Config{Root: upperRoot, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, upper.Close()) })
+	lower, err := New(t.Context(), Config{Root: lowerRoot, SQLite: modernc.Driver{}})
+	require.NoError(t, err,
+		"case-distinct vaults on a case-sensitive filesystem must not share ownership")
+	require.NoError(t, lower.Close())
 }
 
 func TestResetVaultLockConflictLeavesActiveSourceUnmoved(t *testing.T) {

--- a/vault_reset_test.go
+++ b/vault_reset_test.go
@@ -364,6 +364,37 @@ func TestResetVaultReleaseFailureLeavesSourceUnmoved(t *testing.T) {
 	require.NoError(t, vault.Close())
 }
 
+func TestResetVaultParentSyncFailureStopsBeforeFreshInitialization(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	diagnostic := filepath.Join(base, "vault.reset")
+	vault, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	require.NoError(t, vault.Close())
+	canonicalBase, err := home.CanonicalRoot(base)
+	require.NoError(t, err)
+	sourceBefore := mustReadResetFile(t, filepath.Join(root, "docbank.db"))
+	syncErr := errors.New("parent sync failed")
+	originalSync := syncResetParentDirectory
+	syncResetParentDirectory = func(path string) error {
+		assert.Equal(t, canonicalBase, path)
+		return syncErr
+	}
+	t.Cleanup(func() { syncResetParentDirectory = originalSync })
+
+	fresh, err := ResetVault(
+		t.Context(),
+		Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{DiagnosticRoot: diagnostic},
+	)
+
+	assert.Nil(t, fresh)
+	require.ErrorIs(t, err, syncErr)
+	assert.NoDirExists(t, root, "parent sync failure must stop before replacement creation")
+	assert.DirExists(t, diagnostic)
+	assert.Equal(t, sourceBefore, mustReadResetFile(t, filepath.Join(diagnostic, "docbank.db")))
+}
+
 func TestResetVaultFreshInitializationFailurePreservesBothPaths(t *testing.T) {
 	base := t.TempDir()
 	root := filepath.Join(base, "vault")

--- a/vault_reset_test.go
+++ b/vault_reset_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/docbank/internal/home"
 	docsqlite "go.kenn.io/docbank/pkg/sqlite"
 	"go.kenn.io/docbank/pkg/sqlite/modernc"
 )
@@ -233,6 +234,10 @@ func TestResetVaultFreshInitializationFailurePreservesBothPaths(t *testing.T) {
 	vault, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
 	require.NoError(t, err)
 	require.NoError(t, vault.Close())
+	canonicalRoot, err := home.CanonicalRoot(root)
+	require.NoError(t, err)
+	canonicalDiagnostic, err := home.CanonicalRoot(diagnostic)
+	require.NoError(t, err)
 	sourceBefore := mustReadResetFile(t, filepath.Join(root, "docbank.db"))
 	openErr := errors.New("fresh sqlite open failed")
 
@@ -241,8 +246,8 @@ func TestResetVaultFreshInitializationFailurePreservesBothPaths(t *testing.T) {
 
 	assert.Nil(t, fresh)
 	require.ErrorIs(t, err, openErr)
-	require.ErrorContains(t, err, root)
-	require.ErrorContains(t, err, diagnostic)
+	require.ErrorContains(t, err, canonicalRoot)
+	require.ErrorContains(t, err, canonicalDiagnostic)
 	assert.DirExists(t, root, "failed fresh initialization must not delete its partial vault")
 	assert.DirExists(t, diagnostic)
 	assert.Equal(t, sourceBefore, mustReadResetFile(t, filepath.Join(diagnostic, "docbank.db")))

--- a/vault_reset_windows_test.go
+++ b/vault_reset_windows_test.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/pkg/sqlite/modernc"
+	"golang.org/x/sys/windows"
 )
 
 func TestResetVaultRejectsWindowsDirectoryReparsePoint(t *testing.T) {
@@ -89,4 +91,55 @@ func createWindowsJunction(alias, target string) error {
 		return fmt.Errorf("creating directory junction: %w: %s", err, output)
 	}
 	return nil
+}
+
+func TestRenameVaultNoReplaceSupportsWindowsExtendedLengthPaths(t *testing.T) {
+	parent := t.TempDir()
+	for len(parent) < 280 {
+		parent = filepath.Join(parent, strings.Repeat("segment", 8))
+	}
+	require.NoError(t, os.MkdirAll(parent, 0o700))
+	source := filepath.Join(parent, "vault")
+	destination := filepath.Join(parent, "vault.reset")
+	require.NoError(t, os.Mkdir(source, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(source, "sentinel"), []byte("kept"), 0o600))
+
+	require.NoError(t, renameVaultNoReplace(source, destination))
+
+	assert.NoDirExists(t, source)
+	assert.Equal(t, []byte("kept"), mustReadResetFile(t, filepath.Join(destination, "sentinel")))
+}
+
+func TestRenameVaultNoReplacePassesExtendedPathsToMoveFileW(t *testing.T) {
+	for name, paths := range map[string][4]string{
+		"dos": {
+			`C:\vault`,
+			`C:\vault.reset`,
+			`\\?\C:\vault`,
+			`\\?\C:\vault.reset`,
+		},
+		"unc": {
+			`\\server\share\vault`,
+			`\\server\share\vault.reset`,
+			`\\?\UNC\server\share\vault`,
+			`\\?\UNC\server\share\vault.reset`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var movedSource, movedDestination string
+			err := renameVaultNoReplaceWithMove(
+				paths[0],
+				paths[1],
+				func(source, destination *uint16) error {
+					movedSource = windows.UTF16PtrToString(source)
+					movedDestination = windows.UTF16PtrToString(destination)
+					return nil
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, paths[2], movedSource)
+			assert.Equal(t, paths[3], movedDestination)
+		})
+	}
 }

--- a/vault_reset_windows_test.go
+++ b/vault_reset_windows_test.go
@@ -1,0 +1,92 @@
+//go:build windows
+
+package docbank
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/pkg/sqlite/modernc"
+)
+
+func TestResetVaultRejectsWindowsDirectoryReparsePoint(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real-vault")
+	vault, err := New(t.Context(), Config{Root: realRoot, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+	require.NoError(t, vault.Close())
+
+	alias := filepath.Join(base, "vault-alias")
+	require.NoError(t, createWindowsJunction(alias, realRoot))
+	attributes, err := resetSourceAttributesNoFollow(alias)
+	require.NoError(t, err)
+	require.True(t, attributes.directory)
+	require.True(t, attributes.reparse)
+
+	diagnostic := filepath.Join(base, "vault.reset")
+	fresh, err := ResetVault(
+		t.Context(),
+		Config{Root: alias, SQLite: modernc.Driver{}},
+		ResetOptions{DiagnosticRoot: diagnostic},
+	)
+	if fresh != nil {
+		t.Cleanup(func() { _ = fresh.Close() })
+	}
+
+	assert.Nil(t, fresh)
+	require.ErrorContains(t, err, "reparse point")
+	assert.DirExists(t, realRoot)
+	assert.NoDirExists(t, diagnostic)
+}
+
+func TestResetVaultRejectsWindowsDirectoryReparsePointAfterOwnerRelease(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "vault")
+	parked := filepath.Join(base, "vault.parked")
+	diagnostic := filepath.Join(base, "vault.reset")
+	current, err := New(t.Context(), Config{Root: root, SQLite: modernc.Driver{}})
+	require.NoError(t, err)
+
+	fresh, err := ResetVault(
+		t.Context(),
+		Config{Root: root, SQLite: modernc.Driver{}},
+		ResetOptions{
+			DiagnosticRoot: diagnostic,
+			ReleaseCurrent: func() error {
+				if err := current.Close(); err != nil {
+					return err
+				}
+				if err := os.Rename(root, parked); err != nil {
+					return err
+				}
+				return createWindowsJunction(root, parked)
+			},
+		},
+	)
+	if fresh != nil {
+		t.Cleanup(func() { _ = fresh.Close() })
+	}
+
+	assert.Nil(t, fresh)
+	require.ErrorContains(t, err, "reparse point")
+	attributes, inspectErr := resetSourceAttributesNoFollow(root)
+	require.NoError(t, inspectErr)
+	assert.True(t, attributes.directory)
+	assert.True(t, attributes.reparse)
+	assert.DirExists(t, parked)
+	assert.NoDirExists(t, diagnostic)
+}
+
+func createWindowsJunction(alias, target string) error {
+	output, err := exec.Command("cmd.exe", "/c", "mklink", "/J", alias, target).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("creating directory junction: %w: %s", err, output)
+	}
+	return nil
+}

--- a/vault_test.go
+++ b/vault_test.go
@@ -37,6 +37,7 @@ func TestVaultCreateIsImmutableAndIdempotent(t *testing.T) {
 	})
 	require.NoError(err)
 	require.True(created.Created)
+	require.True(created.PhysicalCreated)
 	require.False(created.Replaced)
 	require.Equal(int64(1), created.Node.Revision)
 
@@ -45,10 +46,20 @@ func TestVaultCreateIsImmutableAndIdempotent(t *testing.T) {
 	})
 	require.NoError(err)
 	require.False(retry.Created)
+	require.False(retry.PhysicalCreated)
 	require.False(retry.Replaced)
 	require.Equal(created.Node.ID, retry.Node.ID)
 	require.Equal(created.Node.Revision, retry.Node.Revision)
 	require.Equal(created.Version.ID, retry.Version.ID)
+
+	deduplicated, err := vault.Create(t.Context(), "/copy.txt", bytes.NewReader(content), CreateOptions{
+		MediaType: "text/plain", Expected: expected,
+	})
+	require.NoError(err)
+	require.True(deduplicated.Created)
+	require.False(deduplicated.PhysicalCreated)
+	require.Equal(created.Computed, deduplicated.Computed)
+	require.NotEqual(created.Node.ID, deduplicated.Node.ID)
 
 	tests := []struct {
 		name      string
@@ -1073,6 +1084,7 @@ func TestPutPackedDuplicateRemovesRedundantLoose(t *testing.T) {
 	content := "shared packed content\n"
 	first, err := vault.Put(t.Context(), "/first.txt", strings.NewReader(content), PutOptions{})
 	require.NoError(err)
+	require.True(first.PhysicalCreated)
 	packed, err := vault.Pack(t.Context(), PackOptions{})
 	require.NoError(err)
 	require.Equal(1, packed.BlobsPacked)
@@ -1080,6 +1092,7 @@ func TestPutPackedDuplicateRemovesRedundantLoose(t *testing.T) {
 	second, err := vault.Put(t.Context(), "/second.txt", strings.NewReader(content), PutOptions{})
 	require.NoError(err)
 	require.Equal(first.Computed, second.Computed)
+	require.False(second.PhysicalCreated)
 	require.Equal(PhysicalContent{
 		Kind: "packed", Encoding: "raw", LogicalBytes: int64(len(content)),
 		StoredBytes: second.Physical.StoredBytes, PackEligible: true,


### PR DESCRIPTION
Embedded applications can now distinguish logical node creation from newly published loose bytes through PutReceipt.PhysicalCreated. Physical maintenance can ignore exact retries and cross-path deduplication while PutReceipt.Created retains its existing logical meaning.

ResetVault adds an explicit fail-closed recovery path for an unreadable catalog. It coordinates on the stable canonical path, moves the existing vault to an absent diagnostic sibling without replacement, creates and locks a fresh vault, preserves all paths on failure, and supports a release callback for live embedders. Normal vault opening participates in the same coordinate lock; reset remains explicit and diagnostic cleanup remains manual.