### PR TITLE
Search beneath a stable directory

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -1032,7 +1032,10 @@ func TestSearchCLI(t *testing.T) {
 	setupVaultHome(t)
 	src := writeSourceFile(t, "insurance-2026.txt", "policy")
 	other := writeSourceFile(t, "insurance-draft.txt", "draft")
+	archive := writeSourceFile(t, "insurance-archive.txt", "archive")
 	_, err := runCLI(t, "add", src, other, "--dest", "/inbox")
+	require.NoError(t, err)
+	_, err = runCLI(t, "add", archive, "--dest", "/other")
 	require.NoError(t, err)
 
 	out, err := runCLI(t, "search", "insurance")
@@ -1063,7 +1066,24 @@ func TestSearchCLI(t *testing.T) {
 	require.NoError(t, err, out)
 	require.NoError(t, json.Unmarshal([]byte(out), &report))
 	assert.Equal(t, "text/plain", report.MIMEType)
+	require.Len(t, report.Hits, 3)
+
+	out, err = runCLI(t, "ls", "/inbox", "--json")
+	require.NoError(t, err, out)
+	var inbox directoryListing
+	require.NoError(t, json.Unmarshal([]byte(out), &inbox))
+	out, err = runCLI(t, "search", "insurance", "--under", "/inbox", "--json")
+	require.NoError(t, err, out)
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, inbox.Directory.ID, report.UnderNodeID)
 	require.Len(t, report.Hits, 2)
+	for _, hit := range report.Hits {
+		assert.Contains(t, hit.Path, "/inbox/")
+	}
+	out, err = runCLI(t, "search", "insurance", "--under",
+		formatNodeSelector(inbox.Directory.ID))
+	require.NoError(t, err, out)
+	assert.NotContains(t, out, "/other/")
 }
 
 func TestSearchCLIReportsTruncation(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "28", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "29", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "28", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "29", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "28", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "29", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/exit_test.go
+++ b/cmd/docbank/exit_test.go
@@ -62,6 +62,10 @@ func TestRunProcessDistinguishesUsageAndMissingNodes(t *testing.T) {
 	assert.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "must not include parameters")
 
+	code = run("search", "term", "--under", "relative")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "absolute virtual path or id:")
+
 	code = run("storage", "pack", "--max-bytes", "-1")
 	assert.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "validation")

--- a/cmd/docbank/search.go
+++ b/cmd/docbank/search.go
@@ -21,6 +21,7 @@ var (
 	searchJSON  bool
 	searchTag   string
 	searchMIME  string
+	searchUnder string
 )
 
 var searchCmd = &cobra.Command{
@@ -34,6 +35,13 @@ var searchCmd = &cobra.Command{
 		mimeType, err := store.NormalizeSearchMIMEType(searchMIME)
 		if err != nil {
 			return usageError(err)
+		}
+		var underSelector nodeSelector
+		if searchUnder != "" {
+			underSelector, err = parseNodeSelector(searchUnder)
+			if err != nil {
+				return err
+			}
 		}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
@@ -49,6 +57,18 @@ var searchCmd = &cobra.Command{
 			opts.TagID = tag.ID
 			tagName = tag.Name
 		}
+		var underPath string
+		if searchUnder != "" {
+			directory, resolveErr := underSelector.resolve(cmd.Context(), c)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			if directory.Kind != "dir" {
+				return fmt.Errorf("search scope %q: %w", searchUnder, store.ErrNotDir)
+			}
+			opts.UnderNodeID = directory.ID
+			underPath = directory.Path
+		}
 		rep, err := c.SearchWithOptions(
 			cmd.Context(), strings.Join(args, " "), searchLimit, opts,
 		)
@@ -59,16 +79,21 @@ var searchCmd = &cobra.Command{
 			return writeCLIJSON(cmd.OutOrStdout(), rep)
 		}
 		if len(rep.Hits) == 0 {
-			switch {
-			case tagName != "" && rep.MIMEType != "":
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-					"no matches with tag %q and media type %q\n", tagName, rep.MIMEType)
-			case tagName != "":
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "no matches with tag %q\n", tagName)
-			case rep.MIMEType != "":
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "no matches with media type %q\n", rep.MIMEType)
-			default:
+			var filters []string
+			if tagName != "" {
+				filters = append(filters, fmt.Sprintf("tag %q", tagName))
+			}
+			if rep.MIMEType != "" {
+				filters = append(filters, fmt.Sprintf("media type %q", rep.MIMEType))
+			}
+			if underPath != "" {
+				filters = append(filters, fmt.Sprintf("directory %q", underPath))
+			}
+			if len(filters) == 0 {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no matches")
+			} else {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(),
+					"no matches with "+strings.Join(filters, " and "))
 			}
 			return nil
 		}
@@ -101,6 +126,8 @@ func init() {
 		"require one tag by name or stable ID")
 	searchCmd.Flags().StringVar(&searchMIME, "mime-type", "",
 		"require one current parameter-free media type")
+	searchCmd.Flags().StringVar(&searchUnder, "under", "",
+		"require descendants of one live directory path or id:N")
 	searchCmd.Flags().BoolVar(&searchJSON, "json", false, "emit machine-readable JSON")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -168,6 +168,11 @@ To restrict results by the current file version's format, send a valid
 parameter-free base type as `mime_type`. The response echoes its normalized
 spelling. For example, `text/plain` includes stored charset parameters but does
 not match a retained historical version or a directory.
+To restrict results to one subtree, resolve its live directory once and send
+the stable ID as `under_node_id`. The selected directory is excluded; all
+descendant name and content candidates share the same constraint. Retain the
+echoed ID as authority instead of treating the directory's mutable path as the
+filter identity.
 
 ```bash
 curl --fail-with-body --get \
@@ -175,6 +180,7 @@ curl --fail-with-body --get \
   --data-urlencode 'q=tax return' \
   --data 'tag_id=<tag-uuid>' \
   --data-urlencode 'mime_type=application/pdf' \
+  --data 'under_node_id=42' \
   --data 'limit=100' \
   "$DOCBANK_URL/api/v1/search"
 ```

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -42,7 +42,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /audit/scopes/{scope_id}/history?limit=&cursor=` | read canonical newest-first events across every member of one permanent scope | Implemented |
 | `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
-| `GET /search?q=&tag_id=&mime_type=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity and current base media type, with match source and explicit `truncated` status | Implemented |
+| `GET /search?q=&tag_id=&mime_type=&under_node_id=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity, current base media type, and descendants of a live directory, with match source and explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
 | `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -568,7 +568,7 @@ returns the complete restored node with its resulting path and revision.
 ## docbank search
 
 ```
-docbank search <query>... [--tag <name-or-id>] [--mime-type <type/subtype>] [--limit <n>] [--json]
+docbank search <query>... [--tag <name-or-id>] [--mime-type <type/subtype>] [--under <path-or-id>] [--limit <n>] [--json]
 ```
 
 Full-text search over live node names and verified extracted text (FTS5).
@@ -587,11 +587,15 @@ resolves names before searching, so the request is bound to stable identity.
 current version's base type case-insensitively. Stored parameters do not affect
 the match: `text/plain` includes `text/plain; charset=utf-8`. MIME filtering
 excludes directories and retained non-current versions.
+`--under` accepts an absolute virtual path or stable `id:N` selector for one
+live directory and searches its descendants. The CLI resolves paths before the
+request and the daemon uses the resulting stable directory ID. The directory
+itself is excluded; a file, missing node, or trashed directory is rejected.
 
 `--json` emits the typed search report with `hits`, the applied `limit`, and
 an explicit `truncated` boolean. A filtered report also echoes the stable
-`tag_id` and normalized `mime_type` when supplied. An empty result uses
-`"hits": []`.
+`tag_id`, normalized `mime_type`, and stable `under_node_id` when supplied. An
+empty result uses `"hits": []`.
 
 The daemon indexes current UTF-8 `text/*`, JSON, and JSONL blobs up to 16 MiB
 after a terminally verified read. PDF, Office, and OCR extraction are not yet

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,7 +117,7 @@ and append later changes to the same stable node without touching source files.
 - Additional and overlapping audit scopes
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
-- Date/path search filters; stable tag and current MIME filtering are implemented
+- Date search filters; stable tag, current MIME, and directory-scoped filtering are implemented
 - Additional text extraction workers for PDF text layers and office formats;
   bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
 - External integration surface: generalized ingest provenance —

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -10,6 +10,7 @@ docbank search insurance
 docbank search tax 2026
 docbank search return --tag taxes
 docbank search report --mime-type application/pdf
+docbank search receipt --under /taxes/2026
 docbank search report --limit 200
 docbank search report --json
 ```
@@ -46,6 +47,11 @@ id:198     content  /taxes/2026/car-insurance-notes.md
   case-insensitive and ignores stored parameters, so `text/plain` also matches
   `text/plain; charset=utf-8`. The request itself must be parameter-free;
   directories and historical versions never match it.
+- **Stable directory scoping.** `--under <path-or-id>` restricts results to
+  descendants of one live directory. The CLI resolves a path or `id:N`
+  selector to its stable node ID before searching; JSON echoes that ID as
+  `under_node_id`. The selected directory itself is not a result, and moving or
+  renaming it does not change its identity.
 
 For scripts, `--json` returns `hits`, `limit`, and `truncated` without table
 formatting. `hits` is always an array, including when nothing matches.
@@ -65,7 +71,7 @@ daemon job reaches it. A transient open, read, or verification error leaves the
 item queued and is retried on a bounded delay; it does not become a permanent
 extraction failure. `docbank jobs` shows whether that worker is running.
 
-PDF text layers, office formats, OCR, and date/path search filters are not
+PDF text layers, office formats, OCR, and date search filters are not
 yet available. Their absence never changes name-search results or document authority.
 
 Next: organize documents beyond paths with

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -350,26 +350,30 @@ func registerReadRoutes(api huma.API, d Deps) {
 		Description: "Name matches retain their established BM25 order and appear first; " +
 			"content-only matches follow in their own BM25 order. Every hit names its match source. " +
 			"An optional stable tag ID requires that assignment for every result. An optional " +
-			"parameter-free MIME type matches the current file version with or without parameters.",
+			"parameter-free MIME type matches the current file version with or without parameters. " +
+			"An optional live directory node ID restricts results to its descendants.",
 	}, func(ctx context.Context, in *struct {
-		Q        string `query:"q" required:"true"`
-		Limit    int    `query:"limit" default:"50" minimum:"1" maximum:"1000"`
-		TagID    string `query:"tag_id" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"`
-		MIMEType string `query:"mime_type" maxLength:"255"`
+		Q           string `query:"q" required:"true"`
+		Limit       int    `query:"limit" default:"50" minimum:"1" maximum:"1000"`
+		TagID       string `query:"tag_id" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"`
+		MIMEType    string `query:"mime_type" maxLength:"255"`
+		UnderNodeID int64  `query:"under_node_id" minimum:"1"`
 	}) (*searchOutput, error) {
 		mimeType, err := store.NormalizeSearchMIMEType(in.MIMEType)
 		if err != nil {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 		}
 		hits, truncated, err := d.Store.SearchPageWithOptions(
-			ctx, in.Q, in.Limit, store.SearchOptions{TagID: in.TagID, MIMEType: mimeType},
+			ctx, in.Q, in.Limit, store.SearchOptions{
+				TagID: in.TagID, MIMEType: mimeType, UnderNodeID: in.UnderNodeID,
+			},
 		)
 		if err != nil {
 			return nil, FromStoreError(err)
 		}
 		out := &searchOutput{Body: SearchReport{
 			Hits: []SearchHit{}, Limit: in.Limit, Truncated: truncated,
-			TagID: in.TagID, MIMEType: mimeType,
+			TagID: in.TagID, MIMEType: mimeType, UnderNodeID: in.UnderNodeID,
 		}}
 		for _, h := range hits {
 			out.Body.Hits = append(out.Body.Hits, SearchHit{

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -307,6 +307,26 @@ func TestSearch(t *testing.T) {
 		"/api/v1/search?q=insurance&limit=10&tag_id=11111111-1111-4111-8111-111111111111", nil)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, body)
 
+	archive, err := s.Mkdir(t.Context(), s.RootID(), "archive")
+	require.NoError(t, err)
+	inside, err := s.CreateFile(
+		t.Context(), archive.ID, "insurance-archive.pdf", testHash("scope"), 3, "application/pdf",
+	)
+	require.NoError(t, err)
+	resp, body = get(t, ts, fmt.Sprintf(
+		"/api/v1/search?q=insurance&limit=10&under_node_id=%d", archive.ID,
+	), nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	require.NoError(t, json.Unmarshal([]byte(body), &rep))
+	require.Len(t, rep.Hits, 1)
+	assert.Equal(t, inside.ID, rep.Hits[0].Node.ID)
+	assert.Equal(t, archive.ID, rep.UnderNodeID)
+	resp, body = get(t, ts, fmt.Sprintf(
+		"/api/v1/search?q=insurance&limit=10&under_node_id=%d", inside.ID,
+	), nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"not_dir"`)
+
 	bodyNode := createFileWithContent(t, ts, s, "/notes.txt", "lighthouse archive")
 	require.NoError(t, s.RecordExtraction(t.Context(), store.ExtractionResult{
 		BlobHash: bodyNode.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -433,11 +433,12 @@ type SearchHit struct {
 
 // SearchReport is one bounded search result page.
 type SearchReport struct {
-	Hits      []SearchHit `json:"hits"`
-	Limit     int         `json:"limit"`
-	Truncated bool        `json:"truncated"`
-	TagID     string      `json:"tag_id,omitempty"`
-	MIMEType  string      `json:"mime_type,omitempty"`
+	Hits        []SearchHit `json:"hits"`
+	Limit       int         `json:"limit"`
+	Truncated   bool        `json:"truncated"`
+	TagID       string      `json:"tag_id,omitempty"`
+	MIMEType    string      `json:"mime_type,omitempty"`
+	UnderNodeID int64       `json:"under_node_id,omitempty"`
 }
 
 // IngestFailure records one source path that failed to import.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -670,10 +670,12 @@ func (c *Client) VerifyNodeContent(ctx context.Context, id, revision int64) (api
 	return report, err
 }
 
-// SearchOptions narrows ranked search by stable tag and current media type.
+// SearchOptions narrows ranked search by stable tag, current media type, and
+// one live directory's descendants.
 type SearchOptions struct {
-	TagID    string
-	MIMEType string
+	TagID       string
+	MIMEType    string
+	UnderNodeID int64
 }
 
 func (c *Client) Search(ctx context.Context, query string, limit int) (api.SearchReport, error) {
@@ -692,6 +694,9 @@ func (c *Client) SearchWithOptions(
 	if err != nil {
 		return out, err
 	}
+	if opts.UnderNodeID < 0 {
+		return out, errors.New("search directory node ID must be positive")
+	}
 	queryValues := url.Values{}
 	queryValues.Set("q", query)
 	queryValues.Set("limit", strconv.Itoa(limit))
@@ -701,10 +706,13 @@ func (c *Client) SearchWithOptions(
 	if mimeType != "" {
 		queryValues.Set("mime_type", mimeType)
 	}
+	if opts.UnderNodeID != 0 {
+		queryValues.Set("under_node_id", strconv.FormatInt(opts.UnderNodeID, 10))
+	}
 	if err := c.do(ctx, http.MethodGet, "/api/v1/search?"+queryValues.Encode(), nil, nil, &out); err != nil {
 		return out, err
 	}
-	if out.TagID != opts.TagID || out.MIMEType != mimeType {
+	if out.TagID != opts.TagID || out.MIMEType != mimeType || out.UnderNodeID != opts.UnderNodeID {
 		return api.SearchReport{}, errors.New("search response has inconsistent filter authority")
 	}
 	return out, nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -109,8 +109,10 @@ func TestSearchWithOptionsUsesStableTagIdentity(t *testing.T) {
 	ctx := t.Context()
 	tag, err := s.CreateTag(ctx, "renewal")
 	require.NoError(t, err)
+	directory, err := s.Mkdir(ctx, s.RootID(), "policies")
+	require.NoError(t, err)
 	tagged, err := s.CreateFile(
-		ctx, s.RootID(), "insurance-renewal.pdf", strings.Repeat("a", 64), 1, "application/pdf",
+		ctx, directory.ID, "insurance-renewal.pdf", strings.Repeat("a", 64), 1, "application/pdf",
 	)
 	require.NoError(t, err)
 	_, err = s.CreateFile(
@@ -122,12 +124,13 @@ func TestSearchWithOptionsUsesStableTagIdentity(t *testing.T) {
 
 	report, err := c.SearchWithOptions(
 		ctx, "insurance", 10, client.SearchOptions{
-			TagID: tag.ID, MIMEType: "APPLICATION/PDF",
+			TagID: tag.ID, MIMEType: "APPLICATION/PDF", UnderNodeID: directory.ID,
 		},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, tag.ID, report.TagID)
 	assert.Equal(t, "application/pdf", report.MIMEType)
+	assert.Equal(t, directory.ID, report.UnderNodeID)
 	require.Len(t, report.Hits, 1)
 	assert.Equal(t, tagged.ID, report.Hits[0].Node.ID)
 
@@ -137,6 +140,8 @@ func TestSearchWithOptionsUsesStableTagIdentity(t *testing.T) {
 		MIMEType: "application/pdf; version=1",
 	})
 	require.ErrorContains(t, err, "must not include parameters")
+	_, err = c.SearchWithOptions(ctx, "insurance", 10, client.SearchOptions{UnderNodeID: -1})
+	require.ErrorContains(t, err, "directory node ID must be positive")
 }
 
 func TestMoveToPathValidatesRequestBeforeTransport(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "28"
+	daemonProtocolVersion = "29"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"mime"
 	"strings"
@@ -17,10 +18,12 @@ type SearchHit struct {
 
 // SearchOptions narrows ranked search without changing its name-before-content
 // ordering. TagID identifies one required assignment; MIMEType selects the
-// current file version's parameter-free base media type.
+// current file version's parameter-free base media type; UnderNodeID selects
+// descendants of one live directory.
 type SearchOptions struct {
-	TagID    string
-	MIMEType string
+	TagID       string
+	MIMEType    string
+	UnderNodeID int64
 }
 
 const (
@@ -66,6 +69,22 @@ func (s *Store) SearchPageWithOptions(
 		return nil, false, err
 	}
 	opts.MIMEType = normalizedMIME
+	if opts.UnderNodeID < 0 {
+		return nil, false, errors.New("search directory node ID must be positive")
+	}
+	if opts.UnderNodeID != 0 {
+		directory, err := s.NodeByID(ctx, opts.UnderNodeID)
+		if err != nil {
+			return nil, false, fmt.Errorf("search directory node %d: %w", opts.UnderNodeID, err)
+		}
+		if directory.TrashedAt != nil {
+			return nil, false, fmt.Errorf("search directory node %d is trashed: %w",
+				opts.UnderNodeID, ErrNotFound)
+		}
+		if !directory.IsDir() {
+			return nil, false, fmt.Errorf("search scope node %d: %w", opts.UnderNodeID, ErrNotDir)
+		}
+	}
 	fq := ftsQuery(query)
 	if fq == "" {
 		return nil, false, nil
@@ -166,6 +185,18 @@ func searchFilterSQL(opts SearchOptions) (string, []any) {
 			ELSE substr(cv.mime_type, 1, instr(cv.mime_type, ';')-1)
 		END))=?`)
 		args = append(args, opts.MIMEType)
+	}
+	if opts.UnderNodeID != 0 {
+		clauses = append(clauses, `AND n.id IN (
+			WITH RECURSIVE descendants(id) AS (
+				SELECT id FROM nodes WHERE parent_id=?
+				UNION ALL
+				SELECT child.id FROM nodes child
+				JOIN descendants parent ON child.parent_id=parent.id
+			)
+			SELECT id FROM descendants
+		)`)
+		args = append(args, opts.UnderNodeID)
 	}
 	return strings.Join(clauses, "\n"), args
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -244,6 +244,65 @@ func TestSearchPageFiltersCurrentMediaTypeWithParameters(t *testing.T) {
 	require.ErrorContains(t, err, "must not contain wildcards")
 }
 
+func TestSearchPageFiltersDescendantsByStableDirectory(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	scope, err := s.Mkdir(ctx, s.RootID(), "quarterly")
+	require.NoError(t, err)
+	nested, err := s.Mkdir(ctx, scope.ID, "2026")
+	require.NoError(t, err)
+	insidePDF, err := s.CreateFile(
+		ctx, scope.ID, "quarterly-a.pdf", fakeHash("b8"), 4, "application/pdf",
+	)
+	require.NoError(t, err)
+	insideText, err := s.CreateFile(
+		ctx, nested.ID, "quarterly-b.txt", fakeHash("c9"), 4, "text/plain",
+	)
+	require.NoError(t, err)
+	outside, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-c.pdf", fakeHash("da"), 4, "application/pdf",
+	)
+	require.NoError(t, err)
+	tag, err := s.CreateTag(ctx, "reviewed")
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, tag.ID, insidePDF.ID, insidePDF.Revision)
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, tag.ID, outside.ID, outside.Revision)
+	require.NoError(t, err)
+
+	hits, truncated, err := s.SearchPageWithOptions(
+		ctx, "quarterly", 10, SearchOptions{UnderNodeID: scope.ID},
+	)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, hits, 2)
+	assert.ElementsMatch(t, []int64{insidePDF.ID, insideText.ID},
+		[]int64{hits[0].Node.ID, hits[1].Node.ID})
+	for _, hit := range hits {
+		assert.NotEqual(t, scope.ID, hit.Node.ID, "the selected directory is not its own descendant")
+	}
+
+	hits, _, err = s.SearchPageWithOptions(ctx, "quarterly", 10, SearchOptions{
+		TagID: tag.ID, MIMEType: "application/pdf", UnderNodeID: scope.ID,
+	})
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, insidePDF.ID, hits[0].Node.ID)
+
+	_, _, err = s.SearchPageWithOptions(
+		ctx, "quarterly", 10, SearchOptions{UnderNodeID: insidePDF.ID},
+	)
+	require.ErrorIs(t, err, ErrNotDir)
+	trashed, err := s.Mkdir(ctx, s.RootID(), "old-quarterly")
+	require.NoError(t, err)
+	_, _, err = s.Trash(ctx, trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	_, _, err = s.SearchPageWithOptions(
+		ctx, "quarterly", 10, SearchOptions{UnderNodeID: trashed.ID},
+	)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestSearchContentFollowsStableNameMatches(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()


### PR DESCRIPTION
People and agents often know which collection contains a document even when they do not remember its exact name. Until now, a bounded search always covered the whole vault, so unrelated matches elsewhere could fill the result before the desired subtree appeared.

This adds the ordinary workflow:

    docbank search receipt --under /taxes/2026

`--under` accepts an absolute virtual path or an `id:N` selector. The CLI resolves that selector to one live directory and the search request is bound to its stable node ID, so a rename cannot retarget an in-flight request. Results include descendants only; the selected directory itself is not a result, and files, missing nodes, and trashed directories are rejected. JSON echoes `under_node_id` so agents can retain the authority they searched beneath.

Directory scoping applies equally to filename and verified-content matches and composes with `--tag` and `--mime-type`. Existing name-before-content ranking, current-version eligibility, truncation reporting, and live-node behavior do not change. The daemon protocol advances so an older process cannot silently ignore the new constraint and return a broader page.

Date filtering remains separate work because its time authority and preview semantics deserve an explicit contract rather than being bundled into this addition.