### PR TITLE
Search by current modification time

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -1084,6 +1084,15 @@ func TestSearchCLI(t *testing.T) {
 		formatNodeSelector(inbox.Directory.ID))
 	require.NoError(t, err, out)
 	assert.NotContains(t, out, "/other/")
+
+	out, err = runCLI(t, "search", "insurance",
+		"--modified-since", "2000-01-01T00:00:00-05:00",
+		"--modified-before", "2100-01-01T00:00:00Z", "--json")
+	require.NoError(t, err, out)
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, "2000-01-01T05:00:00.000000000Z", report.ModifiedSince)
+	assert.Equal(t, "2100-01-01T00:00:00.000000000Z", report.ModifiedBefore)
+	require.Len(t, report.Hits, 3)
 }
 
 func TestSearchCLIReportsTruncation(t *testing.T) {

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "29", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "30", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "29", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "30", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "29", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "30", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/exit_test.go
+++ b/cmd/docbank/exit_test.go
@@ -66,6 +66,10 @@ func TestRunProcessDistinguishesUsageAndMissingNodes(t *testing.T) {
 	assert.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "absolute virtual path or id:")
 
+	code = run("search", "term", "--modified-since", "yesterday")
+	assert.Equal(t, exitUsage, code)
+	assert.Contains(t, stderr.String(), "absolute RFC3339 timestamp")
+
 	code = run("storage", "pack", "--max-bytes", "-1")
 	assert.Equal(t, exitUsage, code)
 	assert.Contains(t, stderr.String(), "validation")

--- a/cmd/docbank/search.go
+++ b/cmd/docbank/search.go
@@ -17,11 +17,13 @@ const (
 )
 
 var (
-	searchLimit int
-	searchJSON  bool
-	searchTag   string
-	searchMIME  string
-	searchUnder string
+	searchLimit  int
+	searchJSON   bool
+	searchTag    string
+	searchMIME   string
+	searchUnder  string
+	searchSince  string
+	searchBefore string
 )
 
 var searchCmd = &cobra.Command{
@@ -36,6 +38,12 @@ var searchCmd = &cobra.Command{
 		if err != nil {
 			return usageError(err)
 		}
+		modifiedSince, modifiedBefore, err := store.NormalizeSearchTimeBounds(
+			searchSince, searchBefore,
+		)
+		if err != nil {
+			return usageError(err)
+		}
 		var underSelector nodeSelector
 		if searchUnder != "" {
 			underSelector, err = parseNodeSelector(searchUnder)
@@ -47,7 +55,9 @@ var searchCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		opts := client.SearchOptions{MIMEType: mimeType}
+		opts := client.SearchOptions{
+			MIMEType: mimeType, ModifiedSince: modifiedSince, ModifiedBefore: modifiedBefore,
+		}
 		var tagName string
 		if searchTag != "" {
 			tag, resolveErr := resolveTag(cmd, c, searchTag)
@@ -89,6 +99,12 @@ var searchCmd = &cobra.Command{
 			if underPath != "" {
 				filters = append(filters, fmt.Sprintf("directory %q", underPath))
 			}
+			if rep.ModifiedSince != "" {
+				filters = append(filters, fmt.Sprintf("modified since %q", rep.ModifiedSince))
+			}
+			if rep.ModifiedBefore != "" {
+				filters = append(filters, fmt.Sprintf("modified before %q", rep.ModifiedBefore))
+			}
 			if len(filters) == 0 {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no matches")
 			} else {
@@ -128,6 +144,10 @@ func init() {
 		"require one current parameter-free media type")
 	searchCmd.Flags().StringVar(&searchUnder, "under", "",
 		"require descendants of one live directory path or id:N")
+	searchCmd.Flags().StringVar(&searchSince, "modified-since", "",
+		"require modification at or after an absolute RFC3339 timestamp")
+	searchCmd.Flags().StringVar(&searchBefore, "modified-before", "",
+		"require modification before an absolute RFC3339 timestamp")
 	searchCmd.Flags().BoolVar(&searchJSON, "json", false, "emit machine-readable JSON")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -173,6 +173,11 @@ the stable ID as `under_node_id`. The selected directory is excluded; all
 descendant name and content candidates share the same constraint. Retain the
 echoed ID as authority instead of treating the directory's mutable path as the
 filter identity.
+Use `modified_since` and `modified_before` for an absolute current-node time
+window. The first bound is inclusive and the second exclusive. Both accept
+RFC3339 offsets; the response echoes canonical UTC values. These fields refer
+to the live node's `modified_at`, not source-file provenance or historical
+content-version time.
 
 ```bash
 curl --fail-with-body --get \
@@ -181,6 +186,8 @@ curl --fail-with-body --get \
   --data 'tag_id=<tag-uuid>' \
   --data-urlencode 'mime_type=application/pdf' \
   --data 'under_node_id=42' \
+  --data-urlencode 'modified_since=2026-01-01T00:00:00Z' \
+  --data-urlencode 'modified_before=2026-04-01T00:00:00Z' \
   --data 'limit=100' \
   "$DOCBANK_URL/api/v1/search"
 ```

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -42,7 +42,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /audit/scopes/{scope_id}/history?limit=&cursor=` | read canonical newest-first events across every member of one permanent scope | Implemented |
 | `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
-| `GET /search?q=&tag_id=&mime_type=&under_node_id=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity, current base media type, and descendants of a live directory, with match source and explicit `truncated` status | Implemented |
+| `GET /search?q=&tag_id=&mime_type=&under_node_id=&modified_since=&modified_before=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity, current base media type, descendants of a live directory, and current node modification time, with match source and explicit `truncated` status | Implemented |
 | `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
 | `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -568,7 +568,7 @@ returns the complete restored node with its resulting path and revision.
 ## docbank search
 
 ```
-docbank search <query>... [--tag <name-or-id>] [--mime-type <type/subtype>] [--under <path-or-id>] [--limit <n>] [--json]
+docbank search <query>... [--tag <name-or-id>] [--mime-type <type/subtype>] [--under <path-or-id>] [--modified-since <timestamp>] [--modified-before <timestamp>] [--limit <n>] [--json]
 ```
 
 Full-text search over live node names and verified extracted text (FTS5).
@@ -591,11 +591,17 @@ excludes directories and retained non-current versions.
 live directory and searches its descendants. The CLI resolves paths before the
 request and the daemon uses the resulting stable directory ID. The directory
 itself is excluded; a file, missing node, or trashed directory is rejected.
+`--modified-since` and `--modified-before` accept absolute RFC3339 timestamps
+and filter the live node's current modification time. The lower bound is
+inclusive and the upper bound is exclusive. Either may be used alone; when
+both are present, the lower bound must be earlier. Inputs are normalized to
+canonical UTC before the request.
 
 `--json` emits the typed search report with `hits`, the applied `limit`, and
 an explicit `truncated` boolean. A filtered report also echoes the stable
-`tag_id`, normalized `mime_type`, and stable `under_node_id` when supplied. An
-empty result uses `"hits": []`.
+`tag_id`, normalized `mime_type`, stable `under_node_id`, and canonical
+`modified_since` / `modified_before` bounds when supplied. An empty result uses
+`"hits": []`.
 
 The daemon indexes current UTF-8 `text/*`, JSON, and JSONL blobs up to 16 MiB
 after a terminally verified read. PDF, Office, and OCR extraction are not yet

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,7 +117,6 @@ and append later changes to the same stable node without touching source files.
 - Additional and overlapping audit scopes
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
-- Date search filters; stable tag, current MIME, and directory-scoped filtering are implemented
 - Additional text extraction workers for PDF text layers and office formats;
   bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
 - External integration surface: generalized ingest provenance —

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -11,6 +11,8 @@ docbank search tax 2026
 docbank search return --tag taxes
 docbank search report --mime-type application/pdf
 docbank search receipt --under /taxes/2026
+docbank search report --modified-since 2026-01-01T00:00:00Z
+docbank search report --modified-before 2026-04-01T00:00:00Z
 docbank search report --limit 200
 docbank search report --json
 ```
@@ -52,6 +54,13 @@ id:198     content  /taxes/2026/car-insurance-notes.md
   selector to its stable node ID before searching; JSON echoes that ID as
   `under_node_id`. The selected directory itself is not a result, and moving or
   renaming it does not change its identity.
+- **Current modification time.** `--modified-since <timestamp>` includes nodes
+  modified at or after an absolute RFC3339 timestamp;
+  `--modified-before <timestamp>` excludes that timestamp and everything after
+  it. Together they form a half-open interval, so adjacent searches do not
+  duplicate a boundary result. Inputs with an explicit offset are normalized
+  to UTC and echoed in JSON. The bounds apply to the live node's current
+  `modified_at`, not filesystem provenance or the age of retained versions.
 
 For scripts, `--json` returns `hits`, `limit`, and `truncated` without table
 formatting. `hits` is always an array, including when nothing matches.
@@ -71,8 +80,8 @@ daemon job reaches it. A transient open, read, or verification error leaves the
 item queued and is retried on a bounded delay; it does not become a permanent
 extraction failure. `docbank jobs` shows whether that worker is running.
 
-PDF text layers, office formats, OCR, and date search filters are not
-yet available. Their absence never changes name-search results or document authority.
+PDF text layers, office formats, and OCR are not yet available. Their absence
+never changes name-search results or document authority.
 
 Next: organize documents beyond paths with
 [Organizing & Tagging](organizing.md), or see every search flag in the

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -351,21 +351,31 @@ func registerReadRoutes(api huma.API, d Deps) {
 			"content-only matches follow in their own BM25 order. Every hit names its match source. " +
 			"An optional stable tag ID requires that assignment for every result. An optional " +
 			"parameter-free MIME type matches the current file version with or without parameters. " +
-			"An optional live directory node ID restricts results to its descendants.",
+			"An optional live directory node ID restricts results to its descendants. Optional " +
+			"absolute modification timestamps form an inclusive-since, exclusive-before interval.",
 	}, func(ctx context.Context, in *struct {
-		Q           string `query:"q" required:"true"`
-		Limit       int    `query:"limit" default:"50" minimum:"1" maximum:"1000"`
-		TagID       string `query:"tag_id" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"`
-		MIMEType    string `query:"mime_type" maxLength:"255"`
-		UnderNodeID int64  `query:"under_node_id" minimum:"1"`
+		Q              string `query:"q" required:"true"`
+		Limit          int    `query:"limit" default:"50" minimum:"1" maximum:"1000"`
+		TagID          string `query:"tag_id" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"`
+		MIMEType       string `query:"mime_type" maxLength:"255"`
+		UnderNodeID    int64  `query:"under_node_id" minimum:"1"`
+		ModifiedSince  string `query:"modified_since" maxLength:"64"`
+		ModifiedBefore string `query:"modified_before" maxLength:"64"`
 	}) (*searchOutput, error) {
 		mimeType, err := store.NormalizeSearchMIMEType(in.MIMEType)
+		if err != nil {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+		}
+		modifiedSince, modifiedBefore, err := store.NormalizeSearchTimeBounds(
+			in.ModifiedSince, in.ModifiedBefore,
+		)
 		if err != nil {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 		}
 		hits, truncated, err := d.Store.SearchPageWithOptions(
 			ctx, in.Q, in.Limit, store.SearchOptions{
 				TagID: in.TagID, MIMEType: mimeType, UnderNodeID: in.UnderNodeID,
+				ModifiedSince: modifiedSince, ModifiedBefore: modifiedBefore,
 			},
 		)
 		if err != nil {
@@ -374,6 +384,7 @@ func registerReadRoutes(api huma.API, d Deps) {
 		out := &searchOutput{Body: SearchReport{
 			Hits: []SearchHit{}, Limit: in.Limit, Truncated: truncated,
 			TagID: in.TagID, MIMEType: mimeType, UnderNodeID: in.UnderNodeID,
+			ModifiedSince: modifiedSince, ModifiedBefore: modifiedBefore,
 		}}
 		for _, h := range hits {
 			out.Body.Hits = append(out.Body.Hits, SearchHit{

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -290,6 +290,18 @@ func TestSearch(t *testing.T) {
 	assert.True(t, rep.Truncated)
 	assert.Equal(t, "name", rep.Hits[0].Match)
 
+	resp, body = get(t, ts, "/api/v1/search?q=insurance&limit=10&"+
+		"modified_since=2000-01-01T00:00:00-05:00&modified_before=2100-01-01T00:00:00Z", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	require.NoError(t, json.Unmarshal([]byte(body), &rep))
+	require.Len(t, rep.Hits, 2)
+	assert.Equal(t, "2000-01-01T05:00:00.000000000Z", rep.ModifiedSince)
+	assert.Equal(t, "2100-01-01T00:00:00.000000000Z", rep.ModifiedBefore)
+	resp, body = get(t, ts, "/api/v1/search?q=insurance&limit=10&"+
+		"modified_since=2100-01-01T00:00:00Z&modified_before=2000-01-01T00:00:00Z", nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"validation"`)
+
 	tag, err := s.CreateTag(t.Context(), "renewal")
 	require.NoError(t, err)
 	_, err = s.AssignTag(

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -433,12 +433,14 @@ type SearchHit struct {
 
 // SearchReport is one bounded search result page.
 type SearchReport struct {
-	Hits        []SearchHit `json:"hits"`
-	Limit       int         `json:"limit"`
-	Truncated   bool        `json:"truncated"`
-	TagID       string      `json:"tag_id,omitempty"`
-	MIMEType    string      `json:"mime_type,omitempty"`
-	UnderNodeID int64       `json:"under_node_id,omitempty"`
+	Hits           []SearchHit `json:"hits"`
+	Limit          int         `json:"limit"`
+	Truncated      bool        `json:"truncated"`
+	TagID          string      `json:"tag_id,omitempty"`
+	MIMEType       string      `json:"mime_type,omitempty"`
+	UnderNodeID    int64       `json:"under_node_id,omitempty"`
+	ModifiedSince  string      `json:"modified_since,omitempty"`
+	ModifiedBefore string      `json:"modified_before,omitempty"`
 }
 
 // IngestFailure records one source path that failed to import.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -670,12 +670,15 @@ func (c *Client) VerifyNodeContent(ctx context.Context, id, revision int64) (api
 	return report, err
 }
 
-// SearchOptions narrows ranked search by stable tag, current media type, and
-// one live directory's descendants.
+// SearchOptions narrows ranked search by stable tag, current media type, one
+// live directory's descendants, and an optional half-open modification-time
+// interval.
 type SearchOptions struct {
-	TagID       string
-	MIMEType    string
-	UnderNodeID int64
+	TagID          string
+	MIMEType       string
+	UnderNodeID    int64
+	ModifiedSince  string
+	ModifiedBefore string
 }
 
 func (c *Client) Search(ctx context.Context, query string, limit int) (api.SearchReport, error) {
@@ -697,6 +700,12 @@ func (c *Client) SearchWithOptions(
 	if opts.UnderNodeID < 0 {
 		return out, errors.New("search directory node ID must be positive")
 	}
+	modifiedSince, modifiedBefore, err := store.NormalizeSearchTimeBounds(
+		opts.ModifiedSince, opts.ModifiedBefore,
+	)
+	if err != nil {
+		return out, err
+	}
 	queryValues := url.Values{}
 	queryValues.Set("q", query)
 	queryValues.Set("limit", strconv.Itoa(limit))
@@ -709,10 +718,18 @@ func (c *Client) SearchWithOptions(
 	if opts.UnderNodeID != 0 {
 		queryValues.Set("under_node_id", strconv.FormatInt(opts.UnderNodeID, 10))
 	}
+	if modifiedSince != "" {
+		queryValues.Set("modified_since", modifiedSince)
+	}
+	if modifiedBefore != "" {
+		queryValues.Set("modified_before", modifiedBefore)
+	}
 	if err := c.do(ctx, http.MethodGet, "/api/v1/search?"+queryValues.Encode(), nil, nil, &out); err != nil {
 		return out, err
 	}
-	if out.TagID != opts.TagID || out.MIMEType != mimeType || out.UnderNodeID != opts.UnderNodeID {
+	if out.TagID != opts.TagID || out.MIMEType != mimeType ||
+		out.UnderNodeID != opts.UnderNodeID || out.ModifiedSince != modifiedSince ||
+		out.ModifiedBefore != modifiedBefore {
 		return api.SearchReport{}, errors.New("search response has inconsistent filter authority")
 	}
 	return out, nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -125,12 +125,15 @@ func TestSearchWithOptionsUsesStableTagIdentity(t *testing.T) {
 	report, err := c.SearchWithOptions(
 		ctx, "insurance", 10, client.SearchOptions{
 			TagID: tag.ID, MIMEType: "APPLICATION/PDF", UnderNodeID: directory.ID,
+			ModifiedSince: "2000-01-01T00:00:00-05:00", ModifiedBefore: "2100-01-01T00:00:00Z",
 		},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, tag.ID, report.TagID)
 	assert.Equal(t, "application/pdf", report.MIMEType)
 	assert.Equal(t, directory.ID, report.UnderNodeID)
+	assert.Equal(t, "2000-01-01T05:00:00.000000000Z", report.ModifiedSince)
+	assert.Equal(t, "2100-01-01T00:00:00.000000000Z", report.ModifiedBefore)
 	require.Len(t, report.Hits, 1)
 	assert.Equal(t, tagged.ID, report.Hits[0].Node.ID)
 
@@ -142,6 +145,10 @@ func TestSearchWithOptionsUsesStableTagIdentity(t *testing.T) {
 	require.ErrorContains(t, err, "must not include parameters")
 	_, err = c.SearchWithOptions(ctx, "insurance", 10, client.SearchOptions{UnderNodeID: -1})
 	require.ErrorContains(t, err, "directory node ID must be positive")
+	_, err = c.SearchWithOptions(ctx, "insurance", 10, client.SearchOptions{
+		ModifiedSince: "2100-01-01T00:00:00Z", ModifiedBefore: "2000-01-01T00:00:00Z",
+	})
+	require.ErrorContains(t, err, "must be earlier")
 }
 
 func TestMoveToPathValidatesRequestBeforeTransport(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "29"
+	daemonProtocolVersion = "30"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"mime"
 	"strings"
+	"time"
 )
 
 // SearchHit is a search result with its display path.
@@ -19,11 +20,14 @@ type SearchHit struct {
 // SearchOptions narrows ranked search without changing its name-before-content
 // ordering. TagID identifies one required assignment; MIMEType selects the
 // current file version's parameter-free base media type; UnderNodeID selects
-// descendants of one live directory.
+// descendants of one live directory. ModifiedSince is inclusive and
+// ModifiedBefore is exclusive; both accept absolute RFC3339 timestamps.
 type SearchOptions struct {
-	TagID       string
-	MIMEType    string
-	UnderNodeID int64
+	TagID          string
+	MIMEType       string
+	UnderNodeID    int64
+	ModifiedSince  string
+	ModifiedBefore string
 }
 
 const (
@@ -85,6 +89,14 @@ func (s *Store) SearchPageWithOptions(
 			return nil, false, fmt.Errorf("search scope node %d: %w", opts.UnderNodeID, ErrNotDir)
 		}
 	}
+	modifiedSince, modifiedBefore, err := NormalizeSearchTimeBounds(
+		opts.ModifiedSince, opts.ModifiedBefore,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	opts.ModifiedSince = modifiedSince
+	opts.ModifiedBefore = modifiedBefore
 	fq := ftsQuery(query)
 	if fq == "" {
 		return nil, false, nil
@@ -198,7 +210,44 @@ func searchFilterSQL(opts SearchOptions) (string, []any) {
 		)`)
 		args = append(args, opts.UnderNodeID)
 	}
+	if opts.ModifiedSince != "" {
+		clauses = append(clauses, `AND n.modified_at>=?`)
+		args = append(args, opts.ModifiedSince)
+	}
+	if opts.ModifiedBefore != "" {
+		clauses = append(clauses, `AND n.modified_at<?`)
+		args = append(args, opts.ModifiedBefore)
+	}
 	return strings.Join(clauses, "\n"), args
+}
+
+// NormalizeSearchTimeBounds accepts optional absolute RFC3339 timestamps and
+// returns canonical UTC bounds. The half-open interval makes adjacent searches
+// compose without duplicate boundary results.
+func NormalizeSearchTimeBounds(modifiedSince, modifiedBefore string) (string, string, error) {
+	since, err := normalizeSearchTimestamp("modified_since", modifiedSince)
+	if err != nil {
+		return "", "", err
+	}
+	before, err := normalizeSearchTimestamp("modified_before", modifiedBefore)
+	if err != nil {
+		return "", "", err
+	}
+	if since != "" && before != "" && since >= before {
+		return "", "", errors.New("modified_since must be earlier than modified_before")
+	}
+	return since, before, nil
+}
+
+func normalizeSearchTimestamp(field, value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return "", fmt.Errorf("%s %q must be an absolute RFC3339 timestamp: %w", field, value, err)
+	}
+	return parsed.UTC().Format(timestampLayout), nil
 }
 
 // NormalizeSearchMIMEType accepts one parameter-free media type and returns

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -303,6 +303,65 @@ func TestSearchPageFiltersDescendantsByStableDirectory(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestSearchPageFiltersByModificationTime(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	old, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-old.txt", fakeHash("eb"), 4, "text/plain",
+	)
+	require.NoError(t, err)
+	nameMatch, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-current.txt", fakeHash("fc"), 4, "text/plain",
+	)
+	require.NoError(t, err)
+	contentMatch, err := s.CreateFile(
+		ctx, s.RootID(), "notes.txt", fakeHash("0d"), 4, "text/plain",
+	)
+	require.NoError(t, err)
+	boundary, err := s.CreateFile(
+		ctx, s.RootID(), "quarterly-boundary.txt", fakeHash("1e"), 4, "text/plain",
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: contentMatch.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "quarterly notes",
+	}))
+	for id, stamp := range map[int64]string{
+		old.ID:          "2026-01-01T00:00:00.000000000Z",
+		nameMatch.ID:    "2026-01-02T00:00:00.000000000Z",
+		contentMatch.ID: "2026-01-02T12:00:00.000000000Z",
+		boundary.ID:     "2026-01-03T00:00:00.000000000Z",
+	} {
+		_, err = s.db.ExecContext(ctx, `UPDATE nodes SET modified_at=? WHERE id=?`, stamp, id)
+		require.NoError(t, err)
+	}
+
+	hits, truncated, err := s.SearchPageWithOptions(ctx, "quarterly", 10, SearchOptions{
+		ModifiedSince:  "2026-01-01T19:00:00-05:00",
+		ModifiedBefore: "2026-01-03T00:00:00Z",
+	})
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, hits, 2)
+	assert.Equal(t, nameMatch.ID, hits[0].Node.ID)
+	assert.Equal(t, SearchMatchName, hits[0].Match)
+	assert.Equal(t, contentMatch.ID, hits[1].Node.ID)
+	assert.Equal(t, SearchMatchContent, hits[1].Match)
+
+	since, before, err := NormalizeSearchTimeBounds(
+		"2026-01-01T19:00:00-05:00", "2026-01-03T01:00:00+01:00",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-01-02T00:00:00.000000000Z", since)
+	assert.Equal(t, "2026-01-03T00:00:00.000000000Z", before)
+	_, _, err = NormalizeSearchTimeBounds("yesterday", "")
+	require.ErrorContains(t, err, "absolute RFC3339 timestamp")
+	_, _, err = NormalizeSearchTimeBounds(
+		"2026-01-03T00:00:00Z", "2026-01-03T00:00:00Z",
+	)
+	require.ErrorContains(t, err, "must be earlier")
+}
+
 func TestSearchContentFollowsStableNameMatches(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()


### PR DESCRIPTION
People and agents often remember when a document changed even when they do not remember its exact name. Until now, a bounded search could be filled by matches from the wrong period before the relevant documents appeared.

This adds explicit absolute time bounds:

    docbank search report \
      --modified-since 2026-01-01T00:00:00Z \
      --modified-before 2026-04-01T00:00:00Z

The lower bound is inclusive and the upper bound is exclusive. That half-open interval lets adjacent searches cover a timeline without returning the boundary document twice. Either bound can be used alone, RFC3339 offsets are accepted, and JSON echoes canonical UTC values so an agent can retain the exact authority that was applied. An empty or inverted interval is rejected before daemon startup.

The filter applies to the live node’s current `modified_at`, not the source file’s provenance timestamp or the age of a retained historical version. It constrains filename and verified-content matches equally and composes with stable tag, current MIME, and directory filters without changing ranking or truncation semantics.

The authenticated HTTP API and typed Go client expose the same contract. The daemon protocol advances so an older process cannot silently ignore the bounds and return a broader result.