### PR TITLE
Report maintenance contention immediately

### DIFF
--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "30", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "31", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "30", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "31", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "30", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "31", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/exit.go
+++ b/cmd/docbank/exit.go
@@ -61,7 +61,8 @@ func commandExitCode(err error, started bool) int {
 		return exitStale
 	}
 	if errors.Is(err, home.ErrVaultLocked) || errors.Is(err, backup.ErrRepoLocked) ||
-		errors.Is(err, packstore.ErrPackRetirementDeferred) {
+		errors.Is(err, packstore.ErrPackRetirementDeferred) ||
+		errors.Is(err, client.ErrMaintenanceBusy) {
 		return exitBusy
 	}
 	if errors.Is(err, store.ErrInvalidName) || errors.Is(err, store.ErrInvalidTag) ||

--- a/cmd/docbank/exit_test.go
+++ b/cmd/docbank/exit_test.go
@@ -33,6 +33,7 @@ func TestCommandExitCode(t *testing.T) {
 		{name: "vault busy", err: home.ErrVaultLocked, started: true, want: exitBusy},
 		{name: "repository busy", err: backup.ErrRepoLocked, started: true, want: exitBusy},
 		{name: "retirement busy", err: packstore.ErrPackRetirementDeferred, started: true, want: exitBusy},
+		{name: "maintenance busy", err: client.ErrMaintenanceBusy, started: true, want: exitBusy},
 		{name: "content integrity", err: client.ErrIntegrity, started: true, want: exitIntegrity},
 		{name: "reported integrity", err: integrityError(errors.New("problems")), started: true, want: exitIntegrity},
 	}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -701,9 +701,10 @@ physically reclaimed.
 `POST /api/v1/verify` validates logical metadata and audit history before
 re-hashing every stored blob. It is read-only but can be expensive. Maintenance
 requests serialize against mutations and may run without the ordinary request
-timeout; agents should expose progress as “waiting” rather than assuming a
-queued request is hung. Treat either `metadata_problems` or blob `problems` as a
-failed verification.
+timeout. A new mutation submitted after maintenance is running or queued gets
+`503 maintenance_busy`; retry it after the operator-visible maintenance ends.
+This is a transient refusal, not evidence that the requested mutation committed.
+Treat either `metadata_problems` or blob `problems` as a failed verification.
 
 Use `POST /api/v1/nodes/{id}/verify` when the decision concerns one inspected
 file. Unlike the vault-wide operation it requires `If-Match`, stays bounded to
@@ -743,6 +744,7 @@ Branch on `code`, never `detail`. Useful policy groups:
   `not_dir`, `not_file`, `is_root`.
 - Reconcile desired state: `exists`, `cycle`, `not_trashed`, `not_found`.
 - Stop and surface credentials or topology: `unauthorized`, `loopback_only`.
+- Retry after the active maintenance operation ends: `maintenance_busy`.
 - Release external file locks, then run `storage pack` reconciliation:
   `pack_retirement_deferred`. The preceding repack catalog change already
   committed; never restore the retired mapping or assume rollback.

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -444,9 +444,13 @@ vault lock (held for the daemon's whole lifetime, not per-request), an
 in-process `sync.RWMutex`-shaped gate serializes them against regular
 mutations: ordinary mutating handlers (`PATCH`, trash, restore, create,
 ingest) take the read side and may run concurrently with each other;
-maintenance handlers take the write side. Requests queue rather than
-fail, and maintenance routes are exempt from the per-request timeout
-since `gc`/`verify` can legitimately run long on a large vault.
+maintenance handlers take the write side. Once maintenance is running or
+queued for that write side, a new HTTP mutation fails immediately with
+`503 maintenance_busy` instead of becoming an indistinguishable long wait.
+Daemon-owned background jobs retain blocking gate semantics so a transient
+maintenance run does not permanently fail a watcher or extraction worker.
+Maintenance routes are exempt from the per-request timeout since
+`gc`/`verify` can legitimately run long on a large vault.
 
 Backup creation uses the mutation-exclusive side only for Kit's freeze window.
 Once Docbank's deferred read transaction is pinned, ordinary mutations continue
@@ -506,6 +510,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `loopback_only` | 403 | server-path ingest or preflight called by a non-loopback peer |
 | `digest_mismatch` / `size_mismatch` | 422 | uploaded file bytes disagree with the required declaration; no node/blob authority committed |
 | `too_large` | 413 | upload exceeded its declared size plus bounded multipart overhead |
+| `maintenance_busy` | 503 | exclusive vault maintenance is running or queued; retry the mutation after it finishes |
 | `pack_retirement_deferred` | 503 | repack authority committed but an old source pack remains physically locked; release the lock, then run `storage pack` reconciliation |
 | `unauthorized` | 401 | missing or invalid API key; bad shutdown token |
 | `internal` | 500 | unmapped error (still surfaced with a message — this is a single-user local daemon, not a hardened multi-tenant service) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -64,7 +64,7 @@ stderr. Human error text remains explanatory and may change.
 | `2` | Invalid command usage, arguments, flag combinations, values, or request validation | Correct the invocation |
 | `3` | The daemon returned `not_found` for the requested vault object | Refresh names or identities |
 | `4` | Stale optimistic state: a revision or audit enrollment preview no longer matches | Re-read, reconsider, and retry deliberately |
-| `5` | A vault, backup repository, or physical pack resource is busy or locked | Wait or release the known owner; do not blindly force-unlock |
+| `5` | Vault maintenance is active, or a vault, backup repository, or physical pack resource is busy or locked | Wait and retry, or release the known owner; do not blindly force-unlock |
 | `6` | A completed verification reported integrity findings, or a content stream failed terminal size/hash/digest proof | Do not trust or publish the affected bytes |
 
 Integrity commands may write their complete human or JSON report before
@@ -651,9 +651,10 @@ already reclaimed. With `--run`, loose blob files are deleted first, then their
 metadata rows; output separately reports removed blob records, reclaimed loose
 files, and reclaimed bytes. A crash mid-GC leaves
 rows without files, which the next `gc --run` reconciles and `verify`
-reports in the meantime. The daemon's maintenance gate holds off
-concurrent mutations while `gc --run` runs, so it never races a
-concurrent import (see [Ownership & Concurrency](architecture/locking.md)).
+reports in the meantime. The daemon's maintenance gate rejects new
+mutations with the retryable busy exit code `5` while `gc --run` runs, so it
+never races a concurrent import (see
+[Ownership & Concurrency](architecture/locking.md)).
 GC does not invoke repack, and no automatic GC/repack scheduler exists today.
 
 ## docbank storage status
@@ -676,7 +677,8 @@ docbank storage pack [--max-bytes <bytes>] [--json]
 
 Explicitly converts authorized loose blobs into immutable Kit pack files. The
 operation runs through the authenticated daemon and holds the vault maintenance
-gate; reads remain available, while imports and other mutations wait. Packing
+gate; reads remain available, while imports and other mutations receive the
+retryable busy exit code `5`. Packing
 does not change document identity or blob read authority, and mixed loose and
 packed storage remains valid after an interruption.
 

--- a/docs/internal/daemon-api-design.md
+++ b/docs/internal/daemon-api-design.md
@@ -107,10 +107,13 @@ maintenance sides:
 - create, ingest, move, trash, and restore take the shared side;
 - trash empty, GC, and verify take the exclusive side.
 
-Requests queue rather than returning “busy.” Maintenance is exempt from the
-ordinary request timeout because a personal archive scan may legitimately be
-long. The gate is not the vault lock; the daemon already owns that lock for
-its lifetime.
+Once maintenance is running or queued, a new HTTP mutation returns
+`503 maintenance_busy` instead of waiting indefinitely. Daemon-owned
+background jobs keep the blocking shared-side behavior so a transient
+maintenance pass does not permanently fail durable work. Maintenance is exempt
+from the ordinary request timeout because a personal archive scan may
+legitimately be long. The gate is not the vault lock; the daemon already owns
+that lock for its lifetime.
 
 Any new endpoint that changes reachability or physical content must be placed
 on the correct side of the gate. Read-only metadata and content streams do not

--- a/internal/api/gate.go
+++ b/internal/api/gate.go
@@ -16,6 +16,8 @@ import (
 type OperationGate struct {
 	mu           sync.RWMutex
 	preservation sync.RWMutex
+	admission    sync.RWMutex
+	maintenance  int
 }
 
 // NewOperationGate creates one daemon-wide operation coordinator. Every
@@ -31,15 +33,30 @@ func (g *OperationGate) Mutate(fn func() error) error {
 }
 
 func (g *OperationGate) mutate(fn func() error) error {
-	if !g.mu.TryRLock() {
+	g.admission.RLock()
+	if g.maintenance > 0 {
+		g.admission.RUnlock()
 		return NewError(http.StatusServiceUnavailable, "maintenance_busy",
 			"vault maintenance is running or queued; retry this mutation after it finishes")
 	}
+	// Keep admission pinned until the shared side is held. A short backup
+	// freeze can therefore delay this mutation without being mistaken for
+	// maintenance, while newly queued maintenance cannot overtake it.
+	g.mu.RLock()
+	g.admission.RUnlock()
 	defer g.mu.RUnlock()
 	return fn()
 }
 
 func (g *OperationGate) maintain(fn func() error) error {
+	g.admission.Lock()
+	g.maintenance++
+	g.admission.Unlock()
+	defer func() {
+		g.admission.Lock()
+		g.maintenance--
+		g.admission.Unlock()
+	}()
 	g.preservation.Lock()
 	defer g.preservation.Unlock()
 	g.mu.Lock()

--- a/internal/api/gate.go
+++ b/internal/api/gate.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"net/http"
 	"sync"
 )
 
@@ -29,7 +30,14 @@ func (g *OperationGate) Mutate(fn func() error) error {
 	return fn()
 }
 
-func (g *OperationGate) mutate(fn func() error) error { return g.Mutate(fn) }
+func (g *OperationGate) mutate(fn func() error) error {
+	if !g.mu.TryRLock() {
+		return NewError(http.StatusServiceUnavailable, "maintenance_busy",
+			"vault maintenance is running or queued; retry this mutation after it finishes")
+	}
+	defer g.mu.RUnlock()
+	return fn()
+}
 
 func (g *OperationGate) maintain(fn func() error) error {
 	g.preservation.Lock()

--- a/internal/api/gate_test.go
+++ b/internal/api/gate_test.go
@@ -25,7 +25,7 @@ func TestGateFreezerBlocksMutationOnlyUntilEnd(t *testing.T) {
 
 	mutated := make(chan struct{})
 	go func() {
-		_ = g.Mutate(func() error {
+		_ = g.mutate(func() error {
 			close(mutated)
 			return nil
 		})
@@ -43,6 +43,45 @@ func TestGateFreezerBlocksMutationOnlyUntilEnd(t *testing.T) {
 		t.Fatal("mutation remained blocked after backup freeze ended")
 	}
 	require.Error(t, freezer.End(context.Background()))
+}
+
+func TestQueuedMaintenanceRejectsRouteMutation(t *testing.T) {
+	g := NewOperationGate()
+	captureEntered := make(chan struct{})
+	releaseCapture := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseCapture) }) })
+	captureDone := make(chan error, 1)
+	go func() {
+		captureDone <- g.capture(func() error {
+			close(captureEntered)
+			<-releaseCapture
+			return nil
+		})
+	}()
+	<-captureEntered
+
+	maintenanceDone := make(chan error, 1)
+	go func() {
+		maintenanceDone <- g.maintain(func() error { return nil })
+	}()
+	require.Eventually(t, func() bool {
+		g.admission.RLock()
+		defer g.admission.RUnlock()
+		return g.maintenance == 1
+	}, time.Second, time.Millisecond)
+
+	err := g.mutate(func() error {
+		t.Fatal("route mutation ran while maintenance was queued")
+		return nil
+	})
+	var apiErr *Error
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "maintenance_busy", apiErr.Code)
+
+	releaseOnce.Do(func() { close(releaseCapture) })
+	require.NoError(t, <-captureDone)
+	require.NoError(t, <-maintenanceDone)
 }
 
 func TestBackupCaptureBlocksGCButAllowsLiveDeletion(t *testing.T) {

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -800,41 +799,46 @@ func TestVerifyEndpointReportsBlobInventoryFailureAlongsideMetadataFailure(t *te
 	assert.Contains(t, report.MetadataProblems[1], sentinel.Error())
 }
 
-func TestMaintenanceGateQueuesMutations(t *testing.T) {
-	ts, s := newTestServer(t, nil)
-	// Saturate: fire a gc run and a burst of mkdirs concurrently. Every
-	// request must succeed — the gate queues, it never rejects — and the
-	// store must end up consistent (all dirs present).
-	var wg sync.WaitGroup
-	errs := make(chan error, 20)
-	for i := range 10 {
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			resp, body, err := try(t, ts, http.MethodPost, "/api/v1/gc", nil, map[string]any{"run": true})
-			if err != nil {
-				errs <- fmt.Errorf("gc: transport: %w", err)
-			} else if resp.StatusCode != http.StatusOK {
-				errs <- fmt.Errorf("gc: %d %s", resp.StatusCode, body)
-			}
-		}()
-		go func() {
-			defer wg.Done()
-			resp, body, err := try(t, ts, http.MethodPost, "/api/v1/nodes", nil,
-				map[string]any{"parent_id": s.RootID(), "name": fmt.Sprintf("dir-%d", i), "kind": "dir"})
-			if err != nil {
-				errs <- fmt.Errorf("mkdir: transport: %w", err)
-			} else if resp.StatusCode != http.StatusCreated {
-				errs <- fmt.Errorf("mkdir: %d %s", resp.StatusCode, body)
-			}
-		}()
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Error(err)
-	}
-	kids, err := s.Children(t.Context(), s.RootID())
-	require.NoError(t, err)
-	assert.Len(t, kids, 10)
+func TestMaintenanceGateReportsBusyToMutations(t *testing.T) {
+	gate := api.NewOperationGate()
+	maintenanceEntered := make(chan struct{})
+	releaseMaintenance := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseMaintenance:
+		default:
+			close(releaseMaintenance)
+		}
+	})
+	ts, s := newTestServer(t, func(d *api.Deps) {
+		d.Gate = gate
+		d.VerifyPage = func(
+			context.Context, *store.Store, *blob.Store, internalmaintenance.VerifyOptions,
+		) (internalmaintenance.VerifyReport, error) {
+			close(maintenanceEntered)
+			<-releaseMaintenance
+			return internalmaintenance.VerifyReport{}, nil
+		}
+	})
+
+	verifyDone := make(chan error, 1)
+	go func() {
+		resp, body, err := try(t, ts, http.MethodPost, "/api/v1/verify", nil, nil)
+		if err == nil && resp.StatusCode != http.StatusOK {
+			err = fmt.Errorf("verify: %d %s", resp.StatusCode, body)
+		}
+		verifyDone <- err
+	}()
+	<-maintenanceEntered
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/nodes", nil,
+		map[string]any{"parent_id": s.RootID(), "name": "during-maintenance", "kind": "dir"})
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"maintenance_busy"`)
+
+	close(releaseMaintenance)
+	require.NoError(t, <-verifyDone)
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/nodes", nil,
+		map[string]any{"parent_id": s.RootID(), "name": "after-maintenance", "kind": "dir"})
+	assert.Equal(t, http.StatusCreated, resp.StatusCode, body)
 }

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -820,6 +820,7 @@ func TestMaintenanceGateReportsBusyToMutations(t *testing.T) {
 			return internalmaintenance.VerifyReport{}, nil
 		}
 	})
+	created := createFileWithContent(t, ts, s, "/existing.txt", "old content")
 
 	verifyDone := make(chan error, 1)
 	go func() {
@@ -835,6 +836,21 @@ func TestMaintenanceGateReportsBusyToMutations(t *testing.T) {
 		map[string]any{"parent_id": s.RootID(), "name": "during-maintenance", "kind": "dir"})
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, body)
 	assert.Contains(t, body, `"code":"maintenance_busy"`)
+
+	upload := []byte("new upload")
+	resp, body = sendUpload(t, ts.URL, ts.Client(), s.RootID(), uploadRequest{
+		name: "upload.txt", content: upload,
+		expectedHash: uploadIdentity(upload), expectedSize: int64(len(upload)),
+	})
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"maintenance_busy"`)
+
+	replacement := []byte("replacement")
+	contentResp, contentBody := sendContentReplacement(t, ts.URL, ts.Client(),
+		created.ID, created.Revision, replacement, uploadIdentity(replacement),
+		int64(len(replacement)), "text/plain")
+	assert.Equal(t, http.StatusServiceUnavailable, contentResp.StatusCode, string(contentBody))
+	assert.Contains(t, string(contentBody), `"code":"maintenance_busy"`)
 
 	close(releaseMaintenance)
 	require.NoError(t, <-verifyDone)

--- a/internal/api/routes_upload.go
+++ b/internal/api/routes_upload.go
@@ -213,7 +213,10 @@ func uploadMediaType(value string) (string, error) {
 
 func uploadError(err error) *Error {
 	var maxBytesErr *http.MaxBytesError
+	var apiErr *Error
 	switch {
+	case errors.As(err, &apiErr):
+		return apiErr
 	case errors.Is(err, ingest.ErrUploadDigestMismatch):
 		return NewError(http.StatusUnprocessableEntity, "digest_mismatch", err.Error())
 	case errors.Is(err, ingest.ErrUploadSizeMismatch):

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -75,8 +75,13 @@ func ProblemCode(err error) (string, bool) {
 	return problem.code, true
 }
 
-// ErrIntegrity marks content that failed terminal size, hash, or digest proof.
-var ErrIntegrity = errors.New("content integrity verification failed")
+var (
+	// ErrIntegrity marks content that failed terminal size, hash, or digest proof.
+	ErrIntegrity = errors.New("content integrity verification failed")
+	// ErrMaintenanceBusy marks a mutation rejected while exclusive maintenance
+	// is running or queued. Callers may retry after the operator-visible work ends.
+	ErrMaintenanceBusy = errors.New("vault maintenance is busy")
+)
 
 type integrityError struct{ message string }
 
@@ -172,6 +177,7 @@ var codeToTypedErr = map[string]error{
 	"backup_locked":                backup.ErrRepoLocked,
 	"backup_restore_target_active": home.ErrVaultLocked,
 	"pack_retirement_deferred":     packstore.ErrPackRetirementDeferred,
+	"maintenance_busy":             ErrMaintenanceBusy,
 }
 
 func decodeError(resp *http.Response) error {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -385,6 +385,24 @@ func TestProgressStreamPreservesProblemCode(t *testing.T) {
 	assert.Equal(t, "validation", code)
 }
 
+func TestMaintenanceBusyProblemIsRetryableAndTyped(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(api.Error{
+			Title: "Service Unavailable", Status: http.StatusServiceUnavailable,
+			Code: "maintenance_busy", Detail: "vault maintenance is running",
+		})
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := client.New(ts.URL, "key").Info(t.Context())
+	require.ErrorIs(t, err, client.ErrMaintenanceBusy)
+	code, ok := client.ProblemCode(err)
+	assert.True(t, ok)
+	assert.Equal(t, "maintenance_busy", code)
+}
+
 func TestJSONMethodsRejectInvalidUTF8BeforeRequest(t *testing.T) {
 	var requests atomic.Int64
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "30"
+	daemonProtocolVersion = "31"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
A person or agent can currently issue a normal mutation while `verify`, garbage collection, packing, or other exclusive maintenance is underway and see only a long wait. That is indistinguishable from a stuck daemon, so callers cannot make a sensible retry decision or explain what is happening.

Now a new HTTP mutation receives `503 maintenance_busy` as soon as exclusive maintenance is running or queued. Nothing from the refused mutation has committed, and the caller can retry after the visible maintenance operation finishes. The CLI translates that condition to its existing busy exit code `5`, while the Go client exposes `ErrMaintenanceBusy` for typed retry handling. Reads remain available. Streaming uploads and content replacement return the same typed response.

This response is deliberately limited to operator-visible maintenance. A backup snapshot holds the exclusive metadata gate only briefly; a mutation arriving during that freeze continues to wait and then runs rather than reporting a misleading maintenance error. Daemon-owned background work such as watched inboxes and text extraction also keeps waiting on the same gate, so a short maintenance pass cannot turn durable background work into a permanent job failure.

The daemon protocol advances so a new CLI replaces an older daemon that would silently wait instead of honoring this contract. Deterministic concurrency tests hold active and queued maintenance open, prove ordinary and streaming mutations receive the typed response, confirm backup-freeze contention still waits, and then prove mutations resume after maintenance ends.