### PR TITLE
Show where imported documents came from

### DIFF
--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "31", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "32", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "31", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "32", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "31", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "32", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/provenance.go
+++ b/cmd/docbank/provenance.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/store"
+)
+
+var (
+	provenanceLimit  int
+	provenanceOffset int
+	provenanceJSON   bool
+)
+
+var provenanceCmd = &cobra.Command{
+	Use:   "provenance <path-or-id>",
+	Short: "Show where a document came from",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if provenanceLimit < 1 || provenanceLimit > store.MaxProvenancePageSize {
+			return usageError(fmt.Errorf(
+				"--limit must be between 1 and %d", store.MaxProvenancePageSize,
+			))
+		}
+		if provenanceOffset < 0 {
+			return usageError(errors.New("--offset must not be negative"))
+		}
+		selector, err := parseNodeSelector(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		node, err := selector.resolveIncludingTrash(cmd.Context(), c)
+		if err != nil {
+			return err
+		}
+		page, err := c.Provenance(cmd.Context(), node.ID, provenanceLimit, provenanceOffset)
+		if err != nil {
+			return err
+		}
+		if provenanceJSON {
+			return writeProvenanceJSON(cmd, page)
+		}
+		return writeProvenance(cmd, page)
+	},
+}
+
+func writeProvenanceJSON(cmd *cobra.Command, page api.ProvenancePage) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(page); err != nil {
+		return fmt.Errorf("writing provenance JSON: %w", err)
+	}
+	return nil
+}
+
+func writeProvenance(cmd *cobra.Command, page api.ProvenancePage) error {
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "Node:\t%s\n", formatNodeSelector(page.Node.ID))
+	if page.Node.Path == "" {
+		_, _ = fmt.Fprintln(w, "State:\ttrashed")
+	} else {
+		_, _ = fmt.Fprintf(w, "Path:\t%s\n", strconv.Quote(page.Node.Path))
+	}
+	if page.Total == 0 {
+		_, _ = fmt.Fprintln(w, "Provenance:\tnone recorded")
+	} else if len(page.Items) == 0 {
+		_, _ = fmt.Fprintf(w, "Provenance:\tno facts at offset %d (%d total)\n",
+			page.Offset, page.Total)
+	} else {
+		for i, fact := range page.Items {
+			if i > 0 {
+				_, _ = fmt.Fprintln(w)
+			}
+			state := "superseded"
+			if fact.Active {
+				state = "active"
+			}
+			_, _ = fmt.Fprintf(w, "Provenance:\t%s\n", fact.Identity)
+			_, _ = fmt.Fprintf(w, "Status:\t%s\n", state)
+			_, _ = fmt.Fprintf(w, "Ingest:\t%s at %s\n", fact.IngestID, fact.IngestStartedAt)
+			_, _ = fmt.Fprintf(w, "Source:\t%s / %s\n",
+				strconv.Quote(fact.SourceKind), strconv.Quote(fact.SourceDescription))
+			_, _ = fmt.Fprintf(w, "Original path:\t%s\n", strconv.Quote(fact.OriginalPath))
+			if fact.OriginalMTime != nil {
+				_, _ = fmt.Fprintf(w, "Original modified:\t%s\n", *fact.OriginalMTime)
+			}
+			if fact.Supersedes != nil {
+				_, _ = fmt.Fprintf(w, "Supersedes:\t%s\n", *fact.Supersedes)
+			}
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("writing provenance: %w", err)
+	}
+	if page.Offset+len(page.Items) < page.Total {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"showing %d-%d of %d (use --offset to continue)\n",
+			page.Offset+1, page.Offset+len(page.Items), page.Total)
+	}
+	return nil
+}
+
+func init() {
+	provenanceCmd.Flags().IntVar(&provenanceLimit, "limit", 100,
+		"maximum provenance records to return (1-1000)")
+	provenanceCmd.Flags().IntVar(&provenanceOffset, "offset", 0,
+		"number of provenance records to skip")
+	provenanceCmd.Flags().BoolVar(&provenanceJSON, "json", false,
+		"emit machine-readable JSON")
+	rootCmd.AddCommand(provenanceCmd)
+}

--- a/cmd/docbank/provenance_test.go
+++ b/cmd/docbank/provenance_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestProvenanceCLIShowsHumanAndMachineAuthority(t *testing.T) {
+	_ = setupVaultHome(t)
+	source := writeSourceFile(t, "session.jsonl", `{"message":"synthetic"}`)
+	_, err := runCLI(t, "add", source, "--dest", "/archive")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "provenance", "/archive/session.jsonl")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Node:")
+	assert.Contains(t, out, `"/archive/session.jsonl"`)
+	assert.Contains(t, out, "Status:")
+	assert.Contains(t, out, "active")
+	assert.Contains(t, out, "Original path:")
+	assert.Contains(t, out, filepath.Base(source))
+
+	out, err = runCLI(t, "provenance", "/archive/session.jsonl", "--json")
+	require.NoError(t, err)
+	var page api.ProvenancePage
+	require.NoError(t, json.Unmarshal([]byte(out), &page))
+	assert.Equal(t, "/archive/session.jsonl", page.Node.Path)
+	assert.Equal(t, 1, page.Total)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, source, page.Items[0].OriginalPath)
+	assert.True(t, page.Items[0].Active)
+
+	out, err = runCLI(t, "provenance", "/archive/session.jsonl", "--offset", "10")
+	require.NoError(t, err)
+	assert.Contains(t, out, "no facts at offset 10 (1 total)")
+}
+
+func TestProvenanceCLIValidatesPaginationBeforeDaemonStartup(t *testing.T) {
+	t.Setenv("DOCBANK_HOME", t.TempDir())
+	_, err := runCLI(t, "provenance", "/document", "--limit", "0")
+	require.ErrorContains(t, err, "--limit must be between")
+	_, err = runCLI(t, "provenance", "/document", "--offset", "-1")
+	require.ErrorContains(t, err, "--offset must not be negative")
+}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -476,6 +476,29 @@ directory swaps without temporary names. Require a receipt for every request
 item, in the same order, and reconcile its stable node ID, prior path, final
 path, and resulting revision. Any error means the entire plan was rejected.
 
+## Inspect document provenance
+
+Use the stable node ID to retrieve the immutable facts describing where a file
+was ingested from:
+
+```bash
+curl --fail-with-body \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  "$DOCBANK_URL/api/v1/nodes/42/provenance?limit=100&offset=0"
+```
+
+Do not confuse `node.path`, Docbank's current virtual coordinate, with a fact's
+`original_path`, which names an external source as it was observed by the
+ingest. Branch on `active` when the workflow needs facts that have not been
+superseded, but retain fact identities: a correction adds a successor and keeps
+the superseded record addressable. Paginate using `total`, `limit`, and
+`offset`. A trashed file is
+still inspectable by stable ID and returns an empty live path.
+
+Provenance is evidence, not ownership of the external source. Reading it does
+not open or modify that source, and it does not make a content version a
+retention root.
+
 ## Create and ingest safely
 
 Create a directory under a known parent ID:

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -33,6 +33,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `PUT /nodes/{id}/content` | replace raw content under revision, size, and digest preconditions — see [addendum](#addendum-put-nodesidcontent) | Implemented |
 | `POST /nodes/{id}/revert` | create a new head from a prior version of the same file | Implemented |
 | `GET /nodes/{id}/versions` | list immutable content versions newest-first, paginated (`limit`/`offset`) | Implemented |
+| `GET /nodes/{id}/provenance` | inspect immutable ingest-origin facts newest-first, paginated (`limit`/`offset`) | Implemented |
 | `GET /versions/{version_id}` · `GET /versions/{version_id}/content` | inspect or stream one immutable version by stable UUID | Implemented |
 | `GET /content-references?sha256=&limit=&offset=` | find every stable node/version pair retaining a content hash | Implemented |
 | `GET\|POST /tags` · `GET /tags/by-name` · `GET\|PATCH\|DELETE /tags/{tag_id}` | list, resolve, create, rename, or delete stable tag definitions | Implemented |
@@ -213,6 +214,14 @@ body themselves and compare both their digest and the trailer with the node's
 metadata globally, and its `/content` child streams that version with the same
 identity headers and digest contract. A path rename cannot strand a retained
 version reference.
+
+`GET /nodes/{id}/provenance` returns the requested file node, its live path when
+one exists, and a bounded newest-ingest-first page from one read snapshot. Each
+fact carries its canonical SHA-256 identity, active/superseded state, ingest
+identity and time, source kind and description, original path and mtime, and an
+optional superseded-fact identity. A trashed node remains inspectable by ID but
+has no live `path`. The route is observation only: it neither accesses the
+source nor changes retention authority.
 
 `GET /content-references` is the inverse identity lookup. It accepts one
 canonical lowercase SHA-256 and returns only logical `content_versions`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -139,6 +139,25 @@ source arguments, just as it does for failures inside a directory tree.
 `--json` suppresses progress and returns the same terminal report shape as the
 HTTP JSON endpoint, so stdout remains safe for automation.
 
+## docbank provenance
+
+```
+docbank provenance <path-or-id> [--limit <n>] [--offset <n>] [--json]
+```
+
+Shows the immutable origin facts retained for one file, newest ingest first.
+Each result includes its SHA-256 identity, whether it is the active fact, the
+ingest UUID and time, source kind and description, original source path and
+modification time, and the identity it supersedes when applicable. The page is
+bounded to 1–1,000 facts; human output prints a continuation hint when more
+remain.
+
+Paths resolve live files. A stable `id:<node-id>` may also inspect a trashed
+file; in that case the response has no live virtual path and the human output
+labels it as trashed. `--json` returns the complete node, path, page authority,
+and fact objects. The command is read-only and does not access or alter the
+original source.
+
 ## docbank ls
 
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,6 +176,12 @@ in the failed state and records the reason. Restart the daemon after correcting
 the problem. Per-file successes are written to the daemon log. A configured
 watch keeps a background daemon alive regardless of `idle_timeout`.
 
+Inspect the durable source facts attached to an imported file with
+`docbank provenance <path-or-id>` or `GET /api/v1/nodes/{id}/provenance`.
+This is distinct from job status: provenance survives daemon restarts and
+records successful ingest authority, while `docbank jobs` describes only the
+current daemon run.
+
 Watched inboxes never modify or delete their source files. Configuration is
 machine-local and is not part of metadata-v1 backup/restore, while the stable
 watch name, relative path, stable node mapping, and last accepted content

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ elsewhere only when they materially explain the design and are marked
 | 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.11.0) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
-| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, provenance, watched inboxes, first-scope audit authority, and bounded plain-text extraction implemented; PDF/Office extraction remains |
+| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, first-scope audit authority, and bounded plain-text extraction implemented; PDF/Office extraction remains |
 | 3 | Primary kit-ui web portal and focused operator TUI | Designed |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
@@ -34,7 +34,7 @@ elsewhere only when they materially explain the design and are marked
   separate packed-space reclamation
 - `gc` (dry-run default) and `verify`
 - Inter-process vault locking (`flock` on Unix, `LockFileEx` on Windows)
-- CLI: `add`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`, `search`,
+- CLI: `add`, `provenance`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`, `search`,
   `trash`, `gc`, `verify`
 
 ## Phase 2a — Infrastructure (implemented)
@@ -120,7 +120,7 @@ and append later changes to the same stable node without touching source files.
 - Additional text extraction workers for PDF text layers and office formats;
   bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
 - External integration surface: generalized ingest provenance —
-  today's `provenance` table records the original filesystem path and
+  today's provenance API records and exposes the original filesystem path and
   mtime; `source_kind` / `source_ref` / `source_meta` fields extend it
   to non-file origins (a watched inbox, another application's archive)
   as generic fields, never application-specific tables. To settle before an

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -123,6 +123,28 @@ Two different files arriving at the same virtual name don't conflict —
 the newcomer is suffixed (`scan.pdf` → `scan (2).pdf`). The provenance
 record preserves where each one actually came from.
 
+## Inspect where a document came from
+
+Docbank keeps provenance as durable metadata rather than leaving it hidden in
+an import log. Query a live file by virtual path or any retained file by stable
+node ID:
+
+```bash
+docbank provenance /archive/Documents/report.pdf
+docbank provenance id:42 --json
+```
+
+The bounded newest-first result identifies the ingest, its source kind and
+description, the original source path and modification time, and the immutable
+SHA-256 identity of each provenance fact. `active` means no newer fact
+supersedes it; corrections retain earlier facts instead of rewriting them.
+Because a source path can disclose machine-local names, provenance is available
+only through the same authenticated API as the document itself.
+
+This is inspection, not source management. Reading provenance neither opens nor
+changes the original file, and provenance alone does not pin a document version
+against ordinary retention or deletion policy.
+
 ## Failures don't abort the batch
 
 Unreadable files, permission errors, and non-regular files (symlinks,
@@ -189,6 +211,9 @@ from the source independently of the node's current version, so an unchanged
 source does not overwrite a later edit or revert after daemon restart. Removing
 the source leaves the archived node alone. A renamed source-relative path is a
 new identity, not an implicit move.
+
+Use `docbank provenance <path-or-id>` to inspect the retained watch identity,
+source-relative path, and immutable supersession history for an imported node.
 
 The destination is exact rather than collision-suffixed. If unrelated content
 already occupies the intended path, or the previously mapped node is in the

--- a/internal/api/routes_provenance.go
+++ b/internal/api/routes_provenance.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type provenancePageOutput struct{ Body ProvenancePage }
+
+func registerProvenanceRoutes(api huma.API, d Deps) {
+	huma.Register(api, huma.Operation{
+		OperationID: "listNodeProvenance", Method: http.MethodGet,
+		Path:    "/api/v1/nodes/{id}/provenance",
+		Summary: "List immutable origin facts for one file node",
+		Description: "Returns newest-ingest-first provenance, including superseded facts. " +
+			"The node and its live path come from the same read snapshot; trashed nodes have no path.",
+	}, func(ctx context.Context, in *struct {
+		ID     int64 `path:"id" minimum:"1"`
+		Limit  int   `query:"limit" default:"100" minimum:"1" maximum:"1000"`
+		Offset int   `query:"offset" default:"0" minimum:"0"`
+	}) (*provenancePageOutput, error) {
+		page, err := d.Store.NodeProvenance(ctx, in.ID, in.Limit, in.Offset)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		out := &provenancePageOutput{Body: ProvenancePage{
+			Node: fromStoreNode(page.Node), Items: []ProvenanceFact{},
+			Total: page.Total, Limit: page.Limit, Offset: page.Offset,
+		}}
+		out.Body.Node.Path = page.Path
+		for _, fact := range page.Items {
+			out.Body.Items = append(out.Body.Items, fromStoreProvenanceFact(fact))
+		}
+		return out, nil
+	})
+}

--- a/internal/api/routes_provenance_test.go
+++ b/internal/api/routes_provenance_test.go
@@ -1,0 +1,63 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestNodeProvenanceEndpointReturnsOriginAuthority(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	run, err := s.BeginIngest(t.Context(), "watch", "agent-sessions")
+	require.NoError(t, err)
+	node, added, err := s.IngestFile(t.Context(), run, s.RootID(), "session.jsonl",
+		testHash("session"), 7, "application/x-ndjson", "closed/session.jsonl",
+		"2026-07-21T13:14:15Z")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	resp, body := get(t, ts, fmt.Sprintf("/api/v1/nodes/%d/provenance?limit=1&offset=0", node.ID), nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var page api.ProvenancePage
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+	assert.Equal(t, node.ID, page.Node.ID)
+	assert.Equal(t, "/session.jsonl", page.Node.Path)
+	assert.Equal(t, 1, page.Total)
+	assert.Equal(t, 1, page.Limit)
+	require.Len(t, page.Items, 1)
+	fact := page.Items[0]
+	assert.Equal(t, node.ID, fact.NodeID)
+	assert.Equal(t, run.ID(), fact.IngestID)
+	assert.Equal(t, "watch", fact.SourceKind)
+	assert.Equal(t, "agent-sessions", fact.SourceDescription)
+	assert.Equal(t, "closed/session.jsonl", fact.OriginalPath)
+	require.NotNil(t, fact.OriginalMTime)
+	assert.Equal(t, "2026-07-21T13:14:15Z", *fact.OriginalMTime)
+	assert.True(t, fact.Active)
+	assert.Nil(t, fact.Supersedes)
+}
+
+func TestNodeProvenanceEndpointMapsInvalidTargets(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	resp, body := get(t, ts, fmt.Sprintf("/api/v1/nodes/%d/provenance", s.RootID()), nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"not_file"`)
+
+	resp, body = get(t, ts, "/api/v1/nodes/99999/provenance", nil)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"not_found"`)
+
+	resp, body = get(t, ts, "/api/v1/nodes/0/provenance", nil)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"validation"`)
+
+	_, err := s.NodeProvenance(t.Context(), s.RootID(), 10, 0)
+	require.ErrorIs(t, err, store.ErrNotFile)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -115,6 +115,7 @@ func NewServer(d Deps) *Server {
 	registerContentWriteRoute(mux, humaAPI, d, g)
 	registerContentRevertRoute(humaAPI, d, g)
 	registerContentPruneRoute(humaAPI, d, g)
+	registerProvenanceRoutes(humaAPI, d)
 	registerTagRoutes(humaAPI, d, g)
 	registerAuditRoutes(humaAPI, d, g, s.auditPreviews)
 	clearLongRunningBodyReadDeadlines(humaAPI)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -91,6 +91,31 @@ type ContentVersionPage struct {
 	Offset int              `json:"offset"`
 }
 
+// ProvenanceFact is one immutable origin statement and the ingest operation
+// that introduced it. Superseded facts remain visible as history.
+type ProvenanceFact struct {
+	Identity          string  `json:"identity" pattern:"^[0-9a-f]{64}$"`
+	NodeID            int64   `json:"node_id" minimum:"1"`
+	IngestID          string  `json:"ingest_id" format:"uuid"`
+	IngestStartedAt   string  `json:"ingest_started_at"`
+	SourceKind        string  `json:"source_kind" minLength:"1"`
+	SourceDescription string  `json:"source_description" minLength:"1"`
+	OriginalPath      string  `json:"original_path" minLength:"1"`
+	OriginalMTime     *string `json:"original_mtime,omitempty"`
+	Supersedes        *string `json:"supersedes,omitempty" pattern:"^[0-9a-f]{64}$"`
+	Active            bool    `json:"active"`
+}
+
+// ProvenancePage binds a bounded origin history to one authoritative node
+// snapshot. Node.Path is empty when the stable node is in trash.
+type ProvenancePage struct {
+	Node   Node             `json:"node"`
+	Items  []ProvenanceFact `json:"items"`
+	Total  int              `json:"total" minimum:"0"`
+	Limit  int              `json:"limit" minimum:"1" maximum:"1000"`
+	Offset int              `json:"offset" minimum:"0"`
+}
+
 // VersionPruneRequest selects one explicit history-pruning policy. Exactly one
 // of VersionIDs, KeepNewest, OlderThan, or AllPrior must be set.
 type VersionPruneRequest struct {
@@ -775,6 +800,15 @@ func fromStoreContentVersion(v store.ContentVersion) ContentVersion {
 		MimeType: v.MimeType, RecordedAt: v.RecordedAt, NodeRevision: v.NodeRevision,
 		IntroducedOperationID: v.IntroducedOperationID,
 		TransitionKind:        v.TransitionKind, SourceVersionID: v.SourceVersionID,
+	}
+}
+
+func fromStoreProvenanceFact(fact store.ProvenanceFact) ProvenanceFact {
+	return ProvenanceFact{
+		Identity: fact.Identity, NodeID: fact.NodeID, IngestID: fact.IngestID,
+		IngestStartedAt: fact.IngestStartedAt, SourceKind: fact.SourceKind,
+		SourceDescription: fact.SourceDescription, OriginalPath: fact.OriginalPath,
+		OriginalMTime: fact.OriginalMTime, Supersedes: fact.Supersedes, Active: fact.Active,
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -349,6 +349,31 @@ func (c *Client) Versions(
 	return page, err
 }
 
+// Provenance returns one bounded newest-ingest-first page of immutable origin
+// facts for a stable file node.
+func (c *Client) Provenance(
+	ctx context.Context, nodeID int64, limit, offset int,
+) (api.ProvenancePage, error) {
+	var page api.ProvenancePage
+	if nodeID < 1 {
+		return page, errors.New("provenance node ID must be positive")
+	}
+	if limit < 1 || limit > store.MaxProvenancePageSize {
+		return page, fmt.Errorf("provenance limit must be between 1 and %d", store.MaxProvenancePageSize)
+	}
+	if offset < 0 {
+		return page, errors.New("provenance offset must not be negative")
+	}
+	path := fmt.Sprintf("/api/v1/nodes/%d/provenance?limit=%d&offset=%d", nodeID, limit, offset)
+	if err := c.do(ctx, http.MethodGet, path, nil, nil, &page); err != nil {
+		return api.ProvenancePage{}, err
+	}
+	if err := validateProvenancePage(page, nodeID, limit, offset); err != nil {
+		return api.ProvenancePage{}, err
+	}
+	return page, nil
+}
+
 // Version returns immutable version metadata by stable ID.
 func (c *Client) Version(ctx context.Context, id string) (api.ContentVersion, error) {
 	var version api.ContentVersion
@@ -1674,6 +1699,48 @@ func validateTaggedNodePage(page api.TaggedNodePage, limit, offset int) error {
 			return fmt.Errorf("tagged-node response item %d has inconsistent path state", i)
 		}
 		previous = item.Node.ID
+	}
+	return nil
+}
+
+func validateProvenancePage(page api.ProvenancePage, nodeID int64, limit, offset int) error {
+	if page.Node.ID != nodeID || page.Node.Kind != "file" || page.Node.Revision < 1 ||
+		(page.Node.TrashedAt == "" && !strings.HasPrefix(page.Node.Path, "/")) ||
+		(page.Node.TrashedAt != "" && page.Node.Path != "") {
+		return errors.New("provenance response has inconsistent node authority")
+	}
+	if limit < 1 || limit > store.MaxProvenancePageSize || offset < 0 ||
+		page.Limit != limit || page.Offset != offset || page.Total < 0 || len(page.Items) > limit ||
+		(len(page.Items) == 0 && offset < page.Total) ||
+		(len(page.Items) > 0 && offset+len(page.Items) > page.Total) {
+		return errors.New("provenance response has inconsistent pagination")
+	}
+	seen := make(map[string]struct{}, len(page.Items))
+	for i, fact := range page.Items {
+		startedAt, startedErr := time.Parse(time.RFC3339Nano, fact.IngestStartedAt)
+		mtimeValid := true
+		if fact.OriginalMTime != nil {
+			parsed, err := time.Parse(time.RFC3339Nano, *fact.OriginalMTime)
+			mtimeValid = err == nil && parsed.Location() == time.UTC
+		}
+		if !validSHA256Hex(fact.Identity) || fact.NodeID != nodeID ||
+			!validUUIDv4(fact.IngestID) || startedErr != nil || startedAt.Location() != time.UTC ||
+			fact.SourceKind == "" || fact.SourceDescription == "" || fact.OriginalPath == "" ||
+			!mtimeValid || (fact.Supersedes != nil && !validSHA256Hex(*fact.Supersedes)) {
+			return fmt.Errorf("provenance response item %d has invalid authority", i)
+		}
+		if _, duplicate := seen[fact.Identity]; duplicate {
+			return fmt.Errorf("provenance response repeats identity %s", fact.Identity)
+		}
+		seen[fact.Identity] = struct{}{}
+		if i > 0 {
+			prior := page.Items[i-1]
+			priorTime, _ := time.Parse(time.RFC3339Nano, prior.IngestStartedAt)
+			if priorTime.Before(startedAt) ||
+				(priorTime.Equal(startedAt) && prior.Identity <= fact.Identity) {
+				return errors.New("provenance response is not newest-ingest-first")
+			}
+		}
 	}
 	return nil
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -104,6 +104,47 @@ func TestRoundTrip(t *testing.T) {
 	assert.Equal(t, "/filed", restored.Path)
 }
 
+func TestProvenanceReturnsStableOriginAuthority(t *testing.T) {
+	c, s := newClient(t, serverKey)
+	run, err := s.BeginIngest(t.Context(), "watch", "agent-sessions")
+	require.NoError(t, err)
+	node, added, err := s.IngestFile(t.Context(), run, s.RootID(), "session.jsonl",
+		strings.Repeat("a", 64), 7, "application/x-ndjson", "closed/session.jsonl",
+		"2026-07-21T13:14:15Z")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	page, err := c.Provenance(t.Context(), node.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, node.ID, page.Node.ID)
+	assert.Equal(t, "/session.jsonl", page.Node.Path)
+	assert.Equal(t, 1, page.Total)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, run.ID(), page.Items[0].IngestID)
+	assert.Equal(t, "watch", page.Items[0].SourceKind)
+	assert.Equal(t, "agent-sessions", page.Items[0].SourceDescription)
+	assert.True(t, page.Items[0].Active)
+}
+
+func TestProvenanceRejectsMalformedAuthority(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProvenancePage{
+			Node: api.Node{ID: 42, Kind: "file", Revision: 1, Path: "/session.jsonl"},
+			Items: []api.ProvenanceFact{{
+				Identity: "not-a-digest", NodeID: 42,
+				IngestID:        "11111111-1111-4111-8111-111111111111",
+				IngestStartedAt: "2026-07-21T13:14:15Z", SourceKind: "watch",
+				SourceDescription: "agent-sessions", OriginalPath: "closed/session.jsonl",
+			}},
+			Total: 1, Limit: 10, Offset: 0,
+		})
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := client.New(ts.URL, "key").Provenance(t.Context(), 42, 10, 0)
+	require.ErrorContains(t, err, "invalid authority")
+}
+
 func TestSearchWithOptionsUsesStableTagIdentity(t *testing.T) {
 	c, s := newClient(t, serverKey)
 	ctx := t.Context()

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "31"
+	daemonProtocolVersion = "32"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/provenance_public.go
+++ b/internal/store/provenance_public.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+const MaxProvenancePageSize = 1000
+
+// ProvenanceFact is one immutable statement about where a document entered
+// Docbank. A newer fact may supersede an older fact without rewriting it.
+type ProvenanceFact struct {
+	Identity          string
+	NodeID            int64
+	IngestID          string
+	IngestStartedAt   string
+	SourceKind        string
+	SourceDescription string
+	OriginalPath      string
+	OriginalMTime     *string
+	Supersedes        *string
+	Active            bool
+}
+
+// NodeProvenancePage is one transactionally consistent document and bounded
+// page of its newest-ingest-first provenance facts. Path is empty for trash.
+type NodeProvenancePage struct {
+	Node   Node
+	Path   string
+	Items  []ProvenanceFact
+	Total  int
+	Limit  int
+	Offset int
+}
+
+// NodeProvenance returns immutable origin facts for one file node. The node,
+// live path, count, and page come from one read snapshot so the response cannot
+// combine provenance with a later move or trash operation.
+func (s *Store) NodeProvenance(
+	ctx context.Context, nodeID int64, limit, offset int,
+) (NodeProvenancePage, error) {
+	if limit < 1 || limit > MaxProvenancePageSize {
+		return NodeProvenancePage{}, fmt.Errorf(
+			"provenance limit must be between 1 and %d", MaxProvenancePageSize,
+		)
+	}
+	if offset < 0 {
+		return NodeProvenancePage{}, errors.New("provenance offset must not be negative")
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return NodeProvenancePage{}, fmt.Errorf("starting provenance snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	page := NodeProvenancePage{Items: []ProvenanceFact{}, Limit: limit, Offset: offset}
+	page.Node, err = nodeByIDTx(tx, nodeID)
+	if err != nil {
+		return NodeProvenancePage{}, err
+	}
+	if page.Node.IsDir() {
+		return NodeProvenancePage{}, fmt.Errorf("node %d: %w", nodeID, ErrNotFile)
+	}
+	if page.Node.TrashedAt == nil {
+		page.Path, err = pathOf(ctx, tx, nodeID)
+		if err != nil {
+			return NodeProvenancePage{}, err
+		}
+	}
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM provenance WHERE node_id = ?`, nodeID,
+	).Scan(&page.Total); err != nil {
+		return NodeProvenancePage{}, fmt.Errorf("counting provenance for node %d: %w", nodeID, err)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT p.identity, p.node_id, p.ingest_id, i.started_at,
+		       i.source_kind, i.source_desc, p.original_path,
+		       p.original_mtime, p.supersedes,
+		       NOT EXISTS(SELECT 1 FROM provenance next WHERE next.supersedes = p.identity)
+		FROM provenance p JOIN ingests i ON i.id = p.ingest_id
+		WHERE p.node_id = ?
+		ORDER BY i.started_at DESC, p.identity DESC
+		LIMIT ? OFFSET ?`, nodeID, limit, offset)
+	if err != nil {
+		return NodeProvenancePage{}, fmt.Errorf("listing provenance for node %d: %w", nodeID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var fact ProvenanceFact
+		var originalMTime, supersedes sql.NullString
+		if err := rows.Scan(
+			&fact.Identity, &fact.NodeID, &fact.IngestID, &fact.IngestStartedAt,
+			&fact.SourceKind, &fact.SourceDescription, &fact.OriginalPath,
+			&originalMTime, &supersedes, &fact.Active,
+		); err != nil {
+			return NodeProvenancePage{}, fmt.Errorf("scanning provenance for node %d: %w", nodeID, err)
+		}
+		fact.OriginalMTime = stringPtr(originalMTime)
+		fact.Supersedes = stringPtr(supersedes)
+		page.Items = append(page.Items, fact)
+	}
+	if err := rows.Err(); err != nil {
+		return NodeProvenancePage{}, fmt.Errorf("listing provenance for node %d: %w", nodeID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return NodeProvenancePage{}, fmt.Errorf("closing provenance snapshot: %w", err)
+	}
+	return page, nil
+}

--- a/internal/store/provenance_public_test.go
+++ b/internal/store/provenance_public_test.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeProvenanceReturnsStableBoundedHistory(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	ingest, err := s.BeginIngest(ctx, "cli", "/synthetic/import")
+	require.NoError(t, err)
+	node, added, err := s.IngestFile(ctx, ingest, s.RootID(), "report.txt",
+		fakeHash("origin"), 6, "text/plain", "/synthetic/report.txt", "2026-01-02T03:04:05Z")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	var originalIdentity string
+	require.NoError(t, s.db.QueryRowContext(ctx,
+		`SELECT identity FROM provenance WHERE node_id=?`, node.ID,
+	).Scan(&originalIdentity))
+	successorIngest, err := newUUIDv4()
+	require.NoError(t, err)
+	successorMTime := "2026-07-01T12:00:00.000000000Z"
+	successor := metadataProvenance{
+		Type: metadataProvenanceType, NodeID: node.ID, IngestID: successorIngest,
+		OriginalPath: "/corrected/report.txt", OriginalMTime: &successorMTime,
+		Supersedes: &originalIdentity,
+	}
+	successor.Identity, err = provenanceIdentity(successor)
+	require.NoError(t, err)
+	require.NoError(t, s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO ingests(id,started_at,source_kind,source_desc)
+			VALUES(?,?,?,?)`, successorIngest, "2099-01-01T00:00:00.000000000Z",
+			"watch", "agent-sessions"); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO provenance(
+			identity,node_id,ingest_id,original_path,original_mtime,supersedes)
+			VALUES(?,?,?,?,?,?)`, successor.Identity, successor.NodeID, successor.IngestID,
+			successor.OriginalPath, successor.OriginalMTime, successor.Supersedes)
+		return err
+	}))
+
+	page, err := s.NodeProvenance(ctx, node.ID, 1, 0)
+	require.NoError(t, err)
+	assert.Equal(t, node.ID, page.Node.ID)
+	assert.Equal(t, "/report.txt", page.Path)
+	assert.Equal(t, 2, page.Total)
+	assert.Equal(t, 1, page.Limit)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, successor.Identity, page.Items[0].Identity)
+	assert.Equal(t, "watch", page.Items[0].SourceKind)
+	assert.Equal(t, "agent-sessions", page.Items[0].SourceDescription)
+	assert.True(t, page.Items[0].Active)
+	assert.Equal(t, &originalIdentity, page.Items[0].Supersedes)
+
+	older, err := s.NodeProvenance(ctx, node.ID, 1, 1)
+	require.NoError(t, err)
+	require.Len(t, older.Items, 1)
+	assert.Equal(t, originalIdentity, older.Items[0].Identity)
+	assert.False(t, older.Items[0].Active)
+
+	trashed, _, err := s.Trash(ctx, node.ID, node.Revision)
+	require.NoError(t, err)
+	page, err = s.NodeProvenance(ctx, trashed.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Empty(t, page.Path)
+	assert.NotNil(t, page.Node.TrashedAt)
+}
+
+func TestNodeProvenanceRejectsDirectoriesAndInvalidPages(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.NodeProvenance(t.Context(), s.RootID(), 10, 0)
+	require.ErrorIs(t, err, ErrNotFile)
+	_, err = s.NodeProvenance(t.Context(), 99999, 10, 0)
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.NodeProvenance(t.Context(), s.RootID(), 0, 0)
+	require.ErrorContains(t, err, "limit")
+	_, err = s.NodeProvenance(t.Context(), s.RootID(), 10, -1)
+	require.ErrorContains(t, err, "offset")
+}


### PR DESCRIPTION
Docbank already records where an imported document came from, but until now that evidence was buried inside the database. A person or agent could retrieve the bytes and history while still being unable to answer a basic question: “what source produced this document?”

This adds the ordinary workflow:

```
docbank provenance /archive/Documents/report.pdf
docbank provenance id:42 --json
```

The bounded newest-first result shows each immutable provenance identity, whether it has been superseded, the ingest identity and time, the source kind and description, and the original source path and modification time. The same projection is available through the authenticated HTTP API and typed Go client. Stable IDs can inspect trashed files even though those files no longer have a live virtual path.

The node, live path, total, and selected page come from one read snapshot. A concurrent move or trash operation therefore cannot produce a receipt that combines two different moments. Machine-local source paths may contain sensitive names, so they remain behind the vault’s existing authenticated interface and human output quotes them safely.

This is deliberately inspection only. It does not reopen or modify the source, correct provenance, or turn provenance into a retention pin. Those are separate policy decisions. The daemon protocol advances so a new CLI replaces an older daemon that does not expose this contract.