### PR TITLE
Create virtual directories from the CLI

### DIFF
--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "32", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "33", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "32", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "33", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "32", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "33", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/mkdir.go
+++ b/cmd/docbank/mkdir.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/store"
+)
+
+var mkdirJSON bool
+
+var mkdirCmd = &cobra.Command{
+	Use:   "mkdir <absolute-virtual-path>",
+	Short: "Create a directory in the virtual tree",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateMkdirPathArgument(args[0]); err != nil {
+			return err
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		node, err := c.MkdirPath(cmd.Context(), args[0])
+		if err != nil {
+			return err
+		}
+		if mkdirJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), node)
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "created %s %s\n",
+			formatNodeSelector(node.ID), strconv.Quote(node.Path))
+		if err != nil {
+			return fmt.Errorf("writing created directory: %w", err)
+		}
+		return nil
+	},
+}
+
+func validateMkdirPathArgument(path string) error {
+	if !utf8.ValidString(path) {
+		return usageError(errors.New("directory path is not valid UTF-8"))
+	}
+	if !strings.HasPrefix(path, "/") {
+		return usageError(errors.New("directory path must be absolute (start with /)"))
+	}
+	segments := 0
+	for segment := range strings.SplitSeq(path, "/") {
+		if segment == "" {
+			continue
+		}
+		segments++
+		if _, err := store.NormalizeName(segment); err != nil {
+			return usageError(fmt.Errorf("directory path %q: %w", path, err))
+		}
+	}
+	if segments == 0 {
+		return usageError(errors.New("directory path must not be the vault root"))
+	}
+	return nil
+}
+
+func init() {
+	mkdirCmd.Flags().BoolVar(&mkdirJSON, "json", false, "emit machine-readable JSON")
+	rootCmd.AddCommand(mkdirCmd)
+}

--- a/cmd/docbank/mkdir_test.go
+++ b/cmd/docbank/mkdir_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestMkdirCLICreatesExactDirectory(t *testing.T) {
+	_ = setupVaultHome(t)
+
+	out, err := runCLI(t, "mkdir", "/Projects")
+	require.NoError(t, err)
+	assert.Contains(t, out, "created id:")
+	assert.Contains(t, out, `"/Projects"`)
+
+	out, err = runCLI(t, "mkdir", "/Projects/2026/", "--json")
+	require.NoError(t, err)
+	var node api.Node
+	require.NoError(t, json.Unmarshal([]byte(out), &node))
+	assert.Equal(t, "/Projects/2026", node.Path)
+	assert.Equal(t, "2026", node.Name)
+	assert.Equal(t, "dir", node.Kind)
+
+	_, err = runCLI(t, "mkdir", "/Projects/2026")
+	require.ErrorContains(t, err, "name already exists")
+	_, err = runCLI(t, "mkdir", "/Missing/Child")
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestMkdirCLIValidatesPathBeforeDaemonStartup(t *testing.T) {
+	t.Setenv("DOCBANK_HOME", t.TempDir())
+	for _, path := range []string{"relative", "/", "/valid/../invalid"} {
+		_, err := runCLI(t, "mkdir", path)
+		require.Error(t, err, path)
+	}
+}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -501,7 +501,20 @@ retention root.
 
 ## Create and ingest safely
 
-Create a directory under a known parent ID:
+For a one-shot instruction tied to an exact virtual coordinate, create the
+directory by path. Its parent must already exist:
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{"path":"/receipts/2026"}' \
+  "$DOCBANK_URL/api/v1/path/mkdir"
+```
+
+The parent resolves inside the mutation transaction. When the workflow has
+already selected a particular stable parent identity, create beneath that ID
+instead so a concurrent parent move does not change the intended owner:
 
 ```bash
 curl --fail-with-body -X POST \

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -44,7 +44,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /audit/verify` | independently replay audit authority, optionally prove recorded evidence is an exact prefix, and re-hash every protected blob | Implemented |
 | `POST /nodes/{id}/verify` | re-hash one file, bound to an inspected node revision | Implemented |
 | `GET /search?q=&tag_id=&mime_type=&under_node_id=&modified_since=&modified_before=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity, current base media type, descendants of a live directory, and current node modification time, with match source and explicit `truncated` status | Implemented |
-| `POST /nodes` | create a directory (`kind: "dir"`) | Implemented |
+| `POST /nodes` · `POST /path/mkdir` | create a directory beneath a stable parent ID or at one exact virtual coordinate | Implemented |
 | `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |
 | `PATCH /nodes/{id}` | move and/or rename, including resolving an absolute `dest_path` transactionally | Implemented |
@@ -73,6 +73,14 @@ For stable-identity moves, `PATCH /nodes/{id}` accepts either the lower-level
 mutually exclusive. The latter resolves POSIX-style destination semantics and
 checks `If-Match` in the same transaction. `POST /path/move` remains the
 coordinate-oriented form when the source path itself is the intended target.
+
+Directory creation has the same identity-versus-coordinate choice.
+`POST /nodes` accepts a previously resolved `parent_id`, so a concurrent parent
+move does not change which directory receives the child. `POST /path/mkdir`
+accepts `{"path":"/projects/2026"}` and resolves the existing parent inside
+the creation transaction, so the exact coordinate cannot be redirected between
+separate client requests. Both return the new node and its canonical path from
+that transaction; neither creates missing ancestors.
 
 `POST /batch/move` accepts `{moves:[...]}`. Each item selects its source with
 either `source_path`, or `node_id` plus the revision previously inspected by
@@ -178,6 +186,7 @@ and maintenance are explicit exceptions:
 | `POST /path/move`, `POST /path/trash` | none — the path is resolved and mutated inside one store transaction, so there is no separate read for a revision to guard |
 | `POST /batch/move` | each path source resolves in the transaction; each stable-ID source carries its own required revision |
 | `POST /nodes` (create dir) | none — creation has no prior revision; a name collision is `409` |
+| `POST /path/mkdir` | none — the exact parent coordinate resolves inside the creation transaction; a name collision is `409` |
 | `POST /ingest` · `POST /ingest/stream` | none — long-running bulk operations with per-path partial success; the destination directory may legitimately change while they run |
 | `POST /uploads` | none — creates or idempotently resolves one file under the stable `parent_id`; name/content collision policy is transactional |
 | `POST /trash/empty`, `POST /gc`, `POST /verify` | none — vault-wide maintenance, serialized by the maintenance gate |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -158,6 +158,22 @@ labels it as trashed. `--json` returns the complete node, path, page authority,
 and fact objects. The command is read-only and does not access or alter the
 original source.
 
+## docbank mkdir
+
+```
+docbank mkdir <absolute-virtual-path> [--json]
+```
+
+Creates one directory at the exact virtual coordinate and prints its stable
+`id:N` selector plus quoted canonical path. The parent directory must already
+exist; this command does not recursively invent missing parents. Existing
+names, `/`, relative paths, files used as parents, and `.` or `..` path
+segments are rejected without creating anything.
+
+The daemon resolves the parent and creates the directory in one transaction,
+so a concurrent ancestor move cannot redirect a path-based request. `--json`
+returns the complete authoritative directory node.
+
 ## docbank ls
 
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ elsewhere only when they materially explain the design and are marked
   separate packed-space reclamation
 - `gc` (dry-run default) and `verify`
 - Inter-process vault locking (`flock` on Unix, `LockFileEx` on Windows)
-- CLI: `add`, `provenance`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`, `search`,
+- CLI: `add`, `provenance`, `mkdir`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`, `search`,
   `trash`, `gc`, `verify`
 
 ## Phase 2a — Infrastructure (implemented)

--- a/internal/api/routes_mutate.go
+++ b/internal/api/routes_mutate.go
@@ -55,12 +55,12 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 		}
 		var out *nodeOutput
 		err := g.mutate(func() error {
-			n, err := d.Store.Mkdir(ctx, in.Body.ParentID, in.Body.Name)
+			n, path, err := d.Store.MkdirWithPath(ctx, in.Body.ParentID, in.Body.Name)
 			if err != nil {
 				return FromStoreError(err)
 			}
-			out, err = nodeWithPath(ctx, d, n.ID)
-			return err
+			out = nodeOutputAt(n, path)
+			return nil
 		})
 		return out, err
 	})
@@ -121,6 +121,33 @@ func registerMutateRoutes(api huma.API, d Deps, g *gate) {
 				return FromStoreError(fmt.Errorf("node %d: %w", in.ID, store.ErrIsRoot))
 			}
 			n, path, err := d.Store.Move(ctx, in.ID, *parent, name, rev)
+			if err != nil {
+				return FromStoreError(err)
+			}
+			out = nodeOutputAt(n, path)
+			return nil
+		})
+		return out, err
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "mkdirPath", Method: http.MethodPost, Path: "/api/v1/path/mkdir",
+		Summary:       "Create one directory at an exact virtual path",
+		DefaultStatus: http.StatusCreated,
+		Description: "The parent path is resolved and the directory is created in one transaction, " +
+			"so a concurrent ancestor move cannot redirect the new directory. The parent must exist.",
+	}, func(ctx context.Context, in *struct {
+		Body struct {
+			Path string `json:"path" minLength:"1" example:"/projects/2026"`
+		}
+	}) (*nodeOutput, error) {
+		if !strings.HasPrefix(in.Body.Path, "/") {
+			return nil, NewError(http.StatusUnprocessableEntity, "validation",
+				fmt.Sprintf("path %q must be absolute (start with /)", in.Body.Path))
+		}
+		var out *nodeOutput
+		err := g.mutate(func() error {
+			n, path, err := d.Store.MkdirPath(ctx, in.Body.Path)
 			if err != nil {
 				return FromStoreError(err)
 			}

--- a/internal/api/routes_mutate_test.go
+++ b/internal/api/routes_mutate_test.go
@@ -38,6 +38,32 @@ func TestCreateDirectory(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 }
 
+func TestCreateDirectoryByExactPath(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	parent, err := s.Mkdir(t.Context(), s.RootID(), "projects")
+	require.NoError(t, err)
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/path/mkdir", nil,
+		map[string]any{"path": "/projects/2026/"})
+	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	var node api.Node
+	require.NoError(t, json.Unmarshal([]byte(body), &node))
+	assert.Equal(t, "/projects/2026", node.Path)
+	assert.Equal(t, "2026", node.Name)
+	assert.Equal(t, parent.ID, *node.ParentID)
+	assert.Equal(t, `"1"`, resp.Header.Get("ETag"))
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/path/mkdir", nil,
+		map[string]any{"path": "relative"})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"validation"`)
+
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/path/mkdir", nil,
+		map[string]any{"path": "/missing/child"})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"not_found"`)
+}
+
 func TestMoveRequiresIfMatch(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	_, err := s.Mkdir(t.Context(), s.RootID(), "docs")

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1772,6 +1772,57 @@ func (c *Client) Mkdir(ctx context.Context, parentID int64, name string) (api.No
 	return n, err
 }
 
+// MkdirPath creates one directory at an exact absolute virtual coordinate.
+// The daemon resolves the existing parent and performs the creation in one
+// transaction.
+func (c *Client) MkdirPath(ctx context.Context, path string) (api.Node, error) {
+	canonical, err := canonicalDirectoryPath(path)
+	if err != nil {
+		return api.Node{}, err
+	}
+	var node api.Node
+	headers, err := c.doWithHeaders(ctx, http.MethodPost, "/api/v1/path/mkdir", nil,
+		map[string]string{"path": path}, &node)
+	if err != nil {
+		return api.Node{}, err
+	}
+	expectedName := canonical[strings.LastIndex(canonical, "/")+1:]
+	if node.ID < 1 || node.ParentID == nil || node.Kind != "dir" || node.Name == "" ||
+		node.Name != expectedName || node.Path != canonical || node.Revision != 1 || node.TrashedAt != "" ||
+		node.CurrentVersionID != "" || node.BlobHash != "" || node.Size != 0 || node.MimeType != "" {
+		return api.Node{}, errors.New("mkdir response has inconsistent directory authority")
+	}
+	wantETag := fmt.Sprintf("%q", strconv.FormatInt(node.Revision, 10))
+	if headers.Get("ETag") != wantETag {
+		return api.Node{}, fmt.Errorf("mkdir response ETag %q, expected %q", headers.Get("ETag"), wantETag)
+	}
+	return node, nil
+}
+
+func canonicalDirectoryPath(path string) (string, error) {
+	if !utf8.ValidString(path) {
+		return "", errors.New("directory path is not valid UTF-8")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "", errors.New("directory path must be absolute")
+	}
+	segments := make([]string, 0)
+	for segment := range strings.SplitSeq(path, "/") {
+		if segment == "" {
+			continue
+		}
+		normalized, err := store.NormalizeName(segment)
+		if err != nil {
+			return "", fmt.Errorf("directory path %q: %w", path, err)
+		}
+		segments = append(segments, normalized)
+	}
+	if len(segments) == 0 {
+		return "", errors.New("directory path must not be the vault root")
+	}
+	return "/" + strings.Join(segments, "/"), nil
+}
+
 func (c *Client) Ingest(ctx context.Context, paths []string, dest string) (api.IngestReport, error) {
 	return c.IngestWithOptions(ctx, paths, dest, nil)
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -76,6 +76,10 @@ func TestRoundTrip(t *testing.T) {
 	dir, err := c.Mkdir(ctx, s.RootID(), "docs")
 	require.NoError(t, err)
 	assert.Equal(t, "/docs", dir.Path)
+	createdByPath, err := c.MkdirPath(ctx, "/docs/2026/")
+	require.NoError(t, err)
+	assert.Equal(t, "/docs/2026", createdByPath.Path)
+	assert.Equal(t, dir.ID, *createdByPath.ParentID)
 
 	got, err := c.Stat(ctx, "/docs")
 	require.NoError(t, err)
@@ -475,6 +479,10 @@ func TestJSONMethodsRejectInvalidUTF8BeforeRequest(t *testing.T) {
 			_, err := c.Mkdir(t.Context(), 1, invalidPath)
 			return err
 		}},
+		{name: "mkdir path", call: func() error {
+			_, err := c.MkdirPath(t.Context(), invalidPath)
+			return err
+		}},
 		{name: "move name", call: func() error {
 			_, err := c.Move(t.Context(), 2, 1, nil, &invalidPath)
 			return err
@@ -500,6 +508,32 @@ func TestJSONMethodsRejectInvalidUTF8BeforeRequest(t *testing.T) {
 			assert.Equal(t, before, requests.Load(), "invalid text must not reach JSON or HTTP")
 		})
 	}
+}
+
+func TestMkdirPathValidatesRequestAndReceipt(t *testing.T) {
+	var requests atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", `"1"`)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(api.Node{
+			ID: 9, ParentID: new(int64(1)), Name: "other", Kind: "dir",
+			Revision: 1, Path: "/wrong",
+		})
+	}))
+	t.Cleanup(ts.Close)
+	c := client.New(ts.URL, "key")
+
+	_, err := c.MkdirPath(t.Context(), "relative")
+	require.ErrorContains(t, err, "must be absolute")
+	_, err = c.MkdirPath(t.Context(), "/")
+	require.ErrorContains(t, err, "must not be the vault root")
+	assert.Zero(t, requests.Load())
+
+	_, err = c.MkdirPath(t.Context(), "/expected")
+	require.ErrorContains(t, err, "inconsistent directory authority")
+	assert.Equal(t, int64(1), requests.Load())
 }
 
 func TestBackupCreateStreamRoundTripAndTypedError(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "32"
+	daemonProtocolVersion = "33"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/audit_node_create_test.go
+++ b/internal/store/audit_node_create_test.go
@@ -69,6 +69,27 @@ func TestAuditedNodeCreationInheritsMembershipAndRoundTrips(t *testing.T) {
 	assert.Equal(t, file.CurrentVersionID, restoredFile.CurrentVersionID)
 }
 
+func TestAuditedMkdirPathRecordsInheritedCreation(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+
+	created, path, err := s.MkdirPath(t.Context(), "/Projects/2027")
+	require.NoError(t, err)
+	assert.Equal(t, "/Projects/2027", path)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	var scopeID string
+	require.NoError(t, s.db.QueryRow(
+		`SELECT scope_id FROM audit_memberships WHERE node_id=?`, created.ID,
+	).Scan(&scopeID))
+	assert.Equal(t, testAuditScopeID, scopeID)
+}
+
 func TestAuditedNodeCreationImportRejectsMembershipRetarget(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
 	require.NoError(t, err)

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -59,6 +59,45 @@ func TestMkdirRejectsCollisionAndBadNames(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidName)
 }
 
+func TestMkdirPathCreatesOneExactDirectory(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	projects, err := s.Mkdir(ctx, s.RootID(), "Projects")
+	require.NoError(t, err)
+	created, path, err := s.MkdirPath(ctx, "/Projects/Reports/")
+	require.NoError(t, err)
+	assert.Equal(t, "/Projects/Reports", path)
+	assert.Equal(t, "Reports", created.Name)
+	assert.Equal(t, projects.ID, *created.ParentID)
+
+	resolved, err := s.NodeByPath(ctx, path)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, resolved.ID)
+
+	_, _, err = s.MkdirPath(ctx, "/Projects/Reports")
+	require.ErrorIs(t, err, ErrExists)
+	_, _, err = s.MkdirPath(ctx, "/Missing/Reports")
+	require.ErrorIs(t, err, ErrNotFound)
+	_, _, err = s.MkdirPath(ctx, "/")
+	require.ErrorIs(t, err, ErrExists)
+	_, _, err = s.MkdirPath(ctx, "Projects/Relative")
+	require.ErrorIs(t, err, ErrInvalidName)
+	_, _, err = s.MkdirPath(ctx, "/Projects/../Reports")
+	require.ErrorIs(t, err, ErrInvalidName)
+}
+
+func TestMkdirPathRejectsFileParent(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.CreateFile(
+		t.Context(), s.RootID(), "document.txt", fakeHash("mkdir-parent"), 1, "text/plain",
+	)
+	require.NoError(t, err)
+
+	_, _, err = s.MkdirPath(t.Context(), "/document.txt/child")
+	require.ErrorIs(t, err, ErrNotDir)
+}
+
 func TestMkdirBumpsParentRevision(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -42,45 +42,110 @@ func liveDirTx(tx *sql.Tx, id int64) (Node, error) {
 
 // Mkdir creates a directory under parentID.
 func (s *Store) Mkdir(ctx context.Context, parentID int64, name string) (Node, error) {
+	created, _, err := s.MkdirWithPath(ctx, parentID, name)
+	return created, err
+}
+
+// MkdirWithPath creates a directory under a stable parent identity and returns
+// the new node's canonical path from the same mutation transaction.
+func (s *Store) MkdirWithPath(
+	ctx context.Context, parentID int64, name string,
+) (Node, string, error) {
 	name, err := NormalizeName(name)
+	if err != nil {
+		return Node{}, "", err
+	}
+	var created Node
+	var createdPath string
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		created, err = s.mkdirNodeTx(ctx, tx, parentID, name)
+		if err != nil {
+			return err
+		}
+		createdPath, err = pathOf(ctx, tx, created.ID)
+		return err
+	})
+	if err != nil {
+		return Node{}, "", err
+	}
+	return created, createdPath, nil
+}
+
+// MkdirPath resolves the parent and creates one directory in the same
+// transaction. This is the path-coordinate form for callers whose intent is
+// tied to an exact virtual location rather than a previously resolved parent
+// identity.
+func (s *Store) MkdirPath(ctx context.Context, path string) (Node, string, error) {
+	if !strings.HasPrefix(path, "/") {
+		return Node{}, "", fmt.Errorf("directory path must be absolute: %w", ErrInvalidName)
+	}
+	segments := splitPath(path)
+	for index, segment := range segments {
+		normalized, err := NormalizeName(segment)
+		if err != nil {
+			return Node{}, "", fmt.Errorf("directory path %q: %w", path, err)
+		}
+		segments[index] = normalized
+	}
+	if len(segments) == 0 {
+		return Node{}, "", fmt.Errorf("directory path %q: %w", path, ErrExists)
+	}
+	parentPath := "/" + strings.Join(segments[:len(segments)-1], "/")
+	name := segments[len(segments)-1]
+
+	var created Node
+	var createdPath string
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		parent, err := nodeByPath(ctx, tx, s.rootID, parentPath)
+		if err != nil {
+			return fmt.Errorf("resolving directory parent %q: %w", parentPath, err)
+		}
+		created, err = s.mkdirNodeTx(ctx, tx, parent.ID, name)
+		if err != nil {
+			return err
+		}
+		createdPath, err = pathOf(ctx, tx, created.ID)
+		return err
+	})
+	if err != nil {
+		return Node{}, "", err
+	}
+	return created, createdPath, nil
+}
+
+func (s *Store) mkdirNodeTx(
+	ctx context.Context, tx *sql.Tx, parentID int64, name string,
+) (Node, error) {
+	active, err := auditAuthorityActiveTx(ctx, tx)
 	if err != nil {
 		return Node{}, err
 	}
-	var created Node
-	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		active, err := auditAuthorityActiveTx(ctx, tx)
-		if err != nil {
-			return err
-		}
-		if !active {
-			created, err = s.mkdirTx(tx, parentID, name, nowRFC3339())
-			return err
-		}
-		priorParent, err := liveDirTx(tx, parentID)
-		if err != nil {
-			return err
-		}
-		authority, scopes, _, err := loadAuditedNodeAuthority(ctx, tx, parentID)
-		if err != nil {
-			return err
-		}
-		operationID, err := newUUIDv4()
-		if err != nil {
-			return err
-		}
-		recordedAt := nowRFC3339()
-		created, err = s.mkdirTx(tx, parentID, name, recordedAt)
-		if err != nil {
-			return err
-		}
-		resultingParent, err := nodeByIDTx(tx, parentID)
-		if err != nil {
-			return err
-		}
-		return persistAuditedNodeCreation(ctx, tx, s.vaultID, authority, scopes,
-			priorParent, resultingParent, created, ContentVersion{}, operationID, recordedAt, nil)
-	})
+	if !active {
+		return s.mkdirTx(tx, parentID, name, nowRFC3339())
+	}
+	priorParent, err := liveDirTx(tx, parentID)
 	if err != nil {
+		return Node{}, err
+	}
+	authority, scopes, _, err := loadAuditedNodeAuthority(ctx, tx, parentID)
+	if err != nil {
+		return Node{}, err
+	}
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return Node{}, err
+	}
+	recordedAt := nowRFC3339()
+	created, err := s.mkdirTx(tx, parentID, name, recordedAt)
+	if err != nil {
+		return Node{}, err
+	}
+	resultingParent, err := nodeByIDTx(tx, parentID)
+	if err != nil {
+		return Node{}, err
+	}
+	if err := persistAuditedNodeCreation(ctx, tx, s.vaultID, authority, scopes,
+		priorParent, resultingParent, created, ContentVersion{}, operationID, recordedAt, nil); err != nil {
 		return Node{}, err
 	}
 	return created, nil


### PR DESCRIPTION
Docbank could browse, import into, and reorganize its virtual tree, but the standalone CLI could not create an empty directory. A person or agent had to import placeholder content or bypass the CLI and call the HTTP API for a basic filing operation.

This adds the direct workflow:

```
docbank mkdir /projects
docbank mkdir /projects/2026
```

Each command creates exactly one directory and returns its stable `id:N` selector and canonical path; `--json` returns the complete node. The parent must already exist. This deliberately does not behave like `mkdir -p`, so a typo cannot silently invent an unexpected hierarchy. Collisions, the vault root, relative paths, file parents, and dot segments fail without creating anything.

The parent coordinate is resolved and the child is created in one store transaction. A concurrent move therefore cannot redirect `/projects/2026` beneath a different directory between a client lookup and the mutation. Workflows that already hold a stable parent ID retain the existing `POST /nodes` form, whose returned node and path are now captured in the same mutation transaction as well.

The same capability is available through authenticated HTTP and the typed client. Creation beneath a permanently audited directory continues through the existing audited node-creation writer and inherits that protection. The daemon protocol advances so a new CLI replaces an older process that does not expose the path-oriented contract.