### PR TITLE
Inspect individual nodes from the CLI

### DIFF
--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "33", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "34", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "33", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "34", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -382,6 +382,33 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	batchPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, infoPID, batchPID)
 
+	// Protocol 33 returned an internal storage-derived path when a trashed node
+	// was inspected by ID. Replace it before stat can present that value as a
+	// live virtual coordinate.
+	out, err = run(oldBin, "rm", "/inbox/protocol-batch.txt", "--json")
+	require.NoError(t, err, out)
+	var trashed api.Node
+	require.NoError(t, json.Unmarshal([]byte(out), &trashed))
+	require.NotEmpty(t, trashed.TrashedAt)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.Equal(t, "34", recs[0].Metadata["protocol_version"])
+	recs[0].Metadata["protocol_version"] = "33"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "stat", formatNodeSelector(trashed.ID), "--json")
+	require.NoError(t, err, out)
+	var inspected api.Node
+	require.NoError(t, json.Unmarshal([]byte(out), &inspected))
+	assert.Equal(t, trashed.ID, inspected.ID)
+	assert.Empty(t, inspected.Path)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	statPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, batchPID, statPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -396,7 +423,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "33", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "34", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -409,7 +436,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, batchPID, protocolPID)
+	assert.NotEqual(t, statPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/cmd/docbank/stat.go
+++ b/cmd/docbank/stat.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+var statJSON bool
+
+var statCmd = &cobra.Command{
+	Use:   "stat <path-or-id>",
+	Short: "Inspect one document or directory",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		selector, err := parseNodeSelector(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		node, err := selector.resolveIncludingTrash(cmd.Context(), c)
+		if err != nil {
+			return err
+		}
+		if statJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), node)
+		}
+		return writeNodeStat(cmd, node)
+	},
+}
+
+func writeNodeStat(cmd *cobra.Command, node api.Node) error {
+	createdAt, err := formatHumanTimestamp(node.CreatedAt)
+	if err != nil {
+		return err
+	}
+	modifiedAt, err := formatHumanTimestamp(node.ModifiedAt)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "selector:\t%s\n", formatNodeSelector(node.ID))
+	_, _ = fmt.Fprintf(w, "state:\t%s\n", nodeState(node))
+	if node.Path != "" {
+		_, _ = fmt.Fprintf(w, "path:\t%s\n", strconv.Quote(node.Path))
+	}
+	_, _ = fmt.Fprintf(w, "name:\t%s\n", strconv.Quote(node.Name))
+	_, _ = fmt.Fprintf(w, "kind:\t%s\n", node.Kind)
+	_, _ = fmt.Fprintf(w, "revision:\t%d\n", node.Revision)
+	_, _ = fmt.Fprintf(w, "created:\t%s\n", createdAt)
+	_, _ = fmt.Fprintf(w, "modified:\t%s\n", modifiedAt)
+	if node.TrashedAt != "" {
+		trashedAt, formatErr := formatHumanTimestamp(node.TrashedAt)
+		if formatErr != nil {
+			return formatErr
+		}
+		_, _ = fmt.Fprintf(w, "trashed:\t%s\n", trashedAt)
+	}
+	if node.Kind == "file" {
+		_, _ = fmt.Fprintf(w, "version:\t%s\n", node.CurrentVersionID)
+		_, _ = fmt.Fprintf(w, "sha256:\t%s\n", node.BlobHash)
+		_, _ = fmt.Fprintf(w, "size:\t%d\n", node.Size)
+		mimeType := "not recorded"
+		if node.MimeType != "" {
+			mimeType = strconv.Quote(node.MimeType)
+		}
+		_, _ = fmt.Fprintf(w, "mime:\t%s\n", mimeType)
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("writing node details: %w", err)
+	}
+	return nil
+}
+
+func nodeState(node api.Node) string {
+	if node.TrashedAt != "" {
+		return "trashed"
+	}
+	return "live"
+}
+
+func init() {
+	statCmd.Flags().BoolVar(&statJSON, "json", false, "emit machine-readable JSON")
+	rootCmd.AddCommand(statCmd)
+}

--- a/cmd/docbank/stat_test.go
+++ b/cmd/docbank/stat_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+func TestStatCLIInspectsLiveAndTrashedNodes(t *testing.T) {
+	_ = setupVaultHome(t)
+	source := writeSourceFile(t, "record.txt", "inspectable content")
+	_, err := runCLI(t, "add", source, "--dest", "/archive")
+	require.NoError(t, err)
+
+	c, err := client.Ensure(context.Background())
+	require.NoError(t, err)
+	node, err := c.Stat(context.Background(), "/archive/record.txt")
+	require.NoError(t, err)
+	selector := formatNodeSelector(node.ID)
+
+	out, err := runCLI(t, "stat", "/archive/record.txt")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "selector:  "+selector)
+	assert.Contains(t, out, "state:     live")
+	assert.Contains(t, out, `path:      "/archive/record.txt"`)
+	assert.Contains(t, out, "kind:      file")
+	assert.Contains(t, out, "version:   "+node.CurrentVersionID)
+	assert.Contains(t, out, "sha256:    "+node.BlobHash)
+	assert.Contains(t, out, "mime:      \"text/plain; charset=utf-8\"")
+
+	out, err = runCLI(t, "stat", selector, "--json")
+	require.NoError(t, err, out)
+	var got api.Node
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, node, got)
+
+	_, err = runCLI(t, "rm", selector)
+	require.NoError(t, err)
+	out, err = runCLI(t, "stat", selector)
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "state:     trashed")
+	assert.NotContains(t, out, "path:")
+	assert.Contains(t, out, "trashed:")
+
+	out, err = runCLI(t, "stat", selector, "--json")
+	require.NoError(t, err, out)
+	got = api.Node{}
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.NotEmpty(t, got.TrashedAt)
+	assert.Empty(t, got.Path)
+}
+
+func TestStatCLIValidatesSelectorBeforeDaemonStartup(t *testing.T) {
+	t.Setenv("DOCBANK_HOME", t.TempDir())
+	_, err := runCLI(t, "stat", "relative/path")
+	require.ErrorContains(t, err, "absolute virtual path")
+}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -116,10 +116,16 @@ listings print copyable selectors such as `id:42`, and existing-node commands
 accept either that stable selector or an absolute path:
 
 ```bash
+docbank stat id:42 --json
 docbank cat id:42
 docbank versions list id:42 --json
 docbank mv id:42 /review/approved.pdf --json
 ```
+
+Use `docbank stat` when a shell agent needs one authoritative node snapshot.
+Its JSON includes the node revision and, for files, the current version,
+SHA-256, size, and MIME type. A trashed ID remains inspectable but has no live
+`path`.
 
 The `mv` destination stays a path because it describes a new coordinate. In
 JSON and HTTP requests, node IDs remain numeric rather than `id:` strings.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,7 @@ All commands operate on the vault at `~/.docbank` (override with
 stderr and produce a non-zero exit code. Virtual paths are absolute,
 `/`-separated, and case-sensitive.
 
-Every data command below (`info`, `add`, `ls`, `tree`, `cat`, `put`, `edit`, `versions`, `version`, `refs`, `revert`, `tag`, `audit`, `mv`, `rm`,
+Every data command below (`info`, `stat`, `add`, `ls`, `tree`, `cat`, `put`, `edit`, `versions`, `version`, `refs`, `revert`, `tag`, `audit`, `mv`, `rm`,
 `restore`, `search`, `trash`, `gc`, `verify`, `storage`, `backup`, `jobs`) talks to the `docbank`
 daemon over its HTTP API rather than opening the vault itself; if none
 is running, the command auto-starts one in the background. `docbank
@@ -48,9 +48,25 @@ The destination of `mv` remains an absolute path because it describes where
 the node should go. `restore` also accepts its older bare numeric form for
 compatibility, although new scripts should use the unambiguous `id:42` form.
 Commands that require a live tree entry reject trashed selectors. Read-only
-`cat`, `versions list`, audit status, and audit history can still inspect a
+`stat`, `cat`, `versions list`, audit status, and audit history can still inspect a
 trashed node by stable ID; `restore` is the mutation that returns it to the
 live tree.
+
+## docbank stat
+
+```
+docbank stat <path-or-id> [--json]
+```
+
+Inspects one document or directory. Human output shows its stable `id:N`
+selector, live or trashed state, quoted live path and name, kind, revision, and
+timestamps. Files also show the current immutable version ID, SHA-256 content
+identity, raw size, and recorded MIME type.
+
+A path resolves only a live node. A stable ID can inspect the same node after
+it is moved, renamed, or trashed; trashed output deliberately has no `path`
+because the node has no live coordinate. `--json` returns the complete
+authoritative node object used by the HTTP API.
 
 ## Process exit codes
 

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -54,21 +54,11 @@ func nodeOutputAt(n store.Node, path string) *nodeOutput {
 // nodeWithPath loads the node's display path and builds the single-node
 // response. Every single-node endpoint returns this shape.
 func nodeWithPath(ctx context.Context, d Deps, id int64) (*nodeOutput, error) {
-	n, err := d.Store.NodeByID(ctx, id)
+	view, err := d.Store.NodeViewByID(ctx, id)
 	if err != nil {
 		return nil, FromStoreError(err)
 	}
-	// A trashed node has no live virtual coordinate. In particular, its
-	// storage parent is an implementation detail and must not be presented as
-	// a path that clients can resolve later.
-	if n.TrashedAt != nil {
-		return nodeOutputAt(n, ""), nil
-	}
-	p, err := d.Store.Path(ctx, id)
-	if err != nil {
-		return nil, FromStoreError(err)
-	}
-	return nodeOutputAt(n, p), nil
+	return nodeOutputAt(view.Node, view.Path), nil
 }
 
 func contentResponses() map[string]*huma.Response {
@@ -223,11 +213,11 @@ func registerReadRoutes(api huma.API, d Deps) {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation",
 				fmt.Sprintf("path %q must be absolute (start with /)", in.Path))
 		}
-		n, err := d.Store.NodeByPath(ctx, in.Path)
+		view, err := d.Store.NodeViewByPath(ctx, in.Path)
 		if err != nil {
 			return nil, FromStoreError(err)
 		}
-		return nodeWithPath(ctx, d, n.ID)
+		return nodeOutputAt(view.Node, view.Path), nil
 	})
 
 	type childrenPage struct {

--- a/internal/api/routes_read.go
+++ b/internal/api/routes_read.go
@@ -58,6 +58,12 @@ func nodeWithPath(ctx context.Context, d Deps, id int64) (*nodeOutput, error) {
 	if err != nil {
 		return nil, FromStoreError(err)
 	}
+	// A trashed node has no live virtual coordinate. In particular, its
+	// storage parent is an implementation detail and must not be presented as
+	// a path that clients can resolve later.
+	if n.TrashedAt != nil {
+		return nodeOutputAt(n, ""), nil
+	}
 	p, err := d.Store.Path(ctx, id)
 	if err != nil {
 		return nil, FromStoreError(err)

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -52,6 +52,23 @@ func TestStatByIDAndPath(t *testing.T) {
 	assert.Contains(t, body, `"code":"not_found"`)
 }
 
+func TestStatTrashedNodeHasNoLivePath(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	ctx := t.Context()
+	node, err := s.Mkdir(ctx, s.RootID(), "archived")
+	require.NoError(t, err)
+	_, _, err = s.Trash(ctx, node.ID, node.Revision)
+	require.NoError(t, err)
+
+	resp, body := get(t, ts, fmt.Sprintf("/api/v1/nodes/%d", node.ID), nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var got api.Node
+	require.NoError(t, json.Unmarshal([]byte(body), &got))
+	assert.Equal(t, node.ID, got.ID)
+	assert.NotEmpty(t, got.TrashedAt)
+	assert.Empty(t, got.Path)
+}
+
 func TestChildrenPagination(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	ctx := t.Context()

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -16,8 +16,8 @@ const (
 	ContentVersionHeader = "X-Docbank-Content-Version"
 )
 
-// Node is the wire representation of a store.Node. Path is only populated on
-// single-node responses; list responses omit it.
+// Node is the wire representation of a store.Node. Path is populated on live
+// single-node responses; lists and trashed nodes omit it.
 type Node struct {
 	ID               int64  `json:"id"`
 	ParentID         *int64 `json:"parent_id,omitempty"`
@@ -31,7 +31,7 @@ type Node struct {
 	CreatedAt        string `json:"created_at"`
 	ModifiedAt       string `json:"modified_at"`
 	TrashedAt        string `json:"trashed_at,omitempty"`
-	Path             string `json:"path,omitempty"` // set on single-node responses only
+	Path             string `json:"path,omitempty"` // set on live single-node responses only
 }
 
 // NodePage is one bounded, ordered directory-child listing.

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "33"
+	daemonProtocolVersion = "34"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -32,6 +32,13 @@ type Node struct {
 // IsDir reports whether the node is a directory.
 func (n Node) IsDir() bool { return n.Kind == nodeKindDir }
 
+// NodeView binds one node snapshot to its live canonical path. Path is empty
+// when the snapshot marks the node as trashed.
+type NodeView struct {
+	Node Node
+	Path string
+}
+
 const nodeFrom = `nodes AS n
 	LEFT JOIN content_versions AS cv
 		ON cv.node_id = n.id AND cv.version_id = n.current_version_id`
@@ -64,6 +71,58 @@ func (s *Store) NodeByID(ctx context.Context, id int64) (Node, error) {
 		return Node{}, fmt.Errorf("node %d: %w", id, err)
 	}
 	return n, nil
+}
+
+// NodeViewByID returns a node and its live path from one read transaction.
+func (s *Store) NodeViewByID(ctx context.Context, id int64) (NodeView, error) {
+	return s.nodeView(ctx, func(tx *sql.Tx) (Node, error) {
+		return nodeByIDTx(tx, id)
+	})
+}
+
+// NodeViewByPath resolves a live path and returns its node and canonical path
+// from one read transaction.
+func (s *Store) NodeViewByPath(ctx context.Context, path string) (NodeView, error) {
+	return s.nodeView(ctx, func(tx *sql.Tx) (Node, error) {
+		return nodeByPath(ctx, tx, s.rootID, path)
+	})
+}
+
+func (s *Store) nodeView(
+	ctx context.Context,
+	resolve func(*sql.Tx) (Node, error),
+) (NodeView, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return NodeView{}, fmt.Errorf("starting node snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	node, err := resolve(tx)
+	if err != nil {
+		return NodeView{}, err
+	}
+	view, err := nodeViewForNode(ctx, tx, node)
+	if err != nil {
+		return NodeView{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return NodeView{}, fmt.Errorf("closing node snapshot: %w", err)
+	}
+	return view, nil
+}
+
+func nodeViewForNode(ctx context.Context, q rowQuerier, node Node) (NodeView, error) {
+	view := NodeView{Node: node}
+	if node.TrashedAt != nil {
+		return view, nil
+	}
+	path, err := pathOf(ctx, q, node.ID)
+	if err != nil {
+		return NodeView{}, err
+	}
+	view.Path = path
+	return view, nil
 }
 
 // splitPath turns "/a/b/" into ["a","b"]. "" and "/" yield nil (the root).

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"context"
+	"database/sql"
 	"strings"
 	"sync"
 	"testing"
@@ -8,6 +10,41 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNodeViewPinsNodeAndPathAcrossConcurrentTrash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	parent, err := s.Mkdir(ctx, s.RootID(), "archive")
+	require.NoError(t, err)
+	node, err := s.Mkdir(ctx, parent.ID, "records")
+	require.NoError(t, err)
+
+	trashStarted := make(chan struct{})
+	trashed := make(chan error, 1)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+	snapshot, err := nodeByIDTx(tx, node.ID)
+	require.NoError(t, err)
+
+	go func() {
+		close(trashStarted)
+		_, _, trashErr := s.Trash(context.Background(), node.ID, node.Revision)
+		trashed <- trashErr
+	}()
+	<-trashStarted
+	view, err := nodeViewForNode(ctx, tx, snapshot)
+	require.NoError(t, err)
+	assert.Nil(t, view.Node.TrashedAt)
+	assert.Equal(t, "/archive/records", view.Path)
+	require.NoError(t, tx.Commit())
+	require.NoError(t, <-trashed)
+
+	after, err := s.NodeViewByID(ctx, node.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, after.Node.TrashedAt)
+	assert.Empty(t, after.Path)
+}
 
 func TestMkdirAndLookup(t *testing.T) {
 	s := newTestStore(t)


### PR DESCRIPTION
Docbank can list a directory and summarize an entire vault, but it has no direct shell workflow for a basic question: “what exactly is this document right now?” People and agents should not have to misuse `ls --json` or call HTTP themselves before making a revision-bound decision.

This adds:

```console
docbank stat /archive/record.pdf
docbank stat id:42 --json
```

Human output shows the stable selector, live or trashed state, quoted path and name, kind, revision, and timestamps. Files also show the current immutable version, SHA-256 identity, raw size, and MIME type. JSON returns the complete authoritative node object, so an agent can carry the exact identity and revision into later work.

Stable IDs remain inspectable after a move, rename, or trash operation. A trashed node deliberately has no `path`: Docbank’s internal trash placement is not a live virtual coordinate, and presenting it as one could lead a person or agent to act on the wrong node. Node state and path now come from one read transaction, so concurrent trash or movement cannot combine values from different moments.

The daemon protocol advances to 34 because protocol 33 can return the old storage-derived path for a trashed ID. A new CLI therefore replaces that daemon before inspection instead of accepting an ambiguous result. This remains a read-only feature with no storage-schema or vault-compatibility change.