### PR TITLE
Download verified documents without partial files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,14 @@ platform's toolchain.
 There is no initialization command. The first data command creates the local
 vault and starts its daemon:
 
-> **Release availability:** tag-filtered search is newer than v0.10.0. Build
-> from source to use `docbank search --tag` until the next release is tagged.
+> **Release availability:** tag-filtered search and `docbank get` are newer
+> than v0.10.0. Build from source to use them until the next release is tagged.
 
 ```bash
 docbank add ~/Documents --dest /archive
 docbank tree /archive
 docbank search "tax return"
+docbank get /archive/Documents/receipt.pdf ./receipt.pdf
 docbank versions list /archive/Documents/receipt.pdf
 docbank refs <receipt-sha256>
 docbank tag create taxes

--- a/cmd/docbank/edit.go
+++ b/cmd/docbank/edit.go
@@ -237,7 +237,7 @@ func normalizedMIMEOverride(value string) (string, error) {
 }
 
 func stageCurrentVersion(
-	ctx context.Context, c *client.Client, node api.Node, staging *editStaging,
+	ctx context.Context, c *client.Client, node api.Node, staging *privateStaging,
 	renderer *backupProgressRenderer,
 ) (path string, retErr error) {
 	stream, err := c.VersionContent(ctx, node.CurrentVersionID)

--- a/cmd/docbank/edit_staging.go
+++ b/cmd/docbank/edit_staging.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 )
 
-type editStaging struct {
+type privateStaging struct {
 	path       string
 	root       *os.Root
 	pin        *os.File
 	stagedName string
 }
 
-func openEditStaging(path string, pin *os.File) (*editStaging, error) {
+func openPrivateStaging(path string, pin *os.File) (*privateStaging, error) {
 	root, err := os.OpenRoot(path)
 	if err != nil {
 		var pinErr error
@@ -30,10 +30,10 @@ func openEditStaging(path string, pin *os.File) (*editStaging, error) {
 			os.RemoveAll(path),
 		)
 	}
-	return &editStaging{path: path, root: root, pin: pin}, nil
+	return &privateStaging{path: path, root: root, pin: pin}, nil
 }
 
-func (s *editStaging) createFile(vaultName string) (*os.File, string, error) {
+func (s *privateStaging) createFile(vaultName string) (*os.File, string, error) {
 	pattern := editStagePattern(vaultName)
 	for range 10 {
 		var random [16]byte
@@ -54,7 +54,7 @@ func (s *editStaging) createFile(vaultName string) (*os.File, string, error) {
 	return nil, "", errors.New("creating staged file: repeated name collisions")
 }
 
-func (s *editStaging) removeAll() error {
+func (s *privateStaging) removeAll() error {
 	var removeFileErr error
 	if s.root != nil && s.stagedName != "" {
 		removeFileErr = s.root.Remove(s.stagedName)

--- a/cmd/docbank/edit_staging_unix.go
+++ b/cmd/docbank/edit_staging_unix.go
@@ -2,12 +2,19 @@
 
 package main
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
-func makePrivateEditDir() (*editStaging, error) {
-	path, err := os.MkdirTemp("", "docbank-edit-*")
+func makePrivateEditDir() (*privateStaging, error) {
+	return makePrivateStagingDirAt(os.TempDir(), "docbank-edit-")
+}
+
+func makePrivateStagingDirAt(parentPath, prefix string) (*privateStaging, error) {
+	path, err := os.MkdirTemp(parentPath, prefix+"*")
 	if err != nil {
 		return nil, err
 	}
-	return openEditStaging(path, nil)
+	return openPrivateStaging(filepath.Clean(path), nil)
 }

--- a/cmd/docbank/edit_staging_windows.go
+++ b/cmd/docbank/edit_staging_windows.go
@@ -15,11 +15,15 @@ import (
 	"go.kenn.io/docbank/internal/winsecurity"
 )
 
-func makePrivateEditDir() (*editStaging, error) {
+func makePrivateEditDir() (*privateStaging, error) {
 	return makePrivateEditDirAt(os.TempDir())
 }
 
-func makePrivateEditDirAt(parentPath string) (*editStaging, error) {
+func makePrivateEditDirAt(parentPath string) (*privateStaging, error) {
+	return makePrivateStagingDirAt(parentPath, "docbank-edit-")
+}
+
+func makePrivateStagingDirAt(parentPath, prefix string) (*privateStaging, error) {
 	parent, err := os.OpenRoot(parentPath)
 	if err != nil {
 		return nil, fmt.Errorf("opening edit staging parent: %w", err)
@@ -31,7 +35,7 @@ func makePrivateEditDirAt(parentPath string) (*editStaging, error) {
 		if _, err := rand.Read(random); err != nil {
 			return nil, fmt.Errorf("generating edit staging name: %w", err)
 		}
-		component := "docbank-edit-" + hex.EncodeToString(random)
+		component := prefix + hex.EncodeToString(random)
 		pin, err := winsecurity.MkdirPrivatePinnedAt(parent, component)
 		if err != nil {
 			if errors.Is(err, os.ErrExist) {
@@ -49,7 +53,7 @@ func makePrivateEditDirAt(parentPath string) (*editStaging, error) {
 				cleanupErr,
 			)
 		}
-		return openEditStaging(path, pin)
+		return openPrivateStaging(path, pin)
 	}
 	return nil, errors.New("creating private edit staging: repeated name collisions")
 }

--- a/cmd/docbank/get.go
+++ b/cmd/docbank/get.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/store"
+)
+
+var (
+	getJSON      bool
+	getOverwrite bool
+	getProgress  string
+)
+
+type getReceipt struct {
+	NodeID    int64  `json:"node_id"`
+	VersionID string `json:"version_id"`
+	BlobHash  string `json:"blob_hash"`
+	Size      int64  `json:"size"`
+	Output    string `json:"output"`
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get <path-or-id> <local-file>",
+	Short: "Download one file with end-to-end verification",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGet(cmd, args[0], args[1])
+	},
+}
+
+func runGet(cmd *cobra.Command, rawSelector, rawOutput string) (retErr error) {
+	selector, err := parseNodeSelector(rawSelector)
+	if err != nil {
+		return err
+	}
+	outputPath, err := prepareGetDestination(rawOutput, getOverwrite)
+	if err != nil {
+		return err
+	}
+	mode := backupProgressAuto
+	if !getJSON {
+		mode, err = progressModeFromFlag("get", getProgress)
+		if err != nil {
+			return err
+		}
+	}
+	progressOutput := cmd.ErrOrStderr()
+	if getJSON {
+		progressOutput = io.Discard
+	}
+	renderer := newBackupProgressRenderer(progressOutput, mode)
+	defer renderer.finish()
+
+	staging, err := makePrivateStagingDirAt(filepath.Dir(outputPath), "docbank-get-")
+	if err != nil {
+		return fmt.Errorf("creating private download staging: %w", err)
+	}
+	published := false
+	defer func() {
+		if cleanupErr := staging.removeAll(); cleanupErr != nil {
+			if published {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"warning: downloaded file is complete, but staging cleanup failed: %v\n",
+					cleanupErr)
+				return
+			}
+			retErr = errors.Join(retErr,
+				fmt.Errorf("removing private download staging: %w", cleanupErr))
+		}
+	}()
+
+	c, err := client.Ensure(cmd.Context())
+	if err != nil {
+		return err
+	}
+	node, err := selector.resolveIncludingTrash(cmd.Context(), c)
+	if err != nil {
+		return err
+	}
+	if node.Kind != "file" {
+		return fmt.Errorf("%q: %w", rawSelector, store.ErrNotFile)
+	}
+	stream, err := c.VersionContent(cmd.Context(), node.CurrentVersionID)
+	if err != nil {
+		return err
+	}
+	if err := validateGetStreamAuthority(stream, node); err != nil {
+		_ = stream.Close()
+		return err
+	}
+	written, err := stageAndPublishGet(cmd.Context(), staging, stream, node.Size,
+		outputPath, getOverwrite, renderer)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("destination %s already exists; pass --overwrite to replace it: %w",
+				strconv.Quote(outputPath), os.ErrExist)
+		}
+		if errors.Is(err, client.ErrIntegrity) {
+			return integrityError(fmt.Errorf("downloading %q: %w", rawSelector, err))
+		}
+		return err
+	}
+	published = true
+
+	receipt := getReceipt{
+		NodeID: node.ID, VersionID: node.CurrentVersionID, BlobHash: node.BlobHash,
+		Size: written, Output: outputPath,
+	}
+	if getJSON {
+		return writeCLIJSON(cmd.OutOrStdout(), receipt)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "downloaded %s version %s to %s (%s, sha256 %s)\n",
+		formatNodeSelector(node.ID), node.CurrentVersionID, strconv.Quote(outputPath),
+		formatBackupBytes(written), node.BlobHash)
+	if err != nil {
+		return fmt.Errorf("writing download receipt: %w", err)
+	}
+	return nil
+}
+
+func stageAndPublishGet(
+	ctx context.Context,
+	staging *privateStaging,
+	stream *client.ContentStream,
+	total int64,
+	outputPath string,
+	overwrite bool,
+	renderer *backupProgressRenderer,
+) (written int64, retErr error) {
+	streamOpen := true
+	defer func() {
+		if streamOpen {
+			retErr = errors.Join(retErr, stream.Close())
+		}
+	}()
+	file, stagedPath, err := staging.createFile(filepath.Base(outputPath))
+	if err != nil {
+		return 0, err
+	}
+	fileOpen := true
+	defer func() {
+		if fileOpen {
+			retErr = errors.Join(retErr, file.Close())
+		}
+	}()
+	progress := newEditProgressWriter(ctx, file, total, renderer)
+	written, err = stream.CopyVerified(progress)
+	if err != nil {
+		return written, err
+	}
+	progress.finish()
+	if err := file.Sync(); err != nil {
+		return written, fmt.Errorf("syncing downloaded file: %w", err)
+	}
+	closeErr := file.Close()
+	fileOpen = false
+	if closeErr != nil {
+		return written, fmt.Errorf("closing downloaded file: %w", closeErr)
+	}
+	closeErr = stream.Close()
+	streamOpen = false
+	if closeErr != nil {
+		return written, fmt.Errorf("closing verified download: %w", closeErr)
+	}
+	if err := publishGetFile(stagedPath, outputPath, overwrite); err != nil {
+		return written, fmt.Errorf("publishing downloaded file: %w", err)
+	}
+	return written, nil
+}
+
+func prepareGetDestination(raw string, overwrite bool) (string, error) {
+	if !utf8.ValidString(raw) {
+		return "", usageError(fmt.Errorf("download destination %s is not valid UTF-8",
+			strconv.QuoteToASCII(raw)))
+	}
+	abs, err := filepath.Abs(raw)
+	if err != nil {
+		return "", fmt.Errorf("resolving download destination %q: %w", raw, err)
+	}
+	info, err := os.Lstat(abs)
+	if err == nil {
+		if info.IsDir() {
+			return "", usageError(fmt.Errorf("download destination %s is a directory",
+				strconv.Quote(abs)))
+		}
+		if !overwrite {
+			return "", usageError(fmt.Errorf(
+				"download destination %s already exists; pass --overwrite to replace it",
+				strconv.Quote(abs)))
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("checking download destination %s: %w", strconv.Quote(abs), err)
+	}
+	parent, err := os.Stat(filepath.Dir(abs))
+	if err != nil {
+		return "", fmt.Errorf("checking download destination directory: %w", err)
+	}
+	if !parent.IsDir() {
+		return "", usageError(fmt.Errorf("download destination parent is not a directory: %s",
+			strconv.Quote(filepath.Dir(abs))))
+	}
+	return abs, nil
+}
+
+func validateGetStreamAuthority(stream *client.ContentStream, node api.Node) error {
+	if stream.VersionID == node.CurrentVersionID && stream.BlobHash == node.BlobHash &&
+		stream.Size == node.Size {
+		return nil
+	}
+	return integrityError(fmt.Errorf(
+		"version authority %s/%s/%d disagrees with node authority %s/%s/%d",
+		stream.VersionID, stream.BlobHash, stream.Size,
+		node.CurrentVersionID, node.BlobHash, node.Size,
+	))
+}
+
+func init() {
+	getCmd.Flags().BoolVar(&getOverwrite, "overwrite", false,
+		"replace an existing local file after the download verifies")
+	getCmd.Flags().BoolVar(&getJSON, "json", false,
+		"emit a machine-readable download receipt (progress suppressed)")
+	getCmd.Flags().StringVar(&getProgress, "progress", "auto",
+		"progress output mode: auto, bar, or plain (suppressed by --json)")
+	rootCmd.AddCommand(getCmd)
+}

--- a/cmd/docbank/get_publish.go
+++ b/cmd/docbank/get_publish.go
@@ -4,21 +4,32 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+
+	"go.kenn.io/kit/pack"
 )
+
+var syncGetDestinationDir = pack.SyncDir
 
 func publishGetFile(stagedPath, outputPath string, overwrite bool) error {
 	if overwrite {
-		return os.Rename(stagedPath, outputPath)
+		if err := os.Rename(stagedPath, outputPath); err != nil {
+			return err
+		}
+	} else {
+		linkErr := os.Link(stagedPath, outputPath)
+		if linkErr != nil {
+			if renameErr := renameGetFileNoReplace(stagedPath, outputPath); renameErr != nil {
+				return errors.Join(
+					fmt.Errorf("hard-link publication: %w", linkErr),
+					fmt.Errorf("no-replace rename publication: %w", renameErr),
+				)
+			}
+		}
 	}
-	linkErr := os.Link(stagedPath, outputPath)
-	if linkErr == nil {
-		return nil
-	}
-	if renameErr := renameGetFileNoReplace(stagedPath, outputPath); renameErr != nil {
-		return errors.Join(
-			fmt.Errorf("hard-link publication: %w", linkErr),
-			fmt.Errorf("no-replace rename publication: %w", renameErr),
-		)
+	if err := syncGetDestinationDir(filepath.Dir(outputPath)); err != nil {
+		return fmt.Errorf("file published at %s but destination directory sync failed: %w",
+			outputPath, err)
 	}
 	return nil
 }

--- a/cmd/docbank/get_publish.go
+++ b/cmd/docbank/get_publish.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func publishGetFile(stagedPath, outputPath string, overwrite bool) error {
+	if overwrite {
+		return os.Rename(stagedPath, outputPath)
+	}
+	linkErr := os.Link(stagedPath, outputPath)
+	if linkErr == nil {
+		return nil
+	}
+	if renameErr := renameGetFileNoReplace(stagedPath, outputPath); renameErr != nil {
+		return errors.Join(
+			fmt.Errorf("hard-link publication: %w", linkErr),
+			fmt.Errorf("no-replace rename publication: %w", renameErr),
+		)
+	}
+	return nil
+}

--- a/cmd/docbank/get_publish_darwin.go
+++ b/cmd/docbank/get_publish_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func renameGetFileNoReplace(stagedPath, outputPath string) error {
+	if err := unix.RenamexNp(stagedPath, outputPath, unix.RENAME_EXCL); err != nil {
+		return &os.LinkError{Op: "renamex_np", Old: stagedPath, New: outputPath, Err: err}
+	}
+	return nil
+}

--- a/cmd/docbank/get_publish_linux.go
+++ b/cmd/docbank/get_publish_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func renameGetFileNoReplace(stagedPath, outputPath string) error {
+	if err := unix.Renameat2(unix.AT_FDCWD, stagedPath, unix.AT_FDCWD, outputPath,
+		unix.RENAME_NOREPLACE); err != nil {
+		return &os.LinkError{Op: "renameat2", Old: stagedPath, New: outputPath, Err: err}
+	}
+	return nil
+}

--- a/cmd/docbank/get_publish_other.go
+++ b/cmd/docbank/get_publish_other.go
@@ -1,0 +1,14 @@
+//go:build !darwin && !linux && !windows
+
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+func renameGetFileNoReplace(stagedPath, outputPath string) error {
+	return &os.LinkError{
+		Op: "rename-noreplace", Old: stagedPath, New: outputPath, Err: errors.ErrUnsupported,
+	}
+}

--- a/cmd/docbank/get_publish_windows.go
+++ b/cmd/docbank/get_publish_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func renameGetFileNoReplace(stagedPath, outputPath string) error {
+	stagedName, err := windows.UTF16PtrFromString(stagedPath)
+	if err != nil {
+		return err
+	}
+	outputName, err := windows.UTF16PtrFromString(outputPath)
+	if err != nil {
+		return err
+	}
+	if err := windows.MoveFile(stagedName, outputName); err != nil {
+		return &os.LinkError{Op: "MoveFileW", Old: stagedPath, New: outputPath, Err: err}
+	}
+	return nil
+}

--- a/cmd/docbank/get_test.go
+++ b/cmd/docbank/get_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -133,6 +134,27 @@ func TestGetIntegrityFailureNeverPublishesPartialDestination(t *testing.T) {
 	require.ErrorIs(t, err, client.ErrIntegrity)
 	_, statErr := os.Lstat(output)
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestPublishGetFileSurfacesDestinationDirectorySyncFailure(t *testing.T) {
+	dir := t.TempDir()
+	staged := filepath.Join(dir, "staged")
+	output := filepath.Join(dir, "output")
+	require.NoError(t, os.WriteFile(staged, []byte("durable content"), 0o600))
+	syncErr := errors.New("injected destination directory sync failure")
+	originalSync := syncGetDestinationDir
+	syncGetDestinationDir = func(got string) error {
+		assert.Equal(t, dir, got)
+		return syncErr
+	}
+	t.Cleanup(func() { syncGetDestinationDir = originalSync })
+
+	err := publishGetFile(staged, output, false)
+	require.ErrorIs(t, err, syncErr)
+	require.ErrorContains(t, err, "file published")
+	bytes, readErr := os.ReadFile(output)
+	require.NoError(t, readErr)
+	assert.Equal(t, "durable content", string(bytes))
 }
 
 func assertNoGetStaging(t *testing.T, dir string) {

--- a/cmd/docbank/get_test.go
+++ b/cmd/docbank/get_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+func TestGetPublishesVerifiedCurrentVersion(t *testing.T) {
+	_ = setupVaultHome(t)
+	source := writeSourceFile(t, "statement.bin", "synthetic binary\x00content")
+	_, err := runCLI(t, "add", source, "--dest", "/inbox", "--json")
+	require.NoError(t, err)
+
+	output := filepath.Join(t.TempDir(), "retrieved.bin")
+	out, err := runCLI(t, "get", "/inbox/statement.bin", output, "--json")
+	require.NoError(t, err)
+	var receipt getReceipt
+	require.NoError(t, json.Unmarshal([]byte(out), &receipt), out)
+	assert.Positive(t, receipt.NodeID)
+	assert.NotEmpty(t, receipt.VersionID)
+	assert.Len(t, receipt.BlobHash, 64)
+	assert.Equal(t, int64(len("synthetic binary\x00content")), receipt.Size)
+	absOutput, err := filepath.Abs(output)
+	require.NoError(t, err)
+	assert.Equal(t, absOutput, receipt.Output)
+	bytes, err := os.ReadFile(output)
+	require.NoError(t, err)
+	assert.Equal(t, "synthetic binary\x00content", string(bytes))
+	assert.NotContains(t, out, "download:", "JSON must contain no progress lines")
+	assertNoGetStaging(t, filepath.Dir(output))
+}
+
+func TestGetRefusesExistingDestinationUnlessOverwriteIsExplicit(t *testing.T) {
+	_ = setupVaultHome(t)
+	source := writeSourceFile(t, "report.txt", "authoritative")
+	_, err := runCLI(t, "add", source, "--dest", "/inbox", "--json")
+	require.NoError(t, err)
+
+	output := filepath.Join(t.TempDir(), "report.txt")
+	require.NoError(t, os.WriteFile(output, []byte("keep me"), 0o600))
+	_, err = runCLI(t, "get", "/inbox/report.txt", output)
+	require.ErrorContains(t, err, "pass --overwrite")
+	bytes, readErr := os.ReadFile(output)
+	require.NoError(t, readErr)
+	assert.Equal(t, "keep me", string(bytes))
+	assertNoGetStaging(t, filepath.Dir(output))
+
+	out, err := runCLI(t, "get", "/inbox/report.txt", output, "--overwrite", "--json")
+	require.NoError(t, err)
+	assert.True(t, json.Valid([]byte(out)), out)
+	bytes, readErr = os.ReadFile(output)
+	require.NoError(t, readErr)
+	assert.Equal(t, "authoritative", string(bytes))
+	assertNoGetStaging(t, filepath.Dir(output))
+}
+
+func TestGetCanRetrieveTrashedFileByStableID(t *testing.T) {
+	_ = setupVaultHome(t)
+	source := writeSourceFile(t, "archived.txt", "retained bytes")
+	_, err := runCLI(t, "add", source, "--dest", "/inbox", "--json")
+	require.NoError(t, err)
+	statJSON, err := runCLI(t, "stat", "/inbox/archived.txt", "--json")
+	require.NoError(t, err)
+	var node api.Node
+	require.NoError(t, json.Unmarshal([]byte(statJSON), &node))
+	_, err = runCLI(t, "rm", formatNodeSelector(node.ID), "--json")
+	require.NoError(t, err)
+
+	output := filepath.Join(t.TempDir(), "recovered.txt")
+	_, err = runCLI(t, "get", formatNodeSelector(node.ID), output, "--json")
+	require.NoError(t, err)
+	bytes, err := os.ReadFile(output)
+	require.NoError(t, err)
+	assert.Equal(t, "retained bytes", string(bytes))
+}
+
+func TestGetRejectsDirectoryAndInvalidProgress(t *testing.T) {
+	_ = setupVaultHome(t)
+	_, err := runCLI(t, "get", "/", filepath.Join(t.TempDir(), "root"))
+	require.ErrorContains(t, err, "not a file")
+
+	_, err = runCLI(t, "get", "/missing", filepath.Join(t.TempDir(), "out"),
+		"--progress", "animated")
+	require.ErrorContains(t, err, "invalid --progress value")
+}
+
+func TestPublishGetFileNoReplacePreservesConcurrentDestination(t *testing.T) {
+	dir := t.TempDir()
+	staged := filepath.Join(dir, "staged")
+	output := filepath.Join(dir, "output")
+	require.NoError(t, os.WriteFile(staged, []byte("download"), 0o600))
+	require.NoError(t, os.WriteFile(output, []byte("concurrent"), 0o600))
+
+	err := publishGetFile(staged, output, false)
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrExist)
+	bytes, readErr := os.ReadFile(output)
+	require.NoError(t, readErr)
+	assert.Equal(t, "concurrent", string(bytes))
+}
+
+func TestGetIntegrityFailureNeverPublishesPartialDestination(t *testing.T) {
+	dir := t.TempDir()
+	staging, err := makePrivateStagingDirAt(dir, "docbank-get-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, staging.removeAll()) })
+	content := "complete bytes without the required digest trailer"
+	digest := sha256.Sum256([]byte(content))
+	stream := &client.ContentStream{
+		ReadCloser: io.NopCloser(strings.NewReader(content)),
+		VersionID:  "7b0dbd90-5730-4436-b082-b692790725ff",
+		BlobHash:   hex.EncodeToString(digest[:]),
+		Size:       int64(len(content)),
+	}
+	output := filepath.Join(dir, "must-not-exist")
+	renderer := newBackupProgressRenderer(io.Discard, backupProgressAuto)
+	_, err = stageAndPublishGet(context.Background(), staging, stream, stream.Size,
+		output, false, renderer)
+	require.Error(t, err)
+	require.ErrorIs(t, err, client.ErrIntegrity)
+	_, statErr := os.Lstat(output)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func assertNoGetStaging(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.False(t, strings.HasPrefix(entry.Name(), "docbank-get-"), entry.Name())
+	}
+}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -198,13 +198,26 @@ curl --fail-with-body --get \
   "$DOCBANK_URL/api/v1/search"
 ```
 
-Retrieve file bytes by ID, not path:
+For shell automation, prefer `get` when the bytes must become a local file. It
+keeps incomplete bytes private and emits a structured proof receipt only after
+the complete stream verifies and is atomically published:
+
+```bash
+docbank get id:42 ./document.bin --json
+```
+
+!!! info "Release availability"
+
+    `docbank get` is newer than v0.10.0. Build from source to use it until the
+    next release is tagged.
+
+Independent HTTP clients should retrieve file bytes by ID, not path:
 
 ```bash
 curl --fail \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   "$DOCBANK_URL/api/v1/nodes/42/content" \
-  --output document.bin
+  --output document.bin.staging
 ```
 
 The content response sends `X-Docbank-Content-Version`,
@@ -212,10 +225,12 @@ The content response sends `X-Docbank-Content-Version`,
 it sends an
 [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html) `Content-Digest`
 trailer computed from the bytes actually streamed. A client
-that needs independent transfer proof hashes `document.bin` itself and compares
-that digest, the trailer, and the file node's `blob_hash`. Require the version
+that needs independent transfer proof writes to private staging, hashes the
+staged bytes itself, and compares that digest, the trailer, and the file node's
+`blob_hash`. Require the version
 header to equal the node's `current_version_id`; do not treat catalog headers
-alone as a fresh physical verification.
+alone as a fresh physical verification. Sync and close the staging file before
+publishing it at the caller-visible destination.
 
 List a node's immutable versions with bounded pagination, then address one
 record or byte stream without relying on its current path:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -239,6 +239,30 @@ docbank cat <path-or-id>
 Streams the file's stored bytes to stdout. Fails with `not a file` for
 directories.
 
+## docbank get
+
+!!! info "Release availability"
+
+    `docbank get` is newer than v0.10.0. Build from source to use it until the
+    next release is tagged.
+
+```text
+docbank get <path-or-id> <local-file> [--overwrite] [--progress auto|bar|plain] [--json]
+```
+
+Downloads one current document version to a local file. Docbank writes into an
+owner-private staging directory beside the destination, verifies the complete
+size, SHA-256 identity, and terminal HTTP digest, syncs and closes the file,
+then publishes it atomically. An interrupted or corrupt transfer never exposes
+a partial destination.
+
+Existing files are preserved unless `--overwrite` is explicit. Even then,
+Docbank verifies the replacement before atomically replacing the existing path;
+an existing symlink is replaced rather than followed. `--json` suppresses
+progress and returns the node ID, immutable version ID, hash, size, and absolute
+local output path. A trashed file remains retrievable by its stable `id:N`
+selector while its content version is retained.
+
 ## docbank put
 
 ```text

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,14 +54,15 @@ curl -fsSL https://docbank.ai/install.sh | sh
 The ordinary workflow stays direct:
 
 !!! note "Release availability"
-    Tag-filtered search is newer than v0.10.0. Build from source to use
-    `docbank search --tag` until the next release is tagged.
+    Tag-filtered search and `docbank get` are newer than v0.10.0. Build from
+    source to use them until the next release is tagged.
 
 ```bash
 docbank add ~/Documents/taxes --dest /taxes    # import a folder; sources untouched
 docbank tree /taxes                            # browse the virtual tree
 docbank search "insurance"                     # ranked name and verified plain-text search
 docbank search "return" --tag taxes             # narrow the same ranking by stable tag identity
+docbank get /taxes/2026/return.pdf ./return.pdf # verify, then publish a complete local file
 docbank put revised.pdf /taxes/2026/return.pdf # add a new immutable version
 docbank versions list /taxes/2026/return.pdf   # inspect retained history
 docbank rm /inbox/junk.pdf                     # move to recoverable trash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,11 +72,18 @@ docbank tree /taxes
   checklist.pdf  [231]
 ```
 
-`cat` streams a file's bytes to stdout:
+`cat` streams a file's bytes to stdout. For a durable local file, `get` first
+verifies the complete download in private staging and only then publishes it:
 
 ```bash
-docbank cat /taxes/checklist.pdf > /tmp/checklist.pdf
+docbank cat /taxes/checklist.pdf
+docbank get /taxes/checklist.pdf /tmp/checklist.pdf
 ```
+
+!!! info "Release availability"
+
+    `docbank get` is newer than v0.10.0. Build from source to use it until the
+    next release is tagged.
 
 !!! info "New version-command vocabulary"
 

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -16,7 +16,13 @@ archive is one metadata update.
 docbank ls /taxes          # one directory, with stable selectors, sizes, timestamps
 docbank tree /taxes        # whole subtree, with id:N selectors in brackets
 docbank cat /taxes/w2.pdf  # stream file bytes to stdout
+docbank get /taxes/w2.pdf ./w2.pdf  # verify, then atomically publish a local file
 ```
+
+!!! info "Release availability"
+
+    `docbank get` is newer than v0.10.0. Build from source to use it until the
+    next release is tagged.
 
 Use `ls --json` for a directory envelope containing the resolved directory
 and its ordered children. `tree --json` returns the root plus a flat,
@@ -29,6 +35,7 @@ Commands that target an existing node accept either form:
 
 ```bash
 docbank cat id:42
+docbank get id:42 ./document.pdf
 docbank mv id:42 /taxes/2026/w2.pdf
 docbank rm id:42
 docbank restore id:42


### PR DESCRIPTION
`docbank cat /record.pdf > record.pdf` can leave a partial file behind if the transfer is interrupted or fails its terminal integrity check. That is acceptable stdout behavior for a pipeline, but it is a poor default when a person or agent intends to materialize a trustworthy local copy.

This adds the direct workflow:

```console
docbank get /record.pdf ./record.pdf
docbank get id:42 ./record.pdf --json
```

`get` does not expose the destination until the selected immutable version has been downloaded completely, checked against its recorded size and SHA-256, checked against the daemon's terminal digest, synced and closed, and its destination directory has crossed the filesystem durability boundary. A failed or corrupt transfer leaves no partial destination. Existing files are preserved unless `--overwrite` is explicit; explicit replacement still waits until the new copy is fully verified. Progress is available for large documents, while JSON mode returns a clean receipt containing the stable node and version identities, hash, size, and absolute output path.

The command also works with a trashed file's stable `id:N` selector while that version remains retained. It deliberately handles one file only: recursive tree export needs separate filename, collision, confinement, and progress semantics rather than being smuggled into this focused workflow. No vault-schema or daemon-protocol change is involved.