### PR TITLE
Expose effective watched-inbox status

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -715,6 +715,19 @@ func TestConfiguredWatchIngestsStableFilesAndRemainsObservable(t *testing.T) {
 	assert.Equal(t, "watch:sessions", got.Items[1].Name)
 	assert.Equal(t, "running", got.Items[1].Status)
 
+	out, err = runCLI(t, "watch", "list", "--json")
+	require.NoError(t, err)
+	var watches api.WatchedInboxList
+	require.NoError(t, json.Unmarshal([]byte(out), &watches))
+	require.Len(t, watches.Items, 1)
+	assert.Equal(t, "sessions", watches.Items[0].Name)
+	assert.Equal(t, source, watches.Items[0].Source)
+	assert.Equal(t, "/agents", watches.Items[0].Destination)
+	assert.Equal(t, "50ms", watches.Items[0].SettleTime)
+	assert.Equal(t, "10ms", watches.Items[0].ScanInterval)
+	require.NotNil(t, watches.Items[0].Job)
+	assert.Equal(t, "running", watches.Items[0].Job.Status)
+
 	// A configured watcher keeps a background daemon alive even when the
 	// ordinary request-idle timeout is deliberately tiny.
 	time.Sleep(100 * time.Millisecond)

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "34", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "35", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "34", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "35", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "34", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "35", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -409,6 +409,22 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	statPID := strconv.Itoa(recs[0].PID)
 	assert.NotEqual(t, batchPID, statPID)
 
+	// Protocol 34 predates effective watched-inbox inspection. Replace it
+	// before the CLI calls the new route, even when no watches are configured.
+	recs[0].Metadata["protocol_version"] = "34"
+	_, err = client.RuntimeStore(dir).Write(recs[0])
+	require.NoError(t, err)
+	out, err = run(oldBin, "watch", "list", "--json")
+	require.NoError(t, err, out)
+	var watches api.WatchedInboxList
+	require.NoError(t, json.Unmarshal([]byte(out), &watches))
+	assert.Empty(t, watches.Items)
+	recs, err = client.RuntimeStore(dir).List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	watchPID := strconv.Itoa(recs[0].PID)
+	assert.NotEqual(t, statPID, watchPID)
+
 	// Initialize the repository before making the runtime record stale: the
 	// following backup create must replace that daemon before it calls the new
 	// progress-stream endpoint.
@@ -423,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "34", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "35", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -436,7 +452,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	protocolPID := strconv.Itoa(recs[0].PID)
-	assert.NotEqual(t, statPID, protocolPID)
+	assert.NotEqual(t, watchPID, protocolPID)
 
 	// A mismatched-version start stops the stale daemon and starts its own.
 	out, err = run(newBin, "daemon", "start")

--- a/cmd/docbank/watch.go
+++ b/cmd/docbank/watch.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Inspect configured watched inboxes",
+}
+
+var watchListJSON bool
+
+var watchListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List effective watch configuration and runner status",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := client.Ensure(cmd.Context())
+		if err != nil {
+			return err
+		}
+		items, err := c.WatchedInboxes(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if watchListJSON {
+			return writeCLIJSON(cmd.OutOrStdout(), api.WatchedInboxList{Items: items})
+		}
+		return writeWatchedInboxes(cmd.OutOrStdout(), items)
+	},
+}
+
+func writeWatchedInboxes(w io.Writer, items []api.WatchedInbox) error {
+	if len(items) == 0 {
+		if _, err := fmt.Fprintln(w, "no watched inboxes configured"); err != nil {
+			return fmt.Errorf("writing empty watched-inbox list: %w", err)
+		}
+		return nil
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw,
+		"NAME\tSTATUS\tSOURCE\tDESTINATION\tSETTLE\tSCAN\tEXCLUDES\tERROR"); err != nil {
+		return fmt.Errorf("writing watched-inbox header: %w", err)
+	}
+	for _, item := range items {
+		status, problem := "unavailable", "-"
+		if item.Job != nil {
+			status = item.Job.Status
+			if item.Job.Error != "" {
+				problem = strconv.QuoteToASCII(item.Job.Error)
+			}
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+			item.Name, status, strconv.QuoteToASCII(item.Source),
+			strconv.QuoteToASCII(item.Destination), item.SettleTime,
+			item.ScanInterval, len(item.Exclude), problem); err != nil {
+			return fmt.Errorf("writing watched-inbox row: %w", err)
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("writing watched-inbox list: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	watchListCmd.Flags().BoolVar(&watchListJSON, "json", false, "emit machine-readable JSON")
+	watchCmd.AddCommand(watchListCmd)
+	rootCmd.AddCommand(watchCmd)
+}

--- a/cmd/docbank/watch_test.go
+++ b/cmd/docbank/watch_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestWriteWatchedInboxesEscapesMachineAndVirtualPaths(t *testing.T) {
+	var out bytes.Buffer
+	err := writeWatchedInboxes(&out, []api.WatchedInbox{{
+		Name: "sessions", Source: "/local/agent\nsessions",
+		Destination: "/archives/\x1b[31msessions", SettleTime: "1h0m0s",
+		ScanInterval: "1m0s", Exclude: []string{"cache/"},
+		Job: &api.Job{Status: "running"},
+	}})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), `"/local/agent\nsessions"`)
+	assert.Contains(t, out.String(), `"/archives/\x1b[31msessions"`)
+	assert.NotContains(t, out.String(), "\x1b")
+}
+
+func TestWriteWatchedInboxesExplainsEmptyConfig(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, writeWatchedInboxes(&out, nil))
+	assert.Equal(t, "no watched inboxes configured\n", out.String())
+}

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -41,6 +41,18 @@ placement. `DOCBANK_HOME=/path/to/another/vault docbank info --json` selects
 and confirms another independently owned archive without changing a global
 profile or opening its database directly.
 
+In source builds newer than v0.10.0, a workflow that depends on watched
+ingestion can inspect the daemon's effective configuration and runner state
+rather than assuming the local file is active:
+
+```bash
+docbank watch list --json
+```
+
+Each item reports the machine-local source, virtual destination, full settle
+window, scan interval, literal exclusions, and current job record. This is a
+read-only view; changing `config.toml` still requires a daemon restart.
+
 The canonical contract is generated from the running route definitions:
 
 ```bash

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -154,6 +154,12 @@ indexes supported current text content. Configured watched inboxes add one
 side of the daemon operation gate, so GC cannot retire a blob while the worker
 is reading and publishing its derived index.
 
+`docbank watch list` and authenticated `GET /api/v1/watches` join those runner
+records to the daemon's effective watched-inbox configuration. This gives
+people and agents the source, destination, settling policy, and exclusions they
+need to diagnose an archive without turning the API into a second configuration
+authority.
+
 The supervisor stops accepting work as soon as shutdown begins, cancels every
 runner, and waits before SQLite and blob storage close. Runners must honor
 their context; the wait is bounded so a defective runner cannot prevent daemon

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -55,6 +55,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / validate metadata and re-hash all blobs | Implemented |
 | `GET /storage` · `POST /storage/pack` · `POST /storage/repack` | inspect usage / pack loose blobs / compact sparse packs | Implemented |
 | `GET /jobs` | inspect daemon-owned background tasks and terminal failures | Implemented |
+| `GET /watches` | inspect effective watched-inbox configuration and runner state | Implemented after v0.10.0 |
 | `POST /backup/init` · `POST /backup/snapshots` · `POST /backup/snapshots/stream` · `GET /backup/snapshots` | initialize a repository / create with JSON or streamed progress / list snapshots | Implemented |
 
 Root-level, outside `/api/v1` and auth-exempt: `GET /health`, `GET
@@ -143,6 +144,13 @@ error.
 `error`. Records describe this daemon run only and disappear when it restarts.
 The endpoint is observation, not control: stopping a task requires stopping or
 reconfiguring the daemon feature that owns it.
+
+`GET /watches` returns `{items: [...]}` in stable watch-name order. Each item
+joins the effective machine-local source, virtual destination, settle and scan
+durations, and literal exclusions with its current `watch:<name>` job record.
+The job is omitted only when no runner has been registered, which is not an
+ordinary live-daemon state. Configuration remains file-owned: this endpoint
+does not create, edit, or restart watches.
 
 ### Path resolution: a query parameter, not a URL segment
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -881,6 +881,27 @@ until the daemon restarts. `--json` emits `{"items": [...]}` for automation.
 Every daemon registers `extract:plain-text`; configured watched inboxes add
 `watch:<name>` tasks. See [Daemon](architecture/daemon.md).
 
+## docbank watch
+
+!!! info "Release availability"
+
+    `docbank watch list` is newer than v0.10.0. Build from source to use it
+    until the next release is tagged.
+
+```
+docbank watch list [--json]
+```
+
+Lists the daemon's effective watched-inbox configuration in stable name order:
+the machine-local source, virtual-tree destination, complete settle window,
+scan interval, exclusion count, and current runner state. Human output quotes
+source and destination paths so terminal control characters cannot disguise
+them. `--json` includes the complete exclusion rules and the corresponding
+job record for agents and automation.
+
+This command is inspection only. Edit `config.toml` and restart the daemon to
+change a watch.
+
 ## docbank update
 
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,11 +170,15 @@ person edits or reverts the Docbank node while the source stays unchanged, a
 daemon restart does not overwrite that working version. Only a later byte
 change at the watched source appends another version.
 
-Watchers run as jobs named `watch:<name>`. Inspect them with `docbank jobs` or
-`GET /api/v1/jobs`; a source, destination, or read failure leaves the named job
-in the failed state and records the reason. Restart the daemon after correcting
-the problem. Per-file successes are written to the daemon log. A configured
-watch keeps a background daemon alive regardless of `idle_timeout`.
+Watchers run as jobs named `watch:<name>`. In source builds newer than v0.10.0,
+`docbank watch list` and `GET /api/v1/watches` pair each runner's state with its
+effective source, destination, timing, and exclusion policy; use `--json` when
+an agent needs the complete rules. `docbank jobs` and `GET /api/v1/jobs` remain
+the all-task view.
+A source, destination, or read failure leaves the named job in the failed state
+and records the reason. Restart the daemon after correcting the problem.
+Per-file successes are written to the daemon log. A configured watch keeps a
+background daemon alive regardless of `idle_timeout`.
 
 Inspect the durable source facts attached to an imported file with
 `docbank provenance <path-or-id>` or `GET /api/v1/nodes/{id}/provenance`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,6 +113,8 @@ current allocation and scope chains extend an externally recorded bundle.
 Daemon-owned watched inboxes recursively observe configured local directories,
 wait for stable size and modification time, preserve portable source identity,
 and append later changes to the same stable node without touching source files.
+Their effective source, destination, settling policy, exclusions, and live job
+state are inspectable together through the CLI and authenticated API.
 
 - Additional and overlapping audit scopes
   ([current workflow](usage/audited-history.md),

--- a/internal/api/routes_jobs.go
+++ b/internal/api/routes_jobs.go
@@ -6,7 +6,20 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/docbank/internal/jobs"
 )
+
+func observableJob(snapshot jobs.Snapshot) Job {
+	job := Job{
+		Name: snapshot.Name, Status: string(snapshot.Status),
+		StartedAt: snapshot.StartedAt.Format(time.RFC3339Nano), Error: snapshot.Error,
+	}
+	if snapshot.FinishedAt != nil {
+		job.FinishedAt = snapshot.FinishedAt.Format(time.RFC3339Nano)
+	}
+	return job
+}
 
 func registerJobRoutes(api huma.API, d Deps) {
 	type output struct {
@@ -21,14 +34,7 @@ func registerJobRoutes(api huma.API, d Deps) {
 			return out, nil
 		}
 		for _, snapshot := range d.Jobs.Snapshot() {
-			job := Job{
-				Name: snapshot.Name, Status: string(snapshot.Status),
-				StartedAt: snapshot.StartedAt.Format(time.RFC3339Nano), Error: snapshot.Error,
-			}
-			if snapshot.FinishedAt != nil {
-				job.FinishedAt = snapshot.FinishedAt.Format(time.RFC3339Nano)
-			}
-			out.Body.Items = append(out.Body.Items, job)
+			out.Body.Items = append(out.Body.Items, observableJob(snapshot))
 		}
 		return out, nil
 	})

--- a/internal/api/routes_watches.go
+++ b/internal/api/routes_watches.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"cmp"
+	"context"
+	"net/http"
+	"slices"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/docbank/internal/config"
+)
+
+func registerWatchRoutes(api huma.API, d Deps) {
+	type output struct {
+		Body WatchedInboxList
+	}
+	huma.Register(api, huma.Operation{
+		OperationID: "listWatchedInboxes", Method: http.MethodGet, Path: "/api/v1/watches",
+		Summary: "List effective watched-inbox configuration and runner status",
+	}, func(_ context.Context, _ *struct{}) (*output, error) {
+		watches := slices.Clone(d.Cfg.Watches)
+		slices.SortFunc(watches, func(a, b config.WatchConfig) int {
+			return cmp.Compare(a.Name, b.Name)
+		})
+		jobsByName := make(map[string]Job)
+		if d.Jobs != nil {
+			for _, snapshot := range d.Jobs.Snapshot() {
+				jobsByName[snapshot.Name] = observableJob(snapshot)
+			}
+		}
+		out := &output{Body: WatchedInboxList{Items: make([]WatchedInbox, 0, len(watches))}}
+		for _, watch := range watches {
+			item := WatchedInbox{
+				Name: watch.Name, Source: watch.Source, Destination: watch.Destination,
+				SettleTime:   watch.SettleTime.Std().String(),
+				ScanInterval: watch.ScanInterval.Std().String(),
+				Exclude:      append([]string{}, watch.Exclude...),
+			}
+			if job, ok := jobsByName["watch:"+watch.Name]; ok {
+				item.Job = &job
+			}
+			out.Body.Items = append(out.Body.Items, item)
+		}
+		return out, nil
+	})
+}

--- a/internal/api/routes_watches_test.go
+++ b/internal/api/routes_watches_test.go
@@ -1,0 +1,82 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/jobs"
+)
+
+func TestListWatchedInboxesReturnsEffectiveConfigAndRunnerState(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	supervisor := jobs.New(ctx, slog.New(slog.DiscardHandler))
+	t.Cleanup(func() { require.NoError(t, supervisor.Shutdown(context.Background())) })
+	running := make(chan struct{})
+	release := make(chan struct{})
+	require.NoError(t, supervisor.Start("watch:archive", func(ctx context.Context) error {
+		close(running)
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}))
+	<-running
+
+	source := filepath.Join(t.TempDir(), "source")
+	ts, _ := newTestServer(t, func(d *api.Deps) {
+		d.Jobs = supervisor
+		d.Cfg.Watches = []config.WatchConfig{
+			{
+				Name: "zeta", Source: filepath.Join(t.TempDir(), "later"),
+				Destination: "/later", SettleTime: config.Duration(time.Minute),
+				ScanInterval: config.Duration(time.Second),
+			},
+			{
+				Name: "archive", Source: source, Destination: "/records",
+				SettleTime:   config.Duration(2 * time.Minute),
+				ScanInterval: config.Duration(15 * time.Second),
+				Exclude:      []string{"cache/", ".DS_Store"},
+			},
+		}
+	})
+	resp, body := get(t, ts, "/api/v1/watches", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var got api.WatchedInboxList
+	require.NoError(t, json.Unmarshal([]byte(body), &got))
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, "archive", got.Items[0].Name)
+	assert.Equal(t, source, got.Items[0].Source)
+	assert.Equal(t, "/records", got.Items[0].Destination)
+	assert.Equal(t, "2m0s", got.Items[0].SettleTime)
+	assert.Equal(t, "15s", got.Items[0].ScanInterval)
+	assert.Equal(t, []string{"cache/", ".DS_Store"}, got.Items[0].Exclude)
+	require.NotNil(t, got.Items[0].Job)
+	assert.Equal(t, "watch:archive", got.Items[0].Job.Name)
+	assert.Equal(t, "running", got.Items[0].Job.Status)
+	assert.Equal(t, "zeta", got.Items[1].Name)
+	assert.Empty(t, got.Items[1].Exclude)
+	assert.Nil(t, got.Items[1].Job)
+	close(release)
+}
+
+func TestListWatchedInboxesReturnsEmptyObject(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := get(t, ts, "/api/v1/watches", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var got api.WatchedInboxList
+	require.NoError(t, json.Unmarshal([]byte(body), &got))
+	assert.Empty(t, got.Items)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -111,6 +111,7 @@ func NewServer(d Deps) *Server {
 	registerOpsRoutes(humaAPI, d, g)    // Task 7
 	registerBackupRoutes(humaAPI, d, g)
 	registerJobRoutes(humaAPI, d)
+	registerWatchRoutes(humaAPI, d)
 	registerUploadRoute(mux, humaAPI, d, g)
 	registerContentWriteRoute(mux, humaAPI, d, g)
 	registerContentRevertRoute(humaAPI, d, g)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -665,6 +665,25 @@ type JobList struct {
 	Items []Job `json:"items"`
 }
 
+// WatchedInbox is the daemon's effective configuration and current runner
+// state for one local watched source. Source is intentionally machine-local;
+// Destination is a path in the Docbank virtual tree.
+type WatchedInbox struct {
+	Name         string   `json:"name"`
+	Source       string   `json:"source"`
+	Destination  string   `json:"destination"`
+	SettleTime   string   `json:"settle_time"`
+	ScanInterval string   `json:"scan_interval"`
+	Exclude      []string `json:"exclude"`
+	Job          *Job     `json:"job,omitempty"`
+}
+
+// WatchedInboxList is returned as an object so the contract can gain
+// aggregate state without changing a top-level JSON array.
+type WatchedInboxList struct {
+	Items []WatchedInbox `json:"items"`
+}
+
 // BackupRepository identifies an initialized Kit snapshot repository.
 type BackupRepository struct {
 	ID   string `json:"id"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2512,6 +2512,14 @@ func (c *Client) Jobs(ctx context.Context) ([]api.Job, error) {
 	return out.Items, err
 }
 
+// WatchedInboxes returns effective watched-source configuration and current
+// runner state in stable name order.
+func (c *Client) WatchedInboxes(ctx context.Context) ([]api.WatchedInbox, error) {
+	var out api.WatchedInboxList
+	err := c.do(ctx, http.MethodGet, "/api/v1/watches", nil, nil, &out)
+	return out.Items, err
+}
+
 type BackupVerifyOptions struct {
 	Repo        string
 	SnapshotID  string

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -372,6 +372,13 @@ func TestJobsRoundTrip(t *testing.T) {
 	assert.Empty(t, items)
 }
 
+func TestWatchedInboxesRoundTrip(t *testing.T) {
+	c, _ := newClient(t, serverKey)
+	items, err := c.WatchedInboxes(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
 func TestStoragePackRoundTrip(t *testing.T) {
 	c, _ := newClient(t, serverKey)
 	src := filepath.Join(t.TempDir(), "pack.txt")

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "34"
+	daemonProtocolVersion = "35"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Watched inboxes are already a useful way to archive changing local files, but the only observable state today is an opaque job such as `watch:sessions running`. That does not tell a person or agent which source, destination, settling window, scan interval, or exclusions the running daemon actually accepted.

This adds the direct inspection workflow:

```console
docbank watch list
docbank watch list --json
```

Human output gives a concise, terminal-safe view of every configured inbox and its current runner. JSON exposes the complete effective policy and job record for automation. Results are sorted by stable watch name, and source paths remain behind Docbank’s authenticated local API.

This is deliberately read-only: `config.toml` remains the one configuration authority, and changing it still requires a daemon restart. No scheduler, source-specific session-completion logic, or new storage schema is introduced. The daemon protocol advances to 35 so a current CLI replaces an older process before calling the new route.