### PR TITLE
Enable multiple permanent audit scopes

### DIFF
--- a/cmd/docbank/audit.go
+++ b/cmd/docbank/audit.go
@@ -159,10 +159,18 @@ func writeAuditPreview(w io.Writer, preview api.AuditEnrollmentPreview) error {
 		fmt.Sprintf("Retained versions: %d version(s), %d logical byte(s), %d unique blob(s), %d unique byte(s)",
 			preview.VersionCount, preview.LogicalVersionBytes,
 			preview.UniqueBlobs, preview.UniqueBlobBytes),
-		fmt.Sprintf("Vault-wide permanent metadata: %d topology node(s), %d attached metadata record(s)",
-			preview.VaultTopologyNodes, preview.VaultAttachmentRecords),
 		fmt.Sprintf("Projected audit JSONL growth: %d byte(s)", preview.AuthorityJSONBytes),
 		"Baseline digest: " + preview.BaselineDigest,
+	}
+	if preview.InitialAuthority {
+		lines = append(lines,
+			fmt.Sprintf("Vault-wide permanent metadata: %d topology node(s), %d attached metadata record(s)",
+				preview.VaultTopologyNodes, preview.VaultAttachmentRecords),
+		)
+	} else {
+		lines = append(lines,
+			"Existing vault-wide audit authority remains permanently retained; this scope adds no second genesis.",
+		)
 	}
 	if preview.UnresolvedTrashOrigins > 0 {
 		lines = append(lines, fmt.Sprintf("Unresolved retained trash origins: %d",
@@ -185,10 +193,19 @@ func writeAuditPreview(w io.Writer, preview api.AuditEnrollmentPreview) error {
 }
 
 func writeAuditEnabled(w io.Writer, status api.AuditStatus) error {
-	if len(status.Scopes) != 1 {
-		return errors.New("enabled audit status does not contain exactly one first scope")
+	if status.EnabledScopeID == "" {
+		return errors.New("audit enable receipt does not identify the new scope")
 	}
-	scope := status.Scopes[0]
+	var scope api.AuditScopeStatus
+	for _, candidate := range status.Scopes {
+		if candidate.ID == status.EnabledScopeID {
+			scope = candidate
+			break
+		}
+	}
+	if scope.ID == "" {
+		return errors.New("audit enable receipt omits the new scope")
+	}
 	path := auditDisplayPath(scope.TargetPath)
 	if scope.TargetTrashed {
 		path = "(target is in trash)"

--- a/cmd/docbank/audit_test.go
+++ b/cmd/docbank/audit_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestHumanAuditOutputQuotesPaths(t *testing.T) {
 	const unsafePath = "/Taxes/\n\x1b[31mFORGED"
+	const scopeID = "11111111-1111-4111-8111-111111111111"
 	want := strconv.QuoteToASCII(unsafePath)
 	tests := []struct {
 		name  string
@@ -30,8 +31,8 @@ func TestHumanAuditOutputQuotesPaths(t *testing.T) {
 		{
 			name: "enabled",
 			write: func(w io.Writer) error {
-				return writeAuditEnabled(w, api.AuditStatus{Scopes: []api.AuditScopeStatus{{
-					TargetPath: unsafePath, TargetNodeID: 42,
+				return writeAuditEnabled(w, api.AuditStatus{EnabledScopeID: scopeID, Scopes: []api.AuditScopeStatus{{
+					ID: scopeID, TargetPath: unsafePath, TargetNodeID: 42,
 				}}})
 			},
 		},

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -313,6 +313,9 @@ func TestAuditEnableIsPreviewFirstAndReportsProtection(t *testing.T) {
 	source := writeSourceFile(t, "return.txt", "tax return")
 	_, err := runCLI(t, "add", source, "--dest", "/Taxes")
 	require.NoError(t, err)
+	contractSource := writeSourceFile(t, "contract.txt", "signed agreement")
+	_, err = runCLI(t, "add", contractSource, "--dest", "/Contracts")
+	require.NoError(t, err)
 	c, err := client.Ensure(context.Background())
 	require.NoError(t, err)
 	taxes, err := c.Stat(context.Background(), "/Taxes")
@@ -349,6 +352,21 @@ func TestAuditEnableIsPreviewFirstAndReportsProtection(t *testing.T) {
 	assert.True(t, status.Enabled)
 	require.Len(t, status.Scopes, 1)
 	assert.Equal(t, preview.ScopeID, status.Scopes[0].ID)
+
+	out, err = runCLI(t, "audit", "enable", "/Contracts", "--json")
+	require.NoError(t, err, out)
+	var secondPreview api.AuditEnrollmentPreview
+	require.NoError(t, json.Unmarshal([]byte(out), &secondPreview))
+	assert.False(t, secondPreview.InitialAuthority)
+	humanSecondPreview, err := runCLI(t, "audit", "enable", "/Contracts")
+	require.NoError(t, err, humanSecondPreview)
+	assert.Contains(t, humanSecondPreview, "this scope adds no second genesis")
+	out, err = runCLI(t, "audit", "enable", "--run", "--token", secondPreview.PreviewToken,
+		"--acknowledge-permanent-retention", "--json")
+	require.NoError(t, err, out)
+	require.NoError(t, json.Unmarshal([]byte(out), &status))
+	assert.Equal(t, secondPreview.ScopeID, status.EnabledScopeID)
+	require.Len(t, status.Scopes, 2)
 
 	out, err = runCLI(t, "audit", "status", formatNodeSelector(returnNode.ID))
 	require.NoError(t, err, out)

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "35", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "36", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "35", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "36", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "35", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "36", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "35", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "36", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -6,13 +6,13 @@ description: The permanent, tamper-evident history model for protected directory
 # Audited history
 
 !!! info "Current implementation boundary"
-    Docbank implements permanent first-scope enrollment, sticky membership,
+    Docbank implements permanent disjoint-scope enrollment, sticky membership,
     mutation and allocation chains for the supported changes described below,
     JSONL backup/restore fidelity, status inspection, and bounded per-node
     history. Independent audit verification returns stable terminal evidence
     and checks every protected blob; supplied external evidence is proved as an
-    exact prefix of current allocation and scope chains. Additional scopes,
-    scope-wide browsing, and TUI/web projections remain planned. See
+    exact prefix of current allocation and scope chains. Scope-wide browsing is
+    available; overlapping scopes and TUI/web projections remain planned. See
     [Permanent Audited History](../usage/audited-history.md) for the current
     operator workflow.
 

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -12,7 +12,10 @@ description: The permanent, tamper-evident history model for protected directory
     history. Independent audit verification returns stable terminal evidence
     and checks every protected blob; supplied external evidence is proved as an
     exact prefix of current allocation and scope chains. Scope-wide browsing is
-    available; overlapping scopes and TUI/web projections remain planned. See
+    available. A tag-definition rename or deletion whose assignments span
+    several protected scopes currently fails closed with
+    `audit_mutation_unsupported`; cross-scope attachment fan-out, overlapping
+    scopes, and TUI/web projections remain planned. See
     [Permanent Audited History](../usage/audited-history.md) for the current
     operator workflow.
 
@@ -407,6 +410,13 @@ fan-out events and audited/no-audited mutation marker. Thus an unaudited tag
 change still advances independently verifiable authority, while an omitted
 unassign/reassign or rename-away/rename-back cannot hide behind an unchanged
 final projection.
+
+!!! info "Planned cross-scope attachment fan-out"
+    The canonical model below defines how one attached-metadata change advances
+    every affected scope. The current writer and replay validator implement
+    tag-definition changes only when all audited assignments belong to one
+    scope; a rename or deletion spanning scopes fails closed until this fan-out
+    is implemented.
 
 Fan-out is derived mechanically from that simultaneous transition:
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -525,6 +525,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `audit_mutation_unsupported` | 409 | the audited vault does not yet record this logical mutation class |
 | `audit_already_enabled` | 409 | an initial-scope preview cannot execute because audit authority was enabled concurrently |
 | `audit_scope_overlap` | 409 | the proposed scope shares a live or retained-trash member with permanent protection |
+| `audit_scope_limit` | 409 | the vault already has the maximum 1,000 permanent scopes representable by terminal evidence |
 | `audit_preview_stale` | 409 | the one-use enrollment preview expired, was consumed, came from another daemon, or no longer matches the vault |
 | `audit_acknowledgment_required` | 422 | enrollment execution omitted the explicit permanent-retention acknowledgment |
 | `audit_not_enrolled` | 422 | the selected node exists but is outside every permanent audit scope |

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -523,7 +523,8 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `exists` | 409 | `store.ErrExists` (name collision) |
 | `cycle` | 409 | `store.ErrCycle` (move under own descendant) |
 | `audit_mutation_unsupported` | 409 | the audited vault does not yet record this logical mutation class |
-| `audit_already_enabled` | 409 | this vault already has its first permanent audit scope |
+| `audit_already_enabled` | 409 | an initial-scope preview cannot execute because audit authority was enabled concurrently |
+| `audit_scope_overlap` | 409 | the proposed scope shares a live or retained-trash member with permanent protection |
 | `audit_preview_stale` | 409 | the one-use enrollment preview expired, was consumed, came from another daemon, or no longer matches the vault |
 | `audit_acknowledgment_required` | 422 | enrollment execution omitted the explicit permanent-retention acknowledgment |
 | `audit_not_enrolled` | 422 | the selected node exists but is outside every permanent audit scope |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -551,10 +551,11 @@ scope head remain exact prefixes of current authority. Equal or validly extended
 chains pass; a different vault/lineage, missing scope, shorter chain, or
 divergent head is reported with a stable problem code and exits non-zero.
 
-The current public boundary supports the first scope in a vault; a later
-`audit enable` returns `audit_already_enabled`. See
-[Permanent Audited History](usage/audited-history.md) for supported mutations
-and maintenance behavior.
+The first scope creates the vault-wide genesis. On main after v0.10.0, later
+`audit enable` commands can add disjoint directory scopes without duplicating
+that genesis; overlapping or nested scopes are rejected. See
+[Permanent Audited History](usage/audited-history.md) for enrollment,
+supported mutations, and maintenance behavior.
 
 ## docbank mv
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -118,7 +118,10 @@ share a blob without sharing document identity.
     record is authoritative. Enabling the first scope revalidates the preview and commits
     the preallocated operation/lineage identities, genesis, enrollment, and
     chain authority in one SQLite transaction. A crash either commits that
-    complete state or rolls it back. The shared Go mutation boundary prevents
+    complete state or rolls it back. Later disjoint scopes reuse that genesis,
+    add one enrollment operation to the shared allocation lineage, and begin
+    independent scope chains without rewriting existing authority. The shared
+    Go mutation boundary prevents
     supported store operations from bypassing audit recording; independent
     replay catches divergent state at verification and portability boundaries.
     The enable preview

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ elsewhere only when they materially explain the design and are marked
 | 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.11.0) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
-| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, first-scope audit authority, and bounded plain-text extraction implemented; PDF/Office extraction remains |
+| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
 | 3 | Primary kit-ui web portal and focused operator TUI | Designed |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
@@ -103,8 +103,9 @@ are available across the CLI, authenticated API, typed client, OpenAPI, and
 metadata-v1 backup/restore authority, including bounded forward and reverse
 listings. Transactional batch move validates and applies bounded swaps and
 nested reorganizations as one final-state operation across the CLI, API, typed
-client, and audited history. Permanent first-scope audit enrollment is preview-first across the
-CLI and API. Sticky membership, supported logical mutations, allocation and
+client, and audited history. Permanent audit enrollment is preview-first across the
+CLI and API. The first scope creates one vault-wide genesis; later disjoint
+scopes reuse it and begin independent scope chains. Sticky membership, supported logical mutations, allocation and
 scope chains, status evidence, and JSONL backup/restore validation are
 implemented. Canonical audit history is available by node path, stable node ID,
 or stable scope ID with bounded, append-stable cursor pagination. Independent verification returns

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -215,14 +215,34 @@ Execution of `trash empty --run` and `versions prune --run` is currently
 refused once audit authority exists. Their dry runs remain useful for impact
 inspection. There is deliberately no exceptional audit-destruction command.
 
-## Current boundary
+## Multiple protected directories
 
-The current public workflow enables the first audit scope in a vault. A second
-`audit enable` returns `audit_already_enabled`; adding overlapping scopes is not
-yet exposed. Status, mutation recording, JSONL export/import, and backup capture
-all preserve the first scope's authority.
+!!! note "Available on main after v0.10.0"
+    The latest tagged release supports one scope. The next release adds the
+    disjoint multi-scope workflow described here.
+
+Run the same preview-first command for each unrelated directory whose history
+must become permanent:
+
+```bash
+docbank audit enable /taxes
+docbank audit enable --run --token <preview-token> --acknowledge-permanent-retention
+docbank audit enable /contracts
+docbank audit enable --run --token <preview-token> --acknowledge-permanent-retention
+```
+
+The first scope establishes one vault-wide genesis and allocation lineage.
+Later disjoint scopes reuse that authority, start their own scope chain, and
+add only their selected directory closure. The preview says when no second
+genesis is being created and reports the exact incremental JSONL growth.
+
+Scopes cannot overlap or nest. Docbank rejects a target when any node in its
+live or retained-trash closure is already permanently protected. Moving nodes
+between scopes and other operations that would need one transaction to rewrite
+multiple scope histories remain fail-closed. Status, history, verification,
+JSONL export/import, incremental backup, and restore preserve every scope.
 
 !!! info "Planned"
-    Additional scope enrollment and rich TUI/web history views are not
-    implemented yet. Backup restore already revalidates the portable JSONL
-    authority before publishing a vault.
+    Overlapping scopes and rich TUI/web history views are not implemented.
+    Backup restore revalidates the portable JSONL authority before publishing
+    a vault.

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -244,6 +244,13 @@ permanent scopes so every valid vault can still produce one bounded terminal
 evidence bundle. Status, history, verification,
 JSONL export/import, incremental backup, and restore preserve every scope.
 
+A tag may be assigned to documents in several protected scopes. Renaming or
+deleting that shared tag currently returns `audit_mutation_unsupported` and
+changes nothing, because one definition change would need to advance every
+affected scope atomically. To reorganize it now, unassign it from all but one
+scope before renaming, or unassign it everywhere before deletion; separate tag
+definitions avoid this cross-scope coupling.
+
 !!! info "Planned"
     Overlapping scopes and rich TUI/web history views are not implemented.
     Backup restore revalidates the portable JSONL authority before publishing

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -239,7 +239,9 @@ genesis is being created and reports the exact incremental JSONL growth.
 Scopes cannot overlap or nest. Docbank rejects a target when any node in its
 live or retained-trash closure is already permanently protected. Moving nodes
 between scopes and other operations that would need one transaction to rewrite
-multiple scope histories remain fail-closed. Status, history, verification,
+multiple scope histories remain fail-closed. A vault accepts at most 1,000
+permanent scopes so every valid vault can still produce one bounded terminal
+evidence bundle. Status, history, verification,
 JSONL export/import, incremental backup, and restore preserve every scope.
 
 !!! info "Planned"

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -77,6 +77,7 @@ var storeErrCodes = []struct {
 	{store.ErrAuditMutationUnsupported, http.StatusConflict, "audit_mutation_unsupported"},
 	{store.ErrAuditAlreadyEnabled, http.StatusConflict, "audit_already_enabled"},
 	{store.ErrAuditScopeOverlap, http.StatusConflict, "audit_scope_overlap"},
+	{store.ErrAuditScopeLimit, http.StatusConflict, "audit_scope_limit"},
 	{store.ErrAuditPreviewStale, http.StatusConflict, "audit_preview_stale"},
 	{store.ErrAuditNotEnrolled, http.StatusUnprocessableEntity, "audit_not_enrolled"},
 	{store.ErrInvalidAuditCursor, http.StatusUnprocessableEntity, "invalid_audit_cursor"},

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -76,6 +76,7 @@ var storeErrCodes = []struct {
 	{store.ErrInvalidVersionPrune, http.StatusUnprocessableEntity, "invalid_version_prune"},
 	{store.ErrAuditMutationUnsupported, http.StatusConflict, "audit_mutation_unsupported"},
 	{store.ErrAuditAlreadyEnabled, http.StatusConflict, "audit_already_enabled"},
+	{store.ErrAuditScopeOverlap, http.StatusConflict, "audit_scope_overlap"},
 	{store.ErrAuditPreviewStale, http.StatusConflict, "audit_preview_stale"},
 	{store.ErrAuditNotEnrolled, http.StatusUnprocessableEntity, "audit_not_enrolled"},
 	{store.ErrInvalidAuditCursor, http.StatusUnprocessableEntity, "invalid_audit_cursor"},

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -24,7 +24,7 @@ func registerAuditRoutes(
 	huma.Register(api, huma.Operation{
 		OperationID: "previewAuditEnrollment", Method: http.MethodPost,
 		Path:    "/api/v1/audit/preview",
-		Summary: "Preview the permanent first audit scope without changing the vault",
+		Summary: "Preview one permanent audit scope without changing the vault",
 	}, func(ctx context.Context, in *struct {
 		Body struct {
 			Path       string `json:"path,omitempty"`
@@ -71,7 +71,7 @@ func registerAuditRoutes(
 
 	huma.Register(api, huma.Operation{
 		OperationID: "enableAudit", Method: http.MethodPost, Path: "/api/v1/audit/enable",
-		Summary: "Permanently enable the exact reviewed first audit scope",
+		Summary: "Permanently enable the exact reviewed audit scope",
 		Description: "Consumes a one-use preview token. The acknowledgment explicitly " +
 			"accepts permanent protected history plus names, topology, tags, assignments, " +
 			"ingests, and provenance " +
@@ -297,7 +297,8 @@ func auditEnrollmentPreview(
 	preview store.AuditEnrollmentPreview, token string, expiresAt time.Time,
 ) AuditEnrollmentPreview {
 	return AuditEnrollmentPreview{
-		VaultID: preview.VaultID, ScopeID: preview.ScopeID,
+		InitialAuthority: preview.InitialAuthority,
+		VaultID:          preview.VaultID, ScopeID: preview.ScopeID,
 		OperationID: preview.OperationID, TargetNodeID: preview.TargetNodeID,
 		TargetPath: preview.TargetPath, BaselineDigest: preview.BaselineDigest,
 		MemberCount: preview.MemberCount, FileCount: preview.FileCount,
@@ -314,7 +315,8 @@ func auditEnrollmentPreview(
 
 func auditStatus(status store.AuditStatus) AuditStatus {
 	out := AuditStatus{
-		Enabled: status.Enabled, VaultID: status.VaultID, LineageID: status.LineageID,
+		Enabled: status.Enabled, EnabledScopeID: status.EnabledScopeID,
+		VaultID: status.VaultID, LineageID: status.LineageID,
 		OperationSequenceHighWater: status.OperationSequenceHighWater,
 		AllocationEntryCount:       status.AllocationEntryCount,
 		AllocationHead:             status.AllocationHead, Scopes: []AuditScopeStatus{},

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -176,6 +176,69 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	require.NoError(t, s.ValidateMetadata(t.Context()))
 }
 
+func TestAuditAddsASecondDisjointScope(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	contracts, err := s.Mkdir(t.Context(), s.RootID(), "Contracts")
+	require.NoError(t, err)
+	c := client.New(ts.URL, testAPIKey)
+
+	first, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: taxes.ID})
+	require.NoError(t, err)
+	assert.True(t, first.InitialAuthority)
+	_, err = c.EnableAudit(t.Context(), first.PreviewToken, true)
+	require.NoError(t, err)
+
+	second, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{Path: "/Contracts"})
+	require.NoError(t, err)
+	assert.False(t, second.InitialAuthority)
+	assert.Zero(t, second.VaultTopologyNodes)
+	assert.Zero(t, second.VaultAttachmentRecords)
+	status, err := c.EnableAudit(t.Context(), second.PreviewToken, true)
+	require.NoError(t, err)
+	assert.Equal(t, second.ScopeID, status.EnabledScopeID)
+	assert.Equal(t, int64(2), status.OperationSequenceHighWater)
+	require.Len(t, status.Scopes, 2)
+
+	taxesStatus, err := c.AuditStatus(t.Context(), "", taxes.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{first.ScopeID}, taxesStatus.Membership.ScopeIDs)
+	contractsStatus, err := c.AuditStatus(t.Context(), "", contracts.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{second.ScopeID}, contractsStatus.Membership.ScopeIDs)
+
+	nested, err := s.Mkdir(t.Context(), taxes.ID, "Nested")
+	require.NoError(t, err)
+	_, err = c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: nested.ID})
+	require.ErrorIs(t, err, store.ErrAuditScopeOverlap)
+	_, err = c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: s.RootID()})
+	require.ErrorIs(t, err, store.ErrAuditScopeOverlap)
+	_, err = c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: taxes.ID})
+	require.ErrorIs(t, err, store.ErrAuditScopeOverlap)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAdditionalAuditPreviewBecomesStaleAfterAuditedMutation(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	contracts, err := s.Mkdir(t.Context(), s.RootID(), "Contracts")
+	require.NoError(t, err)
+	c := client.New(ts.URL, testAPIKey)
+	first, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: taxes.ID})
+	require.NoError(t, err)
+	_, err = c.EnableAudit(t.Context(), first.PreviewToken, true)
+	require.NoError(t, err)
+	second, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: contracts.ID})
+	require.NoError(t, err)
+
+	_, err = s.Mkdir(t.Context(), taxes.ID, "2027")
+	require.NoError(t, err)
+	_, err = c.EnableAudit(t.Context(), second.PreviewToken, true)
+	require.ErrorIs(t, err, store.ErrAuditPreviewStale)
+}
+
 func TestAuditVerifyReturnsStableEvidenceAndChecksProtectedBytes(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	c := client.New(ts.URL, testAPIKey)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -212,9 +212,10 @@ type TagDeletionReceipt struct {
 }
 
 // AuditEnrollmentPreview is the exact permanent-retention boundary reviewed
-// before first activation. PreviewToken is daemon-local, short-lived, and
-// consumed by one enable attempt.
+// before creating one scope. InitialAuthority reports whether this scope also
+// creates the vault-wide genesis. PreviewToken is daemon-local and one-use.
 type AuditEnrollmentPreview struct {
+	InitialAuthority       bool   `json:"initial_authority"`
 	VaultID                string `json:"vault_id" format:"uuid"`
 	ScopeID                string `json:"scope_id" format:"uuid"`
 	OperationID            string `json:"operation_id" format:"uuid"`
@@ -229,7 +230,7 @@ type AuditEnrollmentPreview struct {
 	UniqueBlobs            int    `json:"unique_blobs" minimum:"0"`
 	UniqueBlobBytes        int64  `json:"unique_blob_bytes" minimum:"0"`
 	UnresolvedTrashOrigins int    `json:"unresolved_trash_origins" minimum:"0"`
-	VaultTopologyNodes     int    `json:"vault_topology_nodes" minimum:"1"`
+	VaultTopologyNodes     int    `json:"vault_topology_nodes" minimum:"0"`
 	VaultAttachmentRecords int    `json:"vault_attachment_records" minimum:"0"`
 	AuthorityJSONBytes     int64  `json:"authority_json_bytes" minimum:"1"`
 	PreviewToken           string `json:"preview_token" minLength:"43" maxLength:"43"`
@@ -264,6 +265,7 @@ type AuditMembershipStatus struct {
 // membership. Scopes is always a JSON array, including for a dormant vault.
 type AuditStatus struct {
 	Enabled                    bool                   `json:"enabled"`
+	EnabledScopeID             string                 `json:"enabled_scope_id,omitempty" format:"uuid"`
 	VaultID                    string                 `json:"vault_id" format:"uuid"`
 	LineageID                  string                 `json:"lineage_id,omitempty" format:"uuid"`
 	OperationSequenceHighWater int64                  `json:"operation_sequence_high_water" minimum:"0"`

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -264,6 +264,8 @@ func TestAuditedIncrementalSnapshotRestoresCompleteProtectedHistory(t *testing.T
 
 	records, err := fixture.metadata.Mkdir(t.Context(), fixture.metadata.RootID(), "Records")
 	require.NoError(t, err)
+	contracts, err := fixture.metadata.Mkdir(t.Context(), fixture.metadata.RootID(), "Contracts")
+	require.NoError(t, err)
 	document := writeFile(records.ID, "return.txt", "original tax return")
 	initialVersionID := document.CurrentVersionID
 	plan, err := fixture.metadata.PreviewInitialAudit(
@@ -287,6 +289,15 @@ func TestAuditedIncrementalSnapshotRestoresCompleteProtectedHistory(t *testing.T
 	)
 	require.NoError(t, err)
 	assert.Empty(t, baseline.ParentID)
+	secondPlan, err := fixture.metadata.PreviewInitialAudit(
+		t.Context(), contracts.ID, "cli", nil,
+	)
+	require.NoError(t, err)
+	secondStatus, err := fixture.metadata.EnableInitialAudit(t.Context(), secondPlan)
+	require.NoError(t, err)
+	require.Len(t, secondStatus.Scopes, 2)
+	contract := writeFile(contracts.ID, "agreement.txt", "signed agreement")
+	contractVersionID := contract.CurrentVersionID
 
 	const replacementContent = "corrected tax return"
 	var replacement store.ContentVersion
@@ -325,14 +336,17 @@ func TestAuditedIncrementalSnapshotRestoresCompleteProtectedHistory(t *testing.T
 	sourceStorage, err := fixture.blobs.Stats(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 3, int(sourceStorage.PackedBlobs))
-	assert.Equal(t, 2, sourceStorage.LooseBlobs)
+	assert.Equal(t, 3, sourceStorage.LooseBlobs)
 	wantMetadata := exportMetadata(t, fixture.metadata)
 	sourceAudit, err := fixture.metadata.VerifyAudit(t.Context(), nil)
 	require.NoError(t, err)
 	require.True(t, sourceAudit.Evidence.Enabled)
-	require.Len(t, sourceAudit.Evidence.Scopes, 1)
-	assert.Equal(t, initialStatus.Scopes[0].ID, sourceAudit.Evidence.Scopes[0].ID)
-	require.Len(t, sourceAudit.ProtectedBlobs, 3)
+	require.Len(t, sourceAudit.Evidence.Scopes, 2)
+	assert.ElementsMatch(t,
+		[]string{initialStatus.Scopes[0].ID, secondPlan.Preview().ScopeID},
+		[]string{sourceAudit.Evidence.Scopes[0].ID, sourceAudit.Evidence.Scopes[1].ID},
+	)
+	require.Len(t, sourceAudit.ProtectedBlobs, 4)
 
 	manifest, err := backupapp.Create(
 		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs,
@@ -340,7 +354,7 @@ func TestAuditedIncrementalSnapshotRestoresCompleteProtectedHistory(t *testing.T
 	)
 	require.NoError(t, err)
 	assert.Equal(t, baseline.SnapshotID, manifest.ParentID)
-	assert.Equal(t, int64(5), manifest.Attachments.Blobs)
+	assert.Equal(t, int64(6), manifest.Attachments.Blobs)
 	verified, err := backup.Verify(
 		t.Context(), repo, backupapp.New("test-version"),
 		backup.VerifyOptions{All: true, Jobs: 2},
@@ -376,9 +390,10 @@ func TestAuditedIncrementalSnapshotRestoresCompleteProtectedHistory(t *testing.T
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, restoredBlobs.Close()) })
 	for versionID, want := range map[string]string{
-		initialVersionID: "original tax return",
-		replacement.ID:   replacementContent,
-		receiptVersionID: "supporting receipt",
+		initialVersionID:  "original tax return",
+		replacement.ID:    replacementContent,
+		receiptVersionID:  "supporting receipt",
+		contractVersionID: "signed agreement",
 	} {
 		version, versionErr := restoredStore.ContentVersionByID(t.Context(), versionID)
 		require.NoError(t, versionErr)
@@ -399,6 +414,12 @@ func TestAuditedIncrementalSnapshotRestoresCompleteProtectedHistory(t *testing.T
 	require.NotNil(t, restoredStatus.Membership)
 	assert.True(t, restoredStatus.Membership.Protected)
 	assert.Equal(t, []string{initialStatus.Scopes[0].ID}, restoredStatus.Membership.ScopeIDs)
+	restoredContractStatus, err := restoredStore.AuditStatus(t.Context(), &contract.ID)
+	require.NoError(t, err)
+	require.NotNil(t, restoredContractStatus.Membership)
+	assert.True(t, restoredContractStatus.Membership.Protected)
+	assert.Equal(t, []string{secondPlan.Preview().ScopeID},
+		restoredContractStatus.Membership.ScopeIDs)
 	history, err := restoredStore.AuditHistory(t.Context(), restoredReceipt.ID, 100, "")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, history.Total, 4)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -172,6 +172,7 @@ var codeToTypedErr = map[string]error{
 	"invalid_version_prune":        store.ErrInvalidVersionPrune,
 	"audit_already_enabled":        store.ErrAuditAlreadyEnabled,
 	"audit_scope_overlap":          store.ErrAuditScopeOverlap,
+	"audit_scope_limit":            store.ErrAuditScopeLimit,
 	"audit_preview_stale":          store.ErrAuditPreviewStale,
 	"audit_not_enrolled":           store.ErrAuditNotEnrolled,
 	"invalid_audit_cursor":         store.ErrInvalidAuditCursor,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -835,6 +835,9 @@ func (c *Client) EnableAudit(
 	if !status.Enabled {
 		return api.AuditStatus{}, errors.New("audit enable response reports dormant authority")
 	}
+	if status.EnabledScopeID == "" {
+		return api.AuditStatus{}, errors.New("audit enable response lacks enabled scope identity")
+	}
 	return status, nil
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -171,6 +171,7 @@ var codeToTypedErr = map[string]error{
 	"version_already_current":      store.ErrVersionAlreadyCurrent,
 	"invalid_version_prune":        store.ErrInvalidVersionPrune,
 	"audit_already_enabled":        store.ErrAuditAlreadyEnabled,
+	"audit_scope_overlap":          store.ErrAuditScopeOverlap,
 	"audit_preview_stale":          store.ErrAuditPreviewStale,
 	"audit_not_enrolled":           store.ErrAuditNotEnrolled,
 	"invalid_audit_cursor":         store.ErrInvalidAuditCursor,
@@ -766,8 +767,8 @@ func (c *Client) SearchWithOptions(
 	return out, nil
 }
 
-// AuditPreviewOptions selects one live directory for permanent first-scope
-// enrollment. Exactly one of Path or NodeID must be supplied.
+// AuditPreviewOptions selects one live directory for permanent enrollment.
+// Exactly one of Path or NodeID must be supplied.
 type AuditPreviewOptions struct {
 	Path       string
 	NodeID     int64
@@ -1193,7 +1194,10 @@ func validateAuditPreview(preview api.AuditEnrollmentPreview) error {
 		preview.UniqueBlobs < 0 || preview.UniqueBlobs > preview.VersionCount ||
 		preview.UniqueBlobBytes < 0 || preview.UniqueBlobBytes > preview.LogicalVersionBytes ||
 		preview.UnresolvedTrashOrigins < 0 || preview.UnresolvedTrashOrigins > preview.MemberCount ||
-		preview.VaultTopologyNodes < preview.MemberCount || preview.VaultAttachmentRecords < 0 ||
+		preview.VaultTopologyNodes < 0 || preview.VaultAttachmentRecords < 0 ||
+		(preview.InitialAuthority && preview.VaultTopologyNodes < preview.MemberCount) ||
+		(!preview.InitialAuthority && (preview.VaultTopologyNodes != 0 ||
+			preview.VaultAttachmentRecords != 0)) ||
 		preview.AuthorityJSONBytes < 1 || tokenErr != nil || len(secret) != 32 ||
 		timeErr != nil || expiresAt.Location() != time.UTC {
 		return errors.New("audit preview response has inconsistent authority or inventory")
@@ -1207,7 +1211,7 @@ func validateAuditStatus(status api.AuditStatus) error {
 		return errors.New("audit status has invalid vault identity or counters")
 	}
 	if !status.Enabled {
-		if status.LineageID != "" || status.OperationSequenceHighWater != 0 ||
+		if status.EnabledScopeID != "" || status.LineageID != "" || status.OperationSequenceHighWater != 0 ||
 			status.AllocationEntryCount != 0 || status.AllocationHead != "" || len(status.Scopes) != 0 {
 			return errors.New("dormant audit status contains active authority")
 		}
@@ -1232,6 +1236,14 @@ func validateAuditStatus(status api.AuditStatus) error {
 			targetNodeID: scope.TargetNodeID, baselineDigest: scope.BaselineDigest,
 		}
 		previousScopeID = scope.ID
+	}
+	if status.EnabledScopeID != "" {
+		if !validUUIDv4(status.EnabledScopeID) {
+			return errors.New("audit status has invalid enabled scope identity")
+		}
+		if _, ok := seen[status.EnabledScopeID]; !ok {
+			return errors.New("audit status enabled scope is absent from authority")
+		}
 	}
 	if status.Membership != nil {
 		member := status.Membership

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -258,6 +258,31 @@ func TestAuditStatusBindsOnlyScopeTargetToEnrollmentBaseline(t *testing.T) {
 	}
 }
 
+func TestEnableAuditRequiresEnabledScopeIdentity(t *testing.T) {
+	status := api.AuditStatus{
+		Enabled:                    true,
+		VaultID:                    "11111111-1111-4111-8111-111111111111",
+		LineageID:                  "22222222-2222-4222-8222-222222222222",
+		OperationSequenceHighWater: 1,
+		AllocationEntryCount:       1,
+		AllocationHead:             strings.Repeat("a", 64),
+		Scopes: []api.AuditScopeStatus{{
+			ID: "33333333-3333-4333-8333-333333333333", TargetNodeID: 7,
+			TargetPath:        "/Taxes",
+			EnableOperationID: "44444444-4444-4444-8444-444444444444",
+			BaselineDigest:    strings.Repeat("b", 64), MemberCount: 1,
+			EntryCount: 1, ChainHead: strings.Repeat("c", 64),
+		}},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(status)
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := client.New(ts.URL, "key").EnableAudit(t.Context(), "preview-token", true)
+	require.ErrorContains(t, err, "lacks enabled scope identity")
+}
+
 func TestTagRoundTrip(t *testing.T) {
 	c, s := newClient(t, serverKey)
 	ctx := t.Context()

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "35"
+	daemonProtocolVersion = "36"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/audit_content_replace.go
+++ b/internal/store/audit_content_replace.go
@@ -13,6 +13,7 @@ import (
 type auditAuthorityState struct {
 	lineageID       string
 	sequence        int64
+	genesisDigest   string
 	allocationCount int64
 	allocationHead  string
 }
@@ -119,8 +120,9 @@ func loadAuditAuthorityTx(
 ) (auditAuthorityState, int64, error) {
 	var authority auditAuthorityState
 	err := tx.QueryRowContext(ctx, `SELECT lineage_id,operation_sequence_high_water,
-		allocation_entry_count,allocation_head FROM audit_authority WHERE singleton=1`).Scan(
-		&authority.lineageID, &authority.sequence,
+		allocation_genesis_digest,allocation_entry_count,allocation_head
+		FROM audit_authority WHERE singleton=1`).Scan(
+		&authority.lineageID, &authority.sequence, &authority.genesisDigest,
 		&authority.allocationCount, &authority.allocationHead,
 	)
 	if err != nil {

--- a/internal/store/audit_enrollment.go
+++ b/internal/store/audit_enrollment.go
@@ -38,6 +38,17 @@ type initialAuditEnrollmentSet struct {
 	allocationHead          string
 }
 
+type additionalAuditEnrollmentSet struct {
+	input          initialAuditEnrollmentInput
+	authority      auditAuthorityState
+	nodeSequence   int64
+	members        []uint64
+	records        []audit.Record
+	baselineDigest string
+	scopeHead      string
+	allocationHead string
+}
+
 type initialAuditValues struct {
 	vaultID, scopeID, operationID, lineageID audit.Value
 	recordedAt, origin, agentLabel           audit.Value
@@ -182,7 +193,7 @@ func buildInitialAuditEnrollment(
 	eventWrapper := audit.Record{Kind: auditEventField, Fields: []audit.Field{
 		{Name: auditEventField, Value: audit.Nested(event)},
 	}}
-	mutation := makeInitialAuditMutation(values, auditTargetNodeID, baselineDigest, event)
+	mutation := makeAuditEnrollmentMutation(values, 1, auditTargetNodeID, baselineDigest, event)
 	mutationDigest, err := hashAuditRecord(mutation)
 	if err != nil {
 		return initialAuditEnrollmentSet{}, err
@@ -218,6 +229,149 @@ func buildInitialAuditEnrollment(
 		scopeHead:               scopeHead.text,
 		allocationHead:          allocationHead.text,
 	}, nil
+}
+
+func buildAdditionalAuditEnrollment(
+	ctx context.Context, tx *sql.Tx, vaultID string, input initialAuditEnrollmentInput,
+) (additionalAuditEnrollmentSet, error) {
+	authority, nodeSequence, err := loadAuditAuthorityTx(ctx, tx)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	if input.lineageID != authority.lineageID {
+		return additionalAuditEnrollmentSet{}, errors.New("audit enrollment lineage changed")
+	}
+	values, err := makeInitialAuditValues(vaultID, input)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	if input.targetNodeID <= 0 {
+		return additionalAuditEnrollmentSet{}, fmt.Errorf(
+			"audit enrollment target %d must be positive", input.targetNodeID,
+		)
+	}
+	targetNodeID := uint64(input.targetNodeID)
+	topology, err := currentAuditTopology(ctx, tx)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	attachments, err := currentAuditAttachments(ctx, tx)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	members, err := deriveInitialAuditMembers(ctx, tx, targetNodeID)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	if err := requireDisjointAuditMembers(ctx, tx, members); err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	states, err := currentAuditMemberStates(ctx, tx, members)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	versions, err := currentAuditVersions(ctx, tx, members)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	baselineAttachments, err := auditRecordsForNodes(attachments, auditMemberSet(members))
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	baselineNodes, witnesses, err := initialBaselineTopology(topology, members, input.operationID)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	baseline := makeInitialAuditBaseline(values, targetNodeID, members,
+		states, versions, baselineAttachments, baselineNodes, witnesses)
+	baselineDigest, err := hashAuditRecord(baseline)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	event, err := makeInitialAuditEnrollmentEvent(values, targetNodeID, baselineDigest, states)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	eventWrapper := audit.Record{Kind: auditEventField, Fields: []audit.Field{
+		{Name: auditEventField, Value: audit.Nested(event)},
+	}}
+	operationSequence, err := nextAuditInteger("operation sequence", authority.sequence)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	auditOperationSequence, err := positiveAuditInteger("operation sequence", operationSequence)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	mutation := makeAuditEnrollmentMutation(
+		values, auditOperationSequence, targetNodeID, baselineDigest, event,
+	)
+	mutationDigest, err := hashAuditRecord(mutation)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	scopeEntry := audit.Record{Kind: "scope_chain_entry", Fields: []audit.Field{
+		{Name: auditVaultIDField, Value: values.vaultID},
+		{Name: auditScopeIDField, Value: values.scopeID},
+		{Name: "entry_count", Value: audit.Unsigned(1)},
+		{Name: "previous_head", Value: audit.Absent()},
+		{Name: "mutation_hash", Value: mutationDigest.value},
+	}}
+	scopeHead, err := hashAuditRecord(scopeEntry)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	mutationValues := auditedMutationValues{
+		vaultID: values.vaultID, lineageID: values.lineageID,
+		operationID: values.operationID, recordedAt: values.recordedAt,
+		origin: values.origin,
+	}
+	allocation, err := makeAuditAllocationEntry(
+		mutationValues, operationSequence, nodeSequence,
+		authority.allocationHead, mutationDigest.value,
+	)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	allocationHead, err := hashAuditRecord(allocation)
+	if err != nil {
+		return additionalAuditEnrollmentSet{}, err
+	}
+	return additionalAuditEnrollmentSet{
+		input: input, authority: authority, nodeSequence: nodeSequence, members: members,
+		records:        []audit.Record{baseline, eventWrapper, mutation, scopeEntry, allocation},
+		baselineDigest: baselineDigest.text, scopeHead: scopeHead.text,
+		allocationHead: allocationHead.text,
+	}, nil
+}
+
+func requireDisjointAuditMembers(
+	ctx context.Context, tx metadataQuerier, members []uint64,
+) error {
+	wanted := auditMemberSet(members)
+	rows, err := tx.QueryContext(ctx,
+		`SELECT scope_id,node_id FROM audit_memberships ORDER BY scope_id,node_id`)
+	if err != nil {
+		return fmt.Errorf("reading existing audit memberships: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var scopeID string
+		var nodeID uint64
+		if err := rows.Scan(&scopeID, &nodeID); err != nil {
+			return fmt.Errorf("scanning existing audit membership: %w", err)
+		}
+		if wanted[nodeID] {
+			return fmt.Errorf(
+				"node %d is already protected by scope %s: %w",
+				nodeID, scopeID, ErrAuditScopeOverlap,
+			)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("reading existing audit memberships: %w", err)
+	}
+	return nil
 }
 
 type auditRecordHash struct {
@@ -367,9 +521,9 @@ func makeInitialAuditEnrollmentEvent(
 	}}, nil
 }
 
-func makeInitialAuditMutation(
-	values initialAuditValues, targetNodeID uint64, baselineDigest auditRecordHash,
-	event audit.Record,
+func makeAuditEnrollmentMutation(
+	values initialAuditValues, operationSequence uint64, targetNodeID uint64,
+	baselineDigest auditRecordHash, event audit.Record,
 ) audit.Record {
 	binding := audit.Record{Kind: "baseline_binding", Fields: []audit.Field{
 		{Name: auditScopeIDField, Value: values.scopeID},
@@ -378,7 +532,7 @@ func makeInitialAuditMutation(
 	}}
 	return audit.Record{Kind: "canonical_mutation", Fields: []audit.Field{
 		{Name: auditVaultIDField, Value: values.vaultID},
-		{Name: "operation_sequence", Value: audit.Unsigned(1)},
+		{Name: "operation_sequence", Value: audit.Unsigned(operationSequence)},
 		{Name: auditOperationIDField, Value: values.operationID},
 		{Name: "grouping_id", Value: audit.Absent()},
 		{Name: auditRecordedAtField, Value: values.recordedAt},
@@ -455,6 +609,49 @@ func persistInitialAuditEnrollment(
 			input.scopeID, member, set.baselineDigest); err != nil {
 			return fmt.Errorf("creating audit membership for node %d: %w", member, err)
 		}
+	}
+	return nil
+}
+
+func persistAdditionalAuditEnrollment(
+	ctx context.Context, tx *sql.Tx, set additionalAuditEnrollmentSet,
+) error {
+	for _, record := range set.records {
+		if err := insertAuditRecord(ctx, tx, record); err != nil {
+			return err
+		}
+	}
+	input := set.input
+	if _, err := tx.ExecContext(ctx, `INSERT INTO audit_scopes(
+		scope_id,target_node_id,enable_operation_id,entry_count,chain_head)
+		VALUES(?,?,?,1,?)`, input.scopeID, input.targetNodeID,
+		input.operationID, set.scopeHead); err != nil {
+		return fmt.Errorf("creating additional audit scope: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO audit_baselines(
+		digest,scope_id,target_node_id,operation_id) VALUES(?,?,?,?)`,
+		set.baselineDigest, input.scopeID, input.targetNodeID, input.operationID); err != nil {
+		return fmt.Errorf("creating additional audit baseline projection: %w", err)
+	}
+	for _, member := range set.members {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO audit_memberships(
+			scope_id,node_id,baseline_digest) VALUES(?,?,?)`,
+			input.scopeID, member, set.baselineDigest); err != nil {
+			return fmt.Errorf("creating additional audit membership for node %d: %w", member, err)
+		}
+	}
+	nextSequence, err := nextAuditInteger("operation sequence", set.authority.sequence)
+	if err != nil {
+		return err
+	}
+	nextCount, err := nextAuditInteger("allocation entry count", set.authority.allocationCount)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE audit_authority SET
+		operation_sequence_high_water=?,allocation_entry_count=?,allocation_head=?
+		WHERE singleton=1`, nextSequence, nextCount, set.allocationHead); err != nil {
+		return fmt.Errorf("advancing audit authority for additional scope: %w", err)
 	}
 	return nil
 }

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -261,6 +261,16 @@ type auditedHistoryReplay struct {
 	nodeHighWater    uint64
 	baselines        map[string]auditBaselineProjection
 	memberBaselines  map[uint64]string
+	scopes           map[string]*auditScopeReplay
+}
+
+type auditScopeReplay struct {
+	projection      initialAuditScope
+	members         []uint64
+	memberSet       map[uint64]bool
+	memberBaselines map[uint64]string
+	head            string
+	entryCount      int64
 }
 
 type auditBaselineProjection struct {
@@ -270,7 +280,7 @@ type auditBaselineProjection struct {
 
 func validateAuditedHistory(
 	ctx context.Context, tx metadataQuerier, vaultID string, nodeSequence int64,
-	authority initialAuditAuthority, scope initialAuditScope,
+	authority initialAuditAuthority, scopes []initialAuditScope, scope initialAuditScope,
 	records, initial map[string][]storedAuditRecord,
 ) error {
 	if err := validateStoredAuditRecordSchemas(records); err != nil {
@@ -290,7 +300,7 @@ func validateAuditedHistory(
 	if err != nil {
 		return err
 	}
-	entries, err := auditScopeRecordsByCount(records["scope_chain_entry"], scope)
+	entries, err := auditScopeRecordsByScope(records["scope_chain_entry"], scopes)
 	if err != nil {
 		return err
 	}
@@ -319,10 +329,6 @@ func validateAuditedHistory(
 			}
 			continue
 		}
-		scopeEntry, ok := entries[replay.scopeEntryCount+1]
-		if !ok {
-			return fmt.Errorf("validating audit operation %d: audit scope chain is incomplete", sequence)
-		}
 		bindings, bindingErr := auditRecordListField(mutation.record, "baselines")
 		if bindingErr != nil {
 			return fmt.Errorf("validating audit operation %d: %w", sequence, bindingErr)
@@ -330,6 +336,27 @@ func validateAuditedHistory(
 		topologyValue, topologyErr := auditField(mutation.record, auditTopologyDeltaField)
 		if topologyErr != nil {
 			return fmt.Errorf("validating audit operation %d: %w", sequence, topologyErr)
+		}
+		mutationScopeID, scopeErr := auditMutationScopeID(mutation.record)
+		if scopeErr != nil {
+			return fmt.Errorf("validating audit operation %d: %w", sequence, scopeErr)
+		}
+		if len(bindings) != 0 && topologyValue.IsAbsent() && replay.scopes[mutationScopeID] == nil {
+			err = replay.applyAdditionalScopeEnrollment(
+				vaultID, mutation, allocation, scopes, entries, baselines, events,
+				usedBaselines, usedEvents,
+			)
+			if err != nil {
+				return fmt.Errorf("validating audit operation %d: %w", sequence, err)
+			}
+			continue
+		}
+		if err := replay.activateScope(mutationScopeID); err != nil {
+			return fmt.Errorf("validating audit operation %d: %w", sequence, err)
+		}
+		scopeEntry, ok := entries[mutationScopeID][replay.scopeEntryCount+1]
+		if !ok {
+			return fmt.Errorf("validating audit operation %d: audit scope chain is incomplete", sequence)
 		}
 		if len(bindings) == 0 && topologyValue.IsAbsent() {
 			attachedCount, attachedErr := auditUnsignedField(
@@ -416,8 +443,13 @@ func validateAuditedHistory(
 	if authority.sequence != replay.allocationCount || authority.allocationHead != replay.allocationHead {
 		return errors.New("audit allocation authority does not match replayed history")
 	}
-	if scope.entryCount != replay.scopeEntryCount || scope.chainHead != replay.scopeHead {
-		return errors.New("audit scope authority does not match replayed history")
+	replay.saveActiveScope()
+	for _, projection := range scopes {
+		replayed := replay.scopes[projection.scopeID]
+		if replayed == nil || projection.entryCount != replayed.entryCount ||
+			projection.chainHead != replayed.head {
+			return errors.New("audit scope authority does not match replayed history")
+		}
 	}
 	finalNodeHighWater, err := positiveAuditNodeID(nodeSequence)
 	if err != nil {
@@ -427,6 +459,200 @@ func validateAuditedHistory(
 		return errors.New("audit node allocation high-water mark does not match replayed history")
 	}
 	return replay.reconcileCurrentState(ctx, tx)
+}
+
+func (replay *auditedHistoryReplay) applyAdditionalScopeEnrollment(
+	vaultID string, mutation, allocation storedAuditRecord,
+	projections []initialAuditScope,
+	entries map[string]map[int64]storedAuditRecord,
+	baselines map[string]storedAuditRecord,
+	events map[string]storedAuditRecord,
+	usedBaselines, usedEvents map[string]bool,
+) error {
+	bindings, err := auditRecordListField(mutation.record, "baselines")
+	if err != nil || len(bindings) != 1 {
+		return errors.New("additional audit enrollment must bind one baseline")
+	}
+	scopeID, err := auditUUIDField(bindings[0], auditScopeIDField)
+	if err != nil {
+		return err
+	}
+	var scope initialAuditScope
+	for _, candidate := range projections {
+		if candidate.scopeID == scopeID {
+			scope = candidate
+			break
+		}
+	}
+	if scope.scopeID == "" || replay.scopes[scopeID] != nil {
+		return errors.New("additional audit enrollment has an invalid scope projection")
+	}
+	baselineDigest, err := auditDigestField(bindings[0], "baseline_digest")
+	if err != nil {
+		return err
+	}
+	baseline, ok := baselines[baselineDigest]
+	if !ok || usedBaselines[baselineDigest] {
+		return errors.New("additional audit enrollment lacks one unique baseline")
+	}
+	if err := validateAuditEnrollmentBaseline(
+		vaultID, scope, baseline, replay.topology, replay.attachments,
+	); err != nil {
+		return err
+	}
+	members, err := auditUnsignedListField(baseline.record, "members")
+	if err != nil {
+		return err
+	}
+	for _, member := range members {
+		for existingScopeID, existing := range replay.scopes {
+			if existing.memberSet[member] {
+				return fmt.Errorf("additional audit scope overlaps scope %s at node %d", existingScopeID, member)
+			}
+		}
+	}
+	eventList, err := auditRecordListField(mutation.record, "events")
+	if err != nil || len(eventList) != 1 {
+		return errors.New("additional audit enrollment must contain one event")
+	}
+	eventID, err := auditDigestField(eventList[0], "event_id")
+	if err != nil {
+		return err
+	}
+	eventWrapper, ok := events[eventID]
+	if !ok || usedEvents[eventID] {
+		return errors.New("additional audit enrollment lacks one unique event wrapper")
+	}
+	wrapped, err := auditNestedField(eventWrapper.record, auditEventField)
+	if err != nil || !auditRecordEqual(wrapped, eventList[0]) {
+		return errors.New("additional audit event wrapper does not match its mutation")
+	}
+	sequence, err := positiveAuditInteger("operation sequence", *mutation.index.operationSequence)
+	if err != nil {
+		return err
+	}
+	if err := validateAuditEnrollmentMutation(
+		vaultID, scope, baseline, eventWrapper, mutation, sequence,
+	); err != nil {
+		return err
+	}
+	scopeEntry, ok := entries[scopeID][1]
+	if !ok {
+		return errors.New("additional audit scope lacks its initial chain entry")
+	}
+	if err := validateInitialScopeChain(vaultID, scope, mutation, scopeEntry); err != nil {
+		return err
+	}
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	if operationID != scope.operationID {
+		return errors.New("additional audit scope operation does not match its projection")
+	}
+	if err := replay.advanceAllocation(vaultID, operationID, mutation, allocation, "", 0); err != nil {
+		return err
+	}
+	states, err := auditRecordListField(baseline.record, "member_states")
+	if err != nil {
+		return err
+	}
+	versions, err := auditRecordListField(baseline.record, "versions")
+	if err != nil {
+		return err
+	}
+	memberBaselines := make(map[uint64]string, len(members))
+	for _, member := range members {
+		memberBaselines[member] = baselineDigest
+	}
+	for _, state := range states {
+		nodeID, err := auditUnsignedField(state, metadataNodeIDField)
+		if err != nil {
+			return err
+		}
+		if _, exists := replay.states[nodeID]; exists {
+			return fmt.Errorf("additional audit enrollment repeats protected node %d", nodeID)
+		}
+		replay.states[nodeID] = state
+	}
+	for _, version := range versions {
+		versionID, err := auditUUIDField(version, "version_id")
+		if err != nil {
+			return err
+		}
+		if _, exists := replay.versions[versionID]; exists {
+			return fmt.Errorf("additional audit enrollment repeats protected version %s", versionID)
+		}
+		replay.versions[versionID] = version
+	}
+	replay.baselines[baselineDigest] = auditBaselineProjection{
+		scopeID: scopeID, operationID: operationID, targetNodeID: scope.targetNodeID,
+	}
+	replay.scopes[scopeID] = &auditScopeReplay{
+		projection: scope, members: slices.Clone(members), memberSet: auditMemberSet(members),
+		memberBaselines: memberBaselines, head: scopeEntry.digest, entryCount: 1,
+	}
+	usedBaselines[baselineDigest] = true
+	usedEvents[eventID] = true
+	return replay.activateScope(scopeID)
+}
+
+func validateAuditEnrollmentBaseline(
+	vaultID string, scope initialAuditScope, baseline storedAuditRecord,
+	topology []audit.Record, attachments map[string]audit.Record,
+) error {
+	checks := []func() error{
+		func() error { return requireAuditUUID(baseline.record, auditVaultIDField, vaultID) },
+		func() error { return requireAuditUUID(baseline.record, auditScopeIDField, scope.scopeID) },
+		func() error { return requireAuditUnsigned(baseline.record, "target_node_id", scope.targetNodeID) },
+		func() error { return requireAuditUUID(baseline.record, auditOperationIDField, scope.operationID) },
+		func() error { return requireAuditText(baseline.record, "cause", "explicit") },
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	members, err := auditUnsignedListField(baseline.record, "members")
+	if err != nil {
+		return err
+	}
+	expectedMembers, err := deriveInitialAuditMembersFromRecords(topology, scope.targetNodeID)
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(members, expectedMembers) {
+		return errors.New("additional audit enrollment members do not match the protected closure")
+	}
+	states, err := auditRecordListField(baseline.record, "member_states")
+	if err != nil {
+		return err
+	}
+	versions, err := auditRecordListField(baseline.record, "versions")
+	if err != nil {
+		return err
+	}
+	if err := validateInitialAuditMemberProjection(members, topology, states, versions); err != nil {
+		return err
+	}
+	allAttachments := make([]audit.Record, 0, len(attachments))
+	for _, record := range attachments {
+		allAttachments = append(allAttachments, record)
+	}
+	expectedAttachments, err := auditRecordsForNodes(allAttachments, auditMemberSet(members))
+	if err != nil {
+		return err
+	}
+	storedAttachments, err := auditRecordListField(baseline.record, "attachments")
+	if err != nil {
+		return err
+	}
+	if !equalAuditRecordLists(storedAttachments, expectedAttachments) {
+		return errors.New("additional audit enrollment attachments do not match replayed metadata")
+	}
+	return validateInitialBaselineTopology(
+		baseline.record, members, scope.operationID, topology,
+	)
 }
 
 const (
@@ -572,6 +798,7 @@ func newAuditedHistoryReplay(
 			},
 		},
 		memberBaselines: make(map[uint64]string, len(members)),
+		scopes:          make(map[string]*auditScopeReplay),
 	}
 	for _, member := range members {
 		replay.memberBaselines[member] = initialBaseline.digest
@@ -614,7 +841,43 @@ func newAuditedHistoryReplay(
 		}
 		replay.topologyIndex[nodeID] = index
 	}
+	replay.saveActiveScope()
+	replay.scopes[scope.scopeID].projection = scope
 	return replay, nil
+}
+
+func (replay *auditedHistoryReplay) saveActiveScope() {
+	if replay.scopeID == "" {
+		return
+	}
+	current := replay.scopes[replay.scopeID]
+	if current == nil {
+		current = &auditScopeReplay{projection: initialAuditScope{scopeID: replay.scopeID}}
+		replay.scopes[replay.scopeID] = current
+	}
+	current.members = slices.Clone(replay.members)
+	current.memberSet = replay.memberSet
+	current.memberBaselines = replay.memberBaselines
+	current.head = replay.scopeHead
+	current.entryCount = replay.scopeEntryCount
+}
+
+func (replay *auditedHistoryReplay) activateScope(scopeID string) error {
+	if replay.scopeID == scopeID {
+		return nil
+	}
+	replay.saveActiveScope()
+	next := replay.scopes[scopeID]
+	if next == nil {
+		return fmt.Errorf("audit mutation references unknown scope %s", scopeID)
+	}
+	replay.scopeID = scopeID
+	replay.members = slices.Clone(next.members)
+	replay.memberSet = next.memberSet
+	replay.memberBaselines = next.memberBaselines
+	replay.scopeHead = next.head
+	replay.scopeEntryCount = next.entryCount
+	return nil
 }
 
 func validateGenesisProvenanceIngests(attachments []audit.Record) error {
@@ -698,6 +961,78 @@ func auditScopeRecordsByCount(
 		return nil, errors.New("audit scope chain is incomplete")
 	}
 	return result, nil
+}
+
+func auditScopeRecordsByScope(
+	records []storedAuditRecord, scopes []initialAuditScope,
+) (map[string]map[int64]storedAuditRecord, error) {
+	projections := make(map[string]initialAuditScope, len(scopes))
+	result := make(map[string]map[int64]storedAuditRecord, len(scopes))
+	for _, scope := range scopes {
+		if scope.scopeID == "" || scope.entryCount < 1 {
+			return nil, errors.New("audit scope projection has invalid identity or entry count")
+		}
+		if _, exists := projections[scope.scopeID]; exists {
+			return nil, errors.New("audit scope projection repeats an identity")
+		}
+		projections[scope.scopeID] = scope
+		result[scope.scopeID] = make(map[int64]storedAuditRecord, scope.entryCount)
+	}
+	for _, record := range records {
+		if record.index.scopeID == nil || record.index.entryCount == nil {
+			return nil, errors.New("audit scope-chain record lacks relational identity")
+		}
+		scopeID, count := *record.index.scopeID, *record.index.entryCount
+		projection, ok := projections[scopeID]
+		if !ok || count < 1 || count > projection.entryCount ||
+			result[scopeID][count].record.Kind != "" {
+			return nil, errors.New("audit scope-chain record has invalid or duplicate identity")
+		}
+		result[scopeID][count] = record
+	}
+	for scopeID, projection := range projections {
+		if int64(len(result[scopeID])) != projection.entryCount {
+			return nil, fmt.Errorf("audit scope chain %s is incomplete", scopeID)
+		}
+	}
+	return result, nil
+}
+
+func auditMutationScopeID(mutation audit.Record) (string, error) {
+	var scopeID string
+	consider := func(record audit.Record) error {
+		candidate, err := auditUUIDField(record, auditScopeIDField)
+		if err != nil {
+			return err
+		}
+		if scopeID != "" && scopeID != candidate {
+			return errors.New("audit mutation spans multiple scopes")
+		}
+		scopeID = candidate
+		return nil
+	}
+	bindings, err := auditRecordListField(mutation, "baselines")
+	if err != nil {
+		return "", err
+	}
+	for _, binding := range bindings {
+		if err := consider(binding); err != nil {
+			return "", err
+		}
+	}
+	events, err := auditRecordListField(mutation, "events")
+	if err != nil {
+		return "", err
+	}
+	for _, event := range events {
+		if err := consider(event); err != nil {
+			return "", err
+		}
+	}
+	if scopeID == "" {
+		return "", errors.New("audited mutation has no scope identity")
+	}
+	return scopeID, nil
 }
 
 func auditEventRecordsByID(records []storedAuditRecord) (map[string]storedAuditRecord, error) {
@@ -1172,21 +1507,29 @@ func replaceAuditRecordField(record audit.Record, name string, value audit.Value
 func (replay *auditedHistoryReplay) reconcileCurrentState(
 	ctx context.Context, tx metadataQuerier,
 ) error {
+	replay.saveActiveScope()
 	if err := replay.reconcileMembershipProjection(ctx, tx); err != nil {
 		return err
 	}
-	currentStates, err := currentAuditMemberStates(ctx, tx, replay.members)
+	memberSet := make(map[uint64]bool)
+	for _, scope := range replay.scopes {
+		for _, member := range scope.members {
+			memberSet[member] = true
+		}
+	}
+	allMembers := sortedAuditMembers(memberSet)
+	currentStates, err := currentAuditMemberStates(ctx, tx, allMembers)
 	if err != nil {
 		return err
 	}
-	expectedStates := make([]audit.Record, len(replay.members))
-	for index, member := range replay.members {
+	expectedStates := make([]audit.Record, len(allMembers))
+	for index, member := range allMembers {
 		expectedStates[index] = replay.states[member]
 	}
 	if !equalAuditRecordLists(expectedStates, currentStates) {
 		return errors.New("replayed audit member states do not match current nodes")
 	}
-	currentVersions, err := currentAuditVersions(ctx, tx, replay.members)
+	currentVersions, err := currentAuditVersions(ctx, tx, allMembers)
 	if err != nil {
 		return err
 	}
@@ -1221,29 +1564,33 @@ func (replay *auditedHistoryReplay) reconcileCurrentState(
 func (replay *auditedHistoryReplay) reconcileMembershipProjection(
 	ctx context.Context, tx metadataQuerier,
 ) error {
-	rows, err := tx.QueryContext(ctx, `SELECT node_id,baseline_digest FROM audit_memberships
-		WHERE scope_id=? ORDER BY node_id`, replay.scopeID)
+	rows, err := tx.QueryContext(ctx, `SELECT scope_id,node_id,baseline_digest
+		FROM audit_memberships ORDER BY scope_id,node_id`)
 	if err != nil {
 		return fmt.Errorf("reading replayed audit memberships: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	var members []uint64
+	members := make(map[string][]uint64, len(replay.scopes))
 	for rows.Next() {
+		var scopeID string
 		var nodeID uint64
 		var baseline string
-		if err := rows.Scan(&nodeID, &baseline); err != nil {
+		if err := rows.Scan(&scopeID, &nodeID, &baseline); err != nil {
 			return fmt.Errorf("scanning replayed audit membership: %w", err)
 		}
-		if replay.memberBaselines[nodeID] != baseline {
+		scope := replay.scopes[scopeID]
+		if scope == nil || scope.memberBaselines[nodeID] != baseline {
 			return fmt.Errorf("audit membership for node %d does not match replayed baseline", nodeID)
 		}
-		members = append(members, nodeID)
+		members[scopeID] = append(members[scopeID], nodeID)
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("reading replayed audit memberships: %w", err)
 	}
-	if !slices.Equal(members, replay.members) {
-		return errors.New("audit membership projection does not match replayed history")
+	for scopeID, scope := range replay.scopes {
+		if !slices.Equal(members[scopeID], scope.members) {
+			return errors.New("audit membership projection does not match replayed history")
+		}
 	}
 	baselineRows, err := tx.QueryContext(ctx, `SELECT digest,scope_id,target_node_id,operation_id
 		FROM audit_baselines ORDER BY digest`)

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -976,7 +976,10 @@ func auditScopeRecordsByScope(
 			return nil, errors.New("audit scope projection repeats an identity")
 		}
 		projections[scope.scopeID] = scope
-		result[scope.scopeID] = make(map[int64]storedAuditRecord, scope.entryCount)
+		// entryCount comes from imported metadata and is not trusted until the
+		// observed chain records below prove it. Let the map grow only with
+		// records that actually exist instead of allocating from that claim.
+		result[scope.scopeID] = make(map[int64]storedAuditRecord)
 	}
 	for _, record := range records {
 		if record.index.scopeID == nil || record.index.entryCount == nil {

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -42,14 +42,22 @@ func validateAuditAuthority(
 		}
 		return nil
 	}
-	if counts[0] != 1 || counts[1] != 1 || counts[2] < 1 || counts[3] == 0 {
-		return fmt.Errorf("audit authority must contain one authority and scope with baselines: counts=%v", counts)
+	if counts[0] != 1 || counts[1] < 1 || counts[2] < counts[1] || counts[3] == 0 {
+		return fmt.Errorf("audit authority must contain one authority and at least one complete scope: counts=%v", counts)
 	}
-	authority, scope, err := loadInitialAuditProjection(ctx, tx)
+	authority, err := loadAuditAuthorityProjection(ctx, tx)
 	if err != nil {
 		return err
 	}
 	records, err := loadInitialAuditRecords(ctx, tx)
+	if err != nil {
+		return err
+	}
+	scopes, err := loadAuditScopeProjections(ctx, tx)
+	if err != nil {
+		return err
+	}
+	scope, err := initialAuditScopeProjection(scopes, records)
 	if err != nil {
 		return err
 	}
@@ -63,7 +71,7 @@ func validateAuditAuthority(
 		return err
 	}
 	return validateAuditedHistory(
-		ctx, tx, vaultID, nodeSequence, authority, scope, records, initial,
+		ctx, tx, vaultID, nodeSequence, authority, scopes, scope, records, initial,
 	)
 }
 
@@ -85,6 +93,25 @@ func auditAuthorityCounts(ctx context.Context, tx metadataQuerier) ([5]int64, er
 func loadInitialAuditProjection(
 	ctx context.Context, tx metadataQuerier,
 ) (initialAuditAuthority, initialAuditScope, error) {
+	authority, err := loadAuditAuthorityProjection(ctx, tx)
+	if err != nil {
+		return authority, initialAuditScope{}, err
+	}
+	records, err := loadInitialAuditRecords(ctx, tx)
+	if err != nil {
+		return authority, initialAuditScope{}, err
+	}
+	scopes, err := loadAuditScopeProjections(ctx, tx)
+	if err != nil {
+		return authority, initialAuditScope{}, err
+	}
+	scope, err := initialAuditScopeProjection(scopes, records)
+	return authority, scope, err
+}
+
+func loadAuditAuthorityProjection(
+	ctx context.Context, tx metadataQuerier,
+) (initialAuditAuthority, error) {
 	var authority initialAuditAuthority
 	err := tx.QueryRowContext(ctx, `SELECT lineage_id,operation_sequence_high_water,
 		allocation_genesis_digest,allocation_entry_count,allocation_head
@@ -92,17 +119,67 @@ func loadInitialAuditProjection(
 		&authority.lineageID, &authority.sequence, &authority.genesisDigest,
 		&authority.allocationCount, &authority.allocationHead)
 	if err != nil {
-		return authority, initialAuditScope{}, fmt.Errorf("reading initial audit authority: %w", err)
+		return authority, fmt.Errorf("reading initial audit authority: %w", err)
 	}
-	var scope initialAuditScope
-	err = tx.QueryRowContext(ctx, `SELECT scope_id,target_node_id,enable_operation_id,
-		entry_count,chain_head FROM audit_scopes`).Scan(
-		&scope.scopeID, &scope.targetNodeID, &scope.operationID,
-		&scope.entryCount, &scope.chainHead)
+	return authority, nil
+}
+
+func loadAuditScopeProjections(
+	ctx context.Context, tx metadataQuerier,
+) ([]initialAuditScope, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT scope_id,target_node_id,enable_operation_id,
+		entry_count,chain_head FROM audit_scopes ORDER BY scope_id`)
 	if err != nil {
-		return authority, scope, fmt.Errorf("reading initial audit scope: %w", err)
+		return nil, fmt.Errorf("reading audit scopes: %w", err)
 	}
-	return authority, scope, nil
+	defer func() { _ = rows.Close() }()
+	var scopes []initialAuditScope
+	for rows.Next() {
+		var scope initialAuditScope
+		if err := rows.Scan(&scope.scopeID, &scope.targetNodeID, &scope.operationID,
+			&scope.entryCount, &scope.chainHead); err != nil {
+			return nil, fmt.Errorf("scanning audit scope: %w", err)
+		}
+		scopes = append(scopes, scope)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading audit scopes: %w", err)
+	}
+	return scopes, nil
+}
+
+func initialAuditScopeProjection(
+	scopes []initialAuditScope, records map[string][]storedAuditRecord,
+) (initialAuditScope, error) {
+	var operationID string
+	for _, mutation := range records["canonical_mutation"] {
+		if mutation.index.operationSequence == nil || *mutation.index.operationSequence != 1 {
+			continue
+		}
+		var err error
+		operationID, err = auditUUIDField(mutation.record, auditOperationIDField)
+		if err != nil {
+			return initialAuditScope{}, err
+		}
+		break
+	}
+	if operationID == "" {
+		return initialAuditScope{}, errors.New("audit authority lacks its initial mutation")
+	}
+	var result initialAuditScope
+	for _, scope := range scopes {
+		if scope.operationID != operationID {
+			continue
+		}
+		if result.scopeID != "" {
+			return initialAuditScope{}, errors.New("audit authority repeats its initial scope")
+		}
+		result = scope
+	}
+	if result.scopeID == "" {
+		return initialAuditScope{}, errors.New("audit authority lacks its initial scope projection")
+	}
+	return result, nil
 }
 
 func loadInitialAuditRecords(
@@ -173,8 +250,8 @@ func selectInitialAuditRecords(
 		int64(len(records["allocation_entry"])) != authority.allocationCount {
 		return nil, errors.New("audit allocation projection does not match its operation records")
 	}
-	if scope.entryCount < 1 || int64(len(records["scope_chain_entry"])) != scope.entryCount {
-		return nil, errors.New("audit scope projection does not match its chain records")
+	if scope.entryCount < 1 {
+		return nil, errors.New("initial audit scope projection has no chain records")
 	}
 	result := map[string][]storedAuditRecord{
 		"topology_genesis":          records["topology_genesis"],
@@ -473,6 +550,15 @@ func validateInitialMutation(
 	vaultID string, scope initialAuditScope, baseline, eventWrapper,
 	mutation storedAuditRecord,
 ) error {
+	return validateAuditEnrollmentMutation(
+		vaultID, scope, baseline, eventWrapper, mutation, 1,
+	)
+}
+
+func validateAuditEnrollmentMutation(
+	vaultID string, scope initialAuditScope, baseline, eventWrapper,
+	mutation storedAuditRecord, operationSequence uint64,
+) error {
 	event, err := auditNestedField(eventWrapper.record, auditEventField)
 	if err != nil {
 		return err
@@ -483,7 +569,7 @@ func validateInitialMutation(
 	if err := requireAuditUUID(mutation.record, auditVaultIDField, vaultID); err != nil {
 		return err
 	}
-	if err := requireAuditUnsigned(mutation.record, "operation_sequence", 1); err != nil {
+	if err := requireAuditUnsigned(mutation.record, "operation_sequence", operationSequence); err != nil {
 		return err
 	}
 	if err := requireAuditUUID(mutation.record, auditOperationIDField, scope.operationID); err != nil {

--- a/internal/store/audit_initial_validate.go
+++ b/internal/store/audit_initial_validate.go
@@ -42,6 +42,12 @@ func validateAuditAuthority(
 		}
 		return nil
 	}
+	if counts[1] > int64(MaxAuditEvidenceScopes) {
+		return fmt.Errorf(
+			"audit authority has %d permanent scopes (maximum %d): %w",
+			counts[1], MaxAuditEvidenceScopes, ErrAuditScopeLimit,
+		)
+	}
 	if counts[0] != 1 || counts[1] < 1 || counts[2] < counts[1] || counts[3] == 0 {
 		return fmt.Errorf("audit authority must contain one authority and at least one complete scope: counts=%v", counts)
 	}

--- a/internal/store/audit_metadata_test.go
+++ b/internal/store/audit_metadata_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"math"
 	"path/filepath"
 	"testing"
 
@@ -153,6 +155,50 @@ func TestInitialAuditAuthorityImportRejectsIncompleteMembership(t *testing.T) {
 	var records int64
 	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&records))
 	assert.Zero(t, records)
+}
+
+func TestAuditAuthorityImportRejectsUntrustedScopeCounts(t *testing.T) {
+	source, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, source.Close()) })
+	seedMetadataRoundTrip(t, source)
+	target, err := source.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, source, target.ID)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	original := firstAuditScopeMetadataRecord(t, exported.Bytes())
+
+	scopes := make([]any, 0, MaxAuditEvidenceScopes)
+	for index := range MaxAuditEvidenceScopes {
+		scope := original
+		scope.ScopeID = fmt.Sprintf("10000000-0000-4000-8000-%012x", index)
+		scope.EnableOperationID = fmt.Sprintf("20000000-0000-4000-8000-%012x", index)
+		scopes = append(scopes, scope)
+	}
+	input := appendMetadataRecords(t, exported.Bytes(), scopes...)
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	originalVaultID := restored.VaultID()
+
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(input))
+	require.ErrorContains(t, err, "maximum 1000")
+	assert.Equal(t, originalVaultID, restored.VaultID())
+	var nodes, scopeCount int64
+	require.NoError(t, restored.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM nodes),
+		(SELECT COUNT(*) FROM audit_scopes)`).Scan(&nodes, &scopeCount))
+	assert.Equal(t, int64(1), nodes)
+	assert.Zero(t, scopeCount)
+}
+
+func TestAuditScopeRecordsRejectsUntrustedEntryCountWithoutPreallocation(t *testing.T) {
+	_, err := auditScopeRecordsByScope(nil, []initialAuditScope{{
+		scopeID:    "11111111-1111-4111-8111-111111111111",
+		entryCount: math.MaxInt64,
+	}})
+	require.ErrorContains(t, err, "scope chain")
 }
 
 func TestInitialAuditAuthorityImportActivatesAfterWholeStream(t *testing.T) {
@@ -460,6 +506,23 @@ func mutateAuditMetadataRecord(
 	}
 	require.FailNow(t, "metadata record not found", kind)
 	return nil
+}
+
+func firstAuditScopeMetadataRecord(t *testing.T, input []byte) metadataAuditScope {
+	t.Helper()
+	for line := range bytes.SplitSeq(bytes.TrimSpace(input), []byte{'\n'}) {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type == metadataAuditScopeType {
+			var scope metadataAuditScope
+			require.NoError(t, json.Unmarshal(line, &scope))
+			return scope
+		}
+	}
+	require.FailNow(t, "metadata lacks audit scope")
+	return metadataAuditScope{}
 }
 
 func removeFirstAuditMetadataRecord(t *testing.T, input []byte, kind string) []byte {

--- a/internal/store/audit_public.go
+++ b/internal/store/audit_public.go
@@ -12,8 +12,9 @@ import (
 )
 
 // AuditEnrollmentPreview is the exact retention boundary a caller reviews
-// before permanently enabling the first audit scope in a vault.
+// before permanently enabling one audit scope in a vault.
 type AuditEnrollmentPreview struct {
+	InitialAuthority       bool
 	VaultID                string
 	ScopeID                string
 	OperationID            string
@@ -39,7 +40,9 @@ type AuditEnrollmentPreview struct {
 type AuditEnrollmentPlan struct {
 	preview                 AuditEnrollmentPreview
 	input                   initialAuditEnrollmentInput
+	initial                 bool
 	allocationGenesisDigest string
+	allocationHead          string
 }
 
 // Preview returns a copy of the plan's public retention inventory.
@@ -77,6 +80,7 @@ type AuditMembershipStatus struct {
 // AuditStatus is the vault-wide audit authority plus optional node membership.
 type AuditStatus struct {
 	Enabled                    bool
+	EnabledScopeID             string
 	VaultID                    string
 	LineageID                  string
 	OperationSequenceHighWater int64
@@ -86,8 +90,8 @@ type AuditStatus struct {
 	Membership                 *AuditMembershipStatus
 }
 
-// PreviewInitialAudit derives the exact first-scope authority without writing
-// it. The returned plan is useful only for EnableInitialAudit on this vault.
+// PreviewInitialAudit derives the exact next permanent scope without writing
+// it. The first scope creates vault authority; later scopes must be disjoint.
 func (s *Store) PreviewInitialAudit(
 	ctx context.Context, targetNodeID int64, origin string, agentLabel *string,
 ) (*AuditEnrollmentPlan, error) {
@@ -96,7 +100,7 @@ func (s *Store) PreviewInitialAudit(
 	})
 }
 
-// PreviewInitialAuditPath resolves a live path and derives its exact first
+// PreviewInitialAuditPath resolves a live path and derives its exact
 // enrollment boundary in the same database snapshot.
 func (s *Store) PreviewInitialAuditPath(
 	ctx context.Context, path, origin string, agentLabel *string,
@@ -113,9 +117,6 @@ func (s *Store) previewInitialAudit(
 ) (*AuditEnrollmentPlan, error) {
 	var plan *AuditEnrollmentPlan
 	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		if err := requireDormantAuditAuthority(ctx, tx); err != nil {
-			return err
-		}
 		targetNodeID, err := resolveTarget(tx)
 		if err != nil {
 			return err
@@ -123,33 +124,67 @@ func (s *Store) previewInitialAudit(
 		if err := validateLiveAuditEnrollmentTarget(tx, targetNodeID); err != nil {
 			return err
 		}
-		input, err := newInitialAuditEnrollmentInput(targetNodeID, origin, agentLabel)
-		if err != nil {
-			return err
-		}
-		set, err := buildInitialAuditEnrollment(ctx, tx, s.vaultID, input)
-		if err != nil {
-			return err
-		}
 		targetPath, err := pathOf(ctx, tx, targetNodeID)
 		if err != nil {
 			return err
 		}
-		preview, err := summarizeInitialAuditEnrollment(s.vaultID, set, targetPath)
+		counts, err := auditAuthorityCounts(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if counts == [5]int64{} {
+			input, err := newInitialAuditEnrollmentInput(targetNodeID, origin, agentLabel)
+			if err != nil {
+				return err
+			}
+			set, err := buildInitialAuditEnrollment(ctx, tx, s.vaultID, input)
+			if err != nil {
+				return err
+			}
+			preview, err := summarizeInitialAuditEnrollment(s.vaultID, set, targetPath)
+			if err != nil {
+				return err
+			}
+			plan = &AuditEnrollmentPlan{
+				preview: preview, input: input, initial: true,
+				allocationGenesisDigest: set.allocationGenesisDigest,
+			}
+			return nil
+		}
+		if counts[0] != 1 || counts[1] < 1 || counts[2] < 1 || counts[3] < 1 || counts[4] < 8 {
+			return errors.New("audit authority is incomplete")
+		}
+		authority, nodeSequence, err := loadAuditAuthorityTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if err := validateAuditAuthority(ctx, tx, s.vaultID, nodeSequence); err != nil {
+			return fmt.Errorf("validating existing audit authority: %w", err)
+		}
+		input, err := newAdditionalAuditEnrollmentInput(
+			targetNodeID, origin, agentLabel, authority.lineageID,
+		)
+		if err != nil {
+			return err
+		}
+		set, err := buildAdditionalAuditEnrollment(ctx, tx, s.vaultID, input)
+		if err != nil {
+			return err
+		}
+		preview, err := summarizeAdditionalAuditEnrollment(s.vaultID, set, targetPath)
 		if err != nil {
 			return err
 		}
 		plan = &AuditEnrollmentPlan{
-			preview: preview, input: input,
-			allocationGenesisDigest: set.allocationGenesisDigest,
+			preview: preview, input: input, allocationHead: set.allocationHead,
 		}
 		return nil
 	})
 	return plan, err
 }
 
-// EnableInitialAudit commits a previously reviewed first-scope plan only when
-// its baseline and vault-wide genesis still exactly match current metadata.
+// EnableInitialAudit commits a previously reviewed scope only when its
+// baseline and allocation authority still exactly match current metadata.
 func (s *Store) EnableInitialAudit(
 	ctx context.Context, plan *AuditEnrollmentPlan,
 ) (AuditStatus, error) {
@@ -158,27 +193,49 @@ func (s *Store) EnableInitialAudit(
 	}
 	var status AuditStatus
 	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		if err := requireDormantAuditAuthority(ctx, tx); err != nil {
-			return err
-		}
 		if err := requireLiveAuditPreviewTarget(tx, plan.input.targetNodeID); err != nil {
 			return err
 		}
-		set, err := buildInitialAuditEnrollment(ctx, tx, s.vaultID, plan.input)
-		if err != nil {
-			return err
+		if plan.initial {
+			if err := requireDormantAuditAuthority(ctx, tx); err != nil {
+				return err
+			}
+			set, err := buildInitialAuditEnrollment(ctx, tx, s.vaultID, plan.input)
+			if err != nil {
+				return err
+			}
+			if set.baselineDigest != plan.preview.BaselineDigest ||
+				set.allocationGenesisDigest != plan.allocationGenesisDigest {
+				return ErrAuditPreviewStale
+			}
+			if err := persistInitialAuditEnrollment(ctx, tx, set); err != nil {
+				return err
+			}
+			if err := validateMetadataState(ctx, tx, set.nodeSequence); err != nil {
+				return fmt.Errorf("validating created audit authority: %w", err)
+			}
+		} else {
+			set, err := buildAdditionalAuditEnrollment(ctx, tx, s.vaultID, plan.input)
+			if err != nil {
+				if errors.Is(err, ErrAuditScopeOverlap) {
+					return ErrAuditPreviewStale
+				}
+				return err
+			}
+			if set.baselineDigest != plan.preview.BaselineDigest ||
+				set.allocationHead != plan.allocationHead {
+				return ErrAuditPreviewStale
+			}
+			if err := persistAdditionalAuditEnrollment(ctx, tx, set); err != nil {
+				return err
+			}
+			if err := validateMetadataState(ctx, tx, set.nodeSequence); err != nil {
+				return fmt.Errorf("validating additional audit scope: %w", err)
+			}
 		}
-		if set.baselineDigest != plan.preview.BaselineDigest ||
-			set.allocationGenesisDigest != plan.allocationGenesisDigest {
-			return ErrAuditPreviewStale
-		}
-		if err := persistInitialAuditEnrollment(ctx, tx, set); err != nil {
-			return err
-		}
-		if err := validateMetadataState(ctx, tx, set.nodeSequence); err != nil {
-			return fmt.Errorf("validating created audit authority: %w", err)
-		}
+		var err error
 		status, err = auditStatusTx(ctx, tx, s.vaultID, nil)
+		status.EnabledScopeID = plan.input.scopeID
 		return err
 	})
 	return status, err
@@ -269,6 +326,17 @@ func newInitialAuditEnrollmentInput(
 	}, nil
 }
 
+func newAdditionalAuditEnrollmentInput(
+	targetNodeID int64, origin string, agentLabel *string, lineageID string,
+) (initialAuditEnrollmentInput, error) {
+	input, err := newInitialAuditEnrollmentInput(targetNodeID, origin, agentLabel)
+	if err != nil {
+		return initialAuditEnrollmentInput{}, err
+	}
+	input.lineageID = lineageID
+	return input, nil
+}
+
 func requireDormantAuditAuthority(ctx context.Context, tx metadataQuerier) error {
 	counts, err := auditAuthorityCounts(ctx, tx)
 	if err != nil {
@@ -289,15 +357,6 @@ func summarizeInitialAuditEnrollment(
 	if len(set.records) != 8 {
 		return AuditEnrollmentPreview{}, errors.New("initial audit enrollment has an invalid record set")
 	}
-	baseline := set.records[3]
-	baselineNodes, err := auditRecordListField(baseline, "nodes")
-	if err != nil {
-		return AuditEnrollmentPreview{}, err
-	}
-	versions, err := auditRecordListField(baseline, "versions")
-	if err != nil {
-		return AuditEnrollmentPreview{}, err
-	}
 	topology, err := auditRecordListField(set.records[0], "nodes")
 	if err != nil {
 		return AuditEnrollmentPreview{}, err
@@ -306,20 +365,65 @@ func summarizeInitialAuditEnrollment(
 	if err != nil {
 		return AuditEnrollmentPreview{}, err
 	}
-	preview := AuditEnrollmentPreview{
-		VaultID: vaultID, ScopeID: set.input.scopeID,
-		OperationID: set.input.operationID, TargetNodeID: set.input.targetNodeID,
-		TargetPath: targetPath, BaselineDigest: set.baselineDigest,
-		MemberCount: len(set.members), VersionCount: len(versions),
-		VaultTopologyNodes: len(topology), VaultAttachmentRecords: len(attachments),
+	jsonBytes, err := initialAuditMetadataJSONBytes(set)
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
 	}
-	members := auditMemberSet(set.members)
+	return summarizeAuditEnrollment(
+		vaultID, set.input, set.members, set.records[3], targetPath,
+		true, len(topology), len(attachments), jsonBytes,
+	)
+}
+
+func summarizeAdditionalAuditEnrollment(
+	vaultID string, set additionalAuditEnrollmentSet, targetPath string,
+) (AuditEnrollmentPreview, error) {
+	if len(set.records) != 5 {
+		return AuditEnrollmentPreview{}, errors.New("additional audit enrollment has an invalid record set")
+	}
+	jsonBytes, err := additionalAuditMetadataJSONBytes(set)
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
+	}
+	return summarizeAuditEnrollment(
+		vaultID, set.input, set.members, set.records[0], targetPath,
+		false, 0, 0, jsonBytes,
+	)
+}
+
+func summarizeAuditEnrollment(
+	vaultID string, input initialAuditEnrollmentInput, members []uint64,
+	baseline audit.Record, targetPath string, initial bool,
+	topologyCount, attachmentCount int, jsonBytes int64,
+) (AuditEnrollmentPreview, error) {
+	baselineNodes, err := auditRecordListField(baseline, "nodes")
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
+	}
+	versions, err := auditRecordListField(baseline, "versions")
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
+	}
+	preview := AuditEnrollmentPreview{
+		InitialAuthority: initial,
+		VaultID:          vaultID, ScopeID: input.scopeID,
+		OperationID: input.operationID, TargetNodeID: input.targetNodeID,
+		TargetPath: targetPath, MemberCount: len(members), VersionCount: len(versions),
+		VaultTopologyNodes: topologyCount, VaultAttachmentRecords: attachmentCount,
+		AuthorityJSONBytes: jsonBytes,
+	}
+	digest, err := hashAuditRecord(baseline)
+	if err != nil {
+		return AuditEnrollmentPreview{}, err
+	}
+	preview.BaselineDigest = digest.text
+	memberSet := auditMemberSet(members)
 	for _, node := range baselineNodes {
 		nodeID, err := auditUnsignedField(node, metadataNodeIDField)
 		if err != nil {
 			return AuditEnrollmentPreview{}, err
 		}
-		if !members[nodeID] {
+		if !memberSet[nodeID] {
 			continue
 		}
 		kind, err := auditTextField(node, "node_kind")
@@ -370,10 +474,6 @@ func summarizeInitialAuditEnrollment(
 			return AuditEnrollmentPreview{}, errors.New("audit preview unique size overflows int64")
 		}
 		preview.UniqueBlobBytes += size
-	}
-	preview.AuthorityJSONBytes, err = initialAuditMetadataJSONBytes(set)
-	if err != nil {
-		return AuditEnrollmentPreview{}, err
 	}
 	return preview, nil
 }
@@ -439,6 +539,87 @@ func initialAuditMetadataJSONBytes(set initialAuditEnrollmentSet) (int64, error)
 		}
 	}
 	return counter.total, nil
+}
+
+func additionalAuditMetadataJSONBytes(set additionalAuditEnrollmentSet) (int64, error) {
+	input := set.input
+	targetNodeID, err := positiveAuditNodeID(input.targetNodeID)
+	if err != nil {
+		return 0, err
+	}
+	nextSequence, err := nextAuditInteger("operation sequence", set.authority.sequence)
+	if err != nil {
+		return 0, err
+	}
+	nextCount, err := nextAuditInteger("allocation entry count", set.authority.allocationCount)
+	if err != nil {
+		return 0, err
+	}
+	auditNextSequence, err := positiveAuditInteger("operation sequence", nextSequence)
+	if err != nil {
+		return 0, err
+	}
+	auditNextCount, err := positiveAuditInteger("allocation entry count", nextCount)
+	if err != nil {
+		return 0, err
+	}
+	if set.authority.sequence < 1 || set.authority.allocationCount < 1 {
+		return 0, errors.New("additional audit enrollment has invalid authority counters")
+	}
+	oldCounter := new(metadataByteCounter)
+	if err := newMetadataJSONWriter(oldCounter)(metadataAuditAuthority{
+		Type: metadataAuditAuthorityType, LineageID: set.authority.lineageID,
+		OperationSequenceHighWater: uint64(set.authority.sequence),
+		AllocationGenesisDigest:    set.authority.genesisDigest,
+		AllocationEntryCount:       uint64(set.authority.allocationCount),
+		AllocationHead:             set.authority.allocationHead,
+	}); err != nil {
+		return 0, err
+	}
+	counter := new(metadataByteCounter)
+	write := newMetadataJSONWriter(counter)
+	if err := write(metadataAuditAuthority{
+		Type: metadataAuditAuthorityType, LineageID: set.authority.lineageID,
+		OperationSequenceHighWater: auditNextSequence,
+		AllocationGenesisDigest:    set.authority.genesisDigest,
+		AllocationEntryCount:       auditNextCount, AllocationHead: set.allocationHead,
+	}); err != nil {
+		return 0, err
+	}
+	if err := write(metadataAuditScope{
+		Type: metadataAuditScopeType, ScopeID: input.scopeID,
+		TargetNodeID: targetNodeID, EnableOperationID: input.operationID,
+		EntryCount: 1, ChainHead: set.scopeHead,
+	}); err != nil {
+		return 0, err
+	}
+	for _, member := range set.members {
+		if err := write(metadataAuditMembership{
+			Type: metadataAuditMembershipType, ScopeID: input.scopeID,
+			NodeID: member, BaselineDigest: set.baselineDigest,
+		}); err != nil {
+			return 0, err
+		}
+	}
+	for _, record := range set.records {
+		digest, err := hashAuditRecord(record)
+		if err != nil {
+			return 0, err
+		}
+		recordJSON, err := audit.MarshalJSONRecord(record)
+		if err != nil {
+			return 0, fmt.Errorf("encoding projected %s audit record: %w", record.Kind, err)
+		}
+		if err := write(metadataAuditRecord{
+			Type: metadataAuditRecordType, Digest: digest.text, Record: recordJSON,
+		}); err != nil {
+			return 0, err
+		}
+	}
+	if counter.total <= oldCounter.total {
+		return 0, errors.New("additional audit enrollment does not grow metadata")
+	}
+	return counter.total - oldCounter.total, nil
 }
 
 func auditStatusTx(

--- a/internal/store/audit_public.go
+++ b/internal/store/audit_public.go
@@ -154,6 +154,9 @@ func (s *Store) previewInitialAudit(
 		if counts[0] != 1 || counts[1] < 1 || counts[2] < 1 || counts[3] < 1 || counts[4] < 8 {
 			return errors.New("audit authority is incomplete")
 		}
+		if err := requireAdditionalAuditScopeCapacity(counts[1]); err != nil {
+			return err
+		}
 		authority, nodeSequence, err := loadAuditAuthorityTx(ctx, tx)
 		if err != nil {
 			return err
@@ -181,6 +184,19 @@ func (s *Store) previewInitialAudit(
 		return nil
 	})
 	return plan, err
+}
+
+func requireAdditionalAuditScopeCapacity(scopeCount int64) error {
+	if scopeCount < 0 {
+		return errors.New("audit authority has an invalid scope count")
+	}
+	if scopeCount >= int64(MaxAuditEvidenceScopes) {
+		return fmt.Errorf(
+			"vault already has %d permanent audit scopes (maximum %d): %w",
+			scopeCount, MaxAuditEvidenceScopes, ErrAuditScopeLimit,
+		)
+	}
+	return nil
 }
 
 // EnableInitialAudit commits a previously reviewed scope only when its

--- a/internal/store/audit_public_test.go
+++ b/internal/store/audit_public_test.go
@@ -63,6 +63,14 @@ func TestAuditEnrollmentPreviewEnablesExactReviewedAuthority(t *testing.T) {
 	assertAuditMetadataRoundTrip(t, s)
 }
 
+func TestAdditionalAuditScopeCapacityMatchesEvidenceBound(t *testing.T) {
+	require.NoError(t, requireAdditionalAuditScopeCapacity(MaxAuditEvidenceScopes-1))
+	for _, count := range []int64{MaxAuditEvidenceScopes, MaxAuditEvidenceScopes + 1} {
+		err := requireAdditionalAuditScopeCapacity(count)
+		require.ErrorIs(t, err, ErrAuditScopeLimit)
+	}
+}
+
 func TestAuditEnrollmentPreviewRejectsChangedVaultState(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
 	require.NoError(t, err)

--- a/internal/store/audit_public_test.go
+++ b/internal/store/audit_public_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -112,7 +113,7 @@ func TestAuditEnrollmentPreviewRejectsTrashedOrDeletedTargetAsStale(t *testing.T
 	}
 }
 
-func TestAuditEnrollmentPreviewIsVaultBoundAndFirstActivationOnly(t *testing.T) {
+func TestAuditEnrollmentPreviewIsVaultBoundAndRejectsOverlap(t *testing.T) {
 	first, err := Open(filepath.Join(t.TempDir(), "first.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, first.Close()) })
@@ -131,9 +132,76 @@ func TestAuditEnrollmentPreviewIsVaultBoundAndFirstActivationOnly(t *testing.T) 
 	_, err = first.EnableInitialAudit(t.Context(), plan)
 	require.NoError(t, err)
 	_, err = first.PreviewInitialAudit(t.Context(), target.ID, "api", nil)
-	require.ErrorIs(t, err, ErrAuditAlreadyEnabled)
+	require.ErrorIs(t, err, ErrAuditScopeOverlap)
 	_, err = first.EnableInitialAudit(t.Context(), plan)
 	require.ErrorIs(t, err, ErrAuditAlreadyEnabled)
+}
+
+func TestAuditEnrollmentAddsDisjointScopeAndRoundTrips(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	first, err := s.PreviewInitialAudit(t.Context(), projects.ID, "api", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), first)
+	require.NoError(t, err)
+
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	var before bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &before))
+	second, err := s.PreviewInitialAudit(t.Context(), empty.ID, "api", nil)
+	require.NoError(t, err)
+	preview := second.Preview()
+	assert.False(t, preview.InitialAuthority)
+	assert.Zero(t, preview.VaultTopologyNodes)
+	assert.Zero(t, preview.VaultAttachmentRecords)
+	assert.Equal(t, 1, preview.MemberCount)
+
+	status, err := s.EnableInitialAudit(t.Context(), second)
+	require.NoError(t, err)
+	assert.Equal(t, preview.ScopeID, status.EnabledScopeID)
+	assert.Equal(t, int64(2), status.OperationSequenceHighWater)
+	require.Len(t, status.Scopes, 2)
+	var after bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &after))
+	assert.Equal(t, int64(after.Len()-before.Len()), preview.AuthorityJSONBytes)
+
+	_, err = s.Mkdir(t.Context(), projects.ID, "first-scope-child")
+	require.NoError(t, err)
+	_, err = s.Mkdir(t.Context(), empty.ID, "second-scope-child")
+	require.NoError(t, err)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	assertAuditMetadataRoundTrip(t, s)
+
+	incomplete := removeAuditScopeByID(t, after.Bytes(), preview.ScopeID)
+	restored, err := Open(filepath.Join(t.TempDir(), "incomplete.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(incomplete))
+	require.Error(t, err)
+	var auditRecords int
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&auditRecords))
+	assert.Zero(t, auditRecords, "invalid multi-scope import must roll back")
+}
+
+func removeAuditScopeByID(t *testing.T, input []byte, scopeID string) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	for index, line := range lines {
+		var scope metadataAuditScope
+		require.NoError(t, json.Unmarshal(line, &scope))
+		if scope.Type == metadataAuditScopeType && scope.ScopeID == scopeID {
+			lines = append(lines[:index], lines[index+1:]...)
+			return append(bytes.Join(lines, []byte{'\n'}), '\n')
+		}
+	}
+	require.FailNow(t, "audit scope not found", scopeID)
+	return nil
 }
 
 func TestAuditStatusExplainsDormantAndProtectedNodes(t *testing.T) {

--- a/internal/store/audit_tag_rename.go
+++ b/internal/store/audit_tag_rename.go
@@ -96,7 +96,10 @@ func auditedTaggedNodesTx(
 		}
 		if scope != nil && scope.scopeID != current.scopeID {
 			_ = rows.Close()
-			return nil, nil, errors.New("tag rename across multiple audit scopes is not supported")
+			return nil, nil, fmt.Errorf(
+				"tag definition change affects multiple audit scopes: %w",
+				ErrAuditMutationUnsupported,
+			)
 		}
 		if scope == nil {
 			scope = &current

--- a/internal/store/audit_tag_rename_test.go
+++ b/internal/store/audit_tag_rename_test.go
@@ -91,6 +91,74 @@ func TestAuditedTagRenameNoOpDoesNotAdvanceHistory(t *testing.T) {
 	require.NoError(t, s.ValidateMetadata(t.Context()))
 }
 
+func TestAuditedTagDefinitionChangesAcrossScopesFailClosed(t *testing.T) {
+	tests := map[string]func(*Store, Tag) error{
+		"rename": func(s *Store, tag Tag) error {
+			_, err := s.RenameTag(t.Context(), tag.ID, tag.Revision, "renamed")
+			return err
+		},
+		"delete": func(s *Store, tag Tag) error {
+			_, err := s.DeleteTag(t.Context(), tag.ID, tag.Revision)
+			return err
+		},
+	}
+	for name, change := range tests {
+		t.Run(name, func(t *testing.T) {
+			s, tag, first, second := newMultiScopeAuditedTagStore(t)
+			var sequence int64
+			require.NoError(t, s.db.QueryRow(
+				`SELECT operation_sequence_high_water FROM audit_authority`,
+			).Scan(&sequence))
+
+			err := change(s, tag)
+			require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+			current, err := s.TagByID(t.Context(), tag.ID)
+			require.NoError(t, err)
+			assert.Equal(t, tag, current)
+			for _, prior := range []Node{first, second} {
+				node, err := s.NodeByID(t.Context(), prior.ID)
+				require.NoError(t, err)
+				assert.Equal(t, prior, node)
+			}
+			var after int64
+			require.NoError(t, s.db.QueryRow(
+				`SELECT operation_sequence_high_water FROM audit_authority`,
+			).Scan(&after))
+			assert.Equal(t, sequence, after)
+			require.NoError(t, s.ValidateMetadata(t.Context()))
+		})
+	}
+}
+
+func newMultiScopeAuditedTagStore(t *testing.T) (*Store, Tag, Node, Node) {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	tag, err := s.CreateTag(t.Context(), "shared")
+	require.NoError(t, err)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	firstPlan, err := s.PreviewInitialAudit(t.Context(), projects.ID, "api", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), firstPlan)
+	require.NoError(t, err)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	secondPlan, err := s.PreviewInitialAudit(t.Context(), empty.ID, "api", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), secondPlan)
+	require.NoError(t, err)
+	report, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	first, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)
+	require.NoError(t, err)
+	second, err := s.AssignTag(t.Context(), tag.ID, empty.ID, empty.Revision)
+	require.NoError(t, err)
+	return s, second.Tag, first.Node, second.Node
+}
+
 func TestAuditedTagRenameRollsBackDefinitionNodesAndHistory(t *testing.T) {
 	s, tag, report := newAuditedTagStore(t)
 	assigned, err := s.AssignTag(t.Context(), tag.ID, report.ID, report.Revision)

--- a/internal/store/audit_verify.go
+++ b/internal/store/audit_verify.go
@@ -12,8 +12,8 @@ import (
 )
 
 // MaxAuditEvidenceScopes bounds caller-supplied prefix work independently of
-// the HTTP body limit. Current vaults expose one scope; the bound leaves room
-// for the planned multi-scope model without allowing unbounded point lookups.
+// the HTTP body limit. Enrollment enforces the same limit so every valid vault
+// can produce a terminal evidence bundle.
 const MaxAuditEvidenceScopes = 1000
 
 // AuditScopeEvidence is one verified scope-chain terminal.

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -39,10 +39,13 @@ var (
 	// ErrAuditMutationUnsupported means an audited vault cannot perform a
 	// logical mutation until that mutation records its audit transition.
 	ErrAuditMutationUnsupported = errors.New("mutation is not supported for an audited vault")
-	// ErrAuditAlreadyEnabled means first-scope enrollment cannot run because
-	// this vault already has audit authority. Later scope enrollment is a
-	// separate operation with different closure semantics.
+	// ErrAuditAlreadyEnabled means a plan reviewed against dormant authority
+	// cannot run because another operation enabled audit first.
 	ErrAuditAlreadyEnabled = errors.New("audit is already enabled for this vault")
+	// ErrAuditScopeOverlap means an additional scope would share at least one
+	// sticky member with an existing scope. Disjoint scopes are supported first;
+	// overlapping and nested scopes remain fail-closed.
+	ErrAuditScopeOverlap = errors.New("audit scope overlaps existing permanent protection")
 	// ErrAuditPreviewStale means enrollment no longer matches the exact
 	// metadata state reviewed by the caller.
 	ErrAuditPreviewStale = errors.New("audit enrollment preview is stale")

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -46,6 +46,9 @@ var (
 	// sticky member with an existing scope. Disjoint scopes are supported first;
 	// overlapping and nested scopes remain fail-closed.
 	ErrAuditScopeOverlap = errors.New("audit scope overlaps existing permanent protection")
+	// ErrAuditScopeLimit means permanent enrollment has reached the maximum
+	// number of scope terminals one evidence bundle can represent.
+	ErrAuditScopeLimit = errors.New("audit scope limit reached")
 	// ErrAuditPreviewStale means enrollment no longer matches the exact
 	// metadata state reviewed by the caller.
 	ErrAuditPreviewStale = errors.New("audit enrollment preview is stale")


### PR DESCRIPTION
Docbank’s permanent audit workflow could protect only one directory per vault. That made a realistic archive awkward: protecting `/taxes` meant `/contracts` could not receive the same guarantee without creating and operating a separate vault.

This PR makes the existing preview-first workflow repeatable for unrelated collections:

```console
docbank audit enable /taxes
docbank audit enable --run --token <token> --acknowledge-permanent-retention
docbank audit enable /contracts
docbank audit enable --run --token <token> --acknowledge-permanent-retention
```

The first scope still establishes the one vault-wide genesis and allocation lineage. Each later scope reuses that evidence, adds only its selected directory closure, and starts an independent scope chain. The preview says whether it is creating initial authority and reports the exact incremental JSONL growth; the enable receipt identifies the scope just added. Status, history, verification, portable metadata, incremental backup, and restore all preserve every scope.

For now scopes must be disjoint. A target is rejected if its live or retained-trash closure shares any node with existing permanent protection, so nested and overlapping enrollment cannot create an authority shape that current topology mutations do not know how to advance. Operations that would span scopes remain fail-closed. A vault accepts at most 1,000 permanent scopes, matching the bounded terminal-evidence contract so enrollment can never create authority that `audit verify` cannot report.

The backup rehearsal captures one scope in the first snapshot, adds a second scope and protected content before the incremental snapshot, restores the archive, verifies both chain heads against the source evidence, and reads every protected version byte-for-byte. The same lifecycle passes with both supported SQLite implementations.