### PR TITLE
Delay watched ingestion until files are old enough

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -742,6 +742,7 @@ func TestConfiguredWatchIngestsStableFilesAndRemainsObservable(t *testing.T) {
 	assert.Equal(t, source, watches.Items[0].Source)
 	assert.Equal(t, "/agents", watches.Items[0].Destination)
 	assert.Equal(t, "50ms", watches.Items[0].SettleTime)
+	assert.Equal(t, "0s", watches.Items[0].MinimumAge)
 	assert.Equal(t, "10ms", watches.Items[0].ScanInterval)
 	require.NotNil(t, watches.Items[0].Job)
 	assert.Equal(t, "running", watches.Items[0].Job.Status)

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "36", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "37", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "36", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "37", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "36", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "37", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "36", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "37", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/watch.go
+++ b/cmd/docbank/watch.go
@@ -48,7 +48,7 @@ func writeWatchedInboxes(w io.Writer, items []api.WatchedInbox) error {
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	if _, err := fmt.Fprintln(tw,
-		"NAME\tSTATUS\tSOURCE\tDESTINATION\tSETTLE\tSCAN\tEXCLUDES\tERROR"); err != nil {
+		"NAME\tSTATUS\tSOURCE\tDESTINATION\tSETTLE\tMINIMUM AGE\tSCAN\tEXCLUDES\tERROR"); err != nil {
 		return fmt.Errorf("writing watched-inbox header: %w", err)
 	}
 	for _, item := range items {
@@ -59,10 +59,10 @@ func writeWatchedInboxes(w io.Writer, items []api.WatchedInbox) error {
 				problem = strconv.QuoteToASCII(item.Job.Error)
 			}
 		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
 			item.Name, status, strconv.QuoteToASCII(item.Source),
 			strconv.QuoteToASCII(item.Destination), item.SettleTime,
-			item.ScanInterval, len(item.Exclude), problem); err != nil {
+			item.MinimumAge, item.ScanInterval, len(item.Exclude), problem); err != nil {
 			return fmt.Errorf("writing watched-inbox row: %w", err)
 		}
 	}

--- a/cmd/docbank/watch_test.go
+++ b/cmd/docbank/watch_test.go
@@ -15,7 +15,7 @@ func TestWriteWatchedInboxesEscapesMachineAndVirtualPaths(t *testing.T) {
 	err := writeWatchedInboxes(&out, []api.WatchedInbox{{
 		Name: "sessions", Source: "/local/agent\nsessions",
 		Destination: "/archives/\x1b[31msessions", SettleTime: "1h0m0s",
-		ScanInterval: "1m0s", Exclude: []string{"cache/"},
+		MinimumAge: "168h0m0s", ScanInterval: "1m0s", Exclude: []string{"cache/"},
 		Job: &api.Job{Status: "running"},
 	}})
 	require.NoError(t, err)

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -50,8 +50,11 @@ docbank watch list --json
 ```
 
 Each item reports the machine-local source, virtual destination, full settle
-window, scan interval, literal exclusions, and current job record. This is a
-read-only view; changing `config.toml` still requires a daemon restart.
+window, optional minimum source age, scan interval, literal exclusions, and
+current job record. A nonzero minimum age composes with rather than replaces
+the settle window, which is useful when append-heavy session JSONL may pause
+without being complete. This is a read-only view; changing `config.toml` still
+requires a daemon restart.
 
 The canonical contract is generated from the running route definitions:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -895,10 +895,11 @@ docbank watch list [--json]
 
 Lists the daemon's effective watched-inbox configuration in stable name order:
 the machine-local source, virtual-tree destination, complete settle window,
-scan interval, exclusion count, and current runner state. Human output quotes
-source and destination paths so terminal control characters cannot disguise
-them. `--json` includes the complete exclusion rules and the corresponding
-job record for agents and automation.
+minimum source age (`0s` when disabled), scan interval, exclusion count, and
+current runner state. Human output quotes source and destination paths so
+terminal control characters cannot disguise them. `--json` includes the
+complete exclusion rules and the corresponding job record for agents and
+automation. The `minimum_age` field is newer than v0.10.1.
 
 This command is inspection only. Edit `config.toml` and restart the daemon to
 change a watch.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,7 @@ name = "agent-sessions"
 source = "~/agent-sessions"
 destination = "/archives/agents"
 settle_time = "30s"
+minimum_age = "168h" # optional; 7 days since source modification
 scan_interval = "5s"
 exclude = [".DS_Store", "cache/"]
 ```
@@ -148,10 +149,23 @@ own input.
 
 A file must remain the same filesystem object with the same size and
 modification time for the complete `settle_time` before Docbank reads its
-content. After the read, the daemon verifies that the confined source path
-still names that object and grants no node authority if it changed.
-`scan_interval` controls how often it looks for new observations. Zero values select the
-defaults shown above; explicit values must be positive.
+content. Optional `minimum_age` adds a second gate based on the source's
+modification time. For example, `"168h"` requires a file to be at least seven
+days old *and* unchanged for the complete settle window. It defaults to `"0s"`
+(disabled), and unlike the in-memory settle observation, its source timestamp
+still applies after a daemon restart. This is useful for append-heavy agent
+sessions and recording streams that may pause without being finished.
+
+After the read, the daemon verifies that the confined source path still names
+that object and grants no node authority if it changed. `scan_interval`
+controls how often it looks for new observations. Zero values select the
+defaults shown above; explicit settle and scan values must be positive.
+`minimum_age` must not be negative.
+
+Minimum age is a conservative time policy, not proof that the producing
+application explicitly closed a file. Choose a window appropriate to the
+producer, or watch a directory that receives only completed files when the
+producer offers a close/rename handoff.
 
 A file that disappears during observation, or is still held exclusively by a
 Windows producer, is treated as unsettled and retried from a fresh window.
@@ -172,9 +186,10 @@ change at the watched source appends another version.
 
 Watchers run as jobs named `watch:<name>`. In source builds newer than v0.10.0,
 `docbank watch list` and `GET /api/v1/watches` pair each runner's state with its
-effective source, destination, timing, and exclusion policy; use `--json` when
-an agent needs the complete rules. `docbank jobs` and `GET /api/v1/jobs` remain
-the all-task view.
+effective source, destination, settle window, minimum source age, scan interval,
+and exclusion policy; use `--json` when an agent needs the complete rules.
+`minimum_age` itself is newer than v0.10.1. `docbank jobs` and
+`GET /api/v1/jobs` remain the all-task view.
 A source, destination, or read failure leaves the named job in the failed state
 and records the reason. Restart the daemon after correcting the problem.
 Per-file successes are written to the daemon log. A configured watch keeps a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -112,12 +112,13 @@ or stable scope ID with bounded, append-stable cursor pagination. Independent ve
 stable terminal evidence, checks every protected blob, and can prove that
 current allocation and scope chains extend an externally recorded bundle.
 Daemon-owned watched inboxes recursively observe configured local directories,
-wait for stable size and modification time, preserve portable source identity,
-and append later changes to the same stable node without touching source files.
-Their effective source, destination, settling policy, exclusions, and live job
-state are inspectable together through the CLI and authenticated API.
+wait for stable size and modification time plus an optional minimum source age,
+preserve portable source identity, and append later changes to the same stable
+node without touching source files. Their effective source, destination, timing
+policy, exclusions, and live job state are inspectable together through the CLI
+and authenticated API.
 
-- Additional and overlapping audit scopes
+- Overlapping audit scopes
   ([current workflow](usage/audited-history.md),
   [model](architecture/audited-history.md))
 - Additional text extraction workers for PDF text layers and office formats;

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -191,16 +191,25 @@ name = "agent-sessions"
 source = "~/agent-sessions"
 destination = "/archives/agents"
 settle_time = "30s"
+minimum_age = "168h"
 scan_interval = "5s"
 exclude = ["cache/", ".DS_Store"]
 ```
 
 The daemon observes a file's filesystem identity, size, and modification time
-for a full settle window before reading it. It then verifies that the confined
-source path still names the same unchanged object. It never follows entries
-that are symlinks and never changes or deletes source data. A daemon restart
-deliberately forgets partial observations, so every file proves a complete
-settle window again.
+for a full settle window before reading it. `minimum_age = "168h"` additionally
+requires seven days since the source's last modification, which is useful when
+an append-heavy session may pause for minutes or hours without being closed.
+The minimum-age gate survives restart; the settle observation deliberately does
+not, so every file still proves a complete unchanged window in the new daemon.
+Set `minimum_age = "0s"` or omit it for ordinary inboxes that need only the
+settle window.
+
+Docbank then verifies that the confined source path still names the same
+unchanged object. It never follows entries that are symlinks and never changes
+or deletes source data. A time window cannot prove that a producer formally
+closed a file, so use a conservative age or point the watch at a completed-file
+handoff directory when one is available.
 
 The watch name and slash-separated relative source path form a stable,
 portable provenance identity. The first stable observation creates the file
@@ -214,6 +223,9 @@ new identity, not an implicit move.
 
 Use `docbank provenance <path-or-id>` to inspect the retained watch identity,
 source-relative path, and immutable supersession history for an imported node.
+JSONL session content up to the normal extraction limit is indexed by the
+built-in plain-text worker, so ordinary `docbank search` can find archived
+session text without a vendor-specific parser.
 
 The destination is exact rather than collision-suffixed. If unrelated content
 already occupies the intended path, or the previously mapped node is in the

--- a/internal/api/routes_watches.go
+++ b/internal/api/routes_watches.go
@@ -34,6 +34,7 @@ func registerWatchRoutes(api huma.API, d Deps) {
 			item := WatchedInbox{
 				Name: watch.Name, Source: watch.Source, Destination: watch.Destination,
 				SettleTime:   watch.SettleTime.Std().String(),
+				MinimumAge:   watch.MinimumAge.Std().String(),
 				ScanInterval: watch.ScanInterval.Std().String(),
 				Exclude:      append([]string{}, watch.Exclude...),
 			}

--- a/internal/api/routes_watches_test.go
+++ b/internal/api/routes_watches_test.go
@@ -47,6 +47,7 @@ func TestListWatchedInboxesReturnsEffectiveConfigAndRunnerState(t *testing.T) {
 			{
 				Name: "archive", Source: source, Destination: "/records",
 				SettleTime:   config.Duration(2 * time.Minute),
+				MinimumAge:   config.Duration(7 * 24 * time.Hour),
 				ScanInterval: config.Duration(15 * time.Second),
 				Exclude:      []string{"cache/", ".DS_Store"},
 			},
@@ -61,12 +62,14 @@ func TestListWatchedInboxesReturnsEffectiveConfigAndRunnerState(t *testing.T) {
 	assert.Equal(t, source, got.Items[0].Source)
 	assert.Equal(t, "/records", got.Items[0].Destination)
 	assert.Equal(t, "2m0s", got.Items[0].SettleTime)
+	assert.Equal(t, "168h0m0s", got.Items[0].MinimumAge)
 	assert.Equal(t, "15s", got.Items[0].ScanInterval)
 	assert.Equal(t, []string{"cache/", ".DS_Store"}, got.Items[0].Exclude)
 	require.NotNil(t, got.Items[0].Job)
 	assert.Equal(t, "watch:archive", got.Items[0].Job.Name)
 	assert.Equal(t, "running", got.Items[0].Job.Status)
 	assert.Equal(t, "zeta", got.Items[1].Name)
+	assert.Equal(t, "0s", got.Items[1].MinimumAge)
 	assert.Empty(t, got.Items[1].Exclude)
 	assert.Nil(t, got.Items[1].Job)
 	close(release)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -675,6 +675,7 @@ type WatchedInbox struct {
 	Source       string   `json:"source"`
 	Destination  string   `json:"destination"`
 	SettleTime   string   `json:"settle_time"`
+	MinimumAge   string   `json:"minimum_age"`
 	ScanInterval string   `json:"scan_interval"`
 	Exclude      []string `json:"exclude"`
 	Job          *Job     `json:"job,omitempty"`

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -22,7 +22,7 @@ const (
 	metaProtocolVersion = "protocol_version"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "36"
+	daemonProtocolVersion = "37"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type WatchConfig struct {
 	Source       string   `toml:"source"`
 	Destination  string   `toml:"destination"`
 	SettleTime   Duration `toml:"settle_time"`
+	MinimumAge   Duration `toml:"minimum_age"`
 	ScanInterval Duration `toml:"scan_interval"`
 	Exclude      []string `toml:"exclude"`
 }
@@ -254,6 +255,9 @@ func validateWatch(watch WatchConfig) error {
 	}
 	if watch.SettleTime.Std() <= 0 {
 		return fmt.Errorf("[[watch]] %q settle_time must be positive", watch.Name)
+	}
+	if watch.MinimumAge.Std() < 0 {
+		return fmt.Errorf("[[watch]] %q minimum_age must not be negative", watch.Name)
 	}
 	if watch.ScanInterval.Std() <= 0 {
 		return fmt.Errorf("[[watch]] %q scan_interval must be positive", watch.Name)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,7 +75,7 @@ func TestLoadParsesWatchedInboxesAndAppliesDefaults(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.toml"), []byte(
 		"[[watch]]\nname = \"documents\"\nsource = \""+filepath.ToSlash(source)+"\"\n"+
 			"destination = \"/inbox/documents\"\nexclude = [\".tmp\", \"cache/\"]\n"+
-			"settle_time = \"45s\"\nscan_interval = \"3s\"\n\n"+
+			"settle_time = \"45s\"\nminimum_age = \"168h\"\nscan_interval = \"3s\"\n\n"+
 			"[[watch]]\nname = \"sessions\"\nsource = \""+relativeHomeSource+"\"\n"+
 			"destination = \"/agents/sessions\"\n"), 0o600))
 
@@ -85,12 +85,14 @@ func TestLoadParsesWatchedInboxesAndAppliesDefaults(t *testing.T) {
 	assert.Equal(t, filepath.Clean(source), c.Watches[0].Source)
 	assert.Equal(t, "/inbox/documents", c.Watches[0].Destination)
 	assert.Equal(t, 45*time.Second, c.Watches[0].SettleTime.Std())
+	assert.Equal(t, 7*24*time.Hour, c.Watches[0].MinimumAge.Std())
 	assert.Equal(t, 3*time.Second, c.Watches[0].ScanInterval.Std())
 	assert.Equal(t, []string{".tmp", "cache/"}, c.Watches[0].Exclude)
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(home, "agent-sessions"), c.Watches[1].Source)
 	assert.Equal(t, 30*time.Second, c.Watches[1].SettleTime.Std())
+	assert.Zero(t, c.Watches[1].MinimumAge.Std())
 	assert.Equal(t, 5*time.Second, c.Watches[1].ScanInterval.Std())
 	require.NoError(t, c.Validate())
 }
@@ -104,6 +106,8 @@ func TestWatchedInboxConfigRejectsAmbiguousOrUnsafeValues(t *testing.T) {
 		{"relative source", "name='inbox'\nsource='relative'\ndestination='/inbox'", "must be absolute"},
 		{"relative destination", "name='inbox'\nsource='" + source + "'\ndestination='inbox'", "absolute virtual path"},
 		{"invalid name", "name='Bad Name'\nsource='" + source + "'\ndestination='/inbox'", "unsupported characters"},
+		{"negative minimum age", "name='inbox'\nsource='" + source +
+			"'\ndestination='/inbox'\nminimum_age='-1s'", "must not be negative"},
 		{"duplicate name", "name='same'\nsource='" + source + "'\ndestination='/one'\n" +
 			"[[watch]]\nname='same'\nsource='" + filepath.ToSlash(t.TempDir()) + "'\ndestination='/two'", "duplicated"},
 	} {

--- a/internal/ingest/watcher.go
+++ b/internal/ingest/watcher.go
@@ -730,7 +730,10 @@ func (w *Watcher) scanDirectory(
 			}
 			continue
 		}
-		if observation.processed || observedAt.Sub(observation.stableSince) < w.config.SettleTime.Std() {
+		minimumAge := w.config.MinimumAge.Std()
+		if observation.processed ||
+			observedAt.Sub(observation.stableSince) < w.config.SettleTime.Std() ||
+			(minimumAge > 0 && observedAt.Sub(time.Unix(0, fingerprint.modTime)) < minimumAge) {
 			continue
 		}
 		var result WatchResult

--- a/internal/ingest/watcher_test.go
+++ b/internal/ingest/watcher_test.go
@@ -170,6 +170,51 @@ func TestWatcherDoesNotCountTraversalTimeTowardSettle(t *testing.T) {
 	require.ErrorIs(t, err, store.ErrNotFound)
 }
 
+func TestWatcherRequiresMinimumSourceAgeAfterRestart(t *testing.T) {
+	ing := newTestIngester(t)
+	source := writeTree(t, map[string]string{
+		"session.jsonl": "{\"kind\":\"closed-session\"}\n",
+	})
+	producedAt := time.Unix(1_700_000_000, 0)
+	sourcePath := filepath.Join(source, "session.jsonl")
+	require.NoError(t, os.Chtimes(sourcePath, producedAt, producedAt))
+	cfg := config.WatchConfig{
+		Name: "sessions", Source: source, Destination: "/archive",
+		SettleTime: config.Duration(10 * time.Minute),
+		MinimumAge: config.Duration(time.Hour), ScanInterval: config.Duration(time.Minute),
+	}
+	watcher, err := NewWatcher(
+		ing, t.TempDir(), cfg, runTestMutation, slog.New(slog.DiscardHandler),
+	)
+	require.NoError(t, err)
+	root := openWatcherRoot(t, watcher)
+	require.NoError(t, scanWatcherAt(t.Context(), watcher, root, producedAt))
+
+	// Restarting discards the first stability observation. Even after the new
+	// watcher proves a complete settle window, the source is not eligible until
+	// its modification time reaches the independent minimum-age boundary.
+	restarted, err := NewWatcher(
+		ing, t.TempDir(), cfg, runTestMutation, slog.New(slog.DiscardHandler),
+	)
+	require.NoError(t, err)
+	restartedRoot := openWatcherRoot(t, restarted)
+	require.NoError(t, scanWatcherAt(
+		t.Context(), restarted, restartedRoot, producedAt.Add(20*time.Minute),
+	))
+	require.NoError(t, scanWatcherAt(
+		t.Context(), restarted, restartedRoot, producedAt.Add(30*time.Minute),
+	))
+	_, err = ing.Store.NodeByPath(t.Context(), "/archive/session.jsonl")
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, scanWatcherAt(
+		t.Context(), restarted, restartedRoot, producedAt.Add(time.Hour),
+	))
+	node, err := ing.Store.NodeByPath(t.Context(), "/archive/session.jsonl")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), node.Revision)
+}
+
 func TestWatcherRetriesFileThatDisappearsBeforeIngest(t *testing.T) {
 	ing := newTestIngester(t)
 	source := writeTree(t, map[string]string{"document.txt": "ready"})


### PR DESCRIPTION
Agent session logs and other append-heavy files can look quiet for a short settle window even though the producer may resume them later. A watched archive needs a conservative way to say: do not ingest this until it has also been untouched for a longer period.

This adds optional `minimum_age` to each `[[watch]]`. For example:

```toml
settle_time = \"30s\"
minimum_age = \"168h\"
```

A file must satisfy both conditions. The settle observation still restarts with the daemon; the minimum age is derived from the source file's modification time, so restarting cannot bypass it. Leaving the field unset reports `0s` and preserves existing behavior.

`docbank watch list` and the authenticated watch API expose the effective age gate so people and agents can verify the daemon accepted the intended archive policy. Later source changes still append immutable versions to the same stable node, and Docbank never modifies or deletes the source.

This is intentionally format-neutral. JSONL session archives benefit immediately through the existing verified watched ingest, provenance, text extraction/search, packing, and backup paths without teaching Docbank vendor-specific session formats or claiming that elapsed time proves an explicit close event.