### PR TITLE
Record shared tag changes across audit scopes

### DIFF
--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -12,10 +12,9 @@ description: The permanent, tamper-evident history model for protected directory
     history. Independent audit verification returns stable terminal evidence
     and checks every protected blob; supplied external evidence is proved as an
     exact prefix of current allocation and scope chains. Scope-wide browsing is
-    available. A tag-definition rename or deletion whose assignments span
-    several protected scopes currently fails closed with
-    `audit_mutation_unsupported`; cross-scope attachment fan-out, overlapping
-    scopes, and TUI/web projections remain planned. See
+    available. A shared tag-definition rename or deletion advances every
+    affected disjoint scope atomically. Overlapping scopes, cross-scope
+    topology changes, and TUI/web projections remain planned. See
     [Permanent Audited History](../usage/audited-history.md) for the current
     operator workflow.
 
@@ -411,12 +410,13 @@ change still advances independently verifiable authority, while an omitted
 unassign/reassign or rename-away/rename-back cannot hide behind an unchanged
 final projection.
 
-!!! info "Planned cross-scope attachment fan-out"
-    The canonical model below defines how one attached-metadata change advances
-    every affected scope. The current writer and replay validator implement
-    tag-definition changes only when all audited assignments belong to one
-    scope; a rename or deletion spanning scopes fails closed until this fan-out
-    is implemented.
+Shared tag-definition changes use one canonical mutation even when assignments
+span several disjoint scopes. The writer derives the complete affected member
+and scope set from current assignments, emits deterministic events for each
+protected member, and advances every affected scope chain plus the allocation
+lineage in the same transaction. Import independently derives that fan-out from
+the replayed assignments; omitting a member, scope event, or scope-chain entry
+invalidates the metadata stream.
 
 Fan-out is derived mechanically from that simultaneous transition:
 

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -245,11 +245,11 @@ evidence bundle. Status, history, verification,
 JSONL export/import, incremental backup, and restore preserve every scope.
 
 A tag may be assigned to documents in several protected scopes. Renaming or
-deleting that shared tag currently returns `audit_mutation_unsupported` and
-changes nothing, because one definition change would need to advance every
-affected scope atomically. To reorganize it now, unassign it from all but one
-scope before renaming, or unassign it everywhere before deletion; separate tag
-definitions avoid this cross-scope coupling.
+deleting that shared tag is one atomic audited operation: every assigned
+protected node receives the definition event, deletion also records each
+assignment tombstone, every affected scope chain advances, and either all of
+those changes commit or none do. Ordinary optimistic tag revisions still apply,
+so a stale rename or deletion cannot overwrite a newer assignment set.
 
 !!! info "Planned"
     Overlapping scopes and rich TUI/web history views are not implemented.

--- a/internal/api/routes_tags_test.go
+++ b/internal/api/routes_tags_test.go
@@ -165,6 +165,49 @@ func TestTagAssignmentRejectsStaleRevisionAndInvalidName(t *testing.T) {
 	assert.Contains(t, body, `"code":"invalid_tag"`)
 }
 
+func TestSharedAuditedTagDefinitionChangesHTTP(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	first, err := s.Mkdir(t.Context(), s.RootID(), "taxes")
+	require.NoError(t, err)
+	second, err := s.Mkdir(t.Context(), s.RootID(), "contracts")
+	require.NoError(t, err)
+	for _, node := range []int64{first.ID, second.ID} {
+		plan, err := s.PreviewInitialAudit(t.Context(), node, "api", nil)
+		require.NoError(t, err)
+		_, err = s.EnableInitialAudit(t.Context(), plan)
+		require.NoError(t, err)
+	}
+	tag, err := s.CreateTag(t.Context(), "records")
+	require.NoError(t, err)
+	firstAssignment, err := s.AssignTag(t.Context(), tag.ID, first.ID, first.Revision)
+	require.NoError(t, err)
+	secondAssignment, err := s.AssignTag(t.Context(), tag.ID, second.ID, second.Revision)
+	require.NoError(t, err)
+
+	resp, body := do(t, ts, http.MethodPatch, "/api/v1/tags/"+tag.ID,
+		map[string]string{"If-Match": strconv.Quote(strconv.FormatInt(
+			secondAssignment.Tag.Revision, 10,
+		))}, map[string]any{"name": "permanent records"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var renamed api.Tag
+	require.NoError(t, json.Unmarshal([]byte(body), &renamed))
+	assert.Equal(t, "permanent records", renamed.Name)
+	firstAfter, err := s.NodeByID(t.Context(), first.ID)
+	require.NoError(t, err)
+	secondAfter, err := s.NodeByID(t.Context(), second.ID)
+	require.NoError(t, err)
+	assert.Equal(t, firstAssignment.Node.Revision+1, firstAfter.Revision)
+	assert.Equal(t, secondAssignment.Node.Revision+1, secondAfter.Revision)
+
+	resp, body = do(t, ts, http.MethodDelete, "/api/v1/tags/"+tag.ID,
+		map[string]string{"If-Match": strconv.Quote(strconv.FormatInt(renamed.Revision, 10))}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var deleted api.TagDeletionReceipt
+	require.NoError(t, json.Unmarshal([]byte(body), &deleted))
+	assert.Equal(t, 2, deleted.RemovedAssignments)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
 func TestTagPathAssignmentUsesCurrentTopology(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	left, err := s.Mkdir(t.Context(), s.RootID(), "left")

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -337,11 +337,12 @@ func validateAuditedHistory(
 		if topologyErr != nil {
 			return fmt.Errorf("validating audit operation %d: %w", sequence, topologyErr)
 		}
-		mutationScopeID, scopeErr := auditMutationScopeID(mutation.record)
+		mutationScopeIDs, scopeErr := auditMutationScopeIDs(mutation.record)
 		if scopeErr != nil {
 			return fmt.Errorf("validating audit operation %d: %w", sequence, scopeErr)
 		}
-		if len(bindings) != 0 && topologyValue.IsAbsent() && replay.scopes[mutationScopeID] == nil {
+		if len(bindings) != 0 && topologyValue.IsAbsent() && len(mutationScopeIDs) == 1 &&
+			replay.scopes[mutationScopeIDs[0]] == nil {
 			err = replay.applyAdditionalScopeEnrollment(
 				vaultID, mutation, allocation, scopes, entries, baselines, events,
 				usedBaselines, usedEvents,
@@ -351,13 +352,24 @@ func validateAuditedHistory(
 			}
 			continue
 		}
-		if err := replay.activateScope(mutationScopeID); err != nil {
-			return fmt.Errorf("validating audit operation %d: %w", sequence, err)
+		if len(mutationScopeIDs) > 1 && (len(bindings) != 0 || !topologyValue.IsAbsent()) {
+			return fmt.Errorf(
+				"validating audit operation %d: cross-scope mutation has unsupported topology or baselines",
+				sequence,
+			)
 		}
-		scopeEntry, ok := entries[mutationScopeID][replay.scopeEntryCount+1]
-		if !ok {
-			return fmt.Errorf("validating audit operation %d: audit scope chain is incomplete", sequence)
+		scopeEntries := make(map[string]storedAuditRecord, len(mutationScopeIDs))
+		for _, scopeID := range mutationScopeIDs {
+			if err := replay.activateScope(scopeID); err != nil {
+				return fmt.Errorf("validating audit operation %d: %w", sequence, err)
+			}
+			scopeEntry, ok := entries[scopeID][replay.scopeEntryCount+1]
+			if !ok {
+				return fmt.Errorf("validating audit operation %d: audit scope chain is incomplete", sequence)
+			}
+			scopeEntries[scopeID] = scopeEntry
 		}
+		scopeEntry := scopeEntries[mutationScopeIDs[0]]
 		if len(bindings) == 0 && topologyValue.IsAbsent() {
 			attachedCount, attachedErr := auditUnsignedField(
 				mutation.record, auditAttachedMetadataChangeCountField,
@@ -370,14 +382,16 @@ func validateAuditedHistory(
 					err = kindErr
 				} else if kind == "tag_rename" {
 					err = replay.applyTagDefinitionRename(
-						vaultID, mutation, allocation, scopeEntry,
+						vaultID, mutation, allocation, mutationScopeIDs, scopeEntries,
 						attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
 					)
 				} else if kind == "tag_delete" {
 					err = replay.applyTagDefinitionDelete(
-						vaultID, mutation, allocation, scopeEntry,
+						vaultID, mutation, allocation, mutationScopeIDs, scopeEntries,
 						attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
 					)
+				} else if len(mutationScopeIDs) != 1 {
+					err = errors.New("cross-scope attached-metadata mutation is unsupported")
 				} else {
 					err = replay.applyTagAssignment(
 						vaultID, mutation, allocation, scopeEntry,
@@ -385,17 +399,34 @@ func validateAuditedHistory(
 					)
 				}
 			} else {
+				if len(mutationScopeIDs) != 1 {
+					return fmt.Errorf(
+						"validating audit operation %d: cross-scope content mutation is unsupported",
+						sequence,
+					)
+				}
 				err = replay.applyContentTransition(
 					vaultID, mutation, allocation, scopeEntry, events, usedEvents,
 				)
 			}
 		} else if len(bindings) != 0 {
+			if len(mutationScopeIDs) != 1 {
+				return fmt.Errorf(
+					"validating audit operation %d: cross-scope enrollment is unsupported", sequence,
+				)
+			}
 			err = replay.applyNodeCreation(
 				vaultID, mutation, allocation, scopeEntry,
 				baselines, topologyDeltas, attachmentDeltas, events, usedBaselines,
 				usedTopologyDeltas, usedAttachmentDeltas, usedEvents,
 			)
 		} else {
+			if len(mutationScopeIDs) != 1 {
+				return fmt.Errorf(
+					"validating audit operation %d: cross-scope topology mutation is unsupported",
+					sequence,
+				)
+			}
 			kind, kindErr := classifyAuditedTopologyMutation(mutation.record, topologyDeltas)
 			if kindErr != nil {
 				err = kindErr
@@ -1001,41 +1032,43 @@ func auditScopeRecordsByScope(
 	return result, nil
 }
 
-func auditMutationScopeID(mutation audit.Record) (string, error) {
-	var scopeID string
+func auditMutationScopeIDs(mutation audit.Record) ([]string, error) {
+	scopeSet := make(map[string]bool)
 	consider := func(record audit.Record) error {
 		candidate, err := auditUUIDField(record, auditScopeIDField)
 		if err != nil {
 			return err
 		}
-		if scopeID != "" && scopeID != candidate {
-			return errors.New("audit mutation spans multiple scopes")
-		}
-		scopeID = candidate
+		scopeSet[candidate] = true
 		return nil
 	}
 	bindings, err := auditRecordListField(mutation, "baselines")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	for _, binding := range bindings {
 		if err := consider(binding); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 	events, err := auditRecordListField(mutation, "events")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	for _, event := range events {
 		if err := consider(event); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
-	if scopeID == "" {
-		return "", errors.New("audited mutation has no scope identity")
+	if len(scopeSet) == 0 {
+		return nil, errors.New("audited mutation has no scope identity")
 	}
-	return scopeID, nil
+	scopeIDs := make([]string, 0, len(scopeSet))
+	for scopeID := range scopeSet {
+		scopeIDs = append(scopeIDs, scopeID)
+	}
+	slices.Sort(scopeIDs)
+	return scopeIDs, nil
 }
 
 func auditEventRecordsByID(records []storedAuditRecord) (map[string]storedAuditRecord, error) {
@@ -1360,6 +1393,28 @@ func (replay *auditedHistoryReplay) advanceScope(
 		return err
 	}
 	replay.scopeEntryCount, replay.scopeHead = nextCount, entry.digest
+	return nil
+}
+
+func (replay *auditedHistoryReplay) advanceScopes(
+	vaultID string, mutation storedAuditRecord, scopeIDs []string,
+	entries map[string]storedAuditRecord,
+) error {
+	if len(scopeIDs) == 0 || len(scopeIDs) != len(entries) {
+		return errors.New("audited mutation has inconsistent scope-chain authority")
+	}
+	for _, scopeID := range scopeIDs {
+		if err := replay.activateScope(scopeID); err != nil {
+			return err
+		}
+		entry, ok := entries[scopeID]
+		if !ok {
+			return fmt.Errorf("audited mutation lacks scope-chain entry for %s", scopeID)
+		}
+		if err := replay.advanceScope(vaultID, mutation, entry); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/store/audit_tag_definition_validate.go
+++ b/internal/store/audit_tag_definition_validate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"go.kenn.io/docbank/internal/audit"
 )
@@ -20,7 +21,12 @@ type replayedTagDefinitionChange struct {
 	post       audit.Record
 	change     audit.Record
 	digest     string
-	candidates []uint64
+	candidates []replayedAuditedTagCandidate
+}
+
+type replayedAuditedTagCandidate struct {
+	nodeID  uint64
+	scopeID string
 }
 
 func attachedMutationKind(
@@ -106,6 +112,12 @@ func (replay *auditedHistoryReplay) applyUnscopedTagDefinitionChange(
 	if deletion {
 		transition, err := replay.validateTagDeletionDelta(
 			operationID, digest, deltaRecords, usedDeltas,
+		)
+		if err != nil {
+			return err
+		}
+		transition.candidates, err = replay.auditedTagDefinitionCandidates(
+			transition.tagID,
 		)
 		if err != nil {
 			return err
@@ -303,8 +315,13 @@ func validateReplayedTagDefinition(definition audit.Record) error {
 
 func (replay *auditedHistoryReplay) auditedTagDefinitionCandidates(
 	tagID string,
-) ([]uint64, error) {
-	seen := make(map[uint64]bool)
+) ([]replayedAuditedTagCandidate, error) {
+	scopeIDs := make([]string, 0, len(replay.scopes))
+	for scopeID := range replay.scopes {
+		scopeIDs = append(scopeIDs, scopeID)
+	}
+	slices.Sort(scopeIDs)
+	var result []replayedAuditedTagCandidate
 	for _, record := range replay.attachments {
 		if record.Kind != auditTagAssignmentKind {
 			continue
@@ -320,20 +337,29 @@ func (replay *auditedHistoryReplay) auditedTagDefinitionCandidates(
 		if err != nil {
 			return nil, err
 		}
-		if replay.memberSet[nodeID] {
-			seen[nodeID] = true
+		for _, scopeID := range scopeIDs {
+			if replay.scopes[scopeID].memberSet[nodeID] {
+				result = append(result, replayedAuditedTagCandidate{
+					nodeID: nodeID, scopeID: scopeID,
+				})
+			}
 		}
 	}
-	result := make([]uint64, 0, len(seen))
-	for nodeID := range seen {
-		result = append(result, nodeID)
-	}
-	slices.Sort(result)
+	slices.SortFunc(result, func(left, right replayedAuditedTagCandidate) int {
+		if left.nodeID < right.nodeID {
+			return -1
+		}
+		if left.nodeID > right.nodeID {
+			return 1
+		}
+		return strings.Compare(left.scopeID, right.scopeID)
+	})
 	return result, nil
 }
 
 func (replay *auditedHistoryReplay) applyTagDefinitionRename(
-	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	vaultID string, mutation, allocation storedAuditRecord,
+	scopeIDs []string, scopeEntries map[string]storedAuditRecord,
 	deltaRecords, eventRecords map[string]storedAuditRecord,
 	usedDeltas, usedEvents map[string]bool,
 ) error {
@@ -374,12 +400,17 @@ func (replay *auditedHistoryReplay) applyTagDefinitionRename(
 	if len(transition.candidates) == 0 {
 		return errors.New("tag rename fabricates an audited mutation without affected members")
 	}
+	if err := requireAuditedTagScopeFanout("rename", scopeIDs, transition.candidates); err != nil {
+		return err
+	}
 	if err := replay.validateTagRenameEvents(
 		mutation.record, operationID, transition, eventRecords, usedEvents,
 	); err != nil {
 		return err
 	}
-	if err := replay.validateMemberStateChanges(mutation.record, transition.candidates); err != nil {
+	if err := replay.validateMemberStateChanges(
+		mutation.record, auditedTagCandidateNodeIDs(transition.candidates),
+	); err != nil {
 		return err
 	}
 	bindings, err := auditRecordListField(mutation.record, "baselines")
@@ -409,7 +440,7 @@ func (replay *auditedHistoryReplay) applyTagDefinitionRename(
 	); err != nil {
 		return err
 	}
-	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+	if err := replay.advanceScopes(vaultID, mutation, scopeIDs, scopeEntries); err != nil {
 		return err
 	}
 	if err := replay.advanceAllocation(
@@ -436,14 +467,14 @@ func (replay *auditedHistoryReplay) validateTagRenameEvents(
 		return err
 	}
 	ordinal := uint64(0)
-	for index, nodeID := range transition.candidates {
+	for index, candidate := range transition.candidates {
 		event := events[index]
 		if err := validateAuditEventWrapper(
 			operationID, ordinal, event, eventRecords, usedEvents,
 		); err != nil {
 			return err
 		}
-		state := replay.states[nodeID]
+		state := replay.states[candidate.nodeID]
 		revision, err := auditUnsignedField(state, "node_revision")
 		if err != nil {
 			return err
@@ -458,9 +489,9 @@ func (replay *auditedHistoryReplay) validateTagRenameEvents(
 		}
 		checks := []func() error{
 			func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
-			func() error { return requireAuditUnsigned(event, metadataNodeIDField, nodeID) },
+			func() error { return requireAuditUnsigned(event, metadataNodeIDField, candidate.nodeID) },
 			func() error { return requireAuditText(event, "event_kind", "tag_rename") },
-			func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
+			func() error { return requireAuditUUID(event, auditScopeIDField, candidate.scopeID) },
 			func() error { return requireAuditText(event, "attachment_kind", auditTagDefinitionKind) },
 			func() error { return requireAuditUnsigned(event, auditEventOrdinalField, ordinal) },
 			func() error { return requireAuditUnsigned(event, "prior_node_revision", revision) },
@@ -504,7 +535,41 @@ func (replay *auditedHistoryReplay) applyTagDefinitionState(
 	}
 	replay.attachments[key] = record
 	replay.tagDefinitionIDs[transition.tagID] = true
-	return replay.applyTagAffectedNodeState(transition.candidates, mutation)
+	return replay.applyTagAffectedNodeState(
+		auditedTagCandidateNodeIDs(transition.candidates), mutation,
+	)
+}
+
+func auditedTagCandidateNodeIDs(candidates []replayedAuditedTagCandidate) []uint64 {
+	result := make([]uint64, 0, len(candidates))
+	for _, candidate := range candidates {
+		if len(result) == 0 || result[len(result)-1] != candidate.nodeID {
+			result = append(result, candidate.nodeID)
+		}
+	}
+	return result
+}
+
+func auditedTagCandidateScopeIDs(candidates []replayedAuditedTagCandidate) []string {
+	seen := make(map[string]bool)
+	for _, candidate := range candidates {
+		seen[candidate.scopeID] = true
+	}
+	result := make([]string, 0, len(seen))
+	for scopeID := range seen {
+		result = append(result, scopeID)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func requireAuditedTagScopeFanout(
+	kind string, scopeIDs []string, candidates []replayedAuditedTagCandidate,
+) error {
+	if derived := auditedTagCandidateScopeIDs(candidates); !slices.Equal(scopeIDs, derived) {
+		return fmt.Errorf("tag %s scope chains do not match assigned audited nodes", kind)
+	}
+	return nil
 }
 
 func (replay *auditedHistoryReplay) applyTagAffectedNodeState(

--- a/internal/store/audit_tag_delete.go
+++ b/internal/store/audit_tag_delete.go
@@ -16,7 +16,7 @@ func (s *Store) deleteAuditedTagTx(
 	if err != nil {
 		return Tag{}, err
 	}
-	priorNodes, scope, err := auditedTaggedNodesTx(ctx, tx, current.ID)
+	priorNodes, candidates, scopes, err := auditedTaggedNodesTx(ctx, tx, current.ID)
 	if err != nil {
 		return Tag{}, err
 	}
@@ -46,7 +46,7 @@ func (s *Store) deleteAuditedTagTx(
 	}
 	if err := persistAuditedTagDelete(
 		ctx, tx, s.vaultID, operationID, recordedAt, nodeSequence,
-		authority, scope, current, assignmentNodeIDs, priorNodes, resultingNodes,
+		authority, scopes, candidates, current, assignmentNodeIDs, priorNodes, resultingNodes,
 	); err != nil {
 		return Tag{}, err
 	}
@@ -79,10 +79,12 @@ func tagAssignmentNodeIDsTx(
 
 func persistAuditedTagDelete(
 	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
-	nodeSequence int64, authority auditAuthorityState, scope *auditScopeState,
+	nodeSequence int64, authority auditAuthorityState, scopes []auditScopeState,
+	candidates []auditedTagCandidate,
 	deletedTag Tag, assignmentNodeIDs []int64, priorNodes, resultingNodes []Node,
 ) error {
-	if len(priorNodes) != len(resultingNodes) || (len(priorNodes) != 0) != (scope != nil) {
+	if len(priorNodes) != len(resultingNodes) ||
+		(len(candidates) != 0) != (len(scopes) != 0) {
 		return errors.New("audited tag delete has inconsistent affected-node authority")
 	}
 	sequence, err := nextAuditInteger("operation sequence", authority.sequence)
@@ -128,29 +130,34 @@ func persistAuditedTagDelete(
 		changeCount++
 	}
 	mutationHash := audit.Absent()
-	if len(priorNodes) != 0 {
-		events := make([]audit.Record, 0, len(priorNodes)*2)
+	if len(candidates) != 0 {
+		priorByID := nodesByID(priorNodes)
+		resultingByID := nodesByID(resultingNodes)
+		events := make([]audit.Record, 0, len(candidates)*2)
 		stateChanges := make([]audit.Record, len(priorNodes))
 		ordinal := uint64(0)
-		for index := range priorNodes {
+		for _, candidate := range candidates {
 			definitionEvent, err := makeAuditedTagDeleteEvent(
-				values, scope.scopeID, ordinal, priorNodes[index], resultingNodes[index], definition,
+				values, candidate.scopeID, ordinal, priorByID[candidate.nodeID],
+				resultingByID[candidate.nodeID], definition,
 			)
 			if err != nil {
 				return err
 			}
 			events = append(events, definitionEvent)
 			ordinal++
-			assignment := assignments[priorNodes[index].ID]
 			unassignEvent, err := makeAuditedTagAssignmentEvent(
-				values, scope.scopeID, ordinal, priorNodes[index], resultingNodes[index],
-				assignment, false,
+				values, candidate.scopeID, ordinal, priorByID[candidate.nodeID],
+				resultingByID[candidate.nodeID],
+				assignments[candidate.nodeID], false,
 			)
 			if err != nil {
 				return err
 			}
 			events = append(events, unassignEvent)
 			ordinal++
+		}
+		for index := range priorNodes {
 			stateChanges[index], err = makeAuditMemberStateChange(
 				priorNodes[index], resultingNodes[index],
 			)
@@ -189,7 +196,7 @@ func persistAuditedTagDelete(
 			return err
 		}
 		if err := advanceAuditedMutationScopes(
-			ctx, tx, values, []auditScopeState{*scope}, mutationDigest.value,
+			ctx, tx, values, scopes, mutationDigest.value,
 		); err != nil {
 			return err
 		}

--- a/internal/store/audit_tag_delete_test.go
+++ b/internal/store/audit_tag_delete_test.go
@@ -178,7 +178,8 @@ func TestAuditedTagDeleteReplayRejectsOmittedAssignmentTombstone(t *testing.T) {
 	deltas[deleteDigest] = malformed
 
 	err = replay.applyTagDefinitionDelete(
-		s.vaultID, mutations[3], allocations[3], entries[3],
+		s.vaultID, mutations[3], allocations[3], []string{scope.scopeID},
+		map[string]storedAuditRecord{scope.scopeID: entries[3]},
 		deltas, events, usedDeltas, usedEvents,
 	)
 	require.ErrorContains(t, err, "complete assignment set")

--- a/internal/store/audit_tag_delete_validate.go
+++ b/internal/store/audit_tag_delete_validate.go
@@ -13,7 +13,7 @@ type replayedTagDeletion struct {
 	definition  audit.Record
 	assignments map[uint64]audit.Record
 	allNodes    []uint64
-	candidates  []uint64
+	candidates  []replayedAuditedTagCandidate
 	digest      string
 	changeCount uint64
 }
@@ -151,9 +151,6 @@ func (replay *auditedHistoryReplay) validateTagDeletionDelta(
 				"tag deletion includes an assignment for another definition",
 			)
 		}
-		if replay.memberSet[nodeID] {
-			transition.candidates = append(transition.candidates, nodeID)
-		}
 	}
 	expectedNodes, err := replay.tagAssignmentNodes(transition.tagID)
 	if err != nil {
@@ -192,7 +189,8 @@ func (replay *auditedHistoryReplay) tagAssignmentNodes(tagID string) ([]uint64, 
 }
 
 func (replay *auditedHistoryReplay) applyTagDefinitionDelete(
-	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	vaultID string, mutation, allocation storedAuditRecord,
+	scopeIDs []string, scopeEntries map[string]storedAuditRecord,
 	deltaRecords, eventRecords map[string]storedAuditRecord,
 	usedDeltas, usedEvents map[string]bool,
 ) error {
@@ -223,15 +221,24 @@ func (replay *auditedHistoryReplay) applyTagDefinitionDelete(
 	if err != nil {
 		return err
 	}
+	transition.candidates, err = replay.auditedTagDefinitionCandidates(transition.tagID)
+	if err != nil {
+		return err
+	}
 	if len(transition.candidates) == 0 {
 		return errors.New("tag deletion fabricates an audited mutation without affected members")
+	}
+	if err := requireAuditedTagScopeFanout("deletion", scopeIDs, transition.candidates); err != nil {
+		return err
 	}
 	if err := replay.validateTagDeleteEvents(
 		mutation.record, operationID, transition, eventRecords, usedEvents,
 	); err != nil {
 		return err
 	}
-	if err := replay.validateMemberStateChanges(mutation.record, transition.candidates); err != nil {
+	if err := replay.validateMemberStateChanges(
+		mutation.record, auditedTagCandidateNodeIDs(transition.candidates),
+	); err != nil {
 		return err
 	}
 	bindings, err := auditRecordListField(mutation.record, "baselines")
@@ -261,7 +268,7 @@ func (replay *auditedHistoryReplay) applyTagDefinitionDelete(
 	); err != nil {
 		return err
 	}
-	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+	if err := replay.advanceScopes(vaultID, mutation, scopeIDs, scopeEntries); err != nil {
 		return err
 	}
 	if err := replay.advanceAllocation(
@@ -284,8 +291,8 @@ func (replay *auditedHistoryReplay) validateTagDeleteEvents(
 		return errors.New("tag deletion event set does not match assigned audited nodes")
 	}
 	ordinal := uint64(0)
-	for _, nodeID := range transition.candidates {
-		state := replay.states[nodeID]
+	for _, candidate := range transition.candidates {
+		state := replay.states[candidate.nodeID]
 		revision, err := auditUnsignedField(state, "node_revision")
 		if err != nil {
 			return err
@@ -299,7 +306,7 @@ func (replay *auditedHistoryReplay) validateTagDeleteEvents(
 			attachment audit.Record
 		}{
 			{"tag_delete", transition.definition},
-			{"tag_unassign", transition.assignments[nodeID]},
+			{"tag_unassign", transition.assignments[candidate.nodeID]},
 		}
 		for _, item := range expected {
 			event := events[ordinal]
@@ -309,8 +316,8 @@ func (replay *auditedHistoryReplay) validateTagDeleteEvents(
 				return err
 			}
 			if err := validateTagDeleteEvent(
-				mutation, event, operationID, ordinal, nodeID, revision, current,
-				replay.scopeID, item.kind, item.attachment,
+				mutation, event, operationID, ordinal, candidate.nodeID, revision, current,
+				candidate.scopeID, item.kind, item.attachment,
 			); err != nil {
 				return err
 			}
@@ -378,5 +385,7 @@ func (replay *auditedHistoryReplay) applyTagDeletionState(
 		}
 		delete(replay.attachments, key)
 	}
-	return replay.applyTagAffectedNodeState(transition.candidates, mutation)
+	return replay.applyTagAffectedNodeState(
+		auditedTagCandidateNodeIDs(transition.candidates), mutation,
+	)
 }

--- a/internal/store/audit_tag_rename.go
+++ b/internal/store/audit_tag_rename.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	"go.kenn.io/docbank/internal/audit"
 )
@@ -12,7 +14,7 @@ import (
 func (s *Store) renameAuditedTagTx(
 	ctx context.Context, tx *sql.Tx, current Tag, name string,
 ) (Tag, error) {
-	priorNodes, scope, err := auditedTaggedNodesTx(ctx, tx, current.ID)
+	priorNodes, candidates, scopes, err := auditedTaggedNodesTx(ctx, tx, current.ID)
 	if err != nil {
 		return Tag{}, err
 	}
@@ -41,11 +43,16 @@ func (s *Store) renameAuditedTagTx(
 	}
 	if err := persistAuditedTagRename(
 		ctx, tx, s.vaultID, operationID, recordedAt, nodeSequence,
-		authority, scope, current, renamed, priorNodes, resultingNodes,
+		authority, scopes, candidates, current, renamed, priorNodes, resultingNodes,
 	); err != nil {
 		return Tag{}, err
 	}
 	return renamed, nil
+}
+
+type auditedTagCandidate struct {
+	nodeID  int64
+	scopeID string
 }
 
 func touchAuditedTagDefinitionNodesTx(
@@ -70,7 +77,7 @@ func touchAuditedTagDefinitionNodesTx(
 
 func auditedTaggedNodesTx(
 	ctx context.Context, tx *sql.Tx, tagID string,
-) ([]Node, *auditScopeState, error) {
+) ([]Node, []auditedTagCandidate, []auditScopeState, error) {
 	rows, err := tx.QueryContext(ctx, `SELECT membership.node_id,scope.scope_id,
 		scope.entry_count,scope.chain_head
 		FROM node_tags assignment
@@ -78,12 +85,13 @@ func auditedTaggedNodesTx(
 		JOIN audit_scopes scope ON scope.scope_id=membership.scope_id
 		WHERE assignment.tag_id=? ORDER BY membership.node_id,scope.scope_id`, tagID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("listing audited nodes assigned tag %s: %w", tagID, err)
+		return nil, nil, nil, fmt.Errorf("listing audited nodes assigned tag %s: %w", tagID, err)
 	}
 	defer func() { _ = rows.Close() }()
 	var (
-		nodeIDs []int64
-		scope   *auditScopeState
+		nodeIDs    []int64
+		candidates []auditedTagCandidate
+		scopeByID  = make(map[string]auditScopeState)
 	)
 	for rows.Next() {
 		var nodeID int64
@@ -92,45 +100,48 @@ func auditedTaggedNodesTx(
 			&nodeID, &current.scopeID, &current.entryCount, &current.chainHead,
 		); err != nil {
 			_ = rows.Close()
-			return nil, nil, fmt.Errorf("scanning audited tag assignment: %w", err)
+			return nil, nil, nil, fmt.Errorf("scanning audited tag assignment: %w", err)
 		}
-		if scope != nil && scope.scopeID != current.scopeID {
-			_ = rows.Close()
-			return nil, nil, fmt.Errorf(
-				"tag definition change affects multiple audit scopes: %w",
-				ErrAuditMutationUnsupported,
-			)
-		}
-		if scope == nil {
-			scope = &current
-		}
+		candidates = append(candidates, auditedTagCandidate{nodeID: nodeID, scopeID: current.scopeID})
+		scopeByID[current.scopeID] = current
 		if len(nodeIDs) == 0 || nodeIDs[len(nodeIDs)-1] != nodeID {
 			nodeIDs = append(nodeIDs, nodeID)
 		}
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
-		return nil, nil, fmt.Errorf("listing audited nodes assigned tag %s: %w", tagID, err)
+		return nil, nil, nil, fmt.Errorf("listing audited nodes assigned tag %s: %w", tagID, err)
 	}
 	if err := rows.Close(); err != nil {
-		return nil, nil, fmt.Errorf("closing audited tag assignment rows: %w", err)
+		return nil, nil, nil, fmt.Errorf("closing audited tag assignment rows: %w", err)
 	}
+	// The query is node-first for canonical event ordering, so collect scope
+	// authority independently and sort it before advancing the scope chains.
+	scopes := make([]auditScopeState, 0, len(scopeByID))
+	for _, scope := range scopeByID {
+		scopes = append(scopes, scope)
+	}
+	slices.SortFunc(scopes, func(left, right auditScopeState) int {
+		return strings.Compare(left.scopeID, right.scopeID)
+	})
 	nodes := make([]Node, len(nodeIDs))
 	for index, nodeID := range nodeIDs {
 		nodes[index], err = nodeByIDTx(tx, nodeID)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
-	return nodes, scope, nil
+	return nodes, candidates, scopes, nil
 }
 
 func persistAuditedTagRename(
 	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
-	nodeSequence int64, authority auditAuthorityState, scope *auditScopeState,
+	nodeSequence int64, authority auditAuthorityState, scopes []auditScopeState,
+	candidates []auditedTagCandidate,
 	priorTag, resultingTag Tag, priorNodes, resultingNodes []Node,
 ) error {
-	if len(priorNodes) != len(resultingNodes) || (len(priorNodes) != 0) != (scope != nil) {
+	if len(priorNodes) != len(resultingNodes) ||
+		(len(candidates) != 0) != (len(scopes) != 0) {
 		return errors.New("audited tag rename has inconsistent affected-node authority")
 	}
 	sequence, err := nextAuditInteger("operation sequence", authority.sequence)
@@ -161,17 +172,22 @@ func persistAuditedTagRename(
 		return err
 	}
 	mutationHash := audit.Absent()
-	if len(priorNodes) != 0 {
-		events := make([]audit.Record, len(priorNodes))
+	if len(candidates) != 0 {
+		priorByID := nodesByID(priorNodes)
+		resultingByID := nodesByID(resultingNodes)
+		events := make([]audit.Record, len(candidates))
 		stateChanges := make([]audit.Record, len(priorNodes))
-		for index := range priorNodes {
+		for index, candidate := range candidates {
 			events[index], err = makeAuditedTagRenameEvent(
-				values, scope.scopeID, uint64(index), priorNodes[index], resultingNodes[index],
+				values, candidate.scopeID, uint64(index), priorByID[candidate.nodeID],
+				resultingByID[candidate.nodeID],
 				priorDefinition, resultingDefinition,
 			)
 			if err != nil {
 				return err
 			}
+		}
+		for index := range priorNodes {
 			stateChanges[index], err = makeAuditMemberStateChange(
 				priorNodes[index], resultingNodes[index],
 			)
@@ -210,7 +226,7 @@ func persistAuditedTagRename(
 			return err
 		}
 		if err := advanceAuditedMutationScopes(
-			ctx, tx, values, []auditScopeState{*scope}, mutationDigest.value,
+			ctx, tx, values, scopes, mutationDigest.value,
 		); err != nil {
 			return err
 		}
@@ -227,6 +243,14 @@ func persistAuditedTagRename(
 		return err
 	}
 	return advanceAuditAuthority(ctx, tx, authority, sequence, allocation)
+}
+
+func nodesByID(nodes []Node) map[int64]Node {
+	result := make(map[int64]Node, len(nodes))
+	for _, node := range nodes {
+		result[node.ID] = node
+	}
+	return result
 }
 
 func makeAuditedTagRenameEvent(

--- a/internal/store/audit_tag_rename_test.go
+++ b/internal/store/audit_tag_rename_test.go
@@ -3,7 +3,9 @@ package store
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,27 +93,76 @@ func TestAuditedTagRenameNoOpDoesNotAdvanceHistory(t *testing.T) {
 	require.NoError(t, s.ValidateMetadata(t.Context()))
 }
 
-func TestAuditedTagDefinitionChangesAcrossScopesFailClosed(t *testing.T) {
-	tests := map[string]func(*Store, Tag) error{
-		"rename": func(s *Store, tag Tag) error {
-			_, err := s.RenameTag(t.Context(), tag.ID, tag.Revision, "renamed")
-			return err
-		},
-		"delete": func(s *Store, tag Tag) error {
-			_, err := s.DeleteTag(t.Context(), tag.ID, tag.Revision)
-			return err
-		},
-	}
-	for name, change := range tests {
+func TestAuditedTagDefinitionChangesAdvanceEveryAffectedScope(t *testing.T) {
+	for _, name := range []string{"rename", "delete"} {
 		t.Run(name, func(t *testing.T) {
 			s, tag, first, second := newMultiScopeAuditedTagStore(t)
-			var sequence int64
+			beforeScopes := auditScopeEntryCounts(t, s)
+			var beforeSequence int64
 			require.NoError(t, s.db.QueryRow(
 				`SELECT operation_sequence_high_water FROM audit_authority`,
-			).Scan(&sequence))
+			).Scan(&beforeSequence))
 
-			err := change(s, tag)
-			require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+			if name == "rename" {
+				renamed, err := s.RenameTag(t.Context(), tag.ID, tag.Revision, "renamed")
+				require.NoError(t, err)
+				assert.Equal(t, "renamed", renamed.Name)
+			} else {
+				_, err := s.DeleteTag(t.Context(), tag.ID, tag.Revision)
+				require.NoError(t, err)
+				_, err = s.TagByID(t.Context(), tag.ID)
+				require.ErrorIs(t, err, ErrNotFound)
+			}
+			for _, prior := range []Node{first, second} {
+				node, err := s.NodeByID(t.Context(), prior.ID)
+				require.NoError(t, err)
+				assert.Equal(t, prior.Revision+1, node.Revision)
+			}
+			var afterSequence int64
+			require.NoError(t, s.db.QueryRow(
+				`SELECT operation_sequence_high_water FROM audit_authority`,
+			).Scan(&afterSequence))
+			assert.Equal(t, beforeSequence+1, afterSequence)
+			afterScopes := auditScopeEntryCounts(t, s)
+			require.Len(t, afterScopes, len(beforeScopes))
+			for scopeID, before := range beforeScopes {
+				assert.Equal(t, before+1, afterScopes[scopeID])
+			}
+			events := auditEventsForSequence(t, s, afterSequence)
+			if name == "rename" {
+				require.Len(t, events, 2)
+			} else {
+				require.Len(t, events, 4)
+			}
+			assert.Equal(t, sortedStringKeys(beforeScopes), auditEventScopeIDs(t, events))
+			require.NoError(t, s.ValidateMetadata(t.Context()))
+			assertAuditMetadataRoundTrip(t, s)
+		})
+	}
+}
+
+func TestAuditedTagDefinitionChangesAcrossScopesRollBackAtomically(t *testing.T) {
+	for _, name := range []string{"rename", "delete"} {
+		t.Run(name, func(t *testing.T) {
+			s, tag, first, second := newMultiScopeAuditedTagStore(t)
+			beforeScopes := auditScopeEntryCounts(t, s)
+			scopeIDs := sortedStringKeys(beforeScopes)
+			require.Len(t, scopeIDs, 2)
+			_, err := s.db.Exec(fmt.Sprintf(`CREATE TRIGGER reject_second_scope_advance
+				BEFORE UPDATE ON audit_scopes WHEN OLD.scope_id='%s' BEGIN
+				SELECT RAISE(ABORT, 'forced second scope failure'); END`, scopeIDs[1]))
+			require.NoError(t, err)
+			var beforeSequence int64
+			require.NoError(t, s.db.QueryRow(
+				`SELECT operation_sequence_high_water FROM audit_authority`,
+			).Scan(&beforeSequence))
+
+			if name == "rename" {
+				_, err = s.RenameTag(t.Context(), tag.ID, tag.Revision, "renamed")
+			} else {
+				_, err = s.DeleteTag(t.Context(), tag.ID, tag.Revision)
+			}
+			require.ErrorContains(t, err, "forced second scope failure")
 			current, err := s.TagByID(t.Context(), tag.ID)
 			require.NoError(t, err)
 			assert.Equal(t, tag, current)
@@ -120,14 +171,68 @@ func TestAuditedTagDefinitionChangesAcrossScopesFailClosed(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, prior, node)
 			}
-			var after int64
+			assert.Equal(t, beforeScopes, auditScopeEntryCounts(t, s))
+			var afterSequence int64
 			require.NoError(t, s.db.QueryRow(
 				`SELECT operation_sequence_high_water FROM audit_authority`,
-			).Scan(&after))
-			assert.Equal(t, sequence, after)
+			).Scan(&afterSequence))
+			assert.Equal(t, beforeSequence, afterSequence)
 			require.NoError(t, s.ValidateMetadata(t.Context()))
 		})
 	}
+}
+
+func TestAuditedTagDefinitionReplayRejectsOmittedScopeFanout(t *testing.T) {
+	candidates := []replayedAuditedTagCandidate{
+		{nodeID: 10, scopeID: "11111111-1111-4111-8111-111111111111"},
+		{nodeID: 20, scopeID: "22222222-2222-4222-8222-222222222222"},
+	}
+	err := requireAuditedTagScopeFanout(
+		"rename", []string{"11111111-1111-4111-8111-111111111111"}, candidates,
+	)
+	require.ErrorContains(t, err, "scope chains do not match assigned audited nodes")
+}
+
+func sortedStringKeys(values map[string]int64) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func auditEventScopeIDs(t *testing.T, events []audit.Record) []string {
+	t.Helper()
+	seen := make(map[string]bool)
+	for _, event := range events {
+		scopeID, err := auditUUIDField(event, auditScopeIDField)
+		require.NoError(t, err)
+		seen[scopeID] = true
+	}
+	result := make([]string, 0, len(seen))
+	for scopeID := range seen {
+		result = append(result, scopeID)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func auditScopeEntryCounts(t *testing.T, s *Store) map[string]int64 {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT scope_id,entry_count FROM audit_scopes ORDER BY scope_id`)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rows.Close() })
+	result := make(map[string]int64)
+	for rows.Next() {
+		var scopeID string
+		var count int64
+		require.NoError(t, rows.Scan(&scopeID, &count))
+		result[scopeID] = count
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	return result
 }
 
 func newMultiScopeAuditedTagStore(t *testing.T) (*Store, Tag, Node, Node) {
@@ -240,7 +345,8 @@ func TestAuditedTagRenameReplayRejectsOmittedMemberEffect(t *testing.T) {
 	)
 
 	err = replay.applyTagDefinitionRename(
-		s.vaultID, malformed, allocations[3], entries[3],
+		s.vaultID, malformed, allocations[3], []string{scope.scopeID},
+		map[string]storedAuditRecord{scope.scopeID: entries[3]},
 		deltas, events, usedDeltas, usedEvents,
 	)
 	require.ErrorContains(t, err, "event set does not match assigned audited nodes")


### PR DESCRIPTION
A tag can legitimately organize documents in several permanently protected directories. For example, the same `records` tag may be assigned under both `/taxes` and `/contracts`. Until now, renaming or deleting that tag failed even though both scopes and every assignment were otherwise valid.

This makes the definition change one atomic audited operation. Renaming the shared tag records the change for every protected assigned node; deleting it also records every assignment removal. Each affected scope chain advances exactly once, the vault-wide allocation lineage advances once, and either the complete operation commits or nothing changes. Existing optimistic tag revisions still prevent a stale caller from overwriting a newer assignment set.

Portable JSONL restore does not trust the scope list written by the mutation. It independently derives the affected members and scopes from the replayed assignments and rejects a stream that omits a member event or one scope-chain advance. The existing backup and restore path therefore preserves the complete cross-scope history without a new schema or metadata format.

This deliberately keeps the current enrollment boundary: scopes must still be disjoint. Overlapping scopes and cross-scope topology changes such as moves remain separate work because they require broader mutation semantics than this shared metadata operation.