### PR TITLE
Expose generic provenance through the embedded API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Four commitments:
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows
 
+Embedded generic source provenance is newer than v0.10.1. Build from `main` to
+use it until the next release is tagged.
+
 See the [roadmap](docs/roadmap.md) for high-level product direction beyond the
 capabilities listed here.
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ Four commitments:
 - Whole-vault integrity verification
 - Incremental backup repositories with create, list, verify, and confined restore
 - Daemon-first CLI, authenticated loopback HTTP API, and offline OpenAPI output
-- An embedded Go API with exclusive non-overlapping roots, immutable create and
-  verified blob repair, stable bounded tree walks, optional automatic loose
-  zstd storage, resumable maintenance, and selectable CGO or pure-Go SQLite
+- An embedded Go API with exclusive non-overlapping roots, immutable create,
+  generic source provenance, verified blob repair, stable bounded tree walks,
+  optional automatic loose zstd storage, resumable maintenance, and selectable
+  CGO or pure-Go SQLite
 - A release pipeline for Linux, macOS, and Windows on amd64 and arm64, with
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -77,9 +77,47 @@ receipt, err := vault.Create(ctx, "/records/immutable.jsonl", reader,
     docbank.CreateOptions{
         MediaType: "application/x-ndjson",
         Expected: docbank.ContentIdentity{SHA256: digest, Size: size},
+        Provenance: &docbank.ProvenanceSource{
+            Kind:        "agent-session",
+            Description: "local session archive",
+            Reference:   "sessions/01K123.jsonl",
+        },
     },
 )
 ```
+
+`CreateOptions.Provenance` lets an embedded owner record where an immutable
+document came from without inventing application-specific Docbank tables. The
+kind and description identify the source system; the reference is an opaque
+source-local URI, archive key, path, or other stable identifier. An optional
+`ModifiedAt` records the source's own timestamp in canonical UTC form. Docbank
+does not interpret the reference or grant it retention authority.
+
+For a newly created document, the node, first content version, ingest record,
+and provenance fact commit as one metadata transaction. If any part fails,
+none gains authority. An exact `Create` retry succeeds only when its active
+provenance also matches, so a caller cannot accidentally claim source evidence
+that was never recorded. Use `Provenance` to inspect the bounded newest-first
+history:
+
+```go
+page, err := vault.Provenance(ctx, receipt.Node.ID, docbank.ProvenanceOptions{
+    Limit: 100,
+})
+if err != nil {
+    return err
+}
+for _, fact := range page.Items {
+    // fact.SourceReference remains the exact opaque identifier supplied above.
+    _ = fact
+}
+```
+
+The node, live path, total, and page come from one read snapshot. `Path` is
+empty for a trashed node. Provenance is evidence, not ownership: it does not
+prevent trash empty, version pruning, or garbage collection. Applications that
+need independent retention authority should keep that policy outside Docbank
+until the external-reference contract is implemented.
 
 `ContentIdentity` always describes decoded document bytes, regardless of
 whether those bytes are stored raw, zstd-compressed, or in a pack. SHA-256 is

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -72,6 +72,12 @@ different content already stored there. It requires the expected SHA-256 and
 size. An exact retry is idempotent; a different byte identity, media type, or
 node kind returns `ErrContentConflict` without appending a version:
 
+!!! info "Release availability"
+
+    Embedded source provenance is newer than v0.10.1. Build from `main` to use
+    `CreateOptions.Provenance` and `Vault.Provenance` until the next release is
+    tagged.
+
 ```go
 receipt, err := vault.Create(ctx, "/records/immutable.jsonl", reader,
     docbank.CreateOptions{

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -123,12 +123,11 @@ and authenticated API.
   [model](architecture/audited-history.md))
 - Additional text extraction workers for PDF text layers and office formats;
   bounded UTF-8 text, Markdown, JSON, and JSONL extraction is implemented
-- External integration surface: generalized ingest provenance —
-  today's provenance API records and exposes the original filesystem path and
-  mtime; `source_kind` / `source_ref` / `source_meta` fields extend it
-  to non-file origins (a watched inbox, another application's archive)
-  as generic fields, never application-specific tables. To settle before an
-  external-reference schema exists: whether external
+- External integration surface: embedded immutable creation accepts generic
+  source kind, description, opaque reference, and optional modification time,
+  and exposes those portable facts through the root Go API. Standalone local
+  ingestion still presents its source as a filesystem path. To settle before
+  an external-reference schema exists: whether external
   references pin nodes against `trash empty`/`gc`, or dangling-ref
   detection stays the referrer's job (docbank guarantees only that node
   ids are never reused)

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -30,6 +30,9 @@ var (
 	// ErrVersionAlreadyCurrent means a revert selected the node's current head,
 	// which is not a historical transition.
 	ErrVersionAlreadyCurrent = errors.New("content version is already current")
+	// ErrProvenanceMismatch means an immutable retry named source evidence
+	// that is not an active fact on the existing document.
+	ErrProvenanceMismatch = errors.New("provenance does not match existing content")
 	// ErrInvalidVersionPrune means a history-pruning selector is absent,
 	// contradictory, or otherwise unsafe to execute.
 	ErrInvalidVersionPrune = errors.New("invalid version-prune selector")

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -12,7 +12,8 @@ import (
 // that is published with its first imported file. Holding a run grants no
 // metadata authority by itself.
 type IngestRun struct {
-	record metadataIngest
+	record           metadataIngest
+	operationalWatch bool
 }
 
 // ID returns the stable ingest identity.
@@ -22,6 +23,20 @@ func (r IngestRun) ID() string { return r.record.ID }
 // atomically with the first file that actually imports, so audited vaults never
 // contain a run whose provenance was committed in a separate transaction.
 func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) (IngestRun, error) {
+	return s.beginIngest(ctx, sourceKind, sourceDesc, sourceKind == "watch")
+}
+
+// BeginEmbeddedIngest prepares generic provenance without interpreting any
+// source kind as daemon-owned operational state.
+func (s *Store) BeginEmbeddedIngest(
+	ctx context.Context, sourceKind, sourceDesc string,
+) (IngestRun, error) {
+	return s.beginIngest(ctx, sourceKind, sourceDesc, false)
+}
+
+func (s *Store) beginIngest(
+	ctx context.Context, sourceKind, sourceDesc string, operationalWatch bool,
+) (IngestRun, error) {
 	if err := ctx.Err(); err != nil {
 		return IngestRun{}, err
 	}
@@ -36,7 +51,65 @@ func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) 
 	if err := validateIngestRecord(record); err != nil {
 		return IngestRun{}, fmt.Errorf("validating ingest start: %w", err)
 	}
-	return IngestRun{record: record}, nil
+	return IngestRun{record: record, operationalWatch: operationalWatch}, nil
+}
+
+func validateProvenanceSourceFields(
+	sourceKind, sourceDescription, sourceReference, sourceModifiedAt string,
+) error {
+	if sourceKind == "" || sourceDescription == "" || sourceReference == "" {
+		return errors.New("provenance source kind, description, and reference are required")
+	}
+	for name, value := range map[string]string{
+		"kind": sourceKind, "description": sourceDescription, "reference": sourceReference,
+	} {
+		if err := validateUTF8Field("provenance source "+name, value); err != nil {
+			return err
+		}
+	}
+	if sourceModifiedAt != "" {
+		if err := validateProvenanceTime(sourceModifiedAt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func activeProvenanceMatchesTx(
+	ctx context.Context, tx *sql.Tx, nodeID int64,
+	sourceKind, sourceDescription, sourceReference, sourceModifiedAt string,
+) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT i.source_kind, i.source_desc, p.original_path, p.original_mtime
+		FROM provenance AS p JOIN ingests AS i ON i.id = p.ingest_id
+		WHERE p.node_id = ?
+		  AND NOT EXISTS (
+			SELECT 1 FROM provenance AS successor WHERE successor.supersedes = p.identity
+		  )`, nodeID)
+	if err != nil {
+		return false, fmt.Errorf("reading active provenance for node %d: %w", nodeID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var kind, description, reference string
+		var modifiedAt sql.NullString
+		if err := rows.Scan(&kind, &description, &reference, &modifiedAt); err != nil {
+			return false, fmt.Errorf("scanning active provenance for node %d: %w", nodeID, err)
+		}
+		wantModifiedAt := sourceModifiedAt
+		gotModifiedAt := ""
+		if modifiedAt.Valid {
+			gotModifiedAt = modifiedAt.String
+		}
+		if kind == sourceKind && description == sourceDescription &&
+			reference == sourceReference && gotModifiedAt == wantModifiedAt {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("reading active provenance for node %d: %w", nodeID, err)
+	}
+	return false, nil
 }
 
 // ensureIngestRunTx publishes run once and rejects any identity collision with
@@ -190,30 +263,43 @@ func sameOriginTx(tx *sql.Tx, nodeID int64, name string, allowUnknown bool) (boo
 // applying the idempotency rule and recording provenance. Returns
 // added=false when the content is already present under a candidate name.
 func (s *Store) IngestFile(ctx context.Context, run IngestRun, parentID int64, name, blobHash string, size int64, mimeType, originalPath, originalMtime string, physical ...BlobPhysical) (Node, bool, error) {
-	return s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
-		originalPath, originalMtime, false, physical...)
+	receipt, added, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
+		originalPath, originalMtime, false, false, physical...)
+	return receipt.Node, added, err
 }
 
 // IngestFileExact imports one already-durable blob under exactly name. Unlike
 // bulk migration it never suffixes or adopts an existing same-content node;
 // a watched source needs its configured source identity to remain one-to-one.
 func (s *Store) IngestFileExact(ctx context.Context, run IngestRun, parentID int64, name, blobHash string, size int64, mimeType, originalPath, originalMtime string, physical ...BlobPhysical) (Node, error) {
-	node, _, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
-		originalPath, originalMtime, true, physical...)
-	return node, err
+	receipt, _, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
+		originalPath, originalMtime, true, false, physical...)
+	return receipt.Node, err
+}
+
+// IngestFileExactWithReceipt is the receipt-bearing form used by embedded
+// immutable creation. File, version, provenance, ingest, and physical catalog
+// authority commit in one metadata transaction.
+func (s *Store) IngestFileExactWithReceipt(
+	ctx context.Context, run IngestRun, parentID int64, name, blobHash string,
+	size int64, mimeType, originalPath, originalMtime string, physical ...BlobPhysical,
+) (ContentWriteReceipt, error) {
+	receipt, _, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
+		originalPath, originalMtime, true, true, physical...)
+	return receipt, err
 }
 
 func (s *Store) ingestFile(
 	ctx context.Context, run IngestRun, parentID int64, name, blobHash string,
-	size int64, mimeType, originalPath, originalMtime string, exact bool,
+	size int64, mimeType, originalPath, originalMtime string, exact, completeReceipt bool,
 	physical ...BlobPhysical,
-) (Node, bool, error) {
+) (ContentWriteReceipt, bool, error) {
 	name, err := NormalizeName(name)
 	if err != nil {
-		return Node{}, false, err
+		return ContentWriteReceipt{}, false, err
 	}
 	if err := validateIngestRecord(run.record); err != nil {
-		return Node{}, false, fmt.Errorf("validating ingest run: %w", err)
+		return ContentWriteReceipt{}, false, fmt.Errorf("validating ingest run: %w", err)
 	}
 	var recordedMtime *string
 	if originalMtime != "" {
@@ -224,10 +310,10 @@ func (s *Store) ingestFile(
 		OriginalPath: originalPath, OriginalMTime: recordedMtime,
 	}
 	if err := validateProvenanceFields(provenance); err != nil {
-		return Node{}, false, fmt.Errorf("validating ingest provenance: %w", err)
+		return ContentWriteReceipt{}, false, fmt.Errorf("validating ingest provenance: %w", err)
 	}
 	var (
-		created Node
+		receipt ContentWriteReceipt
 		added   bool
 	)
 	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
@@ -256,10 +342,24 @@ func (s *Store) ingestFile(
 				if err := s.EnsureBlobTx(tx, blobHash, size, physical...); err != nil {
 					return fmt.Errorf("reconciling idempotent ingest content: %w", err)
 				}
-				created, err = scanNode(tx.QueryRow(
+				receipt.Node, err = scanNode(tx.QueryRow(
 					`SELECT `+nodeCols+` FROM `+nodeFrom+` WHERE n.id = ?`, existingID))
 				if err != nil {
 					return fmt.Errorf("reading idempotent ingest node %d: %w", existingID, err)
+				}
+				if !completeReceipt {
+					return nil
+				}
+				receipt.Version, err = scanContentVersion(tx.QueryRow(
+					`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`,
+					receipt.Node.CurrentVersionID,
+				))
+				if err != nil {
+					return fmt.Errorf("reading idempotent ingest version of node %d: %w", existingID, err)
+				}
+				receipt.Physical, err = physicalContentTx(tx, blobHash)
+				if err != nil {
+					return err
 				}
 				return nil
 			}
@@ -292,13 +392,14 @@ func (s *Store) ingestFile(
 			return err
 		}
 		var version ContentVersion
-		created, version, err = s.createFileWithOperationTx(
+		receipt.Node, version, err = s.createFileWithOperationTx(
 			tx, parentID, finalName, blobHash, size, mimeType, operation, physical...,
 		)
 		if err != nil {
 			return err
 		}
-		provenance.NodeID = created.ID
+		receipt.Version = version
+		provenance.NodeID = receipt.Node.ID
 		provenance.Identity, err = provenanceIdentity(provenance)
 		if err != nil {
 			return fmt.Errorf("identifying provenance for %q: %w", finalName, err)
@@ -314,10 +415,10 @@ func (s *Store) ingestFile(
 			provenance.OriginalPath, provenance.OriginalMTime, provenance.Supersedes); err != nil {
 			return fmt.Errorf("recording provenance for %q: %w", finalName, err)
 		}
-		if run.record.SourceKind == "watch" {
+		if run.operationalWatch {
 			if err := insertWatchSourceTx(
 				tx, run.record.SourceDesc, provenance.OriginalPath,
-				created.ID, blobHash, size,
+				receipt.Node.ID, blobHash, size,
 			); err != nil {
 				return err
 			}
@@ -335,8 +436,14 @@ func (s *Store) ingestFile(
 			}
 			if err := persistAuditedNodeCreation(
 				ctx, tx, s.vaultID, authority, scopes, prior, resultingParent,
-				created, version, operation.operationID, operation.recordedAt, &metadata,
+				receipt.Node, version, operation.operationID, operation.recordedAt, &metadata,
 			); err != nil {
+				return err
+			}
+		}
+		if completeReceipt {
+			receipt.Physical, err = physicalContentTx(tx, blobHash)
+			if err != nil {
 				return err
 			}
 		}
@@ -344,9 +451,9 @@ func (s *Store) ingestFile(
 		return nil
 	})
 	if err != nil {
-		return Node{}, false, err
+		return ContentWriteReceipt{}, false, err
 	}
-	return created, added, nil
+	return receipt, added, nil
 }
 
 func insertWatchSourceTx(

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -6,7 +6,17 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 )
+
+const embeddedSourceKindPrefix = "embedded:"
+
+func publicProvenanceSourceKind(kind string) string {
+	if embedded, ok := strings.CutPrefix(kind, embeddedSourceKindPrefix); ok {
+		return embedded
+	}
+	return kind
+}
 
 // IngestRun identifies one logical import and carries the immutable metadata
 // that is published with its first imported file. Holding a run grants no
@@ -31,7 +41,13 @@ func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) 
 func (s *Store) BeginEmbeddedIngest(
 	ctx context.Context, sourceKind, sourceDesc string,
 ) (IngestRun, error) {
-	return s.beginIngest(ctx, sourceKind, sourceDesc, false)
+	if sourceKind == "" {
+		return IngestRun{}, errors.New("embedded provenance source kind is required")
+	}
+	if err := validateUTF8Field("embedded provenance source kind", sourceKind); err != nil {
+		return IngestRun{}, err
+	}
+	return s.beginIngest(ctx, embeddedSourceKindPrefix+sourceKind, sourceDesc, false)
 }
 
 func (s *Store) beginIngest(
@@ -152,7 +168,9 @@ func ensureIngestRunTx(ctx context.Context, tx *sql.Tx, run IngestRun) (bool, er
 // auto-suffixed copy ("report (2).pdf" next to an identical "report.pdf")
 // is a distinct file, not a re-import. Otherwise returns the smallest free
 // candidate name.
-func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (string, int64, bool, error) {
+func resolveIngestNameTx(
+	tx *sql.Tx, parentID int64, name, blobHash, sourceKind string,
+) (string, int64, bool, error) {
 	base, ext := splitSuffix(name)
 	rows, err := tx.Query(
 		`SELECT n.id, n.name, cv.blob_hash FROM nodes AS n
@@ -188,7 +206,9 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 		return "", 0, false, fmt.Errorf("listing siblings for %q: %w", name, err)
 	}
 	for _, candidate := range sameHash {
-		imported, err := sameOriginTx(tx, candidate.nodeID, name, candidate.inNameFamily)
+		imported, err := sameOriginTx(
+			tx, candidate.nodeID, name, candidate.inNameFamily, sourceKind,
+		)
 		if err != nil {
 			return "", 0, false, err
 		}
@@ -218,16 +238,18 @@ func resolveIngestNameTx(tx *sql.Tx, parentID int64, name, blobHash string) (str
 	}
 }
 
-// sameOriginTx reports whether node nodeID's active provenance leaf has a
-// source basename (normalized) equal to name — i.e. the incoming file is a
-// re-import of the same logical file, not a distinct source that merely
-// shares content. A node with no provenance matches only when its virtual name
-// belongs to the incoming suffix family: its origin is unknown, so the legacy
-// idempotent fallback must not suppress an unrelated same-content file.
-func sameOriginTx(tx *sql.Tx, nodeID int64, name string, allowUnknown bool) (bool, error) {
+// sameOriginTx reports whether node nodeID's active operational provenance leaf
+// has the same source kind and a basename (normalized) equal to name. Embedded
+// references are opaque and are never interpreted as filesystem paths. A node
+// with no provenance matches only when its virtual name belongs to the incoming
+// suffix family: its origin is unknown, so the legacy idempotent fallback must
+// not suppress an unrelated same-content file.
+func sameOriginTx(
+	tx *sql.Tx, nodeID int64, name string, allowUnknown bool, sourceKind string,
+) (bool, error) {
 	rows, err := tx.Query(`
-		SELECT p.original_path
-		FROM provenance AS p
+		SELECT i.source_kind, p.original_path
+		FROM provenance AS p JOIN ingests AS i ON i.id = p.ingest_id
 		WHERE p.node_id = ?
 		  AND NOT EXISTS (
 			SELECT 1 FROM provenance AS successor WHERE successor.supersedes = p.identity
@@ -240,11 +262,17 @@ func sameOriginTx(tx *sql.Tx, nodeID int64, name string, allowUnknown bool) (boo
 	sawProvenance := false
 	match := false
 	for rows.Next() {
-		var origPath string
-		if err := rows.Scan(&origPath); err != nil {
+		var storedSourceKind, origPath string
+		if err := rows.Scan(&storedSourceKind, &origPath); err != nil {
 			return false, fmt.Errorf("scanning provenance of node %d: %w", nodeID, err)
 		}
 		sawProvenance = true
+		if strings.HasPrefix(storedSourceKind, embeddedSourceKindPrefix) {
+			continue
+		}
+		if storedSourceKind != sourceKind {
+			continue
+		}
 		origName, err := NormalizeName(filepath.Base(origPath))
 		if err != nil {
 			continue // unnormalizable origin can't match a normalized name
@@ -334,7 +362,9 @@ func (s *Store) ingestFile(
 		} else {
 			var existingID int64
 			var skip bool
-			finalName, existingID, skip, err = resolveIngestNameTx(tx, parentID, name, blobHash)
+			finalName, existingID, skip, err = resolveIngestNameTx(
+				tx, parentID, name, blobHash, run.record.SourceKind,
+			)
 			if err != nil {
 				return err
 			}

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -76,6 +76,60 @@ func TestIngestFileIdempotency(t *testing.T) {
 	require.ErrorIs(t, err, ErrPhysicalAuthorityMissing)
 }
 
+func TestFilesystemIngestDoesNotAdoptEmbeddedOpaqueReference(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	embedded, err := s.BeginEmbeddedIngest(ctx, "cli", "application archive")
+	require.NoError(t, err)
+	embeddedNode, err := s.IngestFileExact(
+		ctx, embedded, s.RootID(), "archived.pdf", fakeHash("a1"), 10,
+		"application/pdf", "objects/report.pdf", "",
+	)
+	require.NoError(t, err)
+
+	filesystem, err := s.BeginIngest(ctx, "cli", "/source")
+	require.NoError(t, err)
+	imported, added, err := s.IngestFile(
+		ctx, filesystem, s.RootID(), "report.pdf", fakeHash("a1"), 10,
+		"application/pdf", "/source/report.pdf", "",
+	)
+	require.NoError(t, err)
+	require.True(t, added)
+	require.NotEqual(t, embeddedNode.ID, imported.ID)
+	require.Equal(t, "report.pdf", imported.Name)
+}
+
+func TestEmbeddedWatchKindIsPortableProvenanceNotOperationalState(t *testing.T) {
+	ctx := t.Context()
+	source := newTestStore(t)
+	run, err := source.BeginEmbeddedIngest(ctx, "watch", "application archive")
+	require.NoError(t, err)
+	node, err := source.IngestFileExact(
+		ctx, run, source.RootID(), "record.jsonl", fakeHash("a1"), 10,
+		"application/x-ndjson", "records/record.jsonl", "",
+	)
+	require.NoError(t, err)
+	require.NoError(t, source.ValidateMetadata(ctx))
+
+	page, err := source.NodeProvenance(ctx, node.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	require.Equal(t, "watch", page.Items[0].SourceKind)
+
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(ctx, &exported))
+	require.Contains(t, exported.String(), `"source_kind":"embedded:watch"`)
+	require.NotContains(t, exported.String(), `"type":"watch_source"`)
+
+	restored := newTestStore(t)
+	require.NoError(t, restored.ImportMetadata(ctx, bytes.NewReader(exported.Bytes())))
+	require.NoError(t, restored.ValidateMetadata(ctx))
+	restoredPage, err := restored.NodeProvenance(ctx, node.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, restoredPage.Items, 1)
+	require.Equal(t, "watch", restoredPage.Items[0].SourceKind)
+}
+
 func TestIngestFileMatchesAcrossSuffixGap(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/provenance_public.go
+++ b/internal/store/provenance_public.go
@@ -97,6 +97,7 @@ func (s *Store) NodeProvenance(
 		); err != nil {
 			return NodeProvenancePage{}, fmt.Errorf("scanning provenance for node %d: %w", nodeID, err)
 		}
+		fact.SourceKind = publicProvenanceSourceKind(fact.SourceKind)
 		fact.OriginalMTime = stringPtr(originalMTime)
 		fact.Supersedes = stringPtr(supersedes)
 		page.Items = append(page.Items, fact)

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -221,6 +221,7 @@ func (s *Store) ConfirmIngestedContentWithReceipt(
 	); err != nil {
 		return ContentWriteReceipt{}, err
 	}
+	storedSourceKind := embeddedSourceKindPrefix + sourceKind
 	var receipt ContentWriteReceipt
 	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		n, err := nodeByIDTx(tx, nodeID)
@@ -234,7 +235,7 @@ func (s *Store) ConfirmIngestedContentWithReceipt(
 			return err
 		}
 		matched, err := activeProvenanceMatchesTx(
-			ctx, tx, nodeID, sourceKind, sourceDescription,
+			ctx, tx, nodeID, storedSourceKind, sourceDescription,
 			sourceReference, sourceModifiedAt,
 		)
 		if err != nil {

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -190,30 +190,96 @@ func (s *Store) ConfirmContentWithReceipt(
 		if err != nil {
 			return err
 		}
-		if n.TrashedAt != nil {
-			return fmt.Errorf("node %d is trashed: %w", n.ID, ErrNotFound)
-		}
-		if n.IsDir() {
-			return fmt.Errorf("node %d: %w", n.ID, ErrNotFile)
-		}
-		if n.Revision != ifRev || n.BlobHash != blobHash || n.Size != size || n.MimeType != mimeType {
-			return fmt.Errorf("node %d content changed while confirming revision %d: %w",
-				n.ID, ifRev, ErrStaleRevision)
-		}
-		if err := s.EnsureBlobTx(tx, blobHash, size, physical...); err != nil {
-			return err
-		}
-		receipt.Node = n
-		receipt.Version, err = scanContentVersion(tx.QueryRow(
-			`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`,
-			n.CurrentVersionID,
-		))
-		if err != nil {
-			return fmt.Errorf("reading current version of node %d: %w", n.ID, err)
-		}
-		receipt.Physical, err = physicalContentTx(tx, blobHash)
+		receipt, err = s.confirmContentWithReceiptTx(
+			tx, n, ifRev, blobHash, size, mimeType, physical...,
+		)
 		return err
 	})
+	if err != nil {
+		return ContentWriteReceipt{}, err
+	}
+	return receipt, nil
+}
+
+// ConfirmIngestedContentWithReceipt is the idempotent completion path for an
+// embedded immutable create with provenance. It succeeds only when the
+// existing node has the same content authority and an active matching source
+// fact, so a retry cannot silently claim evidence that was never recorded.
+func (s *Store) ConfirmIngestedContentWithReceipt(
+	ctx context.Context, nodeID, ifRev int64, blobHash string, size int64, mimeType,
+	sourceKind, sourceDescription, sourceReference, sourceModifiedAt string,
+	physical ...BlobPhysical,
+) (ContentWriteReceipt, error) {
+	if size < 0 {
+		return ContentWriteReceipt{}, errors.New("content size must not be negative")
+	}
+	if err := validateUTF8Field("content MIME type", mimeType); err != nil {
+		return ContentWriteReceipt{}, err
+	}
+	if err := validateProvenanceSourceFields(
+		sourceKind, sourceDescription, sourceReference, sourceModifiedAt,
+	); err != nil {
+		return ContentWriteReceipt{}, err
+	}
+	var receipt ContentWriteReceipt
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		n, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		receipt, err = s.confirmContentWithReceiptTx(
+			tx, n, ifRev, blobHash, size, mimeType, physical...,
+		)
+		if err != nil {
+			return err
+		}
+		matched, err := activeProvenanceMatchesTx(
+			ctx, tx, nodeID, sourceKind, sourceDescription,
+			sourceReference, sourceModifiedAt,
+		)
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return fmt.Errorf("node %d: %w", nodeID, ErrProvenanceMismatch)
+		}
+		return nil
+	})
+	if err != nil {
+		return ContentWriteReceipt{}, err
+	}
+	return receipt, nil
+}
+
+func (s *Store) confirmContentWithReceiptTx(
+	tx *sql.Tx, n Node, ifRev int64, blobHash string, size int64, mimeType string,
+	physical ...BlobPhysical,
+) (ContentWriteReceipt, error) {
+	if n.TrashedAt != nil {
+		return ContentWriteReceipt{}, fmt.Errorf("node %d is trashed: %w", n.ID, ErrNotFound)
+	}
+	if n.IsDir() {
+		return ContentWriteReceipt{}, fmt.Errorf("node %d: %w", n.ID, ErrNotFile)
+	}
+	if n.Revision != ifRev || n.BlobHash != blobHash || n.Size != size || n.MimeType != mimeType {
+		return ContentWriteReceipt{}, fmt.Errorf(
+			"node %d content changed while confirming revision %d: %w",
+			n.ID, ifRev, ErrStaleRevision,
+		)
+	}
+	if err := s.EnsureBlobTx(tx, blobHash, size, physical...); err != nil {
+		return ContentWriteReceipt{}, err
+	}
+	receipt := ContentWriteReceipt{Node: n}
+	var err error
+	receipt.Version, err = scanContentVersion(tx.QueryRow(
+		`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id = ?`,
+		n.CurrentVersionID,
+	))
+	if err != nil {
+		return ContentWriteReceipt{}, fmt.Errorf("reading current version of node %d: %w", n.ID, err)
+	}
+	receipt.Physical, err = physicalContentTx(tx, blobHash)
 	if err != nil {
 		return ContentWriteReceipt{}, err
 	}

--- a/types.go
+++ b/types.go
@@ -45,6 +45,53 @@ type ContentVersion struct {
 	SourceVersionID       *string `json:"source_version_id,omitempty"`
 }
 
+// ProvenanceSource describes an application-neutral origin for one immutable
+// document creation. Reference may be a URI, archive key, filesystem path, or
+// another stable source-local identifier; Docbank does not interpret it.
+type ProvenanceSource struct {
+	Kind        string     `json:"kind"`
+	Description string     `json:"description"`
+	Reference   string     `json:"reference"`
+	ModifiedAt  *time.Time `json:"modified_at,omitempty"`
+}
+
+// ProvenanceFact is one immutable statement about where a document came from.
+// Superseded facts remain visible; Active marks the current unsuperseded facts.
+type ProvenanceFact struct {
+	Identity          string  `json:"identity"`
+	NodeID            int64   `json:"node_id"`
+	IngestID          string  `json:"ingest_id"`
+	RecordedAt        string  `json:"recorded_at"`
+	SourceKind        string  `json:"source_kind"`
+	SourceDescription string  `json:"source_description"`
+	SourceReference   string  `json:"source_reference"`
+	SourceModifiedAt  *string `json:"source_modified_at,omitempty"`
+	Supersedes        *string `json:"supersedes,omitempty"`
+	Active            bool    `json:"active"`
+}
+
+const (
+	DefaultProvenanceLimit = 100
+	MaxProvenanceLimit     = store.MaxProvenancePageSize
+)
+
+// ProvenanceOptions selects one bounded newest-first provenance page.
+type ProvenanceOptions struct {
+	Limit  int
+	Offset int
+}
+
+// ProvenancePage binds origin history to a transactionally consistent node.
+// Path is empty when the node is in trash.
+type ProvenancePage struct {
+	Node   Node             `json:"node"`
+	Path   string           `json:"path,omitempty"`
+	Items  []ProvenanceFact `json:"items"`
+	Total  int              `json:"total"`
+	Limit  int              `json:"limit"`
+	Offset int              `json:"offset"`
+}
+
 // PutReceipt proves the computed identity and resulting logical authority.
 type PutReceipt struct {
 	Node     Node            `json:"node"`
@@ -230,6 +277,16 @@ func fromStoreVersion(version store.ContentVersion) ContentVersion {
 		NodeRevision:          version.NodeRevision,
 		IntroducedOperationID: version.IntroducedOperationID,
 		TransitionKind:        version.TransitionKind, SourceVersionID: version.SourceVersionID,
+	}
+}
+
+func fromStoreProvenance(fact store.ProvenanceFact) ProvenanceFact {
+	return ProvenanceFact{
+		Identity: fact.Identity, NodeID: fact.NodeID, IngestID: fact.IngestID,
+		RecordedAt: fact.IngestStartedAt, SourceKind: fact.SourceKind,
+		SourceDescription: fact.SourceDescription, SourceReference: fact.OriginalPath,
+		SourceModifiedAt: fact.OriginalMTime, Supersedes: fact.Supersedes,
+		Active: fact.Active,
 	}
 }
 

--- a/vault.go
+++ b/vault.go
@@ -38,7 +38,7 @@ var (
 	// optional expected byte count.
 	ErrSizeMismatch = errors.New("docbank content size mismatch")
 	// ErrContentConflict means immutable creation targeted an existing path
-	// with different bytes, size, media type, or node kind.
+	// with different bytes, size, media type, provenance, or node kind.
 	ErrContentConflict = errors.New("docbank immutable content conflict")
 
 	ErrNotFound                 = store.ErrNotFound
@@ -274,6 +274,9 @@ type PutOptions struct {
 type CreateOptions struct {
 	MediaType string
 	Expected  ContentIdentity
+	// Provenance optionally records where this immutable document came from.
+	// The source fact commits atomically with a newly created node and version.
+	Provenance *ProvenanceSource
 }
 
 // Put stores a reader at an absolute virtual file path. Missing parent
@@ -282,19 +285,49 @@ type CreateOptions struct {
 func (v *Vault) Put(
 	ctx context.Context, virtualPath string, content io.Reader, opts PutOptions,
 ) (PutReceipt, error) {
-	return v.write(ctx, virtualPath, content, opts, false)
+	return v.write(ctx, virtualPath, content, opts, false, nil)
 }
 
-// Create stores content only when virtualPath is absent. An identical retry
-// returns the existing node and version; any different existing authority
-// returns ErrContentConflict without appending history.
+// Create stores content only when virtualPath is absent. An identical retry,
+// including any supplied provenance, returns the existing node and version;
+// any different existing authority returns ErrContentConflict without
+// appending history.
 func (v *Vault) Create(
 	ctx context.Context, virtualPath string, content io.Reader, opts CreateOptions,
 ) (PutReceipt, error) {
 	expected := opts.Expected
 	return v.write(ctx, virtualPath, content, PutOptions{
 		MediaType: opts.MediaType, Expected: &expected,
-	}, true)
+	}, true, opts.Provenance)
+}
+
+// Provenance returns one bounded page of immutable origin facts for a file.
+// The node, live path, count, and page come from one metadata snapshot. Path is
+// empty when nodeID is in trash.
+func (v *Vault) Provenance(
+	ctx context.Context, nodeID int64, opts ProvenanceOptions,
+) (ProvenancePage, error) {
+	if err := v.begin(); err != nil {
+		return ProvenancePage{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	limit := opts.Limit
+	if limit == 0 {
+		limit = DefaultProvenanceLimit
+	}
+	page, err := v.metadata.NodeProvenance(ctx, nodeID, limit, opts.Offset)
+	if err != nil {
+		return ProvenancePage{}, err
+	}
+	result := ProvenancePage{
+		Node: fromStoreNode(page.Node), Path: page.Path,
+		Items: make([]ProvenanceFact, 0, len(page.Items)),
+		Total: page.Total, Limit: page.Limit, Offset: page.Offset,
+	}
+	for _, fact := range page.Items {
+		result.Items = append(result.Items, fromStoreProvenance(fact))
+	}
+	return result, nil
 }
 
 // MovePath renames or reparents one live path and returns its canonical new
@@ -553,6 +586,7 @@ func (v *Vault) RepairContent(
 
 func (v *Vault) write(
 	ctx context.Context, virtualPath string, content io.Reader, opts PutOptions, immutable bool,
+	provenance *ProvenanceSource,
 ) (PutReceipt, error) {
 	if err := v.begin(); err != nil {
 		return PutReceipt{}, err
@@ -563,6 +597,20 @@ func (v *Vault) write(
 	}
 	if !utf8.ValidString(opts.MediaType) {
 		return PutReceipt{}, errors.New("docbank media type is not valid UTF-8")
+	}
+	if provenance != nil {
+		snapshot := *provenance
+		if provenance.ModifiedAt != nil {
+			modifiedAt := *provenance.ModifiedAt
+			snapshot.ModifiedAt = &modifiedAt
+		}
+		provenance = &snapshot
+		if !immutable {
+			return PutReceipt{}, errors.New("docbank provenance requires immutable creation")
+		}
+		if err := validateProvenanceSource(*provenance); err != nil {
+			return PutReceipt{}, err
+		}
 	}
 	parentPath, name, canonicalPath, err := normalizeVirtualFilePath(virtualPath)
 	if err != nil {
@@ -627,9 +675,24 @@ func (v *Vault) write(
 		existing, lookupErr := v.metadata.NodeByPath(ctx, canonicalPath)
 		switch {
 		case errors.Is(lookupErr, store.ErrNotFound):
-			created, createErr := v.metadata.CreateFileWithReceipt(
-				ctx, parent.ID, name, hash, size, opts.MediaType, physical,
-			)
+			var created store.ContentWriteReceipt
+			var createErr error
+			if provenance == nil {
+				created, createErr = v.metadata.CreateFileWithReceipt(
+					ctx, parent.ID, name, hash, size, opts.MediaType, physical,
+				)
+			} else {
+				run, beginErr := v.metadata.BeginEmbeddedIngest(
+					ctx, provenance.Kind, provenance.Description,
+				)
+				if beginErr != nil {
+					return beginErr
+				}
+				created, createErr = v.metadata.IngestFileExactWithReceipt(
+					ctx, run, parent.ID, name, hash, size, opts.MediaType,
+					provenance.Reference, provenanceModifiedAt(provenance), physical,
+				)
+			}
 			if createErr != nil {
 				return createErr
 			}
@@ -649,10 +712,24 @@ func (v *Vault) write(
 			}
 			return fmt.Errorf("virtual path %q: %w", canonicalPath, store.ErrNotFile)
 		case existing.BlobHash == hash && existing.Size == size && existing.MimeType == opts.MediaType:
-			confirmed, confirmErr := v.metadata.ConfirmContentWithReceipt(
-				ctx, existing.ID, existing.Revision, hash, size, opts.MediaType, physical,
-			)
+			var confirmed store.ContentWriteReceipt
+			var confirmErr error
+			if provenance == nil {
+				confirmed, confirmErr = v.metadata.ConfirmContentWithReceipt(
+					ctx, existing.ID, existing.Revision, hash, size, opts.MediaType, physical,
+				)
+			} else {
+				confirmed, confirmErr = v.metadata.ConfirmIngestedContentWithReceipt(
+					ctx, existing.ID, existing.Revision, hash, size, opts.MediaType,
+					provenance.Kind, provenance.Description, provenance.Reference,
+					provenanceModifiedAt(provenance), physical,
+				)
+			}
 			if confirmErr != nil {
+				if errors.Is(confirmErr, store.ErrProvenanceMismatch) {
+					return fmt.Errorf("virtual path %q has different provenance: %w",
+						canonicalPath, ErrContentConflict)
+				}
 				return confirmErr
 			}
 			receipt.Node = fromStoreNode(confirmed.Node)
@@ -684,6 +761,40 @@ func (v *Vault) write(
 		return receipt, err
 	}
 	return receipt, nil
+}
+
+func validateProvenanceSource(source ProvenanceSource) error {
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{name: "kind", value: source.Kind},
+		{name: "description", value: source.Description},
+		{name: "reference", value: source.Reference},
+	}
+	for _, field := range fields {
+		if field.value == "" {
+			return fmt.Errorf("docbank provenance source %s is required", field.name)
+		}
+		if !utf8.ValidString(field.value) {
+			return fmt.Errorf("docbank provenance source %s is not valid UTF-8", field.name)
+		}
+	}
+	if source.ModifiedAt != nil {
+		encoded := source.ModifiedAt.UTC().Format(time.RFC3339Nano)
+		parsed, err := time.Parse(time.RFC3339Nano, encoded)
+		if err != nil || parsed.UTC().Format(time.RFC3339Nano) != encoded {
+			return errors.New("docbank provenance source modified time is outside RFC3339Nano")
+		}
+	}
+	return nil
+}
+
+func provenanceModifiedAt(source *ProvenanceSource) string {
+	if source == nil || source.ModifiedAt == nil {
+		return ""
+	}
+	return source.ModifiedAt.UTC().Format(time.RFC3339Nano)
 }
 
 func blobPhysical(receipt blob.WriteReceipt) (store.BlobPhysical, error) {

--- a/vault_test.go
+++ b/vault_test.go
@@ -78,6 +78,120 @@ func TestVaultCreateIsImmutableAndIdempotent(t *testing.T) {
 	require.Equal(created.Computed.SHA256, after.BlobHash)
 }
 
+func TestEmbeddedCreateRecordsGenericProvenance(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver docsqlite.Driver
+	}{
+		{name: "build default"},
+		{name: "pure Go", driver: modernc.Driver{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			testEmbeddedCreateRecordsGenericProvenance(t, test.driver)
+		})
+	}
+}
+
+func testEmbeddedCreateRecordsGenericProvenance(t *testing.T, driver docsqlite.Driver) {
+	t.Helper()
+	vault, err := New(t.Context(), Config{Root: t.TempDir(), SQLite: driver})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	content := []byte("archived agent session\n")
+	modifiedAt := time.Date(2026, time.July, 20, 15, 4, 5, 123, time.FixedZone("source", -5*60*60))
+	opts := CreateOptions{
+		MediaType: "application/x-ndjson", Expected: contentIdentity(content),
+		Provenance: &ProvenanceSource{
+			Kind: "agent-session", Description: "local session archive",
+			Reference: "sessions/01K123.jsonl", ModifiedAt: &modifiedAt,
+		},
+	}
+	created, err := vault.Create(
+		t.Context(), "/sessions/01K123.jsonl", bytes.NewReader(content), opts,
+	)
+	require.NoError(t, err)
+	require.True(t, created.Created)
+
+	page, err := vault.Provenance(t.Context(), created.Node.ID, ProvenanceOptions{})
+	require.NoError(t, err)
+	require.Equal(t, created.Node, page.Node)
+	require.Equal(t, "/sessions/01K123.jsonl", page.Path)
+	require.Equal(t, 1, page.Total)
+	require.Equal(t, DefaultProvenanceLimit, page.Limit)
+	require.Len(t, page.Items, 1)
+	fact := page.Items[0]
+	require.Equal(t, created.Node.ID, fact.NodeID)
+	require.Equal(t, "agent-session", fact.SourceKind)
+	require.Equal(t, "local session archive", fact.SourceDescription)
+	require.Equal(t, "sessions/01K123.jsonl", fact.SourceReference)
+	wantModifiedAt := modifiedAt.UTC().Format(time.RFC3339Nano)
+	require.Equal(t, &wantModifiedAt, fact.SourceModifiedAt)
+	require.True(t, fact.Active)
+
+	retry, err := vault.Create(
+		t.Context(), "/sessions/01K123.jsonl", bytes.NewReader(content), opts,
+	)
+	require.NoError(t, err)
+	require.False(t, retry.Created)
+	require.Equal(t, created.Version.ID, retry.Version.ID)
+	page, err = vault.Provenance(t.Context(), created.Node.ID, ProvenanceOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, page.Total)
+
+	different := opts
+	different.Provenance = &ProvenanceSource{
+		Kind: "agent-session", Description: "local session archive",
+		Reference: "sessions/different.jsonl", ModifiedAt: &modifiedAt,
+	}
+	_, err = vault.Create(
+		t.Context(), "/sessions/01K123.jsonl", bytes.NewReader(content), different,
+	)
+	require.ErrorIs(t, err, ErrContentConflict)
+}
+
+func TestEmbeddedAuditedCreateRecordsProvenance(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	plan, err := vault.metadata.PreviewInitialAudit(
+		t.Context(), vault.metadata.RootID(), "api", nil,
+	)
+	require.NoError(t, err)
+	_, err = vault.metadata.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+
+	content := []byte("audited source\n")
+	_, err = vault.Create(t.Context(), "/audited.txt", bytes.NewReader(content), CreateOptions{
+		Expected: contentIdentity(content),
+		Provenance: &ProvenanceSource{
+			Kind: "archive", Description: "test archive", Reference: "objects/audited.txt",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, vault.metadata.ValidateMetadata(t.Context()))
+}
+
+func TestEmbeddedCreateRejectsInvalidProvenanceBeforeWriting(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	content := []byte("not stored\n")
+
+	_, err = vault.Create(t.Context(), "/missing/document.txt", bytes.NewReader(content), CreateOptions{
+		Expected: contentIdentity(content),
+		Provenance: &ProvenanceSource{
+			Kind: "archive", Description: "", Reference: "objects/document.txt",
+		},
+	})
+	require.ErrorContains(t, err, "description is required")
+	_, err = vault.Stat(t.Context(), "/missing")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestVaultCreateRejectsExpectedIdentityMismatch(t *testing.T) {
 	vault, err := New(t.Context(), Config{Root: t.TempDir()})
 	require.NoError(t, err)


### PR DESCRIPTION
An embedded application can now preserve not only a document's bytes, but also a durable answer to: "where did this document come from?"

For example, an agent-session archive can immutably create `/sessions/01K123.jsonl` with a source kind, human description, opaque archive reference, and optional source modification time. The root `go.kenn.io/docbank` package also exposes bounded provenance reads, so the application can inspect that evidence later without using internal packages or running a daemon.

The safety boundary is transactional. For a new document, the node, first immutable version, ingest record, provenance fact, and any permanent-audit evidence either commit together or do not commit. Retrying the same immutable create succeeds only when the active provenance matches too; it cannot report success while silently omitting or changing the claimed source.

Embedded source categories remain distinct from daemon-owned watched inboxes even when an application chooses a kind named `watch`. Opaque embedded references are never interpreted as filesystem paths or used to deduplicate a later local import, so an archive key ending in `report.pdf` cannot absorb an unrelated file with the same basename and bytes.

This reuses Docbank's existing portable provenance representation, so backups and JSONL restore already preserve the new evidence and no storage-schema cutover is needed. The source reference is deliberately opaque and does not pin the node or its bytes against deletion. External retention authority remains a separate policy decision rather than being smuggled into provenance.
