### PR TITLE
Schedule bounded automatic packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Four commitments:
   per-node history, independent chain/protected-byte verification, exact-prefix
   checks against externally recorded evidence, and backup/restore fidelity
 - FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
-- Mixed loose and packed content storage with explicit pack, GC, and repack
+- Mixed loose and packed content storage with explicit pack, GC, and repack,
+  plus an opt-in bounded daemon packing schedule
 - Whole-vault integrity verification
 - Incremental backup repositories with create, list, verify, and confined restore
 - Daemon-first CLI, authenticated loopback HTTP API, and offline OpenAPI output
@@ -78,8 +79,8 @@ Four commitments:
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows
 
-Embedded generic source provenance is newer than v0.10.1. Build from `main` to
-use it until the next release is tagged.
+Embedded generic source provenance and scheduled packing are newer than
+v0.10.1. Build from `main` to use them until the next release is tagged.
 
 See the [roadmap](docs/roadmap.md) for high-level product direction beyond the
 capabilities listed here.

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -704,10 +705,17 @@ func TestConfiguredAutomaticPackingPacksAndKeepsDaemonAlive(t *testing.T) {
 	t.Setenv(client.EnvBackgroundDaemon, "1")
 	startTestDaemon(t, home)
 
-	_, err := runCLI(t, "mkdir", "/agents")
+	var err error
+	require.Eventually(t, func() bool {
+		_, err = runCLI(t, "mkdir", "/agents")
+		return err == nil || !errors.Is(err, client.ErrMaintenanceBusy)
+	}, 5*time.Second, 25*time.Millisecond)
 	require.NoError(t, err)
 	source := writeSourceFile(t, "session.jsonl", "{\"kind\":\"session\"}\n")
-	_, err = runCLI(t, "add", source, "--dest", "/agents")
+	require.Eventually(t, func() bool {
+		_, err = runCLI(t, "add", source, "--dest", "/agents")
+		return err == nil || !errors.Is(err, client.ErrMaintenanceBusy)
+	}, 5*time.Second, 25*time.Millisecond)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		out, runErr := runCLI(t, "storage", "status", "--json")

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -694,6 +694,49 @@ func TestJobsShowsDaemonStatus(t *testing.T) {
 	assert.Equal(t, "running", got.Items[0].Status)
 }
 
+func TestConfiguredAutomaticPackingPacksAndKeepsDaemonAlive(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
+		"[server]\nidle_timeout = \"30ms\"\n"+
+			"[storage]\npack_interval = \"10ms\"\npack_max_bytes = 1048576\n",
+	), 0o600))
+	t.Setenv("DOCBANK_HOME", home)
+	t.Setenv(client.EnvBackgroundDaemon, "1")
+	startTestDaemon(t, home)
+
+	_, err := runCLI(t, "mkdir", "/agents")
+	require.NoError(t, err)
+	source := writeSourceFile(t, "session.jsonl", "{\"kind\":\"session\"}\n")
+	_, err = runCLI(t, "add", source, "--dest", "/agents")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		out, runErr := runCLI(t, "storage", "status", "--json")
+		if runErr != nil {
+			return false
+		}
+		var status api.StorageStatus
+		return json.Unmarshal([]byte(out), &status) == nil &&
+			status.LooseBlobs == 0 && status.PackedBlobs == 1
+	}, 5*time.Second, 25*time.Millisecond)
+	out, err := runCLI(t, "cat", "/agents/session.jsonl")
+	require.NoError(t, err)
+	assert.JSONEq(t, "{\"kind\":\"session\"}\n", out)
+
+	out, err = runCLI(t, "jobs", "--json")
+	require.NoError(t, err)
+	var got api.JobList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, "extract:plain-text", got.Items[0].Name)
+	assert.Equal(t, "storage:pack", got.Items[1].Name)
+	assert.Equal(t, "running", got.Items[1].Status)
+
+	time.Sleep(100 * time.Millisecond)
+	_, _, found, err := client.Find(t.Context(), home)
+	require.NoError(t, err)
+	assert.True(t, found)
+}
+
 func TestConfiguredWatchIngestsStableFilesAndRemainsObservable(t *testing.T) {
 	home := t.TempDir()
 	source := t.TempDir()

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -29,6 +29,7 @@ import (
 	"go.kenn.io/docbank/internal/home"
 	"go.kenn.io/docbank/internal/ingest"
 	"go.kenn.io/docbank/internal/jobs"
+	internalmaintenance "go.kenn.io/docbank/internal/maintenance"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -171,6 +172,24 @@ func runServe(ctx context.Context) (retErr error) {
 	if err := jobSupervisor.Start("extract:plain-text", textWorker.Run); err != nil {
 		return fmt.Errorf("starting text extraction: %w", err)
 	}
+	if cfg.Storage.PackInterval.Std() > 0 {
+		packRun := func(ctx context.Context) (internalmaintenance.PackReport, error) {
+			var report internalmaintenance.PackReport
+			err := operationGate.Maintain(func() error {
+				var err error
+				report, err = internalmaintenance.Pack(
+					ctx, s, blobs, cfg.Storage.PackMaxBytes)
+				return err
+			})
+			return report, err
+		}
+		if err := jobSupervisor.Start("storage:pack", func(ctx context.Context) error {
+			return internalmaintenance.RunPackSchedule(
+				ctx, cfg.Storage.PackInterval.Std(), packRun, logger)
+		}); err != nil {
+			return fmt.Errorf("starting automatic packing: %w", err)
+		}
+	}
 
 	var stopOnce sync.Once
 	stopCh := make(chan struct{})
@@ -188,7 +207,8 @@ func runServe(ctx context.Context) (retErr error) {
 		BaseContext:       func(net.Listener) context.Context { return ctx },
 	}
 
-	if background && cfg.Server.IdleTimeout.Std() > 0 && len(cfg.Watches) == 0 {
+	if background && cfg.Server.IdleTimeout.Std() > 0 && len(cfg.Watches) == 0 &&
+		cfg.Storage.PackInterval.Std() == 0 {
 		if err := jobSupervisor.Start("daemon.idle-timeout", func(ctx context.Context) error {
 			idleWatch(ctx, tracker, cfg.Server.IdleTimeout.Std(), logger, stop)
 			return nil

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,10 @@ enabled = true
 repo = ""           # no implicit repository; set a path or pass --repo
 zstd_level = 0      # 0 = Kit default; otherwise 1-19
 
+[storage]
+pack_interval = "0"        # disabled; for example, "1h"
+pack_max_bytes = 268435456  # 256 MiB soft raw-byte budget per run
+
 [[watch]]
 name = "agent-sessions"
 source = "~/agent-sessions"
@@ -132,6 +136,22 @@ exclude = [".DS_Store", "cache/"]
   Keep the repository outside the live vault in normal deployments.
 - **`[backup] zstd_level`** — repository compression level. `0` uses Kit's
   default; explicit values are limited to `1` through `19`.
+- **`[storage] pack_interval`** — schedules non-destructive packing of
+  authorized loose blobs. `"0"` disables the schedule. A configured schedule
+  runs once when the daemon starts and then at this interval.
+- **`[storage] pack_max_bytes`** — finite soft raw-byte budget for each
+  scheduled run. It must be positive when `pack_interval` is enabled. Remaining
+  loose content waits for a later run.
+
+Scheduled packing is visible as the `storage:pack` job and keeps an auto-started
+daemon alive so the schedule is meaningful. It uses the same maintenance gate
+as `docbank storage pack`: ordinary mutations may briefly receive
+`maintenance_busy` and can retry. Automatic packing does not delete logical
+content and does not run GC or repack; those reclamation operations remain
+explicit operator choices.
+
+Scheduled packing is newer than v0.10.1. Build from `main` to use it until the
+next release is tagged.
 
 ### Watched inboxes
 
@@ -205,7 +225,8 @@ Watched inboxes never modify or delete their source files. Configuration is
 machine-local and is not part of metadata-v1 backup/restore, while the stable
 watch name, relative path, stable node mapping, and last accepted content
 identity are preserved in portable metadata. The watcher does not pack content
-or run storage maintenance automatically.
+itself. Configure `[storage] pack_interval` when accumulated loose content
+should be packed automatically; GC and repack remain explicit.
 
 ### Bind validation
 

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -194,6 +194,10 @@ settle_time = "30s"
 minimum_age = "168h"
 scan_interval = "5s"
 exclude = ["cache/", ".DS_Store"]
+
+[storage]
+pack_interval = "1h"
+pack_max_bytes = 268435456
 ```
 
 The daemon observes a file's filesystem identity, size, and modification time
@@ -225,7 +229,9 @@ Use `docbank provenance <path-or-id>` to inspect the retained watch identity,
 source-relative path, and immutable supersession history for an imported node.
 JSONL session content up to the normal extraction limit is indexed by the
 built-in plain-text worker, so ordinary `docbank search` can find archived
-session text without a vendor-specific parser.
+session text without a vendor-specific parser. The optional `[storage]`
+schedule packs accumulated small files with a finite per-run budget. It does
+not delete source files, prune versions, run GC, or rewrite existing packs.
 
 The destination is exact rather than collision-suffixed. If unrelated content
 already occupies the intended path, or the previously mapped node is in the
@@ -234,3 +240,6 @@ named `watch:<name>` job and any terminal error; correct the problem and restart
 the daemon. Successful additions, updates, and unchanged observations appear
 in the daemon log. See [Configuration](../configuration.md#watched-inboxes) for
 the complete field contract.
+
+Scheduled packing is newer than v0.10.1. Build from `main` to use it until the
+next release is tagged.

--- a/internal/api/gate.go
+++ b/internal/api/gate.go
@@ -32,6 +32,10 @@ func (g *OperationGate) Mutate(fn func() error) error {
 	return fn()
 }
 
+// Maintain runs daemon-owned physical maintenance with the same exclusion and
+// admission behavior as an HTTP maintenance request.
+func (g *OperationGate) Maintain(fn func() error) error { return g.maintain(fn) }
+
 func (g *OperationGate) mutate(fn func() error) error {
 	g.admission.RLock()
 	if g.maintenance > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,14 @@ type BackupConfig struct {
 	ZstdLevel int    `toml:"zstd_level"`
 }
 
+// StorageConfig controls optional daemon-owned physical storage work. Packing
+// is non-destructive to logical document authority; GC and repack remain
+// explicit operator actions.
+type StorageConfig struct {
+	PackInterval Duration `toml:"pack_interval"`
+	PackMaxBytes int64    `toml:"pack_max_bytes"`
+}
+
 // WatchConfig describes one daemon-owned local inbox. Name and each relative
 // source path form the stable, portable source identity; Source itself is a
 // machine-local location and is intentionally not archive metadata.
@@ -78,6 +86,7 @@ type Config struct {
 	Server  ServerConfig  `toml:"server"`
 	Web     WebConfig     `toml:"web"`
 	Backup  BackupConfig  `toml:"backup"`
+	Storage StorageConfig `toml:"storage"`
 	Watches []WatchConfig `toml:"watch"`
 }
 
@@ -88,7 +97,8 @@ func Default() Config {
 			BindAddr:    "127.0.0.1",
 			IdleTimeout: Duration(30 * time.Minute),
 		},
-		Web: WebConfig{Enabled: true},
+		Web:     WebConfig{Enabled: true},
+		Storage: StorageConfig{PackMaxBytes: 256 << 20},
 	}
 }
 
@@ -215,6 +225,15 @@ func resolveBackupRepo(root string, backup *BackupConfig) error {
 func (c Config) Validate() error {
 	if c.Backup.ZstdLevel != 0 && (c.Backup.ZstdLevel < 1 || c.Backup.ZstdLevel > 19) {
 		return fmt.Errorf("[backup] zstd_level %d: want 0 or 1-19", c.Backup.ZstdLevel)
+	}
+	if c.Storage.PackMaxBytes < 0 {
+		return errors.New("[storage] pack_max_bytes must not be negative")
+	}
+	if c.Storage.PackInterval.Std() < 0 {
+		return errors.New("[storage] pack_interval must not be negative")
+	}
+	if c.Storage.PackInterval.Std() > 0 && c.Storage.PackMaxBytes == 0 {
+		return errors.New("[storage] pack_max_bytes must be positive when pack_interval is enabled")
 	}
 	for _, watch := range c.Watches {
 		if err := validateWatch(watch); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,13 +20,16 @@ func TestLoadMissingFileReturnsDefaults(t *testing.T) {
 	assert.True(t, c.Web.Enabled)
 	assert.Empty(t, c.Backup.Repo)
 	assert.Zero(t, c.Backup.ZstdLevel)
+	assert.Zero(t, c.Storage.PackInterval.Std())
+	assert.Equal(t, int64(256<<20), c.Storage.PackMaxBytes)
 }
 
 func TestLoadParsesFile(t *testing.T) {
 	dir := privateTestConfigDir(t)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.toml"), []byte(
 		"[server]\nbind_addr = \"127.0.0.1\"\napi_port = 8080\napi_key = \"k\"\n"+
-			"idle_timeout = \"0\"\n[web]\nenabled = false\n[backup]\nrepo = \"snapshots\"\nzstd_level = 9\n"), 0o600))
+			"idle_timeout = \"0\"\n[web]\nenabled = false\n[backup]\nrepo = \"snapshots\"\nzstd_level = 9\n"+
+			"[storage]\npack_interval = \"1h\"\npack_max_bytes = 1048576\n"), 0o600))
 	c, err := Load(dir)
 	require.NoError(t, err)
 	assert.Equal(t, 8080, c.Server.APIPort)
@@ -35,6 +38,8 @@ func TestLoadParsesFile(t *testing.T) {
 	assert.False(t, c.Web.Enabled)
 	assert.Equal(t, filepath.Join(dir, "snapshots"), c.Backup.Repo)
 	assert.Equal(t, 9, c.Backup.ZstdLevel)
+	assert.Equal(t, time.Hour, c.Storage.PackInterval.Std())
+	assert.Equal(t, int64(1<<20), c.Storage.PackMaxBytes)
 }
 
 func TestLoadExpandsBackupRepoHome(t *testing.T) {
@@ -164,5 +169,32 @@ func TestValidateBackupCompressionLevel(t *testing.T) {
 		c := Default()
 		c.Backup.ZstdLevel = level
 		require.ErrorContains(t, c.Validate(), "zstd_level")
+	}
+}
+
+func TestValidateAutomaticPacking(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		interval time.Duration
+		maxBytes int64
+		want     string
+	}{
+		{name: "disabled", maxBytes: 256 << 20},
+		{name: "enabled", interval: time.Hour, maxBytes: 1 << 20},
+		{name: "negative interval", interval: -time.Second, maxBytes: 1, want: "must not be negative"},
+		{name: "negative bytes", maxBytes: -1, want: "must not be negative"},
+		{name: "unbounded enabled", interval: time.Hour, want: "must be positive"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Default()
+			c.Storage.PackInterval = Duration(tc.interval)
+			c.Storage.PackMaxBytes = tc.maxBytes
+			err := c.Validate()
+			if tc.want == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.want)
+			}
+		})
 	}
 }

--- a/internal/maintenance/automatic.go
+++ b/internal/maintenance/automatic.go
@@ -1,0 +1,55 @@
+package maintenance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// RunPackSchedule performs one bounded pack immediately and then once per
+// interval until shutdown. A failed run remains visible as a failed daemon job
+// instead of being silently retried forever.
+func RunPackSchedule(
+	ctx context.Context,
+	interval time.Duration,
+	run func(context.Context) (PackReport, error),
+	logger *slog.Logger,
+) error {
+	if interval <= 0 {
+		return errors.New("automatic pack interval must be positive")
+	}
+	if run == nil {
+		return errors.New("automatic pack runner is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		report, err := run(ctx)
+		if err != nil {
+			return fmt.Errorf("automatic packing: %w", err)
+		}
+		stats := report.Stats
+		if stats.BlobsPacked > 0 || stats.PacksSealed > 0 || report.More {
+			logger.Info("automatic packing completed",
+				"blobs", stats.BlobsPacked,
+				"raw_bytes", stats.BytesPacked,
+				"packs", stats.PacksSealed,
+				"more", report.More,
+			)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/maintenance/automatic.go
+++ b/internal/maintenance/automatic.go
@@ -30,8 +30,6 @@ func RunPackSchedule(
 		return err
 	}
 
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
 	for {
 		report, err := run(ctx)
 		if err != nil {
@@ -46,10 +44,17 @@ func RunPackSchedule(
 				"more", report.More,
 			)
 		}
+		timer := time.NewTimer(interval)
 		select {
 		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
 			return ctx.Err()
-		case <-ticker.C:
+		case <-timer.C:
 		}
 	}
 }

--- a/internal/maintenance/automatic_test.go
+++ b/internal/maintenance/automatic_test.go
@@ -1,0 +1,39 @@
+package maintenance
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPackScheduleRunsImmediatelyAndStopsWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	var calls atomic.Int32
+	err := RunPackSchedule(ctx, time.Hour, func(context.Context) (PackReport, error) {
+		calls.Add(1)
+		cancel()
+		return PackReport{}, nil
+	}, slog.New(slog.DiscardHandler))
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestRunPackScheduleReportsRunFailure(t *testing.T) {
+	sentinel := errors.New("pack failed")
+	err := RunPackSchedule(t.Context(), time.Hour,
+		func(context.Context) (PackReport, error) { return PackReport{}, sentinel }, nil)
+	require.ErrorIs(t, err, sentinel)
+	require.ErrorContains(t, err, "automatic packing")
+}
+
+func TestRunPackScheduleRejectsInvalidConfiguration(t *testing.T) {
+	run := func(context.Context) (PackReport, error) { return PackReport{}, nil }
+	require.ErrorContains(t, RunPackSchedule(t.Context(), 0, run, nil), "interval")
+	require.ErrorContains(t, RunPackSchedule(t.Context(), time.Second, nil, nil), "runner")
+}

--- a/internal/maintenance/automatic_test.go
+++ b/internal/maintenance/automatic_test.go
@@ -32,6 +32,51 @@ func TestRunPackScheduleReportsRunFailure(t *testing.T) {
 	require.ErrorContains(t, err, "automatic packing")
 }
 
+func TestRunPackScheduleWaitsAfterSlowRun(t *testing.T) {
+	const interval = 200 * time.Millisecond
+	ctx, cancel := context.WithCancel(t.Context())
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+	var calls atomic.Int32
+	done := make(chan error, 1)
+	go func() {
+		done <- RunPackSchedule(ctx, interval, func(context.Context) (PackReport, error) {
+			switch calls.Add(1) {
+			case 1:
+				close(firstStarted)
+				<-releaseFirst
+			case 2:
+				close(secondStarted)
+				cancel()
+			}
+			return PackReport{}, nil
+		}, slog.New(slog.DiscardHandler))
+	}()
+
+	<-firstStarted
+	// Let the old ticker-based implementation queue a tick while the first
+	// run is still active, then prove completion begins a fresh quiet window.
+	time.Sleep(interval + 50*time.Millisecond)
+	close(releaseFirst)
+	select {
+	case <-secondStarted:
+		t.Fatal("second pack started without a full interval after the slow run")
+	case <-time.After(interval / 2):
+	}
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * interval):
+		t.Fatal("second pack did not start after the post-run interval")
+	}
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("pack schedule did not stop after cancellation")
+	}
+}
+
 func TestRunPackScheduleRejectsInvalidConfiguration(t *testing.T) {
 	run := func(context.Context) (PackReport, error) { return PackReport{}, nil }
 	require.ErrorContains(t, RunPackSchedule(t.Context(), 0, run, nil), "interval")


### PR DESCRIPTION
Watched inboxes can run for months and ingest thousands of small files, but until now every blob stayed loose until a person or agent remembered to run `docbank storage pack`. That leaves the unattended archive workflow incomplete.

This adds an opt-in daemon schedule:

```toml
[storage]
pack_interval = "1h"
pack_max_bytes = 268435456
```

When enabled, Docbank packs once at startup and then on the configured interval. Each pass has a finite soft byte budget, remaining work waits for a later pass, and `docbank jobs` exposes the live `storage:pack` job. The schedule keeps an auto-started daemon alive so it can actually run.

Packing uses the same exclusive maintenance boundary as the CLI. A mutation arriving during a pass receives the existing retryable `maintenance_busy` response rather than racing physical storage changes. The archived bytes remain readable after moving into packs.

This is intentionally only automatic packing. It does not prune versions, empty trash, run GC, or repack sparse packs; those operations reclaim or rewrite storage and remain explicit operator choices.