### PR TITLE
Prove the agent session archive lifecycle

### DIFF
--- a/cmd/docbank/session_archive_test.go
+++ b/cmd/docbank/session_archive_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+)
+
+func TestAgentSessionArchiveSurvivesPackedBackupRestore(t *testing.T) {
+	home := t.TempDir()
+	source := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "backup")
+	relativeSource := filepath.Join("codex", "project-alpha", "2026-07", "session-01.jsonl")
+	sourcePath := filepath.Join(source, relativeSource)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sourcePath), 0o700))
+
+	first := []byte("{\"role\":\"user\",\"content\":\"synthetic first turn\"}\n")
+	final := []byte("{\"role\":\"user\",\"content\":\"synthetic first turn\"}\n" +
+		"{\"role\":\"assistant\",\"content\":\"quasar archive complete\"}\n")
+	oldMTime := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Second)
+	writeClosedSession := func(content []byte) {
+		require.NoError(t, os.WriteFile(sourcePath, content, 0o600))
+		require.NoError(t, os.Chtimes(sourcePath, oldMTime, oldMTime))
+	}
+	writeClosedSession(first)
+
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
+		"[server]\nidle_timeout = \"30ms\"\n"+
+			"[backup]\nrepo = \""+filepath.ToSlash(repo)+"\"\n"+
+			"[storage]\npack_interval = \"75ms\"\npack_max_bytes = 1048576\n"+
+			"[[watch]]\nname = \"agent-sessions\"\nsource = \""+filepath.ToSlash(source)+"\"\n"+
+			"destination = \"/archives/agents\"\nsettle_time = \"20ms\"\n"+
+			"minimum_age = \"24h\"\nscan_interval = \"10ms\"\n",
+	), 0o600))
+	t.Setenv("DOCBANK_HOME", home)
+	t.Setenv(client.EnvBackgroundDaemon, "1")
+	startTestDaemon(t, home)
+
+	virtualPath := "/archives/agents/codex/project-alpha/2026-07/session-01.jsonl"
+	require.Eventually(t, func() bool {
+		out, err := runCLI(t, "cat", virtualPath)
+		return err == nil && out == string(first)
+	}, 5*time.Second, 25*time.Millisecond)
+
+	out, err := runCLI(t, "versions", "list", virtualPath, "--json")
+	require.NoError(t, err)
+	var firstVersions api.ContentVersionPage
+	require.NoError(t, json.Unmarshal([]byte(out), &firstVersions))
+	require.Len(t, firstVersions.Items, 1)
+	firstVersionID := firstVersions.Items[0].ID
+
+	writeClosedSession(final)
+	require.Eventually(t, func() bool {
+		out, catErr := runCLI(t, "cat", virtualPath)
+		return catErr == nil && out == string(final)
+	}, 5*time.Second, 25*time.Millisecond)
+
+	out, err = runCLI(t, "versions", "list", virtualPath, "--json")
+	require.NoError(t, err)
+	var versions api.ContentVersionPage
+	require.NoError(t, json.Unmarshal([]byte(out), &versions))
+	require.Len(t, versions.Items, 2)
+	assert.Equal(t, firstVersionID, versions.Items[1].ID)
+
+	require.Eventually(t, func() bool {
+		out, searchErr := runCLI(t, "search", "quasar", "--json")
+		if searchErr != nil {
+			return false
+		}
+		var report api.SearchReport
+		return json.Unmarshal([]byte(out), &report) == nil && len(report.Hits) == 1 &&
+			report.Hits[0].Path == virtualPath && report.Hits[0].Match == "content"
+	}, 5*time.Second, 100*time.Millisecond)
+
+	out, err = runCLI(t, "provenance", virtualPath, "--json")
+	require.NoError(t, err)
+	var provenance api.ProvenancePage
+	require.NoError(t, json.Unmarshal([]byte(out), &provenance))
+	require.Len(t, provenance.Items, 1)
+	assert.Equal(t, "watch", provenance.Items[0].SourceKind)
+	assert.Equal(t, "agent-sessions", provenance.Items[0].SourceDescription)
+	assert.Equal(t, filepath.ToSlash(relativeSource), provenance.Items[0].OriginalPath)
+	require.NotNil(t, provenance.Items[0].OriginalMTime)
+	assert.Equal(t, oldMTime.Format(time.RFC3339Nano), *provenance.Items[0].OriginalMTime)
+
+	require.Eventually(t, func() bool {
+		out, statusErr := runCLI(t, "storage", "status", "--json")
+		if statusErr != nil {
+			return false
+		}
+		var status api.StorageStatus
+		return json.Unmarshal([]byte(out), &status) == nil &&
+			status.LooseBlobs == 0 && status.PackedBlobs == 2
+	}, 5*time.Second, 25*time.Millisecond)
+
+	_, err = runCLI(t, "backup", "init")
+	require.NoError(t, err)
+	var snapshot api.BackupSnapshot
+	require.Eventually(t, func() bool {
+		out, createErr := runCLI(t, "backup", "create", "--tag", "agent-sessions", "--json")
+		if errors.Is(createErr, client.ErrMaintenanceBusy) {
+			return false
+		}
+		if createErr != nil {
+			err = createErr
+			return true
+		}
+		err = json.Unmarshal([]byte(out), &snapshot)
+		return true
+	}, 5*time.Second, 25*time.Millisecond)
+	require.NoError(t, err)
+	require.NotEmpty(t, snapshot.ID)
+
+	out, err = runCLI(t, "backup", "verify", snapshot.ID, "--json")
+	require.NoError(t, err)
+	var backupProof api.BackupVerifyReport
+	require.NoError(t, json.Unmarshal([]byte(out), &backupProof))
+	assert.Empty(t, backupProof.Problems)
+
+	restoreTarget := filepath.Join(t.TempDir(), "restored")
+	out, err = runCLI(t, "backup", "restore", snapshot.ID, "--target", restoreTarget, "--json")
+	require.NoError(t, err)
+	var restoreProof api.BackupRestoreReport
+	require.NoError(t, json.Unmarshal([]byte(out), &restoreProof))
+	assert.True(t, restoreProof.Proof.ContentVerified)
+	assert.True(t, restoreProof.Proof.SQLiteIntegrity)
+	assert.True(t, restoreProof.Proof.ManifestStats)
+
+	t.Setenv("DOCBANK_HOME", restoreTarget)
+	startTestDaemon(t, restoreTarget)
+	out, err = runCLI(t, "cat", virtualPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(final), out)
+	out, err = runCLI(t, "versions", "cat", firstVersionID)
+	require.NoError(t, err)
+	assert.Equal(t, string(first), out)
+
+	out, err = runCLI(t, "versions", "list", virtualPath, "--json")
+	require.NoError(t, err)
+	var restoredVersions api.ContentVersionPage
+	require.NoError(t, json.Unmarshal([]byte(out), &restoredVersions))
+	assert.Equal(t, versions, restoredVersions)
+
+	out, err = runCLI(t, "provenance", virtualPath, "--json")
+	require.NoError(t, err)
+	var restoredProvenance api.ProvenancePage
+	require.NoError(t, json.Unmarshal([]byte(out), &restoredProvenance))
+	assert.Equal(t, provenance, restoredProvenance)
+
+	out, err = runCLI(t, "verify")
+	require.NoError(t, err)
+	assert.Contains(t, out, "2 blob(s) ok")
+
+	sourceBytes, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, final, sourceBytes)
+}

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -225,6 +225,14 @@ source does not overwrite a later edit or revert after daemon restart. Removing
 the source leaves the archived node alone. A renamed source-relative path is a
 new identity, not an implicit move.
 
+For an agent-session archive, use the source tree itself for the organization
+you want to retain. For example,
+`~/agent-sessions/codex/project-alpha/2026/07/session-01.jsonl` becomes
+`/archives/agents/codex/project-alpha/2026/07/session-01.jsonl` with the
+configuration above. Docbank does not reinterpret a vendor's session format:
+the relative path and source facts remain exact, while each accepted byte
+change becomes an immutable version of that document.
+
 Use `docbank provenance <path-or-id>` to inspect the retained watch identity,
 source-relative path, and immutable supersession history for an imported node.
 JSONL session content up to the normal extraction limit is indexed by the
@@ -232,6 +240,8 @@ built-in plain-text worker, so ordinary `docbank search` can find archived
 session text without a vendor-specific parser. The optional `[storage]`
 schedule packs accumulated small files with a finite per-run budget. It does
 not delete source files, prune versions, run GC, or rewrite existing packs.
+Portable [backup and restore](backup.md) preserve the mirrored hierarchy,
+source provenance, every retained version, and its verified bytes.
 
 The destination is exact rather than collision-suffixed. If unrelated content
 already occupies the intended path, or the previously mapped node is in the


### PR DESCRIPTION
Docbank now has one proven workflow for turning closed agent-session JSONL into a durable archive, instead of several features that merely appear compatible in isolation.

For example, a watched source at `codex/project-alpha/2026/07/session-01.jsonl` is filed at the same relative coordinate beneath `/archives/agents`. The watcher waits for both the configured quiet period and minimum age, preserves the source identity and modification time, and appends later byte changes as immutable versions without modifying the source. The resulting JSONL remains searchable and can move into managed packs.

The lifecycle rehearsal then creates and verifies a portable backup, restores it into a separate vault, and proves the current bytes, an earlier immutable version, hierarchy, provenance, and storage integrity again. This is the composition boundary that matters for a long-lived session archive.

The workflow intentionally remains vendor-neutral. Docbank does not reinterpret Claude, Codex, or another producer’s private schema, and it never deletes source sessions; operators can choose a predictable source hierarchy and a conservative completion policy without granting Docbank source-pruning authority.