### PR TITLE
Make the TUI an analytical document table

### DIFF
--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -18,8 +18,11 @@ var tuiCmd = &cobra.Command{
 Navigation:
   Up/Down or j/k       Move between documents
   Enter or Right       Open a directory
+  Enter on a file or i Inspect complete document authority
   Left or Backspace    Return to the parent directory
   /                    Search names and extracted text
+  s                    Cycle the sort column
+  v                    Reverse the sort direction
   r                    Refresh the current view
   ?                    Show keyboard help
   q                    Quit

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -21,17 +21,25 @@ ordinary CLI. It never opens SQLite or the blob store and cannot bypass the
 vault's exclusive owner. Starting it reuses or starts the daemon in the normal
 way.
 
-The left pane shows the current virtual directory or a bounded set of search
-results. The right pane shows the selected document's stable node selector,
-path, kind, revision, modification time, and—when it is a file—its current
-immutable version, SHA-256 identity, raw size, and media type.
+The main view is a full-width document table. At ordinary terminal widths it
+shows each document's name, type, size, and modification time; search results
+also identify the match kind when space permits. Narrow terminals progressively
+hide secondary columns so the document name remains useful.
+
+Press <kbd>i</kbd> to leave the table temporarily and inspect the selected
+document's complete stable node selector, path, revision, modification time,
+and—when it is a file—its immutable version, SHA-256 identity, exact size, and
+media type. Long authority values wrap rather than truncate.
 
 | Key | Action |
 |-----|--------|
 | <kbd>↑</kbd>/<kbd>k</kbd>, <kbd>↓</kbd>/<kbd>j</kbd> | Move between documents |
 | <kbd>Enter</kbd> or <kbd>→</kbd> | Open the selected directory |
+| <kbd>Enter</kbd> on a file, or <kbd>i</kbd> | Inspect complete document authority |
 | <kbd>←</kbd>, <kbd>Backspace</kbd>, or <kbd>Esc</kbd> | Return to the parent directory or leave search results |
 | <kbd>/</kbd> | Search live names and extracted text |
+| <kbd>s</kbd> | Cycle the sort column: name, type, size, and modification time |
+| <kbd>v</kbd> | Reverse the current sort direction |
 | <kbd>r</kbd> | Refresh the current directory or search |
 | <kbd>?</kbd> | Show keyboard help |
 | <kbd>q</kbd> or <kbd>Ctrl-C</kbd> | Quit |
@@ -39,7 +47,9 @@ immutable version, SHA-256 identity, raw size, and media type.
 Search has the same semantics as `docbank search`: name matches precede
 content-only matches, and content is available only for supported documents
 whose current bytes completed verified extraction. Results say whether the
-match came from the name or content. The first interface loads at most 1,000
+match came from the name or content. Relevance order remains the search default;
+pressing <kbd>s</kbd> opts into a column sort, and cycling through the columns
+returns to relevance. The first interface loads at most 1,000
 directory entries or search hits and says when more exist; use the CLI or HTTP
 pagination for exhaustive automation.
 

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -22,7 +22,7 @@ vault's exclusive owner. Starting it reuses or starts the daemon in the normal
 way.
 
 The main view is a full-width document table. At ordinary terminal widths it
-shows each document's name, type, size, and modification time; search results
+shows each document's name, type, size, and UTC modification time; search results
 also identify the match kind when space permits. Narrow terminals progressively
 hide secondary columns so the document name remains useful.
 

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -38,7 +38,7 @@ media type. Long authority values wrap rather than truncate.
 | <kbd>Enter</kbd> on a file, or <kbd>i</kbd> | Inspect complete document authority |
 | <kbd>←</kbd>, <kbd>Backspace</kbd>, or <kbd>Esc</kbd> | Return to the parent directory or leave search results |
 | <kbd>/</kbd> | Search live names and extracted text |
-| <kbd>s</kbd> | Cycle the sort column: name, type, size, and modification time |
+| <kbd>s</kbd> | Cycle the sort column: name, size, and modification time |
 | <kbd>v</kbd> | Reverse the current sort direction |
 | <kbd>r</kbd> | Refresh the current directory or search |
 | <kbd>?</kbd> | Show keyboard help |

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -44,7 +44,6 @@ type sortField uint8
 const (
 	sortByRelevance sortField = iota
 	sortByName
-	sortByKind
 	sortBySize
 	sortByModified
 )
@@ -569,8 +568,6 @@ func (m *Model) cycleSortField() {
 	case sortByRelevance:
 		m.sortField = sortByName
 	case sortByName:
-		m.sortField = sortByKind
-	case sortByKind:
 		m.sortField = sortBySize
 	case sortBySize:
 		m.sortField = sortByModified
@@ -615,8 +612,7 @@ func (m *Model) selectNode(nodeID int64) {
 }
 
 func (m Model) compareRows(left, right row) int {
-	if m.sortField != sortByKind && m.sortField != sortByRelevance &&
-		left.node.Kind != right.node.Kind {
+	if m.sortField != sortByRelevance && left.node.Kind != right.node.Kind {
 		if left.node.Kind == nodeKindDir {
 			return -1
 		}
@@ -628,8 +624,6 @@ func (m Model) compareRows(left, right row) int {
 	switch m.sortField {
 	case sortByRelevance:
 		comparison = cmp.Compare(left.rank, right.rank)
-	case sortByKind:
-		comparison = cmp.Compare(left.node.Kind, right.node.Kind)
 	case sortBySize:
 		comparison = cmp.Compare(left.node.Size, right.node.Size)
 	case sortByModified:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -416,6 +416,10 @@ func (m Model) applyDirectory(msg directoryLoadedMsg) (tea.Model, tea.Cmd) {
 	case navigationInitial, navigationRefresh:
 	}
 	m.mode = modeBrowse
+	if m.sortField == sortByRelevance {
+		m.sortField = sortByName
+		m.sortDesc = false
+	}
 	m.directory = msg.directory
 	m.rows = rowsForDirectory(msg.directory, msg.page.Items)
 	m.total = msg.page.Total

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,9 +2,11 @@
 package tui
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,6 +19,8 @@ import (
 const (
 	maxBrowserItems = 1000
 	maxSearchItems  = 1000
+	nodeKindDir     = "dir"
+	nodeKindFile    = "file"
 )
 
 // Backend is the bounded read surface needed by the first TUI slice.
@@ -35,10 +39,21 @@ const (
 	modeSearch
 )
 
+type sortField uint8
+
+const (
+	sortByRelevance sortField = iota
+	sortByName
+	sortByKind
+	sortBySize
+	sortByModified
+)
+
 type row struct {
 	node  api.Node
 	path  string
 	match string
+	rank  int
 }
 
 type location struct {
@@ -51,6 +66,8 @@ type location struct {
 	offset       int
 	searchQuery  string
 	searchReturn *location
+	sortField    sortField
+	sortDesc     bool
 }
 
 type navigationKind uint8
@@ -99,6 +116,8 @@ type Model struct {
 	cursor    int
 	offset    int
 	stack     []location
+	sortField sortField
+	sortDesc  bool
 
 	searchInput  textinput.Model
 	searching    bool
@@ -133,7 +152,7 @@ func New(ctx context.Context, backend Backend) (Model, error) {
 	return Model{
 		ctx: ctx, backend: backend, loading: true,
 		searchInput: input, styles: newStyles(true), requestID: 1,
-		spinnerActive: true,
+		spinnerActive: true, sortField: sortByName,
 	}, nil
 }
 
@@ -229,6 +248,14 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "?":
 		m.helpOpen = true
 		return m, nil
+	case "s":
+		m.cycleSortField()
+		m.sortRowsPreservingSelection()
+		return m, nil
+	case "v":
+		m.sortDesc = !m.sortDesc
+		m.sortRowsPreservingSelection()
+		return m, nil
 	case "i":
 		if _, ok := m.selected(); ok {
 			m.detailOpen = true
@@ -269,7 +296,7 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case "enter", "right", "l":
 		selected, ok := m.selected()
-		if ok && selected.node.Kind != "dir" {
+		if ok && selected.node.Kind != nodeKindDir {
 			m.detailOpen = true
 			m.detailOffset = 0
 			return m, nil
@@ -347,7 +374,7 @@ func (m Model) loadDirectory(
 		if err != nil {
 			return directoryLoadedMsg{requestID: requestID, kind: kind, err: err}
 		}
-		if directory.Kind != "dir" || directory.TrashedAt != "" || directory.Path == "" {
+		if directory.Kind != nodeKindDir || directory.TrashedAt != "" || directory.Path == "" {
 			return directoryLoadedMsg{
 				requestID: requestID, kind: kind,
 				err: errors.New("selected node is not a live directory"),
@@ -378,7 +405,10 @@ func (m Model) applyDirectory(msg directoryLoadedMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	current := m.snapshot()
-	previousCursor, previousOffset := m.cursor, m.offset
+	previousSelectedID, previousOffset := int64(0), m.offset
+	if selected, ok := m.selected(); ok {
+		previousSelectedID = selected.node.ID
+	}
 	switch msg.kind {
 	case navigationForward:
 		if current.directory.Path != "" {
@@ -392,8 +422,10 @@ func (m Model) applyDirectory(msg directoryLoadedMsg) (tea.Model, tea.Cmd) {
 	m.total = msg.page.Total
 	m.truncated = len(msg.page.Items) < msg.page.Total
 	m.cursor, m.offset = 0, 0
+	m.sortRows()
 	if msg.kind == navigationRefresh {
-		m.cursor, m.offset = previousCursor, previousOffset
+		m.selectNode(previousSelectedID)
+		m.offset = previousOffset
 	}
 	m.err = nil
 	m.clampSelection()
@@ -409,18 +441,33 @@ func (m Model) applySearch(msg searchLoadedMsg) (tea.Model, tea.Cmd) {
 		m.err = msg.err
 		return m, nil
 	}
+	refreshing := m.mode == modeSearch && m.searchQuery == msg.query
+	previousSelectedID, previousOffset := int64(0), m.offset
+	if selected, ok := m.selected(); ok {
+		previousSelectedID = selected.node.ID
+	}
 	m.mode = modeSearch
 	m.searchQuery = msg.query
+	if !refreshing {
+		m.sortField = sortByRelevance
+		m.sortDesc = false
+	}
 	m.rows = make([]row, 0, len(msg.report.Hits))
-	for _, hit := range msg.report.Hits {
+	for rank, hit := range msg.report.Hits {
 		node := hit.Node
 		node.Path = hit.Path
-		m.rows = append(m.rows, row{node: node, path: hit.Path, match: hit.Match})
+		m.rows = append(m.rows, row{node: node, path: hit.Path, match: hit.Match, rank: rank})
 	}
 	m.total = len(msg.report.Hits)
 	m.truncated = msg.report.Truncated
 	m.cursor, m.offset = 0, 0
+	m.sortRows()
+	if refreshing {
+		m.selectNode(previousSelectedID)
+		m.offset = previousOffset
+	}
 	m.err = nil
+	m.clampSelection()
 	return m, nil
 }
 
@@ -434,6 +481,7 @@ func (m Model) snapshot() location {
 		mode: m.mode, directory: m.directory, rows: append([]row(nil), m.rows...),
 		total: m.total, truncated: m.truncated, cursor: m.cursor, offset: m.offset,
 		searchQuery: m.searchQuery, searchReturn: searchReturn,
+		sortField: m.sortField, sortDesc: m.sortDesc,
 	}
 }
 
@@ -447,6 +495,8 @@ func (m *Model) restore(state location) {
 	m.offset = state.offset
 	m.searchQuery = state.searchQuery
 	m.searchReturn = state.searchReturn
+	m.sortField = state.sortField
+	m.sortDesc = state.sortDesc
 	m.loading = false
 	m.err = nil
 	m.clampSelection()
@@ -467,9 +517,9 @@ func spinnerTick() tea.Cmd {
 
 func rowsForDirectory(directory api.Node, nodes []api.Node) []row {
 	rows := make([]row, 0, len(nodes))
-	for _, node := range nodes {
+	for rank, node := range nodes {
 		node.Path = path.Join(directory.Path, node.Name)
-		rows = append(rows, row{node: node, path: node.Path})
+		rows = append(rows, row{node: node, path: node.Path, rank: rank})
 	}
 	return rows
 }
@@ -511,9 +561,97 @@ func (m Model) visibleRows() int {
 		headerLines++
 	}
 	bodyHeight := max(m.height-headerLines-1, 1)
-	listHeight := bodyHeight
-	if m.width < 72 {
-		listHeight = max((bodyHeight*2)/3, 1)
+	return max(bodyHeight-2, 1)
+}
+
+func (m *Model) cycleSortField() {
+	switch m.sortField {
+	case sortByRelevance:
+		m.sortField = sortByName
+	case sortByName:
+		m.sortField = sortByKind
+	case sortByKind:
+		m.sortField = sortBySize
+	case sortBySize:
+		m.sortField = sortByModified
+	case sortByModified:
+		if m.mode == modeSearch {
+			m.sortField = sortByRelevance
+		} else {
+			m.sortField = sortByName
+		}
+	default:
+		m.sortField = sortByName
 	}
-	return max(listHeight-2, 1)
+	m.sortDesc = false
+}
+
+func (m *Model) sortRowsPreservingSelection() {
+	selectedID := int64(0)
+	if selected, ok := m.selected(); ok {
+		selectedID = selected.node.ID
+	}
+	m.sortRows()
+	m.selectNode(selectedID)
+	m.clampSelection()
+}
+
+func (m *Model) sortRows() {
+	sort.SliceStable(m.rows, func(left, right int) bool {
+		return m.compareRows(m.rows[left], m.rows[right]) < 0
+	})
+}
+
+func (m *Model) selectNode(nodeID int64) {
+	if nodeID == 0 {
+		return
+	}
+	for index := range m.rows {
+		if m.rows[index].node.ID == nodeID {
+			m.cursor = index
+			return
+		}
+	}
+}
+
+func (m Model) compareRows(left, right row) int {
+	if m.sortField != sortByKind && m.sortField != sortByRelevance &&
+		left.node.Kind != right.node.Kind {
+		if left.node.Kind == nodeKindDir {
+			return -1
+		}
+		if right.node.Kind == nodeKindDir {
+			return 1
+		}
+	}
+	var comparison int
+	switch m.sortField {
+	case sortByRelevance:
+		comparison = cmp.Compare(left.rank, right.rank)
+	case sortByKind:
+		comparison = cmp.Compare(left.node.Kind, right.node.Kind)
+	case sortBySize:
+		comparison = cmp.Compare(left.node.Size, right.node.Size)
+	case sortByModified:
+		comparison = cmp.Compare(left.node.ModifiedAt, right.node.ModifiedAt)
+	case sortByName:
+		fallthrough
+	default:
+		comparison = compareNames(left, right)
+	}
+	if comparison != 0 {
+		if m.sortDesc {
+			return -comparison
+		}
+		return comparison
+	}
+	return compareNames(left, right)
+}
+
+func compareNames(left, right row) int {
+	leftName, rightName := strings.ToLower(left.path), strings.ToLower(right.path)
+	if comparison := cmp.Compare(leftName, rightName); comparison != 0 {
+		return comparison
+	}
+	return cmp.Compare(left.path, right.path)
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -234,6 +234,25 @@ func TestDirectoryLoadsFollowStableNodeIdentity(t *testing.T) {
 	assert.Equal(t, []int64{2, 2}, backend.nodeIDs)
 }
 
+func TestOpeningDirectoryFromSearchResetsRelevanceSort(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.mode = modeSearch
+	model.sortField = sortByRelevance
+	model.sortDesc = true
+	model.rows = []row{{node: backend.nodes["/docs"], path: "/docs", rank: 0}}
+	model.total = 1
+
+	model, cmd := updateModel(t, model, key(tea.KeyEnter))
+	require.NotNil(t, cmd)
+	model = runModelCommand(t, model, cmd)
+	assert.Equal(t, modeBrowse, model.mode)
+	assert.Equal(t, sortByName, model.sortField)
+	assert.False(t, model.sortDesc)
+	assert.Equal(t, "/docs", model.directory.Path)
+}
+
 func TestNarrowLayoutKeepsSelectionVisible(t *testing.T) {
 	backend := newFakeBackend()
 	model, err := New(t.Context(), backend)
@@ -291,7 +310,7 @@ func TestAnalyticalTableSortsWithoutChangingSelection(t *testing.T) {
 	assert.Contains(t, content, "SIZE↓")
 	assert.Contains(t, content, "MODIFIED")
 	assert.Contains(t, content, "2.0 KB")
-	assert.Contains(t, content, "2026-07-22 14:00")
+	assert.Contains(t, content, "2026-07-22 14:00Z")
 	assert.NotContains(t, content, "Document authority")
 }
 
@@ -401,6 +420,14 @@ func TestChromeAdaptsWithoutDroppingPrimaryContext(t *testing.T) {
 	assert.Contains(t, footer, "↑/↓ move")
 	assert.NotContains(t, footer, "refresh", "low-priority hint should drop first")
 	assert.LessOrEqual(t, lipgloss.Width(footer), model.width)
+
+	model.sortField = sortBySize
+	assert.Contains(t, model.renderLocation(), "size↑",
+		"a hidden active sort column must remain visible")
+}
+
+func TestModifiedTimeIsRenderedAsUTC(t *testing.T) {
+	assert.Equal(t, "2026-07-22 19:00Z", formatModified("2026-07-22T14:00:00-05:00"))
 }
 
 func TestFitHintsDropsLowestPriorityFirst(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -247,15 +247,90 @@ func TestNarrowLayoutKeepsSelectionVisible(t *testing.T) {
 	model.total = len(model.rows)
 	model.loading = false
 
-	assert.Equal(t, 4, model.visibleRows())
+	assert.Equal(t, 7, model.visibleRows())
 	for range 5 {
 		model.moveCursor(1)
 	}
 	assert.Equal(t, 5, model.cursor)
-	assert.Equal(t, 2, model.offset)
-	assert.Contains(t, model.renderList(model.width, 6), "item-05")
+	assert.Equal(t, 0, model.offset)
+	assert.Contains(t, model.renderList(model.width, 9), "item-05")
 	assert.GreaterOrEqual(t, model.cursor, model.offset)
 	assert.Less(t, model.cursor, model.offset+model.visibleRows())
+}
+
+func TestAnalyticalTableSortsWithoutChangingSelection(t *testing.T) {
+	model, err := New(t.Context(), newFakeBackend())
+	require.NoError(t, err)
+	model.width, model.height = 100, 12
+	model.directory = newFakeBackend().nodes["/"]
+	model.rows = []row{
+		{node: api.Node{ID: 10, Kind: "file", Name: "large.bin", Size: 2048,
+			ModifiedAt: "2026-07-22T14:00:00Z"}, path: "/large.bin"},
+		{node: api.Node{ID: 11, Kind: "dir", Name: "zeta",
+			ModifiedAt: "2026-07-20T10:00:00Z"}, path: "/zeta"},
+		{node: api.Node{ID: 12, Kind: "file", Name: "small.txt", Size: 12,
+			ModifiedAt: "2026-07-21T09:30:00Z"}, path: "/small.txt"},
+	}
+	model.total = len(model.rows)
+	model.loading = false
+	model.sortRows()
+	model.selectNode(10)
+
+	model, _ = updateModel(t, model, runeKey('s')) // type
+	model, _ = updateModel(t, model, runeKey('s')) // size
+	require.Equal(t, sortBySize, model.sortField)
+	assert.Equal(t, []int64{11, 12, 10}, rowIDs(model.rows))
+	selected, ok := model.selected()
+	require.True(t, ok)
+	assert.Equal(t, int64(10), selected.node.ID)
+
+	model, _ = updateModel(t, model, runeKey('v'))
+	assert.True(t, model.sortDesc)
+	assert.Equal(t, []int64{11, 10, 12}, rowIDs(model.rows),
+		"directories remain first while file sizes reverse")
+	content := model.View().Content
+	assert.Contains(t, content, "SIZE↓")
+	assert.Contains(t, content, "MODIFIED")
+	assert.Contains(t, content, "2.0 KB")
+	assert.Contains(t, content, "2026-07-22 14:00")
+	assert.NotContains(t, content, "Document authority")
+}
+
+func TestSearchKeepsRelevanceUntilSortChanges(t *testing.T) {
+	model, err := New(t.Context(), newFakeBackend())
+	require.NoError(t, err)
+	model.mode = modeSearch
+	model.sortField = sortByRelevance
+	model.rows = []row{
+		{node: api.Node{ID: 20, Kind: "file", Name: "zeta"}, path: "/zeta", rank: 0},
+		{node: api.Node{ID: 21, Kind: "file", Name: "alpha"}, path: "/alpha", rank: 1},
+	}
+	model.sortRows()
+	assert.Equal(t, []int64{20, 21}, rowIDs(model.rows))
+
+	model, _ = updateModel(t, model, runeKey('s'))
+	assert.Equal(t, sortByName, model.sortField)
+	assert.Equal(t, []int64{21, 20}, rowIDs(model.rows))
+
+	model.sortField = sortBySize
+	model.sortDesc = true
+	model.searchQuery = "report"
+	model.requestID = 7
+	model.selectNode(20)
+	refreshed, _ := updateModel(t, model, searchLoadedMsg{
+		requestID: 7,
+		query:     "report",
+		report: api.SearchReport{Hits: []api.SearchHit{
+			{Node: api.Node{ID: 20, Kind: "file", Name: "zeta", Size: 20}, Path: "/zeta"},
+			{Node: api.Node{ID: 21, Kind: "file", Name: "alpha", Size: 10}, Path: "/alpha"},
+		}},
+	})
+	assert.Equal(t, sortBySize, refreshed.sortField)
+	assert.True(t, refreshed.sortDesc)
+	assert.Equal(t, []int64{20, 21}, rowIDs(refreshed.rows))
+	selected, ok := refreshed.selected()
+	require.True(t, ok)
+	assert.Equal(t, int64(20), selected.node.ID)
 }
 
 func TestExpandedDetailExposesCompleteAuthority(t *testing.T) {
@@ -429,4 +504,12 @@ func key(code rune) tea.KeyPressMsg {
 
 func runeKey(value rune) tea.KeyPressMsg {
 	return tea.KeyPressMsg{Code: value, Text: string(value)}
+}
+
+func rowIDs(rows []row) []int64 {
+	ids := make([]int64, 0, len(rows))
+	for _, item := range rows {
+		ids = append(ids, item.node.ID)
+	}
+	return ids
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -276,7 +276,6 @@ func TestAnalyticalTableSortsWithoutChangingSelection(t *testing.T) {
 	model.sortRows()
 	model.selectNode(10)
 
-	model, _ = updateModel(t, model, runeKey('s')) // type
 	model, _ = updateModel(t, model, runeKey('s')) // size
 	require.Equal(t, sortBySize, model.sortField)
 	assert.Equal(t, []int64{11, 12, 10}, rowIDs(model.rows))

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -119,6 +119,8 @@ func (m Model) renderLocation() string {
 	}
 	if m.width >= 48 {
 		right += " · " + m.sortSummary()
+	} else if !m.sortIndicatorVisible() {
+		right = m.sortSummary()
 	}
 	if m.loading {
 		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
@@ -222,7 +224,7 @@ func newTableLayout(width int, mode viewMode) tableLayout {
 		fixed += 2 + 9
 	}
 	if layout.showModified {
-		fixed += 2 + 16
+		fixed += 2 + 17
 	}
 	layout.document = max(width-fixed, 1)
 	return layout
@@ -246,7 +248,7 @@ func (l tableLayout) render(prefix, document, kind, match, size, modified string
 	}
 	if l.showModified {
 		line.WriteString("  ")
-		line.WriteString(pad(modified, 16))
+		line.WriteString(pad(modified, 17))
 	}
 	return pad(line.String(), l.width)
 }
@@ -276,6 +278,22 @@ func (m Model) sortSummary() string {
 		return label + "↓"
 	}
 	return label + "↑"
+}
+
+func (m Model) sortIndicatorVisible() bool {
+	layout := newTableLayout(m.width, m.mode)
+	switch m.sortField {
+	case sortByName:
+		return layout.document >= lipgloss.Width("DOCUMENT↑")
+	case sortBySize:
+		return layout.showSize
+	case sortByModified:
+		return layout.showModified
+	case sortByRelevance:
+		return false
+	default:
+		return false
+	}
 }
 
 func (m Model) renderExpandedDetail(height int) string {
@@ -501,7 +519,7 @@ func formatModified(value string) string {
 	if err != nil {
 		return value
 	}
-	return parsed.Format("2006-01-02 15:04")
+	return parsed.UTC().Format("2006-01-02 15:04Z")
 }
 
 func quoted(value string) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -139,7 +139,7 @@ func (m Model) renderList(width, height int) string {
 	heading := layout.render(
 		"   ",
 		m.columnHeading("DOCUMENT", sortByName),
-		m.columnHeading("TYPE", sortByKind),
+		"TYPE",
 		"MATCH",
 		m.columnHeading("SIZE", sortBySize),
 		m.columnHeading("MODIFIED", sortByModified),
@@ -266,8 +266,6 @@ func (m Model) sortSummary() string {
 	switch m.sortField {
 	case sortByRelevance:
 		label = "relevance"
-	case sortByKind:
-		label = "type"
 	case sortBySize:
 		label = "size"
 	case sortByModified:

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -116,6 +117,9 @@ func (m Model) renderLocation() string {
 			right = fmt.Sprintf("first %d of %d", len(m.rows), m.total)
 		}
 	}
+	if m.width >= 48 {
+		right += " · " + m.sortSummary()
+	}
 	if m.loading {
 		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
 	}
@@ -126,32 +130,20 @@ func (m Model) renderLocation() string {
 }
 
 func (m Model) renderBody(height int) string {
-	if m.width < 72 {
-		listHeight := max((height*2)/3, 1)
-		detailHeight := max(height-listHeight-1, 0)
-		list := m.renderList(m.width, listHeight)
-		if detailHeight == 0 {
-			return list
-		}
-		return list + "\n" + m.styles.muted.Render(strings.Repeat("─", m.width)) + "\n" +
-			m.renderDetail(m.width, detailHeight)
-	}
-	listWidth := max((m.width*55)/100, 34)
-	detailWidth := max(m.width-listWidth-1, 1)
-	return lipgloss.JoinHorizontal(
-		lipgloss.Top,
-		m.renderList(listWidth, height),
-		m.styles.muted.Render(strings.Repeat("│\n", max(height-1, 0))+"│"),
-		m.renderDetail(detailWidth, height),
-	)
+	return m.renderList(m.width, height)
 }
 
 func (m Model) renderList(width, height int) string {
 	lines := make([]string, 0, height)
-	heading := "    TYPE  DOCUMENT"
-	if m.mode == modeSearch {
-		heading = "    TYPE  MATCH  DOCUMENT"
-	}
+	layout := newTableLayout(width, m.mode)
+	heading := layout.render(
+		"   ",
+		m.columnHeading("DOCUMENT", sortByName),
+		m.columnHeading("TYPE", sortByKind),
+		"MATCH",
+		m.columnHeading("SIZE", sortBySize),
+		m.columnHeading("MODIFIED", sortByModified),
+	)
 	lines = append(lines, m.styles.heading.Render(pad(fit(heading, width), width)))
 	if height > 1 {
 		lines = append(lines, m.styles.separator.Render(strings.Repeat("─", width)))
@@ -168,7 +160,7 @@ func (m Model) renderList(width, height int) string {
 	for index := m.offset; index < end; index++ {
 		item := m.rows[index]
 		kind := "FILE"
-		if item.node.Kind == "dir" {
+		if item.node.Kind == nodeKindDir {
 			kind = "DIR "
 		}
 		label := item.path
@@ -179,12 +171,13 @@ func (m Model) renderList(width, height int) string {
 		if item.match != "" {
 			match = strings.ToUpper(item.match)
 		}
-		var line string
-		if m.mode == modeSearch {
-			line = fmt.Sprintf("  %-4s  %-7s %s", kind, match, quoted(label))
-		} else {
-			line = fmt.Sprintf("  %-4s  %s", kind, quoted(label))
+		size := "-"
+		if item.node.Kind == nodeKindFile {
+			size = formatBytes(item.node.Size)
 		}
+		line := layout.render(
+			"   ", quoted(label), kind, match, size, formatModified(item.node.ModifiedAt),
+		)
 		if index == m.cursor {
 			line = "▶" + line[1:]
 		}
@@ -203,56 +196,88 @@ func (m Model) renderList(width, height int) string {
 	return strings.Join(lines, "\n")
 }
 
-func (m Model) renderDetail(width, height int) string {
-	lines := []string{
-		m.styles.heading.Render(pad(fit(" Document authority", width), width)),
+type tableLayout struct {
+	width        int
+	document     int
+	showKind     bool
+	showMatch    bool
+	showSize     bool
+	showModified bool
+}
+
+func newTableLayout(width int, mode viewMode) tableLayout {
+	layout := tableLayout{
+		width: width, showKind: width >= 30,
+		showSize: width >= 48, showModified: width >= 72,
+		showMatch: mode == modeSearch && width >= 90,
 	}
-	if height > 1 {
-		lines = append(lines, m.styles.separator.Render(strings.Repeat("─", width)))
+	fixed := 3
+	if layout.showKind {
+		fixed += 2 + 4
 	}
-	selected, ok := m.selected()
-	if !ok {
-		lines = append(lines, m.styles.muted.Render(" Nothing selected"))
-	} else {
-		node := selected.node
-		lines = append(lines,
-			" Path: "+quoted(selected.path),
-			fmt.Sprintf(" Selector: id:%d", node.ID),
-			" Kind: "+node.Kind,
-			fmt.Sprintf(" Revision: %d", node.Revision),
-			" Modified: "+node.ModifiedAt,
-		)
-		if node.Kind == "file" {
-			lines = append(lines,
-				" Version: "+node.CurrentVersionID,
-				" SHA-256: "+node.BlobHash,
-				fmt.Sprintf(" Size: %s (%d bytes)", formatBytes(node.Size), node.Size),
-			)
-			if node.MimeType != "" {
-				lines = append(lines, " Media type: "+quoted(node.MimeType))
-			}
-		} else {
-			lines = append(lines, " Enter: open directory")
-		}
+	if layout.showMatch {
+		fixed += 2 + 7
 	}
-	for index := range lines {
-		plain := lines[index]
-		if index == 0 {
-			plain = m.styles.heading.Render(pad(fit(" Document authority", width), width))
-		} else if index == 1 && height > 1 {
-			plain = m.styles.separator.Render(strings.Repeat("─", width))
-		} else {
-			plain = pad(fit(plain, width), width)
-		}
-		lines[index] = plain
+	if layout.showSize {
+		fixed += 2 + 9
 	}
-	if len(lines) > height {
-		lines = lines[:height]
+	if layout.showModified {
+		fixed += 2 + 16
 	}
-	for len(lines) < height {
-		lines = append(lines, strings.Repeat(" ", width))
+	layout.document = max(width-fixed, 1)
+	return layout
+}
+
+func (l tableLayout) render(prefix, document, kind, match, size, modified string) string {
+	var line strings.Builder
+	line.WriteString(fit(prefix, 3))
+	line.WriteString(pad(document, l.document))
+	if l.showKind {
+		line.WriteString("  ")
+		line.WriteString(pad(kind, 4))
 	}
-	return strings.Join(lines, "\n")
+	if l.showMatch {
+		line.WriteString("  ")
+		line.WriteString(pad(match, 7))
+	}
+	if l.showSize {
+		line.WriteString("  ")
+		line.WriteString(padLeft(size, 9))
+	}
+	if l.showModified {
+		line.WriteString("  ")
+		line.WriteString(pad(modified, 16))
+	}
+	return pad(line.String(), l.width)
+}
+
+func (m Model) columnHeading(label string, field sortField) string {
+	if m.sortField != field {
+		return label
+	}
+	if m.sortDesc {
+		return label + "↓"
+	}
+	return label + "↑"
+}
+
+func (m Model) sortSummary() string {
+	label := "name"
+	switch m.sortField {
+	case sortByRelevance:
+		label = "relevance"
+	case sortByKind:
+		label = "type"
+	case sortBySize:
+		label = "size"
+	case sortByModified:
+		label = "modified"
+	case sortByName:
+	}
+	if m.sortDesc {
+		return label + "↓"
+	}
+	return label + "↑"
 }
 
 func (m Model) renderExpandedDetail(height int) string {
@@ -278,7 +303,7 @@ func (m Model) expandedDetailLines(width int) []string {
 
 	node := selected.node
 	fields := make([]string, 0, 10)
-	if node.Kind == "file" {
+	if node.Kind == nodeKindFile {
 		fields = append(fields,
 			" Version: "+node.CurrentVersionID,
 			" SHA-256: "+node.BlobHash,
@@ -291,7 +316,7 @@ func (m Model) expandedDetailLines(width int) []string {
 		fmt.Sprintf(" Revision: %d", node.Revision),
 		" Modified: "+node.ModifiedAt,
 	)
-	if node.Kind == "file" {
+	if node.Kind == nodeKindFile {
 		fields = append(fields, fmt.Sprintf(" Size: %s (%d bytes)", formatBytes(node.Size), node.Size))
 		if node.MimeType != "" {
 			fields = append(fields, " Media type: "+quoted(node.MimeType))
@@ -325,7 +350,7 @@ func (m Model) renderFooter() string {
 	}
 	hints := []hint{{text: "↑/↓ move", priority: 100}}
 	if selected, ok := m.selected(); ok {
-		if selected.node.Kind == "dir" {
+		if selected.node.Kind == nodeKindDir {
 			hints = append(hints, hint{text: "enter open", priority: 80})
 		} else {
 			hints = append(hints, hint{text: "enter inspect", priority: 85})
@@ -337,6 +362,8 @@ func (m Model) renderFooter() string {
 	}
 	hints = append(hints,
 		hint{text: "/ search", priority: 90},
+		hint{text: "s sort", priority: 85},
+		hint{text: "v reverse", priority: 25},
 		hint{text: "r refresh", priority: 20},
 		hint{text: "? help", priority: 70},
 		hint{text: "q quit", priority: 60},
@@ -432,6 +459,8 @@ func (m Model) renderHelp(background string) string {
 		"Enter/i        Inspect complete document authority",
 		"Esc/←/h        Return to the previous view",
 		"/              Search names and extracted text",
+		"s              Cycle the sort column",
+		"v              Reverse the sort direction",
 		"r              Refresh the current view",
 		"?              Open this help",
 		"q              Quit",
@@ -455,7 +484,7 @@ func (m Model) renderHelp(background string) string {
 
 func formatBytes(value int64) string {
 	if value == 0 {
-		return "-"
+		return "0 B"
 	}
 	const unit = 1024
 	if value < unit {
@@ -467,6 +496,14 @@ func formatBytes(value int64) string {
 		exponent++
 	}
 	return fmt.Sprintf("%.1f %cB", float64(value)/float64(divisor), "KMGTPE"[exponent])
+}
+
+func formatModified(value string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return value
+	}
+	return parsed.Format("2006-01-02 15:04")
 }
 
 func quoted(value string) string {
@@ -500,6 +537,11 @@ func joinSides(left, right string, width int) string {
 func pad(value string, width int) string {
 	value = fit(value, width)
 	return value + strings.Repeat(" ", max(width-lipgloss.Width(value), 0))
+}
+
+func padLeft(value string, width int) string {
+	value = fit(value, width)
+	return strings.Repeat(" ", max(width-lipgloss.Width(value), 0)) + value
 }
 
 func (m Model) overlayModal(background, modal string) string {


### PR DESCRIPTION
A real Dropbox-sized collection exposed the wrong default: Docbank devoted nearly half of a wide terminal to authority metadata while the document list omitted file size and modification time. Those identities matter, but they are inspection details—not the primary browsing surface.

This makes the normal TUI a full-width analytical table. At ordinary widths it shows document, type, size, and modified time; wider search views also show whether a match came from the name or extracted content. Narrow terminals progressively drop secondary columns so names keep the available space.

Sorting follows the interaction already established in Msgvault: `s` cycles document, size, and modified time; `v` reverses direction; and the active sortable header carries an arrow. Type remains visible context rather than an unnecessary sort stop. Directories remain grouped ahead of files, the selected stable node stays selected while rows reorder or refresh, and search still begins in relevance order until the user explicitly chooses a column.

Complete node, version, and SHA-256 authority remains available through `i` or Enter on a file, now as a dedicated wrapped and scrollable view rather than permanent screen furniture. The TUI remains read-only and daemon-backed.