### PR TITLE
Browse audited history in the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Four commitments:
   per-node history, independent chain/protected-byte verification, exact-prefix
   checks against externally recorded evidence, and backup/restore fidelity
 - FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
-- A read-only daemon-backed TUI for virtual-tree browsing, search, and stable
-  document/version identity inspection
+- A read-only daemon-backed TUI for analytical tree browsing, search, stable
+  document/version identity inspection, and permanent audited-history timelines
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule
 - Whole-vault integrity verification

--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"sync"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
 	doctui "go.kenn.io/docbank/internal/tui"
 )
@@ -19,6 +23,7 @@ Navigation:
   Up/Down or j/k       Move between documents
   Enter or Right       Open a directory
   Enter on a file or i Inspect complete document authority
+  a                    Browse permanent audited history
   Left or Backspace    Return to the parent directory
   /                    Search names and extracted text
   s                    Cycle the sort column
@@ -35,7 +40,9 @@ mutations, storage maintenance, backup, and permanent-audit enrollment.`,
 		if err != nil {
 			return err
 		}
-		model, err := doctui.New(cmd.Context(), c)
+		backend := &tuiDaemonBackend{ensure: client.Ensure, initial: c}
+		defer func() { _ = backend.Close() }()
+		model, err := doctui.New(cmd.Context(), backend)
 		if err != nil {
 			return err
 		}
@@ -44,6 +51,104 @@ mutations, storage maintenance, backup, and permanent-audit enrollment.`,
 		}
 		return nil
 	},
+}
+
+func (b *tuiDaemonBackend) Close() error {
+	b.mu.Lock()
+	c := b.initial
+	b.initial = nil
+	b.mu.Unlock()
+	if c != nil {
+		return c.Close()
+	}
+	return nil
+}
+
+type tuiClientFactory func(context.Context) (*client.Client, error)
+
+// tuiDaemonBackend reacquires the daemon around each bounded interaction. A
+// TUI can remain open longer than the configured daemon idle timeout, and a
+// proven client intentionally refuses to reconnect its pinned socket to a
+// replacement process.
+type tuiDaemonBackend struct {
+	mu      sync.Mutex
+	ensure  tuiClientFactory
+	initial *client.Client
+}
+
+func (b *tuiDaemonBackend) acquire(ctx context.Context) (*client.Client, error) {
+	b.mu.Lock()
+	if b.initial != nil {
+		c := b.initial
+		b.initial = nil
+		b.mu.Unlock()
+		return c, nil
+	}
+	b.mu.Unlock()
+	return b.ensure(ctx)
+}
+
+func withTUIClient[T any](
+	ctx context.Context, backend *tuiDaemonBackend,
+	request func(*client.Client) (T, error),
+) (T, error) {
+	var zero T
+	for attempt := range 2 {
+		c, err := backend.acquire(ctx)
+		if err != nil {
+			return zero, err
+		}
+		result, requestErr := request(c)
+		_ = c.Close()
+		if requestErr == nil {
+			return result, nil
+		}
+		if _, ok := client.ProblemCode(requestErr); ok ||
+			errors.Is(requestErr, context.Canceled) ||
+			errors.Is(requestErr, context.DeadlineExceeded) {
+			return zero, requestErr
+		}
+		if attempt == 1 {
+			return zero, fmt.Errorf("reconnecting to docbank daemon: %w", requestErr)
+		}
+	}
+	return zero, errors.New("reconnecting to docbank daemon failed")
+}
+
+func (b *tuiDaemonBackend) Stat(ctx context.Context, path string) (api.Node, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) (api.Node, error) {
+		return c.Stat(ctx, path)
+	})
+}
+
+func (b *tuiDaemonBackend) Node(ctx context.Context, nodeID int64) (api.Node, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) (api.Node, error) {
+		return c.Node(ctx, nodeID)
+	})
+}
+
+func (b *tuiDaemonBackend) ChildrenPage(
+	ctx context.Context, nodeID int64, limit, offset int,
+) (api.NodePage, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) (api.NodePage, error) {
+		return c.ChildrenPage(ctx, nodeID, limit, offset)
+	})
+}
+
+func (b *tuiDaemonBackend) Search(
+	ctx context.Context, query string, limit int,
+) (api.SearchReport, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) (api.SearchReport, error) {
+		return c.Search(ctx, query, limit)
+	})
+}
+
+func (b *tuiDaemonBackend) AuditHistory(
+	ctx context.Context, path string, nodeID int64, limit int, cursor string,
+) (api.AuditEventPage, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) (api.AuditEventPage, error) {
+		return c.AuditHistory(ctx, path, nodeID, limit, cursor)
+	})
 }
 
 func init() {

--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -96,6 +96,12 @@ func withTUIClient[T any](
 	for attempt := range 2 {
 		c, err := backend.acquire(ctx)
 		if err != nil {
+			if attempt == 0 &&
+				errors.Is(err, client.ErrTransientDaemonAcquisition) &&
+				!errors.Is(err, context.Canceled) &&
+				!errors.Is(err, context.DeadlineExceeded) {
+				continue
+			}
 			return zero, err
 		}
 		result, requestErr := request(c)

--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -103,7 +103,7 @@ func withTUIClient[T any](
 		if requestErr == nil {
 			return result, nil
 		}
-		if _, ok := client.ProblemCode(requestErr); ok ||
+		if !client.IsTransportError(requestErr) ||
 			errors.Is(requestErr, context.Canceled) ||
 			errors.Is(requestErr, context.DeadlineExceeded) {
 			return zero, requestErr

--- a/cmd/docbank/tui_test.go
+++ b/cmd/docbank/tui_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -86,5 +88,57 @@ func TestTUIBackendDoesNotRetryMalformedDaemonResponses(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decoding GET /api/v1/nodes/42 response")
 	assert.NotContains(t, err.Error(), "reconnecting")
+	assert.Equal(t, int32(1), acquires.Load())
+}
+
+func TestTUIBackendRetriesInterruptedDaemonAcquisition(t *testing.T) {
+	live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(api.Node{
+			ID: 1, Kind: "dir", Path: "/", Revision: 1,
+		}))
+	}))
+	t.Cleanup(live.Close)
+
+	var acquires atomic.Int32
+	backend := &tuiDaemonBackend{ensure: func(context.Context) (*client.Client, error) {
+		if acquires.Add(1) == 1 {
+			return nil, fmt.Errorf(
+				"ownership proof raced daemon exit: %w",
+				client.ErrTransientDaemonAcquisition,
+			)
+		}
+		return client.New(live.URL, ""), nil
+	}}
+	node, err := backend.Stat(t.Context(), "/")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), node.ID)
+	assert.Equal(t, int32(2), acquires.Load())
+}
+
+func TestTUIBackendDoesNotRetryDeterministicAcquisitionFailure(t *testing.T) {
+	deterministic := errors.New("config.toml has an unknown key")
+	var acquires atomic.Int32
+	backend := &tuiDaemonBackend{ensure: func(context.Context) (*client.Client, error) {
+		acquires.Add(1)
+		return nil, deterministic
+	}}
+	_, err := backend.Stat(t.Context(), "/")
+	require.ErrorIs(t, err, deterministic)
+	assert.Equal(t, int32(1), acquires.Load())
+}
+
+func TestTUIBackendDoesNotRetryCanceledAcquisition(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	var acquires atomic.Int32
+	backend := &tuiDaemonBackend{ensure: func(context.Context) (*client.Client, error) {
+		acquires.Add(1)
+		return nil, fmt.Errorf(
+			"%w: %w", client.ErrTransientDaemonAcquisition, context.Canceled,
+		)
+	}}
+	_, err := backend.Stat(ctx, "/")
+	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, int32(1), acquires.Load())
 }

--- a/cmd/docbank/tui_test.go
+++ b/cmd/docbank/tui_test.go
@@ -68,3 +68,23 @@ func TestTUIBackendDoesNotRetryDaemonProblemResponses(t *testing.T) {
 	require.ErrorIs(t, err, store.ErrNotFound)
 	assert.Equal(t, int32(1), acquires.Load())
 }
+
+func TestTUIBackendDoesNotRetryMalformedDaemonResponses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte("{"))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	var acquires atomic.Int32
+	backend := &tuiDaemonBackend{ensure: func(context.Context) (*client.Client, error) {
+		acquires.Add(1)
+		return client.New(server.URL, ""), nil
+	}}
+	_, err := backend.Node(t.Context(), 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding GET /api/v1/nodes/42 response")
+	assert.NotContains(t, err.Error(), "reconnecting")
+	assert.Equal(t, int32(1), acquires.Load())
+}

--- a/cmd/docbank/tui_test.go
+++ b/cmd/docbank/tui_test.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/store"
 )
 
 func TestTUIHelpDefinesReadOnlyInteractiveBoundary(t *testing.T) {
@@ -14,4 +23,48 @@ func TestTUIHelpDefinesReadOnlyInteractiveBoundary(t *testing.T) {
 	assert.Contains(t, out, "authenticated daemon API")
 	assert.Contains(t, out, "initial TUI is deliberately read-only")
 	assert.Contains(t, out, "/                    Search names and extracted text")
+	assert.Contains(t, out, "a                    Browse permanent audited history")
+}
+
+func TestTUIBackendReacquiresAfterPinnedDaemonConnectionCloses(t *testing.T) {
+	live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(api.Node{
+			ID: 1, Kind: "dir", Path: "/", Revision: 1,
+		}))
+	}))
+	t.Cleanup(live.Close)
+
+	var reacquires atomic.Int32
+	backend := &tuiDaemonBackend{
+		initial: client.New("http://127.0.0.1:1", ""),
+		ensure: func(context.Context) (*client.Client, error) {
+			reacquires.Add(1)
+			return client.New(live.URL, ""), nil
+		},
+	}
+	node, err := backend.Stat(t.Context(), "/")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), node.ID)
+	assert.Equal(t, int32(1), reacquires.Load())
+}
+
+func TestTUIBackendDoesNotRetryDaemonProblemResponses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		assert.NoError(t, json.NewEncoder(w).Encode(api.NewError(
+			http.StatusNotFound, "not_found", "synthetic node is absent",
+		)))
+	}))
+	t.Cleanup(server.Close)
+
+	var acquires atomic.Int32
+	backend := &tuiDaemonBackend{ensure: func(context.Context) (*client.Client, error) {
+		acquires.Add(1)
+		return client.New(server.URL, ""), nil
+	}}
+	_, err := backend.Node(t.Context(), 42)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	assert.Equal(t, int32(1), acquires.Load())
 }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,7 +15,7 @@ Every documentation page is also published as raw Markdown at the same path with
 - [Importing Documents](https://docbank.ai/usage/importing.md): Bulk import semantics — recursion, idempotency, collision suffixing, and failure handling.
 - [Organizing & Tagging](https://docbank.ai/usage/organizing.md): Browsing, moving, renaming, and tagging in the virtual tree.
 - [Searching](https://docbank.ai/usage/searching.md): Ranked, prefix-matching search over document names and verified text content.
-- [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse the virtual tree, search document names and extracted text, and inspect stable document identity from a daemon-backed TUI.
+- [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse and sort documents, search names and extracted text, inspect stable identity, and read permanent audited history from a daemon-backed TUI.
 
 ## Protect & Operate
 - [Vault Lifecycle](https://docbank.ai/usage/lifecycle.md): Operate a docbank vault safely from first import through maintenance, upgrades, snapshots, and recovery.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,8 +79,9 @@ docbank tui
 ```
 
 Use the arrow keys or `j`/`k` to select a document, Enter to open a directory,
-and `/` to search names and extracted text. The detail pane keeps the selected
-node, revision, current version, and SHA-256 identity visible. See the
+and `/` to search names and extracted text. Press `i` for complete document
+authority or `a` for the selected node's permanent audited-history timeline.
+See the
 [interactive terminal browser](usage/tui.md) guide for the complete key map.
 
 !!! info "Release availability"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only tree/search/detail TUI implemented; web portal designed |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history TUI implemented; web portal designed |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -141,10 +141,10 @@ Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 
 The focused TUI now has a read-only first slice for virtual-tree navigation,
-name and extracted-content search, and stable document/version/hash detail.
+name and extracted-content search, stable document/version/hash detail, and a
+compact node-focused audited-history timeline with complete event inspection.
 Later slices add ingest and job progress, metadata/evidence,
-move/trash/restore, storage and backup state, plus a compact
-tree/history/detail audit browser. Rich document comparison belongs in
+move/trash/restore, and storage and backup state. Rich document comparison belongs in
 external tools or the web portal. Neither client has privileged operations —
 anything either does, the API can do.
 

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -19,7 +19,9 @@ docbank tui
 The TUI is a read-only view of the same authenticated daemon API used by the
 ordinary CLI. It never opens SQLite or the blob store and cannot bypass the
 vault's exclusive owner. Starting it reuses or starts the daemon in the normal
-way.
+way. A TUI session may outlive the background daemon's idle window, so each
+bounded interaction rediscovers or restarts a compatible daemon before issuing
+its request; leaving the terminal open does not pin an otherwise idle process.
 
 The main view is a full-width document table. At ordinary terminal widths it
 shows each document's name, type, size, and UTC modification time; search results

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive terminal browser
-description: Browse the virtual tree, search document names and extracted text, and inspect stable document identity from a daemon-backed TUI.
+description: Browse and sort documents, search names and extracted text, inspect stable identity, and read permanent audited history from a daemon-backed TUI.
 ---
 
 # Interactive terminal browser
@@ -31,11 +31,20 @@ document's complete stable node selector, path, revision, modification time,
 and—when it is a file—its immutable version, SHA-256 identity, exact size, and
 media type. Long authority values wrap rather than truncate.
 
+Press <kbd>a</kbd> on any selected node to open its permanent audited history.
+The timeline is newest first and shows when each event was recorded, what
+happened, and the primary path, version, or attached-metadata change. Press
+<kbd>Enter</kbd> to inspect the complete immutable event ID, operation and scope
+IDs, revisions, path states, version identities, and typed tag or provenance
+details. Nodes outside an audit scope are identified plainly rather than shown
+with an empty or invented timeline.
+
 | Key | Action |
 |-----|--------|
 | <kbd>↑</kbd>/<kbd>k</kbd>, <kbd>↓</kbd>/<kbd>j</kbd> | Move between documents |
 | <kbd>Enter</kbd> or <kbd>→</kbd> | Open the selected directory |
 | <kbd>Enter</kbd> on a file, or <kbd>i</kbd> | Inspect complete document authority |
+| <kbd>a</kbd> | Browse the selected node's permanent audited history |
 | <kbd>←</kbd>, <kbd>Backspace</kbd>, or <kbd>Esc</kbd> | Return to the parent directory or leave search results |
 | <kbd>/</kbd> | Search live names and extracted text |
 | <kbd>s</kbd> | Cycle the sort column: name, size, and modification time |
@@ -43,6 +52,11 @@ media type. Long authority values wrap rather than truncate.
 | <kbd>r</kbd> | Refresh the current directory or search |
 | <kbd>?</kbd> | Show keyboard help |
 | <kbd>q</kbd> or <kbd>Ctrl-C</kbd> | Quit |
+
+Within audited history, <kbd>n</kbd>/<kbd>→</kbd> loads the next older page and
+<kbd>p</kbd>/<kbd>←</kbd> returns to a cached newer page. Escape returns to the
+same directory or search result and selected document. Each page is bounded to
+100 events; the heading reports its position in the complete history.
 
 Search has the same semantics as `docbank search`: name matches precede
 content-only matches, and content is available only for supported documents
@@ -53,7 +67,7 @@ returns to relevance. The first interface loads at most 1,000
 directory entries or search hits and says when more exist; use the CLI or HTTP
 pagination for exhaustive automation.
 
-Mutations, permanent-audit enrollment and history, backup, and storage
-maintenance deliberately remain outside this first interface. Use their
+Mutations, permanent-audit enrollment and independent verification, backup,
+and storage maintenance remain outside this interface. Use their
 ordinary CLI commands or authenticated HTTP endpoints. Later TUI work can add
 those workflows without creating a privileged path into the vault.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -153,6 +153,18 @@ func New(baseURL, apiKey string) *Client {
 	return &Client{base: baseURL, key: apiKey, hc: &http.Client{Timeout: 0}}
 }
 
+// Close releases idle transport connections owned by this client. It is most
+// useful to long-running callers that periodically reacquire a daemon client
+// after idle shutdown or process replacement.
+func (c *Client) Close() error {
+	if c != nil && c.hc != nil && c.hc.Transport != nil {
+		if transport, ok := c.hc.Transport.(interface{ CloseIdleConnections() }); ok {
+			transport.CloseIdleConnections()
+		}
+	}
+	return nil
+}
+
 // codeToTypedErr preserves server problem codes that have a stable local
 // sentinel for callers using errors.Is.
 var codeToTypedErr = map[string]error{

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -57,6 +57,19 @@ func responseStatus(err error) (int, bool) {
 	return response.status, true
 }
 
+type transportError struct{ err error }
+
+func (e *transportError) Error() string { return e.err.Error() }
+func (e *transportError) Unwrap() error { return e.err }
+
+// IsTransportError reports whether an HTTP request failed before the daemon
+// returned a response. Long-lived clients may use this distinction to
+// reconnect without retrying malformed or contract-invalid responses.
+func IsTransportError(err error) bool {
+	var transport *transportError
+	return errors.As(err, &transport)
+}
+
 type problemError struct {
 	code string
 	err  error
@@ -247,7 +260,9 @@ func (c *Client) doWithHeaders(
 	}
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("calling daemon (%s %s): %w", method, path, err)
+		return nil, &transportError{err: fmt.Errorf(
+			"calling daemon (%s %s): %w", method, path, err,
+		)}
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -32,6 +32,11 @@ const (
 	daemonStartProblemVaultLocked = "vault_locked"
 )
 
+// ErrTransientDaemonAcquisition marks a daemon that disappeared after
+// discovery but before its ownership-proven client was ready. A caller may
+// safely repeat the complete discovery/start/proof sequence.
+var ErrTransientDaemonAcquisition = errors.New("daemon acquisition was interrupted")
+
 type daemonStartError struct {
 	message string
 	cause   error
@@ -183,7 +188,11 @@ func Ensure(ctx context.Context) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newProvenClientFor(ctx, res.Record)
+	c, err := newProvenClientFor(ctx, res.Record)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrTransientDaemonAcquisition, err)
+	}
+	return c, nil
 }
 
 // EnsureDaemon converges the vault on exactly one version- and

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"fmt"
 	"path"
 	"sort"
 	"strings"
@@ -14,22 +15,27 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/store"
 )
 
 const (
 	maxBrowserItems = 1000
 	maxSearchItems  = 1000
+	maxHistoryItems = 100
 	nodeKindDir     = "dir"
 	nodeKindFile    = "file"
 )
 
-// Backend is the bounded read surface needed by the first TUI slice.
+// Backend is the bounded read surface needed by the TUI.
 // *client.Client satisfies it without exposing a direct vault path.
 type Backend interface {
 	Stat(ctx context.Context, path string) (api.Node, error)
 	Node(ctx context.Context, nodeID int64) (api.Node, error)
 	ChildrenPage(ctx context.Context, nodeID int64, limit, offset int) (api.NodePage, error)
 	Search(ctx context.Context, query string, limit int) (api.SearchReport, error)
+	AuditHistory(
+		ctx context.Context, path string, nodeID int64, limit int, cursor string,
+	) (api.AuditEventPage, error)
 }
 
 type viewMode uint8
@@ -92,13 +98,20 @@ type searchLoadedMsg struct {
 	err       error
 }
 
+type historyLoadedMsg struct {
+	requestID uint64
+	pageIndex int
+	page      api.AuditEventPage
+	err       error
+}
+
 type spinnerTickMsg struct{}
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
 const spinnerInterval = 80 * time.Millisecond
 
-// Model is a read-only virtual-tree and search browser. Update uses a value
+// Model is a read-only virtual-tree, search, and audited-history browser. Update uses a value
 // receiver because Bubble Tea treats models as immutable values; small helper
 // methods mutate only the copied value before it is returned.
 //
@@ -123,15 +136,23 @@ type Model struct {
 	searchQuery  string
 	searchReturn *location
 
-	requestID     uint64
-	loading       bool
-	err           error
-	quitting      bool
-	helpOpen      bool
-	detailOpen    bool
-	detailOffset  int
-	spinnerFrame  int
-	spinnerActive bool
+	requestID           uint64
+	loading             bool
+	err                 error
+	quitting            bool
+	helpOpen            bool
+	detailOpen          bool
+	detailOffset        int
+	historyOpen         bool
+	historyNode         row
+	historyPages        []api.AuditEventPage
+	historyPage         int
+	historyCursor       int
+	historyOffset       int
+	historyDetail       bool
+	historyDetailOffset int
+	spinnerFrame        int
+	spinnerActive       bool
 
 	width  int
 	height int
@@ -170,6 +191,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.searchInput.SetWidth(max(msg.Width-4, 1))
 		m.clampSelection()
 		m.clampDetailOffset()
+		m.clampHistorySelection()
+		m.clampHistoryDetailOffset()
 		return m, nil
 	case tea.BackgroundColorMsg:
 		m.styles = newStyles(msg.IsDark())
@@ -178,6 +201,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applyDirectory(msg)
 	case searchLoadedMsg:
 		return m.applySearch(msg)
+	case historyLoadedMsg:
+		return m.applyHistory(msg)
 	case spinnerTickMsg:
 		if !m.loading {
 			m.spinnerActive = false
@@ -189,6 +214,12 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if m.helpOpen {
 			m.helpOpen = false
 			return m, nil
+		}
+		if m.historyDetail {
+			return m.updateHistoryDetailKeys(msg)
+		}
+		if m.historyOpen {
+			return m.updateHistoryKeys(msg)
 		}
 		if m.detailOpen {
 			return m.updateDetailKeys(msg)
@@ -261,6 +292,25 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.detailOffset = 0
 		}
 		return m, nil
+	case "a":
+		selected, ok := m.selected()
+		if !ok {
+			return m, nil
+		}
+		m.historyOpen = true
+		m.historyNode = selected
+		m.historyPages = nil
+		m.historyPage = 0
+		m.historyCursor = 0
+		m.historyOffset = 0
+		m.historyDetail = false
+		m.historyDetailOffset = 0
+		m.loading = true
+		m.err = nil
+		m.requestID++
+		return m, tea.Batch(
+			m.startSpinner(), m.loadHistory(selected.node.ID, "", 0, m.requestID),
+		)
 	case "r":
 		if m.mode == modeSearch && m.searchQuery != "" {
 			m.loading = true
@@ -321,6 +371,93 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.stack = m.stack[:len(m.stack)-1]
 			return m, nil
 		}
+	}
+	return m, nil
+}
+
+func (m Model) updateHistoryKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "?":
+		m.helpOpen = true
+		return m, nil
+	case "esc", "backspace":
+		m.requestID++
+		m.closeHistory()
+		return m, nil
+	case "enter", "i":
+		if _, ok := m.selectedHistoryEvent(); ok {
+			m.historyDetail = true
+			m.historyDetailOffset = 0
+		}
+	case "up", "k":
+		m.moveHistoryCursor(-1)
+	case "down", "j":
+		m.moveHistoryCursor(1)
+	case "pgup":
+		m.moveHistoryCursor(-m.visibleHistoryRows())
+	case "pgdown":
+		m.moveHistoryCursor(m.visibleHistoryRows())
+	case "home", "g":
+		m.historyCursor, m.historyOffset = 0, 0
+	case "end", "G":
+		if page, ok := m.currentHistoryPage(); ok && len(page.Items) > 0 {
+			m.historyCursor = len(page.Items) - 1
+			m.clampHistorySelection()
+		}
+	case "n", "right", "l":
+		return m.openOlderHistoryPage()
+	case "p", "left", "h":
+		if m.historyPage > 0 {
+			m.historyPage--
+			m.historyCursor, m.historyOffset = 0, 0
+			m.err = nil
+		}
+	case "r":
+		m.historyPages = nil
+		m.historyPage = 0
+		m.historyCursor, m.historyOffset = 0, 0
+		m.loading = true
+		m.err = nil
+		m.requestID++
+		return m, tea.Batch(
+			m.startSpinner(), m.loadHistory(m.historyNode.node.ID, "", 0, m.requestID),
+		)
+	}
+	return m, nil
+}
+
+func (m Model) updateHistoryDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "?":
+		m.helpOpen = true
+		return m, nil
+	case "i", "enter", "esc", "left", "h", "backspace":
+		m.historyDetail = false
+		m.historyDetailOffset = 0
+	case "up", "k":
+		m.historyDetailOffset--
+		m.clampHistoryDetailOffset()
+	case "down", "j":
+		m.historyDetailOffset++
+		m.clampHistoryDetailOffset()
+	case "pgup":
+		m.historyDetailOffset -= m.historyViewportHeight()
+		m.clampHistoryDetailOffset()
+	case "pgdown":
+		m.historyDetailOffset += m.historyViewportHeight()
+		m.clampHistoryDetailOffset()
+	case "home", "g":
+		m.historyDetailOffset = 0
+	case "end", "G":
+		m.historyDetailOffset = max(
+			len(m.historyDetailLines(m.width))-m.historyViewportHeight(), 0,
+		)
 	}
 	return m, nil
 }
@@ -391,6 +528,18 @@ func (m Model) loadSearch(query string, requestID uint64) tea.Cmd {
 	return func() tea.Msg {
 		report, err := backend.Search(ctx, query, maxSearchItems)
 		return searchLoadedMsg{requestID: requestID, query: query, report: report, err: err}
+	}
+}
+
+func (m Model) loadHistory(
+	nodeID int64, cursor string, pageIndex int, requestID uint64,
+) tea.Cmd {
+	ctx, backend := m.ctx, m.backend
+	return func() tea.Msg {
+		page, err := backend.AuditHistory(ctx, "", nodeID, maxHistoryItems, cursor)
+		return historyLoadedMsg{
+			requestID: requestID, pageIndex: pageIndex, page: page, err: err,
+		}
 	}
 }
 
@@ -472,6 +621,129 @@ func (m Model) applySearch(msg searchLoadedMsg) (tea.Model, tea.Cmd) {
 	m.err = nil
 	m.clampSelection()
 	return m, nil
+}
+
+func (m Model) applyHistory(msg historyLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.requestID != m.requestID || !m.historyOpen {
+		return m, nil
+	}
+	m.loading = false
+	if msg.err != nil {
+		if errors.Is(msg.err, store.ErrAuditNotEnrolled) {
+			m.err = errors.New("this node is not protected by permanent audit history")
+		} else {
+			m.err = msg.err
+		}
+		return m, nil
+	}
+	if msg.pageIndex < len(m.historyPages) {
+		m.historyPages[msg.pageIndex] = msg.page
+	} else if msg.pageIndex == len(m.historyPages) {
+		m.historyPages = append(m.historyPages, msg.page)
+	} else {
+		m.err = errors.New("audit history returned an unexpected page")
+		return m, nil
+	}
+	m.historyPage = msg.pageIndex
+	m.historyNode.node = msg.page.Node
+	if msg.page.Path != "" {
+		m.historyNode.path = msg.page.Path
+	} else {
+		m.historyNode.path = fmt.Sprintf("id:%d in trash", msg.page.Node.ID)
+	}
+	m.historyCursor, m.historyOffset = 0, 0
+	m.err = nil
+	m.clampHistorySelection()
+	return m, nil
+}
+
+func (m Model) openOlderHistoryPage() (tea.Model, tea.Cmd) {
+	if m.loading {
+		return m, nil
+	}
+	if m.historyPage+1 < len(m.historyPages) {
+		m.historyPage++
+		m.historyCursor, m.historyOffset = 0, 0
+		m.err = nil
+		return m, nil
+	}
+	page, ok := m.currentHistoryPage()
+	if !ok || page.NextCursor == "" {
+		return m, nil
+	}
+	m.loading = true
+	m.err = nil
+	m.requestID++
+	return m, tea.Batch(
+		m.startSpinner(),
+		m.loadHistory(m.historyNode.node.ID, page.NextCursor, len(m.historyPages), m.requestID),
+	)
+}
+
+func (m *Model) closeHistory() {
+	m.historyOpen = false
+	m.historyNode = row{}
+	m.historyPages = nil
+	m.historyPage = 0
+	m.historyCursor, m.historyOffset = 0, 0
+	m.historyDetail = false
+	m.historyDetailOffset = 0
+	m.loading = false
+	m.err = nil
+}
+
+func (m Model) currentHistoryPage() (api.AuditEventPage, bool) {
+	if m.historyPage < 0 || m.historyPage >= len(m.historyPages) {
+		return api.AuditEventPage{}, false
+	}
+	return m.historyPages[m.historyPage], true
+}
+
+func (m Model) selectedHistoryEvent() (api.AuditEvent, bool) {
+	page, ok := m.currentHistoryPage()
+	if !ok || m.historyCursor < 0 || m.historyCursor >= len(page.Items) {
+		return api.AuditEvent{}, false
+	}
+	return page.Items[m.historyCursor], true
+}
+
+func (m *Model) moveHistoryCursor(delta int) {
+	page, ok := m.currentHistoryPage()
+	if !ok || len(page.Items) == 0 {
+		return
+	}
+	m.historyCursor = min(max(m.historyCursor+delta, 0), len(page.Items)-1)
+	m.clampHistorySelection()
+}
+
+func (m *Model) clampHistorySelection() {
+	page, ok := m.currentHistoryPage()
+	if !ok || len(page.Items) == 0 {
+		m.historyCursor, m.historyOffset = 0, 0
+		return
+	}
+	m.historyCursor = min(max(m.historyCursor, 0), len(page.Items)-1)
+	visible := m.visibleHistoryRows()
+	if m.historyCursor < m.historyOffset {
+		m.historyOffset = m.historyCursor
+	}
+	if m.historyCursor >= m.historyOffset+visible {
+		m.historyOffset = m.historyCursor - visible + 1
+	}
+	m.historyOffset = min(max(m.historyOffset, 0), max(len(page.Items)-visible, 0))
+}
+
+func (m Model) visibleHistoryRows() int {
+	return max(m.historyViewportHeight()-2, 1)
+}
+
+func (m Model) historyViewportHeight() int {
+	return max(m.height-3, 1)
+}
+
+func (m *Model) clampHistoryDetailOffset() {
+	maximum := max(len(m.historyDetailLines(m.width))-m.historyViewportHeight(), 0)
+	m.historyDetailOffset = min(max(m.historyDetailOffset, 0), maximum)
 }
 
 func (m Model) snapshot() location {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -147,6 +147,7 @@ type Model struct {
 	historyNode         row
 	historyPages        []api.AuditEventPage
 	historyPage         int
+	historyTotal        int
 	historyCursor       int
 	historyOffset       int
 	historyDetail       bool
@@ -301,6 +302,7 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.historyNode = selected
 		m.historyPages = nil
 		m.historyPage = 0
+		m.historyTotal = 0
 		m.historyCursor = 0
 		m.historyOffset = 0
 		m.historyDetail = false
@@ -426,6 +428,7 @@ func (m Model) updateHistoryKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.historyPages = nil
 		m.historyPage = 0
+		m.historyTotal = 0
 		m.historyCursor, m.historyOffset = 0, 0
 		m.loading = true
 		m.err = nil
@@ -659,6 +662,11 @@ func (m Model) applyHistory(msg historyLoadedMsg) (tea.Model, tea.Cmd) {
 	if msg.pageIndex < len(m.historyPages) {
 		m.historyPages[msg.pageIndex] = msg.page
 	} else if msg.pageIndex == len(m.historyPages) {
+		if msg.pageIndex == 0 {
+			m.historyTotal = msg.page.Total
+		} else {
+			msg.page.Total = m.historyTotal
+		}
 		m.historyPages = append(m.historyPages, msg.page)
 	} else {
 		m.err = errors.New("audit history returned an unexpected page")
@@ -705,6 +713,7 @@ func (m *Model) closeHistory() {
 	m.historyNode = row{}
 	m.historyPages = nil
 	m.historyPage = 0
+	m.historyTotal = 0
 	m.historyCursor, m.historyOffset = 0, 0
 	m.historyDetail = false
 	m.historyDetailOffset = 0

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -389,20 +389,27 @@ func (m Model) updateHistoryKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "enter", "i":
 		if _, ok := m.selectedHistoryEvent(); ok {
+			m.cancelPendingHistoryLoad()
 			m.historyDetail = true
 			m.historyDetailOffset = 0
 		}
 	case "up", "k":
+		m.cancelPendingHistoryLoad()
 		m.moveHistoryCursor(-1)
 	case "down", "j":
+		m.cancelPendingHistoryLoad()
 		m.moveHistoryCursor(1)
 	case "pgup":
+		m.cancelPendingHistoryLoad()
 		m.moveHistoryCursor(-m.visibleHistoryRows())
 	case "pgdown":
+		m.cancelPendingHistoryLoad()
 		m.moveHistoryCursor(m.visibleHistoryRows())
 	case "home", "g":
+		m.cancelPendingHistoryLoad()
 		m.historyCursor, m.historyOffset = 0, 0
 	case "end", "G":
+		m.cancelPendingHistoryLoad()
 		if page, ok := m.currentHistoryPage(); ok && len(page.Items) > 0 {
 			m.historyCursor = len(page.Items) - 1
 			m.clampHistorySelection()
@@ -410,6 +417,7 @@ func (m Model) updateHistoryKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "n", "right", "l":
 		return m.openOlderHistoryPage()
 	case "p", "left", "h":
+		m.cancelPendingHistoryLoad()
 		if m.historyPage > 0 {
 			m.historyPage--
 			m.historyCursor, m.historyOffset = 0, 0
@@ -427,6 +435,15 @@ func (m Model) updateHistoryKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		)
 	}
 	return m, nil
+}
+
+func (m *Model) cancelPendingHistoryLoad() {
+	if !m.loading {
+		return
+	}
+	m.requestID++
+	m.loading = false
+	m.err = nil
 }
 
 func (m Model) updateHistoryDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -441,6 +441,9 @@ func (m *Model) cancelPendingHistoryLoad() {
 	if !m.loading {
 		return
 	}
+	if _, ok := m.currentHistoryPage(); !ok {
+		return
+	}
 	m.requestID++
 	m.loading = false
 	m.err = nil

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -367,6 +367,78 @@ func TestClosingHistoryInvalidatesDelayedResponse(t *testing.T) {
 	assert.Empty(t, model.historyPages)
 }
 
+func TestNewerHistoryNavigationInvalidatesDelayedOlderPage(t *testing.T) {
+	backend := newFakeBackend()
+	first := backend.history[""]
+	first.NextCursor = "older"
+	first.Total = 4
+	backend.history[""] = first
+	older := first
+	older.Items = older.Items[:1]
+	older.Cursor = "older"
+	older.NextCursor = "oldest"
+	backend.history["older"] = older
+	oldest := older
+	oldest.Cursor = "oldest"
+	oldest.NextCursor = ""
+	backend.history["oldest"] = oldest
+
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+	model, cmd := updateModel(t, model, runeKey('a'))
+	model = runModelCommand(t, model, cmd)
+	model, cmd = updateModel(t, model, runeKey('n'))
+	model = runModelCommand(t, model, cmd)
+	require.Equal(t, 1, model.historyPage)
+
+	model, delayed := updateModel(t, model, runeKey('n'))
+	require.NotNil(t, delayed)
+	pendingRequestID := model.requestID
+	model, _ = updateModel(t, model, runeKey('p'))
+	assert.Equal(t, 0, model.historyPage)
+	assert.False(t, model.loading)
+	assert.Greater(t, model.requestID, pendingRequestID)
+
+	model = runModelCommand(t, model, delayed)
+	assert.Equal(t, 0, model.historyPage)
+	assert.Len(t, model.historyPages, 2)
+}
+
+func TestHistoryInspectionInvalidatesDelayedOlderPage(t *testing.T) {
+	backend := newFakeBackend()
+	first := backend.history[""]
+	first.NextCursor = "older"
+	first.Total = 3
+	backend.history[""] = first
+	backend.history["older"] = first
+
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+	model, cmd := updateModel(t, model, runeKey('a'))
+	model = runModelCommand(t, model, cmd)
+	selectedBefore, ok := model.selectedHistoryEvent()
+	require.True(t, ok)
+
+	model, delayed := updateModel(t, model, runeKey('n'))
+	require.NotNil(t, delayed)
+	pendingRequestID := model.requestID
+	model, _ = updateModel(t, model, key(tea.KeyEnter))
+	assert.True(t, model.historyDetail)
+	assert.False(t, model.loading)
+	assert.Greater(t, model.requestID, pendingRequestID)
+
+	model = runModelCommand(t, model, delayed)
+	selectedAfter, ok := model.selectedHistoryEvent()
+	require.True(t, ok)
+	assert.True(t, model.historyDetail)
+	assert.Equal(t, 0, model.historyPage)
+	assert.Equal(t, selectedBefore.ID, selectedAfter.ID)
+}
+
 func TestBackIgnoresDelayedDirectoryRefresh(t *testing.T) {
 	backend := newFakeBackend()
 	model, err := New(t.Context(), backend)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -348,6 +348,64 @@ func TestHistoryPaginatesOlderAndNewerWithoutLosingTreeState(t *testing.T) {
 	assert.Contains(t, model.render(), "node_path")
 }
 
+func TestHistoryPaginationKeepsInitialTimelineTotal(t *testing.T) {
+	backend := newFakeBackend()
+	first := backend.history[""]
+	first.NextCursor = "older"
+	first.Total = 3
+	backend.history[""] = first
+	older := first
+	older.Cursor = "older"
+	older.NextCursor = ""
+	older.Total = 4
+	older.Items = older.Items[:1]
+	backend.history["older"] = older
+
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.width, model.height = 100, 20
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+	model, cmd := updateModel(t, model, runeKey('a'))
+	model = runModelCommand(t, model, cmd)
+	assert.Contains(t, model.render(), "of 3")
+
+	model, cmd = updateModel(t, model, runeKey('n'))
+	model = runModelCommand(t, model, cmd)
+	require.Equal(t, 1, model.historyPage)
+	assert.Equal(t, 3, model.historyPages[1].Total)
+	assert.Contains(t, model.render(), "of 3")
+	assert.NotContains(t, model.render(), "of 4")
+}
+
+func TestOlderHistoryLoadErrorRemainsVisibleWithCachedEvents(t *testing.T) {
+	backend := newFakeBackend()
+	first := backend.history[""]
+	first.NextCursor = "older"
+	backend.history[""] = first
+
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.width, model.height = 100, 20
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+	model, cmd := updateModel(t, model, runeKey('a'))
+	model = runModelCommand(t, model, cmd)
+	require.Len(t, model.historyPages, 1)
+
+	applied, _ := model.applyHistory(historyLoadedMsg{
+		requestID: model.requestID,
+		pageIndex: 1,
+		err:       errors.New("synthetic older-page failure"),
+	})
+	appliedModel, ok := applied.(Model)
+	require.True(t, ok)
+	model = appliedModel
+	rendered := model.render()
+	assert.Contains(t, rendered, "synthetic older-page failure")
+	assert.Contains(t, rendered, "node_path")
+}
+
 func TestClosingHistoryInvalidatesDelayedResponse(t *testing.T) {
 	backend := newFakeBackend()
 	model, err := New(t.Context(), backend)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -439,6 +439,32 @@ func TestHistoryInspectionInvalidatesDelayedOlderPage(t *testing.T) {
 	assert.Equal(t, selectedBefore.ID, selectedAfter.ID)
 }
 
+func TestInitialHistoryLoadSurvivesNavigationKeys(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+
+	model, delayed := updateModel(t, model, runeKey('a'))
+	require.NotNil(t, delayed)
+	pendingRequestID := model.requestID
+	for _, pressed := range []tea.KeyPressMsg{
+		key(tea.KeyUp), runeKey('p'), key(tea.KeyHome),
+	} {
+		model, _ = updateModel(t, model, pressed)
+	}
+	assert.True(t, model.loading)
+	assert.Equal(t, pendingRequestID, model.requestID)
+
+	model = runModelCommand(t, model, delayed)
+	assert.False(t, model.loading)
+	require.Len(t, model.historyPages, 1)
+	event, ok := model.selectedHistoryEvent()
+	require.True(t, ok)
+	assert.Equal(t, "node_path", event.Kind)
+}
+
 func TestBackIgnoresDelayedDirectoryRefresh(t *testing.T) {
 	backend := newFakeBackend()
 	model, err := New(t.Context(), backend)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -13,17 +13,22 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/store"
 )
 
 type fakeBackend struct {
-	nodes      map[string]api.Node
-	children   map[int64]api.NodePage
-	search     api.SearchReport
-	err        error
-	childLimit int
-	searchMax  int
-	nodeIDs    []int64
-	statPaths  []string
+	nodes          map[string]api.Node
+	children       map[int64]api.NodePage
+	search         api.SearchReport
+	err            error
+	childLimit     int
+	searchMax      int
+	nodeIDs        []int64
+	statPaths      []string
+	history        map[string]api.AuditEventPage
+	historyErr     error
+	historyIDs     []int64
+	historyCursors []string
 }
 
 func newFakeBackend() *fakeBackend {
@@ -42,7 +47,9 @@ func newFakeBackend() *fakeBackend {
 		ModifiedAt: "2026-07-22T13:00:00Z",
 	}
 	return &fakeBackend{
-		nodes: map[string]api.Node{"/": root, "/docs": docs},
+		nodes: map[string]api.Node{
+			"/": root, "/docs": docs, "/README.txt": readme, "/docs/report.txt": report,
+		},
 		children: map[int64]api.NodePage{
 			1: {Items: []api.Node{docs, readme}, Total: 2, Limit: maxBrowserItems},
 			2: {Items: []api.Node{report}, Total: 1, Limit: maxBrowserItems},
@@ -50,6 +57,33 @@ func newFakeBackend() *fakeBackend {
 		search: api.SearchReport{
 			Hits:  []api.SearchHit{{Node: report, Path: "/docs/report.txt", Match: "content"}},
 			Limit: maxSearchItems,
+		},
+		history: map[string]api.AuditEventPage{
+			"": {
+				Node: readme, Path: "/README.txt", Total: 2, Limit: maxHistoryItems,
+				Items: []api.AuditEvent{
+					{
+						ID:                strings.Repeat("c", 64),
+						OperationID:       "33333333-3333-4333-8333-333333333333",
+						OperationSequence: 4, Ordinal: 0, NodeID: readme.ID,
+						Kind: "node_path", ScopeID: "44444444-4444-4444-8444-444444444444",
+						RecordedAt: "2026-07-22T14:00:00Z", Origin: "cli",
+						PriorNodeRevision: 1, ResultingNodeRevision: 2,
+						OldPath: &api.AuditPathState{Path: "/notes.txt", State: "live"},
+						NewPath: &api.AuditPathState{Path: "/README.txt", State: "live"},
+					},
+					{
+						ID:                strings.Repeat("d", 64),
+						OperationID:       "55555555-5555-4555-8555-555555555555",
+						OperationSequence: 3, Ordinal: 0, NodeID: readme.ID,
+						Kind: "content_replace", ScopeID: "44444444-4444-4444-8444-444444444444",
+						RecordedAt: "2026-07-22T13:00:00Z", Origin: "agent",
+						PriorNodeRevision: 1, ResultingNodeRevision: 2,
+						PriorCurrentVersionID:     new("66666666-6666-4666-8666-666666666666"),
+						ResultingCurrentVersionID: new("77777777-7777-4777-8777-777777777777"),
+					},
+				},
+			},
 		},
 	}
 }
@@ -97,6 +131,23 @@ func (f *fakeBackend) Search(
 		return api.SearchReport{}, f.err
 	}
 	return f.search, nil
+}
+
+func (f *fakeBackend) AuditHistory(
+	_ context.Context, _ string, nodeID int64, limit int, cursor string,
+) (api.AuditEventPage, error) {
+	f.historyIDs = append(f.historyIDs, nodeID)
+	f.historyCursors = append(f.historyCursors, cursor)
+	if f.historyErr != nil {
+		return api.AuditEventPage{}, f.historyErr
+	}
+	page, ok := f.history[cursor]
+	if !ok {
+		return api.AuditEventPage{}, errors.New("history page not found")
+	}
+	page.Limit = limit
+	page.Cursor = cursor
+	return page, nil
 }
 
 func TestModelNavigatesSearchesAndReturnsToTree(t *testing.T) {
@@ -157,6 +208,163 @@ func TestModelPreservesViewStateAcrossNavigation(t *testing.T) {
 	assert.Equal(t, modeBrowse, model.mode)
 	assert.Equal(t, 1, model.cursor)
 	assert.Equal(t, "README.txt", model.rows[model.cursor].node.Name)
+}
+
+func TestModelBrowsesAuditedHistoryAndReturnsToTree(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.width, model.height = 120, 24
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+
+	model, cmd := updateModel(t, model, runeKey('a'))
+	require.NotNil(t, cmd)
+	assert.True(t, model.historyOpen)
+	model = runModelCommand(t, model, cmd)
+	require.Equal(t, []int64{3}, backend.historyIDs)
+	require.Len(t, model.historyPages, 1)
+	assert.Contains(t, model.render(), "Audit history")
+	assert.Contains(t, model.render(), "node_path")
+	assert.Contains(t, model.render(), `"/notes.txt" → "/README.txt"`)
+
+	model, cmd = updateModel(t, model, key(tea.KeyEnter))
+	require.Nil(t, cmd)
+	assert.True(t, model.historyDetail)
+	detail := model.render()
+	assert.Contains(t, detail, strings.Repeat("c", 64))
+	assert.Contains(t, detail, "33333333-3333-4333-8333-333333333333")
+	assert.Contains(t, detail, "44444444-4444-4444-8444-444444444444")
+
+	model, _ = updateModel(t, model, key(tea.KeyEscape))
+	assert.False(t, model.historyDetail)
+	model, _ = updateModel(t, model, key(tea.KeyEscape))
+	assert.False(t, model.historyOpen)
+	selected, ok := model.selected()
+	require.True(t, ok)
+	assert.Equal(t, int64(3), selected.node.ID)
+}
+
+func TestHistoryDetailShowsCompleteAttachmentTransition(t *testing.T) {
+	backend := newFakeBackend()
+	page := backend.history[""]
+	page.Items = []api.AuditEvent{{
+		ID:                strings.Repeat("f", 64),
+		OperationID:       "99999999-9999-4999-8999-999999999999",
+		OperationSequence: 5, Ordinal: 1, NodeID: page.Node.ID,
+		Kind: "tag_rename", ScopeID: "44444444-4444-4444-8444-444444444444",
+		RecordedAt: "2026-07-22T15:00:00Z", Origin: "agent",
+		PriorNodeRevision: 2, ResultingNodeRevision: 2,
+		Attachment: &api.AuditAttachmentChange{
+			Kind: "tag_definition",
+			Identity: api.AuditAttachmentIdentity{
+				TagID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+			},
+			Before: &api.AuditAttachmentState{
+				TagID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", TagName: "draft",
+			},
+			After: &api.AuditAttachmentState{
+				TagID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", TagName: "final",
+			},
+		},
+	}}
+	backend.history[""] = page
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.width, model.height = 100, 24
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+	model, cmd := updateModel(t, model, runeKey('a'))
+	model = runModelCommand(t, model, cmd)
+	model, _ = updateModel(t, model, key(tea.KeyEnter))
+
+	detail := model.render()
+	assert.Contains(t, detail, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+	assert.Contains(t, detail, `Tag name: "draft"`)
+	assert.Contains(t, detail, `Tag name: "final"`)
+}
+
+func TestHistoryPathsRemainTerminalSafe(t *testing.T) {
+	event := api.AuditEvent{
+		OldPath: &api.AuditPathState{Path: "/old\nname", State: "live"},
+		NewPath: &api.AuditPathState{Path: "/new\x1b[31m", State: "live"},
+	}
+	summary := historyEventSummary(event)
+	assert.NotContains(t, summary, "\n")
+	assert.NotContains(t, summary, "\x1b")
+	assert.Contains(t, summary, `\n`)
+	assert.Contains(t, summary, `\x1b`)
+}
+
+func TestModelReportsUnauditedNodePlainly(t *testing.T) {
+	backend := newFakeBackend()
+	backend.historyErr = store.ErrAuditNotEnrolled
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.width, model.height = 100, 20
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+
+	model, cmd := updateModel(t, model, runeKey('a'))
+	model = runModelCommand(t, model, cmd)
+	assert.True(t, model.historyOpen)
+	assert.Contains(t, model.render(), "not protected by permanent audit history")
+}
+
+func TestHistoryPaginatesOlderAndNewerWithoutLosingTreeState(t *testing.T) {
+	backend := newFakeBackend()
+	first := backend.history[""]
+	first.NextCursor = "older"
+	first.Total = 3
+	backend.history[""] = first
+	backend.history["older"] = api.AuditEventPage{
+		Node: first.Node, Path: first.Path, Total: 3, Limit: maxHistoryItems,
+		Items: []api.AuditEvent{{
+			ID:                strings.Repeat("e", 64),
+			OperationID:       "88888888-8888-4888-8888-888888888888",
+			OperationSequence: 1, Ordinal: 0, NodeID: first.Node.ID,
+			Kind: "audit_enroll", ScopeID: "44444444-4444-4444-8444-444444444444",
+			RecordedAt: "2026-07-22T12:00:00Z", Origin: "cli",
+		}},
+	}
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.width, model.height = 100, 20
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+	model, cmd := updateModel(t, model, runeKey('a'))
+	model = runModelCommand(t, model, cmd)
+
+	model, cmd = updateModel(t, model, runeKey('n'))
+	require.NotNil(t, cmd)
+	model = runModelCommand(t, model, cmd)
+	assert.Equal(t, 1, model.historyPage)
+	assert.Equal(t, []string{"", "older"}, backend.historyCursors)
+	assert.Contains(t, model.render(), "audit_enroll")
+
+	model, cmd = updateModel(t, model, runeKey('p'))
+	require.Nil(t, cmd)
+	assert.Equal(t, 0, model.historyPage)
+	assert.Contains(t, model.render(), "node_path")
+}
+
+func TestClosingHistoryInvalidatesDelayedResponse(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.selectNode(3)
+
+	model, delayed := updateModel(t, model, runeKey('a'))
+	require.NotNil(t, delayed)
+	pendingRequestID := model.requestID
+	model, _ = updateModel(t, model, key(tea.KeyEscape))
+	assert.False(t, model.historyOpen)
+	assert.Greater(t, model.requestID, pendingRequestID)
+
+	model = runModelCommand(t, model, delayed)
+	assert.False(t, model.historyOpen)
+	assert.Empty(t, model.historyPages)
 }
 
 func TestBackIgnoresDelayedDirectoryRefresh(t *testing.T) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -116,7 +116,7 @@ func (m Model) renderHistoryLocation() string {
 		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
 	}
 	if m.err != nil {
-		right = quoted(m.err.Error())
+		right = "history unavailable"
 	}
 	return m.styles.stats.Render(joinSides(left, right, m.width))
 }
@@ -243,10 +243,16 @@ func (m Model) renderHistoryList(height int) string {
 		message := " No recorded events"
 		if m.loading {
 			message = " Loading permanent history..."
-		} else if m.err != nil {
-			message = " " + quoted(m.err.Error())
 		}
-		lines = append(lines, m.styles.muted.Render(pad(fit(message, m.width), m.width)))
+		messages := []string{message}
+		if !m.loading && m.err != nil {
+			messages = strings.Split(ansi.Hardwrap(
+				" "+quoted(m.err.Error()), max(m.width, 1), false,
+			), "\n")
+		}
+		for _, line := range messages[:min(len(messages), visible)] {
+			lines = append(lines, m.styles.muted.Render(pad(fit(line, m.width), m.width)))
+		}
 	}
 	if ok {
 		end := min(m.historyOffset+visible, len(page.Items))

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -9,6 +9,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"go.kenn.io/docbank/internal/api"
 )
 
 type styles struct {
@@ -67,9 +69,11 @@ func (m Model) render() string {
 	if m.width <= 0 || m.height <= 0 {
 		return "Loading Docbank..."
 	}
-	lines := []string{
-		m.renderTitleBar(),
-		m.renderLocation(),
+	lines := []string{m.renderTitleBar()}
+	if m.historyOpen {
+		lines = append(lines, m.renderHistoryLocation())
+	} else {
+		lines = append(lines, m.renderLocation())
 	}
 	if m.searching {
 		lines = append(lines, fit(m.searchInput.View(), m.width))
@@ -77,8 +81,14 @@ func (m Model) render() string {
 
 	bodyHeight := max(m.height-len(lines)-1, 1)
 	body := m.renderBody(bodyHeight)
+	if m.historyOpen {
+		body = m.renderHistoryList(bodyHeight)
+	}
 	if m.detailOpen {
 		body = m.renderExpandedDetail(bodyHeight)
+	}
+	if m.historyDetail {
+		body = m.renderHistoryDetail(bodyHeight)
 	}
 	lines = append(lines, body, m.renderFooter())
 	content := strings.Join(lines, "\n")
@@ -86,6 +96,29 @@ func (m Model) render() string {
 		return m.renderHelp(content)
 	}
 	return content
+}
+
+func (m Model) renderHistoryLocation() string {
+	left := " Audit history · " + quoted(m.historyNode.path)
+	right := ""
+	if page, ok := m.currentHistoryPage(); ok {
+		start := 1
+		for index := range m.historyPage {
+			start += len(m.historyPages[index].Items)
+		}
+		end := start + len(page.Items) - 1
+		if len(page.Items) == 0 {
+			start, end = 0, 0
+		}
+		right = fmt.Sprintf("events %d-%d of %d", start, end, page.Total)
+	}
+	if m.loading {
+		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
+	}
+	if m.err != nil {
+		right = quoted(m.err.Error())
+	}
+	return m.styles.stats.Render(joinSides(left, right, m.width))
 }
 
 func (m Model) renderTitleBar() string {
@@ -196,6 +229,214 @@ func (m Model) renderList(width, height int) string {
 		lines = append(lines, strings.Repeat(" ", width))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderHistoryList(height int) string {
+	lines := make([]string, 0, height)
+	lines = append(lines, m.renderHistoryHeading())
+	if height > 1 {
+		lines = append(lines, m.styles.separator.Render(strings.Repeat("─", m.width)))
+	}
+	visible := max(height-2, 0)
+	page, ok := m.currentHistoryPage()
+	if (!ok || len(page.Items) == 0) && visible > 0 {
+		message := " No recorded events"
+		if m.loading {
+			message = " Loading permanent history..."
+		} else if m.err != nil {
+			message = " " + quoted(m.err.Error())
+		}
+		lines = append(lines, m.styles.muted.Render(pad(fit(message, m.width), m.width)))
+	}
+	if ok {
+		end := min(m.historyOffset+visible, len(page.Items))
+		for index := m.historyOffset; index < end; index++ {
+			line := m.renderHistoryRow(page.Items[index])
+			if index == m.historyCursor {
+				line = "▶" + line[1:]
+			}
+			line = pad(fit(line, m.width), m.width)
+			if index == m.historyCursor {
+				lines = append(lines, m.styles.cursor.Render(line))
+			} else if index%2 == 1 {
+				lines = append(lines, m.styles.alternate.Render(line))
+			} else {
+				lines = append(lines, line)
+			}
+		}
+	}
+	for len(lines) < height {
+		lines = append(lines, strings.Repeat(" ", m.width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderHistoryHeading() string {
+	if m.width >= 72 {
+		return m.styles.heading.Render(pad("   RECORDED            EVENT                   CHANGE", m.width))
+	}
+	return m.styles.heading.Render(pad("   EVENT                   CHANGE", m.width))
+}
+
+func (m Model) renderHistoryRow(event api.AuditEvent) string {
+	prefix := "   "
+	kind := pad(quoted(event.Kind), 22)
+	change := historyEventSummary(event)
+	if m.width >= 72 {
+		return prefix + pad(formatHistoryTime(event.RecordedAt), 17) + "  " + kind + "  " + change
+	}
+	return prefix + kind + "  " + change
+}
+
+func historyEventSummary(event api.AuditEvent) string {
+	if event.OldPath != nil && event.NewPath != nil {
+		return quoted(event.OldPath.Path) + " → " + quoted(event.NewPath.Path)
+	}
+	if event.PriorCurrentVersionID != nil || event.ResultingCurrentVersionID != nil {
+		return "version " + shortAuditID(event.PriorCurrentVersionID) + " → " +
+			shortAuditID(event.ResultingCurrentVersionID)
+	}
+	if event.Attachment != nil {
+		identity := event.Attachment.Identity.TagID
+		if identity == "" {
+			identity = event.Attachment.Identity.ProvenanceID
+		}
+		return quoted(event.Attachment.Kind) + " " + shortString(identity, 12)
+	}
+	return fmt.Sprintf("revision %d → %d", event.PriorNodeRevision, event.ResultingNodeRevision)
+}
+
+func (m Model) renderHistoryDetail(height int) string {
+	lines := m.historyDetailLines(m.width)
+	maximum := max(len(lines)-height, 0)
+	offset := min(m.historyDetailOffset, maximum)
+	end := min(offset+height, len(lines))
+	visible := append([]string(nil), lines[offset:end]...)
+	for len(visible) < height {
+		visible = append(visible, strings.Repeat(" ", m.width))
+	}
+	return strings.Join(visible, "\n")
+}
+
+func (m Model) historyDetailLines(width int) []string {
+	heading := m.styles.heading.Render(pad(fit(" Complete audited event", width), width))
+	separator := m.styles.separator.Render(strings.Repeat("─", max(width, 0)))
+	lines := []string{heading, separator}
+	event, ok := m.selectedHistoryEvent()
+	if !ok {
+		return append(lines, m.styles.muted.Render(" Nothing selected"))
+	}
+	fields := []string{
+		" Event: " + event.ID,
+		" Operation: " + event.OperationID,
+		fmt.Sprintf(" Sequence: %d.%d", event.OperationSequence, event.Ordinal),
+		" Scope: " + event.ScopeID,
+		fmt.Sprintf(" Node: id:%d", event.NodeID),
+		" Kind: " + event.Kind,
+		" Recorded: " + event.RecordedAt,
+		" Origin: " + quoted(event.Origin),
+		fmt.Sprintf(" Revision: %d -> %d", event.PriorNodeRevision, event.ResultingNodeRevision),
+	}
+	if event.AgentLabel != nil {
+		fields = append(fields, " Agent: "+quoted(*event.AgentLabel))
+	}
+	if event.OldPath != nil {
+		fields = append(fields, " Before path: "+auditPathDetail(*event.OldPath))
+	}
+	if event.NewPath != nil {
+		fields = append(fields, " After path: "+auditPathDetail(*event.NewPath))
+	}
+	if event.PriorCurrentVersionID != nil {
+		fields = append(fields, " Before version: "+*event.PriorCurrentVersionID)
+	}
+	if event.ResultingCurrentVersionID != nil {
+		fields = append(fields, " After version: "+*event.ResultingCurrentVersionID)
+	}
+	if event.SourceVersionID != nil {
+		fields = append(fields, " Source version: "+*event.SourceVersionID)
+	}
+	if event.TargetNodeID != nil {
+		fields = append(fields, fmt.Sprintf(" Target node: id:%d", *event.TargetNodeID))
+	}
+	if event.BaselineDigest != nil {
+		fields = append(fields, " Baseline: "+*event.BaselineDigest)
+	}
+	fields = append(fields, auditAttachmentDetail(event.Attachment)...)
+	for _, field := range fields {
+		wrapped := ansi.Hardwrap(field, max(width, 1), false)
+		for line := range strings.SplitSeq(wrapped, "\n") {
+			lines = append(lines, pad(line, width))
+		}
+	}
+	return lines
+}
+
+func auditPathDetail(state api.AuditPathState) string {
+	return quoted(state.Path) + " (" + state.State + ")"
+}
+
+func auditAttachmentDetail(change *api.AuditAttachmentChange) []string {
+	if change == nil {
+		return nil
+	}
+	lines := []string{" Attachment: " + change.Kind}
+	if change.Identity.TagID != "" {
+		lines = append(lines, " Attachment tag: "+change.Identity.TagID)
+	}
+	if change.Identity.NodeID != 0 {
+		lines = append(lines, fmt.Sprintf(" Attachment node: id:%d", change.Identity.NodeID))
+	}
+	if change.Identity.ProvenanceID != "" {
+		lines = append(lines, " Attachment provenance: "+change.Identity.ProvenanceID)
+	}
+	lines = append(lines, auditAttachmentStateDetail("Before attachment", change.Before)...)
+	lines = append(lines, auditAttachmentStateDetail("After attachment", change.After)...)
+	return lines
+}
+
+func auditAttachmentStateDetail(label string, state *api.AuditAttachmentState) []string {
+	if state == nil {
+		return []string{" " + label + ": absent"}
+	}
+	lines := []string{" " + label + ": present"}
+	if state.TagName != "" {
+		lines = append(lines, "   Tag name: "+quoted(state.TagName))
+	}
+	if state.IngestID != "" {
+		lines = append(lines, "   Ingest: "+state.IngestID)
+	}
+	if state.OriginalPath != nil {
+		lines = append(lines, "   Original reference: "+quoted(*state.OriginalPath))
+	}
+	if state.OriginalMTime != nil {
+		lines = append(lines, "   Original modified: "+*state.OriginalMTime)
+	}
+	if state.Supersedes != nil {
+		lines = append(lines, "   Supersedes: "+*state.Supersedes)
+	}
+	return lines
+}
+
+func shortAuditID(value *string) string {
+	if value == nil {
+		return "none"
+	}
+	return shortString(*value, 8)
+}
+
+func shortString(value string, length int) string {
+	if len(value) <= length {
+		return value
+	}
+	return value[:length]
+}
+
+func formatHistoryTime(value string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return value
+	}
+	return parsed.UTC().Format("2006-01-02 15:04Z")
 }
 
 type tableLayout struct {
@@ -361,6 +602,9 @@ func (m *Model) clampDetailOffset() {
 }
 
 func (m Model) renderFooter() string {
+	if m.historyOpen {
+		return m.renderHistoryFooter()
+	}
 	if m.detailOpen {
 		return m.renderDetailFooter()
 	}
@@ -371,7 +615,10 @@ func (m Model) renderFooter() string {
 		} else {
 			hints = append(hints, hint{text: "enter inspect", priority: 85})
 		}
-		hints = append(hints, hint{text: "i inspect", priority: 65})
+		hints = append(hints,
+			hint{text: "i inspect", priority: 65},
+			hint{text: "a history", priority: 68},
+		)
 	}
 	if len(m.stack) > 0 || m.mode == modeSearch {
 		hints = append(hints, hint{text: "← back", priority: 75})
@@ -399,6 +646,41 @@ func (m Model) renderFooter() string {
 	available := max(m.width-lipgloss.Width(position)-1, 0)
 	keys := fitHints(hints, available)
 	return m.styles.footer.Render(joinSides(keys, position, m.width))
+}
+
+func (m Model) renderHistoryFooter() string {
+	if m.historyDetail {
+		lines := m.historyDetailLines(m.width)
+		viewport := m.historyViewportHeight()
+		position := ""
+		if len(lines) > viewport {
+			last := min(m.historyDetailOffset+viewport, len(lines))
+			position = fmt.Sprintf(" %d-%d/%d ", m.historyDetailOffset+1, last, len(lines))
+		}
+		hints := []hint{
+			{text: "↑/↓ scroll", priority: 100},
+			{text: "esc close", priority: 90},
+			{text: "? help", priority: 70},
+			{text: "q quit", priority: 60},
+		}
+		available := max(m.width-lipgloss.Width(position)-1, 0)
+		return m.styles.footer.Render(joinSides(fitHints(hints, available), position, m.width))
+	}
+	hints := []hint{
+		{text: "↑/↓ move", priority: 100},
+		{text: "enter inspect", priority: 90},
+		{text: "p newer", priority: 55},
+		{text: "n older", priority: 60},
+		{text: "esc back", priority: 85},
+		{text: "? help", priority: 70},
+		{text: "q quit", priority: 50},
+	}
+	position := ""
+	if page, ok := m.currentHistoryPage(); ok && len(page.Items) > 0 {
+		position = fmt.Sprintf(" %d/%d ", m.historyCursor+1, len(page.Items))
+	}
+	available := max(m.width-lipgloss.Width(position)-1, 0)
+	return m.styles.footer.Render(joinSides(fitHints(hints, available), position, m.width))
 }
 
 func (m Model) renderDetailFooter() string {
@@ -465,7 +747,58 @@ func (m Model) spinnerIndicator() string {
 }
 
 func (m Model) renderHelp(background string) string {
-	lines := []string{
+	lines := m.helpLines()
+	contentWidth := min(max(m.width-8, 1), 54)
+	maxLines := max(m.height-4, 1)
+	if len(lines) > maxLines {
+		if maxLines >= 2 {
+			lines = append(lines[:maxLines-1], lines[len(lines)-1])
+		} else {
+			lines = lines[:maxLines]
+		}
+	}
+	for index := range lines {
+		lines[index] = fit(lines[index], contentWidth)
+	}
+	if len(lines) > 0 {
+		lines[0] = m.styles.modalTitle.Render(lines[0])
+	}
+	modal := m.styles.modal.Render(strings.Join(lines, "\n"))
+	return m.overlayModal(background, modal)
+}
+
+func (m Model) helpLines() []string {
+	if m.historyDetail {
+		return []string{
+			"Audited event inspection",
+			"",
+			"↑/k, ↓/j       Scroll one line",
+			"PgUp/PgDn      Scroll one visible page",
+			"Home/End       Jump to first or last line",
+			"Enter/i/Esc    Return to the event timeline",
+			"q              Quit",
+			"",
+			"Press any key to close",
+		}
+	}
+	if m.historyOpen {
+		return []string{
+			"Audited history shortcuts",
+			"",
+			"↑/k, ↓/j       Move through recorded events",
+			"PgUp/PgDn      Move one visible page",
+			"Home/End       Jump to first or last event",
+			"Enter/i        Inspect the complete event",
+			"n/→            Load the next older page",
+			"p/←            Return to a newer page",
+			"r              Reload from the newest event",
+			"Esc            Return to documents",
+			"q              Quit",
+			"",
+			"Press any key to close",
+		}
+	}
+	return []string{
 		"Keyboard shortcuts",
 		"",
 		"↑/k, ↓/j       Move through documents",
@@ -473,6 +806,7 @@ func (m Model) renderHelp(background string) string {
 		"Home/End       Jump to first or last",
 		"Enter/→/l      Open a directory",
 		"Enter/i        Inspect complete document authority",
+		"a              Browse permanent audited history",
 		"Esc/←/h        Return to the previous view",
 		"/              Search names and extracted text",
 		"s              Cycle the sort column",
@@ -483,19 +817,6 @@ func (m Model) renderHelp(background string) string {
 		"",
 		"Press any key to close",
 	}
-	contentWidth := min(max(m.width-8, 1), 54)
-	maxLines := max(m.height-4, 1)
-	if len(lines) > maxLines {
-		lines = lines[:maxLines]
-	}
-	for index := range lines {
-		lines[index] = fit(lines[index], contentWidth)
-	}
-	if len(lines) > 0 {
-		lines[0] = m.styles.modalTitle.Render(lines[0])
-	}
-	modal := m.styles.modal.Render(strings.Join(lines, "\n"))
-	return m.overlayModal(background, modal)
 }
 
 func formatBytes(value int64) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -239,20 +239,23 @@ func (m Model) renderHistoryList(height int) string {
 	}
 	visible := max(height-2, 0)
 	page, ok := m.currentHistoryPage()
-	if (!ok || len(page.Items) == 0) && visible > 0 {
+	if !m.loading && m.err != nil && visible > 0 {
+		messages := strings.Split(ansi.Hardwrap(
+			" "+quoted(m.err.Error()), max(m.width, 1), false,
+		), "\n")
+		for _, line := range messages[:min(len(messages), visible)] {
+			lines = append(lines, m.styles.muted.Render(pad(fit(line, m.width), m.width)))
+		}
+		visible -= min(len(messages), visible)
+	} else if (!ok || len(page.Items) == 0) && visible > 0 {
 		message := " No recorded events"
 		if m.loading {
 			message = " Loading permanent history..."
 		}
-		messages := []string{message}
-		if !m.loading && m.err != nil {
-			messages = strings.Split(ansi.Hardwrap(
-				" "+quoted(m.err.Error()), max(m.width, 1), false,
-			), "\n")
-		}
-		for _, line := range messages[:min(len(messages), visible)] {
+		for _, line := range []string{message} {
 			lines = append(lines, m.styles.muted.Render(pad(fit(line, m.width), m.width)))
 		}
+		visible--
 	}
 	if ok {
 		end := min(m.historyOffset+visible, len(page.Items))


### PR DESCRIPTION
Docbank can already retain and independently validate permanent history, but the interactive browser showed only a document's current authority. Investigating how a protected document reached its present state still meant leaving the TUI and translating the selected row into a separate CLI command.

This adds a node-focused audited-history view. Select a document or directory and press `a` to see its newest recorded events, including the primary path, version, tag, or provenance change. Enter opens the complete event: immutable event and operation IDs, scope, revisions, live or trash path states, version identities, and typed attached-metadata details. A node outside permanent audit protection says so plainly.

History is fetched by stable node ID through the authenticated daemon API. Pages are bounded to 100 events; `n` loads older records and `p` returns through already cached newer pages. Escape restores the exact directory or search result and selected document, and late daemon responses cannot reopen a view the operator already left.

A TUI may stay open longer than either an HTTP keep-alive connection or the background daemon's idle window. It now reacquires a compatible daemon around each bounded interaction. If its ownership-proven socket dies during a request, the TUI rediscovers the vault owner and retries once; typed API responses are never retried. This keeps an active terminal usable without weakening the rule that a proven client cannot silently reconnect to whichever process later owns the port, and without pinning an otherwise idle daemon merely because the TUI is open.

The interface remains read-only. Enrollment, independent verification, mutations, backup, and storage maintenance keep their existing explicit CLI and HTTP workflows. The documentation continues to mark the TUI as newer than v0.10.1 until a release containing it is tagged.