### PR TITLE
Publish complete release history and web UI guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,17 +82,20 @@ Instructions for autonomous coding agents working in this repository.
   a general API or CLI command; reserve it for tests, migrations, or a
   purpose-built emergency recovery workflow with a demonstrated need.
 - Documentation is not the implementation tracker. User- and agent-facing
-  pages describe shipped capabilities and current limitations. Architecture
-  and internal pages may preserve durable future design under explicit
-  `!!! info "Planned"` admonitions, but must not carry task breakdowns,
-  sequencing, ownership, or completion criteria. `docs/roadmap.md` is the one
-  high-level public product-status view; kata is the sole source of truth for
-  actionable work and its status.
-- Documentation is published only after releases, not continuously from
-  `main`. Keep the public docs internally consistent as a snapshot of a
-  published release: describe available behavior directly, and do not add
-  publish-from-main fences, "next release" notes, source-build availability
-  comments, or other feature-timing annotations.
+  pages describe the behavior included in their target release snapshot and
+  its current limitations. Architecture and internal pages may preserve
+  durable future design under explicit `!!! info "Planned"` admonitions, but
+  must not carry task breakdowns, sequencing, ownership, or completion
+  criteria. `docs/roadmap.md` is the one high-level public product-status view;
+  kata is the sole source of truth for actionable work and its status.
+- Documentation is published only from release tags, never continuously from
+  `main`. Treat public docs on `main` as the candidate documentation for the
+  next release, not as a live view of the latest published binary. Once a
+  capability merges, describe it directly in present tense so the source tree
+  is coherent when the next tag publishes it; do not add "next release",
+  source-build availability, or other feature-timing annotations. Release
+  preparation must verify that every documented capability is present in the
+  tag; defer documentation for anything that will not ship.
 - v0.9.0 is the first released storage compatibility boundary. Preserve vaults
   created by every supported public release across upgrades. When a released
   SQLite layout is incompatible with the current schema, export its logical

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@ Instructions for autonomous coding agents working in this repository.
   sequencing, ownership, or completion criteria. `docs/roadmap.md` is the one
   high-level public product-status view; kata is the sole source of truth for
   actionable work and its status.
+- Documentation is published only after releases, not continuously from
+  `main`. Keep the public docs internally consistent as a snapshot of a
+  published release: describe available behavior directly, and do not add
+  publish-from-main fences, "next release" notes, source-build availability
+  comments, or other feature-timing annotations.
 - v0.9.0 is the first released storage compatibility boundary. Preserve vaults
   created by every supported public release across upgrades. When a released
   SQLite layout is incompatible with the current schema, export its logical

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,14 +88,16 @@ Instructions for autonomous coding agents working in this repository.
   must not carry task breakdowns, sequencing, ownership, or completion
   criteria. `docs/roadmap.md` is the one high-level public product-status view;
   kata is the sole source of truth for actionable work and its status.
-- Documentation is published only from release tags, never continuously from
-  `main`. Treat public docs on `main` as the candidate documentation for the
-  next release, not as a live view of the latest published binary. Once a
-  capability merges, describe it directly in present tense so the source tree
-  is coherent when the next tag publishes it; do not add "next release",
-  source-build availability, or other feature-timing annotations. Release
-  preparation must verify that every documented capability is present in the
-  tag; defer documentation for anything that will not ship.
+- Documentation is published only from release tags. There is no rendered
+  preview, deployment, or other public documentation build of `main`; the
+  release tag is the first publication boundary. Treat public-doc sources on
+  `main` as the candidate documentation for the next release, not as a live
+  view of the latest published binary or a separately supported publication.
+  Once a capability merges, describe it directly in present tense so the
+  source tree is coherent when the next tag publishes it; do not add "next
+  release", source-build availability, or other feature-timing annotations.
+  Release preparation must verify that every documented capability is present
+  in the tag; defer documentation for anything that will not ship.
 - v0.9.0 is the first released storage compatibility boundary. Preserve vaults
   created by every supported public release across upgrades. When a released
   SQLite layout is incompatible with the current schema, export its logical

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -41,9 +41,8 @@ placement. `DOCBANK_HOME=/path/to/another/vault docbank info --json` selects
 and confirms another independently owned archive without changing a global
 profile or opening its database directly.
 
-In source builds newer than v0.10.0, a workflow that depends on watched
-ingestion can inspect the daemon's effective configuration and runner state
-rather than assuming the local file is active:
+A workflow that depends on watched ingestion can inspect the daemon's effective
+configuration and runner state rather than assuming the local file is active:
 
 ```bash
 docbank watch list --json
@@ -220,11 +219,6 @@ the complete stream verifies and is atomically published:
 ```bash
 docbank get id:42 ./document.bin --json
 ```
-
-!!! info "Release availability"
-
-    `docbank get` is newer than v0.10.0. Build from source to use it until the
-    next release is tagged.
 
 Independent HTTP clients should retrieve file bytes by ID, not path:
 

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -1267,9 +1267,9 @@ out of ordinary agent guidance.
 
 ## JSONL, backup, and restore
 
-Deterministic JSONL is the portable metadata authority. Before the first public
-release, the one `docbank-metadata` format version 1 and backup manifest
-identifier `docbank-metadata-jsonl-v1` will directly adopt the complete model.
+Deterministic JSONL is the portable metadata authority. The
+`docbank-metadata` format version 1 and backup manifest identifier
+`docbank-metadata-jsonl-v1` contain the complete model.
 A **zero-scope v1** stream is valid: it preserves the stable vault ID,
 content versions and current-version references, and stable tag, ingest, and
 provenance identities, but contains no audit genesis, allocation lineage,

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -121,9 +121,9 @@ inside the snapshot.
 The current JSONL authority round-trips the node allocator high-water mark,
 blobs, tree and trash state, content versions and current pointers, ingests,
 provenance, tags, and extraction records. Its relational validation runs before
-a restored database is published. Enrollment is limited to a vault's first
-audit scope; the audited-history contract, including its backup and
-restore behavior, is described in
+a restored database is published. Every disjoint permanent audit scope, its
+membership, and its independent chain are preserved; the complete
+audited-history backup and restore contract is described in
 [Audited History](audited-history.md).
 
 ## Boundary with packed storage

--- a/docs/architecture/editing-and-versions.md
+++ b/docs/architecture/editing-and-versions.md
@@ -36,11 +36,6 @@ also creates no version.
 
 ## Read surfaces
 
-!!! info "Release availability"
-
-    The explicit `versions list|show|cat` command vocabulary is newer than
-    v0.7.0. Build from source to use it until the next release is published.
-
 ```bash
 docbank versions list /taxes/2025/return.pdf
 docbank versions show <version-id> --json

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -55,7 +55,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / validate metadata and re-hash all blobs | Implemented |
 | `GET /storage` · `POST /storage/pack` · `POST /storage/repack` | inspect usage / pack loose blobs / compact sparse packs | Implemented |
 | `GET /jobs` | inspect daemon-owned background tasks and terminal failures | Implemented |
-| `GET /watches` | inspect effective watched-inbox configuration and runner state | Implemented after v0.10.0 |
+| `GET /watches` | inspect effective watched-inbox configuration and runner state | Implemented |
 | `POST /backup/init` · `POST /backup/snapshots` · `POST /backup/snapshots/stream` · `GET /backup/snapshots` | initialize a repository / create with JSON or streamed progress / list snapshots | Implemented |
 
 Root-level, outside `/api/v1` and auth-exempt: `GET /health`, `GET

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,146 +5,213 @@ description: Release history.
 
 # Changelog
 
-docbank is pre-1.0; interfaces and storage migrations may still evolve.
+This page records user-visible changes in every tagged release. Dates come
+from the annotated release tags. Docbank remains pre-1.0, so public interfaces
+may still evolve, but vaults created by v0.9.0 and later are within the
+[storage compatibility boundary](architecture/storage.md#released-upgrades).
 
-## Unreleased
+## [v0.11.0](https://github.com/kenn-io/docbank/tree/v0.11.0) — 2026-07-23
 
-- Standalone vaults compress worthwhile new loose content with zstd while
-  preserving logical hashes, verified reads, backup portability, and explicit
-  packing. Embedded applications can opt into the same policy.
-- The embedded Go API adds immutable create-if-absent writes, verified physical
-  repair that preserves logical references, physical representation receipts,
-  and loose packing-backlog inspection.
-- Search covers live document names and verified UTF-8 plain text, Markdown,
-  JSON, and JSONL content. Name matches keep their established ranking and
-  precede content-only matches, while `docbank jobs` exposes the bounded
-  asynchronous extraction worker.
-- Daemon-owned watched inboxes import stable regular files without touching
-  their sources, preserve portable source identity, and append later changes
-  as versions of the same Docbank node; their lifecycle and failures are
-  visible through `docbank jobs`.
-- The store extends audited recording to filesystem ingest, content
-  reversion, in-scope moves and renames, reversible trash and restore, and
-  tag creation, assignment, rename, and deletion; backup restore and JSONL import
-  independently replay and validate that history.
-- Enrollment of a vault's first audit scope is available through
-  `docbank audit enable` and `docbank audit status`, with a preview-first,
-  token-acknowledged workflow; additional scopes remain unavailable.
-- Bounded per-node audit history exposes canonical path, content, tag, and
-  provenance changes, while `docbank audit verify` independently replays the
-  authority, checks protected bytes, and proves current chains extend a
-  separately recorded evidence report.
-- Legacy browsing, trash, and virtual-tree mutation commands expose typed JSON,
-  and CLI processes use stable exit codes for usage, missing objects, stale
-  state, busy resources, and integrity findings.
+### New features
 
-## v0.5.0 (2026-07-17)
+- Open and browse a vault in a local web application.
+- Explore documents and audited history in a read-only analytical TUI.
+- Schedule bounded automatic vault packing.
+- Manage multiple permanent audit scopes.
+- Inspect nodes, create virtual directories, and download documents from the
+  CLI.
+- View document provenance through the CLI and embedded Go API.
+- Search by directory, tag, media type, and modification time.
+- Access physical write receipts through the embedded Go API.
 
-- The embedded Go API is exposed directly from the module root.
-- Verification classifies unavailable embedded content separately, and
-  embedded content opens report missing or physically size-mismatched bytes
-  as `ErrContentUnavailable` without conflating metadata lookup failures.
-- The store records audited content replacements and inherited audited node
-  creation.
+### Improvements
 
-## v0.4.0 (2026-07-17)
+- Reset vaults fail closed when storage safety cannot be confirmed.
+- Record shared tag changes across all applicable audit scopes.
+- Report effective watched-inbox status.
+- Delay watched-file ingestion until files are old enough to be stable.
+- Publish verified downloads atomically without leaving partial files.
+- Report maintenance lock contention immediately.
+- Display concise human-readable timestamps.
 
-- Embedded Go applications can page immutable content history with `Versions`
-  and open any historical version through the verified read contract with
-  `OpenVersionContent`.
-- The initial audit enrollment authority persists for durable integrity
-  verification, with portable JSON representations of audit authority data.
-- Provenance is stabilized as audit authority with canonical record shapes
-  and collection ordering.
+## [v0.10.1](https://github.com/kenn-io/docbank/tree/v0.10.1) — 2026-07-22
 
-## v0.3.0 (2026-07-16)
+### New features
+
+- Browse permanent audit history across an entire scope.
+- Reorganize multiple documents atomically, so every move succeeds or none do.
+- View the currently selected vault with `docbank info`.
+
+### Improvements
+
+- Show physical byte totals in the loose-blob packing backlog.
+- Preserve operator-approved Markdown in annotated release tags and make
+  release creation an explicit, human-reviewed workflow.
+
+## [v0.10.0](https://github.com/kenn-io/docbank/tree/v0.10.0) — 2026-07-21
+
+### New features
+
+- Add bounded embedded APIs for document ingestion, retrieval, traversal, and
+  maintenance.
+- Add immutable embedded content-addressed storage APIs.
+- Accept stable node IDs as reusable CLI selectors across document operations.
+
+### Improvements
+
+- Compress worthwhile new loose blobs while preserving their logical SHA-256
+  identities and verified-read contract.
+- Bound `tree` output and report truncation so large vaults remain manageable
+  for people and agents.
+
+## [v0.9.0](https://github.com/kenn-io/docbank/tree/v0.9.0) — 2026-07-19
+
+### New features
+
+- Search inside verified UTF-8 plain text, Markdown, JSON, and JSONL content,
+  not only document names and metadata.
+
+### Project changes
+
+- License Docbank under the Apache License 2.0.
+- Establish v0.9.0 as the first released storage-compatibility boundary.
+
+## [v0.8.1](https://github.com/kenn-io/docbank/tree/v0.8.1) — 2026-07-19
+
+- Publish a patch-level conformance-bootstrap release from the same source as
+  v0.8.0. This gave updater checks two releases that both implement
+  `docbank version`, allowing the complete update path to be exercised.
+
+## [v0.8.0](https://github.com/kenn-io/docbank/tree/v0.8.0) — 2026-07-19
+
+- Make CLI and daemon version reporting explicit and consistent through
+  `docbank version`, `docbank daemon version`, and compatible-daemon checks.
+
+## [v0.7.0](https://github.com/kenn-io/docbank/tree/v0.7.0) — 2026-07-19
+
+- Automatically ingest stable regular files from configured watched inboxes.
+- Preserve source identity without modifying the watched files, and append
+  later byte changes as immutable versions of the same document.
+- Expose watcher lifecycle and failures through supervised daemon jobs.
+
+## [v0.6.0](https://github.com/kenn-io/docbank/tree/v0.6.0) — 2026-07-19
+
+### Permanent audited history
+
+- Permanently enroll a directory tree in auditing with a preview-first,
+  acknowledged workflow.
+- Record and browse audited filesystem ingest, content replacement and revert,
+  moves and renames, trash and restore, and tag creation, assignment, rename,
+  and deletion.
+- Independently replay protected authority with `docbank audit verify` and
+  prove that current chains extend a separately recorded evidence report.
+- Preserve and validate audited history through backup, JSONL export, and
+  restore.
+
+### Automation
+
+- Return structured receipts for virtual-tree mutations and typed JSON from
+  established read commands.
+- Publish stable CLI exit codes for usage errors, missing objects, stale state,
+  busy resources, and integrity findings.
+
+## [v0.5.0](https://github.com/kenn-io/docbank/tree/v0.5.0) — 2026-07-17
+
+- Expose the embedded Go API directly from the module root.
+- Create audit authority through production enrollment.
+- Record audited content replacements and inherited audited node creation.
+- Classify unavailable embedded content separately during verification, and
+  report missing or size-mismatched bytes as `ErrContentUnavailable`.
+
+## [v0.4.0](https://github.com/kenn-io/docbank/tree/v0.4.0) — 2026-07-17
+
+- Page immutable content history and open any historical version through the
+  embedded API's verified-read contract.
+- Persist the initial audit enrollment authority for durable integrity
+  verification.
+- Support portable JSON representations of audit authority.
+- Stabilize provenance as audit authority with canonical record shapes and
+  deterministic collection ordering.
+
+## [v0.3.0](https://github.com/kenn-io/docbank/tree/v0.3.0) — 2026-07-16
+
+### Document workflows
 
 - Edit documents interactively with verified, versioned content replacement.
 - List, replace, revert, and explicitly prune immutable content versions.
 - Add, remove, list, and use stable user-facing tags.
-- Look up documents by authoritative content hash.
+- Find documents by authoritative content hash.
+- Preflight large imports without opening content, stream ingest progress, and
+  honor explicitly named cloud-storage roots.
+
+### Embedded and daemon operation
+
 - Embed independently rooted vaults in Go applications with selectable SQLite
   drivers, packing, and bounded child traversal.
-- Preflight large imports without modifying content and stream ingest
-  progress to the terminal.
-- View supervised daemon background jobs and their status.
-- Stable vault and document identities are preserved across ingest and
-  metadata operations, and daemon reliability is strengthened by supervising
-  background work.
-- Explicitly named cloud-storage roots are honored during ingest.
+- Preserve stable vault and document identities across ingest and metadata
+  operations.
+- Supervise daemon background jobs and expose their current state.
 
-## v0.2.1 (2026-07-13)
+## [v0.2.1](https://github.com/kenn-io/docbank/tree/v0.2.1) — 2026-07-13
+
+This recovery release carried the v0.2.0 capabilities through a validated
+six-platform release build after v0.2.0's tag did not produce a published
+GitHub release.
 
 - Create, list, verify, and restore incremental backups with portable JSONL
   metadata.
-- Inspect packed storage, pack loose objects, reclaim sparse packs, and
-  recover safely from interrupted pack retirement.
+- Inspect packed storage, pack loose objects, reclaim sparse packs, and recover
+  safely from interrupted pack retirement.
 - Upload remote content with digest checks and verify content identity over
   HTTP.
-- Run the complete Docbank CLI and daemon lifecycle natively on Windows,
-  with Windows CI covering the complete CLI and internal suite on amd64 and
-  arm64.
-- Stream verified content with separate limits for loose and packed objects
-  to keep memory and disk usage predictable.
-- Install checksum-verified binaries for Linux, macOS, and Windows on amd64
-  and arm64; the shell and PowerShell installers verify archives against
-  `SHA256SUMS` and reject missing, ambiguous, or invalid checksums.
+- Run the complete Docbank CLI and daemon lifecycle natively on Windows.
+- Stream verified loose and packed content within separate resource limits.
+- Install checksum-verified archives on Linux, macOS, and Windows, on both
+  amd64 and arm64.
+- Validate all release builders before tagging and allow a recovery release to
+  span an intervening unpublished tag.
 
-## v0.2.0 (2026-07-13)
+## [v0.2.0](https://github.com/kenn-io/docbank/tree/v0.2.0) — 2026-07-13
 
-- Create incremental backups with authoritative JSONL metadata and
-  daemon-owned snapshots; verify repositories and restore through a
-  confined, exclusive recovery workflow.
+### Backup and packed storage
+
+- Create daemon-owned incremental snapshots with authoritative JSONL metadata.
+- Verify backup repositories and restore through a confined, exclusive
+  recovery workflow.
 - Inspect packed storage, pack loose objects, and reclaim sparse packs with
   explicit maintenance commands.
+- Preserve recoverability when an obsolete pack cannot be retired immediately.
+
+### Portable clients and releases
+
 - Upload remote content with digest checking and retrieve content through
-  verifiable streaming reads.
-- Stream content and backups within bounded resource limits, with separate
-  limits for loose and packed objects.
-- Run the complete Docbank lifecycle natively on Windows: daemon discovery
-  and detached startup, owner-private vaults, no-follow ingest, overlapping
-  vault/restore exclusion, backup, restore, and self-update use native
-  Windows primitives.
-- Install using prebuilt artifacts and installers for Linux, macOS, and
-  Windows on amd64 and arm64.
-- Preserve recoverability when obsolete pack files cannot be retired
-  immediately.
+  verifiable, bounded streaming reads.
+- Run the complete daemon, CLI, lock, backup, restore, and self-update lifecycle
+  with native Windows behavior.
+- Build precompiled archives and installers for Linux, macOS, and Windows on
+  amd64 and arm64.
 
-## v0.1.0 (2026-07-09)
+## [v0.1.0](https://github.com/kenn-io/docbank/tree/v0.1.0) — 2026-07-09
 
-Release hardening:
+### Core vault
 
-- `trash empty` is now a dry run unless `--run` explicitly authorizes
-  permanent metadata deletion, matching `gc`'s mutation boundary; daemon
-  protocol negotiation prevents an older same-version daemon from
-  interpreting that dry run as the legacy destructive request
-- `search --limit` controls the bounded result set and both the API and CLI
-  report when more matches exist
-- Updated the shared `go.kenn.io/kit` dependency to v0.4.0
+- Store documents in a virtual SQLite/FTS5 tree backed by a durable
+  content-addressed blob store.
+- Import directory trees idempotently, preserve provenance, and suffix genuine
+  filename collisions without modifying source files.
+- Browse, search, move, trash, restore, empty trash, garbage-collect, and
+  verify documents from the CLI.
+- Keep permanent deletion explicit: `trash empty` and `gc` preview unless the
+  operator authorizes the mutation.
 
-Phase 2a (Infrastructure) complete:
+### Daemon-first operation
 
-- `docbank daemon` (`run`/`start`/`status`/`restart`/`stop`) on
-  `go.kenn.io/kit` lifecycle primitives: discovery, auto-start, idle
-  shutdown, exclusive vault lock for the daemon's lifetime
-- Huma v2 HTTP API under `/api/v1`: stat, list, content, search,
-  create-directory, ingest, move, trash/restore, trash-empty, gc, verify
-- Every CLI data command rewritten as an HTTP client of the daemon, with
-  auto-start on first use; no command opens the vault directly anymore
-- `config.toml` (`[server]`, `[web]`), with bind/key validation at
-  daemon startup
-- `docbank update`: self-update from GitHub releases, coordinating
-  daemon stop/replace/restart
-- `docbank openapi`: offline OpenAPI document
-- Tag-driven release workflow: Linux (amd64/arm64) and macOS (arm64)
-  archives with SHA256 checksums
-
-Phase 1 (Core) complete:
-
-- Virtual tree store (SQLite, FTS5) with schema-enforced invariants
-- Content-addressed blob store with durable write discipline
-- Idempotent recursive import with collision suffixing and provenance
-- Full core CLI: `add`, `ls`, `tree`, `cat`, `mv`, `rm`, `restore`,
-  `search`, `trash list|empty`, `gc`, `verify`
-- Trash → empty → GC deletion pipeline with `verify` integrity checking
-- Inter-process vault locking (shared for commands, exclusive for `gc`)
+- Run every standalone CLI data command through an auto-started,
+  authenticated, loopback-only daemon rather than opening the vault directly.
+- Expose the versioned HTTP API for tree, content, search, ingest, mutation,
+  reclamation, and verification workflows.
+- Coordinate daemon discovery, idle shutdown, and exclusive vault ownership.
+- Configure server and web behavior in `config.toml`, generate an offline
+  OpenAPI document, and self-update from verified GitHub releases.
+- Bound search with `--limit` and report when additional matches exist.
+- Publish Linux amd64/arm64 and macOS arm64 archives with SHA-256 checksums.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -241,11 +241,6 @@ directories.
 
 ## docbank get
 
-!!! info "Release availability"
-
-    `docbank get` is newer than v0.10.0. Build from source to use it until the
-    next release is tagged.
-
 ```text
 docbank get <path-or-id> <local-file> [--overwrite] [--progress auto|bar|plain] [--json]
 ```
@@ -319,11 +314,6 @@ update already committed, Docbank keeps the command successful, prints the new
 version, and emits a warning rather than encouraging a duplicate retry.
 
 ## docbank versions
-
-!!! info "Release availability"
-
-    The explicit `versions list|show|cat` command vocabulary is newer than
-    v0.7.0. Build from source to use it until the next release is published.
 
 ```text
 docbank versions <command>
@@ -551,9 +541,9 @@ scope head remain exact prefixes of current authority. Equal or validly extended
 chains pass; a different vault/lineage, missing scope, shorter chain, or
 divergent head is reported with a stable problem code and exits non-zero.
 
-The first scope creates the vault-wide genesis. On main after v0.10.0, later
-`audit enable` commands can add disjoint directory scopes without duplicating
-that genesis; overlapping or nested scopes are rejected. See
+The first scope creates the vault-wide genesis. Later `audit enable` commands
+can add disjoint directory scopes without duplicating that genesis; overlapping
+or nested scopes are rejected. See
 [Permanent Audited History](usage/audited-history.md) for enrollment,
 supported mutations, and maintenance behavior.
 
@@ -681,15 +671,10 @@ an explicit `truncated` boolean. A filtered report also echoes the stable
 `"hits": []`.
 
 The daemon indexes current UTF-8 `text/*`, JSON, and JSONL blobs up to 16 MiB
-after a terminally verified read. PDF, Office, and OCR extraction are not yet
-available. See [Searching](usage/searching.md).
+after a terminally verified read. PDF, Office, and OCR extraction are
+unsupported. See [Searching](usage/searching.md).
 
 ## docbank tui
-
-!!! info "Release availability"
-
-    `docbank tui` is newer than v0.10.1. Build from source to use it until the
-    next release is tagged.
 
 ```
 docbank tui
@@ -707,11 +692,6 @@ run backup and storage maintenance. See the
 capability boundary.
 
 ## docbank web
-
-!!! info "Release availability"
-
-    `docbank web` is newer than v0.10.1. Build from source to use it until the
-    next release is tagged.
 
 ```
 docbank web [--no-browser]
@@ -930,11 +910,6 @@ Every daemon registers `extract:plain-text`; configured watched inboxes add
 
 ## docbank watch
 
-!!! info "Release availability"
-
-    `docbank watch list` is newer than v0.10.0. Build from source to use it
-    until the next release is tagged.
-
 ```
 docbank watch list [--json]
 ```
@@ -945,7 +920,7 @@ minimum source age (`0s` when disabled), scan interval, exclusion count, and
 current runner state. Human output quotes source and destination paths so
 terminal control characters cannot disguise them. `--json` includes the
 complete exclusion rules and the corresponding job record for agents and
-automation. The `minimum_age` field is newer than v0.10.1.
+automation.
 
 This command is inspection only. Edit `config.toml` and restart the daemon to
 change a watch.
@@ -979,11 +954,6 @@ against an offline server instance and never invoked. For agents and
 API client generation; see [HTTP API](architecture/http-api.md).
 
 ## docbank version
-
-!!! info "Release availability"
-
-    This command is newer than v0.7.0. Build from source to use it until the
-    next release is published.
 
 ```
 docbank version

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,9 +154,6 @@ as `docbank storage pack`: ordinary mutations may briefly receive
 content and does not run GC or repack; those reclamation operations remain
 explicit operator choices.
 
-Scheduled packing is newer than v0.10.1. Build from `main` to use it until the
-next release is tagged.
-
 ### Watched inboxes
 
 Each `[[watch]]` entry makes the daemon poll one local directory recursively.
@@ -208,12 +205,11 @@ person edits or reverts the Docbank node while the source stays unchanged, a
 daemon restart does not overwrite that working version. Only a later byte
 change at the watched source appends another version.
 
-Watchers run as jobs named `watch:<name>`. In source builds newer than v0.10.0,
-`docbank watch list` and `GET /api/v1/watches` pair each runner's state with its
-effective source, destination, settle window, minimum source age, scan interval,
-and exclusion policy; use `--json` when an agent needs the complete rules.
-`minimum_age` itself is newer than v0.10.1. `docbank jobs` and
-`GET /api/v1/jobs` remain the all-task view.
+Watchers run as jobs named `watch:<name>`. `docbank watch list` and
+`GET /api/v1/watches` pair each runner's state with its effective source,
+destination, settle window, minimum source age, scan interval, and exclusion
+policy; use `--json` when an agent needs the complete rules. `docbank jobs`
+and `GET /api/v1/jobs` remain the all-task view.
 A source, destination, or read failure leaves the named job in the failed state
 and records the reason. Restart the daemon after correcting the problem.
 Per-file successes are written to the daemon log. A configured watch keeps a

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -72,12 +72,6 @@ different content already stored there. It requires the expected SHA-256 and
 size. An exact retry is idempotent; a different byte identity, media type, or
 node kind returns `ErrContentConflict` without appending a version:
 
-!!! info "Release availability"
-
-    Embedded source provenance is newer than v0.10.1. Build from `main` to use
-    `CreateOptions.Provenance` and `Vault.Provenance` until the next release is
-    tagged.
-
 ```go
 receipt, err := vault.Create(ctx, "/records/immutable.jsonl", reader,
     docbank.CreateOptions{

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,11 +54,6 @@ curl -fsSL https://docbank.ai/install.sh | sh
 
 The ordinary workflow stays direct:
 
-!!! note "Release availability"
-    Tag-filtered search and `docbank get` are newer than v0.10.0;
-    `docbank web` is newer than v0.10.1. Build from source to use them until
-    the next release is tagged.
-
 ```bash
 docbank add ~/Documents/taxes --dest /taxes    # import a folder; sources untouched
 docbank tree /taxes                            # browse the virtual tree

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,6 +7,9 @@ Every documentation page is also published as raw Markdown at the same path with
 ## Overview
 - [Your documents. Your agents. One system.](https://docbank.ai/index.md): Docbank is a self-sovereign document storage system for you and your agents, with indexed retrieval, stable identity, verifiable content, incremental recovery, and audited history.
 
+## Changelog
+- [Changelog](https://docbank.ai/changelog.md): Release history.
+
 ## Start Here
 - [Setup](https://docbank.ai/setup.md): Install docbank on Linux, macOS, or Windows and create the vault.
 - [Quickstart](https://docbank.ai/quickstart.md): A ten-minute tour of the docbank CLI.
@@ -48,5 +51,4 @@ Every documentation page is also published as raw Markdown at the same path with
 
 ## Project
 - [Roadmap](https://docbank.ai/roadmap.md): What is implemented today and what each phase adds.
-- [Changelog](https://docbank.ai/changelog.md): Release history.
 - [License](https://docbank.ai/license.md): Docbank is open-source software licensed under the Apache License, Version 2.0.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,11 +84,6 @@ authority or `a` for the selected node's permanent audited-history timeline.
 See the
 [interactive terminal browser](usage/tui.md) guide for the complete key map.
 
-!!! info "Release availability"
-
-    `docbank tui` is newer than v0.10.1. Build from source to use it until the
-    next release is tagged.
-
 `cat` streams a file's bytes to stdout. For a durable local file, `get` first
 verifies the complete download in private staging and only then publishes it:
 
@@ -96,17 +91,6 @@ verifies the complete download in private staging and only then publishes it:
 docbank cat /taxes/checklist.pdf
 docbank get /taxes/checklist.pdf /tmp/checklist.pdf
 ```
-
-!!! info "Release availability"
-
-    `docbank get` is newer than v0.10.0. Build from source to use it until the
-    next release is tagged.
-
-!!! info "New version-command vocabulary"
-
-    `docbank version` and the explicit `docbank versions list|show|cat`
-    commands are newer than v0.7.0. Build from source to use them until the
-    next release is published.
 
 Every imported file also has a stable immutable content-version UUID:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -80,10 +80,8 @@ docbank_<version>_<goos>_<goarch>.tar.gz  # Linux and macOS
 docbank_<version>_windows_<goarch>.zip    # Windows
 ```
 
-Releases produced by the current distribution workflow publish all six
-archives. Earlier tags may contain fewer targets; an installer fails instead
-of substituting another platform. Never install an archive for a different OS
-or architecture.
+Releases publish all six archives. An installer fails instead of substituting
+another platform. Never install an archive for a different OS or architecture.
 
 ## Build and install from source
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -170,9 +170,6 @@ Capture the version, daemon status, failing command or request, and relevant
 log lines. Remove API keys, shutdown tokens, document contents, and private
 paths before sharing them.
 
-`docbank version` is newer than v0.7.0; use a source build until the next
-release is published.
-
 ```bash
 docbank version
 docbank daemon status --json

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -217,10 +217,6 @@ inspection. There is deliberately no exceptional audit-destruction command.
 
 ## Multiple protected directories
 
-!!! note "Available on main after v0.10.0"
-    The latest tagged release supports one scope. The next release adds the
-    disjoint multi-scope workflow described here.
-
 Run the same preview-first command for each unrelated directory whose history
 must become permanent:
 

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -250,6 +250,3 @@ named `watch:<name>` job and any terminal error; correct the problem and restart
 the daemon. Successful additions, updates, and unchanged observations appear
 in the daemon log. See [Configuration](../configuration.md#watched-inboxes) for
 the complete field contract.
-
-Scheduled packing is newer than v0.10.1. Build from `main` to use it until the
-next release is tagged.

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -19,11 +19,6 @@ docbank cat /taxes/w2.pdf  # stream file bytes to stdout
 docbank get /taxes/w2.pdf ./w2.pdf  # verify, then atomically publish a local file
 ```
 
-!!! info "Release availability"
-
-    `docbank get` is newer than v0.10.0. Build from source to use it until the
-    next release is tagged.
-
 Use `ls --json` for a directory envelope containing the resolved directory
 and its ordered children. `tree --json` returns the root plus a flat,
 deterministic pre-order list whose entries carry absolute paths and depths;

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -80,8 +80,8 @@ daemon job reaches it. A transient open, read, or verification error leaves the
 item queued and is retried on a bounded delay; it does not become a permanent
 extraction failure. `docbank jobs` shows whether that worker is running.
 
-PDF text layers, office formats, and OCR are not yet available. Their absence
-never changes name-search results or document authority.
+PDF text layers, office formats, and OCR are unsupported. Their absence never
+changes name-search results or document authority.
 
 Next: organize documents beyond paths with
 [Organizing & Tagging](organizing.md), or see every search flag in the

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -5,11 +5,6 @@ description: Browse and sort documents, search names and extracted text, inspect
 
 # Interactive terminal browser
 
-!!! info "Release availability"
-
-    `docbank tui` is newer than v0.10.1. Build from source to use it until the
-    next release is tagged.
-
 Run:
 
 ```bash

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -5,11 +5,6 @@ description: Browse and search the local vault in a responsive, authenticated, r
 
 # Web application
 
-!!! info "Release availability"
-
-    `docbank web` is newer than v0.10.1. Build from source to use it until the
-    next release is tagged.
-
 Run:
 
 ```bash
@@ -17,15 +12,58 @@ docbank web
 ```
 
 Docbank starts or reconnects to the selected vault's compatible daemon and
-opens its local web application. The first release is a read-only document
-browser: navigate the virtual tree, sort a folder by document name, size, or
-modification time, search names and extracted text, and inspect the selected
-document's stable node ID, revision, current version ID, SHA-256 identity,
-exact size, and media type.
+opens its local web application. It is a read-only document browser: navigate
+the virtual tree, sort a folder by document name, size, or modification time,
+search names and extracted text, and inspect the selected document's stable
+node ID, revision, current version ID, SHA-256 identity, exact size, and media
+type.
 
 The browser is another client of the authenticated HTTP API. It does not open
 SQLite or the blob store, and it has no private route that the CLI or an agent
 cannot use. The daemon remains loopback-only.
+
+![The Docbank web application showing a synthetic vault tree and the selected document's authority.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/v0.11.0/web-vault-browser.png)
+
+*The root browser keeps the document table primary while the authority card
+shows the selected file's stable identity and verified content hash.*
+
+## Browse the vault
+
+- Click a row once to inspect it. The authority card updates without opening
+  or downloading the file.
+- Double-click a folder, select it and press Enter, or use **Open folder** in
+  the authority card to navigate into it.
+- Use the back arrow to restore the previous folder or search view, including
+  its selection and sort order.
+- Click **Document**, **Size**, or **Modified** to sort. Click the active
+  heading again to reverse its direction. Directories remain grouped ahead of
+  files in folder views.
+- Use refresh to reload the current stable directory ID. If another client
+  renamed or moved that directory, the browser adopts its current canonical
+  path.
+
+The browser selects the first row after loading a folder. A selected directory
+shows its path, revision, and modification time. A selected file additionally
+shows its exact logical size, media type, immutable current-version UUID, and
+SHA-256 content identity. The copy buttons copy the complete UUID or digest
+even when the card wraps it across lines.
+
+## Search names and extracted text
+
+Enter a word or phrase in the search box and press Enter. Results can match a
+live document name or verified extracted text. The **Match** column identifies
+which one. Name matches retain their API relevance ranking and appear before
+content-only matches until you choose an explicit column sort.
+
+![The Docbank web application showing extracted-text search results in a synthetic vault.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/v0.11.0/web-search-results.png)
+
+*Search results display complete virtual paths and keep the same authority
+inspection available from ordinary folder browsing.*
+
+Clear the search box to return to the current directory. The web application
+searches names and extracted text only; use `docbank search` when you need the
+directory, tag, media-type, or modification-time filters, structured JSON, or
+another result limit.
 
 ## Browser authentication
 
@@ -54,6 +92,10 @@ Every remaining browser session and its dedicated browser origin disappear
 when that daemon stops. Run `docbank web` again to create a fresh origin and
 session against the ownership-proven daemon.
 
+Closing the browser tab does not stop the daemon or revoke other sessions.
+Use the lock button when the current tab should lose access immediately, and
+use `docbank daemon stop` when every session and the daemon itself should end.
+
 The launch file remains beneath `$DOCBANK_HOME/web-launch/` with the same
 owner-only Unix permissions or Windows DACL as the runtime record. It is
 runtime state, excluded from snapshots, replaced by the next launch, and
@@ -80,3 +122,7 @@ audit scopes, or run maintenance and backup operations. Use the corresponding
 CLI or authenticated HTTP endpoint for those workflows. Future web workflows
 will require deliberately expanded browser-session permissions rather than
 inheriting the master API key.
+
+If a page reports that its browser session expired or was rejected, run
+`docbank web` again. Sessions deliberately do not survive daemon restart, and
+the previous random `.localhost` origin is not reused.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -12,6 +12,7 @@ extra_css = ["stylesheets/extra.css"]
 use_directory_urls = true
 nav = [
   {"Overview" = "index.md"},
+  {"Changelog" = "changelog.md"},
   {"Start Here" = [
     {"Setup" = "setup.md"},
     {"Quickstart" = "quickstart.md"},
@@ -53,7 +54,6 @@ nav = [
   ]},
   {"Project" = [
     {"Roadmap" = "roadmap.md"},
-    {"Changelog" = "changelog.md"},
     {"License" = "license.md"},
   ]},
 ]


### PR DESCRIPTION
Docbank.ai will present a complete, dated history from v0.1.0 through v0.11.0, with the changelog immediately beside the overview and the current web application documented as a real browsing workflow rather than a source-only preview. Users reading any current guide will no longer encounter “next release” or “newer than” fences for commands that have already shipped.

That consistency matters because the site is published as a release snapshot, not continuously from `main`. Mixing development-era availability notes into that snapshot made shipped features appear unavailable and left architecture pages disagreeing about multi-scope audited backup. The repository guidance now makes the release-snapshot boundary explicit for future documentation work.

The web guide includes a vault browser and extracted-text search capture generated from the exact v0.11.0 frontend and pure-Go backend in Docker against a synthetic vault. The PNGs live on the orphan `docs-assets` branch, with capture provenance, so the guide can remain visual without adding binary weight to the main source history.