### PR TITLE
Browse permanent audit history in the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Four commitments:
 - A read-only daemon-backed TUI for analytical tree browsing, search, stable
   document/version identity inspection, and permanent audited-history timelines
 - A read-only kit-ui web application for virtual-tree browsing, sortable
-  document analysis, extracted-text search, and complete current authority
+  document analysis, extracted-text search, and complete current authority;
+  source builds newer than v0.11.0 also expose permanent protection state and
+  full audited event timelines
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule
 - Whole-vault integrity verification

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -699,7 +699,7 @@ func TestConfiguredAutomaticPackingPacksAndKeepsDaemonAlive(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
 		"[server]\nidle_timeout = \"30ms\"\n"+
-			"[storage]\npack_interval = \"10ms\"\npack_max_bytes = 1048576\n",
+			"[storage]\npack_interval = \"250ms\"\npack_max_bytes = 1048576\n",
 	), 0o600))
 	t.Setenv("DOCBANK_HOME", home)
 	t.Setenv(client.EnvBackgroundDaemon, "1")
@@ -709,13 +709,13 @@ func TestConfiguredAutomaticPackingPacksAndKeepsDaemonAlive(t *testing.T) {
 	require.Eventually(t, func() bool {
 		_, err = runCLI(t, "mkdir", "/agents")
 		return err == nil || !errors.Is(err, client.ErrMaintenanceBusy)
-	}, 5*time.Second, 25*time.Millisecond)
+	}, 10*time.Second, 25*time.Millisecond)
 	require.NoError(t, err)
 	source := writeSourceFile(t, "session.jsonl", "{\"kind\":\"session\"}\n")
 	require.Eventually(t, func() bool {
 		_, err = runCLI(t, "add", source, "--dest", "/agents")
 		return err == nil || !errors.Is(err, client.ErrMaintenanceBusy)
-	}, 5*time.Second, 25*time.Millisecond)
+	}, 10*time.Second, 25*time.Millisecond)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		out, runErr := runCLI(t, "storage", "status", "--json")
@@ -725,7 +725,7 @@ func TestConfiguredAutomaticPackingPacksAndKeepsDaemonAlive(t *testing.T) {
 		var status api.StorageStatus
 		return json.Unmarshal([]byte(out), &status) == nil &&
 			status.LooseBlobs == 0 && status.PackedBlobs == 1
-	}, 5*time.Second, 25*time.Millisecond)
+	}, 10*time.Second, 25*time.Millisecond)
 	out, err := runCLI(t, "cat", "/agents/session.jsonl")
 	require.NoError(t, err)
 	assert.JSONEq(t, "{\"kind\":\"session\"}\n", out)

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "39", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "40", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "39", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "40", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "39", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "40", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "39", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "40", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail implemented in both; audited-history browsing implemented in the TUI |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -138,10 +138,12 @@ and authenticated API.
 The kit-ui web portal is the primary human interface over the authenticated
 daemon API. Its first read-only slice implements responsive virtual-tree
 browsing, analytical sorting, name and extracted-text search, and complete
-current document authority. Future slices cover import, metadata/provenance,
-audited history timelines and comparisons, trash, storage, backup, and
-observable jobs. Application-neutral tree, timeline, diff, evidence, and job
-components should be reusable by Msgvault and later tools.
+current document authority. Protected nodes also expose their permanent
+newest-first audit timeline and the complete stable identity and before/after
+state of every event. Future slices cover import, metadata/provenance,
+historical comparison, trash, storage, backup, and observable jobs.
+Application-neutral tree, timeline, diff, evidence, and job components should
+be reusable by Msgvault and later tools.
 
 The focused TUI now has a read-only first slice for virtual-tree navigation,
 name and extracted-content search, stable document/version/hash detail, and a

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -248,6 +248,4 @@ those changes commit or none do. Ordinary optimistic tag revisions still apply,
 so a stale rename or deletion cannot overwrite a newer assignment set.
 
 !!! info "Planned"
-    Overlapping scopes and rich TUI/web history views are not implemented.
-    Backup restore revalidates the portable JSONL authority before publishing
-    a vault.
+    Overlapping or nested scopes are not implemented.

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -16,7 +16,12 @@ opens its local web application. It is a read-only document browser: navigate
 the virtual tree, sort a folder by document name, size, or modification time,
 search names and extracted text, and inspect the selected document's stable
 node ID, revision, current version ID, SHA-256 identity, exact size, and media
-type.
+type. Protected documents also expose their newest-first permanent audit
+timeline and complete event authority.
+
+!!! note "Newer than v0.11.0"
+    Permanent protection badges and audited-history browsing are available in
+    source builds newer than v0.11.0 and will ship in the next tagged release.
 
 The browser is another client of the authenticated HTTP API. It does not open
 SQLite or the blob store, and it has no private route that the CLI or an agent
@@ -65,6 +70,28 @@ searches names and extracted text only; use `docbank search` when you need the
 directory, tag, media-type, or modification-time filters, structured JSON, or
 another result limit.
 
+## Read permanent audited history
+
+The authority card checks the selected node's stable audit membership. A green
+**Protected** badge means ordinary deletion, version pruning, garbage
+collection, and repacking cannot erase that node's retained history.
+**Not audited** means audit authority exists in the vault but the selected node
+is outside every permanent scope. **Dormant** means no scope has been enabled.
+
+Choose **Audit history** on a protected node to open a wide timeline without
+losing the current folder, search results, or selection. The timeline is newest
+first and explains the primary change for each event: live and retained-trash
+paths, content-version transitions, tag definitions and assignments, or
+provenance. Select an event to inspect its complete immutable event, operation,
+scope, and node identities; canonical timestamp and origin; before/after
+revision, path, and version state; and typed tag or provenance payload.
+
+The first page is bounded to 50 events. **Load older events** follows the
+API's append-stable cursor, so new activity cannot shift or duplicate the
+history already being inspected. Protection status remains authoritative even
+when a page contains no events. The web application does not infer protection
+from an empty or non-empty timeline.
+
 ## Browser authentication
 
 When Docbank opens the browser, it writes a small launch page beside the
@@ -83,8 +110,9 @@ service worker or cached script waiting for a future browser session.
 The launch page carries only the read-only session in a URL fragment. Browsers
 do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
-`X-Docbank-Web-Session`, which the daemon accepts only for the tree, node, and
-search reads used by this interface. It cannot call mutation, backup,
+`X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
+search, audit-status, and node-history reads used by this interface. It cannot
+enroll audit scopes, run independent verification, or call mutation, backup,
 maintenance, configuration, or general API endpoints.
 
 The lock button revokes the session in daemon memory and clears the page.
@@ -118,10 +146,10 @@ children in one metadata snapshot, so a concurrent CLI or agent move cannot
 leave the browser constructing child paths beneath an obsolete name.
 
 The current web application does not import, edit, move, tag, trash, enroll
-audit scopes, or run maintenance and backup operations. Use the corresponding
-CLI or authenticated HTTP endpoint for those workflows. Future web workflows
-will require deliberately expanded browser-session permissions rather than
-inheriting the master API key.
+audit scopes, run independent audit verification, or run maintenance and
+backup operations. Use the corresponding CLI or authenticated HTTP endpoint
+for those workflows. Future web workflows will require deliberately expanded
+browser-session permissions rather than inheriting the master API key.
 
 If a page reports that its browser session expired or was rejected, run
 `docbank web` again. Sessions deliberately do not survive daemon restart, and

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,6 +6,7 @@
   import LogOutIcon from "@lucide/svelte/icons/log-out";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import SearchIcon from "@lucide/svelte/icons/search";
+  import HistoryIcon from "@lucide/svelte/icons/history";
   import {
     Button,
     Card,
@@ -21,13 +22,16 @@
     TopBar,
     type SortDirection,
   } from "@kenn-io/kit-ui";
+  import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
   import {
     APIError,
+    auditStatusForNode,
     children,
     revokeSession,
     search,
     statPath,
     takeFragmentSession,
+    type AuditStatus,
     type Node,
     type SearchHit,
   } from "./api.js";
@@ -58,9 +62,15 @@
   let truncated = $state(false);
   let sortField = $state<SortField>("name");
   let sortDirection = $state<SortDirection>("asc");
+  let selectedAudit = $state<AuditStatus | null>(null);
+  let auditLoading = $state(false);
+  let auditError = $state("");
+  let historyOpen = $state(false);
   let generation = 0;
+  let auditGeneration = 0;
 
   const selected = $derived(rows.find((row) => row.node.id === selectedID));
+  const membership = $derived(selectedAudit?.membership);
   const sortedRows = $derived(
     orderRows(rows, sortField, sortDirection, activeQuery !== ""),
   );
@@ -73,6 +83,7 @@
   function handleFailure(cause: unknown): void {
     if (cause instanceof APIError && cause.status === 401) {
       webSession = "";
+      historyOpen = false;
       error = "The browser session expired or was rejected. Run `docbank web` again.";
       return;
     }
@@ -124,7 +135,7 @@
         node: item,
         path: path === "/" ? `/${item.name}` : `${path}/${item.name}`,
       }));
-      selectedID = rows[0]?.node.id;
+      selectNode(rows[0]?.node.id);
       activeQuery = "";
       truncated = page.total > page.items.length;
       sortField = "name";
@@ -173,7 +184,7 @@
       truncated = report.truncated;
       sortField = view.sortField;
       sortDirection = view.sortDirection;
-      selectedID = view.selectedID;
+      selectNode(view.selectedID);
     } catch (cause) {
       if (request === generation) handleFailure(cause);
     } finally {
@@ -187,7 +198,7 @@
     if (!previous) return;
     directory = previous.directory;
     rows = previous.rows;
-    selectedID = previous.selectedID;
+    selectNode(previous.selectedID);
     stack = stack.slice(0, -1);
     activeQuery = previous.activeQuery;
     searchQuery = previous.searchQuery;
@@ -204,9 +215,38 @@
   }
 
   function activate(row: Row): void {
-    selectedID = row.node.id;
+    selectNode(row.node.id);
     if (row.node.kind === "dir") {
       void loadDirectory(row.node.id, true);
+    }
+  }
+
+  function selectNode(nodeID: number | undefined): void {
+    if (selectedID !== nodeID) historyOpen = false;
+    selectedID = nodeID;
+    selectedAudit = null;
+    auditError = "";
+    auditGeneration += 1;
+    if (nodeID !== undefined && webSession) void loadAuditStatus(nodeID);
+  }
+
+  async function loadAuditStatus(nodeID: number): Promise<void> {
+    const request = ++auditGeneration;
+    const session = webSession;
+    auditLoading = true;
+    try {
+      const status = await auditStatusForNode(session, nodeID);
+      if (request !== auditGeneration || session !== webSession || selectedID !== nodeID) return;
+      selectedAudit = status;
+    } catch (cause) {
+      if (request !== auditGeneration || session !== webSession || selectedID !== nodeID) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        handleFailure(cause);
+        return;
+      }
+      auditError = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === auditGeneration) auditLoading = false;
     }
   }
 
@@ -221,12 +261,17 @@
 
   async function lock(): Promise<void> {
     generation += 1;
+    auditGeneration += 1;
     const session = webSession;
     webSession = "";
     directory = null;
     rows = [];
     stack = [];
     selectedID = undefined;
+    selectedAudit = null;
+    auditLoading = false;
+    auditError = "";
+    historyOpen = false;
     activeQuery = "";
     searchQuery = "";
     error = "";
@@ -368,7 +413,7 @@
                   tabindex="0"
                   aria-selected={row.node.id === selectedID}
                   ondblclick={() => activate(row)}
-                  onclick={() => (selectedID = row.node.id)}
+                  onclick={() => selectNode(row.node.id)}
                   onkeydown={(event) => {
                     if (event.key === "Enter") activate(row);
                   }}
@@ -431,6 +476,43 @@
                 </div>
               {/if}
             </dl>
+            <div class="audit-protection">
+              <div class="audit-protection-heading">
+                <span>Permanent audit</span>
+                {#if auditLoading}
+                  <Spinner size={14} />
+                {:else if auditError}
+                  <Chip size="xs" tone="warning">Unavailable</Chip>
+                {:else if membership?.protected}
+                  <Chip size="xs" tone="success" dot>Protected</Chip>
+                {:else if selectedAudit?.enabled}
+                  <Chip size="xs" tone="muted">Not audited</Chip>
+                {:else}
+                  <Chip size="xs" tone="muted">Dormant</Chip>
+                {/if}
+              </div>
+              {#if auditError}
+                <p>{auditError}</p>
+              {:else if membership?.protected}
+                <p>
+                  Permanently protected by {membership.scope_ids.length}
+                  scope{membership.scope_ids.length === 1 ? "" : "s"}.
+                </p>
+                <Button
+                  size="sm"
+                  tone="info"
+                  surface="soft"
+                  onclick={() => (historyOpen = true)}
+                >
+                  <HistoryIcon size="14" aria-hidden="true" />
+                  Audit history
+                </Button>
+              {:else if selectedAudit?.enabled}
+                <p>This node is outside every permanent audit scope.</p>
+              {:else if !auditLoading}
+                <p>Permanent audited history has not been enabled for this vault.</p>
+              {/if}
+            </div>
             {#if selected.node.kind === "dir"}
               <Button size="sm" onclick={() => activate(selected)}>
                 <FolderIcon size="14" aria-hidden="true" />
@@ -450,5 +532,14 @@
         {/if}
       </aside>
     </main>
+    {#if historyOpen && selected && membership?.protected}
+      <AuditHistoryDrawer
+        session={webSession}
+        node={selected.node}
+        path={selected.path}
+        onclose={() => (historyOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
   </div>
 {/if}

--- a/frontend/src/AuditHistoryDrawer.svelte
+++ b/frontend/src/AuditHistoryDrawer.svelte
@@ -130,11 +130,10 @@
         </div>
       </div>
 
-      {#if error}
-        <p class="error" role="alert">{error}</p>
-      {/if}
       {#if loading}
         <div class="loading"><Spinner size={16} /> Loading permanent history…</div>
+      {:else if error && items.length === 0}
+        <p class="error" role="alert">{error}</p>
       {:else if items.length === 0}
         <EmptyState
           title="No events on this page"
@@ -143,6 +142,9 @@
           {#snippet icon()}<ShieldCheckIcon size="22" />{/snippet}
         </EmptyState>
       {:else}
+        {#if error}
+          <p class="error" role="alert">{error}</p>
+        {/if}
         <Timeline ariaLabel="Permanent document history">
           {#each items as event (event.id)}
             <TimelineItem tone={eventTone(event.kind)}>

--- a/frontend/src/AuditHistoryDrawer.svelte
+++ b/frontend/src/AuditHistoryDrawer.svelte
@@ -51,6 +51,14 @@
   const selectedEvent = $derived(
     items.find((event) => event.id === selectedEventID),
   );
+  const historyNode = $derived(page?.node ?? node);
+  const historyPath = $derived(page ? page.path : path);
+  const historyLabel = $derived(
+    historyPath ? basename(historyPath) : `${historyNode.name} (trashed)`,
+  );
+  const historyCoordinate = $derived(
+    historyPath ?? `Trashed node · id:${historyNode.id}`,
+  );
 
   onMount(() => {
     void loadPage("", false);
@@ -102,15 +110,15 @@
 
 <DetailDrawer
   width="min(980px, 100vw)"
-  ariaLabel={`Permanent audit history for ${path}`}
+  ariaLabel={`Permanent audit history for ${historyCoordinate}`}
   {onclose}
 >
   {#snippet header()}
     <div class="drawer-heading">
       <div>
         <span>PERMANENT AUDIT HISTORY</span>
-        <strong>{basename(path)}</strong>
-        <code>{path}</code>
+        <strong>{historyLabel}</strong>
+        <code>{historyCoordinate}</code>
       </div>
       <div class="drawer-actions">
         <Chip tone="success" size="sm" dot>Protected</Chip>

--- a/frontend/src/AuditHistoryDrawer.svelte
+++ b/frontend/src/AuditHistoryDrawer.svelte
@@ -1,0 +1,515 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import ShieldCheckIcon from "@lucide/svelte/icons/shield-check";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Card,
+    Chip,
+    CopyButton,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+    Timeline,
+    TimelineItem,
+    type TimelineTone,
+  } from "@kenn-io/kit-ui";
+  import {
+    APIError,
+    auditHistory,
+    type AuditAttachmentState,
+    type AuditEvent,
+    type AuditEventPage,
+    type Node,
+  } from "./api.js";
+  import {
+    auditEventLabel,
+    auditEventSummary,
+    auditPathLabel,
+  } from "./audit.js";
+  import { basename, formatDate } from "./format.js";
+
+  interface Props {
+    session: string;
+    node: Node;
+    path: string;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, node, path, onclose, onauthfailure }: Props = $props();
+
+  let page = $state<AuditEventPage | null>(null);
+  let items = $state<AuditEvent[]>([]);
+  let selectedEventID = $state("");
+  let loading = $state(true);
+  let loadingOlder = $state(false);
+  let error = $state("");
+  let generation = 0;
+
+  const selectedEvent = $derived(
+    items.find((event) => event.id === selectedEventID),
+  );
+
+  onMount(() => {
+    void loadPage("", false);
+    return () => {
+      generation += 1;
+    };
+  });
+
+  async function loadPage(cursor: string, append: boolean): Promise<void> {
+    const request = ++generation;
+    if (append) loadingOlder = true;
+    else loading = true;
+    error = "";
+    try {
+      const next = await auditHistory(session, node.id, cursor);
+      if (request !== generation) return;
+      page = next;
+      items = append ? [...items, ...next.items] : next.items;
+      if (!selectedEventID) selectedEventID = items[0]?.id ?? "";
+    } catch (cause) {
+      if (request !== generation) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        onclose();
+        return;
+      }
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === generation) {
+        loading = false;
+        loadingOlder = false;
+      }
+    }
+  }
+
+  function eventTone(kind: string): TimelineTone {
+    if (kind.startsWith("audit_")) return "success";
+    if (kind.startsWith("content_")) return "info";
+    if (kind.startsWith("tag_")) return "workspace";
+    if (kind.startsWith("provenance_")) return "merged";
+    if (kind === "node_path") return "warning";
+    return "neutral";
+  }
+
+  function optional(value: string | number | undefined): string {
+    return value === undefined || value === "" ? "—" : String(value);
+  }
+</script>
+
+<DetailDrawer
+  width="min(980px, 100vw)"
+  ariaLabel={`Permanent audit history for ${path}`}
+  {onclose}
+>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>PERMANENT AUDIT HISTORY</span>
+        <strong>{basename(path)}</strong>
+        <code>{path}</code>
+      </div>
+      <div class="drawer-actions">
+        <Chip tone="success" size="sm" dot>Protected</Chip>
+        <IconButton size="sm" ariaLabel="Close audit history" onclick={onclose}>
+          <XIcon size="14" aria-hidden="true" />
+        </IconButton>
+      </div>
+    </div>
+  {/snippet}
+
+  <div class="history-shell">
+    <section class="event-list" aria-label="Recorded events">
+      <div class="section-heading">
+        <div>
+          <span>NEWEST FIRST</span>
+          <strong>{page?.total ?? 0} recorded event{page?.total === 1 ? "" : "s"}</strong>
+        </div>
+      </div>
+
+      {#if error}
+        <p class="error" role="alert">{error}</p>
+      {/if}
+      {#if loading}
+        <div class="loading"><Spinner size={16} /> Loading permanent history…</div>
+      {:else if items.length === 0}
+        <EmptyState
+          title="No events on this page"
+          description="The document remains permanently protected even when a page is empty."
+        >
+          {#snippet icon()}<ShieldCheckIcon size="22" />{/snippet}
+        </EmptyState>
+      {:else}
+        <Timeline ariaLabel="Permanent document history">
+          {#each items as event (event.id)}
+            <TimelineItem tone={eventTone(event.kind)}>
+              <Card
+                level="default"
+                padding="sm"
+                selected={event.id === selectedEventID}
+                onclick={() => (selectedEventID = event.id)}
+                ariaLabel={`${auditEventLabel(event.kind)} at ${formatDate(event.recorded_at)}`}
+                eyebrow={auditEventLabel(event.kind)}
+                meta={formatDate(event.recorded_at)}
+              >
+                <p class="event-summary">{auditEventSummary(event)}</p>
+                <p class="event-origin">
+                  Operation {event.operation_sequence}.{event.ordinal} · {event.origin}
+                </p>
+              </Card>
+            </TimelineItem>
+          {/each}
+        </Timeline>
+        {#if page?.next_cursor}
+          <Button
+            size="sm"
+            disabled={loadingOlder}
+            onclick={() => void loadPage(page?.next_cursor ?? "", true)}
+          >
+            {#if loadingOlder}<Spinner size={14} />{/if}
+            Load older events
+          </Button>
+        {/if}
+      {/if}
+    </section>
+
+    <section class="event-detail" aria-label="Complete audited event">
+      {#if selectedEvent}
+        <Card
+          level="inset"
+          eyebrow={auditEventLabel(selectedEvent.kind)}
+          eyebrowTone={eventTone(selectedEvent.kind)}
+          title="Complete event authority"
+          meta={`${selectedEvent.operation_sequence}.${selectedEvent.ordinal}`}
+        >
+          <dl>
+            <div class="identity">
+              <dt>Event</dt>
+              <dd><code>{selectedEvent.id}</code><CopyButton text={selectedEvent.id} ariaLabel="Copy event ID" /></dd>
+            </div>
+            <div class="identity">
+              <dt>Operation</dt>
+              <dd>
+                <code>{selectedEvent.operation_id}</code>
+                <CopyButton text={selectedEvent.operation_id} ariaLabel="Copy operation ID" />
+              </dd>
+            </div>
+            <div class="identity">
+              <dt>Scope</dt>
+              <dd>
+                <code>{selectedEvent.scope_id}</code>
+                <CopyButton text={selectedEvent.scope_id} ariaLabel="Copy scope ID" />
+              </dd>
+            </div>
+            <div><dt>Node</dt><dd>id:{selectedEvent.node_id}</dd></div>
+            <div><dt>Recorded</dt><dd>{formatDate(selectedEvent.recorded_at)}</dd></div>
+            <div><dt>Canonical time</dt><dd><code>{selectedEvent.recorded_at}</code></dd></div>
+            <div><dt>Origin</dt><dd>{selectedEvent.origin}</dd></div>
+            {#if selectedEvent.agent_label}
+              <div><dt>Agent</dt><dd>{selectedEvent.agent_label}</dd></div>
+            {/if}
+            <div>
+              <dt>Revision</dt>
+              <dd>{selectedEvent.prior_node_revision} → {selectedEvent.resulting_node_revision}</dd>
+            </div>
+            {#if selectedEvent.old_path}
+              <div><dt>Before path</dt><dd><code>{auditPathLabel(selectedEvent.old_path)}</code></dd></div>
+            {/if}
+            {#if selectedEvent.new_path}
+              <div><dt>After path</dt><dd><code>{auditPathLabel(selectedEvent.new_path)}</code></dd></div>
+            {/if}
+            {#if selectedEvent.prior_current_version_id !== undefined}
+              <div class="identity">
+                <dt>Before version</dt>
+                <dd>
+                  <code>{optional(selectedEvent.prior_current_version_id)}</code>
+                  {#if selectedEvent.prior_current_version_id}
+                    <CopyButton text={selectedEvent.prior_current_version_id} ariaLabel="Copy prior version ID" />
+                  {/if}
+                </dd>
+              </div>
+            {/if}
+            {#if selectedEvent.resulting_current_version_id !== undefined}
+              <div class="identity">
+                <dt>After version</dt>
+                <dd>
+                  <code>{optional(selectedEvent.resulting_current_version_id)}</code>
+                  {#if selectedEvent.resulting_current_version_id}
+                    <CopyButton text={selectedEvent.resulting_current_version_id} ariaLabel="Copy resulting version ID" />
+                  {/if}
+                </dd>
+              </div>
+            {/if}
+            {#if selectedEvent.source_version_id}
+              <div class="identity">
+                <dt>Source version</dt>
+                <dd>
+                  <code>{selectedEvent.source_version_id}</code>
+                  <CopyButton text={selectedEvent.source_version_id} ariaLabel="Copy source version ID" />
+                </dd>
+              </div>
+            {/if}
+            {#if selectedEvent.target_node_id}
+              <div><dt>Target node</dt><dd>id:{selectedEvent.target_node_id}</dd></div>
+            {/if}
+            {#if selectedEvent.baseline_digest}
+              <div class="identity">
+                <dt>Baseline</dt>
+                <dd>
+                  <code>{selectedEvent.baseline_digest}</code>
+                  <CopyButton text={selectedEvent.baseline_digest} ariaLabel="Copy baseline digest" />
+                </dd>
+              </div>
+            {/if}
+          </dl>
+
+          {#if selectedEvent.attachment}
+            <div class="attachment">
+              <div class="attachment-heading">
+                <span>ATTACHED METADATA</span>
+                <Chip size="xs" tone="neutral">{selectedEvent.attachment.kind}</Chip>
+              </div>
+              <dl>
+                {#if selectedEvent.attachment.identity.tag_id}
+                  <div class="identity">
+                    <dt>Tag ID</dt>
+                    <dd>
+                      <code>{selectedEvent.attachment.identity.tag_id}</code>
+                      <CopyButton text={selectedEvent.attachment.identity.tag_id} ariaLabel="Copy tag ID" />
+                    </dd>
+                  </div>
+                {/if}
+                {#if selectedEvent.attachment.identity.node_id}
+                  <div><dt>Attached node</dt><dd>id:{selectedEvent.attachment.identity.node_id}</dd></div>
+                {/if}
+                {#if selectedEvent.attachment.identity.provenance_id}
+                  <div class="identity">
+                    <dt>Provenance ID</dt>
+                    <dd>
+                      <code>{selectedEvent.attachment.identity.provenance_id}</code>
+                      <CopyButton text={selectedEvent.attachment.identity.provenance_id} ariaLabel="Copy provenance ID" />
+                    </dd>
+                  </div>
+                {/if}
+              </dl>
+              <div class="attachment-states">
+                {@render attachmentState("Before", selectedEvent.attachment.before)}
+                {@render attachmentState("After", selectedEvent.attachment.after)}
+              </div>
+            </div>
+          {/if}
+        </Card>
+      {:else}
+        <EmptyState
+          title="Select an event"
+          description="Choose a timeline entry to inspect its complete stable identities and before/after state."
+        >
+          {#snippet icon()}<ShieldCheckIcon size="22" />{/snippet}
+        </EmptyState>
+      {/if}
+    </section>
+  </div>
+</DetailDrawer>
+
+{#snippet attachmentState(label: string, state: AuditAttachmentState | undefined)}
+  <Card level="inset" padding="sm" eyebrow={label} title={state ? "Present" : "Absent"}>
+    {#if state}
+      <dl>
+        {#if state.tag_name}<div><dt>Tag name</dt><dd>{state.tag_name}</dd></div>{/if}
+        {#if state.ingest_id}<div><dt>Ingest</dt><dd><code>{state.ingest_id}</code></dd></div>{/if}
+        {#if state.original_path !== undefined}
+          <div><dt>Original reference</dt><dd>{state.original_path ?? "(absent)"}</dd></div>
+        {/if}
+        {#if state.original_mtime !== undefined}
+          <div><dt>Original modified</dt><dd>{state.original_mtime ?? "(absent)"}</dd></div>
+        {/if}
+        {#if state.supersedes !== undefined}
+          <div><dt>Supersedes</dt><dd><code>{state.supersedes ?? "(none)"}</code></dd></div>
+        {/if}
+      </dl>
+    {/if}
+  </Card>
+{/snippet}
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div:not(.drawer-actions),
+  .section-heading > div {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-3);
+    flex-shrink: 0;
+  }
+
+  .drawer-heading span,
+  .section-heading span,
+  .attachment-heading > span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading code {
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .history-shell {
+    display: grid;
+    grid-template-columns: minmax(300px, 0.85fr) minmax(360px, 1.15fr);
+    min-height: 100%;
+  }
+
+  .event-list,
+  .event-detail {
+    min-width: 0;
+    padding: var(--space-5);
+  }
+
+  .event-list {
+    border-right: 1px solid var(--border-default);
+    background: var(--bg-primary);
+  }
+
+  .section-heading {
+    margin-bottom: var(--space-5);
+  }
+
+  .section-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+  }
+
+  .event-summary,
+  .event-origin {
+    margin: 0;
+  }
+
+  .event-summary {
+    overflow-wrap: anywhere;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  .event-origin {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .error {
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+
+  dl {
+    display: grid;
+    gap: var(--space-4);
+    margin: 0;
+  }
+
+  dl > div {
+    display: grid;
+    grid-template-columns: 112px minmax(0, 1fr);
+    gap: var(--space-4);
+  }
+
+  dt {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .identity dd {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  code {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-primary);
+    font-size: var(--font-size-xs);
+  }
+
+  .attachment {
+    display: grid;
+    gap: var(--space-4);
+    margin-top: var(--space-5);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--border-default);
+  }
+
+  .attachment-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .attachment-states {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+  }
+
+  @media (max-width: 760px) {
+    .history-shell {
+      grid-template-columns: 1fr;
+    }
+
+    .event-list {
+      border-right: 0;
+      border-bottom: 1px solid var(--border-default);
+    }
+
+    .attachment-states {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/AuditHistoryDrawer.test.ts
+++ b/frontend/src/AuditHistoryDrawer.test.ts
@@ -63,6 +63,23 @@ afterEach(() => {
 });
 
 describe("audited history drawer", () => {
+  it("does not present a failed initial load as empty history", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("history unavailable", { status: 500 }),
+    );
+
+    render(AuditHistoryDrawer, {
+      session: "short-lived",
+      node,
+      path: "/Taxes/return.pdf",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.queryByText("No events on this page")).toBeNull();
+  });
+
   it("paginates immutable events and exposes complete typed details", async () => {
     const pathEvent = event({});
     const tagEvent = event({

--- a/frontend/src/AuditHistoryDrawer.test.ts
+++ b/frontend/src/AuditHistoryDrawer.test.ts
@@ -63,6 +63,28 @@ afterEach(() => {
 });
 
 describe("audited history drawer", () => {
+  it("uses the authoritative path returned with history", async () => {
+    const response = page([event({})]);
+    response.path = "/Filed/return.pdf";
+    response.node = { ...node, parent_id: 99, revision: 4 };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    render(AuditHistoryDrawer, {
+      session: "short-lived",
+      node,
+      path: "/Taxes/return.pdf",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText("/Filed/return.pdf")).toBeTruthy();
+  });
+
   it("does not present a failed initial load as empty history", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response("history unavailable", { status: 500 }),

--- a/frontend/src/AuditHistoryDrawer.test.ts
+++ b/frontend/src/AuditHistoryDrawer.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
+import type { AuditEvent, AuditEventPage, Node } from "./api.js";
+
+const node: Node = {
+  id: 42,
+  name: "return.pdf",
+  kind: "file",
+  current_version_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  blob_hash: "b".repeat(64),
+  size: 128,
+  mime_type: "application/pdf",
+  revision: 3,
+  created_at: "2026-01-02T03:04:05Z",
+  modified_at: "2026-07-23T12:00:00Z",
+};
+
+function event(overrides: Partial<AuditEvent>): AuditEvent {
+  return {
+    id: "c".repeat(64),
+    operation_id: "11111111-1111-4111-8111-111111111111",
+    operation_sequence: 3,
+    ordinal: 0,
+    node_id: 42,
+    kind: "node_path",
+    scope_id: "22222222-2222-4222-8222-222222222222",
+    recorded_at: "2026-07-23T12:00:00Z",
+    origin: "api",
+    prior_node_revision: 2,
+    resulting_node_revision: 3,
+    old_path: { path: "/Taxes/draft.pdf", state: "live" },
+    new_path: { path: "/Taxes/return.pdf", state: "live" },
+    ...overrides,
+  };
+}
+
+function page(
+  items: AuditEvent[],
+  nextCursor = "",
+  cursor = "",
+): AuditEventPage {
+  return {
+    node,
+    path: "/Taxes/return.pdf",
+    items,
+    total: 2,
+    limit: 50,
+    cursor,
+    next_cursor: nextCursor,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("audited history drawer", () => {
+  it("paginates immutable events and exposes complete typed details", async () => {
+    const pathEvent = event({});
+    const tagEvent = event({
+      id: "d".repeat(64),
+      operation_sequence: 2,
+      kind: "tag_rename",
+      prior_node_revision: 1,
+      resulting_node_revision: 2,
+      old_path: undefined,
+      new_path: undefined,
+      attachment: {
+        kind: "tag_definition",
+        identity: { tag_id: "33333333-3333-4333-8333-333333333333" },
+        before: { tag_name: "draft" },
+        after: { tag_name: "filed" },
+      },
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async () =>
+        new Response(JSON.stringify(page([pathEvent], "older")), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockImplementationOnce(async () =>
+        new Response(JSON.stringify(page([tagEvent], "", "older")), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    const close = vi.fn();
+
+    render(AuditHistoryDrawer, {
+      session: "short-lived",
+      node,
+      path: "/Taxes/return.pdf",
+      onclose: close,
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText("/Taxes/draft.pdf → /Taxes/return.pdf")).toBeTruthy();
+    expect(screen.getByText(pathEvent.id)).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Load older events" }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const tagHeading = await screen.findByText("Tag renamed");
+    const tagButton = tagHeading.closest("button");
+    expect(tagButton).toBeTruthy();
+    await fireEvent.click(tagButton!);
+
+    expect(screen.getByText("draft → filed")).toBeTruthy();
+    expect(screen.getByText("33333333-3333-4333-8333-333333333333")).toBeTruthy();
+    expect(screen.getByText("Before")).toBeTruthy();
+    expect(screen.getByText("After")).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Close audit history" }));
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   APIError,
+  auditHistory,
+  auditStatusForNode,
   requestJSON,
   revokeSession,
   takeFragmentSession,
@@ -65,6 +67,22 @@ describe("browser authentication", () => {
     );
     await expect(requestJSON("/api/v1/path", "bad")).rejects.toEqual(
       new APIError("missing or invalid API key", 401, "unauthorized"),
+    );
+  });
+
+  it("addresses audit status and cursor-stable history by node ID", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ enabled: true, scopes: [], items: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await auditStatusForNode("session", 42);
+    await auditHistory("session", 42, "cursor +/=");
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/audit/status?node_id=42");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "/api/v1/audit/history?node_id=42&limit=50&cursor=cursor+%2B%2F%3D",
     );
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -34,6 +34,101 @@ export interface SearchReport {
   truncated: boolean;
 }
 
+export interface AuditScopeStatus {
+  id: string;
+  target_node_id: number;
+  target_path?: string;
+  target_trashed: boolean;
+  enable_operation_id: string;
+  baseline_digest: string;
+  member_count: number;
+  entry_count: number;
+  chain_head: string;
+}
+
+export interface AuditMembershipStatus {
+  node_id: number;
+  path?: string;
+  trashed: boolean;
+  protected: boolean;
+  scope_ids: string[];
+  baseline_digests: string[];
+}
+
+export interface AuditStatus {
+  enabled: boolean;
+  enabled_scope_id?: string;
+  vault_id: string;
+  lineage_id?: string;
+  operation_sequence_high_water: number;
+  allocation_entry_count: number;
+  allocation_head?: string;
+  scopes: AuditScopeStatus[];
+  membership?: AuditMembershipStatus;
+}
+
+export interface AuditPathState {
+  path: string;
+  state: "live" | "trash";
+}
+
+export interface AuditAttachmentIdentity {
+  tag_id?: string;
+  node_id?: number;
+  provenance_id?: string;
+}
+
+export interface AuditAttachmentState {
+  tag_id?: string;
+  node_id?: number;
+  tag_name?: string;
+  provenance_id?: string;
+  ingest_id?: string;
+  original_path?: string | null;
+  original_mtime?: string | null;
+  supersedes?: string | null;
+}
+
+export interface AuditAttachmentChange {
+  kind: "tag_definition" | "tag_assignment" | "provenance";
+  identity: AuditAttachmentIdentity;
+  before?: AuditAttachmentState;
+  after?: AuditAttachmentState;
+}
+
+export interface AuditEvent {
+  id: string;
+  operation_id: string;
+  operation_sequence: number;
+  ordinal: number;
+  node_id: number;
+  kind: string;
+  scope_id: string;
+  recorded_at: string;
+  origin: string;
+  agent_label?: string;
+  prior_node_revision: number;
+  resulting_node_revision: number;
+  prior_current_version_id?: string;
+  resulting_current_version_id?: string;
+  source_version_id?: string;
+  target_node_id?: number;
+  baseline_digest?: string;
+  attachment?: AuditAttachmentChange;
+  old_path?: AuditPathState;
+  new_path?: AuditPathState;
+}
+
+export interface AuditEventPage {
+  node: Node;
+  path?: string;
+  items: AuditEvent[];
+  total: number;
+  limit: number;
+  cursor?: string;
+  next_cursor?: string;
+}
+
 export interface Problem {
   status?: number;
   code?: string;
@@ -114,6 +209,32 @@ export async function children(session: string, nodeID: number): Promise<NodePag
 export async function search(session: string, query: string): Promise<SearchReport> {
   return requestJSON<SearchReport>(
     `/api/v1/search?q=${encodeURIComponent(query)}&limit=1000`,
+    session,
+  );
+}
+
+export async function auditStatusForNode(
+  session: string,
+  nodeID: number,
+): Promise<AuditStatus> {
+  return requestJSON<AuditStatus>(
+    `/api/v1/audit/status?node_id=${encodeURIComponent(nodeID)}`,
+    session,
+  );
+}
+
+export async function auditHistory(
+  session: string,
+  nodeID: number,
+  cursor = "",
+): Promise<AuditEventPage> {
+  const query = new URLSearchParams({
+    node_id: String(nodeID),
+    limit: "50",
+  });
+  if (cursor) query.set("cursor", cursor);
+  return requestJSON<AuditEventPage>(
+    `/api/v1/audit/history?${query.toString()}`,
     session,
   );
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -237,6 +237,35 @@ dd {
   font-size: var(--font-size-xs);
 }
 
+.audit-protection {
+  display: grid;
+  gap: var(--space-3);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-default);
+}
+
+.audit-protection-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.audit-protection-heading > span {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.audit-protection p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
 .unlock-shell {
   display: grid;
   min-height: 100vh;

--- a/frontend/src/audit.test.ts
+++ b/frontend/src/audit.test.ts
@@ -57,6 +57,8 @@ describe("audit presentation", () => {
       auditEventSummary(
         event({
           kind: "tag_rename",
+          prior_current_version_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          resulting_current_version_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
           attachment: {
             kind: "tag_definition",
             identity: { tag_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc" },
@@ -66,5 +68,23 @@ describe("audit presentation", () => {
         }),
       ),
     ).toBe("draft → filed");
+
+    expect(
+      auditEventSummary(
+        event({
+          kind: "provenance_add",
+          prior_current_version_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          resulting_current_version_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          attachment: {
+            kind: "provenance",
+            identity: { provenance_id: "d".repeat(64) },
+            after: {
+              ingest_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+              original_path: "records/return.pdf",
+            },
+          },
+        }),
+      ),
+    ).toBe("records/return.pdf");
   });
 });

--- a/frontend/src/audit.test.ts
+++ b/frontend/src/audit.test.ts
@@ -86,5 +86,38 @@ describe("audit presentation", () => {
         }),
       ),
     ).toBe("records/return.pdf");
+
+    expect(
+      auditEventSummary(
+        event({
+          kind: "tag_define",
+          attachment: {
+            kind: "tag_definition",
+            identity: { tag_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee" },
+            after: { tag_name: "tax" },
+          },
+        }),
+      ),
+    ).toBe("(absent) → tax");
+
+    expect(
+      auditEventSummary(
+        event({
+          kind: "provenance_supersede",
+          attachment: {
+            kind: "provenance",
+            identity: { provenance_id: "f".repeat(64) },
+            before: {
+              ingest_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+              original_path: "records/draft.pdf",
+            },
+            after: {
+              ingest_id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+              original_path: "records/final.pdf",
+            },
+          },
+        }),
+      ),
+    ).toBe("records/final.pdf");
   });
 });

--- a/frontend/src/audit.test.ts
+++ b/frontend/src/audit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  auditEventLabel,
+  auditEventSummary,
+  auditPathLabel,
+} from "./audit.js";
+import type { AuditEvent } from "./api.js";
+
+function event(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    id: "a".repeat(64),
+    operation_id: "11111111-1111-4111-8111-111111111111",
+    operation_sequence: 2,
+    ordinal: 0,
+    node_id: 42,
+    kind: "content_replace",
+    scope_id: "22222222-2222-4222-8222-222222222222",
+    recorded_at: "2026-07-23T12:00:00Z",
+    origin: "api",
+    prior_node_revision: 1,
+    resulting_node_revision: 2,
+    ...overrides,
+  };
+}
+
+describe("audit presentation", () => {
+  it("uses human event names without hiding unknown canonical kinds", () => {
+    expect(auditEventLabel("content_replace")).toBe("Content replaced");
+    expect(auditEventLabel("future_event")).toBe("future event");
+  });
+
+  it("preserves live and retained-trash coordinates in path summaries", () => {
+    const summary = auditEventSummary(
+      event({
+        kind: "node_path",
+        old_path: { path: "/Taxes/return.pdf", state: "live" },
+        new_path: { path: "@trash/known/Taxes/return.pdf", state: "trash" },
+      }),
+    );
+    expect(summary).toBe(
+      "/Taxes/return.pdf → @trash/known/Taxes/return.pdf (trash)",
+    );
+    expect(auditPathLabel({ path: "/Taxes", state: "live" })).toBe("/Taxes");
+  });
+
+  it("summarizes version and typed attachment changes", () => {
+    expect(
+      auditEventSummary(
+        event({
+          prior_current_version_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          resulting_current_version_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        }),
+      ),
+    ).toBe("Version aaaaaaaa → bbbbbbbb");
+
+    expect(
+      auditEventSummary(
+        event({
+          kind: "tag_rename",
+          attachment: {
+            kind: "tag_definition",
+            identity: { tag_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc" },
+            before: { tag_name: "draft" },
+            after: { tag_name: "filed" },
+          },
+        }),
+      ),
+    ).toBe("draft → filed");
+  });
+});

--- a/frontend/src/audit.ts
+++ b/frontend/src/audit.ts
@@ -24,24 +24,23 @@ export function auditEventLabel(kind: string): string {
 }
 
 export function auditEventSummary(event: AuditEvent): string {
-  if (event.old_path && event.new_path) {
-    return `${auditPathLabel(event.old_path)} → ${auditPathLabel(event.new_path)}`;
-  }
-  if (
-    event.prior_current_version_id !== undefined ||
-    event.resulting_current_version_id !== undefined
-  ) {
-    return `Version ${shortID(event.prior_current_version_id)} → ${shortID(event.resulting_current_version_id)}`;
-  }
-  if (event.attachment) {
-    switch (event.attachment.kind) {
-      case "tag_definition":
-        return `${tagName(event.attachment.before)} → ${tagName(event.attachment.after)}`;
-      case "tag_assignment":
-        return `Tag ${shortID(event.attachment.identity.tag_id)} on id:${event.attachment.identity.node_id ?? event.node_id}`;
-      case "provenance":
-        return provenanceSummary(event.attachment.after ?? event.attachment.before);
-    }
+  switch (event.kind) {
+    case "node_path":
+      if (event.old_path && event.new_path) {
+        return `${auditPathLabel(event.old_path)} → ${auditPathLabel(event.new_path)}`;
+      }
+      break;
+    case "content_create":
+    case "content_replace":
+    case "content_revert":
+      return `Version ${shortID(event.prior_current_version_id)} → ${shortID(event.resulting_current_version_id)}`;
+    case "tag_assign":
+    case "tag_delete":
+    case "tag_rename":
+    case "tag_unassign":
+    case "provenance_add":
+      if (event.attachment) return attachmentSummary(event);
+      break;
   }
   return `Revision ${event.prior_node_revision} → ${event.resulting_node_revision}`;
 }
@@ -62,4 +61,17 @@ function tagName(state: AuditAttachmentState | undefined): string {
 function provenanceSummary(state: AuditAttachmentState | undefined): string {
   if (!state) return "Provenance removed";
   return state.original_path || `Ingest ${shortID(state.ingest_id)}`;
+}
+
+function attachmentSummary(event: AuditEvent): string {
+  const change = event.attachment;
+  if (!change) return `Revision ${event.prior_node_revision} → ${event.resulting_node_revision}`;
+  switch (change.kind) {
+    case "tag_definition":
+      return `${tagName(change.before)} → ${tagName(change.after)}`;
+    case "tag_assignment":
+      return `Tag ${shortID(change.identity.tag_id)} on id:${change.identity.node_id ?? event.node_id}`;
+    case "provenance":
+      return provenanceSummary(change.after ?? change.before);
+  }
 }

--- a/frontend/src/audit.ts
+++ b/frontend/src/audit.ts
@@ -13,7 +13,9 @@ const eventLabels: Record<string, string> = {
   node_create: "Document created",
   node_path: "Path changed",
   provenance_add: "Provenance recorded",
+  provenance_supersede: "Provenance superseded",
   tag_assign: "Tag assigned",
+  tag_define: "Tag defined",
   tag_delete: "Tag deleted",
   tag_rename: "Tag renamed",
   tag_unassign: "Tag removed",
@@ -35,10 +37,12 @@ export function auditEventSummary(event: AuditEvent): string {
     case "content_revert":
       return `Version ${shortID(event.prior_current_version_id)} → ${shortID(event.resulting_current_version_id)}`;
     case "tag_assign":
+    case "tag_define":
     case "tag_delete":
     case "tag_rename":
     case "tag_unassign":
     case "provenance_add":
+    case "provenance_supersede":
       if (event.attachment) return attachmentSummary(event);
       break;
   }

--- a/frontend/src/audit.ts
+++ b/frontend/src/audit.ts
@@ -1,0 +1,65 @@
+import type {
+  AuditAttachmentState,
+  AuditEvent,
+  AuditPathState,
+} from "./api.js";
+
+const eventLabels: Record<string, string> = {
+  audit_enroll: "Audit protection enabled",
+  audit_inherit: "Audit protection inherited",
+  content_create: "Content created",
+  content_replace: "Content replaced",
+  content_revert: "Earlier content restored",
+  node_create: "Document created",
+  node_path: "Path changed",
+  provenance_add: "Provenance recorded",
+  tag_assign: "Tag assigned",
+  tag_delete: "Tag deleted",
+  tag_rename: "Tag renamed",
+  tag_unassign: "Tag removed",
+};
+
+export function auditEventLabel(kind: string): string {
+  return eventLabels[kind] ?? kind.replaceAll("_", " ");
+}
+
+export function auditEventSummary(event: AuditEvent): string {
+  if (event.old_path && event.new_path) {
+    return `${auditPathLabel(event.old_path)} → ${auditPathLabel(event.new_path)}`;
+  }
+  if (
+    event.prior_current_version_id !== undefined ||
+    event.resulting_current_version_id !== undefined
+  ) {
+    return `Version ${shortID(event.prior_current_version_id)} → ${shortID(event.resulting_current_version_id)}`;
+  }
+  if (event.attachment) {
+    switch (event.attachment.kind) {
+      case "tag_definition":
+        return `${tagName(event.attachment.before)} → ${tagName(event.attachment.after)}`;
+      case "tag_assignment":
+        return `Tag ${shortID(event.attachment.identity.tag_id)} on id:${event.attachment.identity.node_id ?? event.node_id}`;
+      case "provenance":
+        return provenanceSummary(event.attachment.after ?? event.attachment.before);
+    }
+  }
+  return `Revision ${event.prior_node_revision} → ${event.resulting_node_revision}`;
+}
+
+export function auditPathLabel(path: AuditPathState): string {
+  return path.state === "trash" ? `${path.path} (trash)` : path.path;
+}
+
+export function shortID(value: string | undefined, length = 8): string {
+  if (!value) return "none";
+  return value.length > length ? value.slice(0, length) : value;
+}
+
+function tagName(state: AuditAttachmentState | undefined): string {
+  return state?.tag_name || "(absent)";
+}
+
+function provenanceSummary(state: AuditAttachmentState | undefined): string {
+  if (!state) return "Provenance removed";
+  return state.original_path || `Ingest ${shortID(state.ingest_id)}`;
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -316,7 +317,19 @@ func TestWebApplication(t *testing.T) {
 }
 
 func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
-	ts, _ := newTestServer(t, nil)
+	ts, s := newTestServer(t, nil)
+	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
+	require.NoError(t, err)
+	document := createFileWithContent(t, ts, s, "/return.txt", "return")
+	document, _, err = s.Move(
+		t.Context(), document.ID, taxes.ID, "return.txt", document.Revision,
+	)
+	require.NoError(t, err)
+	plan, err := s.PreviewInitialAudit(t.Context(), taxes.ID, "api", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/daemon/web-session", nil)
 	require.NoError(t, err)
 	resp, err := ts.Client().Do(req)
@@ -346,6 +359,20 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 
 	resp = webRequest(http.MethodGet, "/api/v1/path?path=/")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = webRequest(http.MethodGet,
+		"/api/v1/audit/status?node_id="+strconv.FormatInt(document.ID, 10))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = webRequest(http.MethodGet,
+		"/api/v1/audit/history?limit=50&node_id="+strconv.FormatInt(document.ID, 10))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = webRequest(http.MethodPost, "/api/v1/audit/verify")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
 	resp = webRequest(http.MethodGet, "/api/v1/info")

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -18,7 +18,7 @@ const (
 
 // webSessionRegistry owns browser credentials for exactly one daemon
 // lifetime. Tokens are random, retained only as digests, and authorize only
-// the read routes used by the built-in document browser.
+// the read routes used by the built-in document and audit-history browser.
 type webSessionRegistry struct {
 	mu     sync.Mutex
 	tokens map[[sha256.Size]byte]struct{}
@@ -64,7 +64,8 @@ func webSessionRequestAllowed(method, path string) bool {
 		return false
 	}
 	switch path {
-	case "/api/v1/path", "/api/v1/search":
+	case "/api/v1/path", "/api/v1/search",
+		"/api/v1/audit/status", "/api/v1/audit/history":
 		return true
 	}
 	const prefix = "/api/v1/nodes/"

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "39"
+	daemonProtocolVersion = "40"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Docbank’s permanent audit trail should be understandable in the same place people browse their documents. Previously, the web app could show a protected document’s current identity and content hash, but answering “how did it get here?” required switching to the CLI.

Protected documents and folders now carry an audit badge in the authority card. Opening Audit history shows a newest-first timeline while preserving the current folder, search results, and selection. Entries describe the change that actually occurred—such as a move, content replacement, tag update, or provenance addition—and the detail view exposes the stable event and operation identities, scope, node, timestamp, revisions, and before/after authority. Pagination uses the existing stable cursor, so new activity cannot reshuffle history already being inspected.

The browser remains deliberately read-only. Its daemon-lifetime credential can read audit status and node history, but it cannot enroll an audit scope, modify documents, run independent verification, or invoke maintenance and backup operations. The daemon protocol advances so the CLI will replace a running daemon that lacks this web capability instead of silently opening an incomplete interface.

This PR is intentionally limited to inspecting one node’s history. Scope-wide exploration, content comparison, audit enrollment, and verification remain separate workflows rather than being bundled into the first web history experience.