### PR TITLE
Show background job health in the web app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,10 @@ Instructions for autonomous coding agents working in this repository.
    body only when it is novel evidence that materially informs review, such as
    a migration rehearsal, benchmark, real-vault hardening run, or compatibility
    experiment.
+7. Every pull request that changes the web app or TUI must include a screenshot
+   of the actual rendered interface in the PR description. Use only synthetic
+   data, visually inspect the image before publishing it, and never substitute a
+   mockup for the implemented UI.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Four commitments:
 - A read-only kit-ui web application for virtual-tree browsing, sortable
   document analysis, extracted-text search, and complete current authority;
   source builds newer than v0.11.0 also expose permanent protection state and
-  full audited event timelines
+  full audited event timelines plus daemon background-job status
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule
 - Whole-vault integrity verification

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "40", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "41", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "40", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "41", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "40", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "41", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "40", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "41", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -140,8 +140,9 @@ daemon API. Its first read-only slice implements responsive virtual-tree
 browsing, analytical sorting, name and extracted-text search, and complete
 current document authority. Protected nodes also expose their permanent
 newest-first audit timeline and the complete stable identity and before/after
-state of every event. Future slices cover import, metadata/provenance,
-historical comparison, trash, storage, backup, and observable jobs.
+state of every event. The portal also reports current and terminal daemon
+background jobs. Future slices cover import, metadata/provenance, historical
+comparison, trash, storage, and backup.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -17,11 +17,13 @@ the virtual tree, sort a folder by document name, size, or modification time,
 search names and extracted text, and inspect the selected document's stable
 node ID, revision, current version ID, SHA-256 identity, exact size, and media
 type. Protected documents also expose their newest-first permanent audit
-timeline and complete event authority.
+timeline and complete event authority. The activity button reports the
+daemon's supervised extraction, watched-inbox, and automatic-packing jobs.
 
 !!! note "Newer than v0.11.0"
     Permanent protection badges and audited-history browsing are available in
-    source builds newer than v0.11.0 and will ship in the next tagged release.
+    source builds newer than v0.11.0, as is background-job status. They will
+    ship in the next tagged release.
 
 The browser is another client of the authenticated HTTP API. It does not open
 SQLite or the blob store, and it has no private route that the CLI or an agent
@@ -92,6 +94,20 @@ history already being inspected. Protection status remains authoritative even
 when a page contains no events. The web application does not infer protection
 from an empty or non-empty timeline.
 
+## Inspect background work
+
+Choose the activity button in the top bar to inspect the jobs owned by the
+current daemon. Each entry identifies the stable job name, whether it is
+running, completed, failed, or cancelled, and its start and finish time.
+Terminal failures include the daemon's bounded error text so an operator can
+distinguish an idle system from a watcher, extractor, or automatic packer that
+stopped.
+
+Use refresh to request a new snapshot. The drawer does not start, stop, retry,
+or reconfigure work; use the relevant configuration, CLI, or authenticated API
+workflow after understanding the failure. Job records belong to one daemon
+lifetime and disappear when that daemon restarts.
+
 ## Browser authentication
 
 When Docbank opens the browser, it writes a small launch page beside the
@@ -111,9 +127,9 @@ The launch page carries only the read-only session in a URL fragment. Browsers
 do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
-search, audit-status, and node-history reads used by this interface. It cannot
-enroll audit scopes, run independent verification, or call mutation, backup,
-maintenance, configuration, or general API endpoints.
+search, audit-status, node-history, and background-job reads used by this
+interface. It cannot enroll audit scopes, run independent verification, or
+call mutation, backup, maintenance, configuration, or general API endpoints.
 
 The lock button revokes the session in daemon memory and clears the page.
 Every remaining browser session and its dedicated browser origin disappear

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import ActivityIcon from "@lucide/svelte/icons/activity";
   import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
   import FileIcon from "@lucide/svelte/icons/file";
   import FolderIcon from "@lucide/svelte/icons/folder";
@@ -23,6 +24,7 @@
     type SortDirection,
   } from "@kenn-io/kit-ui";
   import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
+  import JobsDrawer from "./JobsDrawer.svelte";
   import {
     APIError,
     auditStatusForNode,
@@ -66,6 +68,7 @@
   let auditLoading = $state(false);
   let auditError = $state("");
   let historyOpen = $state(false);
+  let jobsOpen = $state(false);
   let generation = 0;
   let auditGeneration = 0;
 
@@ -84,6 +87,7 @@
     if (cause instanceof APIError && cause.status === 401) {
       webSession = "";
       historyOpen = false;
+      jobsOpen = false;
       error = "The browser session expired or was rejected. Run `docbank web` again.";
       return;
     }
@@ -272,6 +276,7 @@
     auditLoading = false;
     auditError = "";
     historyOpen = false;
+    jobsOpen = false;
     activeQuery = "";
     searchQuery = "";
     error = "";
@@ -326,6 +331,16 @@
         </form>
       {/snippet}
       {#snippet right()}
+        <IconButton
+          size="sm"
+          ariaLabel="Background jobs"
+          onclick={() => {
+            historyOpen = false;
+            jobsOpen = true;
+          }}
+        >
+          <ActivityIcon size="14" aria-hidden="true" />
+        </IconButton>
         <ThemeToggle size="sm" />
         <IconButton size="sm" ariaLabel="Lock web session" onclick={() => void lock()}>
           <LogOutIcon size="14" aria-hidden="true" />
@@ -502,7 +517,10 @@
                   size="sm"
                   tone="info"
                   surface="soft"
-                  onclick={() => (historyOpen = true)}
+                  onclick={() => {
+                    jobsOpen = false;
+                    historyOpen = true;
+                  }}
                 >
                   <HistoryIcon size="14" aria-hidden="true" />
                   Audit history
@@ -538,6 +556,13 @@
         node={selected.node}
         path={selected.path}
         onclose={() => (historyOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if jobsOpen}
+      <JobsDrawer
+        session={webSession}
+        onclose={() => (jobsOpen = false)}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/JobsDrawer.svelte
+++ b/frontend/src/JobsDrawer.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import ActivityIcon from "@lucide/svelte/icons/activity";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Card,
+    Chip,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+    type ChipTone,
+  } from "@kenn-io/kit-ui";
+  import { APIError, listJobs, type Job } from "./api.js";
+  import { formatDate } from "./format.js";
+
+  interface Props {
+    session: string;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, onclose, onauthfailure }: Props = $props();
+
+  let items = $state<Job[]>([]);
+  let loading = $state(true);
+  let error = $state("");
+  let generation = 0;
+
+  const running = $derived(
+    items.filter((job) => job.status === "running").length,
+  );
+
+  onMount(() => {
+    void refresh();
+    return () => {
+      generation += 1;
+    };
+  });
+
+  async function refresh(): Promise<void> {
+    const request = ++generation;
+    loading = true;
+    error = "";
+    try {
+      const next = await listJobs(session);
+      if (request !== generation) return;
+      items = next;
+    } catch (cause) {
+      if (request !== generation) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        onclose();
+        return;
+      }
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === generation) loading = false;
+    }
+  }
+
+  function statusTone(status: Job["status"]): ChipTone {
+    switch (status) {
+      case "running":
+        return "info";
+      case "completed":
+        return "success";
+      case "failed":
+        return "danger";
+      case "cancelled":
+        return "canceled";
+    }
+  }
+</script>
+
+<DetailDrawer
+  width="min(620px, 100vw)"
+  ariaLabel="Daemon background jobs"
+  {onclose}
+>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>DAEMON ACTIVITY</span>
+        <strong>Background jobs</strong>
+        <small>{running} running · {items.length} total</small>
+      </div>
+      <div class="drawer-actions">
+        <IconButton
+          size="sm"
+          ariaLabel="Refresh background jobs"
+          disabled={loading}
+          onclick={() => void refresh()}
+        >
+          <RefreshCwIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton size="sm" ariaLabel="Close background jobs" onclick={onclose}>
+          <XIcon size="14" aria-hidden="true" />
+        </IconButton>
+      </div>
+    </div>
+  {/snippet}
+
+  <div class="jobs">
+    {#if loading && items.length === 0}
+      <div class="loading"><Spinner size={16} /> Loading background jobs…</div>
+    {:else if error && items.length === 0}
+      <div class="load-error">
+        <p role="alert">{error}</p>
+        <Button size="sm" onclick={() => void refresh()}>Try again</Button>
+      </div>
+    {:else if items.length === 0}
+      <EmptyState
+        title="No background jobs"
+        description="This daemon has no supervised extraction, watcher, or packing work."
+      >
+        {#snippet icon()}<ActivityIcon size="22" />{/snippet}
+      </EmptyState>
+    {:else}
+      {#if error}<p class="error" role="alert">{error}</p>{/if}
+      <div class="job-list" aria-live="polite">
+        {#each items as job (job.name)}
+          <Card
+            level="default"
+            padding="sm"
+            eyebrow="BACKGROUND JOB"
+            title={job.name}
+          >
+            {#snippet actions()}
+              <Chip size="xs" tone={statusTone(job.status)} dot={job.status === "running"}>
+                {job.status}
+              </Chip>
+            {/snippet}
+            <dl>
+              <div><dt>Started</dt><dd>{formatDate(job.started_at)}</dd></div>
+              <div>
+                <dt>Finished</dt>
+                <dd>{job.finished_at ? formatDate(job.finished_at) : "Still running"}</dd>
+              </div>
+            </dl>
+            {#if job.error}
+              <p class="job-error" role="alert">{job.error}</p>
+            {/if}
+          </Card>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</DetailDrawer>
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div:first-child {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-heading span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading small {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .drawer-actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .jobs {
+    padding: var(--space-5);
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .load-error {
+    display: grid;
+    justify-items: start;
+    gap: var(--space-4);
+  }
+
+  .load-error p,
+  .error {
+    margin: 0;
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+
+  .job-list {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  dl {
+    display: grid;
+    gap: var(--space-3);
+    margin: 0;
+  }
+
+  dl > div {
+    display: grid;
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: var(--space-3);
+  }
+
+  dt {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  dd {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .job-error {
+    margin: 0;
+    padding: var(--space-3);
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--accent-red) 8%, transparent);
+    color: var(--accent-red);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/frontend/src/JobsDrawer.test.ts
+++ b/frontend/src/JobsDrawer.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/svelte";
+import JobsDrawer from "./JobsDrawer.svelte";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("background jobs drawer", () => {
+  it("distinguishes running work from a terminal failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              name: "extract:plain-text",
+              status: "running",
+              started_at: "2026-07-23T12:00:00Z",
+            },
+            {
+              name: "watch:inbox",
+              status: "failed",
+              started_at: "2026-07-23T11:00:00Z",
+              finished_at: "2026-07-23T11:02:00Z",
+              error: "source is unavailable",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const close = vi.fn();
+
+    render(JobsDrawer, {
+      session: "short-lived",
+      onclose: close,
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText("extract:plain-text")).toBeTruthy();
+    expect(screen.getByText("watch:inbox")).toBeTruthy();
+    expect(screen.getByText("Still running")).toBeTruthy();
+    expect(screen.getByText("source is unavailable")).toBeTruthy();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Close background jobs" }),
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -3,6 +3,7 @@ import {
   APIError,
   auditHistory,
   auditStatusForNode,
+  listJobs,
   requestJSON,
   revokeSession,
   takeFragmentSession,
@@ -84,5 +85,17 @@ describe("browser authentication", () => {
     expect(fetchMock.mock.calls[1]?.[0]).toBe(
       "/api/v1/audit/history?node_id=42&limit=50&cursor=cursor+%2B%2F%3D",
     );
+  });
+
+  it("reads daemon-owned background jobs through the browser session", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(listJobs("session")).resolves.toEqual([]);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/jobs");
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -129,6 +129,18 @@ export interface AuditEventPage {
   next_cursor?: string;
 }
 
+export interface Job {
+  name: string;
+  status: "running" | "completed" | "failed" | "cancelled";
+  started_at: string;
+  finished_at?: string;
+  error?: string;
+}
+
+export interface JobList {
+  items: Job[];
+}
+
 export interface Problem {
   status?: number;
   code?: string;
@@ -237,4 +249,9 @@ export async function auditHistory(
     `/api/v1/audit/history?${query.toString()}`,
     session,
   );
+}
+
+export async function listJobs(session: string): Promise<Job[]> {
+  const result = await requestJSON<JobList>("/api/v1/jobs", session);
+  return result.items;
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -371,6 +371,10 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
+	resp = webRequest(http.MethodGet, "/api/v1/jobs")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
 	resp = webRequest(http.MethodPost, "/api/v1/audit/verify")
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -18,7 +18,7 @@ const (
 
 // webSessionRegistry owns browser credentials for exactly one daemon
 // lifetime. Tokens are random, retained only as digests, and authorize only
-// the read routes used by the built-in document and audit-history browser.
+// the read routes used by the built-in document, audit-history, and job browser.
 type webSessionRegistry struct {
 	mu     sync.Mutex
 	tokens map[[sha256.Size]byte]struct{}
@@ -65,7 +65,7 @@ func webSessionRequestAllowed(method, path string) bool {
 	}
 	switch path {
 	case "/api/v1/path", "/api/v1/search",
-		"/api/v1/audit/status", "/api/v1/audit/history":
+		"/api/v1/audit/status", "/api/v1/audit/history", "/api/v1/jobs":
 		return true
 	}
 	const prefix = "/api/v1/nodes/"

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "40"
+	daemonProtocolVersion = "41"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Docbank’s daemon already runs text extraction, watched inboxes, and automatic packing in the background, but the primary web interface looked identical whether that work was healthy, idle, or permanently failed. A person could browse documents while an important watcher had stopped and receive no indication that the archive was no longer advancing.

The web app now has a top-bar activity view for the current daemon lifetime. It distinguishes running, completed, failed, and cancelled jobs; shows start and finish times; preserves the bounded failure text for diagnosis; and refreshes on demand. It deliberately does not start, stop, retry, or reconfigure anything—after understanding a failure, the operator still uses the existing configuration, CLI, or authenticated API workflow.

The browser remains read-only. Its short-lived credential gains access only to the existing jobs status endpoint, not maintenance or job control, and the daemon protocol advances so an older daemon that cannot serve this view is replaced instead of opening a partially functional interface.

![Docbank web application showing three running background jobs against a synthetic vault](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/pr-136/web-background-jobs.png)

*Actual rendered interface using synthetic documents and a temporary synthetic watched inbox.*