### PR TITLE
Browse immutable versions in the web app

### DIFF
--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "41", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "42", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "41", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "42", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "41", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "42", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "41", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "42", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web version history implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -138,11 +138,13 @@ and authenticated API.
 The kit-ui web portal is the primary human interface over the authenticated
 daemon API. Its first read-only slice implements responsive virtual-tree
 browsing, analytical sorting, name and extracted-text search, and complete
-current document authority. Protected nodes also expose their permanent
-newest-first audit timeline and the complete stable identity and before/after
-state of every event. The portal also reports current and terminal daemon
-background jobs. Future slices cover import, metadata/provenance, historical
-comparison, trash, storage, and backup.
+current document authority. Every file exposes its newest-first immutable
+version history and complete version, hash, operation, and revert-source
+authority. Protected nodes also expose their permanent newest-first audit
+timeline and the complete stable identity and before/after state of every
+event. The portal also reports current and terminal daemon background jobs.
+Future slices cover import, metadata/provenance, historical content comparison,
+trash, storage, and backup.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -19,11 +19,8 @@ node ID, revision, current version ID, SHA-256 identity, exact size, and media
 type. Protected documents also expose their newest-first permanent audit
 timeline and complete event authority. The activity button reports the
 daemon's supervised extraction, watched-inbox, and automatic-packing jobs.
-
-!!! note "Newer than v0.11.0"
-    Permanent protection badges and audited-history browsing are available in
-    source builds newer than v0.11.0, as is background-job status. They will
-    ship in the next tagged release.
+Every file also exposes its retained immutable content versions and the stable
+authority behind each one.
 
 The browser is another client of the authenticated HTTP API. It does not open
 SQLite or the blob store, and it has no private route that the CLI or an agent
@@ -54,6 +51,25 @@ shows its path, revision, and modification time. A selected file additionally
 shows its exact logical size, media type, immutable current-version UUID, and
 SHA-256 content identity. The copy buttons copy the complete UUID or digest
 even when the card wraps it across lines.
+
+## Inspect immutable versions
+
+Choose **Version history** on any file to inspect every retained immutable
+version without losing the current folder, search results, or selected
+document. The newest version appears first. Each entry identifies whether the
+content was created, replaced, or restored from a prior version, along with its
+recorded time, node revision, logical size, and stable version UUID.
+
+Selecting an entry exposes its complete authority: full version UUID, SHA-256
+content identity, exact byte count, media type, canonical timestamp,
+introducing operation UUID, and the source version for a revert. The current
+head is marked explicitly; a revert remains a new immutable version rather
+than erasing or relabeling the earlier one.
+
+The drawer reads at most the newest 1,000 versions and says when older history
+exists. Use `docbank versions list`, its pagination flags, or the authenticated
+HTTP API for exhaustive automation. This view does not download content,
+compare bytes, revert, or prune history.
 
 ## Search names and extracted text
 
@@ -127,9 +143,10 @@ The launch page carries only the read-only session in a URL fragment. Browsers
 do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
-search, audit-status, node-history, and background-job reads used by this
-interface. It cannot enroll audit scopes, run independent verification, or
-call mutation, backup, maintenance, configuration, or general API endpoints.
+search, immutable-version, audit-status, audit-history, and background-job
+reads used by this interface. It cannot enroll audit scopes, run independent
+verification, or call mutation, backup, maintenance, configuration, or general
+API endpoints.
 
 The lock button revokes the session in daemon memory and clears the page.
 Every remaining browser session and its dedicated browser origin disappear
@@ -161,11 +178,12 @@ Refreshing a folder resolves its stable node ID, current canonical path, and
 children in one metadata snapshot, so a concurrent CLI or agent move cannot
 leave the browser constructing child paths beneath an obsolete name.
 
-The current web application does not import, edit, move, tag, trash, enroll
-audit scopes, run independent audit verification, or run maintenance and
-backup operations. Use the corresponding CLI or authenticated HTTP endpoint
-for those workflows. Future web workflows will require deliberately expanded
-browser-session permissions rather than inheriting the master API key.
+The current web application does not download historical content, compare
+versions, import, edit, revert, prune, move, tag, trash, enroll audit scopes,
+run independent audit verification, or run maintenance and backup operations.
+Use the corresponding CLI or authenticated HTTP endpoint for those workflows.
+Future web workflows will require deliberately expanded browser-session
+permissions rather than inheriting the master API key.
 
 If a page reports that its browser session expired or was rejected, run
 `docbank web` again. Sessions deliberately do not survive daemon restart, and

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -25,6 +25,7 @@
   } from "@kenn-io/kit-ui";
   import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
   import JobsDrawer from "./JobsDrawer.svelte";
+  import VersionHistoryDrawer from "./VersionHistoryDrawer.svelte";
   import {
     APIError,
     auditStatusForNode,
@@ -68,6 +69,7 @@
   let auditLoading = $state(false);
   let auditError = $state("");
   let historyOpen = $state(false);
+  let versionsOpen = $state(false);
   let jobsOpen = $state(false);
   let generation = 0;
   let auditGeneration = 0;
@@ -87,6 +89,7 @@
     if (cause instanceof APIError && cause.status === 401) {
       webSession = "";
       historyOpen = false;
+      versionsOpen = false;
       jobsOpen = false;
       error = "The browser session expired or was rejected. Run `docbank web` again.";
       return;
@@ -226,7 +229,10 @@
   }
 
   function selectNode(nodeID: number | undefined): void {
-    if (selectedID !== nodeID) historyOpen = false;
+    if (selectedID !== nodeID) {
+      historyOpen = false;
+      versionsOpen = false;
+    }
     selectedID = nodeID;
     selectedAudit = null;
     auditError = "";
@@ -276,6 +282,7 @@
     auditLoading = false;
     auditError = "";
     historyOpen = false;
+    versionsOpen = false;
     jobsOpen = false;
     activeQuery = "";
     searchQuery = "";
@@ -336,6 +343,7 @@
           ariaLabel="Background jobs"
           onclick={() => {
             historyOpen = false;
+            versionsOpen = false;
             jobsOpen = true;
           }}
         >
@@ -491,6 +499,21 @@
                 </div>
               {/if}
             </dl>
+            {#if selected.node.kind === "file"}
+              <Button
+                size="sm"
+                tone="info"
+                surface="soft"
+                onclick={() => {
+                  historyOpen = false;
+                  jobsOpen = false;
+                  versionsOpen = true;
+                }}
+              >
+                <HistoryIcon size="14" aria-hidden="true" />
+                Version history
+              </Button>
+            {/if}
             <div class="audit-protection">
               <div class="audit-protection-heading">
                 <span>Permanent audit</span>
@@ -519,6 +542,7 @@
                   surface="soft"
                   onclick={() => {
                     jobsOpen = false;
+                    versionsOpen = false;
                     historyOpen = true;
                   }}
                 >
@@ -556,6 +580,15 @@
         node={selected.node}
         path={selected.path}
         onclose={() => (historyOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if versionsOpen && selected?.node.kind === "file"}
+      <VersionHistoryDrawer
+        session={webSession}
+        node={selected.node}
+        path={selected.path}
+        onclose={() => (versionsOpen = false)}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/VersionHistoryDrawer.svelte
+++ b/frontend/src/VersionHistoryDrawer.svelte
@@ -1,0 +1,388 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import HistoryIcon from "@lucide/svelte/icons/history";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Card,
+    Chip,
+    CopyButton,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+    Timeline,
+    TimelineItem,
+    type TimelineTone,
+  } from "@kenn-io/kit-ui";
+  import {
+    APIError,
+    contentVersions,
+    type ContentVersion,
+    type ContentVersionPage,
+    type Node,
+  } from "./api.js";
+  import { basename, formatBytes, formatDate } from "./format.js";
+
+  interface Props {
+    session: string;
+    node: Node;
+    path: string;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, node, path, onclose, onauthfailure }: Props = $props();
+
+  let page = $state<ContentVersionPage | null>(null);
+  let selectedVersionID = $state("");
+  let loading = $state(true);
+  let error = $state("");
+  let generation = 0;
+
+  const selectedVersion = $derived(
+    page?.items.find((version) => version.id === selectedVersionID),
+  );
+
+  onMount(() => {
+    void load();
+    return () => {
+      generation += 1;
+    };
+  });
+
+  async function load(): Promise<void> {
+    const request = ++generation;
+    loading = true;
+    error = "";
+    try {
+      const next = await contentVersions(session, node.id);
+      if (request !== generation) return;
+      page = next;
+      selectedVersionID = next.items[0]?.id ?? "";
+    } catch (cause) {
+      if (request !== generation) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        onclose();
+        return;
+      }
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === generation) loading = false;
+    }
+  }
+
+  function transitionLabel(kind: ContentVersion["transition_kind"]): string {
+    switch (kind) {
+      case "content_create":
+        return "Created";
+      case "content_replace":
+        return "Replaced";
+      case "content_revert":
+        return "Reverted";
+    }
+  }
+
+  function transitionTone(kind: ContentVersion["transition_kind"]): TimelineTone {
+    switch (kind) {
+      case "content_create":
+        return "success";
+      case "content_replace":
+        return "info";
+      case "content_revert":
+        return "warning";
+    }
+  }
+</script>
+
+<DetailDrawer
+  width="min(920px, 100vw)"
+  ariaLabel={`Immutable version history for ${path}`}
+  {onclose}
+>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>IMMUTABLE VERSION HISTORY</span>
+        <strong>{basename(path)}</strong>
+        <code>{path} · id:{node.id}</code>
+      </div>
+      <IconButton size="sm" ariaLabel="Close version history" onclick={onclose}>
+        <XIcon size="14" aria-hidden="true" />
+      </IconButton>
+    </div>
+  {/snippet}
+
+  <div class="history-shell">
+    <section class="version-list" aria-label="Retained versions">
+      <div class="section-heading">
+        <span>NEWEST FIRST</span>
+        <strong>{page?.total ?? 0} retained version{page?.total === 1 ? "" : "s"}</strong>
+      </div>
+
+      {#if loading}
+        <div class="loading"><Spinner size={16} /> Loading immutable versions…</div>
+      {:else if error}
+        <p class="error" role="alert">{error}</p>
+      {:else if !page || page.items.length === 0}
+        <EmptyState
+          title="No retained versions"
+          description="This file does not have an immutable content version."
+        >
+          {#snippet icon()}<HistoryIcon size="22" />{/snippet}
+        </EmptyState>
+      {:else}
+        <Timeline ariaLabel="Immutable content versions">
+          {#each page.items as version (version.id)}
+            <TimelineItem tone={transitionTone(version.transition_kind)}>
+              <Card
+                level="default"
+                padding="sm"
+                selected={version.id === selectedVersionID}
+                onclick={() => (selectedVersionID = version.id)}
+                ariaLabel={`${transitionLabel(version.transition_kind)} at ${formatDate(version.recorded_at)}`}
+                eyebrow={transitionLabel(version.transition_kind)}
+                meta={formatDate(version.recorded_at)}
+              >
+                <div class="version-summary">
+                  <strong>Revision {version.node_revision}</strong>
+                  {#if version.id === node.current_version_id}
+                    <Chip size="xs" tone="success" dot>Current</Chip>
+                  {/if}
+                </div>
+                <p>{formatBytes(version.size)} · <code>{version.id.slice(0, 8)}</code></p>
+              </Card>
+            </TimelineItem>
+          {/each}
+        </Timeline>
+        {#if page.total > page.items.length}
+          <p class="limit-note">
+            Showing the newest {page.items.length} of {page.total} versions.
+            Use the CLI or HTTP API for older history.
+          </p>
+        {/if}
+      {/if}
+    </section>
+
+    <section class="version-detail" aria-label="Complete version authority">
+      {#if selectedVersion}
+        <Card
+          level="inset"
+          eyebrow={transitionLabel(selectedVersion.transition_kind)}
+          eyebrowTone={transitionTone(selectedVersion.transition_kind)}
+          title="Complete version authority"
+          meta={`Revision ${selectedVersion.node_revision}`}
+        >
+          <dl>
+            <div class="identity">
+              <dt>Version</dt>
+              <dd>
+                <code>{selectedVersion.id}</code>
+                <CopyButton text={selectedVersion.id} ariaLabel="Copy version ID" />
+              </dd>
+            </div>
+            <div><dt>Transition</dt><dd>{transitionLabel(selectedVersion.transition_kind)}</dd></div>
+            <div><dt>Recorded</dt><dd>{formatDate(selectedVersion.recorded_at)}</dd></div>
+            <div><dt>Canonical time</dt><dd><code>{selectedVersion.recorded_at}</code></dd></div>
+            <div><dt>Node</dt><dd>id:{selectedVersion.node_id}</dd></div>
+            <div><dt>Node revision</dt><dd>{selectedVersion.node_revision}</dd></div>
+            <div class="identity">
+              <dt>SHA-256</dt>
+              <dd>
+                <code>{selectedVersion.blob_hash}</code>
+                <CopyButton text={selectedVersion.blob_hash} ariaLabel="Copy SHA-256" />
+              </dd>
+            </div>
+            <div>
+              <dt>Size</dt>
+              <dd>{formatBytes(selectedVersion.size)} ({selectedVersion.size} bytes)</dd>
+            </div>
+            <div>
+              <dt>Media type</dt>
+              <dd>{selectedVersion.mime_type || "application/octet-stream"}</dd>
+            </div>
+            <div class="identity">
+              <dt>Operation</dt>
+              <dd>
+                <code>{selectedVersion.introduced_operation_id}</code>
+                <CopyButton
+                  text={selectedVersion.introduced_operation_id}
+                  ariaLabel="Copy introducing operation ID"
+                />
+              </dd>
+            </div>
+            {#if selectedVersion.source_version_id}
+              <div class="identity">
+                <dt>Revert source</dt>
+                <dd>
+                  <code>{selectedVersion.source_version_id}</code>
+                  <CopyButton text={selectedVersion.source_version_id} ariaLabel="Copy revert source version ID" />
+                </dd>
+              </div>
+            {/if}
+          </dl>
+        </Card>
+      {:else}
+        <EmptyState
+          title="Select a version"
+          description="Choose a timeline entry to inspect its stable identity and complete content authority."
+        >
+          {#snippet icon()}<HistoryIcon size="22" />{/snippet}
+        </EmptyState>
+      {/if}
+    </section>
+  </div>
+</DetailDrawer>
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div,
+  .section-heading {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-heading span,
+  .section-heading span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading code {
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .history-shell {
+    display: grid;
+    grid-template-columns: minmax(290px, 0.8fr) minmax(360px, 1.2fr);
+    min-height: 100%;
+  }
+
+  .version-list,
+  .version-detail {
+    min-width: 0;
+    padding: var(--space-5);
+  }
+
+  .version-list {
+    border-right: 1px solid var(--border-default);
+    background: var(--bg-primary);
+  }
+
+  .section-heading {
+    margin-bottom: var(--space-5);
+  }
+
+  .section-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+  }
+
+  .version-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .version-summary strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  .version-summary + p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .error {
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+
+  .limit-note {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  dl {
+    display: grid;
+    gap: var(--space-4);
+    margin: 0;
+  }
+
+  dl > div {
+    display: grid;
+    grid-template-columns: 112px minmax(0, 1fr);
+    gap: var(--space-4);
+  }
+
+  dt {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .identity dd {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  code {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-primary);
+    font-size: var(--font-size-xs);
+  }
+
+  @media (max-width: 760px) {
+    .history-shell {
+      grid-template-columns: 1fr;
+    }
+
+    .version-list {
+      border-right: 0;
+      border-bottom: 1px solid var(--border-default);
+    }
+  }
+</style>

--- a/frontend/src/VersionHistoryDrawer.svelte
+++ b/frontend/src/VersionHistoryDrawer.svelte
@@ -146,7 +146,7 @@
               >
                 <div class="version-summary">
                   <strong>Revision {version.node_revision}</strong>
-                  {#if version.id === node.current_version_id}
+                  {#if version.id === page.items[0]?.id}
                     <Chip size="xs" tone="success" dot>Current</Chip>
                   {/if}
                 </div>

--- a/frontend/src/VersionHistoryDrawer.test.ts
+++ b/frontend/src/VersionHistoryDrawer.test.ts
@@ -73,14 +73,16 @@ describe("version history drawer", () => {
 
     render(VersionHistoryDrawer, {
       session: "short-lived",
-      node,
+      node: { ...node, current_version_id: replacedVersionID },
       path: "/Reports/quarterly-report.txt",
       onclose: close,
       onauthfailure: vi.fn(),
     });
 
     expect(await screen.findByText("3 retained versions")).toBeTruthy();
-    expect(screen.getByText("Current")).toBeTruthy();
+    expect(
+      screen.getByText("Current").closest("button")?.getAttribute("aria-label"),
+    ).toContain("Reverted");
     expect(screen.getByText(currentVersionID)).toBeTruthy();
     expect(screen.getByText(createdVersionID)).toBeTruthy();
     expect(screen.getByText("Revert source")).toBeTruthy();

--- a/frontend/src/VersionHistoryDrawer.test.ts
+++ b/frontend/src/VersionHistoryDrawer.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/svelte";
+import VersionHistoryDrawer from "./VersionHistoryDrawer.svelte";
+import type { ContentVersion, Node } from "./api.js";
+
+const currentVersionID = "33333333-3333-4333-8333-333333333333";
+const replacedVersionID = "22222222-2222-4222-8222-222222222222";
+const createdVersionID = "11111111-1111-4111-8111-111111111111";
+
+const node: Node = {
+  id: 42,
+  name: "quarterly-report.txt",
+  kind: "file",
+  current_version_id: currentVersionID,
+  blob_hash: "c".repeat(64),
+  size: 384,
+  mime_type: "text/plain; charset=utf-8",
+  revision: 3,
+  created_at: "2026-01-02T03:04:05Z",
+  modified_at: "2026-07-24T12:00:00Z",
+};
+
+function version(
+  id: string,
+  revision: number,
+  transition: ContentVersion["transition_kind"],
+  hash: string,
+  sourceVersionID?: string,
+): ContentVersion {
+  return {
+    id,
+    node_id: node.id,
+    blob_hash: hash.repeat(64),
+    size: revision * 128,
+    mime_type: "text/plain; charset=utf-8",
+    recorded_at: `2026-07-${21 + revision}T12:00:00Z`,
+    node_revision: revision,
+    introduced_operation_id: `${revision}${revision}${revision}${revision}${revision}${revision}${revision}${revision}-1111-4111-8111-111111111111`,
+    transition_kind: transition,
+    source_version_id: sourceVersionID,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("version history drawer", () => {
+  it("shows newest-first authority and revert lineage", async () => {
+    const versions = [
+      version(currentVersionID, 3, "content_revert", "c", createdVersionID),
+      version(replacedVersionID, 2, "content_replace", "b"),
+      version(createdVersionID, 1, "content_create", "a"),
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: versions,
+          total: versions.length,
+          limit: 1000,
+          offset: 0,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const close = vi.fn();
+
+    render(VersionHistoryDrawer, {
+      session: "short-lived",
+      node,
+      path: "/Reports/quarterly-report.txt",
+      onclose: close,
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText("3 retained versions")).toBeTruthy();
+    expect(screen.getByText("Current")).toBeTruthy();
+    expect(screen.getByText(currentVersionID)).toBeTruthy();
+    expect(screen.getByText(createdVersionID)).toBeTruthy();
+    expect(screen.getByText("Revert source")).toBeTruthy();
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/v1/nodes/42/versions?limit=1000&offset=0",
+    );
+
+    const createdHeading = screen.getByText("Created");
+    const createdButton = createdHeading.closest("button");
+    expect(createdButton).toBeTruthy();
+    await fireEvent.click(createdButton!);
+
+    expect(screen.getByText("a".repeat(64))).toBeTruthy();
+    expect(screen.queryByText("Revert source")).toBeNull();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Close version history" }),
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -3,6 +3,7 @@ import {
   APIError,
   auditHistory,
   auditStatusForNode,
+  contentVersions,
   listJobs,
   requestJSON,
   revokeSession,
@@ -97,5 +98,19 @@ describe("browser authentication", () => {
 
     await expect(listJobs("session")).resolves.toEqual([]);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/jobs");
+  });
+
+  it("reads immutable versions for one stable node", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ items: [], total: 0, limit: 1000, offset: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await contentVersions("session", 42);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/v1/nodes/42/versions?limit=1000&offset=0",
+    );
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -22,6 +22,29 @@ export interface NodePage {
   offset: number;
 }
 
+export interface ContentVersion {
+  id: string;
+  node_id: number;
+  blob_hash: string;
+  size: number;
+  mime_type?: string;
+  recorded_at: string;
+  node_revision: number;
+  introduced_operation_id: string;
+  transition_kind:
+    | "content_create"
+    | "content_replace"
+    | "content_revert";
+  source_version_id?: string;
+}
+
+export interface ContentVersionPage {
+  items: ContentVersion[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface SearchHit {
   node: Node;
   path: string;
@@ -214,6 +237,16 @@ export async function statPath(session: string, path: string): Promise<Node> {
 export async function children(session: string, nodeID: number): Promise<NodePage> {
   return requestJSON<NodePage>(
     `/api/v1/nodes/${nodeID}/children?limit=1000&offset=0`,
+    session,
+  );
+}
+
+export async function contentVersions(
+  session: string,
+  nodeID: number,
+): Promise<ContentVersionPage> {
+  return requestJSON<ContentVersionPage>(
+    `/api/v1/nodes/${nodeID}/versions?limit=1000&offset=0`,
     session,
   );
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -371,6 +371,11 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
+	resp = webRequest(http.MethodGet,
+		"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/versions?limit=1000&offset=0")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
 	resp = webRequest(http.MethodGet, "/api/v1/jobs")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -79,7 +79,7 @@ func webSessionRequestAllowed(method, path string) bool {
 	if _, err := strconv.ParseInt(parts[0], 10, 64); err != nil {
 		return false
 	}
-	return len(parts) == 1 || parts[1] == "children"
+	return len(parts) == 1 || parts[1] == "children" || parts[1] == "versions"
 }
 
 func registerWebSession(

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "41"
+	daemonProtocolVersion = "42"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Docbank keeps every content version by default, but the web application could show only the current one. A person investigating a report had to leave the browser and translate the selected document into CLI commands just to answer when its bytes changed, which version is current, or what a revert actually restored.

Every file now has a **Version history** action. It opens a newest-first timeline without losing the current folder, search results, or selection. Selecting an entry exposes the complete stable version ID, SHA-256 identity, exact size, media type, recorded and canonical time, node revision, introducing operation, and revert source. The current head is marked explicitly, so a revert reads honestly as a new version linked to earlier content rather than as erased history.

![The actual Docbank web application showing three immutable versions from a synthetic create, replace, and revert workflow](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-version-history/web-version-history.png)

*Actual rendered interface using a temporary synthetic vault; no private corpus data is present.*

The browser remains read-only. Its daemon-lifetime session gains access only to the existing bounded version-list GET route. The drawer shows at most the newest 1,000 entries and directs exhaustive users to the paginated CLI or API; downloading historical bytes, comparison, reversion, pruning, and editing remain separate workflows rather than being smuggled into this inspection slice. A protocol bump ensures `docbank web` replaces a daemon that cannot honor the expanded read-only session.