### PR TITLE
Inspect document provenance in the web app

### DIFF
--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "42", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "43", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "42", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "43", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "42", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "43", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "42", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "43", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web version history implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web version and provenance history implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -140,11 +140,12 @@ daemon API. Its first read-only slice implements responsive virtual-tree
 browsing, analytical sorting, name and extracted-text search, and complete
 current document authority. Every file exposes its newest-first immutable
 version history and complete version, hash, operation, and revert-source
-authority. Protected nodes also expose their permanent newest-first audit
-timeline and the complete stable identity and before/after state of every
-event. The portal also reports current and terminal daemon background jobs.
-Future slices cover import, metadata/provenance, historical content comparison,
-trash, storage, and backup.
+authority, plus its newest-first immutable provenance facts and supersession
+history. Protected nodes also expose their permanent newest-first audit timeline
+and the complete stable identity and before/after state of every event. The
+portal also reports current and terminal daemon background jobs. Future slices
+cover import, tags and broader metadata, historical content comparison, trash,
+storage, and backup.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -20,7 +20,8 @@ type. Protected documents also expose their newest-first permanent audit
 timeline and complete event authority. The activity button reports the
 daemon's supervised extraction, watched-inbox, and automatic-packing jobs.
 Every file also exposes its retained immutable content versions and the stable
-authority behind each one.
+authority behind each one, plus the immutable provenance Docbank recorded when
+the document entered the vault.
 
 The browser is another client of the authenticated HTTP API. It does not open
 SQLite or the blob store, and it has no private route that the CLI or an agent
@@ -70,6 +71,30 @@ The drawer reads at most the newest 1,000 versions and says when older history
 exists. Use `docbank versions list`, its pagination flags, or the authenticated
 HTTP API for exhaustive automation. This view does not download content,
 compare bytes, revert, or prune history.
+
+## Understand where a document came from
+
+Choose **Provenance** on any file to inspect the origin facts Docbank retained
+when it ingested that document. The newest ingest appears first. Each entry
+shows its source kind and description, original reference, ingest time, and
+whether it is the active origin or has been superseded by a corrected fact.
+
+Selecting an entry exposes its complete stable provenance identity, ingest
+UUID, node ID, canonical ingest timestamp, original modification time when one
+was supplied, and supersession link. The drawer adopts the node state returned
+with the provenance page, so a concurrent move displays the current canonical
+path and a trashed document is labeled explicitly rather than retaining an
+obsolete path from the table.
+
+An original reference is evidence, not a live filesystem promise. It may be a
+portable relative path from a watched inbox, a local path recorded by an
+ordinary ingest, or an opaque reference supplied by an embedded application.
+The browser does not open, validate, change, or retain that external source.
+
+The drawer reads at most the newest 1,000 facts and says when older provenance
+exists. Use `docbank provenance`, its pagination flags, or the authenticated
+HTTP API for exhaustive automation. Provenance correction and external-content
+pinning are not browser workflows.
 
 ## Search names and extracted text
 
@@ -143,10 +168,10 @@ The launch page carries only the read-only session in a URL fragment. Browsers
 do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
-search, immutable-version, audit-status, audit-history, and background-job
-reads used by this interface. It cannot enroll audit scopes, run independent
-verification, or call mutation, backup, maintenance, configuration, or general
-API endpoints.
+search, immutable-version, provenance, audit-status, audit-history, and
+background-job reads used by this interface. It cannot enroll audit scopes,
+run independent verification, or call mutation, backup, maintenance,
+configuration, or general API endpoints.
 
 The lock button revokes the session in daemon memory and clears the page.
 Every remaining browser session and its dedicated browser origin disappear

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@
   import FileIcon from "@lucide/svelte/icons/file";
   import FolderIcon from "@lucide/svelte/icons/folder";
   import LogOutIcon from "@lucide/svelte/icons/log-out";
+  import MapPinIcon from "@lucide/svelte/icons/map-pin";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import SearchIcon from "@lucide/svelte/icons/search";
   import HistoryIcon from "@lucide/svelte/icons/history";
@@ -25,6 +26,7 @@
   } from "@kenn-io/kit-ui";
   import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
   import JobsDrawer from "./JobsDrawer.svelte";
+  import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import VersionHistoryDrawer from "./VersionHistoryDrawer.svelte";
   import {
     APIError,
@@ -70,6 +72,7 @@
   let auditError = $state("");
   let historyOpen = $state(false);
   let versionsOpen = $state(false);
+  let provenanceOpen = $state(false);
   let jobsOpen = $state(false);
   let generation = 0;
   let auditGeneration = 0;
@@ -90,6 +93,7 @@
       webSession = "";
       historyOpen = false;
       versionsOpen = false;
+      provenanceOpen = false;
       jobsOpen = false;
       error = "The browser session expired or was rejected. Run `docbank web` again.";
       return;
@@ -232,6 +236,7 @@
     if (selectedID !== nodeID) {
       historyOpen = false;
       versionsOpen = false;
+      provenanceOpen = false;
     }
     selectedID = nodeID;
     selectedAudit = null;
@@ -283,6 +288,7 @@
     auditError = "";
     historyOpen = false;
     versionsOpen = false;
+    provenanceOpen = false;
     jobsOpen = false;
     activeQuery = "";
     searchQuery = "";
@@ -344,6 +350,7 @@
           onclick={() => {
             historyOpen = false;
             versionsOpen = false;
+            provenanceOpen = false;
             jobsOpen = true;
           }}
         >
@@ -500,19 +507,35 @@
               {/if}
             </dl>
             {#if selected.node.kind === "file"}
-              <Button
-                size="sm"
-                tone="info"
-                surface="soft"
-                onclick={() => {
-                  historyOpen = false;
-                  jobsOpen = false;
-                  versionsOpen = true;
-                }}
-              >
-                <HistoryIcon size="14" aria-hidden="true" />
-                Version history
-              </Button>
+              <div class="document-actions">
+                <Button
+                  size="sm"
+                  tone="info"
+                  surface="soft"
+                  onclick={() => {
+                    historyOpen = false;
+                    provenanceOpen = false;
+                    jobsOpen = false;
+                    versionsOpen = true;
+                  }}
+                >
+                  <HistoryIcon size="14" aria-hidden="true" />
+                  Version history
+                </Button>
+                <Button
+                  size="sm"
+                  surface="soft"
+                  onclick={() => {
+                    historyOpen = false;
+                    versionsOpen = false;
+                    jobsOpen = false;
+                    provenanceOpen = true;
+                  }}
+                >
+                  <MapPinIcon size="14" aria-hidden="true" />
+                  Provenance
+                </Button>
+              </div>
             {/if}
             <div class="audit-protection">
               <div class="audit-protection-heading">
@@ -543,6 +566,7 @@
                   onclick={() => {
                     jobsOpen = false;
                     versionsOpen = false;
+                    provenanceOpen = false;
                     historyOpen = true;
                   }}
                 >
@@ -589,6 +613,15 @@
         node={selected.node}
         path={selected.path}
         onclose={() => (versionsOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if provenanceOpen && selected?.node.kind === "file"}
+      <ProvenanceDrawer
+        session={webSession}
+        node={selected.node}
+        path={selected.path}
+        onclose={() => (provenanceOpen = false)}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/ProvenanceDrawer.svelte
+++ b/frontend/src/ProvenanceDrawer.svelte
@@ -1,0 +1,389 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import MapPinIcon from "@lucide/svelte/icons/map-pin";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Card,
+    Chip,
+    CopyButton,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+    Timeline,
+    TimelineItem,
+  } from "@kenn-io/kit-ui";
+  import {
+    APIError,
+    provenance,
+    type Node,
+    type ProvenanceFact,
+    type ProvenancePage,
+  } from "./api.js";
+  import { basename, formatDate } from "./format.js";
+
+  interface Props {
+    session: string;
+    node: Node;
+    path: string;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, node, path, onclose, onauthfailure }: Props = $props();
+
+  let page = $state<ProvenancePage | null>(null);
+  let selectedIdentity = $state("");
+  let loading = $state(true);
+  let error = $state("");
+  let generation = 0;
+
+  const selectedFact = $derived(
+    page?.items.find((fact) => fact.identity === selectedIdentity),
+  );
+  const authorityNode = $derived(page?.node ?? node);
+  const authorityPath = $derived(page ? page.node.path : path);
+  const authorityLabel = $derived(
+    authorityPath
+      ? basename(authorityPath)
+      : `${authorityNode.name} (trashed)`,
+  );
+  const authorityCoordinate = $derived(
+    authorityPath ?? `Trashed node · id:${authorityNode.id}`,
+  );
+
+  onMount(() => {
+    void load();
+    return () => {
+      generation += 1;
+    };
+  });
+
+  async function load(): Promise<void> {
+    const request = ++generation;
+    loading = true;
+    error = "";
+    try {
+      const next = await provenance(session, node.id);
+      if (request !== generation) return;
+      page = next;
+      selectedIdentity = next.items[0]?.identity ?? "";
+    } catch (cause) {
+      if (request !== generation) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        onclose();
+        return;
+      }
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === generation) loading = false;
+    }
+  }
+
+  function factStatus(fact: ProvenanceFact): string {
+    return fact.active ? "Active origin" : "Superseded origin";
+  }
+</script>
+
+<DetailDrawer
+  width="min(940px, 100vw)"
+  ariaLabel={`Immutable provenance for ${authorityCoordinate}`}
+  {onclose}
+>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>DOCUMENT PROVENANCE</span>
+        <strong>{authorityLabel}</strong>
+        <code>{authorityCoordinate}</code>
+      </div>
+      <IconButton size="sm" ariaLabel="Close provenance" onclick={onclose}>
+        <XIcon size="14" aria-hidden="true" />
+      </IconButton>
+    </div>
+  {/snippet}
+
+  <div class="provenance-shell">
+    <section class="fact-list" aria-label="Immutable origin facts">
+      <div class="section-heading">
+        <span>NEWEST INGEST FIRST</span>
+        <strong>{page?.total ?? 0} origin fact{page?.total === 1 ? "" : "s"}</strong>
+      </div>
+
+      {#if loading}
+        <div class="loading"><Spinner size={16} /> Loading provenance…</div>
+      {:else if error}
+        <p class="error" role="alert">{error}</p>
+      {:else if !page || page.items.length === 0}
+        <EmptyState
+          title="No provenance recorded"
+          description="This document has no retained ingest-origin facts."
+        >
+          {#snippet icon()}<MapPinIcon size="22" />{/snippet}
+        </EmptyState>
+      {:else}
+        <Timeline ariaLabel="Document provenance history">
+          {#each page.items as fact (fact.identity)}
+            <TimelineItem tone={fact.active ? "success" : "neutral"}>
+              <Card
+                level="default"
+                padding="sm"
+                selected={fact.identity === selectedIdentity}
+                onclick={() => (selectedIdentity = fact.identity)}
+                ariaLabel={`${factStatus(fact)} from ${fact.source_description}`}
+                eyebrow={fact.source_kind}
+                meta={formatDate(fact.ingest_started_at)}
+              >
+                <div class="fact-summary">
+                  <strong>{fact.source_description}</strong>
+                  <Chip size="xs" tone={fact.active ? "success" : "muted"} dot={fact.active}>
+                    {fact.active ? "Active" : "Superseded"}
+                  </Chip>
+                </div>
+                <p>{fact.original_path}</p>
+              </Card>
+            </TimelineItem>
+          {/each}
+        </Timeline>
+        {#if page.total > page.items.length}
+          <p class="limit-note">
+            Showing the newest {page.items.length} of {page.total} origin facts.
+            Use the CLI or HTTP API for older history.
+          </p>
+        {/if}
+      {/if}
+    </section>
+
+    <section class="fact-detail" aria-label="Complete provenance authority">
+      {#if selectedFact}
+        <Card
+          level="inset"
+          eyebrow={selectedFact.source_kind}
+          eyebrowTone={selectedFact.active ? "success" : "neutral"}
+          title="Complete origin authority"
+          meta={selectedFact.active ? "Active fact" : "Superseded fact"}
+        >
+          <dl>
+            <div class="identity">
+              <dt>Fact</dt>
+              <dd>
+                <code>{selectedFact.identity}</code>
+                <CopyButton text={selectedFact.identity} ariaLabel="Copy provenance identity" />
+              </dd>
+            </div>
+            <div><dt>Status</dt><dd>{factStatus(selectedFact)}</dd></div>
+            <div><dt>Node</dt><dd>id:{selectedFact.node_id}</dd></div>
+            <div class="identity">
+              <dt>Ingest</dt>
+              <dd>
+                <code>{selectedFact.ingest_id}</code>
+                <CopyButton text={selectedFact.ingest_id} ariaLabel="Copy ingest ID" />
+              </dd>
+            </div>
+            <div><dt>Ingest began</dt><dd>{formatDate(selectedFact.ingest_started_at)}</dd></div>
+            <div><dt>Canonical time</dt><dd><code>{selectedFact.ingest_started_at}</code></dd></div>
+            <div><dt>Source kind</dt><dd>{selectedFact.source_kind}</dd></div>
+            <div><dt>Source</dt><dd>{selectedFact.source_description}</dd></div>
+            <div><dt>Original reference</dt><dd>{selectedFact.original_path}</dd></div>
+            <div>
+              <dt>Source modified</dt>
+              <dd>{selectedFact.original_mtime
+                ? formatDate(selectedFact.original_mtime)
+                : "Not recorded"}</dd>
+            </div>
+            {#if selectedFact.original_mtime}
+              <div><dt>Canonical mtime</dt><dd><code>{selectedFact.original_mtime}</code></dd></div>
+            {/if}
+            {#if selectedFact.supersedes}
+              <div class="identity">
+                <dt>Supersedes</dt>
+                <dd>
+                  <code>{selectedFact.supersedes}</code>
+                  <CopyButton text={selectedFact.supersedes} ariaLabel="Copy superseded provenance identity" />
+                </dd>
+              </div>
+            {/if}
+          </dl>
+          <p class="explanation">
+            Provenance records where Docbank was told this document came from.
+            It does not open, manage, or retain the original source.
+          </p>
+        </Card>
+      {:else}
+        <EmptyState
+          title="Select an origin fact"
+          description="Choose an entry to inspect its stable identity, source reference, and ingest authority."
+        >
+          {#snippet icon()}<MapPinIcon size="22" />{/snippet}
+        </EmptyState>
+      {/if}
+    </section>
+  </div>
+</DetailDrawer>
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div,
+  .section-heading {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-heading span,
+  .section-heading span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading code {
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .provenance-shell {
+    display: grid;
+    grid-template-columns: minmax(300px, 0.85fr) minmax(360px, 1.15fr);
+    min-height: 100%;
+  }
+
+  .fact-list,
+  .fact-detail {
+    min-width: 0;
+    padding: var(--space-5);
+  }
+
+  .fact-list {
+    border-right: 1px solid var(--border-default);
+    background: var(--bg-primary);
+  }
+
+  .section-heading {
+    margin-bottom: var(--space-5);
+  }
+
+  .section-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+  }
+
+  .fact-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .fact-summary strong {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .fact-summary + p {
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .error {
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+
+  .limit-note,
+  .explanation {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.45;
+  }
+
+  .explanation {
+    margin: var(--space-5) 0 0;
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--border-default);
+  }
+
+  dl {
+    display: grid;
+    gap: var(--space-4);
+    margin: 0;
+  }
+
+  dl > div {
+    display: grid;
+    grid-template-columns: 118px minmax(0, 1fr);
+    gap: var(--space-4);
+  }
+
+  dt {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .identity dd {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  code {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-primary);
+    font-size: var(--font-size-xs);
+  }
+
+  @media (max-width: 760px) {
+    .provenance-shell {
+      grid-template-columns: 1fr;
+    }
+
+    .fact-list {
+      border-right: 0;
+      border-bottom: 1px solid var(--border-default);
+    }
+  }
+</style>

--- a/frontend/src/ProvenanceDrawer.test.ts
+++ b/frontend/src/ProvenanceDrawer.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/svelte";
+import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
+import type { Node, ProvenanceFact } from "./api.js";
+
+const olderIdentity = "a".repeat(64);
+const activeIdentity = "b".repeat(64);
+
+const node: Node = {
+  id: 42,
+  name: "quarterly-report.txt",
+  kind: "file",
+  current_version_id: "11111111-1111-4111-8111-111111111111",
+  blob_hash: "c".repeat(64),
+  size: 384,
+  mime_type: "text/plain; charset=utf-8",
+  revision: 3,
+  created_at: "2026-01-02T03:04:05Z",
+  modified_at: "2026-07-24T12:00:00Z",
+};
+
+const older: ProvenanceFact = {
+  identity: olderIdentity,
+  node_id: node.id,
+  ingest_id: "22222222-2222-4222-8222-222222222222",
+  ingest_started_at: "2026-07-20T10:00:00Z",
+  source_kind: "filesystem",
+  source_description: "quarterly reports",
+  original_path: "drafts/quarterly-report.txt",
+  original_mtime: "2026-07-20T09:30:00Z",
+  active: false,
+};
+
+const active: ProvenanceFact = {
+  identity: activeIdentity,
+  node_id: node.id,
+  ingest_id: "33333333-3333-4333-8333-333333333333",
+  ingest_started_at: "2026-07-24T12:00:00Z",
+  source_kind: "watch",
+  source_description: "approved reports",
+  original_path: "approved/quarterly-report.txt",
+  original_mtime: "2026-07-24T11:45:00Z",
+  supersedes: olderIdentity,
+  active: true,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("provenance drawer", () => {
+  it("uses authoritative node state and exposes supersession history", async () => {
+    const authoritativeNode = {
+      ...node,
+      parent_id: 99,
+      path: "/Filed/quarterly-report.txt",
+      revision: 4,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          node: authoritativeNode,
+          items: [active, older],
+          total: 2,
+          limit: 1000,
+          offset: 0,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const close = vi.fn();
+
+    render(ProvenanceDrawer, {
+      session: "short-lived",
+      node,
+      path: "/Reports/quarterly-report.txt",
+      onclose: close,
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText("/Filed/quarterly-report.txt")).toBeTruthy();
+    expect(screen.getByText("Active origin")).toBeTruthy();
+    expect(screen.getByText(activeIdentity)).toBeTruthy();
+    expect(screen.getByText("Supersedes")).toBeTruthy();
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/v1/nodes/42/provenance?limit=1000&offset=0",
+    );
+
+    const olderHeading = screen.getByText("quarterly reports");
+    const olderButton = olderHeading.closest("button");
+    expect(olderButton).toBeTruthy();
+    await fireEvent.click(olderButton!);
+
+    expect(screen.getByText("Superseded origin")).toBeTruthy();
+    expect(screen.getByText(olderIdentity)).toBeTruthy();
+    expect(screen.queryByText("Supersedes")).toBeNull();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Close provenance" }),
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -45,6 +45,27 @@ export interface ContentVersionPage {
   offset: number;
 }
 
+export interface ProvenanceFact {
+  identity: string;
+  node_id: number;
+  ingest_id: string;
+  ingest_started_at: string;
+  source_kind: string;
+  source_description: string;
+  original_path: string;
+  original_mtime?: string;
+  supersedes?: string;
+  active: boolean;
+}
+
+export interface ProvenancePage {
+  node: Node;
+  items: ProvenanceFact[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface SearchHit {
   node: Node;
   path: string;
@@ -247,6 +268,16 @@ export async function contentVersions(
 ): Promise<ContentVersionPage> {
   return requestJSON<ContentVersionPage>(
     `/api/v1/nodes/${nodeID}/versions?limit=1000&offset=0`,
+    session,
+  );
+}
+
+export async function provenance(
+  session: string,
+  nodeID: number,
+): Promise<ProvenancePage> {
+  return requestJSON<ProvenancePage>(
+    `/api/v1/nodes/${nodeID}/provenance?limit=1000&offset=0`,
     session,
   );
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -237,6 +237,12 @@ dd {
   font-size: var(--font-size-xs);
 }
 
+.document-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
 .audit-protection {
   display: grid;
   gap: var(--space-3);

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -376,6 +376,11 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
+	resp = webRequest(http.MethodGet,
+		"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/provenance?limit=1000&offset=0")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
 	resp = webRequest(http.MethodGet, "/api/v1/jobs")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -79,7 +79,8 @@ func webSessionRequestAllowed(method, path string) bool {
 	if _, err := strconv.ParseInt(parts[0], 10, 64); err != nil {
 		return false
 	}
-	return len(parts) == 1 || parts[1] == "children" || parts[1] == "versions"
+	return len(parts) == 1 || parts[1] == "children" ||
+		parts[1] == "versions" || parts[1] == "provenance"
 }
 
 func registerWebSession(

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "42"
+	daemonProtocolVersion = "43"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Docbank could already preserve immutable evidence about where a document came
from, but people browsing the vault had no way to see it. Answering “was this
the report imported from the records system, or a corrected origin?” meant
leaving the web application and translating the selected document into CLI
commands.

Every file now has a **Provenance** action. It opens a newest-first timeline of
the recorded origin facts without losing the current folder or selection. The
active origin is distinct from superseded corrections, and selecting a fact
shows its complete stable identity, ingest identity and time, source kind and
description, original reference and modification time, and supersession link.
The drawer uses the daemon's authoritative current node state, so concurrent
moves and trash operations cannot leave it presenting an obsolete live path.

![The actual Docbank web application showing immutable provenance for a synthetic quarterly report](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-provenance/web-provenance.png)

*Actual rendered interface using a temporary synthetic vault; no private
corpus data is present.*

This view is intentionally evidence, not source management. An original
reference may be a portable watched-inbox path, a local ingest path, or an
opaque reference supplied by an embedded application; Docbank does not imply
that it can still open or control that source. The browser remains read-only
and gains access only to the existing provenance GET route. The drawer is
bounded at the newest 1,000 facts and directs exhaustive use to the paginated
CLI or API rather than quietly truncating the history.
