### PR TITLE
Download verified documents from the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Four commitments:
 - A read-only daemon-backed TUI for analytical tree browsing, search, stable
   document/version identity inspection, and permanent audited-history timelines
 - A read-only kit-ui web application for virtual-tree browsing, sortable
-  document analysis, extracted-text search, and complete current authority;
-  source builds newer than v0.11.0 also expose permanent protection state and
-  full audited event timelines plus daemon background-job status
+  document analysis, extracted-text search, complete current authority,
+  verified current-content download, permanent protection and event history,
+  immutable versions and provenance, and daemon background-job status
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule
 - Whole-vault integrity verification
@@ -84,11 +84,6 @@ Four commitments:
 - A release pipeline for Linux, macOS, and Windows on amd64 and arm64, with
   SHA-256 checksums and checksum-enforcing installers
 - Native vault, daemon, and recovery support on Linux, macOS, and Windows
-
-Embedded generic source provenance, scheduled packing, `docbank tui`, and
-`docbank web` are
-newer than v0.10.1. Build from `main` to use them until the next release is
-tagged.
 
 See the [roadmap](docs/roadmap.md) for high-level product direction beyond the
 capabilities listed here.
@@ -130,9 +125,6 @@ toolchain.
 
 There is no initialization command. The first data command creates the local
 vault and starts its daemon:
-
-> **Release availability:** tag-filtered search and `docbank get` are newer
-> than v0.10.0. Build from source to use them until the next release is tagged.
 
 ```bash
 docbank add ~/Documents --dest /archive

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "43", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "44", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "43", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "44", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "43", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "44", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "43", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "44", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ The directory layout is created on first use:
 │   └── tmp/             # staging for in-flight writes
 ├── logs/                # JSON logs from background daemons
 ├── web-launch/          # owner-private browser authentication handoff
+├── web-downloads/       # private, temporary verified browser downloads
 ├── config.toml          # optional; see below
 ├── vault.lock           # advisory lock, held by a daemon or target restore
 └── daemon.<pid>.json    # runtime record of a live daemon
@@ -50,8 +51,9 @@ always describe the decoded content. Docbank chooses it for worthwhile new
 writes and continues to read existing raw files without converting them.
 `config.toml` is configuration, not archive data — optional, but back it
 up if you've customized it (it can hold an `api_key`). `vault.lock` and
-`daemon.<pid>.json` and `web-launch/` are coordination/runtime state, safe to
-ignore in backups and safe to delete when no daemon or restore is running
+`daemon.<pid>.json`, `web-launch/`, and `web-downloads/` are
+coordination/runtime state, safe to ignore in backups and safe to delete when
+no daemon or restore is running
 (`docbank daemon stop` removes its own record cleanly on graceful
 shutdown). The database
 references blobs by hash, so restoring a copied `docbank.db` + `blobs/`

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ documents without losing track of them, every stored byte can be checked, and
 incremental backups can be verified before you rely on them. Work directly
 from the CLI, automate through the authenticated HTTP API, or embed Docbank in
 a Go application. People can browse the same authority in the local web
-application or focused terminal interface.
+application or focused terminal interface; the web application verifies
+current document bytes before handing them to the browser's native save.
 
 Install the latest release on Linux or macOS:
 
@@ -169,7 +170,7 @@ documents: files you still organize, retrieve, and build workflows around.
 - [Setup](setup.md): install the binary and create the vault
 - [Quickstart](quickstart.md): a ten-minute tour of the CLI
 - [Vault Lifecycle](usage/lifecycle.md): operate, snapshot, and recover safely
-- [Web Application](usage/web.md): browse and search the local vault
+- [Web Application](usage/web.md): browse, search, and download verified current content
 - [Docbank for Agents](agents.md): the automation contract
 - [Embed in Go](embedding.md): vaults inside your own application
 - [Troubleshooting](troubleshooting.md): diagnose failures without risking the vault

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web version and provenance history implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web version history, provenance, and verified current-content download implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -138,14 +138,17 @@ and authenticated API.
 The kit-ui web portal is the primary human interface over the authenticated
 daemon API. Its first read-only slice implements responsive virtual-tree
 browsing, analytical sorting, name and extracted-text search, and complete
-current document authority. Every file exposes its newest-first immutable
+current document authority. A selected live file can be downloaded through
+bounded daemon staging: progress is visible, content is terminally verified
+before a one-use browser handoff, and the browser never buffers the whole
+object or receives the vault API key. Every file exposes its newest-first immutable
 version history and complete version, hash, operation, and revert-source
 authority, plus its newest-first immutable provenance facts and supersession
 history. Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
 portal also reports current and terminal daemon background jobs. Future slices
-cover import, tags and broader metadata, historical content comparison, trash,
-storage, and backup.
+cover import, tags and broader metadata, historical content download and
+comparison, trash, storage, and backup.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -53,6 +53,33 @@ shows its exact logical size, media type, immutable current-version UUID, and
 SHA-256 content identity. The copy buttons copy the complete UUID or digest
 even when the card wraps it across lines.
 
+## Download verified current content
+
+Choose **Download** on a file to retrieve its current version. Docbank first
+copies the object from loose or packed storage into owner-private daemon
+staging while the browser shows verified byte progress. The selected node
+revision, version UUID, SHA-256 identity, and exact size must still agree before
+that work starts. A concurrent replacement, move, or trash operation therefore
+asks you to refresh instead of silently downloading a different document.
+
+Only terminally verified bytes receive a short-lived, one-use browser download
+ticket. The native browser save begins after that proof succeeds; cancellation
+or a verification failure removes the private staging file and publishes
+nothing to the browser. The ticket identifies only that prepared file, expires
+after two minutes, and cannot call any other Docbank route. It is not the vault
+API key or the browser session.
+
+Preparation streams on the daemon and does not buffer the object in browser
+memory. It temporarily needs local free space equal to the document's logical
+size. Docbank reports that verified bytes were handed to the browser, not that
+the browser or operating system completed its final save. Use `docbank get`
+when automation needs a durable receipt after private staging, file sync,
+atomic publication, and parent-directory sync.
+
+This action downloads only the selected live document's current version.
+Historical-version download and comparison remain CLI or authenticated API
+workflows.
+
 ## Inspect immutable versions
 
 Choose **Version history** on any file to inspect every retained immutable
@@ -168,10 +195,12 @@ The launch page carries only the read-only session in a URL fragment. Browsers
 do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
-search, immutable-version, provenance, audit-status, audit-history, and
-background-job reads used by this interface. It cannot enroll audit scopes,
-run independent verification, or call mutation, backup, maintenance,
-configuration, or general API endpoints.
+search, immutable-version, provenance, audit-status, audit-history,
+background-job, and verified-download preparation used by this interface.
+Download preparation may write only owner-private temporary bytes and issue
+one exact, expiring file ticket; it cannot mutate document authority. The
+session cannot enroll audit scopes, run independent verification, or call
+mutation, backup, maintenance, configuration, or general API endpoints.
 
 The lock button revokes the session in daemon memory and clears the page.
 Every remaining browser session and its dedicated browser origin disappear

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -25,6 +25,7 @@
     type SortDirection,
   } from "@kenn-io/kit-ui";
   import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
+  import DownloadButton from "./DownloadButton.svelte";
   import JobsDrawer from "./JobsDrawer.svelte";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import VersionHistoryDrawer from "./VersionHistoryDrawer.svelte";
@@ -508,6 +509,13 @@
             </dl>
             {#if selected.node.kind === "file"}
               <div class="document-actions">
+                {#key selected.node.id}
+                  <DownloadButton
+                    session={webSession}
+                    node={selected.node}
+                    onauthfailure={handleFailure}
+                  />
+                {/key}
                 <Button
                   size="sm"
                   tone="info"

--- a/frontend/src/DownloadButton.svelte
+++ b/frontend/src/DownloadButton.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import DownloadIcon from "@lucide/svelte/icons/download";
+  import XIcon from "@lucide/svelte/icons/x";
+  import { Button, Chip, Spinner } from "@kenn-io/kit-ui";
+  import { APIError, type Node } from "./api.js";
+  import {
+    offerPreparedDownload,
+    prepareCurrentDownload,
+    type DownloadProgress,
+  } from "./download.js";
+  import { formatBytes } from "./format.js";
+
+  let {
+    session,
+    node,
+    onauthfailure,
+  }: {
+    session: string;
+    node: Node;
+    onauthfailure: (cause: unknown) => void;
+  } = $props();
+
+  let controller = $state<AbortController | null>(null);
+  let progress = $state<DownloadProgress | null>(null);
+  let outcome = $state("");
+  let failed = $state(false);
+
+  onDestroy(() => controller?.abort());
+
+  async function download(): Promise<void> {
+    if (controller) {
+      controller.abort();
+      return;
+    }
+    const active = new AbortController();
+    controller = active;
+    progress = { received: 0, total: node.size };
+    outcome = "";
+    failed = false;
+    try {
+      const prepared = await prepareCurrentDownload(
+        session,
+        node,
+        active.signal,
+        (next) => {
+          if (controller === active) progress = next;
+        },
+      );
+      if (controller !== active) return;
+      offerPreparedDownload(prepared);
+      outcome = `Verified ${formatBytes(prepared.size)}; browser save started.`;
+    } catch (cause) {
+      if (controller !== active) return;
+      if (cause instanceof DOMException && cause.name === "AbortError") {
+        outcome = "Download cancelled; no file was published.";
+      } else if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+      } else {
+        failed = true;
+        outcome = cause instanceof Error ? cause.message : String(cause);
+      }
+    } finally {
+      if (controller === active) {
+        controller = null;
+        progress = null;
+      }
+    }
+  }
+
+  const percentage = $derived(
+    progress && progress.total > 0
+      ? Math.min(100, Math.round((progress.received * 100) / progress.total))
+      : 0,
+  );
+</script>
+
+<div class="download-control">
+  <Button
+    size="sm"
+    tone={controller ? "danger" : "info"}
+    surface={controller ? "soft" : "solid"}
+    onclick={() => void download()}
+  >
+    {#if controller}
+      <XIcon size="14" aria-hidden="true" />
+      Cancel
+    {:else}
+      <DownloadIcon size="14" aria-hidden="true" />
+      Download
+    {/if}
+  </Button>
+  {#if progress}
+    <div class="download-status" aria-live="polite">
+      <div
+        class="download-progress"
+        role="progressbar"
+        aria-label="Verifying download"
+        aria-valuemin="0"
+        aria-valuemax={progress.total}
+        aria-valuenow={progress.received}
+      >
+        <span style={`width: ${percentage}%`}></span>
+      </div>
+      <span>
+        <Spinner size={12} />
+        Verifying {formatBytes(progress.received)} / {formatBytes(progress.total)}
+      </span>
+    </div>
+  {:else if outcome}
+    <Chip size="xs" tone={failed ? "danger" : "success"} uppercase={false}>{outcome}</Chip>
+  {/if}
+</div>
+
+<style>
+  .download-control {
+    display: flex;
+    min-width: 0;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .download-status {
+    display: grid;
+    min-width: min(260px, 100%);
+    gap: 4px;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .download-status > span {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+  }
+
+  .download-progress {
+    width: 100%;
+    height: 4px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-inset);
+  }
+
+  .download-progress > span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--accent);
+    transition: width 100ms linear;
+  }
+</style>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -224,13 +224,13 @@ async function decodeProblem(response: Response): Promise<Problem> {
   }
 }
 
-export async function requestJSON<T>(
+export async function requestResponse(
   path: string,
   session: string,
   init: RequestInit = {},
-): Promise<T> {
+): Promise<Response> {
   const headers = new Headers(init.headers);
-  headers.set("Accept", "application/json");
+  if (!headers.has("Accept")) headers.set("Accept", "application/json");
   headers.set("X-Docbank-Web-Session", session);
   const response = await fetch(path, {
     ...init,
@@ -242,6 +242,15 @@ export async function requestJSON<T>(
     const detail = problem.detail || problem.title || `HTTP ${response.status}`;
     throw new APIError(detail, response.status, problem.code ?? "");
   }
+  return response;
+}
+
+export async function requestJSON<T>(
+  path: string,
+  session: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const response = await requestResponse(path, session, init);
   if (response.status === 204) return undefined as T;
   return (await response.json()) as T;
 }

--- a/frontend/src/download.test.ts
+++ b/frontend/src/download.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prepareCurrentDownload } from "./download.js";
+import type { Node } from "./api.js";
+
+const node: Node = {
+  id: 7,
+  parent_id: 2,
+  name: "quarterly-report.txt",
+  kind: "file",
+  current_version_id: "12345678-1234-4123-8123-123456789abc",
+  blob_hash: "a".repeat(64),
+  size: 25,
+  mime_type: "text/plain",
+  revision: 3,
+  created_at: "2026-07-26T12:00:00Z",
+  modified_at: "2026-07-26T12:00:00Z",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("prepareCurrentDownload", () => {
+  it("accepts monotonic progress and exact terminal authority", async () => {
+    const events = [
+      JSON.stringify({ phase: "progress", total: 25 }),
+      JSON.stringify({ phase: "progress", received: 12, total: 25 }),
+      JSON.stringify({
+        phase: "ready",
+        received: 25,
+        total: 25,
+        url: "/api/daemon/web-download/file?ticket=one-use",
+        name: node.name,
+        version_id: node.current_version_id,
+        blob_hash: node.blob_hash,
+      }),
+    ].join("\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(events + "\n", {
+          status: 200,
+          headers: { "Content-Type": "application/x-ndjson" },
+        }),
+      ),
+    );
+    const progress: number[] = [];
+
+    const prepared = await prepareCurrentDownload(
+      "browser-session",
+      node,
+      new AbortController().signal,
+      (value) => progress.push(value.received),
+    );
+
+    expect(prepared).toEqual({
+      url: "/api/daemon/web-download/file?ticket=one-use",
+      name: node.name,
+      versionID: node.current_version_id,
+      blobHash: node.blob_hash,
+      size: node.size,
+    });
+    expect(progress).toEqual([0, 12, 25]);
+    const [path, init] = vi.mocked(fetch).mock.calls[0];
+    expect(path).toBe("/api/daemon/web-download");
+    expect(init?.method).toBe("POST");
+    expect(new Headers(init?.headers).get("X-Docbank-Web-Session")).toBe(
+      "browser-session",
+    );
+  });
+
+  it("rejects a ready event that names different content", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          `${JSON.stringify({
+            phase: "ready",
+            received: 25,
+            total: 25,
+            url: "/api/daemon/web-download/file?ticket=one-use",
+            name: node.name,
+            version_id: node.current_version_id,
+            blob_hash: "b".repeat(64),
+          })}\n`,
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await expect(
+      prepareCurrentDownload(
+        "browser-session",
+        node,
+        new AbortController().signal,
+        () => undefined,
+      ),
+    ).rejects.toThrow("disagreed with the selected document");
+  });
+});

--- a/frontend/src/download.ts
+++ b/frontend/src/download.ts
@@ -1,0 +1,169 @@
+import { requestResponse, type Node } from "./api.js";
+
+export interface DownloadProgress {
+  received: number;
+  total: number;
+}
+
+export interface PreparedDownload {
+  url: string;
+  name: string;
+  versionID: string;
+  blobHash: string;
+  size: number;
+}
+
+interface DownloadEvent {
+  phase?: string;
+  received?: number;
+  total?: number;
+  url?: string;
+  name?: string;
+  version_id?: string;
+  blob_hash?: string;
+  detail?: string;
+}
+
+export async function prepareCurrentDownload(
+  session: string,
+  node: Node,
+  signal: AbortSignal,
+  onprogress: (progress: DownloadProgress) => void,
+): Promise<PreparedDownload> {
+  if (
+    node.kind !== "file" ||
+    !node.current_version_id ||
+    !node.blob_hash ||
+    node.revision < 1 ||
+    node.size < 0
+  ) {
+    throw new Error("The selected document does not have complete download authority.");
+  }
+  const response = await requestResponse("/api/daemon/web-download", session, {
+    method: "POST",
+    headers: {
+      Accept: "application/x-ndjson",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      node_id: node.id,
+      revision: node.revision,
+      version_id: node.current_version_id,
+      blob_hash: node.blob_hash,
+      size: node.size,
+    }),
+    signal,
+  });
+  if (!response.body) throw new Error("The download response did not contain a progress stream.");
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  let received = 0;
+  let ready: PreparedDownload | undefined;
+
+  try {
+    while (true) {
+      const result = await reader.read();
+      buffered += decoder.decode(result.value, { stream: !result.done });
+      if (buffered.length > 64 * 1024) {
+        throw new Error("The download progress response was unexpectedly large.");
+      }
+      const lines = buffered.split("\n");
+      buffered = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        if (ready) throw new Error("The download response continued after publication.");
+        const event = JSON.parse(line) as DownloadEvent;
+        if (event.phase === "error") {
+          throw new Error(event.detail || "Docbank could not verify this document.");
+        }
+        if (event.phase === "progress") {
+          const progress = validateProgress(event, node.size, received);
+          received = progress.received;
+          onprogress(progress);
+          continue;
+        }
+        if (event.phase === "ready") {
+          ready = validateReady(event, node);
+          onprogress({ received: ready.size, total: ready.size });
+          continue;
+        }
+        throw new Error("The download response contained an unknown progress event.");
+      }
+      if (result.done) break;
+    }
+    if (buffered.trim()) {
+      const event = JSON.parse(buffered) as DownloadEvent;
+      if (event.phase !== "ready" || ready) {
+        throw new Error("The download response ended with an invalid progress event.");
+      }
+      ready = validateReady(event, node);
+      onprogress({ received: ready.size, total: ready.size });
+    }
+  } catch (cause) {
+    await reader.cancel().catch(() => undefined);
+    throw cause;
+  }
+  if (!ready) throw new Error("The download ended before Docbank published verified bytes.");
+  return ready;
+}
+
+function validateProgress(
+  event: DownloadEvent,
+  expectedTotal: number,
+  previous: number,
+): DownloadProgress {
+  const received = event.received ?? 0;
+  const total = event.total;
+  if (
+    !Number.isSafeInteger(received) ||
+    !Number.isSafeInteger(total) ||
+    total !== expectedTotal ||
+    received < previous ||
+    received < 0 ||
+    received > total
+  ) {
+    throw new Error("The download progress disagreed with document authority.");
+  }
+  return { received, total };
+}
+
+function validateReady(event: DownloadEvent, node: Node): PreparedDownload {
+  const name = event.name;
+  const versionID = event.version_id;
+  const blobHash = event.blob_hash;
+  const url = event.url;
+  if (
+    (event.received ?? 0) !== node.size ||
+    event.total !== node.size ||
+    typeof name !== "string" ||
+    typeof versionID !== "string" ||
+    typeof blobHash !== "string" ||
+    typeof url !== "string" ||
+    name !== node.name ||
+    versionID !== node.current_version_id ||
+    blobHash !== node.blob_hash ||
+    !url?.startsWith("/api/daemon/web-download/file?ticket=")
+  ) {
+    throw new Error("The verified download disagreed with the selected document.");
+  }
+  return {
+    url,
+    name,
+    versionID,
+    blobHash,
+    size: event.total,
+  };
+}
+
+export function offerPreparedDownload(download: PreparedDownload): void {
+  const link = document.createElement("a");
+  link.href = download.url;
+  link.download = download.name;
+  link.rel = "noreferrer";
+  link.hidden = true;
+  document.body.append(link);
+  link.click();
+  link.remove();
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -27,7 +27,8 @@ func timeoutExempt(path string) bool {
 		"/api/v1/storage/pack", "/api/v1/storage/repack", "/api/v1/uploads",
 		"/api/v1/backup/snapshots", "/api/v1/backup/snapshots/stream",
 		"/api/v1/backup/verify", "/api/v1/backup/verify/stream",
-		"/api/v1/backup/restore", "/api/v1/backup/restore/stream":
+		"/api/v1/backup/restore", "/api/v1/backup/restore/stream",
+		webDownloadPreparePath, webDownloadFilePath:
 		return true
 	}
 	if strings.HasPrefix(path, "/api/v1/nodes/") &&
@@ -63,7 +64,7 @@ func clearLongRunningBodyReadDeadlines(api huma.API) {
 // the daemon always has one; see NewServer.
 func authExempt(path string) bool {
 	switch path {
-	case "/", "/health", kitPingPath, daemonauth.ChallengePath:
+	case "/", "/health", kitPingPath, daemonauth.ChallengePath, webDownloadFilePath:
 		return true
 	}
 	return strings.HasPrefix(path, "/docs") ||
@@ -162,6 +163,9 @@ func jsonBodyTextMiddleware(next http.Handler) http.Handler {
 
 func isOpaqueBodyMutation(r *http.Request) bool {
 	if r.Method == http.MethodPost && r.URL.Path == "/api/v1/uploads" {
+		return true
+	}
+	if r.Method == http.MethodPost && r.URL.Path == webDownloadPreparePath {
 		return true
 	}
 	return r.Method == http.MethodPut &&

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -63,6 +63,7 @@ type Server struct {
 	api           huma.API
 	auditPreviews *auditPreviewRegistry
 	webSessions   *webSessionRegistry
+	webDownloads  *webDownloadRegistry
 }
 
 // NewServer wires all routes and middleware onto a fresh mux. The handler
@@ -103,7 +104,7 @@ func NewServer(d Deps) *Server {
 	humaAPI := humago.New(mux, cfg)
 	s := &Server{
 		deps: d, api: humaAPI, auditPreviews: newAuditPreviewRegistry(),
-		webSessions: newWebSessionRegistry(),
+		webSessions: newWebSessionRegistry(), webDownloads: newWebDownloadRegistry(d.VaultRoot),
 	}
 	g := d.Gate
 	if g == nil {
@@ -134,6 +135,7 @@ func NewServer(d Deps) *Server {
 	s.registerShutdown(mux)
 	registerWeb(mux, d.Cfg.Web.Enabled)
 	registerWebSession(mux, d.Cfg.Web.Enabled, d.WebURL, s.webSessions)
+	registerWebDownload(mux, d.Cfg.Web.Enabled, d, s.webDownloads)
 
 	h := http.Handler(mux)
 	// Authenticate and enforce route topology before buffering small JSON

--- a/internal/api/web_download.go
+++ b/internal/api/web_download.go
@@ -1,0 +1,391 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.kenn.io/kit/safefileio"
+)
+
+const (
+	webDownloadPreparePath = "/api/daemon/web-download"
+	webDownloadFilePath    = "/api/daemon/web-download/file"
+	webDownloadTicketTTL   = 2 * time.Minute
+)
+
+type webDownloadRegistry struct {
+	mu       sync.Mutex
+	dir      string
+	initOnce sync.Once
+	initErr  error
+	tickets  map[[sha256.Size]byte]webDownloadTicket
+}
+
+type webDownloadTicket struct {
+	path      string
+	name      string
+	mediaType string
+	versionID string
+	blobHash  string
+	size      int64
+	expiresAt time.Time
+	timer     *time.Timer
+}
+
+type webDownloadRequest struct {
+	NodeID    int64  `json:"node_id"`
+	Revision  int64  `json:"revision"`
+	VersionID string `json:"version_id"`
+	BlobHash  string `json:"blob_hash"`
+	Size      int64  `json:"size"`
+}
+
+type webDownloadEvent struct {
+	Phase     string `json:"phase"`
+	Received  int64  `json:"received"`
+	Total     int64  `json:"total"`
+	URL       string `json:"url,omitempty"`
+	Name      string `json:"name,omitempty"`
+	VersionID string `json:"version_id,omitempty"`
+	BlobHash  string `json:"blob_hash,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+}
+
+func newWebDownloadRegistry(vaultRoot string) *webDownloadRegistry {
+	return &webDownloadRegistry{
+		dir:     filepath.Join(vaultRoot, "web-downloads"),
+		tickets: make(map[[sha256.Size]byte]webDownloadTicket),
+	}
+}
+
+func (r *webDownloadRegistry) createStagingFile() (*os.File, string, error) {
+	r.initOnce.Do(func() {
+		if err := os.RemoveAll(r.dir); err != nil {
+			r.initErr = fmt.Errorf("removing abandoned web downloads: %w", err)
+			return
+		}
+		if err := safefileio.EnsurePrivateDir(r.dir); err != nil {
+			r.initErr = fmt.Errorf("securing web download staging: %w", err)
+		}
+	})
+	if r.initErr != nil {
+		return nil, "", r.initErr
+	}
+	file, err := os.CreateTemp(r.dir, ".download-*")
+	if err != nil {
+		return nil, "", fmt.Errorf("creating web download staging file: %w", err)
+	}
+	return file, file.Name(), nil
+}
+
+func (r *webDownloadRegistry) issue(ticket webDownloadTicket) (string, error) {
+	for range 10 {
+		var raw [32]byte
+		if _, err := rand.Read(raw[:]); err != nil {
+			return "", fmt.Errorf("generating web download ticket: %w", err)
+		}
+		token := base64.RawURLEncoding.EncodeToString(raw[:])
+		key := sha256.Sum256([]byte(token))
+
+		r.mu.Lock()
+		if _, exists := r.tickets[key]; exists {
+			r.mu.Unlock()
+			continue
+		}
+		ticket.expiresAt = time.Now().Add(webDownloadTicketTTL)
+		ticket.timer = time.AfterFunc(webDownloadTicketTTL, func() {
+			r.expire(key)
+		})
+		r.tickets[key] = ticket
+		r.mu.Unlock()
+		return token, nil
+	}
+	return "", errors.New("generating web download ticket: repeated collisions")
+}
+
+func (r *webDownloadRegistry) consume(token string) (webDownloadTicket, bool) {
+	key := sha256.Sum256([]byte(token))
+	r.mu.Lock()
+	ticket, ok := r.tickets[key]
+	if ok {
+		delete(r.tickets, key)
+	}
+	r.mu.Unlock()
+	if !ok {
+		return webDownloadTicket{}, false
+	}
+	ticket.timer.Stop()
+	if time.Now().After(ticket.expiresAt) {
+		_ = os.Remove(ticket.path)
+		return webDownloadTicket{}, false
+	}
+	return ticket, true
+}
+
+func (r *webDownloadRegistry) expire(key [sha256.Size]byte) {
+	r.mu.Lock()
+	ticket, ok := r.tickets[key]
+	if ok {
+		delete(r.tickets, key)
+	}
+	r.mu.Unlock()
+	if ok {
+		_ = os.Remove(ticket.path)
+	}
+}
+
+func registerWebDownload(
+	mux *http.ServeMux,
+	enabled bool,
+	d Deps,
+	downloads *webDownloadRegistry,
+) {
+	mux.HandleFunc("POST "+webDownloadPreparePath, func(w http.ResponseWriter, r *http.Request) {
+		if !enabled || d.WebURL == "" {
+			writeError(w, NewError(http.StatusServiceUnavailable, "web_unavailable",
+				"this daemon is not serving the compiled web application"))
+			return
+		}
+		request, decodeErr := decodeWebDownloadRequest(w, r)
+		if decodeErr != nil {
+			writeError(w, decodeErr)
+			return
+		}
+		view, err := d.Store.NodeViewByID(r.Context(), request.NodeID)
+		if err != nil {
+			writeError(w, webDownloadProblem(err))
+			return
+		}
+		node := view.Node
+		if node.IsDir() {
+			writeError(w, NewError(http.StatusUnprocessableEntity, "not_file",
+				fmt.Sprintf("node %d is a directory", node.ID)))
+			return
+		}
+		if node.TrashedAt != nil {
+			writeError(w, NewError(http.StatusNotFound, "not_found",
+				fmt.Sprintf("node %d is not live", node.ID)))
+			return
+		}
+		if node.Revision != request.Revision ||
+			node.CurrentVersionID != request.VersionID ||
+			node.BlobHash != request.BlobHash ||
+			node.Size != request.Size {
+			writeError(w, NewError(http.StatusConflict, "download_selection_stale",
+				"the selected document changed; refresh it before downloading"))
+			return
+		}
+
+		stream, streamSize, err := d.Blobs.OpenStreamContext(r.Context(), node.BlobHash)
+		if err != nil {
+			writeError(w, NewError(http.StatusInternalServerError, "internal",
+				"opening document content failed; run docbank verify"))
+			return
+		}
+		if streamSize != node.Size {
+			_ = stream.Close()
+			writeError(w, NewError(http.StatusInternalServerError, "internal",
+				"document size authority is inconsistent; run docbank verify"))
+			return
+		}
+
+		file, stagedPath, err := downloads.createStagingFile()
+		if err != nil {
+			_ = stream.Close()
+			writeError(w, NewError(http.StatusInternalServerError, "internal",
+				"creating private download staging failed"))
+			return
+		}
+		keepStaged := false
+		defer func() {
+			if !keepStaged {
+				_ = os.Remove(stagedPath)
+			}
+		}()
+
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusOK)
+		encoder := json.NewEncoder(w)
+		flusher, _ := w.(http.Flusher)
+		report := func(event webDownloadEvent) error {
+			if err := encoder.Encode(event); err != nil {
+				return err
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return nil
+		}
+		if err := report(webDownloadEvent{Phase: "progress", Total: node.Size}); err != nil {
+			_ = file.Close()
+			_ = stream.Close()
+			return
+		}
+
+		progress := &webDownloadProgressWriter{
+			ctx: r.Context(), dst: file, total: node.Size, report: report,
+		}
+		_, copyErr := io.CopyBuffer(progress, stream, make([]byte, 256<<10))
+		closeStreamErr := stream.Close()
+		closeFileErr := file.Close()
+		if err := errors.Join(copyErr, closeStreamErr, closeFileErr); err != nil ||
+			!stream.Verified() || progress.written != node.Size {
+			_ = report(webDownloadEvent{
+				Phase: "error", Total: node.Size,
+				Detail: "Docbank could not verify the complete document; run docbank verify",
+			})
+			return
+		}
+
+		ticket := webDownloadTicket{
+			path: stagedPath, name: node.Name, mediaType: node.MimeType,
+			versionID: node.CurrentVersionID, blobHash: node.BlobHash, size: node.Size,
+		}
+		token, err := downloads.issue(ticket)
+		if err != nil {
+			_ = report(webDownloadEvent{
+				Phase: "error", Total: node.Size,
+				Detail: "Docbank could not publish the verified browser download",
+			})
+			return
+		}
+		keepStaged = true
+		_ = report(webDownloadEvent{
+			Phase: "ready", Received: node.Size, Total: node.Size,
+			URL:  webDownloadFilePath + "?ticket=" + token,
+			Name: node.Name, VersionID: node.CurrentVersionID, BlobHash: node.BlobHash,
+		})
+	})
+
+	mux.HandleFunc("GET "+webDownloadFilePath, func(w http.ResponseWriter, r *http.Request) {
+		ticket, ok := downloads.consume(r.URL.Query().Get("ticket"))
+		if !ok {
+			writeError(w, NewError(http.StatusNotFound, "download_not_found",
+				"the browser download is missing, expired, or already used"))
+			return
+		}
+		defer func() { _ = os.Remove(ticket.path) }()
+
+		file, err := os.Open(ticket.path)
+		if err != nil {
+			writeError(w, NewError(http.StatusGone, "download_unavailable",
+				"the verified browser download is no longer available"))
+			return
+		}
+		defer func() { _ = file.Close() }()
+		info, err := file.Stat()
+		if err != nil || !info.Mode().IsRegular() || info.Size() != ticket.size {
+			writeError(w, NewError(http.StatusGone, "download_unavailable",
+				"the verified browser download is no longer available"))
+			return
+		}
+
+		mediaType := ticket.mediaType
+		if mediaType == "" {
+			mediaType = "application/octet-stream"
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Content-Disposition",
+			mime.FormatMediaType("attachment", map[string]string{"filename": ticket.name}))
+		w.Header().Set("Content-Type", mediaType)
+		w.Header().Set("Content-Length", strconv.FormatInt(ticket.size, 10))
+		w.Header().Set("Content-Digest", contentDigest(mustDecodeHash(ticket.blobHash)))
+		w.Header().Set(ContentVersionHeader, ticket.versionID)
+		w.Header().Set(BlobHashHeader, ticket.blobHash)
+		w.Header().Set(BlobSizeHeader, strconv.FormatInt(ticket.size, 10))
+		w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, bufio.NewReaderSize(file, 256<<10))
+	})
+}
+
+func decodeWebDownloadRequest(w http.ResponseWriter, r *http.Request) (webDownloadRequest, *Error) {
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	var request webDownloadRequest
+	if err := decoder.Decode(&request); err != nil {
+		return webDownloadRequest{}, NewError(http.StatusBadRequest, "validation",
+			"download request must be one JSON object with known fields")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return webDownloadRequest{}, NewError(http.StatusBadRequest, "validation",
+			"download request must contain exactly one JSON object")
+	}
+	if request.NodeID < 1 || request.Revision < 1 || request.Size < 0 ||
+		request.VersionID == "" || len(request.BlobHash) != 64 {
+		return webDownloadRequest{}, NewError(http.StatusUnprocessableEntity, "validation",
+			"download request has invalid document authority")
+	}
+	if _, err := hex.DecodeString(request.BlobHash); err != nil {
+		return webDownloadRequest{}, NewError(http.StatusUnprocessableEntity, "validation",
+			"download request has invalid document authority")
+	}
+	return request, nil
+}
+
+type webDownloadProgressWriter struct {
+	ctx        context.Context
+	dst        io.Writer
+	total      int64
+	written    int64
+	lastReport time.Time
+	report     func(webDownloadEvent) error
+}
+
+func (w *webDownloadProgressWriter) Write(p []byte) (int, error) {
+	if err := w.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := w.dst.Write(p)
+	w.written += int64(n)
+	if err != nil {
+		return n, err
+	}
+	now := time.Now()
+	if w.written == w.total || w.lastReport.IsZero() ||
+		now.Sub(w.lastReport) >= 100*time.Millisecond {
+		w.lastReport = now
+		if err := w.report(webDownloadEvent{
+			Phase: "progress", Received: w.written, Total: w.total,
+		}); err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+func mustDecodeHash(hash string) []byte {
+	decoded, err := hex.DecodeString(hash)
+	if err != nil {
+		panic("validated blob hash became invalid")
+	}
+	return decoded
+}
+
+func webDownloadProblem(err error) *Error {
+	var problem *Error
+	if errors.As(FromStoreError(err), &problem) {
+		return problem
+	}
+	return NewError(http.StatusInternalServerError, "internal", err.Error())
+}

--- a/internal/api/web_download_test.go
+++ b/internal/api/web_download_test.go
@@ -1,0 +1,154 @@
+package api_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestWebDownloadVerifiesBeforeOneUseBrowserHandoff(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	const content = "synthetic quarterly report\n"
+	document := createFileWithContent(t, ts, s, "/quarterly-report.txt", content)
+
+	sessionRequest, err := http.NewRequest(
+		http.MethodPost, ts.URL+"/api/daemon/web-session", nil,
+	)
+	require.NoError(t, err)
+	sessionResponse, err := ts.Client().Do(sessionRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, sessionResponse.StatusCode)
+	var session struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.NewDecoder(sessionResponse.Body).Decode(&session))
+	require.NoError(t, sessionResponse.Body.Close())
+
+	requestBody, err := json.Marshal(map[string]any{
+		"node_id": document.ID, "revision": document.Revision,
+		"version_id": document.CurrentVersionID, "blob_hash": document.BlobHash,
+		"size": document.Size,
+	})
+	require.NoError(t, err)
+	prepareRequest, err := http.NewRequest(
+		http.MethodPost, ts.URL+"/api/daemon/web-download", bytes.NewReader(requestBody),
+	)
+	require.NoError(t, err)
+	prepareRequest.Header["X-Api-Key"] = []string{""}
+	prepareRequest.Header.Set(api.WebSessionHeader, session.Token)
+	prepareRequest.Header.Set("Content-Type", "application/json")
+	prepareResponse, err := ts.Client().Do(prepareRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, prepareResponse.StatusCode)
+	assert.Equal(t, "application/x-ndjson", prepareResponse.Header.Get("Content-Type"))
+
+	var events []struct {
+		Phase     string `json:"phase"`
+		Received  int64  `json:"received"`
+		Total     int64  `json:"total"`
+		URL       string `json:"url"`
+		Name      string `json:"name"`
+		VersionID string `json:"version_id"`
+		BlobHash  string `json:"blob_hash"`
+	}
+	decoder := json.NewDecoder(prepareResponse.Body)
+	for {
+		var event struct {
+			Phase     string `json:"phase"`
+			Received  int64  `json:"received"`
+			Total     int64  `json:"total"`
+			URL       string `json:"url"`
+			Name      string `json:"name"`
+			VersionID string `json:"version_id"`
+			BlobHash  string `json:"blob_hash"`
+		}
+		err := decoder.Decode(&event)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		events = append(events, event)
+	}
+	require.NoError(t, prepareResponse.Body.Close())
+	require.GreaterOrEqual(t, len(events), 2)
+	assert.Equal(t, "progress", events[0].Phase)
+	ready := events[len(events)-1]
+	assert.Equal(t, "ready", ready.Phase)
+	assert.Equal(t, document.Size, ready.Received)
+	assert.Equal(t, document.Size, ready.Total)
+	assert.Equal(t, document.Name, ready.Name)
+	assert.Equal(t, document.CurrentVersionID, ready.VersionID)
+	assert.Equal(t, document.BlobHash, ready.BlobHash)
+	require.Contains(t, ready.URL, "?ticket=")
+
+	downloadRequest, err := http.NewRequest(http.MethodGet, ts.URL+ready.URL, nil)
+	require.NoError(t, err)
+	downloadRequest.Header["X-Api-Key"] = []string{""}
+	downloadResponse, err := ts.Client().Do(downloadRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, downloadResponse.StatusCode)
+	downloaded, err := io.ReadAll(downloadResponse.Body)
+	require.NoError(t, err)
+	require.NoError(t, downloadResponse.Body.Close())
+	assert.Equal(t, content, string(downloaded))
+	assert.Equal(t, strconv.FormatInt(document.Size, 10),
+		downloadResponse.Header.Get("Content-Length"))
+	assert.Equal(t, document.CurrentVersionID,
+		downloadResponse.Header.Get(api.ContentVersionHeader))
+	assert.Equal(t, document.BlobHash, downloadResponse.Header.Get(api.BlobHashHeader))
+	sum := sha256.Sum256([]byte(content))
+	assert.Equal(t, "sha-256=:"+base64.StdEncoding.EncodeToString(sum[:])+":",
+		downloadResponse.Header.Get("Content-Digest"))
+	disposition, params, err := mime.ParseMediaType(
+		downloadResponse.Header.Get("Content-Disposition"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "attachment", disposition)
+	assert.Equal(t, document.Name, params["filename"])
+
+	reusedRequest, err := http.NewRequest(http.MethodGet, ts.URL+ready.URL, nil)
+	require.NoError(t, err)
+	reusedRequest.Header["X-Api-Key"] = []string{""}
+	reusedResponse, err := ts.Client().Do(reusedRequest)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, reusedResponse.StatusCode)
+	require.NoError(t, reusedResponse.Body.Close())
+}
+
+func TestWebDownloadRejectsAStaleSelectionBeforeStaging(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	document := createFileWithContent(t, ts, s, "/report.txt", "report")
+
+	requestBody, err := json.Marshal(map[string]any{
+		"node_id": document.ID, "revision": document.Revision + 1,
+		"version_id": document.CurrentVersionID, "blob_hash": document.BlobHash,
+		"size": document.Size,
+	})
+	require.NoError(t, err)
+	request, err := http.NewRequest(
+		http.MethodPost, ts.URL+"/api/daemon/web-download", bytes.NewReader(requestBody),
+	)
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := ts.Client().Do(request)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, response.StatusCode)
+	var problem struct {
+		Code string `json:"code"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&problem))
+	require.NoError(t, response.Body.Close())
+	assert.Equal(t, "download_selection_stale", problem.Code)
+}

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -57,6 +57,9 @@ func (r *webSessionRegistry) revoke(token string) {
 }
 
 func webSessionRequestAllowed(method, path string) bool {
+	if method == http.MethodPost && path == webDownloadPreparePath {
+		return true
+	}
 	if method == http.MethodDelete && path == webSessionPath {
 		return true
 	}

--- a/internal/backupapp/app.go
+++ b/internal/backupapp/app.go
@@ -114,7 +114,7 @@ func (a *App) Version() string           { return a.version }
 func (a *App) ExcludedPaths() []string {
 	return []string{
 		"config.toml", "logs/", "vault.lock", "launch.lock", "daemon.*.json",
-		"web-launch/", "blobs/tmp/",
+		"web-launch/", "web-downloads/", "blobs/tmp/",
 	}
 }
 

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "43"
+	daemonProtocolVersion = "44"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
People can now retrieve a selected document from Docbank’s primary web interface without giving the browser the vault API key or asking it to buffer a large object in memory.

Clicking **Download** shows byte progress while the daemon copies the exact selected version from loose or packed storage into owner-private temporary staging. The node revision, version UUID, SHA-256 identity, and size are bound to the request. Only a complete stream that reaches verified EOF receives a short-lived, one-use browser handoff; cancellation and verification failure publish nothing.

![The actual Docbank web application after verifying a synthetic report for download](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-verified-download/web-verified-download.png)

*Actual rendered interface using a temporary synthetic vault; no private corpus data is present.*

The success message deliberately says that browser saving has started. It does not claim that the browser or operating system durably published the final destination. Agents and scripts that need that stronger receipt should continue using `docbank get`.

This first slice is limited to the current version of a live file. Historical-version downloads and comparison remain separate workflows. Preparation needs temporary local space equal to the document’s logical size, and abandoned browser handoffs expire after two minutes.

I exercised the rendered flow end to end against a synthetic vault and confirmed that the native browser download was byte-identical with the selected document and its SHA-256 authority.
