### PR TITLE
Inspect and filter tags in the web app

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -105,16 +105,16 @@ Key assumptions reviewers MUST account for:
    archive verification or make the served copy diverge from
    scripts/.
 
-12. DOCS DESCRIBE MAIN: user-facing pages document the capabilities of
-   main, which may be newer than the newest tagged release. A
-   capability that is not yet in a tagged release must carry a release
-   qualifier where users would act on it (homepage, setup). Flagging
-   an unqualified unreleased capability is correct; demanding the
-   capability's documentation be removed entirely is not. The public
-   Zensical site is published only after the corresponding release tag
-   exists; do not require source documentation for merged next-release
-   work to be withheld from main merely because that site publication
-   has not happened yet.
+12. DOCS ARE THE NEXT RELEASE SNAPSHOT: user-facing sources on main
+   describe every merged capability directly in present tense, including
+   homepage and install-adjacent copy. The public Zensical site is
+   published only from release tags, so readers cannot encounter that
+   source snapshot through docbank.ai until the corresponding binary is
+   released. Do not demand "next release", source-build-only, or newest-tag
+   qualifiers for merged capabilities; AGENTS.md explicitly forbids them.
+   DO flag release preparation that would tag documentation for behavior
+   absent from the same tag, or documentation that claims behavior absent
+   from main.
 
 Do NOT flag issues that only apply to public-facing, multi-tenant, or
 internet-exposed services. Focus on bugs, logic errors, data corruption

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Four commitments:
 - A read-only daemon-backed TUI for analytical tree browsing, search, stable
   document/version identity inspection, and permanent audited-history timelines
 - A read-only kit-ui web application for virtual-tree browsing, sortable
-  document analysis, extracted-text search, complete current authority,
+  document analysis, tag-filtered extracted-text search, complete current authority,
   verified current-content download, permanent protection and event history,
   immutable versions and provenance, and daemon background-job status
 - Mixed loose and packed content storage with explicit pack, GC, and repack,

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "45", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "46", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "45", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "46", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "45", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "46", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "45", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "46", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "44", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "45", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "44", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "45", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "44", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "45", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "44", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "45", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,8 @@ incremental backups can be verified before you rely on them. Work directly
 from the CLI, automate through the authenticated HTTP API, or embed Docbank in
 a Go application. People can browse the same authority in the local web
 application or focused terminal interface; the web application verifies
-current document bytes before handing them to the browser's native save.
+current document bytes before handing them to the browser's native save and
+keeps tag organization visible alongside document authority.
 
 Install the latest release on Linux or macOS:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web version history, provenance, and verified current-content download implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web tags, version history, provenance, and verified current-content download implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -144,11 +144,12 @@ before a one-use browser handoff, and the browser never buffers the whole
 object or receives the vault API key. Every file exposes its newest-first immutable
 version history and complete version, hash, operation, and revert-source
 authority, plus its newest-first immutable provenance facts and supersession
-history. Protected nodes also expose their permanent newest-first audit timeline
+history. Every selected node exposes its tag assignments, and text search can
+require one stable tag identity. Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
 portal also reports current and terminal daemon background jobs. Future slices
-cover import, tags and broader metadata, historical content download and
-comparison, trash, storage, and backup.
+cover import, tag mutation and broader metadata, historical content download
+and comparison, trash, storage, and backup.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -16,8 +16,10 @@ opens its local web application. It is a read-only document browser: navigate
 the virtual tree, sort a folder by document name, size, or modification time,
 search names and extracted text, and inspect the selected document's stable
 node ID, revision, current version ID, SHA-256 identity, exact size, and media
-type. Protected documents also expose their newest-first permanent audit
-timeline and complete event authority. The activity button reports the
+type. The authority card also shows every tag assigned to the selected file or
+folder, while search can require one exact tag. Protected documents expose
+their newest-first permanent audit timeline and complete event authority. The
+activity button reports the
 daemon's supervised extraction, watched-inbox, and automatic-packing jobs.
 Every file also exposes its retained immutable content versions and the stable
 authority behind each one, plus the immutable provenance Docbank recorded when
@@ -51,7 +53,10 @@ The browser selects the first row after loading a folder. A selected directory
 shows its path, revision, and modification time. A selected file additionally
 shows its exact logical size, media type, immutable current-version UUID, and
 SHA-256 content identity. The copy buttons copy the complete UUID or digest
-even when the card wraps it across lines.
+even when the card wraps it across lines. Every selected node also shows its
+assigned tag names. Hovering a tag shows its stable UUID and vault-wide
+assignment count; the bounded tag stack expands in place when a node carries
+more than six.
 
 ## Download verified current content
 
@@ -130,15 +135,23 @@ live document name or verified extracted text. The **Match** column identifies
 which one. Name matches retain their API relevance ranking and appear before
 content-only matches until you choose an explicit column sort.
 
+Use the tag selector in the browser toolbar to require one exact assignment
+for the search. Tag names are displayed for people, while the request is bound
+to the tag's stable UUID so a later rename does not silently change which
+definition was selected. Changing the selector reruns an active search. A text
+query remains required; choosing a tag does not turn the current folder into a
+tag-only listing.
+
 ![The Docbank web application showing extracted-text search results in a synthetic vault.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/v0.11.0/web-search-results.png)
 
 *Search results display complete virtual paths and keep the same authority
 inspection available from ordinary folder browsing.*
 
-Clear the search box to return to the current directory. The web application
-searches names and extracted text only; use `docbank search` when you need the
-directory, tag, media-type, or modification-time filters, structured JSON, or
-another result limit.
+Clear the search box to return to the current directory. The selector loads at
+most the first 1,000 name-sorted tag definitions and discloses when more exist.
+Use `docbank search` when you need an exhaustive tag catalog, directory,
+media-type, or modification-time filters, structured JSON, or another result
+limit.
 
 ## Read permanent audited history
 
@@ -195,7 +208,7 @@ The launch page carries only the read-only session in a URL fragment. Browsers
 do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
-search, immutable-version, provenance, audit-status, audit-history,
+search, tag-definition and assignment reads, immutable-version, provenance, audit-status, audit-history,
 background-job, and verified-download preparation used by this interface.
 Download preparation may write only owner-private temporary bytes and issue
 one exact, expiring file ticket; it cannot mutate document authority. The
@@ -233,8 +246,9 @@ children in one metadata snapshot, so a concurrent CLI or agent move cannot
 leave the browser constructing child paths beneath an obsolete name.
 
 The current web application does not download historical content, compare
-versions, import, edit, revert, prune, move, tag, trash, enroll audit scopes,
-run independent audit verification, or run maintenance and backup operations.
+versions, import, edit, revert, prune, move, create or change tags and
+assignments, trash, enroll audit scopes, run independent audit verification,
+or run maintenance and backup operations.
 Use the corresponding CLI or authenticated HTTP endpoint for those workflows.
 Future web workflows will require deliberately expanded browser-session
 permissions rather than inheriting the master API key.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -593,159 +593,167 @@
         {#if selected}
           <Card
             level="raised"
-            eyebrow={selected.node.kind === "dir" ? "FOLDER" : "DOCUMENT AUTHORITY"}
-            title={basename(selected.path)}
-            meta={`id:${selected.node.id}`}
+            padding="sm"
+            ariaLabel={`${selected.node.kind === "dir" ? "Folder" : "Document authority"} for ${basename(selected.path)}`}
           >
-            <dl>
-              <div><dt>Path</dt><dd>{selected.path}</dd></div>
-              <div><dt>Revision</dt><dd>{selected.node.revision}</dd></div>
-              <div><dt>Modified</dt><dd>{formatDate(selected.node.modified_at)}</dd></div>
+            <div class="authority-content">
+              <header class="authority-header">
+                <div>
+                  <span>{selected.node.kind === "dir" ? "Folder" : "Document authority"}</span>
+                  <Chip size="xs" tone="muted" uppercase={false}>id:{selected.node.id}</Chip>
+                </div>
+                <h2>{basename(selected.path)}</h2>
+              </header>
+              <dl>
+                <div class="wide-fact"><dt>Path</dt><dd>{selected.path}</dd></div>
+                <div><dt>Revision</dt><dd>{selected.node.revision}</dd></div>
+                <div><dt>Modified</dt><dd>{formatDate(selected.node.modified_at)}</dd></div>
+                {#if selected.node.kind === "file"}
+                  <div><dt>Size</dt><dd>{formatBytes(selected.node.size)} ({selected.node.size} bytes)</dd></div>
+                  <div><dt>Media type</dt><dd>{selected.node.mime_type || "application/octet-stream"}</dd></div>
+                  <div class="identity">
+                    <dt>Version</dt>
+                    <dd>
+                      <code>{selected.node.current_version_id}</code>
+                      {#if selected.node.current_version_id}
+                        <CopyButton text={selected.node.current_version_id} ariaLabel="Copy version ID" />
+                      {/if}
+                    </dd>
+                  </div>
+                  <div class="identity">
+                    <dt>SHA-256</dt>
+                    <dd>
+                      <code>{selected.node.blob_hash}</code>
+                      {#if selected.node.blob_hash}
+                        <CopyButton text={selected.node.blob_hash} ariaLabel="Copy SHA-256" />
+                      {/if}
+                    </dd>
+                  </div>
+                {/if}
+              </dl>
+              <div class="node-tags">
+                <div class="node-tags-heading">
+                  <span><TagIcon size="13" aria-hidden="true" /> Tags</span>
+                  {#if selectedTagsLoading}
+                    <Spinner size={13} />
+                  {:else if selectedTagsError}
+                    <Chip size="xs" tone="warning">Unavailable</Chip>
+                  {:else}
+                    <span>{selectedTags.length} assigned</span>
+                  {/if}
+                </div>
+                {#if selectedTagsError}
+                  <p>{selectedTagsError}</p>
+                {:else if !selectedTagsLoading && selectedTags.length === 0}
+                  <p>No tags are assigned to this node.</p>
+                {:else if selectedTags.length > 0}
+                  <ChipStack
+                    items={selectedTags}
+                    key={(tag) => tag.id}
+                    maxVisible={6}
+                    size="sm"
+                    ariaLabel="Assigned tags"
+                  >
+                    {#snippet chip(tag)}
+                      <Chip
+                        size="sm"
+                        tone="workspace"
+                        uppercase={false}
+                        title={`${tag.assignment_count} total assignment${tag.assignment_count === 1 ? "" : "s"} · ${tag.id}`}
+                      >
+                        {tag.name}
+                      </Chip>
+                    {/snippet}
+                  </ChipStack>
+                {/if}
+              </div>
               {#if selected.node.kind === "file"}
-                <div><dt>Size</dt><dd>{formatBytes(selected.node.size)} ({selected.node.size} bytes)</dd></div>
-                <div><dt>Media type</dt><dd>{selected.node.mime_type || "application/octet-stream"}</dd></div>
-                <div class="identity">
-                  <dt>Version</dt>
-                  <dd>
-                    <code>{selected.node.current_version_id}</code>
-                    {#if selected.node.current_version_id}
-                      <CopyButton text={selected.node.current_version_id} ariaLabel="Copy version ID" />
-                    {/if}
-                  </dd>
-                </div>
-                <div class="identity">
-                  <dt>SHA-256</dt>
-                  <dd>
-                    <code>{selected.node.blob_hash}</code>
-                    {#if selected.node.blob_hash}
-                      <CopyButton text={selected.node.blob_hash} ariaLabel="Copy SHA-256" />
-                    {/if}
-                  </dd>
+                <div class="document-actions">
+                  {#key selected.node.id}
+                    <DownloadButton
+                      session={webSession}
+                      node={selected.node}
+                      onauthfailure={handleFailure}
+                    />
+                  {/key}
+                  <Button
+                    size="sm"
+                    tone="info"
+                    surface="soft"
+                    onclick={() => {
+                      historyOpen = false;
+                      provenanceOpen = false;
+                      jobsOpen = false;
+                      versionsOpen = true;
+                    }}
+                  >
+                    <HistoryIcon size="14" aria-hidden="true" />
+                    Version history
+                  </Button>
+                  <Button
+                    size="sm"
+                    surface="soft"
+                    onclick={() => {
+                      historyOpen = false;
+                      versionsOpen = false;
+                      jobsOpen = false;
+                      provenanceOpen = true;
+                    }}
+                  >
+                    <MapPinIcon size="14" aria-hidden="true" />
+                    Provenance
+                  </Button>
                 </div>
               {/if}
-            </dl>
-            <div class="node-tags">
-              <div class="node-tags-heading">
-                <span><TagIcon size="13" aria-hidden="true" /> Tags</span>
-                {#if selectedTagsLoading}
-                  <Spinner size={13} />
-                {:else if selectedTagsError}
-                  <Chip size="xs" tone="warning">Unavailable</Chip>
-                {:else}
-                  <span>{selectedTags.length}</span>
-                {/if}
-              </div>
-              {#if selectedTagsError}
-                <p>{selectedTagsError}</p>
-              {:else if !selectedTagsLoading && selectedTags.length === 0}
-                <p>No tags are assigned to this node.</p>
-              {:else if selectedTags.length > 0}
-                <ChipStack
-                  items={selectedTags}
-                  key={(tag) => tag.id}
-                  maxVisible={6}
-                  size="sm"
-                  ariaLabel="Assigned tags"
-                >
-                  {#snippet chip(tag)}
-                    <Chip
-                      size="sm"
-                      tone="workspace"
-                      uppercase={false}
-                      title={`${tag.assignment_count} total assignment${tag.assignment_count === 1 ? "" : "s"} · ${tag.id}`}
-                    >
-                      {tag.name}
-                    </Chip>
-                  {/snippet}
-                </ChipStack>
-              {/if}
-            </div>
-            {#if selected.node.kind === "file"}
-              <div class="document-actions">
-                {#key selected.node.id}
-                  <DownloadButton
-                    session={webSession}
-                    node={selected.node}
-                    onauthfailure={handleFailure}
-                  />
-                {/key}
-                <Button
-                  size="sm"
-                  tone="info"
-                  surface="soft"
-                  onclick={() => {
-                    historyOpen = false;
-                    provenanceOpen = false;
-                    jobsOpen = false;
-                    versionsOpen = true;
-                  }}
-                >
-                  <HistoryIcon size="14" aria-hidden="true" />
-                  Version history
-                </Button>
-                <Button
-                  size="sm"
-                  surface="soft"
-                  onclick={() => {
-                    historyOpen = false;
-                    versionsOpen = false;
-                    jobsOpen = false;
-                    provenanceOpen = true;
-                  }}
-                >
-                  <MapPinIcon size="14" aria-hidden="true" />
-                  Provenance
-                </Button>
-              </div>
-            {/if}
-            <div class="audit-protection">
-              <div class="audit-protection-heading">
-                <span>Permanent audit</span>
-                {#if auditLoading}
-                  <Spinner size={14} />
-                {:else if auditError}
-                  <Chip size="xs" tone="warning">Unavailable</Chip>
+              <div class="audit-protection">
+                <div class="audit-protection-heading">
+                  <span>Permanent audit</span>
+                  {#if auditLoading}
+                    <Spinner size={14} />
+                  {:else if auditError}
+                    <Chip size="xs" tone="warning">Unavailable</Chip>
+                  {:else if membership?.protected}
+                    <Chip size="xs" tone="success" dot>Protected</Chip>
+                  {:else if selectedAudit?.enabled}
+                    <Chip size="xs" tone="muted">Not audited</Chip>
+                  {:else}
+                    <Chip size="xs" tone="muted">Dormant</Chip>
+                  {/if}
+                </div>
+                {#if auditError}
+                  <p>{auditError}</p>
                 {:else if membership?.protected}
-                  <Chip size="xs" tone="success" dot>Protected</Chip>
+                  <p>
+                    Permanently protected by {membership.scope_ids.length}
+                    scope{membership.scope_ids.length === 1 ? "" : "s"}.
+                  </p>
+                  <Button
+                    size="sm"
+                    tone="info"
+                    surface="soft"
+                    onclick={() => {
+                      jobsOpen = false;
+                      versionsOpen = false;
+                      provenanceOpen = false;
+                      historyOpen = true;
+                    }}
+                  >
+                    <HistoryIcon size="14" aria-hidden="true" />
+                    Audit history
+                  </Button>
                 {:else if selectedAudit?.enabled}
-                  <Chip size="xs" tone="muted">Not audited</Chip>
-                {:else}
-                  <Chip size="xs" tone="muted">Dormant</Chip>
+                  <p>This node is outside every permanent audit scope.</p>
+                {:else if !auditLoading}
+                  <p>No permanent audit scope has been enabled for this vault.</p>
                 {/if}
               </div>
-              {#if auditError}
-                <p>{auditError}</p>
-              {:else if membership?.protected}
-                <p>
-                  Permanently protected by {membership.scope_ids.length}
-                  scope{membership.scope_ids.length === 1 ? "" : "s"}.
-                </p>
-                <Button
-                  size="sm"
-                  tone="info"
-                  surface="soft"
-                  onclick={() => {
-                    jobsOpen = false;
-                    versionsOpen = false;
-                    provenanceOpen = false;
-                    historyOpen = true;
-                  }}
-                >
-                  <HistoryIcon size="14" aria-hidden="true" />
-                  Audit history
+              {#if selected.node.kind === "dir"}
+                <Button size="sm" onclick={() => activate(selected)}>
+                  <FolderIcon size="14" aria-hidden="true" />
+                  Open folder
                 </Button>
-              {:else if selectedAudit?.enabled}
-                <p>This node is outside every permanent audit scope.</p>
-              {:else if !auditLoading}
-                <p>Permanent audited history has not been enabled for this vault.</p>
               {/if}
             </div>
-            {#if selected.node.kind === "dir"}
-              <Button size="sm" onclick={() => activate(selected)}>
-                <FolderIcon size="14" aria-hidden="true" />
-                Open folder
-              </Button>
-            {/if}
           </Card>
         {:else}
           <Card level="raised" title="Document authority">

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -41,6 +41,7 @@
     revokeSession,
     search,
     statPath,
+    tagByID,
     tags,
     takeFragmentSession,
     type AuditStatus,
@@ -76,12 +77,14 @@
   let activeTagID = $state("");
   let tagCatalog = $state<Tag[]>([]);
   let tagCatalogTotal = $state(0);
+  let tagCatalogListed = $state(0);
   let tagCatalogError = $state("");
   let selectedTags = $state<Tag[]>([]);
   let selectedTagsTotal = $state(0);
   let selectedTagsLoading = $state(false);
   let selectedTagsError = $state("");
   let loading = $state(false);
+  let searchPending = $state(false);
   let error = $state("");
   let truncated = $state(false);
   let sortField = $state<SortField>("name");
@@ -96,6 +99,7 @@
   let generation = 0;
   let auditGeneration = 0;
   let tagGeneration = 0;
+  let tagCatalogGeneration = 0;
 
   const selected = $derived(rows.find((row) => row.node.id === selectedID));
   const membership = $derived(selectedAudit?.membership);
@@ -128,8 +132,10 @@
       provenanceOpen = false;
       jobsOpen = false;
       tagCatalog = [];
+      tagCatalogListed = 0;
       selectedTags = [];
       selectedTagsTotal = 0;
+      searchPending = false;
       error = "The browser session expired or was rejected. Run `docbank web` again.";
       return;
     }
@@ -154,6 +160,7 @@
 
   async function loadDirectory(nodeID: number, remember: boolean): Promise<void> {
     const request = ++generation;
+    searchPending = false;
     loading = true;
     error = "";
     try {
@@ -212,6 +219,7 @@
     }
     const request = ++generation;
     const requestedTagID = tagFilterID;
+    searchPending = true;
     loading = true;
     error = "";
     try {
@@ -242,12 +250,16 @@
     } catch (cause) {
       if (request === generation) handleFailure(cause);
     } finally {
-      if (request === generation) loading = false;
+      if (request === generation) {
+        searchPending = false;
+        loading = false;
+      }
     }
   }
 
   function goBack(): void {
     generation += 1;
+    searchPending = false;
     const previous = stack.at(-1);
     if (!previous) return;
     directory = previous.directory;
@@ -267,12 +279,12 @@
 
   function clearSearch(): void {
     searchQuery = "";
-    if (activeQuery && directory) void loadDirectory(directory.id, false);
+    if ((activeQuery || searchPending) && directory) void loadDirectory(directory.id, false);
   }
 
   function changeTagFilter(tagID: string): void {
     tagFilterID = tagID;
-    if (searchQuery.trim()) void runSearch();
+    if (activeQuery || searchPending) void runSearch();
   }
 
   function activate(row: Row): void {
@@ -301,19 +313,46 @@
   }
 
   async function loadTagCatalog(): Promise<void> {
+    const request = ++tagCatalogGeneration;
     const session = webSession;
+    const selectedTagID = tagFilterID;
     tagCatalogError = "";
     try {
       const page = await tags(session);
-      if (session !== webSession) return;
-      tagCatalog = page.items;
+      if (request !== tagCatalogGeneration || session !== webSession) return;
+      let items = page.items;
+      let selectedMissing = false;
+      if (
+        selectedTagID &&
+        selectedTagID === tagFilterID &&
+        !items.some((tag) => tag.id === selectedTagID)
+      ) {
+        if (page.total > page.items.length) {
+          try {
+            const selectedTag = await tagByID(session, selectedTagID);
+            if (request !== tagCatalogGeneration || session !== webSession) return;
+            items = [selectedTag, ...items];
+          } catch (cause) {
+            if (request !== tagCatalogGeneration || session !== webSession) return;
+            if (cause instanceof APIError && cause.status === 404) selectedMissing = true;
+            else throw cause;
+          }
+        } else {
+          selectedMissing = true;
+        }
+      }
+      if (request !== tagCatalogGeneration || session !== webSession) return;
+      tagCatalog = selectedTagID === tagFilterID ? items : page.items;
       tagCatalogTotal = page.total;
-      if (tagFilterID && !page.items.some((tag) => tag.id === tagFilterID)) {
+      tagCatalogListed = page.items.length;
+      if (selectedMissing && tagFilterID === selectedTagID) {
+        const rerunSearch = Boolean(activeQuery || searchPending);
         tagFilterID = "";
         activeTagID = "";
+        if (rerunSearch && searchQuery.trim()) void runSearch();
       }
     } catch (cause) {
-      if (session !== webSession) return;
+      if (request !== tagCatalogGeneration || session !== webSession) return;
       if (cause instanceof APIError && cause.status === 401) {
         handleFailure(cause);
         return;
@@ -376,6 +415,7 @@
     generation += 1;
     auditGeneration += 1;
     tagGeneration += 1;
+    tagCatalogGeneration += 1;
     const session = webSession;
     webSession = "";
     directory = null;
@@ -389,6 +429,7 @@
     selectedTagsError = "";
     tagCatalog = [];
     tagCatalogTotal = 0;
+    tagCatalogListed = 0;
     tagCatalogError = "";
     auditLoading = false;
     auditError = "";
@@ -398,6 +439,7 @@
     jobsOpen = false;
     activeQuery = "";
     activeTagID = "";
+    searchPending = false;
     searchQuery = "";
     tagFilterID = "";
     error = "";
@@ -498,8 +540,8 @@
               options={tagOptions}
               title={tagCatalogError
                 ? `Tags unavailable: ${tagCatalogError}`
-                : tagCatalogTotal > tagCatalog.length
-                  ? `Tag filter: showing ${tagCatalog.length} of ${tagCatalogTotal} tags`
+                : tagCatalogTotal > tagCatalogListed
+                  ? `Tag filter: showing ${tagCatalogListed} of ${tagCatalogTotal} tags`
                   : "Filter search by tag"}
               disabled={tagCatalog.length === 0}
               onchange={changeTagFilter}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -275,6 +275,7 @@
     sortDirection = previous.sortDirection;
     error = "";
     loading = false;
+    void loadTagCatalog();
   }
 
   function clearSearch(): void {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -78,6 +78,7 @@
   let tagCatalogTotal = $state(0);
   let tagCatalogError = $state("");
   let selectedTags = $state<Tag[]>([]);
+  let selectedTagsTotal = $state(0);
   let selectedTagsLoading = $state(false);
   let selectedTagsError = $state("");
   let loading = $state(false);
@@ -128,6 +129,7 @@
       jobsOpen = false;
       tagCatalog = [];
       selectedTags = [];
+      selectedTagsTotal = 0;
       error = "The browser session expired or was rejected. Run `docbank web` again.";
       return;
     }
@@ -270,7 +272,7 @@
 
   function changeTagFilter(tagID: string): void {
     tagFilterID = tagID;
-    if (activeQuery) void runSearch();
+    if (searchQuery.trim()) void runSearch();
   }
 
   function activate(row: Row): void {
@@ -289,6 +291,7 @@
     selectedID = nodeID;
     selectedAudit = null;
     selectedTags = [];
+    selectedTagsTotal = 0;
     selectedTagsError = "";
     auditError = "";
     auditGeneration += 1;
@@ -327,6 +330,7 @@
       const page = await nodeTags(session, nodeID);
       if (request !== tagGeneration || session !== webSession || selectedID !== nodeID) return;
       selectedTags = page.items;
+      selectedTagsTotal = page.total;
     } catch (cause) {
       if (request !== tagGeneration || session !== webSession || selectedID !== nodeID) return;
       if (cause instanceof APIError && cause.status === 401) {
@@ -380,6 +384,7 @@
     selectedID = undefined;
     selectedAudit = null;
     selectedTags = [];
+    selectedTagsTotal = 0;
     selectedTagsLoading = false;
     selectedTagsError = "";
     tagCatalog = [];
@@ -639,7 +644,12 @@
                   {:else if selectedTagsError}
                     <Chip size="xs" tone="warning">Unavailable</Chip>
                   {:else}
-                    <span>{selectedTags.length} assigned</span>
+                    <span>
+                      {selectedTags.length < selectedTagsTotal
+                        ? `${selectedTags.length} of ${selectedTagsTotal}`
+                        : selectedTagsTotal}
+                      assigned
+                    </span>
                   {/if}
                 </div>
                 {#if selectedTagsError}
@@ -665,6 +675,9 @@
                       </Chip>
                     {/snippet}
                   </ChipStack>
+                  {#if selectedTags.length < selectedTagsTotal}
+                    <p>Showing the first {selectedTags.length} assigned tags.</p>
+                  {/if}
                 {/if}
               </div>
               {#if selected.node.kind === "file"}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -509,6 +509,7 @@
               size="sm"
               ariaLabel="Refresh current view"
               onclick={() => {
+                void loadTagCatalog();
                 if (activeQuery) void runSearch();
                 else if (directory) void loadDirectory(directory.id, false);
               }}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -8,20 +8,24 @@
   import MapPinIcon from "@lucide/svelte/icons/map-pin";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import SearchIcon from "@lucide/svelte/icons/search";
+  import TagIcon from "@lucide/svelte/icons/tag";
   import HistoryIcon from "@lucide/svelte/icons/history";
   import {
     Button,
     Card,
     Chip,
+    ChipStack,
     CopyButton,
     EmptyState,
     IconButton,
     SearchInput,
+    SelectDropdown,
     Spinner,
     Table,
     TableHeaderCell,
     ThemeToggle,
     TopBar,
+    type SelectDropdownOption,
     type SortDirection,
   } from "@kenn-io/kit-ui";
   import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
@@ -33,13 +37,16 @@
     APIError,
     auditStatusForNode,
     children,
+    nodeTags,
     revokeSession,
     search,
     statPath,
+    tags,
     takeFragmentSession,
     type AuditStatus,
     type Node,
     type SearchHit,
+    type Tag,
   } from "./api.js";
   import { basename, formatBytes, formatDate } from "./format.js";
   import { orderRows, reconcileSearchView, type SortField } from "./rows.js";
@@ -50,7 +57,9 @@
     rows: Row[];
     selectedID?: number;
     activeQuery: string;
+    activeTagID: string;
     searchQuery: string;
+    tagFilterID: string;
     truncated: boolean;
     sortField: SortField;
     sortDirection: SortDirection;
@@ -63,6 +72,14 @@
   let selectedID = $state<number | undefined>();
   let searchQuery = $state("");
   let activeQuery = $state("");
+  let tagFilterID = $state("");
+  let activeTagID = $state("");
+  let tagCatalog = $state<Tag[]>([]);
+  let tagCatalogTotal = $state(0);
+  let tagCatalogError = $state("");
+  let selectedTags = $state<Tag[]>([]);
+  let selectedTagsLoading = $state(false);
+  let selectedTagsError = $state("");
   let loading = $state(false);
   let error = $state("");
   let truncated = $state(false);
@@ -77,16 +94,29 @@
   let jobsOpen = $state(false);
   let generation = 0;
   let auditGeneration = 0;
+  let tagGeneration = 0;
 
   const selected = $derived(rows.find((row) => row.node.id === selectedID));
   const membership = $derived(selectedAudit?.membership);
+  const tagOptions = $derived<SelectDropdownOption[]>([
+    { value: "", label: "All tags" },
+    ...tagCatalog.map((tag) => ({
+      value: tag.id,
+      label: `${tag.name} (${tag.assignment_count})`,
+      triggerLabel: tag.name,
+    })),
+  ]);
+  const activeTag = $derived(tagCatalog.find((tag) => tag.id === activeTagID));
   const sortedRows = $derived(
     orderRows(rows, sortField, sortDirection, activeQuery !== ""),
   );
 
   onMount(() => {
     webSession = takeFragmentSession();
-    if (webSession) void loadRoot();
+    if (webSession) {
+      void loadRoot();
+      void loadTagCatalog();
+    }
   });
 
   function handleFailure(cause: unknown): void {
@@ -96,6 +126,8 @@
       versionsOpen = false;
       provenanceOpen = false;
       jobsOpen = false;
+      tagCatalog = [];
+      selectedTags = [];
       error = "The browser session expired or was rejected. Run `docbank web` again.";
       return;
     }
@@ -133,7 +165,9 @@
             rows,
             selectedID,
             activeQuery,
+            activeTagID,
             searchQuery,
+            tagFilterID,
             truncated,
             sortField,
             sortDirection,
@@ -149,6 +183,7 @@
       }));
       selectNode(rows[0]?.node.id);
       activeQuery = "";
+      activeTagID = "";
       truncated = page.total > page.items.length;
       sortField = "name";
       sortDirection = "asc";
@@ -174,11 +209,15 @@
       return;
     }
     const request = ++generation;
+    const requestedTagID = tagFilterID;
     loading = true;
     error = "";
     try {
-      const report = await search(webSession, query);
+      const report = await search(webSession, query, requestedTagID);
       if (request !== generation) return;
+      if ((report.tag_id ?? "") !== requestedTagID) {
+        throw new Error("Search results did not honor the selected tag filter.");
+      }
       rows = report.hits.map((hit: SearchHit) => ({
         node: hit.node,
         path: hit.path,
@@ -187,12 +226,13 @@
       const view = reconcileSearchView(
         rows,
         query,
-        activeQuery,
+        requestedTagID === activeTagID ? activeQuery : "",
         sortField,
         sortDirection,
         selectedID,
       );
       activeQuery = query;
+      activeTagID = requestedTagID;
       truncated = report.truncated;
       sortField = view.sortField;
       sortDirection = view.sortDirection;
@@ -213,7 +253,9 @@
     selectNode(previous.selectedID);
     stack = stack.slice(0, -1);
     activeQuery = previous.activeQuery;
+    activeTagID = previous.activeTagID;
     searchQuery = previous.searchQuery;
+    tagFilterID = previous.tagFilterID;
     truncated = previous.truncated;
     sortField = previous.sortField;
     sortDirection = previous.sortDirection;
@@ -224,6 +266,11 @@
   function clearSearch(): void {
     searchQuery = "";
     if (activeQuery && directory) void loadDirectory(directory.id, false);
+  }
+
+  function changeTagFilter(tagID: string): void {
+    tagFilterID = tagID;
+    if (activeQuery) void runSearch();
   }
 
   function activate(row: Row): void {
@@ -241,9 +288,55 @@
     }
     selectedID = nodeID;
     selectedAudit = null;
+    selectedTags = [];
+    selectedTagsError = "";
     auditError = "";
     auditGeneration += 1;
+    tagGeneration += 1;
     if (nodeID !== undefined && webSession) void loadAuditStatus(nodeID);
+    if (nodeID !== undefined && webSession) void loadSelectedTags(nodeID);
+  }
+
+  async function loadTagCatalog(): Promise<void> {
+    const session = webSession;
+    tagCatalogError = "";
+    try {
+      const page = await tags(session);
+      if (session !== webSession) return;
+      tagCatalog = page.items;
+      tagCatalogTotal = page.total;
+      if (tagFilterID && !page.items.some((tag) => tag.id === tagFilterID)) {
+        tagFilterID = "";
+        activeTagID = "";
+      }
+    } catch (cause) {
+      if (session !== webSession) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        handleFailure(cause);
+        return;
+      }
+      tagCatalogError = cause instanceof Error ? cause.message : String(cause);
+    }
+  }
+
+  async function loadSelectedTags(nodeID: number): Promise<void> {
+    const request = ++tagGeneration;
+    const session = webSession;
+    selectedTagsLoading = true;
+    try {
+      const page = await nodeTags(session, nodeID);
+      if (request !== tagGeneration || session !== webSession || selectedID !== nodeID) return;
+      selectedTags = page.items;
+    } catch (cause) {
+      if (request !== tagGeneration || session !== webSession || selectedID !== nodeID) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        handleFailure(cause);
+        return;
+      }
+      selectedTagsError = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === tagGeneration) selectedTagsLoading = false;
+    }
   }
 
   async function loadAuditStatus(nodeID: number): Promise<void> {
@@ -278,6 +371,7 @@
   async function lock(): Promise<void> {
     generation += 1;
     auditGeneration += 1;
+    tagGeneration += 1;
     const session = webSession;
     webSession = "";
     directory = null;
@@ -285,6 +379,12 @@
     stack = [];
     selectedID = undefined;
     selectedAudit = null;
+    selectedTags = [];
+    selectedTagsLoading = false;
+    selectedTagsError = "";
+    tagCatalog = [];
+    tagCatalogTotal = 0;
+    tagCatalogError = "";
     auditLoading = false;
     auditError = "";
     historyOpen = false;
@@ -292,7 +392,9 @@
     provenanceOpen = false;
     jobsOpen = false;
     activeQuery = "";
+    activeTagID = "";
     searchQuery = "";
+    tagFilterID = "";
     error = "";
     try {
       await revokeSession(session);
@@ -378,10 +480,25 @@
             </IconButton>
             <div>
               <span>{activeQuery ? "Search results" : "Current folder"}</span>
-              <strong>{activeQuery ? `“${activeQuery}”` : directory?.path ?? "/"}</strong>
+              <strong>
+                {activeQuery
+                  ? `“${activeQuery}”${activeTag ? ` · ${activeTag.name}` : ""}`
+                  : directory?.path ?? "/"}
+              </strong>
             </div>
           </div>
           <div class="toolbar-actions">
+            <SelectDropdown
+              value={tagFilterID}
+              options={tagOptions}
+              title={tagCatalogError
+                ? `Tags unavailable: ${tagCatalogError}`
+                : tagCatalogTotal > tagCatalog.length
+                  ? `Tag filter: showing ${tagCatalog.length} of ${tagCatalogTotal} tags`
+                  : "Filter search by tag"}
+              disabled={tagCatalog.length === 0}
+              onchange={changeTagFilter}
+            />
             <span>{rows.length}{truncated ? "+" : ""} item{rows.length === 1 ? "" : "s"}</span>
             <IconButton
               size="sm"
@@ -507,6 +624,42 @@
                 </div>
               {/if}
             </dl>
+            <div class="node-tags">
+              <div class="node-tags-heading">
+                <span><TagIcon size="13" aria-hidden="true" /> Tags</span>
+                {#if selectedTagsLoading}
+                  <Spinner size={13} />
+                {:else if selectedTagsError}
+                  <Chip size="xs" tone="warning">Unavailable</Chip>
+                {:else}
+                  <span>{selectedTags.length}</span>
+                {/if}
+              </div>
+              {#if selectedTagsError}
+                <p>{selectedTagsError}</p>
+              {:else if !selectedTagsLoading && selectedTags.length === 0}
+                <p>No tags are assigned to this node.</p>
+              {:else if selectedTags.length > 0}
+                <ChipStack
+                  items={selectedTags}
+                  key={(tag) => tag.id}
+                  maxVisible={6}
+                  size="sm"
+                  ariaLabel="Assigned tags"
+                >
+                  {#snippet chip(tag)}
+                    <Chip
+                      size="sm"
+                      tone="workspace"
+                      uppercase={false}
+                      title={`${tag.assignment_count} total assignment${tag.assignment_count === 1 ? "" : "s"} · ${tag.id}`}
+                    >
+                      {tag.name}
+                    </Chip>
+                  {/snippet}
+                </ChipStack>
+              {/if}
+            </div>
             {#if selected.node.kind === "file"}
               <div class="document-actions">
                 {#key selected.node.id}

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -69,6 +69,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
+  let tagCatalogReads = 0;
   const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = String(input);
     if (url === "/api/v1/path?path=%2F") return json(root);
@@ -76,13 +77,14 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       return json({ directory: root, items: [], total: 0, limit: 1000, offset: 0 });
     }
     if (url === "/api/v1/tags?limit=1000&offset=0") {
+      tagCatalogReads += 1;
       return json({
         items: [
           {
             id: "33333333-3333-4333-8333-333333333333",
-            name: "tax",
+            name: tagCatalogReads === 1 ? "tax" : "tax records",
             revision: 1,
-            assignment_count: 1,
+            assignment_count: tagCatalogReads === 1 ? 1 : 2,
           },
         ],
         total: 1,
@@ -146,4 +148,10 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       screen.queryByRole("cell", { name: "/Reports/quarterly-product-report.txt" }),
     ).toBeNull(),
   );
+
+  await fireEvent.click(screen.getByRole("button", { name: "Refresh current view" }));
+  expect(
+    await screen.findByRole("combobox", { name: "Filter search by tag: tax records" }),
+  ).toBeTruthy();
+  expect(screen.getByText("“quarterly” · tax records")).toBeTruthy();
 });

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import App from "./App.svelte";
+
+afterEach(() => {
+  cleanup();
+  history.replaceState(null, "", "/");
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+  vi.restoreAllMocks();
+});
+
+it("supersedes an in-flight search when its tag filter changes", async () => {
+  history.replaceState(null, "", "/#web_session=short-lived");
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+  let resolveUnfiltered!: (response: Response) => void;
+  const unfiltered = new Promise<Response>((resolve) => {
+    resolveUnfiltered = resolve;
+  });
+  const root = {
+    id: 1,
+    name: "",
+    kind: "dir",
+    size: 0,
+    revision: 1,
+    created_at: "2026-07-27T12:00:00Z",
+    modified_at: "2026-07-27T12:00:00Z",
+    path: "/",
+  };
+  const taxReport = {
+    id: 3,
+    parent_id: 2,
+    name: "quarterly-tax-report.txt",
+    kind: "file",
+    current_version_id: "11111111-1111-4111-8111-111111111111",
+    blob_hash: "a".repeat(64),
+    size: 74,
+    mime_type: "text/plain",
+    revision: 3,
+    created_at: "2026-07-27T12:00:00Z",
+    modified_at: "2026-07-27T12:00:00Z",
+  };
+  const productReport = {
+    ...taxReport,
+    id: 4,
+    name: "quarterly-product-report.txt",
+    current_version_id: "22222222-2222-4222-8222-222222222222",
+    blob_hash: "b".repeat(64),
+  };
+  const json = (value: unknown) =>
+    new Response(JSON.stringify(value), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url === "/api/v1/path?path=%2F") return json(root);
+    if (url === "/api/v1/nodes/1/children?limit=1000&offset=0") {
+      return json({ directory: root, items: [], total: 0, limit: 1000, offset: 0 });
+    }
+    if (url === "/api/v1/tags?limit=1000&offset=0") {
+      return json({
+        items: [
+          {
+            id: "33333333-3333-4333-8333-333333333333",
+            name: "tax",
+            revision: 1,
+            assignment_count: 1,
+          },
+        ],
+        total: 1,
+        limit: 1000,
+        offset: 0,
+      });
+    }
+    if (url === "/api/v1/search?q=quarterly&limit=1000") return unfiltered;
+    if (
+      url ===
+      "/api/v1/search?q=quarterly&limit=1000&tag_id=33333333-3333-4333-8333-333333333333"
+    ) {
+      return json({
+        hits: [{ node: taxReport, path: "/Reports/quarterly-tax-report.txt", match: "name" }],
+        limit: 1000,
+        truncated: false,
+        tag_id: "33333333-3333-4333-8333-333333333333",
+      });
+    }
+    if (url === "/api/v1/audit/status?node_id=3") {
+      return json({ enabled: false, scopes: [] });
+    }
+    if (url === "/api/v1/nodes/3/tags?limit=1000&offset=0") {
+      return json({ items: [], total: 0, limit: 1000, offset: 0 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  });
+
+  render(App);
+  const input = await screen.findByRole("searchbox", { name: "Search documents" });
+  await screen.findByRole("combobox", { name: "Filter search by tag: All tags" });
+  await fireEvent.input(input, { target: { value: "quarterly" } });
+  await fireEvent.submit(input.closest("form")!);
+  await waitFor(() =>
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("q=quarterly"))).toBe(true),
+  );
+
+  await fireEvent.click(
+    screen.getByRole("combobox", { name: "Filter search by tag: All tags" }),
+  );
+  await fireEvent.click(screen.getByRole("option", { name: "tax (1)" }));
+  expect(
+    await screen.findByRole("cell", { name: "/Reports/quarterly-tax-report.txt" }),
+  ).toBeTruthy();
+
+  resolveUnfiltered(
+    json({
+      hits: [
+        {
+          node: productReport,
+          path: "/Reports/quarterly-product-report.txt",
+          match: "name",
+        },
+      ],
+      limit: 1000,
+      truncated: false,
+    }),
+  );
+  await waitFor(() =>
+    expect(
+      screen.queryByRole("cell", { name: "/Reports/quarterly-product-report.txt" }),
+    ).toBeNull(),
+  );
+});

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -81,6 +81,8 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       headers: { "Content-Type": "application/json" },
     });
   let tagCatalogReads = 0;
+  let tagReads = 0;
+  let unfilteredSearches = 0;
   const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = String(input);
     if (url === "/api/v1/path?path=%2F") return json(root);
@@ -123,6 +125,16 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       });
     }
     if (url === "/api/v1/tags/33333333-3333-4333-8333-333333333333") {
+      tagReads += 1;
+      if (tagReads > 1) {
+        return new Response(
+          JSON.stringify({ status: 404, detail: "tag not found" }),
+          {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
       return json({
         id: "33333333-3333-4333-8333-333333333333",
         name: "tax records",
@@ -130,7 +142,21 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
         assignment_count: 2,
       });
     }
-    if (url === "/api/v1/search?q=quarterly&limit=1000") return unfiltered;
+    if (url === "/api/v1/search?q=quarterly&limit=1000") {
+      unfilteredSearches += 1;
+      if (unfilteredSearches === 1) return unfiltered;
+      return json({
+        hits: [
+          {
+            node: productReport,
+            path: "/Reports/quarterly-product-report.txt",
+            match: "name",
+          },
+        ],
+        limit: 1000,
+        truncated: false,
+      });
+    }
     if (
       url ===
       "/api/v1/search?q=quarterly&limit=1000&tag_id=33333333-3333-4333-8333-333333333333"
@@ -160,6 +186,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   render(App);
   const input = await screen.findByRole("searchbox", { name: "Search documents" });
   await screen.findByRole("combobox", { name: "Filter search by tag: All tags" });
+  await screen.findByText("This folder is empty");
   await fireEvent.input(input, { target: { value: "quarterly" } });
   await fireEvent.submit(input.closest("form")!);
   await waitFor(() =>
@@ -221,4 +248,22 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   expect(
     fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/v1/search?")),
   ).toHaveLength(searchCalls);
+
+  const back = screen.getByRole("button", { name: "Back to previous directory" });
+  expect(back.hasAttribute("disabled")).toBe(false);
+  await fireEvent.click(back);
+  await waitFor(() => expect(tagCatalogReads).toBe(3));
+  expect(screen.getByRole("combobox").getAttribute("aria-label")).toContain("tax records");
+  await waitFor(() => expect(tagReads).toBe(2));
+  await waitFor(() => expect(unfilteredSearches).toBe(2));
+  expect(
+    await screen.findByRole("cell", { name: "/Reports/quarterly-product-report.txt" }),
+  ).toBeTruthy();
+  expect(screen.getByText("“quarterly”")).toBeTruthy();
+  expect(screen.queryByText("“quarterly” · tax records")).toBeNull();
+  expect(
+    screen.getByRole("combobox", {
+      name: "Tag filter: showing 1 of 1001 tags: All tags",
+    }),
+  ).toBeTruthy();
 });

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -64,6 +64,17 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     current_version_id: "22222222-2222-4222-8222-222222222222",
     blob_hash: "b".repeat(64),
   };
+  const archiveDirectory = {
+    id: 5,
+    parent_id: 1,
+    name: "Archive",
+    kind: "dir",
+    size: 0,
+    revision: 1,
+    created_at: "2026-07-27T12:00:00Z",
+    modified_at: "2026-07-27T12:00:00Z",
+    path: "/Archive",
+  };
   const json = (value: unknown) =>
     new Response(JSON.stringify(value), {
       status: 200,
@@ -76,20 +87,47 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     if (url === "/api/v1/nodes/1/children?limit=1000&offset=0") {
       return json({ directory: root, items: [], total: 0, limit: 1000, offset: 0 });
     }
+    if (url === "/api/v1/nodes/5/children?limit=1000&offset=0") {
+      return json({
+        directory: archiveDirectory,
+        items: [],
+        total: 0,
+        limit: 1000,
+        offset: 0,
+      });
+    }
     if (url === "/api/v1/tags?limit=1000&offset=0") {
       tagCatalogReads += 1;
       return json({
-        items: [
-          {
-            id: "33333333-3333-4333-8333-333333333333",
-            name: tagCatalogReads === 1 ? "tax" : "tax records",
-            revision: 1,
-            assignment_count: tagCatalogReads === 1 ? 1 : 2,
-          },
-        ],
-        total: 1,
+        items:
+          tagCatalogReads === 1
+            ? [
+                {
+                  id: "33333333-3333-4333-8333-333333333333",
+                  name: "tax",
+                  revision: 1,
+                  assignment_count: 1,
+                },
+              ]
+            : [
+                {
+                  id: "44444444-4444-4444-8444-444444444444",
+                  name: "reviewed",
+                  revision: 1,
+                  assignment_count: 7,
+                },
+              ],
+        total: tagCatalogReads === 1 ? 1 : 1001,
         limit: 1000,
         offset: 0,
+      });
+    }
+    if (url === "/api/v1/tags/33333333-3333-4333-8333-333333333333") {
+      return json({
+        id: "33333333-3333-4333-8333-333333333333",
+        name: "tax records",
+        revision: 2,
+        assignment_count: 2,
       });
     }
     if (url === "/api/v1/search?q=quarterly&limit=1000") return unfiltered;
@@ -98,16 +136,22 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       "/api/v1/search?q=quarterly&limit=1000&tag_id=33333333-3333-4333-8333-333333333333"
     ) {
       return json({
-        hits: [{ node: taxReport, path: "/Reports/quarterly-tax-report.txt", match: "name" }],
+        hits: [
+          { node: taxReport, path: "/Reports/quarterly-tax-report.txt", match: "name" },
+          { node: archiveDirectory, path: "/Archive", match: "name" },
+        ],
         limit: 1000,
         truncated: false,
         tag_id: "33333333-3333-4333-8333-333333333333",
       });
     }
-    if (url === "/api/v1/audit/status?node_id=3") {
+    if (url === "/api/v1/audit/status?node_id=3" || url === "/api/v1/audit/status?node_id=5") {
       return json({ enabled: false, scopes: [] });
     }
-    if (url === "/api/v1/nodes/3/tags?limit=1000&offset=0") {
+    if (
+      url === "/api/v1/nodes/3/tags?limit=1000&offset=0" ||
+      url === "/api/v1/nodes/5/tags?limit=1000&offset=0"
+    ) {
       return json({ items: [], total: 0, limit: 1000, offset: 0 });
     }
     throw new Error(`unexpected request: ${url}`);
@@ -150,8 +194,31 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   );
 
   await fireEvent.click(screen.getByRole("button", { name: "Refresh current view" }));
-  expect(
-    await screen.findByRole("combobox", { name: "Filter search by tag: tax records" }),
-  ).toBeTruthy();
+  await waitFor(() =>
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain(
+      "/api/v1/tags/33333333-3333-4333-8333-333333333333",
+    ),
+  );
+  await waitFor(() =>
+    expect(screen.getByRole("combobox").getAttribute("aria-label")).toBe(
+      "Tag filter: showing 1 of 1001 tags: tax records",
+    ),
+  );
   expect(screen.getByText("“quarterly” · tax records")).toBeTruthy();
+
+  await fireEvent.dblClick(screen.getByRole("cell", { name: "/Archive" }));
+  expect(await screen.findByText("This folder is empty")).toBeTruthy();
+  const searchCalls = fetchMock.mock.calls.filter(([url]) =>
+    String(url).startsWith("/api/v1/search?"),
+  ).length;
+  await fireEvent.click(
+    screen.getByRole("combobox", {
+      name: "Tag filter: showing 1 of 1001 tags: tax records",
+    }),
+  );
+  await fireEvent.click(screen.getByRole("option", { name: "All tags" }));
+  expect(screen.getByText("Current folder")).toBeTruthy();
+  expect(
+    fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/v1/search?")),
+  ).toHaveLength(searchCalls);
 });

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -5,8 +5,11 @@ import {
   auditStatusForNode,
   contentVersions,
   listJobs,
+  nodeTags,
   requestJSON,
   revokeSession,
+  search,
+  tags,
   takeFragmentSession,
 } from "./api.js";
 
@@ -112,5 +115,24 @@ describe("browser authentication", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       "/api/v1/nodes/42/versions?limit=1000&offset=0",
     );
+  });
+
+  it("addresses tag authority and tag-filtered search", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(
+        JSON.stringify({ items: [], total: 0, limit: 1000, offset: 0, hits: [] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await tags("session");
+    await nodeTags("session", 42);
+    await search("session", "quarterly report", "11111111-1111-4111-8111-111111111111");
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "/api/v1/tags?limit=1000&offset=0",
+      "/api/v1/nodes/42/tags?limit=1000&offset=0",
+      "/api/v1/search?q=quarterly+report&limit=1000&tag_id=11111111-1111-4111-8111-111111111111",
+    ]);
   });
 });

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -9,6 +9,7 @@ import {
   requestJSON,
   revokeSession,
   search,
+  tagByID,
   tags,
   takeFragmentSession,
 } from "./api.js";
@@ -126,11 +127,13 @@ describe("browser authentication", () => {
     );
 
     await tags("session");
+    await tagByID("session", "11111111-1111-4111-8111-111111111111");
     await nodeTags("session", 42);
     await search("session", "quarterly report", "11111111-1111-4111-8111-111111111111");
 
     expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
       "/api/v1/tags?limit=1000&offset=0",
+      "/api/v1/tags/11111111-1111-4111-8111-111111111111",
       "/api/v1/nodes/42/tags?limit=1000&offset=0",
       "/api/v1/search?q=quarterly+report&limit=1000&tag_id=11111111-1111-4111-8111-111111111111",
     ]);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -76,6 +76,21 @@ export interface SearchReport {
   hits: SearchHit[];
   limit: number;
   truncated: boolean;
+  tag_id?: string;
+}
+
+export interface Tag {
+  id: string;
+  name: string;
+  revision: number;
+  assignment_count: number;
+}
+
+export interface TagPage {
+  items: Tag[];
+  total: number;
+  limit: number;
+  offset: number;
 }
 
 export interface AuditScopeStatus {
@@ -291,9 +306,26 @@ export async function provenance(
   );
 }
 
-export async function search(session: string, query: string): Promise<SearchReport> {
+export async function search(
+  session: string,
+  query: string,
+  tagID = "",
+): Promise<SearchReport> {
+  const params = new URLSearchParams({ q: query, limit: "1000" });
+  if (tagID) params.set("tag_id", tagID);
   return requestJSON<SearchReport>(
-    `/api/v1/search?q=${encodeURIComponent(query)}&limit=1000`,
+    `/api/v1/search?${params.toString()}`,
+    session,
+  );
+}
+
+export async function tags(session: string): Promise<TagPage> {
+  return requestJSON<TagPage>("/api/v1/tags?limit=1000&offset=0", session);
+}
+
+export async function nodeTags(session: string, nodeID: number): Promise<TagPage> {
+  return requestJSON<TagPage>(
+    `/api/v1/nodes/${nodeID}/tags?limit=1000&offset=0`,
     session,
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -323,6 +323,10 @@ export async function tags(session: string): Promise<TagPage> {
   return requestJSON<TagPage>("/api/v1/tags?limit=1000&offset=0", session);
 }
 
+export async function tagByID(session: string, tagID: string): Promise<Tag> {
+  return requestJSON<Tag>(`/api/v1/tags/${encodeURIComponent(tagID)}`, session);
+}
+
 export async function nodeTags(session: string, nodeID: number): Promise<TagPage> {
   return requestJSON<TagPage>(
     `/api/v1/nodes/${nodeID}/tags?limit=1000&offset=0`,

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -439,4 +439,12 @@ dd {
   .document-name {
     min-width: 150px;
   }
+
+  .document-actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .document-actions > :first-child {
+    grid-column: auto;
+  }
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -135,6 +135,11 @@ code {
   white-space: nowrap;
 }
 
+.toolbar-actions .kit-select-dropdown {
+  width: min(190px, 30vw);
+  min-width: 120px;
+}
+
 .loading,
 .banner {
   display: flex;
@@ -241,6 +246,38 @@ dd {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
+}
+
+.node-tags {
+  display: grid;
+  gap: var(--space-3);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-default);
+}
+
+.node-tags-heading,
+.node-tags-heading > span:first-child {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.node-tags-heading {
+  justify-content: space-between;
+}
+
+.node-tags-heading > span {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.node-tags p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
 }
 
 .audit-protection {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -201,16 +201,55 @@ tr:focus-visible {
   top: var(--space-5);
 }
 
+.authority-content {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.authority-header {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.authority-header > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.authority-header > div > span:first-child {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.authority-header h2 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+  font-size: var(--font-size-lg);
+  line-height: 1.2;
+}
+
 dl {
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-3);
   margin: 0;
 }
 
 dl > div {
   display: grid;
-  grid-template-columns: 88px minmax(0, 1fr);
-  gap: var(--space-4);
+  grid-template-columns: 76px minmax(0, 1fr);
+  gap: var(--space-3);
+}
+
+dl > .wide-fact,
+dl > .identity {
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-1);
 }
 
 dt {
@@ -243,15 +282,29 @@ dd {
 }
 
 .document-actions {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-2);
+}
+
+.document-actions > :first-child {
+  grid-column: 1 / -1;
+}
+
+.document-actions > button,
+.document-actions > .download-control,
+.document-actions > .download-control > button {
+  width: 100%;
+}
+
+.document-actions > button {
+  justify-content: center;
 }
 
 .node-tags {
   display: grid;
   gap: var(--space-3);
-  padding-top: var(--space-4);
+  padding-top: var(--space-3);
   border-top: 1px solid var(--border-default);
 }
 
@@ -283,7 +336,7 @@ dd {
 .audit-protection {
   display: grid;
   gap: var(--space-3);
-  padding-top: var(--space-4);
+  padding-top: var(--space-3);
   border-top: 1px solid var(--border-default);
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -392,6 +392,10 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
+	resp = webRequest(http.MethodGet, "/api/v1/tags/"+tag.ID)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
 	resp = webRequest(http.MethodGet,
 		"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/tags?limit=1000&offset=0")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -325,6 +325,13 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 		t.Context(), document.ID, taxes.ID, "return.txt", document.Revision,
 	)
 	require.NoError(t, err)
+	tag, err := s.CreateTag(t.Context(), "tax")
+	require.NoError(t, err)
+	assignment, err := s.AssignTag(
+		t.Context(), tag.ID, document.ID, document.Revision,
+	)
+	require.NoError(t, err)
+	document = assignment.Node
 	plan, err := s.PreviewInitialAudit(t.Context(), taxes.ID, "api", nil)
 	require.NoError(t, err)
 	_, err = s.EnableInitialAudit(t.Context(), plan)
@@ -378,6 +385,15 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 
 	resp = webRequest(http.MethodGet,
 		"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/provenance?limit=1000&offset=0")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = webRequest(http.MethodGet, "/api/v1/tags?limit=1000&offset=0")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = webRequest(http.MethodGet,
+		"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/tags?limit=1000&offset=0")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -68,7 +68,8 @@ func webSessionRequestAllowed(method, path string) bool {
 	}
 	switch path {
 	case "/api/v1/path", "/api/v1/search",
-		"/api/v1/audit/status", "/api/v1/audit/history", "/api/v1/jobs":
+		"/api/v1/audit/status", "/api/v1/audit/history", "/api/v1/jobs",
+		"/api/v1/tags":
 		return true
 	}
 	const prefix = "/api/v1/nodes/"
@@ -83,7 +84,8 @@ func webSessionRequestAllowed(method, path string) bool {
 		return false
 	}
 	return len(parts) == 1 || parts[1] == "children" ||
-		parts[1] == "versions" || parts[1] == "provenance"
+		parts[1] == "versions" || parts[1] == "provenance" ||
+		parts[1] == "tags"
 }
 
 func registerWebSession(

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -72,6 +72,11 @@ func webSessionRequestAllowed(method, path string) bool {
 		"/api/v1/tags":
 		return true
 	}
+	const tagPrefix = "/api/v1/tags/"
+	if after, ok := strings.CutPrefix(path, tagPrefix); ok {
+		tagID := after
+		return tagID != "" && !strings.Contains(tagID, "/")
+	}
 	const prefix = "/api/v1/nodes/"
 	if !strings.HasPrefix(path, prefix) {
 		return false

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "44"
+	daemonProtocolVersion = "45"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "45"
+	daemonProtocolVersion = "46"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Tags already organize a Docbank vault, but the primary browser currently hides them. A person looking at a report cannot see whether it is tagged `tax` or `reviewed`, and narrowing a search by that classification requires leaving the web application.

This adds tags to the selected document or folder’s authority card and gives text search a tag selector. The selector displays the human name, but the request is bound to the tag’s stable UUID, so a rename cannot silently change which definition the browser selected. In the synthetic example below, `quarterly` initially matched two reports; selecting `tax` narrowed the result to the one report carrying that exact tag.

The authority card has also been reorganized for its narrow sidebar: the document name gets a distinct heading, long paths and immutable identities use the full width, and Download plus the history actions form a deliberate primary/secondary grid instead of wrapping arbitrarily.

![The actual Docbank web application showing a text search narrowed by a stable tag](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-tags/web-tags.png?v=3c5ae56)

*Actual daemon-served interface using a temporary synthetic vault; no private corpus data is present.*

The browser remains read-only. Its daemon-lifetime session may inspect tag definitions and assignments, but it cannot create, rename, delete, assign, or remove tags. The selector is intentionally bounded to the first 1,000 name-sorted definitions and discloses when the catalog is larger; exhaustive workflows remain available through the CLI and HTTP API. Search still requires text—tag-only vault exploration and tag mutation are separate workflows.