### PR TITLE
Download retained versions from the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Four commitments:
   document/version identity inspection, and permanent audited-history timelines
 - A read-only kit-ui web application for virtual-tree browsing, sortable
   document analysis, tag-filtered extracted-text search, complete current authority,
-  verified current-content download, permanent protection and event history,
+  verified current and historical content download, permanent protection and event history,
   immutable versions and provenance, and daemon background-job status
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "46", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "47", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "46", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "47", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "46", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "47", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "46", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "47", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ incremental backups can be verified before you rely on them. Work directly
 from the CLI, automate through the authenticated HTTP API, or embed Docbank in
 a Go application. People can browse the same authority in the local web
 application or focused terminal interface; the web application verifies
-current document bytes before handing them to the browser's native save and
+current or retained document bytes before handing them to the browser's native save and
 keeps tag organization visible alongside document authority.
 
 Install the latest release on Linux or macOS:
@@ -171,7 +171,7 @@ documents: files you still organize, retrieve, and build workflows around.
 - [Setup](setup.md): install the binary and create the vault
 - [Quickstart](quickstart.md): a ten-minute tour of the CLI
 - [Vault Lifecycle](usage/lifecycle.md): operate, snapshot, and recover safely
-- [Web Application](usage/web.md): browse, search, and download verified current content
+- [Web Application](usage/web.md): browse, search, and download verified retained content
 - [Docbank for Agents](agents.md): the automation contract
 - [Embed in Go](embedding.md): vaults inside your own application
 - [Troubleshooting](troubleshooting.md): diagnose failures without risking the vault

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web tags, version history, provenance, and verified current-content download implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web tags, version history, provenance, and verified current/historical content download implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -148,8 +148,8 @@ history. Every selected node exposes its tag assignments, and text search can
 require one stable tag identity. Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
 portal also reports current and terminal daemon background jobs. Future slices
-cover import, tag mutation and broader metadata, historical content download
-and comparison, trash, storage, and backup.
+cover import, tag mutation and broader metadata, version comparison, trash,
+storage, and backup.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -58,7 +58,7 @@ assigned tag names. Hovering a tag shows its stable UUID and vault-wide
 assignment count; the bounded tag stack expands in place when a node carries
 more than six.
 
-## Download verified current content
+## Download verified content
 
 Choose **Download** on a file to retrieve its current version. Docbank first
 copies the object from loose or packed storage into owner-private daemon
@@ -81,10 +81,6 @@ the browser or operating system completed its final save. Use `docbank get`
 when automation needs a durable receipt after private staging, file sync,
 atomic publication, and parent-directory sync.
 
-This action downloads only the selected live document's current version.
-Historical-version download and comparison remain CLI or authenticated API
-workflows.
-
 ## Inspect immutable versions
 
 Choose **Version history** on any file to inspect every retained immutable
@@ -99,10 +95,18 @@ introducing operation UUID, and the source version for a revert. The current
 head is marked explicitly; a revert remains a new immutable version rather
 than erasing or relabeling the earlier one.
 
+Choose **Download** in the complete-version panel to retrieve that exact
+retained version through the same private staging, progress, terminal
+verification, and one-use handoff as the current-content action. The stable
+version UUID, owning node, SHA-256 identity, size, and current node revision
+must all agree before preparation begins. Historical versions do not retain a
+filename timeline, so the browser uses the live document's current name.
+Version comparison remains a CLI or authenticated API workflow.
+
 The drawer reads at most the newest 1,000 versions and says when older history
 exists. Use `docbank versions list`, its pagination flags, or the authenticated
-HTTP API for exhaustive automation. This view does not download content,
-compare bytes, revert, or prune history.
+HTTP API for exhaustive automation. This view does not compare bytes, revert,
+or prune history.
 
 ## Understand where a document came from
 
@@ -245,8 +249,8 @@ Refreshing a folder resolves its stable node ID, current canonical path, and
 children in one metadata snapshot, so a concurrent CLI or agent move cannot
 leave the browser constructing child paths beneath an obsolete name.
 
-The current web application does not download historical content, compare
-versions, import, edit, revert, prune, move, create or change tags and
+The current web application does not compare versions, import, edit, revert,
+prune, move, create or change tags and
 assignments, trash, enroll audit scopes, run independent audit verification,
 or run maintenance and backup operations.
 Use the corresponding CLI or authenticated HTTP endpoint for those workflows.

--- a/frontend/src/DownloadButton.svelte
+++ b/frontend/src/DownloadButton.svelte
@@ -3,10 +3,11 @@
   import DownloadIcon from "@lucide/svelte/icons/download";
   import XIcon from "@lucide/svelte/icons/x";
   import { Button, Chip, Spinner } from "@kenn-io/kit-ui";
-  import { APIError, type Node } from "./api.js";
+  import { APIError, type ContentVersion, type Node } from "./api.js";
   import {
     offerPreparedDownload,
     prepareCurrentDownload,
+    prepareVersionDownload,
     type DownloadProgress,
   } from "./download.js";
   import { formatBytes } from "./format.js";
@@ -14,10 +15,14 @@
   let {
     session,
     node,
+    version,
+    label = "Download",
     onauthfailure,
   }: {
     session: string;
     node: Node;
+    version?: ContentVersion;
+    label?: string;
     onauthfailure: (cause: unknown) => void;
   } = $props();
 
@@ -35,18 +40,16 @@
     }
     const active = new AbortController();
     controller = active;
-    progress = { received: 0, total: node.size };
+    progress = { received: 0, total: version?.size ?? node.size };
     outcome = "";
     failed = false;
     try {
-      const prepared = await prepareCurrentDownload(
-        session,
-        node,
-        active.signal,
-        (next) => {
-          if (controller === active) progress = next;
-        },
-      );
+      const report = (next: DownloadProgress) => {
+        if (controller === active) progress = next;
+      };
+      const prepared = version
+        ? await prepareVersionDownload(session, node, version, active.signal, report)
+        : await prepareCurrentDownload(session, node, active.signal, report);
       if (controller !== active) return;
       offerPreparedDownload(prepared);
       outcome = `Verified ${formatBytes(prepared.size)}; browser save started.`;
@@ -87,7 +90,7 @@
       Cancel
     {:else}
       <DownloadIcon size="14" aria-hidden="true" />
-      Download
+      {label}
     {/if}
   </Button>
   {#if progress}

--- a/frontend/src/VersionHistoryDrawer.svelte
+++ b/frontend/src/VersionHistoryDrawer.svelte
@@ -21,6 +21,7 @@
     type ContentVersionPage,
     type Node,
   } from "./api.js";
+  import DownloadButton from "./DownloadButton.svelte";
   import { basename, formatBytes, formatDate } from "./format.js";
 
   interface Props {
@@ -221,6 +222,15 @@
               </div>
             {/if}
           </dl>
+          <div class="version-actions">
+            <DownloadButton
+              {session}
+              {node}
+              version={selectedVersion}
+              label="Download this version"
+              {onauthfailure}
+            />
+          </div>
         </Card>
       {:else}
         <EmptyState
@@ -366,6 +376,12 @@
     display: flex;
     align-items: flex-start;
     gap: var(--space-2);
+  }
+
+  .version-actions {
+    margin-top: var(--space-5);
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--border-default);
   }
 
   code {

--- a/frontend/src/VersionHistoryDrawer.svelte
+++ b/frontend/src/VersionHistoryDrawer.svelte
@@ -223,13 +223,15 @@
             {/if}
           </dl>
           <div class="version-actions">
-            <DownloadButton
-              {session}
-              {node}
-              version={selectedVersion}
-              label="Download this version"
-              {onauthfailure}
-            />
+            {#key selectedVersion.id}
+              <DownloadButton
+                {session}
+                {node}
+                version={selectedVersion}
+                label="Download this version"
+                {onauthfailure}
+              />
+            {/key}
           </div>
         </Card>
       {:else}

--- a/frontend/src/VersionHistoryDrawer.test.ts
+++ b/frontend/src/VersionHistoryDrawer.test.ts
@@ -105,4 +105,52 @@ describe("version history drawer", () => {
     );
     expect(close).toHaveBeenCalledOnce();
   });
+
+  it("aborts a retained-version download when the selection changes", async () => {
+    const versions = [
+      version(currentVersionID, 3, "content_replace", "c"),
+      version(createdVersionID, 1, "content_create", "a"),
+    ];
+    let downloadSignal: AbortSignal | undefined;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            items: versions,
+            total: versions.length,
+            limit: 1000,
+            offset: 0,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockImplementationOnce((_input, init) => {
+        downloadSignal = init?.signal ?? undefined;
+        return new Promise((_resolve, reject) => {
+          downloadSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      });
+
+    render(VersionHistoryDrawer, {
+      session: "short-lived",
+      node,
+      path: "/Reports/quarterly-report.txt",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText("2 retained versions")).toBeTruthy();
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Download this version" }),
+    );
+    await vi.waitFor(() => expect(downloadSignal).toBeTruthy());
+
+    await fireEvent.click(screen.getByText("Created").closest("button")!);
+
+    await vi.waitFor(() => expect(downloadSignal?.aborted).toBe(true));
+  });
 });

--- a/frontend/src/VersionHistoryDrawer.test.ts
+++ b/frontend/src/VersionHistoryDrawer.test.ts
@@ -86,6 +86,7 @@ describe("version history drawer", () => {
     expect(screen.getByText(currentVersionID)).toBeTruthy();
     expect(screen.getByText(createdVersionID)).toBeTruthy();
     expect(screen.getByText("Revert source")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Download this version" })).toBeTruthy();
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       "/api/v1/nodes/42/versions?limit=1000&offset=0",
     );
@@ -97,6 +98,7 @@ describe("version history drawer", () => {
 
     expect(screen.getByText("a".repeat(64))).toBeTruthy();
     expect(screen.queryByText("Revert source")).toBeNull();
+    expect(screen.getByRole("button", { name: "Download this version" })).toBeTruthy();
 
     await fireEvent.click(
       screen.getByRole("button", { name: "Close version history" }),

--- a/frontend/src/download.test.ts
+++ b/frontend/src/download.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { prepareCurrentDownload } from "./download.js";
-import type { Node } from "./api.js";
+import { prepareCurrentDownload, prepareVersionDownload } from "./download.js";
+import type { ContentVersion, Node } from "./api.js";
 
 const node: Node = {
   id: 7,
@@ -14,6 +14,18 @@ const node: Node = {
   revision: 3,
   created_at: "2026-07-26T12:00:00Z",
   modified_at: "2026-07-26T12:00:00Z",
+};
+
+const retainedVersion: ContentVersion = {
+  id: "abcdefab-cdef-4abc-8def-abcdefabcdef",
+  node_id: node.id,
+  blob_hash: "b".repeat(64),
+  size: 12,
+  mime_type: "text/plain",
+  recorded_at: "2026-07-20T12:00:00Z",
+  node_revision: 1,
+  introduced_operation_id: "87654321-4321-4321-8321-cba987654321",
+  transition_kind: "content_create",
 };
 
 afterEach(() => {
@@ -96,5 +108,48 @@ describe("prepareCurrentDownload", () => {
         () => undefined,
       ),
     ).rejects.toThrow("disagreed with the selected document");
+  });
+
+  it("binds a retained-version request and receipt to immutable authority", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          [
+            JSON.stringify({ phase: "progress", total: retainedVersion.size }),
+            JSON.stringify({
+              phase: "ready",
+              received: retainedVersion.size,
+              total: retainedVersion.size,
+              url: "/api/daemon/web-download/file?ticket=historical",
+              name: node.name,
+              version_id: retainedVersion.id,
+              blob_hash: retainedVersion.blob_hash,
+            }),
+            "",
+          ].join("\n"),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const prepared = await prepareVersionDownload(
+      "browser-session",
+      node,
+      retainedVersion,
+      new AbortController().signal,
+      () => undefined,
+    );
+
+    expect(prepared.versionID).toBe(retainedVersion.id);
+    expect(prepared.blobHash).toBe(retainedVersion.blob_hash);
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(JSON.parse(String(init?.body))).toEqual({
+      node_id: node.id,
+      revision: node.revision,
+      version_id: retainedVersion.id,
+      blob_hash: retainedVersion.blob_hash,
+      size: retainedVersion.size,
+    });
   });
 });

--- a/frontend/src/download.ts
+++ b/frontend/src/download.ts
@@ -1,4 +1,4 @@
-import { requestResponse, type Node } from "./api.js";
+import { requestResponse, type ContentVersion, type Node } from "./api.js";
 
 export interface DownloadProgress {
   received: number;
@@ -24,6 +24,15 @@ interface DownloadEvent {
   detail?: string;
 }
 
+interface DownloadAuthority {
+  nodeID: number;
+  revision: number;
+  name: string;
+  versionID: string;
+  blobHash: string;
+  size: number;
+}
+
 export async function prepareCurrentDownload(
   session: string,
   node: Node,
@@ -39,6 +48,59 @@ export async function prepareCurrentDownload(
   ) {
     throw new Error("The selected document does not have complete download authority.");
   }
+  return prepareDownload(
+    session,
+    {
+      nodeID: node.id,
+      revision: node.revision,
+      name: node.name,
+      versionID: node.current_version_id,
+      blobHash: node.blob_hash,
+      size: node.size,
+    },
+    signal,
+    onprogress,
+  );
+}
+
+export async function prepareVersionDownload(
+  session: string,
+  node: Node,
+  version: ContentVersion,
+  signal: AbortSignal,
+  onprogress: (progress: DownloadProgress) => void,
+): Promise<PreparedDownload> {
+  if (
+    node.kind !== "file" ||
+    node.revision < 1 ||
+    version.node_id !== node.id ||
+    !version.id ||
+    !version.blob_hash ||
+    version.size < 0
+  ) {
+    throw new Error("The selected version does not have complete download authority.");
+  }
+  return prepareDownload(
+    session,
+    {
+      nodeID: node.id,
+      revision: node.revision,
+      name: node.name,
+      versionID: version.id,
+      blobHash: version.blob_hash,
+      size: version.size,
+    },
+    signal,
+    onprogress,
+  );
+}
+
+async function prepareDownload(
+  session: string,
+  authority: DownloadAuthority,
+  signal: AbortSignal,
+  onprogress: (progress: DownloadProgress) => void,
+): Promise<PreparedDownload> {
   const response = await requestResponse("/api/daemon/web-download", session, {
     method: "POST",
     headers: {
@@ -46,11 +108,11 @@ export async function prepareCurrentDownload(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      node_id: node.id,
-      revision: node.revision,
-      version_id: node.current_version_id,
-      blob_hash: node.blob_hash,
-      size: node.size,
+      node_id: authority.nodeID,
+      revision: authority.revision,
+      version_id: authority.versionID,
+      blob_hash: authority.blobHash,
+      size: authority.size,
     }),
     signal,
   });
@@ -79,13 +141,13 @@ export async function prepareCurrentDownload(
           throw new Error(event.detail || "Docbank could not verify this document.");
         }
         if (event.phase === "progress") {
-          const progress = validateProgress(event, node.size, received);
+          const progress = validateProgress(event, authority.size, received);
           received = progress.received;
           onprogress(progress);
           continue;
         }
         if (event.phase === "ready") {
-          ready = validateReady(event, node);
+          ready = validateReady(event, authority);
           onprogress({ received: ready.size, total: ready.size });
           continue;
         }
@@ -98,7 +160,7 @@ export async function prepareCurrentDownload(
       if (event.phase !== "ready" || ready) {
         throw new Error("The download response ended with an invalid progress event.");
       }
-      ready = validateReady(event, node);
+      ready = validateReady(event, authority);
       onprogress({ received: ready.size, total: ready.size });
     }
   } catch (cause) {
@@ -129,21 +191,21 @@ function validateProgress(
   return { received, total };
 }
 
-function validateReady(event: DownloadEvent, node: Node): PreparedDownload {
+function validateReady(event: DownloadEvent, authority: DownloadAuthority): PreparedDownload {
   const name = event.name;
   const versionID = event.version_id;
   const blobHash = event.blob_hash;
   const url = event.url;
   if (
-    (event.received ?? 0) !== node.size ||
-    event.total !== node.size ||
+    (event.received ?? 0) !== authority.size ||
+    event.total !== authority.size ||
     typeof name !== "string" ||
     typeof versionID !== "string" ||
     typeof blobHash !== "string" ||
     typeof url !== "string" ||
-    name !== node.name ||
-    versionID !== node.current_version_id ||
-    blobHash !== node.blob_hash ||
+    name !== authority.name ||
+    versionID !== authority.versionID ||
+    blobHash !== authority.blobHash ||
     !url?.startsWith("/api/daemon/web-download/file?ticket=")
   ) {
     throw new Error("The verified download disagreed with the selected document.");

--- a/internal/api/web_download.go
+++ b/internal/api/web_download.go
@@ -166,12 +166,15 @@ func registerWebDownload(
 			writeError(w, decodeErr)
 			return
 		}
-		view, err := d.Store.NodeViewByID(r.Context(), request.NodeID)
+		view, err := d.Store.ContentVersionViewByID(
+			r.Context(), request.NodeID, request.VersionID,
+		)
 		if err != nil {
 			writeError(w, webDownloadProblem(err))
 			return
 		}
 		node := view.Node
+		version := view.Version
 		if node.IsDir() {
 			writeError(w, NewError(http.StatusUnprocessableEntity, "not_file",
 				fmt.Sprintf("node %d is a directory", node.ID)))
@@ -183,21 +186,20 @@ func registerWebDownload(
 			return
 		}
 		if node.Revision != request.Revision ||
-			node.CurrentVersionID != request.VersionID ||
-			node.BlobHash != request.BlobHash ||
-			node.Size != request.Size {
+			version.BlobHash != request.BlobHash ||
+			version.Size != request.Size {
 			writeError(w, NewError(http.StatusConflict, "download_selection_stale",
-				"the selected document changed; refresh it before downloading"))
+				"the selected document or version changed; refresh it before downloading"))
 			return
 		}
 
-		stream, streamSize, err := d.Blobs.OpenStreamContext(r.Context(), node.BlobHash)
+		stream, streamSize, err := d.Blobs.OpenStreamContext(r.Context(), version.BlobHash)
 		if err != nil {
 			writeError(w, NewError(http.StatusInternalServerError, "internal",
 				"opening document content failed; run docbank verify"))
 			return
 		}
-		if streamSize != node.Size {
+		if streamSize != version.Size {
 			_ = stream.Close()
 			writeError(w, NewError(http.StatusInternalServerError, "internal",
 				"document size authority is inconsistent; run docbank verify"))
@@ -233,44 +235,44 @@ func registerWebDownload(
 			}
 			return nil
 		}
-		if err := report(webDownloadEvent{Phase: "progress", Total: node.Size}); err != nil {
+		if err := report(webDownloadEvent{Phase: "progress", Total: version.Size}); err != nil {
 			_ = file.Close()
 			_ = stream.Close()
 			return
 		}
 
 		progress := &webDownloadProgressWriter{
-			ctx: r.Context(), dst: file, total: node.Size, report: report,
+			ctx: r.Context(), dst: file, total: version.Size, report: report,
 		}
 		_, copyErr := io.CopyBuffer(progress, stream, make([]byte, 256<<10))
 		closeStreamErr := stream.Close()
 		closeFileErr := file.Close()
 		if err := errors.Join(copyErr, closeStreamErr, closeFileErr); err != nil ||
-			!stream.Verified() || progress.written != node.Size {
+			!stream.Verified() || progress.written != version.Size {
 			_ = report(webDownloadEvent{
-				Phase: "error", Total: node.Size,
+				Phase: "error", Total: version.Size,
 				Detail: "Docbank could not verify the complete document; run docbank verify",
 			})
 			return
 		}
 
 		ticket := webDownloadTicket{
-			path: stagedPath, name: node.Name, mediaType: node.MimeType,
-			versionID: node.CurrentVersionID, blobHash: node.BlobHash, size: node.Size,
+			path: stagedPath, name: node.Name, mediaType: version.MimeType,
+			versionID: version.ID, blobHash: version.BlobHash, size: version.Size,
 		}
 		token, err := downloads.issue(ticket)
 		if err != nil {
 			_ = report(webDownloadEvent{
-				Phase: "error", Total: node.Size,
+				Phase: "error", Total: version.Size,
 				Detail: "Docbank could not publish the verified browser download",
 			})
 			return
 		}
 		keepStaged = true
 		_ = report(webDownloadEvent{
-			Phase: "ready", Received: node.Size, Total: node.Size,
+			Phase: "ready", Received: version.Size, Total: version.Size,
 			URL:  webDownloadFilePath + "?ticket=" + token,
-			Name: node.Name, VersionID: node.CurrentVersionID, BlobHash: node.BlobHash,
+			Name: node.Name, VersionID: version.ID, BlobHash: version.BlobHash,
 		})
 	})
 

--- a/internal/api/web_download_test.go
+++ b/internal/api/web_download_test.go
@@ -10,6 +10,7 @@ import (
 	"mime"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,6 +126,74 @@ func TestWebDownloadVerifiesBeforeOneUseBrowserHandoff(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, reusedResponse.StatusCode)
 	require.NoError(t, reusedResponse.Body.Close())
+}
+
+func TestWebDownloadPreparesOneRetainedVersion(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	const historicalContent = "synthetic first edition\n"
+	document := createFileWithContent(t, ts, s, "/report.txt", historicalContent)
+	historical, err := s.ContentVersionByID(t.Context(), document.CurrentVersionID)
+	require.NoError(t, err)
+	replacementHash, replacementSize, err := s.Blobs.Write(strings.NewReader("second edition\n"))
+	require.NoError(t, err)
+	document, _, err = s.ReplaceContent(
+		t.Context(), document.ID, document.Revision,
+		replacementHash, replacementSize, "text/plain",
+	)
+	require.NoError(t, err)
+
+	requestBody, err := json.Marshal(map[string]any{
+		"node_id": document.ID, "revision": document.Revision,
+		"version_id": historical.ID, "blob_hash": historical.BlobHash,
+		"size": historical.Size,
+	})
+	require.NoError(t, err)
+	request, err := http.NewRequest(
+		http.MethodPost, ts.URL+"/api/daemon/web-download", bytes.NewReader(requestBody),
+	)
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := ts.Client().Do(request)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	var ready struct {
+		Phase     string `json:"phase"`
+		URL       string `json:"url"`
+		VersionID string `json:"version_id"`
+		BlobHash  string `json:"blob_hash"`
+	}
+	decoder := json.NewDecoder(response.Body)
+	for {
+		var event struct {
+			Phase     string `json:"phase"`
+			URL       string `json:"url"`
+			VersionID string `json:"version_id"`
+			BlobHash  string `json:"blob_hash"`
+		}
+		err := decoder.Decode(&event)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		if event.Phase == "ready" {
+			ready = event
+		}
+	}
+	require.NoError(t, response.Body.Close())
+	require.NotEmpty(t, ready.URL)
+	assert.Equal(t, historical.ID, ready.VersionID)
+	assert.Equal(t, historical.BlobHash, ready.BlobHash)
+
+	download, err := ts.Client().Get(ts.URL + ready.URL)
+	require.NoError(t, err)
+	body, err := io.ReadAll(download.Body)
+	require.NoError(t, err)
+	require.NoError(t, download.Body.Close())
+	require.Equal(t, http.StatusOK, download.StatusCode)
+	assert.Equal(t, historicalContent, string(body))
+	assert.Equal(t, historical.ID, download.Header.Get(api.ContentVersionHeader))
+	assert.Equal(t, historical.BlobHash, download.Header.Get(api.BlobHashHeader))
 }
 
 func TestWebDownloadRejectsAStaleSelectionBeforeStaging(t *testing.T) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "46"
+	daemonProtocolVersion = "47"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -25,6 +25,13 @@ type ContentVersion struct {
 	SourceVersionID       *string
 }
 
+// ContentVersionView binds a file node and one of its retained versions to the
+// same read snapshot.
+type ContentVersionView struct {
+	Node    Node
+	Version ContentVersion
+}
+
 const contentVersionCols = `version_id, node_id, blob_hash, size,
 	COALESCE(mime_type, ''), recorded_at, node_revision,
 	introduced_operation_id, transition_kind, source_version_id`
@@ -54,6 +61,41 @@ func (s *Store) ContentVersionByID(ctx context.Context, id string) (ContentVersi
 		return ContentVersion{}, fmt.Errorf("content version %q: %w", id, err)
 	}
 	return v, nil
+}
+
+// ContentVersionViewByID returns one node-owned version and its node authority
+// from a single read transaction.
+func (s *Store) ContentVersionViewByID(
+	ctx context.Context, nodeID int64, versionID string,
+) (ContentVersionView, error) {
+	if err := validateUUIDv4(versionID); err != nil {
+		return ContentVersionView{}, fmt.Errorf(
+			"content version %q: %w", versionID, ErrNotFound,
+		)
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return ContentVersionView{}, fmt.Errorf("starting content-version snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	node, err := nodeByIDTx(tx, nodeID)
+	if err != nil {
+		return ContentVersionView{}, err
+	}
+	version, err := scanContentVersion(tx.QueryRowContext(ctx,
+		`SELECT `+contentVersionCols+`
+		 FROM content_versions WHERE version_id = ? AND node_id = ?`,
+		versionID, nodeID))
+	if err != nil {
+		return ContentVersionView{}, fmt.Errorf(
+			"content version %q of node %d: %w", versionID, nodeID, err,
+		)
+	}
+	if err := tx.Commit(); err != nil {
+		return ContentVersionView{}, fmt.Errorf("closing content-version snapshot: %w", err)
+	}
+	return ContentVersionView{Node: node, Version: version}, nil
 }
 
 // ContentVersions lists one bounded page newest-first and returns the total


### PR DESCRIPTION
Docbank already keeps every document version by default and the web application can inspect that history, but retrieving an older edition still required leaving the browser and translating its identity into a CLI or API request. This completes the inspection workflow: select any retained entry in **Version history**, then choose **Download this version** to retrieve those exact bytes.

The handoff has the same boundary as current-document downloads. The daemon binds the live node revision and selected version UUID, SHA-256 identity, and size before copying from loose or packed storage into owner-private staging. Only a complete stream that reaches verified EOF receives a short-lived, one-use browser ticket. Changing the selected version cancels an in-flight preparation, so the authority visible in the drawer cannot drift away from the bytes being prepared.

![The actual Docbank web application with an older retained version selected for verified download](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-retained-version-download/web-retained-version-download.png?v=7116473)

*Actual daemon-served interface using a temporary synthetic two-version vault; no private corpus data is present.*

Historical versions do not preserve a filename timeline, so the browser deliberately uses the document's current name. The browser remains read-only: comparison, reversion, pruning, editing, and other mutations are unchanged and remain CLI or authenticated API workflows. Preparation still requires temporary local space equal to the selected version's logical size.