### PR TITLE
Inspect physical storage in the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Four commitments:
 - A read-only kit-ui web application for virtual-tree browsing, sortable
   document analysis, tag-filtered extracted-text search, complete current authority,
   verified current and historical content download, permanent protection and event history,
-  immutable versions and provenance, and daemon background-job status
+  immutable versions and provenance, daemon background-job status, and an
+  honest loose/live-packed/dead-packed storage breakdown
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule
 - Whole-vault integrity verification

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Four commitments:
   document analysis, tag-filtered extracted-text search, complete current authority,
   verified current and historical content download, permanent protection and event history,
   immutable versions and provenance, daemon background-job status, and an
-  honest loose/live-packed/dead-packed storage breakdown
+  honest loose-file/live-packed/dead-packed storage breakdown
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule
 - Whole-vault integrity verification

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "47", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "48", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "47", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "48", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "47", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "48", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "47", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "48", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,8 @@ from the CLI, automate through the authenticated HTTP API, or embed Docbank in
 a Go application. People can browse the same authority in the local web
 application or focused terminal interface; the web application verifies
 current or retained document bytes before handing them to the browser's native save and
-keeps tag organization visible alongside document authority.
+keeps tag organization and the vault's loose/live-packed/dead-packed storage
+breakdown visible alongside document authority.
 
 Install the latest release on Linux or macOS:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ from the CLI, automate through the authenticated HTTP API, or embed Docbank in
 a Go application. People can browse the same authority in the local web
 application or focused terminal interface; the web application verifies
 current or retained document bytes before handing them to the browser's native save and
-keeps tag organization and the vault's loose/live-packed/dead-packed storage
+keeps tag organization and the vault's loose-file/live-packed/dead-packed storage
 breakdown visible alongside document authority.
 
 Install the latest release on Linux or macOS:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -147,9 +147,11 @@ authority, plus its newest-first immutable provenance facts and supersession
 history. Every selected node exposes its tag assignments, and text search can
 require one stable tag identity. Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
-portal also reports current and terminal daemon background jobs. Future slices
+portal also reports current and terminal daemon background jobs and separates
+loose content, live packed content, complete pack payload, and logically dead
+payload awaiting explicit repack. Future slices
 cover import, tag mutation and broader metadata, version comparison, trash,
-storage, and backup.
+storage maintenance, and backup.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,8 +148,8 @@ history. Every selected node exposes its tag assignments, and text search can
 require one stable tag identity. Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
 portal also reports current and terminal daemon background jobs and separates
-loose content, live packed content, complete pack payload, and logically dead
-payload awaiting explicit repack. Future slices
+physical loose files, live packed content, complete pack payload, and
+logically dead payload awaiting explicit repack. Future slices
 cover import, tag mutation and broader metadata, version comparison, trash,
 storage maintenance, and backup.
 Application-neutral tree, timeline, diff, evidence, and job components should

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -199,8 +199,9 @@ lifetime and disappear when that daemon restarts.
 Choose the storage button in the top bar to see how the current vault occupies
 managed blob storage. The summary separates four related quantities:
 
-- **Loose content** is authoritative content stored as individual raw or zstd
-  files.
+- **Loose content** is the physical inventory of individual raw or zstd
+  files. It can include untracked files or redundant loose copies of packed
+  objects, so it is not an authority count.
 - **Live packed content** is authoritative content stored in immutable pack
   files. The view shows both its logical raw size and its stored size.
 - **Pack files** is the complete stored payload of every pack, including live

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -19,8 +19,9 @@ node ID, revision, current version ID, SHA-256 identity, exact size, and media
 type. The authority card also shows every tag assigned to the selected file or
 folder, while search can require one exact tag. Protected documents expose
 their newest-first permanent audit timeline and complete event authority. The
-activity button reports the
-daemon's supervised extraction, watched-inbox, and automatic-packing jobs.
+storage button separates loose content, live packed content, pack-file payload,
+and logically dead packed bytes awaiting repack. The activity button reports
+the daemon's supervised extraction, watched-inbox, and automatic-packing jobs.
 Every file also exposes its retained immutable content versions and the stable
 authority behind each one, plus the immutable provenance Docbank recorded when
 the document entered the vault.
@@ -193,6 +194,32 @@ or reconfigure work; use the relevant configuration, CLI, or authenticated API
 workflow after understanding the failure. Job records belong to one daemon
 lifetime and disappear when that daemon restarts.
 
+## Inspect physical storage
+
+Choose the storage button in the top bar to see how the current vault occupies
+managed blob storage. The summary separates four related quantities:
+
+- **Loose content** is authoritative content stored as individual raw or zstd
+  files.
+- **Live packed content** is authoritative content stored in immutable pack
+  files. The view shows both its logical raw size and its stored size.
+- **Pack files** is the complete stored payload of every pack, including live
+  and logically dead entries.
+- **Pending repack** is logically dead payload that still occupies those
+  immutable pack files.
+
+Pending-repack bytes have not been reclaimed. This distinction matters when a
+GC report has removed unreachable catalog mappings but the vault's disk usage
+has not fallen by the same amount. The percentage beside the pending total
+shows how much of the current pack payload is dead, not a compression ratio or
+a promise that every pack is immediately eligible for compaction.
+
+This drawer is read-only and refreshes from the daemon's current catalog
+authority. It cannot pack, garbage-collect, or repack content. Use
+`docbank storage status` for structured or scripted inspection and run
+`docbank storage repack` explicitly when you intend to rewrite eligible sparse
+packs and retire their old files.
+
 ## Browser authentication
 
 When Docbank opens the browser, it writes a small launch page beside the
@@ -213,7 +240,8 @@ do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
 search, tag-definition and assignment reads, immutable-version, provenance, audit-status, audit-history,
-background-job, and verified-download preparation used by this interface.
+background-job, physical-storage-status, and verified-download preparation
+used by this interface.
 Download preparation may write only owner-private temporary bytes and issue
 one exact, expiring file ticket; it cannot mutate document authority. The
 session cannot enroll audit scopes, run independent verification, or call

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -4,6 +4,7 @@
   import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
   import FileIcon from "@lucide/svelte/icons/file";
   import FolderIcon from "@lucide/svelte/icons/folder";
+  import HardDriveIcon from "@lucide/svelte/icons/hard-drive";
   import LogOutIcon from "@lucide/svelte/icons/log-out";
   import MapPinIcon from "@lucide/svelte/icons/map-pin";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
@@ -32,6 +33,7 @@
   import DownloadButton from "./DownloadButton.svelte";
   import JobsDrawer from "./JobsDrawer.svelte";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
+  import StorageDrawer from "./StorageDrawer.svelte";
   import VersionHistoryDrawer from "./VersionHistoryDrawer.svelte";
   import {
     APIError,
@@ -96,6 +98,7 @@
   let versionsOpen = $state(false);
   let provenanceOpen = $state(false);
   let jobsOpen = $state(false);
+  let storageOpen = $state(false);
   let generation = 0;
   let auditGeneration = 0;
   let tagGeneration = 0;
@@ -131,6 +134,7 @@
       versionsOpen = false;
       provenanceOpen = false;
       jobsOpen = false;
+      storageOpen = false;
       tagCatalog = [];
       tagCatalogListed = 0;
       selectedTags = [];
@@ -438,6 +442,7 @@
     versionsOpen = false;
     provenanceOpen = false;
     jobsOpen = false;
+    storageOpen = false;
     activeQuery = "";
     activeTagID = "";
     searchPending = false;
@@ -497,11 +502,25 @@
       {#snippet right()}
         <IconButton
           size="sm"
+          ariaLabel="Storage status"
+          onclick={() => {
+            historyOpen = false;
+            versionsOpen = false;
+            provenanceOpen = false;
+            jobsOpen = false;
+            storageOpen = true;
+          }}
+        >
+          <HardDriveIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton
+          size="sm"
           ariaLabel="Background jobs"
           onclick={() => {
             historyOpen = false;
             versionsOpen = false;
             provenanceOpen = false;
+            storageOpen = false;
             jobsOpen = true;
           }}
         >
@@ -741,6 +760,7 @@
                       historyOpen = false;
                       provenanceOpen = false;
                       jobsOpen = false;
+                      storageOpen = false;
                       versionsOpen = true;
                     }}
                   >
@@ -754,6 +774,7 @@
                       historyOpen = false;
                       versionsOpen = false;
                       jobsOpen = false;
+                      storageOpen = false;
                       provenanceOpen = true;
                     }}
                   >
@@ -792,6 +813,7 @@
                       jobsOpen = false;
                       versionsOpen = false;
                       provenanceOpen = false;
+                      storageOpen = false;
                       historyOpen = true;
                     }}
                   >
@@ -855,6 +877,13 @@
       <JobsDrawer
         session={webSession}
         onclose={() => (jobsOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if storageOpen}
+      <StorageDrawer
+        session={webSession}
+        onclose={() => (storageOpen = false)}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/StorageDrawer.svelte
+++ b/frontend/src/StorageDrawer.svelte
@@ -33,9 +33,6 @@
   let error = $state("");
   let generation = 0;
 
-  const authorizedObjects = $derived(
-    status ? status.loose_blobs + status.packed_blobs : 0,
-  );
   const storedPayload = $derived(
     status ? status.loose_bytes + status.pack_stored_bytes : 0,
   );
@@ -87,7 +84,8 @@
         <strong>Loose and packed content</strong>
         <small>
           {#if status}
-            {authorizedObjects} authorized object{authorizedObjects === 1 ? "" : "s"}
+            {status.loose_blobs} loose file{status.loose_blobs === 1 ? "" : "s"}
+            · {status.packed_blobs} live packed object{status.packed_blobs === 1 ? "" : "s"}
             · {formatBytes(storedPayload)} stored payload
           {:else}
             Current daemon inventory
@@ -129,8 +127,9 @@
         >
           {#snippet actions()}<HardDriveIcon size="18" aria-hidden="true" />{/snippet}
           <p>
-            {status.loose_blobs} authorized object{status.loose_blobs === 1 ? "" : "s"}
-            stored as individual raw or zstd files.
+            {status.loose_blobs} physical file{status.loose_blobs === 1 ? "" : "s"}
+            stored as raw or zstd. This inventory can include untracked or
+            redundant loose files.
           </p>
         </Card>
 

--- a/frontend/src/StorageDrawer.svelte
+++ b/frontend/src/StorageDrawer.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import ArchiveIcon from "@lucide/svelte/icons/archive";
+  import DatabaseIcon from "@lucide/svelte/icons/database";
+  import HardDriveIcon from "@lucide/svelte/icons/hard-drive";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Card,
+    Chip,
+    DetailDrawer,
+    IconButton,
+    Spinner,
+  } from "@kenn-io/kit-ui";
+  import {
+    APIError,
+    storageStatus,
+    type StorageStatus,
+  } from "./api.js";
+  import { formatBytes } from "./format.js";
+
+  interface Props {
+    session: string;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, onclose, onauthfailure }: Props = $props();
+
+  let status = $state<StorageStatus | null>(null);
+  let loading = $state(true);
+  let error = $state("");
+  let generation = 0;
+
+  const authorizedObjects = $derived(
+    status ? status.loose_blobs + status.packed_blobs : 0,
+  );
+  const storedPayload = $derived(
+    status ? status.loose_bytes + status.pack_stored_bytes : 0,
+  );
+  const deadPackedBytes = $derived(status?.dead_packed_bytes ?? 0);
+  const deadPercent = $derived(
+    status && status.pack_stored_bytes > 0
+      ? Math.round((deadPackedBytes * 100) / status.pack_stored_bytes)
+      : 0,
+  );
+
+  onMount(() => {
+    void refresh();
+    return () => {
+      generation += 1;
+    };
+  });
+
+  async function refresh(): Promise<void> {
+    const request = ++generation;
+    loading = true;
+    error = "";
+    try {
+      const next = await storageStatus(session);
+      if (request !== generation) return;
+      status = next;
+    } catch (cause) {
+      if (request !== generation) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        onclose();
+        return;
+      }
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === generation) loading = false;
+    }
+  }
+</script>
+
+<DetailDrawer
+  width="min(760px, 100vw)"
+  ariaLabel="Physical storage status"
+  {onclose}
+>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>PHYSICAL STORAGE</span>
+        <strong>Loose and packed content</strong>
+        <small>
+          {#if status}
+            {authorizedObjects} authorized object{authorizedObjects === 1 ? "" : "s"}
+            · {formatBytes(storedPayload)} stored payload
+          {:else}
+            Current daemon inventory
+          {/if}
+        </small>
+      </div>
+      <div class="drawer-actions">
+        <IconButton
+          size="sm"
+          ariaLabel="Refresh storage status"
+          disabled={loading}
+          onclick={() => void refresh()}
+        >
+          <RefreshCwIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton size="sm" ariaLabel="Close storage status" onclick={onclose}>
+          <XIcon size="14" aria-hidden="true" />
+        </IconButton>
+      </div>
+    </div>
+  {/snippet}
+
+  <div class="storage">
+    {#if loading && !status}
+      <div class="loading"><Spinner size={16} /> Reading storage inventory…</div>
+    {:else if error && !status}
+      <div class="load-error">
+        <p role="alert">{error}</p>
+        <Button size="sm" onclick={() => void refresh()}>Try again</Button>
+      </div>
+    {:else if status}
+      {#if error}<p class="error" role="alert">{error}</p>{/if}
+      <div class="storage-grid" aria-live="polite">
+        <Card
+          level="default"
+          padding="sm"
+          eyebrow="LOOSE CONTENT"
+          title={formatBytes(status.loose_bytes)}
+        >
+          {#snippet actions()}<HardDriveIcon size="18" aria-hidden="true" />{/snippet}
+          <p>
+            {status.loose_blobs} authorized object{status.loose_blobs === 1 ? "" : "s"}
+            stored as individual raw or zstd files.
+          </p>
+        </Card>
+
+        <Card
+          level="default"
+          padding="sm"
+          eyebrow="LIVE PACKED CONTENT"
+          title={formatBytes(status.packed_stored_bytes)}
+        >
+          {#snippet actions()}<ArchiveIcon size="18" aria-hidden="true" />{/snippet}
+          <dl>
+            <div><dt>Objects</dt><dd>{status.packed_blobs}</dd></div>
+            <div><dt>Raw bytes</dt><dd>{formatBytes(status.packed_raw_bytes)}</dd></div>
+          </dl>
+        </Card>
+
+        <Card
+          level="default"
+          padding="sm"
+          eyebrow="PACK FILES"
+          title={formatBytes(status.pack_stored_bytes)}
+        >
+          {#snippet actions()}<DatabaseIcon size="18" aria-hidden="true" />{/snippet}
+          <p>
+            {status.packs} immutable pack{status.packs === 1 ? "" : "s"} contain
+            live and logically dead stored payload.
+          </p>
+        </Card>
+
+        <Card
+          level="default"
+          padding="sm"
+          eyebrow="PENDING REPACK"
+          title={formatBytes(status.dead_packed_bytes)}
+        >
+          {#snippet actions()}
+            <Chip
+              size="xs"
+              tone={deadPackedBytes > 0 ? "warning" : "success"}
+            >
+              {deadPackedBytes > 0 ? `${deadPercent}% of packs` : "Compact"}
+            </Chip>
+          {/snippet}
+          <p>
+            {#if status.dead_packed_bytes > 0}
+              Logically dead payload still occupies immutable pack files.
+            {:else}
+              No stored pack payload is waiting to be reclaimed.
+            {/if}
+          </p>
+        </Card>
+      </div>
+
+      <aside class="maintenance-note">
+        <strong>This view never changes storage.</strong>
+        <p>
+          Dead packed bytes are not reclaimed space. Run
+          <code>docbank storage repack</code> explicitly when you want Docbank
+          to rewrite eligible sparse packs and retire their old files.
+        </p>
+      </aside>
+    {/if}
+  </div>
+</DetailDrawer>
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div:first-child {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-heading span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading small {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .drawer-actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .storage {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-5);
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .load-error {
+    display: grid;
+    justify-items: start;
+    gap: var(--space-4);
+  }
+
+  .load-error p,
+  .error {
+    margin: 0;
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+
+  .storage-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+  }
+
+  .storage-grid p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.45;
+  }
+
+  dl {
+    display: grid;
+    gap: var(--space-2);
+    margin: 0;
+  }
+
+  dl > div {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  dt {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  dd {
+    margin: 0;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+  }
+
+  .maintenance-note {
+    padding: var(--space-4);
+    border: 1px solid color-mix(in srgb, var(--accent-amber) 35%, var(--border-default));
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent-amber) 7%, var(--bg-surface));
+  }
+
+  .maintenance-note strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  .maintenance-note p {
+    margin: var(--space-2) 0 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+  }
+
+  .maintenance-note code {
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+  }
+
+  @media (max-width: 640px) {
+    .storage-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/StorageDrawer.test.ts
+++ b/frontend/src/StorageDrawer.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/svelte";
+import StorageDrawer from "./StorageDrawer.svelte";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("storage status drawer", () => {
+  it("separates dead packed payload from live physical authority", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          loose_blobs: 3,
+          loose_bytes: 2048,
+          packs: 2,
+          pack_stored_bytes: 10240,
+          packed_blobs: 12,
+          packed_raw_bytes: 16384,
+          packed_stored_bytes: 8192,
+          dead_packed_bytes: 2048,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const close = vi.fn();
+
+    render(StorageDrawer, {
+      session: "short-lived",
+      onclose: close,
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText(/live packed content/i)).toBeTruthy();
+    expect(screen.getByText(/pending repack/i)).toBeTruthy();
+    expect(screen.getByText("20% of packs")).toBeTruthy();
+    expect(screen.getByText(/Dead packed bytes are not reclaimed space/)).toBeTruthy();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Close storage status" }),
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/StorageDrawer.test.ts
+++ b/frontend/src/StorageDrawer.test.ts
@@ -39,6 +39,9 @@ describe("storage status drawer", () => {
 
     expect(await screen.findByText(/live packed content/i)).toBeTruthy();
     expect(screen.getByText(/pending repack/i)).toBeTruthy();
+    expect(screen.getByText(/3 loose files/)).toBeTruthy();
+    expect(screen.getByText(/12 live packed objects/)).toBeTruthy();
+    expect(screen.queryByText(/authorized objects/i)).toBeNull();
     expect(screen.getByText("20% of packs")).toBeTruthy();
     expect(screen.getByText(/Dead packed bytes are not reclaimed space/)).toBeTruthy();
 

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -9,6 +9,7 @@ import {
   requestJSON,
   revokeSession,
   search,
+  storageStatus,
   tagByID,
   tags,
   takeFragmentSession,
@@ -102,6 +103,18 @@ describe("browser authentication", () => {
 
     await expect(listJobs("session")).resolves.toEqual([]);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/jobs");
+  });
+
+  it("reads physical storage authority through the browser session", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ loose_blobs: 0, packs: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await storageStatus("session");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/storage");
   });
 
   it("reads immutable versions for one stable node", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -200,6 +200,17 @@ export interface JobList {
   items: Job[];
 }
 
+export interface StorageStatus {
+  loose_blobs: number;
+  loose_bytes: number;
+  packs: number;
+  pack_stored_bytes: number;
+  packed_blobs: number;
+  packed_raw_bytes: number;
+  packed_stored_bytes: number;
+  dead_packed_bytes: number;
+}
+
 export interface Problem {
   status?: number;
   code?: string;
@@ -363,4 +374,8 @@ export async function auditHistory(
 export async function listJobs(session: string): Promise<Job[]> {
   const result = await requestJSON<JobList>("/api/v1/jobs", session);
   return result.items;
+}
+
+export async function storageStatus(session: string): Promise<StorageStatus> {
+  return requestJSON<StorageStatus>("/api/v1/storage", session);
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -405,6 +405,10 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
+	resp = webRequest(http.MethodGet, "/api/v1/storage")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
 	resp = webRequest(http.MethodPost, "/api/v1/audit/verify")
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -69,7 +69,7 @@ func webSessionRequestAllowed(method, path string) bool {
 	switch path {
 	case "/api/v1/path", "/api/v1/search",
 		"/api/v1/audit/status", "/api/v1/audit/history", "/api/v1/jobs",
-		"/api/v1/tags":
+		"/api/v1/storage", "/api/v1/tags":
 		return true
 	}
 	const tagPrefix = "/api/v1/tags/"

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "47"
+	daemonProtocolVersion = "48"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Docbank already tells the CLI how content occupies managed storage, but the primary human interface could not answer a basic operational question: **why did disk usage remain after GC?** A person had to leave the browser and translate several related counters before learning whether files were loose, objects were live in packs, or pack payload was only logically dead.

The new top-bar storage view makes that state legible in one place. It separates physical loose-file inventory, catalog-authorized live packed content, total immutable pack payload, and bytes still occupying packs while awaiting repack. Loose files and packed objects remain separate because a redundant or untracked loose file is physical inventory—not additional document authority. In the synthetic example below, 384 KiB is explicitly labeled **Pending repack** and **60% of packs**—not “reclaimed”—so the display cannot overstate freed disk space.

![The actual Docbank web application showing loose files, live-packed content, and pending-repack storage](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-storage-status/web-storage-status.png?v=aec92b2)

*Actual daemon-served interface using a temporary synthetic mixed-storage vault; no private corpus data is present.*

This remains an inspection surface, not a maintenance console. The browser session can read the existing physical-storage status route but cannot pack, garbage-collect, or repack anything. The view points operators to the explicit CLI workflow after they understand the state, and the daemon protocol advances so an older daemon cannot open a partially functional browser. The user documentation carries the same physical-inventory/live-authority/dead-payload distinction.