### PR TITLE
Report packed space left by restore

### DIFF
--- a/cmd/docbank/backup.go
+++ b/cmd/docbank/backup.go
@@ -370,9 +370,9 @@ func writeBackupRestoreReport(w io.Writer, report api.BackupRestoreReport) error
 			report.Storage.LooseBlobs, report.Storage.PackedBlobs, report.Storage.Packs))
 		if report.Storage.DeadPackedBytes > 0 {
 			lines = append(lines, fmt.Sprintf(
-				"pending repack: %s still occupies immutable pack files; inspect the restored vault with "+
-					"`docbank storage status` and run `docbank storage repack` when ready\n",
-				formatBackupBytes(report.Storage.DeadPackedBytes)))
+				"pending repack: %s still occupies immutable pack files; set DOCBANK_HOME to %q, "+
+					"then run `docbank storage status` and `docbank storage repack` when ready\n",
+				formatBackupBytes(report.Storage.DeadPackedBytes), report.Target))
 		}
 	}
 	if report.StorageWarning != "" {

--- a/cmd/docbank/backup.go
+++ b/cmd/docbank/backup.go
@@ -364,6 +364,20 @@ func writeBackupRestoreReport(w io.Writer, report api.BackupRestoreReport) error
 	if report.ExtrasFiles > 0 {
 		lines = append(lines, fmt.Sprintf("extras: %d file(s)\n", report.ExtrasFiles))
 	}
+	if report.Storage != nil {
+		lines = append(lines, fmt.Sprintf(
+			"restored storage: %d loose file(s), %d live packed blob(s) in %d pack(s)\n",
+			report.Storage.LooseBlobs, report.Storage.PackedBlobs, report.Storage.Packs))
+		if report.Storage.DeadPackedBytes > 0 {
+			lines = append(lines, fmt.Sprintf(
+				"pending repack: %s still occupies immutable pack files; inspect the restored vault with "+
+					"`docbank storage status` and run `docbank storage repack` when ready\n",
+				formatBackupBytes(report.Storage.DeadPackedBytes)))
+		}
+	}
+	if report.StorageWarning != "" {
+		lines = append(lines, "warning: "+report.StorageWarning+"\n")
+	}
 	lines = append(lines,
 		"proof: content verified, SQLite integrity ok, manifest stats match\n",
 		fmt.Sprintf("duration: %.1fs\n", report.DurationSeconds))

--- a/cmd/docbank/backup_progress_test.go
+++ b/cmd/docbank/backup_progress_test.go
@@ -111,3 +111,20 @@ func TestBackupProgressModesAndClamping(t *testing.T) {
 	assert.InDelta(t, 0, backupProgressPercent(1, 0), 0)
 	assert.InDelta(t, 100, backupProgressPercent(12, 10), 0)
 }
+
+func TestBackupRestoreReportCallsOutPendingRepack(t *testing.T) {
+	var out bytes.Buffer
+	err := writeBackupRestoreReport(&out, api.BackupRestoreReport{
+		SnapshotID: "snapshot", Target: "/restore", DatabasePath: "/restore/docbank.db",
+		Storage: &api.StorageStatus{
+			LooseBlobs: 8, PackedBlobs: 1863, Packs: 37,
+			DeadPackedBytes: 301394002,
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(),
+		"restored storage: 8 loose file(s), 1863 live packed blob(s) in 37 pack(s)")
+	assert.Contains(t, out.String(), "pending repack: 287.4 MiB still occupies immutable pack files")
+	assert.Contains(t, out.String(), "docbank storage repack")
+	assert.NotContains(t, out.String(), "reclaimed")
+}

--- a/cmd/docbank/backup_progress_test.go
+++ b/cmd/docbank/backup_progress_test.go
@@ -125,6 +125,7 @@ func TestBackupRestoreReportCallsOutPendingRepack(t *testing.T) {
 	assert.Contains(t, out.String(),
 		"restored storage: 8 loose file(s), 1863 live packed blob(s) in 37 pack(s)")
 	assert.Contains(t, out.String(), "pending repack: 287.4 MiB still occupies immutable pack files")
+	assert.Contains(t, out.String(), `set DOCBANK_HOME to "/restore"`)
 	assert.Contains(t, out.String(), "docbank storage repack")
 	assert.NotContains(t, out.String(), "reclaimed")
 }

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -1422,6 +1422,8 @@ func TestBackupInitCreateListVerifyCLI(t *testing.T) {
 	}
 	assert.Contains(t, out, "restored snapshot "+created.ID)
 	assert.Contains(t, out, "1 packed in 1 pack(s), 0 loose")
+	assert.Contains(t, out, "restored storage: 0 loose file(s), 1 live packed blob(s) in 1 pack(s)")
+	assert.Contains(t, out, "pending repack:")
 	assert.Contains(t, out, "proof: content verified, SQLite integrity ok, manifest stats match")
 
 	jsonRestoreTarget := filepath.Join(t.TempDir(), "json-restore")
@@ -1441,6 +1443,9 @@ func TestBackupInitCreateListVerifyCLI(t *testing.T) {
 	assert.True(t, restoreReport.Proof.ContentVerified)
 	assert.True(t, restoreReport.Proof.SQLiteIntegrity)
 	assert.True(t, restoreReport.Proof.ManifestStats)
+	require.NotNil(t, restoreReport.Storage)
+	assert.Positive(t, restoreReport.Storage.DeadPackedBytes)
+	assert.Empty(t, restoreReport.StorageWarning)
 
 	overwriteTarget := filepath.Join(t.TempDir(), "overwrite-restore")
 	require.NoError(t, os.MkdirAll(overwriteTarget, 0o700))

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "48", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "49", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "48", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "49", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "48", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "49", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "48", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "49", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/usage/backup.md
+++ b/docs/usage/backup.md
@@ -185,11 +185,18 @@ counts and explicit `content_verified`, `sqlite_integrity`, and
 vault's physical inventory while its target-tree coordination is still held.
 It reports loose files, live packed blobs, pack count, and any logically dead
 packed bytes that still occupy immutable pack files. Those bytes have not been
-reclaimed: inspect the restored vault with `storage status` and run
-`storage repack` explicitly when appropriate. This reporting never performs
-maintenance automatically. If the proved restore succeeded but this ancillary
-inventory cannot be read, the report remains successful and carries a
-`storage_warning` instead of claiming that the committed restore failed.
+reclaimed. Inspect and repack the restored target explicitly, rather than the
+currently running source vault:
+
+```bash
+DOCBANK_HOME=~/Restores/docbank-test docbank storage status
+DOCBANK_HOME=~/Restores/docbank-test docbank storage repack
+```
+
+This reporting never performs maintenance automatically. If the proved
+restore succeeded but this ancillary inventory cannot be read, the report
+remains successful and carries a `storage_warning` instead of claiming that
+the committed restore failed.
 
 A successful report means the target is a complete vault, but it does not
 automatically replace or start it. Inspect it under its own home first:

--- a/docs/usage/backup.md
+++ b/docs/usage/backup.md
@@ -181,9 +181,18 @@ Interactive restore shows metadata, document, extras, SQLite integrity, and
 manifest-statistics progress as separate stages.
 `--json` suppresses progress and returns one report containing physical layout
 counts and explicit `content_verified`, `sqlite_integrity`, and
-`manifest_stats` proof fields. A successful report means the target is a
-complete vault, but it does not automatically replace or start it. Inspect it
-under its own home first:
+`manifest_stats` proof fields. The terminal report also inspects the restored
+vault's physical inventory while its target-tree coordination is still held.
+It reports loose files, live packed blobs, pack count, and any logically dead
+packed bytes that still occupy immutable pack files. Those bytes have not been
+reclaimed: inspect the restored vault with `storage status` and run
+`storage repack` explicitly when appropriate. This reporting never performs
+maintenance automatically. If the proved restore succeeded but this ancillary
+inventory cannot be read, the report remains successful and carries a
+`storage_warning` instead of claiming that the committed restore failed.
+
+A successful report means the target is a complete vault, but it does not
+automatically replace or start it. Inspect it under its own home first:
 
 ```bash
 DOCBANK_HOME=~/Restores/docbank-test docbank verify

--- a/internal/api/restore_lock.go
+++ b/internal/api/restore_lock.go
@@ -20,6 +20,36 @@ type restoreTargetCoordinator interface {
 	ReleasePreparation() error
 }
 
+type retainedRestoreTargetCoordinator struct {
+	restoreTargetCoordinator
+
+	targetLease backup.RestoreTargetLease
+}
+
+func (c *retainedRestoreTargetCoordinator) AcquireRestoreTarget(
+	ctx context.Context, root *os.Root,
+) (backup.RestoreTargetLease, error) {
+	lease, err := c.restoreTargetCoordinator.AcquireRestoreTarget(ctx, root)
+	if err != nil {
+		return nil, fmt.Errorf("acquiring retained restore target: %w", err)
+	}
+	c.targetLease = lease
+	return retainedRestoreTargetLease{}, nil
+}
+
+func (c *retainedRestoreTargetCoordinator) Release() error {
+	var err error
+	if c.targetLease != nil {
+		err = c.targetLease.Release()
+		c.targetLease = nil
+	}
+	return errors.Join(err, c.ReleasePreparation())
+}
+
+type retainedRestoreTargetLease struct{}
+
+func (retainedRestoreTargetLease) Release() error { return nil }
+
 func newRestoreTargetCoordinator(
 	target, repoRoot, vaultRoot string, overwrite bool,
 ) restoreTargetCoordinator {

--- a/internal/api/routes_backup.go
+++ b/internal/api/routes_backup.go
@@ -444,7 +444,7 @@ func restoreBackupSnapshot(
 			*backup.RestoreResult, error,
 		) {
 			return backupapp.RestoreWithDriver(ctx, repo, version, driver, opts)
-		})
+		}, driver)
 }
 
 type backupRestoreRunner func(
@@ -459,6 +459,7 @@ func restoreBackupSnapshotWith(
 	coordinator restoreTargetCoordinator,
 	progress func(backup.ProgressEvent),
 	run backupRestoreRunner,
+	driver docsqlite.Driver,
 ) (report BackupRestoreReport, retErr error) {
 	if err := coordinator.Prepare(ctx); err != nil {
 		return report, err
@@ -477,7 +478,19 @@ func restoreBackupSnapshotWith(
 	if err != nil {
 		return report, fromBackupError(err)
 	}
-	return backupRestoreReport(target, result), nil
+	stats, inspectErr := backupapp.InspectRestoredStorage(
+		context.WithoutCancel(ctx), target, result.DBPath, driver)
+	if inspectErr != nil {
+		return backupRestoreReport(target, result, nil,
+			"restored physical storage inventory unavailable: "+inspectErr.Error()), nil
+	}
+	storage := StorageStatus{
+		LooseBlobs: stats.LooseBlobs, LooseBytes: stats.LooseBytes,
+		Packs: stats.Packs, PackStoredBytes: stats.PackStoredBytes,
+		PackedBlobs: stats.PackedBlobs, PackedRawBytes: stats.PackedRawBytes,
+		PackedStoredBytes: stats.PackedStoredBytes, DeadPackedBytes: stats.DeadPackedBytes,
+	}
+	return backupRestoreReport(target, result, &storage, ""), nil
 }
 
 func restoreTargetHasPayload(entries []os.DirEntry) bool {
@@ -489,7 +502,12 @@ func restoreTargetHasPayload(entries []os.DirEntry) bool {
 	return false
 }
 
-func backupRestoreReport(target string, result *backup.RestoreResult) BackupRestoreReport {
+func backupRestoreReport(
+	target string,
+	result *backup.RestoreResult,
+	storage *StorageStatus,
+	storageWarning string,
+) BackupRestoreReport {
 	fallbackCounts := make(map[string]int)
 	for _, fallback := range result.PackFallbacks {
 		fallbackCounts[string(fallback.Reason)]++
@@ -512,6 +530,7 @@ func backupRestoreReport(target string, result *backup.RestoreResult) BackupRest
 		LooseBlobs: result.LooseAttachmentBlobs, Packs: result.AttachmentPacks,
 		Fallbacks: fallbacks, ExtrasFiles: result.ExtrasFiles,
 		DurationSeconds: result.Duration.Seconds(),
+		Storage:         storage, StorageWarning: storageWarning,
 		Proof: BackupRestoreProof{
 			ContentVerified: true,
 			SQLiteIntegrity: result.DatabaseIntegrityChecked,

--- a/internal/api/routes_backup.go
+++ b/internal/api/routes_backup.go
@@ -464,16 +464,19 @@ func restoreBackupSnapshotWith(
 	if err := coordinator.Prepare(ctx); err != nil {
 		return report, err
 	}
+	retainedCoordinator := &retainedRestoreTargetCoordinator{
+		restoreTargetCoordinator: coordinator,
+	}
 	defer func() {
-		if err := coordinator.ReleasePreparation(); err != nil {
+		if err := retainedCoordinator.Release(); err != nil {
 			retErr = errors.Join(retErr, NewError(http.StatusInternalServerError, "backup_failed",
-				fmt.Sprintf("releasing backup restore target preparation: %v", err)))
+				fmt.Sprintf("releasing backup restore target coordination: %v", err)))
 		}
 	}()
 	result, err := run(ctx, repo, version.Version, backup.RestoreOptions{
 		SnapshotID: in.SnapshotID, TargetDir: target, Overwrite: true,
 		Jobs: in.Jobs, ForceUnlock: in.ForceUnlock, Progress: progress,
-		TargetCoordinator: coordinator,
+		TargetCoordinator: retainedCoordinator,
 	})
 	if err != nil {
 		return report, fromBackupError(err)

--- a/internal/api/routes_backup_internal_test.go
+++ b/internal/api/routes_backup_internal_test.go
@@ -10,6 +10,11 @@ import (
 )
 
 func TestBackupRestoreReportGroupsFallbacksDeterministically(t *testing.T) {
+	storage := &StorageStatus{
+		LooseBlobs: 2, LooseBytes: 21, Packs: 1, PackStoredBytes: 55,
+		PackedBlobs: 1, PackedRawBytes: 13, PackedStoredBytes: 11,
+		DeadPackedBytes: 44,
+	}
 	report := backupRestoreReport("/restore", &backup.RestoreResult{
 		SnapshotID: "snapshot", DBPath: "/restore/docbank.db", DBBytes: 12,
 		AttachmentBlobs: 3, AttachmentBytes: 34, PackedAttachmentBlobs: 1,
@@ -20,7 +25,7 @@ func TestBackupRestoreReportGroupsFallbacksDeterministically(t *testing.T) {
 			{Reason: packstore.FallbackBlobLimit},
 			{Reason: packstore.FallbackPackPublication},
 		},
-	})
+	}, storage, "")
 	assert.Equal(t, []BackupRestoreFallback{
 		{Reason: "blob_limit", Count: 1},
 		{Reason: "pack_publication", Count: 2},
@@ -29,4 +34,6 @@ func TestBackupRestoreReportGroupsFallbacksDeterministically(t *testing.T) {
 	assert.True(t, report.Proof.ContentVerified)
 	assert.True(t, report.Proof.SQLiteIntegrity)
 	assert.True(t, report.Proof.ManifestStats)
+	assert.Equal(t, storage, report.Storage)
+	assert.Empty(t, report.StorageWarning)
 }

--- a/internal/api/routes_backup_lock_test.go
+++ b/internal/api/routes_backup_lock_test.go
@@ -42,6 +42,32 @@ func TestBackupRestoreCoordinatorExcludesRestoreAndDaemon(t *testing.T) {
 	assert.True(t, lockInfo.Mode().IsRegular())
 }
 
+func TestRetainedRestoreTargetCoordinatorHoldsThroughInspection(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "restore-target")
+	require.NoError(t, os.MkdirAll(target, 0o700))
+	root, err := os.OpenRoot(target)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	coordinator := newRestoreTargetCoordinator(target, "", "", true)
+	require.NoError(t, coordinator.Prepare(t.Context()))
+	retained := &retainedRestoreTargetCoordinator{
+		restoreTargetCoordinator: coordinator,
+	}
+	kitLease, err := retained.AcquireRestoreTarget(t.Context(), root)
+	require.NoError(t, err)
+	require.NoError(t, kitLease.Release(), "Kit completes before inventory inspection")
+
+	_, err = (home.Layout{Root: target}).TryLockExclusive()
+	require.ErrorIs(t, err, home.ErrVaultLocked,
+		"the restored target must remain exclusive while Docbank inspects it")
+
+	require.NoError(t, retained.Release())
+	daemonLock, err := (home.Layout{Root: target}).TryLockExclusive()
+	require.NoError(t, err, "inspection completion must release target ownership")
+	require.NoError(t, daemonLock.Release())
+}
+
 func TestBackupRestoreCoordinatorPinsTargetAcrossPathSwap(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows prevents renaming the directory while its restore root is open")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -793,6 +793,8 @@ type BackupRestoreReport struct {
 	ExtrasFiles     int                     `json:"extras_files"`
 	DurationSeconds float64                 `json:"duration_seconds"`
 	Proof           BackupRestoreProof      `json:"proof"`
+	Storage         *StorageStatus          `json:"storage,omitempty"`
+	StorageWarning  string                  `json:"storage_warning,omitempty"`
 }
 
 // BackupRestoreEvent is one line of the backup-restore NDJSON stream. A report

--- a/internal/backupapp/restore.go
+++ b/internal/backupapp/restore.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"go.kenn.io/kit/backup"
 	"go.kenn.io/kit/packstore"
@@ -80,6 +82,46 @@ func RestoreWithDriver(
 		return nil, fmt.Errorf("backupapp: restoring snapshot: %w", err)
 	}
 	return result, nil
+}
+
+// InspectRestoredStorage reads the physical inventory of a proved restore
+// while its caller still owns target-tree coordination. It does not run
+// maintenance or change blob authority.
+func InspectRestoredStorage(
+	ctx context.Context,
+	target, databasePath string,
+	driver docsqlite.Driver,
+) (stats blob.StorageStats, retErr error) {
+	info, err := os.Lstat(databasePath)
+	if err != nil {
+		return stats, fmt.Errorf("checking restored database: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return stats, fmt.Errorf("restored database is not a regular file: %s", databasePath)
+	}
+	metadata, err := store.Open(databasePath, driver)
+	if err != nil {
+		return stats, fmt.Errorf("opening restored metadata: %w", err)
+	}
+	defer func() {
+		if err := metadata.Close(); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("closing restored metadata: %w", err))
+		}
+	}()
+	physical, err := blob.New(store.NewPackCatalog(metadata), filepath.Join(target, "blobs"))
+	if err != nil {
+		return stats, fmt.Errorf("opening restored blob storage: %w", err)
+	}
+	defer func() {
+		if err := physical.Close(); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("closing restored blob storage: %w", err))
+		}
+	}()
+	stats, err = physical.Stats(ctx)
+	if err != nil {
+		return stats, fmt.Errorf("reading restored physical storage: %w", err)
+	}
+	return stats, nil
 }
 
 func (t *packedRestoreTarget) Limits() packstore.Limits { return t.limits }

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "48"
+	daemonProtocolVersion = "49"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
A restored vault can be completely valid and still consume more disk than its live documents require. Repository packs are immutable containers; when restore needs only part of one, the selected objects receive authority but the other stored payload remains physically present until repack. Our representative 2,061-blob recovery finished byte-perfect with roughly 287 MiB in that state, yet the successful receipt gave the operator no indication that the space was still occupied.

Restore now inspects the completed target before releasing its exclusive target-tree lease, so a competing daemon or restore cannot change the vault between publication and measurement. Both human and JSON receipts report the loose-file count, live packed objects and pack count. When dead payload remains, the human receipt calls it **pending repack**, says those bytes still occupy immutable packs, and names the restored target that must be selected through `DOCBANK_HOME` before running `docbank storage status` or `docbank storage repack`. This prevents maintenance from accidentally being applied to the currently running source vault.

This does not make restore perform maintenance. Recovery remains about faithfully materializing and proving the snapshot, while repack stays an explicit capacity-management decision. If that ancillary inventory cannot be read after the target has already passed restore proof, the receipt remains successful and carries `storage_warning` instead of misleading the caller into retrying an already-committed restore.

The existing incremental-backup integration fixture itself reproduces immediate dead pack payload after restore, and the coordination regression proves the restored target remains unavailable to another daemon until inventory inspection finishes.