### PR TITLE
Browse live documents by tag in the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ Four commitments:
 - A read-only daemon-backed TUI for analytical tree browsing, search, stable
   document/version identity inspection, and permanent audited-history timelines
 - A read-only kit-ui web application for virtual-tree browsing, sortable
-  document analysis, tag-filtered extracted-text search, complete current authority,
-  verified current and historical content download, permanent protection and event history,
-  immutable versions and provenance, daemon background-job status, and an
-  honest loose-file/live-packed/dead-packed storage breakdown
+  document analysis, tag browsing, tag-filtered extracted-text search,
+  complete current authority, verified current and historical content download,
+  permanent protection and event history, immutable versions and provenance,
+  daemon background-job status, and an honest
+  loose-file/live-packed/dead-packed storage breakdown
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule
 - Whole-vault integrity verification

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "49", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "50", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "49", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "50", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "49", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "50", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "49", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "50", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -329,7 +329,10 @@ Assignment receipts return `changed`, the resulting node revision/ETag, and
 the tag's current revision and assignment count. `changed: false` is a successful
 idempotent convergence, not an error. Page `GET /nodes/{id}/tags` and `GET
 /tags/{tag_id}/nodes`; the latter includes trashed nodes without pretending
-they have a live path. Rename and delete by UUID with the most recently
+they have a live path. Set `live_only=true` when one bounded response must
+contain only live nodes and paths from the same metadata snapshot;
+`omitted_trashed` reports the assignments excluded by that projection. Rename
+and delete by UUID with the most recently
 inspected tag ETag in `If-Match`; a concurrent definition or assignment change
 returns `412 stale_revision`. Deleting a tag removes assignments only, never
 nodes or document bytes.

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -449,6 +449,9 @@ its assignment set. `POST /tags`, `GET /tags`, `GET /tags/by-name`,
 and `GET|PATCH|DELETE /tags/{tag_id}` expose definition lifecycle. `GET
 /nodes/{id}/tags` and `GET /tags/{tag_id}/nodes` provide bounded forward and
 reverse listings; reverse results include a path only for live nodes.
+`live_only=true` returns a bounded live projection and `omitted_trashed` count
+from one metadata snapshot, which is suitable for an interactive live browser
+without assembling paths and trash states across pages.
 
 `PUT|DELETE /nodes/{id}/tags/{tag_id}` assign and unassign under the required
 node `If-Match` revision. Their receipt contains the resulting node and tag,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -144,8 +144,9 @@ before a one-use browser handoff, and the browser never buffers the whole
 object or receives the vault API key. Every file exposes its newest-first immutable
 version history and complete version, hash, operation, and revert-source
 authority, plus its newest-first immutable provenance facts and supersession
-history. Every selected node exposes its tag assignments, and text search can
-require one stable tag identity. Protected nodes also expose their permanent newest-first audit timeline
+history. Every selected node exposes its tag assignments, and a stable tag
+identity can drive either a live assignment view or a text-search filter.
+Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
 portal also reports current and terminal daemon background jobs and separates
 physical loose files, live packed content, complete pack payload, and

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -142,10 +142,12 @@ which one. Name matches retain their API relevance ranking and appear before
 content-only matches until you choose an explicit column sort.
 
 Use the tag selector in the browser toolbar without a text query to browse
-every live item carrying one exact assignment. The result table shows complete
-virtual paths and retains the same sorting and authority inspection as search.
-Trashed assignments are omitted from this live view and disclosed in its
-count; `docbank tag nodes` remains the exhaustive live-and-trashed workflow.
+up to 1,000 live items carrying one exact assignment. The bounded result is
+read in one metadata snapshot, so its node state and complete virtual paths
+cannot mix concurrent moves, trash operations, or content updates across
+pages. Trashed assignments are omitted from this live view and disclosed in
+its count; `docbank tag nodes` remains the exhaustive paginated
+live-and-trashed workflow.
 
 With text in the search box, the same selector requires that tag in addition
 to the name or content match. Tag names are displayed for people, while both
@@ -274,8 +276,8 @@ logs, screenshots, issue trackers, or chat.
 
 ## Current boundary
 
-Folder and search views are bounded to 1,000 rows and say when more results
-exist; use the CLI or paginated HTTP API for exhaustive automation. Search has
+Folder, tag, and search views are bounded to 1,000 rows and say when more
+results exist; use the CLI or paginated HTTP API for exhaustive automation. Search has
 the same name and verified extracted-text semantics as `docbank search`.
 Results initially preserve the API's relevance ranking. Choosing Document,
 Size, or Modified changes to that explicit column order; Document compares the

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -17,7 +17,8 @@ the virtual tree, sort a folder by document name, size, or modification time,
 search names and extracted text, and inspect the selected document's stable
 node ID, revision, current version ID, SHA-256 identity, exact size, and media
 type. The authority card also shows every tag assigned to the selected file or
-folder, while search can require one exact tag. Protected documents expose
+folder. Selecting a tag browses its live assignments, while search can require
+the same exact tag identity. Protected documents expose
 their newest-first permanent audit timeline and complete event authority. The
 storage button separates loose content, live packed content, pack-file payload,
 and logically dead packed bytes awaiting repack. The activity button reports
@@ -133,30 +134,35 @@ exists. Use `docbank provenance`, its pagination flags, or the authenticated
 HTTP API for exhaustive automation. Provenance correction and external-content
 pinning are not browser workflows.
 
-## Search names and extracted text
+## Browse tags and search text
 
 Enter a word or phrase in the search box and press Enter. Results can match a
 live document name or verified extracted text. The **Match** column identifies
 which one. Name matches retain their API relevance ranking and appear before
 content-only matches until you choose an explicit column sort.
 
-Use the tag selector in the browser toolbar to require one exact assignment
-for the search. Tag names are displayed for people, while the request is bound
-to the tag's stable UUID so a later rename does not silently change which
-definition was selected. Changing the selector reruns an active search. A text
-query remains required; choosing a tag does not turn the current folder into a
-tag-only listing.
+Use the tag selector in the browser toolbar without a text query to browse
+every live item carrying one exact assignment. The result table shows complete
+virtual paths and retains the same sorting and authority inspection as search.
+Trashed assignments are omitted from this live view and disclosed in its
+count; `docbank tag nodes` remains the exhaustive live-and-trashed workflow.
+
+With text in the search box, the same selector requires that tag in addition
+to the name or content match. Tag names are displayed for people, while both
+workflows are bound to the tag's stable UUID so a later rename does not
+silently change which definition was selected. Changing the selector reruns
+the current browse or search.
 
 ![The Docbank web application showing extracted-text search results in a synthetic vault.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/v0.11.0/web-search-results.png)
 
 *Search results display complete virtual paths and keep the same authority
 inspection available from ordinary folder browsing.*
 
-Clear the search box to return to the current directory. The selector loads at
-most the first 1,000 name-sorted tag definitions and discloses when more exist.
-Use `docbank search` when you need an exhaustive tag catalog, directory,
-media-type, or modification-time filters, structured JSON, or another result
-limit.
+Clear the search box to return to the selected tag's assignment view, or to
+the current directory when **All tags** is selected. The selector loads at most
+the first 1,000 name-sorted tag definitions and discloses when more exist. Use
+`docbank search` when you need an exhaustive tag catalog, directory, media-type,
+or modification-time filters, structured JSON, or another result limit.
 
 ## Read permanent audited history
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -39,19 +39,18 @@
     APIError,
     auditStatusForNode,
     children,
+    liveTaggedNodes,
     nodeTags,
     revokeSession,
     search,
     statPath,
     tagByID,
-    taggedNodes,
     tags,
     takeFragmentSession,
     type AuditStatus,
     type Node,
     type SearchHit,
     type Tag,
-    type TaggedNode,
   } from "./api.js";
   import { basename, formatBytes, formatDate } from "./format.js";
   import { orderRows, reconcileSearchView, type SortField } from "./rows.js";
@@ -289,45 +288,16 @@
     loading = true;
     error = "";
     try {
-      let items: TaggedNode[] = [];
-      let total = 0;
-      let stable = false;
-      for (let attempt = 0; attempt < 3 && !stable; attempt += 1) {
-        const before = await tagByID(webSession, tagID);
-        if (request !== generation) return;
-        const byNodeID = new Map<number, TaggedNode>();
-        let inspected = 0;
-        total = before.assignment_count;
-        while (inspected < total) {
-          const page = await taggedNodes(webSession, tagID, inspected);
-          if (request !== generation) return;
-          total = page.total;
-          if (page.items.length === 0) break;
-          inspected += page.items.length;
-          for (const item of page.items) byNodeID.set(item.node.id, item);
-        }
-        const after = await tagByID(webSession, tagID);
-        if (request !== generation) return;
-        stable =
-          before.revision === after.revision &&
-          after.assignment_count === total &&
-          inspected >= total &&
-          byNodeID.size === total;
-        if (stable) items = [...byNodeID.values()];
-      }
-      if (!stable) {
-        throw new Error("Tag assignments changed while loading. Refresh and try again.");
-      }
-      const liveRows = items
-        .filter((item) => !item.node.trashed_at && item.path)
-        .map((item) => ({ node: item.node, path: item.path! }));
+      const page = await liveTaggedNodes(webSession, tagID);
+      if (request !== generation) return;
+      const liveRows = page.items.map((item) => ({ node: item.node, path: item.path! }));
       rows = liveRows;
       activeQuery = "";
       activeTagID = tagID;
-      taggedInspected = items.length;
-      taggedTotal = total;
-      taggedTrashed = items.length - liveRows.length;
-      truncated = total > items.length;
+      taggedInspected = liveRows.length;
+      taggedTotal = page.total;
+      taggedTrashed = page.omitted_trashed ?? 0;
+      truncated = page.total > liveRows.length;
       if (!refreshing) {
         sortField = "name";
         sortDirection = "asc";

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -51,6 +51,7 @@
     type Node,
     type SearchHit,
     type Tag,
+    type TaggedNode,
   } from "./api.js";
   import { basename, formatBytes, formatDate } from "./format.js";
   import { orderRows, reconcileSearchView, type SortField } from "./rows.js";
@@ -287,18 +288,25 @@
     loading = true;
     error = "";
     try {
-      const page = await taggedNodes(webSession, tagID);
-      if (request !== generation) return;
-      const liveRows = page.items
+      const items: TaggedNode[] = [];
+      let total = 0;
+      do {
+        const page = await taggedNodes(webSession, tagID, items.length);
+        if (request !== generation) return;
+        total = page.total;
+        if (page.items.length === 0) break;
+        items.push(...page.items);
+      } while (items.length < total);
+      const liveRows = items
         .filter((item) => !item.node.trashed_at && item.path)
         .map((item) => ({ node: item.node, path: item.path! }));
       rows = liveRows;
       activeQuery = "";
       activeTagID = tagID;
-      taggedInspected = page.items.length;
-      taggedTotal = page.total;
-      taggedTrashed = page.items.length - liveRows.length;
-      truncated = page.total > page.items.length;
+      taggedInspected = items.length;
+      taggedTotal = total;
+      taggedTrashed = items.length - liveRows.length;
+      truncated = total > items.length;
       if (!refreshing) {
         sortField = "name";
         sortDirection = "asc";
@@ -350,7 +358,7 @@
     tagFilterID = tagID;
     if (activeQuery || searchPending) void runSearch();
     else if (tagID) void loadTaggedNodes(tagID);
-    else if (activeTagID && directory) void loadDirectory(directory.id, false);
+    else if (directory) void loadDirectory(directory.id, false);
   }
 
   function activate(row: Row): void {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -281,6 +281,7 @@
   }
 
   async function loadTaggedNodes(tagID: string): Promise<void> {
+    if (!directory) return;
     const request = ++generation;
     const refreshing = activeQuery === "" && activeTagID === tagID;
     const previousSelectedID = selectedID;
@@ -288,15 +289,35 @@
     loading = true;
     error = "";
     try {
-      const items: TaggedNode[] = [];
+      let items: TaggedNode[] = [];
       let total = 0;
-      do {
-        const page = await taggedNodes(webSession, tagID, items.length);
+      let stable = false;
+      for (let attempt = 0; attempt < 3 && !stable; attempt += 1) {
+        const before = await tagByID(webSession, tagID);
         if (request !== generation) return;
-        total = page.total;
-        if (page.items.length === 0) break;
-        items.push(...page.items);
-      } while (items.length < total);
+        const byNodeID = new Map<number, TaggedNode>();
+        let inspected = 0;
+        total = before.assignment_count;
+        while (inspected < total) {
+          const page = await taggedNodes(webSession, tagID, inspected);
+          if (request !== generation) return;
+          total = page.total;
+          if (page.items.length === 0) break;
+          inspected += page.items.length;
+          for (const item of page.items) byNodeID.set(item.node.id, item);
+        }
+        const after = await tagByID(webSession, tagID);
+        if (request !== generation) return;
+        stable =
+          before.revision === after.revision &&
+          after.assignment_count === total &&
+          inspected >= total &&
+          byNodeID.size === total;
+        if (stable) items = [...byNodeID.values()];
+      }
+      if (!stable) {
+        throw new Error("Tag assignments changed while loading. Refresh and try again.");
+      }
       const liveRows = items
         .filter((item) => !item.node.trashed_at && item.path)
         .map((item) => ({ node: item.node, path: item.path! }));
@@ -644,7 +665,7 @@
                 : tagCatalogTotal > tagCatalogListed
                   ? `Browse or filter: showing ${tagCatalogListed} of ${tagCatalogTotal} tags`
                   : "Browse or filter by tag"}
-              disabled={tagCatalog.length === 0}
+              disabled={!directory || tagCatalog.length === 0}
               onchange={changeTagFilter}
             />
             {#if tagBrowse}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -338,7 +338,10 @@
           : liveRows[0]?.node.id,
       );
     } catch (cause) {
-      if (request === generation) handleFailure(cause);
+      if (request === generation) {
+        tagFilterID = activeTagID;
+        handleFailure(cause);
+      }
     } finally {
       if (request === generation) loading = false;
     }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -44,6 +44,7 @@
     search,
     statPath,
     tagByID,
+    taggedNodes,
     tags,
     takeFragmentSession,
     type AuditStatus,
@@ -63,6 +64,9 @@
     activeTagID: string;
     searchQuery: string;
     tagFilterID: string;
+    taggedInspected: number;
+    taggedTotal: number;
+    taggedTrashed: number;
     truncated: boolean;
     sortField: SortField;
     sortDirection: SortDirection;
@@ -77,6 +81,9 @@
   let activeQuery = $state("");
   let tagFilterID = $state("");
   let activeTagID = $state("");
+  let taggedInspected = $state(0);
+  let taggedTotal = $state(0);
+  let taggedTrashed = $state(0);
   let tagCatalog = $state<Tag[]>([]);
   let tagCatalogTotal = $state(0);
   let tagCatalogListed = $state(0);
@@ -115,8 +122,9 @@
     })),
   ]);
   const activeTag = $derived(tagCatalog.find((tag) => tag.id === activeTagID));
+  const tagBrowse = $derived(activeTagID !== "" && activeQuery === "");
   const sortedRows = $derived(
-    orderRows(rows, sortField, sortDirection, activeQuery !== ""),
+    orderRows(rows, sortField, sortDirection, activeQuery !== "" || tagBrowse),
   );
 
   onMount(() => {
@@ -181,6 +189,9 @@
             activeTagID,
             searchQuery,
             tagFilterID,
+            taggedInspected,
+            taggedTotal,
+            taggedTrashed,
             truncated,
             sortField,
             sortDirection,
@@ -197,6 +208,9 @@
       selectNode(rows[0]?.node.id);
       activeQuery = "";
       activeTagID = "";
+      taggedInspected = 0;
+      taggedTotal = 0;
+      taggedTrashed = 0;
       truncated = page.total > page.items.length;
       sortField = "name";
       sortDirection = "asc";
@@ -218,7 +232,8 @@
   async function runSearch(): Promise<void> {
     const query = searchQuery.trim();
     if (!query) {
-      if (directory) await loadDirectory(directory.id, false);
+      if (tagFilterID) await loadTaggedNodes(tagFilterID);
+      else if (directory) await loadDirectory(directory.id, false);
       return;
     }
     const request = ++generation;
@@ -247,6 +262,9 @@
       );
       activeQuery = query;
       activeTagID = requestedTagID;
+      taggedInspected = 0;
+      taggedTotal = 0;
+      taggedTrashed = 0;
       truncated = report.truncated;
       sortField = view.sortField;
       sortDirection = view.sortDirection;
@@ -258,6 +276,42 @@
         searchPending = false;
         loading = false;
       }
+    }
+  }
+
+  async function loadTaggedNodes(tagID: string): Promise<void> {
+    const request = ++generation;
+    const refreshing = activeQuery === "" && activeTagID === tagID;
+    const previousSelectedID = selectedID;
+    searchPending = false;
+    loading = true;
+    error = "";
+    try {
+      const page = await taggedNodes(webSession, tagID);
+      if (request !== generation) return;
+      const liveRows = page.items
+        .filter((item) => !item.node.trashed_at && item.path)
+        .map((item) => ({ node: item.node, path: item.path! }));
+      rows = liveRows;
+      activeQuery = "";
+      activeTagID = tagID;
+      taggedInspected = page.items.length;
+      taggedTotal = page.total;
+      taggedTrashed = page.items.length - liveRows.length;
+      truncated = page.total > page.items.length;
+      if (!refreshing) {
+        sortField = "name";
+        sortDirection = "asc";
+      }
+      selectNode(
+        refreshing && liveRows.some((row) => row.node.id === previousSelectedID)
+          ? previousSelectedID
+          : liveRows[0]?.node.id,
+      );
+    } catch (cause) {
+      if (request === generation) handleFailure(cause);
+    } finally {
+      if (request === generation) loading = false;
     }
   }
 
@@ -274,6 +328,9 @@
     activeTagID = previous.activeTagID;
     searchQuery = previous.searchQuery;
     tagFilterID = previous.tagFilterID;
+    taggedInspected = previous.taggedInspected;
+    taggedTotal = previous.taggedTotal;
+    taggedTrashed = previous.taggedTrashed;
     truncated = previous.truncated;
     sortField = previous.sortField;
     sortDirection = previous.sortDirection;
@@ -284,12 +341,16 @@
 
   function clearSearch(): void {
     searchQuery = "";
-    if ((activeQuery || searchPending) && directory) void loadDirectory(directory.id, false);
+    if (!activeQuery && !searchPending) return;
+    if (tagFilterID) void loadTaggedNodes(tagFilterID);
+    else if (directory) void loadDirectory(directory.id, false);
   }
 
   function changeTagFilter(tagID: string): void {
     tagFilterID = tagID;
     if (activeQuery || searchPending) void runSearch();
+    else if (tagID) void loadTaggedNodes(tagID);
+    else if (activeTagID && directory) void loadDirectory(directory.id, false);
   }
 
   function activate(row: Row): void {
@@ -352,9 +413,14 @@
       tagCatalogListed = page.items.length;
       if (selectedMissing && tagFilterID === selectedTagID) {
         const rerunSearch = Boolean(activeQuery || searchPending);
+        const leaveTagBrowse = activeQuery === "" && activeTagID === selectedTagID;
         tagFilterID = "";
         activeTagID = "";
+        taggedInspected = 0;
+        taggedTotal = 0;
+        taggedTrashed = 0;
         if (rerunSearch && searchQuery.trim()) void runSearch();
+        else if (leaveTagBrowse && directory) void loadDirectory(directory.id, false);
       }
     } catch (cause) {
       if (request !== tagCatalogGeneration || session !== webSession) return;
@@ -445,6 +511,9 @@
     storageOpen = false;
     activeQuery = "";
     activeTagID = "";
+    taggedInspected = 0;
+    taggedTotal = 0;
+    taggedTrashed = 0;
     searchPending = false;
     searchQuery = "";
     tagFilterID = "";
@@ -546,10 +615,14 @@
               <ArrowLeftIcon size="14" aria-hidden="true" />
             </IconButton>
             <div>
-              <span>{activeQuery ? "Search results" : "Current folder"}</span>
+              <span>
+                {activeQuery ? "Search results" : tagBrowse ? "Documents tagged" : "Current folder"}
+              </span>
               <strong>
                 {activeQuery
                   ? `“${activeQuery}”${activeTag ? ` · ${activeTag.name}` : ""}`
+                  : tagBrowse
+                    ? activeTag?.name ?? activeTagID
                   : directory?.path ?? "/"}
               </strong>
             </div>
@@ -561,18 +634,27 @@
               title={tagCatalogError
                 ? `Tags unavailable: ${tagCatalogError}`
                 : tagCatalogTotal > tagCatalogListed
-                  ? `Tag filter: showing ${tagCatalogListed} of ${tagCatalogTotal} tags`
-                  : "Filter search by tag"}
+                  ? `Browse or filter: showing ${tagCatalogListed} of ${tagCatalogTotal} tags`
+                  : "Browse or filter by tag"}
               disabled={tagCatalog.length === 0}
               onchange={changeTagFilter}
             />
-            <span>{rows.length}{truncated ? "+" : ""} item{rows.length === 1 ? "" : "s"}</span>
+            {#if tagBrowse}
+              <span>
+                {rows.length} live shown
+                {#if taggedTrashed > 0} · {taggedTrashed} trashed omitted{/if}
+                {#if truncated} · first {taggedInspected} of {taggedTotal} assignments{/if}
+              </span>
+            {:else}
+              <span>{rows.length}{truncated ? "+" : ""} item{rows.length === 1 ? "" : "s"}</span>
+            {/if}
             <IconButton
               size="sm"
               ariaLabel="Refresh current view"
               onclick={() => {
                 void loadTagCatalog();
                 if (activeQuery) void runSearch();
+                else if (activeTagID) void loadTaggedNodes(activeTagID);
                 else if (directory) void loadDirectory(directory.id, false);
               }}
             >
@@ -588,13 +670,27 @@
           <div class="loading"><Spinner size={16} /> Loading vault…</div>
         {:else if rows.length === 0}
           <EmptyState
-            title={activeQuery ? "No matching documents" : "This folder is empty"}
+            title={activeQuery
+              ? "No matching documents"
+              : tagBrowse
+                ? "No live documents carry this tag"
+                : "This folder is empty"}
             description={activeQuery
               ? "Try another name or phrase from extracted text."
-              : "Use the CLI, API, or an agent to file documents here."}
+              : tagBrowse
+                ? taggedTrashed > 0
+                  ? `${taggedTrashed} trashed assignment${taggedTrashed === 1 ? " is" : "s are"} omitted from this live view.`
+                  : "Choose another tag or return to the current folder."
+                : "Use the CLI, API, or an agent to file documents here."}
           >
             {#snippet icon()}
-              {#if activeQuery}<SearchIcon size="22" />{:else}<FolderIcon size="22" />{/if}
+              {#if activeQuery}
+                <SearchIcon size="22" />
+              {:else if tagBrowse}
+                <TagIcon size="22" />
+              {:else}
+                <FolderIcon size="22" />
+              {/if}
             {/snippet}
           </EmptyState>
         {:else}
@@ -641,7 +737,7 @@
                       {:else}
                         <FileIcon size="15" aria-hidden="true" />
                       {/if}
-                      <span>{activeQuery ? row.path : row.node.name}</span>
+                      <span>{activeQuery || tagBrowse ? row.path : row.node.name}</span>
                     </span>
                   </td>
                   <td>{row.node.kind === "dir" ? "Folder" : row.node.mime_type || "File"}</td>

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -105,6 +105,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     });
   let tagCatalogReads = 0;
   let tagResolutionMode: "browse" | "renamed" | "missing" = "browse";
+  let failNextTagResolution = false;
   let tagConsistencyReads = 0;
   let renamedTagResolved = false;
   let missingTagResolved = false;
@@ -152,6 +153,16 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       });
     }
     if (url === "/api/v1/tags/33333333-3333-4333-8333-333333333333") {
+      if (failNextTagResolution) {
+        failNextTagResolution = false;
+        return new Response(
+          JSON.stringify({ status: 503, detail: "tag catalog temporarily unavailable" }),
+          {
+            status: 503,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
       if (tagResolutionMode === "missing") {
         missingTagResolved = true;
         return new Response(
@@ -275,6 +286,17 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     }),
   );
   await waitFor(() => expect(screen.queryByText("Documents tagged")).toBeNull());
+
+  failNextTagResolution = true;
+  await fireEvent.click(
+    screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
+  );
+  await fireEvent.click(screen.getByRole("option", { name: "tax (3)" }));
+  expect(await screen.findByText("tag catalog temporarily unavailable")).toBeTruthy();
+  expect(
+    screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
+  ).toBeTruthy();
+  expect(screen.getByText("This folder is empty")).toBeTruthy();
 
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -34,6 +34,10 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   const unfiltered = new Promise<Response>((resolve) => {
     resolveUnfiltered = resolve;
   });
+  let resolveInitialTagBrowse!: (response: Response) => void;
+  const initialTagBrowse = new Promise<Response>((resolve) => {
+    resolveInitialTagBrowse = resolve;
+  });
   const root = {
     id: 1,
     name: "",
@@ -72,6 +76,13 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     blob_hash: "f".repeat(64),
     trashed_at: "2026-07-27T12:30:00Z",
   };
+  const olderTrashedReport = {
+    ...trashedReport,
+    id: 7,
+    name: "older-tax-report.txt",
+    current_version_id: "77777777-7777-4777-8777-777777777777",
+    blob_hash: "7".repeat(64),
+  };
   const archiveDirectory = {
     id: 5,
     parent_id: 1,
@@ -90,6 +101,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     });
   let tagCatalogReads = 0;
   let tagReads = 0;
+  let tagBrowseReads = 0;
   let unfilteredSearches = 0;
   const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = String(input);
@@ -116,7 +128,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
                   id: "33333333-3333-4333-8333-333333333333",
                   name: "tax",
                   revision: 1,
-                  assignment_count: 2,
+                  assignment_count: 3,
                 },
               ]
             : [
@@ -147,21 +159,31 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
         id: "33333333-3333-4333-8333-333333333333",
         name: "tax records",
         revision: 2,
-        assignment_count: 2,
+        assignment_count: 3,
       });
     }
     if (
       url ===
       "/api/v1/tags/33333333-3333-4333-8333-333333333333/nodes?limit=1000&offset=0"
     ) {
+      tagBrowseReads += 1;
+      if (tagBrowseReads === 1) return initialTagBrowse;
       return json({
-        items: [
-          { node: taxReport, path: "/Reports/quarterly-tax-report.txt" },
-          { node: trashedReport },
-        ],
-        total: 2,
+        items: [{ node: trashedReport }, { node: olderTrashedReport }],
+        total: 3,
         limit: 1000,
         offset: 0,
+      });
+    }
+    if (
+      url ===
+      "/api/v1/tags/33333333-3333-4333-8333-333333333333/nodes?limit=1000&offset=2"
+    ) {
+      return json({
+        items: [{ node: taxReport, path: "/Reports/quarterly-tax-report.txt" }],
+        total: 3,
+        limit: 1000,
+        offset: 2,
       });
     }
     if (url === "/api/v1/search?q=quarterly&limit=1000") {
@@ -213,14 +235,33 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
   );
-  await fireEvent.click(screen.getByRole("option", { name: "tax (2)" }));
+  await fireEvent.click(screen.getByRole("option", { name: "tax (3)" }));
+  await fireEvent.click(
+    screen.getByRole("combobox", { name: "Browse or filter by tag: tax" }),
+  );
+  await fireEvent.click(screen.getByRole("option", { name: "All tags" }));
+  await screen.findByText("This folder is empty");
+  resolveInitialTagBrowse(
+    json({
+      items: [{ node: trashedReport }, { node: olderTrashedReport }],
+      total: 3,
+      limit: 1000,
+      offset: 0,
+    }),
+  );
+  await waitFor(() => expect(screen.queryByText("Documents tagged")).toBeNull());
+
+  await fireEvent.click(
+    screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
+  );
+  await fireEvent.click(screen.getByRole("option", { name: "tax (3)" }));
   expect(await screen.findByText("Documents tagged")).toBeTruthy();
   expect(screen.getByText("tax", { selector: "strong" })).toBeTruthy();
   expect(
     screen.getByRole("cell", { name: "/Reports/quarterly-tax-report.txt" }),
   ).toBeTruthy();
   expect(screen.queryByText("superseded-tax-report.txt")).toBeNull();
-  expect(screen.getByText(/1 live shown · 1 trashed omitted/)).toBeTruthy();
+  expect(screen.getByText(/1 live shown · 2 trashed omitted/)).toBeTruthy();
 
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Browse or filter by tag: tax" }),
@@ -237,7 +278,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
   );
-  await fireEvent.click(screen.getByRole("option", { name: "tax (2)" }));
+  await fireEvent.click(screen.getByRole("option", { name: "tax (3)" }));
   expect(
     await screen.findByRole("cell", { name: "/Reports/quarterly-tax-report.txt" }),
   ).toBeTruthy();

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -72,21 +72,6 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     current_version_id: "22222222-2222-4222-8222-222222222222",
     blob_hash: "b".repeat(64),
   };
-  const trashedReport = {
-    ...taxReport,
-    id: 6,
-    name: "superseded-tax-report.txt",
-    current_version_id: "66666666-6666-4666-8666-666666666666",
-    blob_hash: "f".repeat(64),
-    trashed_at: "2026-07-27T12:30:00Z",
-  };
-  const olderTrashedReport = {
-    ...trashedReport,
-    id: 7,
-    name: "older-tax-report.txt",
-    current_version_id: "77777777-7777-4777-8777-777777777777",
-    blob_hash: "7".repeat(64),
-  };
   const archiveDirectory = {
     id: 5,
     parent_id: 1,
@@ -105,8 +90,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     });
   let tagCatalogReads = 0;
   let tagResolutionMode: "browse" | "renamed" | "missing" = "browse";
-  let failNextTagResolution = false;
-  let tagConsistencyReads = 0;
+  let failNextTagBrowse = false;
   let renamedTagResolved = false;
   let missingTagResolved = false;
   let tagBrowseReads = 0;
@@ -153,16 +137,6 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       });
     }
     if (url === "/api/v1/tags/33333333-3333-4333-8333-333333333333") {
-      if (failNextTagResolution) {
-        failNextTagResolution = false;
-        return new Response(
-          JSON.stringify({ status: 503, detail: "tag catalog temporarily unavailable" }),
-          {
-            status: 503,
-            headers: { "Content-Type": "application/json" },
-          },
-        );
-      }
       if (tagResolutionMode === "missing") {
         missingTagResolved = true;
         return new Response(
@@ -182,39 +156,35 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
           assignment_count: 3,
         });
       }
-      tagConsistencyReads += 1;
       return json({
         id: "33333333-3333-4333-8333-333333333333",
         name: "tax",
-        revision: tagConsistencyReads >= 3 ? 2 : 1,
+        revision: 1,
         assignment_count: 3,
       });
     }
     if (
       url ===
-      "/api/v1/tags/33333333-3333-4333-8333-333333333333/nodes?limit=1000&offset=0"
+      "/api/v1/tags/33333333-3333-4333-8333-333333333333/nodes?limit=1000&offset=0&live_only=true"
     ) {
       tagBrowseReads += 1;
       if (tagBrowseReads === 1) return initialTagBrowse;
-      return json({
-        items:
-          tagBrowseReads === 2
-            ? [{ node: trashedReport }, { node: trashedReport }]
-            : [{ node: trashedReport }, { node: olderTrashedReport }],
-        total: 3,
-        limit: 1000,
-        offset: 0,
-      });
-    }
-    if (
-      url ===
-      "/api/v1/tags/33333333-3333-4333-8333-333333333333/nodes?limit=1000&offset=2"
-    ) {
+      if (failNextTagBrowse) {
+        failNextTagBrowse = false;
+        return new Response(
+          JSON.stringify({ status: 503, detail: "tag catalog temporarily unavailable" }),
+          {
+            status: 503,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
       return json({
         items: [{ node: taxReport, path: "/Reports/quarterly-tax-report.txt" }],
-        total: 3,
+        total: 1,
         limit: 1000,
-        offset: 2,
+        offset: 0,
+        omitted_trashed: 2,
       });
     }
     if (url === "/api/v1/search?q=quarterly&limit=1000") {
@@ -279,15 +249,16 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   await screen.findByText("This folder is empty");
   resolveInitialTagBrowse(
     json({
-      items: [{ node: trashedReport }, { node: olderTrashedReport }],
-      total: 3,
+      items: [{ node: taxReport, path: "/Reports/quarterly-tax-report.txt" }],
+      total: 1,
       limit: 1000,
       offset: 0,
+      omitted_trashed: 2,
     }),
   );
   await waitFor(() => expect(screen.queryByText("Documents tagged")).toBeNull());
 
-  failNextTagResolution = true;
+  failNextTagBrowse = true;
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
   );

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -34,6 +34,10 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   const unfiltered = new Promise<Response>((resolve) => {
     resolveUnfiltered = resolve;
   });
+  let resolveRoot!: (response: Response) => void;
+  const initialRoot = new Promise<Response>((resolve) => {
+    resolveRoot = resolve;
+  });
   let resolveInitialTagBrowse!: (response: Response) => void;
   const initialTagBrowse = new Promise<Response>((resolve) => {
     resolveInitialTagBrowse = resolve;
@@ -100,12 +104,15 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       headers: { "Content-Type": "application/json" },
     });
   let tagCatalogReads = 0;
-  let tagReads = 0;
+  let tagResolutionMode: "browse" | "renamed" | "missing" = "browse";
+  let tagConsistencyReads = 0;
+  let renamedTagResolved = false;
+  let missingTagResolved = false;
   let tagBrowseReads = 0;
   let unfilteredSearches = 0;
   const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = String(input);
-    if (url === "/api/v1/path?path=%2F") return json(root);
+    if (url === "/api/v1/path?path=%2F") return initialRoot;
     if (url === "/api/v1/nodes/1/children?limit=1000&offset=0") {
       return json({ directory: root, items: [], total: 0, limit: 1000, offset: 0 });
     }
@@ -145,8 +152,8 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       });
     }
     if (url === "/api/v1/tags/33333333-3333-4333-8333-333333333333") {
-      tagReads += 1;
-      if (tagReads > 1) {
+      if (tagResolutionMode === "missing") {
+        missingTagResolved = true;
         return new Response(
           JSON.stringify({ status: 404, detail: "tag not found" }),
           {
@@ -155,10 +162,20 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
           },
         );
       }
+      if (tagResolutionMode === "renamed") {
+        renamedTagResolved = true;
+        return json({
+          id: "33333333-3333-4333-8333-333333333333",
+          name: "tax records",
+          revision: 3,
+          assignment_count: 3,
+        });
+      }
+      tagConsistencyReads += 1;
       return json({
         id: "33333333-3333-4333-8333-333333333333",
-        name: "tax records",
-        revision: 2,
+        name: "tax",
+        revision: tagConsistencyReads >= 3 ? 2 : 1,
         assignment_count: 3,
       });
     }
@@ -169,7 +186,10 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       tagBrowseReads += 1;
       if (tagBrowseReads === 1) return initialTagBrowse;
       return json({
-        items: [{ node: trashedReport }, { node: olderTrashedReport }],
+        items:
+          tagBrowseReads === 2
+            ? [{ node: trashedReport }, { node: trashedReport }]
+            : [{ node: trashedReport }, { node: olderTrashedReport }],
         total: 3,
         limit: 1000,
         offset: 0,
@@ -229,8 +249,13 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
 
   render(App);
   const input = await screen.findByRole("searchbox", { name: "Search documents" });
-  await screen.findByRole("combobox", { name: "Browse or filter by tag: All tags" });
+  const tagSelector = await screen.findByRole("combobox", {
+    name: "Browse or filter by tag: All tags",
+  });
+  expect(tagSelector.hasAttribute("disabled")).toBe(true);
+  resolveRoot(json(root));
   await screen.findByText("This folder is empty");
+  expect(tagSelector.hasAttribute("disabled")).toBe(false);
 
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
@@ -302,6 +327,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     ).toBeNull(),
   );
 
+  tagResolutionMode = "renamed";
   await fireEvent.click(screen.getByRole("button", { name: "Refresh current view" }));
   await waitFor(() =>
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain(
@@ -313,6 +339,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       "Browse or filter: showing 1 of 1001 tags: tax records",
     ),
   );
+  expect(renamedTagResolved).toBe(true);
   expect(screen.getByText("“quarterly” · tax records")).toBeTruthy();
 
   await fireEvent.dblClick(screen.getByRole("cell", { name: "/Archive" }));
@@ -333,10 +360,11 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
 
   const back = screen.getByRole("button", { name: "Back to previous directory" });
   expect(back.hasAttribute("disabled")).toBe(false);
+  tagResolutionMode = "missing";
   await fireEvent.click(back);
   await waitFor(() => expect(tagCatalogReads).toBe(3));
   expect(screen.getByRole("combobox").getAttribute("aria-label")).toContain("tax records");
-  await waitFor(() => expect(tagReads).toBe(2));
+  await waitFor(() => expect(missingTagResolved).toBe(true));
   await waitFor(() => expect(unfilteredSearches).toBe(2));
   expect(
     await screen.findByRole("cell", { name: "/Reports/quarterly-product-report.txt" }),

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -64,6 +64,14 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
     current_version_id: "22222222-2222-4222-8222-222222222222",
     blob_hash: "b".repeat(64),
   };
+  const trashedReport = {
+    ...taxReport,
+    id: 6,
+    name: "superseded-tax-report.txt",
+    current_version_id: "66666666-6666-4666-8666-666666666666",
+    blob_hash: "f".repeat(64),
+    trashed_at: "2026-07-27T12:30:00Z",
+  };
   const archiveDirectory = {
     id: 5,
     parent_id: 1,
@@ -108,7 +116,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
                   id: "33333333-3333-4333-8333-333333333333",
                   name: "tax",
                   revision: 1,
-                  assignment_count: 1,
+                  assignment_count: 2,
                 },
               ]
             : [
@@ -140,6 +148,20 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
         name: "tax records",
         revision: 2,
         assignment_count: 2,
+      });
+    }
+    if (
+      url ===
+      "/api/v1/tags/33333333-3333-4333-8333-333333333333/nodes?limit=1000&offset=0"
+    ) {
+      return json({
+        items: [
+          { node: taxReport, path: "/Reports/quarterly-tax-report.txt" },
+          { node: trashedReport },
+        ],
+        total: 2,
+        limit: 1000,
+        offset: 0,
       });
     }
     if (url === "/api/v1/search?q=quarterly&limit=1000") {
@@ -185,8 +207,27 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
 
   render(App);
   const input = await screen.findByRole("searchbox", { name: "Search documents" });
-  await screen.findByRole("combobox", { name: "Filter search by tag: All tags" });
+  await screen.findByRole("combobox", { name: "Browse or filter by tag: All tags" });
   await screen.findByText("This folder is empty");
+
+  await fireEvent.click(
+    screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
+  );
+  await fireEvent.click(screen.getByRole("option", { name: "tax (2)" }));
+  expect(await screen.findByText("Documents tagged")).toBeTruthy();
+  expect(screen.getByText("tax", { selector: "strong" })).toBeTruthy();
+  expect(
+    screen.getByRole("cell", { name: "/Reports/quarterly-tax-report.txt" }),
+  ).toBeTruthy();
+  expect(screen.queryByText("superseded-tax-report.txt")).toBeNull();
+  expect(screen.getByText(/1 live shown · 1 trashed omitted/)).toBeTruthy();
+
+  await fireEvent.click(
+    screen.getByRole("combobox", { name: "Browse or filter by tag: tax" }),
+  );
+  await fireEvent.click(screen.getByRole("option", { name: "All tags" }));
+  await screen.findByText("This folder is empty");
+
   await fireEvent.input(input, { target: { value: "quarterly" } });
   await fireEvent.submit(input.closest("form")!);
   await waitFor(() =>
@@ -194,9 +235,9 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   );
 
   await fireEvent.click(
-    screen.getByRole("combobox", { name: "Filter search by tag: All tags" }),
+    screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
   );
-  await fireEvent.click(screen.getByRole("option", { name: "tax (1)" }));
+  await fireEvent.click(screen.getByRole("option", { name: "tax (2)" }));
   expect(
     await screen.findByRole("cell", { name: "/Reports/quarterly-tax-report.txt" }),
   ).toBeTruthy();
@@ -228,7 +269,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   );
   await waitFor(() =>
     expect(screen.getByRole("combobox").getAttribute("aria-label")).toBe(
-      "Tag filter: showing 1 of 1001 tags: tax records",
+      "Browse or filter: showing 1 of 1001 tags: tax records",
     ),
   );
   expect(screen.getByText("“quarterly” · tax records")).toBeTruthy();
@@ -240,7 +281,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   ).length;
   await fireEvent.click(
     screen.getByRole("combobox", {
-      name: "Tag filter: showing 1 of 1001 tags: tax records",
+      name: "Browse or filter: showing 1 of 1001 tags: tax records",
     }),
   );
   await fireEvent.click(screen.getByRole("option", { name: "All tags" }));
@@ -263,7 +304,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   expect(screen.queryByText("“quarterly” · tax records")).toBeNull();
   expect(
     screen.getByRole("combobox", {
-      name: "Tag filter: showing 1 of 1001 tags: All tags",
+      name: "Browse or filter: showing 1 of 1001 tags: All tags",
     }),
   ).toBeTruthy();
 });

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -5,6 +5,7 @@ import {
   auditStatusForNode,
   contentVersions,
   listJobs,
+  liveTaggedNodes,
   nodeTags,
   requestJSON,
   revokeSession,
@@ -143,6 +144,7 @@ describe("browser authentication", () => {
     await tags("session");
     await tagByID("session", "11111111-1111-4111-8111-111111111111");
     await taggedNodes("session", "11111111-1111-4111-8111-111111111111");
+    await liveTaggedNodes("session", "11111111-1111-4111-8111-111111111111");
     await nodeTags("session", 42);
     await search("session", "quarterly report", "11111111-1111-4111-8111-111111111111");
 
@@ -150,6 +152,7 @@ describe("browser authentication", () => {
       "/api/v1/tags?limit=1000&offset=0",
       "/api/v1/tags/11111111-1111-4111-8111-111111111111",
       "/api/v1/tags/11111111-1111-4111-8111-111111111111/nodes?limit=1000&offset=0",
+      "/api/v1/tags/11111111-1111-4111-8111-111111111111/nodes?limit=1000&offset=0&live_only=true",
       "/api/v1/nodes/42/tags?limit=1000&offset=0",
       "/api/v1/search?q=quarterly+report&limit=1000&tag_id=11111111-1111-4111-8111-111111111111",
     ]);

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -11,6 +11,7 @@ import {
   search,
   storageStatus,
   tagByID,
+  taggedNodes,
   tags,
   takeFragmentSession,
 } from "./api.js";
@@ -141,12 +142,14 @@ describe("browser authentication", () => {
 
     await tags("session");
     await tagByID("session", "11111111-1111-4111-8111-111111111111");
+    await taggedNodes("session", "11111111-1111-4111-8111-111111111111");
     await nodeTags("session", 42);
     await search("session", "quarterly report", "11111111-1111-4111-8111-111111111111");
 
     expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
       "/api/v1/tags?limit=1000&offset=0",
       "/api/v1/tags/11111111-1111-4111-8111-111111111111",
+      "/api/v1/tags/11111111-1111-4111-8111-111111111111/nodes?limit=1000&offset=0",
       "/api/v1/nodes/42/tags?limit=1000&offset=0",
       "/api/v1/search?q=quarterly+report&limit=1000&tag_id=11111111-1111-4111-8111-111111111111",
     ]);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -93,6 +93,18 @@ export interface TagPage {
   offset: number;
 }
 
+export interface TaggedNode {
+  node: Node;
+  path?: string;
+}
+
+export interface TaggedNodePage {
+  items: TaggedNode[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface AuditScopeStatus {
   id: string;
   target_node_id: number;
@@ -336,6 +348,16 @@ export async function tags(session: string): Promise<TagPage> {
 
 export async function tagByID(session: string, tagID: string): Promise<Tag> {
   return requestJSON<Tag>(`/api/v1/tags/${encodeURIComponent(tagID)}`, session);
+}
+
+export async function taggedNodes(
+  session: string,
+  tagID: string,
+): Promise<TaggedNodePage> {
+  return requestJSON<TaggedNodePage>(
+    `/api/v1/tags/${encodeURIComponent(tagID)}/nodes?limit=1000&offset=0`,
+    session,
+  );
 }
 
 export async function nodeTags(session: string, nodeID: number): Promise<TagPage> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -103,6 +103,7 @@ export interface TaggedNodePage {
   total: number;
   limit: number;
   offset: number;
+  omitted_trashed?: number;
 }
 
 export interface AuditScopeStatus {
@@ -357,6 +358,16 @@ export async function taggedNodes(
 ): Promise<TaggedNodePage> {
   return requestJSON<TaggedNodePage>(
     `/api/v1/tags/${encodeURIComponent(tagID)}/nodes?limit=1000&offset=${offset}`,
+    session,
+  );
+}
+
+export async function liveTaggedNodes(
+  session: string,
+  tagID: string,
+): Promise<TaggedNodePage> {
+  return requestJSON<TaggedNodePage>(
+    `/api/v1/tags/${encodeURIComponent(tagID)}/nodes?limit=1000&offset=0&live_only=true`,
     session,
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -353,9 +353,10 @@ export async function tagByID(session: string, tagID: string): Promise<Tag> {
 export async function taggedNodes(
   session: string,
   tagID: string,
+  offset = 0,
 ): Promise<TaggedNodePage> {
   return requestJSON<TaggedNodePage>(
-    `/api/v1/tags/${encodeURIComponent(tagID)}/nodes?limit=1000&offset=0`,
+    `/api/v1/tags/${encodeURIComponent(tagID)}/nodes?limit=1000&offset=${offset}`,
     session,
   );
 }

--- a/internal/api/routes_tags.go
+++ b/internal/api/routes_tags.go
@@ -73,16 +73,29 @@ func registerTagRoutes(api huma.API, d Deps, g *gate) {
 		Path:    "/api/v1/tags/{tag_id}/nodes",
 		Summary: "List live and trashed nodes carrying a tag",
 	}, func(ctx context.Context, in *struct {
-		TagID  string `path:"tag_id"`
-		Limit  int    `query:"limit" default:"100" minimum:"1" maximum:"1000"`
-		Offset int    `query:"offset" default:"0" minimum:"0"`
+		TagID    string `path:"tag_id"`
+		Limit    int    `query:"limit" default:"100" minimum:"1" maximum:"1000"`
+		Offset   int    `query:"offset" default:"0" minimum:"0"`
+		LiveOnly bool   `query:"live_only" default:"false"`
 	}) (*taggedNodePageOutput, error) {
-		nodes, total, err := d.Store.TaggedNodes(ctx, in.TagID, in.Limit, in.Offset)
+		var (
+			nodes          []store.TaggedNode
+			total          int
+			omittedTrashed int
+			err            error
+		)
+		if in.LiveOnly {
+			nodes, total, omittedTrashed, err =
+				d.Store.LiveTaggedNodes(ctx, in.TagID, in.Limit, in.Offset)
+		} else {
+			nodes, total, err = d.Store.TaggedNodes(ctx, in.TagID, in.Limit, in.Offset)
+		}
 		if err != nil {
 			return nil, FromStoreError(err)
 		}
 		out := &taggedNodePageOutput{Body: TaggedNodePage{
 			Items: []TaggedNode{}, Total: total, Limit: in.Limit, Offset: in.Offset,
+			OmittedTrashed: omittedTrashed,
 		}}
 		for _, node := range nodes {
 			item := TaggedNode{Node: fromStoreNode(node.Node), Path: node.Path}

--- a/internal/api/routes_tags_test.go
+++ b/internal/api/routes_tags_test.go
@@ -84,6 +84,15 @@ func TestTagLifecycleHTTP(t *testing.T) {
 	assert.Equal(t, node.ID, nodes.Items[0].Node.ID)
 	assert.Equal(t, "/records", nodes.Items[0].Path)
 
+	resp, body = get(t, ts,
+		"/api/v1/tags/"+tag.ID+"/nodes?limit=10&offset=0&live_only=true", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	require.NoError(t, json.Unmarshal([]byte(body), &nodes))
+	assert.Equal(t, 1, nodes.Total)
+	assert.Equal(t, 0, nodes.OmittedTrashed)
+	require.Len(t, nodes.Items, 1)
+	assert.Equal(t, "/records", nodes.Items[0].Path)
+
 	resp, body = do(t, ts, http.MethodPatch, "/api/v1/tags/"+tag.ID, nil,
 		map[string]any{"name": "tax records"})
 	assert.Equal(t, http.StatusPreconditionRequired, resp.StatusCode)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -397,6 +397,11 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 
 	resp = webRequest(http.MethodGet,
+		"/api/v1/tags/"+tag.ID+"/nodes?limit=1000&offset=0")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = webRequest(http.MethodGet,
 		"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/tags?limit=1000&offset=0")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -192,10 +192,11 @@ type TaggedNode struct {
 
 // TaggedNodePage is one bounded stable-ID-sorted reverse tag lookup.
 type TaggedNodePage struct {
-	Items  []TaggedNode `json:"items"`
-	Total  int          `json:"total"`
-	Limit  int          `json:"limit"`
-	Offset int          `json:"offset"`
+	Items          []TaggedNode `json:"items"`
+	Total          int          `json:"total"`
+	Limit          int          `json:"limit"`
+	Offset         int          `json:"offset"`
+	OmittedTrashed int          `json:"omitted_trashed,omitempty" minimum:"0"`
 }
 
 // TagAssignmentReceipt records whether an idempotent assignment request

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -74,8 +74,9 @@ func webSessionRequestAllowed(method, path string) bool {
 	}
 	const tagPrefix = "/api/v1/tags/"
 	if after, ok := strings.CutPrefix(path, tagPrefix); ok {
-		tagID := after
-		return tagID != "" && !strings.Contains(tagID, "/")
+		parts := strings.Split(after, "/")
+		return parts[0] != "" &&
+			(len(parts) == 1 || (len(parts) == 2 && parts[1] == "nodes"))
 	}
 	const prefix = "/api/v1/nodes/"
 	if !strings.HasPrefix(path, prefix) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1792,7 +1792,8 @@ func validateTagPage(page api.TagPage, limit, offset int) error {
 
 func validateTaggedNodePage(page api.TaggedNodePage, limit, offset int) error {
 	if limit < 1 || limit > 1000 || offset < 0 || page.Limit != limit ||
-		page.Offset != offset || page.Total < 0 || len(page.Items) > limit ||
+		page.Offset != offset || page.Total < 0 || page.OmittedTrashed < 0 ||
+		len(page.Items) > limit ||
 		(len(page.Items) == 0 && offset < page.Total) ||
 		(len(page.Items) > 0 && offset+len(page.Items) > page.Total) {
 		return errors.New("tagged-node response has inconsistent pagination")

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "49"
+	daemonProtocolVersion = "50"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -499,11 +499,30 @@ func (s *Store) NodeTags(ctx context.Context, nodeID int64, limit, offset int) (
 
 // TaggedNodes lists one ID-sorted page of nodes carrying tagID.
 func (s *Store) TaggedNodes(ctx context.Context, tagID string, limit, offset int) ([]TaggedNode, int, error) {
+	nodes, total, _, err := s.taggedNodes(ctx, tagID, limit, offset, false)
+	return nodes, total, err
+}
+
+// LiveTaggedNodes lists one ID-sorted page of live nodes carrying tagID. The
+// omitted count covers trashed assignments in the same read snapshot.
+func (s *Store) LiveTaggedNodes(
+	ctx context.Context, tagID string, limit, offset int,
+) ([]TaggedNode, int, int, error) {
+	return s.taggedNodes(ctx, tagID, limit, offset, true)
+}
+
+func (s *Store) taggedNodes(
+	ctx context.Context, tagID string, limit, offset int, liveOnly bool,
+) ([]TaggedNode, int, int, error) {
 	if err := validateTagPage(limit, offset); err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
 	if err := validateUUIDv4(tagID); err != nil {
-		return nil, 0, fmt.Errorf("tag %q: %w", tagID, ErrNotFound)
+		return nil, 0, 0, fmt.Errorf("tag %q: %w", tagID, ErrNotFound)
+	}
+	pageFilter := ""
+	if liveOnly {
+		pageFilter = " WHERE trashed_at IS NULL"
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		WITH RECURSIVE target AS (SELECT id FROM tags WHERE id = ?),
@@ -518,8 +537,12 @@ func (s *Store) TaggedNodes(ctx context.Context, tagID string, limit, offset int
 		  WHERE nt.tag_id = ?
 		),
 		page AS (
-		  SELECT * FROM matching ORDER BY id LIMIT ? OFFSET ?
-		), totals AS (SELECT COUNT(*) AS total FROM matching),
+		  SELECT * FROM matching`+pageFilter+` ORDER BY id LIMIT ? OFFSET ?
+		), totals AS (
+		  SELECT COUNT(*) AS total,
+		         COALESCE(SUM(CASE WHEN trashed_at IS NULL THEN 1 ELSE 0 END), 0) AS live_total
+		  FROM matching
+		),
 		ancestry(node_id, id, parent_id, path) AS (
 		  SELECT id, id, parent_id, CASE WHEN name = '' THEN '/' ELSE name END
 		  FROM page WHERE trashed_at IS NULL
@@ -529,7 +552,7 @@ func (s *Store) TaggedNodes(ctx context.Context, tagID string, limit, offset int
 		  FROM nodes n JOIN ancestry a ON n.id = a.parent_id
 		  WHERE n.trashed_at IS NULL
 		), paths AS (SELECT node_id, path FROM ancestry WHERE parent_id IS NULL)
-		SELECT totals.total, COALESCE(page.id, 0), page.parent_id,
+		SELECT totals.total, totals.live_total, COALESCE(page.id, 0), page.parent_id,
 		       COALESCE(page.name, ''), COALESCE(page.kind, ''),
 		       COALESCE(page.current_version_id, ''), COALESCE(page.blob_hash, ''),
 		       COALESCE(page.size, 0), COALESCE(page.mime_type, ''),
@@ -540,33 +563,36 @@ func (s *Store) TaggedNodes(ctx context.Context, tagID string, limit, offset int
 		LEFT JOIN paths ON paths.node_id = page.id ORDER BY page.id`,
 		tagID, tagID, limit, offset)
 	if err != nil {
-		return nil, 0, fmt.Errorf("listing nodes for tag %s: %w", tagID, err)
+		return nil, 0, 0, fmt.Errorf("listing nodes for tag %s: %w", tagID, err)
 	}
 	defer func() { _ = rows.Close() }()
 	var nodes []TaggedNode
-	var total int
+	var assignmentTotal, liveTotal int
 	found := false
 	for rows.Next() {
 		found = true
 		var tagged TaggedNode
-		if err := rows.Scan(&total, &tagged.Node.ID, &tagged.Node.ParentID,
+		if err := rows.Scan(&assignmentTotal, &liveTotal, &tagged.Node.ID, &tagged.Node.ParentID,
 			&tagged.Node.Name, &tagged.Node.Kind, &tagged.Node.CurrentVersionID,
 			&tagged.Node.BlobHash, &tagged.Node.Size, &tagged.Node.MimeType,
 			&tagged.Node.Revision, &tagged.Node.CreatedAt, &tagged.Node.ModifiedAt,
 			&tagged.Node.TrashedAt, &tagged.Path); err != nil {
-			return nil, 0, fmt.Errorf("listing nodes for tag %s: scanning page: %w", tagID, err)
+			return nil, 0, 0, fmt.Errorf("listing nodes for tag %s: scanning page: %w", tagID, err)
 		}
 		if tagged.Node.ID != 0 {
 			nodes = append(nodes, tagged)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, fmt.Errorf("listing nodes for tag %s: %w", tagID, err)
+		return nil, 0, 0, fmt.Errorf("listing nodes for tag %s: %w", tagID, err)
 	}
 	if !found {
-		return nil, 0, fmt.Errorf("tag %q: %w", tagID, ErrNotFound)
+		return nil, 0, 0, fmt.Errorf("tag %q: %w", tagID, ErrNotFound)
 	}
-	return nodes, total, nil
+	if liveOnly {
+		return nodes, liveTotal, assignmentTotal - liveTotal, nil
+	}
+	return nodes, assignmentTotal, 0, nil
 }
 
 func tagByIDTx(tx *sql.Tx, id string) (Tag, error) {

--- a/internal/store/tag_test.go
+++ b/internal/store/tag_test.go
@@ -153,6 +153,18 @@ func TestTagQueriesAreBoundedAndIncludeTrashedNodes(t *testing.T) {
 	require.NotNil(t, nodes[0].Node.TrashedAt)
 	assert.Empty(t, nodes[0].Path)
 
+	live, err := s.Mkdir(ctx, s.RootID(), "live")
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, first.ID, live.ID, live.Revision)
+	require.NoError(t, err)
+	liveNodes, liveTotal, omittedTrashed, err := s.LiveTaggedNodes(ctx, first.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, liveTotal)
+	assert.Equal(t, 1, omittedTrashed)
+	require.Len(t, liveNodes, 1)
+	assert.Equal(t, live.ID, liveNodes[0].Node.ID)
+	assert.Equal(t, "/live", liveNodes[0].Path)
+
 	_, _, err = s.NodeTags(ctx, 99999, 10, 0)
 	require.ErrorIs(t, err, ErrNotFound)
 	_, _, err = s.TaggedNodes(ctx, "00000000-0000-4000-8000-000000000000", 10, 0)


### PR DESCRIPTION
Tags should be useful as a browsing surface, not only as an extra condition attached to a text search. A person can now choose `tax`, `reviewed`, or another tag with an empty search box and immediately see its live documents.

The result uses complete virtual paths and keeps the same sorting, selection, authority inspection, and navigation available elsewhere in the document browser. Docbank reads up to 1,000 live assignments and their paths in one metadata snapshot, so concurrent moves, trash operations, or content updates cannot leave the table assembled from incompatible moments. Trashed assignments stay out of the live table but are counted from that same snapshot, and the browser says when additional live assignments exist. The paginated CLI and HTTP API remain the exhaustive workflow.

Changing the selector remains authoritative even when an older request is still in flight: returning to **All tags** cannot be undone by a delayed tag response. A failed new selection restores the selector to the view still on screen, so Refresh cannot silently target a different tag. Text search continues to use the same selector as an exact stable-ID filter, and tag rename or deletion refresh behavior remains consistent across browsing and search.

The browser remains read-only. Tag creation, assignment, mutation, and exhaustive live-and-trashed automation remain CLI or authenticated API workflows.
