### PR TITLE
Inspect stable document tags in the TUI

### DIFF
--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -149,6 +149,14 @@ func (b *tuiDaemonBackend) Search(
 	})
 }
 
+func (b *tuiDaemonBackend) NodeTags(
+	ctx context.Context, nodeID int64, limit, offset int,
+) (api.TagPage, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) (api.TagPage, error) {
+		return c.NodeTags(ctx, nodeID, limit, offset)
+	})
+}
+
 func (b *tuiDaemonBackend) AuditHistory(
 	ctx context.Context, path string, nodeID int64, limit int, cursor string,
 ) (api.AuditEventPage, error) {

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -26,7 +26,9 @@ hide secondary columns so the document name remains useful.
 Press <kbd>i</kbd> to leave the table temporarily and inspect the selected
 document's complete stable node selector, path, revision, modification time,
 and—when it is a file—its immutable version, SHA-256 identity, exact size, and
-media type. Long authority values wrap rather than truncate.
+media type. The same authority view lists every assigned tag name with its
+stable UUID, so renames remain distinguishable from identity. Long authority
+values wrap rather than truncate.
 
 Press <kbd>a</kbd> on any selected node to open its permanent audited history.
 The timeline is newest first and shows when each event was recorded, what

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -33,6 +33,7 @@ type Backend interface {
 	Node(ctx context.Context, nodeID int64) (api.Node, error)
 	ChildrenPage(ctx context.Context, nodeID int64, limit, offset int) (api.NodePage, error)
 	Search(ctx context.Context, query string, limit int) (api.SearchReport, error)
+	NodeTags(ctx context.Context, nodeID int64, limit, offset int) (api.TagPage, error)
 	AuditHistory(
 		ctx context.Context, path string, nodeID int64, limit int, cursor string,
 	) (api.AuditEventPage, error)
@@ -105,6 +106,12 @@ type historyLoadedMsg struct {
 	err       error
 }
 
+type detailTagsLoadedMsg struct {
+	requestID uint64
+	page      api.TagPage
+	err       error
+}
+
 type spinnerTickMsg struct{}
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -143,6 +150,11 @@ type Model struct {
 	helpOpen            bool
 	detailOpen          bool
 	detailOffset        int
+	detailTags          []api.Tag
+	detailTagsTotal     int
+	detailTagsLoading   bool
+	detailTagsErr       error
+	detailRequestID     uint64
 	historyOpen         bool
 	historyNode         row
 	historyPages        []api.AuditEventPage
@@ -204,6 +216,18 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applySearch(msg)
 	case historyLoadedMsg:
 		return m.applyHistory(msg)
+	case detailTagsLoadedMsg:
+		if !m.detailOpen || msg.requestID != m.detailRequestID {
+			return m, nil
+		}
+		m.detailTagsLoading = false
+		m.detailTagsErr = msg.err
+		if msg.err == nil {
+			m.detailTags = msg.page.Items
+			m.detailTagsTotal = msg.page.Total
+		}
+		m.clampDetailOffset()
+		return m, nil
 	case spinnerTickMsg:
 		if !m.loading {
 			m.spinnerActive = false
@@ -288,11 +312,7 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.sortRowsPreservingSelection()
 		return m, nil
 	case "i":
-		if _, ok := m.selected(); ok {
-			m.detailOpen = true
-			m.detailOffset = 0
-		}
-		return m, nil
+		return m.openDetail()
 	case "a":
 		selected, ok := m.selected()
 		if !ok {
@@ -348,9 +368,7 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "enter", "right", "l":
 		selected, ok := m.selected()
 		if ok && selected.node.Kind != nodeKindDir {
-			m.detailOpen = true
-			m.detailOffset = 0
-			return m, nil
+			return m.openDetail()
 		}
 		if ok {
 			m.loading = true
@@ -496,6 +514,7 @@ func (m Model) updateDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "i", "enter", "esc", "left", "h", "backspace":
 		m.detailOpen = false
 		m.detailOffset = 0
+		m.detailRequestID++
 	case "up", "k":
 		m.detailOffset--
 		m.clampDetailOffset()
@@ -514,6 +533,29 @@ func (m Model) updateDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.detailOffset = max(len(m.expandedDetailLines(m.width))-m.detailViewportHeight(), 0)
 	}
 	return m, nil
+}
+
+func (m Model) openDetail() (tea.Model, tea.Cmd) {
+	selected, ok := m.selected()
+	if !ok {
+		return m, nil
+	}
+	m.detailOpen = true
+	m.detailOffset = 0
+	m.detailTags = nil
+	m.detailTagsTotal = 0
+	m.detailTagsLoading = true
+	m.detailTagsErr = nil
+	m.detailRequestID++
+	return m, m.loadDetailTags(selected.node.ID, m.detailRequestID)
+}
+
+func (m Model) loadDetailTags(nodeID int64, requestID uint64) tea.Cmd {
+	ctx, backend := m.ctx, m.backend
+	return func() tea.Msg {
+		page, err := backend.NodeTags(ctx, nodeID, maxBrowserItems, 0)
+		return detailTagsLoadedMsg{requestID: requestID, page: page, err: err}
+	}
 }
 
 func (m Model) loadDirectory(

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -150,6 +150,7 @@ type Model struct {
 	helpOpen            bool
 	detailOpen          bool
 	detailOffset        int
+	detailNode          row
 	detailTags          []api.Tag
 	detailTagsTotal     int
 	detailTagsLoading   bool
@@ -542,6 +543,7 @@ func (m Model) openDetail() (tea.Model, tea.Cmd) {
 	}
 	m.detailOpen = true
 	m.detailOffset = 0
+	m.detailNode = selected
 	m.detailTags = nil
 	m.detailTagsTotal = 0
 	m.detailTagsLoading = true

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -116,6 +116,10 @@ type spinnerTickMsg struct{}
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
+var errDetailNodeChanged = errors.New(
+	"document changed while loading tags; close and inspect it again",
+)
+
 const spinnerInterval = 80 * time.Millisecond
 
 // Model is a read-only virtual-tree, search, and audited-history browser. Update uses a value
@@ -549,13 +553,22 @@ func (m Model) openDetail() (tea.Model, tea.Cmd) {
 	m.detailTagsLoading = true
 	m.detailTagsErr = nil
 	m.detailRequestID++
-	return m, m.loadDetailTags(selected.node.ID, m.detailRequestID)
+	return m, m.loadDetailTags(
+		selected.node.ID, selected.node.Revision, m.detailRequestID,
+	)
 }
 
-func (m Model) loadDetailTags(nodeID int64, requestID uint64) tea.Cmd {
+func (m Model) loadDetailTags(nodeID, revision int64, requestID uint64) tea.Cmd {
 	ctx, backend := m.ctx, m.backend
 	return func() tea.Msg {
 		page, err := backend.NodeTags(ctx, nodeID, maxBrowserItems, 0)
+		if err == nil {
+			var current api.Node
+			current, err = backend.Node(ctx, nodeID)
+			if err == nil && current.Revision != revision {
+				err = errDetailNodeChanged
+			}
+		}
 		return detailTagsLoadedMsg{requestID: requestID, page: page, err: err}
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -29,6 +29,8 @@ type fakeBackend struct {
 	historyErr     error
 	historyIDs     []int64
 	historyCursors []string
+	tags           map[int64]api.TagPage
+	tagNodeIDs     []int64
 }
 
 func newFakeBackend() *fakeBackend {
@@ -85,6 +87,21 @@ func newFakeBackend() *fakeBackend {
 				},
 			},
 		},
+		tags: map[int64]api.TagPage{
+			readme.ID: {
+				Items: []api.Tag{
+					{
+						ID:   "88888888-8888-4888-8888-888888888888",
+						Name: "reviewed", Revision: 2, AssignmentCount: 3,
+					},
+					{
+						ID:   "99999999-9999-4999-8999-999999999999",
+						Name: "tax", Revision: 4, AssignmentCount: 7,
+					},
+				},
+				Total: 2, Limit: maxBrowserItems,
+			},
+		},
 	}
 }
 
@@ -131,6 +148,19 @@ func (f *fakeBackend) Search(
 		return api.SearchReport{}, f.err
 	}
 	return f.search, nil
+}
+
+func (f *fakeBackend) NodeTags(
+	_ context.Context, nodeID int64, limit, offset int,
+) (api.TagPage, error) {
+	f.tagNodeIDs = append(f.tagNodeIDs, nodeID)
+	if f.err != nil {
+		return api.TagPage{}, f.err
+	}
+	page := f.tags[nodeID]
+	page.Limit = limit
+	page.Offset = offset
+	return page, nil
 }
 
 func (f *fakeBackend) AuditHistory(
@@ -724,14 +754,21 @@ func TestExpandedDetailExposesCompleteAuthority(t *testing.T) {
 	model.cursor = 1
 
 	model, cmd := updateModel(t, model, key(tea.KeyEnter))
-	require.Nil(t, cmd)
+	require.NotNil(t, cmd)
 	require.True(t, model.detailOpen)
+	model = runModelCommand(t, model, cmd)
+	assert.Equal(t, []int64{3}, backend.tagNodeIDs)
 	selected, ok := model.selected()
 	require.True(t, ok)
 	content := model.View().Content
 	assert.Contains(t, content, selected.node.CurrentVersionID)
 	assert.Contains(t, content, selected.node.BlobHash)
 	assert.Contains(t, content, "esc close")
+	fullDetail := strings.Join(model.expandedDetailLines(model.width), "\n")
+	assert.Contains(t, fullDetail, `"reviewed"`)
+	assert.Contains(t, fullDetail, "88888888-8888-4888-8888-888888888888")
+	assert.Contains(t, fullDetail, `"tax"`)
+	assert.Contains(t, fullDetail, "99999999-9999-4999-8999-999999999999")
 
 	model.width, model.height = 24, 8
 	lines := model.expandedDetailLines(model.width)
@@ -744,6 +781,24 @@ func TestExpandedDetailExposesCompleteAuthority(t *testing.T) {
 	model, cmd = updateModel(t, model, key(tea.KeyEscape))
 	require.Nil(t, cmd)
 	assert.False(t, model.detailOpen)
+}
+
+func TestClosingDetailInvalidatesDelayedTags(t *testing.T) {
+	model, err := New(t.Context(), newFakeBackend())
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.cursor = 1
+
+	model, delayed := updateModel(t, model, key(tea.KeyEnter))
+	require.NotNil(t, delayed)
+	pendingRequestID := model.detailRequestID
+	model, _ = updateModel(t, model, key(tea.KeyEscape))
+	assert.False(t, model.detailOpen)
+	assert.Greater(t, model.detailRequestID, pendingRequestID)
+
+	model = runModelCommand(t, model, delayed)
+	assert.False(t, model.detailOpen)
+	assert.Empty(t, model.detailTags)
 }
 
 func TestHelpAndSpinnerAreVisible(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -801,6 +801,42 @@ func TestClosingDetailInvalidatesDelayedTags(t *testing.T) {
 	assert.Empty(t, model.detailTags)
 }
 
+func TestDetailSnapshotSurvivesDelayedRefresh(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.cursor = 1
+
+	model, delayedTags := updateModel(t, model, key(tea.KeyEnter))
+	require.NotNil(t, delayedTags)
+	replacement := api.Node{
+		ID: 10, ParentID: new(int64(1)), Kind: "file", Name: "replacement.txt",
+		Revision: 1, CurrentVersionID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+		BlobHash: strings.Repeat("f", 64), Size: 99, ModifiedAt: "2026-07-28T12:00:00Z",
+	}
+	model, _ = updateModel(t, model, directoryLoadedMsg{
+		requestID: model.requestID,
+		kind:      navigationRefresh,
+		directory: model.directory,
+		page: api.NodePage{
+			Directory: model.directory,
+			Items:     []api.Node{replacement},
+			Total:     1,
+			Limit:     maxBrowserItems,
+		},
+	})
+	require.Equal(t, int64(10), model.rows[0].node.ID)
+
+	model = runModelCommand(t, model, delayedTags)
+	detail := strings.Join(model.expandedDetailLines(120), "\n")
+	assert.Contains(t, detail, `Path: "/README.txt"`)
+	assert.Contains(t, detail, strings.Repeat("a", 64))
+	assert.Contains(t, detail, `"reviewed"`)
+	assert.NotContains(t, detail, "replacement.txt")
+	assert.NotContains(t, detail, strings.Repeat("f", 64))
+}
+
 func TestHelpAndSpinnerAreVisible(t *testing.T) {
 	model, err := New(t.Context(), newFakeBackend())
 	require.NoError(t, err)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -837,6 +837,26 @@ func TestDetailSnapshotSurvivesDelayedRefresh(t *testing.T) {
 	assert.NotContains(t, detail, strings.Repeat("f", 64))
 }
 
+func TestDetailRejectsTagsAfterNodeRevisionChanges(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.cursor = 1
+
+	model, delayedTags := updateModel(t, model, key(tea.KeyEnter))
+	require.NotNil(t, delayedTags)
+	changed := backend.nodes["/README.txt"]
+	changed.Revision++
+	backend.nodes["/README.txt"] = changed
+
+	model = runModelCommand(t, model, delayedTags)
+	require.ErrorIs(t, model.detailTagsErr, errDetailNodeChanged)
+	assert.Empty(t, model.detailTags)
+	assert.Contains(t, strings.Join(model.expandedDetailLines(120), "\n"),
+		"document changed while loading tags")
+}
+
 func TestHelpAndSpinnerAreVisible(t *testing.T) {
 	model, err := New(t.Context(), newFakeBackend())
 	require.NoError(t, err)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -562,12 +562,11 @@ func (m Model) expandedDetailLines(width int) []string {
 	heading := m.styles.heading.Render(pad(fit(" Complete document authority", width), width))
 	separator := m.styles.separator.Render(strings.Repeat("─", max(width, 0)))
 	lines := []string{heading, separator}
-	selected, ok := m.selected()
-	if !ok {
+	if m.detailNode.node.ID == 0 {
 		return append(lines, m.styles.muted.Render(" Nothing selected"))
 	}
 
-	node := selected.node
+	node := m.detailNode.node
 	fields := make([]string, 0, 10)
 	if node.Kind == nodeKindFile {
 		fields = append(fields,
@@ -576,7 +575,7 @@ func (m Model) expandedDetailLines(width int) []string {
 		)
 	}
 	fields = append(fields,
-		" Path: "+quoted(selected.path),
+		" Path: "+quoted(m.detailNode.path),
 		fmt.Sprintf(" Selector: id:%d", node.ID),
 		" Kind: "+node.Kind,
 		fmt.Sprintf(" Revision: %d", node.Revision),

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -594,6 +594,30 @@ func (m Model) expandedDetailLines(width int) []string {
 			lines = append(lines, pad(line, width))
 		}
 	}
+	lines = append(lines, separator)
+	switch {
+	case m.detailTagsLoading:
+		lines = append(lines, m.styles.muted.Render(pad(" Tags: loading...", width)))
+	case m.detailTagsErr != nil:
+		lines = append(lines, m.styles.error.Render(pad(
+			fit(" Tags unavailable: "+quoted(m.detailTagsErr.Error()), width), width,
+		)))
+	case len(m.detailTags) == 0:
+		lines = append(lines, m.styles.muted.Render(pad(" Tags: none", width)))
+	default:
+		label := fmt.Sprintf(" Tags (%d)", m.detailTagsTotal)
+		if m.detailTagsTotal > len(m.detailTags) {
+			label = fmt.Sprintf(" Tags (first %d of %d)", len(m.detailTags), m.detailTagsTotal)
+		}
+		lines = append(lines, m.styles.heading.Render(pad(fit(label, width), width)))
+		for _, tag := range m.detailTags {
+			field := "   " + quoted(tag.Name) + "  " + tag.ID
+			wrapped := ansi.Hardwrap(field, max(width, 1), false)
+			for line := range strings.SplitSeq(wrapped, "\n") {
+				lines = append(lines, pad(line, width))
+			}
+		}
+	}
 	return lines
 }
 


### PR DESCRIPTION
A person browsing Docbank in the terminal can now answer “how is this document classified?” without leaving the TUI. Pressing `i` still opens the complete document-authority view, and that view now includes every assigned tag’s human name and full stable UUID.

![The actual Docbank TUI showing stable tag identities for a synthetic quarterly report](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/tui-tag-inspection/tui-tag-inspection.png?v=1363387)

*Actual TUI output from a temporary synthetic vault; no private corpus data is present.*

Tag names remain the readable surface, while UUIDs make the identity unambiguous after a rename and give an agent something durable to retain. Long values wrap instead of truncating, and a vault with more than the bounded 1,000 assignments says that the view is partial rather than implying completeness.

The TUI remains read-only and daemon-backed. It loads tags only while the authority panel is open, reports loading, absence, and failure explicitly, and discards a delayed response if the panel has already closed. Tag creation and assignment remain ordinary CLI or authenticated API workflows.
