### PR TITLE
Inspect daemon jobs in the TUI

### DIFF
--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -157,6 +157,12 @@ func (b *tuiDaemonBackend) NodeTags(
 	})
 }
 
+func (b *tuiDaemonBackend) Jobs(ctx context.Context) ([]api.Job, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) ([]api.Job, error) {
+		return c.Jobs(ctx)
+	})
+}
+
 func (b *tuiDaemonBackend) AuditHistory(
 	ctx context.Context, path string, nodeID int64, limit int, cursor string,
 ) (api.AuditEventPage, error) {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -19,7 +19,7 @@ Every documentation page is also published as raw Markdown at the same path with
 - [Organizing & Tagging](https://docbank.ai/usage/organizing.md): Browsing, moving, renaming, and tagging in the virtual tree.
 - [Searching](https://docbank.ai/usage/searching.md): Ranked, prefix-matching search over document names and verified text content.
 - [Web application](https://docbank.ai/usage/web.md): Browse and search the local vault in a responsive, authenticated, read-only web interface.
-- [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse and sort documents, search names and extracted text, inspect stable identity, and read permanent audited history from a daemon-backed TUI.
+- [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse documents, inspect authority and permanent history, and observe daemon background work from a read-only TUI.
 
 ## Protect & Operate
 - [Vault Lifecycle](https://docbank.ai/usage/lifecycle.md): Operate a docbank vault safely from first import through maintenance, upgrades, snapshots, and recovery.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail and audited-history browsing implemented in both; web tags, version history, provenance, and verified current/historical content download implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail, audited-history, and daemon-job inspection implemented; web tags, version history, provenance, and verified current/historical content download implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -159,7 +159,9 @@ be reusable by Msgvault and later tools.
 The focused TUI now has a read-only first slice for virtual-tree navigation,
 name and extracted-content search, stable document/version/hash detail, and a
 compact node-focused audited-history timeline with complete event inspection.
-Later slices add ingest and job progress, metadata/evidence,
+Its daemon-activity screen reports supervised job lifecycle, timestamps, and
+complete terminal failures without inventing percentages where workers expose
+no authoritative total. Later slices add ingest progress, metadata/evidence,
 move/trash/restore, and storage and backup state. Rich document comparison belongs in
 external tools or the web portal. Neither client has privileged operations —
 anything either does, the API can do.

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive terminal browser
-description: Browse and sort documents, search names and extracted text, inspect stable identity, and read permanent audited history from a daemon-backed TUI.
+description: Browse documents, inspect authority and permanent history, and observe daemon background work from a read-only TUI.
 ---
 
 # Interactive terminal browser
@@ -38,12 +38,22 @@ IDs, revisions, path states, version identities, and typed tag or provenance
 details. Nodes outside an audit scope are identified plainly rather than shown
 with an empty or invented timeline.
 
+Press <kbd>J</kbd> to inspect daemon-owned background work without leaving the
+document view. The activity screen shows each stable job name, whether it is
+running, completed, failed, or cancelled, and its start and finish times.
+Inspecting a job exposes its complete terminal failure text. Refresh asks the
+current compatible daemon for a new snapshot; closing the screen returns to the
+same document selection. The current daemon contract reports lifecycle rather
+than invented percentages: workers will show numeric progress only when they
+can supply an authoritative completed and total count.
+
 | Key | Action |
 |-----|--------|
 | <kbd>↑</kbd>/<kbd>k</kbd>, <kbd>↓</kbd>/<kbd>j</kbd> | Move between documents |
 | <kbd>Enter</kbd> or <kbd>→</kbd> | Open the selected directory |
 | <kbd>Enter</kbd> on a file, or <kbd>i</kbd> | Inspect complete document authority |
 | <kbd>a</kbd> | Browse the selected node's permanent audited history |
+| <kbd>J</kbd> | Inspect daemon background jobs and failures |
 | <kbd>←</kbd>, <kbd>Backspace</kbd>, or <kbd>Esc</kbd> | Return to the parent directory or leave search results |
 | <kbd>/</kbd> | Search live names and extracted text |
 | <kbd>s</kbd> | Cycle the sort column: name, size, and modification time |

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,6 +22,7 @@ const (
 	maxBrowserItems = 1000
 	maxSearchItems  = 1000
 	maxHistoryItems = 100
+	maxJobItems     = 1000
 	nodeKindDir     = "dir"
 	nodeKindFile    = "file"
 )
@@ -34,6 +35,7 @@ type Backend interface {
 	ChildrenPage(ctx context.Context, nodeID int64, limit, offset int) (api.NodePage, error)
 	Search(ctx context.Context, query string, limit int) (api.SearchReport, error)
 	NodeTags(ctx context.Context, nodeID int64, limit, offset int) (api.TagPage, error)
+	Jobs(ctx context.Context) ([]api.Job, error)
 	AuditHistory(
 		ctx context.Context, path string, nodeID int64, limit int, cursor string,
 	) (api.AuditEventPage, error)
@@ -112,6 +114,12 @@ type detailTagsLoadedMsg struct {
 	err       error
 }
 
+type jobsLoadedMsg struct {
+	requestID uint64
+	items     []api.Job
+	err       error
+}
+
 type spinnerTickMsg struct{}
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -160,6 +168,17 @@ type Model struct {
 	detailTagsLoading   bool
 	detailTagsErr       error
 	detailRequestID     uint64
+	jobsOpen            bool
+	jobs                []api.Job
+	jobsTotal           int
+	jobsRunning         int
+	jobsCursor          int
+	jobsOffset          int
+	jobsLoading         bool
+	jobsErr             error
+	jobsRequestID       uint64
+	jobDetail           bool
+	jobDetailOffset     int
 	historyOpen         bool
 	historyNode         row
 	historyPages        []api.AuditEventPage
@@ -209,6 +228,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.searchInput.SetWidth(max(msg.Width-4, 1))
 		m.clampSelection()
 		m.clampDetailOffset()
+		m.clampJobsSelection()
+		m.clampJobDetailOffset()
 		m.clampHistorySelection()
 		m.clampHistoryDetailOffset()
 		return m, nil
@@ -233,8 +254,26 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.clampDetailOffset()
 		return m, nil
+	case jobsLoadedMsg:
+		if !m.jobsOpen || msg.requestID != m.jobsRequestID {
+			return m, nil
+		}
+		m.jobsLoading = false
+		m.jobsErr = msg.err
+		if msg.err == nil {
+			m.jobsTotal = len(msg.items)
+			m.jobsRunning = 0
+			for _, job := range msg.items {
+				if job.Status == "running" {
+					m.jobsRunning++
+				}
+			}
+			m.jobs = msg.items[:min(len(msg.items), maxJobItems)]
+			m.clampJobsSelection()
+		}
+		return m, nil
 	case spinnerTickMsg:
-		if !m.loading {
+		if !m.loading && !m.jobsLoading {
 			m.spinnerActive = false
 			return m, nil
 		}
@@ -244,6 +283,9 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if m.helpOpen {
 			m.helpOpen = false
 			return m, nil
+		}
+		if m.jobsOpen {
+			return m.updateJobsKeys(msg)
 		}
 		if m.historyDetail {
 			return m.updateHistoryDetailKeys(msg)
@@ -308,6 +350,19 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "?":
 		m.helpOpen = true
 		return m, nil
+	case "J":
+		m.jobsOpen = true
+		m.jobs = nil
+		m.jobsTotal = 0
+		m.jobsRunning = 0
+		m.jobsCursor = 0
+		m.jobsOffset = 0
+		m.jobsLoading = true
+		m.jobsErr = nil
+		m.jobDetail = false
+		m.jobDetailOffset = 0
+		m.jobsRequestID++
+		return m, tea.Batch(m.startSpinner(), m.loadJobs(m.jobsRequestID))
 	case "s":
 		m.cycleSortField()
 		m.sortRowsPreservingSelection()
@@ -396,6 +451,81 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.stack = m.stack[:len(m.stack)-1]
 			return m, nil
 		}
+	}
+	return m, nil
+}
+
+func (m Model) updateJobsKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.jobDetail {
+		return m.updateJobDetailKeys(msg)
+	}
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "?":
+		m.helpOpen = true
+	case "esc", "backspace", "left", "h":
+		m.jobsOpen = false
+		m.jobsLoading = false
+		m.jobsRequestID++
+	case "enter", "i":
+		if _, ok := m.selectedJob(); ok {
+			m.jobDetail = true
+			m.jobDetailOffset = 0
+		}
+	case "r":
+		m.jobsLoading = true
+		m.jobsErr = nil
+		m.jobsRequestID++
+		return m, tea.Batch(m.startSpinner(), m.loadJobs(m.jobsRequestID))
+	case "up", "k":
+		m.moveJobsCursor(-1)
+	case "down", "j":
+		m.moveJobsCursor(1)
+	case "pgup":
+		m.moveJobsCursor(-m.visibleJobRows())
+	case "pgdown":
+		m.moveJobsCursor(m.visibleJobRows())
+	case "home", "g":
+		m.jobsCursor, m.jobsOffset = 0, 0
+	case "end", "G":
+		if len(m.jobs) > 0 {
+			m.jobsCursor = len(m.jobs) - 1
+			m.clampJobsSelection()
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateJobDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "?":
+		m.helpOpen = true
+	case "enter", "i", "esc", "backspace", "left", "h":
+		m.jobDetail = false
+		m.jobDetailOffset = 0
+	case "up", "k":
+		m.jobDetailOffset--
+		m.clampJobDetailOffset()
+	case "down", "j":
+		m.jobDetailOffset++
+		m.clampJobDetailOffset()
+	case "pgup":
+		m.jobDetailOffset -= m.jobsViewportHeight()
+		m.clampJobDetailOffset()
+	case "pgdown":
+		m.jobDetailOffset += m.jobsViewportHeight()
+		m.clampJobDetailOffset()
+	case "home", "g":
+		m.jobDetailOffset = 0
+	case "end", "G":
+		m.jobDetailOffset = max(
+			len(m.jobDetailLines(m.width))-m.jobsViewportHeight(), 0,
+		)
 	}
 	return m, nil
 }
@@ -570,6 +700,14 @@ func (m Model) loadDetailTags(nodeID, revision int64, requestID uint64) tea.Cmd 
 			}
 		}
 		return detailTagsLoadedMsg{requestID: requestID, page: page, err: err}
+	}
+}
+
+func (m Model) loadJobs(requestID uint64) tea.Cmd {
+	ctx, backend := m.ctx, m.backend
+	return func() tea.Msg {
+		items, err := backend.Jobs(ctx)
+		return jobsLoadedMsg{requestID: requestID, items: items, err: err}
 	}
 }
 
@@ -791,6 +929,50 @@ func (m Model) selectedHistoryEvent() (api.AuditEvent, bool) {
 		return api.AuditEvent{}, false
 	}
 	return page.Items[m.historyCursor], true
+}
+
+func (m Model) selectedJob() (api.Job, bool) {
+	if m.jobsCursor < 0 || m.jobsCursor >= len(m.jobs) {
+		return api.Job{}, false
+	}
+	return m.jobs[m.jobsCursor], true
+}
+
+func (m *Model) moveJobsCursor(delta int) {
+	if len(m.jobs) == 0 {
+		return
+	}
+	m.jobsCursor = min(max(m.jobsCursor+delta, 0), len(m.jobs)-1)
+	m.clampJobsSelection()
+}
+
+func (m *Model) clampJobsSelection() {
+	if len(m.jobs) == 0 {
+		m.jobsCursor, m.jobsOffset = 0, 0
+		return
+	}
+	m.jobsCursor = min(max(m.jobsCursor, 0), len(m.jobs)-1)
+	visible := m.visibleJobRows()
+	if m.jobsCursor < m.jobsOffset {
+		m.jobsOffset = m.jobsCursor
+	}
+	if m.jobsCursor >= m.jobsOffset+visible {
+		m.jobsOffset = m.jobsCursor - visible + 1
+	}
+	m.jobsOffset = min(max(m.jobsOffset, 0), max(len(m.jobs)-visible, 0))
+}
+
+func (m Model) visibleJobRows() int {
+	return max(m.jobsViewportHeight()-2, 1)
+}
+
+func (m Model) jobsViewportHeight() int {
+	return max(m.height-3, 1)
+}
+
+func (m *Model) clampJobDetailOffset() {
+	maximum := max(len(m.jobDetailLines(m.width))-m.jobsViewportHeight(), 0)
+	m.jobDetailOffset = min(max(m.jobDetailOffset, 0), maximum)
 }
 
 func (m *Model) moveHistoryCursor(delta int) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -31,6 +31,9 @@ type fakeBackend struct {
 	historyCursors []string
 	tags           map[int64]api.TagPage
 	tagNodeIDs     []int64
+	jobs           []api.Job
+	jobsErr        error
+	jobCalls       int
 }
 
 func newFakeBackend() *fakeBackend {
@@ -102,6 +105,17 @@ func newFakeBackend() *fakeBackend {
 				Total: 2, Limit: maxBrowserItems,
 			},
 		},
+		jobs: []api.Job{
+			{
+				Name: "text-extraction", Status: "running",
+				StartedAt: "2026-07-22T12:00:00Z",
+			},
+			{
+				Name: "watch:inbox", Status: "failed",
+				StartedAt: "2026-07-22T11:00:00Z", FinishedAt: "2026-07-22T11:05:00Z",
+				Error: "source is temporarily unavailable; check the configured inbox path",
+			},
+		},
 	}
 }
 
@@ -161,6 +175,14 @@ func (f *fakeBackend) NodeTags(
 	page.Limit = limit
 	page.Offset = offset
 	return page, nil
+}
+
+func (f *fakeBackend) Jobs(_ context.Context) ([]api.Job, error) {
+	f.jobCalls++
+	if f.jobsErr != nil {
+		return nil, f.jobsErr
+	}
+	return append([]api.Job(nil), f.jobs...), nil
 }
 
 func (f *fakeBackend) AuditHistory(
@@ -855,6 +877,56 @@ func TestDetailRejectsTagsAfterNodeRevisionChanges(t *testing.T) {
 	assert.Empty(t, model.detailTags)
 	assert.Contains(t, strings.Join(model.expandedDetailLines(120), "\n"),
 		"document changed while loading tags")
+}
+
+func TestJobsViewShowsLifecycleAndCompleteFailure(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.width, model.height = 100, 14
+
+	model, cmd := updateModel(t, model, runeKey('J'))
+	require.NotNil(t, cmd)
+	assert.True(t, model.jobsOpen)
+	assert.True(t, model.jobsLoading)
+	model = runModelCommand(t, model, cmd)
+
+	content := model.View().Content
+	assert.Contains(t, content, "Daemon activity")
+	assert.Contains(t, content, "1 running · 2 total")
+	assert.Contains(t, content, `"text-extraction"`)
+	assert.Contains(t, content, `"watch:inbox"`)
+	assert.Equal(t, 1, backend.jobCalls)
+
+	model, _ = updateModel(t, model, key(tea.KeyDown))
+	model, _ = updateModel(t, model, key(tea.KeyEnter))
+	assert.True(t, model.jobDetail)
+	detail := strings.Join(model.jobDetailLines(model.width), "\n")
+	assert.Contains(t, detail, "Status: failed")
+	assert.Contains(t, detail,
+		"source is temporarily unavailable; check the configured inbox path")
+
+	model.width = 36
+	for line := range strings.SplitSeq(model.View().Content, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(line), model.width)
+	}
+}
+
+func TestClosingJobsInvalidatesDelayedLoad(t *testing.T) {
+	model, err := New(t.Context(), newFakeBackend())
+	require.NoError(t, err)
+
+	model, delayed := updateModel(t, model, runeKey('J'))
+	require.NotNil(t, delayed)
+	pendingRequestID := model.jobsRequestID
+	model, _ = updateModel(t, model, key(tea.KeyEscape))
+	assert.False(t, model.jobsOpen)
+	assert.Greater(t, model.jobsRequestID, pendingRequestID)
+
+	model = runModelCommand(t, model, delayed)
+	assert.False(t, model.jobsOpen)
+	assert.Empty(t, model.jobs)
 }
 
 func TestHelpAndSpinnerAreVisible(t *testing.T) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -70,7 +70,9 @@ func (m Model) render() string {
 		return "Loading Docbank..."
 	}
 	lines := []string{m.renderTitleBar()}
-	if m.historyOpen {
+	if m.jobsOpen {
+		lines = append(lines, m.renderJobsLocation())
+	} else if m.historyOpen {
 		lines = append(lines, m.renderHistoryLocation())
 	} else {
 		lines = append(lines, m.renderLocation())
@@ -81,7 +83,9 @@ func (m Model) render() string {
 
 	bodyHeight := max(m.height-len(lines)-1, 1)
 	body := m.renderBody(bodyHeight)
-	if m.historyOpen {
+	if m.jobsOpen {
+		body = m.renderJobsList(bodyHeight)
+	} else if m.historyOpen {
 		body = m.renderHistoryList(bodyHeight)
 	}
 	if m.detailOpen {
@@ -90,12 +94,32 @@ func (m Model) render() string {
 	if m.historyDetail {
 		body = m.renderHistoryDetail(bodyHeight)
 	}
+	if m.jobDetail {
+		body = m.renderJobDetail(bodyHeight)
+	}
 	lines = append(lines, body, m.renderFooter())
 	content := strings.Join(lines, "\n")
 	if m.helpOpen {
 		return m.renderHelp(content)
 	}
 	return content
+}
+
+func (m Model) renderJobsLocation() string {
+	left := " Daemon activity · background jobs"
+	right := fmt.Sprintf("%d running · %d total", m.jobsRunning, m.jobsTotal)
+	if m.jobsTotal > len(m.jobs) {
+		right = fmt.Sprintf(
+			"%d running · first %d of %d", m.jobsRunning, len(m.jobs), m.jobsTotal,
+		)
+	}
+	if m.jobsLoading {
+		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
+	}
+	if m.jobsErr != nil {
+		right = "jobs unavailable"
+	}
+	return m.styles.stats.Render(joinSides(left, right, m.width))
 }
 
 func (m Model) renderHistoryLocation() string {
@@ -166,6 +190,127 @@ func (m Model) renderLocation() string {
 
 func (m Model) renderBody(height int) string {
 	return m.renderList(m.width, height)
+}
+
+func (m Model) renderJobsList(height int) string {
+	lines := make([]string, 0, height)
+	lines = append(lines, m.renderJobsHeading())
+	if height > 1 {
+		lines = append(lines, m.styles.separator.Render(strings.Repeat("─", m.width)))
+	}
+	visible := max(height-2, 0)
+	if m.jobsErr != nil && visible > 0 {
+		wrapped := strings.Split(ansi.Hardwrap(
+			" "+quoted(m.jobsErr.Error()), max(m.width, 1), false,
+		), "\n")
+		for _, line := range wrapped[:min(len(wrapped), visible)] {
+			lines = append(lines, m.styles.error.Render(pad(fit(line, m.width), m.width)))
+		}
+		visible -= min(len(wrapped), visible)
+	} else if len(m.jobs) == 0 && visible > 0 {
+		message := " No background jobs"
+		if m.jobsLoading {
+			message = " Loading background jobs..."
+		}
+		lines = append(lines, m.styles.muted.Render(pad(fit(message, m.width), m.width)))
+		visible--
+	}
+	end := min(m.jobsOffset+visible, len(m.jobs))
+	for index := m.jobsOffset; index < end; index++ {
+		line := m.renderJobRow(m.jobs[index])
+		if index == m.jobsCursor {
+			line = "▶" + line[1:]
+		}
+		line = pad(fit(line, m.width), m.width)
+		if index == m.jobsCursor {
+			lines = append(lines, m.styles.cursor.Render(line))
+		} else if index%2 == 1 {
+			lines = append(lines, m.styles.alternate.Render(line))
+		} else {
+			lines = append(lines, line)
+		}
+	}
+	for len(lines) < height {
+		lines = append(lines, strings.Repeat(" ", m.width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderJobsHeading() string {
+	switch {
+	case m.width >= 88:
+		return m.styles.heading.Render(pad(
+			"   STATUS       JOB                              STARTED            FINISHED", m.width,
+		))
+	case m.width >= 72:
+		return m.styles.heading.Render(pad(
+			"   STATUS       JOB                              STARTED", m.width,
+		))
+	default:
+		return m.styles.heading.Render(pad("   STATUS       JOB", m.width))
+	}
+}
+
+func (m Model) renderJobRow(job api.Job) string {
+	status := pad(strings.ToUpper(job.Status), 11)
+	nameWidth := max(m.width-16, 1)
+	if m.width >= 72 {
+		nameWidth = 32
+	}
+	line := "   " + status + "  " + pad(quoted(job.Name), nameWidth)
+	if m.width >= 72 {
+		line += "  " + pad(formatJobTime(job.StartedAt), 17)
+	}
+	if m.width >= 88 {
+		finished := "running"
+		if job.FinishedAt != "" {
+			finished = formatJobTime(job.FinishedAt)
+		}
+		line += "  " + finished
+	}
+	return line
+}
+
+func (m Model) renderJobDetail(height int) string {
+	lines := m.jobDetailLines(m.width)
+	maximum := max(len(lines)-height, 0)
+	offset := min(m.jobDetailOffset, maximum)
+	end := min(offset+height, len(lines))
+	visible := append([]string(nil), lines[offset:end]...)
+	for len(visible) < height {
+		visible = append(visible, strings.Repeat(" ", m.width))
+	}
+	return strings.Join(visible, "\n")
+}
+
+func (m Model) jobDetailLines(width int) []string {
+	heading := m.styles.heading.Render(pad(fit(" Complete background job", width), width))
+	separator := m.styles.separator.Render(strings.Repeat("─", max(width, 0)))
+	lines := []string{heading, separator}
+	job, ok := m.selectedJob()
+	if !ok {
+		return append(lines, m.styles.muted.Render(" Nothing selected"))
+	}
+	fields := []string{
+		" Name: " + quoted(job.Name),
+		" Status: " + job.Status,
+		" Started: " + job.StartedAt,
+	}
+	if job.FinishedAt == "" {
+		fields = append(fields, " Finished: still running")
+	} else {
+		fields = append(fields, " Finished: "+job.FinishedAt)
+	}
+	if job.Error != "" {
+		fields = append(fields, " Failure: "+quoted(job.Error))
+	}
+	for _, field := range fields {
+		wrapped := ansi.Hardwrap(field, max(width, 1), false)
+		for line := range strings.SplitSeq(wrapped, "\n") {
+			lines = append(lines, pad(line, width))
+		}
+	}
+	return lines
 }
 
 func (m Model) renderList(width, height int) string {
@@ -448,6 +593,13 @@ func formatHistoryTime(value string) string {
 	return parsed.UTC().Format("2006-01-02 15:04Z")
 }
 
+func formatJobTime(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return formatHistoryTime(value)
+}
+
 type tableLayout struct {
 	width        int
 	document     int
@@ -634,6 +786,9 @@ func (m *Model) clampDetailOffset() {
 }
 
 func (m Model) renderFooter() string {
+	if m.jobsOpen {
+		return m.renderJobsFooter()
+	}
 	if m.historyOpen {
 		return m.renderHistoryFooter()
 	}
@@ -657,6 +812,7 @@ func (m Model) renderFooter() string {
 	}
 	hints = append(hints,
 		hint{text: "/ search", priority: 90},
+		hint{text: "J jobs", priority: 68},
 		hint{text: "s sort", priority: 85},
 		hint{text: "v reverse", priority: 25},
 		hint{text: "r refresh", priority: 20},
@@ -678,6 +834,40 @@ func (m Model) renderFooter() string {
 	available := max(m.width-lipgloss.Width(position)-1, 0)
 	keys := fitHints(hints, available)
 	return m.styles.footer.Render(joinSides(keys, position, m.width))
+}
+
+func (m Model) renderJobsFooter() string {
+	if m.jobDetail {
+		lines := m.jobDetailLines(m.width)
+		viewport := m.jobsViewportHeight()
+		position := ""
+		if len(lines) > viewport {
+			last := min(m.jobDetailOffset+viewport, len(lines))
+			position = fmt.Sprintf(" %d-%d/%d ", m.jobDetailOffset+1, last, len(lines))
+		}
+		hints := []hint{
+			{text: "↑/↓ scroll", priority: 100},
+			{text: "esc close", priority: 90},
+			{text: "? help", priority: 70},
+			{text: "q quit", priority: 60},
+		}
+		available := max(m.width-lipgloss.Width(position)-1, 0)
+		return m.styles.footer.Render(joinSides(fitHints(hints, available), position, m.width))
+	}
+	hints := []hint{
+		{text: "↑/↓ move", priority: 100},
+		{text: "enter inspect", priority: 90},
+		{text: "r refresh", priority: 80},
+		{text: "esc back", priority: 85},
+		{text: "? help", priority: 70},
+		{text: "q quit", priority: 60},
+	}
+	position := ""
+	if len(m.jobs) > 0 {
+		position = fmt.Sprintf(" %d/%d ", m.jobsCursor+1, len(m.jobs))
+	}
+	available := max(m.width-lipgloss.Width(position)-1, 0)
+	return m.styles.footer.Render(joinSides(fitHints(hints, available), position, m.width))
 }
 
 func (m Model) renderHistoryFooter() string {
@@ -800,6 +990,34 @@ func (m Model) renderHelp(background string) string {
 }
 
 func (m Model) helpLines() []string {
+	if m.jobsOpen {
+		if m.jobDetail {
+			return []string{
+				"Background job inspection",
+				"",
+				"↑/k, ↓/j       Scroll one line",
+				"PgUp/PgDn      Scroll one visible page",
+				"Home/End       Jump to first or last line",
+				"Enter/i/Esc    Return to daemon activity",
+				"q              Quit",
+				"",
+				"Press any key to close",
+			}
+		}
+		return []string{
+			"Daemon activity shortcuts",
+			"",
+			"↑/k, ↓/j       Move through background jobs",
+			"PgUp/PgDn      Move one visible page",
+			"Home/End       Jump to first or last job",
+			"Enter/i        Inspect complete job state",
+			"r              Refresh background jobs",
+			"Esc            Return to documents",
+			"q              Quit",
+			"",
+			"Press any key to close",
+		}
+	}
 	if m.historyDetail {
 		return []string{
 			"Audited event inspection",
@@ -839,6 +1057,7 @@ func (m Model) helpLines() []string {
 		"Enter/→/l      Open a directory",
 		"Enter/i        Inspect complete document authority",
 		"a              Browse permanent audited history",
+		"J              Inspect daemon background jobs",
 		"Esc/←/h        Return to the previous view",
 		"/              Search names and extracted text",
 		"s              Cycle the sort column",


### PR DESCRIPTION
Docbank supervises text extraction, watched ingestion, automatic packing, and daemon lifecycle work, but a person browsing documents in the terminal currently has to leave the TUI to learn whether that work is healthy. Pressing `J` now opens a dedicated daemon-activity screen without losing the current directory, search, or selection.

![The actual Docbank TUI showing supervised background jobs in a synthetic vault](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/tui-jobs/tui-jobs.png?v=7812520)

*Actual daemon-backed TUI output from an owner-private synthetic vault; no private corpus data is present.*

The screen shows stable job names, running/completed/failed/cancelled state, and start and finish times. Selecting a job exposes its complete terminal failure instead of squeezing an actionable message into a narrow table cell. Refresh reacquires the compatible daemon through the same path as every other TUI read, delayed responses are discarded after the screen closes, and the first 1,000 jobs are explicitly bounded rather than implying an exhaustive view.

This remains read-only observation. It deliberately does not manufacture progress bars or percentages: the current supervisor owns lifecycle and timestamps, but its workers do not yet expose authoritative completed/total counters. Numeric progress can appear on this surface when a worker has a real denominator.