### PR TITLE
Inspect backup snapshots in the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Four commitments:
   document analysis, tag browsing, tag-filtered extracted-text search,
   complete current authority, verified current and historical content download,
   permanent protection and event history, immutable versions and provenance,
-  daemon background-job status, and an honest
+  configured backup recovery points, daemon background-job status, and an honest
   loose-file/live-packed/dead-packed storage breakdown
 - Mixed loose and packed content storage with explicit pack, GC, and repack,
   plus an opt-in bounded daemon packing schedule

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "50", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "51", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "50", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "51", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "50", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "51", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "50", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "51", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -67,8 +67,9 @@ its own shutdown token. The hidden `POST /api/daemon/web-session` exchanges
 that master authority for a random daemon-lifetime browser token and returns
 the fresh loopback origin dedicated to that daemon lifetime, while
 `DELETE /api/daemon/web-session` revokes the calling browser session. Those
-tokens authenticate only the read routes used by the built-in tree and search
-views; they are intentionally not another general API credential.
+tokens authenticate only the explicit read routes used by the built-in
+document, storage, job, and configured-backup views; they are intentionally
+not another general API credential.
 
 `GET /nodes/{id}/children` binds the live directory projection—including its
 current canonical path—and the requested child page to one read transaction.
@@ -120,8 +121,13 @@ parsing human text. Because response headers commit when streaming begins, an
 HTTP 200 means only that the stream started; clients must read through EOF and
 require the terminal event. The CLI uses this variant for human output and the
 single-JSON endpoint for `--json`.
-`GET /backup/snapshots?repo=...` returns `{items: [...]}` so pagination can be
-added later without changing a top-level array contract.
+`GET /backup/snapshots?repo=...` returns
+`{repository: {id, path}, items: [...]}` so clients can identify the repository
+behind the immutable manifests and pagination can be added later without
+changing a top-level array contract. A browser session may use this GET only
+without `repo`, which confines the web application to the daemon's configured
+repository; backup mutations and arbitrary server-path selection still require
+the master API authority.
 
 Explicit repository paths are server filesystem paths and must be absolute.
 The CLI resolves a relative `--repo` against its own working directory before

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -23,6 +23,8 @@ their newest-first permanent audit timeline and complete event authority. The
 storage button separates loose content, live packed content, pack-file payload,
 and logically dead packed bytes awaiting repack. The activity button reports
 the daemon's supervised extraction, watched-inbox, and automatic-packing jobs.
+The backup button lists immutable recovery points in the configured repository
+without running backup or restore work.
 Every file also exposes its retained immutable content versions and the stable
 authority behind each one, plus the immutable provenance Docbank recorded when
 the document entered the vault.
@@ -229,6 +231,25 @@ authority. It cannot pack, garbage-collect, or repack content. Use
 `docbank storage repack` explicitly when you intend to rewrite eligible sparse
 packs and retire their old files.
 
+## Inspect backup snapshots
+
+Choose the backup button in the top bar to inspect the immutable recovery
+points in the repository selected by `[backup] repo` in `config.toml`. The
+repository path and stable repository ID make the authority being inspected
+explicit. Snapshots appear newest first with their tag, immutable ID, creation
+time, full or incremental relationship, logical node/file/blob counts, logical
+content bytes, and the pack bytes newly added by that capture.
+
+An initialized repository with no snapshots is different from an unconfigured
+repository, and the browser reports those states separately. The browser does
+not accept an arbitrary server path, initialize a repository, create a
+snapshot, verify content, restore a vault, or delete retention history.
+
+Seeing a manifest in this list is not proof that its referenced bytes are
+still readable. Run `docbank backup verify` to independently prove repository
+integrity, and periodically restore into a separate vault to rehearse the
+complete recovery path.
+
 ## Browser authentication
 
 When Docbank opens the browser, it writes a small launch page beside the
@@ -249,12 +270,15 @@ do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
 search, tag-definition and assignment reads, immutable-version, provenance, audit-status, audit-history,
-background-job, physical-storage-status, and verified-download preparation
+background-job, physical-storage-status, configured backup-snapshot-list, and
+verified-download preparation
 used by this interface.
 Download preparation may write only owner-private temporary bytes and issue
 one exact, expiring file ticket; it cannot mutate document authority. The
 session cannot enroll audit scopes, run independent verification, or call
-mutation, backup, maintenance, configuration, or general API endpoints.
+mutation, backup creation, verification, restore, maintenance, configuration,
+or general API endpoints. Its sole backup capability is listing the immutable
+snapshots in the repository already configured for this daemon.
 
 The lock button revokes the session in daemon memory and clears the page.
 Every remaining browser session and its dedicated browser origin disappear
@@ -289,7 +313,7 @@ leave the browser constructing child paths beneath an obsolete name.
 The current web application does not compare versions, import, edit, revert,
 prune, move, create or change tags and
 assignments, trash, enroll audit scopes, run independent audit verification,
-or run maintenance and backup operations.
+or run maintenance, backup, verification, or restore operations.
 Use the corresponding CLI or authenticated HTTP endpoint for those workflows.
 Future web workflows will require deliberately expanded browser-session
 permissions rather than inheriting the master API key.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import ActivityIcon from "@lucide/svelte/icons/activity";
+  import ArchiveIcon from "@lucide/svelte/icons/archive";
   import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
   import FileIcon from "@lucide/svelte/icons/file";
   import FolderIcon from "@lucide/svelte/icons/folder";
@@ -30,6 +31,7 @@
     type SortDirection,
   } from "@kenn-io/kit-ui";
   import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
+  import BackupDrawer from "./BackupDrawer.svelte";
   import DownloadButton from "./DownloadButton.svelte";
   import JobsDrawer from "./JobsDrawer.svelte";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
@@ -106,6 +108,7 @@
   let provenanceOpen = $state(false);
   let jobsOpen = $state(false);
   let storageOpen = $state(false);
+  let backupsOpen = $state(false);
   let generation = 0;
   let auditGeneration = 0;
   let tagGeneration = 0;
@@ -143,6 +146,7 @@
       provenanceOpen = false;
       jobsOpen = false;
       storageOpen = false;
+      backupsOpen = false;
       tagCatalog = [];
       tagCatalogListed = 0;
       selectedTags = [];
@@ -511,6 +515,7 @@
     provenanceOpen = false;
     jobsOpen = false;
     storageOpen = false;
+    backupsOpen = false;
     activeQuery = "";
     activeTagID = "";
     taggedInspected = 0;
@@ -573,12 +578,27 @@
       {#snippet right()}
         <IconButton
           size="sm"
+          ariaLabel="Backup snapshots"
+          onclick={() => {
+            historyOpen = false;
+            versionsOpen = false;
+            provenanceOpen = false;
+            jobsOpen = false;
+            storageOpen = false;
+            backupsOpen = true;
+          }}
+        >
+          <ArchiveIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton
+          size="sm"
           ariaLabel="Storage status"
           onclick={() => {
             historyOpen = false;
             versionsOpen = false;
             provenanceOpen = false;
             jobsOpen = false;
+            backupsOpen = false;
             storageOpen = true;
           }}
         >
@@ -592,6 +612,7 @@
             versionsOpen = false;
             provenanceOpen = false;
             storageOpen = false;
+            backupsOpen = false;
             jobsOpen = true;
           }}
         >
@@ -859,6 +880,7 @@
                       provenanceOpen = false;
                       jobsOpen = false;
                       storageOpen = false;
+                      backupsOpen = false;
                       versionsOpen = true;
                     }}
                   >
@@ -873,6 +895,7 @@
                       versionsOpen = false;
                       jobsOpen = false;
                       storageOpen = false;
+                      backupsOpen = false;
                       provenanceOpen = true;
                     }}
                   >
@@ -912,6 +935,7 @@
                       versionsOpen = false;
                       provenanceOpen = false;
                       storageOpen = false;
+                      backupsOpen = false;
                       historyOpen = true;
                     }}
                   >
@@ -975,6 +999,13 @@
       <JobsDrawer
         session={webSession}
         onclose={() => (jobsOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if backupsOpen}
+      <BackupDrawer
+        session={webSession}
+        onclose={() => (backupsOpen = false)}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/BackupDrawer.svelte
+++ b/frontend/src/BackupDrawer.svelte
@@ -1,0 +1,373 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import ArchiveIcon from "@lucide/svelte/icons/archive";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Card,
+    Chip,
+    CopyButton,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+  } from "@kenn-io/kit-ui";
+  import {
+    APIError,
+    backupSnapshots,
+    type BackupSnapshot,
+    type BackupSnapshotList,
+  } from "./api.js";
+  import { formatBytes, formatDate } from "./format.js";
+
+  interface Props {
+    session: string;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, onclose, onauthfailure }: Props = $props();
+
+  let report = $state<BackupSnapshotList | null>(null);
+  let loading = $state(true);
+  let error = $state("");
+  let unconfigured = $state(false);
+  let generation = 0;
+
+  const snapshots = $derived(
+    report
+      ? [...report.items].sort((left, right) =>
+          right.created_at.localeCompare(left.created_at),
+        )
+      : [],
+  );
+
+  onMount(() => {
+    void refresh();
+    return () => {
+      generation += 1;
+    };
+  });
+
+  async function refresh(): Promise<void> {
+    const request = ++generation;
+    loading = true;
+    error = "";
+    unconfigured = false;
+    try {
+      const next = await backupSnapshots(session);
+      if (request !== generation) return;
+      report = next;
+    } catch (cause) {
+      if (request !== generation) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        onclose();
+        return;
+      }
+      if (
+        cause instanceof APIError &&
+        cause.code === "backup_repository" &&
+        cause.message.includes("no backup repository configured")
+      ) {
+        report = null;
+        unconfigured = true;
+        return;
+      }
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === generation) loading = false;
+    }
+  }
+
+  function snapshotKind(snapshot: BackupSnapshot): "Full" | "Incremental" {
+    return snapshot.parent_id ? "Incremental" : "Full";
+  }
+</script>
+
+<DetailDrawer
+  width="min(760px, 100vw)"
+  ariaLabel="Backup snapshots"
+  {onclose}
+>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>RECOVERY POINTS</span>
+        <strong>Backup snapshots</strong>
+        <small>
+          {#if report}
+            {report.items.length} immutable snapshot{report.items.length === 1 ? "" : "s"}
+          {:else}
+            Configured repository history
+          {/if}
+        </small>
+      </div>
+      <div class="drawer-actions">
+        <IconButton
+          size="sm"
+          ariaLabel="Refresh backup snapshots"
+          disabled={loading}
+          onclick={() => void refresh()}
+        >
+          <RefreshCwIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton size="sm" ariaLabel="Close backup snapshots" onclick={onclose}>
+          <XIcon size="14" aria-hidden="true" />
+        </IconButton>
+      </div>
+    </div>
+  {/snippet}
+
+  <div class="backups">
+    {#if loading && !report}
+      <div class="loading"><Spinner size={16} /> Reading backup history…</div>
+    {:else if unconfigured}
+      <EmptyState
+        title="No backup repository configured"
+        description="Set [backup] repo in config.toml, then initialize and create snapshots from the CLI."
+      >
+        {#snippet icon()}<ArchiveIcon size="22" />{/snippet}
+      </EmptyState>
+    {:else if error && !report}
+      <div class="load-error">
+        <p role="alert">{error}</p>
+        <Button size="sm" onclick={() => void refresh()}>Try again</Button>
+      </div>
+    {:else if report}
+      {#if error}<p class="error" role="alert">{error}</p>{/if}
+      <section class="repository" aria-label="Backup repository identity">
+        <div>
+          <span>CONFIGURED REPOSITORY</span>
+          <strong>{report.repository.path}</strong>
+        </div>
+        <div class="repository-id">
+          <code>{report.repository.id}</code>
+          <CopyButton
+            text={report.repository.id}
+            ariaLabel="Copy backup repository ID"
+          />
+        </div>
+      </section>
+
+      {#if snapshots.length === 0}
+        <EmptyState
+          title="No snapshots yet"
+          description="The repository is initialized, but it does not contain a recovery point."
+        >
+          {#snippet icon()}<ArchiveIcon size="22" />{/snippet}
+        </EmptyState>
+      {:else}
+        <div class="snapshot-list" aria-live="polite">
+          {#each snapshots as snapshot (snapshot.id)}
+            <Card
+              level="default"
+              padding="sm"
+              eyebrow={formatDate(snapshot.created_at)}
+              title={snapshot.tag || "Untagged snapshot"}
+            >
+              {#snippet actions()}
+                <Chip size="xs" tone={snapshot.parent_id ? "info" : "neutral"}>
+                  {snapshotKind(snapshot)}
+                </Chip>
+              {/snippet}
+              <div class="snapshot-id">
+                <code>{snapshot.id}</code>
+                <CopyButton
+                  text={snapshot.id}
+                  ariaLabel={`Copy snapshot ID ${snapshot.id}`}
+                />
+              </div>
+              <dl>
+                <div><dt>Tree</dt><dd>{snapshot.files} files · {snapshot.nodes} nodes</dd></div>
+                <div><dt>Content</dt><dd>{snapshot.blobs} blobs · {formatBytes(snapshot.blob_bytes)}</dd></div>
+                <div>
+                  <dt>Added</dt>
+                  <dd>
+                    {formatBytes(snapshot.bytes_added)} · {snapshot.packs_added}
+                    {snapshot.packs_added === 1 ? "pack" : "packs"}
+                  </dd>
+                </div>
+              </dl>
+            </Card>
+          {/each}
+        </div>
+      {/if}
+
+      <aside class="recovery-note">
+        <strong>Snapshot presence is not recovery proof.</strong>
+        <p>
+          This view lists immutable manifests only. Run
+          <code>docbank backup verify</code> to prove repository bytes, and
+          restore into a separate vault to rehearse recovery.
+        </p>
+      </aside>
+    {/if}
+  </div>
+</DetailDrawer>
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div:first-child {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-heading span,
+  .repository span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading small {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .drawer-actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .backups {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-5);
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .load-error {
+    display: grid;
+    justify-items: start;
+    gap: var(--space-4);
+  }
+
+  .load-error p,
+  .error {
+    margin: 0;
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+
+  .repository {
+    display: grid;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-lg);
+    background: var(--bg-inset);
+  }
+
+  .repository > div:first-child {
+    display: grid;
+    gap: var(--space-1);
+    min-width: 0;
+  }
+
+  .repository strong {
+    overflow-wrap: anywhere;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  .repository-id,
+  .snapshot-id {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  code {
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
+  .snapshot-list {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .snapshot-id {
+    margin-bottom: var(--space-4);
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-3);
+    margin: 0;
+  }
+
+  dl > div {
+    display: grid;
+    gap: var(--space-1);
+  }
+
+  dt {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  dd {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  .recovery-note {
+    padding: var(--space-4);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-lg);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .recovery-note strong {
+    color: var(--text-primary);
+  }
+
+  .recovery-note p {
+    margin: var(--space-2) 0 0;
+  }
+
+  .recovery-note code {
+    margin: 0 var(--space-1);
+    color: var(--text-primary);
+  }
+
+  @media (max-width: 640px) {
+    dl {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/BackupDrawer.test.ts
+++ b/frontend/src/BackupDrawer.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/svelte";
+import BackupDrawer from "./BackupDrawer.svelte";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("backup snapshots drawer", () => {
+  it("shows configured recovery points newest first without claiming verification", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          repository: {
+            id: "11111111-1111-4111-8111-111111111111",
+            path: "/var/backups/docbank",
+          },
+          items: [
+            {
+              id: "01JOLD",
+              created_at: "2026-07-20T12:00:00Z",
+              tag: "first import",
+              metadata_format: "docbank-jsonl-v1",
+              nodes: 12,
+              files: 10,
+              blobs: 10,
+              blob_bytes: 4096,
+              packs_added: 1,
+              bytes_added: 2048,
+              duration_seconds: 1.2,
+            },
+            {
+              id: "01JNEW",
+              parent_id: "01JOLD",
+              created_at: "2026-07-27T12:00:00Z",
+              tag: "weekly",
+              metadata_format: "docbank-jsonl-v1",
+              nodes: 14,
+              files: 12,
+              blobs: 12,
+              blob_bytes: 8192,
+              packs_added: 1,
+              bytes_added: 1024,
+              duration_seconds: 0.8,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const close = vi.fn();
+
+    render(BackupDrawer, {
+      session: "short-lived",
+      onclose: close,
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText("/var/backups/docbank")).toBeTruthy();
+    expect(
+      screen
+        .getByText("weekly")
+        .compareDocumentPosition(screen.getByText("first import")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.getByText("Incremental")).toBeTruthy();
+    expect(screen.getByText("Full")).toBeTruthy();
+    expect(screen.getByText(/Snapshot presence is not recovery proof/)).toBeTruthy();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Close backup snapshots" }),
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -3,6 +3,7 @@ import {
   APIError,
   auditHistory,
   auditStatusForNode,
+  backupSnapshots,
   contentVersions,
   listJobs,
   liveTaggedNodes,
@@ -117,6 +118,18 @@ describe("browser authentication", () => {
 
     await storageStatus("session");
     expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/storage");
+  });
+
+  it("reads configured backup snapshots through the browser session", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ repository: { id: "repo", path: "/backups" }, items: [] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await backupSnapshots("session");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/backup/snapshots");
   });
 
   it("reads immutable versions for one stable node", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -106,6 +106,31 @@ export interface TaggedNodePage {
   omitted_trashed?: number;
 }
 
+export interface BackupRepository {
+  id: string;
+  path: string;
+}
+
+export interface BackupSnapshot {
+  id: string;
+  parent_id?: string;
+  created_at: string;
+  tag?: string;
+  metadata_format: string;
+  nodes: number;
+  files: number;
+  blobs: number;
+  blob_bytes: number;
+  packs_added: number;
+  bytes_added: number;
+  duration_seconds: number;
+}
+
+export interface BackupSnapshotList {
+  repository: BackupRepository;
+  items: BackupSnapshot[];
+}
+
 export interface AuditScopeStatus {
   id: string;
   target_node_id: number;
@@ -412,4 +437,10 @@ export async function listJobs(session: string): Promise<Job[]> {
 
 export async function storageStatus(session: string): Promise<StorageStatus> {
   return requestJSON<StorageStatus>("/api/v1/storage", session);
+}
+
+export async function backupSnapshots(
+  session: string,
+): Promise<BackupSnapshotList> {
+  return requestJSON<BackupSnapshotList>("/api/v1/backup/snapshots", session);
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -101,7 +101,7 @@ func authMiddleware(next http.Handler, key string, sessions *webSessionRegistry)
 		}
 		webToken := r.Header.Get(WebSessionHeader)
 		if sessions != nil && sessions.valid(webToken) {
-			if !webSessionRequestAllowed(r.Method, r.URL.Path) {
+			if !webSessionRequestAllowed(r) {
 				writeError(w, NewError(http.StatusForbidden, "web_session_read_only",
 					"browser sessions cannot use this endpoint"))
 				return

--- a/internal/api/routes_backup.go
+++ b/internal/api/routes_backup.go
@@ -154,7 +154,10 @@ func registerBackupRoutes(api huma.API, d Deps, g *gate) {
 		if err != nil {
 			return nil, fromBackupError(err)
 		}
-		out := &listOutput{Body: BackupSnapshotList{Items: make([]BackupSnapshot, 0, len(manifests))}}
+		out := &listOutput{Body: BackupSnapshotList{
+			Repository: &BackupRepository{ID: repo.Config().RepoID, Path: repo.Root()},
+			Items:      make([]BackupSnapshot, 0, len(manifests)),
+		}}
 		for _, manifest := range manifests {
 			snapshot, err := backupSnapshot(manifest)
 			if err != nil {

--- a/internal/api/routes_backup_test.go
+++ b/internal/api/routes_backup_test.go
@@ -100,6 +100,8 @@ func TestBackupInitCreateListRoundTrip(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, body)
 	var listed api.BackupSnapshotList
 	require.NoError(t, json.Unmarshal([]byte(body), &listed))
+	require.NotNil(t, listed.Repository)
+	assert.Equal(t, repository, *listed.Repository)
 	require.Len(t, listed.Items, 2)
 	assert.Equal(t, snapshot.ID, listed.Items[0].ID)
 	assert.Equal(t, second.ID, listed.Items[1].ID)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -414,6 +414,21 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
+	resp = webRequest(http.MethodGet, "/api/v1/backup/snapshots")
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"the read-only route is admitted even when no repository is configured")
+	require.NoError(t, resp.Body.Close())
+
+	resp = webRequest(http.MethodGet, "/api/v1/backup/snapshots?repo=/tmp/other")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"browser sessions cannot select arbitrary server filesystem paths")
+	require.NoError(t, resp.Body.Close())
+
+	resp = webRequest(http.MethodGet, "/api/v1/backup/snapshots?repo=")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"browser sessions cannot supply even an empty repository override")
+	require.NoError(t, resp.Body.Close())
+
 	resp = webRequest(http.MethodPost, "/api/v1/audit/verify")
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -429,6 +429,12 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 		"browser sessions cannot supply even an empty repository override")
 	require.NoError(t, resp.Body.Close())
 
+	resp = webRequest(http.MethodGet,
+		"/api/v1/backup/snapshots?repo=/;/../var/backups/other")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"browser authorization must not parse repository queries differently from Huma")
+	require.NoError(t, resp.Body.Close())
+
 	resp = webRequest(http.MethodPost, "/api/v1/audit/verify")
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -715,7 +715,8 @@ type BackupSnapshot struct {
 // BackupSnapshotList is returned as an object so later pagination can be
 // added without changing a top-level JSON array contract.
 type BackupSnapshotList struct {
-	Items []BackupSnapshot `json:"items"`
+	Repository *BackupRepository `json:"repository,omitempty"`
+	Items      []BackupSnapshot  `json:"items"`
 }
 
 // BackupProgress is one structured update from a long-running backup

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -76,7 +76,7 @@ func webSessionRequestAllowed(r *http.Request) bool {
 		// Browser sessions may inspect only the repository selected by daemon
 		// configuration. An arbitrary repo query is a server-filesystem read
 		// capability and remains exclusive to the master API credential.
-		return !r.URL.Query().Has("repo")
+		return r.URL.RawQuery == ""
 	}
 	const tagPrefix = "/api/v1/tags/"
 	if after, ok := strings.CutPrefix(path, tagPrefix); ok {

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -56,7 +56,8 @@ func (r *webSessionRegistry) revoke(token string) {
 	r.mu.Unlock()
 }
 
-func webSessionRequestAllowed(method, path string) bool {
+func webSessionRequestAllowed(r *http.Request) bool {
+	method, path := r.Method, r.URL.Path
 	if method == http.MethodPost && path == webDownloadPreparePath {
 		return true
 	}
@@ -71,6 +72,11 @@ func webSessionRequestAllowed(method, path string) bool {
 		"/api/v1/audit/status", "/api/v1/audit/history", "/api/v1/jobs",
 		"/api/v1/storage", "/api/v1/tags":
 		return true
+	case "/api/v1/backup/snapshots":
+		// Browser sessions may inspect only the repository selected by daemon
+		// configuration. An arbitrary repo query is a server-filesystem read
+		// capability and remains exclusive to the master API credential.
+		return !r.URL.Query().Has("repo")
 	}
 	const tagPrefix = "/api/v1/tags/"
 	if after, ok := strings.CutPrefix(path, tagPrefix); ok {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "50"
+	daemonProtocolVersion = "51"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Docbank can already create, list, verify, and restore incremental backups, but its primary browser could not answer a basic human question: **when was this vault last captured?** This adds a read-only **Recovery points** drawer to the web application. For example, the synthetic vault below has an initial full capture followed by a weekly incremental snapshot.

The drawer identifies the configured repository by stable ID and server path, then lists immutable snapshots newest first. Each entry distinguishes full from incremental history and reports the logical tree, content population, and pack bytes newly added by that capture. An unconfigured repository, an initialized but empty repository, loading, expired authentication, and ordinary API failure are presented as distinct states.

![The actual Docbank web application showing full and incremental backup snapshots](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-backup-snapshots/web-backup-snapshots.png?v=f97c7b7)

*Actual daemon-served interface using a temporary synthetic vault and backup repository; no private corpus data is present.*

Seeing a snapshot is deliberately not presented as recovery proof. The drawer says that it lists manifests only; `docbank backup verify` and a restore rehearsal remain the workflows that prove repository bytes and recoverability. The browser session may read only the repository already selected in daemon configuration. It cannot submit another server path or initialize, create, verify, restore, retain, or delete backup data.