### PR TITLE
Upload verified documents from the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Four commitments:
 - FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
 - A read-only daemon-backed TUI for analytical tree browsing, search, stable
   document/version identity inspection, and permanent audited-history timelines
-- A read-only kit-ui web application for virtual-tree browsing, sortable
+- A scoped kit-ui web application for verified local-file upload, virtual-tree browsing, sortable
   document analysis, tag browsing, tag-filtered extracted-text search,
   complete current authority, verified current and historical content download,
   permanent protection and event history, immutable versions and provenance,

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -277,7 +277,7 @@ func runServe(ctx context.Context) (retErr error) {
 	shutdownCtx, cancel := context.WithTimeout(
 		context.Background(), daemonlife.HTTPDrainTimeout)
 	defer cancel()
-	var shutdownErr error
+	shutdownErr := srv.Shutdown(shutdownCtx)
 	for _, running := range servers {
 		if err := running.server.Shutdown(shutdownCtx); err != nil {
 			_ = running.server.Close()

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -219,6 +219,7 @@ func runServe(ctx context.Context) (retErr error) {
 		StartedAt: time.Now(), ShutdownToken: shutdownToken, Shutdown: stop, Tracker: tracker,
 		Jobs: jobSupervisor, Gate: operationGate, WebURL: webURL,
 	})
+	defer srv.Close()
 	newHTTPServer := func() *http.Server {
 		return &http.Server{
 			Handler:           srv.Handler(),

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "51", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "52", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "51", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "52", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "51", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "52", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "51", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "52", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/cmd/docbank/web.go
+++ b/cmd/docbank/web.go
@@ -23,12 +23,14 @@ var webCmd = &cobra.Command{
 	Short: "Open the local web application",
 	Long: `Start or reconnect to the current vault's daemon and open its web application.
 
-The browser receives a daemon-lifetime, read-only session in a URL fragment,
+The browser receives daemon-lifetime scoped credentials in a URL fragment,
 which is not sent in the initial HTTP request. The vault's master API key
-never enters the browser.
+never enters the browser. File bytes are sent only after a persistent upload
+channel proves that it belongs to this daemon; a broken channel is not
+reconnected.
 
 With --no-browser, the authenticated URL is printed instead. It contains the
-session key: do not paste it into logs, issue trackers, or chat.`,
+browser credentials: do not paste it into logs, issue trackers, or chat.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		if !docweb.Available() {
@@ -102,6 +104,6 @@ func validateWebLaunchURL(rawURL string) error {
 
 func init() {
 	webCmd.Flags().BoolVar(&webNoBrowser, "no-browser", false,
-		"print the authenticated URL instead of opening it (contains the session key)")
+		"print the authenticated URL instead of opening it (contains browser credentials)")
 	rootCmd.AddCommand(webCmd)
 }

--- a/cmd/docbank/web_test.go
+++ b/cmd/docbank/web_test.go
@@ -28,8 +28,9 @@ func webSessionClient(t *testing.T, token string) (*client.Client, string) {
 		assert.Equal(t, "/api/daemon/web-session", r.URL.Path)
 		assert.Equal(t, "private key", r.Header.Get("X-Api-Key"))
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"token": token,
-			"url":   webOrigin + "/",
+			"token":         token,
+			"upload_secret": "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE",
+			"url":           webOrigin + "/",
 		})
 	}))
 	t.Cleanup(ts.Close)
@@ -60,6 +61,7 @@ func TestRunWebOpensReadOnlySessionWithoutPrintingMasterKey(t *testing.T) {
 	raw, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Contains(t, string(raw), "web_session=read-only-session")
+	assert.Contains(t, string(raw), "web_upload_secret=")
 	assert.NotContains(t, string(raw), "private key")
 }
 
@@ -72,6 +74,7 @@ func TestRunWebNoBrowserExplicitlyPrintsAuthenticatedURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), webOrigin+"/#")
 	assert.Contains(t, out.String(), "#web_session=read-only-session")
+	assert.Contains(t, out.String(), "web_upload_secret=")
 	assert.NotContains(t, out.String(), "private key")
 }
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -64,12 +64,17 @@ and `/` plus `/assets/` (the static web application, when `[web] enabled`). A hi
 /api/daemon/shutdown` (not in the OpenAPI document) backs `docbank
 daemon stop`; it isn't auth-exempt, so it requires both the API key and
 its own shutdown token. The hidden `POST /api/daemon/web-session` exchanges
-that master authority for a random daemon-lifetime browser token and returns
-the fresh loopback origin dedicated to that daemon lifetime, while
+that master authority for a random daemon-lifetime browser token, an
+independent upload-proof secret, and the fresh loopback origin dedicated to
+that daemon lifetime, while
 `DELETE /api/daemon/web-session` revokes the calling browser session. Those
 tokens authenticate only the explicit routes used by the built-in document,
-storage, job, configured-backup, verified-download, and digest-checked upload
-workflows; they are intentionally not another general API credential.
+storage, job, configured-backup, and verified-download workflows; they are
+intentionally not another general API credential. Browser file bytes use the
+hidden `/api/daemon/web-upload` WebSocket instead. The page verifies a
+challenge proof over the upload secret before sending bytes, binds the socket
+to one session, and never reconnects it. An ordinary browser token is
+explicitly forbidden from `POST /api/v1/uploads`.
 
 `GET /nodes/{id}/children` binds the live directory projection—including its
 current canonical path—and the requested child page to one read transaction.

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -67,9 +67,9 @@ its own shutdown token. The hidden `POST /api/daemon/web-session` exchanges
 that master authority for a random daemon-lifetime browser token and returns
 the fresh loopback origin dedicated to that daemon lifetime, while
 `DELETE /api/daemon/web-session` revokes the calling browser session. Those
-tokens authenticate only the explicit read routes used by the built-in
-document, storage, job, and configured-backup views; they are intentionally
-not another general API credential.
+tokens authenticate only the explicit routes used by the built-in document,
+storage, job, configured-backup, verified-download, and digest-checked upload
+workflows; they are intentionally not another general API credential.
 
 `GET /nodes/{id}/children` binds the live directory projection—including its
 current canonical path—and the requested child page to one read transaction.
@@ -560,16 +560,16 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `maintenance_busy` | 503 | exclusive vault maintenance is running or queued; retry the mutation after it finishes |
 | `pack_retirement_deferred` | 503 | repack authority committed but an old source pack remains physically locked; release the lock, then run `storage pack` reconciliation |
 | `unauthorized` | 401 | missing or invalid API key; bad shutdown token |
-| `web_session_read_only` | 403 | a daemon-issued browser session attempted an endpoint outside its explicit read-only allowlist |
+| `web_session_read_only` | 403 | a daemon-issued browser session attempted an endpoint outside its explicit attenuated allowlist |
 | `web_unavailable` | 503 | this daemon is not serving compiled web assets |
 | `internal` | 500 | unmapped error (still surfaced with a message — this is a single-user local daemon, not a hardened multi-tenant service) |
 
 ## Non-goals
 
 - No server-side rendering. The kit-ui application is static public code; it
-  receives a daemon-lifetime read-only session from `docbank web`, and every
-  vault read remains an ordinary authenticated API request. The master API key
-  never enters the browser.
+  receives a daemon-lifetime attenuated session from `docbank web`. Reads,
+  verified-download preparation, and digest-checked file upload remain ordinary
+  authenticated API requests. The master API key never enters the browser.
 - No multi-user model: one vault and one master authority. Browser sessions are
   attenuated local capabilities, not accounts. Sharing is out of scope for v1.
 - No MCP server.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -698,16 +698,19 @@ docbank web [--no-browser]
 ```
 
 Starts or reconnects to the selected vault's compatible daemon and opens the
-embedded read-only web application. An owner-private launch file transfers the
+embedded web application. It can browse and search the vault, inspect and
+download verified document authority, and upload local files into the current
+folder through the caller-declared/server-verified byte-identity contract. An
+owner-private launch file transfers the
 daemon-issued browser session without putting it in a child-process argument.
 The master API key stays on the ownership-pinned CLI connection and never
 enters the browser. Each daemon uses a separate, ephemeral loopback origin for
 the web application even when the API port is fixed. The application removes
-its read-only session token from the address bar before making requests and
-keeps it only in page memory.
+its scoped session token from the address bar before making requests and keeps
+it only in page memory.
 
 `--no-browser` prints that authenticated URL instead of opening it. The output
-contains a live read-only browser session and must be handled as a secret. See the
+contains a live scoped browser session and must be handled as a secret. See the
 [web application guide](usage/web.md) for its capabilities and trust boundary.
 
 ## docbank trash

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -18,7 +18,7 @@ Every documentation page is also published as raw Markdown at the same path with
 - [Importing Documents](https://docbank.ai/usage/importing.md): Bulk import semantics — recursion, idempotency, collision suffixing, and failure handling.
 - [Organizing & Tagging](https://docbank.ai/usage/organizing.md): Browsing, moving, renaming, and tagging in the virtual tree.
 - [Searching](https://docbank.ai/usage/searching.md): Ranked, prefix-matching search over document names and verified text content.
-- [Web application](https://docbank.ai/usage/web.md): Browse and search the local vault in a responsive, authenticated, read-only web interface.
+- [Web application](https://docbank.ai/usage/web.md): Upload, browse, and search the local vault in a responsive, authenticated web interface.
 - [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse documents, inspect authority and permanent history, and observe daemon background work from a read-only TUI.
 
 ## Protect & Operate

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,11 +148,13 @@ history. Every selected node exposes its tag assignments, and a stable tag
 identity can drive either a live assignment view or a text-search filter.
 Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
-portal also reports current and terminal daemon background jobs and separates
-physical loose files, live packed content, complete pack payload, and
-logically dead payload awaiting explicit repack. Future slices
-cover import, tag mutation and broader metadata, version comparison, trash,
-storage maintenance, and backup.
+portal also uploads local files through the same caller-declared and
+server-verified byte-identity contract used by remote agents, lists configured
+backup recovery points, reports current and terminal daemon background jobs,
+and separates physical loose files, live packed content, complete pack payload,
+and logically dead payload awaiting explicit repack. Future slices cover tag
+mutation and broader metadata, version comparison, trash, and storage
+maintenance.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -71,11 +71,18 @@ the destination's stable directory ID and current canonical path.
 
 Docbank makes two bounded-memory passes over each selected file. The first pass
 computes the browser's declared SHA-256 while showing hashing progress. The
-second streams a multipart upload with visible byte progress through the
-ordinary `POST /api/v1/uploads` contract. The daemon independently computes
-the hash and size and grants node/blob authority only when both match. The
-browser compares that receipt again before reporting **Added** or **Already
-present**, then refreshes the destination by stable ID.
+second streams the bytes with visible progress over a dedicated upload channel.
+Before the upload button becomes available, the daemon proves that channel
+with a random secret issued through the ownership-pinned CLI handoff. File
+bytes never use an ordinary reconnectable browser HTTP request.
+
+The channel is bound to one browser session and one daemon lifetime. If it
+breaks, the page permanently disables upload rather than reconnecting to
+whatever process now owns the loopback port; run `docbank web` again to obtain
+a newly proved channel. The daemon independently computes the hash and size
+and grants node/blob authority only when both match. The browser compares that
+receipt again before reporting **Added** or **Already present**, then refreshes
+the destination by stable ID.
 
 Files are independent queue entries: one rejection does not make another
 success ambiguous, and failed entries can be retried. Cancellation can race
@@ -293,18 +300,21 @@ origin is independent of the configured API port and unique to one daemon
 lifetime. A process that later captures either port therefore cannot leave a
 service worker or cached script waiting for a future browser session.
 
-The launch page carries only the scoped session in a URL fragment. Browsers
-do not include fragments in the initial HTTP request; the application removes
-it from the address bar and holds it only in page memory. Requests use
+The launch page carries the scoped session and its random upload-proof secret
+in a URL fragment. Browsers do not include fragments in the initial HTTP
+request; the application removes them from the address bar and holds them only
+in page memory. Ordinary requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
 search, tag-definition and assignment reads, immutable-version, provenance, audit-status, audit-history,
 background-job, physical-storage-status, configured backup-snapshot-list,
-verified-download preparation, and digest-checked file upload
+and verified-download preparation
 used by this interface.
 Download preparation may write only owner-private temporary bytes and issue
-one exact, expiring file ticket. Upload may create only file nodes beneath the
-stable live directory selected in the browser and must satisfy the same
-caller-declared/server-computed byte identity as every remote writer. The
+one exact, expiring file ticket. Upload uses a separate, never-reconnecting
+WebSocket authenticated by a challenge proof over the upload secret. No file
+bytes are sent until that proof succeeds. It may create only file nodes
+beneath the stable live directory selected in the browser and must satisfy the
+same caller-declared/server-computed byte identity as every remote writer. The
 session cannot perform any other document mutation, enroll audit scopes, run
 independent verification, or call backup creation, verification, restore,
 maintenance, configuration, or general API endpoints. Its sole backup
@@ -326,8 +336,8 @@ runtime state, excluded from snapshots, replaced by the next launch, and
 removed when the daemon stops.
 
 Use `docbank web --no-browser` only when another local program must open the
-URL. That output contains the live session key. Do not put it in shell history,
-logs, screenshots, issue trackers, or chat.
+URL. That output contains the live browser credentials. Do not put it in shell
+history, logs, screenshots, issue trackers, or chat.
 
 ## Current boundary
 
@@ -349,6 +359,7 @@ Use the corresponding CLI or authenticated HTTP endpoint for those workflows.
 Future web workflows will require deliberately expanded browser-session
 permissions rather than inheriting the master API key.
 
-If a page reports that its browser session expired or was rejected, run
-`docbank web` again. Sessions deliberately do not survive daemon restart, and
-the previous random `.localhost` origin is not reused.
+If a page reports that its browser session or upload channel expired, ended,
+or was rejected, run `docbank web` again. Neither credential nor the upload
+channel survives daemon restart, and the previous random `.localhost` origin
+is not reused.

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -78,10 +78,13 @@ browser compares that receipt again before reporting **Added** or **Already
 present**, then refreshes the destination by stable ID.
 
 Files are independent queue entries: one rejection does not make another
-success ambiguous, failed entries can be retried, and cancellation stops before
-Docbank reports authority for the current item. Name/content collisions retain
-the ordinary ingest suffix behavior rather than overwriting a document.
-Selecting a local file never changes or removes the source.
+success ambiguous, and failed entries can be retried. Cancellation can race
+with a daemon commit whose receipt did not reach the browser, so the drawer
+labels that item **Unconfirmed**, refreshes the destination, and directs the
+operator to retry; the idempotent upload contract then converges on the stored
+result. Name/content collisions retain the ordinary ingest suffix behavior
+rather than overwriting a document. Selecting a local file never changes or
+removes the source.
 
 This first browser import is file-granular. Folder recursion, server-filesystem
 ingest, watched-inbox configuration, and replacing an existing document remain

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -1,6 +1,6 @@
 ---
 title: Web application
-description: Browse and search the local vault in a responsive, authenticated, read-only web interface.
+description: Upload, browse, and search the local vault in a responsive, authenticated web interface.
 ---
 
 # Web application
@@ -12,9 +12,9 @@ docbank web
 ```
 
 Docbank starts or reconnects to the selected vault's compatible daemon and
-opens its local web application. It is a read-only document browser: navigate
-the virtual tree, sort a folder by document name, size, or modification time,
-search names and extracted text, and inspect the selected document's stable
+opens its local web application. Choose local files for verified upload,
+navigate the virtual tree, sort a folder by document name, size, or modification
+time, search names and extracted text, and inspect the selected document's stable
 node ID, revision, current version ID, SHA-256 identity, exact size, and media
 type. The authority card also shows every tag assigned to the selected file or
 folder. Selecting a tag browses its live assignments, while search can require
@@ -61,6 +61,31 @@ even when the card wraps it across lines. Every selected node also shows its
 assigned tag names. Hovering a tag shows its stable UUID and vault-wide
 assignment count; the bounded tag stack expands in place when a node carries
 more than six.
+
+## Upload verified documents
+
+Choose the upload button while browsing a live folder, then select one or more
+files from this device. Upload is deliberately unavailable from search and
+tag-wide result views so the destination is never ambiguous. The drawer names
+the destination's stable directory ID and current canonical path.
+
+Docbank makes two bounded-memory passes over each selected file. The first pass
+computes the browser's declared SHA-256 while showing hashing progress. The
+second streams a multipart upload with visible byte progress through the
+ordinary `POST /api/v1/uploads` contract. The daemon independently computes
+the hash and size and grants node/blob authority only when both match. The
+browser compares that receipt again before reporting **Added** or **Already
+present**, then refreshes the destination by stable ID.
+
+Files are independent queue entries: one rejection does not make another
+success ambiguous, failed entries can be retried, and cancellation stops before
+Docbank reports authority for the current item. Name/content collisions retain
+the ordinary ingest suffix behavior rather than overwriting a document.
+Selecting a local file never changes or removes the source.
+
+This first browser import is file-granular. Folder recursion, server-filesystem
+ingest, watched-inbox configuration, and replacing an existing document remain
+CLI or authenticated API workflows.
 
 ## Download verified content
 
@@ -265,20 +290,23 @@ origin is independent of the configured API port and unique to one daemon
 lifetime. A process that later captures either port therefore cannot leave a
 service worker or cached script waiting for a future browser session.
 
-The launch page carries only the read-only session in a URL fragment. Browsers
+The launch page carries only the scoped session in a URL fragment. Browsers
 do not include fragments in the initial HTTP request; the application removes
 it from the address bar and holds it only in page memory. Requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
 search, tag-definition and assignment reads, immutable-version, provenance, audit-status, audit-history,
-background-job, physical-storage-status, configured backup-snapshot-list, and
-verified-download preparation
+background-job, physical-storage-status, configured backup-snapshot-list,
+verified-download preparation, and digest-checked file upload
 used by this interface.
 Download preparation may write only owner-private temporary bytes and issue
-one exact, expiring file ticket; it cannot mutate document authority. The
-session cannot enroll audit scopes, run independent verification, or call
-mutation, backup creation, verification, restore, maintenance, configuration,
-or general API endpoints. Its sole backup capability is listing the immutable
-snapshots in the repository already configured for this daemon.
+one exact, expiring file ticket. Upload may create only file nodes beneath the
+stable live directory selected in the browser and must satisfy the same
+caller-declared/server-computed byte identity as every remote writer. The
+session cannot perform any other document mutation, enroll audit scopes, run
+independent verification, or call backup creation, verification, restore,
+maintenance, configuration, or general API endpoints. Its sole backup
+capability is listing the immutable snapshots in the repository already
+configured for this daemon.
 
 The lock button revokes the session in daemon memory and clears the page.
 Every remaining browser session and its dedicated browser origin disappear
@@ -310,8 +338,8 @@ Refreshing a folder resolves its stable node ID, current canonical path, and
 children in one metadata snapshot, so a concurrent CLI or agent move cannot
 leave the browser constructing child paths beneath an obsolete name.
 
-The current web application does not compare versions, import, edit, revert,
-prune, move, create or change tags and
+The current web application does not compare versions, recursively import
+folders, edit, revert, prune, move, create or change tags and
 assignments, trash, enroll audit scopes, run independent audit verification,
 or run maintenance, backup, verification, or restore operations.
 Use the corresponding CLI or authenticated HTTP endpoint for those workflows.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -340,7 +340,7 @@
     },
     "node_modules/@kenn-io/kit-ui": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
+      "resolved": "git+https://github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
       "integrity": "sha512-of4b8+I+kJMYR0/gbF0u7XjGt1V0uQ6QfyoL6qSQiLnTIYnjR/3IZBt10Hb4MdlUN0b/BSNGRb5Ehifz7/4fcw==",
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
         "@lucide/svelte": "1.24.0",
+        "@noble/hashes": "^2.2.0",
         "svelte": "5.56.4"
       },
       "devDependencies": {
@@ -339,7 +340,7 @@
     },
     "node_modules/@kenn-io/kit-ui": {
       "version": "0.0.1",
-      "resolved": "git+https://github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
+      "resolved": "git+ssh://git@github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
       "integrity": "sha512-of4b8+I+kJMYR0/gbF0u7XjGt1V0uQ6QfyoL6qSQiLnTIYnjR/3IZBt10Hb4MdlUN0b/BSNGRb5Ehifz7/4fcw==",
       "license": "Apache-2.0",
       "bin": {
@@ -366,6 +367,18 @@
       "license": "ISC",
       "peerDependencies": {
         "svelte": "^5"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/runtime": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
     "@lucide/svelte": "1.24.0",
+    "@noble/hashes": "^2.2.0",
     "svelte": "5.56.4"
   },
   "devDependencies": {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,6 +12,7 @@
   import SearchIcon from "@lucide/svelte/icons/search";
   import TagIcon from "@lucide/svelte/icons/tag";
   import HistoryIcon from "@lucide/svelte/icons/history";
+  import UploadIcon from "@lucide/svelte/icons/upload";
   import {
     Button,
     Card,
@@ -36,6 +37,7 @@
   import JobsDrawer from "./JobsDrawer.svelte";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import StorageDrawer from "./StorageDrawer.svelte";
+  import UploadDrawer from "./UploadDrawer.svelte";
   import VersionHistoryDrawer from "./VersionHistoryDrawer.svelte";
   import {
     APIError,
@@ -109,6 +111,7 @@
   let jobsOpen = $state(false);
   let storageOpen = $state(false);
   let backupsOpen = $state(false);
+  let uploadTarget = $state<Node | null>(null);
   let generation = 0;
   let auditGeneration = 0;
   let tagGeneration = 0;
@@ -147,6 +150,7 @@
       jobsOpen = false;
       storageOpen = false;
       backupsOpen = false;
+      uploadTarget = null;
       tagCatalog = [];
       tagCatalogListed = 0;
       selectedTags = [];
@@ -516,6 +520,7 @@
     jobsOpen = false;
     storageOpen = false;
     backupsOpen = false;
+    uploadTarget = null;
     activeQuery = "";
     activeTagID = "";
     taggedInspected = 0;
@@ -539,7 +544,7 @@
     <Card level="raised" title="Open your Docbank" eyebrow="LOCAL VAULT">
       <div class="unlock-copy">
         <p>
-          Run <code>docbank web</code> to create a new read-only browser session.
+          Run <code>docbank web</code> to create a new scoped browser session.
           The vault API key is never stored in the browser.
         </p>
         {#if error}<p class="error" role="alert">{error}</p>{/if}
@@ -586,6 +591,7 @@
             jobsOpen = false;
             storageOpen = false;
             backupsOpen = true;
+            uploadTarget = null;
           }}
         >
           <ArchiveIcon size="14" aria-hidden="true" />
@@ -599,6 +605,7 @@
             provenanceOpen = false;
             jobsOpen = false;
             backupsOpen = false;
+            uploadTarget = null;
             storageOpen = true;
           }}
         >
@@ -613,6 +620,7 @@
             provenanceOpen = false;
             storageOpen = false;
             backupsOpen = false;
+            uploadTarget = null;
             jobsOpen = true;
           }}
         >
@@ -671,6 +679,28 @@
             {:else}
               <span>{rows.length}{truncated ? "+" : ""} item{rows.length === 1 ? "" : "s"}</span>
             {/if}
+            <IconButton
+              size="sm"
+              ariaLabel="Upload files to current folder"
+              title={activeQuery || tagBrowse
+                ? "Return to a folder before uploading"
+                : directory?.path
+                  ? `Upload files to ${directory.path}`
+                  : "Upload files"}
+              disabled={!directory || loading || Boolean(activeQuery) || tagBrowse}
+              onclick={() => {
+                if (!directory || activeQuery || tagBrowse) return;
+                historyOpen = false;
+                versionsOpen = false;
+                provenanceOpen = false;
+                jobsOpen = false;
+                storageOpen = false;
+                backupsOpen = false;
+                uploadTarget = directory;
+              }}
+            >
+              <UploadIcon size="14" aria-hidden="true" />
+            </IconButton>
             <IconButton
               size="sm"
               ariaLabel="Refresh current view"
@@ -881,6 +911,7 @@
                       jobsOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
+                      uploadTarget = null;
                       versionsOpen = true;
                     }}
                   >
@@ -896,6 +927,7 @@
                       jobsOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
+                      uploadTarget = null;
                       provenanceOpen = true;
                     }}
                   >
@@ -936,6 +968,7 @@
                       provenanceOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
+                      uploadTarget = null;
                       historyOpen = true;
                     }}
                   >
@@ -1013,6 +1046,17 @@
       <StorageDrawer
         session={webSession}
         onclose={() => (storageOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if uploadTarget}
+      <UploadDrawer
+        session={webSession}
+        directory={uploadTarget}
+        onclose={() => (uploadTarget = null)}
+        oncomplete={() => {
+          if (uploadTarget) void loadDirectory(uploadTarget.id, false);
+        }}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1054,8 +1054,8 @@
         session={webSession}
         directory={uploadTarget}
         onclose={() => (uploadTarget = null)}
-        oncomplete={() => {
-          if (uploadTarget) void loadDirectory(uploadTarget.id, false);
+        oncomplete={async () => {
+          if (uploadTarget) await loadDirectory(uploadTarget.id, false);
         }}
         onauthfailure={handleFailure}
       />

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -58,6 +58,7 @@
   } from "./api.js";
   import { basename, formatBytes, formatDate } from "./format.js";
   import { orderRows, reconcileSearchView, type SortField } from "./rows.js";
+  import { VerifiedUploadChannel } from "./upload.js";
 
   type Row = { node: Node; path: string; match?: "name" | "content" };
   type Snapshot = {
@@ -77,6 +78,8 @@
   };
 
   let webSession = $state("");
+  let uploadChannel = $state<VerifiedUploadChannel | null>(null);
+  let uploadChannelError = $state("");
   let directory = $state<Node | null>(null);
   let rows = $state<Row[]>([]);
   let stack = $state<Snapshot[]>([]);
@@ -134,16 +137,34 @@
   );
 
   onMount(() => {
-    webSession = takeFragmentSession();
-    if (webSession) {
+    const session = takeFragmentSession();
+    if (session) {
+      webSession = session.token;
       void loadRoot();
       void loadTagCatalog();
+      const channel = new VerifiedUploadChannel(session, undefined, () => {
+        if (uploadChannel === channel) uploadChannel = null;
+        uploadChannelError =
+          "The verified upload channel ended. Run `docbank web` again before selecting files.";
+      });
+      void channel.connect().then(
+        () => {
+          if (webSession === session.token) uploadChannel = channel;
+          else channel.close();
+        },
+        (cause) => {
+          uploadChannelError = cause instanceof Error ? cause.message : String(cause);
+        },
+      );
+      return () => channel.close();
     }
   });
 
   function handleFailure(cause: unknown): void {
     if (cause instanceof APIError && cause.status === 401) {
+      uploadChannel?.close();
       webSession = "";
+      uploadChannel = null;
       historyOpen = false;
       versionsOpen = false;
       provenanceOpen = false;
@@ -498,6 +519,8 @@
     tagGeneration += 1;
     tagCatalogGeneration += 1;
     const session = webSession;
+    uploadChannel?.close();
+    uploadChannel = null;
     webSession = "";
     directory = null;
     rows = [];
@@ -684,10 +707,14 @@
               ariaLabel="Upload files to current folder"
               title={activeQuery || tagBrowse
                 ? "Return to a folder before uploading"
+                : uploadChannelError
+                  ? uploadChannelError
+                  : !uploadChannel
+                    ? "Establishing the verified upload channel"
                 : directory?.path
                   ? `Upload files to ${directory.path}`
                   : "Upload files"}
-              disabled={!directory || loading || Boolean(activeQuery) || tagBrowse}
+              disabled={!directory || loading || Boolean(activeQuery) || tagBrowse || !uploadChannel}
               onclick={() => {
                 if (!directory || activeQuery || tagBrowse) return;
                 historyOpen = false;
@@ -1049,9 +1076,9 @@
         onauthfailure={handleFailure}
       />
     {/if}
-    {#if uploadTarget}
+    {#if uploadTarget && uploadChannel}
       <UploadDrawer
-        session={webSession}
+        channel={uploadChannel}
         directory={uploadTarget}
         onclose={() => (uploadTarget = null)}
         oncomplete={async () => {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -143,9 +143,10 @@
       void loadRoot();
       void loadTagCatalog();
       const channel = new VerifiedUploadChannel(session, undefined, () => {
-        if (uploadChannel === channel) uploadChannel = null;
-        uploadChannelError =
-          "The verified upload channel ended. Run `docbank web` again before selecting files.";
+        if (uploadChannel === channel) {
+          uploadChannelError =
+            "The verified upload channel ended. Run `docbank web` again before selecting more files.";
+        }
       });
       void channel.connect().then(
         () => {
@@ -714,7 +715,8 @@
                 : directory?.path
                   ? `Upload files to ${directory.path}`
                   : "Upload files"}
-              disabled={!directory || loading || Boolean(activeQuery) || tagBrowse || !uploadChannel}
+              disabled={!directory || loading || Boolean(activeQuery) || tagBrowse ||
+                !uploadChannel || Boolean(uploadChannelError)}
               onclick={() => {
                 if (!directory || activeQuery || tagBrowse) return;
                 historyOpen = false;
@@ -1080,6 +1082,7 @@
       <UploadDrawer
         channel={uploadChannel}
         directory={uploadTarget}
+        disabledReason={uploadChannelError}
         onclose={() => (uploadTarget = null)}
         oncomplete={async () => {
           if (uploadTarget) await loadDirectory(uploadTarget.id, false);

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -17,7 +17,11 @@ afterEach(() => {
 });
 
 it("supersedes an in-flight search when its tag filter changes", async () => {
-  history.replaceState(null, "", "/#web_session=short-lived");
+  history.replaceState(
+    null,
+    "",
+    "/#web_session=short-lived&web_upload_secret=proof",
+  );
   vi.stubGlobal(
     "ResizeObserver",
     class {

--- a/frontend/src/UploadDrawer.svelte
+++ b/frontend/src/UploadDrawer.svelte
@@ -16,6 +16,7 @@
   import {
     hashFile,
     type TransferProgress,
+    UploadChannelError,
     type UploadTransport,
   } from "./upload.js";
   import { formatBytes } from "./format.js";
@@ -43,12 +44,15 @@
   interface Props {
     channel: UploadTransport;
     directory: Node;
+    disabledReason?: string;
     onclose: () => void;
     oncomplete: () => void | Promise<void>;
     onauthfailure: (cause: unknown) => void;
   }
 
-  let { channel, directory, onclose, oncomplete, onauthfailure }: Props = $props();
+  let {
+    channel, directory, disabledReason = "", onclose, oncomplete, onauthfailure,
+  }: Props = $props();
   let input: HTMLInputElement;
   let items = $state<UploadItem[]>([]);
   let running = $state(false);
@@ -129,14 +133,16 @@
           hash,
           progress: { processed: 0, total: queued.file.size },
         });
-        transmissionStarted = true;
-        refreshNeeded = true;
         const receipt = await channel.uploadFile(
           directory.id,
           queued.file,
           hash,
           active.signal,
-          (progress) => progressFor(queued.id, progress),
+          (progress) => {
+            transmissionStarted = true;
+            refreshNeeded = true;
+            progressFor(queued.id, progress);
+          },
         );
         updateItem(queued.id, {
           state: receipt.status,
@@ -165,10 +171,19 @@
           onauthfailure(cause);
           break;
         }
+        if (transmissionStarted && !(cause instanceof APIError)) {
+          updateItem(queued.id, {
+            state: "unconfirmed",
+            error:
+              "Upload outcome is unconfirmed. Refreshing the folder; retry this file after running `docbank web` again.",
+          });
+          break;
+        }
         updateItem(queued.id, {
           state: "failed",
           error: cause instanceof Error ? cause.message : String(cause),
         });
+        if (cause instanceof UploadChannelError) break;
       }
     }
 
@@ -245,6 +260,9 @@
       over the upload channel proved by this daemon; a broken channel is never
       reconnected.
     </p>
+    {#if disabledReason}
+      <p class="channel-error" role="alert">{disabledReason}</p>
+    {/if}
 
     <input
       bind:this={input}
@@ -256,7 +274,12 @@
     />
 
     <div class="controls">
-      <Button size="sm" surface="soft" disabled={running} onclick={chooseFiles}>
+      <Button
+        size="sm"
+        surface="soft"
+        disabled={running || Boolean(disabledReason)}
+        onclick={chooseFiles}
+      >
         <FileUpIcon size="14" aria-hidden="true" />
         Choose files
       </Button>
@@ -265,7 +288,7 @@
           <XIcon size="14" aria-hidden="true" />
           Cancel current upload
         </Button>
-      {:else if pending > 0}
+      {:else if pending > 0 && !disabledReason}
         <Button size="sm" tone="info" surface="solid" onclick={() => void start()}>
           <FileUpIcon size="14" aria-hidden="true" />
           Upload {pending} file{pending === 1 ? "" : "s"}
@@ -303,7 +326,7 @@
                     ? "danger"
                     : item.state === "added" || item.state === "skipped"
                       ? "success"
-                      : item.state === "cancelled"
+                      : item.state === "cancelled" || item.state === "unconfirmed"
                         ? "warning"
                         : "neutral"}
                   uppercase={false}
@@ -446,6 +469,16 @@
     color: var(--text-secondary);
     font-size: var(--font-size-sm);
     line-height: 1.5;
+  }
+
+  .channel-error {
+    padding: var(--space-3);
+    border: 1px solid color-mix(in srgb, var(--color-danger, #dc2626) 45%, transparent);
+    border-radius: var(--radius-md);
+    margin: 0;
+    background: color-mix(in srgb, var(--color-danger, #dc2626) 10%, transparent);
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
   }
 
   .controls {

--- a/frontend/src/UploadDrawer.svelte
+++ b/frontend/src/UploadDrawer.svelte
@@ -43,7 +43,7 @@
     session: string;
     directory: Node;
     onclose: () => void;
-    oncomplete: () => void;
+    oncomplete: () => void | Promise<void>;
     onauthfailure: (cause: unknown) => void;
   }
 
@@ -104,7 +104,8 @@
     const active = new AbortController();
     controller = active;
     running = true;
-    let accepted = false;
+    let refreshNeeded = false;
+    let authFailed = false;
 
     for (const queued of items) {
       if (!["ready", "failed", "cancelled"].includes(queued.state)) continue;
@@ -126,6 +127,7 @@
           hash,
           progress: { processed: 0, total: queued.file.size },
         });
+        refreshNeeded = true;
         const receipt = await uploadFile(
           session,
           directory.id,
@@ -139,17 +141,18 @@
           receipt,
           progress: { processed: queued.file.size, total: queued.file.size },
         });
-        accepted = true;
       } catch (cause) {
         if (cause instanceof DOMException && cause.name === "AbortError") {
           updateItem(queued.id, {
             state: "cancelled",
-            error: "Cancelled before Docbank granted authority.",
+            error:
+              "Upload outcome is unconfirmed. Refreshing the folder; retry this file to converge safely.",
           });
           break;
         }
         if (cause instanceof APIError && cause.status === 401) {
           updateItem(queued.id, { state: "failed", error: cause.message });
+          authFailed = true;
           onauthfailure(cause);
           break;
         }
@@ -163,7 +166,7 @@
     if (controller === active) {
       controller = null;
       running = false;
-      if (accepted) oncomplete();
+      if (refreshNeeded && !authFailed) await oncomplete();
     }
   }
 
@@ -199,7 +202,7 @@
       case "failed":
         return "Failed";
       case "cancelled":
-        return "Cancelled";
+        return "Unconfirmed";
     }
   }
 </script>

--- a/frontend/src/UploadDrawer.svelte
+++ b/frontend/src/UploadDrawer.svelte
@@ -15,8 +15,8 @@
   import { APIError, type Node, type UploadReceipt } from "./api.js";
   import {
     hashFile,
-    uploadFile,
     type TransferProgress,
+    type UploadTransport,
   } from "./upload.js";
   import { formatBytes } from "./format.js";
 
@@ -40,14 +40,14 @@
   }
 
   interface Props {
-    session: string;
+    channel: UploadTransport;
     directory: Node;
     onclose: () => void;
     oncomplete: () => void | Promise<void>;
     onauthfailure: (cause: unknown) => void;
   }
 
-  let { session, directory, onclose, oncomplete, onauthfailure }: Props = $props();
+  let { channel, directory, onclose, oncomplete, onauthfailure }: Props = $props();
   let input: HTMLInputElement;
   let items = $state<UploadItem[]>([]);
   let running = $state(false);
@@ -128,8 +128,7 @@
           progress: { processed: 0, total: queued.file.size },
         });
         refreshNeeded = true;
-        const receipt = await uploadFile(
-          session,
+        const receipt = await channel.uploadFile(
           directory.id,
           queued.file,
           hash,
@@ -230,7 +229,9 @@
     <p class="contract">
       Docbank reads each file twice: once locally to declare its SHA-256
       identity, then once to stream it. Authority is granted only when the
-      daemon independently computes the same hash and size.
+      daemon independently computes the same hash and size. Bytes travel only
+      over the upload channel proved by this daemon; a broken channel is never
+      reconnected.
     </p>
 
     <input

--- a/frontend/src/UploadDrawer.svelte
+++ b/frontend/src/UploadDrawer.svelte
@@ -1,0 +1,549 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import FileUpIcon from "@lucide/svelte/icons/file-up";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import Trash2Icon from "@lucide/svelte/icons/trash-2";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Chip,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+  } from "@kenn-io/kit-ui";
+  import { APIError, type Node, type UploadReceipt } from "./api.js";
+  import {
+    hashFile,
+    uploadFile,
+    type TransferProgress,
+  } from "./upload.js";
+  import { formatBytes } from "./format.js";
+
+  type UploadState =
+    | "ready"
+    | "hashing"
+    | "uploading"
+    | "added"
+    | "skipped"
+    | "failed"
+    | "cancelled";
+
+  interface UploadItem {
+    id: number;
+    file: File;
+    state: UploadState;
+    progress: TransferProgress;
+    hash?: string;
+    error?: string;
+    receipt?: UploadReceipt;
+  }
+
+  interface Props {
+    session: string;
+    directory: Node;
+    onclose: () => void;
+    oncomplete: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, directory, onclose, oncomplete, onauthfailure }: Props = $props();
+  let input: HTMLInputElement;
+  let items = $state<UploadItem[]>([]);
+  let running = $state(false);
+  let controller: AbortController | null = null;
+  let nextID = 1;
+
+  const pending = $derived(
+    items.filter((item) =>
+      ["ready", "failed", "cancelled"].includes(item.state),
+    ).length,
+  );
+  const completed = $derived(
+    items.filter((item) => item.state === "added" || item.state === "skipped")
+      .length,
+  );
+  const failures = $derived(
+    items.filter((item) => item.state === "failed").length,
+  );
+
+  onDestroy(() => controller?.abort());
+
+  function chooseFiles(): void {
+    input.click();
+  }
+
+  function addFiles(event: Event): void {
+    const selected = Array.from((event.currentTarget as HTMLInputElement).files ?? []);
+    items = [
+      ...items,
+      ...selected.map((file) => ({
+        id: nextID++,
+        file,
+        state: "ready" as const,
+        progress: { processed: 0, total: file.size },
+      })),
+    ];
+    input.value = "";
+  }
+
+  function updateItem(id: number, patch: Partial<UploadItem>): void {
+    items = items.map((item) => (item.id === id ? { ...item, ...patch } : item));
+  }
+
+  function removeItem(id: number): void {
+    if (!running) items = items.filter((item) => item.id !== id);
+  }
+
+  function progressFor(id: number, progress: TransferProgress): void {
+    updateItem(id, { progress });
+  }
+
+  async function start(): Promise<void> {
+    if (running || pending === 0) return;
+    const active = new AbortController();
+    controller = active;
+    running = true;
+    let accepted = false;
+
+    for (const queued of items) {
+      if (!["ready", "failed", "cancelled"].includes(queued.state)) continue;
+      if (active.signal.aborted) break;
+      updateItem(queued.id, {
+        state: "hashing",
+        error: undefined,
+        receipt: undefined,
+        progress: { processed: 0, total: queued.file.size },
+      });
+      try {
+        const hash = await hashFile(
+          queued.file,
+          active.signal,
+          (progress) => progressFor(queued.id, progress),
+        );
+        updateItem(queued.id, {
+          state: "uploading",
+          hash,
+          progress: { processed: 0, total: queued.file.size },
+        });
+        const receipt = await uploadFile(
+          session,
+          directory.id,
+          queued.file,
+          hash,
+          active.signal,
+          (progress) => progressFor(queued.id, progress),
+        );
+        updateItem(queued.id, {
+          state: receipt.status,
+          receipt,
+          progress: { processed: queued.file.size, total: queued.file.size },
+        });
+        accepted = true;
+      } catch (cause) {
+        if (cause instanceof DOMException && cause.name === "AbortError") {
+          updateItem(queued.id, {
+            state: "cancelled",
+            error: "Cancelled before Docbank granted authority.",
+          });
+          break;
+        }
+        if (cause instanceof APIError && cause.status === 401) {
+          updateItem(queued.id, { state: "failed", error: cause.message });
+          onauthfailure(cause);
+          break;
+        }
+        updateItem(queued.id, {
+          state: "failed",
+          error: cause instanceof Error ? cause.message : String(cause),
+        });
+      }
+    }
+
+    if (controller === active) {
+      controller = null;
+      running = false;
+      if (accepted) oncomplete();
+    }
+  }
+
+  function cancel(): void {
+    controller?.abort();
+  }
+
+  function close(): void {
+    controller?.abort();
+    onclose();
+  }
+
+  function percentage(item: UploadItem): number {
+    if (item.progress.total === 0) return item.state === "ready" ? 0 : 100;
+    return Math.min(
+      100,
+      Math.round((item.progress.processed * 100) / item.progress.total),
+    );
+  }
+
+  function stateLabel(item: UploadItem): string {
+    switch (item.state) {
+      case "ready":
+        return "Ready";
+      case "hashing":
+        return "Hashing";
+      case "uploading":
+        return "Uploading";
+      case "added":
+        return "Added";
+      case "skipped":
+        return "Already present";
+      case "failed":
+        return "Failed";
+      case "cancelled":
+        return "Cancelled";
+    }
+  }
+</script>
+
+<DetailDrawer width="min(720px, 100vw)" ariaLabel="Upload documents" onclose={close}>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>VERIFIED IMPORT</span>
+        <strong>Upload documents</strong>
+        <small>{directory.path ?? `Directory id:${directory.id}`}</small>
+      </div>
+      <IconButton size="sm" ariaLabel="Close upload documents" onclick={close}>
+        <XIcon size="14" aria-hidden="true" />
+      </IconButton>
+    </div>
+  {/snippet}
+
+  <div class="upload">
+    <section class="destination" aria-label="Upload destination">
+      <div><span>DESTINATION</span><strong>{directory.path ?? "Moved directory"}</strong></div>
+      <Chip size="xs" tone="muted" uppercase={false}>id:{directory.id}</Chip>
+    </section>
+
+    <p class="contract">
+      Docbank reads each file twice: once locally to declare its SHA-256
+      identity, then once to stream it. Authority is granted only when the
+      daemon independently computes the same hash and size.
+    </p>
+
+    <input
+      bind:this={input}
+      class="kit-sr-only"
+      type="file"
+      multiple
+      onchange={addFiles}
+      aria-label="Choose local files"
+    />
+
+    <div class="controls">
+      <Button size="sm" surface="soft" disabled={running} onclick={chooseFiles}>
+        <FileUpIcon size="14" aria-hidden="true" />
+        Choose files
+      </Button>
+      {#if running}
+        <Button size="sm" tone="danger" surface="soft" onclick={cancel}>
+          <XIcon size="14" aria-hidden="true" />
+          Cancel current upload
+        </Button>
+      {:else if pending > 0}
+        <Button size="sm" tone="info" surface="solid" onclick={() => void start()}>
+          <FileUpIcon size="14" aria-hidden="true" />
+          Upload {pending} file{pending === 1 ? "" : "s"}
+        </Button>
+      {/if}
+    </div>
+
+    {#if items.length === 0}
+      <EmptyState
+        title="Choose files from this device"
+        description="Files are copied into the current Docbank directory. Local source files are never changed or removed."
+      >
+        {#snippet icon()}<FileUpIcon size="22" />{/snippet}
+      </EmptyState>
+    {:else}
+      <div class="queue-heading">
+        <strong>{items.length} selected</strong>
+        <span>
+          {completed} accepted
+          {#if failures > 0} · {failures} failed{/if}
+        </span>
+      </div>
+      <ul class="queue" aria-live="polite">
+        {#each items as item (item.id)}
+          <li>
+            <div class="file-row">
+              <div class="file-authority">
+                <strong>{item.file.name}</strong>
+                <span>{formatBytes(item.file.size)} · {item.file.type || "application/octet-stream"}</span>
+              </div>
+              <div class="file-actions">
+                <Chip
+                  size="xs"
+                  tone={item.state === "failed"
+                    ? "danger"
+                    : item.state === "added" || item.state === "skipped"
+                      ? "success"
+                      : item.state === "cancelled"
+                        ? "warning"
+                        : "neutral"}
+                  uppercase={false}
+                >
+                  {#if item.state === "hashing" || item.state === "uploading"}
+                    <Spinner size={11} />
+                  {/if}
+                  {stateLabel(item)}
+                </Chip>
+                {#if !running && item.state !== "added" && item.state !== "skipped"}
+                  <IconButton
+                    size="sm"
+                    ariaLabel={`Remove ${item.file.name} from upload`}
+                    onclick={() => removeItem(item.id)}
+                  >
+                    <Trash2Icon size="13" aria-hidden="true" />
+                  </IconButton>
+                {/if}
+              </div>
+            </div>
+
+            {#if item.state === "hashing" || item.state === "uploading"}
+              <div class="progress-copy">
+                <span>{stateLabel(item)}</span>
+                <span>{formatBytes(item.progress.processed)} / {formatBytes(item.progress.total)}</span>
+              </div>
+              <div
+                class="progress"
+                role="progressbar"
+                aria-label={`${stateLabel(item)} ${item.file.name}`}
+                aria-valuemin="0"
+                aria-valuemax={item.progress.total}
+                aria-valuenow={item.progress.processed}
+              >
+                <span style={`width: ${percentage(item)}%`}></span>
+              </div>
+            {:else if item.error}
+              <p class="item-error" role="alert">{item.error}</p>
+            {:else if item.receipt}
+              <p class="receipt">
+                {item.receipt.status === "added"
+                  ? `Created node ${item.receipt.node.id}, revision ${item.receipt.node.revision}.`
+                  : `Matched existing node ${item.receipt.node.id}.`}
+                <code>{item.receipt.computed_hash}</code>
+              </p>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+
+    {#if completed > 0 && !running}
+      <aside class="outcome">
+        <RefreshCwIcon size="15" aria-hidden="true" />
+        <span>
+          {completed} file{completed === 1 ? "" : "s"} accepted with matching
+          server receipts. The current folder has been refreshed.
+        </span>
+      </aside>
+    {/if}
+  </div>
+</DetailDrawer>
+
+<style>
+  .drawer-heading,
+  .destination,
+  .controls,
+  .queue-heading,
+  .file-row,
+  .file-actions,
+  .progress-copy,
+  .outcome {
+    display: flex;
+    align-items: center;
+  }
+
+  .drawer-heading,
+  .destination,
+  .queue-heading,
+  .file-row {
+    justify-content: space-between;
+  }
+
+  .drawer-heading {
+    width: 100%;
+    min-width: 0;
+    gap: var(--space-4);
+  }
+
+  .drawer-heading > div,
+  .destination > div,
+  .file-authority {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+  }
+
+  .drawer-heading span,
+  .destination span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading small {
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .upload {
+    display: grid;
+    gap: var(--space-4);
+    padding: var(--space-5);
+  }
+
+  .destination {
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--bg-inset);
+  }
+
+  .destination strong,
+  .file-authority strong {
+    overflow-wrap: anywhere;
+  }
+
+  .contract {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+  }
+
+  .controls {
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .queue-heading {
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .queue-heading span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .queue {
+    display: grid;
+    max-height: min(52vh, 520px);
+    padding: 0;
+    margin: 0;
+    gap: var(--space-2);
+    list-style: none;
+    overflow-y: auto;
+  }
+
+  .queue li {
+    display: grid;
+    padding: var(--space-3);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--bg-surface);
+    gap: var(--space-2);
+  }
+
+  .file-row {
+    min-width: 0;
+    gap: var(--space-3);
+  }
+
+  .file-authority span,
+  .progress-copy,
+  .receipt,
+  .item-error {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .file-actions {
+    flex-shrink: 0;
+    gap: var(--space-1);
+  }
+
+  .progress-copy {
+    justify-content: space-between;
+    gap: var(--space-2);
+  }
+
+  .progress {
+    width: 100%;
+    height: 5px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-inset);
+  }
+
+  .progress > span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--accent);
+    transition: width 100ms linear;
+  }
+
+  .item-error,
+  .receipt {
+    display: grid;
+    margin: 0;
+    gap: var(--space-1);
+    line-height: 1.4;
+  }
+
+  .item-error {
+    color: var(--danger-text);
+  }
+
+  .receipt code {
+    overflow-wrap: anywhere;
+  }
+
+  .outcome {
+    align-items: flex-start;
+    padding: var(--space-3);
+    border: 1px solid var(--success-border);
+    border-radius: var(--radius-md);
+    background: var(--success-bg);
+    color: var(--success-text);
+    font-size: var(--font-size-sm);
+    gap: var(--space-2);
+  }
+
+  @media (max-width: 640px) {
+    .upload {
+      padding: var(--space-4);
+    }
+
+    .file-row {
+      align-items: flex-start;
+    }
+
+    .destination {
+      align-items: flex-start;
+    }
+  }
+</style>

--- a/frontend/src/UploadDrawer.svelte
+++ b/frontend/src/UploadDrawer.svelte
@@ -27,6 +27,7 @@
     | "added"
     | "skipped"
     | "failed"
+    | "unconfirmed"
     | "cancelled";
 
   interface UploadItem {
@@ -56,7 +57,7 @@
 
   const pending = $derived(
     items.filter((item) =>
-      ["ready", "failed", "cancelled"].includes(item.state),
+      ["ready", "failed", "unconfirmed", "cancelled"].includes(item.state),
     ).length,
   );
   const completed = $derived(
@@ -108,8 +109,9 @@
     let authFailed = false;
 
     for (const queued of items) {
-      if (!["ready", "failed", "cancelled"].includes(queued.state)) continue;
+      if (!["ready", "failed", "unconfirmed", "cancelled"].includes(queued.state)) continue;
       if (active.signal.aborted) break;
+      let transmissionStarted = false;
       updateItem(queued.id, {
         state: "hashing",
         error: undefined,
@@ -127,6 +129,7 @@
           hash,
           progress: { processed: 0, total: queued.file.size },
         });
+        transmissionStarted = true;
         refreshNeeded = true;
         const receipt = await channel.uploadFile(
           directory.id,
@@ -142,11 +145,18 @@
         });
       } catch (cause) {
         if (cause instanceof DOMException && cause.name === "AbortError") {
-          updateItem(queued.id, {
-            state: "cancelled",
-            error:
-              "Upload outcome is unconfirmed. Refreshing the folder; retry this file to converge safely.",
-          });
+          if (transmissionStarted) {
+            updateItem(queued.id, {
+              state: "unconfirmed",
+              error:
+                "Upload outcome is unconfirmed. Refreshing the folder; retry this file to converge safely.",
+            });
+          } else {
+            updateItem(queued.id, {
+              state: "cancelled",
+              error: "Cancelled before upload began.",
+            });
+          }
           break;
         }
         if (cause instanceof APIError && cause.status === 401) {
@@ -201,6 +211,8 @@
       case "failed":
         return "Failed";
       case "cancelled":
+        return "Cancelled";
+      case "unconfirmed":
         return "Unconfirmed";
     }
   }

--- a/frontend/src/UploadDrawer.test.ts
+++ b/frontend/src/UploadDrawer.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import UploadDrawer from "./UploadDrawer.svelte";
+import * as upload from "./upload.js";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("upload documents drawer", () => {
+  it("hashes and uploads selected files before refreshing the directory", async () => {
+    const hash = "a".repeat(64);
+    vi.spyOn(upload, "hashFile").mockImplementation(
+      async (file, _signal, onprogress) => {
+        onprogress({ processed: file.size, total: file.size });
+        return hash;
+      },
+    );
+    vi.spyOn(upload, "uploadFile").mockImplementation(
+      async (_session, parentID, file, expectedHash, _signal, onprogress) => {
+        onprogress({ processed: file.size, total: file.size });
+        return {
+          status: "added",
+          computed_hash: expectedHash,
+          computed_size: file.size,
+          node: {
+            id: 8,
+            parent_id: parentID,
+            name: file.name,
+            kind: "file",
+            blob_hash: expectedHash,
+            size: file.size,
+            revision: 1,
+            created_at: "2026-07-28T00:00:00Z",
+            modified_at: "2026-07-28T00:00:00Z",
+          },
+        };
+      },
+    );
+    const complete = vi.fn();
+
+    render(UploadDrawer, {
+      session: "short-lived",
+      directory: {
+        id: 3,
+        name: "Reports",
+        path: "/Reports",
+        kind: "dir",
+        size: 0,
+        revision: 1,
+        created_at: "2026-07-28T00:00:00Z",
+        modified_at: "2026-07-28T00:00:00Z",
+      },
+      onclose: vi.fn(),
+      oncomplete: complete,
+      onauthfailure: vi.fn(),
+    });
+
+    const file = new File(["quarterly"], "quarterly.txt", {
+      type: "text/plain",
+    });
+    await fireEvent.change(screen.getByLabelText("Choose local files"), {
+      target: { files: [file] },
+    });
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Upload 1 file" }),
+    );
+
+    expect(await screen.findByText("Added")).toBeTruthy();
+    expect(screen.getByText(/Created node 8, revision 1/)).toBeTruthy();
+    await waitFor(() => expect(complete).toHaveBeenCalledOnce());
+    expect(upload.hashFile).toHaveBeenCalledOnce();
+    expect(upload.uploadFile).toHaveBeenCalledWith(
+      "short-lived",
+      3,
+      file,
+      hash,
+      expect.any(AbortSignal),
+      expect.any(Function),
+    );
+  });
+});

--- a/frontend/src/UploadDrawer.test.ts
+++ b/frontend/src/UploadDrawer.test.ts
@@ -103,8 +103,10 @@ describe("upload documents drawer", () => {
         _file: File,
         _expectedHash: string,
         signal: AbortSignal,
+        onprogress: (progress: upload.TransferProgress) => void,
       ) =>
         await new Promise<never>((_resolve, reject) => {
+          onprogress({ processed: 0, total: 9 });
           signal.addEventListener(
             "abort",
             () =>
@@ -201,5 +203,57 @@ describe("upload documents drawer", () => {
     expect(screen.getByText("Cancelled before upload began.")).toBeTruthy();
     expect(channel.uploadFile).not.toHaveBeenCalled();
     expect(complete).not.toHaveBeenCalled();
+  });
+
+  it("keeps a disconnected upload visible as unconfirmed and stops the queue", async () => {
+    vi.spyOn(upload, "hashFile").mockResolvedValue("a".repeat(64));
+    const channel: upload.UploadTransport = {
+      uploadFile: vi.fn(
+        async (
+          _parentID: number,
+          _file: File,
+          _expectedHash: string,
+          _signal: AbortSignal,
+          onprogress: (progress: upload.TransferProgress) => void,
+        ) => {
+          onprogress({ processed: 0, total: 9 });
+          throw new upload.UploadChannelError("verified channel ended");
+        },
+      ),
+    };
+    const complete = vi.fn();
+
+    render(UploadDrawer, {
+      channel,
+      directory: {
+        id: 3,
+        name: "Reports",
+        path: "/Reports",
+        kind: "dir",
+        size: 0,
+        revision: 1,
+        created_at: "2026-07-28T00:00:00Z",
+        modified_at: "2026-07-28T00:00:00Z",
+      },
+      onclose: vi.fn(),
+      oncomplete: complete,
+      onauthfailure: vi.fn(),
+    });
+    await fireEvent.change(screen.getByLabelText("Choose local files"), {
+      target: {
+        files: [
+          new File(["quarterly"], "quarterly.txt"),
+          new File(["appendix"], "appendix.txt"),
+        ],
+      },
+    });
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Upload 2 files" }),
+    );
+
+    expect(await screen.findByText("Unconfirmed")).toBeTruthy();
+    expect(screen.getByText(/retry this file after running/)).toBeTruthy();
+    expect(channel.uploadFile).toHaveBeenCalledOnce();
+    await waitFor(() => expect(complete).toHaveBeenCalledOnce());
   });
 });

--- a/frontend/src/UploadDrawer.test.ts
+++ b/frontend/src/UploadDrawer.test.ts
@@ -23,18 +23,25 @@ describe("upload documents drawer", () => {
         return hash;
       },
     );
-    vi.spyOn(upload, "uploadFile").mockImplementation(
-      async (_session, parentID, file, expectedHash, _signal, onprogress) => {
+    const channel: upload.UploadTransport = {
+      uploadFile: vi.fn(
+      async (
+        parentID: number,
+        file: File,
+        expectedHash: string,
+        _signal: AbortSignal,
+        onprogress: (progress: upload.TransferProgress) => void,
+      ) => {
         onprogress({ processed: file.size, total: file.size });
         return {
-          status: "added",
+          status: "added" as const,
           computed_hash: expectedHash,
           computed_size: file.size,
           node: {
             id: 8,
             parent_id: parentID,
             name: file.name,
-            kind: "file",
+            kind: "file" as const,
             blob_hash: expectedHash,
             size: file.size,
             revision: 1,
@@ -42,12 +49,12 @@ describe("upload documents drawer", () => {
             modified_at: "2026-07-28T00:00:00Z",
           },
         };
-      },
-    );
+      }),
+    };
     const complete = vi.fn();
 
     render(UploadDrawer, {
-      session: "short-lived",
+      channel,
       directory: {
         id: 3,
         name: "Reports",
@@ -77,8 +84,7 @@ describe("upload documents drawer", () => {
     expect(screen.getByText(/Created node 8, revision 1/)).toBeTruthy();
     await waitFor(() => expect(complete).toHaveBeenCalledOnce());
     expect(upload.hashFile).toHaveBeenCalledOnce();
-    expect(upload.uploadFile).toHaveBeenCalledWith(
-      "short-lived",
+    expect(channel.uploadFile).toHaveBeenCalledWith(
       3,
       file,
       hash,
@@ -90,9 +96,15 @@ describe("upload documents drawer", () => {
   it("refreshes and reports an unconfirmed outcome after cancellation", async () => {
     const hash = "a".repeat(64);
     vi.spyOn(upload, "hashFile").mockResolvedValue(hash);
-    vi.spyOn(upload, "uploadFile").mockImplementation(
-      async (_session, _parentID, _file, _expectedHash, signal) =>
-        await new Promise((_resolve, reject) => {
+    const channel: upload.UploadTransport = {
+      uploadFile: vi.fn(
+      async (
+        _parentID: number,
+        _file: File,
+        _expectedHash: string,
+        signal: AbortSignal,
+      ) =>
+        await new Promise<never>((_resolve, reject) => {
           signal.addEventListener(
             "abort",
             () =>
@@ -100,11 +112,12 @@ describe("upload documents drawer", () => {
             { once: true },
           );
         }),
-    );
+      ),
+    };
     const complete = vi.fn();
 
     render(UploadDrawer, {
-      session: "short-lived",
+      channel,
       directory: {
         id: 3,
         name: "Reports",

--- a/frontend/src/UploadDrawer.test.ts
+++ b/frontend/src/UploadDrawer.test.ts
@@ -150,4 +150,56 @@ describe("upload documents drawer", () => {
     expect(screen.getByText(/retry this file to converge safely/)).toBeTruthy();
     await waitFor(() => expect(complete).toHaveBeenCalledOnce());
   });
+
+  it("reports hashing cancellation without claiming an upload began", async () => {
+    vi.spyOn(upload, "hashFile").mockImplementation(
+      async (_file, signal) =>
+        await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(new DOMException("The operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    const channel: upload.UploadTransport = {
+      uploadFile: vi.fn(),
+    };
+    const complete = vi.fn();
+
+    render(UploadDrawer, {
+      channel,
+      directory: {
+        id: 3,
+        name: "Reports",
+        path: "/Reports",
+        kind: "dir",
+        size: 0,
+        revision: 1,
+        created_at: "2026-07-28T00:00:00Z",
+        modified_at: "2026-07-28T00:00:00Z",
+      },
+      onclose: vi.fn(),
+      oncomplete: complete,
+      onauthfailure: vi.fn(),
+    });
+
+    await fireEvent.change(screen.getByLabelText("Choose local files"), {
+      target: {
+        files: [new File(["quarterly"], "quarterly.txt", { type: "text/plain" })],
+      },
+    });
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Upload 1 file" }),
+    );
+    await fireEvent.click(
+      await screen.findByRole("button", { name: "Cancel current upload" }),
+    );
+
+    expect(await screen.findByText("Cancelled")).toBeTruthy();
+    expect(screen.getByText("Cancelled before upload began.")).toBeTruthy();
+    expect(channel.uploadFile).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/UploadDrawer.test.ts
+++ b/frontend/src/UploadDrawer.test.ts
@@ -86,4 +86,55 @@ describe("upload documents drawer", () => {
       expect.any(Function),
     );
   });
+
+  it("refreshes and reports an unconfirmed outcome after cancellation", async () => {
+    const hash = "a".repeat(64);
+    vi.spyOn(upload, "hashFile").mockResolvedValue(hash);
+    vi.spyOn(upload, "uploadFile").mockImplementation(
+      async (_session, _parentID, _file, _expectedHash, signal) =>
+        await new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(new DOMException("The operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    const complete = vi.fn();
+
+    render(UploadDrawer, {
+      session: "short-lived",
+      directory: {
+        id: 3,
+        name: "Reports",
+        path: "/Reports",
+        kind: "dir",
+        size: 0,
+        revision: 1,
+        created_at: "2026-07-28T00:00:00Z",
+        modified_at: "2026-07-28T00:00:00Z",
+      },
+      onclose: vi.fn(),
+      oncomplete: complete,
+      onauthfailure: vi.fn(),
+    });
+
+    const file = new File(["quarterly"], "quarterly.txt", {
+      type: "text/plain",
+    });
+    await fireEvent.change(screen.getByLabelText("Choose local files"), {
+      target: { files: [file] },
+    });
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Upload 1 file" }),
+    );
+    await fireEvent.click(
+      await screen.findByRole("button", { name: "Cancel current upload" }),
+    );
+
+    expect(await screen.findByText("Unconfirmed")).toBeTruthy();
+    expect(screen.getByText(/retry this file to converge safely/)).toBeTruthy();
+    await waitFor(() => expect(complete).toHaveBeenCalledOnce());
+  });
 });

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -28,11 +28,18 @@ describe("browser authentication", () => {
   });
 
   it("consumes the browser session without retaining it in web storage", () => {
-    history.replaceState(null, "", "/#web_session=one%20time");
-    expect(takeFragmentSession()).toBe("one time");
+    history.replaceState(
+      null,
+      "",
+      "/#web_session=one%20time&web_upload_secret=proof",
+    );
+    expect(takeFragmentSession()).toEqual({
+      token: "one time",
+      uploadSecret: "proof",
+    });
     expect(location.hash).toBe("");
     expect(sessionStorage.length).toBe(0);
-    expect(takeFragmentSession()).toBe("");
+    expect(takeFragmentSession()).toBeNull();
   });
 
   it("sends only the scoped browser session header", async () => {

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -35,7 +35,7 @@ describe("browser authentication", () => {
     expect(takeFragmentSession()).toBe("");
   });
 
-  it("sends only the read-only browser session header", async () => {
+  it("sends only the scoped browser session header", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ id: 1 }), {
         status: 200,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -274,17 +274,22 @@ export class APIError extends Error {
   }
 }
 
+export interface BrowserSession {
+  token: string;
+  uploadSecret: string;
+}
+
 export function takeFragmentSession(
   location: Location = window.location,
   history: History = window.history,
-): string {
+): BrowserSession | null {
   const params = new URLSearchParams(location.hash.replace(/^#/, ""));
-  const session = params.get("web_session") ?? "";
-  if (session) {
+  const token = params.get("web_session") ?? "";
+  const uploadSecret = params.get("web_upload_secret") ?? "";
+  if (token || uploadSecret) {
     history.replaceState(null, "", `${location.pathname}${location.search}`);
-    return session;
   }
-  return "";
+  return token && uploadSecret ? { token, uploadSecret } : null;
 }
 
 async function decodeProblem(response: Response): Promise<Problem> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -131,6 +131,13 @@ export interface BackupSnapshotList {
   items: BackupSnapshot[];
 }
 
+export interface UploadReceipt {
+  status: "added" | "skipped";
+  node: Node;
+  computed_hash: string;
+  computed_size: number;
+}
+
 export interface AuditScopeStatus {
   id: string;
   target_node_id: number;

--- a/frontend/src/upload.test.ts
+++ b/frontend/src/upload.test.ts
@@ -42,4 +42,32 @@ describe("verified browser upload", () => {
       validateUploadReceipt(receipt, 2, "report.txt", hash, 3),
     ).toThrow(/did not match the declared file authority/);
   });
+
+  it("accepts added and skipped receipts in the requested suffix family", () => {
+    const hash = "a".repeat(64);
+    const receipt: UploadReceipt = {
+      status: "added",
+      computed_hash: hash,
+      computed_size: 3,
+      node: {
+        id: 9,
+        parent_id: 2,
+        name: "report (2).txt",
+        kind: "file",
+        blob_hash: hash,
+        size: 3,
+        revision: 1,
+        created_at: "2026-07-28T00:00:00Z",
+        modified_at: "2026-07-28T00:00:00Z",
+      },
+    };
+
+    expect(() =>
+      validateUploadReceipt(receipt, 2, "report.txt", hash, 3),
+    ).not.toThrow();
+    receipt.status = "skipped";
+    expect(() =>
+      validateUploadReceipt(receipt, 2, "report.txt", hash, 3),
+    ).not.toThrow();
+  });
 });

--- a/frontend/src/upload.test.ts
+++ b/frontend/src/upload.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { UploadReceipt } from "./api.js";
-import { hashFile, validateUploadReceipt } from "./upload.js";
+import {
+  hashFile,
+  validateUploadReceipt,
+  VerifiedUploadChannel,
+} from "./upload.js";
 
 describe("verified browser upload", () => {
   it("hashes file bytes incrementally and reports terminal progress", async () => {
@@ -69,5 +73,48 @@ describe("verified browser upload", () => {
     expect(() =>
       validateUploadReceipt(receipt, 2, "report.txt", hash, 3),
     ).not.toThrow();
+  });
+
+  it("sends no file bytes when an endpoint cannot prove daemon ownership", async () => {
+    class ImpostorSocket extends EventTarget {
+      readonly sent: unknown[] = [];
+      readyState: number = WebSocket.OPEN;
+      binaryType = "blob";
+
+      constructor() {
+        super();
+        queueMicrotask(() => this.dispatchEvent(new Event("open")));
+      }
+
+      send(data: unknown): void {
+        this.sent.push(data);
+        queueMicrotask(() =>
+          this.dispatchEvent(
+            new MessageEvent("message", {
+              data: JSON.stringify({ type: "authenticated", proof: "forged" }),
+            }),
+          ),
+        );
+      }
+
+      close(): void {
+        this.readyState = WebSocket.CLOSED;
+        this.dispatchEvent(new Event("close"));
+      }
+    }
+
+    const socket = new ImpostorSocket();
+    const channel = new VerifiedUploadChannel(
+      {
+        token: "browser-session",
+        uploadSecret: "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE",
+      },
+      () => socket as unknown as WebSocket,
+    );
+
+    await expect(channel.connect()).rejects.toThrow(/No file bytes were sent/);
+    expect(socket.sent).toHaveLength(1);
+    expect(typeof socket.sent[0]).toBe("string");
+    expect(String(socket.sent[0])).not.toContain("private document");
   });
 });

--- a/frontend/src/upload.test.ts
+++ b/frontend/src/upload.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { UploadReceipt } from "./api.js";
+import { hashFile, validateUploadReceipt } from "./upload.js";
+
+describe("verified browser upload", () => {
+  it("hashes file bytes incrementally and reports terminal progress", async () => {
+    const file = new File(["abc"], "report.txt", { type: "text/plain" });
+    const progress: number[] = [];
+
+    const digest = await hashFile(
+      file,
+      new AbortController().signal,
+      (current) => progress.push(current.processed),
+    );
+
+    expect(digest).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    expect(progress).toEqual([0, 3]);
+  });
+
+  it("rejects a server receipt that does not bind the declared authority", () => {
+    const hash = "a".repeat(64);
+    const receipt: UploadReceipt = {
+      status: "added",
+      computed_hash: hash,
+      computed_size: 3,
+      node: {
+        id: 9,
+        parent_id: 2,
+        name: "report.txt",
+        kind: "file",
+        blob_hash: "b".repeat(64),
+        size: 3,
+        revision: 1,
+        created_at: "2026-07-28T00:00:00Z",
+        modified_at: "2026-07-28T00:00:00Z",
+      },
+    };
+
+    expect(() =>
+      validateUploadReceipt(receipt, 2, "report.txt", hash, 3),
+    ).toThrow(/did not match the declared file authority/);
+  });
+});

--- a/frontend/src/upload.test.ts
+++ b/frontend/src/upload.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { hmac } from "@noble/hashes/hmac.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { utf8ToBytes } from "@noble/hashes/utils.js";
 import type { UploadReceipt } from "./api.js";
 import {
   hashFile,
@@ -47,7 +50,7 @@ describe("verified browser upload", () => {
     ).toThrow(/did not match the declared file authority/);
   });
 
-  it("accepts added and skipped receipts in the requested suffix family", () => {
+  it("accepts collision suffixes for additions and provenance matches for skips", () => {
     const hash = "a".repeat(64);
     const receipt: UploadReceipt = {
       status: "added",
@@ -70,9 +73,14 @@ describe("verified browser upload", () => {
       validateUploadReceipt(receipt, 2, "report.txt", hash, 3),
     ).not.toThrow();
     receipt.status = "skipped";
+    receipt.node.name = "renamed-quarterly-report.txt";
     expect(() =>
       validateUploadReceipt(receipt, 2, "report.txt", hash, 3),
     ).not.toThrow();
+    receipt.status = "added";
+    expect(() =>
+      validateUploadReceipt(receipt, 2, "report.txt", hash, 3),
+    ).toThrow(/did not match the declared file authority/);
   });
 
   it("sends no file bytes when an endpoint cannot prove daemon ownership", async () => {
@@ -116,5 +124,103 @@ describe("verified browser upload", () => {
     expect(socket.sent).toHaveLength(1);
     expect(typeof socket.sent[0]).toBe("string");
     expect(String(socket.sent[0])).not.toContain("private document");
+  });
+
+  it("retires the channel when cancellation races the terminal receipt", async () => {
+    const token = "browser-session";
+    const uploadSecret = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE";
+    let endUpload: (() => void) | undefined;
+    const ended = new Promise<void>((resolve) => {
+      endUpload = resolve;
+    });
+    class DaemonSocket extends EventTarget {
+      readyState: number = WebSocket.OPEN;
+      bufferedAmount = 0;
+      binaryType = "blob";
+      closed = false;
+
+      constructor() {
+        super();
+        queueMicrotask(() => this.dispatchEvent(new Event("open")));
+      }
+
+      send(data: string | ArrayBuffer): void {
+        if (typeof data !== "string") return;
+        const message = JSON.parse(data) as {
+          type: string;
+          nonce?: string;
+          request_id?: string;
+        };
+        if (message.type === "authenticate") {
+          const padded = uploadSecret.replaceAll("-", "+").replaceAll("_", "/").padEnd(
+            Math.ceil(uploadSecret.length / 4) * 4,
+            "=",
+          );
+          const secret = Uint8Array.from(
+            atob(padded),
+            (character) => character.charCodeAt(0),
+          );
+          const proofBytes = hmac(
+            sha256,
+            secret,
+            utf8ToBytes(
+              `docbank-web-upload-v1\u0000${token}\u0000${message.nonce}`,
+            ),
+          );
+          let proof = "";
+          for (const byte of proofBytes) proof += String.fromCharCode(byte);
+          proof = btoa(proof)
+            .replaceAll("+", "-")
+            .replaceAll("/", "_")
+            .replace(/=+$/, "");
+          queueMicrotask(() =>
+            this.dispatchEvent(new MessageEvent("message", {
+              data: JSON.stringify({ type: "authenticated", proof }),
+            })),
+          );
+        } else if (message.type === "begin") {
+          queueMicrotask(() =>
+            this.dispatchEvent(new MessageEvent("message", {
+              data: JSON.stringify({
+                type: "ready",
+                request_id: message.request_id,
+              }),
+            })),
+          );
+        } else if (message.type === "end") {
+          endUpload?.();
+        }
+      }
+
+      close(): void {
+        if (this.closed) return;
+        this.closed = true;
+        this.readyState = WebSocket.CLOSED;
+        this.dispatchEvent(new Event("close"));
+      }
+    }
+
+    const socket = new DaemonSocket();
+    let failed = 0;
+    const channel = new VerifiedUploadChannel(
+      { token, uploadSecret },
+      () => socket as unknown as WebSocket,
+      () => failed++,
+    );
+    await channel.connect();
+    const controller = new AbortController();
+    const upload = channel.uploadFile(
+      2,
+      new File(["abc"], "report.txt", { type: "text/plain" }),
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      controller.signal,
+      () => {},
+    );
+    await ended;
+    controller.abort();
+
+    await expect(upload).rejects.toMatchObject({ name: "AbortError" });
+    expect(socket.closed).toBe(true);
+    expect(failed).toBe(1);
   });
 });

--- a/frontend/src/upload.test.ts
+++ b/frontend/src/upload.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { hmac } from "@noble/hashes/hmac.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { utf8ToBytes } from "@noble/hashes/utils.js";
@@ -8,6 +8,91 @@ import {
   validateUploadReceipt,
   VerifiedUploadChannel,
 } from "./upload.js";
+
+const testToken = "browser-session";
+const testUploadSecret = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE";
+
+function daemonProof(nonce: string): string {
+  const proofBytes = hmac(
+    sha256,
+    new Uint8Array(32).fill(1),
+    utf8ToBytes(
+      `docbank-web-upload-v1\u0000${testToken}\u0000${nonce}`,
+    ),
+  );
+  let proof = "";
+  for (const byte of proofBytes) proof += String.fromCharCode(byte);
+  return btoa(proof)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+class DaemonSocket extends EventTarget {
+  readyState: number = WebSocket.OPEN;
+  bufferedAmount = 0;
+  binaryType = "blob";
+  closed = false;
+  authenticate = true;
+  ready = true;
+  cancelAcknowledgment = true;
+  onbegin: (() => void) | undefined;
+  onend: (() => void) | undefined;
+  oncancel: (() => void) | undefined;
+
+  constructor() {
+    super();
+    queueMicrotask(() => this.dispatchEvent(new Event("open")));
+  }
+
+  send(data: string | ArrayBuffer): void {
+    if (typeof data !== "string") return;
+    const message = JSON.parse(data) as {
+      type: string;
+      nonce?: string;
+      request_id?: string;
+    };
+    if (message.type === "authenticate" && this.authenticate) {
+      this.emit({ type: "authenticated", proof: daemonProof(message.nonce ?? "") });
+    } else if (message.type === "begin") {
+      this.onbegin?.();
+      if (this.ready) {
+        this.emit({ type: "ready", request_id: message.request_id });
+      }
+    } else if (message.type === "end") {
+      this.onend?.();
+    } else if (message.type === "cancel") {
+      this.oncancel?.();
+      if (this.cancelAcknowledgment) {
+        this.emit({
+          type: "error",
+          request_id: message.request_id,
+          status: 499,
+          code: "canceled",
+        });
+      }
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.readyState = WebSocket.CLOSED;
+    this.dispatchEvent(new Event("close"));
+  }
+
+  private emit(message: object): void {
+    queueMicrotask(() =>
+      this.dispatchEvent(new MessageEvent("message", {
+        data: JSON.stringify(message),
+      })),
+    );
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("verified browser upload", () => {
   it("hashes file bytes incrementally and reports terminal progress", async () => {
@@ -127,83 +212,15 @@ describe("verified browser upload", () => {
   });
 
   it("retires the channel when cancellation races the terminal receipt", async () => {
-    const token = "browser-session";
-    const uploadSecret = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE";
     let endUpload: (() => void) | undefined;
     const ended = new Promise<void>((resolve) => {
       endUpload = resolve;
     });
-    class DaemonSocket extends EventTarget {
-      readyState: number = WebSocket.OPEN;
-      bufferedAmount = 0;
-      binaryType = "blob";
-      closed = false;
-
-      constructor() {
-        super();
-        queueMicrotask(() => this.dispatchEvent(new Event("open")));
-      }
-
-      send(data: string | ArrayBuffer): void {
-        if (typeof data !== "string") return;
-        const message = JSON.parse(data) as {
-          type: string;
-          nonce?: string;
-          request_id?: string;
-        };
-        if (message.type === "authenticate") {
-          const padded = uploadSecret.replaceAll("-", "+").replaceAll("_", "/").padEnd(
-            Math.ceil(uploadSecret.length / 4) * 4,
-            "=",
-          );
-          const secret = Uint8Array.from(
-            atob(padded),
-            (character) => character.charCodeAt(0),
-          );
-          const proofBytes = hmac(
-            sha256,
-            secret,
-            utf8ToBytes(
-              `docbank-web-upload-v1\u0000${token}\u0000${message.nonce}`,
-            ),
-          );
-          let proof = "";
-          for (const byte of proofBytes) proof += String.fromCharCode(byte);
-          proof = btoa(proof)
-            .replaceAll("+", "-")
-            .replaceAll("/", "_")
-            .replace(/=+$/, "");
-          queueMicrotask(() =>
-            this.dispatchEvent(new MessageEvent("message", {
-              data: JSON.stringify({ type: "authenticated", proof }),
-            })),
-          );
-        } else if (message.type === "begin") {
-          queueMicrotask(() =>
-            this.dispatchEvent(new MessageEvent("message", {
-              data: JSON.stringify({
-                type: "ready",
-                request_id: message.request_id,
-              }),
-            })),
-          );
-        } else if (message.type === "end") {
-          endUpload?.();
-        }
-      }
-
-      close(): void {
-        if (this.closed) return;
-        this.closed = true;
-        this.readyState = WebSocket.CLOSED;
-        this.dispatchEvent(new Event("close"));
-      }
-    }
-
     const socket = new DaemonSocket();
+    socket.onend = () => endUpload?.();
     let failed = 0;
     const channel = new VerifiedUploadChannel(
-      { token, uploadSecret },
+      { token: testToken, uploadSecret: testUploadSecret },
       () => socket as unknown as WebSocket,
       () => failed++,
     );
@@ -222,5 +239,132 @@ describe("verified browser upload", () => {
     await expect(upload).rejects.toMatchObject({ name: "AbortError" });
     expect(socket.closed).toBe(true);
     expect(failed).toBe(1);
+  });
+
+  it("times out a daemon that never proves the upload channel", async () => {
+    vi.useFakeTimers();
+    const socket = new DaemonSocket();
+    socket.authenticate = false;
+    const channel = new VerifiedUploadChannel(
+      { token: testToken, uploadSecret: testUploadSecret },
+      () => socket as unknown as WebSocket,
+    );
+
+    const connecting = channel.connect();
+    const rejected = expect(connecting).rejects.toThrow(/channel ended/);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await rejected;
+    expect(socket.closed).toBe(true);
+  });
+
+  it("aborts while waiting for readiness and backpressure", async () => {
+    const readySocket = new DaemonSocket();
+    readySocket.ready = false;
+    const readyChannel = new VerifiedUploadChannel(
+      { token: testToken, uploadSecret: testUploadSecret },
+      () => readySocket as unknown as WebSocket,
+    );
+    await readyChannel.connect();
+    let sawBegin: (() => void) | undefined;
+    const began = new Promise<void>((resolve) => {
+      sawBegin = resolve;
+    });
+    readySocket.onbegin = () => sawBegin?.();
+    const readyController = new AbortController();
+    const waitingReady = readyChannel.uploadFile(
+      2,
+      new File(["abc"], "report.txt"),
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      readyController.signal,
+      () => {},
+    );
+    await began;
+    readyController.abort();
+    await expect(waitingReady).rejects.toMatchObject({ name: "AbortError" });
+    expect(readySocket.closed).toBe(true);
+
+    const pressureSocket = new DaemonSocket();
+    pressureSocket.bufferedAmount = 3 * 1024 * 1024;
+    const pressureChannel = new VerifiedUploadChannel(
+      { token: testToken, uploadSecret: testUploadSecret },
+      () => pressureSocket as unknown as WebSocket,
+    );
+    await pressureChannel.connect();
+    const pressureController = new AbortController();
+    let becameReady: (() => void) | undefined;
+    const readyProgress = new Promise<void>((resolve) => {
+      becameReady = resolve;
+    });
+    const waitingPressure = pressureChannel.uploadFile(
+      2,
+      new File(["abc"], "report.txt"),
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      pressureController.signal,
+      (progress) => {
+        if (progress.processed === 0) becameReady?.();
+      },
+    );
+    await readyProgress;
+    pressureController.abort();
+    await expect(waitingPressure).rejects.toMatchObject({ name: "AbortError" });
+    expect(pressureSocket.closed).toBe(true);
+  });
+
+  it("bounds cancellation acknowledgment and rejects a waiter on close", async () => {
+    vi.useFakeTimers();
+    const cancelSocket = new DaemonSocket();
+    cancelSocket.cancelAcknowledgment = false;
+    const cancelChannel = new VerifiedUploadChannel(
+      { token: testToken, uploadSecret: testUploadSecret },
+      () => cancelSocket as unknown as WebSocket,
+    );
+    await cancelChannel.connect();
+    const cancelController = new AbortController();
+    let sawCancel: (() => void) | undefined;
+    const canceled = new Promise<void>((resolve) => {
+      sawCancel = resolve;
+    });
+    cancelSocket.oncancel = () => sawCancel?.();
+    const waitingCancel = cancelChannel.uploadFile(
+      2,
+      new File(["abc"], "report.txt"),
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      cancelController.signal,
+      (progress) => {
+        if (progress.processed === 0) cancelController.abort();
+      },
+    );
+    const cancelRejected = expect(waitingCancel).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    await canceled;
+    await vi.advanceTimersByTimeAsync(10_000);
+    await cancelRejected;
+    expect(cancelSocket.closed).toBe(true);
+
+    vi.useRealTimers();
+    const closeSocket = new DaemonSocket();
+    closeSocket.ready = false;
+    const closeChannel = new VerifiedUploadChannel(
+      { token: testToken, uploadSecret: testUploadSecret },
+      () => closeSocket as unknown as WebSocket,
+    );
+    await closeChannel.connect();
+    let closeBegin: (() => void) | undefined;
+    const closeBegan = new Promise<void>((resolve) => {
+      closeBegin = resolve;
+    });
+    closeSocket.onbegin = () => closeBegin?.();
+    const waitingClose = closeChannel.uploadFile(
+      2,
+      new File(["abc"], "report.txt"),
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      new AbortController().signal,
+      () => {},
+    );
+    await closeBegan;
+    closeChannel.close();
+    await expect(waitingClose).rejects.toThrow(/channel ended/);
   });
 });

--- a/frontend/src/upload.ts
+++ b/frontend/src/upload.ts
@@ -112,6 +112,10 @@ export interface UploadTransport {
   ): Promise<UploadReceipt>;
 }
 
+export class UploadChannelError extends Error {
+  override readonly name = "UploadChannelError";
+}
+
 type SocketFactory = (url: string) => WebSocket;
 
 function base64URLBytes(value: string): Uint8Array {
@@ -206,6 +210,7 @@ export class VerifiedUploadChannel implements UploadTransport {
     this.busy = true;
     const requestID = crypto.randomUUID();
     const name = file.name.normalize("NFC");
+    let readyForBytes = false;
     try {
       this.send({
         type: "begin",
@@ -220,6 +225,7 @@ export class VerifiedUploadChannel implements UploadTransport {
       this.requireMessage(ready, requestID);
       this.throwProblem(ready);
       if (ready.type !== "ready") throw this.protocolError();
+      readyForBytes = true;
       onprogress({ processed: 0, total: file.size });
       for (let offset = 0; offset < file.size; offset += hashChunkBytes) {
         if (signal.aborted) {
@@ -242,9 +248,16 @@ export class VerifiedUploadChannel implements UploadTransport {
         validateUploadReceipt(terminal.receipt, parentID, name, expectedHash, file.size);
       } catch (cause) {
         this.fail();
-        throw cause;
+        throw new UploadChannelError(
+          cause instanceof Error ? cause.message : String(cause),
+        );
       }
       return terminal.receipt;
+    } catch (cause) {
+      if (readyForBytes && !(cause instanceof APIError) && !this.unusable) {
+        this.fail();
+      }
+      throw cause;
     } finally {
       this.busy = false;
     }
@@ -413,11 +426,13 @@ export class VerifiedUploadChannel implements UploadTransport {
 
   private protocolError(): Error {
     this.fail();
-    return new Error("The verified upload channel returned an invalid response.");
+    return new UploadChannelError(
+      "The verified upload channel returned an invalid response.",
+    );
   }
 
   private channelError(): Error {
-    return new Error(
+    return new UploadChannelError(
       "The verified upload channel ended. Run `docbank web` again before selecting files.",
     );
   }

--- a/frontend/src/upload.ts
+++ b/frontend/src/upload.ts
@@ -1,0 +1,144 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { APIError, type UploadReceipt } from "./api.js";
+
+const hashChunkBytes = 1024 * 1024;
+
+export interface TransferProgress {
+  processed: number;
+  total: number;
+}
+
+function abortError(): DOMException {
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortError();
+}
+
+export async function hashFile(
+  file: File,
+  signal: AbortSignal,
+  onprogress: (progress: TransferProgress) => void,
+): Promise<string> {
+  const hasher = sha256.create();
+  onprogress({ processed: 0, total: file.size });
+  for (let offset = 0; offset < file.size; offset += hashChunkBytes) {
+    throwIfAborted(signal);
+    const end = Math.min(file.size, offset + hashChunkBytes);
+    hasher.update(new Uint8Array(await file.slice(offset, end).arrayBuffer()));
+    throwIfAborted(signal);
+    onprogress({ processed: end, total: file.size });
+  }
+  throwIfAborted(signal);
+  return bytesToHex(hasher.digest());
+}
+
+function decodeUploadError(xhr: XMLHttpRequest): APIError {
+  let problem: { detail?: string; title?: string; code?: string } = {};
+  try {
+    problem = JSON.parse(xhr.responseText) as typeof problem;
+  } catch {
+    // The status remains useful when a proxy or transport did not return a
+    // Docbank problem document.
+  }
+  return new APIError(
+    problem.detail || problem.title || `HTTP ${xhr.status}`,
+    xhr.status,
+    problem.code ?? "",
+  );
+}
+
+export function validateUploadReceipt(
+  receipt: UploadReceipt,
+  parentID: number,
+  name: string,
+  expectedHash: string,
+  expectedSize: number,
+): void {
+  if (
+    (receipt.status !== "added" && receipt.status !== "skipped") ||
+    receipt.computed_hash !== expectedHash ||
+    receipt.computed_size !== expectedSize ||
+    receipt.node.parent_id !== parentID ||
+    receipt.node.name !== name ||
+    receipt.node.blob_hash !== expectedHash ||
+    receipt.node.size !== expectedSize
+  ) {
+    throw new Error(
+      `The upload receipt for ${JSON.stringify(name)} did not match the declared file authority.`,
+    );
+  }
+}
+
+export function uploadFile(
+  session: string,
+  parentID: number,
+  file: File,
+  expectedHash: string,
+  signal: AbortSignal,
+  onprogress: (progress: TransferProgress) => void,
+): Promise<UploadReceipt> {
+  const name = file.name.normalize("NFC");
+  const form = new FormData();
+  form.append("file", file, name);
+  const query = new URLSearchParams({
+    parent_id: String(parentID),
+    name,
+  });
+
+  return new Promise((resolve, reject) => {
+    throwIfAborted(signal);
+    const xhr = new XMLHttpRequest();
+    const abort = () => xhr.abort();
+    const finish = (action: () => void) => {
+      signal.removeEventListener("abort", abort);
+      action();
+    };
+
+    xhr.open("POST", `/api/v1/uploads?${query.toString()}`);
+    xhr.withCredentials = true;
+    xhr.setRequestHeader("Accept", "application/json");
+    xhr.setRequestHeader("X-Docbank-Web-Session", session);
+    xhr.setRequestHeader("X-Docbank-Blob-Hash", expectedHash);
+    xhr.setRequestHeader("X-Docbank-Blob-Size", String(file.size));
+    xhr.upload.addEventListener("progress", (event) => {
+      const processed =
+        event.lengthComputable && event.total > 0
+          ? Math.round((file.size * event.loaded) / event.total)
+          : Math.min(file.size, event.loaded);
+      onprogress({ processed: Math.min(file.size, processed), total: file.size });
+    });
+    xhr.addEventListener("abort", () => finish(() => reject(abortError())));
+    xhr.addEventListener("error", () =>
+      finish(() => reject(new Error(`Uploading ${JSON.stringify(name)} failed.`))),
+    );
+    xhr.addEventListener("load", () => {
+      if (xhr.status < 200 || xhr.status > 299) {
+        finish(() => reject(decodeUploadError(xhr)));
+        return;
+      }
+      let receipt: UploadReceipt;
+      try {
+        receipt = JSON.parse(xhr.responseText) as UploadReceipt;
+      } catch (cause) {
+        finish(() =>
+          reject(new Error(`Decoding the upload receipt failed: ${String(cause)}`)),
+        );
+        return;
+      }
+      try {
+        validateUploadReceipt(receipt, parentID, name, expectedHash, file.size);
+      } catch (cause) {
+        finish(() => reject(cause));
+        return;
+      }
+      onprogress({ processed: file.size, total: file.size });
+      finish(() => resolve(receipt));
+    });
+    signal.addEventListener("abort", abort, { once: true });
+    onprogress({ processed: 0, total: file.size });
+    xhr.send(form);
+  });
+}

--- a/frontend/src/upload.ts
+++ b/frontend/src/upload.ts
@@ -9,6 +9,28 @@ export interface TransferProgress {
   total: number;
 }
 
+function uploadNameParts(name: string): { base: string; extension: string } {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return { base: name, extension: "" };
+  return { base: name.slice(0, dot), extension: name.slice(dot) };
+}
+
+function permittedUploadName(requested: string, received: string): boolean {
+  if (received === requested) return true;
+  const { base, extension } = uploadNameParts(requested);
+  const prefix = `${base} (`;
+  const suffix = `)${extension}`;
+  if (!received.startsWith(prefix) || !received.endsWith(suffix)) return false;
+  const ordinal = received.slice(prefix.length, received.length - suffix.length);
+  if (!/^[+-]?[0-9]+$/.test(ordinal)) return false;
+  try {
+    const value = BigInt(ordinal);
+    return value >= BigInt(2) && value <= BigInt("9223372036854775807");
+  } catch {
+    return false;
+  }
+}
+
 function abortError(): DOMException {
   return new DOMException("The operation was aborted.", "AbortError");
 }
@@ -62,7 +84,7 @@ export function validateUploadReceipt(
     receipt.computed_hash !== expectedHash ||
     receipt.computed_size !== expectedSize ||
     receipt.node.parent_id !== parentID ||
-    receipt.node.name !== name ||
+    !permittedUploadName(name, receipt.node.name) ||
     receipt.node.blob_hash !== expectedHash ||
     receipt.node.size !== expectedSize
   ) {

--- a/frontend/src/upload.ts
+++ b/frontend/src/upload.ts
@@ -6,6 +6,8 @@ import { APIError, type BrowserSession, type UploadReceipt } from "./api.js";
 const hashChunkBytes = 1024 * 1024;
 const uploadSocketPath = "/api/daemon/web-upload";
 const uploadProofDomain = "docbank-web-upload-v1\u0000";
+const uploadHandshakeTimeoutMs = 10_000;
+const uploadResponseTimeoutMs = 60_000;
 
 export interface TransferProgress {
   processed: number;
@@ -160,10 +162,7 @@ export class VerifiedUploadChannel implements UploadTransport {
     socket.addEventListener("message", (event) => this.receive(event));
     socket.addEventListener("close", () => this.fail());
     socket.addEventListener("error", () => this.fail());
-    await new Promise<void>((resolve, reject) => {
-      socket.addEventListener("open", () => resolve(), { once: true });
-      socket.addEventListener("error", () => reject(this.channelError()), { once: true });
-    });
+    await this.waitForOpen(socket);
     const nonceBytes = crypto.getRandomValues(new Uint8Array(32));
     const nonce = base64URL(nonceBytes);
     socket.send(JSON.stringify({
@@ -171,7 +170,10 @@ export class VerifiedUploadChannel implements UploadTransport {
       token: this.session.token,
       nonce,
     }));
-    const authenticated = await this.nextMessage();
+    const authenticated = await this.nextMessage(
+      undefined,
+      uploadHandshakeTimeoutMs,
+    );
     const proof = expectedProof(
       this.session.uploadSecret,
       this.session.token,
@@ -186,9 +188,7 @@ export class VerifiedUploadChannel implements UploadTransport {
   }
 
   close(): void {
-    this.unusable = true;
-    this.socket?.close(1000, "browser closed");
-    this.socket = null;
+    this.retire(false, 1000, "browser closed");
   }
 
   async uploadFile(
@@ -216,7 +216,7 @@ export class VerifiedUploadChannel implements UploadTransport {
         expected_hash: expectedHash,
         expected_size: file.size,
       });
-      const ready = await this.nextMessage();
+      const ready = await this.nextMessage(signal, uploadResponseTimeoutMs);
       this.requireMessage(ready, requestID);
       this.throwProblem(ready);
       if (ready.type !== "ready") throw this.protocolError();
@@ -225,14 +225,14 @@ export class VerifiedUploadChannel implements UploadTransport {
         if (signal.aborted) {
           await this.cancelUpload(requestID);
         }
-        await this.waitForWritable();
+        await this.waitForWritable(signal);
         const end = Math.min(file.size, offset + hashChunkBytes);
         this.sendBinary(await file.slice(offset, end).arrayBuffer());
         onprogress({ processed: end, total: file.size });
       }
       if (signal.aborted) await this.cancelUpload(requestID);
       this.send({ type: "end", request_id: requestID });
-      const terminal = await this.nextTerminalMessage(signal);
+      const terminal = await this.nextMessage(signal, uploadResponseTimeoutMs);
       this.requireMessage(terminal, requestID);
       this.throwProblem(terminal);
       if (terminal.type !== "receipt" || !terminal.receipt) {
@@ -264,56 +264,115 @@ export class VerifiedUploadChannel implements UploadTransport {
     this.socket.send(bytes);
   }
 
-  private nextMessage(): Promise<UploadMessage> {
+  private nextMessage(
+    signal?: AbortSignal,
+    timeoutMs = uploadResponseTimeoutMs,
+  ): Promise<UploadMessage> {
     if (this.waiter || this.unusable) return Promise.reject(this.channelError());
-    return new Promise((resolve, reject) => {
-      this.waiter = { resolve, reject };
-    });
-  }
-
-  private nextTerminalMessage(signal: AbortSignal): Promise<UploadMessage> {
-    if (signal.aborted) {
+    if (signal?.aborted) {
       this.fail();
       return Promise.reject(abortError());
     }
-    const terminal = this.nextMessage();
     return new Promise((resolve, reject) => {
-      const aborted = (): void => {
-        this.fail();
-        reject(abortError());
+      let timer = 0;
+      const cleanup = (): void => {
+        if (timer) window.clearTimeout(timer);
+        signal?.removeEventListener("abort", aborted);
       };
-      signal.addEventListener("abort", aborted, { once: true });
-      terminal.then(
-        (message) => {
-          signal.removeEventListener("abort", aborted);
-          resolve(message);
-        },
-        (cause) => {
-          signal.removeEventListener("abort", aborted);
-          reject(cause);
-        },
-      );
+      const settle = (
+        finish: (value: UploadMessage | PromiseLike<UploadMessage>) => void,
+        message: UploadMessage,
+      ): void => {
+        if (this.waiter !== waiter) return;
+        this.waiter = null;
+        cleanup();
+        finish(message);
+      };
+      const failWait = (cause: Error): void => {
+        if (this.waiter !== waiter) return;
+        this.waiter = null;
+        cleanup();
+        reject(cause);
+      };
+      const aborted = (): void => {
+        failWait(abortError());
+        this.fail();
+      };
+      const waiter = {
+        resolve: (message: UploadMessage) => settle(resolve, message),
+        reject: failWait,
+      };
+      this.waiter = waiter;
+      signal?.addEventListener("abort", aborted, { once: true });
+      timer = window.setTimeout(() => {
+        failWait(this.channelError());
+        this.fail();
+      }, timeoutMs);
     });
   }
 
   private async cancelUpload(requestID: string): Promise<never> {
     this.send({ type: "cancel", request_id: requestID });
-    const canceled = await this.nextMessage();
-    this.requireMessage(canceled, requestID, "error");
+    try {
+      const canceled = await this.nextMessage(
+        undefined,
+        uploadHandshakeTimeoutMs,
+      );
+      this.requireMessage(canceled, requestID, "error");
+    } catch {
+      this.fail();
+    }
     throw abortError();
   }
 
-  private async waitForWritable(): Promise<void> {
+  private async waitForWritable(signal: AbortSignal): Promise<void> {
+    const deadline = Date.now() + uploadResponseTimeoutMs;
     while (
       this.socket &&
       this.socket.readyState === WebSocket.OPEN &&
       this.socket.bufferedAmount > 2 * hashChunkBytes
     ) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      if (signal.aborted) {
+        this.fail();
+        throw abortError();
+      }
+      if (Date.now() >= deadline) {
+        this.fail();
+        throw this.channelError();
+      }
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    }
+    if (signal.aborted) {
+      this.fail();
+      throw abortError();
     }
     if (!this.socket || this.socket.readyState !== WebSocket.OPEN || this.unusable) {
       throw this.channelError();
     }
+  }
+
+  private waitForOpen(socket: WebSocket): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const cleanup = (): void => {
+        window.clearTimeout(timer);
+        socket.removeEventListener("open", opened);
+        socket.removeEventListener("error", failed);
+        socket.removeEventListener("close", failed);
+      };
+      const opened = (): void => {
+        cleanup();
+        resolve();
+      };
+      const failed = (): void => {
+        cleanup();
+        this.fail();
+        reject(this.channelError());
+      };
+      const timer = window.setTimeout(failed, uploadHandshakeTimeoutMs);
+      socket.addEventListener("open", opened, { once: true });
+      socket.addEventListener("error", failed, { once: true });
+      socket.addEventListener("close", failed, { once: true });
+    });
   }
 
   private receive(event: MessageEvent): void {
@@ -329,7 +388,6 @@ export class VerifiedUploadChannel implements UploadTransport {
       return;
     }
     const waiter = this.waiter;
-    this.waiter = null;
     waiter.resolve(message);
   }
 
@@ -365,13 +423,17 @@ export class VerifiedUploadChannel implements UploadTransport {
   }
 
   private fail(): void {
+    this.retire(true);
+  }
+
+  private retire(notify: boolean, code?: number, reason?: string): void {
     if (this.unusable) return;
     this.unusable = true;
-    this.socket?.close();
+    if (code !== undefined) this.socket?.close(code, reason);
+    else this.socket?.close();
     this.socket = null;
-    this.onfailure();
     const waiter = this.waiter;
-    this.waiter = null;
     waiter?.reject(this.channelError());
+    if (notify) this.onfailure();
   }
 }

--- a/frontend/src/upload.ts
+++ b/frontend/src/upload.ts
@@ -1,8 +1,11 @@
+import { hmac } from "@noble/hashes/hmac.js";
 import { sha256 } from "@noble/hashes/sha2.js";
-import { bytesToHex } from "@noble/hashes/utils.js";
-import { APIError, type UploadReceipt } from "./api.js";
+import { bytesToHex, utf8ToBytes } from "@noble/hashes/utils.js";
+import { APIError, type BrowserSession, type UploadReceipt } from "./api.js";
 
 const hashChunkBytes = 1024 * 1024;
+const uploadSocketPath = "/api/daemon/web-upload";
+const uploadProofDomain = "docbank-web-upload-v1\u0000";
 
 export interface TransferProgress {
   processed: number;
@@ -57,21 +60,6 @@ export async function hashFile(
   return bytesToHex(hasher.digest());
 }
 
-function decodeUploadError(xhr: XMLHttpRequest): APIError {
-  let problem: { detail?: string; title?: string; code?: string } = {};
-  try {
-    problem = JSON.parse(xhr.responseText) as typeof problem;
-  } catch {
-    // The status remains useful when a proxy or transport did not return a
-    // Docbank problem document.
-  }
-  return new APIError(
-    problem.detail || problem.title || `HTTP ${xhr.status}`,
-    xhr.status,
-    problem.code ?? "",
-  );
-}
-
 export function validateUploadReceipt(
   receipt: UploadReceipt,
   parentID: number,
@@ -94,73 +82,269 @@ export function validateUploadReceipt(
   }
 }
 
-export function uploadFile(
-  session: string,
-  parentID: number,
-  file: File,
-  expectedHash: string,
-  signal: AbortSignal,
-  onprogress: (progress: TransferProgress) => void,
-): Promise<UploadReceipt> {
-  const name = file.name.normalize("NFC");
-  const form = new FormData();
-  form.append("file", file, name);
-  const query = new URLSearchParams({
-    parent_id: String(parentID),
-    name,
-  });
+interface UploadMessage {
+  type: string;
+  nonce?: string;
+  proof?: string;
+  request_id?: string;
+  parent_id?: number;
+  name?: string;
+  mime_type?: string;
+  expected_hash?: string;
+  expected_size?: number;
+  receipt?: UploadReceipt;
+  status?: number;
+  code?: string;
+  detail?: string;
+}
 
-  return new Promise((resolve, reject) => {
-    throwIfAborted(signal);
-    const xhr = new XMLHttpRequest();
-    const abort = () => xhr.abort();
-    const finish = (action: () => void) => {
-      signal.removeEventListener("abort", abort);
-      action();
-    };
+export interface UploadTransport {
+  uploadFile(
+    parentID: number,
+    file: File,
+    expectedHash: string,
+    signal: AbortSignal,
+    onprogress: (progress: TransferProgress) => void,
+  ): Promise<UploadReceipt>;
+}
 
-    xhr.open("POST", `/api/v1/uploads?${query.toString()}`);
-    xhr.withCredentials = true;
-    xhr.setRequestHeader("Accept", "application/json");
-    xhr.setRequestHeader("X-Docbank-Web-Session", session);
-    xhr.setRequestHeader("X-Docbank-Blob-Hash", expectedHash);
-    xhr.setRequestHeader("X-Docbank-Blob-Size", String(file.size));
-    xhr.upload.addEventListener("progress", (event) => {
-      const processed =
-        event.lengthComputable && event.total > 0
-          ? Math.round((file.size * event.loaded) / event.total)
-          : Math.min(file.size, event.loaded);
-      onprogress({ processed: Math.min(file.size, processed), total: file.size });
+type SocketFactory = (url: string) => WebSocket;
+
+function base64URLBytes(value: string): Uint8Array {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(
+    Math.ceil(value.length / 4) * 4,
+    "=",
+  );
+  return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+}
+
+function base64URL(bytes: Uint8Array): string {
+  let raw = "";
+  for (const byte of bytes) raw += String.fromCharCode(byte);
+  return btoa(raw).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function expectedProof(
+  secret: string,
+  token: string,
+  nonce: string,
+): string {
+  const input = utf8ToBytes(`${uploadProofDomain}${token}\u0000${nonce}`);
+  return base64URL(hmac(sha256, base64URLBytes(secret), input));
+}
+
+export class VerifiedUploadChannel implements UploadTransport {
+  private socket: WebSocket | null = null;
+  private waiter:
+    | { resolve: (message: UploadMessage) => void; reject: (cause: Error) => void }
+    | null = null;
+  private unusable = false;
+  private busy = false;
+
+  constructor(
+    private readonly session: BrowserSession,
+    private readonly socketFactory: SocketFactory = (url) => new WebSocket(url),
+    private readonly onfailure: () => void = () => {},
+  ) {}
+
+  async connect(): Promise<void> {
+    if (this.socket || this.unusable) {
+      throw new Error("The verified upload channel is unavailable. Run `docbank web` again.");
+    }
+    const scheme = location.protocol === "https:" ? "wss:" : "ws:";
+    const socket = this.socketFactory(`${scheme}//${location.host}${uploadSocketPath}`);
+    this.socket = socket;
+    socket.binaryType = "arraybuffer";
+    socket.addEventListener("message", (event) => this.receive(event));
+    socket.addEventListener("close", () => this.fail());
+    socket.addEventListener("error", () => this.fail());
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener("open", () => resolve(), { once: true });
+      socket.addEventListener("error", () => reject(this.channelError()), { once: true });
     });
-    xhr.addEventListener("abort", () => finish(() => reject(abortError())));
-    xhr.addEventListener("error", () =>
-      finish(() => reject(new Error(`Uploading ${JSON.stringify(name)} failed.`))),
+    const nonceBytes = crypto.getRandomValues(new Uint8Array(32));
+    const nonce = base64URL(nonceBytes);
+    socket.send(JSON.stringify({
+      type: "authenticate",
+      token: this.session.token,
+      nonce,
+    }));
+    const authenticated = await this.nextMessage();
+    const proof = expectedProof(
+      this.session.uploadSecret,
+      this.session.token,
+      nonce,
     );
-    xhr.addEventListener("load", () => {
-      if (xhr.status < 200 || xhr.status > 299) {
-        finish(() => reject(decodeUploadError(xhr)));
-        return;
+    if (authenticated.type !== "authenticated" || authenticated.proof !== proof) {
+      this.fail();
+      throw new Error(
+        "The upload endpoint could not prove it is the current Docbank daemon. No file bytes were sent.",
+      );
+    }
+  }
+
+  close(): void {
+    this.unusable = true;
+    this.socket?.close(1000, "browser closed");
+    this.socket = null;
+  }
+
+  async uploadFile(
+    parentID: number,
+    file: File,
+    expectedHash: string,
+    signal: AbortSignal,
+    onprogress: (progress: TransferProgress) => void,
+  ): Promise<UploadReceipt> {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN || this.unusable) {
+      throw this.channelError();
+    }
+    if (this.busy) throw new Error("Another browser upload is already active.");
+    throwIfAborted(signal);
+    this.busy = true;
+    const requestID = crypto.randomUUID();
+    const name = file.name.normalize("NFC");
+    try {
+      this.send({
+        type: "begin",
+        request_id: requestID,
+        parent_id: parentID,
+        name,
+        mime_type: file.type || "application/octet-stream",
+        expected_hash: expectedHash,
+        expected_size: file.size,
+      });
+      const ready = await this.nextMessage();
+      this.requireMessage(ready, requestID);
+      this.throwProblem(ready);
+      if (ready.type !== "ready") throw this.protocolError();
+      onprogress({ processed: 0, total: file.size });
+      for (let offset = 0; offset < file.size; offset += hashChunkBytes) {
+        if (signal.aborted) {
+          await this.cancelUpload(requestID);
+        }
+        await this.waitForWritable();
+        const end = Math.min(file.size, offset + hashChunkBytes);
+        this.sendBinary(await file.slice(offset, end).arrayBuffer());
+        onprogress({ processed: end, total: file.size });
       }
-      let receipt: UploadReceipt;
+      if (signal.aborted) await this.cancelUpload(requestID);
+      this.send({ type: "end", request_id: requestID });
+      const terminal = await this.nextMessage();
+      this.requireMessage(terminal, requestID);
+      this.throwProblem(terminal);
+      if (terminal.type !== "receipt" || !terminal.receipt) {
+        throw this.protocolError();
+      }
       try {
-        receipt = JSON.parse(xhr.responseText) as UploadReceipt;
+        validateUploadReceipt(terminal.receipt, parentID, name, expectedHash, file.size);
       } catch (cause) {
-        finish(() =>
-          reject(new Error(`Decoding the upload receipt failed: ${String(cause)}`)),
-        );
-        return;
+        this.fail();
+        throw cause;
       }
-      try {
-        validateUploadReceipt(receipt, parentID, name, expectedHash, file.size);
-      } catch (cause) {
-        finish(() => reject(cause));
-        return;
-      }
-      onprogress({ processed: file.size, total: file.size });
-      finish(() => resolve(receipt));
+      return terminal.receipt;
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  private send(message: UploadMessage): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN || this.unusable) {
+      throw this.channelError();
+    }
+    this.socket.send(JSON.stringify(message));
+  }
+
+  private sendBinary(bytes: ArrayBuffer): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN || this.unusable) {
+      throw this.channelError();
+    }
+    this.socket.send(bytes);
+  }
+
+  private nextMessage(): Promise<UploadMessage> {
+    if (this.waiter || this.unusable) return Promise.reject(this.channelError());
+    return new Promise((resolve, reject) => {
+      this.waiter = { resolve, reject };
     });
-    signal.addEventListener("abort", abort, { once: true });
-    onprogress({ processed: 0, total: file.size });
-    xhr.send(form);
-  });
+  }
+
+  private async cancelUpload(requestID: string): Promise<never> {
+    this.send({ type: "cancel", request_id: requestID });
+    const canceled = await this.nextMessage();
+    this.requireMessage(canceled, requestID, "error");
+    throw abortError();
+  }
+
+  private async waitForWritable(): Promise<void> {
+    while (
+      this.socket &&
+      this.socket.readyState === WebSocket.OPEN &&
+      this.socket.bufferedAmount > 2 * hashChunkBytes
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN || this.unusable) {
+      throw this.channelError();
+    }
+  }
+
+  private receive(event: MessageEvent): void {
+    if (!this.waiter || typeof event.data !== "string") {
+      this.fail();
+      return;
+    }
+    let message: UploadMessage;
+    try {
+      message = JSON.parse(event.data) as UploadMessage;
+    } catch {
+      this.fail();
+      return;
+    }
+    const waiter = this.waiter;
+    this.waiter = null;
+    waiter.resolve(message);
+  }
+
+  private requireMessage(
+    message: UploadMessage,
+    requestID: string,
+    type?: string,
+  ): void {
+    if (message.request_id !== requestID || (type && message.type !== type)) {
+      throw this.protocolError();
+    }
+  }
+
+  private throwProblem(message: UploadMessage): void {
+    if (message.type === "error") {
+      throw new APIError(
+        message.detail || "Browser upload failed.",
+        message.status ?? 500,
+        message.code ?? "",
+      );
+    }
+  }
+
+  private protocolError(): Error {
+    this.fail();
+    return new Error("The verified upload channel returned an invalid response.");
+  }
+
+  private channelError(): Error {
+    return new Error(
+      "The verified upload channel ended. Run `docbank web` again before selecting files.",
+    );
+  }
+
+  private fail(): void {
+    if (this.unusable) return;
+    this.unusable = true;
+    this.socket?.close();
+    this.socket = null;
+    this.onfailure();
+    const waiter = this.waiter;
+    this.waiter = null;
+    waiter?.reject(this.channelError());
+  }
 }

--- a/frontend/src/upload.ts
+++ b/frontend/src/upload.ts
@@ -72,7 +72,9 @@ export function validateUploadReceipt(
     receipt.computed_hash !== expectedHash ||
     receipt.computed_size !== expectedSize ||
     receipt.node.parent_id !== parentID ||
-    !permittedUploadName(name, receipt.node.name) ||
+    // New uploads may be collision-suffixed. An idempotent provenance match
+    // can identify the same bytes after the existing node was renamed.
+    (receipt.status === "added" && !permittedUploadName(name, receipt.node.name)) ||
     receipt.node.blob_hash !== expectedHash ||
     receipt.node.size !== expectedSize
   ) {
@@ -230,7 +232,7 @@ export class VerifiedUploadChannel implements UploadTransport {
       }
       if (signal.aborted) await this.cancelUpload(requestID);
       this.send({ type: "end", request_id: requestID });
-      const terminal = await this.nextMessage();
+      const terminal = await this.nextTerminalMessage(signal);
       this.requireMessage(terminal, requestID);
       this.throwProblem(terminal);
       if (terminal.type !== "receipt" || !terminal.receipt) {
@@ -266,6 +268,31 @@ export class VerifiedUploadChannel implements UploadTransport {
     if (this.waiter || this.unusable) return Promise.reject(this.channelError());
     return new Promise((resolve, reject) => {
       this.waiter = { resolve, reject };
+    });
+  }
+
+  private nextTerminalMessage(signal: AbortSignal): Promise<UploadMessage> {
+    if (signal.aborted) {
+      this.fail();
+      return Promise.reject(abortError());
+    }
+    const terminal = this.nextMessage();
+    return new Promise((resolve, reject) => {
+      const aborted = (): void => {
+        this.fail();
+        reject(abortError());
+      };
+      signal.addEventListener("abort", aborted, { once: true });
+      terminal.then(
+        (message) => {
+          signal.removeEventListener("abort", aborted);
+          resolve(message);
+        },
+        (cause) => {
+          signal.removeEventListener("abort", aborted);
+          reject(cause);
+        },
+      );
     });
   }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/coder/websocket v1.8.15
 	github.com/danielgtaylor/huma/v2 v2.38.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mattn/go-sqlite3 v1.14.47

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danielgtaylor/huma/v2 v2.38.0 h1:fb0WZCatnaiHLphMQDDWDjygNxfMkX/ENma3QsRl7vY=

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -28,7 +28,7 @@ func timeoutExempt(path string) bool {
 		"/api/v1/backup/snapshots", "/api/v1/backup/snapshots/stream",
 		"/api/v1/backup/verify", "/api/v1/backup/verify/stream",
 		"/api/v1/backup/restore", "/api/v1/backup/restore/stream",
-		webDownloadPreparePath, webDownloadFilePath:
+		webDownloadPreparePath, webDownloadFilePath, webUploadSocketPath:
 		return true
 	}
 	if strings.HasPrefix(path, "/api/v1/nodes/") &&
@@ -64,7 +64,8 @@ func clearLongRunningBodyReadDeadlines(api huma.API) {
 // the daemon always has one; see NewServer.
 func authExempt(path string) bool {
 	switch path {
-	case "/", "/health", kitPingPath, daemonauth.ChallengePath, webDownloadFilePath:
+	case "/", "/health", kitPingPath, daemonauth.ChallengePath,
+		webDownloadFilePath, webUploadSocketPath:
 		return true
 	}
 	return strings.HasPrefix(path, "/docs") ||

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -135,6 +135,7 @@ func NewServer(d Deps) *Server {
 	s.registerShutdown(mux)
 	registerWeb(mux, d.Cfg.Web.Enabled)
 	registerWebSession(mux, d.Cfg.Web.Enabled, d.WebURL, s.webSessions)
+	registerWebUpload(mux, d.Cfg.Web.Enabled, d.WebURL, d, g, s.webSessions)
 	registerWebDownload(mux, d.Cfg.Web.Enabled, d, s.webDownloads)
 
 	h := http.Handler(mux)
@@ -154,6 +155,10 @@ func NewServer(d Deps) *Server {
 
 func (s *Server) Handler() http.Handler { return s.handler }
 func (s *Server) API() huma.API         { return s.api }
+
+// Close revokes daemon-lifetime browser credentials and closes their
+// hijacked upload connections. net/http shutdown does not own WebSockets.
+func (s *Server) Close() { s.webSessions.closeAll() }
 
 // markRevisionPreconditionsRequired keeps Huma's runtime parser permissive
 // enough for parseIfMatch to return Docbank's structured 428 response while

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -157,8 +157,22 @@ func (s *Server) Handler() http.Handler { return s.handler }
 func (s *Server) API() huma.API         { return s.api }
 
 // Close revokes daemon-lifetime browser credentials and closes their
-// hijacked upload connections. net/http shutdown does not own WebSockets.
-func (s *Server) Close() { s.webSessions.closeAll() }
+// hijacked upload connections. net/http shutdown does not own WebSockets, so
+// Close also waits for their handlers to release mutation and storage
+// resources before returning.
+func (s *Server) Close() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		s.deps.Logger.Error("browser upload shutdown did not drain", "err", err)
+	}
+}
+
+// Shutdown revokes browser credentials, closes every accepted upload
+// connection, and waits for its handler to return.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.webSessions.closeAll(ctx)
+}
 
 // markRevisionPreconditionsRequired keeps Huma's runtime parser permissive
 // enough for parseIfMatch to return Docbank's structured 428 response while

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -133,7 +133,7 @@ func NewServer(d Deps) *Server {
 	}))
 	s.registerChallenge(mux)
 	s.registerShutdown(mux)
-	registerWeb(mux, d.Cfg.Web.Enabled)
+	registerWeb(mux, d.Cfg.Web.Enabled, d.WebURL)
 	registerWebSession(mux, d.Cfg.Web.Enabled, d.WebURL, s.webSessions)
 	registerWebUpload(mux, d.Cfg.Web.Enabled, d.WebURL, d, g, s.webSessions)
 	registerWebDownload(mux, d.Cfg.Web.Enabled, d, s.webDownloads)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -3,11 +3,11 @@ package api_test
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -345,12 +345,16 @@ func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
 	var issued struct {
-		Token string `json:"token"`
-		URL   string `json:"url"`
+		Token        string `json:"token"`
+		UploadSecret string `json:"upload_secret"`
+		URL          string `json:"url"`
 	}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&issued))
 	require.NoError(t, resp.Body.Close())
 	require.NotEmpty(t, issued.Token)
+	secret, err := base64.RawURLEncoding.DecodeString(issued.UploadSecret)
+	require.NoError(t, err)
+	require.Len(t, secret, sha256.Size)
 	assert.Equal(t, testWebURL, issued.URL)
 	assert.NotEqual(t, testAPIKey, issued.Token)
 
@@ -430,27 +434,9 @@ func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 		"browser sessions cannot supply even an empty repository override")
 	require.NoError(t, resp.Body.Close())
 
-	uploadContent := []byte("browser upload")
-	uploadHash := sha256.Sum256(uploadContent)
-	var uploadBody bytes.Buffer
-	uploadWriter := multipart.NewWriter(&uploadBody)
-	uploadPart, err := uploadWriter.CreateFormFile("file", "browser.txt")
-	require.NoError(t, err)
-	_, err = uploadPart.Write(uploadContent)
-	require.NoError(t, err)
-	require.NoError(t, uploadWriter.Close())
-	uploadURL := ts.URL + "/api/v1/uploads?parent_id=" +
-		strconv.FormatInt(taxes.ID, 10) + "&name=browser.txt"
-	uploadRequest, err := http.NewRequest(http.MethodPost, uploadURL, &uploadBody)
-	require.NoError(t, err)
-	uploadRequest.Header["X-Api-Key"] = []string{""}
-	uploadRequest.Header.Set(api.WebSessionHeader, issued.Token)
-	uploadRequest.Header.Set("Content-Type", uploadWriter.FormDataContentType())
-	uploadRequest.Header.Set(api.BlobHashHeader, hex.EncodeToString(uploadHash[:]))
-	uploadRequest.Header.Set(api.BlobSizeHeader, strconv.Itoa(len(uploadContent)))
-	resp, err = ts.Client().Do(uploadRequest)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp = webRequest(http.MethodPost, "/api/v1/uploads")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"browser sessions cannot upload through reconnectable HTTP")
 	require.NoError(t, resp.Body.Close())
 
 	resp = webRequest(http.MethodGet,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -316,7 +317,7 @@ func TestWebApplication(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
-func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
+func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 	ts, s := newTestServer(t, nil)
 	taxes, err := s.Mkdir(t.Context(), s.RootID(), "Taxes")
 	require.NoError(t, err)
@@ -427,6 +428,29 @@ func TestWebSessionIsReadOnlyRevocableAndDaemonLocal(t *testing.T) {
 	resp = webRequest(http.MethodGet, "/api/v1/backup/snapshots?repo=")
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
 		"browser sessions cannot supply even an empty repository override")
+	require.NoError(t, resp.Body.Close())
+
+	uploadContent := []byte("browser upload")
+	uploadHash := sha256.Sum256(uploadContent)
+	var uploadBody bytes.Buffer
+	uploadWriter := multipart.NewWriter(&uploadBody)
+	uploadPart, err := uploadWriter.CreateFormFile("file", "browser.txt")
+	require.NoError(t, err)
+	_, err = uploadPart.Write(uploadContent)
+	require.NoError(t, err)
+	require.NoError(t, uploadWriter.Close())
+	uploadURL := ts.URL + "/api/v1/uploads?parent_id=" +
+		strconv.FormatInt(taxes.ID, 10) + "&name=browser.txt"
+	uploadRequest, err := http.NewRequest(http.MethodPost, uploadURL, &uploadBody)
+	require.NoError(t, err)
+	uploadRequest.Header["X-Api-Key"] = []string{""}
+	uploadRequest.Header.Set(api.WebSessionHeader, issued.Token)
+	uploadRequest.Header.Set("Content-Type", uploadWriter.FormDataContentType())
+	uploadRequest.Header.Set(api.BlobHashHeader, hex.EncodeToString(uploadHash[:]))
+	uploadRequest.Header.Set(api.BlobSizeHeader, strconv.Itoa(len(uploadContent)))
+	resp, err = ts.Client().Do(uploadRequest)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
 	resp = webRequest(http.MethodGet,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -307,7 +307,8 @@ func TestWebApplication(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
 	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
-	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "connect-src 'self'")
+	assert.Contains(t, resp.Header.Get("Content-Security-Policy"),
+		"connect-src 'self' ws://docbank-0123456789abcdef0123456789abcdef.localhost:43210")
 	assert.Equal(t, "no-referrer", resp.Header.Get("Referrer-Policy"))
 	assert.Contains(t, strings.ToLower(body), "<!doctype html>")
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -35,6 +35,7 @@ type testStore struct {
 	Blobs    *blob.Store
 	BlobsDir string
 	DBPath   string
+	Server   *api.Server
 }
 
 // testAPIKey is the default key newTestServer configures: production always
@@ -72,10 +73,14 @@ func newTestServer(t *testing.T, mutate func(*api.Deps)) (*httptest.Server, *tes
 	if mutate != nil {
 		mutate(&d)
 	}
-	ts := httptest.NewServer(api.NewServer(d).Handler())
+	apiServer := api.NewServer(d)
+	t.Cleanup(apiServer.Close)
+	ts := httptest.NewServer(apiServer.Handler())
 	t.Cleanup(ts.Close)
 	ts.Client().Transport = &apiKeyTransport{key: d.Cfg.Server.APIKey, next: ts.Client().Transport}
-	return ts, &testStore{Store: s, Blobs: blobs, BlobsDir: blobsDir, DBPath: dbPath}
+	return ts, &testStore{
+		Store: s, Blobs: blobs, BlobsDir: blobsDir, DBPath: dbPath, Server: apiServer,
+	}
 }
 
 // apiKeyTransport injects key as X-Api-Key on any request that doesn't

--- a/internal/api/web.go
+++ b/internal/api/web.go
@@ -3,6 +3,7 @@ package api
 import (
 	"io/fs"
 	"net/http"
+	"net/url"
 
 	docweb "go.kenn.io/docbank/internal/web"
 )
@@ -10,7 +11,7 @@ import (
 // registerWeb serves the embedded SPA without granting it a privileged data
 // path. JavaScript and styles are public static bytes; every vault read still
 // crosses the authenticated /api/v1 surface.
-func registerWeb(mux *http.ServeMux, enabled bool) {
+func registerWeb(mux *http.ServeMux, enabled bool, webURL string) {
 	if !enabled {
 		return
 	}
@@ -21,22 +22,32 @@ func registerWeb(mux *http.ServeMux, enabled bool) {
 	}
 	static := http.FileServer(http.FS(assets))
 	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, _ *http.Request) {
-		setWebHeaders(w)
+		setWebHeaders(w, webURL)
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = w.Write(indexHTML)
 	})
 	mux.Handle("GET /assets/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		setWebHeaders(w)
+		setWebHeaders(w, webURL)
 		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 		static.ServeHTTP(w, r)
 	}))
 }
 
-func setWebHeaders(w http.ResponseWriter) {
+func setWebHeaders(w http.ResponseWriter, webURL string) {
+	connectSources := "'self'"
+	if parsed, err := url.Parse(webURL); err == nil && parsed.Host != "" {
+		switch parsed.Scheme {
+		case "http":
+			connectSources += " ws://" + parsed.Host
+		case "https":
+			connectSources += " wss://" + parsed.Host
+		}
+	}
 	w.Header().Set("Content-Security-Policy",
 		"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; "+
-			"connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'")
+			"connect-src "+connectSources+"; object-src 'none'; "+
+			"base-uri 'none'; frame-ancestors 'none'")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 }

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -23,8 +25,11 @@ const (
 // the deliberately limited routes used by the built-in browser. Most are
 // reads; verified upload is the one document-authority mutation.
 type webSessionRegistry struct {
-	mu     sync.Mutex
-	tokens map[[sha256.Size]byte]webSessionState
+	mu          sync.Mutex
+	tokens      map[[sha256.Size]byte]webSessionState
+	uploads     map[*websocket.Conn]struct{}
+	uploadGroup sync.WaitGroup
+	closing     bool
 }
 
 type webSessionState struct {
@@ -33,7 +38,10 @@ type webSessionState struct {
 }
 
 func newWebSessionRegistry() *webSessionRegistry {
-	return &webSessionRegistry{tokens: make(map[[sha256.Size]byte]webSessionState)}
+	return &webSessionRegistry{
+		tokens:  make(map[[sha256.Size]byte]webSessionState),
+		uploads: make(map[*websocket.Conn]struct{}),
+	}
 }
 
 func (r *webSessionRegistry) issue() (string, string, error) {
@@ -47,6 +55,10 @@ func (r *webSessionRegistry) issue() (string, string, error) {
 	}
 	token := base64.RawURLEncoding.EncodeToString(raw)
 	r.mu.Lock()
+	if r.closing {
+		r.mu.Unlock()
+		return "", "", errors.New("browser sessions are shutting down")
+	}
 	r.tokens[sha256.Sum256([]byte(token))] = webSessionState{uploadSecret: uploadSecret}
 	r.mu.Unlock()
 	return token, base64.RawURLEncoding.EncodeToString(uploadSecret[:]), nil
@@ -77,12 +89,34 @@ func (r *webSessionRegistry) bindUpload(token string, conn *websocket.Conn) bool
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	state, ok := r.tokens[digest]
-	if !ok || state.upload != nil {
+	if r.closing || !ok || state.upload != nil {
 		return false
 	}
 	state.upload = conn
 	r.tokens[digest] = state
 	return true
+}
+
+func (r *webSessionRegistry) trackUpload(conn *websocket.Conn) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closing {
+		return false
+	}
+	r.uploadGroup.Add(1)
+	r.uploads[conn] = struct{}{}
+	return true
+}
+
+func (r *webSessionRegistry) releaseTrackedUpload(conn *websocket.Conn) {
+	r.mu.Lock()
+	if _, ok := r.uploads[conn]; !ok {
+		r.mu.Unlock()
+		return
+	}
+	delete(r.uploads, conn)
+	r.mu.Unlock()
+	r.uploadGroup.Done()
 }
 
 func (r *webSessionRegistry) releaseUpload(token string, conn *websocket.Conn) {
@@ -107,18 +141,29 @@ func (r *webSessionRegistry) revoke(token string) {
 	}
 }
 
-func (r *webSessionRegistry) closeAll() {
+func (r *webSessionRegistry) closeAll(ctx context.Context) error {
 	r.mu.Lock()
-	conns := make([]*websocket.Conn, 0, len(r.tokens))
-	for digest, state := range r.tokens {
-		if state.upload != nil {
-			conns = append(conns, state.upload)
-		}
-		delete(r.tokens, digest)
+	r.closing = true
+	clear(r.tokens)
+	conns := make([]*websocket.Conn, 0, len(r.uploads))
+	for conn := range r.uploads {
+		conns = append(conns, conn)
 	}
 	r.mu.Unlock()
 	for _, conn := range conns {
 		_ = conn.CloseNow()
+	}
+
+	drained := make(chan struct{})
+	go func() {
+		r.uploadGroup.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for browser upload handlers: %w", ctx.Err())
 	}
 }
 

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -18,7 +18,8 @@ const (
 
 // webSessionRegistry owns browser credentials for exactly one daemon
 // lifetime. Tokens are random, retained only as digests, and authorize only
-// the read routes used by the built-in document, audit-history, and job browser.
+// the deliberately limited routes used by the built-in browser. Most are
+// reads; verified upload is the one document-authority mutation.
 type webSessionRegistry struct {
 	mu     sync.Mutex
 	tokens map[[sha256.Size]byte]struct{}
@@ -59,6 +60,9 @@ func (r *webSessionRegistry) revoke(token string) {
 func webSessionRequestAllowed(r *http.Request) bool {
 	method, path := r.Method, r.URL.Path
 	if method == http.MethodPost && path == webDownloadPreparePath {
+		return true
+	}
+	if method == http.MethodPost && path == "/api/v1/uploads" {
 		return true
 	}
 	if method == http.MethodDelete && path == webSessionPath {

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/coder/websocket"
 )
 
 const (
@@ -22,23 +24,32 @@ const (
 // reads; verified upload is the one document-authority mutation.
 type webSessionRegistry struct {
 	mu     sync.Mutex
-	tokens map[[sha256.Size]byte]struct{}
+	tokens map[[sha256.Size]byte]webSessionState
+}
+
+type webSessionState struct {
+	uploadSecret [sha256.Size]byte
+	upload       *websocket.Conn
 }
 
 func newWebSessionRegistry() *webSessionRegistry {
-	return &webSessionRegistry{tokens: make(map[[sha256.Size]byte]struct{})}
+	return &webSessionRegistry{tokens: make(map[[sha256.Size]byte]webSessionState)}
 }
 
-func (r *webSessionRegistry) issue() (string, error) {
+func (r *webSessionRegistry) issue() (string, string, error) {
 	raw := make([]byte, 32)
 	if _, err := rand.Read(raw); err != nil {
-		return "", fmt.Errorf("generating browser session: %w", err)
+		return "", "", fmt.Errorf("generating browser session: %w", err)
+	}
+	var uploadSecret [sha256.Size]byte
+	if _, err := rand.Read(uploadSecret[:]); err != nil {
+		return "", "", fmt.Errorf("generating browser upload secret: %w", err)
 	}
 	token := base64.RawURLEncoding.EncodeToString(raw)
 	r.mu.Lock()
-	r.tokens[sha256.Sum256([]byte(token))] = struct{}{}
+	r.tokens[sha256.Sum256([]byte(token))] = webSessionState{uploadSecret: uploadSecret}
 	r.mu.Unlock()
-	return token, nil
+	return token, base64.RawURLEncoding.EncodeToString(uploadSecret[:]), nil
 }
 
 func (r *webSessionRegistry) valid(token string) bool {
@@ -51,18 +62,69 @@ func (r *webSessionRegistry) valid(token string) bool {
 	return ok
 }
 
-func (r *webSessionRegistry) revoke(token string) {
+func (r *webSessionRegistry) uploadSecret(token string) ([sha256.Size]byte, bool) {
+	if token == "" {
+		return [sha256.Size]byte{}, false
+	}
 	r.mu.Lock()
-	delete(r.tokens, sha256.Sum256([]byte(token)))
+	state, ok := r.tokens[sha256.Sum256([]byte(token))]
 	r.mu.Unlock()
+	return state.uploadSecret, ok
+}
+
+func (r *webSessionRegistry) bindUpload(token string, conn *websocket.Conn) bool {
+	digest := sha256.Sum256([]byte(token))
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	state, ok := r.tokens[digest]
+	if !ok || state.upload != nil {
+		return false
+	}
+	state.upload = conn
+	r.tokens[digest] = state
+	return true
+}
+
+func (r *webSessionRegistry) releaseUpload(token string, conn *websocket.Conn) {
+	digest := sha256.Sum256([]byte(token))
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	state, ok := r.tokens[digest]
+	if ok && state.upload == conn {
+		state.upload = nil
+		r.tokens[digest] = state
+	}
+}
+
+func (r *webSessionRegistry) revoke(token string) {
+	digest := sha256.Sum256([]byte(token))
+	r.mu.Lock()
+	state := r.tokens[digest]
+	delete(r.tokens, digest)
+	r.mu.Unlock()
+	if state.upload != nil {
+		_ = state.upload.CloseNow()
+	}
+}
+
+func (r *webSessionRegistry) closeAll() {
+	r.mu.Lock()
+	conns := make([]*websocket.Conn, 0, len(r.tokens))
+	for digest, state := range r.tokens {
+		if state.upload != nil {
+			conns = append(conns, state.upload)
+		}
+		delete(r.tokens, digest)
+	}
+	r.mu.Unlock()
+	for _, conn := range conns {
+		_ = conn.CloseNow()
+	}
 }
 
 func webSessionRequestAllowed(r *http.Request) bool {
 	method, path := r.Method, r.URL.Path
 	if method == http.MethodPost && path == webDownloadPreparePath {
-		return true
-	}
-	if method == http.MethodPost && path == "/api/v1/uploads" {
 		return true
 	}
 	if method == http.MethodDelete && path == webSessionPath {
@@ -116,7 +178,7 @@ func registerWebSession(
 				"this daemon is not serving the compiled web application"))
 			return
 		}
-		token, err := sessions.issue()
+		token, uploadSecret, err := sessions.issue()
 		if err != nil {
 			writeError(w, NewError(http.StatusInternalServerError, "internal",
 				"could not create a browser session"))
@@ -124,9 +186,10 @@ func registerWebSession(
 		}
 		w.Header().Set("Cache-Control", "no-store")
 		writeJSON(w, http.StatusCreated, struct {
-			Token string `json:"token"`
-			URL   string `json:"url"`
-		}{Token: token, URL: webURL})
+			Token        string `json:"token"`
+			UploadSecret string `json:"upload_secret"`
+			URL          string `json:"url"`
+		}{Token: token, UploadSecret: uploadSecret, URL: webURL})
 	})
 	mux.HandleFunc("DELETE "+webSessionPath, func(w http.ResponseWriter, r *http.Request) {
 		sessions.revoke(r.Header.Get(WebSessionHeader))

--- a/internal/api/web_upload.go
+++ b/internal/api/web_upload.go
@@ -131,21 +131,31 @@ func handleWebUploadConnection(
 		if err := wsjson.Read(ctx, conn, &begin); err != nil {
 			return
 		}
-		request, problem := validateWebUploadBegin(ctx, d, begin)
+		request, problem := validateWebUploadBegin(begin)
 		if problem != nil {
 			if writeWebUploadProblem(ctx, conn, begin.RequestID, problem) != nil {
 				return
 			}
 			continue
 		}
-		if err := wsjson.Write(ctx, conn, webUploadMessage{
-			Type: "ready", RequestID: request.requestID,
-		}); err != nil {
-			return
-		}
 
 		reader := &webUploadReader{ctx: ctx, conn: conn, requestID: request.requestID}
-		result, uploadErr := executeWebUpload(ctx, d, g, request, reader)
+		var result ingest.UploadResult
+		ready := false
+		uploadErr := g.mutate(func() error {
+			if problem := validateWebUploadDestination(ctx, d, request.parentID); problem != nil {
+				return problem
+			}
+			if err := wsjson.Write(ctx, conn, webUploadMessage{
+				Type: "ready", RequestID: request.requestID,
+			}); err != nil {
+				return fmt.Errorf("writing browser upload readiness: %w", err)
+			}
+			ready = true
+			var err error
+			result, err = executeWebUpload(ctx, d, request, reader)
+			return err
+		})
 		if uploadErr != nil {
 			problem := uploadError(uploadErr)
 			if errors.Is(uploadErr, errWebUploadCanceled) {
@@ -154,7 +164,7 @@ func handleWebUploadConnection(
 			if writeWebUploadProblem(ctx, conn, request.requestID, problem) != nil {
 				return
 			}
-			if !reader.ended {
+			if ready && !reader.ended {
 				_ = conn.Close(websocket.StatusPolicyViolation,
 					"upload stream ended before its terminal marker")
 				return
@@ -177,11 +187,7 @@ func handleWebUploadConnection(
 	}
 }
 
-func validateWebUploadBegin(
-	ctx context.Context,
-	d Deps,
-	begin webUploadMessage,
-) (webUploadRequest, *Error) {
+func validateWebUploadBegin(begin webUploadMessage) (webUploadRequest, *Error) {
 	if begin.Type != "begin" || begin.RequestID == "" || len(begin.RequestID) > 128 {
 		return webUploadRequest{}, NewError(http.StatusUnprocessableEntity, "validation",
 			"upload begin requires a bounded request identity")
@@ -203,49 +209,50 @@ func validateWebUploadBegin(
 	if err != nil {
 		return webUploadRequest{}, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 	}
-	parent, err := d.Store.NodeByID(ctx, begin.ParentID)
-	switch {
-	case errors.Is(err, store.ErrNotFound) || (err == nil && parent.TrashedAt != nil):
-		return webUploadRequest{}, NewError(http.StatusNotFound, "not_found",
-			"upload destination does not exist")
-	case err != nil:
-		var problem *Error
-		if errors.As(FromStoreError(err), &problem) {
-			return webUploadRequest{}, problem
-		}
-		return webUploadRequest{}, NewError(http.StatusInternalServerError, "internal",
-			"could not inspect the upload destination")
-	case !parent.IsDir():
-		return webUploadRequest{}, NewError(http.StatusConflict, "not_dir",
-			"upload destination is not a directory")
-	}
 	return webUploadRequest{
 		requestID: begin.RequestID, parentID: begin.ParentID, name: name,
 		mimeType: mimeType, expectedHash: begin.ExpectedHash, expectedSize: begin.ExpectedSize,
 	}, nil
 }
 
+func validateWebUploadDestination(ctx context.Context, d Deps, parentID int64) *Error {
+	parent, err := d.Store.NodeByID(ctx, parentID)
+	switch {
+	case errors.Is(err, store.ErrNotFound) || (err == nil && parent.TrashedAt != nil):
+		return NewError(http.StatusNotFound, "not_found",
+			"upload destination does not exist")
+	case err != nil:
+		var problem *Error
+		if errors.As(FromStoreError(err), &problem) {
+			return problem
+		}
+		return NewError(http.StatusInternalServerError, "internal",
+			"could not inspect the upload destination")
+	case !parent.IsDir():
+		return NewError(http.StatusConflict, "not_dir",
+			"upload destination is not a directory")
+	}
+	return nil
+}
+
 func executeWebUpload(
 	ctx context.Context,
 	d Deps,
-	g *gate,
 	request webUploadRequest,
 	reader *webUploadReader,
 ) (result ingest.UploadResult, retErr error) {
-	retErr = g.mutate(func() error {
-		return d.Blobs.WithMutation(ctx, func() error {
-			limited := &io.LimitedReader{R: reader, N: request.expectedSize + 1}
-			ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
-			prepared, err := ing.PrepareUpload(
-				ctx, request.parentID, request.name, request.mimeType, limited,
-				request.expectedHash, request.expectedSize,
-			)
-			if err != nil {
-				return err
-			}
-			result, err = prepared.Commit(ctx)
+	retErr = d.Blobs.WithMutation(ctx, func() error {
+		limited := &io.LimitedReader{R: reader, N: request.expectedSize + 1}
+		ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
+		prepared, err := ing.PrepareUpload(
+			ctx, request.parentID, request.name, request.mimeType, limited,
+			request.expectedHash, request.expectedSize,
+		)
+		if err != nil {
 			return err
-		})
+		}
+		result, err = prepared.Commit(ctx)
+		return err
 	})
 	return result, retErr
 }

--- a/internal/api/web_upload.go
+++ b/internal/api/web_upload.go
@@ -90,6 +90,11 @@ func registerWebUpload(
 			return // Accept writes its own handshake error.
 		}
 		conn.SetReadLimit(webUploadChunkBytes + 4096)
+		if !sessions.trackUpload(conn) {
+			_ = conn.Close(websocket.StatusGoingAway, "daemon is shutting down")
+			return
+		}
+		defer sessions.releaseTrackedUpload(conn)
 		handleWebUploadConnection(r.Context(), conn, d, g, sessions)
 	})
 }

--- a/internal/api/web_upload.go
+++ b/internal/api/web_upload.go
@@ -28,6 +28,7 @@ const (
 	webUploadProofDomain = "docbank-web-upload-v1\x00"
 	webUploadChunkBytes  = 1 << 20
 	webUploadAuthTimeout = 10 * time.Second
+	webUploadInactivity  = 30 * time.Second
 )
 
 var (
@@ -89,18 +90,18 @@ func registerWebUpload(
 			return // Accept writes its own handshake error.
 		}
 		conn.SetReadLimit(webUploadChunkBytes + 4096)
-		handleWebUploadConnection(conn, d, g, sessions)
+		handleWebUploadConnection(r.Context(), conn, d, g, sessions)
 	})
 }
 
 func handleWebUploadConnection(
+	ctx context.Context,
 	conn *websocket.Conn,
 	d Deps,
 	g *gate,
 	sessions *webSessionRegistry,
 ) {
 	defer func() { _ = conn.CloseNow() }()
-	ctx := context.Background()
 
 	var auth webUploadMessage
 	authCtx, cancelAuth := context.WithTimeout(ctx, webUploadAuthTimeout)
@@ -139,7 +140,10 @@ func handleWebUploadConnection(
 			continue
 		}
 
-		reader := &webUploadReader{ctx: ctx, conn: conn, requestID: request.requestID}
+		reader := &webUploadReader{
+			ctx: ctx, conn: conn, requestID: request.requestID,
+			inactivity: webUploadInactivity,
+		}
 		var result ingest.UploadResult
 		ready := false
 		uploadErr := g.mutate(func() error {
@@ -156,6 +160,7 @@ func handleWebUploadConnection(
 			result, err = executeWebUpload(ctx, d, request, reader)
 			return err
 		})
+		reader.close()
 		if uploadErr != nil {
 			problem := uploadError(uploadErr)
 			if errors.Is(uploadErr, errWebUploadCanceled) {
@@ -258,37 +263,46 @@ func executeWebUpload(
 }
 
 type webUploadReader struct {
-	ctx       context.Context
-	conn      *websocket.Conn
-	requestID string
-	current   io.Reader
-	ended     bool
+	ctx        context.Context
+	conn       *websocket.Conn
+	requestID  string
+	current    io.Reader
+	cancel     context.CancelFunc
+	inactivity time.Duration
+	ended      bool
 }
 
 func (r *webUploadReader) Read(p []byte) (int, error) {
 	for {
 		if r.current != nil {
 			n, err := r.current.Read(p)
-			if errors.Is(err, io.EOF) {
+			if err != nil {
 				r.current = nil
-				if n > 0 {
+				r.cancel()
+				r.cancel = nil
+				if errors.Is(err, io.EOF) && n > 0 {
 					return n, nil
 				}
-				continue
+				if errors.Is(err, io.EOF) {
+					continue
+				}
 			}
 			return n, err
 		}
-		messageType, next, err := r.conn.Reader(r.ctx)
+		messageType, next, cancel, err := r.nextFrame()
 		if err != nil {
-			return 0, fmt.Errorf("reading browser upload frame: %w", err)
+			return 0, err
 		}
 		switch messageType {
 		case websocket.MessageBinary:
 			r.current = next
+			r.cancel = cancel
 		case websocket.MessageText:
 			var terminal webUploadMessage
 			decoder := json.NewDecoder(io.LimitReader(next, 4096))
-			if err := decoder.Decode(&terminal); err != nil || terminal.RequestID != r.requestID {
+			err := decoder.Decode(&terminal)
+			cancel()
+			if err != nil || terminal.RequestID != r.requestID {
 				return 0, errWebUploadProtocol
 			}
 			r.ended = true
@@ -301,9 +315,30 @@ func (r *webUploadReader) Read(p []byte) (int, error) {
 				return 0, errWebUploadProtocol
 			}
 		default:
+			cancel()
 			return 0, errWebUploadProtocol
 		}
 	}
+}
+
+func (r *webUploadReader) nextFrame() (
+	websocket.MessageType, io.Reader, context.CancelFunc, error,
+) {
+	readCtx, cancel := context.WithTimeout(r.ctx, r.inactivity)
+	messageType, next, err := r.conn.Reader(readCtx)
+	if err != nil {
+		cancel()
+		return 0, nil, nil, fmt.Errorf("waiting for browser upload frame: %w", err)
+	}
+	return messageType, next, cancel, nil
+}
+
+func (r *webUploadReader) close() {
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+	r.current = nil
 }
 
 func writeWebUploadProblem(

--- a/internal/api/web_upload.go
+++ b/internal/api/web_upload.go
@@ -1,0 +1,324 @@
+package api
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/ingest"
+	"go.kenn.io/docbank/internal/store"
+)
+
+const (
+	webUploadSocketPath  = "/api/daemon/web-upload"
+	webUploadProofDomain = "docbank-web-upload-v1\x00"
+	webUploadChunkBytes  = 1 << 20
+	webUploadAuthTimeout = 10 * time.Second
+)
+
+var (
+	errWebUploadCanceled = errors.New("browser upload canceled")
+	errWebUploadProtocol = errors.New("invalid browser upload protocol")
+)
+
+type webUploadMessage struct {
+	Type         string         `json:"type"`
+	Token        string         `json:"token,omitempty"`
+	Nonce        string         `json:"nonce,omitempty"`
+	Proof        string         `json:"proof,omitempty"`
+	RequestID    string         `json:"request_id,omitempty"`
+	ParentID     int64          `json:"parent_id,omitempty"`
+	Name         string         `json:"name,omitempty"`
+	MIMEType     string         `json:"mime_type,omitempty"`
+	ExpectedHash string         `json:"expected_hash,omitempty"`
+	ExpectedSize int64          `json:"expected_size,omitempty"`
+	Receipt      *UploadReceipt `json:"receipt,omitempty"`
+	Status       int            `json:"status,omitempty"`
+	Code         string         `json:"code,omitempty"`
+	Detail       string         `json:"detail,omitempty"`
+}
+
+type webUploadRequest struct {
+	requestID    string
+	parentID     int64
+	name         string
+	mimeType     string
+	expectedHash string
+	expectedSize int64
+}
+
+func registerWebUpload(
+	mux *http.ServeMux,
+	enabled bool,
+	webURL string,
+	d Deps,
+	g *gate,
+	sessions *webSessionRegistry,
+) {
+	if !enabled || webURL == "" {
+		return
+	}
+	origin := strings.TrimSuffix(webURL, "/")
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Scheme != "http" || parsed.Host == "" {
+		panic("api: invalid browser origin for verified upload")
+	}
+	mux.HandleFunc("GET "+webUploadSocketPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Origin") != origin {
+			http.Error(w, "browser upload origin rejected", http.StatusForbidden)
+			return
+		}
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			OriginPatterns: []string{parsed.Host},
+		})
+		if err != nil {
+			return // Accept writes its own handshake error.
+		}
+		conn.SetReadLimit(webUploadChunkBytes + 4096)
+		handleWebUploadConnection(conn, d, g, sessions)
+	})
+}
+
+func handleWebUploadConnection(
+	conn *websocket.Conn,
+	d Deps,
+	g *gate,
+	sessions *webSessionRegistry,
+) {
+	defer func() { _ = conn.CloseNow() }()
+	ctx := context.Background()
+
+	var auth webUploadMessage
+	authCtx, cancelAuth := context.WithTimeout(ctx, webUploadAuthTimeout)
+	err := wsjson.Read(authCtx, conn, &auth)
+	cancelAuth()
+	if err != nil {
+		return
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(auth.Nonce)
+	if auth.Type != "authenticate" || len(nonce) != sha256.Size || err != nil {
+		_ = conn.Close(websocket.StatusPolicyViolation, "invalid upload authentication")
+		return
+	}
+	secret, ok := sessions.uploadSecret(auth.Token)
+	if !ok || !sessions.bindUpload(auth.Token, conn) {
+		_ = conn.Close(websocket.StatusPolicyViolation, "upload session unavailable")
+		return
+	}
+	defer sessions.releaseUpload(auth.Token, conn)
+	if err := wsjson.Write(ctx, conn, webUploadMessage{
+		Type: "authenticated", Proof: webUploadProof(secret, auth.Token, auth.Nonce),
+	}); err != nil {
+		return
+	}
+
+	for {
+		var begin webUploadMessage
+		if err := wsjson.Read(ctx, conn, &begin); err != nil {
+			return
+		}
+		request, problem := validateWebUploadBegin(ctx, d, begin)
+		if problem != nil {
+			if writeWebUploadProblem(ctx, conn, begin.RequestID, problem) != nil {
+				return
+			}
+			continue
+		}
+		if err := wsjson.Write(ctx, conn, webUploadMessage{
+			Type: "ready", RequestID: request.requestID,
+		}); err != nil {
+			return
+		}
+
+		reader := &webUploadReader{ctx: ctx, conn: conn, requestID: request.requestID}
+		result, uploadErr := executeWebUpload(ctx, d, g, request, reader)
+		if uploadErr != nil {
+			problem := uploadError(uploadErr)
+			if errors.Is(uploadErr, errWebUploadCanceled) {
+				problem = NewError(499, "canceled", "browser upload canceled before authority")
+			}
+			if writeWebUploadProblem(ctx, conn, request.requestID, problem) != nil {
+				return
+			}
+			if !reader.ended {
+				_ = conn.Close(websocket.StatusPolicyViolation,
+					"upload stream ended before its terminal marker")
+				return
+			}
+			continue
+		}
+		status := "skipped"
+		if result.Added {
+			status = "added"
+		}
+		receipt := &UploadReceipt{
+			Status: status, Node: fromStoreNode(result.Node),
+			ComputedHash: result.ComputedHash, ComputedSize: result.ComputedSize,
+		}
+		if err := wsjson.Write(ctx, conn, webUploadMessage{
+			Type: "receipt", RequestID: request.requestID, Receipt: receipt,
+		}); err != nil {
+			return
+		}
+	}
+}
+
+func validateWebUploadBegin(
+	ctx context.Context,
+	d Deps,
+	begin webUploadMessage,
+) (webUploadRequest, *Error) {
+	if begin.Type != "begin" || begin.RequestID == "" || len(begin.RequestID) > 128 {
+		return webUploadRequest{}, NewError(http.StatusUnprocessableEntity, "validation",
+			"upload begin requires a bounded request identity")
+	}
+	name, err := store.NormalizeName(begin.Name)
+	if err != nil {
+		return webUploadRequest{}, NewError(http.StatusUnprocessableEntity, "invalid_name", err.Error())
+	}
+	parsedHash, err := packstore.ParseHash(begin.ExpectedHash)
+	if err != nil || parsedHash.String() != begin.ExpectedHash {
+		return webUploadRequest{}, NewError(http.StatusUnprocessableEntity, "validation",
+			"expected_hash must be canonical lowercase SHA-256")
+	}
+	if begin.ExpectedSize < 0 || begin.ExpectedSize > blob.MaxIngestBytes {
+		return webUploadRequest{}, NewError(http.StatusUnprocessableEntity, "validation",
+			fmt.Sprintf("expected_size must be between 0 and %d", blob.MaxIngestBytes))
+	}
+	mimeType, err := uploadMediaType(begin.MIMEType)
+	if err != nil {
+		return webUploadRequest{}, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+	}
+	parent, err := d.Store.NodeByID(ctx, begin.ParentID)
+	switch {
+	case errors.Is(err, store.ErrNotFound) || (err == nil && parent.TrashedAt != nil):
+		return webUploadRequest{}, NewError(http.StatusNotFound, "not_found",
+			"upload destination does not exist")
+	case err != nil:
+		var problem *Error
+		if errors.As(FromStoreError(err), &problem) {
+			return webUploadRequest{}, problem
+		}
+		return webUploadRequest{}, NewError(http.StatusInternalServerError, "internal",
+			"could not inspect the upload destination")
+	case !parent.IsDir():
+		return webUploadRequest{}, NewError(http.StatusConflict, "not_dir",
+			"upload destination is not a directory")
+	}
+	return webUploadRequest{
+		requestID: begin.RequestID, parentID: begin.ParentID, name: name,
+		mimeType: mimeType, expectedHash: begin.ExpectedHash, expectedSize: begin.ExpectedSize,
+	}, nil
+}
+
+func executeWebUpload(
+	ctx context.Context,
+	d Deps,
+	g *gate,
+	request webUploadRequest,
+	reader *webUploadReader,
+) (result ingest.UploadResult, retErr error) {
+	retErr = g.mutate(func() error {
+		return d.Blobs.WithMutation(ctx, func() error {
+			limited := &io.LimitedReader{R: reader, N: request.expectedSize + 1}
+			ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
+			prepared, err := ing.PrepareUpload(
+				ctx, request.parentID, request.name, request.mimeType, limited,
+				request.expectedHash, request.expectedSize,
+			)
+			if err != nil {
+				return err
+			}
+			result, err = prepared.Commit(ctx)
+			return err
+		})
+	})
+	return result, retErr
+}
+
+type webUploadReader struct {
+	ctx       context.Context
+	conn      *websocket.Conn
+	requestID string
+	current   io.Reader
+	ended     bool
+}
+
+func (r *webUploadReader) Read(p []byte) (int, error) {
+	for {
+		if r.current != nil {
+			n, err := r.current.Read(p)
+			if errors.Is(err, io.EOF) {
+				r.current = nil
+				if n > 0 {
+					return n, nil
+				}
+				continue
+			}
+			return n, err
+		}
+		messageType, next, err := r.conn.Reader(r.ctx)
+		if err != nil {
+			return 0, fmt.Errorf("reading browser upload frame: %w", err)
+		}
+		switch messageType {
+		case websocket.MessageBinary:
+			r.current = next
+		case websocket.MessageText:
+			var terminal webUploadMessage
+			decoder := json.NewDecoder(io.LimitReader(next, 4096))
+			if err := decoder.Decode(&terminal); err != nil || terminal.RequestID != r.requestID {
+				return 0, errWebUploadProtocol
+			}
+			r.ended = true
+			switch terminal.Type {
+			case "end":
+				return 0, io.EOF
+			case "cancel":
+				return 0, errWebUploadCanceled
+			default:
+				return 0, errWebUploadProtocol
+			}
+		default:
+			return 0, errWebUploadProtocol
+		}
+	}
+}
+
+func writeWebUploadProblem(
+	ctx context.Context,
+	conn *websocket.Conn,
+	requestID string,
+	problem *Error,
+) error {
+	if err := wsjson.Write(ctx, conn, webUploadMessage{
+		Type: "error", RequestID: requestID, Status: problem.Status,
+		Code: problem.Code, Detail: problem.Detail,
+	}); err != nil {
+		return fmt.Errorf("writing browser upload problem: %w", err)
+	}
+	return nil
+}
+
+func webUploadProof(secret [sha256.Size]byte, token, nonce string) string {
+	mac := hmac.New(sha256.New, secret[:])
+	_, _ = mac.Write([]byte(webUploadProofDomain))
+	_, _ = mac.Write([]byte(token))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(nonce))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/internal/api/web_upload_inactivity_test.go
+++ b/internal/api/web_upload_inactivity_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebUploadInactivityReleasesMutationGate(t *testing.T) {
+	g := NewOperationGate()
+	result := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			result <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+		if err := wsjson.Write(r.Context(), conn, webUploadMessage{
+			Type: "ready", RequestID: "stalled",
+		}); err != nil {
+			result <- err
+			return
+		}
+		reader := &webUploadReader{
+			ctx: r.Context(), conn: conn, requestID: "stalled",
+			inactivity: 25 * time.Millisecond,
+		}
+		result <- g.mutate(func() error {
+			_, err := reader.Read(make([]byte, 1))
+			return err
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	conn, response, err := websocket.Dial(
+		t.Context(), "ws"+strings.TrimPrefix(server.URL, "http"), nil,
+	)
+	require.NoError(t, err)
+	if response != nil && response.Body != nil {
+		require.NoError(t, response.Body.Close())
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+	var ready webUploadMessage
+	require.NoError(t, wsjson.Read(t.Context(), conn, &ready))
+	require.Equal(t, "ready", ready.Type)
+
+	select {
+	case err := <-result:
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded, err)
+	case <-time.After(time.Second):
+		t.Fatal("stalled upload did not release its mutation lease")
+	}
+	require.NoError(t, g.Maintain(func() error { return nil }))
+}

--- a/internal/api/web_upload_test.go
+++ b/internal/api/web_upload_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
@@ -131,4 +133,67 @@ func TestBrowserUploadUsesAuthenticatedPinnedChannel(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, reader.Close())
 	assert.Equal(t, content, stored)
+}
+
+func TestServerShutdownDrainsActiveBrowserUpload(t *testing.T) {
+	gate := api.NewOperationGate()
+	ts, s := newTestServer(t, func(d *api.Deps) {
+		d.Gate = gate
+	})
+	destination, err := s.Mkdir(t.Context(), s.RootID(), "Reports")
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(
+		http.MethodPost, ts.URL+"/api/daemon/web-session", nil,
+	)
+	require.NoError(t, err)
+	response, err := ts.Client().Do(request)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, response.StatusCode)
+	var session struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&session))
+	require.NoError(t, response.Body.Close())
+
+	conn, response, err := websocket.Dial(
+		t.Context(),
+		"ws"+strings.TrimPrefix(ts.URL, "http")+"/api/daemon/web-upload",
+		&websocket.DialOptions{
+			HTTPHeader: http.Header{"Origin": {strings.TrimSuffix(testWebURL, "/")}},
+		},
+	)
+	require.NoError(t, err)
+	if response != nil && response.Body != nil {
+		require.NoError(t, response.Body.Close())
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+	require.NoError(t, wsjson.Write(t.Context(), conn, map[string]any{
+		"type": "authenticate", "token": session.Token,
+		"nonce": "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE",
+	}))
+	var message struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, wsjson.Read(t.Context(), conn, &message))
+	require.Equal(t, "authenticated", message.Type)
+
+	content := []byte("incomplete")
+	digest := sha256.Sum256(content)
+	require.NoError(t, wsjson.Write(t.Context(), conn, map[string]any{
+		"type":          "begin",
+		"request_id":    "shutdown-test",
+		"parent_id":     destination.ID,
+		"name":          "incomplete.txt",
+		"mime_type":     "text/plain",
+		"expected_hash": hex.EncodeToString(digest[:]),
+		"expected_size": len(content),
+	}))
+	require.NoError(t, wsjson.Read(t.Context(), conn, &message))
+	require.Equal(t, "ready", message.Type)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, s.Server.Shutdown(shutdownCtx))
+	require.NoError(t, gate.Maintain(func() error { return nil }))
 }

--- a/internal/api/web_upload_test.go
+++ b/internal/api/web_upload_test.go
@@ -1,0 +1,97 @@
+package api_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestBrowserUploadUsesAuthenticatedPinnedChannel(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	destination, err := s.Mkdir(t.Context(), s.RootID(), "Reports")
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(
+		http.MethodPost, ts.URL+"/api/daemon/web-session", nil,
+	)
+	require.NoError(t, err)
+	response, err := ts.Client().Do(request)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, response.StatusCode)
+	var session struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&session))
+	require.NoError(t, response.Body.Close())
+
+	socketURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/api/daemon/web-upload"
+	conn, response, err := websocket.Dial(t.Context(), socketURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": {strings.TrimSuffix(testWebURL, "/")}},
+	})
+	require.NoError(t, err)
+	if response != nil && response.Body != nil {
+		require.NoError(t, response.Body.Close())
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	require.NoError(t, wsjson.Write(t.Context(), conn, map[string]any{
+		"type": "authenticate", "token": session.Token,
+		"nonce": "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE",
+	}))
+	var message struct {
+		Type      string            `json:"type"`
+		RequestID string            `json:"request_id"`
+		Proof     string            `json:"proof"`
+		Receipt   api.UploadReceipt `json:"receipt"`
+	}
+	require.NoError(t, wsjson.Read(t.Context(), conn, &message))
+	require.Equal(t, "authenticated", message.Type)
+	require.NotEmpty(t, message.Proof)
+
+	content := []byte("quarterly")
+	digest := sha256.Sum256(content)
+	const requestID = "browser-test"
+	require.NoError(t, wsjson.Write(t.Context(), conn, map[string]any{
+		"type":          "begin",
+		"request_id":    requestID,
+		"parent_id":     destination.ID,
+		"name":          "quarterly.txt",
+		"mime_type":     "text/plain",
+		"expected_hash": hex.EncodeToString(digest[:]),
+		"expected_size": len(content),
+	}))
+	require.NoError(t, wsjson.Read(t.Context(), conn, &message))
+	require.Equal(t, "ready", message.Type)
+	require.Equal(t, requestID, message.RequestID)
+	require.NoError(t, conn.Write(
+		t.Context(), websocket.MessageBinary, content,
+	))
+	require.NoError(t, wsjson.Write(t.Context(), conn, map[string]any{
+		"type": "end", "request_id": requestID,
+	}))
+	require.NoError(t, wsjson.Read(t.Context(), conn, &message))
+	require.Equal(t, "receipt", message.Type)
+	require.Equal(t, requestID, message.RequestID)
+	assert.Equal(t, "added", message.Receipt.Status)
+	require.NotNil(t, message.Receipt.Node.ParentID)
+	assert.Equal(t, destination.ID, *message.Receipt.Node.ParentID)
+	assert.Equal(t, "quarterly.txt", message.Receipt.Node.Name)
+	reader, err := s.Blobs.OpenContext(t.Context(), message.Receipt.Node.BlobHash)
+	require.NoError(t, err)
+	stored, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, content, stored)
+}

--- a/internal/api/web_upload_test.go
+++ b/internal/api/web_upload_test.go
@@ -18,7 +18,10 @@ import (
 )
 
 func TestBrowserUploadUsesAuthenticatedPinnedChannel(t *testing.T) {
-	ts, s := newTestServer(t, nil)
+	gate := api.NewOperationGate()
+	ts, s := newTestServer(t, func(d *api.Deps) {
+		d.Gate = gate
+	})
 	destination, err := s.Mkdir(t.Context(), s.RootID(), "Reports")
 	require.NoError(t, err)
 
@@ -54,6 +57,7 @@ func TestBrowserUploadUsesAuthenticatedPinnedChannel(t *testing.T) {
 		Type      string            `json:"type"`
 		RequestID string            `json:"request_id"`
 		Proof     string            `json:"proof"`
+		Code      string            `json:"code"`
 		Receipt   api.UploadReceipt `json:"receipt"`
 	}
 	require.NoError(t, wsjson.Read(t.Context(), conn, &message))
@@ -62,6 +66,39 @@ func TestBrowserUploadUsesAuthenticatedPinnedChannel(t *testing.T) {
 
 	content := []byte("quarterly")
 	digest := sha256.Sum256(content)
+	maintenanceHeld := make(chan struct{})
+	releaseMaintenance := make(chan struct{})
+	maintenanceDone := make(chan error, 1)
+	go func() {
+		maintenanceDone <- gate.Maintain(func() error {
+			close(maintenanceHeld)
+			<-releaseMaintenance
+			return nil
+		})
+	}()
+	<-maintenanceHeld
+	t.Cleanup(func() {
+		select {
+		case <-releaseMaintenance:
+		default:
+			close(releaseMaintenance)
+		}
+	})
+	require.NoError(t, wsjson.Write(t.Context(), conn, map[string]any{
+		"type":          "begin",
+		"request_id":    "busy-browser-test",
+		"parent_id":     destination.ID,
+		"name":          "quarterly.txt",
+		"mime_type":     "text/plain",
+		"expected_hash": hex.EncodeToString(digest[:]),
+		"expected_size": len(content),
+	}))
+	require.NoError(t, wsjson.Read(t.Context(), conn, &message))
+	require.Equal(t, "error", message.Type)
+	require.Equal(t, "maintenance_busy", message.Code)
+	close(releaseMaintenance)
+	require.NoError(t, <-maintenanceDone)
+
 	const requestID = "browser-test"
 	require.NoError(t, wsjson.Write(t.Context(), conn, map[string]any{
 		"type":          "begin",

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -41,9 +41,9 @@ type Client struct {
 }
 
 // WebSessionURL asks the ownership-proven daemon for a daemon-lifetime,
-// read-only browser credential and returns it in the local portal fragment.
-// The master API key stays on the client's pinned connection and never enters
-// the browser.
+// scoped browser credential and a daemon-lifetime upload proof secret, then
+// returns both in the local portal fragment. The master API key stays on the
+// client's pinned connection and never enters the browser.
 func (c *Client) WebSessionURL(ctx context.Context) (string, error) {
 	apiURL, err := url.Parse(c.base)
 	if err != nil {
@@ -56,14 +56,19 @@ func (c *Client) WebSessionURL(ctx context.Context) (string, error) {
 		return "", errors.New("daemon client cannot produce an authenticated web URL")
 	}
 	var session struct {
-		Token string `json:"token"`
-		URL   string `json:"url"`
+		Token        string `json:"token"`
+		UploadSecret string `json:"upload_secret"`
+		URL          string `json:"url"`
 	}
 	if err := c.do(ctx, http.MethodPost, "/api/daemon/web-session", nil, nil, &session); err != nil {
 		return "", err
 	}
 	if session.Token == "" {
 		return "", errors.New("daemon returned an empty browser session")
+	}
+	uploadSecret, err := base64.RawURLEncoding.DecodeString(session.UploadSecret)
+	if err != nil || len(uploadSecret) != sha256.Size {
+		return "", errors.New("daemon returned an invalid browser upload secret")
 	}
 	u, err := url.Parse(session.URL)
 	if err != nil {
@@ -80,7 +85,10 @@ func (c *Client) WebSessionURL(ctx context.Context) (string, error) {
 	u.Path = "/"
 	u.RawPath = ""
 	u.RawQuery = ""
-	u.Fragment = url.Values{"web_session": {session.Token}}.Encode()
+	u.Fragment = url.Values{
+		"web_session":       {session.Token},
+		"web_upload_secret": {session.UploadSecret},
+	}.Encode()
 	return u.String(), nil
 }
 

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "51"
+	daemonProtocolVersion = "52"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/web/bootstrap.go
+++ b/internal/web/bootstrap.go
@@ -17,7 +17,7 @@ const launchDirName = "web-launch"
 
 // WriteBootstrap writes the browser-session handoff beneath the owner-private
 // vault root and returns a credential-free file URL suitable for an OS browser
-// launcher. The handoff carries only a daemon-lifetime, read-only token; the
+// launcher. The handoff carries only daemon-lifetime scoped credentials; the
 // vault API key never enters this file.
 func WriteBootstrap(root, authenticatedURL string) (string, error) {
 	if root == "" {
@@ -33,6 +33,7 @@ func WriteBootstrap(root, authenticatedURL string) (string, error) {
 		strings.HasSuffix(strings.ToLower(host), ".localhost")
 	values, queryErr := url.ParseQuery(target.Fragment)
 	if queryErr != nil || values.Get("web_session") == "" ||
+		values.Get("web_upload_secret") == "" ||
 		(!localName && (ip == nil || !ip.IsLoopback())) {
 		return "", errors.New("web bootstrap requires an authenticated loopback URL")
 	}

--- a/internal/web/bootstrap_test.go
+++ b/internal/web/bootstrap_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestWriteBootstrapKeepsCredentialsOutOfLaunchURL(t *testing.T) {
 	root := t.TempDir()
-	authenticated := "http://docbank-0123456789abcdef.localhost:43210/#web_session=private%20session"
+	authenticated := "http://docbank-0123456789abcdef.localhost:43210/#web_session=private%20session&web_upload_secret=proof"
 	launchURL, err := WriteBootstrap(root, authenticated)
 	require.NoError(t, err)
 	assert.NotContains(t, launchURL, "private")
@@ -36,7 +36,8 @@ func TestWriteBootstrapKeepsCredentialsOutOfLaunchURL(t *testing.T) {
 	defer func() { _ = file.Close() }()
 	raw, err := os.ReadFile(path)
 	require.NoError(t, err)
-	assert.Contains(t, string(raw), authenticated)
+	assert.Contains(t, string(raw), "web_session=private%20session")
+	assert.Contains(t, string(raw), "web_upload_secret=proof")
 	assert.Contains(t, string(raw), "location.replace")
 	assert.NotContains(t, string(raw), `<a href=`)
 }
@@ -45,12 +46,13 @@ func TestWriteBootstrapRejectsUnauthenticatedDestination(t *testing.T) {
 	for _, destination := range []string{
 		"https://127.0.0.1:43210/#web_session=private",
 		"http://127.0.0.1:43210/#api_key=private",
+		"http://127.0.0.1:43210/#web_session=private",
 		"",
 	} {
 		_, err := WriteBootstrap(t.TempDir(), destination)
 		require.Error(t, err, destination)
 	}
-	_, err := WriteBootstrap("", "http://127.0.0.1:43210/#web_session=private")
+	_, err := WriteBootstrap("", "http://127.0.0.1:43210/#web_session=private&web_upload_secret=proof")
 	require.Error(t, err)
 }
 
@@ -76,7 +78,7 @@ func TestFallbackRemovesCredentialFragment(t *testing.T) {
 
 func TestRemoveBootstrapRemovesCredentialHandoff(t *testing.T) {
 	root := t.TempDir()
-	_, err := WriteBootstrap(root, "http://127.0.0.1:43210/#web_session=private")
+	_, err := WriteBootstrap(root, "http://127.0.0.1:43210/#web_session=private&web_upload_secret=proof")
 	require.NoError(t, err)
 	require.NoError(t, RemoveBootstrap(root))
 	require.NoDirExists(t, filepath.Join(root, launchDirName))

--- a/internal/web/bootstrap_unix_test.go
+++ b/internal/web/bootstrap_unix_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestWriteBootstrapAppliesOwnerOnlyUnixModes(t *testing.T) {
 	root := t.TempDir()
-	_, err := WriteBootstrap(root, "http://127.0.0.1:43210/#web_session=private")
+	_, err := WriteBootstrap(root, "http://127.0.0.1:43210/#web_session=private&web_upload_secret=proof")
 	require.NoError(t, err)
 	dir := filepath.Join(root, launchDirName)
 	dirInfo, err := os.Stat(dir)

--- a/internal/web/bootstrap_windows_test.go
+++ b/internal/web/bootstrap_windows_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestWriteBootstrapAppliesRestrictedWindowsDACL(t *testing.T) {
 	root := t.TempDir()
-	_, err := WriteBootstrap(root, "http://127.0.0.1:43210/#web_session=private")
+	_, err := WriteBootstrap(root, "http://127.0.0.1:43210/#web_session=private&web_upload_secret=proof")
 	require.NoError(t, err)
 	dir := filepath.Join(root, launchDirName)
 	require.NoError(t, safefileio.ValidatePrivateDir(dir))


### PR DESCRIPTION
Docbank’s web application can now add local files to the folder a person is already browsing. Before this change, the primary human interface could inspect and retrieve documents, but adding even one file meant leaving the browser for the CLI.

The upload drawer makes the byte-authority contract visible. It hashes each file locally in bounded memory, then streams it to the daemon, which independently computes the SHA-256 and size. The interface reports **Added** or **Already present** only after validating the daemon’s terminal receipt. Files are independent queue entries, so one failure remains retryable without making successful uploads ambiguous. The daemon reserves mutation access and revalidates the destination before it asks for bytes; a maintenance or destination error therefore leaves the same channel ready for the next file. Cancellation after the final bytes are sent reports an unconfirmed outcome, refreshes the folder, and retires the channel rather than claiming authority the browser did not witness. An idempotent retry may resolve the same provenance after the existing node has been renamed; that valid **Already present** receipt remains distinct from collision naming for a newly added file. If the channel disappears after transmission begins, the drawer stays open, marks that file **Unconfirmed**, refreshes the destination, stops the remaining queue, and disables further selection until `docbank web` establishes a new proved channel.

![The actual Docbank web application after two synthetic files received matching server receipts](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-verified-upload/web-verified-upload.png?v=d122534)

*Actual daemon-served interface using a temporary synthetic vault; no private corpus data is present.*

A selected file is not sent through an ordinary reconnectable browser request. When `docbank web` opens the page, it establishes one persistent upload channel and requires the current daemon to prove a fresh, daemon-lifetime secret before any file bytes leave the browser. If that connection breaks because the daemon stops, the session is revoked, or the loopback listener disappears, upload is permanently disabled for that page. The page never reconnects to whatever process might later claim the same port; the operator must run `docbank web` again. Authentication, readiness, backpressure, cancellation acknowledgment, and terminal receipt waits are cancellable or bounded, so a silent peer cannot leave the interface stuck indefinitely. The page’s content policy explicitly permits the exact daemon WebSocket origin rather than relying on browsers to interpret `self` consistently. On the daemon side, a resettable 30-second inactivity deadline applies between upload frames while mutation ownership is held, so a stalled browser cannot block storage maintenance indefinitely. During shutdown, Docbank closes every accepted upload channel and waits for its handler to release mutation and storage ownership before closing the vault.

This remains a deliberately narrow permission rather than general browser mutation access. The proved channel can create or idempotently resolve files only beneath the stable live directory selected in the browser. The ordinary browser token cannot call the HTTP upload endpoint, ingest server paths, recursively import folders, replace existing versions, or perform any other document, audit, backup, or maintenance mutation.

I exercised the rendered flow end to end with two synthetic files, retried both to confirm idempotent **Already present** receipts, and retrieved them again to confirm byte-for-byte and SHA-256 equality. The temporary vault, browser profile, source files, binary, and logs were removed afterward.