### PR TITLE
Move documents to recoverable trash from the web

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ Instructions for autonomous coding agents working in this repository.
   `frontend/package-lock.json`. Run `make frontend-test` for type, kit-ui,
   unit, and production-build checks. Release CI builds the frontend once and
   embeds those exact assets in all six platform archives.
+- Real web screenshots use the repository-owned Playwright harness in
+  `frontend/screenshots/`. Run `make frontend-screenshots`; captures must use
+  its temporary synthetic vault and real daemon, never a developer vault or
+  mocked API data. Generated images stay under `.superpowers/screenshots/`
+  until they are visually inspected and attached to the relevant pull request.
 
 ## Private Data Boundary
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DEFAULT_GOLANGCI_LINT_CACHE := $(shell git rev-parse --path-format=absolute --gi
 GOLANGCI_LINT_CACHE ?= $(DEFAULT_GOLANGCI_LINT_CACHE)
 export GOLANGCI_LINT_CACHE
 
-.PHONY: build install clean test test-v release-scripts-test frontend frontend-test frontend-dev fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve docs-link docs-deploy help
+.PHONY: build install clean test test-v release-scripts-test frontend frontend-test frontend-dev frontend-screenshots fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve docs-link docs-deploy help
 
 build: frontend
 	CGO_ENABLED=1 go build -tags "$(BUILD_TAGS)" -ldflags="$(LDFLAGS)" -o docbank ./cmd/docbank
@@ -53,11 +53,15 @@ frontend-test:
 	cd frontend && npm ci
 	cd frontend && npm run check
 	cd frontend && npm run check:kit-ui
+	cd frontend && npm run screenshots:check
 	cd frontend && npm test
 	cd frontend && npm run build
 
 frontend-dev:
 	cd frontend && npm run dev
+
+frontend-screenshots:
+	cd frontend && npm run screenshots
 
 fmt:
 	go fmt ./...
@@ -118,4 +122,4 @@ docs-deploy: docs-build
 	vercel deploy docs/site --prod --yes
 
 help:
-	@echo "Targets: build install clean test test-v release-scripts-test frontend frontend-test frontend-dev fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve docs-link docs-deploy"
+	@echo "Targets: build install clean test test-v release-scripts-test frontend frontend-test frontend-dev frontend-screenshots fmt lint lint-ci tidy install-hooks docs-install docs-build docs-serve docs-link docs-deploy"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Four commitments:
 - A scoped kit-ui web application for verified local-file upload, virtual-tree browsing, sortable
   document analysis, tag browsing, tag-filtered extracted-text search,
   complete current authority, verified current and historical content download,
+  recoverable move-to-trash,
   permanent protection and event history, immutable versions and provenance,
   configured backup recovery points, daemon background-job status, and an honest
   loose-file/live-packed/dead-packed storage breakdown

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "52", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "53", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "52", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "53", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "52", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "53", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "52", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "53", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ The ordinary workflow stays direct:
 ```bash
 docbank add ~/Documents/taxes --dest /taxes    # import a folder; sources untouched
 docbank tree /taxes                            # browse the virtual tree
-docbank web                                    # open the local read-only browser
+docbank web                                    # open the scoped local browser
 docbank search "insurance"                     # ranked name and verified plain-text search
 docbank search "return" --tag taxes             # narrow the same ranking by stable tag identity
 docbank get /taxes/2026/return.pdf ./return.pdf # verify, then publish a complete local file
@@ -158,7 +158,7 @@ content versions with verified replacement, reversion, pruning, and
 lookup by content hash (`refs`), tags, permanent audited history with
 independent verification, loose and packed storage with explicit
 maintenance, whole-vault integrity verification, incremental backup
-create/verify/restore, a read-only web application and TUI, and the embedded
+create/verify/restore, a scoped web application, read-only TUI, and the embedded
 Go API. Docbank is not yet a
 stable 1.0; the [Roadmap](roadmap.md) gives the product direction.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: read-only analytical tree/search/detail, audited-history, and daemon-job inspection implemented; web tags, version history, provenance, and verified current/historical content download implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: analytical tree/search/detail, audited-history, daemon-job inspection, web tags, version history, provenance, verified current/historical content download, verified upload, and recoverable trash implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -136,7 +136,7 @@ and authenticated API.
 ## Phase 3 — Human applications
 
 The kit-ui web portal is the primary human interface over the authenticated
-daemon API. Its first read-only slice implements responsive virtual-tree
+daemon API. Its browsing foundation implements responsive virtual-tree
 browsing, analytical sorting, name and extracted-text search, and complete
 current document authority. A selected live file can be downloaded through
 bounded daemon staging: progress is visible, content is terminally verified
@@ -149,11 +149,12 @@ identity can drive either a live assignment view or a text-search filter.
 Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
 portal also uploads local files through the same caller-declared and
-server-verified byte-identity contract used by remote agents, lists configured
+server-verified byte-identity contract used by remote agents, moves a selected
+revision-bound live node to recoverable trash after explicit confirmation, lists configured
 backup recovery points, reports current and terminal daemon background jobs,
 and separates physical loose files, live packed content, complete pack payload,
 and logically dead payload awaiting explicit repack. Future slices cover tag
-mutation and broader metadata, version comparison, trash, and storage
+mutation and broader metadata, version comparison, trash restoration, and storage
 maintenance.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -16,7 +16,8 @@ opens its local web application. Choose local files for verified upload,
 navigate the virtual tree, sort a folder by document name, size, or modification
 time, search names and extracted text, and inspect the selected document's stable
 node ID, revision, current version ID, SHA-256 identity, exact size, and media
-type. The authority card also shows every tag assigned to the selected file or
+type. A selected live file or folder can be moved to recoverable trash after an
+explicit confirmation. The authority card also shows every tag assigned to the selected file or
 folder. Selecting a tag browses its live assignments, while search can require
 the same exact tag identity. Protected documents expose
 their newest-first permanent audit timeline and complete event authority. The
@@ -61,6 +62,22 @@ even when the card wraps it across lines. Every selected node also shows its
 assigned tag names. Hovering a tag shows its stable UUID and vault-wide
 assignment count; the bounded tag stack expands in place when a node carries
 more than six.
+
+## Move a node to recoverable trash
+
+Choose **Move to trash** on the selected live file or folder. Docbank opens a
+confirmation that names the complete virtual path, stable node ID, and revision
+being acted upon. A folder and its live descendants move to trash together.
+
+The daemon applies the mutation only if that exact node revision is still
+current. If another person, agent, or CLI command changed the node first, the
+browser keeps the confirmation open and asks you to refresh instead of
+silently acting on stale authority. A successful receipt removes the selection
+and refreshes the current folder, search, or tag view.
+
+This action is deliberately recoverable. It does not empty trash, garbage
+collect content, reclaim packed space, or erase permanent audited history.
+Listing and restoring trash remain CLI or authenticated API workflows.
 
 ## Upload verified documents
 
@@ -307,19 +324,21 @@ in page memory. Ordinary requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
 search, tag-definition and assignment reads, immutable-version, provenance, audit-status, audit-history,
 background-job, physical-storage-status, configured backup-snapshot-list,
-and verified-download preparation
-used by this interface.
+verified-download preparation, and revision-bound move-to-trash request used by
+this interface.
 Download preparation may write only owner-private temporary bytes and issue
 one exact, expiring file ticket. Upload uses a separate, never-reconnecting
 WebSocket authenticated by a challenge proof over the upload secret. No file
 bytes are sent until that proof succeeds. It may create only file nodes
 beneath the stable live directory selected in the browser and must satisfy the
 same caller-declared/server-computed byte identity as every remote writer. The
-session cannot perform any other document mutation, enroll audit scopes, run
-independent verification, or call backup creation, verification, restore,
-maintenance, configuration, or general API endpoints. Its sole backup
-capability is listing the immutable snapshots in the repository already
-configured for this daemon.
+trash request can target only the stable selected node and must carry its
+current revision, so a stale browser view cannot move changed state. The
+session cannot restore or empty trash, perform any other document mutation,
+enroll audit scopes, run independent verification, or call backup creation,
+verification, restore, maintenance, configuration, or general API endpoints.
+Its sole backup capability is listing the immutable snapshots in the
+repository already configured for this daemon.
 
 The lock button revokes the session in daemon memory and clears the page.
 Every remaining browser session and its dedicated browser origin disappear
@@ -353,7 +372,7 @@ leave the browser constructing child paths beneath an obsolete name.
 
 The current web application does not compare versions, recursively import
 folders, edit, revert, prune, move, create or change tags and
-assignments, trash, enroll audit scopes, run independent audit verification,
+assignments, restore trash, enroll audit scopes, run independent audit verification,
 or run maintenance, backup, verification, or restore operations.
 Use the corresponding CLI or authenticated HTTP endpoint for those workflows.
 Future web workflows will require deliberately expanded browser-session

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -341,7 +341,7 @@
     },
     "node_modules/@kenn-io/kit-ui": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
+      "resolved": "git+https://github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
       "integrity": "sha512-of4b8+I+kJMYR0/gbF0u7XjGt1V0uQ6QfyoL6qSQiLnTIYnjR/3IZBt10Hb4MdlUN0b/BSNGRb5Ehifz7/4fcw==",
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "svelte": "5.56.4"
       },
       "devDependencies": {
+        "@playwright/test": "1.61.1",
         "@sveltejs/vite-plugin-svelte": "7.2.0",
         "@testing-library/svelte": "5.3.1",
         "@tsconfig/svelte": "5.0.8",
@@ -340,7 +341,7 @@
     },
     "node_modules/@kenn-io/kit-ui": {
       "version": "0.0.1",
-      "resolved": "git+https://github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
+      "resolved": "git+ssh://git@github.com/kenn-io/kit-ui.git#b35e4ca7df66969f4650327d6e315986afef8716",
       "integrity": "sha512-of4b8+I+kJMYR0/gbF0u7XjGt1V0uQ6QfyoL6qSQiLnTIYnjR/3IZBt10Hb4MdlUN0b/BSNGRb5Ehifz7/4fcw==",
       "license": "Apache-2.0",
       "bin": {
@@ -1142,6 +1143,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -2992,6 +3009,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
     "build": "vp build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:kit-ui": "kit-ui-check src",
+    "screenshots": "node screenshots/run.mjs",
+    "screenshots:check": "tsc -p screenshots/tsconfig.json --noEmit",
     "test": "vp test run"
   },
   "dependencies": {
@@ -20,6 +22,7 @@
     "svelte": "5.56.4"
   },
   "devDependencies": {
+    "@playwright/test": "1.61.1",
     "@sveltejs/vite-plugin-svelte": "7.2.0",
     "@testing-library/svelte": "5.3.1",
     "@tsconfig/svelte": "5.0.8",

--- a/frontend/screenshots/README.md
+++ b/frontend/screenshots/README.md
@@ -1,0 +1,30 @@
+# Web screenshots
+
+This Playwright harness captures the actual daemon-served Docbank interface
+against a temporary synthetic vault. It does not use mocked API responses or a
+developer's existing vault.
+
+Install Chromium once:
+
+```sh
+cd frontend
+npx playwright install chromium
+```
+
+Then run from the repository root:
+
+```sh
+make frontend-screenshots
+```
+
+The command builds the current frontend and Docbank binary, creates and seeds
+an owner-private temporary vault, opens the daemon-issued browser session,
+captures the requested state, stops the daemon, and removes the vault.
+Generated images are written beneath `.superpowers/screenshots/` for visual
+inspection and PR attachment; they are intentionally not committed.
+
+Pass ordinary Playwright arguments after `--` to select a case:
+
+```sh
+npm --prefix frontend run screenshots -- --grep "trash confirmation"
+```

--- a/frontend/screenshots/README.md
+++ b/frontend/screenshots/README.md
@@ -8,7 +8,8 @@ Install Chromium once:
 
 ```sh
 cd frontend
-npx playwright install chromium
+npm ci
+node node_modules/@playwright/test/cli.js install chromium
 ```
 
 Then run from the repository root:

--- a/frontend/screenshots/playwright.config.ts
+++ b/frontend/screenshots/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(here, "..", "..");
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: /.*\.screenshot\.ts/,
+  fullyParallel: false,
+  workers: 1,
+  timeout: 120_000,
+  expect: {
+    timeout: 15_000,
+  },
+  outputDir: path.join(repositoryRoot, ".superpowers", "playwright"),
+  reporter: "line",
+  use: {
+    ...devices["Desktop Chrome"],
+    viewport: { width: 1440, height: 960 },
+    deviceScaleFactor: 1,
+    colorScheme: "dark",
+    trace: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 960 },
+        deviceScaleFactor: 1,
+        colorScheme: "dark",
+      },
+    },
+  ],
+});

--- a/frontend/screenshots/run.mjs
+++ b/frontend/screenshots/run.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(here, "..");
+const repositoryRoot = path.resolve(frontendRoot, "..");
+
+const build = spawnSync("make", ["build"], {
+  cwd: repositoryRoot,
+  stdio: "inherit",
+});
+if (build.error) throw build.error;
+if (build.status !== 0) process.exit(build.status ?? 1);
+
+const playwrightCLI = path.join(
+  frontendRoot,
+  "node_modules",
+  "@playwright",
+  "test",
+  "cli.js",
+);
+const result = spawnSync(
+  process.execPath,
+  [
+    playwrightCLI,
+    "test",
+    "--config",
+    path.join(here, "playwright.config.ts"),
+    "--project",
+    "chromium",
+    ...process.argv.slice(2),
+  ],
+  {
+    cwd: frontendRoot,
+    stdio: "inherit",
+  },
+);
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/frontend/screenshots/tsconfig.json
+++ b/frontend/screenshots/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM"],
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["*.ts"]
+}

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -60,7 +60,20 @@ test.describe("Docbank web screenshots", () => {
 
     await runDocbank(["add", reports, "--dest", "/", "--progress", "plain"]);
     webURL = await runDocbank(["web", "--no-browser"]);
-    if (!webURL.startsWith("http://127.0.0.1:")) {
+    const browserURL = new URL(webURL);
+    const port = Number(browserURL.port);
+    if (
+      browserURL.protocol !== "http:" ||
+      !/^docbank-[0-9a-f]{32}\.localhost$/.test(browserURL.hostname) ||
+      !Number.isInteger(port) ||
+      port < 1 ||
+      port > 65_535 ||
+      browserURL.username !== "" ||
+      browserURL.password !== "" ||
+      browserURL.pathname !== "/" ||
+      browserURL.search !== "" ||
+      browserURL.hash === ""
+    ) {
       throw new Error("docbank web returned an unexpected browser URL");
     }
   });

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -38,6 +38,8 @@ test.describe("Docbank web screenshots", () => {
   test.beforeAll(async () => {
     workspace = await mkdtemp(path.join(tmpdir(), "docbank-screenshot-"));
     vault = path.join(workspace, "vault");
+    await mkdir(path.dirname(screenshotPath), { recursive: true, mode: 0o700 });
+    await rm(screenshotPath, { force: true });
     const reports = path.join(workspace, "synthetic", "Reports");
     await mkdir(reports, { recursive: true, mode: 0o700 });
     await writeFile(
@@ -61,15 +63,32 @@ test.describe("Docbank web screenshots", () => {
     if (!webURL.startsWith("http://127.0.0.1:")) {
       throw new Error("docbank web returned an unexpected browser URL");
     }
-    await mkdir(path.dirname(screenshotPath), { recursive: true, mode: 0o700 });
   });
 
   test.afterAll(async () => {
     if (vault) {
-      try {
-        await runDocbank(["daemon", "stop"]);
-      } catch {
-        // Cleanup below removes only this synthetic workspace.
+      let stopped = false;
+      let stopError: unknown;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          await runDocbank(["daemon", "stop"]);
+          const status = JSON.parse(
+            await runDocbank(["daemon", "status", "--json"]),
+          ) as { running?: unknown };
+          if (status.running !== false) {
+            throw new Error("synthetic Docbank daemon is still running");
+          }
+          stopped = true;
+          break;
+        } catch (cause) {
+          stopError = cause;
+        }
+      }
+      if (!stopped) {
+        throw new Error(
+          `could not stop the synthetic Docbank daemon; workspace retained at ${workspace}`,
+          { cause: stopError },
+        );
       }
     }
     if (workspace) await rm(workspace, { recursive: true, force: true });

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "@playwright/test";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(here, "..", "..");
+const binary = path.join(repositoryRoot, "docbank");
+const screenshotPath = path.join(
+  repositoryRoot,
+  ".superpowers",
+  "screenshots",
+  "web-trash-confirmation.png",
+);
+
+test.describe("Docbank web screenshots", () => {
+  let workspace = "";
+  let vault = "";
+  let webURL = "";
+
+  async function runDocbank(args: string[]): Promise<string> {
+    const result = await execFileAsync(binary, args, {
+      cwd: repositoryRoot,
+      env: {
+        ...process.env,
+        DOCBANK_HOME: vault,
+      },
+      maxBuffer: 1024 * 1024,
+      timeout: 60_000,
+    });
+    return result.stdout.trim();
+  }
+
+  test.beforeAll(async () => {
+    workspace = await mkdtemp(path.join(tmpdir(), "docbank-screenshot-"));
+    vault = path.join(workspace, "vault");
+    const reports = path.join(workspace, "synthetic", "Reports");
+    await mkdir(reports, { recursive: true, mode: 0o700 });
+    await writeFile(
+      path.join(reports, "quarterly-tax-report.txt"),
+      "Synthetic quarterly tax report for screenshot validation.\n",
+      { mode: 0o600 },
+    );
+    await writeFile(
+      path.join(reports, "filing-checklist.md"),
+      "# Filing checklist\n\n- Review totals\n- Confirm signatures\n",
+      { mode: 0o600 },
+    );
+    await writeFile(
+      path.join(reports, "supporting-schedule.csv"),
+      "category,amount\nSynthetic revenue,125000\nSynthetic expense,42000\n",
+      { mode: 0o600 },
+    );
+
+    await runDocbank(["add", reports, "--dest", "/", "--progress", "plain"]);
+    webURL = await runDocbank(["web", "--no-browser"]);
+    if (!webURL.startsWith("http://127.0.0.1:")) {
+      throw new Error("docbank web returned an unexpected browser URL");
+    }
+    await mkdir(path.dirname(screenshotPath), { recursive: true, mode: 0o700 });
+  });
+
+  test.afterAll(async () => {
+    if (vault) {
+      try {
+        await runDocbank(["daemon", "stop"]);
+      } catch {
+        // Cleanup below removes only this synthetic workspace.
+      }
+    }
+    if (workspace) await rm(workspace, { recursive: true, force: true });
+  });
+
+  test("trash confirmation", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("docbank-theme", "dark");
+    });
+    await page.goto(webURL, { waitUntil: "domcontentloaded" });
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation-duration: 0.001s !important;
+          animation-delay: 0s !important;
+          transition-duration: 0s !important;
+          caret-color: transparent !important;
+        }
+      `,
+    });
+
+    await page.getByRole("cell", { name: "Reports", exact: true }).dblclick();
+    const report = page.getByRole("cell", {
+      name: "quarterly-tax-report.txt",
+      exact: true,
+    });
+    await expect(report).toBeVisible();
+    await report.click();
+    await page.getByRole("button", { name: "Move to trash", exact: true }).click();
+
+    const confirmation = page.getByRole("dialog", {
+      name: "Move quarterly-tax-report.txt to trash",
+    });
+    await expect(confirmation).toBeVisible();
+    await expect(confirmation).toContainText("It remains recoverable from trash.");
+    await expect(confirmation).toContainText(
+      "This does not empty trash, reclaim stored bytes, or erase permanent audited history.",
+    );
+    await page.screenshot({
+      path: screenshotPath,
+      fullPage: true,
+      animations: "disabled",
+    });
+  });
+});

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -525,6 +525,35 @@
     else if (directory) void loadDirectory(directory.id, false);
   }
 
+  function handleTrashed(receipt: Node): void {
+    trashTarget = null;
+    if (selectedID === receipt.id) selectNode(undefined);
+
+    // Cached views may contain the removed node or pre-trash parent revisions.
+    // Discard them instead of allowing Back to resurrect stale authority.
+    stack = [];
+
+    const targetPath = receipt.path;
+    const directoryPath = directory?.path;
+    if (
+      targetPath &&
+      directoryPath &&
+      (directoryPath === targetPath || directoryPath.startsWith(`${targetPath}/`))
+    ) {
+      searchQuery = "";
+      activeQuery = "";
+      tagFilterID = "";
+      activeTagID = "";
+      taggedInspected = 0;
+      taggedTotal = 0;
+      taggedTrashed = 0;
+      void loadRoot();
+      void loadTagCatalog();
+      return;
+    }
+    refreshCurrentView();
+  }
+
   async function lock(): Promise<void> {
     generation += 1;
     auditGeneration += 1;
@@ -1146,11 +1175,7 @@
         node={trashTarget.node}
         path={trashTarget.path}
         onclose={() => (trashTarget = null)}
-        ontrashed={(receipt) => {
-          trashTarget = null;
-          if (selectedID === receipt.id) selectNode(undefined);
-          refreshCurrentView();
-        }}
+        ontrashed={handleTrashed}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,6 +12,7 @@
   import SearchIcon from "@lucide/svelte/icons/search";
   import TagIcon from "@lucide/svelte/icons/tag";
   import HistoryIcon from "@lucide/svelte/icons/history";
+  import Trash2Icon from "@lucide/svelte/icons/trash-2";
   import UploadIcon from "@lucide/svelte/icons/upload";
   import {
     Button,
@@ -37,6 +38,7 @@
   import JobsDrawer from "./JobsDrawer.svelte";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import StorageDrawer from "./StorageDrawer.svelte";
+  import TrashNodeModal from "./TrashNodeModal.svelte";
   import UploadDrawer from "./UploadDrawer.svelte";
   import VersionHistoryDrawer from "./VersionHistoryDrawer.svelte";
   import {
@@ -115,6 +117,7 @@
   let storageOpen = $state(false);
   let backupsOpen = $state(false);
   let uploadTarget = $state<Node | null>(null);
+  let trashTarget = $state<Row | null>(null);
   let generation = 0;
   let auditGeneration = 0;
   let tagGeneration = 0;
@@ -173,6 +176,7 @@
       storageOpen = false;
       backupsOpen = false;
       uploadTarget = null;
+      trashTarget = null;
       tagCatalog = [];
       tagCatalogListed = 0;
       selectedTags = [];
@@ -514,6 +518,13 @@
     }
   }
 
+  function refreshCurrentView(): void {
+    void loadTagCatalog();
+    if (activeQuery) void runSearch();
+    else if (activeTagID) void loadTaggedNodes(activeTagID);
+    else if (directory) void loadDirectory(directory.id, false);
+  }
+
   async function lock(): Promise<void> {
     generation += 1;
     auditGeneration += 1;
@@ -545,6 +556,7 @@
     storageOpen = false;
     backupsOpen = false;
     uploadTarget = null;
+    trashTarget = null;
     activeQuery = "";
     activeTagID = "";
     taggedInspected = 0;
@@ -963,6 +975,24 @@
                     <MapPinIcon size="14" aria-hidden="true" />
                     Provenance
                   </Button>
+                  <Button
+                    size="sm"
+                    tone="danger"
+                    surface="soft"
+                    onclick={() => {
+                      historyOpen = false;
+                      versionsOpen = false;
+                      provenanceOpen = false;
+                      jobsOpen = false;
+                      storageOpen = false;
+                      backupsOpen = false;
+                      uploadTarget = null;
+                      trashTarget = selected;
+                    }}
+                  >
+                    <Trash2Icon size="14" aria-hidden="true" />
+                    Move to trash
+                  </Button>
                 </div>
               {/if}
               <div class="audit-protection">
@@ -1011,10 +1041,30 @@
                 {/if}
               </div>
               {#if selected.node.kind === "dir"}
-                <Button size="sm" onclick={() => activate(selected)}>
-                  <FolderIcon size="14" aria-hidden="true" />
-                  Open folder
-                </Button>
+                <div class="directory-actions">
+                  <Button size="sm" onclick={() => activate(selected)}>
+                    <FolderIcon size="14" aria-hidden="true" />
+                    Open folder
+                  </Button>
+                  <Button
+                    size="sm"
+                    tone="danger"
+                    surface="soft"
+                    onclick={() => {
+                      historyOpen = false;
+                      versionsOpen = false;
+                      provenanceOpen = false;
+                      jobsOpen = false;
+                      storageOpen = false;
+                      backupsOpen = false;
+                      uploadTarget = null;
+                      trashTarget = selected;
+                    }}
+                  >
+                    <Trash2Icon size="14" aria-hidden="true" />
+                    Move to trash
+                  </Button>
+                </div>
               {/if}
             </div>
           </Card>
@@ -1086,6 +1136,20 @@
         onclose={() => (uploadTarget = null)}
         oncomplete={async () => {
           if (uploadTarget) await loadDirectory(uploadTarget.id, false);
+        }}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if trashTarget}
+      <TrashNodeModal
+        session={webSession}
+        node={trashTarget.node}
+        path={trashTarget.path}
+        onclose={() => (trashTarget = null)}
+        ontrashed={(receipt) => {
+          trashTarget = null;
+          if (selectedID === receipt.id) selectNode(undefined);
+          refreshCurrentView();
         }}
         onauthfailure={handleFailure}
       />

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -523,6 +523,7 @@
     if (activeQuery) void runSearch();
     else if (activeTagID) void loadTaggedNodes(activeTagID);
     else if (directory) void loadDirectory(directory.id, false);
+    else void loadRoot();
   }
 
   function handleTrashed(receipt: Node): void {
@@ -535,11 +536,19 @@
 
     const targetPath = receipt.path;
     const directoryPath = directory?.path;
+    rows = rows.filter(
+      (row) =>
+        row.node.id !== receipt.id &&
+        (!targetPath ||
+          (row.path !== targetPath && !row.path.startsWith(`${targetPath}/`))),
+    );
     if (
       targetPath &&
       directoryPath &&
       (directoryPath === targetPath || directoryPath.startsWith(`${targetPath}/`))
     ) {
+      directory = null;
+      rows = [];
       searchQuery = "";
       activeQuery = "";
       tagFilterID = "";
@@ -774,12 +783,7 @@
             <IconButton
               size="sm"
               ariaLabel="Refresh current view"
-              onclick={() => {
-                void loadTagCatalog();
-                if (activeQuery) void runSearch();
-                else if (activeTagID) void loadTaggedNodes(activeTagID);
-                else if (directory) void loadDirectory(directory.id, false);
-              }}
+              onclick={refreshCurrentView}
             >
               <RefreshCwIcon size="14" aria-hidden="true" />
             </IconButton>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -526,41 +526,26 @@
     else void loadRoot();
   }
 
-  function handleTrashed(receipt: Node): void {
+  function handleTrashed(_receipt: Node): void {
     trashTarget = null;
-    if (selectedID === receipt.id) selectNode(undefined);
+    selectNode(undefined);
 
     // Cached views may contain the removed node or pre-trash parent revisions.
-    // Discard them instead of allowing Back to resurrect stale authority.
+    // Return to a freshly loaded root rather than leaving the current view
+    // stranded without a valid Back destination.
     stack = [];
-
-    const targetPath = receipt.path;
-    const directoryPath = directory?.path;
-    rows = rows.filter(
-      (row) =>
-        row.node.id !== receipt.id &&
-        (!targetPath ||
-          (row.path !== targetPath && !row.path.startsWith(`${targetPath}/`))),
-    );
-    if (
-      targetPath &&
-      directoryPath &&
-      (directoryPath === targetPath || directoryPath.startsWith(`${targetPath}/`))
-    ) {
-      directory = null;
-      rows = [];
-      searchQuery = "";
-      activeQuery = "";
-      tagFilterID = "";
-      activeTagID = "";
-      taggedInspected = 0;
-      taggedTotal = 0;
-      taggedTrashed = 0;
-      void loadRoot();
-      void loadTagCatalog();
-      return;
-    }
-    refreshCurrentView();
+    directory = null;
+    rows = [];
+    searchQuery = "";
+    activeQuery = "";
+    tagFilterID = "";
+    activeTagID = "";
+    taggedInspected = 0;
+    taggedTotal = 0;
+    taggedTrashed = 0;
+    truncated = false;
+    void loadRoot();
+    void loadTagCatalog();
   }
 
   async function lock(): Promise<void> {

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -376,7 +376,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   ).toBeTruthy();
 });
 
-it("discards cached navigation when search trashes the current directory", async () => {
+it("returns to root when a nested child is trashed and refresh fails", async () => {
   history.replaceState(
     null,
     "",
@@ -416,6 +416,20 @@ it("discards cached navigation when search trashes the current directory", async
     modified_at: "2026-07-28T12:00:00Z",
     path: "/Reports",
   };
+  const quarterlyReport = {
+    id: 3,
+    parent_id: 2,
+    name: "quarterly-report.txt",
+    kind: "file",
+    current_version_id: "11111111-1111-4111-8111-111111111111",
+    blob_hash: "a".repeat(64),
+    size: 74,
+    mime_type: "text/plain",
+    revision: 1,
+    created_at: "2026-07-28T12:00:00Z",
+    modified_at: "2026-07-28T12:00:00Z",
+    path: "/Reports/quarterly-report.txt",
+  };
   const json = (value: unknown) =>
     new Response(JSON.stringify(value), {
       status: 200,
@@ -444,8 +458,8 @@ it("discards cached navigation when search trashes the current directory", async
       }
       return json({
         directory: root,
-        items: trashed ? [] : [reports],
-        total: trashed ? 0 : 1,
+        items: [reports],
+        total: 1,
         limit: 1000,
         offset: 0,
       });
@@ -453,8 +467,8 @@ it("discards cached navigation when search trashes the current directory", async
     if (url === "/api/v1/nodes/2/children?limit=1000&offset=0") {
       return json({
         directory: reports,
-        items: [],
-        total: 0,
+        items: trashed ? [] : [quarterlyReport],
+        total: trashed ? 0 : 1,
         limit: 1000,
         offset: 0,
       });
@@ -462,23 +476,16 @@ it("discards cached navigation when search trashes the current directory", async
     if (url === "/api/v1/tags?limit=1000&offset=0") {
       return json({ items: [], total: 0, limit: 1000, offset: 0 });
     }
-    if (url === "/api/v1/audit/status?node_id=2") {
+    if (url === "/api/v1/audit/status?node_id=3") {
       return json({ enabled: false, scopes: [] });
     }
-    if (url === "/api/v1/nodes/2/tags?limit=1000&offset=0") {
+    if (url === "/api/v1/nodes/3/tags?limit=1000&offset=0") {
       return json({ items: [], total: 0, limit: 1000, offset: 0 });
     }
-    if (url === "/api/v1/search?q=Reports&limit=1000") {
-      return json({
-        hits: [{ node: reports, path: "/Reports", match: "name" }],
-        limit: 1000,
-        truncated: false,
-      });
-    }
-    if (url === "/api/v1/nodes/2/trash" && init?.method === "POST") {
+    if (url === "/api/v1/nodes/3/trash" && init?.method === "POST") {
       trashed = true;
       return json({
-        ...reports,
+        ...quarterlyReport,
         revision: 2,
         trashed_at: "2026-07-28T12:01:00Z",
       });
@@ -488,22 +495,19 @@ it("discards cached navigation when search trashes the current directory", async
 
   render(App);
   await fireEvent.dblClick(await screen.findByRole("cell", { name: "Reports" }));
-  await screen.findByText("This folder is empty");
-
-  const search = screen.getByRole("searchbox", { name: "Search documents" });
-  await fireEvent.input(search, { target: { value: "Reports" } });
-  await fireEvent.submit(search.closest("form")!);
-  await screen.findByRole("cell", { name: "/Reports" });
+  await screen.findByRole("cell", { name: "quarterly-report.txt" });
 
   await fireEvent.click(screen.getByRole("button", { name: "Move to trash" }));
-  const confirmation = screen.getByRole("dialog", { name: "Move Reports to trash" });
+  const confirmation = screen.getByRole("dialog", {
+    name: "Move quarterly-report.txt to trash",
+  });
   await fireEvent.click(
     within(confirmation).getByRole("button", { name: "Move to trash" }),
   );
 
   await waitFor(() => expect(rootReads).toBe(2));
   expect(await screen.findByText("root temporarily unavailable")).toBeTruthy();
-  expect(screen.queryByRole("cell", { name: "/Reports" })).toBeNull();
+  expect(screen.queryByRole("cell", { name: "quarterly-report.txt" })).toBeNull();
   expect(
     screen.getByRole("button", { name: "Back to previous directory" }).hasAttribute(
       "disabled",
@@ -512,6 +516,6 @@ it("discards cached navigation when search trashes the current directory", async
 
   await fireEvent.click(screen.getByRole("button", { name: "Refresh current view" }));
   await waitFor(() => expect(rootReads).toBe(3));
-  expect(screen.getByText("This folder is empty")).toBeTruthy();
-  expect(screen.queryByRole("cell", { name: "/Reports" })).toBeNull();
+  expect(await screen.findByRole("cell", { name: "Reports" })).toBeTruthy();
+  expect(screen.queryByRole("cell", { name: "quarterly-report.txt" })).toBeNull();
 });

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/svelte";
 import App from "./App.svelte";
 
@@ -373,4 +374,125 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
       name: "Browse or filter: showing 1 of 1001 tags: All tags",
     }),
   ).toBeTruthy();
+});
+
+it("discards cached navigation when search trashes the current directory", async () => {
+  history.replaceState(
+    null,
+    "",
+    "/#web_session=short-lived&web_upload_secret=proof",
+  );
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+
+  const root = {
+    id: 1,
+    name: "",
+    kind: "dir",
+    size: 0,
+    revision: 1,
+    created_at: "2026-07-28T12:00:00Z",
+    modified_at: "2026-07-28T12:00:00Z",
+    path: "/",
+  };
+  const reports = {
+    id: 2,
+    parent_id: 1,
+    name: "Reports",
+    kind: "dir",
+    size: 0,
+    revision: 1,
+    created_at: "2026-07-28T12:00:00Z",
+    modified_at: "2026-07-28T12:00:00Z",
+    path: "/Reports",
+  };
+  const json = (value: unknown) =>
+    new Response(JSON.stringify(value), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  let trashed = false;
+  let rootReads = 0;
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/v1/path?path=%2F") return json(root);
+    if (url === "/api/v1/nodes/1/children?limit=1000&offset=0") {
+      rootReads += 1;
+      return json({
+        directory: root,
+        items: trashed ? [] : [reports],
+        total: trashed ? 0 : 1,
+        limit: 1000,
+        offset: 0,
+      });
+    }
+    if (url === "/api/v1/nodes/2/children?limit=1000&offset=0") {
+      return json({
+        directory: reports,
+        items: [],
+        total: 0,
+        limit: 1000,
+        offset: 0,
+      });
+    }
+    if (url === "/api/v1/tags?limit=1000&offset=0") {
+      return json({ items: [], total: 0, limit: 1000, offset: 0 });
+    }
+    if (url === "/api/v1/audit/status?node_id=2") {
+      return json({ enabled: false, scopes: [] });
+    }
+    if (url === "/api/v1/nodes/2/tags?limit=1000&offset=0") {
+      return json({ items: [], total: 0, limit: 1000, offset: 0 });
+    }
+    if (url === "/api/v1/search?q=Reports&limit=1000") {
+      return json({
+        hits: [{ node: reports, path: "/Reports", match: "name" }],
+        limit: 1000,
+        truncated: false,
+      });
+    }
+    if (url === "/api/v1/nodes/2/trash" && init?.method === "POST") {
+      trashed = true;
+      return json({
+        ...reports,
+        revision: 2,
+        trashed_at: "2026-07-28T12:01:00Z",
+      });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  });
+
+  render(App);
+  await fireEvent.dblClick(await screen.findByRole("cell", { name: "Reports" }));
+  await screen.findByText("This folder is empty");
+
+  const search = screen.getByRole("searchbox", { name: "Search documents" });
+  await fireEvent.input(search, { target: { value: "Reports" } });
+  await fireEvent.submit(search.closest("form")!);
+  await screen.findByRole("cell", { name: "/Reports" });
+
+  await fireEvent.click(screen.getByRole("button", { name: "Move to trash" }));
+  const confirmation = screen.getByRole("dialog", { name: "Move Reports to trash" });
+  await fireEvent.click(
+    within(confirmation).getByRole("button", { name: "Move to trash" }),
+  );
+
+  await waitFor(() => expect(rootReads).toBe(2));
+  expect(screen.getByText("This folder is empty")).toBeTruthy();
+  expect(screen.queryByRole("cell", { name: "/Reports" })).toBeNull();
+  expect(
+    screen.getByRole("button", { name: "Back to previous directory" }).hasAttribute(
+      "disabled",
+    ),
+  ).toBe(true);
 });

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -422,12 +422,26 @@ it("discards cached navigation when search trashes the current directory", async
       headers: { "Content-Type": "application/json" },
     });
   let trashed = false;
+  let failRootRefresh = true;
   let rootReads = 0;
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
     const url = String(input);
     if (url === "/api/v1/path?path=%2F") return json(root);
     if (url === "/api/v1/nodes/1/children?limit=1000&offset=0") {
       rootReads += 1;
+      if (trashed && failRootRefresh) {
+        failRootRefresh = false;
+        return new Response(
+          JSON.stringify({
+            status: 503,
+            detail: "root temporarily unavailable",
+          }),
+          {
+            status: 503,
+            headers: { "Content-Type": "application/problem+json" },
+          },
+        );
+      }
       return json({
         directory: root,
         items: trashed ? [] : [reports],
@@ -488,11 +502,16 @@ it("discards cached navigation when search trashes the current directory", async
   );
 
   await waitFor(() => expect(rootReads).toBe(2));
-  expect(screen.getByText("This folder is empty")).toBeTruthy();
+  expect(await screen.findByText("root temporarily unavailable")).toBeTruthy();
   expect(screen.queryByRole("cell", { name: "/Reports" })).toBeNull();
   expect(
     screen.getByRole("button", { name: "Back to previous directory" }).hasAttribute(
       "disabled",
     ),
   ).toBe(true);
+
+  await fireEvent.click(screen.getByRole("button", { name: "Refresh current view" }));
+  await waitFor(() => expect(rootReads).toBe(3));
+  expect(screen.getByText("This folder is empty")).toBeTruthy();
+  expect(screen.queryByRole("cell", { name: "/Reports" })).toBeNull();
 });

--- a/frontend/src/TrashNodeModal.svelte
+++ b/frontend/src/TrashNodeModal.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import Trash2Icon from "@lucide/svelte/icons/trash-2";
+  import { Button, Modal, Spinner } from "@kenn-io/kit-ui";
+  import { APIError, trashNode, type Node } from "./api.js";
+
+  let {
+    session,
+    node,
+    path,
+    onclose,
+    ontrashed,
+    onauthfailure,
+  }: {
+    session: string;
+    node: Node;
+    path: string;
+    onclose: () => void;
+    ontrashed: (receipt: Node) => void;
+    onauthfailure: (cause: unknown) => void;
+  } = $props();
+
+  let pending = $state(false);
+  let failure = $state("");
+
+  function close(): void {
+    if (!pending) onclose();
+  }
+
+  async function confirm(): Promise<void> {
+    if (pending) return;
+    pending = true;
+    failure = "";
+    try {
+      const receipt = await trashNode(session, node.id, node.revision);
+      ontrashed(receipt);
+    } catch (cause) {
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        return;
+      }
+      failure = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<Modal
+  title="Move to trash?"
+  tone="danger"
+  ariaLabel={`Move ${node.name} to trash`}
+  onclose={close}
+  closeOnOverlayClick={!pending}
+>
+  <div class="trash-confirmation">
+    <div class="target">
+      <Trash2Icon size="20" aria-hidden="true" />
+      <div>
+        <strong>{node.name}</strong>
+        <code>{path}</code>
+        <span>Stable node id:{node.id} · revision {node.revision}</span>
+      </div>
+    </div>
+    <p>
+      {#if node.kind === "dir"}
+        This folder and every live item inside it will leave the current tree together.
+      {:else}
+        This document will leave the current tree.
+      {/if}
+      It remains recoverable from trash.
+    </p>
+    <p class="boundary">
+      This does not empty trash, reclaim stored bytes, or erase permanent audited history.
+    </p>
+    {#if failure}
+      <p class="failure" role="alert">{failure}</p>
+    {/if}
+  </div>
+  {#snippet footer()}
+    <Button surface="soft" disabled={pending} onclick={close}>Keep in Docbank</Button>
+    <Button
+      tone="danger"
+      surface="solid"
+      disabled={pending}
+      onclick={() => void confirm()}
+    >
+      {#if pending}<Spinner size={14} /> Moving…{:else}<Trash2Icon size="14" /> Move to trash{/if}
+    </Button>
+  {/snippet}
+</Modal>
+
+<style>
+  .trash-confirmation {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .target {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-inset);
+  }
+
+  .target > :global(svg) {
+    margin-top: 2px;
+    color: var(--accent-red);
+  }
+
+  .target > div {
+    display: grid;
+    min-width: 0;
+    gap: var(--space-1);
+  }
+
+  .target strong {
+    overflow-wrap: anywhere;
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+  }
+
+  .target code {
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
+  .target span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  p {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  .boundary {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+  }
+
+  .failure {
+    padding: var(--space-3);
+    border: 1px solid color-mix(in srgb, var(--accent-red) 35%, transparent);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent-red) 8%, transparent);
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+</style>

--- a/frontend/src/TrashNodeModal.test.ts
+++ b/frontend/src/TrashNodeModal.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import TrashNodeModal from "./TrashNodeModal.svelte";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+it("confirms one revision-bound move to recoverable trash", async () => {
+  const ontrashed = vi.fn();
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        id: 42,
+        parent_id: 1,
+        name: "quarterly-report.txt",
+        kind: "file",
+        size: 74,
+        revision: 4,
+        created_at: "2026-07-28T12:00:00Z",
+        modified_at: "2026-07-28T12:00:00Z",
+        trashed_at: "2026-07-28T12:01:00Z",
+        path: "/Reports/quarterly-report.txt",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+
+  render(TrashNodeModal, {
+    session: "short-lived",
+    node: {
+      id: 42,
+      parent_id: 2,
+      name: "quarterly-report.txt",
+      kind: "file",
+      size: 74,
+      revision: 3,
+      created_at: "2026-07-28T12:00:00Z",
+      modified_at: "2026-07-28T12:00:00Z",
+    },
+    path: "/Reports/quarterly-report.txt",
+    onclose: vi.fn(),
+    ontrashed,
+    onauthfailure: vi.fn(),
+  });
+
+  expect(
+    screen.getByText(
+      "This document will leave the current tree. It remains recoverable from trash.",
+    ),
+  ).toBeTruthy();
+  expect(
+    screen.getByText(
+      "This does not empty trash, reclaim stored bytes, or erase permanent audited history.",
+    ),
+  ).toBeTruthy();
+  await fireEvent.click(screen.getByRole("button", { name: "Move to trash" }));
+
+  expect(fetchMock).toHaveBeenCalledOnce();
+  const [, request] = fetchMock.mock.calls[0] ?? [];
+  expect(new Headers(request?.headers).get("If-Match")).toBe("3");
+  await waitFor(() =>
+    expect(ontrashed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 42,
+        revision: 4,
+        trashed_at: "2026-07-28T12:01:00Z",
+      }),
+    ),
+  );
+});
+
+it("keeps the confirmation open when the inspected revision is stale", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        status: 412,
+        code: "stale_revision",
+        detail: "node changed; refresh before moving it to trash",
+      }),
+      {
+        status: 412,
+        headers: { "Content-Type": "application/problem+json" },
+      },
+    ),
+  );
+
+  render(TrashNodeModal, {
+    session: "short-lived",
+    node: {
+      id: 42,
+      name: "quarterly-report.txt",
+      kind: "file",
+      size: 74,
+      revision: 3,
+      created_at: "2026-07-28T12:00:00Z",
+      modified_at: "2026-07-28T12:00:00Z",
+    },
+    path: "/Reports/quarterly-report.txt",
+    onclose: vi.fn(),
+    ontrashed: vi.fn(),
+    onauthfailure: vi.fn(),
+  });
+
+  await fireEvent.click(screen.getByRole("button", { name: "Move to trash" }));
+  expect(
+    await screen.findByText("node changed; refresh before moving it to trash"),
+  ).toBeTruthy();
+  expect(screen.getByRole("dialog", { name: "Move quarterly-report.txt to trash" }))
+    .toBeTruthy();
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -16,6 +16,7 @@ import {
   taggedNodes,
   tags,
   takeFragmentSession,
+  trashNode,
 } from "./api.js";
 
 describe("browser authentication", () => {
@@ -176,5 +177,34 @@ describe("browser authentication", () => {
       "/api/v1/nodes/42/tags?limit=1000&offset=0",
       "/api/v1/search?q=quarterly+report&limit=1000&tag_id=11111111-1111-4111-8111-111111111111",
     ]);
+  });
+
+  it("trashes one stable node under its inspected revision", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 42,
+          name: "report.txt",
+          kind: "file",
+          size: 12,
+          revision: 8,
+          created_at: "2026-07-28T12:00:00Z",
+          modified_at: "2026-07-28T12:00:00Z",
+          trashed_at: "2026-07-28T12:01:00Z",
+          path: "/Reports/report.txt",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(trashNode("session", 42, 7)).resolves.toMatchObject({
+      id: 42,
+      revision: 8,
+      path: "/Reports/report.txt",
+    });
+    const [path, request] = fetchMock.mock.calls[0] ?? [];
+    expect(path).toBe("/api/v1/nodes/42/trash");
+    expect(request?.method).toBe("POST");
+    expect(new Headers(request?.headers).get("If-Match")).toBe("7");
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -416,6 +416,30 @@ export async function nodeTags(session: string, nodeID: number): Promise<TagPage
   );
 }
 
+export async function trashNode(
+  session: string,
+  nodeID: number,
+  revision: number,
+): Promise<Node> {
+  const node = await requestJSON<Node>(
+    `/api/v1/nodes/${nodeID}/trash`,
+    session,
+    {
+      method: "POST",
+      headers: { "If-Match": String(revision) },
+    },
+  );
+  if (
+    node.id !== nodeID ||
+    node.revision <= revision ||
+    !node.trashed_at ||
+    !node.path?.startsWith("/")
+  ) {
+    throw new Error("The daemon returned an invalid trash receipt.");
+  }
+  return node;
+}
+
 export async function auditStatusForNode(
   session: string,
   nodeID: number,

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -291,6 +291,10 @@ dd {
   grid-column: 1 / -1;
 }
 
+.document-actions > :last-child {
+  grid-column: 1 / -1;
+}
+
 .document-actions > button,
 .document-actions > .download-control,
 .document-actions > .download-control > button {
@@ -298,6 +302,17 @@ dd {
 }
 
 .document-actions > button {
+  justify-content: center;
+}
+
+.directory-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.directory-actions > button {
+  width: 100%;
   justify-content: center;
 }
 
@@ -446,5 +461,13 @@ dd {
 
   .document-actions > :first-child {
     grid-column: auto;
+  }
+
+  .document-actions > :last-child {
+    grid-column: auto;
+  }
+
+  .directory-actions {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -445,6 +445,33 @@ func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 		"browser sessions cannot upload through reconnectable HTTP")
 	require.NoError(t, resp.Body.Close())
 
+	trashRequest, err := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/trash",
+		nil,
+	)
+	require.NoError(t, err)
+	trashRequest.Header["X-Api-Key"] = []string{""}
+	trashRequest.Header.Set(api.WebSessionHeader, issued.Token)
+	trashRequest.Header.Set("If-Match", strconv.FormatInt(document.Revision, 10))
+	resp, err = ts.Client().Do(trashRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var trashed api.Node
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&trashed))
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, document.ID, trashed.ID)
+	assert.NotEmpty(t, trashed.TrashedAt)
+	assert.Equal(t, "/Taxes/return.txt", trashed.Path)
+
+	resp = webRequest(
+		http.MethodPost,
+		"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/restore",
+	)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"browser trash permission does not grant restore or other mutations")
+	require.NoError(t, resp.Body.Close())
+
 	resp = webRequest(http.MethodGet,
 		"/api/v1/backup/snapshots?repo=/;/../var/backups/other")
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode,

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -23,7 +23,8 @@ const (
 // webSessionRegistry owns browser credentials for exactly one daemon
 // lifetime. Tokens are random, retained only as digests, and authorize only
 // the deliberately limited routes used by the built-in browser. Most are
-// reads; verified upload is the one document-authority mutation.
+// reads; verified upload and revision-bound move-to-trash are the only
+// document-authority mutations.
 type webSessionRegistry struct {
 	mu          sync.Mutex
 	tokens      map[[sha256.Size]byte]webSessionState

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -172,6 +172,16 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	if method == http.MethodPost && path == webDownloadPreparePath {
 		return true
 	}
+	if method == http.MethodPost && r.URL.RawQuery == "" {
+		const prefix = "/api/v1/nodes/"
+		if after, ok := strings.CutPrefix(path, prefix); ok {
+			parts := strings.Split(after, "/")
+			nodeID, err := strconv.ParseInt(parts[0], 10, 64)
+			if len(parts) == 2 && parts[1] == "trash" && err == nil && nodeID > 0 {
+				return true
+			}
+		}
+	}
 	if method == http.MethodDelete && path == webSessionPath {
 		return true
 	}

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "52"
+	daemonProtocolVersion = "53"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Docbank’s web application can now move a selected file or folder out of the live tree without turning the browser into a general-purpose mutation client. A person sees the complete path, stable node ID, and inspected revision before confirming. The dialog also makes the lifecycle boundary explicit: the item remains recoverable, no stored bytes are reclaimed, and permanent audited history is not erased.

The operation is bound to the selected revision. If a CLI, agent, or another browser action changes the node first, Docbank leaves the confirmation open and reports the stale decision instead of moving newer state. After success, the browser immediately discards the old table and cached Back snapshots, then returns to a freshly loaded vault root. A failed reload cannot make the removed node appear live, and Refresh can reacquire root without leaving someone stranded inside a nested folder.

This is a deliberately narrow expansion of the daemon-lifetime browser session. It may call only the stable-node move-to-trash endpoint with `If-Match`. It still cannot restore or empty trash, run garbage collection or maintenance, enroll audit scopes, or invoke unrelated document mutations.

The same behavior is documented for people and agents, and the daemon protocol advances so an older process cannot open a partially compatible interface.

The PR also adds `make frontend-screenshots`, a repository-owned Playwright capture harness modeled on Middleman. It builds the exact embedded app, creates an owner-private synthetic vault, drives the real daemon-issued browser session to the trash confirmation, writes `.superpowers/screenshots/web-trash-confirmation.png`, then stops the daemon and removes the vault. Future web UI work can add capture cases without relying on a developer vault or mocked API responses.

![The actual Docbank web application confirming that a synthetic report will move to recoverable trash](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-trash-node/web-trash-confirmation.png?v=4cfc599)

*Actual daemon-served interface using a temporary synthetic vault; no private corpus data is present.*

