### PR TITLE
Restore recoverable trash from the web

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Four commitments:
 - A scoped kit-ui web application for verified local-file upload, virtual-tree browsing, sortable
   document analysis, tag browsing, tag-filtered extracted-text search,
   complete current authority, verified current and historical content download,
-  recoverable move-to-trash,
+  recoverable move-to-trash and revision-bound restoration,
   permanent protection and event history, immutable versions and provenance,
   configured backup recovery points, daemon background-job status, and an honest
   loose-file/live-packed/dead-packed storage breakdown

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "53", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "54", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "53", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "54", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "53", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "54", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "53", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "54", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -51,7 +51,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /path/move` · `POST /path/trash` | move / trash by virtual path, resolved and mutated in one store transaction | Implemented |
 | `POST /batch/move` | validate and apply up to 1,000 moves as one final-state transaction | Implemented |
 | `POST /nodes/{id}/trash` · `POST /nodes/{id}/restore` | soft delete / recover | Implemented |
-| `GET /trash` · `POST /trash/empty` `{run, older_than}` | list / report or hard-delete trash roots | Implemented |
+| `GET /trash` · `POST /trash/empty` `{run, older_than}` | list (optionally paginated) / report or hard-delete trash roots | Implemented |
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / validate metadata and re-hash all blobs | Implemented |
 | `GET /storage` · `POST /storage/pack` · `POST /storage/repack` | inspect usage / pack loose blobs / compact sparse packs | Implemented |
 | `GET /jobs` | inspect daemon-owned background tasks and terminal failures | Implemented |
@@ -69,7 +69,7 @@ independent upload-proof secret, and the fresh loopback origin dedicated to
 that daemon lifetime, while
 `DELETE /api/daemon/web-session` revokes the calling browser session. Those
 tokens authenticate only the explicit routes used by the built-in document,
-storage, job, configured-backup, and verified-download workflows; they are
+recoverable-trash, storage, job, configured-backup, and verified-download workflows; they are
 intentionally not another general API credential. Browser file bytes use the
 hidden `/api/daemon/web-upload` WebSocket instead. The page verifies a
 challenge proof over the upload secret before sending bytes, binds the socket

--- a/docs/index.md
+++ b/docs/index.md
@@ -172,7 +172,7 @@ documents: files you still organize, retrieve, and build workflows around.
 - [Setup](setup.md): install the binary and create the vault
 - [Quickstart](quickstart.md): a ten-minute tour of the CLI
 - [Vault Lifecycle](usage/lifecycle.md): operate, snapshot, and recover safely
-- [Web Application](usage/web.md): browse, search, and download verified retained content
+- [Web Application](usage/web.md): browse, search, upload, download, and manage recoverable trash
 - [Docbank for Agents](agents.md): the automation contract
 - [Embed in Go](embedding.md): vaults inside your own application
 - [Troubleshooting](troubleshooting.md): diagnose failures without risking the vault

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: analytical tree/search/detail, audited-history, daemon-job inspection, web tags, version history, provenance, verified current/historical content download, verified upload, and recoverable trash implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: analytical tree/search/detail, audited-history, daemon-job inspection, web tags, version history, provenance, verified current/historical content download, verified upload, and recoverable trash with restoration implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -150,11 +150,13 @@ Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
 portal also uploads local files through the same caller-declared and
 server-verified byte-identity contract used by remote agents, moves a selected
-revision-bound live node to recoverable trash after explicit confirmation, lists configured
+revision-bound live node to recoverable trash after explicit confirmation,
+lists newest-first trash roots, restores one inspected revision while
+reporting its actual collision- or fallback-resolved path, lists configured
 backup recovery points, reports current and terminal daemon background jobs,
 and separates physical loose files, live packed content, complete pack payload,
 and logically dead payload awaiting explicit repack. Future slices cover tag
-mutation and broader metadata, version comparison, trash restoration, and storage
+mutation and broader metadata, version comparison, and storage
 maintenance.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -17,7 +17,8 @@ navigate the virtual tree, sort a folder by document name, size, or modification
 time, search names and extracted text, and inspect the selected document's stable
 node ID, revision, current version ID, SHA-256 identity, exact size, and media
 type. A selected live file or folder can be moved to recoverable trash after an
-explicit confirmation. The authority card also shows every tag assigned to the selected file or
+explicit confirmation; the trash drawer lists restorable roots and returns one
+to the live tree under its inspected revision. The authority card also shows every tag assigned to the selected file or
 folder. Selecting a tag browses its live assignments, while search can require
 the same exact tag identity. Protected documents expose
 their newest-first permanent audit timeline and complete event authority. The
@@ -77,7 +78,29 @@ and refreshes the current folder, search, or tag view.
 
 This action is deliberately recoverable. It does not empty trash, garbage
 collect content, reclaim packed space, or erase permanent audited history.
-Listing and restoring trash remain CLI or authenticated API workflows.
+
+## Restore from recoverable trash
+
+Choose the trash button in the top bar to inspect the newest 1,000 independently
+restorable roots. Each entry shows its name, kind, stable node ID, revision,
+trash time, and logical size for files. A folder entry represents the complete
+subtree that left the live tree in that trash operation.
+
+Choose **Restore** and confirm the inspected revision. Docbank returns the same
+stable node and retained content to its original live parent when that
+directory still exists. If the parent is unavailable, restore falls back to
+the vault root; if the chosen name is already occupied, Docbank adds its normal
+collision suffix. The completed receipt shows the actual canonical path rather
+than predicting where the item should have landed.
+
+A stale revision leaves the confirmation open so the operator can refresh and
+make a new decision. A successful restore removes the item from the trash
+drawer and reacquires the live tree from root, discarding cached paths whose
+parent revisions may have changed.
+
+The browser cannot empty trash. Permanent tree-metadata deletion, subsequent
+garbage collection, and packed-space reclamation remain explicit CLI or
+master-authenticated API operations.
 
 ## Upload verified documents
 
@@ -324,17 +347,17 @@ in page memory. Ordinary requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
 search, tag-definition and assignment reads, immutable-version, provenance, audit-status, audit-history,
 background-job, physical-storage-status, configured backup-snapshot-list,
-verified-download preparation, and revision-bound move-to-trash request used by
-this interface.
+bounded trash-list, verified-download preparation, and revision-bound
+move-to-trash and restore requests used by this interface.
 Download preparation may write only owner-private temporary bytes and issue
 one exact, expiring file ticket. Upload uses a separate, never-reconnecting
 WebSocket authenticated by a challenge proof over the upload secret. No file
 bytes are sent until that proof succeeds. It may create only file nodes
 beneath the stable live directory selected in the browser and must satisfy the
 same caller-declared/server-computed byte identity as every remote writer. The
-trash request can target only the stable selected node and must carry its
-current revision, so a stale browser view cannot move changed state. The
-session cannot restore or empty trash, perform any other document mutation,
+trash and restore requests can target only the stable selected node and must
+carry its current revision, so a stale browser view cannot move changed state.
+The session cannot empty trash, perform any other document mutation,
 enroll audit scopes, run independent verification, or call backup creation,
 verification, restore, maintenance, configuration, or general API endpoints.
 Its sole backup capability is listing the immutable snapshots in the
@@ -360,7 +383,7 @@ history, logs, screenshots, issue trackers, or chat.
 
 ## Current boundary
 
-Folder, tag, and search views are bounded to 1,000 rows and say when more
+Folder, tag, search, and recoverable-trash views are bounded to 1,000 rows and say when more
 results exist; use the CLI or paginated HTTP API for exhaustive automation. Search has
 the same name and verified extracted-text semantics as `docbank search`.
 Results initially preserve the API's relevance ranking. Choosing Document,
@@ -372,7 +395,7 @@ leave the browser constructing child paths beneath an obsolete name.
 
 The current web application does not compare versions, recursively import
 folders, edit, revert, prune, move, create or change tags and
-assignments, restore trash, enroll audit scopes, run independent audit verification,
+assignments, empty trash, enroll audit scopes, run independent audit verification,
 or run maintenance, backup, verification, or restore operations.
 Use the corresponding CLI or authenticated HTTP endpoint for those workflows.
 Future web workflows will require deliberately expanded browser-session

--- a/frontend/screenshots/README.md
+++ b/frontend/screenshots/README.md
@@ -22,7 +22,8 @@ The command builds the current frontend and Docbank binary, creates and seeds
 an owner-private temporary vault, opens the daemon-issued browser session,
 captures the requested state, stops the daemon, and removes the vault.
 Generated images are written beneath `.superpowers/screenshots/` for visual
-inspection and PR attachment; they are intentionally not committed.
+inspection and PR attachment; the current case captures both move-to-trash and
+restore confirmations. Generated images are intentionally not committed.
 
 Pass ordinary Playwright arguments after `--` to select a case:
 

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -16,6 +16,12 @@ const screenshotPath = path.join(
   "screenshots",
   "web-trash-confirmation.png",
 );
+const restoreScreenshotPath = path.join(
+  repositoryRoot,
+  ".superpowers",
+  "screenshots",
+  "web-trash-restore-confirmation.png",
+);
 
 test.describe("Docbank web screenshots", () => {
   let workspace = "";
@@ -40,6 +46,7 @@ test.describe("Docbank web screenshots", () => {
     vault = path.join(workspace, "vault");
     await mkdir(path.dirname(screenshotPath), { recursive: true, mode: 0o700 });
     await rm(screenshotPath, { force: true });
+    await rm(restoreScreenshotPath, { force: true });
     const reports = path.join(workspace, "synthetic", "Reports");
     await mkdir(reports, { recursive: true, mode: 0o700 });
     await writeFile(
@@ -142,6 +149,26 @@ test.describe("Docbank web screenshots", () => {
     );
     await page.screenshot({
       path: screenshotPath,
+      fullPage: true,
+      animations: "disabled",
+    });
+
+    await confirmation.getByRole("button", { name: "Move to trash" }).click();
+    await expect(confirmation).not.toBeVisible();
+    await page.getByRole("button", { name: "Recoverable trash" }).click();
+    const trash = page.getByRole("dialog", { name: "Recoverable trash" });
+    await expect(trash).toContainText("quarterly-tax-report.txt");
+    await trash.getByRole("button", { name: "Restore" }).click();
+
+    const restore = page.getByRole("dialog", {
+      name: "Restore quarterly-tax-report.txt from trash",
+    });
+    await expect(restore).toBeVisible();
+    await expect(restore).toContainText(
+      "It does not roll back versions or alter permanent audited history.",
+    );
+    await page.screenshot({
+      path: restoreScreenshotPath,
       fullPage: true,
       animations: "disabled",
     });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -38,6 +38,7 @@
   import JobsDrawer from "./JobsDrawer.svelte";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import StorageDrawer from "./StorageDrawer.svelte";
+  import TrashDrawer from "./TrashDrawer.svelte";
   import TrashNodeModal from "./TrashNodeModal.svelte";
   import UploadDrawer from "./UploadDrawer.svelte";
   import VersionHistoryDrawer from "./VersionHistoryDrawer.svelte";
@@ -116,6 +117,7 @@
   let jobsOpen = $state(false);
   let storageOpen = $state(false);
   let backupsOpen = $state(false);
+  let trashOpen = $state(false);
   let uploadTarget = $state<Node | null>(null);
   let trashTarget = $state<Row | null>(null);
   let generation = 0;
@@ -175,6 +177,7 @@
       jobsOpen = false;
       storageOpen = false;
       backupsOpen = false;
+      trashOpen = false;
       uploadTarget = null;
       trashTarget = null;
       tagCatalog = [];
@@ -548,6 +551,27 @@
     void loadTagCatalog();
   }
 
+  function handleRestored(_receipt: Node): void {
+    selectNode(undefined);
+
+    // Restore can advance an arbitrary destination parent and make every
+    // cached path snapshot stale. Keep the trash drawer's authoritative
+    // receipt visible while reacquiring the live tree from root.
+    stack = [];
+    directory = null;
+    rows = [];
+    searchQuery = "";
+    activeQuery = "";
+    tagFilterID = "";
+    activeTagID = "";
+    taggedInspected = 0;
+    taggedTotal = 0;
+    taggedTrashed = 0;
+    truncated = false;
+    void loadRoot();
+    void loadTagCatalog();
+  }
+
   async function lock(): Promise<void> {
     generation += 1;
     auditGeneration += 1;
@@ -578,6 +602,7 @@
     jobsOpen = false;
     storageOpen = false;
     backupsOpen = false;
+    trashOpen = false;
     uploadTarget = null;
     trashTarget = null;
     activeQuery = "";
@@ -642,6 +667,23 @@
       {#snippet right()}
         <IconButton
           size="sm"
+          ariaLabel="Recoverable trash"
+          onclick={() => {
+            historyOpen = false;
+            versionsOpen = false;
+            provenanceOpen = false;
+            jobsOpen = false;
+            storageOpen = false;
+            backupsOpen = false;
+            uploadTarget = null;
+            trashTarget = null;
+            trashOpen = true;
+          }}
+        >
+          <Trash2Icon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton
+          size="sm"
           ariaLabel="Backup snapshots"
           onclick={() => {
             historyOpen = false;
@@ -649,6 +691,7 @@
             provenanceOpen = false;
             jobsOpen = false;
             storageOpen = false;
+            trashOpen = false;
             backupsOpen = true;
             uploadTarget = null;
           }}
@@ -664,6 +707,7 @@
             provenanceOpen = false;
             jobsOpen = false;
             backupsOpen = false;
+            trashOpen = false;
             uploadTarget = null;
             storageOpen = true;
           }}
@@ -679,6 +723,7 @@
             provenanceOpen = false;
             storageOpen = false;
             backupsOpen = false;
+            trashOpen = false;
             uploadTarget = null;
             jobsOpen = true;
           }}
@@ -760,6 +805,7 @@
                 jobsOpen = false;
                 storageOpen = false;
                 backupsOpen = false;
+                trashOpen = false;
                 uploadTarget = directory;
               }}
             >
@@ -970,6 +1016,7 @@
                       jobsOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
+                      trashOpen = false;
                       uploadTarget = null;
                       versionsOpen = true;
                     }}
@@ -986,6 +1033,7 @@
                       jobsOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
+                      trashOpen = false;
                       uploadTarget = null;
                       provenanceOpen = true;
                     }}
@@ -1004,6 +1052,7 @@
                       jobsOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
+                      trashOpen = false;
                       uploadTarget = null;
                       trashTarget = selected;
                     }}
@@ -1045,6 +1094,7 @@
                       provenanceOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
+                      trashOpen = false;
                       uploadTarget = null;
                       historyOpen = true;
                     }}
@@ -1075,6 +1125,7 @@
                       jobsOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
+                      trashOpen = false;
                       uploadTarget = null;
                       trashTarget = selected;
                     }}
@@ -1143,6 +1194,14 @@
       <StorageDrawer
         session={webSession}
         onclose={() => (storageOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if trashOpen}
+      <TrashDrawer
+        session={webSession}
+        onclose={() => (trashOpen = false)}
+        onrestored={handleRestored}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/RestoreNodeModal.svelte
+++ b/frontend/src/RestoreNodeModal.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
+  import { Button, Modal, Spinner } from "@kenn-io/kit-ui";
+  import { APIError, restoreNode, type Node } from "./api.js";
+  import { formatDate } from "./format.js";
+
+  let {
+    session,
+    node,
+    onclose,
+    onrestored,
+    onauthfailure,
+  }: {
+    session: string;
+    node: Node;
+    onclose: () => void;
+    onrestored: (receipt: Node) => void;
+    onauthfailure: (cause: unknown) => void;
+  } = $props();
+
+  let pending = $state(false);
+  let failure = $state("");
+
+  function close(): void {
+    if (!pending) onclose();
+  }
+
+  async function confirm(): Promise<void> {
+    if (pending) return;
+    pending = true;
+    failure = "";
+    try {
+      const receipt = await restoreNode(session, node.id, node.revision);
+      onrestored(receipt);
+    } catch (cause) {
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        return;
+      }
+      failure = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<Modal
+  title="Restore from trash?"
+  tone="info"
+  ariaLabel={`Restore ${node.name} from trash`}
+  onclose={close}
+  closeOnOverlayClick={!pending}
+>
+  <div class="restore-confirmation">
+    <div class="target">
+      <RotateCcwIcon size="20" aria-hidden="true" />
+      <div>
+        <strong>{node.name}</strong>
+        <span>
+          Stable node id:{node.id} · revision {node.revision}
+        </span>
+        <span>Trashed {formatDate(node.trashed_at ?? "")}</span>
+      </div>
+    </div>
+    <p>
+      Docbank will return this {node.kind === "dir" ? "folder" : "document"} to
+      its original live parent when that directory still exists. Otherwise it
+      returns beneath <code>/</code>; a name collision receives a suffix.
+    </p>
+    <p class="boundary">
+      Restore keeps the same stable node and retained content. It does not roll
+      back versions or alter permanent audited history.
+    </p>
+    {#if failure}
+      <p class="failure" role="alert">{failure}</p>
+    {/if}
+  </div>
+  {#snippet footer()}
+    <Button surface="soft" disabled={pending} onclick={close}>Leave in trash</Button>
+    <Button
+      tone="info"
+      surface="solid"
+      disabled={pending}
+      onclick={() => void confirm()}
+    >
+      {#if pending}
+        <Spinner size={14} /> Restoring…
+      {:else}
+        <RotateCcwIcon size="14" /> Restore
+      {/if}
+    </Button>
+  {/snippet}
+</Modal>
+
+<style>
+  .restore-confirmation {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .target {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-inset);
+  }
+
+  .target > :global(svg) {
+    margin-top: 2px;
+    color: var(--accent-blue);
+  }
+
+  .target > div {
+    display: grid;
+    min-width: 0;
+    gap: var(--space-1);
+  }
+
+  .target strong {
+    overflow-wrap: anywhere;
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+  }
+
+  .target span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  p {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  .boundary {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+  }
+
+  .failure {
+    padding: var(--space-3);
+    border: 1px solid color-mix(in srgb, var(--accent-red) 35%, transparent);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent-red) 8%, transparent);
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+</style>

--- a/frontend/src/TrashDrawer.svelte
+++ b/frontend/src/TrashDrawer.svelte
@@ -1,0 +1,416 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import FileIcon from "@lucide/svelte/icons/file";
+  import FolderIcon from "@lucide/svelte/icons/folder";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
+  import Trash2Icon from "@lucide/svelte/icons/trash-2";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Card,
+    Chip,
+    CopyButton,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+  } from "@kenn-io/kit-ui";
+  import RestoreNodeModal from "./RestoreNodeModal.svelte";
+  import { APIError, trashRoots, type Node, type TrashPage } from "./api.js";
+  import { formatBytes, formatDate } from "./format.js";
+
+  interface Props {
+    session: string;
+    onclose: () => void;
+    onrestored: (receipt: Node) => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, onclose, onrestored, onauthfailure }: Props = $props();
+
+  let page = $state<TrashPage | null>(null);
+  let loading = $state(true);
+  let error = $state("");
+  let restoreTarget = $state<Node | null>(null);
+  let restored = $state<Node | null>(null);
+  let generation = 0;
+
+  onMount(() => {
+    void refresh();
+    return () => {
+      generation += 1;
+    };
+  });
+
+  async function refresh(): Promise<void> {
+    const request = ++generation;
+    loading = true;
+    error = "";
+    try {
+      const next = await trashRoots(session);
+      if (request !== generation) return;
+      page = next;
+    } catch (cause) {
+      if (request !== generation) return;
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        onclose();
+        return;
+      }
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === generation) loading = false;
+    }
+  }
+
+  function handleRestored(receipt: Node): void {
+    restoreTarget = null;
+    restored = receipt;
+    if (page) {
+      page = {
+        ...page,
+        items: page.items.filter((item) => item.id !== receipt.id),
+        total: Math.max(0, page.total - 1),
+      };
+    }
+    onrestored(receipt);
+  }
+</script>
+
+<DetailDrawer width="min(720px, 100vw)" ariaLabel="Recoverable trash" {onclose}>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>RECOVERABLE TRASH</span>
+        <strong>Trashed documents</strong>
+        <small>
+          {#if page}
+            {page.total} restorable root{page.total === 1 ? "" : "s"}
+          {:else}
+            Items removed from the live tree
+          {/if}
+        </small>
+      </div>
+      <div class="drawer-actions">
+        <IconButton
+          size="sm"
+          ariaLabel="Refresh recoverable trash"
+          disabled={loading}
+          onclick={() => void refresh()}
+        >
+          <RefreshCwIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton size="sm" ariaLabel="Close recoverable trash" onclick={onclose}>
+          <XIcon size="14" aria-hidden="true" />
+        </IconButton>
+      </div>
+    </div>
+  {/snippet}
+
+  <div class="trash">
+    {#if restored}
+      <aside class="restored" role="status">
+        <RotateCcwIcon size="16" aria-hidden="true" />
+        <div>
+          <strong>Restored {restored.name}</strong>
+          <span>{restored.path}</span>
+        </div>
+      </aside>
+    {/if}
+    {#if loading && !page}
+      <div class="loading"><Spinner size={16} /> Reading recoverable trash…</div>
+    {:else if error && !page}
+      <div class="load-error">
+        <p role="alert">{error}</p>
+        <Button size="sm" onclick={() => void refresh()}>Try again</Button>
+      </div>
+    {:else if page}
+      {#if error}<p class="error" role="alert">{error}</p>{/if}
+      {#if page.items.length === 0}
+        <EmptyState
+          title="Trash is empty"
+          description="Documents moved out of the live tree will remain recoverable here until an explicit trash-empty operation."
+        >
+          {#snippet icon()}<Trash2Icon size="22" />{/snippet}
+        </EmptyState>
+      {:else}
+        <div class="trash-list" aria-live="polite">
+          {#each page.items as node (node.id)}
+            <Card level="default" padding="sm">
+              <div class="trash-item">
+                <div class="trash-icon">
+                  {#if node.kind === "dir"}
+                    <FolderIcon size="18" aria-hidden="true" />
+                  {:else}
+                    <FileIcon size="18" aria-hidden="true" />
+                  {/if}
+                </div>
+                <div class="trash-summary">
+                  <div>
+                    <strong>{node.name}</strong>
+                    <Chip size="xs" tone="muted">
+                      {node.kind === "dir" ? "Folder" : "Document"}
+                    </Chip>
+                  </div>
+                  <span>Trashed {formatDate(node.trashed_at ?? "")}</span>
+                  <dl>
+                    <div>
+                      <dt>Stable node</dt>
+                      <dd>
+                        <code>id:{node.id}</code>
+                        <CopyButton text={String(node.id)} ariaLabel={`Copy node ID ${node.id}`} />
+                      </dd>
+                    </div>
+                    <div><dt>Revision</dt><dd>{node.revision}</dd></div>
+                    {#if node.kind === "file"}
+                      <div><dt>Size</dt><dd>{formatBytes(node.size)}</dd></div>
+                    {/if}
+                  </dl>
+                </div>
+                <Button
+                  size="sm"
+                  tone="info"
+                  surface="soft"
+                  onclick={() => (restoreTarget = node)}
+                >
+                  <RotateCcwIcon size="14" aria-hidden="true" />
+                  Restore
+                </Button>
+              </div>
+            </Card>
+          {/each}
+        </div>
+        {#if page.total > page.items.length}
+          <p class="bounded">
+            Showing the newest {page.items.length} of {page.total} restorable roots.
+            Use the CLI or API for the complete listing.
+          </p>
+        {/if}
+      {/if}
+      <aside class="retention-note">
+        <strong>Trash is recoverable, not reclaimed space.</strong>
+        <p>
+          Restore returns the same stable node and retained content. Only an
+          explicit <code>docbank trash empty</code> operation removes tree
+          metadata; content reclamation remains a separate garbage-collection
+          decision.
+        </p>
+      </aside>
+    {/if}
+  </div>
+</DetailDrawer>
+
+{#if restoreTarget}
+  <RestoreNodeModal
+    {session}
+    node={restoreTarget}
+    onclose={() => (restoreTarget = null)}
+    onrestored={handleRestored}
+    {onauthfailure}
+  />
+{/if}
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div:first-child {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-heading span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading small {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .drawer-actions {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .trash {
+    display: grid;
+    gap: var(--space-4);
+    padding: var(--space-5);
+  }
+
+  .trash-list {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .trash-item {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .trash-icon {
+    display: grid;
+    place-items: center;
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent-blue) 10%, var(--bg-inset));
+    color: var(--accent-blue);
+  }
+
+  .trash-summary {
+    display: grid;
+    min-width: 0;
+    gap: var(--space-2);
+  }
+
+  .trash-summary > div:first-child {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  .trash-summary strong {
+    overflow: hidden;
+    color: var(--text-primary);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .trash-summary > span,
+  .bounded {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  dl {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-4);
+    margin: 0;
+  }
+
+  dl > div {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  dt {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  dd {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
+  .restored,
+  .retention-note {
+    padding: var(--space-4);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-inset);
+  }
+
+  .restored {
+    display: flex;
+    align-items: start;
+    gap: var(--space-3);
+    border-color: color-mix(in srgb, var(--accent-blue) 35%, var(--border-default));
+    color: var(--accent-blue);
+  }
+
+  .restored > div {
+    display: grid;
+    min-width: 0;
+    gap: var(--space-1);
+  }
+
+  .restored strong {
+    color: var(--text-primary);
+  }
+
+  .restored span {
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+  }
+
+  .retention-note strong {
+    color: var(--text-primary);
+  }
+
+  .retention-note p,
+  .load-error p,
+  .error,
+  .bounded {
+    margin: 0;
+  }
+
+  .retention-note p {
+    margin-top: var(--space-2);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+  }
+
+  .loading,
+  .load-error {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .load-error {
+    justify-content: space-between;
+    padding: var(--space-4);
+    border: 1px solid color-mix(in srgb, var(--accent-red) 30%, transparent);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent-red) 8%, transparent);
+  }
+
+  .error {
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+
+  @media (max-width: 640px) {
+    .trash-item {
+      grid-template-columns: auto minmax(0, 1fr);
+    }
+
+    .trash-item > :global(button) {
+      grid-column: 1 / -1;
+      justify-self: stretch;
+    }
+  }
+</style>

--- a/frontend/src/TrashDrawer.test.ts
+++ b/frontend/src/TrashDrawer.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/svelte";
+import TrashDrawer from "./TrashDrawer.svelte";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+it("shows recoverable roots and reports the authoritative restore path", async () => {
+  const trashed = {
+    id: 42,
+    parent_id: 1,
+    name: "quarterly-report.txt",
+    kind: "file",
+    current_version_id: "11111111-1111-4111-8111-111111111111",
+    blob_hash: "a".repeat(64),
+    size: 74,
+    mime_type: "text/plain",
+    revision: 3,
+    created_at: "2026-07-28T12:00:00Z",
+    modified_at: "2026-07-28T12:00:00Z",
+    trashed_at: "2026-07-28T12:01:00Z",
+  };
+  const restored = {
+    ...trashed,
+    name: "quarterly-report (2).txt",
+    revision: 4,
+    modified_at: "2026-07-28T12:02:00Z",
+    trashed_at: undefined,
+    path: "/Reports/quarterly-report (2).txt",
+  };
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
+    new Response(
+      JSON.stringify(
+        String(input).startsWith("/api/v1/trash?")
+          ? { items: [trashed], total: 1, limit: 1000, offset: 0 }
+          : restored,
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+  const onrestored = vi.fn();
+
+  render(TrashDrawer, {
+    session: "short-lived",
+    onclose: vi.fn(),
+    onrestored,
+    onauthfailure: vi.fn(),
+  });
+
+  expect(await screen.findByText("quarterly-report.txt")).toBeTruthy();
+  await fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+  const dialog = screen.getByRole("dialog", {
+    name: "Restore quarterly-report.txt from trash",
+  });
+  expect(dialog).toBeTruthy();
+  expect(
+    screen.getByText(
+      "Restore keeps the same stable node and retained content. It does not roll back versions or alter permanent audited history.",
+    ),
+  ).toBeTruthy();
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Restore" }));
+
+  await waitFor(() => expect(onrestored).toHaveBeenCalledWith(restored));
+  expect(
+    await screen.findByText("/Reports/quarterly-report (2).txt"),
+  ).toBeTruthy();
+  expect(screen.getByText("Trash is empty")).toBeTruthy();
+  const [, request] = fetchMock.mock.calls[1] ?? [];
+  expect(new Headers(request?.headers).get("If-Match")).toBe("3");
+});
+
+it("keeps stale restore authority visible for a fresh decision", async () => {
+  const trashed = {
+    id: 42,
+    name: "quarterly-report.txt",
+    kind: "file",
+    size: 74,
+    revision: 3,
+    created_at: "2026-07-28T12:00:00Z",
+    modified_at: "2026-07-28T12:00:00Z",
+    trashed_at: "2026-07-28T12:01:00Z",
+  };
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    if (String(input).startsWith("/api/v1/trash?")) {
+      return new Response(
+        JSON.stringify({ items: [trashed], total: 1, limit: 1000, offset: 0 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        status: 412,
+        code: "stale_revision",
+        detail: "node changed; refresh trash before restoring it",
+      }),
+      {
+        status: 412,
+        headers: { "Content-Type": "application/problem+json" },
+      },
+    );
+  });
+
+  render(TrashDrawer, {
+    session: "short-lived",
+    onclose: vi.fn(),
+    onrestored: vi.fn(),
+    onauthfailure: vi.fn(),
+  });
+
+  await fireEvent.click(
+    await screen.findByRole("button", { name: "Restore" }),
+  );
+  const dialog = screen.getByRole("dialog", {
+    name: "Restore quarterly-report.txt from trash",
+  });
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Restore" }));
+  expect(
+    await screen.findByText("node changed; refresh trash before restoring it"),
+  ).toBeTruthy();
+  expect(
+    screen.getByRole("dialog", { name: "Restore quarterly-report.txt from trash" }),
+  ).toBeTruthy();
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -9,6 +9,7 @@ import {
   liveTaggedNodes,
   nodeTags,
   requestJSON,
+  restoreNode,
   revokeSession,
   search,
   storageStatus,
@@ -17,6 +18,7 @@ import {
   tags,
   takeFragmentSession,
   trashNode,
+  trashRoots,
 } from "./api.js";
 
 describe("browser authentication", () => {
@@ -206,5 +208,43 @@ describe("browser authentication", () => {
     expect(path).toBe("/api/v1/nodes/42/trash");
     expect(request?.method).toBe("POST");
     expect(new Headers(request?.headers).get("If-Match")).toBe("7");
+  });
+
+  it("lists bounded trash and restores one inspected root", async () => {
+    const restored = {
+      id: 42,
+      parent_id: 2,
+      name: "report.txt",
+      kind: "file",
+      size: 12,
+      revision: 9,
+      created_at: "2026-07-28T12:00:00Z",
+      modified_at: "2026-07-28T12:02:00Z",
+      path: "/Reports/report (2).txt",
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
+      new Response(
+        JSON.stringify(
+          String(input).startsWith("/api/v1/trash?")
+            ? { items: [], total: 0, limit: 1000, offset: 0 }
+            : restored,
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(trashRoots("session")).resolves.toMatchObject({
+      total: 0,
+      limit: 1000,
+    });
+    await expect(restoreNode("session", 42, 8)).resolves.toEqual(restored);
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/v1/trash?limit=1000&offset=0",
+    );
+    const [path, request] = fetchMock.mock.calls[1] ?? [];
+    expect(path).toBe("/api/v1/nodes/42/restore");
+    expect(request?.method).toBe("POST");
+    expect(new Headers(request?.headers).get("If-Match")).toBe("8");
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -22,6 +22,13 @@ export interface NodePage {
   offset: number;
 }
 
+export interface TrashPage {
+  items: Node[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface ContentVersion {
   id: string;
   node_id: number;
@@ -436,6 +443,34 @@ export async function trashNode(
     !node.path?.startsWith("/")
   ) {
     throw new Error("The daemon returned an invalid trash receipt.");
+  }
+  return node;
+}
+
+export async function trashRoots(session: string): Promise<TrashPage> {
+  return requestJSON<TrashPage>("/api/v1/trash?limit=1000&offset=0", session);
+}
+
+export async function restoreNode(
+  session: string,
+  nodeID: number,
+  revision: number,
+): Promise<Node> {
+  const node = await requestJSON<Node>(
+    `/api/v1/nodes/${nodeID}/restore`,
+    session,
+    {
+      method: "POST",
+      headers: { "If-Match": String(revision) },
+    },
+  );
+  if (
+    node.id !== nodeID ||
+    node.revision <= revision ||
+    node.trashed_at ||
+    !node.path?.startsWith("/")
+  ) {
+    throw new Error("The daemon returned an invalid restore receipt.");
   }
   return node;
 }

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -194,20 +194,37 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 	})
 
 	type trashListOutput struct {
-		Body struct {
-			Items []Node `json:"items"`
-		}
+		Body TrashPage
 	}
 	huma.Register(api, huma.Operation{
 		OperationID: "listTrash", Method: http.MethodGet, Path: "/api/v1/trash",
-		Summary: "List restorable trash roots, newest first",
-	}, func(ctx context.Context, _ *struct{}) (*trashListOutput, error) {
-		roots, err := d.Store.TrashedRoots(ctx)
+		Summary: "List restorable trash roots, newest first, optionally paginated",
+	}, func(ctx context.Context, in *struct {
+		Limit  int `query:"limit" default:"0" minimum:"0" maximum:"1000"`
+		Offset int `query:"offset" default:"0" minimum:"0"`
+	}) (*trashListOutput, error) {
+		var (
+			roots []store.Node
+			total int
+			err   error
+		)
+		if in.Limit == 0 {
+			if in.Offset != 0 {
+				return nil, NewError(http.StatusUnprocessableEntity, "validation",
+					"trash offset requires a positive limit")
+			}
+			roots, err = d.Store.TrashedRoots(ctx)
+			total = len(roots)
+		} else {
+			roots, total, err = d.Store.TrashedRootsPage(ctx, in.Limit, in.Offset)
+		}
 		if err != nil {
 			return nil, FromStoreError(err)
 		}
 		out := &trashListOutput{}
-		out.Body.Items = []Node{}
+		out.Body = TrashPage{
+			Items: []Node{}, Total: total, Limit: in.Limit, Offset: in.Offset,
+		}
 		for _, n := range roots {
 			out.Body.Items = append(out.Body.Items, fromStoreNode(n))
 		}

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -295,7 +295,19 @@ func TestTrashListAndEmpty(t *testing.T) {
 
 	resp, body := get(t, ts, "/api/v1/trash", nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Contains(t, body, "old.txt")
+	var trash api.TrashPage
+	require.NoError(t, json.Unmarshal([]byte(body), &trash))
+	require.Len(t, trash.Items, 1)
+	assert.Equal(t, "old.txt", trash.Items[0].Name)
+	assert.Equal(t, 1, trash.Total)
+	assert.Zero(t, trash.Limit)
+	assert.Zero(t, trash.Offset)
+
+	resp, body = get(t, ts, "/api/v1/trash?limit=1&offset=0", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, json.Unmarshal([]byte(body), &trash))
+	assert.Equal(t, 1, trash.Total)
+	assert.Equal(t, 1, trash.Limit)
 
 	resp, body = do(t, ts, http.MethodPost, "/api/v1/trash/empty", nil,
 		map[string]any{"older_than": ""})

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -472,6 +472,11 @@ func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 	require.Len(t, trashPage.Items, 1)
 	assert.Equal(t, document.ID, trashPage.Items[0].ID)
 
+	resp = webRequest(http.MethodGet, "/api/v1/trash")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"browser sessions cannot use the master API's unbounded trash listing")
+	require.NoError(t, resp.Body.Close())
+
 	restoreRequest, err := http.NewRequest(
 		http.MethodPost,
 		ts.URL+"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/restore",

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -464,12 +464,36 @@ func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 	assert.NotEmpty(t, trashed.TrashedAt)
 	assert.Equal(t, "/Taxes/return.txt", trashed.Path)
 
-	resp = webRequest(
+	resp = webRequest(http.MethodGet, "/api/v1/trash?limit=1000&offset=0")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var trashPage api.TrashPage
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&trashPage))
+	require.NoError(t, resp.Body.Close())
+	require.Len(t, trashPage.Items, 1)
+	assert.Equal(t, document.ID, trashPage.Items[0].ID)
+
+	restoreRequest, err := http.NewRequest(
 		http.MethodPost,
-		"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/restore",
+		ts.URL+"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/restore",
+		nil,
 	)
+	require.NoError(t, err)
+	restoreRequest.Header["X-Api-Key"] = []string{""}
+	restoreRequest.Header.Set(api.WebSessionHeader, issued.Token)
+	restoreRequest.Header.Set("If-Match", strconv.FormatInt(trashed.Revision, 10))
+	resp, err = ts.Client().Do(restoreRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var restored api.Node
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&restored))
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, document.ID, restored.ID)
+	assert.Empty(t, restored.TrashedAt)
+	assert.Equal(t, "/Taxes/return.txt", restored.Path)
+
+	resp = webRequest(http.MethodPost, "/api/v1/trash/empty")
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
-		"browser trash permission does not grant restore or other mutations")
+		"browser restore permission does not grant permanent deletion")
 	require.NoError(t, resp.Body.Close())
 
 	resp = webRequest(http.MethodGet,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -43,6 +43,14 @@ type NodePage struct {
 	Offset    int    `json:"offset"`
 }
 
+// TrashPage is one newest-first page of independently restorable trash roots.
+type TrashPage struct {
+	Items  []Node `json:"items"`
+	Total  int    `json:"total"`
+	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
+}
+
 // BatchMoveItem identifies a live source either by absolute virtual path or
 // by stable node identity plus revision. DestinationPath is an exact final
 // coordinate whose parent is resolved in the planned final topology.

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -191,10 +191,15 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	if method != http.MethodGet {
 		return false
 	}
+	if path == "/api/v1/trash" {
+		// The master API retains the released unbounded form, but a browser
+		// session may request only the UI's fixed bounded page.
+		return r.URL.RawQuery == "limit=1000&offset=0"
+	}
 	switch path {
 	case "/api/v1/path", "/api/v1/search",
 		"/api/v1/audit/status", "/api/v1/audit/history", "/api/v1/jobs",
-		"/api/v1/storage", "/api/v1/tags", "/api/v1/trash":
+		"/api/v1/storage", "/api/v1/tags":
 		return true
 	case "/api/v1/backup/snapshots":
 		// Browser sessions may inspect only the repository selected by daemon

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -23,7 +23,7 @@ const (
 // webSessionRegistry owns browser credentials for exactly one daemon
 // lifetime. Tokens are random, retained only as digests, and authorize only
 // the deliberately limited routes used by the built-in browser. Most are
-// reads; verified upload and revision-bound move-to-trash are the only
+// reads; verified upload plus revision-bound trash and restore are the only
 // document-authority mutations.
 type webSessionRegistry struct {
 	mu          sync.Mutex
@@ -178,7 +178,9 @@ func webSessionRequestAllowed(r *http.Request) bool {
 		if after, ok := strings.CutPrefix(path, prefix); ok {
 			parts := strings.Split(after, "/")
 			nodeID, err := strconv.ParseInt(parts[0], 10, 64)
-			if len(parts) == 2 && parts[1] == "trash" && err == nil && nodeID > 0 {
+			if len(parts) == 2 &&
+				(parts[1] == "trash" || parts[1] == "restore") &&
+				err == nil && nodeID > 0 {
 				return true
 			}
 		}
@@ -192,7 +194,7 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	switch path {
 	case "/api/v1/path", "/api/v1/search",
 		"/api/v1/audit/status", "/api/v1/audit/history", "/api/v1/jobs",
-		"/api/v1/storage", "/api/v1/tags":
+		"/api/v1/storage", "/api/v1/tags", "/api/v1/trash":
 		return true
 	case "/api/v1/backup/snapshots":
 		// Browser sessions may inspect only the repository selected by daemon

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2460,18 +2460,9 @@ func (c *Client) TrashPage(
 }
 
 func (c *Client) TrashList(ctx context.Context) ([]api.Node, error) {
-	const pageSize = 1000
-	var roots []api.Node
-	for offset := 0; ; offset += pageSize {
-		page, err := c.TrashPage(ctx, pageSize, offset)
-		if err != nil {
-			return nil, err
-		}
-		roots = append(roots, page.Items...)
-		if len(roots) >= page.Total || len(page.Items) == 0 {
-			return roots, nil
-		}
-	}
+	var out api.TrashPage
+	err := c.do(ctx, http.MethodGet, "/api/v1/trash", nil, nil, &out)
+	return out.Items, err
 }
 
 func (c *Client) TrashEmpty(ctx context.Context, olderThan string, run bool) (api.TrashEmptyReport, error) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2449,12 +2449,29 @@ func (c *Client) Restore(ctx context.Context, id, rev int64) (api.Node, error) {
 	return n, err
 }
 
+func (c *Client) TrashPage(
+	ctx context.Context, limit, offset int,
+) (api.TrashPage, error) {
+	var out api.TrashPage
+	err := c.do(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v1/trash?limit=%d&offset=%d", limit, offset),
+		nil, nil, &out)
+	return out, err
+}
+
 func (c *Client) TrashList(ctx context.Context) ([]api.Node, error) {
-	var out struct {
-		Items []api.Node `json:"items"`
+	const pageSize = 1000
+	var roots []api.Node
+	for offset := 0; ; offset += pageSize {
+		page, err := c.TrashPage(ctx, pageSize, offset)
+		if err != nil {
+			return nil, err
+		}
+		roots = append(roots, page.Items...)
+		if len(roots) >= page.Total || len(page.Items) == 0 {
+			return roots, nil
+		}
 	}
-	err := c.do(ctx, http.MethodGet, "/api/v1/trash", nil, nil, &out)
-	return out.Items, err
 }
 
 func (c *Client) TrashEmpty(ctx context.Context, olderThan string, run bool) (api.TrashEmptyReport, error) {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "53"
+	daemonProtocolVersion = "54"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/store/trash.go
+++ b/internal/store/trash.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const maxTrashPageSize = 1000
+
 // Trash soft-deletes a live node and its live subtree as a unit. All subtree
 // rows share one trashed_at stamp; only the top node records its original
 // location for restore. Unless ifRev is UnconditionalRev, the mutation
@@ -294,6 +296,61 @@ func (s *Store) TrashedRoots(ctx context.Context) ([]Node, error) {
 		return nil, fmt.Errorf("listing trash: %w", err)
 	}
 	return roots, nil
+}
+
+// TrashedRootsPage lists one bounded newest-first page of restorable trash
+// roots and the complete root count from the same read snapshot.
+func (s *Store) TrashedRootsPage(
+	ctx context.Context, limit, offset int,
+) ([]Node, int, error) {
+	if limit < 1 || limit > maxTrashPageSize {
+		return nil, 0, fmt.Errorf(
+			"trash limit must be between 1 and %d", maxTrashPageSize)
+	}
+	if offset < 0 {
+		return nil, 0, errors.New("trash offset must not be negative")
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, 0, fmt.Errorf("starting trash snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var total int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM nodes WHERE trash_name IS NOT NULL`,
+	).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("counting trash: %w", err)
+	}
+	rows, err := tx.QueryContext(ctx,
+		`SELECT `+nodeCols+` FROM `+nodeFrom+`
+		 WHERE n.trash_name IS NOT NULL
+		 ORDER BY n.trashed_at DESC, n.id DESC LIMIT ? OFFSET ?`,
+		limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing trash page: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	roots := make([]Node, 0)
+	for rows.Next() {
+		node, err := scanNode(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		roots = append(roots, node)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("listing trash page: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, fmt.Errorf("closing trash page: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, 0, fmt.Errorf("closing trash snapshot: %w", err)
+	}
+	return roots, total, nil
 }
 
 // TrashEmptyResult reports one trash-empty dry run or execution.

--- a/internal/store/trash_test.go
+++ b/internal/store/trash_test.go
@@ -159,6 +159,35 @@ func TestTrashPath(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestTrashedRootsPageIsBounded(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	for _, name := range []string{"first", "second", "third"} {
+		node, err := s.Mkdir(ctx, s.RootID(), name)
+		require.NoError(t, err)
+		_, _, err = s.Trash(ctx, node.ID, node.Revision)
+		require.NoError(t, err)
+	}
+
+	first, total, err := s.TrashedRootsPage(ctx, 2, 0)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	assert.Equal(t, 3, total)
+
+	last, total, err := s.TrashedRootsPage(ctx, 2, 2)
+	require.NoError(t, err)
+	require.Len(t, last, 1)
+	assert.Equal(t, 3, total)
+	assert.NotEqual(t, first[0].ID, last[0].ID)
+	assert.NotEqual(t, first[1].ID, last[0].ID)
+
+	_, _, err = s.TrashedRootsPage(ctx, 0, 0)
+	require.ErrorContains(t, err, "trash limit")
+	_, _, err = s.TrashedRootsPage(ctx, 1, -1)
+	require.ErrorContains(t, err, "trash offset")
+}
+
 func TestTrashEmpty(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()


### PR DESCRIPTION
Docbank’s browser can now complete the recoverable-trash lifecycle. A person can open **Recoverable trash**, inspect the newest restorable roots, and return one to the live tree after an explicit confirmation. If the original parent no longer exists, Docbank restores beneath `/`; if the name is occupied, the receipt shows the collision-suffixed path that actually won.

The decision is bound to the stable node ID and inspected revision. If a CLI, agent, or another browser action changes the item first, the restore stays uncommitted and reports the stale decision rather than acting on newer state. After success, the browser discards cached live-tree paths and reloads from the root while the trash drawer retains the authoritative returned path.

![The actual Docbank web application confirming restoration of a synthetic report from recoverable trash](https://raw.githubusercontent.com/kenn-io/docbank/93e403c/screenshots/web-trash-restore/web-trash-restore.png)

*Actual daemon-served interface using a temporary synthetic vault; no private corpus data is present.*

This is deliberately not a permanent-deletion surface. The daemon-lifetime browser session may list a bounded 1,000 recoverable roots and restore one inspected revision, but it still cannot empty trash, run garbage collection, or reclaim bytes. The released no-query `GET /trash` behavior remains available to older clients; current clients page through the bounded form when they need the complete list.