### PR TITLE
Manage tag definitions from the web

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Four commitments:
 - A read-only daemon-backed TUI for analytical tree browsing, search, stable
   document/version identity inspection, and permanent audited-history timelines
 - A scoped kit-ui web application for verified local-file upload, virtual-tree browsing, sortable
-  document analysis, tag browsing and assignment, tag-filtered extracted-text search,
+  document analysis, tag-definition management, tag browsing and assignment,
+  tag-filtered extracted-text search,
   complete current authority, verified current and historical content download,
   recoverable move-to-trash and revision-bound restoration,
   permanent protection and event history, immutable versions and provenance,

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "55", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "56", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "55", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "56", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "55", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "56", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "55", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "56", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -69,7 +69,7 @@ independent upload-proof secret, and the fresh loopback origin dedicated to
 that daemon lifetime, while
 `DELETE /api/daemon/web-session` revokes the calling browser session. Those
 tokens authenticate only the explicit routes used by the built-in document,
-tag-assignment, recoverable-trash, storage, job, configured-backup, and
+tag-definition/assignment, recoverable-trash, storage, job, configured-backup, and
 verified-download workflows; they are intentionally not another general API
 credential. Browser file bytes use the
 hidden `/api/daemon/web-upload` WebSocket instead. The page verifies a

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ from the CLI, automate through the authenticated HTTP API, or embed Docbank in
 a Go application. People can browse the same authority in the local web
 application or focused terminal interface; the web application verifies
 current or retained document bytes before handing them to the browser's native
-save, lets people assign existing stable tags, and keeps the vault's
+save, lets people define and assign stable tags, and keeps the vault's
 loose-file/live-packed/dead-packed storage breakdown visible alongside
 document authority.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: analytical tree/search/detail, audited-history, daemon-job inspection, web tag browsing and assignment, version history, provenance, verified current/historical content download, verified upload, and recoverable trash with restoration implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: analytical tree/search/detail, audited-history, daemon-job inspection, web tag definition/browsing/assignment workflows, version history, provenance, verified current/historical content download, verified upload, and recoverable trash with restoration implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -144,9 +144,11 @@ before a one-use browser handoff, and the browser never buffers the whole
 object or receives the vault API key. Every file exposes its newest-first immutable
 version history and complete version, hash, operation, and revert-source
 authority, plus its newest-first immutable provenance facts and supersession
-history. Every selected node exposes its tag assignments, can add or remove
-an existing definition under its inspected revision, and a stable tag identity
-can drive either a live assignment view or a text-search filter.
+history. Every selected node exposes its tag assignments and can add or remove
+an existing definition under its inspected revision. The shared catalog
+creates, revision-safely renames, and deliberately deletes stable definitions,
+and a stable tag identity can drive either a live assignment view or a
+text-search filter.
 Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
 portal also uploads local files through the same caller-declared and
@@ -156,9 +158,8 @@ lists newest-first trash roots, restores one inspected revision while
 reporting its actual collision- or fallback-resolved path, lists configured
 backup recovery points, reports current and terminal daemon background jobs,
 and separates physical loose files, live packed content, complete pack payload,
-and logically dead payload awaiting explicit repack. Future slices cover tag
-definition management and broader metadata, version comparison, and storage
-maintenance.
+and logically dead payload awaiting explicit repack. Future slices cover
+broader metadata, version comparison, and storage maintenance.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -20,7 +20,9 @@ type. A selected live file or folder can be moved to recoverable trash after an
 explicit confirmation; the trash drawer lists restorable roots and returns one
 to the live tree under its inspected revision. The authority card also shows
 every tag assigned to the selected file or folder and can add or remove an
-existing definition under the node's inspected revision. Selecting a tag
+existing definition under the node's inspected revision. The toolbar's tag
+catalog also creates, renames, and deliberately deletes stable definitions.
+Selecting a tag
 browses its live assignments, while search can require the same exact tag
 identity. Protected documents expose
 their newest-first permanent audit timeline and complete event authority. The
@@ -80,11 +82,24 @@ status. If another person, agent, or CLI command changed the node first, the
 dialog keeps the failed decision visible and asks you to refresh rather than
 applying it to newer state.
 
-This surface changes only assignments on the selected live node. Creating,
-renaming, or deleting tag definitions and bulk assignment remain explicit CLI
-or master-authenticated API workflows. When the vault has more than 1,000 tag
-definitions, use those exhaustive interfaces to reach definitions outside the
-browser's catalog page.
+## Manage tag definitions
+
+Choose the tag-catalog button beside the toolbar selector to create, rename,
+or delete the vault's shared tag definitions. Creating allocates a new stable
+UUID. Renaming keeps that identity while advancing the definition revision and
+every assigned node's metadata authority. A stale rename remains visible
+instead of overwriting a definition changed by another person or agent.
+
+Deleting requires a separate confirmation that names the exact stable ID,
+revision, and current assignment count. It removes the definition and all of
+its assignments, but never deletes a document or its stored content. Reusing
+the same name later creates a different stable identity. After a rename or
+deletion, the browser reloads the active folder, search, or tag view so node
+revisions and assignment counts remain authoritative.
+
+The catalog shows the first 1,000 name-sorted definitions and discloses the
+complete count. Use `docbank tag`, the paginated HTTP API, or an embedded client
+for exhaustive definition management and bulk assignment.
 
 ## Move a node to recoverable trash
 
@@ -370,8 +385,8 @@ in page memory. Ordinary requests use
 search, tag-definition and assignment reads, immutable-version, provenance,
 audit-status, audit-history, background-job, physical-storage-status,
 configured backup-snapshot-list, bounded trash-list, verified-download
-preparation, and revision-bound move-to-trash, restore, tag-assignment, and
-tag-removal requests used by this interface.
+preparation, revision-bound move-to-trash and restore, tag assignment/removal,
+and tag-definition create/rename/delete requests used by this interface.
 Download preparation may write only owner-private temporary bytes and issue
 one exact, expiring file ticket. Upload uses a separate, never-reconnecting
 WebSocket authenticated by a challenge proof over the upload secret. No file
@@ -380,8 +395,10 @@ beneath the stable live directory selected in the browser and must satisfy the
 same caller-declared/server-computed byte identity as every remote writer. The
 trash and restore requests can target only the stable selected node and must
 carry its current revision, so a stale browser view cannot move changed state.
-Tag assignment and removal have the same stable-node revision boundary and do
-not grant tag-definition lifecycle or bulk-mutation authority. The session
+Tag assignment and removal have the same stable-node revision boundary.
+Renaming and deleting definitions require their inspected tag revision, and
+definition deletion explicitly reports how many assignments were removed.
+These permissions do not grant bulk tag mutation. The session
 cannot empty trash, perform any other document mutation,
 enroll audit scopes, run independent verification, or call backup creation,
 verification, restore, maintenance, configuration, or general API endpoints.
@@ -419,8 +436,8 @@ children in one metadata snapshot, so a concurrent CLI or agent move cannot
 leave the browser constructing child paths beneath an obsolete name.
 
 The current web application does not compare versions, recursively import
-folders, edit, revert, prune, move, create or change tags and
-assignments, empty trash, enroll audit scopes, run independent audit verification,
+folders, edit, revert, prune, move live nodes between folders, bulk-apply tags,
+empty trash, enroll audit scopes, run independent audit verification,
 or run maintenance, backup, verification, or restore operations.
 Use the corresponding CLI or authenticated HTTP endpoint for those workflows.
 Future web workflows will require deliberately expanded browser-session

--- a/frontend/screenshots/README.md
+++ b/frontend/screenshots/README.md
@@ -23,8 +23,8 @@ an owner-private temporary vault, opens the daemon-issued browser session,
 captures the requested state, stops the daemon, and removes the vault.
 Generated images are written beneath `.superpowers/screenshots/` for visual
 inspection and PR attachment; the current case captures both move-to-trash and
-restore confirmations plus a completed tag assignment. Generated images are
-intentionally not committed.
+restore confirmations, the tag-definition catalog, and a completed tag
+assignment. Generated images are intentionally not committed.
 
 Pass ordinary Playwright arguments after `--` to select a case:
 

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -28,6 +28,12 @@ const tagAssignmentScreenshotPath = path.join(
   "screenshots",
   "web-tag-assignment.png",
 );
+const tagCatalogScreenshotPath = path.join(
+  repositoryRoot,
+  ".superpowers",
+  "screenshots",
+  "web-tag-catalog.png",
+);
 
 test.describe("Docbank web screenshots", () => {
   let workspace = "";
@@ -54,6 +60,7 @@ test.describe("Docbank web screenshots", () => {
     await rm(screenshotPath, { force: true });
     await rm(restoreScreenshotPath, { force: true });
     await rm(tagAssignmentScreenshotPath, { force: true });
+    await rm(tagCatalogScreenshotPath, { force: true });
     const reports = path.join(workspace, "synthetic", "Reports");
     await mkdir(reports, { recursive: true, mode: 0o700 });
     await writeFile(
@@ -145,6 +152,22 @@ test.describe("Docbank web screenshots", () => {
       `,
     });
 
+    await page.getByRole("button", { name: "Manage tag definitions" }).click();
+    const catalog = page.getByRole("dialog", {
+      name: "Manage tag definitions",
+    });
+    await expect(catalog).toContainText("tax");
+    await expect(catalog).toContainText("reviewed");
+    await catalog.getByRole("textbox", { name: "New tag name" }).fill("archived");
+    await catalog.getByRole("button", { name: "Create" }).click();
+    await expect(catalog).toContainText("Created archived.");
+    await page.screenshot({
+      path: tagCatalogScreenshotPath,
+      fullPage: true,
+      animations: "disabled",
+    });
+    await catalog.getByRole("button", { name: "Done" }).click();
+
     await page.getByRole("cell", { name: "Reports", exact: true }).dblclick();
     const report = page.getByRole("cell", {
       name: "quarterly-tax-report.txt",
@@ -153,7 +176,7 @@ test.describe("Docbank web screenshots", () => {
     await expect(report).toBeVisible();
     await report.click();
 
-    await page.getByRole("button", { name: "Manage" }).click();
+    await page.getByRole("button", { name: "Manage", exact: true }).click();
     const tags = page.getByRole("dialog", {
       name: "Manage tags for quarterly-tax-report.txt",
     });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,6 +11,7 @@
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import SearchIcon from "@lucide/svelte/icons/search";
   import TagIcon from "@lucide/svelte/icons/tag";
+  import TagsIcon from "@lucide/svelte/icons/tags";
   import HistoryIcon from "@lucide/svelte/icons/history";
   import Trash2Icon from "@lucide/svelte/icons/trash-2";
   import UploadIcon from "@lucide/svelte/icons/upload";
@@ -39,6 +40,9 @@
   import ManageTagsModal from "./ManageTagsModal.svelte";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import StorageDrawer from "./StorageDrawer.svelte";
+  import TagCatalogModal, {
+    type TagDefinitionChange,
+  } from "./TagCatalogModal.svelte";
   import TrashDrawer from "./TrashDrawer.svelte";
   import TrashNodeModal from "./TrashNodeModal.svelte";
   import UploadDrawer from "./UploadDrawer.svelte";
@@ -99,6 +103,7 @@
   let tagCatalog = $state<Tag[]>([]);
   let tagCatalogTotal = $state(0);
   let tagCatalogListed = $state(0);
+  let tagCatalogLoading = $state(false);
   let tagCatalogError = $state("");
   let selectedTags = $state<Tag[]>([]);
   let selectedTagsTotal = $state(0);
@@ -121,6 +126,7 @@
   let backupsOpen = $state(false);
   let trashOpen = $state(false);
   let manageTagsTarget = $state<Row | null>(null);
+  let tagCatalogOpen = $state(false);
   let uploadTarget = $state<Node | null>(null);
   let trashTarget = $state<Row | null>(null);
   let generation = 0;
@@ -181,10 +187,12 @@
       storageOpen = false;
       backupsOpen = false;
       trashOpen = false;
+      tagCatalogOpen = false;
       uploadTarget = null;
       trashTarget = null;
       tagCatalog = [];
       tagCatalogListed = 0;
+      tagCatalogLoading = false;
       selectedTags = [];
       selectedTagsTotal = 0;
       searchPending = false;
@@ -445,6 +453,7 @@
     const request = ++tagCatalogGeneration;
     const session = webSession;
     const selectedTagID = tagFilterID;
+    tagCatalogLoading = true;
     tagCatalogError = "";
     try {
       const page = await tags(session);
@@ -492,6 +501,8 @@
         return;
       }
       tagCatalogError = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === tagCatalogGeneration) tagCatalogLoading = false;
     }
   }
 
@@ -674,6 +685,60 @@
     }
   }
 
+  function handleTagDefinitionChanged(change: TagDefinitionChange): void {
+    const changedTag = change.tag;
+    if (change.kind === "renamed") {
+      tagCatalog = tagCatalog
+        .map((tag) => (tag.id === changedTag.id ? changedTag : tag))
+        .sort((left, right) => left.name.localeCompare(right.name));
+      selectedTags = selectedTags
+        .map((tag) => (tag.id === changedTag.id ? changedTag : tag))
+        .sort((left, right) => left.name.localeCompare(right.name));
+    } else if (change.kind === "deleted") {
+      tagCatalog = tagCatalog.filter((tag) => tag.id !== changedTag.id);
+      tagCatalogTotal = Math.max(0, tagCatalogTotal - 1);
+      tagCatalogListed = Math.min(tagCatalogListed, tagCatalog.length);
+      if (selectedTags.some((tag) => tag.id === changedTag.id)) {
+        selectedTags = selectedTags.filter((tag) => tag.id !== changedTag.id);
+        selectedTagsTotal = Math.max(0, selectedTagsTotal - 1);
+      }
+      stack = stack.map((snapshot) =>
+        snapshot.tagFilterID === changedTag.id ||
+        snapshot.activeTagID === changedTag.id
+          ? {
+              ...snapshot,
+              tagFilterID:
+                snapshot.tagFilterID === changedTag.id
+                  ? ""
+                  : snapshot.tagFilterID,
+              activeTagID:
+                snapshot.activeTagID === changedTag.id
+                  ? ""
+                  : snapshot.activeTagID,
+            }
+          : snapshot,
+      );
+    }
+
+    void loadTagCatalog();
+    if (change.kind === "created") return;
+
+    const preferredSelectedID = selectedID;
+    if (change.kind === "deleted" && activeTagID === changedTag.id) {
+      tagFilterID = "";
+      activeTagID = "";
+      taggedInspected = 0;
+      taggedTotal = 0;
+      taggedTrashed = 0;
+    }
+    if (activeQuery) void runSearch(preferredSelectedID);
+    else if (activeTagID) {
+      void loadTaggedNodes(activeTagID, preferredSelectedID);
+    } else if (directory) {
+      void loadDirectory(directory.id, false, preferredSelectedID, true);
+    }
+  }
+
   async function lock(): Promise<void> {
     generation += 1;
     auditGeneration += 1;
@@ -695,6 +760,7 @@
     tagCatalog = [];
     tagCatalogTotal = 0;
     tagCatalogListed = 0;
+    tagCatalogLoading = false;
     tagCatalogError = "";
     auditLoading = false;
     auditError = "";
@@ -706,6 +772,7 @@
     backupsOpen = false;
     trashOpen = false;
     manageTagsTarget = null;
+    tagCatalogOpen = false;
     uploadTarget = null;
     trashTarget = null;
     activeQuery = "";
@@ -877,6 +944,27 @@
               disabled={!directory || tagCatalog.length === 0}
               onchange={changeTagFilter}
             />
+            <IconButton
+              size="sm"
+              ariaLabel="Manage tag definitions"
+              title="Create, rename, or delete tag definitions"
+              disabled={loading || tagCatalogLoading}
+              onclick={() => {
+                if (loading || tagCatalogLoading) return;
+                historyOpen = false;
+                versionsOpen = false;
+                provenanceOpen = false;
+                jobsOpen = false;
+                storageOpen = false;
+                backupsOpen = false;
+                trashOpen = false;
+                manageTagsTarget = null;
+                uploadTarget = null;
+                tagCatalogOpen = true;
+              }}
+            >
+              <TagsIcon size="14" aria-hidden="true" />
+            </IconButton>
             {#if tagBrowse}
               <span>
                 {rows.length} live shown
@@ -1332,6 +1420,17 @@
         disabled={loading}
         onclose={() => (manageTagsTarget = null)}
         onchanged={handleTagChanged}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if tagCatalogOpen}
+      <TagCatalogModal
+        session={webSession}
+        catalog={tagCatalog}
+        catalogTotal={tagCatalogTotal}
+        disabled={loading || tagCatalogLoading}
+        onclose={() => (tagCatalogOpen = false)}
+        onchanged={handleTagDefinitionChanged}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/TagCatalogModal.svelte
+++ b/frontend/src/TagCatalogModal.svelte
@@ -1,0 +1,533 @@
+<script module lang="ts">
+  export type TagDefinitionChange =
+    | { kind: "created"; tag: import("./api.js").Tag }
+    | { kind: "renamed"; tag: import("./api.js").Tag }
+    | {
+        kind: "deleted";
+        tag: import("./api.js").Tag;
+        removedAssignments: number;
+      };
+</script>
+
+<script lang="ts">
+  import { untrack } from "svelte";
+  import CheckIcon from "@lucide/svelte/icons/check";
+  import PencilIcon from "@lucide/svelte/icons/pencil";
+  import PlusIcon from "@lucide/svelte/icons/plus";
+  import TagIcon from "@lucide/svelte/icons/tag";
+  import Trash2Icon from "@lucide/svelte/icons/trash-2";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Chip,
+    IconButton,
+    Modal,
+    Spinner,
+    TextInput,
+  } from "@kenn-io/kit-ui";
+  import {
+    APIError,
+    createTag,
+    deleteTag,
+    renameTag,
+    type Tag,
+  } from "./api.js";
+
+  let {
+    session,
+    catalog,
+    catalogTotal,
+    disabled,
+    onclose,
+    onchanged,
+    onauthfailure,
+  }: {
+    session: string;
+    catalog: Tag[];
+    catalogTotal: number;
+    disabled: boolean;
+    onclose: () => void;
+    onchanged: (change: TagDefinitionChange) => void;
+    onauthfailure: (cause: unknown) => void;
+  } = $props();
+
+  let current = $state(untrack(() => [...catalog]));
+  let currentTotal = $state(untrack(() => catalogTotal));
+  let newName = $state("");
+  let editingID = $state("");
+  let editName = $state("");
+  let deleting = $state<Tag | null>(null);
+  let pending = $state(false);
+  let failure = $state("");
+  let notice = $state("");
+
+  function close(): void {
+    if (!pending) onclose();
+  }
+
+  function reportFailure(cause: unknown): void {
+    if (cause instanceof APIError && cause.status === 401) {
+      onauthfailure(cause);
+      return;
+    }
+    failure = cause instanceof Error ? cause.message : String(cause);
+  }
+
+  function beginRename(tag: Tag): void {
+    editingID = tag.id;
+    editName = tag.name;
+    deleting = null;
+    failure = "";
+    notice = "";
+  }
+
+  function cancelRename(): void {
+    editingID = "";
+    editName = "";
+  }
+
+  async function create(): Promise<void> {
+    if (disabled || pending || newName === "") return;
+    pending = true;
+    failure = "";
+    notice = "";
+    try {
+      const tag = await createTag(session, newName);
+      current = [...current, tag].sort((left, right) =>
+        left.name.localeCompare(right.name),
+      );
+      currentTotal += 1;
+      newName = "";
+      notice = `Created ${tag.name}.`;
+      onchanged({ kind: "created", tag });
+    } catch (cause) {
+      reportFailure(cause);
+    } finally {
+      pending = false;
+    }
+  }
+
+  async function saveRename(): Promise<void> {
+    const tag = current.find((item) => item.id === editingID);
+    if (!tag || disabled || pending || editName === "") return;
+    pending = true;
+    failure = "";
+    notice = "";
+    try {
+      const renamed = await renameTag(session, tag.id, tag.revision, editName);
+      current = current
+        .map((item) => (item.id === renamed.id ? renamed : item))
+        .sort((left, right) => left.name.localeCompare(right.name));
+      editingID = "";
+      editName = "";
+      notice = `Renamed tag to ${renamed.name}.`;
+      onchanged({ kind: "renamed", tag: renamed });
+    } catch (cause) {
+      reportFailure(cause);
+    } finally {
+      pending = false;
+    }
+  }
+
+  async function confirmDelete(): Promise<void> {
+    if (!deleting || disabled || pending) return;
+    const target = deleting;
+    pending = true;
+    failure = "";
+    notice = "";
+    try {
+      const receipt = await deleteTag(session, target.id, target.revision);
+      current = current.filter((tag) => tag.id !== target.id);
+      currentTotal = Math.max(0, currentTotal - 1);
+      deleting = null;
+      notice = `Deleted ${receipt.tag.name} and removed ${receipt.removed_assignments} assignment${receipt.removed_assignments === 1 ? "" : "s"}.`;
+      onchanged({
+        kind: "deleted",
+        tag: receipt.tag,
+        removedAssignments: receipt.removed_assignments,
+      });
+    } catch (cause) {
+      reportFailure(cause);
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<Modal
+  title={deleting ? "Delete tag definition?" : "Tag catalog"}
+  tone={deleting ? "danger" : "info"}
+  width="680px"
+  maxWidth="min(680px, calc(100vw - 32px))"
+  ariaLabel={deleting ? `Delete tag ${deleting.name}` : "Manage tag definitions"}
+  onclose={close}
+  closeOnOverlayClick={!pending}
+>
+  {#if deleting}
+    <div class="delete-confirmation">
+      <div class="delete-target">
+        <Trash2Icon size="20" aria-hidden="true" />
+        <div>
+          <strong>{deleting.name}</strong>
+          <code>{deleting.id}</code>
+          <span>
+            Revision {deleting.revision} · {deleting.assignment_count} assignment{deleting.assignment_count === 1 ? "" : "s"}
+          </span>
+        </div>
+      </div>
+      <p>
+        This permanently removes the tag definition and every assignment that
+        currently uses it. Documents and their stored content are not deleted.
+      </p>
+      <p class="boundary">
+        This action cannot be undone. You may create a tag with the same name
+        later, but it will have a different stable identity.
+      </p>
+      {#if failure}<p class="failure" role="alert">{failure}</p>{/if}
+    </div>
+  {:else}
+    <div class="tag-catalog">
+      <header class="catalog-heading">
+        <TagIcon size="20" aria-hidden="true" />
+        <div>
+          <strong>Organize the vault’s shared vocabulary</strong>
+          <span>
+            Names can change; stable tag IDs continue to identify the same definition.
+          </span>
+        </div>
+      </header>
+
+      <section aria-labelledby="create-tag-heading">
+        <div class="section-heading">
+          <div>
+            <span>NEW DEFINITION</span>
+            <strong id="create-tag-heading">Create a tag</strong>
+          </div>
+        </div>
+        <form
+          class="create-row"
+          onsubmit={(event) => {
+            event.preventDefault();
+            void create();
+          }}
+        >
+          <TextInput
+            bind:value={newName}
+            block
+            ariaLabel="New tag name"
+            placeholder="e.g. reviewed"
+            disabled={disabled || pending}
+          />
+          <Button
+            size="sm"
+            tone="info"
+            surface="solid"
+            disabled={disabled || pending || newName === ""}
+            onclick={() => void create()}
+          >
+            {#if pending && !editingID}<Spinner size={13} />{:else}<PlusIcon size="14" />{/if}
+            Create
+          </Button>
+        </form>
+      </section>
+
+      <section aria-labelledby="tag-definitions-heading">
+        <div class="section-heading">
+          <div>
+            <span>TAG DEFINITIONS</span>
+            <strong id="tag-definitions-heading">{current.length} visible</strong>
+          </div>
+          <small>{currentTotal} total</small>
+        </div>
+        {#if current.length === 0}
+          <p class="empty">No tags have been defined yet.</p>
+        {:else}
+          <div class="definition-list">
+            {#each current as tag (tag.id)}
+              <div class="definition-row">
+                {#if editingID === tag.id}
+                  <div class="rename-row">
+                    <TextInput
+                      bind:value={editName}
+                      block
+                      autofocus
+                      ariaLabel={`Rename ${tag.name}`}
+                      disabled={disabled || pending}
+                      onkeydown={(event) => {
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          void saveRename();
+                        } else if (event.key === "Escape") {
+                          cancelRename();
+                        }
+                      }}
+                    />
+                    <IconButton
+                      size="sm"
+                      ariaLabel={`Save renamed tag ${tag.name}`}
+                      disabled={disabled || pending || editName === ""}
+                      onclick={() => void saveRename()}
+                    >
+                      {#if pending}<Spinner size={13} />{:else}<CheckIcon size="14" />{/if}
+                    </IconButton>
+                    <IconButton
+                      size="sm"
+                      ariaLabel={`Cancel renaming ${tag.name}`}
+                      disabled={pending}
+                      onclick={cancelRename}
+                    >
+                      <XIcon size="14" />
+                    </IconButton>
+                  </div>
+                {:else}
+                  <div class="definition-authority">
+                    <div>
+                      <Chip size="sm" tone="workspace" uppercase={false}>{tag.name}</Chip>
+                      <span>{tag.assignment_count} assignment{tag.assignment_count === 1 ? "" : "s"}</span>
+                    </div>
+                    <code>{tag.id}</code>
+                  </div>
+                  <div class="definition-actions">
+                    <IconButton
+                      size="sm"
+                      ariaLabel={`Rename tag ${tag.name}`}
+                      title={`Rename ${tag.name}`}
+                      disabled={disabled || pending}
+                      onclick={() => beginRename(tag)}
+                    >
+                      <PencilIcon size="14" />
+                    </IconButton>
+                    <IconButton
+                      size="sm"
+                      ariaLabel={`Delete tag ${tag.name}`}
+                      title={`Delete ${tag.name}`}
+                      disabled={disabled || pending}
+                      onclick={() => {
+                        cancelRename();
+                        deleting = tag;
+                        failure = "";
+                        notice = "";
+                      }}
+                    >
+                      <Trash2Icon size="14" />
+                    </IconButton>
+                  </div>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+        {#if currentTotal > current.length}
+          <p class="bounded">
+            Showing the first {current.length} of {currentTotal} definitions.
+            Use the CLI or API for definitions outside this bounded catalog.
+          </p>
+        {/if}
+      </section>
+
+      {#if notice}<p class="notice" role="status">{notice}</p>{/if}
+      {#if failure}<p class="failure" role="alert">{failure}</p>{/if}
+    </div>
+  {/if}
+  {#snippet footer()}
+    {#if deleting}
+      <Button surface="soft" disabled={pending} onclick={() => (deleting = null)}>
+        Keep tag
+      </Button>
+      <Button
+        tone="danger"
+        surface="solid"
+        disabled={disabled || pending}
+        onclick={() => void confirmDelete()}
+      >
+        {#if pending}<Spinner size={14} /> Deleting…{:else}<Trash2Icon size="14" /> Delete tag{/if}
+      </Button>
+    {:else}
+      <Button surface="soft" disabled={pending} onclick={close}>Done</Button>
+    {/if}
+  {/snippet}
+</Modal>
+
+<style>
+  .tag-catalog,
+  .delete-confirmation {
+    display: grid;
+    gap: var(--space-5);
+  }
+
+  .catalog-heading,
+  .delete-target {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-inset);
+  }
+
+  .catalog-heading > :global(svg) {
+    margin-top: 2px;
+    color: var(--accent-cyan);
+  }
+
+  .catalog-heading > div,
+  .delete-target > div {
+    display: grid;
+    min-width: 0;
+    gap: var(--space-1);
+  }
+
+  .catalog-heading strong,
+  .delete-target strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+  }
+
+  .catalog-heading span,
+  .delete-target span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.4;
+  }
+
+  section {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .section-heading {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .section-heading > div {
+    display: grid;
+    gap: 2px;
+  }
+
+  .section-heading span,
+  .section-heading small {
+    color: var(--text-muted);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+  }
+
+  .section-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  .create-row,
+  .rename-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .definition-list {
+    display: grid;
+    max-height: min(330px, 42vh);
+    overflow-y: auto;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-inset);
+  }
+
+  .definition-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--space-3);
+    min-height: 56px;
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .definition-row:last-child {
+    border-bottom: 0;
+  }
+
+  .definition-authority {
+    display: grid;
+    min-width: 0;
+    gap: var(--space-2);
+  }
+
+  .definition-authority > div {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .definition-authority span,
+  .definition-authority code,
+  .delete-target code {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .definition-authority code,
+  .delete-target code {
+    overflow-wrap: anywhere;
+  }
+
+  .definition-actions {
+    display: flex;
+    gap: var(--space-1);
+  }
+
+  .rename-row {
+    grid-column: 1 / -1;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+
+  .notice,
+  .failure,
+  .empty,
+  .bounded,
+  .delete-confirmation p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+  }
+
+  .notice {
+    color: var(--accent-green);
+  }
+
+  .failure {
+    padding: var(--space-3);
+    border: 1px solid color-mix(in srgb, var(--accent-red) 35%, transparent);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent-red) 8%, transparent);
+    color: var(--accent-red);
+  }
+
+  .empty,
+  .bounded,
+  .boundary {
+    color: var(--text-muted);
+  }
+
+  .delete-target > :global(svg) {
+    margin-top: 2px;
+    color: var(--accent-red);
+  }
+
+  @media (max-width: 640px) {
+    .definition-row {
+      align-items: start;
+    }
+
+    .definition-authority > div {
+      align-items: start;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/frontend/src/TagCatalogModal.test.ts
+++ b/frontend/src/TagCatalogModal.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import TagCatalogModal from "./TagCatalogModal.svelte";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const tax = {
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "tax",
+  revision: 2,
+  assignment_count: 3,
+};
+
+it("creates, renames, and deliberately deletes stable tag definitions", async () => {
+  const reviewedID = "22222222-2222-4222-8222-222222222222";
+  const onchanged = vi.fn();
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+    async (_path, request) => {
+      if (request?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            id: reviewedID,
+            name: "reviewed",
+            revision: 1,
+            assignment_count: 0,
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (request?.method === "PATCH") {
+        return new Response(
+          JSON.stringify({
+            ...tax,
+            name: "tax filing",
+            revision: 3,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          tag: { ...tax, name: "tax filing", revision: 3 },
+          removed_assignments: 3,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    },
+  );
+
+  render(TagCatalogModal, {
+    session: "short-lived",
+    catalog: [tax],
+    catalogTotal: 1,
+    disabled: false,
+    onclose: vi.fn(),
+    onchanged,
+    onauthfailure: vi.fn(),
+  });
+
+  await fireEvent.input(screen.getByRole("textbox", { name: "New tag name" }), {
+    target: { value: "reviewed" },
+  });
+  await fireEvent.click(screen.getByRole("button", { name: "Create" }));
+  expect(await screen.findByText("Created reviewed.")).toBeTruthy();
+
+  await fireEvent.click(screen.getByRole("button", { name: "Rename tag tax" }));
+  const renameInput = screen.getByRole("textbox", { name: "Rename tax" });
+  await fireEvent.input(renameInput, { target: { value: "tax filing" } });
+  await fireEvent.click(
+    screen.getByRole("button", { name: "Save renamed tag tax" }),
+  );
+  expect(await screen.findByText("Renamed tag to tax filing.")).toBeTruthy();
+
+  await fireEvent.click(
+    screen.getByRole("button", { name: "Delete tag tax filing" }),
+  );
+  expect(
+    screen.getByText(
+      "This permanently removes the tag definition and every assignment that currently uses it. Documents and their stored content are not deleted.",
+    ),
+  ).toBeTruthy();
+  await fireEvent.click(screen.getByRole("button", { name: "Delete tag" }));
+  expect(
+    await screen.findByText(
+      "Deleted tax filing and removed 3 assignments.",
+    ),
+  ).toBeTruthy();
+
+  expect(fetchMock).toHaveBeenCalledTimes(3);
+  expect(
+    new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get("If-Match"),
+  ).toBe("2");
+  expect(
+    new Headers(fetchMock.mock.calls[2]?.[1]?.headers).get("If-Match"),
+  ).toBe("3");
+  expect(onchanged).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      kind: "created",
+      tag: expect.objectContaining({ id: reviewedID }),
+    }),
+  );
+  expect(onchanged).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      kind: "renamed",
+      tag: expect.objectContaining({ name: "tax filing" }),
+    }),
+  );
+  expect(onchanged).toHaveBeenNthCalledWith(
+    3,
+    expect.objectContaining({
+      kind: "deleted",
+      removedAssignments: 3,
+    }),
+  );
+});
+
+it("keeps a stale rename visible without losing the inspected definition", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        status: 412,
+        code: "stale_revision",
+        detail: "tag changed; refresh before renaming",
+      }),
+      {
+        status: 412,
+        headers: { "Content-Type": "application/problem+json" },
+      },
+    ),
+  );
+
+  render(TagCatalogModal, {
+    session: "short-lived",
+    catalog: [tax],
+    catalogTotal: 1,
+    disabled: false,
+    onclose: vi.fn(),
+    onchanged: vi.fn(),
+    onauthfailure: vi.fn(),
+  });
+
+  await fireEvent.click(screen.getByRole("button", { name: "Rename tag tax" }));
+  await fireEvent.input(screen.getByRole("textbox", { name: "Rename tax" }), {
+    target: { value: "tax filing" },
+  });
+  await fireEvent.click(
+    screen.getByRole("button", { name: "Save renamed tag tax" }),
+  );
+
+  expect(
+    await screen.findByText("tag changed; refresh before renaming"),
+  ).toBeTruthy();
+  await waitFor(() =>
+    expect(screen.getByRole("textbox", { name: "Rename tax" })).toBeTruthy(),
+  );
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -6,10 +6,13 @@ import {
   backupSnapshots,
   changeNodeTag,
   contentVersions,
+  createTag,
+  deleteTag,
   listJobs,
   liveTaggedNodes,
   nodeTags,
   requestJSON,
+  renameTag,
   restoreNode,
   revokeSession,
   search,
@@ -180,6 +183,70 @@ describe("browser authentication", () => {
       "/api/v1/nodes/42/tags?limit=1000&offset=0",
       "/api/v1/search?q=quarterly+report&limit=1000&tag_id=11111111-1111-4111-8111-111111111111",
     ]);
+  });
+
+  it("manages tag definitions under stable revision authority", async () => {
+    const tagID = "11111111-1111-4111-8111-111111111111";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_path, request) => {
+        const method = request?.method;
+        if (method === "POST") {
+          return new Response(
+            JSON.stringify({
+              id: tagID,
+              name: "tax",
+              revision: 1,
+              assignment_count: 0,
+            }),
+            { status: 201, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (method === "PATCH") {
+          return new Response(
+            JSON.stringify({
+              id: tagID,
+              name: "tax filing",
+              revision: 2,
+              assignment_count: 3,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            tag: {
+              id: tagID,
+              name: "tax filing",
+              revision: 2,
+              assignment_count: 3,
+            },
+            removed_assignments: 3,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    );
+
+    await createTag("session", "tax");
+    await renameTag("session", tagID, 1, "tax filing");
+    await deleteTag("session", tagID, 2);
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "/api/v1/tags",
+      `/api/v1/tags/${tagID}`,
+      `/api/v1/tags/${tagID}`,
+    ]);
+    expect(fetchMock.mock.calls.map((call) => call[1]?.method)).toEqual([
+      "POST",
+      "PATCH",
+      "DELETE",
+    ]);
+    expect(
+      new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get("If-Match"),
+    ).toBe("1");
+    expect(
+      new Headers(fetchMock.mock.calls[2]?.[1]?.headers).get("If-Match"),
+    ).toBe("2");
   });
 
   it("trashes one stable node under its inspected revision", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -106,6 +106,11 @@ export interface TagAssignmentReceipt {
   changed: boolean;
 }
 
+export interface TagDeletionReceipt {
+  tag: Tag;
+  removed_assignments: number;
+}
+
 export interface TaggedNode {
   node: Node;
   path?: string;
@@ -399,6 +404,72 @@ export async function tags(session: string): Promise<TagPage> {
 
 export async function tagByID(session: string, tagID: string): Promise<Tag> {
   return requestJSON<Tag>(`/api/v1/tags/${encodeURIComponent(tagID)}`, session);
+}
+
+export async function createTag(session: string, name: string): Promise<Tag> {
+  const normalized = name.normalize("NFC");
+  const tag = await requestJSON<Tag>("/api/v1/tags", session, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (
+    !tag.id ||
+    tag.name !== normalized ||
+    tag.revision !== 1 ||
+    tag.assignment_count !== 0
+  ) {
+    throw new Error("The daemon returned an invalid created-tag receipt.");
+  }
+  return tag;
+}
+
+export async function renameTag(
+  session: string,
+  tagID: string,
+  revision: number,
+  name: string,
+): Promise<Tag> {
+  const normalized = name.normalize("NFC");
+  const tag = await requestJSON<Tag>(
+    `/api/v1/tags/${encodeURIComponent(tagID)}`,
+    session,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "If-Match": String(revision),
+      },
+      body: JSON.stringify({ name }),
+    },
+  );
+  if (tag.id !== tagID || tag.name !== normalized || tag.revision < revision) {
+    throw new Error("The daemon returned an invalid renamed-tag receipt.");
+  }
+  return tag;
+}
+
+export async function deleteTag(
+  session: string,
+  tagID: string,
+  revision: number,
+): Promise<TagDeletionReceipt> {
+  const receipt = await requestJSON<TagDeletionReceipt>(
+    `/api/v1/tags/${encodeURIComponent(tagID)}`,
+    session,
+    {
+      method: "DELETE",
+      headers: { "If-Match": String(revision) },
+    },
+  );
+  if (
+    receipt.tag.id !== tagID ||
+    receipt.tag.revision !== revision ||
+    receipt.removed_assignments !== receipt.tag.assignment_count
+  ) {
+    throw new Error("The daemon returned an invalid deleted-tag receipt.");
+  }
+  return receipt;
 }
 
 export async function taggedNodes(

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -459,9 +459,59 @@ func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 	assert.Equal(t, reviewedTag.ID, unassigned.Tag.ID)
 	document.Revision = unassigned.Node.Revision
 
-	resp = webRequest(http.MethodDelete, "/api/v1/tags/"+reviewedTag.ID)
+	createTagRequest, err := http.NewRequest(
+		http.MethodPost, ts.URL+"/api/v1/tags",
+		strings.NewReader(`{"name":"filing"}`),
+	)
+	require.NoError(t, err)
+	createTagRequest.Header["X-Api-Key"] = []string{""}
+	createTagRequest.Header.Set(api.WebSessionHeader, issued.Token)
+	createTagRequest.Header.Set("Content-Type", "application/json")
+	resp, err = ts.Client().Do(createTagRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	var browserTag api.Tag
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&browserTag))
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, "filing", browserTag.Name)
+	assert.EqualValues(t, 1, browserTag.Revision)
+
+	renameTagRequest, err := http.NewRequest(
+		http.MethodPatch, ts.URL+"/api/v1/tags/"+browserTag.ID,
+		strings.NewReader(`{"name":"filed"}`),
+	)
+	require.NoError(t, err)
+	renameTagRequest.Header["X-Api-Key"] = []string{""}
+	renameTagRequest.Header.Set(api.WebSessionHeader, issued.Token)
+	renameTagRequest.Header.Set("Content-Type", "application/json")
+	renameTagRequest.Header.Set("If-Match", strconv.FormatInt(browserTag.Revision, 10))
+	resp, err = ts.Client().Do(renameTagRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&browserTag))
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, "filed", browserTag.Name)
+	assert.EqualValues(t, 2, browserTag.Revision)
+
+	deleteTagRequest, err := http.NewRequest(
+		http.MethodDelete, ts.URL+"/api/v1/tags/"+browserTag.ID, nil,
+	)
+	require.NoError(t, err)
+	deleteTagRequest.Header["X-Api-Key"] = []string{""}
+	deleteTagRequest.Header.Set(api.WebSessionHeader, issued.Token)
+	deleteTagRequest.Header.Set("If-Match", strconv.FormatInt(browserTag.Revision, 10))
+	resp, err = ts.Client().Do(deleteTagRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var deletedTag api.TagDeletionReceipt
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&deletedTag))
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, browserTag.ID, deletedTag.Tag.ID)
+	assert.Zero(t, deletedTag.RemovedAssignments)
+
+	resp = webRequest(http.MethodPatch, "/api/v1/tags/"+reviewedTag.ID+"/extra")
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
-		"tag-assignment permission does not grant tag-definition deletion")
+		"tag-definition permission is limited to one stable tag resource")
 	require.NoError(t, resp.Body.Close())
 
 	resp = webRequest(http.MethodGet, "/api/v1/jobs")

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -23,8 +23,8 @@ const (
 // webSessionRegistry owns browser credentials for exactly one daemon
 // lifetime. Tokens are random, retained only as digests, and authorize only
 // the deliberately limited routes used by the built-in browser. Most are
-// reads; verified upload plus revision-bound trash, restore, and tag
-// assignment are the only document-authority mutations.
+// reads; verified upload plus revision-bound trash, restore, tag assignment,
+// and tag-definition management are the only document-authority mutations.
 type webSessionRegistry struct {
 	mu          sync.Mutex
 	tokens      map[[sha256.Size]byte]webSessionState
@@ -172,6 +172,17 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	method, path := r.Method, r.URL.Path
 	if method == http.MethodPost && path == webDownloadPreparePath {
 		return true
+	}
+	if method == http.MethodPost && path == "/api/v1/tags" &&
+		r.URL.RawQuery == "" {
+		return true
+	}
+	if (method == http.MethodPatch || method == http.MethodDelete) &&
+		r.URL.RawQuery == "" {
+		if tagID, ok := strings.CutPrefix(path, "/api/v1/tags/"); ok &&
+			tagID != "" && !strings.Contains(tagID, "/") {
+			return true
+		}
 	}
 	if method == http.MethodPost && r.URL.RawQuery == "" {
 		const prefix = "/api/v1/nodes/"

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "55"
+	daemonProtocolVersion = "56"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Docbank’s browser can now manage the shared vocabulary it uses to organize documents. Open the tag catalog beside the toolbar filter to create a definition, rename it without changing its stable ID, or delete it after a separate confirmation. For example, a person can define **reviewed** and immediately use the existing document-level **Manage** dialog to assign it without leaving the web application.

Renames and deletions are bound to the definition revision shown to the browser. A concurrent CLI or agent change therefore produces a stale-revision result instead of being overwritten. Deletion names the stable ID and current assignment count, removes those assignments only after confirmation, and never deletes documents or stored content. Reusing the same name later creates a new identity.

The daemon-lifetime browser session gains only these exact definition operations. It still cannot bulk-apply tags or inherit unrelated master-key authority. After a rename or deletion, the active folder, search, or tag view is reacquired so assigned-node revisions and counts do not remain stale; the daemon protocol advances so an older process cannot serve a partially compatible interface.

![The actual Docbank web application after creating a tag in a synthetic vault](https://raw.githubusercontent.com/kenn-io/docbank/b3dc5e3/screenshots/web-tag-catalog/web-tag-catalog.png)

*Actual daemon-served interface using an owner-private synthetic vault; no private corpus data is present.*
