### PR TITLE
Move and restore recoverable trash from the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ Four commitments:
   per-node history, independent chain/protected-byte verification, exact-prefix
   checks against externally recorded evidence, and backup/restore fidelity
 - FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
-- A read-only daemon-backed TUI for analytical tree browsing, search, stable
-  document/version identity inspection, and permanent audited-history timelines
+- A daemon-backed TUI for analytical tree browsing, search, stable
+  document/version identity inspection, permanent audited-history timelines,
+  and revision-bound recoverable trash and restore
 - A scoped kit-ui web application for verified local-file upload, virtual-tree browsing, sortable
   document analysis, tag-definition management, tag browsing and assignment,
   tag-filtered extracted-text search,

--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -206,7 +206,7 @@ func (b *tuiDaemonBackend) Trash(
 	node, err := withTUIMutationClient(ctx, b, func(c *client.Client) (api.Node, error) {
 		return c.Trash(ctx, nodeID, revision)
 	})
-	if client.IsTransportError(err) {
+	if client.IsTransportError(err) || client.IsResponseDecodeError(err) {
 		return api.Node{}, fmt.Errorf(
 			"trash outcome is unconfirmed; refresh before retrying: %w", err,
 		)
@@ -220,7 +220,7 @@ func (b *tuiDaemonBackend) Restore(
 	node, err := withTUIMutationClient(ctx, b, func(c *client.Client) (api.Node, error) {
 		return c.Restore(ctx, nodeID, revision)
 	})
-	if client.IsTransportError(err) {
+	if client.IsTransportError(err) || client.IsResponseDecodeError(err) {
 		return api.Node{}, fmt.Errorf(
 			"restore outcome is unconfirmed; refresh before retrying: %w", err,
 		)

--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -207,9 +207,7 @@ func (b *tuiDaemonBackend) Trash(
 		return c.Trash(ctx, nodeID, revision)
 	})
 	if client.IsTransportError(err) || client.IsResponseDecodeError(err) {
-		return api.Node{}, fmt.Errorf(
-			"trash outcome is unconfirmed; refresh before retrying: %w", err,
-		)
+		return api.Node{}, doctui.NewMutationUnconfirmedError("trash", err)
 	}
 	return node, err
 }
@@ -221,9 +219,7 @@ func (b *tuiDaemonBackend) Restore(
 		return c.Restore(ctx, nodeID, revision)
 	})
 	if client.IsTransportError(err) || client.IsResponseDecodeError(err) {
-		return api.Node{}, fmt.Errorf(
-			"restore outcome is unconfirmed; refresh before retrying: %w", err,
-		)
+		return api.Node{}, doctui.NewMutationUnconfirmedError("restore", err)
 	}
 	return node, err
 }

--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -17,12 +17,14 @@ import (
 var tuiCmd = &cobra.Command{
 	Use:   "tui",
 	Short: "Browse and search the vault interactively",
-	Long: `Open a read-only terminal interface backed by the authenticated daemon API.
+	Long: `Open a terminal interface backed by the authenticated daemon API.
 
 Navigation:
   Up/Down or j/k       Move between documents
   Enter or Right       Open a directory
   Enter on a file or i Inspect complete document authority
+  x                    Move the selected node to recoverable trash
+  T                    Browse and restore recoverable trash
   a                    Browse permanent audited history
   Left or Backspace    Return to the parent directory
   /                    Search names and extracted text
@@ -32,8 +34,9 @@ Navigation:
   ?                    Show keyboard help
   q                    Quit
 
-The initial TUI is deliberately read-only. Use the ordinary CLI or HTTP API for
-mutations, storage maintenance, backup, and permanent-audit enrollment.`,
+Trash and restore require an explicit revision-bound confirmation. Permanent
+deletion, storage maintenance, backup, and permanent-audit enrollment remain
+outside the TUI.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		c, err := client.Ensure(cmd.Context())
@@ -121,6 +124,32 @@ func withTUIClient[T any](
 	return zero, errors.New("reconnecting to docbank daemon failed")
 }
 
+// withTUIMutationClient retries only daemon acquisition. Once a mutation is
+// sent, a lost response is an unconfirmed outcome rather than permission to
+// send the revision-bound operation again.
+func withTUIMutationClient[T any](
+	ctx context.Context, backend *tuiDaemonBackend,
+	request func(*client.Client) (T, error),
+) (T, error) {
+	var zero T
+	for attempt := range 2 {
+		c, err := backend.acquire(ctx)
+		if err != nil {
+			if attempt == 0 &&
+				errors.Is(err, client.ErrTransientDaemonAcquisition) &&
+				!errors.Is(err, context.Canceled) &&
+				!errors.Is(err, context.DeadlineExceeded) {
+				continue
+			}
+			return zero, err
+		}
+		result, requestErr := request(c)
+		_ = c.Close()
+		return result, requestErr
+	}
+	return zero, errors.New("acquiring docbank daemon failed")
+}
+
 func (b *tuiDaemonBackend) Stat(ctx context.Context, path string) (api.Node, error) {
 	return withTUIClient(ctx, b, func(c *client.Client) (api.Node, error) {
 		return c.Stat(ctx, path)
@@ -161,6 +190,42 @@ func (b *tuiDaemonBackend) Jobs(ctx context.Context) ([]api.Job, error) {
 	return withTUIClient(ctx, b, func(c *client.Client) ([]api.Job, error) {
 		return c.Jobs(ctx)
 	})
+}
+
+func (b *tuiDaemonBackend) TrashPage(
+	ctx context.Context, limit, offset int,
+) (api.TrashPage, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) (api.TrashPage, error) {
+		return c.TrashPage(ctx, limit, offset)
+	})
+}
+
+func (b *tuiDaemonBackend) Trash(
+	ctx context.Context, nodeID, revision int64,
+) (api.Node, error) {
+	node, err := withTUIMutationClient(ctx, b, func(c *client.Client) (api.Node, error) {
+		return c.Trash(ctx, nodeID, revision)
+	})
+	if client.IsTransportError(err) {
+		return api.Node{}, fmt.Errorf(
+			"trash outcome is unconfirmed; refresh before retrying: %w", err,
+		)
+	}
+	return node, err
+}
+
+func (b *tuiDaemonBackend) Restore(
+	ctx context.Context, nodeID, revision int64,
+) (api.Node, error) {
+	node, err := withTUIMutationClient(ctx, b, func(c *client.Client) (api.Node, error) {
+		return c.Restore(ctx, nodeID, revision)
+	})
+	if client.IsTransportError(err) {
+		return api.Node{}, fmt.Errorf(
+			"restore outcome is unconfirmed; refresh before retrying: %w", err,
+		)
+	}
+	return node, err
 }
 
 func (b *tuiDaemonBackend) AuditHistory(

--- a/cmd/docbank/tui_test.go
+++ b/cmd/docbank/tui_test.go
@@ -176,3 +176,22 @@ func TestTUIBackendDoesNotReplayMutationAfterResponseIsLost(t *testing.T) {
 	assert.Equal(t, int32(1), requests.Load())
 	assert.Equal(t, int32(1), acquires.Load())
 }
+
+func TestTUIBackendReportsTruncatedMutationReceiptAsUnconfirmed(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("{"))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	backend := &tuiDaemonBackend{ensure: func(context.Context) (*client.Client, error) {
+		return client.New(server.URL, ""), nil
+	}}
+	_, err := backend.Trash(t.Context(), 42, 3)
+	require.ErrorContains(t, err, "trash outcome is unconfirmed")
+	assert.Equal(t, int32(1), requests.Load())
+}

--- a/cmd/docbank/tui_test.go
+++ b/cmd/docbank/tui_test.go
@@ -16,6 +16,7 @@ import (
 	"go.kenn.io/docbank/internal/api"
 	"go.kenn.io/docbank/internal/client"
 	"go.kenn.io/docbank/internal/store"
+	doctui "go.kenn.io/docbank/internal/tui"
 )
 
 func TestTUIHelpDefinesRecoverableMutationBoundary(t *testing.T) {
@@ -193,5 +194,6 @@ func TestTUIBackendReportsTruncatedMutationReceiptAsUnconfirmed(t *testing.T) {
 	}}
 	_, err := backend.Trash(t.Context(), 42, 3)
 	require.ErrorContains(t, err, "trash outcome is unconfirmed")
+	require.ErrorIs(t, err, doctui.ErrMutationUnconfirmed)
 	assert.Equal(t, int32(1), requests.Load())
 }

--- a/cmd/docbank/tui_test.go
+++ b/cmd/docbank/tui_test.go
@@ -18,13 +18,16 @@ import (
 	"go.kenn.io/docbank/internal/store"
 )
 
-func TestTUIHelpDefinesReadOnlyInteractiveBoundary(t *testing.T) {
+func TestTUIHelpDefinesRecoverableMutationBoundary(t *testing.T) {
 	out, err := runCLI(t, "tui", "--help")
 	require.NoError(t, err)
-	assert.Contains(t, out, "Open a read-only terminal interface")
+	assert.Contains(t, out, "Open a terminal interface")
 	assert.Contains(t, out, "authenticated daemon API")
-	assert.Contains(t, out, "initial TUI is deliberately read-only")
+	assert.Contains(t, out, "explicit revision-bound confirmation")
+	assert.Contains(t, out, "outside the TUI")
 	assert.Contains(t, out, "/                    Search names and extracted text")
+	assert.Contains(t, out, "x                    Move the selected node to recoverable trash")
+	assert.Contains(t, out, "T                    Browse and restore recoverable trash")
 	assert.Contains(t, out, "a                    Browse permanent audited history")
 }
 
@@ -140,5 +143,36 @@ func TestTUIBackendDoesNotRetryCanceledAcquisition(t *testing.T) {
 	}}
 	_, err := backend.Stat(ctx, "/")
 	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), acquires.Load())
+}
+
+func TestTUIBackendDoesNotReplayMutationAfterResponseIsLost(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("test server does not support connection hijacking")
+			return
+		}
+		connection, _, err := hijacker.Hijack()
+		if err != nil {
+			t.Errorf("hijacking test connection: %v", err)
+			return
+		}
+		if err := connection.Close(); err != nil {
+			t.Errorf("closing test connection: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var acquires atomic.Int32
+	backend := &tuiDaemonBackend{ensure: func(context.Context) (*client.Client, error) {
+		acquires.Add(1)
+		return client.New(server.URL, ""), nil
+	}}
+	_, err := backend.Trash(t.Context(), 42, 3)
+	require.ErrorContains(t, err, "trash outcome is unconfirmed")
+	assert.Equal(t, int32(1), requests.Load())
 	assert.Equal(t, int32(1), acquires.Load())
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -680,14 +680,16 @@ unsupported. See [Searching](usage/searching.md).
 docbank tui
 ```
 
-Opens a read-only interactive terminal browser over the authenticated daemon
-API. It navigates the live virtual tree, searches names and extracted text,
-and shows the selected node's stable identity, revision, current version,
-SHA-256, size, and media type. It loads at most 1,000 directory entries or
-search results and reports truncation rather than implying completeness.
+Opens an interactive terminal browser over the authenticated daemon API. It
+navigates the live virtual tree, searches names and extracted text, shows the
+selected node's stable authority, and can move one inspected revision to
+recoverable trash or restore one inspected trash root. It loads at most 1,000
+directory entries, search results, or trash roots and reports truncation rather
+than implying completeness.
 
-The initial TUI does not mutate documents, enroll permanent audit scopes, or
-run backup and storage maintenance. See the
+Trash and restore require explicit revision-bound confirmation. The TUI does
+not expose permanent deletion, enroll permanent audit scopes, or run backup and
+storage maintenance. See the
 [interactive terminal browser](usage/tui.md) for navigation keys and the
 capability boundary.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,8 +159,8 @@ content versions with verified replacement, reversion, pruning, and
 lookup by content hash (`refs`), tags, permanent audited history with
 independent verification, loose and packed storage with explicit
 maintenance, whole-vault integrity verification, incremental backup
-create/verify/restore, a scoped web application, read-only TUI, and the embedded
-Go API. Docbank is not yet a
+create/verify/restore, a scoped web application, a TUI with recoverable
+trash and restore, and the embedded Go API. Docbank is not yet a
 stable 1.0; the [Roadmap](roadmap.md) gives the product direction.
 
 Docbank belongs to a family of personal data tools alongside

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -19,7 +19,7 @@ Every documentation page is also published as raw Markdown at the same path with
 - [Organizing & Tagging](https://docbank.ai/usage/organizing.md): Browsing, moving, renaming, and tagging in the virtual tree.
 - [Searching](https://docbank.ai/usage/searching.md): Ranked, prefix-matching search over document names and verified text content.
 - [Web application](https://docbank.ai/usage/web.md): Upload, browse, search, and organize the local vault in a responsive, authenticated web interface.
-- [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse documents, inspect authority and permanent history, and observe daemon background work from a read-only TUI.
+- [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse documents, inspect authority and permanent history, and safely move or restore recoverable trash from the TUI.
 
 ## Protect & Operate
 - [Vault Lifecycle](https://docbank.ai/usage/lifecycle.md): Operate a docbank vault safely from first import through maintenance, upgrades, snapshots, and recovery.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,7 +72,7 @@ docbank tree /taxes
   checklist.pdf  [231]
 ```
 
-For an interactive read-only view of the same tree, open the terminal browser:
+For an interactive view of the same tree, open the terminal browser:
 
 ```bash
 docbank tui
@@ -81,6 +81,8 @@ docbank tui
 Use the arrow keys or `j`/`k` to select a document, Enter to open a directory,
 and `/` to search names and extracted text. Press `i` for complete document
 authority or `a` for the selected node's permanent audited-history timeline.
+Press `x` to review moving the selected revision to recoverable trash, or `T`
+to browse and restore trash roots. The TUI does not expose permanent deletion.
 See the
 [interactive terminal browser](usage/tui.md) guide for the complete key map.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,7 +65,7 @@ elsewhere only when they materially explain the design and are marked
 - Tag-driven release pipeline building archives plus `SHA256SUMS` for Linux,
   macOS, and Windows on amd64 and arm64
 - A responsive kit-ui web application at `/`, launched through `docbank web`
-  with session-local authentication and read-only tree, search, sorting, and
+  with session-local authentication and tree, search, sorting, and
   current-authority inspection
 - Internal mixed loose/packed blob storage on `kit/packstore`: docbank's
   `blobs` rows remain the read-authority boundary, existing loose vaults
@@ -163,15 +163,15 @@ broader metadata, version comparison, and storage maintenance.
 Application-neutral tree, timeline, diff, evidence, and job components should
 be reusable by Msgvault and later tools.
 
-The focused TUI now has a read-only first slice for virtual-tree navigation,
-name and extracted-content search, stable document/version/hash detail, and a
-compact node-focused audited-history timeline with complete event inspection.
-Its daemon-activity screen reports supervised job lifecycle, timestamps, and
+The focused TUI provides virtual-tree navigation, name and extracted-content
+search, stable document/version/hash detail, a compact node-focused
+audited-history timeline, and revision-bound recoverable trash and restore. Its
+daemon-activity screen reports supervised job lifecycle, timestamps, and
 complete terminal failures without inventing percentages where workers expose
-no authoritative total. Later slices add ingest progress, metadata/evidence,
-move/trash/restore, and storage and backup state. Rich document comparison belongs in
-external tools or the web portal. Neither client has privileged operations —
-anything either does, the API can do.
+no authoritative total. Later slices add ingest progress, broader
+metadata/evidence, and storage and backup state. Rich document comparison
+belongs in external tools or the web portal. Neither client has privileged
+operations — anything either does, the API can do.
 
 ## Phase 4 — Backup (implemented)
 

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive terminal browser
-description: Browse documents, inspect authority and permanent history, and observe daemon background work from a read-only TUI.
+description: Browse documents, inspect authority and permanent history, and safely move or restore recoverable trash from the TUI.
 ---
 
 # Interactive terminal browser
@@ -11,12 +11,12 @@ Run:
 docbank tui
 ```
 
-The TUI is a read-only view of the same authenticated daemon API used by the
-ordinary CLI. It never opens SQLite or the blob store and cannot bypass the
-vault's exclusive owner. Starting it reuses or starts the daemon in the normal
-way. A TUI session may outlive the background daemon's idle window, so each
-bounded interaction rediscovers or restarts a compatible daemon before issuing
-its request; leaving the terminal open does not pin an otherwise idle process.
+The TUI uses the same authenticated daemon API as the ordinary CLI. It never
+opens SQLite or the blob store and cannot bypass the vault's exclusive owner.
+Starting it reuses or starts the daemon in the normal way. A TUI session may
+outlive the background daemon's idle window, so each bounded interaction
+rediscovers or restarts a compatible daemon before issuing its request; leaving
+the terminal open does not pin an otherwise idle process.
 
 The main view is a full-width document table. At ordinary terminal widths it
 shows each document's name, type, size, and UTC modification time; search results
@@ -47,11 +47,27 @@ same document selection. The current daemon contract reports lifecycle rather
 than invented percentages: workers will show numeric progress only when they
 can supply an authoritative completed and total count.
 
+Press <kbd>x</kbd> to review moving the selected live node to recoverable
+trash. The confirmation names the escaped path, stable node ID, and exact
+revision that will be changed; a concurrent change is rejected rather than
+silently targeting newer state. The dialog also says plainly that the node
+remains restorable and no content bytes are reclaimed.
+
+Press <kbd>T</kbd> to browse independently restorable trash roots, newest
+first. Enter opens a second revision-bound confirmation. A successful restore
+reports the actual live path selected by the daemon after collision suffixing
+or origin-parent fallback. Restoration does not guess or promise the old path.
+Permanent deletion and physical reclamation are deliberately absent from the
+TUI; use the preview-first CLI or authenticated HTTP workflows when that is
+really intended.
+
 | Key | Action |
 |-----|--------|
 | <kbd>↑</kbd>/<kbd>k</kbd>, <kbd>↓</kbd>/<kbd>j</kbd> | Move between documents |
 | <kbd>Enter</kbd> or <kbd>→</kbd> | Open the selected directory |
 | <kbd>Enter</kbd> on a file, or <kbd>i</kbd> | Inspect complete document authority |
+| <kbd>x</kbd> | Review moving the selected revision to recoverable trash |
+| <kbd>T</kbd> | Browse and restore recoverable trash roots |
 | <kbd>a</kbd> | Browse the selected node's permanent audited history |
 | <kbd>J</kbd> | Inspect daemon background jobs and failures |
 | <kbd>←</kbd>, <kbd>Backspace</kbd>, or <kbd>Esc</kbd> | Return to the parent directory or leave search results |
@@ -76,7 +92,6 @@ returns to relevance. The first interface loads at most 1,000
 directory entries or search hits and says when more exist; use the CLI or HTTP
 pagination for exhaustive automation.
 
-Mutations, permanent-audit enrollment and independent verification, backup,
-and storage maintenance remain outside this interface. Use their
-ordinary CLI commands or authenticated HTTP endpoints. Later TUI work can add
-those workflows without creating a privileged path into the vault.
+Other mutations, permanent deletion, permanent-audit enrollment and independent
+verification, backup, and storage maintenance remain outside this interface.
+Use their ordinary CLI commands or authenticated HTTP endpoints.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -142,6 +142,20 @@ func IsTransportError(err error) bool {
 	return errors.As(err, &transport)
 }
 
+type responseDecodeError struct{ err error }
+
+func (e *responseDecodeError) Error() string { return e.err.Error() }
+func (e *responseDecodeError) Unwrap() error { return e.err }
+
+// IsResponseDecodeError reports whether the daemon returned a successful HTTP
+// status but the client could not decode the response body. Mutation callers
+// must treat this as an unknown outcome because the daemon may have committed
+// before the response was truncated or malformed.
+func IsResponseDecodeError(err error) bool {
+	var decode *responseDecodeError
+	return errors.As(err, &decode)
+}
+
 type problemError struct {
 	code string
 	err  error
@@ -345,7 +359,9 @@ func (c *Client) doWithHeaders(
 		return resp.Header.Clone(), nil
 	}
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-		return nil, fmt.Errorf("decoding %s %s response: %w", method, path, err)
+		return nil, &responseDecodeError{err: fmt.Errorf(
+			"decoding %s %s response: %w", method, path, err,
+		)}
 	}
 	return resp.Header.Clone(), nil
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -581,6 +581,13 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.loadDirectory(m.directory.ID, navigationRefresh, m.requestID),
 			)
 		}
+		m.loading = true
+		m.err = nil
+		m.requestID++
+		return m, tea.Batch(
+			m.startSpinner(),
+			m.loadDirectory(0, navigationInitial, m.requestID),
+		)
 	case "up", "k":
 		m.moveCursor(-1)
 	case "down", "j":

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -23,11 +23,12 @@ const (
 	maxSearchItems  = 1000
 	maxHistoryItems = 100
 	maxJobItems     = 1000
+	maxTrashItems   = 1000
 	nodeKindDir     = "dir"
 	nodeKindFile    = "file"
 )
 
-// Backend is the bounded read surface needed by the TUI.
+// Backend is the bounded daemon surface needed by the TUI.
 // *client.Client satisfies it without exposing a direct vault path.
 type Backend interface {
 	Stat(ctx context.Context, path string) (api.Node, error)
@@ -36,6 +37,9 @@ type Backend interface {
 	Search(ctx context.Context, query string, limit int) (api.SearchReport, error)
 	NodeTags(ctx context.Context, nodeID int64, limit, offset int) (api.TagPage, error)
 	Jobs(ctx context.Context) ([]api.Job, error)
+	TrashPage(ctx context.Context, limit, offset int) (api.TrashPage, error)
+	Trash(ctx context.Context, nodeID, revision int64) (api.Node, error)
+	Restore(ctx context.Context, nodeID, revision int64) (api.Node, error)
 	AuditHistory(
 		ctx context.Context, path string, nodeID int64, limit int, cursor string,
 	) (api.AuditEventPage, error)
@@ -120,6 +124,32 @@ type jobsLoadedMsg struct {
 	err       error
 }
 
+type trashLoadedMsg struct {
+	requestID uint64
+	page      api.TrashPage
+	err       error
+}
+
+type mutationAction uint8
+
+const (
+	mutationTrash mutationAction = iota
+	mutationRestore
+)
+
+type mutationConfirmation struct {
+	action mutationAction
+	target row
+}
+
+type mutationCompletedMsg struct {
+	requestID uint64
+	action    mutationAction
+	target    row
+	node      api.Node
+	err       error
+}
+
 type spinnerTickMsg struct{}
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -130,9 +160,10 @@ var errDetailNodeChanged = errors.New(
 
 const spinnerInterval = 80 * time.Millisecond
 
-// Model is a read-only virtual-tree, search, and audited-history browser. Update uses a value
-// receiver because Bubble Tea treats models as immutable values; small helper
-// methods mutate only the copied value before it is returned.
+// Model is a virtual-tree, search, audited-history, and recoverable-trash
+// browser. Update uses a value receiver because Bubble Tea treats models as
+// immutable values; small helper methods mutate only the copied value before
+// it is returned.
 //
 //nolint:recvcheck // intentional Bubble Tea value-model pattern
 type Model struct {
@@ -179,6 +210,15 @@ type Model struct {
 	jobsRequestID       uint64
 	jobDetail           bool
 	jobDetailOffset     int
+	trashOpen           bool
+	trashItems          []api.Node
+	trashTotal          int
+	trashCursor         int
+	trashOffset         int
+	trashChanged        bool
+	confirmation        *mutationConfirmation
+	mutationRunning     bool
+	notice              string
 	historyOpen         bool
 	historyNode         row
 	historyPages        []api.AuditEventPage
@@ -230,6 +270,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.clampDetailOffset()
 		m.clampJobsSelection()
 		m.clampJobDetailOffset()
+		m.clampTrashSelection()
 		m.clampHistorySelection()
 		m.clampHistoryDetailOffset()
 		return m, nil
@@ -272,8 +313,58 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampJobsSelection()
 		}
 		return m, nil
+	case trashLoadedMsg:
+		if !m.trashOpen || msg.requestID != m.requestID {
+			return m, nil
+		}
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		previousID := int64(0)
+		if selected, ok := m.selectedTrash(); ok {
+			previousID = selected.ID
+		}
+		m.trashItems = msg.page.Items
+		m.trashTotal = msg.page.Total
+		m.trashCursor, m.trashOffset = 0, 0
+		for index := range m.trashItems {
+			if m.trashItems[index].ID == previousID {
+				m.trashCursor = index
+				break
+			}
+		}
+		m.err = nil
+		m.clampTrashSelection()
+		return m, nil
+	case mutationCompletedMsg:
+		if msg.requestID != m.requestID || m.confirmation == nil ||
+			msg.action != m.confirmation.action {
+			return m, nil
+		}
+		m.mutationRunning = false
+		m.confirmation = nil
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.err = nil
+		if msg.action == mutationRestore {
+			m.trashChanged = true
+			m.notice = fmt.Sprintf("Restored %q to %q", msg.target.node.Name, msg.node.Path)
+			m.removeTrashItem(msg.target.node.ID)
+			m.loading = true
+			m.requestID++
+			return m, tea.Batch(m.startSpinner(), m.loadTrash(m.requestID))
+		}
+		m.notice = fmt.Sprintf("Moved %q to recoverable trash", msg.target.path)
+		m.removeTrashedRows(msg.target)
+		m.stack = nil
+		m.searchReturn = nil
+		return m.reloadCurrent()
 	case spinnerTickMsg:
-		if !m.loading && !m.jobsLoading {
+		if !m.loading && !m.jobsLoading && !m.mutationRunning {
 			m.spinnerActive = false
 			return m, nil
 		}
@@ -283,6 +374,12 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if m.helpOpen {
 			m.helpOpen = false
 			return m, nil
+		}
+		if m.confirmation != nil {
+			return m.updateConfirmationKeys(msg)
+		}
+		if m.trashOpen {
+			return m.updateTrashKeys(msg)
 		}
 		if m.jobsOpen {
 			return m.updateJobsKeys(msg)
@@ -349,6 +446,27 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, m.searchInput.Focus()
 	case "?":
 		m.helpOpen = true
+		return m, nil
+	case "T":
+		m.trashOpen = true
+		m.trashItems = nil
+		m.trashTotal = 0
+		m.trashCursor = 0
+		m.trashOffset = 0
+		m.trashChanged = false
+		m.loading = true
+		m.err = nil
+		m.notice = ""
+		m.requestID++
+		return m, tea.Batch(m.startSpinner(), m.loadTrash(m.requestID))
+	case "x":
+		selected, ok := m.selected()
+		if !ok {
+			return m, nil
+		}
+		m.err = nil
+		m.notice = ""
+		m.confirmation = &mutationConfirmation{action: mutationTrash, target: selected}
 		return m, nil
 	case "J":
 		m.jobsOpen = true
@@ -450,6 +568,92 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.restore(m.stack[len(m.stack)-1])
 			m.stack = m.stack[:len(m.stack)-1]
 			return m, nil
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateConfirmationKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		if m.mutationRunning {
+			return m, nil
+		}
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		if !m.mutationRunning {
+			m.confirmation = nil
+		}
+		return m, nil
+	case "enter":
+		if m.mutationRunning || m.confirmation == nil {
+			return m, nil
+		}
+		m.mutationRunning = true
+		m.err = nil
+		m.notice = ""
+		m.requestID++
+		confirmation := *m.confirmation
+		return m, tea.Batch(
+			m.startSpinner(),
+			m.runMutation(confirmation, m.requestID),
+		)
+	}
+	return m, nil
+}
+
+func (m Model) updateTrashKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc", "left", "h", "backspace":
+		m.trashOpen = false
+		m.requestID++
+		m.err = nil
+		if m.trashChanged {
+			m.stack = nil
+			m.searchReturn = nil
+			m.notice = "Trash changes applied"
+			m.loading = true
+			return m, tea.Batch(
+				m.startSpinner(),
+				m.loadDirectory(0, navigationInitial, m.requestID),
+			)
+		}
+		return m, nil
+	case "r":
+		m.loading = true
+		m.err = nil
+		m.notice = ""
+		m.requestID++
+		return m, tea.Batch(m.startSpinner(), m.loadTrash(m.requestID))
+	case "up", "k":
+		m.moveTrashCursor(-1)
+	case "down", "j":
+		m.moveTrashCursor(1)
+	case "pgup":
+		m.moveTrashCursor(-m.visibleTrashRows())
+	case "pgdown":
+		m.moveTrashCursor(m.visibleTrashRows())
+	case "home", "g":
+		m.trashCursor, m.trashOffset = 0, 0
+	case "end", "G":
+		if len(m.trashItems) > 0 {
+			m.trashCursor = len(m.trashItems) - 1
+			m.clampTrashSelection()
+		}
+	case "enter":
+		selected, ok := m.selectedTrash()
+		if !ok {
+			return m, nil
+		}
+		m.err = nil
+		m.notice = ""
+		m.confirmation = &mutationConfirmation{
+			action: mutationRestore,
+			target: row{node: selected},
 		}
 	}
 	return m, nil
@@ -709,6 +913,57 @@ func (m Model) loadJobs(requestID uint64) tea.Cmd {
 		items, err := backend.Jobs(ctx)
 		return jobsLoadedMsg{requestID: requestID, items: items, err: err}
 	}
+}
+
+func (m Model) loadTrash(requestID uint64) tea.Cmd {
+	ctx, backend := m.ctx, m.backend
+	return func() tea.Msg {
+		page, err := backend.TrashPage(ctx, maxTrashItems, 0)
+		return trashLoadedMsg{requestID: requestID, page: page, err: err}
+	}
+}
+
+func (m Model) runMutation(
+	confirmation mutationConfirmation, requestID uint64,
+) tea.Cmd {
+	ctx, backend := m.ctx, m.backend
+	return func() tea.Msg {
+		var (
+			node api.Node
+			err  error
+		)
+		switch confirmation.action {
+		case mutationTrash:
+			node, err = backend.Trash(
+				ctx, confirmation.target.node.ID, confirmation.target.node.Revision,
+			)
+		case mutationRestore:
+			node, err = backend.Restore(
+				ctx, confirmation.target.node.ID, confirmation.target.node.Revision,
+			)
+		default:
+			err = errors.New("unknown TUI mutation")
+		}
+		return mutationCompletedMsg{
+			requestID: requestID, action: confirmation.action,
+			target: confirmation.target, node: node, err: err,
+		}
+	}
+}
+
+func (m Model) reloadCurrent() (tea.Model, tea.Cmd) {
+	m.loading = true
+	m.requestID++
+	if m.mode == modeSearch && m.searchQuery != "" {
+		return m, tea.Batch(
+			m.startSpinner(),
+			m.loadSearch(m.searchQuery, m.requestID),
+		)
+	}
+	return m, tea.Batch(
+		m.startSpinner(),
+		m.loadDirectory(m.directory.ID, navigationRefresh, m.requestID),
+	)
 }
 
 func (m Model) loadDirectory(
@@ -975,6 +1230,72 @@ func (m *Model) clampJobDetailOffset() {
 	m.jobDetailOffset = min(max(m.jobDetailOffset, 0), maximum)
 }
 
+func (m Model) selectedTrash() (api.Node, bool) {
+	if m.trashCursor < 0 || m.trashCursor >= len(m.trashItems) {
+		return api.Node{}, false
+	}
+	return m.trashItems[m.trashCursor], true
+}
+
+func (m *Model) removeTrashItem(nodeID int64) {
+	for index := range m.trashItems {
+		if m.trashItems[index].ID != nodeID {
+			continue
+		}
+		m.trashItems = append(m.trashItems[:index], m.trashItems[index+1:]...)
+		m.trashTotal = max(m.trashTotal-1, 0)
+		m.clampTrashSelection()
+		return
+	}
+}
+
+func (m *Model) removeTrashedRows(target row) {
+	filtered := m.rows[:0]
+	for _, item := range m.rows {
+		if item.node.ID == target.node.ID ||
+			(target.path != "" && strings.HasPrefix(item.path, target.path+"/")) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	removed := len(m.rows) - len(filtered)
+	m.rows = filtered
+	m.total = max(m.total-removed, 0)
+	m.clampSelection()
+}
+
+func (m *Model) moveTrashCursor(delta int) {
+	if len(m.trashItems) == 0 {
+		return
+	}
+	m.trashCursor = min(max(m.trashCursor+delta, 0), len(m.trashItems)-1)
+	m.clampTrashSelection()
+}
+
+func (m *Model) clampTrashSelection() {
+	if len(m.trashItems) == 0 {
+		m.trashCursor, m.trashOffset = 0, 0
+		return
+	}
+	m.trashCursor = min(max(m.trashCursor, 0), len(m.trashItems)-1)
+	visible := m.visibleTrashRows()
+	if m.trashCursor < m.trashOffset {
+		m.trashOffset = m.trashCursor
+	}
+	if m.trashCursor >= m.trashOffset+visible {
+		m.trashOffset = m.trashCursor - visible + 1
+	}
+	m.trashOffset = min(max(m.trashOffset, 0), max(len(m.trashItems)-visible, 0))
+}
+
+func (m Model) visibleTrashRows() int {
+	noticeLines := 0
+	if m.notice != "" {
+		noticeLines = 1
+	}
+	return max(m.height-5-noticeLines, 1)
+}
+
 func (m *Model) moveHistoryCursor(delta int) {
 	page, ok := m.currentHistoryPage()
 	if !ok || len(page.Items) == 0 {
@@ -1101,6 +1422,9 @@ func (m *Model) clampSelection() {
 func (m Model) visibleRows() int {
 	headerLines := 2
 	if m.searching {
+		headerLines++
+	}
+	if m.notice != "" {
 		headerLines++
 	}
 	bodyHeight := max(m.height-headerLines-1, 1)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -616,6 +616,8 @@ func (m Model) updateTrashKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "q", "ctrl+c":
 		m.quitting = true
 		return m, tea.Quit
+	case "?":
+		m.helpOpen = true
 	case "esc", "left", "h", "backspace":
 		m.trashOpen = false
 		m.trashLoading = false

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -80,6 +80,7 @@ type location struct {
 	searchReturn *location
 	sortField    sortField
 	sortDesc     bool
+	stale        bool
 }
 
 type navigationKind uint8
@@ -565,15 +566,12 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case "esc", "left", "h", "backspace":
 		if m.mode == modeSearch && m.searchReturn != nil {
-			m.requestID++
-			m.restore(*m.searchReturn)
-			return m, nil
+			return m.revisit(*m.searchReturn)
 		}
 		if len(m.stack) > 0 {
-			m.requestID++
-			m.restore(m.stack[len(m.stack)-1])
+			state := m.stack[len(m.stack)-1]
 			m.stack = m.stack[:len(m.stack)-1]
-			return m, nil
+			return m.revisit(state)
 		}
 	}
 	return m, nil
@@ -979,6 +977,29 @@ func (m Model) reloadCurrent() (tea.Model, tea.Cmd) {
 	)
 }
 
+func (m Model) revisit(state location) (tea.Model, tea.Cmd) {
+	m.requestID++
+	m.restore(state)
+	if !state.stale {
+		return m, nil
+	}
+	m.loading = true
+	m.rows = nil
+	m.total = 0
+	m.truncated = false
+	m.cursor, m.offset = 0, 0
+	if state.mode == modeSearch && state.searchQuery != "" {
+		return m, tea.Batch(
+			m.startSpinner(),
+			m.loadSearch(state.searchQuery, m.requestID),
+		)
+	}
+	return m, tea.Batch(
+		m.startSpinner(),
+		m.loadDirectory(state.directory.ID, navigationRefresh, m.requestID),
+	)
+}
+
 func (m Model) loadDirectory(
 	nodeID int64, kind navigationKind, requestID uint64,
 ) tea.Cmd {
@@ -1266,29 +1287,58 @@ func (m *Model) removeTrashedRows(target row) {
 	var removed int
 	m.rows, removed = withoutTrashedRows(m.rows, target)
 	m.total = max(m.total-removed, 0)
-	for index := range m.stack {
-		removeTrashedFromLocation(&m.stack[index], target)
-	}
-	if m.searchReturn != nil {
-		removeTrashedFromLocation(m.searchReturn, target)
-	}
+	m.invalidateSavedLocations(target)
 	m.clampSelection()
 }
 
-func removeTrashedFromLocation(state *location, target row) {
-	if state == nil {
+func (m *Model) invalidateSavedLocations(target row) {
+	stack := m.stack[:0]
+	for _, state := range m.stack {
+		sanitized, ok := sanitizeLocationAfterTrash(state, target)
+		if ok {
+			stack = append(stack, sanitized)
+		}
+	}
+	m.stack = stack
+	if m.searchReturn == nil {
 		return
 	}
-	var removed int
-	state.rows, removed = withoutTrashedRows(state.rows, target)
-	state.total = max(state.total-removed, 0)
-	if len(state.rows) == 0 {
-		state.cursor, state.offset = 0, 0
-	} else {
-		state.cursor = min(max(state.cursor, 0), len(state.rows)-1)
-		state.offset = min(max(state.offset, 0), state.cursor)
+	sanitized, ok := sanitizeLocationAfterTrash(*m.searchReturn, target)
+	if ok {
+		m.searchReturn = &sanitized
+		return
 	}
-	removeTrashedFromLocation(state.searchReturn, target)
+	if len(m.stack) > 0 {
+		sanitized = m.stack[len(m.stack)-1]
+		m.stack = m.stack[:len(m.stack)-1]
+		m.searchReturn = &sanitized
+		return
+	}
+	m.searchReturn = &location{
+		mode: modeBrowse, directory: api.Node{Kind: nodeKindDir, Path: "/"},
+		sortField: sortByName, stale: true,
+	}
+}
+
+func sanitizeLocationAfterTrash(state location, target row) (location, bool) {
+	if pathAtOrBelow(state.directory.Path, target.path) {
+		return location{}, false
+	}
+	state.stale = true
+	if state.searchReturn != nil {
+		nested, ok := sanitizeLocationAfterTrash(*state.searchReturn, target)
+		if ok {
+			state.searchReturn = &nested
+		} else {
+			state.searchReturn = nil
+		}
+	}
+	return state, true
+}
+
+func pathAtOrBelow(candidate, ancestor string) bool {
+	return ancestor != "" &&
+		(candidate == ancestor || strings.HasPrefix(candidate, ancestor+"/"))
 }
 
 func withoutTrashedRows(rows []row, target row) ([]row, int) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -216,8 +216,12 @@ type Model struct {
 	trashCursor         int
 	trashOffset         int
 	trashChanged        bool
+	trashLoading        bool
+	trashErr            error
+	trashRequestID      uint64
 	confirmation        *mutationConfirmation
 	mutationRunning     bool
+	mutationRequestID   uint64
 	notice              string
 	historyOpen         bool
 	historyNode         row
@@ -314,12 +318,12 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case trashLoadedMsg:
-		if !m.trashOpen || msg.requestID != m.requestID {
+		if !m.trashOpen || msg.requestID != m.trashRequestID {
 			return m, nil
 		}
-		m.loading = false
+		m.trashLoading = false
 		if msg.err != nil {
-			m.err = msg.err
+			m.trashErr = msg.err
 			return m, nil
 		}
 		previousID := int64(0)
@@ -335,18 +339,22 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 		}
-		m.err = nil
+		m.trashErr = nil
 		m.clampTrashSelection()
 		return m, nil
 	case mutationCompletedMsg:
-		if msg.requestID != m.requestID || m.confirmation == nil ||
+		if msg.requestID != m.mutationRequestID || m.confirmation == nil ||
 			msg.action != m.confirmation.action {
 			return m, nil
 		}
 		m.mutationRunning = false
 		m.confirmation = nil
 		if msg.err != nil {
-			m.err = msg.err
+			if msg.action == mutationRestore {
+				m.trashErr = msg.err
+			} else {
+				m.err = msg.err
+			}
 			return m, nil
 		}
 		m.err = nil
@@ -354,17 +362,15 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.trashChanged = true
 			m.notice = fmt.Sprintf("Restored %q to %q", msg.target.node.Name, msg.node.Path)
 			m.removeTrashItem(msg.target.node.ID)
-			m.loading = true
-			m.requestID++
-			return m, tea.Batch(m.startSpinner(), m.loadTrash(m.requestID))
+			m.trashLoading = true
+			m.trashRequestID++
+			return m, tea.Batch(m.startSpinner(), m.loadTrash(m.trashRequestID))
 		}
 		m.notice = fmt.Sprintf("Moved %q to recoverable trash", msg.target.path)
 		m.removeTrashedRows(msg.target)
-		m.stack = nil
-		m.searchReturn = nil
 		return m.reloadCurrent()
 	case spinnerTickMsg:
-		if !m.loading && !m.jobsLoading && !m.mutationRunning {
+		if !m.loading && !m.jobsLoading && !m.trashLoading && !m.mutationRunning {
 			m.spinnerActive = false
 			return m, nil
 		}
@@ -454,11 +460,11 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.trashCursor = 0
 		m.trashOffset = 0
 		m.trashChanged = false
-		m.loading = true
-		m.err = nil
+		m.trashLoading = true
+		m.trashErr = nil
 		m.notice = ""
-		m.requestID++
-		return m, tea.Batch(m.startSpinner(), m.loadTrash(m.requestID))
+		m.trashRequestID++
+		return m, tea.Batch(m.startSpinner(), m.loadTrash(m.trashRequestID))
 	case "x":
 		selected, ok := m.selected()
 		if !ok {
@@ -591,13 +597,17 @@ func (m Model) updateConfirmationKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			return m, nil
 		}
 		m.mutationRunning = true
-		m.err = nil
+		if m.confirmation.action == mutationRestore {
+			m.trashErr = nil
+		} else {
+			m.err = nil
+		}
 		m.notice = ""
-		m.requestID++
+		m.mutationRequestID++
 		confirmation := *m.confirmation
 		return m, tea.Batch(
 			m.startSpinner(),
-			m.runMutation(confirmation, m.requestID),
+			m.runMutation(confirmation, m.mutationRequestID),
 		)
 	}
 	return m, nil
@@ -610,13 +620,16 @@ func (m Model) updateTrashKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "esc", "left", "h", "backspace":
 		m.trashOpen = false
-		m.requestID++
-		m.err = nil
+		m.trashLoading = false
+		m.trashErr = nil
+		m.trashRequestID++
 		if m.trashChanged {
 			m.stack = nil
 			m.searchReturn = nil
 			m.notice = "Trash changes applied"
 			m.loading = true
+			m.err = nil
+			m.requestID++
 			return m, tea.Batch(
 				m.startSpinner(),
 				m.loadDirectory(0, navigationInitial, m.requestID),
@@ -624,11 +637,11 @@ func (m Model) updateTrashKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "r":
-		m.loading = true
-		m.err = nil
+		m.trashLoading = true
+		m.trashErr = nil
 		m.notice = ""
-		m.requestID++
-		return m, tea.Batch(m.startSpinner(), m.loadTrash(m.requestID))
+		m.trashRequestID++
+		return m, tea.Batch(m.startSpinner(), m.loadTrash(m.trashRequestID))
 	case "up", "k":
 		m.moveTrashCursor(-1)
 	case "down", "j":
@@ -649,7 +662,7 @@ func (m Model) updateTrashKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if !ok {
 			return m, nil
 		}
-		m.err = nil
+		m.trashErr = nil
 		m.notice = ""
 		m.confirmation = &mutationConfirmation{
 			action: mutationRestore,
@@ -1250,18 +1263,44 @@ func (m *Model) removeTrashItem(nodeID int64) {
 }
 
 func (m *Model) removeTrashedRows(target row) {
-	filtered := m.rows[:0]
-	for _, item := range m.rows {
+	var removed int
+	m.rows, removed = withoutTrashedRows(m.rows, target)
+	m.total = max(m.total-removed, 0)
+	for index := range m.stack {
+		removeTrashedFromLocation(&m.stack[index], target)
+	}
+	if m.searchReturn != nil {
+		removeTrashedFromLocation(m.searchReturn, target)
+	}
+	m.clampSelection()
+}
+
+func removeTrashedFromLocation(state *location, target row) {
+	if state == nil {
+		return
+	}
+	var removed int
+	state.rows, removed = withoutTrashedRows(state.rows, target)
+	state.total = max(state.total-removed, 0)
+	if len(state.rows) == 0 {
+		state.cursor, state.offset = 0, 0
+	} else {
+		state.cursor = min(max(state.cursor, 0), len(state.rows)-1)
+		state.offset = min(max(state.offset, 0), state.cursor)
+	}
+	removeTrashedFromLocation(state.searchReturn, target)
+}
+
+func withoutTrashedRows(rows []row, target row) ([]row, int) {
+	filtered := rows[:0]
+	for _, item := range rows {
 		if item.node.ID == target.node.ID ||
 			(target.path != "" && strings.HasPrefix(item.path, target.path+"/")) {
 			continue
 		}
 		filtered = append(filtered, item)
 	}
-	removed := len(m.rows) - len(filtered)
-	m.rows = filtered
-	m.total = max(m.total-removed, 0)
-	m.clampSelection()
+	return filtered, len(rows) - len(filtered)
 }
 
 func (m *Model) moveTrashCursor(delta int) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -159,6 +159,34 @@ var errDetailNodeChanged = errors.New(
 	"document changed while loading tags; close and inspect it again",
 )
 
+// ErrMutationUnconfirmed marks a mutation whose request was sent but whose
+// terminal receipt did not arrive intact. Callers must reacquire authority
+// rather than treating the operation as failed or replaying it.
+var ErrMutationUnconfirmed = errors.New("mutation outcome is unconfirmed")
+
+type mutationUnconfirmedError struct {
+	action string
+	cause  error
+}
+
+func (e *mutationUnconfirmedError) Error() string {
+	return fmt.Sprintf(
+		"%s outcome is unconfirmed; refresh before retrying: %v", e.action, e.cause,
+	)
+}
+
+func (e *mutationUnconfirmedError) Unwrap() error { return e.cause }
+
+func (e *mutationUnconfirmedError) Is(target error) bool {
+	return target == ErrMutationUnconfirmed
+}
+
+// NewMutationUnconfirmedError preserves an uncertain mutation cause for the
+// model while presenting an actionable operator message.
+func NewMutationUnconfirmedError(action string, cause error) error {
+	return &mutationUnconfirmedError{action: action, cause: cause}
+}
+
 const spinnerInterval = 80 * time.Millisecond
 
 // Model is a virtual-tree, search, audited-history, and recoverable-trash
@@ -351,6 +379,25 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.mutationRunning = false
 		m.confirmation = nil
 		if msg.err != nil {
+			if errors.Is(msg.err, ErrMutationUnconfirmed) {
+				m.notice = msg.err.Error()
+				if msg.action == mutationRestore {
+					m.trashChanged = true
+					m.trashErr = msg.err
+					m.trashLoading = true
+					m.trashRequestID++
+					return m, tea.Batch(
+						m.startSpinner(), m.loadTrash(m.trashRequestID),
+					)
+				}
+				m.invalidateLiveView()
+				m.loading = true
+				m.requestID++
+				return m, tea.Batch(
+					m.startSpinner(),
+					m.loadDirectory(0, navigationInitial, m.requestID),
+				)
+			}
 			if msg.action == mutationRestore {
 				m.trashErr = msg.err
 			} else {
@@ -624,8 +671,7 @@ func (m Model) updateTrashKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.trashErr = nil
 		m.trashRequestID++
 		if m.trashChanged {
-			m.stack = nil
-			m.searchReturn = nil
+			m.invalidateLiveView()
 			m.notice = "Trash changes applied"
 			m.loading = true
 			m.err = nil
@@ -670,6 +716,18 @@ func (m Model) updateTrashKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m *Model) invalidateLiveView() {
+	m.mode = modeBrowse
+	m.directory = api.Node{}
+	m.rows = nil
+	m.total = 0
+	m.truncated = false
+	m.cursor, m.offset = 0, 0
+	m.stack = nil
+	m.searchQuery = ""
+	m.searchReturn = nil
 }
 
 func (m Model) updateJobsKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -414,8 +414,21 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.trashRequestID++
 			return m, tea.Batch(m.startSpinner(), m.loadTrash(m.trashRequestID))
 		}
-		m.notice = fmt.Sprintf("Moved %q to recoverable trash", msg.target.path)
-		m.removeTrashedRows(msg.target)
+		target := row{node: msg.node, path: msg.node.Path}
+		m.notice = fmt.Sprintf("Moved %q to recoverable trash", target.path)
+		if target.path == "" ||
+			m.directory.ID == target.node.ID ||
+			(m.mode == modeSearch && target.node.Kind == nodeKindDir) ||
+			pathAtOrBelow(m.directory.Path, target.path) {
+			m.invalidateLiveView()
+			m.loading = true
+			m.requestID++
+			return m, tea.Batch(
+				m.startSpinner(),
+				m.loadDirectory(0, navigationInitial, m.requestID),
+			)
+		}
+		m.removeTrashedRows(target)
 		return m.reloadCurrent()
 	case spinnerTickMsg:
 		if !m.loading && !m.jobsLoading && !m.trashLoading && !m.mutationRunning {
@@ -514,6 +527,10 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.trashRequestID++
 		return m, tea.Batch(m.startSpinner(), m.loadTrash(m.trashRequestID))
 	case "x":
+		if m.loading {
+			m.notice = "Wait for the current view to finish loading"
+			return m, nil
+		}
 		selected, ok := m.selected()
 		if !ok {
 			return m, nil

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -438,6 +438,14 @@ func TestUnconfirmedMutationsInvalidateAuthority(t *testing.T) {
 		assert.Nil(t, model.searchReturn)
 		assert.Contains(t, model.notice, "trash outcome is unconfirmed")
 
+		backend.err = errors.New("daemon temporarily unavailable")
+		model = runModelCommand(t, model, refresh)
+		require.ErrorContains(t, model.err, "daemon temporarily unavailable")
+		assert.Empty(t, model.directory.Path)
+
+		backend.err = nil
+		model, refresh = updateModel(t, model, runeKey('r'))
+		require.NotNil(t, refresh)
 		model = runModelCommand(t, model, refresh)
 		assert.Equal(t, "/", model.directory.Path)
 		require.Len(t, model.rows, 2)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -222,7 +222,7 @@ func (f *fakeBackend) Trash(
 	}
 	for itemPath, node := range f.nodes {
 		if node.ID == nodeID {
-			livePath := node.Path
+			livePath := itemPath
 			node.TrashedAt = "2026-07-22T16:00:00Z"
 			node.Path = ""
 			f.nodes[itemPath] = node
@@ -249,7 +249,9 @@ func (f *fakeBackend) Trash(
 				}
 			}
 			f.search.Hits = hits
-			return node, f.mutationReceiptErr
+			receipt := node
+			receipt.Path = livePath
+			return receipt, f.mutationReceiptErr
 		}
 	}
 	return api.Node{}, errors.New("not found")
@@ -410,6 +412,68 @@ func TestModelCancelsTrashConfirmationWithoutMutation(t *testing.T) {
 	model, _ = updateModel(t, model, key(tea.KeyEscape))
 	assert.Nil(t, model.confirmation)
 	assert.Empty(t, backend.trashed)
+}
+
+func TestTrashWaitsForNavigationAndUsesAuthoritativeReceiptPath(t *testing.T) {
+	backend := newFakeBackend()
+	backend.search.Hits = []api.SearchHit{{
+		Node: backend.nodes["/docs"], Path: "/docs", Match: "name",
+	}}
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(
+		0, navigationInitial, model.requestID,
+	))
+	model, cmd := updateModel(t, model, key(tea.KeyEnter))
+	model = runModelCommand(t, model, cmd)
+	assert.Equal(t, "/docs", model.directory.Path)
+
+	model, delayedRefresh := updateModel(t, model, runeKey('r'))
+	require.NotNil(t, delayedRefresh)
+	model, _ = updateModel(t, model, runeKey('x'))
+	assert.Nil(t, model.confirmation)
+	assert.Contains(t, model.notice, "finish loading")
+	model = runModelCommand(t, model, delayedRefresh)
+
+	model, _ = updateModel(t, model, runeKey('/'))
+	model.searchInput.SetValue("docs")
+	model, cmd = updateModel(t, model, key(tea.KeyEnter))
+	model = runModelCommand(t, model, cmd)
+	model, _ = updateModel(t, model, runeKey('x'))
+	require.NotNil(t, model.confirmation)
+	assert.Equal(t, "/docs", model.confirmation.target.path)
+
+	docs := backend.nodes["/docs"]
+	report := backend.nodes["/docs/report.txt"]
+	delete(backend.nodes, "/docs")
+	delete(backend.nodes, "/docs/report.txt")
+	docs.Name = "documents"
+	docs.Path = "/documents"
+	docs.Revision++
+	report.Path = "/documents/report.txt"
+	backend.nodes["/documents"] = docs
+	backend.nodes["/documents/report.txt"] = report
+	backend.children[1] = api.NodePage{
+		Items: []api.Node{docs, backend.nodes["/README.txt"]},
+		Total: 2, Limit: maxBrowserItems,
+	}
+	backend.children[2] = api.NodePage{
+		Items: []api.Node{report}, Total: 1, Limit: maxBrowserItems,
+	}
+
+	model, mutation := updateModel(t, model, key(tea.KeyEnter))
+	model, rootLoad := updateModel(t, model, mutation())
+	require.NotNil(t, rootLoad)
+	assert.Contains(t, model.notice, `"/documents"`)
+	assert.NotContains(t, model.notice, `"/docs"`)
+	assert.Empty(t, model.rows)
+	assert.Empty(t, model.stack)
+	assert.Nil(t, model.searchReturn)
+
+	model = runModelCommand(t, model, rootLoad)
+	assert.Equal(t, "/", model.directory.Path)
+	require.Len(t, model.rows, 1)
+	assert.Equal(t, "/README.txt", model.rows[0].path)
 }
 
 func TestUnconfirmedMutationsInvalidateAuthority(t *testing.T) {
@@ -604,15 +668,11 @@ func TestTrashAncestorFromSearchFallsBackToLiveParent(t *testing.T) {
 
 	model, _ = updateModel(t, model, runeKey('x'))
 	model, cmd = updateModel(t, model, key(tea.KeyEnter))
-	model = runModelCommand(t, model, cmd)
-	require.NotNil(t, model.searchReturn)
-	assert.Equal(t, "/", model.searchReturn.directory.Path)
-	assert.True(t, model.searchReturn.stale)
+	model, rootLoad := updateModel(t, model, cmd())
+	require.NotNil(t, rootLoad)
+	assert.Nil(t, model.searchReturn)
 	assert.Empty(t, model.stack)
-
-	model, cmd = updateModel(t, model, key(tea.KeyEscape))
-	require.NotNil(t, cmd)
-	model = runModelCommand(t, model, cmd)
+	model = runModelCommand(t, model, rootLoad)
 	assert.Equal(t, modeBrowse, model.mode)
 	assert.Equal(t, "/", model.directory.Path)
 	require.Len(t, model.rows, 1)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -17,28 +17,29 @@ import (
 )
 
 type fakeBackend struct {
-	nodes          map[string]api.Node
-	children       map[int64]api.NodePage
-	search         api.SearchReport
-	err            error
-	childLimit     int
-	searchMax      int
-	nodeIDs        []int64
-	statPaths      []string
-	history        map[string]api.AuditEventPage
-	historyErr     error
-	historyIDs     []int64
-	historyCursors []string
-	tags           map[int64]api.TagPage
-	tagNodeIDs     []int64
-	jobs           []api.Job
-	jobsErr        error
-	jobCalls       int
-	trash          api.TrashPage
-	trashCalls     int
-	trashed        []api.Node
-	restored       []api.Node
-	mutationErr    error
+	nodes              map[string]api.Node
+	children           map[int64]api.NodePage
+	search             api.SearchReport
+	err                error
+	childLimit         int
+	searchMax          int
+	nodeIDs            []int64
+	statPaths          []string
+	history            map[string]api.AuditEventPage
+	historyErr         error
+	historyIDs         []int64
+	historyCursors     []string
+	tags               map[int64]api.TagPage
+	tagNodeIDs         []int64
+	jobs               []api.Job
+	jobsErr            error
+	jobCalls           int
+	trash              api.TrashPage
+	trashCalls         int
+	trashed            []api.Node
+	restored           []api.Node
+	mutationErr        error
+	mutationReceiptErr error
 }
 
 func newFakeBackend() *fakeBackend {
@@ -248,7 +249,7 @@ func (f *fakeBackend) Trash(
 				}
 			}
 			f.search.Hits = hits
-			return node, nil
+			return node, f.mutationReceiptErr
 		}
 	}
 	return api.Node{}, errors.New("not found")
@@ -287,7 +288,7 @@ func (f *fakeBackend) Restore(
 			node.Revision++
 			node.TrashedAt = ""
 			node.Path = "/restored/" + node.Name
-			return node, nil
+			return node, f.mutationReceiptErr
 		}
 	}
 	return api.Node{}, errors.New("not found")
@@ -409,6 +410,71 @@ func TestModelCancelsTrashConfirmationWithoutMutation(t *testing.T) {
 	model, _ = updateModel(t, model, key(tea.KeyEscape))
 	assert.Nil(t, model.confirmation)
 	assert.Empty(t, backend.trashed)
+}
+
+func TestUnconfirmedMutationsInvalidateAuthority(t *testing.T) {
+	t.Run("trash reloads live root", func(t *testing.T) {
+		backend := newFakeBackend()
+		backend.mutationReceiptErr = NewMutationUnconfirmedError(
+			"trash", errors.New("receipt was truncated"),
+		)
+		model, err := New(t.Context(), backend)
+		require.NoError(t, err)
+		model = runModelCommand(t, model, model.loadDirectory(
+			0, navigationInitial, model.requestID,
+		))
+		model, cmd := updateModel(t, model, key(tea.KeyEnter))
+		model = runModelCommand(t, model, cmd)
+		require.Len(t, model.stack, 1)
+
+		model, _ = updateModel(t, model, runeKey('x'))
+		model, mutation := updateModel(t, model, key(tea.KeyEnter))
+		require.NotNil(t, mutation)
+		model, refresh := updateModel(t, model, mutation())
+		require.NotNil(t, refresh)
+		assert.True(t, model.loading)
+		assert.Empty(t, model.rows)
+		assert.Empty(t, model.stack)
+		assert.Nil(t, model.searchReturn)
+		assert.Contains(t, model.notice, "trash outcome is unconfirmed")
+
+		model = runModelCommand(t, model, refresh)
+		assert.Equal(t, "/", model.directory.Path)
+		require.Len(t, model.rows, 2)
+		assert.Equal(t, int64(2), model.rows[0].node.Revision)
+	})
+
+	t.Run("restore refreshes trash and reloads root on close", func(t *testing.T) {
+		backend := newFakeBackend()
+		backend.mutationReceiptErr = NewMutationUnconfirmedError(
+			"restore", errors.New("receipt was truncated"),
+		)
+		model, err := New(t.Context(), backend)
+		require.NoError(t, err)
+		model = runModelCommand(t, model, model.loadDirectory(
+			0, navigationInitial, model.requestID,
+		))
+		model, trashLoad := updateModel(t, model, runeKey('T'))
+		model = runModelCommand(t, model, trashLoad)
+
+		model, _ = updateModel(t, model, key(tea.KeyEnter))
+		model, mutation := updateModel(t, model, key(tea.KeyEnter))
+		require.NotNil(t, mutation)
+		model, refresh := updateModel(t, model, mutation())
+		require.NotNil(t, refresh)
+		assert.True(t, model.trashChanged)
+		assert.True(t, model.trashLoading)
+		assert.Contains(t, model.notice, "restore outcome is unconfirmed")
+
+		model = runModelCommand(t, model, refresh)
+		assert.Empty(t, model.trashItems)
+		model, rootLoad := updateModel(t, model, key(tea.KeyEscape))
+		require.NotNil(t, rootLoad)
+		assert.Empty(t, model.rows)
+		assert.Empty(t, model.stack)
+		model = runModelCommand(t, model, rootLoad)
+		assert.Equal(t, "/", model.directory.Path)
+	})
 }
 
 func TestTrashOverlayDoesNotCancelUnderlyingLoad(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -34,6 +34,11 @@ type fakeBackend struct {
 	jobs           []api.Job
 	jobsErr        error
 	jobCalls       int
+	trash          api.TrashPage
+	trashCalls     int
+	trashed        []api.Node
+	restored       []api.Node
+	mutationErr    error
 }
 
 func newFakeBackend() *fakeBackend {
@@ -116,6 +121,15 @@ func newFakeBackend() *fakeBackend {
 				Error: "source is temporarily unavailable; check the configured inbox path",
 			},
 		},
+		trash: api.TrashPage{
+			Items: []api.Node{
+				{
+					ID: 20, Kind: "file", Name: "old-report.txt", Revision: 4,
+					Size: 42, TrashedAt: "2026-07-22T15:00:00Z",
+				},
+			},
+			Total: 1, Limit: maxTrashItems,
+		},
 	}
 }
 
@@ -185,6 +199,68 @@ func (f *fakeBackend) Jobs(_ context.Context) ([]api.Job, error) {
 	return append([]api.Job(nil), f.jobs...), nil
 }
 
+func (f *fakeBackend) TrashPage(
+	_ context.Context, limit, offset int,
+) (api.TrashPage, error) {
+	f.trashCalls++
+	if f.err != nil {
+		return api.TrashPage{}, f.err
+	}
+	page := f.trash
+	page.Limit = limit
+	page.Offset = offset
+	return page, nil
+}
+
+func (f *fakeBackend) Trash(
+	_ context.Context, nodeID, revision int64,
+) (api.Node, error) {
+	f.trashed = append(f.trashed, api.Node{ID: nodeID, Revision: revision})
+	if f.mutationErr != nil {
+		return api.Node{}, f.mutationErr
+	}
+	for itemPath, node := range f.nodes {
+		if node.ID == nodeID {
+			node.TrashedAt = "2026-07-22T16:00:00Z"
+			node.Path = ""
+			f.nodes[itemPath] = node
+			for parentID, page := range f.children {
+				filtered := page.Items[:0]
+				for _, item := range page.Items {
+					if item.ID != nodeID {
+						filtered = append(filtered, item)
+					}
+				}
+				page.Items = filtered
+				page.Total = len(filtered)
+				f.children[parentID] = page
+			}
+			return node, nil
+		}
+	}
+	return api.Node{}, errors.New("not found")
+}
+
+func (f *fakeBackend) Restore(
+	_ context.Context, nodeID, revision int64,
+) (api.Node, error) {
+	f.restored = append(f.restored, api.Node{ID: nodeID, Revision: revision})
+	if f.mutationErr != nil {
+		return api.Node{}, f.mutationErr
+	}
+	for index, node := range f.trash.Items {
+		if node.ID == nodeID {
+			f.trash.Items = append(f.trash.Items[:index], f.trash.Items[index+1:]...)
+			f.trash.Total--
+			node.Revision++
+			node.TrashedAt = ""
+			node.Path = "/restored/" + node.Name
+			return node, nil
+		}
+	}
+	return api.Node{}, errors.New("not found")
+}
+
 func (f *fakeBackend) AuditHistory(
 	_ context.Context, _ string, nodeID int64, limit int, cursor string,
 ) (api.AuditEventPage, error) {
@@ -240,6 +316,67 @@ func TestModelNavigatesSearchesAndReturnsToTree(t *testing.T) {
 	assert.Equal(t, modeBrowse, model.mode)
 	assert.Equal(t, "/", model.directory.Path)
 	require.Len(t, model.rows, 2)
+}
+
+func TestModelConfirmsRevisionBoundTrashAndRestore(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.width, model.height = 100, 16
+	model.cursor = 1
+
+	model, cmd := updateModel(t, model, runeKey('x'))
+	require.Nil(t, cmd)
+	require.NotNil(t, model.confirmation)
+	assert.Equal(t, mutationTrash, model.confirmation.action)
+	assert.Contains(t, model.View().Content, "Move to recoverable trash?")
+	assert.Contains(t, model.View().Content, "Bound revision: 2")
+	assert.Empty(t, backend.trashed)
+
+	model, cmd = updateModel(t, model, key(tea.KeyEnter))
+	require.NotNil(t, cmd)
+	model = runModelCommand(t, model, cmd)
+	require.Len(t, backend.trashed, 1)
+	assert.Equal(t, api.Node{ID: 3, Revision: 2}, backend.trashed[0])
+	assert.Nil(t, model.confirmation)
+	assert.Contains(t, model.notice, "recoverable trash")
+	assert.NotContains(t, rowIDs(model.rows), int64(3))
+
+	model, cmd = updateModel(t, model, runeKey('T'))
+	require.NotNil(t, cmd)
+	model = runModelCommand(t, model, cmd)
+	assert.True(t, model.trashOpen)
+	require.Len(t, model.trashItems, 1)
+	assert.Contains(t, model.View().Content, `"old-report.txt"`)
+
+	model, cmd = updateModel(t, model, key(tea.KeyEnter))
+	require.Nil(t, cmd)
+	require.NotNil(t, model.confirmation)
+	assert.Equal(t, mutationRestore, model.confirmation.action)
+	assert.Contains(t, model.View().Content, "Restore this node?")
+	assert.Contains(t, model.View().Content, "Bound revision: 4")
+
+	model, cmd = updateModel(t, model, key(tea.KeyEnter))
+	require.NotNil(t, cmd)
+	model = runModelCommand(t, model, cmd)
+	require.Len(t, backend.restored, 1)
+	assert.Equal(t, api.Node{ID: 20, Revision: 4}, backend.restored[0])
+	assert.Contains(t, model.notice, `/restored/old-report.txt`)
+	assert.Empty(t, model.trashItems)
+}
+
+func TestModelCancelsTrashConfirmationWithoutMutation(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+
+	model, _ = updateModel(t, model, runeKey('x'))
+	require.NotNil(t, model.confirmation)
+	model, _ = updateModel(t, model, key(tea.KeyEscape))
+	assert.Nil(t, model.confirmation)
+	assert.Empty(t, backend.trashed)
 }
 
 func TestModelPreservesViewStateAcrossNavigation(t *testing.T) {
@@ -961,7 +1098,7 @@ func TestChromeAdaptsWithoutDroppingPrimaryContext(t *testing.T) {
 	model.loading = false
 
 	assert.Contains(t, model.renderTitleBar(), "docbank")
-	assert.Contains(t, model.renderTitleBar(), "READ ONLY")
+	assert.Contains(t, model.renderTitleBar(), "RECOVERABLE")
 	assert.Contains(t, model.renderLocation(), "1000")
 	footer := model.renderFooter()
 	assert.Contains(t, footer, "↑/↓ move")

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -379,6 +379,81 @@ func TestModelCancelsTrashConfirmationWithoutMutation(t *testing.T) {
 	assert.Empty(t, backend.trashed)
 }
 
+func TestTrashOverlayDoesNotCancelUnderlyingLoad(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	underlyingRequestID := model.requestID
+	delayedDirectory := model.loadDirectory(0, navigationInitial, underlyingRequestID)
+
+	model, delayedTrash := updateModel(t, model, runeKey('T'))
+	require.NotNil(t, delayedTrash)
+	assert.Equal(t, underlyingRequestID, model.requestID)
+	assert.True(t, model.loading)
+	assert.True(t, model.trashLoading)
+
+	pendingTrashRequestID := model.trashRequestID
+	model, _ = updateModel(t, model, key(tea.KeyEscape))
+	assert.False(t, model.trashOpen)
+	assert.False(t, model.trashLoading)
+	assert.True(t, model.loading)
+	assert.Greater(t, model.trashRequestID, pendingTrashRequestID)
+
+	model = runModelCommand(t, model, delayedDirectory)
+	assert.False(t, model.loading)
+	assert.Equal(t, "/", model.directory.Path)
+	require.Len(t, model.rows, 2)
+
+	model = runModelCommand(t, model, delayedTrash)
+	assert.False(t, model.trashOpen)
+	assert.Empty(t, model.trashItems)
+}
+
+func TestSuccessfulTrashPreservesBackAndSearchNavigation(t *testing.T) {
+	t.Run("nested directory", func(t *testing.T) {
+		backend := newFakeBackend()
+		model, err := New(t.Context(), backend)
+		require.NoError(t, err)
+		model = runModelCommand(t, model, model.loadDirectory(
+			0, navigationInitial, model.requestID,
+		))
+		model, cmd := updateModel(t, model, key(tea.KeyEnter))
+		model = runModelCommand(t, model, cmd)
+		require.Len(t, model.stack, 1)
+
+		model, _ = updateModel(t, model, runeKey('x'))
+		model, cmd = updateModel(t, model, key(tea.KeyEnter))
+		model = runModelCommand(t, model, cmd)
+		require.Len(t, model.stack, 1)
+
+		model, _ = updateModel(t, model, key(tea.KeyLeft))
+		assert.Equal(t, "/", model.directory.Path)
+	})
+
+	t.Run("search results", func(t *testing.T) {
+		backend := newFakeBackend()
+		model, err := New(t.Context(), backend)
+		require.NoError(t, err)
+		model = runModelCommand(t, model, model.loadDirectory(
+			0, navigationInitial, model.requestID,
+		))
+		model, _ = updateModel(t, model, runeKey('/'))
+		model.searchInput.SetValue("report")
+		model, cmd := updateModel(t, model, key(tea.KeyEnter))
+		model = runModelCommand(t, model, cmd)
+		require.NotNil(t, model.searchReturn)
+
+		model, _ = updateModel(t, model, runeKey('x'))
+		model, cmd = updateModel(t, model, key(tea.KeyEnter))
+		model = runModelCommand(t, model, cmd)
+		require.NotNil(t, model.searchReturn)
+
+		model, _ = updateModel(t, model, key(tea.KeyEscape))
+		assert.Equal(t, modeBrowse, model.mode)
+		assert.Equal(t, "/", model.directory.Path)
+	})
+}
+
 func TestModelPreservesViewStateAcrossNavigation(t *testing.T) {
 	backend := newFakeBackend()
 	model, err := New(t.Context(), backend)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -441,6 +441,15 @@ func TestTrashOverlayDoesNotCancelUnderlyingLoad(t *testing.T) {
 	assert.Empty(t, model.trashItems)
 }
 
+func TestTrashHelpShortcutOpensHelp(t *testing.T) {
+	model, err := New(t.Context(), newFakeBackend())
+	require.NoError(t, err)
+	model, _ = updateModel(t, model, runeKey('T'))
+	model, _ = updateModel(t, model, runeKey('?'))
+	assert.True(t, model.trashOpen)
+	assert.True(t, model.helpOpen)
+}
+
 func TestSuccessfulTrashPreservesBackAndSearchNavigation(t *testing.T) {
 	t.Run("nested directory", func(t *testing.T) {
 		backend := newFakeBackend()

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -221,13 +221,18 @@ func (f *fakeBackend) Trash(
 	}
 	for itemPath, node := range f.nodes {
 		if node.ID == nodeID {
+			livePath := node.Path
 			node.TrashedAt = "2026-07-22T16:00:00Z"
 			node.Path = ""
 			f.nodes[itemPath] = node
+			if node.ParentID != nil {
+				f.bumpNodeRevision(*node.ParentID)
+			}
 			for parentID, page := range f.children {
 				filtered := page.Items[:0]
 				for _, item := range page.Items {
-					if item.ID != nodeID {
+					if item.ID != nodeID &&
+						(livePath == "" || !strings.HasPrefix(item.Path, livePath+"/")) {
 						filtered = append(filtered, item)
 					}
 				}
@@ -235,10 +240,37 @@ func (f *fakeBackend) Trash(
 				page.Total = len(filtered)
 				f.children[parentID] = page
 			}
+			hits := f.search.Hits[:0]
+			for _, hit := range f.search.Hits {
+				if hit.Node.ID != nodeID &&
+					(livePath == "" || !strings.HasPrefix(hit.Path, livePath+"/")) {
+					hits = append(hits, hit)
+				}
+			}
+			f.search.Hits = hits
 			return node, nil
 		}
 	}
 	return api.Node{}, errors.New("not found")
+}
+
+func (f *fakeBackend) bumpNodeRevision(nodeID int64) {
+	for nodePath, node := range f.nodes {
+		if node.ID != nodeID {
+			continue
+		}
+		node.Revision++
+		f.nodes[nodePath] = node
+		for parentID, page := range f.children {
+			for index := range page.Items {
+				if page.Items[index].ID == nodeID {
+					page.Items[index] = node
+				}
+			}
+			f.children[parentID] = page
+		}
+		return
+	}
 }
 
 func (f *fakeBackend) Restore(
@@ -425,9 +457,15 @@ func TestSuccessfulTrashPreservesBackAndSearchNavigation(t *testing.T) {
 		model, cmd = updateModel(t, model, key(tea.KeyEnter))
 		model = runModelCommand(t, model, cmd)
 		require.Len(t, model.stack, 1)
+		assert.True(t, model.stack[0].stale)
 
-		model, _ = updateModel(t, model, key(tea.KeyLeft))
+		model, cmd = updateModel(t, model, key(tea.KeyLeft))
+		require.NotNil(t, cmd)
+		assert.True(t, model.loading)
+		model = runModelCommand(t, model, cmd)
 		assert.Equal(t, "/", model.directory.Path)
+		require.Len(t, model.rows, 2)
+		assert.Equal(t, int64(2), model.rows[0].node.Revision)
 	})
 
 	t.Run("search results", func(t *testing.T) {
@@ -447,11 +485,55 @@ func TestSuccessfulTrashPreservesBackAndSearchNavigation(t *testing.T) {
 		model, cmd = updateModel(t, model, key(tea.KeyEnter))
 		model = runModelCommand(t, model, cmd)
 		require.NotNil(t, model.searchReturn)
+		assert.True(t, model.searchReturn.stale)
 
-		model, _ = updateModel(t, model, key(tea.KeyEscape))
+		model, cmd = updateModel(t, model, key(tea.KeyEscape))
+		require.NotNil(t, cmd)
+		model = runModelCommand(t, model, cmd)
 		assert.Equal(t, modeBrowse, model.mode)
 		assert.Equal(t, "/", model.directory.Path)
+		require.Len(t, model.rows, 2)
+		assert.Equal(t, int64(2), model.rows[0].node.Revision)
 	})
+}
+
+func TestTrashAncestorFromSearchFallsBackToLiveParent(t *testing.T) {
+	backend := newFakeBackend()
+	backend.search.Hits = []api.SearchHit{{
+		Node: backend.nodes["/docs"], Path: "/docs", Match: "name",
+	}}
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(
+		0, navigationInitial, model.requestID,
+	))
+	model, cmd := updateModel(t, model, key(tea.KeyEnter))
+	model = runModelCommand(t, model, cmd)
+	assert.Equal(t, "/docs", model.directory.Path)
+	require.Len(t, model.stack, 1)
+
+	model, _ = updateModel(t, model, runeKey('/'))
+	model.searchInput.SetValue("docs")
+	model, cmd = updateModel(t, model, key(tea.KeyEnter))
+	model = runModelCommand(t, model, cmd)
+	require.NotNil(t, model.searchReturn)
+	assert.Equal(t, "/docs", model.searchReturn.directory.Path)
+
+	model, _ = updateModel(t, model, runeKey('x'))
+	model, cmd = updateModel(t, model, key(tea.KeyEnter))
+	model = runModelCommand(t, model, cmd)
+	require.NotNil(t, model.searchReturn)
+	assert.Equal(t, "/", model.searchReturn.directory.Path)
+	assert.True(t, model.searchReturn.stale)
+	assert.Empty(t, model.stack)
+
+	model, cmd = updateModel(t, model, key(tea.KeyEscape))
+	require.NotNil(t, cmd)
+	model = runModelCommand(t, model, cmd)
+	assert.Equal(t, modeBrowse, model.mode)
+	assert.Equal(t, "/", model.directory.Path)
+	require.Len(t, model.rows, 1)
+	assert.Equal(t, "/README.txt", model.rows[0].path)
 }
 
 func TestModelPreservesViewStateAcrossNavigation(t *testing.T) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -72,6 +72,8 @@ func (m Model) render() string {
 	lines := []string{m.renderTitleBar()}
 	if m.jobsOpen {
 		lines = append(lines, m.renderJobsLocation())
+	} else if m.trashOpen {
+		lines = append(lines, m.renderTrashLocation())
 	} else if m.historyOpen {
 		lines = append(lines, m.renderHistoryLocation())
 	} else {
@@ -80,11 +82,16 @@ func (m Model) render() string {
 	if m.searching {
 		lines = append(lines, fit(m.searchInput.View(), m.width))
 	}
+	if m.notice != "" {
+		lines = append(lines, m.styles.stats.Render(fit(" "+m.notice, m.width)))
+	}
 
 	bodyHeight := max(m.height-len(lines)-1, 1)
 	body := m.renderBody(bodyHeight)
 	if m.jobsOpen {
 		body = m.renderJobsList(bodyHeight)
+	} else if m.trashOpen {
+		body = m.renderTrashList(bodyHeight)
 	} else if m.historyOpen {
 		body = m.renderHistoryList(bodyHeight)
 	}
@@ -101,6 +108,9 @@ func (m Model) render() string {
 	content := strings.Join(lines, "\n")
 	if m.helpOpen {
 		return m.renderHelp(content)
+	}
+	if m.confirmation != nil {
+		return m.renderConfirmation(content)
 	}
 	return content
 }
@@ -145,13 +155,28 @@ func (m Model) renderHistoryLocation() string {
 	return m.styles.stats.Render(joinSides(left, right, m.width))
 }
 
+func (m Model) renderTrashLocation() string {
+	left := " Recoverable trash · newest first"
+	right := fmt.Sprintf("%d restorable root(s)", m.trashTotal)
+	if m.trashTotal > len(m.trashItems) {
+		right = fmt.Sprintf("first %d of %d", len(m.trashItems), m.trashTotal)
+	}
+	if m.loading {
+		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
+	}
+	if m.err != nil {
+		return m.styles.error.Render(fit(left+" — "+quoted(m.err.Error()), m.width))
+	}
+	return m.styles.stats.Render(joinSides(left, right, m.width))
+}
+
 func (m Model) renderTitleBar() string {
 	if m.width < 3 {
 		return fit("docbank", m.width)
 	}
 	contentWidth := max(m.width-2, 1)
 	left := "docbank  documents for you and your agents"
-	right := "READ ONLY"
+	right := "RECOVERABLE CHANGES"
 	if lipgloss.Width(left)+lipgloss.Width(right)+2 > contentWidth {
 		left = "docbank"
 	}
@@ -317,7 +342,6 @@ func (m Model) renderList(width, height int) string {
 	lines := make([]string, 0, height)
 	layout := newTableLayout(width, m.mode)
 	heading := layout.render(
-		"   ",
 		m.columnHeading("DOCUMENT", sortByName),
 		"TYPE",
 		"MATCH",
@@ -356,13 +380,58 @@ func (m Model) renderList(width, height int) string {
 			size = formatBytes(item.node.Size)
 		}
 		line := layout.render(
-			"   ", quoted(label), kind, match, size, formatModified(item.node.ModifiedAt),
+			quoted(label), kind, match, size, formatModified(item.node.ModifiedAt),
 		)
 		if index == m.cursor {
 			line = "▶" + line[1:]
 		}
 		line = pad(fit(line, width), width)
 		if index == m.cursor {
+			lines = append(lines, m.styles.cursor.Render(line))
+		} else if index%2 == 1 {
+			lines = append(lines, m.styles.alternate.Render(line))
+		} else {
+			lines = append(lines, line)
+		}
+	}
+	for len(lines) < height {
+		lines = append(lines, strings.Repeat(" ", width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderTrashList(height int) string {
+	width := max(m.width, 1)
+	lines := make([]string, 0, height)
+	layout := newTableLayout(width, modeBrowse)
+	heading := layout.render("DOCUMENT", "TYPE", "", "SIZE", "TRASHED")
+	lines = append(lines, m.styles.heading.Render(pad(fit(heading, width), width)))
+	if height > 1 {
+		lines = append(lines, m.styles.separator.Render(strings.Repeat("─", width)))
+	}
+	visible := max(height-2, 0)
+	if len(m.trashItems) == 0 && visible > 0 {
+		message := " Trash is empty"
+		if m.loading {
+			message = " Loading..."
+		}
+		lines = append(lines, m.styles.muted.Render(pad(fit(message, width), width)))
+	}
+	end := min(m.trashOffset+visible, len(m.trashItems))
+	for index := m.trashOffset; index < end; index++ {
+		node := m.trashItems[index]
+		kind, size := "FILE", formatBytes(node.Size)
+		if node.Kind == nodeKindDir {
+			kind, size = "DIR ", "-"
+		}
+		line := layout.render(
+			quoted(node.Name), kind, "", size, formatModified(node.TrashedAt),
+		)
+		if index == m.trashCursor {
+			line = "▶" + line[1:]
+		}
+		line = pad(fit(line, width), width)
+		if index == m.trashCursor {
 			lines = append(lines, m.styles.cursor.Render(line))
 		} else if index%2 == 1 {
 			lines = append(lines, m.styles.alternate.Render(line))
@@ -632,9 +701,9 @@ func newTableLayout(width int, mode viewMode) tableLayout {
 	return layout
 }
 
-func (l tableLayout) render(prefix, document, kind, match, size, modified string) string {
+func (l tableLayout) render(document, kind, match, size, modified string) string {
 	var line strings.Builder
-	line.WriteString(fit(prefix, 3))
+	line.WriteString("   ")
 	line.WriteString(pad(document, l.document))
 	if l.showKind {
 		line.WriteString("  ")
@@ -792,6 +861,9 @@ func (m Model) renderFooter() string {
 	if m.historyOpen {
 		return m.renderHistoryFooter()
 	}
+	if m.trashOpen {
+		return m.renderTrashFooter()
+	}
 	if m.detailOpen {
 		return m.renderDetailFooter()
 	}
@@ -805,6 +877,7 @@ func (m Model) renderFooter() string {
 		hints = append(hints,
 			hint{text: "i inspect", priority: 65},
 			hint{text: "a history", priority: 68},
+			hint{text: "x trash", priority: 72},
 		)
 	}
 	if len(m.stack) > 0 || m.mode == modeSearch {
@@ -812,6 +885,7 @@ func (m Model) renderFooter() string {
 	}
 	hints = append(hints,
 		hint{text: "/ search", priority: 90},
+		hint{text: "T recover", priority: 74},
 		hint{text: "J jobs", priority: 68},
 		hint{text: "s sort", priority: 85},
 		hint{text: "v reverse", priority: 25},
@@ -834,6 +908,23 @@ func (m Model) renderFooter() string {
 	available := max(m.width-lipgloss.Width(position)-1, 0)
 	keys := fitHints(hints, available)
 	return m.styles.footer.Render(joinSides(keys, position, m.width))
+}
+
+func (m Model) renderTrashFooter() string {
+	hints := []hint{
+		{text: "↑/↓ move", priority: 100},
+		{text: "enter restore", priority: 95},
+		{text: "r refresh", priority: 70},
+		{text: "esc back", priority: 90},
+		{text: "? help", priority: 75},
+		{text: "q quit", priority: 60},
+	}
+	position := ""
+	if len(m.trashItems) > 0 {
+		position = fmt.Sprintf(" %d/%d ", m.trashCursor+1, m.trashTotal)
+	}
+	available := max(m.width-lipgloss.Width(position)-1, 0)
+	return m.styles.footer.Render(joinSides(fitHints(hints, available), position, m.width))
 }
 
 func (m Model) renderJobsFooter() string {
@@ -989,7 +1080,66 @@ func (m Model) renderHelp(background string) string {
 	return m.overlayModal(background, modal)
 }
 
+func (m Model) renderConfirmation(background string) string {
+	confirmation := m.confirmation
+	if confirmation == nil {
+		return background
+	}
+	node := confirmation.target.node
+	title := "Move to recoverable trash?"
+	action := "Move"
+	subject := confirmation.target.path
+	detail := []string{"The node remains restorable. No content bytes are reclaimed."}
+	if confirmation.action == mutationRestore {
+		title = "Restore this node?"
+		action = "Restore"
+		subject = node.Name
+		detail = []string{
+			"Docbank reports the actual restored path after resolving",
+			"name collisions or missing origin parents.",
+		}
+	}
+	status := "Enter " + strings.ToLower(action) + " · Esc cancel"
+	if m.mutationRunning {
+		status = m.styles.spinner.Render(m.spinnerIndicator()) + " " +
+			strings.ToLower(action) + " in progress"
+	}
+	contentWidth := min(max(m.width-10, 1), 68)
+	lines := []string{
+		title,
+		"",
+		" " + quoted(subject),
+		fmt.Sprintf(" Stable selector: id:%d", node.ID),
+		fmt.Sprintf(" Bound revision: %d", node.Revision),
+		"",
+	}
+	lines = append(lines, detail...)
+	lines = append(lines, "", status)
+	for index := range lines {
+		lines[index] = fit(lines[index], contentWidth)
+	}
+	lines[0] = m.styles.modalTitle.Render(lines[0])
+	modal := m.styles.modal.Render(strings.Join(lines, "\n"))
+	return m.overlayModal(background, modal)
+}
+
 func (m Model) helpLines() []string {
+	if m.trashOpen {
+		return []string{
+			"Recoverable trash shortcuts",
+			"",
+			"↑/k, ↓/j       Move through restorable roots",
+			"PgUp/PgDn      Move one visible page",
+			"Home/End       Jump to first or last root",
+			"Enter          Review and restore this revision",
+			"r              Refresh recoverable trash",
+			"Esc            Return to documents",
+			"q              Quit",
+			"",
+			"Permanent deletion is not available here.",
+			"Press any key to close",
+		}
+	}
 	if m.jobsOpen {
 		if m.jobDetail {
 			return []string{
@@ -1056,6 +1206,8 @@ func (m Model) helpLines() []string {
 		"Home/End       Jump to first or last",
 		"Enter/→/l      Open a directory",
 		"Enter/i        Inspect complete document authority",
+		"x              Review moving the node to trash",
+		"T              Browse and restore recoverable trash",
 		"a              Browse permanent audited history",
 		"J              Inspect daemon background jobs",
 		"Esc/←/h        Return to the previous view",

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -161,11 +161,11 @@ func (m Model) renderTrashLocation() string {
 	if m.trashTotal > len(m.trashItems) {
 		right = fmt.Sprintf("first %d of %d", len(m.trashItems), m.trashTotal)
 	}
-	if m.loading {
+	if m.trashLoading {
 		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
 	}
-	if m.err != nil {
-		return m.styles.error.Render(fit(left+" — "+quoted(m.err.Error()), m.width))
+	if m.trashErr != nil {
+		return m.styles.error.Render(fit(left+" — "+quoted(m.trashErr.Error()), m.width))
 	}
 	return m.styles.stats.Render(joinSides(left, right, m.width))
 }
@@ -412,7 +412,7 @@ func (m Model) renderTrashList(height int) string {
 	visible := max(height-2, 0)
 	if len(m.trashItems) == 0 && visible > 0 {
 		message := " Trash is empty"
-		if m.loading {
+		if m.trashLoading {
 			message = " Loading..."
 		}
 		lines = append(lines, m.styles.muted.Render(pad(fit(message, width), width)))


### PR DESCRIPTION
Docbank’s terminal browser can now complete the ordinary recoverable lifecycle without sending a person back to separate CLI commands. Press `x` on a live file or folder to review moving that exact revision to trash; press `T` to browse restorable roots newest first and return one to the live tree.

Both decisions show the escaped name or path, stable node ID, and bound revision before anything changes. A concurrent CLI or agent update is therefore rejected instead of silently acting on newer state. After restoration, the TUI reports the canonical path the daemon actually selected, including collision suffixing or root fallback.

![The actual Docbank TUI confirming restoration of a synthetic document](https://raw.githubusercontent.com/kenn-io/docbank/d0be516df8b7f084f8a720e37483af036dfa0df2/screenshots/tui-recoverable-trash/tui-recoverable-trash.png)

*Actual daemon-backed TUI output from an owner-private synthetic vault; no private corpus data is present.*

This remains deliberately recoverable. The TUI cannot empty trash, run garbage collection, or reclaim bytes. A lost mutation response is reported as unconfirmed and is never replayed automatically; confirmed changes disappear from the current table immediately, so a failed refresh cannot make stale authority look live again.

I also exercised the rendered flow end to end against a real temporary vault: trash, revision-bound confirmation, restore, and inspection of the daemon-returned path. The daemon, binary, and synthetic vault were removed afterward.