### PR TITLE
Inspect storage and backups in the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Four commitments:
 - FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
 - A daemon-backed TUI for analytical tree browsing, search, stable
   document/version identity inspection, permanent audited-history timelines,
-  and revision-bound recoverable trash and restore
+  revision-bound recoverable trash and restore, and read-only storage and
+  backup inspection
 - A scoped kit-ui web application for verified local-file upload, virtual-tree browsing, sortable
   document analysis, tag-definition management, tag browsing and assignment,
   tag-filtered extracted-text search,

--- a/cmd/docbank/tui.go
+++ b/cmd/docbank/tui.go
@@ -26,6 +26,7 @@ Navigation:
   x                    Move the selected node to recoverable trash
   T                    Browse and restore recoverable trash
   a                    Browse permanent audited history
+  O                    Inspect storage and backup state
   Left or Backspace    Return to the parent directory
   /                    Search names and extracted text
   s                    Cycle the sort column
@@ -35,8 +36,8 @@ Navigation:
   q                    Quit
 
 Trash and restore require an explicit revision-bound confirmation. Permanent
-deletion, storage maintenance, backup, and permanent-audit enrollment remain
-outside the TUI.`,
+deletion, storage maintenance, backup creation/restore, and permanent-audit
+enrollment remain outside the TUI.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		c, err := client.Ensure(cmd.Context())
@@ -189,6 +190,20 @@ func (b *tuiDaemonBackend) NodeTags(
 func (b *tuiDaemonBackend) Jobs(ctx context.Context) ([]api.Job, error) {
 	return withTUIClient(ctx, b, func(c *client.Client) ([]api.Job, error) {
 		return c.Jobs(ctx)
+	})
+}
+
+func (b *tuiDaemonBackend) Info(ctx context.Context) (api.VaultInfo, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) (api.VaultInfo, error) {
+		return c.Info(ctx)
+	})
+}
+
+func (b *tuiDaemonBackend) BackupList(
+	ctx context.Context,
+) ([]api.BackupSnapshot, error) {
+	return withTUIClient(ctx, b, func(c *client.Client) ([]api.BackupSnapshot, error) {
+		return c.BackupList(ctx, "")
 	})
 }
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -19,7 +19,7 @@ Every documentation page is also published as raw Markdown at the same path with
 - [Organizing & Tagging](https://docbank.ai/usage/organizing.md): Browsing, moving, renaming, and tagging in the virtual tree.
 - [Searching](https://docbank.ai/usage/searching.md): Ranked, prefix-matching search over document names and verified text content.
 - [Web application](https://docbank.ai/usage/web.md): Upload, browse, search, and organize the local vault in a responsive, authenticated web interface.
-- [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse documents, inspect authority and permanent history, and safely move or restore recoverable trash from the TUI.
+- [Interactive terminal browser](https://docbank.ai/usage/tui.md): Browse documents, inspect authority, storage, backups, and permanent history, and safely move or restore recoverable trash from the TUI.
 
 ## Protect & Operate
 - [Vault Lifecycle](https://docbank.ai/usage/lifecycle.md): Operate a docbank vault safely from first import through maintenance, upgrades, snapshots, and recovery.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -82,8 +82,9 @@ Use the arrow keys or `j`/`k` to select a document, Enter to open a directory,
 and `/` to search names and extracted text. Press `i` for complete document
 authority or `a` for the selected node's permanent audited-history timeline.
 Press `x` to review moving the selected revision to recoverable trash, or `T`
-to browse and restore trash roots. The TUI does not expose permanent deletion.
-See the
+to browse and restore trash roots. Press `O` for the read-only storage inventory
+and configured backup recovery points. The TUI does not expose permanent
+deletion or maintenance mutations. See the
 [interactive terminal browser](usage/tui.md) guide for the complete key map.
 
 `cat` streams a file's bytes to stdout. For a durable local file, `get` first

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ elsewhere only when they materially explain the design and are marked
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
-| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: analytical tree/search/detail, audited-history, daemon-job inspection, web tag definition/browsing/assignment workflows, version history, provenance, verified current/historical content download, verified upload, and recoverable trash with restoration implemented |
+| 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: analytical tree/search/detail, audited-history, daemon-job and storage/backup inspection, web tag definition/browsing/assignment workflows, version history, provenance, verified current/historical content download, verified upload, and recoverable trash with restoration implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
 ## Implemented (Phase 1)
@@ -168,10 +168,12 @@ search, stable document/version/hash detail, a compact node-focused
 audited-history timeline, and revision-bound recoverable trash and restore. Its
 daemon-activity screen reports supervised job lifecycle, timestamps, and
 complete terminal failures without inventing percentages where workers expose
-no authoritative total. Later slices add ingest progress, broader
-metadata/evidence, and storage and backup state. Rich document comparison
-belongs in external tools or the web portal. Neither client has privileged
-operations — anything either does, the API can do.
+no authoritative total. A read-only operations screen separates logical
+authority from loose and packed inventory and lists the configured repository's
+backup recovery points. Later slices add ingest progress and broader
+metadata/evidence. Rich document comparison belongs in external tools or the
+web portal. Neither client has privileged operations — anything either does,
+the API can do.
 
 ## Phase 4 — Backup (implemented)
 

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive terminal browser
-description: Browse documents, inspect authority and permanent history, and safely move or restore recoverable trash from the TUI.
+description: Browse documents, inspect authority, storage, backups, and permanent history, and safely move or restore recoverable trash from the TUI.
 ---
 
 # Interactive terminal browser
@@ -47,6 +47,14 @@ same document selection. The current daemon contract reports lifecycle rather
 than invented percentages: workers will show numeric progress only when they
 can supply an authoritative completed and total count.
 
+Press <kbd>O</kbd> for a read-only operational summary. It separates logical
+catalog authority from physical loose-file and pack inventory, including live
+packed content and dead packed payload awaiting an explicit repack. The same
+screen lists the configured backup repository's recovery points with their
+creation time, tag, snapshot ID, file count, and newly added bytes. Storage
+status remains useful when no backup repository is configured; the two
+independent results report their own errors.
+
 Press <kbd>x</kbd> to review moving the selected live node to recoverable
 trash. The confirmation names the escaped path, stable node ID, and exact
 revision that will be changed; a concurrent change is rejected rather than
@@ -70,6 +78,7 @@ really intended.
 | <kbd>T</kbd> | Browse and restore recoverable trash roots |
 | <kbd>a</kbd> | Browse the selected node's permanent audited history |
 | <kbd>J</kbd> | Inspect daemon background jobs and failures |
+| <kbd>O</kbd> | Inspect storage inventory and backup recovery points |
 | <kbd>←</kbd>, <kbd>Backspace</kbd>, or <kbd>Esc</kbd> | Return to the parent directory or leave search results |
 | <kbd>/</kbd> | Search live names and extracted text |
 | <kbd>s</kbd> | Cycle the sort column: name, size, and modification time |
@@ -92,6 +101,7 @@ returns to relevance. The first interface loads at most 1,000
 directory entries or search hits and says when more exist; use the CLI or HTTP
 pagination for exhaustive automation.
 
-Other mutations, permanent deletion, permanent-audit enrollment and independent
-verification, backup, and storage maintenance remain outside this interface.
-Use their ordinary CLI commands or authenticated HTTP endpoints.
+Other mutations, permanent deletion, permanent-audit enrollment, independent
+verification, backup creation/verification/restore, and storage maintenance
+remain outside this interface. Use their ordinary CLI commands or authenticated
+HTTP endpoints.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -24,8 +24,11 @@ const (
 	maxHistoryItems = 100
 	maxJobItems     = 1000
 	maxTrashItems   = 1000
+	maxBackupItems  = 1000
 	nodeKindDir     = "dir"
 	nodeKindFile    = "file"
+	keyCtrlC        = "ctrl+c"
+	keyEscape       = "esc"
 )
 
 // Backend is the bounded daemon surface needed by the TUI.
@@ -37,6 +40,8 @@ type Backend interface {
 	Search(ctx context.Context, query string, limit int) (api.SearchReport, error)
 	NodeTags(ctx context.Context, nodeID int64, limit, offset int) (api.TagPage, error)
 	Jobs(ctx context.Context) ([]api.Job, error)
+	Info(ctx context.Context) (api.VaultInfo, error)
+	BackupList(ctx context.Context) ([]api.BackupSnapshot, error)
 	TrashPage(ctx context.Context, limit, offset int) (api.TrashPage, error)
 	Trash(ctx context.Context, nodeID, revision int64) (api.Node, error)
 	Restore(ctx context.Context, nodeID, revision int64) (api.Node, error)
@@ -123,6 +128,14 @@ type jobsLoadedMsg struct {
 	requestID uint64
 	items     []api.Job
 	err       error
+}
+
+type operationsLoadedMsg struct {
+	requestID  uint64
+	info       api.VaultInfo
+	snapshots  []api.BackupSnapshot
+	storageErr error
+	backupErr  error
 }
 
 type trashLoadedMsg struct {
@@ -215,54 +228,63 @@ type Model struct {
 	searchQuery  string
 	searchReturn *location
 
-	requestID           uint64
-	loading             bool
-	err                 error
-	quitting            bool
-	helpOpen            bool
-	detailOpen          bool
-	detailOffset        int
-	detailNode          row
-	detailTags          []api.Tag
-	detailTagsTotal     int
-	detailTagsLoading   bool
-	detailTagsErr       error
-	detailRequestID     uint64
-	jobsOpen            bool
-	jobs                []api.Job
-	jobsTotal           int
-	jobsRunning         int
-	jobsCursor          int
-	jobsOffset          int
-	jobsLoading         bool
-	jobsErr             error
-	jobsRequestID       uint64
-	jobDetail           bool
-	jobDetailOffset     int
-	trashOpen           bool
-	trashItems          []api.Node
-	trashTotal          int
-	trashCursor         int
-	trashOffset         int
-	trashChanged        bool
-	trashLoading        bool
-	trashErr            error
-	trashRequestID      uint64
-	confirmation        *mutationConfirmation
-	mutationRunning     bool
-	mutationRequestID   uint64
-	notice              string
-	historyOpen         bool
-	historyNode         row
-	historyPages        []api.AuditEventPage
-	historyPage         int
-	historyTotal        int
-	historyCursor       int
-	historyOffset       int
-	historyDetail       bool
-	historyDetailOffset int
-	spinnerFrame        int
-	spinnerActive       bool
+	requestID            uint64
+	loading              bool
+	err                  error
+	quitting             bool
+	helpOpen             bool
+	detailOpen           bool
+	detailOffset         int
+	detailNode           row
+	detailTags           []api.Tag
+	detailTagsTotal      int
+	detailTagsLoading    bool
+	detailTagsErr        error
+	detailRequestID      uint64
+	jobsOpen             bool
+	jobs                 []api.Job
+	jobsTotal            int
+	jobsRunning          int
+	jobsCursor           int
+	jobsOffset           int
+	jobsLoading          bool
+	jobsErr              error
+	jobsRequestID        uint64
+	jobDetail            bool
+	jobDetailOffset      int
+	operationsOpen       bool
+	operationsInfo       api.VaultInfo
+	operationsSnapshots  []api.BackupSnapshot
+	operationsTotal      int
+	operationsOffset     int
+	operationsLoading    bool
+	operationsStorageErr error
+	operationsBackupErr  error
+	operationsRequestID  uint64
+	trashOpen            bool
+	trashItems           []api.Node
+	trashTotal           int
+	trashCursor          int
+	trashOffset          int
+	trashChanged         bool
+	trashLoading         bool
+	trashErr             error
+	trashRequestID       uint64
+	confirmation         *mutationConfirmation
+	mutationRunning      bool
+	mutationRequestID    uint64
+	notice               string
+	historyOpen          bool
+	historyNode          row
+	historyPages         []api.AuditEventPage
+	historyPage          int
+	historyTotal         int
+	historyCursor        int
+	historyOffset        int
+	historyDetail        bool
+	historyDetailOffset  int
+	spinnerFrame         int
+	spinnerActive        bool
 
 	width  int
 	height int
@@ -303,6 +325,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.clampDetailOffset()
 		m.clampJobsSelection()
 		m.clampJobDetailOffset()
+		m.clampOperationsOffset()
 		m.clampTrashSelection()
 		m.clampHistorySelection()
 		m.clampHistoryDetailOffset()
@@ -345,6 +368,27 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.jobs = msg.items[:min(len(msg.items), maxJobItems)]
 			m.clampJobsSelection()
 		}
+		return m, nil
+	case operationsLoadedMsg:
+		if !m.operationsOpen || msg.requestID != m.operationsRequestID {
+			return m, nil
+		}
+		m.operationsLoading = false
+		m.operationsInfo = msg.info
+		m.operationsStorageErr = msg.storageErr
+		m.operationsBackupErr = msg.backupErr
+		if msg.backupErr == nil {
+			snapshots := append([]api.BackupSnapshot(nil), msg.snapshots...)
+			sort.SliceStable(snapshots, func(left, right int) bool {
+				if snapshots[left].CreatedAt != snapshots[right].CreatedAt {
+					return snapshots[left].CreatedAt > snapshots[right].CreatedAt
+				}
+				return snapshots[left].ID > snapshots[right].ID
+			})
+			m.operationsTotal = len(snapshots)
+			m.operationsSnapshots = snapshots[:min(len(snapshots), maxBackupItems)]
+		}
+		m.clampOperationsOffset()
 		return m, nil
 	case trashLoadedMsg:
 		if !m.trashOpen || msg.requestID != m.trashRequestID {
@@ -431,7 +475,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.removeTrashedRows(target)
 		return m.reloadCurrent()
 	case spinnerTickMsg:
-		if !m.loading && !m.jobsLoading && !m.trashLoading && !m.mutationRunning {
+		if !m.loading && !m.jobsLoading && !m.operationsLoading &&
+			!m.trashLoading && !m.mutationRunning {
 			m.spinnerActive = false
 			return m, nil
 		}
@@ -447,6 +492,9 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.trashOpen {
 			return m.updateTrashKeys(msg)
+		}
+		if m.operationsOpen {
+			return m.updateOperationsKeys(msg)
 		}
 		if m.jobsOpen {
 			return m.updateJobsKeys(msg)
@@ -471,10 +519,10 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m Model) updateSearchInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "ctrl+c":
+	case keyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
-	case "esc":
+	case keyEscape:
 		m.searching = false
 		m.searchInput.Blur()
 		return m, nil
@@ -501,7 +549,7 @@ func (m Model) updateSearchInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	switch key {
-	case "q", "ctrl+c":
+	case "q", keyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
 	case "/":
@@ -552,6 +600,19 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.jobDetailOffset = 0
 		m.jobsRequestID++
 		return m, tea.Batch(m.startSpinner(), m.loadJobs(m.jobsRequestID))
+	case "O":
+		m.operationsOpen = true
+		m.operationsInfo = api.VaultInfo{}
+		m.operationsSnapshots = nil
+		m.operationsTotal = 0
+		m.operationsOffset = 0
+		m.operationsLoading = true
+		m.operationsStorageErr = nil
+		m.operationsBackupErr = nil
+		m.operationsRequestID++
+		return m, tea.Batch(
+			m.startSpinner(), m.loadOperations(m.operationsRequestID),
+		)
 	case "s":
 		m.cycleSortField()
 		m.sortRowsPreservingSelection()
@@ -635,7 +696,7 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.loadDirectory(selected.node.ID, navigationForward, m.requestID),
 			)
 		}
-	case "esc", "left", "h", "backspace":
+	case keyEscape, "left", "h", "backspace":
 		if m.mode == modeSearch && m.searchReturn != nil {
 			return m.revisit(*m.searchReturn)
 		}
@@ -650,13 +711,13 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) updateConfirmationKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "q", "ctrl+c":
+	case "q", keyCtrlC:
 		if m.mutationRunning {
 			return m, nil
 		}
 		m.quitting = true
 		return m, tea.Quit
-	case "esc":
+	case keyEscape:
 		if !m.mutationRunning {
 			m.confirmation = nil
 		}
@@ -684,12 +745,12 @@ func (m Model) updateConfirmationKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 
 func (m Model) updateTrashKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "q", "ctrl+c":
+	case "q", keyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
 	case "?":
 		m.helpOpen = true
-	case "esc", "left", "h", "backspace":
+	case keyEscape, "left", "h", "backspace":
 		m.trashOpen = false
 		m.trashLoading = false
 		m.trashErr = nil
@@ -759,12 +820,12 @@ func (m Model) updateJobsKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.updateJobDetailKeys(msg)
 	}
 	switch msg.String() {
-	case "q", "ctrl+c":
+	case "q", keyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
 	case "?":
 		m.helpOpen = true
-	case "esc", "backspace", "left", "h":
+	case keyEscape, "backspace", "left", "h":
 		m.jobsOpen = false
 		m.jobsLoading = false
 		m.jobsRequestID++
@@ -797,14 +858,55 @@ func (m Model) updateJobsKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) updateJobDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+func (m Model) updateOperationsKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "q", "ctrl+c":
+	case "q", keyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
 	case "?":
 		m.helpOpen = true
-	case "enter", "i", "esc", "backspace", "left", "h":
+	case keyEscape, "backspace", "left", "h":
+		m.operationsOpen = false
+		m.operationsLoading = false
+		m.operationsRequestID++
+	case "r":
+		m.operationsLoading = true
+		m.operationsStorageErr = nil
+		m.operationsBackupErr = nil
+		m.operationsRequestID++
+		return m, tea.Batch(
+			m.startSpinner(), m.loadOperations(m.operationsRequestID),
+		)
+	case "up", "k":
+		m.operationsOffset--
+		m.clampOperationsOffset()
+	case "down", "j":
+		m.operationsOffset++
+		m.clampOperationsOffset()
+	case "pgup":
+		m.operationsOffset -= m.operationsViewportHeight()
+		m.clampOperationsOffset()
+	case "pgdown":
+		m.operationsOffset += m.operationsViewportHeight()
+		m.clampOperationsOffset()
+	case "home", "g":
+		m.operationsOffset = 0
+	case "end", "G":
+		m.operationsOffset = max(
+			len(m.operationsLines(m.width))-m.operationsViewportHeight(), 0,
+		)
+	}
+	return m, nil
+}
+
+func (m Model) updateJobDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", keyCtrlC:
+		m.quitting = true
+		return m, tea.Quit
+	case "?":
+		m.helpOpen = true
+	case "enter", "i", keyEscape, "backspace", "left", "h":
 		m.jobDetail = false
 		m.jobDetailOffset = 0
 	case "up", "k":
@@ -831,13 +933,13 @@ func (m Model) updateJobDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) updateHistoryKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "q", "ctrl+c":
+	case "q", keyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
 	case "?":
 		m.helpOpen = true
 		return m, nil
-	case "esc", "backspace":
+	case keyEscape, "backspace":
 		m.requestID++
 		m.closeHistory()
 		return m, nil
@@ -906,13 +1008,13 @@ func (m *Model) cancelPendingHistoryLoad() {
 
 func (m Model) updateHistoryDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "q", "ctrl+c":
+	case "q", keyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
 	case "?":
 		m.helpOpen = true
 		return m, nil
-	case "i", "enter", "esc", "left", "h", "backspace":
+	case "i", "enter", keyEscape, "left", "h", "backspace":
 		m.historyDetail = false
 		m.historyDetailOffset = 0
 	case "up", "k":
@@ -939,13 +1041,13 @@ func (m Model) updateHistoryDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 
 func (m Model) updateDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "q", "ctrl+c":
+	case "q", keyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
 	case "?":
 		m.helpOpen = true
 		return m, nil
-	case "i", "enter", "esc", "left", "h", "backspace":
+	case "i", "enter", keyEscape, "left", "h", "backspace":
 		m.detailOpen = false
 		m.detailOffset = 0
 		m.detailRequestID++
@@ -1007,6 +1109,18 @@ func (m Model) loadJobs(requestID uint64) tea.Cmd {
 	return func() tea.Msg {
 		items, err := backend.Jobs(ctx)
 		return jobsLoadedMsg{requestID: requestID, items: items, err: err}
+	}
+}
+
+func (m Model) loadOperations(requestID uint64) tea.Cmd {
+	ctx, backend := m.ctx, m.backend
+	return func() tea.Msg {
+		info, storageErr := backend.Info(ctx)
+		snapshots, backupErr := backend.BackupList(ctx)
+		return operationsLoadedMsg{
+			requestID: requestID, info: info, snapshots: snapshots,
+			storageErr: storageErr, backupErr: backupErr,
+		}
 	}
 }
 
@@ -1501,6 +1615,17 @@ func (m Model) visibleHistoryRows() int {
 
 func (m Model) historyViewportHeight() int {
 	return max(m.height-3, 1)
+}
+
+func (m Model) operationsViewportHeight() int {
+	return max(m.height-3, 1)
+}
+
+func (m *Model) clampOperationsOffset() {
+	maximum := max(
+		len(m.operationsLines(m.width))-m.operationsViewportHeight(), 0,
+	)
+	m.operationsOffset = min(max(m.operationsOffset, 0), maximum)
 }
 
 func (m *Model) clampHistoryDetailOffset() {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -130,12 +130,16 @@ type jobsLoadedMsg struct {
 	err       error
 }
 
-type operationsLoadedMsg struct {
-	requestID  uint64
-	info       api.VaultInfo
-	snapshots  []api.BackupSnapshot
-	storageErr error
-	backupErr  error
+type operationsInfoLoadedMsg struct {
+	requestID uint64
+	info      api.VaultInfo
+	err       error
+}
+
+type operationsBackupsLoadedMsg struct {
+	requestID uint64
+	snapshots []api.BackupSnapshot
+	err       error
 }
 
 type trashLoadedMsg struct {
@@ -257,7 +261,8 @@ type Model struct {
 	operationsSnapshots  []api.BackupSnapshot
 	operationsTotal      int
 	operationsOffset     int
-	operationsLoading    bool
+	operationsInfoBusy   bool
+	operationsBackupBusy bool
 	operationsStorageErr error
 	operationsBackupErr  error
 	operationsRequestID  uint64
@@ -369,15 +374,22 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampJobsSelection()
 		}
 		return m, nil
-	case operationsLoadedMsg:
+	case operationsInfoLoadedMsg:
 		if !m.operationsOpen || msg.requestID != m.operationsRequestID {
 			return m, nil
 		}
-		m.operationsLoading = false
+		m.operationsInfoBusy = false
 		m.operationsInfo = msg.info
-		m.operationsStorageErr = msg.storageErr
-		m.operationsBackupErr = msg.backupErr
-		if msg.backupErr == nil {
+		m.operationsStorageErr = msg.err
+		m.clampOperationsOffset()
+		return m, nil
+	case operationsBackupsLoadedMsg:
+		if !m.operationsOpen || msg.requestID != m.operationsRequestID {
+			return m, nil
+		}
+		m.operationsBackupBusy = false
+		m.operationsBackupErr = msg.err
+		if msg.err == nil {
 			snapshots := append([]api.BackupSnapshot(nil), msg.snapshots...)
 			sort.SliceStable(snapshots, func(left, right int) bool {
 				if snapshots[left].CreatedAt != snapshots[right].CreatedAt {
@@ -475,7 +487,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.removeTrashedRows(target)
 		return m.reloadCurrent()
 	case spinnerTickMsg:
-		if !m.loading && !m.jobsLoading && !m.operationsLoading &&
+		if !m.loading && !m.jobsLoading &&
+			!m.operationsInfoBusy && !m.operationsBackupBusy &&
 			!m.trashLoading && !m.mutationRunning {
 			m.spinnerActive = false
 			return m, nil
@@ -606,12 +619,15 @@ func (m Model) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.operationsSnapshots = nil
 		m.operationsTotal = 0
 		m.operationsOffset = 0
-		m.operationsLoading = true
+		m.operationsInfoBusy = true
+		m.operationsBackupBusy = true
 		m.operationsStorageErr = nil
 		m.operationsBackupErr = nil
 		m.operationsRequestID++
 		return m, tea.Batch(
-			m.startSpinner(), m.loadOperations(m.operationsRequestID),
+			m.startSpinner(),
+			m.loadOperationsInfo(m.operationsRequestID),
+			m.loadOperationsBackups(m.operationsRequestID),
 		)
 	case "s":
 		m.cycleSortField()
@@ -867,15 +883,19 @@ func (m Model) updateOperationsKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.helpOpen = true
 	case keyEscape, "backspace", "left", "h":
 		m.operationsOpen = false
-		m.operationsLoading = false
+		m.operationsInfoBusy = false
+		m.operationsBackupBusy = false
 		m.operationsRequestID++
 	case "r":
-		m.operationsLoading = true
+		m.operationsInfoBusy = true
+		m.operationsBackupBusy = true
 		m.operationsStorageErr = nil
 		m.operationsBackupErr = nil
 		m.operationsRequestID++
 		return m, tea.Batch(
-			m.startSpinner(), m.loadOperations(m.operationsRequestID),
+			m.startSpinner(),
+			m.loadOperationsInfo(m.operationsRequestID),
+			m.loadOperationsBackups(m.operationsRequestID),
 		)
 	case "up", "k":
 		m.operationsOffset--
@@ -1112,14 +1132,20 @@ func (m Model) loadJobs(requestID uint64) tea.Cmd {
 	}
 }
 
-func (m Model) loadOperations(requestID uint64) tea.Cmd {
+func (m Model) loadOperationsInfo(requestID uint64) tea.Cmd {
 	ctx, backend := m.ctx, m.backend
 	return func() tea.Msg {
-		info, storageErr := backend.Info(ctx)
-		snapshots, backupErr := backend.BackupList(ctx)
-		return operationsLoadedMsg{
-			requestID: requestID, info: info, snapshots: snapshots,
-			storageErr: storageErr, backupErr: backupErr,
+		info, err := backend.Info(ctx)
+		return operationsInfoLoadedMsg{requestID: requestID, info: info, err: err}
+	}
+}
+
+func (m Model) loadOperationsBackups(requestID uint64) tea.Cmd {
+	ctx, backend := m.ctx, m.backend
+	return func() tea.Msg {
+		snapshots, err := backend.BackupList(ctx)
+		return operationsBackupsLoadedMsg{
+			requestID: requestID, snapshots: snapshots, err: err,
 		}
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -392,8 +392,10 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err == nil {
 			snapshots := append([]api.BackupSnapshot(nil), msg.snapshots...)
 			sort.SliceStable(snapshots, func(left, right int) bool {
-				if snapshots[left].CreatedAt != snapshots[right].CreatedAt {
-					return snapshots[left].CreatedAt > snapshots[right].CreatedAt
+				leftTime, _ := time.Parse(time.RFC3339Nano, snapshots[left].CreatedAt)
+				rightTime, _ := time.Parse(time.RFC3339Nano, snapshots[right].CreatedAt)
+				if !leftTime.Equal(rightTime) {
+					return leftTime.After(rightTime)
 				}
 				return snapshots[left].ID > snapshots[right].ID
 			})
@@ -1644,7 +1646,7 @@ func (m Model) historyViewportHeight() int {
 }
 
 func (m Model) operationsViewportHeight() int {
-	return max(m.height-3, 1)
+	return m.bodyViewportHeight()
 }
 
 func (m *Model) clampOperationsOffset() {
@@ -1744,15 +1746,7 @@ func (m *Model) clampSelection() {
 }
 
 func (m Model) visibleRows() int {
-	headerLines := 2
-	if m.searching {
-		headerLines++
-	}
-	if m.notice != "" {
-		headerLines++
-	}
-	bodyHeight := max(m.height-headerLines-1, 1)
-	return max(bodyHeight-2, 1)
+	return max(m.bodyViewportHeight()-2, 1)
 }
 
 func (m *Model) cycleSortField() {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -142,12 +142,12 @@ func newFakeBackend() *fakeBackend {
 		snapshots: []api.BackupSnapshot{
 			{
 				ID:        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-				CreatedAt: "2026-07-21T14:00:00Z", Tag: "baseline",
+				CreatedAt: "2026-07-22T14:30:00+02:00", Tag: "baseline",
 				Files: 10, BytesAdded: 700_000,
 			},
 			{
 				ID:        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-				CreatedAt: "2026-07-22T14:00:00Z", Tag: "weekly",
+				CreatedAt: "2026-07-22T13:00:00Z", Tag: "weekly",
 				Files: 12, BytesAdded: 750_000,
 			},
 		},
@@ -1457,6 +1457,25 @@ func TestOperationsStorageRendersWhileBackupsAreLoading(t *testing.T) {
 	assert.Contains(t, content, "Loading backup recovery points...")
 	assert.Equal(t, 1, backend.infoCalls)
 	assert.Equal(t, 0, backend.backupCalls)
+}
+
+func TestOperationsEndReachesLastLineWithNotice(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.width, model.height = 100, 10
+	model.notice = "Trash changes applied"
+
+	model, _ = updateModel(t, model, runeKey('O'))
+	model = runModelCommand(
+		t, model, model.loadOperationsInfo(model.operationsRequestID),
+	)
+	model = runModelCommand(
+		t, model, model.loadOperationsBackups(model.operationsRequestID),
+	)
+	model, _ = updateModel(t, model, runeKey('G'))
+
+	assert.Contains(t, model.View().Content, strings.Repeat("c", 64))
 }
 
 func TestClosingOperationsInvalidatesDelayedLoad(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1423,7 +1423,8 @@ func TestOperationsViewShowsStorageAndRecoveryPoints(t *testing.T) {
 	model, cmd := updateModel(t, model, runeKey('O'))
 	require.NotNil(t, cmd)
 	assert.True(t, model.operationsOpen)
-	assert.True(t, model.operationsLoading)
+	assert.True(t, model.operationsInfoBusy)
+	assert.True(t, model.operationsBackupBusy)
 	model = runModelCommand(t, model, cmd)
 
 	content := model.View().Content
@@ -1436,6 +1437,26 @@ func TestOperationsViewShowsStorageAndRecoveryPoints(t *testing.T) {
 	assert.Less(t, strings.Index(content, `"weekly"`), strings.Index(content, `"baseline"`))
 	assert.Equal(t, 1, backend.infoCalls)
 	assert.Equal(t, 1, backend.backupCalls)
+}
+
+func TestOperationsStorageRendersWhileBackupsAreLoading(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model.width, model.height = 100, 20
+
+	model, _ = updateModel(t, model, runeKey('O'))
+	model = runModelCommand(
+		t, model, model.loadOperationsInfo(model.operationsRequestID),
+	)
+
+	content := model.View().Content
+	assert.False(t, model.operationsInfoBusy)
+	assert.True(t, model.operationsBackupBusy)
+	assert.Contains(t, content, "Loose inventory: 5 files")
+	assert.Contains(t, content, "Loading backup recovery points...")
+	assert.Equal(t, 1, backend.infoCalls)
+	assert.Equal(t, 0, backend.backupCalls)
 }
 
 func TestClosingOperationsInvalidatesDelayedLoad(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -34,6 +34,12 @@ type fakeBackend struct {
 	jobs               []api.Job
 	jobsErr            error
 	jobCalls           int
+	info               api.VaultInfo
+	infoErr            error
+	infoCalls          int
+	snapshots          []api.BackupSnapshot
+	backupErr          error
+	backupCalls        int
 	trash              api.TrashPage
 	trashCalls         int
 	trashed            []api.Node
@@ -122,6 +128,29 @@ func newFakeBackend() *fakeBackend {
 				Error: "source is temporarily unavailable; check the configured inbox path",
 			},
 		},
+		info: api.VaultInfo{
+			VaultID:   "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+			LiveFiles: 12, LiveDirectories: 4, ContentVersions: 19,
+			TrackedBlobs: 15, TrackedBlobBytes: 3_000_000,
+			Storage: api.StorageStatus{
+				LooseBlobs: 5, LooseBytes: 1_000_000,
+				Packs: 2, PackStoredBytes: 900_000,
+				PackedBlobs: 10, PackedRawBytes: 2_000_000,
+				PackedStoredBytes: 800_000, DeadPackedBytes: 100_000,
+			},
+		},
+		snapshots: []api.BackupSnapshot{
+			{
+				ID:        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+				CreatedAt: "2026-07-21T14:00:00Z", Tag: "baseline",
+				Files: 10, BytesAdded: 700_000,
+			},
+			{
+				ID:        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				CreatedAt: "2026-07-22T14:00:00Z", Tag: "weekly",
+				Files: 12, BytesAdded: 750_000,
+			},
+		},
 		trash: api.TrashPage{
 			Items: []api.Node{
 				{
@@ -198,6 +227,24 @@ func (f *fakeBackend) Jobs(_ context.Context) ([]api.Job, error) {
 		return nil, f.jobsErr
 	}
 	return append([]api.Job(nil), f.jobs...), nil
+}
+
+func (f *fakeBackend) Info(_ context.Context) (api.VaultInfo, error) {
+	f.infoCalls++
+	if f.infoErr != nil {
+		return api.VaultInfo{}, f.infoErr
+	}
+	return f.info, nil
+}
+
+func (f *fakeBackend) BackupList(
+	_ context.Context,
+) ([]api.BackupSnapshot, error) {
+	f.backupCalls++
+	if f.backupErr != nil {
+		return nil, f.backupErr
+	}
+	return append([]api.BackupSnapshot(nil), f.snapshots...), nil
 }
 
 func (f *fakeBackend) TrashPage(
@@ -1364,6 +1411,48 @@ func TestClosingJobsInvalidatesDelayedLoad(t *testing.T) {
 	model = runModelCommand(t, model, delayed)
 	assert.False(t, model.jobsOpen)
 	assert.Empty(t, model.jobs)
+}
+
+func TestOperationsViewShowsStorageAndRecoveryPoints(t *testing.T) {
+	backend := newFakeBackend()
+	model, err := New(t.Context(), backend)
+	require.NoError(t, err)
+	model = runModelCommand(t, model, model.loadDirectory(0, navigationInitial, model.requestID))
+	model.width, model.height = 100, 20
+
+	model, cmd := updateModel(t, model, runeKey('O'))
+	require.NotNil(t, cmd)
+	assert.True(t, model.operationsOpen)
+	assert.True(t, model.operationsLoading)
+	model = runModelCommand(t, model, cmd)
+
+	content := model.View().Content
+	assert.Contains(t, content, "Vault operations")
+	assert.Contains(t, content, "Loose inventory: 5 files")
+	assert.Contains(t, content, "Dead packed payload: 97.7 KB")
+	assert.Contains(t, content, "Backup recovery points")
+	assert.Contains(t, content, `"weekly"`)
+	assert.Contains(t, content, strings.Repeat("b", 64))
+	assert.Less(t, strings.Index(content, `"weekly"`), strings.Index(content, `"baseline"`))
+	assert.Equal(t, 1, backend.infoCalls)
+	assert.Equal(t, 1, backend.backupCalls)
+}
+
+func TestClosingOperationsInvalidatesDelayedLoad(t *testing.T) {
+	model, err := New(t.Context(), newFakeBackend())
+	require.NoError(t, err)
+
+	model, delayed := updateModel(t, model, runeKey('O'))
+	require.NotNil(t, delayed)
+	pendingRequestID := model.operationsRequestID
+	model, _ = updateModel(t, model, key(tea.KeyEscape))
+	assert.False(t, model.operationsOpen)
+	assert.Greater(t, model.operationsRequestID, pendingRequestID)
+
+	model = runModelCommand(t, model, delayed)
+	assert.False(t, model.operationsOpen)
+	assert.Empty(t, model.operationsInfo.VaultID)
+	assert.Empty(t, model.operationsSnapshots)
 }
 
 func TestHelpAndSpinnerAreVisible(t *testing.T) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -88,7 +88,7 @@ func (m Model) render() string {
 		lines = append(lines, m.styles.stats.Render(fit(" "+m.notice, m.width)))
 	}
 
-	bodyHeight := max(m.height-len(lines)-1, 1)
+	bodyHeight := m.bodyViewportHeight()
 	body := m.renderBody(bodyHeight)
 	if m.jobsOpen {
 		body = m.renderJobsList(bodyHeight)
@@ -117,6 +117,17 @@ func (m Model) render() string {
 		return m.renderConfirmation(content)
 	}
 	return content
+}
+
+func (m Model) bodyViewportHeight() int {
+	linesAboveBody := 2
+	if m.searching {
+		linesAboveBody++
+	}
+	if m.notice != "" {
+		linesAboveBody++
+	}
+	return max(m.height-linesAboveBody-1, 1)
 }
 
 func (m Model) renderJobsLocation() string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -145,8 +145,15 @@ func (m Model) renderOperationsLocation() string {
 			len(m.operationsSnapshots), m.operationsTotal,
 		)
 	}
-	if m.operationsLoading {
-		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
+	if m.operationsInfoBusy || m.operationsBackupBusy {
+		switch {
+		case m.operationsInfoBusy && m.operationsBackupBusy:
+			right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
+		case m.operationsInfoBusy:
+			right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading storage"
+		default:
+			right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading backups"
+		}
 	} else if m.operationsStorageErr != nil && m.operationsBackupErr != nil {
 		right = "status unavailable"
 	} else if m.operationsStorageErr != nil || m.operationsBackupErr != nil {
@@ -302,11 +309,11 @@ func (m Model) operationsLines(width int) []string {
 		m.styles.heading.Render(pad(fit(" Storage inventory", width), width)),
 		separator,
 	}
-	if m.operationsLoading && m.operationsInfo.VaultID == "" &&
-		len(m.operationsSnapshots) == 0 {
-		return append(lines, m.styles.muted.Render(pad(" Loading vault operations...", width)))
-	}
-	if m.operationsStorageErr != nil {
+	if m.operationsInfoBusy && m.operationsInfo.VaultID == "" {
+		lines = append(lines, m.styles.muted.Render(pad(
+			" Loading storage inventory...", width,
+		)))
+	} else if m.operationsStorageErr != nil {
 		lines = appendWrapped(lines, " Storage unavailable: "+
 			quoted(m.operationsStorageErr.Error()), width, m.styles.error)
 	} else {
@@ -349,6 +356,10 @@ func (m Model) operationsLines(width int) []string {
 		separator,
 	)
 	switch {
+	case m.operationsBackupBusy && len(m.operationsSnapshots) == 0:
+		lines = append(lines, m.styles.muted.Render(pad(
+			" Loading backup recovery points...", width,
+		)))
 	case m.operationsBackupErr != nil:
 		lines = appendWrapped(lines, " Backup repository unavailable: "+
 			quoted(m.operationsBackupErr.Error()), width, m.styles.error)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -72,6 +72,8 @@ func (m Model) render() string {
 	lines := []string{m.renderTitleBar()}
 	if m.jobsOpen {
 		lines = append(lines, m.renderJobsLocation())
+	} else if m.operationsOpen {
+		lines = append(lines, m.renderOperationsLocation())
 	} else if m.trashOpen {
 		lines = append(lines, m.renderTrashLocation())
 	} else if m.historyOpen {
@@ -90,6 +92,8 @@ func (m Model) render() string {
 	body := m.renderBody(bodyHeight)
 	if m.jobsOpen {
 		body = m.renderJobsList(bodyHeight)
+	} else if m.operationsOpen {
+		body = m.renderOperations(bodyHeight)
 	} else if m.trashOpen {
 		body = m.renderTrashList(bodyHeight)
 	} else if m.historyOpen {
@@ -128,6 +132,25 @@ func (m Model) renderJobsLocation() string {
 	}
 	if m.jobsErr != nil {
 		right = "jobs unavailable"
+	}
+	return m.styles.stats.Render(joinSides(left, right, m.width))
+}
+
+func (m Model) renderOperationsLocation() string {
+	left := " Vault operations · read-only"
+	right := fmt.Sprintf("%d recovery point(s)", m.operationsTotal)
+	if m.operationsTotal > len(m.operationsSnapshots) {
+		right = fmt.Sprintf(
+			"first %d of %d recovery points",
+			len(m.operationsSnapshots), m.operationsTotal,
+		)
+	}
+	if m.operationsLoading {
+		right = m.styles.spinner.Render(m.spinnerIndicator()) + " loading"
+	} else if m.operationsStorageErr != nil && m.operationsBackupErr != nil {
+		right = "status unavailable"
+	} else if m.operationsStorageErr != nil || m.operationsBackupErr != nil {
+		right = "partial status"
 	}
 	return m.styles.stats.Render(joinSides(left, right, m.width))
 }
@@ -259,6 +282,121 @@ func (m Model) renderJobsList(height int) string {
 		lines = append(lines, strings.Repeat(" ", m.width))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderOperations(height int) string {
+	lines := m.operationsLines(m.width)
+	maxOffset := max(len(lines)-height, 0)
+	offset := min(m.operationsOffset, maxOffset)
+	end := min(offset+height, len(lines))
+	visible := append([]string(nil), lines[offset:end]...)
+	for len(visible) < height {
+		visible = append(visible, strings.Repeat(" ", m.width))
+	}
+	return strings.Join(visible, "\n")
+}
+
+func (m Model) operationsLines(width int) []string {
+	separator := m.styles.separator.Render(strings.Repeat("─", max(width, 0)))
+	lines := []string{
+		m.styles.heading.Render(pad(fit(" Storage inventory", width), width)),
+		separator,
+	}
+	if m.operationsLoading && m.operationsInfo.VaultID == "" &&
+		len(m.operationsSnapshots) == 0 {
+		return append(lines, m.styles.muted.Render(pad(" Loading vault operations...", width)))
+	}
+	if m.operationsStorageErr != nil {
+		lines = appendWrapped(lines, " Storage unavailable: "+
+			quoted(m.operationsStorageErr.Error()), width, m.styles.error)
+	} else {
+		info, storage := m.operationsInfo, m.operationsInfo.Storage
+		lines = appendWrapped(lines, " Vault: "+info.VaultID, width, lipgloss.NewStyle())
+		lines = appendWrapped(lines, " Logical authority: "+
+			countLabel(info.LiveFiles, "live file", "live files")+" · "+
+			countLabel(info.LiveDirectories, "directory", "directories")+" · "+
+			countLabel(info.ContentVersions, "version", "versions"),
+			width, lipgloss.NewStyle())
+		lines = appendWrapped(lines, fmt.Sprintf(
+			" Tracked content: %s · %s",
+			countLabel(info.TrackedBlobs, "blob", "blobs"),
+			formatBytes(info.TrackedBlobBytes),
+		), width, lipgloss.NewStyle())
+		lines = appendWrapped(lines, fmt.Sprintf(
+			" Loose inventory: %s · %s",
+			countLabel(int64(storage.LooseBlobs), "file", "files"),
+			formatBytes(storage.LooseBytes),
+		), width, lipgloss.NewStyle())
+		lines = appendWrapped(lines, fmt.Sprintf(
+			" Pack inventory: %s · %s stored",
+			countLabel(int64(storage.Packs), "pack", "packs"),
+			formatBytes(storage.PackStoredBytes),
+		), width, lipgloss.NewStyle())
+		lines = appendWrapped(lines, fmt.Sprintf(
+			" Live packed content: %s · %s raw · %s stored",
+			countLabel(storage.PackedBlobs, "blob", "blobs"),
+			formatBytes(storage.PackedRawBytes),
+			formatBytes(storage.PackedStoredBytes),
+		), width, lipgloss.NewStyle())
+		lines = appendWrapped(lines, fmt.Sprintf(
+			" Dead packed payload: %s awaiting explicit repack",
+			formatBytes(storage.DeadPackedBytes),
+		), width, lipgloss.NewStyle())
+	}
+
+	lines = append(lines, separator,
+		m.styles.heading.Render(pad(fit(" Backup recovery points", width), width)),
+		separator,
+	)
+	switch {
+	case m.operationsBackupErr != nil:
+		lines = appendWrapped(lines, " Backup repository unavailable: "+
+			quoted(m.operationsBackupErr.Error()), width, m.styles.error)
+	case len(m.operationsSnapshots) == 0:
+		lines = append(lines, m.styles.muted.Render(pad(
+			" No snapshots in the configured backup repository", width,
+		)))
+	default:
+		for _, snapshot := range m.operationsSnapshots {
+			tag := snapshot.Tag
+			if tag == "" {
+				tag = "untagged"
+			}
+			lines = appendWrapped(lines, fmt.Sprintf(
+				" %s · %s · %s · +%s",
+				formatModified(snapshot.CreatedAt), quoted(tag),
+				countLabel(snapshot.Files, "file", "files"),
+				formatBytes(snapshot.BytesAdded),
+			), width, lipgloss.NewStyle())
+			lines = appendWrapped(lines, "   Snapshot: "+snapshot.ID,
+				width, m.styles.muted)
+		}
+		if m.operationsTotal > len(m.operationsSnapshots) {
+			lines = append(lines, m.styles.muted.Render(pad(fmt.Sprintf(
+				" Showing the first %d of %d recovery points",
+				len(m.operationsSnapshots), m.operationsTotal,
+			), width)))
+		}
+	}
+	return lines
+}
+
+func appendWrapped(
+	lines []string, value string, width int, style lipgloss.Style,
+) []string {
+	wrapped := ansi.Hardwrap(value, max(width, 1), false)
+	for line := range strings.SplitSeq(wrapped, "\n") {
+		lines = append(lines, style.Render(pad(line, width)))
+	}
+	return lines
+}
+
+func countLabel(value int64, singular, plural string) string {
+	label := plural
+	if value == 1 {
+		label = singular
+	}
+	return fmt.Sprintf("%d %s", value, label)
 }
 
 func (m Model) renderJobsHeading() string {
@@ -858,6 +996,9 @@ func (m Model) renderFooter() string {
 	if m.jobsOpen {
 		return m.renderJobsFooter()
 	}
+	if m.operationsOpen {
+		return m.renderOperationsFooter()
+	}
 	if m.historyOpen {
 		return m.renderHistoryFooter()
 	}
@@ -887,6 +1028,7 @@ func (m Model) renderFooter() string {
 		hint{text: "/ search", priority: 90},
 		hint{text: "T recover", priority: 74},
 		hint{text: "J jobs", priority: 68},
+		hint{text: "O operations", priority: 66},
 		hint{text: "s sort", priority: 85},
 		hint{text: "v reverse", priority: 25},
 		hint{text: "r refresh", priority: 20},
@@ -908,6 +1050,25 @@ func (m Model) renderFooter() string {
 	available := max(m.width-lipgloss.Width(position)-1, 0)
 	keys := fitHints(hints, available)
 	return m.styles.footer.Render(joinSides(keys, position, m.width))
+}
+
+func (m Model) renderOperationsFooter() string {
+	lines := m.operationsLines(m.width)
+	viewport := m.operationsViewportHeight()
+	position := ""
+	if len(lines) > viewport {
+		last := min(m.operationsOffset+viewport, len(lines))
+		position = fmt.Sprintf(" %d-%d/%d ", m.operationsOffset+1, last, len(lines))
+	}
+	hints := []hint{
+		{text: "↑/↓ scroll", priority: 100},
+		{text: "r refresh", priority: 80},
+		{text: "esc back", priority: 90},
+		{text: "? help", priority: 70},
+		{text: "q quit", priority: 60},
+	}
+	available := max(m.width-lipgloss.Width(position)-1, 0)
+	return m.styles.footer.Render(joinSides(fitHints(hints, available), position, m.width))
 }
 
 func (m Model) renderTrashFooter() string {
@@ -1124,6 +1285,22 @@ func (m Model) renderConfirmation(background string) string {
 }
 
 func (m Model) helpLines() []string {
+	if m.operationsOpen {
+		return []string{
+			"Vault operations shortcuts",
+			"",
+			"↑/k, ↓/j       Scroll one line",
+			"PgUp/PgDn      Scroll one visible page",
+			"Home/End       Jump to first or last line",
+			"r              Refresh storage and backups",
+			"Esc            Return to documents",
+			"q              Quit",
+			"",
+			"Packing, repacking, backup creation, and restore",
+			"remain deliberate CLI or API operations.",
+			"Press any key to close",
+		}
+	}
 	if m.trashOpen {
 		return []string{
 			"Recoverable trash shortcuts",


### PR DESCRIPTION
A person using the terminal browser can now answer two operational questions without leaving it: **how is this vault physically stored, and when was it last backed up?** Press `O` to open a read-only summary that separates logical document authority from loose files, live packed content, and dead packed payload awaiting repack. Below that, the configured repository’s recovery points appear newest first with their complete snapshot IDs, tags, file counts, and newly added bytes.

For example, the real synthetic vault below has three blobs in one immutable pack, one newer loose file, and two incremental recovery points. Storage remains visible even if no backup repository is configured; the two sources report failures independently instead of hiding all operational state.

![The actual Docbank TUI showing storage inventory and backup recovery points](https://raw.githubusercontent.com/kenn-io/docbank/22efaf7/screenshots/tui-storage-backup/tui-storage-backup.png)

*Actual daemon-backed TUI output from an owner-private synthetic vault and backup repository; no private corpus data is present.*

This is deliberately inspection rather than maintenance. The TUI cannot pack or repack content, create or verify snapshots, or restore a vault. Those remain explicit CLI and authenticated API workflows, where their progress, confirmation, and failure contracts already live. The screen reacquires a compatible daemon on refresh, discards delayed responses after it closes, and keeps complete identities scrollable rather than truncating them.

I exercised the rendered view end to end with a real temporary daemon, mixed loose/packed synthetic vault, and two actual incremental snapshots. The daemon, vault, repository, binary, and terminal session were removed after the screenshot was inspected.