### PR TITLE
Verify permanent audit evidence in the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Four commitments:
   tag-filtered extracted-text search,
   complete current authority, verified current and historical content download,
   recoverable move-to-trash and revision-bound restoration,
-  permanent protection and event history, immutable versions and provenance,
+  permanent protection, event history, and vault-wide verification evidence,
+  immutable versions and provenance,
   configured backup recovery points, daemon background-job status, and an honest
   loose-file/live-packed/dead-packed storage breakdown
 - Mixed loose and packed content storage with explicit pack, GC, and repack,

--- a/cmd/docbank/daemon_lifecycle_test.go
+++ b/cmd/docbank/daemon_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "56", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "57", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "9"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "56", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "57", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "7"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "56", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "57", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "33"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestDaemonStartReplacesIncompatibleDaemon(t *testing.T) {
 	recs, err = client.RuntimeStore(dir).List()
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, "56", recs[0].Metadata["protocol_version"])
+	require.Equal(t, "57", recs[0].Metadata["protocol_version"])
 	recs[0].Metadata["protocol_version"] = "4"
 	_, err = client.RuntimeStore(dir).Write(recs[0])
 	require.NoError(t, err)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -151,7 +151,9 @@ and a stable tag identity can drive either a live assignment view or a
 text-search filter.
 Protected nodes also expose their permanent newest-first audit timeline
 and the complete stable identity and before/after state of every event. The
-portal also uploads local files through the same caller-declared and
+portal can independently replay permanent authority, verify every protected
+blob, and present the terminal allocation and scope-chain evidence. It also
+uploads local files through the same caller-declared and
 server-verified byte-identity contract used by remote agents, moves a selected
 revision-bound live node to recoverable trash after explicit confirmation,
 lists newest-first trash roots, restores one inspected revision while

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -26,6 +26,8 @@ Selecting a tag
 browses its live assignments, while search can require the same exact tag
 identity. Protected documents expose
 their newest-first permanent audit timeline and complete event authority. The
+audit-verification button independently replays permanent history, hashes every
+protected blob, and exposes the current allocation and scope-chain evidence. The
 storage button separates loose content, live packed content, pack-file payload,
 and logically dead packed bytes awaiting repack. The activity button reports
 the daemon's supervised extraction, watched-inbox, and automatic-packing jobs.
@@ -302,6 +304,29 @@ history already being inspected. Protection status remains authoritative even
 when a page contains no events. The web application does not infer protection
 from an empty or non-empty timeline.
 
+## Verify permanent audit evidence
+
+Choose the shield-check button in the top bar to run the vault-wide permanent
+audit verifier. This is more than reading stored status: Docbank independently
+replays canonical audit history against the current node, version, membership,
+topology, tag, and provenance projections, then reads and recomputes SHA-256 for
+every unique blob retained by protected history.
+
+A successful result reports the protected and verified blob totals, unique raw
+bytes, vault and allocation-lineage identities, operation high-water mark,
+allocation entry count and head, and each scope's terminal entry count and chain
+head. Copy buttons preserve the complete identities even when they wrap. A
+dormant vault is reported separately from a failed verification; metadata,
+missing-content, corruption, and unreadable-content problems remain visible
+with the affected hash.
+
+This drawer runs only a fresh proof of current authority. It does not accept a
+previous evidence bundle, enroll a scope, or change protected state. Record
+`docbank audit verify --json` outside the vault and later use
+`docbank audit verify --expected` when that external copy must act as a rollback
+trust anchor. Closing the drawer cancels its active request; maintenance
+contention or interruption remains visible and can be retried deliberately.
+
 ## Inspect background work
 
 Choose the activity button in the top bar to inspect the jobs owned by the
@@ -383,10 +408,11 @@ request; the application removes them from the address bar and holds them only
 in page memory. Ordinary requests use
 `X-Docbank-Web-Session`, which the daemon accepts only for the tree, node,
 search, tag-definition and assignment reads, immutable-version, provenance,
-audit-status, audit-history, background-job, physical-storage-status,
-configured backup-snapshot-list, bounded trash-list, verified-download
-preparation, revision-bound move-to-trash and restore, tag assignment/removal,
-and tag-definition create/rename/delete requests used by this interface.
+audit-status, audit-history, vault-wide audit verification, background-job,
+physical-storage-status, configured backup-snapshot-list, bounded trash-list,
+verified-download preparation, revision-bound move-to-trash and restore, tag
+assignment/removal, and tag-definition create/rename/delete requests used by
+this interface.
 Download preparation may write only owner-private temporary bytes and issue
 one exact, expiring file ticket. Upload uses a separate, never-reconnecting
 WebSocket authenticated by a challenge proof over the upload secret. No file
@@ -400,8 +426,9 @@ Renaming and deleting definitions require their inspected tag revision, and
 definition deletion explicitly reports how many assignments were removed.
 These permissions do not grant bulk tag mutation. The session
 cannot empty trash, perform any other document mutation,
-enroll audit scopes, run independent verification, or call backup creation,
-verification, restore, maintenance, configuration, or general API endpoints.
+enroll audit scopes, run general metadata/content or backup verification, or
+call backup creation, restore, maintenance, configuration, or general API
+endpoints.
 Its sole backup capability is listing the immutable snapshots in the
 repository already configured for this daemon.
 
@@ -437,8 +464,9 @@ leave the browser constructing child paths beneath an obsolete name.
 
 The current web application does not compare versions, recursively import
 folders, edit, revert, prune, move live nodes between folders, bulk-apply tags,
-empty trash, enroll audit scopes, run independent audit verification,
-or run maintenance, backup, verification, or restore operations.
+empty trash, enroll audit scopes, or run maintenance, backup creation,
+backup verification, general metadata/content verification, or restore
+operations.
 Use the corresponding CLI or authenticated HTTP endpoint for those workflows.
 Future web workflows will require deliberately expanded browser-session
 permissions rather than inheriting the master API key.

--- a/frontend/screenshots/README.md
+++ b/frontend/screenshots/README.md
@@ -24,7 +24,8 @@ captures the requested state, stops the daemon, and removes the vault.
 Generated images are written beneath `.superpowers/screenshots/` for visual
 inspection and PR attachment; the current case captures both move-to-trash and
 restore confirmations, the tag-definition catalog, and a completed tag
-assignment. Generated images are intentionally not committed.
+assignment, plus independently verified permanent-audit evidence. Generated
+images are intentionally not committed.
 
 Pass ordinary Playwright arguments after `--` to select a case:
 

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -34,6 +34,12 @@ const tagCatalogScreenshotPath = path.join(
   "screenshots",
   "web-tag-catalog.png",
 );
+const auditEvidenceScreenshotPath = path.join(
+  repositoryRoot,
+  ".superpowers",
+  "screenshots",
+  "web-audit-evidence.png",
+);
 
 test.describe("Docbank web screenshots", () => {
   let workspace = "";
@@ -61,6 +67,7 @@ test.describe("Docbank web screenshots", () => {
     await rm(restoreScreenshotPath, { force: true });
     await rm(tagAssignmentScreenshotPath, { force: true });
     await rm(tagCatalogScreenshotPath, { force: true });
+    await rm(auditEvidenceScreenshotPath, { force: true });
     const reports = path.join(workspace, "synthetic", "Reports");
     await mkdir(reports, { recursive: true, mode: 0o700 });
     await writeFile(
@@ -87,6 +94,24 @@ test.describe("Docbank web screenshots", () => {
       "assign",
       "tax",
       "/Reports/quarterly-tax-report.txt",
+    ]);
+    const preview = JSON.parse(
+      await runDocbank(["audit", "enable", "/Reports", "--json"]),
+    ) as { preview_token?: unknown };
+    if (
+      typeof preview.preview_token !== "string" ||
+      preview.preview_token === ""
+    ) {
+      throw new Error("audit enrollment preview omitted its token");
+    }
+    await runDocbank([
+      "audit",
+      "enable",
+      "--run",
+      "--token",
+      preview.preview_token,
+      "--acknowledge-permanent-retention",
+      "--json",
     ]);
     webURL = await runDocbank(["web", "--no-browser"]);
     const browserURL = new URL(webURL);
@@ -151,6 +176,25 @@ test.describe("Docbank web screenshots", () => {
         }
       `,
     });
+
+    await page
+      .getByRole("button", { name: "Verify permanent audit evidence" })
+      .click();
+    const auditEvidence = page.getByRole("dialog", {
+      name: "Permanent audit verification",
+    });
+    await expect(auditEvidence).toContainText(
+      "Protected history and content agree",
+    );
+    await expect(auditEvidence).toContainText("1 protected scope");
+    await page.screenshot({
+      path: auditEvidenceScreenshotPath,
+      fullPage: true,
+      animations: "disabled",
+    });
+    await auditEvidence
+      .getByRole("button", { name: "Close permanent audit verification" })
+      .click();
 
     await page.getByRole("button", { name: "Manage tag definitions" }).click();
     const catalog = page.getByRole("dialog", {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import MapPinIcon from "@lucide/svelte/icons/map-pin";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import SearchIcon from "@lucide/svelte/icons/search";
+  import ShieldCheckIcon from "@lucide/svelte/icons/shield-check";
   import TagIcon from "@lucide/svelte/icons/tag";
   import TagsIcon from "@lucide/svelte/icons/tags";
   import HistoryIcon from "@lucide/svelte/icons/history";
@@ -33,6 +34,7 @@
     type SelectDropdownOption,
     type SortDirection,
   } from "@kenn-io/kit-ui";
+  import AuditEvidenceDrawer from "./AuditEvidenceDrawer.svelte";
   import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
   import BackupDrawer from "./BackupDrawer.svelte";
   import DownloadButton from "./DownloadButton.svelte";
@@ -122,6 +124,7 @@
   let versionsOpen = $state(false);
   let provenanceOpen = $state(false);
   let jobsOpen = $state(false);
+  let auditEvidenceOpen = $state(false);
   let storageOpen = $state(false);
   let backupsOpen = $state(false);
   let trashOpen = $state(false);
@@ -184,6 +187,7 @@
       versionsOpen = false;
       provenanceOpen = false;
       jobsOpen = false;
+      auditEvidenceOpen = false;
       storageOpen = false;
       backupsOpen = false;
       trashOpen = false;
@@ -768,6 +772,7 @@
     versionsOpen = false;
     provenanceOpen = false;
     jobsOpen = false;
+    auditEvidenceOpen = false;
     storageOpen = false;
     backupsOpen = false;
     trashOpen = false;
@@ -843,6 +848,7 @@
             versionsOpen = false;
             provenanceOpen = false;
             jobsOpen = false;
+            auditEvidenceOpen = false;
             storageOpen = false;
             backupsOpen = false;
             uploadTarget = null;
@@ -860,6 +866,7 @@
             versionsOpen = false;
             provenanceOpen = false;
             jobsOpen = false;
+            auditEvidenceOpen = false;
             storageOpen = false;
             trashOpen = false;
             backupsOpen = true;
@@ -876,6 +883,7 @@
             versionsOpen = false;
             provenanceOpen = false;
             jobsOpen = false;
+            auditEvidenceOpen = false;
             backupsOpen = false;
             trashOpen = false;
             uploadTarget = null;
@@ -891,6 +899,7 @@
             historyOpen = false;
             versionsOpen = false;
             provenanceOpen = false;
+            auditEvidenceOpen = false;
             storageOpen = false;
             backupsOpen = false;
             trashOpen = false;
@@ -899,6 +908,24 @@
           }}
         >
           <ActivityIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton
+          size="sm"
+          ariaLabel="Verify permanent audit evidence"
+          onclick={() => {
+            historyOpen = false;
+            versionsOpen = false;
+            provenanceOpen = false;
+            jobsOpen = false;
+            storageOpen = false;
+            backupsOpen = false;
+            trashOpen = false;
+            uploadTarget = null;
+            trashTarget = null;
+            auditEvidenceOpen = true;
+          }}
+        >
+          <ShieldCheckIcon size="14" aria-hidden="true" />
         </IconButton>
         <ThemeToggle size="sm" />
         <IconButton size="sm" ariaLabel="Lock web session" onclick={() => void lock()}>
@@ -955,6 +982,7 @@
                 versionsOpen = false;
                 provenanceOpen = false;
                 jobsOpen = false;
+                auditEvidenceOpen = false;
                 storageOpen = false;
                 backupsOpen = false;
                 trashOpen = false;
@@ -994,6 +1022,7 @@
                 versionsOpen = false;
                 provenanceOpen = false;
                 jobsOpen = false;
+                auditEvidenceOpen = false;
                 storageOpen = false;
                 backupsOpen = false;
                 trashOpen = false;
@@ -1218,6 +1247,7 @@
                       historyOpen = false;
                       provenanceOpen = false;
                       jobsOpen = false;
+                      auditEvidenceOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
                       trashOpen = false;
@@ -1235,6 +1265,7 @@
                       historyOpen = false;
                       versionsOpen = false;
                       jobsOpen = false;
+                      auditEvidenceOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
                       trashOpen = false;
@@ -1254,6 +1285,7 @@
                       versionsOpen = false;
                       provenanceOpen = false;
                       jobsOpen = false;
+                      auditEvidenceOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
                       trashOpen = false;
@@ -1296,6 +1328,7 @@
                       jobsOpen = false;
                       versionsOpen = false;
                       provenanceOpen = false;
+                      auditEvidenceOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
                       trashOpen = false;
@@ -1327,6 +1360,7 @@
                       versionsOpen = false;
                       provenanceOpen = false;
                       jobsOpen = false;
+                      auditEvidenceOpen = false;
                       storageOpen = false;
                       backupsOpen = false;
                       trashOpen = false;
@@ -1384,6 +1418,13 @@
       <JobsDrawer
         session={webSession}
         onclose={() => (jobsOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if auditEvidenceOpen}
+      <AuditEvidenceDrawer
+        session={webSession}
+        onclose={() => (auditEvidenceOpen = false)}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/AuditEvidenceDrawer.svelte
+++ b/frontend/src/AuditEvidenceDrawer.svelte
@@ -1,0 +1,507 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import ShieldCheckIcon from "@lucide/svelte/icons/shield-check";
+  import TriangleAlertIcon from "@lucide/svelte/icons/triangle-alert";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Card,
+    Chip,
+    CopyButton,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+  } from "@kenn-io/kit-ui";
+  import {
+    APIError,
+    verifyAudit,
+    type AuditVerifyReport,
+  } from "./api.js";
+  import { formatBytes } from "./format.js";
+
+  interface Props {
+    session: string;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+
+  let { session, onclose, onauthfailure }: Props = $props();
+
+  let report = $state<AuditVerifyReport | null>(null);
+  let loading = $state(true);
+  let error = $state("");
+  let controller: AbortController | null = null;
+  let generation = 0;
+
+  const metadataProblems = $derived(report?.metadata_problems ?? []);
+  const contentProblems = $derived(report?.problems ?? []);
+  const evidence = $derived(report?.evidence);
+  const visibleScopes = $derived(evidence?.scopes.slice(0, 100) ?? []);
+  const verified = $derived(
+    Boolean(
+      report?.enabled &&
+        evidence &&
+        metadataProblems.length === 0 &&
+        contentProblems.length === 0 &&
+        report.verified_blobs === report.protected_blobs,
+    ),
+  );
+
+  onMount(() => {
+    void refresh();
+    return () => {
+      generation += 1;
+      controller?.abort();
+    };
+  });
+
+  async function refresh(): Promise<void> {
+    controller?.abort();
+    const active = new AbortController();
+    controller = active;
+    const request = ++generation;
+    loading = true;
+    error = "";
+    try {
+      const next = await verifyAudit(session, active.signal);
+      if (request !== generation) return;
+      report = next;
+    } catch (cause) {
+      if (request !== generation) return;
+      if (cause instanceof DOMException && cause.name === "AbortError") return;
+      if (cause instanceof APIError && cause.status === 401) {
+        onauthfailure(cause);
+        onclose();
+        return;
+      }
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === generation) {
+        loading = false;
+        controller = null;
+      }
+    }
+  }
+</script>
+
+<DetailDrawer
+  width="min(860px, 100vw)"
+  ariaLabel="Permanent audit verification"
+  {onclose}
+>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>PERMANENT AUDIT</span>
+        <strong>Independent verification</strong>
+        <small>
+          {#if report?.enabled && evidence}
+            {evidence.scopes.length} protected scope{evidence.scopes.length === 1 ? "" : "s"}
+            · {report.verified_blobs} of {report.protected_blobs} blobs verified
+          {:else}
+            Replay history and prove protected bytes
+          {/if}
+        </small>
+      </div>
+      <div class="drawer-actions">
+        <IconButton
+          size="sm"
+          ariaLabel="Run permanent audit verification again"
+          disabled={loading}
+          onclick={() => void refresh()}
+        >
+          <RefreshCwIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton size="sm" ariaLabel="Close permanent audit verification" onclick={onclose}>
+          <XIcon size="14" aria-hidden="true" />
+        </IconButton>
+      </div>
+    </div>
+  {/snippet}
+
+  <div class="verification">
+    {#if loading && !report}
+      <div class="loading">
+        <Spinner size={16} />
+        Replaying protected history and hashing retained content…
+      </div>
+    {:else if error && !report}
+      <div class="load-error">
+        <p role="alert">{error}</p>
+        <Button size="sm" onclick={() => void refresh()}>Try again</Button>
+      </div>
+    {:else if report && !report.enabled}
+      {#if error}<p class="error" role="alert">{error}</p>{/if}
+      <EmptyState
+        title="Permanent audit is dormant"
+        description="No directory has been enrolled in permanent audited history, so there is no protected chain or retained byte set to verify."
+      >
+        {#snippet icon()}<ShieldCheckIcon size="22" />{/snippet}
+      </EmptyState>
+    {:else if report && evidence}
+      {#if error}<p class="error" role="alert">{error}</p>{/if}
+      <section class="result-heading" aria-live="polite">
+        <div class:failed={!verified}>
+          {#if verified}
+            <ShieldCheckIcon size="24" aria-hidden="true" />
+          {:else}
+            <TriangleAlertIcon size="24" aria-hidden="true" />
+          {/if}
+          <div>
+            <span>{verified ? "VERIFIED" : "PROBLEMS FOUND"}</span>
+            <strong>
+              {verified
+                ? "Protected history and content agree"
+                : "Protected authority needs attention"}
+            </strong>
+          </div>
+        </div>
+        <Chip size="sm" tone={verified ? "success" : "danger"} dot>
+          {verified ? "Complete" : "Failed"}
+        </Chip>
+      </section>
+
+      <div class="summary-grid">
+        <Card
+          level="default"
+          padding="sm"
+          eyebrow="PROTECTED CONTENT"
+          title={formatBytes(report.protected_bytes)}
+        >
+          <p>
+            {report.verified_blobs} of {report.protected_blobs} unique retained
+            blob{report.protected_blobs === 1 ? "" : "s"} passed SHA-256 verification.
+          </p>
+        </Card>
+        <Card
+          level="default"
+          padding="sm"
+          eyebrow="ALLOCATION LINEAGE"
+          title={`${evidence.allocation_entry_count} entries`}
+        >
+          <p>
+            Operation sequence high-water:
+            <strong>{evidence.operation_sequence_high_water}</strong>
+          </p>
+        </Card>
+      </div>
+
+      <section class="authority" aria-label="Verified audit authority">
+        <div>
+          <span>VAULT ID</span>
+          <div class="identity">
+            <code>{evidence.vault_id}</code>
+            <CopyButton text={evidence.vault_id} ariaLabel="Copy verified vault ID" />
+          </div>
+        </div>
+        <div>
+          <span>LINEAGE ID</span>
+          <div class="identity">
+            <code>{evidence.lineage_id}</code>
+            <CopyButton text={evidence.lineage_id} ariaLabel="Copy verified lineage ID" />
+          </div>
+        </div>
+        <div class="wide">
+          <span>ALLOCATION HEAD</span>
+          <div class="identity">
+            <code>{evidence.allocation_head}</code>
+            <CopyButton
+              text={evidence.allocation_head}
+              ariaLabel="Copy verified allocation head"
+            />
+          </div>
+        </div>
+      </section>
+
+      {#if metadataProblems.length > 0 || contentProblems.length > 0}
+        <section class="problems" aria-label="Audit verification problems">
+          <div class="section-heading">
+            <span>VERIFICATION PROBLEMS</span>
+            <strong>{metadataProblems.length + contentProblems.length} issue{metadataProblems.length + contentProblems.length === 1 ? "" : "s"}</strong>
+          </div>
+          {#each metadataProblems as problem}
+            <p><strong>Metadata</strong> {problem}</p>
+          {/each}
+          {#each contentProblems as problem}
+            <p>
+              <strong>{problem.problem}</strong>
+              <code>{problem.hash}</code>
+            </p>
+          {/each}
+        </section>
+      {/if}
+
+      <section class="scopes" aria-label="Verified audit scope heads">
+        <div class="section-heading">
+          <span>SCOPE CHAINS</span>
+          <strong>{evidence.scopes.length} terminal head{evidence.scopes.length === 1 ? "" : "s"}</strong>
+        </div>
+        <div class="scope-list">
+          {#each visibleScopes as scope (scope.id)}
+            <Card
+              level="default"
+              padding="sm"
+              eyebrow={`${scope.entry_count} chain entr${scope.entry_count === 1 ? "y" : "ies"}`}
+              title={scope.id}
+            >
+              <div class="identity">
+                <code>{scope.chain_head}</code>
+                <CopyButton
+                  text={scope.chain_head}
+                  ariaLabel={`Copy chain head for scope ${scope.id}`}
+                />
+              </div>
+            </Card>
+          {/each}
+        </div>
+        {#if evidence.scopes.length > visibleScopes.length}
+          <p class="limit-note">
+            Showing the first {visibleScopes.length} of {evidence.scopes.length}
+            verified scopes. Use <code>docbank audit verify --json</code> for
+            the complete evidence bundle.
+          </p>
+        {/if}
+      </section>
+
+      <aside class="evidence-note">
+        <strong>This is a fresh proof, not an external trust anchor.</strong>
+        <p>
+          Save <code>docbank audit verify --json</code> outside this vault and
+          later pass it back with <code>--expected</code> when you need to prove
+          that current history extends an earlier verified state.
+        </p>
+      </aside>
+    {/if}
+  </div>
+</DetailDrawer>
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div:first-child {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-heading span,
+  .section-heading span,
+  .authority > div > span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading small {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .drawer-actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .verification {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-5);
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .load-error {
+    display: grid;
+    justify-items: start;
+    gap: var(--space-4);
+  }
+
+  .load-error p,
+  .error {
+    margin: 0;
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+
+  .result-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-4);
+    border: 1px solid color-mix(in srgb, var(--accent-green) 42%, var(--border-subtle));
+    border-radius: var(--radius-lg);
+    background: color-mix(in srgb, var(--accent-green) 8%, var(--bg-raised));
+  }
+
+  .result-heading > div {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--accent-green);
+  }
+
+  .result-heading > div.failed {
+    color: var(--accent-red);
+  }
+
+  .result-heading span,
+  .result-heading strong {
+    display: block;
+  }
+
+  .result-heading span {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .result-heading strong {
+    color: var(--text-primary);
+  }
+
+  .summary-grid,
+  .authority {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+  }
+
+  .summary-grid p,
+  .evidence-note p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.45;
+  }
+
+  .authority {
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--bg-inset);
+  }
+
+  .authority > div,
+  .scopes,
+  .problems {
+    display: grid;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  .authority .wide {
+    grid-column: 1 / -1;
+  }
+
+  .identity {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  .identity code {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
+  .section-heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .section-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  .scope-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+  }
+
+  .problems {
+    padding: var(--space-4);
+    border: 1px solid color-mix(in srgb, var(--accent-red) 45%, var(--border-subtle));
+    border-radius: var(--radius-lg);
+    background: color-mix(in srgb, var(--accent-red) 7%, var(--bg-raised));
+  }
+
+  .problems p {
+    display: grid;
+    gap: var(--space-1);
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .problems code {
+    overflow-wrap: anywhere;
+    font-size: var(--font-size-xs);
+  }
+
+  .limit-note {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .evidence-note {
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--bg-inset);
+  }
+
+  .evidence-note strong {
+    display: block;
+    margin-bottom: var(--space-1);
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  @media (max-width: 760px) {
+    .summary-grid,
+    .authority,
+    .scope-list {
+      grid-template-columns: 1fr;
+    }
+
+    .authority .wide {
+      grid-column: auto;
+    }
+
+    .result-heading {
+      align-items: flex-start;
+    }
+  }
+</style>

--- a/frontend/src/AuditEvidenceDrawer.svelte
+++ b/frontend/src/AuditEvidenceDrawer.svelte
@@ -63,6 +63,7 @@
     controller = active;
     const request = ++generation;
     loading = true;
+    report = null;
     error = "";
     try {
       const next = await verifyAudit(session, active.signal);
@@ -132,6 +133,26 @@
         <p role="alert">{error}</p>
         <Button size="sm" onclick={() => void refresh()}>Try again</Button>
       </div>
+    {:else if report && metadataProblems.length > 0 && !evidence}
+      <section class="result-heading" aria-live="polite">
+        <div class="failed">
+          <TriangleAlertIcon size="24" aria-hidden="true" />
+          <div>
+            <span>PROBLEMS FOUND</span>
+            <strong>Protected authority needs attention</strong>
+          </div>
+        </div>
+        <Chip size="sm" tone="danger" dot>Failed</Chip>
+      </section>
+      <section class="problems" aria-label="Audit verification problems">
+        <div class="section-heading">
+          <span>VERIFICATION PROBLEMS</span>
+          <strong>{metadataProblems.length} issue{metadataProblems.length === 1 ? "" : "s"}</strong>
+        </div>
+        {#each metadataProblems as problem}
+          <p><strong>Metadata</strong> {problem}</p>
+        {/each}
+      </section>
     {:else if report && !report.enabled}
       {#if error}<p class="error" role="alert">{error}</p>{/if}
       <EmptyState

--- a/frontend/src/AuditEvidenceDrawer.test.ts
+++ b/frontend/src/AuditEvidenceDrawer.test.ts
@@ -110,4 +110,86 @@ describe("audit evidence drawer", () => {
     expect(screen.getByText("c".repeat(64))).toBeTruthy();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("reports metadata replay failures instead of calling the vault dormant", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          enabled: false,
+          protected_blobs: 0,
+          protected_bytes: 0,
+          verified_blobs: 0,
+          metadata_problems: ["audit scope chain does not match its head"],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    render(AuditEvidenceDrawer, {
+      session: "short-lived",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+    });
+
+    expect(
+      await screen.findByText("Protected authority needs attention"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("audit scope chain does not match its head"),
+    ).toBeTruthy();
+    expect(screen.queryByText("Permanent audit is dormant")).toBeNull();
+  });
+
+  it("withdraws an earlier verified result while refresh is unresolved", async () => {
+    let rejectRefresh!: (cause: Error) => void;
+    const refreshResponse = new Promise<Response>((_resolve, reject) => {
+      rejectRefresh = reject;
+    });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            enabled: true,
+            evidence,
+            protected_blobs: 3,
+            protected_bytes: 4096,
+            verified_blobs: 3,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockReturnValueOnce(refreshResponse);
+
+    render(AuditEvidenceDrawer, {
+      session: "short-lived",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+    });
+
+    expect(
+      await screen.findByText("Protected history and content agree"),
+    ).toBeTruthy();
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: "Run permanent audit verification again",
+      }),
+    );
+
+    expect(
+      screen.getByText(
+        "Replaying protected history and hashing retained content…",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Protected history and content agree"),
+    ).toBeNull();
+
+    rejectRefresh(new Error("verification interrupted"));
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "verification interrupted",
+    );
+    expect(
+      screen.queryByText("Protected history and content agree"),
+    ).toBeNull();
+  });
 });

--- a/frontend/src/AuditEvidenceDrawer.test.ts
+++ b/frontend/src/AuditEvidenceDrawer.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/svelte";
+import AuditEvidenceDrawer from "./AuditEvidenceDrawer.svelte";
+
+const evidence = {
+  vault_id: "11111111-1111-4111-8111-111111111111",
+  lineage_id: "22222222-2222-4222-8222-222222222222",
+  operation_sequence_high_water: 18,
+  allocation_entry_count: 18,
+  allocation_head: "a".repeat(64),
+  scopes: [
+    {
+      id: "33333333-3333-4333-8333-333333333333",
+      entry_count: 7,
+      chain_head: "b".repeat(64),
+    },
+  ],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("audit evidence drawer", () => {
+  it("shows independently verified authority and protected content", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          enabled: true,
+          evidence,
+          protected_blobs: 3,
+          protected_bytes: 4096,
+          verified_blobs: 3,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    render(AuditEvidenceDrawer, {
+      session: "short-lived",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+    });
+
+    expect(
+      await screen.findByText("Protected history and content agree"),
+    ).toBeTruthy();
+    expect(screen.getByText("3 of 3 unique retained blobs passed SHA-256 verification.")).toBeTruthy();
+    expect(screen.getByText(evidence.lineage_id)).toBeTruthy();
+    expect(screen.getByText(evidence.scopes[0]!.id)).toBeTruthy();
+    expect(screen.getByText(evidence.scopes[0]!.chain_head)).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/audit/verify",
+      expect.objectContaining({
+        method: "POST",
+        body: "{}",
+        credentials: "same-origin",
+      }),
+    );
+  });
+
+  it("distinguishes a dormant vault and can retry verification", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            enabled: false,
+            protected_blobs: 0,
+            protected_bytes: 0,
+            verified_blobs: 0,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            enabled: true,
+            evidence,
+            protected_blobs: 1,
+            protected_bytes: 12,
+            verified_blobs: 0,
+            problems: [{ hash: "c".repeat(64), problem: "corrupt" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    render(AuditEvidenceDrawer, {
+      session: "short-lived",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+    });
+
+    expect(await screen.findByText("Permanent audit is dormant")).toBeTruthy();
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: "Run permanent audit verification again",
+      }),
+    );
+
+    expect(await screen.findByText("Protected authority needs attention")).toBeTruthy();
+    expect(screen.getByText("corrupt")).toBeTruthy();
+    expect(screen.getByText("c".repeat(64))).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -189,6 +189,36 @@ export interface AuditStatus {
   membership?: AuditMembershipStatus;
 }
 
+export interface AuditScopeEvidence {
+  id: string;
+  entry_count: number;
+  chain_head: string;
+}
+
+export interface AuditEvidence {
+  vault_id: string;
+  lineage_id: string;
+  operation_sequence_high_water: number;
+  allocation_entry_count: number;
+  allocation_head: string;
+  scopes: AuditScopeEvidence[];
+}
+
+export interface VerifyProblem {
+  hash: string;
+  problem: "missing" | "corrupt" | "unreadable";
+}
+
+export interface AuditVerifyReport {
+  enabled: boolean;
+  evidence?: AuditEvidence;
+  protected_blobs: number;
+  protected_bytes: number;
+  verified_blobs: number;
+  problems?: VerifyProblem[];
+  metadata_problems?: string[];
+}
+
 export interface AuditPathState {
   path: string;
   state: "live" | "trash";
@@ -603,6 +633,18 @@ export async function auditHistory(
     `/api/v1/audit/history?${query.toString()}`,
     session,
   );
+}
+
+export async function verifyAudit(
+  session: string,
+  signal?: AbortSignal,
+): Promise<AuditVerifyReport> {
+  return requestJSON<AuditVerifyReport>("/api/v1/audit/verify", session, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+    signal,
+  });
 }
 
 export async function listJobs(session: string): Promise<Job[]> {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.kenn.io/kit v0.11.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
@@ -59,7 +60,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/api/gate.go
+++ b/internal/api/gate.go
@@ -3,9 +3,14 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
+
+	"golang.org/x/sync/semaphore"
 )
+
+const operationGateExclusiveWeight int64 = 1 << 30
 
 // OperationGate serializes maintenance against regular mutations and active backup
 // captures. Regular mutating handlers hold mu's read side and may run
@@ -14,27 +19,36 @@ import (
 // for Kit's short metadata freeze, so ordinary writes resume while maintenance
 // remains queued behind the snapshot's content requirements.
 type OperationGate struct {
-	mu           sync.RWMutex
-	preservation sync.RWMutex
+	mu           *semaphore.Weighted
+	preservation *semaphore.Weighted
 	admission    sync.RWMutex
 	maintenance  int
 }
 
 // NewOperationGate creates one daemon-wide operation coordinator. Every
 // mutating entry point, including daemon-owned jobs, must share this instance.
-func NewOperationGate() *OperationGate { return &OperationGate{} }
+func NewOperationGate() *OperationGate {
+	return &OperationGate{
+		mu:           semaphore.NewWeighted(operationGateExclusiveWeight),
+		preservation: semaphore.NewWeighted(operationGateExclusiveWeight),
+	}
+}
 
 // Mutate runs fn as an ordinary mutation, excluding maintenance while the
 // complete physical-write and metadata-publication operation is in flight.
 func (g *OperationGate) Mutate(fn func() error) error {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	if err := g.mu.Acquire(context.Background(), 1); err != nil {
+		return fmt.Errorf("acquiring mutation gate: %w", err)
+	}
+	defer g.mu.Release(1)
 	return fn()
 }
 
 // Maintain runs daemon-owned physical maintenance with the same exclusion and
 // admission behavior as an HTTP maintenance request.
-func (g *OperationGate) Maintain(fn func() error) error { return g.maintain(fn) }
+func (g *OperationGate) Maintain(fn func() error) error {
+	return g.maintainContext(context.Background(), fn)
+}
 
 func (g *OperationGate) mutate(fn func() error) error {
 	g.admission.RLock()
@@ -46,13 +60,20 @@ func (g *OperationGate) mutate(fn func() error) error {
 	// Keep admission pinned until the shared side is held. A short backup
 	// freeze can therefore delay this mutation without being mistaken for
 	// maintenance, while newly queued maintenance cannot overtake it.
-	g.mu.RLock()
+	err := g.mu.Acquire(context.Background(), 1)
 	g.admission.RUnlock()
-	defer g.mu.RUnlock()
+	if err != nil {
+		return fmt.Errorf("acquiring route mutation gate: %w", err)
+	}
+	defer g.mu.Release(1)
 	return fn()
 }
 
 func (g *OperationGate) maintain(fn func() error) error {
+	return g.maintainContext(context.Background(), fn)
+}
+
+func (g *OperationGate) maintainContext(ctx context.Context, fn func() error) error {
 	g.admission.Lock()
 	g.maintenance++
 	g.admission.Unlock()
@@ -61,16 +82,22 @@ func (g *OperationGate) maintain(fn func() error) error {
 		g.maintenance--
 		g.admission.Unlock()
 	}()
-	g.preservation.Lock()
-	defer g.preservation.Unlock()
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	if err := g.preservation.Acquire(ctx, operationGateExclusiveWeight); err != nil {
+		return fmt.Errorf("acquiring maintenance preservation gate: %w", err)
+	}
+	defer g.preservation.Release(operationGateExclusiveWeight)
+	if err := g.mu.Acquire(ctx, operationGateExclusiveWeight); err != nil {
+		return fmt.Errorf("acquiring maintenance mutation gate: %w", err)
+	}
+	defer g.mu.Release(operationGateExclusiveWeight)
 	return fn()
 }
 
 func (g *OperationGate) capture(fn func() error) error {
-	g.preservation.RLock()
-	defer g.preservation.RUnlock()
+	if err := g.preservation.Acquire(context.Background(), 1); err != nil {
+		return fmt.Errorf("acquiring backup preservation gate: %w", err)
+	}
+	defer g.preservation.Release(1)
 	return fn()
 }
 
@@ -93,10 +120,8 @@ func (f *gateFreezer) Begin(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	f.gate.mu.Lock()
-	if err := ctx.Err(); err != nil {
-		f.gate.mu.Unlock()
-		return err
+	if err := f.gate.mu.Acquire(ctx, operationGateExclusiveWeight); err != nil {
+		return fmt.Errorf("acquiring backup freeze gate: %w", err)
 	}
 	f.held = true
 	return nil
@@ -107,6 +132,6 @@ func (f *gateFreezer) End(context.Context) error {
 		return errors.New("backup freeze is not held")
 	}
 	f.held = false
-	f.gate.mu.Unlock()
+	f.gate.mu.Release(operationGateExclusiveWeight)
 	return nil
 }

--- a/internal/api/gate_test.go
+++ b/internal/api/gate_test.go
@@ -84,6 +84,40 @@ func TestQueuedMaintenanceRejectsRouteMutation(t *testing.T) {
 	require.NoError(t, <-maintenanceDone)
 }
 
+func TestCanceledQueuedMaintenanceStopsRejectingRouteMutation(t *testing.T) {
+	g := NewOperationGate()
+	captureEntered := make(chan struct{})
+	releaseCapture := make(chan struct{})
+	go func() {
+		_ = g.capture(func() error {
+			close(captureEntered)
+			<-releaseCapture
+			return nil
+		})
+	}()
+	<-captureEntered
+	t.Cleanup(func() { close(releaseCapture) })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	maintenanceDone := make(chan error, 1)
+	go func() {
+		maintenanceDone <- g.maintainContext(ctx, func() error {
+			t.Error("canceled maintenance entered")
+			return nil
+		})
+	}()
+	require.Eventually(t, func() bool {
+		g.admission.RLock()
+		defer g.admission.RUnlock()
+		return g.maintenance == 1
+	}, time.Second, time.Millisecond)
+
+	cancel()
+	require.ErrorIs(t, <-maintenanceDone, context.Canceled)
+	require.NoError(t, g.mutate(func() error { return nil }),
+		"canceled maintenance must stop rejecting mutations before backup completes")
+}
+
 func TestBackupCaptureBlocksGCButAllowsLiveDeletion(t *testing.T) {
 	ctx := t.Context()
 	root := t.TempDir()
@@ -111,7 +145,7 @@ func TestBackupCaptureBlocksGCButAllowsLiveDeletion(t *testing.T) {
 
 	repo, err := backup.Init(filepath.Join(root, "backup"))
 	require.NoError(t, err)
-	g := &gate{}
+	g := NewOperationGate()
 	d := Deps{Store: metadata, Blobs: blobs}
 	metadataCaptured := make(chan struct{})
 	resumeBackup := make(chan struct{})

--- a/internal/api/routes_audit.go
+++ b/internal/api/routes_audit.go
@@ -155,7 +155,7 @@ func registerAuditRoutes(
 			expected = &converted
 		}
 		out := &auditVerifyOutput{}
-		err := g.maintain(func() error {
+		err := g.maintainContext(ctx, func() error {
 			verification, err := d.Store.VerifyAudit(ctx, expected)
 			if err != nil {
 				if ctx.Err() != nil {

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -55,7 +55,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 		}
 		out := &storageRepackOutput{}
-		err = g.maintain(func() error {
+		err = g.maintainContext(ctx, func() error {
 			report, err := runRepack(ctx, d, in.Body.MaxBytes, minAge, in.Body.MinDeadBytes)
 			if err != nil {
 				return FromMaintenanceError(err)
@@ -76,7 +76,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		}
 	}) (*storagePackOutput, error) {
 		out := &storagePackOutput{}
-		err := g.maintain(func() error {
+		err := g.maintainContext(ctx, func() error {
 			report, err := internalmaintenance.Pack(ctx, d.Store, d.Blobs, in.Body.MaxBytes)
 			if err != nil {
 				return FromMaintenanceError(err)
@@ -246,7 +246,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 		}
 		out := &emptyOutput{}
-		err = g.maintain(func() error {
+		err = g.maintainContext(ctx, func() error {
 			rep, err := d.Store.TrashEmpty(ctx, age, in.Body.Run)
 			if err != nil {
 				return FromStoreError(err)
@@ -271,7 +271,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		}
 	}) (*gcOutput, error) {
 		out := &gcOutput{}
-		err := g.maintain(func() error {
+		err := g.maintainContext(ctx, func() error {
 			return d.Blobs.WithMutation(ctx, func() error {
 				rep, err := runGC(ctx, d, in.Body.Run)
 				if err != nil {
@@ -290,7 +290,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		Summary: "Validate metadata and re-hash every stored blob",
 	}, func(ctx context.Context, _ *struct{}) (*verifyOutput, error) {
 		out := &verifyOutput{}
-		err := g.maintain(func() error {
+		err := g.maintainContext(ctx, func() error {
 			report, err := runVerify(ctx, d)
 			out.Body = report
 			return err

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -605,7 +605,8 @@ func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 
 	resp = webRequest(http.MethodPost, "/api/v1/audit/verify")
-	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"browser sessions may run the read-only permanent-audit verifier")
 	require.NoError(t, resp.Body.Close())
 
 	resp = webRequest(http.MethodGet, "/api/v1/info")

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -173,6 +173,10 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	if method == http.MethodPost && path == webDownloadPreparePath {
 		return true
 	}
+	if method == http.MethodPost && path == "/api/v1/audit/verify" &&
+		r.URL.RawQuery == "" {
+		return true
+	}
 	if method == http.MethodPost && path == "/api/v1/tags" &&
 		r.URL.RawQuery == "" {
 		return true

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "56"
+	daemonProtocolVersion = "57"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.


### PR DESCRIPTION
Permanent retention is only reassuring if a person can prove that its recorded history still agrees with the vault. Until now Docbank had that verifier, but the primary human interface could show only protection status and individual events; checking the complete authority and retained bytes meant leaving the browser for the CLI.

The new shield action runs the real vault-wide audit verifier. A successful result says how many protected blobs were independently hashed, then exposes the vault and allocation-lineage identities, operation high-water mark, allocation head, and every terminal scope-chain head. Dormant protection is distinct from failure, and metadata, missing-content, corruption, or unreadable-content problems remain visible rather than collapsing into a generic error.

![The actual Docbank web application showing verified permanent-audit evidence for a synthetic vault](https://raw.githubusercontent.com/kenn-io/docbank/dd0bbafca2f8736b8a684d6dfcb7657b2cf7d6df/screenshots/web-audit-evidence/web-audit-evidence.png)

*Actual daemon-served interface using an owner-private temporary vault with synthetic reports; no private corpus data is present.*

This does not turn the browser into an audit administrator. Its daemon-lifetime session gains only the existing read-only verification call: it cannot enroll scopes, destroy protected history, run general vault or backup verification, or invoke maintenance. The drawer also says what the result does not prove—a fresh check is not an external rollback anchor. People and agents still use `docbank audit verify --json` and `--expected` when evidence must survive outside the vault.

I exercised the rendered workflow end to end through the repository’s Playwright harness against a real temporary daemon and audited vault. The harness stopped the daemon and removed the vault after the inspected capture.
