### PR TITLE
Make Docbank's expanded capabilities easier to understand

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,125 +4,76 @@
 [![CI](https://github.com/kenn-io/docbank/actions/workflows/ci.yml/badge.svg)](https://github.com/kenn-io/docbank/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/kenn-io/docbank?include_prereleases)](https://github.com/kenn-io/docbank/releases)
 
-> **Alpha software.** Docbank is pre-1.0. Keep independent copies of
-> irreplaceable material and verify backups before relying on them.
+> **Alpha software.** Keep independent copies of irreplaceable material and
+> verify backups before relying on them.
 
 **Your documents. Your agents. One system.**
 
-Docbank gives you and your agents one authoritative place to file, find,
-organize, version, and verify the PDFs, scans, notes, spreadsheets, and records
-you depend on. You keep the authority: the vault and its history live on your
-own machine rather than inside a provider account. Content is immutable and
-deduplicated under one logical SHA-256 identity, while stable document IDs and
-a virtual tree let people and agents reorganize the archive without losing
-track of anything. Documentation lives at [docbank.ai](https://docbank.ai).
+Docbank is a self-sovereign document system for the records you and your
+agents need to keep, find, change, and prove. It combines a familiar virtual
+tree with stable document IDs, immutable content versions, indexed retrieval,
+recoverable deletion, verified backup, and optional permanent audited history.
+The vault catalog stays under your control instead of inside a provider
+account.
 
-## Why docbank?
+![The Docbank web application browsing a synthetic vault and showing the selected document's stable authority.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/v0.11.0/web-vault-browser.png)
 
-Ordinary folders make a document's location part of its identity, and cloud
-drives couple an archive's integrity, history, and continued existence to an
-account in good standing. Neither makes durable content identity,
-independent verification, and provider-independent retention part of its
-native contract. Docbank does: everything lives on your machine in an
-inspectable layout, imports copy and never touch sources, and integrity is
-provable on demand. One honest boundary — docbank is an archive and system
-of record, not a sync-and-share tool. It makes the copy that must survive
-trustworthy.
+The standalone CLI, web application, TUI, scripts, and agents all use the same
+authenticated daemon contract. Go applications can instead embed independently
+rooted vaults in-process through the public module at `go.kenn.io/docbank`.
 
-Two ways to run it, one authority per vault:
+## Why Docbank?
 
-- **Standalone.** A personal archive: the CLI and a daemon on your machine.
-  Agents and scripts use the same authenticated HTTP contract the CLI uses,
-  with IDs that survive renames and revision preconditions for safe
-  read-modify-write.
-- **Embedded.** A Go module: independently rooted vaults in-process, no
-  daemon, the same storage model and lifecycle guarantees.
+A path is a useful place to find a file, but a poor long-term identity. Cloud
+drives also make account access and provider policy part of the authority for
+your archive. Docbank separates those concerns:
 
-Four commitments:
+- a stable node ID continues to identify a document after moves and renames;
+- every content version is immutable and named by a verifiable SHA-256 digest;
+- revisions turn stale automation into explicit conflicts instead of silent
+  overwrites;
+- trash, permanent deletion, garbage collection, and pack reclamation are
+  separate decisions;
+- incremental backups are verified before restore results are published; and
+- physical content can be placed in fenced filesystem or S3-compatible stores
+  without making those stores the document catalog.
 
-- **Immutable content.** Blob writes are durable before the database ever
-  references them, and every content version keeps a verified SHA-256
-  identity you can re-check at any time with `verify`.
-- **Deliberate lifecycle.** `rm` is always recoverable trash. Emptying
-  trash, collecting unreachable content, and compacting packed space are
-  separate explicit operations — never side effects.
-- **Verified backup & restore.** Incremental snapshot repositories support
-  create, list, verify, and confined restore into a separate vault, so a
-  backup is proven before it is trusted.
-- **Audited history.** Opt a directory into permanent, tamper-evident
-  history with `docbank audit enable`; every supported change is recorded
-  and `verify` independently replays it.
+Docbank is an archive and system of record, not a sync-and-share service. It
+does not mirror a working folder across devices or create public share links.
 
-## Implemented today
+## What you can do
 
-- Virtual folders with listing, tree browsing, rename, move, trash, and restore
-- Resumable bulk import and verified multipart upload
-- Stable content-version UUIDs, verified replacement and reversion, bounded
-  history listing, ID-addressed retrieval, and lookup by content hash
-- Stable tags with define, rename, assign, unassign, delete, and bounded
-  node/tag listings
-- Preview-first permanent audit enrollment for one directory scope, with
-  sticky retention, recorded supported mutations, status evidence, bounded
-  per-node history, independent chain/protected-byte verification, exact-prefix
-  checks against externally recorded evidence, and backup/restore fidelity
-- FTS5 search over names and verified UTF-8 text/Markdown/JSON contents
-- A daemon-backed TUI for analytical tree browsing, search, stable
-  document/version identity inspection, permanent audited-history timelines,
-  revision-bound recoverable trash and restore, and read-only storage and
-  backup inspection
-- A scoped kit-ui web application for verified local-file upload, virtual-tree browsing, sortable
-  document analysis, tag-definition management, tag browsing and assignment,
-  tag-filtered extracted-text search,
-  complete current authority, verified current and historical content download,
-  recoverable move-to-trash and revision-bound restoration,
-  permanent protection, event history, and vault-wide verification evidence,
-  immutable versions and provenance,
-  configured backup recovery points, daemon background-job status, and an honest
-  loose-file/live-packed/dead-packed storage breakdown
-- Mixed loose and packed content storage with explicit pack, GC, and repack,
-  plus an opt-in bounded daemon packing schedule
-- Local-first multi-store placement across configured filesystem and
-  S3-compatible secondaries, with fenced ownership, preview-first movement,
-  repair and salvage, complete backup, and topology-independent restore
-- Whole-vault integrity verification
-- Incremental backup repositories with create, list, verify, and confined restore
-- Daemon-first CLI, authenticated loopback HTTP API, and offline OpenAPI output
-- An embedded Go API with exclusive non-overlapping roots, immutable create,
-  generic source provenance, verified blob repair, stable bounded tree walks,
-  optional automatic loose zstd storage, resumable maintenance, and selectable
-  CGO or pure-Go SQLite
-- A release pipeline for Linux, macOS, and Windows on amd64 and arm64, with
-  SHA-256 checksums and checksum-enforcing installers
-- Native vault, daemon, and recovery support on Linux, macOS, and Windows
+| Need | Docbank capability |
+| --- | --- |
+| File and find records | Recursive import, verified upload, virtual folders, tags, ranked name and extracted-text search |
+| Keep identity through change | Stable node IDs, immutable version UUIDs, verified replacement, reversion, and explicit version pruning |
+| Work safely with agents | Authenticated HTTP and OpenAPI, bounded listings, structured errors, revision preconditions, and digest receipts |
+| Recover from mistakes | Recoverable trash, revision-bound restore, explicit GC and repack, whole-vault verification |
+| Prove recovery | Incremental snapshot repositories, complete content verification, topology-independent restore |
+| Retain a permanent record | Preview-first audited scopes with sticky retention and independently replayed evidence |
+| Manage physical capacity | Loose and packed storage, automatic bounded packing, and deliberate multi-store placement, repair, salvage, and evacuation |
 
-See the [roadmap](docs/roadmap.md) for high-level product direction beyond the
-capabilities listed here.
+See the [capability guide](docs/capabilities.md) for the full product map and
+the [visual tour](docs/tour.md) for the current web and terminal interfaces.
 
-Secondary stores are a deployment trust boundary: Docbank verifies their
-objects but does not encrypt them. Anyone with raw access to a configured
-filesystem root or S3 prefix can decode document content, so those namespaces
-must be owner-controlled or protected by independently managed storage
-encryption and access policy.
+## Install
 
-## Installation
-
-Docbank supports Linux, macOS, and 64-bit Windows on amd64 and arm64. On Linux
-or macOS, install the latest release with:
+Linux or macOS:
 
 ```bash
 curl -fsSL https://docbank.ai/install.sh | sh
 ```
 
-On Windows, run this in PowerShell:
+Windows PowerShell:
 
 ```powershell
 irm https://docbank.ai/install.ps1 | iex
 ```
 
-Both installers select the native archive and refuse to install it unless its
-SHA-256 digest matches the release's `SHA256SUMS`. You can instead download and
-verify an archive manually from
-[GitHub Releases](https://github.com/kenn-io/docbank/releases).
+The installers select the native Linux, macOS, or Windows archive for amd64 or
+arm64 and refuse to install it unless its digest matches the release's
+`SHA256SUMS`. [GitHub Releases](https://github.com/kenn-io/docbank/releases)
+also provides the archives for manual verification.
 
 To build from source, install Go 1.26+, CGO, a C compiler, Node 24+, and npm:
 
@@ -132,36 +83,32 @@ cd docbank
 make install
 ```
 
-On Windows, the [setup guide](docs/setup.md) gives the equivalent PowerShell
-steps for compiling the frontend, copying its embed assets, and building
-`docbank.exe`. It is the installation authority for every platform's
-toolchain.
+The [setup guide](docs/setup.md) is the toolchain authority for every platform.
 
-## Quick start
+## Start a vault
 
-There is no initialization command. The first data command creates the local
-vault and starts its daemon:
+There is no initialization ceremony. The first data command creates the vault
+and starts its daemon:
 
 ```bash
 docbank add ~/Documents --dest /archive
 docbank tree /archive
-docbank tui
-docbank web
 docbank search "tax return"
+docbank web
+```
+
+Retrieve a complete file only after Docbank verifies it, then inspect or change
+the same stable document without rewriting prior content:
+
+```bash
 docbank get /archive/Documents/receipt.pdf ./receipt.pdf
 docbank versions list /archive/Documents/receipt.pdf
-docbank refs <receipt-sha256>
-docbank tag create taxes
-docbank tag assign taxes /archive/Documents/receipt.pdf
-docbank search receipt --tag taxes
 docbank put revised-receipt.pdf /archive/Documents/receipt.pdf
-docbank edit /archive/Documents/notes.md
-docbank revert /archive/Documents/receipt.pdf <prior-version-id>
 docbank mv /archive/Documents/receipt.pdf /archive/Documents/receipt-2026.pdf
 docbank verify
 ```
 
-Create and prove an incremental backup repository:
+Create and prove an incremental recovery point:
 
 ```bash
 docbank backup init --repo ~/Backups/docbank
@@ -170,25 +117,38 @@ docbank backup verify --repo ~/Backups/docbank
 docbank backup restore --repo ~/Backups/docbank --target ~/Restores/docbank-test
 ```
 
+The [ten-minute quickstart](docs/quickstart.md) walks through versions, tags,
+search, recoverable trash, maintenance, and restore.
+
+## Deployment and trust boundaries
+
+- **Standalone:** one daemon owns a vault; every CLI, browser, TUI, script, and
+  external agent goes through its loopback-authenticated API.
+- **Embedded:** one Go application owns each independently rooted vault
+  in-process, with selectable CGO or pure-Go SQLite.
+- **Secondary storage:** Docbank verifies content in configured filesystem and
+  S3-compatible stores but does not encrypt it. Protect those namespaces with
+  owner access controls and storage encryption appropriate to their operator.
+- **Backup:** a stopped copy of the local database and primary blob directory
+  is complete only when every retained blob still has primary authority.
+  `docbank backup create` remains complete across remote-only placement and is
+  the preferred portable recovery path.
+
 ## Documentation
 
-- [Setup](docs/setup.md) and [ten-minute quickstart](docs/quickstart.md)
-- [Using docbank](docs/usage/lifecycle.md), including the
-  [web application](docs/usage/web.md),
-  [interactive terminal browser](docs/usage/tui.md), backup, and recovery
-- [Multi-store storage](docs/usage/storage.md)
-- [Docbank for agents](docs/agents.md) and the detailed
-  [integration guide](docs/agents/integration.md)
+- [Documentation homepage](https://docbank.ai) and [visual tour](docs/tour.md)
+- [Setup](docs/setup.md) and [quickstart](docs/quickstart.md)
+- [Capabilities](docs/capabilities.md) and [vault lifecycle](docs/usage/lifecycle.md)
+- [Web application](docs/usage/web.md) and [terminal browser](docs/usage/tui.md)
+- [Multi-store storage](docs/usage/storage.md) and [backup & restore](docs/usage/backup.md)
+- [Docbank for agents](docs/agents.md) and [integration guide](docs/agents/integration.md)
 - [Embed in Go](docs/embedding.md)
-- [CLI reference](docs/cli-reference.md)
-- [Architecture overview](docs/architecture/overview.md)
-- [Internal design map](docs/internal/README.md) for contributors and coding agents
+- [CLI reference](docs/cli-reference.md) and [architecture overview](docs/architecture/overview.md)
 
 Docbank belongs to a family of personal data tools alongside
-[msgvault](https://msgvault.io), the communications archive. Where msgvault
-preserves an immutable record of your messages, docbank manages working
-documents: files you still organize, retrieve, and build workflows around —
-and a safe document API for external applications.
+[msgvault](https://msgvault.io), the communications archive. Msgvault
+preserves an immutable record of messages; Docbank manages working documents
+that people and agents still organize, retrieve, version, and use.
 
 ## License
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -78,6 +78,10 @@ non-goals.
    repack reclaims physical packed space.
 6. **Dry run before policy-changing maintenance.** Preview destructive work,
    evaluate the result, then make the separate explicit run request.
+7. **Placement is authority, not a copy hint.** A successful storage operation
+   may change which store is allowed to satisfy reads. Bind the preview token
+   to the reviewed plan, follow its durable job ID, and inspect an uncertain
+   result rather than replaying the move blindly.
 
 ## Common agent workflows
 
@@ -104,6 +108,10 @@ non-goals.
 - **Protect a workflow boundary:** create a tagged incremental snapshot, follow
   structured progress to a terminal result, and verify the repository on the
   schedule appropriate for its storage medium.
+- **Manage capacity without losing authority:** inspect store health, preview
+  placement or evacuation, execute the one-use token, and reconcile the durable
+  job receipt. Treat unavailable, fenced, missing, and corrupt locations as
+  different outcomes with different recovery actions.
 
 ## Start integrating
 

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -8,9 +8,9 @@ description: Docbank's JSONL-native Kit snapshot and restore architecture.
 `docbank backup init`, `backup create`, `backup list`, `backup verify`, and
 `backup restore` are implemented over the authenticated daemon API; see the
 [Backup user guide](../usage/backup.md).
-A coherent manual filesystem snapshot remains available by stopping the daemon
-before copying the vault; see
-[Vault Lifecycle](../usage/lifecycle.md#take-a-coherent-manual-snapshot).
+A coherent local-state filesystem snapshot remains available by stopping the
+daemon before copying the vault, but it is not a topology-independent backup;
+see [Vault Lifecycle](../usage/lifecycle.md#take-a-coherent-backup).
 
 The database plus built-in `blobs/` directory is a complete manual archive only
 while every retained blob has primary authority. A vault may deliberately keep

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -12,9 +12,14 @@ A coherent manual filesystem snapshot remains available by stopping the daemon
 before copying the vault; see
 [Vault Lifecycle](../usage/lifecycle.md#take-a-coherent-manual-snapshot).
 
-The essential archive is the database plus `blobs/`. Configuration is useful
-to retain when customized; logs, locks, and runtime records are not archive
-state. A restored copy is not trusted until `docbank verify` succeeds.
+The database plus built-in `blobs/` directory is a complete manual archive only
+while every retained blob has primary authority. A vault may deliberately keep
+its sole verified copy in a secondary store, so the built-in snapshot workflow
+is the topology-independent recovery authority: it reads one verified
+candidate for every logical blob or fails without publishing a partial
+snapshot. Configuration is useful to retain when customized; logs, locks, and
+runtime records are not archive state. A restored copy is not trusted until
+`docbank verify` succeeds.
 
 ## Kit integration status
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -6,11 +6,15 @@ description: The SQLite schema, blob store layout, durability discipline, and en
 # Storage
 
 A standalone vault normally lives under `~/.docbank/`: one SQLite database and
-one built-in primary blob directory. The pair remains the minimum complete
-archive. Optional secondary stores add verified physical locations without
-becoming a second document catalog. Do not copy a running vault as a backup; use
-`docbank backup create`, or stop the daemon before taking a manual filesystem
-snapshot. `docbank verify` proves a completed copy is internally consistent.
+one built-in primary blob directory. That pair is a complete manual archive
+only while every retained blob has authority in the primary. Optional
+secondary stores add verified physical locations without becoming a second
+document catalog, and a vault may deliberately keep its sole verified copy in
+one of them. `docbank backup create` is therefore the topology-independent
+backup path: it reads one verified location for every logical blob or fails
+without publishing a partial snapshot. A stopped filesystem copy remains valid
+for a primary-complete vault; never copy a running vault. `docbank verify`
+proves a completed copy is internally consistent.
 
 ## Blob store
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,130 @@
+---
+title: Capabilities
+description: What Docbank does for people, agents, applications, recovery, and physical storage.
+---
+
+# Capabilities
+
+Docbank is one document authority with several ways to use it. People can work
+through the CLI, web application, or terminal browser. Agents and external
+applications use the authenticated HTTP contract. Go applications can embed
+separately rooted vaults without a sidecar process. Every surface resolves the
+same stable nodes, immutable versions, and verified content.
+
+## Collect and organize
+
+- Recursively import files and directories without modifying their sources.
+- Upload one document through a verified streaming contract.
+- Arrange documents in a virtual tree without moving stored bytes.
+- Address live documents by path or keep stable numeric node IDs across moves,
+  renames, trash, and restore.
+- Define stable tags, rename their display names, and assign them independently
+  of folder placement.
+- Perform an all-or-nothing batch reorganization with exact final coordinates.
+- Configure watched inboxes for settled, repeatable server-side ingestion.
+
+Start with [Importing Documents](usage/importing.md) and
+[Organizing & Tagging](usage/organizing.md).
+
+## Find and retrieve
+
+- Browse bounded directory and tree projections with sizes and modification
+  times.
+- Search live names with FTS5 ranking and filter by path, media type,
+  modification time, or stable tag identity.
+- Search verified extracted text for supported UTF-8 text, Markdown, JSON, and
+  related textual formats.
+- Resolve every retained reference to a known SHA-256 digest.
+- Stream current or historical content while checking size, digest, and
+  terminal verification evidence.
+- Publish a durable local download only after the complete staged file verifies.
+
+See [Searching](usage/searching.md), the [Web Application](usage/web.md), and
+the [Interactive Terminal Browser](usage/tui.md).
+
+## Change without erasing history
+
+- Keep every content edit as an immutable version by default.
+- Replace the current bytes under a revision precondition so a stale editor or
+  agent cannot overwrite a newer decision.
+- Revert by creating a new head that records its historical source rather than
+  rewinding the version graph.
+- Retrieve any retained version by its stable UUID after the document moves.
+- Preview and deliberately prune unwanted non-current history when unlimited
+  retention is not appropriate.
+- Record immutable provenance facts and later corrections without rewriting
+  the prior observation.
+
+See [Editing & Versions](architecture/editing-and-versions.md).
+
+## Recover and verify
+
+- Move nodes to recoverable trash without reclaiming content.
+- Restore the same stable node with explicit collision and missing-parent
+  behavior.
+- Permanently empty selected trash only through a preview-first operation.
+- Reclaim unreachable loose content with explicit garbage collection, then
+  compact dead packed payload separately.
+- Re-hash every authorized object and distinguish missing, corrupt, fenced,
+  unavailable, and malformed-metadata findings.
+- Create incremental snapshot repositories, verify their structure and bytes,
+  and restore into a separately coordinated vault before publication.
+
+See [Trash, GC, Repack & Verify](usage/trash-and-gc.md),
+[Backup & Restore](usage/backup.md), and [Vault Lifecycle](usage/lifecycle.md).
+
+## Retain permanent evidence
+
+- Preview exactly what a permanent audited scope will protect before enabling
+  an irreversible retention promise.
+- Keep enrolled history sticky through moves and trash, with inherited
+  protection for new descendants.
+- Record supported content, topology, tag, and provenance changes in canonical
+  append-only scope chains.
+- Browse typed node or scope history and independently replay the complete
+  authority.
+- Compare current terminal heads with evidence recorded outside the vault.
+- Preserve audited history through deterministic backup and restore.
+
+See [Permanent Audited History](usage/audited-history.md).
+
+## Place physical content deliberately
+
+- Ingest into a fixed local filesystem primary.
+- Store loose content raw or zstd-compressed and combine eligible small objects
+  into sealed immutable packs.
+- Attach fenced secondary filesystem or HTTPS S3-compatible namespaces without
+  placing their deployment coordinates or credentials in portable metadata.
+- Preview copy or move costs, verification reads, egress, scratch space,
+  shared-reference constraints, audit pins, and pack-level reclamation.
+- Repair a damaged location from another verified copy, salvage uniquely held
+  content from a fenced store, and evacuate a secondary before unregistering it.
+- Keep backups complete across remote-only placement and restore either into a
+  fresh local primary or an explicitly mapped target topology.
+
+Placement is capacity management, not synchronization, sharing, encryption, or
+backup. See [Multi-store Storage](usage/storage.md) for the operational and
+trust boundaries.
+
+## Build agent and application workflows
+
+- Discover the current daemon and authenticate over loopback.
+- Generate the live OpenAPI contract offline or retrieve it from the daemon.
+- Use stable IDs, ETags, revisions, bounded pages, typed problem codes, and
+  digest receipts instead of scraping human output.
+- Follow NDJSON progress to one terminal result for long-running work.
+- Inspect durable job IDs after an uncertain client outcome or daemon restart.
+- Embed a vault through `go.kenn.io/docbank`, choosing CGO or pure-Go SQLite,
+  while preserving the same exclusive ownership and content authority rules.
+
+See [Docbank for Agents](agents.md), the
+[Agent Integration Guide](agents/integration.md), and [Embed in Go](embedding.md).
+
+## Deliberate boundaries
+
+Docbank does not synchronize a mutable folder between devices, create public
+share links, provide collaborative editing, or encrypt live secondary stores.
+Text extraction is intentionally limited to formats Docbank can verify and
+decode directly; OCR and semantic embeddings are not part of the current
+retrieval contract. The [Roadmap](roadmap.md) describes product direction
+without turning these capability pages into an implementation tracker.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,9 +65,9 @@ retained blob has authority in the primary. A vault with remote-only content
 also needs its configured secondary stores; copying `config.toml` preserves
 binding coordinates but does not copy those bytes. Prefer `docbank backup
 create`: it reads one verified location for every logical blob and produces a
-topology-independent recovery point. Stop the daemon before taking a manual
+topology-independent recovery point. Stop the daemon before taking a local-state
 filesystem snapshot; see
-[Vault Lifecycle](usage/lifecycle.md#take-a-coherent-manual-snapshot).
+[Vault Lifecycle](usage/lifecycle.md#take-a-coherent-backup).
 
 Docbank also keeps persistent per-user coordination files under
 `~/.local/state/docbank/target-locks`, using the home directory from the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,9 +7,10 @@ description: Vault location, data layout, config.toml, and environment variables
 
 The only required knob is where the vault lives. `config.toml` is optional and
 controls the daemon's listen address, auth, idle behavior, default backup
-repository, and optional watched inboxes. The vault works without the file;
-backup commands require either a configured repository or their explicit
-`--repo` flag.
+repository, watched inboxes, and deployment bindings for secondary stores. A
+primary-only vault works without the file; every registered secondary needs a
+matching configured binding after restart. Backup commands require either a
+configured repository or their explicit `--repo` flag.
 
 ## Vault location
 
@@ -45,21 +46,28 @@ The directory layout is created on first use:
 └── daemon.<pid>.json    # runtime record of a live daemon
 ```
 
-`docbank.db` and `blobs/` together are the archive; back up both. The optional
-`.zst` suffix is only a physical encoding: hashes and reported document sizes
+`docbank.db` and `blobs/` are the local catalog and built-in primary. The
+optional `.zst` suffix is only a physical encoding: hashes and reported
+document sizes
 always describe the decoded content. Docbank chooses it for worthwhile new
 writes and continues to read existing raw files without converting them.
 `config.toml` is configuration, not archive data — optional, but back it
-up if you've customized it (it can hold an `api_key`). `vault.lock` and
+up if you've customized it (it can hold an `api_key`, filesystem paths, S3
+coordinates, and credential-profile names). `vault.lock` and
 `daemon.<pid>.json`, `web-launch/`, and `web-downloads/` are
 coordination/runtime state, safe to ignore in backups and safe to delete when
 no daemon or restore is running
 (`docbank daemon stop` removes its own record cleanly on graceful
-shutdown). The database
-references blobs by hash, so restoring a copied `docbank.db` + `blobs/`
-pair onto any machine yields a working vault — `docbank verify` proves
-the pair is consistent. Stop the daemon before taking a manual filesystem
-snapshot; see [Vault Lifecycle](usage/lifecycle.md#take-a-coherent-manual-snapshot).
+shutdown).
+
+A stopped copy of `docbank.db` plus `blobs/` is complete only when every
+retained blob has authority in the primary. A vault with remote-only content
+also needs its configured secondary stores; copying `config.toml` preserves
+binding coordinates but does not copy those bytes. Prefer `docbank backup
+create`: it reads one verified location for every logical blob and produces a
+topology-independent recovery point. Stop the daemon before taking a manual
+filesystem snapshot; see
+[Vault Lifecycle](usage/lifecycle.md#take-a-coherent-manual-snapshot).
 
 Docbank also keeps persistent per-user coordination files under
 `~/.local/state/docbank/target-locks`, using the home directory from the
@@ -69,8 +77,9 @@ vault trees, including simultaneous restores whose target trees overlap, and
 to serialize daemon launch before the launcher owns or creates the vault root.
 
 !!! warning
-    Don't edit or prune `blobs/` by hand. Blob files are referenced by
-    the database (including as prior document versions); use
+    Don't edit or prune `blobs/` or a secondary namespace by hand. Physical
+    files are authorized by the database (including for prior document
+    versions); use
     `docbank trash empty --run`, `docbank gc --run`, and (for dead packed
     payload) `docbank storage repack` to reclaim space; use `docbank verify` to
     check integrity.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,20 +8,17 @@ description: Docbank is a self-sovereign document storage system for you and you
 # Your documents. Your agents. One system.
 
 Docbank gives you and your agents one authoritative place to file, find,
-organize, version, and verify the documents you depend on. You keep the
-authority: the vault and its history live on your own machine rather than
-inside a provider account. Stable identities let people and agents reorganize
-documents without losing track of them, every stored byte can be checked, and
-incremental backups can be verified before you rely on them. Work directly
-from the CLI, automate through the authenticated HTTP API, or embed Docbank in
-a Go application. People can browse the same authority in the local web
-application or focused terminal interface; the web application verifies
-current or retained document bytes before handing them to the browser's native
-save, lets people define and assign stable tags, and keeps the vault's
-loose-file/live-packed/dead-packed storage breakdown visible alongside
-document authority. Local-first placement can also move verified content into
-configured filesystem or S3-compatible stores without turning those stores
-into the document catalog.
+organize, version, and verify the documents you depend on. Stable identities
+survive reorganization, every stored byte can be checked, and incremental
+backups can be proved before you rely on them. The catalog and history remain
+under your control instead of inside a provider account; verified content may
+stay in the built-in local primary or be deliberately placed in fenced
+filesystem and S3-compatible stores.
+
+Work directly from the CLI, browse through the local web application or TUI,
+automate through the authenticated HTTP API, or embed independently rooted
+vaults in a Go application. Every surface sees the same nodes, revisions,
+immutable versions, and content authority.
 
 Install the latest release on Linux or macOS:
 
@@ -36,6 +33,10 @@ curl -fsSL https://docbank.ai/install.sh | sh
   <a class="md-button" href="quickstart/">Ten-minute tour</a>
   <a class="md-button" href="agents/">Build agent workflows</a>
 </p>
+
+![The Docbank web application browsing a synthetic vault and showing the selected document's stable authority.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/v0.11.0/web-vault-browser.png)
+
+<p class="image-caption">A real synthetic vault in the local web application. <a href="tour/">See the visual tour.</a></p>
 
 ## What Docbank gives you
 
@@ -60,6 +61,10 @@ curl -fsSL https://docbank.ai/install.sh | sh
     <h3>Storage you can place</h3>
     <p>Keep ingest local-first, then deliberately place verified content in filesystem or S3-compatible stores without changing document identity.</p>
   </section>
+  <section>
+    <h3>Automation that fails clearly</h3>
+    <p>Stable IDs, revision preconditions, bounded pages, typed errors, and digest receipts give agents evidence instead of optimistic success.</p>
+  </section>
 </div>
 
 The ordinary workflow stays direct:
@@ -80,11 +85,12 @@ docbank backup create --repo ~/Backups/docbank # incremental snapshot
 
 ## Own the authority, not just the disk
 
-Self-sovereignty here is practical: the vault, catalog, history, and recovery
-path are under your control. Everything lives on your machine in an inspectable
-layout. Import copies files and never touches the sources, so moving a Dropbox
-or Google Drive export into Docbank is safe to attempt and repeat until it is
-complete.
+Self-sovereignty here is practical: the vault catalog, history, placement
+policy, and recovery path are under your control. The built-in primary is an
+inspectable local layout. Optional secondary stores hold verified physical
+copies but never become an independent document catalog. Import copies files
+and never touches the sources, so moving a Dropbox or Google Drive export into
+Docbank is safe to attempt and repeat until it is complete.
 
 ### Why move beyond Dropbox or Google Drive?
 
@@ -157,17 +163,11 @@ ownership rules.
 
 ## Status
 
-Docbank is alpha software. The latest release includes archives and
-checksum-enforcing installers for Linux, macOS, and Windows on amd64 and
-arm64. Implemented and tested today: the core store and ingest
-pipeline, the virtual-tree CLI, the authenticated daemon API, stable
-content versions with verified replacement, reversion, pruning, and
-lookup by content hash (`refs`), tags, permanent audited history with
-independent verification, loose and packed storage with explicit
-maintenance, whole-vault integrity verification, incremental backup
-create/verify/restore, a scoped web application, a TUI with recoverable
-trash and restore, and the embedded Go API. Docbank is not yet a
-stable 1.0; the [Roadmap](roadmap.md) gives the product direction.
+Docbank is alpha software, not yet a stable 1.0. Release archives and
+checksum-enforcing installers cover Linux, macOS, and Windows on amd64 and
+arm64. The [Capabilities](capabilities.md) page is the current product map;
+the [Roadmap](roadmap.md) describes high-level direction rather than acting as
+an implementation tracker.
 
 Docbank belongs to a family of personal data tools alongside
 [msgvault](https://msgvault.io), the communications archive. Where msgvault
@@ -178,6 +178,8 @@ documents: files you still organize, retrieve, and build workflows around.
 
 - [Setup](setup.md): install the binary and create the vault
 - [Quickstart](quickstart.md): a ten-minute tour of the CLI
+- [Capabilities](capabilities.md): the complete human-readable product map
+- [Visual Tour](tour.md): real web and terminal interfaces on synthetic data
 - [Vault Lifecycle](usage/lifecycle.md): operate, snapshot, and recover safely
 - [Web Application](usage/web.md): browse, search, upload, download, and manage recoverable trash
 - [Docbank for Agents](agents.md): the automation contract

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -13,6 +13,8 @@ Every documentation page is also published as raw Markdown at the same path with
 ## Start Here
 - [Setup](https://docbank.ai/setup.md): Install docbank on Linux, macOS, or Windows and create the vault.
 - [Quickstart](https://docbank.ai/quickstart.md): A ten-minute tour of the docbank CLI.
+- [Capabilities](https://docbank.ai/capabilities.md): What Docbank does for people, agents, applications, recovery, and physical storage.
+- [Visual Tour](https://docbank.ai/tour.md): See Docbank's real web and terminal interfaces running against synthetic document vaults.
 
 ## Work with Documents
 - [Importing Documents](https://docbank.ai/usage/importing.md): Bulk import semantics — recursion, idempotency, collision suffixing, and failure handling.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -252,6 +252,8 @@ replaced. See [Backup & Restore](usage/backup.md) for progress modes, snapshot
 selection, overwrite rules, and the exact proof returned by restore.
 
 That is the core document workflow. Continue with
+[Capabilities](capabilities.md) for the complete product map, see the real
+interfaces in the [Visual Tour](tour.md), continue with
 [Vault Lifecycle](usage/lifecycle.md) for maintenance and upgrades, explore
 [Docbank for Agents](agents.md) for automation, or use the
 [CLI Reference](cli-reference.md) for exact command semantics.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -109,6 +109,19 @@
   margin: 1.4rem 0 2rem;
 }
 
+.md-typeset .image-caption {
+  margin: -0.65rem 0 2rem;
+  color: var(--db-muted);
+  font-size: 0.72rem;
+  text-align: center;
+}
+
+.md-typeset img {
+  border: 1px solid var(--db-border);
+  border-radius: 4px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
 .md-typeset .md-button {
   border-color: var(--db-border-strong);
   border-radius: 2px;

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,0 +1,58 @@
+---
+title: Visual Tour
+description: See Docbank's real web and terminal interfaces running against synthetic document vaults.
+---
+
+# Visual tour
+
+These are the actual Docbank interfaces backed by temporary synthetic vaults,
+not mockups. The names, contents, hashes, identifiers, storage history, and
+audit history were generated for the captures.
+
+## Browse one shared document authority
+
+The local web application combines a sortable document table with the selected
+node's current path, stable ID, revision, immutable version, SHA-256 identity,
+tags, provenance, and permanent-audit status. The browser receives scoped,
+daemon-lifetime credentials rather than the daemon's master API key.
+
+![The Docbank web application browsing a synthetic vault and showing the selected document's stable authority.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/v0.11.0/web-vault-browser.png)
+
+## Organize independently of folders
+
+Tags form a shared vocabulary with stable UUIDs and revision-protected
+definitions. People can manage the catalog or a selected document's
+assignments in the web application; agents use the same bounded daemon API.
+
+![The Docbank web application managing a synthetic vault's stable tag catalog.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-tag-catalog/web-tag-catalog.png)
+
+## Verify permanent history
+
+An audited scope permanently retains its protected versions and supported
+changes. Independent verification replays the history, re-hashes protected
+content, and returns terminal scope heads that can be recorded outside the
+vault for later comparison.
+
+![The Docbank web application showing independently verified permanent audit evidence for a synthetic vault.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-audit-evidence/web-audit-evidence.png)
+
+## See where physical authority lives
+
+The document catalog remains authoritative while verified content can occupy a
+fixed local primary and configured filesystem or S3-compatible secondaries.
+The web view is deliberately read-only: it separates logical authority,
+physical inventory, store health, sole copies, and live-document impact without
+exposing deployment paths or credentials.
+
+![The Docbank web application showing the primary and a secondary physical store for a synthetic vault.](https://raw.githubusercontent.com/kenn-io/docbank/f1475f1a97d4d2d5b2bb2625ff2f5f97150a9625/.superpowers/screenshots/web-multi-store-storage.png)
+
+## Operate from a terminal
+
+The daemon-backed TUI provides analytical tree and search views, complete
+document identity, permanent history, recoverable trash and restore, job
+status, and a read-only operational screen. Storage and backup results load
+independently so one unavailable repository does not hide live-vault status.
+
+![The Docbank TUI showing physical storage inventory and two synthetic backup recovery points.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/tui-storage-backup/tui-storage-backup.png)
+
+Continue with the [Quickstart](quickstart.md), or choose a task from
+[Capabilities](capabilities.md).

--- a/docs/usage/audited-history.md
+++ b/docs/usage/audited-history.md
@@ -29,6 +29,8 @@ including records outside the selected directory. Those unrelated documents
 do not become audit members and their content versions are not protected by
 the scope, but the enrollment-time metadata remains part of the evidence.
 
+![The Docbank web application showing independently verified permanent audit evidence for a synthetic vault.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-audit-evidence/web-audit-evidence.png)
+
 ## Review before enabling
 
 Enrollment is always a separate preview and execution. Preview does not change

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -118,8 +118,21 @@ verify`, and `backup restore` for incremental capture and proved recovery from
 an immutable Kit repository; see [Backup](backup.md). Those repositories are
 compressed but **not encrypted**.
 
-A stopped-vault copy remains a simple alternative. Stop the daemon before
-copying so the SQLite database and blob catalog cannot change during the copy.
+A stopped-vault copy remains a simple alternative when every retained blob has
+authority in the built-in primary. Check placement before relying on this path:
+
+```bash
+docbank storage list
+docbank storage status
+```
+
+If any content is held only by a secondary, use `docbank backup create` instead;
+it reads one verified candidate for every logical blob and produces a complete,
+topology-independent recovery point. Merely copying `config.toml` preserves
+binding coordinates, not secondary bytes.
+
+For a primary-complete vault, stop the daemon before copying so the SQLite
+database and blob catalog cannot change during the copy.
 
 ```bash
 vault="${DOCBANK_HOME:-$HOME/.docbank}"
@@ -128,9 +141,9 @@ tar -C "$(dirname "$vault")" -czf "docbank-$(date +%F).tar.gz" "$(basename "$vau
 docbank daemon start
 ```
 
-The whole directory is the simplest snapshot. The essential archive state is
-`docbank.db` plus `blobs/`; `config.toml` is worth retaining when customized.
-Logs, lock files, and stale runtime records are not archive data.
+The whole directory is the simplest primary-complete snapshot. Its archive
+state is `docbank.db` plus `blobs/`; `config.toml` is worth retaining when
+customized. Logs, lock files, and stale runtime records are not archive data.
 
 Protect the snapshot like the vault itself: document contents and a configured
 API key may both be present. Test restoration into a separate
@@ -158,16 +171,25 @@ store through its normal daemon boundary.
 
 ## Move a vault
 
-1. Stop the source daemon.
-2. Copy the complete vault directory while it is stopped.
-3. Point `DOCBANK_HOME` at the copy on the destination machine.
+The portable path is a verified backup restore:
+
+1. Create and verify a snapshot repository.
+2. Restore into a separate target on the destination machine.
+3. Point `DOCBANK_HOME` at that target.
 4. Run `docbank verify`, then `docbank tree /`.
 5. Start using the destination only after both checks succeed.
 
-The database refers to content by hash rather than absolute filesystem path,
-so no path rewriting is required. Linux, macOS, and Windows can open the same
-logical vault format. When moving between filesystems, copy while stopped and
-run both verification commands before treating the destination as authoritative.
+Default restore collapses every source location into a fresh local primary, so
+the destination does not inherit source paths, endpoints, credentials, or
+ownership epochs. Use an owner-private store mapping only when deliberately
+reconstructing selected placement; see
+[Multi-store Storage](storage.md#backup-and-restore).
+
+For a primary-complete vault, a stopped directory copy is also valid: stop the
+source daemon, copy the complete vault directory, and run the same two checks.
+Linux, macOS, and Windows share the logical vault format. A copied customized
+`config.toml` may contain machine-specific watched paths, secondary bindings,
+or credential profiles; review it before starting the destination daemon.
 
 ## When something looks wrong
 

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -119,17 +119,25 @@ an immutable Kit repository; see [Backup](backup.md). Those repositories are
 compressed but **not encrypted**.
 
 A stopped-vault copy remains a simple alternative when every retained blob has
-authority in the built-in primary. Check placement before relying on this path:
+authority in the built-in primary. Prove that condition from the machine-readable
+reports before relying on this path:
 
 ```bash
-docbank storage list
-docbank storage status
+docbank info --json
+docbank storage list --json
 ```
 
-If any content is held only by a secondary, use `docbank backup create` instead;
-it reads one verified candidate for every logical blob and produces a complete,
+Find the store whose `role` is `primary`. Its `authoritative_objects` must equal
+`tracked_blobs` from `docbank info`; only that equality proves every tracked
+blob has a primary location. Do not infer completeness from
+`sole_authority_objects`: a blob held by two secondaries and absent from the
+primary is not a sole copy in either store. If the counts differ or you cannot
+establish the equality, use `docbank backup create` instead. It reads one
+verified candidate for every logical blob and produces a complete,
 topology-independent recovery point. Merely copying `config.toml` preserves
-binding coordinates, not secondary bytes.
+binding coordinates, not secondary bytes. See
+[Prove primary completeness](storage.md#prove-primary-completeness) for the
+count invariant.
 
 For a primary-complete vault, stop the daemon before copying so the SQLite
 database and blob catalog cannot change during the copy.

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -111,36 +111,41 @@ For unattended installation, use `docbank update --yes`; do not use `--force`
 as a routine upgrade flag. It exists to bypass cached release metadata and to
 allow replacing an unversioned development build.
 
-## Take a coherent manual snapshot
+## Take a coherent backup
 
 Docbank provides `backup init`, `backup create`, `backup list`, `backup
 verify`, and `backup restore` for incremental capture and proved recovery from
 an immutable Kit repository; see [Backup](backup.md). Those repositories are
 compressed but **not encrypted**.
 
-A stopped-vault copy remains a simple alternative when every retained blob has
-authority in the built-in primary. Prove that condition from the machine-readable
-reports before relying on this path:
+A stopped-vault copy captures the SQLite database and built-in primary as a
+coherent local-state snapshot. It is not a topology-independent backup: any
+blob held only by a secondary store is absent. The live reports can help
+diagnose primary coverage:
 
 ```bash
 docbank info --json
 docbank storage list --json
 ```
 
-Find the store whose `role` is `primary`. Its `authoritative_objects` must equal
-`tracked_blobs` from `docbank info`; only that equality proves every tracked
-blob has a primary location. Do not infer completeness from
-`sole_authority_objects`: a blob held by two secondaries and absent from the
-primary is not a sole copy in either store. If the counts differ or you cannot
-establish the equality, use `docbank backup create` instead. It reads one
-verified candidate for every logical blob and produces a complete,
-topology-independent recovery point. Merely copying `config.toml` preserves
-binding coordinates, not secondary bytes. See
-[Prove primary completeness](storage.md#prove-primary-completeness) for the
-count invariant.
+Find the store whose `role` is `primary`. Its `authoritative_objects` can be
+compared with `tracked_blobs` from `docbank info`, but the reports are separate
+live snapshots. Watches, ingests, clients, and storage jobs can change either
+count between requests and before daemon shutdown, so matching values are not
+a backup-completeness proof. `sole_authority_objects` is weaker still: a blob
+held by two secondaries and absent from the primary is not a sole copy in
+either store.
 
-For a primary-complete vault, stop the daemon before copying so the SQLite
-database and blob catalog cannot change during the copy.
+Use `docbank backup create` for a complete recovery point. It reads one
+verified candidate for every logical blob and fails rather than publishing a
+partial snapshot. Merely copying `config.toml` preserves binding coordinates,
+not secondary bytes. See [Understand primary coverage](storage.md#understand-primary-coverage)
+for the reporting boundary.
+
+If you deliberately need a local-state snapshot, first stop every producer,
+watch, storage job, and client, then stop the daemon before copying so the
+SQLite database and primary catalog cannot change during the copy. Do not use
+this procedure as a complete backup when the vault has used secondary storage.
 
 ```bash
 vault="${DOCBANK_HOME:-$HOME/.docbank}"

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -80,6 +80,8 @@ Tags organize documents independently of their current paths. Each tag has a
 stable UUID; its name can change without breaking assignments or agent-held
 references.
 
+![The Docbank web application managing a synthetic vault's stable tag catalog.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/web-tag-catalog/web-tag-catalog.png)
+
 ```bash
 docbank tag create taxes
 docbank tag assign taxes /taxes/2026/w2.pdf

--- a/docs/usage/storage.md
+++ b/docs/usage/storage.md
@@ -16,6 +16,12 @@ records which verified stores may satisfy each retained SHA-256 identity, but
 it does not mirror arbitrary filesystem changes, manage bucket lifecycle
 rules, or replace a complete [backup](backup.md).
 
+![The Docbank web application showing the primary and a secondary physical store for a synthetic vault.](https://raw.githubusercontent.com/kenn-io/docbank/f1475f1a97d4d2d5b2bb2625ff2f5f97150a9625/.superpowers/screenshots/web-multi-store-storage.png)
+
+The web application and TUI expose this inventory read-only. Registration,
+placement, repair, takeover, evacuation, and removal remain explicit CLI or
+master-key API operations.
+
 ## Configure a binding
 
 Bindings are machine-local deployment configuration. Paths, endpoints,

--- a/docs/usage/storage.md
+++ b/docs/usage/storage.md
@@ -100,23 +100,25 @@ is currently offline, so two unavailable replicas do not misleadingly look
 readable. Missing, corrupt, fenced, unavailable, and unbound states remain
 distinct because their recovery actions differ.
 
-### Prove primary completeness
+### Understand primary coverage
 
-A stopped copy of the local database and built-in blob directory is complete
-only when every tracked blob has a primary location. Compare two typed reports:
+Two typed reports expose the counts used to diagnose primary coverage:
 
 ```bash
 docbank info --json
 docbank storage list --json
 ```
 
-The `authoritative_objects` value for the store whose `role` is `primary` must
-equal `tracked_blobs` from `docbank info`. A primary has at most one location
-for each tracked SHA-256 identity, so equality proves complete primary
-coverage. A lower count requires `docbank backup create` for a complete
-topology-independent recovery point. `sole_authority_objects` cannot prove
-primary completeness because two secondary replicas can make neither one a
-sole copy while the primary still has no location.
+The `authoritative_objects` value for the store whose `role` is `primary` can
+be compared with `tracked_blobs` from `docbank info`. A lower primary count is
+a warning that content is held elsewhere. Matching counts are not an atomic
+proof: the endpoints use separate live snapshots, and watches, ingests,
+clients, or storage jobs can change placement before shutdown.
+`sole_authority_objects` cannot establish coverage either because two
+secondary replicas can make neither one a sole copy while the primary still
+has no location. Use `docbank backup create` for a complete,
+topology-independent recovery point; it verifies one authorized location for
+every logical blob or fails without publishing a partial backup.
 
 ## Place retained content
 

--- a/docs/usage/storage.md
+++ b/docs/usage/storage.md
@@ -100,6 +100,24 @@ is currently offline, so two unavailable replicas do not misleadingly look
 readable. Missing, corrupt, fenced, unavailable, and unbound states remain
 distinct because their recovery actions differ.
 
+### Prove primary completeness
+
+A stopped copy of the local database and built-in blob directory is complete
+only when every tracked blob has a primary location. Compare two typed reports:
+
+```bash
+docbank info --json
+docbank storage list --json
+```
+
+The `authoritative_objects` value for the store whose `role` is `primary` must
+equal `tracked_blobs` from `docbank info`. A primary has at most one location
+for each tracked SHA-256 identity, so equality proves complete primary
+coverage. A lower count requires `docbank backup create` for a complete
+topology-independent recovery point. `sole_authority_objects` cannot prove
+primary completeness because two secondary replicas can make neither one a
+sole copy while the primary still has no location.
+
 ## Place retained content
 
 Preview a copy while keeping the primary:

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -18,6 +18,8 @@ outlive the background daemon's idle window, so each bounded interaction
 rediscovers or restarts a compatible daemon before issuing its request; leaving
 the terminal open does not pin an otherwise idle process.
 
+![The Docbank TUI showing physical storage inventory and two synthetic backup recovery points.](https://raw.githubusercontent.com/kenn-io/docbank/docs-assets/screenshots/tui-storage-backup/tui-storage-backup.png)
+
 The main view is a full-width document table. At ordinary terminal widths it
 shows each document's name, type, size, and UTC modification time; search results
 also identify the match kind when space permits. Narrow terminals progressively

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -16,6 +16,8 @@ nav = [
   {"Start Here" = [
     {"Setup" = "setup.md"},
     {"Quickstart" = "quickstart.md"},
+    {"Capabilities" = "capabilities.md"},
+    {"Visual Tour" = "tour.md"},
   ]},
   {"Work with Documents" = [
     {"Importing Documents" = "usage/importing.md"},

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	go.kenn.io/kit v0.17.0
+	go.kenn.io/kit v0.17.1-0.20260801111754-c8a9bbae483d
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.kenn.io/kit v0.17.0 h1:u9F8ubpVnMLcKiKRq2kyEplp9PkdujmUKsJc0kWEwWQ=
 go.kenn.io/kit v0.17.0/go.mod h1:SXD5SAxpYlH65wmBnfNqr5Za3NVFzKWJph+Sobx/ZMA=
+go.kenn.io/kit v0.17.1-0.20260801111754-c8a9bbae483d h1:ov+R8uwB9OvoDjyhRqr8v0x7NUQsHoLb3O4EKGBQk6s=
+go.kenn.io/kit v0.17.1-0.20260801111754-c8a9bbae483d/go.mod h1:SXD5SAxpYlH65wmBnfNqr5Za3NVFzKWJph+Sobx/ZMA=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -177,7 +177,7 @@ func (s *Store) detachRuntimeStore(id string) {
 // recovery. The caller owns and must close the returned backend.
 func (s *Store) SalvageBackend(
 	ctx context.Context, id packstore.StoreID,
-) (packstore.Backend, error) {
+) (packstore.ReadBackend, error) {
 	if s.registry == nil {
 		return nil, fmt.Errorf("%w: store registry is unavailable", packstore.ErrStoreUnavailable)
 	}

--- a/internal/blob/placement.go
+++ b/internal/blob/placement.go
@@ -425,7 +425,7 @@ func (r PlacementRunner) runRecovery(
 			return r.fail(ctx, operation.ID, packstore.ErrStoreUnavailable)
 		}
 		moved, err := packstore.Move(
-			ctx, readBackendOnly{ReadBackend: source}, destination,
+			ctx, source, destination,
 			packstore.MoveRequest{
 				Source:      sourceLocation,
 				Destination: packstore.StoreID(plan.Destination),
@@ -578,7 +578,7 @@ func verifyRepairedLoose(
 	return nil
 }
 
-func closePlacementBackend(backend packstore.Backend) error {
+func closePlacementBackend(backend packstore.ReadBackend) error {
 	if closer, ok := backend.(interface{ Close() error }); ok {
 		return closer.Close()
 	}

--- a/internal/blob/registry.go
+++ b/internal/blob/registry.go
@@ -233,7 +233,7 @@ func (r *Registry) refresh(ctx context.Context, id string) StoreObservation {
 // recovery. It never admits publication, retirement, or ordinary reads.
 func (r *Registry) SalvageBackend(
 	ctx context.Context, id packstore.StoreID,
-) (packstore.Backend, error) {
+) (packstore.ReadBackend, error) {
 	r.mu.RLock()
 	spec, known := r.specs[id]
 	observation := r.observations[id]
@@ -250,8 +250,34 @@ func (r *Registry) SalvageBackend(
 	if !bound || binding.Kind != spec.Kind {
 		return nil, fmt.Errorf("salvage store %s has no usable binding", id)
 	}
-	return r.openBackend(ctx, binding, nil)
+	inspector, err := r.openBackend(ctx, binding, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open salvage store %s for inspection: %w", id, err)
+	}
+	actual, ownershipErr := inspector.Ownership(ctx)
+	closeErr := closeBackend(inspector)
+	if ownershipErr != nil || closeErr != nil {
+		return nil, fmt.Errorf(
+			"inspect salvage store %s ownership: %w",
+			id, errors.Join(ownershipErr, closeErr),
+		)
+	}
+	backend, err := r.openBackend(ctx, binding, &actual)
+	if err != nil {
+		return nil, fmt.Errorf("open salvage store %s for verified reads: %w", id, err)
+	}
+	return salvageReadBackend{ReadBackend: backend, backend: backend}, nil
 }
+
+// salvageReadBackend deliberately withholds publication and retirement from
+// fenced-store recovery while retaining ownership of the underlying reader.
+type salvageReadBackend struct {
+	packstore.ReadBackend
+
+	backend packstore.Backend
+}
+
+func (b salvageReadBackend) Close() error { return closeBackend(b.backend) }
 
 // AttachSpec makes a newly committed catalog store available to this daemon
 // without reloading deployment configuration.

--- a/internal/blob/registry.go
+++ b/internal/blob/registry.go
@@ -68,6 +68,7 @@ type Registry struct {
 	vaultID     string
 	bindings    map[string]config.StoreBindingConfig
 	openBackend configuredBackendFactory
+	openSalvage configuredBackendFactory
 	specs       map[packstore.StoreID]StoreSpec
 	backends    map[packstore.StoreID]packstore.Backend
 	// Kit's backend registry has no release callback. Once a backend has been
@@ -89,7 +90,10 @@ func NewRegistry(
 	bindings map[string]config.StoreBindingConfig,
 	stores []StoreSpec,
 ) *Registry {
-	return newRegistry(ctx, vaultID, bindings, stores, newAttachedConfiguredBackend)
+	return newRegistryWithFactories(
+		ctx, vaultID, bindings, stores,
+		newAttachedConfiguredBackend, newSalvageConfiguredBackend,
+	)
 }
 
 func newAttachedConfiguredBackend(
@@ -140,8 +144,22 @@ func newRegistry(
 	stores []StoreSpec,
 	openBackend configuredBackendFactory,
 ) *Registry {
+	return newRegistryWithFactories(
+		ctx, vaultID, bindings, stores, openBackend, openBackend,
+	)
+}
+
+func newRegistryWithFactories(
+	ctx context.Context,
+	vaultID string,
+	bindings map[string]config.StoreBindingConfig,
+	stores []StoreSpec,
+	openBackend configuredBackendFactory,
+	openSalvage configuredBackendFactory,
+) *Registry {
 	registry := &Registry{
-		vaultID: vaultID, bindings: bindings, openBackend: openBackend,
+		vaultID: vaultID, bindings: bindings,
+		openBackend: openBackend, openSalvage: openSalvage,
 		specs:        make(map[packstore.StoreID]StoreSpec, len(stores)),
 		backends:     make(map[packstore.StoreID]packstore.Backend, len(stores)),
 		observations: make(map[packstore.StoreID]StoreObservation, len(stores)),
@@ -262,7 +280,7 @@ func (r *Registry) SalvageBackend(
 			id, errors.Join(ownershipErr, closeErr),
 		)
 	}
-	backend, err := r.openBackend(ctx, binding, &actual)
+	backend, err := r.openSalvage(ctx, binding, &actual)
 	if err != nil {
 		return nil, fmt.Errorf("open salvage store %s for verified reads: %w", id, err)
 	}
@@ -598,6 +616,20 @@ func NewInspectionBackend(
 	return NewConfiguredBackend(ctx, binding, nil)
 }
 
+func newSalvageConfiguredBackend(
+	ctx context.Context,
+	binding config.StoreBindingConfig,
+	expected *packstore.Ownership,
+) (packstore.Backend, error) {
+	if expected == nil {
+		return nil, errors.New("salvage backend requires observed ownership")
+	}
+	if binding.Kind == storeKindFilesystem {
+		return newFilesystemBackend(binding.Path, expected, false)
+	}
+	return NewConfiguredBackend(ctx, binding, expected)
+}
+
 // EnsureFilesystemNamespace securely creates or repairs one filesystem store
 // before registration or restore changes its ownership marker.
 func EnsureFilesystemNamespace(path string) error {
@@ -662,7 +694,7 @@ func checkFilesystemScaffolding(root string, check func(string) error) error {
 
 // NewConfiguredBackend constructs one deployment backend without granting
 // catalog authority. Expected ownership enables destructive work; nil is
-// reserved for registration and explicit fenced-store salvage.
+// reserved for registration and ownership inspection.
 func NewConfiguredBackend(
 	ctx context.Context,
 	binding config.StoreBindingConfig,

--- a/internal/blob/registry_test.go
+++ b/internal/blob/registry_test.go
@@ -562,7 +562,7 @@ func TestRegistrySecuresOwnedFilesystemScaffoldingOnAttachment(t *testing.T) {
 	require.NoError(t, safefileio.ValidatePrivateDir(shard))
 }
 
-func TestRegistryDoesNotRepairMismatchedFilesystemNamespace(t *testing.T) {
+func TestRegistryDoesNotRepairFencedFilesystemNamespace(t *testing.T) {
 	const (
 		vaultID = "10000000-0000-4000-8000-000000000001"
 		storeID = "20000000-0000-4000-8000-000000000001"
@@ -592,6 +592,12 @@ func TestRegistryDoesNotRepairMismatchedFilesystemNamespace(t *testing.T) {
 		}})
 	t.Cleanup(func() { require.NoError(t, registry.Close()) })
 	assert.Equal(t, StoreFenced, registry.Observation(storeID).State)
+	require.Error(t, safefileio.ValidatePrivateDir(shard))
+	salvage, err := registry.SalvageBackend(t.Context(), storeID)
+	require.NoError(t, err)
+	closer, ok := salvage.(interface{ Close() error })
+	require.True(t, ok)
+	require.NoError(t, closer.Close())
 	require.Error(t, safefileio.ValidatePrivateDir(shard))
 }
 

--- a/internal/blob/registry_test.go
+++ b/internal/blob/registry_test.go
@@ -65,6 +65,54 @@ func TestRegistryClassifiesBindingsAndOwnership(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestRegistryReopensFencedStoreAgainstObservedOwnershipForSalvage(t *testing.T) {
+	const (
+		vaultID = "10000000-0000-4000-8000-000000000001"
+		storeID = "20000000-0000-4000-8000-000000000001"
+		epoch   = "30000000-0000-4000-8000-000000000001"
+	)
+	taken := packstore.Ownership{
+		Format: packstore.OwnershipFormatV1,
+		Vault:  "10000000-0000-4000-8000-000000000099",
+		Store:  storeID,
+		Epoch:  "30000000-0000-4000-8000-000000000099",
+	}
+	var openings []*packstore.Ownership
+	registry := newRegistry(t.Context(), vaultID,
+		map[string]config.StoreBindingConfig{
+			"archive": {Kind: storeKindFilesystem, Path: t.TempDir()},
+		}, []StoreSpec{{
+			ID: storeID, Kind: storeKindFilesystem, Role: "secondary",
+			Lifecycle: "active", Binding: "archive", OwnershipEpoch: epoch,
+		}}, func(
+			_ context.Context,
+			_ config.StoreBindingConfig,
+			expected *packstore.Ownership,
+		) (packstore.Backend, error) {
+			if expected == nil {
+				openings = append(openings, nil)
+			} else {
+				expectedOwnership := *expected
+				openings = append(openings, &expectedOwnership)
+			}
+			return &staticOwnershipBackend{ownership: taken}, nil
+		})
+	t.Cleanup(func() { require.NoError(t, registry.Close()) })
+	require.Equal(t, StoreFenced, registry.Observation(storeID).State)
+
+	salvage, err := registry.SalvageBackend(t.Context(), storeID)
+	require.NoError(t, err)
+	_, exposesWrites := salvage.(packstore.Backend)
+	assert.False(t, exposesWrites)
+	require.Len(t, openings, 3)
+	assert.Nil(t, openings[1])
+	require.NotNil(t, openings[2])
+	assert.Equal(t, taken, *openings[2])
+	closer, ok := salvage.(interface{ Close() error })
+	require.True(t, ok)
+	require.NoError(t, closer.Close())
+}
+
 func TestRegistryKeepsAcquiredBackendUsableAcrossConcurrentRefresh(t *testing.T) {
 	const (
 		vaultID = "10000000-0000-4000-8000-000000000001"


### PR DESCRIPTION
Docbank now tells a coherent story to a new reader: it is one document authority for people, agents, and embedded applications, with stable identity, verifiable content, deliberate lifecycle, permanent evidence, and physical storage that can extend beyond the local disk.

The README and homepage lead with that outcome instead of asking readers to decode a long implementation inventory. A new capability guide explains the complete product in task-oriented language, while a visual tour connects the web application and TUI to concrete workflows such as tag organization, permanent-audit verification, backup inspection, and multi-store health.

![Docbank showing the physical authority for a synthetic multi-store vault](https://raw.githubusercontent.com/kenn-io/docbank/f1475f1a97d4d2d5b2bb2625ff2f5f97150a9625/.superpowers/screenshots/web-multi-store-storage.png)

This also fixes an important recovery boundary introduced by multi-store placement. The docs no longer imply that `docbank.db` plus the local `blobs/` directory is always a complete archive: that manual copy is complete only while every retained blob still has primary authority. The built-in backup workflow is now presented as the portable, topology-independent path for vaults with remote-only content.

The visual set was reviewed as a whole and uses five distinct captures from real temporary synthetic vaults. I kept the views that explain a durable capability and left out the older TUI storage capture that foregrounded a partial result and an unconfigured backup error, which would make a poor first explanation of the product.

Release CI also exposed a real fenced-store salvage defect from the just-merged multi-store work: Kit refuses reads from unattached backends, while Docbank had opened salvage that way. This branch now inspects the live marker, reopens against that observed epoch, and hands the recovery worker a read-only interface; independently verified content can be copied back without granting publication or retirement authority.
