### PR TITLE
Pin Kit v0.17.1 before release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	go.kenn.io/kit v0.17.1-0.20260801111754-c8a9bbae483d
+	go.kenn.io/kit v0.17.1
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -150,10 +150,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.kenn.io/kit v0.17.0 h1:u9F8ubpVnMLcKiKRq2kyEplp9PkdujmUKsJc0kWEwWQ=
-go.kenn.io/kit v0.17.0/go.mod h1:SXD5SAxpYlH65wmBnfNqr5Za3NVFzKWJph+Sobx/ZMA=
-go.kenn.io/kit v0.17.1-0.20260801111754-c8a9bbae483d h1:ov+R8uwB9OvoDjyhRqr8v0x7NUQsHoLb3O4EKGBQk6s=
-go.kenn.io/kit v0.17.1-0.20260801111754-c8a9bbae483d/go.mod h1:SXD5SAxpYlH65wmBnfNqr5Za3NVFzKWJph+Sobx/ZMA=
+go.kenn.io/kit v0.17.1 h1:ycQ7IpI3tIDaZ3h3rH5bLtSZY5PCkW2DyjqaqW6BEp0=
+go.kenn.io/kit v0.17.1/go.mod h1:SXD5SAxpYlH65wmBnfNqr5Za3NVFzKWJph+Sobx/ZMA=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=


### PR DESCRIPTION
Docbank can now ship with a stable Kit dependency instead of the temporary commit used while multi-store S3 registration was being hardened.

Kit v0.17.1 contains the complete probe correction: compatible endpoints no longer fail because a stale precondition races a large request body, while an endpoint that applies a stale write but claims `412 Precondition Failed` is still detected during read-back verification. This matters because Docbank uses that probe before trusting a secondary S3-compatible store.

The tagged dependency completed Docbank’s real MinIO placement lifecycle ten consecutive times, and both supported SQLite modes remain green.