### PR TITLE
Publish the v0.12.0 changelog

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -105,16 +105,19 @@ Key assumptions reviewers MUST account for:
    archive verification or make the served copy diverge from
    scripts/.
 
-12. DOCS ARE THE NEXT RELEASE SNAPSHOT: user-facing sources on main
-   describe every merged capability directly in present tense, including
-   homepage and install-adjacent copy. The public Zensical site is
-   published only from release tags, so readers cannot encounter that
-   source snapshot through docbank.ai until the corresponding binary is
-   released. Do not demand "next release", source-build-only, or newest-tag
-   qualifiers for merged capabilities; AGENTS.md explicitly forbids them.
-   DO flag release preparation that would tag documentation for behavior
-   absent from the same tag, or documentation that claims behavior absent
-   from main.
+12. DOCS FOLLOW THE RELEASE BOUNDARY: user-facing sources on main describe
+   every merged capability directly in present tense, including homepage and
+   install-adjacent copy. The public Zensical site is not deployed until the
+   corresponding binary release is tagged, so do not demand "next release",
+   source-build-only, or newest-tag qualifiers for merged capabilities.
+   Release preparation must ensure capability documentation matches the binary
+   being tagged. After the tag and GitHub release exist, the finalized release
+   notes and date are intentionally added to docs/changelog.md in a docs-only
+   follow-up PR, and the website is deployed from the resulting main commit.
+   That changelog commit is necessarily absent from the preceding software tag;
+   DO NOT report that absence or demand another release tag. DO flag a
+   post-release docs change that advertises behavior absent from the released
+   binary, or a pre-release deployment that exposes unreleased behavior.
 
 13. EXTERNAL STORE CONFIDENTIALITY IS A DOCUMENTED DEPLOYMENT BOUNDARY:
    filesystem and S3 secondary objects preserve Kit's physical encoding and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,16 +97,22 @@ Instructions for autonomous coding agents working in this repository.
   must not carry task breakdowns, sequencing, ownership, or completion
   criteria. `docs/roadmap.md` is the one high-level public product-status view;
   kata is the sole source of truth for actionable work and its status.
-- Documentation is published only from release tags. There is no rendered
-  preview, deployment, or other public documentation build of `main`; the
-  release tag is the first publication boundary. Treat public-doc sources on
-  `main` as the candidate documentation for the next release, not as a live
-  view of the latest published binary or a separately supported publication.
-  Once a capability merges, describe it directly in present tense so the
-  source tree is coherent when the next tag publishes it; do not add "next
-  release", source-build availability, or other feature-timing annotations.
-  Release preparation must verify that every documented capability is present
-  in the tag; defer documentation for anything that will not ship.
+- Public documentation deployment is gated by the corresponding software
+  release tag. There is no rendered preview or public deployment of candidate
+  feature documentation before that binary is tagged. Treat public-doc sources
+  on `main` as the candidate documentation for the next release, not as a live
+  view of an unreleased binary. Once a capability merges, describe it directly
+  in present tense; do not add "next release", source-build availability, or
+  other feature-timing annotations. Release preparation must verify that every
+  documented capability is present in the tag and defer documentation for
+  anything that will not ship.
+- The release's own changelog entry is intentionally added after the tag and
+  GitHub release exist, in a documentation-only follow-up PR using the final
+  published notes and date. Wording-only corrections found during that pass may
+  ship with it. The website is then deployed from the resulting `main` commit.
+  That post-tag documentation commit is not expected to be contained in the
+  software tag and does not require a second patch release, provided it does
+  not advertise product behavior absent from the released binary.
 - v0.9.0 is the first released storage compatibility boundary. Preserve vaults
   created by every supported public release across upgrades. When a released
   SQLite layout is incompatible with the current schema, export its logical

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -13,8 +13,10 @@ description: The permanent, tamper-evident history model for protected directory
     and checks every protected blob; supplied external evidence is proved as an
     exact prefix of current allocation and scope chains. Scope-wide browsing is
     available. A shared tag-definition rename or deletion advances every
-    affected disjoint scope atomically. Overlapping scopes, cross-scope
-    topology changes, and TUI/web projections remain planned. See
+    affected disjoint scope atomically. The web application exposes read-only
+    protection status, node history, and independent verification evidence;
+    the TUI exposes node history. Overlapping scopes and cross-scope topology
+    changes remain planned. See
     [Permanent Audited History](../usage/audited-history.md) for the current
     operator workflow.
 

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -1441,33 +1441,36 @@ workflow. The ordinary overwrite form of `docbank backup restore` rejects it.
 
 ## One history model, several clients
 
-The daemon API owns one bounded, cursor-paginated representation for audit
-scope status, events, content versions, comparisons, and chain verification.
-CLI, agents, TUI, and web clients consume that same model; none opens SQLite or
-the blob store directly. Status and terminal verification proofs expose the
-stable vault ID, every scope count/head, and allocation-lineage count/head as one
-evidence bundle suitable for external recording and later expected-state checks.
+The daemon API owns the current audit status, bounded node-history, and
+independent verification representations. CLI, agents, TUI, and web clients
+consume those models; none opens SQLite or the blob store directly. Status and
+terminal verification proofs expose the stable vault ID, every scope
+count/head, and allocation-lineage count/head as one evidence bundle suitable
+for external recording and later expected-state checks.
 
-The event order is canonical and total, while clients project it in three
-useful ways:
+The event order is canonical and total. The model supports three projections,
+with current client availability described below:
 
 - a **scope timeline** aggregates changes to every sticky member;
 - a **node timeline** follows one stable document or directory across paths;
   and
 - a **version history** filters to content heads and reversions.
 
-Interactive clients show newest first by default, but cursors preserve stable
-forward/backward traversal and chain verification reads canonical order.
+Interactive node-history clients show newest first by default, but cursors
+preserve stable forward/backward traversal and chain verification reads
+canonical order.
 Events committed in one metadata transaction share an operation identity. A
 multi-transaction command such as recursive ingest shares only its grouping ID;
 clients may visually group either level without collapsing individual node
 events or presenting the group as one atomic mutation.
 
-Comparison is type-aware but never invents semantic equivalence. Plain text
-and canonical metadata can render inline or side by side. Images and PDFs may
-render side by side when a safe viewer is available. Office and unknown binary
-formats start with hash, size, media type, and metadata changes plus verified
-download/open actions; richer format-aware comparison can be added later.
+!!! info "Planned"
+    Scope timelines and version comparison will use the same canonical event
+    model. Comparison will be type-aware without inventing semantic
+    equivalence: plain text and canonical metadata may render inline or side by
+    side, while images, PDFs, Office documents, and unknown binary formats will
+    begin with identity and metadata changes plus verified download/open
+    actions.
 
 ### CLI and agents
 
@@ -1511,49 +1514,35 @@ report still includes current terminal evidence and protected-byte results.
 
 ### TUI
 
-The TUI is a focused operator browser with three coordinated panes:
+The TUI opens a bounded, newest-first history screen for the selected node.
+Each row summarizes the recorded event, and event inspection exposes complete
+stable event, operation, scope, node, revision, path-state, version, tag, and
+provenance authority without truncating identities. Cursor pagination loads
+older pages while preserving the underlying document selection. Nodes outside
+the permanent audit boundary are identified plainly rather than presented with
+an invented empty history.
 
-1. the virtual tree with audited-scope and sticky-membership badges;
-2. the selected scope/node's ordered changes and content versions; and
-3. event detail showing path transitions, metadata, hashes, and verification.
-
-```text
-┌─ Tree ─────────────┐ ┌─ History ──────────┐ ┌─ Event / Version ─────────┐
-│ ▾ taxes       [A]  │ │ content replaced   │ │ 2026-07-14T09:42:11Z      │
-│   ▾ 2025      [A]  │ │ moved              │ │ /inbox/w2.pdf → /taxes/… │
-│     w2.pdf     [A]  │ │ baseline enrolled  │ │ sha256:…  verified       │
-│     return.pdf [A]  │ │                    │ │ compare · open · verify  │
-└────────────────────┘ └────────────────────┘ └───────────────────────────┘
-```
-
-Selection in the tree drives the history pane; selecting an event or version
-drives detail. Scope and node views are switchable without losing the selected
-stable node. Filtering, comparison, external open, and chain verification are
-first-class actions. Policy enablement shows the dry-run baseline inventory and
-vault-wide metadata-retention disclosure, then requires the separate explicit
-confirmation backed by the preview token; exceptional destruction is absent.
-
-It can render concise text or metadata differences. Rich PDF, office, image,
-and binary comparison opens an external tool or directs the operator to the web
-portal rather than overloading a terminal UI.
+!!! info "Planned"
+    Scope-wide timelines, comparison actions, audited-scope badges in the tree,
+    independent verification, and permanent enrollment remain outside the TUI.
+    Future terminal comparison should keep rich PDF, Office, image, and binary
+    rendering in an external viewer rather than overloading the TUI.
 
 ### Web portal and kit-ui
 
-The web portal is the primary human history experience. It adds filterable
-timelines, side-by-side version and metadata comparison, scope/member views,
-chain and backup evidence, and progress for verification or restore jobs.
-Reusable tree, timeline, diff, evidence, and job components belong in kit-ui
-when they are application-neutral enough for Msgvault and later tools.
+The web portal shows the selected node's permanent-protection status and opens
+its bounded, newest-first event timeline without losing the current directory,
+search result, or selection. Event detail exposes complete canonical identities,
+revision and path transitions, content versions, and typed tag or provenance
+changes. A separate read-only evidence drawer independently replays the current
+history and hashes protected content before reporting allocation and scope-chain
+heads. It does not accept earlier evidence, enroll a scope, or mutate policy.
 
-The primary layout keeps the virtual tree and current document context visible
-while a history workspace supplies filters, compare selection, and an evidence
-drawer. A scope dashboard summarizes enrolled nodes, protected current and
-historical bytes, chain status, latest verification, and snapshots known to
-contain the scope. Enabling audit is a reviewed workflow: preview the baseline
-inventory, storage impact, and vault-wide metadata-retention disclosure; review
-the target's current path and stable IDs; then acknowledge both retention
-boundaries and confirm enrollment. V1 has no separate scope-name field.
-The confirmation consumes the server-issued preview token and must refresh the
-inventory if relevant vault state changed.
+!!! info "Planned"
+    Filterable scope timelines, side-by-side version and metadata comparison,
+    scope/member dashboards, backup-evidence correlation, and permanent audit
+    enrollment remain outside the web application. Reusable timeline, diff,
+    and evidence components belong in kit-ui only when they are sufficiently
+    application-neutral.
 
 Neither UI presents exceptional audit destruction as an ordinary action.

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -164,9 +164,11 @@ The supervisor stops accepting work as soon as shutdown begins, cancels every
 runner, and waits before SQLite and blob storage close. Runners must honor
 their context; the wait is bounded so a defective runner cannot prevent daemon
 exit forever. The background daemon's idle-timeout loop is supervised through
-this same path. Text extraction and watched inboxes use this lifecycle;
-scheduled maintenance remains planned, but must use this lifecycle rather than
-creating unmanaged goroutines.
+this same path. Text extraction, watched inboxes, and configured automatic
+packing use this lifecycle. Scheduled packing appears as the `storage:pack`
+job, waits the configured interval after each completed run, and uses the same
+maintenance gate as explicit packing rather than creating an unmanaged
+goroutine. Garbage collection and repacking remain explicit operator actions.
 
 ## Logs
 

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -22,7 +22,8 @@ reconciliation pass through `Vault.Pack`; it cannot bypass the catalog or Kit's
 maintenance coordinator. `docbank storage repack` compacts eligible sparse packs
 and retires dead pack files. Embedded owners also have bounded `GarbageCollect`,
 `Verify`, and `Repack` passes. Startup never implicitly rewrites blob bytes, and
-no background scheduler runs these operations.
+configured daemon scheduling applies only to bounded packing. Garbage
+collection, verification, and repacking remain explicit operator actions.
 
 Large collections of small files are expensive to enumerate, copy, and restore.
 msgvault uses immutable pack files as the steady-state storage format for

--- a/docs/architecture/packed-storage.md
+++ b/docs/architecture/packed-storage.md
@@ -131,10 +131,12 @@ an implementation format that docbank should own. Recovery belongs in verified
 backup/restore or a concrete repair workflow; the existence of a low-level Kit
 operation is not by itself a product use case.
 
-Automatic background storage maintenance and external content references are not
-current operator capabilities. Backup, replacement, repair, reversion, and
-maintenance already use the catalog and content-hash boundary rather than
-private pack internals.
+Configured automatic packing is a current daemon capability. It applies a
+finite byte budget through the same maintenance gate as explicit packing;
+garbage collection and repacking remain deliberate operator actions. External
+content references are not a current operator capability. Backup, replacement,
+repair, reversion, and maintenance use the catalog and content-hash boundary
+rather than private pack internals.
 
 Next: [Storage](storage.md) documents the schema and blob-store invariants
 beneath this layer; [Trash, GC, Repack & Verify](../usage/trash-and-gc.md) is

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,26 @@ from the annotated release tags. Docbank remains pre-1.0, so public interfaces
 may still evolve, but vaults created by v0.9.0 and later are within the
 [storage compatibility boundary](architecture/storage.md#released-upgrades).
 
+## [v0.12.0](https://github.com/kenn-io/docbank/tree/v0.12.0) — 2026-08-01
+
+### New features
+
+- Add verified multi-store storage with configurable local filesystem and
+  S3-compatible blob placement.
+- Upload new documents and download current or retained historical versions
+  through the web application with integrity verification.
+- Inspect document history, provenance, permanent audit records, background
+  jobs, backups, and physical storage in the web application.
+- Browse tags, assign them to documents, and manage tag definitions in the web
+  application.
+- Manage recoverable trash in the web application and TUI.
+- Inspect tags, background jobs, backups, and physical storage in the TUI.
+
+### Improvements
+
+- Report packed storage left behind after a restore so operators can see what
+  still awaits reclamation.
+
 ## [v0.11.0](https://github.com/kenn-io/docbank/tree/v0.11.0) — 2026-07-23
 
 ### New features

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@ elsewhere only when they materially explain the design and are marked
 
 | Phase | Scope | Status |
 |-------|-------|--------|
-| 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses `kit` v0.11.0) |
+| 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses Kit's shared backup and multi-location packstore engines) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
 | 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |


### PR DESCRIPTION
The documentation now gives people a concise account of what changed in Docbank v0.12.0: verified multi-store placement, integrity-checked web transfer, richer web and TUI inspection, tag workflows, recoverable trash, and clearer post-restore storage reporting. This makes the website useful as a release record instead of requiring readers to reconstruct the product from individual pull requests.

The release audit also found several older statements that no longer matched the shipped product. The roadmap no longer pins Docbank to an obsolete Kit version, automatic packing is documented as an active supervised daemon job, and the audited-history architecture now names the read-only web and TUI views that are actually available.

This remains a capability and release-history update—not an implementation tracker—so the public pages continue to describe v0.12.0 directly in present tense. Repository policy now also makes the publication sequence explicit: capability docs must match the binary before tagging; the finalized release changelog is deliberately added afterward and the website deploys from that docs-only main commit, without requiring a second software release.