### PR TITLE
Keep .superpowers artifacts out of Git

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -10,3 +10,10 @@ language = "system"
 entry = "make fmt lint"
 pass_filenames = false
 always_run = true
+
+[[repos.hooks]]
+id = "forbid-superpowers-artifacts"
+name = "forbid-superpowers-artifacts"
+language = "fail"
+entry = ".superpowers is temporary workspace output; publish inspected screenshots to docs-assets instead"
+files = "^\\.superpowers/"


### PR DESCRIPTION
`.superpowers/` is temporary working output: screenshots awaiting inspection, planning notes, and other generated material. It should never become part of Docbank’s source history.

The existing ignore rule prevents ordinary additions, but it could not protect files that had already been tracked, and `git add -f` bypasses ignores entirely. This adds a commit-time backstop that rejects every staged path beneath `.superpowers/` and tells the contributor to publish inspected documentation screenshots on `docs-assets` instead.

I verified the boundary by force-adding an ignored generated screenshot. The hook rejected it and named the offending path; normal hooks pass after the artifact is unstaged.
