### PR TITLE
Pin Go 1.26.6 for module integrity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/docbank
 
-go 1.26.3
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
Docbank's CI and release builds now use Go 1.26.6, the security patch that fixes [checksum-database bypass and module-cache attacks](https://freenode.net/article/go-1-26-6-and-1-25-13-fix-sumdb-bypass-and-module-cache-attacks). This moves the authoritative toolchain requirement off Go 1.26.3; the existing workflows already consume that requirement from `go.mod`.

The scope is deliberately limited to the toolchain pin. Dependencies and the historical benchmark provenance recorded in the internal storage design remain unchanged.

<sup>generated by a clanker</sup>
