### PR TITLE
Add provider-neutral document normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# The compatibility bundle is a byte-for-byte oracle, not a text file.
+document/internal/compattest/testdata/document-compat-v1.json -text

--- a/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
+++ b/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
@@ -1,106 +1,37 @@
-# Document-understanding implementation delivery
-
-**Status:** Approved design
+# Document-understanding package architecture
 
 **Date:** 2026-08-16
 
-**Implementation work:** `e9jz`
+## Purpose
 
-**Public contract:**
-`2026-08-16-document-understanding-package-contract-design.md`
+Docbank's document-understanding architecture separates reusable behavior into
+two top-level packages. The provider-neutral package is current; the Mistral
+package is explicitly planned below.
 
-**Public contract revision:** `d27bf28`
+- `go.kenn.io/docbank/document` defines provider-neutral source evidence,
+  deterministic normalization, headings, spans, and baseline chunks.
+- `go.kenn.io/docbank/document/mistral` contains Mistral-specific formats,
+  capability evidence, policy, private staging, transport, and probes.
 
-**Compatibility source:** `kenn-io/msgvault#616` at
-`73d6c0b33f74c1fd072a7c0258f1cf1e80054698`
+The package boundary keeps local extraction independent of provider concepts.
+Applications retain consent records, scheduling, queues, persistence, budgets,
+configuration, and search serving.
 
-## Summary
+No committed production or test code imports across the Docbank and Msgvault
+repositories. Msgvault imports released Docbank packages as an ordinary module
+dependency and retains its application-specific legacy policy serializer.
 
-The approved public contract will land in two pull requests. The first adds the
-provider-neutral `go.kenn.io/docbank/document` package and its independent
-compatibility evidence. The second adds the complete
-`go.kenn.io/docbank/document/mistral` package, including formats, policy,
-capability evidence, private staging, bounded transport, fixture generation,
-and authenticated probing.
+## Provider-neutral document package
 
-The split follows the package boundary. `document` is independently useful to
-local consumers and has no Mistral concepts. `document/mistral` must land as a
-complete package because staging, policy, authorization, transport, and probes
-form one upload-safety boundary.
+The `document` package contains:
 
-The implementation uses behavior-first vertical slices. Every slice starts
-with an oracle: either the frozen compatibility bundle or the baseline tests
-that move with the behavior. The code will not pass through an intermediate
-public state with exported provider wire types, reusable filesystem paths, or
-upload methods that lack capability authorization.
-
-## Shared constraints
-
-- Msgvault remains read-only source. Temporary exports of the pinned commit are
-  used for compatibility generation and downstream verification.
-- No committed test or production code imports across repositories.
-- The corrected pre-release `document-compat-v1.json` bundle freezes at merge
-  and never changes afterward.
-- No live capability manifest is committed. Capability evidence is generated
-  by an operator using their credential and deployment target.
-- Docbank does not own application consent, scheduling, queues, persistence,
-  run budgets, or search serving.
-- Normalization preserves baseline behavior except for the approved
-  pre-release soft-break separator correction. Existing request-fingerprint,
-  capability-fingerprint, and Msgvault legacy profile-fingerprint bytes remain
-  unchanged.
-- `internal/extract` adoption is a later, separately scoped change.
-
-## Pull request 1: package `document`
-
-### Compatibility bundle provenance
-
-The bundle is generated before normalization is implemented in Docbank:
-
-1. Export Msgvault commit
-   `73d6c0b33f74c1fd072a7c0258f1cf1e80054698` into an owner-private temporary
-   directory.
-2. Apply the explicit soft-break separator correction to the exported
-   normalizer. Add a throwaway package-local generator inside that export so it
-   can call the corrected `documentindex.NormalizeDocument`, the unmodified
-   Mistral `requestFingerprint`, and `DocumentsConfig.ProfilePolicyJSON`.
-3. Generate the complete three-section bundle and hash its raw file bytes with
-   SHA-256.
-4. Record the exact generator source, invocation, baseline commit, and output
-   digest as evidence on `e9jz`.
-5. Copy only the generated bundle into
-   `document/internal/compattest/testdata/document-compat-v1.json`, then remove
-   the temporary export.
-
-The bundle metadata records:
-
-- `source_pr: kenn-io/msgvault#616`;
-- `baseline_commit: 73d6c0b33f74c1fd072a7c0258f1cf1e80054698`;
-- `generated_by: msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698+soft-break-separation`;
-  and
-- the ownership of `normalization_v2`,
-  `mistral_request_fingerprint_v2`, and
-  `msgvault_profile_policy_v1`.
-
-Pull request 1 pins the complete raw-file digest and asserts only
-`normalization_v2`, the section owned by the package landing in that pull
-request. Pull request 2 adds the `mistral_request_fingerprint_v2` assertion.
-Docbank never asserts the Msgvault legacy profile-policy section.
-
-The internal test-support package `document/internal/compattest` embeds the
-bundle and owns the one pinned digest constant plus the rehash-then-decode
-loader. Tests in both `document` and `document/mistral` import that internal
-package, so the raw-byte guard and schema decoding exist once without adding a
-public test-only API.
-
-### Package contents
-
-The package contains:
-
-- provider-neutral source-document and source-unit evidence;
-- normalized documents, units, headings, spans, and all eight chunk fields;
-- the opaque version-2 normalization policy and its read-only identity; and
-- deterministic normalization, baseline chunking, truncation, and checksums.
+- `SourceDocument` and `SourceUnit` input evidence;
+- normalized documents and units;
+- heading marks and chunk spans;
+- all eight chunk fields: key, ordinal, text, heading path, character count,
+  checksum, truncation state, and spans;
+- an opaque version-2 normalization policy; and
+- deterministic normalization, truncation, baseline chunking, and checksums.
 
 The data flow is:
 
@@ -111,288 +42,227 @@ SourceDocument + NormalizePolicy
 ```
 
 `MaxDocumentChars` is the only public policy input. Structural version-2
-values remain private. `NormalizeDocument` also rejects a zero-value or invalid
-policy so callers cannot accidentally create another version-2 identity.
+values remain private. `NormalizePolicy.Identity()` exposes the effective
+values read-only for serialization. `NormalizeDocument` rejects a zero-value
+or invalid policy, so callers cannot accidentally create another version-2
+identity.
 
-Goldmark is pinned to v1.7.17 and `golang.org/x/net` to v0.56.0 before the
-normalization code is added. Their versions are part of the compatibility
-boundary because parser behavior changes normalized bytes and checksums. The
-module tidy diff is reviewed with those pins.
+Baseline chunks are part of normalized evidence. They support lexical search,
+publication, provenance, and stable document checksums. Model-specific
+embedding recipes can merge or split this evidence without changing the
+normalization contract.
 
-### Tests
+Markdown soft breaks remain separating whitespace, and whitespace at inline
+code and link boundaries stays on the same side of the boundary as the source.
+These rules prevent adjacent evidence or punctuation from moving when HTML
+tokens are converted to canonical text.
 
-- Move the baseline normalization behavior tests with the implementation.
-- Keep boundary tests in package `document` and use a private test policy
-  constructor where the baseline tests vary structural limits.
-- Add package `document_test` coverage that constructs the policy, normalizes a
-  source document, and inspects results using only the public API.
-- Verify that a Markdown soft break remains a separating space instead of
-  joining adjacent words.
-- Rehash the raw compatibility bundle before decoding it.
-- Execute production normalization against every `normalization_v2` expected
-  value rather than regenerating expectations.
-- Run the complete Docbank suite with `-tags fts5` under both
-  `CGO_ENABLED=1` and `CGO_ENABLED=0` before each slice commit.
+### Compatibility evidence
 
-Pull request 1 ends with repository lint, strict documentation build, and
-commit-hook checks.
+`document/internal/compattest/testdata/document-compat-v1.json` is a frozen,
+byte-identical compatibility bundle shared with Msgvault. Its expected values
+were produced from Msgvault source at
+`73d6c0b33f74c1fd072a7c0258f1cf1e80054698`, with the approved pre-release
+soft-break correction applied to normalization version 2.
 
-## Pull request 2: package `document/mistral`
+The bundle contains three independently owned sections:
 
-Pull request 2 begins from `main` after pull request 1 lands. Its internal
-commits remain reviewable by component, but the public package lands only when
-the complete safety boundary is present.
+- `normalization_v2`;
+- `mistral_request_fingerprint_v2`; and
+- `msgvault_profile_policy_v1`.
 
-### Package contents
+Docbank verifies the raw-file digest before decoding the bundle. Each package
+asserts only the section it owns. Msgvault owns the legacy profile-policy
+section. A future contract adds a new bundle instead of editing this file.
 
-The package contains:
+Goldmark v1.7.17 and `golang.org/x/net` v0.56.0 are pinned parser dependencies.
+Parser behavior is part of normalization identity because it can change text
+and checksums. A dependency update must preserve the byte-level compatibility
+evidence or use a new normalization version.
 
-- the static candidate-format registry and format detection;
-- bounded, strict capability-manifest encoding and decoding;
-- observed provider-request and local-exact unit-bound evidence;
-- canonical reusable policy JSON, public fingerprints, and opaque format
-  authorization;
-- private, immutable staging through `PreparedDocument`;
-- local unit counting when a format has a counter implementation;
-- the bounded Mistral client and private retry helper;
-- validated conversion from provider wire results to
-  `document.SourceDocument`;
-- deterministic synthetic fixture generation and validated native seed
-  copying;
-- local fixture validation and authenticated capability probing; and
-- package documentation explaining the fail-closed default and version-1
-  limits.
+## Mistral package
 
-`Policy` exposes both views of normalization:
+!!! info "Planned"
 
-```go
-func (Policy) Values() PolicyValues
-func (Policy) NormalizePolicy() document.NormalizePolicy
-```
+    `document/mistral` will form one upload-safety boundary. The package will
+    include format detection, capability evidence, canonical policy identity,
+    opaque authorization, immutable private staging, bounded transport,
+    deterministic fixtures, local validation, and authenticated probes.
 
-`PolicyValues.Normalization` is the serializable identity.
-`NormalizePolicy()` returns the executable policy that must normalize the
-provider result authorized by the same Mistral policy.
+    The library will ship no live capability manifest. A manifest is dated
+    evidence for an operator's endpoint, model, fixture contract, and
+    credentialed probe. Without a complete validated manifest, production
+    upload authorization fails closed and explains that the operator must run
+    the authenticated probe and supply its manifest.
+
+### Policy and authorization
+
+!!! info "Planned"
+
+    `Policy` will expose both a serializable identity and the executable
+    normalization policy:
+
+    ```go
+    func (Policy) Values() PolicyValues
+    func (Policy) NormalizePolicy() document.NormalizePolicy
+    ```
+
+    `PolicyValues.Normalization` will carry the read-only normalization
+    identity. `NormalizePolicy()` will return the policy that must normalize
+    the provider result authorized by the same Mistral policy.
+
+    `Policy.Authorize` will combine policy limits with a validated capability
+    manifest. It will return an opaque, non-serializable
+    `FormatAuthorization`. The value will attest only that probe evidence and
+    enforceable bounds authorize a format under the policy. It will not attest
+    consent.
+
+    The authorization will carry a private values-only policy digest and the
+    public full fingerprint. `Process` will compare the private digest with its
+    client policy without requiring the client to retain the manifest. The
+    application will compare its consent record with the public fingerprint.
+
+### Capability evidence
+
+!!! info "Planned"
+
+    A capability manifest will record the target, model, fixture contract,
+    detected format, request fingerprint, fixture digest, ordinary extraction
+    observations, and unit-bound observations. Input will be limited to 1 MiB
+    and decoded strictly. Validation will reject partial, duplicated,
+    reordered, target-mismatched, old-contract, malformed, or arithmetically
+    inconsistent evidence.
+
+    Unit-bound methods will be:
+
+    - `provider_request`, where the provider request limits processed units;
+    - `local_exact`, where a local counter must equal the provider count; and
+    - `none`, which grants no production upload authority.
+
+    Each non-`none` value will be backed by recorded probe observations. An
+    unverified bound claim may retain successful extraction evidence while
+    recording `none` and `bound_unverified`; it cannot produce an
+    authorization.
+
+    Version 1 will authorize at most PDF because PDF has a provider-request
+    page bound. Other formats may extract successfully during a probe but will
+    remain unauthorized until they have an enforceable, observed bound.
 
 ### Operator evidence flow
 
-```text
-WriteProbeFixtures
-        -> ValidateProbeFixtures
-           local; no credential or HTTP
+!!! info "Planned"
 
-Client(APIKey) + validated fixtures
-        -> RunCapabilityProbe
-        -> CapabilityManifest
-        -> operator reviews and supplies or commits it
-        -> Policy.Authorize
-```
+    ```text
+    WriteProbeFixtures
+            -> ValidateProbeFixtures
+               local; no credential or HTTP
 
-The library commits no live manifest. A manifest is dated evidence for an
-operator's endpoint, model, fixture contract, and credentialed probe. It is not
-library-wide authority.
+    Client(APIKey) + validated fixtures
+            -> RunCapabilityProbe
+            -> CapabilityManifest
+            -> operator reviews and supplies or commits it
+            -> Policy.Authorize
+    ```
 
-Version 1 can authorize at most PDF. PDF has a provider-request page bound.
-Other formats may extract successfully during a probe but record
-`UnitBoundNone` and remain unauthorized. Package documentation tells operators
-to run the authenticated probe and supply its manifest when no upload authority
-exists.
+    Credentials will enter only when the application explicitly constructs a
+    client. Policy construction, manifest decoding, authorization, fixture
+    generation, fixture validation, format detection, and staging will perform
+    no provider request.
 
 ### Production flow
 
-```text
-Policy + validated manifest
-        -> authorize declared format
-        -> application verifies consent against auth.PolicyFingerprint()
-        -> Prepare source
-        -> Process rechecks sniffed format, policy, and immutable bytes
-        -> Result.Document + policy.NormalizePolicy()
-        -> document.NormalizeDocument
-        -> prepared.Release() on success or failure
-```
+!!! info "Planned"
 
-Authorization precedes staging so an application need not consume spool space
-for a format that lacks upload authority. `Process` still compares the sniffed
-format with the opaque authorization. Docbank exposes the policy fingerprint
-needed by application consent but does not verify or store consent itself.
+    ```text
+    Policy + validated manifest
+            -> authorize declared format
+            -> application verifies consent against auth.PolicyFingerprint()
+            -> Prepare source
+            -> Process rechecks sniffed format, policy, and immutable bytes
+            -> Result.Document + policy.NormalizePolicy()
+            -> document.NormalizeDocument
+            -> prepared.Release() on success or failure
+    ```
 
-Credentials enter only when the application explicitly constructs a client.
-Policy construction, manifest decoding, authorization, fixture generation,
-fixture validation, format detection, and staging perform no provider request.
+    Authorization precedes staging so refused formats do not consume spool
+    space. `Process` will still compare the sniffed format with the opaque
+    authorization. Docbank will expose the policy fingerprint needed by
+    application consent but will not verify or store consent itself.
 
-### Deterministic fixture generation
+### Fixture generation
 
-The public generator is:
+!!! info "Planned"
 
-```go
-type FixtureOptions struct {
-	SeedDirectory string
-}
+    The public generator will be:
 
-func WriteProbeFixtures(
-	context.Context,
-	string,
-	FixtureOptions,
-) error
-```
+    ```go
+    type FixtureOptions struct {
+        SeedDirectory string
+    }
 
-It synthesizes 21 candidate formats from one deterministic implementation. ZIP
-timestamps, identifiers, entry ordering, and sentinel content are fixed. The
-contract-2 PDF fixture contains at least two pages so a provider-request bound
-can be observed with a smaller requested range.
+    func WriteProbeFixtures(
+        context.Context,
+        string,
+        FixtureOptions,
+    ) error
+    ```
 
-Five native formats require operator-supplied synthetic seeds:
+    It will synthesize 21 candidate formats deterministically. ZIP timestamps,
+    identifiers, entry ordering, and sentinel content will be fixed. The
+    contract-2 PDF fixture will contain at least two pages so a smaller
+    provider-request range can demonstrate a bound.
 
-- `doc`;
-- `ppt`;
-- `xls`;
-- `numbers`; and
-- `msg`.
+    Five native formats will require operator-supplied synthetic seeds: `doc`,
+    `ppt`, `xls`, `numbers`, and `msg`. The generator will copy only regular,
+    non-symlink files with the expected names and will validate their detected
+    formats. Their manifest digests will be operator-specific.
 
-The generator reads those exact filenames from `SeedDirectory`, requires
-regular non-symlink files, copies their bytes, and validates each copy with
-`DetectFormat`. Their manifest digests are operator-specific. Production code
-does not synthesize Compound File Binary containers or Numbers IWA data.
+    The destination must not exist. Generation will use a temporary sibling
+    directory with mode 0700 and files with mode 0600. Missing seeds will be
+    reported together. Any missing, mislabeled, unsafe, failed, or cancelled
+    input will prevent publication. Cleanup will remove only paths created by
+    the generator.
 
-The destination must not exist. Generation occurs in a temporary sibling
-directory with mode 0700 and files with mode 0600. Missing seeds are reported
-together. Any missing, mislabeled, unsafe, failed, or cancelled input prevents
-the final rename. Failure cleanup removes only paths created by the generator.
+### Staging and transport safety
 
-Fixture contract 2 still requires the complete 26-format matrix. The later
-`km1t` design may allow missing native seeds to become non-authorizing manifest
-results; this implementation does not.
+!!! info "Planned"
 
-### Failure and safety behavior
+    `Prepare` will always close its source. Quota and free-space refusals will
+    return `ErrSpoolCapacity`; size, hash, format, and permission failures will
+    be terminal. Failure and cancellation will remove the partial file created
+    by that call. `Release` will be idempotent and will make its prepared
+    document unprocessable.
 
-Authorization fails closed when no complete manifest is supplied or no format
-has authority. The error explains the recovery action: run the authenticated
-capability probe and supply its manifest.
+    `ScavengeSpoolDirectory` will remove only stale package-prefixed regular
+    files. Unrelated regular files will remain and continue to count toward
+    quota. A symlink or other non-regular entry will stop scavenging with an
+    error.
 
-Manifest input is capped at 1 MiB and decoded strictly. Validation rejects
-partial, duplicated, reordered, target-mismatched, old-contract, malformed, or
-arithmetically inconsistent evidence.
+    Before every request, `Process` will reject:
 
-`Prepare` always closes its source. Quota and free-space refusals return
-`ErrSpoolCapacity` so an application may reschedule them. Size, hash, format,
-and permission failures are terminal. Failure and cancellation remove the
-partial file created by that call. `Release` is idempotent and makes its
-prepared document unprocessable.
+    - a released prepared document;
+    - a client-policy or authorization-policy digest mismatch;
+    - a sniffed-format and authorization mismatch;
+    - a prepared size above the client policy's `MaxDocumentBytes`;
+    - changed size, identity, permissions, or SHA-256; and
+    - every redirect, including when the caller supplies the HTTP client.
 
-`ScavengeSpoolDirectory` removes only stale package-prefixed regular files.
-Unrelated regular files remain and continue to count toward quota. A symlink or
-other non-regular entry stops scavenging with an error.
+    An injected HTTP client will be shallow-copied. Its timeout will be
+    replaced when it is non-positive or greater than the configured attempt
+    timeout. Each retry will reopen and rehash the staged file.
 
-Before each request, `Process` rejects:
+    `ErrPermanentResponse` and `ErrResponseTooLarge` will not retry. Only
+    `ErrTransientResponse` will retry. Retry-After will accept bounded integer
+    seconds, reject overflow, and otherwise use a capped exponential fallback.
+    Cancellation during an attempt or wait will preserve request accounting.
 
-- a released prepared document;
-- a client-policy or authorization-policy digest mismatch;
-- a sniffed-format and authorization mismatch;
-- a prepared size above the client policy's `MaxDocumentBytes`;
-- changed size, identity, permissions, or SHA-256; and
-- every redirect, including when the caller supplied the HTTP client.
+    Provider units above a `provider_request` bound will return
+    `ErrCapabilityContract`. Under `local_exact`, the provider count must equal
+    the prepared local count in both directions. A provider that may omit empty
+    units cannot use `local_exact`; a less-than-or-equal method would require a
+    separate contract and probe observation.
 
-`NewClient` shallow-copies the supplied client before replacing its redirect
-policy. If the injected client's timeout is non-positive or greater than the
-configured attempt timeout, the clone uses the configured bound. The package
-does not mutate caller-owned configuration, and injection cannot create an
-unbounded or overlong attempt. Each retry reopens and rehashes the staged file.
-
-`ErrPermanentResponse` and `ErrResponseTooLarge` never retry. Only
-`ErrTransientResponse` retries. Retry-After accepts bounded integer seconds,
-rejects overflow, and otherwise uses the existing capped exponential fallback.
-Each attempt has its own timeout. Cancellation during an attempt or wait
-returns with request accounting intact.
-
-For `provider_request`, provider units above the requested bound return
-`ErrCapabilityContract`. For `local_exact`, the provider count must equal the
-prepared local count; either direction of mismatch returns
-`ErrCapabilityContract`. Equality is the meaning of `local_exact`, not merely
-a cost bound. A provider that may omit empty sheets, slides, or other units
-cannot use this method. A future less-than-or-equal method such as
-`local_bound` would require a new contract and new probe evidence rather than a
-relaxation of `local_exact`. Version 1 defines no local-exact formats.
-
-Private wire data is checked for model equality, response size, complete and
-contiguous unit indices, processed-unit consistency, byte accounting, and
-policy bounds before conversion to `document.SourceDocument`.
-
-A format whose additional bound probe does not verify may retain successful
-extraction evidence while recording `UnitBoundNone` and `bound_unverified`.
-That result remains a valid manifest entry but cannot produce a
-`FormatAuthorization`.
-
-### Tests
-
-Baseline format, detection, staging, client, fixture, and probe tests move with
-their production components. Tests add the approved closed-construction and
-failure cases rather than rewriting baseline behavior from the specification.
-
-Capability manifests are constructed programmatically in test code. No
-synthetic manifest JSON is committed. The full-matrix factory includes PDF
-provider-request observations and supports deliberate invalid variants for
-manifest validation, authorization, processing, and `bound_unverified`
-coverage.
-
-Fixture tests:
-
-- generate the 21 synthesized formats twice and compare a pinned SHA-256 for
-  each format across both runs;
-- verify the contract-2 PDF page count is at least two;
-- run production format detection and sentinel checks on all synthesized
-  files;
-- use the baseline test-only minimal Compound File Binary and Numbers ZIP
-  builders as seed inputs for the five native formats;
-- verify native outputs are exact byte copies of validated seed inputs;
-- verify missing, mislabeled, symlinked, cancelled, or otherwise unsafe seeds
-  leave no destination; and
-- verify 0700 directory and 0600 file permissions where the platform exposes
-  Unix modes.
-
-Transport and lifecycle tests cover redirects with default and injected
-clients, response classification, retry limits, Retry-After overflow,
-per-attempt timeout, cancellation accounting, byte revalidation, cross-policy
-byte limits, policy mismatch, exact local counts, provider-request excess,
-idempotent release, failure cleanup, and fail-closed scavenging.
-
-Package `mistral_test` exercises the public surface, including the actionable
-no-authority error. Local fixture validation tests use an HTTP transport that
-fails the test if called, proving the operation performs no network request.
-
-The complete Docbank suite runs with `-tags fts5` under both CGO settings before
-each slice commit. Pull request 2 ends with repository lint, strict
-documentation build, and commit-hook checks.
-
-## Temporary Msgvault consumer verification
-
-After the Docbank API is complete:
-
-1. Export Msgvault commit
-   `73d6c0b33f74c1fd072a7c0258f1cf1e80054698` to an owner-private temporary
-   directory.
-2. Apply the real import and API migration there, retaining Msgvault's legacy
-   profile-policy wrapper and all application-owned behavior.
-3. Add a temporary module replacement pointing `go.kenn.io/docbank` at the
-   exact local Docbank commit under verification.
-4. Run focused document-index behavior tests with Msgvault's required
-   `fts5 sqlite_vec` tags.
-5. Run whole-module `go build -tags "fts5 sqlite_vec" ./...` and
-   `go vet -tags "fts5 sqlite_vec" ./...`.
-6. Record on `e9jz` the exact migration patch, patch digest, Docbank commit,
-   commands, and results.
-7. Remove the complete temporary export and its build output.
-
-This verification proves the real downstream consumer compiles and retains its
-application boundary without committing a cross-repository dependency.
-
-## Completion boundary
-
-Pull request 1 is complete when the provider-neutral package passes the frozen
-normalization oracle and public API tests in both supported SQLite build modes.
-Pull request 2 is complete when the entire Mistral safety boundary, fixture and
-probe tooling, request-fingerprint oracle, and temporary Msgvault consumer all
-pass their specified checks.
-
-`e9jz` remains open until both pull requests are complete. The Superpowers
-design artifacts remain available until the related Msgvault document-indexing
-work can proceed against the released Docbank packages.
+    Private wire data will be checked for model equality, response size,
+    complete and contiguous unit indices, processed-unit consistency, byte
+    accounting, and policy bounds before conversion to
+    `document.SourceDocument`.

--- a/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
+++ b/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
@@ -287,10 +287,10 @@ Before each request, `Process` rejects:
 - every redirect, including when the caller supplied the HTTP client.
 
 `NewClient` shallow-copies the supplied client before replacing its redirect
-policy. If the injected client's timeout is zero or greater than the configured
-attempt timeout, the clone uses the configured bound. The package does not
-mutate caller-owned configuration, and injection cannot create an unbounded or
-overlong attempt. Each retry reopens and rehashes the staged file.
+policy. If the injected client's timeout is non-positive or greater than the
+configured attempt timeout, the clone uses the configured bound. The package
+does not mutate caller-owned configuration, and injection cannot create an
+unbounded or overlong attempt. Each retry reopens and rehashes the staged file.
 
 `ErrPermanentResponse` and `ErrResponseTooLarge` never retry. Only
 `ErrTransientResponse` retries. Retry-After accepts bounded integer seconds,

--- a/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
+++ b/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
@@ -39,13 +39,16 @@ upload methods that lack capability authorization.
 - Msgvault remains read-only source. Temporary exports of the pinned commit are
   used for compatibility generation and downstream verification.
 - No committed test or production code imports across repositories.
-- The complete `document-compat-v1.json` bundle lands once and never changes.
+- The corrected pre-release `document-compat-v1.json` bundle freezes at merge
+  and never changes afterward.
 - No live capability manifest is committed. Capability evidence is generated
   by an operator using their credential and deployment target.
 - Docbank does not own application consent, scheduling, queues, persistence,
   run budgets, or search serving.
-- Existing normalization, request-fingerprint, capability-fingerprint, and
-  Msgvault legacy profile-fingerprint bytes remain unchanged.
+- Normalization preserves baseline behavior except for the approved
+  pre-release soft-break separator correction. Existing request-fingerprint,
+  capability-fingerprint, and Msgvault legacy profile-fingerprint bytes remain
+  unchanged.
 - `internal/extract` adoption is a later, separately scoped change.
 
 ## Pull request 1: package `document`
@@ -57,9 +60,10 @@ The bundle is generated before normalization is implemented in Docbank:
 1. Export Msgvault commit
    `73d6c0b33f74c1fd072a7c0258f1cf1e80054698` into an owner-private temporary
    directory.
-2. Add a throwaway package-local generator inside that export so it can call
-   baseline `documentindex.NormalizeDocument`, the unexported Mistral
-   `requestFingerprint`, and `DocumentsConfig.ProfilePolicyJSON`.
+2. Apply the explicit soft-break separator correction to the exported
+   normalizer. Add a throwaway package-local generator inside that export so it
+   can call the corrected `documentindex.NormalizeDocument`, the unmodified
+   Mistral `requestFingerprint`, and `DocumentsConfig.ProfilePolicyJSON`.
 3. Generate the complete three-section bundle and hash its raw file bytes with
    SHA-256.
 4. Record the exact generator source, invocation, baseline commit, and output
@@ -72,7 +76,7 @@ The bundle metadata records:
 
 - `source_pr: kenn-io/msgvault#616`;
 - `baseline_commit: 73d6c0b33f74c1fd072a7c0258f1cf1e80054698`;
-- `generated_by: msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698`;
+- `generated_by: msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698+soft-break-separation`;
   and
 - the ownership of `normalization_v2`,
   `mistral_request_fingerprint_v2`, and
@@ -122,6 +126,8 @@ module tidy diff is reviewed with those pins.
   constructor where the baseline tests vary structural limits.
 - Add package `document_test` coverage that constructs the policy, normalizes a
   source document, and inspects results using only the public API.
+- Verify that a Markdown soft break remains a separating space instead of
+  joining adjacent words.
 - Rehash the raw compatibility bundle before decoding it.
 - Execute production normalization against every `normalization_v2` expected
   value rather than regenerating expectations.

--- a/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
+++ b/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
@@ -9,6 +9,8 @@
 **Public contract:**
 `2026-08-16-document-understanding-package-contract-design.md`
 
+**Public contract revision:** `d27bf28`
+
 **Compatibility source:** `kenn-io/msgvault#616` at
 `73d6c0b33f74c1fd072a7c0258f1cf1e80054698`
 
@@ -63,8 +65,8 @@ The bundle is generated before normalization is implemented in Docbank:
 4. Record the exact generator source, invocation, baseline commit, and output
    digest as evidence on `e9jz`.
 5. Copy only the generated bundle into
-   `document/testdata/document-compat-v1.json`, then remove the temporary
-   export.
+   `document/internal/compattest/testdata/document-compat-v1.json`, then remove
+   the temporary export.
 
 The bundle metadata records:
 
@@ -80,6 +82,12 @@ Pull request 1 pins the complete raw-file digest and asserts only
 `normalization_v2`, the section owned by the package landing in that pull
 request. Pull request 2 adds the `mistral_request_fingerprint_v2` assertion.
 Docbank never asserts the Msgvault legacy profile-policy section.
+
+The internal test-support package `document/internal/compattest` embeds the
+bundle and owns the one pinned digest constant plus the rehash-then-decode
+loader. Tests in both `document` and `document/mistral` import that internal
+package, so the raw-byte guard and schema decoding exist once without adding a
+public test-only API.
 
 ### Package contents
 
@@ -279,8 +287,10 @@ Before each request, `Process` rejects:
 - every redirect, including when the caller supplied the HTTP client.
 
 `NewClient` shallow-copies the supplied client before replacing its redirect
-policy. It does not mutate caller-owned configuration. Each retry reopens and
-rehashes the staged file.
+policy. If the injected client's timeout is zero or greater than the configured
+attempt timeout, the clone uses the configured bound. The package does not
+mutate caller-owned configuration, and injection cannot create an unbounded or
+overlong attempt. Each retry reopens and rehashes the staged file.
 
 `ErrPermanentResponse` and `ErrResponseTooLarge` never retry. Only
 `ErrTransientResponse` retries. Retry-After accepts bounded integer seconds,

--- a/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
+++ b/docs/superpowers/specs/2026-08-16-document-understanding-implementation-design.md
@@ -1,0 +1,382 @@
+# Document-understanding implementation delivery
+
+**Status:** Approved design
+
+**Date:** 2026-08-16
+
+**Implementation work:** `e9jz`
+
+**Public contract:**
+`2026-08-16-document-understanding-package-contract-design.md`
+
+**Compatibility source:** `kenn-io/msgvault#616` at
+`73d6c0b33f74c1fd072a7c0258f1cf1e80054698`
+
+## Summary
+
+The approved public contract will land in two pull requests. The first adds the
+provider-neutral `go.kenn.io/docbank/document` package and its independent
+compatibility evidence. The second adds the complete
+`go.kenn.io/docbank/document/mistral` package, including formats, policy,
+capability evidence, private staging, bounded transport, fixture generation,
+and authenticated probing.
+
+The split follows the package boundary. `document` is independently useful to
+local consumers and has no Mistral concepts. `document/mistral` must land as a
+complete package because staging, policy, authorization, transport, and probes
+form one upload-safety boundary.
+
+The implementation uses behavior-first vertical slices. Every slice starts
+with an oracle: either the frozen compatibility bundle or the baseline tests
+that move with the behavior. The code will not pass through an intermediate
+public state with exported provider wire types, reusable filesystem paths, or
+upload methods that lack capability authorization.
+
+## Shared constraints
+
+- Msgvault remains read-only source. Temporary exports of the pinned commit are
+  used for compatibility generation and downstream verification.
+- No committed test or production code imports across repositories.
+- The complete `document-compat-v1.json` bundle lands once and never changes.
+- No live capability manifest is committed. Capability evidence is generated
+  by an operator using their credential and deployment target.
+- Docbank does not own application consent, scheduling, queues, persistence,
+  run budgets, or search serving.
+- Existing normalization, request-fingerprint, capability-fingerprint, and
+  Msgvault legacy profile-fingerprint bytes remain unchanged.
+- `internal/extract` adoption is a later, separately scoped change.
+
+## Pull request 1: package `document`
+
+### Compatibility bundle provenance
+
+The bundle is generated before normalization is implemented in Docbank:
+
+1. Export Msgvault commit
+   `73d6c0b33f74c1fd072a7c0258f1cf1e80054698` into an owner-private temporary
+   directory.
+2. Add a throwaway package-local generator inside that export so it can call
+   baseline `documentindex.NormalizeDocument`, the unexported Mistral
+   `requestFingerprint`, and `DocumentsConfig.ProfilePolicyJSON`.
+3. Generate the complete three-section bundle and hash its raw file bytes with
+   SHA-256.
+4. Record the exact generator source, invocation, baseline commit, and output
+   digest as evidence on `e9jz`.
+5. Copy only the generated bundle into
+   `document/testdata/document-compat-v1.json`, then remove the temporary
+   export.
+
+The bundle metadata records:
+
+- `source_pr: kenn-io/msgvault#616`;
+- `baseline_commit: 73d6c0b33f74c1fd072a7c0258f1cf1e80054698`;
+- `generated_by: msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698`;
+  and
+- the ownership of `normalization_v2`,
+  `mistral_request_fingerprint_v2`, and
+  `msgvault_profile_policy_v1`.
+
+Pull request 1 pins the complete raw-file digest and asserts only
+`normalization_v2`, the section owned by the package landing in that pull
+request. Pull request 2 adds the `mistral_request_fingerprint_v2` assertion.
+Docbank never asserts the Msgvault legacy profile-policy section.
+
+### Package contents
+
+The package contains:
+
+- provider-neutral source-document and source-unit evidence;
+- normalized documents, units, headings, spans, and all eight chunk fields;
+- the opaque version-2 normalization policy and its read-only identity; and
+- deterministic normalization, baseline chunking, truncation, and checksums.
+
+The data flow is:
+
+```text
+SourceDocument + NormalizePolicy
+        -> NormalizeDocument
+        -> NormalizedDocument
+```
+
+`MaxDocumentChars` is the only public policy input. Structural version-2
+values remain private. `NormalizeDocument` also rejects a zero-value or invalid
+policy so callers cannot accidentally create another version-2 identity.
+
+Goldmark is pinned to v1.7.17 and `golang.org/x/net` to v0.56.0 before the
+normalization code is added. Their versions are part of the compatibility
+boundary because parser behavior changes normalized bytes and checksums. The
+module tidy diff is reviewed with those pins.
+
+### Tests
+
+- Move the baseline normalization behavior tests with the implementation.
+- Keep boundary tests in package `document` and use a private test policy
+  constructor where the baseline tests vary structural limits.
+- Add package `document_test` coverage that constructs the policy, normalizes a
+  source document, and inspects results using only the public API.
+- Rehash the raw compatibility bundle before decoding it.
+- Execute production normalization against every `normalization_v2` expected
+  value rather than regenerating expectations.
+- Run the complete Docbank suite with `-tags fts5` under both
+  `CGO_ENABLED=1` and `CGO_ENABLED=0` before each slice commit.
+
+Pull request 1 ends with repository lint, strict documentation build, and
+commit-hook checks.
+
+## Pull request 2: package `document/mistral`
+
+Pull request 2 begins from `main` after pull request 1 lands. Its internal
+commits remain reviewable by component, but the public package lands only when
+the complete safety boundary is present.
+
+### Package contents
+
+The package contains:
+
+- the static candidate-format registry and format detection;
+- bounded, strict capability-manifest encoding and decoding;
+- observed provider-request and local-exact unit-bound evidence;
+- canonical reusable policy JSON, public fingerprints, and opaque format
+  authorization;
+- private, immutable staging through `PreparedDocument`;
+- local unit counting when a format has a counter implementation;
+- the bounded Mistral client and private retry helper;
+- validated conversion from provider wire results to
+  `document.SourceDocument`;
+- deterministic synthetic fixture generation and validated native seed
+  copying;
+- local fixture validation and authenticated capability probing; and
+- package documentation explaining the fail-closed default and version-1
+  limits.
+
+`Policy` exposes both views of normalization:
+
+```go
+func (Policy) Values() PolicyValues
+func (Policy) NormalizePolicy() document.NormalizePolicy
+```
+
+`PolicyValues.Normalization` is the serializable identity.
+`NormalizePolicy()` returns the executable policy that must normalize the
+provider result authorized by the same Mistral policy.
+
+### Operator evidence flow
+
+```text
+WriteProbeFixtures
+        -> ValidateProbeFixtures
+           local; no credential or HTTP
+
+Client(APIKey) + validated fixtures
+        -> RunCapabilityProbe
+        -> CapabilityManifest
+        -> operator reviews and supplies or commits it
+        -> Policy.Authorize
+```
+
+The library commits no live manifest. A manifest is dated evidence for an
+operator's endpoint, model, fixture contract, and credentialed probe. It is not
+library-wide authority.
+
+Version 1 can authorize at most PDF. PDF has a provider-request page bound.
+Other formats may extract successfully during a probe but record
+`UnitBoundNone` and remain unauthorized. Package documentation tells operators
+to run the authenticated probe and supply its manifest when no upload authority
+exists.
+
+### Production flow
+
+```text
+Policy + validated manifest
+        -> authorize declared format
+        -> application verifies consent against auth.PolicyFingerprint()
+        -> Prepare source
+        -> Process rechecks sniffed format, policy, and immutable bytes
+        -> Result.Document + policy.NormalizePolicy()
+        -> document.NormalizeDocument
+        -> prepared.Release() on success or failure
+```
+
+Authorization precedes staging so an application need not consume spool space
+for a format that lacks upload authority. `Process` still compares the sniffed
+format with the opaque authorization. Docbank exposes the policy fingerprint
+needed by application consent but does not verify or store consent itself.
+
+Credentials enter only when the application explicitly constructs a client.
+Policy construction, manifest decoding, authorization, fixture generation,
+fixture validation, format detection, and staging perform no provider request.
+
+### Deterministic fixture generation
+
+The public generator is:
+
+```go
+type FixtureOptions struct {
+	SeedDirectory string
+}
+
+func WriteProbeFixtures(
+	context.Context,
+	string,
+	FixtureOptions,
+) error
+```
+
+It synthesizes 21 candidate formats from one deterministic implementation. ZIP
+timestamps, identifiers, entry ordering, and sentinel content are fixed. The
+contract-2 PDF fixture contains at least two pages so a provider-request bound
+can be observed with a smaller requested range.
+
+Five native formats require operator-supplied synthetic seeds:
+
+- `doc`;
+- `ppt`;
+- `xls`;
+- `numbers`; and
+- `msg`.
+
+The generator reads those exact filenames from `SeedDirectory`, requires
+regular non-symlink files, copies their bytes, and validates each copy with
+`DetectFormat`. Their manifest digests are operator-specific. Production code
+does not synthesize Compound File Binary containers or Numbers IWA data.
+
+The destination must not exist. Generation occurs in a temporary sibling
+directory with mode 0700 and files with mode 0600. Missing seeds are reported
+together. Any missing, mislabeled, unsafe, failed, or cancelled input prevents
+the final rename. Failure cleanup removes only paths created by the generator.
+
+Fixture contract 2 still requires the complete 26-format matrix. The later
+`km1t` design may allow missing native seeds to become non-authorizing manifest
+results; this implementation does not.
+
+### Failure and safety behavior
+
+Authorization fails closed when no complete manifest is supplied or no format
+has authority. The error explains the recovery action: run the authenticated
+capability probe and supply its manifest.
+
+Manifest input is capped at 1 MiB and decoded strictly. Validation rejects
+partial, duplicated, reordered, target-mismatched, old-contract, malformed, or
+arithmetically inconsistent evidence.
+
+`Prepare` always closes its source. Quota and free-space refusals return
+`ErrSpoolCapacity` so an application may reschedule them. Size, hash, format,
+and permission failures are terminal. Failure and cancellation remove the
+partial file created by that call. `Release` is idempotent and makes its
+prepared document unprocessable.
+
+`ScavengeSpoolDirectory` removes only stale package-prefixed regular files.
+Unrelated regular files remain and continue to count toward quota. A symlink or
+other non-regular entry stops scavenging with an error.
+
+Before each request, `Process` rejects:
+
+- a released prepared document;
+- a client-policy or authorization-policy digest mismatch;
+- a sniffed-format and authorization mismatch;
+- a prepared size above the client policy's `MaxDocumentBytes`;
+- changed size, identity, permissions, or SHA-256; and
+- every redirect, including when the caller supplied the HTTP client.
+
+`NewClient` shallow-copies the supplied client before replacing its redirect
+policy. It does not mutate caller-owned configuration. Each retry reopens and
+rehashes the staged file.
+
+`ErrPermanentResponse` and `ErrResponseTooLarge` never retry. Only
+`ErrTransientResponse` retries. Retry-After accepts bounded integer seconds,
+rejects overflow, and otherwise uses the existing capped exponential fallback.
+Each attempt has its own timeout. Cancellation during an attempt or wait
+returns with request accounting intact.
+
+For `provider_request`, provider units above the requested bound return
+`ErrCapabilityContract`. For `local_exact`, the provider count must equal the
+prepared local count; either direction of mismatch returns
+`ErrCapabilityContract`. Equality is the meaning of `local_exact`, not merely
+a cost bound. A provider that may omit empty sheets, slides, or other units
+cannot use this method. A future less-than-or-equal method such as
+`local_bound` would require a new contract and new probe evidence rather than a
+relaxation of `local_exact`. Version 1 defines no local-exact formats.
+
+Private wire data is checked for model equality, response size, complete and
+contiguous unit indices, processed-unit consistency, byte accounting, and
+policy bounds before conversion to `document.SourceDocument`.
+
+A format whose additional bound probe does not verify may retain successful
+extraction evidence while recording `UnitBoundNone` and `bound_unverified`.
+That result remains a valid manifest entry but cannot produce a
+`FormatAuthorization`.
+
+### Tests
+
+Baseline format, detection, staging, client, fixture, and probe tests move with
+their production components. Tests add the approved closed-construction and
+failure cases rather than rewriting baseline behavior from the specification.
+
+Capability manifests are constructed programmatically in test code. No
+synthetic manifest JSON is committed. The full-matrix factory includes PDF
+provider-request observations and supports deliberate invalid variants for
+manifest validation, authorization, processing, and `bound_unverified`
+coverage.
+
+Fixture tests:
+
+- generate the 21 synthesized formats twice and compare a pinned SHA-256 for
+  each format across both runs;
+- verify the contract-2 PDF page count is at least two;
+- run production format detection and sentinel checks on all synthesized
+  files;
+- use the baseline test-only minimal Compound File Binary and Numbers ZIP
+  builders as seed inputs for the five native formats;
+- verify native outputs are exact byte copies of validated seed inputs;
+- verify missing, mislabeled, symlinked, cancelled, or otherwise unsafe seeds
+  leave no destination; and
+- verify 0700 directory and 0600 file permissions where the platform exposes
+  Unix modes.
+
+Transport and lifecycle tests cover redirects with default and injected
+clients, response classification, retry limits, Retry-After overflow,
+per-attempt timeout, cancellation accounting, byte revalidation, cross-policy
+byte limits, policy mismatch, exact local counts, provider-request excess,
+idempotent release, failure cleanup, and fail-closed scavenging.
+
+Package `mistral_test` exercises the public surface, including the actionable
+no-authority error. Local fixture validation tests use an HTTP transport that
+fails the test if called, proving the operation performs no network request.
+
+The complete Docbank suite runs with `-tags fts5` under both CGO settings before
+each slice commit. Pull request 2 ends with repository lint, strict
+documentation build, and commit-hook checks.
+
+## Temporary Msgvault consumer verification
+
+After the Docbank API is complete:
+
+1. Export Msgvault commit
+   `73d6c0b33f74c1fd072a7c0258f1cf1e80054698` to an owner-private temporary
+   directory.
+2. Apply the real import and API migration there, retaining Msgvault's legacy
+   profile-policy wrapper and all application-owned behavior.
+3. Add a temporary module replacement pointing `go.kenn.io/docbank` at the
+   exact local Docbank commit under verification.
+4. Run focused document-index behavior tests with Msgvault's required
+   `fts5 sqlite_vec` tags.
+5. Run whole-module `go build -tags "fts5 sqlite_vec" ./...` and
+   `go vet -tags "fts5 sqlite_vec" ./...`.
+6. Record on `e9jz` the exact migration patch, patch digest, Docbank commit,
+   commands, and results.
+7. Remove the complete temporary export and its build output.
+
+This verification proves the real downstream consumer compiles and retains its
+application boundary without committing a cross-repository dependency.
+
+## Completion boundary
+
+Pull request 1 is complete when the provider-neutral package passes the frozen
+normalization oracle and public API tests in both supported SQLite build modes.
+Pull request 2 is complete when the entire Mistral safety boundary, fixture and
+probe tooling, request-fingerprint oracle, and temporary Msgvault consumer all
+pass their specified checks.
+
+`e9jz` remains open until both pull requests are complete. The Superpowers
+design artifacts remain available until the related Msgvault document-indexing
+work can proceed against the released Docbank packages.

--- a/docs/superpowers/specs/2026-08-16-document-understanding-package-contract-design.md
+++ b/docs/superpowers/specs/2026-08-16-document-understanding-package-contract-design.md
@@ -45,9 +45,10 @@ The contract must:
 
 - provide one authoritative implementation of deterministic normalization,
   headings, spans, baseline chunks, truncation, and checksums;
-- preserve normalization policy version 2 and all baseline normalization,
+- preserve normalization policy version 2, fix the baseline soft-break
+  separator defect before release, and preserve all other normalization,
   request-fingerprint, capability-fingerprint, and Msgvault legacy profile
-  fingerprint bytes;
+  fingerprint behavior;
 - expose validated provider output only as provider-neutral source units;
 - prevent production uploads for formats without passing probe evidence and
   an enforceable unit bound;
@@ -243,8 +244,8 @@ Docbank will add those module versions as direct requirements when the code
 moves. Parser behavior is part of normalization version 2 because it can
 change canonical text and every downstream checksum. A later dependency
 upgrade may remain version 2 only when the complete normalization suite and
-the frozen compatibility bundle remain byte-identical. Any output change
-requires normalization version 3.
+the frozen compatibility bundle remain byte-identical. After version 2 first
+ships, any output change requires normalization version 3.
 
 ## Package `document/mistral`
 
@@ -737,7 +738,7 @@ Both repositories will contain a byte-identical immutable fixture named
 - its bundle schema and fixture ID;
 - `source_pr: kenn-io/msgvault#616`;
 - `baseline_commit: 73d6c0b33f74c1fd072a7c0258f1cf1e80054698`;
-- `generated_by: msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698`;
+- `generated_by: msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698+soft-break-separation`;
 - an explicit section ownership map; and
 - synthetic inputs and exact expected values.
 
@@ -748,12 +749,14 @@ The sections are:
 - `msgvault_profile_policy_v1`, owned by Msgvault.
 
 Version-1 expected values are generated before code motion by a throwaway
-package-local generator run against the Msgvault baseline commit. It calls the
-baseline production `documentindex.NormalizeDocument`, Mistral
-`requestFingerprint`, and `DocumentsConfig.ProfilePolicyJSON` implementations.
-The moved Docbank implementation never generates or rewrites the expected
-values it is tested against. This provenance makes the bundle an independent
-compatibility oracle rather than a self-consistency fixture.
+package-local generator run against the Msgvault baseline commit. The export
+applies the approved soft-break separator correction to the baseline
+normalizer, then calls `documentindex.NormalizeDocument`. It calls the
+unmodified Mistral `requestFingerprint` and
+`DocumentsConfig.ProfilePolicyJSON` implementations. The moved Docbank
+implementation never generates or rewrites the expected values it is tested
+against. This provenance makes the bundle an independent compatibility oracle
+rather than a self-consistency fixture.
 
 Each repository pins the same lowercase SHA-256 literal for the entire raw
 file and rehashes the file bytes before decoding. Tests do not hash a
@@ -763,9 +766,10 @@ executes its production legacy serializer against its exact JSON and
 fingerprint section. Unowned sections stay in the file for traceability but
 need not be asserted by that repository.
 
-The bundle is copied once and never synchronized by tooling. Any correction or
-new contract adds a new file; v1 is never edited. There is no cross-repository
-test import, network fetch, CI artifact dependency, or exported compatibility
+The corrected pre-release bundle is frozen when the package first merges and
+is never synchronized by tooling. Any later correction or new contract adds a
+new file; the merged v1 file is never edited. There is no cross-repository test
+import, network fetch, CI artifact dependency, or exported compatibility
 package.
 
 The probe fixture contract-2 change does not alter the request-fingerprint

--- a/docs/superpowers/specs/2026-08-16-document-understanding-package-contract-design.md
+++ b/docs/superpowers/specs/2026-08-16-document-understanding-package-contract-design.md
@@ -4,12 +4,6 @@
 
 **Date:** 2026-08-16
 
-**Kata:** `w30d`
-
-**Parent epic:** `rz07`
-
-**Implementation stage:** `e9jz`
-
 **Compatibility source:** `kenn-io/msgvault#616` at
 `73d6c0b33f74c1fd072a7c0258f1cf1e80054698`
 
@@ -35,9 +29,6 @@ manifest concepts. Provider-specific behavior begins in
 `document/<provider>`. Common provider behavior moves upward only after a
 second concrete provider implementation proves the common contract; a second
 provider initially copies the small behavior it needs.
-
-This design freezes the public contract only. Work on `e9jz` requires a new
-`superpowers:brainstorming` gate before implementation.
 
 ## Goals
 
@@ -688,10 +679,9 @@ text, filenames, raw responses, provider error bodies, credentials, user URLs,
 or full fixture hashes. `ProbeFixtureSentinel` remains public for synthetic
 fixture generation.
 
-## Amendments from implementation brainstorming
+## Additional public surface
 
-The `e9jz` implementation design extends the frozen public contract with these
-approved additions:
+The public contract includes these additions:
 
 - `Policy.NormalizePolicy() document.NormalizePolicy` returns the executable
   normalization policy covered by the Mistral policy identity. This makes the
@@ -776,62 +766,6 @@ The probe fixture contract-2 change does not alter the request-fingerprint
 section because request fingerprints depend on the candidate and request
 options, not fixture bytes. Fixture digests remain capability-manifest data.
 
-## Migration sequence
-
-1. Complete the focused top-level SQLite import migration, documentation
-   update, changelog entry, and `pkg/` removal without aliases.
-2. Invoke `superpowers:brainstorming` for `e9jz`; approval of this document is
-   not approval to implement that issue.
-3. Add and pin the frozen compatibility bundle before moving behavior.
-4. Move normalization behavior and its production behavior tests into
-   `document` without changing version-2 outputs.
-5. Move Mistral formats, manifests, policy, staging, transport, private retry
-   behavior, probes, and their tests into `document/mistral` while applying
-   this contract's closed-construction boundaries.
-6. Update Msgvault to import the public packages. Retain only its legacy policy
-   wrapper and application-owned behavior listed in the non-goals.
-7. Let Docbank's existing extractor adopt `document` in a separately scoped
-   change when it needs the shared normalization output.
-
-## Verification
-
-Implementation evidence must verify behavior rather than source-file motion:
-
-- normalization version, canonical text, headings, spans, all eight chunk
-  fields, unit/chunk/document checksums, and truncation are exact;
-- `NormalizeDocument` rejects `NormalizePolicy{}` and all invalid policies;
-- canonical Mistral policy JSON is deterministic and its fingerprint covers
-  only approved semantic identity;
-- Msgvault legacy policy JSON and fingerprint remain byte-for-byte exact;
-- ordinary request fingerprints remain exact when reconstructed with manifest
-  options, while smaller production ranges remain authorized within manifest
-  unit authority;
-- manifests reject incomplete, reordered, target-mismatched, old-contract,
-  malformed, or arithmetically invalid evidence;
-- an unverified bound produces a valid result with `UnitBoundNone` and
-  `bound_unverified`, and cannot produce a `FormatAuthorization`;
-- `ValidateProbeFixtures` performs no HTTP and requires no credential;
-- production cannot accept a fixture, and probing cannot accept a prepared user
-  document;
-- `Prepare` closes its source on every path, `Release` is idempotent, and
-  cleanup/scavenging remove only package-created files;
-- production re-verifies immutable bytes before every retry and rejects policy
-  or format mismatch and a client-policy byte excess before upload;
-- default and injected HTTP clients both reject redirects without replaying
-  document bytes;
-- provider-request post-response unit excess and either direction of a
-  local-exact count mismatch return `ErrCapabilityContract`;
-- request accounting survives classified failure and retry cancellation;
-- package dependency inspection confirms that `document` and
-  `document/mistral` import no vault, daemon, database, queue, or application
-  internals; and
-- `go test -tags fts5 ./...` passes with both `CGO_ENABLED=1` and
-  `CGO_ENABLED=0`, followed by repository lint, documentation, and commit-hook
-  gates required for the affected changes.
-
-Live authenticated probes are explicit operator evidence. They are not part of
-ordinary automated tests or local fixture validation.
-
 ## Approved decision summary
 
 1. Baseline chunks remain in normalization.
@@ -844,10 +778,9 @@ ordinary automated tests or local fixture validation.
    settings do not enter it; Msgvault keeps an exact legacy wrapper.
 6. Opaque `FormatAuthorization` represents capability authority, while consent
    remains application-owned.
-7. Mistral keeps a private copy of the small retry helper and its behavior
-   tests.
+7. Mistral keeps its retry behavior private to the provider package.
 8. Both repositories carry one byte-identical immutable compatibility bundle.
 9. Normalization version 2 is opaque with `MaxDocumentChars` as its only public
    input.
-10. Public packages are top-level `document` and `document/mistral`; `pkg/` is
-    removed first without compatibility aliases.
+10. Public packages are top-level `document` and `document/mistral`, without
+    compatibility aliases under `pkg/`.

--- a/docs/superpowers/specs/2026-08-16-document-understanding-package-contract-design.md
+++ b/docs/superpowers/specs/2026-08-16-document-understanding-package-contract-design.md
@@ -687,6 +687,28 @@ text, filenames, raw responses, provider error bodies, credentials, user URLs,
 or full fixture hashes. `ProbeFixtureSentinel` remains public for synthetic
 fixture generation.
 
+## Amendments from implementation brainstorming
+
+The `e9jz` implementation design extends the frozen public contract with these
+approved additions:
+
+- `Policy.NormalizePolicy() document.NormalizePolicy` returns the executable
+  normalization policy covered by the Mistral policy identity. This makes the
+  safe production flow direct: the authorized provider result is normalized
+  with the policy that authorized it.
+- `FixtureOptions` and `WriteProbeFixtures` provide one public deterministic
+  fixture writer for Docbank and downstream applications. The writer
+  synthesizes 21 formats and copies validated operator seeds for `doc`, `ppt`,
+  `xls`, `numbers`, and `msg`, avoiding either duplicate fixture bytes or a
+  dependency on a Docbank executable.
+- Capability-manifest input is capped at 1 MiB before strict decoding. This
+  makes the operator-supplied recovery path explicitly bounded as well as
+  structurally validated.
+
+The fixture writer performs no network request and requires no credential. It
+publishes only a complete fixture-contract-2 directory; the five native seed
+digests remain operator-specific.
+
 ## Consent and application ownership
 
 Local configuration, policy construction, manifest decoding and validation,

--- a/document/compat_test.go
+++ b/document/compat_test.go
@@ -1,0 +1,41 @@
+package document
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document/internal/compattest"
+)
+
+type normalizationCompatibilityCase struct {
+	Name             string             `json:"name"`
+	MaxDocumentChars int                `json:"max_document_chars"`
+	Source           SourceDocument     `json:"source"`
+	Expected         NormalizedDocument `json:"expected"`
+}
+
+func TestNormalizeDocumentMatchesMsgvaultBaseline(t *testing.T) {
+	bundle, _, err := compattest.Load()
+	require.NoError(t, err)
+	section, ok := bundle.Sections["normalization_v2"]
+	require.True(t, ok)
+	assert.Equal(t, "go.kenn.io/docbank/document", section.Owner)
+
+	var cases []normalizationCompatibilityCase
+	// Public evidence types intentionally do not define a JSON serialization API.
+	// The frozen test bundle uses their Go field names from the baseline.
+	//nolint:musttag
+	require.NoError(t, json.Unmarshal(section.Cases, &cases))
+	require.Len(t, cases, 2)
+	for _, testCase := range cases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			policy, err := NewNormalizePolicy(testCase.MaxDocumentChars)
+			require.NoError(t, err)
+			actual, err := NormalizeDocument(testCase.Source, policy)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.Expected, actual)
+		})
+	}
+}

--- a/document/doc.go
+++ b/document/doc.go
@@ -1,0 +1,6 @@
+// Package document converts provider-neutral source evidence into deterministic
+// normalized units, headings, spans, and chunks.
+//
+// The package does not perform filesystem, network, storage, database, queue,
+// daemon, vault, or application work.
+package document

--- a/document/internal/compattest/bundle.go
+++ b/document/internal/compattest/bundle.go
@@ -1,0 +1,58 @@
+// Package compattest loads the frozen cross-repository compatibility evidence.
+package compattest
+
+import (
+	"bytes"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// BundleSHA256 is the expected digest of the raw compatibility bundle.
+const BundleSHA256 = "cfeb37f6427a557d0fb5218e9de92c2397e2faa3020c7f688e144ffdf298c51d"
+
+//go:embed testdata/document-compat-v1.json
+var bundleJSON []byte
+
+// Bundle describes the immutable bundle metadata and its independently owned sections.
+type Bundle struct {
+	BundleSchema   int                `json:"bundle_schema"`
+	FixtureID      string             `json:"fixture_id"`
+	SourcePR       string             `json:"source_pr"`
+	BaselineCommit string             `json:"baseline_commit"`
+	GeneratedBy    string             `json:"generated_by"`
+	Sections       map[string]Section `json:"sections"`
+}
+
+// Section leaves its cases encoded so each package decodes only the contract it owns.
+type Section struct {
+	Owner string          `json:"owner"`
+	Cases json.RawMessage `json:"cases"`
+}
+
+// Load verifies the raw bundle before decoding it.
+func Load() (Bundle, []byte, error) {
+	digest := sha256.Sum256(bundleJSON)
+	actual := hex.EncodeToString(digest[:])
+	if actual != BundleSHA256 {
+		return Bundle{}, nil, fmt.Errorf("document compatibility bundle digest is %s, want %s", actual, BundleSHA256)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(bundleJSON))
+	var bundle Bundle
+	if err := decoder.Decode(&bundle); err != nil {
+		return Bundle{}, nil, fmt.Errorf("decode document compatibility bundle: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("additional JSON value")
+		}
+		return Bundle{}, nil, fmt.Errorf("decode document compatibility bundle trailing data: %w", err)
+	}
+	return bundle, bytes.Clone(bundleJSON), nil
+}

--- a/document/internal/compattest/bundle.go
+++ b/document/internal/compattest/bundle.go
@@ -13,7 +13,7 @@ import (
 )
 
 // BundleSHA256 is the expected digest of the raw compatibility bundle.
-const BundleSHA256 = "cfeb37f6427a557d0fb5218e9de92c2397e2faa3020c7f688e144ffdf298c51d"
+const BundleSHA256 = "2f968cce51b67ff5969bab6e5502d5792f815d7cd6c416802ee16ba0f8e36b89"
 
 //go:embed testdata/document-compat-v1.json
 var bundleJSON []byte

--- a/document/internal/compattest/bundle_test.go
+++ b/document/internal/compattest/bundle_test.go
@@ -18,6 +18,7 @@ func TestLoadVerifiesRawBundleAndMetadata(t *testing.T) {
 	assert.Equal(t, "document-compat-v1", bundle.FixtureID)
 	assert.Equal(t, "kenn-io/msgvault#616", bundle.SourcePR)
 	assert.Equal(t, "73d6c0b33f74c1fd072a7c0258f1cf1e80054698", bundle.BaselineCommit)
+	assert.Equal(t, "msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698+soft-break-separation", bundle.GeneratedBy)
 	require.Contains(t, bundle.Sections, "normalization_v2")
 	require.Contains(t, bundle.Sections, "mistral_request_fingerprint_v2")
 	require.Contains(t, bundle.Sections, "msgvault_profile_policy_v1")

--- a/document/internal/compattest/bundle_test.go
+++ b/document/internal/compattest/bundle_test.go
@@ -1,0 +1,24 @@
+package compattest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadVerifiesRawBundleAndMetadata(t *testing.T) {
+	bundle, raw, err := Load()
+	require.NoError(t, err)
+	digest := sha256.Sum256(raw)
+	assert.Equal(t, BundleSHA256, hex.EncodeToString(digest[:]))
+	assert.Equal(t, 1, bundle.BundleSchema)
+	assert.Equal(t, "document-compat-v1", bundle.FixtureID)
+	assert.Equal(t, "kenn-io/msgvault#616", bundle.SourcePR)
+	assert.Equal(t, "73d6c0b33f74c1fd072a7c0258f1cf1e80054698", bundle.BaselineCommit)
+	require.Contains(t, bundle.Sections, "normalization_v2")
+	require.Contains(t, bundle.Sections, "mistral_request_fingerprint_v2")
+	require.Contains(t, bundle.Sections, "msgvault_profile_policy_v1")
+}

--- a/document/internal/compattest/testdata/document-compat-v1.json
+++ b/document/internal/compattest/testdata/document-compat-v1.json
@@ -1,0 +1,593 @@
+{
+  "bundle_schema": 1,
+  "fixture_id": "document-compat-v1",
+  "source_pr": "kenn-io/msgvault#616",
+  "baseline_commit": "73d6c0b33f74c1fd072a7c0258f1cf1e80054698",
+  "generated_by": "msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698",
+  "sections": {
+    "mistral_request_fingerprint_v2": {
+      "owner": "go.kenn.io/docbank/document/mistral",
+      "cases": [
+        {
+          "format_id": "pdf",
+          "candidate": {
+            "id": "pdf",
+            "family": "pdf",
+            "media_type": "application/pdf",
+            "unit_kind": "page"
+          },
+          "options": {
+            "pages": "0-499",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "b93829e3f4ccc8e890b4a999ae155cfa30b40e64def51115bc4b809b5623e788"
+        },
+        {
+          "format_id": "docx",
+          "candidate": {
+            "id": "docx",
+            "family": "word",
+            "media_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "unit_kind": "page"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "9ccde804f16d819351485e0ece8316f286590efee008e5aed654ec2ebb6126ed"
+        },
+        {
+          "format_id": "doc",
+          "candidate": {
+            "id": "doc",
+            "family": "word",
+            "media_type": "application/msword",
+            "unit_kind": "page"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "fb5b4cf745fb6d2b2e661728caa8cc83bf24b8eacda861d947e4a910235027ec"
+        },
+        {
+          "format_id": "odt",
+          "candidate": {
+            "id": "odt",
+            "family": "word",
+            "media_type": "application/vnd.oasis.opendocument.text",
+            "unit_kind": "page"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "afc377ef803839e6215cb90d0e8680ae08bf9fa25afcb51c8d7885368a48cdb7"
+        },
+        {
+          "format_id": "rtf",
+          "candidate": {
+            "id": "rtf",
+            "family": "word",
+            "media_type": "application/rtf",
+            "unit_kind": "page"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "9965faa2549bf7e2b59740c0e2349de7071404e72eeba0df965297c64beacbac"
+        },
+        {
+          "format_id": "pptx",
+          "candidate": {
+            "id": "pptx",
+            "family": "presentation",
+            "media_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "unit_kind": "slide"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "c3bbb745cf927fc1a4c341eb21353e2901084f24817c8ce5c5d7f1ac89f6d604"
+        },
+        {
+          "format_id": "ppt",
+          "candidate": {
+            "id": "ppt",
+            "family": "presentation",
+            "media_type": "application/vnd.ms-powerpoint",
+            "unit_kind": "slide"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "b51eb7b6f0af59b81b66d74475dc9a7b20b9a980c347401da63407611a126182"
+        },
+        {
+          "format_id": "xlsx",
+          "candidate": {
+            "id": "xlsx",
+            "family": "spreadsheet",
+            "media_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "unit_kind": "sheet"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "af1a9e59cb099d6b07187dd72523ebf30eca35b6876a1359f9f6662e54faeebe"
+        },
+        {
+          "format_id": "xls",
+          "candidate": {
+            "id": "xls",
+            "family": "spreadsheet",
+            "media_type": "application/vnd.ms-excel",
+            "unit_kind": "sheet"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "2a98da38bd0706e1f36aef463a4f108663957354612797540ccd39ecc998ad43"
+        },
+        {
+          "format_id": "ods",
+          "candidate": {
+            "id": "ods",
+            "family": "spreadsheet",
+            "media_type": "application/vnd.oasis.opendocument.spreadsheet",
+            "unit_kind": "sheet"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "e73ea9df1715600d7b51f8f33d44a7f1106aff5a3c94fe4c102ad5caba8b9a67"
+        },
+        {
+          "format_id": "numbers",
+          "candidate": {
+            "id": "numbers",
+            "family": "spreadsheet",
+            "media_type": "application/vnd.apple.numbers",
+            "unit_kind": "sheet"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "efb45e648b32de8747e5f6733229bc6f61e08b4ab472d0faf719a01b456a1c6f"
+        },
+        {
+          "format_id": "csv",
+          "candidate": {
+            "id": "csv",
+            "family": "spreadsheet",
+            "media_type": "text/csv",
+            "unit_kind": "record"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "4746a5d061bbff9d52c3cd78043731249ee4d7a449bc3dfb38e5c2d954ddf764"
+        },
+        {
+          "format_id": "epub",
+          "candidate": {
+            "id": "epub",
+            "family": "ebook",
+            "media_type": "application/epub+zip",
+            "unit_kind": "spine"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "3a69fed6297ee569eaedf6f75c30af5aeff448741f9ed547aa9b252c5ad63099"
+        },
+        {
+          "format_id": "txt",
+          "candidate": {
+            "id": "txt",
+            "family": "text",
+            "media_type": "text/plain",
+            "unit_kind": "section"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "51fc55e04ef41b705bfe6ea441f4fd502ba3209641da3489cf9689718644cd39"
+        },
+        {
+          "format_id": "markdown",
+          "candidate": {
+            "id": "markdown",
+            "family": "text",
+            "media_type": "text/markdown",
+            "unit_kind": "section"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "031ffdfa34378964a48ca380012c7ef13ddbfa6032fe741bd6853922b0bb29f0"
+        },
+        {
+          "format_id": "rst",
+          "candidate": {
+            "id": "rst",
+            "family": "text",
+            "media_type": "text/x-rst",
+            "unit_kind": "section"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "a3b89c013d46d80cb3187edb065861394a9ad61ff6520d76a5166c89cacc998a"
+        },
+        {
+          "format_id": "latex",
+          "candidate": {
+            "id": "latex",
+            "family": "text",
+            "media_type": "application/x-tex",
+            "unit_kind": "section"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "938fb82a4311dbda02eafec3e1b4a4d82788ffad08b2fccd3ea48b4ff41c2051"
+        },
+        {
+          "format_id": "json",
+          "candidate": {
+            "id": "json",
+            "family": "structured",
+            "media_type": "application/json",
+            "unit_kind": "record"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "ab58e7842d531e10c9eda2fee3da12a00317548020617477674a075f261f4e18"
+        },
+        {
+          "format_id": "jsonl",
+          "candidate": {
+            "id": "jsonl",
+            "family": "structured",
+            "media_type": "application/x-ndjson",
+            "unit_kind": "record"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "e0b13c0997ff9c5d648088d07fc479b42517537b6f83e2a5684be55696b4fb18"
+        },
+        {
+          "format_id": "xml",
+          "candidate": {
+            "id": "xml",
+            "family": "structured",
+            "media_type": "application/xml",
+            "unit_kind": "record"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "4a63cfa1c36fb4ace7cc013fb4107c5d1ae809158a8145654f89552c941985b2"
+        },
+        {
+          "format_id": "yaml",
+          "candidate": {
+            "id": "yaml",
+            "family": "structured",
+            "media_type": "application/yaml",
+            "unit_kind": "record"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "d66d2f150216529ca393e0f8c36239eaa836b8a8ad1dd1e92eed00dac5fc72b4"
+        },
+        {
+          "format_id": "go",
+          "candidate": {
+            "id": "go",
+            "family": "source",
+            "media_type": "text/x-go",
+            "unit_kind": "section"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "675be2eb17d735ff1d433c9b402d1678148543fb924e1d5db23b23cf388ad130"
+        },
+        {
+          "format_id": "python",
+          "candidate": {
+            "id": "python",
+            "family": "source",
+            "media_type": "text/x-python",
+            "unit_kind": "section"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "3ea50ee331cccae309e8c623810c126f348d909a4ff386048c70c3b20f0f09a9"
+        },
+        {
+          "format_id": "javascript",
+          "candidate": {
+            "id": "javascript",
+            "family": "source",
+            "media_type": "text/javascript",
+            "unit_kind": "section"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "9f99e2191bb929ba319eb0b1e0b03354c0c75d08df6d2573fbbc4003b00866fe"
+        },
+        {
+          "format_id": "eml",
+          "candidate": {
+            "id": "eml",
+            "family": "mail",
+            "media_type": "message/rfc822",
+            "unit_kind": "message"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "784c81bf46616af9b0a061484ab65cd296252b3c9bef05a4a4dd834ec8b7dc63"
+        },
+        {
+          "format_id": "msg",
+          "candidate": {
+            "id": "msg",
+            "family": "mail",
+            "media_type": "application/vnd.ms-outlook",
+            "unit_kind": "message"
+          },
+          "options": {
+            "pages": "",
+            "extract_header": true,
+            "extract_footer": true
+          },
+          "fingerprint": "e7706f5c41c4a7cd8cd13c6cc49db8ea7f8948e9ddcc9640f931a6c5eb224587"
+        }
+      ]
+    },
+    "msgvault_profile_policy_v1": {
+      "owner": "go.kenn.io/msgvault/internal/documentindex",
+      "cases": [
+        {
+          "allowed_media_types": [
+            "application/pdf",
+            "text/csv"
+          ],
+          "policy_json": "{\"version\":1,\"provider\":\"mistral\",\"endpoint\":\"https://api.mistral.ai/v1/ocr\",\"model\":\"mistral-ocr-4-0\",\"retention\":\"unknown\",\"training\":\"unknown\",\"max_file_bytes\":52428800,\"max_pages_per_document\":500,\"max_response_bytes\":67108864,\"max_normalized_chars\":25000000,\"max_spool_bytes\":536870912,\"min_free_space_bytes\":1073741824,\"request_timeout_nanos\":300000000000,\"max_retries\":3,\"max_pages_per_run\":10000,\"max_estimated_cost_usd_per_run\":50,\"message_types\":[\"chat\",\"email\"],\"allowed_media_types\":[\"application/pdf\",\"text/csv\"],\"lexical\":true,\"store_chunk_text\":true,\"extract_header\":true,\"extract_footer\":true,\"normalization_version\":2,\"max_unit_chars\":1000000,\"max_source_unit_bytes\":4000000,\"max_metadata_source_bytes\":65536,\"max_link_chars\":2048,\"max_chunk_runes\":4000,\"chunk_overlap\":200,\"max_chunks\":20000}",
+          "fingerprint": "a4900f4266793ad0a4d65dbb9c1bf5926b733d1c249b2bfd87dc34727768b077"
+        }
+      ]
+    },
+    "normalization_v2": {
+      "owner": "go.kenn.io/docbank/document",
+      "cases": [
+        {
+          "name": "rich_markdown_evidence",
+          "max_document_chars": 100000,
+          "source": {
+            "Family": "pdf",
+            "UnitKind": "page",
+            "Units": [
+              {
+                "Index": 0,
+                "Markdown": "# Damage report\n\nThe carton was **crushed**. [Safe](https://example.test/report?id=42)\nand [unsafe](javascript:alert(1)).\n\n![Photo evidence](data:image/png;base64,AAAA)\n\n| Item | Count |\n| --- | ---: |\n| Carton | 3 |\n| Pallet | 1 |\n\n\u003cscript\u003eprivate_executable_marker()\u003c/script\u003e\n\u003cstyle\u003e.hidden { display: none }\u003c/style\u003e\n\n## Inspection\n\n- First edge\n- Second edge\n\n~~~go\npackage synthetic\n~~~\n",
+                "Header": "Warehouse **A**",
+                "Footer": "Page 1",
+                "Dimensions": {
+                  "DPI": 200,
+                  "Height": 2200,
+                  "Width": 1700
+                }
+              }
+            ]
+          },
+          "expected": {
+            "PolicyVersion": 2,
+            "Family": "pdf",
+            "UnitKind": "page",
+            "Units": [
+              {
+                "Index": 0,
+                "SourceKey": "page:000000",
+                "Kind": "page",
+                "Text": "Warehouse A\n\n# Damage report\nThe carton was crushed. Safe (https://example.test/report?id=42)and unsafe.\nPhoto evidence\nItem | Count\nCarton | 3\nPallet | 1\n## Inspection\n- First edge\n- Second edge\n```go\npackage synthetic\n```\n\nPage 1",
+                "Header": "Warehouse A",
+                "Footer": "Page 1",
+                "Dimensions": {
+                  "DPI": 200,
+                  "Height": 2200,
+                  "Width": 1700
+                },
+                "CharCount": 231,
+                "Checksum": "f9b021723f3c37ae0e777b6e3e6d1a9de0b80f65f11978de3c3d3871f14daba9",
+                "Truncated": false,
+                "HeadingMarks": [
+                  {
+                    "CharOffset": 13,
+                    "Path": [
+                      "Damage report"
+                    ]
+                  },
+                  {
+                    "CharOffset": 155,
+                    "Path": [
+                      "Damage report",
+                      "Inspection"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "Chunks": [
+              {
+                "Key": "page:000000:000000-000231",
+                "Ordinal": 0,
+                "Text": "Warehouse A\n\n# Damage report\nThe carton was crushed. Safe (https://example.test/report?id=42)and unsafe.\nPhoto evidence\nItem | Count\nCarton | 3\nPallet | 1\n## Inspection\n- First edge\n- Second edge\n```go\npackage synthetic\n```\n\nPage 1",
+                "HeadingPath": null,
+                "CharCount": 231,
+                "Checksum": "7e5f2a2d44f080d3b4a9d61c214b2a4b2c409a0a39d282dcbd3d72723d22e007",
+                "Truncated": false,
+                "Spans": [
+                  {
+                    "UnitIndex": 0,
+                    "CharStart": 0,
+                    "CharEnd": 231
+                  }
+                ]
+              }
+            ],
+            "Checksum": "ef8ea1899f80869b7660c084c267f67429ba3405e19878c0666e50c31f3a95ee",
+            "Truncated": false
+          }
+        },
+        {
+          "name": "default_chunk_boundary",
+          "max_document_chars": 100000,
+          "source": {
+            "Family": "text",
+            "UnitKind": "section",
+            "Units": [
+              {
+                "Index": 0,
+                "Markdown": "# Boundary evidence\n\nbounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. ",
+                "Header": "",
+                "Footer": "",
+                "Dimensions": {
+                  "DPI": 0,
+                  "Height": 0,
+                  "Width": 0
+                }
+              }
+            ]
+          },
+          "expected": {
+            "PolicyVersion": 2,
+            "Family": "text",
+            "UnitKind": "section",
+            "Units": [
+              {
+                "Index": 0,
+                "SourceKey": "section:000000",
+                "Kind": "section",
+                "Text": "# Boundary evidence\nbounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence.",
+                "Header": "",
+                "Footer": "",
+                "Dimensions": {
+                  "DPI": 0,
+                  "Height": 0,
+                  "Width": 0
+                },
+                "CharCount": 4879,
+                "Checksum": "b4659737be7532941d951e0d53958904ce3f854aeb62d8da4de5f1acd0314b9e",
+                "Truncated": false,
+                "HeadingMarks": [
+                  {
+                    "CharOffset": 0,
+                    "Path": [
+                      "Boundary evidence"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "Chunks": [
+              {
+                "Key": "section:000000:000000-003997",
+                "Ordinal": 0,
+                "Text": "# Boundary evidence\nbounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded ",
+                "HeadingPath": [
+                  "Boundary evidence"
+                ],
+                "CharCount": 3997,
+                "Checksum": "80074d480028c30ac71abfe57f84b01ee8514120f96be1ef4d008dd99150e3eb",
+                "Truncated": false,
+                "Spans": [
+                  {
+                    "UnitIndex": 0,
+                    "CharStart": 0,
+                    "CharEnd": 3997
+                  }
+                ]
+              },
+              {
+                "Key": "section:000000:003797-004879",
+                "Ordinal": 1,
+                "Text": "e. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence. bounded evidence sentence.",
+                "HeadingPath": [
+                  "Boundary evidence"
+                ],
+                "CharCount": 1082,
+                "Checksum": "289eb0b057dc5fc8a790d8c7a45cde0057eb7975f9c1b40d96306fa1bc782e45",
+                "Truncated": false,
+                "Spans": [
+                  {
+                    "UnitIndex": 0,
+                    "CharStart": 3797,
+                    "CharEnd": 4879
+                  }
+                ]
+              }
+            ],
+            "Checksum": "e1b4ad8a0a814e2f52b12d621c06aaec3019b6557a48a0d5f938296ddc0ffd72",
+            "Truncated": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/document/internal/compattest/testdata/document-compat-v1.json
+++ b/document/internal/compattest/testdata/document-compat-v1.json
@@ -3,7 +3,7 @@
   "fixture_id": "document-compat-v1",
   "source_pr": "kenn-io/msgvault#616",
   "baseline_commit": "73d6c0b33f74c1fd072a7c0258f1cf1e80054698",
-  "generated_by": "msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698",
+  "generated_by": "msgvault@73d6c0b33f74c1fd072a7c0258f1cf1e80054698+soft-break-separation",
   "sections": {
     "mistral_request_fingerprint_v2": {
       "owner": "go.kenn.io/docbank/document/mistral",
@@ -445,7 +445,7 @@
                 "Index": 0,
                 "SourceKey": "page:000000",
                 "Kind": "page",
-                "Text": "Warehouse A\n\n# Damage report\nThe carton was crushed. Safe (https://example.test/report?id=42)and unsafe.\nPhoto evidence\nItem | Count\nCarton | 3\nPallet | 1\n## Inspection\n- First edge\n- Second edge\n```go\npackage synthetic\n```\n\nPage 1",
+                "Text": "Warehouse A\n\n# Damage report\nThe carton was crushed. Safe (https://example.test/report?id=42) and unsafe.\nPhoto evidence\nItem | Count\nCarton | 3\nPallet | 1\n## Inspection\n- First edge\n- Second edge\n```go\npackage synthetic\n```\n\nPage 1",
                 "Header": "Warehouse A",
                 "Footer": "Page 1",
                 "Dimensions": {
@@ -453,8 +453,8 @@
                   "Height": 2200,
                   "Width": 1700
                 },
-                "CharCount": 231,
-                "Checksum": "f9b021723f3c37ae0e777b6e3e6d1a9de0b80f65f11978de3c3d3871f14daba9",
+                "CharCount": 232,
+                "Checksum": "f69068f504196b492564d1c659ba82f169617a3d424d7bd23cd68dfda10ee11d",
                 "Truncated": false,
                 "HeadingMarks": [
                   {
@@ -464,7 +464,7 @@
                     ]
                   },
                   {
-                    "CharOffset": 155,
+                    "CharOffset": 156,
                     "Path": [
                       "Damage report",
                       "Inspection"
@@ -475,23 +475,23 @@
             ],
             "Chunks": [
               {
-                "Key": "page:000000:000000-000231",
+                "Key": "page:000000:000000-000232",
                 "Ordinal": 0,
-                "Text": "Warehouse A\n\n# Damage report\nThe carton was crushed. Safe (https://example.test/report?id=42)and unsafe.\nPhoto evidence\nItem | Count\nCarton | 3\nPallet | 1\n## Inspection\n- First edge\n- Second edge\n```go\npackage synthetic\n```\n\nPage 1",
+                "Text": "Warehouse A\n\n# Damage report\nThe carton was crushed. Safe (https://example.test/report?id=42) and unsafe.\nPhoto evidence\nItem | Count\nCarton | 3\nPallet | 1\n## Inspection\n- First edge\n- Second edge\n```go\npackage synthetic\n```\n\nPage 1",
                 "HeadingPath": null,
-                "CharCount": 231,
-                "Checksum": "7e5f2a2d44f080d3b4a9d61c214b2a4b2c409a0a39d282dcbd3d72723d22e007",
+                "CharCount": 232,
+                "Checksum": "59974e33f785b5129aae632b63eaaf929916af1aaef78fb264855612e382fec5",
                 "Truncated": false,
                 "Spans": [
                   {
                     "UnitIndex": 0,
                     "CharStart": 0,
-                    "CharEnd": 231
+                    "CharEnd": 232
                   }
                 ]
               }
             ],
-            "Checksum": "ef8ea1899f80869b7660c084c267f67429ba3405e19878c0666e50c31f3a95ee",
+            "Checksum": "85e11d30f19d56af4198c4acd96c37efa01508f17fbb32be7befde632bba4e24",
             "Truncated": false
           }
         },

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -76,8 +76,7 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 			result.Truncated = true
 		}
 		combinedChars := utf8.RuneCountInString(text)
-		if combinedChars == 0 && remaining == 0 {
-			result.Truncated = true
+		if combinedChars == 0 && remaining == 0 && truncated {
 			break
 		}
 		remaining -= combinedChars

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -218,8 +218,12 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 		}
 		return
 	}
-	if tag == "script" || tag == "style" || tag == "svg" {
-		if !selfClosing && !isHTMLVoidElement(tag) {
+	if tag == "script" || tag == "style" {
+		w.skipTags = append(w.skipTags, tag)
+		return
+	}
+	if tag == "svg" {
+		if !selfClosing {
 			w.skipTags = append(w.skipTags, tag)
 		}
 		return

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -296,16 +296,22 @@ func (w *canonicalHTMLWriter) endTag(tag string) {
 		w.block()
 	case "code":
 		if !w.inPre {
+			w.flushPendingSpace()
 			w.output.WriteByte('`')
 		}
 	case "a":
+		w.flushPendingSpace()
 		if len(w.links) == 0 {
 			return
 		}
 		link := w.links[len(w.links)-1]
 		w.links = w.links[:len(w.links)-1]
 		if link != "" {
-			w.output.WriteString(" (" + link + ")")
+			if w.output.Len() > 0 &&
+				!strings.HasSuffix(w.output.String(), "\n") && !strings.HasSuffix(w.output.String(), " ") {
+				w.output.WriteByte(' ')
+			}
+			w.output.WriteString("(" + link + ")")
 		}
 	}
 }

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
+	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
 	"golang.org/x/net/html"
 )
 
@@ -156,7 +157,10 @@ func canonicalMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (strin
 		return "", nil, false, errors.New("provider Markdown is invalid UTF-8")
 	}
 	markdown, sourceTruncated := truncateUTF8Bytes(markdown, maxSourceBytes)
-	parser := goldmark.New(goldmark.WithExtensions(extension.GFM))
+	parser := goldmark.New(
+		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithRendererOptions(goldmarkhtml.WithUnsafe()),
+	)
 	var rendered bytes.Buffer
 	if err := parser.Convert([]byte(markdown), &rendered); err != nil {
 		return "", nil, false, fmt.Errorf("parse provider Markdown: %w", err)

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -235,6 +235,7 @@ func (w *canonicalHTMLWriter) startTag(token html.Token) {
 			w.output.WriteByte('\n')
 			w.preFenceOpen = false
 		} else if !w.inPre {
+			w.flushPendingSpace()
 			w.output.WriteByte('`')
 		}
 	case "img":
@@ -324,13 +325,17 @@ func (w *canonicalHTMLWriter) writeText(value string) {
 			w.pendingSpace = true
 			continue
 		}
-		if w.pendingSpace && w.output.Len() > 0 &&
-			!strings.HasSuffix(w.output.String(), "\n") && !strings.HasSuffix(w.output.String(), " ") {
-			w.output.WriteByte(' ')
-		}
-		w.pendingSpace = false
+		w.flushPendingSpace()
 		w.output.WriteRune(character)
 	}
+}
+
+func (w *canonicalHTMLWriter) flushPendingSpace() {
+	if w.pendingSpace && w.output.Len() > 0 &&
+		!strings.HasSuffix(w.output.String(), "\n") && !strings.HasSuffix(w.output.String(), " ") {
+		w.output.WriteByte(' ')
+	}
+	w.pendingSpace = false
 }
 
 func (w *canonicalHTMLWriter) line() {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -252,8 +252,7 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 		if w.inPre && w.preFenceOpen {
 			for _, attribute := range token.Attr {
 				if attribute.Key == "class" && strings.HasPrefix(attribute.Val, "language-") {
-					language := strings.TrimPrefix(attribute.Val, "language-")
-					if language != "" && len(language) <= 64 {
+					if language := safeCodeLanguage(strings.TrimPrefix(attribute.Val, "language-")); language != "" {
 						w.output.WriteString(language)
 					}
 				}
@@ -353,6 +352,22 @@ func (w *canonicalHTMLWriter) endTag(tag string) {
 			w.block()
 		}
 	}
+}
+
+func safeCodeLanguage(language string) string {
+	if language == "" || len(language) > 64 {
+		return ""
+	}
+	for _, character := range language {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			strings.ContainsRune("+#-_.", character) {
+			continue
+		}
+		return ""
+	}
+	return language
 }
 
 func isHTMLVoidElement(tag string) bool {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -177,7 +178,7 @@ type canonicalHTMLWriter struct {
 	output       strings.Builder
 	maxLinkChars int
 	inPre        bool
-	skipDepth    int
+	skipTags     []string
 	cellIndex    int
 	links        []string
 	preFenceOpen bool
@@ -194,12 +195,13 @@ func (w *canonicalHTMLWriter) consume(reader io.Reader) error {
 			}
 			return fmt.Errorf("tokenize normalized document HTML: %w", tokenizer.Err())
 		case html.TextToken:
-			if w.skipDepth == 0 {
+			if len(w.skipTags) == 0 {
 				w.writeText(string(tokenizer.Text()))
 			}
-		case html.StartTagToken, html.SelfClosingTagToken:
-			token := tokenizer.Token()
-			w.startTag(token)
+		case html.StartTagToken:
+			w.startTag(tokenizer.Token(), false)
+		case html.SelfClosingTagToken:
+			w.startTag(tokenizer.Token(), true)
 		case html.EndTagToken:
 			w.endTag(tokenizer.Token().Data)
 		case html.CommentToken, html.DoctypeToken:
@@ -208,14 +210,18 @@ func (w *canonicalHTMLWriter) consume(reader io.Reader) error {
 	}
 }
 
-func (w *canonicalHTMLWriter) startTag(token html.Token) {
+func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 	tag := token.Data
-	if w.skipDepth > 0 {
-		w.skipDepth++
+	if len(w.skipTags) > 0 {
+		if !selfClosing && !isHTMLVoidElement(tag) {
+			w.skipTags = append(w.skipTags, tag)
+		}
 		return
 	}
 	if tag == "script" || tag == "style" || tag == "svg" {
-		w.skipDepth = 1
+		if !selfClosing && !isHTMLVoidElement(tag) {
+			w.skipTags = append(w.skipTags, tag)
+		}
 		return
 	}
 	switch tag {
@@ -224,8 +230,6 @@ func (w *canonicalHTMLWriter) startTag(token html.Token) {
 		level := int(tag[1] - '0')
 		_, _ = fmt.Fprintf(&w.output, "%cH%d%c", headingSentinelStart, level, headingSentinelEnd)
 		w.output.WriteString(strings.Repeat("#", level) + " ")
-	case "p", "div", "section", "blockquote", "ul", "ol", "table":
-		w.block()
 	case "li":
 		w.line()
 		w.output.WriteString("- ")
@@ -294,16 +298,25 @@ func (w *canonicalHTMLWriter) startTag(token html.Token) {
 			}
 		}
 		w.links = append(w.links, link)
+	default:
+		if isHTMLBlockElement(tag) {
+			w.block()
+		}
 	}
 }
 
 func (w *canonicalHTMLWriter) endTag(tag string) {
-	if w.skipDepth > 0 {
-		w.skipDepth--
+	if len(w.skipTags) > 0 {
+		for index, v := range slices.Backward(w.skipTags) {
+			if v == tag {
+				w.skipTags = w.skipTags[:index]
+				break
+			}
+		}
 		return
 	}
 	switch tag {
-	case "h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "section", "blockquote", "ul", "ol", "table":
+	case "h1", "h2", "h3", "h4", "h5", "h6":
 		w.block()
 	case "li", "tr":
 		w.line()
@@ -335,6 +348,28 @@ func (w *canonicalHTMLWriter) endTag(tag string) {
 			}
 			w.output.WriteString("(" + link + ")")
 		}
+	default:
+		if isHTMLBlockElement(tag) {
+			w.block()
+		}
+	}
+}
+
+func isHTMLVoidElement(tag string) bool {
+	switch tag {
+	case "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr":
+		return true
+	default:
+		return false
+	}
+}
+
+func isHTMLBlockElement(tag string) bool {
+	switch tag {
+	case "address", "article", "aside", "blockquote", "body", "caption", "center", "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form", "header", "hgroup", "hr", "html", "main", "menu", "nav", "ol", "p", "search", "section", "summary", "table", "tbody", "tfoot", "thead", "ul":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -315,10 +315,10 @@ func (w *canonicalHTMLWriter) writeText(value string) {
 			w.output.WriteByte('\n')
 			w.preFenceOpen = false
 		}
-		w.output.WriteString(stripUnsafeControls(value, true))
+		w.output.WriteString(stripUnsafeControls(value))
 		return
 	}
-	value = stripUnsafeControls(value, false)
+	value = stripUnsafeControls(value)
 	for _, character := range value {
 		if unicode.IsSpace(character) {
 			w.pendingSpace = true
@@ -347,9 +347,9 @@ func (w *canonicalHTMLWriter) block() {
 	}
 }
 
-func stripUnsafeControls(value string, preserveNewlines bool) string {
+func stripUnsafeControls(value string) string {
 	return strings.Map(func(character rune) rune {
-		if character == '\n' && preserveNewlines || character == '\t' {
+		if character == '\n' || character == '\t' {
 			return character
 		}
 		if unicode.IsControl(character) || character == '\u2028' || character == '\u2029' ||

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -1,0 +1,569 @@
+package document
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"golang.org/x/net/html"
+)
+
+const (
+	headingSentinelStart = '\ue000'
+	headingSentinelEnd   = '\ue001'
+)
+
+// NormalizeDocument converts transient provider Markdown into deterministic,
+// inert canonical text plus exact unit spans. It never retains raw responses.
+func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (NormalizedDocument, error) {
+	if source.Family == "" || source.UnitKind == "" || len(source.Units) == 0 {
+		return NormalizedDocument{}, errors.New("document normalization requires family, unit kind, and units")
+	}
+	if err := policy.validate(); err != nil {
+		return NormalizedDocument{}, err
+	}
+
+	result := NormalizedDocument{
+		PolicyVersion: normalizationPolicyVersion, Family: source.Family, UnitKind: source.UnitKind,
+		Units: make([]NormalizedUnit, 0, len(source.Units)),
+	}
+	remaining := policy.maxDocumentChars
+	for i, unit := range source.Units {
+		if unit.Index != i {
+			return NormalizedDocument{}, fmt.Errorf("document source unit %d has noncontiguous index %d", i, unit.Index)
+		}
+		if unit.Dimensions.DPI < 0 || unit.Dimensions.Height < 0 || unit.Dimensions.Width < 0 ||
+			unit.Dimensions.DPI > 100_000 || unit.Dimensions.Height > 10_000_000 || unit.Dimensions.Width > 10_000_000 {
+			return NormalizedDocument{}, fmt.Errorf("document source unit %d has invalid dimensions", i)
+		}
+		text, headings, sourceTruncated, err := canonicalMarkdown(
+			unit.Markdown, policy.maxLinkChars, policy.maxSourceUnitBytes,
+		)
+		if err != nil {
+			return NormalizedDocument{}, fmt.Errorf("normalize document source unit %d: %w", i, err)
+		}
+		header, _, headerSourceTruncated, err := canonicalMarkdown(
+			unit.Header, policy.maxLinkChars, policy.maxMetadataSourceBytes,
+		)
+		if err != nil {
+			return NormalizedDocument{}, fmt.Errorf("normalize document source unit %d header: %w", i, err)
+		}
+		footer, _, footerSourceTruncated, err := canonicalMarkdown(
+			unit.Footer, policy.maxLinkChars, policy.maxMetadataSourceBytes,
+		)
+		if err != nil {
+			return NormalizedDocument{}, fmt.Errorf("normalize document source unit %d footer: %w", i, err)
+		}
+		unitTruncated := sourceTruncated || headerSourceTruncated || footerSourceTruncated
+		header, truncated := truncateRunes(header, min(policy.maxUnitChars, 16_384))
+		unitTruncated = unitTruncated || truncated
+		footer, truncated = truncateRunes(footer, min(policy.maxUnitChars, 16_384))
+		unitTruncated = unitTruncated || truncated
+		text, bodyOffset := joinDocumentUnitEvidence(header, text, footer)
+		for headingIndex := range headings {
+			headings[headingIndex].CharOffset += bodyOffset
+		}
+		text, truncated = truncateRunes(text, min(policy.maxUnitChars, remaining))
+		unitTruncated = unitTruncated || truncated
+		if truncated {
+			result.Truncated = true
+		}
+		combinedChars := utf8.RuneCountInString(text)
+		if combinedChars == 0 && remaining == 0 {
+			result.Truncated = true
+			break
+		}
+		remaining -= combinedChars
+		headings = boundHeadingMarks(text, headings)
+		normalized := NormalizedUnit{
+			Index: unit.Index, SourceKey: fmt.Sprintf("%s:%06d", source.UnitKind, unit.Index), Kind: source.UnitKind,
+			Text: text, Header: header, Footer: footer, Dimensions: unit.Dimensions,
+			CharCount: utf8.RuneCountInString(text), Truncated: unitTruncated, HeadingMarks: headings,
+		}
+		normalized.Checksum = checksumStrings(normalized.SourceKey, normalized.Text, normalized.Header, normalized.Footer)
+		result.Units = append(result.Units, normalized)
+		result.Truncated = result.Truncated || unitTruncated
+	}
+	if len(result.Units) == 0 {
+		return NormalizedDocument{}, errors.New("document normalization produced no units")
+	}
+
+	chunks, chunksTruncated := chunkNormalizedUnits(result.Units, policy)
+	result.Chunks = chunks
+	result.Truncated = result.Truncated || chunksTruncated
+	checksumParts := []string{fmt.Sprintf("v%d", result.PolicyVersion), result.Family, result.UnitKind}
+	for _, unit := range result.Units {
+		checksumParts = append(checksumParts, unit.Checksum)
+	}
+	for _, chunk := range result.Chunks {
+		checksumParts = append(checksumParts, chunk.Checksum)
+	}
+	result.Checksum = checksumStrings(checksumParts...)
+	return result, nil
+}
+
+func joinDocumentUnitEvidence(header, body, footer string) (string, int) {
+	parts := make([]string, 0, 3)
+	bodyOffset := 0
+	if header != "" {
+		parts = append(parts, header)
+		bodyOffset = utf8.RuneCountInString(header)
+		if body != "" || footer != "" {
+			bodyOffset += 2
+		}
+	}
+	if body != "" {
+		parts = append(parts, body)
+	}
+	if footer != "" {
+		parts = append(parts, footer)
+	}
+	return strings.Join(parts, "\n\n"), bodyOffset
+}
+
+func canonicalMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (string, []HeadingMark, bool, error) {
+	if markdown == "" {
+		return "", nil, false, nil
+	}
+	if !utf8.ValidString(markdown) {
+		return "", nil, false, errors.New("provider Markdown is invalid UTF-8")
+	}
+	markdown, sourceTruncated := truncateUTF8Bytes(markdown, maxSourceBytes)
+	parser := goldmark.New(goldmark.WithExtensions(extension.GFM))
+	var rendered bytes.Buffer
+	if err := parser.Convert([]byte(markdown), &rendered); err != nil {
+		return "", nil, false, fmt.Errorf("parse provider Markdown: %w", err)
+	}
+	writer := canonicalHTMLWriter{maxLinkChars: maxLinkChars}
+	if err := writer.consume(bytes.NewReader(rendered.Bytes())); err != nil {
+		return "", nil, false, err
+	}
+	text, headings := canonicalWhitespace(writer.output.String())
+	return text, headings, sourceTruncated, nil
+}
+
+type canonicalHTMLWriter struct {
+	output       strings.Builder
+	maxLinkChars int
+	inPre        bool
+	skipDepth    int
+	cellIndex    int
+	links        []string
+	preFenceOpen bool
+	pendingSpace bool
+}
+
+func (w *canonicalHTMLWriter) consume(reader io.Reader) error {
+	tokenizer := html.NewTokenizer(reader)
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			if errors.Is(tokenizer.Err(), io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("tokenize normalized document HTML: %w", tokenizer.Err())
+		case html.TextToken:
+			if w.skipDepth == 0 {
+				w.writeText(string(tokenizer.Text()))
+			}
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			w.startTag(token)
+		case html.EndTagToken:
+			w.endTag(tokenizer.Token().Data)
+		case html.CommentToken, html.DoctypeToken:
+			// Comments and document declarations are not searchable evidence.
+		}
+	}
+}
+
+func (w *canonicalHTMLWriter) startTag(token html.Token) {
+	tag := token.Data
+	if w.skipDepth > 0 {
+		w.skipDepth++
+		return
+	}
+	if tag == "script" || tag == "style" || tag == "svg" {
+		w.skipDepth = 1
+		return
+	}
+	switch tag {
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		w.block()
+		level := int(tag[1] - '0')
+		_, _ = fmt.Fprintf(&w.output, "%cH%d%c", headingSentinelStart, level, headingSentinelEnd)
+		w.output.WriteString(strings.Repeat("#", level) + " ")
+	case "p", "div", "section", "blockquote", "ul", "ol", "table":
+		w.block()
+	case "li":
+		w.line()
+		w.output.WriteString("- ")
+	case "br":
+		w.line()
+	case "tr":
+		w.line()
+		w.cellIndex = 0
+	case "td", "th":
+		if w.cellIndex > 0 {
+			w.output.WriteString(" | ")
+		}
+		w.cellIndex++
+	case "pre":
+		w.block()
+		w.output.WriteString("```")
+		w.inPre = true
+		w.preFenceOpen = true
+	case "code":
+		if w.inPre && w.preFenceOpen {
+			for _, attribute := range token.Attr {
+				if attribute.Key == "class" && strings.HasPrefix(attribute.Val, "language-") {
+					language := strings.TrimPrefix(attribute.Val, "language-")
+					if language != "" && len(language) <= 64 {
+						w.output.WriteString(language)
+					}
+				}
+			}
+			w.output.WriteByte('\n')
+			w.preFenceOpen = false
+		} else if !w.inPre {
+			w.output.WriteByte('`')
+		}
+	case "img":
+		for _, attribute := range token.Attr {
+			if attribute.Key == "alt" {
+				w.writeText(attribute.Val)
+				break
+			}
+		}
+	case "input":
+		isCheckbox := false
+		checked := false
+		for _, attribute := range token.Attr {
+			if attribute.Key == "type" && attribute.Val == "checkbox" {
+				isCheckbox = true
+			}
+			if attribute.Key == "checked" {
+				checked = true
+			}
+		}
+		if isCheckbox {
+			if checked {
+				w.output.WriteString("[x] ")
+			} else {
+				w.output.WriteString("[ ] ")
+			}
+		}
+	case "a":
+		link := ""
+		for _, attribute := range token.Attr {
+			if attribute.Key == "href" {
+				link = safeStoredLink(attribute.Val, w.maxLinkChars)
+				break
+			}
+		}
+		w.links = append(w.links, link)
+	}
+}
+
+func (w *canonicalHTMLWriter) endTag(tag string) {
+	if w.skipDepth > 0 {
+		w.skipDepth--
+		return
+	}
+	switch tag {
+	case "h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "section", "blockquote", "ul", "ol", "table":
+		w.block()
+	case "li", "tr":
+		w.line()
+	case "pre":
+		if w.preFenceOpen {
+			w.output.WriteByte('\n')
+		}
+		w.inPre = false
+		w.preFenceOpen = false
+		w.line()
+		w.output.WriteString("```")
+		w.block()
+	case "code":
+		if !w.inPre {
+			w.output.WriteByte('`')
+		}
+	case "a":
+		if len(w.links) == 0 {
+			return
+		}
+		link := w.links[len(w.links)-1]
+		w.links = w.links[:len(w.links)-1]
+		if link != "" {
+			w.output.WriteString(" (" + link + ")")
+		}
+	}
+}
+
+func (w *canonicalHTMLWriter) writeText(value string) {
+	if w.inPre {
+		if w.preFenceOpen {
+			w.output.WriteByte('\n')
+			w.preFenceOpen = false
+		}
+		w.output.WriteString(stripUnsafeControls(value, true))
+		return
+	}
+	value = stripUnsafeControls(value, false)
+	for _, character := range value {
+		if unicode.IsSpace(character) {
+			w.pendingSpace = true
+			continue
+		}
+		if w.pendingSpace && w.output.Len() > 0 &&
+			!strings.HasSuffix(w.output.String(), "\n") && !strings.HasSuffix(w.output.String(), " ") {
+			w.output.WriteByte(' ')
+		}
+		w.pendingSpace = false
+		w.output.WriteRune(character)
+	}
+}
+
+func (w *canonicalHTMLWriter) line() {
+	w.pendingSpace = false
+	if w.output.Len() > 0 && !strings.HasSuffix(w.output.String(), "\n") {
+		w.output.WriteByte('\n')
+	}
+}
+
+func (w *canonicalHTMLWriter) block() {
+	w.line()
+	if w.output.Len() > 0 && !strings.HasSuffix(w.output.String(), "\n\n") {
+		w.output.WriteByte('\n')
+	}
+}
+
+func stripUnsafeControls(value string, preserveNewlines bool) string {
+	return strings.Map(func(character rune) rune {
+		if character == '\n' && preserveNewlines || character == '\t' {
+			return character
+		}
+		if unicode.IsControl(character) || character == '\u2028' || character == '\u2029' ||
+			character == headingSentinelStart || character == headingSentinelEnd {
+			return -1
+		}
+		return character
+	}, strings.ReplaceAll(strings.ReplaceAll(value, "\r\n", "\n"), "\r", "\n"))
+}
+
+func safeStoredLink(value string, maxChars int) string {
+	if utf8.RuneCountInString(value) > maxChars {
+		return ""
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.User != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
+		return ""
+	}
+	return parsed.String()
+}
+
+func canonicalWhitespace(value string) (string, []HeadingMark) {
+	lines := strings.Split(strings.ReplaceAll(value, "\r\n", "\n"), "\n")
+	var output strings.Builder
+	headings := make([]HeadingMark, 0)
+	headingPath := make([]string, 0, 6)
+	blank := false
+	endsWithNewline := false
+	runeOffset := 0
+	writeNewline := func() {
+		output.WriteByte('\n')
+		endsWithNewline = true
+		runeOffset++
+	}
+	for _, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			if output.Len() == 0 || blank {
+				continue
+			}
+			blank = true
+			writeNewline()
+			continue
+		}
+		level := 0
+		prefix := string(headingSentinelStart) + "H"
+		if strings.HasPrefix(line, prefix) {
+			end := strings.IndexRune(line, headingSentinelEnd)
+			if end == len(prefix)+1 && line[len(prefix)] >= '1' && line[len(prefix)] <= '6' {
+				level = int(line[len(prefix)] - '0')
+				line = line[end+utf8.RuneLen(headingSentinelEnd):]
+			}
+		}
+		blank = false
+		if output.Len() > 0 && !endsWithNewline {
+			writeNewline()
+		}
+		offset := runeOffset
+		output.WriteString(line)
+		runeOffset += utf8.RuneCountInString(line)
+		endsWithNewline = false
+		if level > 0 {
+			for len(headingPath) < level {
+				headingPath = append(headingPath, "")
+			}
+			headingPath = headingPath[:level]
+			headingPath[level-1] = strings.TrimSpace(strings.TrimLeft(line, "#"))
+			headings = append(headings, HeadingMark{
+				CharOffset: offset,
+				Path:       append([]string(nil), compactHeadingPath(headingPath)...),
+			})
+		}
+	}
+	return strings.TrimRight(output.String(), "\n"), headings
+}
+
+func boundHeadingMarks(text string, headings []HeadingMark) []HeadingMark {
+	textRunes := []rune(text)
+	bounded := make([]HeadingMark, 0, len(headings))
+	for _, heading := range headings {
+		if heading.CharOffset < 0 || heading.CharOffset >= len(textRunes) || len(heading.Path) == 0 {
+			continue
+		}
+		end := heading.CharOffset
+		for end < len(textRunes) && textRunes[end] != '\n' {
+			end++
+		}
+		title := strings.TrimSpace(strings.TrimLeft(string(textRunes[heading.CharOffset:end]), "#"))
+		path := append([]string(nil), heading.Path...)
+		path[len(path)-1] = title
+		bounded = append(bounded, HeadingMark{CharOffset: heading.CharOffset, Path: path})
+	}
+	return bounded
+}
+
+func truncateUTF8Bytes(value string, limit int) (string, bool) {
+	if len(value) <= limit {
+		return value, false
+	}
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return value[:cut], true
+}
+
+func truncateRunes(value string, limit int) (string, bool) {
+	if limit < 0 {
+		limit = 0
+	}
+	if utf8.RuneCountInString(value) <= limit {
+		return value, false
+	}
+	for byteOffset := range value {
+		if limit == 0 {
+			return value[:byteOffset], true
+		}
+		limit--
+	}
+	return value, false
+}
+
+func chunkNormalizedUnits(units []NormalizedUnit, policy NormalizePolicy) ([]Chunk, bool) {
+	chunks := make([]Chunk, 0)
+	truncated := false
+	for _, unit := range units {
+		spans := chunkUnitText(unit.Text, policy.maxChunkRunes, policy.chunkOverlap)
+		for _, span := range spans {
+			if len(chunks) >= policy.maxChunks {
+				return chunks, true
+			}
+			chunk := Chunk{
+				Key:     fmt.Sprintf("%s:%06d-%06d", unit.SourceKey, span.CharStart, span.CharEnd),
+				Ordinal: len(chunks), Text: span.Text, HeadingPath: headingPathAt(unit.HeadingMarks, span.CharStart),
+				CharCount: utf8.RuneCountInString(span.Text), Truncated: unit.Truncated,
+				Spans: []ChunkSpan{{UnitIndex: unit.Index, CharStart: span.CharStart, CharEnd: span.CharEnd}},
+			}
+			chunk.Checksum = checksumStrings(chunk.Key, chunk.Text, strings.Join(chunk.HeadingPath, "\x00"))
+			chunks = append(chunks, chunk)
+		}
+	}
+	return chunks, truncated
+}
+
+type unitChunkSpan struct {
+	Text      string
+	CharStart int
+	CharEnd   int
+}
+
+func chunkUnitText(text string, maxRunes, overlapRunes int) []unitChunkSpan {
+	if text == "" {
+		return nil
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return []unitChunkSpan{{Text: text, CharEnd: len(runes)}}
+	}
+	spans := make([]unitChunkSpan, 0, len(runes)/maxRunes+1)
+	for cursor := 0; cursor < len(runes); {
+		end := min(cursor+maxRunes, len(runes))
+		cut := end
+		if end < len(runes) {
+			floor := max(cursor+(maxRunes*3/4), cursor+1)
+			for i := end - 1; i >= floor; i-- {
+				if runes[i] == '\n' {
+					cut = i + 1
+					break
+				}
+			}
+			if cut == end {
+				for i := end - 1; i >= floor; i-- {
+					if unicode.IsSpace(runes[i]) {
+						cut = i + 1
+						break
+					}
+				}
+			}
+		}
+		spans = append(spans, unitChunkSpan{Text: string(runes[cursor:cut]), CharStart: cursor, CharEnd: cut})
+		if cut == len(runes) {
+			break
+		}
+		cursor += max((cut-cursor)-overlapRunes, 1)
+	}
+	return spans
+}
+
+func compactHeadingPath(path []string) []string {
+	result := make([]string, 0, len(path))
+	for _, part := range path {
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}
+
+func headingPathAt(marks []HeadingMark, offset int) []string {
+	var result []string
+	for _, mark := range marks {
+		if mark.CharOffset > offset {
+			break
+		}
+		result = mark.Path
+	}
+	return append([]string(nil), result...)
+}
+
+func checksumStrings(values ...string) string {
+	hash := sha256.New()
+	for _, value := range values {
+		_, _ = io.WriteString(hash, fmt.Sprintf("%d:", len(value)))
+		_, _ = io.WriteString(hash, value)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -450,7 +450,8 @@ func stripUnsafeControls(value string) string {
 }
 
 func safeStoredLink(value string, maxChars int) string {
-	if utf8.RuneCountInString(value) > maxChars {
+	if utf8.RuneCountInString(value) > maxChars ||
+		strings.ContainsRune(value, headingSentinelStart) || strings.ContainsRune(value, headingSentinelEnd) {
 		return ""
 	}
 	parsed, err := url.Parse(value)

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -285,6 +285,7 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 			}
 		}
 		if isCheckbox {
+			w.flushPendingSpace()
 			if checked {
 				w.output.WriteString("[x] ")
 			} else {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -79,11 +79,11 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 			break
 		}
 		remaining -= combinedChars
-		headings = boundHeadingMarks(text, headings)
+		boundedHeadings := boundHeadingMarks(text, headings)
 		normalized := NormalizedUnit{
 			Index: unit.Index, SourceKey: fmt.Sprintf("%s:%06d", source.UnitKind, unit.Index), Kind: source.UnitKind,
 			Text: text, Header: header, Footer: footer, Dimensions: unit.Dimensions,
-			CharCount: utf8.RuneCountInString(text), Truncated: unitTruncated, HeadingMarks: headings,
+			CharCount: utf8.RuneCountInString(text), Truncated: unitTruncated, HeadingMarks: boundedHeadings,
 		}
 		normalized.Checksum = checksumStrings(normalized.SourceKey, normalized.Text, normalized.Header, normalized.Footer)
 		result.Units = append(result.Units, normalized)
@@ -148,7 +148,7 @@ func joinDocumentUnitEvidence(header, body, footer string) (string, int) {
 	return strings.Join(parts, "\n\n"), bodyOffset
 }
 
-func canonicalMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (string, []HeadingMark, bool, error) {
+func canonicalMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (string, []canonicalHeadingMark, bool, error) {
 	if markdown == "" {
 		return "", nil, false, nil
 	}
@@ -378,11 +378,16 @@ func (w *canonicalHTMLWriter) block() {
 
 func stripUnsafeControls(value string) string {
 	return strings.Map(func(character rune) rune {
-		if character == '\n' || character == '\t' {
+		switch character {
+		case '\n', '\t':
 			return character
+		case '\f', '\v', '\u0085', '\u2028', '\u2029':
+			return '\n'
 		}
-		if unicode.IsControl(character) || character == '\u2028' || character == '\u2029' ||
-			character == headingSentinelStart || character == headingSentinelEnd {
+		if unicode.IsSpace(character) {
+			return ' '
+		}
+		if unicode.IsControl(character) || character == headingSentinelStart || character == headingSentinelEnd {
 			return -1
 		}
 		return character
@@ -400,11 +405,15 @@ func safeStoredLink(value string, maxChars int) string {
 	return parsed.String()
 }
 
-func canonicalWhitespace(value string) (string, []HeadingMark) {
+type canonicalHeadingMark struct {
+	CharOffset int
+	Level      int
+}
+
+func canonicalWhitespace(value string) (string, []canonicalHeadingMark) {
 	lines := strings.Split(strings.ReplaceAll(value, "\r\n", "\n"), "\n")
 	var output strings.Builder
-	headings := make([]HeadingMark, 0)
-	headingPath := make([]string, 0, 6)
+	headings := make([]canonicalHeadingMark, 0)
 	blank := false
 	endsWithNewline := false
 	runeOffset := 0
@@ -441,25 +450,18 @@ func canonicalWhitespace(value string) (string, []HeadingMark) {
 		runeOffset += utf8.RuneCountInString(line)
 		endsWithNewline = false
 		if level > 0 {
-			for len(headingPath) < level {
-				headingPath = append(headingPath, "")
-			}
-			headingPath = headingPath[:level]
-			headingPath[level-1] = strings.TrimSpace(strings.TrimLeft(line, "#"))
-			headings = append(headings, HeadingMark{
-				CharOffset: offset,
-				Path:       append([]string(nil), compactHeadingPath(headingPath)...),
-			})
+			headings = append(headings, canonicalHeadingMark{CharOffset: offset, Level: level})
 		}
 	}
 	return strings.TrimRight(output.String(), "\n"), headings
 }
 
-func boundHeadingMarks(text string, headings []HeadingMark) []HeadingMark {
+func boundHeadingMarks(text string, headings []canonicalHeadingMark) []HeadingMark {
 	textRunes := []rune(text)
 	bounded := make([]HeadingMark, 0, len(headings))
+	headingPath := make([]string, 0, 6)
 	for _, heading := range headings {
-		if heading.CharOffset < 0 || heading.CharOffset >= len(textRunes) || len(heading.Path) == 0 {
+		if heading.CharOffset < 0 || heading.CharOffset >= len(textRunes) || heading.Level < 1 || heading.Level > 6 {
 			continue
 		}
 		end := heading.CharOffset
@@ -467,9 +469,15 @@ func boundHeadingMarks(text string, headings []HeadingMark) []HeadingMark {
 			end++
 		}
 		title := strings.TrimSpace(strings.TrimLeft(string(textRunes[heading.CharOffset:end]), "#"))
-		path := append([]string(nil), heading.Path...)
-		path[len(path)-1] = title
-		bounded = append(bounded, HeadingMark{CharOffset: heading.CharOffset, Path: path})
+		for len(headingPath) < heading.Level {
+			headingPath = append(headingPath, "")
+		}
+		headingPath = headingPath[:heading.Level]
+		headingPath[heading.Level-1] = title
+		bounded = append(bounded, HeadingMark{
+			CharOffset: heading.CharOffset,
+			Path:       compactHeadingPath(headingPath),
+		})
 	}
 	return bounded
 }

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -22,6 +21,7 @@ import (
 const (
 	headingSentinelStart = '\ue000'
 	headingSentinelEnd   = '\ue001'
+	headingMarkerClose   = "\ue000E\ue001"
 )
 
 // NormalizeDocument converts transient provider Markdown into deterministic,
@@ -69,6 +69,7 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 		text, bodyOffset := joinDocumentUnitEvidence(header, text, footer)
 		for headingIndex := range headings {
 			headings[headingIndex].CharOffset += bodyOffset
+			headings[headingIndex].EndOffset += bodyOffset
 		}
 		text, truncated = truncateRunes(text, min(policy.maxUnitChars, remaining))
 		unitTruncated = unitTruncated || truncated
@@ -177,7 +178,8 @@ type canonicalHTMLWriter struct {
 	output       strings.Builder
 	maxLinkChars int
 	inPre        bool
-	skipTags     []string
+	skipTag      string
+	skipDepth    int
 	cellIndex    int
 	links        []string
 	preFenceOpen bool
@@ -194,7 +196,7 @@ func (w *canonicalHTMLWriter) consume(reader io.Reader) error {
 			}
 			return fmt.Errorf("tokenize normalized document HTML: %w", tokenizer.Err())
 		case html.TextToken:
-			if len(w.skipTags) == 0 {
+			if w.skipDepth == 0 {
 				w.writeText(string(tokenizer.Text()))
 			}
 		case html.StartTagToken:
@@ -211,19 +213,21 @@ func (w *canonicalHTMLWriter) consume(reader io.Reader) error {
 
 func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 	tag := token.Data
-	if len(w.skipTags) > 0 {
-		if !selfClosing && !isHTMLVoidElement(tag) {
-			w.skipTags = append(w.skipTags, tag)
+	if w.skipDepth > 0 {
+		if tag == w.skipTag && !selfClosing {
+			w.skipDepth++
 		}
 		return
 	}
 	if tag == "script" || tag == "style" {
-		w.skipTags = append(w.skipTags, tag)
+		w.skipTag = tag
+		w.skipDepth = 1
 		return
 	}
 	if tag == "svg" {
 		if !selfClosing {
-			w.skipTags = append(w.skipTags, tag)
+			w.skipTag = tag
+			w.skipDepth = 1
 		}
 		return
 	}
@@ -309,17 +313,19 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 }
 
 func (w *canonicalHTMLWriter) endTag(tag string) {
-	if len(w.skipTags) > 0 {
-		for index, v := range slices.Backward(w.skipTags) {
-			if v == tag {
-				w.skipTags = w.skipTags[:index]
-				break
+	if w.skipDepth > 0 {
+		if tag == w.skipTag {
+			w.skipDepth--
+			if w.skipDepth == 0 {
+				w.skipTag = ""
 			}
 		}
 		return
 	}
 	switch tag {
 	case "h1", "h2", "h3", "h4", "h5", "h6":
+		w.flushPendingSpace()
+		w.output.WriteString(headingMarkerClose)
 		w.block()
 	case "li", "tr":
 		w.line()
@@ -372,15 +378,6 @@ func safeCodeLanguage(language string) string {
 		return ""
 	}
 	return language
-}
-
-func isHTMLVoidElement(tag string) bool {
-	switch tag {
-	case "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr":
-		return true
-	default:
-		return false
-	}
 }
 
 func isHTMLBlockElement(tag string) bool {
@@ -465,6 +462,7 @@ func safeStoredLink(value string, maxChars int) string {
 
 type canonicalHeadingMark struct {
 	CharOffset int
+	EndOffset  int
 	Level      int
 }
 
@@ -472,6 +470,7 @@ func canonicalWhitespace(value string) (string, []canonicalHeadingMark) {
 	lines := strings.Split(strings.ReplaceAll(value, "\r\n", "\n"), "\n")
 	var output strings.Builder
 	headings := make([]canonicalHeadingMark, 0)
+	activeHeadings := make([]int, 0, 1)
 	blank := false
 	endsWithNewline := false
 	runeOffset := 0
@@ -480,16 +479,17 @@ func canonicalWhitespace(value string) (string, []canonicalHeadingMark) {
 		endsWithNewline = true
 		runeOffset++
 	}
-	for _, line := range lines {
-		line = strings.TrimRight(line, " \t")
-		if line == "" {
-			if output.Len() == 0 || blank {
-				continue
+	closeHeadings := func(count int) {
+		for range count {
+			if len(activeHeadings) == 0 {
+				return
 			}
-			blank = true
-			writeNewline()
-			continue
+			index := activeHeadings[len(activeHeadings)-1]
+			activeHeadings = activeHeadings[:len(activeHeadings)-1]
+			headings[index].EndOffset = runeOffset
 		}
+	}
+	for _, line := range lines {
 		level := 0
 		prefix := string(headingSentinelStart) + "H"
 		if strings.HasPrefix(line, prefix) {
@@ -499,17 +499,34 @@ func canonicalWhitespace(value string) (string, []canonicalHeadingMark) {
 				line = line[end+utf8.RuneLen(headingSentinelEnd):]
 			}
 		}
+		closedHeadings := strings.Count(line, headingMarkerClose)
+		line = strings.ReplaceAll(line, headingMarkerClose, "")
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			closeHeadings(closedHeadings)
+			if output.Len() == 0 || blank {
+				continue
+			}
+			blank = true
+			writeNewline()
+			continue
+		}
 		blank = false
 		if output.Len() > 0 && !endsWithNewline {
 			writeNewline()
 		}
 		offset := runeOffset
+		if level > 0 {
+			headings = append(headings, canonicalHeadingMark{CharOffset: offset, Level: level})
+			activeHeadings = append(activeHeadings, len(headings)-1)
+		}
 		output.WriteString(line)
 		runeOffset += utf8.RuneCountInString(line)
 		endsWithNewline = false
-		if level > 0 {
-			headings = append(headings, canonicalHeadingMark{CharOffset: offset, Level: level})
-		}
+		closeHeadings(closedHeadings)
+	}
+	for _, index := range activeHeadings {
+		headings[index].EndOffset = runeOffset
 	}
 	return strings.TrimRight(output.String(), "\n"), headings
 }
@@ -522,11 +539,8 @@ func boundHeadingMarks(text string, headings []canonicalHeadingMark) []HeadingMa
 		if heading.CharOffset < 0 || heading.CharOffset >= len(textRunes) || heading.Level < 1 || heading.Level > 6 {
 			continue
 		}
-		end := heading.CharOffset
-		for end < len(textRunes) && textRunes[end] != '\n' {
-			end++
-		}
-		title := strings.TrimSpace(strings.TrimLeft(string(textRunes[heading.CharOffset:end]), "#"))
+		end := min(max(heading.EndOffset, heading.CharOffset), len(textRunes))
+		title := strings.Join(strings.Fields(strings.TrimLeft(string(textRunes[heading.CharOffset:end]), "#")), " ")
 		for len(headingPath) < heading.Level {
 			headingPath = append(headingPath, "")
 		}

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -31,6 +31,9 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 	if err := policy.validate(); err != nil {
 		return NormalizedDocument{}, err
 	}
+	if err := validateSourceUnits(source.Units); err != nil {
+		return NormalizedDocument{}, err
+	}
 
 	result := NormalizedDocument{
 		PolicyVersion: normalizationPolicyVersion, Family: source.Family, UnitKind: source.UnitKind,
@@ -38,13 +41,6 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 	}
 	remaining := policy.maxDocumentChars
 	for i, unit := range source.Units {
-		if unit.Index != i {
-			return NormalizedDocument{}, fmt.Errorf("document source unit %d has noncontiguous index %d", i, unit.Index)
-		}
-		if unit.Dimensions.DPI < 0 || unit.Dimensions.Height < 0 || unit.Dimensions.Width < 0 ||
-			unit.Dimensions.DPI > 100_000 || unit.Dimensions.Height > 10_000_000 || unit.Dimensions.Width > 10_000_000 {
-			return NormalizedDocument{}, fmt.Errorf("document source unit %d has invalid dimensions", i)
-		}
 		text, headings, sourceTruncated, err := canonicalMarkdown(
 			unit.Markdown, policy.maxLinkChars, policy.maxSourceUnitBytes,
 		)
@@ -109,6 +105,28 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 	}
 	result.Checksum = checksumStrings(checksumParts...)
 	return result, nil
+}
+
+func validateSourceUnits(units []SourceUnit) error {
+	for i, unit := range units {
+		if unit.Index != i {
+			return fmt.Errorf("document source unit %d has noncontiguous index %d", i, unit.Index)
+		}
+		if unit.Dimensions.DPI < 0 || unit.Dimensions.Height < 0 || unit.Dimensions.Width < 0 ||
+			unit.Dimensions.DPI > 100_000 || unit.Dimensions.Height > 10_000_000 || unit.Dimensions.Width > 10_000_000 {
+			return fmt.Errorf("document source unit %d has invalid dimensions", i)
+		}
+		if !utf8.ValidString(unit.Markdown) {
+			return fmt.Errorf("normalize document source unit %d: provider Markdown is invalid UTF-8", i)
+		}
+		if !utf8.ValidString(unit.Header) {
+			return fmt.Errorf("normalize document source unit %d header: provider Markdown is invalid UTF-8", i)
+		}
+		if !utf8.ValidString(unit.Footer) {
+			return fmt.Errorf("normalize document source unit %d footer: provider Markdown is invalid UTF-8", i)
+		}
+	}
+	return nil
 }
 
 func joinDocumentUnitEvidence(header, body, footer string) (string, int) {

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -1,0 +1,233 @@
+package document
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeDocumentPreservesEvidenceAndRemovesActiveContent(t *testing.T) {
+	assert := assert.New(t)
+	markdown := `# Damage report
+
+The carton was **crushed**. [Safe](https://example.test/report?id=42)
+and [unsafe](javascript:alert(1)).
+
+![Photo evidence](data:image/png;base64,AAAA)
+
+| Item | Count |
+| --- | ---: |
+| Carton | 3 |
+| Pallet | 1 |
+
+<script>private_executable_marker()</script>
+<style>.hidden { display: none }</style>
+
+## Inspection
+
+- First edge
+- Second edge
+
+~~~go
+package synthetic
+~~~
+`
+	source := SourceDocument{Family: "pdf", UnitKind: "page", Units: []SourceUnit{{
+		Index: 0, Markdown: markdown, Header: "Warehouse **A**", Footer: "Page 1",
+		Dimensions: UnitDimensions{DPI: 200, Height: 2200, Width: 1700},
+	}}}
+	policy := testNormalizePolicy(t, 100_000)
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	require.Len(t, normalized.Units, 1)
+	unit := normalized.Units[0]
+	assert.Contains(unit.Text, "# Damage report")
+	assert.Contains(unit.Text, "carton was crushed")
+	assert.Contains(unit.Text, "Safe (https://example.test/report?id=42)")
+	assert.Contains(unit.Text, "unsafe")
+	assert.NotContains(unit.Text, "javascript:")
+	assert.Contains(unit.Text, "Photo evidence")
+	assert.NotContains(unit.Text, "data:image")
+	assert.Contains(unit.Text, "Item | Count")
+	assert.Contains(unit.Text, "Carton | 3")
+	assert.Contains(unit.Text, "Pallet | 1")
+	assert.NotContains(unit.Text, "private_executable_marker")
+	assert.NotContains(unit.Text, "display: none")
+	assert.Contains(unit.Text, "```go\npackage synthetic\n```")
+	assert.Contains(unit.Text, "Warehouse A")
+	assert.Contains(unit.Text, "Page 1")
+	assert.Equal("Warehouse A", unit.Header)
+	assert.Equal("Page 1", unit.Footer)
+	assert.Regexp(`^[0-9a-f]{64}$`, unit.Checksum)
+	assert.Regexp(`^[0-9a-f]{64}$`, normalized.Checksum)
+}
+
+func TestNormalizeDocumentRejectsZeroPolicy(t *testing.T) {
+	source := SourceDocument{
+		Family: "text", UnitKind: "section",
+		Units: []SourceUnit{{Index: 0, Markdown: "synthetic evidence"}},
+	}
+
+	_, err := NormalizeDocument(source, NormalizePolicy{})
+	require.ErrorContains(t, err, "use NewNormalizePolicy")
+}
+
+func TestNormalizeDocumentPublishesHeaderAndFooterOnlyEvidence(t *testing.T) {
+	source := SourceDocument{Family: "pdf", UnitKind: "page", Units: []SourceUnit{{
+		Index: 0, Header: "Confidential **shipment**", Footer: "Dock 7",
+	}}}
+
+	normalized, err := NormalizeDocument(source, testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+	require.Len(t, normalized.Units, 1)
+	assert.Equal(t, "Confidential shipment\n\nDock 7", normalized.Units[0].Text)
+	assert.Equal(t, "Confidential shipment", normalized.Units[0].Header)
+	assert.Equal(t, "Dock 7", normalized.Units[0].Footer)
+	require.Len(t, normalized.Chunks, 1)
+	assert.Equal(t, normalized.Units[0].Text, normalized.Chunks[0].Text)
+	assert.Equal(t, 0, normalized.Chunks[0].Spans[0].CharStart)
+	assert.Equal(t, normalized.Units[0].CharCount, normalized.Chunks[0].Spans[0].CharEnd)
+}
+
+func TestNormalizeDocumentChunksHaveExactUnitSpansAndHeadingPaths(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	markdown := "# Alpha\n\n" + strings.Repeat("alpha evidence sentence. ", 8) +
+		"\n\n## Beta\n\n" + strings.Repeat("beta evidence sentence. ", 8)
+	policy := testNormalizePolicy(t, 10_000)
+	policy.maxChunkRunes = 100
+	policy.chunkOverlap = 10
+	source := SourceDocument{Family: "word", UnitKind: "page", Units: []SourceUnit{{Index: 0, Markdown: markdown}}}
+
+	first, err := NormalizeDocument(source, policy)
+	require.NoError(err)
+	second, err := NormalizeDocument(source, policy)
+	require.NoError(err)
+	assert.Equal(first, second)
+	require.Greater(len(first.Chunks), 1)
+
+	runes := []rune(first.Units[0].Text)
+	for ordinal, chunk := range first.Chunks {
+		assert.Equal(ordinal, chunk.Ordinal)
+		require.Len(chunk.Spans, 1)
+		span := chunk.Spans[0]
+		assert.Equal(chunk.Text, string(runes[span.CharStart:span.CharEnd]))
+		assert.Equal(utf8.RuneCountInString(chunk.Text), chunk.CharCount)
+		assert.Regexp(`^[0-9a-f]{64}$`, chunk.Checksum)
+	}
+	assert.Equal([]string{"Alpha"}, first.Chunks[0].HeadingPath)
+	assert.Contains(first.Chunks[len(first.Chunks)-1].HeadingPath, "Beta")
+}
+
+func TestNormalizeDocumentBoundsUnicodeAndRejectsImpossibleUnits(t *testing.T) {
+	assert := assert.New(t)
+	policy := testNormalizePolicy(t, 6)
+	policy.maxUnitChars = 6
+	policy.maxChunkRunes = 3
+	policy.chunkOverlap = 1
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{Index: 0, Markdown: "é日🙂abcdef"}}}
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	assert.Equal("é日🙂abc", normalized.Units[0].Text)
+	assert.True(normalized.Units[0].Truncated)
+	assert.True(normalized.Truncated)
+	assert.True(utf8.ValidString(normalized.Units[0].Text))
+
+	source.Units = append(source.Units, SourceUnit{Index: 3, Markdown: "later"})
+	_, err = NormalizeDocument(source, policy)
+	require.ErrorContains(t, err, "noncontiguous index")
+
+	source.Units = []SourceUnit{{Index: 0, Markdown: "x", Dimensions: UnitDimensions{Width: -1}}}
+	_, err = NormalizeDocument(source, policy)
+	require.ErrorContains(t, err, "invalid dimensions")
+}
+
+func TestNormalizeDocumentCapsChunksWithoutInventingSpans(t *testing.T) {
+	assert := assert.New(t)
+	policy := testNormalizePolicy(t, 100_000)
+	policy.maxChunkRunes = 20
+	policy.chunkOverlap = 2
+	policy.maxChunks = 2
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{
+		Index: 0, Markdown: strings.Repeat("bounded evidence ", 20),
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	assert.Len(normalized.Chunks, 2)
+	assert.True(normalized.Truncated)
+	for _, chunk := range normalized.Chunks {
+		assert.NotEmpty(chunk.Text)
+		assert.Len(chunk.Spans, 1)
+	}
+}
+
+func TestNormalizeDocumentBoundsHeadingProvenanceToRetainedText(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	policy := testNormalizePolicy(t, 12)
+	policy.maxUnitChars = 12
+	policy.maxChunkRunes = 12
+	policy.chunkOverlap = 2
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{
+		Index: 0, Markdown: "# retained-heading-content-that-is-cut\n\nbody",
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(err)
+	require.Len(normalized.Units, 1)
+	unit := normalized.Units[0]
+	require.Len(unit.HeadingMarks, 1)
+	assert.Equal("# retained-h", unit.Text)
+	assert.Equal([]string{"retained-h"}, unit.HeadingMarks[0].Path)
+	assert.NotContains(unit.HeadingMarks[0].Path[0], "content")
+}
+
+func TestNormalizeDocumentPreservesInlineAdjacencyAndTaskState(t *testing.T) {
+	assert := assert.New(t)
+	policy := testNormalizePolicy(t, 10_000)
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{
+		Index:    0,
+		Markdown: "pre**condition**ed and `identifier`\n\n- [x] shipped\n- [ ] pending",
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	text := normalized.Units[0].Text
+	assert.Contains(text, "preconditioned")
+	assert.NotContains(text, "pre condition ed")
+	assert.Contains(text, "- [x] shipped")
+	assert.Contains(text, "- [ ] pending")
+}
+
+func TestNormalizeDocumentHeadingMetadataIgnoresCodeAndBoundsSource(t *testing.T) {
+	assert := assert.New(t)
+	policy := testNormalizePolicy(t, 10_000)
+	policy.maxSourceUnitBytes = 120
+	source := SourceDocument{Family: "source", UnitKind: "section", Units: []SourceUnit{{
+		Index:    0,
+		Markdown: "# Real\n\n```sh\n# not a heading\necho safe\n```\n\n" + strings.Repeat("bounded tail ", 20),
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	require.Len(t, normalized.Units, 1)
+	unit := normalized.Units[0]
+	assert.True(unit.Truncated)
+	assert.True(normalized.Truncated)
+	require.Len(t, unit.HeadingMarks, 1)
+	assert.Equal([]string{"Real"}, unit.HeadingMarks[0].Path)
+	for _, chunk := range normalized.Chunks {
+		assert.NotContains(chunk.HeadingPath, "not a heading")
+	}
+}
+
+func testNormalizePolicy(t *testing.T, maxDocumentChars int) NormalizePolicy {
+	t.Helper()
+	policy, err := NewNormalizePolicy(maxDocumentChars)
+	require.NoError(t, err)
+	return policy
+}

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -170,6 +170,23 @@ func TestNormalizeDocumentValidatesUnitsAfterCharacterBudget(t *testing.T) {
 	}
 }
 
+func TestNormalizeDocumentRetainsEmptyUnitAtExactCharacterBudget(t *testing.T) {
+	dimensions := UnitDimensions{DPI: 200, Height: 1200, Width: 800}
+	source := SourceDocument{Family: "pdf", UnitKind: "page", Units: []SourceUnit{
+		{Index: 0, Markdown: "x"},
+		{Index: 1, Dimensions: dimensions},
+	}}
+
+	normalized, err := NormalizeDocument(source, testNormalizePolicy(t, 1))
+	require.NoError(t, err)
+	assert.False(t, normalized.Truncated)
+	require.Len(t, normalized.Units, 2)
+	assert.Equal(t, "page:000001", normalized.Units[1].SourceKey)
+	assert.Equal(t, dimensions, normalized.Units[1].Dimensions)
+	assert.Empty(t, normalized.Units[1].Text)
+	assert.False(t, normalized.Units[1].Truncated)
+}
+
 func TestNormalizeDocumentCapsChunksWithoutInventingSpans(t *testing.T) {
 	assert := assert.New(t)
 	policy := testNormalizePolicy(t, 100_000)

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -203,6 +203,17 @@ func TestNormalizeDocumentPreservesInlineAdjacencyAndTaskState(t *testing.T) {
 	assert.Contains(text, "- [ ] pending")
 }
 
+func TestNormalizeDocumentPreservesSoftBreakSeparation(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{
+		Index: 0, Markdown: "alpha\nbeta",
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha beta", normalized.Units[0].Text)
+}
+
 func TestNormalizeDocumentHeadingMetadataIgnoresCodeAndBoundsSource(t *testing.T) {
 	assert := assert.New(t)
 	policy := testNormalizePolicy(t, 10_000)

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -259,6 +259,9 @@ func TestNormalizeDocumentPreservesInertRawHTMLText(t *testing.T) {
 	}{
 		{name: "line break", markdown: "alpha<br>beta", want: "alpha\nbeta"},
 		{name: "block container", markdown: "<div>alpha <strong>beta</strong></div>", want: "alpha beta"},
+		{name: "content after self-closing SVG child", markdown: "<svg><path/></svg>after", want: "after"},
+		{name: "content after void SVG child", markdown: "<svg><br></svg>after", want: "after"},
+		{name: "adjacent definition blocks", markdown: "<dl><dt>Term</dt><dd>Definition</dd></dl>", want: "Term\nDefinition"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -261,6 +261,8 @@ func TestNormalizeDocumentPreservesInertRawHTMLText(t *testing.T) {
 		{name: "block container", markdown: "<div>alpha <strong>beta</strong></div>", want: "alpha beta"},
 		{name: "content after self-closing SVG child", markdown: "<svg><path/></svg>after", want: "after"},
 		{name: "content after void SVG child", markdown: "<svg><br></svg>after", want: "after"},
+		{name: "self-closing script syntax", markdown: "<script/>payload</script>safe", want: "safe"},
+		{name: "self-closing style syntax", markdown: "<style/>payload</style>safe", want: "safe"},
 		{name: "adjacent definition blocks", markdown: "<dl><dt>Term</dt><dd>Definition</dd></dl>", want: "Term\nDefinition"},
 	}
 	for _, test := range tests {

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -214,6 +214,17 @@ func TestNormalizeDocumentPreservesSoftBreakSeparation(t *testing.T) {
 	assert.Equal(t, "alpha beta", normalized.Units[0].Text)
 }
 
+func TestNormalizeDocumentPreservesSpaceBeforeInlineCode(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
+		Index: 0, Markdown: "Use `name` now.",
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "Use `name` now.", normalized.Units[0].Text)
+}
+
 func TestNormalizeDocumentHeadingMetadataIgnoresCodeAndBoundsSource(t *testing.T) {
 	assert := assert.New(t)
 	policy := testNormalizePolicy(t, 10_000)

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -381,11 +381,15 @@ func TestNormalizeDocumentBoundsHeadingPathsByLevel(t *testing.T) {
 func TestNormalizeDocumentPreservesHeadingTextAcrossEmbeddedBreaks(t *testing.T) {
 	policy := testNormalizePolicy(t, 10_000)
 	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
-		Index: 0, Markdown: "# Alpha<br>Beta\n\nbody",
+		Index: 0,
+		Markdown: `<h1>Alpha<br><a href="https://example.test/&#xe000;E&#xe001;">Beta</a></h1>
+
+body`,
 	}}}
 
 	normalized, err := NormalizeDocument(source, policy)
 	require.NoError(t, err)
+	assert.Equal(t, "# Alpha\nBeta\nbody", normalized.Units[0].Text)
 	require.Len(t, normalized.Units[0].HeadingMarks, 1)
 	assert.Equal(t, []string{"Alpha Beta"}, normalized.Units[0].HeadingMarks[0].Path)
 	require.NotEmpty(t, normalized.Chunks)

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -296,6 +296,19 @@ func TestNormalizeDocumentPreservesInertRawHTMLText(t *testing.T) {
 	}
 }
 
+func TestNormalizeDocumentHandlesDeepMalformedExcludedHTML(t *testing.T) {
+	policy := testNormalizePolicy(t, 100_000)
+	markdown := "<svg>" + strings.Repeat("<g>", 4_096) +
+		strings.Repeat("</missing>", 4_096) + "</svg>after"
+	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
+		Index: 0, Markdown: markdown,
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "after", normalized.Units[0].Text)
+}
+
 func TestNormalizeDocumentPreservesSpaceBeforeInlineCode(t *testing.T) {
 	policy := testNormalizePolicy(t, 10_000)
 	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
@@ -363,6 +376,20 @@ func TestNormalizeDocumentBoundsHeadingPathsByLevel(t *testing.T) {
 			assert.Equal(t, test.want, normalized.Units[0].HeadingMarks)
 		})
 	}
+}
+
+func TestNormalizeDocumentPreservesHeadingTextAcrossEmbeddedBreaks(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
+		Index: 0, Markdown: "# Alpha<br>Beta\n\nbody",
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	require.Len(t, normalized.Units[0].HeadingMarks, 1)
+	assert.Equal(t, []string{"Alpha Beta"}, normalized.Units[0].HeadingMarks[0].Path)
+	require.NotEmpty(t, normalized.Chunks)
+	assert.Equal(t, []string{"Alpha Beta"}, normalized.Chunks[0].HeadingPath)
 }
 
 func TestNormalizeDocumentHeadingMetadataIgnoresCodeAndBoundsSource(t *testing.T) {

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -367,6 +367,20 @@ func TestNormalizeDocumentHeadingMetadataIgnoresCodeAndBoundsSource(t *testing.T
 	}
 }
 
+func TestNormalizeDocumentRejectsHeadingMarkupInCodeLanguage(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
+		Index:    0,
+		Markdown: `<pre><code class="language-go&#10;&#xe000;H1&#xe001;# Forged">body</code></pre>`,
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	require.Len(t, normalized.Units, 1)
+	assert.Equal(t, "```\nbody\n```", normalized.Units[0].Text)
+	assert.Empty(t, normalized.Units[0].HeadingMarks)
+}
+
 func testNormalizePolicy(t *testing.T, maxDocumentChars int) NormalizePolicy {
 	t.Helper()
 	policy, err := NewNormalizePolicy(maxDocumentChars)

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -250,6 +250,29 @@ func TestNormalizeDocumentPreservesUnicodeWhitespaceSeparation(t *testing.T) {
 	assert.Equal(t, "alpha beta gamma delta epsilon zeta", normalized.Units[0].Text)
 }
 
+func TestNormalizeDocumentPreservesInertRawHTMLText(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	tests := []struct {
+		name     string
+		markdown string
+		want     string
+	}{
+		{name: "line break", markdown: "alpha<br>beta", want: "alpha\nbeta"},
+		{name: "block container", markdown: "<div>alpha <strong>beta</strong></div>", want: "alpha beta"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
+				Index: 0, Markdown: test.markdown,
+			}}}
+
+			normalized, err := NormalizeDocument(source, policy)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, normalized.Units[0].Text)
+		})
+	}
+}
+
 func TestNormalizeDocumentPreservesSpaceBeforeInlineCode(t *testing.T) {
 	policy := testNormalizePolicy(t, 10_000)
 	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -145,6 +145,31 @@ func TestNormalizeDocumentBoundsUnicodeAndRejectsImpossibleUnits(t *testing.T) {
 	require.ErrorContains(t, err, "invalid dimensions")
 }
 
+func TestNormalizeDocumentValidatesUnitsAfterCharacterBudget(t *testing.T) {
+	policy := testNormalizePolicy(t, 1)
+	tests := []struct {
+		name    string
+		invalid SourceUnit
+		want    string
+	}{
+		{name: "index", invalid: SourceUnit{Index: 3, Markdown: "z"}, want: "noncontiguous index"},
+		{name: "dimensions", invalid: SourceUnit{Index: 2, Markdown: "z", Dimensions: UnitDimensions{Width: -1}}, want: "invalid dimensions"},
+		{name: "UTF-8", invalid: SourceUnit{Index: 2, Markdown: string([]byte{0xff})}, want: "invalid UTF-8"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{
+				{Index: 0, Markdown: "x"},
+				{Index: 1, Markdown: "y"},
+				test.invalid,
+			}}
+
+			_, err := NormalizeDocument(source, policy)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
 func TestNormalizeDocumentCapsChunksWithoutInventingSpans(t *testing.T) {
 	assert := assert.New(t)
 	policy := testNormalizePolicy(t, 100_000)

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -280,6 +280,7 @@ func TestNormalizeDocumentPreservesInertRawHTMLText(t *testing.T) {
 		{name: "content after void SVG child", markdown: "<svg><br></svg>after", want: "after"},
 		{name: "self-closing script syntax", markdown: "<script/>payload</script>safe", want: "safe"},
 		{name: "self-closing style syntax", markdown: "<style/>payload</style>safe", want: "safe"},
+		{name: "checkbox after soft break", markdown: "alpha\n<input type=\"checkbox\">beta", want: "alpha [ ] beta"},
 		{name: "adjacent definition blocks", markdown: "<dl><dt>Term</dt><dd>Definition</dd></dl>", want: "Term\nDefinition"},
 	}
 	for _, test := range tests {

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -225,6 +225,29 @@ func TestNormalizeDocumentPreservesSpaceBeforeInlineCode(t *testing.T) {
 	assert.Equal(t, "Use `name` now.", normalized.Units[0].Text)
 }
 
+func TestNormalizeDocumentKeepsPunctuationAfterInlineElements(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	tests := []struct {
+		name     string
+		markdown string
+		want     string
+	}{
+		{name: "code", markdown: "`value `.", want: "`value `."},
+		{name: "link", markdown: "[value ](https://example.com).", want: "value (https://example.com)."},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
+				Index: 0, Markdown: test.markdown,
+			}}}
+
+			normalized, err := NormalizeDocument(source, policy)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, normalized.Units[0].Text)
+		})
+	}
+}
+
 func TestNormalizeDocumentHeadingMetadataIgnoresCodeAndBoundsSource(t *testing.T) {
 	assert := assert.New(t)
 	policy := testNormalizePolicy(t, 10_000)

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -239,6 +239,17 @@ func TestNormalizeDocumentPreservesSoftBreakSeparation(t *testing.T) {
 	assert.Equal(t, "alpha beta", normalized.Units[0].Text)
 }
 
+func TestNormalizeDocumentPreservesUnicodeWhitespaceSeparation(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
+		Index: 0, Markdown: "alpha\u2028beta\u2029gamma\u0085delta\fepsilon\u00a0zeta",
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha beta gamma delta epsilon zeta", normalized.Units[0].Text)
+}
+
 func TestNormalizeDocumentPreservesSpaceBeforeInlineCode(t *testing.T) {
 	policy := testNormalizePolicy(t, 10_000)
 	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
@@ -269,6 +280,41 @@ func TestNormalizeDocumentKeepsPunctuationAfterInlineElements(t *testing.T) {
 			normalized, err := NormalizeDocument(source, policy)
 			require.NoError(t, err)
 			assert.Equal(t, test.want, normalized.Units[0].Text)
+		})
+	}
+}
+
+func TestNormalizeDocumentBoundsHeadingPathsByLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		limit    int
+		want     []HeadingMark
+	}{
+		{
+			name: "truncated child title retains parent", markdown: "# Parent\n\n## Child title\n\nbody", limit: 11,
+			want: []HeadingMark{{CharOffset: 0, Path: []string{"Parent"}}, {CharOffset: 9, Path: []string{"Parent"}}},
+		},
+		{
+			name: "empty top-level heading resets path", markdown: "# Parent\n\n## Child\n\n#\n\nafter", limit: 10_000,
+			want: []HeadingMark{
+				{CharOffset: 0, Path: []string{"Parent"}},
+				{CharOffset: 9, Path: []string{"Parent", "Child"}},
+				{CharOffset: 18, Path: []string{}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy := testNormalizePolicy(t, test.limit)
+			policy.maxUnitChars = test.limit
+			source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{
+				Index: 0, Markdown: test.markdown,
+			}}}
+
+			normalized, err := NormalizeDocument(source, policy)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, normalized.Units[0].HeadingMarks)
 		})
 	}
 }

--- a/document/policy.go
+++ b/document/policy.go
@@ -1,0 +1,80 @@
+package document
+
+import "errors"
+
+const normalizationPolicyVersion = 2
+
+// NormalizePolicy fixes the version-2 normalization behavior. Its structural
+// values are private because changing any of them requires a new version.
+type NormalizePolicy struct {
+	version                int
+	maxDocumentChars       int
+	maxUnitChars           int
+	maxSourceUnitBytes     int
+	maxMetadataSourceBytes int
+	maxLinkChars           int
+	maxChunkRunes          int
+	chunkOverlap           int
+	maxChunks              int
+}
+
+// NormalizePolicyIdentity is a read-only copy of every effective policy value.
+type NormalizePolicyIdentity struct {
+	Version                int
+	MaxDocumentChars       int
+	MaxUnitChars           int
+	MaxSourceUnitBytes     int
+	MaxMetadataSourceBytes int
+	MaxLinkChars           int
+	MaxChunkRunes          int
+	ChunkOverlap           int
+	MaxChunks              int
+}
+
+// NewNormalizePolicy returns the fixed version-2 policy for a document limit.
+func NewNormalizePolicy(maxDocumentChars int) (NormalizePolicy, error) {
+	policy := NormalizePolicy{
+		version:                normalizationPolicyVersion,
+		maxDocumentChars:       maxDocumentChars,
+		maxUnitChars:           1_000_000,
+		maxSourceUnitBytes:     4_000_000,
+		maxMetadataSourceBytes: 65_536,
+		maxLinkChars:           2_048,
+		maxChunkRunes:          4_000,
+		chunkOverlap:           200,
+		maxChunks:              20_000,
+	}
+	if err := policy.validate(); err != nil {
+		return NormalizePolicy{}, err
+	}
+	return policy, nil
+}
+
+// Identity returns a copy of every value that defines normalization output.
+func (p NormalizePolicy) Identity() NormalizePolicyIdentity {
+	return NormalizePolicyIdentity{
+		Version:                p.version,
+		MaxDocumentChars:       p.maxDocumentChars,
+		MaxUnitChars:           p.maxUnitChars,
+		MaxSourceUnitBytes:     p.maxSourceUnitBytes,
+		MaxMetadataSourceBytes: p.maxMetadataSourceBytes,
+		MaxLinkChars:           p.maxLinkChars,
+		MaxChunkRunes:          p.maxChunkRunes,
+		ChunkOverlap:           p.chunkOverlap,
+		MaxChunks:              p.maxChunks,
+	}
+}
+
+func (p NormalizePolicy) validate() error {
+	if p.version != normalizationPolicyVersion {
+		return errors.New("document normalization policy version is invalid; use NewNormalizePolicy")
+	}
+	if p.maxUnitChars <= 0 || p.maxDocumentChars <= 0 || p.maxSourceUnitBytes <= 0 ||
+		p.maxMetadataSourceBytes <= 0 || p.maxLinkChars <= 0 || p.maxChunkRunes <= 0 || p.maxChunks <= 0 {
+		return errors.New("document normalization limits must be positive")
+	}
+	if p.chunkOverlap < 0 || p.chunkOverlap >= p.maxChunkRunes {
+		return errors.New("document normalization limits are inconsistent")
+	}
+	return nil
+}

--- a/document/policy_test.go
+++ b/document/policy_test.go
@@ -1,0 +1,45 @@
+package document
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNormalizePolicyReturnsVersionTwoIdentity(t *testing.T) {
+	policy, err := NewNormalizePolicy(25_000_000)
+	require.NoError(t, err)
+	assert.Equal(t, NormalizePolicyIdentity{
+		Version:                2,
+		MaxDocumentChars:       25_000_000,
+		MaxUnitChars:           1_000_000,
+		MaxSourceUnitBytes:     4_000_000,
+		MaxMetadataSourceBytes: 65_536,
+		MaxLinkChars:           2_048,
+		MaxChunkRunes:          4_000,
+		ChunkOverlap:           200,
+		MaxChunks:              20_000,
+	}, policy.Identity())
+	assert.NoError(t, policy.validate())
+}
+
+func TestNormalizePolicyRejectsInvalidConstruction(t *testing.T) {
+	_, err := NewNormalizePolicy(0)
+	require.Error(t, err)
+	_, err = NewNormalizePolicy(-1)
+	require.Error(t, err)
+	require.Error(t, (NormalizePolicy{}).validate())
+}
+
+func TestNormalizePolicyIdentityCannotMutatePolicy(t *testing.T) {
+	policy, err := NewNormalizePolicy(25_000_000)
+	require.NoError(t, err)
+
+	identity := policy.Identity()
+	identity.MaxChunkRunes = 1
+	identity.MaxDocumentChars = 1
+
+	assert.Equal(t, 4_000, policy.Identity().MaxChunkRunes)
+	assert.Equal(t, 25_000_000, policy.Identity().MaxDocumentChars)
+}

--- a/document/public_test.go
+++ b/document/public_test.go
@@ -1,0 +1,38 @@
+package document_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+)
+
+func TestPublicSourceEvidenceAndPolicy(t *testing.T) {
+	policy, err := document.NewNormalizePolicy(25_000_000)
+	require.NoError(t, err)
+	assert.Equal(t, 2, policy.Identity().Version)
+	assert.Equal(t, 25_000_000, policy.Identity().MaxDocumentChars)
+
+	source := document.SourceDocument{
+		Family:   "pdf",
+		UnitKind: "page",
+		Units: []document.SourceUnit{{
+			Index:    0,
+			Markdown: "# Synthetic report",
+			Header:   "Example header",
+			Footer:   "Page 1",
+			Dimensions: document.UnitDimensions{
+				DPI: 200, Height: 2200, Width: 1700,
+			},
+		}},
+	}
+	require.Len(t, source.Units, 1)
+	assert.Equal(t, "pdf", source.Family)
+	assert.Equal(t, "page", source.UnitKind)
+	assert.Equal(t, 0, source.Units[0].Index)
+	assert.Equal(t, "# Synthetic report", source.Units[0].Markdown)
+	assert.Equal(t, "Example header", source.Units[0].Header)
+	assert.Equal(t, "Page 1", source.Units[0].Footer)
+	assert.Equal(t, document.UnitDimensions{DPI: 200, Height: 2200, Width: 1700}, source.Units[0].Dimensions)
+}

--- a/document/public_test.go
+++ b/document/public_test.go
@@ -35,4 +35,14 @@ func TestPublicSourceEvidenceAndPolicy(t *testing.T) {
 	assert.Equal(t, "Example header", source.Units[0].Header)
 	assert.Equal(t, "Page 1", source.Units[0].Footer)
 	assert.Equal(t, document.UnitDimensions{DPI: 200, Height: 2200, Width: 1700}, source.Units[0].Dimensions)
+
+	normalized, err := document.NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	require.Len(t, normalized.Units, 1)
+	require.NotEmpty(t, normalized.Units[0].HeadingMarks)
+	require.NotEmpty(t, normalized.Chunks)
+	require.NotEmpty(t, normalized.Chunks[0].Spans)
+	assert.Equal(t, "Synthetic report", normalized.Units[0].HeadingMarks[0].Path[0])
+	assert.Equal(t, 0, normalized.Chunks[0].Ordinal)
+	assert.Equal(t, 0, normalized.Chunks[0].Spans[0].UnitIndex)
 }

--- a/document/types.go
+++ b/document/types.go
@@ -1,0 +1,75 @@
+package document
+
+// SourceDocument contains provider-neutral evidence in source order.
+type SourceDocument struct {
+	Family   string
+	UnitKind string
+	Units    []SourceUnit
+}
+
+// SourceUnit contains the transient evidence for one source unit.
+type SourceUnit struct {
+	Index      int
+	Markdown   string
+	Header     string
+	Footer     string
+	Dimensions UnitDimensions
+}
+
+// UnitDimensions records source dimensions when the provider reports them.
+type UnitDimensions struct {
+	DPI    int
+	Height int
+	Width  int
+}
+
+// NormalizedDocument is deterministic, inert document evidence.
+type NormalizedDocument struct {
+	PolicyVersion int
+	Family        string
+	UnitKind      string
+	Units         []NormalizedUnit
+	Chunks        []Chunk
+	Checksum      string
+	Truncated     bool
+}
+
+// NormalizedUnit is one canonical source unit and its provenance.
+type NormalizedUnit struct {
+	Index        int
+	SourceKey    string
+	Kind         string
+	Text         string
+	Header       string
+	Footer       string
+	Dimensions   UnitDimensions
+	CharCount    int
+	Checksum     string
+	Truncated    bool
+	HeadingMarks []HeadingMark
+}
+
+// HeadingMark records the active heading path at a character offset.
+type HeadingMark struct {
+	CharOffset int
+	Path       []string
+}
+
+// Chunk is a stable publication and provenance unit.
+type Chunk struct {
+	Key         string
+	Ordinal     int
+	Text        string
+	HeadingPath []string
+	CharCount   int
+	Checksum    string
+	Truncated   bool
+	Spans       []ChunkSpan
+}
+
+// ChunkSpan maps a chunk range to its normalized source unit.
+type ChunkSpan struct {
+	UnitIndex int
+	CharStart int
+	CharEnd   int
+}

--- a/go.mod
+++ b/go.mod
@@ -75,9 +75,11 @@ require (
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yuin/goldmark v1.7.17
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
+	golang.org/x/net v0.56.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.kenn.io/kit v0.17.1 h1:ycQ7IpI3tIDaZ3h3rH5bLtSZY5PCkW2DyjqaqW6BEp0=
@@ -159,6 +161,8 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Docbank now provides deterministic document normalization as a normal public Go package. Applications can turn source units into stable text, headings, chunks, spans, and checksums without opening a vault or using Docbank's daemon, storage, queue, or application code.

The version-2 policy has one caller choice: the total document character limit. Chunk sizes and the other structural values are fixed because changing them would change document identity. Expected results come from the pinned Msgvault PR #616 source with the approved soft-break separator correction applied before generation. This keeps the oracle independent while avoiding a known defect that joined words across ordinary Markdown line breaks.

This pull request deliberately stops at the provider-neutral boundary. It does not add Mistral uploads, staging, capability probes, or upload authorization; those safety-sensitive pieces will arrive together in a separate pull request.
