### PR TITLE
Expose Mistral integration contracts

### DIFF
--- a/document/mistral/capabilities.go
+++ b/document/mistral/capabilities.go
@@ -11,13 +11,14 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"go.kenn.io/docbank/document/mistral/internal/probecontract"
 )
 
 const (
-	CapabilitySchemaVersion   = 3
-	probeFixtureContract      = 2
-	requestFingerprintVersion = 2
-	maxManifestBytes          = int64(1 << 20)
+	CapabilitySchemaVersion = 3
+	probeFixtureContract    = probecontract.FixtureVersion
+	maxManifestBytes        = int64(1 << 20)
 )
 
 // UnitBoundMethod identifies how a format's per-document unit limit is
@@ -42,7 +43,7 @@ const (
 const (
 	reasonBoundFixtureOutOfRange = "bound_fixture_out_of_range"
 	reasonBoundRequestFailed     = "bound_request_failed"
-	reasonBoundUnitsMismatch     = "bound_units_mismatch"
+	reasonBoundUnitsMismatch     = probecontract.ReasonBoundUnitsMismatch
 )
 
 var boundUnverifiedReasonCodes = []string{
@@ -121,7 +122,7 @@ func (m CapabilityManifest) ValidateComplete() error {
 	if m.Endpoint != defaultEndpoint || m.Region != defaultRegion || m.RequestedModel != defaultModel {
 		return errors.New("mistral capability manifest endpoint, region, or model is not pinned")
 	}
-	if m.MaxUnits <= 1 || m.MaxUnits > hardMaxUnits {
+	if m.MaxUnits < MinUnits || m.MaxUnits > MaxUnits {
 		return errors.New("mistral capability manifest has invalid unit limit")
 	}
 	if len(m.Results) != len(candidateFormats) {
@@ -307,19 +308,7 @@ func canonicalJSONKey(key string) bool {
 	return true
 }
 
-type requestOptions struct {
-	Pages         string `json:"pages"`
-	ExtractHeader bool   `json:"extract_header"`
-	ExtractFooter bool   `json:"extract_footer"`
-}
-
-type requestFingerprintPayload struct {
-	Version   int             `json:"version"`
-	Endpoint  string          `json:"endpoint"`
-	Model     string          `json:"model"`
-	Candidate CandidateFormat `json:"candidate"`
-	Options   requestOptions  `json:"options"`
-}
+type requestOptions = probecontract.RequestOptions
 
 func requestFingerprint(candidate CandidateFormat, options requestOptions) string {
 	return requestFingerprintForTarget(defaultEndpoint, defaultModel, candidate, options)
@@ -331,15 +320,10 @@ func requestFingerprintForTarget(
 	candidate CandidateFormat,
 	options requestOptions,
 ) string {
-	payload, err := json.Marshal(requestFingerprintPayload{
-		Version: requestFingerprintVersion, Endpoint: endpoint, Model: model,
-		Candidate: candidate, Options: options,
-	})
-	if err != nil {
-		panic(err)
-	}
-	digest := sha256.Sum256(payload)
-	return hex.EncodeToString(digest[:])
+	return probecontract.Fingerprint(endpoint, model, probecontract.Candidate{
+		ID: candidate.ID, Family: candidate.Family, MediaType: candidate.MediaType,
+		UnitKind: candidate.UnitKind,
+	}, options)
 }
 
 func probeRequestOptions(candidate CandidateFormat, maxUnits int, extractHeader, extractFooter bool) requestOptions {

--- a/document/mistral/client.go
+++ b/document/mistral/client.go
@@ -21,15 +21,21 @@ import (
 )
 
 const (
-	defaultTimeout       = 5 * time.Minute
-	defaultMaxRetries    = 3
-	defaultMaxRetryDelay = 30 * time.Second
-	hardMaxTimeout       = 30 * time.Minute
-	hardMaxRetries       = 10
-	hardMaxRetryDelay    = 60 * time.Second
-	maxSourceUnitDPI     = 100_000
-	maxSourceUnitHeight  = 10_000_000
-	maxSourceUnitWidth   = 10_000_000
+	// DefaultTimeout is used when ClientConfig.Timeout is zero.
+	DefaultTimeout = 5 * time.Minute
+	// DefaultMaxRetries is used when ClientConfig.MaxRetries is zero.
+	DefaultMaxRetries = 3
+	// DefaultMaxRetryDelay is used when ClientConfig.MaxRetryDelay is zero.
+	DefaultMaxRetryDelay = 30 * time.Second
+	// MaxTimeout is the largest per-attempt timeout accepted by NewClient.
+	MaxTimeout = 30 * time.Minute
+	// MaxRetries is the largest retry count accepted by NewClient.
+	MaxRetries = 10
+	// MaxRetryDelay is the largest retry delay accepted by NewClient.
+	MaxRetryDelay       = 60 * time.Second
+	maxSourceUnitDPI    = 100_000
+	maxSourceUnitHeight = 10_000_000
+	maxSourceUnitWidth  = 10_000_000
 )
 
 var (
@@ -131,21 +137,21 @@ func NewClient(policy Policy, config ClientConfig) (*Client, error) {
 		return nil, errors.New("mistral OCR API key is required and must not contain surrounding whitespace")
 	}
 	if config.Timeout == 0 {
-		config.Timeout = defaultTimeout
+		config.Timeout = DefaultTimeout
 	}
-	if config.Timeout < 0 || config.Timeout > hardMaxTimeout {
+	if config.Timeout < 0 || config.Timeout > MaxTimeout {
 		return nil, errors.New("mistral OCR timeout is outside package bounds")
 	}
-	if config.MaxRetries < 0 || config.MaxRetries > hardMaxRetries {
+	if config.MaxRetries < 0 || config.MaxRetries > MaxRetries {
 		return nil, errors.New("mistral OCR max retries is outside package bounds")
 	}
 	if config.MaxRetries == 0 {
-		config.MaxRetries = defaultMaxRetries
+		config.MaxRetries = DefaultMaxRetries
 	}
 	if config.MaxRetryDelay == 0 {
-		config.MaxRetryDelay = defaultMaxRetryDelay
+		config.MaxRetryDelay = DefaultMaxRetryDelay
 	}
-	if config.MaxRetryDelay < 0 || config.MaxRetryDelay > hardMaxRetryDelay {
+	if config.MaxRetryDelay < 0 || config.MaxRetryDelay > MaxRetryDelay {
 		return nil, errors.New("mistral OCR retry delay is outside package bounds")
 	}
 

--- a/document/mistral/client_test.go
+++ b/document/mistral/client_test.go
@@ -561,11 +561,11 @@ func TestNewClientValidatesAndAppliesTransportBounds(t *testing.T) {
 		want   string
 	}{
 		{name: "negative timeout", config: ClientConfig{Timeout: -time.Second}, want: "timeout"},
-		{name: "timeout above cap", config: ClientConfig{Timeout: hardMaxTimeout + time.Second}, want: "timeout"},
+		{name: "timeout above cap", config: ClientConfig{Timeout: MaxTimeout + time.Second}, want: "timeout"},
 		{name: "negative retries", config: ClientConfig{MaxRetries: -1}, want: "max retries"},
-		{name: "retries above cap", config: ClientConfig{MaxRetries: hardMaxRetries + 1}, want: "max retries"},
+		{name: "retries above cap", config: ClientConfig{MaxRetries: MaxRetries + 1}, want: "max retries"},
 		{name: "negative retry delay", config: ClientConfig{MaxRetryDelay: -time.Second}, want: "retry delay"},
-		{name: "retry delay above cap", config: ClientConfig{MaxRetryDelay: hardMaxRetryDelay + time.Second}, want: "retry delay"},
+		{name: "retry delay above cap", config: ClientConfig{MaxRetryDelay: MaxRetryDelay + time.Second}, want: "retry delay"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -579,9 +579,9 @@ func TestNewClientValidatesAndAppliesTransportBounds(t *testing.T) {
 		APIKey: "synthetic-key", HTTPClient: &http.Client{},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, defaultMaxRetries, client.maxRetries)
-	assert.Equal(t, defaultMaxRetryDelay, client.maxRetryDelay)
-	assert.Equal(t, defaultTimeout, client.http.Timeout)
+	assert.Equal(t, DefaultMaxRetries, client.maxRetries)
+	assert.Equal(t, DefaultMaxRetryDelay, client.maxRetryDelay)
+	assert.Equal(t, DefaultTimeout, client.http.Timeout)
 
 	client, err = NewClient(policy, ClientConfig{
 		APIKey: "synthetic-key", Timeout: time.Minute,

--- a/document/mistral/errors.go
+++ b/document/mistral/errors.go
@@ -1,0 +1,9 @@
+package mistral
+
+import "errors"
+
+// IsRetryable reports whether err is a transient provider or transport failure,
+// or a spool-capacity refusal that an application can schedule again later.
+func IsRetryable(err error) bool {
+	return errors.Is(err, ErrTransientResponse) || errors.Is(err, ErrSpoolCapacity)
+}

--- a/document/mistral/internal/probecontract/probecontract.go
+++ b/document/mistral/internal/probecontract/probecontract.go
@@ -1,0 +1,51 @@
+// Package probecontract owns the private serialized request identity shared by
+// production probing and consumer test support.
+package probecontract
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+const (
+	FixtureVersion            = 2
+	RequestFingerprintVersion = 2
+	ReasonBoundUnitsMismatch  = "bound_units_mismatch"
+)
+
+// Candidate is the fingerprinted subset of a detected document format.
+type Candidate struct {
+	ID        string `json:"id"`
+	Family    string `json:"family"`
+	MediaType string `json:"media_type"`
+	UnitKind  string `json:"unit_kind"`
+}
+
+// RequestOptions is the fingerprinted provider request shape.
+type RequestOptions struct {
+	Pages         string `json:"pages"`
+	ExtractHeader bool   `json:"extract_header"`
+	ExtractFooter bool   `json:"extract_footer"`
+}
+
+type fingerprintPayload struct {
+	Version   int            `json:"version"`
+	Endpoint  string         `json:"endpoint"`
+	Model     string         `json:"model"`
+	Candidate Candidate      `json:"candidate"`
+	Options   RequestOptions `json:"options"`
+}
+
+// Fingerprint returns the lowercase SHA-256 identity of one probe request.
+func Fingerprint(endpoint, model string, candidate Candidate, options RequestOptions) string {
+	payload, err := json.Marshal(fingerprintPayload{
+		Version: RequestFingerprintVersion, Endpoint: endpoint, Model: model,
+		Candidate: candidate, Options: options,
+	})
+	if err != nil {
+		panic(err)
+	}
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:])
+}

--- a/document/mistral/internal/testfixture/pdf.go
+++ b/document/mistral/internal/testfixture/pdf.go
@@ -1,0 +1,33 @@
+// Package testfixture contains deterministic synthetic document bytes shared
+// by Docbank's tests and its consumer test-support package.
+package testfixture
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+)
+
+// MinimalPDF returns a deterministic one-page PDF containing a synthetic label
+// in a comment. It is suitable for format and staging tests, not OCR probes.
+func MinimalPDF(label string) []byte {
+	objects := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>",
+	}
+	var output bytes.Buffer
+	_, _ = fmt.Fprintf(&output, "%%PDF-1.4\n%%%s\n", hex.EncodeToString([]byte(label)))
+	offsets := make([]int, len(objects))
+	for index, object := range objects {
+		offsets[index] = output.Len()
+		_, _ = fmt.Fprintf(&output, "%d 0 obj\n%s\nendobj\n", index+1, object)
+	}
+	xref := output.Len()
+	_, _ = fmt.Fprintf(&output, "xref\n0 %d\n0000000000 65535 f \n", len(objects)+1)
+	for _, offset := range offsets {
+		_, _ = fmt.Fprintf(&output, "%010d 00000 n \n", offset)
+	}
+	_, _ = fmt.Fprintf(&output, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
+	return output.Bytes()
+}

--- a/document/mistral/mistraltest/mistraltest.go
+++ b/document/mistral/mistraltest/mistraltest.go
@@ -1,0 +1,76 @@
+// Package mistraltest provides deterministic synthetic documents and
+// capability evidence for applications that test Mistral integrations.
+//
+// Synthetic manifests are fabricated test inputs. They are not observations
+// from an authenticated provider probe and must not be used as production
+// upload authority.
+package mistraltest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/document/mistral"
+	"go.kenn.io/docbank/document/mistral/internal/probecontract"
+	"go.kenn.io/docbank/document/mistral/internal/testfixture"
+)
+
+// SyntheticManifest returns a complete, validated manifest for application
+// tests. When pdfBound is true, PDF has provider-request upload authority;
+// every other format remains unbounded.
+func SyntheticManifest(policy mistral.Policy, pdfBound bool) (mistral.CapabilityManifest, error) {
+	values := policy.Values()
+	if values.Provider == "" {
+		return mistral.CapabilityManifest{}, errors.New("mistraltest requires a valid policy")
+	}
+	manifest := mistral.CapabilityManifest{
+		SchemaVersion:        mistral.CapabilitySchemaVersion,
+		ProbeFixtureContract: probecontract.FixtureVersion,
+		ObservedOn:           "2026-08-16", Endpoint: values.Endpoint, Region: values.Region,
+		RequestedModel: values.Model, MaxUnits: values.MaxUnits,
+		Results: make([]mistral.CapabilityResult, 0, len(mistral.CandidateFormats())),
+	}
+	for _, candidate := range mistral.CandidateFormats() {
+		digest := sha256.Sum256([]byte(candidate.ID))
+		options := probecontract.RequestOptions{
+			ExtractHeader: values.ExtractHeader, ExtractFooter: values.ExtractFooter,
+		}
+		if candidate.Family == "pdf" {
+			options.Pages = fmt.Sprintf("0-%d", manifest.MaxUnits-1)
+		}
+		result := mistral.CapabilityResult{
+			FormatID: candidate.ID, Family: candidate.Family, MediaType: candidate.MediaType,
+			UnitKind: candidate.UnitKind, Status: mistral.ProbeStatusPassed,
+			FixtureDigest: hex.EncodeToString(digest[:])[:16],
+			RequestFingerprint: probecontract.Fingerprint(values.Endpoint, values.Model, probecontract.Candidate{
+				ID: candidate.ID, Family: candidate.Family, MediaType: candidate.MediaType,
+				UnitKind: candidate.UnitKind,
+			}, options),
+			ReturnedModel: values.Model, UnitCount: 1, UnitsProcessed: 1,
+			UnitBoundMethod: mistral.UnitBoundNone,
+		}
+		if candidate.ID == "pdf" {
+			result.UnitCount = 2
+			result.UnitsProcessed = 2
+			if pdfBound {
+				result.UnitBoundMethod = mistral.UnitBoundProviderRequest
+				result.FixtureUnits = 2
+				result.BoundRequestedUnits = 1
+				result.BoundUnitsProcessed = 1
+			} else {
+				result.ReasonCode = probecontract.ReasonBoundUnitsMismatch
+			}
+		}
+		manifest.Results = append(manifest.Results, result)
+	}
+	if err := manifest.ValidateComplete(); err != nil {
+		return mistral.CapabilityManifest{}, fmt.Errorf("build synthetic Mistral manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+// MinimalPDF returns deterministic one-page PDF bytes for format, staging, and
+// application orchestration tests. It is not a capability-probe fixture.
+func MinimalPDF(label string) []byte { return testfixture.MinimalPDF(label) }

--- a/document/mistral/mistraltest/mistraltest_test.go
+++ b/document/mistral/mistraltest/mistraltest_test.go
@@ -1,0 +1,44 @@
+package mistraltest_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/mistral"
+	"go.kenn.io/docbank/document/mistral/mistraltest"
+)
+
+func TestSyntheticManifestAuthorizesPDF(t *testing.T) {
+	normalization, err := document.NewNormalizePolicy(100_000)
+	require.NoError(t, err)
+	policy, err := mistral.NewPolicy(mistral.PolicyConfig{
+		Region: mistral.RegionEU, Model: mistral.DefaultModel,
+		Retention: mistral.RetentionZDR, Training: mistral.TrainingOptedOut,
+		MaxDocumentBytes: 1024, MaxResponseBytes: 1 << 20, MaxUnits: 10,
+		ExtractHeader: true, ExtractFooter: true, NormalizePolicy: normalization,
+	})
+	require.NoError(t, err)
+
+	manifest, err := mistraltest.SyntheticManifest(policy, true)
+	require.NoError(t, err)
+	authorization, err := policy.Authorize(manifest, "pdf")
+	require.NoError(t, err)
+	assert.Equal(t, "pdf", authorization.Format().ID)
+
+	pdf := mistraltest.MinimalPDF("synthetic")
+	format, err := mistral.DetectFormat(bytes.NewReader(pdf), int64(len(pdf)), "application/pdf")
+	require.NoError(t, err)
+	assert.Equal(t, "pdf", format.ID)
+}
+
+func TestRetryClassification(t *testing.T) {
+	assert.True(t, mistral.IsRetryable(fmt.Errorf("provider: %w", mistral.ErrTransientResponse)))
+	assert.True(t, mistral.IsRetryable(fmt.Errorf("spool: %w", mistral.ErrSpoolCapacity)))
+	assert.False(t, mistral.IsRetryable(mistral.ErrPermanentResponse))
+	assert.False(t, mistral.IsRetryable(errors.New("application failure")))
+}

--- a/document/mistral/policy.go
+++ b/document/mistral/policy.go
@@ -28,13 +28,17 @@ const (
 	TrainingDefaultOptOut = "default-opt-out"
 	// TrainingOptedOut identifies an explicit training opt-out posture.
 	TrainingOptedOut = "opted-out"
+	// MaxDocumentBytes is the largest document accepted by Policy.
+	MaxDocumentBytes = int64(500 << 20)
+	// MaxResponseBytes is the largest provider response accepted by Policy.
+	MaxResponseBytes = int64(512 << 20)
+	// MinUnits is the smallest per-document unit limit accepted by Policy.
+	MinUnits = 3
+	// MaxUnits is the largest per-document unit limit accepted by Policy.
+	MaxUnits = 5_000
 
 	defaultRegion = RegionEU
 	defaultModel  = DefaultModel
-
-	hardMaxDocumentBytes = int64(500 << 20)
-	hardMaxResponseBytes = int64(512 << 20)
-	hardMaxUnits         = 5_000
 )
 
 // PolicyConfig contains reusable processing and privacy policy.
@@ -86,9 +90,9 @@ func NewPolicy(config PolicyConfig) (Policy, error) {
 	if !slices.Contains([]string{TrainingDefaultOptOut, TrainingOptedOut}, config.Training) {
 		return Policy{}, errors.New("mistral policy training posture must be known")
 	}
-	if config.MaxDocumentBytes <= 0 || config.MaxDocumentBytes > hardMaxDocumentBytes ||
-		config.MaxResponseBytes <= 0 || config.MaxResponseBytes > hardMaxResponseBytes ||
-		config.MaxUnits < 3 || config.MaxUnits > hardMaxUnits {
+	if config.MaxDocumentBytes <= 0 || config.MaxDocumentBytes > MaxDocumentBytes ||
+		config.MaxResponseBytes <= 0 || config.MaxResponseBytes > MaxResponseBytes ||
+		config.MaxUnits < MinUnits || config.MaxUnits > MaxUnits {
 		return Policy{}, errors.New("mistral policy processing bounds are invalid")
 	}
 	normalization := config.NormalizePolicy.Identity()

--- a/document/mistral/sniff.go
+++ b/document/mistral/sniff.go
@@ -51,7 +51,7 @@ func DetectFormat(reader io.ReaderAt, size int64, declaredMediaType string) (Can
 	if reader == nil || size <= 0 {
 		return CandidateFormat{}, errors.New("document format detection requires nonempty bytes")
 	}
-	if size > hardMaxDocumentBytes {
+	if size > MaxDocumentBytes {
 		return CandidateFormat{}, errors.New("document exceeds the format-detection byte limit")
 	}
 	mediaType, parameters, err := mime.ParseMediaType(declaredMediaType)

--- a/document/mistral/sniff_test.go
+++ b/document/mistral/sniff_test.go
@@ -136,7 +136,7 @@ func TestDetectFormatRejectsMismatchUnsafeZIPAndAmbiguousCompound(t *testing.T) 
 }
 
 func TestDetectFormatBoundsCompoundAllocationBeforeReadingSectors(t *testing.T) {
-	_, err := DetectFormat(bytes.NewReader([]byte("x")), hardMaxDocumentBytes+1, "text/plain")
+	_, err := DetectFormat(bytes.NewReader([]byte("x")), MaxDocumentBytes+1, "text/plain")
 	require.ErrorContains(t, err, "format-detection byte limit")
 
 	header := make([]byte, 512)
@@ -145,7 +145,7 @@ func TestDetectFormatBoundsCompoundAllocationBeforeReadingSectors(t *testing.T) 
 	binary.LittleEndian.PutUint16(header[28:30], 0xfffe)
 	binary.LittleEndian.PutUint16(header[30:32], 9)
 	binary.LittleEndian.PutUint32(header[44:48], ^uint32(0))
-	_, err = compoundDirectoryNames(bytes.NewReader(header), hardMaxDocumentBytes)
+	_, err = compoundDirectoryNames(bytes.NewReader(header), MaxDocumentBytes)
 	require.ErrorContains(t, err, "allocation table exceeds limits")
 }
 

--- a/document/mistral/test_helpers_test.go
+++ b/document/mistral/test_helpers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/mistral/internal/testfixture"
 	"go.kenn.io/kit/safefileio"
 )
 
@@ -108,25 +109,7 @@ func newProbeFixtureDestination(t *testing.T, name string) string {
 }
 
 func testPDF(label string) []byte {
-	objects := []string{
-		"<< /Type /Catalog /Pages 2 0 R >>",
-		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
-		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>",
-	}
-	var output bytes.Buffer
-	_, _ = fmt.Fprintf(&output, "%%PDF-1.4\n%%%s\n", hex.EncodeToString([]byte(label)))
-	offsets := make([]int, len(objects))
-	for index, object := range objects {
-		offsets[index] = output.Len()
-		_, _ = fmt.Fprintf(&output, "%d 0 obj\n%s\nendobj\n", index+1, object)
-	}
-	xref := output.Len()
-	_, _ = fmt.Fprintf(&output, "xref\n0 %d\n0000000000 65535 f \n", len(objects)+1)
-	for _, offset := range offsets {
-		_, _ = fmt.Fprintf(&output, "%010d 00000 n \n", offset)
-	}
-	_, _ = fmt.Fprintf(&output, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
-	return output.Bytes()
+	return testfixture.MinimalPDF(label)
 }
 
 func testPDFXRefStream() []byte {


### PR DESCRIPTION
Applications can now use Docbank’s exact Mistral limits and retry classification instead of copying private constants and error rules.

The new `document/mistral/mistraltest` package creates deterministic PDF bytes and complete synthetic capability manifests for downstream tests. It shares Docbank’s private request-fingerprint implementation, so consumers no longer need to reproduce the serialized payload or fixture-contract version. Synthetic manifests are explicitly test evidence and must never replace an authenticated production probe.

The production fingerprint format, fixture-contract version, endpoint allowlist, upload authorization, and application-owned consent boundary remain private and unchanged.
