### PR TITLE
Document the v0.13 document understanding APIs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,16 @@ may still evolve, but vaults created by v0.9.0 and later are within the
 
 ## Unreleased
 
+## [v0.13.0](https://github.com/kenn-io/docbank/tree/v0.13.0) — 2026-08-18
+
+### New features
+
+- Add storage-neutral Go packages for deterministic document normalization,
+  including normalized units, headings, spans, chunks, and checksums.
+- Add bounded Mistral OCR processing with format detection, private staging,
+  capability manifests, authenticated probes, retry handling, and fail-closed
+  upload authorization.
+
 ### Breaking changes
 
 - Move the public SQLite driver imports from `go.kenn.io/docbank/pkg/sqlite`

--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -1,0 +1,103 @@
+---
+title: Document Understanding in Go
+description: Normalize extracted documents and use bounded Mistral OCR without opening a Docbank vault.
+---
+
+# Document Understanding in Go
+
+Docbank provides reusable Go packages for turning extracted document evidence
+into stable text, provenance, and chunks. These packages are independent of a
+Docbank vault: importing them does not start a daemon, open storage, or connect
+to an existing installation.
+
+Use `go.kenn.io/docbank/document` for provider-neutral normalization. Use
+`go.kenn.io/docbank/document/mistral` when an application explicitly chooses
+Mistral OCR as its extraction provider.
+
+## Normalize provider output
+
+`document.NormalizeDocument` accepts ordered source units and an opaque
+normalization policy. It produces deterministic normalized units, heading
+paths, exact source spans, baseline chunks, and checksums.
+
+```go
+policy, err := document.NewNormalizePolicy(2_000_000)
+if err != nil {
+	return err
+}
+
+normalized, err := document.NormalizeDocument(document.SourceDocument{
+	Family:   "pdf",
+	UnitKind: "page",
+	Units: []document.SourceUnit{
+		{Index: 0, Markdown: "# Quarterly report\n\nRevenue increased."},
+	},
+}, policy)
+if err != nil {
+	return err
+}
+```
+
+The policy's structural values are fixed for its normalization version. The
+only caller-selected input is the maximum normalized document size. A future
+change to the algorithm or structural values requires a new normalization
+version rather than silently changing the meaning of existing checksums.
+
+## Run Mistral OCR safely
+
+Mistral uploads fail closed until an operator has produced and supplied a
+validated capability manifest for the configured endpoint, model, and policy.
+Docbank ships no live manifest and does not treat documentation as evidence of
+provider behavior.
+
+The operator flow is:
+
+```text
+WriteProbeFixtures
+  -> ValidateProbeFixtures (local only; no credentials or HTTP)
+  -> NewClient(API key) + RunCapabilityProbe
+  -> review and retain the CapabilityManifest
+```
+
+Fixture generation creates 21 formats deterministically. Five legacy formats
+require operator-supplied synthetic seeds named `doc`, `ppt`, `xls`, `numbers`,
+and `msg`. Fixture and staging directories must be private. The initial
+capability contract can authorize at most PDF because it is the only format
+with a probe-tested pre-upload unit bound. Other formats may extract during a
+probe but remain unauthorized for production uploads.
+
+For each production document, the application flow is:
+
+```text
+Policy.Authorize(validated manifest, declared format)
+  -> application verifies its own consent record against PolicyFingerprint
+  -> Prepare(private staging)
+  -> Process(sniffed format must match the authorization)
+  -> Release
+  -> NormalizeDocument(Result.Document, Policy.NormalizePolicy())
+```
+
+`Prepare` copies one input into a private, bounded, immutable staging file.
+`Process` reopens and verifies those bytes for every attempt, derives request
+options from the policy and authorization, bounds the response, and converts
+validated provider output into `document.SourceDocument`. Call `Release` on
+every success or failure path.
+
+The importing application remains responsible for credentials, human consent,
+spending and scheduling limits, durable manifests, job orchestration,
+persistence, and search serving. Those application decisions are intentionally
+outside the reusable packages and their policy identity.
+
+## Package boundary
+
+The dependency direction is deliberate:
+
+```text
+application storage and workers
+  -> document/mistral (optional provider transport)
+  -> document (provider-neutral normalization)
+```
+
+Neither public package imports Docbank's vault, database, daemon, or queue.
+Local extractors can use `document` without depending on Mistral or any network
+transport.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -35,6 +35,7 @@ Every documentation page is also published as raw Markdown at the same path with
 - [Docbank for Agents](https://docbank.ai/agents.md): Why agents use docbank, which interface to choose, and the safety model for document automation.
 - [Agent Integration Guide](https://docbank.ai/agents/integration.md): Connect an agent to docbank safely using its OpenAPI contract, authenticated HTTP API, revisions, and dry-run maintenance operations.
 - [Embed in Go](https://docbank.ai/embedding.md): Own one or more independently rooted Docbank vaults inside a Go application, with CGO or pure-Go SQLite.
+- [Document Understanding in Go](https://docbank.ai/document-understanding.md): Normalize extracted documents and use bounded Mistral OCR without opening a Docbank vault.
 
 ## Reference
 - [CLI Reference](https://docbank.ai/cli-reference.md): Every docbank command, flag, output format, and error behavior.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,10 +6,9 @@ description: What is implemented today and what each phase adds.
 # Roadmap
 
 docbank ships in independently useful increments. This page is a high-level
-public view of current capability and product direction, not an execution
-ledger. The repository's kata ledger is the source of truth for actionable
-work, ordering, blockers, and completion state. Durable future contracts appear
-elsewhere only when they materially explain the design and are marked
+public view of current capability and product direction. It does not track
+tasks, ordering, blockers, or completion criteria. Durable future contracts
+appear elsewhere only when they materially explain the design and are marked
 "Planned."
 
 | Phase | Scope | Status |
@@ -17,7 +16,7 @@ elsewhere only when they materially explain the design and are marked
 | 0 | Extract msgvault's pack/backup and packed-CAS engines into `go.kenn.io/kit` | **Implemented** (Docbank uses Kit's shared backup and multi-location packstore engines) |
 | 1 | Core: store, blob store, ingest pipeline, full CLI | **Implemented** |
 | 2a | Infrastructure: daemon, HTTP API, daemon-first CLI, self-update, release pipeline | **Implemented** |
-| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; PDF/Office extraction remains |
+| 2b | Features: content versions, versioned editing, full audit, tags, watched inboxes, text extraction, ingest provenance | **In progress**: versions, tags, queryable provenance, watched inboxes, disjoint audit scopes, and bounded plain-text extraction implemented; reusable document normalization and Mistral OCR packages are available, while automatic PDF/Office extraction into a Docbank vault remains |
 | 3 | Primary kit-ui web portal and focused operator TUI | **In progress**: analytical tree/search/detail, audited-history, daemon-job and storage/backup inspection, web tag definition/browsing/assignment workflows, version history, provenance, verified current/historical content download, verified upload, and recoverable trash with restoration implemented |
 | 4 | Backup commands over the kit engine | **Implemented**; representative-corpus hardening continues |
 
@@ -210,6 +209,6 @@ management, and browser/TUI mutation controls are deliberately deferred.
 
 ## Deferred beyond v1
 
-OCR of scans, embeddings/AI tagging, at-rest encryption of the live store,
+Automatic OCR of scans within a Docbank vault, embeddings/AI tagging, at-rest encryption of the live store,
 encryption for backup repositories, importing attachments out of msgvault,
 multi-user/sharing, and an MCP server wrapping the API.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -38,6 +38,7 @@ nav = [
     {"Docbank for Agents" = "agents.md"},
     {"Agent Integration Guide" = "agents/integration.md"},
     {"Embed in Go" = "embedding.md"},
+    {"Document Understanding in Go" = "document-understanding.md"},
   ]},
   {"Reference" = [
     {"CLI Reference" = "cli-reference.md"},


### PR DESCRIPTION
Docbank v0.13 now has a public guide for using document normalization and bounded Mistral OCR as ordinary Go libraries, without opening a vault or starting a daemon.

The guide explains the fail-closed capability-probe flow, the initial PDF-only upload authority, private staging and release lifecycle, and the responsibilities that remain with the importing application. The release changelog now records these APIs and the SQLite import-path change under v0.13.0, while the roadmap distinguishes the shipped reusable library from automatic OCR inside a Docbank vault.