### PR TITLE
ci: adopt Windows 11 ARM VS2026 runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - windows-11-vs2026-arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       matrix:
         include:
           - { runner: windows-latest, goarch: amd64 }
-          - { runner: windows-11-arm, goarch: arm64 }
+          - { runner: windows-11-vs2026-arm, goarch: arm64 }
     runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.runner) && github.repository == 'kenn-io/docbank' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.runner }}
     steps:
       - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
       matrix:
         include:
           - { runner: windows-latest, goarch: amd64 }
-          - { runner: windows-11-arm, goarch: arm64 }
+          - { runner: windows-11-vs2026-arm, goarch: arm64 }
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
     defaults:


### PR DESCRIPTION
Move the Windows ARM CI and release jobs to the GA windows-11-vs2026-arm image now instead of waiting for the staged migration of windows-11-arm. The workflows continue to use their existing Go and LLVM-MinGW toolchains; only the hosted runner image changes. The actionlint configuration lists the new label so workflow validation accepts it.
