### PR TITLE
feat(document): add reusable embedding plans

### DIFF
--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -47,6 +47,8 @@ The policy's structural values are fixed for its normalization version. The
 only caller-selected input is the maximum normalized document size. A future
 change to the algorithm or structural values requires a new normalization
 version rather than silently changing the meaning of existing checksums.
+Source family and unit-kind identifiers must be valid UTF-8 without control
+characters so they remain stable in fingerprints and provider-facing locators.
 Version 3 binds truncation into unit, chunk, and document checksums. A complete
 shorter document therefore cannot share an identity with a longer document
 whose retained evidence or remaining units were truncated by a normalization

--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -47,6 +47,9 @@ The policy's structural values are fixed for its normalization version. The
 only caller-selected input is the maximum normalized document size. A future
 change to the algorithm or structural values requires a new normalization
 version rather than silently changing the meaning of existing checksums.
+Version 3 also binds document-level truncation into the document checksum, so
+a complete shorter document cannot share an identity with a longer document
+whose remaining units were removed by the character budget.
 
 ## Run Mistral OCR safely
 

--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -130,10 +130,12 @@ if err != nil {
 Context includes bounded filename, title, heading path, and source locator
 fields. The recipe's heading bound applies to both final embedding inputs and
 distillation partitions, and yields to the enclosing limit so source content
-still fits. Every final input is truncated on rune boundaries to the recipe's
+still fits. Filename and title context must be valid UTF-8; provider, model,
+revision, and vector-normalization identifiers must also be free of control
+characters. Every final input is truncated on rune boundaries to the recipe's
 provider input cap. Recipe, context, plan, source, and individual input
-fingerprints let an application store derived state without making worker
-batch size or claim timing part of vector identity.
+fingerprints let an application store derived state without making worker batch
+size or claim timing part of vector identity.
 
 For optional distillation, configure `Distillation` on a `distilled` or
 `combined` recipe and use this flow:

--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -132,10 +132,11 @@ fields. The recipe's heading bound applies to both final embedding inputs and
 distillation partitions, and yields to the enclosing limit so source content
 still fits. Filename and title context must be valid UTF-8; provider, model,
 revision, and vector-normalization identifiers must also be free of control
-characters. Every final input is truncated on rune boundaries to the recipe's
-provider input cap. Recipe, context, plan, source, and individual input
-fingerprints let an application store derived state without making worker batch
-size or claim timing part of vector identity.
+characters. Filename or title clipping is recorded in the context fingerprint
+and every affected input's truncation identity. Every final input is truncated
+on rune boundaries to the recipe's provider input cap. Recipe, context, plan,
+source, and individual input fingerprints let an application store derived
+state without making worker batch size or claim timing part of vector identity.
 
 For optional distillation, configure `Distillation` on a `distilled` or
 `combined` recipe and use this flow:

--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -105,8 +105,9 @@ combined plan containing both representations.
 
 ```go
 recipe, err := embedding.NewRecipe(embedding.RecipeConfig{
-	Mode:          embedding.RepresentationRaw,
-	MaxInputRunes: 8_000,
+	Mode:            embedding.RepresentationRaw,
+	MaxInputRunes:   8_000,
+	MaxHeadingRunes: 512,
 })
 if err != nil {
 	return err
@@ -124,7 +125,9 @@ if err != nil {
 ```
 
 Context includes bounded filename, title, heading path, and source locator
-fields. Every final input is truncated on rune boundaries to the recipe's
+fields. The recipe's heading bound applies to both final embedding inputs and
+distillation partitions, and yields to the enclosing limit so source content
+still fits. Every final input is truncated on rune boundaries to the recipe's
 provider input cap. Recipe, context, plan, source, and individual input
 fingerprints let an application store derived state without making worker
 batch size or claim timing part of vector identity.

--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -47,9 +47,10 @@ The policy's structural values are fixed for its normalization version. The
 only caller-selected input is the maximum normalized document size. A future
 change to the algorithm or structural values requires a new normalization
 version rather than silently changing the meaning of existing checksums.
-Version 3 also binds document-level truncation into the document checksum, so
-a complete shorter document cannot share an identity with a longer document
-whose remaining units were removed by the character budget.
+Version 3 binds truncation into unit, chunk, and document checksums. A complete
+shorter document therefore cannot share an identity with a longer document
+whose retained evidence or remaining units were truncated by a normalization
+bound.
 
 ## Run Mistral OCR safely
 

--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -1,6 +1,6 @@
 ---
 title: Document Understanding in Go
-description: Normalize extracted documents, use bounded Mistral OCR, and embed images and video through Voyage without opening a Docbank vault.
+description: Normalize and prepare documents for search, use bounded Mistral OCR, and embed images and video through Voyage without opening a Docbank vault.
 ---
 
 # Document Understanding in Go
@@ -11,6 +11,9 @@ Docbank vault: importing them does not start a daemon, open storage, or connect
 to an existing installation.
 
 Use `go.kenn.io/docbank/document` for provider-neutral normalization. Use
+`go.kenn.io/docbank/document/embedding` to build deterministic text-embedding
+plans, optionally with a pre-embedding distillation step. Use
+`go.kenn.io/docbank/document/embedding/eval` to compare retrieval recipes. Use
 `go.kenn.io/docbank/document/mistral` when an application explicitly chooses
 Mistral OCR as its extraction provider. Use `go.kenn.io/docbank/document/media`
 to detect and bound images and video, and `go.kenn.io/docbank/document/voyage`
@@ -89,6 +92,84 @@ The importing application remains responsible for credentials, human consent,
 spending and scheduling limits, durable manifests, job orchestration,
 persistence, and search serving. Those application decisions are intentionally
 outside the reusable packages and their policy identity.
+
+## Prepare text for semantic retrieval
+
+`embedding.BuildEmbeddingPlan` converts a complete `NormalizedDocument` into a
+deterministic set of bounded provider inputs. Raw normalized chunks are the
+default representation. A recipe may instead select distilled sections or a
+combined plan containing both representations.
+
+```go
+recipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+	Mode:          embedding.RepresentationRaw,
+	MaxInputRunes: 8_000,
+})
+if err != nil {
+	return err
+}
+
+plan, err := embedding.BuildEmbeddingPlan(
+	normalized,
+	embedding.DocumentContext{Filename: "quarterly-report.pdf"},
+	recipe,
+	nil,
+)
+if err != nil {
+	return err
+}
+```
+
+Context includes bounded filename, title, heading path, and source locator
+fields. Every final input is truncated on rune boundaries to the recipe's
+provider input cap. Recipe, context, plan, source, and individual input
+fingerprints let an application store derived state without making worker
+batch size or claim timing part of vector identity.
+
+For optional distillation, configure `Distillation` on a `distilled` or
+`combined` recipe and use this flow:
+
+```text
+PrepareDistillation(complete normalized document)
+  -> application checks separate distillation consent
+  -> Distiller.Distill
+  -> ValidateDistillate
+  -> BuildEmbeddingPlan
+```
+
+Partitions contain complete normalized chunks in source order. A distiller's
+result must cover every partition exactly once in that order and stays linked
+to exact source spans. Derived text is untrusted, non-authoritative evidence;
+callers should retain normalized source evidence for display and verification.
+Different provider output gets a different content-addressed distillate and
+plan identity.
+
+Docbank defines the provider-neutral `Distiller` interface but does not choose
+a distillation provider or make network requests. Provider implementations are
+responsible for authenticated capability checks, transport bounds, redirect
+policy, and per-request consent enforcement. `EgressIdentity` gives
+applications separate endpoint-sensitive fingerprints for document
+distillation, document embedding, and query embedding. Credentials are not
+part of those identities. `VectorSpaceIdentity` separately pins provider,
+model revision, dimension, and normalization without an endpoint, allowing an
+application to reuse compatible vectors while still requiring fresh consent
+when their destination changes.
+
+The shared retrieval helpers make omitted and `auto` search lexical, so a
+query is not sent to an embedding provider without explicit `semantic` or
+`hybrid` mode. Candidate limits default to 100 and are bounded at 1,000.
+`CollectScopedCandidates` requires the backend to apply scope before its
+vector cutoff and pages until authoritative exhaustion or a `limit+1`
+overflow probe. Reciprocal-rank fusion preserves lexical and semantic signals
+and reports overflow from either input lane or the fused union.
+
+`document/embedding/eval` runs versioned public or synthetic corpora through
+repeatable retrieval systems. Reports include Recall@5/10/20, nDCG@10, MRR,
+critical misses, provider calls and input/output usage, estimated cost, and
+latency. Repeated trials retain individual observations and report empirical
+minimum, mean, and maximum values instead of hiding hosted-provider variance.
+Applications should keep raw as the default unless measured results justify a
+different recipe.
 
 ## Detect and bound visual attachments
 
@@ -192,9 +273,14 @@ application storage and workers
 application storage and workers
   -> document/voyage (optional provider transport)
   -> document/media (provider-neutral detection and eligibility)
+
+application storage and workers
+  -> document/embedding (provider-neutral text planning and retrieval contracts)
+  -> document (provider-neutral normalization)
 ```
 
 No public package imports Docbank's vault, database, daemon, or queue. Local
 extractors can use `document` without depending on Mistral or any network
-transport, and applications can use `document/media` alone to record image
-dimensions at ingest without any provider.
+transport, applications can use `document/embedding` without a database or
+provider client, and applications can use `document/media` alone to record
+image dimensions at ingest without any provider.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -35,7 +35,7 @@ Every documentation page is also published as raw Markdown at the same path with
 - [Docbank for Agents](https://docbank.ai/agents.md): Why agents use docbank, which interface to choose, and the safety model for document automation.
 - [Agent Integration Guide](https://docbank.ai/agents/integration.md): Connect an agent to docbank safely using its OpenAPI contract, authenticated HTTP API, revisions, and dry-run maintenance operations.
 - [Embed in Go](https://docbank.ai/embedding.md): Own one or more independently rooted Docbank vaults inside a Go application, with CGO or pure-Go SQLite.
-- [Document Understanding in Go](https://docbank.ai/document-understanding.md): Normalize extracted documents, use bounded Mistral OCR, and embed images and video through Voyage without opening a Docbank vault.
+- [Document Understanding in Go](https://docbank.ai/document-understanding.md): Normalize and prepare documents for search, use bounded Mistral OCR, and embed images and video through Voyage without opening a Docbank vault.
 
 ## Reference
 - [CLI Reference](https://docbank.ai/cli-reference.md): Every docbank command, flag, output format, and error behavior.

--- a/document/compat_test.go
+++ b/document/compat_test.go
@@ -39,8 +39,22 @@ func TestNormalizeDocumentVersionThreePreservesVersionTwoEvidence(t *testing.T) 
 			assert.Equal(t, 3, actual.PolicyVersion)
 			assert.Equal(t, testCase.Expected.Family, actual.Family)
 			assert.Equal(t, testCase.Expected.UnitKind, actual.UnitKind)
-			assert.Equal(t, testCase.Expected.Units, actual.Units)
-			assert.Equal(t, testCase.Expected.Chunks, actual.Chunks)
+			expectedUnits := append([]NormalizedUnit(nil), testCase.Expected.Units...)
+			actualUnits := append([]NormalizedUnit(nil), actual.Units...)
+			for index := range actualUnits {
+				assert.NotEqual(t, expectedUnits[index].Checksum, actualUnits[index].Checksum)
+				expectedUnits[index].Checksum = ""
+				actualUnits[index].Checksum = ""
+			}
+			assert.Equal(t, expectedUnits, actualUnits)
+			expectedChunks := append([]Chunk(nil), testCase.Expected.Chunks...)
+			actualChunks := append([]Chunk(nil), actual.Chunks...)
+			for index := range actualChunks {
+				assert.NotEqual(t, expectedChunks[index].Checksum, actualChunks[index].Checksum)
+				expectedChunks[index].Checksum = ""
+				actualChunks[index].Checksum = ""
+			}
+			assert.Equal(t, expectedChunks, actualChunks)
 			assert.Equal(t, testCase.Expected.Truncated, actual.Truncated)
 			assert.NotEqual(t, testCase.Expected.Checksum, actual.Checksum)
 		})

--- a/document/compat_test.go
+++ b/document/compat_test.go
@@ -16,7 +16,7 @@ type normalizationCompatibilityCase struct {
 	Expected         NormalizedDocument `json:"expected"`
 }
 
-func TestNormalizeDocumentMatchesMsgvaultBaseline(t *testing.T) {
+func TestNormalizeDocumentVersionThreePreservesVersionTwoEvidence(t *testing.T) {
 	bundle, _, err := compattest.Load()
 	require.NoError(t, err)
 	section, ok := bundle.Sections["normalization_v2"]
@@ -35,7 +35,14 @@ func TestNormalizeDocumentMatchesMsgvaultBaseline(t *testing.T) {
 			require.NoError(t, err)
 			actual, err := NormalizeDocument(testCase.Source, policy)
 			require.NoError(t, err)
-			assert.Equal(t, testCase.Expected, actual)
+			require.NoError(t, ValidateNormalizedDocument(actual))
+			assert.Equal(t, 3, actual.PolicyVersion)
+			assert.Equal(t, testCase.Expected.Family, actual.Family)
+			assert.Equal(t, testCase.Expected.UnitKind, actual.UnitKind)
+			assert.Equal(t, testCase.Expected.Units, actual.Units)
+			assert.Equal(t, testCase.Expected.Chunks, actual.Chunks)
+			assert.Equal(t, testCase.Expected.Truncated, actual.Truncated)
+			assert.NotEqual(t, testCase.Expected.Checksum, actual.Checksum)
 		})
 	}
 }

--- a/document/embedding/distillation.go
+++ b/document/embedding/distillation.go
@@ -77,6 +77,7 @@ type SourcePartition struct {
 	Text       string      `json:"text"`
 	SourceRefs []SourceRef `json:"source_refs"`
 	Checksum   string      `json:"checksum"`
+	Truncated  bool        `json:"truncated"`
 }
 
 type partitionIdentity struct {
@@ -84,6 +85,7 @@ type partitionIdentity struct {
 	Ordinal        int         `json:"ordinal"`
 	Refs           []SourceRef `json:"refs"`
 	Checksum       string      `json:"checksum"`
+	Truncated      bool        `json:"truncated"`
 }
 
 type derivedSectionIdentity struct {
@@ -91,6 +93,7 @@ type derivedSectionIdentity struct {
 	Ordinal            int         `json:"ordinal"`
 	Checksum           string      `json:"checksum"`
 	Refs               []SourceRef `json:"refs"`
+	Truncated          bool        `json:"truncated"`
 }
 
 // DistillationRequest is the immutable input to a Distiller.
@@ -139,6 +142,7 @@ type DerivedSection struct {
 	Text       string      `json:"text"`
 	SourceRefs []SourceRef `json:"source_refs"`
 	Checksum   string      `json:"checksum"`
+	Truncated  bool        `json:"truncated"`
 }
 
 // Distillate is a validated, content-addressed distillation artifact.
@@ -196,8 +200,9 @@ func PrepareDistillation(normalized document.NormalizedDocument, context Documen
 func partitionDocument(normalized document.NormalizedDocument, maxRunes, maxHeadingRunes int) ([]SourcePartition, error) {
 	partitions := make([]SourcePartition, 0, len(normalized.Chunks))
 	type partitionChunk struct {
-		chunk document.Chunk
-		text  string
+		chunk     document.Chunk
+		text      string
+		truncated bool
 	}
 	var chunks []partitionChunk
 	runes := 0
@@ -210,12 +215,13 @@ func partitionDocument(normalized document.NormalizedDocument, maxRunes, maxHead
 		for _, item := range chunks {
 			texts = append(texts, item.text)
 			partition.SourceRefs = append(partition.SourceRefs, sourceRef(item.chunk))
+			partition.Truncated = partition.Truncated || item.truncated
 		}
 		partition.Text = strings.Join(texts, "\n\n")
 		partition.Checksum = fingerprint([]byte(partition.Text))
 		keyBytes, err := json.Marshal(partitionIdentity{
 			SourceChecksum: normalized.Checksum, Ordinal: partition.Ordinal,
-			Refs: partition.SourceRefs, Checksum: partition.Checksum,
+			Refs: partition.SourceRefs, Checksum: partition.Checksum, Truncated: partition.Truncated,
 		})
 		if err != nil {
 			return fmt.Errorf("encode distillation partition identity: %w", err)
@@ -227,7 +233,7 @@ func partitionDocument(normalized document.NormalizedDocument, maxRunes, maxHead
 		return nil
 	}
 	for _, chunk := range normalized.Chunks {
-		chunkText := formatDistillationChunk(normalized, chunk, maxRunes, maxHeadingRunes)
+		chunkText, headingTruncated := formatDistillationChunk(normalized, chunk, maxRunes, maxHeadingRunes)
 		chunkRunes := utf8.RuneCountInString(chunkText)
 		if chunkRunes > maxRunes {
 			return nil, fmt.Errorf("normalized chunk %q exceeds distillation partition limit", chunk.Key)
@@ -241,7 +247,10 @@ func partitionDocument(normalized document.NormalizedDocument, maxRunes, maxHead
 				return nil, err
 			}
 		}
-		chunks = append(chunks, partitionChunk{chunk: chunk, text: chunkText})
+		chunks = append(chunks, partitionChunk{
+			chunk: chunk, text: chunkText,
+			truncated: normalized.Truncated || chunk.Truncated || headingTruncated,
+		})
 		runes += separator + chunkRunes
 	}
 	if err := flush(); err != nil {
@@ -250,12 +259,16 @@ func partitionDocument(normalized document.NormalizedDocument, maxRunes, maxHead
 	return partitions, nil
 }
 
-func formatDistillationChunk(normalized document.NormalizedDocument, chunk document.Chunk, maxRunes, maxHeadingRunes int) string {
+func formatDistillationChunk(
+	normalized document.NormalizedDocument,
+	chunk document.Chunk,
+	maxRunes, maxHeadingRunes int,
+) (string, bool) {
 	source := "Source: " + formatLocator(normalized, chunk.Spans) + "\nContent:\n" + chunk.Text
-	heading, _ := boundedHeadingContext(
+	heading, headingTruncated := boundedHeadingContext(
 		chunk.HeadingPath, maxHeadingRunes, maxRunes-utf8.RuneCountInString(source),
 	)
-	return heading + source
+	return heading + source, headingTruncated
 }
 
 // ValidateDistillate validates provider output, attaches exact source
@@ -302,11 +315,12 @@ func ValidateDistillate(request DistillationRequest, result DistillationResult) 
 			seen[key] = true
 			nextPartition++
 			section.SourceRefs = append(section.SourceRefs, cloneSourceRefs(partition.SourceRefs)...)
+			section.Truncated = section.Truncated || partition.Truncated
 		}
 		section.Checksum = fingerprint([]byte(section.Text))
 		keyBytes, err := json.Marshal(derivedSectionIdentity{
 			RequestFingerprint: request.Fingerprint, Ordinal: section.Ordinal,
-			Checksum: section.Checksum, Refs: section.SourceRefs,
+			Checksum: section.Checksum, Refs: section.SourceRefs, Truncated: section.Truncated,
 		})
 		if err != nil {
 			return Distillate{}, fmt.Errorf("encode derived section identity: %w", err)
@@ -365,7 +379,7 @@ func validateDistillationRequest(request DistillationRequest) error {
 		}
 		keyBytes, err := json.Marshal(partitionIdentity{
 			SourceChecksum: request.SourceChecksum, Ordinal: partition.Ordinal,
-			Refs: partition.SourceRefs, Checksum: partition.Checksum,
+			Refs: partition.SourceRefs, Checksum: partition.Checksum, Truncated: partition.Truncated,
 		})
 		if err != nil {
 			return fmt.Errorf("encode distillation partition identity: %w", err)

--- a/document/embedding/distillation.go
+++ b/document/embedding/distillation.go
@@ -163,7 +163,10 @@ func PrepareDistillation(normalized document.NormalizedDocument, context Documen
 	if !recipe.valid() || recipe.values.Distillation == nil {
 		return DistillationRequest{}, errors.New("embedding recipe does not configure distillation")
 	}
-	context = normalizeContext(context, recipe.values)
+	context, err := normalizeContext(context, recipe.values)
+	if err != nil {
+		return DistillationRequest{}, err
+	}
 	contextFingerprint, err := digestJSON(context)
 	if err != nil {
 		return DistillationRequest{}, err
@@ -334,6 +337,18 @@ func validateDistillationRequest(request DistillationRequest) error {
 		request.PromptTemplateVersion < 1 || request.MaxSections < 1 || request.MaxSectionRunes < 1 || len(request.Partitions) == 0 {
 		return errors.New("distillation request is incomplete")
 	}
+	if err := validateContextText(request.Context); err != nil {
+		return err
+	}
+	for _, identity := range [...]struct{ name, value string }{
+		{name: "distillation provider", value: request.Provider},
+		{name: "distillation model", value: request.Model},
+		{name: "distillation model revision", value: request.ModelRevision},
+	} {
+		if err := validateIdentityText(identity.name, identity.value); err != nil {
+			return err
+		}
+	}
 	contextFingerprint, err := digestJSON(request.Context)
 	if err != nil {
 		return err
@@ -401,11 +416,14 @@ func digestJSON(value any) (string, error) {
 	return fingerprint(encoded), nil
 }
 
-func normalizeContext(value DocumentContext, recipe RecipeValues) DocumentContext {
+func normalizeContext(value DocumentContext, recipe RecipeValues) (DocumentContext, error) {
+	if err := validateContextText(value); err != nil {
+		return DocumentContext{}, err
+	}
 	return DocumentContext{
 		Filename: truncateRunes(normalizeMetadata(value.Filename), recipe.MaxFilenameRunes),
 		Title:    truncateRunes(normalizeMetadata(value.Title), recipe.MaxTitleRunes),
-	}
+	}, nil
 }
 
 func normalizeMetadata(value string) string {

--- a/document/embedding/distillation.go
+++ b/document/embedding/distillation.go
@@ -1,0 +1,456 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+)
+
+// DocumentContext is bounded, non-authoritative context attached to document
+// inputs. Applications should populate it only from trusted metadata fields.
+type DocumentContext struct {
+	Filename string `json:"filename,omitempty"`
+	Title    string `json:"title,omitempty"`
+}
+
+// SourceRef identifies the normalized source evidence represented by an input.
+type SourceRef struct {
+	ChunkKey      string               `json:"chunk_key"`
+	ChunkChecksum string               `json:"chunk_checksum"`
+	UnitSpans     []document.ChunkSpan `json:"unit_spans"`
+}
+
+type sourceRefJSON struct {
+	ChunkKey      string          `json:"chunk_key"`
+	ChunkChecksum string          `json:"chunk_checksum"`
+	UnitSpans     []chunkSpanJSON `json:"unit_spans"`
+}
+
+type chunkSpanJSON struct {
+	UnitIndex int `json:"unit_index"`
+	CharStart int `json:"char_start"`
+	CharEnd   int `json:"char_end"`
+}
+
+// MarshalJSON gives SourceRef a stable encoding without changing the JSON
+// contract of document.ChunkSpan itself.
+func (ref SourceRef) MarshalJSON() ([]byte, error) {
+	encoded := sourceRefJSON{ChunkKey: ref.ChunkKey, ChunkChecksum: ref.ChunkChecksum}
+	for _, span := range ref.UnitSpans {
+		encoded.UnitSpans = append(encoded.UnitSpans, chunkSpanJSON{
+			UnitIndex: span.UnitIndex, CharStart: span.CharStart, CharEnd: span.CharEnd,
+		})
+	}
+	return json.Marshal(encoded)
+}
+
+// UnmarshalJSON restores SourceRef from its stable encoding.
+func (ref *SourceRef) UnmarshalJSON(data []byte) error {
+	var encoded sourceRefJSON
+	if err := json.Unmarshal(data, &encoded); err != nil {
+		return fmt.Errorf("decode embedding source reference: %w", err)
+	}
+	ref.ChunkKey = encoded.ChunkKey
+	ref.ChunkChecksum = encoded.ChunkChecksum
+	ref.UnitSpans = make([]document.ChunkSpan, 0, len(encoded.UnitSpans))
+	for _, span := range encoded.UnitSpans {
+		ref.UnitSpans = append(ref.UnitSpans, document.ChunkSpan{
+			UnitIndex: span.UnitIndex, CharStart: span.CharStart, CharEnd: span.CharEnd,
+		})
+	}
+	return nil
+}
+
+// SourcePartition is a deterministic, whole-document distillation partition.
+// Partitions contain complete normalized chunks and never depend on worker
+// batch size or claim timing.
+type SourcePartition struct {
+	Key        string      `json:"key"`
+	Ordinal    int         `json:"ordinal"`
+	Text       string      `json:"text"`
+	SourceRefs []SourceRef `json:"source_refs"`
+	Checksum   string      `json:"checksum"`
+}
+
+type partitionIdentity struct {
+	SourceChecksum string      `json:"source_checksum"`
+	Ordinal        int         `json:"ordinal"`
+	Refs           []SourceRef `json:"refs"`
+	Checksum       string      `json:"checksum"`
+}
+
+type derivedSectionIdentity struct {
+	RequestFingerprint string      `json:"request_fingerprint"`
+	Ordinal            int         `json:"ordinal"`
+	Checksum           string      `json:"checksum"`
+	Refs               []SourceRef `json:"refs"`
+}
+
+// DistillationRequest is the immutable input to a Distiller.
+type DistillationRequest struct {
+	RecipeFingerprint     string            `json:"recipe_fingerprint"`
+	SourceChecksum        string            `json:"source_checksum"`
+	Context               DocumentContext   `json:"context"`
+	ContextFingerprint    string            `json:"context_fingerprint"`
+	Provider              string            `json:"provider"`
+	Model                 string            `json:"model"`
+	ModelRevision         string            `json:"model_revision"`
+	PromptTemplateVersion int               `json:"prompt_template_version"`
+	MaxSections           int               `json:"max_sections"`
+	MaxSectionRunes       int               `json:"max_section_runes"`
+	Partitions            []SourcePartition `json:"partitions"`
+	Fingerprint           string            `json:"fingerprint"`
+}
+
+// Distiller transforms deterministic source partitions into derived sections.
+// Implementations own provider transport, authentication, retry, redirect,
+// and per-request consent enforcement.
+type Distiller interface {
+	Distill(ctx context.Context, request DistillationRequest) (DistillationResult, error)
+}
+
+// DistillationResult is provider output awaiting structural validation.
+type DistillationResult struct {
+	Provider      string                 `json:"provider"`
+	Model         string                 `json:"model"`
+	ModelRevision string                 `json:"model_revision"`
+	Sections      []DerivedSectionResult `json:"sections"`
+}
+
+// DerivedSectionResult is one provider-produced section and the exact source
+// partitions it summarizes.
+type DerivedSectionResult struct {
+	Text          string   `json:"text"`
+	PartitionKeys []string `json:"partition_keys"`
+}
+
+// DerivedSection is validated, content-addressed derived evidence. Its text is
+// untrusted and non-authoritative; SourceRefs point back to normalized evidence.
+type DerivedSection struct {
+	Key        string      `json:"key"`
+	Ordinal    int         `json:"ordinal"`
+	Text       string      `json:"text"`
+	SourceRefs []SourceRef `json:"source_refs"`
+	Checksum   string      `json:"checksum"`
+}
+
+// Distillate is a validated, content-addressed distillation artifact.
+type Distillate struct {
+	RequestFingerprint string           `json:"request_fingerprint"`
+	RecipeFingerprint  string           `json:"recipe_fingerprint"`
+	SourceChecksum     string           `json:"source_checksum"`
+	ContextFingerprint string           `json:"context_fingerprint"`
+	Provider           string           `json:"provider"`
+	Model              string           `json:"model"`
+	ModelRevision      string           `json:"model_revision"`
+	Sections           []DerivedSection `json:"sections"`
+	Fingerprint        string           `json:"fingerprint"`
+}
+
+// PrepareDistillation deterministically partitions a complete normalized
+// document for the recipe's configured Distiller.
+func PrepareDistillation(normalized document.NormalizedDocument, context DocumentContext, recipe Recipe) (DistillationRequest, error) {
+	if err := validateNormalizedDocument(normalized); err != nil {
+		return DistillationRequest{}, err
+	}
+	if !recipe.valid() || recipe.values.Distillation == nil {
+		return DistillationRequest{}, errors.New("embedding recipe does not configure distillation")
+	}
+	context = normalizeContext(context, recipe.values)
+	contextFingerprint, err := digestJSON(context)
+	if err != nil {
+		return DistillationRequest{}, err
+	}
+	partitions, err := partitionDocument(normalized, recipe.values.Distillation.MaxPartitionRunes)
+	if err != nil {
+		return DistillationRequest{}, err
+	}
+	config := recipe.values.Distillation
+	request := DistillationRequest{
+		RecipeFingerprint: recipe.digest, SourceChecksum: normalized.Checksum,
+		Context: context, ContextFingerprint: contextFingerprint,
+		Provider: config.Provider, Model: config.Model, ModelRevision: config.ModelRevision,
+		PromptTemplateVersion: config.PromptTemplateVersion, MaxSections: config.MaxSections,
+		MaxSectionRunes: config.MaxSectionRunes, Partitions: partitions,
+	}
+	fingerprint, err := distillationRequestFingerprint(request)
+	if err != nil {
+		return DistillationRequest{}, err
+	}
+	request.Fingerprint = fingerprint
+	return request, nil
+}
+
+func partitionDocument(normalized document.NormalizedDocument, maxRunes int) ([]SourcePartition, error) {
+	partitions := make([]SourcePartition, 0, len(normalized.Chunks))
+	type partitionChunk struct {
+		chunk document.Chunk
+		text  string
+	}
+	var chunks []partitionChunk
+	runes := 0
+	flush := func() error {
+		if len(chunks) == 0 {
+			return nil
+		}
+		partition := SourcePartition{Ordinal: len(partitions)}
+		texts := make([]string, 0, len(chunks))
+		for _, item := range chunks {
+			texts = append(texts, item.text)
+			partition.SourceRefs = append(partition.SourceRefs, sourceRef(item.chunk))
+		}
+		partition.Text = strings.Join(texts, "\n\n")
+		partition.Checksum = fingerprint([]byte(partition.Text))
+		keyBytes, err := json.Marshal(partitionIdentity{
+			SourceChecksum: normalized.Checksum, Ordinal: partition.Ordinal,
+			Refs: partition.SourceRefs, Checksum: partition.Checksum,
+		})
+		if err != nil {
+			return fmt.Errorf("encode distillation partition identity: %w", err)
+		}
+		partition.Key = fingerprint(keyBytes)
+		partitions = append(partitions, partition)
+		chunks = nil
+		runes = 0
+		return nil
+	}
+	for _, chunk := range normalized.Chunks {
+		chunkText := formatDistillationChunk(normalized, chunk)
+		chunkRunes := utf8.RuneCountInString(chunkText)
+		if chunkRunes > maxRunes {
+			return nil, fmt.Errorf("normalized chunk %q exceeds distillation partition limit", chunk.Key)
+		}
+		separator := 0
+		if len(chunks) > 0 {
+			separator = 2
+		}
+		if runes+separator+chunkRunes > maxRunes {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		}
+		chunks = append(chunks, partitionChunk{chunk: chunk, text: chunkText})
+		runes += separator + chunkRunes
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return partitions, nil
+}
+
+func formatDistillationChunk(normalized document.NormalizedDocument, chunk document.Chunk) string {
+	var builder strings.Builder
+	if len(chunk.HeadingPath) > 0 {
+		builder.WriteString("Heading: ")
+		builder.WriteString(strings.Join(chunk.HeadingPath, " > "))
+		builder.WriteByte('\n')
+	}
+	builder.WriteString("Source: ")
+	builder.WriteString(formatLocator(normalized, chunk.Spans))
+	builder.WriteString("\nContent:\n")
+	builder.WriteString(chunk.Text)
+	return builder.String()
+}
+
+// ValidateDistillate validates provider output, attaches exact source
+// provenance, and returns a content-addressed artifact.
+func ValidateDistillate(request DistillationRequest, result DistillationResult) (Distillate, error) {
+	if err := validateDistillationRequest(request); err != nil {
+		return Distillate{}, err
+	}
+	if result.Provider != request.Provider || result.Model != request.Model || result.ModelRevision != request.ModelRevision {
+		return Distillate{}, errors.New("distillation result target differs from request")
+	}
+	if len(result.Sections) == 0 || len(result.Sections) > request.MaxSections {
+		return Distillate{}, errors.New("distillation result section count is outside request bounds")
+	}
+	partitionByKey := make(map[string]SourcePartition, len(request.Partitions))
+	partitionOrder := make(map[string]int, len(request.Partitions))
+	for index, partition := range request.Partitions {
+		partitionByKey[partition.Key] = partition
+		partitionOrder[partition.Key] = index
+	}
+	seen := make(map[string]bool, len(request.Partitions))
+	nextPartition := 0
+	sections := make([]DerivedSection, 0, len(result.Sections))
+	for index, candidate := range result.Sections {
+		if candidate.Text == "" || !utf8.ValidString(candidate.Text) || utf8.RuneCountInString(candidate.Text) > request.MaxSectionRunes {
+			return Distillate{}, fmt.Errorf("distillation section %d text is invalid or exceeds its rune limit", index)
+		}
+		text := normalizeDerivedText(candidate.Text)
+		if text == "" {
+			return Distillate{}, fmt.Errorf("distillation section %d has no usable text", index)
+		}
+		if len(candidate.PartitionKeys) == 0 {
+			return Distillate{}, fmt.Errorf("distillation section %d has no source partitions", index)
+		}
+		section := DerivedSection{Ordinal: index, Text: text}
+		for _, key := range candidate.PartitionKeys {
+			partition, ok := partitionByKey[key]
+			if !ok {
+				return Distillate{}, fmt.Errorf("distillation section %d references unknown partition %q", index, key)
+			}
+			if seen[key] || partitionOrder[key] != nextPartition {
+				return Distillate{}, errors.New("distillation result must cover source partitions exactly once in source order")
+			}
+			seen[key] = true
+			nextPartition++
+			section.SourceRefs = append(section.SourceRefs, cloneSourceRefs(partition.SourceRefs)...)
+		}
+		section.Checksum = fingerprint([]byte(section.Text))
+		keyBytes, err := json.Marshal(derivedSectionIdentity{
+			RequestFingerprint: request.Fingerprint, Ordinal: section.Ordinal,
+			Checksum: section.Checksum, Refs: section.SourceRefs,
+		})
+		if err != nil {
+			return Distillate{}, fmt.Errorf("encode derived section identity: %w", err)
+		}
+		section.Key = fingerprint(keyBytes)
+		sections = append(sections, section)
+	}
+	if nextPartition != len(request.Partitions) {
+		return Distillate{}, errors.New("distillation result does not cover every source partition")
+	}
+	distillate := Distillate{
+		RequestFingerprint: request.Fingerprint, RecipeFingerprint: request.RecipeFingerprint,
+		SourceChecksum: request.SourceChecksum, ContextFingerprint: request.ContextFingerprint,
+		Provider: result.Provider, Model: result.Model, ModelRevision: result.ModelRevision,
+		Sections: sections,
+	}
+	fingerprint, err := distillateFingerprint(distillate)
+	if err != nil {
+		return Distillate{}, err
+	}
+	distillate.Fingerprint = fingerprint
+	return distillate, nil
+}
+
+func validateDistillationRequest(request DistillationRequest) error {
+	if request.Fingerprint == "" || request.RecipeFingerprint == "" || request.SourceChecksum == "" ||
+		request.Provider == "" || request.Model == "" || request.ModelRevision == "" ||
+		request.PromptTemplateVersion < 1 || request.MaxSections < 1 || request.MaxSectionRunes < 1 || len(request.Partitions) == 0 {
+		return errors.New("distillation request is incomplete")
+	}
+	contextFingerprint, err := digestJSON(request.Context)
+	if err != nil {
+		return err
+	}
+	if contextFingerprint != request.ContextFingerprint {
+		return errors.New("distillation request context fingerprint is invalid")
+	}
+	for index, partition := range request.Partitions {
+		if partition.Ordinal != index || partition.Key == "" || partition.Text == "" || partition.Checksum != fingerprint([]byte(partition.Text)) || len(partition.SourceRefs) == 0 {
+			return fmt.Errorf("distillation partition %d is invalid", index)
+		}
+		if err := validateSourceRefs(partition.SourceRefs); err != nil {
+			return fmt.Errorf("distillation partition %d: %w", index, err)
+		}
+		keyBytes, err := json.Marshal(partitionIdentity{
+			SourceChecksum: request.SourceChecksum, Ordinal: partition.Ordinal,
+			Refs: partition.SourceRefs, Checksum: partition.Checksum,
+		})
+		if err != nil {
+			return fmt.Errorf("encode distillation partition identity: %w", err)
+		}
+		if partition.Key != fingerprint(keyBytes) {
+			return fmt.Errorf("distillation partition %d key is invalid", index)
+		}
+	}
+	expected, err := distillationRequestFingerprint(request)
+	if err != nil {
+		return err
+	}
+	if expected != request.Fingerprint {
+		return errors.New("distillation request fingerprint is invalid")
+	}
+	return nil
+}
+
+func validateSourceRefs(refs []SourceRef) error {
+	for _, ref := range refs {
+		if ref.ChunkKey == "" || ref.ChunkChecksum == "" || len(ref.UnitSpans) == 0 {
+			return errors.New("source reference is incomplete")
+		}
+		for _, span := range ref.UnitSpans {
+			if span.UnitIndex < 0 || span.CharStart < 0 || span.CharEnd <= span.CharStart {
+				return errors.New("source reference span is invalid")
+			}
+		}
+	}
+	return nil
+}
+
+func distillationRequestFingerprint(request DistillationRequest) (string, error) {
+	request.Fingerprint = ""
+	return digestJSON(request)
+}
+
+func distillateFingerprint(distillate Distillate) (string, error) {
+	distillate.Fingerprint = ""
+	return digestJSON(distillate)
+}
+
+func digestJSON(value any) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("encode embedding identity: %w", err)
+	}
+	return fingerprint(encoded), nil
+}
+
+func normalizeContext(value DocumentContext, recipe RecipeValues) DocumentContext {
+	return DocumentContext{
+		Filename: truncateRunes(normalizeMetadata(value.Filename), recipe.MaxFilenameRunes),
+		Title:    truncateRunes(normalizeMetadata(value.Title), recipe.MaxTitleRunes),
+	}
+}
+
+func normalizeMetadata(value string) string {
+	return strings.Join(strings.FieldsFunc(value, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r) || unicode.In(r, unicode.Cf)
+	}), " ")
+}
+
+func normalizeDerivedText(value string) string {
+	var builder strings.Builder
+	for _, r := range strings.ReplaceAll(strings.ReplaceAll(value, "\r\n", "\n"), "\r", "\n") {
+		switch {
+		case r == '\n':
+			builder.WriteByte('\n')
+		case unicode.IsSpace(r):
+			builder.WriteByte(' ')
+		case unicode.IsControl(r) || unicode.In(r, unicode.Cf):
+			continue
+		default:
+			builder.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func truncateRunes(value string, limit int) string {
+	if utf8.RuneCountInString(value) <= limit {
+		return value
+	}
+	return string([]rune(value)[:limit])
+}
+
+func sourceRef(chunk document.Chunk) SourceRef {
+	return SourceRef{ChunkKey: chunk.Key, ChunkChecksum: chunk.Checksum, UnitSpans: slices.Clone(chunk.Spans)}
+}
+
+func cloneSourceRefs(refs []SourceRef) []SourceRef {
+	result := make([]SourceRef, len(refs))
+	for index, ref := range refs {
+		result[index] = ref
+		result[index].UnitSpans = slices.Clone(ref.UnitSpans)
+	}
+	return result
+}

--- a/document/embedding/distillation.go
+++ b/document/embedding/distillation.go
@@ -20,6 +20,11 @@ type DocumentContext struct {
 	Title    string `json:"title,omitempty"`
 }
 
+type documentContextIdentity struct {
+	Context   DocumentContext `json:"context"`
+	Truncated bool            `json:"truncated"`
+}
+
 // SourceRef identifies the normalized source evidence represented by an input.
 type SourceRef struct {
 	ChunkKey      string               `json:"chunk_key"`
@@ -101,6 +106,7 @@ type DistillationRequest struct {
 	RecipeFingerprint     string            `json:"recipe_fingerprint"`
 	SourceChecksum        string            `json:"source_checksum"`
 	Context               DocumentContext   `json:"context"`
+	ContextTruncated      bool              `json:"context_truncated"`
 	ContextFingerprint    string            `json:"context_fingerprint"`
 	Provider              string            `json:"provider"`
 	Model                 string            `json:"model"`
@@ -167,11 +173,11 @@ func PrepareDistillation(normalized document.NormalizedDocument, context Documen
 	if !recipe.valid() || recipe.values.Distillation == nil {
 		return DistillationRequest{}, errors.New("embedding recipe does not configure distillation")
 	}
-	context, err := normalizeContext(context, recipe.values)
+	context, contextTruncated, err := normalizeContext(context, recipe.values)
 	if err != nil {
 		return DistillationRequest{}, err
 	}
-	contextFingerprint, err := digestJSON(context)
+	contextFingerprint, err := fingerprintContext(context, contextTruncated)
 	if err != nil {
 		return DistillationRequest{}, err
 	}
@@ -184,7 +190,7 @@ func PrepareDistillation(normalized document.NormalizedDocument, context Documen
 	config := recipe.values.Distillation
 	request := DistillationRequest{
 		RecipeFingerprint: recipe.digest, SourceChecksum: normalized.Checksum,
-		Context: context, ContextFingerprint: contextFingerprint,
+		Context: context, ContextTruncated: contextTruncated, ContextFingerprint: contextFingerprint,
 		Provider: config.Provider, Model: config.Model, ModelRevision: config.ModelRevision,
 		PromptTemplateVersion: config.PromptTemplateVersion, MaxSections: config.MaxSections,
 		MaxSectionRunes: config.MaxSectionRunes, Partitions: partitions,
@@ -363,7 +369,7 @@ func validateDistillationRequest(request DistillationRequest) error {
 			return err
 		}
 	}
-	contextFingerprint, err := digestJSON(request.Context)
+	contextFingerprint, err := fingerprintContext(request.Context, request.ContextTruncated)
 	if err != nil {
 		return err
 	}
@@ -430,14 +436,21 @@ func digestJSON(value any) (string, error) {
 	return fingerprint(encoded), nil
 }
 
-func normalizeContext(value DocumentContext, recipe RecipeValues) (DocumentContext, error) {
+func normalizeContext(value DocumentContext, recipe RecipeValues) (DocumentContext, bool, error) {
 	if err := validateContextText(value); err != nil {
-		return DocumentContext{}, err
+		return DocumentContext{}, false, err
 	}
-	return DocumentContext{
-		Filename: truncateRunes(normalizeMetadata(value.Filename), recipe.MaxFilenameRunes),
-		Title:    truncateRunes(normalizeMetadata(value.Title), recipe.MaxTitleRunes),
-	}, nil
+	filename := normalizeMetadata(value.Filename)
+	title := normalizeMetadata(value.Title)
+	context := DocumentContext{
+		Filename: strings.TrimSpace(truncateRunes(filename, recipe.MaxFilenameRunes)),
+		Title:    strings.TrimSpace(truncateRunes(title, recipe.MaxTitleRunes)),
+	}
+	return context, context.Filename != filename || context.Title != title, nil
+}
+
+func fingerprintContext(context DocumentContext, truncated bool) (string, error) {
+	return digestJSON(documentContextIdentity{Context: context, Truncated: truncated})
 }
 
 func normalizeMetadata(value string) string {

--- a/document/embedding/distillation.go
+++ b/document/embedding/distillation.go
@@ -168,7 +168,9 @@ func PrepareDistillation(normalized document.NormalizedDocument, context Documen
 	if err != nil {
 		return DistillationRequest{}, err
 	}
-	partitions, err := partitionDocument(normalized, recipe.values.Distillation.MaxPartitionRunes)
+	partitions, err := partitionDocument(
+		normalized, recipe.values.Distillation.MaxPartitionRunes, recipe.values.MaxHeadingRunes,
+	)
 	if err != nil {
 		return DistillationRequest{}, err
 	}
@@ -188,7 +190,7 @@ func PrepareDistillation(normalized document.NormalizedDocument, context Documen
 	return request, nil
 }
 
-func partitionDocument(normalized document.NormalizedDocument, maxRunes int) ([]SourcePartition, error) {
+func partitionDocument(normalized document.NormalizedDocument, maxRunes, maxHeadingRunes int) ([]SourcePartition, error) {
 	partitions := make([]SourcePartition, 0, len(normalized.Chunks))
 	type partitionChunk struct {
 		chunk document.Chunk
@@ -222,7 +224,7 @@ func partitionDocument(normalized document.NormalizedDocument, maxRunes int) ([]
 		return nil
 	}
 	for _, chunk := range normalized.Chunks {
-		chunkText := formatDistillationChunk(normalized, chunk)
+		chunkText := formatDistillationChunk(normalized, chunk, maxRunes, maxHeadingRunes)
 		chunkRunes := utf8.RuneCountInString(chunkText)
 		if chunkRunes > maxRunes {
 			return nil, fmt.Errorf("normalized chunk %q exceeds distillation partition limit", chunk.Key)
@@ -245,18 +247,12 @@ func partitionDocument(normalized document.NormalizedDocument, maxRunes int) ([]
 	return partitions, nil
 }
 
-func formatDistillationChunk(normalized document.NormalizedDocument, chunk document.Chunk) string {
-	var builder strings.Builder
-	if len(chunk.HeadingPath) > 0 {
-		builder.WriteString("Heading: ")
-		builder.WriteString(strings.Join(chunk.HeadingPath, " > "))
-		builder.WriteByte('\n')
-	}
-	builder.WriteString("Source: ")
-	builder.WriteString(formatLocator(normalized, chunk.Spans))
-	builder.WriteString("\nContent:\n")
-	builder.WriteString(chunk.Text)
-	return builder.String()
+func formatDistillationChunk(normalized document.NormalizedDocument, chunk document.Chunk, maxRunes, maxHeadingRunes int) string {
+	source := "Source: " + formatLocator(normalized, chunk.Spans) + "\nContent:\n" + chunk.Text
+	heading, _ := boundedHeadingContext(
+		chunk.HeadingPath, maxHeadingRunes, maxRunes-utf8.RuneCountInString(source),
+	)
+	return heading + source
 }
 
 // ValidateDistillate validates provider output, attaches exact source

--- a/document/embedding/doc.go
+++ b/document/embedding/doc.go
@@ -1,0 +1,7 @@
+// Package embedding prepares deterministic, provider-neutral document inputs
+// for text embedding and optional pre-embedding distillation.
+//
+// The package performs no network, storage, queue, database, or consent work.
+// Applications own those effects and use the fingerprints returned here as
+// stable identities for derived artifacts and egress approvals.
+package embedding

--- a/document/embedding/egress.go
+++ b/document/embedding/egress.go
@@ -105,5 +105,8 @@ func canonicalEndpoint(raw string) (string, error) {
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	parsed.Host = strings.ToLower(parsed.Host)
+	if parsed.RawPath == "" && parsed.Path == "/" {
+		parsed.Path = ""
+	}
 	return parsed.String(), nil
 }

--- a/document/embedding/egress.go
+++ b/document/embedding/egress.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -106,10 +105,5 @@ func canonicalEndpoint(raw string) (string, error) {
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	parsed.Host = strings.ToLower(parsed.Host)
-	parsed.RawPath = ""
-	parsed.Path = path.Clean("/" + strings.TrimPrefix(parsed.Path, "/"))
-	if parsed.Path == "/" {
-		parsed.Path = ""
-	}
-	return strings.TrimSuffix(parsed.String(), "/"), nil
+	return parsed.String(), nil
 }

--- a/document/embedding/egress.go
+++ b/document/embedding/egress.go
@@ -46,6 +46,16 @@ func (identity VectorSpaceIdentity) CanonicalJSON() ([]byte, error) {
 	if identity.Provider == "" || identity.Model == "" || identity.ModelRevision == "" || identity.Dimension < 1 || identity.Normalization == "" {
 		return nil, errors.New("vector space provider, model, revision, dimension, and normalization are required")
 	}
+	for _, value := range [...]struct{ name, text string }{
+		{name: "vector space provider", text: identity.Provider},
+		{name: "vector space model", text: identity.Model},
+		{name: "vector space model revision", text: identity.ModelRevision},
+		{name: "vector space normalization", text: identity.Normalization},
+	} {
+		if err := validateIdentityText(value.name, value.text); err != nil {
+			return nil, err
+		}
+	}
 	encoded, err := json.Marshal(identity)
 	if err != nil {
 		return nil, fmt.Errorf("encode vector space identity: %w", err)
@@ -71,6 +81,15 @@ func (identity EgressIdentity) CanonicalJSON() ([]byte, error) {
 	}
 	if identity.Provider == "" || identity.Model == "" {
 		return nil, errors.New("embedding egress provider and model are required")
+	}
+	for _, value := range [...]struct{ name, text string }{
+		{name: "embedding egress provider", text: identity.Provider},
+		{name: "embedding egress model", text: identity.Model},
+		{name: "embedding egress model revision", text: identity.ModelRevision},
+	} {
+		if err := validateIdentityText(value.name, value.text); err != nil {
+			return nil, err
+		}
 	}
 	endpoint, err := canonicalEndpoint(identity.Endpoint)
 	if err != nil {

--- a/document/embedding/egress.go
+++ b/document/embedding/egress.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 )
@@ -104,7 +105,11 @@ func canonicalEndpoint(raw string) (string, error) {
 		return "", errors.New("embedding egress endpoint cannot contain credentials, query, or fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	parsed.Host = strings.ToLower(parsed.Host)
+	hostname := parsed.Hostname()
+	address, _, _ := strings.Cut(hostname, "%")
+	if net.ParseIP(address) == nil {
+		parsed.Host = strings.Replace(parsed.Host, hostname, strings.ToLower(hostname), 1)
+	}
 	if parsed.RawPath == "" && parsed.Path == "/" {
 		parsed.Path = ""
 	}

--- a/document/embedding/egress.go
+++ b/document/embedding/egress.go
@@ -1,0 +1,115 @@
+package embedding
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// EgressPurpose distinguishes privacy approvals that must not be reused for a
+// different class of plaintext.
+type EgressPurpose string
+
+const (
+	EgressDistillation      EgressPurpose = "document_distillation"
+	EgressDocumentEmbedding EgressPurpose = "document_embedding"
+	EgressQueryEmbedding    EgressPurpose = "query_embedding"
+)
+
+// EgressIdentity contains privacy-relevant provider settings. Credentials are
+// deliberately excluded so rotation does not invalidate consent.
+type EgressIdentity struct {
+	Purpose       EgressPurpose `json:"purpose"`
+	Provider      string        `json:"provider"`
+	Endpoint      string        `json:"endpoint"`
+	Model         string        `json:"model"`
+	ModelRevision string        `json:"model_revision,omitempty"`
+}
+
+// VectorSpaceIdentity contains the endpoint-independent settings required to
+// compare and reuse vectors safely. Endpoint belongs to EgressIdentity because
+// changing destination requires fresh consent without necessarily requiring a
+// corpus rebuild.
+type VectorSpaceIdentity struct {
+	Provider      string `json:"provider"`
+	Model         string `json:"model"`
+	ModelRevision string `json:"model_revision"`
+	Dimension     int    `json:"dimension"`
+	Normalization string `json:"normalization"`
+}
+
+// CanonicalJSON validates and returns the canonical vector-space identity.
+func (identity VectorSpaceIdentity) CanonicalJSON() ([]byte, error) {
+	if identity.Provider == "" || identity.Model == "" || identity.ModelRevision == "" || identity.Dimension < 1 || identity.Normalization == "" {
+		return nil, errors.New("vector space provider, model, revision, dimension, and normalization are required")
+	}
+	encoded, err := json.Marshal(identity)
+	if err != nil {
+		return nil, fmt.Errorf("encode vector space identity: %w", err)
+	}
+	return encoded, nil
+}
+
+// Fingerprint returns lowercase SHA-256 over CanonicalJSON.
+func (identity VectorSpaceIdentity) Fingerprint() (string, error) {
+	encoded, err := identity.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return fingerprint(encoded), nil
+}
+
+// CanonicalJSON validates and canonicalizes an egress identity. The endpoint
+// must identify an exact HTTP(S) destination without credentials, query, or
+// fragment components.
+func (identity EgressIdentity) CanonicalJSON() ([]byte, error) {
+	if identity.Purpose != EgressDistillation && identity.Purpose != EgressDocumentEmbedding && identity.Purpose != EgressQueryEmbedding {
+		return nil, fmt.Errorf("unsupported embedding egress purpose %q", identity.Purpose)
+	}
+	if identity.Provider == "" || identity.Model == "" {
+		return nil, errors.New("embedding egress provider and model are required")
+	}
+	endpoint, err := canonicalEndpoint(identity.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	identity.Endpoint = endpoint
+	encoded, err := json.Marshal(identity)
+	if err != nil {
+		return nil, fmt.Errorf("encode embedding egress identity: %w", err)
+	}
+	return encoded, nil
+}
+
+// Fingerprint returns lowercase SHA-256 over CanonicalJSON.
+func (identity EgressIdentity) Fingerprint() (string, error) {
+	encoded, err := identity.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return fingerprint(encoded), nil
+}
+
+func canonicalEndpoint(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse embedding egress endpoint: %w", err)
+	}
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return "", errors.New("embedding egress endpoint must be an absolute HTTP(S) URL")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New("embedding egress endpoint cannot contain credentials, query, or fragment")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.RawPath = ""
+	parsed.Path = path.Clean("/" + strings.TrimPrefix(parsed.Path, "/"))
+	if parsed.Path == "/" {
+		parsed.Path = ""
+	}
+	return strings.TrimSuffix(parsed.String(), "/"), nil
+}

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -120,6 +120,107 @@ func TestRawRecipeNeedsNoDistillationAndRejectsIt(t *testing.T) {
 	assert.Len(t, plan.Inputs, len(normalized.Chunks))
 }
 
+func TestEmptyHeadingResetBuildsEmbeddingPlan(t *testing.T) {
+	policy, err := document.NewNormalizePolicy(10_000)
+	require.NoError(t, err)
+	normalized, err := document.NormalizeDocument(document.SourceDocument{
+		Family: "text", UnitKind: "page", Units: []document.SourceUnit{{
+			Index: 0, Markdown: "# Parent\n\nbefore\n\n#\n\nafter",
+		}},
+	}, policy)
+	require.NoError(t, err)
+	require.Len(t, normalized.Units[0].HeadingMarks, 2)
+	assert.Empty(t, normalized.Units[0].HeadingMarks[1].Path)
+
+	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{})
+	require.NoError(t, err)
+	plan, err := embedding.BuildEmbeddingPlan(normalized, embedding.DocumentContext{}, recipe, nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, plan.Inputs)
+}
+
+func TestHeadingContextIsBoundedInPlanAndDistillation(t *testing.T) {
+	policy, err := document.NewNormalizePolicy(50_000)
+	require.NoError(t, err)
+	normalized, err := document.NormalizeDocument(document.SourceDocument{
+		Family: "text", UnitKind: "page", Units: []document.SourceUnit{{
+			Index: 0, Markdown: "# " + strings.Repeat("heading ", 700) + "\n\nsource evidence",
+		}},
+	}, policy)
+	require.NoError(t, err)
+	require.NotEmpty(t, normalized.Chunks)
+
+	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationCombined, MaxInputRunes: 220, MaxHeadingRunes: 32,
+		Distillation: &embedding.DistillationConfig{
+			Provider: "synthetic", Model: "summarizer", ModelRevision: "revision-1",
+			PromptTemplateVersion: 1, MaxPartitionRunes: 4_100,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 32, recipe.Values().MaxHeadingRunes)
+	widerHeadingRecipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationCombined, MaxInputRunes: 220, MaxHeadingRunes: 33,
+		Distillation: &embedding.DistillationConfig{
+			Provider: "synthetic", Model: "summarizer", ModelRevision: "revision-1",
+			PromptTemplateVersion: 1, MaxPartitionRunes: 4_100,
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, recipe.Fingerprint(), widerHeadingRecipe.Fingerprint())
+
+	request, err := embedding.PrepareDistillation(normalized, embedding.DocumentContext{}, recipe)
+	require.NoError(t, err)
+	var partitionText strings.Builder
+	headingLines := 0
+	for _, partition := range request.Partitions {
+		assert.LessOrEqual(t, utf8.RuneCountInString(partition.Text), 4_100)
+		for line := range strings.SplitSeq(partition.Text, "\n") {
+			heading, ok := strings.CutPrefix(line, "Heading: ")
+			if ok {
+				headingLines++
+				assert.LessOrEqual(t, utf8.RuneCountInString(heading), 32)
+			}
+		}
+		partitionText.WriteString(partition.Text)
+	}
+	assert.Positive(t, headingLines)
+	for _, chunk := range normalized.Chunks {
+		assert.Contains(t, partitionText.String(), chunk.Text)
+	}
+
+	sections := make([]embedding.DerivedSectionResult, 0, len(request.Partitions))
+	for _, partition := range request.Partitions {
+		sections = append(sections, embedding.DerivedSectionResult{
+			Text: "bounded summary", PartitionKeys: []string{partition.Key},
+		})
+	}
+	distillate, err := embedding.ValidateDistillate(request, embedding.DistillationResult{
+		Provider: request.Provider, Model: request.Model, ModelRevision: request.ModelRevision,
+		Sections: sections,
+	})
+	require.NoError(t, err)
+	plan, err := embedding.BuildEmbeddingPlan(normalized, embedding.DocumentContext{}, recipe, &distillate)
+	require.NoError(t, err)
+	headingLines = 0
+	for _, input := range plan.Inputs {
+		assert.LessOrEqual(t, utf8.RuneCountInString(input.Text), 220)
+		if input.Kind == embedding.RepresentationKindRaw {
+			for line := range strings.SplitSeq(input.Text, "\n") {
+				heading, ok := strings.CutPrefix(line, "Heading: ")
+				if ok {
+					headingLines++
+					assert.LessOrEqual(t, utf8.RuneCountInString(heading), 32)
+				}
+			}
+			_, content, found := strings.Cut(input.Text, "Content:\n")
+			assert.True(t, found)
+			assert.NotEmpty(t, content)
+		}
+	}
+	assert.Positive(t, headingLines)
+}
+
 func TestEgressFingerprintSeparatesPurposeAndDestination(t *testing.T) {
 	base := embedding.EgressIdentity{
 		Purpose: embedding.EgressDocumentEmbedding, Provider: "synthetic",

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -1,0 +1,167 @@
+package embedding_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/embedding"
+)
+
+func TestCombinedRecipeBuildsDeterministicBoundedPlan(t *testing.T) {
+	normalized := normalizedDocument(t)
+	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationCombined, MaxInputRunes: 220,
+		Distillation: &embedding.DistillationConfig{
+			Provider: "synthetic", Model: "summarizer", ModelRevision: "revision-1",
+			PromptTemplateVersion: 3, MaxPartitionRunes: 4_100, MaxSections: 20, MaxSectionRunes: 500,
+		},
+	})
+	require.NoError(t, err)
+	contextValue := embedding.DocumentContext{
+		Filename: "  quarterly\tresults.pdf ",
+		Title:    "Synthetic report\nfor testing",
+	}
+
+	request, err := embedding.PrepareDistillation(normalized, contextValue, recipe)
+	require.NoError(t, err)
+	requestJSON, err := json.Marshal(request)
+	require.NoError(t, err)
+	var restoredRequest embedding.DistillationRequest
+	require.NoError(t, json.Unmarshal(requestJSON, &restoredRequest))
+	assert.Equal(t, request, restoredRequest)
+	request = restoredRequest
+	require.NotEmpty(t, request.Partitions)
+	assert.Equal(t, recipe.Fingerprint(), request.RecipeFingerprint)
+	for index, partition := range request.Partitions {
+		assert.Equal(t, index, partition.Ordinal)
+		assert.LessOrEqual(t, utf8.RuneCountInString(partition.Text), 4_100)
+		assert.NotEmpty(t, partition.SourceRefs)
+	}
+
+	sections := make([]embedding.DerivedSectionResult, 0, len(request.Partitions))
+	for _, partition := range request.Partitions {
+		sections = append(sections, embedding.DerivedSectionResult{
+			Text: "\u202eConcise synthetic summary\r\nfor " + partition.Key[:8], PartitionKeys: []string{partition.Key},
+		})
+	}
+	distillate, err := embedding.ValidateDistillate(request, embedding.DistillationResult{
+		Provider: request.Provider, Model: request.Model, ModelRevision: request.ModelRevision, Sections: sections,
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, distillate.Sections[0].Text, "\u202e")
+	assert.NotContains(t, distillate.Sections[0].Text, "\r")
+	distillateJSON, err := json.Marshal(distillate)
+	require.NoError(t, err)
+	var restoredDistillate embedding.Distillate
+	require.NoError(t, json.Unmarshal(distillateJSON, &restoredDistillate))
+	assert.Equal(t, distillate, restoredDistillate)
+	distillate = restoredDistillate
+
+	plan, err := embedding.BuildEmbeddingPlan(normalized, contextValue, recipe, &distillate)
+	require.NoError(t, err)
+	require.Len(t, plan.Inputs, len(normalized.Chunks)+len(distillate.Sections))
+	assert.Equal(t, distillate.Fingerprint, plan.DistillateFingerprint)
+	assert.True(t, plan.Inputs[0].Truncated)
+	for index, input := range plan.Inputs {
+		assert.Equal(t, index, input.Ordinal)
+		assert.LessOrEqual(t, utf8.RuneCountInString(input.Text), 220)
+		assert.True(t, utf8.ValidString(input.Text))
+		assert.NotEmpty(t, input.SourceRefs)
+	}
+
+	repeated, err := embedding.BuildEmbeddingPlan(normalized, contextValue, recipe, &distillate)
+	require.NoError(t, err)
+	assert.Equal(t, plan, repeated)
+}
+
+func TestDistillateRequiresCompleteOrderedCoverage(t *testing.T) {
+	normalized := normalizedDocument(t)
+	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationDistilled,
+		Distillation: &embedding.DistillationConfig{
+			Provider: "synthetic", Model: "summarizer", ModelRevision: "revision-1",
+			PromptTemplateVersion: 1, MaxPartitionRunes: 4_100,
+		},
+	})
+	require.NoError(t, err)
+	request, err := embedding.PrepareDistillation(normalized, embedding.DocumentContext{}, recipe)
+	require.NoError(t, err)
+	require.Greater(t, len(request.Partitions), 1)
+
+	_, err = embedding.ValidateDistillate(request, embedding.DistillationResult{
+		Provider: request.Provider, Model: request.Model, ModelRevision: request.ModelRevision,
+		Sections: []embedding.DerivedSectionResult{{
+			Text: "Incomplete summary", PartitionKeys: []string{request.Partitions[1].Key},
+		}},
+	})
+	assert.ErrorContains(t, err, "source order")
+}
+
+func TestRawRecipeNeedsNoDistillationAndRejectsIt(t *testing.T) {
+	normalized := normalizedDocument(t)
+	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, embedding.RepresentationRaw, recipe.Values().Mode)
+
+	_, err = embedding.PrepareDistillation(normalized, embedding.DocumentContext{}, recipe)
+	require.ErrorContains(t, err, "does not configure distillation")
+	plan, err := embedding.BuildEmbeddingPlan(normalized, embedding.DocumentContext{}, recipe, nil)
+	require.NoError(t, err)
+	assert.Len(t, plan.Inputs, len(normalized.Chunks))
+}
+
+func TestEgressFingerprintSeparatesPurposeAndDestination(t *testing.T) {
+	base := embedding.EgressIdentity{
+		Purpose: embedding.EgressDocumentEmbedding, Provider: "synthetic",
+		Endpoint: "HTTPS://EXAMPLE.COM/v1/", Model: "embed-1", ModelRevision: "2026-08",
+	}
+	first, err := base.Fingerprint()
+	require.NoError(t, err)
+	canonical, err := (embedding.EgressIdentity{
+		Purpose: embedding.EgressDocumentEmbedding, Provider: "synthetic",
+		Endpoint: "https://example.com/v1", Model: "embed-1", ModelRevision: "2026-08",
+	}).Fingerprint()
+	require.NoError(t, err)
+	assert.Equal(t, first, canonical)
+
+	query := base
+	query.Purpose = embedding.EgressQueryEmbedding
+	queryFingerprint, err := query.Fingerprint()
+	require.NoError(t, err)
+	assert.NotEqual(t, first, queryFingerprint)
+
+	redirected := base
+	redirected.Endpoint = "https://other.example/v1"
+	redirectedFingerprint, err := redirected.Fingerprint()
+	require.NoError(t, err)
+	assert.NotEqual(t, first, redirectedFingerprint)
+
+	space := embedding.VectorSpaceIdentity{
+		Provider: "synthetic", Model: "embed-1", ModelRevision: "2026-08",
+		Dimension: 1_024, Normalization: "unit-length",
+	}
+	spaceFingerprint, err := space.Fingerprint()
+	require.NoError(t, err)
+	assert.NotEmpty(t, spaceFingerprint)
+}
+
+func normalizedDocument(t *testing.T) document.NormalizedDocument {
+	t.Helper()
+	policy, err := document.NewNormalizePolicy(50_000)
+	require.NoError(t, err)
+	longText := strings.Repeat("café résumé semantic evidence. ", 260)
+	normalized, err := document.NormalizeDocument(document.SourceDocument{
+		Family: "pdf", UnitKind: "page",
+		Units: []document.SourceUnit{
+			{Index: 0, Markdown: "# Revenue\n" + longText},
+			{Index: 1, Markdown: "# Risks\n" + longText},
+		},
+	}, policy)
+	require.NoError(t, err)
+	return normalized
+}

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -347,6 +347,13 @@ func TestMetadataContextIsBoundedByProviderInputLimit(t *testing.T) {
 	}
 	request, err := embedding.PrepareDistillation(normalized, contextValue, recipe)
 	require.NoError(t, err)
+	assert.True(t, request.ContextTruncated)
+	exactRequest, err := embedding.PrepareDistillation(normalized, request.Context, recipe)
+	require.NoError(t, err)
+	assert.False(t, exactRequest.ContextTruncated)
+	assert.Equal(t, request.Context, exactRequest.Context)
+	assert.NotEqual(t, request.ContextFingerprint, exactRequest.ContextFingerprint)
+	assert.NotEqual(t, request.Fingerprint, exactRequest.Fingerprint)
 	sections := make([]embedding.DerivedSectionResult, 0, len(request.Partitions))
 	for _, partition := range request.Partitions {
 		sections = append(sections, embedding.DerivedSectionResult{
@@ -374,6 +381,32 @@ func TestMetadataContextIsBoundedByProviderInputLimit(t *testing.T) {
 			assert.True(t, found)
 			assert.NotEmpty(t, content)
 		}
+	}
+}
+
+func TestMetadataCapTruncationChangesPlanAndInputIdentities(t *testing.T) {
+	normalized := normalizedDocument(t)
+	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		MaxFilenameRunes: 4,
+		MaxTitleRunes:    4,
+	})
+	require.NoError(t, err)
+	exact, err := embedding.BuildEmbeddingPlan(
+		normalized, embedding.DocumentContext{Filename: "file", Title: "name"}, recipe, nil,
+	)
+	require.NoError(t, err)
+	truncated, err := embedding.BuildEmbeddingPlan(
+		normalized, embedding.DocumentContext{Filename: "file suffix", Title: "name suffix"}, recipe, nil,
+	)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, exact.ContextFingerprint, truncated.ContextFingerprint)
+	assert.NotEqual(t, exact.Fingerprint, truncated.Fingerprint)
+	require.Len(t, truncated.Inputs, len(exact.Inputs))
+	for index := range exact.Inputs {
+		assert.False(t, exact.Inputs[index].Truncated)
+		assert.True(t, truncated.Inputs[index].Truncated)
+		assert.NotEqual(t, exact.Inputs[index].Key, truncated.Inputs[index].Key)
 	}
 }
 

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -256,6 +256,53 @@ func TestHeadingContextIsBoundedInPlanAndDistillation(t *testing.T) {
 	assert.Positive(t, headingLines)
 }
 
+func TestMetadataContextIsBoundedByProviderInputLimit(t *testing.T) {
+	normalized := normalizedDocument(t)
+	const maxInputRunes = 96
+	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationCombined, MaxInputRunes: maxInputRunes,
+		Distillation: &embedding.DistillationConfig{
+			Provider: "synthetic", Model: "summarizer", ModelRevision: "revision-1",
+			PromptTemplateVersion: 1, MaxPartitionRunes: 4_100,
+		},
+	})
+	require.NoError(t, err)
+	contextValue := embedding.DocumentContext{
+		Filename: strings.Repeat("résumé-日本-", 40),
+		Title:    strings.Repeat("long 🙂 title ", 60),
+	}
+	request, err := embedding.PrepareDistillation(normalized, contextValue, recipe)
+	require.NoError(t, err)
+	sections := make([]embedding.DerivedSectionResult, 0, len(request.Partitions))
+	for _, partition := range request.Partitions {
+		sections = append(sections, embedding.DerivedSectionResult{
+			Text: "bounded summary", PartitionKeys: []string{partition.Key},
+		})
+	}
+	distillate, err := embedding.ValidateDistillate(request, embedding.DistillationResult{
+		Provider: request.Provider, Model: request.Model, ModelRevision: request.ModelRevision, Sections: sections,
+	})
+	require.NoError(t, err)
+
+	plan, err := embedding.BuildEmbeddingPlan(normalized, contextValue, recipe, &distillate)
+	require.NoError(t, err)
+	for _, input := range plan.Inputs {
+		assert.LessOrEqual(t, utf8.RuneCountInString(input.Text), maxInputRunes)
+		assert.True(t, utf8.ValidString(input.Text))
+		assert.True(t, input.Truncated)
+		switch input.Kind {
+		case embedding.RepresentationKindRaw:
+			_, content, found := strings.Cut(input.Text, "Content:\n")
+			assert.True(t, found)
+			assert.NotEmpty(t, content)
+		case embedding.RepresentationKindDistilled:
+			_, content, found := strings.Cut(input.Text, "Derived summary (verify against source):\n")
+			assert.True(t, found)
+			assert.NotEmpty(t, content)
+		}
+	}
+}
+
 func TestEgressFingerprintSeparatesPurposeAndDestination(t *testing.T) {
 	base := embedding.EgressIdentity{
 		Purpose: embedding.EgressDocumentEmbedding, Provider: "synthetic",

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -153,6 +153,68 @@ func TestTruncationStateChangesPublishedIdentities(t *testing.T) {
 	unitPlan, err := embedding.BuildEmbeddingPlan(unitTruncated, embedding.DocumentContext{}, recipe, nil)
 	require.NoError(t, err)
 	assert.NotEqual(t, documentPlan.Inputs[0].Key, unitPlan.Inputs[0].Key)
+
+	distilledRecipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationDistilled,
+		Distillation: &embedding.DistillationConfig{
+			Provider: "synthetic", Model: "summarizer", ModelRevision: "revision-1",
+			PromptTemplateVersion: 1,
+		},
+	})
+	require.NoError(t, err)
+	for _, test := range []struct {
+		name       string
+		normalized document.NormalizedDocument
+	}{
+		{name: "document", normalized: documentTruncated},
+		{name: "unit and chunk", normalized: unitTruncated},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := embedding.PrepareDistillation(
+				test.normalized, embedding.DocumentContext{}, distilledRecipe,
+			)
+			require.NoError(t, err)
+			sections := make([]embedding.DerivedSectionResult, 0, len(request.Partitions))
+			for _, partition := range request.Partitions {
+				assert.True(t, partition.Truncated)
+				sections = append(sections, embedding.DerivedSectionResult{
+					Text: "summary", PartitionKeys: []string{partition.Key},
+				})
+			}
+			tamperedRequest := request
+			tamperedRequest.Partitions = append([]embedding.SourcePartition(nil), request.Partitions...)
+			tamperedRequest.Partitions[0].Truncated = false
+			_, err = embedding.ValidateDistillate(tamperedRequest, embedding.DistillationResult{
+				Provider: request.Provider, Model: request.Model, ModelRevision: request.ModelRevision,
+				Sections: sections,
+			})
+			require.ErrorContains(t, err, "key is invalid")
+
+			distillate, err := embedding.ValidateDistillate(request, embedding.DistillationResult{
+				Provider: request.Provider, Model: request.Model, ModelRevision: request.ModelRevision,
+				Sections: sections,
+			})
+			require.NoError(t, err)
+			for _, section := range distillate.Sections {
+				assert.True(t, section.Truncated)
+			}
+			plan, err := embedding.BuildEmbeddingPlan(
+				test.normalized, embedding.DocumentContext{}, distilledRecipe, &distillate,
+			)
+			require.NoError(t, err)
+			for _, input := range plan.Inputs {
+				assert.True(t, input.Truncated)
+			}
+
+			tampered := distillate
+			tampered.Sections = append([]embedding.DerivedSection(nil), distillate.Sections...)
+			tampered.Sections[0].Truncated = false
+			_, err = embedding.BuildEmbeddingPlan(
+				test.normalized, embedding.DocumentContext{}, distilledRecipe, &tampered,
+			)
+			assert.ErrorContains(t, err, "key is invalid")
+		})
+	}
 }
 
 func TestEmptyHeadingResetBuildsEmbeddingPlan(t *testing.T) {

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -123,6 +123,10 @@ func TestRawRecipeNeedsNoDistillationAndRejectsIt(t *testing.T) {
 func TestTruncationStateChangesPublishedIdentities(t *testing.T) {
 	policy, err := document.NewNormalizePolicy(3)
 	require.NoError(t, err)
+	complete, err := document.NormalizeDocument(document.SourceDocument{
+		Family: "text", UnitKind: "unit", Units: []document.SourceUnit{{Index: 0, Markdown: "one"}},
+	}, policy)
+	require.NoError(t, err)
 	documentTruncated, err := document.NormalizeDocument(document.SourceDocument{
 		Family: "text", UnitKind: "unit", Units: []document.SourceUnit{
 			{Index: 0, Markdown: "one"},
@@ -135,6 +139,7 @@ func TestTruncationStateChangesPublishedIdentities(t *testing.T) {
 	}, policy)
 	require.NoError(t, err)
 
+	assert.False(t, complete.Truncated)
 	assert.True(t, documentTruncated.Truncated)
 	assert.True(t, unitTruncated.Truncated)
 	assert.False(t, documentTruncated.Units[0].Truncated)
@@ -146,16 +151,23 @@ func TestTruncationStateChangesPublishedIdentities(t *testing.T) {
 
 	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{})
 	require.NoError(t, err)
+	completePlan, err := embedding.BuildEmbeddingPlan(
+		complete, embedding.DocumentContext{}, recipe, nil,
+	)
+	require.NoError(t, err)
 	documentPlan, err := embedding.BuildEmbeddingPlan(
 		documentTruncated, embedding.DocumentContext{}, recipe, nil,
 	)
 	require.NoError(t, err)
 	unitPlan, err := embedding.BuildEmbeddingPlan(unitTruncated, embedding.DocumentContext{}, recipe, nil)
 	require.NoError(t, err)
+	assert.False(t, completePlan.Inputs[0].Truncated)
+	assert.True(t, documentPlan.Inputs[0].Truncated)
+	assert.NotEqual(t, completePlan.Inputs[0].Key, documentPlan.Inputs[0].Key)
 	assert.NotEqual(t, documentPlan.Inputs[0].Key, unitPlan.Inputs[0].Key)
 
-	distilledRecipe, err := embedding.NewRecipe(embedding.RecipeConfig{
-		Mode: embedding.RepresentationDistilled,
+	combinedRecipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationCombined,
 		Distillation: &embedding.DistillationConfig{
 			Provider: "synthetic", Model: "summarizer", ModelRevision: "revision-1",
 			PromptTemplateVersion: 1,
@@ -171,7 +183,7 @@ func TestTruncationStateChangesPublishedIdentities(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			request, err := embedding.PrepareDistillation(
-				test.normalized, embedding.DocumentContext{}, distilledRecipe,
+				test.normalized, embedding.DocumentContext{}, combinedRecipe,
 			)
 			require.NoError(t, err)
 			sections := make([]embedding.DerivedSectionResult, 0, len(request.Partitions))
@@ -199,7 +211,7 @@ func TestTruncationStateChangesPublishedIdentities(t *testing.T) {
 				assert.True(t, section.Truncated)
 			}
 			plan, err := embedding.BuildEmbeddingPlan(
-				test.normalized, embedding.DocumentContext{}, distilledRecipe, &distillate,
+				test.normalized, embedding.DocumentContext{}, combinedRecipe, &distillate,
 			)
 			require.NoError(t, err)
 			for _, input := range plan.Inputs {
@@ -210,7 +222,7 @@ func TestTruncationStateChangesPublishedIdentities(t *testing.T) {
 			tampered.Sections = append([]embedding.DerivedSection(nil), distillate.Sections...)
 			tampered.Sections[0].Truncated = false
 			_, err = embedding.BuildEmbeddingPlan(
-				test.normalized, embedding.DocumentContext{}, distilledRecipe, &tampered,
+				test.normalized, embedding.DocumentContext{}, combinedRecipe, &tampered,
 			)
 			assert.ErrorContains(t, err, "key is invalid")
 		})

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -23,8 +23,8 @@ func TestCombinedRecipeBuildsDeterministicBoundedPlan(t *testing.T) {
 	})
 	require.NoError(t, err)
 	contextValue := embedding.DocumentContext{
-		Filename: "  quarterly\tresults.pdf ",
-		Title:    "Synthetic report\nfor testing",
+		Filename: "  résumé\tresults.pdf ",
+		Title:    "東京 synthetic report\nfor testing",
 	}
 
 	request, err := embedding.PrepareDistillation(normalized, contextValue, recipe)
@@ -334,6 +334,56 @@ func TestEgressFingerprintSeparatesPurposeAndDestination(t *testing.T) {
 	spaceFingerprint, err := space.Fingerprint()
 	require.NoError(t, err)
 	assert.NotEmpty(t, spaceFingerprint)
+}
+
+func TestEmbeddingRejectsUnstableTextFields(t *testing.T) {
+	normalized := normalizedDocument(t)
+	rawRecipe, err := embedding.NewRecipe(embedding.RecipeConfig{})
+	require.NoError(t, err)
+	invalidUTF8 := string([]byte{0xff})
+
+	_, err = embedding.BuildEmbeddingPlan(
+		normalized, embedding.DocumentContext{Filename: invalidUTF8}, rawRecipe, nil,
+	)
+	require.ErrorContains(t, err, "invalid UTF-8")
+
+	distilledConfig := embedding.DistillationConfig{
+		Provider: "synthetic", Model: "summarizer", ModelRevision: "revision-1",
+		PromptTemplateVersion: 1,
+	}
+	distilledRecipe, err := embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationDistilled, Distillation: &distilledConfig,
+	})
+	require.NoError(t, err)
+	_, err = embedding.PrepareDistillation(
+		normalized, embedding.DocumentContext{Title: invalidUTF8}, distilledRecipe,
+	)
+	require.ErrorContains(t, err, "invalid UTF-8")
+
+	distilledConfig.Provider = invalidUTF8
+	_, err = embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationDistilled, Distillation: &distilledConfig,
+	})
+	require.ErrorContains(t, err, "invalid UTF-8")
+
+	distilledConfig.Provider = "synthetic"
+	distilledConfig.Model = "summary\nother"
+	_, err = embedding.NewRecipe(embedding.RecipeConfig{
+		Mode: embedding.RepresentationDistilled, Distillation: &distilledConfig,
+	})
+	require.ErrorContains(t, err, "control character")
+
+	_, err = (embedding.EgressIdentity{
+		Purpose: embedding.EgressDocumentEmbedding, Provider: "synthetic",
+		Endpoint: "https://example.com/v1", Model: "embed", ModelRevision: invalidUTF8,
+	}).Fingerprint()
+	require.ErrorContains(t, err, "invalid UTF-8")
+
+	_, err = (embedding.VectorSpaceIdentity{
+		Provider: "synthetic", Model: "embed", ModelRevision: "revision-1",
+		Dimension: 1_024, Normalization: "unit\nlength",
+	}).Fingerprint()
+	require.ErrorContains(t, err, "control character")
 }
 
 func normalizedDocument(t *testing.T) document.NormalizedDocument {

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -120,6 +120,41 @@ func TestRawRecipeNeedsNoDistillationAndRejectsIt(t *testing.T) {
 	assert.Len(t, plan.Inputs, len(normalized.Chunks))
 }
 
+func TestTruncationStateChangesPublishedIdentities(t *testing.T) {
+	policy, err := document.NewNormalizePolicy(3)
+	require.NoError(t, err)
+	documentTruncated, err := document.NormalizeDocument(document.SourceDocument{
+		Family: "text", UnitKind: "unit", Units: []document.SourceUnit{
+			{Index: 0, Markdown: "one"},
+			{Index: 1, Markdown: "two"},
+		},
+	}, policy)
+	require.NoError(t, err)
+	unitTruncated, err := document.NormalizeDocument(document.SourceDocument{
+		Family: "text", UnitKind: "unit", Units: []document.SourceUnit{{Index: 0, Markdown: "one more"}},
+	}, policy)
+	require.NoError(t, err)
+
+	assert.True(t, documentTruncated.Truncated)
+	assert.True(t, unitTruncated.Truncated)
+	assert.False(t, documentTruncated.Units[0].Truncated)
+	assert.True(t, unitTruncated.Units[0].Truncated)
+	assert.Equal(t, documentTruncated.Units[0].Text, unitTruncated.Units[0].Text)
+	assert.NotEqual(t, documentTruncated.Units[0].Checksum, unitTruncated.Units[0].Checksum)
+	assert.NotEqual(t, documentTruncated.Chunks[0].Checksum, unitTruncated.Chunks[0].Checksum)
+	assert.NotEqual(t, documentTruncated.Checksum, unitTruncated.Checksum)
+
+	recipe, err := embedding.NewRecipe(embedding.RecipeConfig{})
+	require.NoError(t, err)
+	documentPlan, err := embedding.BuildEmbeddingPlan(
+		documentTruncated, embedding.DocumentContext{}, recipe, nil,
+	)
+	require.NoError(t, err)
+	unitPlan, err := embedding.BuildEmbeddingPlan(unitTruncated, embedding.DocumentContext{}, recipe, nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, documentPlan.Inputs[0].Key, unitPlan.Inputs[0].Key)
+}
+
 func TestEmptyHeadingResetBuildsEmbeddingPlan(t *testing.T) {
 	policy, err := document.NewNormalizePolicy(10_000)
 	require.NoError(t, err)

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -181,6 +181,16 @@ func TestEgressFingerprintSeparatesPurposeAndDestination(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, rootFingerprint, escapedRootFingerprint)
 
+	upperZone := base
+	upperZone.Endpoint = "http://[fe80::1%25ETH0]/v1"
+	upperZoneFingerprint, err := upperZone.Fingerprint()
+	require.NoError(t, err)
+	lowerZone := base
+	lowerZone.Endpoint = "http://[fe80::1%25eth0]/v1"
+	lowerZoneFingerprint, err := lowerZone.Fingerprint()
+	require.NoError(t, err)
+	assert.NotEqual(t, upperZoneFingerprint, lowerZoneFingerprint)
+
 	space := embedding.VectorSpaceIdentity{
 		Provider: "synthetic", Model: "embed-1", ModelRevision: "2026-08",
 		Dimension: 1_024, Normalization: "unit-length",

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -77,6 +77,11 @@ func TestCombinedRecipeBuildsDeterministicBoundedPlan(t *testing.T) {
 	repeated, err := embedding.BuildEmbeddingPlan(normalized, contextValue, recipe, &distillate)
 	require.NoError(t, err)
 	assert.Equal(t, plan, repeated)
+
+	partial := normalized
+	partial.Chunks = append([]document.Chunk(nil), normalized.Chunks[:len(normalized.Chunks)-1]...)
+	_, err = embedding.PrepareDistillation(partial, contextValue, recipe)
+	assert.ErrorContains(t, err, "checksum")
 }
 
 func TestDistillateRequiresCompleteOrderedCoverage(t *testing.T) {
@@ -124,7 +129,7 @@ func TestEgressFingerprintSeparatesPurposeAndDestination(t *testing.T) {
 	require.NoError(t, err)
 	canonical, err := (embedding.EgressIdentity{
 		Purpose: embedding.EgressDocumentEmbedding, Provider: "synthetic",
-		Endpoint: "https://example.com/v1", Model: "embed-1", ModelRevision: "2026-08",
+		Endpoint: "https://example.com/v1/", Model: "embed-1", ModelRevision: "2026-08",
 	}).Fingerprint()
 	require.NoError(t, err)
 	assert.Equal(t, first, canonical)
@@ -140,6 +145,26 @@ func TestEgressFingerprintSeparatesPurposeAndDestination(t *testing.T) {
 	redirectedFingerprint, err := redirected.Fingerprint()
 	require.NoError(t, err)
 	assert.NotEqual(t, first, redirectedFingerprint)
+
+	escaped := base
+	escaped.Endpoint = "https://example.com/tenant%2Fprivate"
+	escapedFingerprint, err := escaped.Fingerprint()
+	require.NoError(t, err)
+	literal := base
+	literal.Endpoint = "https://example.com/tenant/private"
+	literalFingerprint, err := literal.Fingerprint()
+	require.NoError(t, err)
+	assert.NotEqual(t, escapedFingerprint, literalFingerprint)
+
+	encodedDots := base
+	encodedDots.Endpoint = "https://example.com/a/%2e%2e/private"
+	encodedDotsFingerprint, err := encodedDots.Fingerprint()
+	require.NoError(t, err)
+	cleaned := base
+	cleaned.Endpoint = "https://example.com/private"
+	cleanedFingerprint, err := cleaned.Fingerprint()
+	require.NoError(t, err)
+	assert.NotEqual(t, encodedDotsFingerprint, cleanedFingerprint)
 
 	space := embedding.VectorSpaceIdentity{
 		Provider: "synthetic", Model: "embed-1", ModelRevision: "2026-08",

--- a/document/embedding/embedding_test.go
+++ b/document/embedding/embedding_test.go
@@ -166,6 +166,21 @@ func TestEgressFingerprintSeparatesPurposeAndDestination(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, encodedDotsFingerprint, cleanedFingerprint)
 
+	root := base
+	root.Endpoint = "https://example.com/"
+	rootFingerprint, err := root.Fingerprint()
+	require.NoError(t, err)
+	emptyPath := base
+	emptyPath.Endpoint = "https://example.com"
+	emptyPathFingerprint, err := emptyPath.Fingerprint()
+	require.NoError(t, err)
+	assert.Equal(t, rootFingerprint, emptyPathFingerprint)
+	escapedRoot := base
+	escapedRoot.Endpoint = "https://example.com/%2F"
+	escapedRootFingerprint, err := escapedRoot.Fingerprint()
+	require.NoError(t, err)
+	assert.NotEqual(t, rootFingerprint, escapedRootFingerprint)
+
 	space := embedding.VectorSpaceIdentity{
 		Provider: "synthetic", Model: "embed-1", ModelRevision: "2026-08",
 		Dimension: 1_024, Normalization: "unit-length",

--- a/document/embedding/eval/doc.go
+++ b/document/embedding/eval/doc.go
@@ -1,0 +1,3 @@
+// Package eval evaluates document retrieval recipes against versioned public
+// or synthetic corpora with graded relevance judgments.
+package eval

--- a/document/embedding/eval/eval.go
+++ b/document/embedding/eval/eval.go
@@ -122,7 +122,8 @@ type Report struct {
 // Evaluate executes every system over every query for the requested number of
 // repetitions and computes metrics from observed rankings.
 func Evaluate(ctx context.Context, corpus Corpus, systems []System, repetitions int, runner Runner) (Report, error) {
-	if err := validateCorpus(corpus); err != nil {
+	documentIDs, err := validateCorpus(corpus)
+	if err != nil {
 		return Report{}, err
 	}
 	if len(systems) == 0 || repetitions < 1 || runner == nil {
@@ -137,7 +138,7 @@ func Evaluate(ctx context.Context, corpus Corpus, systems []System, repetitions 
 		seenSystems[system.ID] = true
 		systemReport := SystemReport{System: system}
 		for repetition := range repetitions {
-			trial, err := runTrial(ctx, corpus, system, repetition, runner)
+			trial, err := runTrial(ctx, corpus, documentIDs, system, repetition, runner)
 			if err != nil {
 				return Report{}, fmt.Errorf("evaluate system %q repetition %d: %w", system.ID, repetition+1, err)
 			}
@@ -149,7 +150,14 @@ func Evaluate(ctx context.Context, corpus Corpus, systems []System, repetitions 
 	return report, nil
 }
 
-func runTrial(ctx context.Context, corpus Corpus, system System, repetition int, runner Runner) (TrialReport, error) {
+func runTrial(
+	ctx context.Context,
+	corpus Corpus,
+	documentIDs map[string]bool,
+	system System,
+	repetition int,
+	runner Runner,
+) (TrialReport, error) {
 	trial := TrialReport{Repetition: repetition + 1}
 	for _, query := range corpus.Queries {
 		result, err := runner.Search(ctx, system, corpus, query)
@@ -160,7 +168,7 @@ func runTrial(ctx context.Context, corpus Corpus, system System, repetition int,
 			result.Usage.EstimatedCostMicros < 0 || result.Usage.Latency < 0 {
 			return TrialReport{}, fmt.Errorf("query %q: provider usage cannot be negative", query.ID)
 		}
-		if err := validateRanking(corpus, result.DocumentIDs); err != nil {
+		if err := validateRanking(documentIDs, result.DocumentIDs); err != nil {
 			return TrialReport{}, fmt.Errorf("query %q: %w", query.ID, err)
 		}
 		metrics := score(query.Judgments, result.DocumentIDs)
@@ -278,28 +286,28 @@ func interval(trials []TrialReport, value func(MetricSet) float64) MetricInterva
 	return result
 }
 
-func validateCorpus(corpus Corpus) error {
+func validateCorpus(corpus Corpus) (map[string]bool, error) {
 	if corpus.ID == "" || corpus.Version == "" || len(corpus.Documents) == 0 || len(corpus.Queries) == 0 {
-		return errors.New("evaluation corpus ID, version, documents, and queries are required")
+		return nil, errors.New("evaluation corpus ID, version, documents, and queries are required")
 	}
 	documents := make(map[string]bool, len(corpus.Documents))
 	for _, document := range corpus.Documents {
 		if document.ID == "" || document.Text == "" || documents[document.ID] {
-			return errors.New("evaluation document IDs and text must be non-empty and IDs unique")
+			return nil, errors.New("evaluation document IDs and text must be non-empty and IDs unique")
 		}
 		documents[document.ID] = true
 	}
 	queries := make(map[string]bool, len(corpus.Queries))
 	for _, query := range corpus.Queries {
 		if query.ID == "" || query.Text == "" || len(query.Judgments) == 0 || queries[query.ID] {
-			return errors.New("evaluation query IDs, text, and judgments must be non-empty and IDs unique")
+			return nil, errors.New("evaluation query IDs, text, and judgments must be non-empty and IDs unique")
 		}
 		queries[query.ID] = true
 		judged := make(map[string]bool, len(query.Judgments))
 		relevant := 0
 		for _, judgment := range query.Judgments {
 			if !documents[judgment.DocumentID] || judgment.Grade < 0 || judged[judgment.DocumentID] {
-				return fmt.Errorf("evaluation query %q has an invalid judgment", query.ID)
+				return nil, fmt.Errorf("evaluation query %q has an invalid judgment", query.ID)
 			}
 			judged[judgment.DocumentID] = true
 			if judgment.Grade > 0 {
@@ -307,17 +315,13 @@ func validateCorpus(corpus Corpus) error {
 			}
 		}
 		if relevant == 0 {
-			return fmt.Errorf("evaluation query %q has no relevant judgment", query.ID)
+			return nil, fmt.Errorf("evaluation query %q has no relevant judgment", query.ID)
 		}
 	}
-	return nil
+	return documents, nil
 }
 
-func validateRanking(corpus Corpus, ranking []string) error {
-	documents := make(map[string]bool, len(corpus.Documents))
-	for _, document := range corpus.Documents {
-		documents[document.ID] = true
-	}
+func validateRanking(documents map[string]bool, ranking []string) error {
 	seen := make(map[string]bool, len(ranking))
 	for _, documentID := range ranking {
 		if !documents[documentID] || seen[documentID] {

--- a/document/embedding/eval/eval.go
+++ b/document/embedding/eval/eval.go
@@ -1,0 +1,337 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"time"
+)
+
+// Corpus is a versioned, redistributable document retrieval benchmark.
+type Corpus struct {
+	ID        string
+	Version   string
+	Documents []Document
+	Queries   []Query
+}
+
+// Document is one public or synthetic benchmark document.
+type Document struct {
+	ID   string
+	Text string
+}
+
+// Query contains query text and graded relevance judgments.
+type Query struct {
+	ID        string
+	Text      string
+	Judgments []Judgment
+}
+
+// Judgment assigns a non-negative relevance grade to one document. Critical
+// judgments identify results whose absence from the top 20 is reported
+// separately from aggregate metrics.
+type Judgment struct {
+	DocumentID string
+	Grade      int
+	Critical   bool
+}
+
+// System identifies one retrieval recipe under evaluation. Fingerprints make
+// reports attributable without coupling the evaluator to a provider.
+type System struct {
+	ID                     string
+	RecipeFingerprint      string
+	VectorSpaceFingerprint string
+}
+
+// Usage records provider work and observed latency for one query.
+type Usage struct {
+	ProviderCalls       int
+	ProviderInputRunes  int
+	ProviderOutputUnits int
+	EstimatedCostMicros int64
+	Latency             time.Duration
+}
+
+// SearchResult is one ranked retrieval result.
+type SearchResult struct {
+	DocumentIDs []string
+	Usage       Usage
+}
+
+// Runner executes one system/query pair. Hosted runners should return fresh
+// observations rather than replaying cached results when repeated trials are
+// intended to characterize provider variance.
+type Runner interface {
+	Search(ctx context.Context, system System, corpus Corpus, query Query) (SearchResult, error)
+}
+
+// MetricSet contains the preregistered document retrieval metrics.
+type MetricSet struct {
+	RecallAt5      float64
+	RecallAt10     float64
+	RecallAt20     float64
+	NDCGAt10       float64
+	MRR            float64
+	CriticalMisses int
+}
+
+// TrialReport contains one complete pass over all benchmark queries.
+type TrialReport struct {
+	Repetition int
+	Metrics    MetricSet
+	Usage      Usage
+}
+
+// MetricInterval is an empirical repeated-trial range and mean. It is not a
+// parametric confidence interval.
+type MetricInterval struct {
+	Min  float64
+	Mean float64
+	Max  float64
+}
+
+// AggregateReport summarizes repeated hosted or local trials.
+type AggregateReport struct {
+	RecallAt5      MetricInterval
+	RecallAt10     MetricInterval
+	RecallAt20     MetricInterval
+	NDCGAt10       MetricInterval
+	MRR            MetricInterval
+	CriticalMisses MetricInterval
+}
+
+// SystemReport contains all observations for one retrieval system.
+type SystemReport struct {
+	System    System
+	Trials    []TrialReport
+	Aggregate AggregateReport
+}
+
+// Report is attributable evaluation output for one corpus version.
+type Report struct {
+	CorpusID      string
+	CorpusVersion string
+	Repetitions   int
+	Systems       []SystemReport
+}
+
+// Evaluate executes every system over every query for the requested number of
+// repetitions and computes metrics from observed rankings.
+func Evaluate(ctx context.Context, corpus Corpus, systems []System, repetitions int, runner Runner) (Report, error) {
+	if err := validateCorpus(corpus); err != nil {
+		return Report{}, err
+	}
+	if len(systems) == 0 || repetitions < 1 || runner == nil {
+		return Report{}, errors.New("evaluation requires systems, positive repetitions, and a runner")
+	}
+	report := Report{CorpusID: corpus.ID, CorpusVersion: corpus.Version, Repetitions: repetitions}
+	seenSystems := make(map[string]bool, len(systems))
+	for _, system := range systems {
+		if system.ID == "" || system.RecipeFingerprint == "" || seenSystems[system.ID] {
+			return Report{}, errors.New("evaluation system IDs and recipe fingerprints must be non-empty and unique")
+		}
+		seenSystems[system.ID] = true
+		systemReport := SystemReport{System: system}
+		for repetition := range repetitions {
+			trial, err := runTrial(ctx, corpus, system, repetition, runner)
+			if err != nil {
+				return Report{}, fmt.Errorf("evaluate system %q repetition %d: %w", system.ID, repetition+1, err)
+			}
+			systemReport.Trials = append(systemReport.Trials, trial)
+		}
+		systemReport.Aggregate = aggregate(systemReport.Trials)
+		report.Systems = append(report.Systems, systemReport)
+	}
+	return report, nil
+}
+
+func runTrial(ctx context.Context, corpus Corpus, system System, repetition int, runner Runner) (TrialReport, error) {
+	trial := TrialReport{Repetition: repetition + 1}
+	for _, query := range corpus.Queries {
+		result, err := runner.Search(ctx, system, corpus, query)
+		if err != nil {
+			return TrialReport{}, fmt.Errorf("query %q: %w", query.ID, err)
+		}
+		if result.Usage.ProviderCalls < 0 || result.Usage.ProviderInputRunes < 0 || result.Usage.ProviderOutputUnits < 0 ||
+			result.Usage.EstimatedCostMicros < 0 || result.Usage.Latency < 0 {
+			return TrialReport{}, fmt.Errorf("query %q: provider usage cannot be negative", query.ID)
+		}
+		if err := validateRanking(corpus, result.DocumentIDs); err != nil {
+			return TrialReport{}, fmt.Errorf("query %q: %w", query.ID, err)
+		}
+		metrics := score(query.Judgments, result.DocumentIDs)
+		trial.Metrics.RecallAt5 += metrics.RecallAt5
+		trial.Metrics.RecallAt10 += metrics.RecallAt10
+		trial.Metrics.RecallAt20 += metrics.RecallAt20
+		trial.Metrics.NDCGAt10 += metrics.NDCGAt10
+		trial.Metrics.MRR += metrics.MRR
+		trial.Metrics.CriticalMisses += metrics.CriticalMisses
+		addUsage(&trial.Usage, result.Usage)
+	}
+	count := float64(len(corpus.Queries))
+	trial.Metrics.RecallAt5 /= count
+	trial.Metrics.RecallAt10 /= count
+	trial.Metrics.RecallAt20 /= count
+	trial.Metrics.NDCGAt10 /= count
+	trial.Metrics.MRR /= count
+	return trial, nil
+}
+
+func score(judgments []Judgment, ranking []string) MetricSet {
+	grades := make(map[string]int, len(judgments))
+	critical := make(map[string]bool)
+	relevant := 0
+	for _, judgment := range judgments {
+		grades[judgment.DocumentID] = judgment.Grade
+		if judgment.Grade > 0 {
+			relevant++
+			if judgment.Critical {
+				critical[judgment.DocumentID] = true
+			}
+		}
+	}
+	metrics := MetricSet{
+		RecallAt5: recallAt(ranking, grades, relevant, 5), RecallAt10: recallAt(ranking, grades, relevant, 10),
+		RecallAt20: recallAt(ranking, grades, relevant, 20), NDCGAt10: ndcgAt(ranking, grades, 10),
+	}
+	for index, documentID := range ranking {
+		if grades[documentID] > 0 {
+			metrics.MRR = 1 / float64(index+1)
+			break
+		}
+	}
+	for documentID := range critical {
+		index := slices.Index(ranking, documentID)
+		if index < 0 || index >= 20 {
+			metrics.CriticalMisses++
+		}
+	}
+	return metrics
+}
+
+func recallAt(ranking []string, grades map[string]int, relevant, cutoff int) float64 {
+	if relevant == 0 {
+		return 1
+	}
+	found := 0
+	for _, documentID := range ranking[:min(len(ranking), cutoff)] {
+		if grades[documentID] > 0 {
+			found++
+		}
+	}
+	return float64(found) / float64(relevant)
+}
+
+func ndcgAt(ranking []string, grades map[string]int, cutoff int) float64 {
+	dcg := 0.0
+	for index, documentID := range ranking[:min(len(ranking), cutoff)] {
+		dcg += discountedGain(grades[documentID], index)
+	}
+	idealGrades := make([]int, 0, len(grades))
+	for _, grade := range grades {
+		if grade > 0 {
+			idealGrades = append(idealGrades, grade)
+		}
+	}
+	slices.SortFunc(idealGrades, func(left, right int) int { return right - left })
+	idcg := 0.0
+	for index, grade := range idealGrades[:min(len(idealGrades), cutoff)] {
+		idcg += discountedGain(grade, index)
+	}
+	if idcg == 0 {
+		return 1
+	}
+	return dcg / idcg
+}
+
+func discountedGain(grade, zeroBasedRank int) float64 {
+	if grade <= 0 {
+		return 0
+	}
+	return (math.Pow(2, float64(grade)) - 1) / math.Log2(float64(zeroBasedRank)+2)
+}
+
+func aggregate(trials []TrialReport) AggregateReport {
+	return AggregateReport{
+		RecallAt5:      interval(trials, func(metric MetricSet) float64 { return metric.RecallAt5 }),
+		RecallAt10:     interval(trials, func(metric MetricSet) float64 { return metric.RecallAt10 }),
+		RecallAt20:     interval(trials, func(metric MetricSet) float64 { return metric.RecallAt20 }),
+		NDCGAt10:       interval(trials, func(metric MetricSet) float64 { return metric.NDCGAt10 }),
+		MRR:            interval(trials, func(metric MetricSet) float64 { return metric.MRR }),
+		CriticalMisses: interval(trials, func(metric MetricSet) float64 { return float64(metric.CriticalMisses) }),
+	}
+}
+
+func interval(trials []TrialReport, value func(MetricSet) float64) MetricInterval {
+	result := MetricInterval{Min: math.Inf(1), Max: math.Inf(-1)}
+	for _, trial := range trials {
+		observed := value(trial.Metrics)
+		result.Min = min(result.Min, observed)
+		result.Max = max(result.Max, observed)
+		result.Mean += observed
+	}
+	result.Mean /= float64(len(trials))
+	return result
+}
+
+func validateCorpus(corpus Corpus) error {
+	if corpus.ID == "" || corpus.Version == "" || len(corpus.Documents) == 0 || len(corpus.Queries) == 0 {
+		return errors.New("evaluation corpus ID, version, documents, and queries are required")
+	}
+	documents := make(map[string]bool, len(corpus.Documents))
+	for _, document := range corpus.Documents {
+		if document.ID == "" || document.Text == "" || documents[document.ID] {
+			return errors.New("evaluation document IDs and text must be non-empty and IDs unique")
+		}
+		documents[document.ID] = true
+	}
+	queries := make(map[string]bool, len(corpus.Queries))
+	for _, query := range corpus.Queries {
+		if query.ID == "" || query.Text == "" || len(query.Judgments) == 0 || queries[query.ID] {
+			return errors.New("evaluation query IDs, text, and judgments must be non-empty and IDs unique")
+		}
+		queries[query.ID] = true
+		judged := make(map[string]bool, len(query.Judgments))
+		relevant := 0
+		for _, judgment := range query.Judgments {
+			if !documents[judgment.DocumentID] || judgment.Grade < 0 || judged[judgment.DocumentID] {
+				return fmt.Errorf("evaluation query %q has an invalid judgment", query.ID)
+			}
+			judged[judgment.DocumentID] = true
+			if judgment.Grade > 0 {
+				relevant++
+			}
+		}
+		if relevant == 0 {
+			return fmt.Errorf("evaluation query %q has no relevant judgment", query.ID)
+		}
+	}
+	return nil
+}
+
+func validateRanking(corpus Corpus, ranking []string) error {
+	documents := make(map[string]bool, len(corpus.Documents))
+	for _, document := range corpus.Documents {
+		documents[document.ID] = true
+	}
+	seen := make(map[string]bool, len(ranking))
+	for _, documentID := range ranking {
+		if !documents[documentID] || seen[documentID] {
+			return errors.New("ranking contains an unknown or duplicate document ID")
+		}
+		seen[documentID] = true
+	}
+	return nil
+}
+
+func addUsage(total *Usage, observed Usage) {
+	total.ProviderCalls += observed.ProviderCalls
+	total.ProviderInputRunes += observed.ProviderInputRunes
+	total.ProviderOutputUnits += observed.ProviderOutputUnits
+	total.EstimatedCostMicros += observed.EstimatedCostMicros
+	total.Latency += observed.Latency
+}

--- a/document/embedding/eval/eval_test.go
+++ b/document/embedding/eval/eval_test.go
@@ -1,0 +1,57 @@
+package eval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	embeddingeval "go.kenn.io/docbank/document/embedding/eval"
+)
+
+func TestEvaluateReportsRetrievalQualityAndProviderUsage(t *testing.T) {
+	corpus := embeddingeval.Corpus{
+		ID: "synthetic-documents", Version: "1",
+		Documents: []embeddingeval.Document{
+			{ID: "revenue", Text: "Synthetic quarterly revenue increased."},
+			{ID: "risk", Text: "Synthetic supply risk disclosure."},
+			{ID: "other", Text: "Unrelated synthetic material."},
+		},
+		Queries: []embeddingeval.Query{
+			{ID: "q-revenue", Text: "sales growth", Judgments: []embeddingeval.Judgment{{DocumentID: "revenue", Grade: 3, Critical: true}}},
+			{ID: "q-risk", Text: "supply problem", Judgments: []embeddingeval.Judgment{{DocumentID: "risk", Grade: 2}}},
+		},
+	}
+	runner := staticRunner{rankings: map[string][]string{
+		"q-revenue": {"other", "revenue", "risk"},
+		"q-risk":    {"risk", "other", "revenue"},
+	}}
+	report, err := embeddingeval.Evaluate(context.Background(), corpus, []embeddingeval.System{{
+		ID: "raw", RecipeFingerprint: "recipe-fingerprint", VectorSpaceFingerprint: "space-fingerprint",
+	}}, 2, runner)
+	require.NoError(t, err)
+	require.Len(t, report.Systems, 1)
+	require.Len(t, report.Systems[0].Trials, 2)
+	assert.InDelta(t, 0.75, report.Systems[0].Trials[0].Metrics.MRR, 0.0001)
+	assert.InDelta(t, 1.0, report.Systems[0].Trials[0].Metrics.RecallAt5, 0.0001)
+	assert.Zero(t, report.Systems[0].Trials[0].Metrics.CriticalMisses)
+	assert.Equal(t, 2, report.Systems[0].Trials[0].Usage.ProviderCalls)
+	assert.Equal(t, 22, report.Systems[0].Trials[0].Usage.ProviderInputRunes)
+	assert.Equal(t, 4*time.Millisecond, report.Systems[0].Trials[0].Usage.Latency)
+	assert.InDelta(t, report.Systems[0].Aggregate.MRR.Min, report.Systems[0].Aggregate.MRR.Max, 0.0001)
+}
+
+type staticRunner struct {
+	rankings map[string][]string
+}
+
+func (runner staticRunner) Search(_ context.Context, _ embeddingeval.System, _ embeddingeval.Corpus, query embeddingeval.Query) (embeddingeval.SearchResult, error) {
+	return embeddingeval.SearchResult{
+		DocumentIDs: runner.rankings[query.ID],
+		Usage: embeddingeval.Usage{
+			ProviderCalls: 1, ProviderInputRunes: 11, ProviderOutputUnits: 3,
+			EstimatedCostMicros: 7, Latency: 2 * time.Millisecond,
+		},
+	}, nil
+}

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -30,10 +30,11 @@ type EmbeddingInput struct {
 }
 
 type embeddingInputIdentity struct {
-	Ordinal  int                `json:"ordinal"`
-	Kind     RepresentationKind `json:"kind"`
-	Checksum string             `json:"checksum"`
-	Refs     []SourceRef        `json:"refs"`
+	Ordinal   int                `json:"ordinal"`
+	Kind      RepresentationKind `json:"kind"`
+	Checksum  string             `json:"checksum"`
+	Refs      []SourceRef        `json:"refs"`
+	Truncated bool               `json:"truncated"`
 }
 
 // EmbeddingPlan is an immutable set of inputs for one complete normalized
@@ -142,7 +143,8 @@ func makeInput(ordinal int, kind RepresentationKind, text string, refs []SourceR
 		Checksum: fingerprint([]byte(text)), Truncated: truncated,
 	}
 	keyBytes, err := json.Marshal(embeddingInputIdentity{
-		Ordinal: input.Ordinal, Kind: input.Kind, Checksum: input.Checksum, Refs: input.SourceRefs,
+		Ordinal: input.Ordinal, Kind: input.Kind, Checksum: input.Checksum,
+		Refs: input.SourceRefs, Truncated: input.Truncated,
 	})
 	if err != nil {
 		return EmbeddingInput{}, fmt.Errorf("encode embedding input identity: %w", err)

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -132,7 +132,7 @@ func rawInput(ordinal int, normalized document.NormalizedDocument, chunk documen
 	}
 	return makeInput(
 		ordinal, RepresentationKindRaw, text, []SourceRef{sourceRef(chunk)},
-		chunk.Truncated || contextTruncated || headingTruncated || truncated,
+		normalized.Truncated || chunk.Truncated || contextTruncated || headingTruncated || truncated,
 	)
 }
 

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -117,8 +117,10 @@ func BuildEmbeddingPlan(normalized document.NormalizedDocument, context Document
 }
 
 func rawInput(ordinal int, normalized document.NormalizedDocument, chunk document.Chunk, context DocumentContext, maxRunes, maxHeadingRunes int) (EmbeddingInput, error) {
-	contextPrefix := formatContext(context)
 	sourcePrefix := "Source: " + formatLocator(normalized, chunk.Spans) + "\nContent:\n"
+	contextPrefix, contextTruncated := boundedContext(
+		context, maxRunes-utf8.RuneCountInString(sourcePrefix)-1,
+	)
 	heading, headingTruncated := boundedHeadingContext(
 		chunk.HeadingPath, maxHeadingRunes,
 		maxRunes-utf8.RuneCountInString(contextPrefix)-utf8.RuneCountInString(sourcePrefix)-1,
@@ -128,16 +130,23 @@ func rawInput(ordinal int, normalized document.NormalizedDocument, chunk documen
 	if err != nil {
 		return EmbeddingInput{}, fmt.Errorf("format normalized chunk %q: %w", chunk.Key, err)
 	}
-	return makeInput(ordinal, RepresentationKindRaw, text, []SourceRef{sourceRef(chunk)}, chunk.Truncated || headingTruncated || truncated)
+	return makeInput(
+		ordinal, RepresentationKindRaw, text, []SourceRef{sourceRef(chunk)},
+		chunk.Truncated || contextTruncated || headingTruncated || truncated,
+	)
 }
 
 func distilledInput(ordinal int, section DerivedSection, context DocumentContext, maxRunes int) (EmbeddingInput, error) {
-	prefix := formatContext(context) + "Source: " + formatSourceRefs(section.SourceRefs) + "\nDerived summary (verify against source):\n"
+	sourcePrefix := "Source: " + formatSourceRefs(section.SourceRefs) + "\nDerived summary (verify against source):\n"
+	contextPrefix, contextTruncated := boundedContext(
+		context, maxRunes-utf8.RuneCountInString(sourcePrefix)-1,
+	)
+	prefix := contextPrefix + sourcePrefix
 	text, truncated, err := boundedInput(prefix, section.Text, maxRunes)
 	if err != nil {
 		return EmbeddingInput{}, fmt.Errorf("format distilled section %q: %w", section.Key, err)
 	}
-	return makeInput(ordinal, RepresentationKindDistilled, text, section.SourceRefs, truncated)
+	return makeInput(ordinal, RepresentationKindDistilled, text, section.SourceRefs, contextTruncated || truncated)
 }
 
 func makeInput(ordinal int, kind RepresentationKind, text string, refs []SourceRef, truncated bool) (EmbeddingInput, error) {
@@ -169,6 +178,41 @@ func formatContext(context DocumentContext) string {
 		builder.WriteByte('\n')
 	}
 	return builder.String()
+}
+
+func boundedContext(context DocumentContext, availableRunes int) (string, bool) {
+	formatted := formatContext(context)
+	if utf8.RuneCountInString(formatted) <= availableRunes {
+		return formatted, false
+	}
+	if availableRunes < 1 {
+		return "", formatted != ""
+	}
+
+	var builder strings.Builder
+	usedRunes := 0
+	truncated := false
+	for _, field := range [...]struct{ label, value string }{
+		{label: "Filename: ", value: context.Filename},
+		{label: "Title: ", value: context.Title},
+	} {
+		if field.value == "" {
+			continue
+		}
+		remaining := availableRunes - usedRunes
+		valueLimit := remaining - utf8.RuneCountInString(field.label) - 1
+		if valueLimit < 1 {
+			truncated = true
+			continue
+		}
+		value := truncateRunes(field.value, valueLimit)
+		builder.WriteString(field.label)
+		builder.WriteString(value)
+		builder.WriteByte('\n')
+		usedRunes += utf8.RuneCountInString(field.label) + utf8.RuneCountInString(value) + 1
+		truncated = truncated || value != field.value
+	}
+	return builder.String(), truncated
 }
 
 func boundedHeadingContext(path []string, maxHeadingRunes, availableRunes int) (string, bool) {

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -59,7 +59,10 @@ func BuildEmbeddingPlan(normalized document.NormalizedDocument, context Document
 	if !recipe.valid() {
 		return EmbeddingPlan{}, errors.New("embedding recipe is invalid; use NewRecipe")
 	}
-	context = normalizeContext(context, recipe.values)
+	context, err := normalizeContext(context, recipe.values)
+	if err != nil {
+		return EmbeddingPlan{}, err
+	}
 	contextFingerprint, err := digestJSON(context)
 	if err != nil {
 		return EmbeddingPlan{}, err

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -245,21 +245,11 @@ func embeddingPlanFingerprint(plan EmbeddingPlan) (string, error) {
 }
 
 func validateNormalizedDocument(normalized document.NormalizedDocument) error {
-	if normalized.Checksum == "" || normalized.PolicyVersion < 1 || len(normalized.Chunks) == 0 {
-		return errors.New("normalized document is incomplete or has no chunks")
+	if err := document.ValidateNormalizedDocument(normalized); err != nil {
+		return fmt.Errorf("validate normalized document: %w", err)
 	}
-	keys := make(map[string]bool, len(normalized.Chunks))
-	for index, chunk := range normalized.Chunks {
-		if chunk.Ordinal != index || chunk.Key == "" || chunk.Checksum == "" || chunk.Text == "" || !utf8.ValidString(chunk.Text) ||
-			chunk.CharCount != utf8.RuneCountInString(chunk.Text) || len(chunk.Spans) == 0 || keys[chunk.Key] {
-			return fmt.Errorf("normalized document chunk %d is invalid", index)
-		}
-		keys[chunk.Key] = true
-		for _, span := range chunk.Spans {
-			if span.UnitIndex < 0 || span.UnitIndex >= len(normalized.Units) || span.CharStart < 0 || span.CharEnd < span.CharStart || span.CharEnd > normalized.Units[span.UnitIndex].CharCount {
-				return fmt.Errorf("normalized document chunk %d has an invalid source span", index)
-			}
-		}
+	if len(normalized.Chunks) == 0 {
+		return errors.New("normalized document has no chunks")
 	}
 	return nil
 }

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -59,11 +59,11 @@ func BuildEmbeddingPlan(normalized document.NormalizedDocument, context Document
 	if !recipe.valid() {
 		return EmbeddingPlan{}, errors.New("embedding recipe is invalid; use NewRecipe")
 	}
-	context, err := normalizeContext(context, recipe.values)
+	context, contextTruncated, err := normalizeContext(context, recipe.values)
 	if err != nil {
 		return EmbeddingPlan{}, err
 	}
-	contextFingerprint, err := digestJSON(context)
+	contextFingerprint, err := fingerprintContext(context, contextTruncated)
 	if err != nil {
 		return EmbeddingPlan{}, err
 	}
@@ -87,7 +87,7 @@ func BuildEmbeddingPlan(normalized document.NormalizedDocument, context Document
 		for _, chunk := range normalized.Chunks {
 			input, err := rawInput(
 				len(plan.Inputs), normalized, chunk, context,
-				recipe.values.MaxInputRunes, recipe.values.MaxHeadingRunes,
+				contextTruncated, recipe.values.MaxInputRunes, recipe.values.MaxHeadingRunes,
 			)
 			if err != nil {
 				return EmbeddingPlan{}, err
@@ -98,7 +98,9 @@ func BuildEmbeddingPlan(normalized document.NormalizedDocument, context Document
 	if recipe.values.Mode == RepresentationDistilled || recipe.values.Mode == RepresentationCombined {
 		plan.DistillateFingerprint = distillate.Fingerprint
 		for _, section := range distillate.Sections {
-			input, err := distilledInput(len(plan.Inputs), section, context, recipe.values.MaxInputRunes)
+			input, err := distilledInput(
+				len(plan.Inputs), section, context, contextTruncated, recipe.values.MaxInputRunes,
+			)
 			if err != nil {
 				return EmbeddingPlan{}, err
 			}
@@ -116,9 +118,16 @@ func BuildEmbeddingPlan(normalized document.NormalizedDocument, context Document
 	return plan, nil
 }
 
-func rawInput(ordinal int, normalized document.NormalizedDocument, chunk document.Chunk, context DocumentContext, maxRunes, maxHeadingRunes int) (EmbeddingInput, error) {
+func rawInput(
+	ordinal int,
+	normalized document.NormalizedDocument,
+	chunk document.Chunk,
+	context DocumentContext,
+	contextTruncated bool,
+	maxRunes, maxHeadingRunes int,
+) (EmbeddingInput, error) {
 	sourcePrefix := "Source: " + formatLocator(normalized, chunk.Spans) + "\nContent:\n"
-	contextPrefix, contextTruncated := boundedContext(
+	contextPrefix, inputContextTruncated := boundedContext(
 		context, maxRunes-utf8.RuneCountInString(sourcePrefix)-1,
 	)
 	heading, headingTruncated := boundedHeadingContext(
@@ -132,13 +141,19 @@ func rawInput(ordinal int, normalized document.NormalizedDocument, chunk documen
 	}
 	return makeInput(
 		ordinal, RepresentationKindRaw, text, []SourceRef{sourceRef(chunk)},
-		normalized.Truncated || chunk.Truncated || contextTruncated || headingTruncated || truncated,
+		normalized.Truncated || chunk.Truncated || contextTruncated || inputContextTruncated || headingTruncated || truncated,
 	)
 }
 
-func distilledInput(ordinal int, section DerivedSection, context DocumentContext, maxRunes int) (EmbeddingInput, error) {
+func distilledInput(
+	ordinal int,
+	section DerivedSection,
+	context DocumentContext,
+	contextTruncated bool,
+	maxRunes int,
+) (EmbeddingInput, error) {
 	sourcePrefix := "Source: " + formatSourceRefs(section.SourceRefs) + "\nDerived summary (verify against source):\n"
-	contextPrefix, contextTruncated := boundedContext(
+	contextPrefix, inputContextTruncated := boundedContext(
 		context, maxRunes-utf8.RuneCountInString(sourcePrefix)-1,
 	)
 	prefix := contextPrefix + sourcePrefix
@@ -148,7 +163,7 @@ func distilledInput(ordinal int, section DerivedSection, context DocumentContext
 	}
 	return makeInput(
 		ordinal, RepresentationKindDistilled, text, section.SourceRefs,
-		section.Truncated || contextTruncated || truncated,
+		section.Truncated || contextTruncated || inputContextTruncated || truncated,
 	)
 }
 

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -146,7 +146,10 @@ func distilledInput(ordinal int, section DerivedSection, context DocumentContext
 	if err != nil {
 		return EmbeddingInput{}, fmt.Errorf("format distilled section %q: %w", section.Key, err)
 	}
-	return makeInput(ordinal, RepresentationKindDistilled, text, section.SourceRefs, contextTruncated || truncated)
+	return makeInput(
+		ordinal, RepresentationKindDistilled, text, section.SourceRefs,
+		section.Truncated || contextTruncated || truncated,
+	)
 }
 
 func makeInput(ordinal int, kind RepresentationKind, text string, refs []SourceRef, truncated bool) (EmbeddingInput, error) {
@@ -290,7 +293,7 @@ func validateDistillateForPlan(distillate Distillate, sourceChecksum, contextFin
 		}
 		keyBytes, err := json.Marshal(derivedSectionIdentity{
 			RequestFingerprint: distillate.RequestFingerprint, Ordinal: section.Ordinal,
-			Checksum: section.Checksum, Refs: section.SourceRefs,
+			Checksum: section.Checksum, Refs: section.SourceRefs, Truncated: section.Truncated,
 		})
 		if err != nil {
 			return fmt.Errorf("encode derived section identity: %w", err)

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -81,7 +81,10 @@ func BuildEmbeddingPlan(normalized document.NormalizedDocument, context Document
 	}
 	if recipe.values.Mode == RepresentationRaw || recipe.values.Mode == RepresentationCombined {
 		for _, chunk := range normalized.Chunks {
-			input, err := rawInput(len(plan.Inputs), normalized, chunk, context, recipe.values.MaxInputRunes)
+			input, err := rawInput(
+				len(plan.Inputs), normalized, chunk, context,
+				recipe.values.MaxInputRunes, recipe.values.MaxHeadingRunes,
+			)
 			if err != nil {
 				return EmbeddingPlan{}, err
 			}
@@ -109,17 +112,19 @@ func BuildEmbeddingPlan(normalized document.NormalizedDocument, context Document
 	return plan, nil
 }
 
-func rawInput(ordinal int, normalized document.NormalizedDocument, chunk document.Chunk, context DocumentContext, maxRunes int) (EmbeddingInput, error) {
-	prefix := formatContext(context)
-	if len(chunk.HeadingPath) > 0 {
-		prefix += "Heading: " + strings.Join(chunk.HeadingPath, " > ") + "\n"
-	}
-	prefix += "Source: " + formatLocator(normalized, chunk.Spans) + "\nContent:\n"
+func rawInput(ordinal int, normalized document.NormalizedDocument, chunk document.Chunk, context DocumentContext, maxRunes, maxHeadingRunes int) (EmbeddingInput, error) {
+	contextPrefix := formatContext(context)
+	sourcePrefix := "Source: " + formatLocator(normalized, chunk.Spans) + "\nContent:\n"
+	heading, headingTruncated := boundedHeadingContext(
+		chunk.HeadingPath, maxHeadingRunes,
+		maxRunes-utf8.RuneCountInString(contextPrefix)-utf8.RuneCountInString(sourcePrefix)-1,
+	)
+	prefix := contextPrefix + heading + sourcePrefix
 	text, truncated, err := boundedInput(prefix, chunk.Text, maxRunes)
 	if err != nil {
 		return EmbeddingInput{}, fmt.Errorf("format normalized chunk %q: %w", chunk.Key, err)
 	}
-	return makeInput(ordinal, RepresentationKindRaw, text, []SourceRef{sourceRef(chunk)}, chunk.Truncated || truncated)
+	return makeInput(ordinal, RepresentationKindRaw, text, []SourceRef{sourceRef(chunk)}, chunk.Truncated || headingTruncated || truncated)
 }
 
 func distilledInput(ordinal int, section DerivedSection, context DocumentContext, maxRunes int) (EmbeddingInput, error) {
@@ -159,6 +164,22 @@ func formatContext(context DocumentContext) string {
 		builder.WriteByte('\n')
 	}
 	return builder.String()
+}
+
+func boundedHeadingContext(path []string, maxHeadingRunes, availableRunes int) (string, bool) {
+	if len(path) == 0 {
+		return "", false
+	}
+	const headingPrefix = "Heading: "
+	const headingSuffix = "\n"
+	overhead := utf8.RuneCountInString(headingPrefix + headingSuffix)
+	textLimit := min(maxHeadingRunes, availableRunes-overhead)
+	if textLimit < 1 {
+		return "", true
+	}
+	heading := strings.Join(path, " > ")
+	bounded := truncateRunes(heading, textLimit)
+	return headingPrefix + bounded + headingSuffix, bounded != heading
 }
 
 func formatLocator(normalized document.NormalizedDocument, spans []document.ChunkSpan) string {

--- a/document/embedding/plan.go
+++ b/document/embedding/plan.go
@@ -1,0 +1,265 @@
+package embedding
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+)
+
+// RepresentationKind identifies the source representation of an input.
+type RepresentationKind string
+
+const (
+	RepresentationKindRaw       RepresentationKind = "raw"
+	RepresentationKindDistilled RepresentationKind = "distilled"
+)
+
+// EmbeddingInput is one deterministic, bounded provider input.
+type EmbeddingInput struct {
+	Key        string             `json:"key"`
+	Ordinal    int                `json:"ordinal"`
+	Kind       RepresentationKind `json:"kind"`
+	Text       string             `json:"text"`
+	SourceRefs []SourceRef        `json:"source_refs"`
+	Checksum   string             `json:"checksum"`
+	Truncated  bool               `json:"truncated"`
+}
+
+type embeddingInputIdentity struct {
+	Ordinal  int                `json:"ordinal"`
+	Kind     RepresentationKind `json:"kind"`
+	Checksum string             `json:"checksum"`
+	Refs     []SourceRef        `json:"refs"`
+}
+
+// EmbeddingPlan is an immutable set of inputs for one complete normalized
+// document. Applications can claim these plan inputs independently without
+// changing their text or identity.
+type EmbeddingPlan struct {
+	RecipeFingerprint     string           `json:"recipe_fingerprint"`
+	SourceChecksum        string           `json:"source_checksum"`
+	ContextFingerprint    string           `json:"context_fingerprint"`
+	DistillateFingerprint string           `json:"distillate_fingerprint,omitempty"`
+	Inputs                []EmbeddingInput `json:"inputs"`
+	Fingerprint           string           `json:"fingerprint"`
+}
+
+// BuildEmbeddingPlan constructs all inputs for a complete normalized document.
+// Distilled and combined recipes require the exact validated distillate
+// prepared from the same document, recipe, and context.
+func BuildEmbeddingPlan(normalized document.NormalizedDocument, context DocumentContext, recipe Recipe, distillate *Distillate) (EmbeddingPlan, error) {
+	if err := validateNormalizedDocument(normalized); err != nil {
+		return EmbeddingPlan{}, err
+	}
+	if !recipe.valid() {
+		return EmbeddingPlan{}, errors.New("embedding recipe is invalid; use NewRecipe")
+	}
+	context = normalizeContext(context, recipe.values)
+	contextFingerprint, err := digestJSON(context)
+	if err != nil {
+		return EmbeddingPlan{}, err
+	}
+	if recipe.values.Mode == RepresentationRaw && distillate != nil {
+		return EmbeddingPlan{}, errors.New("raw embedding recipe does not accept a distillate")
+	}
+	if recipe.values.Mode != RepresentationRaw {
+		if distillate == nil {
+			return EmbeddingPlan{}, errors.New("distilled and combined embedding recipes require a distillate")
+		}
+		if err := validateDistillateForPlan(*distillate, normalized.Checksum, contextFingerprint, recipe); err != nil {
+			return EmbeddingPlan{}, err
+		}
+	}
+
+	plan := EmbeddingPlan{
+		RecipeFingerprint: recipe.digest, SourceChecksum: normalized.Checksum,
+		ContextFingerprint: contextFingerprint,
+	}
+	if recipe.values.Mode == RepresentationRaw || recipe.values.Mode == RepresentationCombined {
+		for _, chunk := range normalized.Chunks {
+			input, err := rawInput(len(plan.Inputs), normalized, chunk, context, recipe.values.MaxInputRunes)
+			if err != nil {
+				return EmbeddingPlan{}, err
+			}
+			plan.Inputs = append(plan.Inputs, input)
+		}
+	}
+	if recipe.values.Mode == RepresentationDistilled || recipe.values.Mode == RepresentationCombined {
+		plan.DistillateFingerprint = distillate.Fingerprint
+		for _, section := range distillate.Sections {
+			input, err := distilledInput(len(plan.Inputs), section, context, recipe.values.MaxInputRunes)
+			if err != nil {
+				return EmbeddingPlan{}, err
+			}
+			plan.Inputs = append(plan.Inputs, input)
+		}
+	}
+	if len(plan.Inputs) == 0 {
+		return EmbeddingPlan{}, errors.New("embedding plan has no eligible inputs")
+	}
+	fingerprint, err := embeddingPlanFingerprint(plan)
+	if err != nil {
+		return EmbeddingPlan{}, err
+	}
+	plan.Fingerprint = fingerprint
+	return plan, nil
+}
+
+func rawInput(ordinal int, normalized document.NormalizedDocument, chunk document.Chunk, context DocumentContext, maxRunes int) (EmbeddingInput, error) {
+	prefix := formatContext(context)
+	if len(chunk.HeadingPath) > 0 {
+		prefix += "Heading: " + strings.Join(chunk.HeadingPath, " > ") + "\n"
+	}
+	prefix += "Source: " + formatLocator(normalized, chunk.Spans) + "\nContent:\n"
+	text, truncated, err := boundedInput(prefix, chunk.Text, maxRunes)
+	if err != nil {
+		return EmbeddingInput{}, fmt.Errorf("format normalized chunk %q: %w", chunk.Key, err)
+	}
+	return makeInput(ordinal, RepresentationKindRaw, text, []SourceRef{sourceRef(chunk)}, chunk.Truncated || truncated)
+}
+
+func distilledInput(ordinal int, section DerivedSection, context DocumentContext, maxRunes int) (EmbeddingInput, error) {
+	prefix := formatContext(context) + "Source: " + formatSourceRefs(section.SourceRefs) + "\nDerived summary (verify against source):\n"
+	text, truncated, err := boundedInput(prefix, section.Text, maxRunes)
+	if err != nil {
+		return EmbeddingInput{}, fmt.Errorf("format distilled section %q: %w", section.Key, err)
+	}
+	return makeInput(ordinal, RepresentationKindDistilled, text, section.SourceRefs, truncated)
+}
+
+func makeInput(ordinal int, kind RepresentationKind, text string, refs []SourceRef, truncated bool) (EmbeddingInput, error) {
+	input := EmbeddingInput{
+		Ordinal: ordinal, Kind: kind, Text: text, SourceRefs: cloneSourceRefs(refs),
+		Checksum: fingerprint([]byte(text)), Truncated: truncated,
+	}
+	keyBytes, err := json.Marshal(embeddingInputIdentity{
+		Ordinal: input.Ordinal, Kind: input.Kind, Checksum: input.Checksum, Refs: input.SourceRefs,
+	})
+	if err != nil {
+		return EmbeddingInput{}, fmt.Errorf("encode embedding input identity: %w", err)
+	}
+	input.Key = fingerprint(keyBytes)
+	return input, nil
+}
+
+func formatContext(context DocumentContext) string {
+	var builder strings.Builder
+	if context.Filename != "" {
+		builder.WriteString("Filename: ")
+		builder.WriteString(context.Filename)
+		builder.WriteByte('\n')
+	}
+	if context.Title != "" {
+		builder.WriteString("Title: ")
+		builder.WriteString(context.Title)
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}
+
+func formatLocator(normalized document.NormalizedDocument, spans []document.ChunkSpan) string {
+	if len(spans) == 0 {
+		return "document"
+	}
+	first := spans[0].UnitIndex
+	last := spans[len(spans)-1].UnitIndex
+	kind := normalized.UnitKind
+	if kind == "" {
+		kind = "unit"
+	}
+	if first == last {
+		return fmt.Sprintf("%s %d", kind, first+1)
+	}
+	return fmt.Sprintf("%ss %d-%d", kind, first+1, last+1)
+}
+
+func formatSourceRefs(refs []SourceRef) string {
+	if len(refs) == 0 || len(refs[0].UnitSpans) == 0 {
+		return "document"
+	}
+	first := refs[0].UnitSpans[0].UnitIndex + 1
+	lastRef := refs[len(refs)-1]
+	last := lastRef.UnitSpans[len(lastRef.UnitSpans)-1].UnitIndex + 1
+	if first == last {
+		return fmt.Sprintf("unit %d", first)
+	}
+	return fmt.Sprintf("units %d-%d", first, last)
+}
+
+func boundedInput(prefix, body string, limit int) (string, bool, error) {
+	prefixRunes := utf8.RuneCountInString(prefix)
+	if prefixRunes >= limit {
+		return "", false, errors.New("embedding input context consumes the configured rune limit")
+	}
+	bodyLimit := limit - prefixRunes
+	truncated := utf8.RuneCountInString(body) > bodyLimit
+	return prefix + truncateRunes(body, bodyLimit), truncated, nil
+}
+
+func validateDistillateForPlan(distillate Distillate, sourceChecksum, contextFingerprint string, recipe Recipe) error {
+	if distillate.SourceChecksum != sourceChecksum || distillate.ContextFingerprint != contextFingerprint || distillate.RecipeFingerprint != recipe.digest {
+		return errors.New("distillate identity differs from embedding plan inputs")
+	}
+	config := recipe.values.Distillation
+	if config == nil || distillate.Provider != config.Provider || distillate.Model != config.Model || distillate.ModelRevision != config.ModelRevision {
+		return errors.New("distillate target differs from embedding recipe")
+	}
+	if distillate.Fingerprint == "" || len(distillate.Sections) == 0 {
+		return errors.New("distillate is incomplete")
+	}
+	for index, section := range distillate.Sections {
+		if section.Ordinal != index || section.Key == "" || section.Text == "" || section.Checksum != fingerprint([]byte(section.Text)) {
+			return fmt.Errorf("distillate section %d is invalid", index)
+		}
+		if err := validateSourceRefs(section.SourceRefs); err != nil {
+			return fmt.Errorf("distillate section %d: %w", index, err)
+		}
+		keyBytes, err := json.Marshal(derivedSectionIdentity{
+			RequestFingerprint: distillate.RequestFingerprint, Ordinal: section.Ordinal,
+			Checksum: section.Checksum, Refs: section.SourceRefs,
+		})
+		if err != nil {
+			return fmt.Errorf("encode derived section identity: %w", err)
+		}
+		if section.Key != fingerprint(keyBytes) {
+			return fmt.Errorf("distillate section %d key is invalid", index)
+		}
+	}
+	expected, err := distillateFingerprint(distillate)
+	if err != nil {
+		return err
+	}
+	if expected != distillate.Fingerprint {
+		return errors.New("distillate fingerprint is invalid")
+	}
+	return nil
+}
+
+func embeddingPlanFingerprint(plan EmbeddingPlan) (string, error) {
+	plan.Fingerprint = ""
+	return digestJSON(plan)
+}
+
+func validateNormalizedDocument(normalized document.NormalizedDocument) error {
+	if normalized.Checksum == "" || normalized.PolicyVersion < 1 || len(normalized.Chunks) == 0 {
+		return errors.New("normalized document is incomplete or has no chunks")
+	}
+	keys := make(map[string]bool, len(normalized.Chunks))
+	for index, chunk := range normalized.Chunks {
+		if chunk.Ordinal != index || chunk.Key == "" || chunk.Checksum == "" || chunk.Text == "" || !utf8.ValidString(chunk.Text) ||
+			chunk.CharCount != utf8.RuneCountInString(chunk.Text) || len(chunk.Spans) == 0 || keys[chunk.Key] {
+			return fmt.Errorf("normalized document chunk %d is invalid", index)
+		}
+		keys[chunk.Key] = true
+		for _, span := range chunk.Spans {
+			if span.UnitIndex < 0 || span.UnitIndex >= len(normalized.Units) || span.CharStart < 0 || span.CharEnd < span.CharStart || span.CharEnd > normalized.Units[span.UnitIndex].CharCount {
+				return fmt.Errorf("normalized document chunk %d has an invalid source span", index)
+			}
+		}
+	}
+	return nil
+}

--- a/document/embedding/recipe.go
+++ b/document/embedding/recipe.go
@@ -144,6 +144,15 @@ func normalizeDistillation(mode RepresentationMode, config *DistillationConfig) 
 	if values.Provider == "" || values.Model == "" || values.ModelRevision == "" || values.PromptTemplateVersion < 1 {
 		return DistillationConfig{}, false, errors.New("distillation provider, model, revision, and prompt template version are required")
 	}
+	for _, identity := range [...]struct{ name, value string }{
+		{name: "distillation provider", value: values.Provider},
+		{name: "distillation model", value: values.Model},
+		{name: "distillation model revision", value: values.ModelRevision},
+	} {
+		if err := validateIdentityText(identity.name, identity.value); err != nil {
+			return DistillationConfig{}, false, err
+		}
+	}
 	if values.MaxPartitionRunes < 1 || values.MaxSections < 1 || values.MaxSectionRunes < 1 {
 		return DistillationConfig{}, false, errors.New("distillation bounds must be positive")
 	}

--- a/document/embedding/recipe.go
+++ b/document/embedding/recipe.go
@@ -1,0 +1,176 @@
+package embedding
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	recipeVersion      = 1
+	inputFormatVersion = 1
+
+	defaultMaxInputRunes     = 8_000
+	defaultMaxFilenameRunes  = 256
+	defaultMaxTitleRunes     = 512
+	defaultMaxPartitionRunes = 16_000
+	defaultMaxSections       = 128
+	defaultMaxSectionRunes   = 4_000
+)
+
+// RepresentationMode selects which document representations enter an
+// embedding plan.
+type RepresentationMode string
+
+const (
+	// RepresentationRaw embeds normalized source chunks without distillation.
+	RepresentationRaw RepresentationMode = "raw"
+	// RepresentationDistilled embeds only validated derived sections.
+	RepresentationDistilled RepresentationMode = "distilled"
+	// RepresentationCombined embeds both normalized chunks and derived sections.
+	RepresentationCombined RepresentationMode = "combined"
+)
+
+// DistillationConfig fixes the behavior and bounds of an optional
+// pre-embedding distillation step. Endpoint and credentials are deliberately
+// excluded; endpoint-sensitive consent uses EgressIdentity.
+type DistillationConfig struct {
+	Provider              string `json:"provider"`
+	Model                 string `json:"model"`
+	ModelRevision         string `json:"model_revision"`
+	PromptTemplateVersion int    `json:"prompt_template_version"`
+	MaxPartitionRunes     int    `json:"max_partition_runes"`
+	MaxSections           int    `json:"max_sections"`
+	MaxSectionRunes       int    `json:"max_section_runes"`
+}
+
+// RecipeConfig configures deterministic embedding-plan construction.
+type RecipeConfig struct {
+	Mode             RepresentationMode
+	MaxInputRunes    int
+	MaxFilenameRunes int
+	MaxTitleRunes    int
+	Distillation     *DistillationConfig
+}
+
+// RecipeValues is a read-only copy of every value that defines plan output.
+type RecipeValues struct {
+	Version            int                 `json:"version"`
+	InputFormatVersion int                 `json:"input_format_version"`
+	Mode               RepresentationMode  `json:"mode"`
+	MaxInputRunes      int                 `json:"max_input_runes"`
+	MaxFilenameRunes   int                 `json:"max_filename_runes"`
+	MaxTitleRunes      int                 `json:"max_title_runes"`
+	Distillation       *DistillationConfig `json:"distillation,omitempty"`
+}
+
+// Recipe is an immutable document embedding recipe.
+type Recipe struct {
+	values RecipeValues
+	digest string
+}
+
+// NewRecipe validates and constructs a recipe. Zero bounds select conservative
+// defaults. Raw is the default mode and does not permit distillation settings.
+func NewRecipe(config RecipeConfig) (Recipe, error) {
+	if config.Mode == "" {
+		config.Mode = RepresentationRaw
+	}
+	if config.MaxInputRunes == 0 {
+		config.MaxInputRunes = defaultMaxInputRunes
+	}
+	if config.MaxFilenameRunes == 0 {
+		config.MaxFilenameRunes = defaultMaxFilenameRunes
+	}
+	if config.MaxTitleRunes == 0 {
+		config.MaxTitleRunes = defaultMaxTitleRunes
+	}
+	if config.MaxInputRunes < 1 || config.MaxFilenameRunes < 1 || config.MaxTitleRunes < 1 {
+		return Recipe{}, errors.New("embedding recipe bounds must be positive")
+	}
+	if config.Mode != RepresentationRaw && config.Mode != RepresentationDistilled && config.Mode != RepresentationCombined {
+		return Recipe{}, fmt.Errorf("unsupported embedding representation mode %q", config.Mode)
+	}
+
+	distillation, hasDistillation, err := normalizeDistillation(config.Mode, config.Distillation)
+	if err != nil {
+		return Recipe{}, err
+	}
+	var distillationValues *DistillationConfig
+	if hasDistillation {
+		distillationValues = &distillation
+	}
+	values := RecipeValues{
+		Version: recipeVersion, InputFormatVersion: inputFormatVersion, Mode: config.Mode,
+		MaxInputRunes: config.MaxInputRunes, MaxFilenameRunes: config.MaxFilenameRunes,
+		MaxTitleRunes: config.MaxTitleRunes, Distillation: distillationValues,
+	}
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("encode embedding recipe: %w", err)
+	}
+	return Recipe{values: values, digest: fingerprint(encoded)}, nil
+}
+
+func normalizeDistillation(mode RepresentationMode, config *DistillationConfig) (DistillationConfig, bool, error) {
+	if mode == RepresentationRaw {
+		if config != nil {
+			return DistillationConfig{}, false, errors.New("raw embedding recipe cannot configure distillation")
+		}
+		return DistillationConfig{}, false, nil
+	}
+	if config == nil {
+		return DistillationConfig{}, false, errors.New("distilled and combined embedding recipes require distillation settings")
+	}
+	values := *config
+	if values.MaxPartitionRunes == 0 {
+		values.MaxPartitionRunes = defaultMaxPartitionRunes
+	}
+	if values.MaxSections == 0 {
+		values.MaxSections = defaultMaxSections
+	}
+	if values.MaxSectionRunes == 0 {
+		values.MaxSectionRunes = defaultMaxSectionRunes
+	}
+	if values.Provider == "" || values.Model == "" || values.ModelRevision == "" || values.PromptTemplateVersion < 1 {
+		return DistillationConfig{}, false, errors.New("distillation provider, model, revision, and prompt template version are required")
+	}
+	if values.MaxPartitionRunes < 1 || values.MaxSections < 1 || values.MaxSectionRunes < 1 {
+		return DistillationConfig{}, false, errors.New("distillation bounds must be positive")
+	}
+	return values, true, nil
+}
+
+// Values returns a deep copy of every effective recipe value.
+func (r Recipe) Values() RecipeValues {
+	values := r.values
+	if r.values.Distillation != nil {
+		distillation := *r.values.Distillation
+		values.Distillation = &distillation
+	}
+	return values
+}
+
+// CanonicalJSON returns the canonical recipe identity.
+func (r Recipe) CanonicalJSON() ([]byte, error) {
+	if !r.valid() {
+		return nil, errors.New("embedding recipe is invalid; use NewRecipe")
+	}
+	encoded, err := json.Marshal(r.values)
+	if err != nil {
+		return nil, fmt.Errorf("encode embedding recipe: %w", err)
+	}
+	return encoded, nil
+}
+
+// Fingerprint returns lowercase SHA-256 over CanonicalJSON.
+func (r Recipe) Fingerprint() string { return r.digest }
+
+func (r Recipe) valid() bool { return r.digest != "" }
+
+func fingerprint(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}

--- a/document/embedding/recipe.go
+++ b/document/embedding/recipe.go
@@ -15,6 +15,7 @@ const (
 	defaultMaxInputRunes     = 8_000
 	defaultMaxFilenameRunes  = 256
 	defaultMaxTitleRunes     = 512
+	defaultMaxHeadingRunes   = 512
 	defaultMaxPartitionRunes = 16_000
 	defaultMaxSections       = 128
 	defaultMaxSectionRunes   = 4_000
@@ -52,6 +53,7 @@ type RecipeConfig struct {
 	MaxInputRunes    int
 	MaxFilenameRunes int
 	MaxTitleRunes    int
+	MaxHeadingRunes  int
 	Distillation     *DistillationConfig
 }
 
@@ -63,6 +65,7 @@ type RecipeValues struct {
 	MaxInputRunes      int                 `json:"max_input_runes"`
 	MaxFilenameRunes   int                 `json:"max_filename_runes"`
 	MaxTitleRunes      int                 `json:"max_title_runes"`
+	MaxHeadingRunes    int                 `json:"max_heading_runes"`
 	Distillation       *DistillationConfig `json:"distillation,omitempty"`
 }
 
@@ -87,7 +90,10 @@ func NewRecipe(config RecipeConfig) (Recipe, error) {
 	if config.MaxTitleRunes == 0 {
 		config.MaxTitleRunes = defaultMaxTitleRunes
 	}
-	if config.MaxInputRunes < 1 || config.MaxFilenameRunes < 1 || config.MaxTitleRunes < 1 {
+	if config.MaxHeadingRunes == 0 {
+		config.MaxHeadingRunes = defaultMaxHeadingRunes
+	}
+	if config.MaxInputRunes < 1 || config.MaxFilenameRunes < 1 || config.MaxTitleRunes < 1 || config.MaxHeadingRunes < 1 {
 		return Recipe{}, errors.New("embedding recipe bounds must be positive")
 	}
 	if config.Mode != RepresentationRaw && config.Mode != RepresentationDistilled && config.Mode != RepresentationCombined {
@@ -105,7 +111,8 @@ func NewRecipe(config RecipeConfig) (Recipe, error) {
 	values := RecipeValues{
 		Version: recipeVersion, InputFormatVersion: inputFormatVersion, Mode: config.Mode,
 		MaxInputRunes: config.MaxInputRunes, MaxFilenameRunes: config.MaxFilenameRunes,
-		MaxTitleRunes: config.MaxTitleRunes, Distillation: distillationValues,
+		MaxTitleRunes: config.MaxTitleRunes, MaxHeadingRunes: config.MaxHeadingRunes,
+		Distillation: distillationValues,
 	}
 	encoded, err := json.Marshal(values)
 	if err != nil {

--- a/document/embedding/retrieval.go
+++ b/document/embedding/retrieval.go
@@ -1,0 +1,256 @@
+package embedding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+)
+
+const (
+	// DefaultCandidateLimit is the shared lexical, semantic, and hybrid default.
+	DefaultCandidateLimit = 100
+	// MaxCandidateLimit bounds final scoped candidate collection.
+	MaxCandidateLimit = 1_000
+	// DefaultReciprocalRankConstant is the shared RRF smoothing constant.
+	DefaultReciprocalRankConstant = 60
+)
+
+// SearchMode selects query behavior. Auto is deliberately lexical so omitted
+// mode never sends query plaintext to an embedding provider.
+type SearchMode string
+
+const (
+	SearchModeAuto     SearchMode = "auto"
+	SearchModeLexical  SearchMode = "lexical"
+	SearchModeSemantic SearchMode = "semantic"
+	SearchModeHybrid   SearchMode = "hybrid"
+)
+
+// SearchOptions contains shared search controls.
+type SearchOptions struct {
+	Mode           SearchMode
+	CandidateLimit int
+}
+
+// NormalizeSearchOptions applies shared defaults and validates public bounds.
+func NormalizeSearchOptions(options SearchOptions) (SearchOptions, error) {
+	if options.Mode == "" || options.Mode == SearchModeAuto {
+		options.Mode = SearchModeLexical
+	}
+	if options.Mode != SearchModeLexical && options.Mode != SearchModeSemantic && options.Mode != SearchModeHybrid {
+		return SearchOptions{}, fmt.Errorf("unsupported document search mode %q", options.Mode)
+	}
+	if options.CandidateLimit == 0 {
+		options.CandidateLimit = DefaultCandidateLimit
+	}
+	if options.CandidateLimit < 1 || options.CandidateLimit > MaxCandidateLimit {
+		return SearchOptions{}, fmt.Errorf("document search candidate limit must be between 1 and %d", MaxCandidateLimit)
+	}
+	return options, nil
+}
+
+// PageRequest requests one deterministic page of already-scoped candidates.
+// Scope must be applied by the source before its global vector cutoff.
+type PageRequest struct {
+	Cursor string
+	Limit  int
+}
+
+// Provenance is an opaque application-defined fact that must survive ranking
+// and hybrid fusion, such as a matching person or source occurrence.
+type Provenance struct {
+	Kind  string
+	Value string
+}
+
+// Candidate is one source-ranked search candidate.
+type Candidate struct {
+	Key        string
+	Score      float64
+	Provenance []Provenance
+}
+
+// CandidatePage is one stable page. Exhausted is authoritative; callers must
+// not infer exhaustion merely because a short page was returned.
+type CandidatePage struct {
+	Candidates []Candidate
+	NextCursor string
+	Exhausted  bool
+}
+
+// ScopedPageSource returns candidates after applying every requested scope
+// constraint. Implementations must provide stable ordering and cursors.
+type ScopedPageSource interface {
+	SearchPage(ctx context.Context, request PageRequest) (CandidatePage, error)
+}
+
+// RankedCandidate records a candidate's rank in one retrieval lane.
+type RankedCandidate struct {
+	Key        string
+	Rank       int
+	Score      float64
+	Provenance []Provenance
+}
+
+// ScopedCandidates is a bounded, scope-complete candidate set.
+type ScopedCandidates struct {
+	Candidates []RankedCandidate
+	Truncated  bool
+}
+
+// CollectScopedCandidates pages an already-scoped backend until it observes
+// candidateLimit+1 unique candidates or authoritative exhaustion. pageSize is
+// an independent backend bound and may be smaller than candidateLimit.
+func CollectScopedCandidates(ctx context.Context, source ScopedPageSource, candidateLimit, pageSize int) (ScopedCandidates, error) {
+	if source == nil {
+		return ScopedCandidates{}, errors.New("scoped candidate source is required")
+	}
+	if candidateLimit < 1 || candidateLimit > MaxCandidateLimit {
+		return ScopedCandidates{}, fmt.Errorf("candidate limit must be between 1 and %d", MaxCandidateLimit)
+	}
+	if pageSize < 1 || pageSize > MaxCandidateLimit {
+		return ScopedCandidates{}, fmt.Errorf("candidate page size must be between 1 and %d", MaxCandidateLimit)
+	}
+
+	wanted := candidateLimit + 1
+	cursor := ""
+	seen := make(map[string]bool, wanted)
+	collected := make([]RankedCandidate, 0, wanted)
+	for len(collected) < wanted {
+		requestLimit := min(pageSize, wanted-len(collected))
+		page, err := source.SearchPage(ctx, PageRequest{Cursor: cursor, Limit: requestLimit})
+		if err != nil {
+			return ScopedCandidates{}, err
+		}
+		if len(page.Candidates) > requestLimit {
+			return ScopedCandidates{}, errors.New("scoped candidate source exceeded requested page size")
+		}
+		if len(page.Candidates) == 0 && !page.Exhausted {
+			return ScopedCandidates{}, errors.New("non-exhausted candidate page returned no candidates")
+		}
+		for _, candidate := range page.Candidates {
+			if candidate.Key == "" {
+				return ScopedCandidates{}, errors.New("scoped candidate key is empty")
+			}
+			if seen[candidate.Key] {
+				return ScopedCandidates{}, fmt.Errorf("scoped candidate %q was returned more than once", candidate.Key)
+			}
+			seen[candidate.Key] = true
+			collected = append(collected, RankedCandidate{
+				Key: candidate.Key, Rank: len(collected) + 1, Score: candidate.Score,
+				Provenance: slices.Clone(candidate.Provenance),
+			})
+		}
+		if page.Exhausted {
+			break
+		}
+		if page.NextCursor == "" || page.NextCursor == cursor {
+			return ScopedCandidates{}, errors.New("non-exhausted candidate page did not advance its cursor")
+		}
+		cursor = page.NextCursor
+	}
+
+	result := ScopedCandidates{Candidates: collected, Truncated: len(collected) > candidateLimit}
+	if result.Truncated {
+		result.Candidates = result.Candidates[:candidateLimit]
+	}
+	return result, nil
+}
+
+// CandidateSignal preserves one lane's score and rank through hybrid fusion.
+type CandidateSignal struct {
+	Rank       int
+	Score      float64
+	Provenance []Provenance
+}
+
+// FusedCandidate is one deterministic reciprocal-rank-fused result.
+type FusedCandidate struct {
+	Key      string
+	Rank     int
+	Score    float64
+	Lexical  *CandidateSignal
+	Semantic *CandidateSignal
+}
+
+// FusionInput contains the fully scoped results from each retrieval lane.
+type FusionInput struct {
+	Lexical  ScopedCandidates
+	Semantic ScopedCandidates
+}
+
+// FusedCandidates contains bounded hybrid results and accurate upstream or
+// post-fusion overflow metadata.
+type FusedCandidates struct {
+	Candidates []FusedCandidate
+	Truncated  bool
+}
+
+// FuseReciprocalRank combines lexical and semantic candidates with
+// deterministic RRF ordering while preserving both source signals.
+func FuseReciprocalRank(input FusionInput, candidateLimit int) (FusedCandidates, error) {
+	if candidateLimit < 1 || candidateLimit > MaxCandidateLimit {
+		return FusedCandidates{}, fmt.Errorf("candidate limit must be between 1 and %d", MaxCandidateLimit)
+	}
+	byKey := make(map[string]*FusedCandidate, len(input.Lexical.Candidates)+len(input.Semantic.Candidates))
+	if err := addFusionLane(byKey, input.Lexical.Candidates, true); err != nil {
+		return FusedCandidates{}, fmt.Errorf("lexical candidates: %w", err)
+	}
+	if err := addFusionLane(byKey, input.Semantic.Candidates, false); err != nil {
+		return FusedCandidates{}, fmt.Errorf("semantic candidates: %w", err)
+	}
+	candidates := make([]FusedCandidate, 0, len(byKey))
+	for _, candidate := range byKey {
+		candidates = append(candidates, *candidate)
+	}
+	slices.SortFunc(candidates, func(left, right FusedCandidate) int {
+		switch {
+		case left.Score > right.Score:
+			return -1
+		case left.Score < right.Score:
+			return 1
+		case left.Key < right.Key:
+			return -1
+		case left.Key > right.Key:
+			return 1
+		default:
+			return 0
+		}
+	})
+	for index := range candidates {
+		candidates[index].Rank = index + 1
+	}
+	truncated := input.Lexical.Truncated || input.Semantic.Truncated || len(candidates) > candidateLimit
+	if len(candidates) > candidateLimit {
+		candidates = candidates[:candidateLimit]
+	}
+	return FusedCandidates{Candidates: candidates, Truncated: truncated}, nil
+}
+
+func addFusionLane(byKey map[string]*FusedCandidate, candidates []RankedCandidate, lexical bool) error {
+	seen := make(map[string]bool, len(candidates))
+	lastRank := 0
+	for _, source := range candidates {
+		if source.Key == "" || source.Rank <= lastRank || seen[source.Key] {
+			return errors.New("candidate keys must be unique with strictly increasing positive ranks")
+		}
+		seen[source.Key] = true
+		lastRank = source.Rank
+		candidate := byKey[source.Key]
+		if candidate == nil {
+			candidate = &FusedCandidate{Key: source.Key}
+			byKey[source.Key] = candidate
+		}
+		signal := &CandidateSignal{
+			Rank: source.Rank, Score: source.Score, Provenance: slices.Clone(source.Provenance),
+		}
+		candidate.Score += 1 / float64(DefaultReciprocalRankConstant+source.Rank)
+		if lexical {
+			candidate.Lexical = signal
+		} else {
+			candidate.Semantic = signal
+		}
+	}
+	return nil
+}

--- a/document/embedding/retrieval_test.go
+++ b/document/embedding/retrieval_test.go
@@ -1,0 +1,84 @@
+package embedding_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document/embedding"
+)
+
+func TestSearchDefaultsToLexicalWithSharedCandidateLimit(t *testing.T) {
+	options, err := embedding.NormalizeSearchOptions(embedding.SearchOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, embedding.SearchModeLexical, options.Mode)
+	assert.Equal(t, embedding.DefaultCandidateLimit, options.CandidateLimit)
+
+	options, err = embedding.NormalizeSearchOptions(embedding.SearchOptions{
+		Mode: embedding.SearchModeSemantic, CandidateLimit: 37,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 37, options.CandidateLimit)
+}
+
+func TestCollectScopedCandidatesUsesOverflowProbe(t *testing.T) {
+	source := &slicePageSource{candidates: []embedding.Candidate{
+		{Key: "in-scope-1", Score: 0.9}, {Key: "in-scope-2", Score: 0.8}, {Key: "in-scope-3", Score: 0.7},
+	}}
+	result, err := embedding.CollectScopedCandidates(context.Background(), source, 2, 1)
+	require.NoError(t, err)
+	assert.True(t, result.Truncated)
+	assert.Equal(t, []embedding.RankedCandidate{
+		{Key: "in-scope-1", Rank: 1, Score: 0.9}, {Key: "in-scope-2", Rank: 2, Score: 0.8},
+	}, result.Candidates)
+	assert.Equal(t, 3, source.calls)
+
+	exact := &slicePageSource{candidates: source.candidates[:2]}
+	result, err = embedding.CollectScopedCandidates(context.Background(), exact, 2, 1)
+	require.NoError(t, err)
+	assert.False(t, result.Truncated)
+	assert.Len(t, result.Candidates, 2)
+}
+
+func TestHybridFusionPreservesSignalsAndDetectsUnionOverflow(t *testing.T) {
+	result, err := embedding.FuseReciprocalRank(embedding.FusionInput{
+		Lexical: embedding.ScopedCandidates{Candidates: []embedding.RankedCandidate{
+			{Key: "shared", Rank: 1, Score: 11, Provenance: []embedding.Provenance{{Kind: "person", Value: "synthetic-person"}}},
+			{Key: "lexical", Rank: 2, Score: 7},
+		}},
+		Semantic: embedding.ScopedCandidates{Candidates: []embedding.RankedCandidate{
+			{Key: "shared", Rank: 1, Score: 0.91}, {Key: "semantic", Rank: 2, Score: 0.83},
+		}},
+	}, 2)
+	require.NoError(t, err)
+	require.Len(t, result.Candidates, 2)
+	assert.True(t, result.Truncated)
+	assert.Equal(t, "shared", result.Candidates[0].Key)
+	assert.NotNil(t, result.Candidates[0].Lexical)
+	assert.NotNil(t, result.Candidates[0].Semantic)
+	assert.Equal(t, []embedding.Provenance{{Kind: "person", Value: "synthetic-person"}}, result.Candidates[0].Lexical.Provenance)
+}
+
+type slicePageSource struct {
+	candidates []embedding.Candidate
+	calls      int
+}
+
+func (source *slicePageSource) SearchPage(_ context.Context, request embedding.PageRequest) (embedding.CandidatePage, error) {
+	source.calls++
+	start := 0
+	if request.Cursor != "" {
+		parsed, err := strconv.Atoi(request.Cursor)
+		if err != nil {
+			return embedding.CandidatePage{}, fmt.Errorf("parse test cursor: %w", err)
+		}
+		start = parsed
+	}
+	end := min(start+request.Limit, len(source.candidates))
+	return embedding.CandidatePage{
+		Candidates: source.candidates[start:end], NextCursor: strconv.Itoa(end), Exhausted: end == len(source.candidates),
+	}, nil
+}

--- a/document/embedding/text.go
+++ b/document/embedding/text.go
@@ -1,0 +1,32 @@
+package embedding
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+func validateUTF8Text(name, value string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s contains invalid UTF-8", name)
+	}
+	return nil
+}
+
+func validateIdentityText(name, value string) error {
+	if err := validateUTF8Text(name, value); err != nil {
+		return err
+	}
+	if strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return fmt.Errorf("%s contains a control character", name)
+	}
+	return nil
+}
+
+func validateContextText(context DocumentContext) error {
+	if err := validateUTF8Text("document filename", context.Filename); err != nil {
+		return err
+	}
+	return validateUTF8Text("document title", context.Title)
+}

--- a/document/mistral/capabilities_test.go
+++ b/document/mistral/capabilities_test.go
@@ -43,10 +43,8 @@ func TestPolicyFingerprintExcludesObservationDate(t *testing.T) {
 
 	encoded, err := policy.CanonicalJSON(first)
 	require.NoError(t, err)
-	want := `{"version":1,"provider":"mistral","endpoint":"https://api.eu.mistral.ai/v1/ocr","region":"eu","model":"mistral-ocr-4-0","retention":"zdr","training":"opted-out","max_document_bytes":1048576,"max_response_bytes":1048576,"max_units":500,"extract_header":true,"extract_footer":true,"normalization":{"version":2,"max_document_chars":100000,"max_unit_chars":1000000,"max_source_unit_bytes":4000000,"max_metadata_source_bytes":65536,"max_link_chars":2048,"max_chunk_runes":4000,"chunk_overlap":200,"max_chunks":20000},"format_authorities":[{"format_id":"pdf","unit_bound_method":"provider_request","request_fingerprint":"c5121284012927f702b20c744152a3afab0df72b76f07a6c065a39bb8b846b38","fixture_digest":"c35b21d6ca39aa7c"}]}`
-	if string(encoded) != want {
-		t.Fatalf("canonical policy JSON changed:\n got: %s\nwant: %s", encoded, want)
-	}
+	want := `{"version":1,"provider":"mistral","endpoint":"https://api.eu.mistral.ai/v1/ocr","region":"eu","model":"mistral-ocr-4-0","retention":"zdr","training":"opted-out","max_document_bytes":1048576,"max_response_bytes":1048576,"max_units":500,"extract_header":true,"extract_footer":true,"normalization":{"version":3,"max_document_chars":100000,"max_unit_chars":1000000,"max_source_unit_bytes":4000000,"max_metadata_source_bytes":65536,"max_link_chars":2048,"max_chunk_runes":4000,"chunk_overlap":200,"max_chunks":20000},"format_authorities":[{"format_id":"pdf","unit_bound_method":"provider_request","request_fingerprint":"c5121284012927f702b20c744152a3afab0df72b76f07a6c065a39bb8b846b38","fixture_digest":"c35b21d6ca39aa7c"}]}`
+	assert.Equal(t, want, string(encoded), "canonical policy JSON changed")
 }
 
 func TestPolicyRejectsUnknownPrivacyPostureAndMismatchedProbePolicy(t *testing.T) {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -161,7 +161,7 @@ func validateNormalizedUnit(unitKind string, index int, unit NormalizedUnit) err
 	}
 	previousOffset := -1
 	for _, mark := range unit.HeadingMarks {
-		if mark.CharOffset <= previousOffset || mark.CharOffset < 0 || mark.CharOffset >= unit.CharCount || len(mark.Path) == 0 {
+		if mark.CharOffset <= previousOffset || mark.CharOffset < 0 || mark.CharOffset >= unit.CharCount {
 			return fmt.Errorf("normalized document unit %d has invalid heading marks", index)
 		}
 		if slices.Contains(mark.Path, "") {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -99,19 +99,12 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 	chunks, chunksTruncated := chunkNormalizedUnits(result.Units, policy)
 	result.Chunks = chunks
 	result.Truncated = result.Truncated || chunksTruncated
-	checksumParts := []string{fmt.Sprintf("v%d", result.PolicyVersion), result.Family, result.UnitKind}
-	for _, unit := range result.Units {
-		checksumParts = append(checksumParts, unit.Checksum)
-	}
-	for _, chunk := range result.Chunks {
-		checksumParts = append(checksumParts, chunk.Checksum)
-	}
-	result.Checksum = checksumStrings(checksumParts...)
+	result.Checksum = checksumNormalizedDocument(result)
 	return result, nil
 }
 
 // ValidateNormalizedDocument verifies that a normalized document is a
-// structurally complete, internally consistent version-2 normalization
+// structurally complete, internally consistent version-3 normalization
 // result. It detects stale identities after callers deserialize or copy the
 // public evidence structs.
 func ValidateNormalizedDocument(normalized NormalizedDocument) error {
@@ -120,28 +113,39 @@ func ValidateNormalizedDocument(normalized NormalizedDocument) error {
 		return errors.New("normalized document identity is incomplete")
 	}
 	anyTruncated := false
-	checksumParts := []string{fmt.Sprintf("v%d", normalized.PolicyVersion), normalized.Family, normalized.UnitKind}
 	for index, unit := range normalized.Units {
 		if err := validateNormalizedUnit(normalized.UnitKind, index, unit); err != nil {
 			return err
 		}
-		checksumParts = append(checksumParts, unit.Checksum)
 		anyTruncated = anyTruncated || unit.Truncated
 	}
 	for index, chunk := range normalized.Chunks {
 		if err := validateNormalizedChunk(normalized, index, chunk); err != nil {
 			return err
 		}
-		checksumParts = append(checksumParts, chunk.Checksum)
 		anyTruncated = anyTruncated || chunk.Truncated
 	}
-	if normalized.Checksum != checksumStrings(checksumParts...) {
+	if normalized.Checksum != checksumNormalizedDocument(normalized) {
 		return errors.New("normalized document checksum is invalid")
 	}
 	if anyTruncated && !normalized.Truncated {
 		return errors.New("normalized document truncation state is invalid")
 	}
 	return nil
+}
+
+func checksumNormalizedDocument(normalized NormalizedDocument) string {
+	checksumParts := []string{
+		fmt.Sprintf("v%d", normalized.PolicyVersion), normalized.Family, normalized.UnitKind,
+		fmt.Sprintf("truncated:%t", normalized.Truncated),
+	}
+	for _, unit := range normalized.Units {
+		checksumParts = append(checksumParts, unit.Checksum)
+	}
+	for _, chunk := range normalized.Chunks {
+		checksumParts = append(checksumParts, chunk.Checksum)
+	}
+	return checksumStrings(checksumParts...)
 }
 
 func validateNormalizedUnit(unitKind string, index int, unit NormalizedUnit) error {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -107,6 +108,93 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 	}
 	result.Checksum = checksumStrings(checksumParts...)
 	return result, nil
+}
+
+// ValidateNormalizedDocument verifies that a normalized document is a
+// structurally complete, internally consistent version-2 normalization
+// result. It detects stale identities after callers deserialize or copy the
+// public evidence structs.
+func ValidateNormalizedDocument(normalized NormalizedDocument) error {
+	if normalized.PolicyVersion != normalizationPolicyVersion || normalized.Family == "" ||
+		normalized.UnitKind == "" || len(normalized.Units) == 0 {
+		return errors.New("normalized document identity is incomplete")
+	}
+	anyTruncated := false
+	checksumParts := []string{fmt.Sprintf("v%d", normalized.PolicyVersion), normalized.Family, normalized.UnitKind}
+	for index, unit := range normalized.Units {
+		if err := validateNormalizedUnit(normalized.UnitKind, index, unit); err != nil {
+			return err
+		}
+		checksumParts = append(checksumParts, unit.Checksum)
+		anyTruncated = anyTruncated || unit.Truncated
+	}
+	for index, chunk := range normalized.Chunks {
+		if err := validateNormalizedChunk(normalized, index, chunk); err != nil {
+			return err
+		}
+		checksumParts = append(checksumParts, chunk.Checksum)
+		anyTruncated = anyTruncated || chunk.Truncated
+	}
+	if normalized.Checksum != checksumStrings(checksumParts...) {
+		return errors.New("normalized document checksum is invalid")
+	}
+	if anyTruncated && !normalized.Truncated {
+		return errors.New("normalized document truncation state is invalid")
+	}
+	return nil
+}
+
+func validateNormalizedUnit(unitKind string, index int, unit NormalizedUnit) error {
+	expectedKey := fmt.Sprintf("%s:%06d", unitKind, index)
+	if unit.Index != index || unit.SourceKey != expectedKey || unit.Kind != unitKind ||
+		!utf8.ValidString(unit.Text) || !utf8.ValidString(unit.Header) || !utf8.ValidString(unit.Footer) ||
+		unit.CharCount != utf8.RuneCountInString(unit.Text) {
+		return fmt.Errorf("normalized document unit %d is invalid", index)
+	}
+	if unit.Dimensions.DPI < 0 || unit.Dimensions.Height < 0 || unit.Dimensions.Width < 0 ||
+		unit.Dimensions.DPI > 100_000 || unit.Dimensions.Height > 10_000_000 || unit.Dimensions.Width > 10_000_000 {
+		return fmt.Errorf("normalized document unit %d has invalid dimensions", index)
+	}
+	previousOffset := -1
+	for _, mark := range unit.HeadingMarks {
+		if mark.CharOffset <= previousOffset || mark.CharOffset < 0 || mark.CharOffset >= unit.CharCount || len(mark.Path) == 0 {
+			return fmt.Errorf("normalized document unit %d has invalid heading marks", index)
+		}
+		if slices.Contains(mark.Path, "") {
+			return fmt.Errorf("normalized document unit %d has invalid heading marks", index)
+		}
+		previousOffset = mark.CharOffset
+	}
+	if unit.Checksum != checksumStrings(unit.SourceKey, unit.Text, unit.Header, unit.Footer) {
+		return fmt.Errorf("normalized document unit %d checksum is invalid", index)
+	}
+	return nil
+}
+
+func validateNormalizedChunk(normalized NormalizedDocument, index int, chunk Chunk) error {
+	if chunk.Ordinal != index || chunk.Text == "" || !utf8.ValidString(chunk.Text) ||
+		chunk.CharCount != utf8.RuneCountInString(chunk.Text) || len(chunk.Spans) != 1 {
+		return fmt.Errorf("normalized document chunk %d is invalid", index)
+	}
+	span := chunk.Spans[0]
+	if span.UnitIndex < 0 || span.UnitIndex >= len(normalized.Units) || span.CharStart < 0 || span.CharEnd <= span.CharStart {
+		return fmt.Errorf("normalized document chunk %d has an invalid source span", index)
+	}
+	unit := normalized.Units[span.UnitIndex]
+	unitRunes := []rune(unit.Text)
+	if span.CharEnd > len(unitRunes) || string(unitRunes[span.CharStart:span.CharEnd]) != chunk.Text {
+		return fmt.Errorf("normalized document chunk %d does not match its source span", index)
+	}
+	expectedKey := fmt.Sprintf("%s:%06d-%06d", unit.SourceKey, span.CharStart, span.CharEnd)
+	expectedHeadingPath := headingPathAt(unit.HeadingMarks, span.CharStart)
+	if chunk.Key != expectedKey || !slices.Equal(chunk.HeadingPath, expectedHeadingPath) || chunk.Truncated != unit.Truncated {
+		return fmt.Errorf("normalized document chunk %d identity is invalid", index)
+	}
+	expectedChecksum := checksumStrings(chunk.Key, chunk.Text, strings.Join(chunk.HeadingPath, "\x00"))
+	if chunk.Checksum != expectedChecksum {
+		return fmt.Errorf("normalized document chunk %d checksum is invalid", index)
+	}
+	return nil
 }
 
 func validateSourceUnits(units []SourceUnit) error {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -31,6 +31,9 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 	if source.Family == "" || source.UnitKind == "" || len(source.Units) == 0 {
 		return NormalizedDocument{}, errors.New("document normalization requires family, unit kind, and units")
 	}
+	if err := validateDocumentIdentifiers(source.Family, source.UnitKind); err != nil {
+		return NormalizedDocument{}, err
+	}
 	if err := policy.validate(); err != nil {
 		return NormalizedDocument{}, err
 	}
@@ -112,6 +115,9 @@ func ValidateNormalizedDocument(normalized NormalizedDocument) error {
 		normalized.UnitKind == "" || len(normalized.Units) == 0 {
 		return errors.New("normalized document identity is incomplete")
 	}
+	if err := validateDocumentIdentifiers(normalized.Family, normalized.UnitKind); err != nil {
+		return err
+	}
 	anyTruncated := false
 	for index, unit := range normalized.Units {
 		if err := validateNormalizedUnit(normalized.UnitKind, index, unit); err != nil {
@@ -130,6 +136,22 @@ func ValidateNormalizedDocument(normalized NormalizedDocument) error {
 	}
 	if anyTruncated && !normalized.Truncated {
 		return errors.New("normalized document truncation state is invalid")
+	}
+	return nil
+}
+
+func validateDocumentIdentifiers(family, unitKind string) error {
+	identifiers := [...]struct{ name, value string }{
+		{name: "family", value: family},
+		{name: "unit kind", value: unitKind},
+	}
+	for _, identifier := range identifiers {
+		if !utf8.ValidString(identifier.value) {
+			return fmt.Errorf("document %s contains invalid UTF-8", identifier.name)
+		}
+		if strings.IndexFunc(identifier.value, unicode.IsControl) >= 0 {
+			return fmt.Errorf("document %s contains a control character", identifier.name)
+		}
 	}
 	return nil
 }

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -88,7 +88,7 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 			Text: text, Header: header, Footer: footer, Dimensions: unit.Dimensions,
 			CharCount: utf8.RuneCountInString(text), Truncated: unitTruncated, HeadingMarks: boundedHeadings,
 		}
-		normalized.Checksum = checksumStrings(normalized.SourceKey, normalized.Text, normalized.Header, normalized.Footer)
+		normalized.Checksum = checksumNormalizedUnit(normalized)
 		result.Units = append(result.Units, normalized)
 		result.Truncated = result.Truncated || unitTruncated
 	}
@@ -148,6 +148,20 @@ func checksumNormalizedDocument(normalized NormalizedDocument) string {
 	return checksumStrings(checksumParts...)
 }
 
+func checksumNormalizedUnit(unit NormalizedUnit) string {
+	return checksumStrings(
+		unit.SourceKey, unit.Text, unit.Header, unit.Footer,
+		fmt.Sprintf("truncated:%t", unit.Truncated),
+	)
+}
+
+func checksumNormalizedChunk(chunk Chunk) string {
+	return checksumStrings(
+		chunk.Key, chunk.Text, strings.Join(chunk.HeadingPath, "\x00"),
+		fmt.Sprintf("truncated:%t", chunk.Truncated),
+	)
+}
+
 func validateNormalizedUnit(unitKind string, index int, unit NormalizedUnit) error {
 	expectedKey := fmt.Sprintf("%s:%06d", unitKind, index)
 	if unit.Index != index || unit.SourceKey != expectedKey || unit.Kind != unitKind ||
@@ -169,7 +183,7 @@ func validateNormalizedUnit(unitKind string, index int, unit NormalizedUnit) err
 		}
 		previousOffset = mark.CharOffset
 	}
-	if unit.Checksum != checksumStrings(unit.SourceKey, unit.Text, unit.Header, unit.Footer) {
+	if unit.Checksum != checksumNormalizedUnit(unit) {
 		return fmt.Errorf("normalized document unit %d checksum is invalid", index)
 	}
 	return nil
@@ -194,7 +208,7 @@ func validateNormalizedChunk(normalized NormalizedDocument, index int, chunk Chu
 	if chunk.Key != expectedKey || !slices.Equal(chunk.HeadingPath, expectedHeadingPath) || chunk.Truncated != unit.Truncated {
 		return fmt.Errorf("normalized document chunk %d identity is invalid", index)
 	}
-	expectedChecksum := checksumStrings(chunk.Key, chunk.Text, strings.Join(chunk.HeadingPath, "\x00"))
+	expectedChecksum := checksumNormalizedChunk(chunk)
 	if chunk.Checksum != expectedChecksum {
 		return fmt.Errorf("normalized document chunk %d checksum is invalid", index)
 	}
@@ -689,7 +703,7 @@ func chunkNormalizedUnits(units []NormalizedUnit, policy NormalizePolicy) ([]Chu
 				CharCount: utf8.RuneCountInString(span.Text), Truncated: unit.Truncated,
 				Spans: []ChunkSpan{{UnitIndex: unit.Index, CharStart: span.CharStart, CharEnd: span.CharEnd}},
 			}
-			chunk.Checksum = checksumStrings(chunk.Key, chunk.Text, strings.Join(chunk.HeadingPath, "\x00"))
+			chunk.Checksum = checksumNormalizedChunk(chunk)
 			chunks = append(chunks, chunk)
 		}
 	}

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -119,14 +119,16 @@ func ValidateNormalizedDocument(normalized NormalizedDocument) error {
 		return err
 	}
 	anyTruncated := false
+	unitRunes := make([][]rune, len(normalized.Units))
 	for index, unit := range normalized.Units {
 		if err := validateNormalizedUnit(normalized.UnitKind, index, unit); err != nil {
 			return err
 		}
+		unitRunes[index] = []rune(unit.Text)
 		anyTruncated = anyTruncated || unit.Truncated
 	}
 	for index, chunk := range normalized.Chunks {
-		if err := validateNormalizedChunk(normalized, index, chunk); err != nil {
+		if err := validateNormalizedChunk(normalized, unitRunes, index, chunk); err != nil {
 			return err
 		}
 		anyTruncated = anyTruncated || chunk.Truncated
@@ -211,7 +213,7 @@ func validateNormalizedUnit(unitKind string, index int, unit NormalizedUnit) err
 	return nil
 }
 
-func validateNormalizedChunk(normalized NormalizedDocument, index int, chunk Chunk) error {
+func validateNormalizedChunk(normalized NormalizedDocument, unitRunes [][]rune, index int, chunk Chunk) error {
 	if chunk.Ordinal != index || chunk.Text == "" || !utf8.ValidString(chunk.Text) ||
 		chunk.CharCount != utf8.RuneCountInString(chunk.Text) || len(chunk.Spans) != 1 {
 		return fmt.Errorf("normalized document chunk %d is invalid", index)
@@ -221,8 +223,8 @@ func validateNormalizedChunk(normalized NormalizedDocument, index int, chunk Chu
 		return fmt.Errorf("normalized document chunk %d has an invalid source span", index)
 	}
 	unit := normalized.Units[span.UnitIndex]
-	unitRunes := []rune(unit.Text)
-	if span.CharEnd > len(unitRunes) || string(unitRunes[span.CharStart:span.CharEnd]) != chunk.Text {
+	unitText := unitRunes[span.UnitIndex]
+	if span.CharEnd > len(unitText) || string(unitText[span.CharStart:span.CharEnd]) != chunk.Text {
 		return fmt.Errorf("normalized document chunk %d does not match its source span", index)
 	}
 	expectedKey := fmt.Sprintf("%s:%06d-%06d", unit.SourceKey, span.CharStart, span.CharEnd)

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -173,10 +173,20 @@ func checksumNormalizedDocument(normalized NormalizedDocument) string {
 }
 
 func checksumNormalizedUnit(unit NormalizedUnit) string {
-	return checksumStrings(
+	checksumParts := []string{
 		unit.SourceKey, unit.Text, unit.Header, unit.Footer,
+		fmt.Sprintf("dimensions:%d:%d:%d", unit.Dimensions.DPI, unit.Dimensions.Height, unit.Dimensions.Width),
 		fmt.Sprintf("truncated:%t", unit.Truncated),
-	)
+		fmt.Sprintf("heading-marks:%d", len(unit.HeadingMarks)),
+	}
+	for _, mark := range unit.HeadingMarks {
+		checksumParts = append(checksumParts,
+			fmt.Sprintf("offset:%d", mark.CharOffset),
+			fmt.Sprintf("path-parts:%d", len(mark.Path)),
+		)
+		checksumParts = append(checksumParts, mark.Path...)
+	}
+	return checksumStrings(checksumParts...)
 }
 
 func checksumNormalizedChunk(chunk Chunk) string {

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -398,6 +398,18 @@ func TestNormalizeDocumentBoundsHeadingPathsByLevel(t *testing.T) {
 	}
 }
 
+func TestValidateNormalizedDocumentRejectsEmptyHeadingPathElements(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	normalized, err := NormalizeDocument(SourceDocument{
+		Family: "text", UnitKind: "page", Units: []SourceUnit{{Index: 0, Markdown: "# Parent\n\nbody"}},
+	}, policy)
+	require.NoError(t, err)
+	normalized.Units[0].HeadingMarks[0].Path = []string{"Parent", ""}
+
+	err = ValidateNormalizedDocument(normalized)
+	assert.ErrorContains(t, err, "invalid heading marks")
+}
+
 func TestNormalizeDocumentPreservesHeadingTextAcrossEmbeddedBreaks(t *testing.T) {
 	policy := testNormalizePolicy(t, 10_000)
 	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -75,6 +75,47 @@ func TestNormalizeDocumentRejectsZeroPolicy(t *testing.T) {
 	require.ErrorContains(t, err, "use NewNormalizePolicy")
 }
 
+func TestNormalizeAndValidateRejectInvalidDocumentIdentifiers(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	validSource := SourceDocument{
+		Family: "text", UnitKind: "unit", Units: []SourceUnit{{Index: 0, Markdown: "evidence"}},
+	}
+	validNormalized, err := NormalizeDocument(validSource, policy)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name, family, unitKind, want string
+	}{
+		{
+			name: "family invalid UTF-8", family: string([]byte{0xff}), unitKind: "unit", want: "invalid UTF-8",
+		},
+		{
+			name: "unit kind invalid UTF-8", family: "text", unitKind: string([]byte{0xff}), want: "invalid UTF-8",
+		},
+		{
+			name: "family control character", family: "text\nother", unitKind: "unit", want: "control character",
+		},
+		{
+			name: "unit kind control character", family: "text", unitKind: "unit\tother", want: "control character",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := validSource
+			source.Family = test.family
+			source.UnitKind = test.unitKind
+			_, err := NormalizeDocument(source, policy)
+			require.ErrorContains(t, err, test.want)
+
+			normalized := validNormalized
+			normalized.Family = test.family
+			normalized.UnitKind = test.unitKind
+			err = ValidateNormalizedDocument(normalized)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
 func TestNormalizeDocumentChecksumIncludesDocumentTruncation(t *testing.T) {
 	policy := testNormalizePolicy(t, 3)
 	complete, err := NormalizeDocument(SourceDocument{

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -78,12 +78,12 @@ func TestNormalizeDocumentRejectsZeroPolicy(t *testing.T) {
 func TestNormalizeDocumentChecksumIncludesDocumentTruncation(t *testing.T) {
 	policy := testNormalizePolicy(t, 3)
 	complete, err := NormalizeDocument(SourceDocument{
-		Family: "text", UnitKind: "section",
+		Family: "text", UnitKind: "unit",
 		Units: []SourceUnit{{Index: 0, Markdown: "one"}},
 	}, policy)
 	require.NoError(t, err)
 	truncated, err := NormalizeDocument(SourceDocument{
-		Family: "text", UnitKind: "section",
+		Family: "text", UnitKind: "unit",
 		Units: []SourceUnit{{Index: 0, Markdown: "one"}, {Index: 1, Markdown: "two"}},
 	}, policy)
 	require.NoError(t, err)

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -75,6 +75,26 @@ func TestNormalizeDocumentRejectsZeroPolicy(t *testing.T) {
 	require.ErrorContains(t, err, "use NewNormalizePolicy")
 }
 
+func TestNormalizeDocumentChecksumIncludesDocumentTruncation(t *testing.T) {
+	policy := testNormalizePolicy(t, 3)
+	complete, err := NormalizeDocument(SourceDocument{
+		Family: "text", UnitKind: "section",
+		Units: []SourceUnit{{Index: 0, Markdown: "one"}},
+	}, policy)
+	require.NoError(t, err)
+	truncated, err := NormalizeDocument(SourceDocument{
+		Family: "text", UnitKind: "section",
+		Units: []SourceUnit{{Index: 0, Markdown: "one"}, {Index: 1, Markdown: "two"}},
+	}, policy)
+	require.NoError(t, err)
+
+	assert.False(t, complete.Truncated)
+	assert.True(t, truncated.Truncated)
+	assert.Equal(t, complete.Units, truncated.Units)
+	assert.Equal(t, complete.Chunks, truncated.Chunks)
+	assert.NotEqual(t, complete.Checksum, truncated.Checksum)
+}
+
 func TestNormalizeDocumentPublishesHeaderAndFooterOnlyEvidence(t *testing.T) {
 	source := SourceDocument{Family: "pdf", UnitKind: "page", Units: []SourceUnit{{
 		Index: 0, Header: "Confidential **shipment**", Footer: "Dock 7",

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -451,6 +451,47 @@ func TestValidateNormalizedDocumentRejectsEmptyHeadingPathElements(t *testing.T)
 	assert.ErrorContains(t, err, "invalid heading marks")
 }
 
+func TestValidateNormalizedDocumentRejectsChangedUnitProvenance(t *testing.T) {
+	policy := testNormalizePolicy(t, 10_000)
+	normalized, err := NormalizeDocument(SourceDocument{
+		Family: "pdf", UnitKind: "page", Units: []SourceUnit{{
+			Index: 0, Markdown: "# Parent\n\nbody",
+			Dimensions: UnitDimensions{DPI: 200, Height: 1200, Width: 800},
+		}},
+	}, policy)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		mutate func(*NormalizedDocument)
+	}{
+		{
+			name: "dimensions",
+			mutate: func(changed *NormalizedDocument) {
+				changed.Units[0].Dimensions.Width++
+			},
+		},
+		{
+			name: "heading mark",
+			mutate: func(changed *NormalizedDocument) {
+				changed.Units[0].HeadingMarks[0].Path[0] = "Changed"
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			changed := normalized
+			changed.Units = append([]NormalizedUnit(nil), normalized.Units...)
+			changed.Units[0].HeadingMarks = append([]HeadingMark(nil), normalized.Units[0].HeadingMarks...)
+			changed.Units[0].HeadingMarks[0].Path = append([]string(nil), normalized.Units[0].HeadingMarks[0].Path...)
+			test.mutate(&changed)
+
+			err := ValidateNormalizedDocument(changed)
+			assert.ErrorContains(t, err, "checksum is invalid")
+		})
+	}
+}
+
 func TestNormalizeDocumentPreservesHeadingTextAcrossEmbeddedBreaks(t *testing.T) {
 	policy := testNormalizePolicy(t, 10_000)
 	source := SourceDocument{Family: "text", UnitKind: "page", Units: []SourceUnit{{

--- a/document/policy.go
+++ b/document/policy.go
@@ -2,9 +2,9 @@ package document
 
 import "errors"
 
-const normalizationPolicyVersion = 2
+const normalizationPolicyVersion = 3
 
-// NormalizePolicy fixes the version-2 normalization behavior. Its structural
+// NormalizePolicy fixes the version-3 normalization behavior. Its structural
 // values are private because changing any of them requires a new version.
 type NormalizePolicy struct {
 	version                int
@@ -31,7 +31,7 @@ type NormalizePolicyIdentity struct {
 	MaxChunks              int `json:"max_chunks"`
 }
 
-// NewNormalizePolicy returns the fixed version-2 policy for a document limit.
+// NewNormalizePolicy returns the fixed version-3 policy for a document limit.
 func NewNormalizePolicy(maxDocumentChars int) (NormalizePolicy, error) {
 	policy := NormalizePolicy{
 		version:                normalizationPolicyVersion,

--- a/document/policy_test.go
+++ b/document/policy_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewNormalizePolicyReturnsVersionTwoIdentity(t *testing.T) {
+func TestNewNormalizePolicyReturnsVersionThreeIdentity(t *testing.T) {
 	policy, err := NewNormalizePolicy(25_000_000)
 	require.NoError(t, err)
 	assert.Equal(t, NormalizePolicyIdentity{
-		Version:                2,
+		Version:                3,
 		MaxDocumentChars:       25_000_000,
 		MaxUnitChars:           1_000_000,
 		MaxSourceUnitBytes:     4_000_000,

--- a/document/public_test.go
+++ b/document/public_test.go
@@ -38,6 +38,7 @@ func TestPublicSourceEvidenceAndPolicy(t *testing.T) {
 
 	normalized, err := document.NormalizeDocument(source, policy)
 	require.NoError(t, err)
+	require.NoError(t, document.ValidateNormalizedDocument(normalized))
 	require.Len(t, normalized.Units, 1)
 	require.NotEmpty(t, normalized.Units[0].HeadingMarks)
 	require.NotEmpty(t, normalized.Chunks)
@@ -45,4 +46,14 @@ func TestPublicSourceEvidenceAndPolicy(t *testing.T) {
 	assert.Equal(t, "Synthetic report", normalized.Units[0].HeadingMarks[0].Path[0])
 	assert.Equal(t, 0, normalized.Chunks[0].Ordinal)
 	assert.Equal(t, 0, normalized.Chunks[0].Spans[0].UnitIndex)
+
+	stale := normalized
+	stale.Chunks = append([]document.Chunk(nil), normalized.Chunks...)
+	stale.Chunks[0].Text = "altered normalized evidence"
+	stale.Chunks[0].CharCount = len([]rune(stale.Chunks[0].Text))
+	require.Error(t, document.ValidateNormalizedDocument(stale))
+
+	partial := normalized
+	partial.Chunks = nil
+	assert.ErrorContains(t, document.ValidateNormalizedDocument(partial), "checksum")
 }

--- a/document/public_test.go
+++ b/document/public_test.go
@@ -11,7 +11,7 @@ import (
 func TestPublicSourceEvidenceAndPolicy(t *testing.T) {
 	policy, err := document.NewNormalizePolicy(25_000_000)
 	require.NoError(t, err)
-	assert.Equal(t, 2, policy.Identity().Version)
+	assert.Equal(t, 3, policy.Identity().Version)
 	assert.Equal(t, 25_000_000, policy.Identity().MaxDocumentChars)
 
 	source := document.SourceDocument{


### PR DESCRIPTION
Document-search consumers can now share one storage-neutral contract for preparing normalized evidence, optional pre-embedding distillation, vector identity, scoped retrieval, and relevance evaluation. Raw normalized chunks remain the default; applications must explicitly select distilled or combined representations.

## Shared embedding behavior

- `document/embedding` plans complete normalized documents into stable, rune-bounded raw, distilled, or combined inputs with filename, title, heading, locator, and exact source provenance.
- Optional distillation uses deterministic source partitions, a provider-neutral `Distiller` interface, strict output validation, and content-addressed artifacts. Derived text remains untrusted and linked to normalized source spans, with upstream truncation preserved through partitions, sections, and final input identities.
- Endpoint-independent vector-space identity is separate from endpoint- and purpose-sensitive egress identity for document distillation, document embedding, and query embedding.
- Search defaults to lexical, applies scope before candidate cutoffs through pageable retrieval, detects overflow with an extra candidate, and preserves both lane signals through deterministic reciprocal-rank fusion.
- `document/embedding/eval` records Recall@5/10/20, nDCG@10, MRR, critical misses, repeated-trial ranges, provider usage, estimated cost, and latency for versioned public or synthetic corpora.

## Identity changes

Normalization advances from version 2 to version 3. Unit, chunk, and document checksums bind their truncation state; unit checksums also bind source dimensions and complete heading-mark provenance; and embedding-input keys bind their effective truncation state. A complete shorter document therefore cannot share derived artifacts with a longer document whose retained evidence or remaining units were truncated. Identity-bearing source, provider, model, revision, and vector-normalization strings must be valid, control-free UTF-8; filename and title context must be valid UTF-8 before normalization. This keeps fingerprints, serialized requests, and provider-facing text aligned across transport. The frozen version-2 corpus confirms that normalized text and provenance remain unchanged while these identities intentionally rotate. Consumers upgrading to version 3 must regenerate normalized-document-derived state; this PR adds no version-2 fallback.

Egress fingerprints preserve escaped route semantics and IPv6 zone case while still canonicalizing DNS hostname case and equivalent empty/root paths. Consent therefore follows the exact HTTP destination without rotating for ordinary DNS spelling differences.

## Boundary

The packages perform no network, database, queue, daemon, or consent-record work. Applications still choose provider transports, enforce per-request consent, persist derived artifacts and vectors, and run hosted evaluations before selecting anything other than the raw default.