### PR TITLE
Prepare CI lint for Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: v2.13.1
 
   windows:
     name: Windows ${{ matrix.goarch }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -204,6 +204,18 @@ linters:
         path: _test\.go
         text: "SA5011"
 
+      # CreateRaw owns the legacy DOS timestamp bytes in published Mistral
+      # fixtures. Using FileHeader.Modified adds an extended timestamp and
+      # changes their digests.
+      - linters: [staticcheck]
+        path: document/mistral/fixture_writer\.go
+        text: "SA1019"
+
+      # TOML requires pointer-receiver UnmarshalText while callers use the
+      # value-semantic Std accessor.
+      - linters: [recvcheck]
+        path: internal/config/config\.go
+
       # bodyclose can't see across function boundaries: internal/api's get()
       # test helper reads and closes the response body itself before
       # returning it for status/header assertions. Every route test file in

--- a/cmd/docbank/exit.go
+++ b/cmd/docbank/exit.go
@@ -47,8 +47,7 @@ func commandExitCode(err error, started bool) int {
 	if err == nil {
 		return exitSuccess
 	}
-	var classified *exitError
-	if errors.As(err, &classified) {
+	if classified, ok := errors.AsType[*exitError](err); ok {
 		return classified.code
 	}
 	if errors.Is(err, client.ErrIntegrity) {

--- a/cmd/docbank/web.go
+++ b/cmd/docbank/web.go
@@ -82,7 +82,7 @@ func runWeb(
 	if err := open(ctx, launchURL); err != nil {
 		return fmt.Errorf("opening Docbank web application: %w", err)
 	}
-	base := strings.SplitN(rawURL, "#", 2)[0]
+	base, _, _ := strings.Cut(rawURL, "#")
 	_, err = fmt.Fprintf(out, "opened Docbank web application at %s\n", base)
 	if err != nil {
 		return fmt.Errorf("printing web application status: %w", err)

--- a/document/media/detect.go
+++ b/document/media/detect.go
@@ -416,7 +416,7 @@ type mp4Info struct {
 	movieDuration        uint64
 	trackDurations       []uint64
 	mediaDurations       []mp4Duration
-	unknownDuration bool
+	unknownDuration      bool
 }
 
 type mp4Duration struct {

--- a/document/mistral/client.go
+++ b/document/mistral/client.go
@@ -85,8 +85,7 @@ func (e *processError) Unwrap() error { return e.err }
 
 // MetricsFromError recovers provider request accounting from a Process error.
 func MetricsFromError(err error) RequestMetrics {
-	var processErr *processError
-	if errors.As(err, &processErr) {
+	if processErr, ok := errors.AsType[*processError](err); ok {
 		return processErr.metrics
 	}
 	return RequestMetrics{}

--- a/document/mistral/fixture_writer.go
+++ b/document/mistral/fixture_writer.go
@@ -332,7 +332,7 @@ func zipFixture(entries []zipEntry) ([]byte, bool, error) {
 			Method: zip.Store,
 			// CreateRaw deliberately owns the DOS timestamp bytes; using Modified
 			// adds an extended timestamp and changes the published fixture digests.
-			ModifiedDate: zipEpochDate, //nolint:staticcheck // byte-identity contract
+			ModifiedDate: zipEpochDate,
 		}
 		value := []byte(entry.value)
 		header.CRC32 = crc32.ChecksumIEEE(value)

--- a/document/mistral/fixture_writer.go
+++ b/document/mistral/fixture_writer.go
@@ -328,9 +328,11 @@ func zipFixture(entries []zipEntry) ([]byte, bool, error) {
 	writer := zip.NewWriter(&output)
 	for _, entry := range entries {
 		header := &zip.FileHeader{
-			Name:         entry.name,
-			Method:       zip.Store,
-			ModifiedDate: zipEpochDate,
+			Name:   entry.name,
+			Method: zip.Store,
+			// CreateRaw deliberately owns the DOS timestamp bytes; using Modified
+			// adds an extended timestamp and changes the published fixture digests.
+			ModifiedDate: zipEpochDate, //nolint:staticcheck // byte-identity contract
 		}
 		value := []byte(entry.value)
 		header.CRC32 = crc32.ChecksumIEEE(value)

--- a/document/voyage/errors.go
+++ b/document/voyage/errors.go
@@ -84,8 +84,7 @@ func RetryAfter(err error) (time.Duration, bool) {
 // MetricsFromError recovers provider request accounting from an embedding
 // error.
 func MetricsFromError(err error) RequestMetrics {
-	var providerErr *ProviderError
-	if errors.As(err, &providerErr) {
+	if providerErr, ok := errors.AsType[*ProviderError](err); ok {
 		return providerErr.Metrics
 	}
 	return RequestMetrics{}

--- a/internal/api/routes_backup.go
+++ b/internal/api/routes_backup.go
@@ -751,8 +751,7 @@ func fromBackupError(err error) error {
 }
 
 func backupProblem(err error) *Error {
-	var problem *Error
-	if errors.As(err, &problem) {
+	if problem, ok := errors.AsType[*Error](err); ok {
 		return problem
 	}
 	if errors.Is(err, backup.ErrRepoLocked) {

--- a/internal/api/routes_upload.go
+++ b/internal/api/routes_upload.go
@@ -130,8 +130,7 @@ func handleUpload(w http.ResponseWriter, r *http.Request, d Deps, g *gate) {
 						"%w: upload contains more than one multipart part", errInvalidUploadEnvelope,
 					), prepared.Discard())
 				}
-				var maxBytesErr *http.MaxBytesError
-				if errors.As(nextErr, &maxBytesErr) {
+				if _, ok := errors.AsType[*http.MaxBytesError](nextErr); ok {
 					return errors.Join(
 						fmt.Errorf("upload multipart body exceeded limit: %w", nextErr),
 						prepared.Discard(),
@@ -161,8 +160,7 @@ func handleUpload(w http.ResponseWriter, r *http.Request, d Deps, g *gate) {
 }
 
 func uploadMultipartReadError(err error, detail string) *Error {
-	var maxBytesErr *http.MaxBytesError
-	if errors.As(err, &maxBytesErr) {
+	if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 		return NewError(http.StatusRequestEntityTooLarge, "too_large", detail+": "+err.Error())
 	}
 	return NewError(http.StatusUnprocessableEntity, "validation", detail+": "+err.Error())

--- a/internal/api/web_download.go
+++ b/internal/api/web_download.go
@@ -385,8 +385,7 @@ func mustDecodeHash(hash string) []byte {
 }
 
 func webDownloadProblem(err error) *Error {
-	var problem *Error
-	if errors.As(FromStoreError(err), &problem) {
+	if problem, ok := errors.AsType[*Error](FromStoreError(err)); ok {
 		return problem
 	}
 	return NewError(http.StatusInternalServerError, "internal", err.Error())

--- a/internal/api/web_upload.go
+++ b/internal/api/web_upload.go
@@ -232,8 +232,7 @@ func validateWebUploadDestination(ctx context.Context, d Deps, parentID int64) *
 		return NewError(http.StatusNotFound, "not_found",
 			"upload destination does not exist")
 	case err != nil:
-		var problem *Error
-		if errors.As(FromStoreError(err), &problem) {
+		if problem, ok := errors.AsType[*Error](FromStoreError(err)); ok {
 			return problem
 		}
 		return NewError(http.StatusInternalServerError, "internal",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,7 @@ import (
 // Duration is a time.Duration that unmarshals from a TOML string such as
 // "30m"; "0" disables the associated timeout.
 //
-//nolint:recvcheck // UnmarshalText needs a pointer receiver; Std is value semantics by design.
+
 type Duration time.Duration
 
 // UnmarshalText parses a duration string, rejecting negative durations.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,8 +22,6 @@ import (
 
 // Duration is a time.Duration that unmarshals from a TOML string such as
 // "30m"; "0" disables the associated timeout.
-//
-
 type Duration time.Duration
 
 // UnmarshalText parses a duration string, rejecting negative durations.


### PR DESCRIPTION
Prepare CI to analyze the Go 1.27 upgrade before that upgrade merges. Pull
requests deliberately execute the reusable workflow pinned to `main`, where
golangci-lint 2.12.2 was built with Go 1.26 and refuses to analyze a module
that targets Go 1.27.

Pin golangci-lint 2.13.1 on `main` and accept its focused mechanical cleanups.
The Mistral fixture keeps its raw DOS timestamp field because replacing it
changes the published fixture digests; narrow path-and-diagnostic exclusions
express that byte-identity contract and the existing TOML receiver contract
consistently across both linter versions.

After this prerequisite merges, PR #178 can rerun against the updated trusted
workflow. This does not change the main module's Go version.
