### PR TITLE
Build safe Markdown renditions from canonical evidence

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 document/internal/compattest/testdata/document-compat-v1.json -text
 # The evidence golden bundle is a byte-for-byte oracle, not a text file.
 document/testdata/normalized-evidence-v1.golden.json -text
+# The rendition golden bundle is a byte-for-byte oracle, not a text file.
+document/testdata/rendition-v1.golden.md -text

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -559,6 +559,7 @@ type renditionHTMLWriter struct {
 	inlineText         strings.Builder
 	ignoredLinkDepth   int
 	linkDepthTruncated bool
+	suppressedTags     []string
 
 	inTable          bool
 	inRow            bool
@@ -842,7 +843,10 @@ func (w *renditionHTMLWriter) consumeFragment(fragment []byte, suppressText bool
 		case html.SelfClosingTagToken:
 			w.startTag(tokenizer.Token(), tokenOffset, suppressText)
 		case html.EndTagToken:
-			w.endTag(tokenizer.Token().Data)
+			tag := tokenizer.Token().Data
+			if !w.endSuppressedTag(tag) {
+				w.endTag(tag)
+			}
 		case html.CommentToken, html.DoctypeToken:
 			// Not searchable evidence.
 		}
@@ -876,6 +880,12 @@ func (w *renditionHTMLWriter) startTag(token html.Token, tokenOffset int, suppre
 	if w.skipDepth > 0 {
 		if tag == w.skipTag {
 			w.skipDepth++
+		}
+		return
+	}
+	if suppressText {
+		if isRenditionStatefulTag(tag) {
+			w.suppressedTags = append(w.suppressedTags, tag)
 		}
 		return
 	}
@@ -1021,6 +1031,23 @@ func (w *renditionHTMLWriter) startTag(token html.Token, tokenOffset int, suppre
 			w.startBlock(renditionParagraph, 0)
 		}
 	}
+}
+
+func isRenditionStatefulTag(tag string) bool {
+	switch tag {
+	case "ul", "ol", "li", "table", "tr", "td", "th", "pre", "code", "a":
+		return true
+	default:
+		return false
+	}
+}
+
+func (w *renditionHTMLWriter) endSuppressedTag(tag string) bool {
+	if len(w.suppressedTags) == 0 || w.suppressedTags[len(w.suppressedTags)-1] != tag {
+		return false
+	}
+	w.suppressedTags = w.suppressedTags[:len(w.suppressedTags)-1]
+	return true
 }
 
 func parserGeneratedCheckboxMarker(token html.Token) (string, bool) {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -9,13 +9,17 @@ import (
 	"io"
 	"net/url"
 	"slices"
+	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/yuin/goldmark"
+	goldmarkast "github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/renderer"
 	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
 	"golang.org/x/net/html"
 )
 
@@ -47,19 +51,19 @@ func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (Normalize
 	}
 	remaining := policy.maxDocumentChars
 	for i, unit := range source.Units {
-		text, headings, sourceTruncated, err := canonicalMarkdown(
+		text, headings, sourceTruncated, err := sanitizeMarkdown(
 			unit.Markdown, policy.maxLinkChars, policy.maxSourceUnitBytes,
 		)
 		if err != nil {
 			return NormalizedDocument{}, fmt.Errorf("normalize document source unit %d: %w", i, err)
 		}
-		header, _, headerSourceTruncated, err := canonicalMarkdown(
+		header, _, headerSourceTruncated, err := sanitizeMarkdown(
 			unit.Header, policy.maxLinkChars, policy.maxMetadataSourceBytes,
 		)
 		if err != nil {
 			return NormalizedDocument{}, fmt.Errorf("normalize document source unit %d header: %w", i, err)
 		}
-		footer, _, footerSourceTruncated, err := canonicalMarkdown(
+		footer, _, footerSourceTruncated, err := sanitizeMarkdown(
 			unit.Footer, policy.maxLinkChars, policy.maxMetadataSourceBytes,
 		)
 		if err != nil {
@@ -290,7 +294,168 @@ func joinDocumentUnitEvidence(header, body, footer string) (string, int) {
 	return strings.Join(parts, "\n\n"), bodyOffset
 }
 
-func canonicalMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (string, []canonicalHeadingMark, bool, error) {
+// sanitizeMarkdown converts untrusted provider Markdown into inert canonical
+// Markdown-like text. It preserves NormalizeDocument's frozen behavior.
+func sanitizeMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (string, []canonicalHeadingMark, bool, error) {
+	return sanitizeMarkdownWithActiveHTML(markdown, maxLinkChars, maxSourceBytes, false)
+}
+
+// sanitizeRenditionMarkdown applies the normalizer's frozen text rules plus
+// removes the body of active HTML elements from a durable rendition.
+func sanitizeRenditionMarkdown(markdown string, maxLinkChars, maxSourceBytes, maxRunes int) (string, bool, bool, error) {
+	if markdown == "" {
+		return "", false, false, nil
+	}
+	if !utf8.ValidString(markdown) {
+		return "", false, false, errors.New("provider Markdown is invalid UTF-8")
+	}
+	markdown, sourceTruncated := truncateUTF8Bytes(markdown, maxSourceBytes)
+	var rendered bytes.Buffer
+	listTightness := make(map[int]bool)
+	rawSpans := make([]renditionRawSpan, 0)
+	parser := goldmark.New(
+		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithRendererOptions(
+			goldmarkhtml.WithUnsafe(),
+			renderer.WithNodeRenderers(util.Prioritized(&renditionHTMLRenderer{
+				output: &rendered, tightness: listTightness, rawSpans: &rawSpans,
+			}, 0)),
+		),
+	)
+	source := []byte(markdown)
+	if err := parser.Convert(source, &rendered); err != nil {
+		return "", false, false, fmt.Errorf("parse provider Markdown: %w", err)
+	}
+	writer := renditionHTMLWriter{maxLinkChars: maxLinkChars, listTightness: listTightness}
+	if err := writer.consumeFragments(rendered.Bytes(), rawSpans); err != nil {
+		return "", false, false, err
+	}
+	text, renditionTruncated := serializeRenditionBlocks(writer.blocks, maxRunes)
+	renditionTruncated = renditionTruncated || writer.linkDepthTruncated
+	return text, sourceTruncated, renditionTruncated, nil
+}
+
+// renditionHTMLRenderer records parser-derived list tightness and hard
+// boundaries around every provider-controlled raw HTML node. Each bounded
+// fragment gets an independent tokenizer so raw-text state cannot escape the
+// source AST node that introduced it.
+type renditionHTMLRenderer struct {
+	output    *bytes.Buffer
+	tightness map[int]bool
+	rawSpans  *[]renditionRawSpan
+}
+
+type renditionRawSpan struct {
+	start            int
+	end              int
+	inline           bool
+	linkDestination  string
+	closesLink       bool
+	startsActiveBody bool
+	endsActiveBody   bool
+}
+
+func (r *renditionHTMLRenderer) RegisterFuncs(registerer renderer.NodeRendererFuncRegisterer) {
+	registerer.Register(goldmarkast.KindList, r.renderList)
+	registerer.Register(goldmarkast.KindHTMLBlock, r.renderHTMLBlock)
+	registerer.Register(goldmarkast.KindRawHTML, r.renderRawHTML)
+}
+
+func (r *renditionHTMLRenderer) offset(writer util.BufWriter) int {
+	return r.output.Len() + writer.Buffered()
+}
+
+func (r *renditionHTMLRenderer) appendRawSpan(start int, writer util.BufWriter, inline bool) {
+	end := r.offset(writer)
+	if end > start {
+		*r.rawSpans = append(*r.rawSpans, renditionRawSpan{start: start, end: end, inline: inline})
+	}
+}
+
+func (r *renditionHTMLRenderer) renderList(
+	writer util.BufWriter,
+	_ []byte,
+	node goldmarkast.Node,
+	entering bool,
+) (goldmarkast.WalkStatus, error) {
+	list, ok := node.(*goldmarkast.List)
+	if !ok {
+		return goldmarkast.WalkStop, fmt.Errorf("render list node: unexpected %T", node)
+	}
+	tag := "ul"
+	if list.IsOrdered() {
+		tag = "ol"
+	}
+	if entering {
+		r.tightness[r.offset(writer)] = list.IsTight
+		_ = writer.WriteByte('<')
+		_, _ = writer.WriteString(tag)
+		if list.IsOrdered() && list.Start != 1 {
+			_, _ = fmt.Fprintf(writer, " start=\"%d\"", list.Start)
+		}
+		if list.Attributes() != nil {
+			goldmarkhtml.RenderAttributes(writer, list, goldmarkhtml.ListAttributeFilter)
+		}
+		_, _ = writer.WriteString(">\n")
+	} else {
+		_, _ = writer.WriteString("</")
+		_, _ = writer.WriteString(tag)
+		_, _ = writer.WriteString(">\n")
+	}
+	return goldmarkast.WalkContinue, nil
+}
+
+func (r *renditionHTMLRenderer) renderHTMLBlock(
+	writer util.BufWriter,
+	source []byte,
+	node goldmarkast.Node,
+	entering bool,
+) (goldmarkast.WalkStatus, error) {
+	block, ok := node.(*goldmarkast.HTMLBlock)
+	if !ok {
+		return goldmarkast.WalkStop, fmt.Errorf("render HTML block node: unexpected %T", node)
+	}
+	start := r.offset(writer)
+	if entering {
+		lines := block.Lines()
+		for index := range lines.Len() {
+			segment := lines.At(index)
+			goldmarkhtml.DefaultWriter.SecureWrite(writer, segment.Value(source))
+		}
+	} else if block.HasClosure() {
+		goldmarkhtml.DefaultWriter.SecureWrite(writer, block.ClosureLine.Value(source))
+	}
+	r.appendRawSpan(start, writer, false)
+	return goldmarkast.WalkContinue, nil
+}
+
+func (r *renditionHTMLRenderer) renderRawHTML(
+	writer util.BufWriter,
+	source []byte,
+	node goldmarkast.Node,
+	entering bool,
+) (goldmarkast.WalkStatus, error) {
+	if !entering {
+		return goldmarkast.WalkContinue, nil
+	}
+	raw, ok := node.(*goldmarkast.RawHTML)
+	if !ok {
+		return goldmarkast.WalkStop, fmt.Errorf("render raw HTML node: unexpected %T", node)
+	}
+	start := r.offset(writer)
+	for index := range raw.Segments.Len() {
+		segment := raw.Segments.At(index)
+		_, _ = writer.Write(segment.Value(source))
+	}
+	r.appendRawSpan(start, writer, true)
+	return goldmarkast.WalkSkipChildren, nil
+}
+
+func sanitizeMarkdownWithActiveHTML(
+	markdown string,
+	maxLinkChars, maxSourceBytes int,
+	dropActiveHTML bool,
+) (string, []canonicalHeadingMark, bool, error) {
 	if markdown == "" {
 		return "", nil, false, nil
 	}
@@ -306,7 +471,9 @@ func canonicalMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (strin
 	if err := parser.Convert([]byte(markdown), &rendered); err != nil {
 		return "", nil, false, fmt.Errorf("parse provider Markdown: %w", err)
 	}
-	writer := canonicalHTMLWriter{maxLinkChars: maxLinkChars}
+	writer := canonicalHTMLWriter{
+		maxLinkChars: maxLinkChars, dropActiveHTML: dropActiveHTML, escapeMarkdown: dropActiveHTML,
+	}
 	if err := writer.consume(bytes.NewReader(rendered.Bytes())); err != nil {
 		return "", nil, false, err
 	}
@@ -314,16 +481,1657 @@ func canonicalMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (strin
 	return text, headings, sourceTruncated, nil
 }
 
+type renditionBlockKind uint8
+
+const (
+	renditionParagraph renditionBlockKind = iota
+	renditionHeading
+	renditionCodeBlock
+	renditionTable
+	renditionListBlock
+)
+
+type renditionInlineKind uint8
+
+const (
+	renditionText renditionInlineKind = iota
+	renditionInlineCode
+	renditionLinkInline
+)
+
+type renditionInline struct {
+	kind        renditionInlineKind
+	text        string
+	destination string
+	children    []renditionInline
+}
+
+const maxRenditionInlineDepth = 64
+
+type renditionBlock struct {
+	kind     renditionBlockKind
+	level    int
+	inlines  []renditionInline
+	language string
+	code     string
+	rows     [][][]renditionInline
+	list     *renditionList
+}
+
+type renditionList struct {
+	ordered bool
+	start   string
+	tight   bool
+	items   []renditionListItem
+}
+
+type renditionListItem struct {
+	present bool
+	blocks  []renditionBlock
+}
+
+type renditionListFrame struct {
+	list      *renditionList
+	itemIndex int
+}
+
+// renditionHTMLWriter builds the safe rendition's semantic blocks before any
+// Markdown is emitted. Its output is intentionally separate from the frozen
+// canonicalHTMLWriter used by NormalizeDocument.
+type renditionHTMLWriter struct {
+	maxLinkChars   int
+	rawFragment    bool
+	blocks         []renditionBlock
+	listTightness  map[int]bool
+	renderedOffset int
+	currentKind    renditionBlockKind
+	currentLevel   int
+	current        []renditionInline
+	pendingSpace   bool
+
+	skipTag            string
+	skipDepth          int
+	inPre              bool
+	preInCell          bool
+	preLang            string
+	preText            strings.Builder
+	inlineCode         bool
+	inlineText         strings.Builder
+	ignoredLinkDepth   int
+	linkDepthTruncated bool
+
+	inTable          bool
+	inRow            bool
+	inCell           bool
+	nestedTableDepth int
+	tableListDepth   int
+	table            [][][]renditionInline
+	tableRow         [][]renditionInline
+	tableCell        []renditionInline
+	links            []renditionInline
+	lists            []renditionListFrame
+}
+
+func (w *renditionHTMLWriter) consumeFragments(rendered []byte, rawSpans []renditionRawSpan) error {
+	sort.Slice(rawSpans, func(left, right int) bool {
+		return rawSpans[left].start < rawSpans[right].start
+	})
+	pairRenditionRawActiveElements(rendered, rawSpans)
+	pairRenditionRawLinks(rendered, rawSpans, w.maxLinkChars)
+	offset := 0
+	activeDepth := 0
+	for _, span := range rawSpans {
+		if span.start < offset || span.end > len(rendered) {
+			continue
+		}
+		if span.start > offset {
+			if err := w.consumeFragment(rendered[offset:span.start], activeDepth > 0); err != nil {
+				return err
+			}
+		}
+		switch {
+		case span.startsActiveBody:
+			w.pendingSpace = false
+			activeDepth++
+		case span.endsActiveBody:
+			if activeDepth > 0 {
+				activeDepth--
+			}
+		case activeDepth > 0:
+			// Provider raw HTML inside an active element is not searchable evidence.
+		case span.linkDestination != "":
+			w.flushPendingSpace()
+			w.startLink(span.linkDestination)
+		case span.closesLink:
+			w.endTag("a")
+		default:
+			if err := w.consumeRawFragment(rendered[span.start:span.end], span.inline); err != nil {
+				return err
+			}
+		}
+		w.renderedOffset = span.end
+		offset = span.end
+	}
+	if offset < len(rendered) {
+		if err := w.consumeFragment(rendered[offset:], activeDepth > 0); err != nil {
+			return err
+		}
+	}
+	w.finalize()
+	return nil
+}
+
+func pairRenditionRawActiveElements(rendered []byte, spans []renditionRawSpan) {
+	type activeElement struct {
+		tag   string
+		index int
+	}
+	stack := make([]activeElement, 0)
+	for index := range spans {
+		span := &spans[index]
+		fragment := rendered[span.start:span.end]
+		if tag, ok := isolatedRawActiveStart(fragment); ok {
+			stack = append(stack, activeElement{tag: tag, index: index})
+			continue
+		}
+		tag, ok := isolatedRawActiveEnd(fragment)
+		if !ok || len(stack) == 0 {
+			continue
+		}
+		matching := len(stack) - 1
+		for matching >= 0 && stack[matching].tag != tag {
+			matching--
+		}
+		if matching < 0 {
+			continue
+		}
+		opening := stack[matching]
+		stack = stack[:matching]
+		spans[opening.index].startsActiveBody = true
+		span.endsActiveBody = true
+	}
+}
+
+func isolatedRawActiveStart(fragment []byte) (string, bool) {
+	fragment = bytes.TrimSpace(fragment)
+	tokenizer := html.NewTokenizer(bytes.NewReader(fragment))
+	tokenType := tokenizer.Next()
+	if tokenType != html.StartTagToken && tokenType != html.SelfClosingTagToken {
+		return "", false
+	}
+	tag := tokenizer.Token().Data
+	if !isRenditionActiveHTML(tag) || isHTMLVoidElement(tag) || tokenizer.Next() != html.ErrorToken ||
+		!errors.Is(tokenizer.Err(), io.EOF) {
+		return "", false
+	}
+	return tag, true
+}
+
+func isolatedRawActiveEnd(fragment []byte) (string, bool) {
+	fragment = bytes.TrimSpace(fragment)
+	tokenizer := html.NewTokenizer(bytes.NewReader(fragment))
+	if tokenizer.Next() != html.EndTagToken {
+		return "", false
+	}
+	tag := tokenizer.Token().Data
+	if !isRenditionActiveHTML(tag) || tokenizer.Next() != html.ErrorToken || !errors.Is(tokenizer.Err(), io.EOF) {
+		return "", false
+	}
+	return tag, true
+}
+
+func isRenditionActiveHTML(tag string) bool {
+	return tag == "script" || tag == "style" || tag == "svg" || isActiveHTML(tag)
+}
+
+func pairRenditionRawLinks(rendered []byte, spans []renditionRawSpan, maxLinkChars int) {
+	for index := 0; index+1 < len(spans); index++ {
+		opening := &spans[index]
+		closing := &spans[index+1]
+		if !opening.inline || !closing.inline {
+			continue
+		}
+		destination, ok := isolatedRawLinkStart(rendered[opening.start:opening.end], maxLinkChars)
+		if !ok || !isolatedRawLinkEnd(rendered[closing.start:closing.end]) ||
+			!isInlineGeneratedHTML(rendered[opening.end:closing.start]) {
+			continue
+		}
+		opening.linkDestination = destination
+		closing.closesLink = true
+		index++
+	}
+}
+
+func isolatedRawLinkStart(fragment []byte, maxLinkChars int) (string, bool) {
+	tokenizer := html.NewTokenizer(bytes.NewReader(fragment))
+	if tokenizer.Next() != html.StartTagToken {
+		return "", false
+	}
+	token := tokenizer.Token()
+	if token.Data != "a" || tokenizer.Next() != html.ErrorToken || !errors.Is(tokenizer.Err(), io.EOF) {
+		return "", false
+	}
+	for _, attribute := range token.Attr {
+		if attribute.Key == "href" {
+			destination := safeRenditionLink(attribute.Val, maxLinkChars)
+			return destination, destination != ""
+		}
+	}
+	return "", false
+}
+
+func isolatedRawLinkEnd(fragment []byte) bool {
+	tokenizer := html.NewTokenizer(bytes.NewReader(fragment))
+	if tokenizer.Next() != html.EndTagToken || tokenizer.Token().Data != "a" {
+		return false
+	}
+	return tokenizer.Next() == html.ErrorToken && errors.Is(tokenizer.Err(), io.EOF)
+}
+
+func isInlineGeneratedHTML(fragment []byte) bool {
+	tokenizer := html.NewTokenizer(bytes.NewReader(fragment))
+	for {
+		switch tokenizer.Next() {
+		case html.TextToken, html.CommentToken:
+			continue
+		case html.ErrorToken:
+			return errors.Is(tokenizer.Err(), io.EOF)
+		default:
+			return false
+		}
+	}
+}
+
+func (w *renditionHTMLWriter) consumeRawFragment(fragment []byte, inline bool) error {
+	raw := renditionHTMLWriter{maxLinkChars: w.maxLinkChars, rawFragment: true}
+	if err := raw.consumeFragment(fragment, false); err != nil {
+		return err
+	}
+	raw.finalize()
+	w.linkDepthTruncated = w.linkDepthTruncated || raw.linkDepthTruncated
+	raw.blocks = readableRawBlocks(raw.blocks)
+	if inline {
+		w.appendRawInlineBlocks(raw.blocks)
+		return nil
+	}
+	if len(raw.blocks) == 0 {
+		return nil
+	}
+	w.startBlockBoundary()
+	for _, block := range raw.blocks {
+		w.appendBlock(block)
+	}
+	return nil
+}
+
+func readableRawBlocks(blocks []renditionBlock) []renditionBlock {
+	readable := blocks[:0]
+	for _, block := range blocks {
+		switch block.kind {
+		case renditionParagraph, renditionHeading:
+			inlines := block.inlines[:0]
+			for _, inline := range block.inlines {
+				if inline.kind != renditionText && strings.TrimSpace(inline.text) == "" && len(inline.children) == 0 {
+					continue
+				}
+				inlines = append(inlines, inline)
+			}
+			block.inlines = inlines
+			if len(block.inlines) == 0 {
+				continue
+			}
+		case renditionCodeBlock:
+			if strings.TrimSpace(block.code) == "" {
+				continue
+			}
+		case renditionTable, renditionListBlock:
+			// Their child topology determines readability during serialization.
+		}
+		readable = append(readable, block)
+	}
+	return readable
+}
+
+func (w *renditionHTMLWriter) appendRawInlineBlocks(blocks []renditionBlock) {
+	for _, block := range blocks {
+		if w.targetHasContent() {
+			w.pendingSpace = true
+		}
+		switch block.kind {
+		case renditionParagraph, renditionHeading:
+			w.flushPendingSpace()
+			w.appendFlattenedInlines(block.inlines)
+		case renditionCodeBlock:
+			w.writeText(block.code)
+		case renditionTable:
+			for _, row := range block.rows {
+				for _, cell := range row {
+					w.flushPendingSpace()
+					w.appendFlattenedInlines(cell)
+					w.pendingSpace = true
+				}
+			}
+		case renditionListBlock:
+			if block.list != nil {
+				for _, item := range block.list.items {
+					w.appendRawInlineBlocks(item.blocks)
+				}
+			}
+		}
+	}
+}
+
+func (w *renditionHTMLWriter) consumeFragment(fragment []byte, suppressText bool) error {
+	tokenizer := html.NewTokenizer(bytes.NewReader(fragment))
+	for {
+		tokenType := tokenizer.Next()
+		tokenOffset := w.renderedOffset
+		w.renderedOffset += len(tokenizer.Raw())
+		switch tokenType {
+		case html.ErrorToken:
+			if errors.Is(tokenizer.Err(), io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("tokenize rendition HTML: %w", tokenizer.Err())
+		case html.TextToken:
+			if w.skipDepth == 0 && !suppressText {
+				w.writeText(string(tokenizer.Text()))
+			}
+		case html.StartTagToken:
+			w.startTag(tokenizer.Token(), tokenOffset, suppressText)
+		case html.SelfClosingTagToken:
+			w.startTag(tokenizer.Token(), tokenOffset, suppressText)
+		case html.EndTagToken:
+			w.endTag(tokenizer.Token().Data)
+		case html.CommentToken, html.DoctypeToken:
+			// Not searchable evidence.
+		}
+	}
+}
+
+func (w *renditionHTMLWriter) finalize() {
+	if w.inlineCode {
+		w.appendInline(renditionInline{kind: renditionInlineCode, text: stripUnsafeControls(w.inlineText.String())})
+		w.inlineCode = false
+	}
+	if w.inPre {
+		w.endTag("pre")
+	}
+	w.closeLinks()
+	w.nestedTableDepth = 0
+	if w.inCell {
+		w.endTag("td")
+	}
+	if w.inTable {
+		if w.inRow {
+			w.endTag("tr")
+		}
+		w.endTag("table")
+	}
+	w.finishBlock()
+}
+
+func (w *renditionHTMLWriter) startTag(token html.Token, tokenOffset int, suppressText bool) {
+	tag := token.Data
+	if w.skipDepth > 0 {
+		if tag == w.skipTag {
+			w.skipDepth++
+		}
+		return
+	}
+	if tag == "input" && !w.rawFragment && !suppressText {
+		if marker, ok := parserGeneratedCheckboxMarker(token); ok {
+			w.writeText(marker)
+			return
+		}
+	}
+	if isRenditionActiveHTML(tag) {
+		if !isHTMLVoidElement(tag) {
+			w.skipTag = tag
+			w.skipDepth = 1
+		}
+		return
+	}
+	if w.nestedTableDepth > 0 {
+		switch tag {
+		case "table":
+			w.nestedTableDepth++
+			w.pendingSpace = true
+			return
+		case "thead", "tbody", "tfoot", "tr", "td", "th":
+			w.pendingSpace = true
+			return
+		}
+	}
+	switch tag {
+	case "ul", "ol":
+		if w.inTable {
+			w.pendingSpace = true
+			w.tableListDepth++
+			return
+		}
+		w.startBlockBoundary()
+		start := "1"
+		tight := true
+		if parserTightness, ok := w.listTightness[tokenOffset]; ok {
+			tight = parserTightness
+		}
+		if tag == "ol" {
+			for _, attribute := range token.Attr {
+				if attribute.Key == "start" {
+					if parsed, ok := canonicalNonnegativeDecimal(attribute.Val); ok {
+						start = parsed
+					}
+				}
+			}
+		}
+		list := &renditionList{ordered: tag == "ol", start: start, tight: tight}
+		w.appendBlock(renditionBlock{kind: renditionListBlock, list: list})
+		w.lists = append(w.lists, renditionListFrame{list: list, itemIndex: -1})
+	case "table":
+		if w.inTable {
+			w.nestedTableDepth = 1
+			w.pendingSpace = true
+			return
+		}
+		w.startBlockBoundary()
+		w.inTable = true
+		w.inRow = false
+		w.table = nil
+	case "thead", "tbody", "tfoot":
+		// Table row and cell tokens carry the retained structure.
+	case "tr":
+		if w.inTable {
+			if w.inRow {
+				w.endTag("tr")
+			}
+			w.inRow = true
+			w.tableRow = nil
+		}
+	case "td", "th":
+		if w.inTable {
+			if w.inCell {
+				w.endTag("td")
+			}
+			if !w.inRow {
+				w.inRow = true
+				w.tableRow = nil
+			}
+			w.inCell = true
+			w.tableCell = nil
+		}
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		w.startBlock(renditionHeading, int(tag[1]-'0'))
+	case "li":
+		if w.inTable {
+			w.pendingSpace = true
+			return
+		}
+		w.startListItem()
+	case "p", "div", "article", "section", "header", "footer", "main", "aside", "figure", "figcaption", "blockquote":
+		if tag == "p" && len(w.lists) > 0 && w.lists[len(w.lists)-1].itemIndex >= 0 {
+			w.lists[len(w.lists)-1].list.tight = false
+		}
+		w.startBlock(renditionParagraph, 0)
+	case "br":
+		w.pendingSpace = true
+	case "pre":
+		if !w.inCell {
+			w.closeLinks()
+			w.startBlockBoundary()
+		}
+		w.inPre = true
+		w.preInCell = w.inCell
+		w.preLang = ""
+		w.preText.Reset()
+	case "code":
+		if w.inPre {
+			for _, attribute := range token.Attr {
+				if attribute.Key == "class" && strings.HasPrefix(attribute.Val, "language-") {
+					w.preLang = safeCodeLanguage(strings.TrimPrefix(attribute.Val, "language-"))
+				}
+			}
+			return
+		}
+		w.flushPendingSpace()
+		w.inlineCode = true
+		w.inlineText.Reset()
+	case "img":
+		if suppressText {
+			return
+		}
+		for _, attribute := range token.Attr {
+			if attribute.Key == "alt" {
+				w.writeText(attribute.Val)
+				break
+			}
+		}
+	case "a":
+		w.flushPendingSpace()
+		destination := ""
+		for _, attribute := range token.Attr {
+			if attribute.Key == "href" {
+				destination = safeRenditionLink(attribute.Val, w.maxLinkChars)
+				break
+			}
+		}
+		w.startLink(destination)
+	default:
+		if isHTMLBlockElement(tag) {
+			w.startBlock(renditionParagraph, 0)
+		}
+	}
+}
+
+func parserGeneratedCheckboxMarker(token html.Token) (string, bool) {
+	checkbox, checked := false, false
+	for _, attribute := range token.Attr {
+		switch attribute.Key {
+		case "type":
+			checkbox = attribute.Val == "checkbox"
+		case "checked":
+			checked = true
+		}
+	}
+	if !checkbox {
+		return "", false
+	}
+	if checked {
+		return "[x] ", true
+	}
+	return "[ ] ", true
+}
+
+func (w *renditionHTMLWriter) endTag(tag string) {
+	if w.skipDepth > 0 {
+		if tag == w.skipTag {
+			w.skipDepth--
+			if w.skipDepth == 0 {
+				w.skipTag = ""
+			}
+		}
+		return
+	}
+	if w.nestedTableDepth > 0 {
+		switch tag {
+		case "table":
+			w.nestedTableDepth--
+			w.pendingSpace = true
+			return
+		case "thead", "tbody", "tfoot", "tr", "td", "th":
+			w.pendingSpace = true
+			return
+		}
+	}
+	switch tag {
+	case "ul", "ol":
+		if w.inTable {
+			if w.tableListDepth > 0 {
+				w.tableListDepth--
+			}
+			return
+		}
+		w.closeLinks()
+		w.finishBlock()
+		if len(w.lists) > 0 {
+			w.lists = w.lists[:len(w.lists)-1]
+		}
+	case "h1", "h2", "h3", "h4", "h5", "h6", "li", "p", "div", "article", "section", "header", "footer", "main", "aside", "figure", "figcaption", "blockquote":
+		if tag == "li" && w.inTable {
+			return
+		}
+		w.finishBlock()
+		if tag == "li" && len(w.lists) > 0 {
+			w.lists[len(w.lists)-1].itemIndex = -1
+		}
+	case "tr":
+		if w.inTable && w.inRow {
+			if w.inCell {
+				w.endTag("td")
+			}
+			w.table = append(w.table, append([][]renditionInline(nil), w.tableRow...))
+			w.tableRow = nil
+			w.inRow = false
+		}
+	case "td", "th":
+		if w.inTable && w.inCell {
+			w.flushPendingSpace()
+			w.tableRow = append(w.tableRow, append([]renditionInline(nil), w.tableCell...))
+			w.tableCell = nil
+			w.inCell = false
+		}
+	case "table":
+		if w.inTable {
+			if w.inCell {
+				w.endTag("td")
+			}
+			if w.inRow {
+				w.endTag("tr")
+			}
+			w.inTable = false
+			w.inRow = false
+			w.nestedTableDepth = 0
+			w.tableListDepth = 0
+			if len(w.table) > 0 {
+				w.appendBlock(renditionBlock{kind: renditionTable, rows: w.table})
+			}
+			w.table = nil
+		}
+	case "pre":
+		if w.inPre {
+			content := stripUnsafeControls(w.preText.String())
+			if w.preInCell {
+				w.appendInline(renditionInline{kind: renditionInlineCode, text: strings.Join(strings.Fields(content), " ")})
+			} else {
+				w.appendBlock(renditionBlock{kind: renditionCodeBlock, language: w.preLang, code: content})
+			}
+			w.inPre = false
+			w.preInCell = false
+			w.preLang = ""
+			w.preText.Reset()
+		}
+	case "code":
+		if !w.inPre && w.inlineCode {
+			w.appendInline(renditionInline{kind: renditionInlineCode, text: stripUnsafeControls(w.inlineText.String())})
+			w.inlineCode = false
+			w.inlineText.Reset()
+		}
+	case "a":
+		if w.ignoredLinkDepth > 0 {
+			w.ignoredLinkDepth--
+			return
+		}
+		if len(w.links) == 0 {
+			return
+		}
+		link := w.links[len(w.links)-1]
+		w.links = w.links[:len(w.links)-1]
+		if link.destination == "" {
+			w.appendFlattenedInlines(link.children)
+			return
+		}
+		w.appendInline(link)
+	}
+}
+
+func (w *renditionHTMLWriter) startLink(destination string) {
+	if w.ignoredLinkDepth > 0 || len(w.links) >= maxRenditionInlineDepth {
+		w.ignoredLinkDepth++
+		w.linkDepthTruncated = true
+		return
+	}
+	w.links = append(w.links, renditionInline{kind: renditionLinkInline, destination: destination})
+}
+
+func (w *renditionHTMLWriter) writeText(value string) {
+	value = stripUnsafeControls(value)
+	if w.inPre {
+		w.preText.WriteString(value)
+		return
+	}
+	if w.inlineCode {
+		w.inlineText.WriteString(value)
+		return
+	}
+	var chunk strings.Builder
+	flushChunk := func() {
+		if chunk.Len() == 0 {
+			return
+		}
+		w.appendText(chunk.String())
+		chunk.Reset()
+	}
+	for _, character := range value {
+		if unicode.IsSpace(character) {
+			flushChunk()
+			w.pendingSpace = true
+			continue
+		}
+		if w.pendingSpace {
+			flushChunk()
+			w.flushPendingSpace()
+		}
+		chunk.WriteRune(character)
+	}
+	flushChunk()
+}
+
+func (w *renditionHTMLWriter) startBlock(kind renditionBlockKind, level int) {
+	if w.inTable {
+		w.pendingSpace = true
+		return
+	}
+	w.closeLinks()
+	w.finishBlock()
+	w.currentKind = kind
+	w.currentLevel = level
+}
+
+func (w *renditionHTMLWriter) startListItem() {
+	w.closeLinks()
+	w.finishBlock()
+	if len(w.lists) == 0 {
+		w.currentKind = renditionParagraph
+		return
+	}
+	frame := &w.lists[len(w.lists)-1]
+	frame.list.items = append(frame.list.items, renditionListItem{present: true})
+	frame.itemIndex = len(frame.list.items) - 1
+	w.currentKind = renditionParagraph
+}
+
+func (w *renditionHTMLWriter) startBlockBoundary() {
+	if !w.inTable {
+		w.closeLinks()
+		w.finishBlock()
+	}
+}
+
+func (w *renditionHTMLWriter) finishBlock() {
+	w.flushPendingSpace()
+	if len(w.current) > 0 {
+		w.appendBlock(renditionBlock{kind: w.currentKind, level: w.currentLevel, inlines: w.current})
+	}
+	w.current = nil
+	w.currentKind = renditionParagraph
+	w.currentLevel = 0
+	w.pendingSpace = false
+}
+
+func (w *renditionHTMLWriter) closeLinks() {
+	for len(w.links) > 0 {
+		link := w.links[len(w.links)-1]
+		w.links = w.links[:len(w.links)-1]
+		w.appendFlattenedInlines(link.children)
+	}
+}
+
+func (w *renditionHTMLWriter) appendBlock(block renditionBlock) {
+	if len(w.lists) > 0 {
+		frame := &w.lists[len(w.lists)-1]
+		if frame.itemIndex >= 0 {
+			item := &frame.list.items[frame.itemIndex]
+			item.blocks = append(item.blocks, block)
+			return
+		}
+	}
+	w.blocks = append(w.blocks, block)
+}
+
+func (w *renditionHTMLWriter) appendFlattenedInlines(inlines []renditionInline) {
+	for _, inline := range inlines {
+		switch inline.kind {
+		case renditionText, renditionInlineCode:
+			w.appendText(inline.text)
+		case renditionLinkInline:
+			w.appendFlattenedInlines(inline.children)
+		}
+	}
+}
+
+func (w *renditionHTMLWriter) flushPendingSpace() {
+	if w.pendingSpace && w.targetHasContent() {
+		w.appendText(" ")
+	}
+	w.pendingSpace = false
+}
+
+func (w *renditionHTMLWriter) targetHasContent() bool {
+	if len(w.links) > 0 {
+		return len(w.links[len(w.links)-1].children) > 0
+	}
+	if w.inCell {
+		return len(w.tableCell) > 0
+	}
+	return len(w.current) > 0
+}
+
+func (w *renditionHTMLWriter) appendText(value string) {
+	if value == "" {
+		return
+	}
+	w.appendInline(renditionInline{kind: renditionText, text: value})
+}
+
+func (w *renditionHTMLWriter) appendInline(inline renditionInline) {
+	if len(w.links) > 0 {
+		last := len(w.links) - 1
+		w.links[last].children = appendRenditionInline(w.links[last].children, inline)
+		return
+	}
+	if w.inCell {
+		w.tableCell = appendRenditionInline(w.tableCell, inline)
+		return
+	}
+	w.current = appendRenditionInline(w.current, inline)
+}
+
+func appendRenditionInline(target []renditionInline, inline renditionInline) []renditionInline {
+	return append(target, inline)
+}
+
+type renditionBuilder struct {
+	strings.Builder
+
+	runes int
+}
+
+func (b *renditionBuilder) WriteString(value string) {
+	b.Builder.WriteString(value)
+	b.runes += utf8.RuneCountInString(value)
+}
+
+func serializeRenditionBlocks(blocks []renditionBlock, limit int) (string, bool) {
+	var output renditionBuilder
+	truncated := false
+	previousList := false
+	previousListOrdered := false
+	previousListAlternate := false
+	previousKind := renditionParagraph
+	for _, block := range blocks {
+		separator := ""
+		listAlternate := false
+		if output.Len() > 0 {
+			separator = "\n"
+			if previousKind == renditionParagraph && block.kind == renditionParagraph ||
+				previousKind == renditionTable && block.kind == renditionTable ||
+				previousKind == renditionListBlock && block.kind == renditionParagraph ||
+				previousKind == renditionParagraph && block.kind == renditionListBlock && block.list != nil &&
+					block.list.ordered && block.list.start != "1" {
+				separator = "\n\n"
+			}
+			if previousList && block.kind == renditionListBlock && block.list != nil &&
+				block.list.ordered == previousListOrdered {
+				listAlternate = !previousListAlternate
+			}
+		}
+		available := limit - output.runes - utf8.RuneCountInString(separator)
+		if available < 0 {
+			return finishRenditionMarkdown(output.String()), true
+		}
+		value, blockTruncated := serializeRenditionBlock(block, available, listAlternate)
+		if value == "" && blockTruncated {
+			return finishRenditionMarkdown(output.String()), true
+		}
+		if value != "" {
+			output.WriteString(separator)
+			output.WriteString(value)
+			previousKind = block.kind
+			previousList = block.kind == renditionListBlock && block.list != nil
+			if previousList {
+				previousListOrdered = block.list.ordered
+				previousListAlternate = listAlternate
+			}
+		}
+		if blockTruncated {
+			truncated = true
+			break
+		}
+	}
+	return finishRenditionMarkdown(output.String()), truncated
+}
+
+func finishRenditionMarkdown(value string) string {
+	return strings.TrimRight(value, "\n")
+}
+
+func canonicalNonnegativeDecimal(value string) (string, bool) {
+	value = strings.TrimPrefix(value, "+")
+	if value == "" {
+		return "", false
+	}
+	for _, character := range value {
+		if character < '0' || character > '9' {
+			return "", false
+		}
+	}
+	value = strings.TrimLeft(value, "0")
+	if value == "" {
+		return "0", true
+	}
+	return value, true
+}
+
+func incrementNonnegativeDecimal(value string) string {
+	digits := []byte(value)
+	for index := len(digits) - 1; index >= 0; index-- {
+		if digits[index] < '9' {
+			digits[index]++
+			return string(digits)
+		}
+		digits[index] = '0'
+	}
+	return "1" + string(digits)
+}
+
+func serializeRenditionBlock(block renditionBlock, available int, listAlternate bool) (string, bool) {
+	switch block.kind {
+	case renditionCodeBlock:
+		value := serializeRenditionCodeBlock(block.language, block.code)
+		if utf8.RuneCountInString(value) > available {
+			return "", true
+		}
+		return value, false
+	case renditionTable:
+		value := serializeRenditionTable(block.rows)
+		if utf8.RuneCountInString(value) > available {
+			return "", true
+		}
+		return value, false
+	case renditionListBlock:
+		if block.list == nil {
+			return "", false
+		}
+		return serializeRenditionList(*block.list, available, listAlternate)
+	case renditionParagraph, renditionHeading:
+		prefix := ""
+		switch block.kind {
+		case renditionParagraph:
+			// Paragraphs have no generated block marker.
+		case renditionHeading:
+			prefix = strings.Repeat("#", block.level) + " "
+		case renditionCodeBlock, renditionTable, renditionListBlock:
+			return "", false
+		}
+		if utf8.RuneCountInString(prefix) > available {
+			return "", true
+		}
+		value, truncated := serializeRenditionInlines(block.inlines, available-utf8.RuneCountInString(prefix), false)
+		if value == "" && truncated {
+			return "", true
+		}
+		return prefix + value, truncated
+	default:
+		return "", false
+	}
+}
+
+func serializeRenditionList(list renditionList, available int, alternate bool) (string, bool) {
+	var output renditionBuffer
+	result := appendRenditionList(&output, list, available, 0, alternate)
+	return output.String(), result.truncated
+}
+
+type renditionListResult struct {
+	truncated        bool
+	emitted          int
+	contentIndent    int
+	looseFallback    renditionBufferCheckpoint
+	hasLooseFallback bool
+}
+
+type renditionSerializedItemRange struct {
+	ordinal string
+	start   int
+	end     int
+}
+
+func appendRenditionList(
+	output *renditionBuffer,
+	list renditionList,
+	limit int,
+	indent int,
+	alternate bool,
+) renditionListResult {
+	start := output.checkpoint()
+	var result renditionListResult
+	if list.ordered && len(list.start) <= maxOrderedListMarkerDigits {
+		result = appendRepresentableOrderedListItems(output, list, limit, indent, alternate)
+	} else {
+		result = appendRenditionListItems(output, list, limit, indent, alternate, list.ordered)
+	}
+	if list.tight || result.emitted != 1 {
+		return result
+	}
+	looseBoundary := renditionLooseBoundary(result.contentIndent)
+	if output.runes+utf8.RuneCountInString(looseBoundary) > limit {
+		if !result.hasLooseFallback {
+			output.rollback(start.bytes, start.runes)
+			return renditionListResult{truncated: true}
+		}
+		output.rollback(result.looseFallback.bytes, result.looseFallback.runes)
+		result.truncated = true
+	}
+	output.WriteString(looseBoundary)
+	return result
+}
+
+func renditionLooseBoundary(contentIndent int) string {
+	return "\n\n" + strings.Repeat(" ", contentIndent) + "<!-- -->"
+}
+
+func appendRepresentableOrderedListItems(
+	output *renditionBuffer,
+	list renditionList,
+	limit int,
+	indent int,
+	alternate bool,
+) renditionListResult {
+	listStart := output.checkpoint()
+	entries := make([]renditionSerializedItemRange, 0, len(list.items))
+	result := renditionListResult{}
+	ordinal := list.start
+	degraded := false
+	var fallback []byte
+	fallbackRunes := 0
+	for _, item := range list.items {
+		if !item.present {
+			continue
+		}
+		if !degraded && len(ordinal) > maxOrderedListMarkerDigits {
+			fallback = append([]byte(nil), output.bytes[listStart.bytes:]...)
+			fallbackRunes = output.runes - listStart.runes
+			var converted renditionBuffer
+			for index, entry := range entries {
+				if index > 0 {
+					converted.WriteString(renditionListItemSeparator(list.tight))
+				}
+				converted.WriteString(degradeOrderedListItem(serializedOrderedListItem{
+					ordinal: entry.ordinal,
+					value:   string(output.bytes[entry.start:entry.end]),
+				}, indent, alternate))
+			}
+			output.rollback(listStart.bytes, listStart.runes)
+			output.WriteString(converted.String())
+			if output.runes > limit {
+				output.rollback(listStart.bytes, listStart.runes)
+				output.WriteBytes(fallback, fallbackRunes)
+				result.truncated = true
+				return result
+			}
+			degraded = true
+		}
+
+		itemStart := output.checkpoint()
+		if result.emitted > 0 {
+			output.WriteString(renditionListItemSeparator(list.tight))
+		}
+		marker := ordinal + "."
+		if alternate {
+			marker = ordinal + ")"
+		}
+		labelPrefix := ""
+		if degraded {
+			marker = "-"
+			if alternate {
+				marker = "*"
+			}
+			labelPrefix = ordinal + "\\. "
+		}
+		itemFallback := newRenditionLooseItemFallback(list, limit, indent, marker, result.emitted, output.runes)
+		valueStart := len(output.bytes)
+		wrote, truncated := appendRenditionListItem(output, item, limit, indent, marker, labelPrefix, itemFallback)
+		if !wrote {
+			output.rollback(itemStart.bytes, itemStart.runes)
+			if fallback != nil {
+				output.rollback(listStart.bytes, listStart.runes)
+				output.WriteBytes(fallback, fallbackRunes)
+			}
+			result.truncated = true
+			return result
+		}
+		if !degraded {
+			entries = append(entries, renditionSerializedItemRange{ordinal: ordinal, start: valueStart, end: len(output.bytes)})
+		}
+		fallback = nil
+		result.emitted++
+		if result.emitted == 1 {
+			result.contentIndent = indent + utf8.RuneCountInString(marker) + 1
+			result.looseFallback, result.hasLooseFallback = itemFallback.result()
+		}
+		if truncated {
+			result.truncated = true
+			return result
+		}
+		ordinal = incrementNonnegativeDecimal(ordinal)
+	}
+	return result
+}
+
+func appendRenditionListItems(
+	output *renditionBuffer,
+	list renditionList,
+	limit int,
+	indent int,
+	alternate bool,
+	degraded bool,
+) renditionListResult {
+	result := renditionListResult{}
+	ordinal := list.start
+	for _, item := range list.items {
+		if !item.present {
+			continue
+		}
+		itemStart := output.checkpoint()
+		if result.emitted > 0 {
+			output.WriteString(renditionListItemSeparator(list.tight))
+		}
+		marker := "-"
+		if alternate {
+			marker = "*"
+		}
+		labelPrefix := ""
+		if list.ordered && !degraded {
+			marker = ordinal + "."
+			if alternate {
+				marker = ordinal + ")"
+			}
+		} else if list.ordered {
+			labelPrefix = ordinal + "\\. "
+		}
+		itemFallback := newRenditionLooseItemFallback(list, limit, indent, marker, result.emitted, output.runes)
+		wrote, truncated := appendRenditionListItem(output, item, limit, indent, marker, labelPrefix, itemFallback)
+		if !wrote {
+			output.rollback(itemStart.bytes, itemStart.runes)
+			result.truncated = true
+			return result
+		}
+		result.emitted++
+		if result.emitted == 1 {
+			result.contentIndent = indent + utf8.RuneCountInString(marker) + 1
+			result.looseFallback, result.hasLooseFallback = itemFallback.result()
+		}
+		if truncated {
+			result.truncated = true
+			return result
+		}
+		if list.ordered {
+			ordinal = incrementNonnegativeDecimal(ordinal)
+		}
+	}
+	return result
+}
+
+func newRenditionLooseItemFallback(
+	list renditionList,
+	limit int,
+	indent int,
+	marker string,
+	emitted int,
+	itemStartRunes int,
+) *renditionBufferFallback {
+	if list.tight || emitted != 0 {
+		return nil
+	}
+	contentIndent := indent + utf8.RuneCountInString(marker) + 1
+	return &renditionBufferFallback{
+		limit:    limit - utf8.RuneCountInString(renditionLooseBoundary(contentIndent)),
+		minRunes: itemStartRunes,
+	}
+}
+
+func appendRenditionListItem(
+	output *renditionBuffer,
+	item renditionListItem,
+	limit int,
+	indent int,
+	marker string,
+	labelPrefix string,
+	fallback *renditionBufferFallback,
+) (bool, bool) {
+	start := output.checkpoint()
+	markerLine := strings.Repeat(" ", indent) + marker
+	markerAnchor := markerLine
+	if labelPrefix != "" {
+		markerAnchor += " " + strings.TrimSuffix(labelPrefix, " ")
+	}
+	contentIndent := indent + utf8.RuneCountInString(marker) + 1
+	if len(item.blocks) == 0 {
+		if output.runes+utf8.RuneCountInString(markerAnchor) > limit {
+			return false, true
+		}
+		output.WriteString(markerAnchor)
+		fallback.mark(output)
+		return true, false
+	}
+	previousList := false
+	previousListOrdered := false
+	previousListAlternate := false
+	previousListIndent := contentIndent
+	for _, block := range item.blocks {
+		separator := ""
+		listAlternate := false
+		listIndent := contentIndent
+		if output.runes > start.runes {
+			if block.kind == renditionListBlock {
+				separator = "\n"
+				if previousList {
+					listIndent = previousListIndent
+				}
+				if block.list != nil && previousList && block.list.ordered == previousListOrdered {
+					listAlternate = !previousListAlternate
+				} else if block.list != nil && !previousList && block.list.ordered && block.list.start != "1" {
+					separator = "\n\n"
+				}
+			} else {
+				separator = "\n\n"
+			}
+		}
+
+		if block.kind == renditionListBlock {
+			if block.list == nil {
+				continue
+			}
+			if output.runes == start.runes {
+				if block.list.ordered && block.list.start != "1" {
+					listIndent += 2
+				}
+				if output.runes+utf8.RuneCountInString(markerAnchor) > limit {
+					return false, true
+				}
+				output.WriteString(markerAnchor)
+				if output.runes+1 > limit {
+					return true, true
+				}
+				separator = "\n"
+			}
+			separatorStart := output.checkpoint()
+			if output.runes+utf8.RuneCountInString(separator) > limit {
+				return output.runes > start.runes, true
+			}
+			output.WriteString(separator)
+			nestedStartRunes := output.runes
+			result := appendRenditionList(output, *block.list, limit, listIndent, listAlternate)
+			if output.runes == nestedStartRunes {
+				output.rollback(separatorStart.bytes, separatorStart.runes)
+				return output.runes > start.runes, result.truncated
+			}
+			previousList = true
+			previousListOrdered = block.list.ordered
+			previousListAlternate = listAlternate
+			previousListIndent = listIndent
+			fallback.mark(output)
+			if result.truncated {
+				return true, true
+			}
+			continue
+		}
+
+		separatorStart := output.checkpoint()
+		if output.runes+utf8.RuneCountInString(separator) > limit {
+			return output.runes > start.runes, true
+		}
+		output.WriteString(separator)
+		firstPrefix := strings.Repeat(" ", contentIndent)
+		if output.runes == start.runes {
+			firstPrefix = markerLine + " " + labelPrefix
+		}
+		wrote, truncated := appendRenditionItemBlock(
+			output, block, limit, firstPrefix, strings.Repeat(" ", contentIndent), fallback,
+		)
+		if !wrote {
+			output.rollback(separatorStart.bytes, separatorStart.runes)
+		}
+		if !wrote && truncated {
+			return output.runes > start.runes, true
+		}
+		if wrote {
+			previousList = false
+		}
+		if truncated {
+			return output.runes > start.runes, true
+		}
+	}
+	return output.runes > start.runes, false
+}
+
+const maxOrderedListMarkerDigits = 9
+
+type serializedOrderedListItem struct {
+	ordinal string
+	value   string
+}
+
+func renditionListItemSeparator(tight bool) string {
+	if tight {
+		return "\n"
+	}
+	return "\n\n"
+}
+
+func degradeOrderedListItem(item serializedOrderedListItem, indent int, alternate bool) string {
+	normalMarker := item.ordinal + "."
+	degradedMarker := "-"
+	if alternate {
+		normalMarker = item.ordinal + ")"
+		degradedMarker = "*"
+	}
+	normalPrefix := strings.Repeat(" ", indent) + normalMarker
+	degradedPrefix := strings.Repeat(" ", indent) + degradedMarker + " " + item.ordinal + "\\."
+	lines := strings.Split(item.value, "\n")
+	lines[0] = degradedPrefix + strings.TrimPrefix(lines[0], normalPrefix)
+	normalIndent := strings.Repeat(" ", indent+utf8.RuneCountInString(normalMarker)+1)
+	degradedIndent := strings.Repeat(" ", indent+2)
+	for index := 1; index < len(lines); index++ {
+		if after, ok := strings.CutPrefix(lines[index], normalIndent); ok {
+			lines[index] = degradedIndent + after
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func appendRenditionItemBlock(
+	output *renditionBuffer,
+	block renditionBlock,
+	limit int,
+	firstPrefix string,
+	continuationPrefix string,
+	fallback *renditionBufferFallback,
+) (bool, bool) {
+	start := output.checkpoint()
+	if block.kind == renditionParagraph || block.kind == renditionHeading {
+		if block.kind == renditionHeading {
+			firstPrefix += strings.Repeat("#", block.level) + " "
+		}
+		prefixRunes := utf8.RuneCountInString(firstPrefix)
+		if output.runes+prefixRunes > limit {
+			return false, true
+		}
+		output.WriteString(firstPrefix)
+		inlineStart := output.checkpoint()
+		truncated := appendRenditionInlinesWithFallback(
+			output, block.inlines, limit-output.runes, false, fallback,
+		)
+		if output.runes == inlineStart.runes && truncated {
+			output.rollback(start.bytes, start.runes)
+			return false, true
+		}
+		fallback.mark(output)
+		return true, truncated
+	}
+
+	var value string
+	switch block.kind {
+	case renditionCodeBlock:
+		value = serializeRenditionCodeBlock(block.language, block.code)
+	case renditionTable:
+		value = serializeRenditionTable(block.rows)
+	default:
+		return false, false
+	}
+	value = prefixRenditionLines(value, firstPrefix, continuationPrefix)
+	if output.runes+utf8.RuneCountInString(value) > limit {
+		return false, true
+	}
+	output.WriteString(value)
+	fallback.mark(output)
+	return true, false
+}
+
+func prefixRenditionLines(value, firstPrefix, continuationPrefix string) string {
+	return firstPrefix + strings.ReplaceAll(value, "\n", "\n"+continuationPrefix)
+}
+
+func serializeRenditionInlines(inlines []renditionInline, available int, inTable bool) (string, bool) {
+	var output renditionBuffer
+	truncated := appendRenditionInlines(&output, inlines, available, inTable)
+	return output.String(), truncated
+}
+
+type renditionBuffer struct {
+	bytes []byte
+	runes int
+}
+
+type renditionBufferCheckpoint struct {
+	bytes int
+	runes int
+}
+
+type renditionBufferFallback struct {
+	limit      int
+	minRunes   int
+	checkpoint renditionBufferCheckpoint
+	valid      bool
+}
+
+func (f *renditionBufferFallback) mark(output *renditionBuffer) {
+	if f == nil || output.runes <= f.minRunes || output.runes > f.limit {
+		return
+	}
+	f.checkpoint = output.checkpoint()
+	f.valid = true
+}
+
+func (f *renditionBufferFallback) markEscapedText(
+	start renditionBufferCheckpoint,
+	value string,
+) {
+	if f == nil || start.runes >= f.limit {
+		return
+	}
+	prefix := truncateEscapedRenditionText(value, f.limit-start.runes)
+	if prefix == "" {
+		return
+	}
+	f.checkpoint = renditionBufferCheckpoint{
+		bytes: start.bytes + len(prefix),
+		runes: start.runes + utf8.RuneCountInString(prefix),
+	}
+	f.valid = true
+}
+
+func (f *renditionBufferFallback) result() (renditionBufferCheckpoint, bool) {
+	if f == nil {
+		return renditionBufferCheckpoint{}, false
+	}
+	return f.checkpoint, f.valid
+}
+
+func (b *renditionBuffer) WriteString(value string) {
+	b.bytes = append(b.bytes, value...)
+	b.runes += utf8.RuneCountInString(value)
+}
+
+func (b *renditionBuffer) WriteBytes(value []byte, runes int) {
+	b.bytes = append(b.bytes, value...)
+	b.runes += runes
+}
+
+func (b *renditionBuffer) String() string {
+	return string(b.bytes)
+}
+
+func (b *renditionBuffer) rollback(bytes, runes int) {
+	b.bytes = b.bytes[:bytes]
+	b.runes = runes
+}
+
+func (b *renditionBuffer) checkpoint() renditionBufferCheckpoint {
+	return renditionBufferCheckpoint{bytes: len(b.bytes), runes: b.runes}
+}
+
+func appendRenditionInlines(
+	output *renditionBuffer,
+	inlines []renditionInline,
+	available int,
+	inTable bool,
+) bool {
+	return appendRenditionInlinesWithFallback(output, inlines, available, inTable, nil)
+}
+
+func appendRenditionInlinesWithFallback(
+	output *renditionBuffer,
+	inlines []renditionInline,
+	available int,
+	inTable bool,
+	fallback *renditionBufferFallback,
+) bool {
+	startRunes := output.runes
+	for _, inline := range inlines {
+		if inline.kind == renditionLinkInline && inline.destination == "" {
+			remaining := available
+			if available >= 0 {
+				remaining -= output.runes - startRunes
+			}
+			if appendRenditionInlinesWithFallback(output, inline.children, remaining, inTable, fallback) {
+				return true
+			}
+			continue
+		}
+		remaining := available
+		if available >= 0 {
+			remaining -= output.runes - startRunes
+		}
+		switch inline.kind {
+		case renditionText:
+			textStart := output.checkpoint()
+			value := escapeRenditionText(inline.text)
+			if available >= 0 && utf8.RuneCountInString(value) > remaining {
+				output.WriteString(truncateEscapedRenditionText(inline.text, max(0, remaining)))
+				fallback.markEscapedText(textStart, inline.text)
+				return true
+			}
+			output.WriteString(value)
+			fallback.markEscapedText(textStart, inline.text)
+		case renditionInlineCode:
+			value := serializeRenditionInlineCode(inline.text, inTable)
+			if available >= 0 && utf8.RuneCountInString(value) > remaining {
+				return true
+			}
+			output.WriteString(value)
+			fallback.mark(output)
+		case renditionLinkInline:
+			overhead := utf8.RuneCountInString(inline.destination) + 4
+			if available >= 0 && overhead > remaining {
+				return true
+			}
+			markBytes, markRunes := len(output.bytes), output.runes
+			output.WriteString("[")
+			labelStart := output.runes
+			labelBudget := -1
+			if available >= 0 {
+				labelBudget = remaining - overhead
+			}
+			if appendRenditionInlinesWithFallback(output, inline.children, labelBudget, inTable, nil) {
+				output.rollback(markBytes, markRunes)
+				return true
+			}
+			if output.runes == labelStart {
+				output.rollback(markBytes, markRunes)
+				continue
+			}
+			output.WriteString("](")
+			output.WriteString(inline.destination)
+			output.WriteString(")")
+			fallback.mark(output)
+		}
+	}
+	return false
+}
+
+func escapeRenditionText(value string) string {
+	var output strings.Builder
+	for _, character := range value {
+		if isMarkdownASCIIPunctuation(character) {
+			output.WriteByte('\\')
+		}
+		output.WriteRune(character)
+	}
+	return output.String()
+}
+
+func truncateEscapedRenditionText(value string, limit int) string {
+	var output strings.Builder
+	used := 0
+	for _, character := range value {
+		cost := 1
+		if isMarkdownASCIIPunctuation(character) {
+			cost++
+		}
+		if used+cost > limit {
+			break
+		}
+		if cost == 2 {
+			output.WriteByte('\\')
+		}
+		output.WriteRune(character)
+		used += cost
+	}
+	return output.String()
+}
+
+func isMarkdownASCIIPunctuation(character rune) bool {
+	return character >= '!' && character <= '/' || character >= ':' && character <= '@' ||
+		character >= '[' && character <= '`' || character >= '{' && character <= '~'
+}
+
+func serializeRenditionInlineCode(content string, inTable bool) string {
+	content = strings.ReplaceAll(strings.ReplaceAll(content, "\r\n", " "), "\n", " ")
+	if inTable {
+		content = strings.ReplaceAll(content, "|", "\\|")
+	}
+	fence := strings.Repeat("`", maxBacktickRun(content)+1)
+	if strings.HasPrefix(content, "`") || strings.HasSuffix(content, "`") {
+		content = " " + content + " "
+	}
+	return fence + content + fence
+}
+
+func serializeRenditionCodeBlock(language, content string) string {
+	fence := strings.Repeat("`", max(3, maxBacktickRun(content)+1))
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	return fence + language + "\n" + content + fence
+}
+
+func serializeRenditionTable(rows [][][]renditionInline) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	columns := 0
+	for _, row := range rows {
+		columns = max(columns, len(row))
+	}
+	if columns == 0 {
+		return ""
+	}
+	format := func(row [][]renditionInline) string {
+		cells := make([]string, columns)
+		for index, cell := range row {
+			cells[index], _ = serializeRenditionInlines(cell, -1, true)
+		}
+		return "| " + strings.Join(cells, " | ") + " |"
+	}
+	delimiter := make([]string, columns)
+	for index := range delimiter {
+		delimiter[index] = "---"
+	}
+	lines := []string{format(rows[0]), "| " + strings.Join(delimiter, " | ") + " |"}
+	for _, row := range rows[1:] {
+		lines = append(lines, format(row))
+	}
+	return strings.Join(lines, "\n")
+}
+
 type canonicalHTMLWriter struct {
-	output       strings.Builder
-	maxLinkChars int
-	inPre        bool
-	skipTag      string
-	skipDepth    int
-	cellIndex    int
-	links        []string
-	preFenceOpen bool
-	pendingSpace bool
+	output         strings.Builder
+	maxLinkChars   int
+	inPre          bool
+	skipTag        string
+	skipDepth      int
+	cellIndex      int
+	links          []string
+	renditionLinks []*renditionLink
+	preFenceOpen   bool
+	pendingSpace   bool
+	dropActiveHTML bool
+	escapeMarkdown bool
+	preLanguage    string
+	preContent     strings.Builder
+	inlineCode     bool
+	inlineContent  strings.Builder
+	inTable        bool
+	inTableCell    bool
+	tableRows      [][]string
+	tableRow       []string
+	tableCell      strings.Builder
+}
+
+type renditionLink struct {
+	destination string
+	text        strings.Builder
 }
 
 func (w *canonicalHTMLWriter) consume(reader io.Reader) error {
@@ -364,6 +2172,13 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 		w.skipDepth = 1
 		return
 	}
+	if w.dropActiveHTML && isActiveHTML(tag) {
+		if !selfClosing && !isHTMLVoidElement(tag) {
+			w.skipTag = tag
+			w.skipDepth = 1
+		}
+		return
+	}
 	if tag == "svg" {
 		if !selfClosing {
 			w.skipTag = tag
@@ -372,6 +2187,14 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 		return
 	}
 	switch tag {
+	case "table":
+		if w.escapeMarkdown {
+			w.block()
+			w.inTable = true
+			w.tableRows = nil
+			return
+		}
+		w.block()
 	case "h1", "h2", "h3", "h4", "h5", "h6":
 		w.block()
 		level := int(tag[1] - '0')
@@ -383,15 +2206,31 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 	case "br":
 		w.line()
 	case "tr":
+		if w.escapeMarkdown && w.inTable {
+			w.tableRow = nil
+			return
+		}
 		w.line()
 		w.cellIndex = 0
 	case "td", "th":
+		if w.escapeMarkdown && w.inTable {
+			w.inTableCell = true
+			w.tableCell.Reset()
+			return
+		}
 		if w.cellIndex > 0 {
 			w.output.WriteString(" | ")
 		}
 		w.cellIndex++
 	case "pre":
 		w.block()
+		if w.escapeMarkdown {
+			w.inPre = true
+			w.preFenceOpen = true
+			w.preLanguage = ""
+			w.preContent.Reset()
+			return
+		}
 		w.output.WriteString("```")
 		w.inPre = true
 		w.preFenceOpen = true
@@ -400,15 +2239,26 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 			for _, attribute := range token.Attr {
 				if attribute.Key == "class" && strings.HasPrefix(attribute.Val, "language-") {
 					if language := safeCodeLanguage(strings.TrimPrefix(attribute.Val, "language-")); language != "" {
-						w.output.WriteString(language)
+						if w.escapeMarkdown {
+							w.preLanguage = language
+						} else {
+							w.output.WriteString(language)
+						}
 					}
 				}
 			}
-			w.output.WriteByte('\n')
+			if !w.escapeMarkdown {
+				w.output.WriteByte('\n')
+			}
 			w.preFenceOpen = false
 		} else if !w.inPre {
 			w.flushPendingSpace()
-			w.output.WriteByte('`')
+			if w.escapeMarkdown {
+				w.inlineCode = true
+				w.inlineContent.Reset()
+			} else {
+				w.output.WriteByte('`')
+			}
 		}
 	case "img":
 		for _, attribute := range token.Attr {
@@ -437,10 +2287,26 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 			}
 		}
 	case "a":
+		if w.escapeMarkdown {
+			w.flushPendingSpace()
+			link := ""
+			for _, attribute := range token.Attr {
+				if attribute.Key == "href" {
+					link = safeRenditionLink(attribute.Val, w.maxLinkChars)
+					break
+				}
+			}
+			w.renditionLinks = append(w.renditionLinks, &renditionLink{destination: link})
+			return
+		}
 		link := ""
 		for _, attribute := range token.Attr {
 			if attribute.Key == "href" {
-				link = safeStoredLink(attribute.Val, w.maxLinkChars)
+				if w.escapeMarkdown {
+					link = safeRenditionLink(attribute.Val, w.maxLinkChars)
+				} else {
+					link = safeStoredLink(attribute.Val, w.maxLinkChars)
+				}
 				break
 			}
 		}
@@ -449,6 +2315,24 @@ func (w *canonicalHTMLWriter) startTag(token html.Token, selfClosing bool) {
 		if isHTMLBlockElement(tag) {
 			w.block()
 		}
+	}
+}
+
+func isActiveHTML(tag string) bool {
+	switch tag {
+	case "applet", "audio", "button", "embed", "form", "iframe", "input", "object", "select", "textarea", "video":
+		return true
+	default:
+		return false
+	}
+}
+
+func isHTMLVoidElement(tag string) bool {
+	switch tag {
+	case "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -467,9 +2351,40 @@ func (w *canonicalHTMLWriter) endTag(tag string) {
 		w.flushPendingSpace()
 		w.output.WriteString(headingMarkerClose)
 		w.block()
-	case "li", "tr":
+	case "li":
 		w.line()
+	case "tr":
+		if w.escapeMarkdown && w.inTable {
+			w.tableRows = append(w.tableRows, append([]string(nil), w.tableRow...))
+			return
+		}
+		w.line()
+	case "td", "th":
+		if w.escapeMarkdown && w.inTable && w.inTableCell {
+			w.tableRow = append(w.tableRow, w.tableCell.String())
+			w.tableCell.Reset()
+			w.inTableCell = false
+			return
+		}
+	case "table":
+		if w.escapeMarkdown && w.inTable {
+			w.inTable = false
+			w.writeRenditionRaw(serializeGFMTable(w.tableRows))
+			w.tableRows = nil
+			w.block()
+			return
+		}
+		w.block()
 	case "pre":
+		if w.escapeMarkdown {
+			w.writeSafeCodeFence(w.preLanguage, w.preContent.String())
+			w.inPre = false
+			w.preFenceOpen = false
+			w.preLanguage = ""
+			w.preContent.Reset()
+			w.block()
+			return
+		}
 		if w.preFenceOpen {
 			w.output.WriteByte('\n')
 		}
@@ -481,9 +2396,28 @@ func (w *canonicalHTMLWriter) endTag(tag string) {
 	case "code":
 		if !w.inPre {
 			w.flushPendingSpace()
-			w.output.WriteByte('`')
+			if w.escapeMarkdown {
+				w.writeSafeInlineCode(w.inlineContent.String())
+				w.inlineCode = false
+				w.inlineContent.Reset()
+			} else {
+				w.output.WriteByte('`')
+			}
 		}
 	case "a":
+		if w.escapeMarkdown {
+			if len(w.renditionLinks) == 0 {
+				return
+			}
+			link := w.renditionLinks[len(w.renditionLinks)-1]
+			w.renditionLinks = w.renditionLinks[:len(w.renditionLinks)-1]
+			if link.destination == "" {
+				w.writeRenditionRaw(link.text.String())
+			} else {
+				w.writeRenditionRaw("[" + link.text.String() + "](" + link.destination + ")")
+			}
+			return
+		}
 		w.flushPendingSpace()
 		if len(w.links) == 0 {
 			return
@@ -531,11 +2465,19 @@ func isHTMLBlockElement(tag string) bool {
 
 func (w *canonicalHTMLWriter) writeText(value string) {
 	if w.inPre {
+		if w.escapeMarkdown {
+			w.preContent.WriteString(stripUnsafeControls(value))
+			return
+		}
 		if w.preFenceOpen {
 			w.output.WriteByte('\n')
 			w.preFenceOpen = false
 		}
 		w.output.WriteString(stripUnsafeControls(value))
+		return
+	}
+	if w.inlineCode {
+		w.inlineContent.WriteString(stripUnsafeControls(value))
 		return
 	}
 	value = stripUnsafeControls(value)
@@ -545,11 +2487,111 @@ func (w *canonicalHTMLWriter) writeText(value string) {
 			continue
 		}
 		w.flushPendingSpace()
-		w.output.WriteRune(character)
+		w.writeMarkdownRune(character)
 	}
 }
 
+func (w *canonicalHTMLWriter) writeMarkdownRune(character rune) {
+	if w.escapeMarkdown && strings.ContainsRune("\\\\`*_{}[]<>#!|~", character) {
+		w.writeRenditionRaw("\\")
+	}
+	if w.escapeMarkdown {
+		w.writeRenditionRaw(string(character))
+		return
+	}
+	w.output.WriteRune(character)
+}
+
+func (w *canonicalHTMLWriter) writeRenditionRaw(value string) {
+	if len(w.renditionLinks) > 0 {
+		w.renditionLinks[len(w.renditionLinks)-1].text.WriteString(value)
+		return
+	}
+	if w.inTableCell {
+		w.tableCell.WriteString(value)
+		return
+	}
+	w.output.WriteString(value)
+}
+
+func (w *canonicalHTMLWriter) writeSafeInlineCode(content string) {
+	fence := strings.Repeat("`", maxBacktickRun(content)+1)
+	w.writeRenditionRaw(fence)
+	if strings.HasPrefix(content, "`") || strings.HasSuffix(content, "`") {
+		w.writeRenditionRaw(" ")
+	}
+	w.writeRenditionRaw(content)
+	if strings.HasPrefix(content, "`") || strings.HasSuffix(content, "`") {
+		w.writeRenditionRaw(" ")
+	}
+	w.writeRenditionRaw(fence)
+}
+
+func serializeGFMTable(rows [][]string) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	columns := 0
+	for _, row := range rows {
+		columns = max(columns, len(row))
+	}
+	if columns == 0 {
+		return ""
+	}
+	format := func(row []string) string {
+		cells := make([]string, columns)
+		copy(cells, row)
+		return "| " + strings.Join(cells, " | ") + " |"
+	}
+	delimiter := make([]string, columns)
+	for index := range delimiter {
+		delimiter[index] = "---"
+	}
+	lines := []string{format(rows[0]), "| " + strings.Join(delimiter, " | ") + " |"}
+	for _, row := range rows[1:] {
+		lines = append(lines, format(row))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (w *canonicalHTMLWriter) writeSafeCodeFence(language, content string) {
+	if w.inTableCell {
+		w.writeSafeInlineCode(strings.ReplaceAll(strings.Join(strings.Fields(content), " "), "|", "\\|"))
+		return
+	}
+	fence := strings.Repeat("`", max(3, maxBacktickRun(content)+1))
+	w.writeRenditionRaw(fence)
+	w.writeRenditionRaw(language)
+	w.writeRenditionRaw("\n")
+	w.writeRenditionRaw(content)
+	if !strings.HasSuffix(content, "\n") {
+		w.writeRenditionRaw("\n")
+	}
+	w.writeRenditionRaw(fence)
+}
+
+func maxBacktickRun(value string) int {
+	maximum := 0
+	current := 0
+	for _, character := range value {
+		if character == '`' {
+			current++
+			maximum = max(maximum, current)
+		} else {
+			current = 0
+		}
+	}
+	return maximum
+}
+
 func (w *canonicalHTMLWriter) flushPendingSpace() {
+	if w.escapeMarkdown {
+		if w.pendingSpace && w.renditionTargetHasContent() {
+			w.writeRenditionRaw(" ")
+		}
+		w.pendingSpace = false
+		return
+	}
 	if w.pendingSpace && w.output.Len() > 0 &&
 		!strings.HasSuffix(w.output.String(), "\n") && !strings.HasSuffix(w.output.String(), " ") {
 		w.output.WriteByte(' ')
@@ -557,7 +2599,21 @@ func (w *canonicalHTMLWriter) flushPendingSpace() {
 	w.pendingSpace = false
 }
 
+func (w *canonicalHTMLWriter) renditionTargetHasContent() bool {
+	if len(w.renditionLinks) > 0 {
+		return w.renditionLinks[len(w.renditionLinks)-1].text.Len() > 0
+	}
+	if w.inTableCell {
+		return w.tableCell.Len() > 0
+	}
+	return w.output.Len() > 0 && !strings.HasSuffix(w.output.String(), "\n")
+}
+
 func (w *canonicalHTMLWriter) line() {
+	if w.escapeMarkdown && w.inTable {
+		w.pendingSpace = false
+		return
+	}
 	w.pendingSpace = false
 	if w.output.Len() > 0 && !strings.HasSuffix(w.output.String(), "\n") {
 		w.output.WriteByte('\n')
@@ -565,6 +2621,10 @@ func (w *canonicalHTMLWriter) line() {
 }
 
 func (w *canonicalHTMLWriter) block() {
+	if w.escapeMarkdown && w.inTable {
+		w.pendingSpace = false
+		return
+	}
 	w.line()
 	if w.output.Len() > 0 && !strings.HasSuffix(w.output.String(), "\n\n") {
 		w.output.WriteByte('\n')
@@ -599,6 +2659,47 @@ func safeStoredLink(value string, maxChars int) string {
 		return ""
 	}
 	return parsed.String()
+}
+
+func safeRenditionLink(value string, maxChars int) string {
+	if hasStructuralLinkCharacter(value) {
+		return ""
+	}
+	stored := safeStoredLink(value, maxChars)
+	if stored == "" {
+		return ""
+	}
+	if hasStructuralLinkCharacter(stored) {
+		return ""
+	}
+	return "<" + encodeRenditionURL(stored) + ">"
+}
+
+func encodeRenditionURL(value string) string {
+	var output strings.Builder
+	for _, byteValue := range []byte(value) {
+		if (byteValue >= 'a' && byteValue <= 'z') || (byteValue >= 'A' && byteValue <= 'Z') ||
+			(byteValue >= '0' && byteValue <= '9') || strings.ContainsRune(":/?&=#%@;,+-.", rune(byteValue)) {
+			output.WriteByte(byteValue)
+			continue
+		}
+		_, _ = fmt.Fprintf(&output, "%%%02X", byteValue)
+	}
+	return output.String()
+}
+
+func hasStructuralLinkCharacter(value string) bool {
+	for range 4 {
+		if strings.ContainsAny(value, "<>[]\\`") {
+			return true
+		}
+		decoded := html.UnescapeString(value)
+		if decoded == value {
+			return false
+		}
+		value = decoded
+	}
+	return strings.ContainsAny(value, "<>[]\\`")
 }
 
 type canonicalHeadingMark struct {

--- a/document/normalize.go
+++ b/document/normalize.go
@@ -1994,6 +1994,7 @@ func appendRenditionInlinesWithFallback(
 		case renditionLinkInline:
 			overhead := utf8.RuneCountInString(inline.destination) + 4
 			if available >= 0 && overhead > remaining {
+				appendRenditionPlainLabel(output, inline.children, remaining, fallback)
 				return true
 			}
 			markBytes, markRunes := len(output.bytes), output.runes
@@ -2005,6 +2006,7 @@ func appendRenditionInlinesWithFallback(
 			}
 			if appendRenditionInlinesWithFallback(output, inline.children, labelBudget, inTable, nil) {
 				output.rollback(markBytes, markRunes)
+				appendRenditionPlainLabel(output, inline.children, remaining, fallback)
 				return true
 			}
 			if output.runes == labelStart {
@@ -2015,6 +2017,38 @@ func appendRenditionInlinesWithFallback(
 			output.WriteString(inline.destination)
 			output.WriteString(")")
 			fallback.mark(output)
+		}
+	}
+	return false
+}
+
+func appendRenditionPlainLabel(
+	output *renditionBuffer,
+	inlines []renditionInline,
+	available int,
+	fallback *renditionBufferFallback,
+) bool {
+	startRunes := output.runes
+	for _, inline := range inlines {
+		remaining := available
+		if available >= 0 {
+			remaining -= output.runes - startRunes
+		}
+		switch inline.kind {
+		case renditionText, renditionInlineCode:
+			textStart := output.checkpoint()
+			value := escapeRenditionText(inline.text)
+			if available >= 0 && utf8.RuneCountInString(value) > remaining {
+				output.WriteString(truncateEscapedRenditionText(inline.text, max(0, remaining)))
+				fallback.markEscapedText(textStart, inline.text)
+				return true
+			}
+			output.WriteString(value)
+			fallback.markEscapedText(textStart, inline.text)
+		case renditionLinkInline:
+			if appendRenditionPlainLabel(output, inline.children, remaining, fallback) {
+				return true
+			}
 		}
 	}
 	return false

--- a/document/normalize_test.go
+++ b/document/normalize_test.go
@@ -65,6 +65,20 @@ package synthetic
 	assert.Regexp(`^[0-9a-f]{64}$`, normalized.Checksum)
 }
 
+func TestNormalizeDocumentKeepsFrozenTableBoundaries(t *testing.T) {
+	normalized, err := NormalizeDocument(SourceDocument{
+		Family: "text", UnitKind: "section", Units: []SourceUnit{{
+			Index: 0, Markdown: "before<table><tr><td>x</td></tr></table>after",
+		}},
+	}, testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	require.Len(t, normalized.Units, 1)
+	assert.Equal(t, "before\nx\nafter", normalized.Units[0].Text)
+	assert.Equal(t, "a8a611c408751feacca74b4da4d7842bfd0833e8ffe20406073a9b5c38c6a644", normalized.Units[0].Checksum)
+	assert.Equal(t, "31a205248e1b22cd02ded0386ad37ba1684ff7afa7c6820411d7f71334106546", normalized.Checksum)
+}
+
 func TestNormalizeDocumentRejectsZeroPolicy(t *testing.T) {
 	source := SourceDocument{
 		Family: "text", UnitKind: "section",

--- a/document/rendition.go
+++ b/document/rendition.go
@@ -1,0 +1,87 @@
+package document
+
+import (
+	"errors"
+	"fmt"
+)
+
+// RenditionContractV1 identifies the durable, sanitized rendition contract.
+const RenditionContractV1 = "rendition/v1"
+
+// RenditionPolicy binds rendition construction to the frozen document
+// normalization limits.
+type RenditionPolicy struct {
+	normalization NormalizePolicy
+}
+
+// NewRenditionPolicy returns a policy whose bounds match the supplied document
+// normalization policy.
+func NewRenditionPolicy(normalization NormalizePolicy) (RenditionPolicy, error) {
+	if err := normalization.validate(); err != nil {
+		return RenditionPolicy{}, fmt.Errorf("rendition normalization policy: %w", err)
+	}
+	return RenditionPolicy{normalization: normalization}, nil
+}
+
+func (p RenditionPolicy) validate() error {
+	if err := p.normalization.validate(); err != nil {
+		return fmt.Errorf("rendition policy: %w", err)
+	}
+	return nil
+}
+
+// RenditionWarningV1 records a non-fatal loss of source provenance while
+// retaining sanitized readable evidence.
+type RenditionWarningV1 struct {
+	Code string
+}
+
+// NormalizedUnitV1 is one sanitized text unit with a stable link to its
+// canonical evidence unit.
+type NormalizedUnitV1 struct {
+	Checksum       string
+	EvidenceUnitID string
+	HeadingPath    []string
+	ID             string
+	Locator        EvidenceLocatorV1
+	Order          int
+	Text           string
+}
+
+// LexicalSegmentV1 is one model-independent, half-open rune span in a
+// normalized rendition unit.
+type LexicalSegmentV1 struct {
+	CharEnd   int
+	CharStart int
+	Checksum  string
+	ID        string
+	Order     int
+	Text      string
+	UnitID    string
+}
+
+// RenditionV1 contains every durable output derived from the same normalized
+// evidence walk. Checksum covers the complete rendition manifest; Markdown and
+// its checksum are retained independently for blob storage.
+type RenditionV1 struct {
+	Checksum         string
+	Completeness     EvidenceCompleteness
+	ContractVersion  string
+	EvidenceChecksum string
+	LexicalSegments  []LexicalSegmentV1
+	Markdown         []byte
+	MarkdownChecksum string
+	Units            []NormalizedUnitV1
+	Warnings         []RenditionWarningV1
+}
+
+func validateRenditionPolicy(policy RenditionPolicy) error {
+	if err := policy.validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func invalidRenditionError(reason string) error {
+	return errors.New("invalid rendition: " + reason)
+}

--- a/document/rendition_normalize.go
+++ b/document/rendition_normalize.go
@@ -1,0 +1,126 @@
+package document
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// BuildRenditionV1 derives sanitized Markdown, normalized units, and lexical
+// spans from exactly one validated normalized-evidence/v1 authority.
+func BuildRenditionV1(evidence NormalizedEvidenceV1, policy RenditionPolicy) (RenditionV1, error) {
+	if err := validateRenditionPolicy(policy); err != nil {
+		return RenditionV1{}, err
+	}
+	_, evidenceChecksum, err := MarshalNormalizedEvidenceV1(evidence)
+	if err != nil {
+		return RenditionV1{}, fmt.Errorf("validate rendition evidence: %w", err)
+	}
+
+	result := RenditionV1{
+		Completeness:     evidence.Completeness,
+		ContractVersion:  RenditionContractV1,
+		EvidenceChecksum: evidenceChecksum,
+		Units:            make([]NormalizedUnitV1, 0, len(evidence.Units)),
+	}
+	if evidence.Completeness == EvidenceDegradedProvenance {
+		result.Warnings = []RenditionWarningV1{{Code: "degraded_provenance"}}
+	}
+
+	markdownUnits := make([]string, 0, len(evidence.Units))
+	remaining := policy.normalization.maxDocumentChars
+	truncated := false
+	for _, evidenceUnit := range evidence.Units {
+		separatorBudget := 0
+		if len(markdownUnits) > 0 {
+			separatorBudget = utf8.RuneCountInString("\n\n---\n\n")
+		}
+		unitBudget := min(policy.normalization.maxUnitChars, max(remaining-separatorBudget, 0))
+		text, sourceTruncated, renditionTruncated, err := sanitizeRenditionMarkdown(
+			evidenceUnit.Text,
+			policy.normalization.maxLinkChars,
+			policy.normalization.maxSourceUnitBytes,
+			unitBudget,
+		)
+		if err != nil {
+			return RenditionV1{}, fmt.Errorf("render evidence unit %d: %w", evidenceUnit.Order, err)
+		}
+		truncated = truncated || sourceTruncated || renditionTruncated
+		unit := normalizedRenditionUnit(evidenceUnit, text)
+		result.Units = append(result.Units, unit)
+		if text != "" {
+			remaining = max(0, remaining-separatorBudget)
+			remaining = max(0, remaining-utf8.RuneCountInString(text))
+			markdownUnits = append(markdownUnits, text)
+			result.LexicalSegments = append(result.LexicalSegments, lexicalSegment(unit, len(result.LexicalSegments)))
+		}
+	}
+	if truncated {
+		result.Warnings = append(result.Warnings, RenditionWarningV1{Code: "truncated"})
+	}
+
+	if len(markdownUnits) == 0 {
+		return RenditionV1{}, invalidRenditionError("evidence produced no readable text")
+	}
+	result.Markdown = []byte(strings.Join(markdownUnits, "\n\n---\n\n") + "\n")
+	result.MarkdownChecksum = checksumBytes(result.Markdown)
+	result.Checksum = renditionChecksum(result)
+	return result, nil
+}
+
+func normalizedRenditionUnit(evidenceUnit NormalizedEvidenceUnitV1, text string) NormalizedUnitV1 {
+	unit := NormalizedUnitV1{
+		EvidenceUnitID: evidenceUnit.ID,
+		HeadingPath:    append([]string(nil), evidenceUnit.HeadingPath...),
+		Locator:        evidenceUnit.Locator,
+		Order:          evidenceUnit.Order,
+		Text:           text,
+	}
+	unit.Checksum = checksumStrings(
+		RenditionContractV1, unit.EvidenceUnitID, strconv.Itoa(unit.Order), unit.Text,
+		strings.Join(unit.HeadingPath, "\x00"),
+		string(unit.Locator.Kind), string(unit.Locator.IndexOrigin),
+		strconv.FormatInt(unit.Locator.Start, 10), strconv.FormatInt(unit.Locator.End, 10), unit.Locator.Name,
+	)
+	unit.ID = "rendition_unit_" + unit.Checksum
+	return unit
+}
+
+func lexicalSegment(unit NormalizedUnitV1, order int) LexicalSegmentV1 {
+	segment := LexicalSegmentV1{
+		CharEnd: utf8.RuneCountInString(unit.Text),
+		Order:   order,
+		Text:    unit.Text,
+		UnitID:  unit.ID,
+	}
+	segment.Checksum = checksumStrings(
+		RenditionContractV1, unit.ID, strconv.Itoa(segment.Order),
+		strconv.Itoa(segment.CharStart), strconv.Itoa(segment.CharEnd), segment.Text,
+	)
+	segment.ID = "lexical_segment_" + segment.Checksum
+	return segment
+}
+
+func renditionChecksum(rendition RenditionV1) string {
+	parts := []string{
+		RenditionContractV1, rendition.EvidenceChecksum, string(rendition.Completeness), rendition.MarkdownChecksum,
+	}
+	for _, unit := range rendition.Units {
+		parts = append(parts, unit.Checksum)
+	}
+	for _, segment := range rendition.LexicalSegments {
+		parts = append(parts, segment.Checksum)
+	}
+	for _, warning := range rendition.Warnings {
+		parts = append(parts, warning.Code)
+	}
+	return checksumStrings(parts...)
+}
+
+func checksumBytes(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}

--- a/document/rendition_normalize_test.go
+++ b/document/rendition_normalize_test.go
@@ -213,6 +213,23 @@ func TestBuildRenditionV1DropsGeneratedTextInsideActiveHTML(t *testing.T) {
 	assert.NotContains(t, html, "[x]")
 }
 
+func TestBuildRenditionV1DoesNotEmitStructuresOpenedInsideActiveHTML(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{name: "list", source: "<iframe>\n\n- hidden\n\n</iframe>"},
+		{name: "table", source: "<iframe>\n\n| h |\n| --- |\n| hidden |\n\n</iframe>"},
+		{name: "code", source: "<iframe>\n\n```text\nhidden\n```\n\n</iframe>"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := buildRenditionMarkdownResultForTest(t, test.source, 100_000)
+
+			require.ErrorContains(t, err, "evidence produced no readable text")
+		})
+	}
+}
+
 func TestBuildRenditionV1TreatsSelfClosingActiveSyntaxAsAnOpener(t *testing.T) {
 	for _, tag := range []string{"script", "iframe"} {
 		t.Run(tag, func(t *testing.T) {

--- a/document/rendition_normalize_test.go
+++ b/document/rendition_normalize_test.go
@@ -1748,6 +1748,27 @@ func TestBuildRenditionV1PrefixTruncatesRejectedLinkLabels(t *testing.T) {
 	}
 }
 
+func TestBuildRenditionV1PrefixTruncatesSafeLinkLabels(t *testing.T) {
+	const source = `<a href="https://example.test/safe">a*b</a>`
+	const full = `[a\*b](<https://example.test/safe>)`
+	for _, test := range []struct {
+		name  string
+		limit int
+		want  string
+	}{
+		{name: "one rune", limit: 1, want: "a"},
+		{name: "before escaped punctuation", limit: 2, want: "a"},
+		{name: "escaped punctuation", limit: 3, want: `a\*`},
+		{name: "below complete link", limit: len(full) - 1, want: `a\*b`},
+		{name: "complete link", limit: len(full), want: full},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rendered := buildRenditionMarkdownForTest(t, source, test.limit)
+			assert.Equal(t, test.want+"\n", string(rendered.Markdown))
+		})
+	}
+}
+
 func assertTruncatedRenditionIsInert(t *testing.T, evidence NormalizedEvidenceV1, normalization NormalizePolicy) {
 	t.Helper()
 	policy, err := NewRenditionPolicy(normalization)

--- a/document/rendition_normalize_test.go
+++ b/document/rendition_normalize_test.go
@@ -1,0 +1,1834 @@
+package document
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	extensionast "github.com/yuin/goldmark/extension/ast"
+	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
+)
+
+func TestBuildRenditionV1(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "pdf",
+		UnitKind:        EvidenceUnitPage,
+		Units: []SourceEvidenceUnitV1{
+			{
+				Order: 0,
+				Locator: SourceEvidenceLocatorV1{
+					Kind: EvidenceLocatorPage, IndexOrigin: EvidenceIndexOriginOne, Start: 1, End: 1,
+				},
+				Text: "# Damage report\n\nThe carton was **crushed**. [Safe](https://example.test/report?id=42) and [unsafe](javascript:alert(1)).\n\n![Photo evidence](data:image/png;base64,AAAA)\n\n| Item | Count |\n| --- | ---: |\n| Carton | 3 |\n| Pallet | 1 |\n\n<script>private_executable_marker()</script>\n<style>.hidden { display: none }</style>\n\n## Inspection\n\n- First edge\n- Second edge\n\n~~~go\npackage synthetic\n~~~",
+			},
+			{
+				Order: 1,
+				Locator: SourceEvidenceLocatorV1{
+					Kind: EvidenceLocatorPage, IndexOrigin: EvidenceIndexOriginOne, Start: 2, End: 2,
+				},
+				Text: "# Follow-up\n\n[Allowed](https://example.test/follow-up)\n\n<iframe src=\"https://example.test/active\">active_markup()</iframe>",
+			},
+		},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	again, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	assert.Equal(t, rendered, again)
+
+	want, err := os.ReadFile("testdata/rendition-v1.golden.md")
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(rendered.Markdown))
+	assert.Equal(t, RenditionContractV1, rendered.ContractVersion)
+	assert.Equal(t, evidence.Checksum, rendered.EvidenceChecksum)
+	assert.Equal(t, EvidenceComplete, rendered.Completeness)
+	assert.Empty(t, rendered.Warnings)
+	assert.NotEmpty(t, rendered.Checksum)
+	assert.NotEmpty(t, rendered.MarkdownChecksum)
+	require.Len(t, rendered.Units, 2)
+	require.Len(t, rendered.LexicalSegments, 2)
+
+	for index, segment := range rendered.LexicalSegments {
+		unit := rendered.Units[index]
+		assert.Equal(t, unit.ID, segment.UnitID)
+		assert.Equal(t, index, segment.Order)
+		assert.Equal(t, string([]rune(unit.Text)[segment.CharStart:segment.CharEnd]), segment.Text)
+		assert.Equal(t, utf8.RuneCountInString(segment.Text), segment.CharEnd-segment.CharStart)
+		assert.NotEmpty(t, segment.Checksum)
+	}
+
+	markdown := string(rendered.Markdown)
+	assert.Contains(t, markdown, "# Damage report")
+	assert.Contains(t, markdown, "- First edge")
+	assert.Contains(t, markdown, "| Item | Count |\n| --- | --- |")
+	assert.Contains(t, markdown, "```go\npackage synthetic\n```")
+	assert.Contains(t, markdown, "\n\n---\n\n")
+	assert.Contains(t, markdown, "[Safe](<https://example.test/report?id=42>)")
+	assert.NotContains(t, markdown, "private_executable_marker")
+	assert.NotContains(t, markdown, "display: none")
+	assert.NotContains(t, markdown, "data:image")
+	assert.NotContains(t, markdown, "javascript:")
+	assert.NotContains(t, markdown, "active_markup")
+	assert.NotContains(t, markdown, "<iframe")
+	assert.Contains(t, renderUnsafeMarkdown(t, rendered.Markdown), "<table>")
+}
+
+func TestNormalizedRenditionUnitChecksumIncludesEveryLocatorField(t *testing.T) {
+	evidenceUnit := NormalizedEvidenceUnitV1{
+		ID: "evidence_unit_test",
+		Locator: EvidenceLocatorV1{
+			Kind: EvidenceLocatorLine, IndexOrigin: EvidenceIndexOriginOne,
+			Start: 1, End: 2, Name: "range-a",
+		},
+	}
+	wantDifferentFrom := normalizedRenditionUnit(evidenceUnit, "text").Checksum
+
+	for _, test := range []struct {
+		name   string
+		mutate func(*EvidenceLocatorV1)
+	}{
+		{name: "kind", mutate: func(locator *EvidenceLocatorV1) { locator.Kind = EvidenceLocatorRecord }},
+		{name: "index origin", mutate: func(locator *EvidenceLocatorV1) { locator.IndexOrigin = EvidenceIndexOriginZero }},
+		{name: "start", mutate: func(locator *EvidenceLocatorV1) { locator.Start = 2 }},
+		{name: "end", mutate: func(locator *EvidenceLocatorV1) { locator.End = 3 }},
+		{name: "name", mutate: func(locator *EvidenceLocatorV1) { locator.Name = "range-b" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := evidenceUnit
+			test.mutate(&changed.Locator)
+
+			assert.NotEqual(t, wantDifferentFrom, normalizedRenditionUnit(changed, "text").Checksum)
+		})
+	}
+}
+
+func TestBuildRenditionV1DegradesGenericUnitsWithoutInventingProvenance(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceDegradedProvenance,
+		Family:          "text",
+		UnitKind:        EvidenceUnitGeneric,
+		Omissions: []SourceEvidenceOmissionV1{{
+			Field: "provenance", Kind: EvidenceOmissionField, Reason: "source has no natural units",
+		}},
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorGeneric, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    "plain **synthetic** text",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, "plain synthetic text\n", string(rendered.Markdown))
+	require.Len(t, rendered.Warnings, 1)
+	assert.Equal(t, "degraded_provenance", rendered.Warnings[0].Code)
+	assert.NotContains(t, string(rendered.Markdown), "page")
+}
+
+func normalizeRenditionEvidence(t *testing.T, source SourceEvidenceV1) NormalizedEvidenceV1 {
+	t.Helper()
+	policy, err := NewEvidencePolicy(100_000)
+	require.NoError(t, err)
+	evidence, err := NormalizeEvidenceV1(source, policy)
+	require.NoError(t, err)
+	return evidence
+}
+
+func TestBuildRenditionV1RejectsInvalidEvidenceAndPolicy(t *testing.T) {
+	_, err := BuildRenditionV1(NormalizedEvidenceV1{}, RenditionPolicy{})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "rendition") || strings.Contains(err.Error(), "evidence"))
+
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+	_, err = BuildRenditionV1(NormalizedEvidenceV1{}, policy)
+	require.ErrorContains(t, err, "validate rendition evidence")
+}
+
+func TestBuildRenditionV1DropsSelfClosingActiveHTMLWithoutDroppingFollowingText(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    "before <input type=\"text\" value=\"provider control\"> after",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "before after\n", string(rendered.Markdown))
+}
+
+func TestBuildRenditionV1DropsMatchedInlineActiveHTMLBodies(t *testing.T) {
+	for _, tag := range []string{"script", "style", "iframe", "textarea"} {
+		t.Run(tag, func(t *testing.T) {
+			source := "before <" + tag + ">private_marker()</" + tag + "> after"
+			rendered := buildRenditionMarkdownForTest(t, source, 100_000)
+
+			assert.Equal(t, "before after\n", string(rendered.Markdown))
+			assert.NotContains(t, rendered.Units[0].Text, "private_marker")
+		})
+	}
+}
+
+func TestBuildRenditionV1DropsBlockActiveHTMLBodiesAcrossBlankLines(t *testing.T) {
+	rendered := buildRenditionMarkdownForTest(t, "before\n\n<iframe>\n\nprivate_marker\n\n</iframe>", 100_000)
+
+	assert.Equal(t, "before\n", string(rendered.Markdown))
+	assert.NotContains(t, rendered.Units[0].Text, "private_marker")
+}
+
+func TestBuildRenditionV1DropsGeneratedTextInsideActiveHTML(t *testing.T) {
+	source := "before <iframe>hidden\n\n![private_image](https://example.test/image)\n\n- [x] private_task\n\nsuppressed</iframe> after"
+	rendered := buildRenditionMarkdownForTest(t, source, 100_000)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.NotContains(t, html, "private_image")
+	assert.NotContains(t, html, "[x]")
+}
+
+func TestBuildRenditionV1TreatsSelfClosingActiveSyntaxAsAnOpener(t *testing.T) {
+	for _, tag := range []string{"script", "iframe"} {
+		t.Run(tag, func(t *testing.T) {
+			source := "before <" + tag + "/>private_marker()</" + tag + "> after"
+			rendered := buildRenditionMarkdownForTest(t, source, 100_000)
+
+			assert.Equal(t, "before after\n", string(rendered.Markdown))
+		})
+	}
+}
+
+func TestBuildRenditionV1DropsMalformedNestedActiveHTMLBodies(t *testing.T) {
+	rendered := buildRenditionMarkdownForTest(t, "before <iframe>secret<textarea>x</iframe> after", 100_000)
+
+	assert.Equal(t, "before after\n", string(rendered.Markdown))
+	assert.NotContains(t, rendered.Units[0].Text, "secret")
+	assert.NotContains(t, rendered.Units[0].Text, "x")
+}
+
+func TestBuildRenditionV1PreservesGeneratedStructureCrossedByActiveHTML(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "list", source: "- kept <iframe>hidden\n\nsuppressed</iframe> after", want: "- kept\n\nafter\n"},
+		{name: "table", source: "| value |\n| --- |\n| kept <iframe>hidden |\n\nsuppressed</iframe> after", want: "| value |\n| --- |\n| kept |\nafter\n"},
+		{name: "heading", source: "# kept <iframe>hidden\n\nsuppressed</iframe> after", want: "# kept\nafter\n"},
+		{name: "link", source: "[kept <iframe>hidden](https://example.test)\n\nsuppressed</iframe> after", want: "[kept](<https://example.test>)\n\nafter\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rendered := buildRenditionMarkdownForTest(t, test.source, 100_000)
+
+			assert.Equal(t, test.want, string(rendered.Markdown))
+			assert.NotContains(t, rendered.Units[0].Text, "hidden")
+			assert.NotContains(t, rendered.Units[0].Text, "suppressed")
+		})
+	}
+}
+
+func TestBuildRenditionV1PreservesParserGeneratedTaskCheckboxes(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    "- [x] shipped\n- [ ] pending",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "- \\[x\\] shipped\n- \\[ \\] pending\n", string(rendered.Markdown))
+}
+
+func TestBuildRenditionV1DropsProviderSuppliedCheckboxControls(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    "alpha <input type=\"checkbox\" checked> beta",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha beta\n", string(rendered.Markdown))
+}
+
+func TestBuildRenditionV1AppliesDocumentCharacterLimit(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    "é日🙂abcdef",
+		}},
+	})
+	normalization := testNormalizePolicy(t, 6)
+	normalization.maxUnitChars = 100
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "é日🙂abc\n", string(rendered.Markdown))
+	require.Len(t, rendered.Warnings, 1)
+	assert.Equal(t, "truncated", rendered.Warnings[0].Code)
+}
+
+func TestBuildRenditionV1SerializesDecodedTextAsInertMarkdown(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text: "\\[escaped](javascript:alert(1))\n\n" +
+				"&lt;iframe src=\"https://example.test/active\"&gt;active_markup()&lt;/iframe&gt;\n\n" +
+				"~~~go\nfirst\n```\n[escaped_code_fence](javascript:alert(1))\n~~~",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.NotContains(t, html, `href="javascript:`)
+	assert.NotContains(t, html, "<iframe")
+	assert.Contains(t, html, "escaped")
+	assert.Contains(t, html, "active_markup()")
+	assert.Contains(t, string(rendered.Markdown), "````go")
+	assert.Contains(t, string(rendered.Markdown), "[escaped_code_fence](javascript:alert(1))")
+}
+
+func TestBuildRenditionV1WarnsWhenSourceByteLimitTruncates(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    "abcdef",
+		}},
+	})
+	normalization := testNormalizePolicy(t, 100_000)
+	normalization.maxSourceUnitBytes = 4
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "abcd\n", string(rendered.Markdown))
+	require.Len(t, rendered.Warnings, 1)
+	assert.Equal(t, "truncated", rendered.Warnings[0].Code)
+}
+
+func TestBuildRenditionV1PadsAsymmetricInlineCodeBackticks(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text: "`` `<iframe src=\"https://example.test/active\">active</iframe> " +
+				"[unsafe](javascript:alert(1))``` ``",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.NotContains(t, html, "<iframe")
+	assert.NotContains(t, html, `href="javascript:`)
+	assert.Contains(t, html, "active")
+}
+
+func TestBuildRenditionV1RejectsStructuralCharactersInSafeLinkDestinations(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    `<a href="https://example.test/?q=&lt;iframe&gt;">safe</a>`,
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.NotContains(t, string(rendered.Markdown), "https://example.test/?q=")
+	assert.NotContains(t, html, "<iframe")
+	assert.NotContains(t, html, `href="https://example.test`)
+	assert.Contains(t, html, "safe")
+}
+
+func TestNormalizeDocumentKeepsFrozenStructuralLinkText(t *testing.T) {
+	normalized, err := NormalizeDocument(SourceDocument{
+		Family: "text", UnitKind: "section", Units: []SourceUnit{{
+			Index: 0, Markdown: `<a href="https://example.test/?q=&lt;iframe&gt;">safe</a>`,
+		}},
+	}, testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+	assert.Equal(t, "safe (https://example.test/?q=<iframe>)", normalized.Units[0].Text)
+}
+
+func TestBuildRenditionV1TruncatesStructuralMarkdownWithoutExposingCode(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text: "prefix `inline <iframe src=\"https://example.test/active\"> " +
+				"[unsafe](javascript:alert(1))` suffix\n\n~~~text\n" +
+				"<iframe src=\"https://example.test/block\">\n[unsafe](javascript:alert(1))\n~~~",
+		}},
+	})
+	for limit := 1; limit < 110; limit++ {
+		t.Run("unit-"+strconv.Itoa(limit), func(t *testing.T) {
+			normalization := testNormalizePolicy(t, 100_000)
+			normalization.maxUnitChars = limit
+			assertTruncatedRenditionIsInert(t, evidence, normalization)
+		})
+		t.Run("document-"+strconv.Itoa(limit), func(t *testing.T) {
+			normalization := testNormalizePolicy(t, limit)
+			normalization.maxUnitChars = 100_000
+			assertTruncatedRenditionIsInert(t, evidence, normalization)
+		})
+	}
+}
+
+func TestBuildRenditionV1KeepsCodeAndTablesInTheirOriginalContexts(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text: "~~~text\na | b\n~~~\n\noutside `a | b`\n\n" +
+				"| Name | Code |\n| --- | --- |\n| left | `a | b` |",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.Contains(t, html, "<pre><code")
+	assert.Contains(t, html, "a | b")
+	assert.Contains(t, html, "<table>")
+	assert.Equal(t, 2, strings.Count(html, "<th>"))
+	assert.Equal(t, 2, strings.Count(html, "<td>"))
+}
+
+func TestBuildRenditionV1KeepsFencedCodeInsideItsTableCell(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    `<table><tr><th>Name</th><th>Code</th></tr><tr><td>left</td><td><pre><code>a | b</code></pre></td></tr></table>`,
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.Equal(t, 1, strings.Count(html, "<table>"))
+	assert.Equal(t, 2, strings.Count(html, "<th>"))
+	assert.Equal(t, 2, strings.Count(html, "<td>"))
+	assert.Contains(t, html, "<code>a | b</code>")
+}
+
+func TestBuildRenditionV1EncodesSafeLinksInEveryMarkdownContext(t *testing.T) {
+	link := "http://127.0.0.1:8080/a*(b)_c|d?x=(y)*_"
+	local := "http://localhost:8080/a*(b)_c|d?x=(y)*_"
+	tableLink := strings.ReplaceAll(link, "|", "&#124;")
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text: `<a href="` + link + `">IP</a> <a href="` + local + `">local</a>
+
+| Link | Value |
+| --- | --- |
+| <a href="` + tableLink + `">cell</a> | safe |`,
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.Contains(t, string(rendered.Markdown), "%2A")
+	assert.Contains(t, string(rendered.Markdown), "%28")
+	assert.Contains(t, string(rendered.Markdown), "%5F")
+	assert.Contains(t, string(rendered.Markdown), "%7C")
+	assert.Contains(t, html, `href="http://127.0.0.1:8080/a%2A%28b%29%5Fc%7Cd?x=%28y%29%2A%5F"`)
+	assert.Contains(t, html, `href="http://localhost:8080/a%2A%28b%29%5Fc%7Cd?x=%28y%29%2A%5F"`)
+	assert.Contains(t, html, "<table>")
+	assert.Equal(t, 3, strings.Count(html, "<a href="))
+}
+
+func TestBuildRenditionV1KeepsNestedLinkCodeInertAtEveryLimit(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text: `prefix <a href="https://example.test/safe"><pre><code>&lt;iframe src="https://example.test/active"&gt;` +
+				`[unsafe](javascript:alert(1))&lt;/iframe&gt;</code></pre></a>` + strings.Repeat(" tail", 40),
+		}},
+	})
+	for limit := 1; limit < 160; limit++ {
+		t.Run("unit-"+strconv.Itoa(limit), func(t *testing.T) {
+			normalization := testNormalizePolicy(t, 100_000)
+			normalization.maxUnitChars = limit
+			assertNestedLinkCodeIsInert(t, evidence, normalization)
+		})
+		t.Run("document-"+strconv.Itoa(limit), func(t *testing.T) {
+			normalization := testNormalizePolicy(t, limit)
+			normalization.maxUnitChars = 100_000
+			assertNestedLinkCodeIsInert(t, evidence, normalization)
+		})
+	}
+}
+
+func TestBuildRenditionV1KeepsProviderTextFromCreatingMarkdownBlocks(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text: "<p>&#45; entity item</p><p>\\- escaped item</p><p>&#42;&#42;&#42;</p>" +
+				"<p>&#49;&#46; entity ordered</p><p>\\1\\. escaped ordered</p>" +
+				"<p>&gt; entity quote</p><p>\\> escaped quote</p>" +
+				"<p>&#35; entity heading</p><p>\\# escaped heading</p>" +
+				"<p>&#96;&#96;&#96; entity fence</p><p>\\`\\`\\` escaped fence</p>",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.NotContains(t, html, "<ul>")
+	assert.NotContains(t, html, "<ol>")
+	assert.NotContains(t, html, "<hr>")
+	assert.NotContains(t, html, "<blockquote>")
+	assert.NotContains(t, html, "<h1>")
+	assert.NotContains(t, html, "<pre><code>")
+	assert.Contains(t, html, "entity item")
+	assert.Contains(t, html, "entity fence")
+}
+
+func TestBuildRenditionV1PreservesEscapedPipeInsideTableInlineCode(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    "| Name | Code |\n| --- | --- |\n| left | `a \\| b` |",
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+
+	assert.Equal(t, 1, strings.Count(html, "<table>"))
+	assert.Equal(t, 2, strings.Count(html, "<th>"))
+	assert.Equal(t, 2, strings.Count(html, "<td>"))
+	assert.Contains(t, html, "<td><code>a | b</code></td>")
+}
+
+func TestBuildRenditionV1KeepsExactFitBudgetsAcrossBlocksAndUnits(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{
+			{
+				Order:   0,
+				Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+				Text:    "first\n\nsecond",
+			},
+			{
+				Order:   1,
+				Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+				Text:    "later",
+			},
+		},
+	})
+	normalization := testNormalizePolicy(t, 5)
+	normalization.maxUnitChars = 5
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+
+	require.Len(t, rendered.Units, 2)
+	assert.Equal(t, "first", rendered.Units[0].Text)
+	assert.Empty(t, rendered.Units[1].Text)
+	assert.Equal(t, "first\n", string(rendered.Markdown))
+	assert.LessOrEqual(t, utf8.RuneCountInString(rendered.Units[0].Text), normalization.maxUnitChars)
+	assert.LessOrEqual(t, utf8.RuneCountInString(rendered.Units[1].Text), normalization.maxUnitChars)
+	assert.LessOrEqual(t, utf8.RuneCountInString(strings.TrimSuffix(string(rendered.Markdown), "\n")), normalization.maxDocumentChars)
+	assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+}
+
+func TestBuildRenditionV1ChargesAggregateSeparators(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{ContractVersion: SourceEvidenceContractV1, Completeness: EvidenceComplete, Family: "text", UnitKind: EvidenceUnitSection, Units: []SourceEvidenceUnitV1{
+		{Order: 0, Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone}, Text: "one"},
+		{Order: 1, Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone}, Text: "two"},
+	}})
+	for limit := 1; limit < 16; limit++ {
+		policy, err := NewRenditionPolicy(testNormalizePolicy(t, limit))
+		require.NoError(t, err)
+		rendered, err := BuildRenditionV1(evidence, policy)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, utf8.RuneCountInString(strings.TrimSuffix(string(rendered.Markdown), "\n")), limit)
+		if limit < 13 {
+			assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+		}
+	}
+}
+
+func TestBuildRenditionV1FinalizesTruncatedHTMLContexts(t *testing.T) {
+	for _, source := range []string{`<a href="javascript:alert(1)">label`, `<code>code`, `<pre><code>block`, `<table><tr><td>cell`} {
+		evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{ContractVersion: SourceEvidenceContractV1, Completeness: EvidenceComplete, Family: "text", UnitKind: EvidenceUnitSection, Units: []SourceEvidenceUnitV1{{Order: 0, Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone}, Text: source}}})
+		for limit := 1; limit < len(source); limit++ {
+			normalization := testNormalizePolicy(t, 10_000)
+			normalization.maxSourceUnitBytes = limit
+			policy, err := NewRenditionPolicy(normalization)
+			require.NoError(t, err)
+			rendered, err := BuildRenditionV1(evidence, policy)
+			if err == nil {
+				html := renderUnsafeMarkdown(t, rendered.Markdown)
+				assert.NotContains(t, html, `href="javascript:`)
+			}
+		}
+	}
+}
+
+func TestBuildRenditionV1PreservesTypedLists(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{ContractVersion: SourceEvidenceContractV1, Completeness: EvidenceComplete, Family: "text", UnitKind: EvidenceUnitSection, Units: []SourceEvidenceUnitV1{{Order: 0, Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone}, Text: `<ol start="3"><li>third</li><li><p>loose one</p><p>loose two</p><ul><li>nested</li></ul></li></ol><ul><li>plain</li></ul>`}}})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+	assert.Contains(t, string(rendered.Markdown), "3. third")
+	assert.Contains(t, html, "<ol start=\"3\">")
+	assert.Contains(t, html, "<ul>")
+	assert.Contains(t, html, "loose two")
+	assert.Contains(t, html, "nested")
+}
+
+func TestBuildRenditionV1KeepsTableListsInsideTheirOuterListItem(t *testing.T) {
+	source := `<ul><li>outer<table><tr><td><ul><li>inner</li></ul></td></tr></table>tail</li></ul>`
+	rendered := buildRenditionMarkdownForTest(t, source, 100_000)
+
+	assert.Equal(t, "- outer\n\n  | inner |\n  | --- |\n\n  tail\n", string(rendered.Markdown))
+	assert.Equal(t, `ul(tight=false)[item[paragraph("outer"),table,paragraph("tail")]]`, renditionMarkdownTopology(t, rendered.Markdown))
+}
+
+func TestBuildRenditionV1FlattensNestedTablesIntoOuterCell(t *testing.T) {
+	source := `<table><tr><td>before<table><tr><td>inner</td></tr></table>after</td></tr></table>`
+	rendered := buildRenditionMarkdownForTest(t, source, 100_000)
+
+	assert.Equal(t, "| before inner after |\n| --- |\n", string(rendered.Markdown))
+	assert.Equal(t, "table", renditionMarkdownTopology(t, rendered.Markdown))
+}
+
+func TestBuildRenditionV1ClosesImplicitTableCellsAndRows(t *testing.T) {
+	source := `<table><tr><td>first<td>second<tr><td>third<td>fourth</table>`
+	rendered := buildRenditionMarkdownForTest(t, source, 100_000)
+
+	assert.Equal(t, "| first | second |\n| --- | --- |\n| third | fourth |\n", string(rendered.Markdown))
+	assert.Equal(t, "table", renditionMarkdownTopology(t, rendered.Markdown))
+}
+
+func TestBuildRenditionV1SeparatesFlattenedTableCellBlocks(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{name: "paragraphs", source: `<table><tr><td><p>New</p><p>York</p></td></tr></table>`},
+		{name: "list items", source: `<table><tr><td><ul><li>New</li><li>York</li></ul></td></tr></table>`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rendered := buildRenditionMarkdownForTest(t, test.source, 100_000)
+
+			assert.Equal(t, "| New York |\n| --- |\n", string(rendered.Markdown))
+		})
+	}
+}
+
+func TestBuildRenditionV1SeparatesIndependentTopLevelBlocks(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		source   string
+		topology string
+	}{
+		{name: "paragraphs", source: "one\n\ntwo", topology: `paragraph("one") | paragraph("two")`},
+		{
+			name: "tables",
+			source: "| a |\n| --- |\n| one |\n\n" +
+				"| b |\n| --- |\n| two |",
+			topology: "table | table",
+		},
+		{
+			name: "non-one ordered list after paragraph", source: "before\n\n3. third",
+			topology: `paragraph("before") | ol(start=3,tight=true)[item[paragraph("third")]]`,
+		},
+		{
+			name: "paragraph after list", source: "- item\n\nafter",
+			topology: `ul(tight=true)[item[paragraph("item")]] | paragraph("after")`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rendered := buildRenditionMarkdownForTest(t, test.source, 100_000)
+
+			assert.Equal(t, test.topology, renditionMarkdownTopology(t, rendered.Markdown))
+		})
+	}
+}
+
+func TestBuildRenditionV1PreservesExactListHierarchy(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text: `<ol start="0"><li><p>zero</p><ul><li>nested alpha</li><li>nested beta<ol start="4"><li>deep</li></ol></li></ul><p>after nested</p></li><li>one</li></ol>` +
+				`<ul><li>tail</li><li>end</li></ul>`,
+		}},
+	})
+	policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, "0. zero\n   - nested alpha\n   - nested beta\n\n     4. deep\n\n   after nested\n\n1. one\n- tail\n- end\n", string(rendered.Markdown))
+	assert.Equal(t, `<ol start="0">
+<li>
+<p>zero</p>
+<ul>
+<li>
+<p>nested alpha</p>
+</li>
+<li>
+<p>nested beta</p>
+<ol start="4">
+<li>deep</li>
+</ol>
+</li>
+</ul>
+<p>after nested</p>
+</li>
+<li>
+<p>one</p>
+</li>
+</ol>
+<ul>
+<li>tail</li>
+<li>end</li>
+</ul>
+`, renderUnsafeMarkdown(t, rendered.Markdown))
+}
+
+func TestBuildRenditionV1PreservesBoundedListHierarchy(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    `<ol start="0"><li>zero<ul><li>nested alpha</li><li>nested beta</li></ul></li><li>one</li></ol>`,
+		}},
+	})
+	normalization := testNormalizePolicy(t, 36)
+	normalization.maxUnitChars = 36
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, "0. zero\n   - nested alpha\n   - neste\n", string(rendered.Markdown))
+	assert.Equal(t, `<ol start="0">
+<li>zero
+<ul>
+<li>nested alpha</li>
+<li>neste</li>
+</ul>
+</li>
+</ol>
+`, renderUnsafeMarkdown(t, rendered.Markdown))
+	assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+}
+
+func TestBuildRenditionV1PreservesEveryListTopologyAtFullAndBoundedBudgets(t *testing.T) {
+	tests := []struct {
+		name            string
+		source          string
+		fullMarkdown    string
+		boundedMarkdown string
+		fullTopology    string
+		boundedTopology string
+	}{
+		{
+			name:            "loose single paragraph items",
+			source:          `<ul><li><p>one</p></li><li><p>two</p></li></ul>`,
+			fullMarkdown:    "- one\n\n- two",
+			boundedMarkdown: "- one\n\n- tw",
+			fullTopology:    `ul(tight=false)[item[paragraph("one")],item[paragraph("two")]]`,
+			boundedTopology: `ul(tight=false)[item[paragraph("one")],item[paragraph("tw")]]`,
+		},
+		{
+			name:            "empty item",
+			source:          `<ul><li></li><li>filled</li></ul>`,
+			fullMarkdown:    "-\n- filled",
+			boundedMarkdown: "-\n- fil",
+			fullTopology:    `ul(tight=true)[item[],item[paragraph("filled")]]`,
+			boundedTopology: `ul(tight=true)[item[],item[paragraph("fil")]]`,
+		},
+		{
+			name:            "nested only item",
+			source:          `<ul><li><ul><li>nested</li></ul></li></ul>`,
+			fullMarkdown:    "-\n  - nested",
+			boundedMarkdown: "-\n  - nes",
+			fullTopology:    `ul(tight=true)[item[ul(tight=true)[item[paragraph("nested")]]]]`,
+			boundedTopology: `ul(tight=true)[item[ul(tight=true)[item[paragraph("nes")]]]]`,
+		},
+		{
+			name:            "leading code item",
+			source:          `<ul><li><pre><code class="language-go">code` + "\n" + `line</code></pre></li><li>tail</li></ul>`,
+			fullMarkdown:    "- ```go\n  code\n  line\n  ```\n- tail",
+			boundedMarkdown: "- ```go\n  code\n  line\n  ```\n- ta",
+			fullTopology:    `ul(tight=true)[item[code("code\nline")],item[paragraph("tail")]]`,
+			boundedTopology: `ul(tight=true)[item[code("code\nline")],item[paragraph("ta")]]`,
+		},
+		{
+			name:            "leading table item",
+			source:          `<ul><li><table><tr><th>h</th></tr><tr><td>v</td></tr></table></li><li>tail</li></ul>`,
+			fullMarkdown:    "- | h |\n  | --- |\n  | v |\n- tail",
+			boundedMarkdown: "- | h |\n  | --- |\n  | v |\n- ta",
+			fullTopology:    `ul(tight=true)[item[table],item[paragraph("tail")]]`,
+			boundedTopology: `ul(tight=true)[item[table],item[paragraph("ta")]]`,
+		},
+		{
+			name:            "adjacent unordered roots",
+			source:          `<ul><li>first</li></ul><ul><li>second</li></ul>`,
+			fullMarkdown:    "- first\n* second",
+			boundedMarkdown: "- first\n* se",
+			fullTopology:    `ul(tight=true)[item[paragraph("first")]] | ul(tight=true)[item[paragraph("second")]]`,
+			boundedTopology: `ul(tight=true)[item[paragraph("first")]] | ul(tight=true)[item[paragraph("se")]]`,
+		},
+		{
+			name:            "adjacent ordered roots",
+			source:          `<ol start="2"><li>two</li></ol><ol start="7"><li>seven</li></ol>`,
+			fullMarkdown:    "2. two\n7) seven",
+			boundedMarkdown: "2. two\n7) se",
+			fullTopology:    `ol(start=2,tight=true)[item[paragraph("two")]] | ol(start=7,tight=true)[item[paragraph("seven")]]`,
+			boundedTopology: `ol(start=2,tight=true)[item[paragraph("two")]] | ol(start=7,tight=true)[item[paragraph("se")]]`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+				ContractVersion: SourceEvidenceContractV1,
+				Completeness:    EvidenceComplete,
+				Family:          "text",
+				UnitKind:        EvidenceUnitSection,
+				Units: []SourceEvidenceUnitV1{{
+					Order:   0,
+					Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+					Text:    test.source,
+				}},
+			})
+
+			t.Run("full", func(t *testing.T) {
+				policy, err := NewRenditionPolicy(testNormalizePolicy(t, 100_000))
+				require.NoError(t, err)
+				rendered, err := BuildRenditionV1(evidence, policy)
+				require.NoError(t, err)
+				assert.Equal(t, test.fullMarkdown+"\n", string(rendered.Markdown))
+				assert.Equal(t, test.fullTopology, renditionMarkdownTopology(t, rendered.Markdown))
+			})
+
+			t.Run("bounded", func(t *testing.T) {
+				normalization := testNormalizePolicy(t, len(test.boundedMarkdown))
+				normalization.maxUnitChars = len(test.boundedMarkdown)
+				policy, err := NewRenditionPolicy(normalization)
+				require.NoError(t, err)
+				rendered, err := BuildRenditionV1(evidence, policy)
+				require.NoError(t, err)
+				assert.Equal(t, test.boundedMarkdown+"\n", string(rendered.Markdown))
+				assert.Equal(t, test.boundedTopology, renditionMarkdownTopology(t, rendered.Markdown))
+				assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+			})
+		})
+	}
+}
+
+func TestBuildRenditionV1PreservesStructuralOnlyLooseListAtEveryCutoff(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    "- # Heading\n\n  ```go\n  code\n  ```",
+		}},
+	})
+	const fullMarkdown = "- # Heading\n\n  ```go\n  code\n  ```\n\n  <!-- -->"
+
+	for limit := 1; limit <= len(fullMarkdown); limit++ {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			normalization := testNormalizePolicy(t, limit)
+			normalization.maxUnitChars = limit
+			policy, err := NewRenditionPolicy(normalization)
+			require.NoError(t, err)
+			rendered, err := BuildRenditionV1(evidence, policy)
+			if limit < 17 {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.LessOrEqual(t, utf8.RuneCountInString(strings.TrimSuffix(string(rendered.Markdown), "\n")), limit)
+
+			heading := "Heading"
+			if limit < 23 {
+				heading = heading[:limit-16]
+			}
+			expected := `ul(tight=false)[item[heading(level=1,` + strconv.Quote(heading) + `)]]`
+			if limit == len(fullMarkdown) {
+				expected = `ul(tight=false)[item[heading(level=1,"Heading"),code("code")]]`
+			}
+			assert.Equal(t, expected, renditionMarkdownTopology(t, rendered.Markdown))
+			assert.Contains(t, string(rendered.Markdown), "<!-- -->")
+			if limit < len(fullMarkdown) {
+				assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+			}
+		})
+	}
+}
+
+func TestBuildRenditionV1PreservesMultiItemLooseListPrefixAtEveryCutoff(t *testing.T) {
+	const (
+		first        = "aaaaaaaaaaaaaaaaaaaaaaaa"
+		second       = "second"
+		fullMarkdown = "- " + first + "\n\n- " + second
+		looseSuffix  = "\n\n  <!-- -->"
+	)
+	for limit := 1; limit <= len(fullMarkdown); limit++ {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			rendered, err := buildRenditionMarkdownResultForTest(t, fullMarkdown, limit)
+			if limit < 15 {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			var expectedMarkdown string
+			var expectedTopology string
+			if limit < 31 {
+				retainedFirst := first[:limit-14]
+				expectedMarkdown = "- " + retainedFirst + looseSuffix
+				expectedTopology = `ul(tight=false)[item[paragraph(` + strconv.Quote(retainedFirst) + `)]]`
+			} else {
+				retainedSecond := second[:limit-30]
+				expectedMarkdown = "- " + first + "\n\n- " + retainedSecond
+				expectedTopology = `ul(tight=false)[item[paragraph("` + first + `")],item[paragraph(` + strconv.Quote(retainedSecond) + `)]]`
+			}
+			assert.Equal(t, expectedMarkdown+"\n", string(rendered.Markdown))
+			assert.Equal(t, expectedTopology, renditionMarkdownTopology(t, rendered.Markdown))
+			assert.LessOrEqual(t, utf8.RuneCountInString(strings.TrimSuffix(string(rendered.Markdown), "\n")), limit)
+			if limit < len(fullMarkdown) {
+				assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+			}
+		})
+	}
+}
+
+func TestBuildRenditionV1SeparatesNestedSameKindListsAtEveryCutoff(t *testing.T) {
+	tests := []struct {
+		name         string
+		source       string
+		fullMarkdown string
+		ordered      bool
+	}{
+		{
+			name:         "unordered siblings",
+			source:       `<ul><li><ul><li>one</li></ul><ul><li>two</li></ul></li></ul>`,
+			fullMarkdown: "-\n  - one\n  * two",
+		},
+		{
+			name:         "ordered siblings including second start one",
+			source:       `<ul><li><ol start="4"><li>one</li></ol><ol start="1"><li>two</li></ol></li></ul>`,
+			fullMarkdown: "-\n    4. one\n    1) two",
+			ordered:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+				ContractVersion: SourceEvidenceContractV1,
+				Completeness:    EvidenceComplete,
+				Family:          "text",
+				UnitKind:        EvidenceUnitSection,
+				Units: []SourceEvidenceUnitV1{{
+					Order:   0,
+					Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+					Text:    test.source,
+				}},
+			})
+
+			for limit := 1; limit <= len(test.fullMarkdown); limit++ {
+				t.Run(strconv.Itoa(limit), func(t *testing.T) {
+					normalization := testNormalizePolicy(t, limit)
+					normalization.maxUnitChars = limit
+					policy, err := NewRenditionPolicy(normalization)
+					require.NoError(t, err)
+					rendered, err := BuildRenditionV1(evidence, policy)
+					require.NoError(t, err)
+					assert.LessOrEqual(t, utf8.RuneCountInString(strings.TrimSuffix(string(rendered.Markdown), "\n")), limit)
+					assert.Equal(t, expectedNestedSiblingMarkdown(limit, test.ordered)+"\n", string(rendered.Markdown))
+					assert.Equal(t, expectedNestedSiblingTopology(limit, test.ordered), renditionMarkdownTopology(t, rendered.Markdown))
+					if limit < len(test.fullMarkdown) {
+						assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestBuildRenditionV1RepresentsOrderedStartsWithoutOverflow(t *testing.T) {
+	tests := []struct {
+		name            string
+		source          string
+		fullMarkdown    string
+		boundedMarkdown string
+		fullTopology    string
+		boundedTopology string
+	}{
+		{
+			name:            "nine digit maximum",
+			source:          `<ol start="999999999"><li>max</li></ol>`,
+			fullMarkdown:    "999999999. max",
+			boundedMarkdown: "999999999. m",
+			fullTopology:    `ol(start=999999999,tight=true)[item[paragraph("max")]]`,
+			boundedTopology: `ol(start=999999999,tight=true)[item[paragraph("m")]]`,
+		},
+		{
+			name:            "ten digit input",
+			source:          `<ol start="1000000000"><li>ten</li></ol>`,
+			fullMarkdown:    `- 1000000000\. ten`,
+			boundedMarkdown: `- 1000000000\. t`,
+			fullTopology:    `ul(tight=true)[item[paragraph("1000000000\\. ten")]]`,
+			boundedTopology: `ul(tight=true)[item[paragraph("1000000000\\. t")]]`,
+		},
+		{
+			name:            "overflow edge",
+			source:          `<ol start="18446744073709551615"><li>edge</li><li>next</li></ol>`,
+			fullMarkdown:    "- 18446744073709551615\\. edge\n- 18446744073709551616\\. next",
+			boundedMarkdown: "- 18446744073709551615\\. edge\n- 18446744073709551616\\. n",
+			fullTopology:    `ul(tight=true)[item[paragraph("18446744073709551615\\. edge")],item[paragraph("18446744073709551616\\. next")]]`,
+			boundedTopology: `ul(tight=true)[item[paragraph("18446744073709551615\\. edge")],item[paragraph("18446744073709551616\\. n")]]`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+				ContractVersion: SourceEvidenceContractV1,
+				Completeness:    EvidenceComplete,
+				Family:          "text",
+				UnitKind:        EvidenceUnitSection,
+				Units: []SourceEvidenceUnitV1{{
+					Order:   0,
+					Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+					Text:    test.source,
+				}},
+			})
+
+			for name, expected := range map[string]struct {
+				markdown string
+				topology string
+			}{
+				"full":    {markdown: test.fullMarkdown, topology: test.fullTopology},
+				"bounded": {markdown: test.boundedMarkdown, topology: test.boundedTopology},
+			} {
+				t.Run(name, func(t *testing.T) {
+					normalization := testNormalizePolicy(t, len(expected.markdown))
+					normalization.maxUnitChars = len(expected.markdown)
+					policy, err := NewRenditionPolicy(normalization)
+					require.NoError(t, err)
+					rendered, err := BuildRenditionV1(evidence, policy)
+					require.NoError(t, err)
+					assert.Equal(t, expected.markdown+"\n", string(rendered.Markdown))
+					assert.Equal(t, expected.topology, renditionMarkdownTopology(t, rendered.Markdown))
+				})
+			}
+		})
+	}
+}
+
+func TestBuildRenditionV1KeepsRepresentableOrderedPrefixAtEveryCutoff(t *testing.T) {
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    `<ol start="999999999"><li>nine</li><li>ten</li></ol>`,
+		}},
+	})
+	const orderedPrefix = "999999999. nine"
+	const degraded = "- 999999999\\. nine\n- 1000000000\\. ten"
+
+	for limit := 1; limit <= len(degraded); limit++ {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			normalization := testNormalizePolicy(t, limit)
+			normalization.maxUnitChars = limit
+			policy, err := NewRenditionPolicy(normalization)
+			require.NoError(t, err)
+			rendered, err := BuildRenditionV1(evidence, policy)
+			if limit < 12 {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			expectedMarkdown := orderedPrefix
+			switch {
+			case limit <= len(orderedPrefix):
+				expectedMarkdown = orderedPrefix[:limit]
+			case limit >= 35:
+				expectedMarkdown = degraded[:limit]
+			}
+			assert.Equal(t, expectedMarkdown+"\n", string(rendered.Markdown))
+			assert.Equal(t, expectedOrderedCrossingTopology(limit), renditionMarkdownTopology(t, rendered.Markdown))
+			if limit < len(degraded) {
+				assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+			}
+		})
+	}
+}
+
+func TestBuildRenditionV1CarriesOnlyParserListTightness(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		source   string
+		markdown string
+		topology string
+	}{
+		{
+			name:     "real tight Markdown",
+			source:   "- one",
+			markdown: "- one",
+			topology: `ul(tight=true)[item[paragraph("one")]]`,
+		},
+		{
+			name:     "real structural-only loose Markdown",
+			source:   "- # Heading\n\n  ```go\n  code\n  ```",
+			markdown: "- # Heading\n\n  ```go\n  code\n  ```\n\n  <!-- -->",
+			topology: `ul(tight=false)[item[heading(level=1,"Heading"),code("code")]]`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rendered := buildRenditionMarkdownForTest(t, test.source, 100_000)
+			assert.Equal(t, test.markdown+"\n", string(rendered.Markdown))
+			assert.Equal(t, test.topology, renditionMarkdownTopology(t, rendered.Markdown))
+		})
+	}
+
+	const plain = `<ul><li>one</li></ul>`
+	const spoofed = `<ul data-docbank-rendition-tight="false"><li>one</li></ul>`
+	for limit := 1; limit <= len("- one\n\n  <!-- -->"); limit++ {
+		t.Run("spoof/"+strconv.Itoa(limit), func(t *testing.T) {
+			plainRendition, plainErr := buildRenditionMarkdownResultForTest(t, plain, limit)
+			spoofedRendition, spoofedErr := buildRenditionMarkdownResultForTest(t, spoofed, limit)
+			assert.Equal(t, plainErr != nil, spoofedErr != nil)
+			if plainErr != nil || spoofedErr != nil {
+				return
+			}
+			assert.Equal(t, plainRendition.Markdown, spoofedRendition.Markdown)
+			assert.Equal(t, plainRendition.Units[0].Text, spoofedRendition.Units[0].Text)
+			assert.Equal(t, plainRendition.Warnings, spoofedRendition.Warnings)
+			assert.Equal(t, renditionMarkdownTopology(t, plainRendition.Markdown), renditionMarkdownTopology(t, spoofedRendition.Markdown))
+		})
+	}
+}
+
+func TestBuildRenditionV1IsolatesRawHTMLTokenizerStateAtEveryBudget(t *testing.T) {
+	tests := []struct {
+		name     string
+		neutral  string
+		poisoned string
+		markdown string
+		topology string
+	}{
+		{
+			name:     "plaintext before loose Markdown list",
+			neutral:  "<div>poison</div>\n\n- # Heading\n\n  ```go\n  code\n  ```",
+			poisoned: "<plaintext>poison\n\n- # Heading\n\n  ```go\n  code\n  ```",
+			markdown: "poison\n- # Heading\n\n  ```go\n  code\n  ```\n\n  <!-- -->",
+			topology: `paragraph("poison") | ul(tight=false)[item[heading(level=1,"Heading"),code("code")]]`,
+		},
+		{
+			name:     "raw text between tight Markdown lists",
+			neutral:  "- before\n\n# <span>middle</span>\n\n- after",
+			poisoned: "- before\n\n# <xmp>middle\n\n- after",
+			markdown: "- before\n# middle\n- after",
+			topology: `ul(tight=true)[item[paragraph("before")]] | heading(level=1,"middle") | ul(tight=true)[item[paragraph("after")]]`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for limit := 1; limit <= len(test.markdown); limit++ {
+				t.Run(strconv.Itoa(limit), func(t *testing.T) {
+					neutral, neutralErr := buildRenditionMarkdownResultForTest(t, test.neutral, limit)
+					poisoned, poisonedErr := buildRenditionMarkdownResultForTest(t, test.poisoned, limit)
+					assert.Equal(t, neutralErr != nil, poisonedErr != nil)
+					if neutralErr != nil || poisonedErr != nil {
+						return
+					}
+					assert.Equal(t, neutral.Markdown, poisoned.Markdown)
+					assert.Equal(t, neutral.Units[0].Text, poisoned.Units[0].Text)
+					assert.Equal(t, neutral.Warnings, poisoned.Warnings)
+					assert.NotContains(t, renderUnsafeMarkdown(t, poisoned.Markdown), "<plaintext")
+					assert.NotContains(t, renderUnsafeMarkdown(t, poisoned.Markdown), "<xmp")
+				})
+			}
+
+			rendered := buildRenditionMarkdownForTest(t, test.poisoned, len(test.markdown))
+			assert.Equal(t, test.markdown+"\n", string(rendered.Markdown))
+			assert.Equal(t, test.topology, renditionMarkdownTopology(t, rendered.Markdown))
+		})
+	}
+}
+
+func TestBuildRenditionV1IsolatesEveryRawHTMLSemanticScopeAtEveryBudget(t *testing.T) {
+	inlineMarkdown := "- tight\n# boundary\n- # loose\n\n  ```go\n  code\n  ```\n\n  <!-- -->"
+	inlineTopology := `ul(tight=true)[item[paragraph("tight")]] | heading(level=1,"boundary") | ul(tight=false)[item[heading(level=1,"loose"),code("code")]]`
+	blockMarkdown := "- tight\n* # loose\n\n  ```go\n  code\n  ```\n\n  <!-- -->"
+	blockTopology := `ul(tight=true)[item[paragraph("tight")]] | ul(tight=false)[item[heading(level=1,"loose"),code("code")]]`
+	tags := []string{
+		"<script>",
+		"<textarea>",
+		"<pre>",
+		"<table>",
+		`<a href="https://safe.example/path">`,
+		"<code>",
+	}
+	for _, tag := range tags {
+		name := strings.Trim(tag, "</>")
+		t.Run("inline "+name, func(t *testing.T) {
+			neutral := "- tight\n\n# boundary<span>\n\n- # loose\n\n  ```go\n  code\n  ```"
+			poisoned := "- tight\n\n# boundary" + tag + "\n\n- # loose\n\n  ```go\n  code\n  ```"
+			assertEquivalentRenditionAtEveryBudget(t, neutral, poisoned, inlineMarkdown, inlineTopology)
+		})
+		t.Run("block "+name, func(t *testing.T) {
+			neutral := "- tight\n\n<div><span>\n\n- # loose\n\n  ```go\n  code\n  ```"
+			poisoned := "- tight\n\n<div>" + tag + "\n\n- # loose\n\n  ```go\n  code\n  ```"
+			assertEquivalentRenditionAtEveryBudget(t, neutral, poisoned, blockMarkdown, blockTopology)
+		})
+	}
+}
+
+func assertEquivalentRenditionAtEveryBudget(
+	t *testing.T,
+	neutral string,
+	poisoned string,
+	wantMarkdown string,
+	wantTopology string,
+) {
+	t.Helper()
+	for limit := 1; limit <= utf8.RuneCountInString(wantMarkdown); limit++ {
+		neutralRendition, neutralErr := buildRenditionMarkdownResultForTest(t, neutral, limit)
+		poisonedRendition, poisonedErr := buildRenditionMarkdownResultForTest(t, poisoned, limit)
+		assert.Equal(t, neutralErr != nil, poisonedErr != nil, "limit %d", limit)
+		if neutralErr != nil || poisonedErr != nil {
+			continue
+		}
+		assert.Equal(t, neutralRendition.Markdown, poisonedRendition.Markdown, "limit %d", limit)
+		assert.Equal(t, neutralRendition.Units[0].Text, poisonedRendition.Units[0].Text, "limit %d", limit)
+		assert.Equal(t, neutralRendition.Warnings, poisonedRendition.Warnings, "limit %d", limit)
+		unsafe := renderUnsafeMarkdown(t, poisonedRendition.Markdown)
+		for _, active := range []string{"<script", "<textarea", "<a href="} {
+			assert.NotContains(t, unsafe, active, "limit %d", limit)
+		}
+	}
+
+	rendered := buildRenditionMarkdownForTest(t, poisoned, utf8.RuneCountInString(wantMarkdown))
+	assert.Equal(t, wantMarkdown+"\n", string(rendered.Markdown))
+	assert.Equal(t, wantTopology, renditionMarkdownTopology(t, rendered.Markdown))
+}
+
+func TestBuildRenditionV1ScalesLinearlyAtNearLimit(t *testing.T) {
+	allocatedBytes := func(size int) int64 {
+		t.Helper()
+		input := strings.Repeat("a", size)
+		result := testing.Benchmark(func(b *testing.B) {
+			b.Helper()
+			b.ReportAllocs()
+			for b.Loop() {
+				_, _, _, err := sanitizeRenditionMarkdown(input, 1_000, 4_000_000, size)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		return result.AllocedBytesPerOp()
+	}
+	smallBytes := allocatedBytes(4_096)
+	largeBytes := allocatedBytes(8_192)
+	require.Less(t, largeBytes, smallBytes*3, "doubling input must not produce quadratic allocated bytes")
+
+	const size = 900_000
+	source := strings.Repeat("a", size)
+	evidencePolicy, err := NewEvidencePolicy(size)
+	require.NoError(t, err)
+	evidence, err := NormalizeEvidenceV1(SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    source,
+		}},
+	}, evidencePolicy)
+	require.NoError(t, err)
+	normalization := testNormalizePolicy(t, size)
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	expectedMarkdown := []byte(source + "\n")
+	expectedDigest := sha256.Sum256(expectedMarkdown)
+	assert.Equal(t, expectedMarkdown, rendered.Markdown)
+	assert.Equal(t, source, rendered.Units[0].Text)
+	assert.Equal(t, source, rendered.LexicalSegments[0].Text)
+	assert.Equal(t, hex.EncodeToString(expectedDigest[:]), rendered.MarkdownChecksum)
+}
+
+func TestSerializeRenditionTreeUsesOneBudgetedLinearWalk(t *testing.T) {
+	allocatedBytes := func(run func() (string, bool)) int64 {
+		t.Helper()
+		var value string
+		result := testing.Benchmark(func(b *testing.B) {
+			b.Helper()
+			b.ReportAllocs()
+			for b.Loop() {
+				value, _ = run()
+			}
+		})
+		require.NotNil(t, []byte(value))
+		return result.AllocedBytesPerOp()
+	}
+
+	decimalList := func(digits, items int) renditionList {
+		list := renditionList{ordered: true, start: strings.Repeat("9", digits), tight: true}
+		for range items {
+			list.items = append(list.items, renditionListItem{present: true, blocks: []renditionBlock{{
+				kind: renditionParagraph, inlines: []renditionInline{{kind: renditionText, text: "x"}},
+			}}})
+		}
+		return list
+	}
+	smallDecimal := decimalList(2_048, 32)
+	largeDecimal := decimalList(4_096, 64)
+	smallDecimalBytes := allocatedBytes(func() (string, bool) {
+		return serializeRenditionList(smallDecimal, 8, false)
+	})
+	largeDecimalBytes := allocatedBytes(func() (string, bool) {
+		return serializeRenditionList(largeDecimal, 8, false)
+	})
+	require.Less(t, largeDecimalBytes, smallDecimalBytes*3, "unadmitted decimal ordinals must not be preallocated")
+	value, truncated := serializeRenditionList(largeDecimal, 8, false)
+	assert.Empty(t, value)
+	assert.True(t, truncated)
+
+	firstText := strings.Repeat("a", 8_192)
+	firstItem := renditionListItem{present: true, blocks: []renditionBlock{{
+		kind: renditionParagraph, inlines: []renditionInline{{kind: renditionText, text: firstText}},
+	}}}
+	singleRepresentable := renditionList{ordered: true, start: "999999999", tight: true, items: []renditionListItem{firstItem}}
+	crossing := singleRepresentable
+	crossing.items = append(append([]renditionListItem(nil), crossing.items...), renditionListItem{
+		present: true,
+		blocks:  []renditionBlock{{kind: renditionParagraph, inlines: []renditionInline{{kind: renditionText, text: "x"}}}},
+	})
+	wantCrossing := "- 999999999\\. " + firstText + "\n- 1000000000\\. x"
+	singleBytes := allocatedBytes(func() (string, bool) {
+		return serializeRenditionList(singleRepresentable, len(wantCrossing)-1, false)
+	})
+	crossingBytes := allocatedBytes(func() (string, bool) {
+		return serializeRenditionList(crossing, len(wantCrossing), false)
+	})
+	require.Less(t, crossingBytes, singleBytes*2, "ordered degradation must not rebuild admitted item subtrees")
+	value, truncated = serializeRenditionList(crossing, len(wantCrossing), false)
+	assert.Equal(t, wantCrossing, value)
+	assert.False(t, truncated)
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    `<ol start="999999999"><li>` + firstText + `</li><li>x</li></ol>`,
+		}},
+	})
+	normalization := testNormalizePolicy(t, len(wantCrossing))
+	normalization.maxUnitChars = len(wantCrossing)
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	wantMarkdown := []byte(wantCrossing + "\n")
+	wantDigest := sha256.Sum256(wantMarkdown)
+	assert.Equal(t, wantMarkdown, rendered.Markdown)
+	assert.Equal(t, hex.EncodeToString(wantDigest[:]), rendered.MarkdownChecksum)
+
+	looseTree := func(depth int) renditionList {
+		block := renditionBlock{kind: renditionParagraph, inlines: []renditionInline{{kind: renditionText, text: "leaf"}}}
+		for range depth - 1 {
+			nested := renditionList{tight: false, items: []renditionListItem{{present: true, blocks: []renditionBlock{block}}}}
+			block = renditionBlock{kind: renditionListBlock, list: &nested}
+		}
+		return renditionList{tight: false, items: []renditionListItem{{present: true, blocks: []renditionBlock{block}}}}
+	}
+	expectedLooseTree := func(depth int) string {
+		var output strings.Builder
+		for level := range depth {
+			if level > 0 {
+				output.WriteByte('\n')
+			}
+			output.WriteString(strings.Repeat(" ", level*2))
+			output.WriteByte('-')
+			if level == depth-1 {
+				output.WriteString(" leaf")
+			}
+		}
+		for level := depth; level > 0; level-- {
+			output.WriteString("\n\n")
+			output.WriteString(strings.Repeat(" ", level*2))
+			output.WriteString("<!-- -->")
+		}
+		return output.String()
+	}
+	const smallDepth = 20
+	const largeDepth = 40
+	smallLoose := looseTree(smallDepth)
+	largeLoose := looseTree(largeDepth)
+	smallLooseMarkdown := expectedLooseTree(smallDepth)
+	largeLooseMarkdown := expectedLooseTree(largeDepth)
+	smallLooseBytes := allocatedBytes(func() (string, bool) {
+		return serializeRenditionList(smallLoose, len(smallLooseMarkdown), false)
+	})
+	largeLooseBytes := allocatedBytes(func() (string, bool) {
+		return serializeRenditionList(largeLoose, len(largeLooseMarkdown), false)
+	})
+	require.Less(
+		t,
+		largeLooseBytes*int64(len(smallLooseMarkdown))*2,
+		smallLooseBytes*int64(len(largeLooseMarkdown))*3,
+		"allocations per emitted byte must remain linear across fully admitted loose trees",
+	)
+	for _, test := range []struct {
+		name     string
+		list     renditionList
+		markdown string
+	}{{name: "small", list: smallLoose, markdown: smallLooseMarkdown}, {name: "large", list: largeLoose, markdown: largeLooseMarkdown}} {
+		t.Run(test.name+" fully admitted", func(t *testing.T) {
+			actual, actualTruncated := serializeRenditionList(test.list, len(test.markdown), false)
+			require.False(t, actualTruncated)
+			assert.Equal(t, test.markdown, actual)
+			assert.Contains(t, actual, "leaf")
+			expectedDigest := sha256.Sum256([]byte(test.markdown))
+			actualDigest := sha256.Sum256([]byte(actual))
+			assert.Equal(t, hex.EncodeToString(expectedDigest[:]), hex.EncodeToString(actualDigest[:]))
+		})
+	}
+
+	nestedLink := func(depth int) []renditionInline {
+		inline := renditionInline{kind: renditionText, text: "x"}
+		for range depth {
+			inline = renditionInline{
+				kind: renditionLinkInline, destination: "https://safe.example/", children: []renditionInline{inline},
+			}
+		}
+		return []renditionInline{inline}
+	}
+	smallLinks := nestedLink(64)
+	largeLinks := nestedLink(128)
+	smallLinkBytes := allocatedBytes(func() (string, bool) {
+		return serializeRenditionInlines(smallLinks, 64, false)
+	})
+	largeLinkBytes := allocatedBytes(func() (string, bool) {
+		return serializeRenditionInlines(largeLinks, 128, false)
+	})
+	require.Less(t, largeLinkBytes, smallLinkBytes*3, "nested link labels must serialize only once")
+}
+
+func TestBuildRenditionV1TruncatesExcessiveInlineNesting(t *testing.T) {
+	const depth = 1_024
+	source := `<div>` + strings.Repeat(`<a href="https://safe.example/">`, depth) +
+		"marker" + strings.Repeat(`</a>`, depth) + `</div>`
+	rendered := buildRenditionMarkdownForTest(t, source, 100_000)
+
+	assert.Contains(t, string(rendered.Markdown), "marker")
+	assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+}
+
+func expectedOrderedCrossingTopology(limit int) string {
+	if limit < 35 {
+		text := "nine"[:min(limit-11, len("nine"))]
+		return `ol(start=999999999,tight=true)[item[paragraph(` + strconv.Quote(text) + `)]]`
+	}
+	secondText := "ten"[:limit-34]
+	second := `paragraph(` + strconv.Quote(`1000000000\.`+" "+secondText) + `)`
+	return `ul(tight=true)[item[paragraph("999999999\\. nine")],item[` + second + `]]`
+}
+
+func buildRenditionMarkdownForTest(t *testing.T, source string, limit int) RenditionV1 {
+	t.Helper()
+	rendered, err := buildRenditionMarkdownResultForTest(t, source, limit)
+	require.NoError(t, err)
+	return rendered
+}
+
+func buildRenditionMarkdownResultForTest(t *testing.T, source string, limit int) (RenditionV1, error) {
+	t.Helper()
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    source,
+		}},
+	})
+	normalization := testNormalizePolicy(t, limit)
+	normalization.maxUnitChars = limit
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+	return BuildRenditionV1(evidence, policy)
+}
+
+func expectedNestedSiblingTopology(limit int, ordered bool) string {
+	topology := `ul(tight=true)[item[`
+	if ordered {
+		if limit >= 10 {
+			topology += `ol(start=4,tight=true)[item[`
+			one := "one"[:min(limit-9, len("one"))]
+			topology += `paragraph(` + strconv.Quote(one) + `)`
+			topology += `]]`
+		}
+		if limit >= 21 {
+			topology += `,ol(start=1,tight=true)[item[`
+			two := "two"[:limit-20]
+			topology += `paragraph(` + strconv.Quote(two) + `)`
+			topology += `]]`
+		}
+	} else {
+		if limit >= 7 {
+			topology += `ul(tight=true)[item[`
+			one := "one"[:min(limit-6, len("one"))]
+			topology += `paragraph(` + strconv.Quote(one) + `)`
+			topology += `]]`
+		}
+		if limit >= 15 {
+			topology += `,ul(tight=true)[item[`
+			two := "two"[:limit-14]
+			topology += `paragraph(` + strconv.Quote(two) + `)`
+			topology += `]]`
+		}
+	}
+	return topology + `]]`
+}
+
+func expectedNestedSiblingMarkdown(limit int, ordered bool) string {
+	full := "-\n  - one\n  * two"
+	firstStarts := 7
+	firstComplete := 9
+	secondStarts := 15
+	if ordered {
+		full = "-\n    4. one\n    1) two"
+		firstStarts = 10
+		firstComplete = 12
+		secondStarts = 21
+	}
+	if limit < firstStarts {
+		return "-"
+	}
+	if limit > firstComplete && limit < secondStarts {
+		return full[:firstComplete]
+	}
+	return full[:limit]
+}
+
+func TestBuildRenditionV1FinalizesOpenTableCellContextsInPlace(t *testing.T) {
+	prefix := `<table><tr><td>first</td><td><a href="javascript:alert(1)"><pre><code>retained inert`
+	evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceComplete,
+		Family:          "text",
+		UnitKind:        EvidenceUnitSection,
+		Units: []SourceEvidenceUnitV1{{
+			Order:   0,
+			Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+			Text:    prefix + `</code></pre></a></td></tr></table> discarded`,
+		}},
+	})
+	normalization := testNormalizePolicy(t, 100_000)
+	normalization.maxSourceUnitBytes = len(prefix)
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, "| first | retained inert |\n| --- | --- |\n", string(rendered.Markdown))
+	assert.NotContains(t, renderUnsafeMarkdown(t, rendered.Markdown), `href="javascript:`)
+	assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+}
+
+func TestBuildRenditionV1PrefixTruncatesRejectedLinkLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		text   string
+	}{
+		{name: "text only", source: `<a href="javascript:alert(1)">textonly</a>`, text: "textonly"},
+		{name: "code only", source: `<a href="javascript:alert(1)"><code>codeonly</code></a>`, text: "codeonly"},
+		{name: "mixed", source: `<a href="javascript:alert(1)">pre<code>code</code>post</a>`, text: "precodepost"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			evidence := normalizeRenditionEvidence(t, SourceEvidenceV1{
+				ContractVersion: SourceEvidenceContractV1,
+				Completeness:    EvidenceComplete,
+				Family:          "text",
+				UnitKind:        EvidenceUnitSection,
+				Units: []SourceEvidenceUnitV1{{
+					Order:   0,
+					Locator: SourceEvidenceLocatorV1{Kind: EvidenceLocatorSection, IndexOrigin: EvidenceIndexOriginNone},
+					Text:    test.source,
+				}},
+			})
+			for limit := 1; limit <= len(test.text); limit++ {
+				t.Run(strconv.Itoa(limit), func(t *testing.T) {
+					normalization := testNormalizePolicy(t, limit)
+					normalization.maxUnitChars = limit
+					policy, err := NewRenditionPolicy(normalization)
+					require.NoError(t, err)
+
+					rendered, err := BuildRenditionV1(evidence, policy)
+					require.NoError(t, err)
+					assert.Equal(t, test.text[:limit]+"\n", string(rendered.Markdown))
+					assert.NotContains(t, renderUnsafeMarkdown(t, rendered.Markdown), `href="javascript:`)
+				})
+			}
+		})
+	}
+}
+
+func assertTruncatedRenditionIsInert(t *testing.T, evidence NormalizedEvidenceV1, normalization NormalizePolicy) {
+	t.Helper()
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+	assert.NotContains(t, html, "<iframe")
+	assert.NotContains(t, html, `href="javascript:`)
+	assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+}
+
+func assertNestedLinkCodeIsInert(t *testing.T, evidence NormalizedEvidenceV1, normalization NormalizePolicy) {
+	t.Helper()
+	policy, err := NewRenditionPolicy(normalization)
+	require.NoError(t, err)
+	rendered, err := BuildRenditionV1(evidence, policy)
+	require.NoError(t, err)
+	html := renderUnsafeMarkdown(t, rendered.Markdown)
+	assert.NotContains(t, html, "<iframe")
+	assert.NotContains(t, html, `href="javascript:`)
+	assert.NotContains(t, html, `href="https://example.test/safe"`)
+	assert.Contains(t, rendered.Warnings, RenditionWarningV1{Code: "truncated"})
+}
+
+func renderUnsafeMarkdown(t *testing.T, markdown []byte) string {
+	t.Helper()
+	parser := goldmark.New(
+		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithRendererOptions(goldmarkhtml.WithUnsafe()),
+	)
+	var rendered bytes.Buffer
+	require.NoError(t, parser.Convert(markdown, &rendered))
+	return rendered.String()
+}
+
+func renditionMarkdownTopology(t *testing.T, markdown []byte) string {
+	t.Helper()
+	parser := goldmark.New(goldmark.WithExtensions(extension.GFM)).Parser()
+	document := parser.Parse(text.NewReader(markdown))
+	roots := make([]string, 0, document.ChildCount())
+	for child := document.FirstChild(); child != nil; child = child.NextSibling() {
+		if block, ok := child.(*ast.HTMLBlock); ok && strings.TrimSpace(string(block.Lines().Value(markdown))) == "<!-- -->" {
+			continue
+		}
+		roots = append(roots, renditionMarkdownNodeTopology(child, markdown))
+	}
+	return strings.Join(roots, " | ")
+}
+
+func renditionMarkdownNodeTopology(node ast.Node, source []byte) string {
+	switch typed := node.(type) {
+	case *ast.List:
+		kind := "ul(tight=" + strconv.FormatBool(typed.IsTight) + ")"
+		if typed.IsOrdered() {
+			kind = "ol(start=" + strconv.Itoa(typed.Start) + ",tight=" + strconv.FormatBool(typed.IsTight) + ")"
+		}
+		children := renditionMarkdownChildTopologies(typed, source)
+		return kind + "[" + strings.Join(children, ",") + "]"
+	case *ast.ListItem:
+		return "item[" + strings.Join(renditionMarkdownChildTopologies(typed, source), ",") + "]"
+	case *ast.Paragraph, *ast.TextBlock:
+		return "paragraph(" + strconv.Quote(string(node.Lines().Value(source))) + ")"
+	case *ast.Heading:
+		return "heading(level=" + strconv.Itoa(typed.Level) + "," + strconv.Quote(string(typed.Lines().Value(source))) + ")"
+	case *ast.FencedCodeBlock:
+		return "code(" + strconv.Quote(strings.TrimSuffix(string(typed.Lines().Value(source)), "\n")) + ")"
+	case *extensionast.Table:
+		return "table"
+	default:
+		return node.Kind().String()
+	}
+}
+
+func renditionMarkdownChildTopologies(node ast.Node, source []byte) []string {
+	children := make([]string, 0, node.ChildCount())
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		if block, ok := child.(*ast.HTMLBlock); ok && strings.TrimSpace(string(block.Lines().Value(source))) == "<!-- -->" {
+			continue
+		}
+		children = append(children, renditionMarkdownNodeTopology(child, source))
+	}
+	return children
+}

--- a/document/testdata/rendition-v1.golden.md
+++ b/document/testdata/rendition-v1.golden.md
@@ -1,0 +1,19 @@
+# Damage report
+The carton was crushed\. [Safe](<https://example.test/report?id=42>) and unsafe\.
+
+Photo evidence
+| Item | Count |
+| --- | --- |
+| Carton | 3 |
+| Pallet | 1 |
+## Inspection
+- First edge
+- Second edge
+```go
+package synthetic
+```
+
+---
+
+# Follow\-up
+[Allowed](<https://example.test/follow-up>)


### PR DESCRIPTION
## What changed

Docbank can now turn canonical evidence into sanitized Markdown, normalized units, and model-independent lexical segments in one bounded pass. The rendition keeps useful document structure—headings, lists, task checkboxes, tables, code, safe links, and page boundaries—while stripping active HTML, scripts, styles, unsafe URLs, and provider control markup.

Stable checksums bind the displayed Markdown and lexical index to the same source rendition. If a source or output budget is exhausted, Docbank emits a structurally valid prefix instead of malformed Markdown.

## Why

Provider output cannot become durable document authority as-is. We need one deterministic boundary that preserves useful structure without letting active content, unsafe links, or provider-specific markup leak into stored Markdown or search.

## Usage

Build a safe rendition from canonical evidence:

```go
policy, err := document.NewRenditionPolicy(normalizePolicy)
if err != nil {
	return err
}
rendition, err := document.BuildRenditionV1(evidence, policy)
```

This adds the document contract only; it does not change storage or serving yet.

Part of #176 (F2).
