### PR TITLE
Publish renditions and lexical generations atomically

### DIFF
--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -321,17 +321,18 @@ func TestJSONLSnapshotRestoresRenditionBytesBeforeVerifyingHeads(t *testing.T) {
 		},
 	}
 	require.NoError(t, fixture.metadata.StageRenditionBuild(t.Context(), build))
+	generation, err := fixture.metadata.StageLexicalGeneration(t.Context(), strings.Repeat("f", 64))
+	require.NoError(t, err)
 	attachment := store.RenditionAttachmentRecord{
 		ID: strings.Repeat("9", 64), VaultID: fixture.metadata.VaultID(),
 		ContentVersionID: source.CurrentVersionID, BuildID: build.ID,
 		Profile: profileRecord, AttachedAt: "2026-08-25T12:01:00.000000000Z",
 	}
-	require.NoError(t, fixture.metadata.AttachRenditionBuild(t.Context(), attachment))
-	require.NoError(t, fixture.metadata.PublishRenditionHead(t.Context(), store.RenditionHeadRecord{
+	require.NoError(t, fixture.metadata.PublishRenditionAndLexicalHeads(t.Context(), attachment, store.RenditionHeadRecord{
 		ContentVersionID:             source.CurrentVersionID,
 		ProcessingProfileFingerprint: profileRecord.Fingerprint,
 		AttachmentID:                 attachment.ID, PublishedAt: "2026-08-25T12:02:00.000000000Z",
-	}))
+	}, generation.ID))
 
 	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
 	require.NoError(t, err)

--- a/internal/processing/artifacts.go
+++ b/internal/processing/artifacts.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 
 	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/internal/blob"
@@ -221,7 +222,7 @@ func validateStagedRendition(staged StagedRendition) error {
 	}
 	if !reflect.DeepEqual(units, staged.Build.Units) ||
 		!reflect.DeepEqual(segments, staged.Build.LexicalSegments) ||
-		!reflect.DeepEqual(warnings, staged.Build.Warnings) {
+		!slices.Equal(warnings, staged.Build.Warnings) {
 		return errors.New("staged rendition units, lexical segments, or warnings disagree with its build")
 	}
 

--- a/internal/processing/artifacts.go
+++ b/internal/processing/artifacts.go
@@ -1,0 +1,280 @@
+package processing
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/store"
+)
+
+// StagedArtifact binds one immutable catalog member to its retained payload.
+// Payload is consumed once by PublishRendition.
+type StagedArtifact struct {
+	ID      string
+	Payload io.Reader
+}
+
+// StagedRendition contains one complete dormant catalog candidate and the
+// exact version-scoped authority that may publish it.
+type StagedRendition struct {
+	Rendition           document.RenditionV1
+	RenditionPolicy     document.RenditionPolicy
+	Build               store.RenditionBuildRecord
+	Attachment          store.RenditionAttachmentRecord
+	Head                store.RenditionHeadRecord
+	LexicalGenerationID string
+	Artifacts           []StagedArtifact
+}
+
+// PublishedArtifact is the verified physical receipt for one retained member.
+type PublishedArtifact struct {
+	ID   string
+	Hash string
+	Size int64
+}
+
+// PublishedRendition records the exact immutable and mutable heads selected by
+// one successful publication.
+type PublishedRendition struct {
+	BuildID           string
+	AttachmentID      string
+	LexicalGeneration LexicalGeneration
+	Artifacts         []PublishedArtifact
+}
+
+type renditionBlobWriter interface {
+	WriteDetailedContext(ctx context.Context, reader io.Reader) (blob.WriteReceipt, error)
+	WithMutation(ctx context.Context, fn func() error) error
+}
+
+type renditionPublicationCatalog interface {
+	RecordRenditionBlob(
+		ctx context.Context, hash string, size int64, physical store.BlobPhysical,
+	) error
+	StageRenditionBuild(ctx context.Context, record store.RenditionBuildRecord) error
+	StageLexicalGeneration(
+		ctx context.Context, generationID string,
+	) (store.LexicalGeneration, error)
+	PublishRenditionAndLexicalHeads(
+		ctx context.Context, attachment store.RenditionAttachmentRecord,
+		head store.RenditionHeadRecord, generationID string,
+	) error
+}
+
+// ArtifactPublisher verifies retained bytes, stages immutable catalog and FTS
+// state, then publishes only through one atomic attachment/head transaction.
+type ArtifactPublisher struct {
+	catalog renditionPublicationCatalog
+	blobs   renditionBlobWriter
+}
+
+// NewArtifactPublisher binds publication to one vault catalog and its verified
+// Docbank CAS writer.
+func NewArtifactPublisher(
+	catalog renditionPublicationCatalog, blobs renditionBlobWriter,
+) (*ArtifactPublisher, error) {
+	if catalog == nil || blobs == nil {
+		return nil, errors.New("artifact publisher requires catalog and blob stores")
+	}
+	return &ArtifactPublisher{catalog: catalog, blobs: blobs}, nil
+}
+
+// PublishRendition writes and verifies every retained payload before the
+// catalog build exists. The build and FTS generation remain unreachable until
+// the final transaction inserts the attachment and flips both serving heads.
+func (p *ArtifactPublisher) PublishRendition(
+	ctx context.Context, staged StagedRendition,
+) (PublishedRendition, error) {
+	if err := validateStagedRendition(staged); err != nil {
+		return PublishedRendition{}, err
+	}
+	var published PublishedRendition
+	err := p.blobs.WithMutation(ctx, func() error {
+		artifacts := make(map[string]StagedArtifact, len(staged.Artifacts))
+		for _, artifact := range staged.Artifacts {
+			artifacts[artifact.ID] = artifact
+		}
+		type verifiedArtifact struct {
+			published PublishedArtifact
+			physical  store.BlobPhysical
+		}
+		verified := make([]verifiedArtifact, 0, len(staged.Build.Artifacts))
+		var normalizedEvidence []byte
+		for _, record := range staged.Build.Artifacts {
+			candidate := artifacts[record.ID]
+			reader := candidate.Payload
+			var evidence bytes.Buffer
+			if record.Role == "normalized_evidence" {
+				reader = io.TeeReader(reader, &evidence)
+			}
+			receipt, err := p.blobs.WriteDetailedContext(ctx, reader)
+			if err != nil {
+				return fmt.Errorf("publishing rendition artifact %s: %w", record.ID, err)
+			}
+			if receipt.Hash != record.BlobHash || receipt.Size != record.Size {
+				return fmt.Errorf(
+					"publishing rendition artifact %s: verified receipt %s/%d does not match catalog %s/%d",
+					record.ID, receipt.Hash, receipt.Size, record.BlobHash, record.Size,
+				)
+			}
+			encoding, err := receipt.EncodingName()
+			if err != nil {
+				return fmt.Errorf("publishing rendition artifact %s: %w", record.ID, err)
+			}
+			physical := store.BlobPhysical{
+				Encoding: encoding, StoredBytes: receipt.StoredSize,
+				PackEligible: receipt.PackEligible, Created: receipt.Created,
+			}
+			verified = append(verified, verifiedArtifact{
+				published: PublishedArtifact{ID: record.ID, Hash: receipt.Hash, Size: receipt.Size},
+				physical:  physical,
+			})
+			if record.Role == "normalized_evidence" {
+				normalizedEvidence = append([]byte(nil), evidence.Bytes()...)
+			}
+		}
+		if err := validateStagedRenditionGraph(staged, normalizedEvidence); err != nil {
+			return err
+		}
+		publishedArtifacts := make([]PublishedArtifact, 0, len(verified))
+		for _, artifact := range verified {
+			if err := p.catalog.RecordRenditionBlob(
+				ctx, artifact.published.Hash, artifact.published.Size, artifact.physical,
+			); err != nil {
+				return fmt.Errorf("recording rendition artifact %s: %w", artifact.published.ID, err)
+			}
+			publishedArtifacts = append(publishedArtifacts, artifact.published)
+		}
+		if err := p.catalog.StageRenditionBuild(ctx, staged.Build); err != nil {
+			return fmt.Errorf("staging rendition catalog: %w", err)
+		}
+		generation, err := rebuildLexicalGeneration(ctx, p.catalog, staged.LexicalGenerationID)
+		if err != nil {
+			return fmt.Errorf("rebuilding lexical generation: %w", err)
+		}
+		if err := p.catalog.PublishRenditionAndLexicalHeads(
+			ctx, staged.Attachment, staged.Head, generation.ID,
+		); err != nil {
+			return fmt.Errorf("publishing rendition generation: %w", err)
+		}
+		published = PublishedRendition{
+			BuildID: staged.Build.ID, AttachmentID: staged.Attachment.ID,
+			LexicalGeneration: generation, Artifacts: publishedArtifacts,
+		}
+		return nil
+	})
+	if err != nil {
+		return PublishedRendition{}, err
+	}
+	return published, nil
+}
+
+func validateStagedRendition(staged StagedRendition) error {
+	if staged.Build.ID == "" || staged.Attachment.ID == "" || staged.LexicalGenerationID == "" {
+		return errors.New("staged rendition lacks exact publication identities")
+	}
+	if staged.Attachment.BuildID != staged.Build.ID || staged.Head.AttachmentID != staged.Attachment.ID ||
+		staged.Head.ContentVersionID != staged.Attachment.ContentVersionID ||
+		staged.Head.ProcessingProfileFingerprint != staged.Attachment.Profile.Fingerprint {
+		return errors.New("staged rendition head does not resolve through its exact attachment and build")
+	}
+	if staged.Rendition.ContractVersion != document.RenditionContractV1 ||
+		staged.Rendition.Checksum != staged.Build.RenditionChecksum ||
+		staged.Rendition.EvidenceChecksum != staged.Build.EvidenceChecksum ||
+		staged.Rendition.MarkdownChecksum != staged.Build.MarkdownChecksum ||
+		staged.Rendition.Completeness != staged.Build.Completeness {
+		return errors.New("staged rendition does not match its immutable build")
+	}
+	markdownDigest := sha256.Sum256(staged.Rendition.Markdown)
+	if hex.EncodeToString(markdownDigest[:]) != staged.Rendition.MarkdownChecksum {
+		return errors.New("staged rendition Markdown checksum does not match its bytes")
+	}
+
+	units := make([]store.RenditionUnitRecord, len(staged.Rendition.Units))
+	for index, unit := range staged.Rendition.Units {
+		units[index] = store.RenditionUnitRecord{
+			ID: unit.ID, EvidenceUnitID: unit.EvidenceUnitID, Order: unit.Order,
+			Checksum: unit.Checksum, HeadingPath: append([]string(nil), unit.HeadingPath...),
+			Locator: unit.Locator,
+		}
+	}
+	segments := make([]store.RenditionLexicalSegmentRecord, len(staged.Rendition.LexicalSegments))
+	for index, segment := range staged.Rendition.LexicalSegments {
+		segments[index] = store.RenditionLexicalSegmentRecord{
+			ID: segment.ID, UnitID: segment.UnitID, Order: segment.Order,
+			CharStart: segment.CharStart, CharEnd: segment.CharEnd,
+			Checksum: segment.Checksum, Text: segment.Text,
+		}
+	}
+	warnings := make([]string, len(staged.Rendition.Warnings))
+	for index, warning := range staged.Rendition.Warnings {
+		warnings[index] = warning.Code
+	}
+	if !reflect.DeepEqual(units, staged.Build.Units) ||
+		!reflect.DeepEqual(segments, staged.Build.LexicalSegments) ||
+		!reflect.DeepEqual(warnings, staged.Build.Warnings) {
+		return errors.New("staged rendition units, lexical segments, or warnings disagree with its build")
+	}
+
+	if len(staged.Artifacts) != len(staged.Build.Artifacts) {
+		return errors.New("staged rendition retained payload membership is incomplete")
+	}
+	declared := make(map[string]store.RenditionArtifactRecord, len(staged.Build.Artifacts))
+	for _, artifact := range staged.Build.Artifacts {
+		if _, exists := declared[artifact.ID]; exists {
+			return fmt.Errorf("staged rendition artifact %q is duplicated", artifact.ID)
+		}
+		declared[artifact.ID] = artifact
+		if artifact.Role == "sanitized_markdown" && artifact.BlobHash != staged.Rendition.MarkdownChecksum {
+			return errors.New("staged sanitized Markdown artifact disagrees with rendition bytes")
+		}
+		if artifact.Role == "normalized_evidence" && artifact.BlobHash != staged.Rendition.EvidenceChecksum {
+			return errors.New("staged normalized evidence artifact disagrees with rendition bytes")
+		}
+	}
+	seen := make(map[string]bool, len(staged.Artifacts))
+	for _, artifact := range staged.Artifacts {
+		if artifact.ID == "" || artifact.Payload == nil {
+			return errors.New("staged rendition artifact payload is incomplete")
+		}
+		if _, exists := declared[artifact.ID]; !exists || seen[artifact.ID] {
+			return fmt.Errorf("staged rendition artifact payload %q is not exact membership", artifact.ID)
+		}
+		seen[artifact.ID] = true
+	}
+	return nil
+}
+
+func validateStagedRenditionGraph(staged StagedRendition, normalizedEvidence []byte) error {
+	var evidence document.NormalizedEvidenceV1
+	if err := json.Unmarshal(normalizedEvidence, &evidence, json.RejectUnknownMembers(true)); err != nil {
+		return fmt.Errorf("staged normalized evidence is invalid: %w", err)
+	}
+	canonicalEvidence, evidenceChecksum, err := document.MarshalNormalizedEvidenceV1(evidence)
+	if err != nil {
+		return fmt.Errorf("staged normalized evidence is invalid: %w", err)
+	}
+	if !bytes.Equal(canonicalEvidence, normalizedEvidence) {
+		return errors.New("staged normalized evidence is not exact canonical bytes")
+	}
+	if evidenceChecksum != staged.Rendition.EvidenceChecksum {
+		return errors.New("staged normalized evidence checksum does not match the rendition")
+	}
+	expected, err := document.BuildRenditionV1(evidence, staged.RenditionPolicy)
+	if err != nil {
+		return fmt.Errorf("rebuilding staged rendition from normalized evidence: %w", err)
+	}
+	if !reflect.DeepEqual(expected, staged.Rendition) {
+		return errors.New("staged rendition does not match deterministic producer output")
+	}
+	return nil
+}

--- a/internal/processing/artifacts_test.go
+++ b/internal/processing/artifacts_test.go
@@ -1,0 +1,542 @@
+package processing
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/jsontext"
+	"errors"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/store"
+)
+
+var errInjectedPublication = errors.New("injected publication failure")
+
+func TestPublishRenditionPublishesVerifiedArtifactsAndHeads(t *testing.T) {
+	// Mutation caught: omitting physical membership or either head publication
+	// would leave the successful result unreadable through its public stores.
+	fixture := newPublicationFixture(t)
+	publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+	require.NoError(t, err)
+
+	published, err := publisher.PublishRendition(t.Context(), fixture.stage(t,
+		publicationIDs{"b1", "51", "91"}, "searchable mercury evidence", "first markdown",
+	))
+	require.NoError(t, err)
+	assert.Equal(t, processingHash("b1"), published.BuildID)
+	assert.Equal(t, processingHash("51"), published.AttachmentID)
+	assert.Equal(t, processingHash("91"), published.LexicalGeneration.ID)
+	require.Len(t, published.Artifacts, 2)
+	for _, artifact := range published.Artifacts {
+		physical, err := fixture.catalog.PhysicalContent(t.Context(), artifact.Hash)
+		require.NoError(t, err)
+		assert.Equal(t, artifact.Size, physical.LogicalBytes)
+	}
+
+	view, err := fixture.catalog.ActiveRendition(
+		t.Context(), fixture.versionID, fixture.profile.Fingerprint,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, published.BuildID, view.Build.ID)
+	active, err := fixture.catalog.ActiveLexicalGeneration(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, published.LexicalGeneration, active)
+	hits, _, err := fixture.catalog.SearchPage(t.Context(), "mercury", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, fixture.versionID, hits[0].Node.CurrentVersionID)
+	assert.Equal(t, store.SearchMatchContent, hits[0].Match)
+}
+
+func TestPublishRenditionRejectsArtifactReceiptMismatchBeforeCatalogAuthority(t *testing.T) {
+	// Mutation caught: trusting declared size instead of the verified CAS
+	// receipt would grant catalog authority to bytes from a rejected candidate.
+	fixture := newPublicationFixture(t)
+	publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+	require.NoError(t, err)
+	staged := fixture.stage(t,
+		publicationIDs{"b1", "51", "91"}, "searchable mercury evidence", "first markdown",
+	)
+	actualHash := staged.Build.Artifacts[0].BlobHash
+	staged.Build.Artifacts[0].Size++
+
+	_, err = publisher.PublishRendition(t.Context(), staged)
+	require.Error(t, err)
+	_, err = fixture.catalog.PhysicalContent(t.Context(), actualHash)
+	require.ErrorIs(t, err, store.ErrNotFound,
+		"a rejected receipt must not gain catalog-authorized membership")
+	_, err = fixture.catalog.ActiveRendition(
+		t.Context(), fixture.versionID, fixture.profile.Fingerprint,
+	)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestPublishRenditionRejectsForgedProducerGraph(t *testing.T) {
+	// Mutation caught: trusting caller-supplied rendition, unit, and segment
+	// checksums allows unrelated evidence, Markdown, and searchable text to be
+	// staged as one immutable build.
+	for _, testCase := range []struct {
+		name   string
+		want   string
+		mutate func(*testing.T, *StagedRendition)
+	}{
+		{
+			name: "noncanonical normalized evidence bytes with forged checksums",
+			want: "not exact canonical bytes",
+			mutate: func(t *testing.T, staged *StagedRendition) {
+				t.Helper()
+				evidenceBytes, err := io.ReadAll(staged.Artifacts[0].Payload)
+				require.NoError(t, err)
+				evidenceBytes = append(evidenceBytes, '\n')
+				evidenceHash := processingSHA256(evidenceBytes)
+				staged.Artifacts[0].Payload = bytes.NewReader(evidenceBytes)
+				staged.Build.Artifacts[0].BlobHash = evidenceHash
+				staged.Build.Artifacts[0].Checksum = evidenceHash
+				staged.Build.Artifacts[0].Size = int64(len(evidenceBytes))
+				staged.Rendition.EvidenceChecksum = evidenceHash
+				staged.Build.EvidenceChecksum = evidenceHash
+				staged.Rendition.Checksum = processingRenditionChecksum(staged.Rendition)
+				staged.Build.RenditionChecksum = staged.Rendition.Checksum
+			},
+		},
+		{
+			name: "search text unrelated to rendition unit with forged checksums",
+			want: "does not match deterministic producer output",
+			mutate: func(t *testing.T, staged *StagedRendition) {
+				t.Helper()
+				segment := &staged.Rendition.LexicalSegments[0]
+				segment.Text = "forged searchable text"
+				segment.CharEnd = len([]rune(segment.Text))
+				segment.Checksum = processingChecksumStrings(
+					document.RenditionContractV1, segment.UnitID, strconv.Itoa(segment.Order),
+					strconv.Itoa(segment.CharStart), strconv.Itoa(segment.CharEnd), segment.Text,
+				)
+				segment.ID = "lexical_segment_" + segment.Checksum
+				staged.Build.LexicalSegments[0] = store.RenditionLexicalSegmentRecord{
+					ID: segment.ID, UnitID: segment.UnitID, Order: segment.Order,
+					CharStart: segment.CharStart, CharEnd: segment.CharEnd,
+					Checksum: segment.Checksum, Text: segment.Text,
+				}
+				staged.Rendition.Checksum = processingRenditionChecksum(staged.Rendition)
+				staged.Build.RenditionChecksum = staged.Rendition.Checksum
+			},
+		},
+		{
+			name: "self consistent rendition unrelated to producer output",
+			want: "does not match deterministic producer output",
+			mutate: func(t *testing.T, staged *StagedRendition) {
+				t.Helper()
+				unit := &staged.Rendition.Units[0]
+				unit.Text = "fully forged but internally consistent text"
+				unit.Checksum = processingChecksumStrings(
+					document.RenditionContractV1, unit.EvidenceUnitID, strconv.Itoa(unit.Order),
+					unit.Text, strings.Join(unit.HeadingPath, "\x00"),
+				)
+				unit.ID = "rendition_unit_" + unit.Checksum
+				staged.Build.Units[0] = store.RenditionUnitRecord{
+					ID: unit.ID, EvidenceUnitID: unit.EvidenceUnitID, Order: unit.Order,
+					Checksum: unit.Checksum, HeadingPath: append([]string(nil), unit.HeadingPath...),
+					Locator: unit.Locator,
+				}
+				staged.Rendition.Markdown = []byte(unit.Text + "\n")
+				staged.Rendition.MarkdownChecksum = processingSHA256(staged.Rendition.Markdown)
+				staged.Build.MarkdownChecksum = staged.Rendition.MarkdownChecksum
+				staged.Artifacts[1].Payload = bytes.NewReader(staged.Rendition.Markdown)
+				staged.Build.Artifacts[1].BlobHash = staged.Rendition.MarkdownChecksum
+				staged.Build.Artifacts[1].Checksum = staged.Rendition.MarkdownChecksum
+				staged.Build.Artifacts[1].Size = int64(len(staged.Rendition.Markdown))
+
+				segment := &staged.Rendition.LexicalSegments[0]
+				segment.UnitID = unit.ID
+				segment.Text = unit.Text
+				segment.CharEnd = len([]rune(segment.Text))
+				segment.Checksum = processingChecksumStrings(
+					document.RenditionContractV1, segment.UnitID, strconv.Itoa(segment.Order),
+					strconv.Itoa(segment.CharStart), strconv.Itoa(segment.CharEnd), segment.Text,
+				)
+				segment.ID = "lexical_segment_" + segment.Checksum
+				staged.Build.LexicalSegments[0] = store.RenditionLexicalSegmentRecord{
+					ID: segment.ID, UnitID: segment.UnitID, Order: segment.Order,
+					CharStart: segment.CharStart, CharEnd: segment.CharEnd,
+					Checksum: segment.Checksum, Text: segment.Text,
+				}
+				staged.Rendition.Checksum = processingRenditionChecksum(staged.Rendition)
+				staged.Build.RenditionChecksum = staged.Rendition.Checksum
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newPublicationFixture(t)
+			publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+			require.NoError(t, err)
+			staged := fixture.stage(t,
+				publicationIDs{"bf", "5f", "9f"}, "canonical searchable text", "canonical heading",
+			)
+			testCase.mutate(t, &staged)
+
+			_, err = publisher.PublishRendition(t.Context(), staged)
+			require.ErrorContains(t, err, testCase.want)
+			_, err = fixture.catalog.ActiveRendition(
+				t.Context(), fixture.versionID, fixture.profile.Fingerprint,
+			)
+			require.ErrorIs(t, err, store.ErrNotFound)
+		})
+	}
+}
+
+func TestPublishRenditionFailureAfterBlobClosePreservesPriorHeads(t *testing.T) {
+	// Mutation caught: continuing after a blob writer reports a terminal-close
+	// failure would make an unverified retained payload reachable.
+	fixture := newPublicationFixture(t)
+	publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+	require.NoError(t, err)
+	first, err := publisher.PublishRendition(t.Context(), fixture.stage(t,
+		publicationIDs{"b1", "51", "91"}, "prior mercury evidence", "first markdown",
+	))
+	require.NoError(t, err)
+
+	failingWriter := &failAfterClosedBlobWriter{Store: fixture.blobs}
+	failingPublisher, err := NewArtifactPublisher(fixture.catalog, failingWriter)
+	require.NoError(t, err)
+	_, err = failingPublisher.PublishRendition(t.Context(), fixture.stage(t,
+		publicationIDs{"b2", "52", "92"}, "replacement venus evidence", "second markdown",
+	))
+	require.ErrorIs(t, err, errInjectedPublication)
+	assertPriorPublicationServes(t, fixture, first)
+}
+
+func TestPublishRenditionFailureAfterCatalogStagePreservesPriorHeads(t *testing.T) {
+	// Mutation caught: treating a staged immutable build as published would let
+	// catalog membership bypass version-scoped attachment and head authority.
+	fixture := newPublicationFixture(t)
+	publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+	require.NoError(t, err)
+	first, err := publisher.PublishRendition(t.Context(), fixture.stage(t,
+		publicationIDs{"b1", "51", "91"}, "prior mercury evidence", "first markdown",
+	))
+	require.NoError(t, err)
+
+	failingCatalog := &failAfterCatalogStage{renditionPublicationCatalog: fixture.catalog}
+	failingPublisher, err := NewArtifactPublisher(failingCatalog, fixture.blobs)
+	require.NoError(t, err)
+	second := fixture.replacementStage(t,
+		publicationIDs{"b2", "52", "92"}, "replacement venus evidence", "second markdown",
+	)
+	_, err = failingPublisher.PublishRendition(t.Context(), second)
+	require.ErrorIs(t, err, errInjectedPublication)
+	assertPriorPublicationServes(t, fixture, first)
+
+	assert.True(t, failingCatalog.staged,
+		"the injected failure occurs after the immutable build is staged")
+}
+
+type publicationFixture struct {
+	catalog         *store.Store
+	blobs           *blob.Store
+	profile         store.ProcessingProfileRecord
+	evidencePolicy  document.EvidencePolicy
+	renditionPolicy document.RenditionPolicy
+	versionID       string
+}
+
+type publicationIDs struct {
+	build, attachment, generation string
+}
+
+func newPublicationFixture(t *testing.T) publicationFixture {
+	t.Helper()
+	root := t.TempDir()
+	catalog, err := store.Open(filepath.Join(root, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, catalog.Close()) })
+	blobs, err := blob.New(store.NewPackCatalog(catalog), filepath.Join(root, "blobs"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, blobs.Close()) })
+
+	source := []byte("synthetic private-free source")
+	receipt, err := blobs.WriteDetailedContext(t.Context(), bytes.NewReader(source))
+	require.NoError(t, err)
+	physical := processingBlobPhysical(t, receipt)
+	node, err := catalog.CreateFile(
+		t.Context(), catalog.RootID(), "source.pdf", receipt.Hash, receipt.Size,
+		"application/pdf", physical,
+	)
+	require.NoError(t, err)
+	evidencePolicy, err := document.NewEvidencePolicy(100_000)
+	require.NoError(t, err)
+	normalizationPolicy, err := document.NewNormalizePolicy(100_000)
+	require.NoError(t, err)
+	renditionPolicy, err := document.NewRenditionPolicy(normalizationPolicy)
+	require.NoError(t, err)
+	return publicationFixture{
+		catalog: catalog, blobs: blobs, profile: processingProfile(t),
+		evidencePolicy: evidencePolicy, renditionPolicy: renditionPolicy,
+		versionID: node.CurrentVersionID,
+	}
+}
+
+func (f publicationFixture) stage(
+	t *testing.T,
+	ids publicationIDs, lexicalText, markdown string,
+) StagedRendition {
+	t.Helper()
+	return f.stageForSource(t, ids, lexicalText, markdown, f.versionID, f.mustSourceHash())
+}
+
+func (f publicationFixture) replacementStage(
+	t *testing.T, ids publicationIDs, lexicalText, markdown string,
+) StagedRendition {
+	t.Helper()
+	source := []byte("replacement source " + ids.build)
+	receipt, err := f.blobs.WriteDetailedContext(t.Context(), bytes.NewReader(source))
+	require.NoError(t, err)
+	node, err := f.catalog.CreateFile(
+		t.Context(), f.catalog.RootID(), "replacement-"+ids.build+".pdf",
+		receipt.Hash, receipt.Size, "application/pdf", processingBlobPhysical(t, receipt),
+	)
+	require.NoError(t, err)
+	return f.stageForSource(t, ids, lexicalText, markdown, node.CurrentVersionID, receipt.Hash)
+}
+
+func (f publicationFixture) stageForSource(
+	t *testing.T,
+	ids publicationIDs, lexicalText, markdown, versionID, sourceHash string,
+) StagedRendition {
+	t.Helper()
+	normalizedEvidence, err := document.NormalizeEvidenceV1(document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1,
+		Completeness:    document.EvidenceComplete,
+		Family:          "pdf",
+		UnitKind:        document.EvidenceUnitPage,
+		Units: []document.SourceEvidenceUnitV1{{
+			Order: 0, Text: lexicalText, HeadingPath: []string{markdown},
+			Locator: document.SourceEvidenceLocatorV1{
+				Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginOne,
+				Start: 1, End: 1,
+			},
+		}},
+	}, f.evidencePolicy)
+	require.NoError(t, err)
+	evidence, evidenceHash, err := document.MarshalNormalizedEvidenceV1(normalizedEvidence)
+	require.NoError(t, err)
+	rendition, err := document.BuildRenditionV1(normalizedEvidence, f.renditionPolicy)
+	require.NoError(t, err)
+	markdownBytes := rendition.Markdown
+	markdownHash := rendition.MarkdownChecksum
+	policy := jsontext.Value(`{"roles":[{"max_count":1,"min_count":1,"role":"normalized_evidence"},{"max_count":1,"min_count":1,"role":"sanitized_markdown"}],"version":1}`)
+	warnings := make([]string, len(rendition.Warnings))
+	for index, warning := range rendition.Warnings {
+		warnings[index] = warning.Code
+	}
+	units := make([]store.RenditionUnitRecord, len(rendition.Units))
+	for index, unit := range rendition.Units {
+		units[index] = store.RenditionUnitRecord{
+			ID: unit.ID, EvidenceUnitID: unit.EvidenceUnitID, Order: unit.Order,
+			Checksum: unit.Checksum, HeadingPath: append([]string(nil), unit.HeadingPath...),
+			Locator: unit.Locator,
+		}
+	}
+	segments := make([]store.RenditionLexicalSegmentRecord, len(rendition.LexicalSegments))
+	for index, segment := range rendition.LexicalSegments {
+		segments[index] = store.RenditionLexicalSegmentRecord{
+			ID: segment.ID, UnitID: segment.UnitID, Order: segment.Order,
+			CharStart: segment.CharStart, CharEnd: segment.CharEnd,
+			Checksum: segment.Checksum, Text: segment.Text,
+		}
+	}
+	build := store.RenditionBuildRecord{
+		ID: processingHash(ids.build), VaultID: f.catalog.VaultID(),
+		SourceSHA256:                      sourceHash,
+		RenditionRequestFingerprint:       f.profile.RenditionRequestFingerprint,
+		EvidenceLexicalFingerprint:        f.profile.EvidenceLexicalFingerprint,
+		CapturedArtifactPolicyFingerprint: processingSHA256(policy),
+		CapturedArtifactPolicy:            policy, AuthorizationChecksum: processingHash(ids.build + "a6"),
+		ProviderOperationID: "synthetic-operation-" + ids.build,
+		ProviderReceipt:     jsontext.Value(`{"provider":"synthetic","request_id":"` + ids.build + `"}`),
+		EvidenceChecksum:    evidenceHash, RenditionChecksum: rendition.Checksum,
+		MarkdownChecksum: markdownHash, Completeness: document.EvidenceComplete,
+		Warnings: warnings, CompletedAt: "2026-08-22T09:00:00.000000000Z",
+		DeclaredArtifactCount: 2,
+		Artifacts: []store.RenditionArtifactRecord{
+			{ID: "artifact_" + processingHash(ids.build+"21"), Role: "normalized_evidence", BlobHash: evidenceHash,
+				Size: int64(len(evidence)), Checksum: evidenceHash, State: store.RenditionArtifactVerified},
+			{ID: "artifact_" + processingHash(ids.build+"22"), Role: "sanitized_markdown", BlobHash: markdownHash,
+				Size: int64(len(markdownBytes)), Checksum: markdownHash, State: store.RenditionArtifactVerified},
+		},
+		Units: units, LexicalSegments: segments,
+	}
+	attachment := store.RenditionAttachmentRecord{
+		ID: processingHash(ids.attachment), VaultID: f.catalog.VaultID(),
+		ContentVersionID: versionID, BuildID: build.ID, Profile: f.profile,
+		AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+	return StagedRendition{
+		Rendition: rendition, RenditionPolicy: f.renditionPolicy,
+		Build: build, Attachment: attachment,
+		Head: store.RenditionHeadRecord{
+			ContentVersionID: versionID, ProcessingProfileFingerprint: f.profile.Fingerprint,
+			AttachmentID: attachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+		},
+		LexicalGenerationID: processingHash(ids.generation),
+		Artifacts: []StagedArtifact{
+			{ID: build.Artifacts[0].ID, Payload: bytes.NewReader(evidence)},
+			{ID: build.Artifacts[1].ID, Payload: bytes.NewReader(markdownBytes)},
+		},
+	}
+}
+
+func (f publicationFixture) mustSourceHash() string {
+	node, err := f.catalog.NodeByPath(context.Background(), "/source.pdf")
+	if err != nil {
+		panic(err)
+	}
+	return node.BlobHash
+}
+
+func processingProfile(t *testing.T) store.ProcessingProfileRecord {
+	t.Helper()
+	profile := document.ProcessingProfileV1{
+		ContractVersion: document.ProcessingProfileContractV1,
+		Rendition: &document.RenditionBindingV1{
+			AdapterContract: "rendition-adapter/v1", AuthorizationFingerprint: processingHash("a1"),
+			CredentialBinding: "credential:synthetic", DeploymentFingerprint: processingHash("a2"),
+			Descriptor:            document.ProviderDescriptorV1{ID: "synthetic-rendition", Fingerprint: processingHash("a3")},
+			DisclosureFingerprint: processingHash("a4"), MaxDocumentBytes: 1 << 20,
+			MaxResponseBytes: 1 << 20, MaxUnits: 100, Name: "primary",
+			RequestedArtifacts: []document.EvidenceArtifactRole{document.EvidenceArtifactStructured},
+			TrustBoundary:      "synthetic-vault", UploadOptionsFingerprint: processingHash("a5"),
+		},
+		EvidenceLexical: document.EvidenceLexicalPolicyV1{
+			CompletenessFingerprint: processingHash("b1"), LexicalSegmenterFingerprint: processingHash("b2"),
+			MaxSegmentRunes: 100, MaxUnitRunes: 1000,
+			NormalizedEvidenceContract: document.NormalizedEvidenceContractV1,
+			NormalizerFingerprint:      processingHash("b3"), RenditionContract: document.RenditionContractV1,
+			SanitizerFingerprint: processingHash("b4"), SourceEvidenceContract: document.SourceEvidenceContractV1,
+		},
+		Retrieval: document.RetrievalPolicyV1{LexicalLimit: 100, VectorLimit: 100},
+		RetentionDisclosure: document.RetentionDisclosurePolicyV1{
+			AttachmentPolicyFingerprint: processingHash("c1"), ConsentFingerprint: processingHash("c2"),
+			RetainSanitizedMarkdown: true, RetainTypedArtifacts: true, TrustBoundary: "synthetic-vault",
+		},
+	}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	require.NoError(t, err)
+	return store.ProcessingProfileRecord{
+		Fingerprint: fingerprints.Profile, CanonicalProfile: jsontext.Value(canonical),
+		RenditionRequestFingerprint:    fingerprints.RenditionRequest,
+		EvidenceLexicalFingerprint:     fingerprints.EvidenceLexical,
+		RetentionDisclosureFingerprint: fingerprints.RetentionDisclosure,
+		AttachmentPolicyFingerprint:    profile.RetentionDisclosure.AttachmentPolicyFingerprint,
+		ConsentFingerprint:             profile.RetentionDisclosure.ConsentFingerprint,
+		RenditionDisclosureFingerprint: profile.Rendition.DisclosureFingerprint,
+		TrustBoundary:                  profile.RetentionDisclosure.TrustBoundary,
+	}
+}
+
+func processingBlobPhysical(t *testing.T, receipt blob.WriteReceipt) store.BlobPhysical {
+	t.Helper()
+	encoding, err := receipt.EncodingName()
+	require.NoError(t, err)
+	return store.BlobPhysical{
+		Encoding: encoding, StoredBytes: receipt.StoredSize,
+		PackEligible: receipt.PackEligible, Created: receipt.Created,
+	}
+}
+
+type failAfterClosedBlobWriter struct {
+	*blob.Store
+
+	failed bool
+}
+
+func (w *failAfterClosedBlobWriter) WriteDetailedContext(
+	ctx context.Context, reader io.Reader,
+) (blob.WriteReceipt, error) {
+	receipt, err := w.Store.WriteDetailedContext(ctx, reader)
+	if err == nil && !w.failed {
+		w.failed = true
+		return receipt, errInjectedPublication
+	}
+	return receipt, err
+}
+
+type failAfterCatalogStage struct {
+	renditionPublicationCatalog
+
+	staged bool
+}
+
+func (c *failAfterCatalogStage) StageRenditionBuild(
+	ctx context.Context, record store.RenditionBuildRecord,
+) error {
+	if err := c.renditionPublicationCatalog.StageRenditionBuild(ctx, record); err != nil {
+		return err
+	}
+	c.staged = true
+	return errInjectedPublication
+}
+
+func assertPriorPublicationServes(
+	t *testing.T, fixture publicationFixture, prior PublishedRendition,
+) {
+	t.Helper()
+	view, err := fixture.catalog.ActiveRendition(
+		t.Context(), fixture.versionID, fixture.profile.Fingerprint,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, prior.BuildID, view.Build.ID)
+	active, err := fixture.catalog.ActiveLexicalGeneration(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, prior.LexicalGeneration, active)
+	hits, _, err := fixture.catalog.SearchPage(t.Context(), "mercury", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	hits, _, err = fixture.catalog.SearchPage(t.Context(), "venus", 10)
+	require.NoError(t, err)
+	assert.Empty(t, hits)
+}
+
+func processingHash(seed string) string { return processingSHA256([]byte(seed)) }
+
+func processingSHA256(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}
+
+func processingChecksumStrings(values ...string) string {
+	hash := sha256.New()
+	for _, value := range values {
+		_, _ = io.WriteString(hash, strconv.Itoa(len(value)))
+		_, _ = io.WriteString(hash, ":")
+		_, _ = io.WriteString(hash, value)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func processingRenditionChecksum(rendition document.RenditionV1) string {
+	parts := []string{
+		document.RenditionContractV1, rendition.EvidenceChecksum,
+		string(rendition.Completeness), rendition.MarkdownChecksum,
+	}
+	for _, unit := range rendition.Units {
+		parts = append(parts, unit.Checksum)
+	}
+	for _, segment := range rendition.LexicalSegments {
+		parts = append(parts, segment.Checksum)
+	}
+	for _, warning := range rendition.Warnings {
+		parts = append(parts, warning.Code)
+	}
+	return processingChecksumStrings(parts...)
+}

--- a/internal/processing/artifacts_test.go
+++ b/internal/processing/artifacts_test.go
@@ -59,6 +59,22 @@ func TestPublishRenditionPublishesVerifiedArtifactsAndHeads(t *testing.T) {
 	assert.Equal(t, store.SearchMatchContent, hits[0].Match)
 }
 
+func TestPublishRenditionAcceptsNilBuildWarnings(t *testing.T) {
+	// Mutation caught: exact slice comparison rejects a warning-free build
+	// when one representation uses nil and the other uses an empty slice.
+	fixture := newPublicationFixture(t)
+	publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+	require.NoError(t, err)
+	staged := fixture.stage(t,
+		publicationIDs{"b1", "51", "91"}, "searchable mercury evidence", "first markdown",
+	)
+	require.Empty(t, staged.Rendition.Warnings)
+	staged.Build.Warnings = nil
+
+	_, err = publisher.PublishRendition(t.Context(), staged)
+	require.NoError(t, err)
+}
+
 func TestPublishRenditionRejectsArtifactReceiptMismatchBeforeCatalogAuthority(t *testing.T) {
 	// Mutation caught: trusting declared size instead of the verified CAS
 	// receipt would grant catalog authority to bytes from a rejected candidate.

--- a/internal/processing/lexical.go
+++ b/internal/processing/lexical.go
@@ -1,0 +1,32 @@
+// Package processing publishes verified document derivatives without making
+// their provider or rebuild state part of document authority.
+package processing
+
+import (
+	"context"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+// LexicalGeneration identifies one complete immutable search projection.
+type LexicalGeneration = store.LexicalGeneration
+
+type lexicalGenerationStore interface {
+	StageLexicalGeneration(
+		ctx context.Context, generationID string,
+	) (store.LexicalGeneration, error)
+}
+
+// RebuildLexicalGeneration builds a complete unreachable FTS generation.
+// Publication remains a separate atomic attachment and head operation.
+func RebuildLexicalGeneration(
+	ctx context.Context, catalog *store.Store, generationID string,
+) (LexicalGeneration, error) {
+	return rebuildLexicalGeneration(ctx, catalog, generationID)
+}
+
+func rebuildLexicalGeneration(
+	ctx context.Context, catalog lexicalGenerationStore, generationID string,
+) (LexicalGeneration, error) {
+	return catalog.StageLexicalGeneration(ctx, generationID)
+}

--- a/internal/processing/lexical_test.go
+++ b/internal/processing/lexical_test.go
@@ -1,0 +1,40 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLexicalGenerationRebuildRemainsUnreachableUntilPublication(t *testing.T) {
+	// Mutation caught: rebuilding a generation must not flip the lexical head;
+	// only the later atomic attachment/rendition/lexical publication may do so.
+	fixture := newPublicationFixture(t)
+	publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+	require.NoError(t, err)
+	first, err := publisher.PublishRendition(t.Context(), fixture.stage(t,
+		publicationIDs{"b1", "51", "91"}, "prior mercury evidence", "first markdown",
+	))
+	require.NoError(t, err)
+
+	failingCatalog := &failAfterCatalogStage{renditionPublicationCatalog: fixture.catalog}
+	failingPublisher, err := NewArtifactPublisher(failingCatalog, fixture.blobs)
+	require.NoError(t, err)
+	_, err = failingPublisher.PublishRendition(t.Context(), fixture.replacementStage(t,
+		publicationIDs{"b2", "52", "92"}, "replacement venus evidence", "second markdown",
+	))
+	require.ErrorIs(t, err, errInjectedPublication)
+
+	rebuilt, err := RebuildLexicalGeneration(t.Context(), fixture.catalog, processingHash("92"))
+	require.NoError(t, err)
+	assert.Equal(t, processingHash("92"), rebuilt.ID)
+	assert.Positive(t, rebuilt.SegmentCount)
+	active, err := fixture.catalog.ActiveLexicalGeneration(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, first.LexicalGeneration, active)
+
+	hits, _, err := fixture.catalog.SearchPage(t.Context(), "venus", 10)
+	require.NoError(t, err)
+	assert.Empty(t, hits, "an unreachable generation cannot serve")
+}

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -1327,11 +1327,9 @@ func TestProcessingMetadataNilHeadingPathRoundTripsAsEmptyArray(t *testing.T) {
 		ID: catalogAttachmentFirst, VaultID: source.VaultID(), ContentVersionID: versions[0],
 		BuildID: build.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
 	}
-	require.NoError(t, source.AttachRenditionBuild(t.Context(), attachment))
-	require.NoError(t, source.PublishRenditionHead(t.Context(), RenditionHeadRecord{
-		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
-		AttachmentID: attachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
-	}))
+	require.NoError(t, publishRenditionForTest(
+		t, source, attachment, "2026-08-22T10:01:00.000000000Z", fakeHash("c8"),
+	))
 
 	var exported bytes.Buffer
 	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
@@ -1422,13 +1420,11 @@ func seedProcessingMetadataCatalog(
 			BuildID: build.ID, Profile: profiles[1], AttachedAt: "2026-08-22T10:01:00.000000000Z"},
 	}
 	for index, attachment := range attachments {
-		require.NoError(t, s.AttachRenditionBuild(t.Context(), attachment))
-		require.NoError(t, s.PublishRenditionHead(t.Context(), RenditionHeadRecord{
-			ContentVersionID:             attachment.ContentVersionID,
-			ProcessingProfileFingerprint: attachment.Profile.Fingerprint,
-			AttachmentID:                 attachment.ID,
-			PublishedAt:                  time.Date(2026, time.August, 22, 10, 2+index, 0, 0, time.UTC).Format(timestampLayout),
-		}))
+		require.NoError(t, publishRenditionForTest(
+			t, s, attachment,
+			time.Date(2026, time.August, 22, 10, 2+index, 0, 0, time.UTC).Format(timestampLayout),
+			fakeHash("c9"),
+		))
 	}
 	return versions, profiles, build
 }

--- a/internal/store/processing_catalog.go
+++ b/internal/store/processing_catalog.go
@@ -258,82 +258,6 @@ func (s *Store) StageRenditionBuild(ctx context.Context, record RenditionBuildRe
 	})
 }
 
-// AttachRenditionBuild inserts or exactly reuses one version-scoped authority
-// grant. Sharing bytes never carries another version's profile or consent.
-func (s *Store) AttachRenditionBuild(ctx context.Context, record RenditionAttachmentRecord) error {
-	normalized, err := normalizeRenditionAttachmentRecord(record)
-	if err != nil {
-		return fmt.Errorf("attaching rendition build: %w", err)
-	}
-	if normalized.VaultID != s.vaultID {
-		return fmt.Errorf("attaching rendition build: vault %q does not match store vault %q",
-			normalized.VaultID, s.vaultID)
-	}
-	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		if err := ensureProcessingProfileTx(ctx, tx, normalized.Profile); err != nil {
-			return err
-		}
-		build, err := loadRenditionBuild(ctx, tx, normalized.BuildID)
-		if err != nil {
-			return fmt.Errorf("reading rendition build %s: %w", normalized.BuildID, err)
-		}
-		if build.VaultID != normalized.VaultID {
-			return errors.New("rendition attachment and build belong to different vaults")
-		}
-		if build.RenditionRequestFingerprint != normalized.Profile.RenditionRequestFingerprint ||
-			build.EvidenceLexicalFingerprint != normalized.Profile.EvidenceLexicalFingerprint {
-			return errors.New("rendition attachment profile does not match build component identity")
-		}
-		if err := validateRenditionArtifactRolesForProfile(normalized.Profile, build); err != nil {
-			return err
-		}
-		var sourceSHA256 string
-		if err := tx.QueryRowContext(ctx,
-			`SELECT blob_hash FROM content_versions WHERE version_id=?`, normalized.ContentVersionID,
-		).Scan(&sourceSHA256); errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("content version %s: %w", normalized.ContentVersionID, ErrNotFound)
-		} else if err != nil {
-			return fmt.Errorf("reading content version %s: %w", normalized.ContentVersionID, err)
-		}
-		if sourceSHA256 != build.SourceSHA256 {
-			return errors.New("rendition attachment source does not match content version")
-		}
-		if err := validateRenditionBuildStateTx(ctx, tx, build.ID); err != nil {
-			return err
-		}
-		result, err := tx.ExecContext(ctx, `
-			INSERT OR IGNORE INTO rendition_attachments(
-				attachment_id,vault_uid,content_version_id,build_id,profile_fingerprint,
-				retention_disclosure_fingerprint,attachment_policy_fingerprint,
-				consent_fingerprint,rendition_disclosure_fingerprint,trust_boundary,attached_at
-			) VALUES(?,?,?,?,?,?,?,?,?,?,?)`,
-			normalized.ID, normalized.VaultID, normalized.ContentVersionID, normalized.BuildID,
-			normalized.Profile.Fingerprint, normalized.Profile.RetentionDisclosureFingerprint,
-			normalized.Profile.AttachmentPolicyFingerprint, normalized.Profile.ConsentFingerprint,
-			normalized.Profile.RenditionDisclosureFingerprint, normalized.Profile.TrustBoundary,
-			normalized.AttachedAt,
-		)
-		if err != nil {
-			return fmt.Errorf("inserting rendition attachment %s: %w", normalized.ID, err)
-		}
-		inserted, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("checking rendition attachment %s insertion: %w", normalized.ID, err)
-		}
-		if inserted != 0 {
-			return nil
-		}
-		stored, err := loadRenditionAttachment(ctx, tx, normalized.ID)
-		if err != nil {
-			return fmt.Errorf("reading rendition attachment %s: %w", normalized.ID, err)
-		}
-		if !reflect.DeepEqual(stored, normalized) {
-			return fmt.Errorf("rendition attachment %s names different immutable metadata", normalized.ID)
-		}
-		return nil
-	})
-}
-
 func validateRenditionArtifactRolesForProfile(
 	record ProcessingProfileRecord, build RenditionBuildRecord,
 ) error {
@@ -367,41 +291,6 @@ func validateRenditionArtifactRolesForProfile(
 		return fmt.Errorf("rendition artifact role %q is forbidden by attachment profile", artifact.Role)
 	}
 	return nil
-}
-
-// PublishRenditionHead atomically validates and activates one exact
-// version/profile attachment. Any failure leaves the prior head unchanged.
-func (s *Store) PublishRenditionHead(ctx context.Context, record RenditionHeadRecord) error {
-	if err := validateRenditionHeadRecord(record); err != nil {
-		return fmt.Errorf("publishing rendition head: %w", err)
-	}
-	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		attachment, err := loadRenditionAttachment(ctx, tx, record.AttachmentID)
-		if err != nil {
-			return fmt.Errorf("reading rendition head attachment %s: %w", record.AttachmentID, err)
-		}
-		if attachment.ContentVersionID != record.ContentVersionID ||
-			attachment.Profile.Fingerprint != record.ProcessingProfileFingerprint {
-			return errors.New("rendition head does not resolve through its exact attachment")
-		}
-		if err := validateRenditionBuildStateTx(ctx, tx, attachment.BuildID); err != nil {
-			return err
-		}
-		_, err = tx.ExecContext(ctx, `
-			INSERT INTO rendition_heads(
-				content_version_id,profile_fingerprint,attachment_id,published_at
-			) VALUES(?,?,?,?)
-			ON CONFLICT(content_version_id,profile_fingerprint) DO UPDATE SET
-				attachment_id=excluded.attachment_id,
-				published_at=excluded.published_at`,
-			record.ContentVersionID, record.ProcessingProfileFingerprint,
-			record.AttachmentID, record.PublishedAt,
-		)
-		if err != nil {
-			return fmt.Errorf("publishing rendition head: %w", err)
-		}
-		return nil
-	})
 }
 
 // ActiveRendition returns the active attachment and immutable build at one

--- a/internal/store/processing_catalog_test.go
+++ b/internal/store/processing_catalog_test.go
@@ -55,16 +55,12 @@ func TestRenditionCatalogSharesOneBuildAcrossVersionProfilesWithinVault(t *testi
 		ContentVersionID: versions[1], BuildID: build.ID, Profile: embeddingProfile,
 		AttachedAt: "2026-08-22T10:01:00.000000000Z",
 	}
-	require.NoError(t, s.AttachRenditionBuild(t.Context(), first))
-	require.NoError(t, s.AttachRenditionBuild(t.Context(), second))
-	require.NoError(t, s.PublishRenditionHead(t.Context(), RenditionHeadRecord{
-		ContentVersionID: versions[0], ProcessingProfileFingerprint: baseProfile.Fingerprint,
-		AttachmentID: first.ID, PublishedAt: "2026-08-22T10:02:00.000000000Z",
-	}))
-	require.NoError(t, s.PublishRenditionHead(t.Context(), RenditionHeadRecord{
-		ContentVersionID: versions[1], ProcessingProfileFingerprint: embeddingProfile.Fingerprint,
-		AttachmentID: second.ID, PublishedAt: "2026-08-22T10:03:00.000000000Z",
-	}))
+	require.NoError(t, publishRenditionForTest(
+		t, s, first, "2026-08-22T10:02:00.000000000Z", fakeHash("c1"),
+	))
+	require.NoError(t, publishRenditionForTest(
+		t, s, second, "2026-08-22T10:03:00.000000000Z", fakeHash("c1"),
+	))
 
 	firstView, err := s.ActiveRendition(t.Context(), versions[0], baseProfile.Fingerprint)
 	require.NoError(t, err)
@@ -91,11 +87,11 @@ func TestRenditionCatalogRejectsCrossVaultAttachment(t *testing.T) {
 	build := catalogRenditionBuild(s, profile)
 	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
 
-	err := s.AttachRenditionBuild(t.Context(), RenditionAttachmentRecord{
+	err := publishRenditionForTest(t, s, RenditionAttachmentRecord{
 		ID: catalogAttachmentFirst, VaultID: other.VaultID(),
 		ContentVersionID: versions[0], BuildID: build.ID, Profile: profile,
 		AttachedAt: "2026-08-22T10:00:00.000000000Z",
-	})
+	}, "2026-08-22T10:01:00.000000000Z", fakeHash("c2"))
 	require.ErrorContains(t, err, "vault")
 
 	var count int
@@ -156,10 +152,10 @@ func TestRenditionCatalogRejectsArtifactsForbiddenByAttachmentProfile(t *testing
 			}
 			require.NoError(t, s.StageRenditionBuild(t.Context(), build))
 
-			err := s.AttachRenditionBuild(t.Context(), RenditionAttachmentRecord{
+			err := publishRenditionForTest(t, s, RenditionAttachmentRecord{
 				ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
 				BuildID: build.ID, Profile: profile, AttachedAt: "2026-08-25T15:00:00.000000000Z",
-			})
+			}, "2026-08-25T15:01:00.000000000Z", fakeHash("c3"))
 			require.ErrorContains(t, err, "artifact role")
 
 			var count int
@@ -218,11 +214,11 @@ func TestRenditionCatalogRejectsIncompleteArtifactsWithoutPartialStage(t *testin
 	assert.Zero(t, buildCount, "a rejected aggregate must not leave its parent row")
 	assert.Zero(t, artifactCount, "a rejected aggregate must not leave child rows")
 
-	err = s.AttachRenditionBuild(t.Context(), RenditionAttachmentRecord{
+	err = publishRenditionForTest(t, s, RenditionAttachmentRecord{
 		ID: catalogAttachmentFirst, VaultID: s.VaultID(),
 		ContentVersionID: versions[0], BuildID: build.ID, Profile: profile,
 		AttachedAt: "2026-08-22T10:00:00.000000000Z",
-	})
+	}, "2026-08-22T10:01:00.000000000Z", fakeHash("c4"))
 	require.Error(t, err)
 	_, err = s.ActiveRendition(t.Context(), versions[0], profile.Fingerprint)
 	require.ErrorIs(t, err, ErrNotFound)
@@ -718,12 +714,18 @@ func TestRenditionCatalogInsertOrReuseRejectsImmutableConflicts(t *testing.T) {
 		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
 		BuildID: build.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
 	}
-	require.NoError(t, s.AttachRenditionBuild(t.Context(), attachment))
-	require.NoError(t, s.AttachRenditionBuild(t.Context(), attachment), "an exact retry must reuse the immutable attachment")
+	require.NoError(t, publishRenditionForTest(
+		t, s, attachment, "2026-08-22T10:01:00.000000000Z", fakeHash("c5"),
+	))
+	require.NoError(t, publishRenditionForTest(
+		t, s, attachment, "2026-08-22T10:01:00.000000000Z", fakeHash("c5"),
+	), "an exact retry must reuse the immutable attachment")
 
 	conflictingAttachment := attachment
 	conflictingAttachment.AttachedAt = "2026-08-22T10:00:01.000000000Z"
-	err = s.AttachRenditionBuild(t.Context(), conflictingAttachment)
+	err = publishRenditionForTest(
+		t, s, conflictingAttachment, "2026-08-22T10:01:00.000000000Z", fakeHash("c5"),
+	)
 	require.ErrorContains(t, err, "different immutable")
 
 	var providerOperationID string
@@ -757,11 +759,9 @@ func TestRenditionCatalogFailedReplacementKeepsOldHead(t *testing.T) {
 		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
 		BuildID: oldBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
 	}
-	require.NoError(t, s.AttachRenditionBuild(t.Context(), oldAttachment))
-	require.NoError(t, s.PublishRenditionHead(t.Context(), RenditionHeadRecord{
-		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
-		AttachmentID: oldAttachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
-	}))
+	require.NoError(t, publishRenditionForTest(
+		t, s, oldAttachment, "2026-08-22T10:01:00.000000000Z", fakeHash("c6"),
+	))
 
 	replacement := cloneCatalogBuild(oldBuild)
 	replacement.ID = catalogBuildReplacement
@@ -776,17 +776,14 @@ func TestRenditionCatalogFailedReplacementKeepsOldHead(t *testing.T) {
 		ID: catalogAttachmentSecond, VaultID: s.VaultID(), ContentVersionID: versions[0],
 		BuildID: replacement.ID, Profile: profile, AttachedAt: "2026-08-22T11:01:00.000000000Z",
 	}
-	require.NoError(t, s.AttachRenditionBuild(t.Context(), newAttachment))
-
 	_, err := s.db.Exec(`CREATE TRIGGER synthetic_reject_rendition_head_update
 		BEFORE UPDATE ON rendition_heads BEGIN
 			SELECT RAISE(ABORT, 'synthetic head publication failure');
 		END`)
 	require.NoError(t, err)
-	err = s.PublishRenditionHead(t.Context(), RenditionHeadRecord{
-		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
-		AttachmentID: newAttachment.ID, PublishedAt: "2026-08-22T11:02:00.000000000Z",
-	})
+	err = publishRenditionForTest(
+		t, s, newAttachment, "2026-08-22T11:02:00.000000000Z", fakeHash("c7"),
+	)
 	require.ErrorContains(t, err, "synthetic head publication failure")
 
 	active, err := s.ActiveRendition(t.Context(), versions[0], profile.Fingerprint)
@@ -800,6 +797,20 @@ func newRenditionCatalogFixture(t *testing.T) (*Store, []string) {
 	t.Helper()
 	s := newTestStore(t)
 	return s, seedRenditionCatalogVersions(t, s)
+}
+
+func publishRenditionForTest(
+	t *testing.T, s *Store, attachment RenditionAttachmentRecord, publishedAt, generationID string,
+) error {
+	t.Helper()
+	generation, err := s.StageLexicalGeneration(t.Context(), generationID)
+	require.NoError(t, err)
+	return s.PublishRenditionAndLexicalHeads(t.Context(), attachment, RenditionHeadRecord{
+		ContentVersionID:             attachment.ContentVersionID,
+		ProcessingProfileFingerprint: attachment.Profile.Fingerprint,
+		AttachmentID:                 attachment.ID,
+		PublishedAt:                  publishedAt,
+	}, generation.ID)
 }
 
 func seedRenditionCatalogVersions(t *testing.T, s *Store) []string {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -248,6 +248,44 @@ func readLexicalManifestRowsTx(
 	return scanLexicalManifestRows(rows, "lexical generation "+generationID+" manifest")
 }
 
+func readPublishedLexicalManifestRowsTx(
+	ctx context.Context, tx *sql.Tx, generationID string,
+) ([]lexicalManifestRow, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if generationID == "" {
+		rows, err = tx.QueryContext(ctx, `
+			SELECT s.build_id,s.segment_id,s.text
+			FROM rendition_lexical_segments s
+			WHERE EXISTS (
+			  SELECT 1 FROM rendition_attachments a
+			  JOIN rendition_heads h
+			    ON h.content_version_id=a.content_version_id
+			   AND h.profile_fingerprint=a.profile_fingerprint
+			   AND h.attachment_id=a.attachment_id
+			  WHERE a.build_id=s.build_id
+			)`)
+	} else {
+		rows, err = tx.QueryContext(ctx, `
+			SELECT f.build_id,f.segment_id,f.text
+			FROM rendition_lexical_fts f
+			WHERE f.generation_id=? AND EXISTS (
+			  SELECT 1 FROM rendition_attachments a
+			  JOIN rendition_heads h
+			    ON h.content_version_id=a.content_version_id
+			   AND h.profile_fingerprint=a.profile_fingerprint
+			   AND h.attachment_id=a.attachment_id
+			  WHERE a.build_id=f.build_id
+			)`, generationID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading published lexical manifest: %w", err)
+	}
+	return scanLexicalManifestRows(rows, "published lexical manifest")
+}
+
 func scanLexicalManifestRows(
 	rows *sql.Rows, description string,
 ) (_ []lexicalManifestRow, retErr error) {
@@ -476,6 +514,18 @@ func (s *Store) PublishRenditionAndLexicalHeads(
 		if !generationManifest.Valid || len(generationRows) != generationSegments ||
 			lexicalManifestDigest(generationRows) != generationManifest.String {
 			return fmt.Errorf("lexical generation %s has a different immutable manifest", generationID)
+		}
+		publishedCatalogRows, err := readPublishedLexicalManifestRowsTx(ctx, tx, "")
+		if err != nil {
+			return err
+		}
+		publishedGenerationRows, err := readPublishedLexicalManifestRowsTx(ctx, tx, generationID)
+		if err != nil {
+			return err
+		}
+		if len(publishedGenerationRows) != len(publishedCatalogRows) ||
+			lexicalManifestDigest(publishedGenerationRows) != lexicalManifestDigest(publishedCatalogRows) {
+			return fmt.Errorf("lexical generation %s does not cover published rendition builds", generationID)
 		}
 		if err := ensureProcessingProfileTx(ctx, tx, normalized.Profile); err != nil {
 			return err

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -2,11 +2,18 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"mime"
+	"reflect"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -34,6 +41,532 @@ const (
 	SearchMatchName    = "name"
 	SearchMatchContent = "content"
 )
+
+// LexicalGeneration identifies one complete, immutable FTS projection. Rows
+// remain unreachable until rendition and lexical heads are flipped together.
+type LexicalGeneration struct {
+	ID             string
+	SegmentCount   int
+	ManifestDigest string
+}
+
+// LexicalGenerationRoot is one exact immutable generation currently retained
+// by in-process readers. Task 8 garbage collection consumes these roots in
+// addition to the active database head.
+type LexicalGenerationRoot struct {
+	GenerationID string
+	ReaderCount  int
+}
+
+// LexicalGenerationLease pins one exact generation until Release. Generation
+// does not follow later head flips.
+type LexicalGenerationLease struct {
+	Generation LexicalGeneration
+	store      *Store
+	released   bool
+}
+
+var lexicalGenerationReaders = struct {
+	sync.Mutex
+
+	stores map[*Store]map[string]int
+}{stores: make(map[*Store]map[string]int)}
+
+const lexicalProjectionSchema = `
+CREATE TABLE IF NOT EXISTS rendition_lexical_generations (
+    generation_id TEXT PRIMARY KEY,
+    segment_count INTEGER NOT NULL CHECK (segment_count >= 0),
+    built_at      TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS rendition_lexical_generation_manifests (
+    generation_id  TEXT PRIMARY KEY REFERENCES rendition_lexical_generations(generation_id),
+    manifest_digest TEXT NOT NULL CHECK (length(manifest_digest) = 64)
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS rendition_lexical_fts USING fts5(
+    generation_id UNINDEXED,
+    build_id      UNINDEXED,
+    segment_id    UNINDEXED,
+    text
+);
+CREATE TABLE IF NOT EXISTS rendition_lexical_heads (
+    singleton     INTEGER PRIMARY KEY CHECK (singleton = 1),
+    generation_id TEXT NOT NULL REFERENCES rendition_lexical_generations(generation_id)
+);`
+
+// RecordRenditionBlob grants catalog authority to one verified Docbank blob
+// receipt without creating a document version or conferring visibility.
+func (s *Store) RecordRenditionBlob(
+	ctx context.Context, hash string, size int64, physical BlobPhysical,
+) error {
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, hash, size, physical)
+	})
+}
+
+// StageLexicalGeneration builds a complete unreachable FTS projection over
+// every immutable rendition build currently staged in this vault.
+func (s *Store) StageLexicalGeneration(
+	ctx context.Context, generationID string,
+) (LexicalGeneration, error) {
+	if err := validateCatalogSHA256(generationID, "lexical generation ID"); err != nil {
+		return LexicalGeneration{}, err
+	}
+	generation := LexicalGeneration{ID: generationID}
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, lexicalProjectionSchema); err != nil {
+			return fmt.Errorf("initializing lexical projection: %w", err)
+		}
+		var storedCount int
+		var storedManifest sql.NullString
+		err := tx.QueryRowContext(ctx, `
+			SELECT g.segment_count,m.manifest_digest
+			FROM rendition_lexical_generations g
+			LEFT JOIN rendition_lexical_generation_manifests m
+			  ON m.generation_id=g.generation_id
+			WHERE g.generation_id=?`,
+			generationID,
+		).Scan(&storedCount, &storedManifest)
+		if err == nil {
+			actualRows, err := readLexicalManifestRowsTx(ctx, tx, generationID, "")
+			if err != nil {
+				return err
+			}
+			actualManifest := lexicalManifestDigest(actualRows)
+			if !storedManifest.Valid || len(actualRows) != storedCount ||
+				actualManifest != storedManifest.String {
+				return fmt.Errorf("lexical generation %s has a different immutable manifest", generationID)
+			}
+			generation.SegmentCount = storedCount
+			generation.ManifestDigest = storedManifest.String
+			return nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("reading lexical generation %s: %w", generationID, err)
+		}
+
+		segments, err := readCatalogLexicalManifestRowsTx(ctx, tx, "")
+		if err != nil {
+			return err
+		}
+
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM rendition_lexical_fts WHERE generation_id=?`, generationID,
+		); err != nil {
+			return fmt.Errorf("clearing interrupted lexical generation %s: %w", generationID, err)
+		}
+		for _, segment := range segments {
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO rendition_lexical_fts(generation_id,build_id,segment_id,text)
+				VALUES(?,?,?,?)`, generationID, segment.buildID, segment.segmentID, segment.text,
+			); err != nil {
+				return fmt.Errorf("building lexical generation %s: %w", generationID, err)
+			}
+		}
+		generation.SegmentCount = len(segments)
+		generation.ManifestDigest = lexicalManifestDigest(segments)
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO rendition_lexical_generations(generation_id,segment_count,built_at)
+			VALUES(?,?,?)`, generationID, generation.SegmentCount, nowRFC3339(),
+		); err != nil {
+			return fmt.Errorf("completing lexical generation %s: %w", generationID, err)
+		}
+		actualRows, err := readLexicalManifestRowsTx(ctx, tx, generationID, "")
+		if err != nil {
+			return err
+		}
+		if len(actualRows) != generation.SegmentCount ||
+			lexicalManifestDigest(actualRows) != generation.ManifestDigest {
+			return fmt.Errorf("lexical generation %s has a different immutable manifest", generationID)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO rendition_lexical_generation_manifests(generation_id,manifest_digest)
+			VALUES(?,?)`, generationID, generation.ManifestDigest,
+		); err != nil {
+			return fmt.Errorf("recording lexical generation %s manifest: %w", generationID, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return LexicalGeneration{}, err
+	}
+	return generation, nil
+}
+
+type lexicalManifestRow struct {
+	buildID   string
+	segmentID string
+	text      string
+}
+
+func readCatalogLexicalManifestRowsTx(
+	ctx context.Context, tx *sql.Tx, buildID string,
+) ([]lexicalManifestRow, error) {
+	query := `
+		SELECT build_id,segment_id,text
+		FROM rendition_lexical_segments
+		ORDER BY build_id,segment_order,segment_id`
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if buildID == "" {
+		rows, err = tx.QueryContext(ctx, query)
+	} else {
+		rows, err = tx.QueryContext(ctx, `
+			SELECT build_id,segment_id,text
+			FROM rendition_lexical_segments
+			WHERE build_id=?
+			ORDER BY build_id,segment_order,segment_id`, buildID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading staged lexical manifest: %w", err)
+	}
+	return scanLexicalManifestRows(rows, "staged lexical manifest")
+}
+
+func readLexicalManifestRowsTx(
+	ctx context.Context, tx *sql.Tx, generationID, buildID string,
+) ([]lexicalManifestRow, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if buildID == "" {
+		rows, err = tx.QueryContext(ctx, `
+			SELECT build_id,segment_id,text
+			FROM rendition_lexical_fts
+			WHERE generation_id=?`, generationID)
+	} else {
+		rows, err = tx.QueryContext(ctx, `
+			SELECT build_id,segment_id,text
+			FROM rendition_lexical_fts
+			WHERE generation_id=? AND build_id=?`, generationID, buildID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading lexical generation %s manifest: %w", generationID, err)
+	}
+	return scanLexicalManifestRows(rows, "lexical generation "+generationID+" manifest")
+}
+
+func scanLexicalManifestRows(
+	rows *sql.Rows, description string,
+) (_ []lexicalManifestRow, retErr error) {
+	defer func() {
+		if err := rows.Close(); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("closing %s: %w", description, err))
+		}
+	}()
+	var result []lexicalManifestRow
+	for rows.Next() {
+		var row lexicalManifestRow
+		if err := rows.Scan(&row.buildID, &row.segmentID, &row.text); err != nil {
+			return nil, fmt.Errorf("reading %s row: %w", description, err)
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s rows: %w", description, err)
+	}
+	return result, nil
+}
+
+func lexicalManifestDigest(rows []lexicalManifestRow) string {
+	ordered := append([]lexicalManifestRow(nil), rows...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].buildID != ordered[j].buildID {
+			return ordered[i].buildID < ordered[j].buildID
+		}
+		if ordered[i].segmentID != ordered[j].segmentID {
+			return ordered[i].segmentID < ordered[j].segmentID
+		}
+		return ordered[i].text < ordered[j].text
+	})
+	hash := sha256.New()
+	for _, row := range ordered {
+		for _, field := range [...]string{row.buildID, row.segmentID, row.text} {
+			_, _ = io.WriteString(hash, strconv.Itoa(len(field)))
+			_, _ = io.WriteString(hash, ":")
+			_, _ = io.WriteString(hash, field)
+		}
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// ActiveLexicalGeneration returns the exact complete projection selected by
+// the lexical head. Call AcquireLexicalGeneration when the generation must
+// remain rooted after this lookup returns.
+func (s *Store) ActiveLexicalGeneration(ctx context.Context) (LexicalGeneration, error) {
+	return readActiveLexicalGeneration(ctx, s.db)
+}
+
+func readActiveLexicalGeneration(
+	ctx context.Context, queryer rowQuerier,
+) (LexicalGeneration, error) {
+	var generation LexicalGeneration
+	err := queryer.QueryRowContext(ctx, `
+		SELECT g.generation_id,g.segment_count,m.manifest_digest
+		FROM rendition_lexical_heads h
+		JOIN rendition_lexical_generations g ON g.generation_id=h.generation_id
+		JOIN rendition_lexical_generation_manifests m ON m.generation_id=g.generation_id
+		WHERE h.singleton=1`).Scan(
+		&generation.ID, &generation.SegmentCount, &generation.ManifestDigest,
+	)
+	if errors.Is(err, sql.ErrNoRows) || isMissingLexicalSchema(err) {
+		return LexicalGeneration{}, ErrNotFound
+	}
+	if err != nil {
+		return LexicalGeneration{}, fmt.Errorf("reading active lexical generation: %w", err)
+	}
+	return generation, nil
+}
+
+// AcquireLexicalGeneration pins the exact generation selected by the current
+// lexical head. The caller must release the returned lease.
+func (s *Store) AcquireLexicalGeneration(ctx context.Context) (*LexicalGenerationLease, error) {
+	return s.acquireLexicalGeneration(ctx, s.db)
+}
+
+func (s *Store) acquireLexicalGeneration(
+	ctx context.Context, queryer rowQuerier,
+) (*LexicalGenerationLease, error) {
+	lexicalGenerationReaders.Lock()
+	defer lexicalGenerationReaders.Unlock()
+
+	generation, err := readActiveLexicalGeneration(ctx, queryer)
+	if err != nil {
+		return nil, err
+	}
+	readers := lexicalGenerationReaders.stores[s]
+	if readers == nil {
+		readers = make(map[string]int)
+		lexicalGenerationReaders.stores[s] = readers
+	}
+	readers[generation.ID]++
+	return &LexicalGenerationLease{Generation: generation, store: s}, nil
+}
+
+func (s *Store) withLexicalGenerationRead(
+	ctx context.Context, fn func(queryer metadataQuerier, generation LexicalGeneration) error,
+) (retErr error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring lexical generation connection: %w", err)
+	}
+	active := false
+	var lease *LexicalGenerationLease
+	defer func() {
+		if active {
+			_, err := conn.ExecContext(context.Background(), "ROLLBACK")
+			retErr = errors.Join(retErr, err)
+		}
+		if lease != nil {
+			retErr = errors.Join(retErr, lease.Release())
+		}
+		retErr = errors.Join(retErr, conn.Close())
+	}()
+	if _, err := conn.ExecContext(ctx, "BEGIN DEFERRED"); err != nil {
+		return fmt.Errorf("starting lexical generation read: %w", err)
+	}
+	active = true
+	lease, err = s.acquireLexicalGeneration(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if err := fn(conn, lease.Generation); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("committing lexical generation read: %w", err)
+	}
+	active = false
+	return nil
+}
+
+// Release removes this lease's generation root. Repeated release is safe.
+func (l *LexicalGenerationLease) Release() error {
+	if l == nil {
+		return nil
+	}
+	lexicalGenerationReaders.Lock()
+	defer lexicalGenerationReaders.Unlock()
+	if l.released {
+		return nil
+	}
+	l.released = true
+	readers := lexicalGenerationReaders.stores[l.store]
+	readers[l.Generation.ID]--
+	if readers[l.Generation.ID] == 0 {
+		delete(readers, l.Generation.ID)
+	}
+	if len(readers) == 0 {
+		delete(lexicalGenerationReaders.stores, l.store)
+	}
+	return nil
+}
+
+// LeasedLexicalGenerationRoots returns a deterministic snapshot of exact
+// generations pinned by this store's current readers.
+func (s *Store) LeasedLexicalGenerationRoots() []LexicalGenerationRoot {
+	lexicalGenerationReaders.Lock()
+	defer lexicalGenerationReaders.Unlock()
+
+	readers := lexicalGenerationReaders.stores[s]
+	roots := make([]LexicalGenerationRoot, 0, len(readers))
+	for generationID, readerCount := range readers {
+		roots = append(roots, LexicalGenerationRoot{
+			GenerationID: generationID,
+			ReaderCount:  readerCount,
+		})
+	}
+	sort.Slice(roots, func(i, j int) bool {
+		return roots[i].GenerationID < roots[j].GenerationID
+	})
+	return roots
+}
+
+// PublishRenditionAndLexicalHeads inserts one version-scoped attachment and
+// flips its rendition head together with the complete lexical generation.
+// Any failure rolls back all three visibility changes.
+func (s *Store) PublishRenditionAndLexicalHeads(
+	ctx context.Context, attachment RenditionAttachmentRecord,
+	head RenditionHeadRecord, generationID string,
+) error {
+	normalized, err := normalizeRenditionAttachmentRecord(attachment)
+	if err != nil {
+		return fmt.Errorf("publishing rendition attachment: %w", err)
+	}
+	if err := validateRenditionHeadRecord(head); err != nil {
+		return fmt.Errorf("publishing rendition head: %w", err)
+	}
+	if err := validateCatalogSHA256(generationID, "lexical generation ID"); err != nil {
+		return err
+	}
+	if head.ContentVersionID != normalized.ContentVersionID ||
+		head.ProcessingProfileFingerprint != normalized.Profile.Fingerprint ||
+		head.AttachmentID != normalized.ID {
+		return errors.New("rendition head does not resolve through its exact attachment")
+	}
+	if normalized.VaultID != s.vaultID {
+		return fmt.Errorf("publishing rendition attachment: vault %q does not match store vault %q",
+			normalized.VaultID, s.vaultID)
+	}
+
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, lexicalProjectionSchema); err != nil {
+			return fmt.Errorf("initializing lexical projection: %w", err)
+		}
+		var generationSegments int
+		var generationManifest sql.NullString
+		if err := tx.QueryRowContext(ctx, `
+			SELECT g.segment_count,m.manifest_digest
+			FROM rendition_lexical_generations g
+			LEFT JOIN rendition_lexical_generation_manifests m
+			  ON m.generation_id=g.generation_id
+			WHERE g.generation_id=?`,
+			generationID,
+		).Scan(&generationSegments, &generationManifest); errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("lexical generation %s: %w", generationID, ErrNotFound)
+		} else if err != nil {
+			return fmt.Errorf("reading lexical generation %s: %w", generationID, err)
+		}
+		generationRows, err := readLexicalManifestRowsTx(ctx, tx, generationID, "")
+		if err != nil {
+			return err
+		}
+		if !generationManifest.Valid || len(generationRows) != generationSegments ||
+			lexicalManifestDigest(generationRows) != generationManifest.String {
+			return fmt.Errorf("lexical generation %s has a different immutable manifest", generationID)
+		}
+		if err := ensureProcessingProfileTx(ctx, tx, normalized.Profile); err != nil {
+			return err
+		}
+		build, err := loadRenditionBuild(ctx, tx, normalized.BuildID)
+		if err != nil {
+			return fmt.Errorf("reading rendition build %s: %w", normalized.BuildID, err)
+		}
+		if build.VaultID != normalized.VaultID {
+			return errors.New("rendition attachment and build belong to different vaults")
+		}
+		if build.RenditionRequestFingerprint != normalized.Profile.RenditionRequestFingerprint ||
+			build.EvidenceLexicalFingerprint != normalized.Profile.EvidenceLexicalFingerprint {
+			return errors.New("rendition attachment profile does not match build component identity")
+		}
+		var sourceSHA256 string
+		if err := tx.QueryRowContext(ctx,
+			`SELECT blob_hash FROM content_versions WHERE version_id=?`, normalized.ContentVersionID,
+		).Scan(&sourceSHA256); errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("content version %s: %w", normalized.ContentVersionID, ErrNotFound)
+		} else if err != nil {
+			return fmt.Errorf("reading content version %s: %w", normalized.ContentVersionID, err)
+		}
+		if sourceSHA256 != build.SourceSHA256 {
+			return errors.New("rendition attachment source does not match content version")
+		}
+		if err := validateRenditionBuildStateTx(ctx, tx, build.ID); err != nil {
+			return err
+		}
+		expectedBuildRows, err := readCatalogLexicalManifestRowsTx(ctx, tx, build.ID)
+		if err != nil {
+			return err
+		}
+		indexedBuildRows, err := readLexicalManifestRowsTx(ctx, tx, generationID, build.ID)
+		if err != nil {
+			return err
+		}
+		if len(indexedBuildRows) != len(expectedBuildRows) ||
+			lexicalManifestDigest(indexedBuildRows) != lexicalManifestDigest(expectedBuildRows) {
+			return fmt.Errorf("lexical generation %s does not exactly contain build %s",
+				generationID, build.ID)
+		}
+
+		result, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO rendition_attachments(
+				attachment_id,vault_uid,content_version_id,build_id,profile_fingerprint,
+				retention_disclosure_fingerprint,attachment_policy_fingerprint,
+				consent_fingerprint,rendition_disclosure_fingerprint,trust_boundary,attached_at
+			) VALUES(?,?,?,?,?,?,?,?,?,?,?)`,
+			normalized.ID, normalized.VaultID, normalized.ContentVersionID, normalized.BuildID,
+			normalized.Profile.Fingerprint, normalized.Profile.RetentionDisclosureFingerprint,
+			normalized.Profile.AttachmentPolicyFingerprint, normalized.Profile.ConsentFingerprint,
+			normalized.Profile.RenditionDisclosureFingerprint, normalized.Profile.TrustBoundary,
+			normalized.AttachedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("inserting rendition attachment %s: %w", normalized.ID, err)
+		}
+		inserted, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("checking rendition attachment %s insertion: %w", normalized.ID, err)
+		}
+		if inserted == 0 {
+			stored, err := loadRenditionAttachment(ctx, tx, normalized.ID)
+			if err != nil {
+				return fmt.Errorf("reading rendition attachment %s: %w", normalized.ID, err)
+			}
+			if !reflect.DeepEqual(stored, normalized) {
+				return fmt.Errorf("rendition attachment %s names different immutable metadata", normalized.ID)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO rendition_heads(content_version_id,profile_fingerprint,attachment_id,published_at)
+			VALUES(?,?,?,?)
+			ON CONFLICT(content_version_id,profile_fingerprint) DO UPDATE SET
+				attachment_id=excluded.attachment_id,published_at=excluded.published_at`,
+			head.ContentVersionID, head.ProcessingProfileFingerprint,
+			head.AttachmentID, head.PublishedAt,
+		); err != nil {
+			return fmt.Errorf("publishing rendition head: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO rendition_lexical_heads(singleton,generation_id) VALUES(1,?)
+			ON CONFLICT(singleton) DO UPDATE SET generation_id=excluded.generation_id`,
+			generationID,
+		); err != nil {
+			return fmt.Errorf("publishing lexical head: %w", err)
+		}
+		return nil
+	})
+}
 
 // ftsQuery converts free-form user input into a safe FTS5 query: each
 // whitespace-separated term becomes a quoted prefix term. Embedded double
@@ -132,29 +665,88 @@ func (s *Store) SearchPageWithOptions(
 	// Content may also match a node already returned by name. Over-fetch by
 	// the complete name set so duplicate filtering cannot conceal truncation.
 	remaining := limit - len(nameHits)
-	contentArgs := []any{fq}
-	contentArgs = append(contentArgs, filterArgs...)
-	contentArgs = append(contentArgs, remaining+len(nameHits)+1)
-	rows, err = s.db.QueryContext(ctx, `
-		WITH matched_blobs AS (
-		  SELECT blob_hash, MIN(rank) AS best_rank
-		  FROM content_fts WHERE content_fts MATCH ?
-		  GROUP BY blob_hash
-		)
-		SELECT `+nodeCols+`
-		FROM `+nodeFrom+`
-		JOIN matched_blobs mb ON mb.blob_hash = cv.blob_hash
-		JOIN text_searchable_versions tsv ON tsv.version_id = cv.version_id
-		WHERE n.trashed_at IS NULL
-		  `+filterSQL+`
-		ORDER BY mb.best_rank, n.name, n.id
-		LIMIT ?`, contentArgs...)
-	if err != nil {
-		return nil, false, fmt.Errorf("searching extracted content for %q: %w", query, err)
-	}
-	contentHits, err := scanSearchRows(rows, SearchMatchContent, query)
+	lexical, err := s.hasLexicalProjection(ctx)
 	if err != nil {
 		return nil, false, err
+	}
+	var contentHits []SearchHit
+	queryContent := func(queryer metadataQuerier, generationID string) error {
+		contentArgs := []any{fq}
+		contentQuery := `
+			WITH matched_blobs AS (
+			  SELECT blob_hash, MIN(rank) AS best_rank
+			  FROM content_fts WHERE content_fts MATCH ?
+			  GROUP BY blob_hash
+			)
+			SELECT ` + nodeCols + `
+			FROM ` + nodeFrom + `
+			JOIN matched_blobs mb ON mb.blob_hash = cv.blob_hash
+			JOIN text_searchable_versions tsv ON tsv.version_id = cv.version_id
+			WHERE n.trashed_at IS NULL
+			  ` + filterSQL + `
+			ORDER BY mb.best_rank, n.name, n.id
+			LIMIT ?`
+		if generationID != "" {
+			// Selection, attachment resolution, and row consumption share
+			// this reader's one immutable publication snapshot.
+			contentQuery = `
+				WITH matched_versions(version_id,best_rank) AS (
+				  SELECT cv_legacy.version_id, MIN(content_fts.rank)
+				  FROM content_fts
+				  JOIN content_versions cv_legacy ON cv_legacy.blob_hash=content_fts.blob_hash
+				  JOIN text_searchable_versions tsv_legacy
+				    ON tsv_legacy.version_id=cv_legacy.version_id
+				  WHERE content_fts MATCH ?
+				  GROUP BY cv_legacy.version_id
+				  UNION ALL
+				  SELECT a.content_version_id, MIN(rendition_lexical_fts.rank)
+				  FROM rendition_lexical_fts
+				  JOIN rendition_attachments a ON a.build_id=rendition_lexical_fts.build_id
+				  JOIN rendition_heads rh
+				    ON rh.content_version_id=a.content_version_id
+				   AND rh.profile_fingerprint=a.profile_fingerprint
+				   AND rh.attachment_id=a.attachment_id
+				  WHERE rendition_lexical_fts MATCH ?
+				    AND rendition_lexical_fts.generation_id=?
+				  GROUP BY a.content_version_id
+				), best_versions AS (
+				  SELECT version_id,MIN(best_rank) AS best_rank
+				  FROM matched_versions GROUP BY version_id
+				)
+				SELECT ` + nodeCols + `
+				FROM ` + nodeFrom + `
+				JOIN best_versions mv ON mv.version_id=cv.version_id
+				WHERE n.trashed_at IS NULL
+				  ` + filterSQL + `
+				ORDER BY mv.best_rank,n.name,n.id
+				LIMIT ?`
+			contentArgs = append(contentArgs, fq, generationID)
+		}
+		contentArgs = append(contentArgs, filterArgs...)
+		contentArgs = append(contentArgs, remaining+len(nameHits)+1)
+		rows, err := queryer.QueryContext(ctx, contentQuery, contentArgs...)
+		if err != nil {
+			return fmt.Errorf("searching extracted content for %q: %w", query, err)
+		}
+		contentHits, err = scanSearchRows(rows, SearchMatchContent, query)
+		return err
+	}
+	if lexical {
+		err = s.withLexicalGenerationRead(ctx, func(
+			queryer metadataQuerier, generation LexicalGeneration,
+		) error {
+			return queryContent(queryer, generation.ID)
+		})
+		if errors.Is(err, ErrNotFound) {
+			lexical = false
+		} else if err != nil {
+			return nil, false, err
+		}
+	}
+	if !lexical {
+		if err := queryContent(s.db, ""); err != nil {
+			return nil, false, err
+		}
 	}
 	seen := make(map[int64]struct{}, len(nameHits))
 	for _, hit := range nameHits {
@@ -178,6 +770,22 @@ func (s *Store) SearchPageWithOptions(
 		return nil, false, err
 	}
 	return hits, truncated, nil
+}
+
+func (s *Store) hasLexicalProjection(ctx context.Context) (bool, error) {
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(
+		  SELECT 1 FROM sqlite_schema
+		  WHERE type='table' AND name='rendition_lexical_heads'
+		)`).Scan(&exists); err != nil {
+		return false, fmt.Errorf("checking lexical projection: %w", err)
+	}
+	return exists, nil
+}
+
+func isMissingLexicalSchema(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no such table: rendition_lexical_heads")
 }
 
 func searchFilterSQL(opts SearchOptions) (string, []any) {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -491,6 +491,9 @@ func (s *Store) PublishRenditionAndLexicalHeads(
 			build.EvidenceLexicalFingerprint != normalized.Profile.EvidenceLexicalFingerprint {
 			return errors.New("rendition attachment profile does not match build component identity")
 		}
+		if err := validateRenditionArtifactRolesForProfile(normalized.Profile, build); err != nil {
+			return err
+		}
 		var sourceSHA256 string
 		if err := tx.QueryRowContext(ctx,
 			`SELECT blob_hash FROM content_versions WHERE version_id=?`, normalized.ContentVersionID,

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
 )
 
 func TestSearchFindsLiveNodesOnly(t *testing.T) {
@@ -597,6 +599,35 @@ func TestLexicalGenerationHeadFailureRollsBackAttachmentAndBothHeads(t *testing.
 	hits, _, err = s.SearchPage(ctx, "venus", 10)
 	require.NoError(t, err)
 	assert.Empty(t, hits)
+}
+
+func TestLexicalGenerationPublicationRejectsForbiddenArtifacts(t *testing.T) {
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	buildProfile := catalogProcessingProfile(t, false)
+	build := catalogRenditionBuild(s, buildProfile)
+	require.NoError(t, s.StageRenditionBuild(ctx, build))
+	generation, err := s.StageLexicalGeneration(ctx, fakeHash("9c"))
+	require.NoError(t, err)
+
+	attachmentProfile := catalogProcessingProfileWith(t, false, func(profile *document.ProcessingProfileV1) {
+		profile.RetentionDisclosure.RetainSanitizedMarkdown = false
+	})
+	attachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(),
+		ContentVersionID: versions[0], BuildID: build.ID, Profile: attachmentProfile,
+		AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+	err = s.PublishRenditionAndLexicalHeads(ctx, attachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: attachmentProfile.Fingerprint,
+		AttachmentID: attachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+	}, generation.ID)
+	require.ErrorContains(t, err, `artifact role "sanitized_markdown" is forbidden`)
+
+	_, err = s.ActiveRendition(ctx, versions[0], attachmentProfile.Fingerprint)
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.ActiveLexicalGeneration(ctx)
+	require.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestLexicalGenerationReaderLeasePinsAndEnumeratesExactRoots(t *testing.T) {

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -458,11 +458,6 @@ func TestSearchAttachmentEligibilityKeepsSharedBuildVersionScoped(t *testing.T) 
 		ContentVersionID: versions[1], BuildID: build.ID, Profile: secondProfile,
 		AttachedAt: "2026-08-22T10:02:00.000000000Z",
 	}
-	require.NoError(t, s.AttachRenditionBuild(ctx, second))
-	hits, _, err = s.SearchPage(ctx, "mercury", 10)
-	require.NoError(t, err)
-	require.Len(t, hits, 1, "a staged attachment without a head is not eligible")
-
 	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, second, RenditionHeadRecord{
 		ContentVersionID: versions[1], ProcessingProfileFingerprint: secondProfile.Fingerprint,
 		AttachmentID: second.ID, PublishedAt: "2026-08-22T10:03:00.000000000Z",
@@ -627,6 +622,47 @@ func TestLexicalGenerationPublicationRejectsForbiddenArtifacts(t *testing.T) {
 	_, err = s.ActiveRendition(ctx, versions[0], attachmentProfile.Fingerprint)
 	require.ErrorIs(t, err, ErrNotFound)
 	_, err = s.ActiveLexicalGeneration(ctx)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestLexicalGenerationPublicationRejectsGenerationMissingPublishedBuild(t *testing.T) {
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	firstBuild := lexicalSearchBuild(s, profile, fakeHash("b7"), "first mercury phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, firstBuild))
+	staleGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("9d"))
+	require.NoError(t, err)
+
+	secondBuild, secondVersion := lexicalSearchReplacementBuild(
+		t, s, profile, fakeHash("b8"), "second venus phrase",
+	)
+	require.NoError(t, s.StageRenditionBuild(ctx, secondBuild))
+	currentGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("9e"))
+	require.NoError(t, err)
+	secondAttachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentSecond, VaultID: s.VaultID(), ContentVersionID: secondVersion,
+		BuildID: secondBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, secondAttachment, RenditionHeadRecord{
+		ContentVersionID: secondVersion, ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: secondAttachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+	}, currentGeneration.ID))
+
+	firstAttachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: firstBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:02:00.000000000Z",
+	}
+	err = s.PublishRenditionAndLexicalHeads(ctx, firstAttachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: firstAttachment.ID, PublishedAt: "2026-08-22T10:03:00.000000000Z",
+	}, staleGeneration.ID)
+	require.ErrorContains(t, err, "does not cover published rendition build")
+
+	active, err := s.ActiveLexicalGeneration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, currentGeneration, active)
+	_, err = s.ActiveRendition(ctx, versions[0], profile.Fingerprint)
 	require.ErrorIs(t, err, ErrNotFound)
 }
 

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"encoding/json/jsontext"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -418,6 +420,402 @@ func TestSearchContentFollowsStableNameMatches(t *testing.T) {
 	require.Len(t, hits, 1)
 	assert.False(t, truncated)
 	assert.Equal(t, nameMatch.ID, hits[0].Node.ID)
+}
+
+func TestSearchAttachmentEligibilityKeepsSharedBuildVersionScoped(t *testing.T) {
+	// Mutation caught: joining lexical rows to content by source hash or build
+	// alone would let one attachment confer search visibility on another version.
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	build := lexicalSearchBuild(s, profile, catalogBuildID, "eligible mercury phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, build))
+	generation, err := s.StageLexicalGeneration(ctx, fakeHash("91"))
+	require.NoError(t, err)
+
+	first := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(),
+		ContentVersionID: versions[0], BuildID: build.ID, Profile: profile,
+		AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, first, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: first.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+	}, generation.ID))
+
+	hits, truncated, err := s.SearchPage(ctx, "mercury", 10)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, hits, 1)
+	assert.Equal(t, versions[0], hits[0].Node.CurrentVersionID)
+	assert.Equal(t, SearchMatchContent, hits[0].Match)
+
+	secondProfile := catalogProcessingProfile(t, true)
+	second := RenditionAttachmentRecord{
+		ID: catalogAttachmentSecond, VaultID: s.VaultID(),
+		ContentVersionID: versions[1], BuildID: build.ID, Profile: secondProfile,
+		AttachedAt: "2026-08-22T10:02:00.000000000Z",
+	}
+	require.NoError(t, s.AttachRenditionBuild(ctx, second))
+	hits, _, err = s.SearchPage(ctx, "mercury", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1, "a staged attachment without a head is not eligible")
+
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, second, RenditionHeadRecord{
+		ContentVersionID: versions[1], ProcessingProfileFingerprint: secondProfile.Fingerprint,
+		AttachmentID: second.ID, PublishedAt: "2026-08-22T10:03:00.000000000Z",
+	}, generation.ID))
+	hits, _, err = s.SearchPageWithOptions(ctx, "mercury", 10, SearchOptions{MIMEType: "application/pdf"})
+	require.NoError(t, err)
+	require.Len(t, hits, 2, "independently headed attachments may share one vault-local build")
+	assert.Equal(t, "synthetic-source-a.pdf", hits[0].Node.Name)
+	assert.Equal(t, "synthetic-source-b.pdf", hits[1].Node.Name)
+
+	secondNode, err := s.NodeByPath(ctx, "/synthetic-source-b.pdf")
+	require.NoError(t, err)
+	_, _, err = s.Trash(ctx, secondNode.ID, secondNode.Revision)
+	require.NoError(t, err)
+	hits, _, err = s.SearchPage(ctx, "mercury", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1, "a trashed attachment must not remain searchable")
+
+	firstNode, err := s.NodeByPath(ctx, "/synthetic-source-a.pdf")
+	require.NoError(t, err)
+	_, _, err = s.ReplaceContent(
+		ctx, firstNode.ID, firstNode.Revision, fakeHash("d9"), 7, "application/pdf",
+	)
+	require.NoError(t, err)
+	hits, _, err = s.SearchPage(ctx, "mercury", 10)
+	require.NoError(t, err)
+	assert.Empty(t, hits, "an attachment to a historical source version must not serve")
+}
+
+func TestLexicalGenerationBuildFailureLeavesNoReadablePartialGeneration(t *testing.T) {
+	// Mutation caught: committing FTS rows before marking the generation
+	// complete would leave a failed generation available to a later head flip.
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	firstBuild := lexicalSearchBuild(s, profile, catalogBuildID, "prior mercury phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, firstBuild))
+	firstGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("92"))
+	require.NoError(t, err)
+	firstAttachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: firstBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, firstAttachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: firstAttachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+	}, firstGeneration.ID))
+
+	secondBuild, _ := lexicalSearchReplacementBuild(
+		t, s, profile, fakeHash("b3"), "replacement venus phrase",
+	)
+	require.NoError(t, s.StageRenditionBuild(ctx, secondBuild))
+	secondGenerationID := fakeHash("93")
+	_, err = s.db.Exec(`
+		CREATE TRIGGER fail_lexical_generation_catalog
+		BEFORE INSERT ON rendition_lexical_generations
+		WHEN new.generation_id = '` + secondGenerationID + `'
+		BEGIN SELECT RAISE(ABORT, 'injected failure after FTS build'); END`)
+	require.NoError(t, err)
+
+	_, err = s.StageLexicalGeneration(ctx, secondGenerationID)
+	require.ErrorContains(t, err, "injected failure after FTS build")
+	var partialRows int
+	require.NoError(t, s.db.QueryRow(
+		`SELECT COUNT(*) FROM rendition_lexical_fts WHERE generation_id=?`, secondGenerationID,
+	).Scan(&partialRows))
+	assert.Zero(t, partialRows)
+	active, err := s.ActiveLexicalGeneration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, firstGeneration, active)
+	hits, _, err := s.SearchPage(ctx, "mercury", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	hits, _, err = s.SearchPage(ctx, "venus", 10)
+	require.NoError(t, err)
+	assert.Empty(t, hits)
+}
+
+func TestLexicalGenerationHeadFailureRollsBackAttachmentAndBothHeads(t *testing.T) {
+	// Mutation caught: publishing the attachment or rendition head outside the
+	// lexical-head transaction would replace the prior serving state on failure.
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	firstBuild := lexicalSearchBuild(s, profile, catalogBuildID, "prior mercury phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, firstBuild))
+	firstGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("94"))
+	require.NoError(t, err)
+	firstAttachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: firstBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, firstAttachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: firstAttachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+	}, firstGeneration.ID))
+
+	secondBuild, secondVersion := lexicalSearchReplacementBuild(
+		t, s, profile, fakeHash("b4"), "replacement venus phrase",
+	)
+	require.NoError(t, s.StageRenditionBuild(ctx, secondBuild))
+	secondGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("95"))
+	require.NoError(t, err)
+	secondAttachment := RenditionAttachmentRecord{
+		ID: fakeHash("53"), VaultID: s.VaultID(), ContentVersionID: secondVersion,
+		BuildID: secondBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:02:00.000000000Z",
+	}
+	_, err = s.db.Exec(`
+		CREATE TRIGGER fail_lexical_head_flip
+		BEFORE UPDATE ON rendition_lexical_heads
+		BEGIN SELECT RAISE(ABORT, 'injected failure before head flip'); END`)
+	require.NoError(t, err)
+
+	err = s.PublishRenditionAndLexicalHeads(ctx, secondAttachment, RenditionHeadRecord{
+		ContentVersionID: secondVersion, ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: secondAttachment.ID, PublishedAt: "2026-08-22T10:03:00.000000000Z",
+	}, secondGeneration.ID)
+	require.ErrorContains(t, err, "injected failure before head flip")
+
+	view, err := s.ActiveRendition(ctx, versions[0], profile.Fingerprint)
+	require.NoError(t, err)
+	assert.Equal(t, firstAttachment.ID, view.Attachment.ID)
+	active, err := s.ActiveLexicalGeneration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, firstGeneration, active)
+	var attachments int
+	require.NoError(t, s.db.QueryRow(
+		`SELECT COUNT(*) FROM rendition_attachments WHERE attachment_id=?`, secondAttachment.ID,
+	).Scan(&attachments))
+	assert.Zero(t, attachments)
+	hits, _, err := s.SearchPage(ctx, "mercury", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	hits, _, err = s.SearchPage(ctx, "venus", 10)
+	require.NoError(t, err)
+	assert.Empty(t, hits)
+}
+
+func TestLexicalGenerationReaderLeasePinsAndEnumeratesExactRoots(t *testing.T) {
+	// Mutation caught: returning only the active generation value leaves no
+	// acquire/release lifetime or enumerable root for generation garbage collection.
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	firstBuild := lexicalSearchBuild(s, profile, catalogBuildID, "prior mercury phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, firstBuild))
+	firstGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("96"))
+	require.NoError(t, err)
+	firstAttachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: firstBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, firstAttachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: firstAttachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+	}, firstGeneration.ID))
+
+	firstLease, err := s.AcquireLexicalGeneration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, firstGeneration, firstLease.Generation)
+	assert.Equal(t, []LexicalGenerationRoot{{
+		GenerationID: firstGeneration.ID, ReaderCount: 1,
+	}}, s.LeasedLexicalGenerationRoots())
+
+	secondBuild, secondVersion := lexicalSearchReplacementBuild(
+		t, s, profile, fakeHash("b6"), "replacement venus phrase",
+	)
+	require.NoError(t, s.StageRenditionBuild(ctx, secondBuild))
+	secondGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("97"))
+	require.NoError(t, err)
+	secondAttachment := RenditionAttachmentRecord{
+		ID: fakeHash("57"), VaultID: s.VaultID(), ContentVersionID: secondVersion,
+		BuildID: secondBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:02:00.000000000Z",
+	}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, secondAttachment, RenditionHeadRecord{
+		ContentVersionID: secondVersion, ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: secondAttachment.ID, PublishedAt: "2026-08-22T10:03:00.000000000Z",
+	}, secondGeneration.ID))
+	assert.Equal(t, []LexicalGenerationRoot{{
+		GenerationID: firstGeneration.ID, ReaderCount: 1,
+	}}, s.LeasedLexicalGenerationRoots(), "the old generation remains rooted after the head flip")
+
+	secondLease, err := s.AcquireLexicalGeneration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, secondGeneration, secondLease.Generation)
+	assert.Equal(t, []LexicalGenerationRoot{
+		{GenerationID: firstGeneration.ID, ReaderCount: 1},
+		{GenerationID: secondGeneration.ID, ReaderCount: 1},
+	}, s.LeasedLexicalGenerationRoots())
+
+	require.NoError(t, firstLease.Release())
+	assert.Equal(t, []LexicalGenerationRoot{{
+		GenerationID: secondGeneration.ID, ReaderCount: 1,
+	}}, s.LeasedLexicalGenerationRoots())
+	require.NoError(t, firstLease.Release(), "release is idempotent")
+	require.NoError(t, secondLease.Release())
+	assert.Empty(t, s.LeasedLexicalGenerationRoots())
+}
+
+func TestLexicalGenerationReadSnapshotCannotMixPublicationEpochs(t *testing.T) {
+	// Mutation caught: selecting a generation before starting the query's read
+	// snapshot lets a concurrent head flip combine old FTS rows with new
+	// rendition heads, returning the empty hybrid instead of either epoch.
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	firstBuild := lexicalSearchBuild(s, profile, catalogBuildID, "prior epoch phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, firstBuild))
+	firstGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("9a"))
+	require.NoError(t, err)
+	firstAttachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: firstBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, firstAttachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: firstAttachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+	}, firstGeneration.ID))
+
+	secondBuild := lexicalSearchBuild(s, profile, fakeHash("ba"), "replacement epoch phrase")
+	secondPolicy := jsontext.Value(`{"roles":[{"max_count":1,"min_count":1,"role":"normalized_evidence"},{"max_count":1,"min_count":0,"role":"provider_markdown"},{"max_count":1,"min_count":1,"role":"sanitized_markdown"}],"version":1}`)
+	secondBuild.CapturedArtifactPolicy = secondPolicy
+	secondBuild.CapturedArtifactPolicyFingerprint = testSHA256(secondPolicy)
+	secondBuild.ProviderOperationID = "synthetic-operation-replacement"
+	require.NoError(t, s.StageRenditionBuild(ctx, secondBuild))
+	secondGeneration, err := s.StageLexicalGeneration(ctx, fakeHash("9b"))
+	require.NoError(t, err)
+	secondAttachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentSecond, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: secondBuild.ID, Profile: profile, AttachedAt: "2026-08-22T10:02:00.000000000Z",
+	}
+
+	var visibleBuildIDs []string
+	err = s.withLexicalGenerationRead(ctx, func(
+		queryer metadataQuerier, generation LexicalGeneration,
+	) (retErr error) {
+		assert.Equal(t, firstGeneration, generation)
+		require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, secondAttachment, RenditionHeadRecord{
+			ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+			AttachmentID: secondAttachment.ID, PublishedAt: "2026-08-22T10:03:00.000000000Z",
+		}, secondGeneration.ID))
+		assert.Equal(t, []LexicalGenerationRoot{{
+			GenerationID: firstGeneration.ID, ReaderCount: 1,
+		}}, s.LeasedLexicalGenerationRoots(), "the selected old generation remains externally rooted")
+
+		rows, queryErr := queryer.QueryContext(ctx, `
+			SELECT f.build_id
+			FROM rendition_lexical_fts f
+			JOIN rendition_attachments a ON a.build_id=f.build_id
+			JOIN rendition_heads rh
+			  ON rh.content_version_id=a.content_version_id
+			 AND rh.profile_fingerprint=a.profile_fingerprint
+			 AND rh.attachment_id=a.attachment_id
+			WHERE rendition_lexical_fts MATCH 'epoch'
+			  AND f.generation_id=?`, generation.ID)
+		if queryErr != nil {
+			return queryErr
+		}
+		defer func() {
+			retErr = errors.Join(retErr, rows.Close())
+		}()
+		for rows.Next() {
+			var buildID string
+			if queryErr := rows.Scan(&buildID); queryErr != nil {
+				return queryErr
+			}
+			visibleBuildIDs = append(visibleBuildIDs, buildID)
+		}
+		if queryErr := rows.Err(); queryErr != nil {
+			return queryErr
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{firstBuild.ID}, visibleBuildIDs,
+		"the read returns the complete old epoch; old FTS plus new heads would be empty")
+	assert.Empty(t, s.LeasedLexicalGenerationRoots(), "the lease releases after row consumption")
+	active, err := s.ActiveLexicalGeneration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, secondGeneration, active)
+}
+
+func TestLexicalGenerationReuseRejectsSameCountContentSubstitution(t *testing.T) {
+	// Mutation caught: validating only row counts lets a substituted FTS row
+	// masquerade as an already-complete immutable generation.
+	s, _ := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	build := lexicalSearchBuild(s, profile, catalogBuildID, "canonical mercury phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, build))
+	generationID := fakeHash("98")
+	_, err := s.StageLexicalGeneration(ctx, generationID)
+	require.NoError(t, err)
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE rendition_lexical_fts SET text='substituted venus phrase'
+		WHERE generation_id=? AND build_id=?`, generationID, build.ID)
+	require.NoError(t, err)
+
+	_, err = s.StageLexicalGeneration(ctx, generationID)
+	require.ErrorContains(t, err, "immutable manifest")
+}
+
+func TestLexicalGenerationPublicationRejectsSameCountContentSubstitution(t *testing.T) {
+	// Mutation caught: target-build count equality alone allows substituted FTS
+	// content to become serving authority during the atomic head flip.
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	build := lexicalSearchBuild(s, profile, catalogBuildID, "canonical mercury phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, build))
+	generationID := fakeHash("99")
+	_, err := s.StageLexicalGeneration(ctx, generationID)
+	require.NoError(t, err)
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE rendition_lexical_fts SET text='substituted venus phrase'
+		WHERE generation_id=? AND build_id=?`, generationID, build.ID)
+	require.NoError(t, err)
+	attachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: build.ID, Profile: profile, AttachedAt: "2026-08-22T10:00:00.000000000Z",
+	}
+
+	err = s.PublishRenditionAndLexicalHeads(ctx, attachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: attachment.ID, PublishedAt: "2026-08-22T10:01:00.000000000Z",
+	}, generationID)
+	require.ErrorContains(t, err, "immutable manifest")
+	_, err = s.ActiveLexicalGeneration(ctx)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func lexicalSearchBuild(
+	s *Store, profile ProcessingProfileRecord, buildID, text string,
+) RenditionBuildRecord {
+	build := catalogRenditionBuild(s, profile)
+	build.ID = buildID
+	build.LexicalSegments[0].Text = text
+	build.LexicalSegments[0].CharEnd = len([]rune(text))
+	build.LexicalSegments[0].Checksum = testSHA256([]byte(text))
+	return build
+}
+
+func lexicalSearchReplacementBuild(
+	t *testing.T, s *Store, profile ProcessingProfileRecord, buildID, text string,
+) (RenditionBuildRecord, string) {
+	t.Helper()
+	sourceHash := fakeHash(buildID[:2] + "d8")
+	node, err := s.CreateFile(
+		t.Context(), s.RootID(), "replacement-"+buildID[:8]+".pdf",
+		sourceHash, 7, "application/pdf",
+	)
+	require.NoError(t, err)
+	build := lexicalSearchBuild(s, profile, buildID, text)
+	build.SourceSHA256 = sourceHash
+	return build, node.CurrentVersionID
 }
 
 func TestPendingAndFailedTextExtractions(t *testing.T) {


### PR DESCRIPTION
## What changed

Docbank can now publish a verified rendition and its lexical search generation as one atomic authority. A failure after blob write, catalog staging, FTS construction, or immediately before the head flip leaves the previous publication serving.

Every retained payload is checked against its exact hash and size. Canonical evidence is rebuilt under the captured rendition policy, lexical manifests cover their exact content, and active attachments are selected in the same SQLite snapshot used to read their rows.

## Why

The derivative catalog from #184 was intentionally dormant. Publishing it piecemeal would expose half-built state, stale search rows, or shared builds under the wrong content version. The head should move only when the complete rendition and lexical generation agree.

## Usage

There is no standalone CLI yet. Processing workers can stage a rendition build and lexical generation, validate the complete manifest, then publish both together. Readers keep using the previous head until that transaction succeeds.

Part of #176 (F5). Stacks on #184.
