### PR TITLE
Move legacy plain-text renditions into canonical authority

### DIFF
--- a/internal/store/extraction.go
+++ b/internal/store/extraction.go
@@ -313,6 +313,20 @@ func (s *Store) RecordExtraction(ctx context.Context, result ExtractionResult) e
 		if !exists {
 			return fmt.Errorf("blob %s: %w", result.BlobHash, ErrNotFound)
 		}
+		var storedVersion int64
+		err := tx.QueryRowContext(ctx, `
+			SELECT extractor_version FROM extracted_text
+			WHERE blob_hash=? AND extractor=?`, result.BlobHash, result.Extractor,
+		).Scan(&storedVersion)
+		if err == nil && result.ExtractorVersion < storedVersion {
+			return fmt.Errorf(
+				"extractor %s result version %d is older than stored version %d",
+				result.Extractor, result.ExtractorVersion, storedVersion,
+			)
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("reading stored extraction version: %w", err)
+		}
 		var extractErr, text any
 		if result.Error != "" {
 			extractErr = result.Error

--- a/internal/store/extraction.go
+++ b/internal/store/extraction.go
@@ -299,7 +299,11 @@ func (s *Store) RecordExtraction(ctx context.Context, result ExtractionResult) e
 		return fmt.Errorf("invalid extraction status %q", result.Status)
 	}
 
-	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+	publishRendition := false
+	exactLegacySuccess := result.Extractor == legacyPlainTextExtractor &&
+		result.ExtractorVersion == legacyPlainTextExtractorVersion &&
+		result.Status == ExtractionOK
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		var exists bool
 		if err := tx.QueryRowContext(ctx,
 			`SELECT EXISTS(SELECT 1 FROM blobs WHERE hash = ?)`, result.BlobHash,
@@ -334,13 +338,53 @@ func (s *Store) RecordExtraction(ctx context.Context, result ExtractionResult) e
 		if err := replaceContentFTSTx(ctx, tx, result.BlobHash, result.Extractor, text); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx,
-			`DELETE FROM text_extraction_queue WHERE blob_hash = ?`, result.BlobHash,
-		); err != nil {
-			return fmt.Errorf("finishing text extraction: %w", err)
+		if exactLegacySuccess {
+			published, publishErr := hasPublishedLexicalHeadTx(ctx, tx)
+			if publishErr != nil {
+				return publishErr
+			}
+			publishRendition = published
+		}
+		if !publishRendition {
+			if _, err := tx.ExecContext(ctx,
+				`DELETE FROM text_extraction_queue WHERE blob_hash = ?`, result.BlobHash,
+			); err != nil {
+				return fmt.Errorf("finishing text extraction: %w", err)
+			}
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	if !publishRendition {
+		return nil
+	}
+	if _, err := s.MigrateLegacyPlainText(ctx); err != nil {
+		return fmt.Errorf("publishing extracted text rendition: %w", err)
+	}
+	return nil
+}
+
+func hasPublishedLexicalHeadTx(ctx context.Context, tx *sql.Tx) (bool, error) {
+	var schemaExists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM sqlite_schema
+			WHERE type='table' AND name='rendition_lexical_heads'
+		)`).Scan(&schemaExists); err != nil {
+		return false, fmt.Errorf("checking lexical projection schema: %w", err)
+	}
+	if !schemaExists {
+		return false, nil
+	}
+	var published bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM rendition_lexical_heads WHERE singleton=1)
+	`).Scan(&published); err != nil {
+		return false, fmt.Errorf("checking published lexical authority: %w", err)
+	}
+	return published, nil
 }
 
 func replaceContentFTSTx(

--- a/internal/store/extraction.go
+++ b/internal/store/extraction.go
@@ -314,14 +314,22 @@ func (s *Store) RecordExtraction(ctx context.Context, result ExtractionResult) e
 			return fmt.Errorf("blob %s: %w", result.BlobHash, ErrNotFound)
 		}
 		var storedVersion int64
+		var storedStatus string
 		err := tx.QueryRowContext(ctx, `
-			SELECT extractor_version FROM extracted_text
+			SELECT extractor_version,status FROM extracted_text
 			WHERE blob_hash=? AND extractor=?`, result.BlobHash, result.Extractor,
-		).Scan(&storedVersion)
+		).Scan(&storedVersion, &storedStatus)
 		if err == nil && result.ExtractorVersion < storedVersion {
 			return fmt.Errorf(
 				"extractor %s result version %d is older than stored version %d",
 				result.Extractor, result.ExtractorVersion, storedVersion,
+			)
+		}
+		if err == nil && result.ExtractorVersion == storedVersion &&
+			storedStatus == ExtractionOK && result.Status == ExtractionFailed {
+			return fmt.Errorf(
+				"cannot replace a successful extraction with a same-version failure for extractor %s version %d",
+				result.Extractor, result.ExtractorVersion,
 			)
 		}
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/internal/store/processing_migration.go
+++ b/internal/store/processing_migration.go
@@ -84,12 +84,16 @@ func (s *Store) MigrateLegacyPlainText(
 		}
 
 		eligible := make(map[string]legacyPlainTextRow)
-		newerSuccessful := make(map[string]struct{})
 		for _, row := range rows {
 			if row.extractor == legacyPlainTextExtractor &&
 				row.extractorVersion > legacyPlainTextExtractorVersion &&
 				row.status == ExtractionOK && row.text.Valid && utf8.ValidString(row.text.String) {
-				newerSuccessful[row.blobHash] = struct{}{}
+				if len(selectedByBlob[row.blobHash]) != 0 {
+					return fmt.Errorf(
+						"unsupported newer plain-text extraction version %d for selected blob %s",
+						row.extractorVersion, row.blobHash,
+					)
+				}
 			}
 			if row.extractor != legacyPlainTextExtractor ||
 				row.extractorVersion != legacyPlainTextExtractorVersion ||
@@ -172,8 +176,7 @@ func (s *Store) MigrateLegacyPlainText(
 		queued := make(map[string]struct{})
 		for blobHash := range selectedByBlob {
 			_, migrated := eligible[blobHash]
-			_, newer := newerSuccessful[blobHash]
-			if migrated || newer {
+			if migrated {
 				if _, err := tx.ExecContext(ctx,
 					`DELETE FROM text_extraction_queue WHERE blob_hash=?`, blobHash,
 				); err != nil {

--- a/internal/store/processing_migration.go
+++ b/internal/store/processing_migration.go
@@ -51,6 +51,7 @@ type legacySelectedVersion struct {
 	versionID string
 	blobHash  string
 	name      string
+	trashed   bool
 }
 
 // MigrateLegacyPlainText retains the portable extracted_text cache while
@@ -83,7 +84,13 @@ func (s *Store) MigrateLegacyPlainText(
 		}
 
 		eligible := make(map[string]legacyPlainTextRow)
+		newerSuccessful := make(map[string]struct{})
 		for _, row := range rows {
+			if row.extractor == legacyPlainTextExtractor &&
+				row.extractorVersion > legacyPlainTextExtractorVersion &&
+				row.status == ExtractionOK && row.text.Valid && utf8.ValidString(row.text.String) {
+				newerSuccessful[row.blobHash] = struct{}{}
+			}
 			if row.extractor != legacyPlainTextExtractor ||
 				row.extractorVersion != legacyPlainTextExtractorVersion ||
 				row.status != ExtractionOK || !row.text.Valid ||
@@ -164,7 +171,9 @@ func (s *Store) MigrateLegacyPlainText(
 
 		queued := make(map[string]struct{})
 		for blobHash := range selectedByBlob {
-			if _, ok := eligible[blobHash]; ok {
+			_, migrated := eligible[blobHash]
+			_, newer := newerSuccessful[blobHash]
+			if migrated || newer {
 				if _, err := tx.ExecContext(ctx,
 					`DELETE FROM text_extraction_queue WHERE blob_hash=?`, blobHash,
 				); err != nil {
@@ -233,11 +242,10 @@ func readLegacySelectedVersions(
 	ctx context.Context, tx *sql.Tx,
 ) ([]legacySelectedVersion, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT v.version_id,v.blob_hash,n.name
+		SELECT v.version_id,v.blob_hash,n.name,n.trashed_at IS NOT NULL
 		FROM text_searchable_versions sv
 		JOIN content_versions v ON v.version_id=sv.version_id
 		JOIN nodes n ON n.current_version_id=v.version_id
-		WHERE n.trashed_at IS NULL
 		ORDER BY v.version_id`)
 	if err != nil {
 		return nil, fmt.Errorf("reading legacy searchable versions: %w", err)
@@ -246,7 +254,9 @@ func readLegacySelectedVersions(
 	var result []legacySelectedVersion
 	for rows.Next() {
 		var version legacySelectedVersion
-		if err := rows.Scan(&version.versionID, &version.blobHash, &version.name); err != nil {
+		if err := rows.Scan(
+			&version.versionID, &version.blobHash, &version.name, &version.trashed,
+		); err != nil {
 			return nil, fmt.Errorf("reading legacy searchable version: %w", err)
 		}
 		result = append(result, version)
@@ -572,6 +582,9 @@ func compareLegacyServingCompatibilityTx(
 	type authority struct{ name, text string }
 	want := make(map[string]authority)
 	for _, version := range selected {
+		if version.trashed {
+			continue
+		}
 		if row, ok := eligible[version.blobHash]; ok {
 			want[version.versionID] = authority{name: version.name, text: row.text.String}
 		}

--- a/internal/store/processing_migration.go
+++ b/internal/store/processing_migration.go
@@ -1,0 +1,614 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json/jsontext"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+)
+
+const (
+	legacyPlainTextExtractor        = "plain-text"
+	legacyPlainTextExtractorVersion = int64(1)
+	legacyPlainTextProvider         = "plain-text/legacy-v1"
+	legacyPlainTextUnitSourceKey    = "legacy:0"
+	legacyPlainTextSegmentRunes     = 1 << 20
+)
+
+var legacyPlainTextCapturedPolicy = jsontext.Value(`{"roles":[],"version":1}`)
+
+// LegacyMigrationReport describes one legacy cache-to-catalog cutover. Counts
+// name the deterministic desired authority, so a repeated migration reports
+// the same result instead of depending on SQLite's insert/no-op distinction.
+type LegacyMigrationReport struct {
+	EligibleRows        int
+	MigratedBuilds      int
+	MigratedAttachments int
+	QueuedBlobs         int
+	ProfileFingerprint  string
+	LexicalGenerationID string
+}
+
+type legacyPlainTextRow struct {
+	blobHash         string
+	extractor        string
+	extractorVersion int64
+	status           string
+	text             sql.NullString
+	extractedAt      string
+}
+
+type legacySelectedVersion struct {
+	versionID string
+	blobHash  string
+	name      string
+}
+
+// MigrateLegacyPlainText retains the portable extracted_text cache while
+// moving its exact released plain-text/v1 successes under rendition authority.
+// Catalog rows, version heads, the complete lexical projection, legacy FTS
+// fencing, and fresh-work repair publish in one SQLite transaction.
+func (s *Store) MigrateLegacyPlainText(
+	ctx context.Context,
+) (LegacyMigrationReport, error) {
+	profile, err := legacyPlainTextProfile()
+	if err != nil {
+		return LegacyMigrationReport{}, err
+	}
+	report := LegacyMigrationReport{ProfileFingerprint: profile.Fingerprint}
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		rows, err := readLegacyPlainTextRows(ctx, tx)
+		if err != nil {
+			return err
+		}
+		selected, err := readLegacySelectedVersions(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 && len(selected) == 0 {
+			return nil
+		}
+		selectedByBlob := make(map[string][]legacySelectedVersion)
+		for _, version := range selected {
+			selectedByBlob[version.blobHash] = append(selectedByBlob[version.blobHash], version)
+		}
+
+		eligible := make(map[string]legacyPlainTextRow)
+		for _, row := range rows {
+			if row.extractor != legacyPlainTextExtractor ||
+				row.extractorVersion != legacyPlainTextExtractorVersion ||
+				row.status != ExtractionOK || !row.text.Valid ||
+				!utf8.ValidString(row.text.String) {
+				continue
+			}
+			if _, authorityErr := requirePhysicalAuthorityTx(tx, row.blobHash); authorityErr != nil {
+				if errors.Is(authorityErr, ErrNotFound) ||
+					errors.Is(authorityErr, ErrPhysicalAuthorityMissing) {
+					continue
+				}
+				return fmt.Errorf("checking legacy plain-text blob %s: %w", row.blobHash, authorityErr)
+			}
+			eligible[row.blobHash] = row
+		}
+		report.EligibleRows = len(eligible)
+
+		if len(eligible) != 0 {
+			if err := ensureProcessingProfileTx(ctx, tx, profile); err != nil {
+				return fmt.Errorf("recording legacy plain-text profile: %w", err)
+			}
+		}
+		for _, row := range rows {
+			if _, ok := eligible[row.blobHash]; !ok || row.extractor != legacyPlainTextExtractor {
+				continue
+			}
+			build, err := legacyPlainTextBuild(s.vaultID, profile, row)
+			if err != nil {
+				return err
+			}
+			if err := insertLegacyRenditionBuildTx(ctx, tx, build); err != nil {
+				return err
+			}
+			report.MigratedBuilds++
+		}
+
+		generation, err := stageLegacyLexicalGenerationTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		report.LexicalGenerationID = generation.ID
+
+		for _, version := range selected {
+			row, ok := eligible[version.blobHash]
+			if !ok {
+				continue
+			}
+			buildID := legacyPlainTextBuildFingerprint(
+				row.blobHash, row.extractor, row.extractorVersion, row.status,
+				[]byte(row.text.String),
+			)
+			attachmentID := legacyPlainTextAttachmentID(version.versionID, buildID)
+			attachment := RenditionAttachmentRecord{
+				ID: attachmentID, VaultID: s.vaultID, ContentVersionID: version.versionID,
+				BuildID: buildID, Profile: profile, AttachedAt: row.extractedAt,
+			}
+			if err := insertLegacyRenditionAttachmentTx(ctx, tx, attachment); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO rendition_heads(
+					content_version_id,profile_fingerprint,attachment_id,published_at
+				) VALUES(?,?,?,?)
+				ON CONFLICT(content_version_id,profile_fingerprint) DO UPDATE SET
+					attachment_id=excluded.attachment_id,published_at=excluded.published_at`,
+				version.versionID, profile.Fingerprint, attachmentID, row.extractedAt,
+			); err != nil {
+				return fmt.Errorf("publishing migrated legacy plain-text head: %w", err)
+			}
+			report.MigratedAttachments++
+		}
+
+		if err := compareLegacyServingCompatibilityTx(
+			ctx, tx, selected, eligible, profile.Fingerprint, generation.ID,
+		); err != nil {
+			return err
+		}
+
+		queued := make(map[string]struct{})
+		for blobHash := range selectedByBlob {
+			if _, ok := eligible[blobHash]; ok {
+				if _, err := tx.ExecContext(ctx,
+					`DELETE FROM text_extraction_queue WHERE blob_hash=?`, blobHash,
+				); err != nil {
+					return fmt.Errorf("clearing migrated legacy plain-text work: %w", err)
+				}
+				continue
+			}
+			queued[blobHash] = struct{}{}
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO text_extraction_queue(blob_hash,next_attempt_at) VALUES(?,?)
+				ON CONFLICT(blob_hash) DO NOTHING`, blobHash, nowRFC3339(),
+			); err != nil {
+				return fmt.Errorf("queueing legacy plain-text repair for %s: %w", blobHash, err)
+			}
+		}
+		report.QueuedBlobs = len(queued)
+
+		// extracted_text remains portable and recoverable. Its FTS projection is
+		// deliberately empty after the new lexical head becomes authoritative.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM content_fts`); err != nil {
+			return fmt.Errorf("fencing legacy plain-text search authority: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO rendition_lexical_heads(singleton,generation_id) VALUES(1,?)
+			ON CONFLICT(singleton) DO UPDATE SET generation_id=excluded.generation_id`,
+			generation.ID,
+		); err != nil {
+			return fmt.Errorf("publishing migrated legacy lexical head: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return LegacyMigrationReport{}, fmt.Errorf("migrating legacy plain-text authority: %w", err)
+	}
+	return report, nil
+}
+
+func readLegacyPlainTextRows(
+	ctx context.Context, tx *sql.Tx,
+) ([]legacyPlainTextRow, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT blob_hash,extractor,extractor_version,status,text,extracted_at
+		FROM extracted_text ORDER BY blob_hash,extractor`)
+	if err != nil {
+		return nil, fmt.Errorf("reading legacy extracted-text cache: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var result []legacyPlainTextRow
+	for rows.Next() {
+		var row legacyPlainTextRow
+		if err := rows.Scan(
+			&row.blobHash, &row.extractor, &row.extractorVersion,
+			&row.status, &row.text, &row.extractedAt,
+		); err != nil {
+			return nil, fmt.Errorf("reading legacy extracted-text row: %w", err)
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading legacy extracted-text cache: %w", err)
+	}
+	return result, nil
+}
+
+func readLegacySelectedVersions(
+	ctx context.Context, tx *sql.Tx,
+) ([]legacySelectedVersion, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT v.version_id,v.blob_hash,n.name
+		FROM text_searchable_versions sv
+		JOIN content_versions v ON v.version_id=sv.version_id
+		JOIN nodes n ON n.current_version_id=v.version_id
+		WHERE n.trashed_at IS NULL
+		ORDER BY v.version_id`)
+	if err != nil {
+		return nil, fmt.Errorf("reading legacy searchable versions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var result []legacySelectedVersion
+	for rows.Next() {
+		var version legacySelectedVersion
+		if err := rows.Scan(&version.versionID, &version.blobHash, &version.name); err != nil {
+			return nil, fmt.Errorf("reading legacy searchable version: %w", err)
+		}
+		result = append(result, version)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading legacy searchable versions: %w", err)
+	}
+	return result, nil
+}
+
+func legacyPlainTextProfile() (ProcessingProfileRecord, error) {
+	fingerprint := func(field string) string {
+		digest := sha256.Sum256([]byte("docbank-legacy-plain-text-profile/v1\x00" + field))
+		return hex.EncodeToString(digest[:])
+	}
+	profile := document.ProcessingProfileV1{
+		ContractVersion: document.ProcessingProfileContractV1,
+		Rendition: &document.RenditionBindingV1{ //nolint:gosec // Contains a non-secret credential:<name> reference.
+			AdapterContract:          legacyPlainTextProvider,
+			AuthorizationFingerprint: fingerprint("authorization"),
+			CredentialBinding:        "credential:legacy-import",
+			DeploymentFingerprint:    fingerprint("deployment"),
+			Descriptor: document.ProviderDescriptorV1{
+				ID: legacyPlainTextProvider, Fingerprint: fingerprint("descriptor"),
+			},
+			DisclosureFingerprint: fingerprint("disclosure"), MaxDocumentBytes: 1 << 40,
+			MaxResponseBytes: 1 << 30, MaxUnits: 1, Name: "plain-text-legacy-v1",
+			RequestedArtifacts: []document.EvidenceArtifactRole{document.EvidenceArtifactStructured},
+			TrustBoundary:      "local-vault", UploadOptionsFingerprint: fingerprint("upload-options"),
+		},
+		EvidenceLexical: document.EvidenceLexicalPolicyV1{
+			CompletenessFingerprint:     fingerprint("degraded-provenance"),
+			LexicalSegmenterFingerprint: fingerprint("exact-stored-text"),
+			MaxSegmentRunes:             legacyPlainTextSegmentRunes, MaxUnitRunes: 256 << 20,
+			NormalizedEvidenceContract: document.NormalizedEvidenceContractV1,
+			NormalizerFingerprint:      fingerprint("no-normalization"),
+			RenditionContract:          document.RenditionContractV1,
+			SanitizerFingerprint:       fingerprint("legacy-trusted-local-cache"),
+			SourceEvidenceContract:     document.SourceEvidenceContractV1,
+		},
+		Retrieval: document.RetrievalPolicyV1{LexicalLimit: 100, VectorLimit: 100},
+		RetentionDisclosure: document.RetentionDisclosurePolicyV1{
+			AttachmentPolicyFingerprint: fingerprint("attachment-policy"),
+			ConsentFingerprint:          fingerprint("legacy-local-consent"),
+			RetainTypedArtifacts:        true, TrustBoundary: "local-vault",
+		},
+	}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	if err != nil {
+		return ProcessingProfileRecord{}, fmt.Errorf("constructing legacy plain-text profile: %w", err)
+	}
+	return ProcessingProfileRecord{
+		Fingerprint: fingerprints.Profile, CanonicalProfile: jsontext.Value(canonical),
+		RenditionRequestFingerprint:    fingerprints.RenditionRequest,
+		EvidenceLexicalFingerprint:     fingerprints.EvidenceLexical,
+		RetentionDisclosureFingerprint: fingerprints.RetentionDisclosure,
+		AttachmentPolicyFingerprint:    profile.RetentionDisclosure.AttachmentPolicyFingerprint,
+		ConsentFingerprint:             profile.RetentionDisclosure.ConsentFingerprint,
+		RenditionDisclosureFingerprint: profile.Rendition.DisclosureFingerprint,
+		TrustBoundary:                  profile.RetentionDisclosure.TrustBoundary,
+	}, nil
+}
+
+func legacyPlainTextBuild(
+	vaultID string, profile ProcessingProfileRecord, row legacyPlainTextRow,
+) (RenditionBuildRecord, error) {
+	textBytes := []byte(row.text.String)
+	textDigest := sha256.Sum256(textBytes)
+	textChecksum := hex.EncodeToString(textDigest[:])
+	buildID := legacyPlainTextBuildFingerprint(
+		row.blobHash, row.extractor, row.extractorVersion, row.status, textBytes,
+	)
+	segments := legacyPlainTextSegments(row.text.String)
+	policyFingerprint := sha256.Sum256(legacyPlainTextCapturedPolicy)
+	authorization := sha256.Sum256([]byte("docbank-legacy-plain-text-authorization/v1"))
+	return normalizeRenditionBuildRecord(RenditionBuildRecord{
+		ID: buildID, VaultID: vaultID, SourceSHA256: row.blobHash,
+		RenditionRequestFingerprint:       profile.RenditionRequestFingerprint,
+		EvidenceLexicalFingerprint:        profile.EvidenceLexicalFingerprint,
+		CapturedArtifactPolicyFingerprint: hex.EncodeToString(policyFingerprint[:]),
+		CapturedArtifactPolicy:            append(jsontext.Value(nil), legacyPlainTextCapturedPolicy...),
+		AuthorizationChecksum:             hex.EncodeToString(authorization[:]),
+		ProviderOperationID:               legacyPlainTextProvider,
+		ProviderReceipt: jsontext.Value(
+			`{"extractor":"plain-text","extractor_version":1,"migration":"legacy-v1","status":"ok"}`,
+		),
+		EvidenceChecksum: textChecksum, RenditionChecksum: buildID, MarkdownChecksum: textChecksum,
+		Completeness: document.EvidenceDegradedProvenance, Warnings: []string{},
+		CompletedAt: row.extractedAt, DeclaredArtifactCount: 0,
+		Units: []RenditionUnitRecord{{
+			ID: legacyPlainTextUnitSourceKey, EvidenceUnitID: legacyPlainTextUnitSourceKey,
+			Order: 0, Checksum: textChecksum, HeadingPath: []string{},
+			Locator: document.EvidenceLocatorV1{
+				Kind: document.EvidenceLocatorGeneric, IndexOrigin: document.EvidenceIndexOriginNone,
+			},
+		}},
+		LexicalSegments: segments,
+	})
+}
+
+func legacyPlainTextSegments(text string) []RenditionLexicalSegmentRecord {
+	var result []RenditionLexicalSegmentRecord
+	byteStart, runeStart := 0, 0
+	for byteStart < len(text) || byteStart == 0 && len(text) == 0 {
+		byteEnd := byteStart
+		runes := 0
+		for byteEnd < len(text) && runes < legacyPlainTextSegmentRunes {
+			_, size := utf8.DecodeRuneInString(text[byteEnd:])
+			byteEnd += size
+			runes++
+		}
+		segmentText := text[byteStart:byteEnd]
+		digest := sha256.Sum256([]byte(segmentText))
+		index := len(result)
+		result = append(result, RenditionLexicalSegmentRecord{
+			ID: "legacy:" + strconv.Itoa(index), UnitID: legacyPlainTextUnitSourceKey,
+			Order: index, CharStart: runeStart, CharEnd: runeStart + runes,
+			Checksum: hex.EncodeToString(digest[:]), Text: segmentText,
+		})
+		byteStart = byteEnd
+		runeStart += runes
+		if byteStart == len(text) {
+			break
+		}
+	}
+	return result
+}
+
+func legacyPlainTextBuildFingerprint(
+	blobHash, extractor string, version int64, status string, text []byte,
+) string {
+	textChecksum := sha256.Sum256(text)
+	hash := sha256.New()
+	_, _ = io.WriteString(hash, "docbank-legacy-plain-text/v1\x00")
+	for _, field := range []string{blobHash, extractor, strconv.FormatInt(version, 10), status} {
+		_, _ = io.WriteString(hash, field)
+		_, _ = hash.Write([]byte{0})
+	}
+	_, _ = hash.Write(textChecksum[:])
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func legacyPlainTextAttachmentID(versionID, buildID string) string {
+	hash := sha256.New()
+	_, _ = io.WriteString(hash, "docbank-legacy-plain-text-attachment/v1\x00")
+	_, _ = io.WriteString(hash, versionID)
+	_, _ = hash.Write([]byte{0})
+	_, _ = io.WriteString(hash, buildID)
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func insertLegacyRenditionBuildTx(
+	ctx context.Context, tx *sql.Tx, record RenditionBuildRecord,
+) error {
+	if err := validateRenditionBuildBlobAuthorityTx(ctx, tx, record); err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO rendition_builds(
+			build_id,vault_uid,source_sha256,rendition_request_fingerprint,
+			evidence_lexical_fingerprint,captured_artifact_policy_fingerprint,
+			captured_artifact_policy_json,authorization_checksum,provider_operation_id,
+			provider_receipt_json,evidence_checksum,rendition_checksum,markdown_checksum,
+			completeness,partial_success,truncated,warnings_json,completed_at,
+			declared_artifact_count,unit_count,lexical_segment_count
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		record.ID, record.VaultID, record.SourceSHA256,
+		record.RenditionRequestFingerprint, record.EvidenceLexicalFingerprint,
+		record.CapturedArtifactPolicyFingerprint, string(record.CapturedArtifactPolicy),
+		record.AuthorizationChecksum, record.ProviderOperationID, string(record.ProviderReceipt),
+		record.EvidenceChecksum, record.RenditionChecksum, record.MarkdownChecksum,
+		record.Completeness, record.PartialSuccess, record.Truncated,
+		mustCatalogJSON(record.Warnings), record.CompletedAt, record.DeclaredArtifactCount,
+		len(record.Units), len(record.LexicalSegments),
+	)
+	if err != nil {
+		return fmt.Errorf("inserting legacy rendition build %s: %w", record.ID, err)
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking legacy rendition build %s: %w", record.ID, err)
+	}
+	if inserted != 0 {
+		if err := insertRenditionBuildChildrenTx(ctx, tx, record); err != nil {
+			return err
+		}
+	} else {
+		stored, err := loadRenditionBuild(ctx, tx, record.ID)
+		if err != nil {
+			return err
+		}
+		record.CompletedAt = stored.CompletedAt
+		if !legacyPlainTextBuildEqual(stored, record) {
+			return fmt.Errorf("legacy rendition build %s names different immutable metadata", record.ID)
+		}
+	}
+	return validateRenditionBuildStateTx(ctx, tx, record.ID)
+}
+
+func legacyPlainTextBuildEqual(left, right RenditionBuildRecord) bool {
+	canonicalizeEmptyLists := func(record RenditionBuildRecord) RenditionBuildRecord {
+		if len(record.Warnings) == 0 {
+			record.Warnings = nil
+		}
+		if len(record.Artifacts) == 0 {
+			record.Artifacts = nil
+		}
+		record.Units = append([]RenditionUnitRecord(nil), record.Units...)
+		for i := range record.Units {
+			if len(record.Units[i].HeadingPath) == 0 {
+				record.Units[i].HeadingPath = nil
+			}
+		}
+		return record
+	}
+	return reflect.DeepEqual(canonicalizeEmptyLists(left), canonicalizeEmptyLists(right))
+}
+
+func insertLegacyRenditionAttachmentTx(
+	ctx context.Context, tx *sql.Tx, record RenditionAttachmentRecord,
+) error {
+	normalized, err := normalizeRenditionAttachmentRecord(record)
+	if err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO rendition_attachments(
+			attachment_id,vault_uid,content_version_id,build_id,profile_fingerprint,
+			retention_disclosure_fingerprint,attachment_policy_fingerprint,
+			consent_fingerprint,rendition_disclosure_fingerprint,trust_boundary,attached_at
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?)`,
+		normalized.ID, normalized.VaultID, normalized.ContentVersionID, normalized.BuildID,
+		normalized.Profile.Fingerprint, normalized.Profile.RetentionDisclosureFingerprint,
+		normalized.Profile.AttachmentPolicyFingerprint, normalized.Profile.ConsentFingerprint,
+		normalized.Profile.RenditionDisclosureFingerprint, normalized.Profile.TrustBoundary,
+		normalized.AttachedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting legacy rendition attachment %s: %w", normalized.ID, err)
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted == 0 {
+		stored, err := loadRenditionAttachment(ctx, tx, normalized.ID)
+		if err != nil {
+			return err
+		}
+		normalized.AttachedAt = stored.AttachedAt
+		if !reflect.DeepEqual(stored, normalized) {
+			return fmt.Errorf("legacy rendition attachment %s names different immutable metadata", normalized.ID)
+		}
+	}
+	return nil
+}
+
+func stageLegacyLexicalGenerationTx(
+	ctx context.Context, tx *sql.Tx,
+) (LexicalGeneration, error) {
+	if _, err := tx.ExecContext(ctx, lexicalProjectionSchema); err != nil {
+		return LexicalGeneration{}, fmt.Errorf("initializing migrated lexical projection: %w", err)
+	}
+	rows, err := readCatalogLexicalManifestRowsTx(ctx, tx, "")
+	if err != nil {
+		return LexicalGeneration{}, err
+	}
+	generation := LexicalGeneration{
+		ID: lexicalManifestDigest(rows), SegmentCount: len(rows),
+		ManifestDigest: lexicalManifestDigest(rows),
+	}
+	var existingCount int
+	var existingManifest sql.NullString
+	err = tx.QueryRowContext(ctx, `
+		SELECT g.segment_count,m.manifest_digest
+		FROM rendition_lexical_generations g
+		LEFT JOIN rendition_lexical_generation_manifests m USING(generation_id)
+		WHERE g.generation_id=?`, generation.ID,
+	).Scan(&existingCount, &existingManifest)
+	if err == nil {
+		existingRows, err := readLexicalManifestRowsTx(ctx, tx, generation.ID, "")
+		if err != nil {
+			return LexicalGeneration{}, err
+		}
+		if !existingManifest.Valid || existingCount != generation.SegmentCount ||
+			lexicalManifestDigest(existingRows) != generation.ManifestDigest {
+			return LexicalGeneration{}, fmt.Errorf(
+				"migrated lexical generation %s has a different immutable manifest", generation.ID,
+			)
+		}
+		return generation, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return LexicalGeneration{}, fmt.Errorf("reading migrated lexical generation: %w", err)
+	}
+	for _, row := range rows {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO rendition_lexical_fts(generation_id,build_id,segment_id,text)
+			VALUES(?,?,?,?)`, generation.ID, row.buildID, row.segmentID, row.text,
+		); err != nil {
+			return LexicalGeneration{}, fmt.Errorf("building migrated lexical generation: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO rendition_lexical_generations(generation_id,segment_count,built_at)
+		VALUES(?,?,?)`, generation.ID, generation.SegmentCount, nowRFC3339(),
+	); err != nil {
+		return LexicalGeneration{}, fmt.Errorf("completing migrated lexical generation: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO rendition_lexical_generation_manifests(generation_id,manifest_digest)
+		VALUES(?,?)`, generation.ID, generation.ManifestDigest,
+	); err != nil {
+		return LexicalGeneration{}, fmt.Errorf("recording migrated lexical manifest: %w", err)
+	}
+	return generation, nil
+}
+
+func compareLegacyServingCompatibilityTx(
+	ctx context.Context, tx *sql.Tx, selected []legacySelectedVersion,
+	eligible map[string]legacyPlainTextRow, profileFingerprint, generationID string,
+) error {
+	type authority struct{ name, text string }
+	want := make(map[string]authority)
+	for _, version := range selected {
+		if row, ok := eligible[version.blobHash]; ok {
+			want[version.versionID] = authority{name: version.name, text: row.text.String}
+		}
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT h.content_version_id,n.name,f.text
+		FROM rendition_heads h
+		JOIN rendition_attachments a ON a.attachment_id=h.attachment_id
+		JOIN rendition_lexical_fts f ON f.build_id=a.build_id
+		JOIN content_versions v ON v.version_id=h.content_version_id
+		JOIN nodes n ON n.current_version_id=v.version_id
+		WHERE h.profile_fingerprint=? AND f.generation_id=? AND n.trashed_at IS NULL
+		ORDER BY h.content_version_id,f.segment_id`, profileFingerprint, generationID)
+	if err != nil {
+		return fmt.Errorf("comparing migrated search compatibility: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	got := make(map[string]authority)
+	for rows.Next() {
+		var versionID, name, text string
+		if err := rows.Scan(&versionID, &name, &text); err != nil {
+			return fmt.Errorf("comparing migrated search row: %w", err)
+		}
+		item := got[versionID]
+		if item.name == "" {
+			item.name = name
+		} else if item.name != name {
+			return errors.New("migrated name search authority changed during cutover")
+		}
+		item.text += text
+		got[versionID] = item
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("comparing migrated search compatibility: %w", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		return errors.New("migrated name/text search authority is not exactly compatible")
+	}
+	return nil
+}

--- a/internal/store/processing_migration_test.go
+++ b/internal/store/processing_migration_test.go
@@ -49,9 +49,6 @@ func TestMigrateLegacyPlainTextCutsOverExactEligibleRows(t *testing.T) {
 	unknownHash := seedLegacyMigrationRow(t, s, "unknown.txt", "63", ExtractionResult{
 		Extractor: "other", ExtractorVersion: 1, Status: ExtractionOK, Text: "unknown-authority-token",
 	})
-	seedLegacyMigrationRow(t, s, "obsolete.txt", "64", ExtractionResult{
-		Extractor: "plain-text", ExtractorVersion: 2, Status: ExtractionOK, Text: "obsolete-authority-token",
-	})
 	invalidHash := fakeHash("65")
 	_, err = s.CreateFile(ctx, s.RootID(), "invalid.txt", invalidHash, 1, "text/plain")
 	require.NoError(t, err)
@@ -93,11 +90,9 @@ func TestMigrateLegacyPlainTextCutsOverExactEligibleRows(t *testing.T) {
 	assert.Equal(t, beforeName, afterName, "name search remains byte-for-byte compatible")
 	assert.Equal(t, beforeText, afterText, "eligible text search keeps exact result order")
 
-	for _, query := range []string{"unknown-authority-token", "obsolete-authority-token"} {
-		hits, _, searchErr := s.SearchPage(ctx, query, 20)
-		require.NoError(t, searchErr)
-		assert.Empty(t, hits, "%s must not keep serving from the portable cache", query)
-	}
+	hits, _, searchErr := s.SearchPage(ctx, "unknown-authority-token", 20)
+	require.NoError(t, searchErr)
+	assert.Empty(t, hits, "unknown extractors must not keep serving from the portable cache")
 
 	var builds, units, segments, attachments, heads, legacyFTS int
 	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_builds`).Scan(&builds))
@@ -147,7 +142,7 @@ func TestMigrateLegacyPlainTextCutsOverExactEligibleRows(t *testing.T) {
 
 	var retainedRows int
 	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM extracted_text`).Scan(&retainedRows))
-	assert.Equal(t, 7, retainedRows, "portable legacy rows remain recoverable")
+	assert.Equal(t, 6, retainedRows, "portable legacy rows remain recoverable")
 }
 
 // Mutation caught: publishing heads, the lexical generation, cache fencing,
@@ -483,20 +478,24 @@ func TestLegacyMigrationRestoresTrashedContentSearch(t *testing.T) {
 	assert.Equal(t, SearchMatchContent, hits[0].Match)
 }
 
-// Mutation caught: treating a successful newer extractor result as missing
-// work lets the legacy worker replace it with version 1.
-func TestLegacyMigrationDoesNotQueueNewerExtractionSuccess(t *testing.T) {
+// Mutation caught: silently accepting an unsupported newer extractor result
+// fences its serving cache without publishing equivalent rendition authority.
+func TestLegacyMigrationRejectsUnsupportedNewerExtraction(t *testing.T) {
 	s := newTestStore(t)
 	seedLegacyMigrationRow(t, s, "newer.txt", "7f", ExtractionResult{
 		Extractor: "plain-text", ExtractorVersion: 2,
 		Status: ExtractionOK, Text: "newer-extractor-authority",
 	})
-	_, err := s.MigrateLegacyPlainText(t.Context())
+	before, _, err := s.SearchPage(t.Context(), "newer-extractor-authority", 20)
 	require.NoError(t, err)
+	require.Len(t, before, 1)
 
-	pending, err := s.PendingTextExtractions(t.Context(), 20)
+	_, err = s.MigrateLegacyPlainText(t.Context())
+	require.ErrorContains(t, err, "unsupported newer plain-text extraction")
+
+	after, _, err := s.SearchPage(t.Context(), "newer-extractor-authority", 20)
 	require.NoError(t, err)
-	assert.Empty(t, pending)
+	assert.Equal(t, before, after, "a rejected cutover must preserve serving authority")
 }
 
 // Mutation caught: restricting legacy convergence to released-schema staging

--- a/internal/store/processing_migration_test.go
+++ b/internal/store/processing_migration_test.go
@@ -24,7 +24,7 @@ func TestLegacyPlainTextBuildFingerprintUsesExactStoredBytes(t *testing.T) {
 
 // Mutations caught: broadening the eligible extractor row, building once per
 // version instead of per blob, normalizing stored bytes, leaving legacy FTS
-// serving, or failing to queue every selected blob without an eligible row.
+// serving, or failing to queue every repairable selected blob without an eligible row.
 func TestMigrateLegacyPlainTextCutsOverExactEligibleRows(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
@@ -49,7 +49,7 @@ func TestMigrateLegacyPlainTextCutsOverExactEligibleRows(t *testing.T) {
 	unknownHash := seedLegacyMigrationRow(t, s, "unknown.txt", "63", ExtractionResult{
 		Extractor: "other", ExtractorVersion: 1, Status: ExtractionOK, Text: "unknown-authority-token",
 	})
-	obsoleteHash := seedLegacyMigrationRow(t, s, "obsolete.txt", "64", ExtractionResult{
+	seedLegacyMigrationRow(t, s, "obsolete.txt", "64", ExtractionResult{
 		Extractor: "plain-text", ExtractorVersion: 2, Status: ExtractionOK, Text: "obsolete-authority-token",
 	})
 	invalidHash := fakeHash("65")
@@ -82,7 +82,7 @@ func TestMigrateLegacyPlainTextCutsOverExactEligibleRows(t *testing.T) {
 	assert.Equal(t, 1, report.EligibleRows)
 	assert.Equal(t, 1, report.MigratedBuilds)
 	assert.Equal(t, 2, report.MigratedAttachments)
-	assert.Equal(t, 5, report.QueuedBlobs)
+	assert.Equal(t, 4, report.QueuedBlobs)
 	require.NotEmpty(t, report.ProfileFingerprint)
 	require.NotEmpty(t, report.LexicalGenerationID)
 
@@ -135,7 +135,7 @@ func TestMigrateLegacyPlainTextCutsOverExactEligibleRows(t *testing.T) {
 
 	queued := queuedLegacyHashes(t, s)
 	assert.Equal(t, []string{
-		failedHash, unknownHash, obsoleteHash, invalidHash, missingExtractionHash,
+		failedHash, unknownHash, invalidHash, missingExtractionHash,
 	}, queued)
 
 	for _, versionID := range []string{first.CurrentVersionID, second.CurrentVersionID} {
@@ -421,6 +421,82 @@ func TestLegacyMigrationPreservesSearchAcrossSegmentBoundary(t *testing.T) {
 	after, _, err := s.SearchPage(t.Context(), "left-boundary right-boundary", 20)
 	require.NoError(t, err)
 	assert.Equal(t, before, after)
+}
+
+// Mutation caught: comparing raw legacy catalog segments with their coalesced
+// serving row prevents every later rendition head from publishing.
+func TestLegacyMigrationAllowsLaterPublicationAfterSegmentCoalescing(t *testing.T) {
+	s, _ := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	text := strings.Repeat("x", legacyPlainTextSegmentRunes) + " later-publication-boundary"
+	hash := fakeHash("7a")
+	_, err := s.CreateFile(ctx, s.RootID(), "legacy-long.txt", hash, int64(len(text)), "text/plain")
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: text,
+	}))
+	_, err = s.MigrateLegacyPlainText(ctx)
+	require.NoError(t, err)
+
+	profile := catalogProcessingProfile(t, false)
+	build, versionID := lexicalSearchReplacementBuild(
+		t, s, profile, fakeHash("7b"), "later rendition authority",
+	)
+	require.NoError(t, s.StageRenditionBuild(ctx, build))
+	generation, err := s.StageLexicalGeneration(ctx, fakeHash("7c"))
+	require.NoError(t, err)
+	attachment := RenditionAttachmentRecord{
+		ID: fakeHash("7d"), VaultID: s.VaultID(), ContentVersionID: versionID,
+		BuildID: build.ID, Profile: profile, AttachedAt: "2026-08-22T13:00:00.000000000Z",
+	}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, attachment, RenditionHeadRecord{
+		ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: attachment.ID, PublishedAt: "2026-08-22T13:01:00.000000000Z",
+	}, generation.ID))
+}
+
+// Mutation caught: excluding trashed current versions from migrated heads
+// leaves their retained text unreachable after restore.
+func TestLegacyMigrationRestoresTrashedContentSearch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	const text = "restored-heritage-authority"
+	hash := fakeHash("7e")
+	node, err := s.CreateFile(ctx, s.RootID(), "archived.txt", hash, int64(len(text)), "text/plain")
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: text,
+	}))
+	trashed, _, err := s.Trash(ctx, node.ID, node.Revision)
+	require.NoError(t, err)
+	_, err = s.MigrateLegacyPlainText(ctx)
+	require.NoError(t, err)
+
+	_, _, err = s.Restore(ctx, trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	hits, _, err := s.SearchPage(ctx, text, 20)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, "/archived.txt", hits[0].Path)
+	assert.Equal(t, SearchMatchContent, hits[0].Match)
+}
+
+// Mutation caught: treating a successful newer extractor result as missing
+// work lets the legacy worker replace it with version 1.
+func TestLegacyMigrationDoesNotQueueNewerExtractionSuccess(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMigrationRow(t, s, "newer.txt", "7f", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 2,
+		Status: ExtractionOK, Text: "newer-extractor-authority",
+	})
+	_, err := s.MigrateLegacyPlainText(t.Context())
+	require.NoError(t, err)
+
+	pending, err := s.PendingTextExtractions(t.Context(), 20)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
 }
 
 // Mutation caught: restricting legacy convergence to released-schema staging

--- a/internal/store/processing_migration_test.go
+++ b/internal/store/processing_migration_test.go
@@ -1,0 +1,514 @@
+package store
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const legacyMigrationTimestamp = "2026-08-22T12:00:00.000000000Z"
+
+// Mutation caught: hashing normalized text, omitting one legacy identity
+// field, or changing the domain separator silently aliases a different build.
+func TestLegacyPlainTextBuildFingerprintUsesExactStoredBytes(t *testing.T) {
+	text := []byte("Cafe\u0301\r\nline\rtrail")
+	assert.Equal(t,
+		"10fb8bb322c770ba112a9a5bb5438369705cfccd95b43a301db1b0005d3833b2",
+		legacyPlainTextBuildFingerprint(fakeHash("61"), "plain-text", 1, "ok", text),
+	)
+}
+
+// Mutations caught: broadening the eligible extractor row, building once per
+// version instead of per blob, normalizing stored bytes, leaving legacy FTS
+// serving, or failing to queue every selected blob without an eligible row.
+func TestMigrateLegacyPlainTextCutsOverExactEligibleRows(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	exactText := "Cafe\u0301\r\nline\rtrail migration-compatible"
+	eligibleHash := fakeHash("61")
+	first, err := s.CreateFile(ctx, s.RootID(), "report-eligible.txt", eligibleHash, int64(len(exactText)), "text/plain")
+	require.NoError(t, err)
+	second, err := s.CreateFile(ctx, s.RootID(), "shared-eligible.txt", eligibleHash, int64(len(exactText)), "text/plain")
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: eligibleHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: exactText,
+	}))
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: eligibleHash, Extractor: "other", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "same-blob-competitor",
+	}))
+
+	failedHash := seedLegacyMigrationRow(t, s, "failed.txt", "62", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 1, Status: ExtractionFailed, Error: "synthetic failure",
+	})
+	unknownHash := seedLegacyMigrationRow(t, s, "unknown.txt", "63", ExtractionResult{
+		Extractor: "other", ExtractorVersion: 1, Status: ExtractionOK, Text: "unknown-authority-token",
+	})
+	obsoleteHash := seedLegacyMigrationRow(t, s, "obsolete.txt", "64", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 2, Status: ExtractionOK, Text: "obsolete-authority-token",
+	})
+	invalidHash := fakeHash("65")
+	_, err = s.CreateFile(ctx, s.RootID(), "invalid.txt", invalidHash, 1, "text/plain")
+	require.NoError(t, err)
+	_, err = s.db.Exec(`INSERT INTO extracted_text(
+		blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at
+	) VALUES(?, 'plain-text', 1, 'ok', NULL, 1, CAST(X'80' AS TEXT), ?)`,
+		invalidHash, legacyMigrationTimestamp)
+	require.NoError(t, err)
+	missingRowHash := fakeHash("66")
+	_, err = s.db.Exec(`INSERT INTO extracted_text(
+		blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at
+	) VALUES(?, 'plain-text', 1, 'ok', NULL, 1, 'dangling', ?)`,
+		missingRowHash, legacyMigrationTimestamp)
+	require.NoError(t, err)
+	missingExtractionHash := fakeHash("67")
+	_, err = s.CreateFile(ctx, s.RootID(), "missing.txt", missingExtractionHash, 7, "text/plain")
+	require.NoError(t, err)
+
+	beforeName, _, err := s.SearchPage(ctx, "report", 20)
+	require.NoError(t, err)
+	beforeText, _, err := s.SearchPage(ctx, "migration-compatible", 20)
+	require.NoError(t, err)
+	require.Len(t, beforeName, 1)
+	require.Len(t, beforeText, 2)
+
+	report, err := s.MigrateLegacyPlainText(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.EligibleRows)
+	assert.Equal(t, 1, report.MigratedBuilds)
+	assert.Equal(t, 2, report.MigratedAttachments)
+	assert.Equal(t, 5, report.QueuedBlobs)
+	require.NotEmpty(t, report.ProfileFingerprint)
+	require.NotEmpty(t, report.LexicalGenerationID)
+
+	afterName, _, err := s.SearchPage(ctx, "report", 20)
+	require.NoError(t, err)
+	afterText, _, err := s.SearchPage(ctx, "migration-compatible", 20)
+	require.NoError(t, err)
+	assert.Equal(t, beforeName, afterName, "name search remains byte-for-byte compatible")
+	assert.Equal(t, beforeText, afterText, "eligible text search keeps exact result order")
+
+	for _, query := range []string{"unknown-authority-token", "obsolete-authority-token"} {
+		hits, _, searchErr := s.SearchPage(ctx, query, 20)
+		require.NoError(t, searchErr)
+		assert.Empty(t, hits, "%s must not keep serving from the portable cache", query)
+	}
+
+	var builds, units, segments, attachments, heads, legacyFTS int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_builds`).Scan(&builds))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_units`).Scan(&units))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_lexical_segments`).Scan(&segments))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_attachments`).Scan(&attachments))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_heads`).Scan(&heads))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&legacyFTS))
+	assert.Equal(t, 1, builds, "a shared blob owns one immutable build")
+	assert.Equal(t, 1, units)
+	assert.Equal(t, 1, segments)
+	assert.Equal(t, 2, attachments)
+	assert.Equal(t, 2, heads)
+	assert.Zero(t, legacyFTS, "the retained portable cache is non-serving")
+
+	var unitID, evidenceUnitID, storedText string
+	require.NoError(t, s.db.QueryRow(`
+		SELECT u.unit_id,u.evidence_unit_id,l.text
+		FROM rendition_units u JOIN rendition_lexical_segments l USING(build_id)
+	`).Scan(&unitID, &evidenceUnitID, &storedText))
+	assert.Equal(t, "legacy:0", unitID)
+	assert.Equal(t, "legacy:0", evidenceUnitID)
+	assert.Equal(t, []byte(exactText), []byte(storedText), "migration must not normalize Unicode or newlines")
+
+	var sourceHash, providerOperation string
+	require.NoError(t, s.db.QueryRow(`
+		SELECT source_sha256,provider_operation_id FROM rendition_builds
+	`).Scan(&sourceHash, &providerOperation))
+	assert.Equal(t, eligibleHash, sourceHash)
+	assert.Equal(t, "plain-text/legacy-v1", providerOperation)
+
+	var canonicalProfile string
+	require.NoError(t, s.db.QueryRow(`SELECT canonical_profile FROM processing_profiles`).Scan(&canonicalProfile))
+	assert.Contains(t, canonicalProfile, `"adapter_contract":"plain-text/legacy-v1"`)
+
+	queued := queuedLegacyHashes(t, s)
+	assert.Equal(t, []string{
+		failedHash, unknownHash, obsoleteHash, invalidHash, missingExtractionHash,
+	}, queued)
+
+	for _, versionID := range []string{first.CurrentVersionID, second.CurrentVersionID} {
+		view, activeErr := s.ActiveRendition(ctx, versionID, report.ProfileFingerprint)
+		require.NoError(t, activeErr)
+		assert.Equal(t, report.ProfileFingerprint, view.Head.ProcessingProfileFingerprint)
+		assert.Equal(t, eligibleHash, view.Build.SourceSHA256)
+	}
+
+	var retainedRows int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM extracted_text`).Scan(&retainedRows))
+	assert.Equal(t, 7, retainedRows, "portable legacy rows remain recoverable")
+}
+
+// Mutation caught: publishing heads, the lexical generation, cache fencing,
+// and queue repair in separate transactions exposes a partial authority epoch.
+func TestMigrateLegacyPlainTextRollsBackOneAtomicCutover(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMigrationRow(t, s, "atomic.txt", "71", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 1, Status: ExtractionOK, Text: "atomic legacy text",
+	})
+	_, err := s.db.Exec(`
+		CREATE TRIGGER reject_legacy_head BEFORE INSERT ON rendition_heads BEGIN
+			SELECT RAISE(ABORT, 'synthetic legacy head failure');
+		END`)
+	require.NoError(t, err)
+
+	_, err = s.MigrateLegacyPlainText(t.Context())
+	require.ErrorContains(t, err, "synthetic legacy head failure")
+
+	for _, table := range []string{
+		"processing_profiles", "rendition_builds", "rendition_units",
+		"rendition_lexical_segments", "rendition_attachments", "rendition_heads",
+	} {
+		var count int
+		require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM `+table).Scan(&count))
+		assert.Zero(t, count, table+" must roll back")
+	}
+	var legacyFTS int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&legacyFTS))
+	assert.Equal(t, 1, legacyFTS, "legacy serving remains intact when cutover aborts")
+}
+
+// Mutation caught: comparing catalog segments instead of the staged serving
+// generation publishes even when the exact FTS projection disappears.
+func TestMigrateLegacyPlainTextRejectsCorruptStagedProjection(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMigrationRow(t, s, "projection.txt", "77", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "staged-projection-authority",
+	})
+	_, err := s.db.Exec(lexicalProjectionSchema)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`
+		CREATE TRIGGER erase_staged_projection
+		AFTER INSERT ON rendition_lexical_generation_manifests BEGIN
+			DELETE FROM rendition_lexical_fts WHERE generation_id=NEW.generation_id;
+		END`)
+	require.NoError(t, err)
+
+	_, err = s.MigrateLegacyPlainText(t.Context())
+	require.ErrorContains(t, err, "search authority is not exactly compatible")
+	var legacyFTS, lexicalHeads, renditionHeads int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&legacyFTS))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_lexical_heads`).Scan(&lexicalHeads))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_heads`).Scan(&renditionHeads))
+	assert.Equal(t, 1, legacyFTS, "the prior authority survives rejected publication")
+	assert.Zero(t, lexicalHeads)
+	assert.Zero(t, renditionHeads)
+}
+
+// Mutation caught: recording a queued repair only in the fenced legacy cache
+// leaves successful fresh work non-serving until the store is reopened.
+func TestPostCutoverExtractionPublishesRenditionAuthority(t *testing.T) {
+	s := newTestStore(t)
+	hash := seedLegacyMigrationRow(t, s, "repair.txt", "72", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 1, Status: ExtractionFailed,
+		Error: "synthetic pre-cutover failure",
+	})
+	initial, err := s.MigrateLegacyPlainText(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(t.Context(), ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "repaired-legacy-authority",
+	}))
+
+	var cached, builds, heads int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&cached))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_builds`).Scan(&builds))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_heads`).Scan(&heads))
+	assert.Zero(t, cached, "the portable cache remains fenced")
+	assert.Equal(t, 1, builds)
+	assert.Equal(t, 1, heads)
+	var generationID string
+	require.NoError(t, s.db.QueryRow(`
+		SELECT generation_id FROM rendition_lexical_heads WHERE singleton=1
+	`).Scan(&generationID))
+	assert.NotEqual(t, initial.LexicalGenerationID, generationID)
+	hits, _, err := s.SearchPage(t.Context(), "repaired-legacy-authority", 20)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, "/repair.txt", hits[0].Path)
+	assert.Equal(t, SearchMatchContent, hits[0].Match)
+}
+
+// Mutation caught: rebuilding an existing content-derived identity with the
+// latest extraction time rejects its first immutable build and attachment.
+func TestPostCutoverIdenticalReExtractionPreservesImmutableRecords(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "reextract.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if s != nil {
+			require.NoError(t, s.Close())
+		}
+	})
+	const text = "identical-reextraction-authority"
+	hash := fakeHash("78")
+	first, err := s.CreateFile(
+		t.Context(), s.RootID(), "first.txt", hash, int64(len(text)), "text/plain",
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(t.Context(), ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: text,
+	}))
+	_, err = s.db.Exec(`UPDATE extracted_text SET extracted_at=? WHERE blob_hash=?`,
+		legacyMigrationTimestamp, hash)
+	require.NoError(t, err)
+	_, err = s.MigrateLegacyPlainText(t.Context())
+	require.NoError(t, err)
+
+	var buildID, completedAt, firstAttachmentID, firstAttachedAt string
+	require.NoError(t, s.db.QueryRow(`
+		SELECT build_id,completed_at FROM rendition_builds
+		WHERE source_sha256=?`, hash,
+	).Scan(&buildID, &completedAt))
+	require.NoError(t, s.db.QueryRow(`
+		SELECT attachment_id,attached_at FROM rendition_attachments
+		WHERE content_version_id=?`, first.CurrentVersionID,
+	).Scan(&firstAttachmentID, &firstAttachedAt))
+	assert.Equal(t, legacyMigrationTimestamp, completedAt)
+	assert.Equal(t, legacyMigrationTimestamp, firstAttachedAt)
+
+	second, err := s.CreateFile(
+		t.Context(), s.RootID(), "second.txt", hash, int64(len(text)), "text/plain",
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(t.Context(), ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: text,
+	}))
+
+	var builds, attachments, heads, queued, cached int
+	for query, destination := range map[string]*int{
+		`SELECT COUNT(*) FROM rendition_builds`:      &builds,
+		`SELECT COUNT(*) FROM rendition_attachments`: &attachments,
+		`SELECT COUNT(*) FROM rendition_heads`:       &heads,
+		`SELECT COUNT(*) FROM text_extraction_queue`: &queued,
+		`SELECT COUNT(*) FROM content_fts`:           &cached,
+	} {
+		require.NoError(t, s.db.QueryRow(query).Scan(destination))
+	}
+	assert.Equal(t, 1, builds)
+	assert.Equal(t, 2, attachments)
+	assert.Equal(t, 2, heads)
+	assert.Zero(t, queued)
+	assert.Zero(t, cached)
+	var stableCompletedAt, stableAttachmentID, stableAttachedAt string
+	require.NoError(t, s.db.QueryRow(`
+		SELECT completed_at FROM rendition_builds WHERE build_id=?`, buildID,
+	).Scan(&stableCompletedAt))
+	require.NoError(t, s.db.QueryRow(`
+		SELECT attachment_id,attached_at FROM rendition_attachments
+		WHERE content_version_id=?`, first.CurrentVersionID,
+	).Scan(&stableAttachmentID, &stableAttachedAt))
+	assert.Equal(t, completedAt, stableCompletedAt)
+	assert.Equal(t, firstAttachmentID, stableAttachmentID)
+	assert.Equal(t, firstAttachedAt, stableAttachedAt)
+	var secondAttachedAt string
+	require.NoError(t, s.db.QueryRow(`
+		SELECT attached_at FROM rendition_attachments WHERE content_version_id=?`,
+		second.CurrentVersionID,
+	).Scan(&secondAttachedAt))
+	assert.NotEqual(t, legacyMigrationTimestamp, secondAttachedAt)
+
+	hits, _, err := s.SearchPage(t.Context(), text, 20)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.ElementsMatch(t, []string{"/first.txt", "/second.txt"},
+		[]string{hits[0].Path, hits[1].Path})
+	require.NoError(t, s.Close())
+	s = nil
+	s, err = Open(dbPath)
+	require.NoError(t, err)
+	reopened, _, err := s.SearchPage(t.Context(), text, 20)
+	require.NoError(t, err)
+	require.Len(t, reopened, 2)
+}
+
+// Mutation caught: deleting queued work in the cache transaction loses the
+// only automatic retry when the later rendition publication rolls back.
+func TestPostCutoverPublicationFailureKeepsExtractionQueued(t *testing.T) {
+	s := newTestStore(t)
+	const text = "retry-publication-authority"
+	hash := fakeHash("79")
+	_, err := s.CreateFile(
+		t.Context(), s.RootID(), "published.txt", hash, int64(len(text)), "text/plain",
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(t.Context(), ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: text,
+	}))
+	initial, err := s.MigrateLegacyPlainText(t.Context())
+	require.NoError(t, err)
+	_, err = s.CreateFile(
+		t.Context(), s.RootID(), "waiting.txt", hash, int64(len(text)), "text/plain",
+	)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`
+		CREATE TRIGGER reject_reextraction_head BEFORE INSERT ON rendition_heads BEGIN
+			SELECT RAISE(ABORT, 'synthetic reextraction publication failure');
+		END`)
+	require.NoError(t, err)
+
+	err = s.RecordExtraction(t.Context(), ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: text,
+	})
+	require.ErrorContains(t, err, "synthetic reextraction publication failure")
+	var queued int
+	require.NoError(t, s.db.QueryRow(`
+		SELECT COUNT(*) FROM text_extraction_queue WHERE blob_hash=?`, hash,
+	).Scan(&queued))
+	assert.Equal(t, 1, queued, "failed publication remains retryable")
+	var generationID string
+	require.NoError(t, s.db.QueryRow(`
+		SELECT generation_id FROM rendition_lexical_heads WHERE singleton=1
+	`).Scan(&generationID))
+	assert.Equal(t, initial.LexicalGenerationID, generationID)
+	hits, _, err := s.SearchPage(t.Context(), text, 20)
+	require.NoError(t, err)
+	require.Len(t, hits, 1, "the prior lexical generation remains sole serving authority")
+	assert.Equal(t, "/published.txt", hits[0].Path)
+
+	_, err = s.db.Exec(`DROP TRIGGER reject_reextraction_head`)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(t.Context(), ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: text,
+	}))
+	require.NoError(t, s.db.QueryRow(`
+		SELECT COUNT(*) FROM text_extraction_queue WHERE blob_hash=?`, hash,
+	).Scan(&queued))
+	assert.Zero(t, queued)
+	hits, _, err = s.SearchPage(t.Context(), text, 20)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+}
+
+// Mutation caught: indexing one FTS row per bounded rendition segment loses
+// legacy whole-document AND matches when terms land in different segments.
+func TestLegacyMigrationPreservesSearchAcrossSegmentBoundary(t *testing.T) {
+	s := newTestStore(t)
+	text := "left-boundary " + strings.Repeat("x", legacyPlainTextSegmentRunes) +
+		" right-boundary"
+	hash := fakeHash("73")
+	_, err := s.CreateFile(
+		t.Context(), s.RootID(), "boundary.txt", hash, int64(len(text)), "text/plain",
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(t.Context(), ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: text,
+	}))
+
+	before, _, err := s.SearchPage(t.Context(), "left-boundary right-boundary", 20)
+	require.NoError(t, err)
+	require.Len(t, before, 1, "legacy whole-row FTS proves the compatibility expectation")
+	_, err = s.MigrateLegacyPlainText(t.Context())
+	require.NoError(t, err)
+	after, _, err := s.SearchPage(t.Context(), "left-boundary right-boundary", 20)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+}
+
+// Mutation caught: restricting legacy convergence to released-schema staging
+// leaves an already-current database serving only its legacy cache forever.
+func TestOpenMigratesLegacyPlainTextInCurrentSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "current.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	seedLegacyMigrationRow(t, s, "current.txt", "74", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "current-schema-legacy-text",
+	})
+	require.NoError(t, s.Close())
+
+	s, err = Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	var heads, legacyFTS int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_heads`).Scan(&heads))
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&legacyFTS))
+	assert.Equal(t, 1, heads)
+	assert.Zero(t, legacyFTS)
+	hits, _, err := s.SearchPage(t.Context(), "current-schema-legacy-text", 20)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, "/current.txt", hits[0].Path)
+}
+
+// Mutation caught: reusing the ordinary enqueue upsert on migration retry
+// postpones already-scheduled repair work and makes convergence non-idempotent.
+func TestMigrateLegacyPlainTextRetryPreservesQueuedWork(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMigrationRow(t, s, "stable.txt", "76", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "stable immutable legacy build",
+	})
+	hash := seedLegacyMigrationRow(t, s, "retry.txt", "75", ExtractionResult{
+		Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionFailed, Error: "synthetic retry failure",
+	})
+	first, err := s.MigrateLegacyPlainText(t.Context())
+	require.NoError(t, err)
+	const scheduled = "2030-01-02T03:04:05.000000000Z"
+	_, err = s.db.Exec(`UPDATE text_extraction_queue SET next_attempt_at=? WHERE blob_hash=?`, scheduled, hash)
+	require.NoError(t, err)
+
+	second, err := s.MigrateLegacyPlainText(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	var stored string
+	require.NoError(t, s.db.QueryRow(
+		`SELECT next_attempt_at FROM text_extraction_queue WHERE blob_hash=?`, hash,
+	).Scan(&stored))
+	assert.Equal(t, scheduled, stored)
+	for _, table := range []string{
+		"rendition_lexical_generations", "rendition_lexical_generation_manifests",
+	} {
+		var count int
+		require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM `+table).Scan(&count))
+		assert.Equal(t, 1, count, table)
+	}
+}
+
+func seedLegacyMigrationRow(
+	t *testing.T, s *Store, name, hashSuffix string, result ExtractionResult,
+) string {
+	t.Helper()
+	hash := fakeHash(hashSuffix)
+	node, err := s.CreateFile(t.Context(), s.RootID(), name, hash, 32, "text/plain")
+	require.NoError(t, err)
+	require.NotEmpty(t, node.CurrentVersionID)
+	result.BlobHash = hash
+	require.NoError(t, s.RecordExtraction(t.Context(), result))
+	return hash
+}
+
+func queuedLegacyHashes(t *testing.T, s *Store) []string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT blob_hash FROM text_extraction_queue ORDER BY blob_hash`)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	var hashes []string
+	for rows.Next() {
+		var hash string
+		require.NoError(t, rows.Scan(&hash))
+		hashes = append(hashes, hash)
+	}
+	require.NoError(t, rows.Err())
+	sort.Strings(hashes)
+	return hashes
+}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -200,11 +200,12 @@ type lexicalManifestRow struct {
 
 func readCatalogLexicalManifestRowsTx(
 	ctx context.Context, tx *sql.Tx, buildID string,
-) ([]lexicalManifestRow, error) {
+) (_ []lexicalManifestRow, retErr error) {
 	query := `
-		SELECT build_id,segment_id,text
-		FROM rendition_lexical_segments
-		ORDER BY build_id,segment_order,segment_id`
+		SELECT s.build_id,s.segment_id,s.text,b.provider_operation_id
+		FROM rendition_lexical_segments s
+		JOIN rendition_builds b ON b.build_id=s.build_id
+		ORDER BY s.build_id,s.segment_order,s.segment_id`
 	var (
 		rows *sql.Rows
 		err  error
@@ -213,15 +214,41 @@ func readCatalogLexicalManifestRowsTx(
 		rows, err = tx.QueryContext(ctx, query)
 	} else {
 		rows, err = tx.QueryContext(ctx, `
-			SELECT build_id,segment_id,text
-			FROM rendition_lexical_segments
-			WHERE build_id=?
-			ORDER BY build_id,segment_order,segment_id`, buildID)
+			SELECT s.build_id,s.segment_id,s.text,b.provider_operation_id
+			FROM rendition_lexical_segments s
+			JOIN rendition_builds b ON b.build_id=s.build_id
+			WHERE s.build_id=?
+			ORDER BY s.build_id,s.segment_order,s.segment_id`, buildID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("reading staged lexical manifest: %w", err)
 	}
-	return scanLexicalManifestRows(rows, "staged lexical manifest")
+	defer func() {
+		if err := rows.Close(); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("closing staged lexical manifest: %w", err))
+		}
+	}()
+
+	var result []lexicalManifestRow
+	for rows.Next() {
+		var (
+			row               lexicalManifestRow
+			providerOperation string
+		)
+		if err := rows.Scan(&row.buildID, &row.segmentID, &row.text, &providerOperation); err != nil {
+			return nil, fmt.Errorf("reading staged lexical manifest row: %w", err)
+		}
+		if providerOperation == legacyPlainTextProvider && len(result) > 0 &&
+			result[len(result)-1].buildID == row.buildID {
+			result[len(result)-1].text += row.text
+			continue
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading staged lexical manifest rows: %w", err)
+	}
+	return result, nil
 }
 
 func readLexicalManifestRowsTx(
@@ -741,17 +768,10 @@ func (s *Store) SearchPageWithOptions(
 			LIMIT ?`
 		if generationID != "" {
 			// Selection, attachment resolution, and row consumption share
-			// this reader's one immutable publication snapshot.
+			// this reader's one immutable publication snapshot. Once a
+			// lexical head exists, legacy content_fts is a non-serving cache.
 			contentQuery = `
 				WITH matched_versions(version_id,best_rank) AS (
-				  SELECT cv_legacy.version_id, MIN(content_fts.rank)
-				  FROM content_fts
-				  JOIN content_versions cv_legacy ON cv_legacy.blob_hash=content_fts.blob_hash
-				  JOIN text_searchable_versions tsv_legacy
-				    ON tsv_legacy.version_id=cv_legacy.version_id
-				  WHERE content_fts MATCH ?
-				  GROUP BY cv_legacy.version_id
-				  UNION ALL
 				  SELECT a.content_version_id, MIN(rendition_lexical_fts.rank)
 				  FROM rendition_lexical_fts
 				  JOIN rendition_attachments a ON a.build_id=rendition_lexical_fts.build_id
@@ -762,18 +782,15 @@ func (s *Store) SearchPageWithOptions(
 				  WHERE rendition_lexical_fts MATCH ?
 				    AND rendition_lexical_fts.generation_id=?
 				  GROUP BY a.content_version_id
-				), best_versions AS (
-				  SELECT version_id,MIN(best_rank) AS best_rank
-				  FROM matched_versions GROUP BY version_id
 				)
 				SELECT ` + nodeCols + `
 				FROM ` + nodeFrom + `
-				JOIN best_versions mv ON mv.version_id=cv.version_id
+				JOIN matched_versions mv ON mv.version_id=cv.version_id
 				WHERE n.trashed_at IS NULL
 				  ` + filterSQL + `
 				ORDER BY mv.best_rank,n.name,n.id
 				LIMIT ?`
-			contentArgs = append(contentArgs, fq, generationID)
+			contentArgs = append(contentArgs, generationID)
 		}
 		contentArgs = append(contentArgs, filterArgs...)
 		contentArgs = append(contentArgs, remaining+len(nameHits)+1)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -200,7 +200,7 @@ type lexicalManifestRow struct {
 
 func readCatalogLexicalManifestRowsTx(
 	ctx context.Context, tx *sql.Tx, buildID string,
-) (_ []lexicalManifestRow, retErr error) {
+) ([]lexicalManifestRow, error) {
 	query := `
 		SELECT s.build_id,s.segment_id,s.text,b.provider_operation_id
 		FROM rendition_lexical_segments s
@@ -223,32 +223,7 @@ func readCatalogLexicalManifestRowsTx(
 	if err != nil {
 		return nil, fmt.Errorf("reading staged lexical manifest: %w", err)
 	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			retErr = errors.Join(retErr, fmt.Errorf("closing staged lexical manifest: %w", err))
-		}
-	}()
-
-	var result []lexicalManifestRow
-	for rows.Next() {
-		var (
-			row               lexicalManifestRow
-			providerOperation string
-		)
-		if err := rows.Scan(&row.buildID, &row.segmentID, &row.text, &providerOperation); err != nil {
-			return nil, fmt.Errorf("reading staged lexical manifest row: %w", err)
-		}
-		if providerOperation == legacyPlainTextProvider && len(result) > 0 &&
-			result[len(result)-1].buildID == row.buildID {
-			result[len(result)-1].text += row.text
-			continue
-		}
-		result = append(result, row)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("reading staged lexical manifest rows: %w", err)
-	}
-	return result, nil
+	return scanCatalogLexicalManifestRows(rows, "staged lexical manifest")
 }
 
 func readLexicalManifestRowsTx(
@@ -284,8 +259,9 @@ func readPublishedLexicalManifestRowsTx(
 	)
 	if generationID == "" {
 		rows, err = tx.QueryContext(ctx, `
-			SELECT s.build_id,s.segment_id,s.text
+			SELECT s.build_id,s.segment_id,s.text,b.provider_operation_id
 			FROM rendition_lexical_segments s
+			JOIN rendition_builds b ON b.build_id=s.build_id
 			WHERE EXISTS (
 			  SELECT 1 FROM rendition_attachments a
 			  JOIN rendition_heads h
@@ -293,7 +269,8 @@ func readPublishedLexicalManifestRowsTx(
 			   AND h.profile_fingerprint=a.profile_fingerprint
 			   AND h.attachment_id=a.attachment_id
 			  WHERE a.build_id=s.build_id
-			)`)
+			)
+			ORDER BY s.build_id,s.segment_order,s.segment_id`)
 	} else {
 		rows, err = tx.QueryContext(ctx, `
 			SELECT f.build_id,f.segment_id,f.text
@@ -310,7 +287,38 @@ func readPublishedLexicalManifestRowsTx(
 	if err != nil {
 		return nil, fmt.Errorf("reading published lexical manifest: %w", err)
 	}
+	if generationID == "" {
+		return scanCatalogLexicalManifestRows(rows, "published lexical manifest")
+	}
 	return scanLexicalManifestRows(rows, "published lexical manifest")
+}
+
+func scanCatalogLexicalManifestRows(
+	rows *sql.Rows, description string,
+) (_ []lexicalManifestRow, retErr error) {
+	defer func() {
+		if err := rows.Close(); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("closing %s: %w", description, err))
+		}
+	}()
+	var result []lexicalManifestRow
+	for rows.Next() {
+		var row lexicalManifestRow
+		var providerOperation string
+		if err := rows.Scan(&row.buildID, &row.segmentID, &row.text, &providerOperation); err != nil {
+			return nil, fmt.Errorf("reading %s row: %w", description, err)
+		}
+		if providerOperation == legacyPlainTextProvider && len(result) > 0 &&
+			result[len(result)-1].buildID == row.buildID {
+			result[len(result)-1].text += row.text
+			continue
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s rows: %w", description, err)
+	}
+	return result, nil
 }
 
 func scanLexicalManifestRows(

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -966,6 +966,33 @@ func TestRecordExtractionRejectsVersionDowngrade(t *testing.T) {
 	require.Len(t, hits, 1)
 }
 
+// Mutation caught: replacing a successful extraction with a same-version
+// failure leaves its published rendition ahead of the portable cache.
+func TestRecordExtractionRejectsSameVersionFailureAfterSuccess(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	hash := fakeHash("aa")
+	_, err := s.CreateFile(ctx, s.RootID(), "stable.txt", hash, 10, "text/plain")
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "stable-extraction-authority",
+	}))
+	_, err = s.MigrateLegacyPlainText(ctx)
+	require.NoError(t, err)
+
+	err = s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionFailed, Error: "synthetic later failure",
+	})
+	require.ErrorContains(t, err, "cannot replace a successful extraction")
+	_, err = s.MigrateLegacyPlainText(ctx)
+	require.NoError(t, err)
+	hits, _, err := s.SearchPage(ctx, "stable-extraction-authority", 20)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+}
+
 func TestPendingTextExtractionsSkipsSupersededQueuedContent(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -935,6 +935,37 @@ func TestPendingAndFailedTextExtractions(t *testing.T) {
 	assert.Len(t, pending, 2)
 }
 
+// Mutation caught: accepting an older extractor result replaces newer cached
+// text and its serving projection with a version downgrade.
+func TestRecordExtractionRejectsVersionDowngrade(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	hash := fakeHash("a9")
+	_, err := s.CreateFile(ctx, s.RootID(), "versioned.txt", hash, 10, "text/plain")
+	require.NoError(t, err)
+	require.NoError(t, s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 2,
+		Status: ExtractionOK, Text: "newer-version-authority",
+	}))
+
+	err = s.RecordExtraction(ctx, ExtractionResult{
+		BlobHash: hash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: ExtractionOK, Text: "downgraded-authority",
+	})
+	require.Error(t, err)
+	var version int64
+	var text string
+	require.NoError(t, s.db.QueryRow(`
+		SELECT extractor_version,text FROM extracted_text
+		WHERE blob_hash=? AND extractor='plain-text'`, hash,
+	).Scan(&version, &text))
+	assert.Equal(t, int64(2), version)
+	assert.Equal(t, "newer-version-authority", text)
+	hits, _, err := s.SearchPage(ctx, "newer-version-authority", 20)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+}
+
 func TestPendingTextExtractionsSkipsSupersededQueuedContent(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -52,7 +52,14 @@ func Open(path string, drivers ...docsqlite.Driver) (*Store, error) {
 	if err := prepareReleasedSchemaUpgrade(path, driver); err != nil {
 		return nil, err
 	}
-	return openCurrentStore(path, driver)
+	s, err := openCurrentStore(path, driver)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.MigrateLegacyPlainText(context.Background()); err != nil {
+		return nil, errors.Join(err, s.Close())
+	}
+	return s, nil
 }
 
 func openCurrentStore(path string, driver docsqlite.Driver) (*Store, error) {

--- a/internal/store/upgrade.go
+++ b/internal/store/upgrade.go
@@ -434,6 +434,11 @@ func cutoverReleasedDatabase(
 		_ = closeSource()
 		return err
 	}
+	if _, err := target.MigrateLegacyPlainText(context.Background()); err != nil {
+		_ = target.Close()
+		_ = closeSource()
+		return fmt.Errorf("migrating %s legacy plain-text authority: %w", sourceSchema.release, err)
+	}
 	if err := target.ValidateMetadata(context.Background()); err != nil {
 		_ = target.Close()
 		_ = closeSource()
@@ -1010,6 +1015,12 @@ func validateUpgradeStage(path string, driver docsqlite.Driver) error {
 	store, err := openCurrentStore(path, driver)
 	if err != nil {
 		return fmt.Errorf("opening interrupted upgrade staging store: %w", err)
+	}
+	if _, err := store.MigrateLegacyPlainText(context.Background()); err != nil {
+		return errors.Join(
+			fmt.Errorf("migrating interrupted upgrade staging authority: %w", err),
+			store.Close(),
+		)
 	}
 	validateErr := store.ValidateMetadata(context.Background())
 	closeErr = store.Close()

--- a/internal/store/upgrade_test.go
+++ b/internal/store/upgrade_test.go
@@ -110,6 +110,88 @@ func TestOpenCutsOverReleasedV090ThroughJSONL(t *testing.T) {
 	}
 }
 
+// Mutations caught: omitting legacy rendition migration from the released
+// JSONL rebuild, deleting the recovery cache, or serving both legacy and
+// rendition FTS after publication.
+func TestUpgradeLegacyPlainTextCutsOverServingAuthority(t *testing.T) {
+	for _, test := range v090UpgradeDrivers() {
+		t.Run(test.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "docbank.db")
+			fixture := createV090Fixture(t, dbPath, test.driver)
+			const legacyText = "heritage-token Cafe\u0301\r\nlegacy line"
+			const legacyVersion = "20000000-0000-4000-8000-000000000001"
+
+			db, err := test.driver.Open(dbPath, docsqlite.OpenOptions{
+				Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+			})
+			require.NoError(t, err)
+			result, err := db.Exec(`INSERT INTO extracted_text(
+				blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at
+			) VALUES(?, 'plain-text', 1, 'ok', NULL, 1, ?, ?)`,
+				fixture.looseHash, legacyText, legacyMigrationTimestamp)
+			require.NoError(t, err)
+			rowID, err := result.LastInsertId()
+			require.NoError(t, err)
+			_, err = db.Exec(`INSERT INTO content_fts(rowid,blob_hash,extractor,text)
+				VALUES(?,?,'plain-text',?)`, rowID, fixture.looseHash, legacyText)
+			require.NoError(t, err)
+			_, err = db.Exec(`INSERT INTO text_searchable_versions(version_id) VALUES(?)`, legacyVersion)
+			require.NoError(t, err)
+			var oldTextName string
+			require.NoError(t, db.QueryRow(`
+				SELECT n.name FROM content_fts
+				JOIN content_versions v ON v.blob_hash=content_fts.blob_hash
+				JOIN nodes n ON n.current_version_id=v.version_id
+				JOIN text_searchable_versions sv ON sv.version_id=v.version_id
+				WHERE content_fts MATCH '"heritage-token"*'
+			`).Scan(&oldTextName))
+			assert.Equal(t, "loose.txt", oldTextName)
+			require.NoError(t, db.Close())
+
+			s, err := Open(dbPath, test.driver)
+			require.NoError(t, err)
+			textHits, _, err := s.SearchPage(t.Context(), "heritage-token", 20)
+			require.NoError(t, err)
+			require.Len(t, textHits, 1)
+			assert.Equal(t, "/loose.txt", textHits[0].Path)
+			assert.Equal(t, SearchMatchContent, textHits[0].Match)
+			nameHits, _, err := s.SearchPage(t.Context(), "loose", 20)
+			require.NoError(t, err)
+			require.Len(t, nameHits, 1)
+			assert.Equal(t, "/loose.txt", nameHits[0].Path)
+			assert.Equal(t, SearchMatchName, nameHits[0].Match)
+
+			var builds, heads, legacyFTS int
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_builds`).Scan(&builds))
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_heads`).Scan(&heads))
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&legacyFTS))
+			assert.Equal(t, 1, builds)
+			assert.Equal(t, 1, heads)
+			assert.Zero(t, legacyFTS, "published current database serves only rendition authority")
+			var unitID, text string
+			require.NoError(t, s.db.QueryRow(`
+				SELECT u.evidence_unit_id,l.text FROM rendition_units u
+				JOIN rendition_lexical_segments l USING(build_id)
+			`).Scan(&unitID, &text))
+			assert.Equal(t, "legacy:0", unitID)
+			assert.Equal(t, []byte(legacyText), []byte(text))
+			require.NoError(t, s.Close())
+
+			backup, err := test.driver.Open(dbPath+v090BackupSuffix, docsqlite.OpenOptions{
+				Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Deferred,
+			})
+			require.NoError(t, err)
+			var retainedText string
+			require.NoError(t, backup.QueryRow(`
+				SELECT text FROM extracted_text
+				WHERE blob_hash=? AND extractor='plain-text'`, fixture.looseHash,
+			).Scan(&retainedText))
+			assert.Equal(t, []byte(legacyText), []byte(retainedText))
+			require.NoError(t, backup.Close())
+		})
+	}
+}
+
 func TestFreshStoresRecordCurrentStorageSchemaVersion(t *testing.T) {
 	for _, test := range v090UpgradeDrivers() {
 		t.Run(test.name, func(t *testing.T) {
@@ -227,6 +309,55 @@ func TestOpenCutsOverReleasedSchemaV3ThroughJSONL(t *testing.T) {
 	}
 }
 
+// Coverage guard: both released schema-v2 layouts must carry legacy text
+// through the same one-authority cutover in both supported SQLite modes.
+func TestUpgradeEveryReleasedSchemaV2LayoutMigratesLegacyPlainText(t *testing.T) {
+	layouts := []struct {
+		name     string
+		addition string
+	}{
+		{name: "v0.10.0"},
+		{name: "v0.10.1-v0.11.0", addition: schemaV0110AdditionSQL},
+	}
+	for _, driver := range v090UpgradeDrivers() {
+		for _, layout := range layouts {
+			t.Run(driver.name+"/"+layout.name, func(t *testing.T) {
+				dbPath := filepath.Join(t.TempDir(), "docbank.db")
+				fixture := createV2Fixture(t, dbPath, driver.driver, layout.addition)
+				const legacyText = "schema-v2-heritage Cafe\u0301\r\nexact bytes"
+				addV2LegacyPlainText(t, dbPath, driver.driver, fixture.rawHash, legacyText)
+
+				s, err := Open(dbPath, driver.driver)
+				require.NoError(t, err)
+				var builds, heads, legacyFTS int
+				require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_builds`).Scan(&builds))
+				require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_heads`).Scan(&heads))
+				require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&legacyFTS))
+				assert.Equal(t, 1, builds)
+				assert.Equal(t, 1, heads)
+				assert.Zero(t, legacyFTS)
+				hits, _, err := s.SearchPage(t.Context(), "schema-v2-heritage", 20)
+				require.NoError(t, err)
+				require.Len(t, hits, 1)
+				assert.Equal(t, "/raw.txt", hits[0].Path)
+				require.NoError(t, s.Close())
+
+				backup, err := driver.driver.Open(dbPath+v2BackupSuffix, docsqlite.OpenOptions{
+					Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Deferred,
+				})
+				require.NoError(t, err)
+				var retained string
+				require.NoError(t, backup.QueryRow(`
+					SELECT text FROM extracted_text
+					WHERE blob_hash=? AND extractor='plain-text'`, fixture.rawHash,
+				).Scan(&retained))
+				assert.Equal(t, []byte(legacyText), []byte(retained))
+				require.NoError(t, backup.Close())
+			})
+		}
+	}
+}
+
 func TestOpenRejectsDatabaseFromNewerStorageSchema(t *testing.T) {
 	for _, test := range v090UpgradeDrivers() {
 		t.Run(test.name, func(t *testing.T) {
@@ -324,6 +455,48 @@ func TestOpenCompletesInterruptedReleasedCutover(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist)
 	_, err = os.Stat(dbPath + sourceSchema.backupSuffix)
 	require.NoError(t, err)
+}
+
+// Mutation caught: validating an interrupted current-schema stage without
+// converging its legacy authority can publish a stage that was never cut over.
+func TestInterruptedUpgradeStageMigratesLegacyBeforePublication(t *testing.T) {
+	for _, test := range v090UpgradeDrivers() {
+		t.Run(test.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "docbank.db")
+			fixture := createV090Fixture(t, dbPath, test.driver)
+			const legacyText = "interrupted-stage-heritage"
+			addV090LegacyPlainText(t, dbPath, test.driver, fixture.looseHash, legacyText)
+			sourceSchema := releasedStorageSchemas[0]
+			stagePath := upgradeStagePath(dbPath, sourceSchema.version)
+			jsonlPath := upgradeJSONLPath(dbPath, sourceSchema.version)
+
+			source, err := openReleasedSource(dbPath, test.driver, sourceSchema)
+			require.NoError(t, err)
+			snapshot, err := source.BeginTx(t.Context(), &sql.TxOptions{ReadOnly: true})
+			require.NoError(t, err)
+			require.NoError(t, writeUpgradeJSONL(snapshot, jsonlPath, sourceSchema))
+			target, err := openCurrentStore(stagePath, test.driver)
+			require.NoError(t, err)
+			require.NoError(t, importUpgradeJSONL(target, jsonlPath, sourceSchema))
+			require.NoError(t, sourceSchema.restorePhysical(t.Context(), snapshot, target))
+			require.NoError(t, target.Close())
+			require.NoError(t, snapshot.Rollback())
+			require.NoError(t, source.Close())
+
+			require.NoError(t, validateUpgradeStage(stagePath, test.driver))
+			stage, err := openCurrentStore(stagePath, test.driver)
+			require.NoError(t, err)
+			var heads, legacyFTS int
+			require.NoError(t, stage.db.QueryRow(`SELECT COUNT(*) FROM rendition_heads`).Scan(&heads))
+			require.NoError(t, stage.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&legacyFTS))
+			assert.Equal(t, 1, heads)
+			assert.Zero(t, legacyFTS)
+			hits, _, err := stage.SearchPage(t.Context(), "interrupted-stage-heritage", 20)
+			require.NoError(t, err)
+			require.Len(t, hits, 1)
+			require.NoError(t, stage.Close())
+		})
+	}
 }
 
 func TestInvalidStageRestoresSourceBeforeRemovingRecoveryMarker(t *testing.T) {
@@ -468,6 +641,29 @@ func createV090Fixture(t *testing.T, path string, driver docsqlite.Driver) v090F
 	}
 }
 
+func addV090LegacyPlainText(
+	t *testing.T, path string, driver docsqlite.Driver, blobHash, text string,
+) {
+	t.Helper()
+	db, err := driver.Open(path, docsqlite.OpenOptions{
+		Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+	})
+	require.NoError(t, err)
+	result, err := db.Exec(`INSERT INTO extracted_text(
+		blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at
+	) VALUES(?,'plain-text',1,'ok',NULL,1,?,?)`, blobHash, text, legacyMigrationTimestamp)
+	require.NoError(t, err)
+	rowID, err := result.LastInsertId()
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO content_fts(rowid,blob_hash,extractor,text)
+		VALUES(?,?,'plain-text',?)`, rowID, blobHash, text)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO text_searchable_versions(version_id)
+		VALUES('20000000-0000-4000-8000-000000000001')`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
 func createV2Fixture(
 	t *testing.T, path string, driver docsqlite.Driver, layoutAddition string,
 ) v2Fixture {
@@ -591,6 +787,48 @@ func createV3Fixture(t *testing.T, path string, driver docsqlite.Driver) v3Fixtu
 		blobHash: blobHash, primaryStoreID: primaryStoreID,
 		secondaryStoreID: secondaryStoreID, metadata: metadata.Bytes(),
 	}
+}
+
+func addV2LegacyPlainText(
+	t *testing.T, path string, driver docsqlite.Driver, blobHash, text string,
+) {
+	t.Helper()
+	db, err := driver.Open(path, docsqlite.OpenOptions{
+		Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+	})
+	require.NoError(t, err)
+	const (
+		timestamp = "2026-07-19T12:00:00.000000000Z"
+		versionID = "20000000-0000-4000-8000-000000000001"
+		operation = "30000000-0000-4000-8000-000000000001"
+	)
+	tx, err := db.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	_, err = tx.Exec(`PRAGMA defer_foreign_keys = ON`)
+	require.NoError(t, err)
+	_, err = tx.Exec(`INSERT INTO nodes(id,parent_id,name,kind,current_version_id,revision,
+		created_at,modified_at) VALUES(2,1,'raw.txt','file',?,1,?,?)`,
+		versionID, timestamp, timestamp)
+	require.NoError(t, err)
+	_, err = tx.Exec(`INSERT INTO content_versions(
+		version_id,node_id,blob_hash,size,mime_type,recorded_at,node_revision,
+		introduced_operation_id,transition_kind
+	) VALUES(?,2,?,5,'text/plain',?,1,?,'content_create')`,
+		versionID, blobHash, timestamp, operation)
+	require.NoError(t, err)
+	result, err := tx.Exec(`INSERT INTO extracted_text(
+		blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at
+	) VALUES(?,'plain-text',1,'ok',NULL,1,?,?)`, blobHash, text, timestamp)
+	require.NoError(t, err)
+	rowID, err := result.LastInsertId()
+	require.NoError(t, err)
+	_, err = tx.Exec(`INSERT INTO content_fts(rowid,blob_hash,extractor,text)
+		VALUES(?,?,'plain-text',?)`, rowID, blobHash, text)
+	require.NoError(t, err)
+	_, err = tx.Exec(`INSERT INTO text_searchable_versions(version_id) VALUES(?)`, versionID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.NoError(t, db.Close())
 }
 
 func assertPhysicalContent(t *testing.T, s *Store, hash string, want PhysicalContent) {

--- a/internal/store/upgrade_test.go
+++ b/internal/store/upgrade_test.go
@@ -309,6 +309,79 @@ func TestOpenCutsOverReleasedSchemaV3ThroughJSONL(t *testing.T) {
 	}
 }
 
+// Coverage guard: the exact released v0.14 schema must carry its plain-text
+// search result through the one-authority cutover in both SQLite modes.
+func TestUpgradeReleasedV014MigratesPlainText(t *testing.T) {
+	for _, test := range v090UpgradeDrivers() {
+		t.Run(test.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "docbank.db")
+			fixture := createV3Fixture(t, dbPath, test.driver)
+			const (
+				timestamp = "2026-08-16T12:00:00.000000000Z"
+				versionID = "40000000-0000-4000-8000-000000000003"
+				operation = "50000000-0000-4000-8000-000000000003"
+				text      = "v014-search-token"
+			)
+
+			db, err := test.driver.Open(dbPath, docsqlite.OpenOptions{
+				Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+			})
+			require.NoError(t, err)
+			tx, err := db.BeginTx(t.Context(), nil)
+			require.NoError(t, err)
+			_, err = tx.Exec(`INSERT INTO nodes(
+				id,parent_id,name,kind,current_version_id,revision,created_at,modified_at
+			) VALUES(2,1,'released.txt','file',?,1,?,?)`, versionID, timestamp, timestamp)
+			require.NoError(t, err)
+			_, err = tx.Exec(`INSERT INTO content_versions(
+				version_id,node_id,blob_hash,size,mime_type,recorded_at,node_revision,
+				introduced_operation_id,transition_kind
+			) VALUES(?,2,?,17,'text/plain',?,1,?,'content_create')`,
+				versionID, fixture.blobHash, timestamp, operation)
+			require.NoError(t, err)
+			result, err := tx.Exec(`INSERT INTO extracted_text(
+				blob_hash,extractor,extractor_version,status,error,attempts,text,extracted_at
+			) VALUES(?,'plain-text',1,'ok',NULL,1,?,?)`, fixture.blobHash, text, timestamp)
+			require.NoError(t, err)
+			rowID, err := result.LastInsertId()
+			require.NoError(t, err)
+			_, err = tx.Exec(`INSERT INTO content_fts(rowid,blob_hash,extractor,text)
+				VALUES(?,?,'plain-text',?)`, rowID, fixture.blobHash, text)
+			require.NoError(t, err)
+			_, err = tx.Exec(`INSERT INTO text_searchable_versions(version_id) VALUES(?)`, versionID)
+			require.NoError(t, err)
+			require.NoError(t, tx.Commit())
+			require.NoError(t, db.Close())
+
+			s, err := Open(dbPath, test.driver)
+			require.NoError(t, err)
+			hits, _, err := s.SearchPage(t.Context(), text, 20)
+			require.NoError(t, err)
+			require.Len(t, hits, 1)
+			assert.Equal(t, "/released.txt", hits[0].Path)
+			assert.Equal(t, SearchMatchContent, hits[0].Match)
+			var heads, legacyFTS int
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_heads`).Scan(&heads))
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts`).Scan(&legacyFTS))
+			assert.Equal(t, 1, heads)
+			assert.Zero(t, legacyFTS)
+			require.NoError(t, s.Close())
+
+			backup, err := test.driver.Open(dbPath+v3BackupSuffix, docsqlite.OpenOptions{
+				Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Deferred,
+			})
+			require.NoError(t, err)
+			var retained string
+			require.NoError(t, backup.QueryRow(`
+				SELECT text FROM extracted_text
+				WHERE blob_hash=? AND extractor='plain-text'`, fixture.blobHash,
+			).Scan(&retained))
+			assert.Equal(t, text, retained)
+			require.NoError(t, backup.Close())
+		})
+	}
+}
+
 // Coverage guard: both released schema-v2 layouts must carry legacy text
 // through the same one-authority cutover in both supported SQLite modes.
 func TestUpgradeEveryReleasedSchemaV2LayoutMigratesLegacyPlainText(t *testing.T) {


### PR DESCRIPTION
## What changed

Existing successful `plain-text` v1 records now migrate into canonical rendition builds, per-version attachments, rendition heads, and one complete lexical generation when a current or released vault opens. The cutover preserves the exact stored UTF-8 bytes and validates the replacement FTS generation against current name and text search before publishing it.

Failed, missing, invalid, or obsolete rows stay outside serving authority and remain queued for fresh extraction. The legacy cache and released source database remain recoverable but stop acting as a second live search authority.

## Why

Serving from both the released plain-text cache and the new derivative catalog would make upgrades and retries vulnerable to mixed or incomplete state. Existing vaults need one deterministic cutover without rewriting their extracted text or throwing away recovery data.

## Usage

No manual migration command is required. Opening an older supported vault performs the cutover automatically; the previous head keeps serving until the replacement catalog and lexical generation are complete.

Part of #176 (F6). Stacks on #185.
