### PR TITLE
Back up and restore document derivatives without providers

### DIFF
--- a/internal/backupapp/app.go
+++ b/internal/backupapp/app.go
@@ -21,18 +21,19 @@ import (
 // snapshot. Physical pack rows are deliberately excluded: restore may choose a
 // different loose/packed representation while preserving the same archive.
 type Stats struct {
-	Nodes           int64 `json:"nodes"`
-	Files           int64 `json:"files"`
-	Directories     int64 `json:"directories"`
-	TrashedNodes    int64 `json:"trashed_nodes"`
-	Blobs           int64 `json:"blobs"`
-	BlobBytes       int64 `json:"blob_bytes"`
-	ContentVersions int64 `json:"content_versions"`
-	Ingests         int64 `json:"ingests"`
-	Provenance      int64 `json:"provenance"`
-	Tags            int64 `json:"tags"`
-	NodeTags        int64 `json:"node_tags"`
-	ExtractedText   int64 `json:"extracted_text"`
+	Nodes               int64                     `json:"nodes"`
+	Files               int64                     `json:"files"`
+	Directories         int64                     `json:"directories"`
+	TrashedNodes        int64                     `json:"trashed_nodes"`
+	Blobs               int64                     `json:"blobs"`
+	BlobBytes           int64                     `json:"blob_bytes"`
+	ContentVersions     int64                     `json:"content_versions"`
+	Ingests             int64                     `json:"ingests"`
+	Provenance          int64                     `json:"provenance"`
+	Tags                int64                     `json:"tags"`
+	NodeTags            int64                     `json:"node_tags"`
+	ExtractedText       int64                     `json:"extracted_text"`
+	DerivativeAuthority *DerivativeAuthorityStats `json:"derivative_authority,omitempty"`
 }
 
 type rowQuerier interface {
@@ -40,7 +41,44 @@ type rowQuerier interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
-func computeStats(ctx context.Context, q rowQuerier) (Stats, error) {
+const authorizedContentRowsQuery = store.BackupBlobAuthorityCTE + `
+SELECT b.hash,b.size FROM blobs b
+JOIN backup_authorized_blobs a ON a.hash=b.hash
+ORDER BY b.hash`
+
+const authorizedContentStatsQuery = store.BackupBlobAuthorityCTE + `
+SELECT COUNT(*),COALESCE(SUM(b.size),0) FROM blobs b
+JOIN backup_authorized_blobs a ON a.hash=b.hash`
+
+const authorizedExtractedTextStatsQuery = store.BackupBlobAuthorityCTE + `
+SELECT COUNT(*) FROM extracted_text e
+JOIN backup_authorized_blobs a ON a.hash=e.blob_hash`
+
+const restoredContentStatsQuery = `SELECT COUNT(*),COALESCE(SUM(size),0) FROM blobs`
+
+const restoredExtractedTextStatsQuery = `SELECT COUNT(*) FROM extracted_text`
+
+// statsScope selects the blob population each fidelity number describes.
+// Capture scopes blob and extracted-text counts to catalog authority so a
+// snapshot never claims unreferenced provider output. Restore recomputes over
+// exactly the tables the snapshot's own metadata stream rebuilt: scoped
+// snapshots carry only authorized rows, so the full-table recount matches the
+// scoped manifest, while pre-scope v1 snapshots carried every row and keep
+// restoring against their unscoped recorded stats.
+type statsScope struct {
+	blobs         string
+	extractedText string
+}
+
+var captureStatsScope = statsScope{
+	blobs: authorizedContentStatsQuery, extractedText: authorizedExtractedTextStatsQuery,
+}
+
+var restoredStatsScope = statsScope{
+	blobs: restoredContentStatsQuery, extractedText: restoredExtractedTextStatsQuery,
+}
+
+func computeStats(ctx context.Context, q rowQuerier, scope statsScope) (Stats, error) {
 	var stats Stats
 	counts := []struct {
 		dst   *int64
@@ -55,17 +93,26 @@ func computeStats(ctx context.Context, q rowQuerier) (Stats, error) {
 		{&stats.Provenance, `SELECT COUNT(*) FROM provenance`},
 		{&stats.Tags, `SELECT COUNT(*) FROM tags`},
 		{&stats.NodeTags, `SELECT COUNT(*) FROM node_tags`},
-		{&stats.ExtractedText, `SELECT COUNT(*) FROM extracted_text`},
 	}
 	for _, count := range counts {
 		if err := q.QueryRowContext(ctx, count.query).Scan(count.dst); err != nil {
 			return Stats{}, fmt.Errorf("backupapp: stats query %q: %w", count.query, err)
 		}
 	}
-	if err := q.QueryRowContext(ctx,
-		`SELECT COUNT(*), COALESCE(SUM(size), 0) FROM blobs`,
-	).Scan(&stats.Blobs, &stats.BlobBytes); err != nil {
+	if err := q.QueryRowContext(ctx, scope.blobs).Scan(
+		&stats.Blobs, &stats.BlobBytes,
+	); err != nil {
 		return Stats{}, fmt.Errorf("backupapp: blob stats: %w", err)
+	}
+	if err := q.QueryRowContext(ctx, scope.extractedText).Scan(&stats.ExtractedText); err != nil {
+		return Stats{}, fmt.Errorf("backupapp: extracted text stats: %w", err)
+	}
+	derivatives, hasDerivatives, err := computeDerivativeAuthorityStats(ctx, q)
+	if err != nil {
+		return Stats{}, err
+	}
+	if hasDerivatives {
+		stats.DerivativeAuthority = derivatives
 	}
 	return stats, nil
 }
@@ -122,7 +169,7 @@ func (a *App) ExcludedPaths() []string {
 type frozenView struct{ tx rowQuerier }
 
 func (v *frozenView) ContentInfo(ctx context.Context) (*backup.ContentInfo, error) {
-	rows, err := v.tx.QueryContext(ctx, `SELECT hash, size FROM blobs ORDER BY hash`)
+	rows, err := v.tx.QueryContext(ctx, authorizedContentRowsQuery)
 	if err != nil {
 		return nil, fmt.Errorf("backupapp: listing frozen blobs: %w", err)
 	}
@@ -148,7 +195,7 @@ func (v *frozenView) ContentInfo(ctx context.Context) (*backup.ContentInfo, erro
 }
 
 func (v *frozenView) Stats(ctx context.Context) (jsontext.Value, error) {
-	stats, err := computeStats(ctx, v.tx)
+	stats, err := computeStats(ctx, v.tx, captureStatsScope)
 	if err != nil {
 		return nil, err
 	}
@@ -171,6 +218,11 @@ func restoredContentPaths(ctx context.Context, db *sql.DB, allowPackedRestore bo
 			return nil, errors.New("backupapp: snapshot contains packed blob authority; use backupapp.Restore")
 		}
 	}
+	// The restored database is rebuilt from the snapshot's own metadata
+	// stream, which capture already scoped to catalog authority. Recomputing
+	// over its complete blobs table therefore matches scoped snapshots while
+	// pre-scope v1 snapshots, whose streams carried every blob row, keep the
+	// placement and count fidelity their manifests recorded.
 	rows, err := db.QueryContext(ctx, `SELECT hash FROM blobs ORDER BY hash`)
 	if err != nil {
 		return nil, fmt.Errorf("backupapp: listing restored blobs: %w", err)
@@ -195,7 +247,7 @@ func restoredContentPaths(ctx context.Context, db *sql.DB, allowPackedRestore bo
 }
 
 func (a *App) RestoredStats(ctx context.Context, db *sql.DB) (jsontext.Value, error) {
-	stats, err := computeStats(ctx, db)
+	stats, err := computeStats(ctx, db, restoredStatsScope)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -1617,6 +1617,132 @@ func TestPrunedVersionHistoryRoundTripsWithoutResurrection(t *testing.T) {
 	assert.Equal(t, replaced.CurrentVersionID, versions[0].ID)
 }
 
+func TestWatchCursorSurvivesBackupWithoutRetainingPrunedSourceBytes(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	const (
+		watchName  = "synthetic-watch"
+		sourceRef  = "inbox/watched.txt"
+		sourceData = "watched source before a manual edit"
+		manualData = "manual replacement retained as authority"
+	)
+	var watched store.Node
+	var sourceHash string
+	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
+		var sourceSize int64
+		var err error
+		sourceHash, sourceSize, err = fixture.blobs.WriteContext(
+			t.Context(), strings.NewReader(sourceData),
+		)
+		if err != nil {
+			return err
+		}
+		run, err := fixture.metadata.BeginIngest(t.Context(), "watch", watchName)
+		if err != nil {
+			return err
+		}
+		watched, err = fixture.metadata.IngestFileExact(
+			t.Context(), run, fixture.metadata.RootID(), "watched.txt",
+			sourceHash, sourceSize, "text/plain", sourceRef, "",
+		)
+		return err
+	}))
+	prunedVersionID := watched.CurrentVersionID
+	var replaced store.Node
+	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
+		manualHash, manualSize, err := fixture.blobs.WriteContext(
+			t.Context(), strings.NewReader(manualData),
+		)
+		if err != nil {
+			return err
+		}
+		replaced, _, err = fixture.metadata.ReplaceContent(
+			t.Context(), watched.ID, watched.Revision,
+			manualHash, manualSize, "text/plain",
+		)
+		return err
+	}))
+	pruned, err := fixture.metadata.PruneContentVersions(
+		t.Context(), watched.ID, replaced.Revision,
+		store.VersionPruneSelector{AllPrior: true}, true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned.DeletedVersions)
+	unreachable, err := fixture.metadata.UnreachableBlobs(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, unreachable, store.BlobInfo{Hash: sourceHash, Size: int64(len(sourceData))},
+		"the operational cursor must not defeat explicit version pruning")
+
+	ordinaryMetadata := string(exportMetadata(t, fixture.metadata))
+	assert.Contains(t, ordinaryMetadata, `{"type":"blob","hash":"`+sourceHash+`"`,
+		"ordinary metadata export preserves catalog rows for direct import")
+	wantMetadata := string(exportBackupMetadata(t, fixture.metadata))
+	assert.NotContains(t, wantMetadata, `{"type":"blob","hash":"`+sourceHash+`"`,
+		"backup must not retain bytes released from document authority")
+	assert.Contains(t, wantMetadata,
+		`{"type":"watch_source","watch_name":"`+watchName+`","source_ref":"`+sourceRef+`"`,
+		"backup must preserve the operational cursor across daemon restarts")
+	assert.Contains(t, wantMetadata, `"blob_hash":"`+sourceHash+`"`)
+
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	manifest, err := backupapp.Create(
+		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs,
+		backup.CreateOptions{Jobs: 2},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), manifest.Attachments.Blobs,
+		"backup carries the two fixture heads and the manual replacement, not pruned source bytes")
+
+	target := filepath.Join(t.TempDir(), "restored")
+	_, err = backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{
+		TargetDir: target, Jobs: 2,
+	})
+	require.NoError(t, err)
+	restoredStore, err := store.OpenForRestore(
+		filepath.Join(target, "docbank.db"), store.DefaultSQLiteDriver(),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, restoredStore.Close()) }()
+	restoredMetadata := string(exportMetadata(t, restoredStore))
+	assert.Contains(t, restoredMetadata,
+		`{"type":"watch_source","watch_name":"`+watchName+`","source_ref":"`+sourceRef+`"`)
+	assert.NotContains(t, restoredMetadata, `{"type":"blob","hash":"`+sourceHash+`"`)
+	_, err = restoredStore.ContentVersionByID(t.Context(), prunedVersionID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	restoredNode, err := restoredStore.NodeByID(t.Context(), watched.ID)
+	require.NoError(t, err)
+	assert.Equal(t, replaced.CurrentVersionID, restoredNode.CurrentVersionID)
+	restoredBlobs, err := blob.New(
+		store.NewPackCatalog(restoredStore), filepath.Join(target, "blobs"),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, restoredBlobs.Close()) }()
+	var unchanged store.Node
+	var noVersion store.ContentVersion
+	var changed bool
+	require.NoError(t, restoredBlobs.WithMutation(t.Context(), func() error {
+		incomingHash, incomingSize, writeErr := restoredBlobs.WriteContext(
+			t.Context(), strings.NewReader(sourceData),
+		)
+		if writeErr != nil {
+			return writeErr
+		}
+		if incomingHash != sourceHash {
+			return fmt.Errorf("restored watch input hash = %s, want %s", incomingHash, sourceHash)
+		}
+		unchanged, noVersion, changed, writeErr = restoredStore.SyncWatchedContent(
+			t.Context(), watchName, sourceRef,
+			incomingHash, incomingSize, "text/plain",
+		)
+		return writeErr
+	}))
+	assert.False(t, changed,
+		"the restored cursor must recognize unchanged source bytes")
+	assert.Empty(t, noVersion.ID)
+	assert.Equal(t, replaced.CurrentVersionID, unchanged.CurrentVersionID,
+		"an unchanged watched source must not overwrite the retained manual edit")
+}
+
 func TestDerivativeAuthoritySnapshotRestoresCatalogBlobsAndRebuildsLexicalProjection(t *testing.T) {
 	fixture := newArchiveFixture(t)
 	source, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -2388,6 +2388,9 @@ func (s legacyMetadataSnapshot) Close() error {
 }
 
 func TestPlacementRestoreDoesNotMigrateLegacySnapshotBeforePublication(t *testing.T) {
+	// v0.14 snapshots used metadata JSONL v1 with full-table fidelity stats.
+	// That released schema had extracted_text but no rendition catalog, so its
+	// manifest cannot contain derivative_authority.
 	fixture := newArchiveFixture(t)
 	alpha, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")
 	require.NoError(t, err)
@@ -2399,12 +2402,15 @@ func TestPlacementRestoreDoesNotMigrateLegacySnapshotBeforePublication(t *testin
 
 	repo, err := backup.Init(filepath.Join(t.TempDir(), "legacy-placement-repo"))
 	require.NoError(t, err)
-	_, err = backup.Create(t.Context(), repo, backupapp.New("legacy-version"),
+	manifest, err := backup.Create(t.Context(), repo, backupapp.New("legacy-version"),
 		backup.CreateOptions{
 			MetadataSource: legacyMetadataSource{metadata: fixture.metadata},
 			ContentSource:  backupapp.NewContentSource(fixture.blobs),
 		})
 	require.NoError(t, err)
+	require.NotNil(t, manifest.Metadata)
+	assert.Equal(t, backupapp.MetadataFormat, manifest.Metadata.Format)
+	assert.NotContains(t, string(manifest.Stats), `"derivative_authority"`)
 
 	target := filepath.Join(t.TempDir(), "restored")
 	_, err = backupapp.RestoreWithPlacement(

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -4,13 +4,19 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
+	"go.kenn.io/kit/pack"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,6 +58,45 @@ func (source rawMetadataSource) OpenSnapshot(context.Context) (backup.MetadataSn
 }
 
 type rawMetadataSnapshot struct{ metadata []byte }
+
+type overriddenMetadataSource struct {
+	source   backup.MetadataSource
+	metadata []byte
+}
+
+func (s overriddenMetadataSource) Format() string { return s.source.Format() }
+
+func (s overriddenMetadataSource) OpenSnapshot(ctx context.Context) (backup.MetadataSnapshot, error) {
+	snapshot, err := s.source.OpenSnapshot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("opening overridden metadata snapshot: %w", err)
+	}
+	return overriddenMetadataSnapshot{MetadataSnapshot: snapshot, metadata: s.metadata}, nil
+}
+
+type overriddenMetadataSnapshot struct {
+	backup.MetadataSnapshot
+
+	metadata []byte
+}
+
+func (s overriddenMetadataSnapshot) OpenMetadata(context.Context) (io.ReadCloser, int64, error) {
+	return io.NopCloser(bytes.NewReader(s.metadata)), int64(len(s.metadata)), nil
+}
+
+func (s overriddenMetadataSnapshot) AuxiliaryArtifacts(
+	ctx context.Context,
+) ([]backup.AuxiliaryArtifact, error) {
+	source, ok := s.MetadataSnapshot.(backup.AuxiliarySource)
+	if !ok {
+		return nil, nil
+	}
+	artifacts, err := source.AuxiliaryArtifacts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("opening overridden auxiliary artifacts: %w", err)
+	}
+	return artifacts, nil
+}
 
 type auxiliaryTargetFunc func(context.Context, []backup.RestoredAuxiliary) error
 
@@ -141,6 +186,46 @@ func exportMetadata(t *testing.T, metadata *store.Store) []byte {
 	var dst bytes.Buffer
 	require.NoError(t, metadata.ExportMetadata(t.Context(), &dst))
 	return dst.Bytes()
+}
+
+func exportBackupMetadata(t *testing.T, metadata *store.Store) []byte {
+	t.Helper()
+	snapshot, err := backupapp.NewMetadataSource(metadata).OpenSnapshot(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, snapshot.Close()) })
+	stream, _, err := snapshot.OpenMetadata(t.Context())
+	require.NoError(t, err)
+	data, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.NoError(t, stream.Close())
+	return data
+}
+
+func markRestoreTarget(t *testing.T, target string) string {
+	t.Helper()
+	seedOwnedVault(t, target)
+	metadata, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	_, err = metadata.Mkdir(t.Context(), metadata.RootID(), "preexisting-restore-marker")
+	require.NoError(t, err)
+	require.NoError(t, metadata.Close())
+	data, err := os.ReadFile(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func assertRestoreTargetUnchanged(t *testing.T, target, wantDigest string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	digest := sha256.Sum256(data)
+	assert.Equal(t, wantDigest, hex.EncodeToString(digest[:]))
+	metadata, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, metadata.Close()) }()
+	_, err = metadata.NodeByPath(t.Context(), "/preexisting-restore-marker")
+	assert.NoError(t, err)
 }
 
 func TestJSONLLooseSnapshotVerifyAndRestore(t *testing.T) {
@@ -1453,6 +1538,7 @@ func TestPrunedVersionHistoryRoundTripsWithoutResurrection(t *testing.T) {
 	alpha, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")
 	require.NoError(t, err)
 	prunedVersionID := alpha.CurrentVersionID
+	prunedBlobHash := alpha.BlobHash
 	const replacement = "retained replacement"
 	var replaced store.Node
 	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
@@ -1465,11 +1551,31 @@ func TestPrunedVersionHistoryRoundTripsWithoutResurrection(t *testing.T) {
 		)
 		return writeErr
 	}))
+	currentVersion, err := fixture.metadata.ContentVersionByID(t.Context(), replaced.CurrentVersionID)
+	require.NoError(t, err)
+	require.NoError(t, fixture.metadata.RecordExtraction(t.Context(), store.ExtractionResult{
+		BlobHash: prunedBlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: store.ExtractionOK, Text: "stale pruned extraction",
+	}))
+	require.NoError(t, fixture.metadata.RecordExtraction(t.Context(), store.ExtractionResult{
+		BlobHash: currentVersion.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: store.ExtractionOK, Text: "live retained extraction",
+	}))
 	pruned, err := fixture.metadata.PruneContentVersions(t.Context(), alpha.ID, replaced.Revision,
 		store.VersionPruneSelector{AllPrior: true}, true)
 	require.NoError(t, err)
 	require.Equal(t, 1, pruned.DeletedVersions)
-	wantMetadata := exportMetadata(t, fixture.metadata)
+	ordinaryMetadata := exportMetadata(t, fixture.metadata)
+	assert.Contains(t, string(ordinaryMetadata), prunedBlobHash,
+		"ordinary metadata export retains unreachable rows for direct import and upgrades")
+	assert.Contains(t, string(ordinaryMetadata), "stale pruned extraction")
+	wantMetadata := exportBackupMetadata(t, fixture.metadata)
+	assert.NotContains(t, string(wantMetadata), prunedBlobHash,
+		"backup metadata excludes a blob with no retained logical authority")
+	assert.NotContains(t, string(wantMetadata), "stale pruned extraction",
+		"backup metadata excludes cache rows whose blobs have no retained authority")
+	assert.Contains(t, string(wantMetadata), "live retained extraction",
+		"backup metadata retains cache rows for current blob authority")
 
 	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
 	require.NoError(t, err)
@@ -1481,16 +1587,24 @@ func TestPrunedVersionHistoryRoundTripsWithoutResurrection(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), stats.ContentVersions,
 		"backup metadata must contain only the retained heads")
+	assert.Equal(t, int64(1), stats.ExtractedText,
+		"backup stats count only cache rows carried by the scoped metadata stream")
 
 	target := filepath.Join(t.TempDir(), "restored")
 	_, err = backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{
 		TargetDir: target, Jobs: 2,
 	})
 	require.NoError(t, err)
-	restoredStore, err := store.Open(filepath.Join(target, "docbank.db"))
+	restoredStore, err := store.OpenForRestore(
+		filepath.Join(target, "docbank.db"), store.DefaultSQLiteDriver(),
+	)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, restoredStore.Close()) }()
-	assert.Equal(t, string(wantMetadata), string(exportMetadata(t, restoredStore)))
+	restoredMetadata := exportMetadata(t, restoredStore)
+	assert.Equal(t, string(wantMetadata), string(restoredMetadata))
+	assert.NotContains(t, string(restoredMetadata), prunedBlobHash)
+	assert.NotContains(t, string(restoredMetadata), "stale pruned extraction")
+	assert.Contains(t, string(restoredMetadata), "live retained extraction")
 	_, err = restoredStore.ContentVersionByID(t.Context(), prunedVersionID)
 	require.ErrorIs(t, err, store.ErrNotFound,
 		"backup and restore must not resurrect released history")
@@ -1501,4 +1615,763 @@ func TestPrunedVersionHistoryRoundTripsWithoutResurrection(t *testing.T) {
 	require.Equal(t, 1, total)
 	require.Len(t, versions, 1)
 	assert.Equal(t, replaced.CurrentVersionID, versions[0].ID)
+}
+
+func TestDerivativeAuthoritySnapshotRestoresCatalogBlobsAndRebuildsLexicalProjection(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	source, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")
+	require.NoError(t, err)
+	var providerCalls atomic.Int64
+	providerSentinel := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		providerCalls.Add(1)
+	}))
+	t.Cleanup(providerSentinel.Close)
+
+	orphanProviderOutput := "synthetic provider result abandoned before staging"
+	evidence := "synthetic normalized evidence"
+	markdown := "# Synthetic backup rendition\n"
+	stagedSource := "synthetic source retained by an unattached staged build"
+	var orphanHash, evidenceHash, markdownHash, stagedSourceHash string
+	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
+		orphanReceipt, writeErr := fixture.blobs.WriteDetailedContext(
+			t.Context(), strings.NewReader(orphanProviderOutput),
+		)
+		if writeErr != nil {
+			return writeErr
+		}
+		orphanEncoding, err := orphanReceipt.EncodingName()
+		if err != nil {
+			return err
+		}
+		orphanHash = orphanReceipt.Hash
+		if err := fixture.metadata.RecordRenditionBlob(t.Context(), orphanReceipt.Hash, orphanReceipt.Size,
+			store.BlobPhysical{Encoding: orphanEncoding, StoredBytes: orphanReceipt.StoredSize,
+				PackEligible: orphanReceipt.PackEligible, Created: orphanReceipt.Created}); err != nil {
+			return err
+		}
+
+		stagedSourceReceipt, writeErr := fixture.blobs.WriteDetailedContext(
+			t.Context(), strings.NewReader(stagedSource),
+		)
+		if writeErr != nil {
+			return writeErr
+		}
+		stagedSourceEncoding, err := stagedSourceReceipt.EncodingName()
+		if err != nil {
+			return err
+		}
+		stagedSourceHash = stagedSourceReceipt.Hash
+		if err := fixture.metadata.RecordRenditionBlob(
+			t.Context(), stagedSourceReceipt.Hash, stagedSourceReceipt.Size,
+			store.BlobPhysical{Encoding: stagedSourceEncoding, StoredBytes: stagedSourceReceipt.StoredSize,
+				PackEligible: stagedSourceReceipt.PackEligible, Created: stagedSourceReceipt.Created},
+		); err != nil {
+			return err
+		}
+
+		evidenceReceipt, writeErr := fixture.blobs.WriteDetailedContext(t.Context(), strings.NewReader(evidence))
+		if writeErr != nil {
+			return writeErr
+		}
+		evidenceEncoding, err := evidenceReceipt.EncodingName()
+		if err != nil {
+			return err
+		}
+		evidenceHash = evidenceReceipt.Hash
+		if err := fixture.metadata.RecordRenditionBlob(t.Context(), evidenceReceipt.Hash, evidenceReceipt.Size,
+			store.BlobPhysical{Encoding: evidenceEncoding, StoredBytes: evidenceReceipt.StoredSize,
+				PackEligible: evidenceReceipt.PackEligible, Created: evidenceReceipt.Created}); err != nil {
+			return err
+		}
+		markdownReceipt, writeErr := fixture.blobs.WriteDetailedContext(t.Context(), strings.NewReader(markdown))
+		if writeErr != nil {
+			return writeErr
+		}
+		markdownEncoding, err := markdownReceipt.EncodingName()
+		if err != nil {
+			return err
+		}
+		markdownHash = markdownReceipt.Hash
+		return fixture.metadata.RecordRenditionBlob(t.Context(), markdownReceipt.Hash, markdownReceipt.Size,
+			store.BlobPhysical{Encoding: markdownEncoding, StoredBytes: markdownReceipt.StoredSize,
+				PackEligible: markdownReceipt.PackEligible, Created: markdownReceipt.Created})
+	}))
+
+	profile := backupProcessingProfile(t)
+	build := store.RenditionBuildRecord{
+		ID:                                backupHash("build"),
+		VaultID:                           fixture.metadata.VaultID(),
+		SourceSHA256:                      source.BlobHash,
+		RenditionRequestFingerprint:       profile.RenditionRequestFingerprint,
+		EvidenceLexicalFingerprint:        profile.EvidenceLexicalFingerprint,
+		CapturedArtifactPolicyFingerprint: backupHash(backupCapturedArtifactPolicy),
+		CapturedArtifactPolicy:            jsontext.Value(backupCapturedArtifactPolicy),
+		AuthorizationChecksum:             backupHash("authorization"),
+		ProviderOperationID:               "synthetic-provider-operation",
+		ProviderReceipt: jsontext.Value(fmt.Sprintf(
+			`{"endpoint":%q,"provider":"synthetic"}`, providerSentinel.URL,
+		)),
+		EvidenceChecksum:      evidenceHash,
+		RenditionChecksum:     backupHash("rendition"),
+		MarkdownChecksum:      markdownHash,
+		Completeness:          document.EvidenceComplete,
+		Warnings:              []string{},
+		CompletedAt:           "2026-08-23T00:00:00.000000000Z",
+		DeclaredArtifactCount: 2,
+		Artifacts: []store.RenditionArtifactRecord{
+			{ID: "evidence", Role: "normalized_evidence", BlobHash: evidenceHash,
+				Size: int64(len(evidence)), Checksum: evidenceHash, State: store.RenditionArtifactVerified},
+			{ID: "markdown", Role: "sanitized_markdown", BlobHash: markdownHash,
+				Size: int64(len(markdown)), Checksum: markdownHash, State: store.RenditionArtifactVerified},
+		},
+		Units: []store.RenditionUnitRecord{{
+			ID: "unit", EvidenceUnitID: "evidence-unit", Order: 0, Checksum: backupHash("unit"),
+			HeadingPath: []string{"Synthetic backup rendition"},
+			Locator: document.EvidenceLocatorV1{Kind: document.EvidenceLocatorPage,
+				IndexOrigin: document.EvidenceIndexOriginOne, Start: 1, End: 1},
+		}},
+		LexicalSegments: []store.RenditionLexicalSegmentRecord{{
+			ID: "segment", UnitID: "unit", Order: 0, CharStart: 0, CharEnd: len("Synthetic backup rendition"),
+			Checksum: backupHash("segment"), Text: "Synthetic backup rendition",
+		}},
+	}
+	require.NoError(t, fixture.metadata.StageRenditionBuild(t.Context(), build))
+	stagedBuild := build
+	stagedBuild.ID = backupHash("unattached-staged-build")
+	stagedBuild.SourceSHA256 = stagedSourceHash
+	stagedBuild.ProviderOperationID = "synthetic-unattached-staged-build"
+	require.NoError(t, fixture.metadata.StageRenditionBuild(t.Context(), stagedBuild))
+	generation, err := fixture.metadata.StageLexicalGeneration(
+		t.Context(), backupHash("restored-lexical-generation"),
+	)
+	require.NoError(t, err)
+	attachment := store.RenditionAttachmentRecord{
+		ID: backupHash("attachment"), VaultID: fixture.metadata.VaultID(),
+		ContentVersionID: source.CurrentVersionID, BuildID: build.ID, Profile: profile,
+		AttachedAt: "2026-08-23T00:01:00.000000000Z",
+	}
+	require.NoError(t, fixture.metadata.PublishRenditionAndLexicalHeads(
+		t.Context(), attachment, store.RenditionHeadRecord{
+			ContentVersionID: source.CurrentVersionID, ProcessingProfileFingerprint: profile.Fingerprint,
+			AttachmentID: attachment.ID, PublishedAt: "2026-08-23T00:02:00.000000000Z",
+		}, generation.ID))
+	assert.Contains(t, string(exportMetadata(t, fixture.metadata)), orphanHash,
+		"ordinary metadata export preserves upgrade and direct-import blob semantics")
+	backupMetadata := exportBackupMetadata(t, fixture.metadata)
+	assert.NotContains(t, string(backupMetadata), orphanHash,
+		"backup metadata must omit provider output with no catalog authority")
+	assert.Contains(t, string(backupMetadata), stagedSourceHash,
+		"backup metadata exports every retained staged rendition build source")
+
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	manifest, err := backupapp.Create(
+		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs, backup.CreateOptions{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), manifest.Attachments.Rows,
+		"two original versions, two derivative artifacts, and one staged build source are the complete authority")
+	assert.Equal(t, int64(5), manifest.Attachments.Blobs)
+	assert.Equal(t, int64(len("alpha backup")+len("bravo backup")+len(evidence)+len(markdown)+len(stagedSource)),
+		manifest.Attachments.BlobBytes)
+	known, err := repo.LoadBlobIndex()
+	require.NoError(t, err)
+	refs, _, err := backup.LoadListRefs(repo, known, manifest.Attachments.Lists, nil, packstore.PackExt)
+	require.NoError(t, err)
+	assert.NotContains(t, refs, backup.ContentRef{Hash: orphanHash, Size: int64(len(orphanProviderOutput))})
+	assert.Contains(t, refs, backup.ContentRef{Hash: evidenceHash, Size: int64(len(evidence))})
+	assert.Contains(t, refs, backup.ContentRef{Hash: markdownHash, Size: int64(len(markdown))})
+	assert.Contains(t, refs, backup.ContentRef{Hash: stagedSourceHash, Size: int64(len(stagedSource))})
+	var snapshotStats struct {
+		DerivativeAuthority *struct {
+			Version           int      `json:"version"`
+			ProviderDependent []string `json:"provider_dependent"`
+			Classes           []struct {
+				Class          string `json:"class"`
+				Classification string `json:"classification"`
+				Count          int64  `json:"count"`
+				LogicalBytes   int64  `json:"logical_bytes"`
+				BlobCount      int64  `json:"blob_count"`
+				Checksum       string `json:"checksum"`
+			} `json:"classes"`
+		} `json:"derivative_authority"`
+	}
+	require.NoError(t, json.Unmarshal(manifest.Stats, &snapshotStats))
+	require.NotNil(t, snapshotStats.DerivativeAuthority)
+	authority := snapshotStats.DerivativeAuthority
+	assert.Equal(t, 1, authority.Version)
+	assert.Empty(t, authority.ProviderDependent, "no vector authority exists before the embedding foundation")
+	require.Len(t, authority.Classes, 3)
+	assert.Equal(t, "normalized_evidence", authority.Classes[0].Class)
+	assert.Equal(t, "included", authority.Classes[0].Classification)
+	assert.Equal(t, int64(2), authority.Classes[0].Count)
+	assert.Equal(t, int64(2*len(evidence)), authority.Classes[0].LogicalBytes)
+	assert.Equal(t, int64(1), authority.Classes[0].BlobCount)
+	assert.NotEmpty(t, authority.Classes[0].Checksum)
+	assert.Equal(t, "sanitized_markdown", authority.Classes[1].Class)
+	assert.Equal(t, "included", authority.Classes[1].Classification)
+	assert.Equal(t, int64(2), authority.Classes[1].Count)
+	assert.Equal(t, int64(2*len(markdown)), authority.Classes[1].LogicalBytes)
+	assert.Equal(t, int64(1), authority.Classes[1].BlobCount)
+	assert.NotEmpty(t, authority.Classes[1].Checksum)
+	assert.Equal(t, "lexical_projection", authority.Classes[2].Class)
+	assert.Equal(t, "reconstructible", authority.Classes[2].Classification)
+	assert.Equal(t, int64(2), authority.Classes[2].Count)
+	assert.Equal(t, int64(2*len("Synthetic backup rendition")), authority.Classes[2].LogicalBytes)
+	assert.Zero(t, authority.Classes[2].BlobCount)
+	assert.NotEmpty(t, authority.Classes[2].Checksum)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	result, err := backupapp.Restore(t.Context(), repo, "test-version", backup.RestoreOptions{TargetDir: target})
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), result.AttachmentBlobs)
+	assert.Equal(t, int64(5), result.PackedAttachmentBlobs)
+	assert.Zero(t, result.LooseAttachmentBlobs)
+	restored, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	_, err = restored.BlobInfo(t.Context(), orphanHash)
+	require.ErrorIs(t, err, store.ErrNotFound,
+		"restore must not publish an unreferenced provider-output blob row")
+	orphanID, err := packstore.ParseHash(orphanHash)
+	require.NoError(t, err)
+	orphanResolution, err := restored.ResolveBlobLocations(t.Context(), orphanID)
+	require.NoError(t, err)
+	assert.False(t, orphanResolution.Member,
+		"restore must not publish physical authority for unreferenced provider output")
+	for _, hash := range []string{source.BlobHash, evidenceHash, markdownHash, stagedSourceHash} {
+		want, sourceErr := fixture.metadata.BlobInfo(t.Context(), hash)
+		require.NoError(t, sourceErr)
+		got, restoreErr := restored.BlobInfo(t.Context(), hash)
+		require.NoError(t, restoreErr)
+		assert.Equal(t, want, got, "authorized blob record %s must remain byte-stable", hash)
+		id, parseErr := packstore.ParseHash(hash)
+		require.NoError(t, parseErr)
+		resolution, resolveErr := restored.ResolveBlobLocations(t.Context(), id)
+		require.NoError(t, resolveErr)
+		assert.True(t, resolution.Member)
+		assert.NotEmpty(t, resolution.Candidates)
+	}
+	_, err = restored.ActiveLexicalGeneration(t.Context())
+	require.NoError(t, err, "restore must rebuild the excluded lexical projection locally")
+	hits, truncated, err := restored.SearchPage(t.Context(), "Synthetic backup", 10)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, hits, 1)
+	assert.Equal(t, source.ID, hits[0].Node.ID)
+	assert.Zero(t, providerCalls.Load(), "restore must not contact the configured provider sentinel")
+
+	looseRepo, err := backup.Init(filepath.Join(t.TempDir(), "loose-repo"))
+	require.NoError(t, err)
+	_, err = backupapp.Create(
+		t.Context(), looseRepo, "test-version", fixture.metadata, fixture.blobs, backup.CreateOptions{},
+	)
+	require.NoError(t, err)
+	looseTarget := filepath.Join(t.TempDir(), "loose-restored")
+	looseResult, err := backupapp.RestoreWithPlacement(
+		t.Context(), looseRepo, "test-version", store.DefaultSQLiteDriver(),
+		backup.RestoreOptions{TargetDir: looseTarget},
+		backupapp.RestorePlacementOptions{Map: &backupapp.RestoreStoreMap{
+			Version: backupapp.RestoreStoreMapVersion,
+		}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), looseResult.AttachmentBlobs)
+	assert.Zero(t, looseResult.PackedAttachmentBlobs)
+	assert.Equal(t, int64(5), looseResult.LooseAttachmentBlobs)
+	looseStore, err := store.Open(filepath.Join(looseTarget, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, looseStore.Close()) })
+	_, err = looseStore.ActiveRendition(t.Context(), source.CurrentVersionID, profile.Fingerprint)
+	require.NoError(t, err)
+	assert.Zero(t, providerCalls.Load(), "loose restore must not contact the configured provider sentinel")
+
+	t.Run("rejects a staged rendition source whose restored packed authority disagrees", func(t *testing.T) {
+		originalMetadata := exportBackupMetadata(t, fixture.metadata)
+		mismatch := bytes.Replace(
+			originalMetadata,
+			[]byte(fmt.Sprintf(`"hash":"%s","size":%d,`, stagedSourceHash, len(stagedSource))),
+			[]byte(fmt.Sprintf(`"hash":"%s","size":%d,`, stagedSourceHash, len(stagedSource)-1)),
+			1,
+		)
+		require.NotEqual(t, originalMetadata, mismatch)
+		mismatchRepo, createErr := backup.Init(filepath.Join(t.TempDir(), "mismatch-repo"))
+		require.NoError(t, createErr)
+		_, createErr = backup.Create(t.Context(), mismatchRepo, backupapp.New("test-version"), backup.CreateOptions{
+			MetadataSource: overriddenMetadataSource{
+				source: backupapp.NewMetadataSource(fixture.metadata), metadata: mismatch,
+			},
+			ContentSource: backupapp.NewContentSource(fixture.blobs),
+		})
+		require.NoError(t, createErr)
+
+		failureTarget := filepath.Join(t.TempDir(), "preexisting-target")
+		beforeDigest := markRestoreTarget(t, failureTarget)
+		_, restoreErr := backupapp.Restore(t.Context(), mismatchRepo, "test-version", backup.RestoreOptions{
+			TargetDir: failureTarget, Overwrite: true,
+		})
+		require.ErrorContains(t, restoreErr, "rendition blob catalog size authority")
+		assertRestoreTargetUnchanged(t, failureTarget, beforeDigest)
+		assert.Zero(t, providerCalls.Load(), "authority rejection must not contact a provider")
+	})
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(t *testing.T, repo *backup.Repo, preseedIndex string, hash string)
+		want   string
+	}{
+		{
+			name: "missing authorized derivative",
+			mutate: func(t *testing.T, _ *backup.Repo, preseedIndex, _ string) {
+				t.Helper()
+				require.NoError(t, os.Remove(preseedIndex))
+			},
+			want: "not present in any index",
+		},
+		{
+			name: "checksum mismatched authorized derivative",
+			mutate: func(t *testing.T, repo *backup.Repo, _ string, hash string) {
+				t.Helper()
+				corruptArchiveBlob(t, repo, hash)
+			},
+			want: evidenceHash,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			corruptRepo, createErr := backup.Init(filepath.Join(t.TempDir(), "corrupt-repo"))
+			require.NoError(t, createErr)
+			preseedIndex := preseedArchiveBlob(t, corruptRepo, []byte(evidence))
+			_, createErr = backupapp.Create(
+				t.Context(), corruptRepo, "test-version", fixture.metadata, fixture.blobs, backup.CreateOptions{},
+			)
+			require.NoError(t, createErr)
+
+			failureTarget := filepath.Join(t.TempDir(), "existing-target")
+			_, restoreErr := backupapp.Restore(
+				t.Context(), corruptRepo, "test-version", backup.RestoreOptions{TargetDir: failureTarget},
+			)
+			require.NoError(t, restoreErr)
+			marker, markerErr := store.Open(filepath.Join(failureTarget, "docbank.db"))
+			require.NoError(t, markerErr)
+			_, markerErr = marker.Mkdir(t.Context(), marker.RootID(), "preexisting-restore-marker")
+			require.NoError(t, markerErr)
+			require.NoError(t, marker.Close())
+			beforeDigestData, readErr := os.ReadFile(filepath.Join(failureTarget, "docbank.db"))
+			require.NoError(t, readErr)
+			beforeDigestSum := sha256.Sum256(beforeDigestData)
+			beforeDigest := hex.EncodeToString(beforeDigestSum[:])
+			before := activeDerivative(t, failureTarget, source.CurrentVersionID, profile.Fingerprint)
+
+			tt.mutate(t, corruptRepo, preseedIndex, evidenceHash)
+			_, restoreErr = backupapp.Restore(
+				t.Context(), corruptRepo, "test-version",
+				backup.RestoreOptions{TargetDir: failureTarget, Overwrite: true},
+			)
+			require.ErrorContains(t, restoreErr, tt.want)
+			after := activeDerivative(t, failureTarget, source.CurrentVersionID, profile.Fingerprint)
+			assert.Equal(t, before.Head, after.Head, "failed restore must not publish a replacement head")
+			assert.Equal(t, before.Attachment.ID, after.Attachment.ID)
+			assert.Equal(t, before.Build.ID, after.Build.ID)
+			assertRestoreTargetUnchanged(t, failureTarget, beforeDigest)
+			assert.Zero(t, providerCalls.Load(), "failed restore must not contact the configured provider sentinel")
+		})
+	}
+}
+
+func preseedArchiveBlob(t *testing.T, repo *backup.Repo, raw []byte) string {
+	t.Helper()
+	known, err := repo.LoadBlobIndex()
+	require.NoError(t, err)
+	appender := backup.NewPackAppender(repo, known, pack.DefaultZstdLevel, nil, packstore.PackExt)
+	id, added, err := appender.Add(raw)
+	require.NoError(t, err)
+	assert.True(t, added)
+	assert.Equal(t, backupHash(string(raw)), id.String())
+	_, entries, err := appender.Finish()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	indexID, err := repo.WriteIndex(entries)
+	require.NoError(t, err)
+	return repo.Path("indexes", indexID+".mvidx")
+}
+
+func corruptArchiveBlob(t *testing.T, repo *backup.Repo, hash string) {
+	t.Helper()
+	id, err := pack.ParseBlobID(hash)
+	require.NoError(t, err)
+	known, err := repo.LoadBlobIndex()
+	require.NoError(t, err)
+	entry, ok := known[id]
+	require.True(t, ok)
+	path := repo.Path("packs", entry.PackID[:2], entry.PackID+packstore.PackExt)
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	var byteAtEntry [1]byte
+	_, err = file.ReadAt(byteAtEntry[:], int64(entry.Offset))
+	require.NoError(t, err)
+	byteAtEntry[0] ^= 0xff
+	_, err = file.WriteAt(byteAtEntry[:], int64(entry.Offset))
+	require.NoError(t, err)
+	require.NoError(t, file.Sync())
+	require.NoError(t, file.Close())
+}
+
+func activeDerivative(t *testing.T, target, versionID, profileID string) store.RenditionView {
+	t.Helper()
+	metadata, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, metadata.Close()) }()
+	view, err := metadata.ActiveRendition(t.Context(), versionID, profileID)
+	require.NoError(t, err)
+	return view
+}
+
+const backupCapturedArtifactPolicy = `{"roles":[{"max_count":1,"min_count":1,"role":"normalized_evidence"},{"max_count":1,"min_count":1,"role":"sanitized_markdown"}],"version":1}`
+
+func backupHash(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
+}
+
+func backupProcessingProfile(t *testing.T) store.ProcessingProfileRecord {
+	t.Helper()
+	profile := document.ProcessingProfileV1{
+		ContractVersion: document.ProcessingProfileContractV1,
+		Rendition: &document.RenditionBindingV1{
+			AdapterContract: "rendition-adapter/v1", AuthorizationFingerprint: backupHash("authorization-binding"),
+			CredentialBinding: "credential:synthetic", DeploymentFingerprint: backupHash("deployment"),
+			Descriptor:            document.ProviderDescriptorV1{ID: "synthetic-rendition", Fingerprint: backupHash("provider")},
+			DisclosureFingerprint: backupHash("disclosure"), MaxDocumentBytes: 1 << 20,
+			MaxResponseBytes: 1 << 20, MaxUnits: 100, Name: "primary",
+			RequestedArtifacts: []document.EvidenceArtifactRole{document.EvidenceArtifactStructured},
+			TrustBoundary:      "synthetic-vault", UploadOptionsFingerprint: backupHash("upload-options"),
+		},
+		EvidenceLexical: document.EvidenceLexicalPolicyV1{
+			CompletenessFingerprint: backupHash("completeness"), LexicalSegmenterFingerprint: backupHash("segmenter"),
+			MaxSegmentRunes: 100, MaxUnitRunes: 1_000,
+			NormalizedEvidenceContract: document.NormalizedEvidenceContractV1,
+			NormalizerFingerprint:      backupHash("normalizer"), RenditionContract: document.RenditionContractV1,
+			SanitizerFingerprint: backupHash("sanitizer"), SourceEvidenceContract: document.SourceEvidenceContractV1,
+		},
+		Retrieval: document.RetrievalPolicyV1{LexicalLimit: 100, VectorLimit: 100},
+		RetentionDisclosure: document.RetentionDisclosurePolicyV1{
+			AttachmentPolicyFingerprint: backupHash("attachment-policy"), ConsentFingerprint: backupHash("consent"),
+			RetainSanitizedMarkdown: true, RetainTypedArtifacts: true, TrustBoundary: "synthetic-vault",
+		},
+	}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	require.NoError(t, err)
+	return store.ProcessingProfileRecord{
+		Fingerprint: fingerprints.Profile, CanonicalProfile: jsontext.Value(canonical),
+		RenditionRequestFingerprint:    fingerprints.RenditionRequest,
+		EvidenceLexicalFingerprint:     fingerprints.EvidenceLexical,
+		RetentionDisclosureFingerprint: fingerprints.RetentionDisclosure,
+		AttachmentPolicyFingerprint:    profile.RetentionDisclosure.AttachmentPolicyFingerprint,
+		ConsentFingerprint:             profile.RetentionDisclosure.ConsentFingerprint,
+		RenditionDisclosureFingerprint: profile.Rendition.DisclosureFingerprint,
+		TrustBoundary:                  profile.RetentionDisclosure.TrustBoundary,
+	}
+}
+
+// legacyMetadataSnapshot reproduces the pre-scope v1 capture surface: every
+// blobs row in the attachment lists and metadata stream, and fidelity stats
+// counted over the complete tables rather than catalog authority.
+type legacyMetadataSource struct{ metadata *store.Store }
+
+func (legacyMetadataSource) Format() string { return backupapp.MetadataFormat }
+
+func (s legacyMetadataSource) OpenSnapshot(
+	ctx context.Context,
+) (backup.MetadataSnapshot, error) {
+	embedded, err := backupapp.NewMetadataSource(s.metadata).OpenSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	pinned, err := s.metadata.BeginMetadataSnapshot(ctx)
+	if err != nil {
+		_ = embedded.Close()
+		return nil, err
+	}
+	return legacyMetadataSnapshot{MetadataSnapshot: embedded, pinned: pinned}, nil
+}
+
+type legacyMetadataSnapshot struct {
+	backup.MetadataSnapshot
+
+	pinned *store.MetadataSnapshot
+}
+
+func (s legacyMetadataSnapshot) OpenMetadata(
+	ctx context.Context,
+) (io.ReadCloser, int64, error) {
+	var buffer bytes.Buffer
+	if err := s.pinned.Export(ctx, &buffer); err != nil {
+		return nil, 0, err
+	}
+	return io.NopCloser(bytes.NewReader(buffer.Bytes())), int64(buffer.Len()), nil
+}
+
+func (s legacyMetadataSnapshot) ContentInfo(
+	ctx context.Context,
+) (*backup.ContentInfo, error) {
+	rows, err := s.pinned.QueryContext(ctx, `SELECT hash, size FROM blobs ORDER BY hash`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var refs []backup.ContentRef
+	for rows.Next() {
+		var ref backup.ContentRef
+		if err := rows.Scan(&ref.Hash, &ref.Size); err != nil {
+			return nil, err
+		}
+		parsed, err := packstore.ParseHash(ref.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("legacy blob hash %q: %w", ref.Hash, err)
+		}
+		_ = parsed
+		refs = append(refs, ref)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return &backup.ContentInfo{Refs: refs, Rows: int64(len(refs))}, nil
+}
+
+func (s legacyMetadataSnapshot) Stats(ctx context.Context) (jsontext.Value, error) {
+	stats := backupapp.Stats{}
+	counts := []struct {
+		dst   *int64
+		query string
+	}{
+		{&stats.Nodes, `SELECT COUNT(*) FROM nodes`},
+		{&stats.Files, `SELECT COUNT(*) FROM nodes WHERE kind = 'file'`},
+		{&stats.Directories, `SELECT COUNT(*) FROM nodes WHERE kind = 'dir'`},
+		{&stats.TrashedNodes, `SELECT COUNT(*) FROM nodes WHERE trashed_at IS NOT NULL`},
+		{&stats.ContentVersions, `SELECT COUNT(*) FROM content_versions`},
+		{&stats.Ingests, `SELECT COUNT(*) FROM ingests`},
+		{&stats.Provenance, `SELECT COUNT(*) FROM provenance`},
+		{&stats.Tags, `SELECT COUNT(*) FROM tags`},
+		{&stats.NodeTags, `SELECT COUNT(*) FROM node_tags`},
+	}
+	for _, count := range counts {
+		if err := s.pinned.QueryRowContext(ctx, count.query).Scan(count.dst); err != nil {
+			return nil, err
+		}
+	}
+	if err := s.pinned.QueryRowContext(ctx,
+		`SELECT COUNT(*), COALESCE(SUM(size), 0) FROM blobs`,
+	).Scan(&stats.Blobs, &stats.BlobBytes); err != nil {
+		return nil, err
+	}
+	if err := s.pinned.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM extracted_text`).Scan(&stats.ExtractedText); err != nil {
+		return nil, err
+	}
+	return json.Marshal(stats)
+}
+
+func (s legacyMetadataSnapshot) Close() error {
+	return errors.Join(s.pinned.Close(), s.MetadataSnapshot.Close())
+}
+
+func TestLegacyUnscopedSnapshotWithUnreachableBlobRestoresFaithfully(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	orphanPayload := "synthetic pre-scope unreferenced blob"
+	var orphanHash string
+	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
+		receipt, writeErr := fixture.blobs.WriteDetailedContext(
+			t.Context(), strings.NewReader(orphanPayload),
+		)
+		if writeErr != nil {
+			return writeErr
+		}
+		encoding, err := receipt.EncodingName()
+		if err != nil {
+			return err
+		}
+		orphanHash = receipt.Hash
+		if err := fixture.metadata.RecordRenditionBlob(t.Context(), receipt.Hash, receipt.Size,
+			store.BlobPhysical{Encoding: encoding, StoredBytes: receipt.StoredSize,
+				PackEligible: receipt.PackEligible, Created: receipt.Created}); err != nil {
+			return err
+		}
+		return fixture.metadata.RecordExtraction(t.Context(), store.ExtractionResult{
+			BlobHash: orphanHash, Extractor: "synthetic-legacy-extractor", ExtractorVersion: 1,
+			Status: store.ExtractionOK, Text: "synthetic legacy extraction",
+		})
+	}))
+
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "legacy-repo"))
+	require.NoError(t, err)
+	manifest, err := backup.Create(t.Context(), repo, backupapp.New("legacy-version"),
+		backup.CreateOptions{
+			MetadataSource: legacyMetadataSource{metadata: fixture.metadata},
+			ContentSource:  backupapp.NewContentSource(fixture.blobs),
+		})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), manifest.Attachments.Blobs,
+		"a legacy snapshot captured every blobs row including the unreachable one")
+	stats, err := backupapp.ParseStats(manifest.Stats)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.Blobs)
+	assert.Equal(t, int64(1), stats.ExtractedText)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	result, err := backupapp.Restore(t.Context(), repo, "legacy-version",
+		backup.RestoreOptions{TargetDir: target, Jobs: 2},
+	)
+	require.NoError(t, err,
+		"a pre-scope v1 snapshot containing an unreachable blob must restore faithfully")
+	assert.Equal(t, int64(3), result.AttachmentBlobs)
+
+	restored, err := store.Open(filepath.Join(target, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	info, err := restored.BlobInfo(t.Context(), orphanHash)
+	require.NoError(t, err, "the legacy snapshot's unreachable blob row must be restored")
+	assert.Equal(t, int64(len(orphanPayload)), info.Size)
+	restoredBlobs, err := blob.New(
+		store.NewPackCatalog(restored), filepath.Join(target, "blobs"),
+	)
+	require.NoError(t, err)
+	reader, err := restoredBlobs.OpenContext(t.Context(), orphanHash)
+	require.NoError(t, err)
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, orphanPayload, string(got),
+		"the legacy snapshot's unreachable blob bytes must be materialized")
+	require.NoError(t, restoredBlobs.Close())
+}
+
+func TestDerivativeAuthorityCoversEveryProviderArtifactRole(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	evidence := "synthetic normalized evidence"
+	markdown := "# Synthetic provider-role rendition\n"
+	rolePayloads := []struct {
+		role    document.EvidenceArtifactRole
+		payload string
+	}{
+		{document.EvidenceArtifactImage, "synthetic provider image payload"},
+		{document.EvidenceArtifactMarkdown, "synthetic provider markdown payload"},
+		{document.EvidenceArtifactStructured, "synthetic structured evidence payload"},
+		{document.EvidenceArtifactTranscript, "synthetic provider transcript payload"},
+	}
+	hashes := map[string]string{}
+	require.NoError(t, fixture.blobs.WithMutation(t.Context(), func() error {
+		write := func(key, payload string) error {
+			receipt, writeErr := fixture.blobs.WriteDetailedContext(
+				t.Context(), strings.NewReader(payload),
+			)
+			if writeErr != nil {
+				return writeErr
+			}
+			encoding, err := receipt.EncodingName()
+			if err != nil {
+				return err
+			}
+			hashes[key] = receipt.Hash
+			return fixture.metadata.RecordRenditionBlob(t.Context(), receipt.Hash, receipt.Size,
+				store.BlobPhysical{Encoding: encoding, StoredBytes: receipt.StoredSize,
+					PackEligible: receipt.PackEligible, Created: receipt.Created})
+		}
+		if err := write("normalized_evidence", evidence); err != nil {
+			return err
+		}
+		if err := write("sanitized_markdown", markdown); err != nil {
+			return err
+		}
+		for _, entry := range rolePayloads {
+			if err := write(string(entry.role), entry.payload); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	source, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")
+	require.NoError(t, err)
+	policy := `{"roles":[` +
+		`{"max_count":1,"min_count":1,"role":"normalized_evidence"},` +
+		`{"max_count":1,"min_count":1,"role":"provider_image"},` +
+		`{"max_count":1,"min_count":1,"role":"provider_markdown"},` +
+		`{"max_count":1,"min_count":1,"role":"provider_transcript"},` +
+		`{"max_count":1,"min_count":1,"role":"sanitized_markdown"},` +
+		`{"max_count":1,"min_count":1,"role":"structured_evidence"}` +
+		`],"version":1}`
+	artifacts := []store.RenditionArtifactRecord{
+		{ID: "artifact_evidence", Role: "normalized_evidence", BlobHash: hashes["normalized_evidence"],
+			Size: int64(len(evidence)), Checksum: hashes["normalized_evidence"],
+			State: store.RenditionArtifactVerified},
+		{ID: "artifact_markdown", Role: "sanitized_markdown", BlobHash: hashes["sanitized_markdown"],
+			Size: int64(len(markdown)), Checksum: hashes["sanitized_markdown"],
+			State: store.RenditionArtifactVerified},
+	}
+	for _, entry := range rolePayloads {
+		artifacts = append(artifacts, store.RenditionArtifactRecord{
+			ID: "artifact_" + strings.ToLower(string(entry.role)), Role: string(entry.role),
+			BlobHash: hashes[string(entry.role)], Size: int64(len(entry.payload)),
+			Checksum: hashes[string(entry.role)], State: store.RenditionArtifactVerified,
+		})
+	}
+	profile := backupProcessingProfile(t)
+	build := store.RenditionBuildRecord{
+		ID:                                backupHash("provider-role-build"),
+		VaultID:                           fixture.metadata.VaultID(),
+		SourceSHA256:                      source.BlobHash,
+		RenditionRequestFingerprint:       profile.RenditionRequestFingerprint,
+		EvidenceLexicalFingerprint:        profile.EvidenceLexicalFingerprint,
+		CapturedArtifactPolicyFingerprint: backupHash(policy),
+		CapturedArtifactPolicy:            jsontext.Value(policy),
+		AuthorizationChecksum:             backupHash("authorization"),
+		ProviderOperationID:               "synthetic-provider-operation",
+		ProviderReceipt:                   jsontext.Value(`{"provider":"synthetic"}`),
+		EvidenceChecksum:                  hashes["normalized_evidence"],
+		RenditionChecksum:                 backupHash("rendition"),
+		MarkdownChecksum:                  hashes["sanitized_markdown"],
+		Completeness:                      document.EvidenceComplete,
+		Warnings:                          []string{},
+		CompletedAt:                       "2026-08-23T00:00:00.000000000Z",
+		DeclaredArtifactCount:             len(artifacts),
+		Artifacts:                         artifacts,
+		Units: []store.RenditionUnitRecord{{
+			ID: "unit", EvidenceUnitID: "evidence-unit", Order: 0, Checksum: backupHash("unit"),
+			HeadingPath: []string{"Synthetic provider-role rendition"},
+			Locator: document.EvidenceLocatorV1{Kind: document.EvidenceLocatorPage,
+				IndexOrigin: document.EvidenceIndexOriginOne, Start: 1, End: 1},
+		}},
+		LexicalSegments: []store.RenditionLexicalSegmentRecord{{
+			ID: "segment", UnitID: "unit", Order: 0, CharStart: 0,
+			CharEnd: len("Synthetic provider-role rendition"), Checksum: backupHash("segment"),
+			Text: "Synthetic provider-role rendition",
+		}},
+	}
+	require.NoError(t, fixture.metadata.StageRenditionBuild(t.Context(), build))
+
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	manifest, err := backupapp.Create(
+		t.Context(), repo, "test-version", fixture.metadata, fixture.blobs, backup.CreateOptions{},
+	)
+	require.NoError(t, err,
+		"every catalog-authorized provider artifact role must be capturable")
+	stats, err := backupapp.ParseStats(manifest.Stats)
+	require.NoError(t, err)
+	require.NotNil(t, stats.DerivativeAuthority)
+	var classes []string
+	for _, class := range stats.DerivativeAuthority.Classes {
+		classes = append(classes, class.Class)
+		want := "included"
+		if class.Class == "lexical_projection" {
+			want = "reconstructible"
+		}
+		assert.Equal(t, want, class.Classification)
+		assert.Equal(t, int64(1), class.Count)
+	}
+	assert.Equal(t, []string{
+		"normalized_evidence", "sanitized_markdown",
+		"provider_image", "provider_markdown", "structured_evidence",
+		"provider_transcript", "lexical_projection",
+	}, classes)
 }

--- a/internal/backupapp/app_test.go
+++ b/internal/backupapp/app_test.go
@@ -973,6 +973,78 @@ func TestCompressedLooseSnapshotRestoresIndexedAuthority(t *testing.T) {
 	require.NoError(t, reader.Close())
 }
 
+func TestStagedRenditionVerificationReadsLooseZstdAuthority(t *testing.T) {
+	root := t.TempDir()
+	databasePath := filepath.Join(root, "docbank.db")
+	metadata, err := store.Open(databasePath)
+	require.NoError(t, err)
+	blobsDir := filepath.Join(root, "blobs")
+	require.NoError(t, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
+	blobs, err := blob.NewWithOptions(store.NewPackCatalog(metadata), blobsDir, blob.Options{
+		LooseCompression: blob.LooseCompressionOptions{
+			Enabled: true, MinBytes: 1, MinSavingsPercent: 0,
+		},
+	})
+	require.NoError(t, err)
+
+	content := strings.Repeat("synthetic staged rendition source\n", 64)
+	var sourceHash string
+	require.NoError(t, blobs.WithMutation(t.Context(), func() error {
+		receipt, writeErr := blobs.WriteDetailedContext(t.Context(), strings.NewReader(content))
+		if writeErr != nil {
+			return writeErr
+		}
+		if receipt.Encoding != packstore.LooseEncodingZstd {
+			return fmt.Errorf("staged rendition encoding = %v, want zstd", receipt.Encoding)
+		}
+		sourceHash = receipt.Hash
+		node, createErr := metadata.CreateFile(
+			t.Context(), metadata.RootID(), "staged.txt",
+			receipt.Hash, receipt.Size, "text/plain",
+			store.BlobPhysical{
+				Encoding: "zstd", StoredBytes: receipt.StoredSize,
+				PackEligible: receipt.PackEligible, Created: receipt.Created,
+			},
+		)
+		if createErr != nil {
+			return createErr
+		}
+		return metadata.RecordExtraction(t.Context(), store.ExtractionResult{
+			BlobHash: node.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+			Status: store.ExtractionOK, Text: "synthetic extracted text",
+		})
+	}))
+	report, err := metadata.MigrateLegacyPlainText(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, report.MigratedBuilds)
+	require.NoError(t, blobs.Close())
+	require.NoError(t, metadata.Close())
+
+	driver := store.DefaultSQLiteDriver()
+	raw, err := driver.Open(databasePath, docsqlite.OpenOptions{
+		Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+	})
+	require.NoError(t, err)
+	_, err = raw.ExecContext(t.Context(), `DELETE FROM rendition_heads`)
+	require.NoError(t, err)
+	_, err = raw.ExecContext(t.Context(), `DELETE FROM rendition_attachments`)
+	require.NoError(t, err)
+	_, err = raw.ExecContext(t.Context(), `UPDATE blobs SET size=size-1 WHERE hash=?`, sourceHash)
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	restored, err := store.OpenForRestore(databasePath, driver)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, restored.Close()) }()
+	restoredBlobs, err := blob.New(store.NewPackCatalog(restored), blobsDir)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, restoredBlobs.Close()) }()
+	require.NoError(t, restored.VerifyRenditionBlobAuthority(t.Context()),
+		"the catalog-only check cannot derive decoded zstd length")
+	err = restored.VerifyRenditionBlobBytes(t.Context(), restoredBlobs)
+	require.ErrorContains(t, err, "opening restored rendition blob "+sourceHash)
+}
+
 func TestAuditedIncrementalSnapshotRestoresCompleteProtectedHistory(t *testing.T) {
 	fixture := newArchiveFixture(t)
 	writeFile := func(parentID int64, name, content string) store.Node {
@@ -2036,7 +2108,7 @@ func TestDerivativeAuthoritySnapshotRestoresCatalogBlobsAndRebuildsLexicalProjec
 		_, restoreErr := backupapp.Restore(t.Context(), mismatchRepo, "test-version", backup.RestoreOptions{
 			TargetDir: failureTarget, Overwrite: true,
 		})
-		require.ErrorContains(t, restoreErr, "rendition blob catalog size authority")
+		require.ErrorContains(t, restoreErr, "restored rendition blob "+stagedSourceHash+" size")
 		assertRestoreTargetUnchanged(t, failureTarget, beforeDigest)
 		assert.Zero(t, providerCalls.Load(), "authority rejection must not contact a provider")
 	})
@@ -2227,6 +2299,20 @@ type legacyMetadataSnapshot struct {
 	pinned *store.MetadataSnapshot
 }
 
+func (s legacyMetadataSnapshot) AuxiliaryArtifacts(
+	ctx context.Context,
+) ([]backup.AuxiliaryArtifact, error) {
+	source, ok := s.MetadataSnapshot.(backup.AuxiliarySource)
+	if !ok {
+		return nil, nil
+	}
+	artifacts, err := source.AuxiliaryArtifacts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("opening legacy metadata auxiliary artifacts: %w", err)
+	}
+	return artifacts, nil
+}
+
 func (s legacyMetadataSnapshot) OpenMetadata(
 	ctx context.Context,
 ) (io.ReadCloser, int64, error) {
@@ -2299,6 +2385,43 @@ func (s legacyMetadataSnapshot) Stats(ctx context.Context) (jsontext.Value, erro
 
 func (s legacyMetadataSnapshot) Close() error {
 	return errors.Join(s.pinned.Close(), s.MetadataSnapshot.Close())
+}
+
+func TestPlacementRestoreDoesNotMigrateLegacySnapshotBeforePublication(t *testing.T) {
+	fixture := newArchiveFixture(t)
+	alpha, err := fixture.metadata.NodeByPath(t.Context(), "/alpha.txt")
+	require.NoError(t, err)
+	require.NoError(t, fixture.metadata.RecordExtraction(t.Context(), store.ExtractionResult{
+		BlobHash: alpha.BlobHash, Extractor: "plain-text", ExtractorVersion: 1,
+		Status: store.ExtractionOK, Text: "synthetic legacy searchable text",
+	}))
+	wantMetadata := exportMetadata(t, fixture.metadata)
+
+	repo, err := backup.Init(filepath.Join(t.TempDir(), "legacy-placement-repo"))
+	require.NoError(t, err)
+	_, err = backup.Create(t.Context(), repo, backupapp.New("legacy-version"),
+		backup.CreateOptions{
+			MetadataSource: legacyMetadataSource{metadata: fixture.metadata},
+			ContentSource:  backupapp.NewContentSource(fixture.blobs),
+		})
+	require.NoError(t, err)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	_, err = backupapp.RestoreWithPlacement(
+		t.Context(), repo, "legacy-version", store.DefaultSQLiteDriver(),
+		backup.RestoreOptions{TargetDir: target},
+		backupapp.RestorePlacementOptions{Map: &backupapp.RestoreStoreMap{
+			Version: backupapp.RestoreStoreMapVersion,
+		}},
+	)
+	require.NoError(t, err)
+	restored, err := store.OpenForRestore(
+		filepath.Join(target, "docbank.db"), store.DefaultSQLiteDriver(),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, restored.Close()) }()
+	assert.Equal(t, string(wantMetadata), string(exportMetadata(t, restored)),
+		"placement reconstruction must not add rendition authority absent from the snapshot")
 }
 
 func TestLegacyUnscopedSnapshotWithUnreachableBlobRestoresFaithfully(t *testing.T) {

--- a/internal/backupapp/metadata.go
+++ b/internal/backupapp/metadata.go
@@ -2,15 +2,20 @@ package backupapp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json/jsontext"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"math"
 	"os"
+	"strconv"
 
 	"go.kenn.io/kit/backup"
 
+	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/internal/store"
 	docsqlite "go.kenn.io/docbank/sqlite"
 )
@@ -18,6 +23,164 @@ import (
 // MetadataFormat is the stable Kit manifest identifier for Docbank's
 // deterministic logical metadata stream.
 const MetadataFormat = "docbank-metadata-jsonl-v1"
+
+const derivativeAuthorityVersion = 1
+
+// DerivativeAuthorityStats describes the catalog-authorized derivative
+// authority pinned by one backup snapshot. Future derivative classes extend
+// this versioned list; absent classes do not claim unavailable coverage.
+type DerivativeAuthorityStats struct {
+	Version           int                    `json:"version"`
+	Classes           []DerivativeClassStats `json:"classes"`
+	ProviderDependent []string               `json:"provider_dependent"`
+}
+
+// DerivativeClassStats records one current derivative class. Checksum is a
+// deterministic digest of the class's catalog records, not provider output.
+type DerivativeClassStats struct {
+	Class          string `json:"class"`
+	Classification string `json:"classification"`
+	Count          int64  `json:"count"`
+	LogicalBytes   int64  `json:"logical_bytes"`
+	BlobCount      int64  `json:"blob_count"`
+	Checksum       string `json:"checksum"`
+}
+
+type derivativeClassAccumulator struct {
+	DerivativeClassStats
+
+	checksum hash.Hash
+	blobs    map[string]struct{}
+}
+
+func computeDerivativeAuthorityStats(ctx context.Context, q rowQuerier) (*DerivativeAuthorityStats, bool, error) {
+	classes := make(map[string]*derivativeClassAccumulator)
+	get := func(classification, class string) *derivativeClassAccumulator {
+		item := classes[class]
+		if item != nil {
+			return item
+		}
+		item = &derivativeClassAccumulator{
+			Class: class, Classification: classification,
+			checksum: sha256.New(),
+			blobs:    make(map[string]struct{}),
+		}
+		writeDerivativeClassField(item.checksum, class)
+		writeDerivativeClassField(item.checksum, classification)
+		classes[class] = item
+		return item
+	}
+
+	if err := func() error {
+		rows, err := q.QueryContext(ctx, `
+			SELECT role,build_id,artifact_id,blob_hash,size,checksum
+			FROM rendition_artifacts
+			ORDER BY role,build_id,artifact_id`)
+		if err != nil {
+			return fmt.Errorf("listing derivative artifacts: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var role, buildID, artifactID, blobHash, checksum string
+			var size int64
+			if err := rows.Scan(&role, &buildID, &artifactID, &blobHash, &size, &checksum); err != nil {
+				return fmt.Errorf("scanning derivative artifact: %w", err)
+			}
+			item := get("included", role)
+			if err := addDerivativeClassBytes(&item.LogicalBytes, size); err != nil {
+				return fmt.Errorf("derivative class %s: %w", role, err)
+			}
+			item.Count++
+			item.blobs[blobHash] = struct{}{}
+			for _, field := range []string{buildID, artifactID, blobHash, checksum, strconv.FormatInt(size, 10)} {
+				writeDerivativeClassField(item.checksum, field)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterating derivative artifacts: %w", err)
+		}
+		return nil
+	}(); err != nil {
+		return nil, false, fmt.Errorf("backupapp: %w", err)
+	}
+
+	if err := func() error {
+		rows, err := q.QueryContext(ctx, `
+			SELECT build_id,segment_id,checksum,text
+			FROM rendition_lexical_segments
+			ORDER BY build_id,segment_order,segment_id`)
+		if err != nil {
+			return fmt.Errorf("listing lexical projection: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var buildID, segmentID, checksum, text string
+			if err := rows.Scan(&buildID, &segmentID, &checksum, &text); err != nil {
+				return fmt.Errorf("scanning lexical projection: %w", err)
+			}
+			item := get("reconstructible", "lexical_projection")
+			if err := addDerivativeClassBytes(&item.LogicalBytes, int64(len(text))); err != nil {
+				return fmt.Errorf("lexical projection: %w", err)
+			}
+			item.Count++
+			for _, field := range []string{buildID, segmentID, checksum, text} {
+				writeDerivativeClassField(item.checksum, field)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterating lexical projection: %w", err)
+		}
+		return nil
+	}(); err != nil {
+		return nil, false, fmt.Errorf("backupapp: %w", err)
+	}
+
+	if len(classes) == 0 {
+		return nil, false, nil
+	}
+	// Class names are the exact rendition_artifacts.role values the catalog
+	// persists (document.EvidenceArtifact* constants plus the two catalog-local
+	// roles); lexical_projection is synthesized above from segment rows.
+	ordered := []string{
+		"normalized_evidence", "sanitized_markdown",
+		string(document.EvidenceArtifactImage),
+		string(document.EvidenceArtifactMarkdown),
+		string(document.EvidenceArtifactStructured),
+		string(document.EvidenceArtifactTranscript),
+		"lexical_projection",
+	}
+	result := &DerivativeAuthorityStats{
+		Version: derivativeAuthorityVersion, ProviderDependent: []string{},
+	}
+	for _, class := range ordered {
+		item := classes[class]
+		if item == nil {
+			continue
+		}
+		item.BlobCount = int64(len(item.blobs))
+		item.Checksum = hex.EncodeToString(item.checksum.Sum(nil))
+		result.Classes = append(result.Classes, item.DerivativeClassStats)
+		delete(classes, class)
+	}
+	if len(classes) != 0 {
+		return nil, false, errors.New("backupapp: derivative artifact class is not catalog-authorized")
+	}
+	return result, true, nil
+}
+
+func addDerivativeClassBytes(total *int64, value int64) error {
+	if value < 0 || value > math.MaxInt64-*total {
+		return errors.New("logical bytes exceed int64")
+	}
+	*total += value
+	return nil
+}
+
+func writeDerivativeClassField(dst hash.Hash, value string) {
+	_, _ = io.WriteString(dst, strconv.Itoa(len(value)))
+	_, _ = io.WriteString(dst, ":")
+	_, _ = io.WriteString(dst, value)
+}
 
 // MetadataSource pins one Docbank transaction for JSONL, content membership,
 // and fidelity statistics. OpenMetadata performs a counting pass and then
@@ -62,14 +225,14 @@ func (s *metadataSnapshot) OpenMetadata(ctx context.Context) (io.ReadCloser, int
 	}
 	s.opened = true
 	var count byteCounter
-	if err := s.tx.Export(ctx, &count); err != nil {
+	if err := s.tx.ExportBackup(ctx, &count); err != nil {
 		return nil, 0, fmt.Errorf("backupapp: sizing metadata JSONL: %w", err)
 	}
 	reader, writer := io.Pipe()
 	s.reader = reader
 	s.exportDone = make(chan error, 1)
 	go func() {
-		exportErr := s.tx.Export(ctx, writer)
+		exportErr := s.tx.ExportBackup(ctx, writer)
 		closeErr := writer.CloseWithError(exportErr)
 		s.exportDone <- errors.Join(exportErr, closeErr)
 	}()

--- a/internal/backupapp/placement.go
+++ b/internal/backupapp/placement.go
@@ -13,6 +13,8 @@ import (
 	"go.kenn.io/kit/backup"
 	"go.kenn.io/kit/pack"
 	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/internal/store"
 )
 
 const (
@@ -63,11 +65,14 @@ func (s *metadataSnapshot) AuxiliaryArtifacts(
 }
 
 func encodePlacementManifest(ctx context.Context, q rowQuerier) ([]byte, error) {
-	rows, err := q.QueryContext(ctx, `
+	rows, err := q.QueryContext(ctx, store.BackupBlobAuthorityCTE+`
 		SELECT s.store_id, s.name, s.kind, s.role,
 		       COUNT(l.blob_hash), COALESCE(SUM(b.size), 0)
 		FROM blob_stores s
-		LEFT JOIN blob_locations l ON l.store_id = s.store_id
+		LEFT JOIN (
+			SELECT l.* FROM blob_locations l
+			JOIN backup_authorized_blobs a ON a.hash = l.blob_hash
+		) l ON l.store_id = s.store_id
 		LEFT JOIN blobs b ON b.hash = l.blob_hash
 		GROUP BY s.store_id, s.name, s.kind, s.role
 		ORDER BY CASE s.role WHEN 'primary' THEN 0 ELSE 1 END, s.name, s.store_id`)
@@ -95,9 +100,9 @@ func encodePlacementManifest(ctx context.Context, q rowQuerier) ([]byte, error) 
 		return nil, fmt.Errorf("backupapp: closing placement stores: %w", err)
 	}
 
-	rows, err = q.QueryContext(ctx, `
+	rows, err = q.QueryContext(ctx, store.BackupBlobAuthorityCTE+`
 		SELECT b.hash, l.store_id
-		FROM blobs b
+		FROM blobs b JOIN backup_authorized_blobs a ON a.hash = b.hash
 		LEFT JOIN blob_locations l ON l.blob_hash = b.hash
 		ORDER BY b.hash, l.store_id`)
 	if err != nil {

--- a/internal/backupapp/restore.go
+++ b/internal/backupapp/restore.go
@@ -257,7 +257,7 @@ func verifyRestoredRenditionHeads(
 	defer func() {
 		retErr = errors.Join(retErr, physical.Close())
 	}()
-	if err := metadata.VerifyRenditionHeadBytes(ctx, physical); err != nil {
+	if err := metadata.VerifyRenditionBlobBytes(ctx, physical); err != nil {
 		return fmt.Errorf("backupapp: verifying restored rendition bytes: %w", err)
 	}
 	if err := metadata.RebuildRenditionLexicalProjection(ctx); err != nil {

--- a/internal/backupapp/restore.go
+++ b/internal/backupapp/restore.go
@@ -238,13 +238,16 @@ func RestoreWithPlacement(
 func verifyRestoredRenditionHeads(
 	ctx context.Context, target, databasePath string, driver docsqlite.Driver,
 ) (retErr error) {
-	metadata, err := store.Open(databasePath, driver)
+	metadata, err := store.OpenForRestore(databasePath, driver)
 	if err != nil {
 		return fmt.Errorf("backupapp: opening restored rendition catalog: %w", err)
 	}
 	defer func() {
 		retErr = errors.Join(retErr, metadata.Close())
 	}()
+	if err := metadata.VerifyRenditionBlobAuthority(ctx); err != nil {
+		return fmt.Errorf("backupapp: verifying restored rendition authority: %w", err)
+	}
 	physical, err := blob.NewPreparedRestoreReader(
 		store.NewPackCatalog(metadata), filepath.Join(target, "blobs"),
 	)
@@ -256,6 +259,9 @@ func verifyRestoredRenditionHeads(
 	}()
 	if err := metadata.VerifyRenditionHeadBytes(ctx, physical); err != nil {
 		return fmt.Errorf("backupapp: verifying restored rendition bytes: %w", err)
+	}
+	if err := metadata.RebuildRenditionLexicalProjection(ctx); err != nil {
+		return fmt.Errorf("backupapp: rebuilding restored lexical projection: %w", err)
 	}
 	return nil
 }

--- a/internal/backupapp/restore_placement.go
+++ b/internal/backupapp/restore_placement.go
@@ -324,7 +324,7 @@ func applyRestorePlacement(
 	if err := config.EnsureStoreBindings(target, restoreBindings); err != nil {
 		return fmt.Errorf("backupapp: provisioning restored store bindings: %w", err)
 	}
-	metadata, err := store.Open(databasePath, driver)
+	metadata, err := store.OpenForRestore(databasePath, driver)
 	if err != nil {
 		return fmt.Errorf("backupapp: opening restored placement catalog: %w", err)
 	}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -622,7 +622,7 @@ func (s *Store) ImportMetadata(ctx context.Context, r io.Reader) error {
 }
 
 // ImportMetadataForBackupRestore imports logical metadata before Kit restores
-// physical content. The backup restore must call VerifyRenditionHeadBytes after
+// physical content. The backup restore must call VerifyRenditionBlobBytes after
 // every loose or packed blob is available and before publishing the target.
 func (s *Store) ImportMetadataForBackupRestore(ctx context.Context, r io.Reader) error {
 	return s.importMetadata(ctx, r, false)

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -217,8 +217,9 @@ type metadataAuditMembership struct {
 
 // BackupBlobAuthorityCTE is the complete blob closure for portable backup:
 // retained document versions, rendition artifacts, staged rendition sources,
-// and watcher cursor bytes. Rows outside this closure were never published as
-// logical authority and are deliberately excluded from new snapshots.
+// and no operational cursor or cache rows. Rows outside this closure were
+// never published as logical authority and are deliberately excluded from new
+// snapshots.
 const BackupBlobAuthorityCTE = `
 WITH backup_authorized_blobs(hash) AS (
 	SELECT blob_hash FROM content_versions
@@ -226,8 +227,6 @@ WITH backup_authorized_blobs(hash) AS (
 	SELECT blob_hash FROM rendition_artifacts
 	UNION
 	SELECT source_sha256 FROM rendition_builds
-	UNION
-	SELECT blob_hash FROM watch_sources
 )
 `
 
@@ -323,7 +322,7 @@ func exportMetadataSnapshotWithVaultIdentity(
 	if err := exportProvenance(ctx, tx, write); err != nil {
 		return err
 	}
-	if err := exportWatchSources(ctx, tx, write, backupScoped); err != nil {
+	if err := exportWatchSources(ctx, tx, write); err != nil {
 		return err
 	}
 	if err := exportTags(ctx, tx, write); err != nil {
@@ -492,19 +491,11 @@ func exportProvenance(ctx context.Context, tx metadataQuerier, write metadataWri
 }
 
 func exportWatchSources(
-	ctx context.Context, tx metadataQuerier, write metadataWrite, backupScoped bool,
+	ctx context.Context, tx metadataQuerier, write metadataWrite,
 ) error {
-	query := `
+	rows, err := tx.QueryContext(ctx, `
 		SELECT watch_name, source_ref, node_id, blob_hash, size
-		FROM watch_sources ORDER BY watch_name, source_ref`
-	if backupScoped {
-		query = BackupBlobAuthorityCTE + `
-		SELECT w.watch_name, w.source_ref, w.node_id, w.blob_hash, w.size
-		FROM watch_sources w
-		JOIN backup_authorized_blobs a ON a.hash = w.blob_hash
-		ORDER BY w.watch_name, w.source_ref`
-	}
-	rows, err := tx.QueryContext(ctx, query)
+		FROM watch_sources ORDER BY watch_name, source_ref`)
 	if err != nil {
 		return fmt.Errorf("exporting watched sources: %w", err)
 	}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -57,6 +57,13 @@ func (s *MetadataSnapshot) Export(ctx context.Context, w io.Writer) error {
 	return exportMetadataSnapshot(ctx, s, w)
 }
 
+// ExportBackup writes the deterministic logical authority carried by a backup
+// snapshot. Unlike Export, it omits blob and extraction-cache rows that are not
+// reachable from retained logical authority and therefore have no attachment.
+func (s *MetadataSnapshot) ExportBackup(ctx context.Context, w io.Writer) error {
+	return exportBackupMetadataSnapshot(ctx, s, w)
+}
+
 // BeginMetadataSnapshot establishes a pinned read transaction for logical
 // backup capture. The initial read is required: BeginTx alone is lazy in
 // SQLite and would not pin a snapshot before Kit releases the mutation gate.
@@ -208,6 +215,22 @@ type metadataAuditMembership struct {
 	BaselineDigest string `json:"baseline_digest"`
 }
 
+// BackupBlobAuthorityCTE is the complete blob closure for portable backup:
+// retained document versions, rendition artifacts, staged rendition sources,
+// and watcher cursor bytes. Rows outside this closure were never published as
+// logical authority and are deliberately excluded from new snapshots.
+const BackupBlobAuthorityCTE = `
+WITH backup_authorized_blobs(hash) AS (
+	SELECT blob_hash FROM content_versions
+	UNION
+	SELECT blob_hash FROM rendition_artifacts
+	UNION
+	SELECT source_sha256 FROM rendition_builds
+	UNION
+	SELECT blob_hash FROM watch_sources
+)
+`
+
 // ExportMetadata writes a deterministic JSONL description of Docbank's
 // logical state. Rebuildable FTS data and physical pack authority are omitted.
 func (s *Store) ExportMetadata(ctx context.Context, w io.Writer) error {
@@ -250,15 +273,19 @@ type metadataQuerier interface {
 // Backup capture uses this entry point so metadata and blob membership come
 // from the same frozen transaction.
 func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer) error {
-	return exportMetadataSnapshotWithVaultIdentity(ctx, tx, w, false)
+	return exportMetadataSnapshotWithVaultIdentity(ctx, tx, w, false, false)
+}
+
+func exportBackupMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer) error {
+	return exportMetadataSnapshotWithVaultIdentity(ctx, tx, w, false, true)
 }
 
 func exportV090MetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer) error {
-	return exportMetadataSnapshotWithVaultIdentity(ctx, tx, w, true)
+	return exportMetadataSnapshotWithVaultIdentity(ctx, tx, w, true, false)
 }
 
 func exportMetadataSnapshotWithVaultIdentity(
-	ctx context.Context, tx metadataQuerier, w io.Writer, legacyV090 bool,
+	ctx context.Context, tx metadataQuerier, w io.Writer, legacyV090, backupScoped bool,
 ) error {
 	if tx == nil {
 		return errors.New("exporting metadata: nil transaction")
@@ -281,7 +308,7 @@ func exportMetadataSnapshotWithVaultIdentity(
 	}); err != nil {
 		return err
 	}
-	if err := exportBlobs(ctx, tx, write); err != nil {
+	if err := exportBlobs(ctx, tx, write, backupScoped); err != nil {
 		return err
 	}
 	if err := exportNodes(ctx, tx, write); err != nil {
@@ -296,7 +323,7 @@ func exportMetadataSnapshotWithVaultIdentity(
 	if err := exportProvenance(ctx, tx, write); err != nil {
 		return err
 	}
-	if err := exportWatchSources(ctx, tx, write); err != nil {
+	if err := exportWatchSources(ctx, tx, write, backupScoped); err != nil {
 		return err
 	}
 	if err := exportTags(ctx, tx, write); err != nil {
@@ -305,7 +332,7 @@ func exportMetadataSnapshotWithVaultIdentity(
 	if err := exportNodeTags(ctx, tx, write); err != nil {
 		return err
 	}
-	if err := exportExtractedText(ctx, tx, write); err != nil {
+	if err := exportExtractedText(ctx, tx, write, backupScoped); err != nil {
 		return err
 	}
 	if err := exportAuditMetadata(ctx, tx, write); err != nil {
@@ -329,8 +356,17 @@ func newMetadataJSONWriter(w io.Writer) metadataWrite {
 	}
 }
 
-func exportBlobs(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
-	rows, err := tx.QueryContext(ctx, `SELECT hash, size, created_at FROM blobs ORDER BY hash`)
+func exportBlobs(
+	ctx context.Context, tx metadataQuerier, write metadataWrite, backupScoped bool,
+) error {
+	query := `SELECT hash, size, created_at FROM blobs ORDER BY hash`
+	if backupScoped {
+		query = BackupBlobAuthorityCTE + `
+SELECT b.hash, b.size, b.created_at
+FROM blobs b JOIN backup_authorized_blobs a ON a.hash = b.hash
+ORDER BY b.hash`
+	}
+	rows, err := tx.QueryContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("exporting blobs: %w", err)
 	}
@@ -455,10 +491,20 @@ func exportProvenance(ctx context.Context, tx metadataQuerier, write metadataWri
 	return rowsError(metadataProvenanceType, rows)
 }
 
-func exportWatchSources(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
-	rows, err := tx.QueryContext(ctx, `
+func exportWatchSources(
+	ctx context.Context, tx metadataQuerier, write metadataWrite, backupScoped bool,
+) error {
+	query := `
 		SELECT watch_name, source_ref, node_id, blob_hash, size
-		FROM watch_sources ORDER BY watch_name, source_ref`)
+		FROM watch_sources ORDER BY watch_name, source_ref`
+	if backupScoped {
+		query = BackupBlobAuthorityCTE + `
+		SELECT w.watch_name, w.source_ref, w.node_id, w.blob_hash, w.size
+		FROM watch_sources w
+		JOIN backup_authorized_blobs a ON a.hash = w.blob_hash
+		ORDER BY w.watch_name, w.source_ref`
+	}
+	rows, err := tx.QueryContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("exporting watched sources: %w", err)
 	}
@@ -520,10 +566,21 @@ func exportNodeTags(ctx context.Context, tx metadataQuerier, write metadataWrite
 	return rowsError("node tag", rows)
 }
 
-func exportExtractedText(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
-	rows, err := tx.QueryContext(ctx, `
+func exportExtractedText(
+	ctx context.Context, tx metadataQuerier, write metadataWrite, backupScoped bool,
+) error {
+	query := `
 		SELECT blob_hash, extractor, extractor_version, status, error, attempts, text, extracted_at
-		FROM extracted_text ORDER BY blob_hash, extractor`)
+		FROM extracted_text ORDER BY blob_hash, extractor`
+	if backupScoped {
+		query = BackupBlobAuthorityCTE + `
+		SELECT e.blob_hash, e.extractor, e.extractor_version, e.status,
+		       e.error, e.attempts, e.text, e.extracted_at
+		FROM extracted_text e
+		JOIN backup_authorized_blobs a ON a.hash = e.blob_hash
+		ORDER BY e.blob_hash, e.extractor`
+	}
+	rows, err := tx.QueryContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("exporting extracted text: %w", err)
 	}

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -533,49 +533,41 @@ type RenditionBlobReader interface {
 	OpenStreamContext(ctx context.Context, hash string) (packstore.VerifiedReadCloser, int64, error)
 }
 
-// VerifyRenditionHeadBytes verifies every source and artifact reachable from
-// an active rendition head through the restored mixed-storage catalog.
-func (s *Store) VerifyRenditionHeadBytes(ctx context.Context, reader RenditionBlobReader) error {
+// VerifyRenditionBlobBytes verifies every retained rendition source and
+// artifact through the restored mixed-storage catalog, including builds that
+// are staged but not attached to an active head.
+func (s *Store) VerifyRenditionBlobBytes(ctx context.Context, reader RenditionBlobReader) error {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT b.source_sha256, source.size
-		FROM rendition_heads h
-		JOIN rendition_attachments a
-		  ON a.content_version_id=h.content_version_id
-		 AND a.profile_fingerprint=h.profile_fingerprint
-		 AND a.attachment_id=h.attachment_id
-		JOIN rendition_builds b ON b.build_id=a.build_id AND b.vault_uid=a.vault_uid
+		FROM rendition_builds b
 		JOIN blobs source ON source.hash=b.source_sha256
 		UNION
 		SELECT artifact.blob_hash, artifact.size
-		FROM rendition_heads h
-		JOIN rendition_attachments a
-		  ON a.content_version_id=h.content_version_id
-		 AND a.profile_fingerprint=h.profile_fingerprint
-		 AND a.attachment_id=h.attachment_id
-		JOIN rendition_artifacts artifact ON artifact.build_id=a.build_id
+		FROM rendition_artifacts artifact
 		ORDER BY 1, 2`)
 	if err != nil {
-		return fmt.Errorf("listing active rendition bytes: %w", err)
+		return fmt.Errorf("listing retained rendition bytes: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var blob importedProcessingBlob
 		if err := rows.Scan(&blob.hash, &blob.size); err != nil {
-			return fmt.Errorf("scanning active rendition bytes: %w", err)
+			return fmt.Errorf("scanning retained rendition bytes: %w", err)
 		}
 		if err := verifyRenditionBlob(ctx, reader, blob); err != nil {
 			return err
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterating active rendition bytes: %w", err)
+		return fmt.Errorf("iterating retained rendition bytes: %w", err)
 	}
 	return nil
 }
 
 // VerifyRenditionBlobAuthority verifies the relational and physical-catalog
-// authority for every retained rendition source and artifact, including staged
-// builds that are not currently attached to a document version.
+// location authority for every retained rendition source and artifact,
+// including staged builds that are not currently attached to a document
+// version. VerifyRenditionBlobBytes separately reads and verifies each location.
 func (s *Store) VerifyRenditionBlobAuthority(ctx context.Context) (retErr error) {
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
@@ -609,41 +601,9 @@ func verifyRenditionBlobCatalogAuthority(ctx context.Context, tx *sql.Tx) (retEr
 		if _, err := requirePhysicalAuthorityTx(tx, hash); err != nil {
 			return fmt.Errorf("processing blob %s: %w", hash, err)
 		}
-		if err := verifyRenditionBlobCatalogSizeAuthorityTx(ctx, tx, hash); err != nil {
-			return err
-		}
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterating processing blob catalog authority: %w", err)
-	}
-	return nil
-}
-
-func verifyRenditionBlobCatalogSizeAuthorityTx(
-	ctx context.Context, tx metadataQuerier, hash string,
-) error {
-	var valid bool
-	err := tx.QueryRowContext(ctx, `
-		SELECT EXISTS(
-			SELECT 1
-			FROM blobs b
-			JOIN blob_locations l ON l.blob_hash=b.hash
-			LEFT JOIN blob_pack_entries e
-			  ON e.blob_hash=l.blob_hash AND e.store_id=l.store_id
-			WHERE b.hash=?
-			  AND (
-				(l.kind='loose' AND l.encoding='raw' AND l.stored_size=b.size)
-				OR (l.kind='loose' AND l.encoding='zstd')
-				OR (l.kind='packed' AND e.raw_len=b.size)
-			  )
-		)`, hash).Scan(&valid)
-	if err != nil {
-		return fmt.Errorf("reading rendition blob catalog size authority %s: %w", hash, err)
-	}
-	if !valid {
-		return fmt.Errorf(
-			"rendition blob catalog size authority %s disagrees with logical metadata", hash,
-		)
 	}
 	return nil
 }

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -573,6 +573,124 @@ func (s *Store) VerifyRenditionHeadBytes(ctx context.Context, reader RenditionBl
 	return nil
 }
 
+// VerifyRenditionBlobAuthority verifies the relational and physical-catalog
+// authority for every retained rendition source and artifact, including staged
+// builds that are not currently attached to a document version.
+func (s *Store) VerifyRenditionBlobAuthority(ctx context.Context) (retErr error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return fmt.Errorf("starting processing blob verification: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, tx.Rollback()) }()
+	if err := validateProcessingMetadataState(ctx, tx); err != nil {
+		return fmt.Errorf("validating processing blob authority: %w", err)
+	}
+	if err := verifyRenditionBlobCatalogAuthority(ctx, tx); err != nil {
+		return fmt.Errorf("verifying processing blob authority: %w", err)
+	}
+	return nil
+}
+
+func verifyRenditionBlobCatalogAuthority(ctx context.Context, tx *sql.Tx) (retErr error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT source_sha256 FROM rendition_builds
+		UNION
+		SELECT blob_hash FROM rendition_artifacts
+		ORDER BY source_sha256`)
+	if err != nil {
+		return fmt.Errorf("reading processing blob catalog authority: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, rows.Close()) }()
+	for rows.Next() {
+		var hash string
+		if err := rows.Scan(&hash); err != nil {
+			return fmt.Errorf("scanning processing blob catalog authority: %w", err)
+		}
+		if _, err := requirePhysicalAuthorityTx(tx, hash); err != nil {
+			return fmt.Errorf("processing blob %s: %w", hash, err)
+		}
+		if err := verifyRenditionBlobCatalogSizeAuthorityTx(ctx, tx, hash); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating processing blob catalog authority: %w", err)
+	}
+	return nil
+}
+
+func verifyRenditionBlobCatalogSizeAuthorityTx(
+	ctx context.Context, tx metadataQuerier, hash string,
+) error {
+	var valid bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1
+			FROM blobs b
+			JOIN blob_locations l ON l.blob_hash=b.hash
+			LEFT JOIN blob_pack_entries e
+			  ON e.blob_hash=l.blob_hash AND e.store_id=l.store_id
+			WHERE b.hash=?
+			  AND (
+				(l.kind='loose' AND l.encoding='raw' AND l.stored_size=b.size)
+				OR (l.kind='loose' AND l.encoding='zstd')
+				OR (l.kind='packed' AND e.raw_len=b.size)
+			  )
+		)`, hash).Scan(&valid)
+	if err != nil {
+		return fmt.Errorf("reading rendition blob catalog size authority %s: %w", hash, err)
+	}
+	if !valid {
+		return fmt.Errorf(
+			"rendition blob catalog size authority %s disagrees with logical metadata", hash,
+		)
+	}
+	return nil
+}
+
+// RebuildRenditionLexicalProjection reconstructs the excluded FTS projection
+// solely from restored catalog rows. No provider or network access is involved.
+func (s *Store) RebuildRenditionLexicalProjection(ctx context.Context) error {
+	var generationID string
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		present, err := processingMetadataSchemaPresent(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if !present {
+			return nil
+		}
+		var heads int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM rendition_heads`).Scan(&heads); err != nil {
+			return fmt.Errorf("counting rendition heads for lexical rebuild: %w", err)
+		}
+		if heads == 0 {
+			return nil
+		}
+		rows, err := readCatalogLexicalManifestRowsTx(ctx, tx, "")
+		if err != nil {
+			return err
+		}
+		generationID = lexicalManifestDigest(rows)
+		return nil
+	})
+	if err != nil || generationID == "" {
+		return err
+	}
+	if _, err := s.StageLexicalGeneration(ctx, generationID); err != nil {
+		return fmt.Errorf("rebuilding restored lexical projection: %w", err)
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO rendition_lexical_heads(singleton,generation_id) VALUES(1,?)
+			ON CONFLICT(singleton) DO UPDATE SET generation_id=excluded.generation_id`, generationID,
+		); err != nil {
+			return fmt.Errorf("publishing rebuilt lexical projection: %w", err)
+		}
+		return nil
+	})
+}
+
 func verifyRenditionBlob(
 	ctx context.Context, reader RenditionBlobReader, blob importedProcessingBlob,
 ) (retErr error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -62,6 +62,17 @@ func Open(path string, drivers ...docsqlite.Driver) (*Store, error) {
 	return s, nil
 }
 
+// OpenForRestore opens a staged restore database without migrating legacy
+// extraction state. Restore validation must observe the snapshot exactly as it
+// was imported; the ordinary Open path performs that forward migration only
+// after the restored vault has been published for normal use.
+func OpenForRestore(path string, driver docsqlite.Driver) (*Store, error) {
+	if err := docsqlite.Validate(driver); err != nil {
+		return nil, fmt.Errorf("opening restore database: %w", err)
+	}
+	return openCurrentStore(path, driver)
+}
+
 func openCurrentStore(path string, driver docsqlite.Driver) (*Store, error) {
 	db, err := driver.Open(path, docsqlite.OpenOptions{
 		Access: docsqlite.Create, TransactionMode: docsqlite.Immediate,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -62,10 +62,11 @@ func Open(path string, drivers ...docsqlite.Driver) (*Store, error) {
 	return s, nil
 }
 
-// OpenForRestore opens a staged restore database without migrating legacy
-// extraction state. Restore validation must observe the snapshot exactly as it
-// was imported; the ordinary Open path performs that forward migration only
-// after the restored vault has been published for normal use.
+// OpenForRestore opens a current-schema staged database built from portable
+// metadata without migrating legacy extraction state. Released on-disk schema
+// upgrades belong to the ordinary Open path; restore validation must observe
+// the logical snapshot exactly as it was imported, before that post-publication
+// migration runs.
 func OpenForRestore(path string, driver docsqlite.Driver) (*Store, error) {
 	if err := docsqlite.Validate(driver); err != nil {
 		return nil, fmt.Errorf("opening restore database: %w", err)


### PR DESCRIPTION
## What changed

Backups now include the complete catalog-authorized document authority: current source versions, rendition artifacts, and staged rendition-build sources. Snapshot metadata says which derivative classes are included, locally reconstructible, or provider-dependent, with deterministic counts, bytes, blob totals, and checksums.

Restore validates the logical and physical authority after materializing loose or packed bytes, then rebuilds the lexical projection locally before any restored head can publish. Missing, corrupt, or inconsistent data leaves an existing target unchanged.

## Why

The catalog was durable inside one vault, but backup still treated its bytes as generic storage. That could retain sensitive provider output without disclosing it or restore a vault whose catalog, blobs, and search head did not agree.

## Usage

Use the existing backup and restore commands. Derivative authority is included and reported automatically, and restore never calls a rendition or embedding provider.

Part of #176 (F7). Stacks on #186.
