### PR TITLE
Define the enforceable rendition provider contract

### DIFF
--- a/document/doc.go
+++ b/document/doc.go
@@ -1,6 +1,10 @@
-// Package document converts provider-neutral source evidence into deterministic
-// normalized units, headings, spans, and chunks.
+// Package document defines the storage-neutral rendition-provider boundary and
+// converts provider-neutral source evidence into deterministic normalized
+// units, headings, spans, and chunks.
 //
-// The package does not perform filesystem, network, storage, database, queue,
-// daemon, vault, or application work.
+// Provider adapters receive only one-shot, hash-bound AuthorizedUpload readers.
+// Descriptors, authorizations, results, receipts, and errors are validated here;
+// provider-specific network and credential handling remains outside this
+// package. The package does not perform filesystem, network, storage, database,
+// queue, daemon, vault, or application work.
 package document

--- a/document/provider.go
+++ b/document/provider.go
@@ -153,6 +153,11 @@ type RenditionAuthorization struct {
 	ExpiresAt                   string                 `json:"expires_at"`
 }
 
+// Fingerprint returns the canonical identity of every authorization field.
+func (authorization RenditionAuthorization) Fingerprint() (string, error) {
+	return componentFingerprint("rendition_authorization", cloneRenditionAuthorization(authorization))
+}
+
 // RenditionArtifact is one bounded, checksum-addressed provider output.
 type RenditionArtifact struct {
 	Role      EvidenceArtifactRole `json:"role"`
@@ -176,6 +181,7 @@ type RenditionReceipt struct {
 	DescriptorFingerprint       string         `json:"descriptor_fingerprint"`
 	PolicyFingerprint           string         `json:"policy_fingerprint"`
 	RenditionRequestFingerprint string         `json:"rendition_request_fingerprint"`
+	AuthorizationFingerprint    string         `json:"authorization_fingerprint"`
 	SourceSHA256                string         `json:"source_sha256"`
 	OperationID                 string         `json:"operation_id"`
 	StartedAt                   string         `json:"started_at"`
@@ -813,10 +819,10 @@ func validateRenditionDescriptorFields(descriptor RenditionDescriptor) error {
 	seenRoles := make(map[EvidenceArtifactRole]struct{}, len(descriptor.ArtifactRoles))
 	for _, role := range descriptor.ArtifactRoles {
 		if !validProfileArtifactRole(role) {
-			return fmt.Errorf("descriptor artifact role %q is invalid", role)
+			return errors.New("descriptor artifact role is invalid")
 		}
 		if _, exists := seenRoles[role]; exists {
-			return fmt.Errorf("descriptor artifact role %q is duplicated", role)
+			return errors.New("descriptor artifact role is duplicated")
 		}
 		seenRoles[role] = struct{}{}
 	}
@@ -964,11 +970,14 @@ func validateAuthorizedRoles(descriptor RenditionDescriptor, roles []EvidenceArt
 	}
 	seen := make(map[EvidenceArtifactRole]struct{}, len(roles))
 	for _, role := range roles {
-		if !validProfileArtifactRole(role) || !slices.Contains(descriptor.ArtifactRoles, role) {
-			return fmt.Errorf("authorization artifact role %q is not declared", role)
+		if !validProfileArtifactRole(role) {
+			return errors.New("authorization artifact role is invalid")
+		}
+		if !slices.Contains(descriptor.ArtifactRoles, role) {
+			return errors.New("authorization artifact role is not declared")
 		}
 		if _, exists := seen[role]; exists {
-			return fmt.Errorf("authorization artifact role %q is duplicated", role)
+			return errors.New("authorization artifact role is duplicated")
 		}
 		seen[role] = struct{}{}
 	}
@@ -986,7 +995,7 @@ func validateRenditionArtifacts(
 	for _, artifact := range artifacts {
 		if !validProfileArtifactRole(artifact.Role) || !slices.Contains(descriptor.ArtifactRoles, artifact.Role) ||
 			!slices.Contains(authorization.AllowedArtifactRoles, artifact.Role) {
-			return fmt.Errorf("provider artifact role %q is not authorized", artifact.Role)
+			return errors.New("provider artifact role is not authorized")
 		}
 		if err := validateCanonicalMediaType(artifact.MediaType); err != nil {
 			return fmt.Errorf("provider artifact: %w", err)
@@ -1025,7 +1034,7 @@ func validateEvidenceArtifactAuthorization(
 	referenced := make(map[identity]struct{}, len(evidence))
 	for _, artifact := range evidence {
 		if !slices.Contains(authorization.AllowedArtifactRoles, artifact.Role) {
-			return fmt.Errorf("source evidence artifact role %q is not authorized", artifact.Role)
+			return errors.New("source evidence artifact role is not authorized")
 		}
 		key := identity{role: artifact.Role, sha256: artifact.SHA256}
 		if _, ok := retainedSet[key]; !ok {
@@ -1044,9 +1053,14 @@ func validateEvidenceArtifactAuthorization(
 func validateRenditionReceipt(
 	descriptor RenditionDescriptor, authorization RenditionAuthorization, receipt RenditionReceipt,
 ) error {
+	authorizationFingerprint, err := authorization.Fingerprint()
+	if err != nil {
+		return fmt.Errorf("fingerprint rendition authorization: %w", err)
+	}
 	if receipt.ProviderID != descriptor.ID || receipt.DescriptorFingerprint != descriptor.Fingerprint ||
 		receipt.PolicyFingerprint != authorization.PolicyFingerprint ||
 		receipt.RenditionRequestFingerprint != authorization.RenditionRequestFingerprint ||
+		receipt.AuthorizationFingerprint != authorizationFingerprint ||
 		receipt.SourceSHA256 != authorization.SourceSHA256 {
 		return errors.New("provider receipt does not match authorization")
 	}

--- a/document/provider.go
+++ b/document/provider.go
@@ -263,6 +263,11 @@ func RenderRendition(
 			err = errors.Join(err, fmt.Errorf("close authorized upload: %w", closeErr))
 		}
 	}()
+	stopClose := context.AfterFunc(ctx, func() { _ = ownedUpload.Close() })
+	defer stopClose()
+	if err := ctx.Err(); err != nil {
+		return RenditionResult{}, err
+	}
 
 	sealed := cloneRenditionAuthorization(authorization)
 	descriptor, metadata, err := validateRenditionProviderRequestAt(time.Now().UTC(), provider, ownedUpload, sealed)
@@ -278,8 +283,14 @@ func RenderRendition(
 		source: ownedUpload, metadata: metadata, limited: limited,
 		reader: io.TeeReader(limited, hasher), hasher: hasher, expectedSHA256: sealed.SourceSHA256,
 	}
+	if err := ctx.Err(); err != nil {
+		return RenditionResult{}, err
+	}
 	result, err = provider.Render(ctx, providerUpload, cloneRenditionAuthorization(sealed))
 	_ = providerUpload.Close()
+	if contextErr := ctx.Err(); contextErr != nil {
+		return RenditionResult{}, contextErr
+	}
 	if err != nil {
 		if classified := ValidateRenditionProviderError(err); classified != nil {
 			return RenditionResult{}, classified
@@ -290,6 +301,9 @@ func RenderRendition(
 		return RenditionResult{}, err
 	}
 	if err := providerUpload.verify(ctx); err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return RenditionResult{}, contextErr
+		}
 		return RenditionResult{}, err
 	}
 	return result, nil

--- a/document/provider.go
+++ b/document/provider.go
@@ -1,0 +1,841 @@
+package document
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	// RenditionProviderContractVersion identifies the provider boundary defined here.
+	RenditionProviderContractVersion = 1
+
+	maxRenditionFormats          = 64
+	maxRenditionArtifactRoles    = 16
+	maxRenditionArtifacts        = 64
+	maxRenditionSourceBytes      = int64(1 << 40)
+	maxRenditionMarkdownBytes    = 64 << 20
+	maxRenditionArtifactBytes    = 256 << 20
+	maxRenditionTotalResultBytes = 512 << 20
+	maxRenditionWarnings         = 64
+	maxRenditionUsageValue       = int64(1 << 50)
+	renditionTimestampForm       = "2006-01-02T15:04:05.000000000Z"
+)
+
+// RenditionProvider renders one authorized upload into provider-neutral evidence.
+type RenditionProvider interface {
+	Descriptor() RenditionDescriptor
+	Render(ctx context.Context, upload AuthorizedUpload, authorization RenditionAuthorization) (RenditionResult, error)
+}
+
+// AuthorizedUpload is a read-once upload with immutable, authorization-bound metadata.
+type AuthorizedUpload interface {
+	io.ReadCloser
+	Metadata() AuthorizedUploadMetadata
+}
+
+// RenditionTrustBoundary identifies where provider-controlled processing occurs.
+type RenditionTrustBoundary string
+
+const (
+	// RenditionTrustLocalProcess keeps processing within a local child process.
+	RenditionTrustLocalProcess RenditionTrustBoundary = "local_process"
+	// RenditionTrustOperatorNetwork sends input to operator-controlled infrastructure.
+	RenditionTrustOperatorNetwork RenditionTrustBoundary = "operator_network"
+	// RenditionTrustHostedProvider sends input to a third-party provider.
+	RenditionTrustHostedProvider RenditionTrustBoundary = "hosted_provider"
+)
+
+// RenditionInputKind identifies the exact representation accepted by a provider.
+type RenditionInputKind string
+
+const (
+	// RenditionInputOriginalFile sends the exact source file.
+	RenditionInputOriginalFile RenditionInputKind = "original_file"
+	// RenditionInputDerivedUpload sends a separately authorized derived representation.
+	RenditionInputDerivedUpload RenditionInputKind = "derived_upload"
+)
+
+// RenditionFormatCapability is one exact supported media-family, media-type, and input-kind tuple.
+type RenditionFormatCapability struct {
+	MediaFamily string             `json:"media_family"`
+	MediaType   string             `json:"media_type"`
+	InputKind   RenditionInputKind `json:"input_kind"`
+}
+
+// RenditionDescriptor is the canonical immutable identity of a provider contract.
+type RenditionDescriptor struct {
+	ID                string                      `json:"id"`
+	ContractVersion   int                         `json:"contract_version"`
+	PolicyFingerprint string                      `json:"policy_fingerprint"`
+	TrustBoundary     RenditionTrustBoundary      `json:"trust_boundary"`
+	SupportedFormats  []RenditionFormatCapability `json:"supported_formats"`
+	ReturnsMarkdown   bool                        `json:"returns_markdown"`
+	ReturnsStructured bool                        `json:"returns_structured"`
+	ArtifactRoles     []EvidenceArtifactRole      `json:"artifact_roles"`
+	Fingerprint       string                      `json:"fingerprint"`
+}
+
+type renditionDescriptorIdentity struct {
+	ID                string                      `json:"id"`
+	ContractVersion   int                         `json:"contract_version"`
+	PolicyFingerprint string                      `json:"policy_fingerprint"`
+	TrustBoundary     RenditionTrustBoundary      `json:"trust_boundary"`
+	SupportedFormats  []RenditionFormatCapability `json:"supported_formats"`
+	ReturnsMarkdown   bool                        `json:"returns_markdown"`
+	ReturnsStructured bool                        `json:"returns_structured"`
+	ArtifactRoles     []EvidenceArtifactRole      `json:"artifact_roles"`
+}
+
+// NewRenditionDescriptor validates, canonicalizes, and fingerprints a descriptor.
+func NewRenditionDescriptor(value RenditionDescriptor) (RenditionDescriptor, error) {
+	value.Fingerprint = ""
+	value.SupportedFormats = slices.Clone(value.SupportedFormats)
+	value.ArtifactRoles = slices.Clone(value.ArtifactRoles)
+	slices.SortFunc(value.SupportedFormats, compareRenditionFormats)
+	slices.Sort(value.ArtifactRoles)
+	if err := validateRenditionDescriptorFields(value); err != nil {
+		return RenditionDescriptor{}, err
+	}
+	encoded, err := canonicalJSON(descriptorIdentity(value))
+	if err != nil {
+		return RenditionDescriptor{}, fmt.Errorf("encode rendition descriptor: %w", err)
+	}
+	value.Fingerprint = sha256Hex(encoded)
+	return value, nil
+}
+
+// AuthorizedUploadMetadata describes the exact bytes presented to a provider.
+type AuthorizedUploadMetadata struct {
+	Filename                 string             `json:"filename"`
+	MediaFamily              string             `json:"media_family"`
+	MediaType                string             `json:"media_type"`
+	ByteLength               int64              `json:"byte_length"`
+	SHA256                   string             `json:"sha256"`
+	CapabilityRecordChecksum string             `json:"capability_record_checksum"`
+	ProviderMetadataChecksum string             `json:"provider_metadata_checksum"`
+	InputKind                RenditionInputKind `json:"input_kind"`
+}
+
+// RenditionAuthorization binds one provider invocation to exact input and output limits.
+type RenditionAuthorization struct {
+	ProviderID                  string                 `json:"provider_id"`
+	DescriptorFingerprint       string                 `json:"descriptor_fingerprint"`
+	PolicyFingerprint           string                 `json:"policy_fingerprint"`
+	RenditionRequestFingerprint string                 `json:"rendition_request_fingerprint"`
+	SourceSHA256                string                 `json:"source_sha256"`
+	SourceBytes                 int64                  `json:"source_bytes"`
+	CapabilityRecordChecksum    string                 `json:"capability_record_checksum"`
+	ProviderMetadataChecksum    string                 `json:"provider_metadata_checksum"`
+	MediaFamily                 string                 `json:"media_family"`
+	MediaType                   string                 `json:"media_type"`
+	InputKind                   RenditionInputKind     `json:"input_kind"`
+	AllowedArtifactRoles        []EvidenceArtifactRole `json:"allowed_artifact_roles"`
+	MaxProviderMarkdownBytes    int                    `json:"max_provider_markdown_bytes"`
+	MaxArtifactBytes            int                    `json:"max_artifact_bytes"`
+	MaxArtifacts                int                    `json:"max_artifacts"`
+	MaxTotalResultBytes         int                    `json:"max_total_result_bytes"`
+	AuthorizedAt                string                 `json:"authorized_at"`
+	ExpiresAt                   string                 `json:"expires_at"`
+}
+
+// RenditionArtifact is one bounded, checksum-addressed provider output.
+type RenditionArtifact struct {
+	Role      EvidenceArtifactRole `json:"role"`
+	MediaType string               `json:"media_type"`
+	Payload   []byte               `json:"payload"`
+	SHA256    string               `json:"sha256"`
+}
+
+// RenditionUsage contains bounded numeric provider accounting only.
+type RenditionUsage struct {
+	Requests    int64 `json:"requests"`
+	Retries     int64 `json:"retries"`
+	InputBytes  int64 `json:"input_bytes"`
+	OutputBytes int64 `json:"output_bytes"`
+	Units       int64 `json:"units"`
+}
+
+// RenditionReceipt is a sanitized, bounded execution record without provider bodies or secrets.
+type RenditionReceipt struct {
+	ProviderID            string         `json:"provider_id"`
+	DescriptorFingerprint string         `json:"descriptor_fingerprint"`
+	PolicyFingerprint     string         `json:"policy_fingerprint"`
+	SourceSHA256          string         `json:"source_sha256"`
+	OperationID           string         `json:"operation_id"`
+	StartedAt             string         `json:"started_at"`
+	CompletedAt           string         `json:"completed_at"`
+	Warnings              []string       `json:"warnings,omitempty"`
+	Usage                 RenditionUsage `json:"usage"`
+	RetryDelayMillis      int64          `json:"retry_delay_millis,omitempty"`
+}
+
+// RenditionResult contains bounded provider output and its sanitized receipt.
+type RenditionResult struct {
+	Evidence         SourceEvidenceV1    `json:"evidence"`
+	ProviderMarkdown []byte              `json:"provider_markdown,omitempty"`
+	Artifacts        []RenditionArtifact `json:"artifacts,omitempty"`
+	Receipt          RenditionReceipt    `json:"receipt"`
+}
+
+// ValidateRenditionProviderRequest validates the provider snapshot and exact upload authorization.
+func ValidateRenditionProviderRequest(
+	provider RenditionProvider, upload AuthorizedUpload, authorization RenditionAuthorization,
+) (RenditionDescriptor, error) {
+	return ValidateRenditionProviderRequestAt(time.Now().UTC(), provider, upload, authorization)
+}
+
+// ValidateRenditionProviderRequestAt validates a request against an explicit
+// trusted clock. Callers with a transaction clock can avoid time-of-check
+// drift while retaining the same expiry boundary.
+func ValidateRenditionProviderRequestAt(
+	now time.Time, provider RenditionProvider, upload AuthorizedUpload,
+	authorization RenditionAuthorization,
+) (RenditionDescriptor, error) {
+	if nilInterface(provider) {
+		return RenditionDescriptor{}, errors.New("rendition provider is required")
+	}
+	if nilInterface(upload) {
+		return RenditionDescriptor{}, errors.New("authorized upload is required")
+	}
+	authorization = cloneRenditionAuthorization(authorization)
+	descriptor := cloneRenditionDescriptor(provider.Descriptor())
+	if err := validateRenditionDescriptor(descriptor); err != nil {
+		return RenditionDescriptor{}, err
+	}
+	if second := cloneRenditionDescriptor(provider.Descriptor()); !equalRenditionDescriptors(descriptor, second) {
+		return RenditionDescriptor{}, errors.New("rendition descriptor changed during validation")
+	}
+	metadata := upload.Metadata()
+	if err := validateAuthorizedUploadMetadata(metadata); err != nil {
+		return RenditionDescriptor{}, err
+	}
+	if second := upload.Metadata(); second != metadata {
+		return RenditionDescriptor{}, errors.New("authorized upload metadata changed during validation")
+	}
+	if err := validateRenditionAuthorization(descriptor, metadata, authorization); err != nil {
+		return RenditionDescriptor{}, err
+	}
+	if err := validateAuthorizationCurrentAt(authorization, now); err != nil {
+		return RenditionDescriptor{}, err
+	}
+	return cloneRenditionDescriptor(descriptor), nil
+}
+
+// RenderRendition validates immutable boundary snapshots, gives the provider
+// a separate authorization copy, and validates its result against the sealed
+// copy. Provider mutation therefore cannot broaden its own output authority.
+func RenderRendition(
+	ctx context.Context, provider RenditionProvider, upload AuthorizedUpload,
+	authorization RenditionAuthorization,
+) (RenditionResult, error) {
+	sealed := cloneRenditionAuthorization(authorization)
+	descriptor, err := ValidateRenditionProviderRequest(provider, upload, sealed)
+	if err != nil {
+		return RenditionResult{}, err
+	}
+	result, err := provider.Render(ctx, upload, cloneRenditionAuthorization(sealed))
+	if err != nil {
+		if classified := ValidateRenditionProviderError(err); classified != nil {
+			return RenditionResult{}, classified
+		}
+		return RenditionResult{}, err
+	}
+	if err := ValidateRenditionResult(descriptor, sealed, result); err != nil {
+		return RenditionResult{}, err
+	}
+	return result, nil
+}
+
+// ValidateRenditionResult rejects provider output outside the authorized contract.
+func ValidateRenditionResult(
+	descriptor RenditionDescriptor, authorization RenditionAuthorization, result RenditionResult,
+) error {
+	if err := validateRenditionDescriptor(descriptor); err != nil {
+		return err
+	}
+	if err := validateAuthorizationWithoutUpload(descriptor, authorization); err != nil {
+		return err
+	}
+	if err := ValidateSourceEvidenceV1(result.Evidence); err != nil {
+		return fmt.Errorf("provider evidence: %w", err)
+	}
+	if result.Evidence.Family != authorization.MediaFamily {
+		return errors.New("provider evidence family does not match authorization")
+	}
+	if !descriptor.ReturnsMarkdown && len(result.ProviderMarkdown) != 0 {
+		return errors.New("provider Markdown is not declared by descriptor")
+	}
+	if len(result.ProviderMarkdown) > authorization.MaxProviderMarkdownBytes {
+		return errors.New("provider Markdown exceeds authorized byte limit")
+	}
+	if err := validateRenditionArtifacts(descriptor, authorization, result.Artifacts); err != nil {
+		return err
+	}
+	if err := validateEvidenceArtifactAuthorization(
+		authorization, result.Evidence.Artifacts, result.Artifacts); err != nil {
+		return err
+	}
+	if err := validateRenditionReceipt(descriptor, authorization, result.Receipt); err != nil {
+		return err
+	}
+	encodedEvidence, err := canonicalJSON(result.Evidence)
+	if err != nil {
+		return fmt.Errorf("encode provider evidence: %w", err)
+	}
+	total := len(encodedEvidence) + len(result.ProviderMarkdown)
+	for _, artifact := range result.Artifacts {
+		total += len(artifact.Payload)
+	}
+	if total > authorization.MaxTotalResultBytes {
+		return errors.New("provider total result bytes exceed authorization")
+	}
+	return nil
+}
+
+// RenditionErrorCode is a stable, bounded provider failure class.
+type RenditionErrorCode string
+
+const (
+	RenditionErrorUnsupportedInput    RenditionErrorCode = "unsupported_input"
+	RenditionErrorPolicyRejected      RenditionErrorCode = "policy_rejected"
+	RenditionErrorAuthentication      RenditionErrorCode = "authentication"
+	RenditionErrorCapacity            RenditionErrorCode = "capacity"
+	RenditionErrorRateLimited         RenditionErrorCode = "rate_limited"
+	RenditionErrorTransient           RenditionErrorCode = "transient"
+	RenditionErrorMalformedEvidence   RenditionErrorCode = "malformed_evidence"
+	RenditionErrorUnknownJob          RenditionErrorCode = "unknown_job"
+	RenditionErrorCanceled            RenditionErrorCode = "canceled"
+	RenditionErrorAmbiguousSubmission RenditionErrorCode = "ambiguous_submission"
+)
+
+// RenditionProviderError preserves a private cause behind a sanitized error class and message.
+type RenditionProviderError struct {
+	code       RenditionErrorCode
+	message    string
+	retryAfter time.Duration
+	cause      error
+}
+
+// NewRenditionProviderError constructs a classified provider failure.
+func NewRenditionProviderError(
+	code RenditionErrorCode, message string, retryAfter time.Duration, cause error,
+) (*RenditionProviderError, error) {
+	providerError := &RenditionProviderError{code: code, message: message, retryAfter: retryAfter, cause: cause}
+	if err := validateClassifiedProviderError(providerError); err != nil {
+		return nil, err
+	}
+	return providerError, nil
+}
+
+// Error returns only the sanitized failure class and message.
+func (providerError *RenditionProviderError) Error() string {
+	if providerError == nil {
+		return "rendition provider error"
+	}
+	return fmt.Sprintf("rendition provider %s: %s", providerError.code, providerError.message)
+}
+
+// Unwrap exposes the private cause for programmatic matching without rendering it.
+func (providerError *RenditionProviderError) Unwrap() error {
+	if providerError == nil {
+		return nil
+	}
+	return providerError.cause
+}
+
+// Code returns the stable provider failure class.
+func (providerError *RenditionProviderError) Code() RenditionErrorCode {
+	if providerError == nil {
+		return ""
+	}
+	return providerError.code
+}
+
+// RetryAfter returns the bounded provider-supplied delay.
+func (providerError *RenditionProviderError) RetryAfter() time.Duration {
+	if providerError == nil {
+		return 0
+	}
+	return providerError.retryAfter
+}
+
+// ValidateRenditionProviderError rejects raw, unclassified provider failures.
+func ValidateRenditionProviderError(err error) error {
+	providerError, ok := err.(*RenditionProviderError) //nolint:errorlint // wrappers may expose unsanitized text
+	if !ok {
+		return errors.New("unclassified rendition provider error")
+	}
+	return validateClassifiedProviderError(providerError)
+}
+
+// IsRenditionProviderErrorRetryable reports whether an explicitly classified failure is retryable.
+func IsRenditionProviderErrorRetryable(err error) bool {
+	providerError, ok := err.(*RenditionProviderError) //nolint:errorlint // only the top-level safe error is retryable
+	if !ok || validateClassifiedProviderError(providerError) != nil {
+		return false
+	}
+	switch providerError.code {
+	case RenditionErrorCapacity, RenditionErrorRateLimited, RenditionErrorTransient:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateRenditionDescriptor(descriptor RenditionDescriptor) error {
+	if err := validateRenditionDescriptorFields(descriptor); err != nil {
+		return err
+	}
+	if err := validateFingerprint(descriptor.Fingerprint, "descriptor fingerprint"); err != nil {
+		return err
+	}
+	canonical, err := NewRenditionDescriptor(descriptor)
+	if err != nil {
+		return err
+	}
+	if canonical.Fingerprint != descriptor.Fingerprint || !equalRenditionDescriptors(canonical, descriptor) {
+		return errors.New("descriptor fingerprint or canonical ordering is invalid")
+	}
+	return nil
+}
+
+func cloneRenditionAuthorization(value RenditionAuthorization) RenditionAuthorization {
+	value.AllowedArtifactRoles = slices.Clone(value.AllowedArtifactRoles)
+	return value
+}
+
+func validateRenditionDescriptorFields(descriptor RenditionDescriptor) error {
+	if err := validateStableToken(descriptor.ID, "descriptor ID", 128); err != nil {
+		return err
+	}
+	if descriptor.ContractVersion != RenditionProviderContractVersion {
+		return fmt.Errorf("descriptor contract version must be %d", RenditionProviderContractVersion)
+	}
+	if err := validateFingerprint(descriptor.PolicyFingerprint, "descriptor policy fingerprint"); err != nil {
+		return err
+	}
+	switch descriptor.TrustBoundary {
+	case RenditionTrustLocalProcess, RenditionTrustOperatorNetwork, RenditionTrustHostedProvider:
+	default:
+		return errors.New("descriptor trust boundary is invalid")
+	}
+	if len(descriptor.SupportedFormats) == 0 || len(descriptor.SupportedFormats) > maxRenditionFormats {
+		return fmt.Errorf("descriptor supported formats must contain 1-%d entries", maxRenditionFormats)
+	}
+	seenFormats := make(map[RenditionFormatCapability]struct{}, len(descriptor.SupportedFormats))
+	for _, format := range descriptor.SupportedFormats {
+		if err := validateRenditionFormat(format); err != nil {
+			return err
+		}
+		if _, exists := seenFormats[format]; exists {
+			return errors.New("descriptor contains duplicate supported format")
+		}
+		seenFormats[format] = struct{}{}
+	}
+	if len(descriptor.ArtifactRoles) > maxRenditionArtifactRoles {
+		return errors.New("descriptor has too many artifact roles")
+	}
+	seenRoles := make(map[EvidenceArtifactRole]struct{}, len(descriptor.ArtifactRoles))
+	for _, role := range descriptor.ArtifactRoles {
+		if !validProfileArtifactRole(role) {
+			return fmt.Errorf("descriptor artifact role %q is invalid", role)
+		}
+		if _, exists := seenRoles[role]; exists {
+			return fmt.Errorf("descriptor artifact role %q is duplicated", role)
+		}
+		seenRoles[role] = struct{}{}
+	}
+	if !descriptor.ReturnsMarkdown && !descriptor.ReturnsStructured && len(descriptor.ArtifactRoles) == 0 {
+		return errors.New("descriptor must declare at least one result kind")
+	}
+	return nil
+}
+
+func validateRenditionFormat(format RenditionFormatCapability) error {
+	if err := validateStableToken(format.MediaFamily, "media family", 63); err != nil {
+		return err
+	}
+	if err := validateCanonicalMediaType(format.MediaType); err != nil {
+		return err
+	}
+	if !validRenditionInputKind(format.InputKind) {
+		return errors.New("rendition input kind is invalid")
+	}
+	return nil
+}
+
+func validateAuthorizedUploadMetadata(metadata AuthorizedUploadMetadata) error {
+	if metadata.Filename == "" || len(metadata.Filename) > 255 || strings.ContainsAny(metadata.Filename, "/\\\x00") {
+		return errors.New("upload filename must be a safe basename of at most 255 bytes")
+	}
+	if err := validateRenditionFormat(RenditionFormatCapability{
+		MediaFamily: metadata.MediaFamily, MediaType: metadata.MediaType, InputKind: metadata.InputKind,
+	}); err != nil {
+		return fmt.Errorf("upload metadata: %w", err)
+	}
+	if metadata.ByteLength <= 0 || metadata.ByteLength > maxRenditionSourceBytes {
+		return errors.New("upload byte length is outside the supported bound")
+	}
+	for subject, value := range map[string]string{
+		"upload SHA-256": metadata.SHA256, "capability record checksum": metadata.CapabilityRecordChecksum,
+		"provider metadata checksum": metadata.ProviderMetadataChecksum,
+	} {
+		if err := validateFingerprint(value, subject); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRenditionAuthorization(
+	descriptor RenditionDescriptor, metadata AuthorizedUploadMetadata, authorization RenditionAuthorization,
+) error {
+	if err := validateAuthorizationWithoutUpload(descriptor, authorization); err != nil {
+		return err
+	}
+	if authorization.SourceSHA256 != metadata.SHA256 || authorization.SourceBytes != metadata.ByteLength {
+		return errors.New("authorization does not match exact upload bytes")
+	}
+	if authorization.CapabilityRecordChecksum != metadata.CapabilityRecordChecksum {
+		return errors.New("authorization capability record checksum does not match upload")
+	}
+	if authorization.ProviderMetadataChecksum != metadata.ProviderMetadataChecksum {
+		return errors.New("authorization provider metadata checksum does not match upload")
+	}
+	if authorization.MediaFamily != metadata.MediaFamily || authorization.MediaType != metadata.MediaType ||
+		authorization.InputKind != metadata.InputKind {
+		return errors.New("authorization format does not match upload metadata")
+	}
+	return nil
+}
+
+func validateAuthorizationWithoutUpload(descriptor RenditionDescriptor, authorization RenditionAuthorization) error {
+	if authorization.ProviderID != descriptor.ID {
+		return errors.New("authorization provider ID does not match descriptor")
+	}
+	if authorization.DescriptorFingerprint != descriptor.Fingerprint {
+		return errors.New("authorization descriptor fingerprint does not match descriptor")
+	}
+	if authorization.PolicyFingerprint != descriptor.PolicyFingerprint {
+		return errors.New("authorization policy fingerprint does not match descriptor")
+	}
+	for subject, value := range map[string]string{
+		"rendition request fingerprint": authorization.RenditionRequestFingerprint,
+		"source SHA-256":                authorization.SourceSHA256, "capability record checksum": authorization.CapabilityRecordChecksum,
+		"provider metadata checksum": authorization.ProviderMetadataChecksum,
+	} {
+		if err := validateFingerprint(value, subject); err != nil {
+			return err
+		}
+	}
+	format := RenditionFormatCapability{
+		MediaFamily: authorization.MediaFamily, MediaType: authorization.MediaType, InputKind: authorization.InputKind,
+	}
+	if !slices.Contains(descriptor.SupportedFormats, format) {
+		return errors.New("authorization requests an unsupported format")
+	}
+	if authorization.SourceBytes <= 0 || authorization.SourceBytes > maxRenditionSourceBytes {
+		return errors.New("authorization source bytes are outside the supported bound")
+	}
+	if err := validateAuthorizedRoles(descriptor, authorization.AllowedArtifactRoles); err != nil {
+		return err
+	}
+	if authorization.MaxProviderMarkdownBytes < 0 || authorization.MaxProviderMarkdownBytes > maxRenditionMarkdownBytes ||
+		(!descriptor.ReturnsMarkdown && authorization.MaxProviderMarkdownBytes != 0) {
+		return errors.New("authorization provider Markdown bytes are invalid")
+	}
+	if authorization.MaxArtifactBytes < 0 || authorization.MaxArtifactBytes > maxRenditionArtifactBytes {
+		return errors.New("authorization artifact bytes are invalid")
+	}
+	if authorization.MaxArtifacts < 0 || authorization.MaxArtifacts > maxRenditionArtifacts ||
+		authorization.MaxArtifacts > len(authorization.AllowedArtifactRoles) {
+		return errors.New("authorization artifact count is invalid")
+	}
+	if authorization.MaxTotalResultBytes <= 0 || authorization.MaxTotalResultBytes > maxRenditionTotalResultBytes {
+		return errors.New("authorization total result bytes are invalid")
+	}
+	authorizedAt, err := parseRenditionTimestamp(authorization.AuthorizedAt)
+	if err != nil {
+		return errors.New("authorization time must be canonical RFC3339Nano")
+	}
+	expiresAt, err := parseRenditionTimestamp(authorization.ExpiresAt)
+	if err != nil || !expiresAt.After(authorizedAt) {
+		return errors.New("authorization expiry must be canonical and after authorization time")
+	}
+	return nil
+}
+
+func validateAuthorizationCurrentAt(authorization RenditionAuthorization, now time.Time) error {
+	authorizedAt, err := parseRenditionTimestamp(authorization.AuthorizedAt)
+	if err != nil {
+		return errors.New("authorization time must be canonical")
+	}
+	expiresAt, err := parseRenditionTimestamp(authorization.ExpiresAt)
+	if err != nil {
+		return errors.New("authorization expiry must be canonical")
+	}
+	if now.Before(authorizedAt) || !now.Before(expiresAt) {
+		return errors.New("authorization is not current")
+	}
+	return nil
+}
+
+func validateAuthorizedRoles(descriptor RenditionDescriptor, roles []EvidenceArtifactRole) error {
+	if len(roles) > maxRenditionArtifactRoles {
+		return errors.New("authorization has too many artifact roles")
+	}
+	seen := make(map[EvidenceArtifactRole]struct{}, len(roles))
+	for _, role := range roles {
+		if !validProfileArtifactRole(role) || !slices.Contains(descriptor.ArtifactRoles, role) {
+			return fmt.Errorf("authorization artifact role %q is not declared", role)
+		}
+		if _, exists := seen[role]; exists {
+			return fmt.Errorf("authorization artifact role %q is duplicated", role)
+		}
+		seen[role] = struct{}{}
+	}
+	return nil
+}
+
+func validateRenditionArtifacts(
+	descriptor RenditionDescriptor, authorization RenditionAuthorization, artifacts []RenditionArtifact,
+) error {
+	seen := make(map[EvidenceArtifactRole]struct{}, len(artifacts))
+	for _, artifact := range artifacts {
+		if !validProfileArtifactRole(artifact.Role) || !slices.Contains(descriptor.ArtifactRoles, artifact.Role) ||
+			!slices.Contains(authorization.AllowedArtifactRoles, artifact.Role) {
+			return fmt.Errorf("provider artifact role %q is not authorized", artifact.Role)
+		}
+		if _, exists := seen[artifact.Role]; exists {
+			return fmt.Errorf("provider artifact role %q is duplicated", artifact.Role)
+		}
+		seen[artifact.Role] = struct{}{}
+		if err := validateCanonicalMediaType(artifact.MediaType); err != nil {
+			return fmt.Errorf("provider artifact: %w", err)
+		}
+		if len(artifact.Payload) > authorization.MaxArtifactBytes {
+			return errors.New("provider artifact exceeds authorized byte limit")
+		}
+		digest := sha256.Sum256(artifact.Payload)
+		if artifact.SHA256 != hex.EncodeToString(digest[:]) {
+			return errors.New("provider artifact checksum does not match payload")
+		}
+	}
+	if len(artifacts) > authorization.MaxArtifacts {
+		return errors.New("provider artifact count exceeds authorization")
+	}
+	return nil
+}
+
+func validateEvidenceArtifactAuthorization(
+	authorization RenditionAuthorization, evidence []SourceEvidenceArtifactV1,
+	retained []RenditionArtifact,
+) error {
+	type identity struct {
+		role   EvidenceArtifactRole
+		sha256 string
+	}
+	retainedSet := make(map[identity]struct{}, len(retained))
+	for _, artifact := range retained {
+		retainedSet[identity{role: artifact.Role, sha256: artifact.SHA256}] = struct{}{}
+	}
+	referenced := make(map[identity]struct{}, len(evidence))
+	for _, artifact := range evidence {
+		if !slices.Contains(authorization.AllowedArtifactRoles, artifact.Role) {
+			return fmt.Errorf("source evidence artifact role %q is not authorized", artifact.Role)
+		}
+		key := identity{role: artifact.Role, sha256: artifact.SHA256}
+		if _, ok := retainedSet[key]; !ok {
+			return errors.New("source evidence artifact does not match a retained provider artifact")
+		}
+		referenced[key] = struct{}{}
+	}
+	for key := range retainedSet {
+		if _, ok := referenced[key]; !ok {
+			return errors.New("retained provider artifact is absent from source evidence")
+		}
+	}
+	return nil
+}
+
+func validateRenditionReceipt(
+	descriptor RenditionDescriptor, authorization RenditionAuthorization, receipt RenditionReceipt,
+) error {
+	if receipt.ProviderID != descriptor.ID || receipt.DescriptorFingerprint != descriptor.Fingerprint ||
+		receipt.PolicyFingerprint != authorization.PolicyFingerprint || receipt.SourceSHA256 != authorization.SourceSHA256 {
+		return errors.New("provider receipt does not match authorization")
+	}
+	if err := validateStableToken(receipt.OperationID, "operation ID", 128); err != nil {
+		return err
+	}
+	startedAt, err := parseRenditionTimestamp(receipt.StartedAt)
+	if err != nil {
+		return errors.New("receipt start time must be canonical RFC3339Nano")
+	}
+	completedAt, err := parseRenditionTimestamp(receipt.CompletedAt)
+	if err != nil || completedAt.Before(startedAt) {
+		return errors.New("receipt completion time must be canonical and not precede start")
+	}
+	authorizedAt, _ := parseRenditionTimestamp(authorization.AuthorizedAt)
+	expiresAt, _ := parseRenditionTimestamp(authorization.ExpiresAt)
+	if startedAt.Before(authorizedAt) || completedAt.After(expiresAt) {
+		return errors.New("receipt execution is outside the authorization interval")
+	}
+	if len(receipt.Warnings) > maxRenditionWarnings {
+		return errors.New("receipt has too many warning codes")
+	}
+	seenWarnings := make(map[string]struct{}, len(receipt.Warnings))
+	for _, warning := range receipt.Warnings {
+		if err := validateStableToken(warning, "receipt warning", 63); err != nil {
+			return err
+		}
+		if _, exists := seenWarnings[warning]; exists {
+			return errors.New("receipt warning codes must be unique")
+		}
+		seenWarnings[warning] = struct{}{}
+	}
+	if err := validateRenditionUsage(receipt.Usage); err != nil {
+		return err
+	}
+	if receipt.Usage.Retries > receipt.Usage.Requests {
+		return errors.New("receipt retries cannot exceed requests")
+	}
+	if receipt.RetryDelayMillis < 0 || receipt.RetryDelayMillis > int64((24*time.Hour)/time.Millisecond) {
+		return errors.New("receipt retry delay is outside the supported bound")
+	}
+	return nil
+}
+
+func validateRenditionUsage(usage RenditionUsage) error {
+	for subject, value := range map[string]int64{
+		"requests": usage.Requests, "retries": usage.Retries, "input bytes": usage.InputBytes,
+		"output bytes": usage.OutputBytes, "units": usage.Units,
+	} {
+		if value < 0 || value > maxRenditionUsageValue {
+			return fmt.Errorf("receipt usage %s is outside the supported bound", subject)
+		}
+	}
+	return nil
+}
+
+func validateClassifiedProviderError(providerError *RenditionProviderError) error {
+	if providerError == nil {
+		return errors.New("classified rendition provider error is nil")
+	}
+	switch providerError.code {
+	case RenditionErrorUnsupportedInput, RenditionErrorPolicyRejected, RenditionErrorAuthentication,
+		RenditionErrorCapacity, RenditionErrorRateLimited, RenditionErrorTransient,
+		RenditionErrorMalformedEvidence, RenditionErrorUnknownJob, RenditionErrorCanceled,
+		RenditionErrorAmbiguousSubmission:
+	default:
+		return errors.New("rendition provider error code is invalid")
+	}
+	if err := validateSafeMessage(providerError.message); err != nil {
+		return err
+	}
+	if providerError.retryAfter < 0 || providerError.retryAfter > 24*time.Hour {
+		return errors.New("rendition provider retry delay is outside the supported bound")
+	}
+	return nil
+}
+
+func validateSafeMessage(value string) error {
+	if value == "" || len(value) > 160 || strings.ContainsAny(value, "\r\n{}[]<>=\"") {
+		return errors.New("rendition provider error message must be a bounded safe summary")
+	}
+	lower := strings.ToLower(value)
+	for _, unsafe := range []string{"authorization:", "bearer ", "api_key", "apikey", "secret", "token="} {
+		if strings.Contains(lower, unsafe) {
+			return errors.New("rendition provider error message contains credential-shaped content")
+		}
+	}
+	return nil
+}
+
+func validateStableToken(value, subject string, maxLength int) error {
+	if value == "" || len(value) > maxLength {
+		return fmt.Errorf("%s must contain 1-%d characters", subject, maxLength)
+	}
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '_' || char == '-' || char == '.' {
+			continue
+		}
+		return fmt.Errorf("%s contains unsupported characters", subject)
+	}
+	return nil
+}
+
+func validateCanonicalMediaType(value string) error {
+	parsed, parameters, err := mime.ParseMediaType(value)
+	if err != nil || parsed != value || len(parameters) != 0 || !strings.Contains(value, "/") {
+		return fmt.Errorf("media type %q must be canonical and contain no parameters", value)
+	}
+	return nil
+}
+
+func validRenditionInputKind(kind RenditionInputKind) bool {
+	return kind == RenditionInputOriginalFile || kind == RenditionInputDerivedUpload
+}
+
+func parseRenditionTimestamp(value string) (time.Time, error) {
+	parsed, err := time.Parse(renditionTimestampForm, value)
+	if err != nil || parsed.Format(renditionTimestampForm) != value {
+		return time.Time{}, errors.New("timestamp is not canonical UTC RFC3339Nano")
+	}
+	return parsed, nil
+}
+
+func compareRenditionFormats(left, right RenditionFormatCapability) int {
+	if comparison := strings.Compare(left.MediaFamily, right.MediaFamily); comparison != 0 {
+		return comparison
+	}
+	if comparison := strings.Compare(left.MediaType, right.MediaType); comparison != 0 {
+		return comparison
+	}
+	return strings.Compare(string(left.InputKind), string(right.InputKind))
+}
+
+func descriptorIdentity(value RenditionDescriptor) renditionDescriptorIdentity {
+	return renditionDescriptorIdentity{
+		ID: value.ID, ContractVersion: value.ContractVersion, PolicyFingerprint: value.PolicyFingerprint,
+		TrustBoundary: value.TrustBoundary, SupportedFormats: value.SupportedFormats,
+		ReturnsMarkdown: value.ReturnsMarkdown, ReturnsStructured: value.ReturnsStructured,
+		ArtifactRoles: value.ArtifactRoles,
+	}
+}
+
+func cloneRenditionDescriptor(value RenditionDescriptor) RenditionDescriptor {
+	value.SupportedFormats = slices.Clone(value.SupportedFormats)
+	value.ArtifactRoles = slices.Clone(value.ArtifactRoles)
+	return value
+}
+
+func equalRenditionDescriptors(left, right RenditionDescriptor) bool {
+	return left.ID == right.ID && left.ContractVersion == right.ContractVersion &&
+		left.PolicyFingerprint == right.PolicyFingerprint && left.TrustBoundary == right.TrustBoundary &&
+		left.ReturnsMarkdown == right.ReturnsMarkdown && left.ReturnsStructured == right.ReturnsStructured &&
+		left.Fingerprint == right.Fingerprint && slices.Equal(left.SupportedFormats, right.SupportedFormats) &&
+		slices.Equal(left.ArtifactRoles, right.ArtifactRoles)
+}
+
+func nilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/document/provider.go
+++ b/document/provider.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"mime"
 	"reflect"
@@ -255,7 +256,7 @@ func RenderRendition(
 	if nilInterface(upload) {
 		return RenditionResult{}, errors.New("authorized upload is required")
 	}
-	ownedUpload := &ownedAuthorizedUpload{AuthorizedUpload: upload}
+	ownedUpload := &ownedAuthorizedUpload{upload: upload}
 	defer func() {
 		closeErr := ownedUpload.Close()
 		if closeErr != nil && !errors.Is(err, closeErr) {
@@ -271,8 +272,14 @@ func RenderRendition(
 	if !sealed.DiscloseFilename {
 		metadata.Filename = ""
 	}
-	providerUpload := &sealedAuthorizedUpload{ReadCloser: ownedUpload, metadata: metadata}
+	hasher := sha256.New()
+	limited := &io.LimitedReader{R: ownedUpload, N: sealed.SourceBytes}
+	providerUpload := &sealedAuthorizedUpload{
+		source: ownedUpload, metadata: metadata, limited: limited,
+		reader: io.TeeReader(limited, hasher), hasher: hasher, expectedSHA256: sealed.SourceSHA256,
+	}
 	result, err = provider.Render(ctx, providerUpload, cloneRenditionAuthorization(sealed))
+	_ = providerUpload.Close()
 	if err != nil {
 		if classified := ValidateRenditionProviderError(err); classified != nil {
 			return RenditionResult{}, classified
@@ -280,6 +287,9 @@ func RenderRendition(
 		return RenditionResult{}, err
 	}
 	if err := ValidateRenditionResult(descriptor, sealed, result); err != nil {
+		return RenditionResult{}, err
+	}
+	if err := providerUpload.verify(ctx); err != nil {
 		return RenditionResult{}, err
 	}
 	return result, nil
@@ -469,25 +479,110 @@ func cloneRenditionAuthorization(value RenditionAuthorization) RenditionAuthoriz
 }
 
 type sealedAuthorizedUpload struct {
-	io.ReadCloser
+	mu sync.Mutex
 
-	metadata AuthorizedUploadMetadata
+	source         *ownedAuthorizedUpload
+	metadata       AuthorizedUploadMetadata
+	reader         io.Reader
+	limited        *io.LimitedReader
+	hasher         hash.Hash
+	expectedSHA256 string
+	providerClosed bool
 }
 
 func (upload *sealedAuthorizedUpload) Metadata() AuthorizedUploadMetadata {
 	return upload.metadata
 }
 
+func (upload *sealedAuthorizedUpload) Read(buffer []byte) (int, error) {
+	upload.mu.Lock()
+	defer upload.mu.Unlock()
+	if upload.providerClosed {
+		return 0, io.ErrClosedPipe
+	}
+	return upload.reader.Read(buffer)
+}
+
+// Close ends provider access. RenderRendition retains the source until it has
+// verified and closed the exact authorized stream.
+func (upload *sealedAuthorizedUpload) Close() error {
+	upload.mu.Lock()
+	defer upload.mu.Unlock()
+	upload.providerClosed = true
+	return nil
+}
+
+func (upload *sealedAuthorizedUpload) verify(ctx context.Context) error {
+	upload.mu.Lock()
+	defer upload.mu.Unlock()
+	upload.providerClosed = true
+	buffer := make([]byte, 128<<10)
+	noProgress := 0
+	for upload.limited.N != 0 {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("verify authorized upload: %w", err)
+		}
+		count, err := upload.reader.Read(buffer)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("read authorized upload: %w", err)
+		}
+		if errors.Is(err, io.EOF) && upload.limited.N != 0 {
+			return errors.New("authorized upload is shorter than declared byte length")
+		}
+		if count == 0 && err == nil {
+			noProgress++
+			if noProgress >= 100 {
+				return io.ErrNoProgress
+			}
+		} else {
+			noProgress = 0
+		}
+	}
+	var extra [1]byte
+	noProgress = 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("verify authorized upload: %w", err)
+		}
+		count, err := upload.source.Read(extra[:])
+		if count != 0 {
+			return errors.New("authorized upload exceeds declared byte length")
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read authorized upload: %w", err)
+		}
+		noProgress++
+		if noProgress >= 100 {
+			return io.ErrNoProgress
+		}
+	}
+	if hex.EncodeToString(upload.hasher.Sum(nil)) != upload.expectedSHA256 {
+		return errors.New("authorized upload SHA-256 does not match authorization")
+	}
+	return nil
+}
+
 type ownedAuthorizedUpload struct {
-	AuthorizedUpload
+	upload AuthorizedUpload
 
 	closeErr  error
 	closeOnce sync.Once
 }
 
+func (upload *ownedAuthorizedUpload) Read(buffer []byte) (int, error) {
+	return upload.upload.Read(buffer)
+}
+
+func (upload *ownedAuthorizedUpload) Metadata() AuthorizedUploadMetadata {
+	return upload.upload.Metadata()
+}
+
 func (upload *ownedAuthorizedUpload) Close() error {
 	upload.closeOnce.Do(func() {
-		upload.closeErr = upload.AuthorizedUpload.Close()
+		upload.closeErr = upload.upload.Close()
 	})
 	return upload.closeErr
 }

--- a/document/provider.go
+++ b/document/provider.go
@@ -274,21 +274,35 @@ func RenderRendition(
 	if err != nil {
 		return RenditionResult{}, err
 	}
+	expiresAt, err := parseRenditionTimestamp(sealed.ExpiresAt)
+	if err != nil {
+		return RenditionResult{}, errors.New("authorization expiry must be canonical")
+	}
+	executionCtx, cancelExecution := context.WithDeadline(ctx, expiresAt)
+	defer cancelExecution()
+	stopExecutionClose := context.AfterFunc(executionCtx, func() { _ = ownedUpload.Close() })
+	defer stopExecutionClose()
 	if !sealed.DiscloseFilename {
 		metadata.Filename = ""
 	}
 	hasher := sha256.New()
 	limited := &io.LimitedReader{R: ownedUpload, N: sealed.SourceBytes}
 	providerUpload := &sealedAuthorizedUpload{
-		source: ownedUpload, metadata: metadata, limited: limited,
+		ctx: executionCtx, source: ownedUpload, metadata: metadata, limited: limited,
 		reader: io.TeeReader(limited, hasher), hasher: hasher, expectedSHA256: sealed.SourceSHA256,
 	}
-	if err := ctx.Err(); err != nil {
+	if err := executionCtx.Err(); err != nil {
 		return RenditionResult{}, err
 	}
-	result, err = provider.Render(ctx, providerUpload, cloneRenditionAuthorization(sealed))
+	result, err = provider.Render(executionCtx, providerUpload, cloneRenditionAuthorization(sealed))
 	_ = providerUpload.Close()
 	if contextErr := ctx.Err(); contextErr != nil {
+		return RenditionResult{}, contextErr
+	}
+	if err := validateAuthorizationCurrentAt(sealed, time.Now().UTC()); err != nil {
+		return RenditionResult{}, err
+	}
+	if contextErr := executionCtx.Err(); contextErr != nil {
 		return RenditionResult{}, contextErr
 	}
 	if err != nil {
@@ -304,10 +318,19 @@ func RenderRendition(
 	if err := ValidateRenditionResult(descriptor, sealed, result); err != nil {
 		return RenditionResult{}, err
 	}
-	if err := providerUpload.verify(ctx); err != nil {
+	if err := providerUpload.verify(executionCtx); err != nil {
 		if contextErr := ctx.Err(); contextErr != nil {
 			return RenditionResult{}, contextErr
 		}
+		if currentErr := validateAuthorizationCurrentAt(sealed, time.Now().UTC()); currentErr != nil {
+			return RenditionResult{}, currentErr
+		}
+		if contextErr := executionCtx.Err(); contextErr != nil {
+			return RenditionResult{}, contextErr
+		}
+		return RenditionResult{}, err
+	}
+	if err := validateAuthorizationCurrentAt(sealed, time.Now().UTC()); err != nil {
 		return RenditionResult{}, err
 	}
 	return result, nil
@@ -563,6 +586,7 @@ func cloneSourceEvidenceOmissions(source []SourceEvidenceOmissionV1) []SourceEvi
 type sealedAuthorizedUpload struct {
 	mu sync.Mutex
 
+	ctx            context.Context
 	source         *ownedAuthorizedUpload
 	metadata       AuthorizedUploadMetadata
 	reader         io.Reader
@@ -579,6 +603,9 @@ func (upload *sealedAuthorizedUpload) Metadata() AuthorizedUploadMetadata {
 func (upload *sealedAuthorizedUpload) Read(buffer []byte) (int, error) {
 	upload.mu.Lock()
 	defer upload.mu.Unlock()
+	if err := upload.ctx.Err(); err != nil {
+		return 0, err
+	}
 	if upload.providerClosed {
 		return 0, io.ErrClosedPipe
 	}

--- a/document/provider.go
+++ b/document/provider.go
@@ -300,6 +300,9 @@ func RenderRendition(
 		}
 		return RenditionResult{}, err
 	}
+	if err := validateRenditionArtifactCount(sealed.MaxArtifacts, result.Artifacts); err != nil {
+		return RenditionResult{}, err
+	}
 	if err := preflightRenditionResult(sealed.MaxTotalResultBytes, result); err != nil {
 		return RenditionResult{}, err
 	}
@@ -333,6 +336,9 @@ func ValidateRenditionResult(
 		return err
 	}
 	if err := validateAuthorizationWithoutUpload(descriptor, authorization); err != nil {
+		return err
+	}
+	if err := validateRenditionArtifactCount(authorization.MaxArtifacts, result.Artifacts); err != nil {
 		return err
 	}
 	if err := preflightRenditionResult(authorization.MaxTotalResultBytes, result); err != nil {
@@ -1013,7 +1019,11 @@ func validateRenditionArtifacts(
 		}
 		seen[key] = struct{}{}
 	}
-	if len(artifacts) > authorization.MaxArtifacts {
+	return nil
+}
+
+func validateRenditionArtifactCount(maxArtifacts int, artifacts []RenditionArtifact) error {
+	if len(artifacts) > maxArtifacts {
 		return errors.New("provider artifact count exceeds authorization")
 	}
 	return nil

--- a/document/provider.go
+++ b/document/provider.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -21,6 +22,7 @@ const (
 	maxRenditionFormats          = 64
 	maxRenditionArtifactRoles    = 16
 	maxRenditionArtifacts        = 64
+	maxRenditionMediaTypeBytes   = 255
 	maxRenditionSourceBytes      = int64(1 << 40)
 	maxRenditionMarkdownBytes    = 64 << 20
 	maxRenditionArtifactBytes    = 256 << 20
@@ -241,23 +243,36 @@ func validateRenditionProviderRequestAt(
 	return cloneRenditionDescriptor(descriptor), metadata, nil
 }
 
-// RenderRendition validates immutable boundary snapshots, gives the provider
-// a separate authorization copy, and validates its result against the sealed
-// copy. Provider mutation therefore cannot broaden its own output authority.
+// RenderRendition takes ownership of upload, validates immutable boundary
+// snapshots, gives the provider a separate authorization copy, and validates
+// its result against the sealed copy. Provider mutation therefore cannot
+// broaden its own output authority. The upload is closed exactly once before
+// return, including when validation or the provider fails.
 func RenderRendition(
 	ctx context.Context, provider RenditionProvider, upload AuthorizedUpload,
 	authorization RenditionAuthorization,
-) (RenditionResult, error) {
+) (result RenditionResult, err error) {
+	if nilInterface(upload) {
+		return RenditionResult{}, errors.New("authorized upload is required")
+	}
+	ownedUpload := &ownedAuthorizedUpload{AuthorizedUpload: upload}
+	defer func() {
+		closeErr := ownedUpload.Close()
+		if closeErr != nil && !errors.Is(err, closeErr) {
+			err = errors.Join(err, fmt.Errorf("close authorized upload: %w", closeErr))
+		}
+	}()
+
 	sealed := cloneRenditionAuthorization(authorization)
-	descriptor, metadata, err := validateRenditionProviderRequestAt(time.Now().UTC(), provider, upload, sealed)
+	descriptor, metadata, err := validateRenditionProviderRequestAt(time.Now().UTC(), provider, ownedUpload, sealed)
 	if err != nil {
 		return RenditionResult{}, err
 	}
 	if !sealed.DiscloseFilename {
 		metadata.Filename = ""
 	}
-	providerUpload := &sealedAuthorizedUpload{ReadCloser: upload, metadata: metadata}
-	result, err := provider.Render(ctx, providerUpload, cloneRenditionAuthorization(sealed))
+	providerUpload := &sealedAuthorizedUpload{ReadCloser: ownedUpload, metadata: metadata}
+	result, err = provider.Render(ctx, providerUpload, cloneRenditionAuthorization(sealed))
 	if err != nil {
 		if classified := ValidateRenditionProviderError(err); classified != nil {
 			return RenditionResult{}, classified
@@ -306,11 +321,14 @@ func ValidateRenditionResult(
 	if err != nil {
 		return fmt.Errorf("encode provider evidence: %w", err)
 	}
-	total := len(encodedEvidence) + len(result.ProviderMarkdown)
+	total := int64(len(encodedEvidence) + len(result.ProviderMarkdown))
 	for _, artifact := range result.Artifacts {
-		total += len(artifact.Payload)
+		total += int64(len(artifact.Role) + len(artifact.MediaType) + len(artifact.SHA256) + len(artifact.Payload))
+		if total > int64(authorization.MaxTotalResultBytes) {
+			return errors.New("provider total result bytes exceed authorization")
+		}
 	}
-	if total > authorization.MaxTotalResultBytes {
+	if total > int64(authorization.MaxTotalResultBytes) {
 		return errors.New("provider total result bytes exceed authorization")
 	}
 	return nil
@@ -460,6 +478,20 @@ func (upload *sealedAuthorizedUpload) Metadata() AuthorizedUploadMetadata {
 	return upload.metadata
 }
 
+type ownedAuthorizedUpload struct {
+	AuthorizedUpload
+
+	closeErr  error
+	closeOnce sync.Once
+}
+
+func (upload *ownedAuthorizedUpload) Close() error {
+	upload.closeOnce.Do(func() {
+		upload.closeErr = upload.AuthorizedUpload.Close()
+	})
+	return upload.closeErr
+}
+
 func validateRenditionDescriptorFields(descriptor RenditionDescriptor) error {
 	if err := validateStableToken(descriptor.ID, "descriptor ID", 128); err != nil {
 		return err
@@ -501,8 +533,8 @@ func validateRenditionDescriptorFields(descriptor RenditionDescriptor) error {
 		}
 		seenRoles[role] = struct{}{}
 	}
-	if !descriptor.ReturnsMarkdown && !descriptor.ReturnsStructured && len(descriptor.ArtifactRoles) == 0 {
-		return errors.New("descriptor must declare at least one result kind")
+	if !descriptor.ReturnsStructured {
+		return errors.New("descriptor must declare structured evidence")
 	}
 	return nil
 }
@@ -813,6 +845,9 @@ func validateStableToken(value, subject string, maxLength int) error {
 }
 
 func validateCanonicalMediaType(value string) error {
+	if len(value) == 0 || len(value) > maxRenditionMediaTypeBytes {
+		return fmt.Errorf("media type must contain 1-%d bytes", maxRenditionMediaTypeBytes)
+	}
 	parsed, parameters, err := mime.ParseMediaType(value)
 	if err != nil || parsed != value || len(parameters) != 0 || !strings.Contains(value, "/") {
 		return fmt.Errorf("media type %q must be canonical and contain no parameters", value)

--- a/document/provider.go
+++ b/document/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"hash"
@@ -192,24 +193,6 @@ type RenditionResult struct {
 	Receipt          RenditionReceipt    `json:"receipt"`
 }
 
-// ValidateRenditionProviderRequest validates the provider snapshot and exact upload authorization.
-func ValidateRenditionProviderRequest(
-	provider RenditionProvider, upload AuthorizedUpload, authorization RenditionAuthorization,
-) (RenditionDescriptor, error) {
-	return ValidateRenditionProviderRequestAt(time.Now().UTC(), provider, upload, authorization)
-}
-
-// ValidateRenditionProviderRequestAt validates a request against an explicit
-// trusted clock. Callers with a transaction clock can avoid time-of-check
-// drift while retaining the same expiry boundary.
-func ValidateRenditionProviderRequestAt(
-	now time.Time, provider RenditionProvider, upload AuthorizedUpload,
-	authorization RenditionAuthorization,
-) (RenditionDescriptor, error) {
-	descriptor, _, err := validateRenditionProviderRequestAt(now, provider, upload, authorization)
-	return descriptor, err
-}
-
 func validateRenditionProviderRequestAt(
 	now time.Time, provider RenditionProvider, upload AuthorizedUpload,
 	authorization RenditionAuthorization,
@@ -311,7 +294,7 @@ func RenderRendition(
 		}
 		return RenditionResult{}, err
 	}
-	if err := ValidateRenditionResult(descriptor, sealed, result); err != nil {
+	if err := preflightRenditionResult(sealed.MaxTotalResultBytes, result); err != nil {
 		return RenditionResult{}, err
 	}
 	result = cloneRenditionResult(result)
@@ -346,6 +329,9 @@ func ValidateRenditionResult(
 	if err := validateAuthorizationWithoutUpload(descriptor, authorization); err != nil {
 		return err
 	}
+	if err := preflightRenditionResult(authorization.MaxTotalResultBytes, result); err != nil {
+		return err
+	}
 	if err := ValidateSourceEvidenceV1(result.Evidence); err != nil {
 		return fmt.Errorf("provider evidence: %w", err)
 	}
@@ -368,25 +354,122 @@ func ValidateRenditionResult(
 	if err := validateRenditionReceipt(descriptor, authorization, result.Receipt); err != nil {
 		return err
 	}
-	encodedEvidence, err := canonicalJSON(result.Evidence)
-	if err != nil {
-		return fmt.Errorf("encode provider evidence: %w", err)
+	return nil
+}
+
+var errRenditionResultTooLarge = errors.New("provider total result bytes exceed authorization")
+
+type renditionResultSizeWriter struct {
+	remaining int64
+}
+
+func (writer *renditionResultSizeWriter) Write(value []byte) (int, error) {
+	if int64(len(value)) > writer.remaining {
+		return 0, errRenditionResultTooLarge
 	}
-	encodedReceipt, err := canonicalJSON(result.Receipt)
-	if err != nil {
-		return fmt.Errorf("encode provider receipt: %w", err)
+	writer.remaining -= int64(len(value))
+	return len(value), nil
+}
+
+func preflightRenditionResult(maxBytes int, result RenditionResult) error {
+	// Bound encoded string and byte tokens without first copying them into
+	// the streaming encoder's buffer, then count the complete JSON structure.
+	remaining := int64(maxBytes)
+	if !consumeRenditionResultTokens(reflect.ValueOf(result), &remaining) {
+		return errRenditionResultTooLarge
 	}
-	total := int64(len(encodedEvidence)) + int64(len(encodedReceipt)) + int64(len(result.ProviderMarkdown))
-	for _, artifact := range result.Artifacts {
-		total += int64(len(artifact.Role) + len(artifact.MediaType) + len(artifact.SHA256) + len(artifact.Payload))
-		if total > int64(authorization.MaxTotalResultBytes) {
-			return errors.New("provider total result bytes exceed authorization")
+	writer := renditionResultSizeWriter{remaining: int64(maxBytes)}
+	if err := json.MarshalWrite(&writer, result); err != nil {
+		if errors.Is(err, errRenditionResultTooLarge) {
+			return errRenditionResultTooLarge
 		}
-	}
-	if total > int64(authorization.MaxTotalResultBytes) {
-		return errors.New("provider total result bytes exceed authorization")
+		return fmt.Errorf("encode provider result: %w", err)
 	}
 	return nil
+}
+
+func consumeRenditionResultTokens(value reflect.Value, remaining *int64) bool {
+	if !value.IsValid() {
+		return true
+	}
+	switch value.Kind() {
+	case reflect.Interface, reflect.Pointer:
+		return value.IsNil() || consumeRenditionResultTokens(value.Elem(), remaining)
+	case reflect.String:
+		return consumeRenditionJSONString(value.String(), remaining)
+	case reflect.Slice:
+		if value.Type().Elem().Kind() == reflect.Uint8 {
+			if value.Len() == 0 {
+				return true
+			}
+			encodedBytes := int64(value.Len()/3) * 4
+			if value.Len()%3 != 0 {
+				encodedBytes += 4
+			}
+			return consumeRenditionBytes(encodedBytes+2, remaining)
+		}
+		fallthrough
+	case reflect.Array:
+		for index := range value.Len() {
+			if !consumeRenditionResultTokens(value.Index(index), remaining) {
+				return false
+			}
+		}
+	case reflect.Struct:
+		for _, field := range value.Fields() {
+			if !consumeRenditionResultTokens(field, remaining) {
+				return false
+			}
+		}
+	case reflect.Map:
+		iterator := value.MapRange()
+		for iterator.Next() {
+			if !consumeRenditionResultTokens(iterator.Key(), remaining) ||
+				!consumeRenditionResultTokens(iterator.Value(), remaining) {
+				return false
+			}
+		}
+	case reflect.Invalid,
+		reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128,
+		reflect.Chan, reflect.Func, reflect.UnsafePointer:
+	}
+	return true
+}
+
+func consumeRenditionJSONString(value string, remaining *int64) bool {
+	if value == "" {
+		return true
+	}
+	if !consumeRenditionBytes(2, remaining) {
+		return false
+	}
+	for index := range len(value) {
+		encodedBytes := int64(1)
+		switch value[index] {
+		case '\\', '"', '\b', '\f', '\n', '\r', '\t':
+			encodedBytes = 2
+		default:
+			if value[index] < 0x20 {
+				encodedBytes = 6
+			}
+		}
+		if !consumeRenditionBytes(encodedBytes, remaining) {
+			return false
+		}
+	}
+	return true
+}
+
+func consumeRenditionBytes(count int64, remaining *int64) bool {
+	if count > *remaining {
+		return false
+	}
+	*remaining -= count
+	return true
 }
 
 // RenditionErrorCode is a stable, bounded provider failure class.

--- a/document/provider.go
+++ b/document/provider.go
@@ -300,6 +300,10 @@ func RenderRendition(
 	if err := ValidateRenditionResult(descriptor, sealed, result); err != nil {
 		return RenditionResult{}, err
 	}
+	result = cloneRenditionResult(result)
+	if err := ValidateRenditionResult(descriptor, sealed, result); err != nil {
+		return RenditionResult{}, err
+	}
 	if err := providerUpload.verify(ctx); err != nil {
 		if contextErr := ctx.Err(); contextErr != nil {
 			return RenditionResult{}, contextErr
@@ -345,7 +349,11 @@ func ValidateRenditionResult(
 	if err != nil {
 		return fmt.Errorf("encode provider evidence: %w", err)
 	}
-	total := int64(len(encodedEvidence) + len(result.ProviderMarkdown))
+	encodedReceipt, err := canonicalJSON(result.Receipt)
+	if err != nil {
+		return fmt.Errorf("encode provider receipt: %w", err)
+	}
+	total := int64(len(encodedEvidence)) + int64(len(encodedReceipt)) + int64(len(result.ProviderMarkdown))
 	for _, artifact := range result.Artifacts {
 		total += int64(len(artifact.Role) + len(artifact.MediaType) + len(artifact.SHA256) + len(artifact.Payload))
 		if total > int64(authorization.MaxTotalResultBytes) {
@@ -490,6 +498,66 @@ func validateRenditionDescriptor(descriptor RenditionDescriptor) error {
 func cloneRenditionAuthorization(value RenditionAuthorization) RenditionAuthorization {
 	value.AllowedArtifactRoles = slices.Clone(value.AllowedArtifactRoles)
 	return value
+}
+
+func cloneRenditionResult(value RenditionResult) RenditionResult {
+	value.Evidence = cloneSourceEvidenceV1(value.Evidence)
+	value.ProviderMarkdown = slices.Clone(value.ProviderMarkdown)
+	value.Artifacts = slices.Clone(value.Artifacts)
+	for index := range value.Artifacts {
+		value.Artifacts[index].Payload = slices.Clone(value.Artifacts[index].Payload)
+	}
+	value.Receipt.Warnings = slices.Clone(value.Receipt.Warnings)
+	return value
+}
+
+func cloneSourceEvidenceV1(value SourceEvidenceV1) SourceEvidenceV1 {
+	value.Artifacts = slices.Clone(value.Artifacts)
+	value.Omissions = cloneSourceEvidenceOmissions(value.Omissions)
+	value.Units = slices.Clone(value.Units)
+	for unitIndex := range value.Units {
+		unit := &value.Units[unitIndex]
+		if unit.Confidence != nil {
+			confidence := *unit.Confidence
+			unit.Confidence = &confidence
+		}
+		unit.HeadingPath = slices.Clone(unit.HeadingPath)
+		unit.Omissions = cloneSourceEvidenceOmissions(unit.Omissions)
+		unit.Regions = slices.Clone(unit.Regions)
+		for regionIndex := range unit.Regions {
+			region := &unit.Regions[regionIndex]
+			if region.Confidence != nil {
+				confidence := *region.Confidence
+				region.Confidence = &confidence
+			}
+			if region.Geometry != nil {
+				geometry := *region.Geometry
+				geometry.Boxes = slices.Clone(geometry.Boxes)
+				geometry.Polygons = cloneEvidencePolygons(geometry.Polygons)
+				region.Geometry = &geometry
+			}
+		}
+		unit.Tables = slices.Clone(unit.Tables)
+		for tableIndex := range unit.Tables {
+			unit.Tables[tableIndex].Cells = slices.Clone(unit.Tables[tableIndex].Cells)
+		}
+	}
+	return value
+}
+
+func cloneSourceEvidenceOmissions(source []SourceEvidenceOmissionV1) []SourceEvidenceOmissionV1 {
+	result := slices.Clone(source)
+	for index := range result {
+		if result[index].Locator != nil {
+			locator := *result[index].Locator
+			result[index].Locator = &locator
+		}
+		if result[index].Range != nil {
+			textRange := *result[index].Range
+			result[index].Range = &textRange
+		}
+	}
+	return result
 }
 
 type sealedAuthorizedUpload struct {
@@ -662,7 +730,7 @@ func validateRenditionFormat(format RenditionFormatCapability) error {
 }
 
 func validateAuthorizedUploadMetadata(metadata AuthorizedUploadMetadata) error {
-	if metadata.Filename == "" || len(metadata.Filename) > 255 || strings.ContainsAny(metadata.Filename, "/\\\x00") {
+	if len(metadata.Filename) > 255 || strings.ContainsAny(metadata.Filename, "/\\\x00") {
 		return errors.New("upload filename must be a safe basename of at most 255 bytes")
 	}
 	if err := validateRenditionFormat(RenditionFormatCapability{
@@ -689,6 +757,9 @@ func validateRenditionAuthorization(
 ) error {
 	if err := validateAuthorizationWithoutUpload(descriptor, authorization); err != nil {
 		return err
+	}
+	if authorization.DiscloseFilename && metadata.Filename == "" {
+		return errors.New("authorization requires filename disclosure but upload filename is empty")
 	}
 	if authorization.SourceSHA256 != metadata.SHA256 || authorization.SourceBytes != metadata.ByteLength {
 		return errors.New("authorization does not match exact upload bytes")

--- a/document/provider.go
+++ b/document/provider.go
@@ -114,6 +114,7 @@ func NewRenditionDescriptor(value RenditionDescriptor) (RenditionDescriptor, err
 }
 
 // AuthorizedUploadMetadata describes the exact bytes presented to a provider.
+// Filename is empty when the authorization withholds filename disclosure.
 type AuthorizedUploadMetadata struct {
 	Filename                 string             `json:"filename"`
 	MediaFamily              string             `json:"media_family"`
@@ -138,6 +139,7 @@ type RenditionAuthorization struct {
 	MediaFamily                 string                 `json:"media_family"`
 	MediaType                   string                 `json:"media_type"`
 	InputKind                   RenditionInputKind     `json:"input_kind"`
+	DiscloseFilename            bool                   `json:"disclose_filename"`
 	AllowedArtifactRoles        []EvidenceArtifactRole `json:"allowed_artifact_roles"`
 	MaxProviderMarkdownBytes    int                    `json:"max_provider_markdown_bytes"`
 	MaxArtifactBytes            int                    `json:"max_artifact_bytes"`
@@ -166,16 +168,17 @@ type RenditionUsage struct {
 
 // RenditionReceipt is a sanitized, bounded execution record without provider bodies or secrets.
 type RenditionReceipt struct {
-	ProviderID            string         `json:"provider_id"`
-	DescriptorFingerprint string         `json:"descriptor_fingerprint"`
-	PolicyFingerprint     string         `json:"policy_fingerprint"`
-	SourceSHA256          string         `json:"source_sha256"`
-	OperationID           string         `json:"operation_id"`
-	StartedAt             string         `json:"started_at"`
-	CompletedAt           string         `json:"completed_at"`
-	Warnings              []string       `json:"warnings,omitempty"`
-	Usage                 RenditionUsage `json:"usage"`
-	RetryDelayMillis      int64          `json:"retry_delay_millis,omitempty"`
+	ProviderID                  string         `json:"provider_id"`
+	DescriptorFingerprint       string         `json:"descriptor_fingerprint"`
+	PolicyFingerprint           string         `json:"policy_fingerprint"`
+	RenditionRequestFingerprint string         `json:"rendition_request_fingerprint"`
+	SourceSHA256                string         `json:"source_sha256"`
+	OperationID                 string         `json:"operation_id"`
+	StartedAt                   string         `json:"started_at"`
+	CompletedAt                 string         `json:"completed_at"`
+	Warnings                    []string       `json:"warnings,omitempty"`
+	Usage                       RenditionUsage `json:"usage"`
+	RetryDelayMillis            int64          `json:"retry_delay_millis,omitempty"`
 }
 
 // RenditionResult contains bounded provider output and its sanitized receipt.
@@ -200,34 +203,42 @@ func ValidateRenditionProviderRequestAt(
 	now time.Time, provider RenditionProvider, upload AuthorizedUpload,
 	authorization RenditionAuthorization,
 ) (RenditionDescriptor, error) {
+	descriptor, _, err := validateRenditionProviderRequestAt(now, provider, upload, authorization)
+	return descriptor, err
+}
+
+func validateRenditionProviderRequestAt(
+	now time.Time, provider RenditionProvider, upload AuthorizedUpload,
+	authorization RenditionAuthorization,
+) (RenditionDescriptor, AuthorizedUploadMetadata, error) {
 	if nilInterface(provider) {
-		return RenditionDescriptor{}, errors.New("rendition provider is required")
+		return RenditionDescriptor{}, AuthorizedUploadMetadata{}, errors.New("rendition provider is required")
 	}
 	if nilInterface(upload) {
-		return RenditionDescriptor{}, errors.New("authorized upload is required")
+		return RenditionDescriptor{}, AuthorizedUploadMetadata{}, errors.New("authorized upload is required")
 	}
 	authorization = cloneRenditionAuthorization(authorization)
 	descriptor := cloneRenditionDescriptor(provider.Descriptor())
 	if err := validateRenditionDescriptor(descriptor); err != nil {
-		return RenditionDescriptor{}, err
+		return RenditionDescriptor{}, AuthorizedUploadMetadata{}, err
 	}
 	if second := cloneRenditionDescriptor(provider.Descriptor()); !equalRenditionDescriptors(descriptor, second) {
-		return RenditionDescriptor{}, errors.New("rendition descriptor changed during validation")
+		return RenditionDescriptor{}, AuthorizedUploadMetadata{}, errors.New("rendition descriptor changed during validation")
 	}
 	metadata := upload.Metadata()
 	if err := validateAuthorizedUploadMetadata(metadata); err != nil {
-		return RenditionDescriptor{}, err
+		return RenditionDescriptor{}, AuthorizedUploadMetadata{}, err
 	}
 	if second := upload.Metadata(); second != metadata {
-		return RenditionDescriptor{}, errors.New("authorized upload metadata changed during validation")
+		return RenditionDescriptor{}, AuthorizedUploadMetadata{}, errors.New("authorized upload metadata changed during validation")
 	}
 	if err := validateRenditionAuthorization(descriptor, metadata, authorization); err != nil {
-		return RenditionDescriptor{}, err
+		return RenditionDescriptor{}, AuthorizedUploadMetadata{}, err
 	}
 	if err := validateAuthorizationCurrentAt(authorization, now); err != nil {
-		return RenditionDescriptor{}, err
+		return RenditionDescriptor{}, AuthorizedUploadMetadata{}, err
 	}
-	return cloneRenditionDescriptor(descriptor), nil
+	return cloneRenditionDescriptor(descriptor), metadata, nil
 }
 
 // RenderRendition validates immutable boundary snapshots, gives the provider
@@ -238,11 +249,15 @@ func RenderRendition(
 	authorization RenditionAuthorization,
 ) (RenditionResult, error) {
 	sealed := cloneRenditionAuthorization(authorization)
-	descriptor, err := ValidateRenditionProviderRequest(provider, upload, sealed)
+	descriptor, metadata, err := validateRenditionProviderRequestAt(time.Now().UTC(), provider, upload, sealed)
 	if err != nil {
 		return RenditionResult{}, err
 	}
-	result, err := provider.Render(ctx, upload, cloneRenditionAuthorization(sealed))
+	if !sealed.DiscloseFilename {
+		metadata.Filename = ""
+	}
+	providerUpload := &sealedAuthorizedUpload{ReadCloser: upload, metadata: metadata}
+	result, err := provider.Render(ctx, providerUpload, cloneRenditionAuthorization(sealed))
 	if err != nil {
 		if classified := ValidateRenditionProviderError(err); classified != nil {
 			return RenditionResult{}, classified
@@ -317,31 +332,53 @@ const (
 	RenditionErrorAmbiguousSubmission RenditionErrorCode = "ambiguous_submission"
 )
 
-// RenditionProviderError preserves a private cause behind a sanitized error class and message.
+// RenditionProviderError preserves a private cause behind a fixed error class.
 type RenditionProviderError struct {
 	code       RenditionErrorCode
-	message    string
 	retryAfter time.Duration
 	cause      error
 }
 
 // NewRenditionProviderError constructs a classified provider failure.
 func NewRenditionProviderError(
-	code RenditionErrorCode, message string, retryAfter time.Duration, cause error,
+	code RenditionErrorCode, retryAfter time.Duration, cause error,
 ) (*RenditionProviderError, error) {
-	providerError := &RenditionProviderError{code: code, message: message, retryAfter: retryAfter, cause: cause}
+	providerError := &RenditionProviderError{code: code, retryAfter: retryAfter, cause: cause}
 	if err := validateClassifiedProviderError(providerError); err != nil {
 		return nil, err
 	}
 	return providerError, nil
 }
 
-// Error returns only the sanitized failure class and message.
+// Error returns only the fixed message for the failure class.
 func (providerError *RenditionProviderError) Error() string {
 	if providerError == nil {
 		return "rendition provider error"
 	}
-	return fmt.Sprintf("rendition provider %s: %s", providerError.code, providerError.message)
+	switch providerError.code {
+	case RenditionErrorUnsupportedInput:
+		return "rendition provider does not support the input"
+	case RenditionErrorPolicyRejected:
+		return "rendition provider rejected the request policy"
+	case RenditionErrorAuthentication:
+		return "rendition provider authentication failed"
+	case RenditionErrorCapacity:
+		return "rendition provider has insufficient capacity"
+	case RenditionErrorRateLimited:
+		return "rendition provider rate limit reached"
+	case RenditionErrorTransient:
+		return "rendition provider failed temporarily"
+	case RenditionErrorMalformedEvidence:
+		return "rendition provider returned malformed evidence"
+	case RenditionErrorUnknownJob:
+		return "rendition provider job is unknown"
+	case RenditionErrorCanceled:
+		return "rendition provider request was canceled"
+	case RenditionErrorAmbiguousSubmission:
+		return "rendition provider submission status is ambiguous"
+	default:
+		return "rendition provider error"
+	}
 }
 
 // Unwrap exposes the private cause for programmatic matching without rendering it.
@@ -411,6 +448,16 @@ func validateRenditionDescriptor(descriptor RenditionDescriptor) error {
 func cloneRenditionAuthorization(value RenditionAuthorization) RenditionAuthorization {
 	value.AllowedArtifactRoles = slices.Clone(value.AllowedArtifactRoles)
 	return value
+}
+
+type sealedAuthorizedUpload struct {
+	io.ReadCloser
+
+	metadata AuthorizedUploadMetadata
+}
+
+func (upload *sealedAuthorizedUpload) Metadata() AuthorizedUploadMetadata {
+	return upload.metadata
 }
 
 func validateRenditionDescriptorFields(descriptor RenditionDescriptor) error {
@@ -557,7 +604,7 @@ func validateAuthorizationWithoutUpload(descriptor RenditionDescriptor, authoriz
 		return errors.New("authorization artifact bytes are invalid")
 	}
 	if authorization.MaxArtifacts < 0 || authorization.MaxArtifacts > maxRenditionArtifacts ||
-		authorization.MaxArtifacts > len(authorization.AllowedArtifactRoles) {
+		authorization.MaxArtifacts > 0 && len(authorization.AllowedArtifactRoles) == 0 {
 		return errors.New("authorization artifact count is invalid")
 	}
 	if authorization.MaxTotalResultBytes <= 0 || authorization.MaxTotalResultBytes > maxRenditionTotalResultBytes {
@@ -609,16 +656,16 @@ func validateAuthorizedRoles(descriptor RenditionDescriptor, roles []EvidenceArt
 func validateRenditionArtifacts(
 	descriptor RenditionDescriptor, authorization RenditionAuthorization, artifacts []RenditionArtifact,
 ) error {
-	seen := make(map[EvidenceArtifactRole]struct{}, len(artifacts))
+	type identity struct {
+		role   EvidenceArtifactRole
+		sha256 string
+	}
+	seen := make(map[identity]struct{}, len(artifacts))
 	for _, artifact := range artifacts {
 		if !validProfileArtifactRole(artifact.Role) || !slices.Contains(descriptor.ArtifactRoles, artifact.Role) ||
 			!slices.Contains(authorization.AllowedArtifactRoles, artifact.Role) {
 			return fmt.Errorf("provider artifact role %q is not authorized", artifact.Role)
 		}
-		if _, exists := seen[artifact.Role]; exists {
-			return fmt.Errorf("provider artifact role %q is duplicated", artifact.Role)
-		}
-		seen[artifact.Role] = struct{}{}
 		if err := validateCanonicalMediaType(artifact.MediaType); err != nil {
 			return fmt.Errorf("provider artifact: %w", err)
 		}
@@ -629,6 +676,11 @@ func validateRenditionArtifacts(
 		if artifact.SHA256 != hex.EncodeToString(digest[:]) {
 			return errors.New("provider artifact checksum does not match payload")
 		}
+		key := identity{role: artifact.Role, sha256: artifact.SHA256}
+		if _, exists := seen[key]; exists {
+			return errors.New("provider artifact identity is duplicated")
+		}
+		seen[key] = struct{}{}
 	}
 	if len(artifacts) > authorization.MaxArtifacts {
 		return errors.New("provider artifact count exceeds authorization")
@@ -671,7 +723,9 @@ func validateRenditionReceipt(
 	descriptor RenditionDescriptor, authorization RenditionAuthorization, receipt RenditionReceipt,
 ) error {
 	if receipt.ProviderID != descriptor.ID || receipt.DescriptorFingerprint != descriptor.Fingerprint ||
-		receipt.PolicyFingerprint != authorization.PolicyFingerprint || receipt.SourceSHA256 != authorization.SourceSHA256 {
+		receipt.PolicyFingerprint != authorization.PolicyFingerprint ||
+		receipt.RenditionRequestFingerprint != authorization.RenditionRequestFingerprint ||
+		receipt.SourceSHA256 != authorization.SourceSHA256 {
 		return errors.New("provider receipt does not match authorization")
 	}
 	if err := validateStableToken(receipt.OperationID, "operation ID", 128); err != nil {
@@ -739,24 +793,8 @@ func validateClassifiedProviderError(providerError *RenditionProviderError) erro
 	default:
 		return errors.New("rendition provider error code is invalid")
 	}
-	if err := validateSafeMessage(providerError.message); err != nil {
-		return err
-	}
 	if providerError.retryAfter < 0 || providerError.retryAfter > 24*time.Hour {
 		return errors.New("rendition provider retry delay is outside the supported bound")
-	}
-	return nil
-}
-
-func validateSafeMessage(value string) error {
-	if value == "" || len(value) > 160 || strings.ContainsAny(value, "\r\n{}[]<>=\"") {
-		return errors.New("rendition provider error message must be a bounded safe summary")
-	}
-	lower := strings.ToLower(value)
-	for _, unsafe := range []string{"authorization:", "bearer ", "api_key", "apikey", "secret", "token="} {
-		if strings.Contains(lower, unsafe) {
-			return errors.New("rendition provider error message contains credential-shaped content")
-		}
 	}
 	return nil
 }

--- a/document/provider.go
+++ b/document/provider.go
@@ -1087,7 +1087,7 @@ func validateRenditionReceipt(
 	}
 	authorizedAt, _ := parseRenditionTimestamp(authorization.AuthorizedAt)
 	expiresAt, _ := parseRenditionTimestamp(authorization.ExpiresAt)
-	if startedAt.Before(authorizedAt) || completedAt.After(expiresAt) {
+	if startedAt.Before(authorizedAt) || !completedAt.Before(expiresAt) {
 		return errors.New("receipt execution is outside the authorization interval")
 	}
 	if len(receipt.Warnings) > maxRenditionWarnings {

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -241,6 +241,23 @@ func TestRenditionProviderContractCountsArtifactMetadataAgainstTotal(t *testing.
 	)
 }
 
+func TestRenditionProviderContractCountsReceiptAgainstTotal(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	result := validRenditionResult(descriptor, authorization)
+	encodedEvidence, err := canonicalJSON(result.Evidence)
+	require.NoError(t, err)
+	artifact := result.Artifacts[0]
+	authorization.MaxTotalResultBytes = len(encodedEvidence) + len(result.ProviderMarkdown) +
+		len(artifact.Role) + len(artifact.MediaType) + len(artifact.SHA256) + len(artifact.Payload)
+
+	require.ErrorContains(t,
+		ValidateRenditionResult(descriptor, authorization, result),
+		"total result bytes",
+	)
+}
+
 func TestRenditionProviderContractAcceptsRepeatedArtifactRoles(t *testing.T) {
 	descriptor := validRenditionDescriptor(t)
 	metadata := validAuthorizedUploadMetadata()
@@ -472,6 +489,34 @@ func TestRenderRenditionKeepsSealedAuthorizationSeparateFromProvider(t *testing.
 		"provider mutation must not reach the caller or sealed validation snapshot")
 }
 
+func TestRenderRenditionOwnsValidatedResult(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	provided := validRenditionResult(descriptor, authorization)
+	expected, err := canonicalJSON(provided)
+	require.NoError(t, err)
+	provider := &mutatingRenditionProvider{descriptor: descriptor}
+	provider.render = func(_ AuthorizedUpload, _ RenditionAuthorization) RenditionResult {
+		return provided
+	}
+	upload := &syntheticAuthorizedUpload{
+		ReadCloser: io.NopCloser(strings.NewReader("synthetic exact source")), metadata: metadata,
+	}
+
+	result, err := RenderRendition(t.Context(), provider, upload, authorization)
+	require.NoError(t, err)
+	provided.Evidence.Artifacts[0].Pointer = "provider/changed.json"
+	provided.Evidence.Omissions[0].Reason = "changed"
+	provided.Evidence.Units[0].Text = "changed"
+	provided.ProviderMarkdown[0] = 'X'
+	provided.Artifacts[0].Payload[0] = 'X'
+	provided.Receipt.Warnings[0] = "changed"
+	actual, err := canonicalJSON(result)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
 func TestRenderRenditionOwnsUpload(t *testing.T) {
 	t.Run("validation failure preserves close error", func(t *testing.T) {
 		descriptor := validRenditionDescriptor(t)
@@ -596,16 +641,21 @@ func TestRenderRenditionCancellationClosesBlockedUpload(t *testing.T) {
 
 func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {
 	for _, testCase := range []struct {
-		name     string
-		disclose bool
-		want     string
+		name           string
+		sourceFilename string
+		disclose       bool
+		want           string
+		wantError      string
 	}{
-		{name: "withheld", want: ""},
-		{name: "disclosed", disclose: true, want: "document.pdf"},
+		{name: "withheld", sourceFilename: "document.pdf", want: ""},
+		{name: "already redacted", want: ""},
+		{name: "disclosed", sourceFilename: "document.pdf", disclose: true, want: "document.pdf"},
+		{name: "missing disclosed filename", disclose: true, wantError: "filename disclosure"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			descriptor := validRenditionDescriptor(t)
 			metadata := validAuthorizedUploadMetadata()
+			metadata.Filename = testCase.sourceFilename
 			authorization := validRenditionAuthorization(descriptor, metadata)
 			authorization.DiscloseFilename = testCase.disclose
 			provider := &mutatingRenditionProvider{descriptor: descriptor}
@@ -646,10 +696,14 @@ func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {
 			}
 
 			_, err := RenderRendition(t.Context(), provider, upload, authorization)
+			if testCase.wantError != "" {
+				require.ErrorContains(t, err, testCase.wantError)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, testCase.want, received.Filename)
 			assert.Equal(t, testCase.want, reflectedFilename)
-			assert.Equal(t, "document.pdf", upload.Metadata().Filename)
+			assert.Equal(t, testCase.sourceFilename, upload.Metadata().Filename)
 		})
 	}
 }

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -181,6 +181,7 @@ func TestRenditionProviderContractRejectsDuplicateAndOversizedOutputs(t *testing
 	descriptor := validRenditionDescriptor(t)
 	metadata := validAuthorizedUploadMetadata()
 	authorization := validRenditionAuthorization(descriptor, metadata)
+	authorization.MaxArtifacts = 2
 	for _, testCase := range []struct {
 		name   string
 		mutate func(*RenditionResult)
@@ -222,6 +223,21 @@ func TestRenditionProviderContractRejectsDuplicateAndOversizedOutputs(t *testing
 				ValidateRenditionResult(descriptor, authorization, result), testCase.want)
 		})
 	}
+}
+
+func TestRenditionProviderContractRejectsArtifactCountBeforeResultProcessing(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	authorization.MaxTotalResultBytes = 128
+	result := validRenditionResult(descriptor, authorization)
+	result.Artifacts = append(result.Artifacts, result.Artifacts[0])
+	result.Evidence.ContractVersion = "malformed"
+
+	require.ErrorContains(t,
+		ValidateRenditionResult(descriptor, authorization, result),
+		"artifact count",
+	)
 }
 
 func TestRenditionProviderContractCountsArtifactMetadataAgainstTotal(t *testing.T) {

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -557,6 +557,43 @@ func TestRenderRenditionEnforcesExactUploadBytes(t *testing.T) {
 	}
 }
 
+func TestRenderRenditionCancellationClosesBlockedUpload(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	pipeReader, pipeWriter := io.Pipe()
+	t.Cleanup(func() { _ = pipeWriter.Close() })
+	upload := &syntheticAuthorizedUpload{ReadCloser: pipeReader, metadata: metadata}
+	started := make(chan struct{})
+	readDone := make(chan error, 1)
+	provider := &mutatingRenditionProvider{descriptor: descriptor}
+	provider.render = func(upload AuthorizedUpload, received RenditionAuthorization) RenditionResult {
+		close(started)
+		_, readErr := upload.Read(make([]byte, 1))
+		readDone <- readErr
+		return validRenditionResult(descriptor, received)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, err := RenderRendition(ctx, provider, upload, authorization)
+		done <- err
+	}()
+	<-started
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		_ = pipeReader.Close()
+		<-done
+		t.Fatal("RenderRendition did not close a blocked upload after cancellation")
+	}
+	require.Error(t, <-readDone)
+	assert.Equal(t, 1, upload.closeCalls)
+}
+
 func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {
 	for _, testCase := range []struct {
 		name     string

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -1,0 +1,522 @@
+package document
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type syntheticRenditionProvider struct {
+	descriptor RenditionDescriptor
+	result     RenditionResult
+	err        error
+}
+
+func (provider syntheticRenditionProvider) Descriptor() RenditionDescriptor {
+	return provider.descriptor
+}
+
+func (provider syntheticRenditionProvider) Render(
+	context.Context, AuthorizedUpload, RenditionAuthorization,
+) (RenditionResult, error) {
+	return provider.result, provider.err
+}
+
+var _ RenditionProvider = syntheticRenditionProvider{}
+
+type syntheticAuthorizedUpload struct {
+	io.ReadCloser
+
+	metadata AuthorizedUploadMetadata
+}
+
+func (upload *syntheticAuthorizedUpload) Metadata() AuthorizedUploadMetadata {
+	return upload.metadata
+}
+
+var _ AuthorizedUpload = (*syntheticAuthorizedUpload)(nil)
+
+type changingRenditionProvider struct {
+	descriptors []RenditionDescriptor
+	calls       int
+}
+
+type mutatingRenditionProvider struct {
+	descriptor       RenditionDescriptor
+	render           func(RenditionAuthorization) RenditionResult
+	mutateDescriptor bool
+	calls            int
+}
+
+func (provider *mutatingRenditionProvider) Descriptor() RenditionDescriptor {
+	provider.calls++
+	if provider.mutateDescriptor && provider.calls == 2 {
+		provider.descriptor.ArtifactRoles[0] = EvidenceArtifactImage
+	}
+	return provider.descriptor
+}
+
+func (provider *mutatingRenditionProvider) Render(
+	_ context.Context, _ AuthorizedUpload, authorization RenditionAuthorization,
+) (RenditionResult, error) {
+	return provider.render(authorization), nil
+}
+
+func (provider *changingRenditionProvider) Descriptor() RenditionDescriptor {
+	descriptor := provider.descriptors[provider.calls]
+	provider.calls++
+	return descriptor
+}
+
+func (*changingRenditionProvider) Render(
+	context.Context, AuthorizedUpload, RenditionAuthorization,
+) (RenditionResult, error) {
+	return RenditionResult{}, nil
+}
+
+type changingAuthorizedUpload struct {
+	io.ReadCloser
+
+	metadata []AuthorizedUploadMetadata
+	calls    int
+}
+
+func (upload *changingAuthorizedUpload) Metadata() AuthorizedUploadMetadata {
+	metadata := upload.metadata[upload.calls]
+	upload.calls++
+	return metadata
+}
+
+func TestRenditionProviderContractAcceptsExactBoundedResult(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	result := validRenditionResult(descriptor, authorization)
+	provider := syntheticRenditionProvider{descriptor: descriptor, result: result}
+	upload := &syntheticAuthorizedUpload{
+		ReadCloser: io.NopCloser(strings.NewReader("synthetic exact source")), metadata: metadata,
+	}
+
+	validated, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+	require.NoError(t, err)
+	assert.Equal(t, descriptor, validated)
+	produced, err := provider.Render(t.Context(), upload, authorization)
+	require.NoError(t, err)
+	require.NoError(t, ValidateRenditionResult(validated, authorization, produced))
+}
+
+func TestRenditionProviderContractRejectsInvalidDescriptorAndAuthorization(t *testing.T) {
+	metadata := validAuthorizedUploadMetadata()
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*RenditionDescriptor, *RenditionAuthorization)
+		want   string
+	}{
+		{
+			name: "empty descriptor identity",
+			mutate: func(descriptor *RenditionDescriptor, _ *RenditionAuthorization) {
+				descriptor.ID = ""
+			},
+			want: "descriptor ID",
+		},
+		{
+			name: "unsupported format",
+			mutate: func(_ *RenditionDescriptor, authorization *RenditionAuthorization) {
+				authorization.MediaFamily = "image"
+				authorization.MediaType = "image/png"
+			},
+			want: "unsupported format",
+		},
+		{
+			name: "mismatched descriptor authorization",
+			mutate: func(_ *RenditionDescriptor, authorization *RenditionAuthorization) {
+				authorization.DescriptorFingerprint = strings.Repeat("9", 64)
+			},
+			want: "descriptor fingerprint",
+		},
+		{
+			name: "oversized result declaration",
+			mutate: func(_ *RenditionDescriptor, authorization *RenditionAuthorization) {
+				authorization.MaxTotalResultBytes = math.MaxInt64
+			},
+			want: "total result bytes",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			descriptor := validRenditionDescriptor(t)
+			authorization := validRenditionAuthorization(descriptor, metadata)
+			testCase.mutate(&descriptor, &authorization)
+			provider := syntheticRenditionProvider{descriptor: descriptor}
+			upload := &syntheticAuthorizedUpload{
+				ReadCloser: io.NopCloser(bytes.NewReader(nil)), metadata: metadata,
+			}
+			_, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+			require.ErrorContains(t, err, testCase.want)
+		})
+	}
+}
+
+func TestRenditionProviderContractRejectsDuplicateAndOversizedOutputs(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*RenditionResult)
+		want   string
+	}{
+		{
+			name: "duplicate artifact role",
+			mutate: func(result *RenditionResult) {
+				result.Artifacts = append(result.Artifacts, result.Artifacts[0])
+			},
+			want: "artifact role",
+		},
+		{
+			name: "oversized provider Markdown",
+			mutate: func(result *RenditionResult) {
+				result.ProviderMarkdown = bytes.Repeat([]byte("x"), authorization.MaxProviderMarkdownBytes+1)
+			},
+			want: "provider Markdown",
+		},
+		{
+			name: "artifact checksum mismatch",
+			mutate: func(result *RenditionResult) {
+				result.Artifacts[0].SHA256 = strings.Repeat("0", 64)
+			},
+			want: "artifact checksum",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := validRenditionResult(descriptor, authorization)
+			testCase.mutate(&result)
+			require.ErrorContains(t,
+				ValidateRenditionResult(descriptor, authorization, result), testCase.want)
+		})
+	}
+}
+
+func TestRenditionProviderContractRejectsUnauthorizedOrUnmatchedEvidenceArtifacts(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+
+	result := validRenditionResult(descriptor, authorization)
+	result.Evidence.Artifacts[0].Role = EvidenceArtifactImage
+	require.ErrorContains(t, ValidateRenditionResult(descriptor, authorization, result),
+		"not authorized")
+
+	result = validRenditionResult(descriptor, authorization)
+	result.Evidence.Artifacts[0].SHA256 = strings.Repeat("9", 64)
+	require.ErrorContains(t, ValidateRenditionResult(descriptor, authorization, result),
+		"does not match")
+
+	result = validRenditionResult(descriptor, authorization)
+	result.Evidence.Artifacts = nil
+	require.ErrorContains(t, ValidateRenditionResult(descriptor, authorization, result),
+		"absent from source evidence")
+}
+
+func TestRenditionProviderContractRejectsUnsafeReceiptFields(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*RenditionReceipt)
+		want   string
+	}{
+		{
+			name: "provider body in warning",
+			mutate: func(receipt *RenditionReceipt) {
+				receipt.Warnings = []string{"raw body: {\"document\":\"secret\"}"}
+			},
+			want: "warning",
+		},
+		{
+			name: "credential-shaped operation identity",
+			mutate: func(receipt *RenditionReceipt) {
+				receipt.OperationID = "Authorization: Bearer secret"
+			},
+			want: "operation ID",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := validRenditionResult(descriptor, authorization)
+			testCase.mutate(&result.Receipt)
+			require.ErrorContains(t,
+				ValidateRenditionResult(descriptor, authorization, result), testCase.want)
+		})
+	}
+}
+
+func TestRenditionProviderContractRejectsUnclassifiedErrors(t *testing.T) {
+	require.ErrorContains(t,
+		ValidateRenditionProviderError(errors.New("raw provider body with secret")),
+		"unclassified",
+	)
+	cause := errors.New("raw provider body with secret")
+	providerError, err := NewRenditionProviderError(
+		RenditionErrorRateLimited, "provider rate limit", 30*time.Second, cause,
+	)
+	require.NoError(t, err)
+	require.NoError(t, ValidateRenditionProviderError(providerError))
+	assert.True(t, IsRenditionProviderErrorRetryable(providerError))
+	wrapped := fmt.Errorf("unsafe wrapper includes provider body: %w", providerError)
+	require.ErrorContains(t, ValidateRenditionProviderError(wrapped), "unclassified")
+	assert.False(t, IsRenditionProviderErrorRetryable(wrapped))
+	assert.NotContains(t, providerError.Error(), "secret")
+	assert.ErrorIs(t, providerError, cause)
+}
+
+func TestRenditionProviderContractRejectsExpiredAuthorizationAndOutOfWindowReceipt(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	upload := &syntheticAuthorizedUpload{
+		ReadCloser: io.NopCloser(bytes.NewReader([]byte("synthetic exact source"))), metadata: metadata,
+	}
+	provider := syntheticRenditionProvider{descriptor: descriptor}
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	now, err := parseRenditionTimestamp(authorization.ExpiresAt)
+	require.NoError(t, err)
+	_, err = ValidateRenditionProviderRequestAt(now, provider, upload, authorization)
+	require.ErrorContains(t, err, "not current")
+	authorizedAt, err := parseRenditionTimestamp(authorization.AuthorizedAt)
+	require.NoError(t, err)
+	_, err = ValidateRenditionProviderRequestAt(
+		authorizedAt.Add(-time.Nanosecond),
+		provider, upload, authorization)
+	require.ErrorContains(t, err, "not current")
+
+	result := validRenditionResult(descriptor, authorization)
+	result.Receipt.StartedAt = authorizedAt.Add(-time.Nanosecond).Format(renditionTimestampForm)
+	require.ErrorContains(t, ValidateRenditionResult(descriptor, authorization, result),
+		"outside the authorization interval")
+	result = validRenditionResult(descriptor, authorization)
+	result.Receipt.CompletedAt = now.Add(time.Nanosecond).Format(renditionTimestampForm)
+	require.ErrorContains(t, ValidateRenditionResult(descriptor, authorization, result),
+		"outside the authorization interval")
+}
+
+func TestRenditionDescriptorCanonicalizesAndOwnsCollections(t *testing.T) {
+	formats := []RenditionFormatCapability{
+		{MediaFamily: "text", MediaType: "text/plain", InputKind: RenditionInputOriginalFile},
+		{MediaFamily: "pdf", MediaType: "application/pdf", InputKind: RenditionInputOriginalFile},
+	}
+	roles := []EvidenceArtifactRole{EvidenceArtifactTranscript, EvidenceArtifactStructured}
+	descriptor, err := NewRenditionDescriptor(RenditionDescriptor{
+		ID: "synthetic-rendition", ContractVersion: RenditionProviderContractVersion,
+		PolicyFingerprint: strings.Repeat("1", 64), TrustBoundary: RenditionTrustHostedProvider,
+		SupportedFormats: formats, ReturnsStructured: true, ArtifactRoles: roles,
+	})
+	require.NoError(t, err)
+	formats[0].MediaFamily = "mutated"
+	roles[0] = EvidenceArtifactImage
+	assert.Equal(t, "pdf", descriptor.SupportedFormats[0].MediaFamily)
+	assert.Equal(t, EvidenceArtifactTranscript, descriptor.ArtifactRoles[0])
+
+	reordered, err := NewRenditionDescriptor(RenditionDescriptor{
+		ID: "synthetic-rendition", ContractVersion: RenditionProviderContractVersion,
+		PolicyFingerprint: strings.Repeat("1", 64), TrustBoundary: RenditionTrustHostedProvider,
+		SupportedFormats: []RenditionFormatCapability{
+			{MediaFamily: "pdf", MediaType: "application/pdf", InputKind: RenditionInputOriginalFile},
+			{MediaFamily: "text", MediaType: "text/plain", InputKind: RenditionInputOriginalFile},
+		},
+		ReturnsStructured: true,
+		ArtifactRoles:     []EvidenceArtifactRole{EvidenceArtifactStructured, EvidenceArtifactTranscript},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, descriptor, reordered)
+}
+
+func TestRenditionProviderContractRejectsMutableBoundarySnapshots(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+
+	changedDescriptor := descriptor
+	changedDescriptor.ID = "changed-provider"
+	provider := &changingRenditionProvider{descriptors: []RenditionDescriptor{descriptor, changedDescriptor}}
+	upload := &syntheticAuthorizedUpload{ReadCloser: io.NopCloser(bytes.NewReader(nil)), metadata: metadata}
+	_, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+	require.ErrorContains(t, err, "descriptor changed")
+
+	changedMetadata := metadata
+	changedMetadata.Filename = "changed.pdf"
+	provider = &changingRenditionProvider{descriptors: []RenditionDescriptor{descriptor, descriptor}}
+	changingUpload := &changingAuthorizedUpload{
+		ReadCloser: io.NopCloser(bytes.NewReader(nil)),
+		metadata:   []AuthorizedUploadMetadata{metadata, changedMetadata},
+	}
+	_, err = ValidateRenditionProviderRequest(provider, changingUpload, authorization)
+	require.ErrorContains(t, err, "upload metadata changed")
+}
+
+func TestRenditionProviderContractFreezesAliasedDescriptorSlices(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	provider := &mutatingRenditionProvider{descriptor: descriptor, mutateDescriptor: true}
+	upload := &syntheticAuthorizedUpload{
+		ReadCloser: io.NopCloser(bytes.NewReader(nil)), metadata: metadata,
+	}
+
+	_, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+	require.ErrorContains(t, err, "descriptor changed")
+}
+
+func TestRenderRenditionKeepsSealedAuthorizationSeparateFromProvider(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	provider := &mutatingRenditionProvider{descriptor: descriptor}
+	provider.render = func(received RenditionAuthorization) RenditionResult {
+		received.AllowedArtifactRoles[0] = EvidenceArtifactImage
+		result := validRenditionResult(descriptor, received)
+		result.Artifacts[0].Role = EvidenceArtifactImage
+		result.Evidence.Artifacts[0].Role = EvidenceArtifactImage
+		return result
+	}
+	upload := &syntheticAuthorizedUpload{
+		ReadCloser: io.NopCloser(strings.NewReader("synthetic exact source")), metadata: metadata,
+	}
+
+	_, err := RenderRendition(t.Context(), provider, upload, authorization)
+	require.ErrorContains(t, err, "not authorized")
+	assert.Equal(t, []EvidenceArtifactRole{EvidenceArtifactStructured}, authorization.AllowedArtifactRoles,
+		"provider mutation must not reach the caller or sealed validation snapshot")
+}
+
+func TestRenditionProviderContractRejectsTypedNilBoundaryValues(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+
+	var provider *changingRenditionProvider
+	upload := &syntheticAuthorizedUpload{ReadCloser: io.NopCloser(bytes.NewReader(nil)), metadata: metadata}
+	assert.NotPanics(t, func() {
+		_, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+		require.ErrorContains(t, err, "provider is required")
+	})
+
+	validProvider := syntheticRenditionProvider{descriptor: descriptor}
+	var nilUpload *syntheticAuthorizedUpload
+	assert.NotPanics(t, func() {
+		_, err := ValidateRenditionProviderRequest(validProvider, nilUpload, authorization)
+		require.ErrorContains(t, err, "upload is required")
+	})
+}
+
+func validRenditionDescriptor(t *testing.T) RenditionDescriptor {
+	t.Helper()
+	descriptor, err := NewRenditionDescriptor(RenditionDescriptor{
+		ID:                "synthetic-rendition",
+		ContractVersion:   RenditionProviderContractVersion,
+		PolicyFingerprint: strings.Repeat("1", 64),
+		TrustBoundary:     RenditionTrustHostedProvider,
+		SupportedFormats: []RenditionFormatCapability{{
+			MediaFamily: "pdf", MediaType: "application/pdf", InputKind: RenditionInputOriginalFile,
+		}},
+		ReturnsMarkdown:   true,
+		ReturnsStructured: true,
+		ArtifactRoles:     []EvidenceArtifactRole{EvidenceArtifactStructured},
+	})
+	require.NoError(t, err)
+	return descriptor
+}
+
+func validAuthorizedUploadMetadata() AuthorizedUploadMetadata {
+	source := []byte("synthetic exact source")
+	digest := sha256.Sum256(source)
+	return AuthorizedUploadMetadata{
+		Filename:                 "document.pdf",
+		MediaFamily:              "pdf",
+		MediaType:                "application/pdf",
+		ByteLength:               int64(len(source)),
+		SHA256:                   hex.EncodeToString(digest[:]),
+		CapabilityRecordChecksum: strings.Repeat("2", 64),
+		ProviderMetadataChecksum: strings.Repeat("3", 64),
+		InputKind:                RenditionInputOriginalFile,
+	}
+}
+
+func validRenditionAuthorization(
+	descriptor RenditionDescriptor, metadata AuthorizedUploadMetadata,
+
+) RenditionAuthorization {
+	authorizedAt := time.Now().UTC().Add(-time.Minute)
+	expiresAt := authorizedAt.Add(10 * time.Minute)
+	return RenditionAuthorization{
+		ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+		PolicyFingerprint:           descriptor.PolicyFingerprint,
+		RenditionRequestFingerprint: strings.Repeat("4", 64),
+		SourceSHA256:                metadata.SHA256, SourceBytes: metadata.ByteLength,
+		CapabilityRecordChecksum: metadata.CapabilityRecordChecksum,
+		ProviderMetadataChecksum: metadata.ProviderMetadataChecksum,
+		MediaFamily:              metadata.MediaFamily, MediaType: metadata.MediaType, InputKind: metadata.InputKind,
+		AllowedArtifactRoles:     []EvidenceArtifactRole{EvidenceArtifactStructured},
+		MaxProviderMarkdownBytes: 1_024, MaxArtifactBytes: 1_024,
+		MaxArtifacts: 1, MaxTotalResultBytes: 4_096,
+		AuthorizedAt: authorizedAt.Format(renditionTimestampForm),
+		ExpiresAt:    expiresAt.Format(renditionTimestampForm),
+	}
+}
+
+func validRenditionResult(
+	descriptor RenditionDescriptor, authorization RenditionAuthorization,
+) RenditionResult {
+	authorizedAt, _ := parseRenditionTimestamp(authorization.AuthorizedAt)
+	payload := []byte(`{"synthetic":"structured"}`)
+	digest := sha256.Sum256(payload)
+	return RenditionResult{
+		Evidence: SourceEvidenceV1{
+			ContractVersion: SourceEvidenceContractV1,
+			Completeness:    EvidenceDegradedProvenance,
+			Family:          "pdf",
+			Artifacts: []SourceEvidenceArtifactV1{{
+				ProviderID: "provider-artifact-1", Pointer: "provider/structured.json",
+				Role: EvidenceArtifactStructured, SHA256: hex.EncodeToString(digest[:]),
+			}},
+			UnitKind: EvidenceUnitGeneric,
+			Omissions: []SourceEvidenceOmissionV1{{
+				Kind: EvidenceOmissionField, Field: "natural_provenance",
+				Reason: "synthetic provider returned generic evidence",
+			}},
+			Units: []SourceEvidenceUnitV1{{
+				Order: 0, Text: "synthetic evidence",
+				Locator: SourceEvidenceLocatorV1{
+					Kind: EvidenceLocatorGeneric, IndexOrigin: EvidenceIndexOriginNone,
+				},
+			}},
+		},
+		ProviderMarkdown: []byte("synthetic evidence\n"),
+		Artifacts: []RenditionArtifact{{
+			Role: EvidenceArtifactStructured, MediaType: "application/json",
+			Payload: payload, SHA256: hex.EncodeToString(digest[:]),
+		}},
+		Receipt: RenditionReceipt{
+			ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+			PolicyFingerprint: authorization.PolicyFingerprint,
+			SourceSHA256:      authorization.SourceSHA256,
+			OperationID:       "operation-synthetic-1",
+			StartedAt:         authorizedAt.Add(time.Second).Format(renditionTimestampForm),
+			CompletedAt:       authorizedAt.Add(2 * time.Second).Format(renditionTimestampForm),
+			Warnings:          []string{"degraded_provenance"},
+			Usage: RenditionUsage{
+				Requests: 1, InputBytes: authorization.SourceBytes,
+				OutputBytes: int64(len(payload) + len("synthetic evidence\n")), Units: 1,
+			},
+		},
+	}
+}

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -354,6 +354,40 @@ func TestRenditionProviderContractRejectsUnsafeReceiptFields(t *testing.T) {
 	}
 }
 
+func TestRenditionProviderContractRejectsReceiptFromDifferentAuthorization(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	result := validRenditionResult(descriptor, authorization)
+	different := authorization
+	different.CapabilityRecordChecksum = strings.Repeat("9", 64)
+
+	require.ErrorContains(t,
+		ValidateRenditionResult(descriptor, different, result),
+		"receipt does not match authorization",
+	)
+}
+
+func TestRenditionProviderContractDoesNotReflectInvalidArtifactRoles(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	descriptor.Fingerprint = ""
+	descriptor.ArtifactRoles = []EvidenceArtifactRole{
+		EvidenceArtifactRole(strings.Repeat("provider-controlled", 4_096)),
+	}
+	_, err := NewRenditionDescriptor(descriptor)
+	require.EqualError(t, err, "descriptor artifact role is invalid")
+
+	descriptor = validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	result := validRenditionResult(descriptor, authorization)
+	result.Artifacts[0].Role = EvidenceArtifactRole("provider-controlled-value")
+	require.EqualError(t,
+		ValidateRenditionResult(descriptor, authorization, result),
+		"provider artifact role is not authorized",
+	)
+}
+
 func TestRenditionProviderContractRejectsUnclassifiedErrors(t *testing.T) {
 	require.ErrorContains(t,
 		ValidateRenditionProviderError(errors.New("raw provider body with secret")),
@@ -829,6 +863,7 @@ func validRenditionResult(
 	descriptor RenditionDescriptor, authorization RenditionAuthorization,
 ) RenditionResult {
 	authorizedAt, _ := parseRenditionTimestamp(authorization.AuthorizedAt)
+	authorizationFingerprint, _ := authorization.Fingerprint()
 	payload := []byte(`{"synthetic":"structured"}`)
 	digest := sha256.Sum256(payload)
 	return RenditionResult{
@@ -861,6 +896,7 @@ func validRenditionResult(
 			ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
 			PolicyFingerprint:           authorization.PolicyFingerprint,
 			RenditionRequestFingerprint: authorization.RenditionRequestFingerprint,
+			AuthorizationFingerprint:    authorizationFingerprint,
 			SourceSHA256:                authorization.SourceSHA256,
 			OperationID:                 "operation-synthetic-1",
 			StartedAt:                   authorizedAt.Add(time.Second).Format(renditionTimestampForm),

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -54,7 +54,7 @@ type changingRenditionProvider struct {
 
 type mutatingRenditionProvider struct {
 	descriptor       RenditionDescriptor
-	render           func(RenditionAuthorization) RenditionResult
+	render           func(AuthorizedUpload, RenditionAuthorization) RenditionResult
 	mutateDescriptor bool
 	calls            int
 }
@@ -68,9 +68,9 @@ func (provider *mutatingRenditionProvider) Descriptor() RenditionDescriptor {
 }
 
 func (provider *mutatingRenditionProvider) Render(
-	_ context.Context, _ AuthorizedUpload, authorization RenditionAuthorization,
+	_ context.Context, upload AuthorizedUpload, authorization RenditionAuthorization,
 ) (RenditionResult, error) {
-	return provider.render(authorization), nil
+	return provider.render(upload, authorization), nil
 }
 
 func (provider *changingRenditionProvider) Descriptor() RenditionDescriptor {
@@ -177,11 +177,11 @@ func TestRenditionProviderContractRejectsDuplicateAndOversizedOutputs(t *testing
 		want   string
 	}{
 		{
-			name: "duplicate artifact role",
+			name: "duplicate artifact identity",
 			mutate: func(result *RenditionResult) {
 				result.Artifacts = append(result.Artifacts, result.Artifacts[0])
 			},
-			want: "artifact role",
+			want: "artifact identity",
 		},
 		{
 			name: "oversized provider Markdown",
@@ -205,6 +205,28 @@ func TestRenditionProviderContractRejectsDuplicateAndOversizedOutputs(t *testing
 				ValidateRenditionResult(descriptor, authorization, result), testCase.want)
 		})
 	}
+}
+
+func TestRenditionProviderContractAcceptsRepeatedArtifactRoles(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	authorization.MaxArtifacts = 2
+	result := validRenditionResult(descriptor, authorization)
+
+	payload := []byte(`{"synthetic":"second structured artifact"}`)
+	digest := sha256.Sum256(payload)
+	checksum := hex.EncodeToString(digest[:])
+	result.Artifacts = append(result.Artifacts, RenditionArtifact{
+		Role: EvidenceArtifactStructured, MediaType: "application/json",
+		Payload: payload, SHA256: checksum,
+	})
+	result.Evidence.Artifacts = append(result.Evidence.Artifacts, SourceEvidenceArtifactV1{
+		ProviderID: "provider-artifact-2", Pointer: "provider/structured-2.json",
+		Role: EvidenceArtifactStructured, SHA256: checksum,
+	})
+
+	require.NoError(t, ValidateRenditionResult(descriptor, authorization, result))
 }
 
 func TestRenditionProviderContractRejectsUnauthorizedOrUnmatchedEvidenceArtifacts(t *testing.T) {
@@ -238,6 +260,13 @@ func TestRenditionProviderContractRejectsUnsafeReceiptFields(t *testing.T) {
 		want   string
 	}{
 		{
+			name: "rendition request mismatch",
+			mutate: func(receipt *RenditionReceipt) {
+				receipt.RenditionRequestFingerprint = strings.Repeat("9", 64)
+			},
+			want: "does not match",
+		},
+		{
 			name: "provider body in warning",
 			mutate: func(receipt *RenditionReceipt) {
 				receipt.Warnings = []string{"raw body: {\"document\":\"secret\"}"}
@@ -268,7 +297,7 @@ func TestRenditionProviderContractRejectsUnclassifiedErrors(t *testing.T) {
 	)
 	cause := errors.New("raw provider body with secret")
 	providerError, err := NewRenditionProviderError(
-		RenditionErrorRateLimited, "provider rate limit", 30*time.Second, cause,
+		RenditionErrorRateLimited, 30*time.Second, cause,
 	)
 	require.NoError(t, err)
 	require.NoError(t, ValidateRenditionProviderError(providerError))
@@ -276,6 +305,7 @@ func TestRenditionProviderContractRejectsUnclassifiedErrors(t *testing.T) {
 	wrapped := fmt.Errorf("unsafe wrapper includes provider body: %w", providerError)
 	require.ErrorContains(t, ValidateRenditionProviderError(wrapped), "unclassified")
 	assert.False(t, IsRenditionProviderErrorRetryable(wrapped))
+	assert.Equal(t, "rendition provider rate limit reached", providerError.Error())
 	assert.NotContains(t, providerError.Error(), "secret")
 	assert.ErrorIs(t, providerError, cause)
 }
@@ -381,7 +411,7 @@ func TestRenderRenditionKeepsSealedAuthorizationSeparateFromProvider(t *testing.
 	metadata := validAuthorizedUploadMetadata()
 	authorization := validRenditionAuthorization(descriptor, metadata)
 	provider := &mutatingRenditionProvider{descriptor: descriptor}
-	provider.render = func(received RenditionAuthorization) RenditionResult {
+	provider.render = func(_ AuthorizedUpload, received RenditionAuthorization) RenditionResult {
 		received.AllowedArtifactRoles[0] = EvidenceArtifactImage
 		result := validRenditionResult(descriptor, received)
 		result.Artifacts[0].Role = EvidenceArtifactImage
@@ -396,6 +426,38 @@ func TestRenderRenditionKeepsSealedAuthorizationSeparateFromProvider(t *testing.
 	require.ErrorContains(t, err, "not authorized")
 	assert.Equal(t, []EvidenceArtifactRole{EvidenceArtifactStructured}, authorization.AllowedArtifactRoles,
 		"provider mutation must not reach the caller or sealed validation snapshot")
+}
+
+func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		disclose bool
+		want     string
+	}{
+		{name: "withheld", want: ""},
+		{name: "disclosed", disclose: true, want: "document.pdf"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			descriptor := validRenditionDescriptor(t)
+			metadata := validAuthorizedUploadMetadata()
+			authorization := validRenditionAuthorization(descriptor, metadata)
+			authorization.DiscloseFilename = testCase.disclose
+			provider := &mutatingRenditionProvider{descriptor: descriptor}
+			var received AuthorizedUploadMetadata
+			provider.render = func(upload AuthorizedUpload, receivedAuthorization RenditionAuthorization) RenditionResult {
+				received = upload.Metadata()
+				return validRenditionResult(descriptor, receivedAuthorization)
+			}
+			upload := &syntheticAuthorizedUpload{
+				ReadCloser: io.NopCloser(strings.NewReader("synthetic exact source")), metadata: metadata,
+			}
+
+			_, err := RenderRendition(t.Context(), provider, upload, authorization)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, received.Filename)
+			assert.Equal(t, "document.pdf", upload.Metadata().Filename)
+		})
+	}
 }
 
 func TestRenditionProviderContractRejectsTypedNilBoundaryValues(t *testing.T) {
@@ -465,6 +527,7 @@ func validRenditionAuthorization(
 		CapabilityRecordChecksum: metadata.CapabilityRecordChecksum,
 		ProviderMetadataChecksum: metadata.ProviderMetadataChecksum,
 		MediaFamily:              metadata.MediaFamily, MediaType: metadata.MediaType, InputKind: metadata.InputKind,
+		DiscloseFilename:         false,
 		AllowedArtifactRoles:     []EvidenceArtifactRole{EvidenceArtifactStructured},
 		MaxProviderMarkdownBytes: 1_024, MaxArtifactBytes: 1_024,
 		MaxArtifacts: 1, MaxTotalResultBytes: 4_096,
@@ -507,12 +570,13 @@ func validRenditionResult(
 		}},
 		Receipt: RenditionReceipt{
 			ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
-			PolicyFingerprint: authorization.PolicyFingerprint,
-			SourceSHA256:      authorization.SourceSHA256,
-			OperationID:       "operation-synthetic-1",
-			StartedAt:         authorizedAt.Add(time.Second).Format(renditionTimestampForm),
-			CompletedAt:       authorizedAt.Add(2 * time.Second).Format(renditionTimestampForm),
-			Warnings:          []string{"degraded_provenance"},
+			PolicyFingerprint:           authorization.PolicyFingerprint,
+			RenditionRequestFingerprint: authorization.RenditionRequestFingerprint,
+			SourceSHA256:                authorization.SourceSHA256,
+			OperationID:                 "operation-synthetic-1",
+			StartedAt:                   authorizedAt.Add(time.Second).Format(renditionTimestampForm),
+			CompletedAt:                 authorizedAt.Add(2 * time.Second).Format(renditionTimestampForm),
+			Warnings:                    []string{"degraded_provenance"},
 			Usage: RenditionUsage{
 				Requests: 1, InputBytes: authorization.SourceBytes,
 				OutputBytes: int64(len(payload) + len("synthetic evidence\n")), Units: 1,

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -512,6 +513,50 @@ func TestRenderRenditionOwnsUpload(t *testing.T) {
 	})
 }
 
+func TestRenderRenditionEnforcesExactUploadBytes(t *testing.T) {
+	exact := []byte("synthetic exact source")
+	mismatch := bytes.Clone(exact)
+	mismatch[0] = 'S'
+	for _, testCase := range []struct {
+		name         string
+		source       []byte
+		wantReceived []byte
+		wantError    string
+	}{
+		{name: "exact", source: exact, wantReceived: exact},
+		{name: "extra", source: append(bytes.Clone(exact), []byte("private tail")...), wantReceived: exact,
+			wantError: "exceeds declared byte length"},
+		{name: "short", source: exact[:len(exact)-1], wantReceived: exact[:len(exact)-1],
+			wantError: "shorter than declared byte length"},
+		{name: "mismatched hash", source: mismatch, wantReceived: mismatch,
+			wantError: "SHA-256 does not match"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			descriptor := validRenditionDescriptor(t)
+			metadata := validAuthorizedUploadMetadata()
+			authorization := validRenditionAuthorization(descriptor, metadata)
+			provider := &mutatingRenditionProvider{descriptor: descriptor}
+			var received []byte
+			provider.render = func(upload AuthorizedUpload, receivedAuthorization RenditionAuthorization) RenditionResult {
+				received, _ = io.ReadAll(upload)
+				return validRenditionResult(descriptor, receivedAuthorization)
+			}
+			upload := &syntheticAuthorizedUpload{
+				ReadCloser: io.NopCloser(bytes.NewReader(testCase.source)), metadata: metadata,
+			}
+
+			_, err := RenderRendition(t.Context(), provider, upload, authorization)
+			assert.Equal(t, testCase.wantReceived, received)
+			if testCase.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, testCase.wantError)
+			}
+			assert.Equal(t, 1, upload.closeCalls)
+		})
+	}
+}
+
 func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {
 	for _, testCase := range []struct {
 		name     string
@@ -528,8 +573,35 @@ func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {
 			authorization.DiscloseFilename = testCase.disclose
 			provider := &mutatingRenditionProvider{descriptor: descriptor}
 			var received AuthorizedUploadMetadata
+			var reflectedFilename string
 			provider.render = func(upload AuthorizedUpload, receivedAuthorization RenditionAuthorization) RenditionResult {
 				received = upload.Metadata()
+				var inspect func(reflect.Value)
+				inspect = func(value reflect.Value) {
+					if reflectedFilename != "" || !value.IsValid() {
+						return
+					}
+					if value.CanInterface() {
+						if nested, ok := reflect.TypeAssert[AuthorizedUpload](value); ok {
+							reflectedFilename = nested.Metadata().Filename
+							if reflectedFilename != "" {
+								return
+							}
+						}
+					}
+					switch value.Kind() {
+					case reflect.Interface, reflect.Pointer:
+						inspect(value.Elem())
+					case reflect.Struct:
+						for _, field := range value.Fields() {
+							if field.CanInterface() {
+								inspect(field)
+							}
+						}
+					default:
+					}
+				}
+				inspect(reflect.ValueOf(upload))
 				return validRenditionResult(descriptor, receivedAuthorization)
 			}
 			upload := &syntheticAuthorizedUpload{
@@ -539,6 +611,7 @@ func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {
 			_, err := RenderRendition(t.Context(), provider, upload, authorization)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.want, received.Filename)
+			assert.Equal(t, testCase.want, reflectedFilename)
 			assert.Equal(t, "document.pdf", upload.Metadata().Filename)
 		})
 	}

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -119,12 +119,9 @@ func TestRenditionProviderContractAcceptsExactBoundedResult(t *testing.T) {
 		ReadCloser: io.NopCloser(strings.NewReader("synthetic exact source")), metadata: metadata,
 	}
 
-	validated, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+	produced, err := RenderRendition(t.Context(), provider, upload, authorization)
 	require.NoError(t, err)
-	assert.Equal(t, descriptor, validated)
-	produced, err := provider.Render(t.Context(), upload, authorization)
-	require.NoError(t, err)
-	require.NoError(t, ValidateRenditionResult(validated, authorization, produced))
+	assert.Equal(t, result, produced)
 }
 
 func TestRenditionProviderContractRejectsInvalidDescriptorAndAuthorization(t *testing.T) {
@@ -172,7 +169,9 @@ func TestRenditionProviderContractRejectsInvalidDescriptorAndAuthorization(t *te
 			upload := &syntheticAuthorizedUpload{
 				ReadCloser: io.NopCloser(bytes.NewReader(nil)), metadata: metadata,
 			}
-			_, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+			_, _, err := validateRenditionProviderRequestAt(
+				time.Now().UTC(), provider, upload, authorization,
+			)
 			require.ErrorContains(t, err, testCase.want)
 		})
 	}
@@ -251,6 +250,20 @@ func TestRenditionProviderContractCountsReceiptAgainstTotal(t *testing.T) {
 	artifact := result.Artifacts[0]
 	authorization.MaxTotalResultBytes = len(encodedEvidence) + len(result.ProviderMarkdown) +
 		len(artifact.Role) + len(artifact.MediaType) + len(artifact.SHA256) + len(artifact.Payload)
+
+	require.ErrorContains(t,
+		ValidateRenditionResult(descriptor, authorization, result),
+		"total result bytes",
+	)
+}
+
+func TestRenditionProviderContractPreflightsTotalBeforeEvidenceValidation(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	authorization.MaxTotalResultBytes = 128
+	result := validRenditionResult(descriptor, authorization)
+	result.Evidence.ContractVersion = "malformed"
 
 	require.ErrorContains(t,
 		ValidateRenditionResult(descriptor, authorization, result),
@@ -371,11 +384,11 @@ func TestRenditionProviderContractRejectsExpiredAuthorizationAndOutOfWindowRecei
 	authorization := validRenditionAuthorization(descriptor, metadata)
 	now, err := parseRenditionTimestamp(authorization.ExpiresAt)
 	require.NoError(t, err)
-	_, err = ValidateRenditionProviderRequestAt(now, provider, upload, authorization)
+	_, _, err = validateRenditionProviderRequestAt(now, provider, upload, authorization)
 	require.ErrorContains(t, err, "not current")
 	authorizedAt, err := parseRenditionTimestamp(authorization.AuthorizedAt)
 	require.NoError(t, err)
-	_, err = ValidateRenditionProviderRequestAt(
+	_, _, err = validateRenditionProviderRequestAt(
 		authorizedAt.Add(-time.Nanosecond),
 		provider, upload, authorization)
 	require.ErrorContains(t, err, "not current")
@@ -440,7 +453,7 @@ func TestRenditionProviderContractRejectsMutableBoundarySnapshots(t *testing.T) 
 	changedDescriptor.ID = "changed-provider"
 	provider := &changingRenditionProvider{descriptors: []RenditionDescriptor{descriptor, changedDescriptor}}
 	upload := &syntheticAuthorizedUpload{ReadCloser: io.NopCloser(bytes.NewReader(nil)), metadata: metadata}
-	_, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+	_, _, err := validateRenditionProviderRequestAt(time.Now().UTC(), provider, upload, authorization)
 	require.ErrorContains(t, err, "descriptor changed")
 
 	changedMetadata := metadata
@@ -450,7 +463,9 @@ func TestRenditionProviderContractRejectsMutableBoundarySnapshots(t *testing.T) 
 		ReadCloser: io.NopCloser(bytes.NewReader(nil)),
 		metadata:   []AuthorizedUploadMetadata{metadata, changedMetadata},
 	}
-	_, err = ValidateRenditionProviderRequest(provider, changingUpload, authorization)
+	_, _, err = validateRenditionProviderRequestAt(
+		time.Now().UTC(), provider, changingUpload, authorization,
+	)
 	require.ErrorContains(t, err, "upload metadata changed")
 }
 
@@ -463,7 +478,7 @@ func TestRenditionProviderContractFreezesAliasedDescriptorSlices(t *testing.T) {
 		ReadCloser: io.NopCloser(bytes.NewReader(nil)), metadata: metadata,
 	}
 
-	_, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+	_, _, err := validateRenditionProviderRequestAt(time.Now().UTC(), provider, upload, authorization)
 	require.ErrorContains(t, err, "descriptor changed")
 }
 
@@ -740,14 +755,16 @@ func TestRenditionProviderContractRejectsTypedNilBoundaryValues(t *testing.T) {
 	var provider *changingRenditionProvider
 	upload := &syntheticAuthorizedUpload{ReadCloser: io.NopCloser(bytes.NewReader(nil)), metadata: metadata}
 	assert.NotPanics(t, func() {
-		_, err := ValidateRenditionProviderRequest(provider, upload, authorization)
+		_, _, err := validateRenditionProviderRequestAt(time.Now().UTC(), provider, upload, authorization)
 		require.ErrorContains(t, err, "provider is required")
 	})
 
 	validProvider := syntheticRenditionProvider{descriptor: descriptor}
 	var nilUpload *syntheticAuthorizedUpload
 	assert.NotPanics(t, func() {
-		_, err := ValidateRenditionProviderRequest(validProvider, nilUpload, authorization)
+		_, _, err := validateRenditionProviderRequestAt(
+			time.Now().UTC(), validProvider, nilUpload, authorization,
+		)
 		require.ErrorContains(t, err, "upload is required")
 	})
 }

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -448,6 +448,10 @@ func TestRenditionProviderContractRejectsExpiredAuthorizationAndOutOfWindowRecei
 	require.ErrorContains(t, ValidateRenditionResult(descriptor, authorization, result),
 		"outside the authorization interval")
 	result = validRenditionResult(descriptor, authorization)
+	result.Receipt.CompletedAt = now.Format(renditionTimestampForm)
+	require.ErrorContains(t, ValidateRenditionResult(descriptor, authorization, result),
+		"outside the authorization interval")
+	result = validRenditionResult(descriptor, authorization)
 	result.Receipt.CompletedAt = now.Add(time.Nanosecond).Format(renditionTimestampForm)
 	require.ErrorContains(t, ValidateRenditionResult(descriptor, authorization, result),
 		"outside the authorization interval")

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -38,11 +38,21 @@ var _ RenditionProvider = syntheticRenditionProvider{}
 type syntheticAuthorizedUpload struct {
 	io.ReadCloser
 
-	metadata AuthorizedUploadMetadata
+	closeCalls int
+	closeErr   error
+	metadata   AuthorizedUploadMetadata
 }
 
 func (upload *syntheticAuthorizedUpload) Metadata() AuthorizedUploadMetadata {
 	return upload.metadata
+}
+
+func (upload *syntheticAuthorizedUpload) Close() error {
+	upload.closeCalls++
+	if upload.closeErr != nil {
+		return upload.closeErr
+	}
+	return upload.ReadCloser.Close()
 }
 
 var _ AuthorizedUpload = (*syntheticAuthorizedUpload)(nil)
@@ -184,6 +194,13 @@ func TestRenditionProviderContractRejectsDuplicateAndOversizedOutputs(t *testing
 			want: "artifact identity",
 		},
 		{
+			name: "oversized artifact media type",
+			mutate: func(result *RenditionResult) {
+				result.Artifacts[0].MediaType = "application/" + strings.Repeat("x", maxRenditionMediaTypeBytes)
+			},
+			want: "media type",
+		},
+		{
 			name: "oversized provider Markdown",
 			mutate: func(result *RenditionResult) {
 				result.ProviderMarkdown = bytes.Repeat([]byte("x"), authorization.MaxProviderMarkdownBytes+1)
@@ -205,6 +222,22 @@ func TestRenditionProviderContractRejectsDuplicateAndOversizedOutputs(t *testing
 				ValidateRenditionResult(descriptor, authorization, result), testCase.want)
 		})
 	}
+}
+
+func TestRenditionProviderContractCountsArtifactMetadataAgainstTotal(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	result := validRenditionResult(descriptor, authorization)
+	encodedEvidence, err := canonicalJSON(result.Evidence)
+	require.NoError(t, err)
+	authorization.MaxTotalResultBytes = len(encodedEvidence) +
+		len(result.ProviderMarkdown) + len(result.Artifacts[0].Payload)
+
+	require.ErrorContains(t,
+		ValidateRenditionResult(descriptor, authorization, result),
+		"total result bytes",
+	)
 }
 
 func TestRenditionProviderContractAcceptsRepeatedArtifactRoles(t *testing.T) {
@@ -370,6 +403,16 @@ func TestRenditionDescriptorCanonicalizesAndOwnsCollections(t *testing.T) {
 	assert.Equal(t, descriptor, reordered)
 }
 
+func TestRenditionDescriptorRequiresStructuredEvidence(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	descriptor.Fingerprint = ""
+	descriptor.ReturnsStructured = false
+	descriptor.ReturnsMarkdown = true
+
+	_, err := NewRenditionDescriptor(descriptor)
+	require.ErrorContains(t, err, "structured evidence")
+}
+
 func TestRenditionProviderContractRejectsMutableBoundarySnapshots(t *testing.T) {
 	descriptor := validRenditionDescriptor(t)
 	metadata := validAuthorizedUploadMetadata()
@@ -426,6 +469,47 @@ func TestRenderRenditionKeepsSealedAuthorizationSeparateFromProvider(t *testing.
 	require.ErrorContains(t, err, "not authorized")
 	assert.Equal(t, []EvidenceArtifactRole{EvidenceArtifactStructured}, authorization.AllowedArtifactRoles,
 		"provider mutation must not reach the caller or sealed validation snapshot")
+}
+
+func TestRenderRenditionOwnsUpload(t *testing.T) {
+	t.Run("validation failure preserves close error", func(t *testing.T) {
+		descriptor := validRenditionDescriptor(t)
+		metadata := validAuthorizedUploadMetadata()
+		authorization := validRenditionAuthorization(descriptor, metadata)
+		authorization.ProviderID = "wrong-provider"
+		closeErr := errors.New("synthetic close failure")
+		upload := &syntheticAuthorizedUpload{
+			ReadCloser: io.NopCloser(strings.NewReader("synthetic exact source")),
+			closeErr:   closeErr,
+			metadata:   metadata,
+		}
+
+		_, err := RenderRendition(
+			t.Context(), syntheticRenditionProvider{descriptor: descriptor}, upload, authorization,
+		)
+		require.ErrorContains(t, err, "provider ID")
+		require.ErrorIs(t, err, closeErr)
+		assert.Equal(t, 1, upload.closeCalls)
+	})
+
+	t.Run("provider close remains exactly once", func(t *testing.T) {
+		descriptor := validRenditionDescriptor(t)
+		metadata := validAuthorizedUploadMetadata()
+		authorization := validRenditionAuthorization(descriptor, metadata)
+		provider := &mutatingRenditionProvider{descriptor: descriptor}
+		provider.render = func(upload AuthorizedUpload, received RenditionAuthorization) RenditionResult {
+			require.NoError(t, upload.Close())
+			return validRenditionResult(descriptor, received)
+		}
+		upload := &syntheticAuthorizedUpload{
+			ReadCloser: io.NopCloser(strings.NewReader("synthetic exact source")),
+			metadata:   metadata,
+		}
+
+		_, err := RenderRendition(t.Context(), provider, upload, authorization)
+		require.NoError(t, err)
+		assert.Equal(t, 1, upload.closeCalls)
+	})
 }
 
 func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {

--- a/document/provider_test.go
+++ b/document/provider_test.go
@@ -639,6 +639,30 @@ func TestRenderRenditionCancellationClosesBlockedUpload(t *testing.T) {
 	assert.Equal(t, 1, upload.closeCalls)
 }
 
+func TestRenderRenditionEnforcesAuthorizationExpiryDuringExecution(t *testing.T) {
+	descriptor := validRenditionDescriptor(t)
+	metadata := validAuthorizedUploadMetadata()
+	authorization := validRenditionAuthorization(descriptor, metadata)
+	expiresAt := time.Now().UTC().Add(250 * time.Millisecond)
+	authorization.ExpiresAt = expiresAt.Format(renditionTimestampForm)
+	upload := &syntheticAuthorizedUpload{
+		ReadCloser: io.NopCloser(strings.NewReader("synthetic exact source")), metadata: metadata,
+	}
+	readDone := make(chan error, 1)
+	provider := &mutatingRenditionProvider{descriptor: descriptor}
+	provider.render = func(upload AuthorizedUpload, received RenditionAuthorization) RenditionResult {
+		time.Sleep(time.Until(expiresAt.Add(20 * time.Millisecond)))
+		_, readErr := upload.Read(make([]byte, 1))
+		readDone <- readErr
+		return validRenditionResult(descriptor, received)
+	}
+
+	_, err := RenderRendition(t.Context(), provider, upload, authorization)
+	require.ErrorContains(t, err, "authorization is not current")
+	require.Error(t, <-readDone)
+	assert.Equal(t, 1, upload.closeCalls)
+}
+
 func TestRenderRenditionEnforcesFilenameDisclosure(t *testing.T) {
 	for _, testCase := range []struct {
 		name           string


### PR DESCRIPTION
## What changed

Docbank now has one provider-neutral contract for rendition descriptors, one-shot uploads, authorization, results, receipts, and classified errors. The boundary rejects stale or mismatched authority, changed provider or upload metadata, unsupported formats, oversized output, invalid evidence, and unsanitized provider failures.

Credentials, raw response bodies, storage, jobs, and consent stay outside the provider contract.

## Why

Every adapter needs the same enforceable boundary before it can receive document bytes. Otherwise provider-specific behavior can leak into durable authority or escape the exact source, policy, and output limits Docbank approved.

## Usage

Provider implementations expose a descriptor and accept only an authorized one-shot upload plus matching rendition authority. Callers validate the result through the shared contract before anything can enter the derivative catalog.

There is no standalone operator command in this PR; concrete adapters build on this boundary.

Part of #176 (R1). Stacks on #188.
