### PR TITLE
Bind provider DNS policy to the actual connection

### DIFF
--- a/document/glmocr/client.go
+++ b/document/glmocr/client.go
@@ -13,7 +13,9 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/netip"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +23,7 @@ import (
 
 	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/document/ocr"
+	"go.kenn.io/docbank/document/providerhttp"
 )
 
 const (
@@ -87,7 +90,26 @@ func NewClient(policy Policy, config ClientConfig) (*Client, error) {
 	}
 	httpClient := config.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: config.Timeout}
+		endpoint, err := url.Parse(policy.values.Endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("parse GLM-OCR endpoint for egress: %w", err)
+		}
+		port, err := strconv.ParseUint(endpoint.Port(), 10, 16)
+		if err != nil || port == 0 {
+			return nil, errors.New("GLM-OCR endpoint has an invalid egress port")
+		}
+		transport, err := providerhttp.NewTransport(providerhttp.EgressPolicy{
+			Scheme: endpoint.Scheme, Host: endpoint.Hostname(), Port: uint16(port),
+			AllowedCIDRs: []netip.Prefix{
+				netip.MustParsePrefix("127.0.0.0/8"),
+				netip.MustParsePrefix("::1/128"),
+			},
+			ProxyMode: providerhttp.ProxyDisabled,
+		}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create GLM-OCR egress transport: %w", err)
+		}
+		httpClient = &http.Client{Timeout: config.Timeout, Transport: transport}
 	} else {
 		clone := *httpClient
 		httpClient = &clone
@@ -95,7 +117,7 @@ func NewClient(policy Policy, config ClientConfig) (*Client, error) {
 			httpClient.Timeout = config.Timeout
 		}
 	}
-	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	httpClient.CheckRedirect = providerhttp.RefuseRedirects
 	return &Client{policy: policy, http: httpClient, maxRetries: config.MaxRetries, maxRetryDelay: config.MaxRetryDelay}, nil
 }
 

--- a/document/glmocr/client_internal_test.go
+++ b/document/glmocr/client_internal_test.go
@@ -1,0 +1,44 @@
+package glmocr
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+func TestDefaultClientRefusesEgressDestinationDrift(t *testing.T) {
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "provider")
+	}))
+	defer provider.Close()
+	var driftRequests atomic.Int32
+	drift := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		driftRequests.Add(1)
+		_, _ = io.WriteString(w, "drift")
+	}))
+	defer drift.Close()
+	normalize, err := document.NewNormalizePolicy(1_000_000)
+	require.NoError(t, err)
+	policy, err := NewPolicy(PolicyConfig{
+		Endpoint: provider.URL + "/glmocr/parse", MaxDocumentBytes: 1 << 20,
+		MaxResponseBytes: 1 << 20, MaxUnits: 1, NormalizePolicy: normalize,
+	})
+	require.NoError(t, err)
+	client, err := NewClient(policy, ClientConfig{Timeout: time.Second})
+	require.NoError(t, err)
+
+	response, err := client.http.Get(drift.URL)
+	if response != nil {
+		require.NoError(t, response.Body.Close())
+	}
+	require.ErrorIs(t, err, providerhttp.ErrDestinationDenied)
+	assert.Zero(t, driftRequests.Load())
+}

--- a/document/glmocr/client_test.go
+++ b/document/glmocr/client_test.go
@@ -110,7 +110,7 @@ func TestClientRetriesHTTPClientTimeout(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Equal(t, ocr.ErrorTransient, ocr.ErrorKindOf(err))
 	assert.Equal(t, 2, ocr.MetricsFromError(err).Requests)
-	assert.Equal(t, int32(2), requests.Load())
+	require.Eventually(t, func() bool { return requests.Load() == 2 }, time.Second, time.Millisecond)
 }
 
 func TestClientDoesNotRetryUnsuitableInput(t *testing.T) {

--- a/document/providerhttp/policy.go
+++ b/document/providerhttp/policy.go
@@ -1,0 +1,154 @@
+// Package providerhttp constructs HTTP transports whose network destination is
+// bound to an explicit provider egress policy.
+package providerhttp
+
+import (
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultConnectTimeout bounds one TCP connection attempt.
+	DefaultConnectTimeout = 30 * time.Second
+	// DefaultKeepAlive preserves the standard library's TCP keepalive cadence.
+	DefaultKeepAlive = 30 * time.Second
+	// DefaultTLSHandshakeTimeout bounds a provider TLS handshake.
+	DefaultTLSHandshakeTimeout = 10 * time.Second
+	maxTransportTimeout        = 5 * time.Minute
+)
+
+// ProxyMode describes whether a provider transport may use a proxy.
+type ProxyMode string
+
+const (
+	// ProxyDisabled makes all connections directly to a policy-approved IP.
+	// Environment proxy variables are never consulted.
+	ProxyDisabled ProxyMode = "disabled"
+)
+
+// TLSPolicy contains optional certificate authority and SPKI pin restrictions.
+// Normal hostname and chain verification always runs before a pin is checked.
+type TLSPolicy struct {
+	RootCAs    *x509.CertPool
+	SPKISHA256 []string
+}
+
+// EgressPolicy authorizes one exact scheme, host, and port plus every network
+// prefix to which that hostname is allowed to resolve.
+type EgressPolicy struct {
+	Scheme              string
+	Host                string
+	Port                uint16
+	AllowedCIDRs        []netip.Prefix
+	ProxyMode           ProxyMode
+	ConnectTimeout      time.Duration
+	KeepAlive           time.Duration
+	TLSHandshakeTimeout time.Duration
+	TLS                 TLSPolicy
+}
+
+type validatedPolicy struct {
+	scheme       string
+	host         string
+	port         uint16
+	allowedCIDRs []netip.Prefix
+	rootCAs      *x509.CertPool
+	spkiPins     [][32]byte
+	connect      time.Duration
+	keepAlive    time.Duration
+	tlsHandshake time.Duration
+}
+
+func validatePolicy(policy EgressPolicy) (validatedPolicy, error) {
+	if policy.Scheme != "http" && policy.Scheme != "https" {
+		return validatedPolicy{}, errors.New("provider egress scheme must be http or https")
+	}
+	host, err := normalizeHost(policy.Host)
+	if err != nil {
+		return validatedPolicy{}, err
+	}
+	if policy.Port == 0 {
+		return validatedPolicy{}, errors.New("provider egress port is required")
+	}
+	if policy.ProxyMode != "" && policy.ProxyMode != ProxyDisabled {
+		return validatedPolicy{}, errors.New("provider egress supports only direct connections")
+	}
+	if policy.ConnectTimeout == 0 {
+		policy.ConnectTimeout = DefaultConnectTimeout
+	}
+	if policy.KeepAlive == 0 {
+		policy.KeepAlive = DefaultKeepAlive
+	}
+	if policy.TLSHandshakeTimeout == 0 {
+		policy.TLSHandshakeTimeout = DefaultTLSHandshakeTimeout
+	}
+	if policy.ConnectTimeout < 0 || policy.ConnectTimeout > maxTransportTimeout ||
+		policy.KeepAlive < 0 || policy.KeepAlive > maxTransportTimeout ||
+		policy.TLSHandshakeTimeout < 0 || policy.TLSHandshakeTimeout > maxTransportTimeout {
+		return validatedPolicy{}, errors.New("provider egress transport timeout is outside package bounds")
+	}
+	if len(policy.AllowedCIDRs) == 0 {
+		return validatedPolicy{}, errors.New("provider egress requires at least one allowed CIDR")
+	}
+	allowed := make([]netip.Prefix, len(policy.AllowedCIDRs))
+	for index, prefix := range policy.AllowedCIDRs {
+		if !prefix.IsValid() || prefix.Addr().Zone() != "" {
+			return validatedPolicy{}, fmt.Errorf("provider egress CIDR %d is invalid", index)
+		}
+		allowed[index] = prefix.Masked()
+	}
+	if policy.Scheme != "https" && (policy.TLS.RootCAs != nil || len(policy.TLS.SPKISHA256) != 0) {
+		return validatedPolicy{}, errors.New("provider egress TLS policy requires an https scheme")
+	}
+	pins := make([][32]byte, len(policy.TLS.SPKISHA256))
+	for index, encoded := range policy.TLS.SPKISHA256 {
+		decoded, err := hex.DecodeString(encoded)
+		if err != nil || len(decoded) != len(pins[index]) {
+			return validatedPolicy{}, fmt.Errorf("provider egress SPKI pin %d must be a SHA-256 hex digest", index)
+		}
+		copy(pins[index][:], decoded)
+	}
+	var roots *x509.CertPool
+	if policy.TLS.RootCAs != nil {
+		roots = policy.TLS.RootCAs.Clone()
+	}
+	return validatedPolicy{
+		scheme: policy.Scheme, host: host, port: policy.Port,
+		allowedCIDRs: allowed, rootCAs: roots, spkiPins: pins,
+		connect: policy.ConnectTimeout, keepAlive: policy.KeepAlive,
+		tlsHandshake: policy.TLSHandshakeTimeout,
+	}, nil
+}
+
+func normalizeHost(host string) (string, error) {
+	if host == "" || host != strings.TrimSpace(host) {
+		return "", errors.New("provider egress host is required without surrounding whitespace")
+	}
+	if address, err := netip.ParseAddr(host); err == nil {
+		if address.Zone() != "" {
+			return "", errors.New("provider egress IP host cannot contain a zone")
+		}
+		return address.Unmap().String(), nil
+	}
+	if len(host) > 253 || strings.ContainsAny(host, ":/\\?#@[]") {
+		return "", errors.New("provider egress host must be a bare DNS name or IP address")
+	}
+	host = strings.ToLower(host)
+	for label := range strings.SplitSeq(host, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return "", errors.New("provider egress host is not a valid DNS name")
+		}
+		for _, character := range label {
+			if (character < 'a' || character > 'z') &&
+				(character < '0' || character > '9') && character != '-' {
+				return "", errors.New("provider egress host is not a valid ASCII DNS name")
+			}
+		}
+	}
+	return host, nil
+}

--- a/document/providerhttp/transport.go
+++ b/document/providerhttp/transport.go
@@ -179,9 +179,12 @@ func (dialer *policyDialer) dial(
 		return nil, fmt.Errorf("%w: malformed address", ErrDestinationDenied)
 	}
 	host, err = normalizeHost(host)
-	if err != nil || host != dialer.policy.host || port != strconv.Itoa(int(dialer.policy.port)) {
+	parsedPort, portErr := strconv.ParseUint(port, 10, 16)
+	if err != nil || portErr != nil || parsedPort == 0 ||
+		host != dialer.policy.host || uint16(parsedPort) != dialer.policy.port {
 		return nil, fmt.Errorf("%w: host or port", ErrDestinationDenied)
 	}
+	port = strconv.Itoa(int(parsedPort))
 	addresses, err := dialer.resolve(ctx)
 	if err != nil {
 		return nil, err

--- a/document/providerhttp/transport.go
+++ b/document/providerhttp/transport.go
@@ -1,0 +1,252 @@
+package providerhttp
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strconv"
+)
+
+var (
+	// ErrDestinationDenied means the requested scheme, host, or port was not
+	// the exact destination authorized by the egress policy.
+	ErrDestinationDenied = errors.New("provider egress destination denied")
+	// ErrAddressDenied means DNS returned at least one address outside every
+	// network prefix authorized by the egress policy.
+	ErrAddressDenied = errors.New("provider egress address denied")
+	// ErrCertificatePin means normal TLS verification succeeded but the leaf
+	// certificate did not match an authorized SHA-256 SPKI digest.
+	ErrCertificatePin = errors.New("provider egress certificate pin mismatch")
+)
+
+// Resolver performs the one DNS lookup allowed for each connection attempt.
+type Resolver interface {
+	LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error)
+}
+
+// RefuseRedirects is an http.Client CheckRedirect function that prevents a
+// request body or credential from being replayed, including to the same host.
+func RefuseRedirects(*http.Request, []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+// NewTransport returns a transport that resolves once per connection attempt,
+// validates every answer, and connects to one exact allowed IP without an
+// ambient proxy or a second hostname lookup.
+func NewTransport(policy EgressPolicy, resolver Resolver) (*http.Transport, error) {
+	validated, err := validatePolicy(policy)
+	if err != nil {
+		return nil, err
+	}
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	dialer := &policyDialer{
+		policy: validated, resolver: resolver,
+		dialer: net.Dialer{Timeout: validated.connect, KeepAlive: validated.keepAlive},
+	}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    validated.rootCAs,
+		ServerName: validated.host,
+	}
+	if len(validated.spkiPins) != 0 {
+		pins := append([][32]byte(nil), validated.spkiPins...)
+		tlsConfig.VerifyConnection = func(state tls.ConnectionState) error {
+			if len(state.PeerCertificates) == 0 {
+				return ErrCertificatePin
+			}
+			digest := sha256.Sum256(state.PeerCertificates[0].RawSubjectPublicKeyInfo)
+			for _, pin := range pins {
+				if subtle.ConstantTimeCompare(digest[:], pin[:]) == 1 {
+					return nil
+				}
+			}
+			return ErrCertificatePin
+		}
+	}
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("default HTTP transport has an unsupported implementation")
+	}
+	transport := defaultTransport.Clone()
+	transport.Proxy = func(request *http.Request) (*url.URL, error) {
+		if err := validated.validateRequest(request); err != nil {
+			return nil, err
+		}
+		return nil, nil //nolint:nilnil // nil is the http.Transport contract for a direct connection.
+	}
+	transport.TLSClientConfig = tlsConfig
+	transport.TLSHandshakeTimeout = validated.tlsHandshake
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if validated.scheme != "http" {
+			return nil, fmt.Errorf("%w: plaintext connection", ErrDestinationDenied)
+		}
+		return dialer.dial(ctx, network, address)
+	}
+	transport.DialTLSContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if validated.scheme != "https" {
+			return nil, fmt.Errorf("%w: TLS connection", ErrDestinationDenied)
+		}
+		connection, err := dialer.dial(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		tlsConnection := tls.Client(connection, tlsConfig.Clone())
+		handshakeContext, cancel := context.WithTimeout(ctx, validated.tlsHandshake)
+		defer cancel()
+		if err := tlsConnection.HandshakeContext(handshakeContext); err != nil {
+			handshakeErr := fmt.Errorf("handshake with provider: %w", err)
+			if closeErr := connection.Close(); closeErr != nil {
+				return nil, errors.Join(handshakeErr, fmt.Errorf("close failed provider connection: %w", closeErr))
+			}
+			return nil, handshakeErr
+		}
+		return tlsConnection, nil
+	}
+	return transport, nil
+}
+
+func (policy validatedPolicy) validateRequest(request *http.Request) error {
+	if request == nil || request.URL == nil || request.URL.Scheme != policy.scheme ||
+		request.URL.User != nil {
+		return fmt.Errorf("%w: request scheme or authority", ErrDestinationDenied)
+	}
+	host, port, err := parseAuthority(request.URL.Host, policy.scheme)
+	if err != nil || host != policy.host || port != policy.port {
+		return fmt.Errorf("%w: request host or port", ErrDestinationDenied)
+	}
+	if request.Host != "" {
+		host, port, err = parseAuthority(request.Host, policy.scheme)
+		if err != nil || host != policy.host || port != policy.port {
+			return fmt.Errorf("%w: Host header", ErrDestinationDenied)
+		}
+	}
+	return nil
+}
+
+func parseAuthority(authority, scheme string) (string, uint16, error) {
+	parsed, err := url.Parse(scheme + "://" + authority)
+	if err != nil || parsed.User != nil || parsed.Host == "" || parsed.Path != "" ||
+		parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", 0, errors.New("invalid provider egress authority")
+	}
+	host, err := normalizeHost(parsed.Hostname())
+	if err != nil {
+		return "", 0, err
+	}
+	port := parsed.Port()
+	if port == "" {
+		switch scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		default:
+			return "", 0, errors.New("invalid provider egress scheme")
+		}
+	}
+	parsedPort, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || parsedPort == 0 {
+		return "", 0, errors.New("invalid provider egress port")
+	}
+	return host, uint16(parsedPort), nil
+}
+
+type policyDialer struct {
+	policy   validatedPolicy
+	resolver Resolver
+	dialer   net.Dialer
+}
+
+func (dialer *policyDialer) dial(
+	ctx context.Context,
+	network string,
+	address string,
+) (net.Conn, error) {
+	if network != "tcp" && network != "tcp4" && network != "tcp6" {
+		return nil, fmt.Errorf("%w: unsupported network", ErrDestinationDenied)
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("%w: malformed address", ErrDestinationDenied)
+	}
+	host, err = normalizeHost(host)
+	if err != nil || host != dialer.policy.host || port != strconv.Itoa(int(dialer.policy.port)) {
+		return nil, fmt.Errorf("%w: host or port", ErrDestinationDenied)
+	}
+	addresses, err := dialer.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var failures []error
+	for _, selected := range addresses {
+		exactNetwork := "tcp6"
+		if selected.Is4() {
+			exactNetwork = "tcp4"
+		}
+		connection, dialErr := dialer.dialer.DialContext(
+			ctx, exactNetwork, net.JoinHostPort(selected.String(), port),
+		)
+		if dialErr == nil {
+			return connection, nil
+		}
+		failures = append(failures, dialErr)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("dial provider IPs: %w", errors.Join(failures...))
+}
+
+func (dialer *policyDialer) resolve(ctx context.Context) ([]netip.Addr, error) {
+	if address, err := netip.ParseAddr(dialer.policy.host); err == nil {
+		addresses := []netip.Addr{address.Unmap()}
+		if err := dialer.validateAddresses(addresses); err != nil {
+			return nil, err
+		}
+		return addresses, nil
+	}
+	addresses, err := dialer.resolver.LookupNetIP(ctx, "ip", dialer.policy.host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve provider egress host: %w", err)
+	}
+	if err := dialer.validateAddresses(addresses); err != nil {
+		return nil, err
+	}
+	result := make([]netip.Addr, len(addresses))
+	for index, address := range addresses {
+		result[index] = address.Unmap()
+	}
+	return result, nil
+}
+
+func (dialer *policyDialer) validateAddresses(addresses []netip.Addr) error {
+	if len(addresses) == 0 {
+		return errors.New("provider egress DNS returned no addresses")
+	}
+	for _, address := range addresses {
+		if !address.IsValid() || address.Zone() != "" {
+			return fmt.Errorf("%w: invalid DNS answer", ErrAddressDenied)
+		}
+		address = address.Unmap()
+		allowed := false
+		for _, prefix := range dialer.policy.allowedCIDRs {
+			if prefix.Contains(address) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return ErrAddressDenied
+		}
+	}
+	return nil
+}

--- a/document/providerhttp/transport_test.go
+++ b/document/providerhttp/transport_test.go
@@ -51,6 +51,26 @@ func TestEgressDialsResolvedIPWithoutASecondLookup(t *testing.T) {
 	assert.Equal(t, []string{"provider.invalid"}, resolver.hosts())
 }
 
+func TestEgressAcceptsAnEquivalentZeroPaddedPort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "provider")
+	}))
+	defer server.Close()
+	host, port := endpoint(t, server.Listener.Addr())
+	transport := newHTTPTransport(t, port, &recordingResolver{
+		answers: [][]netip.Addr{{netip.MustParseAddr(host)}},
+	})
+
+	response, err := (&http.Client{Transport: transport}).Get(
+		"http://provider.invalid:0" + strconv.Itoa(int(port)),
+	)
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	assert.Equal(t, "provider", string(body))
+}
+
 func TestEgressIgnoresAmbientProxy(t *testing.T) {
 	var proxyRequests atomic.Int32
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/document/providerhttp/transport_test.go
+++ b/document/providerhttp/transport_test.go
@@ -1,0 +1,450 @@
+package providerhttp_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+func TestEgressDialsResolvedIPWithoutASecondLookup(t *testing.T) {
+	var hostHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hostHeader = r.Host
+		_, _ = io.WriteString(w, "direct")
+	}))
+	defer server.Close()
+	host, port := endpoint(t, server.Listener.Addr())
+	resolver := &recordingResolver{answers: [][]netip.Addr{{netip.MustParseAddr(host)}}}
+	transport := newHTTPTransport(t, port, resolver)
+	client := &http.Client{Transport: transport, CheckRedirect: providerhttp.RefuseRedirects}
+
+	response, err := client.Get("http://provider.invalid:" + strconv.Itoa(int(port)) + "/source")
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	assert.Equal(t, "direct", string(body))
+	assert.Equal(t, "provider.invalid:"+strconv.Itoa(int(port)), hostHeader)
+	assert.Equal(t, []string{"provider.invalid"}, resolver.hosts())
+}
+
+func TestEgressIgnoresAmbientProxy(t *testing.T) {
+	var proxyRequests atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		proxyRequests.Add(1)
+		http.Error(w, "proxy used", http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+	t.Setenv("NO_PROXY", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "origin")
+	}))
+	defer server.Close()
+	host, port := endpoint(t, server.Listener.Addr())
+	transport := newHTTPTransport(t, port, &recordingResolver{
+		answers: [][]netip.Addr{{netip.MustParseAddr(host)}},
+	})
+
+	response, err := (&http.Client{Transport: transport}).Get(
+		"http://provider.invalid:" + strconv.Itoa(int(port)),
+	)
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	assert.Equal(t, "origin", string(body))
+	assert.Zero(t, proxyRequests.Load())
+}
+
+func TestEgressRejectsMixedAllowedAndDeniedDNSAnswers(t *testing.T) {
+	resolver := &recordingResolver{answers: [][]netip.Addr{{
+		netip.MustParseAddr("127.0.0.1"),
+		netip.MustParseAddr("203.0.113.10"),
+	}}}
+	transport, err := providerhttp.NewTransport(providerhttp.EgressPolicy{
+		Scheme: "http", Host: "provider.invalid", Port: 8080,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+		ProxyMode:    providerhttp.ProxyDisabled,
+	}, resolver)
+	require.NoError(t, err)
+
+	response, err := (&http.Client{Transport: transport}).Get("http://provider.invalid:8080/")
+	if response != nil {
+		require.NoError(t, response.Body.Close())
+	}
+	require.ErrorIs(t, err, providerhttp.ErrAddressDenied)
+	assert.Equal(t, []string{"provider.invalid"}, resolver.hosts())
+}
+
+func TestEgressRevalidatesDNSOnEachConnection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "first")
+	}))
+	defer server.Close()
+	host, port := endpoint(t, server.Listener.Addr())
+	resolver := &recordingResolver{answers: [][]netip.Addr{
+		{netip.MustParseAddr(host)},
+		{netip.MustParseAddr("203.0.113.10")},
+	}}
+	transport := newHTTPTransport(t, port, resolver)
+	transport.DisableKeepAlives = true
+	client := &http.Client{Transport: transport}
+	url := "http://provider.invalid:" + strconv.Itoa(int(port)) + "/"
+
+	first, err := client.Get(url)
+	require.NoError(t, err)
+	require.NoError(t, first.Body.Close())
+	second, err := client.Get(url)
+	if second != nil {
+		require.NoError(t, second.Body.Close())
+	}
+
+	require.ErrorIs(t, err, providerhttp.ErrAddressDenied)
+	assert.Equal(t, []string{"provider.invalid", "provider.invalid"}, resolver.hosts())
+}
+
+func TestEgressFallsBackAcrossApprovedDNSAnswers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "fallback")
+	}))
+	defer server.Close()
+	_, port := endpoint(t, server.Listener.Addr())
+	resolver := &recordingResolver{answers: [][]netip.Addr{{
+		netip.MustParseAddr("127.0.0.2"),
+		netip.MustParseAddr("127.0.0.1"),
+	}}}
+	transport := newHTTPTransport(t, port, resolver)
+
+	response, err := (&http.Client{Transport: transport}).Get(
+		"http://provider.invalid:" + strconv.Itoa(int(port)),
+	)
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	assert.Equal(t, "fallback", string(body))
+	assert.Equal(t, []string{"provider.invalid"}, resolver.hosts())
+}
+
+func TestEgressRejectsUnapprovedDestinationBeforeResolution(t *testing.T) {
+	resolver := &recordingResolver{answers: [][]netip.Addr{{netip.MustParseAddr("127.0.0.1")}}}
+	transport, err := providerhttp.NewTransport(providerhttp.EgressPolicy{
+		Scheme: "http", Host: "provider.invalid", Port: 8080,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+	}, resolver)
+	require.NoError(t, err)
+	client := &http.Client{Transport: transport}
+
+	for _, rawURL := range []string{
+		"http://other.invalid:8080/",
+		"http://provider.invalid:8081/",
+		"https://provider.invalid:8080/",
+	} {
+		response, err := client.Get(rawURL)
+		if response != nil {
+			require.NoError(t, response.Body.Close())
+		}
+		require.ErrorIs(t, err, providerhttp.ErrDestinationDenied, rawURL)
+	}
+	request, err := http.NewRequest(http.MethodGet, "http://provider.invalid:8080/", nil)
+	require.NoError(t, err)
+	request.Host = "other.invalid:8080"
+	response, err := client.Do(request)
+	if response != nil {
+		require.NoError(t, response.Body.Close())
+	}
+	require.ErrorIs(t, err, providerhttp.ErrDestinationDenied)
+	assert.Empty(t, resolver.hosts())
+}
+
+func TestEgressUsesLiteralIPWithoutDNS(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "literal")
+	}))
+	defer server.Close()
+	host, port := endpoint(t, server.Listener.Addr())
+	resolver := &recordingResolver{}
+	transport, err := providerhttp.NewTransport(providerhttp.EgressPolicy{
+		Scheme: "http", Host: host, Port: port,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+	}, resolver)
+	require.NoError(t, err)
+
+	response, err := (&http.Client{Transport: transport}).Get(server.URL)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	assert.Empty(t, resolver.hosts())
+}
+
+func TestEgressPreservesTLSIdentityAndEnforcesSPKIPin(t *testing.T) {
+	certificate, roots, pin := providerCertificate(t, "provider.invalid")
+	var sni string
+	var hostHeader string
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hostHeader = r.Host
+		_, _ = io.WriteString(w, "secure")
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			sni = hello.ServerName
+			return nil, nil //nolint:nilnil // nil keeps this server's configured certificate.
+		},
+	}
+	server.StartTLS()
+	defer server.Close()
+	host, port := endpoint(t, server.Listener.Addr())
+	resolver := &recordingResolver{answers: [][]netip.Addr{{netip.MustParseAddr(host)}}}
+	policy := providerhttp.EgressPolicy{
+		Scheme: "https", Host: "provider.invalid", Port: port,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+		TLS:          providerhttp.TLSPolicy{RootCAs: roots, SPKISHA256: []string{pin}},
+	}
+	transport, err := providerhttp.NewTransport(policy, resolver)
+	require.NoError(t, err)
+	client := &http.Client{Transport: transport}
+	url := "https://provider.invalid:" + strconv.Itoa(int(port)) + "/result"
+
+	response, err := client.Get(url)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	assert.Equal(t, "provider.invalid", sni)
+	assert.Equal(t, "provider.invalid:"+strconv.Itoa(int(port)), hostHeader)
+
+	policy.TLS.SPKISHA256 = []string{hex.EncodeToString(make([]byte, sha256.Size))}
+	transport, err = providerhttp.NewTransport(policy, resolver)
+	require.NoError(t, err)
+	response, err = (&http.Client{Transport: transport}).Get(url)
+	if response != nil {
+		require.NoError(t, response.Body.Close())
+	}
+	require.ErrorIs(t, err, providerhttp.ErrCertificatePin)
+}
+
+func TestEgressBoundsTLSHandshake(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			accepted <- connection
+		}
+	}()
+	_, port := endpoint(t, listener.Addr())
+	transport, err := providerhttp.NewTransport(providerhttp.EgressPolicy{
+		Scheme: "https", Host: "127.0.0.1", Port: port,
+		AllowedCIDRs:        []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+		TLSHandshakeTimeout: 25 * time.Millisecond,
+	}, &recordingResolver{})
+	require.NoError(t, err)
+	started := time.Now()
+
+	response, err := (&http.Client{Transport: transport}).Get(
+		"https://127.0.0.1:" + strconv.Itoa(int(port)),
+	)
+	if response != nil {
+		require.NoError(t, response.Body.Close())
+	}
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), time.Second)
+	select {
+	case connection := <-accepted:
+		require.NoError(t, connection.Close())
+	case <-time.After(time.Second):
+		require.Fail(t, "provider connection was not accepted")
+	}
+}
+
+func TestEgressPolicyIsImmutableAfterTransportCreation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "immutable")
+	}))
+	defer server.Close()
+	host, port := endpoint(t, server.Listener.Addr())
+	allowed := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+	policy := providerhttp.EgressPolicy{
+		Scheme: "http", Host: "provider.invalid", Port: port, AllowedCIDRs: allowed,
+	}
+	transport, err := providerhttp.NewTransport(policy, &recordingResolver{
+		answers: [][]netip.Addr{{netip.MustParseAddr(host)}},
+	})
+	require.NoError(t, err)
+	allowed[0] = netip.MustParsePrefix("203.0.113.0/24")
+
+	response, err := (&http.Client{Transport: transport}).Get(
+		"http://provider.invalid:" + strconv.Itoa(int(port)),
+	)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+}
+
+func TestEgressRefusesRedirectReplay(t *testing.T) {
+	var redirected atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirected" {
+			redirected.Add(1)
+			return
+		}
+		http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	host, port := endpoint(t, server.Listener.Addr())
+	transport := newHTTPTransport(t, port, &recordingResolver{
+		answers: [][]netip.Addr{{netip.MustParseAddr(host)}},
+	})
+	client := &http.Client{Transport: transport, CheckRedirect: providerhttp.RefuseRedirects}
+
+	response, err := client.Get("http://provider.invalid:" + strconv.Itoa(int(port)))
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	assert.Equal(t, http.StatusTemporaryRedirect, response.StatusCode)
+	assert.Zero(t, redirected.Load())
+}
+
+func TestEgressValidatesPolicy(t *testing.T) {
+	valid := providerhttp.EgressPolicy{
+		Scheme: "https", Host: "provider.invalid", Port: 443,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")},
+		ProxyMode:    providerhttp.ProxyDisabled,
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*providerhttp.EgressPolicy)
+	}{
+		{name: "scheme", mutate: func(policy *providerhttp.EgressPolicy) { policy.Scheme = "ftp" }},
+		{name: "host", mutate: func(policy *providerhttp.EgressPolicy) { policy.Host = "" }},
+		{name: "host with port", mutate: func(policy *providerhttp.EgressPolicy) { policy.Host = "provider.invalid:443" }},
+		{name: "port", mutate: func(policy *providerhttp.EgressPolicy) { policy.Port = 0 }},
+		{name: "CIDRs", mutate: func(policy *providerhttp.EgressPolicy) { policy.AllowedCIDRs = nil }},
+		{name: "proxy", mutate: func(policy *providerhttp.EgressPolicy) { policy.ProxyMode = "environment" }},
+		{name: "pin", mutate: func(policy *providerhttp.EgressPolicy) { policy.TLS.SPKISHA256 = []string{"bad"} }},
+		{name: "connect timeout", mutate: func(policy *providerhttp.EgressPolicy) { policy.ConnectTimeout = -time.Second }},
+		{name: "keepalive", mutate: func(policy *providerhttp.EgressPolicy) { policy.KeepAlive = -time.Second }},
+		{name: "TLS handshake timeout", mutate: func(policy *providerhttp.EgressPolicy) { policy.TLSHandshakeTimeout = -time.Second }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			policy := valid
+			test.mutate(&policy)
+			_, err := providerhttp.NewTransport(policy, &recordingResolver{})
+			require.Error(t, err)
+		})
+	}
+}
+
+func newHTTPTransport(
+	t *testing.T,
+	port uint16,
+	resolver providerhttp.Resolver,
+) *http.Transport {
+	t.Helper()
+	transport, err := providerhttp.NewTransport(providerhttp.EgressPolicy{
+		Scheme: "http", Host: "provider.invalid", Port: port,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+		ProxyMode:    providerhttp.ProxyDisabled,
+	}, resolver)
+	require.NoError(t, err)
+	return transport
+}
+
+func endpoint(t *testing.T, address net.Addr) (string, uint16) {
+	t.Helper()
+	host, rawPort, err := net.SplitHostPort(address.String())
+	require.NoError(t, err)
+	port, err := strconv.ParseUint(rawPort, 10, 16)
+	require.NoError(t, err)
+	return host, uint16(port)
+}
+
+type recordingResolver struct {
+	mu      sync.Mutex
+	answers [][]netip.Addr
+	calls   []string
+}
+
+func (resolver *recordingResolver) LookupNetIP(
+	_ context.Context,
+	network string,
+	host string,
+) ([]netip.Addr, error) {
+	resolver.mu.Lock()
+	defer resolver.mu.Unlock()
+	resolver.calls = append(resolver.calls, host)
+	if network != "ip" {
+		return nil, assert.AnError
+	}
+	if len(resolver.answers) == 0 {
+		return nil, assert.AnError
+	}
+	answer := resolver.answers[0]
+	if len(resolver.answers) > 1 {
+		resolver.answers = resolver.answers[1:]
+	}
+	return append([]netip.Addr(nil), answer...), nil
+}
+
+func (resolver *recordingResolver) hosts() []string {
+	resolver.mu.Lock()
+	defer resolver.mu.Unlock()
+	return append([]string(nil), resolver.calls...)
+}
+
+func providerCertificate(t *testing.T, hostname string) (tls.Certificate, *x509.CertPool, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 120))
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: hostname},
+		DNSNames:     []string{hostname},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	certificate, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+	)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	roots := x509.NewCertPool()
+	roots.AddCert(parsed)
+	digest := sha256.Sum256(parsed.RawSubjectPublicKeyInfo)
+	return certificate, roots, hex.EncodeToString(digest[:])
+}


### PR DESCRIPTION
## What changed

Docbank now applies one transport policy to an exact scheme, host, port, CIDR set, proxy mode, and optional TLS roots or SPKI pins. It resolves once per connection attempt, rejects the entire DNS answer set if any address escapes policy, and dials only the validated IPs while preserving the original Host and TLS identity.

Redirects, destination drift, ambient proxies, and unbounded connect or TLS work are refused. The default local GLM-OCR client now uses the same boundary.

## Why

Checking a hostname and then handing it back to the standard dialer leaves a second DNS lookup and ambient proxy behavior outside the reviewed boundary. Resolution must stay bound to the socket that actually receives provider bytes.

## Usage

Build provider HTTP clients from an explicit egress policy. The same policy must approve every resolved address for each connection attempt; retries can move only across that approved set.

There is no user-facing command change.

Part of #176 (R3). Stacks on #190.
