### PR TITLE
Add durable, revocable processing consent

### DIFF
--- a/internal/store/consent.go
+++ b/internal/store/consent.go
@@ -1,0 +1,426 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+var (
+	ErrProcessingConsentRequired = errors.New("processing consent is required")
+	ErrProcessingConsentExpired  = errors.New("processing consent has expired")
+	ErrProcessingConsentRevoked  = errors.New("processing consent has been revoked")
+)
+
+// ProcessingIncarnation is the local authority boundary for provider access.
+// Restores keep historical consent records but start with a new incarnation.
+type ProcessingIncarnation struct {
+	ID        string
+	CreatedAt time.Time
+}
+
+// ProcessingConsentGrantRequest binds one consent grant to exact policy and
+// disclosure identities plus the byte and retention classes it permits.
+type ProcessingConsentGrantRequest struct {
+	Principal               string
+	Scope                   string
+	ProfileFingerprint      string
+	DisclosureFingerprint   string
+	InputClasses            []string
+	RetainedArtifactClasses []string
+	ExpiresAt               *time.Time
+}
+
+// ProcessingConsentGrant is immutable authority within one vault incarnation.
+type ProcessingConsentGrant struct {
+	ID                      string
+	VaultID                 string
+	ProcessingIncarnationID string
+	Principal               string
+	Scope                   string
+	ProfileFingerprint      string
+	DisclosureFingerprint   string
+	InputClasses            []string
+	RetainedArtifactClasses []string
+	RevocationFence         int64
+	IssuedAt                time.Time
+	ExpiresAt               *time.Time
+}
+
+// ProcessingConsentRevocationRequest advances the fence for one principal and scope.
+type ProcessingConsentRevocationRequest struct {
+	Principal string
+	Scope     string
+}
+
+// ProcessingConsentRevocation is an immutable scope-fence advancement.
+type ProcessingConsentRevocation struct {
+	ID                      string
+	VaultID                 string
+	ProcessingIncarnationID string
+	Principal               string
+	Scope                   string
+	Fence                   int64
+	RevokedAt               time.Time
+}
+
+// ProviderOperationAuthorizationRequest describes the exact outbound operation
+// and retained outputs that core is about to authorize.
+type ProviderOperationAuthorizationRequest struct {
+	Principal               string
+	Scope                   string
+	ProfileFingerprint      string
+	DisclosureFingerprint   string
+	InputClasses            []string
+	RetainedArtifactClasses []string
+	// PriorAuthorization is set when a leased operation rechecks authority
+	// immediately before publication. A later replacement grant cannot revive
+	// work authorized below an earlier revocation fence.
+	PriorAuthorization *ProviderOperationAuthorization
+}
+
+// ProviderOperationAuthorization is an immutable receipt. It is evidence of a
+// successful check, not a bearer capability: publication must authorize again.
+type ProviderOperationAuthorization struct {
+	GrantID                 string
+	ProcessingIncarnationID string
+	RevocationFence         int64
+	AuthorizedAt            time.Time
+}
+
+type normalizedConsentAuthority struct {
+	principal, scope, profile, disclosure string
+	inputs, retained                      []string
+	inputsJSON, retainedJSON              string
+}
+
+func ensureProcessingIncarnationTx(tx *sql.Tx) error {
+	var count int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM current_processing_incarnation`).Scan(&count); err != nil {
+		return fmt.Errorf("checking processing incarnation: %w", err)
+	}
+	if count == 1 {
+		return nil
+	}
+	if count != 0 {
+		return fmt.Errorf("processing incarnation pointer has %d rows", count)
+	}
+	id, err := newUUIDv4()
+	if err != nil {
+		return fmt.Errorf("creating processing incarnation: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO processing_incarnations(incarnation_id,created_at) VALUES(?,?)`,
+		id, nowRFC3339()); err != nil {
+		return fmt.Errorf("creating processing incarnation: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO current_processing_incarnation(singleton,incarnation_id) VALUES(1,?)`, id); err != nil {
+		return fmt.Errorf("activating processing incarnation: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) CurrentProcessingIncarnation(ctx context.Context) (ProcessingIncarnation, error) {
+	var value ProcessingIncarnation
+	var created string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT i.incarnation_id,i.created_at
+		FROM current_processing_incarnation c
+		JOIN processing_incarnations i ON i.incarnation_id=c.incarnation_id
+		WHERE c.singleton=1`).Scan(&value.ID, &created)
+	if err != nil {
+		return ProcessingIncarnation{}, fmt.Errorf("reading current processing incarnation: %w", err)
+	}
+	value.CreatedAt, err = time.Parse(timestampLayout, created)
+	if err != nil {
+		return ProcessingIncarnation{}, fmt.Errorf("reading current processing incarnation timestamp: %w", err)
+	}
+	return value, nil
+}
+
+func (s *Store) GrantConsent(
+	ctx context.Context, request ProcessingConsentGrantRequest,
+) (ProcessingConsentGrant, error) {
+	authority, err := normalizeConsentAuthority(ProviderOperationAuthorizationRequest{
+		Principal: request.Principal, Scope: request.Scope,
+		ProfileFingerprint:      request.ProfileFingerprint,
+		DisclosureFingerprint:   request.DisclosureFingerprint,
+		InputClasses:            request.InputClasses,
+		RetainedArtifactClasses: request.RetainedArtifactClasses,
+	})
+	if err != nil {
+		return ProcessingConsentGrant{}, err
+	}
+	id, err := newUUIDv4()
+	if err != nil {
+		return ProcessingConsentGrant{}, fmt.Errorf("granting processing consent: %w", err)
+	}
+	issuedAt := time.Now().UTC()
+	issuedRaw := issuedAt.Format(timestampLayout)
+	var expiresRaw any
+	var expiresAt *time.Time
+	if request.ExpiresAt != nil {
+		value := request.ExpiresAt.UTC()
+		expiresRaw = value.Format(timestampLayout)
+		expiresAt = &value
+	}
+	grant := ProcessingConsentGrant{
+		ID: id, VaultID: s.vaultID, Principal: authority.principal, Scope: authority.scope,
+		ProfileFingerprint: authority.profile, DisclosureFingerprint: authority.disclosure,
+		InputClasses: authority.inputs, RetainedArtifactClasses: authority.retained,
+		IssuedAt: issuedAt, ExpiresAt: expiresAt,
+	}
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		incarnationID, err := currentProcessingIncarnationIDTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		grant.ProcessingIncarnationID = incarnationID
+		grant.RevocationFence, err = consentRevocationFenceTx(ctx, tx, s.vaultID,
+			incarnationID, authority.principal, authority.scope)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO processing_consent_grants(
+				grant_id,vault_uid,incarnation_id,principal,scope,profile_fingerprint,
+				disclosure_fingerprint,input_classes_json,retained_classes_json,
+				revocation_fence,issued_at,expires_at
+			) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`, grant.ID, grant.VaultID,
+			grant.ProcessingIncarnationID, grant.Principal, grant.Scope,
+			grant.ProfileFingerprint, grant.DisclosureFingerprint, authority.inputsJSON,
+			authority.retainedJSON, grant.RevocationFence, issuedRaw, expiresRaw)
+		return err
+	})
+	if err != nil {
+		return ProcessingConsentGrant{}, fmt.Errorf("granting processing consent: %w", err)
+	}
+	return grant, nil
+}
+
+func (s *Store) RevokeConsent(
+	ctx context.Context, request ProcessingConsentRevocationRequest,
+) (ProcessingConsentRevocation, error) {
+	principal, err := normalizeConsentLabel("principal", request.Principal)
+	if err != nil {
+		return ProcessingConsentRevocation{}, err
+	}
+	scope, err := normalizeConsentLabel("scope", request.Scope)
+	if err != nil {
+		return ProcessingConsentRevocation{}, err
+	}
+	id, err := newUUIDv4()
+	if err != nil {
+		return ProcessingConsentRevocation{}, fmt.Errorf("revoking processing consent: %w", err)
+	}
+	revokedAt := time.Now().UTC()
+	result := ProcessingConsentRevocation{
+		ID: id, VaultID: s.vaultID, Principal: principal, Scope: scope, RevokedAt: revokedAt,
+	}
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		result.ProcessingIncarnationID, err = currentProcessingIncarnationIDTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		prior, err := consentRevocationFenceTx(ctx, tx, s.vaultID,
+			result.ProcessingIncarnationID, principal, scope)
+		if err != nil {
+			return err
+		}
+		result.Fence = prior + 1
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO processing_consent_revocations(
+				revocation_id,vault_uid,incarnation_id,principal,scope,fence,revoked_at
+			) VALUES(?,?,?,?,?,?,?)`, result.ID, result.VaultID,
+			result.ProcessingIncarnationID, principal, scope, result.Fence,
+			revokedAt.Format(timestampLayout))
+		return err
+	})
+	if err != nil {
+		return ProcessingConsentRevocation{}, fmt.Errorf("revoking processing consent: %w", err)
+	}
+	return result, nil
+}
+
+func (s *Store) AuthorizeProviderOperation(
+	ctx context.Context, request ProviderOperationAuthorizationRequest,
+) (ProviderOperationAuthorization, error) {
+	authority, err := normalizeConsentAuthority(request)
+	if err != nil {
+		return ProviderOperationAuthorization{}, err
+	}
+	now := time.Now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	incarnationID, err := currentProcessingIncarnationIDTx(ctx, tx)
+	if err != nil {
+		return ProviderOperationAuthorization{}, err
+	}
+	fence, err := consentRevocationFenceTx(ctx, tx, s.vaultID, incarnationID,
+		authority.principal, authority.scope)
+	if err != nil {
+		return ProviderOperationAuthorization{}, err
+	}
+	if request.PriorAuthorization != nil &&
+		(request.PriorAuthorization.ProcessingIncarnationID != incarnationID ||
+			request.PriorAuthorization.RevocationFence != fence) {
+		return ProviderOperationAuthorization{}, ErrProcessingConsentRevoked
+	}
+	query := `
+		SELECT grant_id,revocation_fence,expires_at
+		FROM processing_consent_grants
+		WHERE vault_uid=? AND incarnation_id=? AND principal=? AND scope=?
+		  AND profile_fingerprint=? AND disclosure_fingerprint=?
+		  AND input_classes_json=? AND retained_classes_json=?`
+	args := []any{s.vaultID, incarnationID,
+		authority.principal, authority.scope, authority.profile, authority.disclosure,
+		authority.inputsJSON, authority.retainedJSON}
+	if request.PriorAuthorization != nil {
+		query += ` AND grant_id=?`
+		args = append(args, request.PriorAuthorization.GrantID)
+	}
+	query += ` ORDER BY issued_at DESC,grant_id DESC`
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	foundCurrentFence, foundRevoked := false, false
+	for rows.Next() {
+		var grantID string
+		var grantFence int64
+		var expires sql.NullString
+		if err := rows.Scan(&grantID, &grantFence, &expires); err != nil {
+			return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: %w", err)
+		}
+		if grantFence != fence {
+			foundRevoked = true
+			continue
+		}
+		foundCurrentFence = true
+		if expires.Valid {
+			expiry, err := time.Parse(timestampLayout, expires.String)
+			if err != nil {
+				return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: invalid grant expiry: %w", err)
+			}
+			if !expiry.After(now) {
+				continue
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: %w", err)
+		}
+		return ProviderOperationAuthorization{
+			GrantID: grantID, ProcessingIncarnationID: incarnationID,
+			RevocationFence: fence, AuthorizedAt: now,
+		}, nil
+	}
+	if err := rows.Err(); err != nil {
+		return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: %w", err)
+	}
+	if foundCurrentFence {
+		return ProviderOperationAuthorization{}, ErrProcessingConsentExpired
+	}
+	if foundRevoked {
+		return ProviderOperationAuthorization{}, ErrProcessingConsentRevoked
+	}
+	return ProviderOperationAuthorization{}, ErrProcessingConsentRequired
+}
+
+func currentProcessingIncarnationIDTx(
+	ctx context.Context, tx interface {
+		QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	},
+) (string, error) {
+	var id string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT incarnation_id FROM current_processing_incarnation WHERE singleton=1`).Scan(&id); err != nil {
+		return "", fmt.Errorf("reading current processing incarnation: %w", err)
+	}
+	return id, nil
+}
+
+func consentRevocationFenceTx(
+	ctx context.Context, tx interface {
+		QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	},
+	vaultID, incarnationID, principal, scope string,
+) (int64, error) {
+	var fence int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(fence),0) FROM processing_consent_revocations
+		WHERE vault_uid=? AND incarnation_id=? AND principal=? AND scope=?`,
+		vaultID, incarnationID, principal, scope).Scan(&fence); err != nil {
+		return 0, fmt.Errorf("reading processing consent revocation fence: %w", err)
+	}
+	return fence, nil
+}
+
+func normalizeConsentAuthority(
+	request ProviderOperationAuthorizationRequest,
+) (normalizedConsentAuthority, error) {
+	principal, err := normalizeConsentLabel("principal", request.Principal)
+	if err != nil {
+		return normalizedConsentAuthority{}, err
+	}
+	scope, err := normalizeConsentLabel("scope", request.Scope)
+	if err != nil {
+		return normalizedConsentAuthority{}, err
+	}
+	if err := validateCatalogSHA256(request.ProfileFingerprint, "processing consent profile fingerprint"); err != nil {
+		return normalizedConsentAuthority{}, err
+	}
+	if err := validateCatalogSHA256(request.DisclosureFingerprint, "processing consent disclosure fingerprint"); err != nil {
+		return normalizedConsentAuthority{}, err
+	}
+	inputs, inputsJSON, err := normalizeConsentClasses("input", request.InputClasses, true)
+	if err != nil {
+		return normalizedConsentAuthority{}, err
+	}
+	retained, retainedJSON, err := normalizeConsentClasses("retained artifact", request.RetainedArtifactClasses, false)
+	if err != nil {
+		return normalizedConsentAuthority{}, err
+	}
+	return normalizedConsentAuthority{
+		principal: principal, scope: scope, profile: request.ProfileFingerprint,
+		disclosure: request.DisclosureFingerprint, inputs: inputs, retained: retained,
+		inputsJSON: inputsJSON, retainedJSON: retainedJSON,
+	}, nil
+}
+
+func normalizeConsentLabel(subject, value string) (string, error) {
+	if !utf8.ValidString(value) || value == "" || len(value) > 256 || strings.TrimSpace(value) != value {
+		return "", fmt.Errorf("processing consent %s must be 1 to 256 UTF-8 bytes without surrounding whitespace", subject)
+	}
+	return value, nil
+}
+
+func normalizeConsentClasses(subject string, values []string, required bool) ([]string, string, error) {
+	if (required && len(values) == 0) || len(values) > 64 {
+		return nil, "", fmt.Errorf("processing consent %s classes have an invalid count", subject)
+	}
+	result := slices.Clone(values)
+	if result == nil {
+		result = []string{}
+	}
+	for _, value := range result {
+		if !utf8.ValidString(value) || value == "" || len(value) > 128 || strings.TrimSpace(value) != value {
+			return nil, "", fmt.Errorf("processing consent %s class must be 1 to 128 UTF-8 bytes without surrounding whitespace", subject)
+		}
+	}
+	slices.Sort(result)
+	result = slices.Compact(result)
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, "", fmt.Errorf("encoding processing consent %s classes: %w", subject, err)
+	}
+	return result, string(encoded), nil
+}

--- a/internal/store/consent.go
+++ b/internal/store/consent.go
@@ -79,9 +79,8 @@ type ProviderOperationAuthorizationRequest struct {
 	DisclosureFingerprint   string
 	InputClasses            []string
 	RetainedArtifactClasses []string
-	// PriorAuthorization is set when a leased operation rechecks authority
-	// immediately before publication. A later replacement grant cannot revive
-	// work authorized below an earlier revocation fence.
+	// PriorAuthorization is set only for atomic publication. A later replacement
+	// grant cannot revive work authorized below an earlier revocation fence.
 	PriorAuthorization *ProviderOperationAuthorization
 }
 
@@ -250,16 +249,33 @@ func (s *Store) RevokeConsent(
 func (s *Store) AuthorizeProviderOperation(
 	ctx context.Context, request ProviderOperationAuthorizationRequest,
 ) (ProviderOperationAuthorization, error) {
-	authority, err := normalizeConsentAuthority(request)
-	if err != nil {
-		return ProviderOperationAuthorization{}, err
+	if request.PriorAuthorization != nil {
+		return ProviderOperationAuthorization{}, errors.New(
+			"prior processing authorization can only be checked during atomic publication",
+		)
 	}
-	now := time.Now().UTC()
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	authorization, err := s.authorizeProviderOperationTx(ctx, tx, request, time.Now().UTC())
+	if err != nil {
+		return ProviderOperationAuthorization{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: %w", err)
+	}
+	return authorization, nil
+}
+
+func (s *Store) authorizeProviderOperationTx(
+	ctx context.Context, tx *sql.Tx, request ProviderOperationAuthorizationRequest, now time.Time,
+) (ProviderOperationAuthorization, error) {
+	authority, err := normalizeConsentAuthority(request)
+	if err != nil {
+		return ProviderOperationAuthorization{}, err
+	}
 	incarnationID, err := currentProcessingIncarnationIDTx(ctx, tx)
 	if err != nil {
 		return ProviderOperationAuthorization{}, err
@@ -314,9 +330,6 @@ func (s *Store) AuthorizeProviderOperation(
 			if !expiry.After(now) {
 				continue
 			}
-		}
-		if err := tx.Commit(); err != nil {
-			return ProviderOperationAuthorization{}, fmt.Errorf("authorizing provider operation: %w", err)
 		}
 		return ProviderOperationAuthorization{
 			GrantID: grantID, ProcessingIncarnationID: incarnationID,

--- a/internal/store/consent_test.go
+++ b/internal/store/consent_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
 )
 
 func TestProcessingConsentAuthorizesOnlyExactCurrentGrant(t *testing.T) {
@@ -131,7 +133,15 @@ func TestProcessingConsentRevocationFencesSubmissionAndPublication(t *testing.T)
 func TestProcessingConsentRevocationIsCheckedInPublicationTransaction(t *testing.T) {
 	s, versions := newRenditionCatalogFixture(t)
 	profile := catalogProcessingProfile(t, false)
+	operation := document.RenditionAuthorization{
+		RenditionRequestFingerprint: profile.RenditionRequestFingerprint,
+		SourceSHA256:                catalogSourceHash,
+		InputKind:                   document.RenditionInputOriginalFile,
+	}
+	operationChecksum, err := operation.Fingerprint()
+	require.NoError(t, err)
 	build := lexicalSearchBuild(s, profile, catalogBuildID, "authorized synthetic evidence")
+	build.AuthorizationChecksum = operationChecksum
 	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
 	generation, err := s.StageLexicalGeneration(t.Context(), fakeHash("c9"))
 	require.NoError(t, err)
@@ -146,6 +156,7 @@ func TestProcessingConsentRevocationIsCheckedInPublicationTransaction(t *testing
 	request := testProviderAuthorizationRequest()
 	request.ProfileFingerprint = profile.Fingerprint
 	request.DisclosureFingerprint = profile.RenditionDisclosureFingerprint
+	request.RetainedArtifactClasses = []string{"normalized_evidence", "sanitized_markdown"}
 	_, err = s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
 	require.NoError(t, err)
 	leased, err := s.AuthorizeProviderOperation(t.Context(), request)
@@ -158,19 +169,48 @@ func TestProcessingConsentRevocationIsCheckedInPublicationTransaction(t *testing
 	publication := request
 	publication.PriorAuthorization = &leased
 	err = s.PublishAuthorizedRenditionAndLexicalHeads(
-		t.Context(), attachment, head, generation.ID, publication,
+		t.Context(), attachment, head, generation.ID, publication, operation,
 	)
 	require.ErrorIs(t, err, ErrProcessingConsentRevoked)
 	_, err = s.ActiveRendition(t.Context(), versions[0], profile.Fingerprint)
 	require.ErrorIs(t, err, ErrNotFound)
 
+	narrow := request
+	narrow.RetainedArtifactClasses = []string{"normalized_evidence"}
+	_, err = s.GrantConsent(t.Context(), grantRequestForAuthorization(narrow, nil))
+	require.NoError(t, err)
+	current, err := s.AuthorizeProviderOperation(t.Context(), narrow)
+	require.NoError(t, err)
+	publication = narrow
+	publication.PriorAuthorization = &current
+	err = s.PublishAuthorizedRenditionAndLexicalHeads(
+		t.Context(), attachment, head, generation.ID, publication, operation,
+	)
+	require.ErrorContains(t, err, "retained artifact classes do not match")
+	_, err = s.ActiveRendition(t.Context(), versions[0], profile.Fingerprint)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	wrongInput := request
+	wrongInput.InputClasses = []string{string(document.RenditionInputDerivedUpload)}
+	_, err = s.GrantConsent(t.Context(), grantRequestForAuthorization(wrongInput, nil))
+	require.NoError(t, err)
+	current, err = s.AuthorizeProviderOperation(t.Context(), wrongInput)
+	require.NoError(t, err)
+	publication = wrongInput
+	publication.PriorAuthorization = &current
+	err = s.PublishAuthorizedRenditionAndLexicalHeads(
+		t.Context(), attachment, head, generation.ID, publication, operation,
+	)
+	require.ErrorContains(t, err, "input classes do not match")
+
 	_, err = s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
 	require.NoError(t, err)
-	current, err := s.AuthorizeProviderOperation(t.Context(), request)
+	current, err = s.AuthorizeProviderOperation(t.Context(), request)
 	require.NoError(t, err)
+	publication = request
 	publication.PriorAuthorization = &current
 	require.NoError(t, s.PublishAuthorizedRenditionAndLexicalHeads(
-		t.Context(), attachment, head, generation.ID, publication,
+		t.Context(), attachment, head, generation.ID, publication, operation,
 	))
 	published, err := s.ActiveRendition(t.Context(), versions[0], profile.Fingerprint)
 	require.NoError(t, err)

--- a/internal/store/consent_test.go
+++ b/internal/store/consent_test.go
@@ -1,0 +1,215 @@
+package store
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessingConsentAuthorizesOnlyExactCurrentGrant(t *testing.T) {
+	s := newTestStore(t)
+	request := testProviderAuthorizationRequest()
+
+	_, err := s.AuthorizeProviderOperation(t.Context(), request)
+	require.ErrorIs(t, err, ErrProcessingConsentRequired)
+
+	grant, err := s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: request.Principal, Scope: request.Scope,
+		ProfileFingerprint:      request.ProfileFingerprint,
+		DisclosureFingerprint:   request.DisclosureFingerprint,
+		InputClasses:            request.InputClasses,
+		RetainedArtifactClasses: request.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	require.NoError(t, validateUUIDv4(grant.ID))
+	require.NoError(t, validateUUIDv4(grant.ProcessingIncarnationID))
+	assert.Equal(t, s.VaultID(), grant.VaultID)
+	assert.Equal(t, int64(0), grant.RevocationFence)
+
+	authorization, err := s.AuthorizeProviderOperation(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, grant.ID, authorization.GrantID)
+	assert.Equal(t, grant.ProcessingIncarnationID, authorization.ProcessingIncarnationID)
+	assert.Equal(t, grant.RevocationFence, authorization.RevocationFence)
+}
+
+func TestProcessingConsentRejectsExpiredAndDriftedOperations(t *testing.T) {
+	tests := map[string]func(ProviderOperationAuthorizationRequest) ProviderOperationAuthorizationRequest{
+		"profile drift including endpoint or deployment epoch": func(r ProviderOperationAuthorizationRequest) ProviderOperationAuthorizationRequest {
+			r.ProfileFingerprint = testConsentFingerprint("profile-b")
+			return r
+		},
+		"disclosure drift": func(r ProviderOperationAuthorizationRequest) ProviderOperationAuthorizationRequest {
+			r.DisclosureFingerprint = testConsentFingerprint("disclosure-b")
+			return r
+		},
+		"changed source or derived inputs": func(r ProviderOperationAuthorizationRequest) ProviderOperationAuthorizationRequest {
+			r.InputClasses = []string{"original_file", "rendition_chunk"}
+			return r
+		},
+		"changed retained artifact classes": func(r ProviderOperationAuthorizationRequest) ProviderOperationAuthorizationRequest {
+			r.RetainedArtifactClasses = []string{"normalized_evidence", "provider_markdown"}
+			return r
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := newTestStore(t)
+			request := testProviderAuthorizationRequest()
+			_, err := s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
+			require.NoError(t, err)
+
+			_, err = s.AuthorizeProviderOperation(t.Context(), mutate(request))
+			require.ErrorIs(t, err, ErrProcessingConsentRequired)
+		})
+	}
+
+	t.Run("expired grant", func(t *testing.T) {
+		s := newTestStore(t)
+		request := testProviderAuthorizationRequest()
+		expired := time.Now().Add(-time.Minute)
+		_, err := s.GrantConsent(t.Context(), grantRequestForAuthorization(request, &expired))
+		require.NoError(t, err)
+
+		_, err = s.AuthorizeProviderOperation(t.Context(), request)
+		require.ErrorIs(t, err, ErrProcessingConsentExpired)
+	})
+
+	t.Run("expired current-fence grant takes precedence over revoked history", func(t *testing.T) {
+		s := newTestStore(t)
+		request := testProviderAuthorizationRequest()
+		_, err := s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
+		require.NoError(t, err)
+		_, err = s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{
+			Principal: request.Principal, Scope: request.Scope,
+		})
+		require.NoError(t, err)
+		expired := time.Now().Add(-time.Minute)
+		_, err = s.GrantConsent(t.Context(), grantRequestForAuthorization(request, &expired))
+		require.NoError(t, err)
+
+		_, err = s.AuthorizeProviderOperation(t.Context(), request)
+		require.ErrorIs(t, err, ErrProcessingConsentExpired)
+	})
+}
+
+func TestProcessingConsentRevocationFencesSubmissionAndPublication(t *testing.T) {
+	s := newTestStore(t)
+	request := testProviderAuthorizationRequest()
+	first, err := s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
+	require.NoError(t, err)
+	leased, err := s.AuthorizeProviderOperation(t.Context(), request)
+	require.NoError(t, err)
+
+	revocation, err := s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{
+		Principal: request.Principal, Scope: request.Scope,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), revocation.Fence)
+	assert.Equal(t, first.ProcessingIncarnationID, revocation.ProcessingIncarnationID)
+
+	recheck := request
+	recheck.PriorAuthorization = &leased
+	_, err = s.AuthorizeProviderOperation(t.Context(), recheck)
+	require.ErrorIs(t, err, ErrProcessingConsentRevoked,
+		"publication must recheck consent after a leased operation returns")
+	assert.Equal(t, int64(0), leased.RevocationFence,
+		"the earlier authorization receipt must remain immutable evidence")
+
+	second, err := s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
+	require.NoError(t, err)
+	assert.Equal(t, revocation.Fence, second.RevocationFence)
+	_, err = s.AuthorizeProviderOperation(t.Context(), request)
+	require.NoError(t, err, "a grant issued after the revocation fence is current authority")
+	_, err = s.AuthorizeProviderOperation(t.Context(), recheck)
+	require.ErrorIs(t, err, ErrProcessingConsentRevoked,
+		"a replacement grant must not revive work leased below the revocation fence")
+}
+
+func TestProcessingConsentHistoryIsAppendOnly(t *testing.T) {
+	s := newTestStore(t)
+	request := testProviderAuthorizationRequest()
+	grant, err := s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
+	require.NoError(t, err)
+	revocation, err := s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{
+		Principal: request.Principal, Scope: request.Scope,
+	})
+	require.NoError(t, err)
+
+	for _, statement := range []string{
+		`UPDATE processing_consent_grants SET scope='changed' WHERE grant_id='` + grant.ID + `'`,
+		`DELETE FROM processing_consent_grants WHERE grant_id='` + grant.ID + `'`,
+		`UPDATE processing_consent_revocations SET scope='changed' WHERE revocation_id='` + revocation.ID + `'`,
+		`DELETE FROM processing_consent_revocations WHERE revocation_id='` + revocation.ID + `'`,
+	} {
+		_, err := s.db.Exec(statement)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "immutable")
+	}
+}
+
+func TestProcessingConsentRestorePreservesHistoryButRotatesIncarnation(t *testing.T) {
+	source := newTestStore(t)
+	request := testProviderAuthorizationRequest()
+	grant, err := source.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
+	require.NoError(t, err)
+
+	var snapshot bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &snapshot))
+	assert.Contains(t, snapshot.String(), grant.ID)
+
+	target, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	freshIncarnation, err := target.CurrentProcessingIncarnation(t.Context())
+	require.NoError(t, err)
+	require.NotEqual(t, grant.ProcessingIncarnationID, freshIncarnation.ID)
+
+	require.NoError(t, target.ImportMetadataForBackupRestore(t.Context(), bytes.NewReader(snapshot.Bytes())))
+	current, err := target.CurrentProcessingIncarnation(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, freshIncarnation.ID, current.ID)
+	assert.Equal(t, source.VaultID(), target.VaultID())
+
+	_, err = target.AuthorizeProviderOperation(t.Context(), request)
+	require.ErrorIs(t, err, ErrProcessingConsentRequired,
+		"a restored historical grant must not authorize the fresh incarnation")
+	var historical int
+	require.NoError(t, target.db.QueryRow(
+		`SELECT COUNT(*) FROM processing_consent_grants WHERE grant_id=?`, grant.ID,
+	).Scan(&historical))
+	assert.Equal(t, 1, historical)
+	var restored bytes.Buffer
+	require.NoError(t, target.ExportMetadata(t.Context(), &restored))
+	assert.Equal(t, snapshot.String(), restored.String(),
+		"the fresh local incarnation is omitted while append-only consent history round-trips exactly")
+}
+
+func testProviderAuthorizationRequest() ProviderOperationAuthorizationRequest {
+	return ProviderOperationAuthorizationRequest{
+		Principal: "operator:vladimir", Scope: "document-processing",
+		ProfileFingerprint:      testConsentFingerprint("profile-a"),
+		DisclosureFingerprint:   testConsentFingerprint("disclosure-a"),
+		InputClasses:            []string{"original_file"},
+		RetainedArtifactClasses: []string{"normalized_evidence"},
+	}
+}
+
+func grantRequestForAuthorization(
+	request ProviderOperationAuthorizationRequest, expiresAt *time.Time,
+) ProcessingConsentGrantRequest {
+	return ProcessingConsentGrantRequest{
+		Principal: request.Principal, Scope: request.Scope,
+		ProfileFingerprint:      request.ProfileFingerprint,
+		DisclosureFingerprint:   request.DisclosureFingerprint,
+		InputClasses:            request.InputClasses,
+		RetainedArtifactClasses: request.RetainedArtifactClasses,
+		ExpiresAt:               expiresAt,
+	}
+}
+
+func testConsentFingerprint(value string) string { return testSHA256([]byte(value)) }

--- a/internal/store/consent_test.go
+++ b/internal/store/consent_test.go
@@ -239,6 +239,57 @@ func TestProcessingConsentHistoryIsAppendOnly(t *testing.T) {
 	}
 }
 
+func TestProcessingConsentValidationRejectsCorruptRows(t *testing.T) {
+	t.Run("noncanonical grant classes", func(t *testing.T) {
+		s := newTestStore(t)
+		grant, err := s.GrantConsent(
+			t.Context(), grantRequestForAuthorization(testProviderAuthorizationRequest(), nil),
+		)
+		require.NoError(t, err)
+
+		_, err = s.db.Exec(`DROP TRIGGER processing_consent_grants_immutable_update`)
+		require.NoError(t, err)
+		_, err = s.db.Exec(`
+			UPDATE processing_consent_grants SET input_classes_json=? WHERE grant_id=?`,
+			`["rendition_chunk","original_file"]`, grant.ID)
+		require.NoError(t, err)
+		_, err = s.db.Exec(`
+			CREATE TRIGGER processing_consent_grants_immutable_update
+			BEFORE UPDATE ON processing_consent_grants BEGIN
+				SELECT RAISE(ABORT, 'processing consent grant records are immutable');
+			END`)
+		require.NoError(t, err)
+
+		err = validateProcessingMetadataState(t.Context(), s.db)
+		require.ErrorContains(t, err, "processing consent class sets are not canonical")
+	})
+
+	t.Run("invalid revocation timestamp", func(t *testing.T) {
+		s := newTestStore(t)
+		request := testProviderAuthorizationRequest()
+		revocation, err := s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{
+			Principal: request.Principal, Scope: request.Scope,
+		})
+		require.NoError(t, err)
+
+		_, err = s.db.Exec(`DROP TRIGGER processing_consent_revocations_immutable_update`)
+		require.NoError(t, err)
+		_, err = s.db.Exec(`
+			UPDATE processing_consent_revocations SET revoked_at=? WHERE revocation_id=?`,
+			`not-a-timestamp`, revocation.ID)
+		require.NoError(t, err)
+		_, err = s.db.Exec(`
+			CREATE TRIGGER processing_consent_revocations_immutable_update
+			BEFORE UPDATE ON processing_consent_revocations BEGIN
+				SELECT RAISE(ABORT, 'processing consent revocation records are immutable');
+			END`)
+		require.NoError(t, err)
+
+		err = validateProcessingMetadataState(t.Context(), s.db)
+		require.ErrorContains(t, err, "processing consent revoked_at")
+	})
+}
+
 func TestProcessingConsentRestorePreservesHistoryButRotatesIncarnation(t *testing.T) {
 	source := newTestStore(t)
 	request := testProviderAuthorizationRequest()

--- a/internal/store/consent_test.go
+++ b/internal/store/consent_test.go
@@ -264,6 +264,30 @@ func TestProcessingConsentValidationRejectsCorruptRows(t *testing.T) {
 		require.ErrorContains(t, err, "processing consent class sets are not canonical")
 	})
 
+	t.Run("null retained classes", func(t *testing.T) {
+		s := newTestStore(t)
+		grant, err := s.GrantConsent(
+			t.Context(), grantRequestForAuthorization(testProviderAuthorizationRequest(), nil),
+		)
+		require.NoError(t, err)
+
+		_, err = s.db.Exec(`DROP TRIGGER processing_consent_grants_immutable_update`)
+		require.NoError(t, err)
+		_, err = s.db.Exec(`
+			UPDATE processing_consent_grants SET retained_classes_json='null' WHERE grant_id=?`,
+			grant.ID)
+		require.NoError(t, err)
+		_, err = s.db.Exec(`
+			CREATE TRIGGER processing_consent_grants_immutable_update
+			BEFORE UPDATE ON processing_consent_grants BEGIN
+				SELECT RAISE(ABORT, 'processing consent grant records are immutable');
+			END`)
+		require.NoError(t, err)
+
+		err = validateProcessingMetadataState(t.Context(), s.db)
+		require.ErrorContains(t, err, "retained artifact classes cannot be null")
+	})
+
 	t.Run("invalid revocation timestamp", func(t *testing.T) {
 		s := newTestStore(t)
 		request := testProviderAuthorizationRequest()

--- a/internal/store/consent_test.go
+++ b/internal/store/consent_test.go
@@ -115,8 +115,7 @@ func TestProcessingConsentRevocationFencesSubmissionAndPublication(t *testing.T)
 	recheck := request
 	recheck.PriorAuthorization = &leased
 	_, err = s.AuthorizeProviderOperation(t.Context(), recheck)
-	require.ErrorIs(t, err, ErrProcessingConsentRevoked,
-		"publication must recheck consent after a leased operation returns")
+	require.ErrorContains(t, err, "only be checked during atomic publication")
 	assert.Equal(t, int64(0), leased.RevocationFence,
 		"the earlier authorization receipt must remain immutable evidence")
 
@@ -126,8 +125,56 @@ func TestProcessingConsentRevocationFencesSubmissionAndPublication(t *testing.T)
 	_, err = s.AuthorizeProviderOperation(t.Context(), request)
 	require.NoError(t, err, "a grant issued after the revocation fence is current authority")
 	_, err = s.AuthorizeProviderOperation(t.Context(), recheck)
-	require.ErrorIs(t, err, ErrProcessingConsentRevoked,
-		"a replacement grant must not revive work leased below the revocation fence")
+	require.ErrorContains(t, err, "only be checked during atomic publication")
+}
+
+func TestProcessingConsentRevocationIsCheckedInPublicationTransaction(t *testing.T) {
+	s, versions := newRenditionCatalogFixture(t)
+	profile := catalogProcessingProfile(t, false)
+	build := lexicalSearchBuild(s, profile, catalogBuildID, "authorized synthetic evidence")
+	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+	generation, err := s.StageLexicalGeneration(t.Context(), fakeHash("c9"))
+	require.NoError(t, err)
+	attachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: build.ID, Profile: profile, AttachedAt: "2026-08-29T14:00:00.000000000Z",
+	}
+	head := RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: attachment.ID, PublishedAt: "2026-08-29T14:01:00.000000000Z",
+	}
+	request := testProviderAuthorizationRequest()
+	request.ProfileFingerprint = profile.Fingerprint
+	request.DisclosureFingerprint = profile.RenditionDisclosureFingerprint
+	_, err = s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
+	require.NoError(t, err)
+	leased, err := s.AuthorizeProviderOperation(t.Context(), request)
+	require.NoError(t, err)
+	_, err = s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{
+		Principal: request.Principal, Scope: request.Scope,
+	})
+	require.NoError(t, err)
+
+	publication := request
+	publication.PriorAuthorization = &leased
+	err = s.PublishAuthorizedRenditionAndLexicalHeads(
+		t.Context(), attachment, head, generation.ID, publication,
+	)
+	require.ErrorIs(t, err, ErrProcessingConsentRevoked)
+	_, err = s.ActiveRendition(t.Context(), versions[0], profile.Fingerprint)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	_, err = s.GrantConsent(t.Context(), grantRequestForAuthorization(request, nil))
+	require.NoError(t, err)
+	current, err := s.AuthorizeProviderOperation(t.Context(), request)
+	require.NoError(t, err)
+	publication.PriorAuthorization = &current
+	require.NoError(t, s.PublishAuthorizedRenditionAndLexicalHeads(
+		t.Context(), attachment, head, generation.ID, publication,
+	))
+	published, err := s.ActiveRendition(t.Context(), versions[0], profile.Fingerprint)
+	require.NoError(t, err)
+	assert.Equal(t, attachment.ID, published.Attachment.ID)
 }
 
 func TestProcessingConsentHistoryIsAppendOnly(t *testing.T) {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -697,7 +697,12 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		    + (SELECT COUNT(*) FROM rendition_attachments)
 		    + (SELECT COUNT(*) FROM rendition_heads)
 		    + (SELECT COUNT(*) FROM current_rendition_roots)
-		    + (SELECT COUNT(*) FROM derivative_purge_suppressions),
+		    + (SELECT COUNT(*) FROM derivative_purge_suppressions)
+		    + (SELECT COUNT(*) FROM processing_consent_grants)
+		    + (SELECT COUNT(*) FROM processing_consent_revocations)
+		    + (SELECT COUNT(*) FROM processing_incarnations
+		       WHERE incarnation_id != (SELECT incarnation_id
+		         FROM current_processing_incarnation WHERE singleton=1)),
 		  (SELECT COUNT(*) FROM blob_locations)
 		    + (SELECT COUNT(*) FROM blob_packs)
 		    + (SELECT COUNT(*) FROM blob_pack_entries)
@@ -997,6 +1002,9 @@ var metadataRequiredFields = map[string][]string{
 	metadataAuditScopeType:                 {metadataTypeField, auditScopeIDField, "target_node_id", "enable_operation_id", "entry_count", "chain_head"},
 	metadataAuditMembershipType:            {metadataTypeField, auditScopeIDField, metadataNodeIDField, "baseline_digest"},
 	metadataAuditRecordType:                {metadataTypeField, "digest", "record"},
+	metadataProcessingIncarnationType:      processingMetadataRequiredFields[metadataProcessingIncarnationType],
+	metadataProcessingConsentGrantType:     processingMetadataRequiredFields[metadataProcessingConsentGrantType],
+	metadataProcessingConsentRevokeType:    processingMetadataRequiredFields[metadataProcessingConsentRevokeType],
 	metadataProcessingProfileType:          processingMetadataRequiredFields[metadataProcessingProfileType],
 	metadataRenditionBuildType:             processingMetadataRequiredFields[metadataRenditionBuildType],
 	metadataRenditionArtifactType:          processingMetadataRequiredFields[metadataRenditionArtifactType],
@@ -1014,10 +1022,11 @@ var metadataNullableFields = map[string]map[string]bool{
 		"parent_id": true, "current_version_id": true, "trashed_at": true,
 		"trash_parent": true, "trash_name": true,
 	},
-	"content_version":                {"mime_type": true, "source_version_id": true},
-	metadataProvenanceType:           {"original_mtime": true, "supersedes": true},
-	"extracted_text":                 {"error": true, "text": true},
-	metadataCurrentRenditionRootType: {"released_at": true},
+	"content_version":                  {"mime_type": true, "source_version_id": true},
+	metadataProvenanceType:             {"original_mtime": true, "supersedes": true},
+	"extracted_text":                   {"error": true, "text": true},
+	metadataCurrentRenditionRootType:   {"released_at": true},
+	metadataProcessingConsentGrantType: {"expires_at": true},
 	metadataDerivativePurgeSuppressionType: {
 		"superseded_at": true, "superseding_build_id": true,
 	},

--- a/internal/store/processing_catalog_test.go
+++ b/internal/store/processing_catalog_test.go
@@ -709,6 +709,10 @@ func TestProcessingMetadataOpenRejectsMismatchedCompleteSchemas(t *testing.T) {
 			t.Helper()
 			corruptProcessingSchemaBoundForTest(t, path, driver)
 		},
+		"current layout with weakened consent bound": func(t *testing.T, path string, driver docsqlite.Driver) {
+			t.Helper()
+			corruptProcessingConsentSchemaBoundForTest(t, path, driver)
+		},
 		"current layout with extra trigger": func(t *testing.T, path string, driver docsqlite.Driver) {
 			t.Helper()
 			addProcessingSchemaTriggerForTest(t, path, driver)
@@ -1053,6 +1057,32 @@ func corruptProcessingSchemaBoundForTest(t *testing.T, path string, driver docsq
 			'1'
 		)
 		WHERE type='table' AND name='rendition_builds'`)
+	require.NoError(t, err)
+	changed, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, changed)
+	_, err = db.Exec(`PRAGMA writable_schema = OFF`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func corruptProcessingConsentSchemaBoundForTest(
+	t *testing.T, path string, driver docsqlite.Driver,
+) {
+	t.Helper()
+	db, err := driver.Open(path, docsqlite.OpenOptions{
+		Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+	})
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	require.NoError(t, db.Ping())
+	_, err = db.Exec(`PRAGMA writable_schema = ON`)
+	require.NoError(t, err)
+	result, err := db.Exec(`
+		UPDATE sqlite_schema
+		SET sql=replace(sql, 'CHECK (revocation_fence >= 0)', 'CHECK (1)')
+		WHERE type='table' AND name='processing_consent_grants'
+		  AND instr(sql, 'CHECK (revocation_fence >= 0)') > 0`)
 	require.NoError(t, err)
 	changed, err := result.RowsAffected()
 	require.NoError(t, err)

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -1137,6 +1137,9 @@ func validateMetadataProcessingConsentGrant(
 			return normalizedConsentAuthority{}, fmt.Errorf("invalid processing consent %s: %w", subject, err)
 		}
 	}
+	if value.RetainedArtifactClasses == nil {
+		return normalizedConsentAuthority{}, errors.New("processing consent retained artifact classes cannot be null")
+	}
 	authority, err := normalizeConsentAuthority(ProviderOperationAuthorizationRequest{
 		Principal: value.Principal, Scope: value.Scope,
 		ProfileFingerprint:      value.ProfileFingerprint,

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -29,6 +29,9 @@ const (
 	metadataLexicalGenerationType          = "rendition_lexical_generation"
 	metadataCurrentRenditionRootType       = "current_rendition_root"
 	metadataDerivativePurgeSuppressionType = "derivative_purge_suppression"
+	metadataProcessingIncarnationType      = "processing_incarnation"
+	metadataProcessingConsentGrantType     = "processing_consent_grant"
+	metadataProcessingConsentRevokeType    = "processing_consent_revocation"
 )
 
 type metadataProcessingProfile struct {
@@ -160,7 +163,53 @@ type metadataDerivativePurgeSuppression struct {
 	SupersedingBuildID *string `json:"superseding_build_id"`
 }
 
+type metadataProcessingIncarnation struct {
+	Type      string `json:"type"`
+	ID        string `json:"incarnation_id"`
+	CreatedAt string `json:"created_at"`
+}
+
+type metadataProcessingConsentGrant struct {
+	Type                    string   `json:"type"`
+	ID                      string   `json:"grant_id"`
+	VaultID                 string   `json:"vault_id"`
+	ProcessingIncarnationID string   `json:"incarnation_id"`
+	Principal               string   `json:"principal"`
+	Scope                   string   `json:"scope"`
+	ProfileFingerprint      string   `json:"profile_fingerprint"`
+	DisclosureFingerprint   string   `json:"disclosure_fingerprint"`
+	InputClasses            []string `json:"input_classes"`
+	RetainedArtifactClasses []string `json:"retained_artifact_classes"`
+	RevocationFence         int64    `json:"revocation_fence"`
+	IssuedAt                string   `json:"issued_at"`
+	ExpiresAt               *string  `json:"expires_at"`
+}
+
+type metadataProcessingConsentRevocation struct {
+	Type                    string `json:"type"`
+	ID                      string `json:"revocation_id"`
+	VaultID                 string `json:"vault_id"`
+	ProcessingIncarnationID string `json:"incarnation_id"`
+	Principal               string `json:"principal"`
+	Scope                   string `json:"scope"`
+	Fence                   int64  `json:"fence"`
+	RevokedAt               string `json:"revoked_at"`
+}
+
 var processingMetadataRequiredFields = map[string][]string{
+	metadataProcessingIncarnationType: {
+		metadataTypeField, "incarnation_id", metadataCreatedAtField,
+	},
+	metadataProcessingConsentGrantType: {
+		metadataTypeField, "grant_id", auditVaultIDField, "incarnation_id",
+		"principal", "scope", "profile_fingerprint", "disclosure_fingerprint",
+		"input_classes", "retained_artifact_classes", "revocation_fence",
+		"issued_at", "expires_at",
+	},
+	metadataProcessingConsentRevokeType: {
+		metadataTypeField, "revocation_id", auditVaultIDField, "incarnation_id",
+		"principal", "scope", "fence", "revoked_at",
+	},
 	metadataProcessingProfileType: {
 		metadataTypeField, "profile_fingerprint", "canonical_profile",
 		"rendition_request_fingerprint", "evidence_lexical_fingerprint",
@@ -221,6 +270,9 @@ func exportProcessingMetadata(ctx context.Context, tx metadataQuerier, write met
 	if !present {
 		return nil
 	}
+	if err := exportProcessingConsent(ctx, tx, write); err != nil {
+		return err
+	}
 	if err := exportProcessingProfiles(ctx, tx, write); err != nil {
 		return err
 	}
@@ -249,6 +301,102 @@ func exportProcessingMetadata(ctx context.Context, tx metadataQuerier, write met
 		return err
 	}
 	return exportDerivativePurgeSuppressions(ctx, tx, write)
+}
+
+func exportProcessingConsent(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	if err := exportProcessingIncarnations(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportProcessingConsentRevocations(ctx, tx, write); err != nil {
+		return err
+	}
+	return exportProcessingConsentGrants(ctx, tx, write)
+}
+
+func exportProcessingIncarnations(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT i.incarnation_id,i.created_at
+		FROM processing_incarnations i
+		WHERE EXISTS(SELECT 1 FROM processing_consent_grants g
+		             WHERE g.incarnation_id=i.incarnation_id)
+		   OR EXISTS(SELECT 1 FROM processing_consent_revocations r
+		             WHERE r.incarnation_id=i.incarnation_id)
+		ORDER BY i.incarnation_id`)
+	if err != nil {
+		return fmt.Errorf("exporting processing incarnations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataProcessingIncarnation{Type: metadataProcessingIncarnationType}
+		if err := rows.Scan(&value.ID, &value.CreatedAt); err != nil {
+			return fmt.Errorf("scanning processing incarnation metadata: %w", err)
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("processing incarnation", rows)
+}
+
+func exportProcessingConsentRevocations(
+	ctx context.Context, tx metadataQuerier, write metadataWrite,
+) error {
+	revocations, err := tx.QueryContext(ctx, `
+		SELECT revocation_id,vault_uid,incarnation_id,principal,scope,fence,revoked_at
+		FROM processing_consent_revocations ORDER BY incarnation_id,principal,scope,fence`)
+	if err != nil {
+		return fmt.Errorf("exporting processing consent revocations: %w", err)
+	}
+	defer func() { _ = revocations.Close() }()
+	for revocations.Next() {
+		value := metadataProcessingConsentRevocation{Type: metadataProcessingConsentRevokeType}
+		if err := revocations.Scan(&value.ID, &value.VaultID, &value.ProcessingIncarnationID,
+			&value.Principal, &value.Scope, &value.Fence, &value.RevokedAt); err != nil {
+			return fmt.Errorf("scanning processing consent revocation metadata: %w", err)
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("processing consent revocation", revocations)
+}
+
+func exportProcessingConsentGrants(
+	ctx context.Context, tx metadataQuerier, write metadataWrite,
+) error {
+	grants, err := tx.QueryContext(ctx, `
+		SELECT grant_id,vault_uid,incarnation_id,principal,scope,profile_fingerprint,
+		       disclosure_fingerprint,input_classes_json,retained_classes_json,
+		       revocation_fence,issued_at,expires_at
+		FROM processing_consent_grants ORDER BY incarnation_id,issued_at,grant_id`)
+	if err != nil {
+		return fmt.Errorf("exporting processing consent grants: %w", err)
+	}
+	defer func() { _ = grants.Close() }()
+	for grants.Next() {
+		value := metadataProcessingConsentGrant{Type: metadataProcessingConsentGrantType}
+		var inputs, retained string
+		var expires sql.NullString
+		if err := grants.Scan(&value.ID, &value.VaultID, &value.ProcessingIncarnationID,
+			&value.Principal, &value.Scope, &value.ProfileFingerprint,
+			&value.DisclosureFingerprint, &inputs, &retained, &value.RevocationFence,
+			&value.IssuedAt, &expires); err != nil {
+			return fmt.Errorf("scanning processing consent grant metadata: %w", err)
+		}
+		if err := json.Unmarshal([]byte(inputs), &value.InputClasses); err != nil {
+			return fmt.Errorf("decoding processing consent input classes: %w", err)
+		}
+		if err := json.Unmarshal([]byte(retained), &value.RetainedArtifactClasses); err != nil {
+			return fmt.Errorf("decoding processing consent retained classes: %w", err)
+		}
+		if expires.Valid {
+			value.ExpiresAt = &expires.String
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("processing consent grant", grants)
 }
 
 func exportLexicalGenerations(
@@ -581,6 +729,53 @@ func (s *Store) importProcessingMetadataRecord(
 	ctx context.Context, tx *sql.Tx, kind string, raw jsontext.Value, verifyPhysicalBytes bool,
 ) error {
 	switch kind {
+	case metadataProcessingIncarnationType:
+		var value metadataProcessingIncarnation
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if err := validateMetadataProcessingIncarnation(value); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO processing_incarnations(incarnation_id,created_at) VALUES(?,?)`,
+			value.ID, value.CreatedAt)
+		return err
+	case metadataProcessingConsentRevokeType:
+		var value metadataProcessingConsentRevocation
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if err := validateMetadataProcessingConsentRevocation(value); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO processing_consent_revocations(
+			revocation_id,vault_uid,incarnation_id,principal,scope,fence,revoked_at
+		) VALUES(?,?,?,?,?,?,?)`, value.ID, value.VaultID, value.ProcessingIncarnationID,
+			value.Principal, value.Scope, value.Fence, value.RevokedAt)
+		return err
+	case metadataProcessingConsentGrantType:
+		var value metadataProcessingConsentGrant
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		authority, err := validateMetadataProcessingConsentGrant(value)
+		if err != nil {
+			return err
+		}
+		var expires any
+		if value.ExpiresAt != nil {
+			expires = *value.ExpiresAt
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO processing_consent_grants(
+			grant_id,vault_uid,incarnation_id,principal,scope,profile_fingerprint,
+			disclosure_fingerprint,input_classes_json,retained_classes_json,
+			revocation_fence,issued_at,expires_at
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`, value.ID, value.VaultID,
+			value.ProcessingIncarnationID, authority.principal, authority.scope,
+			authority.profile, authority.disclosure, authority.inputsJSON,
+			authority.retainedJSON, value.RevocationFence, value.IssuedAt, expires)
+		return err
 	case metadataProcessingProfileType:
 		var value metadataProcessingProfile
 		if err := decodeMetadataRecord(raw, &value); err != nil {
@@ -893,6 +1088,78 @@ func validateMetadataDerivativePurgeSuppression(
 		return validateCatalogSHA256(*value.SupersedingBuildID, "superseding build ID")
 	}
 	return nil
+}
+
+func validateMetadataProcessingIncarnation(value metadataProcessingIncarnation) error {
+	if value.Type != metadataProcessingIncarnationType {
+		return errors.New("invalid processing incarnation record")
+	}
+	if err := validateUUIDv4(value.ID); err != nil {
+		return fmt.Errorf("invalid processing incarnation ID: %w", err)
+	}
+	return validateMetadataTime("processing incarnation created_at", value.CreatedAt)
+}
+
+func validateMetadataProcessingConsentRevocation(
+	value metadataProcessingConsentRevocation,
+) error {
+	if value.Type != metadataProcessingConsentRevokeType || value.Fence <= 0 {
+		return errors.New("invalid processing consent revocation record")
+	}
+	for subject, id := range map[string]string{
+		"revocation ID": value.ID, "processing incarnation ID": value.ProcessingIncarnationID,
+		"vault ID": value.VaultID,
+	} {
+		if err := validateUUIDv4(id); err != nil {
+			return fmt.Errorf("invalid processing consent %s: %w", subject, err)
+		}
+	}
+	if _, err := normalizeConsentLabel("principal", value.Principal); err != nil {
+		return err
+	}
+	if _, err := normalizeConsentLabel("scope", value.Scope); err != nil {
+		return err
+	}
+	return validateMetadataTime("processing consent revoked_at", value.RevokedAt)
+}
+
+func validateMetadataProcessingConsentGrant(
+	value metadataProcessingConsentGrant,
+) (normalizedConsentAuthority, error) {
+	if value.Type != metadataProcessingConsentGrantType || value.RevocationFence < 0 {
+		return normalizedConsentAuthority{}, errors.New("invalid processing consent grant record")
+	}
+	for subject, id := range map[string]string{
+		"grant ID": value.ID, "processing incarnation ID": value.ProcessingIncarnationID,
+		"vault ID": value.VaultID,
+	} {
+		if err := validateUUIDv4(id); err != nil {
+			return normalizedConsentAuthority{}, fmt.Errorf("invalid processing consent %s: %w", subject, err)
+		}
+	}
+	authority, err := normalizeConsentAuthority(ProviderOperationAuthorizationRequest{
+		Principal: value.Principal, Scope: value.Scope,
+		ProfileFingerprint:      value.ProfileFingerprint,
+		DisclosureFingerprint:   value.DisclosureFingerprint,
+		InputClasses:            value.InputClasses,
+		RetainedArtifactClasses: value.RetainedArtifactClasses,
+	})
+	if err != nil {
+		return normalizedConsentAuthority{}, err
+	}
+	if !slices.Equal(authority.inputs, value.InputClasses) ||
+		!slices.Equal(authority.retained, value.RetainedArtifactClasses) {
+		return normalizedConsentAuthority{}, errors.New("processing consent class sets are not canonical")
+	}
+	if err := validateMetadataTime("processing consent issued_at", value.IssuedAt); err != nil {
+		return normalizedConsentAuthority{}, err
+	}
+	if value.ExpiresAt != nil {
+		if err := validateMetadataTime("processing consent expires_at", *value.ExpiresAt); err != nil {
+			return normalizedConsentAuthority{}, err
+		}
+	}
+	return authority, nil
 }
 
 func validateDurableCurrentRenditionRootMetadata(
@@ -1411,6 +1678,9 @@ func validateProcessingMetadataState(ctx context.Context, tx metadataQuerier) er
 	if !present {
 		return nil
 	}
+	if err := validateProcessingConsentState(ctx, tx); err != nil {
+		return err
+	}
 	profileIDs, err := loadProcessingMetadataIDs(
 		ctx, tx, "processing profile", `SELECT profile_fingerprint FROM processing_profiles ORDER BY profile_fingerprint`,
 	)
@@ -1563,6 +1833,79 @@ func validateProcessingMetadataState(ctx context.Context, tx metadataQuerier) er
 		return err
 	}
 	return validateCurrentRenditionRootState(ctx, tx)
+}
+
+func validateProcessingConsentState(ctx context.Context, tx metadataQuerier) error {
+	var currentCount int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM current_processing_incarnation`).Scan(
+		&currentCount); err != nil {
+		return fmt.Errorf("validating current processing incarnation: %w", err)
+	}
+	if currentCount != 1 {
+		return fmt.Errorf("current processing incarnation has %d rows", currentCount)
+	}
+
+	if err := validateProcessingIncarnations(ctx, tx); err != nil {
+		return err
+	}
+
+	var invalid bool
+	checks := []struct {
+		name  string
+		query string
+	}{
+		{"processing consent belongs to another vault", `
+			SELECT EXISTS(
+			  SELECT 1 FROM processing_consent_grants
+			  WHERE vault_uid != (SELECT vault_uid FROM vault_metadata WHERE singleton=1)
+			  UNION ALL
+			  SELECT 1 FROM processing_consent_revocations
+			  WHERE vault_uid != (SELECT vault_uid FROM vault_metadata WHERE singleton=1)
+			)`},
+		{"processing consent revocation fence is not contiguous", `
+			SELECT EXISTS(
+			  SELECT 1 FROM processing_consent_revocations
+			  GROUP BY vault_uid,incarnation_id,principal,scope
+			  HAVING MIN(fence) != 1 OR MAX(fence) != COUNT(*)
+			)`},
+		{"processing consent grant has an impossible revocation fence", `
+			SELECT EXISTS(
+			  SELECT 1 FROM processing_consent_grants g
+			  WHERE g.revocation_fence > COALESCE((
+			    SELECT MAX(r.fence) FROM processing_consent_revocations r
+			    WHERE r.vault_uid=g.vault_uid AND r.incarnation_id=g.incarnation_id
+			      AND r.principal=g.principal AND r.scope=g.scope
+			  ),0)
+			)`},
+	}
+	for _, check := range checks {
+		if err := tx.QueryRowContext(ctx, check.query).Scan(&invalid); err != nil {
+			return fmt.Errorf("validating processing consent (%s): %w", check.name, err)
+		}
+		if invalid {
+			return errors.New(check.name)
+		}
+	}
+	return nil
+}
+
+func validateProcessingIncarnations(ctx context.Context, tx metadataQuerier) error {
+	incarnations, err := tx.QueryContext(ctx, `
+		SELECT incarnation_id,created_at FROM processing_incarnations ORDER BY incarnation_id`)
+	if err != nil {
+		return fmt.Errorf("validating processing incarnations: %w", err)
+	}
+	defer func() { _ = incarnations.Close() }()
+	for incarnations.Next() {
+		value := metadataProcessingIncarnation{Type: metadataProcessingIncarnationType}
+		if err := incarnations.Scan(&value.ID, &value.CreatedAt); err != nil {
+			return err
+		}
+		if err := validateMetadataProcessingIncarnation(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("processing incarnation", incarnations)
 }
 
 func validateCurrentRenditionRootState(ctx context.Context, tx metadataQuerier) (_ error) {

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -1848,6 +1848,12 @@ func validateProcessingConsentState(ctx context.Context, tx metadataQuerier) err
 	if err := validateProcessingIncarnations(ctx, tx); err != nil {
 		return err
 	}
+	if err := validateProcessingConsentRevocations(ctx, tx); err != nil {
+		return err
+	}
+	if err := validateProcessingConsentGrants(ctx, tx); err != nil {
+		return err
+	}
 
 	var invalid bool
 	checks := []struct {
@@ -1887,6 +1893,63 @@ func validateProcessingConsentState(ctx context.Context, tx metadataQuerier) err
 		}
 	}
 	return nil
+}
+
+func validateProcessingConsentRevocations(ctx context.Context, tx metadataQuerier) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT revocation_id,vault_uid,incarnation_id,principal,scope,fence,revoked_at
+		FROM processing_consent_revocations ORDER BY incarnation_id,principal,scope,fence`)
+	if err != nil {
+		return fmt.Errorf("validating processing consent revocations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataProcessingConsentRevocation{Type: metadataProcessingConsentRevokeType}
+		if err := rows.Scan(&value.ID, &value.VaultID, &value.ProcessingIncarnationID,
+			&value.Principal, &value.Scope, &value.Fence, &value.RevokedAt); err != nil {
+			return fmt.Errorf("scanning processing consent revocation metadata: %w", err)
+		}
+		if err := validateMetadataProcessingConsentRevocation(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("processing consent revocation", rows)
+}
+
+func validateProcessingConsentGrants(ctx context.Context, tx metadataQuerier) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT grant_id,vault_uid,incarnation_id,principal,scope,profile_fingerprint,
+		       disclosure_fingerprint,input_classes_json,retained_classes_json,
+		       revocation_fence,issued_at,expires_at
+		FROM processing_consent_grants ORDER BY incarnation_id,issued_at,grant_id`)
+	if err != nil {
+		return fmt.Errorf("validating processing consent grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataProcessingConsentGrant{Type: metadataProcessingConsentGrantType}
+		var inputs, retained string
+		var expires sql.NullString
+		if err := rows.Scan(&value.ID, &value.VaultID, &value.ProcessingIncarnationID,
+			&value.Principal, &value.Scope, &value.ProfileFingerprint,
+			&value.DisclosureFingerprint, &inputs, &retained, &value.RevocationFence,
+			&value.IssuedAt, &expires); err != nil {
+			return fmt.Errorf("scanning processing consent grant metadata: %w", err)
+		}
+		if err := json.Unmarshal([]byte(inputs), &value.InputClasses); err != nil {
+			return fmt.Errorf("decoding processing consent input classes: %w", err)
+		}
+		if err := json.Unmarshal([]byte(retained), &value.RetainedArtifactClasses); err != nil {
+			return fmt.Errorf("decoding processing consent retained classes: %w", err)
+		}
+		if expires.Valid {
+			value.ExpiresAt = &expires.String
+		}
+		if _, err := validateMetadataProcessingConsentGrant(value); err != nil {
+			return err
+		}
+	}
+	return rowsError("processing consent grant", rows)
 }
 
 func validateProcessingIncarnations(ctx context.Context, tx metadataQuerier) error {

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -728,6 +728,97 @@ WHEN NEW.supersedes IS NOT NULL AND EXISTS (
     SELECT RAISE(ABORT, 'provenance supersession must stay on one node');
 END;
 
+-- Processing consent is scoped to a random local incarnation. The pointer is
+-- deliberately not backup authority: a restored database keeps the imported
+-- grant history while the fresh restore target retains its own incarnation.
+CREATE TABLE IF NOT EXISTS processing_incarnations (
+    incarnation_id TEXT PRIMARY KEY,
+    created_at     TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS current_processing_incarnation (
+    singleton      INTEGER PRIMARY KEY CHECK (singleton = 1),
+    incarnation_id TEXT NOT NULL UNIQUE REFERENCES processing_incarnations(incarnation_id)
+);
+
+CREATE TRIGGER IF NOT EXISTS current_processing_incarnation_immutable_update
+BEFORE UPDATE ON current_processing_incarnation BEGIN
+    SELECT RAISE(ABORT, 'current processing incarnation is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS current_processing_incarnation_immutable_delete
+BEFORE DELETE ON current_processing_incarnation BEGIN
+    SELECT RAISE(ABORT, 'current processing incarnation is immutable');
+END;
+
+CREATE TABLE IF NOT EXISTS processing_consent_grants (
+    grant_id                  TEXT PRIMARY KEY,
+    vault_uid                 TEXT NOT NULL REFERENCES vault_metadata(vault_uid),
+    incarnation_id            TEXT NOT NULL REFERENCES processing_incarnations(incarnation_id),
+    principal                 TEXT NOT NULL,
+    scope                     TEXT NOT NULL,
+    profile_fingerprint       TEXT NOT NULL,
+    disclosure_fingerprint    TEXT NOT NULL,
+    input_classes_json        TEXT NOT NULL,
+    retained_classes_json     TEXT NOT NULL,
+    revocation_fence          INTEGER NOT NULL CHECK (revocation_fence >= 0),
+    issued_at                 TEXT NOT NULL,
+    expires_at                TEXT
+);
+
+CREATE INDEX IF NOT EXISTS processing_consent_grants_authority
+    ON processing_consent_grants(
+        vault_uid, incarnation_id, principal, scope, profile_fingerprint,
+        disclosure_fingerprint, input_classes_json, retained_classes_json,
+        issued_at, grant_id
+    );
+
+CREATE TABLE IF NOT EXISTS processing_consent_revocations (
+    revocation_id  TEXT PRIMARY KEY,
+    vault_uid      TEXT NOT NULL REFERENCES vault_metadata(vault_uid),
+    incarnation_id TEXT NOT NULL REFERENCES processing_incarnations(incarnation_id),
+    principal      TEXT NOT NULL,
+    scope          TEXT NOT NULL,
+    fence          INTEGER NOT NULL CHECK (fence > 0),
+    revoked_at     TEXT NOT NULL,
+    UNIQUE (vault_uid, incarnation_id, principal, scope, fence)
+);
+
+CREATE INDEX IF NOT EXISTS processing_consent_revocations_scope
+    ON processing_consent_revocations(
+        vault_uid, incarnation_id, principal, scope, fence
+    );
+
+CREATE TRIGGER IF NOT EXISTS processing_incarnations_immutable_update
+BEFORE UPDATE ON processing_incarnations BEGIN
+    SELECT RAISE(ABORT, 'processing incarnation records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS processing_incarnations_immutable_delete
+BEFORE DELETE ON processing_incarnations BEGIN
+    SELECT RAISE(ABORT, 'processing incarnation records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS processing_consent_grants_immutable_update
+BEFORE UPDATE ON processing_consent_grants BEGIN
+    SELECT RAISE(ABORT, 'processing consent grant records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS processing_consent_grants_immutable_delete
+BEFORE DELETE ON processing_consent_grants BEGIN
+    SELECT RAISE(ABORT, 'processing consent grant records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS processing_consent_revocations_immutable_update
+BEFORE UPDATE ON processing_consent_revocations BEGIN
+    SELECT RAISE(ABORT, 'processing consent revocation records are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS processing_consent_revocations_immutable_delete
+BEFORE DELETE ON processing_consent_revocations BEGIN
+    SELECT RAISE(ABORT, 'processing consent revocation records are immutable');
+END;
+
 -- Processing profiles are immutable canonical policy snapshots. Rendition
 -- builds deliberately reference only their rendition/evidence components;
 -- embedding-only profile fields never enter build identity.

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -12,6 +12,80 @@ CREATE TEMP TABLE IF NOT EXISTS docbank_processing_schema_v1_expected (
 );
 DELETE FROM docbank_processing_schema_v1_expected;
 INSERT INTO docbank_processing_schema_v1_expected(object_type, object_name, object_sql) VALUES
+('table', 'processing_incarnations', 'CREATE TABLE processing_incarnations (
+    incarnation_id TEXT PRIMARY KEY,
+    created_at     TEXT NOT NULL
+)'),
+('table', 'current_processing_incarnation', 'CREATE TABLE current_processing_incarnation (
+    singleton      INTEGER PRIMARY KEY CHECK (singleton = 1),
+    incarnation_id TEXT NOT NULL UNIQUE REFERENCES processing_incarnations(incarnation_id)
+)'),
+('trigger', 'current_processing_incarnation_immutable_update', 'CREATE TRIGGER current_processing_incarnation_immutable_update
+BEFORE UPDATE ON current_processing_incarnation BEGIN
+    SELECT RAISE(ABORT, ''current processing incarnation is immutable'');
+END'),
+('trigger', 'current_processing_incarnation_immutable_delete', 'CREATE TRIGGER current_processing_incarnation_immutable_delete
+BEFORE DELETE ON current_processing_incarnation BEGIN
+    SELECT RAISE(ABORT, ''current processing incarnation is immutable'');
+END'),
+('table', 'processing_consent_grants', 'CREATE TABLE processing_consent_grants (
+    grant_id                  TEXT PRIMARY KEY,
+    vault_uid                 TEXT NOT NULL REFERENCES vault_metadata(vault_uid),
+    incarnation_id            TEXT NOT NULL REFERENCES processing_incarnations(incarnation_id),
+    principal                 TEXT NOT NULL,
+    scope                     TEXT NOT NULL,
+    profile_fingerprint       TEXT NOT NULL,
+    disclosure_fingerprint    TEXT NOT NULL,
+    input_classes_json        TEXT NOT NULL,
+    retained_classes_json     TEXT NOT NULL,
+    revocation_fence          INTEGER NOT NULL CHECK (revocation_fence >= 0),
+    issued_at                 TEXT NOT NULL,
+    expires_at                TEXT
+)'),
+('index', 'processing_consent_grants_authority', 'CREATE INDEX processing_consent_grants_authority
+    ON processing_consent_grants(
+        vault_uid, incarnation_id, principal, scope, profile_fingerprint,
+        disclosure_fingerprint, input_classes_json, retained_classes_json,
+        issued_at, grant_id
+    )'),
+('table', 'processing_consent_revocations', 'CREATE TABLE processing_consent_revocations (
+    revocation_id  TEXT PRIMARY KEY,
+    vault_uid      TEXT NOT NULL REFERENCES vault_metadata(vault_uid),
+    incarnation_id TEXT NOT NULL REFERENCES processing_incarnations(incarnation_id),
+    principal      TEXT NOT NULL,
+    scope          TEXT NOT NULL,
+    fence          INTEGER NOT NULL CHECK (fence > 0),
+    revoked_at     TEXT NOT NULL,
+    UNIQUE (vault_uid, incarnation_id, principal, scope, fence)
+)'),
+('index', 'processing_consent_revocations_scope', 'CREATE INDEX processing_consent_revocations_scope
+    ON processing_consent_revocations(
+        vault_uid, incarnation_id, principal, scope, fence
+    )'),
+('trigger', 'processing_incarnations_immutable_update', 'CREATE TRIGGER processing_incarnations_immutable_update
+BEFORE UPDATE ON processing_incarnations BEGIN
+    SELECT RAISE(ABORT, ''processing incarnation records are immutable'');
+END'),
+('trigger', 'processing_incarnations_immutable_delete', 'CREATE TRIGGER processing_incarnations_immutable_delete
+BEFORE DELETE ON processing_incarnations BEGIN
+    SELECT RAISE(ABORT, ''processing incarnation records are immutable'');
+END'),
+('trigger', 'processing_consent_grants_immutable_update', 'CREATE TRIGGER processing_consent_grants_immutable_update
+BEFORE UPDATE ON processing_consent_grants BEGIN
+    SELECT RAISE(ABORT, ''processing consent grant records are immutable'');
+END'),
+('trigger', 'processing_consent_grants_immutable_delete', 'CREATE TRIGGER processing_consent_grants_immutable_delete
+BEFORE DELETE ON processing_consent_grants BEGIN
+    SELECT RAISE(ABORT, ''processing consent grant records are immutable'');
+END'),
+('trigger', 'processing_consent_revocations_immutable_update', 'CREATE TRIGGER processing_consent_revocations_immutable_update
+BEFORE UPDATE ON processing_consent_revocations BEGIN
+    SELECT RAISE(ABORT, ''processing consent revocation records are immutable'');
+END'),
+('trigger', 'processing_consent_revocations_immutable_delete', 'CREATE TRIGGER processing_consent_revocations_immutable_delete
+BEFORE DELETE ON processing_consent_revocations BEGIN
+    SELECT RAISE(ABORT, ''processing consent revocation records are immutable'');
+END'),
 ('table', 'processing_profiles', 'CREATE TABLE processing_profiles (
     profile_fingerprint               TEXT PRIMARY KEY,
     canonical_profile                 TEXT NOT NULL
@@ -233,6 +307,8 @@ SELECT CASE
         SELECT 1 FROM sqlite_schema
         WHERE name IN (SELECT object_name FROM docbank_processing_schema_v1_expected)
            OR (type IN ('index', 'trigger') AND sql IS NOT NULL AND tbl_name IN (
+            'processing_incarnations', 'current_processing_incarnation',
+            'processing_consent_grants', 'processing_consent_revocations',
             'processing_profiles', 'rendition_builds', 'rendition_artifacts',
             'rendition_units', 'rendition_lexical_segments',
             'rendition_attachments', 'rendition_heads',
@@ -248,6 +324,8 @@ SELECT CASE
         SELECT type, name, sql FROM sqlite_schema
         WHERE name IN (SELECT object_name FROM docbank_processing_schema_v1_expected)
            OR (type IN ('index', 'trigger') AND sql IS NOT NULL AND tbl_name IN (
+            'processing_incarnations', 'current_processing_incarnation',
+            'processing_consent_grants', 'processing_consent_revocations',
             'processing_profiles', 'rendition_builds', 'rendition_artifacts',
             'rendition_units', 'rendition_lexical_segments',
             'rendition_attachments', 'rendition_heads',
@@ -259,6 +337,8 @@ SELECT CASE
         SELECT type, name, sql FROM sqlite_schema
         WHERE name IN (SELECT object_name FROM docbank_processing_schema_v1_expected)
            OR (type IN ('index', 'trigger') AND sql IS NOT NULL AND tbl_name IN (
+            'processing_incarnations', 'current_processing_incarnation',
+            'processing_consent_grants', 'processing_consent_revocations',
             'processing_profiles', 'rendition_builds', 'rendition_artifacts',
             'rendition_units', 'rendition_lexical_segments',
             'rendition_attachments', 'rendition_heads',

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -632,6 +632,29 @@ func (s *Store) PublishRenditionAndLexicalHeads(
 	ctx context.Context, attachment RenditionAttachmentRecord,
 	head RenditionHeadRecord, generationID string,
 ) error {
+	return s.publishRenditionAndLexicalHeads(ctx, attachment, head, generationID, nil)
+}
+
+// PublishAuthorizedRenditionAndLexicalHeads rechecks the exact provider grant
+// in the transaction that makes its rendition and lexical heads visible.
+func (s *Store) PublishAuthorizedRenditionAndLexicalHeads(
+	ctx context.Context, attachment RenditionAttachmentRecord,
+	head RenditionHeadRecord, generationID string,
+	authorization ProviderOperationAuthorizationRequest,
+) error {
+	if authorization.PriorAuthorization == nil {
+		return fmt.Errorf("publishing authorized rendition: %w", ErrProcessingConsentRequired)
+	}
+	return s.publishRenditionAndLexicalHeads(
+		ctx, attachment, head, generationID, &authorization,
+	)
+}
+
+func (s *Store) publishRenditionAndLexicalHeads(
+	ctx context.Context, attachment RenditionAttachmentRecord,
+	head RenditionHeadRecord, generationID string,
+	authorization *ProviderOperationAuthorizationRequest,
+) error {
 	normalized, err := normalizeRenditionAttachmentRecord(attachment)
 	if err != nil {
 		return fmt.Errorf("publishing rendition attachment: %w", err)
@@ -650,6 +673,11 @@ func (s *Store) PublishRenditionAndLexicalHeads(
 	if normalized.VaultID != s.vaultID {
 		return fmt.Errorf("publishing rendition attachment: vault %q does not match store vault %q",
 			normalized.VaultID, s.vaultID)
+	}
+	if authorization != nil &&
+		(authorization.ProfileFingerprint != normalized.Profile.Fingerprint ||
+			authorization.DisclosureFingerprint != normalized.Profile.RenditionDisclosureFingerprint) {
+		return errors.New("provider authorization does not match rendition publication policy")
 	}
 
 	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
@@ -724,6 +752,13 @@ func (s *Store) PublishRenditionAndLexicalHeads(
 			lexicalManifestDigest(indexedBuildRows) != lexicalManifestDigest(expectedBuildRows) {
 			return fmt.Errorf("lexical generation %s does not exactly contain build %s",
 				generationID, build.ID)
+		}
+		if authorization != nil {
+			if _, err := s.authorizeProviderOperationTx(
+				ctx, tx, *authorization, time.Now().UTC(),
+			); err != nil {
+				return fmt.Errorf("authorizing rendition publication: %w", err)
+			}
 		}
 
 		result, err := tx.ExecContext(ctx, `

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"go.kenn.io/docbank/document"
 )
 
 // SearchHit is a search result with its display path.
@@ -635,25 +637,43 @@ func (s *Store) PublishRenditionAndLexicalHeads(
 	return s.publishRenditionAndLexicalHeads(ctx, attachment, head, generationID, nil)
 }
 
-// PublishAuthorizedRenditionAndLexicalHeads rechecks the exact provider grant
-// in the transaction that makes its rendition and lexical heads visible.
+// PublishAuthorizedRenditionAndLexicalHeads binds the verified provider
+// operation and exact retained outputs to a grant in the transaction that
+// makes its rendition and lexical heads visible.
 func (s *Store) PublishAuthorizedRenditionAndLexicalHeads(
 	ctx context.Context, attachment RenditionAttachmentRecord,
 	head RenditionHeadRecord, generationID string,
 	authorization ProviderOperationAuthorizationRequest,
+	operation document.RenditionAuthorization,
 ) error {
 	if authorization.PriorAuthorization == nil {
 		return fmt.Errorf("publishing authorized rendition: %w", ErrProcessingConsentRequired)
 	}
+	operationChecksum, err := operation.Fingerprint()
+	if err != nil {
+		return fmt.Errorf("fingerprinting rendition authorization: %w", err)
+	}
 	return s.publishRenditionAndLexicalHeads(
-		ctx, attachment, head, generationID, &authorization,
+		ctx, attachment, head, generationID, &providerPublicationAuthorization{
+			consent: authorization, operationChecksum: operationChecksum,
+			inputClass: string(operation.InputKind), sourceSHA256: operation.SourceSHA256,
+			renditionRequestFingerprint: operation.RenditionRequestFingerprint,
+		},
 	)
+}
+
+type providerPublicationAuthorization struct {
+	consent                     ProviderOperationAuthorizationRequest
+	operationChecksum           string
+	inputClass                  string
+	sourceSHA256                string
+	renditionRequestFingerprint string
 }
 
 func (s *Store) publishRenditionAndLexicalHeads(
 	ctx context.Context, attachment RenditionAttachmentRecord,
 	head RenditionHeadRecord, generationID string,
-	authorization *ProviderOperationAuthorizationRequest,
+	authorization *providerPublicationAuthorization,
 ) error {
 	normalized, err := normalizeRenditionAttachmentRecord(attachment)
 	if err != nil {
@@ -675,8 +695,8 @@ func (s *Store) publishRenditionAndLexicalHeads(
 			normalized.VaultID, s.vaultID)
 	}
 	if authorization != nil &&
-		(authorization.ProfileFingerprint != normalized.Profile.Fingerprint ||
-			authorization.DisclosureFingerprint != normalized.Profile.RenditionDisclosureFingerprint) {
+		(authorization.consent.ProfileFingerprint != normalized.Profile.Fingerprint ||
+			authorization.consent.DisclosureFingerprint != normalized.Profile.RenditionDisclosureFingerprint) {
 		return errors.New("provider authorization does not match rendition publication policy")
 	}
 
@@ -697,6 +717,12 @@ func (s *Store) publishRenditionAndLexicalHeads(
 		if build.RenditionRequestFingerprint != normalized.Profile.RenditionRequestFingerprint ||
 			build.EvidenceLexicalFingerprint != normalized.Profile.EvidenceLexicalFingerprint {
 			return errors.New("rendition attachment profile does not match build component identity")
+		}
+		if authorization != nil &&
+			(authorization.operationChecksum != build.AuthorizationChecksum ||
+				authorization.sourceSHA256 != build.SourceSHA256 ||
+				authorization.renditionRequestFingerprint != build.RenditionRequestFingerprint) {
+			return errors.New("provider authorization does not match rendition build operation")
 		}
 		if err := validateRenditionArtifactRolesForProfile(normalized.Profile, build); err != nil {
 			return err
@@ -754,8 +780,24 @@ func (s *Store) publishRenditionAndLexicalHeads(
 				generationID, build.ID)
 		}
 		if authorization != nil {
+			authority, err := normalizeConsentAuthority(authorization.consent)
+			if err != nil {
+				return err
+			}
+			if !slices.Equal(authority.inputs, []string{authorization.inputClass}) {
+				return errors.New("processing consent input classes do not match rendition build input")
+			}
+			retained := make([]string, len(build.Artifacts))
+			for index, artifact := range build.Artifacts {
+				retained[index] = artifact.Role
+			}
+			slices.Sort(retained)
+			retained = slices.Compact(retained)
+			if !slices.Equal(authority.retained, retained) {
+				return errors.New("processing consent retained artifact classes do not match rendition build artifacts")
+			}
 			if _, err := s.authorizeProviderOperationTx(
-				ctx, tx, *authorization, time.Now().UTC(),
+				ctx, tx, authorization.consent, time.Now().UTC(),
 			); err != nil {
 				return fmt.Errorf("authorizing rendition publication: %w", err)
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -146,6 +146,9 @@ func (s *Store) bootstrapTx() error {
 		if err := validateUUIDv4(s.vaultID); err != nil {
 			return fmt.Errorf("validating vault identity: %w", err)
 		}
+		if err := ensureProcessingIncarnationTx(tx); err != nil {
+			return err
+		}
 		primary, err := ensurePrimaryBlobStoreTx(tx)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What changed

Docbank now records immutable processing grants and revocations against the current vault incarnation, exact profile and disclosure fingerprints, permitted input classes, and retained artifact classes. Expiry and the revocation fence are checked again before provider access and publication, so a later grant cannot revive work leased under older authority.

Every new or restored vault gets a fresh processing incarnation. Backup JSONL keeps prior consent as history, but restored grants cannot authorize new network activity.

## Why

Restoring a vault must not silently restore permission to send its bytes somewhere. Consent needs to be durable enough to audit and narrow enough to fail closed when the endpoint, deployment, disclosure, inputs, retained outputs, expiry, or revocation state changes.

## Usage

Runtime integrations grant or revoke an exact provider operation through the store boundary, then recheck that authority immediately before egress and publication. No operator-facing command is added here; later application surfaces call this contract.

Part of #176 (R4). Stacks on #191.
