### PR TITLE
Add auxiliary MD5 fingerprints without changing content identity

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -686,13 +686,20 @@ func TestJobsShowsDaemonStatus(t *testing.T) {
 	assert.Contains(t, out, "extract:plain-text")
 	assert.Contains(t, out, "running")
 
-	out, err = runCLI(t, "jobs", "--json")
-	require.NoError(t, err)
 	var got api.JobList
-	require.NoError(t, json.Unmarshal([]byte(out), &got))
-	require.Len(t, got.Items, 1)
+	require.Eventually(t, func() bool {
+		out, err = runCLI(t, "jobs", "--json")
+		if err != nil || json.Unmarshal([]byte(out), &got) != nil || len(got.Items) != 2 {
+			return false
+		}
+		return got.Items[1].Name == "maintenance:auxiliary-checksums" &&
+			got.Items[1].Status == "completed"
+	}, 5*time.Second, 25*time.Millisecond)
+	require.Len(t, got.Items, 2)
 	assert.Equal(t, "extract:plain-text", got.Items[0].Name)
 	assert.Equal(t, "running", got.Items[0].Status)
+	assert.Equal(t, "maintenance:auxiliary-checksums", got.Items[1].Name)
+	assert.Equal(t, "completed", got.Items[1].Status)
 }
 
 func TestConfiguredAutomaticPackingPacksAndKeepsDaemonAlive(t *testing.T) {
@@ -734,10 +741,11 @@ func TestConfiguredAutomaticPackingPacksAndKeepsDaemonAlive(t *testing.T) {
 	require.NoError(t, err)
 	var got api.JobList
 	require.NoError(t, json.Unmarshal([]byte(out), &got))
-	require.Len(t, got.Items, 2)
+	require.Len(t, got.Items, 3)
 	assert.Equal(t, "extract:plain-text", got.Items[0].Name)
-	assert.Equal(t, "storage:pack", got.Items[1].Name)
-	assert.Equal(t, "running", got.Items[1].Status)
+	assert.Equal(t, "maintenance:auxiliary-checksums", got.Items[1].Name)
+	assert.Equal(t, "storage:pack", got.Items[2].Name)
+	assert.Equal(t, "running", got.Items[2].Status)
 
 	time.Sleep(100 * time.Millisecond)
 	_, _, found, err := client.Find(t.Context(), home)
@@ -778,11 +786,12 @@ func TestConfiguredWatchIngestsStableFilesAndRemainsObservable(t *testing.T) {
 	require.NoError(t, err)
 	var got api.JobList
 	require.NoError(t, json.Unmarshal([]byte(out), &got))
-	require.Len(t, got.Items, 2)
+	require.Len(t, got.Items, 3)
 	assert.Equal(t, "extract:plain-text", got.Items[0].Name)
 	assert.Equal(t, "running", got.Items[0].Status)
-	assert.Equal(t, "watch:sessions", got.Items[1].Name)
-	assert.Equal(t, "running", got.Items[1].Status)
+	assert.Equal(t, "maintenance:auxiliary-checksums", got.Items[1].Name)
+	assert.Equal(t, "watch:sessions", got.Items[2].Name)
+	assert.Equal(t, "running", got.Items[2].Status)
 
 	out, err = runCLI(t, "watch", "list", "--json")
 	require.NoError(t, err)

--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -32,6 +32,7 @@ import (
 	"go.kenn.io/docbank/internal/ingest"
 	"go.kenn.io/docbank/internal/jobs"
 	internalmaintenance "go.kenn.io/docbank/internal/maintenance"
+	"go.kenn.io/docbank/internal/processing"
 	"go.kenn.io/docbank/internal/store"
 	docweb "go.kenn.io/docbank/internal/web"
 )
@@ -149,6 +150,24 @@ func runServe(ctx context.Context) (retErr error) {
 		}
 	}()
 	operationGate := api.NewOperationGate()
+	if err := jobSupervisor.Start("maintenance:auxiliary-checksums", func(ctx context.Context) error {
+		for {
+			completed := 0
+			err := operationGate.MaintainContext(ctx, func() error {
+				var backfillErr error
+				completed, backfillErr = processing.BackfillAuxiliaryChecksums(ctx, s, blobs, 100)
+				return backfillErr
+			})
+			if err != nil {
+				return err
+			}
+			if completed == 0 {
+				return nil
+			}
+		}
+	}); err != nil {
+		return fmt.Errorf("starting auxiliary checksum backfill: %w", err)
+	}
 	placementRunner := blob.PlacementRunner{
 		Metadata: s, Blobs: blobs, Commit: operationGate.PhysicalMutate,
 	}

--- a/cmd/docbank/stat.go
+++ b/cmd/docbank/stat.go
@@ -68,6 +68,9 @@ func writeNodeStat(cmd *cobra.Command, node api.Node) error {
 	if node.Kind == "file" {
 		_, _ = fmt.Fprintf(w, "version:\t%s\n", node.CurrentVersionID)
 		_, _ = fmt.Fprintf(w, "sha256:\t%s\n", node.BlobHash)
+		if node.MD5 != "" {
+			_, _ = fmt.Fprintf(w, "md5:\t%s\n", node.MD5)
+		}
 		_, _ = fmt.Fprintf(w, "size:\t%d\n", node.Size)
 		mimeType := "not recorded"
 		if node.MimeType != "" {

--- a/cmd/docbank/stat_test.go
+++ b/cmd/docbank/stat_test.go
@@ -32,6 +32,7 @@ func TestStatCLIInspectsLiveAndTrashedNodes(t *testing.T) {
 	assert.Contains(t, out, "kind:      file")
 	assert.Contains(t, out, "version:   "+node.CurrentVersionID)
 	assert.Contains(t, out, "sha256:    "+node.BlobHash)
+	assert.Contains(t, out, "md5:       "+node.MD5)
 	assert.Contains(t, out, "mime:      \"text/plain; charset=utf-8\"")
 
 	out, err = runCLI(t, "stat", selector, "--json")

--- a/cmd/docbank/versions.go
+++ b/cmd/docbank/versions.go
@@ -117,6 +117,9 @@ var versionsShowCmd = &cobra.Command{
 		_, _ = fmt.Fprintf(w, "Recorded:\t%s\n", version.RecordedAt)
 		_, _ = fmt.Fprintf(w, "Kind:\t%s\n", version.TransitionKind)
 		_, _ = fmt.Fprintf(w, "Blob:\t%s\n", version.BlobHash)
+		if version.MD5 != "" {
+			_, _ = fmt.Fprintf(w, "MD5:\t%s\n", version.MD5)
+		}
 		_, _ = fmt.Fprintf(w, "Size:\t%d\n", version.Size)
 		if version.MimeType != "" {
 			_, _ = fmt.Fprintf(w, "Media type:\t%s\n", version.MimeType)

--- a/cmd/docbank/versions_test.go
+++ b/cmd/docbank/versions_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/client"
+)
+
+func TestVersionsShowIncludesAuxiliaryMD5(t *testing.T) {
+	_ = setupVaultHome(t)
+	source := writeSourceFile(t, "versioned.txt", "versioned content")
+	_, err := runCLI(t, "add", source, "--dest", "/archive")
+	require.NoError(t, err)
+
+	c, err := client.Ensure(context.Background())
+	require.NoError(t, err)
+	node, err := c.Stat(context.Background(), "/archive/versioned.txt")
+	require.NoError(t, err)
+	require.NotEmpty(t, node.MD5)
+
+	out, err := runCLI(t, "versions", "show", node.CurrentVersionID)
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "Blob:           "+node.BlobHash)
+	assert.Contains(t, out, "MD5:            "+node.MD5)
+}

--- a/internal/api/gate.go
+++ b/internal/api/gate.go
@@ -50,6 +50,12 @@ func (g *OperationGate) Maintain(fn func() error) error {
 	return g.maintainContext(context.Background(), fn)
 }
 
+// MaintainContext is Maintain with cancellation while waiting for exclusive
+// daemon-owned maintenance admission.
+func (g *OperationGate) MaintainContext(ctx context.Context, fn func() error) error {
+	return g.maintainContext(ctx, fn)
+}
+
 // PhysicalMutate serializes a short physical-authority commit with backup
 // preservation without blocking unrelated logical document mutations.
 func (g *OperationGate) PhysicalMutate(fn func() error) error {

--- a/internal/api/routes_read_test.go
+++ b/internal/api/routes_read_test.go
@@ -2,8 +2,10 @@
 package api_test
 
 import (
+	"crypto/md5" //nolint:gosec // Test coverage for explicitly auxiliary interoperability metadata.
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json/v2"
 	"fmt"
 	"net/http"
@@ -138,19 +140,21 @@ func TestContentStreamsBlob(t *testing.T) {
 
 func TestFileNodeExposesBlobIdentity(t *testing.T) {
 	ts, s := newTestServer(t, nil)
-	n := createFileWithContent(t, ts, s, "/identity.txt", "identity")
+	n := createFileWithChecksum(t, s, "identity.txt", "identity")
 	resp, body := get(t, ts, fmt.Sprintf("/api/v1/nodes/%d", n.ID), nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	var got api.Node
 	require.NoError(t, json.Unmarshal([]byte(body), &got))
 	assert.Equal(t, n.BlobHash, got.BlobHash)
+	md5sum := md5.Sum([]byte("identity")) //nolint:gosec // Explicit auxiliary MD5 assertion.
+	assert.Equal(t, hex.EncodeToString(md5sum[:]), got.MD5)
 	assert.Equal(t, n.Size, got.Size)
 	assert.Equal(t, n.CurrentVersionID, got.CurrentVersionID)
 }
 
 func TestContentVersionListMetadataAndPackedBytes(t *testing.T) {
 	ts, s := newTestServer(t, nil)
-	n := createFileWithContent(t, ts, s, "/versioned.txt", "stable version bytes")
+	n := createFileWithChecksum(t, s, "versioned.txt", "stable version bytes")
 	require.NotEmpty(t, n.CurrentVersionID)
 
 	resp, body := get(t, ts,
@@ -165,6 +169,8 @@ func TestContentVersionListMetadataAndPackedBytes(t *testing.T) {
 	assert.Equal(t, n.CurrentVersionID, version.ID)
 	assert.Equal(t, n.ID, version.NodeID)
 	assert.Equal(t, n.BlobHash, version.BlobHash)
+	md5sum := md5.Sum([]byte("stable version bytes")) //nolint:gosec // Explicit auxiliary MD5 assertion.
+	assert.Equal(t, hex.EncodeToString(md5sum[:]), version.MD5)
 	assert.Equal(t, "content_create", version.TransitionKind)
 	assert.Equal(t, int64(1), version.NodeRevision)
 
@@ -187,6 +193,21 @@ func TestContentVersionListMetadataAndPackedBytes(t *testing.T) {
 	resp, body = get(t, ts, "/api/v1/nodes/"+strconv.FormatInt(s.RootID(), 10)+"/versions", nil)
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	assert.Contains(t, body, `"code":"not_file"`)
+}
+
+func createFileWithChecksum(t *testing.T, s *testStore, name, content string) store.Node {
+	t.Helper()
+	receipt, err := s.Blobs.WriteDetailedContext(t.Context(), strings.NewReader(content))
+	require.NoError(t, err)
+	encoding, err := receipt.EncodingName()
+	require.NoError(t, err)
+	node, err := s.CreateFile(t.Context(), s.RootID(), name, receipt.Hash, receipt.Size,
+		"text/plain", store.BlobPhysical{
+			Encoding: encoding, StoredBytes: receipt.StoredSize,
+			PackEligible: receipt.PackEligible, Created: receipt.Created, MD5: receipt.MD5,
+		})
+	require.NoError(t, err)
+	return node
 }
 
 func TestContentReferenceLookupIsLogicalPaginatedAndRepresentationNeutral(t *testing.T) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -25,6 +25,7 @@ type Node struct {
 	Kind             string `json:"kind" enum:"dir,file"`
 	CurrentVersionID string `json:"current_version_id,omitzero" format:"uuid"`
 	BlobHash         string `json:"blob_hash,omitzero" pattern:"^[0-9a-f]{64}$"`
+	MD5              string `json:"md5,omitzero" pattern:"^[0-9a-f]{32}$"`
 	Size             int64  `json:"size"`
 	MimeType         string `json:"mime_type,omitzero"`
 	Revision         int64  `json:"revision"`
@@ -83,6 +84,7 @@ type ContentVersion struct {
 	ID                    string  `json:"id" format:"uuid"`
 	NodeID                int64   `json:"node_id"`
 	BlobHash              string  `json:"blob_hash" pattern:"^[0-9a-f]{64}$"`
+	MD5                   string  `json:"md5,omitzero" pattern:"^[0-9a-f]{32}$"`
 	Size                  int64   `json:"size" minimum:"0"`
 	MimeType              string  `json:"mime_type,omitzero"`
 	RecordedAt            string  `json:"recorded_at"`
@@ -923,7 +925,7 @@ type BackupRestoreEvent struct {
 func fromStoreNode(n store.Node) Node {
 	out := Node{
 		ID: n.ID, ParentID: n.ParentID, Name: n.Name, Kind: n.Kind,
-		CurrentVersionID: n.CurrentVersionID, BlobHash: n.BlobHash,
+		CurrentVersionID: n.CurrentVersionID, BlobHash: n.BlobHash, MD5: n.MD5,
 		Size: n.Size, MimeType: n.MimeType, Revision: n.Revision,
 		CreatedAt: n.CreatedAt, ModifiedAt: n.ModifiedAt,
 	}
@@ -935,7 +937,7 @@ func fromStoreNode(n store.Node) Node {
 
 func fromStoreContentVersion(v store.ContentVersion) ContentVersion {
 	return ContentVersion{
-		ID: v.ID, NodeID: v.NodeID, BlobHash: v.BlobHash, Size: v.Size,
+		ID: v.ID, NodeID: v.NodeID, BlobHash: v.BlobHash, MD5: v.MD5, Size: v.Size,
 		MimeType: v.MimeType, RecordedAt: v.RecordedAt, NodeRevision: v.NodeRevision,
 		IntroducedOperationID: v.IntroducedOperationID,
 		TransitionKind:        v.TransitionKind, SourceVersionID: v.SourceVersionID,

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -4,6 +4,8 @@ package blob
 
 import (
 	"context"
+	"crypto/md5" //nolint:gosec // Auxiliary MD5 is interoperability metadata; SHA-256 remains authoritative.
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -249,6 +251,7 @@ func ValidateOptions(opts Options) error {
 // WriteReceipt describes the physical result of one logical blob write.
 type WriteReceipt struct {
 	Hash         string
+	MD5          string
 	Size         int64
 	Encoding     packstore.LooseEncoding
 	StoredSize   int64
@@ -608,7 +611,8 @@ func (s *Store) WriteContext(ctx context.Context, r io.Reader) (string, int64, e
 // representation. The caller holds a mutation lease across the subsequent
 // metadata transaction.
 func (s *Store) WriteDetailedContext(ctx context.Context, r io.Reader) (WriteReceipt, error) {
-	result, err := s.loose.Write(ctx, r, packstore.WriteOptions{
+	auxiliary := md5.New() //nolint:gosec // Interoperability-only digest; SHA-256 remains authoritative.
+	result, err := s.loose.Write(ctx, io.TeeReader(r, auxiliary), packstore.WriteOptions{
 		Durability:  packstore.DurablePublication,
 		Dedup:       packstore.VerifyTypeAndSize,
 		MaxBytes:    MaxIngestBytes,
@@ -617,7 +621,9 @@ func (s *Store) WriteDetailedContext(ctx context.Context, r io.Reader) (WriteRec
 	if err != nil {
 		return WriteReceipt{}, fmt.Errorf("writing blob: %w", err)
 	}
-	return writeReceipt(result), nil
+	receipt := writeReceipt(result)
+	receipt.MD5 = hex.EncodeToString(auxiliary.Sum(nil))
+	return receipt, nil
 }
 
 // RepairContext verifies trusted bytes against one required logical identity
@@ -656,7 +662,8 @@ func (s *Store) repairContext(
 	if err != nil {
 		return WriteReceipt{}, fmt.Errorf("blob hash %q: %w", hash, ErrInvalidHash)
 	}
-	result, err := s.loose.Repair(ctx, trusted, packstore.LooseIdentity{
+	auxiliary := md5.New() //nolint:gosec // Interoperability-only digest; SHA-256 remains authoritative.
+	result, err := s.loose.Repair(ctx, io.TeeReader(trusted, auxiliary), packstore.LooseIdentity{
 		Hash: parsed, Size: size,
 	}, packstore.RepairOptions{
 		Durability:  packstore.DurablePublication,
@@ -666,7 +673,9 @@ func (s *Store) repairContext(
 	if err != nil {
 		return WriteReceipt{}, fmt.Errorf("repairing blob %s: %w", hash, err)
 	}
-	return writeReceipt(result), nil
+	receipt := writeReceipt(result)
+	receipt.MD5 = hex.EncodeToString(auxiliary.Sum(nil))
+	return receipt, nil
 }
 
 func writeReceipt(result packstore.WriteResult) WriteReceipt {

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -3,6 +3,7 @@ package blob
 import (
 	"bytes"
 	"context"
+	"crypto/md5" //nolint:gosec // F9 requires auxiliary MD5 interoperability metadata.
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -19,6 +20,29 @@ import (
 	"go.kenn.io/kit/pack"
 	"go.kenn.io/kit/packstore"
 )
+
+func TestWriteReceiptIncludesAuxiliaryMD5WithoutChangingSHA256Identity(t *testing.T) {
+	bs := newTestBlobStore(t)
+	for name, content := range map[string][]byte{
+		"content": []byte("synthetic auxiliary checksum bytes"),
+		"empty":   {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			first, err := bs.WriteDetailedContext(t.Context(), bytes.NewReader(content))
+			require.NoError(t, err)
+			wantSHA256 := sha256.Sum256(content)
+			wantMD5 := md5.Sum(content) //nolint:gosec // Explicit auxiliary-checksum expectation.
+			assert.Equal(t, hex.EncodeToString(wantSHA256[:]), first.Hash)
+			assert.Equal(t, hex.EncodeToString(wantMD5[:]), first.MD5)
+
+			second, err := bs.WriteDetailedContext(t.Context(), bytes.NewReader(content))
+			require.NoError(t, err)
+			assert.Equal(t, first.Hash, second.Hash)
+			assert.Equal(t, first.MD5, second.MD5)
+			assert.False(t, second.Created)
+		})
+	}
+}
 
 func newTestBlobStore(t *testing.T) *Store {
 	t.Helper()

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"bytes"
 	"context"
+	"crypto/md5" //nolint:gosec // Test coverage for explicitly auxiliary interoperability metadata.
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -694,6 +695,9 @@ func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {
 	sum := sha256.Sum256(content)
 	wantHash := hex.EncodeToString(sum[:])
 	assert.Equal(t, wantHash, node.BlobHash)
+	auxiliary := md5.Sum(content) //nolint:gosec // Explicit auxiliary MD5 assertion.
+	wantMD5 := hex.EncodeToString(auxiliary[:])
+	assert.Equal(t, wantMD5, node.MD5)
 	require.NotEmpty(t, node.CurrentVersionID)
 
 	page, err := c.Versions(t.Context(), node.ID, 10, 0)
@@ -701,6 +705,7 @@ func TestContentIdentityAndVerificationRoundTrip(t *testing.T) {
 	assert.Equal(t, 1, page.Total)
 	require.Len(t, page.Items, 1)
 	assert.Equal(t, node.CurrentVersionID, page.Items[0].ID)
+	assert.Equal(t, wantMD5, page.Items[0].MD5)
 	version, err := c.Version(t.Context(), node.CurrentVersionID)
 	require.NoError(t, err)
 	assert.Equal(t, page.Items[0], version)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -197,7 +197,7 @@ func physicalReceipt(receipt blob.WriteReceipt) (store.BlobPhysical, error) {
 	}
 	return store.BlobPhysical{
 		Encoding: encoding, StoredBytes: receipt.StoredSize,
-		PackEligible: receipt.PackEligible, Created: receipt.Created,
+		PackEligible: receipt.PackEligible, MD5: receipt.MD5, Created: receipt.Created,
 	}, nil
 }
 

--- a/internal/processing/artifacts.go
+++ b/internal/processing/artifacts.go
@@ -3,6 +3,7 @@ package processing
 import (
 	"bytes"
 	"context"
+	"crypto/md5" //nolint:gosec // Auxiliary MD5 is interoperability metadata; SHA-256 remains authoritative.
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json/v2"
@@ -16,6 +17,7 @@ import (
 	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/store"
+	"go.kenn.io/kit/packstore"
 )
 
 // StagedArtifact binds one immutable catalog member to its retained payload.
@@ -41,6 +43,7 @@ type StagedRendition struct {
 type PublishedArtifact struct {
 	ID   string
 	Hash string
+	MD5  string
 	Size int64
 }
 
@@ -70,6 +73,69 @@ type renditionPublicationCatalog interface {
 		ctx context.Context, attachment store.RenditionAttachmentRecord,
 		head store.RenditionHeadRecord, generationID string,
 	) error
+}
+
+type auxiliaryChecksumCatalog interface {
+	MissingBlobChecksumTargets(ctx context.Context, limit int) ([]store.BlobChecksumTarget, error)
+	RecordVerifiedBlobChecksum(ctx context.Context, record store.BlobChecksumRecord) error
+}
+
+type auxiliaryChecksumBlobReader interface {
+	OpenStreamContext(
+		ctx context.Context, hash string,
+	) (packstore.VerifiedReadCloser, int64, error)
+}
+
+// BackfillAuxiliaryChecksums computes one resumable batch over exact retained
+// originals and sanitized Markdown. Progress is committed only after the
+// mixed-store stream reaches verified EOF with its cataloged size.
+func BackfillAuxiliaryChecksums(
+	ctx context.Context, catalog auxiliaryChecksumCatalog,
+	blobs auxiliaryChecksumBlobReader, limit int,
+) (int, error) {
+	if catalog == nil || blobs == nil {
+		return 0, errors.New("auxiliary checksum backfill requires catalog and blob stores")
+	}
+	targets, err := catalog.MissingBlobChecksumTargets(ctx, limit)
+	if err != nil {
+		return 0, err
+	}
+	completed := 0
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return completed, err
+		}
+		stream, size, err := blobs.OpenStreamContext(ctx, target.BlobSHA256)
+		if err != nil {
+			return completed, fmt.Errorf("opening checksum target %s: %w", target.BlobSHA256, err)
+		}
+		if size != target.Size {
+			_ = stream.Close()
+			return completed, fmt.Errorf(
+				"checksum target %s size changed: catalog=%d stream=%d",
+				target.BlobSHA256, target.Size, size,
+			)
+		}
+		digest := md5.New() //nolint:gosec // Auxiliary MD5 never grants content authority.
+		read, copyErr := io.Copy(digest, stream)
+		closeErr := stream.Close()
+		if err := errors.Join(copyErr, closeErr); err != nil {
+			return completed, fmt.Errorf("verifying checksum target %s: %w", target.BlobSHA256, err)
+		}
+		if read != target.Size {
+			return completed, fmt.Errorf(
+				"checksum target %s length changed: catalog=%d read=%d",
+				target.BlobSHA256, target.Size, read,
+			)
+		}
+		if err := catalog.RecordVerifiedBlobChecksum(ctx, store.BlobChecksumRecord{
+			BlobSHA256: target.BlobSHA256, MD5: hex.EncodeToString(digest.Sum(nil)),
+		}); err != nil {
+			return completed, fmt.Errorf("recording checksum target %s: %w", target.BlobSHA256, err)
+		}
+		completed++
+	}
+	return completed, nil
 }
 
 // ArtifactPublisher verifies retained bytes, stages immutable catalog and FTS
@@ -119,7 +185,7 @@ func (p *ArtifactPublisher) PublishRendition(
 			}
 			receipt, writeErr := p.blobs.WriteDetailedContext(ctx, reader)
 			if receipt.Hash != "" {
-				if err := p.recordRenditionReceipt(ctx, receipt); err != nil {
+				if err := p.recordRenditionReceipt(ctx, record.Role, receipt); err != nil {
 					if writeErr != nil {
 						return fmt.Errorf("publishing rendition artifact %s: %w",
 							record.ID, errors.Join(writeErr, err))
@@ -136,8 +202,14 @@ func (p *ArtifactPublisher) PublishRendition(
 					record.ID, receipt.Hash, receipt.Size, record.BlobHash, record.Size,
 				)
 			}
+			publishedMD5 := ""
+			if record.Role == "sanitized_markdown" {
+				publishedMD5 = receipt.MD5
+			}
 			verified = append(verified, verifiedArtifact{
-				published: PublishedArtifact{ID: record.ID, Hash: receipt.Hash, Size: receipt.Size},
+				published: PublishedArtifact{
+					ID: record.ID, Hash: receipt.Hash, MD5: publishedMD5, Size: receipt.Size,
+				},
 			})
 			if record.Role == "normalized_evidence" {
 				normalizedEvidence = evidence.Bytes()
@@ -175,16 +247,20 @@ func (p *ArtifactPublisher) PublishRendition(
 }
 
 func (p *ArtifactPublisher) recordRenditionReceipt(
-	ctx context.Context, receipt blob.WriteReceipt,
+	ctx context.Context, role string, receipt blob.WriteReceipt,
 ) error {
 	encoding, err := receipt.EncodingName()
 	if err != nil {
 		return err
 	}
-	if err := p.catalog.RecordRenditionBlob(ctx, receipt.Hash, receipt.Size, store.BlobPhysical{
+	physical := store.BlobPhysical{
 		Encoding: encoding, StoredBytes: receipt.StoredSize,
 		PackEligible: receipt.PackEligible, Created: receipt.Created,
-	}); err != nil {
+	}
+	if role == "sanitized_markdown" {
+		physical.MD5 = receipt.MD5
+	}
+	if err := p.catalog.RecordRenditionBlob(ctx, receipt.Hash, receipt.Size, physical); err != nil {
 		return fmt.Errorf("recording retained bytes as rendition staging: %w", err)
 	}
 	return nil

--- a/internal/processing/artifacts_test.go
+++ b/internal/processing/artifacts_test.go
@@ -76,6 +76,24 @@ func TestPublishRenditionPublishesVerifiedArtifactsAndHeads(t *testing.T) {
 	assert.Equal(t, store.SearchMatchContent, hits[0].Match)
 }
 
+func TestPublishRenditionExactRetryIgnoresDerivedMD5(t *testing.T) {
+	// Mutation caught: loading the first publication hydrates the Markdown MD5,
+	// which must not change the immutable build declaration used by a retry.
+	fixture := newPublicationFixture(t)
+	publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+	require.NoError(t, err)
+	ids := publicationIDs{"b1", "51", "91"}
+
+	first := fixture.stage(t, ids, "searchable mercury evidence", "first markdown")
+	first.Build.Warnings = nil
+	_, err = publisher.PublishRendition(t.Context(), first)
+	require.NoError(t, err)
+	retry := fixture.stage(t, ids, "searchable mercury evidence", "first markdown")
+	retry.Build.Warnings = nil
+	_, err = publisher.PublishRendition(t.Context(), retry)
+	require.NoError(t, err, "an exact retry must reuse the immutable build")
+}
+
 func TestPublishRenditionAcceptsNilBuildWarnings(t *testing.T) {
 	// Mutation caught: exact slice comparison rejects a warning-free build
 	// when one representation uses nil and the other uses an empty slice.

--- a/internal/processing/artifacts_test.go
+++ b/internal/processing/artifacts_test.go
@@ -3,6 +3,7 @@ package processing
 import (
 	"bytes"
 	"context"
+	"crypto/md5" //nolint:gosec // Test coverage for explicitly auxiliary interoperability metadata.
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json/jsontext"
@@ -23,6 +24,7 @@ import (
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/maintenance"
 	"go.kenn.io/docbank/internal/store"
+	"go.kenn.io/kit/packstore"
 )
 
 var errInjectedPublication = errors.New("injected publication failure")
@@ -47,11 +49,22 @@ func TestPublishRenditionPublishesVerifiedArtifactsAndHeads(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, artifact.Size, physical.LogicalBytes)
 	}
-
 	view, err := fixture.catalog.ActiveRendition(
 		t.Context(), fixture.versionID, fixture.profile.Fingerprint,
 	)
 	require.NoError(t, err)
+	for _, artifact := range view.Build.Artifacts {
+		checksum, checksumErr := fixture.catalog.BlobChecksums(t.Context(), artifact.BlobHash)
+		if artifact.Role == "sanitized_markdown" {
+			require.NoError(t, checksumErr)
+			assert.Equal(t, artifact.MD5, checksum.MD5)
+			assert.Len(t, artifact.MD5, 32)
+		} else {
+			require.ErrorIs(t, checksumErr, store.ErrNotFound)
+			assert.Empty(t, artifact.MD5)
+		}
+	}
+
 	assert.Equal(t, published.BuildID, view.Build.ID)
 	active, err := fixture.catalog.ActiveLexicalGeneration(t.Context())
 	require.NoError(t, err)
@@ -77,6 +90,71 @@ func TestPublishRenditionAcceptsNilBuildWarnings(t *testing.T) {
 
 	_, err = publisher.PublishRendition(t.Context(), staged)
 	require.NoError(t, err)
+}
+
+func TestAuxiliaryChecksumBackfillResumesAndReadsPackedOnlyContent(t *testing.T) {
+	root := t.TempDir()
+	catalog, err := store.Open(filepath.Join(root, "docbank.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, catalog.Close()) })
+	blobs, err := blob.New(store.NewPackCatalog(catalog), filepath.Join(root, "blobs"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, blobs.Close()) })
+
+	payloads := [][]byte{[]byte("first legacy original"), []byte("second legacy original")}
+	for index, payload := range payloads {
+		receipt, writeErr := blobs.WriteDetailedContext(t.Context(), bytes.NewReader(payload))
+		require.NoError(t, writeErr)
+		encoding, encodingErr := receipt.EncodingName()
+		require.NoError(t, encodingErr)
+		_, createErr := catalog.CreateFile(t.Context(), catalog.RootID(),
+			"legacy-"+strconv.Itoa(index)+".bin", receipt.Hash, receipt.Size,
+			"application/octet-stream", store.BlobPhysical{
+				Encoding: encoding, StoredBytes: receipt.StoredSize,
+				PackEligible: receipt.PackEligible, Created: receipt.Created,
+			})
+		require.NoError(t, createErr)
+	}
+	packed, err := blobs.Maintainer().Pack(t.Context(), packstore.PackOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 2, packed.BlobsPacked)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	interrupted := &cancelOnSecondChecksumOpen{delegate: blobs, cancel: cancel}
+	completed, err := BackfillAuxiliaryChecksums(ctx, catalog, interrupted, 10)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, completed)
+
+	completed, err = BackfillAuxiliaryChecksums(t.Context(), catalog, blobs, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, completed)
+	completed, err = BackfillAuxiliaryChecksums(t.Context(), catalog, blobs, 10)
+	require.NoError(t, err)
+	assert.Zero(t, completed, "completed rows must not be recomputed")
+
+	for _, payload := range payloads {
+		sha := sha256.Sum256(payload)
+		record, lookupErr := catalog.BlobChecksums(t.Context(), hex.EncodeToString(sha[:]))
+		require.NoError(t, lookupErr)
+		want := md5.Sum(payload) //nolint:gosec // Explicit auxiliary MD5 assertion.
+		assert.Equal(t, hex.EncodeToString(want[:]), record.MD5)
+	}
+}
+
+type cancelOnSecondChecksumOpen struct {
+	delegate auxiliaryChecksumBlobReader
+	cancel   context.CancelFunc
+	calls    int
+}
+
+func (r *cancelOnSecondChecksumOpen) OpenStreamContext(
+	ctx context.Context, hash string,
+) (packstore.VerifiedReadCloser, int64, error) {
+	r.calls++
+	if r.calls == 2 {
+		r.cancel()
+	}
+	return r.delegate.OpenStreamContext(ctx, hash)
 }
 
 func TestPublishRenditionRejectsLexicalSegmentLimitOutsideCanonicalProfile(t *testing.T) {
@@ -676,7 +754,7 @@ func processingBlobPhysical(t *testing.T, receipt blob.WriteReceipt) store.BlobP
 	require.NoError(t, err)
 	return store.BlobPhysical{
 		Encoding: encoding, StoredBytes: receipt.StoredSize,
-		PackEligible: receipt.PackEligible, Created: receipt.Created,
+		PackEligible: receipt.PackEligible, MD5: receipt.MD5, Created: receipt.Created,
 	}
 }
 

--- a/internal/store/content_checksums.go
+++ b/internal/store/content_checksums.go
@@ -1,0 +1,141 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.kenn.io/kit/packstore"
+)
+
+const auxiliaryMD5Length = 32
+
+// BlobChecksumRecord binds auxiliary interoperability metadata to Docbank's
+// authoritative SHA-256 blob identity.
+type BlobChecksumRecord struct {
+	BlobSHA256 string `json:"blob_sha256"`
+	MD5        string `json:"md5"`
+}
+
+// BlobChecksumTarget identifies retained bytes whose auxiliary checksum is
+// not yet known. The SHA-256 identity and size remain authoritative.
+type BlobChecksumTarget struct {
+	BlobSHA256 string
+	Size       int64
+}
+
+func validateAuxiliaryMD5(value string) error {
+	if len(value) != auxiliaryMD5Length || value != strings.ToLower(value) {
+		return errors.New("auxiliary checksum must be canonical lowercase MD5")
+	}
+	for _, character := range value {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return errors.New("auxiliary checksum must be canonical lowercase MD5")
+		}
+	}
+	return nil
+}
+
+func validateBlobChecksumRecord(record BlobChecksumRecord) error {
+	parsed, err := packstore.ParseHash(record.BlobSHA256)
+	if err != nil || parsed.String() != record.BlobSHA256 {
+		return errors.New("blob checksum SHA-256 identity is invalid")
+	}
+	return validateAuxiliaryMD5(record.MD5)
+}
+
+func ensureBlobChecksumTx(tx *sql.Tx, record BlobChecksumRecord) error {
+	if record.MD5 == "" {
+		return nil
+	}
+	if err := validateBlobChecksumRecord(record); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`INSERT INTO blob_checksums(blob_sha256,md5) VALUES(?,?)
+		ON CONFLICT(blob_sha256) DO NOTHING`, record.BlobSHA256, record.MD5); err != nil {
+		return fmt.Errorf("recording auxiliary checksum for blob %s: %w", record.BlobSHA256, err)
+	}
+	var stored string
+	if err := tx.QueryRow(`SELECT md5 FROM blob_checksums WHERE blob_sha256=?`,
+		record.BlobSHA256).Scan(&stored); err != nil {
+		return fmt.Errorf("reading auxiliary checksum for blob %s: %w", record.BlobSHA256, err)
+	}
+	if stored != record.MD5 {
+		return fmt.Errorf("blob %s has different MD5 %s", record.BlobSHA256, stored)
+	}
+	return nil
+}
+
+// BlobChecksums returns auxiliary checksums for one retained SHA-256 blob.
+func (s *Store) BlobChecksums(ctx context.Context, sha256 string) (BlobChecksumRecord, error) {
+	if _, err := packstore.ParseHash(sha256); err != nil {
+		return BlobChecksumRecord{}, fmt.Errorf("blob checksum %q: %w", sha256, ErrNotFound)
+	}
+	record := BlobChecksumRecord{}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT blob_sha256,md5 FROM blob_checksums WHERE blob_sha256=?`, sha256,
+	).Scan(&record.BlobSHA256, &record.MD5); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return BlobChecksumRecord{}, ErrNotFound
+		}
+		return BlobChecksumRecord{}, fmt.Errorf("reading blob checksum %s: %w", sha256, err)
+	}
+	return record, nil
+}
+
+// RecordVerifiedBlobChecksum commits a locally computed auxiliary checksum.
+// The caller must have read the exact bytes through a verified blob resolver.
+func (s *Store) RecordVerifiedBlobChecksum(ctx context.Context, record BlobChecksumRecord) error {
+	if err := validateBlobChecksumRecord(record); err != nil {
+		return err
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		var present int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM blobs WHERE hash=?`, record.BlobSHA256,
+		).Scan(&present); err != nil {
+			return fmt.Errorf("checking blob checksum target %s: %w", record.BlobSHA256, err)
+		}
+		if present != 1 {
+			return fmt.Errorf("blob checksum target %s: %w", record.BlobSHA256, ErrNotFound)
+		}
+		return ensureBlobChecksumTx(tx, record)
+	})
+}
+
+// MissingBlobChecksumTargets returns a deterministic resumable batch of
+// retained originals and sanitized Markdown without auxiliary checksums.
+func (s *Store) MissingBlobChecksumTargets(
+	ctx context.Context, limit int,
+) ([]BlobChecksumTarget, error) {
+	if limit < 1 || limit > 1000 {
+		return nil, errors.New("blob checksum backfill limit must be between 1 and 1000")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT b.hash,b.size FROM blobs b
+		LEFT JOIN blob_checksums c ON c.blob_sha256=b.hash
+		WHERE c.blob_sha256 IS NULL AND (
+		  EXISTS(SELECT 1 FROM content_versions v WHERE v.blob_hash=b.hash)
+		  OR EXISTS(SELECT 1 FROM rendition_artifacts a
+		            WHERE a.blob_hash=b.hash AND a.role='sanitized_markdown')
+		)
+		ORDER BY b.hash LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("listing missing blob checksums: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	targets := make([]BlobChecksumTarget, 0)
+	for rows.Next() {
+		var target BlobChecksumTarget
+		if err := rows.Scan(&target.BlobSHA256, &target.Size); err != nil {
+			return nil, fmt.Errorf("scanning missing blob checksum: %w", err)
+		}
+		targets = append(targets, target)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing missing blob checksums: %w", err)
+	}
+	return targets, nil
+}

--- a/internal/store/content_checksums_test.go
+++ b/internal/store/content_checksums_test.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuxiliaryChecksumPersistsByAuthoritativeSHA256Identity(t *testing.T) {
+	s := newTestStore(t)
+	hash := fakeHash("a9")
+	const md5sum = "f6fdffe48c908deb0f4c3bd36c032e72"
+	physical := BlobPhysical{
+		Encoding: "raw", StoredBytes: 9, PackEligible: true, Created: true, MD5: md5sum,
+	}
+	node, err := s.CreateFile(t.Context(), s.RootID(), "source.bin", hash, 9, "", physical)
+	require.NoError(t, err)
+
+	record, err := s.BlobChecksums(t.Context(), hash)
+	require.NoError(t, err)
+	assert.Equal(t, BlobChecksumRecord{BlobSHA256: hash, MD5: md5sum}, record)
+	assert.Equal(t, hash, node.BlobHash, "MD5 must not replace SHA-256 identity")
+
+	_, err = s.CreateFile(t.Context(), s.RootID(), "deduplicated.bin", hash, 9, "",
+		BlobPhysical{Encoding: "raw", StoredBytes: 9, PackEligible: true, MD5: md5sum})
+	require.NoError(t, err)
+	_, err = s.CreateFile(t.Context(), s.RootID(), "disagreement.bin", hash, 9, "",
+		BlobPhysical{Encoding: "raw", StoredBytes: 9, PackEligible: true,
+			MD5: "00000000000000000000000000000000"})
+	require.ErrorContains(t, err, "different MD5")
+}
+
+func TestAuxiliaryChecksumValidationAndMissingBackfillTargets(t *testing.T) {
+	s := newTestStore(t)
+	hash := fakeHash("b8")
+	_, err := s.CreateFile(t.Context(), s.RootID(), "legacy.bin", hash, 4, "")
+	require.NoError(t, err)
+	_, err = s.BlobChecksums(t.Context(), hash)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	targets, err := s.MissingBlobChecksumTargets(t.Context(), 10)
+	require.NoError(t, err)
+	require.Equal(t, []BlobChecksumTarget{{BlobSHA256: hash, Size: 4}}, targets)
+
+	for _, invalid := range []string{"", "ABCDEF0123456789ABCDEF0123456789", strings.Repeat("g", 32), "abcd"} {
+		err = s.RecordVerifiedBlobChecksum(context.Background(), BlobChecksumRecord{
+			BlobSHA256: hash, MD5: invalid,
+		})
+		require.ErrorContains(t, err, "canonical lowercase MD5")
+	}
+	require.NoError(t, s.RecordVerifiedBlobChecksum(t.Context(), BlobChecksumRecord{
+		BlobSHA256: hash, MD5: "8d777f385d3dfec8815d20f7496026dc",
+	}))
+	targets, err = s.MissingBlobChecksumTargets(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+}

--- a/internal/store/content_reference.go
+++ b/internal/store/content_reference.go
@@ -40,11 +40,14 @@ func (s *Store) ContentReferencesByHash(
 	// recursive path projection runs only for live nodes in the selected page.
 	rows, err := s.db.QueryContext(ctx, `
 		WITH RECURSIVE matching AS (
-			SELECT v.version_id, v.node_id, v.blob_hash, v.size, v.mime_type,
+			SELECT v.version_id, v.node_id, v.blob_hash,
+			       COALESCE((SELECT md5 FROM blob_checksums WHERE blob_sha256=v.blob_hash), '') AS md5,
+			       v.size, v.mime_type,
 			       v.recorded_at, v.node_revision, v.introduced_operation_id,
 			       v.transition_kind, v.source_version_id,
 			       n.parent_id, n.name, n.kind, n.current_version_id,
 			       current.blob_hash AS current_blob_hash,
+			       COALESCE((SELECT md5 FROM blob_checksums WHERE blob_sha256=current.blob_hash), '') AS current_md5,
 			       current.size AS current_size, current.mime_type AS current_mime_type,
 			       n.revision, n.created_at, n.modified_at, n.trashed_at,
 			       n.trashed_at IS NOT NULL AS trashed_sort,
@@ -74,14 +77,16 @@ func (s *Store) ContentReferencesByHash(
 		)
 		SELECT totals.total,
 		       COALESCE(page.version_id, ''), COALESCE(page.node_id, 0),
-		       COALESCE(page.blob_hash, ''), COALESCE(page.size, 0),
+		       COALESCE(page.blob_hash, ''), COALESCE(page.md5, ''),
+		       COALESCE(page.size, 0),
 		       COALESCE(page.mime_type, ''), COALESCE(page.recorded_at, ''),
 		       COALESCE(page.node_revision, 0),
 		       COALESCE(page.introduced_operation_id, ''),
 		       COALESCE(page.transition_kind, ''), page.source_version_id,
 		       COALESCE(page.node_id, 0), page.parent_id, COALESCE(page.name, ''),
 		       COALESCE(page.kind, ''), COALESCE(page.current_version_id, ''),
-		       COALESCE(page.current_blob_hash, ''), COALESCE(page.current_size, 0),
+		       COALESCE(page.current_blob_hash, ''), COALESCE(page.current_md5, ''),
+		       COALESCE(page.current_size, 0),
 		       COALESCE(page.current_mime_type, ''), COALESCE(page.revision, 0),
 		       COALESCE(page.created_at, ''), COALESCE(page.modified_at, ''),
 		       page.trashed_at, COALESCE(paths.path, ''),
@@ -102,11 +107,11 @@ func (s *Store) ContentReferencesByHash(
 		if err := rows.Scan(
 			&total,
 			&ref.Version.ID, &ref.Version.NodeID, &ref.Version.BlobHash,
-			&ref.Version.Size, &ref.Version.MimeType, &ref.Version.RecordedAt,
+			&ref.Version.MD5, &ref.Version.Size, &ref.Version.MimeType, &ref.Version.RecordedAt,
 			&ref.Version.NodeRevision, &ref.Version.IntroducedOperationID,
 			&ref.Version.TransitionKind, &ref.Version.SourceVersionID,
 			&ref.Node.ID, &ref.Node.ParentID, &ref.Node.Name, &ref.Node.Kind,
-			&ref.Node.CurrentVersionID, &ref.Node.BlobHash, &ref.Node.Size,
+			&ref.Node.CurrentVersionID, &ref.Node.BlobHash, &ref.Node.MD5, &ref.Node.Size,
 			&ref.Node.MimeType, &ref.Node.Revision, &ref.Node.CreatedAt,
 			&ref.Node.ModifiedAt, &ref.Node.TrashedAt, &ref.Path, &ref.IsCurrent,
 		); err != nil {

--- a/internal/store/content_reference_test.go
+++ b/internal/store/content_reference_test.go
@@ -13,6 +13,8 @@ func TestContentReferencesByHashIncludesCurrentHistoricalAndTrash(t *testing.T) 
 	ctx := t.Context()
 	wanted := fakeHash("a1")
 	replacement := fakeHash("b2")
+	const wantedMD5 = "f6fdffe48c908deb0f4c3bd36c032e72"
+	const replacementMD5 = "8d777f385d3dfec8815d20f7496026dc"
 
 	historical, err := s.CreateFile(ctx, s.RootID(), "historical.txt", wanted, 10, "text/plain")
 	require.NoError(t, err)
@@ -28,6 +30,10 @@ func TestContentReferencesByHashIncludesCurrentHistoricalAndTrash(t *testing.T) 
 	require.NoError(t, err)
 	trashed, _, err = s.Trash(ctx, trashed.ID, trashed.Revision)
 	require.NoError(t, err)
+	require.NoError(t, s.RecordVerifiedBlobChecksum(ctx,
+		BlobChecksumRecord{BlobSHA256: wanted, MD5: wantedMD5}))
+	require.NoError(t, s.RecordVerifiedBlobChecksum(ctx,
+		BlobChecksumRecord{BlobSHA256: replacement, MD5: replacementMD5}))
 
 	refs, total, err := s.ContentReferencesByHash(ctx, wanted, 10, 0)
 	require.NoError(t, err)
@@ -36,6 +42,8 @@ func TestContentReferencesByHashIncludesCurrentHistoricalAndTrash(t *testing.T) 
 
 	assert.Equal(t, current.ID, refs[0].Node.ID, "live current references sort first")
 	assert.Equal(t, current.CurrentVersionID, refs[0].Version.ID)
+	assert.Equal(t, wantedMD5, refs[0].Version.MD5)
+	assert.Equal(t, wantedMD5, refs[0].Node.MD5)
 	assert.True(t, refs[0].IsCurrent)
 	assert.Equal(t, "/current.txt", refs[0].Path)
 	assert.Nil(t, refs[0].Node.TrashedAt)
@@ -45,6 +53,8 @@ func TestContentReferencesByHashIncludesCurrentHistoricalAndTrash(t *testing.T) 
 	assert.False(t, refs[1].IsCurrent)
 	assert.Equal(t, replacement, refs[1].Node.BlobHash,
 		"the node projection describes its current authority")
+	assert.Equal(t, wantedMD5, refs[1].Version.MD5)
+	assert.Equal(t, replacementMD5, refs[1].Node.MD5)
 	assert.Equal(t, "/historical.txt", refs[1].Path)
 
 	assert.Equal(t, trashed.ID, refs[2].Node.ID, "trashed references sort last")

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -887,9 +887,13 @@ func (s *Store) importMetadataRecord(
 		if err := decodeMetadataRecord(raw, &v); err != nil {
 			return err
 		}
-		return ensureBlobChecksumTx(tx, BlobChecksumRecord{
+		record := BlobChecksumRecord{
 			BlobSHA256: v.BlobSHA256, MD5: v.MD5,
-		})
+		}
+		if err := validateBlobChecksumRecord(record); err != nil {
+			return err
+		}
+		return ensureBlobChecksumTx(tx, record)
 	case "node":
 		var v metadataNode
 		if err := decodeMetadataRecord(raw, &v); err != nil {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -103,6 +103,12 @@ type metadataBlob struct {
 	CreatedAt string `json:"created_at"`
 }
 
+type metadataBlobChecksum struct {
+	Type       string `json:"type"`
+	BlobSHA256 string `json:"blob_sha256"`
+	MD5        string `json:"md5"`
+}
+
 type metadataNode struct {
 	Type             string  `json:"type"`
 	ID               int64   `json:"id"`
@@ -308,6 +314,9 @@ func exportMetadataSnapshotWithVaultIdentity(
 	if err := exportBlobs(ctx, tx, write, backupScoped); err != nil {
 		return err
 	}
+	if err := exportBlobChecksums(ctx, tx, write, backupScoped); err != nil {
+		return err
+	}
 	if err := exportNodes(ctx, tx, write); err != nil {
 		return err
 	}
@@ -381,6 +390,49 @@ ORDER BY b.hash`
 		}
 	}
 	return rowsError("blob", rows)
+}
+
+func exportBlobChecksums(
+	ctx context.Context, tx metadataQuerier, write metadataWrite, backupScoped bool,
+) error {
+	var checksumTable bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM sqlite_master WHERE type='table' AND name='blob_checksums'
+	)`).Scan(&checksumTable); err != nil {
+		return fmt.Errorf("detecting blob checksum schema: %w", err)
+	}
+	// Released source layouts predate auxiliary checksums. Their deterministic
+	// cutover stream intentionally omits records for a later verified backfill.
+	if !checksumTable {
+		return nil
+	}
+	query := `SELECT blob_sha256,md5 FROM blob_checksums ORDER BY blob_sha256`
+	if backupScoped {
+		query = BackupBlobAuthorityCTE + `
+SELECT c.blob_sha256,c.md5 FROM blob_checksums c
+JOIN backup_authorized_blobs a ON a.hash=c.blob_sha256
+ORDER BY c.blob_sha256`
+	}
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("exporting blob checksums: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		record := metadataBlobChecksum{Type: metadataBlobChecksumType}
+		if err := rows.Scan(&record.BlobSHA256, &record.MD5); err != nil {
+			return fmt.Errorf("scanning blob checksum metadata: %w", err)
+		}
+		if err := validateBlobChecksumRecord(BlobChecksumRecord{
+			BlobSHA256: record.BlobSHA256, MD5: record.MD5,
+		}); err != nil {
+			return fmt.Errorf("validating blob checksum metadata for export: %w", err)
+		}
+		if err := write(record); err != nil {
+			return err
+		}
+	}
+	return rowsError("blob checksum", rows)
 }
 
 func exportNodes(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
@@ -677,6 +729,7 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		SELECT
 		  (SELECT COUNT(*) FROM nodes),
 		  (SELECT COUNT(*) FROM blobs) + (SELECT COUNT(*) FROM content_versions)
+		    + (SELECT COUNT(*) FROM blob_checksums)
 		    + (SELECT COUNT(*) FROM ingests) + (SELECT COUNT(*) FROM provenance)
 		    + (SELECT COUNT(*) FROM watch_sources)
 		    + (SELECT COUNT(*) FROM tags) + (SELECT COUNT(*) FROM node_tags)
@@ -829,6 +882,14 @@ func (s *Store) importMetadataRecord(
 			v.Size, maxPackEligibleBytes, blobStoreRolePrimary,
 		)
 		return err
+	case metadataBlobChecksumType:
+		var v metadataBlobChecksum
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		return ensureBlobChecksumTx(tx, BlobChecksumRecord{
+			BlobSHA256: v.BlobSHA256, MD5: v.MD5,
+		})
 	case "node":
 		var v metadataNode
 		if err := decodeMetadataRecord(raw, &v); err != nil {
@@ -984,12 +1045,14 @@ const (
 	metadataAuditScopeType                = "audit_scope"
 	metadataAuditMembershipType           = "audit_membership"
 	metadataAuditRecordType               = "audit_record"
+	metadataBlobChecksumType              = "blob_checksum"
 )
 
 var metadataHeaderFields = []string{metadataTypeField, "format", "version", auditVaultIDField, "node_sequence"}
 
 var metadataRequiredFields = map[string][]string{
 	"blob":                                 {metadataTypeField, "hash", metadataSizeField, metadataCreatedAtField},
+	metadataBlobChecksumType:               {metadataTypeField, "blob_sha256", "md5"},
 	"node":                                 {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", metadataCreatedAtField, "modified_at", "trashed_at", "trash_parent", "trash_name"},
 	"content_version":                      {metadataTypeField, "version_id", metadataNodeIDField, "blob_hash", metadataSizeField, "mime_type", auditRecordedAtField, "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
 	metadataIngestType:                     {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -76,14 +76,24 @@ func TestAuxiliaryChecksumMetadataRoundTripsAndRejectsMalformedMD5(t *testing.T)
 			require.NoError(t, err)
 			assert.Equal(t, md5sum, record.MD5)
 
-			malformed := strings.Replace(exported.String(), md5sum, strings.ToUpper(md5sum), 1)
-			rejected, err := Open(filepath.Join(t.TempDir(), "rejected.db"), testCase.driver)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, rejected.Close()) })
-			err = rejected.ImportMetadata(t.Context(), strings.NewReader(malformed))
-			require.ErrorContains(t, err, "canonical lowercase MD5")
-			_, err = rejected.BlobChecksums(t.Context(), metadataHashCurrent)
-			require.ErrorIs(t, err, ErrNotFound)
+			for _, invalid := range []struct {
+				name string
+				md5  string
+			}{
+				{name: "uppercase", md5: strings.ToUpper(md5sum)},
+				{name: "empty", md5: ""},
+			} {
+				t.Run(invalid.name, func(t *testing.T) {
+					malformed := strings.Replace(exported.String(), md5sum, invalid.md5, 1)
+					rejected, err := Open(filepath.Join(t.TempDir(), "rejected.db"), testCase.driver)
+					require.NoError(t, err)
+					t.Cleanup(func() { require.NoError(t, rejected.Close()) })
+					err = rejected.ImportMetadata(t.Context(), strings.NewReader(malformed))
+					require.ErrorContains(t, err, "canonical lowercase MD5")
+					_, err = rejected.BlobChecksums(t.Context(), metadataHashCurrent)
+					require.ErrorIs(t, err, ErrNotFound)
+				})
+			}
 		})
 	}
 }

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	docsqlite "go.kenn.io/docbank/sqlite"
 	"go.kenn.io/docbank/sqlite/modernc"
 	"go.kenn.io/kit/packstore"
 )
@@ -41,6 +42,50 @@ func TestExportMetadataPreservesV1JavaScriptSeparatorEscapes(t *testing.T) {
 	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
 	assert.Contains(t, exported.String(), `"name":"line\u2028paragraph\u2029"`)
 	assert.NotContains(t, exported.String(), "line\u2028paragraph\u2029")
+}
+
+func TestAuxiliaryChecksumMetadataRoundTripsAndRejectsMalformedMD5(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		driver docsqlite.Driver
+	}{
+		{name: "default", driver: DefaultSQLiteDriver()},
+		{name: "pure Go", driver: modernc.Driver{}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			source, err := Open(filepath.Join(t.TempDir(), "source.db"), testCase.driver)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, source.Close()) })
+			const md5sum = "f6fdffe48c908deb0f4c3bd36c032e72"
+			_, err = source.CreateFile(t.Context(), source.RootID(), "source.bin",
+				metadataHashCurrent, 9, "application/octet-stream", BlobPhysical{
+					Encoding: "raw", StoredBytes: 9, PackEligible: true,
+					Created: true, MD5: md5sum,
+				})
+			require.NoError(t, err)
+			var exported bytes.Buffer
+			require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+			assert.Contains(t, exported.String(),
+				`{"type":"blob_checksum","blob_sha256":"`+metadataHashCurrent+`","md5":"`+md5sum+`"}`)
+
+			target, err := Open(filepath.Join(t.TempDir(), "target.db"), testCase.driver)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, target.Close()) })
+			require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+			record, err := target.BlobChecksums(t.Context(), metadataHashCurrent)
+			require.NoError(t, err)
+			assert.Equal(t, md5sum, record.MD5)
+
+			malformed := strings.Replace(exported.String(), md5sum, strings.ToUpper(md5sum), 1)
+			rejected, err := Open(filepath.Join(t.TempDir(), "rejected.db"), testCase.driver)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, rejected.Close()) })
+			err = rejected.ImportMetadata(t.Context(), strings.NewReader(malformed))
+			require.ErrorContains(t, err, "canonical lowercase MD5")
+			_, err = rejected.BlobChecksums(t.Context(), metadataHashCurrent)
+			require.ErrorIs(t, err, ErrNotFound)
+		})
+	}
 }
 
 func TestBackupExcludesUncommittedProviderStaging(t *testing.T) {

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -21,6 +21,7 @@ type Node struct {
 	Kind             string // "dir" | "file"
 	CurrentVersionID string
 	BlobHash         string
+	MD5              string
 	Size             int64
 	MimeType         string
 	Revision         int64
@@ -54,13 +55,14 @@ const nodeFrom = `nodes AS n
 
 const nodeCols = `n.id, n.parent_id, n.name, n.kind,
 	COALESCE(n.current_version_id, ''), COALESCE(cv.blob_hash, ''),
+	COALESCE((SELECT md5 FROM blob_checksums WHERE blob_sha256=cv.blob_hash), ''),
 	COALESCE(cv.size, 0), COALESCE(cv.mime_type, ''),
 	n.revision, n.created_at, n.modified_at, n.trashed_at`
 
 func scanNode(row interface{ Scan(args ...any) error }) (Node, error) {
 	var n Node
 	err := row.Scan(&n.ID, &n.ParentID, &n.Name, &n.Kind,
-		&n.CurrentVersionID, &n.BlobHash, &n.Size, &n.MimeType,
+		&n.CurrentVersionID, &n.BlobHash, &n.MD5, &n.Size, &n.MimeType,
 		&n.Revision, &n.CreatedAt, &n.ModifiedAt, &n.TrashedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Node{}, ErrNotFound

--- a/internal/store/pack_catalog.go
+++ b/internal/store/pack_catalog.go
@@ -468,6 +468,11 @@ func (s *Store) RepairBlobAuthority(
 			return fmt.Errorf("blob %s: recorded size %d does not match repaired size %d",
 				hash, recordedSize, size)
 		}
+		if err := ensureBlobChecksumTx(tx, BlobChecksumRecord{
+			BlobSHA256: hash, MD5: storage.MD5,
+		}); err != nil {
+			return err
+		}
 		if err := tx.QueryRowContext(ctx,
 			`SELECT COUNT(*) FROM content_versions WHERE blob_hash = ?`, hash,
 		).Scan(&references); err != nil {

--- a/internal/store/pack_catalog_test.go
+++ b/internal/store/pack_catalog_test.go
@@ -211,7 +211,8 @@ func TestRepairBlobAuthorityPreservesReferences(t *testing.T) {
 	assert.Equal(t, "packed", physical.Kind)
 
 	references, err := s.RepairBlobAuthority(ctx, hash, 20,
-		BlobPhysical{Encoding: "zstd", StoredBytes: 8, PackEligible: true})
+		BlobPhysical{Encoding: "zstd", StoredBytes: 8, PackEligible: true,
+			MD5: "f6fdffe48c908deb0f4c3bd36c032e72"})
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), references)
 	physical, err = s.PhysicalContent(ctx, hash)
@@ -229,6 +230,9 @@ func TestRepairBlobAuthorityPreservesReferences(t *testing.T) {
 	require.NoError(t, s.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM blob_pack_entries WHERE blob_hash = ?`, hash).Scan(&mappings))
 	assert.Zero(t, mappings)
+	checksum, err := s.BlobChecksums(ctx, hash)
+	require.NoError(t, err)
+	assert.Equal(t, "f6fdffe48c908deb0f4c3bd36c032e72", checksum.MD5)
 }
 
 func TestRepairBlobAuthorityRequiresExistingMembership(t *testing.T) {

--- a/internal/store/physical_storage.go
+++ b/internal/store/physical_storage.go
@@ -46,6 +46,9 @@ type BlobPhysical struct {
 	Encoding     string
 	StoredBytes  int64
 	PackEligible bool
+	// MD5 is an auxiliary digest computed from the exact logical bytes in the
+	// same streaming pass as the authoritative SHA-256 write.
+	MD5 string
 	// Created proves this write published a new, fully hashed canonical loose
 	// representation rather than deduplicating an existing file by type and size.
 	Created bool
@@ -59,6 +62,11 @@ func normalizeBlobPhysical(size int64, physical []BlobPhysical) (BlobPhysical, e
 		return BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: size, PackEligible: size <= maxPackEligibleBytes}, nil
 	}
 	result := physical[0]
+	if result.MD5 != "" {
+		if err := validateAuxiliaryMD5(result.MD5); err != nil {
+			return BlobPhysical{}, err
+		}
+	}
 	if result.Encoding != looseEncodingRaw && result.Encoding != looseEncodingZstd {
 		return BlobPhysical{}, fmt.Errorf("invalid loose encoding %q", result.Encoding)
 	}

--- a/internal/store/processing_catalog.go
+++ b/internal/store/processing_catalog.go
@@ -310,7 +310,7 @@ func stageRenditionBuildTx(
 		if loadErr != nil {
 			return loadErr
 		}
-		if !reflect.DeepEqual(stored, normalized) {
+		if !renditionBuildDeclarationEqual(stored, normalized) {
 			return fmt.Errorf("rendition build %s names different immutable metadata", normalized.ID)
 		}
 		return validateRenditionBuildStateTx(ctx, tx, normalized.ID)
@@ -319,6 +319,19 @@ func stageRenditionBuildTx(
 		return err
 	}
 	return validateRenditionBuildStateTx(ctx, tx, normalized.ID)
+}
+
+func renditionBuildDeclarationEqual(first, second RenditionBuildRecord) bool {
+	// MD5 is hydrated from the blob checksum catalog after publication. It is
+	// not part of the immutable rendition build declaration.
+	clearDerivedMD5 := func(record RenditionBuildRecord) RenditionBuildRecord {
+		record.Artifacts = append([]RenditionArtifactRecord(nil), record.Artifacts...)
+		for index := range record.Artifacts {
+			record.Artifacts[index].MD5 = ""
+		}
+		return record
+	}
+	return reflect.DeepEqual(clearDerivedMD5(first), clearDerivedMD5(second))
 }
 
 func validateRenditionArtifactRolesForProfile(

--- a/internal/store/processing_catalog.go
+++ b/internal/store/processing_catalog.go
@@ -100,6 +100,7 @@ type RenditionArtifactRecord struct {
 	ID       string
 	Role     string
 	BlobHash string
+	MD5      string
 	Size     int64
 	Checksum string
 	State    RenditionArtifactState
@@ -943,8 +944,10 @@ func loadRenditionBuild(ctx context.Context, tx metadataQuerier, buildID string)
 	}
 	record.Artifacts = make([]RenditionArtifactRecord, 0, record.DeclaredArtifactCount)
 	rows, err := tx.QueryContext(ctx, `
-		SELECT artifact_id,role,blob_hash,size,checksum,state
-		FROM rendition_artifacts WHERE build_id=? ORDER BY artifact_id`, buildID)
+		SELECT a.artifact_id,a.role,a.blob_hash,COALESCE(c.md5,''),a.size,a.checksum,a.state
+		FROM rendition_artifacts a
+		LEFT JOIN blob_checksums c ON c.blob_sha256=a.blob_hash
+		WHERE a.build_id=? ORDER BY a.artifact_id`, buildID)
 	if err != nil {
 		return RenditionBuildRecord{}, err
 	}
@@ -954,7 +957,7 @@ func loadRenditionBuild(ctx context.Context, tx metadataQuerier, buildID string)
 			return RenditionBuildRecord{}, fmt.Errorf("rendition build %s exceeds artifact limit", buildID)
 		}
 		var artifact RenditionArtifactRecord
-		if err := rows.Scan(&artifact.ID, &artifact.Role, &artifact.BlobHash,
+		if err := rows.Scan(&artifact.ID, &artifact.Role, &artifact.BlobHash, &artifact.MD5,
 			&artifact.Size, &artifact.Checksum, &artifact.State); err != nil {
 			_ = rows.Close()
 			return RenditionBuildRecord{}, err

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -472,6 +472,19 @@ CREATE TABLE IF NOT EXISTS blobs (
     created_at TEXT NOT NULL
 );
 
+-- MD5 is auxiliary interoperability metadata over the same exact logical
+-- bytes. SHA-256 remains the sole content identity and authority.
+CREATE TABLE IF NOT EXISTS blob_checksums (
+    blob_sha256 TEXT PRIMARY KEY REFERENCES blobs(hash) ON DELETE CASCADE,
+    md5         TEXT NOT NULL
+        CHECK (length(md5) = 32 AND md5 NOT GLOB '*[^0-9a-f]*')
+);
+
+CREATE TRIGGER IF NOT EXISTS blob_checksums_immutable_update
+BEFORE UPDATE ON blob_checksums BEGIN
+    SELECT RAISE(ABORT, 'blob checksum records are immutable');
+END;
+
 -- Physical placement authority is store-scoped. The logical blobs table says
 -- which content Docbank retains; these rows say where verified bytes live.
 -- Lifecycle and placement policy stay in Go.

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -530,6 +530,7 @@ func (s *Store) taggedNodes(
 		  SELECT n.id AS id, n.parent_id AS parent_id, n.name AS name, n.kind AS kind,
 		         COALESCE(n.current_version_id, '') AS current_version_id,
 		         COALESCE(cv.blob_hash, '') AS blob_hash,
+		         COALESCE((SELECT md5 FROM blob_checksums WHERE blob_sha256=cv.blob_hash), '') AS md5,
 		         COALESCE(cv.size, 0) AS size, COALESCE(cv.mime_type, '') AS mime_type,
 		         n.revision AS revision, n.created_at AS created_at,
 		         n.modified_at AS modified_at, n.trashed_at AS trashed_at
@@ -555,7 +556,7 @@ func (s *Store) taggedNodes(
 		SELECT totals.total, totals.live_total, COALESCE(page.id, 0), page.parent_id,
 		       COALESCE(page.name, ''), COALESCE(page.kind, ''),
 		       COALESCE(page.current_version_id, ''), COALESCE(page.blob_hash, ''),
-		       COALESCE(page.size, 0), COALESCE(page.mime_type, ''),
+		       COALESCE(page.md5, ''), COALESCE(page.size, 0), COALESCE(page.mime_type, ''),
 		       COALESCE(page.revision, 0), COALESCE(page.created_at, ''),
 		       COALESCE(page.modified_at, ''), page.trashed_at,
 		       COALESCE(paths.path, '')
@@ -574,7 +575,7 @@ func (s *Store) taggedNodes(
 		var tagged TaggedNode
 		if err := rows.Scan(&assignmentTotal, &liveTotal, &tagged.Node.ID, &tagged.Node.ParentID,
 			&tagged.Node.Name, &tagged.Node.Kind, &tagged.Node.CurrentVersionID,
-			&tagged.Node.BlobHash, &tagged.Node.Size, &tagged.Node.MimeType,
+			&tagged.Node.BlobHash, &tagged.Node.MD5, &tagged.Node.Size, &tagged.Node.MimeType,
 			&tagged.Node.Revision, &tagged.Node.CreatedAt, &tagged.Node.ModifiedAt,
 			&tagged.Node.TrashedAt, &tagged.Path); err != nil {
 			return nil, 0, 0, fmt.Errorf("listing nodes for tag %s: scanning page: %w", tagID, err)

--- a/internal/store/tag_test.go
+++ b/internal/store/tag_test.go
@@ -153,7 +153,9 @@ func TestTagQueriesAreBoundedAndIncludeTrashedNodes(t *testing.T) {
 	require.NotNil(t, nodes[0].Node.TrashedAt)
 	assert.Empty(t, nodes[0].Path)
 
-	live, err := s.Mkdir(ctx, s.RootID(), "live")
+	const liveMD5 = "098f6bcd4621d373cade4e832627b4f6"
+	live, err := s.CreateFile(ctx, s.RootID(), "live.txt", fakeHash("c4"), 4, "text/plain",
+		BlobPhysical{Encoding: "raw", StoredBytes: 4, PackEligible: true, Created: true, MD5: liveMD5})
 	require.NoError(t, err)
 	_, err = s.AssignTag(ctx, first.ID, live.ID, live.Revision)
 	require.NoError(t, err)
@@ -163,7 +165,8 @@ func TestTagQueriesAreBoundedAndIncludeTrashedNodes(t *testing.T) {
 	assert.Equal(t, 1, omittedTrashed)
 	require.Len(t, liveNodes, 1)
 	assert.Equal(t, live.ID, liveNodes[0].Node.ID)
-	assert.Equal(t, "/live", liveNodes[0].Path)
+	assert.Equal(t, liveMD5, liveNodes[0].Node.MD5)
+	assert.Equal(t, "/live.txt", liveNodes[0].Path)
 
 	_, _, err = s.NodeTags(ctx, 99999, 10, 0)
 	require.ErrorIs(t, err, ErrNotFound)

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -16,6 +16,7 @@ type ContentVersion struct {
 	ID                    string
 	NodeID                int64
 	BlobHash              string
+	MD5                   string
 	Size                  int64
 	MimeType              string
 	RecordedAt            string
@@ -32,13 +33,14 @@ type ContentVersionView struct {
 	Version ContentVersion
 }
 
-const contentVersionCols = `version_id, node_id, blob_hash, size,
+const contentVersionCols = `version_id, node_id, blob_hash,
+	COALESCE((SELECT md5 FROM blob_checksums WHERE blob_sha256=content_versions.blob_hash), ''), size,
 	COALESCE(mime_type, ''), recorded_at, node_revision,
 	introduced_operation_id, transition_kind, source_version_id`
 
 func scanContentVersion(row interface{ Scan(args ...any) error }) (ContentVersion, error) {
 	var v ContentVersion
-	err := row.Scan(&v.ID, &v.NodeID, &v.BlobHash, &v.Size, &v.MimeType,
+	err := row.Scan(&v.ID, &v.NodeID, &v.BlobHash, &v.MD5, &v.Size, &v.MimeType,
 		&v.RecordedAt, &v.NodeRevision, &v.IntroducedOperationID,
 		&v.TransitionKind, &v.SourceVersionID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -126,7 +128,9 @@ func (s *Store) ContentVersions(
 		 )
 		 SELECT target.kind, totals.total,
 		        COALESCE(page.version_id, ''), COALESCE(page.node_id, 0),
-		        COALESCE(page.blob_hash, ''), COALESCE(page.size, 0),
+		        COALESCE(page.blob_hash, ''),
+		        COALESCE((SELECT md5 FROM blob_checksums WHERE blob_sha256=page.blob_hash), ''),
+		        COALESCE(page.size, 0),
 		        COALESCE(page.mime_type, ''), COALESCE(page.recorded_at, ''),
 		        COALESCE(page.node_revision, 0),
 		        COALESCE(page.introduced_operation_id, ''),
@@ -145,7 +149,7 @@ func (s *Store) ContentVersions(
 		found = true
 		var kind string
 		var v ContentVersion
-		if err := rows.Scan(&kind, &total, &v.ID, &v.NodeID, &v.BlobHash, &v.Size,
+		if err := rows.Scan(&kind, &total, &v.ID, &v.NodeID, &v.BlobHash, &v.MD5, &v.Size,
 			&v.MimeType, &v.RecordedAt, &v.NodeRevision, &v.IntroducedOperationID,
 			&v.TransitionKind, &v.SourceVersionID); err != nil {
 			return nil, 0, fmt.Errorf("listing content versions of node %d: scanning page: %w", nodeID, err)

--- a/internal/store/walk.go
+++ b/internal/store/walk.go
@@ -226,7 +226,7 @@ func (w *Walker) popFrontier(ctx context.Context) (WalkEntry, int, error) {
 		LIMIT 1`,
 	).Scan(&entry.Path, &depth,
 		&entry.Node.ID, &entry.Node.ParentID, &entry.Node.Name, &entry.Node.Kind,
-		&entry.Node.CurrentVersionID, &entry.Node.BlobHash, &entry.Node.Size,
+		&entry.Node.CurrentVersionID, &entry.Node.BlobHash, &entry.Node.MD5, &entry.Node.Size,
 		&entry.Node.MimeType, &entry.Node.Revision, &entry.Node.CreatedAt,
 		&entry.Node.ModifiedAt, &entry.Node.TrashedAt,
 	)

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -256,6 +256,11 @@ func (s *Store) EnsureBlobTx(tx *sql.Tx, hash string, size int64, physical ...Bl
 	if err != nil {
 		return fmt.Errorf("checking blob %s insertion: %w", hash, err)
 	}
+	if err := ensureBlobChecksumTx(tx, BlobChecksumRecord{
+		BlobSHA256: hash, MD5: storage.MD5,
+	}); err != nil {
+		return err
+	}
 	if inserted != 0 {
 		return writeLooseLocationTx(
 			context.Background(), tx, s.primaryStoreID, hash, storage,

--- a/types.go
+++ b/types.go
@@ -23,6 +23,7 @@ type Node struct {
 	Kind             string  `json:"kind"`
 	CurrentVersionID string  `json:"current_version_id,omitzero"`
 	BlobHash         string  `json:"blob_hash,omitzero"`
+	MD5              string  `json:"md5,omitzero"`
 	Size             int64   `json:"size"`
 	MediaType        string  `json:"media_type,omitzero"`
 	Revision         int64   `json:"revision"`
@@ -36,6 +37,7 @@ type ContentVersion struct {
 	ID                    string  `json:"id"`
 	NodeID                int64   `json:"node_id"`
 	BlobHash              string  `json:"blob_hash"`
+	MD5                   string  `json:"md5,omitzero"`
 	Size                  int64   `json:"size"`
 	MediaType             string  `json:"media_type,omitzero"`
 	RecordedAt            string  `json:"recorded_at"`
@@ -280,7 +282,7 @@ type VersionContentRange struct {
 func fromStoreNode(node store.Node) Node {
 	return Node{
 		ID: node.ID, ParentID: node.ParentID, Name: node.Name, Kind: node.Kind,
-		CurrentVersionID: node.CurrentVersionID, BlobHash: node.BlobHash,
+		CurrentVersionID: node.CurrentVersionID, BlobHash: node.BlobHash, MD5: node.MD5,
 		Size: node.Size, MediaType: node.MimeType, Revision: node.Revision,
 		CreatedAt: node.CreatedAt, ModifiedAt: node.ModifiedAt, TrashedAt: node.TrashedAt,
 	}
@@ -288,7 +290,7 @@ func fromStoreNode(node store.Node) Node {
 
 func fromStoreVersion(version store.ContentVersion) ContentVersion {
 	return ContentVersion{
-		ID: version.ID, NodeID: version.NodeID, BlobHash: version.BlobHash,
+		ID: version.ID, NodeID: version.NodeID, BlobHash: version.BlobHash, MD5: version.MD5,
 		Size: version.Size, MediaType: version.MimeType, RecordedAt: version.RecordedAt,
 		NodeRevision:          version.NodeRevision,
 		IntroducedOperationID: version.IntroducedOperationID,

--- a/vault.go
+++ b/vault.go
@@ -900,7 +900,7 @@ func blobPhysical(receipt blob.WriteReceipt) (store.BlobPhysical, error) {
 	}
 	return store.BlobPhysical{
 		Encoding: encoding, StoredBytes: receipt.StoredSize,
-		PackEligible: receipt.PackEligible, Created: receipt.Created,
+		PackEligible: receipt.PackEligible, MD5: receipt.MD5, Created: receipt.Created,
 	}, nil
 }
 

--- a/vault_test.go
+++ b/vault_test.go
@@ -3,6 +3,7 @@ package docbank
 import (
 	"bytes"
 	"context"
+	"crypto/md5" //nolint:gosec // Test coverage for explicitly auxiliary interoperability metadata.
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -1344,6 +1345,18 @@ func testEmbeddedVersions(t *testing.T, driver docsqlite.Driver) {
 	require.NoError(err)
 	third, err := vault.Put(ctx, "/notes/entry.md", strings.NewReader("third\n"), PutOptions{})
 	require.NoError(err)
+	firstMD5 := md5.Sum([]byte("first\n"))   //nolint:gosec // Explicit auxiliary-checksum expectation.
+	secondMD5 := md5.Sum([]byte("second\n")) //nolint:gosec // Explicit auxiliary-checksum expectation.
+	thirdMD5 := md5.Sum([]byte("third\n"))   //nolint:gosec // Explicit auxiliary-checksum expectation.
+	wantFirstMD5 := hex.EncodeToString(firstMD5[:])
+	wantSecondMD5 := hex.EncodeToString(secondMD5[:])
+	wantThirdMD5 := hex.EncodeToString(thirdMD5[:])
+	require.Equal(wantFirstMD5, receipt.Node.MD5)
+	require.Equal(wantFirstMD5, receipt.Version.MD5)
+
+	current, err := vault.Stat(ctx, "/notes/entry.md")
+	require.NoError(err)
+	require.Equal(wantThirdMD5, current.MD5)
 
 	page, err := vault.Versions(ctx, receipt.Node.ID, VersionsOptions{Limit: 2})
 	require.NoError(err)
@@ -1354,6 +1367,9 @@ func testEmbeddedVersions(t *testing.T, driver docsqlite.Driver) {
 	require.Equal([]string{third.Version.ID, second.Version.ID}, []string{
 		page.Items[0].ID, page.Items[1].ID,
 	})
+	require.Equal([]string{wantThirdMD5, wantSecondMD5}, []string{
+		page.Items[0].MD5, page.Items[1].MD5,
+	})
 
 	secondPage, err := vault.Versions(ctx, receipt.Node.ID, VersionsOptions{Limit: 2, Offset: 2})
 	require.NoError(err)
@@ -1362,6 +1378,7 @@ func testEmbeddedVersions(t *testing.T, driver docsqlite.Driver) {
 	require.Equal(2, secondPage.Offset)
 	require.Len(secondPage.Items, 1)
 	require.Equal([]string{receipt.Version.ID}, []string{secondPage.Items[0].ID})
+	require.Equal(wantFirstMD5, secondPage.Items[0].MD5)
 
 	defaultPage, err := vault.Versions(ctx, receipt.Node.ID, VersionsOptions{})
 	require.NoError(err)


### PR DESCRIPTION
## What changed

Docbank now records an auxiliary MD5 fingerprint for original documents and retained sanitized Markdown while keeping SHA-256 as the only content identity. New writes calculate both digests in one bounded pass, and node, version, API, client, and CLI detail return MD5 when it is available.

Existing vaults converge through a supervised resumable backfill that reads loose or packed bytes through the verified resolver. Missing, corrupt, or conflicting content stays incomplete instead of publishing an unverified checksum. Backup and restore preserve completed fingerprints in both SQLite implementations.

## Why

Some external document workflows still use MD5 for comparison and reconciliation. We need to expose that compatibility fingerprint without weakening deduplication, authorization, audit, or blob identity.

## Usage

Use the existing node or version detail surfaces, including `docbank stat`, to read MD5 when the backfill has completed. SHA-256 remains authoritative everywhere else; MD5 is comparison metadata only.

Part of #176 (F9). Stacks on #193.
