### PR TITLE
Add a verified local provider for plain-text renditions

### DIFF
--- a/document/plaintext/provider.go
+++ b/document/plaintext/provider.go
@@ -1,0 +1,229 @@
+// Package plaintext implements the bounded in-process UTF-8 rendition provider.
+package plaintext
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+)
+
+const (
+	providerID     = "plaintext.in-process-v1"
+	profileVersion = "docbank-plaintext-profile/v1"
+	timestampForm  = "2006-01-02T15:04:05.000000000Z"
+
+	// MaxDocumentBytes preserves the released bounded plain-text extraction limit.
+	MaxDocumentBytes = int64(16 << 20)
+)
+
+// Profile fixes the maximum exact upload size accepted by one provider instance.
+type Profile struct {
+	MaxDocumentBytes int64
+}
+
+// Provider renders verified UTF-8 bytes without network access.
+type Provider struct {
+	descriptor       document.RenditionDescriptor
+	maxDocumentBytes int64
+}
+
+// New constructs one immutable local provider profile.
+func New(profile Profile) (*Provider, error) {
+	if profile.MaxDocumentBytes <= 0 || profile.MaxDocumentBytes > MaxDocumentBytes {
+		return nil, fmt.Errorf("plaintext: max document bytes must be between 1 and %d", MaxDocumentBytes)
+	}
+	policyDigest := sha256.Sum256([]byte(profileVersion + "\x00" +
+		strconv.FormatInt(profile.MaxDocumentBytes, 10)))
+	descriptor, err := document.NewRenditionDescriptor(document.RenditionDescriptor{
+		ID:                providerID,
+		ContractVersion:   document.RenditionProviderContractVersion,
+		PolicyFingerprint: hex.EncodeToString(policyDigest[:]),
+		TrustBoundary:     document.RenditionTrustLocalProcess,
+		SupportedFormats:  supportedFormats(),
+		ReturnsStructured: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("plaintext: construct descriptor: %w", err)
+	}
+	return &Provider{descriptor: cloneDescriptor(descriptor), maxDocumentBytes: profile.MaxDocumentBytes}, nil
+}
+
+// Descriptor returns the immutable provider identity fixed by the profile.
+func (provider *Provider) Descriptor() document.RenditionDescriptor {
+	if provider == nil {
+		return document.RenditionDescriptor{}
+	}
+	return cloneDescriptor(provider.descriptor)
+}
+
+// Render reads and re-verifies one authorized upload, then emits one exact
+// generic evidence unit. The provider never opens a path or performs I/O
+// beyond the supplied read-once upload.
+func (provider *Provider) Render(
+	ctx context.Context, upload document.AuthorizedUpload,
+	authorization document.RenditionAuthorization,
+) (document.RenditionResult, error) {
+	if provider == nil {
+		return document.RenditionResult{}, errors.New("plaintext: provider is required")
+	}
+	metadata := upload.Metadata()
+	if metadata.ByteLength > provider.maxDocumentBytes {
+		return document.RenditionResult{}, classifiedError(document.RenditionErrorPolicyRejected,
+			"input exceeds the plain-text byte limit", nil)
+	}
+	if err := ctx.Err(); err != nil {
+		return document.RenditionResult{}, classifiedError(document.RenditionErrorCanceled,
+			"plain-text rendering canceled", err)
+	}
+
+	startedAt := time.Now().UTC()
+	data, err := readExact(ctx, upload, metadata.ByteLength, provider.maxDocumentBytes)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	digest := sha256.Sum256(data)
+	if hex.EncodeToString(digest[:]) != metadata.SHA256 {
+		return document.RenditionResult{}, classifiedError(document.RenditionErrorPolicyRejected,
+			"authorized upload identity mismatch", nil)
+	}
+	if !utf8.Valid(data) || bytes.IndexByte(data, 0) >= 0 {
+		return document.RenditionResult{}, classifiedError(document.RenditionErrorUnsupportedInput,
+			"input is not UTF-8 plain text", nil)
+	}
+	completedAt := time.Now().UTC()
+	authorizationFingerprint, err := authorization.Fingerprint()
+	if err != nil {
+		return document.RenditionResult{}, classifiedError(document.RenditionErrorPolicyRejected,
+			"authorization fingerprint is invalid", err)
+	}
+	return document.RenditionResult{
+		Evidence: document.SourceEvidenceV1{
+			ContractVersion: document.SourceEvidenceContractV1,
+			Completeness:    document.EvidenceDegradedProvenance,
+			Family:          authorization.MediaFamily,
+			UnitKind:        document.EvidenceUnitGeneric,
+			Omissions: []document.SourceEvidenceOmissionV1{{
+				Kind: document.EvidenceOmissionField, Field: "natural_provenance",
+				Reason: "plain-text provider emits one generic unit",
+			}},
+			Units: []document.SourceEvidenceUnitV1{{
+				Order: 0, Text: string(data),
+				Locator: document.SourceEvidenceLocatorV1{
+					Kind: document.EvidenceLocatorGeneric, IndexOrigin: document.EvidenceIndexOriginNone,
+				},
+			}},
+		},
+		Receipt: document.RenditionReceipt{
+			ProviderID: provider.descriptor.ID, DescriptorFingerprint: provider.descriptor.Fingerprint,
+			PolicyFingerprint:           authorization.PolicyFingerprint,
+			RenditionRequestFingerprint: authorization.RenditionRequestFingerprint,
+			AuthorizationFingerprint:    authorizationFingerprint,
+			SourceSHA256:                metadata.SHA256,
+			OperationID:                 "plaintext-" + authorization.RenditionRequestFingerprint[:24],
+			StartedAt:                   startedAt.Format(timestampForm), CompletedAt: completedAt.Format(timestampForm),
+			Warnings: []string{"degraded_provenance"},
+			Usage: document.RenditionUsage{
+				Requests: 1, InputBytes: int64(len(data)), OutputBytes: int64(len(data)), Units: 1,
+			},
+		},
+	}, nil
+}
+
+func readExact(
+	ctx context.Context, reader io.Reader, expectedBytes, maxBytes int64,
+) ([]byte, error) {
+	data := make([]byte, 0, expectedBytes)
+	buffer := make([]byte, 32<<10)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, classifiedError(document.RenditionErrorCanceled,
+				"plain-text rendering canceled", err)
+		}
+		read, err := reader.Read(buffer)
+		if read > 0 {
+			if int64(len(data))+int64(read) > maxBytes {
+				return nil, classifiedError(document.RenditionErrorPolicyRejected,
+					"input exceeds the plain-text byte limit", nil)
+			}
+			data = append(data, buffer[:read]...)
+		}
+		switch {
+		case errors.Is(err, io.EOF):
+			if int64(len(data)) != expectedBytes {
+				return nil, classifiedError(document.RenditionErrorPolicyRejected,
+					"authorized upload identity mismatch", nil)
+			}
+			return data, nil
+		case err != nil:
+			if contextErr := ctx.Err(); contextErr != nil {
+				return nil, classifiedError(document.RenditionErrorCanceled,
+					"plain-text rendering canceled", contextErr)
+			}
+			return nil, classifiedError(document.RenditionErrorTransient,
+				"could not read the authorized upload", err)
+		case read == 0:
+			return nil, classifiedError(document.RenditionErrorTransient,
+				"authorized upload stopped making progress", io.ErrNoProgress)
+		}
+	}
+}
+
+func classifiedError(code document.RenditionErrorCode, message string, cause error) error {
+	if cause == nil {
+		cause = errors.New(message)
+	} else {
+		cause = fmt.Errorf("%s: %w", message, cause)
+	}
+	providerError, err := document.NewRenditionProviderError(code, 0, cause)
+	if err != nil {
+		return fmt.Errorf("plaintext: classify provider error: %w", err)
+	}
+	return providerError
+}
+
+func supportedFormats() []document.RenditionFormatCapability {
+	formats := []struct {
+		family    string
+		mediaType string
+	}{
+		{family: "mail", mediaType: "message/rfc822"},
+		{family: "source", mediaType: "text/javascript"},
+		{family: "source", mediaType: "text/x-go"},
+		{family: "source", mediaType: "text/x-python"},
+		{family: "spreadsheet", mediaType: "text/csv"},
+		{family: "structured", mediaType: "application/json"},
+		{family: "structured", mediaType: "application/x-ndjson"},
+		{family: "structured", mediaType: "application/xml"},
+		{family: "structured", mediaType: "application/yaml"},
+		{family: "text", mediaType: "application/x-tex"},
+		{family: "text", mediaType: "text/markdown"},
+		{family: "text", mediaType: "text/plain"},
+		{family: "text", mediaType: "text/x-rst"},
+	}
+	result := make([]document.RenditionFormatCapability, 0, len(formats))
+	for _, format := range formats {
+		result = append(result, document.RenditionFormatCapability{
+			MediaFamily: format.family, MediaType: format.mediaType,
+			InputKind: document.RenditionInputOriginalFile,
+		})
+	}
+	return result
+}
+
+func cloneDescriptor(value document.RenditionDescriptor) document.RenditionDescriptor {
+	value.SupportedFormats = slices.Clone(value.SupportedFormats)
+	value.ArtifactRoles = slices.Clone(value.ArtifactRoles)
+	return value
+}
+
+var _ document.RenditionProvider = (*Provider)(nil)

--- a/document/plaintext/provider_test.go
+++ b/document/plaintext/provider_test.go
@@ -1,0 +1,198 @@
+package plaintext
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+)
+
+func TestProviderRendersExactUTF8AsOneGenericUnit(t *testing.T) {
+	provider, err := New(Profile{MaxDocumentBytes: 1024})
+	require.NoError(t, err)
+	source := []byte("alpha\nβeta\n")
+	upload := newTestUpload(source)
+	authorization := testAuthorization(provider.Descriptor(), upload.Metadata())
+
+	result, err := document.RenderRendition(t.Context(), provider, upload, authorization)
+	require.NoError(t, err)
+	require.Len(t, result.Evidence.Units, 1)
+	assert.Equal(t, string(source), result.Evidence.Units[0].Text)
+	assert.Equal(t, document.EvidenceUnitGeneric, result.Evidence.UnitKind)
+	assert.Equal(t, document.EvidenceLocatorGeneric, result.Evidence.Units[0].Locator.Kind)
+	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+	assert.Equal(t, int64(len(source)), result.Receipt.Usage.InputBytes)
+	assert.Equal(t, authorization.SourceSHA256, result.Receipt.SourceSHA256)
+
+	policy, err := document.NewEvidencePolicy(1024)
+	require.NoError(t, err)
+	normalized, err := document.NormalizeEvidenceV1(result.Evidence, policy)
+	require.NoError(t, err)
+	_, checksum, err := document.MarshalNormalizedEvidenceV1(normalized)
+	require.NoError(t, err)
+	assert.Equal(t, "unit_2bd7c59368d78ac033cd5ca2b3cf879c4023c4564f5b4f3b05548f3414e4271f",
+		normalized.Units[0].ID)
+	assert.Equal(t, "a7242bb9ba14c427bfafabdc43e8171ea58c839d7bfec2f26ec802c7406939c7", checksum)
+}
+
+func TestProviderRejectsInvalidUTF8AndNUL(t *testing.T) {
+	provider, err := New(Profile{MaxDocumentBytes: 1024})
+	require.NoError(t, err)
+	for _, testCase := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "invalid UTF-8", data: []byte{0xff, 0xfe}},
+		{name: "NUL", data: []byte("alpha\x00beta")},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			upload := newTestUpload(testCase.data)
+			_, err := provider.Render(t.Context(), upload,
+				testAuthorization(provider.Descriptor(), upload.Metadata()))
+			require.Error(t, err)
+			providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
+			require.True(t, ok)
+			assert.Equal(t, document.RenditionErrorUnsupportedInput, providerErr.Code())
+		})
+	}
+}
+
+func TestProviderRejectsEmptyInputBeforeReading(t *testing.T) {
+	provider, err := New(Profile{MaxDocumentBytes: 1024})
+	require.NoError(t, err)
+	upload := newTestUpload(nil)
+	authorization := testAuthorization(provider.Descriptor(), upload.Metadata())
+
+	_, err = document.RenderRendition(t.Context(), provider, upload, authorization)
+	require.ErrorContains(t, err, "byte length")
+	assert.Zero(t, upload.reads)
+}
+
+func TestProviderEnforcesProfileSizeBeforeReading(t *testing.T) {
+	provider, err := New(Profile{MaxDocumentBytes: 4})
+	require.NoError(t, err)
+	upload := newTestUpload([]byte("alpha"))
+
+	_, err = provider.Render(t.Context(), upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	require.Error(t, err)
+	providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
+	require.True(t, ok)
+	assert.Equal(t, document.RenditionErrorPolicyRejected, providerErr.Code())
+	assert.Zero(t, upload.reads)
+}
+
+func TestProviderHonorsCancellationBeforeReading(t *testing.T) {
+	provider, err := New(Profile{MaxDocumentBytes: 1024})
+	require.NoError(t, err)
+	upload := newTestUpload([]byte("alpha"))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = provider.Render(ctx, upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	require.ErrorIs(t, err, context.Canceled)
+	providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
+	require.True(t, ok)
+	assert.Equal(t, document.RenditionErrorCanceled, providerErr.Code())
+	assert.Zero(t, upload.reads)
+}
+
+func TestProviderRejectsUploadByteSubstitution(t *testing.T) {
+	provider, err := New(Profile{MaxDocumentBytes: 1024})
+	require.NoError(t, err)
+	upload := newTestUpload([]byte("omega"))
+	metadata := upload.Metadata()
+	want := sha256.Sum256([]byte("alpha"))
+	metadata.SHA256 = hex.EncodeToString(want[:])
+	upload.metadata = metadata
+
+	_, err = provider.Render(t.Context(), upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	require.Error(t, err)
+	providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
+	require.True(t, ok)
+	assert.Equal(t, document.RenditionErrorPolicyRejected, providerErr.Code())
+}
+
+func TestNewRejectsInvalidBoundsAndDescriptorIsImmutable(t *testing.T) {
+	_, err := New(Profile{})
+	require.ErrorContains(t, err, "max document bytes")
+	_, err = New(Profile{MaxDocumentBytes: MaxDocumentBytes + 1})
+	require.ErrorContains(t, err, "max document bytes")
+
+	provider, err := New(Profile{MaxDocumentBytes: 1024})
+	require.NoError(t, err)
+	descriptor := provider.Descriptor()
+	assert.Equal(t, document.RenditionTrustLocalProcess, descriptor.TrustBoundary)
+	assert.True(t, descriptor.ReturnsStructured)
+	assert.False(t, descriptor.ReturnsMarkdown)
+	require.NotEmpty(t, descriptor.SupportedFormats)
+	descriptor.SupportedFormats[0].MediaType = "application/pdf"
+	assert.NotEqual(t, descriptor.SupportedFormats, provider.Descriptor().SupportedFormats)
+}
+
+type testUpload struct {
+	reader   *bytes.Reader
+	metadata document.AuthorizedUploadMetadata
+	reads    int
+}
+
+func newTestUpload(data []byte) *testUpload {
+	digest := sha256.Sum256(data)
+	return &testUpload{
+		reader: bytes.NewReader(data),
+		metadata: document.AuthorizedUploadMetadata{
+			Filename: "notes.txt", MediaFamily: "text", MediaType: "text/plain",
+			ByteLength: int64(len(data)), SHA256: hex.EncodeToString(digest[:]),
+			CapabilityRecordChecksum: strings.Repeat("2", 64),
+			ProviderMetadataChecksum: strings.Repeat("3", 64),
+			InputKind:                document.RenditionInputOriginalFile,
+		},
+	}
+}
+
+func (upload *testUpload) Read(buffer []byte) (int, error) {
+	upload.reads++
+	read, err := upload.reader.Read(buffer)
+	if err != nil {
+		return read, fmt.Errorf("read test upload: %w", err)
+	}
+	return read, nil
+}
+
+func (*testUpload) Close() error { return nil }
+
+func (upload *testUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+var _ document.AuthorizedUpload = (*testUpload)(nil)
+var _ io.ReadCloser = (*testUpload)(nil)
+
+func testAuthorization(
+	descriptor document.RenditionDescriptor, metadata document.AuthorizedUploadMetadata,
+) document.RenditionAuthorization {
+	started := time.Now().UTC().Add(-time.Minute)
+	return document.RenditionAuthorization{
+		ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+		PolicyFingerprint:           descriptor.PolicyFingerprint,
+		RenditionRequestFingerprint: strings.Repeat("4", 64),
+		SourceSHA256:                metadata.SHA256, SourceBytes: metadata.ByteLength,
+		CapabilityRecordChecksum: metadata.CapabilityRecordChecksum,
+		ProviderMetadataChecksum: metadata.ProviderMetadataChecksum,
+		MediaFamily:              metadata.MediaFamily, MediaType: metadata.MediaType,
+		InputKind: metadata.InputKind, MaxTotalResultBytes: 1 << 20,
+		AuthorizedAt: started.Format("2006-01-02T15:04:05.000000000Z"),
+		ExpiresAt:    started.Add(10 * time.Minute).Format("2006-01-02T15:04:05.000000000Z"),
+	}
+}


### PR DESCRIPTION
## What changed

Docbank now has a private in-process rendition provider for authorized UTF-8 files. It rereads the supplied bytes, verifies their exact length and SHA-256, and emits one stable provider-neutral evidence unit under an explicit 16 MiB profile cap.

Empty input, invalid UTF-8, NUL bytes, cancellation, oversize input, and byte substitution all fail closed. The provider has no network client, credential binding, hosted consent, retained artifact, or filesystem reopen path.

## Why

Plain text should not need a hosted provider or an ambient filesystem path. It still needs the same exact-byte and evidence authority as every other rendition path so local processing cannot become a privileged shortcut.

## Usage

For library use, construct the provider with `plaintext.New(profile)` and call it through `document.RenditionProvider` with an authorized UTF-8 upload.

This PR does not add daemon, API, or CLI selection. The S1–S3 application-surface work will build the process-local runtime registration around this provider.

Part of #176 (R6). Stacks on #195.
