### PR TITLE
[F10–E12 04/25] Add the Datalab Convert rendition provider

### DIFF
--- a/document/bridge/client.go
+++ b/document/bridge/client.go
@@ -93,12 +93,9 @@ func New(profile Profile, secrets SecretResolver, httpClient *http.Client) (*Cli
 		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maxBridgeResponseBytes {
 		return nil, errors.New("bridge: execution bounds are invalid")
 	}
-	isolatedHTTP := *httpClient
-	isolatedHTTP.CheckRedirect = providerhttp.RefuseRedirects
-	isolatedHTTP.Jar = nil
 	return &Client{
 		origin: origin, descriptor: cloneDescriptor(descriptor),
-		secretBinding: profile.SecretBinding, secrets: secrets, http: &isolatedHTTP,
+		secretBinding: profile.SecretBinding, secrets: secrets, http: providerhttp.IsolateClient(httpClient),
 		requestTimeout: profile.RequestTimeout, totalTimeout: profile.TotalTimeout,
 		pollInterval: profile.PollInterval, maxPollAttempts: profile.MaxPollAttempts,
 		maxResponseBytes: profile.MaxResponseBytes,

--- a/document/datalab/client.go
+++ b/document/datalab/client.go
@@ -1,0 +1,939 @@
+// Package datalab implements the fixed uploaded-file Datalab Convert flow.
+package datalab
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	xhtml "golang.org/x/net/html"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	providerID  = "datalab.convert-v1"
+	convertPath = "/api/v1/convert"
+
+	defaultRequestTimeout   = 30 * time.Second
+	defaultTotalTimeout     = 10 * time.Minute
+	defaultPollInterval     = 2 * time.Second
+	defaultMaxPollAttempts  = 300
+	defaultMaxResponseBytes = int64(64 << 20)
+	defaultMaxDocumentBytes = int64(200 << 20)
+	maxTimeout              = 24 * time.Hour
+	maxPollAttempts         = 10_000
+	maxResponseBytes        = int64(512 << 20)
+	maxDocumentBytes        = int64(200 << 20)
+	maxSecretBytes          = 64 << 10
+	maxRequestIDBytes       = 120
+	timestampForm           = "2006-01-02T15:04:05.000000000Z"
+)
+
+var (
+	_                      document.RenditionProvider = (*Client)(nil)
+	errDatalabTotalTimeout                            = errors.New("datalab total timeout")
+)
+
+// SecretResolver resolves the one profile-bound Datalab API-key binding.
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, name string) (string, error)
+}
+
+// Profile fixes one Datalab origin, descriptor, credential, conversion mode,
+// optional provider-version snapshot, and every network/result bound.
+type Profile struct {
+	Origin           string
+	Descriptor       document.RenditionDescriptor
+	SecretBinding    string
+	Mode             string
+	ExpectedVersions json.RawMessage
+	RequestTimeout   time.Duration
+	TotalTimeout     time.Duration
+	PollInterval     time.Duration
+	MaxPollAttempts  int
+	MaxResponseBytes int64
+	MaxDocumentBytes int64
+}
+
+// Client renders exact authorized uploads through fixed Datalab Convert routes.
+type Client struct {
+	origin                      string
+	descriptor                  document.RenditionDescriptor
+	secretBinding               string
+	secrets                     SecretResolver
+	http                        *http.Client
+	mode                        string
+	expectedVersionsFingerprint string
+	requestTimeout              time.Duration
+	totalTimeout                time.Duration
+	pollInterval                time.Duration
+	maxPollAttempts             int
+	maxResponseBytes            int64
+	maxDocumentBytes            int64
+}
+
+type requestUsage struct {
+	requests    int64
+	retries     int64
+	outputBytes int64
+}
+
+type versionState struct {
+	expected string
+	observed string
+}
+
+// New validates a fixed hosted profile and isolates the supplied HTTP client
+// from ambient cookies and redirect behavior.
+func New(profile Profile, secrets SecretResolver, httpClient *http.Client) (*Client, error) {
+	origin, err := validateOrigin(profile.Origin, profile.Descriptor.TrustBoundary)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, err := document.NewRenditionDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		if err == nil {
+			err = errors.New("descriptor is not canonical")
+		}
+		return nil, fmt.Errorf("datalab: invalid descriptor: %w", err)
+	}
+	if descriptor.ID != providerID {
+		return nil, errors.New("datalab: descriptor ID must be datalab.convert-v1")
+	}
+	if profile.SecretBinding == "" || secrets == nil {
+		return nil, errors.New("datalab: a named secret binding and resolver are required")
+	}
+	if err := validateToken(profile.SecretBinding, "secret binding"); err != nil {
+		return nil, err
+	}
+	if httpClient == nil {
+		return nil, errors.New("datalab: HTTP client is required")
+	}
+	if profile.Mode == "" {
+		profile.Mode = "balanced"
+	}
+	if !slices.Contains([]string{"fast", "balanced", "accurate"}, profile.Mode) {
+		return nil, errors.New("datalab: mode must be fast, balanced, or accurate")
+	}
+	expectedVersionsFingerprint := ""
+	if len(profile.ExpectedVersions) != 0 {
+		expectedVersionsFingerprint, err = versionsFingerprint(profile.ExpectedVersions)
+		if err != nil || expectedVersionsFingerprint == "" {
+			return nil, errors.New("datalab: expected versions must be a non-null JSON object or string")
+		}
+	}
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = defaultRequestTimeout
+	}
+	if profile.TotalTimeout == 0 {
+		profile.TotalTimeout = defaultTotalTimeout
+	}
+	if profile.PollInterval == 0 {
+		profile.PollInterval = defaultPollInterval
+	}
+	if profile.MaxPollAttempts == 0 {
+		profile.MaxPollAttempts = defaultMaxPollAttempts
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = defaultMaxResponseBytes
+	}
+	if profile.MaxDocumentBytes == 0 {
+		profile.MaxDocumentBytes = defaultMaxDocumentBytes
+	}
+	if profile.RequestTimeout <= 0 || profile.RequestTimeout > maxTimeout ||
+		profile.TotalTimeout <= 0 || profile.TotalTimeout > maxTimeout ||
+		profile.PollInterval <= 0 || profile.PollInterval > profile.TotalTimeout ||
+		profile.MaxPollAttempts < 1 || profile.MaxPollAttempts > maxPollAttempts ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maxResponseBytes ||
+		profile.MaxDocumentBytes < 1 || profile.MaxDocumentBytes > maxDocumentBytes {
+		return nil, errors.New("datalab: execution bounds are invalid")
+	}
+	return &Client{
+		origin: origin, descriptor: providerutil.CloneDescriptor(descriptor), secretBinding: profile.SecretBinding,
+		secrets: secrets, http: providerhttp.IsolateClient(httpClient), mode: profile.Mode,
+		expectedVersionsFingerprint: expectedVersionsFingerprint,
+		requestTimeout:              profile.RequestTimeout, totalTimeout: profile.TotalTimeout,
+		pollInterval: profile.PollInterval, maxPollAttempts: profile.MaxPollAttempts,
+		maxResponseBytes: profile.MaxResponseBytes, maxDocumentBytes: profile.MaxDocumentBytes,
+	}, nil
+}
+
+// Descriptor returns an immutable copy of the configured identity.
+func (client *Client) Descriptor() document.RenditionDescriptor {
+	if client == nil {
+		return document.RenditionDescriptor{}
+	}
+	return providerutil.CloneDescriptor(client.descriptor)
+}
+
+// Render verifies sealed bytes before egress, submits them once, and polls only
+// the fixed same-origin route derived from the returned request ID.
+func (client *Client) Render(
+	ctx context.Context, upload document.AuthorizedUpload, authorization document.RenditionAuthorization,
+) (document.RenditionResult, error) {
+	if client == nil {
+		return document.RenditionResult{}, errors.New("datalab: client is required")
+	}
+	metadata := upload.Metadata()
+	if metadata.ByteLength > client.maxDocumentBytes {
+		return document.RenditionResult{}, classifiedError(document.RenditionErrorPolicyRejected,
+			"input exceeds the Datalab byte limit", nil)
+	}
+	expiresAt, err := time.Parse(timestampForm, authorization.ExpiresAt)
+	if err != nil {
+		return document.RenditionResult{}, classifiedError(document.RenditionErrorPolicyRejected,
+			"Datalab authorization expiry is invalid", nil)
+	}
+	totalCtx, cancel := client.operationContext(ctx, expiresAt)
+	defer cancel()
+	if err := checkOperation(totalCtx, expiresAt); err != nil {
+		return document.RenditionResult{}, err
+	}
+	stopInterrupt := context.AfterFunc(totalCtx, func() { _ = document.InterruptAuthorizedUpload(upload) })
+	source, err := providerutil.ReadAuthorizedUpload(totalCtx, upload, metadata, "Datalab")
+	stopInterrupt()
+	if err != nil {
+		if operationErr := checkOperation(totalCtx, expiresAt); operationErr != nil {
+			return document.RenditionResult{}, operationErr
+		}
+		return document.RenditionResult{}, err
+	}
+	started := time.Now().UTC()
+	usage := &requestUsage{}
+	versions := &versionState{expected: client.expectedVersionsFingerprint}
+	includeMarkdown := client.descriptor.ReturnsMarkdown && authorization.MaxProviderMarkdownBytes > 0
+	requestID, err := client.submit(totalCtx, expiresAt, usage, versions, metadata, source, includeMarkdown)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+
+	var result finalResponse
+	for range client.maxPollAttempts {
+		result, err = client.poll(totalCtx, expiresAt, usage, versions, requestID, includeMarkdown,
+			min(client.maxResponseBytes, int64(authorization.MaxTotalResultBytes)))
+		if err != nil {
+			if operationErr := checkOperation(totalCtx, expiresAt); operationErr != nil {
+				return document.RenditionResult{}, knownJobOperationError(operationErr)
+			}
+			if !document.IsRenditionProviderErrorRetryable(err) {
+				return document.RenditionResult{}, err
+			}
+			usage.retries++
+			if waitErr := providerutil.Wait(totalCtx, client.pollInterval); waitErr != nil {
+				if operationErr := checkOperation(totalCtx, expiresAt); operationErr != nil {
+					return document.RenditionResult{}, knownJobOperationError(operationErr)
+				}
+				return document.RenditionResult{}, classifiedError(document.RenditionErrorCanceled,
+					"Datalab rendering canceled", waitErr)
+			}
+			continue
+		}
+		if result.status == "complete" {
+			return client.buildResult(result, requestID, metadata, authorization, source, started, usage, includeMarkdown)
+		}
+		if result.status != "processing" {
+			return document.RenditionResult{}, malformedError("Datalab result status is unsupported", nil)
+		}
+		if waitErr := providerutil.Wait(totalCtx, client.pollInterval); waitErr != nil {
+			if operationErr := checkOperation(totalCtx, expiresAt); operationErr != nil {
+				return document.RenditionResult{}, knownJobOperationError(operationErr)
+			}
+			return document.RenditionResult{}, classifiedError(document.RenditionErrorCanceled,
+				"Datalab rendering canceled", waitErr)
+		}
+	}
+	return document.RenditionResult{}, ambiguousJobError(classifiedError(
+		document.RenditionErrorCapacity, "Datalab polling limit reached", nil))
+}
+
+type initialResponse struct {
+	success  bool
+	id       string
+	versions json.RawMessage
+}
+
+type finalResponse struct {
+	status     string
+	success    *bool
+	markdown   []byte
+	structured json.RawMessage
+	pageCount  int
+	versions   json.RawMessage
+}
+
+func (client *Client) submit(
+	ctx context.Context, expiresAt time.Time, usage *requestUsage, versions *versionState,
+	metadata document.AuthorizedUploadMetadata, source []byte, includeMarkdown bool,
+) (string, error) {
+	filename := metadata.Filename
+	if filename == "" {
+		filename = "document"
+		if extensions, _ := mime.ExtensionsByType(metadata.MediaType); len(extensions) != 0 {
+			filename += extensions[0]
+		}
+	}
+	if strings.ContainsAny(filename, "\r\n") {
+		return "", classifiedError(document.RenditionErrorPolicyRejected,
+			"Datalab upload filename contains a newline", nil)
+	}
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", multipart.FileContentDisposition("file", filename))
+	header.Set("Content-Type", metadata.MediaType)
+	part, err := writer.CreatePart(header)
+	if err != nil {
+		return "", classifiedError(document.RenditionErrorTransient, "could not prepare Datalab upload", err)
+	}
+	if _, err := part.Write(source); err != nil {
+		return "", classifiedError(document.RenditionErrorTransient, "could not prepare Datalab upload", err)
+	}
+	outputFormat := "json"
+	if includeMarkdown {
+		outputFormat = "markdown,json"
+	}
+	for name, value := range map[string]string{
+		"output_format": outputFormat, "mode": client.mode, "paginate": "true", "disable_image_extraction": "true",
+	} {
+		if err := writer.WriteField(name, value); err != nil {
+			return "", classifiedError(document.RenditionErrorTransient, "could not prepare Datalab upload", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return "", classifiedError(document.RenditionErrorTransient, "could not prepare Datalab upload", err)
+	}
+	responseBody, status, err := client.request(ctx, expiresAt, usage, http.MethodPost, convertPath,
+		writer.FormDataContentType(), body.Bytes(), client.maxResponseBytes)
+	if err != nil {
+		if status == http.StatusOK || status == http.StatusAccepted {
+			return "", ambiguousSubmissionError(err)
+		}
+		return "", err
+	}
+	if status != http.StatusOK && status != http.StatusAccepted {
+		err = statusError("submission", status)
+		if status == http.StatusRequestTimeout || status >= http.StatusInternalServerError && status < 600 ||
+			status == http.StatusTooManyRequests {
+			return "", ambiguousSubmissionError(err)
+		}
+		return "", err
+	}
+	initial, err := parseInitial(responseBody)
+	if err != nil {
+		return "", ambiguousSubmissionError(err)
+	}
+	if err := versions.observe(initial.versions); err != nil {
+		return "", ambiguousSubmissionError(err)
+	}
+	return initial.id, nil
+}
+
+func (client *Client) poll(
+	ctx context.Context, expiresAt time.Time, usage *requestUsage, versions *versionState, requestID string,
+	requireMarkdown bool, maxResponseBytes int64,
+) (finalResponse, error) {
+	body, status, err := client.request(ctx, expiresAt, usage, http.MethodGet, convertPath+"/"+requestID,
+		"", nil, maxResponseBytes)
+	if err != nil {
+		return finalResponse{}, err
+	}
+	if status != http.StatusOK && status != http.StatusAccepted {
+		return finalResponse{}, statusError("poll", status)
+	}
+	result, err := parseFinal(body, requireMarkdown)
+	if err != nil {
+		return finalResponse{}, err
+	}
+	if err := versions.observe(result.versions); err != nil {
+		return finalResponse{}, err
+	}
+	return result, nil
+}
+
+func (client *Client) buildResult(
+	result finalResponse, requestID string, metadata document.AuthorizedUploadMetadata,
+	authorization document.RenditionAuthorization, source []byte, started time.Time, usage *requestUsage,
+	includeMarkdown bool,
+) (document.RenditionResult, error) {
+	if result.success == nil || !*result.success {
+		return document.RenditionResult{}, malformedError("Datalab completed without a successful result", nil)
+	}
+	providerMarkdown := result.markdown
+	if !includeMarkdown {
+		providerMarkdown = nil
+	}
+	if providerutil.InjectsDocbankFrontmatter(providerMarkdown) {
+		return document.RenditionResult{}, malformedError(
+			"Datalab provider Markdown attempts Docbank frontmatter injection", nil)
+	}
+	if len(providerMarkdown) > authorization.MaxProviderMarkdownBytes {
+		return document.RenditionResult{}, malformedError("Datalab Markdown exceeds authorization", nil)
+	}
+	evidence, structured, usable := mapEvidence(result.structured, authorization.MediaFamily, result.pageCount)
+	if !usable {
+		if len(providerMarkdown) == 0 {
+			return document.RenditionResult{}, malformedError("Datalab result has no usable bounded evidence", nil)
+		}
+		evidence = providerutil.DegradedEvidence(authorization.MediaFamily, string(providerMarkdown),
+			"Datalab structured evidence is unavailable")
+		structured = nil
+	}
+	artifacts := make([]document.RenditionArtifact, 0, 1)
+	if len(structured) != 0 && providerutil.AllowsStructured(authorization) {
+		if len(structured) > authorization.MaxArtifactBytes {
+			return document.RenditionResult{}, malformedError("Datalab structured output exceeds authorization", nil)
+		}
+		digest := providerutil.SHA256Hex(structured)
+		artifacts = append(artifacts, document.RenditionArtifact{
+			Role: document.EvidenceArtifactStructured, MediaType: "application/json", Payload: append([]byte(nil), structured...), SHA256: digest,
+		})
+		evidence.Artifacts = []document.SourceEvidenceArtifactV1{{
+			ProviderID: "datalab-document", Pointer: "json", Role: document.EvidenceArtifactStructured, SHA256: digest,
+		}}
+	}
+	completed := time.Now().UTC()
+	authorizationFingerprint, err := authorization.Fingerprint()
+	if err != nil {
+		return document.RenditionResult{}, classifiedError(document.RenditionErrorPolicyRejected,
+			"authorization fingerprint is invalid", err)
+	}
+	return document.RenditionResult{
+		Evidence: evidence, ProviderMarkdown: append([]byte(nil), providerMarkdown...), Artifacts: artifacts,
+		Receipt: document.RenditionReceipt{
+			ProviderID: client.descriptor.ID, DescriptorFingerprint: client.descriptor.Fingerprint,
+			PolicyFingerprint:           authorization.PolicyFingerprint,
+			RenditionRequestFingerprint: authorization.RenditionRequestFingerprint,
+			AuthorizationFingerprint:    authorizationFingerprint,
+			SourceSHA256:                metadata.SHA256,
+			OperationID:                 "datalab-" + requestID, StartedAt: started.Format(timestampForm), CompletedAt: completed.Format(timestampForm),
+			Usage: document.RenditionUsage{
+				Requests: usage.requests, Retries: usage.retries, InputBytes: int64(len(source)),
+				OutputBytes: usage.outputBytes, Units: int64(len(evidence.Units)),
+			},
+		},
+	}, nil
+}
+
+func (client *Client) request(
+	ctx context.Context, expiresAt time.Time, usage *requestUsage, method, path, contentType string,
+	body []byte, maxResponseBytes int64,
+) ([]byte, int, error) {
+	if err := checkOperation(ctx, expiresAt); err != nil {
+		return nil, 0, err
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(requestCtx, method, client.origin+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, classifiedError(document.RenditionErrorTransient, "could not create Datalab request", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	if contentType != "" {
+		request.Header.Set("Content-Type", contentType)
+	}
+	if err := client.authorize(request); err != nil {
+		return nil, 0, err
+	}
+	if err := checkOperation(ctx, expiresAt); err != nil {
+		return nil, 0, err
+	}
+	usage.requests++
+	response, err := client.http.Do(request)
+	if err != nil {
+		requestErr := checkOperation(ctx, expiresAt)
+		if requestErr == nil {
+			requestErr = classifiedError(document.RenditionErrorTransient, "Datalab request failed", err)
+		}
+		if method == http.MethodPost {
+			requestErr = ambiguousSubmissionError(requestErr)
+		}
+		return nil, 0, requestErr
+	}
+	defer func() { _ = response.Body.Close() }()
+	responseBody, err := readBounded(response.Body, min(maxResponseBytes, client.maxResponseBytes))
+	usage.outputBytes += int64(len(responseBody))
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return responseBody, response.StatusCode, nil
+	}
+	if err != nil {
+		if operationErr := checkOperation(ctx, expiresAt); operationErr != nil {
+			return nil, response.StatusCode, operationErr
+		}
+		return nil, response.StatusCode, err
+	}
+	mediaType, _, mediaErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if mediaErr != nil || mediaType != "application/json" {
+		return nil, response.StatusCode, malformedError("Datalab response content type is invalid", mediaErr)
+	}
+	if !utf8.Valid(responseBody) {
+		return nil, response.StatusCode, malformedError("Datalab response JSON is not valid UTF-8", nil)
+	}
+	return responseBody, response.StatusCode, nil
+}
+
+func (client *Client) authorize(request *http.Request) error {
+	secret, err := client.secrets.ResolveSecret(request.Context(), client.secretBinding)
+	if err != nil {
+		return classifiedError(document.RenditionErrorAuthentication, "Datalab credential is unavailable", err)
+	}
+	if secret == "" || len(secret) > maxSecretBytes || strings.ContainsAny(secret, "\r\n\x00") {
+		return classifiedError(document.RenditionErrorAuthentication, "Datalab credential is invalid", nil)
+	}
+	request.Header.Set("X-Api-Key", secret)
+	return nil
+}
+
+func parseInitial(body []byte) (initialResponse, error) {
+	var wire struct {
+		Success         *bool           `json:"success"`
+		RequestID       string          `json:"request_id"`
+		RequestCheckURL string          `json:"request_check_url"`
+		Versions        json.RawMessage `json:"versions"`
+	}
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return initialResponse{}, malformedError("Datalab submission JSON is invalid", err)
+	}
+	if wire.Success == nil || !*wire.Success {
+		return initialResponse{}, malformedError("Datalab rejected the conversion request", nil)
+	}
+	if err := validateRequestID(wire.RequestID); err != nil {
+		return initialResponse{}, malformedError("Datalab request ID is invalid", err)
+	}
+	if wire.RequestCheckURL == "" || !utf8.ValidString(wire.RequestCheckURL) {
+		return initialResponse{}, malformedError("Datalab request check URL is missing", nil)
+	}
+	return initialResponse{success: true, id: wire.RequestID, versions: cloneRaw(wire.Versions)}, nil
+}
+
+func parseFinal(body []byte, requireMarkdown bool) (finalResponse, error) {
+	var wire struct {
+		Status       string          `json:"status"`
+		Success      *bool           `json:"success"`
+		OutputFormat string          `json:"output_format"`
+		Markdown     *string         `json:"markdown"`
+		JSON         json.RawMessage `json:"json"`
+		PageCount    *int            `json:"page_count"`
+		Versions     json.RawMessage `json:"versions"`
+	}
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return finalResponse{}, malformedError("Datalab result JSON is invalid", err)
+	}
+	if wire.Status != "processing" && wire.Status != "complete" && wire.Status != "failed" {
+		return finalResponse{}, malformedError("Datalab result status is unsupported", nil)
+	}
+	if wire.Status == "failed" {
+		return finalResponse{}, malformedError("Datalab conversion failed", nil)
+	}
+	if wire.PageCount != nil && *wire.PageCount < 0 {
+		return finalResponse{}, malformedError("Datalab page count is invalid", nil)
+	}
+	if requireMarkdown && wire.OutputFormat != "" && !containsOutputFormat(wire.OutputFormat, "markdown") {
+		return finalResponse{}, malformedError("Datalab result omitted requested Markdown format", nil)
+	}
+	structured, err := decodeStructured(wire.JSON)
+	if err != nil {
+		return finalResponse{}, malformedError("Datalab structured result is invalid", err)
+	}
+	result := finalResponse{status: wire.Status, success: wire.Success, structured: structured, versions: cloneRaw(wire.Versions)}
+	if wire.Markdown != nil {
+		result.markdown = []byte(*wire.Markdown)
+	}
+	if wire.PageCount != nil {
+		result.pageCount = *wire.PageCount
+	}
+	return result, nil
+}
+
+func mapEvidence(raw json.RawMessage, family string, pageCount int) (document.SourceEvidenceV1, []byte, bool) {
+	if len(raw) == 0 {
+		return document.SourceEvidenceV1{}, nil, false
+	}
+	var root markerNode
+	if json.Unmarshal(raw, &root) != nil || root.BlockType != "Document" || len(root.Children) == 0 {
+		return document.SourceEvidenceV1{}, nil, false
+	}
+	kind, locatorKind, natural := familyUnit(family)
+	if !natural {
+		return document.SourceEvidenceV1{}, nil, false
+	}
+	pages := make(map[int]markerNode, len(root.Children))
+	for _, child := range root.Children {
+		if child.BlockType != "Page" {
+			return document.SourceEvidenceV1{}, nil, false
+		}
+		page, ok := pageIndex(child.ID)
+		if !ok {
+			return document.SourceEvidenceV1{}, nil, false
+		}
+		if _, exists := pages[page]; exists {
+			return document.SourceEvidenceV1{}, nil, false
+		}
+		pages[page] = child
+	}
+	if pageCount > 0 && pageCount != len(pages) {
+		return document.SourceEvidenceV1{}, nil, false
+	}
+	evidence := document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1, Completeness: document.EvidenceComplete,
+		Family: family, UnitKind: kind, Units: make([]document.SourceEvidenceUnitV1, 0, len(pages)),
+	}
+	hasMappedText := false
+	hasUnmappedContent := false
+	for index := range len(pages) {
+		page, ok := pages[index]
+		if !ok {
+			return document.SourceEvidenceV1{}, nil, false
+		}
+		text, unmapped, ok := nodeText(page)
+		if !ok {
+			return document.SourceEvidenceV1{}, nil, false
+		}
+		hasUnmappedContent = hasUnmappedContent || unmapped
+		if strings.TrimSpace(text) != "" {
+			hasMappedText = true
+		}
+		evidence.Units = append(evidence.Units, document.SourceEvidenceUnitV1{
+			Order: index, ProviderID: page.ID, Text: text,
+			Locator: document.SourceEvidenceLocatorV1{
+				Kind: locatorKind, IndexOrigin: document.EvidenceIndexOriginZero, Start: int64(index), End: int64(index),
+			},
+		})
+	}
+	if !hasMappedText {
+		return document.SourceEvidenceV1{}, nil, false
+	}
+	if hasUnmappedContent {
+		evidence.Completeness = document.EvidencePartial
+		evidence.Omissions = []document.SourceEvidenceOmissionV1{{
+			Kind: document.EvidenceOmissionField, Field: "structured_blocks",
+			Reason: "Datalab structured content is not fully mapped",
+		}}
+	}
+	return evidence, append([]byte(nil), raw...), true
+}
+
+type markerNode struct {
+	ID        string       `json:"id"`
+	BlockType string       `json:"block_type"`
+	HTML      *string      `json:"html"`
+	Children  []markerNode `json:"children"`
+}
+
+func nodeText(node markerNode) (string, bool, bool) {
+	parts := make([]string, 0)
+	unmapped := false
+	var walk func(markerNode, bool) bool
+	walk = func(current markerNode, page bool) bool {
+		if page {
+			if current.BlockType != "Page" {
+				return false
+			}
+		} else if current.BlockType != "Text" {
+			unmapped = true
+		}
+		if len(current.Children) != 0 {
+			if !page && current.BlockType == "Text" {
+				unmapped = true
+			}
+			for _, child := range current.Children {
+				if !walk(child, false) {
+					return false
+				}
+			}
+			return true
+		}
+		if current.HTML == nil {
+			return page
+		}
+		if page {
+			unmapped = true
+		}
+		text, err := htmlText(*current.HTML)
+		if err != nil {
+			return false
+		}
+		if text != "" {
+			parts = append(parts, text)
+		}
+		return true
+	}
+	if !walk(node, true) {
+		return "", false, false
+	}
+	return strings.Join(parts, "\n\n"), unmapped, true
+}
+
+func htmlText(value string) (string, error) {
+	documentNode, err := xhtml.Parse(strings.NewReader(value))
+	if err != nil {
+		return "", fmt.Errorf("parse Datalab block HTML: %w", err)
+	}
+	parts := make([]string, 0)
+	var walk func(*xhtml.Node, bool)
+	walk = func(node *xhtml.Node, hidden bool) {
+		if node.Type == xhtml.ElementNode && (node.Data == "script" || node.Data == "style") {
+			hidden = true
+		}
+		if node.Type == xhtml.TextNode && !hidden {
+			if text := strings.TrimSpace(node.Data); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child, hidden)
+		}
+	}
+	walk(documentNode, false)
+	return strings.Join(parts, " "), nil
+}
+
+func familyUnit(family string) (document.EvidenceUnitKind, document.EvidenceLocatorKind, bool) {
+	switch family {
+	case "pdf", "image", "word":
+		return document.EvidenceUnitPage, document.EvidenceLocatorPage, true
+	case "presentation":
+		return document.EvidenceUnitSlide, document.EvidenceLocatorSlide, true
+	default:
+		return "", "", false
+	}
+}
+
+func (state *versionState) observe(raw json.RawMessage) error {
+	fingerprint, err := versionsFingerprint(raw)
+	if err != nil {
+		return classifiedError(document.RenditionErrorPolicyRejected, "Datalab provider versions are malformed", err)
+	}
+	if state.expected != "" && fingerprint != state.expected {
+		return classifiedError(document.RenditionErrorPolicyRejected, "Datalab provider version drift detected", nil)
+	}
+	if fingerprint == "" {
+		return nil
+	}
+	if state.observed != "" && fingerprint != state.observed {
+		return classifiedError(document.RenditionErrorPolicyRejected, "Datalab provider version changed during conversion", nil)
+	}
+	state.observed = fingerprint
+	return nil
+}
+
+func versionsFingerprint(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	if decoder.Decode(new(any)) != io.EOF {
+		return "", errors.New("trailing JSON")
+	}
+	switch value.(type) {
+	case map[string]any, string:
+	default:
+		return "", errors.New("versions are not an object or string")
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return providerutil.SHA256Hex(canonical), nil
+}
+
+func decodeStructured(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	if raw[0] == '"' {
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, err
+		}
+		raw = []byte(value)
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	if _, ok := value.(map[string]any); !ok {
+		return nil, errors.New("structured output is not an object")
+	}
+	return append([]byte(nil), raw...), nil
+}
+
+func containsOutputFormat(value, wanted string) bool {
+	for item := range strings.SplitSeq(value, ",") {
+		if strings.TrimSpace(item) == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func pageIndex(value string) (int, bool) {
+	if !strings.HasPrefix(value, "/page/") {
+		return 0, false
+	}
+	rest := strings.TrimPrefix(value, "/page/")
+	indexText, _, ok := strings.Cut(rest, "/")
+	if !ok || indexText == "" {
+		return 0, false
+	}
+	index, err := strconv.Atoi(indexText)
+	return index, err == nil && index >= 0
+}
+
+func (client *Client) operationContext(ctx context.Context, expiresAt time.Time) (context.Context, context.CancelFunc) {
+	totalCtx, cancelTotal := context.WithTimeoutCause(ctx, client.totalTimeout, errDatalabTotalTimeout)
+	operationCtx, cancelExpiry := context.WithDeadline(totalCtx, expiresAt)
+	return operationCtx, func() {
+		cancelExpiry()
+		cancelTotal()
+	}
+}
+
+func checkOperation(ctx context.Context, expiresAt time.Time) error {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return classifiedError(document.RenditionErrorCanceled, "Datalab rendering canceled", ctx.Err())
+	}
+	if !time.Now().Before(expiresAt) {
+		return classifiedError(document.RenditionErrorPolicyRejected, "Datalab authorization expired", nil)
+	}
+	if errors.Is(context.Cause(ctx), errDatalabTotalTimeout) {
+		return classifiedError(document.RenditionErrorCapacity, "Datalab total timeout reached", errDatalabTotalTimeout)
+	}
+	if err := ctx.Err(); err != nil {
+		return classifiedError(document.RenditionErrorCanceled, "Datalab rendering canceled", err)
+	}
+	return nil
+}
+
+func knownJobOperationError(err error) error {
+	if document.IsRenditionProviderErrorRetryable(err) {
+		return ambiguousJobError(err)
+	}
+	return err
+}
+
+func validateOrigin(raw string, trust document.RenditionTrustBoundary) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Opaque != "" ||
+		parsed.ForceQuery || parsed.Fragment != "" || (parsed.Path != "" && parsed.Path != "/") {
+		return "", errors.New("datalab: origin must be one absolute origin without path, credentials, query, or fragment")
+	}
+	if parsed.Scheme != "https" {
+		return "", errors.New("datalab: hosted origins require HTTPS")
+	}
+	if trust != document.RenditionTrustHostedProvider {
+		return "", errors.New("datalab: descriptor trust boundary must be hosted_provider")
+	}
+	return parsed.Scheme + "://" + parsed.Host, nil
+}
+
+func validateToken(value, subject string) error {
+	if value == "" || len(value) > maxRequestIDBytes || value != strings.TrimSpace(value) || !utf8.ValidString(value) {
+		return fmt.Errorf("datalab: %s is invalid", subject)
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '.' && character != '_' && character != '-' {
+			return fmt.Errorf("datalab: %s is invalid", subject)
+		}
+	}
+	return nil
+}
+
+func validateRequestID(value string) error {
+	if value == "" || len(value) > maxRequestIDBytes || value == "." || value == ".." {
+		return errors.New("invalid request ID")
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') && (character < '0' || character > '9') &&
+			character != '_' && character != '-' {
+			return errors.New("invalid request ID")
+		}
+	}
+	return nil
+}
+
+func cloneRaw(value json.RawMessage) json.RawMessage { return append(json.RawMessage(nil), value...) }
+
+func readBounded(reader io.Reader, maximum int64) ([]byte, error) {
+	value, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if err != nil {
+		return value, classifiedError(document.RenditionErrorTransient, "could not read Datalab response", err)
+	}
+	if int64(len(value)) > maximum {
+		return value, malformedError("Datalab response exceeds byte limit", nil)
+	}
+	return value, nil
+}
+
+func statusError(operation string, status int) error {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return classifiedError(document.RenditionErrorAuthentication, "Datalab authentication failed", nil)
+	case http.StatusNotFound, http.StatusGone:
+		if operation == "poll" {
+			return classifiedError(document.RenditionErrorUnknownJob, "Datalab request is unknown or expired", nil)
+		}
+		return malformedError("Datalab returned an unexpected HTTP status", nil)
+	case http.StatusUnsupportedMediaType:
+		if operation == "submission" {
+			return classifiedError(document.RenditionErrorUnsupportedInput, "Datalab does not support the submitted input", nil)
+		}
+		return malformedError("Datalab returned an unexpected HTTP status", nil)
+	case http.StatusRequestEntityTooLarge:
+		if operation == "submission" {
+			return classifiedError(document.RenditionErrorPolicyRejected, "Datalab rejected the input size", nil)
+		}
+		return malformedError("Datalab returned an unexpected HTTP status", nil)
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		if operation == "submission" {
+			return classifiedError(document.RenditionErrorPolicyRejected, "Datalab rejected the submitted input", nil)
+		}
+		return malformedError("Datalab returned an unexpected HTTP status", nil)
+	case http.StatusTooManyRequests:
+		return classifiedError(document.RenditionErrorRateLimited, "Datalab rate limit", nil)
+	case http.StatusServiceUnavailable:
+		return classifiedError(document.RenditionErrorCapacity, "Datalab capacity is temporarily unavailable", nil)
+	case http.StatusRequestTimeout, http.StatusInternalServerError, http.StatusBadGateway, http.StatusGatewayTimeout:
+		return classifiedError(document.RenditionErrorTransient, "Datalab is temporarily unavailable", nil)
+	default:
+		return malformedError("Datalab returned an unexpected HTTP status", nil)
+	}
+}
+
+func ambiguousSubmissionError(cause error) error {
+	return classifiedError(document.RenditionErrorAmbiguousSubmission, "Datalab submission outcome is unknown", cause)
+}
+
+func ambiguousJobError(cause error) error {
+	return classifiedError(document.RenditionErrorAmbiguousSubmission, "Datalab job outcome is unknown", cause)
+}
+
+func malformedError(message string, cause error) error {
+	return classifiedError(document.RenditionErrorMalformedEvidence, message, cause)
+}
+
+func classifiedError(code document.RenditionErrorCode, message string, cause error) error {
+	return providerutil.ClassifiedError("Datalab", code, message, cause)
+}

--- a/document/datalab/client_test.go
+++ b/document/datalab/client_test.go
@@ -1,0 +1,590 @@
+package datalab
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+)
+
+//go:embed testdata/convert-complete.json
+var completeResponse []byte
+
+//go:embed testdata/convert-schema-drift.json
+var driftResponse []byte
+
+type testUpload struct {
+	io.Reader
+
+	metadata document.AuthorizedUploadMetadata
+}
+
+func (*testUpload) Close() error                                       { return nil }
+func (upload *testUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+type testSecrets map[string]string
+
+func (secrets testSecrets) ResolveSecret(_ context.Context, name string) (string, error) {
+	value, ok := secrets[name]
+	if !ok {
+		return "", errors.New("missing test secret")
+	}
+	return value, nil
+}
+
+func TestClientRendersVerifiedPagesThroughFixedRoutes(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	versions := json.RawMessage(`{"marker":"2.1.0","surya":"0.8.0"}`)
+	var polls atomic.Int64
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "synthetic-secret", request.Header.Get("X-Api-Key"))
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == convertPath:
+			assertSubmission(t, request, "document.pdf", fixture.metadata.MediaType, fixture.source, "markdown,json")
+			writeJSON(t, response, map[string]any{
+				"success": true, "request_id": "request-1",
+				"request_check_url": "https://attacker.invalid/check",
+				"versions":          map[string]any{"marker": "2.1.0", "surya": "0.8.0"},
+			})
+		case request.Method == http.MethodGet && request.URL.Path == convertPath+"/request-1":
+			if polls.Add(1) == 1 {
+				writeJSON(t, response, map[string]any{"status": "processing", "versions": map[string]any{"marker": "2.1.0", "surya": "0.8.0"}})
+				return
+			}
+			writeRecordedJSON(t, response, completeResponse)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := newClient(t, server, fixture.descriptor, versions)
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	require.Len(t, result.Evidence.Units, 2)
+	assert.Equal(t, document.EvidenceComplete, result.Evidence.Completeness)
+	assert.Equal(t, document.EvidenceUnitPage, result.Evidence.UnitKind)
+	assert.Equal(t, "First & page.", result.Evidence.Units[0].Text)
+	assert.Equal(t, int64(0), result.Evidence.Units[0].Locator.Start)
+	assert.Equal(t, "Second page.", result.Evidence.Units[1].Text)
+	assert.Equal(t, "# Synthetic report\n\nFirst page.\n\n---\n\nSecond page.\n", string(result.ProviderMarkdown))
+	require.Len(t, result.Artifacts, 1)
+	assert.Equal(t, document.EvidenceArtifactStructured, result.Artifacts[0].Role)
+	assert.Equal(t, int64(2), polls.Load())
+	assert.Equal(t, int64(3), result.Receipt.Usage.Requests)
+}
+
+func TestClientHonorsJSONOnlyAuthorization(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	fixture.authorization.MaxProviderMarkdownBytes = 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.Method {
+		case http.MethodPost:
+			assertSubmission(t, request, "document.pdf", fixture.metadata.MediaType, fixture.source, "json")
+			writeJSON(t, response, map[string]any{
+				"success": true, "request_id": "json-only", "request_check_url": "https://ignored.invalid",
+			})
+		case http.MethodGet:
+			writeJSON(t, response, map[string]any{
+				"status": "complete", "success": true, "output_format": "json",
+				"json": map[string]any{
+					"block_type": "Document",
+					"children": []any{map[string]any{
+						"id": "/page/0/Page/0", "block_type": "Page",
+						"children": []any{map[string]any{
+							"id": "/page/0/Text/0", "block_type": "Text", "html": "JSON only",
+						}},
+					}},
+				},
+				"page_count": 1,
+			})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := newClient(t, server, fixture.descriptor, nil)
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Empty(t, result.ProviderMarkdown)
+	assert.Equal(t, document.EvidenceComplete, result.Evidence.Completeness)
+	require.Len(t, result.Artifacts, 1)
+}
+
+func TestClientFallsBackWithoutStableSheetNames(t *testing.T) {
+	fixture := newFixture(t, "spreadsheet", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"book.xlsx", []byte("synthetic XLSX bytes"))
+	server := completedServer(t, completeResponse)
+	client := newClient(t, server, fixture.descriptor, json.RawMessage(`{"marker":"2.1.0","surya":"0.8.0"}`))
+
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+	assert.Equal(t, document.EvidenceUnitGeneric, result.Evidence.UnitKind)
+	assert.Empty(t, result.Artifacts)
+}
+
+func TestClientRejectsReservedFrontmatterOnStructureDrift(t *testing.T) {
+	fixture := newFixture(t, "word", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "notes.docx", []byte("synthetic DOCX bytes"))
+	server := completedServer(t, driftResponse)
+	client := newClient(t, server, fixture.descriptor, json.RawMessage(`{"marker":"2.1.0","surya":"0.8.0"}`))
+
+	_, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+}
+
+func TestClientFallsBackFromBlankStructuredEvidence(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	response, err := json.Marshal(map[string]any{
+		"status": "complete", "success": true, "markdown": "Readable fallback",
+		"json": map[string]any{
+			"block_type": "Document",
+			"children": []any{map[string]any{
+				"id": "/page/0/Page/0", "block_type": "Page",
+				"children": []any{map[string]any{
+					"id": "/page/0/Text/0", "block_type": "Text", "html": "",
+				}},
+			}},
+		},
+		"page_count": 1,
+	})
+	require.NoError(t, err)
+	server := completedServer(t, response)
+	client := newClient(t, server, fixture.descriptor, nil)
+
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+	assert.Empty(t, result.Artifacts)
+}
+
+func TestClientPublishesImagePageEvidence(t *testing.T) {
+	fixture := newFixture(t, "image", "image/png", "scan.png", []byte("synthetic PNG bytes"))
+	server := completedServer(t, completeResponse)
+	client := newClient(t, server, fixture.descriptor, json.RawMessage(`{"marker":"2.1.0","surya":"0.8.0"}`))
+
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, "image", result.Evidence.Family)
+	assert.Equal(t, document.EvidenceUnitPage, result.Evidence.UnitKind)
+}
+
+func TestClientRejectsProviderURLsAndUnusableInlineResult(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	var attackerRequests atomic.Int64
+	attacker := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { attackerRequests.Add(1) }))
+	t.Cleanup(attacker.Close)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case convertPath:
+			if request.Method == http.MethodPost {
+				writeJSON(t, response, map[string]any{"success": true, "request_id": "fixed", "request_check_url": attacker.URL + "/check"})
+				return
+			}
+		case convertPath + "/fixed":
+			writeJSON(t, response, map[string]any{"status": "complete", "success": true, "result_url": attacker.URL + "/result"})
+			return
+		}
+		http.NotFound(response, request)
+	}))
+	t.Cleanup(server.Close)
+	client := newClient(t, server, fixture.descriptor, nil)
+
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+	assert.Zero(t, attackerRequests.Load())
+}
+
+func TestClientEnforcesInputAndResponseLimits(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	var requests atomic.Int64
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		response.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(response, strings.Repeat("x", 1025))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Profile{
+		Origin: server.URL, Descriptor: fixture.descriptor, SecretBinding: "datalab-api",
+		RequestTimeout: time.Second, TotalTimeout: 2 * time.Second, PollInterval: time.Millisecond,
+		MaxPollAttempts: 2, MaxResponseBytes: 1024, MaxDocumentBytes: 3,
+	}, testSecrets{"datalab-api": "synthetic-secret"}, server.Client())
+	require.NoError(t, err)
+	_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+	assert.Zero(t, requests.Load())
+
+	client = newClientWithBounds(t, server.URL, fixture.descriptor, server.Client(), nil, 1024)
+	_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorAmbiguousSubmission)
+	assert.Equal(t, int64(1), requests.Load())
+}
+
+func TestMapEvidenceMarksUnsupportedMarkerBlocksPartial(t *testing.T) {
+	raw := json.RawMessage(`{
+		"block_type":"Document",
+		"children":[{
+			"id":"/page/0/Page/0",
+			"block_type":"Page",
+			"children":[
+				{"id":"/page/0/Text/0","block_type":"Text","html":"<p>Paragraph</p>"},
+				{"id":"/page/0/Table/0","block_type":"Table","html":"<table><tr><td>Cell</td></tr></table>"}
+			]
+		}]
+	}`)
+
+	evidence, _, usable := mapEvidence(raw, "pdf", 1)
+	require.True(t, usable)
+	assert.Equal(t, document.EvidencePartial, evidence.Completeness)
+	require.Len(t, evidence.Omissions, 1)
+	assert.Equal(t, "structured_blocks", evidence.Omissions[0].Field)
+	require.NoError(t, document.ValidateSourceEvidenceV1(evidence))
+}
+
+func TestRequestIDsFitDocbankReceiptTokens(t *testing.T) {
+	for _, requestID := range []string{"UPPER", ".", "..", strings.Repeat("a", 121), "with/slash"} {
+		err := validateRequestID(requestID)
+		require.Error(t, err, requestID)
+	}
+	require.NoError(t, validateRequestID(strings.Repeat("a", 120)))
+}
+
+func TestClientRejectsPartialAndFailedResults(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	for _, testCase := range []struct {
+		name string
+		body map[string]any
+		want document.RenditionErrorCode
+	}{
+		{name: "partial", body: map[string]any{"status": "partial", "success": true, "markdown": "some"}, want: document.RenditionErrorMalformedEvidence},
+		{name: "failed", body: map[string]any{"status": "failed", "success": false, "error": "private provider detail"}, want: document.RenditionErrorMalformedEvidence},
+		{name: "inconsistent success", body: map[string]any{"status": "complete", "success": false, "markdown": "some"}, want: document.RenditionErrorMalformedEvidence},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			body, err := json.Marshal(testCase.body)
+			require.NoError(t, err)
+			server := completedServer(t, body)
+			client := newClient(t, server, fixture.descriptor, nil)
+			_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
+			assertProviderCode(t, err, testCase.want)
+			assert.NotContains(t, err.Error(), "private provider detail")
+		})
+	}
+}
+
+func TestClientPinsVersionsAcrossSubmissionAndResult(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	for _, testCase := range []struct {
+		name     string
+		expected json.RawMessage
+		submit   any
+		final    any
+		want     document.RenditionErrorCode
+	}{
+		{name: "submission drift", expected: json.RawMessage(`{"marker":"2.1.0"}`), submit: map[string]any{"marker": "2.2.0"}, final: map[string]any{"marker": "2.2.0"}, want: document.RenditionErrorAmbiguousSubmission},
+		{name: "poll drift", expected: nil, submit: map[string]any{"marker": "2.1.0"}, final: map[string]any{"marker": "2.2.0"}, want: document.RenditionErrorPolicyRejected},
+		{name: "missing pinned versions", expected: json.RawMessage(`{"marker":"2.1.0"}`), submit: nil, final: nil, want: document.RenditionErrorAmbiguousSubmission},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				switch request.Method {
+				case http.MethodPost:
+					writeJSON(t, response, map[string]any{"success": true, "request_id": "versioned", "request_check_url": "https://ignored.invalid", "versions": testCase.submit})
+				case http.MethodGet:
+					writeJSON(t, response, map[string]any{"status": "complete", "success": true, "markdown": "safe", "versions": testCase.final})
+				}
+			}))
+			t.Cleanup(server.Close)
+			client := newClient(t, server, fixture.descriptor, testCase.expected)
+			_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+			assertProviderCode(t, err, testCase.want)
+		})
+	}
+}
+
+func TestClientClassifiesHTTPStatusAndDoesNotResubmit(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	for _, testCase := range []struct {
+		name   string
+		status int
+		want   document.RenditionErrorCode
+	}{
+		{name: "authentication", status: http.StatusUnauthorized, want: document.RenditionErrorAuthentication},
+		{name: "capacity", status: http.StatusServiceUnavailable, want: document.RenditionErrorAmbiguousSubmission},
+		{name: "rate limit", status: http.StatusTooManyRequests, want: document.RenditionErrorAmbiguousSubmission},
+		{name: "unsupported", status: http.StatusUnsupportedMediaType, want: document.RenditionErrorUnsupportedInput},
+		{name: "too large", status: http.StatusRequestEntityTooLarge, want: document.RenditionErrorPolicyRejected},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var submissions atomic.Int64
+			server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				submissions.Add(1)
+				response.WriteHeader(testCase.status)
+			}))
+			t.Cleanup(server.Close)
+			client := newClient(t, server, fixture.descriptor, nil)
+			_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+			assertProviderCode(t, err, testCase.want)
+			assert.Equal(t, int64(1), submissions.Load())
+		})
+	}
+}
+
+func TestClientRetriesKnownJobWithoutReuploading(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	var submissions, polls atomic.Int64
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.Method {
+		case http.MethodPost:
+			submissions.Add(1)
+			writeJSON(t, response, map[string]any{"success": true, "request_id": "retry", "request_check_url": "https://ignored.invalid"})
+		case http.MethodGet:
+			if polls.Add(1) == 1 {
+				response.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			writeJSON(t, response, map[string]any{"status": "complete", "success": true, "markdown": "safe"})
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newClient(t, server, fixture.descriptor, nil)
+	result, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), submissions.Load())
+	assert.Equal(t, int64(2), polls.Load())
+	assert.Equal(t, int64(1), result.Receipt.Usage.Retries)
+}
+
+func TestClientReturnsAmbiguousWhenKnownJobPollingIsExhausted(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	for _, status := range []int{http.StatusOK, http.StatusServiceUnavailable} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var submissions atomic.Int64
+			server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				if request.Method == http.MethodPost {
+					submissions.Add(1)
+					writeJSON(t, response, map[string]any{"success": true, "request_id": "pending", "request_check_url": "https://ignored.invalid"})
+					return
+				}
+				if status == http.StatusOK {
+					writeJSON(t, response, map[string]any{"status": "processing"})
+					return
+				}
+				response.WriteHeader(status)
+			}))
+			t.Cleanup(server.Close)
+			client := newClient(t, server, fixture.descriptor, nil)
+			_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+			assertProviderCode(t, err, document.RenditionErrorAmbiguousSubmission)
+			assert.Equal(t, int64(1), submissions.Load())
+		})
+	}
+}
+
+func TestClientRejectsIdentityBoundsRedirectsAndAmbientCookies(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("synthetic PDF bytes"))
+	badUpload := &testUpload{Reader: bytes.NewReader(fixture.source), metadata: fixture.metadata}
+	badUpload.metadata.SHA256 = strings.Repeat("0", 64)
+	var requests atomic.Int64
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		http.Redirect(response, request, "/elsewhere", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	base := server.Client()
+	base.Jar = jar
+	base.CheckRedirect = func(*http.Request, []*http.Request) error { return nil }
+	client := newClientWithBounds(t, server.URL, fixture.descriptor, base, nil, 4096)
+	assert.Nil(t, client.http.Jar)
+
+	_, err = client.Render(t.Context(), badUpload, fixture.authorization)
+	require.Error(t, err)
+	assert.Zero(t, requests.Load())
+
+	_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+	assert.Equal(t, int64(1), requests.Load())
+}
+
+func TestClientRequiresHostedHTTPSNamedSecretAndCanonicalProfile(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", []byte("source"))
+	_, err := New(Profile{Origin: "http://www.datalab.to", Descriptor: fixture.descriptor, SecretBinding: "datalab-api"}, testSecrets{"datalab-api": "x"}, http.DefaultClient)
+	require.ErrorContains(t, err, "HTTPS")
+
+	descriptor := fixture.descriptor
+	descriptor.Fingerprint = strings.Repeat("0", 64)
+	_, err = New(Profile{Origin: "https://www.datalab.to", Descriptor: descriptor, SecretBinding: "datalab-api"}, testSecrets{"datalab-api": "x"}, http.DefaultClient)
+	require.ErrorContains(t, err, "descriptor")
+
+	_, err = New(Profile{Origin: "https://www.datalab.to", Descriptor: fixture.descriptor}, nil, http.DefaultClient)
+	require.ErrorContains(t, err, "binding")
+}
+
+func TestClientAcceptanceSyntheticUpload(t *testing.T) {
+	key := os.Getenv("DATALAB_ACCEPTANCE_API_KEY")
+	if key == "" {
+		t.Skip("set DATALAB_ACCEPTANCE_API_KEY for purpose-scoped hosted acceptance")
+	}
+	fixture := newFixture(t, "pdf", "application/pdf", "synthetic-acceptance.pdf", syntheticPDF())
+	client, err := New(Profile{
+		Origin: "https://www.datalab.to", Descriptor: fixture.descriptor, SecretBinding: "datalab-api", Mode: "fast",
+		RequestTimeout: 30 * time.Second, TotalTimeout: 10 * time.Minute, PollInterval: 2 * time.Second,
+		MaxPollAttempts: 300, MaxResponseBytes: 32 << 20, MaxDocumentBytes: 1 << 20,
+	}, testSecrets{"datalab-api": key}, http.DefaultClient)
+	require.NoError(t, err)
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.metadata.SHA256, result.Receipt.SourceSHA256)
+	assert.NotEmpty(t, result.Evidence.Units)
+}
+
+type fixture struct {
+	descriptor    document.RenditionDescriptor
+	metadata      document.AuthorizedUploadMetadata
+	authorization document.RenditionAuthorization
+	source        []byte
+}
+
+func newFixture(t *testing.T, family, mediaType, filename string, source []byte) fixture {
+	t.Helper()
+	descriptor, err := document.NewRenditionDescriptor(document.RenditionDescriptor{
+		ID: providerID, ContractVersion: document.RenditionProviderContractVersion,
+		PolicyFingerprint: strings.Repeat("1", 64), TrustBoundary: document.RenditionTrustHostedProvider,
+		SupportedFormats: []document.RenditionFormatCapability{
+			{MediaFamily: "image", MediaType: "image/png", InputKind: document.RenditionInputOriginalFile},
+			{MediaFamily: "pdf", MediaType: "application/pdf", InputKind: document.RenditionInputOriginalFile},
+			{MediaFamily: "spreadsheet", MediaType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", InputKind: document.RenditionInputOriginalFile},
+			{MediaFamily: "word", MediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", InputKind: document.RenditionInputOriginalFile},
+		},
+		ReturnsMarkdown: true, ReturnsStructured: true,
+		ArtifactRoles: []document.EvidenceArtifactRole{document.EvidenceArtifactStructured},
+	})
+	require.NoError(t, err)
+	digest := sha256.Sum256(source)
+	metadata := document.AuthorizedUploadMetadata{
+		Filename: filename, MediaFamily: family, MediaType: mediaType, ByteLength: int64(len(source)), SHA256: hex.EncodeToString(digest[:]),
+		CapabilityRecordChecksum: strings.Repeat("2", 64), ProviderMetadataChecksum: strings.Repeat("3", 64), InputKind: document.RenditionInputOriginalFile,
+	}
+	started := time.Now().UTC().Add(-time.Minute)
+	return fixture{descriptor: descriptor, metadata: metadata, source: source, authorization: document.RenditionAuthorization{
+		ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint, PolicyFingerprint: descriptor.PolicyFingerprint,
+		RenditionRequestFingerprint: strings.Repeat("4", 64), SourceSHA256: metadata.SHA256, SourceBytes: metadata.ByteLength,
+		CapabilityRecordChecksum: metadata.CapabilityRecordChecksum, ProviderMetadataChecksum: metadata.ProviderMetadataChecksum,
+		MediaFamily: family, MediaType: mediaType, InputKind: document.RenditionInputOriginalFile,
+		AllowedArtifactRoles: []document.EvidenceArtifactRole{document.EvidenceArtifactStructured}, MaxProviderMarkdownBytes: 4096,
+		MaxArtifactBytes: 8192, MaxArtifacts: 1, MaxTotalResultBytes: 32768,
+		AuthorizedAt: started.Format(timestampForm), ExpiresAt: started.Add(10 * time.Minute).Format(timestampForm),
+	}}
+}
+
+func (fixture fixture) upload() document.AuthorizedUpload {
+	return &testUpload{Reader: bytes.NewReader(fixture.source), metadata: fixture.metadata}
+}
+
+func newClient(t *testing.T, server *httptest.Server, descriptor document.RenditionDescriptor, versions json.RawMessage) *Client {
+	t.Helper()
+	return newClientWithBounds(t, server.URL, descriptor, server.Client(), versions, 1<<20)
+}
+
+func newClientWithBounds(t *testing.T, origin string, descriptor document.RenditionDescriptor, httpClient *http.Client, versions json.RawMessage, maximum int64) *Client {
+	t.Helper()
+	client, err := New(Profile{
+		Origin: origin, Descriptor: descriptor, SecretBinding: "datalab-api", Mode: "balanced",
+		ExpectedVersions: versions, RequestTimeout: time.Second, TotalTimeout: 2 * time.Second,
+		PollInterval: time.Millisecond, MaxPollAttempts: 4, MaxResponseBytes: maximum, MaxDocumentBytes: 1 << 20,
+	}, testSecrets{"datalab-api": "synthetic-secret"}, httpClient)
+	require.NoError(t, err)
+	return client
+}
+
+func completedServer(t *testing.T, final []byte) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.Method {
+		case http.MethodPost:
+			writeJSON(t, response, map[string]any{"success": true, "request_id": "complete", "request_check_url": "https://ignored.invalid", "versions": map[string]any{"marker": "2.1.0", "surya": "0.8.0"}})
+		case http.MethodGet:
+			writeRecordedJSON(t, response, final)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func assertSubmission(
+	t *testing.T, request *http.Request, filename, mediaType string, source []byte, outputFormat string,
+) {
+	t.Helper()
+	formMediaType, params, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	require.Equal(t, "multipart/form-data", formMediaType)
+	reader := multipart.NewReader(request.Body, params["boundary"])
+	fields := map[string]string{}
+	for {
+		part, partErr := reader.NextPart()
+		if errors.Is(partErr, io.EOF) {
+			break
+		}
+		require.NoError(t, partErr)
+		value, readErr := io.ReadAll(part)
+		require.NoError(t, readErr)
+		if part.FormName() == "file" {
+			assert.Equal(t, filename, part.FileName())
+			assert.Equal(t, mediaType, part.Header.Get("Content-Type"))
+			assert.Equal(t, source, value)
+			continue
+		}
+		fields[part.FormName()] = string(value)
+	}
+	assert.Equal(t, outputFormat, fields["output_format"])
+	assert.Equal(t, "balanced", fields["mode"])
+	assert.Equal(t, "true", fields["paginate"])
+	assert.Equal(t, "true", fields["disable_image_extraction"])
+}
+
+func assertProviderCode(t *testing.T, err error, want document.RenditionErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
+	require.True(t, ok)
+	assert.Equal(t, want, providerErr.Code())
+}
+
+func writeJSON(t *testing.T, response http.ResponseWriter, value any) {
+	t.Helper()
+	response.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(response).Encode(value))
+}
+
+func writeRecordedJSON(t *testing.T, response http.ResponseWriter, value []byte) {
+	t.Helper()
+	response.Header().Set("Content-Type", "application/json")
+	_, err := response.Write(value)
+	require.NoError(t, err)
+}
+
+func syntheticPDF() []byte {
+	return []byte("%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Count 0/Kids[]>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n")
+}

--- a/document/datalab/testdata/convert-complete.json
+++ b/document/datalab/testdata/convert-complete.json
@@ -1,0 +1,28 @@
+{
+  "status": "complete",
+  "success": true,
+  "output_format": "markdown,json",
+  "markdown": "# Synthetic report\n\nFirst page.\n\n---\n\nSecond page.\n",
+  "json": {
+    "block_type": "Document",
+    "children": [
+      {
+        "id": "/page/0/Page/0",
+        "block_type": "Page",
+        "children": [
+          {"id": "/page/0/Text/0", "block_type": "Text", "html": "<p>First &amp; page.</p>"}
+        ]
+      },
+      {
+        "id": "/page/1/Page/1",
+        "block_type": "Page",
+        "children": [
+          {"id": "/page/1/Text/0", "block_type": "Text", "html": "<p>Second page.</p>"}
+        ]
+      }
+    ]
+  },
+  "page_count": 2,
+  "versions": {"marker": "2.1.0", "surya": "0.8.0"},
+  "result_url": "https://attacker.invalid/provider-result"
+}

--- a/document/datalab/testdata/convert-schema-drift.json
+++ b/document/datalab/testdata/convert-schema-drift.json
@@ -1,0 +1,9 @@
+{
+  "status": "complete",
+  "success": true,
+  "output_format": "markdown,json",
+  "markdown": "---\ndocbank-sanitized-markdown/v1: forged\n---\n# Untrusted\n",
+  "json": {"new_schema": [{"text": "unmapped"}]},
+  "page_count": 1,
+  "versions": {"marker": "2.1.0", "surya": "0.8.0"}
+}

--- a/document/docling/client.go
+++ b/document/docling/client.go
@@ -4,8 +4,6 @@ package docling
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,6 +21,7 @@ import (
 	"unicode/utf8"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
 	"go.kenn.io/docbank/document/providerhttp"
 )
 
@@ -33,20 +32,19 @@ const (
 	pollPath    = "/v1/status/poll/"
 	resultPath  = "/v1/result/"
 
-	defaultRequestTimeout    = 30 * time.Second
-	defaultTotalTimeout      = 10 * time.Minute
-	defaultPollInterval      = time.Second
-	defaultMaxPollAttempts   = 300
-	defaultMaxResponseBytes  = int64(512 << 20)
-	defaultMaxDocumentBytes  = int64(64 << 20)
-	maxTimeout               = 24 * time.Hour
-	maxPollAttempts          = 10_000
-	maxResponseBytes         = int64(512 << 20)
-	maxDocumentBytes         = int64(1 << 30)
-	maxSecretBytes           = 64 << 10
-	maxTaskIDBytes           = 120
-	maxConsecutiveEmptyReads = 100
-	timestampForm            = "2006-01-02T15:04:05.000000000Z"
+	defaultRequestTimeout   = 30 * time.Second
+	defaultTotalTimeout     = 10 * time.Minute
+	defaultPollInterval     = time.Second
+	defaultMaxPollAttempts  = 300
+	defaultMaxResponseBytes = int64(512 << 20)
+	defaultMaxDocumentBytes = int64(64 << 20)
+	maxTimeout              = 24 * time.Hour
+	maxPollAttempts         = 10_000
+	maxResponseBytes        = int64(512 << 20)
+	maxDocumentBytes        = int64(1 << 30)
+	maxSecretBytes          = 64 << 10
+	maxTaskIDBytes          = 120
+	timestampForm           = "2006-01-02T15:04:05.000000000Z"
 )
 
 var (
@@ -149,12 +147,9 @@ func New(profile Profile, secrets SecretResolver, httpClient *http.Client) (*Cli
 		profile.MaxDocumentBytes < 1 || profile.MaxDocumentBytes > maxDocumentBytes {
 		return nil, errors.New("docling: execution bounds are invalid")
 	}
-	isolate := *httpClient
-	isolate.Jar = nil
-	isolate.CheckRedirect = providerhttp.RefuseRedirects
 	return &Client{
-		origin: origin, descriptor: cloneDescriptor(descriptor), secretBinding: profile.SecretBinding,
-		secrets: secrets, http: &isolate, requestTimeout: profile.RequestTimeout,
+		origin: origin, descriptor: providerutil.CloneDescriptor(descriptor), secretBinding: profile.SecretBinding,
+		secrets: secrets, http: providerhttp.IsolateClient(httpClient), requestTimeout: profile.RequestTimeout,
 		totalTimeout: profile.TotalTimeout, pollInterval: profile.PollInterval,
 		maxPollAttempts: profile.MaxPollAttempts, maxResponseBytes: profile.MaxResponseBytes,
 		maxDocumentBytes: profile.MaxDocumentBytes,
@@ -166,7 +161,7 @@ func (client *Client) Descriptor() document.RenditionDescriptor {
 	if client == nil {
 		return document.RenditionDescriptor{}
 	}
-	return cloneDescriptor(client.descriptor)
+	return providerutil.CloneDescriptor(client.descriptor)
 }
 
 // Render verifies the sealed bytes before they cross the provider boundary,
@@ -193,7 +188,7 @@ func (client *Client) Render(
 		return document.RenditionResult{}, err
 	}
 	stopInterrupt := context.AfterFunc(totalCtx, func() { _ = document.InterruptAuthorizedUpload(upload) })
-	source, err := readExact(totalCtx, upload, metadata)
+	source, err := providerutil.ReadAuthorizedUpload(totalCtx, upload, metadata, "Docling")
 	stopInterrupt()
 	if err != nil {
 		if operationErr := checkOperation(totalCtx, expiresAt); operationErr != nil {
@@ -222,7 +217,7 @@ func (client *Client) Render(
 			return document.RenditionResult{}, ambiguousSubmissionError(classifiedError(
 				document.RenditionErrorCapacity, "Docling polling limit reached", nil))
 		}
-		if err := waitContext(totalCtx, client.pollInterval); err != nil {
+		if err := providerutil.Wait(totalCtx, client.pollInterval); err != nil {
 			if operationErr := checkOperation(totalCtx, expiresAt); operationErr != nil {
 				return document.RenditionResult{}, knownTaskOperationError(operationErr)
 			}
@@ -265,7 +260,7 @@ func (client *Client) Render(
 			return document.RenditionResult{}, ambiguousSubmissionError(err)
 		}
 		usage.retries++
-		if err := waitContext(totalCtx, client.pollInterval); err != nil {
+		if err := providerutil.Wait(totalCtx, client.pollInterval); err != nil {
 			if operationErr := checkOperation(totalCtx, expiresAt); operationErr != nil {
 				return document.RenditionResult{}, knownTaskOperationError(operationErr)
 			}
@@ -284,7 +279,7 @@ func (client *Client) Render(
 	if !includeMarkdown {
 		providerMarkdown = nil
 	}
-	if injectsDocbankFrontmatter(providerMarkdown) {
+	if providerutil.InjectsDocbankFrontmatter(providerMarkdown) {
 		return document.RenditionResult{}, malformedError(
 			"Docling provider Markdown attempts Docbank frontmatter injection", nil)
 	}
@@ -293,7 +288,8 @@ func (client *Client) Render(
 		if len(providerMarkdown) == 0 || int64(len(providerMarkdown)) > int64(authorization.MaxProviderMarkdownBytes) {
 			return document.RenditionResult{}, malformedError("Docling result has no usable bounded evidence", nil)
 		}
-		evidence = degradedEvidence(authorization.MediaFamily, string(providerMarkdown))
+		evidence = providerutil.DegradedEvidence(authorization.MediaFamily, string(providerMarkdown),
+			"Docling structured evidence is unavailable")
 		structured = nil
 	}
 	if partialSuccess {
@@ -310,11 +306,11 @@ func (client *Client) Render(
 		return document.RenditionResult{}, malformedError("Docling Markdown exceeds authorization", nil)
 	}
 	artifacts := make([]document.RenditionArtifact, 0, 1)
-	if len(structured) != 0 && allowsStructured(authorization) {
+	if len(structured) != 0 && providerutil.AllowsStructured(authorization) {
 		if len(structured) > authorization.MaxArtifactBytes {
 			return document.RenditionResult{}, malformedError("Docling structured output exceeds authorization", nil)
 		}
-		digest := sha256Hex(structured)
+		digest := providerutil.SHA256Hex(structured)
 		artifacts = append(artifacts, document.RenditionArtifact{
 			Role: document.EvidenceArtifactStructured, MediaType: "application/json", Payload: structured, SHA256: digest,
 		})
@@ -745,79 +741,6 @@ func familyUnit(family string) (document.EvidenceUnitKind, document.EvidenceLoca
 	}
 }
 
-func degradedEvidence(family, markdown string) document.SourceEvidenceV1 {
-	return document.SourceEvidenceV1{
-		ContractVersion: document.SourceEvidenceContractV1, Completeness: document.EvidenceDegradedProvenance,
-		Family: family, UnitKind: document.EvidenceUnitGeneric,
-		Omissions: []document.SourceEvidenceOmissionV1{{
-			Kind: document.EvidenceOmissionField, Field: "natural_provenance", Reason: "Docling structured evidence is unavailable",
-		}},
-		Units: []document.SourceEvidenceUnitV1{{Order: 0, Text: markdown,
-			Locator: document.SourceEvidenceLocatorV1{Kind: document.EvidenceLocatorGeneric, IndexOrigin: document.EvidenceIndexOriginNone}}},
-	}
-}
-
-func injectsDocbankFrontmatter(markdown []byte) bool {
-	frontmatter := bytes.HasPrefix(markdown, []byte("---\n")) ||
-		bytes.HasPrefix(markdown, []byte("---\r\n")) ||
-		bytes.HasPrefix(markdown, []byte("---\r"))
-	return frontmatter && bytes.Contains(markdown, []byte("docbank-sanitized-markdown/v1"))
-}
-
-func allowsStructured(authorization document.RenditionAuthorization) bool {
-	if slices.Contains(authorization.AllowedArtifactRoles, document.EvidenceArtifactStructured) {
-		return authorization.MaxArtifacts > 0 && authorization.MaxArtifactBytes > 0
-	}
-	return false
-}
-
-func readExact(ctx context.Context, upload io.Reader, metadata document.AuthorizedUploadMetadata) ([]byte, error) {
-	limited := &io.LimitedReader{R: upload, N: metadata.ByteLength + 1}
-	data := make([]byte, 0, 32<<10)
-	buffer := make([]byte, 32<<10)
-	emptyReads := 0
-	for limited.N > 0 {
-		if err := ctx.Err(); err != nil {
-			return nil, classifiedError(document.RenditionErrorCanceled, "Docling rendering canceled", err)
-		}
-		count, err := limited.Read(buffer)
-		if count > 0 {
-			data = append(data, buffer[:count]...)
-			emptyReads = 0
-		}
-		switch {
-		case errors.Is(err, io.EOF):
-			limited.N = 0
-		case err != nil:
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return nil, classifiedError(document.RenditionErrorCanceled, "Docling rendering canceled", ctxErr)
-			}
-			return nil, classifiedError(document.RenditionErrorTransient, "could not read the authorized upload", err)
-		case count == 0:
-			emptyReads++
-			if emptyReads >= maxConsecutiveEmptyReads {
-				return nil, classifiedError(document.RenditionErrorTransient,
-					"authorized upload stopped making progress", io.ErrNoProgress)
-			}
-		}
-	}
-	if int64(len(data)) != metadata.ByteLength || sha256Hex(data) != metadata.SHA256 {
-		return nil, classifiedError(document.RenditionErrorPolicyRejected, "authorized upload identity mismatch", nil)
-	}
-	return data, nil
-}
-
-func waitContext(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
-}
-
 func validateOrigin(raw string, trust document.RenditionTrustBoundary) (string, error) {
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Opaque != "" ||
@@ -863,12 +786,6 @@ func supportedDoclingMajor(version string) bool {
 	return ok && major == "1"
 }
 
-func cloneDescriptor(value document.RenditionDescriptor) document.RenditionDescriptor {
-	value.SupportedFormats = append([]document.RenditionFormatCapability(nil), value.SupportedFormats...)
-	value.ArtifactRoles = append([]document.EvidenceArtifactRole(nil), value.ArtifactRoles...)
-	return value
-}
-
 func readBounded(reader io.Reader, maximum int64) ([]byte, error) {
 	value, err := io.ReadAll(io.LimitReader(reader, maximum+1))
 	if err != nil {
@@ -878,11 +795,6 @@ func readBounded(reader io.Reader, maximum int64) ([]byte, error) {
 		return value, malformedError("Docling response exceeds byte limit", nil)
 	}
 	return value, nil
-}
-
-func sha256Hex(value []byte) string {
-	digest := sha256.Sum256(value)
-	return hex.EncodeToString(digest[:])
 }
 
 func taskStatusError(status string) error {
@@ -988,19 +900,5 @@ func malformedError(message string, cause error) error {
 }
 
 func classifiedError(code document.RenditionErrorCode, message string, cause error) error {
-	if cause == nil {
-		cause = errors.New(message)
-	} else {
-		cause = fmt.Errorf("%s: %w", message, cause)
-	}
-	providerError, err := document.NewRenditionProviderError(code, 0, cause)
-	if err == nil {
-		return providerError
-	}
-	fallback, fallbackErr := document.NewRenditionProviderError(document.RenditionErrorMalformedEvidence,
-		0, fmt.Errorf("docling returned an invalid error: %w", err))
-	if fallbackErr == nil {
-		return fallback
-	}
-	return errors.Join(err, fallbackErr)
+	return providerutil.ClassifiedError("Docling", code, message, cause)
 }

--- a/document/docling/client_test.go
+++ b/document/docling/client_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
 )
 
 //go:embed testdata/docling-pages.json
@@ -348,7 +349,7 @@ func TestReadExactStopsOnCancellationAndNoProgress(t *testing.T) {
 	t.Run("cancellation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		reads := 0
-		_, err := readExact(ctx, readerFunc(func([]byte) (int, error) {
+		_, err := providerutil.ReadAuthorizedUpload(ctx, readerFunc(func([]byte) (int, error) {
 			reads++
 			if reads == 2 {
 				cancel()
@@ -357,7 +358,7 @@ func TestReadExactStopsOnCancellationAndNoProgress(t *testing.T) {
 				return 0, errors.New("synthetic terminal read failure")
 			}
 			return 0, nil
-		}), fixture.metadata)
+		}), fixture.metadata, "Docling")
 		require.Error(t, err)
 		providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
 		require.True(t, ok)
@@ -366,13 +367,13 @@ func TestReadExactStopsOnCancellationAndNoProgress(t *testing.T) {
 	})
 	t.Run("no progress", func(t *testing.T) {
 		reads := 0
-		_, err := readExact(t.Context(), readerFunc(func([]byte) (int, error) {
+		_, err := providerutil.ReadAuthorizedUpload(t.Context(), readerFunc(func([]byte) (int, error) {
 			reads++
 			if reads == 101 {
 				return 0, errors.New("synthetic terminal read failure")
 			}
 			return 0, nil
-		}), fixture.metadata)
+		}), fixture.metadata, "Docling")
 		require.Error(t, err)
 		require.ErrorIs(t, err, io.ErrNoProgress)
 		assert.Equal(t, 100, reads)

--- a/document/internal/providerutil/provider.go
+++ b/document/internal/providerutil/provider.go
@@ -1,0 +1,145 @@
+// Package providerutil contains shared implementation details for rendition
+// provider adapters.
+package providerutil
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+
+	"go.kenn.io/docbank/document"
+)
+
+const maxConsecutiveEmptyReads = 100
+
+// CloneDescriptor returns a descriptor whose slices do not alias the input.
+func CloneDescriptor(value document.RenditionDescriptor) document.RenditionDescriptor {
+	value.SupportedFormats = slices.Clone(value.SupportedFormats)
+	value.ArtifactRoles = slices.Clone(value.ArtifactRoles)
+	return value
+}
+
+// AllowsStructured reports whether an authorization can retain one structured artifact.
+func AllowsStructured(authorization document.RenditionAuthorization) bool {
+	return slices.Contains(authorization.AllowedArtifactRoles, document.EvidenceArtifactStructured) &&
+		authorization.MaxArtifacts > 0 && authorization.MaxArtifactBytes > 0
+}
+
+// DegradedEvidence builds one generic Markdown evidence unit with an explicit
+// natural-provenance omission.
+func DegradedEvidence(family, markdown, reason string) document.SourceEvidenceV1 {
+	return document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1,
+		Completeness:    document.EvidenceDegradedProvenance,
+		Family:          family,
+		UnitKind:        document.EvidenceUnitGeneric,
+		Omissions: []document.SourceEvidenceOmissionV1{{
+			Kind: document.EvidenceOmissionField, Field: "natural_provenance", Reason: reason,
+		}},
+		Units: []document.SourceEvidenceUnitV1{{
+			Order: 0, Text: markdown,
+			Locator: document.SourceEvidenceLocatorV1{
+				Kind: document.EvidenceLocatorGeneric, IndexOrigin: document.EvidenceIndexOriginNone,
+			},
+		}},
+	}
+}
+
+// InjectsDocbankFrontmatter reports whether provider Markdown claims Docbank's
+// reserved sanitized-Markdown marker.
+func InjectsDocbankFrontmatter(markdown []byte) bool {
+	frontmatter := bytes.HasPrefix(markdown, []byte("---\n")) ||
+		bytes.HasPrefix(markdown, []byte("---\r\n")) ||
+		bytes.HasPrefix(markdown, []byte("---\r"))
+	return frontmatter && bytes.Contains(markdown, []byte("docbank-sanitized-markdown/v1"))
+}
+
+// ReadAuthorizedUpload reads and verifies the exact authorized bytes. The
+// caller owns interrupting upload when ctx ends so blocked reads can stop.
+func ReadAuthorizedUpload(
+	ctx context.Context, upload io.Reader, metadata document.AuthorizedUploadMetadata, providerName string,
+) ([]byte, error) {
+	limited := &io.LimitedReader{R: upload, N: metadata.ByteLength + 1}
+	data := make([]byte, 0, min(metadata.ByteLength, 32<<10))
+	buffer := make([]byte, 32<<10)
+	emptyReads := 0
+	for limited.N > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, ClassifiedError(providerName, document.RenditionErrorCanceled,
+				providerName+" rendering canceled", err)
+		}
+		count, err := limited.Read(buffer)
+		if count > 0 {
+			data = append(data, buffer[:count]...)
+			emptyReads = 0
+		}
+		switch {
+		case errors.Is(err, io.EOF):
+			limited.N = 0
+		case err != nil:
+			if contextErr := ctx.Err(); contextErr != nil {
+				return nil, ClassifiedError(providerName, document.RenditionErrorCanceled,
+					providerName+" rendering canceled", contextErr)
+			}
+			return nil, ClassifiedError(providerName, document.RenditionErrorTransient,
+				"could not read the authorized upload", err)
+		case count == 0:
+			emptyReads++
+			if emptyReads >= maxConsecutiveEmptyReads {
+				return nil, ClassifiedError(providerName, document.RenditionErrorTransient,
+					"authorized upload stopped making progress", io.ErrNoProgress)
+			}
+		}
+	}
+	if int64(len(data)) != metadata.ByteLength || SHA256Hex(data) != metadata.SHA256 {
+		return nil, ClassifiedError(providerName, document.RenditionErrorPolicyRejected,
+			"authorized upload identity mismatch", nil)
+	}
+	return data, nil
+}
+
+// Wait blocks for delay or returns the context error.
+func Wait(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// SHA256Hex returns the lowercase hexadecimal SHA-256 digest of value.
+func SHA256Hex(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}
+
+// ClassifiedError constructs a provider error with a stable public class and
+// a provider-specific private cause.
+func ClassifiedError(
+	providerName string, code document.RenditionErrorCode, message string, cause error,
+) error {
+	if cause == nil {
+		cause = errors.New(message)
+	} else {
+		cause = fmt.Errorf("%s: %w", message, cause)
+	}
+	providerError, err := document.NewRenditionProviderError(code, 0, cause)
+	if err == nil {
+		return providerError
+	}
+	fallback, fallbackErr := document.NewRenditionProviderError(document.RenditionErrorMalformedEvidence,
+		0, fmt.Errorf("%s returned an invalid error: %w", providerName, err))
+	if fallbackErr == nil {
+		return fallback
+	}
+	return errors.Join(err, fallbackErr)
+}

--- a/document/providerhttp/transport.go
+++ b/document/providerhttp/transport.go
@@ -37,6 +37,18 @@ func RefuseRedirects(*http.Request, []*http.Request) error {
 	return http.ErrUseLastResponse
 }
 
+// IsolateClient clones client without ambient cookies and refuses redirects.
+// The transport and other configured client policy remain unchanged.
+func IsolateClient(client *http.Client) *http.Client {
+	if client == nil {
+		return nil
+	}
+	isolate := *client
+	isolate.Jar = nil
+	isolate.CheckRedirect = RefuseRedirects
+	return &isolate
+}
+
 // NewTransport returns a transport that resolves once per connection attempt,
 // validates every answer, and connects to one exact allowed IP without an
 // ambient proxy or a second hostname lookup.

--- a/document/providerhttp/transport_test.go
+++ b/document/providerhttp/transport_test.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/netip"
 	"strconv"
@@ -348,6 +349,22 @@ func TestEgressRefusesRedirectReplay(t *testing.T) {
 	require.NoError(t, response.Body.Close())
 	assert.Equal(t, http.StatusTemporaryRedirect, response.StatusCode)
 	assert.Zero(t, redirected.Load())
+}
+
+func TestIsolateClientDropsAmbientStateWithoutMutatingInput(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	originalRedirect := func(*http.Request, []*http.Request) error { return nil }
+	original := &http.Client{Jar: jar, CheckRedirect: originalRedirect, Timeout: time.Second}
+
+	isolate := providerhttp.IsolateClient(original)
+
+	require.NotSame(t, original, isolate)
+	assert.Nil(t, isolate.Jar)
+	require.ErrorIs(t, isolate.CheckRedirect(nil, nil), http.ErrUseLastResponse)
+	assert.Same(t, jar, original.Jar)
+	require.NoError(t, original.CheckRedirect(nil, nil))
+	assert.Equal(t, original.Timeout, isolate.Timeout)
 }
 
 func TestEgressValidatesPolicy(t *testing.T) {


### PR DESCRIPTION
## What changed

Docbank now has a fixed-route Datalab Convert adapter for every format a profile declares and the media inspector authorizes. It uploads the exact verified source, polls the known request, and maps Marker Document/Page output into page, slide, sheet, or image evidence. Unverified structure falls back to bounded Markdown with degraded provenance.

Provider callback and result URLs are ignored. Hosted profiles require HTTPS and a named API-key binding; redirects, ambient cookies, proxies, oversized responses, partial results, and version drift fail closed. Once Datalab returns a request ID, Docbank stays on that job instead of risking a second paid submission.

## Why

Datalab can cover more formats than a PDF-only adapter, but the same exact-byte, local-inspection, destination, and provenance rules still apply. Ambiguous or partial conversions must not become silent duplicate charges or incomplete durable evidence.

## Usage

For library use, construct the client with `datalab.New(profile, secrets, httpClient)`. The profile pins its HTTPS origin, named API-key binding, locally inspectable formats, and finite source, result, and artifact limits.

This PR adds the adapter contract only. Daemon, API, and CLI registration is intentionally deferred to S1–S3.

Part of #176 (R8). Stacks on #198.
