### PR TITLE
[F10–E12 05/25] Run Mistral OCR through the rendition contract

### DIFF
--- a/document/mistral/client.go
+++ b/document/mistral/client.go
@@ -66,6 +66,7 @@ type Result struct {
 	ReturnedModel  string
 	UnitsProcessed int
 	ProviderBytes  *int64
+	ResponseBytes  int64
 	Metrics        RequestMetrics
 }
 
@@ -122,7 +123,7 @@ type wireUsage struct {
 // Client calls the single endpoint derived from its policy.
 type Client struct {
 	policy        Policy
-	apiKey        string
+	credential    func(context.Context) (string, error)
 	maxRetries    int
 	maxRetryDelay time.Duration
 	http          *http.Client
@@ -135,6 +136,21 @@ func NewClient(policy Policy, config ClientConfig) (*Client, error) {
 	}
 	if config.APIKey == "" || config.APIKey != strings.TrimSpace(config.APIKey) {
 		return nil, errors.New("mistral OCR API key is required and must not contain surrounding whitespace")
+	}
+	apiKey := config.APIKey
+	return newClientWithCredential(policy, config, func(context.Context) (string, error) {
+		return apiKey, nil
+	})
+}
+
+func newClientWithCredential(
+	policy Policy, config ClientConfig, credential func(context.Context) (string, error),
+) (*Client, error) {
+	if policy.digest == "" {
+		return nil, errors.New("mistral policy is invalid; use NewPolicy")
+	}
+	if credential == nil {
+		return nil, errors.New("mistral OCR credential resolver is required")
 	}
 	if config.Timeout == 0 {
 		config.Timeout = DefaultTimeout
@@ -169,7 +185,7 @@ func NewClient(policy Policy, config ClientConfig) (*Client, error) {
 		return http.ErrUseLastResponse
 	}
 	return &Client{
-		policy: policy, apiKey: config.APIKey, maxRetries: config.MaxRetries,
+		policy: policy, credential: credential, maxRetries: config.MaxRetries,
 		maxRetryDelay: config.MaxRetryDelay, http: httpClient,
 	}, nil
 }
@@ -221,6 +237,20 @@ func (c *Client) process(
 	method UnitBoundMethod,
 	maxUnits int,
 ) (Result, error) {
+	return c.processWith(ctx, snapshotForAttempt, readVerifiedDocument, nil, options, method, maxUnits,
+		c.policy.values.MaxResponseBytes)
+}
+
+func (c *Client) processWith(
+	ctx context.Context,
+	snapshotForAttempt func() (preparedSnapshot, error),
+	readDocument func(context.Context, preparedSnapshot) ([]byte, error),
+	beforeEgress func() error,
+	options requestOptions,
+	method UnitBoundMethod,
+	maxUnits int,
+	maxResponseBytes int64,
+) (Result, error) {
 	requests := 0
 	var providerLatency time.Duration
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
@@ -238,7 +268,8 @@ func (c *Client) process(
 			return Result{}, newProcessError(err, requests, providerLatency)
 		}
 		result, retryHeader, requested, latency, processErr := c.processOnce(
-			ctx, snapshot, prefix, suffix, encodedLength, method, maxUnits,
+			ctx, snapshot, readDocument, beforeEgress, prefix, suffix, encodedLength, method, maxUnits,
+			maxResponseBytes,
 		)
 		if requested {
 			requests++
@@ -284,12 +315,15 @@ func (c *Client) validatePreparedSnapshot(
 func (c *Client) processOnce(
 	ctx context.Context,
 	snapshot preparedSnapshot,
+	readDocument func(context.Context, preparedSnapshot) ([]byte, error),
+	beforeEgress func() error,
 	prefix, suffix []byte,
 	encodedLength int64,
 	method UnitBoundMethod,
 	maxUnits int,
+	maxResponseBytes int64,
 ) (Result, string, bool, time.Duration, error) {
-	documentBytes, err := readVerifiedDocument(ctx, snapshot)
+	documentBytes, err := readDocument(ctx, snapshot)
 	if err != nil {
 		return Result{}, "", false, 0, err
 	}
@@ -315,7 +349,25 @@ func (c *Client) processOnce(
 	}
 	request.ContentLength = encodedLength
 	request.Header.Set("Content-Type", mediaTypeJSON)
-	request.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if beforeEgress != nil {
+		if err := beforeEgress(); err != nil {
+			return Result{}, "", false, 0, err
+		}
+	}
+	apiKey, err := c.credential(ctx)
+	if err != nil {
+		return Result{}, "", false, 0, &credentialError{cause: err}
+	}
+	if apiKey == "" || len(apiKey) > 64<<10 || apiKey != strings.TrimSpace(apiKey) ||
+		strings.ContainsAny(apiKey, "\r\n\x00") {
+		return Result{}, "", false, 0, &credentialError{}
+	}
+	request.Header.Set("Authorization", "Bearer "+apiKey)
+	if beforeEgress != nil {
+		if err := beforeEgress(); err != nil {
+			return Result{}, "", false, 0, err
+		}
+	}
 
 	started := time.Now()
 	response, err := c.http.Do(request)
@@ -332,7 +384,7 @@ func (c *Client) processOnce(
 		return Result{}, response.Header.Get("Retry-After"), true, latency, &transientError{status: response.StatusCode}
 	}
 	if response.StatusCode >= http.StatusBadRequest {
-		return Result{}, "", true, latency, fmt.Errorf("mistral OCR HTTP %d: %w", response.StatusCode, ErrPermanentResponse)
+		return Result{}, "", true, latency, &permanentResponseError{status: response.StatusCode}
 	}
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return Result{}, "", true, latency, fmt.Errorf("mistral OCR unexpected HTTP %d", response.StatusCode)
@@ -349,7 +401,7 @@ func (c *Client) processOnce(
 	// request body. Read both sides concurrently so neither blocks the other.
 	bodyDone := make(chan bodyResult, 1)
 	go func() {
-		body, readErr := io.ReadAll(io.LimitReader(response.Body, c.policy.values.MaxResponseBytes+1))
+		body, readErr := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
 		bodyDone <- bodyResult{body: body, err: readErr}
 	}()
 	streamResults := streamDone
@@ -383,7 +435,7 @@ func (c *Client) processOnce(
 					cause: fmt.Errorf("read Mistral OCR response: %w", result.err),
 				}
 			}
-			if int64(len(body)) > c.policy.values.MaxResponseBytes {
+			if int64(len(body)) > maxResponseBytes {
 				latency = time.Since(started)
 				return Result{}, "", true, latency, ErrResponseTooLarge
 			}
@@ -409,7 +461,9 @@ func (c *Client) processOnce(
 	if err := validateWireResult(wire, c.policy.values.Model, snapshot, method, maxUnits); err != nil {
 		return Result{}, "", true, latency, err
 	}
-	return providerNeutralResult(wire, snapshot.format), "", true, latency, nil
+	result := providerNeutralResult(wire, snapshot.format)
+	result.ResponseBytes = int64(len(body))
+	return result, "", true, latency, nil
 }
 
 func newProcessError(err error, requests int, providerLatency time.Duration) error {
@@ -427,6 +481,19 @@ type transientError struct {
 	status int
 	cause  error
 }
+
+type credentialError struct{ cause error }
+
+func (e *credentialError) Error() string { return "Mistral OCR credential is unavailable" }
+func (e *credentialError) Unwrap() error { return e.cause }
+
+type permanentResponseError struct{ status int }
+
+func (e *permanentResponseError) Error() string {
+	return fmt.Sprintf("mistral OCR HTTP %d: %s", e.status, ErrPermanentResponse)
+}
+
+func (e *permanentResponseError) Unwrap() error { return ErrPermanentResponse }
 
 func (e *transientError) Error() string {
 	if e.cause != nil {
@@ -655,7 +722,8 @@ func validateWireResult(
 		return errors.New("mistral OCR response omitted model")
 	}
 	if result.Model != expectedModel {
-		return fmt.Errorf("mistral OCR response model %q does not match requested model", result.Model)
+		return fmt.Errorf("mistral OCR response model %q does not match requested model: %w",
+			result.Model, ErrCapabilityContract)
 	}
 	if result.Pages == nil {
 		return errors.New("mistral OCR response omitted pages")

--- a/document/mistral/rendition.go
+++ b/document/mistral/rendition.go
@@ -1,0 +1,500 @@
+package mistral
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/formatdetect"
+	"go.kenn.io/docbank/document/internal/providerutil"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	renditionProviderID = "mistral.ocr-v1"
+	renditionTimeForm   = "2006-01-02T15:04:05.000000000Z"
+)
+
+var _ document.RenditionProvider = (*RenditionClient)(nil)
+
+// SecretResolver resolves only the profile-bound Mistral OCR credential.
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, name string) (string, error)
+}
+
+// Profile binds one rendition adapter to the existing Mistral OCR policy and
+// its complete capability evidence.
+type Profile struct {
+	Policy             Policy
+	CapabilityManifest CapabilityManifest
+	Descriptor         document.RenditionDescriptor
+	SecretBinding      string
+	Timeout            time.Duration
+	MaxRetries         int
+	MaxRetryDelay      time.Duration
+}
+
+// RenditionClient adapts the bounded Mistral OCR operation to Docbank source
+// evidence. OCR remains separate from Mistral embedding operations.
+type RenditionClient struct {
+	descriptor document.RenditionDescriptor
+	policy     Policy
+	manifest   CapabilityManifest
+	ocr        *Client
+}
+
+// NewRenditionProvider validates a fixed hosted OCR profile without resolving
+// its named credential or performing network access.
+func NewRenditionProvider(
+	profile Profile, secrets SecretResolver, httpClient *http.Client,
+) (*RenditionClient, error) {
+	if profile.Policy.digest == "" {
+		return nil, errors.New("mistral rendition policy is invalid; use NewPolicy")
+	}
+	manifest := cloneCapabilityManifest(profile.CapabilityManifest)
+	if err := manifest.ValidateComplete(); err != nil {
+		return nil, fmt.Errorf("mistral rendition capability manifest: %w", err)
+	}
+	descriptor, err := document.NewRenditionDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		if err == nil {
+			err = errors.New("descriptor is not canonical")
+		}
+		return nil, fmt.Errorf("mistral rendition descriptor: %w", err)
+	}
+	if descriptor.ID != renditionProviderID {
+		return nil, fmt.Errorf("mistral rendition descriptor ID must be %s", renditionProviderID)
+	}
+	if descriptor.TrustBoundary != document.RenditionTrustHostedProvider ||
+		!descriptor.ReturnsMarkdown || !descriptor.ReturnsStructured || len(descriptor.ArtifactRoles) != 0 {
+		return nil, errors.New("mistral rendition descriptor result or trust contract is invalid")
+	}
+	fingerprint, err := profile.Policy.Fingerprint(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("mistral rendition policy fingerprint: %w", err)
+	}
+	if descriptor.PolicyFingerprint != fingerprint {
+		return nil, errors.New("mistral rendition descriptor policy fingerprint does not match capability evidence")
+	}
+	for _, format := range descriptor.SupportedFormats {
+		candidate, ok := renditionCandidate(format)
+		if !ok || format.InputKind != document.RenditionInputOriginalFile {
+			return nil, errors.New("mistral rendition descriptor format is not locally detectable")
+		}
+		authority, authorizeErr := profile.Policy.Authorize(manifest, candidate.ID)
+		if authorizeErr != nil || authority.method == UnitBoundNone {
+			return nil, fmt.Errorf("mistral rendition format %q has no enforceable upload authority", candidate.ID)
+		}
+	}
+	if profile.SecretBinding == "" || nilValue(secrets) {
+		return nil, errors.New("mistral rendition requires a named secret binding and resolver")
+	}
+	if err := validateRenditionToken(profile.SecretBinding, "secret binding"); err != nil {
+		return nil, err
+	}
+	if httpClient == nil {
+		return nil, errors.New("mistral rendition HTTP client is required")
+	}
+	if profile.Timeout == 0 {
+		profile.Timeout = DefaultTimeout
+	}
+	if profile.MaxRetries == 0 {
+		profile.MaxRetries = DefaultMaxRetries
+	}
+	if profile.MaxRetryDelay == 0 {
+		profile.MaxRetryDelay = DefaultMaxRetryDelay
+	}
+	if profile.Timeout < 0 || profile.Timeout > MaxTimeout ||
+		profile.MaxRetries < 0 || profile.MaxRetries > MaxRetries ||
+		profile.MaxRetryDelay < 0 || profile.MaxRetryDelay > MaxRetryDelay {
+		return nil, errors.New("mistral rendition execution bounds are invalid")
+	}
+	isolate := providerhttp.IsolateClient(httpClient)
+	if isolate.Timeout <= 0 || isolate.Timeout > profile.Timeout {
+		isolate.Timeout = profile.Timeout
+	}
+	ocr, err := newClientWithCredential(profile.Policy, ClientConfig{
+		Timeout: profile.Timeout, MaxRetries: profile.MaxRetries,
+		MaxRetryDelay: profile.MaxRetryDelay, HTTPClient: isolate,
+	}, func(ctx context.Context) (string, error) {
+		return secrets.ResolveSecret(ctx, profile.SecretBinding)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mistral rendition client: %w", err)
+	}
+	return &RenditionClient{
+		descriptor: providerutil.CloneDescriptor(descriptor), policy: profile.Policy, manifest: manifest,
+		ocr: ocr,
+	}, nil
+}
+
+// Descriptor returns an immutable copy of the configured provider identity.
+func (client *RenditionClient) Descriptor() document.RenditionDescriptor {
+	if client == nil {
+		return document.RenditionDescriptor{}
+	}
+	return providerutil.CloneDescriptor(client.descriptor)
+}
+
+// Render verifies the one-shot upload again, re-detects its exact media type,
+// and maps bounded OCR output into provider-neutral source evidence.
+func (client *RenditionClient) Render(
+	ctx context.Context, upload document.AuthorizedUpload,
+	authorization document.RenditionAuthorization,
+) (document.RenditionResult, error) {
+	if client == nil {
+		return document.RenditionResult{}, errors.New("mistral rendition client is required")
+	}
+	metadata := upload.Metadata()
+	if metadata.ByteLength > client.policy.values.MaxDocumentBytes {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorPolicyRejected,
+			"Mistral input exceeds the policy byte limit", nil)
+	}
+	expiresAt, err := time.Parse(renditionTimeForm, authorization.ExpiresAt)
+	if err != nil {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorPolicyRejected,
+			"Mistral authorization expiry is invalid", err)
+	}
+	startedAt := time.Now().UTC()
+	if !startedAt.Before(expiresAt) {
+		return document.RenditionResult{}, expiredRenditionError()
+	}
+	operationCtx, cancel := context.WithDeadline(ctx, expiresAt)
+	defer cancel()
+	stopInterrupt := context.AfterFunc(operationCtx, func() { _ = document.InterruptAuthorizedUpload(upload) })
+	source, err := providerutil.ReadAuthorizedUpload(operationCtx, upload, metadata, "Mistral")
+	stopInterrupt()
+	if err != nil {
+		if authorizationDeadlineExpired(ctx, operationCtx) {
+			return document.RenditionResult{}, expiredRenditionError()
+		}
+		return document.RenditionResult{}, err
+	}
+	defer clear(source)
+	candidate, err := formatdetect.DetectFormat(bytes.NewReader(source), int64(len(source)), metadata.MediaType)
+	if err != nil {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorUnsupportedInput,
+			"Mistral input format could not be verified", err)
+	}
+	if candidate.Family != metadata.MediaFamily || candidate.MediaType != metadata.MediaType {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorPolicyRejected,
+			"Mistral input identity does not match authorization", nil)
+	}
+	localUnits := int64(0)
+	if candidate.ID == formatIDPDF {
+		localUnits, err = formatdetect.CountPDFPages(source)
+		if err != nil {
+			return document.RenditionResult{}, renditionError(document.RenditionErrorUnsupportedInput,
+				"Mistral PDF page count could not be verified", err)
+		}
+		if localUnits <= 0 || localUnits > int64(client.policy.values.MaxUnits) {
+			return document.RenditionResult{}, renditionError(document.RenditionErrorPolicyRejected,
+				"Mistral PDF exceeds the complete unit limit", nil)
+		}
+	}
+	formatAuthorization, err := client.policy.Authorize(client.manifest, candidate.ID)
+	if err != nil {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorUnsupportedInput,
+			"Mistral input has no enforceable upload authority", err)
+	}
+	snapshot := preparedSnapshot{
+		size: int64(len(source)), sha256: metadata.SHA256, format: candidate,
+		mediaType: metadata.MediaType,
+	}
+	snapshotForAttempt := func() (preparedSnapshot, error) {
+		digest := sha256.Sum256(source)
+		if int64(len(source)) != metadata.ByteLength || hex.EncodeToString(digest[:]) != metadata.SHA256 {
+			return preparedSnapshot{}, errors.New("mistral rendition source identity changed")
+		}
+		return snapshot, nil
+	}
+	readDocument := func(attemptCtx context.Context, attempt preparedSnapshot) ([]byte, error) {
+		if err := attemptCtx.Err(); err != nil {
+			return nil, err
+		}
+		if attempt.size != int64(len(source)) || attempt.sha256 != metadata.SHA256 {
+			return nil, errors.New("mistral rendition source identity changed")
+		}
+		return bytes.Clone(source), nil
+	}
+	checkExpiry := func() error {
+		if !time.Now().UTC().Before(expiresAt) {
+			return expiredRenditionError()
+		}
+		return nil
+	}
+	options := probeRequestOptions(candidate, client.policy.values.MaxUnits,
+		client.policy.values.ExtractHeader, client.policy.values.ExtractFooter)
+	providerResult, err := client.ocr.processWith(
+		operationCtx, snapshotForAttempt, readDocument, checkExpiry, options,
+		formatAuthorization.method, client.policy.values.MaxUnits,
+		min(client.policy.values.MaxResponseBytes, int64(authorization.MaxTotalResultBytes)),
+	)
+	if err != nil {
+		if authorizationDeadlineExpired(ctx, operationCtx) {
+			return document.RenditionResult{}, expiredRenditionError()
+		}
+		return document.RenditionResult{}, classifyRenditionError(ctx, err)
+	}
+	if candidate.ID == formatIDPDF && int64(providerResult.UnitsProcessed) != localUnits {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorPolicyRejected,
+			"Mistral OCR page count changed", ErrCapabilityContract)
+	}
+	completedAt := time.Now().UTC()
+	if !completedAt.Before(expiresAt) {
+		return document.RenditionResult{}, expiredRenditionError()
+	}
+	includeMarkdown := authorization.MaxProviderMarkdownBytes > 0
+	evidence, markdown, err := mistralEvidence(
+		providerResult.Document, includeMarkdown, int64(authorization.MaxTotalResultBytes),
+	)
+	if err != nil {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorMalformedEvidence,
+			"Mistral OCR output is malformed", err)
+	}
+	if providerutil.InjectsDocbankFrontmatter(markdown) {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorMalformedEvidence,
+			"Mistral OCR provider Markdown attempts Docbank frontmatter injection", nil)
+	}
+	if len(markdown) > authorization.MaxProviderMarkdownBytes {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorMalformedEvidence,
+			"Mistral OCR Markdown exceeds authorization", nil)
+	}
+	authorizationFingerprint, err := authorization.Fingerprint()
+	if err != nil {
+		return document.RenditionResult{}, renditionError(document.RenditionErrorPolicyRejected,
+			"Mistral authorization fingerprint is invalid", err)
+	}
+	return document.RenditionResult{
+		Evidence: evidence, ProviderMarkdown: markdown,
+		Receipt: document.RenditionReceipt{
+			ProviderID: client.descriptor.ID, DescriptorFingerprint: client.descriptor.Fingerprint,
+			PolicyFingerprint:           authorization.PolicyFingerprint,
+			RenditionRequestFingerprint: authorization.RenditionRequestFingerprint,
+			AuthorizationFingerprint:    authorizationFingerprint,
+			SourceSHA256:                metadata.SHA256,
+			OperationID:                 "mistral-" + authorization.RenditionRequestFingerprint[:24],
+			StartedAt:                   startedAt.Format(renditionTimeForm),
+			CompletedAt:                 completedAt.Format(renditionTimeForm),
+			Usage: document.RenditionUsage{
+				Requests: int64(providerResult.Metrics.Requests), Retries: int64(providerResult.Metrics.Retries),
+				InputBytes: metadata.ByteLength, OutputBytes: providerResult.ResponseBytes,
+				Units: int64(providerResult.UnitsProcessed),
+			},
+		},
+	}, nil
+}
+
+func mistralEvidence(
+	source document.SourceDocument, includeMarkdown bool, maxResultBytes int64,
+) (document.SourceEvidenceV1, []byte, error) {
+	unitKind, locatorKind, indexed, ok := renditionUnitKinds(source.UnitKind)
+	if !ok || len(source.Units) == 0 || maxResultBytes <= 0 {
+		return document.SourceEvidenceV1{}, nil, errors.New("unsupported or empty Mistral OCR unit sequence")
+	}
+	evidence := document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1, Completeness: document.EvidenceComplete,
+		Family: source.Family, UnitKind: unitKind,
+		Units: make([]document.SourceEvidenceUnitV1, 0, len(source.Units)),
+	}
+	markdownPages := make([]string, 0, len(source.Units))
+	remainingBytes := maxResultBytes
+	for order, sourceUnit := range source.Units {
+		if sourceUnit.Index != order || !utf8.ValidString(sourceUnit.Markdown) ||
+			!utf8.ValidString(sourceUnit.Header) || !utf8.ValidString(sourceUnit.Footer) {
+			return document.SourceEvidenceV1{}, nil, errors.New("invalid Mistral OCR unit")
+		}
+		evidenceBytes := mistralUnitBytes(sourceUnit)
+		markdownBytes := int64(0)
+		if includeMarkdown {
+			markdownBytes = int64(len(sourceUnit.Markdown))
+			if order > 0 {
+				markdownBytes += int64(len("\n\n---\n\n"))
+			}
+		}
+		if evidenceBytes > remainingBytes || markdownBytes > remainingBytes-evidenceBytes {
+			return document.SourceEvidenceV1{}, nil, errors.New("mistral OCR output exceeds authorization")
+		}
+		remainingBytes -= evidenceBytes + markdownBytes
+		text := joinMistralUnit(sourceUnit)
+		locator := document.SourceEvidenceLocatorV1{
+			Kind: locatorKind, IndexOrigin: document.EvidenceIndexOriginNone,
+		}
+		if indexed {
+			locator.IndexOrigin = document.EvidenceIndexOriginZero
+			locator.Start, locator.End = int64(order), int64(order)
+			if locatorKind == document.EvidenceLocatorSheet {
+				locator.Name = fmt.Sprintf("mistral-unit-%d", order)
+			}
+		} else {
+			locator.Name = fmt.Sprintf("mistral-unit-%d", order)
+		}
+		evidence.Units = append(evidence.Units, document.SourceEvidenceUnitV1{
+			Order: order, ProviderID: fmt.Sprintf("mistral-unit-%d", order), Text: text, Locator: locator,
+		})
+		if includeMarkdown {
+			markdownPages = append(markdownPages, sourceUnit.Markdown)
+		}
+	}
+	var markdown []byte
+	if includeMarkdown {
+		markdown = []byte(strings.Join(markdownPages, "\n\n---\n\n"))
+		if len(markdown) == 0 {
+			return document.SourceEvidenceV1{}, nil, errors.New("mistral OCR returned empty Markdown")
+		}
+	}
+	if err := document.ValidateSourceEvidenceV1(evidence); err != nil {
+		return document.SourceEvidenceV1{}, nil, err
+	}
+	return evidence, markdown, nil
+}
+
+func mistralUnitBytes(unit document.SourceUnit) int64 {
+	parts := int64(0)
+	total := int64(0)
+	for _, part := range []string{unit.Header, unit.Markdown, unit.Footer} {
+		if part == "" {
+			continue
+		}
+		if parts > 0 {
+			total += int64(len("\n\n"))
+		}
+		total += int64(len(part))
+		parts++
+	}
+	return total
+}
+
+func joinMistralUnit(unit document.SourceUnit) string {
+	parts := make([]string, 0, 3)
+	for _, part := range []string{unit.Header, unit.Markdown, unit.Footer} {
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func renditionUnitKinds(
+	unitKind string,
+) (document.EvidenceUnitKind, document.EvidenceLocatorKind, bool, bool) {
+	switch unitKind {
+	case "page":
+		return document.EvidenceUnitPage, document.EvidenceLocatorPage, true, true
+	case "slide":
+		return document.EvidenceUnitSlide, document.EvidenceLocatorSlide, true, true
+	case "sheet":
+		return document.EvidenceUnitSheet, document.EvidenceLocatorSheet, true, true
+	case "record":
+		return document.EvidenceUnitRecord, document.EvidenceLocatorRecord, true, true
+	case "spine":
+		return document.EvidenceUnitSpine, document.EvidenceLocatorSpine, true, true
+	case "line":
+		return document.EvidenceUnitLine, document.EvidenceLocatorLine, true, true
+	case "message":
+		return document.EvidenceUnitMessage, document.EvidenceLocatorMessage, false, true
+	case "section":
+		return document.EvidenceUnitSection, document.EvidenceLocatorSection, false, true
+	default:
+		return "", "", false, false
+	}
+}
+
+func classifyRenditionError(ctx context.Context, cause error) error {
+	if providerError, ok := errors.AsType[*document.RenditionProviderError](cause); ok {
+		return providerError
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return renditionError(document.RenditionErrorCanceled, "Mistral rendering canceled", ctxErr)
+	}
+	if _, ok := errors.AsType[*credentialError](cause); ok {
+		return renditionError(document.RenditionErrorAuthentication,
+			"Mistral credential is unavailable", cause)
+	}
+	if transient, ok := errors.AsType[*transientError](cause); ok && transient.status == http.StatusTooManyRequests {
+		return renditionError(document.RenditionErrorRateLimited, "Mistral rate limit was exhausted", cause)
+	}
+	if transient, ok := errors.AsType[*transientError](cause); ok &&
+		(transient.status == http.StatusServiceUnavailable || transient.status == http.StatusInsufficientStorage) {
+		return renditionError(document.RenditionErrorCapacity, "Mistral capacity is unavailable", cause)
+	}
+	if permanent, ok := errors.AsType[*permanentResponseError](cause); ok {
+		switch permanent.status {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return renditionError(document.RenditionErrorAuthentication, "Mistral authentication was rejected", cause)
+		case http.StatusUnsupportedMediaType:
+			return renditionError(document.RenditionErrorUnsupportedInput, "Mistral input format was rejected", cause)
+		default:
+			return renditionError(document.RenditionErrorPolicyRejected, "Mistral rejected the OCR request", cause)
+		}
+	}
+	switch {
+	case errors.Is(cause, ErrTransientResponse):
+		return renditionError(document.RenditionErrorTransient, "Mistral request retries were exhausted", cause)
+	case errors.Is(cause, ErrCapabilityContract):
+		return renditionError(document.RenditionErrorPolicyRejected, "Mistral OCR capability changed", cause)
+	case errors.Is(cause, ErrPermanentResponse):
+		return renditionError(document.RenditionErrorPolicyRejected, "Mistral rejected the OCR request", cause)
+	case errors.Is(cause, ErrResponseTooLarge):
+		return renditionError(document.RenditionErrorMalformedEvidence, "Mistral OCR response exceeds policy", cause)
+	default:
+		return renditionError(document.RenditionErrorMalformedEvidence, "Mistral OCR response is malformed", cause)
+	}
+}
+
+func expiredRenditionError() error {
+	return renditionError(document.RenditionErrorPolicyRejected, "Mistral authorization expired", nil)
+}
+
+func authorizationDeadlineExpired(callerCtx, operationCtx context.Context) bool {
+	return callerCtx.Err() == nil && errors.Is(operationCtx.Err(), context.DeadlineExceeded)
+}
+
+func renditionError(code document.RenditionErrorCode, message string, cause error) error {
+	return providerutil.ClassifiedError("Mistral", code, message, cause)
+}
+
+func renditionCandidate(format document.RenditionFormatCapability) (CandidateFormat, bool) {
+	for _, candidate := range candidateFormats {
+		if candidate.Family == format.MediaFamily && candidate.MediaType == format.MediaType {
+			return candidate, true
+		}
+	}
+	return CandidateFormat{}, false
+}
+
+func validateRenditionToken(value, subject string) error {
+	if value == "" || len(value) > 128 || value != strings.TrimSpace(value) || !utf8.ValidString(value) {
+		return fmt.Errorf("mistral rendition %s must contain 1-128 characters", subject)
+	}
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' ||
+			char >= '0' && char <= '9' || strings.ContainsRune("_.-", char) {
+			continue
+		}
+		return fmt.Errorf("mistral rendition %s contains unsupported characters", subject)
+	}
+	return nil
+}
+
+func nilValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/document/mistral/rendition_test.go
+++ b/document/mistral/rendition_test.go
@@ -1,0 +1,668 @@
+package mistral
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+)
+
+var _ document.RenditionProvider = (*RenditionClient)(nil)
+
+type renditionSecrets map[string]string
+
+func (secrets renditionSecrets) ResolveSecret(_ context.Context, name string) (string, error) {
+	return secrets[name], nil
+}
+
+func TestNewRenditionProviderAdvertisesOnlyManifestAuthorizedFormats(t *testing.T) {
+	policy := testPolicy(t, 1<<20, 10)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+
+	client, err := NewRenditionProvider(Profile{
+		Policy: policy, CapabilityManifest: manifest, Descriptor: descriptor,
+		SecretBinding: "mistral-ocr",
+	}, renditionSecrets{"mistral-ocr": "synthetic-key"}, http.DefaultClient)
+	require.NoError(t, err)
+	assert.Equal(t, descriptor, client.Descriptor())
+
+	broader := renditionDescriptor(t, policy, manifest, "pdf", "doc")
+	_, err = NewRenditionProvider(Profile{
+		Policy: policy, CapabilityManifest: manifest, Descriptor: broader,
+		SecretBinding: "mistral-ocr",
+	}, renditionSecrets{"mistral-ocr": "synthetic-key"}, http.DefaultClient)
+	require.ErrorContains(t, err, "no enforceable upload authority")
+
+	incomplete := manifest
+	incomplete.Results = incomplete.Results[:1]
+	_, err = NewRenditionProvider(Profile{
+		Policy: policy, CapabilityManifest: incomplete, Descriptor: descriptor,
+		SecretBinding: "mistral-ocr",
+	}, renditionSecrets{"mistral-ocr": "synthetic-key"}, http.DefaultClient)
+	require.ErrorContains(t, err, "capability manifest")
+}
+
+func TestRenditionClientMapsExactMistralOCRResponse(t *testing.T) {
+	policy := testPolicy(t, 1<<20, 10)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	source := testPDF("rendition")
+	fixture := renditionFixture(t, descriptor, source)
+	var uploaded []byte
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		assert.Equal(t, "Bearer synthetic-key", request.Header.Get("Authorization"))
+		body, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		var wire struct {
+			Document struct {
+				URL string `json:"document_url"`
+			} `json:"document"`
+		}
+		require.NoError(t, json.Unmarshal(body, &wire))
+		uploaded, err = base64.StdEncoding.DecodeString(strings.TrimPrefix(
+			wire.Document.URL, "data:application/pdf;base64,",
+		))
+		require.NoError(t, err)
+		response := fmt.Sprintf(`{"model":"mistral-ocr-4-0","pages":[{"index":0,"markdown":"# Synthetic","header":"Header","footer":"Footer","dimensions":{"dpi":144,"height":792,"width":612}}],"usage_info":{"pages_processed":1,"doc_size_bytes":%d}}`, len(source))
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(response)), Request: request,
+		}, nil
+	})}
+	client, err := NewRenditionProvider(Profile{
+		Policy: policy, CapabilityManifest: manifest, Descriptor: descriptor,
+		SecretBinding: "mistral-ocr", Timeout: time.Second, MaxRetries: 1,
+		MaxRetryDelay: time.Millisecond,
+	}, renditionSecrets{"mistral-ocr": "synthetic-key"}, httpClient)
+	require.NoError(t, err)
+
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, source, uploaded)
+	assert.Equal(t, document.SourceEvidenceContractV1, result.Evidence.ContractVersion)
+	assert.Equal(t, document.EvidenceComplete, result.Evidence.Completeness)
+	assert.Equal(t, "pdf", result.Evidence.Family)
+	assert.Equal(t, document.EvidenceUnitPage, result.Evidence.UnitKind)
+	require.Len(t, result.Evidence.Units, 1)
+	assert.Equal(t, "Header\n\n# Synthetic\n\nFooter", result.Evidence.Units[0].Text)
+	assert.Equal(t, document.SourceEvidenceLocatorV1{
+		Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginZero,
+		Start: 0, End: 0,
+	}, result.Evidence.Units[0].Locator)
+	assert.Equal(t, "# Synthetic", string(result.ProviderMarkdown))
+	assert.Equal(t, fixture.metadata.SHA256, result.Receipt.SourceSHA256)
+	assert.Equal(t, int64(1), result.Receipt.Usage.Requests)
+	assert.Equal(t, int64(len(source)), result.Receipt.Usage.InputBytes)
+	assert.Equal(t, int64(1), result.Receipt.Usage.Units)
+	assert.NotContains(t, fmt.Sprintf("%+v", result.Receipt), "synthetic-key")
+}
+
+func TestRenditionClientClassifiesHTTPAndModelFailures(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		status int
+		body   string
+		want   document.RenditionErrorCode
+	}{
+		{name: "authentication", status: http.StatusUnauthorized, want: document.RenditionErrorAuthentication},
+		{name: "unsupported", status: http.StatusUnsupportedMediaType, want: document.RenditionErrorUnsupportedInput},
+		{name: "too large", status: http.StatusRequestEntityTooLarge, want: document.RenditionErrorPolicyRejected},
+		{name: "capacity", status: http.StatusServiceUnavailable, want: document.RenditionErrorCapacity},
+		{name: "rate limited", status: http.StatusTooManyRequests, want: document.RenditionErrorRateLimited},
+		{name: "model drift", status: http.StatusOK, body: `{"model":"mistral-ocr-next","pages":[{"index":0,"markdown":"safe"}],"usage_info":{"pages_processed":1}}`, want: document.RenditionErrorPolicyRejected},
+		{name: "malformed", status: http.StatusOK, body: `{`, want: document.RenditionErrorMalformedEvidence},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			policy := testPolicy(t, 1<<20, 10)
+			manifest := syntheticManifest(t, policy, true)
+			descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+			fixture := renditionFixture(t, descriptor, testPDF("classified"))
+			body := testCase.body
+			if body == "" {
+				body = `{"private":"provider detail"}`
+			}
+			client := newRenditionTestClient(t, policy, manifest, descriptor,
+				renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: testCase.status, Header: http.Header{"Content-Type": []string{"application/json"}},
+						Body: io.NopCloser(strings.NewReader(body)), Request: request,
+					}, nil
+				}))
+			_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+			assertRenditionCode(t, err, testCase.want)
+			assert.NotContains(t, err.Error(), "provider detail")
+		})
+	}
+}
+
+func TestRenditionClientRechecksIdentityAndDetectsMediaBeforeEgress(t *testing.T) {
+	policy := testPolicy(t, 1<<20, 10)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	fixture := renditionFixture(t, descriptor, testPDF("identity"))
+	var requests atomic.Int64
+	client := newRenditionTestClient(t, policy, manifest, descriptor,
+		renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requests.Add(1)
+			return nil, errors.New("unexpected request")
+		}))
+
+	short, ok := fixture.upload().(*renditionUpload)
+	require.True(t, ok)
+	short.Reader = bytes.NewReader(fixture.source[:len(fixture.source)-1])
+	_, err := client.Render(t.Context(), short, fixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorPolicyRejected)
+
+	text := []byte("not a PDF")
+	textFixture := renditionFixture(t, descriptor, text)
+	_, err = client.Render(t.Context(), textFixture.upload(), textFixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorUnsupportedInput)
+
+	unsafePDF := testPDFXRefStreamWith(func(entries []byte, _ []int) []byte {
+		return entries[:7]
+	})
+	unsafeFixture := renditionFixture(t, descriptor, unsafePDF)
+	_, err = client.Render(t.Context(), unsafeFixture.upload(), unsafeFixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorUnsupportedInput)
+	assert.Zero(t, requests.Load())
+}
+
+type countingSecrets struct {
+	calls atomic.Int64
+	err   error
+}
+
+func (secrets *countingSecrets) ResolveSecret(context.Context, string) (string, error) {
+	secrets.calls.Add(1)
+	if secrets.err != nil {
+		return "", secrets.err
+	}
+	return "synthetic-key", nil
+}
+
+func TestRenditionClientResolvesSecretPerAttemptAndStopsAtExpiry(t *testing.T) {
+	policy := testPolicy(t, 1<<20, 10)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	fixture := renditionFixture(t, descriptor, testPDF("expiry"))
+	fixture.authorization.ExpiresAt = time.Now().UTC().Add(20 * time.Millisecond).Format("2006-01-02T15:04:05.000000000Z")
+	secrets := &countingSecrets{}
+	var requests atomic.Int64
+	client := newRenditionTestClient(t, policy, manifest, descriptor, secrets,
+		roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			requests.Add(1)
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"1"}, "Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{}`)), Request: request,
+			}, nil
+		}))
+
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorPolicyRejected)
+	assert.Equal(t, int64(1), requests.Load())
+	assert.Equal(t, int64(1), secrets.calls.Load(), "expired retry must not resolve another credential")
+}
+
+func TestRenditionClientExpiryCancelsInFlightUpload(t *testing.T) {
+	policy := testPolicy(t, 1<<20, 10)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	fixture := renditionFixture(t, descriptor, testPDF("slow-upload"))
+	expiresAt := time.Now().UTC().Add(150 * time.Millisecond)
+	fixture.authorization.ExpiresAt = expiresAt.Format("2006-01-02T15:04:05.000000000Z")
+	requestStarted := make(chan struct{})
+	client, err := NewRenditionProvider(Profile{
+		Policy: policy, CapabilityManifest: manifest, Descriptor: descriptor,
+		SecretBinding: "mistral-ocr", Timeout: time.Second, MaxRetries: 1,
+		MaxRetryDelay: time.Millisecond,
+	}, renditionSecrets{"mistral-ocr": "synthetic-key"}, &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		close(requestStarted)
+		buffer := make([]byte, 1)
+		for {
+			if _, readErr := request.Body.Read(buffer); readErr != nil {
+				return nil, readErr
+			}
+			timer := time.NewTimer(5 * time.Millisecond)
+			select {
+			case <-request.Context().Done():
+				timer.Stop()
+				return nil, request.Context().Err()
+			case <-timer.C:
+			}
+		}
+	})})
+	require.NoError(t, err)
+	callerCtx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	started := time.Now()
+	_, err = client.Render(callerCtx, fixture.upload(), fixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorPolicyRejected)
+	require.ErrorContains(t, errors.Unwrap(err), "authorization expired")
+	assert.Less(t, time.Since(started), 600*time.Millisecond)
+	select {
+	case <-requestStarted:
+	default:
+		t.Fatal("slow upload never reached the transport")
+	}
+}
+
+func TestRenditionClientRejectsPDFAboveCompleteUnitLimitBeforeEgress(t *testing.T) {
+	policy := testPolicy(t, 1<<20, MinUnits)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	fixture := renditionFixture(t, descriptor, testMultipagePDF(MinUnits+1))
+	var requests atomic.Int64
+	client := newRenditionTestClient(t, policy, manifest, descriptor,
+		renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requests.Add(1)
+			return nil, errors.New("unexpected provider request")
+		}))
+
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorPolicyRejected)
+	require.ErrorContains(t, errors.Unwrap(err), "unit limit")
+	assert.Zero(t, requests.Load())
+}
+
+func TestRenditionClientRejectsIncompletePDFResponse(t *testing.T) {
+	policy := testPolicy(t, 1<<20, MinUnits)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	fixture := renditionFixture(t, descriptor, testMultipagePDF(2))
+	client := newRenditionTestClient(t, policy, manifest, descriptor,
+		renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"model":"mistral-ocr-4-0","pages":[{"index":0,"markdown":"first"}],"usage_info":{"pages_processed":1}}`,
+				)), Request: request,
+			}, nil
+		}))
+
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorPolicyRejected)
+	require.ErrorContains(t, errors.Unwrap(err), "page count changed")
+}
+
+func TestRenditionClientBoundsResponseAndKeepsCredentialErrorsSafe(t *testing.T) {
+	policy := testPolicy(t, 1<<20, 10)
+	policy.values.MaxResponseBytes = 64
+	var err error
+	policy.digest, err = policyValuesDigest(policy.values)
+	require.NoError(t, err)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	fixture := renditionFixture(t, descriptor, testPDF("bounded"))
+	client := newRenditionTestClient(t, policy, manifest, descriptor,
+		renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(strings.Repeat("x", 65))), Request: request,
+			}, nil
+		}))
+	_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorMalformedEvidence)
+
+	privateCause := errors.New("secret provider token=private-value")
+	secrets := &countingSecrets{err: privateCause}
+	client = newRenditionTestClient(t, policy, manifest, descriptor, secrets,
+		roundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("credential failure must precede egress")
+			return nil, errors.New("unexpected egress")
+		}))
+	_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorAuthentication)
+	assert.NotContains(t, err.Error(), "private-value")
+}
+
+func TestRenditionClientResolvesNamedSecretForEveryEgress(t *testing.T) {
+	policy := testPolicy(t, 1<<20, 10)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	fixture := renditionFixture(t, descriptor, testPDF("retry-secret"))
+	secrets := &countingSecrets{}
+	var requests atomic.Int64
+	client := newRenditionTestClient(t, policy, manifest, descriptor, secrets,
+		roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			attempt := requests.Add(1)
+			if attempt == 1 {
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     http.Header{"Retry-After": []string{"0"}}, Body: io.NopCloser(strings.NewReader(`{}`)), Request: request,
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"model":"mistral-ocr-4-0","pages":[{"index":0,"markdown":"safe"}],"usage_info":{"pages_processed":1}}`,
+				)), Request: request,
+			}, nil
+		}))
+	result, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), requests.Load())
+	assert.Equal(t, int64(2), secrets.calls.Load())
+	assert.Equal(t, int64(1), result.Receipt.Usage.Retries)
+}
+
+func TestRenditionClientRefusesRedirects(t *testing.T) {
+	policy := testPolicy(t, 1<<20, 10)
+	manifest := syntheticManifest(t, policy, true)
+	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+	fixture := renditionFixture(t, descriptor, testPDF("redirect"))
+	var targetRequests atomic.Int64
+	target := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { targetRequests.Add(1) })
+	targetServer := newTLSServer(t, target)
+	redirectServer := newTLSServer(t, http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Redirect(response, request, targetServer.URL, http.StatusTemporaryRedirect)
+	}))
+	client := renditionServerClient(t, policy, manifest, descriptor, redirectServer)
+
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertRenditionCode(t, err, document.RenditionErrorMalformedEvidence)
+	assert.Zero(t, targetRequests.Load())
+}
+
+func TestRenditionClientHonorsResultAuthorization(t *testing.T) {
+	t.Run("response size", func(t *testing.T) {
+		policy := testPolicy(t, 1<<20, 10)
+		manifest := syntheticManifest(t, policy, true)
+		descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+		fixture := renditionFixture(t, descriptor, testPDF("bounded-response"))
+		client := newRenditionTestClient(t, policy, manifest, descriptor,
+			renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(
+						strings.Repeat("x", fixture.authorization.MaxTotalResultBytes+1),
+					)), Request: request,
+				}, nil
+			}))
+
+		_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+		assertRenditionCode(t, err, document.RenditionErrorMalformedEvidence)
+		assert.ErrorIs(t, err, ErrResponseTooLarge)
+	})
+
+	t.Run("materialized result size", func(t *testing.T) {
+		policy := testPolicy(t, 1<<20, 10)
+		manifest := syntheticManifest(t, policy, true)
+		descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+		fixture := renditionFixture(t, descriptor, testPDF("bounded-result"))
+		fixture.authorization.MaxTotalResultBytes = 512
+		client := newRenditionTestClient(t, policy, manifest, descriptor,
+			renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(
+						mistralRenditionResponse(strings.Repeat("x", 300)),
+					)), Request: request,
+				}, nil
+			}))
+
+		_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+		assertRenditionCode(t, err, document.RenditionErrorMalformedEvidence)
+		assert.ErrorContains(t, errors.Unwrap(err), "output exceeds authorization")
+	})
+
+	t.Run("reserved frontmatter", func(t *testing.T) {
+		policy := testPolicy(t, 1<<20, 10)
+		manifest := syntheticManifest(t, policy, true)
+		descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+		fixture := renditionFixture(t, descriptor, testPDF("reserved-frontmatter"))
+		client := newRenditionTestClient(t, policy, manifest, descriptor,
+			renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(mistralRenditionResponse(
+						"---\ncontract: docbank-sanitized-markdown/v1\n---\nunsafe",
+					))), Request: request,
+				}, nil
+			}))
+
+		_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+		assertRenditionCode(t, err, document.RenditionErrorMalformedEvidence)
+		assert.ErrorContains(t, errors.Unwrap(err), "frontmatter injection")
+	})
+
+	t.Run("zero Markdown allowance", func(t *testing.T) {
+		policy := testPolicy(t, 1<<20, 10)
+		manifest := syntheticManifest(t, policy, true)
+		descriptor := renditionDescriptor(t, policy, manifest, "pdf")
+		fixture := renditionFixture(t, descriptor, testPDF("structured-only"))
+		fixture.authorization.MaxProviderMarkdownBytes = 0
+		client := newRenditionTestClient(t, policy, manifest, descriptor,
+			renditionSecrets{"mistral-ocr": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(mistralRenditionResponse("evidence only"))), Request: request,
+				}, nil
+			}))
+
+		result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+		require.NoError(t, err)
+		assert.Empty(t, result.ProviderMarkdown)
+		require.Len(t, result.Evidence.Units, 1)
+		assert.Equal(t, "evidence only", result.Evidence.Units[0].Text)
+	})
+}
+
+func TestMistralEvidenceMapsNaturalFamilies(t *testing.T) {
+	for _, testCase := range []struct {
+		name, family, sourceKind string
+		wantKind                 document.EvidenceUnitKind
+		wantLocator              document.EvidenceLocatorKind
+	}{
+		{name: "pdf", family: "pdf", sourceKind: "page", wantKind: document.EvidenceUnitPage, wantLocator: document.EvidenceLocatorPage},
+		{name: "word", family: "word", sourceKind: "page", wantKind: document.EvidenceUnitPage, wantLocator: document.EvidenceLocatorPage},
+		{name: "presentation", family: "presentation", sourceKind: "slide", wantKind: document.EvidenceUnitSlide, wantLocator: document.EvidenceLocatorSlide},
+		{name: "spreadsheet sheet", family: "spreadsheet", sourceKind: "sheet", wantKind: document.EvidenceUnitSheet, wantLocator: document.EvidenceLocatorSheet},
+		{name: "spreadsheet record", family: "spreadsheet", sourceKind: "record", wantKind: document.EvidenceUnitRecord, wantLocator: document.EvidenceLocatorRecord},
+		{name: "ebook", family: "ebook", sourceKind: "spine", wantKind: document.EvidenceUnitSpine, wantLocator: document.EvidenceLocatorSpine},
+		{name: "structured", family: "structured", sourceKind: "record", wantKind: document.EvidenceUnitRecord, wantLocator: document.EvidenceLocatorRecord},
+		{name: "text", family: "text", sourceKind: "section", wantKind: document.EvidenceUnitSection, wantLocator: document.EvidenceLocatorSection},
+		{name: "source", family: "source", sourceKind: "section", wantKind: document.EvidenceUnitSection, wantLocator: document.EvidenceLocatorSection},
+		{name: "mail", family: "mail", sourceKind: "message", wantKind: document.EvidenceUnitMessage, wantLocator: document.EvidenceLocatorMessage},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			evidence, markdown, err := mistralEvidence(document.SourceDocument{
+				Family: testCase.family, UnitKind: testCase.sourceKind,
+				Units: []document.SourceUnit{{Index: 0, Markdown: "synthetic"}},
+			}, true, 1<<20)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.wantKind, evidence.UnitKind)
+			assert.Equal(t, testCase.wantLocator, evidence.Units[0].Locator.Kind)
+			if testCase.wantLocator == document.EvidenceLocatorSheet {
+				assert.Equal(t, "mistral-unit-0", evidence.Units[0].Locator.Name)
+			}
+			assert.Equal(t, "synthetic", string(markdown))
+		})
+	}
+}
+
+func mistralRenditionResponse(markdown string) string {
+	return fmt.Sprintf(
+		`{"model":"mistral-ocr-4-0","pages":[{"index":0,"markdown":%q}],"usage_info":{"pages_processed":1}}`,
+		markdown,
+	)
+}
+
+func newRenditionTestClient(
+	t *testing.T, policy Policy, manifest CapabilityManifest, descriptor document.RenditionDescriptor,
+	secrets SecretResolver, transport http.RoundTripper,
+) *RenditionClient {
+	t.Helper()
+	drainingTransport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		_, err := io.Copy(io.Discard, request.Body)
+		require.NoError(t, err)
+		return transport.RoundTrip(request)
+	})
+	client, err := NewRenditionProvider(Profile{
+		Policy: policy, CapabilityManifest: manifest, Descriptor: descriptor,
+		SecretBinding: "mistral-ocr", Timeout: time.Second, MaxRetries: 1,
+		MaxRetryDelay: 50 * time.Millisecond,
+	}, secrets, &http.Client{Transport: drainingTransport})
+	require.NoError(t, err)
+	return client
+}
+
+func newTLSServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func renditionServerClient(
+	t *testing.T, policy Policy, manifest CapabilityManifest,
+	descriptor document.RenditionDescriptor, server *httptest.Server,
+) *RenditionClient {
+	t.Helper()
+	target, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	base := server.Client()
+	transport := base.Transport
+	client, err := NewRenditionProvider(Profile{
+		Policy: policy, CapabilityManifest: manifest, Descriptor: descriptor,
+		SecretBinding: "mistral-ocr", Timeout: time.Second, MaxRetries: 1,
+		MaxRetryDelay: 50 * time.Millisecond,
+	}, renditionSecrets{"mistral-ocr": "synthetic-key"}, &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		clone := request.Clone(request.Context())
+		clone.URL.Scheme, clone.URL.Host = target.Scheme, target.Host
+		return transport.RoundTrip(clone)
+	})})
+	require.NoError(t, err)
+	return client
+}
+
+func assertRenditionCode(t *testing.T, err error, want document.RenditionErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	providerError, ok := errors.AsType[*document.RenditionProviderError](err)
+	require.True(t, ok, "%T: %v", err, err)
+	assert.Equal(t, want, providerError.Code())
+}
+
+type renditionUpload struct {
+	*bytes.Reader
+
+	metadata document.AuthorizedUploadMetadata
+}
+
+func (upload *renditionUpload) Close() error { return nil }
+
+func (upload *renditionUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+type renditionTestFixture struct {
+	metadata      document.AuthorizedUploadMetadata
+	authorization document.RenditionAuthorization
+	source        []byte
+}
+
+func renditionFixture(
+	t *testing.T, descriptor document.RenditionDescriptor, source []byte,
+) renditionTestFixture {
+	t.Helper()
+	digest := sha256.Sum256(source)
+	metadata := document.AuthorizedUploadMetadata{
+		Filename: "document.pdf", MediaFamily: "pdf", MediaType: "application/pdf",
+		ByteLength: int64(len(source)), SHA256: hex.EncodeToString(digest[:]),
+		CapabilityRecordChecksum: strings.Repeat("2", 64),
+		ProviderMetadataChecksum: strings.Repeat("3", 64),
+		InputKind:                document.RenditionInputOriginalFile,
+	}
+	started := time.Now().UTC().Add(-time.Minute)
+	return renditionTestFixture{metadata: metadata, source: source, authorization: document.RenditionAuthorization{
+		ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+		PolicyFingerprint:           descriptor.PolicyFingerprint,
+		RenditionRequestFingerprint: strings.Repeat("4", 64), SourceSHA256: metadata.SHA256,
+		SourceBytes: metadata.ByteLength, CapabilityRecordChecksum: metadata.CapabilityRecordChecksum,
+		ProviderMetadataChecksum: metadata.ProviderMetadataChecksum, MediaFamily: metadata.MediaFamily,
+		MediaType: metadata.MediaType, InputKind: metadata.InputKind,
+		MaxProviderMarkdownBytes: 4096, MaxTotalResultBytes: 32768,
+		AuthorizedAt: started.Format("2006-01-02T15:04:05.000000000Z"),
+		ExpiresAt:    started.Add(10 * time.Minute).Format("2006-01-02T15:04:05.000000000Z"),
+	}}
+}
+
+func (fixture renditionTestFixture) upload() document.AuthorizedUpload {
+	return &renditionUpload{Reader: bytes.NewReader(fixture.source), metadata: fixture.metadata}
+}
+
+func renditionDescriptor(
+	t *testing.T, policy Policy, manifest CapabilityManifest, formatIDs ...string,
+) document.RenditionDescriptor {
+	t.Helper()
+	formats := make([]document.RenditionFormatCapability, 0, len(formatIDs))
+	for _, formatID := range formatIDs {
+		candidate, ok := CandidateFormatByID(formatID)
+		require.True(t, ok)
+		formats = append(formats, document.RenditionFormatCapability{
+			MediaFamily: candidate.Family, MediaType: candidate.MediaType,
+			InputKind: document.RenditionInputOriginalFile,
+		})
+	}
+	fingerprint, err := policy.Fingerprint(manifest)
+	require.NoError(t, err)
+	descriptor, err := document.NewRenditionDescriptor(document.RenditionDescriptor{
+		ID: "mistral.ocr-v1", ContractVersion: document.RenditionProviderContractVersion,
+		PolicyFingerprint: fingerprint, TrustBoundary: document.RenditionTrustHostedProvider,
+		SupportedFormats: formats, ReturnsMarkdown: true, ReturnsStructured: true,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, descriptor.Fingerprint, " ")
+	return descriptor
+}
+
+func testMultipagePDF(pages int) []byte {
+	objects := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+	}
+	kids := make([]string, pages)
+	for index := range pages {
+		kids[index] = fmt.Sprintf("%d 0 R", index+3)
+	}
+	objects = append(objects, fmt.Sprintf("<< /Type /Pages /Kids [%s] /Count %d >>", strings.Join(kids, " "), pages))
+	for index := range pages {
+		objects = append(objects, fmt.Sprintf(
+			"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents %d 0 R >>",
+			pages+index+3,
+		))
+	}
+	for index := range pages {
+		objects = append(objects, fmt.Sprintf("<< /Length 0 >>\nstream\n\nendstream %% %d", index))
+	}
+	var output bytes.Buffer
+	output.WriteString("%PDF-1.4\n")
+	offsets := make([]int, len(objects))
+	for index, object := range objects {
+		offsets[index] = output.Len()
+		_, _ = fmt.Fprintf(&output, "%d 0 obj\n%s\nendobj\n", index+1, object)
+	}
+	xref := output.Len()
+	_, _ = fmt.Fprintf(&output, "xref\n0 %d\n0000000000 65535 f \n", len(objects)+1)
+	for _, offset := range offsets {
+		_, _ = fmt.Fprintf(&output, "%010d 00000 n \n", offset)
+	}
+	_, _ = fmt.Fprintf(&output,
+		"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
+	return output.Bytes()
+}

--- a/document/mistral/test_helpers_test.go
+++ b/document/mistral/test_helpers_test.go
@@ -3,6 +3,7 @@ package mistral
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -113,13 +114,43 @@ func testPDF(label string) []byte {
 }
 
 func testPDFXRefStream() []byte {
+	return testPDFXRefStreamWith(nil)
+}
+
+func testPDFXRefStreamWith(mutate func([]byte, []int) []byte) []byte {
 	var output bytes.Buffer
 	output.WriteString("%PDF-1.5\n")
+	offsets := make([]int, 3)
+	for index, object := range []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R >>",
+	} {
+		offsets[index] = output.Len()
+		_, _ = fmt.Fprintf(&output, "%d 0 obj\n%s\nendobj\n", index+1, object)
+	}
 	xref := output.Len()
-	_, _ = fmt.Fprintf(&output, "1 0 obj\n<< /Type /XRef /Size 2 /Root 2 0 R /W [1 2 1] /Length 4 >>\nstream\n")
-	output.Write([]byte{0, 0, 0, 0})
+	entries := make([]byte, 5*7)
+	putTestXRefEntry(entries, 0, 0, 0, 65_535)
+	for index, offset := range offsets {
+		putTestXRefEntry(entries, index+1, 1, uint32(offset), 0) // #nosec G115 -- bounded fixture.
+	}
+	putTestXRefEntry(entries, 4, 1, uint32(xref), 0) // #nosec G115 -- bounded fixture.
+	if mutate != nil {
+		entries = mutate(entries, offsets)
+	}
+	_, _ = fmt.Fprintf(&output,
+		"4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length %d >>\nstream\n", len(entries))
+	output.Write(entries)
 	_, _ = fmt.Fprintf(&output, "\nendstream\nendobj\nstartxref\n%d\n%%%%EOF\n", xref)
 	return output.Bytes()
+}
+
+func putTestXRefEntry(entries []byte, index int, kind byte, offset uint32, generation uint16) {
+	entry := entries[index*7 : (index+1)*7]
+	entry[0] = kind
+	binary.BigEndian.PutUint32(entry[1:5], offset)
+	binary.BigEndian.PutUint16(entry[5:7], generation)
 }
 
 type errorReader struct {


### PR DESCRIPTION
## What changed

Docbank now runs the existing Mistral OCR path through the same provider-neutral rendition contract as Docling and Datalab. It verifies one sealed upload, resolves the named credential per attempt, keeps authority expiry active through upload and retries, and converts Mistral pages into complete PDF evidence plus bounded Markdown and a sanitized receipt.

Docbank counts PDF pages locally before egress. Oversized documents, missing returned pages, malformed output, filtered or compressed authority it cannot inspect, and unsupported non-PDF formats fail closed.

## Why

Mistral should not bypass the exact source, disclosure, output, and evidence rules just because an OCR client already existed. Provider support also cannot be broader than Docbank’s enforceable local unit authority.

## Usage

For library use, construct the adapter with `mistral.NewRenditionProvider(profile, secrets, httpClient)` and pass it an authorized PDF. PDF is the only advertised format in this PR; non-PDF input remains blocked until its local unit bounds are enforceable.

Daemon, API, and CLI registration is intentionally deferred to S1–S3.

Part of #176 (R9). Stacks on #199.
