### PR TITLE
[F10–E12 07/25] Add the self-hosted Marker rendition provider

### DIFF
--- a/document/marker/client.go
+++ b/document/marker/client.go
@@ -218,6 +218,9 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 	if metadata.ByteLength > client.profile.MaxDocumentBytes {
 		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker input exceeds the document byte limit", nil)
 	}
+	if metadata.MediaFamily == "image" && metadata.ByteLength > media.MaxBytes {
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker image exceeds the verification byte limit", nil)
+	}
 	if strings.ContainsAny(metadata.Filename, "\r\n") {
 		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker upload filename contains a newline", nil)
 	}
@@ -376,7 +379,11 @@ func (client *Client) parseResult(body []byte, family string, expectedNaturalUni
 	}
 	evidence, natural := naturalEvidence(family, *wire.Output, stats)
 	if !natural {
-		evidence = providerutil.DegradedEvidence(family, *wire.Output,
+		degradedMarkdown := stripPaginationMarkers(*wire.Output)
+		if degradedMarkdown == "" {
+			return parsedResult{}, nil, malformedError("Marker result contains no usable evidence", nil)
+		}
+		evidence = providerutil.DegradedEvidence(family, degradedMarkdown,
 			"Marker returned no source-native unit mapping")
 	}
 	warnings := []string(nil)
@@ -489,6 +496,17 @@ func pageLine(line string) (int, bool) {
 	}
 	value, err := strconv.Atoi(line[1:closeIndex])
 	return value, err == nil && value >= 0
+}
+
+func stripPaginationMarkers(markdown string) string {
+	lines := strings.Split(markdown, "\n")
+	clean := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if _, separator := pageLine(line); !separator {
+			clean = append(clean, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(clean, "\n"))
 }
 
 func validateImages(images map[string]string, maximum int, maxBytes int64) error {

--- a/document/marker/client.go
+++ b/document/marker/client.go
@@ -57,7 +57,10 @@ const (
 	pageSeparator           = "------------------------------------------------"
 )
 
-var _ document.RenditionProvider = (*Client)(nil)
+var (
+	_                       document.RenditionProvider = (*Client)(nil)
+	errMarkerRequestTimeout                            = errors.New("marker request timeout")
+)
 
 // SecretResolver resolves an optional operator-fronted Marker credential.
 type SecretResolver interface {
@@ -226,11 +229,16 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 	}
 	operationCtx, cancel := operationContext(ctx, expiresAt, client.profile.RequestTimeout)
 	defer cancel()
-	if err := checkOperation(operationCtx, expiresAt); err != nil {
+	if err := checkOperation(ctx, operationCtx, expiresAt); err != nil {
 		return document.RenditionResult{}, err
 	}
+	stopInterrupt := context.AfterFunc(operationCtx, func() { _ = document.InterruptAuthorizedUpload(upload) })
 	source, err := providerutil.ReadAuthorizedUpload(operationCtx, upload, metadata, "Marker")
+	stopInterrupt()
 	if err != nil {
+		if operationErr := checkOperation(ctx, operationCtx, expiresAt); operationErr != nil {
+			return document.RenditionResult{}, operationErr
+		}
 		return document.RenditionResult{}, err
 	}
 	defer clear(source)
@@ -272,19 +280,19 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 	if err := client.authorize(request); err != nil {
 		return document.RenditionResult{}, err
 	}
-	if err := checkOperation(operationCtx, expiresAt); err != nil {
+	if err := checkOperation(ctx, operationCtx, expiresAt); err != nil {
 		return document.RenditionResult{}, err
 	}
 	response, err := client.http.Do(request)
 	if err != nil {
-		if operationErr := checkOperation(operationCtx, expiresAt); operationErr != nil {
+		if operationErr := postSubmissionOperationError(ctx, operationCtx, expiresAt, err); operationErr != nil {
 			return document.RenditionResult{}, operationErr
 		}
 		return document.RenditionResult{}, providerError(document.RenditionErrorAmbiguousSubmission, "Marker submission outcome is unknown", err)
 	}
 	defer func() { _ = response.Body.Close() }()
 	responseLimit := min(client.profile.MaxResponseBytes, int64(authorization.MaxTotalResultBytes))
-	responseBody, err := readBounded(operationCtx, expiresAt, response.Body, responseLimit)
+	responseBody, err := readBounded(ctx, operationCtx, expiresAt, response.Body, responseLimit)
 	if err != nil {
 		return document.RenditionResult{}, err
 	}
@@ -638,38 +646,47 @@ func filenameWithExtension(filename, extension, required string) (string, bool) 
 }
 
 func operationContext(ctx context.Context, expiresAt time.Time, timeout time.Duration) (context.Context, context.CancelFunc) {
-	deadline := time.Now().Add(timeout)
-	if caller, ok := ctx.Deadline(); ok && caller.Before(deadline) {
-		deadline = caller
+	requestCtx, cancelRequest := context.WithTimeoutCause(ctx, timeout, errMarkerRequestTimeout)
+	operationCtx, cancelExpiry := context.WithDeadline(requestCtx, expiresAt)
+	return operationCtx, func() {
+		cancelExpiry()
+		cancelRequest()
 	}
-	if expiresAt.Before(deadline) {
-		deadline = expiresAt
-	}
-	return context.WithDeadline(ctx, deadline)
 }
 
-func checkOperation(ctx context.Context, expiresAt time.Time) error {
-	if errors.Is(ctx.Err(), context.Canceled) {
-		return providerError(document.RenditionErrorCanceled, "Marker rendering canceled", ctx.Err())
+func checkOperation(callerCtx, operationCtx context.Context, expiresAt time.Time) error {
+	if err := callerCtx.Err(); err != nil {
+		return providerError(document.RenditionErrorCanceled, "Marker rendering canceled", err)
 	}
 	if !time.Now().Before(expiresAt) {
 		return expiredError()
 	}
-	if err := ctx.Err(); err != nil {
+	if errors.Is(context.Cause(operationCtx), errMarkerRequestTimeout) {
+		return providerError(document.RenditionErrorCapacity, "Marker request timeout reached", errMarkerRequestTimeout)
+	}
+	if err := operationCtx.Err(); err != nil {
 		return providerError(document.RenditionErrorCanceled, "Marker rendering canceled", err)
 	}
 	return nil
 }
 
-func readBounded(ctx context.Context, expiresAt time.Time, reader io.Reader, maximum int64) ([]byte, error) {
+func postSubmissionOperationError(callerCtx, operationCtx context.Context, expiresAt time.Time, cause error) error {
+	if callerCtx.Err() == nil && time.Now().Before(expiresAt) &&
+		errors.Is(context.Cause(operationCtx), errMarkerRequestTimeout) {
+		return providerError(document.RenditionErrorAmbiguousSubmission, "Marker submission outcome is unknown", cause)
+	}
+	return checkOperation(callerCtx, operationCtx, expiresAt)
+}
+
+func readBounded(callerCtx, operationCtx context.Context, expiresAt time.Time, reader io.Reader, maximum int64) ([]byte, error) {
 	value, err := io.ReadAll(io.LimitReader(reader, maximum+1))
 	if err != nil {
-		if operationErr := checkOperation(ctx, expiresAt); operationErr != nil {
+		if operationErr := postSubmissionOperationError(callerCtx, operationCtx, expiresAt, err); operationErr != nil {
 			return nil, operationErr
 		}
 		return nil, providerError(document.RenditionErrorAmbiguousSubmission, "could not read Marker result", err)
 	}
-	if operationErr := checkOperation(ctx, expiresAt); operationErr != nil {
+	if operationErr := postSubmissionOperationError(callerCtx, operationCtx, expiresAt, operationCtx.Err()); operationErr != nil {
 		return nil, operationErr
 	}
 	if int64(len(value)) > maximum {

--- a/document/marker/client.go
+++ b/document/marker/client.go
@@ -1,0 +1,728 @@
+// Package marker implements the fixed uploaded-file self-hosted Marker flow.
+package marker
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/formatdetect"
+	"go.kenn.io/docbank/document/internal/providerutil"
+	"go.kenn.io/docbank/document/media"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	providerID              = "marker.self-hosted-v1"
+	uploadPath              = "/marker/upload"
+	adapterContract         = "marker-self-hosted-adapter/v1"
+	timestampForm           = "2006-01-02T15:04:05.000000000Z"
+	defaultRequestTimeout   = 10 * time.Minute
+	defaultMaxDocumentBytes = int64(200 << 20)
+	defaultMaxRequestBytes  = int64(201 << 20)
+	defaultMaxResponseBytes = int64(64 << 20)
+	defaultMaxMetadataBytes = int64(4 << 20)
+	defaultMaxImages        = 64
+	defaultMaxImageBytes    = int64(16 << 20)
+	defaultMaxUnits         = 10_000
+	maxTimeout              = 24 * time.Hour
+	maxDocumentBytes        = int64(1 << 30)
+	maxRequestBytes         = int64(1<<30) + (2 << 20)
+	maxResponseBytes        = int64(512 << 20)
+	maxMetadataBytes        = int64(64 << 20)
+	maxImages               = 64
+	maxImageBytes           = int64(256 << 20)
+	maxUnits                = 1_000_000
+	maxSecretBytes          = 64 << 10
+	pageSeparator           = "------------------------------------------------"
+)
+
+var _ document.RenditionProvider = (*Client)(nil)
+
+// SecretResolver resolves an optional operator-fronted Marker credential.
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, name string) (string, error)
+}
+
+// Profile pins the operator deployment, runtime, credential name, conversion
+// mode, fixed wire contract, and every request/result bound.
+type Profile struct {
+	Origin                string
+	Descriptor            document.RenditionDescriptor
+	DeploymentFingerprint string
+	RuntimeFingerprint    string
+	SecretBinding         string
+	Mode                  string
+	RequestTimeout        time.Duration
+	MaxDocumentBytes      int64
+	MaxRequestBytes       int64
+	MaxResponseBytes      int64
+	MaxMetadataBytes      int64
+	MaxImages             int
+	MaxImageBytes         int64
+	MaxUnits              int
+}
+
+type policyIdentity struct {
+	AdapterContract       string                               `json:"adapter_contract"`
+	Origin                string                               `json:"origin"`
+	Route                 string                               `json:"route"`
+	DeploymentFingerprint string                               `json:"deployment_fingerprint"`
+	RuntimeFingerprint    string                               `json:"runtime_fingerprint"`
+	CredentialBinding     string                               `json:"credential_binding"`
+	Mode                  string                               `json:"mode"`
+	OutputFormat          string                               `json:"output_format"`
+	ForceOCR              bool                                 `json:"force_ocr"`
+	PaginateOutput        bool                                 `json:"paginate_output"`
+	RequestTimeoutNanos   int64                                `json:"request_timeout_nanos"`
+	MaxDocumentBytes      int64                                `json:"max_document_bytes"`
+	MaxRequestBytes       int64                                `json:"max_request_bytes"`
+	MaxResponseBytes      int64                                `json:"max_response_bytes"`
+	MaxMetadataBytes      int64                                `json:"max_metadata_bytes"`
+	MaxImages             int                                  `json:"max_images"`
+	MaxImageBytes         int64                                `json:"max_image_bytes"`
+	MaxUnits              int                                  `json:"max_units"`
+	SupportedFormats      []document.RenditionFormatCapability `json:"supported_formats"`
+}
+
+// SupportedFormats returns the exact Marker families for which Docbank has
+// bounded original-file upload authority.
+func SupportedFormats() []document.RenditionFormatCapability {
+	return []document.RenditionFormatCapability{
+		{MediaFamily: "pdf", MediaType: "application/pdf", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/jpeg", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/png", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/webp", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/gif", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "word", MediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "spreadsheet", MediaType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "presentation", MediaType: "application/vnd.openxmlformats-officedocument.presentationml.presentation", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "ebook", MediaType: "application/epub+zip", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "text", MediaType: "text/html", InputKind: document.RenditionInputOriginalFile},
+	}
+}
+
+// PolicyFingerprint returns the canonical profile identity expected in the
+// rendition descriptor. Credential values and transports are never included.
+func PolicyFingerprint(profile Profile) (string, error) {
+	normalized, err := normalizeProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	identity := policyIdentity{AdapterContract: adapterContract, Origin: normalized.Origin,
+		Route: uploadPath, DeploymentFingerprint: normalized.DeploymentFingerprint,
+		RuntimeFingerprint: normalized.RuntimeFingerprint, CredentialBinding: normalized.SecretBinding,
+		Mode: normalized.Mode, OutputFormat: "markdown", ForceOCR: false, PaginateOutput: true,
+		RequestTimeoutNanos: int64(normalized.RequestTimeout), MaxDocumentBytes: normalized.MaxDocumentBytes,
+		MaxRequestBytes: normalized.MaxRequestBytes, MaxResponseBytes: normalized.MaxResponseBytes,
+		MaxMetadataBytes: normalized.MaxMetadataBytes, MaxImages: normalized.MaxImages,
+		MaxImageBytes: normalized.MaxImageBytes, MaxUnits: normalized.MaxUnits,
+		SupportedFormats: SupportedFormats()}
+	encoded, err := json.Marshal(identity, json.Deterministic(true))
+	if err != nil {
+		return "", fmt.Errorf("marker: encode policy identity: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// Client renders exact authorized uploads through one fixed Marker route.
+type Client struct {
+	profile    Profile
+	descriptor document.RenditionDescriptor
+	secrets    SecretResolver
+	http       *http.Client
+}
+
+// New validates a pinned self-hosted profile. The injected transport is the
+// operator's hardened destination policy; Client removes ambient cookies and
+// always refuses redirects.
+func New(profile Profile, secrets SecretResolver, transport http.RoundTripper) (*Client, error) {
+	normalized, err := normalizeProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, err := document.NewRenditionDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		if err == nil {
+			err = errors.New("descriptor is not canonical")
+		}
+		return nil, fmt.Errorf("marker: invalid descriptor: %w", err)
+	}
+	if descriptor.ID != providerID || descriptor.TrustBoundary != document.RenditionTrustOperatorNetwork ||
+		!descriptor.ReturnsMarkdown || !descriptor.ReturnsStructured || len(descriptor.ArtifactRoles) != 0 {
+		return nil, errors.New("marker: descriptor result or trust contract is invalid")
+	}
+	wantFormats := SupportedFormats()
+	slices.SortFunc(wantFormats, compareFormats)
+	if !slices.Equal(descriptor.SupportedFormats, wantFormats) {
+		return nil, errors.New("marker: descriptor must advertise the exact supported format set")
+	}
+	fingerprint, err := PolicyFingerprint(normalized)
+	if err != nil {
+		return nil, err
+	}
+	if descriptor.PolicyFingerprint != fingerprint {
+		return nil, errors.New("marker: descriptor policy fingerprint does not match profile")
+	}
+	if normalized.SecretBinding == "" {
+		if !nilValue(secrets) {
+			return nil, errors.New("marker: secret resolver requires a named binding")
+		}
+	} else if nilValue(secrets) {
+		return nil, errors.New("marker: named secret binding requires a resolver")
+	}
+	if transport == nil {
+		return nil, errors.New("marker: hardened transport is required")
+	}
+	normalized.Descriptor = descriptor
+	return &Client{profile: normalized, descriptor: providerutil.CloneDescriptor(descriptor), secrets: secrets,
+		http: providerhttp.IsolateClient(&http.Client{Transport: transport})}, nil
+}
+
+func (client *Client) Descriptor() document.RenditionDescriptor {
+	if client == nil {
+		return document.RenditionDescriptor{}
+	}
+	return providerutil.CloneDescriptor(client.descriptor)
+}
+
+func (client *Client) Render(ctx context.Context, upload document.AuthorizedUpload, authorization document.RenditionAuthorization) (document.RenditionResult, error) {
+	if client == nil {
+		return document.RenditionResult{}, errors.New("marker: client is required")
+	}
+	metadata := upload.Metadata()
+	if metadata.ByteLength > client.profile.MaxDocumentBytes {
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker input exceeds the document byte limit", nil)
+	}
+	if !filenameMatches(metadata) {
+		return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput, "Marker input filename does not match the authorized format", nil)
+	}
+	expiresAt, err := time.Parse(timestampForm, authorization.ExpiresAt)
+	if err != nil {
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker authorization expiry is invalid", nil)
+	}
+	operationCtx, cancel := operationContext(ctx, expiresAt, client.profile.RequestTimeout)
+	defer cancel()
+	if err := checkOperation(operationCtx, expiresAt); err != nil {
+		return document.RenditionResult{}, err
+	}
+	source, err := providerutil.ReadAuthorizedUpload(operationCtx, upload, metadata, "Marker")
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	defer clear(source)
+	expectedNaturalUnits := 0
+	switch metadata.MediaFamily {
+	case "pdf":
+		pages, countErr := formatdetect.CountPDFPages(source)
+		if countErr != nil || pages <= 0 {
+			return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput, "Marker PDF page authority is invalid", countErr)
+		}
+		if pages > int64(client.profile.MaxUnits) {
+			return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker PDF exceeds the unit limit", nil)
+		}
+		expectedNaturalUnits = int(pages)
+	case "image":
+		detected, detectErr := media.DetectBytes(source, metadata.MediaType)
+		if detectErr != nil {
+			return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput, "Marker image authority is invalid", detectErr)
+		}
+		if detected.Kind != media.KindImage || detected.MediaType != metadata.MediaType {
+			return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput, "Marker image identity does not match the authorization", nil)
+		}
+		if detected.FrameCount != 1 || detected.Animated {
+			return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput, "Marker requires a single-frame image", nil)
+		}
+		expectedNaturalUnits = 1
+	}
+	body, contentType, err := buildMultipart(metadata, source, client.profile.Mode, client.profile.MaxRequestBytes)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	started := time.Now().UTC()
+	request, err := http.NewRequestWithContext(operationCtx, http.MethodPost, client.profile.Origin+uploadPath, bytes.NewReader(body))
+	if err != nil {
+		return document.RenditionResult{}, providerError(document.RenditionErrorTransient, "could not prepare Marker request", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", contentType)
+	if err := client.authorize(request); err != nil {
+		return document.RenditionResult{}, err
+	}
+	if err := checkOperation(operationCtx, expiresAt); err != nil {
+		return document.RenditionResult{}, err
+	}
+	response, err := client.http.Do(request)
+	if err != nil {
+		if operationErr := checkOperation(operationCtx, expiresAt); operationErr != nil {
+			return document.RenditionResult{}, operationErr
+		}
+		return document.RenditionResult{}, providerError(document.RenditionErrorAmbiguousSubmission, "Marker submission outcome is unknown", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	responseBody, err := readBounded(operationCtx, expiresAt, response.Body, client.profile.MaxResponseBytes)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return document.RenditionResult{}, statusError(response.StatusCode)
+	}
+	mediaType, _, mediaErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if mediaErr != nil || mediaType != "application/json" {
+		return document.RenditionResult{}, malformedError("Marker response content type is invalid", mediaErr)
+	}
+	if len(responseBody) > authorization.MaxTotalResultBytes {
+		return document.RenditionResult{}, malformedError("Marker response exceeds authorization", nil)
+	}
+	result, warnings, err := client.parseResult(responseBody, metadata.MediaFamily, expectedNaturalUnits)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	if len(result.markdown) > authorization.MaxProviderMarkdownBytes {
+		return document.RenditionResult{}, malformedError("Marker Markdown exceeds authorization", nil)
+	}
+	completed := time.Now().UTC()
+	authorizationFingerprint, err := authorization.Fingerprint()
+	if err != nil {
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected,
+			"Marker authorization fingerprint is invalid", err)
+	}
+	return document.RenditionResult{Evidence: result.evidence, ProviderMarkdown: result.markdown,
+		Receipt: document.RenditionReceipt{ProviderID: client.descriptor.ID,
+			DescriptorFingerprint:       client.descriptor.Fingerprint,
+			PolicyFingerprint:           authorization.PolicyFingerprint,
+			RenditionRequestFingerprint: authorization.RenditionRequestFingerprint,
+			AuthorizationFingerprint:    authorizationFingerprint,
+			SourceSHA256:                metadata.SHA256, OperationID: "marker-" + authorization.RenditionRequestFingerprint[:24],
+			StartedAt: started.Format(timestampForm), CompletedAt: completed.Format(timestampForm), Warnings: warnings,
+			Usage: document.RenditionUsage{Requests: 1, InputBytes: int64(len(source)), OutputBytes: int64(len(responseBody)), Units: int64(len(result.evidence.Units))}}}, nil
+}
+
+type parsedResult struct {
+	markdown []byte
+	evidence document.SourceEvidenceV1
+}
+
+func (client *Client) parseResult(body []byte, family string, expectedNaturalUnits int) (parsedResult, []string, error) {
+	var wire struct {
+		Format   *string           `json:"format"`
+		Output   *string           `json:"output"`
+		Images   map[string]string `json:"images"`
+		Metadata jsontext.Value    `json:"metadata"`
+		Success  *bool             `json:"success"`
+		Error    string            `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(body, &wire, json.RejectUnknownMembers(true)); err != nil {
+		return parsedResult{}, nil, malformedError("Marker result JSON is invalid", err)
+	}
+	if wire.Success == nil || !*wire.Success || wire.Format == nil || *wire.Format != "markdown" ||
+		wire.Output == nil || *wire.Output == "" || wire.Images == nil || len(wire.Metadata) == 0 || wire.Error != "" {
+		return parsedResult{}, nil, malformedError("Marker result is incomplete or unsuccessful", nil)
+	}
+	if len(wire.Metadata) > int(client.profile.MaxMetadataBytes) {
+		return parsedResult{}, nil, malformedError("Marker metadata exceeds byte limit", nil)
+	}
+	if err := validateImages(wire.Images, client.profile.MaxImages, client.profile.MaxImageBytes); err != nil {
+		return parsedResult{}, nil, err
+	}
+	stats, err := parseMetadata(wire.Metadata, client.profile.MaxUnits)
+	if err != nil {
+		return parsedResult{}, nil, err
+	}
+	if expectedNaturalUnits > 0 && !statsProveUnits(stats, expectedNaturalUnits) {
+		return parsedResult{}, nil, malformedError("Marker result does not prove complete source units", nil)
+	}
+	markdown := []byte(*wire.Output)
+	evidence, natural := naturalEvidence(family, *wire.Output, stats)
+	if !natural {
+		evidence = providerutil.DegradedEvidence(family, *wire.Output,
+			"Marker returned no source-native unit mapping")
+	}
+	warnings := []string(nil)
+	if len(wire.Images) != 0 {
+		warnings = []string{"provider_images_not_retained"}
+	}
+	return parsedResult{markdown: markdown, evidence: evidence}, warnings, nil
+}
+
+type pageStat struct{ PageID int }
+
+func statsProveUnits(stats []pageStat, expected int) bool {
+	if len(stats) != expected {
+		return false
+	}
+	for index, stat := range stats {
+		if stat.PageID != index {
+			return false
+		}
+	}
+	return true
+}
+
+func parseMetadata(raw jsontext.Value, maximum int) ([]pageStat, error) {
+	var metadata struct {
+		TableOfContents jsontext.Value `json:"table_of_contents"`
+		PageStats       []struct {
+			PageID               *int           `json:"page_id"`
+			TextExtractionMethod string         `json:"text_extraction_method"`
+			BlockCounts          jsontext.Value `json:"block_counts"`
+			BlockMetadata        jsontext.Value `json:"block_metadata"`
+		} `json:"page_stats"`
+	}
+	if err := json.Unmarshal(raw, &metadata, json.RejectUnknownMembers(true)); err != nil {
+		return nil, malformedError("Marker metadata schema changed", err)
+	}
+	if len(metadata.TableOfContents) == 0 || metadata.PageStats == nil || len(metadata.PageStats) > maximum {
+		return nil, malformedError("Marker metadata is incomplete or exceeds the unit limit", nil)
+	}
+	stats := make([]pageStat, len(metadata.PageStats))
+	for index, stat := range metadata.PageStats {
+		if stat.PageID == nil || *stat.PageID < 0 || len(stat.TextExtractionMethod) > 128 ||
+			len(stat.BlockCounts) == 0 || len(stat.BlockMetadata) == 0 {
+			return nil, malformedError("Marker page metadata is incomplete", nil)
+		}
+		stats[index] = pageStat{PageID: *stat.PageID}
+	}
+	return stats, nil
+}
+
+func naturalEvidence(family, markdown string, stats []pageStat) (document.SourceEvidenceV1, bool) {
+	if family != "pdf" && family != "image" {
+		return document.SourceEvidenceV1{}, false
+	}
+	parts, ok := splitPages(markdown, stats)
+	if !ok {
+		return document.SourceEvidenceV1{}, false
+	}
+	evidence := document.SourceEvidenceV1{ContractVersion: document.SourceEvidenceContractV1,
+		Completeness: document.EvidenceComplete, Family: family, UnitKind: document.EvidenceUnitPage,
+		Units: make([]document.SourceEvidenceUnitV1, len(parts))}
+	for index, text := range parts {
+		evidence.Units[index] = document.SourceEvidenceUnitV1{Order: index,
+			ProviderID: "marker-page-" + strconv.Itoa(index), Text: text,
+			Locator: document.SourceEvidenceLocatorV1{Kind: document.EvidenceLocatorPage,
+				IndexOrigin: document.EvidenceIndexOriginZero, Start: int64(index), End: int64(index)}}
+	}
+	return evidence, true
+}
+
+func splitPages(markdown string, stats []pageStat) ([]string, bool) {
+	if len(stats) == 0 {
+		return nil, false
+	}
+	lines := strings.Split(markdown, "\n")
+	parts := make([]string, 0, len(stats))
+	current := make([]string, 0)
+	seen := false
+	for _, line := range lines {
+		index, separator := pageLine(line)
+		if separator {
+			if seen {
+				parts = append(parts, strings.TrimSpace(strings.Join(current, "\n")))
+				current = current[:0]
+			}
+			if index != len(parts) || index >= len(stats) || stats[index].PageID != index {
+				return nil, false
+			}
+			seen = true
+			continue
+		}
+		if !seen && strings.TrimSpace(line) != "" {
+			return nil, false
+		}
+		if seen {
+			current = append(current, line)
+		}
+	}
+	if seen {
+		parts = append(parts, strings.TrimSpace(strings.Join(current, "\n")))
+	}
+	return parts, len(parts) == len(stats)
+}
+
+func pageLine(line string) (int, bool) {
+	open := strings.IndexByte(line, '{')
+	closeIndex := strings.IndexByte(line, '}')
+	if open != 0 || closeIndex <= 1 || line[closeIndex+1:] != pageSeparator {
+		return 0, false
+	}
+	value, err := strconv.Atoi(line[1:closeIndex])
+	return value, err == nil && value >= 0
+}
+
+func validateImages(images map[string]string, maximum int, maxBytes int64) error {
+	if len(images) > maximum {
+		return malformedError("Marker returned too many images", nil)
+	}
+	for name, encoded := range images {
+		if name == "" || len(name) > 1024 || !utf8.ValidString(name) || strings.ContainsRune(name, 0) ||
+			int64(base64.StdEncoding.DecodedLen(len(encoded))) > maxBytes {
+			return malformedError("Marker image output is invalid or exceeds limits", nil)
+		}
+		decoder := base64.NewDecoder(base64.StdEncoding.Strict(), strings.NewReader(encoded))
+		count, err := io.Copy(io.Discard, io.LimitReader(decoder, maxBytes+1))
+		if err != nil || count > maxBytes {
+			return malformedError("Marker image output is invalid or exceeds limits", err)
+		}
+	}
+	return nil
+}
+
+func buildMultipart(metadata document.AuthorizedUploadMetadata, source []byte, mode string, maximum int64) ([]byte, string, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", multipart.FileContentDisposition("file", metadata.Filename))
+	header.Set("Content-Type", metadata.MediaType)
+	part, err := writer.CreatePart(header)
+	if err == nil {
+		_, err = part.Write(source)
+	}
+	for _, field := range [][2]string{{"mode", mode}, {"force_ocr", "false"}, {"paginate_output", "true"}, {"output_format", "markdown"}} {
+		if err == nil {
+			err = writer.WriteField(field[0], field[1])
+		}
+	}
+	if err == nil {
+		err = writer.Close()
+	}
+	if err != nil {
+		return nil, "", providerError(document.RenditionErrorTransient, "could not prepare Marker upload", err)
+	}
+	if int64(body.Len()) > maximum {
+		return nil, "", providerError(document.RenditionErrorPolicyRejected, "Marker multipart request exceeds byte limit", nil)
+	}
+	return body.Bytes(), writer.FormDataContentType(), nil
+}
+
+func (client *Client) authorize(request *http.Request) error {
+	if client.profile.SecretBinding == "" {
+		return nil
+	}
+	secret, err := client.secrets.ResolveSecret(request.Context(), client.profile.SecretBinding)
+	if err != nil || secret == "" || len(secret) > maxSecretBytes || strings.ContainsAny(secret, "\r\n\x00") {
+		return providerError(document.RenditionErrorAuthentication, "Marker credential is unavailable or invalid", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+secret)
+	return nil
+}
+
+func normalizeProfile(profile Profile) (Profile, error) {
+	origin, err := validateOrigin(profile.Origin)
+	if err != nil {
+		return Profile{}, err
+	}
+	profile.Origin = origin
+	if !validFingerprint(profile.DeploymentFingerprint) || !validFingerprint(profile.RuntimeFingerprint) {
+		return Profile{}, errors.New("marker: deployment and runtime fingerprints must be lowercase SHA-256")
+	}
+	if profile.SecretBinding != "" && !validToken(profile.SecretBinding) {
+		return Profile{}, errors.New("marker: secret binding is invalid")
+	}
+	if profile.Mode != "fast" && profile.Mode != "balanced" {
+		return Profile{}, errors.New("marker: mode must be fast or balanced")
+	}
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = defaultRequestTimeout
+	}
+	if profile.MaxDocumentBytes == 0 {
+		profile.MaxDocumentBytes = defaultMaxDocumentBytes
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = defaultMaxRequestBytes
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = defaultMaxResponseBytes
+	}
+	if profile.MaxMetadataBytes == 0 {
+		profile.MaxMetadataBytes = defaultMaxMetadataBytes
+	}
+	if profile.MaxImages == 0 {
+		profile.MaxImages = defaultMaxImages
+	}
+	if profile.MaxImageBytes == 0 {
+		profile.MaxImageBytes = defaultMaxImageBytes
+	}
+	if profile.MaxUnits == 0 {
+		profile.MaxUnits = defaultMaxUnits
+	}
+	if profile.RequestTimeout <= 0 || profile.RequestTimeout > maxTimeout || profile.MaxDocumentBytes <= 0 || profile.MaxDocumentBytes > maxDocumentBytes ||
+		profile.MaxRequestBytes <= profile.MaxDocumentBytes || profile.MaxRequestBytes > maxRequestBytes ||
+		profile.MaxResponseBytes <= 0 || profile.MaxResponseBytes > maxResponseBytes || profile.MaxMetadataBytes <= 0 || profile.MaxMetadataBytes > maxMetadataBytes ||
+		profile.MaxMetadataBytes > profile.MaxResponseBytes || profile.MaxImages < 1 || profile.MaxImages > maxImages ||
+		profile.MaxImageBytes <= 0 || profile.MaxImageBytes > maxImageBytes || profile.MaxImageBytes > profile.MaxResponseBytes ||
+		profile.MaxUnits < 1 || profile.MaxUnits > maxUnits {
+		return Profile{}, errors.New("marker: execution bounds are invalid")
+	}
+	return profile, nil
+}
+
+func validateOrigin(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Opaque != "" || parsed.ForceQuery || parsed.Fragment != "" ||
+		(parsed.Path != "" && parsed.Path != "/") || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", errors.New("marker: origin must be one HTTP(S) origin without path, credentials, query, or fragment")
+	}
+	return parsed.Scheme + "://" + parsed.Host, nil
+}
+
+func filenameMatches(metadata document.AuthorizedUploadMetadata) bool {
+	ext := strings.ToLower(filepath.Ext(metadata.Filename))
+	switch metadata.MediaType {
+	case "application/pdf":
+		return ext == ".pdf"
+	case "image/jpeg":
+		return ext == ".jpg" || ext == ".jpeg"
+	case "image/png":
+		return ext == ".png"
+	case "image/webp":
+		return ext == ".webp"
+	case "image/gif":
+		return ext == ".gif"
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		return ext == ".docx"
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return ext == ".xlsx"
+	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+		return ext == ".pptx"
+	case "application/epub+zip":
+		return ext == ".epub"
+	case "text/html":
+		return ext == ".html" || ext == ".htm"
+	default:
+		return false
+	}
+}
+
+func operationContext(ctx context.Context, expiresAt time.Time, timeout time.Duration) (context.Context, context.CancelFunc) {
+	deadline := time.Now().Add(timeout)
+	if caller, ok := ctx.Deadline(); ok && caller.Before(deadline) {
+		deadline = caller
+	}
+	if expiresAt.Before(deadline) {
+		deadline = expiresAt
+	}
+	return context.WithDeadline(ctx, deadline)
+}
+
+func checkOperation(ctx context.Context, expiresAt time.Time) error {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return providerError(document.RenditionErrorCanceled, "Marker rendering canceled", ctx.Err())
+	}
+	if !time.Now().Before(expiresAt) {
+		return expiredError()
+	}
+	if err := ctx.Err(); err != nil {
+		return providerError(document.RenditionErrorCanceled, "Marker rendering canceled", err)
+	}
+	return nil
+}
+
+func readBounded(ctx context.Context, expiresAt time.Time, reader io.Reader, maximum int64) ([]byte, error) {
+	value, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if err != nil {
+		if operationErr := checkOperation(ctx, expiresAt); operationErr != nil {
+			return nil, operationErr
+		}
+		return nil, providerError(document.RenditionErrorAmbiguousSubmission, "could not read Marker result", err)
+	}
+	if operationErr := checkOperation(ctx, expiresAt); operationErr != nil {
+		return nil, operationErr
+	}
+	if int64(len(value)) > maximum {
+		return nil, malformedError("Marker response exceeds byte limit", nil)
+	}
+	return value, nil
+}
+
+func statusError(status int) error {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return providerError(document.RenditionErrorAuthentication, "Marker authentication failed", nil)
+	case http.StatusTooManyRequests:
+		return providerError(document.RenditionErrorRateLimited, "Marker rate limit is exhausted", nil)
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, http.StatusInsufficientStorage:
+		return providerError(document.RenditionErrorCapacity, "Marker capacity is unavailable", nil)
+	case http.StatusInternalServerError:
+		return providerError(document.RenditionErrorTransient, "Marker is temporarily unavailable", nil)
+	case http.StatusUnsupportedMediaType, http.StatusUnprocessableEntity:
+		return providerError(document.RenditionErrorUnsupportedInput, "Marker rejected the input format", nil)
+	case http.StatusBadRequest, http.StatusRequestEntityTooLarge:
+		return providerError(document.RenditionErrorPolicyRejected, "Marker rejected the upload", nil)
+	default:
+		return malformedError("Marker returned an unexpected HTTP status", nil)
+	}
+}
+
+func expiredError() error {
+	return providerError(document.RenditionErrorPolicyRejected, "Marker authorization expired", nil)
+}
+func malformedError(message string, cause error) error {
+	return providerError(document.RenditionErrorMalformedEvidence, message, cause)
+}
+
+func providerError(code document.RenditionErrorCode, message string, cause error) error {
+	return providerutil.ClassifiedError("Marker", code, message, cause)
+}
+
+func validFingerprint(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size && value == strings.ToLower(value)
+}
+
+func validToken(value string) bool {
+	if value == "" || len(value) > 128 || value != strings.TrimSpace(value) || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || strings.ContainsRune("_.-", character) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func compareFormats(left, right document.RenditionFormatCapability) int {
+	if value := strings.Compare(left.MediaFamily, right.MediaFamily); value != 0 {
+		return value
+	}
+	if value := strings.Compare(left.MediaType, right.MediaType); value != 0 {
+		return value
+	}
+	return strings.Compare(string(left.InputKind), string(right.InputKind))
+}
+
+func nilValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/document/marker/client.go
+++ b/document/marker/client.go
@@ -215,9 +215,11 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 	if metadata.ByteLength > client.profile.MaxDocumentBytes {
 		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker input exceeds the document byte limit", nil)
 	}
-	if !filenameMatches(metadata) {
+	filename, ok := uploadFilename(metadata)
+	if !ok {
 		return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput, "Marker input filename does not match the authorized format", nil)
 	}
+	metadata.Filename = filename
 	expiresAt, err := time.Parse(timestampForm, authorization.ExpiresAt)
 	if err != nil {
 		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker authorization expiry is invalid", nil)
@@ -281,7 +283,8 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 		return document.RenditionResult{}, providerError(document.RenditionErrorAmbiguousSubmission, "Marker submission outcome is unknown", err)
 	}
 	defer func() { _ = response.Body.Close() }()
-	responseBody, err := readBounded(operationCtx, expiresAt, response.Body, client.profile.MaxResponseBytes)
+	responseLimit := min(client.profile.MaxResponseBytes, int64(authorization.MaxTotalResultBytes))
+	responseBody, err := readBounded(operationCtx, expiresAt, response.Body, responseLimit)
 	if err != nil {
 		return document.RenditionResult{}, err
 	}
@@ -299,7 +302,10 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 	if err != nil {
 		return document.RenditionResult{}, err
 	}
-	if len(result.markdown) > authorization.MaxProviderMarkdownBytes {
+	providerMarkdown := result.markdown
+	if authorization.MaxProviderMarkdownBytes == 0 {
+		providerMarkdown = nil
+	} else if len(providerMarkdown) > authorization.MaxProviderMarkdownBytes {
 		return document.RenditionResult{}, malformedError("Marker Markdown exceeds authorization", nil)
 	}
 	completed := time.Now().UTC()
@@ -308,7 +314,7 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected,
 			"Marker authorization fingerprint is invalid", err)
 	}
-	return document.RenditionResult{Evidence: result.evidence, ProviderMarkdown: result.markdown,
+	return document.RenditionResult{Evidence: result.evidence, ProviderMarkdown: providerMarkdown,
 		Receipt: document.RenditionReceipt{ProviderID: client.descriptor.ID,
 			DescriptorFingerprint:       client.descriptor.Fingerprint,
 			PolicyFingerprint:           authorization.PolicyFingerprint,
@@ -354,6 +360,9 @@ func (client *Client) parseResult(body []byte, family string, expectedNaturalUni
 		return parsedResult{}, nil, malformedError("Marker result does not prove complete source units", nil)
 	}
 	markdown := []byte(*wire.Output)
+	if providerutil.InjectsDocbankFrontmatter(markdown) {
+		return parsedResult{}, nil, malformedError("Marker Markdown contains reserved Docbank frontmatter", nil)
+	}
 	evidence, natural := naturalEvidence(family, *wire.Output, stats)
 	if !natural {
 		evidence = providerutil.DegradedEvidence(family, *wire.Output,
@@ -587,32 +596,45 @@ func validateOrigin(raw string) (string, error) {
 	return parsed.Scheme + "://" + parsed.Host, nil
 }
 
-func filenameMatches(metadata document.AuthorizedUploadMetadata) bool {
+func uploadFilename(metadata document.AuthorizedUploadMetadata) (string, bool) {
 	ext := strings.ToLower(filepath.Ext(metadata.Filename))
 	switch metadata.MediaType {
 	case "application/pdf":
-		return ext == ".pdf"
+		return filenameWithExtension(metadata.Filename, ext, ".pdf")
 	case "image/jpeg":
-		return ext == ".jpg" || ext == ".jpeg"
+		if metadata.Filename == "" {
+			return "document.jpg", true
+		}
+		return metadata.Filename, ext == ".jpg" || ext == ".jpeg"
 	case "image/png":
-		return ext == ".png"
+		return filenameWithExtension(metadata.Filename, ext, ".png")
 	case "image/webp":
-		return ext == ".webp"
+		return filenameWithExtension(metadata.Filename, ext, ".webp")
 	case "image/gif":
-		return ext == ".gif"
+		return filenameWithExtension(metadata.Filename, ext, ".gif")
 	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-		return ext == ".docx"
+		return filenameWithExtension(metadata.Filename, ext, ".docx")
 	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
-		return ext == ".xlsx"
+		return filenameWithExtension(metadata.Filename, ext, ".xlsx")
 	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-		return ext == ".pptx"
+		return filenameWithExtension(metadata.Filename, ext, ".pptx")
 	case "application/epub+zip":
-		return ext == ".epub"
+		return filenameWithExtension(metadata.Filename, ext, ".epub")
 	case "text/html":
-		return ext == ".html" || ext == ".htm"
+		if metadata.Filename == "" {
+			return "document.html", true
+		}
+		return metadata.Filename, ext == ".html" || ext == ".htm"
 	default:
-		return false
+		return "", false
 	}
+}
+
+func filenameWithExtension(filename, extension, required string) (string, bool) {
+	if filename == "" {
+		return "document" + required, true
+	}
+	return filename, extension == required
 }
 
 func operationContext(ctx context.Context, expiresAt time.Time, timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -657,15 +679,13 @@ func readBounded(ctx context.Context, expiresAt time.Time, reader io.Reader, max
 }
 
 func statusError(status int) error {
+	if status == http.StatusRequestTimeout || status == http.StatusTooManyRequests ||
+		status >= http.StatusInternalServerError && status <= 599 {
+		return providerError(document.RenditionErrorAmbiguousSubmission, "Marker submission outcome is unknown", nil)
+	}
 	switch status {
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return providerError(document.RenditionErrorAuthentication, "Marker authentication failed", nil)
-	case http.StatusTooManyRequests:
-		return providerError(document.RenditionErrorRateLimited, "Marker rate limit is exhausted", nil)
-	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, http.StatusInsufficientStorage:
-		return providerError(document.RenditionErrorCapacity, "Marker capacity is unavailable", nil)
-	case http.StatusInternalServerError:
-		return providerError(document.RenditionErrorTransient, "Marker is temporarily unavailable", nil)
 	case http.StatusUnsupportedMediaType, http.StatusUnprocessableEntity:
 		return providerError(document.RenditionErrorUnsupportedInput, "Marker rejected the input format", nil)
 	case http.StatusBadRequest, http.StatusRequestEntityTooLarge:

--- a/document/marker/client.go
+++ b/document/marker/client.go
@@ -218,6 +218,9 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 	if metadata.ByteLength > client.profile.MaxDocumentBytes {
 		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker input exceeds the document byte limit", nil)
 	}
+	if strings.ContainsAny(metadata.Filename, "\r\n") {
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected, "Marker upload filename contains a newline", nil)
+	}
 	filename, ok := uploadFilename(metadata)
 	if !ok {
 		return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput, "Marker input filename does not match the authorized format", nil)
@@ -291,13 +294,13 @@ func (client *Client) Render(ctx context.Context, upload document.AuthorizedUplo
 		return document.RenditionResult{}, providerError(document.RenditionErrorAmbiguousSubmission, "Marker submission outcome is unknown", err)
 	}
 	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return document.RenditionResult{}, statusError(response.StatusCode)
+	}
 	responseLimit := min(client.profile.MaxResponseBytes, int64(authorization.MaxTotalResultBytes))
 	responseBody, err := readBounded(ctx, operationCtx, expiresAt, response.Body, responseLimit)
 	if err != nil {
 		return document.RenditionResult{}, err
-	}
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		return document.RenditionResult{}, statusError(response.StatusCode)
 	}
 	mediaType, _, mediaErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
 	if mediaErr != nil || mediaType != "application/json" {

--- a/document/marker/client_test.go
+++ b/document/marker/client_test.go
@@ -25,12 +25,18 @@ import (
 )
 
 type testUpload struct {
-	*bytes.Reader
+	io.Reader
 
 	metadata document.AuthorizedUploadMetadata
+	close    func() error
 }
 
-func (*testUpload) Close() error                                       { return nil }
+func (upload *testUpload) Close() error {
+	if upload.close != nil {
+		return upload.close()
+	}
+	return nil
+}
 func (upload *testUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
 
 type testSecrets map[string]string
@@ -388,6 +394,67 @@ func TestClientRechecksExpiryAndCancellationWhileReadingResponse(t *testing.T) {
 		_, err := document.RenderRendition(ctx, client, fixture.upload(), fixture.authorization)
 
 		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestClientRequestTimeoutInterruptsBlockedUpload(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "blocked.pdf", testPDF(1))
+	fixture.profile.RequestTimeout = 10 * time.Millisecond
+	fixture.profile.Descriptor = descriptorFor(t, fixture.profile)
+	fixture = fixture.withDescriptor(fixture.profile.Descriptor)
+	reader, writer := io.Pipe()
+	t.Cleanup(func() { _ = writer.Close() })
+	entered := make(chan struct{})
+	upload := &testUpload{
+		Reader:   &callbackReadCloser{reader: reader, before: func() { close(entered) }},
+		metadata: fixture.metadata,
+		close:    reader.Close,
+	}
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK, `{}`))
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Render(t.Context(), upload, fixture.authorization)
+		done <- err
+	}()
+	<-entered
+	select {
+	case err := <-done:
+		assertProviderCode(t, err, document.RenditionErrorCapacity)
+	case <-time.After(250 * time.Millisecond):
+		require.NoError(t, upload.Close())
+		<-done
+		t.Fatal("Client.Render did not interrupt the blocked upload")
+	}
+}
+
+func TestClientDistinguishesRequestTimeoutFromCallerCancellationAfterSubmission(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+
+	t.Run("request timeout", func(t *testing.T) {
+		fixture.profile.RequestTimeout = 20 * time.Millisecond
+		fixture.profile.Descriptor = descriptorFor(t, fixture.profile)
+		fixture = fixture.withDescriptor(fixture.profile.Descriptor)
+		client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		}))
+
+		_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+
+		assertProviderCode(t, err, document.RenditionErrorAmbiguousSubmission)
+	})
+
+	t.Run("caller cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			cancel()
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		}))
+
+		_, err := client.Render(ctx, fixture.upload(), fixture.authorization)
+
+		assertProviderCode(t, err, document.RenditionErrorCanceled)
 	})
 }
 

--- a/document/marker/client_test.go
+++ b/document/marker/client_test.go
@@ -208,6 +208,11 @@ func TestClientRejectsUnsupportedFilenameIdentityAndBoundsBeforeEgress(t *testin
 	_, err := client.Render(t.Context(), wrong.upload(), wrong.authorization)
 	assertProviderCode(t, err, document.RenditionErrorUnsupportedInput)
 
+	unsafe := fixture
+	unsafe.metadata.Filename = "report\r\nx-marker: injected.pdf"
+	_, err = client.Render(t.Context(), unsafe.upload(), unsafe.authorization)
+	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+
 	wrong = fixture
 	wrong.metadata.SHA256 = strings.Repeat("0", 64)
 	wrong.authorization.SourceSHA256 = wrong.metadata.SHA256
@@ -480,6 +485,16 @@ func TestClientClassifiesAuthCapacityTransportExpiryAndCancellation(t *testing.T
 		return nil, errors.New("private transport")
 	}))
 	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorAmbiguousSubmission)
+
+	bounded := fixture.profile
+	bounded.MaxResponseBytes = 64
+	bounded.MaxMetadataBytes = 32
+	bounded.Descriptor = descriptorFor(t, bounded)
+	boundedFixture := fixture.withDescriptor(bounded.Descriptor)
+	client = newClient(t, bounded, testSecrets{"marker-front": "secret"}, staticTransport(
+		http.StatusServiceUnavailable, strings.Repeat("x", 65)))
+	_, err = client.Render(t.Context(), boundedFixture.upload(), boundedFixture.authorization)
 	assertProviderCode(t, err, document.RenditionErrorAmbiguousSubmission)
 
 	expired := fixture

--- a/document/marker/client_test.go
+++ b/document/marker/client_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media"
 	"go.kenn.io/docbank/document/media/mediatest"
 )
 
@@ -192,6 +193,8 @@ func TestClientDegradesTransformedFamiliesWithoutInventingUnits(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
 			assert.Equal(t, document.EvidenceUnitGeneric, result.Evidence.UnitKind)
+			require.Len(t, result.Evidence.Units, 1)
+			assert.Equal(t, "Readable", result.Evidence.Units[0].Text)
 		})
 	}
 }
@@ -227,6 +230,20 @@ func TestClientRejectsUnsupportedFilenameIdentityAndBoundsBeforeEgress(t *testin
 	tooLargeFixture := fixture.withDescriptor(tooLarge.Descriptor)
 	_, err = client.Render(t.Context(), tooLargeFixture.upload(), tooLargeFixture.authorization)
 	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+
+	oversizedImage := newFixture(t, "image", "image/png", "scan.png", mediatest.PNG(4, 3, nil))
+	oversizedImage.profile.MaxDocumentBytes = media.MaxBytes + 1
+	oversizedImage.profile.MaxRequestBytes = media.MaxBytes + (1 << 20)
+	oversizedImage.profile.Descriptor = descriptorFor(t, oversizedImage.profile)
+	oversizedImage = oversizedImage.withDescriptor(oversizedImage.profile.Descriptor)
+	oversizedImage.metadata.ByteLength = media.MaxBytes + 1
+	oversizedImage.authorization.SourceBytes = oversizedImage.metadata.ByteLength
+	var reads atomic.Int64
+	upload := &testUpload{Reader: &callbackReadCloser{reader: bytes.NewReader(oversizedImage.source), before: func() { reads.Add(1) }}, metadata: oversizedImage.metadata}
+	client = newClient(t, oversizedImage.profile, testSecrets{"marker-front": "secret"}, transport)
+	_, err = client.Render(t.Context(), upload, oversizedImage.authorization)
+	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+	assert.Zero(t, reads.Load())
 	assert.Zero(t, calls.Load())
 }
 

--- a/document/marker/client_test.go
+++ b/document/marker/client_test.go
@@ -96,6 +96,35 @@ func TestClientUploadsExactBytesToFixedRouteAndMapsProvenPages(t *testing.T) {
 	assert.Equal(t, fixture.metadata.SHA256, result.Receipt.SourceSHA256)
 }
 
+func TestClientUsesSyntheticFilenameWhenDisclosureIsWithheld(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "private-report.pdf", testPDF(1))
+	fixture.authorization.DiscloseFilename = false
+	expectedMetadata := fixture.metadata
+	expectedMetadata.Filename = "document.pdf"
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		assertMultipart(t, request, expectedMetadata, fixture.source)
+		return jsonResponse(request, http.StatusOK, `{"format":"markdown","output":"{0}------------------------------------------------\n\nComplete","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"pdftext","block_counts":[],"block_metadata":{}}]},"success":true}`), nil
+	}))
+
+	_, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+
+	require.NoError(t, err)
+}
+
+func TestClientUsesMarkdownForEvidenceWhenRetentionIsNotAuthorized(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	fixture.authorization.MaxProviderMarkdownBytes = 0
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK,
+		`{"format":"markdown","output":"{0}------------------------------------------------\n\nComplete","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"pdftext","block_counts":[],"block_metadata":{}}]},"success":true}`))
+
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ProviderMarkdown)
+	require.Len(t, result.Evidence.Units, 1)
+	assert.Equal(t, "Complete", result.Evidence.Units[0].Text)
+}
+
 func TestDescriptorCoversMarkerConverterFamilies(t *testing.T) {
 	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
 	want := []document.RenditionFormatCapability{
@@ -252,6 +281,31 @@ func TestClientRequiresLocalProofOfCompletePDFUnitsAndTotalResultBound(t *testin
 	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
 }
 
+func TestClientBoundsResponseBufferByAuthorization(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	fixture.authorization.MaxTotalResultBytes = 64
+	responseSource := strings.NewReader(strings.Repeat("x", 1024))
+	responseBody := &callbackReadCloser{reader: responseSource, before: func() {}}
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: responseBody, Request: request}, nil
+	}))
+
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+	assert.Equal(t, 1024-65, responseSource.Len())
+}
+
+func TestClientRejectsReservedDocbankFrontmatter(t *testing.T) {
+	fixture := newFixture(t, "word", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "notes.docx", []byte("synthetic source"))
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK,
+		`{"format":"markdown","output":"---\ndocbank-sanitized-markdown/v1\n---\nprovider content","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"surya","block_counts":[],"block_metadata":{}}]},"success":true}`))
+
+	_, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+}
+
 func TestClientProvesStillImageIdentityBeforeEgress(t *testing.T) {
 	const complete = `{"format":"markdown","output":"{0}------------------------------------------------\n\nImage text","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"surya","block_counts":[],"block_metadata":{}}]},"success":true}`
 	still := newFixture(t, "image", "image/png", "scan.png", mediatest.PNG(4, 3, nil))
@@ -344,8 +398,10 @@ func TestClientClassifiesAuthCapacityTransportExpiryAndCancellation(t *testing.T
 		want   document.RenditionErrorCode
 	}{
 		{http.StatusUnauthorized, document.RenditionErrorAuthentication},
-		{http.StatusTooManyRequests, document.RenditionErrorRateLimited},
-		{http.StatusServiceUnavailable, document.RenditionErrorCapacity},
+		{http.StatusRequestTimeout, document.RenditionErrorAmbiguousSubmission},
+		{http.StatusTooManyRequests, document.RenditionErrorAmbiguousSubmission},
+		{http.StatusInternalServerError, document.RenditionErrorAmbiguousSubmission},
+		{http.StatusServiceUnavailable, document.RenditionErrorAmbiguousSubmission},
 		{http.StatusUnsupportedMediaType, document.RenditionErrorUnsupportedInput},
 	} {
 		client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(testCase.status, "private"))

--- a/document/marker/client_test.go
+++ b/document/marker/client_test.go
@@ -1,0 +1,532 @@
+package marker
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media/mediatest"
+)
+
+type testUpload struct {
+	*bytes.Reader
+
+	metadata document.AuthorizedUploadMetadata
+}
+
+func (*testUpload) Close() error                                       { return nil }
+func (upload *testUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+type testSecrets map[string]string
+
+func (secrets testSecrets) ResolveSecret(_ context.Context, name string) (string, error) {
+	value, ok := secrets[name]
+	if !ok {
+		return "", errors.New("missing secret")
+	}
+	return value, nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return fn(request) }
+
+type callbackReadCloser struct {
+	reader io.Reader
+	once   sync.Once
+	before func()
+}
+
+func (body *callbackReadCloser) Read(value []byte) (int, error) {
+	body.once.Do(body.before)
+	return body.reader.Read(value)
+}
+
+func (*callbackReadCloser) Close() error { return nil }
+
+type errorReadCloser struct {
+	once   sync.Once
+	before func()
+	err    error
+}
+
+func (body *errorReadCloser) Read([]byte) (int, error) {
+	body.once.Do(body.before)
+	return 0, body.err
+}
+
+func (*errorReadCloser) Close() error { return nil }
+
+func TestClientUploadsExactBytesToFixedRouteAndMapsProvenPages(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(2))
+	var calls atomic.Int64
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "synthetic-secret"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "https://marker.internal/marker/upload", request.URL.String())
+		assert.Equal(t, "Bearer synthetic-secret", request.Header.Get("Authorization"))
+		assertMultipart(t, request, fixture.metadata, fixture.source)
+		return jsonResponse(request, http.StatusOK, `{"format":"markdown","output":"{0}------------------------------------------------\n\n# First\n\n{1}------------------------------------------------\n\nSecond","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"pdftext","block_counts":[],"block_metadata":{}},{"page_id":1,"text_extraction_method":"pdftext","block_counts":[],"block_metadata":{}}]},"success":true}`), nil
+	}))
+
+	result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), calls.Load())
+	assert.Equal(t, document.EvidenceComplete, result.Evidence.Completeness)
+	assert.Equal(t, document.EvidenceUnitPage, result.Evidence.UnitKind)
+	require.Len(t, result.Evidence.Units, 2)
+	assert.Equal(t, "# First", result.Evidence.Units[0].Text)
+	assert.Equal(t, int64(1), result.Evidence.Units[1].Locator.Start)
+	assert.Equal(t, fixture.metadata.SHA256, result.Receipt.SourceSHA256)
+}
+
+func TestDescriptorCoversMarkerConverterFamilies(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	want := []document.RenditionFormatCapability{
+		{MediaFamily: "pdf", MediaType: "application/pdf", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/jpeg", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/png", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/webp", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/gif", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "word", MediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "spreadsheet", MediaType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "presentation", MediaType: "application/vnd.openxmlformats-officedocument.presentationml.presentation", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "ebook", MediaType: "application/epub+zip", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "text", MediaType: "text/html", InputKind: document.RenditionInputOriginalFile},
+	}
+	assert.ElementsMatch(t, want, fixture.descriptor.SupportedFormats)
+
+	changed := fixture.profile
+	changed.RuntimeFingerprint = strings.Repeat("9", 64)
+	fingerprint, err := PolicyFingerprint(changed)
+	require.NoError(t, err)
+	assert.NotEqual(t, fixture.descriptor.PolicyFingerprint, fingerprint)
+	changed = fixture.profile
+	changed.SecretBinding = "other"
+	fingerprint, err = PolicyFingerprint(changed)
+	require.NoError(t, err)
+	assert.NotEqual(t, fixture.descriptor.PolicyFingerprint, fingerprint)
+}
+
+func TestClientRequiresPinnedProfileAndOptionalCredentialPair(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	changed := fixture.profile
+	changed.RuntimeFingerprint = strings.Repeat("9", 64)
+	_, err := New(changed, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK, `{}`))
+	require.ErrorContains(t, err, "policy fingerprint")
+
+	withoutCredential := fixture.profile
+	withoutCredential.SecretBinding = ""
+	withoutCredential.Descriptor = descriptorFor(t, withoutCredential)
+	_, err = New(withoutCredential, nil, staticTransport(http.StatusOK, `{}`))
+	require.NoError(t, err)
+	_, err = New(withoutCredential, testSecrets{}, staticTransport(http.StatusOK, `{}`))
+	require.ErrorContains(t, err, "named binding")
+}
+
+func TestClientDegradesTransformedFamiliesWithoutInventingUnits(t *testing.T) {
+	for _, input := range []struct{ family, mediaType, filename string }{
+		{"word", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "notes.docx"},
+		{"spreadsheet", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "book.xlsx"},
+		{"presentation", "application/vnd.openxmlformats-officedocument.presentationml.presentation", "deck.pptx"},
+		{"ebook", "application/epub+zip", "book.epub"},
+		{"text", "text/html", "page.html"},
+		{"text", "text/html", "page.htm"},
+	} {
+		t.Run(input.family, func(t *testing.T) {
+			fixture := newFixture(t, input.family, input.mediaType, input.filename, []byte("synthetic source"))
+			client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK,
+				`{"format":"markdown","output":"{0}------------------------------------------------\n\nReadable","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"pdftext","block_counts":[],"block_metadata":{}}]},"success":true}`))
+			result, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+			require.NoError(t, err)
+			assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+			assert.Equal(t, document.EvidenceUnitGeneric, result.Evidence.UnitKind)
+		})
+	}
+}
+
+func TestClientRejectsUnsupportedFilenameIdentityAndBoundsBeforeEgress(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	var calls atomic.Int64
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) { calls.Add(1); return nil, errors.New("unexpected") })
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, transport)
+
+	wrong := fixture
+	wrong.metadata.Filename = "report.txt"
+	wrong.authorization.ProviderMetadataChecksum = wrong.metadata.ProviderMetadataChecksum
+	_, err := client.Render(t.Context(), wrong.upload(), wrong.authorization)
+	assertProviderCode(t, err, document.RenditionErrorUnsupportedInput)
+
+	wrong = fixture
+	wrong.metadata.SHA256 = strings.Repeat("0", 64)
+	wrong.authorization.SourceSHA256 = wrong.metadata.SHA256
+	_, err = client.Render(t.Context(), wrong.upload(), wrong.authorization)
+	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+
+	tooLarge := fixture.profile
+	tooLarge.MaxDocumentBytes = 2
+	tooLarge.MaxRequestBytes = 1024
+	tooLarge.Descriptor = descriptorFor(t, tooLarge)
+	client = newClient(t, tooLarge, testSecrets{"marker-front": "secret"}, transport)
+	tooLargeFixture := fixture.withDescriptor(tooLarge.Descriptor)
+	_, err = client.Render(t.Context(), tooLargeFixture.upload(), tooLargeFixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+	assert.Zero(t, calls.Load())
+}
+
+func TestClientRejectsRedirectMalformedPartialAndOversizedResults(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	for _, testCase := range []struct {
+		name   string
+		status int
+		body   string
+		want   document.RenditionErrorCode
+	}{
+		{"redirect", http.StatusFound, "", document.RenditionErrorMalformedEvidence},
+		{"malformed", http.StatusOK, `{`, document.RenditionErrorMalformedEvidence},
+		{"partial", http.StatusOK, `{"format":"markdown","output":"some","images":{},"metadata":{"table_of_contents":[],"page_stats":[]},"success":false,"error":"private"}`, document.RenditionErrorMalformedEvidence},
+		{"schema drift", http.StatusOK, `{"format":"markdown","output":"some","images":{},"metadata":{"table_of_contents":[],"page_stats":[]},"success":true,"new_field":1}`, document.RenditionErrorMalformedEvidence},
+		{"wrong format", http.StatusOK, `{"format":"html","output":"some","images":{},"metadata":{"table_of_contents":[],"page_stats":[]},"success":true}`, document.RenditionErrorMalformedEvidence},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(testCase.status, testCase.body))
+			_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+			assertProviderCode(t, err, testCase.want)
+			assert.NotContains(t, err.Error(), "private")
+		})
+	}
+
+	bounded := fixture.profile
+	bounded.MaxResponseBytes = 64
+	bounded.MaxMetadataBytes = 32
+	bounded.Descriptor = descriptorFor(t, bounded)
+	client := newClient(t, bounded, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK, strings.Repeat("x", 65)))
+	boundedFixture := fixture.withDescriptor(bounded.Descriptor)
+	_, err := client.Render(t.Context(), boundedFixture.upload(), boundedFixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+}
+
+func TestClientNeverFollowsRedirects(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	var calls atomic.Int64
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		response := jsonResponse(request, http.StatusFound, "")
+		response.Header.Set("Location", "https://attacker.invalid/result")
+		return response, nil
+	})
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, transport)
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+func TestClientRequiresLocalProofOfCompletePDFUnitsAndTotalResultBound(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(2))
+	partial := `{"format":"markdown","output":"{0}------------------------------------------------\n\nOnly first","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"pdftext","block_counts":[],"block_metadata":{}}]},"success":true}`
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK, partial))
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+
+	fixture = newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	fixture.authorization.MaxTotalResultBytes = 128
+	complete := `{"format":"markdown","output":"{0}------------------------------------------------\n\nComplete","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"pdftext","block_counts":[],"block_metadata":{}}]},"success":true}`
+	client = newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK, complete))
+	_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+}
+
+func TestClientProvesStillImageIdentityBeforeEgress(t *testing.T) {
+	const complete = `{"format":"markdown","output":"{0}------------------------------------------------\n\nImage text","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"surya","block_counts":[],"block_metadata":{}}]},"success":true}`
+	still := newFixture(t, "image", "image/png", "scan.png", mediatest.PNG(4, 3, nil))
+	client := newClient(t, still.profile, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK, complete))
+	result, err := document.RenderRendition(t.Context(), client, still.upload(), still.authorization)
+	require.NoError(t, err)
+	assert.Equal(t, document.EvidenceComplete, result.Evidence.Completeness)
+	require.Len(t, result.Evidence.Units, 1)
+
+	for _, testCase := range []struct {
+		name      string
+		mediaType string
+		filename  string
+		source    []byte
+	}{
+		{name: "malformed", mediaType: "image/png", filename: "scan.png", source: []byte("not a png")},
+		{name: "mismatched", mediaType: "image/jpeg", filename: "scan.jpg", source: mediatest.PNG(4, 3, nil)},
+		{name: "animated", mediaType: "image/gif", filename: "scan.gif", source: mediatest.GIF(2, 2, 2)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, "image", testCase.mediaType, testCase.filename, testCase.source)
+			var calls atomic.Int64
+			transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, errors.New("unexpected egress")
+			})
+			client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, transport)
+
+			_, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+
+			assertProviderCode(t, err, document.RenditionErrorUnsupportedInput)
+			assert.Zero(t, calls.Load())
+		})
+	}
+}
+
+func TestClientRechecksExpiryAndCancellationWhileReadingResponse(t *testing.T) {
+	const complete = `{"format":"markdown","output":"{0}------------------------------------------------\n\nComplete","images":{},"metadata":{"table_of_contents":[],"page_stats":[{"page_id":0,"text_extraction_method":"pdftext","block_counts":[],"block_metadata":{}}]},"success":true}`
+
+	t.Run("expiry after complete body", func(t *testing.T) {
+		fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+		expiresAt := time.Now().UTC().Add(30 * time.Millisecond)
+		fixture.authorization.ExpiresAt = expiresAt.Format(timestampForm)
+		body := &callbackReadCloser{reader: strings.NewReader(complete), before: func() {
+			time.Sleep(time.Until(expiresAt) + 10*time.Millisecond)
+		}}
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: body, Request: request}, nil
+		})
+		client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, transport)
+
+		_, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+
+		require.ErrorContains(t, err, "authorization is not current")
+	})
+
+	t.Run("cancellation after complete body", func(t *testing.T) {
+		fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+		ctx, cancel := context.WithCancel(t.Context())
+		body := &callbackReadCloser{reader: strings.NewReader(complete), before: cancel}
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: body, Request: request}, nil
+		})
+		client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, transport)
+
+		_, err := document.RenderRendition(ctx, client, fixture.upload(), fixture.authorization)
+
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("cancellation on body read error", func(t *testing.T) {
+		fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+		ctx, cancel := context.WithCancel(t.Context())
+		body := &errorReadCloser{before: cancel, err: errors.New("private body failure")}
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: body, Request: request}, nil
+		})
+		client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, transport)
+
+		_, err := document.RenderRendition(ctx, client, fixture.upload(), fixture.authorization)
+
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestClientClassifiesAuthCapacityTransportExpiryAndCancellation(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	for _, testCase := range []struct {
+		status int
+		want   document.RenditionErrorCode
+	}{
+		{http.StatusUnauthorized, document.RenditionErrorAuthentication},
+		{http.StatusTooManyRequests, document.RenditionErrorRateLimited},
+		{http.StatusServiceUnavailable, document.RenditionErrorCapacity},
+		{http.StatusUnsupportedMediaType, document.RenditionErrorUnsupportedInput},
+	} {
+		client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(testCase.status, "private"))
+		_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+		assertProviderCode(t, err, testCase.want)
+		assert.NotContains(t, err.Error(), "private")
+	}
+	client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("private transport")
+	}))
+	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorAmbiguousSubmission)
+
+	expired := fixture
+	expired.authorization.ExpiresAt = time.Now().UTC().Add(-time.Second).Format(timestampForm)
+	_, err = client.Render(t.Context(), expired.upload(), expired.authorization)
+	require.Error(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = client.Render(ctx, fixture.upload(), fixture.authorization)
+	assertProviderCode(t, err, document.RenditionErrorCanceled)
+}
+
+func TestClientBoundsImageAndMetadataPayloads(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	for _, body := range []string{
+		`{"format":"markdown","output":"safe","images":{"a":"c3ludGhldGljIGltYWdl"},"metadata":{"table_of_contents":[],"page_stats":[]},"success":true}`,
+		`{"format":"markdown","output":"safe","images":{},"metadata":{"table_of_contents":"` + strings.Repeat("x", 257) + `","page_stats":[]},"success":true}`,
+	} {
+		client := newClient(t, fixture.profile, testSecrets{"marker-front": "secret"}, staticTransport(http.StatusOK, body))
+		_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+		assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+	}
+}
+
+type fixture struct {
+	profile       Profile
+	descriptor    document.RenditionDescriptor
+	metadata      document.AuthorizedUploadMetadata
+	authorization document.RenditionAuthorization
+	source        []byte
+}
+
+func newFixture(t *testing.T, family, mediaType, filename string, source []byte) fixture {
+	t.Helper()
+	profile := Profile{Origin: "https://marker.internal", SecretBinding: "marker-front", Mode: "fast",
+		DeploymentFingerprint: strings.Repeat("d", 64), RuntimeFingerprint: strings.Repeat("r", 64),
+		RequestTimeout: time.Second, MaxDocumentBytes: 1 << 20, MaxRequestBytes: 2 << 20,
+		MaxResponseBytes: 1 << 20, MaxMetadataBytes: 256, MaxImages: 1, MaxImageBytes: 8, MaxUnits: 32}
+	// Runtime fingerprints are SHA-256 values, so use hexadecimal input.
+	profile.RuntimeFingerprint = strings.Repeat("e", 64)
+	profile.Descriptor = descriptorFor(t, profile)
+	digest := sha256.Sum256(source)
+	metadata := document.AuthorizedUploadMetadata{Filename: filename, MediaFamily: family, MediaType: mediaType,
+		ByteLength: int64(len(source)), SHA256: hex.EncodeToString(digest[:]), CapabilityRecordChecksum: strings.Repeat("2", 64),
+		ProviderMetadataChecksum: strings.Repeat("3", 64), InputKind: document.RenditionInputOriginalFile}
+	started := time.Now().UTC().Add(-time.Minute)
+	authorization := document.RenditionAuthorization{ProviderID: profile.Descriptor.ID, DescriptorFingerprint: profile.Descriptor.Fingerprint,
+		PolicyFingerprint: profile.Descriptor.PolicyFingerprint, RenditionRequestFingerprint: strings.Repeat("4", 64),
+		SourceSHA256: metadata.SHA256, SourceBytes: metadata.ByteLength, CapabilityRecordChecksum: metadata.CapabilityRecordChecksum,
+		ProviderMetadataChecksum: metadata.ProviderMetadataChecksum, MediaFamily: family, MediaType: mediaType,
+		InputKind: document.RenditionInputOriginalFile, DiscloseFilename: true,
+		MaxProviderMarkdownBytes: 4096, MaxTotalResultBytes: 32768,
+		AuthorizedAt: started.Format(timestampForm), ExpiresAt: started.Add(10 * time.Minute).Format(timestampForm)}
+	return fixture{profile: profile, descriptor: profile.Descriptor, metadata: metadata, authorization: authorization, source: source}
+}
+
+func descriptorFor(t *testing.T, profile Profile) document.RenditionDescriptor {
+	t.Helper()
+	fingerprint, err := PolicyFingerprint(profile)
+	require.NoError(t, err)
+	descriptor, err := document.NewRenditionDescriptor(document.RenditionDescriptor{ID: providerID,
+		ContractVersion: document.RenditionProviderContractVersion, PolicyFingerprint: fingerprint,
+		TrustBoundary: document.RenditionTrustOperatorNetwork, SupportedFormats: SupportedFormats(),
+		ReturnsMarkdown: true, ReturnsStructured: true})
+	require.NoError(t, err)
+	return descriptor
+}
+
+func (fixture fixture) upload() document.AuthorizedUpload {
+	return &testUpload{Reader: bytes.NewReader(fixture.source), metadata: fixture.metadata}
+}
+
+func (fixture fixture) withDescriptor(descriptor document.RenditionDescriptor) fixture {
+	fixture.descriptor, fixture.profile.Descriptor = descriptor, descriptor
+	fixture.authorization.ProviderID = descriptor.ID
+	fixture.authorization.DescriptorFingerprint = descriptor.Fingerprint
+	fixture.authorization.PolicyFingerprint = descriptor.PolicyFingerprint
+	return fixture
+}
+
+func newClient(t *testing.T, profile Profile, secrets SecretResolver, transport http.RoundTripper) *Client {
+	t.Helper()
+	client, err := New(profile, secrets, transport)
+	require.NoError(t, err)
+	return client
+}
+
+func staticTransport(status int, body string) http.RoundTripper {
+	return roundTripFunc(func(request *http.Request) (*http.Response, error) { return jsonResponse(request, status, body), nil })
+}
+
+func jsonResponse(request *http.Request, status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body)), Request: request}
+}
+
+func assertMultipart(t *testing.T, request *http.Request, metadata document.AuthorizedUploadMetadata, source []byte) {
+	t.Helper()
+	mediaType, params, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	require.Equal(t, "multipart/form-data", mediaType)
+	reader := multipart.NewReader(request.Body, params["boundary"])
+	fields := map[string]string{}
+	for {
+		part, partErr := reader.NextPart()
+		if errors.Is(partErr, io.EOF) {
+			break
+		}
+		require.NoError(t, partErr)
+		value, readErr := io.ReadAll(part)
+		require.NoError(t, readErr)
+		if part.FormName() == "file" {
+			assert.Equal(t, metadata.Filename, part.FileName())
+			assert.Equal(t, metadata.MediaType, part.Header.Get("Content-Type"))
+			assert.Equal(t, source, value)
+		} else {
+			fields[part.FormName()] = string(value)
+		}
+	}
+	assert.Equal(t, map[string]string{"mode": "fast", "force_ocr": "false", "paginate_output": "true", "output_format": "markdown"}, fields)
+}
+
+func assertProviderCode(t *testing.T, err error, want document.RenditionErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
+	require.True(t, ok, "%T: %v", err, err)
+	assert.Equal(t, want, providerErr.Code())
+}
+
+func TestPolicyFingerprintIsCanonical(t *testing.T) {
+	fixture := newFixture(t, "pdf", "application/pdf", "report.pdf", testPDF(1))
+	first, err := PolicyFingerprint(fixture.profile)
+	require.NoError(t, err)
+	encoded, err := json.Marshal(map[string]string{"fingerprint": first}, json.Deterministic(true))
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), first)
+}
+
+func testPDF(pageCount int) []byte {
+	var output bytes.Buffer
+	output.WriteString("%PDF-1.4\n%synthetic-marker-fixture\n")
+	objects := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		fmt.Sprintf("<< /Type /Pages /Kids [%s] /Count %d >>", pdfKids(pageCount), pageCount),
+	}
+	for index := range pageCount {
+		objects = append(objects, fmt.Sprintf("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents %d 0 R >>", pageCount+3+index))
+	}
+	for range pageCount {
+		objects = append(objects, "<< /Length 0 >>\nstream\n\nendstream")
+	}
+	offsets := make([]int, len(objects))
+	for index, object := range objects {
+		offsets[index] = output.Len()
+		_, _ = fmt.Fprintf(&output, "%d 0 obj\n%s\nendobj\n", index+1, object)
+	}
+	xref := output.Len()
+	_, _ = fmt.Fprintf(&output, "xref\n0 %d\n0000000000 65535 f \n", len(objects)+1)
+	for _, offset := range offsets {
+		_, _ = fmt.Fprintf(&output, "%010d 00000 n \n", offset)
+	}
+	_, _ = fmt.Fprintf(&output, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
+	return output.Bytes()
+}
+
+func pdfKids(pageCount int) string {
+	children := make([]string, pageCount)
+	for index := range pageCount {
+		children[index] = fmt.Sprintf("%d 0 R", index+3)
+	}
+	return strings.Join(children, " ")
+}

--- a/document/mistral/rendition_test.go
+++ b/document/mistral/rendition_test.go
@@ -252,11 +252,9 @@ func TestRenditionClientExpiryCancelsInFlightUpload(t *testing.T) {
 	require.NoError(t, err)
 	callerCtx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
-	started := time.Now()
 	_, err = client.Render(callerCtx, fixture.upload(), fixture.authorization)
 	assertRenditionCode(t, err, document.RenditionErrorPolicyRejected)
 	require.ErrorContains(t, errors.Unwrap(err), "authorization expired")
-	assert.Less(t, time.Since(started), 600*time.Millisecond)
 	select {
 	case <-requestStarted:
 	default:


### PR DESCRIPTION
## What changed

Self-hosted Marker is now a first-class broad-format rendition provider. Docbank uploads the exact authorized bytes to the operator-pinned `/marker/upload` route for PDF, safe still images, DOCX, XLSX, PPTX, EPUB, and HTML/HTM.

PDF and still-image results keep complete natural evidence only when Docbank can prove the local source units match. Transformed document families are marked degraded instead of inventing provenance. Redirects, provider-authored destinations, malformed or partial output, animated images, expired authority, and runtime drift fail closed.

## Why

Marker is useful beyond PDF, but self-hosting should not create a loose local-network trust boundary. The adapter still needs pinned deployment and runtime identity, exact bytes, fixed routes, finite limits, and locally provable evidence.

## Usage

For library use, run the audited Marker service and construct the adapter with `marker.New(profile, secrets, transport)`. The injected transport owns the operator-network destination policy, and Docbank never gives Marker a vault path.

This PR does not add daemon, API, or CLI registration. That application wiring is intentionally deferred to S1–S3.

Part of #176 (R11). Stacks on #202.
