### PR TITLE
[F10–E12 09/25] Add the hosted LlamaParse rendition provider

### DIFF
--- a/document/internal/providerutil/multipart.go
+++ b/document/internal/providerutil/multipart.go
@@ -7,7 +7,17 @@ import (
 	"io"
 	"mime/multipart"
 	"net/textproto"
+	"strings"
 )
+
+// ValidateMultipartFilename rejects line breaks before a filename is placed in
+// a multipart Content-Disposition header.
+func ValidateMultipartFilename(filename string) error {
+	if strings.ContainsAny(filename, "\r\n") {
+		return errors.New("multipart filename contains a line break")
+	}
+	return nil
+}
 
 // MultipartUpload streams one file and its form fields as multipart/form-data
 // without buffering the body: the request reads from a pipe while a goroutine
@@ -50,6 +60,9 @@ func (writer *countingWriter) Write(value []byte) (int, error) {
 }
 
 func (upload MultipartUpload) write(writer *multipart.Writer) error {
+	if err := ValidateMultipartFilename(upload.Filename); err != nil {
+		return err
+	}
 	if upload.Prologue != nil {
 		if err := upload.Prologue(writer); err != nil {
 			return err

--- a/document/internal/providerutil/operation.go
+++ b/document/internal/providerutil/operation.go
@@ -16,11 +16,12 @@ var ErrTotalTimeout = errors.New("provider total timeout")
 // Operation bounds one Render call by the caller context, the authorization
 // expiry, and the adapter's total timeout.
 type Operation struct {
-	provider  Provider
-	caller    context.Context
-	ctx       context.Context
-	cancel    context.CancelFunc
-	expiresAt time.Time
+	provider      Provider
+	caller        context.Context
+	ctx           context.Context
+	cancel        context.CancelFunc
+	expiresAt     time.Time
+	enforceExpiry bool
 }
 
 // NewOperation parses the authorization expiry and derives a context bounded
@@ -34,19 +35,36 @@ func NewOperation(
 		return nil, provider.Classified(document.RenditionErrorPolicyRejected,
 			string(provider)+" authorization expiry is invalid", nil)
 	}
+	return newOperation(ctx, provider, expiry, totalTimeout, true), nil
+}
+
+// NewResumedOperation bounds a durable resume by the caller and adapter total
+// timeout without reopening the historical authorization interval. The caller
+// must validate the sealed resume authority before constructing the operation.
+func NewResumedOperation(ctx context.Context, provider Provider, totalTimeout time.Duration) *Operation {
+	return newOperation(ctx, provider, time.Time{}, totalTimeout, false)
+}
+
+func newOperation(
+	ctx context.Context, provider Provider, expiresAt time.Time, totalTimeout time.Duration, enforceExpiry bool,
+) *Operation {
 	bounded := ctx
 	cancelTotal := context.CancelFunc(func() {})
 	if totalTimeout > 0 {
 		bounded, cancelTotal = context.WithTimeoutCause(ctx, totalTimeout, ErrTotalTimeout)
 	}
-	operationCtx, cancelExpiry := context.WithDeadline(bounded, expiry)
+	operationCtx := bounded
+	cancelExpiry := context.CancelFunc(func() {})
+	if enforceExpiry {
+		operationCtx, cancelExpiry = context.WithDeadline(bounded, expiresAt)
+	}
 	return &Operation{
-		provider: provider, caller: ctx, ctx: operationCtx, expiresAt: expiry,
+		provider: provider, caller: ctx, ctx: operationCtx, expiresAt: expiresAt, enforceExpiry: enforceExpiry,
 		cancel: func() {
 			cancelExpiry()
 			cancelTotal()
 		},
-	}, nil
+	}
 }
 
 // Context returns the bounded operation context.
@@ -65,7 +83,7 @@ func (operation *Operation) Check() error {
 	if err := operation.caller.Err(); err != nil {
 		return operation.provider.Canceled(err)
 	}
-	if !time.Now().Before(operation.expiresAt) {
+	if operation.enforceExpiry && !time.Now().Before(operation.expiresAt) {
 		return operation.provider.Expired()
 	}
 	if errors.Is(context.Cause(operation.ctx), ErrTotalTimeout) {

--- a/document/internal/providerutil/provider.go
+++ b/document/internal/providerutil/provider.go
@@ -277,6 +277,7 @@ type Receipt struct {
 	CompletedAt   time.Time
 	Warnings      []string
 	Usage         document.RenditionUsage
+	RetryDelay    time.Duration
 }
 
 // NewReceipt binds a completed rendering to its descriptor and authorization.
@@ -297,5 +298,6 @@ func NewReceipt(provider Provider, input Receipt) (document.RenditionReceipt, er
 		CompletedAt:                 input.CompletedAt.UTC().Format(TimestampForm),
 		Warnings:                    input.Warnings,
 		Usage:                       input.Usage,
+		RetryDelayMillis:            input.RetryDelay.Milliseconds(),
 	}, nil
 }

--- a/document/internal/providerutil/provider.go
+++ b/document/internal/providerutil/provider.go
@@ -121,10 +121,17 @@ func (provider Provider) CanonicalDescriptor(
 	return CloneDescriptor(canonical), nil
 }
 
+// AllowsArtifact reports whether an authorization can retain at least one artifact with role.
+func AllowsArtifact(
+	authorization document.RenditionAuthorization, role document.EvidenceArtifactRole,
+) bool {
+	return slices.Contains(authorization.AllowedArtifactRoles, role) &&
+		authorization.MaxArtifacts > 0 && authorization.MaxArtifactBytes > 0
+}
+
 // AllowsStructured reports whether an authorization can retain one structured artifact.
 func AllowsStructured(authorization document.RenditionAuthorization) bool {
-	return slices.Contains(authorization.AllowedArtifactRoles, document.EvidenceArtifactStructured) &&
-		authorization.MaxArtifacts > 0 && authorization.MaxArtifactBytes > 0
+	return AllowsArtifact(authorization, document.EvidenceArtifactStructured)
 }
 
 // NaturalUnit maps a media family to the evidence unit its provider output

--- a/document/internal/providerutil/provider_test.go
+++ b/document/internal/providerutil/provider_test.go
@@ -37,6 +37,12 @@ func TestParseRetryAfterAcceptsSecondsAndHTTPDate(t *testing.T) {
 	assert.Zero(t, ParseRetryAfter(http.Header{}))
 }
 
+func TestRequireMediaTypeAcceptsOnlyTheRequestedWildcardFamily(t *testing.T) {
+	require.NoError(t, testProvider.RequireMediaType("image/png", "image/*"))
+	assertCode(t, testProvider.RequireMediaType("application/json", "image/*"),
+		document.RenditionErrorMalformedEvidence)
+}
+
 func TestStatusErrorUsesOneTableForEveryStage(t *testing.T) {
 	for _, testCase := range []struct {
 		name      string
@@ -108,6 +114,15 @@ func TestOperationCheckOrdersCallerExpiryAndTotalTimeout(t *testing.T) {
 		require.NoError(t, err)
 		defer operation.Cancel()
 		assertCode(t, operation.Check(), document.RenditionErrorPolicyRejected)
+	})
+
+	t.Run("resumed operation uses only a new total timeout", func(t *testing.T) {
+		operation := NewResumedOperation(t.Context(), testProvider, time.Millisecond)
+		defer operation.Cancel()
+		<-operation.Context().Done()
+		err := operation.Check()
+		assertCode(t, err, document.RenditionErrorCapacity)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 }
 

--- a/document/internal/providerutil/provider_test.go
+++ b/document/internal/providerutil/provider_test.go
@@ -224,6 +224,14 @@ func TestExecutorDeliversMultipartFieldsAndCountsResponseBytes(t *testing.T) {
 	assert.Equal(t, int64(encoded.Len()), encodedLength)
 }
 
+func TestMultipartUploadRejectsFilenameLineBreaks(t *testing.T) {
+	for _, filename := range []string{"report\r.pdf", "report\n.pdf"} {
+		upload := MultipartUpload{FieldName: "file", Filename: filename, MediaType: "application/pdf"}
+		_, err := upload.EncodedLength()
+		require.ErrorContains(t, err, "line break")
+	}
+}
+
 func TestExecutorCountsPartialBodyAndClassifiesReadFailure(t *testing.T) {
 	payload := []byte("partial provider response")
 	executor := &Executor{

--- a/document/internal/providerutil/request.go
+++ b/document/internal/providerutil/request.go
@@ -247,7 +247,10 @@ func (provider Provider) RequireMediaType(got, want string) error {
 		return provider.Malformed(string(provider)+" response content type is invalid", err)
 	}
 	wantType, wantParams, err := mime.ParseMediaType(want)
-	if err != nil || gotType != wantType || len(wantParams) != 0 && !reflect.DeepEqual(gotParams, wantParams) {
+	wantFamily, wantSubtype, wildcard := strings.Cut(wantType, "/")
+	gotFamily, _, _ := strings.Cut(gotType, "/")
+	matches := gotType == wantType || wildcard && wantSubtype == "*" && gotFamily == wantFamily
+	if err != nil || !matches || len(wantParams) != 0 && !reflect.DeepEqual(gotParams, wantParams) {
 		return provider.Malformed(string(provider)+" response content type does not match protocol", err)
 	}
 	return nil

--- a/document/llamaparse/client.go
+++ b/document/llamaparse/client.go
@@ -1,0 +1,876 @@
+package llamaparse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
+	"go.kenn.io/docbank/document/media"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	apiHost                = "api.cloud.llamaindex.ai"
+	apiOrigin              = "https://" + apiHost
+	uploadPath             = "/api/v1/parsing/upload"
+	providerID             = "llamaparse.parse-v1"
+	timeForm               = providerutil.TimestampForm
+	markdownPageSeparator  = "\n\n---\n\n"
+	maxConfiguredBytes     = 512 << 20
+	maxConfiguredPolls     = 100_000
+	maxConfiguredDuration  = 24 * time.Hour
+	defaultUploadBytes     = 50 << 20
+	defaultRequestOverhead = 1 << 20
+	defaultControlBytes    = 64 << 10
+	defaultResultBytes     = 64 << 20
+	defaultArtifactBytes   = 16 << 20
+)
+
+var errExecutionIdentityChanged = errors.New("reported execution identity changed")
+
+var provider = providerutil.Provider("LlamaParse")
+
+var (
+	_ document.RenditionProvider          = (*Client)(nil)
+	_ document.ResumableRenditionProvider = (*Client)(nil)
+)
+
+// SecretResolver resolves the one credential named by a frozen profile.
+type SecretResolver = providerutil.SecretResolver
+
+// Profile freezes the hosted model, parse preset, and every network/output
+// bound. API origin and routes are deliberately not configurable.
+type Profile struct {
+	Model            string
+	Preset           string
+	SecretBinding    string
+	MaxUploadBytes   int64
+	MaxRequestBytes  int64
+	MaxControlBytes  int64
+	MaxPolls         int
+	PollInterval     time.Duration
+	RequestTimeout   time.Duration
+	MaxResultBytes   int64
+	MaxArtifactBytes int64
+	MaxArtifacts     int
+	MaxWallTime      time.Duration
+	RetainImages     bool
+}
+
+// Client is a fixed-origin hosted LlamaParse rendition provider.
+type Client struct {
+	descriptor document.RenditionDescriptor
+	profile    Profile
+	executor   providerutil.Executor
+}
+
+// NewProvider constructs a provider around an injected hardened transport.
+// It never resolves credentials or performs network access during setup.
+func NewProvider(profile Profile, secrets SecretResolver, transport http.RoundTripper) (*Client, error) {
+	profile = defaultProfile(profile)
+	if err := validateProfile(profile); err != nil {
+		return nil, err
+	}
+	if providerutil.IsNil(secrets) {
+		return nil, errors.New("LlamaParse named credential resolver is required")
+	}
+	if providerutil.IsNil(transport) {
+		return nil, errors.New("LlamaParse hardened transport is required")
+	}
+	credential := providerutil.BearerCredential(profile.SecretBinding, secrets)
+	if err := credential.Validate(provider); err != nil {
+		return nil, err
+	}
+	policyFingerprint := providerutil.SHA256Hex([]byte(fmt.Sprintf(
+		"llamaparse-profile/v1\x00%s\x00%s\x00%s\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%t",
+		profile.Model, profile.Preset, profile.SecretBinding, profile.MaxUploadBytes,
+		profile.MaxRequestBytes, profile.MaxControlBytes, profile.MaxPolls,
+		profile.PollInterval, profile.RequestTimeout, profile.MaxResultBytes,
+		profile.MaxArtifactBytes, profile.MaxWallTime, profile.RetainImages,
+	)))
+	roles := []document.EvidenceArtifactRole(nil)
+	if profile.RetainImages {
+		roles = []document.EvidenceArtifactRole{document.EvidenceArtifactImage}
+	}
+	descriptor, err := document.NewRenditionDescriptor(document.RenditionDescriptor{
+		ID: providerID, ContractVersion: document.RenditionProviderContractVersion,
+		PolicyFingerprint: policyFingerprint,
+		TrustBoundary:     document.RenditionTrustHostedProvider,
+		SupportedFormats: []document.RenditionFormatCapability{{
+			MediaFamily: "pdf", MediaType: "application/pdf",
+			InputKind: document.RenditionInputOriginalFile,
+		}},
+		ReturnsMarkdown: true, ReturnsStructured: true, ArtifactRoles: roles,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("LlamaParse descriptor: %w", err)
+	}
+	return &Client{
+		descriptor: providerutil.CloneDescriptor(descriptor), profile: profile,
+		executor: providerutil.Executor{
+			Provider: provider, HTTP: providerhttp.IsolateClient(&http.Client{Transport: transport}),
+			Origin: apiOrigin, RequestTimeout: profile.RequestTimeout,
+			MaxResponseBytes: max(profile.MaxControlBytes, profile.MaxResultBytes, profile.MaxArtifactBytes),
+			Credential:       credential,
+		},
+	}, nil
+}
+
+// Descriptor returns a defensive copy of the immutable provider identity.
+func (client *Client) Descriptor() document.RenditionDescriptor {
+	if client == nil {
+		return document.RenditionDescriptor{}
+	}
+	return providerutil.CloneDescriptor(client.descriptor)
+}
+
+// Render starts and completes one hosted parse operation.
+func (client *Client) Render(
+	ctx context.Context, upload document.AuthorizedUpload,
+	authorization document.RenditionAuthorization,
+) (document.RenditionResult, error) {
+	return client.RenderResumable(ctx, upload, authorization, nil, nil)
+}
+
+// RenderResumable submits exact authorized bytes or resumes one known UUID
+// handle. A new handle is checkpointed before the first status request.
+func (client *Client) RenderResumable(
+	ctx context.Context, upload document.AuthorizedUpload,
+	authorization document.RenditionAuthorization, resume *document.RenditionResumeHandle,
+	checkpoint document.RenditionResumeCheckpoint,
+) (document.RenditionResult, error) {
+	if client == nil {
+		return document.RenditionResult{}, errors.New("LlamaParse client is required")
+	}
+	resumeState, err := client.validateInvocation(upload, authorization, resume)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	var operation *providerutil.Operation
+	if resume == nil {
+		operation, err = providerutil.NewOperation(ctx, provider, authorization.ExpiresAt, client.profile.MaxWallTime)
+		if err != nil {
+			return document.RenditionResult{}, err
+		}
+	} else {
+		operation = providerutil.NewResumedOperation(ctx, provider, client.profile.MaxWallTime)
+	}
+	defer operation.Cancel()
+	state := operationState{startedAt: resumeState.submittedAt, completedAt: resumeState.checkpointedAt,
+		operation: operation}
+	var jobID string
+	if resume == nil {
+		jobID, err = client.submit(upload, &state)
+		if err != nil {
+			return document.RenditionResult{}, err
+		}
+		checkpointedAt := time.Now().UTC()
+		if err := operation.Check(); err != nil {
+			return document.RenditionResult{}, err
+		}
+		handle := encodeResumeHandle(resumeStateV1{
+			jobID: jobID, submittedAt: state.startedAt, checkpointedAt: checkpointedAt,
+		})
+		if checkpoint != nil {
+			if err := checkpoint(document.RenditionResumeHandle{Value: handle}); err != nil {
+				return document.RenditionResult{}, err
+			}
+		}
+	} else {
+		jobID = resumeState.jobID
+	}
+	if err := client.poll(jobID, &state); err != nil {
+		return document.RenditionResult{}, err
+	}
+	result, err := client.result(jobID, authorization, &state)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	acceptedAt := time.Now().UTC()
+	if resume == nil {
+		state.completedAt = acceptedAt
+	}
+	if err := operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	result.Receipt, err = providerutil.NewReceipt(provider, providerutil.Receipt{
+		Descriptor: client.descriptor, Authorization: authorization, SourceSHA256: authorization.SourceSHA256,
+		OperationID: "llamaparse-" + jobID[:8], StartedAt: state.startedAt, CompletedAt: state.completedAt,
+		Warnings:   state.warnings,
+		Usage:      state.usage.Rendition(authorization.SourceBytes, int64(len(result.Evidence.Units))),
+		RetryDelay: state.pollDelay,
+	})
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	return result, nil
+}
+
+func (client *Client) validateInvocation(
+	upload document.AuthorizedUpload, authorization document.RenditionAuthorization,
+	resume *document.RenditionResumeHandle,
+) (resumeStateV1, error) {
+	expiresAt, err := time.Parse(timeForm, authorization.ExpiresAt)
+	if err != nil {
+		return resumeStateV1{}, provider.Classified(document.RenditionErrorPolicyRejected,
+			"LlamaParse authorization expiry is invalid", err)
+	}
+	if resume == nil {
+		if providerutil.IsNil(upload) {
+			return resumeStateV1{}, errors.New("LlamaParse authorized upload is required for submission")
+		}
+	} else {
+		if !providerutil.IsNil(upload) {
+			return resumeStateV1{}, errors.New("LlamaParse resume must not receive source bytes")
+		}
+		parsed, parseErr := parseResumeHandle(resume.Value)
+		if parseErr != nil {
+			return resumeStateV1{}, provider.Classified(document.RenditionErrorUnknownJob,
+				"LlamaParse resume handle is invalid", parseErr)
+		}
+		if authorization.ProviderID != client.descriptor.ID ||
+			authorization.DescriptorFingerprint != client.descriptor.Fingerprint ||
+			authorization.PolicyFingerprint != client.descriptor.PolicyFingerprint {
+			return resumeStateV1{}, provider.Classified(document.RenditionErrorPolicyRejected,
+				"LlamaParse resume authority changed", nil)
+		}
+		authorizedAt, authErr := time.Parse(timeForm, authorization.AuthorizedAt)
+		if authErr != nil || parsed.submittedAt.Before(authorizedAt) ||
+			parsed.checkpointedAt.Before(parsed.submittedAt) || parsed.checkpointedAt.After(expiresAt) {
+			return resumeStateV1{}, provider.Classified(document.RenditionErrorPolicyRejected,
+				"LlamaParse resume receipt facts are outside the sealed authorization", authErr)
+		}
+		return parsed, nil
+	}
+	return resumeStateV1{}, nil
+}
+
+func (client *Client) submit(
+	upload document.AuthorizedUpload, state *operationState,
+) (string, error) {
+	metadata := upload.Metadata()
+	if metadata.ByteLength > client.profile.MaxUploadBytes {
+		return "", provider.Classified(document.RenditionErrorPolicyRejected,
+			"LlamaParse upload exceeds profile limit", nil)
+	}
+	source, err := state.operation.ReadUpload(upload)
+	if err != nil {
+		return "", err
+	}
+	defer clear(source)
+	body := &providerutil.MultipartUpload{
+		FieldName: "file", Filename: metadata.Filename, MediaType: metadata.MediaType,
+		Source: bytes.NewReader(source), Length: int64(len(source)), Fields: [][2]string{
+			{"model", client.profile.Model}, {"preset", client.profile.Preset},
+			{"page_error_tolerance", "0"}, {"save_images", strconv.FormatBool(client.profile.RetainImages)},
+			{"disable_image_extraction", strconv.FormatBool(!client.profile.RetainImages)},
+			{"take_screenshot", "false"},
+		},
+	}
+	requestBytes, err := body.EncodedLength()
+	if err != nil {
+		return "", provider.Classified(document.RenditionErrorTransient,
+			"LlamaParse request could not be built", err)
+	}
+	if requestBytes > client.profile.MaxRequestBytes {
+		return "", provider.Classified(document.RenditionErrorPolicyRejected,
+			"LlamaParse request exceeds profile limit", nil)
+	}
+	state.startedAt = time.Now().UTC()
+	response, err := client.executor.Do(state.operation, &state.usage, providerutil.Request{
+		Stage: providerutil.StageSubmission, Method: http.MethodPost, Path: uploadPath,
+		Upload: body, MaxResponseBytes: client.profile.MaxControlBytes,
+	})
+	if err != nil {
+		return "", err
+	}
+	if !response.Success() {
+		return "", provider.StatusError(providerutil.StageSubmission, response.Status, response.RetryAfter, nil)
+	}
+	var job jobResponse
+	if err := strictJSON(response.Body, &job); err != nil || validateJobID(job.ID) != nil {
+		return "", provider.AmbiguousSubmission(provider.Malformed("LlamaParse submission schema changed", err))
+	}
+	if err := validateInitialStatus(job.Status); err != nil {
+		return "", err
+	}
+	return job.ID, nil
+}
+
+func (client *Client) poll(
+	jobID string, state *operationState,
+) error {
+	for attempt := range client.profile.MaxPolls {
+		response, err := client.executor.Do(state.operation, &state.usage, providerutil.Request{
+			Stage: providerutil.StageJob, Method: http.MethodGet, Path: statusPath(jobID),
+			MaxResponseBytes: client.profile.MaxControlBytes,
+		})
+		if err != nil {
+			if operationErr := state.operation.Check(); operationErr != nil {
+				return provider.KnownJobError(operationErr)
+			}
+			return err
+		}
+		if !response.Success() {
+			return provider.StatusError(providerutil.StageJob, response.Status, response.RetryAfter, nil)
+		}
+		var job jobResponse
+		if err := strictJSON(response.Body, &job); err != nil || job.ID != jobID {
+			return provider.Malformed(
+				"LlamaParse status schema changed", err)
+		}
+		switch job.Status {
+		case "SUCCESS":
+			return nil
+		case "PENDING":
+			if attempt+1 == client.profile.MaxPolls {
+				break
+			}
+			state.usage.Retries++
+			if err := state.operation.Wait(client.profile.PollInterval); err != nil {
+				return provider.KnownJobError(err)
+			}
+			state.pollDelay += client.profile.PollInterval
+		case "ERROR":
+			return provider.Classified(document.RenditionErrorUnsupportedInput,
+				"LlamaParse could not parse the input", nil)
+		case "PARTIAL_SUCCESS":
+			return provider.Malformed(
+				"LlamaParse returned partial output", nil)
+		case "CANCELLED":
+			return provider.Classified(document.RenditionErrorCanceled,
+				"LlamaParse job was canceled", nil)
+		default:
+			return provider.Classified(document.RenditionErrorPolicyRejected,
+				"LlamaParse status schema changed", nil)
+		}
+	}
+	return provider.AmbiguousJob(provider.Classified(document.RenditionErrorCapacity,
+		"LlamaParse polling limit was reached", nil))
+}
+
+func (client *Client) result(
+	jobID string, authorization document.RenditionAuthorization, state *operationState,
+) (document.RenditionResult, error) {
+	budget := min(client.profile.MaxResultBytes, int64(authorization.MaxTotalResultBytes))
+	response, err := client.executor.Do(state.operation, &state.usage, providerutil.Request{
+		Stage: providerutil.StageJob, Method: http.MethodGet, Path: jsonResultPath(jobID),
+		MaxResponseBytes: budget,
+	})
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	if !response.Success() {
+		return document.RenditionResult{}, provider.StatusError(
+			providerutil.StageJob, response.Status, response.RetryAfter, nil)
+	}
+	budget -= int64(len(response.Body))
+	var envelope jsonResult
+	parseErr := strictJSON(response.Body, &envelope)
+	if err := state.operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	if parseErr != nil || len(envelope.Pages) == 0 || !jsonObject(envelope.JobMetadata) {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse result schema changed", parseErr)
+	}
+	jobPages, err := client.validateJobMetadata(envelope.JobMetadata)
+	if lifecycleErr := state.operation.Check(); lifecycleErr != nil {
+		return document.RenditionResult{}, lifecycleErr
+	}
+	if err != nil {
+		if errors.Is(err, errExecutionIdentityChanged) {
+			return document.RenditionResult{}, provider.Classified(document.RenditionErrorPolicyRejected,
+				"LlamaParse model or preset changed", err)
+		}
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse result metadata is malformed", err)
+	}
+	var pages []resultPage
+	pageParseErr := strictJSON(envelope.Pages, &pages)
+	if err := state.operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	if pageParseErr != nil {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse page schema changed", pageParseErr)
+	}
+	if len(pages) == 0 {
+		if jobPages != 0 {
+			return document.RenditionResult{}, provider.Malformed(
+				"LlamaParse page output is incomplete", nil)
+		}
+		return client.markdownFallback(jobID, authorization, jobPages, budget, state)
+	}
+	if jobPages <= 0 || len(pages) != jobPages {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse page output is incomplete", nil)
+	}
+	evidence, markdown, imageName, err := client.pageEvidence(pages, authorization)
+	if lifecycleErr := state.operation.Check(); lifecycleErr != nil {
+		return document.RenditionResult{}, lifecycleErr
+	}
+	if err != nil {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse page output is incomplete", err)
+	}
+	if len(markdown) > authorization.MaxProviderMarkdownBytes {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse Markdown exceeds authorization", nil)
+	}
+	result := document.RenditionResult{Evidence: evidence, ProviderMarkdown: markdown}
+	if imageName != "" {
+		artifact, sourceArtifact, artifactErr := client.fetchImage(
+			jobID, imageName, authorization, budget, state)
+		if artifactErr != nil {
+			return document.RenditionResult{}, artifactErr
+		}
+		result.Artifacts = []document.RenditionArtifact{artifact}
+		result.Evidence.Artifacts = []document.SourceEvidenceArtifactV1{sourceArtifact}
+	}
+	if err := state.operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	return result, nil
+}
+
+func (client *Client) markdownFallback(
+	jobID string, authorization document.RenditionAuthorization,
+	expectedJobPages int, budget int64, state *operationState,
+) (document.RenditionResult, error) {
+	response, err := client.executor.Do(state.operation, &state.usage, providerutil.Request{
+		Stage: providerutil.StageJob, Method: http.MethodGet, Path: markdownResultPath(jobID),
+		MaxResponseBytes: budget,
+	})
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	if !response.Success() {
+		return document.RenditionResult{}, provider.StatusError(
+			providerutil.StageJob, response.Status, response.RetryAfter, nil)
+	}
+	var envelope markdownResult
+	parseErr := strictJSON(response.Body, &envelope)
+	if err := state.operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	if parseErr != nil || !jsonObject(envelope.JobMetadata) ||
+		envelope.Markdown == "" || !utf8.ValidString(envelope.Markdown) {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse Markdown result is malformed", parseErr)
+	}
+	jobPages, metadataErr := client.validateJobMetadata(envelope.JobMetadata)
+	if err := state.operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	if metadataErr != nil {
+		if errors.Is(metadataErr, errExecutionIdentityChanged) {
+			return document.RenditionResult{}, provider.Classified(document.RenditionErrorPolicyRejected,
+				"LlamaParse model or preset changed", metadataErr)
+		}
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse result metadata is malformed", metadataErr)
+	}
+	if jobPages != expectedJobPages {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse result page counts disagree", nil)
+	}
+	markdown := []byte(envelope.Markdown)
+	if len(markdown) > authorization.MaxProviderMarkdownBytes {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse Markdown exceeds authorization", nil)
+	}
+	evidence := providerutil.DegradedEvidence(authorization.MediaFamily, envelope.Markdown,
+		"LlamaParse returned Markdown without page provenance")
+	evidence.Units[0].ProviderID = "llamaparse-markdown"
+	evidence.Units[0].Locator.Name = "llamaparse-markdown"
+	if err := document.ValidateSourceEvidenceV1(evidence); err != nil {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse Markdown cannot be represented", err)
+	}
+	if err := state.operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	state.warnings = []string{"degraded_provenance"}
+	return document.RenditionResult{Evidence: evidence, ProviderMarkdown: markdown}, nil
+}
+
+func (client *Client) pageEvidence(
+	pages []resultPage, authorization document.RenditionAuthorization,
+) (document.SourceEvidenceV1, []byte, string, error) {
+	evidence := document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1, Completeness: document.EvidenceComplete,
+		Family: authorization.MediaFamily, UnitKind: document.EvidenceUnitPage,
+		Units: make([]document.SourceEvidenceUnitV1, 0, len(pages)),
+	}
+	markdown := make([]string, 0, len(pages))
+	imageName := ""
+	for order, page := range pages {
+		if page.Page == nil || *page.Page != order {
+			return document.SourceEvidenceV1{}, nil, "", errors.New("page sequence is not complete")
+		}
+		if page.Status != nil && *page.Status != "" && *page.Status != "SUCCESS" {
+			return document.SourceEvidenceV1{}, nil, "", errors.New("page has a non-success status")
+		}
+		text := ""
+		if page.Markdown != nil {
+			text = *page.Markdown
+		} else if page.Text != nil {
+			text = *page.Text
+		}
+		if !utf8.ValidString(text) || text == "" && (page.NoTextContent == nil || !*page.NoTextContent) {
+			return document.SourceEvidenceV1{}, nil, "", errors.New("page has no representable text")
+		}
+		if page.Confidence != nil && (math.IsNaN(*page.Confidence) || math.IsInf(*page.Confidence, 0) ||
+			*page.Confidence < 0 || *page.Confidence > 1) {
+			return document.SourceEvidenceV1{}, nil, "", errors.New("page confidence is invalid")
+		}
+		unit := document.SourceEvidenceUnitV1{
+			Order: order, ProviderID: fmt.Sprintf("llamaparse-page-%d", order), Text: text,
+			Locator: document.SourceEvidenceLocatorV1{
+				Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginZero,
+				Start: int64(order), End: int64(order),
+			},
+		}
+		if page.Confidence != nil {
+			unit.Confidence = &document.SourceEvidenceConfidenceV1{
+				Interpretation: document.EvidenceConfidenceProbability,
+				Minimum:        0, Maximum: 1, Value: *page.Confidence,
+			}
+		}
+		evidence.Units = append(evidence.Units, unit)
+		markdown = append(markdown, text)
+		for _, image := range page.Images {
+			if !client.profile.RetainImages || imageName != "" || validateArtifactName(image.Name) != nil {
+				return document.SourceEvidenceV1{}, nil, "", errors.New("provider images are unrepresentable")
+			}
+			imageName = image.Name
+		}
+	}
+	if imageName != "" && (client.profile.MaxArtifacts != 1 || authorization.MaxArtifacts < 1 ||
+		!slices.Contains(authorization.AllowedArtifactRoles, document.EvidenceArtifactImage)) {
+		return document.SourceEvidenceV1{}, nil, "", errors.New("provider image is not authorized")
+	}
+	if err := document.ValidateSourceEvidenceV1(evidence); err != nil {
+		return document.SourceEvidenceV1{}, nil, "", err
+	}
+	return evidence, []byte(strings.Join(markdown, markdownPageSeparator)), imageName, nil
+}
+
+func (client *Client) validateJobMetadata(raw json.RawMessage) (int, error) {
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return 0, err
+	}
+	encodedPages, present := metadata["job_pages"]
+	if !present {
+		return 0, errors.New("reported page count is missing")
+	}
+	var pages int
+	if err := strictJSON(encodedPages, &pages); err != nil || pages < 0 {
+		return 0, errors.New("reported page count is invalid")
+	}
+	for field, expected := range map[string]string{
+		"model": client.profile.Model, "preset": client.profile.Preset,
+	} {
+		encoded, present := metadata[field]
+		if !present {
+			continue
+		}
+		var actual string
+		if err := strictJSON(encoded, &actual); err != nil || actual != expected {
+			return 0, errExecutionIdentityChanged
+		}
+	}
+	return pages, nil
+}
+
+func (client *Client) fetchImage(
+	jobID, name string, authorization document.RenditionAuthorization,
+	budget int64, state *operationState,
+) (document.RenditionArtifact, document.SourceEvidenceArtifactV1, error) {
+	limit := min(client.profile.MaxArtifactBytes, int64(authorization.MaxArtifactBytes))
+	limit = min(limit, budget)
+	response, err := client.executor.Do(state.operation, &state.usage, providerutil.Request{
+		Stage: providerutil.StageJob, Method: http.MethodGet, Path: imageResultPath(jobID, name),
+		MaxResponseBytes: limit, ResponseMediaType: "image/*",
+	})
+	if err != nil {
+		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, err
+	}
+	if !response.Success() {
+		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{},
+			provider.StatusError(providerutil.StageJob, response.Status, response.RetryAfter, nil)
+	}
+	canonical, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || (canonical != "image/png" && canonical != "image/jpeg" && canonical != "image/webp") {
+		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, provider.Malformed(
+			"LlamaParse image media type changed", err)
+	}
+	detected, err := media.DetectBytes(response.Body, canonical)
+	if err != nil || detected.Kind != media.KindImage || detected.MediaType != canonical ||
+		detected.FrameCount != 1 || detected.Animated {
+		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, provider.Malformed(
+			"LlamaParse image result is malformed", err)
+	}
+	if err := state.operation.Check(); err != nil {
+		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, err
+	}
+	checksum := providerutil.SHA256Hex(response.Body)
+	pointer := "images/" + name
+	return document.RenditionArtifact{
+		Role: document.EvidenceArtifactImage, MediaType: canonical,
+		Payload: response.Body, SHA256: checksum,
+	}, document.SourceEvidenceArtifactV1{
+		Pointer: pointer, ProviderID: "llamaparse-image-0",
+		Role: document.EvidenceArtifactImage, SHA256: checksum,
+	}, nil
+}
+
+type operationState struct {
+	operation   *providerutil.Operation
+	usage       providerutil.Usage
+	startedAt   time.Time
+	completedAt time.Time
+	pollDelay   time.Duration
+	warnings    []string
+}
+
+type resumeStateV1 struct {
+	jobID          string
+	submittedAt    time.Time
+	checkpointedAt time.Time
+}
+
+type jobResponse struct {
+	ID           string  `json:"id"`
+	Status       string  `json:"status"`
+	ErrorCode    *string `json:"error_code,omitempty"`
+	ErrorMessage *string `json:"error_message,omitempty"`
+}
+
+type jsonResult struct {
+	Pages       json.RawMessage `json:"pages"`
+	JobMetadata json.RawMessage `json:"job_metadata"`
+}
+
+type markdownResult struct {
+	Markdown    string          `json:"markdown"`
+	JobMetadata json.RawMessage `json:"job_metadata"`
+}
+
+type resultPage struct {
+	Page                *int            `json:"page"`
+	Text                *string         `json:"text,omitempty"`
+	Markdown            *string         `json:"md,omitempty"`
+	Images              []resultImage   `json:"images"`
+	Charts              json.RawMessage `json:"charts"`
+	Tables              json.RawMessage `json:"tables"`
+	Layout              json.RawMessage `json:"layout"`
+	Items               json.RawMessage `json:"items"`
+	Status              *string         `json:"status,omitempty"`
+	Links               json.RawMessage `json:"links"`
+	Width               *float64        `json:"width,omitempty"`
+	Height              *float64        `json:"height,omitempty"`
+	TriggeredAutoMode   *bool           `json:"triggeredAutoMode,omitempty"`
+	ParsingMode         string          `json:"parsingMode"`
+	StructuredData      json.RawMessage `json:"structuredData,omitempty"`
+	NoStructuredContent bool            `json:"noStructuredContent"`
+	NoTextContent       *bool           `json:"noTextContent"`
+	IsAudioTranscript   bool            `json:"isAudioTranscript,omitempty"`
+	DurationInSeconds   *float64        `json:"durationInSeconds,omitempty"`
+	SlideSpeakerNotes   *string         `json:"slideSpeakerNotes,omitempty"`
+	Confidence          *float64        `json:"confidence,omitempty"`
+	PrintedPageNumber   *string         `json:"printedPageNumber,omitempty"`
+	PageHeaderMarkdown  *string         `json:"pageHeaderMarkdown,omitempty"`
+	PageFooterMarkdown  *string         `json:"pageFooterMarkdown,omitempty"`
+}
+
+type resultImage struct {
+	Name           string   `json:"name"`
+	Height         *float64 `json:"height,omitempty"`
+	Width          *float64 `json:"width,omitempty"`
+	X              *float64 `json:"x,omitempty"`
+	Y              *float64 `json:"y,omitempty"`
+	OriginalWidth  *int     `json:"original_width,omitempty"`
+	OriginalHeight *int     `json:"original_height,omitempty"`
+	Type           *string  `json:"type,omitempty"`
+}
+
+func statusPath(jobID string) string            { return "/api/v1/parsing/job/" + jobID }
+func jsonResultPath(jobID string) string        { return statusPath(jobID) + "/result/json" }
+func markdownResultPath(jobID string) string    { return statusPath(jobID) + "/result/markdown" }
+func imageResultPath(jobID, name string) string { return statusPath(jobID) + "/result/image/" + name }
+
+func defaultProfile(profile Profile) Profile {
+	if profile.MaxUploadBytes == 0 {
+		profile.MaxUploadBytes = defaultUploadBytes
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = profile.MaxUploadBytes + defaultRequestOverhead
+	}
+	if profile.MaxControlBytes == 0 {
+		profile.MaxControlBytes = defaultControlBytes
+	}
+	if profile.MaxPolls == 0 {
+		profile.MaxPolls = 600
+	}
+	if profile.PollInterval == 0 {
+		profile.PollInterval = time.Second
+	}
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = 30 * time.Second
+	}
+	if profile.MaxResultBytes == 0 {
+		profile.MaxResultBytes = defaultResultBytes
+	}
+	if profile.MaxArtifactBytes == 0 {
+		profile.MaxArtifactBytes = defaultArtifactBytes
+	}
+	if profile.MaxWallTime == 0 {
+		profile.MaxWallTime = 30 * time.Minute
+	}
+	if profile.RetainImages && profile.MaxArtifacts == 0 {
+		profile.MaxArtifacts = 1
+	}
+	return profile
+}
+
+func validateProfile(profile Profile) error {
+	if err := provider.ValidateIdentifier(profile.Model, "model"); err != nil {
+		return err
+	}
+	if err := provider.ValidateIdentifier(profile.Preset, "preset"); err != nil {
+		return err
+	}
+	if profile.MaxUploadBytes <= 0 || profile.MaxUploadBytes > maxConfiguredBytes ||
+		profile.MaxRequestBytes <= profile.MaxUploadBytes || profile.MaxRequestBytes > maxConfiguredBytes+defaultRequestOverhead ||
+		profile.MaxControlBytes <= 0 || profile.MaxControlBytes > 1<<20 ||
+		profile.MaxResultBytes <= 0 || profile.MaxResultBytes > maxConfiguredBytes ||
+		profile.MaxArtifactBytes <= 0 || profile.MaxArtifactBytes > maxConfiguredBytes ||
+		profile.MaxPolls <= 0 || profile.MaxPolls > maxConfiguredPolls ||
+		profile.PollInterval <= 0 || profile.PollInterval > time.Hour ||
+		profile.RequestTimeout <= 0 || profile.RequestTimeout > maxConfiguredDuration ||
+		profile.MaxWallTime <= 0 || profile.MaxWallTime > maxConfiguredDuration {
+		return errors.New("LlamaParse profile bounds are invalid")
+	}
+	if profile.RetainImages && profile.MaxArtifacts != 1 || !profile.RetainImages && profile.MaxArtifacts != 0 {
+		return errors.New("LlamaParse image artifact count is unrepresentable")
+	}
+	return nil
+}
+
+func validateJobID(value string) error {
+	if len(value) != 36 {
+		return errors.New("job ID is not a canonical UUID")
+	}
+	for index, char := range value {
+		if index == 8 || index == 13 || index == 18 || index == 23 {
+			if char != '-' {
+				return errors.New("job ID is not a canonical UUID")
+			}
+			continue
+		}
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return errors.New("job ID is not a canonical UUID")
+		}
+	}
+	return nil
+}
+
+func encodeResumeHandle(state resumeStateV1) string {
+	return fmt.Sprintf("lp1.%s.%d.%d", state.jobID,
+		state.submittedAt.UnixNano(), state.checkpointedAt.UnixNano())
+}
+
+func parseResumeHandle(value string) (resumeStateV1, error) {
+	if len(value) > 512 {
+		return resumeStateV1{}, errors.New("resume handle exceeds its bound")
+	}
+	parts := strings.Split(value, ".")
+	if len(parts) != 4 || parts[0] != "lp1" {
+		return resumeStateV1{}, errors.New("resume handle version is invalid")
+	}
+	if err := validateJobID(parts[1]); err != nil {
+		return resumeStateV1{}, err
+	}
+	parseTime := func(encoded string) (time.Time, error) {
+		nanoseconds, err := strconv.ParseInt(encoded, 10, 64)
+		if err != nil || nanoseconds <= 0 || strconv.FormatInt(nanoseconds, 10) != encoded {
+			return time.Time{}, errors.New("resume handle timestamp is invalid")
+		}
+		return time.Unix(0, nanoseconds).UTC(), nil
+	}
+	submittedAt, err := parseTime(parts[2])
+	if err != nil {
+		return resumeStateV1{}, err
+	}
+	checkpointedAt, err := parseTime(parts[3])
+	if err != nil || checkpointedAt.Before(submittedAt) {
+		return resumeStateV1{}, errors.New("resume handle checkpoint time is invalid")
+	}
+	return resumeStateV1{
+		jobID: parts[1], submittedAt: submittedAt, checkpointedAt: checkpointedAt,
+	}, nil
+}
+
+func validateInitialStatus(status string) error {
+	switch status {
+	case "PENDING", "SUCCESS":
+		return nil
+	case "ERROR":
+		return provider.Classified(document.RenditionErrorUnsupportedInput, "LlamaParse could not parse the input", nil)
+	case "PARTIAL_SUCCESS":
+		return provider.Malformed("LlamaParse returned partial output", nil)
+	case "CANCELLED":
+		return provider.Classified(document.RenditionErrorCanceled, "LlamaParse job was canceled", nil)
+	default:
+		return provider.Classified(document.RenditionErrorPolicyRejected, "LlamaParse submission schema changed", nil)
+	}
+}
+
+func validateArtifactName(name string) error {
+	if err := provider.ValidatePathIdentifier(name, "artifact name"); err != nil {
+		return err
+	}
+	escaped := url.PathEscape(name)
+	if escaped != name || strings.ContainsAny(name, "/\\:%") {
+		return errors.New("artifact name is not an opaque path segment")
+	}
+	return nil
+}
+
+func strictJSON(raw []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if decoder.More() {
+		return errors.New("JSON response has trailing values")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return errors.New("JSON response has trailing data")
+	}
+	return nil
+}
+
+func jsonObject(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' && json.Valid(trimmed)
+}

--- a/document/llamaparse/client.go
+++ b/document/llamaparse/client.go
@@ -174,10 +174,11 @@ func (client *Client) RenderResumable(
 		operation: operation}
 	var jobID string
 	if resume == nil {
-		jobID, err = client.submit(upload, &state)
-		if err != nil {
-			return document.RenditionResult{}, err
+		job, submitErr := client.submit(upload, &state)
+		if submitErr != nil {
+			return document.RenditionResult{}, submitErr
 		}
+		jobID = job.ID
 		checkpointedAt := time.Now().UTC()
 		handle := encodeResumeHandle(resumeStateV1{
 			jobID: jobID, authorizationFingerprint: resumeState.authorizationFingerprint,
@@ -187,6 +188,9 @@ func (client *Client) RenderResumable(
 			if err := checkpoint(document.RenditionResumeHandle{Value: handle}); err != nil {
 				return document.RenditionResult{}, err
 			}
+		}
+		if err := validateInitialStatus(job); err != nil {
+			return document.RenditionResult{}, err
 		}
 		if err := operation.Check(); err != nil {
 			return document.RenditionResult{}, provider.KnownJobError(err)
@@ -268,10 +272,10 @@ func (client *Client) validateInvocation(
 
 func (client *Client) submit(
 	upload document.AuthorizedUpload, state *operationState,
-) (string, error) {
+) (jobResponse, error) {
 	metadata := upload.Metadata()
 	if metadata.ByteLength > client.profile.MaxUploadBytes {
-		return "", provider.Classified(document.RenditionErrorPolicyRejected,
+		return jobResponse{}, provider.Classified(document.RenditionErrorPolicyRejected,
 			"LlamaParse upload exceeds profile limit", nil)
 	}
 	filename := metadata.Filename
@@ -279,12 +283,12 @@ func (client *Client) submit(
 		filename = "document.pdf"
 	}
 	if err := providerutil.ValidateMultipartFilename(filename); err != nil {
-		return "", provider.Classified(document.RenditionErrorPolicyRejected,
+		return jobResponse{}, provider.Classified(document.RenditionErrorPolicyRejected,
 			"LlamaParse upload filename contains a line break", err)
 	}
 	source, err := state.operation.ReadUpload(upload)
 	if err != nil {
-		return "", err
+		return jobResponse{}, err
 	}
 	defer clear(source)
 	body := &providerutil.MultipartUpload{
@@ -298,11 +302,11 @@ func (client *Client) submit(
 	}
 	requestBytes, err := body.EncodedLength()
 	if err != nil {
-		return "", provider.Classified(document.RenditionErrorTransient,
+		return jobResponse{}, provider.Classified(document.RenditionErrorTransient,
 			"LlamaParse request could not be built", err)
 	}
 	if requestBytes > client.profile.MaxRequestBytes {
-		return "", provider.Classified(document.RenditionErrorPolicyRejected,
+		return jobResponse{}, provider.Classified(document.RenditionErrorPolicyRejected,
 			"LlamaParse request exceeds profile limit", nil)
 	}
 	state.startedAt = time.Now().UTC()
@@ -311,19 +315,18 @@ func (client *Client) submit(
 		Upload: body, MaxResponseBytes: client.profile.MaxControlBytes,
 	})
 	if err != nil {
-		return "", err
+		return jobResponse{}, err
 	}
 	if !response.Success() {
-		return "", provider.StatusError(providerutil.StageSubmission, response.Status, response.RetryAfter, nil)
+		return jobResponse{}, provider.StatusError(
+			providerutil.StageSubmission, response.Status, response.RetryAfter, nil)
 	}
 	var job jobResponse
 	if err := strictJSON(response.Body, &job); err != nil || validateJobID(job.ID) != nil {
-		return "", provider.AmbiguousSubmission(provider.Malformed("LlamaParse submission schema changed", err))
+		return jobResponse{}, provider.AmbiguousSubmission(
+			provider.Malformed("LlamaParse submission schema changed", err))
 	}
-	if err := validateInitialStatus(job); err != nil {
-		return "", err
-	}
-	return job.ID, nil
+	return job, nil
 }
 
 func (client *Client) poll(
@@ -370,8 +373,7 @@ func (client *Client) poll(
 			return provider.Classified(document.RenditionErrorCanceled,
 				"LlamaParse job was canceled", nil)
 		default:
-			return provider.Classified(document.RenditionErrorPolicyRejected,
-				"LlamaParse status schema changed", nil)
+			return provider.AmbiguousJob(provider.Malformed("LlamaParse status schema changed", nil))
 		}
 	}
 	return provider.AmbiguousJob(provider.Classified(document.RenditionErrorCapacity,
@@ -882,7 +884,7 @@ func validateInitialStatus(job jobResponse) error {
 	case "CANCELLED":
 		return provider.Classified(document.RenditionErrorCanceled, "LlamaParse job was canceled", nil)
 	default:
-		return provider.Classified(document.RenditionErrorPolicyRejected, "LlamaParse submission schema changed", nil)
+		return provider.AmbiguousJob(provider.Malformed("LlamaParse submission schema changed", nil))
 	}
 }
 

--- a/document/llamaparse/client.go
+++ b/document/llamaparse/client.go
@@ -274,7 +274,11 @@ func (client *Client) submit(
 		return "", provider.Classified(document.RenditionErrorPolicyRejected,
 			"LlamaParse upload exceeds profile limit", nil)
 	}
-	if err := providerutil.ValidateMultipartFilename(metadata.Filename); err != nil {
+	filename := metadata.Filename
+	if filename == "" {
+		filename = "document.pdf"
+	}
+	if err := providerutil.ValidateMultipartFilename(filename); err != nil {
 		return "", provider.Classified(document.RenditionErrorPolicyRejected,
 			"LlamaParse upload filename contains a line break", err)
 	}
@@ -284,7 +288,7 @@ func (client *Client) submit(
 	}
 	defer clear(source)
 	body := &providerutil.MultipartUpload{
-		FieldName: "file", Filename: metadata.Filename, MediaType: metadata.MediaType,
+		FieldName: "file", Filename: filename, MediaType: metadata.MediaType,
 		Source: bytes.NewReader(source), Length: int64(len(source)), Fields: [][2]string{
 			{"model", client.profile.Model}, {"preset", client.profile.Preset},
 			{"page_error_tolerance", "0"}, {"save_images", strconv.FormatBool(client.profile.RetainImages)},
@@ -631,6 +635,10 @@ func (client *Client) fetchImage(
 	jobID, name string, authorization document.RenditionAuthorization,
 	budget int64, state *operationState,
 ) (document.RenditionArtifact, document.SourceEvidenceArtifactV1, error) {
+	if authorization.MaxArtifactBytes <= 0 {
+		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, provider.Classified(
+			document.RenditionErrorPolicyRejected, "LlamaParse image artifact byte limit is invalid", nil)
+	}
 	if budget <= 0 {
 		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, provider.Malformed(
 			"LlamaParse result exhausted the authorized byte budget", nil)

--- a/document/llamaparse/client.go
+++ b/document/llamaparse/client.go
@@ -11,7 +11,6 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -174,7 +173,7 @@ func (client *Client) RenderResumable(
 		operation: operation}
 	var jobID string
 	if resume == nil {
-		job, submitErr := client.submit(upload, &state)
+		job, submitErr := client.submit(upload, authorization, &state)
 		if submitErr != nil {
 			return document.RenditionResult{}, submitErr
 		}
@@ -271,7 +270,7 @@ func (client *Client) validateInvocation(
 }
 
 func (client *Client) submit(
-	upload document.AuthorizedUpload, state *operationState,
+	upload document.AuthorizedUpload, authorization document.RenditionAuthorization, state *operationState,
 ) (jobResponse, error) {
 	metadata := upload.Metadata()
 	if metadata.ByteLength > client.profile.MaxUploadBytes {
@@ -291,12 +290,13 @@ func (client *Client) submit(
 		return jobResponse{}, err
 	}
 	defer clear(source)
+	retainImages := client.retainsImages(authorization)
 	body := &providerutil.MultipartUpload{
 		FieldName: "file", Filename: filename, MediaType: metadata.MediaType,
 		Source: bytes.NewReader(source), Length: int64(len(source)), Fields: [][2]string{
 			{"model", client.profile.Model}, {"preset", client.profile.Preset},
-			{"page_error_tolerance", "0"}, {"save_images", strconv.FormatBool(client.profile.RetainImages)},
-			{"disable_image_extraction", strconv.FormatBool(!client.profile.RetainImages)},
+			{"page_error_tolerance", "0"}, {"save_images", strconv.FormatBool(retainImages)},
+			{"disable_image_extraction", strconv.FormatBool(!retainImages)},
 			{"take_screenshot", "false"},
 		},
 	}
@@ -589,20 +589,24 @@ func (client *Client) pageEvidence(
 		evidence.Units = append(evidence.Units, unit)
 		markdown = append(markdown, text)
 		for _, image := range page.Images {
-			if !client.profile.RetainImages || imageName != "" || validateArtifactName(image.Name) != nil {
+			if !client.retainsImages(authorization) {
+				continue
+			}
+			if imageName != "" || validateArtifactName(image.Name) != nil {
 				return document.SourceEvidenceV1{}, nil, "", errors.New("provider images are unrepresentable")
 			}
 			imageName = image.Name
 		}
 	}
-	if imageName != "" && (client.profile.MaxArtifacts != 1 || authorization.MaxArtifacts < 1 ||
-		!slices.Contains(authorization.AllowedArtifactRoles, document.EvidenceArtifactImage)) {
-		return document.SourceEvidenceV1{}, nil, "", errors.New("provider image is not authorized")
-	}
 	if err := document.ValidateSourceEvidenceV1(evidence); err != nil {
 		return document.SourceEvidenceV1{}, nil, "", err
 	}
 	return evidence, []byte(strings.Join(markdown, markdownPageSeparator)), imageName, nil
+}
+
+func (client *Client) retainsImages(authorization document.RenditionAuthorization) bool {
+	return client.profile.RetainImages &&
+		providerutil.AllowsArtifact(authorization, document.EvidenceArtifactImage)
 }
 
 func (client *Client) validateJobMetadata(raw json.RawMessage) (int, error) {

--- a/document/llamaparse/client.go
+++ b/document/llamaparse/client.go
@@ -323,10 +323,11 @@ func (client *Client) poll(
 			if operationErr := state.operation.Check(); operationErr != nil {
 				return provider.KnownJobError(operationErr)
 			}
-			return err
+			return provider.KnownJobError(err)
 		}
 		if !response.Success() {
-			return provider.StatusError(providerutil.StageJob, response.Status, response.RetryAfter, nil)
+			return provider.KnownJobError(
+				provider.StatusError(providerutil.StageJob, response.Status, response.RetryAfter, nil))
 		}
 		var job jobResponse
 		if err := strictJSON(response.Body, &job); err != nil || job.ID != jobID {
@@ -372,11 +373,11 @@ func (client *Client) result(
 		MaxResponseBytes: budget,
 	})
 	if err != nil {
-		return document.RenditionResult{}, err
+		return document.RenditionResult{}, provider.KnownJobError(err)
 	}
 	if !response.Success() {
-		return document.RenditionResult{}, provider.StatusError(
-			providerutil.StageJob, response.Status, response.RetryAfter, nil)
+		return document.RenditionResult{}, provider.KnownJobError(provider.StatusError(
+			providerutil.StageJob, response.Status, response.RetryAfter, nil))
 	}
 	budget -= int64(len(response.Body))
 	var envelope jsonResult
@@ -428,7 +429,13 @@ func (client *Client) result(
 		return document.RenditionResult{}, provider.Malformed(
 			"LlamaParse page output is incomplete", err)
 	}
-	if len(markdown) > authorization.MaxProviderMarkdownBytes {
+	if providerutil.InjectsDocbankFrontmatter(markdown) {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse provider Markdown attempts Docbank frontmatter injection", nil)
+	}
+	if authorization.MaxProviderMarkdownBytes == 0 {
+		markdown = nil
+	} else if len(markdown) > authorization.MaxProviderMarkdownBytes {
 		return document.RenditionResult{}, provider.Malformed(
 			"LlamaParse Markdown exceeds authorization", nil)
 	}
@@ -457,11 +464,11 @@ func (client *Client) markdownFallback(
 		MaxResponseBytes: budget,
 	})
 	if err != nil {
-		return document.RenditionResult{}, err
+		return document.RenditionResult{}, provider.KnownJobError(err)
 	}
 	if !response.Success() {
-		return document.RenditionResult{}, provider.StatusError(
-			providerutil.StageJob, response.Status, response.RetryAfter, nil)
+		return document.RenditionResult{}, provider.KnownJobError(provider.StatusError(
+			providerutil.StageJob, response.Status, response.RetryAfter, nil))
 	}
 	var envelope markdownResult
 	parseErr := strictJSON(response.Body, &envelope)
@@ -490,7 +497,13 @@ func (client *Client) markdownFallback(
 			"LlamaParse result page counts disagree", nil)
 	}
 	markdown := []byte(envelope.Markdown)
-	if len(markdown) > authorization.MaxProviderMarkdownBytes {
+	if providerutil.InjectsDocbankFrontmatter(markdown) {
+		return document.RenditionResult{}, provider.Malformed(
+			"LlamaParse provider Markdown attempts Docbank frontmatter injection", nil)
+	}
+	if authorization.MaxProviderMarkdownBytes == 0 {
+		markdown = nil
+	} else if len(markdown) > authorization.MaxProviderMarkdownBytes {
 		return document.RenditionResult{}, provider.Malformed(
 			"LlamaParse Markdown exceeds authorization", nil)
 	}
@@ -520,7 +533,8 @@ func (client *Client) pageEvidence(
 	markdown := make([]string, 0, len(pages))
 	imageName := ""
 	for order, page := range pages {
-		if page.Page == nil || *page.Page != order {
+		pageNumber := order + 1
+		if page.Page == nil || *page.Page != pageNumber {
 			return document.SourceEvidenceV1{}, nil, "", errors.New("page sequence is not complete")
 		}
 		if page.Status != nil && *page.Status != "" && *page.Status != "SUCCESS" {
@@ -540,10 +554,10 @@ func (client *Client) pageEvidence(
 			return document.SourceEvidenceV1{}, nil, "", errors.New("page confidence is invalid")
 		}
 		unit := document.SourceEvidenceUnitV1{
-			Order: order, ProviderID: fmt.Sprintf("llamaparse-page-%d", order), Text: text,
+			Order: order, ProviderID: fmt.Sprintf("llamaparse-page-%d", pageNumber), Text: text,
 			Locator: document.SourceEvidenceLocatorV1{
-				Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginZero,
-				Start: int64(order), End: int64(order),
+				Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginOne,
+				Start: int64(pageNumber), End: int64(pageNumber),
 			},
 		}
 		if page.Confidence != nil {
@@ -610,11 +624,12 @@ func (client *Client) fetchImage(
 		MaxResponseBytes: limit, ResponseMediaType: "image/*",
 	})
 	if err != nil {
-		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, err
+		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, provider.KnownJobError(err)
 	}
 	if !response.Success() {
 		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{},
-			provider.StatusError(providerutil.StageJob, response.Status, response.RetryAfter, nil)
+			provider.KnownJobError(
+				provider.StatusError(providerutil.StageJob, response.Status, response.RetryAfter, nil))
 	}
 	canonical, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
 	if err != nil || (canonical != "image/png" && canonical != "image/jpeg" && canonical != "image/webp") {

--- a/document/llamaparse/client.go
+++ b/document/llamaparse/client.go
@@ -183,7 +183,8 @@ func (client *Client) RenderResumable(
 			return document.RenditionResult{}, err
 		}
 		handle := encodeResumeHandle(resumeStateV1{
-			jobID: jobID, submittedAt: state.startedAt, checkpointedAt: checkpointedAt,
+			jobID: jobID, authorizationFingerprint: resumeState.authorizationFingerprint,
+			submittedAt: state.startedAt, checkpointedAt: checkpointedAt,
 		})
 		if checkpoint != nil {
 			if err := checkpoint(document.RenditionResumeHandle{Value: handle}); err != nil {
@@ -229,6 +230,11 @@ func (client *Client) validateInvocation(
 		return resumeStateV1{}, provider.Classified(document.RenditionErrorPolicyRejected,
 			"LlamaParse authorization expiry is invalid", err)
 	}
+	authorizationFingerprint, err := authorization.Fingerprint()
+	if err != nil {
+		return resumeStateV1{}, provider.Classified(document.RenditionErrorPolicyRejected,
+			"LlamaParse authorization fingerprint is invalid", err)
+	}
 	if resume == nil {
 		if providerutil.IsNil(upload) {
 			return resumeStateV1{}, errors.New("LlamaParse authorized upload is required for submission")
@@ -242,7 +248,8 @@ func (client *Client) validateInvocation(
 			return resumeStateV1{}, provider.Classified(document.RenditionErrorUnknownJob,
 				"LlamaParse resume handle is invalid", parseErr)
 		}
-		if authorization.ProviderID != client.descriptor.ID ||
+		if parsed.authorizationFingerprint != authorizationFingerprint ||
+			authorization.ProviderID != client.descriptor.ID ||
 			authorization.DescriptorFingerprint != client.descriptor.Fingerprint ||
 			authorization.PolicyFingerprint != client.descriptor.PolicyFingerprint {
 			return resumeStateV1{}, provider.Classified(document.RenditionErrorPolicyRejected,
@@ -256,7 +263,7 @@ func (client *Client) validateInvocation(
 		}
 		return parsed, nil
 	}
-	return resumeStateV1{}, nil
+	return resumeStateV1{authorizationFingerprint: authorizationFingerprint}, nil
 }
 
 func (client *Client) submit(
@@ -266,6 +273,10 @@ func (client *Client) submit(
 	if metadata.ByteLength > client.profile.MaxUploadBytes {
 		return "", provider.Classified(document.RenditionErrorPolicyRejected,
 			"LlamaParse upload exceeds profile limit", nil)
+	}
+	if err := providerutil.ValidateMultipartFilename(metadata.Filename); err != nil {
+		return "", provider.Classified(document.RenditionErrorPolicyRejected,
+			"LlamaParse upload filename contains a line break", err)
 	}
 	source, err := state.operation.ReadUpload(upload)
 	if err != nil {
@@ -305,7 +316,7 @@ func (client *Client) submit(
 	if err := strictJSON(response.Body, &job); err != nil || validateJobID(job.ID) != nil {
 		return "", provider.AmbiguousSubmission(provider.Malformed("LlamaParse submission schema changed", err))
 	}
-	if err := validateInitialStatus(job.Status); err != nil {
+	if err := validateInitialStatus(job); err != nil {
 		return "", err
 	}
 	return job.ID, nil
@@ -347,8 +358,7 @@ func (client *Client) poll(
 			}
 			state.pollDelay += client.profile.PollInterval
 		case "ERROR":
-			return provider.Classified(document.RenditionErrorUnsupportedInput,
-				"LlamaParse could not parse the input", nil)
+			return jobError(job)
 		case "PARTIAL_SUCCESS":
 			return provider.Malformed(
 				"LlamaParse returned partial output", nil)
@@ -414,6 +424,10 @@ func (client *Client) result(
 		if jobPages != 0 {
 			return document.RenditionResult{}, provider.Malformed(
 				"LlamaParse page output is incomplete", nil)
+		}
+		if budget <= 0 {
+			return document.RenditionResult{}, provider.Malformed(
+				"LlamaParse result exhausted the authorized byte budget", nil)
 		}
 		return client.markdownFallback(jobID, authorization, jobPages, budget, state)
 	}
@@ -617,6 +631,10 @@ func (client *Client) fetchImage(
 	jobID, name string, authorization document.RenditionAuthorization,
 	budget int64, state *operationState,
 ) (document.RenditionArtifact, document.SourceEvidenceArtifactV1, error) {
+	if budget <= 0 {
+		return document.RenditionArtifact{}, document.SourceEvidenceArtifactV1{}, provider.Malformed(
+			"LlamaParse result exhausted the authorized byte budget", nil)
+	}
 	limit := min(client.profile.MaxArtifactBytes, int64(authorization.MaxArtifactBytes))
 	limit = min(limit, budget)
 	response, err := client.executor.Do(state.operation, &state.usage, providerutil.Request{
@@ -666,9 +684,10 @@ type operationState struct {
 }
 
 type resumeStateV1 struct {
-	jobID          string
-	submittedAt    time.Time
-	checkpointedAt time.Time
+	jobID                    string
+	authorizationFingerprint string
+	submittedAt              time.Time
+	checkpointedAt           time.Time
 }
 
 type jobResponse struct {
@@ -808,7 +827,7 @@ func validateJobID(value string) error {
 }
 
 func encodeResumeHandle(state resumeStateV1) string {
-	return fmt.Sprintf("lp1.%s.%d.%d", state.jobID,
+	return fmt.Sprintf("lp2.%s.%s.%d.%d", state.jobID, state.authorizationFingerprint,
 		state.submittedAt.UnixNano(), state.checkpointedAt.UnixNano())
 }
 
@@ -817,7 +836,7 @@ func parseResumeHandle(value string) (resumeStateV1, error) {
 		return resumeStateV1{}, errors.New("resume handle exceeds its bound")
 	}
 	parts := strings.Split(value, ".")
-	if len(parts) != 4 || parts[0] != "lp1" {
+	if len(parts) != 5 || parts[0] != "lp2" {
 		return resumeStateV1{}, errors.New("resume handle version is invalid")
 	}
 	if err := validateJobID(parts[1]); err != nil {
@@ -830,31 +849,51 @@ func parseResumeHandle(value string) (resumeStateV1, error) {
 		}
 		return time.Unix(0, nanoseconds).UTC(), nil
 	}
-	submittedAt, err := parseTime(parts[2])
+	submittedAt, err := parseTime(parts[3])
 	if err != nil {
 		return resumeStateV1{}, err
 	}
-	checkpointedAt, err := parseTime(parts[3])
+	checkpointedAt, err := parseTime(parts[4])
 	if err != nil || checkpointedAt.Before(submittedAt) {
 		return resumeStateV1{}, errors.New("resume handle checkpoint time is invalid")
 	}
 	return resumeStateV1{
-		jobID: parts[1], submittedAt: submittedAt, checkpointedAt: checkpointedAt,
+		jobID: parts[1], authorizationFingerprint: parts[2],
+		submittedAt: submittedAt, checkpointedAt: checkpointedAt,
 	}, nil
 }
 
-func validateInitialStatus(status string) error {
-	switch status {
+func validateInitialStatus(job jobResponse) error {
+	switch job.Status {
 	case "PENDING", "SUCCESS":
 		return nil
 	case "ERROR":
-		return provider.Classified(document.RenditionErrorUnsupportedInput, "LlamaParse could not parse the input", nil)
+		return jobError(job)
 	case "PARTIAL_SUCCESS":
 		return provider.Malformed("LlamaParse returned partial output", nil)
 	case "CANCELLED":
 		return provider.Classified(document.RenditionErrorCanceled, "LlamaParse job was canceled", nil)
 	default:
 		return provider.Classified(document.RenditionErrorPolicyRejected, "LlamaParse submission schema changed", nil)
+	}
+}
+
+func jobError(job jobResponse) error {
+	if job.ErrorCode == nil {
+		return provider.Malformed("LlamaParse failed without a recognized error code", nil)
+	}
+	switch *job.ErrorCode {
+	case "UNSUPPORTED_FILE_TYPE":
+		return provider.Classified(document.RenditionErrorUnsupportedInput,
+			"LlamaParse does not support the submitted input", nil)
+	case "DOCUMENT_TOO_LARGE":
+		return provider.Classified(document.RenditionErrorPolicyRejected,
+			"LlamaParse document exceeds the provider limit", nil)
+	case "ERROR_DURING_PROCESSING", "RECONSTRUCTION_ERROR", "MARKDOWN_EXTRACTION_FAILED":
+		return provider.Classified(document.RenditionErrorTransient,
+			"LlamaParse processing failed temporarily", nil)
+	default:
+		return provider.Malformed("LlamaParse returned an unknown job error code", nil)
 	}
 }
 

--- a/document/llamaparse/client.go
+++ b/document/llamaparse/client.go
@@ -179,9 +179,6 @@ func (client *Client) RenderResumable(
 			return document.RenditionResult{}, err
 		}
 		checkpointedAt := time.Now().UTC()
-		if err := operation.Check(); err != nil {
-			return document.RenditionResult{}, err
-		}
 		handle := encodeResumeHandle(resumeStateV1{
 			jobID: jobID, authorizationFingerprint: resumeState.authorizationFingerprint,
 			submittedAt: state.startedAt, checkpointedAt: checkpointedAt,
@@ -190,6 +187,9 @@ func (client *Client) RenderResumable(
 			if err := checkpoint(document.RenditionResumeHandle{Value: handle}); err != nil {
 				return document.RenditionResult{}, err
 			}
+		}
+		if err := operation.Check(); err != nil {
+			return document.RenditionResult{}, provider.KnownJobError(err)
 		}
 	} else {
 		jobID = resumeState.jobID
@@ -898,8 +898,7 @@ func jobError(job jobResponse) error {
 		return provider.Classified(document.RenditionErrorPolicyRejected,
 			"LlamaParse document exceeds the provider limit", nil)
 	case "ERROR_DURING_PROCESSING", "RECONSTRUCTION_ERROR", "MARKDOWN_EXTRACTION_FAILED":
-		return provider.Classified(document.RenditionErrorTransient,
-			"LlamaParse processing failed temporarily", nil)
+		return provider.Malformed("LlamaParse processing failed terminally", nil)
 	default:
 		return provider.Malformed("LlamaParse returned an unknown job error code", nil)
 	}

--- a/document/llamaparse/client_test.go
+++ b/document/llamaparse/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -97,10 +98,13 @@ func TestClientUploadsExactAuthorizedBytesAndMapsNaturalPages(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	assert.True(t, strings.HasPrefix(checkpoint.Value, "lp1."+testJobID+"."))
+	assert.True(t, strings.HasPrefix(checkpoint.Value, "lp2."+testJobID+"."))
 	handleParts := strings.Split(checkpoint.Value, ".")
-	require.Len(t, handleParts, 4)
-	checkpointNanos, err := strconv.ParseInt(handleParts[3], 10, 64)
+	require.Len(t, handleParts, 5)
+	authorizationFingerprint, err := fixture.authorization.Fingerprint()
+	require.NoError(t, err)
+	assert.Equal(t, authorizationFingerprint, handleParts[2])
+	checkpointNanos, err := strconv.ParseInt(handleParts[4], 10, 64)
 	require.NoError(t, err)
 	completedAt, err := time.Parse(timeForm, result.Receipt.CompletedAt)
 	require.NoError(t, err)
@@ -145,7 +149,8 @@ func TestClientResumesWithoutUploadingSource(t *testing.T) {
 	client := fixture.client(t, transport)
 	now := time.Now().UTC()
 	result, err := client.RenderResumable(t.Context(), nil, fixture.authorization,
-		&document.RenditionResumeHandle{Value: testResumeHandle(now.Add(-time.Second), now)}, nil)
+		&document.RenditionResumeHandle{Value: testResumeHandle(
+			t, fixture.authorization, now.Add(-time.Second), now)}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{statusPath(testJobID), jsonResultPath(testJobID)}, paths)
 	assert.Equal(t, "Resumed", result.Evidence.Units[0].Text)
@@ -159,35 +164,42 @@ func TestClientRejectsInvalidResumeFactsWithoutEgress(t *testing.T) {
 	require.NoError(t, err)
 	validSubmittedAt := authorizedAt.Add(time.Nanosecond)
 	validCheckpointedAt := validSubmittedAt.Add(time.Nanosecond)
+	authorizationFingerprint, err := fixture.authorization.Fingerprint()
+	require.NoError(t, err)
 	tests := []struct {
 		name   string
 		handle string
 		want   document.RenditionErrorCode
 	}{
 		{
-			name:   "submitted before authorization",
-			handle: testResumeHandle(authorizedAt.Add(-time.Nanosecond), validCheckpointedAt),
-			want:   document.RenditionErrorPolicyRejected,
+			name: "submitted before authorization",
+			handle: testResumeHandle(t, fixture.authorization,
+				authorizedAt.Add(-time.Nanosecond), validCheckpointedAt),
+			want: document.RenditionErrorPolicyRejected,
 		},
 		{
-			name:   "checkpoint after expiry",
-			handle: testResumeHandle(validSubmittedAt, expiresAt.Add(time.Nanosecond)),
-			want:   document.RenditionErrorPolicyRejected,
+			name: "checkpoint after expiry",
+			handle: testResumeHandle(t, fixture.authorization,
+				validSubmittedAt, expiresAt.Add(time.Nanosecond)),
+			want: document.RenditionErrorPolicyRejected,
 		},
 		{
-			name:   "noncanonical timestamp",
-			handle: fmt.Sprintf("lp1.%s.0%d.%d", testJobID, validSubmittedAt.UnixNano(), validCheckpointedAt.UnixNano()),
-			want:   document.RenditionErrorUnknownJob,
+			name: "noncanonical timestamp",
+			handle: fmt.Sprintf("lp2.%s.%s.0%d.%d", testJobID, authorizationFingerprint,
+				validSubmittedAt.UnixNano(), validCheckpointedAt.UnixNano()),
+			want: document.RenditionErrorUnknownJob,
 		},
 		{
-			name:   "unparseable timestamp",
-			handle: fmt.Sprintf("lp1.%s.not-a-time.%d", testJobID, validCheckpointedAt.UnixNano()),
-			want:   document.RenditionErrorUnknownJob,
+			name: "unparseable timestamp",
+			handle: fmt.Sprintf("lp2.%s.%s.not-a-time.%d", testJobID,
+				authorizationFingerprint, validCheckpointedAt.UnixNano()),
+			want: document.RenditionErrorUnknownJob,
 		},
 		{
-			name:   "wrong version",
-			handle: strings.Replace(testResumeHandle(validSubmittedAt, validCheckpointedAt), "lp1.", "lp2.", 1),
-			want:   document.RenditionErrorUnknownJob,
+			name: "wrong version",
+			handle: strings.Replace(testResumeHandle(t, fixture.authorization,
+				validSubmittedAt, validCheckpointedAt), "lp2.", "lp3.", 1),
+			want: document.RenditionErrorUnknownJob,
 		},
 		{name: "legacy bare job ID", handle: testJobID, want: document.RenditionErrorUnknownJob},
 	}
@@ -202,6 +214,64 @@ func TestClientRejectsInvalidResumeFactsWithoutEgress(t *testing.T) {
 				&document.RenditionResumeHandle{Value: testCase.handle}, nil)
 
 			assertCode(t, err, testCase.want)
+			assert.Zero(t, fixture.secrets.calls())
+		})
+	}
+}
+
+func TestClientRejectsResumeHandleFromDifferentAuthorizationWithoutEgress(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nbound resume\n%%EOF\n"))
+	now := time.Now().UTC()
+	handle := testResumeHandle(t, fixture.authorization, now.Add(-time.Second), now)
+	tests := []struct {
+		name   string
+		mutate func(*document.RenditionAuthorization)
+	}{
+		{
+			name: "source",
+			mutate: func(authorization *document.RenditionAuthorization) {
+				authorization.SourceSHA256 = strings.Repeat("9", 64)
+			},
+		},
+		{
+			name: "request",
+			mutate: func(authorization *document.RenditionAuthorization) {
+				authorization.RenditionRequestFingerprint = strings.Repeat("8", 64)
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			authorization := fixture.authorization
+			testCase.mutate(&authorization)
+			client := fixture.client(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("mismatched resume authority reached egress")
+				return nil, errors.New("unexpected egress")
+			}))
+
+			_, err := client.RenderResumable(t.Context(), nil, authorization,
+				&document.RenditionResumeHandle{Value: handle}, nil)
+
+			assertCode(t, err, document.RenditionErrorPolicyRejected)
+			assert.Zero(t, fixture.secrets.calls())
+		})
+	}
+}
+
+func TestClientRejectsMultipartFilenameNewlinesBeforeSubmission(t *testing.T) {
+	for _, filename := range []string{"report\r.pdf", "report\n.pdf"} {
+		t.Run(strconv.Quote(filename), func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\nfilename\n%%EOF\n"))
+			fixture.metadata.Filename = filename
+			client := fixture.client(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("unsafe filename reached egress")
+				return nil, errors.New("unexpected egress")
+			}))
+
+			_, err := document.RenderRenditionWithResume(t.Context(), client, fixture.upload(),
+				fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+
+			assertCode(t, err, document.RenditionErrorPolicyRejected)
 			assert.Zero(t, fixture.secrets.calls())
 		})
 	}
@@ -441,6 +511,46 @@ func TestClientClassifiesHostedFailuresWithoutLeakingProviderBodies(t *testing.T
 	}
 }
 
+func TestClientClassifiesProviderJobErrorsByCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code *string
+		want document.RenditionErrorCode
+	}{
+		{name: "unsupported file", code: new("UNSUPPORTED_FILE_TYPE"), want: document.RenditionErrorUnsupportedInput},
+		{name: "document too large", code: new("DOCUMENT_TOO_LARGE"), want: document.RenditionErrorPolicyRejected},
+		{name: "processing failure", code: new("ERROR_DURING_PROCESSING"), want: document.RenditionErrorTransient},
+		{name: "reconstruction failure", code: new("RECONSTRUCTION_ERROR"), want: document.RenditionErrorTransient},
+		{name: "Markdown failure", code: new("MARKDOWN_EXTRACTION_FAILED"), want: document.RenditionErrorTransient},
+		{name: "unknown code", code: new("NEW_PROVIDER_ERROR"), want: document.RenditionErrorMalformedEvidence},
+		{name: "missing code", want: document.RenditionErrorMalformedEvidence},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\njob error\n%%EOF\n"))
+			status := map[string]any{
+				"id": testJobID, "status": "ERROR", "error_message": "private provider detail",
+			}
+			if testCase.code != nil {
+				status["error_code"] = *testCase.code
+			}
+			statusBody, err := json.Marshal(status)
+			require.NoError(t, err)
+			transport := routeTransport(t, map[string]routeResponse{
+				uploadPath:            {body: `{"id":"` + testJobID + `","status":"PENDING"}`},
+				statusPath(testJobID): {body: string(statusBody)},
+			})
+
+			_, err = document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+				fixture.upload(), fixture.authorization, nil,
+				func(document.RenditionResumeHandle) error { return nil })
+
+			assertCode(t, err, testCase.want)
+			assert.NotContains(t, err.Error(), "private provider detail")
+		})
+	}
+}
+
 func TestClientClassifiesAmbiguousSubmissionAndUnknownJobs(t *testing.T) {
 	fixture := newFixture(t, []byte("%PDF-1.7\nambiguous\n%%EOF\n"))
 	client := fixture.client(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
@@ -457,7 +567,8 @@ func TestClientClassifiesAmbiguousSubmissionAndUnknownJobs(t *testing.T) {
 		}))
 		now := time.Now().UTC()
 		_, err = client.RenderResumable(t.Context(), nil, fixture.authorization,
-			&document.RenditionResumeHandle{Value: testResumeHandle(now.Add(-time.Second), now)}, nil)
+			&document.RenditionResumeHandle{Value: testResumeHandle(
+				t, fixture.authorization, now.Add(-time.Second), now)}, nil)
 		assertCode(t, err, document.RenditionErrorUnknownJob)
 	}
 }
@@ -730,6 +841,67 @@ func TestClientEnforcesUploadPollResultAndArtifactBounds(t *testing.T) {
 			func(document.RenditionResumeHandle) error { return nil })
 		assertCode(t, err, document.RenditionErrorMalformedEvidence)
 	})
+
+	t.Run("fallback after exact result budget", func(t *testing.T) {
+		const resultBody = `{"pages":[],"job_metadata":{"job_pages":0}}`
+		fixture := newFixture(t, []byte("%PDF-1.7\nno fallback budget\n%%EOF\n"))
+		fixture.authorization.MaxProviderMarkdownBytes = 0
+		fixture.authorization.MaxTotalResultBytes = len(resultBody)
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Path {
+			case uploadPath, statusPath(testJobID):
+				return response(request, http.StatusOK,
+					`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+			case jsonResultPath(testJobID):
+				return response(request, http.StatusOK, resultBody), nil
+			case markdownResultPath(testJobID):
+				t.Fatal("exhausted result budget reached fallback egress")
+				return nil, errors.New("unexpected egress")
+			default:
+				t.Fatalf("unexpected route %s", request.URL.Path)
+				return nil, errors.New("unexpected egress")
+			}
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+
+		assertCode(t, err, document.RenditionErrorMalformedEvidence)
+	})
+
+	t.Run("image after exact result budget", func(t *testing.T) {
+		const resultBody = `{"pages":[{"page":1,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`
+		fixture := newFixture(t, []byte("%PDF-1.7\nno image budget\n%%EOF\n"))
+		fixture.profile.RetainImages = true
+		fixture.profile.MaxArtifacts = 1
+		fixture.authorization.MaxProviderMarkdownBytes = 0
+		fixture.authorization.AllowedArtifactRoles = []document.EvidenceArtifactRole{document.EvidenceArtifactImage}
+		fixture.authorization.MaxArtifacts = 1
+		fixture.authorization.MaxArtifactBytes = 128
+		fixture.authorization.MaxTotalResultBytes = len(resultBody)
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Path {
+			case uploadPath, statusPath(testJobID):
+				return response(request, http.StatusOK,
+					`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+			case jsonResultPath(testJobID):
+				return response(request, http.StatusOK, resultBody), nil
+			case imageResultPath(testJobID, "figure-1.png"):
+				t.Fatal("exhausted result budget reached image egress")
+				return nil, errors.New("unexpected egress")
+			default:
+				t.Fatalf("unexpected route %s", request.URL.Path)
+				return nil, errors.New("unexpected egress")
+			}
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+
+		assertCode(t, err, document.RenditionErrorMalformedEvidence)
+	})
 }
 
 func TestClientClassifiesExactUploadReadLifecycle(t *testing.T) {
@@ -842,7 +1014,8 @@ func TestClientResumesHistoricalSealedAuthorizationWithRecordedReceiptTimes(t *t
 	require.NoError(t, err)
 
 	result, err := document.ResumeRendition(t.Context(), client, snapshot,
-		document.RenditionResumeHandle{Value: testResumeHandle(submittedAt, checkpointedAt)}, nil)
+		document.RenditionResumeHandle{Value: testResumeHandle(
+			t, fixture.authorization, submittedAt, checkpointedAt)}, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, submittedAt.Format(timeForm), result.Receipt.StartedAt)
@@ -1112,8 +1285,14 @@ func bytesResponse(request *http.Request, status int, body []byte) *http.Respons
 	}
 }
 
-func testResumeHandle(submittedAt, checkpointedAt time.Time) string {
-	return fmt.Sprintf("lp1.%s.%d.%d", testJobID, submittedAt.UnixNano(), checkpointedAt.UnixNano())
+func testResumeHandle(
+	t *testing.T, authorization document.RenditionAuthorization, submittedAt, checkpointedAt time.Time,
+) string {
+	t.Helper()
+	authorizationFingerprint, err := authorization.Fingerprint()
+	require.NoError(t, err)
+	return fmt.Sprintf("lp2.%s.%s.%d.%d", testJobID, authorizationFingerprint,
+		submittedAt.UnixNano(), checkpointedAt.UnixNano())
 }
 
 func assertCode(t *testing.T, err error, want document.RenditionErrorCode) {

--- a/document/llamaparse/client_test.go
+++ b/document/llamaparse/client_test.go
@@ -550,9 +550,9 @@ func TestClientClassifiesProviderJobErrorsByCode(t *testing.T) {
 	}{
 		{name: "unsupported file", code: new("UNSUPPORTED_FILE_TYPE"), want: document.RenditionErrorUnsupportedInput},
 		{name: "document too large", code: new("DOCUMENT_TOO_LARGE"), want: document.RenditionErrorPolicyRejected},
-		{name: "processing failure", code: new("ERROR_DURING_PROCESSING"), want: document.RenditionErrorTransient},
-		{name: "reconstruction failure", code: new("RECONSTRUCTION_ERROR"), want: document.RenditionErrorTransient},
-		{name: "Markdown failure", code: new("MARKDOWN_EXTRACTION_FAILED"), want: document.RenditionErrorTransient},
+		{name: "processing failure", code: new("ERROR_DURING_PROCESSING"), want: document.RenditionErrorMalformedEvidence},
+		{name: "reconstruction failure", code: new("RECONSTRUCTION_ERROR"), want: document.RenditionErrorMalformedEvidence},
+		{name: "Markdown failure", code: new("MARKDOWN_EXTRACTION_FAILED"), want: document.RenditionErrorMalformedEvidence},
 		{name: "unknown code", code: new("NEW_PROVIDER_ERROR"), want: document.RenditionErrorMalformedEvidence},
 		{name: "missing code", want: document.RenditionErrorMalformedEvidence},
 	}
@@ -1145,6 +1145,64 @@ func TestClientRechecksLifecycleAfterResponseBodiesAndBeforeReturn(t *testing.T)
 
 		assertCode(t, err, document.RenditionErrorCanceled)
 	})
+
+	t.Run("accepted job is checkpointed before cancellation", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\ncheckpoint before cancel\n%%EOF\n"))
+		ctx, cancel := context.WithCancel(t.Context())
+		checkpointed := false
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path != uploadPath {
+				t.Fatalf("canceled accepted job reached %s", request.URL.Path)
+			}
+			result := response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"PENDING"}`)
+			result.Body = &callbackReadCloser{
+				reader: result.Body,
+				afterClose: func() {
+					cancel()
+				},
+			}
+			return result, nil
+		})
+
+		_, err := document.RenderRenditionWithResume(ctx, fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error {
+				checkpointed = true
+				return nil
+			})
+
+		require.ErrorIs(t, err, context.Canceled)
+		assert.True(t, checkpointed)
+	})
+
+	t.Run("accepted job is checkpointed before wall timeout", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\ncheckpoint before timeout\n%%EOF\n"))
+		fixture.profile.MaxWallTime = 20 * time.Millisecond
+		checkpointed := false
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path != uploadPath {
+				t.Fatalf("timed-out accepted job reached %s", request.URL.Path)
+			}
+			result := response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"PENDING"}`)
+			result.Body = &callbackReadCloser{
+				reader: result.Body,
+				afterClose: func() {
+					<-request.Context().Done()
+				},
+			}
+			return result, nil
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error {
+				checkpointed = true
+				return nil
+			})
+
+		assertCode(t, err, document.RenditionErrorAmbiguousSubmission)
+		assert.True(t, checkpointed)
+	})
 }
 
 type fixture struct {
@@ -1229,17 +1287,26 @@ type testSecrets struct {
 }
 
 type callbackReadCloser struct {
-	reader io.Reader
-	once   sync.Once
-	before func()
+	reader     io.Reader
+	once       sync.Once
+	closeOnce  sync.Once
+	before     func()
+	afterClose func()
 }
 
 func (body *callbackReadCloser) Read(buffer []byte) (int, error) {
-	body.once.Do(body.before)
+	if body.before != nil {
+		body.once.Do(body.before)
+	}
 	return body.reader.Read(buffer)
 }
 
-func (*callbackReadCloser) Close() error { return nil }
+func (body *callbackReadCloser) Close() error {
+	if body.afterClose != nil {
+		body.closeOnce.Do(body.afterClose)
+	}
+	return nil
+}
 
 type cancelWhenCheckedContext struct {
 	context.Context

--- a/document/llamaparse/client_test.go
+++ b/document/llamaparse/client_test.go
@@ -277,6 +277,37 @@ func TestClientRejectsMultipartFilenameNewlinesBeforeSubmission(t *testing.T) {
 	}
 }
 
+func TestClientUsesSyntheticFilenameWhenDisclosureIsWithheld(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nwithheld filename\n%%EOF\n"))
+	fixture.authorization.DiscloseFilename = false
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		switch request.URL.Path {
+		case uploadPath:
+			_, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+			require.NoError(t, err)
+			part, err := multipart.NewReader(request.Body, parameters["boundary"]).NextPart()
+			require.NoError(t, err)
+			assert.Equal(t, "document.pdf", part.FileName())
+			return response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case statusPath(testJobID):
+			return response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case jsonResultPath(testJobID):
+			return response(request, http.StatusOK,
+				`{"pages":[{"page":1,"md":"Page","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+		default:
+			t.Fatalf("unexpected route %s", request.URL.Path)
+			return nil, errors.New("unexpected route")
+		}
+	})
+
+	_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+		fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+
+	require.NoError(t, err)
+}
+
 func TestClientPreservesExplicitMiddleBlankPage(t *testing.T) {
 	fixture := newFixture(t, []byte("%PDF-1.7\nblank page\n%%EOF\n"))
 	transport := routeTransport(t, map[string]routeResponse{
@@ -901,6 +932,38 @@ func TestClientEnforcesUploadPollResultAndArtifactBounds(t *testing.T) {
 			func(document.RenditionResumeHandle) error { return nil })
 
 		assertCode(t, err, document.RenditionErrorMalformedEvidence)
+	})
+
+	t.Run("image with zero artifact byte limit", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nno artifact budget\n%%EOF\n"))
+		fixture.profile.RetainImages = true
+		fixture.profile.MaxArtifacts = 1
+		fixture.authorization.MaxProviderMarkdownBytes = 0
+		fixture.authorization.AllowedArtifactRoles = []document.EvidenceArtifactRole{document.EvidenceArtifactImage}
+		fixture.authorization.MaxArtifacts = 1
+		fixture.authorization.MaxArtifactBytes = 0
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Path {
+			case uploadPath, statusPath(testJobID):
+				return response(request, http.StatusOK,
+					`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+			case jsonResultPath(testJobID):
+				return response(request, http.StatusOK,
+					`{"pages":[{"page":1,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+			case imageResultPath(testJobID, "figure-1.png"):
+				t.Fatal("zero artifact byte limit reached image egress")
+				return nil, errors.New("unexpected egress")
+			default:
+				t.Fatalf("unexpected route %s", request.URL.Path)
+				return nil, errors.New("unexpected egress")
+			}
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+
+		assertCode(t, err, document.RenditionErrorPolicyRejected)
 	})
 }
 

--- a/document/llamaparse/client_test.go
+++ b/document/llamaparse/client_test.go
@@ -129,6 +129,53 @@ func TestClientUploadsExactAuthorizedBytesAndMapsNaturalPages(t *testing.T) {
 	assert.Equal(t, 4, fixture.secrets.calls())
 }
 
+func TestClientDoesNotRequestOrRetainUnauthorizedImages(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nno images authorized\n%%EOF\n"))
+	fixture.profile.RetainImages = true
+	fixture.profile.MaxArtifacts = 1
+	var transport http.RoundTripper = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		switch request.URL.Path {
+		case uploadPath:
+			_, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+			require.NoError(t, err)
+			reader := multipart.NewReader(request.Body, parameters["boundary"])
+			fields := map[string]string{}
+			for {
+				part, nextErr := reader.NextPart()
+				if errors.Is(nextErr, io.EOF) {
+					break
+				}
+				require.NoError(t, nextErr)
+				payload, readErr := io.ReadAll(part)
+				require.NoError(t, readErr)
+				if part.FormName() != "file" {
+					fields[part.FormName()] = string(payload)
+				}
+			}
+			assert.Equal(t, "false", fields["save_images"])
+			assert.Equal(t, "true", fields["disable_image_extraction"])
+			return response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case statusPath(testJobID):
+			return response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case jsonResultPath(testJobID):
+			return response(request, http.StatusOK,
+				`{"pages":[{"page":1,"md":"Page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+		default:
+			t.Fatalf("unexpected route %s", request.URL.String())
+			return nil, errors.New("unexpected route")
+		}
+	})
+
+	result, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+		fixture.upload(), fixture.authorization, nil,
+		func(document.RenditionResumeHandle) error { return nil })
+	require.NoError(t, err)
+	assert.Empty(t, result.Artifacts)
+	assert.Empty(t, result.Evidence.Artifacts)
+}
+
 func TestClientResumesWithoutUploadingSource(t *testing.T) {
 	fixture := newFixture(t, []byte("%PDF-1.7\nresume\n%%EOF\n"))
 	var paths []string
@@ -999,11 +1046,13 @@ func TestClientEnforcesUploadPollResultAndArtifactBounds(t *testing.T) {
 			}
 		})
 
-		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+		result, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
 			fixture.upload(), fixture.authorization, nil,
 			func(document.RenditionResumeHandle) error { return nil })
 
-		assertCode(t, err, document.RenditionErrorPolicyRejected)
+		require.NoError(t, err)
+		assert.Empty(t, result.Artifacts)
+		assert.Empty(t, result.Evidence.Artifacts)
 	})
 }
 

--- a/document/llamaparse/client_test.go
+++ b/document/llamaparse/client_test.go
@@ -582,6 +582,46 @@ func TestClientClassifiesProviderJobErrorsByCode(t *testing.T) {
 	}
 }
 
+func TestClientCheckpointsSubmissionBeforeInitialStatusValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want document.RenditionErrorCode
+	}{
+		{
+			name: "unknown status",
+			body: `{"id":"` + testJobID + `","status":"NEW_STATUS"}`,
+			want: document.RenditionErrorAmbiguousSubmission,
+		},
+		{
+			name: "terminal input error",
+			body: `{"id":"` + testJobID + `","status":"ERROR","error_code":"UNSUPPORTED_FILE_TYPE"}`,
+			want: document.RenditionErrorUnsupportedInput,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\ninitial status\n%%EOF\n"))
+			var checkpoint document.RenditionResumeHandle
+			transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				if request.URL.Path != uploadPath {
+					t.Fatalf("initial status reached %s", request.URL.Path)
+				}
+				return response(request, http.StatusOK, testCase.body), nil
+			})
+
+			_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+				fixture.upload(), fixture.authorization, nil, func(handle document.RenditionResumeHandle) error {
+					checkpoint = handle
+					return nil
+				})
+
+			assertCode(t, err, testCase.want)
+			assert.True(t, strings.HasPrefix(checkpoint.Value, "lp2."+testJobID+"."))
+		})
+	}
+}
+
 func TestClientClassifiesAmbiguousSubmissionAndUnknownJobs(t *testing.T) {
 	fixture := newFixture(t, []byte("%PDF-1.7\nambiguous\n%%EOF\n"))
 	client := fixture.client(t, roundTripFunc(func(*http.Request) (*http.Response, error) {

--- a/document/llamaparse/client_test.go
+++ b/document/llamaparse/client_test.go
@@ -76,8 +76,8 @@ func TestClientUploadsExactAuthorizedBytesAndMapsNaturalPages(t *testing.T) {
 		case jsonResultPath(testJobID):
 			return response(request, http.StatusOK, `{
 				"pages":[
-					{"page":0,"text":"First page","md":"# First page","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false},
-					{"page":1,"text":"Second page","md":"Second page","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}
+					{"page":1,"text":"First page","md":"# First page","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false},
+					{"page":2,"text":"Second page","md":"Second page","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}
 				],
 				"job_metadata":{"job_pages":2}
 			}`), nil
@@ -109,7 +109,9 @@ func TestClientUploadsExactAuthorizedBytesAndMapsNaturalPages(t *testing.T) {
 	assert.Equal(t, document.EvidenceComplete, result.Evidence.Completeness)
 	assert.Equal(t, document.EvidenceUnitPage, result.Evidence.UnitKind)
 	require.Len(t, result.Evidence.Units, 2)
-	assert.Equal(t, int64(0), result.Evidence.Units[0].Locator.Start)
+	assert.Equal(t, document.EvidenceIndexOriginOne, result.Evidence.Units[0].Locator.IndexOrigin)
+	assert.Equal(t, int64(1), result.Evidence.Units[0].Locator.Start)
+	assert.Equal(t, int64(2), result.Evidence.Units[1].Locator.Start)
 	assert.Equal(t, "# First page", result.Evidence.Units[0].Text)
 	assert.Equal(t, "# First page\n\n---\n\nSecond page", string(result.ProviderMarkdown))
 	assert.Equal(t, int64(1), result.Receipt.Usage.Retries)
@@ -134,7 +136,7 @@ func TestClientResumesWithoutUploadingSource(t *testing.T) {
 				`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
 		case jsonResultPath(testJobID):
 			return response(request, http.StatusOK,
-				`{"pages":[{"page":0,"text":"Resumed","md":"Resumed","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+				`{"pages":[{"page":1,"text":"Resumed","md":"Resumed","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
 		default:
 			t.Fatalf("unexpected route %s", request.URL.Path)
 			return nil, errors.New("unexpected route")
@@ -211,9 +213,9 @@ func TestClientPreservesExplicitMiddleBlankPage(t *testing.T) {
 		uploadPath:            {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
 		statusPath(testJobID): {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
 		jsonResultPath(testJobID): {body: `{"pages":[
-			{"page":0,"md":"First","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false},
-			{"page":1,"md":"","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":true,"triggeredAutoMode":false},
-			{"page":2,"md":"Third","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}
+			{"page":1,"md":"First","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false},
+			{"page":2,"md":"","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":true,"triggeredAutoMode":false},
+			{"page":3,"md":"Third","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}
 		],"job_metadata":{"job_pages":3}}`},
 	})
 
@@ -223,7 +225,7 @@ func TestClientPreservesExplicitMiddleBlankPage(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Evidence.Units, 3)
 	assert.Empty(t, result.Evidence.Units[1].Text)
-	assert.Equal(t, int64(1), result.Evidence.Units[1].Locator.Start)
+	assert.Equal(t, int64(2), result.Evidence.Units[1].Locator.Start)
 }
 
 func TestClientUsesExplicitDegradedMarkdownOnlyWithoutPageProvenance(t *testing.T) {
@@ -243,6 +245,94 @@ func TestClientUsesExplicitDegradedMarkdownOnlyWithoutPageProvenance(t *testing.
 	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
 	assert.Equal(t, document.EvidenceUnitGeneric, result.Evidence.UnitKind)
 	assert.Equal(t, []string{"degraded_provenance"}, result.Receipt.Warnings)
+}
+
+func TestClientOmitsUnauthorizedProviderMarkdown(t *testing.T) {
+	tests := []struct {
+		name   string
+		routes map[string]routeResponse
+	}{
+		{
+			name: "structured pages",
+			routes: map[string]routeResponse{
+				jsonResultPath(testJobID): {
+					body: `{"pages":[{"page":1,"md":"Evidence only","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`,
+				},
+			},
+		},
+		{
+			name: "Markdown fallback",
+			routes: map[string]routeResponse{
+				jsonResultPath(testJobID):     {body: `{"pages":[],"job_metadata":{"job_pages":0}}`},
+				markdownResultPath(testJobID): {body: `{"markdown":"Fallback evidence","job_metadata":{"job_pages":0}}`},
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\nJSON only\n%%EOF\n"))
+			fixture.authorization.MaxProviderMarkdownBytes = 0
+			testCase.routes[uploadPath] = routeResponse{
+				body: `{"id":"` + testJobID + `","status":"SUCCESS"}`,
+			}
+			testCase.routes[statusPath(testJobID)] = routeResponse{
+				body: `{"id":"` + testJobID + `","status":"SUCCESS"}`,
+			}
+
+			result, err := document.RenderRenditionWithResume(t.Context(),
+				fixture.client(t, routeTransport(t, testCase.routes)), fixture.upload(), fixture.authorization,
+				nil, func(document.RenditionResumeHandle) error { return nil })
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, result.Evidence.Units)
+			assert.Empty(t, result.ProviderMarkdown)
+		})
+	}
+}
+
+func TestClientRejectsReservedFrontmatterInProviderMarkdown(t *testing.T) {
+	const injected = `---\ncontract: docbank-sanitized-markdown/v1\n---\nprovider content`
+	tests := []struct {
+		name   string
+		routes map[string]routeResponse
+	}{
+		{
+			name: "structured pages",
+			routes: map[string]routeResponse{
+				jsonResultPath(testJobID): {
+					body: `{"pages":[{"page":1,"md":"---\ncontract: docbank-sanitized-markdown/v1\n---\nprovider content","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`,
+				},
+			},
+		},
+		{
+			name: "Markdown fallback",
+			routes: map[string]routeResponse{
+				jsonResultPath(testJobID): {body: `{"pages":[],"job_metadata":{"job_pages":0}}`},
+				markdownResultPath(testJobID): {
+					body: `{"markdown":"---\ncontract: docbank-sanitized-markdown/v1\n---\nprovider content","job_metadata":{"job_pages":0}}`,
+				},
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\nfrontmatter\n%%EOF\n"))
+			testCase.routes[uploadPath] = routeResponse{
+				body: `{"id":"` + testJobID + `","status":"SUCCESS"}`,
+			}
+			testCase.routes[statusPath(testJobID)] = routeResponse{
+				body: `{"id":"` + testJobID + `","status":"SUCCESS"}`,
+			}
+
+			_, err := document.RenderRenditionWithResume(t.Context(),
+				fixture.client(t, routeTransport(t, testCase.routes)), fixture.upload(), fixture.authorization,
+				nil, func(document.RenditionResumeHandle) error { return nil })
+
+			assertCode(t, err, document.RenditionErrorMalformedEvidence)
+			require.ErrorContains(t, errors.Unwrap(err), "frontmatter injection")
+			assert.NotContains(t, err.Error(), injected)
+		})
+	}
 }
 
 func TestClientRejectsContradictoryFallbackPageCounts(t *testing.T) {
@@ -283,13 +373,13 @@ func TestClientRejectsPartialPagesAndSchemaDrift(t *testing.T) {
 		name string
 		body string
 	}{
-		{name: "partial page status", body: `{"pages":[{"page":0,"md":"partial","status":"ERROR","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
-		{name: "page gap", body: `{"pages":[{"page":1,"md":"gap","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
-		{name: "unknown page field", body: `{"pages":[{"page":0,"md":"drift","provider_url":"https://evil.example/result","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
-		{name: "provider page count exceeds result", body: `{"pages":[{"page":0,"md":"partial","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":2}}`},
+		{name: "partial page status", body: `{"pages":[{"page":1,"md":"partial","status":"ERROR","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		{name: "page gap", body: `{"pages":[{"page":2,"md":"gap","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		{name: "unknown page field", body: `{"pages":[{"page":1,"md":"drift","provider_url":"https://evil.example/result","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		{name: "provider page count exceeds result", body: `{"pages":[{"page":1,"md":"partial","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":2}}`},
 		{name: "missing explicit page index", body: `{"pages":[{"md":"invented zero","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
-		{name: "missing provider page count", body: `{"pages":[{"page":0,"md":"unproven","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{}}`},
-		{name: "unexplained empty page", body: `{"pages":[{"page":0,"md":"","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		{name: "missing provider page count", body: `{"pages":[{"page":1,"md":"unproven","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{}}`},
+		{name: "unexplained empty page", body: `{"pages":[{"page":1,"md":"","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -313,7 +403,7 @@ func TestClientRejectsReportedModelDrift(t *testing.T) {
 	transport := routeTransport(t, map[string]routeResponse{
 		uploadPath:                {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
 		statusPath(testJobID):     {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
-		jsonResultPath(testJobID): {body: `{"pages":[{"page":0,"md":"drift","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1,"model":"parse-model-next","preset":"document-v1"}}`},
+		jsonResultPath(testJobID): {body: `{"pages":[{"page":1,"md":"drift","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1,"model":"parse-model-next","preset":"document-v1"}}`},
 	})
 	_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
 		fixture.upload(), fixture.authorization, nil,
@@ -369,6 +459,65 @@ func TestClientClassifiesAmbiguousSubmissionAndUnknownJobs(t *testing.T) {
 		_, err = client.RenderResumable(t.Context(), nil, fixture.authorization,
 			&document.RenditionResumeHandle{Value: testResumeHandle(now.Add(-time.Second), now)}, nil)
 		assertCode(t, err, document.RenditionErrorUnknownJob)
+	}
+}
+
+func TestClientTreatsRetryableKnownJobRequestFailuresAsAmbiguous(t *testing.T) {
+	tests := []struct {
+		name           string
+		failPath       string
+		transportError bool
+		fallback       bool
+		image          bool
+	}{
+		{name: "poll transport", failPath: statusPath(testJobID), transportError: true},
+		{name: "JSON result HTTP", failPath: jsonResultPath(testJobID)},
+		{name: "Markdown fallback HTTP", failPath: markdownResultPath(testJobID), fallback: true},
+		{name: "image HTTP", failPath: imageResultPath(testJobID, "figure-1.png"), image: true},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\nknown job\n%%EOF\n"))
+			if testCase.image {
+				fixture.profile.RetainImages = true
+				fixture.profile.MaxArtifacts = 1
+				fixture.authorization.AllowedArtifactRoles = []document.EvidenceArtifactRole{
+					document.EvidenceArtifactImage,
+				}
+				fixture.authorization.MaxArtifacts = 1
+				fixture.authorization.MaxArtifactBytes = 1024
+			}
+			transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				if request.URL.Path == testCase.failPath {
+					if testCase.transportError {
+						return nil, errors.New("private transport failure")
+					}
+					return response(request, http.StatusServiceUnavailable, `{"detail":"private failure"}`), nil
+				}
+				switch request.URL.Path {
+				case uploadPath, statusPath(testJobID):
+					return response(request, http.StatusOK,
+						`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+				case jsonResultPath(testJobID):
+					if testCase.fallback {
+						return response(request, http.StatusOK,
+							`{"pages":[],"job_metadata":{"job_pages":0}}`), nil
+					}
+					return response(request, http.StatusOK,
+						`{"pages":[{"page":1,"md":"Known job","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+				default:
+					t.Fatalf("unexpected route %s", request.URL.String())
+					return nil, errors.New("unexpected route")
+				}
+			})
+
+			_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+				fixture.upload(), fixture.authorization, nil,
+				func(document.RenditionResumeHandle) error { return nil })
+
+			assertCode(t, err, document.RenditionErrorAmbiguousSubmission)
+			assert.NotContains(t, err.Error(), "private")
+		})
 	}
 }
 
@@ -440,7 +589,7 @@ func TestClientPreservesCredentialFailureClassificationAcrossResultStages(t *tes
 				return response(request, http.StatusOK,
 					`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
 			case jsonResultPath(testJobID):
-				return response(request, http.StatusOK, `{"pages":[{"page":0,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+				return response(request, http.StatusOK, `{"pages":[{"page":1,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
 			default:
 				t.Fatalf("credential failure reached %s egress", request.URL.Path)
 				return nil, errors.New("unexpected egress")
@@ -471,7 +620,7 @@ func TestClientRefusesProviderAuthoredArtifactURLsAndUsesFixedImageRoute(t *test
 		case statusPath(testJobID):
 			return response(request, http.StatusOK, `{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
 		case jsonResultPath(testJobID):
-			return response(request, http.StatusOK, `{"pages":[{"page":0,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+			return response(request, http.StatusOK, `{"pages":[{"page":1,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
 		case imageResultPath(testJobID, "figure-1.png"):
 			result := bytesResponse(request, http.StatusOK, mediatest.PNG(4, 3, nil))
 			result.Header.Set("Content-Type", "image/png")
@@ -494,7 +643,7 @@ func TestClientRefusesProviderAuthoredArtifactURLsAndUsesFixedImageRoute(t *test
 		transport = routeTransport(t, map[string]routeResponse{
 			uploadPath:                {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
 			statusPath(testJobID):     {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
-			jsonResultPath(testJobID): {body: `{"pages":[{"page":0,"md":"unsafe","images":[{"name":"` + name + `"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+			jsonResultPath(testJobID): {body: `{"pages":[{"page":1,"md":"unsafe","images":[{"name":"` + name + `"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
 		})
 		_, err = document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
 			fixture.upload(), fixture.authorization, nil,
@@ -525,7 +674,7 @@ func TestClientRejectsMalformedOrMismatchedRetainedImages(t *testing.T) {
 				case uploadPath, statusPath(testJobID):
 					return response(request, http.StatusOK, `{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
 				case jsonResultPath(testJobID):
-					return response(request, http.StatusOK, `{"pages":[{"page":0,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+					return response(request, http.StatusOK, `{"pages":[{"page":1,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
 				case imageResultPath(testJobID, "figure-1.png"):
 					result := bytesResponse(request, http.StatusOK, testCase.payload)
 					result.Header.Set("Content-Type", testCase.mediaType)
@@ -673,7 +822,7 @@ func TestClientResumesHistoricalSealedAuthorizationWithRecordedReceiptTimes(t *t
 	transport := routeTransport(t, map[string]routeResponse{
 		statusPath(testJobID): {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
 		jsonResultPath(testJobID): {
-			body: `{"pages":[{"page":0,"md":"Historical","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`,
+			body: `{"pages":[{"page":1,"md":"Historical","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`,
 		},
 	})
 	client := fixture.client(t, transport)
@@ -701,7 +850,7 @@ func TestClientResumesHistoricalSealedAuthorizationWithRecordedReceiptTimes(t *t
 }
 
 func TestClientRechecksLifecycleAfterResponseBodiesAndBeforeReturn(t *testing.T) {
-	const resultBody = `{"pages":[{"page":0,"md":"Complete","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`
+	const resultBody = `{"pages":[{"page":1,"md":"Complete","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`
 
 	t.Run("caller cancellation after complete body", func(t *testing.T) {
 		fixture := newFixture(t, []byte("%PDF-1.7\nbody cancel\n%%EOF\n"))
@@ -726,7 +875,7 @@ func TestClientRechecksLifecycleAfterResponseBodiesAndBeforeReturn(t *testing.T)
 		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
 			fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
 
-		assertCode(t, err, document.RenditionErrorCapacity)
+		assertCode(t, err, document.RenditionErrorAmbiguousSubmission)
 	})
 
 	t.Run("authorization expiry after complete body", func(t *testing.T) {

--- a/document/llamaparse/client_test.go
+++ b/document/llamaparse/client_test.go
@@ -1,0 +1,976 @@
+package llamaparse
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
+	"go.kenn.io/docbank/document/media/mediatest"
+)
+
+const testJobID = "123e4567-e89b-12d3-a456-426614174000"
+
+var _ document.ResumableRenditionProvider = (*Client)(nil)
+
+func TestClientUploadsExactAuthorizedBytesAndMapsNaturalPages(t *testing.T) {
+	source := []byte("%PDF-1.7\nsynthetic exact bytes\n%%EOF\n")
+	fixture := newFixture(t, source)
+	var requests []*http.Request
+	pollCount := 0
+	var transport http.RoundTripper = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests = append(requests, request.Clone(request.Context()))
+		assert.Equal(t, "Bearer synthetic-secret", request.Header.Get("Authorization"))
+		switch request.URL.Path {
+		case uploadPath:
+			assert.Equal(t, http.MethodPost, request.Method)
+			mediaType, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+			require.NoError(t, err)
+			assert.Equal(t, "multipart/form-data", mediaType)
+			reader := multipart.NewReader(request.Body, parameters["boundary"])
+			fields := map[string]string{}
+			for {
+				part, nextErr := reader.NextPart()
+				if errors.Is(nextErr, io.EOF) {
+					break
+				}
+				require.NoError(t, nextErr)
+				payload, readErr := io.ReadAll(part)
+				require.NoError(t, readErr)
+				if part.FormName() == "file" {
+					assert.Equal(t, "synthetic.pdf", part.FileName())
+					assert.Equal(t, "application/pdf", part.Header.Get("Content-Type"))
+					assert.Equal(t, source, payload)
+				} else {
+					fields[part.FormName()] = string(payload)
+				}
+			}
+			assert.Equal(t, "parse-model-v1", fields["model"])
+			assert.Equal(t, "document-v1", fields["preset"])
+			assert.Equal(t, "0", fields["page_error_tolerance"])
+			return response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"PENDING"}`), nil
+		case statusPath(testJobID):
+			pollCount++
+			if pollCount == 1 {
+				return response(request, http.StatusOK,
+					`{"id":"`+testJobID+`","status":"PENDING"}`), nil
+			}
+			return response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case jsonResultPath(testJobID):
+			return response(request, http.StatusOK, `{
+				"pages":[
+					{"page":0,"text":"First page","md":"# First page","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false},
+					{"page":1,"text":"Second page","md":"Second page","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}
+				],
+				"job_metadata":{"job_pages":2}
+			}`), nil
+		default:
+			t.Fatalf("unexpected route %s", request.URL.String())
+			return nil, errors.New("unexpected route")
+		}
+	})
+	client := fixture.client(t, transport)
+	var checkpoint document.RenditionResumeHandle
+	result, err := document.RenderRenditionWithResume(
+		t.Context(), client, fixture.upload(), fixture.authorization, nil,
+		func(handle document.RenditionResumeHandle) error {
+			checkpoint = handle
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(checkpoint.Value, "lp1."+testJobID+"."))
+	handleParts := strings.Split(checkpoint.Value, ".")
+	require.Len(t, handleParts, 4)
+	checkpointNanos, err := strconv.ParseInt(handleParts[3], 10, 64)
+	require.NoError(t, err)
+	completedAt, err := time.Parse(timeForm, result.Receipt.CompletedAt)
+	require.NoError(t, err)
+	assert.True(t, completedAt.After(time.Unix(0, checkpointNanos)),
+		"fresh completion must follow the durable checkpoint")
+	assert.Equal(t, document.EvidenceComplete, result.Evidence.Completeness)
+	assert.Equal(t, document.EvidenceUnitPage, result.Evidence.UnitKind)
+	require.Len(t, result.Evidence.Units, 2)
+	assert.Equal(t, int64(0), result.Evidence.Units[0].Locator.Start)
+	assert.Equal(t, "# First page", result.Evidence.Units[0].Text)
+	assert.Equal(t, "# First page\n\n---\n\nSecond page", string(result.ProviderMarkdown))
+	assert.Equal(t, int64(1), result.Receipt.Usage.Retries)
+	assert.Equal(t, testJobID[:8], result.Receipt.OperationID[len("llamaparse-"):])
+	require.Len(t, requests, 4)
+	for _, request := range requests {
+		assert.Equal(t, "https", request.URL.Scheme)
+		assert.Equal(t, apiHost, request.URL.Host)
+		assert.Empty(t, request.URL.RawQuery)
+	}
+	assert.Equal(t, 4, fixture.secrets.calls())
+}
+
+func TestClientResumesWithoutUploadingSource(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nresume\n%%EOF\n"))
+	var paths []string
+	var transport http.RoundTripper = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		paths = append(paths, request.URL.Path)
+		switch request.URL.Path {
+		case statusPath(testJobID):
+			return response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case jsonResultPath(testJobID):
+			return response(request, http.StatusOK,
+				`{"pages":[{"page":0,"text":"Resumed","md":"Resumed","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+		default:
+			t.Fatalf("unexpected route %s", request.URL.Path)
+			return nil, errors.New("unexpected route")
+		}
+	})
+	client := fixture.client(t, transport)
+	now := time.Now().UTC()
+	result, err := client.RenderResumable(t.Context(), nil, fixture.authorization,
+		&document.RenditionResumeHandle{Value: testResumeHandle(now.Add(-time.Second), now)}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{statusPath(testJobID), jsonResultPath(testJobID)}, paths)
+	assert.Equal(t, "Resumed", result.Evidence.Units[0].Text)
+}
+
+func TestClientRejectsInvalidResumeFactsWithoutEgress(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\ninvalid resume\n%%EOF\n"))
+	authorizedAt, err := time.Parse(timeForm, fixture.authorization.AuthorizedAt)
+	require.NoError(t, err)
+	expiresAt, err := time.Parse(timeForm, fixture.authorization.ExpiresAt)
+	require.NoError(t, err)
+	validSubmittedAt := authorizedAt.Add(time.Nanosecond)
+	validCheckpointedAt := validSubmittedAt.Add(time.Nanosecond)
+	tests := []struct {
+		name   string
+		handle string
+		want   document.RenditionErrorCode
+	}{
+		{
+			name:   "submitted before authorization",
+			handle: testResumeHandle(authorizedAt.Add(-time.Nanosecond), validCheckpointedAt),
+			want:   document.RenditionErrorPolicyRejected,
+		},
+		{
+			name:   "checkpoint after expiry",
+			handle: testResumeHandle(validSubmittedAt, expiresAt.Add(time.Nanosecond)),
+			want:   document.RenditionErrorPolicyRejected,
+		},
+		{
+			name:   "noncanonical timestamp",
+			handle: fmt.Sprintf("lp1.%s.0%d.%d", testJobID, validSubmittedAt.UnixNano(), validCheckpointedAt.UnixNano()),
+			want:   document.RenditionErrorUnknownJob,
+		},
+		{
+			name:   "unparseable timestamp",
+			handle: fmt.Sprintf("lp1.%s.not-a-time.%d", testJobID, validCheckpointedAt.UnixNano()),
+			want:   document.RenditionErrorUnknownJob,
+		},
+		{
+			name:   "wrong version",
+			handle: strings.Replace(testResumeHandle(validSubmittedAt, validCheckpointedAt), "lp1.", "lp2.", 1),
+			want:   document.RenditionErrorUnknownJob,
+		},
+		{name: "legacy bare job ID", handle: testJobID, want: document.RenditionErrorUnknownJob},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := fixture.client(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("invalid resume handle reached egress")
+				return nil, errors.New("unexpected egress")
+			}))
+
+			_, err := client.RenderResumable(t.Context(), nil, fixture.authorization,
+				&document.RenditionResumeHandle{Value: testCase.handle}, nil)
+
+			assertCode(t, err, testCase.want)
+			assert.Zero(t, fixture.secrets.calls())
+		})
+	}
+}
+
+func TestClientPreservesExplicitMiddleBlankPage(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nblank page\n%%EOF\n"))
+	transport := routeTransport(t, map[string]routeResponse{
+		uploadPath:            {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+		statusPath(testJobID): {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+		jsonResultPath(testJobID): {body: `{"pages":[
+			{"page":0,"md":"First","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false},
+			{"page":1,"md":"","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":true,"triggeredAutoMode":false},
+			{"page":2,"md":"Third","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}
+		],"job_metadata":{"job_pages":3}}`},
+	})
+
+	result, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+		fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+
+	require.NoError(t, err)
+	require.Len(t, result.Evidence.Units, 3)
+	assert.Empty(t, result.Evidence.Units[1].Text)
+	assert.Equal(t, int64(1), result.Evidence.Units[1].Locator.Start)
+}
+
+func TestClientUsesExplicitDegradedMarkdownOnlyWithoutPageProvenance(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nfallback\n%%EOF\n"))
+	transport := routeTransport(t, map[string]routeResponse{
+		uploadPath:                {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+		statusPath(testJobID):     {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+		jsonResultPath(testJobID): {body: `{"pages":[],"job_metadata":{"job_pages":0}}`},
+		markdownResultPath(testJobID): {
+			body: `{"markdown":"# Fallback markdown","job_metadata":{"job_pages":0}}`,
+		},
+	})
+	result, err := document.RenderRenditionWithResume(
+		t.Context(), fixture.client(t, transport), fixture.upload(), fixture.authorization,
+		nil, func(document.RenditionResumeHandle) error { return nil })
+	require.NoError(t, err)
+	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+	assert.Equal(t, document.EvidenceUnitGeneric, result.Evidence.UnitKind)
+	assert.Equal(t, []string{"degraded_provenance"}, result.Receipt.Warnings)
+}
+
+func TestClientRejectsContradictoryFallbackPageCounts(t *testing.T) {
+	tests := []struct {
+		name          string
+		jsonPages     int
+		markdownPages int
+	}{
+		{name: "structured result reports missing pages", jsonPages: 2, markdownPages: 2},
+		{name: "fallback changes the reported count", jsonPages: 0, markdownPages: 1},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\ncontradictory fallback\n%%EOF\n"))
+			transport := routeTransport(t, map[string]routeResponse{
+				uploadPath:            {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+				statusPath(testJobID): {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+				jsonResultPath(testJobID): {
+					body: fmt.Sprintf(`{"pages":[],"job_metadata":{"job_pages":%d}}`, testCase.jsonPages),
+				},
+				markdownResultPath(testJobID): {
+					body: fmt.Sprintf(`{"markdown":"Fallback","job_metadata":{"job_pages":%d}}`,
+						testCase.markdownPages),
+				},
+			})
+
+			_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+				fixture.upload(), fixture.authorization, nil,
+				func(document.RenditionResumeHandle) error { return nil })
+
+			assertCode(t, err, document.RenditionErrorMalformedEvidence)
+		})
+	}
+}
+
+func TestClientRejectsPartialPagesAndSchemaDrift(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "partial page status", body: `{"pages":[{"page":0,"md":"partial","status":"ERROR","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		{name: "page gap", body: `{"pages":[{"page":1,"md":"gap","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		{name: "unknown page field", body: `{"pages":[{"page":0,"md":"drift","provider_url":"https://evil.example/result","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		{name: "provider page count exceeds result", body: `{"pages":[{"page":0,"md":"partial","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":2}}`},
+		{name: "missing explicit page index", body: `{"pages":[{"md":"invented zero","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		{name: "missing provider page count", body: `{"pages":[{"page":0,"md":"unproven","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{}}`},
+		{name: "unexplained empty page", body: `{"pages":[{"page":0,"md":"","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\npartial\n%%EOF\n"))
+			transport := routeTransport(t, map[string]routeResponse{
+				uploadPath:                {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+				statusPath(testJobID):     {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+				jsonResultPath(testJobID): {body: testCase.body},
+			})
+			_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+				fixture.upload(), fixture.authorization, nil,
+				func(document.RenditionResumeHandle) error { return nil })
+			assertCode(t, err, document.RenditionErrorMalformedEvidence)
+			assert.NotContains(t, err.Error(), "evil.example")
+		})
+	}
+}
+
+func TestClientRejectsReportedModelDrift(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nmodel drift\n%%EOF\n"))
+	transport := routeTransport(t, map[string]routeResponse{
+		uploadPath:                {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+		statusPath(testJobID):     {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+		jsonResultPath(testJobID): {body: `{"pages":[{"page":0,"md":"drift","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1,"model":"parse-model-next","preset":"document-v1"}}`},
+	})
+	_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+		fixture.upload(), fixture.authorization, nil,
+		func(document.RenditionResumeHandle) error { return nil })
+	assertCode(t, err, document.RenditionErrorPolicyRejected)
+}
+
+func TestClientClassifiesHostedFailuresWithoutLeakingProviderBodies(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		want   document.RenditionErrorCode
+	}{
+		{name: "authentication", status: http.StatusUnauthorized, want: document.RenditionErrorAuthentication},
+		{name: "rate", status: http.StatusTooManyRequests, want: document.RenditionErrorRateLimited},
+		{name: "capacity", status: http.StatusServiceUnavailable, want: document.RenditionErrorAmbiguousSubmission},
+		{name: "terminal input", status: http.StatusUnsupportedMediaType, want: document.RenditionErrorUnsupportedInput},
+		{name: "redirect", status: http.StatusTemporaryRedirect, want: document.RenditionErrorMalformedEvidence},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\nerrors\n%%EOF\n"))
+			transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				response := response(request, testCase.status,
+					`{"detail":"provider body secret synthetic-source"}`)
+				response.Header.Set("Location", "https://evil.example/stolen")
+				return response, nil
+			})
+			_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+				fixture.upload(), fixture.authorization, nil, nil)
+			assertCode(t, err, testCase.want)
+			assert.NotContains(t, err.Error(), "provider body")
+			assert.NotContains(t, err.Error(), "evil.example")
+		})
+	}
+}
+
+func TestClientClassifiesAmbiguousSubmissionAndUnknownJobs(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nambiguous\n%%EOF\n"))
+	client := fixture.client(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("private transport failure")
+	}))
+	_, err := document.RenderRenditionWithResume(t.Context(), client, fixture.upload(),
+		fixture.authorization, nil, nil)
+	assertCode(t, err, document.RenditionErrorAmbiguousSubmission)
+	assert.NotContains(t, err.Error(), "private transport")
+
+	for _, status := range []int{http.StatusNotFound, http.StatusGone} {
+		client = fixture.client(t, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return response(request, status, `{"detail":"private unknown detail"}`), nil
+		}))
+		now := time.Now().UTC()
+		_, err = client.RenderResumable(t.Context(), nil, fixture.authorization,
+			&document.RenditionResumeHandle{Value: testResumeHandle(now.Add(-time.Second), now)}, nil)
+		assertCode(t, err, document.RenditionErrorUnknownJob)
+	}
+}
+
+func TestClientPreservesPreEgressCredentialFailureClassification(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nauth failure\n%%EOF\n"))
+	fixture.secrets.value = ""
+	client := fixture.client(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("credential failure reached egress")
+		return nil, errors.New("unexpected egress")
+	}))
+
+	_, err := document.RenderRenditionWithResume(t.Context(), client, fixture.upload(),
+		fixture.authorization, nil, nil)
+
+	assertCode(t, err, document.RenditionErrorAuthentication)
+}
+
+func TestClientPreservesCredentialFailureClassificationAcrossResultStages(t *testing.T) {
+	t.Run("poll", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\npoll credential\n%%EOF\n"))
+		fixture.secrets.failAt = 2
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path != uploadPath {
+				t.Fatalf("credential failure reached %s egress", request.URL.Path)
+			}
+			return response(request, http.StatusOK,
+				`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+
+		assertCode(t, err, document.RenditionErrorAuthentication)
+	})
+
+	t.Run("result", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nresult credential\n%%EOF\n"))
+		fixture.secrets.failAt = 3
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Path {
+			case uploadPath, statusPath(testJobID):
+				return response(request, http.StatusOK,
+					`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+			default:
+				t.Fatalf("credential failure reached %s egress", request.URL.Path)
+				return nil, errors.New("unexpected egress")
+			}
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+
+		assertCode(t, err, document.RenditionErrorAuthentication)
+	})
+
+	t.Run("image", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nimage credential\n%%EOF\n"))
+		fixture.profile.RetainImages = true
+		fixture.profile.MaxArtifacts = 1
+		fixture.authorization.AllowedArtifactRoles = []document.EvidenceArtifactRole{document.EvidenceArtifactImage}
+		fixture.authorization.MaxArtifacts = 1
+		fixture.authorization.MaxArtifactBytes = 1024
+		fixture.secrets.failAt = 4
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Path {
+			case uploadPath, statusPath(testJobID):
+				return response(request, http.StatusOK,
+					`{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+			case jsonResultPath(testJobID):
+				return response(request, http.StatusOK, `{"pages":[{"page":0,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+			default:
+				t.Fatalf("credential failure reached %s egress", request.URL.Path)
+				return nil, errors.New("unexpected egress")
+			}
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+
+		assertCode(t, err, document.RenditionErrorAuthentication)
+	})
+}
+
+func TestClientRefusesProviderAuthoredArtifactURLsAndUsesFixedImageRoute(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nimage\n%%EOF\n"))
+	fixture.profile.RetainImages = true
+	fixture.profile.MaxArtifacts = 1
+	fixture.authorization.AllowedArtifactRoles = []document.EvidenceArtifactRole{document.EvidenceArtifactImage}
+	fixture.authorization.MaxArtifacts = 1
+	fixture.authorization.MaxArtifactBytes = 128
+	var paths []string
+	var transport http.RoundTripper = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		paths = append(paths, request.URL.Path)
+		switch request.URL.Path {
+		case uploadPath:
+			return response(request, http.StatusOK, `{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case statusPath(testJobID):
+			return response(request, http.StatusOK, `{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case jsonResultPath(testJobID):
+			return response(request, http.StatusOK, `{"pages":[{"page":0,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+		case imageResultPath(testJobID, "figure-1.png"):
+			result := bytesResponse(request, http.StatusOK, mediatest.PNG(4, 3, nil))
+			result.Header.Set("Content-Type", "image/png")
+			return result, nil
+		default:
+			t.Fatalf("unexpected route %s", request.URL.String())
+			return nil, errors.New("unexpected route")
+		}
+	})
+	result, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+		fixture.upload(), fixture.authorization, nil,
+		func(document.RenditionResumeHandle) error { return nil })
+	require.NoError(t, err)
+	require.Len(t, result.Artifacts, 1)
+	assert.Equal(t, mediatest.PNG(4, 3, nil), result.Artifacts[0].Payload)
+	assert.Equal(t, imageResultPath(testJobID, "figure-1.png"), paths[len(paths)-1])
+
+	for _, name := range []string{"https://evil.example/a.png", ".", ".."} {
+		paths = nil
+		transport = routeTransport(t, map[string]routeResponse{
+			uploadPath:                {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+			statusPath(testJobID):     {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+			jsonResultPath(testJobID): {body: `{"pages":[{"page":0,"md":"unsafe","images":[{"name":"` + name + `"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`},
+		})
+		_, err = document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+		assertCode(t, err, document.RenditionErrorMalformedEvidence)
+	}
+}
+
+func TestClientRejectsMalformedOrMismatchedRetainedImages(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		mediaType string
+		payload   []byte
+	}{
+		{name: "malformed", mediaType: "image/png", payload: []byte("not a PNG")},
+		{name: "mismatched", mediaType: "image/jpeg", payload: mediatest.PNG(4, 3, nil)},
+		{name: "animated", mediaType: "image/gif", payload: mediatest.GIF(2, 2, 2)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\nimage validation\n%%EOF\n"))
+			fixture.profile.RetainImages = true
+			fixture.profile.MaxArtifacts = 1
+			fixture.authorization.AllowedArtifactRoles = []document.EvidenceArtifactRole{document.EvidenceArtifactImage}
+			fixture.authorization.MaxArtifacts = 1
+			fixture.authorization.MaxArtifactBytes = 1024
+			transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				switch request.URL.Path {
+				case uploadPath, statusPath(testJobID):
+					return response(request, http.StatusOK, `{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+				case jsonResultPath(testJobID):
+					return response(request, http.StatusOK, `{"pages":[{"page":0,"md":"Image page","images":[{"name":"figure-1.png"}],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`), nil
+				case imageResultPath(testJobID, "figure-1.png"):
+					result := bytesResponse(request, http.StatusOK, testCase.payload)
+					result.Header.Set("Content-Type", testCase.mediaType)
+					return result, nil
+				default:
+					return nil, errors.New("unexpected route")
+				}
+			})
+
+			_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+				fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+
+			assertCode(t, err, document.RenditionErrorMalformedEvidence)
+		})
+	}
+}
+
+func TestClientEnforcesUploadPollResultAndArtifactBounds(t *testing.T) {
+	t.Run("upload identity", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nidentity\n%%EOF\n"))
+		upload := &testUpload{Reader: bytes.NewReader([]byte("different")), metadata: fixture.metadata}
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t,
+			roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("mismatched source reached egress")
+				return nil, errors.New("mismatched source reached egress")
+			})), upload, fixture.authorization, nil, nil)
+		assertCode(t, err, document.RenditionErrorPolicyRejected)
+	})
+
+	t.Run("poll limit", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\npoll\n%%EOF\n"))
+		fixture.profile.MaxPolls = 2
+		transport := routeTransport(t, map[string]routeResponse{
+			uploadPath:            {body: `{"id":"` + testJobID + `","status":"PENDING"}`},
+			statusPath(testJobID): {body: `{"id":"` + testJobID + `","status":"PENDING"}`},
+		})
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+		assertCode(t, err, document.RenditionErrorAmbiguousSubmission)
+	})
+
+	t.Run("result bytes", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nresult\n%%EOF\n"))
+		fixture.profile.MaxResultBytes = 64
+		transport := routeTransport(t, map[string]routeResponse{
+			uploadPath:                {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+			statusPath(testJobID):     {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+			jsonResultPath(testJobID): {body: strings.Repeat("x", 65)},
+		})
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil,
+			func(document.RenditionResumeHandle) error { return nil })
+		assertCode(t, err, document.RenditionErrorMalformedEvidence)
+	})
+}
+
+func TestClientClassifiesExactUploadReadLifecycle(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(*fixture)
+		duringRead func(context.CancelFunc)
+		wantCode   document.RenditionErrorCode
+		wantError  error
+	}{
+		{
+			name: "caller cancellation",
+			duringRead: func(cancel context.CancelFunc) {
+				cancel()
+			},
+			wantError: context.Canceled,
+		},
+		{
+			name: "authorization expiry",
+			configure: func(fixture *fixture) {
+				fixture.authorization.ExpiresAt = time.Now().UTC().Add(20 * time.Millisecond).Format(timeForm)
+			},
+			duringRead: func(context.CancelFunc) {
+				time.Sleep(40 * time.Millisecond)
+			},
+			wantError: document.ErrRenditionAuthorizationExpired,
+		},
+		{
+			name: "wall timeout",
+			configure: func(fixture *fixture) {
+				fixture.profile.MaxWallTime = 20 * time.Millisecond
+			},
+			duringRead: func(context.CancelFunc) {
+				time.Sleep(40 * time.Millisecond)
+			},
+			wantCode: document.RenditionErrorCapacity,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, []byte("%PDF-1.7\nslow upload\n%%EOF\n"))
+			if testCase.configure != nil {
+				testCase.configure(fixture)
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			upload := &testUpload{
+				Reader: &callbackReadCloser{
+					reader: bytes.NewReader(fixture.source),
+					before: func() { testCase.duringRead(cancel) },
+				},
+				metadata: fixture.metadata,
+			}
+			client := fixture.client(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("expired upload reached egress")
+				return nil, errors.New("unexpected egress")
+			}))
+
+			_, err := document.RenderRenditionWithResume(ctx, client, upload,
+				fixture.authorization, nil, nil)
+
+			if testCase.wantError != nil {
+				assert.ErrorIs(t, err, testCase.wantError)
+			} else {
+				assertCode(t, err, testCase.wantCode)
+			}
+		})
+	}
+}
+
+func TestClientClassifiesCancellationAndAuthorizationExpiry(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\ncancel\n%%EOF\n"))
+	ctx, cancel := context.WithCancel(t.Context())
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path == uploadPath {
+			return response(request, http.StatusOK, `{"id":"`+testJobID+`","status":"PENDING"}`), nil
+		}
+		cancel()
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	})
+	_, err := document.RenderRenditionWithResume(ctx, fixture.client(t, transport),
+		fixture.upload(), fixture.authorization, nil,
+		func(document.RenditionResumeHandle) error { return nil })
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClientResumesHistoricalSealedAuthorizationWithRecordedReceiptTimes(t *testing.T) {
+	fixture := newFixture(t, []byte("%PDF-1.7\nhistorical resume\n%%EOF\n"))
+	transport := routeTransport(t, map[string]routeResponse{
+		statusPath(testJobID): {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+		jsonResultPath(testJobID): {
+			body: `{"pages":[{"page":0,"md":"Historical","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`,
+		},
+	})
+	client := fixture.client(t, transport)
+	historical := time.Now().UTC().Add(-time.Hour)
+	fixture.authorization.AuthorizedAt = historical.Format(timeForm)
+	fixture.authorization.ExpiresAt = historical.Add(time.Minute).Format(timeForm)
+	submittedAt := historical.Add(10 * time.Second)
+	checkpointedAt := historical.Add(11 * time.Second)
+	evidencePolicy, err := document.NewEvidencePolicy(100_000)
+	require.NoError(t, err)
+	renditionPolicy, err := document.NewRenditionPolicy(document.RenditionLimits{
+		MaxDocumentChars: 100_000, MaxUnitRunes: 1_000_000, MaxSegmentRunes: 1_000,
+	})
+	require.NoError(t, err)
+	snapshot, err := document.SealRenditionExecutionAt(historical.Add(time.Second), client,
+		fixture.upload(), fixture.authorization, evidencePolicy, renditionPolicy)
+	require.NoError(t, err)
+
+	result, err := document.ResumeRendition(t.Context(), client, snapshot,
+		document.RenditionResumeHandle{Value: testResumeHandle(submittedAt, checkpointedAt)}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, submittedAt.Format(timeForm), result.Receipt.StartedAt)
+	assert.Equal(t, checkpointedAt.Format(timeForm), result.Receipt.CompletedAt)
+}
+
+func TestClientRechecksLifecycleAfterResponseBodiesAndBeforeReturn(t *testing.T) {
+	const resultBody = `{"pages":[{"page":0,"md":"Complete","images":[],"charts":[],"tables":[],"layout":[],"items":[],"links":[],"parsingMode":"parse_page","noStructuredContent":true,"noTextContent":false,"triggeredAutoMode":false}],"job_metadata":{"job_pages":1}}`
+
+	t.Run("caller cancellation after complete body", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nbody cancel\n%%EOF\n"))
+		ctx, cancel := context.WithCancel(t.Context())
+		transport := resultBodyTransport(t, resultBody, func(request *http.Request) io.ReadCloser {
+			return &callbackReadCloser{reader: strings.NewReader(resultBody), before: cancel}
+		})
+
+		_, err := document.RenderRenditionWithResume(ctx, fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("wall timeout after complete body", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nbody timeout\n%%EOF\n"))
+		fixture.profile.MaxWallTime = 20 * time.Millisecond
+		transport := resultBodyTransport(t, resultBody, func(request *http.Request) io.ReadCloser {
+			return &callbackReadCloser{reader: strings.NewReader(resultBody), before: func() { time.Sleep(40 * time.Millisecond) }}
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+
+		assertCode(t, err, document.RenditionErrorCapacity)
+	})
+
+	t.Run("authorization expiry after complete body", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nbody expiry\n%%EOF\n"))
+		expiresAt := time.Now().UTC().Add(20 * time.Millisecond)
+		fixture.authorization.ExpiresAt = expiresAt.Format(timeForm)
+		transport := resultBodyTransport(t, resultBody, func(request *http.Request) io.ReadCloser {
+			return &callbackReadCloser{reader: strings.NewReader(resultBody), before: func() {
+				time.Sleep(time.Until(expiresAt) + 10*time.Millisecond)
+			}}
+		})
+
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+
+		assert.ErrorIs(t, err, document.ErrRenditionAuthorizationExpired)
+	})
+
+	t.Run("caller cancellation at final acceptance", func(t *testing.T) {
+		fixture := newFixture(t, []byte("%PDF-1.7\nfinal cancel\n%%EOF\n"))
+		ctx := newCancelWhenCheckedContext(t.Context())
+		defer ctx.cancel()
+		transport := routeTransport(t, map[string]routeResponse{
+			uploadPath:                {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+			statusPath(testJobID):     {body: `{"id":"` + testJobID + `","status":"SUCCESS"}`},
+			jsonResultPath(testJobID): {body: resultBody},
+		})
+
+		_, err := fixture.client(t, transport).RenderResumable(ctx, fixture.upload(),
+			fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+
+		assertCode(t, err, document.RenditionErrorCanceled)
+	})
+}
+
+type fixture struct {
+	profile       Profile
+	secrets       *testSecrets
+	metadata      document.AuthorizedUploadMetadata
+	source        []byte
+	authorization document.RenditionAuthorization
+}
+
+func newFixture(t *testing.T, source []byte) *fixture {
+	t.Helper()
+	profile := Profile{
+		Model: "parse-model-v1", Preset: "document-v1", SecretBinding: "llamaparse-production",
+		MaxUploadBytes: 1024, MaxRequestBytes: 4096, MaxControlBytes: 1024,
+		MaxPolls: 3, PollInterval: time.Millisecond, RequestTimeout: time.Second,
+		MaxResultBytes: 32 << 10, MaxArtifactBytes: 1024, MaxArtifacts: 0,
+		MaxWallTime: time.Second,
+	}
+	secrets := &testSecrets{value: "synthetic-secret"}
+	client, err := NewProvider(profile, secrets, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("unused fixture transport")
+	}))
+	require.NoError(t, err)
+	descriptor := client.Descriptor()
+	digest := sha256.Sum256(source)
+	metadata := document.AuthorizedUploadMetadata{
+		Filename: "synthetic.pdf", MediaFamily: "pdf", MediaType: "application/pdf",
+		ByteLength: int64(len(source)), SHA256: hex.EncodeToString(digest[:]),
+		CapabilityRecordChecksum: strings.Repeat("1", 64),
+		ProviderMetadataChecksum: strings.Repeat("2", 64),
+		InputKind:                document.RenditionInputOriginalFile,
+	}
+	now := time.Now().UTC()
+	return &fixture{
+		profile: profile, secrets: secrets, metadata: metadata, source: bytes.Clone(source),
+		authorization: document.RenditionAuthorization{
+			ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+			PolicyFingerprint:           descriptor.PolicyFingerprint,
+			RenditionRequestFingerprint: strings.Repeat("3", 64),
+			SourceSHA256:                metadata.SHA256, SourceBytes: metadata.ByteLength,
+			CapabilityRecordChecksum: metadata.CapabilityRecordChecksum,
+			ProviderMetadataChecksum: metadata.ProviderMetadataChecksum,
+			MediaFamily:              metadata.MediaFamily, MediaType: metadata.MediaType,
+			InputKind: metadata.InputKind, DiscloseFilename: true, MaxProviderMarkdownBytes: 16 << 10,
+			MaxTotalResultBytes: 64 << 10,
+			AuthorizedAt:        now.Add(-time.Second).Format(timeForm),
+			ExpiresAt:           now.Add(time.Minute).Format(timeForm),
+		},
+	}
+}
+
+func (fixture *fixture) client(t *testing.T, transport http.RoundTripper) *Client {
+	t.Helper()
+	client, err := NewProvider(fixture.profile, fixture.secrets, transport)
+	require.NoError(t, err)
+	descriptor := client.Descriptor()
+	fixture.authorization.ProviderID = descriptor.ID
+	fixture.authorization.DescriptorFingerprint = descriptor.Fingerprint
+	fixture.authorization.PolicyFingerprint = descriptor.PolicyFingerprint
+	return client
+}
+
+func (fixture *fixture) upload() document.AuthorizedUpload {
+	return &testUpload{Reader: bytes.NewReader(fixture.source), metadata: fixture.metadata}
+}
+
+type testUpload struct {
+	io.Reader
+
+	metadata document.AuthorizedUploadMetadata
+}
+
+func (upload *testUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+func (upload *testUpload) Close() error                                { return nil }
+
+type testSecrets struct {
+	mu     sync.Mutex
+	value  string
+	count  int
+	failAt int
+}
+
+type callbackReadCloser struct {
+	reader io.Reader
+	once   sync.Once
+	before func()
+}
+
+func (body *callbackReadCloser) Read(buffer []byte) (int, error) {
+	body.once.Do(body.before)
+	return body.reader.Read(buffer)
+}
+
+func (*callbackReadCloser) Close() error { return nil }
+
+type cancelWhenCheckedContext struct {
+	context.Context
+
+	done chan struct{}
+	once sync.Once
+}
+
+func newCancelWhenCheckedContext(parent context.Context) *cancelWhenCheckedContext {
+	return &cancelWhenCheckedContext{Context: parent, done: make(chan struct{})}
+}
+
+func (ctx *cancelWhenCheckedContext) Done() <-chan struct{} { return ctx.done }
+
+func (ctx *cancelWhenCheckedContext) Err() error {
+	ctx.cancel()
+	return context.Canceled
+}
+
+func (ctx *cancelWhenCheckedContext) cancel() {
+	ctx.once.Do(func() { close(ctx.done) })
+}
+
+func (secrets *testSecrets) ResolveSecret(context.Context, string) (string, error) {
+	secrets.mu.Lock()
+	defer secrets.mu.Unlock()
+	secrets.count++
+	if secrets.count == secrets.failAt {
+		return "", errors.New("synthetic credential failure")
+	}
+	return secrets.value, nil
+}
+
+func (secrets *testSecrets) calls() int {
+	secrets.mu.Lock()
+	defer secrets.mu.Unlock()
+	return secrets.count
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.Body != nil {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			return nil, err
+		}
+		if err := request.Body.Close(); err != nil {
+			return nil, err
+		}
+		request.Body = io.NopCloser(bytes.NewReader(body))
+		request.ContentLength = int64(len(body))
+	}
+	return function(request)
+}
+
+type routeResponse struct {
+	status int
+	body   string
+}
+
+func routeTransport(t *testing.T, routes map[string]routeResponse) http.RoundTripper {
+	t.Helper()
+	return roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		route, ok := routes[request.URL.Path]
+		if !ok {
+			t.Fatalf("unexpected route %s", request.URL.String())
+		}
+		status := route.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		return response(request, status, route.body), nil
+	})
+}
+
+func resultBodyTransport(
+	t *testing.T, resultBody string, body func(*http.Request) io.ReadCloser,
+) http.RoundTripper {
+	t.Helper()
+	return roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		switch request.URL.Path {
+		case uploadPath, statusPath(testJobID):
+			return response(request, http.StatusOK, `{"id":"`+testJobID+`","status":"SUCCESS"}`), nil
+		case jsonResultPath(testJobID):
+			result := response(request, http.StatusOK, resultBody)
+			result.Body = body(request)
+			return result, nil
+		default:
+			t.Fatalf("unexpected route %s", request.URL.String())
+			return nil, errors.New("unexpected route")
+		}
+	})
+}
+
+func response(request *http.Request, status int, body string) *http.Response {
+	return bytesResponse(request, status, []byte(body))
+}
+
+func bytesResponse(request *http.Request, status int, body []byte) *http.Response {
+	header := make(http.Header)
+	header.Set("Content-Type", providerutil.JSONMediaType)
+	return &http.Response{
+		StatusCode: status, Status: http.StatusText(status), Header: header,
+		Body: io.NopCloser(bytes.NewReader(body)), Request: request,
+	}
+}
+
+func testResumeHandle(submittedAt, checkpointedAt time.Time) string {
+	return fmt.Sprintf("lp1.%s.%d.%d", testJobID, submittedAt.UnixNano(), checkpointedAt.UnixNano())
+}
+
+func assertCode(t *testing.T, err error, want document.RenditionErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	providerError, ok := errors.AsType[*document.RenditionProviderError](err)
+	require.True(t, ok, "expected classified provider error, got %T: %v", err, err)
+	assert.Equal(t, want, providerError.Code())
+}

--- a/document/llamaparse/doc.go
+++ b/document/llamaparse/doc.go
@@ -1,0 +1,3 @@
+// Package llamaparse adapts the fixed hosted LlamaParse v1 API to Docbank's
+// storage-neutral, resumable rendition provider contract.
+package llamaparse

--- a/document/pymupdf/provider_test.go
+++ b/document/pymupdf/provider_test.go
@@ -128,7 +128,7 @@ func TestProviderRejectsMalformedPartialAndDriftedOutput(t *testing.T) {
 		"source-size-drift", "partial", "page-count-drift", "gap", "duplicate", "empty-unexplained",
 	} {
 		t.Run(mode, func(t *testing.T) {
-			provider := newTestProvider(t, helperExecutable(t, mode), time.Second, 1<<20)
+			provider := newTestProvider(t, helperExecutable(t, mode), 30*time.Second, 1<<20)
 			upload := newTestUpload(testPDF(2))
 
 			_, err := provider.Render(t.Context(), upload,


### PR DESCRIPTION
## What changed

Docbank now has a hosted LlamaParse adapter that receives only sealed authorized document bytes. Structured pages keep page-level evidence; Markdown fallback is marked degraded, and contradictory or partial results fail closed.

Accepted jobs get a durable secret-free resume handle, so a restart can continue the known parse instead of repeating an ambiguous paid submission. Fixed routes, model identity, request and result limits, returned image bytes, redirects, provider-authored URLs, expiry, cancellation, rate limits, and capacity failures all stay inside the shared rendition boundary.

## Why

Hosted parsing needs durable resume semantics and explicit provenance. A transient failure after submission must not cause duplicate work, and provider output must not gain destination or evidence authority just because the service returned it.

## Usage

For library use, construct the client with `llamaparse.NewProvider(profile, secrets, transport)`. The profile pins the hosted identity and finite limits; the injected transport owns the approved destination policy.

Durable resume is consumed by the R10 worker contract. Daemon, API, and CLI registration is intentionally deferred to S1–S3.

Part of #176 (R13). Stacks on #204.
