### PR TITLE
[F10–E12 11/25] Add the broad-format Unstructured bridge profile

### DIFF
--- a/document/bridge/client.go
+++ b/document/bridge/client.go
@@ -31,6 +31,7 @@ const (
 	maxBridgeTimeout        = 24 * time.Hour
 	maxBridgePollAttempts   = 10_000
 	maxBridgeResponseBytes  = int64(512 << 20)
+	maxBridgeDocumentBytes  = int64(1 << 40)
 	maxBridgeErrorMessage   = 1024
 	maxBridgeCleanupTimeout = 5 * time.Second
 )
@@ -67,7 +68,8 @@ func New(profile Profile, secrets SecretResolver, httpClient *http.Client) (*Cli
 		!providerutil.Bounded(&profile.TotalTimeout, defaultTotalTimeout, maxBridgeTimeout) ||
 		!providerutil.Bounded(&profile.PollInterval, defaultPollInterval, profile.TotalTimeout) ||
 		!providerutil.Bounded(&profile.MaxPollAttempts, defaultMaxPollAttempts, maxBridgePollAttempts) ||
-		!providerutil.Bounded(&profile.MaxResponseBytes, defaultMaxResponseBytes, maxBridgeResponseBytes) {
+		!providerutil.Bounded(&profile.MaxResponseBytes, defaultMaxResponseBytes, maxBridgeResponseBytes) ||
+		profile.MaxDocumentBytes < 0 || profile.MaxDocumentBytes > maxBridgeDocumentBytes {
 		return nil, errors.New("bridge: execution bounds are invalid")
 	}
 	return &Client{
@@ -78,6 +80,7 @@ func New(profile Profile, secrets SecretResolver, httpClient *http.Client) (*Cli
 		},
 		descriptor: descriptor, totalTimeout: profile.TotalTimeout,
 		pollInterval: profile.PollInterval, maxPollAttempts: profile.MaxPollAttempts,
+		maxDocumentBytes: profile.MaxDocumentBytes,
 	}, nil
 }
 
@@ -98,6 +101,11 @@ func (client *Client) Render(
 		return document.RenditionResult{}, errors.New("bridge: client is required")
 	}
 	metadata := upload.Metadata()
+	if client.maxDocumentBytes > 0 && (metadata.ByteLength > client.maxDocumentBytes ||
+		authorization.SourceBytes > client.maxDocumentBytes) {
+		return document.RenditionResult{}, provider.Classified(document.RenditionErrorPolicyRejected,
+			"bridge input exceeds the document byte limit", nil)
+	}
 	if strings.ContainsAny(metadata.Filename, "\r\n") {
 		return document.RenditionResult{}, provider.Classified(document.RenditionErrorPolicyRejected,
 			"bridge filename contains unsupported line breaks", nil)

--- a/document/bridge/client_test.go
+++ b/document/bridge/client_test.go
@@ -169,6 +169,27 @@ func TestBridgeContractRejectsMultilineFilenameBeforeSubmission(t *testing.T) {
 	assert.Zero(t, requests.Load())
 }
 
+func TestBridgeContractRejectsDocumentAboveProfileLimitBeforeSubmission(t *testing.T) {
+	fixture := newBridgeFixture(t)
+	fixture.source = bytes.Repeat([]byte("x"), (1<<20)+1)
+	fixture.metadata.ByteLength = int64(len(fixture.source))
+	fixture.metadata.SHA256 = sha256String(fixture.source)
+	fixture.authorization.SourceBytes = fixture.metadata.ByteLength
+	fixture.authorization.SourceSHA256 = fixture.metadata.SHA256
+	var requests atomic.Int64
+	client := newTestBridgeClientWithHTTP(t, "https://bridge.invalid", fixture.descriptor, nil,
+		&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requests.Add(1)
+			return nil, errors.New("unexpected bridge request")
+		})})
+
+	_, err := document.RenderRendition(t.Context(), client, fixture.upload(), fixture.authorization)
+	var providerError *document.RenditionProviderError
+	require.ErrorAs(t, err, &providerError)
+	assert.Equal(t, document.RenditionErrorPolicyRejected, providerError.Code())
+	assert.Zero(t, requests.Load())
+}
+
 func TestBridgeContractIdempotencyReplayAndForwardCompatibleEnvelope(t *testing.T) {
 	fixture := newBridgeFixture(t)
 	var keys []string
@@ -1198,6 +1219,7 @@ func newTestBridgeClientWithHTTP(
 		Origin: origin, Descriptor: descriptor, SecretBinding: secretBinding,
 		RequestTimeout: time.Second, TotalTimeout: 2 * time.Second,
 		PollInterval: time.Millisecond, MaxPollAttempts: 4, MaxResponseBytes: 1 << 20,
+		MaxDocumentBytes: 1 << 20,
 	}, secrets, httpClient)
 	require.NoError(t, err)
 	return client

--- a/document/bridge/types.go
+++ b/document/bridge/types.go
@@ -44,15 +44,17 @@ type Profile struct {
 	PollInterval     time.Duration
 	MaxPollAttempts  int
 	MaxResponseBytes int64
+	MaxDocumentBytes int64
 }
 
 // Client implements document.RenditionProvider through docbank-rendition/v1.
 type Client struct {
-	executor        providerutil.Executor
-	descriptor      document.RenditionDescriptor
-	totalTimeout    time.Duration
-	pollInterval    time.Duration
-	maxPollAttempts int
+	executor         providerutil.Executor
+	descriptor       document.RenditionDescriptor
+	totalTimeout     time.Duration
+	pollInterval     time.Duration
+	maxPollAttempts  int
+	maxDocumentBytes int64
 }
 
 // AuthorizationManifest is the canonical multipart policy part sent beside

--- a/document/unstructured/profile.go
+++ b/document/unstructured/profile.go
@@ -1,0 +1,283 @@
+// Package unstructured defines the fixed compatibility profile used when an
+// operator deploys an Unstructured adapter behind docbank-rendition/v1.
+package unstructured
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/bridge"
+	"go.kenn.io/docbank/document/internal/providerutil"
+	canonicaljson "go.kenn.io/docbank/internal/canonical"
+)
+
+const (
+	// ProfileContractV1 identifies the canonical Unstructured bridge profile.
+	ProfileContractV1 = "unstructured-bridge-profile/v1"
+	descriptorID      = "unstructured.bridge.v1"
+)
+
+var provider = providerutil.Provider("Unstructured")
+
+// Config supplies the only operator-specific profile values. It deliberately
+// has no routes, URLs, fetch controls, or provider options.
+type Config struct {
+	DeploymentID      string
+	RuntimeID         string
+	CredentialBinding string
+}
+
+// LimitsV1 fixes every finite input, output, polling, and wall-clock bound.
+type LimitsV1 struct {
+	MaxDocumentBytes     int64 `json:"max_document_bytes"`
+	MaxPollAttempts      int   `json:"max_poll_attempts"`
+	MaxResponseBytes     int64 `json:"max_response_bytes"`
+	PollIntervalMillis   int64 `json:"poll_interval_millis"`
+	RequestTimeoutMillis int64 `json:"request_timeout_millis"`
+	TotalTimeoutMillis   int64 `json:"total_timeout_millis"`
+}
+
+// DisclosurePolicyV1 permits only the exact supplied bytes and records the
+// bridge's safe-basename disclosure. Authorization binds every byte and tuple.
+type DisclosurePolicyV1 struct {
+	DiscloseFilename bool   `json:"disclose_filename"`
+	Source           string `json:"source"`
+}
+
+// EvidencePolicyV1 fixes bounded provider-neutral evidence and Markdown.
+type EvidencePolicyV1 struct {
+	MaxProviderMarkdownBytes int    `json:"max_provider_markdown_bytes"`
+	MaxTotalResultBytes      int    `json:"max_total_result_bytes"`
+	MaxUnits                 int    `json:"max_units"`
+	SourceEvidenceContract   string `json:"source_evidence_contract"`
+}
+
+// ArtifactPolicyV1 permits only one bounded structured-evidence artifact.
+type ArtifactPolicyV1 struct {
+	AllowedRoles     []document.EvidenceArtifactRole `json:"allowed_roles"`
+	MaxArtifactBytes int64                           `json:"max_artifact_bytes"`
+	MaxArtifacts     int                             `json:"max_artifacts"`
+}
+
+// ProfileV1 is the immutable compatibility identity expected from an
+// operator-network Unstructured bridge deployment.
+type ProfileV1 struct {
+	ArtifactPolicy    ArtifactPolicyV1                     `json:"artifact_policy"`
+	BridgeContract    string                               `json:"bridge_contract"`
+	ContractVersion   string                               `json:"contract_version"`
+	CredentialBinding string                               `json:"credential_binding"`
+	DeploymentID      string                               `json:"deployment_id"`
+	Disclosure        DisclosurePolicyV1                   `json:"disclosure"`
+	EvidencePolicy    EvidencePolicyV1                     `json:"evidence_policy"`
+	InputKind         document.RenditionInputKind          `json:"input_kind"`
+	Limits            LimitsV1                             `json:"limits"`
+	PolicyFingerprint string                               `json:"policy_fingerprint"`
+	RuntimeID         string                               `json:"runtime_id"`
+	SupportedFormats  []document.RenditionFormatCapability `json:"supported_formats"`
+	TrustBoundary     document.RenditionTrustBoundary      `json:"trust_boundary"`
+}
+
+// NewProfile returns the standard profile with operator-pinned deployment and
+// runtime identity and an optional named credential binding.
+func NewProfile(config Config) (ProfileV1, error) {
+	profile := ProfileV1{
+		ArtifactPolicy: standardArtifactPolicy(),
+		BridgeContract: bridge.ContractVersion, ContractVersion: ProfileContractV1,
+		CredentialBinding: config.CredentialBinding, DeploymentID: config.DeploymentID,
+		Disclosure:     standardDisclosurePolicy(),
+		EvidencePolicy: standardEvidencePolicy(),
+		InputKind:      document.RenditionInputOriginalFile,
+		Limits:         standardLimits(),
+		RuntimeID:      config.RuntimeID, SupportedFormats: standardFormats(),
+		TrustBoundary: document.RenditionTrustOperatorNetwork,
+	}
+	_, fingerprint, err := CanonicalProfile(profile)
+	if err != nil {
+		return ProfileV1{}, err
+	}
+	profile.PolicyFingerprint = fingerprint
+	return profile, nil
+}
+
+// CanonicalProfile validates, sorts, and deterministically encodes a profile.
+// A populated fingerprint must match the canonical identity.
+func CanonicalProfile(profile ProfileV1) ([]byte, string, error) {
+	canonical := cloneProfile(profile)
+	slices.SortFunc(canonical.SupportedFormats, compareFormats)
+	slices.Sort(canonical.ArtifactPolicy.AllowedRoles)
+	claimed := canonical.PolicyFingerprint
+	canonical.PolicyFingerprint = ""
+	if err := validateProfile(canonical); err != nil {
+		return nil, "", fmt.Errorf("unstructured: invalid profile: %w", err)
+	}
+	identityJSON, err := canonicaljson.Marshal(canonical)
+	if err != nil {
+		return nil, "", fmt.Errorf("unstructured: encode profile identity: %w", err)
+	}
+	fingerprint := providerutil.SHA256Hex(identityJSON)
+	if claimed != "" && claimed != fingerprint {
+		return nil, "", errors.New("unstructured: policy fingerprint does not match canonical profile")
+	}
+	canonical.PolicyFingerprint = fingerprint
+	encoded, err := canonicaljson.Marshal(canonical)
+	if err != nil {
+		return nil, "", fmt.Errorf("unstructured: encode canonical profile: %w", err)
+	}
+	return encoded, fingerprint, nil
+}
+
+// ParseProfile accepts only the exact canonical v1 representation.
+func ParseProfile(raw []byte) (ProfileV1, error) {
+	profile, err := canonicaljson.DecodeWith(raw, func(value ProfileV1) ([]byte, error) {
+		encoded, _, encodeErr := CanonicalProfile(value)
+		return encoded, encodeErr
+	})
+	if err != nil {
+		return ProfileV1{}, fmt.Errorf("unstructured: decode profile: %w", err)
+	}
+	return cloneProfile(profile), nil
+}
+
+// BridgeProfile projects the compatibility identity into the generic hardened
+// bridge. Origin remains generic bridge configuration, not profile schema.
+// Per-result limits stay in the signed authorization; the bridge applies them
+// while decoding each response and artifact.
+func BridgeProfile(profile ProfileV1, origin string) (bridge.Profile, error) {
+	_, fingerprint, err := CanonicalProfile(profile)
+	if err != nil {
+		return bridge.Profile{}, err
+	}
+	descriptor, err := document.NewRenditionDescriptor(document.RenditionDescriptor{
+		ID: descriptorID, ContractVersion: document.RenditionProviderContractVersion,
+		PolicyFingerprint: fingerprint, TrustBoundary: document.RenditionTrustOperatorNetwork,
+		SupportedFormats: slices.Clone(profile.SupportedFormats), ReturnsMarkdown: true,
+		ReturnsStructured: true,
+		ArtifactRoles:     slices.Clone(profile.ArtifactPolicy.AllowedRoles),
+	})
+	if err != nil {
+		return bridge.Profile{}, fmt.Errorf("unstructured: construct bridge descriptor: %w", err)
+	}
+	return bridge.Profile{
+		Origin: origin, Descriptor: descriptor, SecretBinding: profile.CredentialBinding,
+		RequestTimeout:  time.Duration(profile.Limits.RequestTimeoutMillis) * time.Millisecond,
+		TotalTimeout:    time.Duration(profile.Limits.TotalTimeoutMillis) * time.Millisecond,
+		PollInterval:    time.Duration(profile.Limits.PollIntervalMillis) * time.Millisecond,
+		MaxPollAttempts: profile.Limits.MaxPollAttempts, MaxResponseBytes: profile.Limits.MaxResponseBytes,
+	}, nil
+}
+
+func validateProfile(profile ProfileV1) error {
+	if profile.ContractVersion != ProfileContractV1 || profile.BridgeContract != bridge.ContractVersion {
+		return errors.New("contract version is invalid")
+	}
+	if err := validateIdentity(profile.DeploymentID, "deployment ID", false, 256); err != nil {
+		return err
+	}
+	if err := validateIdentity(profile.RuntimeID, "runtime ID", true, 256); err != nil {
+		return err
+	}
+	if profile.CredentialBinding != "" {
+		if err := provider.ValidateIdentifier(profile.CredentialBinding, "credential binding"); err != nil {
+			return err
+		}
+	}
+	if profile.TrustBoundary != document.RenditionTrustOperatorNetwork ||
+		profile.InputKind != document.RenditionInputOriginalFile ||
+		profile.Disclosure != standardDisclosurePolicy() {
+		return errors.New("disclosure or execution boundary is invalid")
+	}
+	if !slices.Equal(profile.SupportedFormats, standardFormats()) {
+		return errors.New("supported formats differ from the standard profile")
+	}
+	if !slices.Equal(profile.ArtifactPolicy.AllowedRoles,
+		[]document.EvidenceArtifactRole{document.EvidenceArtifactStructured}) {
+		return errors.New("artifact roles differ from the standard profile")
+	}
+	standardArtifacts := standardArtifactPolicy()
+	if profile.Limits != standardLimits() || profile.EvidencePolicy != standardEvidencePolicy() ||
+		profile.ArtifactPolicy.MaxArtifactBytes != standardArtifacts.MaxArtifactBytes ||
+		profile.ArtifactPolicy.MaxArtifacts != standardArtifacts.MaxArtifacts {
+		return errors.New("limits differ from the finite standard profile")
+	}
+	return nil
+}
+
+func standardLimits() LimitsV1 {
+	return LimitsV1{
+		MaxDocumentBytes: 100 << 20, MaxPollAttempts: 300, MaxResponseBytes: 128 << 20,
+		PollIntervalMillis: 1_000, RequestTimeoutMillis: 30_000, TotalTimeoutMillis: 600_000,
+	}
+}
+
+func standardDisclosurePolicy() DisclosurePolicyV1 {
+	return DisclosurePolicyV1{DiscloseFilename: true, Source: "exact_supplied_bytes"}
+}
+
+func standardEvidencePolicy() EvidencePolicyV1 {
+	return EvidencePolicyV1{
+		MaxProviderMarkdownBytes: 32 << 20, MaxTotalResultBytes: 128 << 20,
+		MaxUnits: 100_000, SourceEvidenceContract: document.SourceEvidenceContractV1,
+	}
+}
+
+func standardArtifactPolicy() ArtifactPolicyV1 {
+	return ArtifactPolicyV1{
+		AllowedRoles:     []document.EvidenceArtifactRole{document.EvidenceArtifactStructured},
+		MaxArtifactBytes: 64 << 20, MaxArtifacts: 1,
+	}
+}
+
+func validateIdentity(value, subject string, allowColon bool, maximum int) error {
+	if value == "" || len(value) > maximum || !utf8.ValidString(value) || strings.TrimSpace(value) != value {
+		return fmt.Errorf("%s is invalid", subject)
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' || strings.ContainsRune("._-", character) ||
+			allowColon && character == ':' {
+			continue
+		}
+		return fmt.Errorf("%s is invalid", subject)
+	}
+	return nil
+}
+
+func standardFormats() []document.RenditionFormatCapability {
+	formats := []document.RenditionFormatCapability{
+		{MediaFamily: "pdf", MediaType: "application/pdf", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "presentation", MediaType: "application/vnd.openxmlformats-officedocument.presentationml.presentation", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "spreadsheet", MediaType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "spreadsheet", MediaType: "application/vnd.oasis.opendocument.spreadsheet", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "spreadsheet", MediaType: "text/csv", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "ebook", MediaType: "application/epub+zip", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "mail", MediaType: "message/rfc822", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "structured", MediaType: "application/xml", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "text", MediaType: "text/plain", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "text", MediaType: "text/markdown", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/jpeg", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/png", InputKind: document.RenditionInputOriginalFile},
+	}
+	slices.SortFunc(formats, compareFormats)
+	return formats
+}
+
+func compareFormats(left, right document.RenditionFormatCapability) int {
+	if comparison := strings.Compare(left.MediaFamily, right.MediaFamily); comparison != 0 {
+		return comparison
+	}
+	if comparison := strings.Compare(left.MediaType, right.MediaType); comparison != 0 {
+		return comparison
+	}
+	return strings.Compare(string(left.InputKind), string(right.InputKind))
+}
+
+func cloneProfile(profile ProfileV1) ProfileV1 {
+	profile.SupportedFormats = slices.Clone(profile.SupportedFormats)
+	profile.ArtifactPolicy.AllowedRoles = slices.Clone(profile.ArtifactPolicy.AllowedRoles)
+	return profile
+}

--- a/document/unstructured/profile.go
+++ b/document/unstructured/profile.go
@@ -168,6 +168,7 @@ func BridgeProfile(profile ProfileV1, origin string) (bridge.Profile, error) {
 		TotalTimeout:    time.Duration(profile.Limits.TotalTimeoutMillis) * time.Millisecond,
 		PollInterval:    time.Duration(profile.Limits.PollIntervalMillis) * time.Millisecond,
 		MaxPollAttempts: profile.Limits.MaxPollAttempts, MaxResponseBytes: profile.Limits.MaxResponseBytes,
+		MaxDocumentBytes: profile.Limits.MaxDocumentBytes,
 	}, nil
 }
 

--- a/document/unstructured/profile_test.go
+++ b/document/unstructured/profile_test.go
@@ -111,6 +111,7 @@ func TestReferenceProfileBuildsStandardBridgeAndRejectsDrift(t *testing.T) {
 		bridgeProfile.PollInterval)
 	assert.Equal(t, profile.Limits.MaxPollAttempts, bridgeProfile.MaxPollAttempts)
 	assert.Equal(t, profile.Limits.MaxResponseBytes, bridgeProfile.MaxResponseBytes)
+	assert.Equal(t, profile.Limits.MaxDocumentBytes, bridgeProfile.MaxDocumentBytes)
 	_, err = bridge.New(bridgeProfile, staticSecretResolver{}, http.DefaultClient)
 	require.NoError(t, err)
 

--- a/document/unstructured/profile_test.go
+++ b/document/unstructured/profile_test.go
@@ -1,0 +1,163 @@
+package unstructured
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/bridge"
+)
+
+func TestReferenceProfileCanonicalizationPinsCompatibilityIdentity(t *testing.T) {
+	profile, err := NewProfile(Config{
+		DeploymentID:      "operator-unstructured-primary",
+		RuntimeID:         "sha256:" + strings.Repeat("a", 64),
+		CredentialBinding: "unstructured-api",
+	})
+	require.NoError(t, err)
+
+	canonical, fingerprint, err := CanonicalProfile(profile)
+	require.NoError(t, err)
+	assert.Equal(t, fingerprint, profile.PolicyFingerprint)
+	assert.JSONEq(t, `{
+		"artifact_policy":{"allowed_roles":["structured_evidence"],"max_artifact_bytes":67108864,"max_artifacts":1},
+		"bridge_contract":"docbank-rendition/v1",
+		"contract_version":"unstructured-bridge-profile/v1",
+		"credential_binding":"unstructured-api",
+		"deployment_id":"operator-unstructured-primary",
+		"disclosure":{"disclose_filename":true,"source":"exact_supplied_bytes"},
+		"evidence_policy":{"max_provider_markdown_bytes":33554432,"max_total_result_bytes":134217728,"max_units":100000,"source_evidence_contract":"source-evidence/v1"},
+		"input_kind":"original_file",
+		"limits":{"max_document_bytes":104857600,"max_poll_attempts":300,"max_response_bytes":134217728,"poll_interval_millis":1000,"request_timeout_millis":30000,"total_timeout_millis":600000},
+		"policy_fingerprint":"`+fingerprint+`",
+		"runtime_id":"sha256:`+strings.Repeat("a", 64)+`",
+			"supported_formats":[
+				{"media_family":"ebook","media_type":"application/epub+zip","input_kind":"original_file"},
+				{"media_family":"image","media_type":"image/jpeg","input_kind":"original_file"},
+				{"media_family":"image","media_type":"image/png","input_kind":"original_file"},
+				{"media_family":"mail","media_type":"message/rfc822","input_kind":"original_file"},
+				{"media_family":"pdf","media_type":"application/pdf","input_kind":"original_file"},
+				{"media_family":"presentation","media_type":"application/vnd.openxmlformats-officedocument.presentationml.presentation","input_kind":"original_file"},
+				{"media_family":"spreadsheet","media_type":"application/vnd.oasis.opendocument.spreadsheet","input_kind":"original_file"},
+				{"media_family":"spreadsheet","media_type":"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet","input_kind":"original_file"},
+				{"media_family":"spreadsheet","media_type":"text/csv","input_kind":"original_file"},
+				{"media_family":"structured","media_type":"application/xml","input_kind":"original_file"},
+				{"media_family":"text","media_type":"text/markdown","input_kind":"original_file"},
+				{"media_family":"text","media_type":"text/plain","input_kind":"original_file"}
+		],
+		"trust_boundary":"operator_network"
+	}`, string(canonical))
+
+	parsed, err := ParseProfile(canonical)
+	require.NoError(t, err)
+	assert.Equal(t, profile, parsed)
+	_, err = ParseProfile(append(canonical, '\n'))
+	require.ErrorContains(t, err, "not canonical")
+}
+
+func TestReferenceProfileAdvertisesOnlyEnforceableBroadSuppliedByteFormats(t *testing.T) {
+	profile, err := NewProfile(Config{
+		DeploymentID: "operator-unstructured-primary",
+		RuntimeID:    "sha256:" + strings.Repeat("b", 64),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []document.RenditionFormatCapability{
+		{MediaFamily: "ebook", MediaType: "application/epub+zip", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/jpeg", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "image", MediaType: "image/png", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "mail", MediaType: "message/rfc822", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "pdf", MediaType: "application/pdf", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "presentation", MediaType: "application/vnd.openxmlformats-officedocument.presentationml.presentation", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "spreadsheet", MediaType: "application/vnd.oasis.opendocument.spreadsheet", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "spreadsheet", MediaType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "spreadsheet", MediaType: "text/csv", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "structured", MediaType: "application/xml", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "text", MediaType: "text/markdown", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "text", MediaType: "text/plain", InputKind: document.RenditionInputOriginalFile},
+	}, profile.SupportedFormats)
+	assert.Equal(t, "exact_supplied_bytes", profile.Disclosure.Source)
+	assert.True(t, profile.Disclosure.DiscloseFilename)
+	assert.Equal(t, []document.EvidenceArtifactRole{document.EvidenceArtifactStructured},
+		profile.ArtifactPolicy.AllowedRoles)
+}
+
+func TestReferenceProfileBuildsStandardBridgeAndRejectsDrift(t *testing.T) {
+	profile, err := NewProfile(Config{
+		DeploymentID:      "operator-unstructured-primary",
+		RuntimeID:         "sha256:" + strings.Repeat("c", 64),
+		CredentialBinding: "unstructured-api",
+	})
+	require.NoError(t, err)
+
+	bridgeProfile, err := BridgeProfile(profile, "http://127.0.0.1:8421")
+	require.NoError(t, err)
+	assert.Equal(t, bridge.ContractVersion, profile.BridgeContract)
+	assert.Equal(t, profile.CredentialBinding, bridgeProfile.SecretBinding)
+	assert.Equal(t, document.RenditionTrustOperatorNetwork, bridgeProfile.Descriptor.TrustBoundary)
+	assert.Equal(t, profile.PolicyFingerprint, bridgeProfile.Descriptor.PolicyFingerprint)
+	assert.Equal(t, profile.SupportedFormats, bridgeProfile.Descriptor.SupportedFormats)
+	assert.Equal(t, time.Duration(profile.Limits.RequestTimeoutMillis)*time.Millisecond,
+		bridgeProfile.RequestTimeout)
+	assert.Equal(t, time.Duration(profile.Limits.TotalTimeoutMillis)*time.Millisecond,
+		bridgeProfile.TotalTimeout)
+	assert.Equal(t, time.Duration(profile.Limits.PollIntervalMillis)*time.Millisecond,
+		bridgeProfile.PollInterval)
+	assert.Equal(t, profile.Limits.MaxPollAttempts, bridgeProfile.MaxPollAttempts)
+	assert.Equal(t, profile.Limits.MaxResponseBytes, bridgeProfile.MaxResponseBytes)
+	_, err = bridge.New(bridgeProfile, staticSecretResolver{}, http.DefaultClient)
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		mutate func(*ProfileV1)
+		want   string
+	}{
+		{mutate: func(value *ProfileV1) { value.RuntimeID = "sha256:" + strings.Repeat("d", 64) }, want: "policy fingerprint does not match"},
+		{mutate: func(value *ProfileV1) { value.Limits.MaxDocumentBytes++ }, want: "limits differ"},
+	} {
+		drifted := profile
+		test.mutate(&drifted)
+		_, err := BridgeProfile(drifted, "http://127.0.0.1:8421")
+		require.ErrorContains(t, err, test.want)
+	}
+}
+
+func TestReferenceProfileRejectsUnpinnedIdentityAndUnboundedLimits(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+		want   string
+	}{
+		{name: "deployment", config: Config{RuntimeID: "sha256:" + strings.Repeat("e", 64)}, want: "deployment ID"},
+		{name: "runtime", config: Config{DeploymentID: "operator-unstructured-primary"}, want: "runtime ID"},
+		{name: "credential", config: Config{DeploymentID: "operator-unstructured-primary", RuntimeID: "runtime-v1", CredentialBinding: "https://secret.invalid"}, want: "credential binding"},
+		{name: "credential length", config: Config{DeploymentID: "operator-unstructured-primary", RuntimeID: "runtime-v1", CredentialBinding: strings.Repeat("c", 129)}, want: "credential binding"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewProfile(test.config)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+
+	profile, err := NewProfile(Config{DeploymentID: "operator-unstructured-primary", RuntimeID: "runtime-v1"})
+	require.NoError(t, err)
+	profile.Limits.MaxResponseBytes++
+	profile.PolicyFingerprint = ""
+	_, _, err = CanonicalProfile(profile)
+	require.ErrorContains(t, err, "limits")
+}
+
+type staticSecretResolver struct{}
+
+func (staticSecretResolver) ResolveSecret(context.Context, string) (string, error) {
+	return "synthetic-secret", nil
+}
+
+var _ bridge.SecretResolver = staticSecretResolver{}


### PR DESCRIPTION
## What changed

Docbank now has a hardened Unstructured bridge profile for the formats it can currently inspect and bound locally: PDF, PPTX, XLSX, ODS, CSV, EPUB, EML, XML, Markdown, plain text, JPEG, and PNG.

The profile pins deployment and runtime identity, exact-byte disclosure, finite source, evidence, Markdown, result, and artifact limits, and the one allowed structured artifact. The generic bridge enforces those ceilings before upload and across inline or separately fetched results. Provider acceptance alone never expands the advertised format set.

## Why

Unstructured supports a broad surface, but “the provider accepts it” is not enough to make the input or output safe durable authority. Docbank should expose the useful intersection it can inspect and bound today, then expand deliberately as local authority improves.

## Usage

For library or adapter deployment, build the canonical compatibility profile with `unstructured.NewProfile(config)`. The operator’s bridge implementation must match that identity and run behind `docbank-rendition/v1`; unsupported upstream formats do not enter the profile automatically.

This PR adds the reference profile, not daemon, API, or CLI registration. That application wiring is intentionally deferred to S1–S3.

Part of #176 (R15). Stacks on #206.
