### PR TITLE
[F10–E12 13/25] Add the isolated Trafilatura HTML provider

### DIFF
--- a/document/internal/providerutil/bounded_buffer.go
+++ b/document/internal/providerutil/bounded_buffer.go
@@ -1,0 +1,65 @@
+package providerutil
+
+import (
+	"slices"
+	"sync"
+)
+
+// BoundedBuffer retains at most limit bytes and calls onOverflow once when a
+// writer supplies more. It remains safe while command cancellation and output
+// collection run concurrently.
+type BoundedBuffer struct {
+	mu         sync.Mutex
+	data       []byte
+	limit      int64
+	exceeded   bool
+	overflow   sync.Once
+	onOverflow func()
+}
+
+// NewBoundedBuffer constructs a bounded process-output sink. Callers must
+// supply a positive limit.
+func NewBoundedBuffer(limit int64, onOverflow func()) *BoundedBuffer {
+	return &BoundedBuffer{limit: limit, onOverflow: onOverflow}
+}
+
+// Write retains the bounded prefix and consumes the full write. The overflow
+// callback owns stopping a producer that would otherwise continue writing.
+func (buffer *BoundedBuffer) Write(value []byte) (int, error) {
+	buffer.mu.Lock()
+	remaining := buffer.limit - int64(len(buffer.data))
+	if remaining > 0 {
+		kept := min(int64(len(value)), remaining)
+		buffer.data = append(buffer.data, value[:kept]...)
+	}
+	exceeded := int64(len(value)) > remaining
+	if exceeded {
+		buffer.exceeded = true
+	}
+	buffer.mu.Unlock()
+	if exceeded && buffer.onOverflow != nil {
+		buffer.overflow.Do(buffer.onOverflow)
+	}
+	return len(value), nil
+}
+
+// Bytes returns an unaliased copy of the retained prefix.
+func (buffer *BoundedBuffer) Bytes() []byte {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return slices.Clone(buffer.data)
+}
+
+// Len returns the number of retained bytes.
+func (buffer *BoundedBuffer) Len() int {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return len(buffer.data)
+}
+
+// Exceeded reports whether any supplied bytes exceeded the limit.
+func (buffer *BoundedBuffer) Exceeded() bool {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return buffer.exceeded
+}

--- a/document/internal/providerutil/provider.go
+++ b/document/internal/providerutil/provider.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -26,6 +27,18 @@ const (
 
 	maxConsecutiveEmptyReads = 100
 )
+
+// ValidOptionalFilename accepts an undisclosed filename or one safe basename
+// whose case-insensitive extension is in allowedExtensions.
+func ValidOptionalFilename(filename string, allowedExtensions ...string) bool {
+	if filename == "" {
+		return true
+	}
+	if filename != strings.TrimSpace(filename) || strings.ContainsAny(filename, "/\\:\x00") {
+		return false
+	}
+	return slices.Contains(allowedExtensions, strings.ToLower(filepath.Ext(filename)))
+}
 
 // Provider is one adapter's display name. It prefixes every classified
 // error cause the adapter produces and, lowercased, every constructor error.

--- a/document/internal/providerutil/provider_test.go
+++ b/document/internal/providerutil/provider_test.go
@@ -289,6 +289,15 @@ func TestValidateJobIDFitsReceiptTokens(t *testing.T) {
 	require.Error(t, testProvider.ValidatePathIdentifier("..", "job ID"))
 }
 
+func TestValidOptionalFilename(t *testing.T) {
+	for _, filename := range []string{"", "article.html", "ARTICLE.HTML"} {
+		assert.True(t, ValidOptionalFilename(filename, ".html"), filename)
+	}
+	for _, filename := range []string{"article.xhtml", " article.html", "path/article.html", "article.html\x00"} {
+		assert.False(t, ValidOptionalFilename(filename, ".html"), filename)
+	}
+}
+
 func newTestExecutor(server *httptest.Server) *Executor {
 	return &Executor{
 		Provider: testProvider, HTTP: server.Client(), Origin: server.URL,

--- a/document/internal/providerutil/python_process.go
+++ b/document/internal/providerutil/python_process.go
@@ -1,0 +1,51 @@
+package providerutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// PythonEnvironment returns the deterministic, ambient-credential-free
+// environment used by pinned Python bridge executables.
+func PythonEnvironment() []string {
+	environment := []string{
+		"LANG=C.UTF-8", "LC_ALL=C.UTF-8", "TZ=UTC", "PYTHONHASHSEED=0",
+		"PYTHONNOUSERSITE=1", "PYTHONDONTWRITEBYTECODE=1",
+	}
+	if runtime.GOOS == "windows" {
+		if systemRoot := os.Getenv("SystemRoot"); systemRoot != "" {
+			environment = append(environment, "SystemRoot="+systemRoot)
+		}
+	}
+	return environment
+}
+
+// IsPythonInterpreter reports whether path names a generic Python interpreter
+// instead of a pinned bridge executable.
+func IsPythonInterpreter(path string) bool {
+	name := strings.TrimSuffix(strings.ToLower(filepath.Base(path)), ".exe")
+	if name == "py" || name == "pyw" {
+		return true
+	}
+	for _, prefix := range []string{"python", "pypy"} {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		suffix := strings.TrimPrefix(name, prefix)
+		if prefix == "python" {
+			suffix = strings.TrimPrefix(suffix, "w")
+		}
+		if suffix == "" {
+			return true
+		}
+		for _, character := range suffix {
+			if (character < '0' || character > '9') && character != '.' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}

--- a/document/pymupdf/provider.go
+++ b/document/pymupdf/provider.go
@@ -42,10 +42,6 @@ const (
 	MaxTimeout = 30 * time.Minute
 )
 
-var (
-	errOutputTooLarge = errors.New("child output exceeds limit")
-)
-
 // Profile fixes one executable, immutable runtime identity, and all local bounds.
 type Profile struct {
 	Executable       string
@@ -74,7 +70,7 @@ func New(profile Profile) (*Provider, error) {
 	if !filepath.IsAbs(profile.Executable) || filepath.Clean(profile.Executable) != profile.Executable {
 		return nil, errors.New("pymupdf: executable must be an absolute clean path")
 	}
-	if pythonInterpreter(filepath.Base(profile.Executable)) {
+	if providerutil.IsPythonInterpreter(profile.Executable) {
 		return nil, errors.New("pymupdf: executable must not be a Python interpreter")
 	}
 	pinnedExecutable, err := providerutil.LoadPinnedExecutable(
@@ -196,22 +192,26 @@ func (provider *Provider) Render(
 	defer func() { _ = cleanupExecutable() }()
 
 	responseLimit := min(provider.maxResponseBytes, int64(authorization.MaxTotalResultBytes))
-	stdout := &boundedBuffer{limit: responseLimit}
+	var managedCommand *providerutil.ManagedCommand
+	stdout := providerutil.NewBoundedBuffer(responseLimit, func() {
+		if managedCommand != nil {
+			_ = managedCommand.Kill()
+		}
+	})
 	command := exec.CommandContext( //nolint:gosec // the operator pins one direct executable; source bytes never select it
 		operationCtx, executable, "--protocol", protocolVersion,
 	)
 	command.Dir = filepath.Dir(executable)
-	command.Env = cleanEnvironment()
+	command.Env = providerutil.PythonEnvironment()
 	command.Stdin = bytes.NewReader(source)
 	command.Stdout = stdout
 	command.Stderr = io.Discard
 	command.WaitDelay = childDrainWindow
-	managedCommand, err := providerutil.NewManagedCommand(command)
+	managedCommand, err = providerutil.NewManagedCommand(command)
 	if err != nil {
 		return document.RenditionResult{}, providerError(document.RenditionErrorTransient,
 			"PyMuPDF executable could not be isolated", err)
 	}
-	stdout.overflow = func() { _ = managedCommand.Kill() }
 	runErr := managedCommand.Run()
 	cleanupErr := cleanupExecutable()
 	if operationCtx.Err() != nil {
@@ -221,7 +221,7 @@ func (provider *Provider) Render(
 		return document.RenditionResult{}, providerError(document.RenditionErrorTransient,
 			"PyMuPDF executable cleanup failed", cleanupErr)
 	}
-	if stdout.exceeded {
+	if stdout.Exceeded() {
 		return document.RenditionResult{}, providerError(document.RenditionErrorMalformedEvidence,
 			"PyMuPDF output exceeds the configured byte limit", nil)
 	}
@@ -346,42 +346,6 @@ func parseResponse(
 	return wire, nil
 }
 
-type boundedBuffer struct {
-	data     bytes.Buffer
-	limit    int64
-	exceeded bool
-	overflow func()
-}
-
-func (buffer *boundedBuffer) Write(data []byte) (int, error) {
-	remaining := buffer.limit - int64(buffer.data.Len())
-	if remaining <= 0 {
-		buffer.failOverflow()
-		return 0, errOutputTooLarge
-	}
-	if int64(len(data)) > remaining {
-		written, _ := buffer.data.Write(data[:remaining])
-		buffer.failOverflow()
-		return written, errOutputTooLarge
-	}
-	written, _ := buffer.data.Write(data)
-	return written, nil
-}
-
-func (buffer *boundedBuffer) Bytes() []byte { return buffer.data.Bytes() }
-
-func (buffer *boundedBuffer) Len() int { return buffer.data.Len() }
-
-func (buffer *boundedBuffer) failOverflow() {
-	if buffer.exceeded {
-		return
-	}
-	buffer.exceeded = true
-	if buffer.overflow != nil {
-		buffer.overflow()
-	}
-}
-
 func (provider *Provider) contextError(parent context.Context, expiry bool, cause error) error {
 	if parent.Err() != nil {
 		return providerError(document.RenditionErrorCanceled, "PyMuPDF rendering canceled", parent.Err())
@@ -412,13 +376,6 @@ func providerError(code document.RenditionErrorCode, message string, cause error
 	return providerutil.ClassifiedError("PyMuPDF", code, message, 0, cause)
 }
 
-func cleanEnvironment() []string {
-	return []string{
-		"LANG=C.UTF-8", "LC_ALL=C.UTF-8", "TZ=UTC", "PYTHONHASHSEED=0",
-		"PYTHONNOUSERSITE=1", "PYTHONDONTWRITEBYTECODE=1",
-	}
-}
-
 func validateRuntimeIdentity(value string) error {
 	if value == "" || len(value) > 512 || value != strings.TrimSpace(value) || !utf8.ValidString(value) {
 		return errors.New("pymupdf: runtime identity must be non-empty bounded UTF-8")
@@ -441,29 +398,6 @@ func validExplanation(value string) bool {
 		}
 	}
 	return true
-}
-
-func pythonInterpreter(base string) bool {
-	name := strings.TrimSuffix(strings.ToLower(base), ".exe")
-	if name == "py" {
-		return true
-	}
-	for _, prefix := range []string{"python", "pypy"} {
-		if !strings.HasPrefix(name, prefix) {
-			continue
-		}
-		suffix := strings.TrimPrefix(name, prefix)
-		if suffix == "" {
-			return true
-		}
-		for _, char := range suffix {
-			if (char < '0' || char > '9') && char != '.' {
-				return false
-			}
-		}
-		return true
-	}
-	return false
 }
 
 var _ document.RenditionProvider = (*Provider)(nil)

--- a/document/trafilatura/doc.go
+++ b/document/trafilatura/doc.go
@@ -1,0 +1,18 @@
+// Package trafilatura renders supplied HTML bytes through an operator-pinned
+// local Trafilatura bridge.
+//
+// A nil Profile.Runner selects the production Linux runner. It executes a
+// digest-verified sealed copy of the bridge inside new user, network, PID, and
+// mount namespaces. Landlock hides host files outside a read-only system-runtime
+// allowlist, while private mounts provide /proc and temporary storage. The runner
+// bounds stdout and kills the PID-namespace init on cancellation or overflow so
+// the kernel reaps every descendant. It fails closed when the host disables the
+// required namespace or Landlock controls. The native runner is not available on
+// macOS or Windows; callers there must inject a separately audited IsolatedRunner
+// or construction fails before any child can launch.
+//
+// An injected runner is an explicit trusted deployment boundary. Its immutable
+// identity and exact per-run attestation are checked, but a dishonest runner can
+// still lie. Deployments using one must audit and pin its platform-specific
+// isolation implementation.
+package trafilatura

--- a/document/trafilatura/native_launcher_linux.go
+++ b/document/trafilatura/native_launcher_linux.go
@@ -1,0 +1,287 @@
+//go:build linux
+
+package trafilatura
+
+import (
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	nativeLauncherMarker          = "--docbank-internal-trafilatura-launch-v3"
+	nativeLauncherExecutableFD    = 3
+	nativeLauncherControlFD       = 4
+	nativeLauncherStatusFD        = 5
+	nativeLauncherTokenBytes      = 32
+	nativeLauncherFailureExitCode = 125
+	nativeLauncherReadyStatus     = byte(1)
+	nativeLauncherFailureStatus   = byte(2)
+	nativeX32SyscallBit           = uint32(0x40000000)
+	nativeMinimumLandlockABI      = uintptr(3)
+)
+
+const nativeLandlockBaseAccess = uint64(
+	unix.LANDLOCK_ACCESS_FS_EXECUTE |
+		unix.LANDLOCK_ACCESS_FS_WRITE_FILE |
+		unix.LANDLOCK_ACCESS_FS_READ_FILE |
+		unix.LANDLOCK_ACCESS_FS_READ_DIR |
+		unix.LANDLOCK_ACCESS_FS_REMOVE_DIR |
+		unix.LANDLOCK_ACCESS_FS_REMOVE_FILE |
+		unix.LANDLOCK_ACCESS_FS_MAKE_CHAR |
+		unix.LANDLOCK_ACCESS_FS_MAKE_DIR |
+		unix.LANDLOCK_ACCESS_FS_MAKE_REG |
+		unix.LANDLOCK_ACCESS_FS_MAKE_SOCK |
+		unix.LANDLOCK_ACCESS_FS_MAKE_FIFO |
+		unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+		unix.LANDLOCK_ACCESS_FS_MAKE_SYM |
+		unix.LANDLOCK_ACCESS_FS_REFER |
+		unix.LANDLOCK_ACCESS_FS_TRUNCATE)
+
+func init() {
+	executable, authenticated := authenticatedNativeLaunch(os.Args, nativeLauncherControlFD)
+	if !authenticated {
+		return
+	}
+	if runNativeLauncher(executable, nativeLauncherStatusFD) != nil {
+		_ = writeNativeLauncherStatus(nativeLauncherStatusFD, nativeLauncherFailureStatus)
+		os.Exit(nativeLauncherFailureExitCode)
+	}
+	_ = writeNativeLauncherStatus(nativeLauncherStatusFD, nativeLauncherFailureStatus)
+	os.Exit(nativeLauncherFailureExitCode)
+}
+
+func authenticatedNativeLaunch(arguments []string, controlFD int) (string, bool) {
+	if len(arguments) != 4 || arguments[1] != nativeLauncherMarker ||
+		!filepath.IsAbs(arguments[3]) || filepath.Clean(arguments[3]) != arguments[3] {
+		return "", false
+	}
+	want, err := hex.DecodeString(arguments[2])
+	if err != nil || len(want) != nativeLauncherTokenBytes {
+		return "", false
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(controlFD, &stat); err != nil ||
+		stat.Mode&unix.S_IFMT != unix.S_IFREG || stat.Size != nativeLauncherTokenBytes {
+		return "", false
+	}
+	seals := unix.F_SEAL_WRITE | unix.F_SEAL_GROW | unix.F_SEAL_SHRINK | unix.F_SEAL_SEAL
+	applied, err := unix.FcntlInt(uintptr(controlFD), unix.F_GET_SEALS, 0)
+	if err != nil || applied&seals != seals {
+		return "", false
+	}
+	got := make([]byte, nativeLauncherTokenBytes)
+	read, err := unix.Pread(controlFD, got, 0)
+	if err != nil || read != len(got) || subtle.ConstantTimeCompare(got, want) != 1 {
+		return "", false
+	}
+	return arguments[3], true
+}
+
+func runNativeLauncher(executable string, statusFD int) error {
+	if err := unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		return fmt.Errorf("make mount propagation private: %w", err)
+	}
+	if err := unix.MountSetattr(unix.AT_FDCWD, "/", unix.AT_RECURSIVE,
+		&unix.MountAttr{Attr_set: unix.MOUNT_ATTR_RDONLY}); err != nil {
+		return fmt.Errorf("make inherited host mounts read-only: %w", err)
+	}
+	if err := unix.Mount("tmpfs", "/tmp", "tmpfs",
+		unix.MS_NOSUID|unix.MS_NODEV|unix.MS_NOEXEC, "mode=1777,size=256m"); err != nil {
+		return fmt.Errorf("mount private temporary directory: %w", err)
+	}
+	if err := unix.Mount("proc", "/proc", "proc",
+		unix.MS_NOSUID|unix.MS_NODEV|unix.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("mount private proc: %w", err)
+	}
+	if err := unix.Chdir("/tmp"); err != nil {
+		return fmt.Errorf("enter private working directory: %w", err)
+	}
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("set no-new-privileges: %w", err)
+	}
+	if err := installNativeFilesystemLandlock(); err != nil {
+		return err
+	}
+	if err := installNativeNetworkSeccomp(); err != nil {
+		return err
+	}
+	if err := unix.Close(nativeLauncherControlFD); err != nil {
+		return fmt.Errorf("close launcher control: %w", err)
+	}
+	unix.CloseOnExec(nativeLauncherExecutableFD)
+	if err := writeNativeLauncherStatus(statusFD, nativeLauncherReadyStatus); err != nil {
+		return err
+	}
+	unix.CloseOnExec(statusFD)
+	if err := unix.Exec("/proc/self/fd/3", []string{executable, "--protocol", protocolVersion}, cleanEnvironment()); err != nil {
+		return fmt.Errorf("execute sealed bridge: %w", err)
+	}
+	return nil
+}
+
+func installNativeFilesystemLandlock() error {
+	version, _, errno := unix.Syscall6(
+		unix.SYS_LANDLOCK_CREATE_RULESET, 0, 0, unix.LANDLOCK_CREATE_RULESET_VERSION, 0, 0, 0,
+	)
+	if errno != 0 {
+		return fmt.Errorf("query Landlock filesystem ABI: %w", errno)
+	}
+	if version < nativeMinimumLandlockABI {
+		return fmt.Errorf("require Landlock filesystem ABI %d, host provides %d",
+			nativeMinimumLandlockABI, version)
+	}
+	handledAccess := nativeLandlockBaseAccess
+	if version >= 5 {
+		handledAccess |= unix.LANDLOCK_ACCESS_FS_IOCTL_DEV
+	}
+	rulesetAttribute := unix.LandlockRulesetAttr{Access_fs: handledAccess}
+	rulesetFD, _, errno := unix.Syscall6(
+		unix.SYS_LANDLOCK_CREATE_RULESET,
+		//nolint:gosec // Landlock requires a pointer to this fixed kernel ABI structure.
+		uintptr(unsafe.Pointer(&rulesetAttribute)), unsafe.Sizeof(rulesetAttribute), 0, 0, 0, 0,
+	)
+	if errno != 0 {
+		return fmt.Errorf("create Landlock filesystem ruleset: %w", errno)
+	}
+	defer func() { _ = unix.Close(int(rulesetFD)) }()
+
+	readOnly := uint64(unix.LANDLOCK_ACCESS_FS_EXECUTE |
+		unix.LANDLOCK_ACCESS_FS_READ_FILE | unix.LANDLOCK_ACCESS_FS_READ_DIR)
+	for _, path := range []string{"/usr", "/lib", "/lib64", "/bin", "/proc"} {
+		if err := addNativeLandlockPath(rulesetFD, path, readOnly, true); err != nil {
+			return err
+		}
+	}
+	for _, path := range []string{"/etc/ld.so.cache", "/etc/localtime"} {
+		if err := addNativeLandlockPath(rulesetFD, path, unix.LANDLOCK_ACCESS_FS_READ_FILE, true); err != nil {
+			return err
+		}
+	}
+	for path, access := range map[string]uint64{
+		"/dev/null":    unix.LANDLOCK_ACCESS_FS_READ_FILE | unix.LANDLOCK_ACCESS_FS_WRITE_FILE,
+		"/dev/urandom": unix.LANDLOCK_ACCESS_FS_READ_FILE,
+		"/dev/zero":    unix.LANDLOCK_ACCESS_FS_READ_FILE,
+	} {
+		if err := addNativeLandlockPath(rulesetFD, path, access, true); err != nil {
+			return err
+		}
+	}
+	privateTemporaryAccess := handledAccess &^ (unix.LANDLOCK_ACCESS_FS_EXECUTE | unix.LANDLOCK_ACCESS_FS_IOCTL_DEV)
+	if err := addNativeLandlockPath(rulesetFD, "/tmp", privateTemporaryAccess, false); err != nil {
+		return err
+	}
+	if _, _, errno := unix.Syscall(unix.SYS_LANDLOCK_RESTRICT_SELF, rulesetFD, 0, 0); errno != 0 {
+		return fmt.Errorf("enforce Landlock filesystem ruleset: %w", errno)
+	}
+	return nil
+}
+
+func addNativeLandlockPath(rulesetFD uintptr, path string, allowedAccess uint64, optional bool) error {
+	pathFD, err := unix.Open(path, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if optional && errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open Landlock path %q: %w", path, err)
+	}
+	defer func() { _ = unix.Close(pathFD) }()
+	pathAttribute := unix.LandlockPathBeneathAttr{
+		Allowed_access: allowedAccess,
+		Parent_fd:      int32(pathFD), //nolint:gosec // Linux file descriptors fit the kernel's signed 32-bit ABI field.
+	}
+	if _, _, errno := unix.Syscall6(
+		unix.SYS_LANDLOCK_ADD_RULE, rulesetFD, unix.LANDLOCK_RULE_PATH_BENEATH,
+		//nolint:gosec // Landlock requires a pointer to this fixed kernel ABI structure.
+		uintptr(unsafe.Pointer(&pathAttribute)), 0, 0, 0,
+	); errno != 0 {
+		return fmt.Errorf("add Landlock path %q: %w", path, errno)
+	}
+	return nil
+}
+
+func writeNativeLauncherStatus(fd int, status byte) error {
+	written, err := unix.Write(fd, []byte{status})
+	if err != nil {
+		return fmt.Errorf("write launcher status: %w", err)
+	}
+	if written != 1 {
+		return fmt.Errorf("write launcher status: wrote %d bytes", written)
+	}
+	return nil
+}
+
+func installNativeNetworkSeccomp() error {
+	architecture, ok := nativeAuditArchitecture()
+	if !ok {
+		return unix.ENOTSUP
+	}
+	filters, err := buildNativeNetworkSeccompFilters(architecture)
+	if err != nil {
+		return err
+	}
+	program := unix.SockFprog{Len: uint16(len(filters)), Filter: &filters[0]} //nolint:gosec // filter count is fixed and bounded below uint16
+	//nolint:gosec // SockFprog requires the audited kernel ABI pointer for the bounded filter slice.
+	_, _, errno := unix.Syscall(unix.SYS_SECCOMP, unix.SECCOMP_SET_MODE_FILTER,
+		unix.SECCOMP_FILTER_FLAG_TSYNC, uintptr(unsafe.Pointer(&program)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func buildNativeNetworkSeccompFilters(architecture uint32) ([]unix.SockFilter, error) {
+	if architecture != unix.AUDIT_ARCH_X86_64 && architecture != unix.AUDIT_ARCH_AARCH64 {
+		return nil, unix.ENOTSUP
+	}
+	filters := []unix.SockFilter{
+		{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: 4},
+		{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 1, K: architecture},
+		{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_KILL_PROCESS},
+		{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: 0},
+	}
+	if architecture == unix.AUDIT_ARCH_X86_64 {
+		filters = append(filters,
+			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JSET | unix.BPF_K, Jf: 1, K: nativeX32SyscallBit},
+			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM)},
+		)
+	}
+	for _, syscallNumber := range nativeBlockedNetworkSyscalls() {
+		filters = append(filters,
+			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: 1, K: uint32(syscallNumber)}, //nolint:gosec // Linux syscall numbers are nonnegative uint32 values
+			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM)},
+		)
+	}
+	filters = append(filters, unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ALLOW})
+	return filters, nil
+}
+
+func nativeAuditArchitecture() (uint32, bool) {
+	switch runtime.GOARCH {
+	case "amd64":
+		return unix.AUDIT_ARCH_X86_64, true
+	case "arm64":
+		return unix.AUDIT_ARCH_AARCH64, true
+	default:
+		return 0, false
+	}
+}
+
+func nativeBlockedNetworkSyscalls() []uintptr {
+	return []uintptr{
+		unix.SYS_SOCKET, unix.SYS_SOCKETPAIR,
+		unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_LISTEN, unix.SYS_ACCEPT, unix.SYS_ACCEPT4,
+		unix.SYS_SENDTO, unix.SYS_SENDMSG, unix.SYS_SENDMMSG,
+		unix.SYS_RECVFROM, unix.SYS_RECVMSG, unix.SYS_RECVMMSG,
+		unix.SYS_SHUTDOWN, unix.SYS_GETSOCKNAME, unix.SYS_GETPEERNAME,
+		unix.SYS_SETSOCKOPT, unix.SYS_GETSOCKOPT,
+		unix.SYS_IO_URING_SETUP, unix.SYS_IO_URING_ENTER, unix.SYS_IO_URING_REGISTER,
+	}
+}

--- a/document/trafilatura/native_runner_linux.go
+++ b/document/trafilatura/native_runner_linux.go
@@ -1,0 +1,249 @@
+//go:build linux
+
+package trafilatura
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"go.kenn.io/docbank/document/internal/providerutil"
+)
+
+const (
+	nativeRunnerIdentity   = "sha256:afc3202c30a20fbb62fe6b7a4ccf282dea0ba16e40d22e7bdfa3f1d28819db16"
+	nativeChildDrainWindow = 250 * time.Millisecond
+)
+
+type nativeRunner struct{}
+
+func newNativeRunner() (IsolatedRunner, error) {
+	return nativeRunner{}, nil
+}
+
+func (nativeRunner) Identity() string {
+	return nativeRunnerIdentity
+}
+
+func (runner nativeRunner) Run(
+	ctx context.Context, request IsolatedRunRequest,
+) (IsolatedRunResult, error) {
+	if err := validateNativeRequest(request); err != nil {
+		return IsolatedRunResult{}, ErrIsolationUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return IsolatedRunResult{}, errors.Join(errNativeCanceledBeforeLaunch, err)
+	}
+	executable, err := openVerifiedExecutable(ctx, request)
+	if err != nil {
+		if ctx.Err() != nil {
+			return IsolatedRunResult{}, errors.Join(errNativeCanceledBeforeLaunch, ctx.Err())
+		}
+		return IsolatedRunResult{}, ErrIsolationUnavailable
+	}
+	defer func() { _ = executable.Close() }()
+	control, launchToken, err := openNativeLaunchControl()
+	if err != nil {
+		return IsolatedRunResult{}, ErrIsolationUnavailable
+	}
+	defer func() { _ = control.Close() }()
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		return IsolatedRunResult{}, ErrIsolationUnavailable
+	}
+	defer func() { _ = statusReader.Close() }()
+	defer func() { _ = statusWriter.Close() }()
+	if err := ctx.Err(); err != nil {
+		return IsolatedRunResult{}, errors.Join(errNativeCanceledBeforeLaunch, err)
+	}
+
+	var command *exec.Cmd
+	output := providerutil.NewBoundedBuffer(request.MaxStdoutBytes, func() {
+		if command != nil && command.Process != nil {
+			_ = command.Process.Kill()
+		}
+	})
+	command = exec.Command( //nolint:gosec // request validation fixes the executable fd and complete argument vector
+		"/proc/self/exe", nativeLauncherMarker, launchToken, request.Executable,
+	)
+	command.Dir = request.Directory
+	command.Env = slices.Clone(request.Environment)
+	command.Stdin = bytes.NewReader(request.Stdin)
+	command.Stdout = output
+	command.Stderr = io.Discard
+	command.ExtraFiles = []*os.File{executable, control, statusWriter}
+	command.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWUSER | syscall.CLONE_NEWNET |
+			syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
+		UidMappings:                []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}},
+		GidMappings:                []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}},
+		GidMappingsEnableSetgroups: false,
+		Pdeathsig:                  syscall.SIGKILL,
+	}
+	command.WaitDelay = nativeChildDrainWindow
+	if err := command.Start(); err != nil {
+		return IsolatedRunResult{}, ErrIsolationUnavailable
+	}
+	_ = statusWriter.Close()
+
+	waited := make(chan error, 1)
+	go func() { waited <- command.Wait() }()
+	launcherStatus := make(chan bool, 1)
+	go func() { launcherStatus <- nativeLauncherFailed(statusReader) }()
+	var runErr error
+	select {
+	case runErr = <-waited:
+	case <-ctx.Done():
+		_ = command.Process.Kill()
+		runErr = <-waited
+	}
+	launcherFailed := <-launcherStatus
+	result := IsolatedRunResult{
+		Stdout: output.Bytes(), Attestation: nativeAttestation(request),
+	}
+	if output.Exceeded() {
+		return result, ErrChildOutputTooLarge
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if err := classifyNativeRunError(runErr, launcherFailed); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func nativeLauncherFailed(reader io.Reader) bool {
+	status, err := io.ReadAll(io.LimitReader(reader, 3))
+	return err != nil || !bytes.Equal(status, []byte{nativeLauncherReadyStatus})
+}
+
+func classifyNativeRunError(runErr error, launcherFailed bool) error {
+	if launcherFailed {
+		return ErrIsolationUnavailable
+	}
+	if runErr != nil {
+		return ErrChildFailed
+	}
+	return nil
+}
+
+func openNativeLaunchControl() (*os.File, string, error) {
+	token := make([]byte, nativeLauncherTokenBytes)
+	if _, err := rand.Read(token); err != nil {
+		return nil, "", fmt.Errorf("create launcher token: %w", err)
+	}
+	fd, err := unix.MemfdCreate("docbank-trafilatura-launch", unix.MFD_CLOEXEC|unix.MFD_ALLOW_SEALING)
+	if err != nil {
+		return nil, "", fmt.Errorf("create launcher control: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), "docbank-trafilatura-launch")
+	valid := false
+	defer func() {
+		if !valid {
+			_ = file.Close()
+		}
+	}()
+	if _, err := file.Write(token); err != nil {
+		return nil, "", err
+	}
+	seals := unix.F_SEAL_WRITE | unix.F_SEAL_GROW | unix.F_SEAL_SHRINK | unix.F_SEAL_SEAL
+	if _, err := unix.FcntlInt(file.Fd(), unix.F_ADD_SEALS, seals); err != nil {
+		return nil, "", fmt.Errorf("seal launcher control: %w", err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, "", err
+	}
+	valid = true
+	return file, hex.EncodeToString(token), nil
+}
+
+func validateNativeRequest(request IsolatedRunRequest) error {
+	stdinDigest := sha256.Sum256(request.Stdin)
+	if !filepath.IsAbs(request.Executable) || filepath.Clean(request.Executable) != request.Executable ||
+		request.Directory != filepath.Dir(request.Executable) ||
+		!slices.Equal(request.Arguments, []string{"--protocol", protocolVersion}) ||
+		!slices.Equal(request.Environment, cleanEnvironment()) ||
+		request.StdinSHA256 != hex.EncodeToString(stdinDigest[:]) ||
+		request.MaxStdoutBytes <= 0 || request.MaxStdoutBytes > MaxResponseBytes ||
+		!request.Requirements.NetworkDisabled || !request.Requirements.KillProcessTree ||
+		!request.Requirements.VerifyExecutableSHA256 || !request.Requirements.FilesystemIsolated ||
+		request.PolicyFingerprint != isolationRequestPolicyFingerprint(nativeRunnerIdentity, request) {
+		return errors.New("native isolation request is outside the fixed policy")
+	}
+	if err := validateSHA256(request.ExecutableSHA256, "executable SHA-256"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func openVerifiedExecutable(ctx context.Context, request IsolatedRunRequest) (*os.File, error) {
+	source, err := os.Open(request.Executable)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = source.Close() }()
+	info, err := source.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > MaxExecutableBytes {
+		return nil, errors.New("executable identity is outside the supported bound")
+	}
+	fd, err := unix.MemfdCreate("docbank-trafilatura", unix.MFD_CLOEXEC|unix.MFD_ALLOW_SEALING)
+	if err != nil {
+		return nil, fmt.Errorf("create sealed executable: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), "docbank-trafilatura")
+	valid := false
+	defer func() {
+		if !valid {
+			_ = file.Close()
+		}
+	}()
+	hash := sha256.New()
+	written, err := io.Copy(
+		io.MultiWriter(file, hash),
+		io.LimitReader(contextReader{ctx: ctx, reader: source}, MaxExecutableBytes+1),
+	)
+	if err != nil || written != info.Size() || hex.EncodeToString(hash.Sum(nil)) != request.ExecutableSHA256 {
+		return nil, errors.New("executable identity changed")
+	}
+	if err := unix.Fchmod(fd, 0o500); err != nil {
+		return nil, fmt.Errorf("make sealed executable runnable: %w", err)
+	}
+	seals := unix.F_SEAL_WRITE | unix.F_SEAL_GROW | unix.F_SEAL_SHRINK | unix.F_SEAL_SEAL
+	if _, err := unix.FcntlInt(file.Fd(), unix.F_ADD_SEALS, seals); err != nil {
+		return nil, fmt.Errorf("seal executable content: %w", err)
+	}
+	applied, err := unix.FcntlInt(file.Fd(), unix.F_GET_SEALS, 0)
+	if err != nil || applied&seals != seals {
+		return nil, errors.New("executable content could not be sealed")
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	valid = true
+	return file, nil
+}
+
+func nativeAttestation(request IsolatedRunRequest) IsolationAttestation {
+	return IsolationAttestation{
+		RunnerIdentity: nativeRunnerIdentity, PolicyFingerprint: request.PolicyFingerprint,
+		ExecutableSHA256: request.ExecutableSHA256, StdinSHA256: request.StdinSHA256,
+		NetworkDisabled: true, ProcessTreeContained: true, DigestVerifiedLaunch: true,
+		FilesystemIsolated: true,
+	}
+}
+
+var _ IsolatedRunner = nativeRunner{}

--- a/document/trafilatura/native_runner_linux.go
+++ b/document/trafilatura/native_runner_linux.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"debug/elf"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -29,6 +30,15 @@ const (
 )
 
 type nativeRunner struct{}
+
+func validateNativeExecutable(path string) error {
+	executable, err := elf.Open(path)
+	if err != nil {
+		return errors.New("trafilatura: native runner requires an ELF executable")
+	}
+	_ = executable.Close()
+	return nil
+}
 
 func newNativeRunner() (IsolatedRunner, error) {
 	return nativeRunner{}, nil

--- a/document/trafilatura/native_runner_linux_test.go
+++ b/document/trafilatura/native_runner_linux_test.go
@@ -29,6 +29,16 @@ type nativeRunOutcome struct {
 	err    error
 }
 
+func TestNewRejectsScriptWithNativeRunner(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "trafilatura-bridge")
+	require.NoError(t, os.WriteFile(executable, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+	profile := testProfile(t, executable, time.Second, 1<<20)
+	profile.Runner = nil
+
+	_, err := New(profile)
+	require.ErrorContains(t, err, "native runner requires an ELF executable")
+}
+
 func TestNativeRunnerUsesExactStdinArgumentsAndCleanEnvironment(t *testing.T) {
 	executable := buildIsolatedHelper(t, "echo", "")
 	runner, err := newNativeRunner()
@@ -343,7 +353,7 @@ func TestVerifiedExecutableContentCannotChangeAfterDigestVerification(t *testing
 }
 
 func TestNewUsesNativeRunnerWhenNoneIsInjected(t *testing.T) {
-	profile := testProfile(t, helperExecutable(t, "complete"), time.Second, 1<<20)
+	profile := testProfile(t, buildIsolatedHelper(t, "echo", ""), time.Second, 1<<20)
 	profile.Runner = nil
 
 	provider, err := New(profile)

--- a/document/trafilatura/native_runner_linux_test.go
+++ b/document/trafilatura/native_runner_linux_test.go
@@ -1,0 +1,427 @@
+//go:build linux
+
+package trafilatura
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+type nativeRunOutcome struct {
+	result IsolatedRunResult
+	err    error
+}
+
+func TestNativeRunnerUsesExactStdinArgumentsAndCleanEnvironment(t *testing.T) {
+	executable := buildIsolatedHelper(t, "echo", "")
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	stdin := []byte("exact supplied bytes\x00remain data, never arguments")
+	request := nativeTestRequest(t, runner, executable, stdin, 1<<20)
+
+	result, err := runner.Run(t.Context(), request)
+	skipUnavailableNativeIsolation(t, err)
+	require.NoError(t, err)
+
+	var response struct {
+		Arguments   []string `json:"arguments"`
+		Environment []string `json:"environment"`
+		StdinSHA256 string   `json:"stdin_sha256"`
+	}
+	require.NoError(t, json.Unmarshal(result.Stdout, &response))
+	digest := sha256.Sum256(stdin)
+	assert.Equal(t, hex.EncodeToString(digest[:]), response.StdinSHA256)
+	assert.Equal(t, []string{"--protocol", protocolVersion}, response.Arguments)
+	assert.Equal(t, cleanEnvironment(), response.Environment)
+	assert.Equal(t, nativeRunnerIdentity, result.Attestation.RunnerIdentity)
+	assert.True(t, result.Attestation.NetworkDisabled)
+	assert.True(t, result.Attestation.ProcessTreeContained)
+	assert.True(t, result.Attestation.DigestVerifiedLaunch)
+	assert.True(t, result.Attestation.FilesystemIsolated)
+}
+
+func TestNativeRunnerDeniesLoopbackNetworkAccess(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+	executable := buildIsolatedHelper(t, "network", listener.Addr().String())
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("network probe"), 1<<20)
+
+	result, err := runner.Run(t.Context(), request)
+	skipUnavailableNativeIsolation(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, "denied", string(result.Stdout))
+}
+
+func TestNativeRunnerDeniesHostPathnameUnixSocketAccess(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "host.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+	executable := buildIsolatedHelper(t, "unix-network", socketPath)
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("unix network probe"), 1<<20)
+
+	result, err := runner.Run(t.Context(), request)
+	skipUnavailableNativeIsolation(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, "denied", string(result.Stdout))
+}
+
+func TestNativeRunnerCannotReadOrModifyHostFiles(t *testing.T) {
+	// The target must remain on a host mount because the sandbox replaces /tmp.
+	hostDirectory, err := os.MkdirTemp(".", ".trafilatura-host-") //nolint:usetesting
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(hostDirectory)) })
+	hostPath, err := filepath.Abs(filepath.Join(hostDirectory, "host-only.txt"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(hostPath, []byte("host-only"), 0o600))
+	before, err := os.Stat(hostPath)
+	require.NoError(t, err)
+	executable := buildIsolatedHelper(t, "host-file", hostPath)
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("filesystem probe"), 1<<20)
+
+	result, err := runner.Run(t.Context(), request)
+	skipUnavailableNativeIsolation(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, "denied", string(result.Stdout))
+	content, err := os.ReadFile(hostPath)
+	require.NoError(t, err)
+	assert.Equal(t, "host-only", string(content))
+	after, err := os.Stat(hostPath)
+	require.NoError(t, err)
+	assert.Equal(t, before.Mode(), after.Mode())
+	assert.Equal(t, before.ModTime(), after.ModTime())
+}
+
+func TestNativeFilesystemLandlockDeniesHostFileAccess(t *testing.T) {
+	const targetEnvironment = "DOCBANK_TEST_TRAFILATURA_HOST_FILE"
+	if target := os.Getenv(targetEnvironment); target != "" {
+		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+			os.Exit(70)
+		}
+		if err := installNativeFilesystemLandlock(); err != nil {
+			_, _ = fmt.Fprint(os.Stderr, err)
+			os.Exit(77)
+		}
+		if _, err := os.ReadFile(target); err == nil {
+			os.Exit(71)
+		}
+		if err := os.WriteFile(target, []byte("modified"), 0o600); err == nil {
+			os.Exit(72)
+		}
+		if err := exec.Command("/bin/true").Run(); err != nil {
+			os.Exit(73)
+		}
+		os.Exit(0)
+	}
+
+	// The target must be outside the /tmp path explicitly allowed to the subprocess.
+	hostDirectory, err := os.MkdirTemp(".", ".trafilatura-landlock-") //nolint:usetesting
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(hostDirectory)) })
+	hostPath, err := filepath.Abs(filepath.Join(hostDirectory, "host-only.txt"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(hostPath, []byte("host-only"), 0o600))
+	command := exec.Command( //nolint:gosec // os.Args[0] is the trusted current test executable
+		os.Args[0], "-test.run=^TestNativeFilesystemLandlockDeniesHostFileAccess$",
+	)
+	command.Env = append(os.Environ(), targetEnvironment+"="+hostPath)
+	output, err := command.CombinedOutput()
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() == 77 {
+		t.Skipf("Landlock filesystem isolation unavailable: %s", output)
+	}
+	require.NoError(t, err, "%s", output)
+	content, err := os.ReadFile(hostPath)
+	require.NoError(t, err)
+	assert.Equal(t, "host-only", string(content))
+}
+
+func TestNativeSeccompDeniesPathnameUnixSockets(t *testing.T) {
+	const helperEnvironment = "DOCBANK_TEST_TRAFILATURA_SECCOMP"
+	if socketPath := os.Getenv(helperEnvironment); socketPath != "" {
+		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+			os.Exit(10)
+		}
+		if err := installNativeNetworkSeccomp(); err != nil {
+			os.Exit(11)
+		}
+		connection, err := net.DialTimeout("unix", socketPath, time.Second)
+		if connection != nil {
+			_ = connection.Close()
+		}
+		if !errors.Is(err, unix.EPERM) {
+			os.Exit(12)
+		}
+		os.Exit(0)
+	}
+
+	socketPath := filepath.Join(t.TempDir(), "seccomp.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+	connection, err := net.DialTimeout("unix", socketPath, time.Second)
+	require.NoError(t, err, "the host listener must be reachable before filtering")
+	require.NoError(t, connection.Close())
+	command := exec.Command( //nolint:gosec // os.Args[0] is the trusted current test executable
+		os.Args[0], "-test.run=^TestNativeSeccompDeniesPathnameUnixSockets$",
+	)
+	command.Env = append(os.Environ(), helperEnvironment+"="+socketPath)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+}
+
+func TestNativeSeccompFilterDeniesX32ABI(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("x32 ABI exists only on amd64")
+	}
+	filters, err := buildNativeNetworkSeccompFilters(unix.AUDIT_ARCH_X86_64)
+	require.NoError(t, err)
+	denied := unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM)
+	for name, syscallNumber := range map[string]uint32{
+		"socket":   unix.SYS_SOCKET,
+		"connect":  unix.SYS_CONNECT,
+		"io_uring": unix.SYS_IO_URING_SETUP,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, denied, evaluateNativeSeccomp(t, filters, syscallNumber))
+			assert.Equal(t, denied, evaluateNativeSeccomp(t, filters, syscallNumber|nativeX32SyscallBit))
+		})
+	}
+	assert.Equal(t, uint32(unix.SECCOMP_RET_ALLOW),
+		evaluateNativeSeccomp(t, filters, unix.SYS_GETPID))
+	assert.Equal(t, denied,
+		evaluateNativeSeccomp(t, filters, unix.SYS_GETPID|nativeX32SyscallBit))
+}
+
+func TestNativeLauncherRequiresSealedMatchingInheritedControl(t *testing.T) {
+	control, token, err := openNativeLaunchControl()
+	require.NoError(t, err)
+	defer func() { _ = control.Close() }()
+	arguments := []string{"/proc/self/exe", nativeLauncherMarker, token, "/opt/trafilatura-bridge"}
+
+	executable, authenticated := authenticatedNativeLaunch(arguments, int(control.Fd()))
+	assert.True(t, authenticated)
+	assert.Equal(t, "/opt/trafilatura-bridge", executable)
+
+	_, authenticated = authenticatedNativeLaunch(arguments, -1)
+	assert.False(t, authenticated)
+	arguments[2] = strings.Repeat("0", nativeLauncherTokenBytes*2)
+	_, authenticated = authenticatedNativeLaunch(arguments, int(control.Fd()))
+	assert.False(t, authenticated)
+}
+
+func TestNativeRunnerCancellationReapsDescendantProcessTree(t *testing.T) {
+	executable := buildIsolatedHelper(t, "descendant", "")
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("descendant probe"), 1<<20)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	finished := make(chan nativeRunOutcome, 1)
+	started := time.Now()
+	go func() {
+		result, runErr := runner.Run(ctx, request)
+		finished <- nativeRunOutcome{result: result, err: runErr}
+	}()
+
+	select {
+	case outcome := <-finished:
+		skipUnavailableNativeIsolation(t, outcome.err)
+		require.FailNow(t, "isolated runner exited before cancellation", "%v", outcome.err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	cancel()
+	outcome := <-finished
+	require.ErrorIs(t, outcome.err, context.Canceled)
+	assert.Less(t, time.Since(started), 2*time.Second)
+	assert.True(t, outcome.result.Attestation.ProcessTreeContained)
+	assert.Contains(t, string(outcome.result.Stdout), "spawned")
+	assert.Contains(t, string(outcome.result.Stdout), "descendant-ready")
+}
+
+func TestNativeRunnerTerminatesPromptlyOnStdoutOverflow(t *testing.T) {
+	executable := buildIsolatedHelper(t, "overflow", "")
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("overflow probe"), 1024)
+	started := time.Now()
+
+	result, err := runner.Run(t.Context(), request)
+	skipUnavailableNativeIsolation(t, err)
+	require.ErrorIs(t, err, ErrChildOutputTooLarge)
+	assert.Less(t, time.Since(started), 2*time.Second)
+	assert.LessOrEqual(t, int64(len(result.Stdout)), request.MaxStdoutBytes)
+}
+
+func TestNativeRunnerDoesNotMisclassifyBridgeExit125AsLauncherFailure(t *testing.T) {
+	executable := buildIsolatedHelper(t, "exit-125", "")
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("exit probe"), 1<<20)
+
+	_, err = runner.Run(t.Context(), request)
+	skipUnavailableNativeIsolation(t, err)
+	require.ErrorIs(t, err, ErrChildFailed)
+	require.NotErrorIs(t, err, ErrIsolationUnavailable)
+}
+
+func TestNativeRunErrorClassificationUsesOutOfBandLauncherStatus(t *testing.T) {
+	runErr := exec.Command("/bin/sh", "-c", "exit 125").Run()
+	require.Error(t, runErr)
+	require.ErrorIs(t, classifyNativeRunError(runErr, false), ErrChildFailed)
+	require.ErrorIs(t, classifyNativeRunError(runErr, true), ErrIsolationUnavailable)
+}
+
+func TestNativeRunnerHonorsCancellationBeforeExecutablePreparation(t *testing.T) {
+	executable := buildIsolatedHelper(t, "echo", "")
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("canceled probe"), 1<<20)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = runner.Run(ctx, request)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestNativeRunnerNeverLaunchesExecutableContentOutsidePinnedDigest(t *testing.T) {
+	executable := buildIsolatedHelper(t, "echo", "")
+	replacement := buildIsolatedHelper(t, "replacement", "")
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("identity probe"), 1<<20)
+	require.NoError(t, os.Rename(replacement, executable))
+
+	_, err = runner.Run(t.Context(), request)
+	require.ErrorIs(t, err, ErrIsolationUnavailable)
+}
+
+func TestVerifiedExecutableContentCannotChangeAfterDigestVerification(t *testing.T) {
+	executable := buildIsolatedHelper(t, "echo", "")
+	replacement := buildIsolatedHelper(t, "replacement", "")
+	runner, err := newNativeRunner()
+	require.NoError(t, err)
+	request := nativeTestRequest(t, runner, executable, []byte("identity probe"), 1<<20)
+	want, err := os.ReadFile(executable)
+	require.NoError(t, err)
+	prepared, err := openVerifiedExecutable(t.Context(), request)
+	require.NoError(t, err)
+	defer func() { _ = prepared.Close() }()
+	replacementBytes, err := os.ReadFile(replacement)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(executable, replacementBytes, 0o700))
+
+	got, err := os.ReadFile("/proc/self/fd/" + strconv.FormatUint(uint64(prepared.Fd()), 10))
+	require.NoError(t, err)
+	wantDigest := sha256.Sum256(want)
+	gotDigest := sha256.Sum256(got)
+	assert.Equal(t, wantDigest, gotDigest)
+}
+
+func TestNewUsesNativeRunnerWhenNoneIsInjected(t *testing.T) {
+	profile := testProfile(t, helperExecutable(t, "complete"), time.Second, 1<<20)
+	profile.Runner = nil
+
+	provider, err := New(profile)
+	require.NoError(t, err)
+	assert.Equal(t, nativeRunnerIdentity, provider.runnerIdentity)
+}
+
+func nativeTestRequest(
+	t *testing.T, runner IsolatedRunner, executable string, stdin []byte, maxStdout int64,
+) IsolatedRunRequest {
+	t.Helper()
+	data, err := os.ReadFile(executable)
+	require.NoError(t, err)
+	digest := sha256.Sum256(data)
+	provider := &Provider{
+		executable: executable, executableSHA256: hex.EncodeToString(digest[:]),
+		runnerIdentity: runner.Identity(), environment: cleanEnvironment(),
+	}
+	return provider.isolatedRequest(stdin, maxStdout)
+}
+
+func buildIsolatedHelper(t *testing.T, mode, networkAddress string) string {
+	t.Helper()
+	target := filepath.Join(t.TempDir(), "isolated-helper")
+	ldflags := strings.Join([]string{
+		"-X=main.mode=" + mode,
+		"-X=main.networkAddress=" + networkAddress,
+	}, " ")
+	command := exec.Command("go", "build", "-trimpath", "-ldflags", ldflags,
+		"-o", target, "./testdata/isolatedhelper")
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	return target
+}
+
+func skipUnavailableNativeIsolation(t *testing.T, err error) {
+	t.Helper()
+	if errors.Is(err, ErrIsolationUnavailable) {
+		t.Skipf("native Linux namespace isolation unavailable: %v", err)
+	}
+}
+
+func evaluateNativeSeccomp(
+	t *testing.T, filters []unix.SockFilter, syscallNumber uint32,
+) uint32 {
+	t.Helper()
+	accumulator := uint32(0)
+	for programCounter, steps := 0, 0; programCounter < len(filters) && steps <= len(filters); steps++ {
+		instruction := filters[programCounter]
+		switch instruction.Code {
+		case unix.BPF_LD | unix.BPF_W | unix.BPF_ABS:
+			switch instruction.K {
+			case 0:
+				accumulator = syscallNumber
+			case 4:
+				accumulator = unix.AUDIT_ARCH_X86_64
+			default:
+				require.FailNow(t, "unexpected seccomp load offset", "%d", instruction.K)
+			}
+			programCounter++
+		case unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K:
+			if accumulator == instruction.K {
+				programCounter += int(instruction.Jt) + 1
+			} else {
+				programCounter += int(instruction.Jf) + 1
+			}
+		case unix.BPF_JMP | unix.BPF_JSET | unix.BPF_K:
+			if accumulator&instruction.K != 0 {
+				programCounter += int(instruction.Jt) + 1
+			} else {
+				programCounter += int(instruction.Jf) + 1
+			}
+		case unix.BPF_RET | unix.BPF_K:
+			return instruction.K
+		default:
+			require.FailNow(t, "unexpected seccomp instruction", "%#x", instruction.Code)
+		}
+	}
+	require.FailNow(t, "seccomp filter did not return")
+	return 0
+}

--- a/document/trafilatura/native_runner_unsupported.go
+++ b/document/trafilatura/native_runner_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package trafilatura
+
+func newNativeRunner() (IsolatedRunner, error) {
+	return nil, ErrIsolationUnavailable
+}

--- a/document/trafilatura/native_runner_unsupported.go
+++ b/document/trafilatura/native_runner_unsupported.go
@@ -2,6 +2,8 @@
 
 package trafilatura
 
+func validateNativeExecutable(string) error { return ErrIsolationUnavailable }
+
 func newNativeRunner() (IsolatedRunner, error) {
 	return nil, ErrIsolationUnavailable
 }

--- a/document/trafilatura/provider.go
+++ b/document/trafilatura/provider.go
@@ -1,0 +1,797 @@
+package trafilatura
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/net/html"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
+)
+
+const (
+	providerID      = "trafilatura.local-v1"
+	protocolVersion = "docbank-trafilatura/v2"
+	profileVersion  = "docbank-trafilatura-profile/v2"
+	providerName    = providerutil.Provider("Trafilatura")
+
+	// MaxDocumentBytes is the largest supplied HTML document accepted by a profile.
+	MaxDocumentBytes = int64(50 << 20)
+	// MaxResponseBytes is the largest structured child response accepted by a profile.
+	MaxResponseBytes = int64(64 << 20)
+	// MaxUnits is the largest extracted unit sequence accepted by a profile.
+	MaxUnits = 100_000
+	// MaxTimeout is the largest local child deadline accepted by a profile.
+	MaxTimeout = 30 * time.Minute
+	// MaxExecutableBytes bounds executable identity verification.
+	MaxExecutableBytes = int64(256 << 20)
+)
+
+var (
+	errNativeCanceledBeforeLaunch = errors.New("native isolated runner canceled before launch")
+	// ErrIsolationUnavailable means the runner could not enforce the requested isolation policy.
+	ErrIsolationUnavailable = errors.New("isolated runner policy unavailable")
+	// ErrChildOutputTooLarge means the isolated child exceeded its stdout allowance.
+	ErrChildOutputTooLarge = errors.New("isolated child output exceeds limit")
+	// ErrChildFailed means the isolated child exited without a valid response.
+	ErrChildFailed = errors.New("isolated child failed")
+)
+
+// IsolationRequirements are mandatory runner controls. A runner must fail
+// closed rather than execute when any requested control is unavailable.
+type IsolationRequirements struct {
+	NetworkDisabled        bool
+	KillProcessTree        bool
+	VerifyExecutableSHA256 bool
+	FilesystemIsolated     bool
+}
+
+// IsolatedRunRequest is the complete, fixed child execution authority.
+type IsolatedRunRequest struct {
+	Executable        string
+	ExecutableSHA256  string
+	Arguments         []string
+	Environment       []string
+	Directory         string
+	Stdin             []byte
+	StdinSHA256       string
+	MaxStdoutBytes    int64
+	PolicyFingerprint string
+	Requirements      IsolationRequirements
+}
+
+// IsolationAttestation reports the exact controls applied to a completed run.
+type IsolationAttestation struct {
+	RunnerIdentity       string
+	PolicyFingerprint    string
+	ExecutableSHA256     string
+	StdinSHA256          string
+	NetworkDisabled      bool
+	ProcessTreeContained bool
+	DigestVerifiedLaunch bool
+	FilesystemIsolated   bool
+}
+
+// IsolatedRunResult is bounded stdout plus its isolation attestation.
+type IsolatedRunResult struct {
+	Stdout      []byte
+	Attestation IsolationAttestation
+}
+
+// IsolatedRunner is the trusted cross-platform process isolation boundary.
+// Run must launch the digest-verified executable without a path re-open race,
+// deny all network access, hide host files outside the fixed runtime allowlist,
+// contain the process tree, and reap that tree on cancellation. It must return
+// ErrIsolationUnavailable rather than weaken a requested control.
+type IsolatedRunner interface {
+	Identity() string
+	Run(ctx context.Context, request IsolatedRunRequest) (IsolatedRunResult, error)
+}
+
+// Profile fixes one executable, immutable runtime identity, and all local bounds.
+type Profile struct {
+	Executable       string
+	ExecutableSHA256 string
+	RuntimeIdentity  string
+	Runner           IsolatedRunner
+	MaxDocumentBytes int64
+	MaxResponseBytes int64
+	MaxUnits         int
+	Timeout          time.Duration
+}
+
+// Provider renders exact, caller-supplied HTML bytes through one local bridge.
+type Provider struct {
+	descriptor       document.RenditionDescriptor
+	executable       string
+	executableSHA256 string
+	runtimeIdentity  string
+	runnerIdentity   string
+	runner           IsolatedRunner
+	environment      []string
+	maxDocumentBytes int64
+	maxResponseBytes int64
+	maxUnits         int
+	timeout          time.Duration
+}
+
+// New constructs one immutable local-process provider profile.
+func New(profile Profile) (*Provider, error) {
+	if !filepath.IsAbs(profile.Executable) || filepath.Clean(profile.Executable) != profile.Executable {
+		return nil, errors.New("trafilatura: executable must be an absolute clean path")
+	}
+	if providerutil.IsPythonInterpreter(profile.Executable) {
+		return nil, errors.New("trafilatura: executable must not be a Python interpreter")
+	}
+	info, err := os.Lstat(profile.Executable)
+	if err != nil {
+		return nil, errors.New("trafilatura: configured executable is unavailable")
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("trafilatura: executable must be a regular non-symlink file")
+	}
+	if info.Size() <= 0 || info.Size() > MaxExecutableBytes {
+		return nil, errors.New("trafilatura: executable size is outside the supported bound")
+	}
+	if err := validateSHA256(profile.ExecutableSHA256, "executable SHA-256"); err != nil {
+		return nil, err
+	}
+	executableDigest, err := hashExecutable(profile.Executable)
+	if err != nil || executableDigest != profile.ExecutableSHA256 {
+		return nil, errors.New("trafilatura: executable SHA-256 does not match configured content")
+	}
+	if err := validateImmutableIdentity(profile.RuntimeIdentity, "runtime identity"); err != nil {
+		return nil, err
+	}
+	runner := profile.Runner
+	if runner == nil {
+		runner, err = newNativeRunner()
+		if err != nil {
+			return nil, fmt.Errorf("trafilatura: native isolated runner: %w", err)
+		}
+	}
+	runnerIdentity := runner.Identity()
+	if err := validateImmutableIdentity(runnerIdentity, "runner identity"); err != nil {
+		return nil, err
+	}
+	if profile.MaxDocumentBytes <= 0 || profile.MaxDocumentBytes > MaxDocumentBytes {
+		return nil, fmt.Errorf("trafilatura: max document bytes must be between 1 and %d", MaxDocumentBytes)
+	}
+	if profile.MaxResponseBytes <= 0 || profile.MaxResponseBytes > MaxResponseBytes {
+		return nil, fmt.Errorf("trafilatura: max response bytes must be between 1 and %d", MaxResponseBytes)
+	}
+	if profile.MaxUnits <= 0 || profile.MaxUnits > MaxUnits {
+		return nil, fmt.Errorf("trafilatura: max units must be between 1 and %d", MaxUnits)
+	}
+	if profile.Timeout <= 0 || profile.Timeout > MaxTimeout {
+		return nil, fmt.Errorf("trafilatura: timeout must be between 1ns and %s", MaxTimeout)
+	}
+	environment := cleanEnvironment()
+	identity := strings.Join([]string{
+		profileVersion, protocolVersion, profile.Executable, profile.ExecutableSHA256,
+		profile.RuntimeIdentity, runnerIdentity, strings.Join(environment, "\x1f"),
+		strconv.FormatInt(profile.MaxDocumentBytes, 10), strconv.FormatInt(profile.MaxResponseBytes, 10),
+		strconv.Itoa(profile.MaxUnits), strconv.FormatInt(int64(profile.Timeout), 10),
+	}, "\x00")
+	policyDigest := sha256.Sum256([]byte(identity))
+	descriptor, err := document.NewRenditionDescriptor(document.RenditionDescriptor{
+		ID: providerID, ContractVersion: document.RenditionProviderContractVersion,
+		PolicyFingerprint: hex.EncodeToString(policyDigest[:]),
+		TrustBoundary:     document.RenditionTrustLocalProcess,
+		SupportedFormats: []document.RenditionFormatCapability{
+			{MediaFamily: "text", MediaType: "text/html", InputKind: document.RenditionInputOriginalFile},
+			{MediaFamily: "text", MediaType: "application/xhtml+xml", InputKind: document.RenditionInputOriginalFile},
+		},
+		ReturnsStructured: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("trafilatura: construct descriptor: %w", err)
+	}
+	return &Provider{
+		descriptor: providerutil.CloneDescriptor(descriptor), executable: profile.Executable,
+		executableSHA256: profile.ExecutableSHA256, runtimeIdentity: profile.RuntimeIdentity,
+		runnerIdentity: runnerIdentity, runner: runner, maxDocumentBytes: profile.MaxDocumentBytes,
+		environment: slices.Clone(environment), maxResponseBytes: profile.MaxResponseBytes,
+		maxUnits: profile.MaxUnits, timeout: profile.Timeout,
+	}, nil
+}
+
+// Descriptor returns the immutable provider identity fixed by the profile.
+func (provider *Provider) Descriptor() document.RenditionDescriptor {
+	if provider == nil {
+		return document.RenditionDescriptor{}
+	}
+	return providerutil.CloneDescriptor(provider.descriptor)
+}
+
+// Render validates supplied HTML locally and sends its exact bytes over stdin only.
+func (provider *Provider) Render(
+	ctx context.Context, upload document.AuthorizedUpload,
+	authorization document.RenditionAuthorization,
+) (document.RenditionResult, error) {
+	if provider == nil {
+		return document.RenditionResult{}, errors.New("trafilatura: provider is required")
+	}
+	metadata := upload.Metadata()
+	if metadata.ByteLength > provider.maxDocumentBytes {
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected,
+			"Trafilatura input exceeds the configured byte limit", nil)
+	}
+	if !validFilename(metadata.Filename, metadata.MediaType) {
+		return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput,
+			"Trafilatura requires a supplied HTML filename", nil)
+	}
+	startedAt := time.Now().UTC()
+	operation, err := providerutil.NewOperation(ctx, providerName, authorization.ExpiresAt, provider.timeout)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	defer operation.Cancel()
+	if err := operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+
+	source, err := operation.ReadUpload(upload)
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	defer clear(source)
+	authority, err := inspectHTML(source, metadata.MediaType, provider.maxUnits)
+	if err != nil {
+		return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput,
+			"Trafilatura input is not locally verified HTML", err)
+	}
+	if err := operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+
+	if err := provider.reverifyExecutionBoundary(operation.Context()); err != nil {
+		if operationErr := operation.Check(); operationErr != nil {
+			return document.RenditionResult{}, operationErr
+		}
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected,
+			"Trafilatura isolated runtime identity changed", err)
+	}
+	runnerInput := slices.Clone(source)
+	defer clear(runnerInput)
+	stdoutLimit := min(provider.maxResponseBytes, int64(authorization.MaxTotalResultBytes))
+	request := provider.isolatedRequest(runnerInput, stdoutLimit)
+	runResult, runErr := provider.runner.Run(operation.Context(), request)
+	defer func() { clear(runResult.Stdout) }()
+	if errors.Is(runErr, errNativeCanceledBeforeLaunch) && operation.Context().Err() != nil {
+		return document.RenditionResult{}, operation.Check()
+	}
+	if errors.Is(runErr, ErrIsolationUnavailable) {
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected,
+			"Trafilatura isolation policy could not be enforced", runErr)
+	}
+	if err := provider.validateAttestation(request, runResult.Attestation); err != nil {
+		clear(runResult.Stdout)
+		return document.RenditionResult{}, providerError(document.RenditionErrorPolicyRejected,
+			"Trafilatura isolation attestation is invalid", err)
+	}
+	if err := operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	if errors.Is(runErr, ErrChildOutputTooLarge) {
+		return document.RenditionResult{}, providerError(document.RenditionErrorMalformedEvidence,
+			"Trafilatura output exceeds the configured byte limit", nil)
+	}
+	if runErr != nil {
+		return document.RenditionResult{}, providerError(document.RenditionErrorTransient,
+			"Trafilatura executable failed", runErr)
+	}
+	if int64(len(runResult.Stdout)) > request.MaxStdoutBytes {
+		return document.RenditionResult{}, providerError(document.RenditionErrorMalformedEvidence,
+			"Trafilatura output exceeds the configured byte limit", nil)
+	}
+	raw := runResult.Stdout
+	if err := operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+
+	wire, err := parseResponse(operation.Context(), raw, provider.runtimeIdentity, metadata, authority, provider.maxUnits)
+	if err != nil {
+		if operationErr := operation.Check(); operationErr != nil {
+			return document.RenditionResult{}, operationErr
+		}
+		return document.RenditionResult{}, providerError(document.RenditionErrorMalformedEvidence,
+			"Trafilatura output is malformed", err)
+	}
+	evidence := evidenceFromResponse(wire)
+	if err := document.ValidateSourceEvidenceV1(evidence); err != nil {
+		return document.RenditionResult{}, providerError(document.RenditionErrorMalformedEvidence,
+			"Trafilatura output is malformed", err)
+	}
+	if err := operation.Check(); err != nil {
+		return document.RenditionResult{}, err
+	}
+	completedAt := time.Now().UTC()
+	warnings := []string(nil)
+	if !*wire.ProvenanceComplete {
+		warnings = []string{"degraded_provenance"}
+	}
+	receipt, err := providerutil.NewReceipt(providerName, providerutil.Receipt{
+		Descriptor: provider.descriptor, Authorization: authorization, SourceSHA256: metadata.SHA256,
+		OperationID: "trafilatura-" + authorization.RenditionRequestFingerprint[:24],
+		StartedAt:   startedAt, CompletedAt: completedAt, Warnings: warnings,
+		Usage: document.RenditionUsage{Requests: 1, InputBytes: metadata.ByteLength,
+			OutputBytes: int64(len(raw)), Units: int64(len(evidence.Units))},
+	})
+	if err != nil {
+		return document.RenditionResult{}, err
+	}
+	return document.RenditionResult{Evidence: evidence, Receipt: receipt}, nil
+}
+
+type response struct {
+	ContractVersion    string         `json:"contract_version"`
+	RuntimeIdentity    string         `json:"runtime_identity"`
+	SourceSHA256       string         `json:"source_sha256"`
+	SourceBytes        int64          `json:"source_bytes"`
+	ExtractionComplete bool           `json:"extraction_complete"`
+	ProvenanceComplete *bool          `json:"provenance_complete"`
+	Units              []responseUnit `json:"units"`
+}
+
+type responseUnit struct {
+	SourcePath string `json:"source_path,omitempty"`
+	Heading    string `json:"heading,omitempty"`
+	Text       string `json:"text"`
+}
+
+type htmlAuthority struct {
+	visibleTokens []string
+	sections      []htmlSectionAuthority
+}
+
+type htmlSectionAuthority struct {
+	path    string
+	heading string
+	tokens  []string
+}
+
+func (provider *Provider) isolatedRequest(stdin []byte, maxStdoutBytes int64) IsolatedRunRequest {
+	arguments := []string{"--protocol", protocolVersion}
+	environment := slices.Clone(provider.environment)
+	requirements := IsolationRequirements{
+		NetworkDisabled: true, KillProcessTree: true, VerifyExecutableSHA256: true,
+		FilesystemIsolated: true,
+	}
+	stdinDigest := sha256.Sum256(stdin)
+	stdinSHA256 := hex.EncodeToString(stdinDigest[:])
+	request := IsolatedRunRequest{
+		Executable: provider.executable, ExecutableSHA256: provider.executableSHA256,
+		Arguments: arguments, Environment: environment, Directory: filepath.Dir(provider.executable),
+		Stdin: stdin, StdinSHA256: stdinSHA256, MaxStdoutBytes: maxStdoutBytes,
+		Requirements: requirements,
+	}
+	request.PolicyFingerprint = isolationRequestPolicyFingerprint(provider.runnerIdentity, request)
+	return request
+}
+
+func isolationRequestPolicyFingerprint(runnerIdentity string, request IsolatedRunRequest) string {
+	identity := strings.Join([]string{
+		"docbank-isolated-run/v1", runnerIdentity, request.Executable,
+		request.ExecutableSHA256, strings.Join(request.Arguments, "\x1f"), strings.Join(request.Environment, "\x1f"),
+		request.Directory, request.StdinSHA256, strconv.FormatInt(request.MaxStdoutBytes, 10),
+		"network-disabled", "kill-process-tree", "digest-verified-launch", "host-filesystem-hidden",
+	}, "\x00")
+	digest := sha256.Sum256([]byte(identity))
+	return hex.EncodeToString(digest[:])
+}
+
+func (provider *Provider) reverifyExecutionBoundary(ctx context.Context) error {
+	if provider.runner == nil || provider.runner.Identity() != provider.runnerIdentity {
+		return errors.New("isolated runner identity changed")
+	}
+	digest, err := hashExecutableContext(ctx, provider.executable)
+	if err != nil || digest != provider.executableSHA256 {
+		return errors.New("executable content changed")
+	}
+	return nil
+}
+
+func (provider *Provider) validateAttestation(
+	request IsolatedRunRequest, attestation IsolationAttestation,
+) error {
+	stdinDigest := sha256.Sum256(request.Stdin)
+	if attestation.RunnerIdentity != provider.runnerIdentity ||
+		attestation.PolicyFingerprint != request.PolicyFingerprint ||
+		attestation.ExecutableSHA256 != provider.executableSHA256 ||
+		request.StdinSHA256 != hex.EncodeToString(stdinDigest[:]) || attestation.StdinSHA256 != request.StdinSHA256 ||
+		!attestation.NetworkDisabled || !attestation.ProcessTreeContained || !attestation.DigestVerifiedLaunch ||
+		!attestation.FilesystemIsolated {
+		return errors.New("isolated runner did not attest the exact required policy")
+	}
+	return nil
+}
+
+func parseResponse(
+	ctx context.Context, raw []byte, runtimeIdentity string,
+	metadata document.AuthorizedUploadMetadata, authority htmlAuthority, maxUnits int,
+) (response, error) {
+	if len(raw) == 0 {
+		return response{}, errors.New("empty response")
+	}
+	var wire response
+	if err := json.Unmarshal(raw, &wire, json.RejectUnknownMembers(true)); err != nil {
+		return response{}, err
+	}
+	if wire.ContractVersion != protocolVersion || wire.RuntimeIdentity != runtimeIdentity {
+		return response{}, errors.New("local protocol identity changed")
+	}
+	if wire.SourceSHA256 != metadata.SHA256 || wire.SourceBytes != metadata.ByteLength {
+		return response{}, errors.New("source identity changed")
+	}
+	if !wire.ExtractionComplete {
+		return response{}, errors.New("response does not attest complete extraction")
+	}
+	if wire.ProvenanceComplete == nil {
+		return response{}, errors.New("response does not attest provenance completeness")
+	}
+	if len(wire.Units) == 0 || len(wire.Units) > maxUnits {
+		return response{}, errors.New("unit count is invalid")
+	}
+	outputTokens := make([]string, 0)
+	for index := range wire.Units {
+		if err := ctx.Err(); err != nil {
+			return response{}, err
+		}
+		unit := &wire.Units[index]
+		if !validOutputText(unit.Text) {
+			return response{}, errors.New("unit text is invalid")
+		}
+		unit.Text = strings.TrimSpace(unit.Text)
+		unitTokens := strings.Fields(unit.Text)
+		outputTokens = append(outputTokens, unitTokens...)
+	}
+	if !slices.Equal(outputTokens, authority.visibleTokens) {
+		return response{}, errors.New("output does not cover exact supplied HTML text")
+	}
+	if !*wire.ProvenanceComplete {
+		for _, unit := range wire.Units {
+			if unit.SourcePath != "" || unit.Heading != "" {
+				return response{}, errors.New("degraded output claims unverified natural provenance")
+			}
+		}
+		return wire, nil
+	}
+	if len(authority.sections) == 0 || len(wire.Units) != len(authority.sections) {
+		return response{}, errors.New("complete section structure is not locally verified")
+	}
+	for index, unit := range wire.Units {
+		section := authority.sections[index]
+		if unit.SourcePath != section.path || strings.Join(strings.Fields(unit.Heading), " ") != section.heading ||
+			!slices.Equal(strings.Fields(unit.Text), section.tokens) {
+			return response{}, errors.New("section output does not match locally verified HTML structure")
+		}
+	}
+	return wire, nil
+}
+
+func evidenceFromResponse(wire response) document.SourceEvidenceV1 {
+	if !*wire.ProvenanceComplete {
+		parts := make([]string, len(wire.Units))
+		for index, unit := range wire.Units {
+			parts[index] = unit.Text
+		}
+		return document.SourceEvidenceV1{
+			ContractVersion: document.SourceEvidenceContractV1,
+			Completeness:    document.EvidenceDegradedProvenance,
+			Family:          "text", UnitKind: document.EvidenceUnitGeneric,
+			Omissions: []document.SourceEvidenceOmissionV1{{
+				Kind: document.EvidenceOmissionField, Field: "natural_structure",
+				Reason: "All supplied text is extracted but natural HTML section boundaries are not proven",
+			}},
+			Units: []document.SourceEvidenceUnitV1{{Order: 0, Text: strings.Join(parts, "\n\n"),
+				Locator: document.SourceEvidenceLocatorV1{Kind: document.EvidenceLocatorGeneric,
+					IndexOrigin: document.EvidenceIndexOriginNone}}},
+		}
+	}
+	units := make([]document.SourceEvidenceUnitV1, len(wire.Units))
+	for index, unit := range wire.Units {
+		units[index] = document.SourceEvidenceUnitV1{
+			Order: index, ProviderID: fmt.Sprintf("trafilatura-section-%d", index+1), Text: unit.Text,
+			Locator: document.SourceEvidenceLocatorV1{Kind: document.EvidenceLocatorSection,
+				IndexOrigin: document.EvidenceIndexOriginNone, Name: unit.SourcePath},
+		}
+	}
+	return document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1, Completeness: document.EvidenceComplete,
+		Family: "text", UnitKind: document.EvidenceUnitSection, Units: units,
+	}
+}
+
+func inspectHTML(source []byte, mediaType string, maxSections int) (htmlAuthority, error) {
+	if len(source) == 0 || !utf8.Valid(source) || bytes.IndexByte(source, 0) >= 0 {
+		return htmlAuthority{}, errors.New("HTML must be nonempty safe UTF-8")
+	}
+	if mediaType == "application/xhtml+xml" {
+		if err := validateXHTML(source); err != nil {
+			return htmlAuthority{}, err
+		}
+	} else if mediaType != "text/html" || !hasHTMLStructure(source) {
+		return htmlAuthority{}, errors.New("HTML structure is missing")
+	}
+	node, err := html.Parse(bytes.NewReader(source))
+	if err != nil {
+		return htmlAuthority{}, fmt.Errorf("parse supplied HTML: %w", err)
+	}
+	if err := validateVisibleText(node); err != nil {
+		return htmlAuthority{}, err
+	}
+	visible := visibleTokens(node)
+	if len(visible) == 0 {
+		return htmlAuthority{}, errors.New("HTML has no visible supplied text")
+	}
+	sections := naturalSections(node, maxSections)
+	sectionTokens := make([]string, 0, len(visible))
+	for _, section := range sections {
+		sectionTokens = append(sectionTokens, section.tokens...)
+	}
+	if !slices.Equal(sectionTokens, visible) {
+		sections = nil
+	}
+	return htmlAuthority{visibleTokens: visible, sections: sections}, nil
+}
+
+func validateVisibleText(node *html.Node) error {
+	var walk func(*html.Node, bool) error
+	walk = func(current *html.Node, hidden bool) error {
+		if current.Type == html.ElementNode {
+			hidden = hidden || hiddenElement(strings.ToLower(current.Data))
+		}
+		if current.Type == html.TextNode && !hidden {
+			for _, char := range current.Data {
+				if unicode.IsControl(char) && char != '\n' && char != '\r' && char != '\t' {
+					return errors.New("HTML visible text contains an unsupported control character")
+				}
+			}
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			if err := walk(child, hidden); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return walk(node, false)
+}
+
+func visibleTokens(node *html.Node) []string {
+	var tokens []string
+	var walk func(*html.Node, bool)
+	walk = func(current *html.Node, hidden bool) {
+		if current.Type == html.ElementNode {
+			hidden = hidden || hiddenElement(strings.ToLower(current.Data))
+		}
+		if current.Type == html.TextNode && !hidden {
+			tokens = append(tokens, strings.Fields(current.Data)...)
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			walk(child, hidden)
+		}
+	}
+	walk(node, false)
+	return tokens
+}
+
+func hiddenElement(tag string) bool {
+	return tag == "head" || tag == "script" || tag == "style" ||
+		tag == "noscript" || tag == "template" || tag == "svg"
+}
+
+func naturalSections(root *html.Node, maxSections int) []htmlSectionAuthority {
+	var sections []htmlSectionAuthority
+	var path []string
+	var walk func(*html.Node) bool
+	walk = func(current *html.Node) bool {
+		isSection := current.Type == html.ElementNode && strings.EqualFold(current.Data, "section")
+		if isSection {
+			if len(sections) >= maxSections {
+				return false
+			}
+			sections = append(sections, htmlSectionAuthority{
+				path: "/" + strings.Join(path, "/"), heading: firstSectionHeading(current), tokens: visibleTokens(current),
+			})
+			return true
+		}
+		var ordinals map[string]int
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			if child.Type == html.ElementNode {
+				if ordinals == nil {
+					ordinals = make(map[string]int)
+				}
+				tag := strings.ToLower(child.Data)
+				ordinals[tag]++
+				path = append(path, tag+"["+strconv.Itoa(ordinals[tag])+"]")
+			}
+			if !walk(child) {
+				return false
+			}
+			if child.Type == html.ElementNode {
+				path = path[:len(path)-1]
+			}
+		}
+		return true
+	}
+	if !walk(root) {
+		return nil
+	}
+	return sections
+}
+
+func firstSectionHeading(section *html.Node) string {
+	var find func(*html.Node) *html.Node
+	find = func(current *html.Node) *html.Node {
+		if current.Type == html.ElementNode {
+			tag := strings.ToLower(current.Data)
+			if len(tag) == 2 && tag[0] == 'h' && tag[1] >= '1' && tag[1] <= '6' {
+				return current
+			}
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			if found := find(child); found != nil {
+				return found
+			}
+		}
+		return nil
+	}
+	heading := find(section)
+	if heading == nil {
+		return ""
+	}
+	return strings.Join(visibleTokens(heading), " ")
+}
+
+func hasHTMLStructure(source []byte) bool {
+	tokenizer := html.NewTokenizer(bytes.NewReader(source))
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			return false
+		case html.StartTagToken, html.SelfClosingTagToken:
+			name, _ := tokenizer.TagName()
+			if strings.EqualFold(string(name), "html") || strings.EqualFold(string(name), "body") {
+				return true
+			}
+		default:
+		}
+	}
+}
+
+func validateXHTML(source []byte) error {
+	decoder := xml.NewDecoder(bytes.NewReader(source))
+	depth := 0
+	roots := 0
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			if roots == 1 && depth == 0 {
+				return nil
+			}
+			return errors.New("XHTML root is invalid")
+		}
+		if err != nil {
+			return errors.New("XHTML is malformed")
+		}
+		switch value := token.(type) {
+		case xml.StartElement:
+			if depth == 0 {
+				roots++
+				if roots != 1 || value.Name.Local != "html" ||
+					(value.Name.Space != "" && value.Name.Space != "http://www.w3.org/1999/xhtml") {
+					return errors.New("XHTML root is invalid")
+				}
+			}
+			depth++
+		case xml.EndElement:
+			depth--
+			if depth < 0 {
+				return errors.New("XHTML is malformed")
+			}
+		case xml.CharData:
+			if depth == 0 && len(bytes.TrimSpace(value)) != 0 {
+				return errors.New("XHTML has text outside its root")
+			}
+		}
+	}
+}
+
+func providerError(code document.RenditionErrorCode, message string, cause error) error {
+	return providerName.Classified(code, message, cause)
+}
+
+func cleanEnvironment() []string {
+	return providerutil.PythonEnvironment()
+}
+
+func validFilename(filename, mediaType string) bool {
+	switch mediaType {
+	case "text/html":
+		return providerutil.ValidOptionalFilename(filename, ".html", ".htm")
+	case "application/xhtml+xml":
+		return providerutil.ValidOptionalFilename(filename, ".xhtml")
+	default:
+		return false
+	}
+}
+
+func validateImmutableIdentity(value, subject string) error {
+	if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+sha256.Size*2 {
+		return fmt.Errorf("trafilatura: %s must be an immutable sha256 identity", subject)
+	}
+	return validateSHA256(strings.TrimPrefix(value, "sha256:"), subject)
+}
+
+func validateSHA256(value, subject string) error {
+	if len(value) != sha256.Size*2 {
+		return fmt.Errorf("trafilatura: %s must be a lowercase SHA-256 digest", subject)
+	}
+	decoded, err := hex.DecodeString(value)
+	if err != nil || hex.EncodeToString(decoded) != value {
+		return fmt.Errorf("trafilatura: %s must be a lowercase SHA-256 digest", subject)
+	}
+	return nil
+}
+
+func hashExecutable(path string) (string, error) {
+	return hashExecutableContext(context.Background(), path)
+}
+
+func hashExecutableContext(ctx context.Context, path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	written, err := io.Copy(hash, io.LimitReader(contextReader{ctx: ctx, reader: file}, MaxExecutableBytes+1))
+	if err != nil || written <= 0 || written > MaxExecutableBytes {
+		return "", errors.New("executable content could not be bounded and hashed")
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (reader contextReader) Read(value []byte) (int, error) {
+	if err := reader.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return reader.reader.Read(value)
+}
+
+func validOutputText(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || !utf8.ValidString(value) || strings.ContainsRune(value, '\x00') {
+		return false
+	}
+	for _, char := range value {
+		if unicode.IsControl(char) && char != '\n' && char != '\r' && char != '\t' {
+			return false
+		}
+	}
+	return true
+}
+
+var _ document.RenditionProvider = (*Provider)(nil)

--- a/document/trafilatura/provider.go
+++ b/document/trafilatura/provider.go
@@ -165,6 +165,9 @@ func New(profile Profile) (*Provider, error) {
 		if err != nil {
 			return nil, fmt.Errorf("trafilatura: native isolated runner: %w", err)
 		}
+		if err := validateNativeExecutable(profile.Executable); err != nil {
+			return nil, err
+		}
 	}
 	runnerIdentity := runner.Identity()
 	if err := validateImmutableIdentity(runnerIdentity, "runner identity"); err != nil {
@@ -252,8 +255,11 @@ func (provider *Provider) Render(
 		return document.RenditionResult{}, err
 	}
 	defer clear(source)
-	authority, err := inspectHTML(source, metadata.MediaType, provider.maxUnits)
+	authority, err := inspectHTML(operation.Context(), source, metadata.MediaType, provider.maxUnits)
 	if err != nil {
+		if operationErr := operation.Check(); operationErr != nil {
+			return document.RenditionResult{}, operationErr
+		}
 		return document.RenditionResult{}, providerError(document.RenditionErrorUnsupportedInput,
 			"Trafilatura input is not locally verified HTML", err)
 	}
@@ -519,29 +525,42 @@ func evidenceFromResponse(wire response) document.SourceEvidenceV1 {
 	}
 }
 
-func inspectHTML(source []byte, mediaType string, maxSections int) (htmlAuthority, error) {
+func inspectHTML(ctx context.Context, source []byte, mediaType string, maxSections int) (htmlAuthority, error) {
+	if err := ctx.Err(); err != nil {
+		return htmlAuthority{}, err
+	}
 	if len(source) == 0 || !utf8.Valid(source) || bytes.IndexByte(source, 0) >= 0 {
 		return htmlAuthority{}, errors.New("HTML must be nonempty safe UTF-8")
 	}
 	if mediaType == "application/xhtml+xml" {
-		if err := validateXHTML(source); err != nil {
+		if err := validateXHTML(ctx, source); err != nil {
 			return htmlAuthority{}, err
 		}
-	} else if mediaType != "text/html" || !hasHTMLStructure(source) {
+	} else if mediaType != "text/html" {
+		return htmlAuthority{}, errors.New("HTML structure is missing")
+	} else if structured, err := hasHTMLStructure(ctx, source); err != nil {
+		return htmlAuthority{}, err
+	} else if !structured {
 		return htmlAuthority{}, errors.New("HTML structure is missing")
 	}
-	node, err := html.Parse(bytes.NewReader(source))
+	node, err := html.Parse(contextReader{ctx: ctx, reader: bytes.NewReader(source)})
 	if err != nil {
 		return htmlAuthority{}, fmt.Errorf("parse supplied HTML: %w", err)
 	}
-	if err := validateVisibleText(node); err != nil {
+	if err := validateVisibleText(ctx, node); err != nil {
 		return htmlAuthority{}, err
 	}
-	visible := visibleTokens(node)
+	visible, err := visibleTokens(ctx, node)
+	if err != nil {
+		return htmlAuthority{}, err
+	}
 	if len(visible) == 0 {
 		return htmlAuthority{}, errors.New("HTML has no visible supplied text")
 	}
-	sections := naturalSections(node, maxSections)
+	sections, err := naturalSections(ctx, node, maxSections)
+	if err != nil {
+		return htmlAuthority{}, err
+	}
 	sectionTokens := make([]string, 0, len(visible))
 	for _, section := range sections {
 		sectionTokens = append(sectionTokens, section.tokens...)
@@ -552,9 +571,12 @@ func inspectHTML(source []byte, mediaType string, maxSections int) (htmlAuthorit
 	return htmlAuthority{visibleTokens: visible, sections: sections}, nil
 }
 
-func validateVisibleText(node *html.Node) error {
+func validateVisibleText(ctx context.Context, node *html.Node) error {
 	var walk func(*html.Node, bool) error
 	walk = func(current *html.Node, hidden bool) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if current.Type == html.ElementNode {
 			hidden = hidden || hiddenElement(strings.ToLower(current.Data))
 		}
@@ -575,10 +597,13 @@ func validateVisibleText(node *html.Node) error {
 	return walk(node, false)
 }
 
-func visibleTokens(node *html.Node) []string {
+func visibleTokens(ctx context.Context, node *html.Node) ([]string, error) {
 	var tokens []string
-	var walk func(*html.Node, bool)
-	walk = func(current *html.Node, hidden bool) {
+	var walk func(*html.Node, bool) error
+	walk = func(current *html.Node, hidden bool) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if current.Type == html.ElementNode {
 			hidden = hidden || hiddenElement(strings.ToLower(current.Data))
 		}
@@ -586,11 +611,16 @@ func visibleTokens(node *html.Node) []string {
 			tokens = append(tokens, strings.Fields(current.Data)...)
 		}
 		for child := current.FirstChild; child != nil; child = child.NextSibling {
-			walk(child, hidden)
+			if err := walk(child, hidden); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
-	walk(node, false)
-	return tokens
+	if err := walk(node, false); err != nil {
+		return nil, err
+	}
+	return tokens, nil
 }
 
 func hiddenElement(tag string) bool {
@@ -598,18 +628,33 @@ func hiddenElement(tag string) bool {
 		tag == "noscript" || tag == "template" || tag == "svg"
 }
 
-func naturalSections(root *html.Node, maxSections int) []htmlSectionAuthority {
+func naturalSections(ctx context.Context, root *html.Node, maxSections int) ([]htmlSectionAuthority, error) {
 	var sections []htmlSectionAuthority
 	var path []string
+	var walkErr error
 	var walk func(*html.Node) bool
 	walk = func(current *html.Node) bool {
+		if err := ctx.Err(); err != nil {
+			walkErr = err
+			return false
+		}
 		isSection := current.Type == html.ElementNode && strings.EqualFold(current.Data, "section")
 		if isSection {
 			if len(sections) >= maxSections {
 				return false
 			}
+			heading, err := firstSectionHeading(ctx, current)
+			if err != nil {
+				walkErr = err
+				return false
+			}
+			tokens, err := visibleTokens(ctx, current)
+			if err != nil {
+				walkErr = err
+				return false
+			}
 			sections = append(sections, htmlSectionAuthority{
-				path: "/" + strings.Join(path, "/"), heading: firstSectionHeading(current), tokens: visibleTokens(current),
+				path: "/" + strings.Join(path, "/"), heading: heading, tokens: tokens,
 			})
 			return true
 		}
@@ -633,56 +678,73 @@ func naturalSections(root *html.Node, maxSections int) []htmlSectionAuthority {
 		return true
 	}
 	if !walk(root) {
-		return nil
+		return nil, walkErr
 	}
-	return sections
+	return sections, nil
 }
 
-func firstSectionHeading(section *html.Node) string {
-	var find func(*html.Node) *html.Node
-	find = func(current *html.Node) *html.Node {
+func firstSectionHeading(ctx context.Context, section *html.Node) (string, error) {
+	var heading *html.Node
+	var find func(*html.Node) error
+	find = func(current *html.Node) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if current.Type == html.ElementNode {
 			tag := strings.ToLower(current.Data)
 			if len(tag) == 2 && tag[0] == 'h' && tag[1] >= '1' && tag[1] <= '6' {
-				return current
+				heading = current
+				return nil
 			}
 		}
 		for child := current.FirstChild; child != nil; child = child.NextSibling {
-			if found := find(child); found != nil {
-				return found
+			if err := find(child); err != nil || heading != nil {
+				return err
 			}
 		}
 		return nil
 	}
-	heading := find(section)
-	if heading == nil {
-		return ""
+	if err := find(section); err != nil {
+		return "", err
 	}
-	return strings.Join(visibleTokens(heading), " ")
+	if heading == nil {
+		return "", nil
+	}
+	tokens, err := visibleTokens(ctx, heading)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(tokens, " "), nil
 }
 
-func hasHTMLStructure(source []byte) bool {
-	tokenizer := html.NewTokenizer(bytes.NewReader(source))
+func hasHTMLStructure(ctx context.Context, source []byte) (bool, error) {
+	tokenizer := html.NewTokenizer(contextReader{ctx: ctx, reader: bytes.NewReader(source)})
 	for {
 		switch tokenizer.Next() {
 		case html.ErrorToken:
-			return false
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+			return false, nil
 		case html.StartTagToken, html.SelfClosingTagToken:
 			name, _ := tokenizer.TagName()
 			if strings.EqualFold(string(name), "html") || strings.EqualFold(string(name), "body") {
-				return true
+				return true, nil
 			}
 		default:
 		}
 	}
 }
 
-func validateXHTML(source []byte) error {
-	decoder := xml.NewDecoder(bytes.NewReader(source))
+func validateXHTML(ctx context.Context, source []byte) error {
+	decoder := xml.NewDecoder(contextReader{ctx: ctx, reader: bytes.NewReader(source)})
 	depth := 0
 	roots := 0
 	for {
 		token, err := decoder.Token()
+		if contextErr := ctx.Err(); contextErr != nil {
+			return contextErr
+		}
 		if errors.Is(err, io.EOF) {
 			if roots == 1 && depth == 0 {
 				return nil

--- a/document/trafilatura/provider_test.go
+++ b/document/trafilatura/provider_test.go
@@ -1,0 +1,419 @@
+package trafilatura
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
+)
+
+const testRuntimeIdentity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestProviderRendersExactSuppliedHTMLWithoutFetchingRemoteReferences(t *testing.T) {
+	t.Setenv("DOCBANK_TRAFILATURA_AMBIENT_SECRET", "must-not-reach-child")
+	provider := newTestProvider(t, helperExecutable(t, "complete"), time.Second, 1<<20)
+	source := []byte(`<!doctype html><html><body><h1>Local title</h1><p>Local body</p><a href="https://private.example/fetch-me">link</a><img src="https://private.example/image.png"></body></html>`)
+	upload := newTestUpload(source, "article.html", "text/html")
+
+	result, err := document.RenderRendition(t.Context(), provider, upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	require.NoError(t, err)
+	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+	assert.Equal(t, "text", result.Evidence.Family)
+	assert.Equal(t, document.EvidenceUnitGeneric, result.Evidence.UnitKind)
+	require.Len(t, result.Evidence.Units, 1)
+	assert.Equal(t, "Local title Local body link", result.Evidence.Units[0].Text)
+	assert.NotContains(t, result.Evidence.Units[0].Text, "private.example")
+	assert.Equal(t, int64(len(source)), result.Receipt.Usage.InputBytes)
+	assert.Equal(t, upload.metadata.SHA256, result.Receipt.SourceSHA256)
+}
+
+func TestProviderDeclaresDegradedEvidenceWithoutCompleteSourceProof(t *testing.T) {
+	provider := newTestProvider(t, helperExecutable(t, "degraded"), time.Second, 1<<20)
+	upload := newTestUpload(testHTML, "article.html", "text/html")
+
+	result, err := provider.Render(t.Context(), upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	require.NoError(t, err, "cause: %v", errors.Unwrap(err))
+	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+	assert.Equal(t, document.EvidenceUnitGeneric, result.Evidence.UnitKind)
+	require.Len(t, result.Evidence.Units, 1)
+	assert.Equal(t, "Local title\n\nLocal body", result.Evidence.Units[0].Text)
+	assert.Equal(t, []string{"degraded_provenance"}, result.Receipt.Warnings)
+}
+
+func TestProviderSupportsSuppliedXHTMLBytes(t *testing.T) {
+	provider := newTestProvider(t, helperExecutable(t, "xhtml"), time.Second, 1<<20)
+	source := []byte(`<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"><body><h1>Local title</h1><p>Local body</p></body></html>`)
+	upload := newTestUpload(source, "article.xhtml", "application/xhtml+xml")
+
+	result, err := provider.Render(t.Context(), upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	require.NoError(t, err)
+	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+}
+
+func TestProviderRendersWithoutDisclosingFilename(t *testing.T) {
+	provider := newTestProvider(t, helperExecutable(t, "complete"), time.Second, 1<<20)
+	upload := newTestUpload(testHTML, "article.html", "text/html")
+	authorization := testAuthorization(provider.Descriptor(), upload.Metadata())
+	authorization.DiscloseFilename = false
+
+	result, err := document.RenderRendition(t.Context(), provider, upload, authorization)
+	require.NoError(t, err)
+	assert.Equal(t, document.EvidenceDegradedProvenance, result.Evidence.Completeness)
+}
+
+func TestProviderRejectsIncompleteOrTruncatedExtraction(t *testing.T) {
+	for _, mode := range []string{"extraction-incomplete", "truncated-degraded"} {
+		t.Run(mode, func(t *testing.T) {
+			provider := newTestProvider(t, helperExecutable(t, mode), time.Second, 1<<20)
+			upload := newTestUpload(testHTML, "article.html", "text/html")
+			_, err := provider.Render(t.Context(), upload,
+				testAuthorization(provider.Descriptor(), upload.Metadata()))
+			assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+		})
+	}
+}
+
+func TestProviderClaimsCompleteSectionsOnlyForLocallyVerifiedStructure(t *testing.T) {
+	source := []byte(`<!doctype html><html><body><section><h1>Local title</h1><p>Local body</p></section></body></html>`)
+	t.Run("verified path", func(t *testing.T) {
+		provider := newTestProvider(t, helperExecutable(t, "structured"), time.Second, 1<<20)
+		upload := newTestUpload(source, "article.html", "text/html")
+		result, err := provider.Render(t.Context(), upload,
+			testAuthorization(provider.Descriptor(), upload.Metadata()))
+		require.NoError(t, err)
+		assert.Equal(t, document.EvidenceComplete, result.Evidence.Completeness)
+		assert.Equal(t, document.EvidenceUnitSection, result.Evidence.UnitKind)
+		require.Len(t, result.Evidence.Units, 1)
+		assert.Equal(t, "/html[1]/body[1]/section[1]", result.Evidence.Units[0].Locator.Name)
+	})
+	for _, mode := range []string{"structured-path-drift", "structured-boundary-drift"} {
+		t.Run(mode, func(t *testing.T) {
+			provider := newTestProvider(t, helperExecutable(t, mode), time.Second, 1<<20)
+			upload := newTestUpload(source, "article.html", "text/html")
+			_, err := provider.Render(t.Context(), upload,
+				testAuthorization(provider.Descriptor(), upload.Metadata()))
+			assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+		})
+	}
+}
+
+func TestProviderUsesVerifiedPathsForDuplicateSectionHeadings(t *testing.T) {
+	source := []byte(`<!doctype html><html><body>
+		<section><h2>Repeat</h2><p>First</p></section>
+		<section><h2>Repeat</h2><p>Second</p></section>
+	</body></html>`)
+	provider := newTestProvider(t, helperExecutable(t, "structured-duplicate"), time.Second, 1<<20)
+	upload := newTestUpload(source, "article.html", "text/html")
+
+	result, err := provider.Render(t.Context(), upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	require.NoError(t, err)
+	require.Len(t, result.Evidence.Units, 2)
+	assert.Equal(t, "/html[1]/body[1]/section[1]", result.Evidence.Units[0].Locator.Name)
+	assert.Equal(t, "/html[1]/body[1]/section[2]", result.Evidence.Units[1].Locator.Name)
+}
+
+func TestInspectHTMLBoundsNaturalSectionsAndPreservesSiblingOrdinals(t *testing.T) {
+	source := []byte(`<!doctype html><html><body>
+		<section><h1>One</h1><p>First</p></section>
+		<div></div>
+		<section><h2>Two</h2><p>Second</p></section>
+		<section><h3>Three</h3><p>Third</p></section>
+	</body></html>`)
+	authority, err := inspectHTML(source, "text/html", 3)
+	require.NoError(t, err)
+	require.Len(t, authority.sections, 3)
+	assert.Equal(t, []string{
+		"/html[1]/body[1]/section[1]",
+		"/html[1]/body[1]/section[2]",
+		"/html[1]/body[1]/section[3]",
+	}, []string{authority.sections[0].path, authority.sections[1].path, authority.sections[2].path})
+
+	authority, err = inspectHTML(source, "text/html", 2)
+	require.NoError(t, err)
+	assert.Nil(t, authority.sections, "over-bound structure must use degraded provenance")
+}
+
+func TestProviderRejectsOutputNotDerivableFromSuppliedBytes(t *testing.T) {
+	provider := newTestProvider(t, helperExecutable(t, "fetched"), time.Second, 1<<20)
+	upload := newTestUpload(testHTML, "article.html", "text/html")
+
+	_, err := provider.Render(t.Context(), upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+	assert.NotContains(t, err.Error(), "REMOTE_FETCH_TOKEN")
+}
+
+func TestProviderRejectsMalformedPartialAndDriftedOutput(t *testing.T) {
+	for _, mode := range []string{
+		"malformed", "unknown-field", "missing-provenance-complete", "version-drift", "runtime-drift", "source-hash-drift",
+		"source-size-drift", "partial", "empty", "bad-heading", "complete-inexact",
+	} {
+		t.Run(mode, func(t *testing.T) {
+			provider := newTestProvider(t, helperExecutable(t, mode), time.Second, 1<<20)
+			upload := newTestUpload(testHTML, "article.html", "text/html")
+			_, err := provider.Render(t.Context(), upload,
+				testAuthorization(provider.Descriptor(), upload.Metadata()))
+			assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+		})
+	}
+}
+
+func TestProviderRejectsNonHTMLMalformedXHTMLAndSubstitutedInput(t *testing.T) {
+	provider := newTestProvider(t, helperExecutable(t, "failure"), time.Second, 1<<20)
+	for _, test := range []struct {
+		name, filename, mediaType string
+		content                   []byte
+	}{
+		{name: "plain text", filename: "article.html", mediaType: "text/html", content: []byte("not html")},
+		{name: "malformed HTML", filename: "article.html", mediaType: "text/html", content: []byte("<html><body>broken\x00</body></html>")},
+		{name: "control character in visible text", filename: "article.html", mediaType: "text/html", content: []byte("<html><body>broken\x07text</body></html>")},
+		{name: "vertical tab in visible text", filename: "article.html", mediaType: "text/html", content: []byte("<html><body>broken\vtext</body></html>")},
+		{name: "form feed in visible text", filename: "article.html", mediaType: "text/html", content: []byte("<html><body>broken\ftext</body></html>")},
+		{name: "malformed XHTML", filename: "article.xhtml", mediaType: "application/xhtml+xml", content: []byte(`<html xmlns="http://www.w3.org/1999/xhtml"><body>broken</html>`)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			upload := newTestUpload(test.content, test.filename, test.mediaType)
+			_, err := provider.Render(t.Context(), upload,
+				testAuthorization(provider.Descriptor(), upload.Metadata()))
+			assertProviderCode(t, err, document.RenditionErrorUnsupportedInput)
+		})
+	}
+	t.Run("substituted bytes", func(t *testing.T) {
+		upload := newTestUpload(testHTML, "article.html", "text/html")
+		upload.Reader = bytes.NewReader([]byte(`<html><body>replacement</body></html>`))
+		_, err := provider.Render(t.Context(), upload,
+			testAuthorization(provider.Descriptor(), upload.Metadata()))
+		assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+	})
+}
+
+func TestProviderBoundsOutputAndSanitizesProcessFailure(t *testing.T) {
+	t.Run("unbounded stdout stops promptly", func(t *testing.T) {
+		provider := newTestProvider(t, helperExecutable(t, "unbounded-output"), 10*time.Second, 1024)
+		upload := newTestUpload(testHTML, "article.html", "text/html")
+		started := time.Now()
+		_, err := provider.Render(t.Context(), upload,
+			testAuthorization(provider.Descriptor(), upload.Metadata()))
+		assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
+		assert.Less(t, time.Since(started), time.Second)
+	})
+	t.Run("private stderr", func(t *testing.T) {
+		provider := newTestProvider(t, helperExecutable(t, "failure"), time.Second, 1<<20)
+		upload := newTestUpload(testHTML, "article.html", "text/html")
+		_, err := provider.Render(t.Context(), upload,
+			testAuthorization(provider.Descriptor(), upload.Metadata()))
+		assertProviderCode(t, err, document.RenditionErrorTransient)
+		assert.NotContains(t, err.Error(), "private-stderr-token")
+		assert.NotContains(t, err.Error(), provider.executable)
+	})
+}
+
+func TestProviderEnforcesTimeoutCancellationAndExpiry(t *testing.T) {
+	t.Run("timeout", func(t *testing.T) {
+		provider := newTestProvider(t, helperExecutable(t, "wait"), 20*time.Millisecond, 1<<20)
+		upload := newTestUpload(testHTML, "article.html", "text/html")
+		_, err := provider.Render(t.Context(), upload,
+			testAuthorization(provider.Descriptor(), upload.Metadata()))
+		assertProviderCode(t, err, document.RenditionErrorCapacity)
+	})
+	t.Run("cancellation", func(t *testing.T) {
+		provider := newTestProvider(t, helperExecutable(t, "wait"), time.Second, 1<<20)
+		upload := newTestUpload(testHTML, "article.html", "text/html")
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := provider.Render(ctx, upload,
+			testAuthorization(provider.Descriptor(), upload.Metadata()))
+		assertProviderCode(t, err, document.RenditionErrorCanceled)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+	t.Run("expired after child", func(t *testing.T) {
+		provider := newTestProvider(t, helperExecutable(t, "slow-complete"), time.Second, 1<<20)
+		upload := newTestUpload(testHTML, "article.html", "text/html")
+		authorization := testAuthorization(provider.Descriptor(), upload.Metadata())
+		authorization.ExpiresAt = time.Now().UTC().Add(15 * time.Millisecond).Format(providerutil.TimestampForm)
+		_, err := provider.Render(t.Context(), upload, authorization)
+		assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+	})
+}
+
+func TestProviderCancellationClosesBlockedAuthorizedUploadBeforeStartingRunner(t *testing.T) {
+	executable := helperExecutable(t, "complete")
+	runner := &recordingRunner{identity: testRunnerIdentity}
+	profile := testProfile(t, executable, time.Second, 1<<20)
+	profile.Runner = runner
+	provider, err := New(profile)
+	require.NoError(t, err)
+	base := newTestUpload(testHTML, "article.html", "text/html")
+	upload := &blockingUpload{metadata: base.metadata, started: make(chan struct{}), closed: make(chan struct{})}
+	ctx, cancel := context.WithCancel(t.Context())
+	result := make(chan error, 1)
+	go func() {
+		_, renderErr := provider.Render(ctx, upload,
+			testAuthorization(provider.Descriptor(), upload.Metadata()))
+		result <- renderErr
+	}()
+	<-upload.started
+	cancel()
+
+	select {
+	case err := <-result:
+		assertProviderCode(t, err, document.RenditionErrorCanceled)
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("render remained blocked in the authorized upload read after cancellation")
+	}
+	assert.Nil(t, runner.request)
+}
+
+func TestNewPinsExecutableRuntimeIdentityAndBounds(t *testing.T) {
+	first := newTestProvider(t, helperExecutable(t, "complete"), time.Second, 1<<20)
+	second := newTestProvider(t, helperExecutable(t, "complete-copy"), time.Second, 1<<20)
+	descriptor := first.Descriptor()
+	assert.Equal(t, document.RenditionTrustLocalProcess, descriptor.TrustBoundary)
+	assert.Equal(t, []document.RenditionFormatCapability{
+		{MediaFamily: "text", MediaType: "application/xhtml+xml", InputKind: document.RenditionInputOriginalFile},
+		{MediaFamily: "text", MediaType: "text/html", InputKind: document.RenditionInputOriginalFile},
+	}, descriptor.SupportedFormats)
+	assert.True(t, descriptor.ReturnsStructured)
+	assert.NotEqual(t, descriptor.Fingerprint, second.Descriptor().Fingerprint)
+
+	for _, name := range []string{"pyw.exe", "python3", "pythonw.exe", "pythonw3.11.exe"} {
+		python := filepath.Join(t.TempDir(), name)
+		require.NoError(t, os.WriteFile(python, []byte("synthetic"), 0o700))
+		_, err := New(Profile{Executable: python, RuntimeIdentity: testRuntimeIdentity,
+			MaxDocumentBytes: 1, MaxResponseBytes: 1, MaxUnits: 1, Timeout: time.Second})
+		require.ErrorContains(t, err, "must not be a Python interpreter")
+	}
+
+	valid := testProfile(t, helperExecutable(t, "complete"), time.Second, 1024)
+	valid.MaxDocumentBytes = 1024
+	valid.MaxUnits = 1
+	for _, mutate := range []func(*Profile){
+		func(profile *Profile) { profile.Executable = "renderer" },
+		func(profile *Profile) { profile.RuntimeIdentity = "" },
+		func(profile *Profile) { profile.MaxDocumentBytes = 0 },
+		func(profile *Profile) { profile.MaxResponseBytes = 0 },
+		func(profile *Profile) { profile.MaxUnits = 0 },
+		func(profile *Profile) { profile.Timeout = 0 },
+	} {
+		profile := valid
+		mutate(&profile)
+		_, err := New(profile)
+		require.Error(t, err)
+	}
+}
+
+var testHTML = []byte(`<!doctype html><html><body><h1>Local title</h1><p>Local body</p></body></html>`)
+
+func newTestProvider(t *testing.T, executable string, timeout time.Duration, maxResponse int64) *Provider {
+	t.Helper()
+	profile := testProfile(t, executable, timeout, maxResponse)
+	provider, err := New(profile)
+	require.NoError(t, err)
+	return provider
+}
+
+func testProfile(t *testing.T, executable string, timeout time.Duration, maxResponse int64) Profile {
+	t.Helper()
+	data, err := os.ReadFile(executable)
+	require.NoError(t, err)
+	digest := sha256.Sum256(data)
+	return Profile{
+		Executable: executable, ExecutableSHA256: hex.EncodeToString(digest[:]),
+		RuntimeIdentity: testRuntimeIdentity, Runner: &recordingRunner{identity: testRunnerIdentity},
+		MaxDocumentBytes: 1 << 20, MaxResponseBytes: maxResponse, MaxUnits: 10, Timeout: timeout,
+	}
+}
+
+func assertProviderCode(t *testing.T, err error, want document.RenditionErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
+	require.True(t, ok, "%T: %v", err, err)
+	assert.Equal(t, want, providerErr.Code())
+}
+
+func helperExecutable(t *testing.T, mode string) string {
+	t.Helper()
+	target := filepath.Join(t.TempDir(), "renderer-"+mode)
+	require.NoError(t, os.WriteFile(target, []byte("synthetic isolated executable fixture\n"), 0o700))
+	return target
+}
+
+type testUpload struct {
+	*bytes.Reader
+
+	metadata document.AuthorizedUploadMetadata
+}
+
+func newTestUpload(data []byte, filename, mediaType string) *testUpload {
+	digest := sha256.Sum256(data)
+	return &testUpload{Reader: bytes.NewReader(data), metadata: document.AuthorizedUploadMetadata{
+		Filename: filename, MediaFamily: "text", MediaType: mediaType,
+		ByteLength: int64(len(data)), SHA256: hex.EncodeToString(digest[:]),
+		CapabilityRecordChecksum: strings.Repeat("2", 64), ProviderMetadataChecksum: strings.Repeat("3", 64),
+		InputKind: document.RenditionInputOriginalFile,
+	}}
+}
+
+func (*testUpload) Close() error                                       { return nil }
+func (upload *testUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+func testAuthorization(descriptor document.RenditionDescriptor, metadata document.AuthorizedUploadMetadata) document.RenditionAuthorization {
+	started := time.Now().UTC().Add(-time.Minute)
+	return document.RenditionAuthorization{
+		ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+		PolicyFingerprint: descriptor.PolicyFingerprint, RenditionRequestFingerprint: strings.Repeat("4", 64),
+		SourceSHA256: metadata.SHA256, SourceBytes: metadata.ByteLength,
+		CapabilityRecordChecksum: metadata.CapabilityRecordChecksum,
+		ProviderMetadataChecksum: metadata.ProviderMetadataChecksum,
+		MediaFamily:              metadata.MediaFamily, MediaType: metadata.MediaType,
+		InputKind: metadata.InputKind, DiscloseFilename: true, MaxTotalResultBytes: 1 << 20,
+		AuthorizedAt: started.Format(providerutil.TimestampForm),
+		ExpiresAt:    started.Add(10 * time.Minute).Format(providerutil.TimestampForm),
+	}
+}
+
+var _ document.AuthorizedUpload = (*testUpload)(nil)
+var _ io.ReadCloser = (*testUpload)(nil)
+
+type blockingUpload struct {
+	metadata  document.AuthorizedUploadMetadata
+	started   chan struct{}
+	closed    chan struct{}
+	startOnce sync.Once
+	closeOnce sync.Once
+}
+
+func (upload *blockingUpload) Read([]byte) (int, error) {
+	upload.startOnce.Do(func() { close(upload.started) })
+	<-upload.closed
+	return 0, errors.New("synthetic read closed")
+}
+
+func (upload *blockingUpload) Close() error {
+	upload.closeOnce.Do(func() { close(upload.closed) })
+	return nil
+}
+
+func (upload *blockingUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+var _ document.AuthorizedUpload = (*blockingUpload)(nil)

--- a/document/trafilatura/provider_test.go
+++ b/document/trafilatura/provider_test.go
@@ -137,7 +137,7 @@ func TestInspectHTMLBoundsNaturalSectionsAndPreservesSiblingOrdinals(t *testing.
 		<section><h2>Two</h2><p>Second</p></section>
 		<section><h3>Three</h3><p>Third</p></section>
 	</body></html>`)
-	authority, err := inspectHTML(source, "text/html", 3)
+	authority, err := inspectHTML(t.Context(), source, "text/html", 3)
 	require.NoError(t, err)
 	require.Len(t, authority.sections, 3)
 	assert.Equal(t, []string{
@@ -146,9 +146,17 @@ func TestInspectHTMLBoundsNaturalSectionsAndPreservesSiblingOrdinals(t *testing.
 		"/html[1]/body[1]/section[3]",
 	}, []string{authority.sections[0].path, authority.sections[1].path, authority.sections[2].path})
 
-	authority, err = inspectHTML(source, "text/html", 2)
+	authority, err = inspectHTML(t.Context(), source, "text/html", 2)
 	require.NoError(t, err)
 	assert.Nil(t, authority.sections, "over-bound structure must use degraded provenance")
+}
+
+func TestInspectHTMLHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := inspectHTML(ctx, testHTML, "text/html", 10)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestProviderRejectsOutputNotDerivableFromSuppliedBytes(t *testing.T) {

--- a/document/trafilatura/runner_contract_test.go
+++ b/document/trafilatura/runner_contract_test.go
@@ -37,6 +37,14 @@ func TestNewRequiresPinnedIsolatedRunnerAndExecutableDigest(t *testing.T) {
 	require.NoError(t, err)
 
 	profile.Runner = nil
+	if runtime.GOOS == "linux" {
+		profile.Executable, err = os.Executable()
+		require.NoError(t, err)
+		executableBytes, err = os.ReadFile(profile.Executable)
+		require.NoError(t, err)
+		digest = sha256.Sum256(executableBytes)
+		profile.ExecutableSHA256 = hex.EncodeToString(digest[:])
+	}
 	provider, err := New(profile)
 	if runtime.GOOS == "linux" {
 		require.NoError(t, err)

--- a/document/trafilatura/runner_contract_test.go
+++ b/document/trafilatura/runner_contract_test.go
@@ -1,0 +1,346 @@
+package trafilatura
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+)
+
+const testRunnerIdentity = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+func TestNewRequiresPinnedIsolatedRunnerAndExecutableDigest(t *testing.T) {
+	executable := helperExecutable(t, "complete")
+	executableBytes, err := os.ReadFile(executable)
+	require.NoError(t, err)
+	digest := sha256.Sum256(executableBytes)
+	profile := Profile{
+		Executable: executable, ExecutableSHA256: hex.EncodeToString(digest[:]),
+		RuntimeIdentity: testRuntimeIdentity, Runner: &recordingRunner{identity: testRunnerIdentity},
+		MaxDocumentBytes: 1 << 20, MaxResponseBytes: 1 << 20, MaxUnits: 10, Timeout: time.Second,
+	}
+
+	_, err = New(profile)
+	require.NoError(t, err)
+
+	profile.Runner = nil
+	provider, err := New(profile)
+	if runtime.GOOS == "linux" {
+		require.NoError(t, err)
+		require.NotNil(t, provider.runner)
+	} else {
+		require.ErrorIs(t, err, ErrIsolationUnavailable)
+	}
+
+	profile.Runner = &recordingRunner{identity: "mutable-latest"}
+	_, err = New(profile)
+	require.ErrorContains(t, err, "runner identity")
+
+	profile.Runner = &recordingRunner{identity: testRunnerIdentity}
+	profile.ExecutableSHA256 = ""
+	_, err = New(profile)
+	require.ErrorContains(t, err, "executable SHA-256")
+
+	profile.ExecutableSHA256 = hex.EncodeToString(digest[:])
+	profile.RuntimeIdentity = "mutable-latest"
+	_, err = New(profile)
+	require.ErrorContains(t, err, "runtime identity")
+}
+
+func TestProviderDelegatesOnlyAnExactFailClosedIsolationRequest(t *testing.T) {
+	t.Setenv("DOCBANK_TRAFILATURA_AMBIENT_SECRET", "must-not-reach-runner")
+	executable := helperExecutable(t, "complete")
+	runner := &recordingRunner{identity: testRunnerIdentity}
+	profile := testProfile(t, executable, time.Second, 1<<20)
+	profile.Runner = runner
+	provider, err := New(profile)
+	require.NoError(t, err)
+	source := []byte(`<!doctype html><html><body><h1>Local title</h1><p>Local body</p><a href="https://private.example/a">link</a></body></html>`)
+	upload := newTestUpload(source, "article.html", "text/html")
+
+	_, err = document.RenderRendition(t.Context(), provider, upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	require.NoError(t, err)
+	require.NotNil(t, runner.request, "provider bypassed the isolated runner")
+	assert.Equal(t, executable, runner.request.Executable)
+	assert.Equal(t, profile.ExecutableSHA256, runner.request.ExecutableSHA256)
+	assert.Equal(t, []string{"--protocol", protocolVersion}, runner.request.Arguments)
+	expectedEnvironment := []string{
+		"LANG=C.UTF-8", "LC_ALL=C.UTF-8", "TZ=UTC", "PYTHONHASHSEED=0",
+		"PYTHONNOUSERSITE=1", "PYTHONDONTWRITEBYTECODE=1",
+	}
+	if runtime.GOOS == "windows" {
+		if systemRoot := os.Getenv("SystemRoot"); systemRoot != "" {
+			expectedEnvironment = append(expectedEnvironment, "SystemRoot="+systemRoot)
+		}
+	}
+	assert.Equal(t, expectedEnvironment, runner.request.Environment)
+	assert.NotContains(t, strings.Join(runner.request.Environment, "\n"), "must-not-reach-runner")
+	assert.Equal(t, filepath.Dir(executable), runner.request.Directory)
+	assert.Equal(t, source, runner.request.Stdin)
+	stdinDigest := sha256.Sum256(source)
+	assert.Equal(t, hex.EncodeToString(stdinDigest[:]), runner.request.StdinSHA256)
+	assert.Equal(t, int64(1<<20), runner.request.MaxStdoutBytes)
+	assert.Equal(t, IsolationRequirements{
+		NetworkDisabled: true, KillProcessTree: true, VerifyExecutableSHA256: true,
+		FilesystemIsolated: true,
+	}, runner.request.Requirements)
+	require.Len(t, runner.request.PolicyFingerprint, 64)
+}
+
+func TestProviderRejectsIncompleteOrMismatchedIsolationAttestation(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*IsolationAttestation)
+	}{
+		{name: "runner identity", mutate: func(value *IsolationAttestation) { value.RunnerIdentity = testRuntimeIdentity }},
+		{name: "policy", mutate: func(value *IsolationAttestation) { value.PolicyFingerprint = strings.Repeat("0", 64) }},
+		{name: "executable", mutate: func(value *IsolationAttestation) { value.ExecutableSHA256 = strings.Repeat("0", 64) }},
+		{name: "stdin", mutate: func(value *IsolationAttestation) { value.StdinSHA256 = strings.Repeat("0", 64) }},
+		{name: "network", mutate: func(value *IsolationAttestation) { value.NetworkDisabled = false }},
+		{name: "process tree", mutate: func(value *IsolationAttestation) { value.ProcessTreeContained = false }},
+		{name: "digest launch", mutate: func(value *IsolationAttestation) { value.DigestVerifiedLaunch = false }},
+		{name: "filesystem", mutate: func(value *IsolationAttestation) { value.FilesystemIsolated = false }},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			executable := helperExecutable(t, "complete")
+			runner := &recordingRunner{identity: testRunnerIdentity}
+			runner.run = func(ctx context.Context, request IsolatedRunRequest) (IsolatedRunResult, error) {
+				result, err := defaultRun(ctx, runner.identity, request)
+				testCase.mutate(&result.Attestation)
+				return result, err
+			}
+			profile := testProfile(t, executable, time.Second, 1<<20)
+			profile.Runner = runner
+			provider, err := New(profile)
+			require.NoError(t, err)
+			upload := newTestUpload(testHTML, "article.html", "text/html")
+
+			_, err = provider.Render(t.Context(), upload,
+				testAuthorization(provider.Descriptor(), upload.Metadata()))
+			assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+		})
+	}
+}
+
+func TestProviderReverifiesExecutableAndRunnerIdentityBeforeEveryRun(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		mutate func(t *testing.T, executable string, runner *recordingRunner)
+	}{
+		{name: "executable replacement", mutate: func(t *testing.T, executable string, _ *recordingRunner) {
+			t.Helper()
+			require.NoError(t, os.WriteFile(executable, []byte("synthetic replacement"), 0o700))
+		}},
+		{name: "runner identity drift", mutate: func(_ *testing.T, _ string, runner *recordingRunner) {
+			runner.identity = testRuntimeIdentity
+		}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			executable := helperExecutable(t, "complete")
+			runner := &recordingRunner{identity: testRunnerIdentity}
+			profile := testProfile(t, executable, time.Second, 1<<20)
+			profile.Runner = runner
+			provider, err := New(profile)
+			require.NoError(t, err)
+			testCase.mutate(t, executable, runner)
+			upload := newTestUpload(testHTML, "article.html", "text/html")
+
+			_, err = provider.Render(t.Context(), upload,
+				testAuthorization(provider.Descriptor(), upload.Metadata()))
+			assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+			assert.Nil(t, runner.request)
+		})
+	}
+}
+
+func TestProviderFailsClosedWhenRunnerCannotEnforceIsolation(t *testing.T) {
+	executable := helperExecutable(t, "complete")
+	runner := &recordingRunner{identity: testRunnerIdentity, run: func(
+		context.Context, IsolatedRunRequest,
+	) (IsolatedRunResult, error) {
+		return IsolatedRunResult{}, errors.Join(ErrIsolationUnavailable, errors.New("private-runner-detail"))
+	}}
+	profile := testProfile(t, executable, time.Second, 1<<20)
+	profile.Runner = runner
+	provider, err := New(profile)
+	require.NoError(t, err)
+	upload := newTestUpload(testHTML, "article.html", "text/html")
+
+	_, err = provider.Render(t.Context(), upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+	assert.NotContains(t, err.Error(), "private-runner-detail")
+}
+
+func TestProviderRequiresProcessTreeCleanupAttestationAfterRunnerCancellation(t *testing.T) {
+	executable := helperExecutable(t, "complete")
+	runner := &recordingRunner{identity: testRunnerIdentity}
+	runner.run = func(ctx context.Context, request IsolatedRunRequest) (IsolatedRunResult, error) {
+		<-ctx.Done()
+		result := isolatedResult(runner.identity, request, nil)
+		result.Attestation.ProcessTreeContained = false
+		return result, ctx.Err()
+	}
+	profile := testProfile(t, executable, 10*time.Millisecond, 1<<20)
+	profile.Runner = runner
+	provider, err := New(profile)
+	require.NoError(t, err)
+	upload := newTestUpload(testHTML, "article.html", "text/html")
+
+	_, err = provider.Render(t.Context(), upload,
+		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+}
+
+func TestProviderConstrainsRunnerStdoutToAuthorizedTotalResultBytes(t *testing.T) {
+	executable := helperExecutable(t, "complete")
+	runner := &recordingRunner{identity: testRunnerIdentity, run: func(
+		context.Context, IsolatedRunRequest,
+	) (IsolatedRunResult, error) {
+		return IsolatedRunResult{}, ErrIsolationUnavailable
+	}}
+	profile := testProfile(t, executable, time.Second, 1<<20)
+	profile.Runner = runner
+	provider, err := New(profile)
+	require.NoError(t, err)
+	upload := newTestUpload(testHTML, "article.html", "text/html")
+	authorization := testAuthorization(provider.Descriptor(), upload.Metadata())
+	authorization.MaxTotalResultBytes = 128
+
+	_, err = provider.Render(t.Context(), upload, authorization)
+	assertProviderCode(t, err, document.RenditionErrorPolicyRejected)
+	require.NotNil(t, runner.request)
+	assert.Equal(t, int64(128), runner.request.MaxStdoutBytes)
+}
+
+type recordingRunner struct {
+	identity string
+	request  *IsolatedRunRequest
+	run      func(context.Context, IsolatedRunRequest) (IsolatedRunResult, error)
+}
+
+func (runner *recordingRunner) Identity() string { return runner.identity }
+
+func (runner *recordingRunner) Run(ctx context.Context, request IsolatedRunRequest) (IsolatedRunResult, error) {
+	copied := request
+	copied.Arguments = append([]string(nil), request.Arguments...)
+	copied.Environment = append([]string(nil), request.Environment...)
+	copied.Stdin = append([]byte(nil), request.Stdin...)
+	runner.request = &copied
+	if runner.run != nil {
+		return runner.run(ctx, request)
+	}
+	return defaultRun(ctx, runner.identity, request)
+}
+
+func defaultRun(ctx context.Context, runnerIdentity string, request IsolatedRunRequest) (IsolatedRunResult, error) {
+	mode := strings.TrimSuffix(filepath.Base(request.Executable), filepath.Ext(request.Executable))
+	mode = strings.TrimPrefix(mode, "renderer-")
+	switch mode {
+	case "failure":
+		return isolatedResult(runnerIdentity, request, nil),
+			errors.Join(ErrChildFailed, errors.New("private-stderr-token"))
+	case "wait":
+		<-ctx.Done()
+		return isolatedResult(runnerIdentity, request, nil), ctx.Err()
+	case "slow-complete":
+		select {
+		case <-ctx.Done():
+			return isolatedResult(runnerIdentity, request, nil), ctx.Err()
+		case <-time.After(40 * time.Millisecond):
+		}
+	case "unbounded-output":
+		return isolatedResult(runnerIdentity, request, nil), ErrChildOutputTooLarge
+	case "malformed":
+		return isolatedResult(runnerIdentity, request, []byte("{")), nil
+	}
+	digest := sha256.Sum256(request.Stdin)
+	value := response{ContractVersion: protocolVersion, RuntimeIdentity: testRuntimeIdentity,
+		SourceSHA256: hex.EncodeToString(digest[:]), SourceBytes: int64(len(request.Stdin)),
+		ExtractionComplete: true, ProvenanceComplete: new(false),
+		Units: []responseUnit{{Text: "Local title Local body"}},
+	}
+	if strings.Contains(string(request.Stdin), "link") {
+		value.Units[0].Text += " link"
+	}
+	switch mode {
+	case "degraded":
+		value.Units[0].Text = "Local title\n\nLocal body"
+	case "fetched":
+		value.Units[0].Text += " REMOTE_FETCH_TOKEN"
+	case "version-drift":
+		value.ContractVersion += ".next"
+	case "runtime-drift":
+		value.RuntimeIdentity = "sha256:" + strings.Repeat("c", 64)
+	case "source-hash-drift":
+		value.SourceSHA256 = strings.Repeat("c", 64)
+	case "source-size-drift":
+		value.SourceBytes++
+	case "partial":
+		value.Units = append(value.Units, responseUnit{})
+	case "empty":
+		value.Units = nil
+	case "bad-heading":
+		value.Units[0].Heading = "Fetched heading"
+	case "complete-inexact":
+		value.Units[0].Text = "Local title"
+	case "extraction-incomplete":
+		value.ExtractionComplete = false
+	case "truncated-degraded":
+		value.Units[0].Text = "Local title"
+	case "structured":
+		value.ProvenanceComplete = new(true)
+		value.Units[0].SourcePath = "/html[1]/body[1]/section[1]"
+		value.Units[0].Heading = "Local title"
+	case "structured-path-drift":
+		value.ProvenanceComplete = new(true)
+		value.Units[0].SourcePath = "/html[1]/body[1]/section[2]"
+		value.Units[0].Heading = "Local title"
+	case "structured-boundary-drift":
+		value.ProvenanceComplete = new(true)
+		value.Units[0].SourcePath = "/html[1]/body[1]/section[1]"
+		value.Units[0].Heading = "Local title"
+		value.Units[0].Text = "Local title"
+	case "structured-duplicate":
+		value.ProvenanceComplete = new(true)
+		value.Units = []responseUnit{
+			{SourcePath: "/html[1]/body[1]/section[1]", Heading: "Repeat", Text: "Repeat First"},
+			{SourcePath: "/html[1]/body[1]/section[2]", Heading: "Repeat", Text: "Repeat Second"},
+		}
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return IsolatedRunResult{}, err
+	}
+	if mode == "unknown-field" {
+		encoded = append(encoded[:len(encoded)-1], []byte(`,"unexpected":true}`)...)
+	}
+	if mode == "missing-provenance-complete" {
+		encoded = bytes.Replace(encoded, []byte(`,"provenance_complete":false`), nil, 1)
+	}
+	return isolatedResult(runnerIdentity, request, encoded), nil
+}
+
+func isolatedResult(runnerIdentity string, request IsolatedRunRequest, stdout []byte) IsolatedRunResult {
+	stdinDigest := sha256.Sum256(request.Stdin)
+	return IsolatedRunResult{Stdout: stdout, Attestation: IsolationAttestation{
+		RunnerIdentity: runnerIdentity, PolicyFingerprint: request.PolicyFingerprint,
+		ExecutableSHA256: request.ExecutableSHA256, StdinSHA256: hex.EncodeToString(stdinDigest[:]),
+		NetworkDisabled: true, ProcessTreeContained: true, DigestVerifiedLaunch: true,
+		FilesystemIsolated: true,
+	}}
+}

--- a/document/trafilatura/testdata/isolatedhelper/main.go
+++ b/document/trafilatura/testdata/isolatedhelper/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+)
+
+var (
+	mode           = "echo"
+	networkAddress string
+)
+
+type echoResponse struct {
+	Arguments   []string `json:"arguments"`
+	Environment []string `json:"environment"`
+	StdinSHA256 string   `json:"stdin_sha256"`
+}
+
+func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--descendant" {
+		if _, err := fmt.Fprintln(os.Stdout, "descendant-ready"); err != nil || os.Stdout.Sync() != nil {
+			os.Exit(6)
+		}
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+
+	switch mode {
+	case "echo", "replacement":
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			os.Exit(2)
+		}
+		digest := sha256.Sum256(data)
+		_ = json.NewEncoder(os.Stdout).Encode(echoResponse{
+			Arguments: os.Args[1:], Environment: os.Environ(),
+			StdinSHA256: hex.EncodeToString(digest[:]),
+		})
+	case "network":
+		connection, err := net.DialTimeout("tcp", networkAddress, time.Second)
+		if err != nil {
+			fmt.Print("denied")
+			return
+		}
+		_ = connection.Close()
+		fmt.Print("connected")
+	case "unix-network":
+		connection, err := net.DialTimeout("unix", networkAddress, time.Second)
+		if err != nil {
+			fmt.Print("denied")
+			return
+		}
+		_ = connection.Close()
+		fmt.Print("connected")
+	case "host-file":
+		_, readErr := os.ReadFile(networkAddress)
+		writeErr := os.WriteFile(networkAddress, []byte("modified"), 0o600)
+		chmodErr := os.Chmod(networkAddress, 0o644)
+		changedTime := time.Unix(1, 0)
+		timesErr := os.Chtimes(networkAddress, changedTime, changedTime)
+		if readErr != nil && writeErr != nil && chmodErr != nil && timesErr != nil {
+			fmt.Print("denied")
+		} else {
+			fmt.Print("exposed")
+		}
+	case "descendant":
+		command := exec.Command("/proc/self/exe", "--descendant")
+		command.Stdout = os.Stdout
+		command.Stderr = os.Stderr
+		if err := command.Start(); err != nil {
+			os.Exit(3)
+		}
+		fmt.Print("spawned")
+		_ = os.Stdout.Sync()
+		for {
+			time.Sleep(time.Hour)
+		}
+	case "overflow":
+		block := make([]byte, 32<<10)
+		for {
+			if _, err := os.Stdout.Write(block); err != nil {
+				return
+			}
+		}
+	case "exit-125":
+		os.Exit(125)
+	default:
+		os.Exit(4)
+	}
+}


### PR DESCRIPTION
## What changed

Docbank now has a local Trafilatura provider for exact supplied HTML and XHTML bytes. It exposes no URL, redirect, linked-resource, feed, sitemap, remote-metadata, or arbitrary option surface. Accepted output must cover the locally parsed visible text exactly; section provenance is complete only when Docbank verifies the supplied DOM paths and headings itself.

On Linux, the default runner seals the digest-verified bridge executable, launches it inside private user, network, PID, and mount namespaces, and applies no-new-privileges plus a seccomp boundary. IP and Unix sockets, io_uring networking paths, and the amd64 x32 syscall ABI are denied. Output is bounded while streaming, cancellation and overflow tear down the full process tree, and launcher setup failures remain distinct from bridge exit codes.

## Why

HTML extraction should stay local and never turn into ambient web fetching or invented structure. Running a parser binary also needs a real isolation boundary; “local process” is not enough if it can reach the network, host sockets, unrelated processes, or arbitrary files.

## Usage

For library use on Linux, construct the provider with `trafilatura.New(profile)`. The profile pins the exact bridge executable, its SHA-256, immutable runtime identity, and finite limits; the built-in runner supplies the isolation boundary. macOS and Windows require a separately audited injected runner and otherwise fail closed.

This PR does not add daemon, API, or CLI selection. The approved S1–S3 application-surface work will construct and register providers with the R10 runtime registry.

Part of #176 (R17). Stacks on #208.
