### PR TITLE
[F10–E12 16/25] Make embedding generations durable and independently activatable

### DIFF
--- a/document/chunking_test.go
+++ b/document/chunking_test.go
@@ -706,6 +706,37 @@ func TestEmbeddingInputGenerationDecodeAppliesCallerBounds(t *testing.T) {
 	require.ErrorContains(t, err, "decode bound is invalid")
 }
 
+func TestEmbeddingInputGenerationValidatesEvidenceSpans(t *testing.T) {
+	evidence := testChunkEvidence(t, []sourceChunkUnit{{text: "é界AB", heading: []string{"Evidence"}}})
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*GeneratedEmbeddingInput)
+	}{
+		{"missing unit", func(input *GeneratedEmbeddingInput) { input.SourceSpan.UnitIndex = 1 }},
+		{"out of bounds", func(input *GeneratedEmbeddingInput) { input.SourceSpan.CharEnd = 100 }},
+		{"wrong span", func(input *GeneratedEmbeddingInput) {
+			input.SourceSpan.CharStart++
+			input.SourceSpan.CharEnd++
+		}},
+		{"headings", func(input *GeneratedEmbeddingInput) { input.HeadingPath = []string{"Invented"} }},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			generation := build(t, evidence, testInputPolicy(t, 1, 0))
+			require.NoError(t, generation.ValidateEvidence(evidence))
+			testCase.mutate(&generation.Inputs[0])
+			var err error
+			generation.Checksum, err = generationChecksum(generation)
+			require.NoError(t, err)
+			_, err = MarshalEmbeddingInputGeneration(generation)
+			require.NoError(t, err, "the forgery must satisfy internal generation validation")
+			require.ErrorContains(t, generation.ValidateEvidence(evidence), "source span")
+		})
+	}
+	generation := build(t, evidence, testInputPolicy(t, 1, 0))
+	otherEvidence := testChunkEvidence(t, []sourceChunkUnit{{text: "Other text"}})
+	require.ErrorContains(t, generation.ValidateEvidence(otherEvidence), "evidence checksum")
+}
+
 func TestEmbeddingInputGenerationMapsContextIntoE1ExactlyOnce(t *testing.T) {
 	evidence := testChunkEvidence(t, []sourceChunkUnit{{text: "AABB", heading: []string{"Evidence"}}})
 	attachment, err := NewAttachmentContextSnapshot("Human title", "Human context")
@@ -866,6 +897,7 @@ func testChunkEvidence(t *testing.T, units []sourceChunkUnit) NormalizedEvidence
 
 func assertGenerationSpans(t *testing.T, evidence NormalizedEvidenceV1, generation EmbeddingInputGeneration) {
 	t.Helper()
+	require.NoError(t, generation.ValidateEvidence(evidence))
 	for _, input := range generation.Inputs {
 		span := input.SourceSpan
 		require.GreaterOrEqual(t, span.UnitIndex, 0)

--- a/document/generation.go
+++ b/document/generation.go
@@ -214,6 +214,43 @@ func DecodeEmbeddingInputGeneration(data []byte, bounds EmbeddingInputGeneration
 	return generation, nil
 }
 
+// ValidateEvidence verifies that each input's text and headings come from its
+// declared span in the canonical evidence. Checksums within a generation alone
+// cannot establish this relationship.
+func (generation EmbeddingInputGeneration) ValidateEvidence(evidence NormalizedEvidenceV1) error {
+	if err := validateEmbeddingInputGeneration(generation); err != nil {
+		return err
+	}
+	_, checksum, err := MarshalNormalizedEvidenceV1(evidence)
+	if err != nil {
+		return err
+	}
+	if checksum != generation.EvidenceChecksum {
+		return errors.New("embedding generation evidence checksum mismatch")
+	}
+	unitRunes := make(map[int][]rune)
+	for index, input := range generation.Inputs {
+		span := input.SourceSpan
+		if span.UnitIndex < 0 || span.UnitIndex >= len(evidence.Units) {
+			return fmt.Errorf("embedding input %d source span names a missing evidence unit", index)
+		}
+		unit := evidence.Units[span.UnitIndex]
+		runes, ok := unitRunes[span.UnitIndex]
+		if !ok {
+			runes = []rune(unit.Text)
+			unitRunes[span.UnitIndex] = runes
+		}
+		if span.CharStart < 0 || span.CharEnd <= span.CharStart || span.CharEnd > len(runes) ||
+			string(runes[span.CharStart:span.CharEnd]) != input.Content {
+			return fmt.Errorf("embedding input %d content does not match evidence source span", index)
+		}
+		if !slices.Equal(input.HeadingPath, unit.HeadingPath) {
+			return fmt.Errorf("embedding input %d headings do not match evidence source span", index)
+		}
+	}
+	return nil
+}
+
 // ToEmbeddingInputs reconstructs the contextualized pre-envelope text for E1.
 // The complete model-input fingerprint must match before any input is exposed,
 // even when two contracts happen to share a document envelope.

--- a/document/pymupdf/provider_test.go
+++ b/document/pymupdf/provider_test.go
@@ -177,14 +177,14 @@ func TestProviderBoundsOutputAndSanitizesProcessFailure(t *testing.T) {
 }
 
 func TestProviderTerminatesChildThatNeverStopsOversizedOutput(t *testing.T) {
-	provider := newTestProvider(t, helperExecutable(t, "unbounded-output"), 2*time.Second, 1024)
+	provider := newTestProvider(t, helperExecutable(t, "unbounded-output"), 30*time.Second, 1024)
 	upload := newTestUpload(testPDF(2))
-	started := time.Now()
 
 	_, err := provider.Render(t.Context(), upload,
 		testAuthorization(provider.Descriptor(), upload.Metadata()))
+	// A child stopped only by the deadline returns a timeout error instead.
+	// Check the termination reason, not executable startup and cleanup speed.
 	assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
-	assert.Less(t, time.Since(started), time.Second)
 	assert.NotContains(t, err.Error(), "broken pipe")
 }
 

--- a/internal/store/blob_roots.go
+++ b/internal/store/blob_roots.go
@@ -11,6 +11,16 @@ const (
 type blobReference struct {
 	table  string
 	column string
+	// condition restricts references whose column serves another purpose in
+	// other rows. It uses the same r alias as the shared query builders.
+	condition string
+}
+
+func (reference blobReference) conditionSQL() string {
+	if reference.condition == "" {
+		return ""
+	}
+	return " AND " + reference.condition
 }
 
 // blobRootReferences is the single definition of "something still needs
@@ -25,6 +35,7 @@ var blobRootReferences = []blobReference{
 	{table: "rendition_jobs", column: columnSourceSHA256},
 	{table: "rendition_artifacts", column: columnBlobHash},
 	{table: "embedding_input_generations", column: "generation_blob_hash"},
+	{table: "embedding_input_generations", column: "evidence_fingerprint", condition: "r.generation_blob_hash IS NOT NULL"},
 	{table: "embedding_vector_sets", column: "payload_blob_hash"},
 	{table: "visual_preview_generations", column: "output_blob_hash"},
 }
@@ -44,7 +55,7 @@ func blobUnreferencedSQL(hashExpr string, references ...[]blobReference) string 
 	for _, group := range references {
 		for _, reference := range group {
 			clauses = append(clauses, "NOT EXISTS (SELECT 1 FROM "+reference.table+
-				" r WHERE r."+reference.column+" = "+hashExpr+")")
+				" r WHERE r."+reference.column+" = "+hashExpr+reference.conditionSQL()+")")
 		}
 	}
 	return strings.Join(clauses, "\n\t\t  AND ")
@@ -57,7 +68,7 @@ func blobReferencedSQL(hashExpr string, references ...[]blobReference) string {
 	for _, group := range references {
 		for _, reference := range group {
 			clauses = append(clauses, "EXISTS (SELECT 1 FROM "+reference.table+
-				" r WHERE r."+reference.column+" = "+hashExpr+")")
+				" r WHERE r."+reference.column+" = "+hashExpr+reference.conditionSQL()+")")
 		}
 	}
 	return strings.Join(clauses, "\n\t\t   OR ")
@@ -70,8 +81,8 @@ func blobReferenceRowsSQL(references ...[]blobReference) string {
 	var selects []string
 	for _, group := range references {
 		for _, reference := range group {
-			selects = append(selects, "SELECT "+reference.column+" AS blob_hash FROM "+
-				reference.table+" WHERE "+reference.column+" IS NOT NULL")
+			selects = append(selects, "SELECT r."+reference.column+" AS blob_hash FROM "+
+				reference.table+" r WHERE r."+reference.column+" IS NOT NULL"+reference.conditionSQL())
 		}
 	}
 	return strings.Join(selects, "\n\t\t\tUNION ALL\n\t\t\t")

--- a/internal/store/blob_roots.go
+++ b/internal/store/blob_roots.go
@@ -24,6 +24,8 @@ var blobRootReferences = []blobReference{
 	{table: "rendition_builds", column: columnSourceSHA256},
 	{table: "rendition_jobs", column: columnSourceSHA256},
 	{table: "rendition_artifacts", column: columnBlobHash},
+	{table: "embedding_input_generations", column: "generation_blob_hash"},
+	{table: "embedding_vector_sets", column: "payload_blob_hash"},
 	{table: "visual_preview_generations", column: "output_blob_hash"},
 }
 

--- a/internal/store/derivative_suppression.go
+++ b/internal/store/derivative_suppression.go
@@ -70,51 +70,57 @@ func (s *Store) AuthorizeDerivativeRebuild(
 		return err
 	}
 	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		prior, err := loadDerivativePurgeSuppressionTx(ctx, tx, authorization.SourceSHA256,
-			profileFingerprint, authorization.PurgedBuildID)
-		if err != nil {
-			return fmt.Errorf("authorizing derivative rebuild: %w", err)
+		return s.authorizeDerivativeRebuildTx(ctx, tx, authorization, profileFingerprint)
+	})
+}
+
+func (s *Store) authorizeDerivativeRebuildTx(
+	ctx context.Context, tx *sql.Tx, authorization DerivativeRebuildAuthorization, profileFingerprint string,
+) error {
+	prior, err := loadDerivativePurgeSuppressionTx(ctx, tx, authorization.SourceSHA256,
+		profileFingerprint, authorization.PurgedBuildID)
+	if err != nil {
+		return fmt.Errorf("authorizing derivative rebuild: %w", err)
+	}
+	resulting := prior
+	resulting.active = false
+	resulting.supersededAt = authorization.AuthorizedAt
+	resulting.supersedingBuildID = authorization.SupersedingBuildID
+	if !prior.active {
+		if prior == resulting {
+			return nil
 		}
-		resulting := prior
-		resulting.active = false
-		resulting.supersededAt = authorization.AuthorizedAt
-		resulting.supersedingBuildID = authorization.SupersedingBuildID
-		if !prior.active {
-			if prior == resulting {
-				return nil
-			}
-			return errors.New("derivative purge suppression was already superseded differently")
-		}
-		result, err := tx.ExecContext(ctx, `
+		return errors.New("derivative purge suppression was already superseded differently")
+	}
+	result, err := tx.ExecContext(ctx, `
 			UPDATE derivative_purge_suppressions
 			SET active=0,superseded_at=?,superseding_build_id=?
 			WHERE source_sha256=? AND profile_fingerprint=? AND build_id=? AND active=1`,
-			authorization.AuthorizedAt, authorization.SupersedingBuildID,
-			authorization.SourceSHA256, profileFingerprint,
-			authorization.PurgedBuildID)
-		if err != nil {
-			return fmt.Errorf("superseding derivative purge suppression: %w", err)
-		}
-		count, err := rowsAffectedInt(result)
-		if err != nil {
-			return err
-		}
-		if count != 1 {
-			return errors.New("derivative purge suppression changed concurrently")
-		}
-		active, err := auditAuthorityActiveTx(ctx, tx)
-		if err != nil {
-			return err
-		}
-		if !active {
-			return nil
-		}
-		change, err := derivativeSuppressionAuditChange(prior, resulting)
-		if err != nil {
-			return err
-		}
-		return s.persistAuditedDerivativeSuppressionChanges(ctx, tx, []audit.Record{change})
-	})
+		authorization.AuthorizedAt, authorization.SupersedingBuildID,
+		authorization.SourceSHA256, profileFingerprint,
+		authorization.PurgedBuildID)
+	if err != nil {
+		return fmt.Errorf("superseding derivative purge suppression: %w", err)
+	}
+	count, err := rowsAffectedInt(result)
+	if err != nil {
+		return err
+	}
+	if count != 1 {
+		return errors.New("derivative purge suppression changed concurrently")
+	}
+	active, err := auditAuthorityActiveTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if !active {
+		return nil
+	}
+	change, err := derivativeSuppressionAuditChange(prior, resulting)
+	if err != nil {
+		return err
+	}
+	return s.persistAuditedDerivativeSuppressionChanges(ctx, tx, []audit.Record{change})
 }
 
 func installDerivativePurgeSuppressionsTx(

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -149,6 +149,9 @@ type EmbeddingFailureRecord struct {
 	InputKind                    EmbeddingInputKind
 	FailureCode                  EmbeddingFailureCode
 	FailedAt                     string
+	// AttachmentID names the rendition used by a chunk attempt and is empty
+	// for original-file attempts.
+	AttachmentID string
 	// FencingToken uses the same attempt sequence as EmbeddingHeadRecord.
 	FencingToken int64
 }
@@ -559,20 +562,22 @@ func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFail
 		if err == nil && suppression.active {
 			return errors.New("embedding failure binding has an active purge suppression")
 		}
-		if err := validateEmbeddingFailureHeadFence(ctx, tx, record); err != nil {
+		if err := validateEmbeddingFailureEligibility(ctx, tx, record); err != nil {
 			return err
 		}
 		result, err := tx.ExecContext(ctx, `INSERT INTO embedding_failures(
-			content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at,fencing_token
-		) VALUES(?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
-		DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at,fencing_token=excluded.fencing_token
+			content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at,fencing_token,attachment_id
+		) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
+		DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at,
+		fencing_token=excluded.fencing_token,attachment_id=excluded.attachment_id
 		WHERE excluded.fencing_token>embedding_failures.fencing_token OR (
 			excluded.fencing_token=embedding_failures.fencing_token AND
 			excluded.failure_code=embedding_failures.failure_code AND
+			excluded.attachment_id=embedding_failures.attachment_id AND
 			excluded.failed_at=embedding_failures.failed_at
 		)`, record.ContentVersionID,
 			record.ProcessingProfileFingerprint, record.BindingID, record.InputKind,
-			record.FailureCode, record.FailedAt, record.FencingToken)
+			record.FailureCode, record.FailedAt, record.FencingToken, record.AttachmentID)
 		if err != nil {
 			return fmt.Errorf("recording embedding failure: %w", err)
 		}
@@ -587,7 +592,15 @@ func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFail
 	})
 }
 
-func validateEmbeddingFailureHeadFence(ctx context.Context, query metadataQuerier, record EmbeddingFailureRecord) error {
+func validateEmbeddingFailureEligibility(ctx context.Context, query metadataQuerier, record EmbeddingFailureRecord) error {
+	current, err := embeddingAttachmentEligible(ctx, query, record.ContentVersionID,
+		record.ProcessingProfileFingerprint, record.AttachmentID)
+	if err != nil {
+		return fmt.Errorf("checking embedding failure attachment: %w", err)
+	}
+	if !current {
+		return errors.New("embedding failure attachment is not current")
+	}
 	var newerHead bool
 	if err := query.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM embedding_heads
 		WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?
@@ -1321,22 +1334,22 @@ func embeddingSetEligibleTx(ctx context.Context, tx *sql.Tx, set EmbeddingSetRec
 	if live != 1 {
 		return false, nil
 	}
-	return embeddingAttachmentEligible(ctx, tx, set)
+	return embeddingAttachmentEligible(ctx, tx, set.ContentVersionID,
+		set.ProcessingProfileFingerprint, set.InputGeneration.AttachmentID)
 }
 
-// The attachment fence also applies to restored heads. Source visibility is
-// checked on publication, not restore: historical and trashed versions may
-// retain their independently published heads.
-func embeddingAttachmentEligible(ctx context.Context, tx metadataQuerier, set EmbeddingSetRecord) (bool, error) {
-	if set.InputGeneration.AttachmentID == "" {
+// Heads and failures share the attachment fence, including during restore.
+// Source visibility is checked on publication, not restore: historical and
+// trashed versions may retain their independently published heads.
+func embeddingAttachmentEligible(ctx context.Context, tx metadataQuerier, versionID, profileFingerprint, attachmentID string) (bool, error) {
+	if attachmentID == "" {
 		return true, nil
 	}
 	var attached int
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM rendition_heads h
 		JOIN rendition_attachments a ON a.attachment_id=h.attachment_id
 		WHERE h.content_version_id=? AND h.profile_fingerprint=? AND h.attachment_id=?`,
-		set.ContentVersionID, set.ProcessingProfileFingerprint,
-		set.InputGeneration.AttachmentID).Scan(&attached); err != nil {
+		versionID, profileFingerprint, attachmentID).Scan(&attached); err != nil {
 		return false, err
 	}
 	return attached == 1, nil
@@ -1380,6 +1393,13 @@ func validateEmbeddingFailureRecord(record EmbeddingFailureRecord) error {
 	if err := validateCatalogSHA256(record.ProcessingProfileFingerprint, "embedding failure profile"); err != nil {
 		return err
 	}
+	if record.InputKind == document.EmbeddingInputRenditionChunk {
+		if err := validateCatalogSHA256(record.AttachmentID, "embedding failure attachment ID"); err != nil {
+			return err
+		}
+	} else if record.AttachmentID != "" {
+		return errors.New("original-file embedding failure must not name an attachment")
+	}
 	switch record.FailureCode {
 	case EmbeddingFailureProviderUnavailable, EmbeddingFailureAuthorization,
 		EmbeddingFailureInvalidResponse, EmbeddingFailureInputRejected, EmbeddingFailureStaleAuthority:
@@ -1418,7 +1438,7 @@ var embeddingCatalogSchema = []embeddingCatalogTableSchema{
 	{"embedding_vector_rows", []string{"vector_set_id", "row_id", "row_order", "input_id", "dimensions", "checksum"}},
 	{"embedding_sets", []string{"embedding_set_id", "vault_uid", "binding_id", "input_kind", metadataContentVersionIDField, metadataEmbeddingProfileField, "embedding_input_fingerprint", metadataEmbeddingVectorSpaceIDField, "input_generation_id", "vector_set_id", metadataCreatedAtField}},
 	{"embedding_heads", []string{metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at", "fencing_token"}},
-	{"embedding_failures", []string{metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at", "fencing_token"}},
+	{"embedding_failures", []string{metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at", "fencing_token", "attachment_id"}},
 }
 
 func validateEmbeddingCatalogSchemaTx(ctx context.Context, tx *sql.Tx) error {

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -149,6 +149,8 @@ type EmbeddingFailureRecord struct {
 	InputKind                    EmbeddingInputKind
 	FailureCode                  EmbeddingFailureCode
 	FailedAt                     string
+	// FencingToken uses the same attempt sequence as EmbeddingHeadRecord.
+	FencingToken int64
 }
 
 // EmbeddingFailureCode is a closed provider-neutral outcome vocabulary. It is
@@ -486,6 +488,16 @@ func (s *Store) PublishEmbeddingHead(ctx context.Context, record EmbeddingHeadRe
 		if !eligible {
 			return errors.New("publishing embedding head: source or attachment is not eligible")
 		}
+		var newerFailure bool
+		if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM embedding_failures
+			WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?
+			AND fencing_token>=?)`, record.Key.ContentVersionID, record.ProcessingProfileFingerprint,
+			record.Key.BindingID, record.Key.InputKind, record.FencingToken).Scan(&newerFailure); err != nil {
+			return fmt.Errorf("checking embedding failure fence: %w", err)
+		}
+		if newerFailure {
+			return errors.New("publishing embedding head: stale or reused fencing token")
+		}
 		result, err := tx.ExecContext(ctx, `INSERT INTO embedding_heads(
 			content_version_id,binding_id,input_kind,embedding_set_id,vector_space_id,
 			profile_fingerprint,published_at,fencing_token
@@ -547,14 +559,46 @@ func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFail
 		if err == nil && suppression.active {
 			return errors.New("embedding failure binding has an active purge suppression")
 		}
-		_, err = tx.ExecContext(ctx, `INSERT INTO embedding_failures(
-			content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at
-		) VALUES(?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
-		DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at`, record.ContentVersionID,
+		if err := validateEmbeddingFailureHeadFence(ctx, tx, record); err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `INSERT INTO embedding_failures(
+			content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at,fencing_token
+		) VALUES(?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
+		DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at,fencing_token=excluded.fencing_token
+		WHERE excluded.fencing_token>embedding_failures.fencing_token OR (
+			excluded.fencing_token=embedding_failures.fencing_token AND
+			excluded.failure_code=embedding_failures.failure_code AND
+			excluded.failed_at=embedding_failures.failed_at
+		)`, record.ContentVersionID,
 			record.ProcessingProfileFingerprint, record.BindingID, record.InputKind,
-			record.FailureCode, record.FailedAt)
-		return err
+			record.FailureCode, record.FailedAt, record.FencingToken)
+		if err != nil {
+			return fmt.Errorf("recording embedding failure: %w", err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("checking embedding failure write: %w", err)
+		}
+		if changed != 1 {
+			return errors.New("recording embedding failure: stale or reused fencing token")
+		}
+		return nil
 	})
+}
+
+func validateEmbeddingFailureHeadFence(ctx context.Context, query metadataQuerier, record EmbeddingFailureRecord) error {
+	var newerHead bool
+	if err := query.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM embedding_heads
+		WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?
+		AND fencing_token>=?)`, record.ContentVersionID, record.ProcessingProfileFingerprint,
+		record.BindingID, record.InputKind, record.FencingToken).Scan(&newerHead); err != nil {
+		return fmt.Errorf("checking embedding failure head fence: %w", err)
+	}
+	if newerHead {
+		return errors.New("embedding failure fencing token is not newer than the published head")
+	}
+	return nil
 }
 
 func validateEmbeddingFailureBinding(ctx context.Context, query metadataQuerier, record EmbeddingFailureRecord) error {
@@ -1327,6 +1371,9 @@ func validateEmbeddingHeadRecord(record EmbeddingHeadRecord) error {
 }
 
 func validateEmbeddingFailureRecord(record EmbeddingFailureRecord) error {
+	if record.FencingToken < 1 {
+		return errors.New("embedding failure fencing token must be positive")
+	}
 	if err := validateEmbeddingHeadKey(EmbeddingHeadKey{record.ContentVersionID, record.BindingID, record.InputKind}); err != nil {
 		return err
 	}
@@ -1371,7 +1418,7 @@ var embeddingCatalogSchema = []embeddingCatalogTableSchema{
 	{"embedding_vector_rows", []string{"vector_set_id", "row_id", "row_order", "input_id", "dimensions", "checksum"}},
 	{"embedding_sets", []string{"embedding_set_id", "vault_uid", "binding_id", "input_kind", metadataContentVersionIDField, metadataEmbeddingProfileField, "embedding_input_fingerprint", metadataEmbeddingVectorSpaceIDField, "input_generation_id", "vector_set_id", metadataCreatedAtField}},
 	{"embedding_heads", []string{metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at", "fencing_token"}},
-	{"embedding_failures", []string{metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at"}},
+	{"embedding_failures", []string{metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at", "fencing_token"}},
 }
 
 func validateEmbeddingCatalogSchemaTx(ctx context.Context, tx *sql.Tx) error {

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -176,6 +176,9 @@ func (s *Store) StageEmbeddingSet(ctx context.Context, record EmbeddingSetRecord
 		if err := validateEmbeddingSetFencesTx(ctx, tx, record); err != nil {
 			return err
 		}
+		if err := requireEmbeddingPurgeAuthorityTx(ctx, tx, record); err != nil {
+			return err
+		}
 		// Payload bytes are validated before the transaction writes catalog
 		// authority. SQLite retains only the immutable blob reference and the
 		// canonical row projection derived from those bytes.
@@ -459,6 +462,9 @@ func (s *Store) PublishEmbeddingHead(ctx context.Context, record EmbeddingHeadRe
 			set.InputKind != record.Key.InputKind || set.VectorSpace.ID != record.VectorSpaceID ||
 			set.ProcessingProfileFingerprint != record.ProcessingProfileFingerprint {
 			return errors.New("publishing embedding head: stale source, profile, binding, or vector-space fence")
+		}
+		if err := requireEmbeddingPurgeAuthorityTx(ctx, tx, set); err != nil {
+			return err
 		}
 		eligible, err := embeddingSetEligibleTx(ctx, tx, set)
 		if err != nil {

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -136,6 +136,9 @@ type EmbeddingHeadRecord struct {
 	VectorSpaceID                string
 	ProcessingProfileFingerprint string
 	PublishedAt                  string
+	// FencingToken is assigned before work starts and increases for each
+	// attempt in this version/profile/binding/input-kind scope.
+	FencingToken int64
 }
 
 // EmbeddingFailureRecord records provider-neutral coverage failure only.
@@ -483,17 +486,29 @@ func (s *Store) PublishEmbeddingHead(ctx context.Context, record EmbeddingHeadRe
 		if !eligible {
 			return errors.New("publishing embedding head: source or attachment is not eligible")
 		}
-		_, err = tx.ExecContext(ctx, `INSERT INTO embedding_heads(
+		result, err := tx.ExecContext(ctx, `INSERT INTO embedding_heads(
 			content_version_id,binding_id,input_kind,embedding_set_id,vector_space_id,
-			profile_fingerprint,published_at
-		) VALUES(?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
+			profile_fingerprint,published_at,fencing_token
+		) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
 		DO UPDATE SET embedding_set_id=excluded.embedding_set_id,
 		vector_space_id=excluded.vector_space_id,profile_fingerprint=excluded.profile_fingerprint,
-		published_at=excluded.published_at`, record.Key.ContentVersionID, record.Key.BindingID,
+		published_at=excluded.published_at,fencing_token=excluded.fencing_token
+		WHERE excluded.fencing_token>embedding_heads.fencing_token OR (
+			excluded.fencing_token=embedding_heads.fencing_token AND
+			excluded.embedding_set_id=embedding_heads.embedding_set_id AND
+			excluded.published_at=embedding_heads.published_at
+		)`, record.Key.ContentVersionID, record.Key.BindingID,
 			record.Key.InputKind, record.SetID, record.VectorSpaceID,
-			record.ProcessingProfileFingerprint, record.PublishedAt)
+			record.ProcessingProfileFingerprint, record.PublishedAt, record.FencingToken)
 		if err != nil {
 			return fmt.Errorf("publishing embedding head: %w", err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("checking embedding publication: %w", err)
+		}
+		if changed != 1 {
+			return errors.New("publishing embedding head: stale or reused fencing token")
 		}
 		_, err = tx.ExecContext(ctx, `DELETE FROM embedding_failures
 			WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?`,
@@ -1262,6 +1277,13 @@ func embeddingSetEligibleTx(ctx context.Context, tx *sql.Tx, set EmbeddingSetRec
 	if live != 1 {
 		return false, nil
 	}
+	return embeddingAttachmentEligible(ctx, tx, set)
+}
+
+// The attachment fence also applies to restored heads. Source visibility is
+// checked on publication, not restore: historical and trashed versions may
+// retain their independently published heads.
+func embeddingAttachmentEligible(ctx context.Context, tx metadataQuerier, set EmbeddingSetRecord) (bool, error) {
 	if set.InputGeneration.AttachmentID == "" {
 		return true, nil
 	}
@@ -1289,6 +1311,9 @@ func validateEmbeddingHeadKey(key EmbeddingHeadKey) error {
 func validateEmbeddingHeadRecord(record EmbeddingHeadRecord) error {
 	if err := validateEmbeddingHeadKey(record.Key); err != nil {
 		return err
+	}
+	if record.FencingToken < 1 {
+		return errors.New("embedding head fencing token must be positive")
 	}
 	for value, subject := range map[string]string{
 		record.SetID: "embedding head set ID", record.VectorSpaceID: "embedding head vector-space ID",
@@ -1345,7 +1370,7 @@ var embeddingCatalogSchema = []embeddingCatalogTableSchema{
 	{"embedding_vector_sets", []string{"vector_set_id", "contract_version", metadataEmbeddingVectorSpaceIDField, "payload_blob_hash", "payload_size", "payload_checksum", "manifest_checksum", "row_count", "dimensions"}},
 	{"embedding_vector_rows", []string{"vector_set_id", "row_id", "row_order", "input_id", "dimensions", "checksum"}},
 	{"embedding_sets", []string{"embedding_set_id", "vault_uid", "binding_id", "input_kind", metadataContentVersionIDField, metadataEmbeddingProfileField, "embedding_input_fingerprint", metadataEmbeddingVectorSpaceIDField, "input_generation_id", "vector_set_id", metadataCreatedAtField}},
-	{"embedding_heads", []string{metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at"}},
+	{"embedding_heads", []string{metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at", "fencing_token"}},
 	{"embedding_failures", []string{metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at"}},
 }
 

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -67,6 +67,9 @@ type EmbeddingInputGenerationRecord struct {
 	SourceVersionID              string
 	ProcessingProfileFingerprint string
 	GenerationJSON               []byte
+	// EvidenceJSON supplies canonical normalized evidence for chunk staging only.
+	// Its hash is retained as EvidenceFingerprint; the bytes live in blob storage.
+	EvidenceJSON                 []byte
 	GenerationBlobHash           string
 	GenerationEncodedSize        int64
 	GenerationChecksum           string
@@ -187,6 +190,7 @@ func (s *Store) StageEmbeddingSet(ctx context.Context, record EmbeddingSetRecord
 		// canonical row projection derived from those bytes.
 		record.VectorSet.Payload = nil
 		record.InputGeneration.GenerationJSON = nil
+		record.InputGeneration.EvidenceJSON = nil
 		if err := insertVectorSpaceTx(ctx, tx, record.VectorSpace); err != nil {
 			return err
 		}
@@ -779,13 +783,35 @@ func embeddingVectorManifestChecksum(rows []EmbeddingVectorRowRecord) string {
 	return hex.EncodeToString(hash.Sum(nil))
 }
 
+func validateEmbeddingGenerationEvidence(record EmbeddingInputGenerationRecord, generationJSON, evidenceJSON []byte) error {
+	if len(evidenceJSON) == 0 || len(evidenceJSON) > 64<<20 {
+		return errors.New("embedding generation requires bounded canonical evidence bytes")
+	}
+	if hashCatalogBytes(evidenceJSON) != record.EvidenceFingerprint {
+		return errors.New("embedding generation canonical evidence hash mismatch")
+	}
+	var evidence document.NormalizedEvidenceV1
+	if err := jsonv2.Unmarshal(evidenceJSON, &evidence, jsonv2.RejectUnknownMembers(true)); err != nil {
+		return fmt.Errorf("decoding embedding generation evidence: %w", err)
+	}
+	var generation document.EmbeddingInputGeneration
+	if err := json.Unmarshal(generationJSON, &generation); err != nil {
+		return err
+	}
+	return generation.ValidateEvidence(evidence)
+}
+
 func requireEmbeddingPhysicalAuthorityTx(ctx context.Context, tx *sql.Tx, record EmbeddingSetRecord) error {
 	var source string
 	if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`,
 		record.ContentVersionID).Scan(&source); err != nil {
 		return fmt.Errorf("reading embedding source blob: %w", err)
 	}
-	for _, hash := range []string{source, record.VectorSet.PayloadBlobHash, record.InputGeneration.GenerationBlobHash} {
+	hashes := []string{source, record.VectorSet.PayloadBlobHash, record.InputGeneration.GenerationBlobHash}
+	if record.InputGeneration.GenerationBlobHash != "" {
+		hashes = append(hashes, record.InputGeneration.EvidenceFingerprint)
+	}
+	for _, hash := range hashes {
 		if hash == "" {
 			continue // Original-file inputs have no separate generation artifact.
 		}
@@ -842,12 +868,24 @@ func validateEmbeddingSetFencesTx(ctx context.Context, tx *sql.Tx, record Embedd
 		if generationBlobCount != 1 || generationBlobSize != int64(len(record.InputGeneration.GenerationJSON)) {
 			return errors.New("embedding set references a missing exact E2 generation artifact")
 		}
+		if err := validateEmbeddingGenerationEvidence(record.InputGeneration,
+			record.InputGeneration.GenerationJSON, record.InputGeneration.EvidenceJSON); err != nil {
+			return err
+		}
+		var evidenceSize int64
+		if err := tx.QueryRowContext(ctx, `SELECT size FROM blobs WHERE hash=?`,
+			record.InputGeneration.EvidenceFingerprint).Scan(&evidenceSize); err != nil {
+			return fmt.Errorf("reading embedding evidence blob: %w", err)
+		}
+		if evidenceSize != int64(len(record.InputGeneration.EvidenceJSON)) {
+			return errors.New("embedding evidence blob size mismatch")
+		}
 	}
 	if record.InputKind == document.EmbeddingInputRenditionChunk && record.InputGeneration.AttachmentID == "" {
 		return errors.New("chunk embedding set requires rendition attachment authority")
 	}
 	if record.InputKind == document.EmbeddingInputOriginalFile {
-		if record.InputGeneration.AttachmentID != "" || len(record.InputGeneration.GenerationJSON) != 0 ||
+		if record.InputGeneration.AttachmentID != "" || len(record.InputGeneration.GenerationJSON) != 0 || len(record.InputGeneration.EvidenceJSON) != 0 ||
 			record.InputGeneration.GenerationBlobHash != "" || record.InputGeneration.GenerationEncodedSize != 0 ||
 			len(record.InputGeneration.Inputs) != 1 {
 			return errors.New("original-file input authority cannot claim rendition attachment or E2 generation")

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -494,12 +494,8 @@ func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFail
 		return err
 	}
 	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		binding, _, err := embeddingProfileBindingAuthority(ctx, tx, record.ProcessingProfileFingerprint, record.BindingID)
-		if err != nil {
+		if err := validateEmbeddingFailureBinding(ctx, tx, record); err != nil {
 			return err
-		}
-		if binding.InputKind != record.InputKind {
-			return errors.New("embedding failure does not match processing profile binding kind")
 		}
 		var count int
 		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_versions v
@@ -510,7 +506,7 @@ func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFail
 		if count != 1 {
 			return ErrNotFound
 		}
-		_, err = tx.ExecContext(ctx, `INSERT INTO embedding_failures(
+		_, err := tx.ExecContext(ctx, `INSERT INTO embedding_failures(
 			content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at
 		) VALUES(?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
 		DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at`, record.ContentVersionID,
@@ -518,6 +514,17 @@ func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFail
 			record.FailureCode, record.FailedAt)
 		return err
 	})
+}
+
+func validateEmbeddingFailureBinding(ctx context.Context, query metadataQuerier, record EmbeddingFailureRecord) error {
+	binding, _, err := embeddingProfileBindingAuthority(ctx, query, record.ProcessingProfileFingerprint, record.BindingID)
+	if err != nil {
+		return err
+	}
+	if binding.InputKind != record.InputKind {
+		return errors.New("embedding failure does not match processing profile binding kind")
+	}
+	return nil
 }
 
 func embeddingProfileBindingAuthority(ctx context.Context, query metadataQuerier, profileFingerprint, bindingID string) (document.EmbeddingBindingV1, document.FingerprintSet, error) {

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -179,6 +179,9 @@ func (s *Store) StageEmbeddingSet(ctx context.Context, record EmbeddingSetRecord
 		if err := requireEmbeddingPurgeAuthorityTx(ctx, tx, record); err != nil {
 			return err
 		}
+		if err := requireEmbeddingPhysicalAuthorityTx(ctx, tx, record); err != nil {
+			return err
+		}
 		// Payload bytes are validated before the transaction writes catalog
 		// authority. SQLite retains only the immutable blob reference and the
 		// canonical row projection derived from those bytes.
@@ -464,6 +467,9 @@ func (s *Store) PublishEmbeddingHead(ctx context.Context, record EmbeddingHeadRe
 			return errors.New("publishing embedding head: stale source, profile, binding, or vector-space fence")
 		}
 		if err := requireEmbeddingPurgeAuthorityTx(ctx, tx, set); err != nil {
+			return err
+		}
+		if err := requireEmbeddingPhysicalAuthorityTx(ctx, tx, set); err != nil {
 			return err
 		}
 		eligible, err := embeddingSetEligibleTx(ctx, tx, set)
@@ -771,6 +777,23 @@ func embeddingVectorManifestChecksum(rows []EmbeddingVectorRowRecord) string {
 		_, _ = hash.Write([]byte{'\n'})
 	}
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func requireEmbeddingPhysicalAuthorityTx(ctx context.Context, tx *sql.Tx, record EmbeddingSetRecord) error {
+	var source string
+	if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`,
+		record.ContentVersionID).Scan(&source); err != nil {
+		return fmt.Errorf("reading embedding source blob: %w", err)
+	}
+	for _, hash := range []string{source, record.VectorSet.PayloadBlobHash, record.InputGeneration.GenerationBlobHash} {
+		if hash == "" {
+			continue // Original-file inputs have no separate generation artifact.
+		}
+		if _, err := requirePhysicalAuthorityTx(tx, hash); err != nil {
+			return fmt.Errorf("validating embedding blob physical authority: %w", err)
+		}
+	}
+	return nil
 }
 
 func validateEmbeddingSetFencesTx(ctx context.Context, tx *sql.Tx, record EmbeddingSetRecord) error {

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -391,7 +391,7 @@ func validateExactEmbeddingGenerationArtifact(record EmbeddingInputGenerationRec
 
 func validateExactEmbeddingVectorArtifact(
 	vectorSet EmbeddingVectorSetRecord, space EmbeddingVectorSpaceRecord,
-	generation EmbeddingInputGenerationRecord, data []byte,
+	data []byte,
 ) error {
 	if int64(len(data)) != vectorSet.PayloadSize || hashCatalogBytes(data) != vectorSet.PayloadBlobHash {
 		return errors.New("vector-set artifact bytes do not match catalog authority")
@@ -409,17 +409,15 @@ func validateExactEmbeddingVectorArtifact(
 	if vectorSet.ID != checksum || vectorSet.PayloadChecksum != checksum ||
 		decoded.VectorSpaceFingerprint != space.ID || decoded.Dimension != space.Dimensions ||
 		decoded.Metric != space.Metric || decoded.Normalization != space.Normalization ||
-		len(decoded.InputKeys) != len(generation.Inputs) || len(vectorSet.rows) != len(generation.Inputs) {
+		len(decoded.InputKeys) != len(vectorSet.rows) {
 		return errors.New("vector-set artifact header or count does not match catalog authority")
 	}
-	for index := range generation.Inputs {
-		if decoded.InputKeys[index] != generation.Inputs[index].ID ||
-			decoded.InputChecksums[index] != generation.Inputs[index].RenderedChecksum ||
-			vectorSet.rows[index] != (EmbeddingVectorRowRecord{
-				RowID: decoded.InputKeys[index], InputID: decoded.InputKeys[index],
-				Dimensions: decoded.Dimension, Checksum: decoded.InputChecksums[index],
-			}) {
-			return errors.New("vector-set artifact rows do not match exact E2 inputs")
+	for index, row := range vectorSet.rows {
+		if row != (EmbeddingVectorRowRecord{
+			RowID: decoded.InputKeys[index], InputID: decoded.InputKeys[index],
+			Dimensions: decoded.Dimension, Checksum: decoded.InputChecksums[index],
+		}) {
+			return errors.New("vector-set artifact rows do not match catalog authority")
 		}
 	}
 	if vectorSet.ManifestChecksum != embeddingVectorManifestChecksum(vectorSet.rows) {

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -504,7 +504,8 @@ func (s *Store) PublishEmbeddingHead(ctx context.Context, record EmbeddingHeadRe
 }
 
 // RecordEmbeddingFailure records provider-neutral plan status without
-// disturbing any rendition or sibling embedding head.
+// disturbing any rendition or sibling embedding head. Active purge suppression
+// blocks reports until an explicit rebuild is authorized for the binding.
 func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFailureRecord) error {
 	if err := validateEmbeddingFailureRecord(record); err != nil {
 		return err
@@ -522,7 +523,16 @@ func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFail
 		if count != 1 {
 			return ErrNotFound
 		}
-		_, err := tx.ExecContext(ctx, `INSERT INTO embedding_failures(
+		suppression, err := loadEmbeddingPurgeSuppressionTx(ctx, tx,
+			EmbeddingHeadKey{record.ContentVersionID, record.BindingID, record.InputKind},
+			record.ProcessingProfileFingerprint)
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("checking embedding failure purge suppression: %w", err)
+		}
+		if err == nil && suppression.active {
+			return errors.New("embedding failure binding has an active purge suppression")
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO embedding_failures(
 			content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at
 		) VALUES(?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
 		DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at`, record.ContentVersionID,

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -1,0 +1,1308 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	jsonv2 "encoding/json/v2"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/docbank/document"
+)
+
+const (
+	EmbeddingVectorSpaceContractV1 = "embedding-vector-space/v1"
+	EmbeddingVectorSetContractV1   = "vector-set/v1"
+
+	maxEmbeddingCatalogRows    = 100_000
+	maxEmbeddingDimensions     = 1_048_576
+	maxEmbeddingCatalogIDBytes = 1 << 10
+	maxEmbeddingDescriptorJSON = 1 << 16
+)
+
+// EmbeddingInputKind is the canonical E1 evidence-kind vocabulary. Keep the
+// alias so store callers do not need to translate a document contract token.
+type EmbeddingInputKind = document.EmbeddingInputKind
+
+// EmbeddingVectorSpaceRecord seals every identity that makes vectors mutually
+// comparable. Credentials and provider request payloads are deliberately not
+// part of durable catalog authority.
+type EmbeddingVectorSpaceRecord struct {
+	ID                    string
+	ContractVersion       string
+	Descriptor            document.EmbeddingDescriptor
+	ProviderDescriptor    string
+	ProviderRevision      string
+	DescriptorFingerprint string
+	CompatibilityID       string
+	Dimensions            int
+	Metric                string
+	Normalization         string
+	ScalarEncoding        string
+	DocumentFormatter     string
+	QueryFormatter        string
+	ModelInputFingerprint string
+}
+
+// EmbeddingInputReference retains only bounded identity and rendered checksum;
+// exact rendered text remains in the E2 artifact outside SQLite.
+type EmbeddingInputReference struct {
+	ID               string
+	RenderedChecksum string
+}
+
+// EmbeddingInputGenerationRecord is the bounded catalog projection of one E2
+// generation. AttachmentID fences eligibility; a non-empty context fingerprint
+// additionally prevents reuse under another attachment identity.
+type EmbeddingInputGenerationRecord struct {
+	ID                           string
+	SourceVersionID              string
+	ProcessingProfileFingerprint string
+	GenerationJSON               []byte
+	GenerationBlobHash           string
+	GenerationEncodedSize        int64
+	GenerationChecksum           string
+	EvidenceFingerprint          string
+	TokenizerFingerprint         string
+	ChunkPolicyFingerprint       string
+	FormatterFingerprint         string
+	AttachmentContextFingerprint string
+	AttachmentID                 string
+	Inputs                       []EmbeddingInputReference
+	CreatedAt                    string
+}
+
+// EmbeddingVectorRowRecord binds one canonical vector-set row to one exact E2
+// input without storing vector scalar values in SQLite.
+type EmbeddingVectorRowRecord struct {
+	RowID      string
+	InputID    string
+	Dimensions int
+	Checksum   string
+}
+
+// EmbeddingVectorSetRecord references one canonical vector-set/v1 payload.
+type EmbeddingVectorSetRecord struct {
+	ID               string
+	ContractVersion  string
+	VectorSpaceID    string
+	PayloadBlobHash  string
+	PayloadSize      int64
+	PayloadChecksum  string
+	Payload          []byte
+	ManifestChecksum string
+	RowCount         int
+	Dimensions       int
+	rows             []EmbeddingVectorRowRecord
+}
+
+// EmbeddingSetRecord is one immutable content/profile/binding membership.
+type EmbeddingSetRecord struct {
+	ID                           string
+	VaultID                      string
+	BindingID                    string
+	InputKind                    EmbeddingInputKind
+	ContentVersionID             string
+	ProcessingProfileFingerprint string
+	EmbeddingInputFingerprint    string
+	VectorSpace                  EmbeddingVectorSpaceRecord
+	InputGeneration              EmbeddingInputGenerationRecord
+	VectorSet                    EmbeddingVectorSetRecord
+	CreatedAt                    string
+}
+
+// EmbeddingHeadKey identifies one independently activated binding.
+type EmbeddingHeadKey struct {
+	ContentVersionID string
+	BindingID        string
+	InputKind        EmbeddingInputKind
+}
+
+// EmbeddingHeadRecord is the mutable pointer to one immutable set.
+type EmbeddingHeadRecord struct {
+	Key                          EmbeddingHeadKey
+	SetID                        string
+	VectorSpaceID                string
+	ProcessingProfileFingerprint string
+	PublishedAt                  string
+}
+
+// EmbeddingFailureRecord records provider-neutral coverage failure only.
+type EmbeddingFailureRecord struct {
+	ContentVersionID             string
+	ProcessingProfileFingerprint string
+	BindingID                    string
+	InputKind                    EmbeddingInputKind
+	FailureCode                  EmbeddingFailureCode
+	FailedAt                     string
+}
+
+// EmbeddingFailureCode is a closed provider-neutral outcome vocabulary. It is
+// deliberately too small to carry provider messages, request fragments, or
+// credentials into catalog metadata.
+type EmbeddingFailureCode string
+
+const (
+	EmbeddingFailureProviderUnavailable EmbeddingFailureCode = "provider_unavailable"
+	EmbeddingFailureAuthorization       EmbeddingFailureCode = "authorization"
+	EmbeddingFailureInvalidResponse     EmbeddingFailureCode = "invalid_response"
+	EmbeddingFailureInputRejected       EmbeddingFailureCode = "input_rejected"
+	EmbeddingFailureStaleAuthority      EmbeddingFailureCode = "stale_authority"
+)
+
+// StageEmbeddingSet atomically records or exactly reuses every immutable
+// authority named by a completed embedding set.
+func (s *Store) StageEmbeddingSet(ctx context.Context, record EmbeddingSetRecord) error {
+	var err error
+	record, err = normalizeEmbeddingSetRecord(record)
+	if err != nil {
+		return fmt.Errorf("staging embedding set: %w", err)
+	}
+	if err := validateEmbeddingSetRecord(record); err != nil {
+		return fmt.Errorf("staging embedding set: %w", err)
+	}
+	if record.VaultID != s.vaultID {
+		return errors.New("staging embedding set: vault identity does not match store")
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if err := validateEmbeddingSetFencesTx(ctx, tx, record); err != nil {
+			return err
+		}
+		// Payload bytes are validated before the transaction writes catalog
+		// authority. SQLite retains only the immutable blob reference and the
+		// canonical row projection derived from those bytes.
+		record.VectorSet.Payload = nil
+		record.InputGeneration.GenerationJSON = nil
+		if err := insertVectorSpaceTx(ctx, tx, record.VectorSpace); err != nil {
+			return err
+		}
+		if err := insertInputGenerationTx(ctx, tx, record.InputGeneration); err != nil {
+			return err
+		}
+		if err := insertVectorSetTx(ctx, tx, record.VectorSet); err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO embedding_sets(
+			embedding_set_id,vault_uid,binding_id,input_kind,content_version_id,
+			profile_fingerprint,embedding_input_fingerprint,vector_space_id,input_generation_id,vector_set_id,created_at
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?)`, record.ID, record.VaultID, record.BindingID,
+			record.InputKind, record.ContentVersionID, record.ProcessingProfileFingerprint,
+			record.EmbeddingInputFingerprint, record.VectorSpace.ID, record.InputGeneration.ID, record.VectorSet.ID, record.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("inserting embedding set %s: %w", record.ID, err)
+		}
+		inserted, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("checking embedding set insertion: %w", err)
+		}
+		if inserted == 0 {
+			stored, err := loadEmbeddingSetTx(ctx, tx, record.ID)
+			if err != nil {
+				return err
+			}
+			if !reflect.DeepEqual(stored, record) {
+				return fmt.Errorf("embedding set %s names different immutable authority", record.ID)
+			}
+		}
+		return nil
+	})
+}
+
+func normalizeEmbeddingSetRecord(record EmbeddingSetRecord) (EmbeddingSetRecord, error) {
+	if !reflect.DeepEqual(record.VectorSpace.Descriptor, document.EmbeddingDescriptor{}) {
+		descriptor, err := document.NewEmbeddingDescriptor(record.VectorSpace.Descriptor)
+		if err != nil {
+			return EmbeddingSetRecord{}, fmt.Errorf("invalid E1 descriptor: %w", err)
+		}
+		if !reflect.DeepEqual(descriptor, record.VectorSpace.Descriptor) {
+			return EmbeddingSetRecord{}, errors.New("E1 descriptor is not canonical")
+		}
+		record.VectorSpace.ProviderDescriptor = descriptor.ID
+		record.VectorSpace.ProviderRevision = descriptor.ModelRevision
+		record.VectorSpace.DescriptorFingerprint = descriptor.Fingerprint
+		record.VectorSpace.CompatibilityID = descriptor.CompatibilityID
+		record.VectorSpace.Dimensions = descriptor.Dimension
+		record.VectorSpace.Metric = descriptor.Metric
+		record.VectorSpace.Normalization = descriptor.Normalization
+		record.VectorSpace.ScalarEncoding = descriptor.ScalarEncoding
+		record.VectorSpace.DocumentFormatter = descriptor.DocumentFormatter
+		record.VectorSpace.QueryFormatter = descriptor.QueryFormatter
+		record.VectorSpace.ModelInputFingerprint = descriptor.ModelInput.Fingerprint
+	}
+	if record.InputKind == document.EmbeddingInputRenditionChunk {
+		if len(record.InputGeneration.GenerationJSON) == 0 {
+			return EmbeddingSetRecord{}, errors.New("canonical E2 generation JSON is required")
+		}
+		generation, err := document.DecodeEmbeddingInputGeneration(record.InputGeneration.GenerationJSON, document.EmbeddingInputGenerationDecodeBounds{
+			MaxEncodedBytes: 64 << 20, MaxInputs: maxEmbeddingCatalogRows,
+		})
+		if err != nil {
+			return EmbeddingSetRecord{}, fmt.Errorf("decoding canonical E2 generation JSON: %w", err)
+		}
+		if generation.Version != document.EmbeddingInputGenerationVersion {
+			return EmbeddingSetRecord{}, errors.New("E2 generation artifact is not the current policy-complete version")
+		}
+		canonical, err := document.MarshalEmbeddingInputGeneration(generation)
+		if err != nil {
+			return EmbeddingSetRecord{}, fmt.Errorf("encoding canonical E2 generation JSON: %w", err)
+		}
+		if !bytes.Equal(canonical, record.InputGeneration.GenerationJSON) {
+			return EmbeddingSetRecord{}, errors.New("E2 generation JSON is not canonical")
+		}
+		generationBlobHash := hashCatalogBytes(record.InputGeneration.GenerationJSON)
+		if record.InputGeneration.GenerationBlobHash != "" && record.InputGeneration.GenerationBlobHash != generationBlobHash {
+			return EmbeddingSetRecord{}, errors.New("E2 generation blob hash does not match exact bytes")
+		}
+		if record.InputGeneration.GenerationEncodedSize != 0 && record.InputGeneration.GenerationEncodedSize != int64(len(record.InputGeneration.GenerationJSON)) {
+			return EmbeddingSetRecord{}, errors.New("E2 generation encoded size does not match exact bytes")
+		}
+		if record.InputGeneration.GenerationChecksum != "" && record.InputGeneration.GenerationChecksum != generation.Checksum {
+			return EmbeddingSetRecord{}, errors.New("E2 generation checksum does not match exact artifact")
+		}
+		record.InputGeneration.GenerationBlobHash = generationBlobHash
+		record.InputGeneration.GenerationEncodedSize = int64(len(record.InputGeneration.GenerationJSON))
+		record.InputGeneration.GenerationChecksum = generation.Checksum
+		expectedGenerationID := generation.Checksum
+		if record.InputGeneration.AttachmentID != "" {
+			expectedGenerationID = hashCatalogText("embedding-generation-attachment/v1\x00" + generation.Checksum + "\x00" + record.InputGeneration.AttachmentID)
+		}
+		if record.InputGeneration.ID != expectedGenerationID {
+			return EmbeddingSetRecord{}, errors.New("E2 generation ID does not match its canonical checksum")
+		}
+		record.InputGeneration.EvidenceFingerprint = generation.EvidenceChecksum
+		record.InputGeneration.TokenizerFingerprint = tokenizerCatalogFingerprint(document.TokenizerIdentity{
+			Name: generation.Chunk.Tokenizer, Revision: generation.Chunk.TokenizerRevision,
+		})
+		record.InputGeneration.ChunkPolicyFingerprint = generation.PolicyFingerprint
+		record.InputGeneration.FormatterFingerprint = hashCatalogText(generation.Chunk.Formatter)
+		record.InputGeneration.AttachmentContextFingerprint = ""
+		if generation.AttachmentContext != nil {
+			encodedContext, marshalErr := json.Marshal(generation.AttachmentContext)
+			if marshalErr != nil {
+				return EmbeddingSetRecord{}, marshalErr
+			}
+			record.InputGeneration.AttachmentContextFingerprint = hashCatalogText(string(encodedContext))
+		}
+		record.InputGeneration.Inputs = make([]EmbeddingInputReference, len(generation.Inputs))
+		for index, input := range generation.Inputs {
+			record.InputGeneration.Inputs[index] = EmbeddingInputReference{ID: input.Key, RenderedChecksum: input.Checksum}
+		}
+	}
+	if len(record.VectorSet.Payload) == 0 {
+		return EmbeddingSetRecord{}, errors.New("canonical vector payload is required")
+	}
+	decoded, _, err := document.DecodeVectorSetV1(record.VectorSet.Payload, document.VectorBounds{
+		MaxRows: maxEmbeddingCatalogRows, MaxDimension: maxEmbeddingDimensions, MaxBytes: 64 << 20,
+	})
+	if err != nil {
+		return EmbeddingSetRecord{}, fmt.Errorf("decoding canonical vector payload: %w", err)
+	}
+	canonicalPayload, checksum, err := document.EncodeVectorSetV1(decoded)
+	if err != nil {
+		return EmbeddingSetRecord{}, fmt.Errorf("encoding canonical vector payload: %w", err)
+	}
+	if !bytes.Equal(canonicalPayload, record.VectorSet.Payload) {
+		return EmbeddingSetRecord{}, errors.New("vector payload is not canonical vector-set/v1")
+	}
+	if record.VectorSet.ID != checksum || record.VectorSet.PayloadChecksum != checksum {
+		return EmbeddingSetRecord{}, errors.New("vector payload checksum does not match vector-set identity")
+	}
+	payloadHash := hashCatalogBytes(record.VectorSet.Payload)
+	if record.VectorSet.PayloadBlobHash != payloadHash {
+		return EmbeddingSetRecord{}, errors.New("vector payload blob hash does not match exact bytes")
+	}
+	record.VectorSet.PayloadSize = int64(len(record.VectorSet.Payload))
+	if record.VectorSet.VectorSpaceID != decoded.VectorSpaceFingerprint || record.VectorSpace.ID != decoded.VectorSpaceFingerprint {
+		return EmbeddingSetRecord{}, errors.New("vector payload names a different vector space")
+	}
+	if decoded.Metric != record.VectorSpace.Metric || decoded.Normalization != record.VectorSpace.Normalization {
+		return EmbeddingSetRecord{}, errors.New("vector payload metric or normalization does not match vector space")
+	}
+	record.VectorSet.RowCount = len(decoded.Vectors)
+	record.VectorSet.Dimensions = decoded.Dimension
+	canonicalRows := make([]EmbeddingVectorRowRecord, len(decoded.Vectors))
+	for index := range decoded.Vectors {
+		canonicalRows[index] = EmbeddingVectorRowRecord{
+			RowID: decoded.InputKeys[index], InputID: decoded.InputKeys[index],
+			Dimensions: decoded.Dimension, Checksum: decoded.InputChecksums[index],
+		}
+	}
+	record.VectorSet.rows = canonicalRows
+	record.VectorSet.ManifestChecksum = embeddingVectorManifestChecksum(canonicalRows)
+	return record, nil
+}
+
+func validateExactEmbeddingGenerationArtifact(record EmbeddingInputGenerationRecord, data []byte) error {
+	if int64(len(data)) != record.GenerationEncodedSize || hashCatalogBytes(data) != record.GenerationBlobHash {
+		return errors.New("E2 generation artifact bytes do not match catalog authority")
+	}
+	generation, err := document.DecodeEmbeddingInputGeneration(data, document.EmbeddingInputGenerationDecodeBounds{
+		MaxEncodedBytes: record.GenerationEncodedSize, MaxInputs: maxEmbeddingCatalogRows,
+	})
+	if err != nil {
+		return err
+	}
+	if generation.Version != document.EmbeddingInputGenerationVersion {
+		return errors.New("E2 generation artifact is not the current policy-complete version")
+	}
+	canonical, err := document.MarshalEmbeddingInputGeneration(generation)
+	if err != nil || !bytes.Equal(canonical, data) {
+		return errors.New("E2 generation artifact is not canonical")
+	}
+	expectedID := generation.Checksum
+	if record.AttachmentID != "" {
+		expectedID = hashCatalogText("embedding-generation-attachment/v1\x00" + generation.Checksum + "\x00" + record.AttachmentID)
+	}
+	if record.ID != expectedID || record.GenerationChecksum != generation.Checksum ||
+		record.EvidenceFingerprint != generation.EvidenceChecksum ||
+		record.TokenizerFingerprint != tokenizerCatalogFingerprint(document.TokenizerIdentity{
+			Name: generation.Chunk.Tokenizer, Revision: generation.Chunk.TokenizerRevision,
+		}) ||
+		record.ChunkPolicyFingerprint != generation.PolicyFingerprint ||
+		record.FormatterFingerprint != hashCatalogText(generation.Chunk.Formatter) {
+		return errors.New("E2 generation catalog projection does not match exact artifact")
+	}
+	contextFingerprint := ""
+	if generation.AttachmentContext != nil {
+		encoded, marshalErr := json.Marshal(generation.AttachmentContext)
+		if marshalErr != nil {
+			return marshalErr
+		}
+		contextFingerprint = hashCatalogBytes(encoded)
+	}
+	if record.AttachmentContextFingerprint != contextFingerprint || len(record.Inputs) != len(generation.Inputs) {
+		return errors.New("E2 generation context or input count does not match exact artifact")
+	}
+	for index, input := range generation.Inputs {
+		if record.Inputs[index] != (EmbeddingInputReference{ID: input.Key, RenderedChecksum: input.Checksum}) {
+			return errors.New("E2 generation inputs do not match exact artifact")
+		}
+	}
+	return nil
+}
+
+func validateExactEmbeddingVectorArtifact(
+	vectorSet EmbeddingVectorSetRecord, space EmbeddingVectorSpaceRecord,
+	generation EmbeddingInputGenerationRecord, data []byte,
+) error {
+	if int64(len(data)) != vectorSet.PayloadSize || hashCatalogBytes(data) != vectorSet.PayloadBlobHash {
+		return errors.New("vector-set artifact bytes do not match catalog authority")
+	}
+	decoded, _, err := document.DecodeVectorSetV1(data, document.VectorBounds{
+		MaxRows: maxEmbeddingCatalogRows, MaxDimension: maxEmbeddingDimensions, MaxBytes: len(data),
+	})
+	if err != nil {
+		return err
+	}
+	canonical, checksum, err := document.EncodeVectorSetV1(decoded)
+	if err != nil || !bytes.Equal(canonical, data) {
+		return errors.New("vector-set artifact is not canonical")
+	}
+	if vectorSet.ID != checksum || vectorSet.PayloadChecksum != checksum ||
+		decoded.VectorSpaceFingerprint != space.ID || decoded.Dimension != space.Dimensions ||
+		decoded.Metric != space.Metric || decoded.Normalization != space.Normalization ||
+		len(decoded.InputKeys) != len(generation.Inputs) || len(vectorSet.rows) != len(generation.Inputs) {
+		return errors.New("vector-set artifact header or count does not match catalog authority")
+	}
+	for index := range generation.Inputs {
+		if decoded.InputKeys[index] != generation.Inputs[index].ID ||
+			decoded.InputChecksums[index] != generation.Inputs[index].RenderedChecksum ||
+			vectorSet.rows[index] != (EmbeddingVectorRowRecord{
+				RowID: decoded.InputKeys[index], InputID: decoded.InputKeys[index],
+				Dimensions: decoded.Dimension, Checksum: decoded.InputChecksums[index],
+			}) {
+			return errors.New("vector-set artifact rows do not match exact E2 inputs")
+		}
+	}
+	if vectorSet.ManifestChecksum != embeddingVectorManifestChecksum(vectorSet.rows) {
+		return errors.New("vector-set artifact manifest checksum does not match rows")
+	}
+	return nil
+}
+
+func tokenizerCatalogFingerprint(identity document.TokenizerIdentity) string {
+	return hashCatalogText(identity.Name + "\x00" + identity.Revision)
+}
+
+func hashCatalogText(value string) string { return hashCatalogBytes([]byte(value)) }
+
+func hashCatalogBytes(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}
+
+func nullableCatalogString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+// PublishEmbeddingHead activates exactly one binding without changing any
+// other chunk/direct-file head or the independent rendition head.
+func (s *Store) PublishEmbeddingHead(ctx context.Context, record EmbeddingHeadRecord) error {
+	if err := validateEmbeddingHeadRecord(record); err != nil {
+		return fmt.Errorf("publishing embedding head: %w", err)
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		set, err := loadEmbeddingSetTx(ctx, tx, record.SetID)
+		if err != nil {
+			return fmt.Errorf("publishing embedding head: %w", err)
+		}
+		if set.ContentVersionID != record.Key.ContentVersionID || set.BindingID != record.Key.BindingID ||
+			set.InputKind != record.Key.InputKind || set.VectorSpace.ID != record.VectorSpaceID ||
+			set.ProcessingProfileFingerprint != record.ProcessingProfileFingerprint {
+			return errors.New("publishing embedding head: stale source, profile, binding, or vector-space fence")
+		}
+		eligible, err := embeddingSetEligibleTx(ctx, tx, set)
+		if err != nil {
+			return err
+		}
+		if !eligible {
+			return errors.New("publishing embedding head: source or attachment is not eligible")
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO embedding_heads(
+			content_version_id,binding_id,input_kind,embedding_set_id,vector_space_id,
+			profile_fingerprint,published_at
+		) VALUES(?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
+		DO UPDATE SET embedding_set_id=excluded.embedding_set_id,
+		vector_space_id=excluded.vector_space_id,profile_fingerprint=excluded.profile_fingerprint,
+		published_at=excluded.published_at`, record.Key.ContentVersionID, record.Key.BindingID,
+			record.Key.InputKind, record.SetID, record.VectorSpaceID,
+			record.ProcessingProfileFingerprint, record.PublishedAt)
+		if err != nil {
+			return fmt.Errorf("publishing embedding head: %w", err)
+		}
+		_, err = tx.ExecContext(ctx, `DELETE FROM embedding_failures
+			WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?`,
+			record.Key.ContentVersionID, record.ProcessingProfileFingerprint,
+			record.Key.BindingID, record.Key.InputKind)
+		return err
+	})
+}
+
+// RecordEmbeddingFailure records provider-neutral plan status without
+// disturbing any rendition or sibling embedding head.
+func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFailureRecord) error {
+	if err := validateEmbeddingFailureRecord(record); err != nil {
+		return err
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		binding, _, err := embeddingProfileBindingAuthority(ctx, tx, record.ProcessingProfileFingerprint, record.BindingID)
+		if err != nil {
+			return err
+		}
+		if binding.InputKind != record.InputKind {
+			return errors.New("embedding failure does not match processing profile binding kind")
+		}
+		var count int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_versions v
+			JOIN processing_profiles p ON p.profile_fingerprint=? WHERE v.version_id=?`,
+			record.ProcessingProfileFingerprint, record.ContentVersionID).Scan(&count); err != nil {
+			return err
+		}
+		if count != 1 {
+			return ErrNotFound
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO embedding_failures(
+			content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at
+		) VALUES(?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
+		DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at`, record.ContentVersionID,
+			record.ProcessingProfileFingerprint, record.BindingID, record.InputKind,
+			record.FailureCode, record.FailedAt)
+		return err
+	})
+}
+
+func embeddingProfileBindingAuthority(ctx context.Context, query metadataQuerier, profileFingerprint, bindingID string) (document.EmbeddingBindingV1, document.FingerprintSet, error) {
+	record, err := loadProcessingProfile(ctx, query, profileFingerprint)
+	if err != nil {
+		return document.EmbeddingBindingV1{}, document.FingerprintSet{}, fmt.Errorf("embedding processing profile: %w", err)
+	}
+	var profile document.ProcessingProfileV1
+	if err := json.Unmarshal(record.CanonicalProfile, &profile); err != nil {
+		return document.EmbeddingBindingV1{}, document.FingerprintSet{}, fmt.Errorf("decoding embedding processing profile: %w", err)
+	}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	if err != nil || !bytes.Equal(canonical, record.CanonicalProfile) || fingerprints.Profile != profileFingerprint {
+		return document.EmbeddingBindingV1{}, document.FingerprintSet{}, errors.New("embedding processing profile is not canonical")
+	}
+	for _, binding := range profile.Embeddings {
+		if binding.Name == bindingID {
+			return binding, fingerprints, nil
+		}
+	}
+	return document.EmbeddingBindingV1{}, document.FingerprintSet{}, fmt.Errorf("processing profile binding %q does not exist", bindingID)
+}
+
+func validateEmbeddingSetRecord(record EmbeddingSetRecord) error {
+	if err := validateCatalogSHA256(record.ID, "embedding set ID"); err != nil {
+		return err
+	}
+	if err := validateUUIDv4(record.VaultID); err != nil {
+		return fmt.Errorf("embedding vault ID: %w", err)
+	}
+	if err := validateUUIDv4(record.ContentVersionID); err != nil {
+		return fmt.Errorf("embedding content version ID: %w", err)
+	}
+	if err := validateCatalogSHA256(record.ProcessingProfileFingerprint, "embedding profile fingerprint"); err != nil {
+		return err
+	}
+	if err := validateEmbeddingCatalogText(record.BindingID, "embedding binding ID"); err != nil {
+		return err
+	}
+	if err := validateEmbeddingInputKind(record.InputKind); err != nil {
+		return err
+	}
+	if err := validateEmbeddingVectorSpace(record.VectorSpace); err != nil {
+		return err
+	}
+	if err := validateEmbeddingInputGeneration(record.InputGeneration); err != nil {
+		return err
+	}
+	if err := validateEmbeddingVectorSet(record.VectorSet, record.VectorSpace, record.InputGeneration); err != nil {
+		return err
+	}
+	if record.InputGeneration.SourceVersionID != record.ContentVersionID ||
+		record.InputGeneration.ProcessingProfileFingerprint != record.ProcessingProfileFingerprint {
+		return errors.New("embedding generation source/profile membership does not match set")
+	}
+	return validateMetadataTime("embedding set created_at", record.CreatedAt)
+}
+
+func validateEmbeddingVectorSpace(record EmbeddingVectorSpaceRecord) error {
+	if record.ContractVersion != EmbeddingVectorSpaceContractV1 {
+		return errors.New("embedding vector-space contract version is unsupported")
+	}
+	for value, subject := range map[string]string{
+		record.ID: "vector-space ID", record.DescriptorFingerprint: "descriptor fingerprint",
+		record.ModelInputFingerprint: "model-input fingerprint",
+	} {
+		if err := validateCatalogSHA256(value, subject); err != nil {
+			return err
+		}
+	}
+	for value, subject := range map[string]string{
+		record.ProviderDescriptor: "provider descriptor", record.ProviderRevision: "provider revision",
+		record.CompatibilityID: "compatibility ID", record.Metric: "vector metric",
+		record.Normalization: "vector normalization", record.ScalarEncoding: "scalar encoding",
+		record.DocumentFormatter: "document formatter", record.QueryFormatter: "query formatter",
+	} {
+		if err := validateEmbeddingCatalogText(value, subject); err != nil {
+			return err
+		}
+	}
+	if record.Dimensions < 1 || record.Dimensions > maxEmbeddingDimensions {
+		return errors.New("embedding vector-space dimensions are invalid")
+	}
+	if err := validateEmbeddingVectorSpaceProjection(record); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateEmbeddingVectorSpaceProjection(record EmbeddingVectorSpaceRecord) error {
+	descriptor, err := document.NewEmbeddingDescriptor(record.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, record.Descriptor) {
+		return errors.New("embedding vector-space E1 descriptor is not canonical")
+	}
+	if record.ProviderDescriptor != descriptor.ID || record.ProviderRevision != descriptor.ModelRevision ||
+		record.DescriptorFingerprint != descriptor.Fingerprint || record.CompatibilityID != descriptor.CompatibilityID ||
+		record.Dimensions != descriptor.Dimension || record.Metric != descriptor.Metric ||
+		record.Normalization != descriptor.Normalization || record.ScalarEncoding != descriptor.ScalarEncoding ||
+		record.DocumentFormatter != descriptor.DocumentFormatter || record.QueryFormatter != descriptor.QueryFormatter ||
+		record.ModelInputFingerprint != descriptor.ModelInput.Fingerprint {
+		return errors.New("embedding vector-space projection does not match canonical E1 descriptor")
+	}
+	return nil
+}
+
+func validateEmbeddingInputGeneration(record EmbeddingInputGenerationRecord) error {
+	if err := validateUUIDv4(record.SourceVersionID); err != nil {
+		return fmt.Errorf("source version ID: %w", err)
+	}
+	for value, subject := range map[string]string{
+		record.ID:                           "input-generation ID",
+		record.ProcessingProfileFingerprint: "input-generation profile fingerprint",
+		record.EvidenceFingerprint:          "evidence fingerprint", record.TokenizerFingerprint: "tokenizer fingerprint",
+		record.ChunkPolicyFingerprint: "chunk policy fingerprint", record.FormatterFingerprint: "formatter fingerprint",
+		record.GenerationChecksum: "input-generation checksum",
+	} {
+		if err := validateCatalogSHA256(value, subject); err != nil {
+			return err
+		}
+	}
+	if record.GenerationBlobHash != "" {
+		if err := validateCatalogSHA256(record.GenerationBlobHash, "input-generation blob hash"); err != nil {
+			return err
+		}
+		if record.GenerationEncodedSize < 2 || record.GenerationEncodedSize > 64<<20 {
+			return errors.New("input-generation encoded size is invalid")
+		}
+	} else if record.GenerationEncodedSize != 0 {
+		return errors.New("input-generation blob size requires a blob hash")
+	}
+	if record.AttachmentContextFingerprint != "" {
+		if err := validateCatalogSHA256(record.AttachmentContextFingerprint, "attachment-context fingerprint"); err != nil {
+			return err
+		}
+		if record.AttachmentID == "" {
+			return errors.New("attachment context requires an attachment identity")
+		}
+	}
+	if record.AttachmentID != "" {
+		if err := validateCatalogSHA256(record.AttachmentID, "embedding attachment ID"); err != nil {
+			return err
+		}
+	}
+	if len(record.Inputs) < 1 || len(record.Inputs) > maxEmbeddingCatalogRows {
+		return errors.New("embedding input generation count is invalid")
+	}
+	seen := make(map[string]struct{}, len(record.Inputs))
+	for _, input := range record.Inputs {
+		if err := validateEmbeddingCatalogText(input.ID, "embedding input ID"); err != nil {
+			return err
+		}
+		if err := validateCatalogSHA256(input.RenderedChecksum, "rendered input checksum"); err != nil {
+			return err
+		}
+		if _, duplicate := seen[input.ID]; duplicate {
+			return errors.New("embedding input generation contains duplicate input IDs")
+		}
+		seen[input.ID] = struct{}{}
+	}
+	return validateMetadataTime("input-generation created_at", record.CreatedAt)
+}
+
+func validateEmbeddingVectorSet(vectorSet EmbeddingVectorSetRecord, space EmbeddingVectorSpaceRecord, generation EmbeddingInputGenerationRecord) error {
+	if vectorSet.ContractVersion != EmbeddingVectorSetContractV1 {
+		return errors.New("embedding vector-set contract version is unsupported")
+	}
+	for value, subject := range map[string]string{
+		vectorSet.ID: "vector-set ID", vectorSet.PayloadBlobHash: "vector payload blob hash",
+		vectorSet.PayloadChecksum: "vector payload checksum", vectorSet.ManifestChecksum: "vector manifest checksum",
+		vectorSet.VectorSpaceID: "vector-set vector-space ID",
+	} {
+		if err := validateCatalogSHA256(value, subject); err != nil {
+			return err
+		}
+	}
+	if vectorSet.RowCount != len(vectorSet.rows) || vectorSet.RowCount != len(generation.Inputs) ||
+		vectorSet.RowCount < 1 || vectorSet.RowCount > maxEmbeddingCatalogRows {
+		return errors.New("embedding vector-set row count does not match input generation")
+	}
+	if vectorSet.ID != vectorSet.PayloadChecksum {
+		return errors.New("embedding vector-set ID does not match payload checksum")
+	}
+	if vectorSet.Dimensions != space.Dimensions || vectorSet.VectorSpaceID != space.ID {
+		return errors.New("embedding vector-set dimensions do not match vector space")
+	}
+	if vectorSet.PayloadSize < 1 || vectorSet.PayloadSize > 64<<20 {
+		return errors.New("embedding vector payload size is invalid")
+	}
+	inputs := make(map[string]struct{}, len(generation.Inputs))
+	for _, input := range generation.Inputs {
+		inputs[input.ID] = struct{}{}
+	}
+	seenRows := make(map[string]struct{}, len(vectorSet.rows))
+	seenInputs := make(map[string]struct{}, len(vectorSet.rows))
+	for index, row := range vectorSet.rows {
+		if err := validateEmbeddingCatalogText(row.RowID, "embedding vector row ID"); err != nil {
+			return err
+		}
+		if err := validateCatalogSHA256(row.Checksum, "embedding vector row checksum"); err != nil {
+			return err
+		}
+		if row.Dimensions != space.Dimensions {
+			return errors.New("embedding vector row dimension mismatch")
+		}
+		if _, expected := inputs[row.InputID]; !expected {
+			return errors.New("embedding vector set contains an unexpected input row")
+		}
+		if _, duplicate := seenRows[row.RowID]; duplicate {
+			return errors.New("embedding vector set contains duplicate row IDs")
+		}
+		if _, duplicate := seenInputs[row.InputID]; duplicate {
+			return errors.New("embedding vector set contains duplicate input rows")
+		}
+		if row.RowID != row.InputID {
+			return errors.New("embedding vector row ID does not match canonical input key")
+		}
+		if row.InputID != generation.Inputs[index].ID || row.Checksum != generation.Inputs[index].RenderedChecksum {
+			return errors.New("embedding vector rows do not match ordered generation inputs and checksums")
+		}
+		seenRows[row.RowID], seenInputs[row.InputID] = struct{}{}, struct{}{}
+	}
+	if embeddingVectorManifestChecksum(vectorSet.rows) != vectorSet.ManifestChecksum {
+		return errors.New("embedding vector-set manifest checksum mismatch")
+	}
+	return nil
+}
+
+func embeddingVectorManifestChecksum(rows []EmbeddingVectorRowRecord) string {
+	hash := sha256.New()
+	for _, row := range rows {
+		_, _ = hash.Write([]byte(row.RowID))
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(row.InputID))
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(strconv.Itoa(row.Dimensions)))
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(row.Checksum))
+		_, _ = hash.Write([]byte{'\n'})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func validateEmbeddingSetFencesTx(ctx context.Context, tx *sql.Tx, record EmbeddingSetRecord) error {
+	profileRecord, err := loadProcessingProfile(ctx, tx, record.ProcessingProfileFingerprint)
+	if err != nil {
+		return fmt.Errorf("embedding set processing profile: %w", err)
+	}
+	var profile document.ProcessingProfileV1
+	if err := json.Unmarshal(profileRecord.CanonicalProfile, &profile); err != nil {
+		return fmt.Errorf("decoding embedding processing profile: %w", err)
+	}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	if err != nil || !bytes.Equal(canonical, profileRecord.CanonicalProfile) || fingerprints.Profile != record.ProcessingProfileFingerprint {
+		return errors.New("embedding processing profile authority is not canonical")
+	}
+	var binding *document.EmbeddingBindingV1
+	for index := range profile.Embeddings {
+		if profile.Embeddings[index].Name == record.BindingID {
+			binding = &profile.Embeddings[index]
+			break
+		}
+	}
+	if binding == nil {
+		return fmt.Errorf("processing profile binding %q does not exist", record.BindingID)
+	}
+	if err := validateEmbeddingBindingAuthority(record, *binding, fingerprints); err != nil {
+		return err
+	}
+	var versionCount, blobCount, blobSize int64
+	if err := tx.QueryRowContext(ctx, `SELECT
+		(SELECT COUNT(*) FROM content_versions WHERE version_id=?),
+		(SELECT COUNT(*) FROM blobs WHERE hash=?),
+		COALESCE((SELECT size FROM blobs WHERE hash=?),-1)`, record.ContentVersionID,
+		record.VectorSet.PayloadBlobHash, record.VectorSet.PayloadBlobHash).Scan(&versionCount, &blobCount, &blobSize); err != nil {
+		return err
+	}
+	if versionCount != 1 || blobCount != 1 || blobSize != int64(len(record.VectorSet.Payload)) {
+		return errors.New("embedding set references a missing source version or exact vector payload")
+	}
+	if record.InputKind == document.EmbeddingInputRenditionChunk {
+		var generationBlobCount, generationBlobSize int64
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*),COALESCE(MAX(size),-1) FROM blobs WHERE hash=?`,
+			record.InputGeneration.GenerationBlobHash).Scan(&generationBlobCount, &generationBlobSize); err != nil {
+			return err
+		}
+		if generationBlobCount != 1 || generationBlobSize != int64(len(record.InputGeneration.GenerationJSON)) {
+			return errors.New("embedding set references a missing exact E2 generation artifact")
+		}
+	}
+	if record.InputKind == document.EmbeddingInputRenditionChunk && record.InputGeneration.AttachmentID == "" {
+		return errors.New("chunk embedding set requires rendition attachment authority")
+	}
+	if record.InputKind == document.EmbeddingInputOriginalFile {
+		if record.InputGeneration.AttachmentID != "" || len(record.InputGeneration.GenerationJSON) != 0 ||
+			record.InputGeneration.GenerationBlobHash != "" || record.InputGeneration.GenerationEncodedSize != 0 ||
+			len(record.InputGeneration.Inputs) != 1 {
+			return errors.New("original-file input authority cannot claim rendition attachment or E2 generation")
+		}
+		var sourceHash string
+		if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`, record.ContentVersionID).Scan(&sourceHash); err != nil {
+			return err
+		}
+		if record.InputGeneration.GenerationChecksum != sourceHash ||
+			record.InputGeneration.Inputs[0] != (EmbeddingInputReference{ID: record.ContentVersionID, RenderedChecksum: sourceHash}) {
+			return errors.New("original-file input authority must name the exact source version bytes")
+		}
+	} else if record.InputGeneration.AttachmentID != "" {
+		var count int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM rendition_attachments
+			WHERE attachment_id=? AND content_version_id=? AND profile_fingerprint=?`,
+			record.InputGeneration.AttachmentID, record.ContentVersionID,
+			record.ProcessingProfileFingerprint).Scan(&count); err != nil {
+			return err
+		}
+		if count != 1 {
+			return errors.New("embedding generation attachment fence does not match source/profile")
+		}
+		var evidenceChecksum, sourceHash string
+		if err := tx.QueryRowContext(ctx, `SELECT b.evidence_checksum,b.source_sha256
+			FROM rendition_attachments a JOIN rendition_builds b ON b.build_id=a.build_id
+			WHERE a.attachment_id=?`, record.InputGeneration.AttachmentID).Scan(&evidenceChecksum, &sourceHash); err != nil {
+			return err
+		}
+		var generation document.EmbeddingInputGeneration
+		if err := json.Unmarshal(record.InputGeneration.GenerationJSON, &generation); err != nil {
+			return err
+		}
+		if generation.EvidenceChecksum != evidenceChecksum {
+			return errors.New("E2 generation evidence checksum does not match attachment authority")
+		}
+		var contentHash string
+		if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`, record.ContentVersionID).Scan(&contentHash); err != nil {
+			return err
+		}
+		if contentHash != sourceHash {
+			return errors.New("E2 attachment source does not match content version")
+		}
+	}
+	return nil
+}
+
+func validateEmbeddingBindingAuthority(record EmbeddingSetRecord, binding document.EmbeddingBindingV1, fingerprints document.FingerprintSet) error {
+	space := record.VectorSpace
+	if record.InputKind != binding.InputKind ||
+		record.EmbeddingInputFingerprint != fingerprints.EmbeddingInput[binding.Name] ||
+		space.ID != fingerprints.VectorSpace[binding.Name] {
+		return errors.New("embedding set does not match exact processing profile binding identity")
+	}
+	descriptor := space.Descriptor
+	if descriptor.ID != binding.Descriptor.ID || descriptor.Fingerprint != binding.Descriptor.Fingerprint ||
+		descriptor.Model != binding.Model || descriptor.Dimension != binding.Dimensions ||
+		descriptor.Metric != binding.Metric || descriptor.Normalization != binding.Normalization ||
+		descriptor.ScalarEncoding != binding.ScalarEncoding || descriptor.DocumentFormatter != binding.DocumentFormatter ||
+		descriptor.QueryFormatter != binding.QueryFormatter || descriptor.CompatibilityID != binding.CompatibilityID ||
+		descriptor.ModelInput != binding.ModelInput || string(descriptor.TrustBoundary) != binding.TrustBoundary ||
+		!slices.Contains(descriptor.InputKinds, binding.InputKind) {
+		return errors.New("E1 descriptor does not match exact processing profile embedding binding")
+	}
+	if record.InputKind == document.EmbeddingInputRenditionChunk {
+		if len(record.InputGeneration.GenerationJSON) == 0 {
+			return nil
+		}
+		var generation document.EmbeddingInputGeneration
+		if err := json.Unmarshal(record.InputGeneration.GenerationJSON, &generation); err != nil {
+			return err
+		}
+		if binding.Chunk == nil || generation.ModelInputFingerprint != binding.ModelInput.Fingerprint ||
+			generation.LexicalEvidenceFingerprint != fingerprints.EvidenceLexical ||
+			generation.Chunk != *binding.Chunk ||
+			generation.MaxInputTokens != binding.MaxInputTokens ||
+			generation.MaxInputBytes != binding.MaxInputBytes {
+			return errors.New("E2 generation does not match exact processing profile embedding binding")
+		}
+		for _, input := range generation.Inputs {
+			if input.ContentTokens > binding.Chunk.MaxTokens {
+				return errors.New("E2 generation exceeds processing profile chunk token bound")
+			}
+		}
+	}
+	return nil
+}
+
+func insertVectorSpaceTx(ctx context.Context, tx *sql.Tx, record EmbeddingVectorSpaceRecord) error {
+	descriptorJSON, err := encodeCanonicalEmbeddingDescriptor(record.Descriptor)
+	if err != nil {
+		return fmt.Errorf("encoding E1 descriptor: %w", err)
+	}
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO embedding_vector_spaces(
+		vector_space_id,contract_version,descriptor_json,
+		provider_descriptor,provider_revision,
+		descriptor_fingerprint,compatibility_id,dimensions,metric,normalization,
+		scalar_encoding,document_formatter,query_formatter,model_input_fingerprint
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, record.ID, record.ContractVersion, descriptorJSON,
+		record.ProviderDescriptor, record.ProviderRevision, record.DescriptorFingerprint,
+		record.CompatibilityID, record.Dimensions, record.Metric, record.Normalization,
+		record.ScalarEncoding, record.DocumentFormatter, record.QueryFormatter,
+		record.ModelInputFingerprint)
+	if err != nil {
+		return fmt.Errorf("inserting embedding vector space: %w", err)
+	}
+	inserted, _ := result.RowsAffected()
+	if inserted == 0 {
+		stored, err := loadVectorSpaceTx(ctx, tx, record.ID)
+		if err != nil || !reflect.DeepEqual(stored, record) {
+			return fmt.Errorf("embedding vector space %s names different immutable authority", record.ID)
+		}
+	}
+	return nil
+}
+
+func insertInputGenerationTx(ctx context.Context, tx *sql.Tx, record EmbeddingInputGenerationRecord) error {
+	var attachment any
+	if record.AttachmentID != "" {
+		attachment = record.AttachmentID
+	}
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO embedding_input_generations(
+		generation_id,generation_blob_hash,generation_encoded_size,generation_checksum,source_version_id,profile_fingerprint,
+		evidence_fingerprint,tokenizer_fingerprint,chunk_policy_fingerprint,
+		formatter_fingerprint,attachment_context_fingerprint,attachment_id,
+		input_count,created_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, record.ID, nullableCatalogString(record.GenerationBlobHash), record.GenerationEncodedSize, record.GenerationChecksum,
+		record.SourceVersionID, record.ProcessingProfileFingerprint, record.EvidenceFingerprint,
+		record.TokenizerFingerprint, record.ChunkPolicyFingerprint, record.FormatterFingerprint,
+		record.AttachmentContextFingerprint, attachment,
+		len(record.Inputs), record.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("inserting embedding input generation: %w", err)
+	}
+	inserted, _ := result.RowsAffected()
+	if inserted == 0 {
+		stored, err := loadInputGenerationTx(ctx, tx, record.ID)
+		if err != nil || !reflect.DeepEqual(stored, record) {
+			return fmt.Errorf("embedding input generation %s names different immutable authority", record.ID)
+		}
+		return nil
+	}
+	for order, input := range record.Inputs {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO embedding_generation_inputs(
+			generation_id,input_id,input_order,rendered_checksum) VALUES(?,?,?,?)`,
+			record.ID, input.ID, order, input.RenderedChecksum); err != nil {
+			return fmt.Errorf("inserting embedding input: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertVectorSetTx(ctx context.Context, tx *sql.Tx, record EmbeddingVectorSetRecord) error {
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO embedding_vector_sets(
+		vector_set_id,contract_version,vector_space_id,payload_blob_hash,payload_size,payload_checksum,
+		manifest_checksum,row_count,dimensions) VALUES(?,?,?,?,?,?,?,?,?)`, record.ID,
+		record.ContractVersion, record.VectorSpaceID, record.PayloadBlobHash, record.PayloadSize, record.PayloadChecksum,
+		record.ManifestChecksum, record.RowCount, record.Dimensions)
+	if err != nil {
+		return fmt.Errorf("inserting embedding vector set: %w", err)
+	}
+	inserted, _ := result.RowsAffected()
+	if inserted == 0 {
+		stored, err := loadVectorSetTx(ctx, tx, record.ID)
+		if err != nil || !reflect.DeepEqual(stored, record) {
+			return fmt.Errorf("embedding vector set %s names different immutable authority", record.ID)
+		}
+		return nil
+	}
+	for order, row := range record.rows {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO embedding_vector_rows(
+			vector_set_id,row_id,row_order,input_id,dimensions,checksum) VALUES(?,?,?,?,?,?)`,
+			record.ID, row.RowID, order, row.InputID, row.Dimensions, row.Checksum); err != nil {
+			return fmt.Errorf("inserting embedding vector row: %w", err)
+		}
+	}
+	return nil
+}
+
+func loadEmbeddingSetTx(ctx context.Context, tx metadataQuerier, id string) (EmbeddingSetRecord, error) {
+	var result EmbeddingSetRecord
+	err := tx.QueryRowContext(ctx, `SELECT embedding_set_id,vault_uid,binding_id,input_kind,
+		content_version_id,profile_fingerprint,embedding_input_fingerprint,vector_space_id,input_generation_id,
+		vector_set_id,created_at FROM embedding_sets WHERE embedding_set_id=?`, id).Scan(
+		&result.ID, &result.VaultID, &result.BindingID, &result.InputKind,
+		&result.ContentVersionID, &result.ProcessingProfileFingerprint, &result.EmbeddingInputFingerprint, &result.VectorSpace.ID,
+		&result.InputGeneration.ID, &result.VectorSet.ID, &result.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return EmbeddingSetRecord{}, ErrNotFound
+	}
+	if err != nil {
+		return EmbeddingSetRecord{}, fmt.Errorf("loading embedding set: %w", err)
+	}
+	if result.VectorSpace, err = loadVectorSpaceTx(ctx, tx, result.VectorSpace.ID); err != nil {
+		return EmbeddingSetRecord{}, err
+	}
+	if result.InputGeneration, err = loadInputGenerationTx(ctx, tx, result.InputGeneration.ID); err != nil {
+		return EmbeddingSetRecord{}, err
+	}
+	if result.VectorSet, err = loadVectorSetTx(ctx, tx, result.VectorSet.ID); err != nil {
+		return EmbeddingSetRecord{}, err
+	}
+	return result, nil
+}
+
+func loadVectorSpaceTx(ctx context.Context, tx metadataQuerier, id string) (EmbeddingVectorSpaceRecord, error) {
+	var record EmbeddingVectorSpaceRecord
+	var descriptorJSON []byte
+	err := tx.QueryRowContext(ctx, `SELECT vector_space_id,contract_version,
+		descriptor_json,provider_descriptor,provider_revision,descriptor_fingerprint,compatibility_id,
+		dimensions,metric,normalization,scalar_encoding,document_formatter,query_formatter,
+		model_input_fingerprint FROM embedding_vector_spaces WHERE vector_space_id=?`, id).Scan(
+		&record.ID, &record.ContractVersion, &descriptorJSON, &record.ProviderDescriptor, &record.ProviderRevision,
+		&record.DescriptorFingerprint, &record.CompatibilityID, &record.Dimensions, &record.Metric,
+		&record.Normalization, &record.ScalarEncoding, &record.DocumentFormatter,
+		&record.QueryFormatter, &record.ModelInputFingerprint)
+	if errors.Is(err, sql.ErrNoRows) {
+		return record, ErrNotFound
+	}
+	if err == nil {
+		record.Descriptor, err = decodeCanonicalEmbeddingDescriptor(descriptorJSON)
+	}
+	return record, err
+}
+
+func encodeCanonicalEmbeddingDescriptor(descriptor document.EmbeddingDescriptor) ([]byte, error) {
+	canonical, err := document.NewEmbeddingDescriptor(descriptor)
+	if err != nil {
+		return nil, err
+	}
+	if !reflect.DeepEqual(canonical, descriptor) {
+		return nil, errors.New("E1 descriptor is not canonical")
+	}
+	encoded, err := json.Marshal(canonical)
+	if err != nil {
+		return nil, err
+	}
+	if len(encoded) < 2 || len(encoded) > maxEmbeddingDescriptorJSON {
+		return nil, errors.New("E1 descriptor JSON exceeds bounds")
+	}
+	return encoded, nil
+}
+
+func decodeCanonicalEmbeddingDescriptor(data []byte) (document.EmbeddingDescriptor, error) {
+	if len(data) < 2 || len(data) > maxEmbeddingDescriptorJSON {
+		return document.EmbeddingDescriptor{}, errors.New("E1 descriptor JSON exceeds bounds")
+	}
+	var descriptor document.EmbeddingDescriptor
+	if err := jsonv2.Unmarshal(data, &descriptor, jsonv2.RejectUnknownMembers(true)); err != nil {
+		return document.EmbeddingDescriptor{}, fmt.Errorf("decoding strict E1 descriptor JSON: %w", err)
+	}
+	encoded, err := encodeCanonicalEmbeddingDescriptor(descriptor)
+	if err != nil {
+		return document.EmbeddingDescriptor{}, err
+	}
+	if !bytes.Equal(encoded, data) {
+		return document.EmbeddingDescriptor{}, errors.New("E1 descriptor JSON is not the canonical staged encoding")
+	}
+	return descriptor, nil
+}
+
+func loadInputGenerationTx(ctx context.Context, tx metadataQuerier, id string) (EmbeddingInputGenerationRecord, error) {
+	var record EmbeddingInputGenerationRecord
+	var attachment sql.NullString
+	var count int
+	var generationBlob sql.NullString
+	err := tx.QueryRowContext(ctx, `SELECT generation_id,generation_blob_hash,generation_encoded_size,generation_checksum,source_version_id,
+		profile_fingerprint,evidence_fingerprint,tokenizer_fingerprint,
+		chunk_policy_fingerprint,formatter_fingerprint,attachment_context_fingerprint,
+		attachment_id,input_count,created_at
+		FROM embedding_input_generations WHERE generation_id=?`, id).Scan(&record.ID,
+		&generationBlob, &record.GenerationEncodedSize, &record.GenerationChecksum, &record.SourceVersionID, &record.ProcessingProfileFingerprint,
+		&record.EvidenceFingerprint, &record.TokenizerFingerprint, &record.ChunkPolicyFingerprint,
+		&record.FormatterFingerprint, &record.AttachmentContextFingerprint, &attachment,
+		&count, &record.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return record, ErrNotFound
+	}
+	if err != nil {
+		return record, err
+	}
+	if attachment.Valid {
+		record.AttachmentID = attachment.String
+	}
+	if generationBlob.Valid {
+		record.GenerationBlobHash = generationBlob.String
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT input_id,rendered_checksum
+		FROM embedding_generation_inputs WHERE generation_id=? ORDER BY input_order`, id)
+	if err != nil {
+		return record, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var input EmbeddingInputReference
+		if err := rows.Scan(&input.ID, &input.RenderedChecksum); err != nil {
+			return record, err
+		}
+		record.Inputs = append(record.Inputs, input)
+		if len(record.Inputs) > maxEmbeddingCatalogRows {
+			return record, errors.New("embedding input generation exceeds bounded count")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return record, err
+	}
+	if len(record.Inputs) != count {
+		return record, errors.New("embedding input generation count is corrupt")
+	}
+	return record, nil
+}
+
+func loadVectorSetTx(ctx context.Context, tx metadataQuerier, id string) (EmbeddingVectorSetRecord, error) {
+	var record EmbeddingVectorSetRecord
+	err := tx.QueryRowContext(ctx, `SELECT vector_set_id,contract_version,vector_space_id,payload_blob_hash,
+		payload_size,payload_checksum,manifest_checksum,row_count,dimensions
+		FROM embedding_vector_sets WHERE vector_set_id=?`, id).Scan(&record.ID,
+		&record.ContractVersion, &record.VectorSpaceID, &record.PayloadBlobHash, &record.PayloadSize, &record.PayloadChecksum,
+		&record.ManifestChecksum, &record.RowCount, &record.Dimensions)
+	if errors.Is(err, sql.ErrNoRows) {
+		return record, ErrNotFound
+	}
+	if err != nil {
+		return record, err
+	}
+	if record.RowCount < 1 || record.RowCount > maxEmbeddingCatalogRows {
+		return record, errors.New("embedding vector-set count is corrupt")
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT row_id,input_id,dimensions,checksum
+		FROM embedding_vector_rows WHERE vector_set_id=? ORDER BY row_order`, id)
+	if err != nil {
+		return record, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var row EmbeddingVectorRowRecord
+		if err := rows.Scan(&row.RowID, &row.InputID, &row.Dimensions, &row.Checksum); err != nil {
+			return record, err
+		}
+		record.rows = append(record.rows, row)
+		if len(record.rows) > record.RowCount {
+			return record, errors.New("embedding vector-set rows exceed declared count")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return record, err
+	}
+	if len(record.rows) != record.RowCount || embeddingVectorManifestChecksum(record.rows) != record.ManifestChecksum {
+		return record, errors.New("embedding vector-set manifest is corrupt")
+	}
+	return record, nil
+}
+
+func embeddingSetEligibleTx(ctx context.Context, tx *sql.Tx, set EmbeddingSetRecord) (bool, error) {
+	var live int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_versions v
+		JOIN nodes n ON n.id=v.node_id AND n.current_version_id=v.version_id AND n.trashed_at IS NULL
+		WHERE v.version_id=?`, set.ContentVersionID).Scan(&live); err != nil {
+		return false, err
+	}
+	if live != 1 {
+		return false, nil
+	}
+	if set.InputGeneration.AttachmentID == "" {
+		return true, nil
+	}
+	var attached int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM rendition_heads h
+		JOIN rendition_attachments a ON a.attachment_id=h.attachment_id
+		WHERE h.content_version_id=? AND h.profile_fingerprint=? AND h.attachment_id=?`,
+		set.ContentVersionID, set.ProcessingProfileFingerprint,
+		set.InputGeneration.AttachmentID).Scan(&attached); err != nil {
+		return false, err
+	}
+	return attached == 1, nil
+}
+
+func validateEmbeddingHeadKey(key EmbeddingHeadKey) error {
+	if err := validateUUIDv4(key.ContentVersionID); err != nil {
+		return fmt.Errorf("embedding head content version: %w", err)
+	}
+	if err := validateEmbeddingCatalogText(key.BindingID, "embedding head binding"); err != nil {
+		return err
+	}
+	return validateEmbeddingInputKind(key.InputKind)
+}
+
+func validateEmbeddingHeadRecord(record EmbeddingHeadRecord) error {
+	if err := validateEmbeddingHeadKey(record.Key); err != nil {
+		return err
+	}
+	for value, subject := range map[string]string{
+		record.SetID: "embedding head set ID", record.VectorSpaceID: "embedding head vector-space ID",
+		record.ProcessingProfileFingerprint: "embedding head profile fingerprint",
+	} {
+		if err := validateCatalogSHA256(value, subject); err != nil {
+			return err
+		}
+	}
+	return validateMetadataTime("embedding head published_at", record.PublishedAt)
+}
+
+func validateEmbeddingFailureRecord(record EmbeddingFailureRecord) error {
+	if err := validateEmbeddingHeadKey(EmbeddingHeadKey{record.ContentVersionID, record.BindingID, record.InputKind}); err != nil {
+		return err
+	}
+	if err := validateCatalogSHA256(record.ProcessingProfileFingerprint, "embedding failure profile"); err != nil {
+		return err
+	}
+	switch record.FailureCode {
+	case EmbeddingFailureProviderUnavailable, EmbeddingFailureAuthorization,
+		EmbeddingFailureInvalidResponse, EmbeddingFailureInputRejected, EmbeddingFailureStaleAuthority:
+	default:
+		return errors.New("embedding failure code is not in the provider-neutral vocabulary")
+	}
+	return validateMetadataTime("embedding failure failed_at", record.FailedAt)
+}
+
+func validateEmbeddingInputKind(kind EmbeddingInputKind) error {
+	switch kind {
+	case document.EmbeddingInputRenditionChunk, document.EmbeddingInputOriginalFile:
+		return nil
+	default:
+		return fmt.Errorf("embedding input kind %q is unsupported", kind)
+	}
+}
+
+func validateEmbeddingCatalogText(value, subject string) error {
+	if strings.TrimSpace(value) == "" || len(value) > maxEmbeddingCatalogIDBytes {
+		return fmt.Errorf("%s must be bounded non-empty text", subject)
+	}
+	return nil
+}
+
+type embeddingCatalogTableSchema struct {
+	name    string
+	columns []string
+}
+
+var embeddingCatalogSchema = []embeddingCatalogTableSchema{
+	{"embedding_vector_spaces", []string{metadataEmbeddingVectorSpaceIDField, "contract_version", "descriptor_json", "provider_descriptor", "provider_revision", "descriptor_fingerprint", "compatibility_id", "dimensions", "metric", "normalization", "scalar_encoding", "document_formatter", "query_formatter", "model_input_fingerprint"}},
+	{"embedding_input_generations", []string{metadataGenerationIDField, "generation_blob_hash", "generation_encoded_size", "generation_checksum", auditSourceVersionIDField, metadataEmbeddingProfileField, "evidence_fingerprint", "tokenizer_fingerprint", "chunk_policy_fingerprint", "formatter_fingerprint", "attachment_context_fingerprint", "attachment_id", "input_count", metadataCreatedAtField}},
+	{"embedding_generation_inputs", []string{metadataGenerationIDField, "input_id", "input_order", "rendered_checksum"}},
+	{"embedding_vector_sets", []string{"vector_set_id", "contract_version", metadataEmbeddingVectorSpaceIDField, "payload_blob_hash", "payload_size", "payload_checksum", "manifest_checksum", "row_count", "dimensions"}},
+	{"embedding_vector_rows", []string{"vector_set_id", "row_id", "row_order", "input_id", "dimensions", "checksum"}},
+	{"embedding_sets", []string{"embedding_set_id", "vault_uid", "binding_id", "input_kind", metadataContentVersionIDField, metadataEmbeddingProfileField, "embedding_input_fingerprint", metadataEmbeddingVectorSpaceIDField, "input_generation_id", "vector_set_id", metadataCreatedAtField}},
+	{"embedding_heads", []string{metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at"}},
+	{"embedding_failures", []string{metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at"}},
+}
+
+func validateEmbeddingCatalogSchemaTx(ctx context.Context, tx *sql.Tx) error {
+	return validateEmbeddingCatalogSchema(ctx, tx)
+}
+
+type embeddingCatalogSchemaQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+func validateEmbeddingCatalogSchema(ctx context.Context, query embeddingCatalogSchemaQuerier) error {
+	for _, table := range embeddingCatalogSchema {
+		got, err := embeddingCatalogSchemaColumns(ctx, query, table.name)
+		if err != nil {
+			return fmt.Errorf("validating embedding catalog schema %s: %w", table.name, err)
+		}
+		if !slices.Equal(got, table.columns) {
+			return fmt.Errorf("embedding catalog schema %s columns are invalid", table.name)
+		}
+	}
+	return nil
+}
+
+func embeddingCatalogSchemaColumns(
+	ctx context.Context, query embeddingCatalogSchemaQuerier, table string,
+) (_ []string, retErr error) {
+	rows, err := query.QueryContext(ctx, `SELECT name FROM pragma_table_info(?) ORDER BY cid`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { retErr = errors.Join(retErr, rows.Close()) }()
+	var columns []string
+	for rows.Next() {
+		var column string
+		if err := rows.Scan(&column); err != nil {
+			return nil, err
+		}
+		columns = append(columns, column)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return columns, nil
+}

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -898,6 +898,9 @@ func validateEmbeddingBindingAuthority(record EmbeddingSetRecord, binding docume
 			generation.MaxInputBytes != binding.MaxInputBytes {
 			return errors.New("E2 generation does not match exact processing profile embedding binding")
 		}
+		if _, err := generation.ToEmbeddingInputs(binding.ModelInput); err != nil {
+			return fmt.Errorf("E2 generation model-input contract: %w", err)
+		}
 		for _, input := range generation.Inputs {
 			if input.ContentTokens > binding.Chunk.MaxTokens {
 				return errors.New("E2 generation exceeds processing profile chunk token bound")

--- a/internal/store/embedding_catalog_authority_test.go
+++ b/internal/store/embedding_catalog_authority_test.go
@@ -326,14 +326,17 @@ func TestEmbeddingCatalogReadsPackedArtifactAuthority(t *testing.T) {
 	require.Equal(t, data, read)
 }
 
-func TestEmbeddingCatalogProviderFreeRestoreVerifiesLooseAndPackedArtifacts(t *testing.T) {
+func TestEmbeddingCatalogBackupRestoreVerifiesLooseAndPackedArtifacts(t *testing.T) {
 	for _, packed := range []bool{false, true} {
 		t.Run(map[bool]string{false: "loose", true: "packed"}[packed], func(t *testing.T) {
 			source, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
 			record := embeddingSetFixture(source, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
 			require.NoError(t, source.StageEmbeddingSet(t.Context(), record))
+			snapshot, err := source.BeginMetadataSnapshot(t.Context())
+			require.NoError(t, err)
+			defer func() { require.NoError(t, snapshot.Close()) }()
 			var metadata bytes.Buffer
-			require.NoError(t, source.ExportMetadata(t.Context(), &metadata))
+			require.NoError(t, snapshot.ExportBackup(t.Context(), &metadata))
 
 			target := newTestStore(t)
 			artifacts := map[string][]byte{
@@ -344,7 +347,24 @@ func TestEmbeddingCatalogProviderFreeRestoreVerifiesLooseAndPackedArtifacts(t *t
 				testSHA256(record.InputGeneration.EvidenceJSON): record.InputGeneration.EvidenceJSON,
 				record.VectorSet.PayloadBlobHash:                record.VectorSet.Payload,
 			}
-			layout := materializeEmbeddingRestoreArtifacts(t, target, artifacts)
+			// Copy only the bytes selected by the portable backup closure, not
+			// every fixture blob. The embedding evidence has no rendition-artifact
+			// reference to bring it into the backup on the generation's behalf.
+			require.NotEqual(t, catalogEvidenceBlobHash, testSHA256(record.InputGeneration.EvidenceJSON))
+			rows, err := snapshot.QueryContext(t.Context(), BackupBlobAuthorityCTE+
+				`SELECT hash FROM backup_authorized_blobs`)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, rows.Close()) }()
+			backupArtifacts := make(map[string][]byte)
+			for rows.Next() {
+				var hash string
+				require.NoError(t, rows.Scan(&hash))
+				require.Contains(t, artifacts, hash)
+				backupArtifacts[hash] = artifacts[hash]
+			}
+			require.NoError(t, rows.Err())
+			require.NoError(t, rows.Close())
+			layout := materializeEmbeddingRestoreArtifacts(t, target, backupArtifacts)
 			require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(metadata.Bytes())))
 			if packed {
 				packEmbeddingRestoreArtifacts(t, target, layout, map[string][]byte{

--- a/internal/store/embedding_catalog_authority_test.go
+++ b/internal/store/embedding_catalog_authority_test.go
@@ -145,13 +145,13 @@ func TestEmbeddingCatalogRevalidatesExactArtifactsProviderFree(t *testing.T) {
 		stored, err := loadEmbeddingSetTx(t.Context(), tx, record.ID)
 		require.NoError(t, err)
 		require.NoError(t, validateExactEmbeddingGenerationArtifact(stored.InputGeneration, generationBytes))
-		require.NoError(t, validateExactEmbeddingVectorArtifact(stored.VectorSet, stored.VectorSpace, stored.InputGeneration, vectorBytes))
+		require.NoError(t, validateExactEmbeddingVectorArtifact(stored.VectorSet, stored.VectorSpace, vectorBytes))
 		corruptGeneration := append([]byte(nil), generationBytes...)
 		corruptGeneration[len(corruptGeneration)/2] ^= 1
 		require.Error(t, validateExactEmbeddingGenerationArtifact(stored.InputGeneration, corruptGeneration))
 		corruptVector := append([]byte(nil), vectorBytes...)
 		corruptVector[len(corruptVector)-1] ^= 1
-		require.Error(t, validateExactEmbeddingVectorArtifact(stored.VectorSet, stored.VectorSpace, stored.InputGeneration, corruptVector))
+		require.Error(t, validateExactEmbeddingVectorArtifact(stored.VectorSet, stored.VectorSpace, corruptVector))
 		return nil
 	}))
 }
@@ -248,6 +248,46 @@ func TestEmbeddingCatalogProviderFreeRestoreVerifiesLooseAndPackedArtifacts(t *t
 			}))
 		})
 	}
+}
+
+func TestEmbeddingCatalogRestoreVerifiesVectorSetRetainedAfterVersionPrune(t *testing.T) {
+	source, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(source, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, source.StageEmbeddingSet(t.Context(), record))
+
+	var nodeID, revision int64
+	require.NoError(t, source.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`,
+		versionID).Scan(&nodeID, &revision))
+	replacementHash := testSHA256([]byte("orphan-vector-restore-replacement"))
+	require.NoError(t, source.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		return source.EnsureBlobTx(tx, replacementHash, 24)
+	}))
+	updated, _, err := source.ReplaceContent(
+		t.Context(), nodeID, revision, replacementHash, 24, "application/pdf",
+	)
+	require.NoError(t, err)
+	_, err = source.PruneContentVersions(t.Context(), nodeID, updated.Revision,
+		VersionPruneSelector{VersionIDs: []string{versionID}}, true)
+	require.NoError(t, err)
+
+	var metadata bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &metadata))
+	target := newTestStore(t)
+	layout := materializeEmbeddingRestoreArtifacts(t, target, map[string][]byte{
+		catalogSourceHash:                catalogBlobContents[catalogSourceHash],
+		catalogEvidenceBlobHash:          catalogBlobContents[catalogEvidenceBlobHash],
+		catalogMarkdownBlobHash:          catalogBlobContents[catalogMarkdownBlobHash],
+		record.VectorSet.PayloadBlobHash: record.VectorSet.Payload,
+	})
+	require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(metadata.Bytes())))
+	require.NoError(t, target.VerifyRenditionBlobAuthority(t.Context()))
+	backend, err := packstore.NewFilesystemBackend(*layout, packstore.FilesystemBackendOptions{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, backend.Close()) }()
+	require.NoError(t, target.VerifyRenditionBlobBytes(t.Context(), &embeddingRestoreReader{
+		store: target, backend: backend,
+	}))
 }
 
 type embeddingRestoreReader struct {

--- a/internal/store/embedding_catalog_authority_test.go
+++ b/internal/store/embedding_catalog_authority_test.go
@@ -19,6 +19,7 @@ import (
 	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/canonical"
 )
 
 // Mutation caught: accepting a store-local input-kind vocabulary lets a caller
@@ -133,6 +134,77 @@ func TestEmbeddingCatalogRejectsGenerationFromDifferentChunkPolicy(t *testing.T)
 		return s.EnsureBlobTx(tx, record.InputGeneration.GenerationBlobHash, int64(len(encoded)))
 	}))
 	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "exact processing profile")
+}
+
+func TestEmbeddingCatalogRejectsGenerationRenderedOutsideModelInputContract(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	generation, err := document.DecodeEmbeddingInputGeneration(
+		record.InputGeneration.GenerationJSON,
+		document.EmbeddingInputGenerationDecodeBounds{
+			MaxEncodedBytes: int64(len(record.InputGeneration.GenerationJSON)), MaxInputs: 128,
+		},
+	)
+	require.NoError(t, err)
+
+	input := &generation.Inputs[0]
+	mutatedRendered := strings.Repeat("x", len(input.Rendered))
+	require.NotEqual(t, input.Rendered, mutatedRendered)
+	input.Rendered = mutatedRendered
+	input.Checksum = testSHA256([]byte(input.Rendered))
+	input.Key = fmt.Sprintf("chunk-%06d-%s", 0, input.Checksum[:12])
+	generation.Checksum = ""
+	checksumInput, err := canonical.Marshal(generation)
+	require.NoError(t, err)
+	generation.Checksum = testSHA256(checksumInput)
+	encodedGeneration, err := document.MarshalEmbeddingInputGeneration(generation)
+	require.NoError(t, err)
+	record.InputGeneration.GenerationJSON = encodedGeneration
+	record.InputGeneration.GenerationBlobHash = testSHA256(encodedGeneration)
+	record.InputGeneration.GenerationEncodedSize = int64(len(encodedGeneration))
+	record.InputGeneration.GenerationChecksum = generation.Checksum
+	record.InputGeneration.ID = testSHA256([]byte(
+		"embedding-generation-attachment/v1\x00" + generation.Checksum + "\x00" + attachmentID,
+	))
+
+	decodedVectors, _, err := document.DecodeVectorSetV1(record.VectorSet.Payload, document.VectorBounds{
+		MaxRows: 128, MaxDimension: record.VectorSpace.Descriptor.Dimension, MaxBytes: len(record.VectorSet.Payload),
+	})
+	require.NoError(t, err)
+	decodedVectors.InputKeys[0] = input.Key
+	decodedVectors.InputChecksums[0] = input.Checksum
+	values := make([][]float64, len(decodedVectors.Vectors))
+	for row := range decodedVectors.Vectors {
+		values[row] = make([]float64, len(decodedVectors.Vectors[row]))
+		for column, value := range decodedVectors.Vectors[row] {
+			values[row][column] = float64(value)
+		}
+	}
+	mutatedVectors, err := document.NewVectorSetV1(document.VectorSetV1Input{
+		VectorSpaceFingerprint: decodedVectors.VectorSpaceFingerprint,
+		Metric:                 decodedVectors.Metric,
+		Normalization:          decodedVectors.Normalization,
+		Dimension:              decodedVectors.Dimension,
+		InputKeys:              decodedVectors.InputKeys,
+		InputChecksums:         decodedVectors.InputChecksums,
+		Values:                 values,
+	})
+	require.NoError(t, err)
+	encodedVectors, vectorChecksum, err := document.EncodeVectorSetV1(mutatedVectors)
+	require.NoError(t, err)
+	record.VectorSet.Payload = encodedVectors
+	record.VectorSet.ID = vectorChecksum
+	record.VectorSet.PayloadChecksum = vectorChecksum
+	record.VectorSet.PayloadBlobHash = testSHA256(encodedVectors)
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		if err := s.EnsureBlobTx(tx, record.InputGeneration.GenerationBlobHash, int64(len(encodedGeneration))); err != nil {
+			return err
+		}
+		return s.EnsureBlobTx(tx, record.VectorSet.PayloadBlobHash, int64(len(encodedVectors)))
+	}))
+
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "model-input contract")
 }
 
 func TestEmbeddingCatalogRevalidatesExactArtifactsProviderFree(t *testing.T) {

--- a/internal/store/embedding_catalog_authority_test.go
+++ b/internal/store/embedding_catalog_authority_test.go
@@ -136,75 +136,115 @@ func TestEmbeddingCatalogRejectsGenerationFromDifferentChunkPolicy(t *testing.T)
 	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "exact processing profile")
 }
 
-func TestEmbeddingCatalogRejectsGenerationRenderedOutsideModelInputContract(t *testing.T) {
-	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
-	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
-		document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
-	generation, err := document.DecodeEmbeddingInputGeneration(
-		record.InputGeneration.GenerationJSON,
-		document.EmbeddingInputGenerationDecodeBounds{
-			MaxEncodedBytes: int64(len(record.InputGeneration.GenerationJSON)), MaxInputs: 128,
-		},
-	)
-	require.NoError(t, err)
+func TestEmbeddingCatalogRejectsGenerationOutsideInputAuthority(t *testing.T) {
+	for _, mutation := range []string{"rendered", "content"} {
+		t.Run(mutation, func(t *testing.T) {
+			s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+				document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+			generation, err := document.DecodeEmbeddingInputGeneration(
+				record.InputGeneration.GenerationJSON,
+				document.EmbeddingInputGenerationDecodeBounds{
+					MaxEncodedBytes: int64(len(record.InputGeneration.GenerationJSON)), MaxInputs: 128,
+				},
+			)
+			require.NoError(t, err)
 
-	input := &generation.Inputs[0]
-	mutatedRendered := strings.Repeat("x", len(input.Rendered))
-	require.NotEqual(t, input.Rendered, mutatedRendered)
-	input.Rendered = mutatedRendered
-	input.Checksum = testSHA256([]byte(input.Rendered))
-	input.Key = fmt.Sprintf("chunk-%06d-%s", 0, input.Checksum[:12])
-	generation.Checksum = ""
-	checksumInput, err := canonical.Marshal(generation)
-	require.NoError(t, err)
-	generation.Checksum = testSHA256(checksumInput)
-	encodedGeneration, err := document.MarshalEmbeddingInputGeneration(generation)
-	require.NoError(t, err)
-	record.InputGeneration.GenerationJSON = encodedGeneration
-	record.InputGeneration.GenerationBlobHash = testSHA256(encodedGeneration)
-	record.InputGeneration.GenerationEncodedSize = int64(len(encodedGeneration))
-	record.InputGeneration.GenerationChecksum = generation.Checksum
-	record.InputGeneration.ID = testSHA256([]byte(
-		"embedding-generation-attachment/v1\x00" + generation.Checksum + "\x00" + attachmentID,
-	))
+			input := &generation.Inputs[0]
+			mutatedRendered := strings.Repeat("x", len(input.Rendered))
+			require.NotEqual(t, input.Rendered, mutatedRendered)
+			if mutation == "content" {
+				content := strings.Repeat("x", len(input.Content))
+				input.Rendered = strings.Replace(input.Rendered, input.Content, content, 1)
+				input.Content = content
+			} else {
+				input.Rendered = mutatedRendered
+			}
+			input.Checksum = testSHA256([]byte(input.Rendered))
+			input.Key = fmt.Sprintf("chunk-%06d-%s", 0, input.Checksum[:12])
+			generation.Checksum = ""
+			checksumInput, err := canonical.Marshal(generation)
+			require.NoError(t, err)
+			generation.Checksum = testSHA256(checksumInput)
+			encodedGeneration, err := document.MarshalEmbeddingInputGeneration(generation)
+			require.NoError(t, err)
+			record.InputGeneration.GenerationJSON = encodedGeneration
+			record.InputGeneration.GenerationBlobHash = testSHA256(encodedGeneration)
+			record.InputGeneration.GenerationEncodedSize = int64(len(encodedGeneration))
+			record.InputGeneration.GenerationChecksum = generation.Checksum
+			record.InputGeneration.ID = testSHA256([]byte(
+				"embedding-generation-attachment/v1\x00" + generation.Checksum + "\x00" + attachmentID,
+			))
 
-	decodedVectors, _, err := document.DecodeVectorSetV1(record.VectorSet.Payload, document.VectorBounds{
-		MaxRows: 128, MaxDimension: record.VectorSpace.Descriptor.Dimension, MaxBytes: len(record.VectorSet.Payload),
-	})
-	require.NoError(t, err)
-	decodedVectors.InputKeys[0] = input.Key
-	decodedVectors.InputChecksums[0] = input.Checksum
-	values := make([][]float64, len(decodedVectors.Vectors))
-	for row := range decodedVectors.Vectors {
-		values[row] = make([]float64, len(decodedVectors.Vectors[row]))
-		for column, value := range decodedVectors.Vectors[row] {
-			values[row][column] = float64(value)
-		}
+			decodedVectors, _, err := document.DecodeVectorSetV1(record.VectorSet.Payload, document.VectorBounds{
+				MaxRows: 128, MaxDimension: record.VectorSpace.Descriptor.Dimension, MaxBytes: len(record.VectorSet.Payload),
+			})
+			require.NoError(t, err)
+			decodedVectors.InputKeys[0] = input.Key
+			decodedVectors.InputChecksums[0] = input.Checksum
+			values := make([][]float64, len(decodedVectors.Vectors))
+			for row := range decodedVectors.Vectors {
+				values[row] = make([]float64, len(decodedVectors.Vectors[row]))
+				for column, value := range decodedVectors.Vectors[row] {
+					values[row][column] = float64(value)
+				}
+			}
+			mutatedVectors, err := document.NewVectorSetV1(document.VectorSetV1Input{
+				VectorSpaceFingerprint: decodedVectors.VectorSpaceFingerprint,
+				Metric:                 decodedVectors.Metric,
+				Normalization:          decodedVectors.Normalization,
+				Dimension:              decodedVectors.Dimension,
+				InputKeys:              decodedVectors.InputKeys,
+				InputChecksums:         decodedVectors.InputChecksums,
+				Values:                 values,
+			})
+			require.NoError(t, err)
+			encodedVectors, vectorChecksum, err := document.EncodeVectorSetV1(mutatedVectors)
+			require.NoError(t, err)
+			record.VectorSet.Payload = encodedVectors
+			record.VectorSet.ID = vectorChecksum
+			record.VectorSet.PayloadChecksum = vectorChecksum
+			record.VectorSet.PayloadBlobHash = testSHA256(encodedVectors)
+			require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+				if err := s.EnsureBlobTx(tx, record.InputGeneration.GenerationBlobHash, int64(len(encodedGeneration))); err != nil {
+					return err
+				}
+				return s.EnsureBlobTx(tx, record.VectorSet.PayloadBlobHash, int64(len(encodedVectors)))
+			}))
+
+			want := "model-input contract"
+			if mutation == "content" {
+				want = "source span"
+			}
+			require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), want)
+			if mutation == "content" {
+				// Simulate imported orphan authority: no set remains to validate the
+				// generation on its behalf. Restore must still reject the forged text.
+				normalized, err := normalizeEmbeddingSetRecord(record)
+				require.NoError(t, err)
+				require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+					return insertInputGenerationTx(t.Context(), tx, normalized.InputGeneration)
+				}))
+				var metadata bytes.Buffer
+				require.NoError(t, s.ExportMetadata(t.Context(), &metadata))
+				target := newTestStore(t)
+				layout := materializeEmbeddingRestoreArtifacts(t, target, map[string][]byte{
+					catalogSourceHash:                               catalogBlobContents[catalogSourceHash],
+					catalogEvidenceBlobHash:                         catalogBlobContents[catalogEvidenceBlobHash],
+					catalogMarkdownBlobHash:                         catalogBlobContents[catalogMarkdownBlobHash],
+					record.InputGeneration.GenerationBlobHash:       record.InputGeneration.GenerationJSON,
+					testSHA256(record.InputGeneration.EvidenceJSON): record.InputGeneration.EvidenceJSON,
+				})
+				require.NoError(t, target.ImportMetadata(t.Context(), &metadata))
+				backend, err := packstore.NewFilesystemBackend(*layout, packstore.FilesystemBackendOptions{})
+				require.NoError(t, err)
+				defer func() { require.NoError(t, backend.Close()) }()
+				require.ErrorContains(t, target.VerifyRenditionBlobBytes(t.Context(), &embeddingRestoreReader{
+					store: target, backend: backend,
+				}), "source span")
+			}
+		})
 	}
-	mutatedVectors, err := document.NewVectorSetV1(document.VectorSetV1Input{
-		VectorSpaceFingerprint: decodedVectors.VectorSpaceFingerprint,
-		Metric:                 decodedVectors.Metric,
-		Normalization:          decodedVectors.Normalization,
-		Dimension:              decodedVectors.Dimension,
-		InputKeys:              decodedVectors.InputKeys,
-		InputChecksums:         decodedVectors.InputChecksums,
-		Values:                 values,
-	})
-	require.NoError(t, err)
-	encodedVectors, vectorChecksum, err := document.EncodeVectorSetV1(mutatedVectors)
-	require.NoError(t, err)
-	record.VectorSet.Payload = encodedVectors
-	record.VectorSet.ID = vectorChecksum
-	record.VectorSet.PayloadChecksum = vectorChecksum
-	record.VectorSet.PayloadBlobHash = testSHA256(encodedVectors)
-	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
-		if err := s.EnsureBlobTx(tx, record.InputGeneration.GenerationBlobHash, int64(len(encodedGeneration))); err != nil {
-			return err
-		}
-		return s.EnsureBlobTx(tx, record.VectorSet.PayloadBlobHash, int64(len(encodedVectors)))
-	}))
-
-	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "model-input contract")
 }
 
 func TestEmbeddingCatalogRevalidatesExactArtifactsProviderFree(t *testing.T) {
@@ -297,18 +337,20 @@ func TestEmbeddingCatalogProviderFreeRestoreVerifiesLooseAndPackedArtifacts(t *t
 
 			target := newTestStore(t)
 			artifacts := map[string][]byte{
-				catalogSourceHash:                         catalogBlobContents[catalogSourceHash],
-				catalogEvidenceBlobHash:                   catalogBlobContents[catalogEvidenceBlobHash],
-				catalogMarkdownBlobHash:                   catalogBlobContents[catalogMarkdownBlobHash],
-				record.InputGeneration.GenerationBlobHash: record.InputGeneration.GenerationJSON,
-				record.VectorSet.PayloadBlobHash:          record.VectorSet.Payload,
+				catalogSourceHash:                               catalogBlobContents[catalogSourceHash],
+				catalogEvidenceBlobHash:                         catalogBlobContents[catalogEvidenceBlobHash],
+				catalogMarkdownBlobHash:                         catalogBlobContents[catalogMarkdownBlobHash],
+				record.InputGeneration.GenerationBlobHash:       record.InputGeneration.GenerationJSON,
+				testSHA256(record.InputGeneration.EvidenceJSON): record.InputGeneration.EvidenceJSON,
+				record.VectorSet.PayloadBlobHash:                record.VectorSet.Payload,
 			}
 			layout := materializeEmbeddingRestoreArtifacts(t, target, artifacts)
 			require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(metadata.Bytes())))
 			if packed {
 				packEmbeddingRestoreArtifacts(t, target, layout, map[string][]byte{
-					record.InputGeneration.GenerationBlobHash: record.InputGeneration.GenerationJSON,
-					record.VectorSet.PayloadBlobHash:          record.VectorSet.Payload,
+					record.InputGeneration.GenerationBlobHash:       record.InputGeneration.GenerationJSON,
+					testSHA256(record.InputGeneration.EvidenceJSON): record.InputGeneration.EvidenceJSON,
+					record.VectorSet.PayloadBlobHash:                record.VectorSet.Payload,
 				})
 			}
 			require.NoError(t, target.VerifyRenditionBlobAuthority(t.Context()))
@@ -322,11 +364,14 @@ func TestEmbeddingCatalogProviderFreeRestoreVerifiesLooseAndPackedArtifacts(t *t
 	}
 }
 
-func TestEmbeddingCatalogRestoreVerifiesVectorSetRetainedAfterVersionPrune(t *testing.T) {
-	source, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+func TestEmbeddingCatalogRestoreVerifiesArtifactsRetainedAfterVersionPrune(t *testing.T) {
+	source, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
 	record := embeddingSetFixture(source, versionID, profile.Fingerprint,
 		document.EmbeddingInputOriginalFile, "optional", "")
 	require.NoError(t, source.StageEmbeddingSet(t.Context(), record))
+	chunk := embeddingSetFixture(source, versionID, profile.Fingerprint,
+		document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	require.NoError(t, source.StageEmbeddingSet(t.Context(), chunk))
 
 	var nodeID, revision int64
 	require.NoError(t, source.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`,
@@ -347,10 +392,13 @@ func TestEmbeddingCatalogRestoreVerifiesVectorSetRetainedAfterVersionPrune(t *te
 	require.NoError(t, source.ExportMetadata(t.Context(), &metadata))
 	target := newTestStore(t)
 	layout := materializeEmbeddingRestoreArtifacts(t, target, map[string][]byte{
-		catalogSourceHash:                catalogBlobContents[catalogSourceHash],
-		catalogEvidenceBlobHash:          catalogBlobContents[catalogEvidenceBlobHash],
-		catalogMarkdownBlobHash:          catalogBlobContents[catalogMarkdownBlobHash],
-		record.VectorSet.PayloadBlobHash: record.VectorSet.Payload,
+		catalogSourceHash:                              catalogBlobContents[catalogSourceHash],
+		catalogEvidenceBlobHash:                        catalogBlobContents[catalogEvidenceBlobHash],
+		catalogMarkdownBlobHash:                        catalogBlobContents[catalogMarkdownBlobHash],
+		record.VectorSet.PayloadBlobHash:               record.VectorSet.Payload,
+		chunk.VectorSet.PayloadBlobHash:                chunk.VectorSet.Payload,
+		chunk.InputGeneration.GenerationBlobHash:       chunk.InputGeneration.GenerationJSON,
+		testSHA256(chunk.InputGeneration.EvidenceJSON): chunk.InputGeneration.EvidenceJSON,
 	})
 	require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(metadata.Bytes())))
 	require.NoError(t, target.VerifyRenditionBlobAuthority(t.Context()))
@@ -458,6 +506,14 @@ func TestEmbeddingCatalogRequiresCanonicalGenerationAndVectorPayloads(t *testing
 	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
 	record.InputGeneration.GenerationJSON = nil
 	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "generation JSON")
+
+	record = embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	evidenceJSON := record.InputGeneration.EvidenceJSON
+	record.InputGeneration.EvidenceJSON = nil
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "canonical evidence bytes")
+	record.InputGeneration.EvidenceJSON = bytes.Replace(evidenceJSON, []byte("Synthetic evidence"), []byte("Invented evidence!"), 1)
+	require.NotEqual(t, evidenceJSON, record.InputGeneration.EvidenceJSON)
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "evidence hash mismatch")
 
 	record = embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
 	record.VectorSet.Payload = nil

--- a/internal/store/embedding_catalog_authority_test.go
+++ b/internal/store/embedding_catalog_authority_test.go
@@ -575,6 +575,7 @@ func TestEmbeddingCatalogFailureCodesAreClosedProviderNeutralTokens(t *testing.T
 	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
 	for _, code := range []EmbeddingFailureCode{"provider said secret=token", "provider\nmessage", "", "timeout: https://provider.invalid/request/1"} {
 		err := s.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+			FencingToken:     1,
 			ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
 			BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
 			FailureCode: code, FailedAt: embeddingCatalogTime,

--- a/internal/store/embedding_catalog_authority_test.go
+++ b/internal/store/embedding_catalog_authority_test.go
@@ -1,0 +1,396 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/pack"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/document"
+)
+
+// Mutation caught: accepting a store-local input-kind vocabulary lets a caller
+// stage authority that does not name the exact E1 processing-profile binding.
+func TestEmbeddingCatalogUsesCanonicalInputKindsAndProfileAuthority(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	record.BindingID = "not-in-profile"
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "processing profile binding")
+}
+
+func TestEmbeddingCatalogDoesNotPersistGenerationTextInSQLiteOrMetadata(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	require.Contains(t, string(record.InputGeneration.GenerationJSON), "Synthetic evidence")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+
+	var columns string
+	rows, err := s.db.Query(`SELECT name FROM pragma_table_info('embedding_input_generations') ORDER BY cid`)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	var columnsSb34 strings.Builder
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		columnsSb34.WriteString(name + "\n")
+	}
+	require.NoError(t, rows.Err())
+	columns += columnsSb34.String()
+	require.NotContains(t, columns, "generation_json")
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	require.NotContains(t, exported.String(), "Synthetic evidence")
+	require.Contains(t, exported.String(), record.InputGeneration.GenerationBlobHash)
+}
+
+func TestEmbeddingCatalogRejectsOriginalFileAttachmentBypassAndVectorHeaderMismatch(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	original := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	original.InputGeneration.AttachmentID = attachmentID
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), original), "cannot claim rendition attachment")
+
+	chunk := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	decoded, _, err := document.DecodeVectorSetV1(chunk.VectorSet.Payload, document.VectorBounds{MaxRows: 128, MaxDimension: 8, MaxBytes: len(chunk.VectorSet.Payload)})
+	require.NoError(t, err)
+	values := make([][]float64, len(decoded.Vectors))
+	for index, vector := range decoded.Vectors {
+		values[index] = make([]float64, len(vector))
+		for column, scalar := range vector {
+			values[index][column] = float64(scalar)
+		}
+	}
+	wrong, err := document.NewVectorSetV1(document.VectorSetV1Input{
+		VectorSpaceFingerprint: decoded.VectorSpaceFingerprint, Metric: document.VectorMetricDotProduct,
+		Normalization: decoded.Normalization, Dimension: decoded.Dimension,
+		InputKeys: decoded.InputKeys, InputChecksums: decoded.InputChecksums, Values: values,
+	})
+	require.NoError(t, err)
+	payload, checksum, err := document.EncodeVectorSetV1(wrong)
+	require.NoError(t, err)
+	chunk.VectorSet.Payload = payload
+	chunk.VectorSet.ID, chunk.VectorSet.PayloadChecksum, chunk.VectorSet.PayloadBlobHash = checksum, checksum, testSHA256(payload)
+	require.NoError(t, s.withStorageTx(context.Background(), func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, chunk.VectorSet.PayloadBlobHash, int64(len(payload)))
+	}))
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), chunk), "metric or normalization")
+}
+
+func TestEmbeddingCatalogRejectsGenerationBlobIdentityMismatch(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	record.InputGeneration.GenerationBlobHash = fakeHash("wrong generation blob")
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "blob hash")
+}
+
+func TestEmbeddingCatalogRejectsGenerationFromDifferentChunkPolicy(t *testing.T) {
+	s, versionID, profileRecord, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profileRecord.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	var profile document.ProcessingProfileV1
+	require.NoError(t, json.Unmarshal(profileRecord.CanonicalProfile, &profile))
+	_, fingerprints, err := document.CanonicalProfile(profile)
+	require.NoError(t, err)
+	var binding document.EmbeddingBindingV1
+	for _, candidate := range profile.Embeddings {
+		if candidate.Name == "chunk" {
+			binding = candidate
+		}
+	}
+	changedBinding := binding
+	changedChunk := *binding.Chunk
+	changedChunk.OverlapTokens = 1
+	changedBinding.Chunk = &changedChunk
+	contextSnapshot, err := document.NewAttachmentContextSnapshot("Synthetic title", "Synthetic context")
+	require.NoError(t, err)
+	policy, err := document.NewInputPolicy(changedBinding, embeddingCatalogTokenizer{}, fingerprints.EvidenceLexical, &contextSnapshot)
+	require.NoError(t, err)
+	generation, err := document.BuildEmbeddingInputs(embeddingCatalogEvidence(t), policy, document.GenerationLimits{
+		MaxInputs: 128, MaxTotalContentTokens: 4096, MaxTotalRenderedTokens: 8192,
+		MaxTotalContentBytes: 1 << 20, MaxTotalRenderedBytes: 2 << 20,
+		MaxFittingWorkTokens: 1 << 20, MaxFittingWorkBytes: 8 << 20,
+	})
+	require.NoError(t, err)
+	encoded, err := document.MarshalEmbeddingInputGeneration(generation)
+	require.NoError(t, err)
+	record.InputGeneration.GenerationJSON = encoded
+	record.InputGeneration.GenerationBlobHash = testSHA256(encoded)
+	record.InputGeneration.GenerationEncodedSize = int64(len(encoded))
+	record.InputGeneration.GenerationChecksum = generation.Checksum
+	record.InputGeneration.ID = testSHA256([]byte("embedding-generation-attachment/v1\x00" + generation.Checksum + "\x00" + attachmentID))
+	require.NoError(t, s.withStorageTx(context.Background(), func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, record.InputGeneration.GenerationBlobHash, int64(len(encoded)))
+	}))
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "exact processing profile")
+}
+
+func TestEmbeddingCatalogRevalidatesExactArtifactsProviderFree(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	generationBytes := append([]byte(nil), record.InputGeneration.GenerationJSON...)
+	vectorBytes := append([]byte(nil), record.VectorSet.Payload...)
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		stored, err := loadEmbeddingSetTx(t.Context(), tx, record.ID)
+		require.NoError(t, err)
+		require.NoError(t, validateExactEmbeddingGenerationArtifact(stored.InputGeneration, generationBytes))
+		require.NoError(t, validateExactEmbeddingVectorArtifact(stored.VectorSet, stored.VectorSpace, stored.InputGeneration, vectorBytes))
+		corruptGeneration := append([]byte(nil), generationBytes...)
+		corruptGeneration[len(corruptGeneration)/2] ^= 1
+		require.Error(t, validateExactEmbeddingGenerationArtifact(stored.InputGeneration, corruptGeneration))
+		corruptVector := append([]byte(nil), vectorBytes...)
+		corruptVector[len(corruptVector)-1] ^= 1
+		require.Error(t, validateExactEmbeddingVectorArtifact(stored.VectorSet, stored.VectorSpace, stored.InputGeneration, corruptVector))
+		return nil
+	}))
+}
+
+func TestEmbeddingCatalogMetadataRejectsDivergentE1Projection(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	mutated := strings.Replace(exported.String(),
+		`"provider_revision":"2026-08-25"`, `"provider_revision":"forged-revision"`, 1)
+	require.NotEqual(t, exported.String(), mutated)
+	target := newTestStore(t)
+	require.ErrorContains(t, target.ImportMetadata(t.Context(), strings.NewReader(mutated)), "projection")
+}
+
+func TestEmbeddingCatalogReadsPackedArtifactAuthority(t *testing.T) {
+	s := newTestStore(t)
+	data := []byte("synthetic packed embedding authority")
+	hash, err := packstore.ParseHash(testSHA256(data))
+	require.NoError(t, err)
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, hash.String(), int64(len(data)))
+	}))
+	layout, err := packstore.NewLayout(filepath.Join(filepath.Dir(s.path), "blobs"),
+		packstore.LayoutOptions{Staging: packstore.StagingStoreDirectory, StagingDir: "tmp"})
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(layout.PacksDir(), 0o700))
+	writer, err := pack.NewWriter(layout.PacksDir(), pack.WriterOptions{})
+	require.NoError(t, err)
+	entry, err := writer.Append(data)
+	require.NoError(t, err)
+	packID := writer.ID()
+	require.NoError(t, os.MkdirAll(filepath.Dir(layout.PackPath(packID)), 0o700))
+	entries, err := writer.Seal(layout.PackPath(packID))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	index := packstore.IndexEntry{
+		Hash: hash, PackID: packID, Offset: int64(entry.Offset), StoredLen: int64(entry.StoredLen),
+		RawLen: int64(entry.RawLen), Flags: uint8(entry.Flags), CRC32C: entry.CRC32C,
+	}
+	require.NoError(t, NewPackCatalog(s).RecordPack(t.Context(), packstore.PackRecord{
+		PackID: packID, EntryCount: 1, StoredBytes: int64(entry.StoredLen), CreatedAt: time.Now().UTC(),
+	}, []packstore.Adoption{{Entry: index, OriginalHashes: []string{hash.String()}}}))
+	backend, err := packstore.NewFilesystemBackend(layout, packstore.FilesystemBackendOptions{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, backend.Close()) }()
+	resolution, err := s.ResolveBlobLocations(t.Context(), hash)
+	require.NoError(t, err)
+	require.Len(t, resolution.Candidates, 1)
+	require.NotNil(t, resolution.Candidates[0].Pack)
+	stream, logicalSize, err := backend.OpenPack(t.Context(), hash, *resolution.Candidates[0].Pack)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, stream.Close()) }()
+	require.Equal(t, int64(len(data)), logicalSize)
+	read, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.NoError(t, stream.Verify())
+	require.Equal(t, data, read)
+}
+
+func TestEmbeddingCatalogProviderFreeRestoreVerifiesLooseAndPackedArtifacts(t *testing.T) {
+	for _, packed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "loose", true: "packed"}[packed], func(t *testing.T) {
+			source, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(source, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+			require.NoError(t, source.StageEmbeddingSet(t.Context(), record))
+			var metadata bytes.Buffer
+			require.NoError(t, source.ExportMetadata(t.Context(), &metadata))
+
+			target := newTestStore(t)
+			artifacts := map[string][]byte{
+				catalogSourceHash:                         catalogBlobContents[catalogSourceHash],
+				catalogEvidenceBlobHash:                   catalogBlobContents[catalogEvidenceBlobHash],
+				catalogMarkdownBlobHash:                   catalogBlobContents[catalogMarkdownBlobHash],
+				record.InputGeneration.GenerationBlobHash: record.InputGeneration.GenerationJSON,
+				record.VectorSet.PayloadBlobHash:          record.VectorSet.Payload,
+			}
+			layout := materializeEmbeddingRestoreArtifacts(t, target, artifacts)
+			require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(metadata.Bytes())))
+			if packed {
+				packEmbeddingRestoreArtifacts(t, target, layout, map[string][]byte{
+					record.InputGeneration.GenerationBlobHash: record.InputGeneration.GenerationJSON,
+					record.VectorSet.PayloadBlobHash:          record.VectorSet.Payload,
+				})
+			}
+			require.NoError(t, target.VerifyRenditionBlobAuthority(t.Context()))
+			backend, err := packstore.NewFilesystemBackend(*layout, packstore.FilesystemBackendOptions{})
+			require.NoError(t, err)
+			defer func() { require.NoError(t, backend.Close()) }()
+			require.NoError(t, target.VerifyRenditionBlobBytes(t.Context(), &embeddingRestoreReader{
+				store: target, backend: backend,
+			}))
+		})
+	}
+}
+
+type embeddingRestoreReader struct {
+	store   *Store
+	backend *packstore.FilesystemBackend
+}
+
+func (r *embeddingRestoreReader) OpenStreamContext(
+	ctx context.Context, rawHash string,
+) (packstore.VerifiedReadCloser, int64, error) {
+	hash, err := packstore.ParseHash(rawHash)
+	if err != nil {
+		return nil, 0, fmt.Errorf("parse embedding artifact hash: %w", err)
+	}
+	resolution, err := r.store.ResolveBlobLocations(ctx, hash)
+	if err != nil {
+		return nil, 0, err
+	}
+	for _, location := range resolution.Candidates {
+		if location.Loose != nil {
+			stream, size, err := r.backend.OpenLoose(ctx, hash, *location.Loose)
+			if err != nil {
+				return nil, 0, fmt.Errorf("open loose embedding artifact: %w", err)
+			}
+			return stream, size, nil
+		}
+		if location.Pack != nil {
+			stream, size, err := r.backend.OpenPack(ctx, hash, *location.Pack)
+			if err != nil {
+				return nil, 0, fmt.Errorf("open packed embedding artifact: %w", err)
+			}
+			return stream, size, nil
+		}
+	}
+	return nil, 0, errors.New("no catalog-authorized embedding artifact location")
+}
+
+func materializeEmbeddingRestoreArtifacts(t *testing.T, s *Store, artifacts map[string][]byte) *packstore.Layout {
+	t.Helper()
+	layout, err := packstore.NewLayout(filepath.Join(filepath.Dir(s.path), "blobs"),
+		packstore.LayoutOptions{Staging: packstore.StagingStoreDirectory, StagingDir: "tmp"})
+	require.NoError(t, err)
+	for rawHash, data := range artifacts {
+		hash, err := packstore.ParseHash(rawHash)
+		require.NoError(t, err)
+		path := layout.LoosePath(hash)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, data, 0o600))
+	}
+	return &layout
+}
+
+func packEmbeddingRestoreArtifacts(t *testing.T, s *Store, layout *packstore.Layout, artifacts map[string][]byte) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(layout.PacksDir(), 0o700))
+	writer, err := pack.NewWriter(layout.PacksDir(), pack.WriterOptions{})
+	require.NoError(t, err)
+	adoptions := make([]packstore.Adoption, 0, len(artifacts))
+	for rawHash, data := range artifacts {
+		hash, err := packstore.ParseHash(rawHash)
+		require.NoError(t, err)
+		entry, err := writer.Append(data)
+		require.NoError(t, err)
+		adoptions = append(adoptions, packstore.Adoption{Entry: packstore.IndexEntry{
+			Hash: hash, PackID: writer.ID(), Offset: int64(entry.Offset), StoredLen: int64(entry.StoredLen),
+			RawLen: int64(entry.RawLen), Flags: uint8(entry.Flags), CRC32C: entry.CRC32C,
+		}, OriginalHashes: []string{rawHash}})
+	}
+	packID := writer.ID()
+	require.NoError(t, os.MkdirAll(filepath.Dir(layout.PackPath(packID)), 0o700))
+	entries, err := writer.Seal(layout.PackPath(packID))
+	require.NoError(t, err)
+	require.Len(t, entries, len(artifacts))
+	var storedBytes int64
+	for _, adoption := range adoptions {
+		storedBytes += adoption.Entry.StoredLen
+	}
+	require.NoError(t, NewPackCatalog(s).RecordPack(t.Context(), packstore.PackRecord{
+		PackID: packID, EntryCount: int64(len(adoptions)), StoredBytes: storedBytes, CreatedAt: time.Now().UTC(),
+	}, adoptions))
+	for rawHash := range artifacts {
+		hash, err := packstore.ParseHash(rawHash)
+		require.NoError(t, err)
+		require.NoError(t, os.Remove(layout.LoosePath(hash)))
+		resolution, err := s.ResolveBlobLocations(t.Context(), hash)
+		require.NoError(t, err)
+		require.NotEmpty(t, resolution.Candidates)
+		require.NotNil(t, resolution.Candidates[0].Pack)
+	}
+}
+
+// Mutation caught: trusting caller-authored input rows instead of decoding the
+// exact E2 artifact loses headings, spans, truncation and attachment context.
+func TestEmbeddingCatalogRequiresCanonicalGenerationAndVectorPayloads(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	record.InputGeneration.GenerationJSON = nil
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "generation JSON")
+
+	record = embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	record.VectorSet.Payload = nil
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "vector payload")
+}
+
+func TestEmbeddingCatalogRejectsRotatedE1AndReorderedVectorAuthority(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+
+	rotated := cloneEmbeddingSetRecord(record)
+	rotated.VectorSpace.Descriptor.ModelRevision = "rotated"
+	rotated.VectorSpace.Descriptor.Fingerprint = ""
+	descriptor, err := document.NewEmbeddingDescriptor(rotated.VectorSpace.Descriptor)
+	require.NoError(t, err)
+	rotated.VectorSpace.Descriptor = descriptor
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), rotated), "processing profile embedding binding")
+
+	reordered := cloneEmbeddingSetRecord(record)
+	decoded, _, err := document.DecodeVectorSetV1(reordered.VectorSet.Payload, document.VectorBounds{MaxRows: 128, MaxDimension: 8, MaxBytes: len(reordered.VectorSet.Payload)})
+	require.NoError(t, err)
+	require.Len(t, decoded.InputKeys, 2)
+	decoded.InputKeys[0], decoded.InputKeys[1] = decoded.InputKeys[1], decoded.InputKeys[0]
+	decoded.InputChecksums[0], decoded.InputChecksums[1] = decoded.InputChecksums[1], decoded.InputChecksums[0]
+	decoded.Vectors[0], decoded.Vectors[1] = decoded.Vectors[1], decoded.Vectors[0]
+	payload, checksum, err := document.EncodeVectorSetV1(decoded)
+	require.NoError(t, err)
+	reordered.VectorSet.Payload = payload
+	reordered.VectorSet.PayloadBlobHash = testSHA256(payload)
+	reordered.VectorSet.PayloadChecksum = checksum
+	reordered.VectorSet.ID = checksum
+	require.NoError(t, s.withStorageTx(context.Background(), func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, reordered.VectorSet.PayloadBlobHash, int64(len(payload)))
+	}))
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), reordered), "ordered generation inputs")
+}
+
+func TestEmbeddingCatalogFailureCodesAreClosedProviderNeutralTokens(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	for _, code := range []EmbeddingFailureCode{"provider said secret=token", "provider\nmessage", "", "timeout: https://provider.invalid/request/1"} {
+		err := s.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+			ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+			BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
+			FailureCode: code, FailedAt: embeddingCatalogTime,
+		})
+		require.ErrorContains(t, err, "provider-neutral vocabulary")
+	}
+}

--- a/internal/store/embedding_catalog_integrity_test.go
+++ b/internal/store/embedding_catalog_integrity_test.go
@@ -51,6 +51,33 @@ func TestEmbeddingCatalogPurgeUsesSingleRootExpiryBoundary(t *testing.T) {
 	require.NoError(t, s.ValidateMetadata(t.Context()))
 }
 
+func TestEmbeddingCatalogRejectsJobRootsBeforePersistence(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	for kind, target := range map[CurrentRenditionTargetKind]string{
+		RenditionRootEmbeddingSet:        record.ID,
+		RenditionRootEmbeddingGeneration: record.InputGeneration.ID,
+		RenditionRootEmbeddingVectorSet:  record.VectorSet.ID,
+		RenditionRootEmbeddingPayload:    record.VectorSet.PayloadBlobHash,
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			root := CurrentRenditionRoot{
+				ID: "unsupported-job-" + string(kind), Kind: RenditionRootJob,
+				TargetKind: kind, TargetID: target, FencingToken: 1, RecordedAt: embeddingCatalogTime,
+			}
+			require.ErrorContains(t, s.PutCurrentRenditionRoot(t.Context(), root), "job root target")
+			var count int
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM current_rendition_roots WHERE root_id=?`, root.ID).Scan(&count))
+			assert.Zero(t, count)
+			require.NoError(t, s.ValidateMetadata(t.Context()))
+			var exported bytes.Buffer
+			require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+		})
+	}
+}
+
 func TestEmbeddingCatalogExplicitPurgePreservesEveryActiveRoot(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/internal/store/embedding_catalog_integrity_test.go
+++ b/internal/store/embedding_catalog_integrity_test.go
@@ -202,6 +202,7 @@ func TestEmbeddingCatalogExplicitChunkPurgeRetainsRootAttachmentChain(t *testing
 			for _, record := range []EmbeddingSetRecord{chunk, direct} {
 				require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
 				require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+					FencingToken: 1,
 					Key: EmbeddingHeadKey{
 						ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind,
 					},
@@ -425,8 +426,9 @@ func TestEmbeddingCatalogLiveWritesRequireCanonicalTimestamps(t *testing.T) {
 		record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
 		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
 		head := EmbeddingHeadRecord{
-			Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
-			SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+			FencingToken: 1,
+			Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+			SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
 			ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: "2026-08-25T10:00:00.000000000+00:00",
 		}
 		require.ErrorContains(t, s.PublishEmbeddingHead(t.Context(), head), "embedding head published_at")
@@ -452,8 +454,9 @@ func TestEmbeddingCatalogMetadataImportRequiresCanonicalTimestamps(t *testing.T)
 	record := embeddingSetFixture(source, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
 	require.NoError(t, source.StageEmbeddingSet(t.Context(), record))
 	require.NoError(t, source.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
-		SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+		SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 	require.NoError(t, source.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{

--- a/internal/store/embedding_catalog_integrity_test.go
+++ b/internal/store/embedding_catalog_integrity_test.go
@@ -439,6 +439,7 @@ func TestEmbeddingCatalogLiveWritesRequireCanonicalTimestamps(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
 		failure := EmbeddingFailureRecord{
+			FencingToken:     1,
 			ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
 			BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
 			FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: "not-a-time",
@@ -460,6 +461,7 @@ func TestEmbeddingCatalogMetadataImportRequiresCanonicalTimestamps(t *testing.T)
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 	require.NoError(t, source.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+		FencingToken:     1,
 		ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
 		BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
 		FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,

--- a/internal/store/embedding_catalog_integrity_test.go
+++ b/internal/store/embedding_catalog_integrity_test.go
@@ -31,10 +31,9 @@ func TestEmbeddingCatalogPurgeUsesSingleRootExpiryBoundary(t *testing.T) {
 	require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
 
 	report := PurgeReport{}
-	var suppressions []derivativePurgeSuppression
 	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
 		_, err := purgeEmbeddingCatalogTx(t.Context(), tx, stringSet([]string{versionID}), nil, nil,
-			false, asOf, &report, make(map[string]struct{}), &suppressions)
+			false, asOf, &report, make(map[string]struct{}))
 		return err
 	}))
 

--- a/internal/store/embedding_catalog_integrity_test.go
+++ b/internal/store/embedding_catalog_integrity_test.go
@@ -31,9 +31,10 @@ func TestEmbeddingCatalogPurgeUsesSingleRootExpiryBoundary(t *testing.T) {
 	require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
 
 	report := PurgeReport{}
+	var suppressions []derivativePurgeSuppression
 	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
 		_, err := purgeEmbeddingCatalogTx(t.Context(), tx, stringSet([]string{versionID}), nil, nil,
-			false, asOf, &report, make(map[string]struct{}))
+			false, asOf, &report, make(map[string]struct{}), &suppressions)
 		return err
 	}))
 

--- a/internal/store/embedding_catalog_integrity_test.go
+++ b/internal/store/embedding_catalog_integrity_test.go
@@ -1,0 +1,438 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/json/jsontext"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	docsqlite "go.kenn.io/docbank/sqlite"
+)
+
+func TestEmbeddingCatalogExplicitPurgePreservesEveryActiveRoot(t *testing.T) {
+	testCases := []struct {
+		name       string
+		kind       CurrentRenditionRootKind
+		targetKind CurrentRenditionTargetKind
+		target     func(EmbeddingSetRecord) string
+		lease      bool
+	}{
+		{"reader lease set", RenditionRootReaderLease, RenditionRootEmbeddingSet, func(value EmbeddingSetRecord) string { return value.ID }, true},
+		{"worker lease generation", RenditionRootWorkerLease, RenditionRootEmbeddingGeneration, func(value EmbeddingSetRecord) string { return value.InputGeneration.ID }, true},
+		{"backup set", RenditionRootBackupPin, RenditionRootEmbeddingSet, func(value EmbeddingSetRecord) string { return value.ID }, false},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+			require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+			var nodeID, revision int64
+			require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, versionID).Scan(&nodeID, &revision))
+			root := CurrentRenditionRoot{
+				ID: "explicit-purge-" + strings.ReplaceAll(testCase.name, " ", "-"), Kind: testCase.kind,
+				TargetKind: testCase.targetKind, TargetID: testCase.target(record), FencingToken: 1,
+				RecordedAt: embeddingCatalogTime,
+			}
+			if testCase.lease {
+				root.ExpiresAt = "2099-08-25T10:00:00.000000000Z"
+			}
+			require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+
+			report, err := s.PurgeDerivatives(t.Context(), PurgeRequest{ContentVersionIDs: []string{versionID}})
+			require.NoError(t, err)
+			assert.Zero(t, report.RemovedEmbeddingSets)
+			assert.Zero(t, report.RemovedEmbeddingInputGenerations)
+			assert.Zero(t, report.RemovedEmbeddingVectorSets)
+			assert.True(t, report.ImmutableBackupCopiesUntouched)
+			var authorities, activeRoots int
+			require.NoError(t, s.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM embedding_sets WHERE embedding_set_id=?) +
+				(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?) +
+				(SELECT COUNT(*) FROM embedding_vector_sets WHERE vector_set_id=?) +
+				(SELECT COUNT(*) FROM embedding_vector_spaces WHERE vector_space_id=?),
+				(SELECT COUNT(*) FROM current_rendition_roots WHERE root_id=? AND active=1)`,
+				record.ID, record.InputGeneration.ID, record.VectorSet.ID, record.VectorSpace.ID, root.ID,
+			).Scan(&authorities, &activeRoots))
+			assert.Equal(t, 4, authorities)
+			assert.Equal(t, 1, activeRoots)
+			require.NoError(t, s.ValidateMetadata(t.Context()))
+			var exported bytes.Buffer
+			require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+
+			_, _, err = s.Trash(t.Context(), nodeID, revision)
+			require.NoError(t, err)
+			plan, err := s.DerivativeGCPlan(t.Context())
+			require.NoError(t, err)
+			assert.Empty(t, plan.EmbeddingSets, "an active root must retain the complete selected set")
+
+			// Releasing a reader, worker, policy, restore, or backup root is a separate
+			// authority transition from live-vault purge.
+			released, err := s.ReleaseCurrentRenditionRoot(t.Context(), root.ID, root.FencingToken)
+			require.NoError(t, err)
+			assert.True(t, released)
+			plan, err = s.DerivativeGCPlan(t.Context())
+			require.NoError(t, err)
+			require.Len(t, plan.EmbeddingSets, 1)
+			assert.Equal(t, record.ID, plan.EmbeddingSets[0].SetID)
+			report, err = s.PurgeDerivatives(t.Context(), PurgeRequest{})
+			require.NoError(t, err)
+			assert.Equal(t, 1, report.RemovedEmbeddingSets)
+			require.NoError(t, s.ValidateMetadata(t.Context()))
+		})
+	}
+}
+
+func TestEmbeddingCatalogExplicitChunkPurgeRetainsRootAttachmentChain(t *testing.T) {
+	testCases := []struct {
+		name          string
+		kind          CurrentRenditionRootKind
+		targetKind    CurrentRenditionTargetKind
+		target        func(EmbeddingSetRecord) string
+		request       func(string, string, string) PurgeRequest
+		expires       bool
+		removesDirect bool
+	}{
+		{
+			name: "content version", kind: RenditionRootReaderLease,
+			targetKind: RenditionRootEmbeddingSet, target: func(value EmbeddingSetRecord) string { return value.ID },
+			request: func(versionID, _, _ string) PurgeRequest {
+				return PurgeRequest{ContentVersionIDs: []string{versionID}}
+			},
+			expires: true, removesDirect: true,
+		},
+		{
+			name: "attachment", kind: RenditionRootWorkerLease,
+			targetKind: RenditionRootEmbeddingGeneration, target: func(value EmbeddingSetRecord) string { return value.InputGeneration.ID },
+			request: func(_, attachmentID, _ string) PurgeRequest {
+				return PurgeRequest{AttachmentIDs: []string{attachmentID}}
+			},
+			expires: true,
+		},
+		{
+			name: "build", kind: RenditionRootRetention,
+			targetKind: RenditionRootEmbeddingVectorSet, target: func(value EmbeddingSetRecord) string { return value.VectorSet.ID },
+			request: func(_, _, buildID string) PurgeRequest {
+				return PurgeRequest{BuildIDs: []string{buildID}}
+			},
+		},
+		{
+			name: "all", kind: RenditionRootBackupPin,
+			targetKind: RenditionRootEmbeddingPayload, target: func(value EmbeddingSetRecord) string { return value.VectorSet.PayloadBlobHash },
+			request:       func(_, _, _ string) PurgeRequest { return PurgeRequest{All: true} },
+			removesDirect: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+			var buildID string
+			require.NoError(t, s.db.QueryRow(`SELECT build_id FROM rendition_attachments WHERE attachment_id=?`, attachmentID).Scan(&buildID))
+
+			chunk := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+			direct := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+			for _, record := range []EmbeddingSetRecord{chunk, direct} {
+				require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+				require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+					Key: EmbeddingHeadKey{
+						ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind,
+					},
+					SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+					ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+				}))
+			}
+			root := CurrentRenditionRoot{
+				ID: "rooted-chunk-" + strings.ReplaceAll(testCase.name, " ", "-"), Kind: testCase.kind,
+				TargetKind: testCase.targetKind, TargetID: testCase.target(chunk), FencingToken: 1,
+				RecordedAt: embeddingCatalogTime,
+			}
+			if testCase.expires {
+				root.ExpiresAt = "2099-08-25T10:00:00.000000000Z"
+			}
+			require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+			request := testCase.request(versionID, attachmentID, buildID)
+
+			report, err := s.PurgeDerivatives(t.Context(), request)
+			require.NoError(t, err, "a rooted chunk generation must not roll back explicit purge")
+			assert.Equal(t, 1, report.RemovedHeads)
+			assert.Zero(t, report.RemovedAttachments)
+			assert.Zero(t, report.RemovedBuilds)
+			assert.Equal(t, []string{buildID}, report.RetainedBuildIDs)
+			removedEmbeddingHeads := 1
+			if testCase.removesDirect {
+				removedEmbeddingHeads++
+				assert.Equal(t, 1, report.RemovedEmbeddingSets,
+					"root retention must not weaken explicit purge for an unrelated selected set")
+			} else {
+				assert.Zero(t, report.RemovedEmbeddingSets,
+					"attachment/build selectors must not expand to a direct-file set")
+			}
+			assert.Equal(t, removedEmbeddingHeads, report.RemovedEmbeddingHeads)
+			assert.True(t, report.ImmutableBackupCopiesUntouched)
+
+			_, err = s.ActiveRendition(t.Context(), versionID, profile.Fingerprint)
+			require.ErrorIs(t, err, ErrNotFound)
+			var chunkHeads int
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_heads
+				WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?`,
+				versionID, profile.Fingerprint, chunk.BindingID, chunk.InputKind).Scan(&chunkHeads))
+			assert.Zero(t, chunkHeads)
+			var retained, directSets, directHeads int
+			require.NoError(t, s.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM rendition_attachments WHERE attachment_id=?) +
+				(SELECT COUNT(*) FROM rendition_builds WHERE build_id=?) +
+				(SELECT COUNT(*) FROM embedding_sets WHERE embedding_set_id=?) +
+				(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?) +
+				(SELECT COUNT(*) FROM embedding_vector_sets WHERE vector_set_id=?) +
+				(SELECT COUNT(*) FROM current_rendition_roots WHERE root_id=? AND active=1),
+				(SELECT COUNT(*) FROM embedding_sets WHERE embedding_set_id=?),
+				(SELECT COUNT(*) FROM embedding_heads WHERE embedding_set_id=?)`,
+				attachmentID, buildID, chunk.ID, chunk.InputGeneration.ID, chunk.VectorSet.ID, root.ID,
+				direct.ID, direct.ID,
+			).Scan(&retained, &directSets, &directHeads))
+			assert.Equal(t, 6, retained,
+				"the rooted chunk set and its required attachment/build chain must remain complete")
+			if testCase.removesDirect {
+				assert.Equal(t, []int{0, 0}, []int{directSets, directHeads})
+			} else {
+				assert.Equal(t, []int{1, 1}, []int{directSets, directHeads})
+			}
+			require.NoError(t, s.ValidateMetadata(t.Context()))
+			var exported bytes.Buffer
+			require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+
+			if testCase.expires {
+				root.FencingToken++
+				root.RecordedAt = "2026-08-26T10:00:00.000000000Z"
+				root.ExpiresAt = "2020-08-25T10:00:00.000000000Z"
+				require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+			} else {
+				released, err := s.ReleaseCurrentRenditionRoot(t.Context(), root.ID, root.FencingToken)
+				require.NoError(t, err)
+				assert.True(t, released)
+			}
+			plan, err := s.DerivativeGCPlan(t.Context())
+			require.NoError(t, err)
+			require.Len(t, plan.EmbeddingSets, 1)
+			assert.Equal(t, chunk.ID, plan.EmbeddingSets[0].SetID)
+			if testCase.expires {
+				assert.Contains(t, plan.ExpiredRootIDs, root.ID)
+			}
+
+			report, err = s.PurgeDerivatives(t.Context(), request)
+			require.NoError(t, err)
+			assert.Equal(t, 1, report.RemovedAttachments)
+			assert.Equal(t, 1, report.RemovedBuilds)
+			assert.Equal(t, 1, report.RemovedEmbeddingSets)
+			assert.Equal(t, 1, report.RemovedEmbeddingInputGenerations)
+			assert.Equal(t, 1, report.RemovedEmbeddingVectorSets)
+			if testCase.expires {
+				assert.Equal(t, 1, report.ExpiredRootsRemoved)
+			}
+			var remaining int
+			require.NoError(t, s.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM rendition_attachments WHERE attachment_id=?) +
+				(SELECT COUNT(*) FROM rendition_builds WHERE build_id=?) +
+				(SELECT COUNT(*) FROM embedding_sets WHERE embedding_set_id=?) +
+				(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?) +
+				(SELECT COUNT(*) FROM embedding_vector_sets WHERE vector_set_id=?)`,
+				attachmentID, buildID, chunk.ID, chunk.InputGeneration.ID, chunk.VectorSet.ID,
+			).Scan(&remaining))
+			assert.Zero(t, remaining)
+			require.NoError(t, s.ValidateMetadata(t.Context()))
+			exported.Reset()
+			require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+		})
+	}
+}
+
+func TestEmbeddingCatalogCurrentSchemaMissingTableFailsClosedBeforeBootstrap(t *testing.T) {
+	tables := []string{
+		"embedding_vector_spaces", "embedding_input_generations", "embedding_generation_inputs",
+		"embedding_vector_sets", "embedding_vector_rows", "embedding_sets", "embedding_heads",
+		"embedding_failures",
+	}
+	for _, driverCase := range v090UpgradeDrivers() {
+		for _, table := range tables {
+			t.Run(driverCase.name+"/"+table, func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "catalog.db")
+				s, err := Open(path, driverCase.driver)
+				require.NoError(t, err)
+				require.NoError(t, s.Close())
+				db, err := driverCase.driver.Open(path, docsqlite.OpenOptions{
+					Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+				})
+				require.NoError(t, err)
+				_, err = db.Exec(`DROP TABLE ` + table)
+				require.NoError(t, err)
+				require.NoError(t, db.Close())
+
+				reopened, openErr := Open(path, driverCase.driver)
+				if reopened != nil {
+					require.NoError(t, reopened.Close())
+				}
+				require.ErrorContains(t, openErr, "embedding catalog schema")
+
+				db, err = driverCase.driver.Open(path, docsqlite.OpenOptions{
+					Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+				})
+				require.NoError(t, err)
+				columns, err := tableColumns(db, table)
+				require.NoError(t, err)
+				assert.Empty(t, columns, "failed open must not recreate missing current-schema authority")
+				require.NoError(t, db.Close())
+			})
+		}
+	}
+}
+
+func TestEmbeddingCatalogRestoreRejectsNoncanonicalDescriptorBytes(t *testing.T) {
+	source, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(source, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, source.StageEmbeddingSet(t.Context(), record))
+	var metadata bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &metadata))
+
+	const privateMaterial = "synthetic-private-token"
+	canonicalPrefix := fmt.Sprintf(`{"id":%q,"contract_version":1,`, record.VectorSpace.Descriptor.ID)
+	reorderedPrefix := fmt.Sprintf(`{"contract_version":1,"id":%q,`, record.VectorSpace.Descriptor.ID)
+	for _, testCase := range []struct {
+		name   string
+		mutate func([]byte) []byte
+	}{
+		{"unknown private field", func(value []byte) []byte {
+			return bytes.Replace(value, []byte(`{"id":`), []byte(`{"private_material":"`+privateMaterial+`","id":`), 1)
+		}},
+		{"noncanonical field order", func(value []byte) []byte {
+			return bytes.Replace(value, []byte(canonicalPrefix), []byte(reorderedPrefix), 1)
+		}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			mutated := mutateFirstProcessingMetadataRecord(
+				t, metadata.Bytes(), metadataEmbeddingVectorSpaceType,
+				func(fields map[string]jsontext.Value) {
+					var descriptor []byte
+					require.NoError(t, json.Unmarshal(fields["descriptor_json"], &descriptor))
+					changed := testCase.mutate(descriptor)
+					require.NotEqual(t, descriptor, changed)
+					var err error
+					fields["descriptor_json"], err = json.Marshal(changed)
+					require.NoError(t, err)
+				},
+			)
+			target := newTestStore(t)
+			err := target.ImportMetadata(t.Context(), bytes.NewReader(mutated))
+			require.ErrorContains(t, err, "descriptor")
+			assert.NotContains(t, err.Error(), privateMaterial)
+			var spaces int
+			require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM embedding_vector_spaces`).Scan(&spaces))
+			assert.Zero(t, spaces)
+		})
+	}
+}
+
+func TestEmbeddingCatalogLiveWritesRequireCanonicalTimestamps(t *testing.T) {
+	const secretLikeTimestamp = "token=synthetic-private-value"
+
+	t.Run("set", func(t *testing.T) {
+		s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+		record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+		record.CreatedAt = secretLikeTimestamp
+		require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "embedding set created_at")
+		record.CreatedAt = embeddingCatalogTime
+		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	})
+
+	t.Run("generation", func(t *testing.T) {
+		s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+		record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+		record.InputGeneration.CreatedAt = "2026-08-25T10:00:00Z"
+		require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "input-generation created_at")
+		record.InputGeneration.CreatedAt = embeddingCatalogTime
+		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	})
+
+	t.Run("head", func(t *testing.T) {
+		s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+		record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+		head := EmbeddingHeadRecord{
+			Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+			SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+			ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: "2026-08-25T10:00:00.000000000+00:00",
+		}
+		require.ErrorContains(t, s.PublishEmbeddingHead(t.Context(), head), "embedding head published_at")
+		head.PublishedAt = embeddingCatalogTime
+		require.NoError(t, s.PublishEmbeddingHead(t.Context(), head))
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+		failure := EmbeddingFailureRecord{
+			ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+			BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
+			FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: "not-a-time",
+		}
+		require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), failure), "embedding failure failed_at")
+		failure.FailedAt = embeddingCatalogTime
+		require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure))
+	})
+}
+
+func TestEmbeddingCatalogMetadataImportRequiresCanonicalTimestamps(t *testing.T) {
+	source, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(source, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, source.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, source.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+		SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+	require.NoError(t, source.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+		ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+		BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
+		FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
+	}))
+	var metadata bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &metadata))
+
+	for _, testCase := range []struct {
+		name, kind, field, value, want string
+	}{
+		{"generation", metadataEmbeddingGenerationType, "created_at", "token=synthetic-private-value", "input-generation created_at"},
+		{"set", metadataEmbeddingSetType, "created_at", "not-a-time", "embedding set created_at"},
+		{"head", metadataEmbeddingHeadType, "published_at", "2026-08-25T10:00:00Z", "embedding head published_at"},
+		{"failure", metadataEmbeddingFailureType, "failed_at", "2026-08-25T10:00:00.000000000+00:00", "embedding failure failed_at"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			mutated := mutateFirstProcessingMetadataRecord(
+				t, metadata.Bytes(), testCase.kind,
+				func(fields map[string]jsontext.Value) {
+					fields[testCase.field] = jsonStringForTest(t, testCase.value)
+				},
+			)
+			target := newTestStore(t)
+			err := target.ImportMetadata(t.Context(), bytes.NewReader(mutated))
+			require.ErrorContains(t, err, testCase.want)
+			var rows int
+			require.NoError(t, target.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM embedding_sets) +
+				(SELECT COUNT(*) FROM embedding_heads) +
+				(SELECT COUNT(*) FROM embedding_failures)`).Scan(&rows))
+			assert.Zero(t, rows, "malformed timestamp import must roll back atomically")
+		})
+	}
+}
+
+func jsonStringForTest(t *testing.T, value string) jsontext.Value {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return encoded
+}

--- a/internal/store/embedding_catalog_integrity_test.go
+++ b/internal/store/embedding_catalog_integrity_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"encoding/json/jsontext"
 	"fmt"
@@ -15,6 +16,40 @@ import (
 	"go.kenn.io/docbank/document"
 	docsqlite "go.kenn.io/docbank/sqlite"
 )
+
+func TestEmbeddingCatalogPurgeUsesSingleRootExpiryBoundary(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	const asOf = "2026-08-25T10:00:00.000000000Z"
+	root := CurrentRenditionRoot{
+		ID: "embedding-purge-boundary", Kind: RenditionRootReaderLease,
+		TargetKind: RenditionRootEmbeddingSet, TargetID: record.ID, FencingToken: 1,
+		RecordedAt: embeddingCatalogTime, ExpiresAt: "2026-08-25T10:00:00.000000001Z",
+	}
+	require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+
+	report := PurgeReport{}
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		_, err := purgeEmbeddingCatalogTx(t.Context(), tx, stringSet([]string{versionID}), nil, nil,
+			false, asOf, &report, make(map[string]struct{}))
+		return err
+	}))
+
+	assert.Zero(t, report.RemovedEmbeddingSets)
+	assert.Zero(t, report.RemovedEmbeddingInputGenerations)
+	assert.Zero(t, report.RemovedEmbeddingVectorSets)
+	var authorities int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM embedding_sets WHERE embedding_set_id=?) +
+		(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?) +
+		(SELECT COUNT(*) FROM embedding_vector_sets WHERE vector_set_id=?) +
+		(SELECT COUNT(*) FROM current_rendition_roots WHERE root_id=? AND active=1)`,
+		record.ID, record.InputGeneration.ID, record.VectorSet.ID, root.ID).Scan(&authorities))
+	assert.Equal(t, 4, authorities)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
 
 func TestEmbeddingCatalogExplicitPurgePreservesEveryActiveRoot(t *testing.T) {
 	testCases := []struct {

--- a/internal/store/embedding_catalog_review_test.go
+++ b/internal/store/embedding_catalog_review_test.go
@@ -1,0 +1,199 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+)
+
+func TestEmbeddingCatalogRejectsRowsThatDivergeFromPayload(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	normalized, err := normalizeEmbeddingSetRecord(cloneEmbeddingSetRecord(record))
+	require.NoError(t, err)
+	record = normalized
+
+	decoded, _, err := document.DecodeVectorSetV1(record.VectorSet.Payload, document.VectorBounds{
+		MaxRows: 128, MaxDimension: record.VectorSpace.Dimensions, MaxBytes: len(record.VectorSet.Payload),
+	})
+	require.NoError(t, err)
+	require.Len(t, decoded.Vectors, 2)
+	values := make([][]float64, len(decoded.Vectors))
+	for row := range decoded.Vectors {
+		values[row] = make([]float64, len(decoded.Vectors[row]))
+		for column, value := range decoded.Vectors[row] {
+			values[row][column] = float64(value)
+		}
+	}
+	decoded.InputKeys[0], decoded.InputKeys[1] = decoded.InputKeys[1], decoded.InputKeys[0]
+	decoded.InputChecksums[0], decoded.InputChecksums[1] = decoded.InputChecksums[1], decoded.InputChecksums[0]
+	values[0], values[1] = values[1], values[0]
+	swapped, err := document.NewVectorSetV1(document.VectorSetV1Input{
+		VectorSpaceFingerprint: decoded.VectorSpaceFingerprint,
+		Metric:                 decoded.Metric,
+		Normalization:          decoded.Normalization,
+		Dimension:              decoded.Dimension,
+		InputKeys:              decoded.InputKeys,
+		InputChecksums:         decoded.InputChecksums,
+		Values:                 values,
+	})
+	require.NoError(t, err)
+	payload, checksum, err := document.EncodeVectorSetV1(swapped)
+	require.NoError(t, err)
+	record.VectorSet.Payload = payload
+	record.VectorSet.ID = checksum
+	record.VectorSet.PayloadChecksum = checksum
+	record.VectorSet.PayloadBlobHash = testSHA256(payload)
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, record.VectorSet.PayloadBlobHash, int64(len(payload)))
+	}))
+
+	require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "input")
+}
+
+func TestEmbeddingCatalogHeadsAndFailuresAreProfileScoped(t *testing.T) {
+	s, versionID, firstProfile, _ := newEmbeddingCatalogFixture(t)
+	secondProfile := embeddingCatalogProfileVariant(t)
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		return ensureProcessingProfileTx(t.Context(), tx, secondProfile)
+	}))
+
+	first := embeddingSetFixture(s, versionID, firstProfile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	second := embeddingSetFixture(s, versionID, secondProfile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	second.ID = testSHA256([]byte("second-profile-embedding-set"))
+	second.InputGeneration.ID = testSHA256([]byte("second-profile-input-generation"))
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), first))
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), second))
+	for _, item := range []struct {
+		profile ProcessingProfileRecord
+		set     EmbeddingSetRecord
+	}{
+		{profile: firstProfile, set: first},
+		{profile: secondProfile, set: second},
+	} {
+		require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+			Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional",
+				InputKind: document.EmbeddingInputOriginalFile},
+			SetID: item.set.ID, VectorSpaceID: item.set.VectorSpace.ID,
+			ProcessingProfileFingerprint: item.profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+		}))
+		require.NoError(t, s.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+			ContentVersionID: versionID, ProcessingProfileFingerprint: item.profile.Fingerprint,
+			BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
+			FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
+		}))
+	}
+
+	var heads, failures int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM embedding_heads WHERE content_version_id=?),
+		(SELECT COUNT(*) FROM embedding_failures WHERE content_version_id=?)`,
+		versionID, versionID).Scan(&heads, &failures))
+	assert.Equal(t, 2, heads)
+	assert.Equal(t, 2, failures)
+}
+
+func TestEmbeddingCatalogVersionPruneRetainsPinnedArtifactsUntilGC(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	roots := []CurrentRenditionRoot{
+		{ID: "pruned-generation-reader", Kind: RenditionRootReaderLease,
+			TargetKind: RenditionRootEmbeddingGeneration, TargetID: record.InputGeneration.ID,
+			FencingToken: 1, RecordedAt: embeddingCatalogTime, ExpiresAt: "2099-08-25T10:00:00.000000000Z"},
+		{ID: "pruned-vector-backup", Kind: RenditionRootBackupPin,
+			TargetKind: RenditionRootEmbeddingVectorSet, TargetID: record.VectorSet.ID,
+			FencingToken: 1, RecordedAt: embeddingCatalogTime},
+	}
+	for _, root := range roots {
+		require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+	}
+
+	var nodeID, revision int64
+	require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`,
+		versionID).Scan(&nodeID, &revision))
+	replacementHash := fakeHash("pinned-authority-prune-replacement")
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, replacementHash, 24)
+	}))
+	updated, _, err := s.ReplaceContent(t.Context(), nodeID, revision, replacementHash, 24, "application/pdf")
+	require.NoError(t, err)
+	_, err = s.PruneContentVersions(t.Context(), nodeID, updated.Revision,
+		VersionPruneSelector{VersionIDs: []string{versionID}}, true)
+	require.NoError(t, err)
+
+	var versionAndSet, artifacts, activeRoots int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM content_versions WHERE version_id=?) +
+		(SELECT COUNT(*) FROM embedding_sets WHERE embedding_set_id=?),
+		(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?) +
+		(SELECT COUNT(*) FROM embedding_vector_sets WHERE vector_set_id=?),
+		(SELECT COUNT(*) FROM current_rendition_roots WHERE root_id IN (?,?) AND active=1)`,
+		versionID, record.ID, record.InputGeneration.ID, record.VectorSet.ID,
+		roots[0].ID, roots[1].ID).Scan(&versionAndSet, &artifacts, &activeRoots))
+	assert.Zero(t, versionAndSet)
+	assert.Equal(t, 2, artifacts)
+	assert.Equal(t, 2, activeRoots)
+
+	for _, root := range roots {
+		released, releaseErr := s.ReleaseCurrentRenditionRoot(t.Context(), root.ID, root.FencingToken)
+		require.NoError(t, releaseErr)
+		require.True(t, released)
+	}
+	_, err = s.PurgeDerivatives(t.Context(), PurgeRequest{})
+	require.NoError(t, err)
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?) +
+		(SELECT COUNT(*) FROM embedding_vector_sets WHERE vector_set_id=?)`,
+		record.InputGeneration.ID, record.VectorSet.ID).Scan(&artifacts))
+	assert.Zero(t, artifacts)
+}
+
+func TestEmbeddingCatalogSnapshotValidationChecksStoredRows(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(t.Context(), `DELETE FROM embedding_sets WHERE embedding_set_id=?`, record.ID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(t.Context(), `DROP TRIGGER embedding_vector_rows_immutable_update`); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(t.Context(), `UPDATE embedding_vector_rows SET checksum=? WHERE vector_set_id=?`,
+			fakeHash("corrupt-stored-vector-row"), record.VectorSet.ID)
+		return err
+	}))
+
+	require.ErrorContains(t, s.ValidateMetadata(t.Context()), "manifest")
+}
+
+func embeddingCatalogProfileVariant(t *testing.T) ProcessingProfileRecord {
+	t.Helper()
+	base := embeddingCatalogProfile(t)
+	var profile document.ProcessingProfileV1
+	require.NoError(t, json.Unmarshal(base.CanonicalProfile, &profile))
+	profile.Retrieval.VectorLimit++
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	require.NoError(t, err)
+	return ProcessingProfileRecord{
+		Fingerprint: fingerprints.Profile, CanonicalProfile: canonical,
+		RenditionRequestFingerprint:    fingerprints.RenditionRequest,
+		EvidenceLexicalFingerprint:     fingerprints.EvidenceLexical,
+		RetentionDisclosureFingerprint: fingerprints.RetentionDisclosure,
+		AttachmentPolicyFingerprint:    profile.RetentionDisclosure.AttachmentPolicyFingerprint,
+		ConsentFingerprint:             profile.RetentionDisclosure.ConsentFingerprint,
+		RenditionDisclosureFingerprint: profile.Rendition.DisclosureFingerprint,
+		TrustBoundary:                  profile.RetentionDisclosure.TrustBoundary,
+	}
+}

--- a/internal/store/embedding_catalog_review_test.go
+++ b/internal/store/embedding_catalog_review_test.go
@@ -101,6 +101,74 @@ func TestEmbeddingCatalogHeadsAndFailuresAreProfileScoped(t *testing.T) {
 	assert.Equal(t, 2, failures)
 }
 
+func TestEmbeddingCatalogVocabularyIsValidatedOutsideSQLite(t *testing.T) {
+	testCases := []struct {
+		name, dropTrigger, before, mutation, want string
+	}{
+		{
+			name: "vector-space contract", dropTrigger: "embedding_vector_spaces_immutable_update",
+			mutation: `UPDATE embedding_vector_spaces SET contract_version='embedding-vector-space/v2'`,
+			want:     "vector-space contract version is unsupported",
+		},
+		{
+			name: "vector-set contract", dropTrigger: "embedding_vector_sets_immutable_update",
+			mutation: `UPDATE embedding_vector_sets SET contract_version='vector-set/v2'`,
+			want:     "vector-set contract version is unsupported",
+		},
+		{
+			name: "set input kind", dropTrigger: "embedding_sets_immutable_update",
+			before:   `DELETE FROM embedding_heads`,
+			mutation: `UPDATE embedding_sets SET input_kind='future_input'`,
+			want:     "embedding input kind",
+		},
+		{
+			name:     "head input kind",
+			mutation: `UPDATE embedding_heads SET input_kind='future_input'`,
+			want:     "embedding input kind",
+		},
+		{
+			name:     "failure input kind",
+			mutation: `UPDATE embedding_failures SET input_kind='future_input'`,
+			want:     "embedding input kind",
+		},
+		{
+			name:     "failure code",
+			mutation: `UPDATE embedding_failures SET failure_code='future_failure'`,
+			want:     "provider-neutral vocabulary",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+				document.EmbeddingInputOriginalFile, "optional", "")
+			require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+			require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+				Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID,
+					InputKind: record.InputKind},
+				SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+				ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+			}))
+			require.NoError(t, s.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+				ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+				BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
+				FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
+			}))
+			if testCase.dropTrigger != "" {
+				_, err := s.db.Exec(`DROP TRIGGER ` + testCase.dropTrigger)
+				require.NoError(t, err)
+			}
+			if testCase.before != "" {
+				_, err := s.db.Exec(testCase.before)
+				require.NoError(t, err)
+			}
+			_, err := s.db.Exec(testCase.mutation)
+			require.NoError(t, err)
+			require.ErrorContains(t, s.ValidateMetadata(t.Context()), testCase.want)
+		})
+	}
+}
+
 func TestEmbeddingCatalogVersionPruneRetainsPinnedArtifactsUntilGC(t *testing.T) {
 	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
 	record := embeddingSetFixture(s, versionID, profile.Fingerprint,

--- a/internal/store/embedding_catalog_review_test.go
+++ b/internal/store/embedding_catalog_review_test.go
@@ -81,6 +81,7 @@ func TestEmbeddingCatalogHeadsAndFailuresAreProfileScoped(t *testing.T) {
 		{profile: secondProfile, set: second},
 	} {
 		require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+			FencingToken: 1,
 			Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional",
 				InputKind: document.EmbeddingInputOriginalFile},
 			SetID: item.set.ID, VectorSpaceID: item.set.VectorSpace.ID,
@@ -145,6 +146,7 @@ func TestEmbeddingCatalogVocabularyIsValidatedOutsideSQLite(t *testing.T) {
 				document.EmbeddingInputOriginalFile, "optional", "")
 			require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
 			require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+				FencingToken: 1,
 				Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID,
 					InputKind: record.InputKind},
 				SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,

--- a/internal/store/embedding_catalog_review_test.go
+++ b/internal/store/embedding_catalog_review_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -163,6 +164,77 @@ func TestEmbeddingCatalogVocabularyIsValidatedOutsideSQLite(t *testing.T) {
 				require.NoError(t, err)
 			}
 			_, err := s.db.Exec(testCase.mutation)
+			require.NoError(t, err)
+			require.ErrorContains(t, s.ValidateMetadata(t.Context()), testCase.want)
+		})
+	}
+}
+
+func TestEmbeddingCatalogMetadataRejectsFailureOutsideProfile(t *testing.T) {
+	for _, testCase := range []struct {
+		name, bindingID string
+		inputKind       EmbeddingInputKind
+		want            string
+	}{
+		{name: "missing binding", bindingID: "missing", inputKind: document.EmbeddingInputOriginalFile,
+			want: "processing profile binding"},
+		{name: "wrong input kind", bindingID: "chunk", inputKind: document.EmbeddingInputOriginalFile,
+			want: "does not match processing profile binding kind"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+			require.NoError(t, s.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+				ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+				BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
+				FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
+			}))
+			_, err := s.db.Exec(`UPDATE embedding_failures SET binding_id=?,input_kind=?`,
+				testCase.bindingID, testCase.inputKind)
+			require.NoError(t, err)
+			require.ErrorContains(t, s.ValidateMetadata(t.Context()), testCase.want)
+		})
+	}
+}
+
+func TestEmbeddingCatalogPolicyLimitsAreValidatedOutsideSQLite(t *testing.T) {
+	for _, testCase := range []struct {
+		name, table, mutation, want string
+		args                        []any
+	}{
+		{
+			name: "descriptor bytes", table: "embedding_vector_spaces",
+			mutation: `UPDATE embedding_vector_spaces SET descriptor_json=?`,
+			args:     []any{strings.Repeat("x", (64<<10)+1)}, want: "descriptor JSON exceeds bounds",
+		},
+		{
+			name: "projected text", table: "embedding_vector_spaces",
+			mutation: `UPDATE embedding_vector_spaces SET provider_descriptor=?`,
+			args:     []any{strings.Repeat("x", maxEmbeddingCatalogIDBytes+1)}, want: "provider descriptor",
+		},
+		{
+			name: "dimensions", table: "embedding_vector_spaces",
+			mutation: `UPDATE embedding_vector_spaces SET dimensions=?`,
+			args:     []any{maxEmbeddingDimensions + 1}, want: "dimensions are invalid",
+		},
+		{
+			name: "payload bytes", table: "embedding_vector_sets",
+			mutation: `UPDATE embedding_vector_sets SET payload_size=?`,
+			args:     []any{(64 << 20) + 1}, want: "payload size is invalid",
+		},
+		{
+			name: "row count", table: "embedding_vector_sets",
+			mutation: `UPDATE embedding_vector_sets SET row_count=?`,
+			args:     []any{maxEmbeddingCatalogRows + 1}, want: "count or head authority is corrupt",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+				document.EmbeddingInputOriginalFile, "optional", "")
+			require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+			_, err := s.db.Exec(`DROP TRIGGER embedding_` + strings.TrimPrefix(testCase.table, "embedding_") + `_immutable_update`)
+			require.NoError(t, err)
+			_, err = s.db.Exec(testCase.mutation, testCase.args...)
 			require.NoError(t, err)
 			require.ErrorContains(t, s.ValidateMetadata(t.Context()), testCase.want)
 		})

--- a/internal/store/embedding_catalog_review_test.go
+++ b/internal/store/embedding_catalog_review_test.go
@@ -88,6 +88,7 @@ func TestEmbeddingCatalogHeadsAndFailuresAreProfileScoped(t *testing.T) {
 			ProcessingProfileFingerprint: item.profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 		}))
 		require.NoError(t, s.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+			FencingToken:     1,
 			ContentVersionID: versionID, ProcessingProfileFingerprint: item.profile.Fingerprint,
 			BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
 			FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
@@ -153,6 +154,7 @@ func TestEmbeddingCatalogVocabularyIsValidatedOutsideSQLite(t *testing.T) {
 				ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 			}))
 			require.NoError(t, s.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+				FencingToken:     1,
 				ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
 				BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
 				FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
@@ -186,6 +188,7 @@ func TestEmbeddingCatalogMetadataRejectsFailureOutsideProfile(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
 			require.NoError(t, s.RecordEmbeddingFailure(t.Context(), EmbeddingFailureRecord{
+				FencingToken:     1,
 				ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
 				BindingID: "required", InputKind: document.EmbeddingInputOriginalFile,
 				FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,

--- a/internal/store/embedding_catalog_test.go
+++ b/internal/store/embedding_catalog_test.go
@@ -406,7 +406,7 @@ func TestEmbeddingCatalogMetadataRejectsCorruptionAndOversizedCounts(t *testing.
 	}{
 		{"unknown contract", func(value string) string {
 			return strings.Replace(value, EmbeddingVectorSpaceContractV1, "embedding-vector-space/v2", 1)
-		}, "constraint"},
+		}, "unsupported"},
 		{"oversized count", func(value string) string {
 			return strings.Replace(value, `"input_count":1`, `"input_count":100001`, 1)
 		}, "exceeds bounds"},

--- a/internal/store/embedding_catalog_test.go
+++ b/internal/store/embedding_catalog_test.go
@@ -1,0 +1,739 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	docsqlite "go.kenn.io/docbank/sqlite"
+	"go.kenn.io/docbank/sqlite/modernc"
+)
+
+func TestEmbeddingCatalogChunkAndDirectFileHeadsCoexist(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	direct := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	chunk := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), direct))
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), chunk))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
+		SetID: direct.ID, VectorSpaceID: direct.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk},
+		SetID: chunk.ID, VectorSpaceID: chunk.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+
+	assert.Equal(t, direct.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint,
+		"optional", document.EmbeddingInputOriginalFile))
+	assert.Equal(t, chunk.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint,
+		"chunk", document.EmbeddingInputRenditionChunk))
+}
+
+func TestEmbeddingCatalogDeduplicatesExactSetsButFencesAttachmentContext(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+
+	var sets, generations, vectorSets int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM embedding_sets),
+		(SELECT COUNT(*) FROM embedding_input_generations),
+		(SELECT COUNT(*) FROM embedding_vector_sets)`).Scan(&sets, &generations, &vectorSets))
+	assert.Equal(t, 1, sets)
+	assert.Equal(t, 1, generations)
+	assert.Equal(t, 1, vectorSets)
+
+	var secondVersion, buildID string
+	require.NoError(t, s.db.QueryRow(`SELECT version_id FROM content_versions WHERE version_id<>? AND blob_hash=? ORDER BY version_id LIMIT 1`, versionID, catalogSourceHash).Scan(&secondVersion))
+	require.NoError(t, s.db.QueryRow(`SELECT build_id FROM rendition_attachments WHERE attachment_id=?`, attachmentID).Scan(&buildID))
+	secondAttachment := testSHA256([]byte("second-embedding-attachment"))
+	secondAttachmentRecord := RenditionAttachmentRecord{
+		ID: secondAttachment, VaultID: s.VaultID(), ContentVersionID: secondVersion,
+		BuildID: buildID, Profile: profile, AttachedAt: embeddingCatalogTime,
+	}
+	require.NoError(t, publishRenditionForTest(
+		t, s, secondAttachmentRecord, embeddingCatalogTime, testSHA256([]byte("second-embedding-lexical-generation")),
+	))
+	second := embeddingSetFixture(s, secondVersion, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", secondAttachment)
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), second))
+	assert.NotEqual(t, record.InputGeneration.ID, second.InputGeneration.ID)
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_input_generations`).Scan(&generations))
+	assert.Equal(t, 2, generations, "attachment identities must not share catalog generation authority")
+}
+
+func TestEmbeddingCatalogRejectsInvalidRowsAndPublicationFences(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	base := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*EmbeddingSetRecord)
+	}{
+		{"corrupt payload", func(value *EmbeddingSetRecord) { value.VectorSet.Payload[len(value.VectorSet.Payload)-1] ^= 1 }},
+		{"wrong vector space", func(value *EmbeddingSetRecord) { value.VectorSet.VectorSpaceID = fakeHash("wrong-space") }},
+		{"checksum mismatch", func(value *EmbeddingSetRecord) { value.VectorSet.PayloadChecksum = fakeHash("wrong") }},
+		{"identity mismatch", func(value *EmbeddingSetRecord) { value.VectorSet.ID = fakeHash("wrong-id") }},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			record := cloneEmbeddingSetRecord(base)
+			testCase.mutate(&record)
+			err := s.StageEmbeddingSet(t.Context(), record)
+			require.Error(t, err)
+		})
+	}
+
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), base))
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*EmbeddingHeadRecord)
+		want   string
+	}{
+		{"source", func(value *EmbeddingHeadRecord) { value.Key.ContentVersionID = "00000000-0000-4000-8000-000000000176" }, "stale source"},
+		{"profile", func(value *EmbeddingHeadRecord) { value.ProcessingProfileFingerprint = fakeHash("missing-profile") }, "profile fingerprint"},
+		{"space", func(value *EmbeddingHeadRecord) { value.VectorSpaceID = fakeHash("missing-space") }, "vector-space ID"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			head := EmbeddingHeadRecord{
+				Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
+				SetID: base.ID, VectorSpaceID: base.VectorSpace.ID,
+				ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+			}
+			testCase.mutate(&head)
+			err := s.PublishEmbeddingHead(t.Context(), head)
+			require.ErrorContains(t, err, testCase.want)
+		})
+	}
+}
+
+func TestEmbeddingCatalogRejectsLegacyGenerationShapeAsPolicyAuthority(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	legacy := append([]byte(nil), record.InputGeneration.GenerationJSON[:len(record.InputGeneration.GenerationJSON)-1]...)
+	legacy = append(legacy, []byte(`,"tokenizer_identity":{"name":"catalog-runes","revision":"v1"}}`)...)
+	record.InputGeneration.GenerationJSON = legacy
+	err := s.StageEmbeddingSet(t.Context(), record)
+	require.ErrorContains(t, err, "decode embedding input generation")
+}
+
+func TestEmbeddingCatalogMetadataRoundTripsDeterministically(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
+		SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+	chunk := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), chunk))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk},
+		SetID: chunk.ID, VectorSpaceID: chunk.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+
+	var first, second bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &first))
+	require.NoError(t, s.ExportMetadata(t.Context(), &second))
+	assert.Equal(t, first.Bytes(), second.Bytes())
+	assert.NotContains(t, first.String(), "synthetic source pdf")
+	assert.NotContains(t, first.String(), "input text")
+
+	restored := newTestStoreWithDriver(t, modernc.Driver{})
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(first.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, first.Bytes(), roundTrip.Bytes())
+	assert.Equal(t, record.ID, embeddingHeadSetIDForTest(t, restored, versionID, profile.Fingerprint,
+		"optional", document.EmbeddingInputOriginalFile))
+	assert.Equal(t, chunk.ID, embeddingHeadSetIDForTest(t, restored, versionID, profile.Fingerprint,
+		"chunk", document.EmbeddingInputRenditionChunk))
+}
+
+func TestEmbeddingCatalogDerivativePurgeAndGCLeaveOriginalAuthority(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
+		SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+
+	plan, err := s.DerivativeGCPlan(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, plan.EmbeddingSets, "an active embedding head must retain its complete set")
+
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		_, err := tx.Exec(`DELETE FROM embedding_heads WHERE embedding_set_id=?`, record.ID)
+		return err
+	}))
+	var nodeID, revision int64
+	require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, versionID).Scan(&nodeID, &revision))
+	_, _, err = s.Trash(t.Context(), nodeID, revision)
+	require.NoError(t, err)
+	plan, err = s.DerivativeGCPlan(t.Context())
+	require.NoError(t, err)
+	require.Len(t, plan.EmbeddingSets, 1)
+	assert.Equal(t, record.ID, plan.EmbeddingSets[0].SetID)
+	assert.Equal(t, record.VectorSet.PayloadBlobHash, plan.EmbeddingSets[0].PayloadBlobHash)
+
+	report, err := s.PurgeDerivatives(t.Context(), PurgeRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.RemovedEmbeddingSets)
+	assert.Equal(t, 1, report.RemovedEmbeddingInputGenerations)
+	assert.Equal(t, 1, report.RemovedEmbeddingVectorSets)
+	assert.Contains(t, report.PhysicalDerivativeBlobsPendingGC, record.VectorSet.PayloadBlobHash)
+	var versions, vectorRows int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM content_versions WHERE version_id=?),
+		(SELECT COUNT(*) FROM embedding_vector_rows WHERE vector_set_id=?)`,
+		versionID, record.VectorSet.ID).Scan(&versions, &vectorRows))
+	assert.Equal(t, 1, versions, "derivative collection must not remove original content authority")
+	assert.Zero(t, vectorRows)
+}
+
+func TestEmbeddingCatalogRootsRetainEveryAuthorityTransitively(t *testing.T) {
+	testCases := []struct {
+		name       string
+		kind       CurrentRenditionRootKind
+		targetKind CurrentRenditionTargetKind
+		target     func(EmbeddingSetRecord) string
+		lease      bool
+	}{
+		{"reader lease set", RenditionRootReaderLease, RenditionRootEmbeddingSet, func(value EmbeddingSetRecord) string { return value.ID }, true},
+		{"worker lease generation", RenditionRootWorkerLease, RenditionRootEmbeddingGeneration, func(value EmbeddingSetRecord) string { return value.InputGeneration.ID }, true},
+		{"backup set", RenditionRootBackupPin, RenditionRootEmbeddingSet, func(value EmbeddingSetRecord) string { return value.ID }, false},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+			require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+			var nodeID, revision int64
+			require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, versionID).Scan(&nodeID, &revision))
+			_, _, err := s.Trash(t.Context(), nodeID, revision)
+			require.NoError(t, err)
+			root := CurrentRenditionRoot{
+				ID: "embedding-root-" + strings.ReplaceAll(testCase.name, " ", "-"), Kind: testCase.kind,
+				TargetKind: testCase.targetKind, TargetID: testCase.target(record), FencingToken: 1,
+				RecordedAt: embeddingCatalogTime,
+			}
+			if testCase.lease {
+				root.ExpiresAt = "2099-08-25T10:00:00.000000000Z"
+			}
+			require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+			plan, err := s.DerivativeGCPlan(t.Context())
+			require.NoError(t, err)
+			assert.Empty(t, plan.EmbeddingSets)
+			report, err := s.PurgeDerivatives(t.Context(), PurgeRequest{})
+			require.NoError(t, err)
+			assert.Zero(t, report.RemovedEmbeddingSets)
+			released, err := s.ReleaseCurrentRenditionRoot(t.Context(), root.ID, root.FencingToken)
+			require.NoError(t, err)
+			assert.True(t, released)
+			plan, err = s.DerivativeGCPlan(t.Context())
+			require.NoError(t, err)
+			require.Len(t, plan.EmbeddingSets, 1)
+			assert.Equal(t, record.ID, plan.EmbeddingSets[0].SetID)
+		})
+	}
+	t.Run("expired lease", func(t *testing.T) {
+		s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+		record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+		var nodeID, revision int64
+		require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, versionID).Scan(&nodeID, &revision))
+		_, _, err := s.Trash(t.Context(), nodeID, revision)
+		require.NoError(t, err)
+		root := CurrentRenditionRoot{
+			ID: "expired-embedding-reader", Kind: RenditionRootReaderLease,
+			TargetKind: RenditionRootEmbeddingSet, TargetID: record.ID, FencingToken: 1,
+			RecordedAt: embeddingCatalogTime, ExpiresAt: "2020-08-25T10:00:00.000000000Z",
+		}
+		require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+		plan, err := s.DerivativeGCPlan(t.Context())
+		require.NoError(t, err)
+		require.Len(t, plan.EmbeddingSets, 1)
+		assert.Contains(t, plan.ExpiredRootIDs, root.ID)
+	})
+}
+
+func TestEmbeddingCatalogVersionPruneDeletesDirectAndChunkAuthority(t *testing.T) {
+	s, firstVersion, profile, firstAttachment := newEmbeddingCatalogFixture(t)
+	var versionID, buildID string
+	require.NoError(t, s.db.QueryRow(`SELECT version_id FROM content_versions WHERE version_id<>? AND blob_hash=? ORDER BY version_id LIMIT 1`, firstVersion, catalogSourceHash).Scan(&versionID))
+	require.NoError(t, s.db.QueryRow(`SELECT build_id FROM rendition_attachments WHERE attachment_id=?`, firstAttachment).Scan(&buildID))
+	attachmentID := testSHA256([]byte("pruned-embedding-attachment"))
+	attachment := RenditionAttachmentRecord{
+		ID: attachmentID, VaultID: s.VaultID(), ContentVersionID: versionID, BuildID: buildID,
+		Profile: profile, AttachedAt: embeddingCatalogTime,
+	}
+	require.NoError(t, publishRenditionForTest(
+		t, s, attachment, embeddingCatalogTime, testSHA256([]byte("pruned-embedding-lexical-generation")),
+	))
+	records := []EmbeddingSetRecord{
+		embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", ""),
+		embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID),
+	}
+	for _, record := range records {
+		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+		require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+			Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+			SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+			ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+		}))
+	}
+	var nodeID, revision int64
+	require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, versionID).Scan(&nodeID, &revision))
+	replacementHash := fakeHash("e3")
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error { return s.EnsureBlobTx(tx, replacementHash, 24) }))
+	updated, _, err := s.ReplaceContent(t.Context(), nodeID, revision, replacementHash, 24, "application/pdf")
+	require.NoError(t, err)
+	result, err := s.PruneContentVersions(t.Context(), nodeID, updated.Revision, VersionPruneSelector{VersionIDs: []string{versionID}}, true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.DeletedVersions)
+	var remaining int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM content_versions WHERE version_id=?) +
+		(SELECT COUNT(*) FROM embedding_sets WHERE content_version_id=?) +
+		(SELECT COUNT(*) FROM rendition_attachments WHERE attachment_id=?)`,
+		versionID, versionID, attachmentID).Scan(&remaining))
+	assert.Zero(t, remaining)
+
+	var generations, vectorSets int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id IN (?,?)),
+		(SELECT COUNT(*) FROM embedding_vector_sets WHERE vector_set_id IN (?,?))`,
+		records[0].InputGeneration.ID, records[1].InputGeneration.ID,
+		records[0].VectorSet.ID, records[1].VectorSet.ID).Scan(&generations, &vectorSets))
+	assert.Equal(t, 2, generations)
+	assert.Equal(t, 2, vectorSets)
+
+	report, err := s.PurgeDerivatives(t.Context(), PurgeRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, report.RemovedEmbeddingInputGenerations)
+	assert.Equal(t, 2, report.RemovedEmbeddingVectorSets)
+}
+
+func TestEmbeddingCatalogVersionPrunePreservesSharedAuthorityRoots(t *testing.T) {
+	s, sourceVersion, profile, _ := newEmbeddingCatalogFixture(t)
+	var deletedVersion string
+	require.NoError(t, s.db.QueryRow(`SELECT version_id FROM content_versions WHERE version_id<>? AND blob_hash=? ORDER BY version_id LIMIT 1`, sourceVersion, catalogSourceHash).Scan(&deletedVersion))
+	third, err := s.CreateFile(t.Context(), s.RootID(), "shared-embedding-consumer.pdf", catalogSourceHash, int64(len(catalogBlobContents[catalogSourceHash])), "application/pdf")
+	require.NoError(t, err)
+	record := embeddingSetFixture(s, sourceVersion, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	deletedSetID := fakeHash("deleted-shared-version-embedding-set")
+	survivingSetID := fakeHash("surviving-shared-version-embedding-set")
+	for setID, versionID := range map[string]string{deletedSetID: deletedVersion, survivingSetID: third.CurrentVersionID} {
+		_, err = s.db.Exec(`INSERT INTO embedding_sets(
+		embedding_set_id,vault_uid,binding_id,input_kind,content_version_id,
+		profile_fingerprint,embedding_input_fingerprint,vector_space_id,
+		input_generation_id,vector_set_id,created_at)
+		SELECT ?,vault_uid,binding_id,input_kind,?,profile_fingerprint,
+		embedding_input_fingerprint,vector_space_id,input_generation_id,vector_set_id,created_at
+		FROM embedding_sets WHERE embedding_set_id=?`, setID, versionID, record.ID)
+		require.NoError(t, err)
+	}
+
+	roots := []CurrentRenditionRoot{
+		{ID: "deleted-set-pin", Kind: RenditionRootBackupPin, TargetKind: RenditionRootEmbeddingSet, TargetID: deletedSetID, FencingToken: 1, RecordedAt: embeddingCatalogTime},
+		{ID: "shared-generation-lease", Kind: RenditionRootReaderLease, TargetKind: RenditionRootEmbeddingGeneration, TargetID: record.InputGeneration.ID, FencingToken: 1, RecordedAt: embeddingCatalogTime, ExpiresAt: "2099-08-25T10:00:00.000000000Z"},
+		{ID: "shared-vector-pin", Kind: RenditionRootBackupPin, TargetKind: RenditionRootEmbeddingVectorSet, TargetID: record.VectorSet.ID, FencingToken: 1, RecordedAt: embeddingCatalogTime},
+		{ID: "shared-payload-pin", Kind: RenditionRootRetention, TargetKind: RenditionRootEmbeddingPayload, TargetID: record.VectorSet.PayloadBlobHash, FencingToken: 1, RecordedAt: embeddingCatalogTime},
+	}
+	for _, root := range roots {
+		require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+	}
+
+	var deletedNodeID, deletedRevision int64
+	require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, deletedVersion).Scan(&deletedNodeID, &deletedRevision))
+	replacementHash := fakeHash("shared-authority-replacement")
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error { return s.EnsureBlobTx(tx, replacementHash, 24) }))
+	updated, _, err := s.ReplaceContent(t.Context(), deletedNodeID, deletedRevision, replacementHash, 24, "application/pdf")
+	require.NoError(t, err)
+	_, err = s.PruneContentVersions(t.Context(), deletedNodeID, updated.Revision, VersionPruneSelector{VersionIDs: []string{deletedVersion}}, true)
+	require.NoError(t, err)
+
+	var survivingAuthorities, survivingRoots, deletedSetRoots int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM embedding_sets WHERE embedding_set_id=?) +
+		(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?) +
+		(SELECT COUNT(*) FROM embedding_vector_sets WHERE vector_set_id=?)`,
+		survivingSetID, record.InputGeneration.ID, record.VectorSet.ID).Scan(&survivingAuthorities))
+	require.Equal(t, 3, survivingAuthorities)
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM current_rendition_roots WHERE root_id IN (?,?,?)`,
+		roots[1].ID, roots[2].ID, roots[3].ID).Scan(&survivingRoots))
+	require.Equal(t, 3, survivingRoots)
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM current_rendition_roots WHERE root_id=?`, roots[0].ID).Scan(&deletedSetRoots))
+	assert.Zero(t, deletedSetRoots)
+
+	for _, versionID := range []string{sourceVersion, third.CurrentVersionID} {
+		var nodeID, revision int64
+		require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, versionID).Scan(&nodeID, &revision))
+		_, _, err = s.Trash(t.Context(), nodeID, revision)
+		require.NoError(t, err)
+	}
+	plan, err := s.DerivativeGCPlan(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, plan.EmbeddingSets, "shared generation/vector/payload roots must retain their surviving consumer")
+}
+
+func TestEmbeddingCatalogMetadataRejectsCorruptionAndOversizedCounts(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+
+	for _, testCase := range []struct {
+		name   string
+		mutate func(string) string
+		want   string
+	}{
+		{"unknown contract", func(value string) string {
+			return strings.Replace(value, EmbeddingVectorSpaceContractV1, "embedding-vector-space/v2", 1)
+		}, "constraint"},
+		{"oversized count", func(value string) string {
+			return strings.Replace(value, `"input_count":1`, `"input_count":100001`, 1)
+		}, "exceeds bounds"},
+		{"missing input row", func(value string) string {
+			lines := strings.Split(value, "\n")
+			for index, line := range lines {
+				if strings.Contains(line, `"type":"embedding_generation_input"`) {
+					return strings.Join(append(lines[:index], lines[index+1:]...), "\n")
+				}
+			}
+			return value
+		}, "count"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			target := newTestStore(t)
+			err := target.ImportMetadata(t.Context(), strings.NewReader(testCase.mutate(exported.String())))
+			require.ErrorContains(t, err, testCase.want)
+			var sets int
+			require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM embedding_sets`).Scan(&sets))
+			assert.Zero(t, sets, "corrupt import must roll back atomically")
+		})
+	}
+}
+
+func TestEmbeddingCatalogSchemaCorruptionFailsClosedOnOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.db")
+	s, err := Open(path)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+	driver := DefaultSQLiteDriver()
+	db, err := driver.Open(path, docsqlite.OpenOptions{
+		Access: docsqlite.ReadWriteExisting, TransactionMode: docsqlite.Immediate,
+	})
+	require.NoError(t, err)
+	_, err = db.Exec(`ALTER TABLE embedding_sets ADD COLUMN unexpected TEXT`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	_, err = Open(path, driver)
+	require.ErrorContains(t, err, "embedding catalog schema")
+}
+
+const embeddingCatalogTime = "2026-08-25T10:00:00.000000000Z"
+
+func embeddingHeadSetIDForTest(
+	t *testing.T, s *Store, versionID, profileFingerprint, bindingID string, kind EmbeddingInputKind,
+) string {
+	t.Helper()
+	var setID string
+	require.NoError(t, s.db.QueryRow(`SELECT embedding_set_id FROM embedding_heads
+		WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?`,
+		versionID, profileFingerprint, bindingID, kind).Scan(&setID))
+	return setID
+}
+
+func newEmbeddingCatalogFixture(t *testing.T) (*Store, string, ProcessingProfileRecord, string) {
+	t.Helper()
+	s, versions := newRenditionCatalogFixture(t)
+	profile := embeddingCatalogProfile(t)
+	build := catalogRenditionBuild(s, profile)
+	build.EvidenceChecksum = embeddingCatalogEvidence(t).Checksum
+	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+	attachment := RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0],
+		BuildID: build.ID, Profile: profile, AttachedAt: embeddingCatalogTime,
+	}
+	require.NoError(t, publishRenditionForTest(
+		t, s, attachment, embeddingCatalogTime, testSHA256([]byte("embedding-catalog-lexical-generation")),
+	))
+	return s, versions[0], profile, attachment.ID
+}
+
+func embeddingSetFixture(
+	s *Store, versionID, profileFingerprint string, kind EmbeddingInputKind, bindingID, attachmentID string,
+) EmbeddingSetRecord {
+	seed := bindingID + string(kind) + versionID + attachmentID
+	var canonicalProfile string
+	if err := s.db.QueryRow(`SELECT canonical_profile FROM processing_profiles WHERE profile_fingerprint=?`, profileFingerprint).Scan(&canonicalProfile); err != nil {
+		panic(err)
+	}
+	var profile document.ProcessingProfileV1
+	if err := json.Unmarshal([]byte(canonicalProfile), &profile); err != nil {
+		panic(err)
+	}
+	_, fingerprints, err := document.CanonicalProfile(profile)
+	if err != nil {
+		panic(err)
+	}
+	var binding document.EmbeddingBindingV1
+	for _, candidate := range profile.Embeddings {
+		if candidate.Name == bindingID {
+			binding = candidate
+			break
+		}
+	}
+	descriptor := embeddingCatalogDescriptor()
+	space := EmbeddingVectorSpaceRecord{
+		ID: fingerprints.VectorSpace[bindingID], ContractVersion: EmbeddingVectorSpaceContractV1,
+		Descriptor: descriptor,
+	}
+	generation := EmbeddingInputGenerationRecord{
+		ID:              testSHA256([]byte(seed + "generation")),
+		SourceVersionID: versionID, ProcessingProfileFingerprint: profileFingerprint,
+		EvidenceFingerprint: testSHA256([]byte(seed + "evidence")), TokenizerFingerprint: testSHA256([]byte(seed + "tokenizer")),
+		ChunkPolicyFingerprint: testSHA256([]byte(seed + "chunk-policy")), FormatterFingerprint: testSHA256([]byte(seed + "formatter")),
+		AttachmentID: attachmentID, GenerationChecksum: catalogSourceHash,
+		CreatedAt: embeddingCatalogTime,
+	}
+	if kind == document.EmbeddingInputRenditionChunk {
+		generated := embeddingCatalogGeneration(profile, fingerprints.EvidenceLexical, attachmentID)
+		generation.ID = testSHA256([]byte("embedding-generation-attachment/v1\x00" + generated.Checksum + "\x00" + attachmentID))
+		generation.GenerationJSON, err = document.MarshalEmbeddingInputGeneration(generated)
+		if err != nil {
+			panic(err)
+		}
+		generation.GenerationBlobHash = testSHA256(generation.GenerationJSON)
+		generation.GenerationEncodedSize = int64(len(generation.GenerationJSON))
+		generation.GenerationChecksum = generated.Checksum
+		if err := s.withStorageTx(context.Background(), func(tx *sql.Tx) error {
+			return s.EnsureBlobTx(tx, generation.GenerationBlobHash, generation.GenerationEncodedSize)
+		}); err != nil {
+			panic(err)
+		}
+		generation.Inputs = make([]EmbeddingInputReference, len(generated.Inputs))
+		for index, input := range generated.Inputs {
+			generation.Inputs[index] = EmbeddingInputReference{ID: input.Key, RenderedChecksum: input.Checksum}
+		}
+	} else {
+		generation.Inputs = []EmbeddingInputReference{{ID: versionID, RenderedChecksum: catalogSourceHash}}
+	}
+	expectedKeys := make([]string, len(generation.Inputs))
+	expectedChecksums := make([]string, len(generation.Inputs))
+	if kind == document.EmbeddingInputRenditionChunk {
+		generated, err := document.DecodeEmbeddingInputGeneration(generation.GenerationJSON, document.EmbeddingInputGenerationDecodeBounds{
+			MaxEncodedBytes: int64(len(generation.GenerationJSON)), MaxInputs: len(generation.Inputs),
+		})
+		if err != nil {
+			panic(err)
+		}
+		for index, input := range generated.Inputs {
+			expectedKeys[index], expectedChecksums[index] = input.Key, input.Checksum
+		}
+	} else {
+		expectedKeys[0], expectedChecksums[0] = versionID, catalogSourceHash
+	}
+	values := make([][]float64, len(expectedKeys))
+	for index := range values {
+		values[index] = []float64{float64(index + 1), 2, 3, 4, 5, 6, 7, 8}
+	}
+	canonicalVectors, err := document.NewVectorSetV1(document.VectorSetV1Input{
+		VectorSpaceFingerprint: space.ID, Metric: binding.Metric, Normalization: binding.Normalization,
+		Dimension: binding.Dimensions, InputKeys: expectedKeys, InputChecksums: expectedChecksums, Values: values,
+	})
+	if err != nil {
+		panic(err)
+	}
+	payload, payloadChecksum, err := document.EncodeVectorSetV1(canonicalVectors)
+	if err != nil {
+		panic(err)
+	}
+	payloadHash := testSHA256(payload)
+	if err := s.withStorageTx(context.Background(), func(tx *sql.Tx) error { return s.EnsureBlobTx(tx, payloadHash, int64(len(payload))) }); err != nil {
+		panic(err)
+	}
+	vectorSet := EmbeddingVectorSetRecord{
+		ID: payloadChecksum, ContractVersion: EmbeddingVectorSetContractV1, VectorSpaceID: space.ID,
+		PayloadBlobHash: payloadHash, PayloadChecksum: payloadChecksum, Payload: payload,
+	}
+	return EmbeddingSetRecord{
+		ID: testSHA256([]byte(seed + "set")), VaultID: s.VaultID(), BindingID: bindingID, InputKind: kind,
+		ContentVersionID: versionID, ProcessingProfileFingerprint: profileFingerprint,
+		EmbeddingInputFingerprint: fingerprints.EmbeddingInput[bindingID],
+		VectorSpace:               space, InputGeneration: generation, VectorSet: vectorSet, CreatedAt: embeddingCatalogTime,
+	}
+}
+
+type embeddingCatalogTokenizer struct{}
+
+func (embeddingCatalogTokenizer) Identity() document.TokenizerIdentity {
+	return document.TokenizerIdentity{Name: "catalog-runes", Revision: "v1"}
+}
+
+func (embeddingCatalogTokenizer) PrefixTokenCountsMonotonic() bool { return true }
+
+func (embeddingCatalogTokenizer) Tokenize(text string, limit int) ([]document.TokenBoundary, error) {
+	runes := []rune(text)
+	if len(runes) > limit {
+		return nil, document.ErrTokenizerLimit
+	}
+	result := make([]document.TokenBoundary, len(runes))
+	for index := range runes {
+		result[index] = document.TokenBoundary{Start: index, End: index + 1}
+	}
+	return result, nil
+}
+
+func embeddingCatalogEvidence(t *testing.T) document.NormalizedEvidenceV1 {
+	t.Helper()
+	policy, err := document.NewEvidencePolicy(4096)
+	require.NoError(t, err)
+	evidence, err := document.NormalizeEvidenceV1(document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1, Completeness: document.EvidenceComplete,
+		Family: "pdf", UnitKind: document.EvidenceUnitPage,
+		Units: []document.SourceEvidenceUnitV1{
+			{Order: 0, Text: "Synthetic evidence", Locator: document.SourceEvidenceLocatorV1{Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginOne, Start: 1, End: 1}},
+			{Order: 1, Text: "Second evidence", Locator: document.SourceEvidenceLocatorV1{Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginOne, Start: 2, End: 2}},
+		},
+	}, policy)
+	require.NoError(t, err)
+	return evidence
+}
+
+func embeddingCatalogDescriptor() document.EmbeddingDescriptor {
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfileCustom, CompatibilityID: "synthetic-space",
+		Document: document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "document: {{content}}"},
+		Query:    document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "query: {{content}}"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	descriptor, err := document.NewEmbeddingDescriptor(document.EmbeddingDescriptor{
+		ID: "synthetic-embedding", ContractVersion: document.EmbeddingProviderContractVersion,
+		PolicyFingerprint: fakeHash("e1"), TrustBoundary: document.EmbeddingTrustLocalProcess,
+		Model: "synthetic-v1", ModelRevision: "2026-08-25", Dimension: 8,
+		Metric: document.VectorMetricCosine, Normalization: document.VectorNormalizationNone,
+		ScalarEncoding: "float32", DocumentFormatter: "document/v1", QueryFormatter: "query/v1",
+		InputKinds:      []document.EmbeddingInputKind{document.EmbeddingInputOriginalFile, document.EmbeddingInputRenditionChunk},
+		CompatibilityID: "synthetic-space", SupportsTextQuery: true, ModelInput: contract,
+		SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeText},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return descriptor
+}
+
+func embeddingCatalogProfile(t *testing.T) ProcessingProfileRecord {
+	t.Helper()
+	descriptor := embeddingCatalogDescriptor()
+	base := catalogProcessingProfile(t, false)
+	var profile document.ProcessingProfileV1
+	require.NoError(t, json.Unmarshal(base.CanonicalProfile, &profile))
+	makeBinding := func(name string, activation document.EmbeddingActivation, kind document.EmbeddingInputKind) document.EmbeddingBindingV1 {
+		binding := document.EmbeddingBindingV1{
+			Activation: activation, AuthorizationFingerprint: fakeHash("d1"), CompatibilityID: descriptor.CompatibilityID,
+			CredentialBinding: "credential:catalog-embedding", Descriptor: document.ProviderDescriptorV1{ID: descriptor.ID, Fingerprint: descriptor.Fingerprint},
+			Dimensions: descriptor.Dimension, DisclosureFingerprint: fakeHash("d3"), DocumentFormatter: descriptor.DocumentFormatter,
+			InputKind: kind, MaxBatchItems: 128, MaxInputBytes: 1 << 20, MaxResponseBytes: 1 << 20,
+			Metric: descriptor.Metric, Model: descriptor.Model, ModelInput: descriptor.ModelInput, Name: name,
+			Normalization: descriptor.Normalization, QueryFormatter: descriptor.QueryFormatter,
+			ScalarEncoding: descriptor.ScalarEncoding, TrustBoundary: string(descriptor.TrustBoundary),
+		}
+		if kind == document.EmbeddingInputRenditionChunk {
+			binding.MaxInputTokens = 512
+			binding.Chunk = &document.EmbeddingChunkPolicyV1{ContextFingerprint: fakeHash("d4"), Formatter: "evidence-text/v1", MaxTokens: 128, OverlapTokens: 0, Tokenizer: "catalog-runes", TokenizerRevision: "v1", TruncationPolicy: document.TruncationPolicyReject}
+		}
+		return binding
+	}
+	profile.Embeddings = []document.EmbeddingBindingV1{
+		makeBinding("optional", document.EmbeddingOptional, document.EmbeddingInputOriginalFile),
+		makeBinding("required", document.EmbeddingRequired, document.EmbeddingInputOriginalFile),
+		makeBinding("chunk", document.EmbeddingOptional, document.EmbeddingInputRenditionChunk),
+	}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	require.NoError(t, err)
+	return ProcessingProfileRecord{
+		Fingerprint: fingerprints.Profile, CanonicalProfile: canonical,
+		RenditionRequestFingerprint: fingerprints.RenditionRequest, EvidenceLexicalFingerprint: fingerprints.EvidenceLexical,
+		RetentionDisclosureFingerprint: fingerprints.RetentionDisclosure,
+		AttachmentPolicyFingerprint:    profile.RetentionDisclosure.AttachmentPolicyFingerprint,
+		ConsentFingerprint:             profile.RetentionDisclosure.ConsentFingerprint,
+		RenditionDisclosureFingerprint: profile.Rendition.DisclosureFingerprint,
+		TrustBoundary:                  profile.RetentionDisclosure.TrustBoundary,
+	}
+}
+
+func embeddingCatalogGeneration(profile document.ProcessingProfileV1, lexicalFingerprint, attachmentID string) document.EmbeddingInputGeneration {
+	policy, err := document.NewEvidencePolicy(4096)
+	if err != nil {
+		panic(err)
+	}
+	evidence, err := document.NormalizeEvidenceV1(document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1, Completeness: document.EvidenceComplete,
+		Family: "pdf", UnitKind: document.EvidenceUnitPage,
+		Units: []document.SourceEvidenceUnitV1{
+			{Order: 0, Text: "Synthetic evidence", Locator: document.SourceEvidenceLocatorV1{Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginOne, Start: 1, End: 1}},
+			{Order: 1, Text: "Second evidence", Locator: document.SourceEvidenceLocatorV1{Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginOne, Start: 2, End: 2}},
+		},
+	}, policy)
+	if err != nil {
+		panic(err)
+	}
+	binding := profile.Embeddings[0]
+	for _, candidate := range profile.Embeddings {
+		if candidate.Name == "chunk" {
+			binding = candidate
+		}
+	}
+	var attachment *document.AttachmentContextSnapshot
+	if attachmentID != "" {
+		context, contextErr := document.NewAttachmentContextSnapshot("Synthetic title", "Synthetic context")
+		if contextErr != nil {
+			panic(contextErr)
+		}
+		attachment = &context
+	}
+	inputPolicy, err := document.NewInputPolicy(binding, embeddingCatalogTokenizer{}, lexicalFingerprint, attachment)
+	if err != nil {
+		panic(err)
+	}
+	generation, err := document.BuildEmbeddingInputs(evidence, inputPolicy, document.GenerationLimits{
+		MaxInputs: 128, MaxTotalContentTokens: 4096, MaxTotalRenderedTokens: 8192,
+		MaxTotalContentBytes: 1 << 20, MaxTotalRenderedBytes: 2 << 20,
+		MaxFittingWorkTokens: 1 << 20, MaxFittingWorkBytes: 8 << 20,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return generation
+}
+
+func cloneEmbeddingSetRecord(value EmbeddingSetRecord) EmbeddingSetRecord {
+	clone := value
+	clone.InputGeneration.GenerationJSON = append([]byte(nil), value.InputGeneration.GenerationJSON...)
+	clone.InputGeneration.Inputs = append([]EmbeddingInputReference(nil), value.InputGeneration.Inputs...)
+	clone.VectorSet.Payload = append([]byte(nil), value.VectorSet.Payload...)
+	clone.VectorSet.rows = append([]EmbeddingVectorRowRecord(nil), value.VectorSet.rows...)
+	return clone
+}

--- a/internal/store/embedding_catalog_test.go
+++ b/internal/store/embedding_catalog_test.go
@@ -143,6 +143,22 @@ func TestEmbeddingCatalogMetadataRoundTripsDeterministically(t *testing.T) {
 		SetID: chunk.ID, VectorSpaceID: chunk.VectorSpace.ID,
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
+	for _, root := range []CurrentRenditionRoot{
+		{ID: "embedding-roundtrip-set", Kind: RenditionRootRetention,
+			TargetKind: RenditionRootEmbeddingSet, TargetID: chunk.ID,
+			FencingToken: 1, RecordedAt: embeddingCatalogTime},
+		{ID: "embedding-roundtrip-generation", Kind: RenditionRootRetention,
+			TargetKind: RenditionRootEmbeddingGeneration, TargetID: chunk.InputGeneration.ID,
+			FencingToken: 1, RecordedAt: embeddingCatalogTime},
+		{ID: "embedding-roundtrip-vector-set", Kind: RenditionRootRetention,
+			TargetKind: RenditionRootEmbeddingVectorSet, TargetID: chunk.VectorSet.ID,
+			FencingToken: 1, RecordedAt: embeddingCatalogTime},
+		{ID: "embedding-roundtrip-payload", Kind: RenditionRootRetention,
+			TargetKind: RenditionRootEmbeddingPayload, TargetID: chunk.VectorSet.PayloadBlobHash,
+			FencingToken: 1, RecordedAt: embeddingCatalogTime},
+	} {
+		require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+	}
 
 	var first, second bytes.Buffer
 	require.NoError(t, s.ExportMetadata(t.Context(), &first))
@@ -160,6 +176,10 @@ func TestEmbeddingCatalogMetadataRoundTripsDeterministically(t *testing.T) {
 		"optional", document.EmbeddingInputOriginalFile))
 	assert.Equal(t, chunk.ID, embeddingHeadSetIDForTest(t, restored, versionID, profile.Fingerprint,
 		"chunk", document.EmbeddingInputRenditionChunk))
+	var restoredRoots int
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM current_rendition_roots
+		WHERE root_id LIKE 'embedding-roundtrip-%' AND active=1`).Scan(&restoredRoots))
+	assert.Equal(t, 4, restoredRoots)
 }
 
 func TestEmbeddingCatalogDerivativePurgeAndGCLeaveOriginalAuthority(t *testing.T) {

--- a/internal/store/embedding_catalog_test.go
+++ b/internal/store/embedding_catalog_test.go
@@ -341,11 +341,18 @@ func TestEmbeddingCatalogVersionPruneDeletesDirectAndChunkAuthority(t *testing.T
 		records[0].VectorSet.ID, records[1].VectorSet.ID).Scan(&generations, &vectorSets))
 	assert.Equal(t, 2, generations)
 	assert.Equal(t, 2, vectorSets)
+	evidenceHash := testSHA256(records[1].InputGeneration.EvidenceJSON)
+	unreachable, err := s.UnreachableBlobs(t.Context())
+	require.NoError(t, err)
+	for _, blob := range unreachable {
+		assert.NotEqual(t, evidenceHash, blob.Hash, "orphan generation still needs evidence for restore verification")
+	}
 
 	report, err := s.PurgeDerivatives(t.Context(), PurgeRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, 2, report.RemovedEmbeddingInputGenerations)
 	assert.Equal(t, 2, report.RemovedEmbeddingVectorSets)
+	assert.Contains(t, report.PhysicalDerivativeBlobsPendingGC, evidenceHash)
 }
 
 func TestEmbeddingCatalogVersionPrunePreservesSharedAuthorityRoots(t *testing.T) {
@@ -536,7 +543,11 @@ func embeddingSetFixture(
 		CreatedAt: embeddingCatalogTime,
 	}
 	if kind == document.EmbeddingInputRenditionChunk {
-		generated := embeddingCatalogGeneration(profile, fingerprints.EvidenceLexical, attachmentID)
+		generated, evidence := embeddingCatalogGeneration(profile, fingerprints.EvidenceLexical, attachmentID)
+		generation.EvidenceJSON, _, err = document.MarshalNormalizedEvidenceV1(evidence)
+		if err != nil {
+			panic(err)
+		}
 		generation.ID = testSHA256([]byte("embedding-generation-attachment/v1\x00" + generated.Checksum + "\x00" + attachmentID))
 		generation.GenerationJSON, err = document.MarshalEmbeddingInputGeneration(generated)
 		if err != nil {
@@ -546,6 +557,9 @@ func embeddingSetFixture(
 		generation.GenerationEncodedSize = int64(len(generation.GenerationJSON))
 		generation.GenerationChecksum = generated.Checksum
 		if err := s.withStorageTx(context.Background(), func(tx *sql.Tx) error {
+			if err := s.EnsureBlobTx(tx, testSHA256(generation.EvidenceJSON), int64(len(generation.EvidenceJSON))); err != nil {
+				return err
+			}
 			return s.EnsureBlobTx(tx, generation.GenerationBlobHash, generation.GenerationEncodedSize)
 		}); err != nil {
 			panic(err)
@@ -704,7 +718,7 @@ func embeddingCatalogProfile(t *testing.T) ProcessingProfileRecord {
 	}
 }
 
-func embeddingCatalogGeneration(profile document.ProcessingProfileV1, lexicalFingerprint, attachmentID string) document.EmbeddingInputGeneration {
+func embeddingCatalogGeneration(profile document.ProcessingProfileV1, lexicalFingerprint, attachmentID string) (document.EmbeddingInputGeneration, document.NormalizedEvidenceV1) {
 	policy, err := document.NewEvidencePolicy(4096)
 	if err != nil {
 		panic(err)
@@ -746,12 +760,13 @@ func embeddingCatalogGeneration(profile document.ProcessingProfileV1, lexicalFin
 	if err != nil {
 		panic(err)
 	}
-	return generation
+	return generation, evidence
 }
 
 func cloneEmbeddingSetRecord(value EmbeddingSetRecord) EmbeddingSetRecord {
 	clone := value
 	clone.InputGeneration.GenerationJSON = append([]byte(nil), value.InputGeneration.GenerationJSON...)
+	clone.InputGeneration.EvidenceJSON = append([]byte(nil), value.InputGeneration.EvidenceJSON...)
 	clone.InputGeneration.Inputs = append([]EmbeddingInputReference(nil), value.InputGeneration.Inputs...)
 	clone.VectorSet.Payload = append([]byte(nil), value.VectorSet.Payload...)
 	clone.VectorSet.rows = append([]EmbeddingVectorRowRecord(nil), value.VectorSet.rows...)

--- a/internal/store/embedding_catalog_test.go
+++ b/internal/store/embedding_catalog_test.go
@@ -24,13 +24,15 @@ func TestEmbeddingCatalogChunkAndDirectFileHeadsCoexist(t *testing.T) {
 	require.NoError(t, s.StageEmbeddingSet(t.Context(), direct))
 	require.NoError(t, s.StageEmbeddingSet(t.Context(), chunk))
 	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
-		SetID: direct.ID, VectorSpaceID: direct.VectorSpace.ID,
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
+		SetID:        direct.ID, VectorSpaceID: direct.VectorSpace.ID,
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk},
-		SetID: chunk.ID, VectorSpaceID: chunk.VectorSpace.ID,
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk},
+		SetID:        chunk.ID, VectorSpaceID: chunk.VectorSpace.ID,
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 
@@ -103,11 +105,13 @@ func TestEmbeddingCatalogRejectsInvalidRowsAndPublicationFences(t *testing.T) {
 		{"source", func(value *EmbeddingHeadRecord) { value.Key.ContentVersionID = "00000000-0000-4000-8000-000000000176" }, "stale source"},
 		{"profile", func(value *EmbeddingHeadRecord) { value.ProcessingProfileFingerprint = fakeHash("missing-profile") }, "profile fingerprint"},
 		{"space", func(value *EmbeddingHeadRecord) { value.VectorSpaceID = fakeHash("missing-space") }, "vector-space ID"},
+		{"unfenced", func(value *EmbeddingHeadRecord) { value.FencingToken = 0 }, "fencing token"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			head := EmbeddingHeadRecord{
-				Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
-				SetID: base.ID, VectorSpaceID: base.VectorSpace.ID,
+				FencingToken: 1,
+				Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
+				SetID:        base.ID, VectorSpaceID: base.VectorSpace.ID,
 				ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 			}
 			testCase.mutate(&head)
@@ -132,15 +136,17 @@ func TestEmbeddingCatalogMetadataRoundTripsDeterministically(t *testing.T) {
 	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
 	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
 	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
-		SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
+		SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 	chunk := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
 	require.NoError(t, s.StageEmbeddingSet(t.Context(), chunk))
 	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk},
-		SetID: chunk.ID, VectorSpaceID: chunk.VectorSpace.ID,
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk},
+		SetID:        chunk.ID, VectorSpaceID: chunk.VectorSpace.ID,
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 	for _, root := range []CurrentRenditionRoot{
@@ -187,8 +193,9 @@ func TestEmbeddingCatalogDerivativePurgeAndGCLeaveOriginalAuthority(t *testing.T
 	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
 	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
 	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
-		SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "optional", InputKind: document.EmbeddingInputOriginalFile},
+		SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 
@@ -311,8 +318,9 @@ func TestEmbeddingCatalogVersionPruneDeletesDirectAndChunkAuthority(t *testing.T
 	for _, record := range records {
 		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
 		require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-			Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
-			SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+			FencingToken: 1,
+			Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+			SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
 			ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 		}))
 	}

--- a/internal/store/embedding_lifecycle.go
+++ b/internal/store/embedding_lifecycle.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+type embeddingOrphanCollection struct {
+	inputGenerations int
+	vectorSets       int
+	payloads         []string
+}
+
+// collectOrphanEmbeddingArtifactsTx is the shared terminal collection path
+// for explicit purge and ordinary derivative GC. Sets own membership; active
+// roots can retain either immutable artifact independently.
+func collectOrphanEmbeddingArtifactsTx(
+	ctx context.Context, tx *sql.Tx, asOf string,
+) (_ embeddingOrphanCollection, retErr error) {
+	var result embeddingOrphanCollection
+	generationRows, err := tx.QueryContext(ctx, `DELETE FROM embedding_input_generations AS g
+		WHERE NOT EXISTS (
+			SELECT 1 FROM embedding_sets s WHERE s.input_generation_id=g.generation_id
+		) AND NOT EXISTS (
+			SELECT 1 FROM current_rendition_roots r
+			WHERE r.target_kind='embedding_input_generation' AND r.target_id=g.generation_id
+			  AND r.active=1 AND (r.expires_at IS NULL OR r.expires_at>?)
+		) RETURNING COALESCE(generation_blob_hash,'')`, asOf)
+	if err != nil {
+		return result, fmt.Errorf("collecting orphan embedding input generations: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, generationRows.Close()) }()
+	for generationRows.Next() {
+		var blobHash string
+		if err := generationRows.Scan(&blobHash); err != nil {
+			return result, fmt.Errorf("scanning collected embedding input generation: %w", err)
+		}
+		result.inputGenerations++
+		if blobHash != "" {
+			result.payloads = append(result.payloads, blobHash)
+		}
+	}
+	if err := generationRows.Err(); err != nil {
+		return result, fmt.Errorf("collecting orphan embedding input generations: %w", err)
+	}
+	if err := generationRows.Close(); err != nil {
+		return result, fmt.Errorf("closing collected embedding input generations: %w", err)
+	}
+
+	vectorRows, err := tx.QueryContext(ctx, `DELETE FROM embedding_vector_sets AS v
+		WHERE NOT EXISTS (
+			SELECT 1 FROM embedding_sets s WHERE s.vector_set_id=v.vector_set_id
+		) AND NOT EXISTS (
+			SELECT 1 FROM current_rendition_roots r
+			WHERE r.active=1 AND (r.expires_at IS NULL OR r.expires_at>?) AND (
+				(r.target_kind='embedding_vector_set' AND r.target_id=v.vector_set_id) OR
+				(r.target_kind='embedding_payload' AND r.target_id=v.payload_blob_hash)
+			)
+		) RETURNING payload_blob_hash`, asOf)
+	if err != nil {
+		return result, fmt.Errorf("collecting orphan embedding vector sets: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, vectorRows.Close()) }()
+	for vectorRows.Next() {
+		var payloadHash string
+		if err := vectorRows.Scan(&payloadHash); err != nil {
+			return result, fmt.Errorf("scanning collected embedding vector set: %w", err)
+		}
+		result.vectorSets++
+		result.payloads = append(result.payloads, payloadHash)
+	}
+	if err := vectorRows.Err(); err != nil {
+		return result, fmt.Errorf("collecting orphan embedding vector sets: %w", err)
+	}
+	if err := vectorRows.Close(); err != nil {
+		return result, fmt.Errorf("closing collected embedding vector sets: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_vector_spaces AS v
+		WHERE NOT EXISTS (SELECT 1 FROM embedding_sets s WHERE s.vector_space_id=v.vector_space_id)
+		  AND NOT EXISTS (SELECT 1 FROM embedding_vector_sets s WHERE s.vector_space_id=v.vector_space_id)`); err != nil {
+		return result, fmt.Errorf("collecting orphan embedding vector spaces: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM current_rendition_roots
+		WHERE (target_kind='embedding_input_generation' AND NOT EXISTS (
+			SELECT 1 FROM embedding_input_generations g WHERE g.generation_id=target_id
+		)) OR (target_kind='embedding_vector_set' AND NOT EXISTS (
+			SELECT 1 FROM embedding_vector_sets v WHERE v.vector_set_id=target_id
+		)) OR (target_kind='embedding_payload' AND NOT EXISTS (
+			SELECT 1 FROM embedding_vector_sets v WHERE v.payload_blob_hash=target_id
+		))`); err != nil {
+		return result, fmt.Errorf("removing collected embedding roots: %w", err)
+	}
+	return result, nil
+}

--- a/internal/store/embedding_lifecycle.go
+++ b/internal/store/embedding_lifecycle.go
@@ -27,19 +27,19 @@ func collectOrphanEmbeddingArtifactsTx(
 			SELECT 1 FROM current_rendition_roots r
 			WHERE r.target_kind='embedding_input_generation' AND r.target_id=g.generation_id
 			  AND r.active=1 AND (r.expires_at IS NULL OR r.expires_at>?)
-		) RETURNING COALESCE(generation_blob_hash,'')`, asOf)
+		) RETURNING COALESCE(generation_blob_hash,''),evidence_fingerprint`, asOf)
 	if err != nil {
 		return result, fmt.Errorf("collecting orphan embedding input generations: %w", err)
 	}
 	defer func() { retErr = errors.Join(retErr, generationRows.Close()) }()
 	for generationRows.Next() {
-		var blobHash string
-		if err := generationRows.Scan(&blobHash); err != nil {
+		var blobHash, evidenceHash string
+		if err := generationRows.Scan(&blobHash, &evidenceHash); err != nil {
 			return result, fmt.Errorf("scanning collected embedding input generation: %w", err)
 		}
 		result.inputGenerations++
 		if blobHash != "" {
-			result.payloads = append(result.payloads, blobHash)
+			result.payloads = append(result.payloads, blobHash, evidenceHash)
 		}
 	}
 	if err := generationRows.Err(); err != nil {

--- a/internal/store/embedding_metadata.go
+++ b/internal/store/embedding_metadata.go
@@ -443,7 +443,57 @@ func isEmbeddingMetadataType(kind string) bool {
 	return ok
 }
 
-func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) error {
+func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (retErr error) {
+	headRows, err := tx.QueryContext(ctx, `SELECT content_version_id,binding_id,input_kind,
+		embedding_set_id,vector_space_id,profile_fingerprint,published_at
+		FROM embedding_heads ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
+	if err != nil {
+		return fmt.Errorf("listing embedding heads for validation: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, headRows.Close()) }()
+	for headRows.Next() {
+		var record EmbeddingHeadRecord
+		if err := headRows.Scan(&record.Key.ContentVersionID, &record.Key.BindingID,
+			&record.Key.InputKind, &record.SetID, &record.VectorSpaceID,
+			&record.ProcessingProfileFingerprint, &record.PublishedAt); err != nil {
+			return fmt.Errorf("reading embedding head for validation: %w", err)
+		}
+		if err := validateEmbeddingHeadRecord(record); err != nil {
+			return fmt.Errorf("validating embedding head: %w", err)
+		}
+	}
+	if err := headRows.Err(); err != nil {
+		return fmt.Errorf("iterating embedding heads for validation: %w", err)
+	}
+	if err := headRows.Close(); err != nil {
+		return fmt.Errorf("closing embedding heads after validation: %w", err)
+	}
+
+	failureRows, err := tx.QueryContext(ctx, `SELECT content_version_id,profile_fingerprint,
+		binding_id,input_kind,failure_code,failed_at
+		FROM embedding_failures ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
+	if err != nil {
+		return fmt.Errorf("listing embedding failures for validation: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, failureRows.Close()) }()
+	for failureRows.Next() {
+		var record EmbeddingFailureRecord
+		if err := failureRows.Scan(&record.ContentVersionID,
+			&record.ProcessingProfileFingerprint, &record.BindingID, &record.InputKind,
+			&record.FailureCode, &record.FailedAt); err != nil {
+			return fmt.Errorf("reading embedding failure for validation: %w", err)
+		}
+		if err := validateEmbeddingFailureRecord(record); err != nil {
+			return fmt.Errorf("validating embedding failure: %w", err)
+		}
+	}
+	if err := failureRows.Err(); err != nil {
+		return fmt.Errorf("iterating embedding failures for validation: %w", err)
+	}
+	if err := failureRows.Close(); err != nil {
+		return fmt.Errorf("closing embedding failures after validation: %w", err)
+	}
+
 	var invalid int
 	if err := tx.QueryRowContext(ctx, `SELECT
 		(SELECT COUNT(*) FROM embedding_input_generations g WHERE g.input_count !=

--- a/internal/store/embedding_metadata.go
+++ b/internal/store/embedding_metadata.go
@@ -115,6 +115,7 @@ type metadataEmbeddingHead struct {
 	VectorSpaceID      string             `json:"vector_space_id"`
 	ProfileFingerprint string             `json:"profile_fingerprint"`
 	PublishedAt        string             `json:"published_at"`
+	FencingToken       int64              `json:"fencing_token"`
 }
 
 type metadataEmbeddingFailure struct {
@@ -134,7 +135,7 @@ var embeddingMetadataRequiredFields = map[string][]string{
 	metadataEmbeddingVectorSetType:   {metadataTypeField, "vector_set_id", "contract_version", metadataEmbeddingVectorSpaceIDField, "payload_blob_hash", "payload_size", "payload_checksum", "manifest_checksum", "row_count", "dimensions"},
 	metadataEmbeddingVectorRowType:   {metadataTypeField, "vector_set_id", "row_id", "order", "input_id", "dimensions", "checksum"},
 	metadataEmbeddingSetType:         {metadataTypeField, "embedding_set_id", auditVaultIDField, "binding_id", "input_kind", metadataContentVersionIDField, metadataEmbeddingProfileField, "embedding_input_fingerprint", metadataEmbeddingVectorSpaceIDField, metadataGenerationIDField, "vector_set_id", metadataCreatedAtField},
-	metadataEmbeddingHeadType:        {metadataTypeField, metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at"},
+	metadataEmbeddingHeadType:        {metadataTypeField, metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at", "fencing_token"},
 	metadataEmbeddingFailureType:     {metadataTypeField, metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at"},
 }
 
@@ -292,7 +293,7 @@ func exportEmbeddingSets(ctx context.Context, tx metadataQuerier, write metadata
 
 func exportEmbeddingHeads(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `SELECT content_version_id,binding_id,input_kind,
-		embedding_set_id,vector_space_id,profile_fingerprint,published_at
+		embedding_set_id,vector_space_id,profile_fingerprint,published_at,fencing_token
 		FROM embedding_heads ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
 	if err != nil {
 		return err
@@ -301,7 +302,7 @@ func exportEmbeddingHeads(ctx context.Context, tx metadataQuerier, write metadat
 	for rows.Next() {
 		value := metadataEmbeddingHead{Type: metadataEmbeddingHeadType}
 		if err := rows.Scan(&value.ContentVersionID, &value.BindingID, &value.InputKind,
-			&value.SetID, &value.VectorSpaceID, &value.ProfileFingerprint, &value.PublishedAt); err != nil {
+			&value.SetID, &value.VectorSpaceID, &value.ProfileFingerprint, &value.PublishedAt, &value.FencingToken); err != nil {
 			return err
 		}
 		if err := write(value); err != nil {
@@ -418,7 +419,7 @@ func importEmbeddingMetadataRecord(ctx context.Context, tx *sql.Tx, kind string,
 		if err := validateMetadataTime("embedding head published_at", value.PublishedAt); err != nil {
 			return err
 		}
-		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_heads VALUES(?,?,?,?,?,?,?)`, value.ContentVersionID, value.BindingID, value.InputKind, value.SetID, value.VectorSpaceID, value.ProfileFingerprint, value.PublishedAt)
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_heads VALUES(?,?,?,?,?,?,?,?)`, value.ContentVersionID, value.BindingID, value.InputKind, value.SetID, value.VectorSpaceID, value.ProfileFingerprint, value.PublishedAt, value.FencingToken)
 	case metadataEmbeddingFailureType:
 		var value metadataEmbeddingFailure
 		if err := decodeMetadataRecord(raw, &value); err != nil {
@@ -445,7 +446,7 @@ func isEmbeddingMetadataType(kind string) bool {
 
 func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (retErr error) {
 	headRows, err := tx.QueryContext(ctx, `SELECT content_version_id,binding_id,input_kind,
-		embedding_set_id,vector_space_id,profile_fingerprint,published_at
+		embedding_set_id,vector_space_id,profile_fingerprint,published_at,fencing_token
 		FROM embedding_heads ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
 	if err != nil {
 		return fmt.Errorf("listing embedding heads for validation: %w", err)
@@ -455,11 +456,22 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 		var record EmbeddingHeadRecord
 		if err := headRows.Scan(&record.Key.ContentVersionID, &record.Key.BindingID,
 			&record.Key.InputKind, &record.SetID, &record.VectorSpaceID,
-			&record.ProcessingProfileFingerprint, &record.PublishedAt); err != nil {
+			&record.ProcessingProfileFingerprint, &record.PublishedAt, &record.FencingToken); err != nil {
 			return fmt.Errorf("reading embedding head for validation: %w", err)
 		}
 		if err := validateEmbeddingHeadRecord(record); err != nil {
 			return fmt.Errorf("validating embedding head: %w", err)
+		}
+		set, err := loadEmbeddingSetTx(ctx, tx, record.SetID)
+		if err != nil {
+			return err
+		}
+		eligible, err := embeddingAttachmentEligible(ctx, tx, set)
+		if err != nil {
+			return err
+		}
+		if !eligible {
+			return errors.New("embedding head attachment is not current")
 		}
 	}
 	if err := headRows.Err(); err != nil {

--- a/internal/store/embedding_metadata.go
+++ b/internal/store/embedding_metadata.go
@@ -127,6 +127,7 @@ type metadataEmbeddingFailure struct {
 	FailureCode        EmbeddingFailureCode `json:"failure_code"`
 	FailedAt           string               `json:"failed_at"`
 	FencingToken       int64                `json:"fencing_token"`
+	AttachmentID       string               `json:"attachment_id"`
 }
 
 var embeddingMetadataRequiredFields = map[string][]string{
@@ -137,7 +138,7 @@ var embeddingMetadataRequiredFields = map[string][]string{
 	metadataEmbeddingVectorRowType:   {metadataTypeField, "vector_set_id", "row_id", "order", "input_id", "dimensions", "checksum"},
 	metadataEmbeddingSetType:         {metadataTypeField, "embedding_set_id", auditVaultIDField, "binding_id", "input_kind", metadataContentVersionIDField, metadataEmbeddingProfileField, "embedding_input_fingerprint", metadataEmbeddingVectorSpaceIDField, metadataGenerationIDField, "vector_set_id", metadataCreatedAtField},
 	metadataEmbeddingHeadType:        {metadataTypeField, metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at", "fencing_token"},
-	metadataEmbeddingFailureType:     {metadataTypeField, metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at", "fencing_token"},
+	metadataEmbeddingFailureType:     {metadataTypeField, metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at", "fencing_token", "attachment_id"},
 }
 
 func exportEmbeddingMetadata(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
@@ -315,7 +316,7 @@ func exportEmbeddingHeads(ctx context.Context, tx metadataQuerier, write metadat
 
 func exportEmbeddingFailures(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `SELECT content_version_id,profile_fingerprint,binding_id,
-		input_kind,failure_code,failed_at,fencing_token FROM embedding_failures
+		input_kind,failure_code,failed_at,fencing_token,attachment_id FROM embedding_failures
 		ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
 	if err != nil {
 		return err
@@ -324,7 +325,7 @@ func exportEmbeddingFailures(ctx context.Context, tx metadataQuerier, write meta
 	for rows.Next() {
 		value := metadataEmbeddingFailure{Type: metadataEmbeddingFailureType}
 		if err := rows.Scan(&value.ContentVersionID, &value.ProfileFingerprint, &value.BindingID,
-			&value.InputKind, &value.FailureCode, &value.FailedAt, &value.FencingToken); err != nil {
+			&value.InputKind, &value.FailureCode, &value.FailedAt, &value.FencingToken, &value.AttachmentID); err != nil {
 			return err
 		}
 		if err := write(value); err != nil {
@@ -429,7 +430,7 @@ func importEmbeddingMetadataRecord(ctx context.Context, tx *sql.Tx, kind string,
 		if err := validateMetadataTime("embedding failure failed_at", value.FailedAt); err != nil {
 			return err
 		}
-		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_failures VALUES(?,?,?,?,?,?,?)`, value.ContentVersionID, value.ProfileFingerprint, value.BindingID, value.InputKind, value.FailureCode, value.FailedAt, value.FencingToken)
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_failures VALUES(?,?,?,?,?,?,?,?)`, value.ContentVersionID, value.ProfileFingerprint, value.BindingID, value.InputKind, value.FailureCode, value.FailedAt, value.FencingToken, value.AttachmentID)
 	default:
 		return fmt.Errorf("unknown embedding metadata type %q", kind)
 	}
@@ -467,7 +468,8 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 		if err != nil {
 			return err
 		}
-		eligible, err := embeddingAttachmentEligible(ctx, tx, set)
+		eligible, err := embeddingAttachmentEligible(ctx, tx, set.ContentVersionID,
+			set.ProcessingProfileFingerprint, set.InputGeneration.AttachmentID)
 		if err != nil {
 			return err
 		}
@@ -483,7 +485,7 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 	}
 
 	failureRows, err := tx.QueryContext(ctx, `SELECT content_version_id,profile_fingerprint,
-		binding_id,input_kind,failure_code,failed_at,fencing_token
+		binding_id,input_kind,failure_code,failed_at,fencing_token,attachment_id
 		FROM embedding_failures ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
 	if err != nil {
 		return fmt.Errorf("listing embedding failures for validation: %w", err)
@@ -494,7 +496,7 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 		var record EmbeddingFailureRecord
 		if err := failureRows.Scan(&record.ContentVersionID,
 			&record.ProcessingProfileFingerprint, &record.BindingID, &record.InputKind,
-			&record.FailureCode, &record.FailedAt, &record.FencingToken); err != nil {
+			&record.FailureCode, &record.FailedAt, &record.FencingToken, &record.AttachmentID); err != nil {
 			return fmt.Errorf("reading embedding failure for validation: %w", err)
 		}
 		if err := validateEmbeddingFailureRecord(record); err != nil {
@@ -512,8 +514,8 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 		if err := validateEmbeddingFailureBinding(ctx, tx, record); err != nil {
 			return fmt.Errorf("validating embedding failure profile binding: %w", err)
 		}
-		if err := validateEmbeddingFailureHeadFence(ctx, tx, record); err != nil {
-			return fmt.Errorf("validating embedding failure head fence: %w", err)
+		if err := validateEmbeddingFailureEligibility(ctx, tx, record); err != nil {
+			return fmt.Errorf("validating embedding failure eligibility: %w", err)
 		}
 	}
 

--- a/internal/store/embedding_metadata.go
+++ b/internal/store/embedding_metadata.go
@@ -1,0 +1,574 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json/jsontext"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"go.kenn.io/docbank/document"
+)
+
+const (
+	metadataEmbeddingVectorSpaceType    = "embedding_vector_space"
+	metadataEmbeddingGenerationType     = "embedding_input_generation"
+	metadataEmbeddingInputType          = "embedding_generation_input"
+	metadataEmbeddingVectorSetType      = "embedding_vector_set"
+	metadataEmbeddingVectorRowType      = "embedding_vector_row"
+	metadataEmbeddingSetType            = "embedding_set"
+	metadataEmbeddingHeadType           = "embedding_head"
+	metadataEmbeddingFailureType        = "embedding_failure"
+	metadataEmbeddingVectorSpaceIDField = "vector_space_id"
+	metadataEmbeddingProfileField       = "profile_fingerprint"
+)
+
+type metadataEmbeddingVectorSpace struct {
+	Type                  string `json:"type"`
+	ID                    string `json:"vector_space_id"`
+	ContractVersion       string `json:"contract_version"`
+	DescriptorJSON        []byte `json:"descriptor_json"`
+	ProviderDescriptor    string `json:"provider_descriptor"`
+	ProviderRevision      string `json:"provider_revision"`
+	DescriptorFingerprint string `json:"descriptor_fingerprint"`
+	CompatibilityID       string `json:"compatibility_id"`
+	Dimensions            int    `json:"dimensions"`
+	Metric                string `json:"metric"`
+	Normalization         string `json:"normalization"`
+	ScalarEncoding        string `json:"scalar_encoding"`
+	DocumentFormatter     string `json:"document_formatter"`
+	QueryFormatter        string `json:"query_formatter"`
+	ModelInputFingerprint string `json:"model_input_fingerprint"`
+}
+
+type metadataEmbeddingGeneration struct {
+	Type                         string  `json:"type"`
+	ID                           string  `json:"generation_id"`
+	GenerationBlobHash           string  `json:"generation_blob_hash"`
+	GenerationEncodedSize        int64   `json:"generation_encoded_size"`
+	GenerationChecksum           string  `json:"generation_checksum"`
+	SourceVersionID              string  `json:"source_version_id"`
+	ProfileFingerprint           string  `json:"profile_fingerprint"`
+	EvidenceFingerprint          string  `json:"evidence_fingerprint"`
+	TokenizerFingerprint         string  `json:"tokenizer_fingerprint"`
+	ChunkPolicyFingerprint       string  `json:"chunk_policy_fingerprint"`
+	FormatterFingerprint         string  `json:"formatter_fingerprint"`
+	AttachmentContextFingerprint string  `json:"attachment_context_fingerprint"`
+	AttachmentID                 *string `json:"attachment_id"`
+	InputCount                   int     `json:"input_count"`
+	CreatedAt                    string  `json:"created_at"`
+}
+
+type metadataEmbeddingInput struct {
+	Type             string `json:"type"`
+	GenerationID     string `json:"generation_id"`
+	InputID          string `json:"input_id"`
+	Order            int    `json:"order"`
+	RenderedChecksum string `json:"rendered_checksum"`
+}
+
+type metadataEmbeddingVectorSet struct {
+	Type             string `json:"type"`
+	ID               string `json:"vector_set_id"`
+	ContractVersion  string `json:"contract_version"`
+	VectorSpaceID    string `json:"vector_space_id"`
+	PayloadBlobHash  string `json:"payload_blob_hash"`
+	PayloadSize      int64  `json:"payload_size"`
+	PayloadChecksum  string `json:"payload_checksum"`
+	ManifestChecksum string `json:"manifest_checksum"`
+	RowCount         int    `json:"row_count"`
+	Dimensions       int    `json:"dimensions"`
+}
+
+type metadataEmbeddingVectorRow struct {
+	Type        string `json:"type"`
+	VectorSetID string `json:"vector_set_id"`
+	RowID       string `json:"row_id"`
+	Order       int    `json:"order"`
+	InputID     string `json:"input_id"`
+	Dimensions  int    `json:"dimensions"`
+	Checksum    string `json:"checksum"`
+}
+
+type metadataEmbeddingSet struct {
+	Type               string             `json:"type"`
+	ID                 string             `json:"embedding_set_id"`
+	VaultID            string             `json:"vault_id"`
+	BindingID          string             `json:"binding_id"`
+	InputKind          EmbeddingInputKind `json:"input_kind"`
+	ContentVersionID   string             `json:"content_version_id"`
+	ProfileFingerprint string             `json:"profile_fingerprint"`
+	InputFingerprint   string             `json:"embedding_input_fingerprint"`
+	VectorSpaceID      string             `json:"vector_space_id"`
+	GenerationID       string             `json:"generation_id"`
+	VectorSetID        string             `json:"vector_set_id"`
+	CreatedAt          string             `json:"created_at"`
+}
+
+type metadataEmbeddingHead struct {
+	Type               string             `json:"type"`
+	ContentVersionID   string             `json:"content_version_id"`
+	BindingID          string             `json:"binding_id"`
+	InputKind          EmbeddingInputKind `json:"input_kind"`
+	SetID              string             `json:"embedding_set_id"`
+	VectorSpaceID      string             `json:"vector_space_id"`
+	ProfileFingerprint string             `json:"profile_fingerprint"`
+	PublishedAt        string             `json:"published_at"`
+}
+
+type metadataEmbeddingFailure struct {
+	Type               string               `json:"type"`
+	ContentVersionID   string               `json:"content_version_id"`
+	ProfileFingerprint string               `json:"profile_fingerprint"`
+	BindingID          string               `json:"binding_id"`
+	InputKind          EmbeddingInputKind   `json:"input_kind"`
+	FailureCode        EmbeddingFailureCode `json:"failure_code"`
+	FailedAt           string               `json:"failed_at"`
+}
+
+var embeddingMetadataRequiredFields = map[string][]string{
+	metadataEmbeddingVectorSpaceType: {metadataTypeField, metadataEmbeddingVectorSpaceIDField, "contract_version", "descriptor_json", "provider_descriptor", "provider_revision", "descriptor_fingerprint", "compatibility_id", "dimensions", "metric", "normalization", "scalar_encoding", "document_formatter", "query_formatter", "model_input_fingerprint"},
+	metadataEmbeddingGenerationType:  {metadataTypeField, metadataGenerationIDField, "generation_blob_hash", "generation_encoded_size", "generation_checksum", auditSourceVersionIDField, metadataEmbeddingProfileField, "evidence_fingerprint", "tokenizer_fingerprint", "chunk_policy_fingerprint", "formatter_fingerprint", "attachment_context_fingerprint", "attachment_id", "input_count", metadataCreatedAtField},
+	metadataEmbeddingInputType:       {metadataTypeField, metadataGenerationIDField, "input_id", "order", "rendered_checksum"},
+	metadataEmbeddingVectorSetType:   {metadataTypeField, "vector_set_id", "contract_version", metadataEmbeddingVectorSpaceIDField, "payload_blob_hash", "payload_size", "payload_checksum", "manifest_checksum", "row_count", "dimensions"},
+	metadataEmbeddingVectorRowType:   {metadataTypeField, "vector_set_id", "row_id", "order", "input_id", "dimensions", "checksum"},
+	metadataEmbeddingSetType:         {metadataTypeField, "embedding_set_id", auditVaultIDField, "binding_id", "input_kind", metadataContentVersionIDField, metadataEmbeddingProfileField, "embedding_input_fingerprint", metadataEmbeddingVectorSpaceIDField, metadataGenerationIDField, "vector_set_id", metadataCreatedAtField},
+	metadataEmbeddingHeadType:        {metadataTypeField, metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at"},
+	metadataEmbeddingFailureType:     {metadataTypeField, metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at"},
+}
+
+func exportEmbeddingMetadata(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	exports := []func(context.Context, metadataQuerier, metadataWrite) error{
+		exportEmbeddingVectorSpaces, exportEmbeddingGenerations, exportEmbeddingInputs,
+		exportEmbeddingVectorSets, exportEmbeddingVectorRows, exportEmbeddingSets,
+		exportEmbeddingHeads, exportEmbeddingFailures,
+	}
+	for _, export := range exports {
+		if err := export(ctx, tx, write); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func exportEmbeddingVectorSpaces(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT vector_space_id,contract_version,descriptor_json,provider_descriptor,
+		provider_revision,descriptor_fingerprint,compatibility_id,dimensions,metric,
+		normalization,scalar_encoding,document_formatter,query_formatter,model_input_fingerprint
+		FROM embedding_vector_spaces ORDER BY vector_space_id`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataEmbeddingVectorSpace{Type: metadataEmbeddingVectorSpaceType}
+		if err := rows.Scan(&value.ID, &value.ContractVersion, &value.DescriptorJSON, &value.ProviderDescriptor,
+			&value.ProviderRevision, &value.DescriptorFingerprint, &value.CompatibilityID,
+			&value.Dimensions, &value.Metric, &value.Normalization, &value.ScalarEncoding,
+			&value.DocumentFormatter, &value.QueryFormatter, &value.ModelInputFingerprint); err != nil {
+			return err
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func exportEmbeddingGenerations(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT generation_id,generation_blob_hash,generation_encoded_size,generation_checksum,source_version_id,
+		profile_fingerprint,evidence_fingerprint,tokenizer_fingerprint,chunk_policy_fingerprint,
+		formatter_fingerprint,attachment_context_fingerprint,attachment_id,
+		input_count,created_at FROM embedding_input_generations ORDER BY generation_id`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataEmbeddingGeneration{Type: metadataEmbeddingGenerationType}
+		var generationBlob sql.NullString
+		var attachment sql.NullString
+		if err := rows.Scan(&value.ID, &generationBlob, &value.GenerationEncodedSize, &value.GenerationChecksum, &value.SourceVersionID,
+			&value.ProfileFingerprint, &value.EvidenceFingerprint, &value.TokenizerFingerprint,
+			&value.ChunkPolicyFingerprint, &value.FormatterFingerprint,
+			&value.AttachmentContextFingerprint, &attachment,
+			&value.InputCount, &value.CreatedAt); err != nil {
+			return err
+		}
+		if attachment.Valid {
+			value.AttachmentID = &attachment.String
+		}
+		if generationBlob.Valid {
+			value.GenerationBlobHash = generationBlob.String
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func exportEmbeddingInputs(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT generation_id,input_id,input_order,rendered_checksum
+		FROM embedding_generation_inputs ORDER BY generation_id,input_order`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataEmbeddingInput{Type: metadataEmbeddingInputType}
+		if err := rows.Scan(&value.GenerationID, &value.InputID, &value.Order, &value.RenderedChecksum); err != nil {
+			return err
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func exportEmbeddingVectorSets(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT vector_set_id,contract_version,vector_space_id,payload_blob_hash,
+		payload_size,payload_checksum,manifest_checksum,row_count,dimensions FROM embedding_vector_sets ORDER BY vector_set_id`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataEmbeddingVectorSet{Type: metadataEmbeddingVectorSetType}
+		if err := rows.Scan(&value.ID, &value.ContractVersion, &value.VectorSpaceID, &value.PayloadBlobHash, &value.PayloadSize,
+			&value.PayloadChecksum, &value.ManifestChecksum, &value.RowCount, &value.Dimensions); err != nil {
+			return err
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func exportEmbeddingVectorRows(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT vector_set_id,row_id,row_order,input_id,dimensions,checksum
+		FROM embedding_vector_rows ORDER BY vector_set_id,row_order`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataEmbeddingVectorRow{Type: metadataEmbeddingVectorRowType}
+		if err := rows.Scan(&value.VectorSetID, &value.RowID, &value.Order, &value.InputID,
+			&value.Dimensions, &value.Checksum); err != nil {
+			return err
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func exportEmbeddingSets(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT embedding_set_id,vault_uid,binding_id,input_kind,
+		content_version_id,profile_fingerprint,embedding_input_fingerprint,vector_space_id,input_generation_id,
+		vector_set_id,created_at FROM embedding_sets ORDER BY embedding_set_id`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataEmbeddingSet{Type: metadataEmbeddingSetType}
+		if err := rows.Scan(&value.ID, &value.VaultID, &value.BindingID, &value.InputKind,
+			&value.ContentVersionID, &value.ProfileFingerprint, &value.InputFingerprint, &value.VectorSpaceID,
+			&value.GenerationID, &value.VectorSetID, &value.CreatedAt); err != nil {
+			return err
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func exportEmbeddingHeads(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT content_version_id,binding_id,input_kind,
+		embedding_set_id,vector_space_id,profile_fingerprint,published_at
+		FROM embedding_heads ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataEmbeddingHead{Type: metadataEmbeddingHeadType}
+		if err := rows.Scan(&value.ContentVersionID, &value.BindingID, &value.InputKind,
+			&value.SetID, &value.VectorSpaceID, &value.ProfileFingerprint, &value.PublishedAt); err != nil {
+			return err
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func exportEmbeddingFailures(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	rows, err := tx.QueryContext(ctx, `SELECT content_version_id,profile_fingerprint,binding_id,
+		input_kind,failure_code,failed_at FROM embedding_failures
+		ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value := metadataEmbeddingFailure{Type: metadataEmbeddingFailureType}
+		if err := rows.Scan(&value.ContentVersionID, &value.ProfileFingerprint, &value.BindingID,
+			&value.InputKind, &value.FailureCode, &value.FailedAt); err != nil {
+			return err
+		}
+		if err := write(value); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func importEmbeddingMetadataRecord(ctx context.Context, tx *sql.Tx, kind string, raw jsontext.Value) error {
+	switch kind {
+	case metadataEmbeddingVectorSpaceType:
+		var value metadataEmbeddingVectorSpace
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if _, err := decodeCanonicalEmbeddingDescriptor(value.DescriptorJSON); err != nil {
+			return err
+		}
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_vector_spaces(
+			vector_space_id,contract_version,descriptor_json,provider_descriptor,provider_revision,
+			descriptor_fingerprint,compatibility_id,dimensions,metric,normalization,scalar_encoding,
+			document_formatter,query_formatter,model_input_fingerprint) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, value.ID, value.ContractVersion, value.DescriptorJSON, value.ProviderDescriptor, value.ProviderRevision, value.DescriptorFingerprint, value.CompatibilityID, value.Dimensions, value.Metric, value.Normalization, value.ScalarEncoding, value.DocumentFormatter, value.QueryFormatter, value.ModelInputFingerprint)
+	case metadataEmbeddingGenerationType:
+		var value metadataEmbeddingGeneration
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if value.InputCount < 1 || value.InputCount > maxEmbeddingCatalogRows {
+			return errors.New("embedding input count exceeds bounds")
+		}
+		if (value.GenerationBlobHash == "") != (value.GenerationEncodedSize == 0) ||
+			value.GenerationEncodedSize < 0 || value.GenerationEncodedSize > 64<<20 {
+			return errors.New("embedding generation artifact reference exceeds bounds")
+		}
+		if err := validateMetadataTime("input-generation created_at", value.CreatedAt); err != nil {
+			return err
+		}
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_input_generations(
+			generation_id,generation_blob_hash,generation_encoded_size,generation_checksum,source_version_id,profile_fingerprint,evidence_fingerprint,
+			tokenizer_fingerprint,chunk_policy_fingerprint,formatter_fingerprint,
+			attachment_context_fingerprint,attachment_id,input_count,created_at)
+			VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, value.ID, nullableCatalogString(value.GenerationBlobHash), value.GenerationEncodedSize, value.GenerationChecksum, value.SourceVersionID, value.ProfileFingerprint, value.EvidenceFingerprint, value.TokenizerFingerprint, value.ChunkPolicyFingerprint, value.FormatterFingerprint, value.AttachmentContextFingerprint, value.AttachmentID, value.InputCount, value.CreatedAt)
+	case metadataEmbeddingInputType:
+		var value metadataEmbeddingInput
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if value.Order < 0 || value.Order >= maxEmbeddingCatalogRows {
+			return errors.New("embedding input order exceeds bounds")
+		}
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_generation_inputs VALUES(?,?,?,?)`, value.GenerationID, value.InputID, value.Order, value.RenderedChecksum)
+	case metadataEmbeddingVectorSetType:
+		var value metadataEmbeddingVectorSet
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if value.RowCount < 1 || value.RowCount > maxEmbeddingCatalogRows {
+			return errors.New("embedding vector row count exceeds bounds")
+		}
+		if value.PayloadSize < 1 || value.PayloadSize > 64<<20 {
+			return errors.New("embedding vector payload size exceeds bounds")
+		}
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_vector_sets(
+			vector_set_id,contract_version,vector_space_id,payload_blob_hash,payload_size,payload_checksum,
+			manifest_checksum,row_count,dimensions) VALUES(?,?,?,?,?,?,?,?,?)`, value.ID, value.ContractVersion, value.VectorSpaceID, value.PayloadBlobHash, value.PayloadSize, value.PayloadChecksum, value.ManifestChecksum, value.RowCount, value.Dimensions)
+	case metadataEmbeddingVectorRowType:
+		var value metadataEmbeddingVectorRow
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if value.Order < 0 || value.Order >= maxEmbeddingCatalogRows {
+			return errors.New("embedding vector row order exceeds bounds")
+		}
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_vector_rows VALUES(?,?,?,?,?,?)`, value.VectorSetID, value.RowID, value.Order, value.InputID, value.Dimensions, value.Checksum)
+	case metadataEmbeddingSetType:
+		var value metadataEmbeddingSet
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if err := validateMetadataTime("embedding set created_at", value.CreatedAt); err != nil {
+			return err
+		}
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_sets(
+			embedding_set_id,vault_uid,binding_id,input_kind,content_version_id,profile_fingerprint,
+			embedding_input_fingerprint,vector_space_id,input_generation_id,vector_set_id,created_at)
+			VALUES(?,?,?,?,?,?,?,?,?,?,?)`, value.ID, value.VaultID, value.BindingID, value.InputKind, value.ContentVersionID, value.ProfileFingerprint, value.InputFingerprint, value.VectorSpaceID, value.GenerationID, value.VectorSetID, value.CreatedAt)
+	case metadataEmbeddingHeadType:
+		var value metadataEmbeddingHead
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if err := validateMetadataTime("embedding head published_at", value.PublishedAt); err != nil {
+			return err
+		}
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_heads VALUES(?,?,?,?,?,?,?)`, value.ContentVersionID, value.BindingID, value.InputKind, value.SetID, value.VectorSpaceID, value.ProfileFingerprint, value.PublishedAt)
+	case metadataEmbeddingFailureType:
+		var value metadataEmbeddingFailure
+		if err := decodeMetadataRecord(raw, &value); err != nil {
+			return err
+		}
+		if err := validateMetadataTime("embedding failure failed_at", value.FailedAt); err != nil {
+			return err
+		}
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_failures VALUES(?,?,?,?,?,?)`, value.ContentVersionID, value.ProfileFingerprint, value.BindingID, value.InputKind, value.FailureCode, value.FailedAt)
+	default:
+		return fmt.Errorf("unknown embedding metadata type %q", kind)
+	}
+}
+
+func execEmbeddingImport(ctx context.Context, tx *sql.Tx, query string, args ...any) error {
+	_, err := tx.ExecContext(ctx, query, args...)
+	return err
+}
+
+func isEmbeddingMetadataType(kind string) bool {
+	_, ok := embeddingMetadataRequiredFields[kind]
+	return ok
+}
+
+func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) error {
+	var invalid int
+	if err := tx.QueryRowContext(ctx, `SELECT
+		(SELECT COUNT(*) FROM embedding_input_generations g WHERE g.input_count !=
+		 (SELECT COUNT(*) FROM embedding_generation_inputs i WHERE i.generation_id=g.generation_id)) +
+		(SELECT COUNT(*) FROM embedding_vector_sets s WHERE s.row_count !=
+		 (SELECT COUNT(*) FROM embedding_vector_rows r WHERE r.vector_set_id=s.vector_set_id)) +
+		(SELECT COUNT(*) FROM embedding_heads h JOIN embedding_sets s ON s.embedding_set_id=h.embedding_set_id
+		 WHERE h.content_version_id!=s.content_version_id OR h.binding_id!=s.binding_id OR
+		 h.input_kind!=s.input_kind OR h.vector_space_id!=s.vector_space_id OR
+		 h.profile_fingerprint!=s.profile_fingerprint)`).Scan(&invalid); err != nil {
+		return fmt.Errorf("validating embedding catalog counts: %w", err)
+	}
+	if invalid != 0 {
+		return errors.New("embedding catalog count or head authority is corrupt")
+	}
+	spaceIDs, err := loadProcessingMetadataIDs(ctx, tx, "embedding vector space",
+		`SELECT vector_space_id FROM embedding_vector_spaces ORDER BY vector_space_id`)
+	if err != nil {
+		return err
+	}
+	for _, id := range spaceIDs {
+		space, err := loadVectorSpaceTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if err := validateEmbeddingVectorSpace(space); err != nil {
+			return fmt.Errorf("validating embedding vector space %s: %w", id, err)
+		}
+	}
+	generationIDs, err := loadProcessingMetadataIDs(ctx, tx, "embedding input generation",
+		`SELECT generation_id FROM embedding_input_generations ORDER BY generation_id`)
+	if err != nil {
+		return err
+	}
+	for _, id := range generationIDs {
+		generation, err := loadInputGenerationTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if err := validateEmbeddingInputGeneration(generation); err != nil {
+			return fmt.Errorf("validating embedding input generation %s: %w", id, err)
+		}
+	}
+	vectorSetIDs, err := loadProcessingMetadataIDs(ctx, tx, "embedding vector set",
+		`SELECT vector_set_id FROM embedding_vector_sets ORDER BY vector_set_id`)
+	if err != nil {
+		return err
+	}
+	for _, id := range vectorSetIDs {
+		vectorSet, err := loadVectorSetTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		space, err := loadVectorSpaceTx(ctx, tx, vectorSet.VectorSpaceID)
+		if err != nil {
+			return err
+		}
+		generation := EmbeddingInputGenerationRecord{Inputs: make([]EmbeddingInputReference, len(vectorSet.rows))}
+		for index, row := range vectorSet.rows {
+			generation.Inputs[index] = EmbeddingInputReference{ID: row.InputID, RenderedChecksum: row.Checksum}
+		}
+		if err := validateEmbeddingVectorSet(vectorSet, space, generation); err != nil {
+			return fmt.Errorf("validating embedding vector set %s: %w", id, err)
+		}
+	}
+	setIDs, err := loadProcessingMetadataIDs(ctx, tx, "embedding set", `SELECT embedding_set_id FROM embedding_sets ORDER BY embedding_set_id`)
+	if err != nil {
+		return err
+	}
+	for _, id := range setIDs {
+		set, err := loadEmbeddingSetTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if err := validateEmbeddingSetRecord(set); err != nil {
+			return fmt.Errorf("validating embedding set %s: %w", id, err)
+		}
+		if err := validateRestoredEmbeddingAuthority(ctx, tx, set); err != nil {
+			return fmt.Errorf("validating restored embedding set %s: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func validateRestoredEmbeddingAuthority(ctx context.Context, tx metadataQuerier, set EmbeddingSetRecord) error {
+	descriptor, err := document.NewEmbeddingDescriptor(set.VectorSpace.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, set.VectorSpace.Descriptor) {
+		return errors.New("stored E1 descriptor is not canonical")
+	}
+	binding, fingerprints, err := embeddingProfileBindingAuthority(ctx, tx, set.ProcessingProfileFingerprint, set.BindingID)
+	if err != nil {
+		return err
+	}
+	if err := validateEmbeddingBindingAuthority(set, binding, fingerprints); err != nil {
+		return err
+	}
+	if set.InputKind == document.EmbeddingInputOriginalFile {
+		var sourceHash string
+		if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`, set.ContentVersionID).Scan(&sourceHash); err != nil {
+			return err
+		}
+		if set.InputGeneration.GenerationBlobHash != "" || set.InputGeneration.GenerationEncodedSize != 0 ||
+			set.InputGeneration.AttachmentID != "" || len(set.InputGeneration.Inputs) != 1 ||
+			set.InputGeneration.GenerationChecksum != sourceHash ||
+			set.InputGeneration.Inputs[0] != (EmbeddingInputReference{ID: set.ContentVersionID, RenderedChecksum: sourceHash}) {
+			return errors.New("stored original-file generation does not match source bytes")
+		}
+		return nil
+	}
+	if set.InputGeneration.GenerationBlobHash == "" || set.InputGeneration.GenerationEncodedSize < 2 {
+		return errors.New("stored E2 generation artifact reference is missing")
+	}
+	expectedGenerationID := hashCatalogText("embedding-generation-attachment/v1\x00" + set.InputGeneration.GenerationChecksum + "\x00" + set.InputGeneration.AttachmentID)
+	if set.InputGeneration.ID != expectedGenerationID {
+		return errors.New("stored E2 generation identity does not match attachment-fenced checksum")
+	}
+	var evidenceChecksum string
+	if err := tx.QueryRowContext(ctx, `SELECT b.evidence_checksum FROM rendition_attachments a
+		JOIN rendition_builds b ON b.build_id=a.build_id WHERE a.attachment_id=?
+		AND a.content_version_id=? AND a.profile_fingerprint=?`, set.InputGeneration.AttachmentID,
+		set.ContentVersionID, set.ProcessingProfileFingerprint).Scan(&evidenceChecksum); err != nil {
+		return err
+	}
+	if evidenceChecksum != set.InputGeneration.EvidenceFingerprint {
+		return errors.New("stored E2 generation evidence does not match attachment")
+	}
+	return nil
+}

--- a/internal/store/embedding_metadata.go
+++ b/internal/store/embedding_metadata.go
@@ -476,6 +476,7 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 		return fmt.Errorf("listing embedding failures for validation: %w", err)
 	}
 	defer func() { retErr = errors.Join(retErr, failureRows.Close()) }()
+	var failures []EmbeddingFailureRecord
 	for failureRows.Next() {
 		var record EmbeddingFailureRecord
 		if err := failureRows.Scan(&record.ContentVersionID,
@@ -486,12 +487,18 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 		if err := validateEmbeddingFailureRecord(record); err != nil {
 			return fmt.Errorf("validating embedding failure: %w", err)
 		}
+		failures = append(failures, record)
 	}
 	if err := failureRows.Err(); err != nil {
 		return fmt.Errorf("iterating embedding failures for validation: %w", err)
 	}
 	if err := failureRows.Close(); err != nil {
 		return fmt.Errorf("closing embedding failures after validation: %w", err)
+	}
+	for _, record := range failures {
+		if err := validateEmbeddingFailureBinding(ctx, tx, record); err != nil {
+			return fmt.Errorf("validating embedding failure profile binding: %w", err)
+		}
 	}
 
 	var invalid int

--- a/internal/store/embedding_metadata.go
+++ b/internal/store/embedding_metadata.go
@@ -126,6 +126,7 @@ type metadataEmbeddingFailure struct {
 	InputKind          EmbeddingInputKind   `json:"input_kind"`
 	FailureCode        EmbeddingFailureCode `json:"failure_code"`
 	FailedAt           string               `json:"failed_at"`
+	FencingToken       int64                `json:"fencing_token"`
 }
 
 var embeddingMetadataRequiredFields = map[string][]string{
@@ -136,7 +137,7 @@ var embeddingMetadataRequiredFields = map[string][]string{
 	metadataEmbeddingVectorRowType:   {metadataTypeField, "vector_set_id", "row_id", "order", "input_id", "dimensions", "checksum"},
 	metadataEmbeddingSetType:         {metadataTypeField, "embedding_set_id", auditVaultIDField, "binding_id", "input_kind", metadataContentVersionIDField, metadataEmbeddingProfileField, "embedding_input_fingerprint", metadataEmbeddingVectorSpaceIDField, metadataGenerationIDField, "vector_set_id", metadataCreatedAtField},
 	metadataEmbeddingHeadType:        {metadataTypeField, metadataContentVersionIDField, "binding_id", "input_kind", "embedding_set_id", metadataEmbeddingVectorSpaceIDField, metadataEmbeddingProfileField, "published_at", "fencing_token"},
-	metadataEmbeddingFailureType:     {metadataTypeField, metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at"},
+	metadataEmbeddingFailureType:     {metadataTypeField, metadataContentVersionIDField, metadataEmbeddingProfileField, "binding_id", "input_kind", "failure_code", "failed_at", "fencing_token"},
 }
 
 func exportEmbeddingMetadata(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
@@ -314,7 +315,7 @@ func exportEmbeddingHeads(ctx context.Context, tx metadataQuerier, write metadat
 
 func exportEmbeddingFailures(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
 	rows, err := tx.QueryContext(ctx, `SELECT content_version_id,profile_fingerprint,binding_id,
-		input_kind,failure_code,failed_at FROM embedding_failures
+		input_kind,failure_code,failed_at,fencing_token FROM embedding_failures
 		ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
 	if err != nil {
 		return err
@@ -323,7 +324,7 @@ func exportEmbeddingFailures(ctx context.Context, tx metadataQuerier, write meta
 	for rows.Next() {
 		value := metadataEmbeddingFailure{Type: metadataEmbeddingFailureType}
 		if err := rows.Scan(&value.ContentVersionID, &value.ProfileFingerprint, &value.BindingID,
-			&value.InputKind, &value.FailureCode, &value.FailedAt); err != nil {
+			&value.InputKind, &value.FailureCode, &value.FailedAt, &value.FencingToken); err != nil {
 			return err
 		}
 		if err := write(value); err != nil {
@@ -428,7 +429,7 @@ func importEmbeddingMetadataRecord(ctx context.Context, tx *sql.Tx, kind string,
 		if err := validateMetadataTime("embedding failure failed_at", value.FailedAt); err != nil {
 			return err
 		}
-		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_failures VALUES(?,?,?,?,?,?)`, value.ContentVersionID, value.ProfileFingerprint, value.BindingID, value.InputKind, value.FailureCode, value.FailedAt)
+		return execEmbeddingImport(ctx, tx, `INSERT INTO embedding_failures VALUES(?,?,?,?,?,?,?)`, value.ContentVersionID, value.ProfileFingerprint, value.BindingID, value.InputKind, value.FailureCode, value.FailedAt, value.FencingToken)
 	default:
 		return fmt.Errorf("unknown embedding metadata type %q", kind)
 	}
@@ -482,7 +483,7 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 	}
 
 	failureRows, err := tx.QueryContext(ctx, `SELECT content_version_id,profile_fingerprint,
-		binding_id,input_kind,failure_code,failed_at
+		binding_id,input_kind,failure_code,failed_at,fencing_token
 		FROM embedding_failures ORDER BY content_version_id,profile_fingerprint,binding_id,input_kind`)
 	if err != nil {
 		return fmt.Errorf("listing embedding failures for validation: %w", err)
@@ -493,7 +494,7 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 		var record EmbeddingFailureRecord
 		if err := failureRows.Scan(&record.ContentVersionID,
 			&record.ProcessingProfileFingerprint, &record.BindingID, &record.InputKind,
-			&record.FailureCode, &record.FailedAt); err != nil {
+			&record.FailureCode, &record.FailedAt, &record.FencingToken); err != nil {
 			return fmt.Errorf("reading embedding failure for validation: %w", err)
 		}
 		if err := validateEmbeddingFailureRecord(record); err != nil {
@@ -510,6 +511,9 @@ func validateEmbeddingMetadataState(ctx context.Context, tx metadataQuerier) (re
 	for _, record := range failures {
 		if err := validateEmbeddingFailureBinding(ctx, tx, record); err != nil {
 			return fmt.Errorf("validating embedding failure profile binding: %w", err)
+		}
+		if err := validateEmbeddingFailureHeadFence(ctx, tx, record); err != nil {
+			return fmt.Errorf("validating embedding failure head fence: %w", err)
 		}
 	}
 

--- a/internal/store/embedding_publication_test.go
+++ b/internal/store/embedding_publication_test.go
@@ -173,7 +173,7 @@ func TestEmbeddingPurgeFencesUnstagedChunkBindings(t *testing.T) {
 
 func TestEmbeddingWritesRequirePhysicalBlobAuthority(t *testing.T) {
 	for _, operation := range []string{"stage", "publish"} {
-		for _, missing := range []string{"source", "vectors", "generation"} {
+		for _, missing := range []string{"source", "vectors", "generation", "evidence"} {
 			t.Run(operation+"/"+missing, func(t *testing.T) {
 				s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
 				record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
@@ -185,7 +185,7 @@ func TestEmbeddingWritesRequirePhysicalBlobAuthority(t *testing.T) {
 				restored := newTestStore(t)
 				require.NoError(t, restored.ImportMetadata(t.Context(), &exported))
 				blobs := map[string]string{"source": catalogSourceHash, "vectors": record.VectorSet.PayloadBlobHash,
-					"generation": record.InputGeneration.GenerationBlobHash}
+					"generation": record.InputGeneration.GenerationBlobHash, "evidence": testSHA256(record.InputGeneration.EvidenceJSON)}
 				var size int64
 				require.NoError(t, restored.db.QueryRow(`SELECT size FROM blobs WHERE hash=?`, blobs[missing]).Scan(&size))
 				hash, err := packstore.ParseHash(blobs[missing])

--- a/internal/store/embedding_publication_test.go
+++ b/internal/store/embedding_publication_test.go
@@ -103,6 +103,61 @@ func TestEmbeddingPublicationRejectsOlderWorker(t *testing.T) {
 	require.NoError(t, restored.PublishEmbeddingHead(t.Context(), stale))
 }
 
+func TestEmbeddingFailureRejectsOlderWorkerAfterPublication(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	set := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), set))
+	failure := EmbeddingFailureRecord{
+		FencingToken:     1,
+		ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+		BindingID: set.BindingID, InputKind: set.InputKind,
+		FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
+	}
+	unfenced := failure
+	unfenced.FencingToken = 0
+	require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), unfenced), "fencing token")
+	require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure))
+	head := EmbeddingHeadRecord{
+		FencingToken: 2,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: set.BindingID, InputKind: set.InputKind},
+		SetID:        set.ID, VectorSpaceID: set.VectorSpace.ID, ProcessingProfileFingerprint: profile.Fingerprint,
+		PublishedAt: embeddingCatalogTime,
+	}
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), head))
+	failure.FailedAt = nowRFC3339()
+	require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), failure), "fencing token")
+	var failures int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_failures`).Scan(&failures))
+	assert.Zero(t, failures, "a late failure must not replace a newer successful outcome")
+	assert.Equal(t, set.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, set.BindingID, set.InputKind))
+	failure.FencingToken = head.FencingToken
+	require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), failure), "fencing token")
+	failure.FencingToken = 3
+	require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure), "a later attempt may fail without revoking the last good head")
+	require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure), "an exact failure retry is idempotent")
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored := newTestStore(t)
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	require.NoError(t, restored.RecordEmbeddingFailure(t.Context(), failure))
+	failure.FailureCode = EmbeddingFailureInputRejected
+	require.ErrorContains(t, restored.RecordEmbeddingFailure(t.Context(), failure), "fencing token", "a token cannot name two outcomes")
+	failure.FencingToken = 1
+	require.ErrorContains(t, restored.RecordEmbeddingFailure(t.Context(), failure), "fencing token")
+	require.ErrorContains(t, restored.PublishEmbeddingHead(t.Context(), head), "fencing token", "an old success must not clear a newer failure")
+	head.FencingToken = 4
+	require.NoError(t, restored.PublishEmbeddingHead(t.Context(), head))
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM embedding_failures`).Scan(&failures))
+	assert.Zero(t, failures)
+
+	// Import must enforce the same ordering as live failure writes.
+	stale := mutateFirstProcessingMetadataRecord(t, exported.Bytes(), metadataEmbeddingFailureType,
+		func(fields map[string]jsontext.Value) { fields["fencing_token"] = jsontext.Value(`1`) })
+	rejected := newTestStore(t)
+	require.ErrorContains(t, rejected.ImportMetadata(t.Context(), bytes.NewReader(stale)), "fencing token")
+}
+
 func TestEmbeddingRestoreRetainsHeadsForNonLiveVersions(t *testing.T) {
 	for _, mutation := range []string{"trash", "replace"} {
 		t.Run(mutation, func(t *testing.T) {
@@ -268,6 +323,7 @@ func TestEmbeddingScopedPurgeClearsAndFencesFailures(t *testing.T) {
 			var buildID string
 			require.NoError(t, s.db.QueryRow(`SELECT build_id FROM rendition_attachments WHERE attachment_id=?`, attachmentID).Scan(&buildID))
 			chunk := EmbeddingFailureRecord{
+				FencingToken:     1,
 				ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
 				BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk,
 				FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,

--- a/internal/store/embedding_publication_test.go
+++ b/internal/store/embedding_publication_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"testing"
 	"time"
 
@@ -22,8 +23,9 @@ func TestRenditionPublicationRevokesStaleChunkEmbeddingHead(t *testing.T) {
 	for _, record := range []EmbeddingSetRecord{chunk, direct} {
 		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
 		require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-			Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
-			SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+			FencingToken: 1,
+			Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+			SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
 			ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 		}))
 	}
@@ -47,6 +49,92 @@ func TestRenditionPublicationRevokesStaleChunkEmbeddingHead(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, plan.EmbeddingSets, 1)
 	assert.Equal(t, chunk.ID, plan.EmbeddingSets[0].SetID)
+
+	// Retaining the old set is valid, but restoring its revoked head is not.
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored := newTestStore(t)
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	staleHead, err := json.Marshal(metadataEmbeddingHead{
+		FencingToken: 1,
+		Type:         metadataEmbeddingHeadType, ContentVersionID: versionID, BindingID: chunk.BindingID,
+		InputKind: chunk.InputKind, SetID: chunk.ID, VectorSpaceID: chunk.VectorSpace.ID,
+		ProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	})
+	require.NoError(t, err)
+	exported.Write(staleHead)
+	exported.WriteByte('\n')
+	rejected := newTestStore(t)
+	require.ErrorContains(t, rejected.ImportMetadata(t.Context(), &exported), "attachment is not current")
+}
+
+func TestEmbeddingPublicationRejectsOlderWorker(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	older := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	newer := cloneEmbeddingSetRecord(older)
+	newer.ID = testSHA256([]byte("newer-worker-set"))
+	newer.InputGeneration.ID = testSHA256([]byte("newer-worker-generation"))
+	for _, set := range []EmbeddingSetRecord{older, newer} {
+		require.NoError(t, s.StageEmbeddingSet(t.Context(), set))
+	}
+	head := EmbeddingHeadRecord{
+		FencingToken: 2,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: newer.BindingID, InputKind: newer.InputKind},
+		SetID:        newer.ID, VectorSpaceID: newer.VectorSpace.ID, ProcessingProfileFingerprint: profile.Fingerprint,
+		PublishedAt: embeddingCatalogTime,
+	}
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), head))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), head), "an exact retry is idempotent")
+	stale := head
+	stale.SetID, stale.FencingToken = older.ID, 1
+	stale.PublishedAt = nowRFC3339()
+	require.ErrorContains(t, s.PublishEmbeddingHead(t.Context(), stale), "fencing token")
+	assert.Equal(t, newer.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, head.Key.BindingID, head.Key.InputKind))
+	stale.FencingToken = head.FencingToken
+	require.ErrorContains(t, s.PublishEmbeddingHead(t.Context(), stale), "fencing token", "one token cannot name two sets")
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored := newTestStore(t)
+	require.NoError(t, restored.ImportMetadata(t.Context(), &exported))
+	stale.FencingToken = 1
+	require.ErrorContains(t, restored.PublishEmbeddingHead(t.Context(), stale), "fencing token")
+	stale.FencingToken = 3
+	require.NoError(t, restored.PublishEmbeddingHead(t.Context(), stale))
+}
+
+func TestEmbeddingRestoreRetainsHeadsForNonLiveVersions(t *testing.T) {
+	for _, mutation := range []string{"trash", "replace"} {
+		t.Run(mutation, func(t *testing.T) {
+			s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+			chunk := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+			require.NoError(t, s.StageEmbeddingSet(t.Context(), chunk))
+			require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+				Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: chunk.BindingID, InputKind: chunk.InputKind},
+				SetID: chunk.ID, VectorSpaceID: chunk.VectorSpace.ID, ProcessingProfileFingerprint: profile.Fingerprint,
+				PublishedAt: embeddingCatalogTime, FencingToken: 1,
+			}))
+			var nodeID, revision int64
+			require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, versionID).Scan(&nodeID, &revision))
+			if mutation == "trash" {
+				_, _, err := s.Trash(t.Context(), nodeID, revision)
+				require.NoError(t, err)
+			} else {
+				hash := testSHA256([]byte("replacement document"))
+				require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+					return s.EnsureBlobTx(tx, hash, 20)
+				}))
+				_, _, err := s.ReplaceContent(t.Context(), nodeID, revision, hash, 20, "application/pdf")
+				require.NoError(t, err)
+			}
+			var exported bytes.Buffer
+			require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+			restored := newTestStore(t)
+			require.NoError(t, restored.ImportMetadata(t.Context(), &exported))
+			assert.Equal(t, chunk.ID, embeddingHeadSetIDForTest(t, restored, versionID,
+				profile.Fingerprint, chunk.BindingID, chunk.InputKind))
+		})
+	}
 }
 
 func TestEmbeddingPurgeRejectsStalePublication(t *testing.T) {
@@ -60,8 +148,9 @@ func TestEmbeddingPurgeRejectsStalePublication(t *testing.T) {
 			record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
 			require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
 			head := EmbeddingHeadRecord{
-				Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
-				SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+				FencingToken: 1,
+				Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+				SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
 				ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 			}
 			require.NoError(t, s.PublishEmbeddingHead(t.Context(), head))
@@ -121,8 +210,9 @@ func TestEmbeddingAttachmentPurgeLeavesDirectBindingPublishable(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, s.StageEmbeddingSet(t.Context(), direct))
 	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: direct.BindingID, InputKind: direct.InputKind},
-		SetID: direct.ID, VectorSpaceID: direct.VectorSpace.ID,
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: direct.BindingID, InputKind: direct.InputKind},
+		SetID:        direct.ID, VectorSpaceID: direct.VectorSpace.ID,
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 	assert.Equal(t, direct.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, direct.BindingID, direct.InputKind))
@@ -265,8 +355,9 @@ func TestEmbeddingWritesRequirePhysicalBlobAuthority(t *testing.T) {
 						return restored.StageEmbeddingSet(t.Context(), record)
 					}
 					return restored.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
-						Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
-						SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+						FencingToken: 1,
+						Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+						SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
 						ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 					})
 				}

--- a/internal/store/embedding_publication_test.go
+++ b/internal/store/embedding_publication_test.go
@@ -5,11 +5,14 @@ import (
 	"database/sql"
 	"encoding/json/jsontext"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/kit/pack"
+	"go.kenn.io/kit/packstore"
 )
 
 func TestRenditionPublicationRevokesStaleChunkEmbeddingHead(t *testing.T) {
@@ -123,4 +126,96 @@ func TestEmbeddingAttachmentPurgeLeavesDirectBindingPublishable(t *testing.T) {
 		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 	}))
 	assert.Equal(t, direct.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, direct.BindingID, direct.InputKind))
+}
+
+func TestEmbeddingPurgeFencesWorkBeforeStaging(t *testing.T) {
+	for _, all := range []bool{false, true} {
+		name := "version"
+		if all {
+			name = "all"
+		}
+		t.Run(name, func(t *testing.T) {
+			s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+			request := PurgeRequest{ContentVersionIDs: []string{versionID}}
+			if all {
+				request = PurgeRequest{All: true}
+			}
+			_, err := s.PurgeDerivatives(t.Context(), request)
+			require.NoError(t, err)
+			require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "purge")
+		})
+	}
+}
+
+func TestEmbeddingPurgeFencesUnstagedChunkBindings(t *testing.T) {
+	for _, selector := range []string{"attachment", "build"} {
+		t.Run(selector, func(t *testing.T) {
+			s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+			var buildID string
+			require.NoError(t, s.db.QueryRow(`SELECT build_id FROM rendition_attachments WHERE attachment_id=?`, attachmentID).Scan(&buildID))
+			request := PurgeRequest{AttachmentIDs: []string{attachmentID}}
+			if selector == "build" {
+				request = PurgeRequest{BuildIDs: []string{buildID}}
+			}
+			_, err := s.PurgeDerivatives(t.Context(), request)
+			require.NoError(t, err)
+			// An unstaged binding must have a durable fence that an explicit
+			// rebuild can supersede, even after its attachment has been removed.
+			require.NoError(t, s.AuthorizeEmbeddingRebuild(t.Context(), EmbeddingRebuildAuthorization{
+				Key:                          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk},
+				ProcessingProfileFingerprint: profile.Fingerprint, SetID: testSHA256([]byte("unstaged-rebuild-set")),
+				AuthorizedAt: nowRFC3339(),
+			}))
+		})
+	}
+}
+
+func TestEmbeddingWritesRequirePhysicalBlobAuthority(t *testing.T) {
+	for _, operation := range []string{"stage", "publish"} {
+		for _, missing := range []string{"source", "vectors", "generation"} {
+			t.Run(operation+"/"+missing, func(t *testing.T) {
+				s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+				record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+				if operation == "publish" {
+					require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+				}
+				var exported bytes.Buffer
+				require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+				restored := newTestStore(t)
+				require.NoError(t, restored.ImportMetadata(t.Context(), &exported))
+				blobs := map[string]string{"source": catalogSourceHash, "vectors": record.VectorSet.PayloadBlobHash,
+					"generation": record.InputGeneration.GenerationBlobHash}
+				var size int64
+				require.NoError(t, restored.db.QueryRow(`SELECT size FROM blobs WHERE hash=?`, blobs[missing]).Scan(&size))
+				hash, err := packstore.ParseHash(blobs[missing])
+				require.NoError(t, err)
+				packID := pack.NewPackID()
+				catalog := NewPackCatalog(restored)
+				require.NoError(t, catalog.RecordPack(t.Context(), packstore.PackRecord{
+					PackID: packID, EntryCount: 1, StoredBytes: size + pack.MinEntryOffset,
+					CreatedAt: time.Now().UTC(),
+				}, []packstore.Adoption{{Entry: packstore.IndexEntry{
+					Hash: hash, PackID: packID, Offset: pack.MinEntryOffset, StoredLen: size, RawLen: size,
+				}}}))
+				require.NoError(t, catalog.DeleteIndexEntry(t.Context(), hash))
+				_, err = restored.PhysicalContent(t.Context(), blobs[missing])
+				require.ErrorIs(t, err, ErrPhysicalAuthorityMissing)
+				write := func() error {
+					if operation == "stage" {
+						return restored.StageEmbeddingSet(t.Context(), record)
+					}
+					return restored.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+						Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+						SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+						ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+					})
+				}
+				require.ErrorIs(t, write(), ErrPhysicalAuthorityMissing)
+				_, err = restored.RepairBlobAuthority(t.Context(), blobs[missing], size, BlobPhysical{Encoding: "raw", StoredBytes: size})
+				require.NoError(t, err)
+				require.NoError(t, write())
+			})
+		}
+	}
 }

--- a/internal/store/embedding_publication_test.go
+++ b/internal/store/embedding_publication_test.go
@@ -29,6 +29,20 @@ func TestRenditionPublicationRevokesStaleChunkEmbeddingHead(t *testing.T) {
 			ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
 		}))
 	}
+	failure := EmbeddingFailureRecord{
+		ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+		BindingID: chunk.BindingID, InputKind: chunk.InputKind, AttachmentID: attachmentID,
+		FencingToken: 2, FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
+	}
+	unbound := failure
+	unbound.AttachmentID = ""
+	require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), unbound), "attachment ID")
+	require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure))
+	directFailure := failure
+	directFailure.BindingID, directFailure.InputKind = direct.BindingID, direct.InputKind
+	require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), directFailure), "must not name an attachment")
+	directFailure.AttachmentID = ""
+	require.NoError(t, s.RecordEmbeddingFailure(t.Context(), directFailure))
 	build := catalogRenditionBuild(s, profile)
 	build.ID = testSHA256([]byte("replacement-embedding-build"))
 	build.CapturedArtifactPolicy = jsontext.Value(`{"roles":[{"max_count":1,"min_count":1,"role":"normalized_evidence"},{"max_count":1,"min_count":0,"role":"provider_markdown"},{"max_count":1,"min_count":1,"role":"sanitized_markdown"}],"version":1}`)
@@ -45,6 +59,15 @@ func TestRenditionPublicationRevokesStaleChunkEmbeddingHead(t *testing.T) {
 	err := s.db.QueryRow(`SELECT embedding_set_id FROM embedding_heads WHERE embedding_set_id=?`, chunk.ID).Scan(&headID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 	assert.Equal(t, direct.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, direct.BindingID, direct.InputKind))
+	var failures int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_failures WHERE binding_id=?`, chunk.BindingID).Scan(&failures))
+	assert.Zero(t, failures, "replacing the rendition clears its previous failure status")
+	failure.FencingToken = 3
+	require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), failure), "attachment is not current")
+	require.NoError(t, s.RecordEmbeddingFailure(t.Context(), directFailure), "original-file failure status is unchanged")
+	currentFailure := failure
+	currentFailure.AttachmentID = replacement.ID
+	require.NoError(t, s.RecordEmbeddingFailure(t.Context(), currentFailure))
 	plan, err := s.DerivativeGCPlan(t.Context())
 	require.NoError(t, err)
 	require.Len(t, plan.EmbeddingSets, 1)
@@ -55,6 +78,12 @@ func TestRenditionPublicationRevokesStaleChunkEmbeddingHead(t *testing.T) {
 	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
 	restored := newTestStore(t)
 	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	require.NoError(t, restored.RecordEmbeddingFailure(t.Context(), currentFailure))
+	require.ErrorContains(t, restored.RecordEmbeddingFailure(t.Context(), failure), "attachment is not current")
+	staleFailure := mutateFirstProcessingMetadataRecord(t, exported.Bytes(), metadataEmbeddingFailureType,
+		func(fields map[string]jsontext.Value) { fields["attachment_id"] = jsonStringForTest(t, attachmentID) })
+	rejectedFailure := newTestStore(t)
+	require.ErrorContains(t, rejectedFailure.ImportMetadata(t.Context(), bytes.NewReader(staleFailure)), "attachment is not current")
 	staleHead, err := json.Marshal(metadataEmbeddingHead{
 		FencingToken: 1,
 		Type:         metadataEmbeddingHeadType, ContentVersionID: versionID, BindingID: chunk.BindingID,
@@ -325,10 +354,11 @@ func TestEmbeddingScopedPurgeClearsAndFencesFailures(t *testing.T) {
 			chunk := EmbeddingFailureRecord{
 				FencingToken:     1,
 				ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
-				BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk,
+				BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk, AttachmentID: attachmentID,
 				FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
 			}
 			direct := chunk
+			direct.AttachmentID = ""
 			direct.BindingID, direct.InputKind = "optional", document.EmbeddingInputOriginalFile
 			for _, failure := range []EmbeddingFailureRecord{chunk, direct} {
 				require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure))
@@ -371,7 +401,8 @@ func TestEmbeddingScopedPurgeClearsAndFencesFailures(t *testing.T) {
 				AuthorizedAt: nowRFC3339(),
 			}))
 			chunk.FailedAt = nowRFC3339()
-			require.NoError(t, restored.RecordEmbeddingFailure(t.Context(), chunk))
+			require.ErrorContains(t, restored.RecordEmbeddingFailure(t.Context(), chunk), "attachment is not current",
+				"rebuild authorization does not make a purged rendition current again")
 		})
 	}
 }

--- a/internal/store/embedding_publication_test.go
+++ b/internal/store/embedding_publication_test.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json/jsontext"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+)
+
+func TestRenditionPublicationRevokesStaleChunkEmbeddingHead(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	chunk := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	direct := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	for _, record := range []EmbeddingSetRecord{chunk, direct} {
+		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+		require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+			Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+			SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+			ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+		}))
+	}
+	build := catalogRenditionBuild(s, profile)
+	build.ID = testSHA256([]byte("replacement-embedding-build"))
+	build.CapturedArtifactPolicy = jsontext.Value(`{"roles":[{"max_count":1,"min_count":1,"role":"normalized_evidence"},{"max_count":1,"min_count":0,"role":"provider_markdown"},{"max_count":1,"min_count":1,"role":"sanitized_markdown"}],"version":1}`)
+	build.CapturedArtifactPolicyFingerprint = testSHA256(build.CapturedArtifactPolicy)
+	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+	replacement := RenditionAttachmentRecord{
+		ID: testSHA256([]byte("replacement-embedding-attachment")), VaultID: s.VaultID(), ContentVersionID: versionID,
+		BuildID: build.ID, Profile: profile, AttachedAt: embeddingCatalogTime,
+	}
+	require.NoError(t, publishRenditionForTest(t, s, replacement, embeddingCatalogTime,
+		testSHA256([]byte("replacement-embedding-lexical-generation"))))
+
+	var headID string
+	err := s.db.QueryRow(`SELECT embedding_set_id FROM embedding_heads WHERE embedding_set_id=?`, chunk.ID).Scan(&headID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+	assert.Equal(t, direct.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, direct.BindingID, direct.InputKind))
+	plan, err := s.DerivativeGCPlan(t.Context())
+	require.NoError(t, err)
+	require.Len(t, plan.EmbeddingSets, 1)
+	assert.Equal(t, chunk.ID, plan.EmbeddingSets[0].SetID)
+}
+
+func TestEmbeddingPurgeRejectsStalePublication(t *testing.T) {
+	for _, retained := range []bool{false, true} {
+		name := "deleted"
+		if retained {
+			name = "retained by lease"
+		}
+		t.Run(name, func(t *testing.T) {
+			s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+			require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+			head := EmbeddingHeadRecord{
+				Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+				SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+				ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+			}
+			require.NoError(t, s.PublishEmbeddingHead(t.Context(), head))
+			if retained {
+				require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), CurrentRenditionRoot{
+					ID: "purged-embedding-reader", Kind: RenditionRootReaderLease,
+					TargetKind: RenditionRootEmbeddingSet, TargetID: record.ID, FencingToken: 1,
+					RecordedAt: embeddingCatalogTime, ExpiresAt: "2099-08-25T10:00:00.000000000Z",
+				}))
+				seedInitialAuditAuthority(t, s, s.RootID())
+			}
+			_, err := s.PurgeDerivatives(t.Context(), PurgeRequest{ContentVersionIDs: []string{versionID}})
+			require.NoError(t, err)
+			require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), record), "purge")
+			require.Error(t, s.PublishEmbeddingHead(t.Context(), head))
+			replacement := cloneEmbeddingSetRecord(record)
+			replacement.ID = testSHA256([]byte("authorized-embedding-replacement"))
+			replacement.InputGeneration.ID = testSHA256([]byte("replacement-original-input-generation"))
+			require.ErrorContains(t, s.StageEmbeddingSet(t.Context(), replacement), "purge",
+				"a different set ID must not evade the binding's purge")
+
+			var exported bytes.Buffer
+			require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+			restored := newTestStore(t)
+			require.NoError(t, restored.ImportMetadata(t.Context(), &exported))
+			require.ErrorContains(t, restored.StageEmbeddingSet(t.Context(), record), "purge")
+			require.Error(t, restored.PublishEmbeddingHead(t.Context(), head))
+
+			require.NoError(t, restored.AuthorizeEmbeddingRebuild(t.Context(), EmbeddingRebuildAuthorization{
+				Key: head.Key, ProcessingProfileFingerprint: profile.Fingerprint,
+				SetID: replacement.ID, AuthorizedAt: nowRFC3339(),
+			}))
+			require.ErrorContains(t, restored.StageEmbeddingSet(t.Context(), record), "purge",
+				"authorizing the replacement must not authorize stale work")
+			require.NoError(t, restored.StageEmbeddingSet(t.Context(), replacement))
+			head.SetID = replacement.ID
+			require.NoError(t, restored.PublishEmbeddingHead(t.Context(), head))
+			assert.Equal(t, replacement.ID, embeddingHeadSetIDForTest(t, restored, versionID,
+				profile.Fingerprint, head.Key.BindingID, head.Key.InputKind))
+			require.NoError(t, restored.ValidateMetadata(t.Context()))
+			_, err = restored.PurgeDerivatives(t.Context(), PurgeRequest{ContentVersionIDs: []string{versionID}})
+			require.NoError(t, err)
+			require.ErrorContains(t, restored.StageEmbeddingSet(t.Context(), replacement), "purge",
+				"a later purge must revoke the earlier rebuild authorization")
+		})
+	}
+}
+
+func TestEmbeddingAttachmentPurgeLeavesDirectBindingPublishable(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	chunk := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	direct := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+	for _, record := range []EmbeddingSetRecord{chunk, direct} {
+		require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	}
+	_, err := s.PurgeDerivatives(t.Context(), PurgeRequest{AttachmentIDs: []string{attachmentID}})
+	require.NoError(t, err)
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), direct))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: direct.BindingID, InputKind: direct.InputKind},
+		SetID: direct.ID, VectorSpaceID: direct.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+	assert.Equal(t, direct.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, direct.BindingID, direct.InputKind))
+}

--- a/internal/store/embedding_publication_test.go
+++ b/internal/store/embedding_publication_test.go
@@ -171,6 +171,65 @@ func TestEmbeddingPurgeFencesUnstagedChunkBindings(t *testing.T) {
 	}
 }
 
+func TestEmbeddingScopedPurgeClearsAndFencesFailures(t *testing.T) {
+	for _, selector := range []string{"attachment", "build", "version", "all"} {
+		t.Run(selector, func(t *testing.T) {
+			s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+			var buildID string
+			require.NoError(t, s.db.QueryRow(`SELECT build_id FROM rendition_attachments WHERE attachment_id=?`, attachmentID).Scan(&buildID))
+			chunk := EmbeddingFailureRecord{
+				ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+				BindingID: "chunk", InputKind: document.EmbeddingInputRenditionChunk,
+				FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
+			}
+			direct := chunk
+			direct.BindingID, direct.InputKind = "optional", document.EmbeddingInputOriginalFile
+			for _, failure := range []EmbeddingFailureRecord{chunk, direct} {
+				require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure))
+			}
+			requests := map[string]PurgeRequest{
+				"attachment": {AttachmentIDs: []string{attachmentID}},
+				"build":      {BuildIDs: []string{buildID}},
+				"version":    {ContentVersionIDs: []string{versionID}},
+				"all":        {All: true},
+			}
+			// A failed attempt need not have staged a set. Its attachment/profile
+			// scope must still be cleared and fenced by the purge.
+			_, err := s.PurgeDerivatives(t.Context(), requests[selector])
+			require.NoError(t, err)
+			var chunkFailures int
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_failures
+				WHERE content_version_id=? AND profile_fingerprint=? AND binding_id='chunk'`,
+				versionID, profile.Fingerprint).Scan(&chunkFailures))
+			assert.Zero(t, chunkFailures)
+			require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), chunk), "purge suppression")
+			var directFailures int
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_failures
+				WHERE content_version_id=? AND profile_fingerprint=? AND binding_id='optional'`,
+				versionID, profile.Fingerprint).Scan(&directFailures))
+			if selector == "attachment" || selector == "build" {
+				assert.Equal(t, 1, directFailures, "scoped rendition purge must leave original-file failures alone")
+				require.NoError(t, s.RecordEmbeddingFailure(t.Context(), direct))
+			} else {
+				assert.Zero(t, directFailures)
+				require.ErrorContains(t, s.RecordEmbeddingFailure(t.Context(), direct), "purge suppression")
+			}
+			var exported bytes.Buffer
+			require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+			restored := newTestStore(t)
+			require.NoError(t, restored.ImportMetadata(t.Context(), &exported))
+			require.ErrorContains(t, restored.RecordEmbeddingFailure(t.Context(), chunk), "purge suppression")
+			require.NoError(t, restored.AuthorizeEmbeddingRebuild(t.Context(), EmbeddingRebuildAuthorization{
+				Key:                          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: chunk.BindingID, InputKind: chunk.InputKind},
+				ProcessingProfileFingerprint: profile.Fingerprint, SetID: testSHA256([]byte("failure-rebuild-set")),
+				AuthorizedAt: nowRFC3339(),
+			}))
+			chunk.FailedAt = nowRFC3339()
+			require.NoError(t, restored.RecordEmbeddingFailure(t.Context(), chunk))
+		})
+	}
+}
+
 func TestEmbeddingWritesRequirePhysicalBlobAuthority(t *testing.T) {
 	for _, operation := range []string{"stage", "publish"} {
 		for _, missing := range []string{"source", "vectors", "generation", "evidence"} {

--- a/internal/store/embedding_publication_test.go
+++ b/internal/store/embedding_publication_test.go
@@ -345,6 +345,58 @@ func TestEmbeddingPurgeFencesUnstagedChunkBindings(t *testing.T) {
 	}
 }
 
+func TestEmbeddingHistoricalRenditionPurgePreservesCurrentBinding(t *testing.T) {
+	for _, selector := range []string{"attachment", "build"} {
+		t.Run(selector, func(t *testing.T) {
+			s, versionID, profile, oldAttachmentID := newEmbeddingCatalogFixture(t)
+			var oldBuildID string
+			require.NoError(t, s.db.QueryRow(`SELECT build_id FROM rendition_attachments WHERE attachment_id=?`, oldAttachmentID).Scan(&oldBuildID))
+			build := catalogRenditionBuild(s, profile)
+			build.ID = testSHA256([]byte("replacement-embedding-build"))
+			build.EvidenceChecksum = embeddingCatalogEvidence(t).Checksum
+			build.CapturedArtifactPolicy = jsontext.Value(`{"roles":[{"max_count":1,"min_count":1,"role":"normalized_evidence"},{"max_count":1,"min_count":0,"role":"provider_markdown"},{"max_count":1,"min_count":1,"role":"sanitized_markdown"}],"version":1}`)
+			build.CapturedArtifactPolicyFingerprint = testSHA256(build.CapturedArtifactPolicy)
+			require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+			replacement := RenditionAttachmentRecord{
+				ID: testSHA256([]byte("replacement-embedding-attachment")), VaultID: s.VaultID(), ContentVersionID: versionID,
+				BuildID: build.ID, Profile: profile, AttachedAt: embeddingCatalogTime,
+			}
+			require.NoError(t, publishRenditionForTest(t, s, replacement, embeddingCatalogTime,
+				testSHA256([]byte("replacement-embedding-lexical-generation"))))
+			set := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", replacement.ID)
+			require.NoError(t, s.StageEmbeddingSet(t.Context(), set))
+			head := EmbeddingHeadRecord{
+				Key:   EmbeddingHeadKey{ContentVersionID: versionID, BindingID: set.BindingID, InputKind: set.InputKind},
+				SetID: set.ID, VectorSpaceID: set.VectorSpace.ID, ProcessingProfileFingerprint: profile.Fingerprint,
+				PublishedAt: embeddingCatalogTime, FencingToken: 1,
+			}
+			require.NoError(t, s.PublishEmbeddingHead(t.Context(), head))
+			failure := EmbeddingFailureRecord{
+				ContentVersionID: versionID, ProcessingProfileFingerprint: profile.Fingerprint,
+				BindingID: set.BindingID, InputKind: set.InputKind, AttachmentID: replacement.ID,
+				FencingToken: 2, FailureCode: EmbeddingFailureProviderUnavailable, FailedAt: embeddingCatalogTime,
+			}
+			require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure))
+			request := PurgeRequest{AttachmentIDs: []string{oldAttachmentID}}
+			if selector == "build" {
+				request = PurgeRequest{BuildIDs: []string{oldBuildID}}
+			}
+			_, err := s.PurgeDerivatives(t.Context(), request)
+			require.NoError(t, err)
+			var oldAttachments, failures int
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM rendition_attachments WHERE attachment_id=?`, oldAttachmentID).Scan(&oldAttachments))
+			assert.Zero(t, oldAttachments, "the selected historical rendition is purged")
+			assert.Equal(t, set.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, set.BindingID, set.InputKind))
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_failures WHERE attachment_id=?`, replacement.ID).Scan(&failures))
+			assert.Equal(t, 1, failures, "purging history must preserve current failure status")
+			require.NoError(t, s.RecordEmbeddingFailure(t.Context(), failure))
+			require.NoError(t, s.StageEmbeddingSet(t.Context(), set))
+			head.FencingToken = 3
+			require.NoError(t, s.PublishEmbeddingHead(t.Context(), head))
+		})
+	}
+}
+
 func TestEmbeddingScopedPurgeClearsAndFencesFailures(t *testing.T) {
 	for _, selector := range []string{"attachment", "build", "version", "all"} {
 		t.Run(selector, func(t *testing.T) {

--- a/internal/store/embedding_suppression.go
+++ b/internal/store/embedding_suppression.go
@@ -10,9 +10,10 @@ import (
 	"go.kenn.io/docbank/document"
 )
 
-// Capture every affected binding before deleting attachments or sets. Work
-// admitted under a registered profile may still be running without a set row.
-func embeddingPurgeSuppressionsTx(
+// Clear failures and capture suppression for every affected binding before
+// deleting attachments or sets. Work admitted under a registered profile may
+// still be running without a set row.
+func prepareEmbeddingPurgeTx(
 	ctx context.Context, tx *sql.Tx, request PurgeRequest, asOf string,
 ) (_ []derivativePurgeSuppression, retErr error) {
 	if !request.All && len(request.ContentVersionIDs)+len(request.AttachmentIDs)+len(request.BuildIDs) == 0 {
@@ -62,6 +63,11 @@ func embeddingPurgeSuppressionsTx(
 		for _, binding := range profile.Embeddings {
 			if !allBindings && binding.InputKind != document.EmbeddingInputRenditionChunk {
 				continue
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_failures
+				WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?`,
+				versionID, fingerprint, binding.Name, binding.InputKind); err != nil {
+				return nil, fmt.Errorf("clearing purged embedding failures: %w", err)
 			}
 			result = append(result, derivativePurgeSuppression{
 				sourceSHA256: source, profileFingerprint: derivativeBuildSuppressionProfile,
@@ -122,14 +128,9 @@ func embeddingPurgeScope(key EmbeddingHeadKey, profileFingerprint string) string
 }
 
 func requireEmbeddingPurgeAuthorityTx(ctx context.Context, tx *sql.Tx, set EmbeddingSetRecord) error {
-	var source string
-	if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`,
-		set.ContentVersionID).Scan(&source); err != nil {
-		return fmt.Errorf("reading embedding purge source: %w", err)
-	}
-	scope := embeddingPurgeScope(EmbeddingHeadKey{set.ContentVersionID, set.BindingID, set.InputKind},
+	suppression, err := loadEmbeddingPurgeSuppressionTx(ctx, tx,
+		EmbeddingHeadKey{set.ContentVersionID, set.BindingID, set.InputKind},
 		set.ProcessingProfileFingerprint)
-	suppression, err := loadDerivativePurgeSuppressionTx(ctx, tx, source, derivativeBuildSuppressionProfile, scope)
 	if errors.Is(err, ErrNotFound) {
 		return nil
 	}
@@ -140,4 +141,16 @@ func requireEmbeddingPurgeAuthorityTx(ctx context.Context, tx *sql.Tx, set Embed
 		return errors.New("embedding binding has a purge suppression without authorization for this set")
 	}
 	return nil
+}
+
+func loadEmbeddingPurgeSuppressionTx(
+	ctx context.Context, tx *sql.Tx, key EmbeddingHeadKey, profileFingerprint string,
+) (derivativePurgeSuppression, error) {
+	var source string
+	if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`,
+		key.ContentVersionID).Scan(&source); err != nil {
+		return derivativePurgeSuppression{}, fmt.Errorf("reading embedding purge source: %w", err)
+	}
+	return loadDerivativePurgeSuppressionTx(ctx, tx, source, derivativeBuildSuppressionProfile,
+		embeddingPurgeScope(key, profileFingerprint))
 }

--- a/internal/store/embedding_suppression.go
+++ b/internal/store/embedding_suppression.go
@@ -1,0 +1,74 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// EmbeddingRebuildAuthorization permits one exact replacement set after an
+// explicit purge. Worker staging and publication never grant this authority.
+type EmbeddingRebuildAuthorization struct {
+	Key                          EmbeddingHeadKey
+	ProcessingProfileFingerprint string
+	SetID                        string
+	AuthorizedAt                 string
+}
+
+func (s *Store) AuthorizeEmbeddingRebuild(ctx context.Context, authorization EmbeddingRebuildAuthorization) error {
+	if err := validateEmbeddingHeadKey(authorization.Key); err != nil {
+		return err
+	}
+	if err := validateCatalogSHA256(authorization.SetID, "embedding rebuild set ID"); err != nil {
+		return err
+	}
+	if err := validateCatalogSHA256(authorization.ProcessingProfileFingerprint, "embedding rebuild profile"); err != nil {
+		return err
+	}
+	if err := validateMetadataTime("embedding rebuild authorized_at", authorization.AuthorizedAt); err != nil {
+		return err
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		var source string
+		if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`,
+			authorization.Key.ContentVersionID).Scan(&source); err != nil {
+			return fmt.Errorf("reading embedding rebuild source: %w", err)
+		}
+		return s.authorizeDerivativeRebuildTx(ctx, tx, DerivativeRebuildAuthorization{
+			SourceSHA256:       source,
+			PurgedBuildID:      embeddingPurgeScope(authorization.Key, authorization.ProcessingProfileFingerprint),
+			SupersedingBuildID: authorization.SetID, AuthorizedAt: authorization.AuthorizedAt,
+		}, derivativeBuildSuppressionProfile)
+	})
+}
+
+// The shared suppression ledger stores an opaque derivative identity in its
+// build_id column. A domain-separated binding scope fences every set for this
+// version/profile/binding/kind, even when a retry chooses a different set ID.
+// Reusing the ledger also preserves its export, restore, and audit authority.
+func embeddingPurgeScope(key EmbeddingHeadKey, profileFingerprint string) string {
+	return hashCatalogText("docbank:embedding-purge-scope:v1\x00" + key.ContentVersionID + "\x00" +
+		profileFingerprint + "\x00" + key.BindingID + "\x00" + string(key.InputKind))
+}
+
+func requireEmbeddingPurgeAuthorityTx(ctx context.Context, tx *sql.Tx, set EmbeddingSetRecord) error {
+	var source string
+	if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`,
+		set.ContentVersionID).Scan(&source); err != nil {
+		return fmt.Errorf("reading embedding purge source: %w", err)
+	}
+	scope := embeddingPurgeScope(EmbeddingHeadKey{set.ContentVersionID, set.BindingID, set.InputKind},
+		set.ProcessingProfileFingerprint)
+	suppression, err := loadDerivativePurgeSuppressionTx(ctx, tx, source, derivativeBuildSuppressionProfile, scope)
+	if errors.Is(err, ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("checking embedding purge suppression: %w", err)
+	}
+	if suppression.active || suppression.supersedingBuildID != set.ID {
+		return errors.New("embedding binding has a purge suppression without authorization for this set")
+	}
+	return nil
+}

--- a/internal/store/embedding_suppression.go
+++ b/internal/store/embedding_suppression.go
@@ -3,9 +3,78 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
+
+	"go.kenn.io/docbank/document"
 )
+
+// Capture every affected binding before deleting attachments or sets. Work
+// admitted under a registered profile may still be running without a set row.
+func embeddingPurgeSuppressionsTx(
+	ctx context.Context, tx *sql.Tx, request PurgeRequest, asOf string,
+) (_ []derivativePurgeSuppression, retErr error) {
+	if !request.All && len(request.ContentVersionIDs)+len(request.AttachmentIDs)+len(request.BuildIDs) == 0 {
+		return nil, nil
+	}
+	args := []any{request.All}
+	for _, ids := range [][]string{request.ContentVersionIDs, request.AttachmentIDs, request.BuildIDs} {
+		for _, id := range ids {
+			args = append(args, id)
+		}
+	}
+	rows, err := tx.QueryContext(ctx, `WITH scopes AS (
+		SELECT cv.version_id,p.profile_fingerprint,1 AS all_bindings
+		FROM content_versions cv CROSS JOIN processing_profiles p
+		WHERE ? OR cv.version_id IN (`+placeholders(len(request.ContentVersionIDs))+`)
+		UNION ALL
+		SELECT a.content_version_id,a.profile_fingerprint,0
+		FROM rendition_attachments a
+		WHERE a.attachment_id IN (`+placeholders(len(request.AttachmentIDs))+`)
+		   OR a.build_id IN (`+placeholders(len(request.BuildIDs))+`)
+	)
+	SELECT cv.version_id,cv.blob_hash,p.profile_fingerprint,p.canonical_profile,MAX(s.all_bindings)
+	FROM scopes s JOIN content_versions cv ON cv.version_id=s.version_id
+	JOIN processing_profiles p ON p.profile_fingerprint=s.profile_fingerprint
+	GROUP BY p.profile_fingerprint,cv.version_id
+	ORDER BY p.profile_fingerprint,cv.version_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing embedding purge scopes: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, rows.Close()) }()
+	var result []derivativePurgeSuppression
+	var lastProfile string
+	var profile document.ProcessingProfileV1
+	for rows.Next() {
+		var versionID, source, fingerprint, canonical string
+		var allBindings bool
+		if err := rows.Scan(&versionID, &source, &fingerprint, &canonical, &allBindings); err != nil {
+			return nil, fmt.Errorf("reading embedding purge scope: %w", err)
+		}
+		if fingerprint != lastProfile {
+			profile = document.ProcessingProfileV1{}
+			if err := json.Unmarshal([]byte(canonical), &profile); err != nil {
+				return nil, fmt.Errorf("decoding embedding purge profile: %w", err)
+			}
+			lastProfile = fingerprint
+		}
+		for _, binding := range profile.Embeddings {
+			if !allBindings && binding.InputKind != document.EmbeddingInputRenditionChunk {
+				continue
+			}
+			result = append(result, derivativePurgeSuppression{
+				sourceSHA256: source, profileFingerprint: derivativeBuildSuppressionProfile,
+				buildID:  embeddingPurgeScope(EmbeddingHeadKey{versionID, binding.Name, binding.InputKind}, fingerprint),
+				purgedAt: asOf, active: true,
+			})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing embedding purge scopes: %w", err)
+	}
+	return result, nil
+}
 
 // EmbeddingRebuildAuthorization permits one exact replacement set after an
 // explicit purge. Worker staging and publication never grant this authority.

--- a/internal/store/embedding_suppression.go
+++ b/internal/store/embedding_suppression.go
@@ -12,7 +12,9 @@ import (
 
 // Clear failures and capture suppression for every affected binding before
 // deleting attachments or sets. Work admitted under a registered profile may
-// still be running without a set row.
+// still be running without a set row. A scoped rendition purge fences bindings
+// only when it selects their current rendition; obsolete attachments already
+// fail the current-attachment check and must not suppress newer work.
 func prepareEmbeddingPurgeTx(
 	ctx context.Context, tx *sql.Tx, request PurgeRequest, asOf string,
 ) (_ []derivativePurgeSuppression, retErr error) {
@@ -32,6 +34,8 @@ func prepareEmbeddingPurgeTx(
 		UNION ALL
 		SELECT a.content_version_id,a.profile_fingerprint,0
 		FROM rendition_attachments a
+		JOIN rendition_heads h ON h.content_version_id=a.content_version_id
+		  AND h.profile_fingerprint=a.profile_fingerprint AND h.attachment_id=a.attachment_id
 		WHERE a.attachment_id IN (`+placeholders(len(request.AttachmentIDs))+`)
 		   OR a.build_id IN (`+placeholders(len(request.BuildIDs))+`)
 	)

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -1098,6 +1098,10 @@ func validateCurrentRenditionRoot(root CurrentRenditionRoot) error {
 	default:
 		return fmt.Errorf("current rendition target kind %q is invalid", root.TargetKind)
 	}
+	if root.Kind == RenditionRootJob && root.TargetKind != RenditionRootBuild &&
+		root.TargetKind != RenditionRootLexicalGeneration {
+		return fmt.Errorf("current rendition job root target kind %q is invalid", root.TargetKind)
+	}
 	return validateMetadataTime("current rendition root recorded_at", root.RecordedAt)
 }
 

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -45,6 +45,16 @@ type DerivativeBuildGC struct {
 	ArtifactBlobHashes []string
 }
 
+// EmbeddingSetGC identifies one complete embedding disclosure unit whose
+// heads, eligible source, corpus manifests, and pins have all disappeared.
+type EmbeddingSetGC struct {
+	SetID              string
+	InputGenerationID  string
+	VectorSetID        string
+	PayloadBlobHash    string
+	GenerationBlobHash string
+}
+
 // CurrentRenditionRootKind identifies the producer retaining an exact current
 // rendition build or lexical generation.
 type CurrentRenditionRootKind string
@@ -65,8 +75,12 @@ const (
 type CurrentRenditionTargetKind string
 
 const (
-	RenditionRootBuild             CurrentRenditionTargetKind = "rendition_build"
-	RenditionRootLexicalGeneration CurrentRenditionTargetKind = "lexical_generation"
+	RenditionRootBuild               CurrentRenditionTargetKind = "rendition_build"
+	RenditionRootLexicalGeneration   CurrentRenditionTargetKind = "lexical_generation"
+	RenditionRootEmbeddingSet        CurrentRenditionTargetKind = "embedding_set"
+	RenditionRootEmbeddingGeneration CurrentRenditionTargetKind = "embedding_input_generation"
+	RenditionRootEmbeddingVectorSet  CurrentRenditionTargetKind = "embedding_vector_set"
+	RenditionRootEmbeddingPayload    CurrentRenditionTargetKind = "embedding_payload"
 )
 
 // CurrentRenditionRoot is one fenced exact-root grant. Reader and worker
@@ -89,6 +103,7 @@ var ErrCurrentRenditionRootFenced = errors.New("current rendition root is fenced
 type DerivativeGCPlan struct {
 	Builds             []DerivativeBuildGC
 	LexicalGenerations []string
+	EmbeddingSets      []EmbeddingSetGC
 	ExpiredRootIDs     []string
 }
 
@@ -116,6 +131,10 @@ type PurgeReport struct {
 	RemovedLexicalGenerations        int
 	RemovedLexicalRows               int
 	RemovedLegacyCacheRows           int
+	RemovedEmbeddingHeads            int
+	RemovedEmbeddingSets             int
+	RemovedEmbeddingInputGenerations int
+	RemovedEmbeddingVectorSets       int
 	ExpiredRootsRemoved              int
 	RetainedBuildIDs                 []string
 	RetainedLexicalGenerations       []string
@@ -220,6 +239,14 @@ func (s *Store) PurgeDerivatives(
 		attachmentSet := stringSet(request.AttachmentIDs)
 		explicitBuilds := stringSet(request.BuildIDs)
 		requestedBuilds := stringSet(request.BuildIDs)
+		rootedEmbeddingAttachments := make(map[string]struct{})
+		embeddingPayloads, err := purgeEmbeddingCatalogTx(
+			ctx, tx, versionSet, attachmentSet, explicitBuilds, request.All,
+			&report, rootedEmbeddingAttachments,
+		)
+		if err != nil {
+			return err
+		}
 		jobPurgeScopes, err := purgeRenditionJobWaitersTx(
 			ctx, tx, versionSet, attachmentSet, explicitBuilds, request.All, asOf)
 		if err != nil {
@@ -259,6 +286,9 @@ func (s *Store) PurgeDerivatives(
 				return err
 			}
 			report.RemovedHeads += count
+			if _, rooted := rootedEmbeddingAttachments[attachment.id]; rooted {
+				continue
+			}
 			result, err = tx.ExecContext(ctx,
 				`DELETE FROM rendition_attachments WHERE attachment_id=?`, attachment.id)
 			if err != nil {
@@ -498,6 +528,9 @@ func (s *Store) PurgeDerivatives(
 		report.RemovedLexicalRows += count
 
 		artifactBlobs := make(map[string]struct{})
+		for _, hash := range embeddingPayloads {
+			artifactBlobs[hash] = struct{}{}
+		}
 		if err := func() (retErr error) {
 			stagedRows, err := tx.QueryContext(ctx,
 				`SELECT blob_hash FROM rendition_blob_staging ORDER BY blob_hash`)
@@ -758,6 +791,152 @@ func validatePurgeRequest(request PurgeRequest) error {
 	return nil
 }
 
+func purgeEmbeddingCatalogTx(
+	ctx context.Context, tx *sql.Tx, versionSet, attachmentSet, buildSet map[string]struct{},
+	all bool, report *PurgeReport, rootedAttachments map[string]struct{},
+) (_ []string, retErr error) {
+	rows, err := tx.QueryContext(ctx, `SELECT s.embedding_set_id,s.content_version_id,
+		s.input_generation_id,s.vector_set_id,v.payload_blob_hash,
+		COALESCE(g.attachment_id,''),COALESCE(a.build_id,'')
+		FROM embedding_sets s
+		JOIN embedding_input_generations g ON g.generation_id=s.input_generation_id
+		JOIN embedding_vector_sets v ON v.vector_set_id=s.vector_set_id
+		LEFT JOIN rendition_attachments a ON a.attachment_id=g.attachment_id
+		ORDER BY s.embedding_set_id`)
+	if err != nil {
+		return nil, fmt.Errorf("listing embedding sets for derivative purge: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, rows.Close()) }()
+	type embeddingPurgeSet struct {
+		id, versionID, generationID, vectorSetID string
+		payload, attachmentID, buildID           string
+		explicit                                 bool
+	}
+	var catalogSets []embeddingPurgeSet
+	for rows.Next() {
+		var candidate embeddingPurgeSet
+		if err := rows.Scan(&candidate.id, &candidate.versionID, &candidate.generationID,
+			&candidate.vectorSetID, &candidate.payload,
+			&candidate.attachmentID, &candidate.buildID); err != nil {
+			return nil, fmt.Errorf("scanning embedding set for derivative purge: %w", err)
+		}
+		_, versionSelected := versionSet[candidate.versionID]
+		_, attachmentSelected := attachmentSet[candidate.attachmentID]
+		_, buildSelected := buildSet[candidate.buildID]
+		candidate.explicit = all || versionSelected ||
+			(candidate.attachmentID != "" && attachmentSelected) ||
+			(candidate.buildID != "" && buildSelected)
+		catalogSets = append(catalogSets, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing embedding sets for derivative purge: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("closing embedding set purge selection: %w", err)
+	}
+
+	var candidates []embeddingPurgeSet
+	for _, candidate := range catalogSets {
+		var rooted bool
+		if err := tx.QueryRowContext(ctx, `SELECT EXISTS(
+			SELECT 1 FROM current_rendition_roots r
+			WHERE r.active=1 AND (r.expires_at IS NULL OR r.expires_at>?) AND (
+				(r.target_kind='embedding_set' AND r.target_id=?) OR
+				(r.target_kind='embedding_input_generation' AND r.target_id=?) OR
+				(r.target_kind='embedding_vector_set' AND r.target_id=?) OR
+				(r.target_kind='embedding_payload' AND r.target_id=?)
+			))`, nowRFC3339(), candidate.id, candidate.generationID,
+			candidate.vectorSetID, candidate.payload).Scan(&rooted); err != nil {
+			return nil, fmt.Errorf("checking embedding set roots: %w", err)
+		}
+		if rooted {
+			if candidate.explicit {
+				result, err := tx.ExecContext(ctx,
+					`DELETE FROM embedding_heads WHERE embedding_set_id=?`, candidate.id)
+				if err != nil {
+					return nil, fmt.Errorf("removing rooted embedding head: %w", err)
+				}
+				count, err := rowsAffectedInt(result)
+				if err != nil {
+					return nil, err
+				}
+				report.RemovedEmbeddingHeads += count
+			}
+			if candidate.attachmentID != "" {
+				rootedAttachments[candidate.attachmentID] = struct{}{}
+			}
+			continue
+		}
+		if !candidate.explicit {
+			var collectable bool
+			if err := tx.QueryRowContext(ctx, `SELECT
+				NOT EXISTS(SELECT 1 FROM embedding_heads WHERE embedding_set_id=?)
+				AND NOT EXISTS(
+					SELECT 1 FROM content_versions cv
+					JOIN nodes n ON n.id=cv.node_id AND n.current_version_id=cv.version_id
+					 AND n.trashed_at IS NULL
+					WHERE cv.version_id=? AND (
+						?='' OR EXISTS(SELECT 1 FROM rendition_heads rh
+							WHERE rh.content_version_id=? AND rh.attachment_id=?)
+					)
+				)`, candidate.id, candidate.versionID, candidate.attachmentID,
+				candidate.versionID, candidate.attachmentID).Scan(&collectable); err != nil {
+				return nil, fmt.Errorf("checking embedding set reachability: %w", err)
+			}
+			if !collectable {
+				continue
+			}
+		}
+		candidates = append(candidates, candidate)
+	}
+
+	payloads := make(map[string]struct{})
+	for _, candidate := range candidates {
+		result, err := tx.ExecContext(ctx,
+			`DELETE FROM embedding_heads WHERE embedding_set_id=?`, candidate.id)
+		if err != nil {
+			return nil, fmt.Errorf("removing embedding head: %w", err)
+		}
+		count, err := rowsAffectedInt(result)
+		if err != nil {
+			return nil, err
+		}
+		report.RemovedEmbeddingHeads += count
+		result, err = tx.ExecContext(ctx,
+			`DELETE FROM embedding_sets WHERE embedding_set_id=?`, candidate.id)
+		if err != nil {
+			return nil, fmt.Errorf("removing embedding set: %w", err)
+		}
+		count, err = rowsAffectedInt(result)
+		if err != nil {
+			return nil, err
+		}
+		report.RemovedEmbeddingSets += count
+	}
+	collected, err := collectOrphanEmbeddingArtifactsTx(ctx, tx, nowRFC3339())
+	if err != nil {
+		return nil, err
+	}
+	report.RemovedEmbeddingInputGenerations += collected.inputGenerations
+	report.RemovedEmbeddingVectorSets += collected.vectorSets
+	for _, payload := range collected.payloads {
+		payloads[payload] = struct{}{}
+	}
+	if all {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_failures`); err != nil {
+			return nil, fmt.Errorf("removing embedding failures: %w", err)
+		}
+	} else {
+		for versionID := range versionSet {
+			if _, err := tx.ExecContext(ctx,
+				`DELETE FROM embedding_failures WHERE content_version_id=?`, versionID); err != nil {
+				return nil, fmt.Errorf("removing embedding failure: %w", err)
+			}
+		}
+	}
+	return derivativeSortedKeys(payloads), nil
+}
+
 func stringSet(values []string) map[string]struct{} {
 	result := make(map[string]struct{}, len(values))
 	for _, value := range values {
@@ -904,7 +1083,9 @@ func validateCurrentRenditionRoot(root CurrentRenditionRoot) error {
 		return fmt.Errorf("current rendition root kind %q is invalid", root.Kind)
 	}
 	switch root.TargetKind {
-	case RenditionRootBuild, RenditionRootLexicalGeneration:
+	case RenditionRootBuild, RenditionRootLexicalGeneration, RenditionRootEmbeddingSet,
+		RenditionRootEmbeddingGeneration, RenditionRootEmbeddingVectorSet,
+		RenditionRootEmbeddingPayload:
 	default:
 		return fmt.Errorf("current rendition target kind %q is invalid", root.TargetKind)
 	}
@@ -927,6 +1108,30 @@ func requireCurrentRenditionTargetTx(
 			SELECT 1 FROM rendition_lexical_generations WHERE generation_id=?
 		)`, root.TargetID).Scan(&present); err != nil {
 			return fmt.Errorf("checking current lexical generation root: %w", err)
+		}
+	case RenditionRootEmbeddingSet:
+		if err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM embedding_sets WHERE embedding_set_id=?)`, root.TargetID,
+		).Scan(&present); err != nil {
+			return fmt.Errorf("checking embedding set root: %w", err)
+		}
+	case RenditionRootEmbeddingGeneration:
+		if err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM embedding_input_generations WHERE generation_id=?)`, root.TargetID,
+		).Scan(&present); err != nil {
+			return fmt.Errorf("checking embedding generation root: %w", err)
+		}
+	case RenditionRootEmbeddingVectorSet:
+		if err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM embedding_vector_sets WHERE vector_set_id=?)`, root.TargetID,
+		).Scan(&present); err != nil {
+			return fmt.Errorf("checking embedding vector-set root: %w", err)
+		}
+	case RenditionRootEmbeddingPayload:
+		if err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM embedding_vector_sets WHERE payload_blob_hash=?)`, root.TargetID,
+		).Scan(&present); err != nil {
+			return fmt.Errorf("checking embedding payload root: %w", err)
 		}
 	}
 	if !present {
@@ -1049,6 +1254,54 @@ func (s *Store) DerivativeGCPlan(ctx context.Context) (_ DerivativeGCPlan, retEr
 			}
 		}
 		plan.Builds = candidates
+	}
+	embeddingRows, err := tx.QueryContext(ctx, `
+		SELECT s.embedding_set_id,s.input_generation_id,s.vector_set_id,v.payload_blob_hash,
+		       COALESCE(g.generation_blob_hash,'')
+		FROM embedding_sets s
+		JOIN embedding_input_generations g ON g.generation_id=s.input_generation_id
+		JOIN embedding_vector_sets v ON v.vector_set_id=s.vector_set_id
+		WHERE NOT EXISTS (SELECT 1 FROM embedding_heads h WHERE h.embedding_set_id=s.embedding_set_id)
+		  AND NOT EXISTS (
+			SELECT 1 FROM current_rendition_roots r
+			WHERE r.active=1 AND (r.expires_at IS NULL OR r.expires_at>?) AND (
+				(r.target_kind='embedding_set' AND r.target_id=s.embedding_set_id) OR
+				(r.target_kind='embedding_input_generation' AND r.target_id=s.input_generation_id) OR
+				(r.target_kind='embedding_vector_set' AND r.target_id=s.vector_set_id) OR
+				(r.target_kind='embedding_payload' AND r.target_id=v.payload_blob_hash)
+			)
+		  )
+		  AND NOT EXISTS (
+			SELECT 1 FROM content_versions cv
+			JOIN nodes n ON n.id=cv.node_id AND n.current_version_id=cv.version_id
+			 AND n.trashed_at IS NULL
+			WHERE cv.version_id=s.content_version_id AND (
+				g.attachment_id IS NULL OR EXISTS(
+					SELECT 1 FROM rendition_heads rh
+					WHERE rh.content_version_id=s.content_version_id
+					  AND rh.profile_fingerprint=s.profile_fingerprint
+					  AND rh.attachment_id=g.attachment_id
+				)
+			)
+		  )
+		ORDER BY s.embedding_set_id`, asOf)
+	if err != nil {
+		return DerivativeGCPlan{}, fmt.Errorf("planning embedding sets: %w", err)
+	}
+	defer func() { _ = embeddingRows.Close() }()
+	for embeddingRows.Next() {
+		var candidate EmbeddingSetGC
+		if err := embeddingRows.Scan(&candidate.SetID, &candidate.InputGenerationID,
+			&candidate.VectorSetID, &candidate.PayloadBlobHash, &candidate.GenerationBlobHash); err != nil {
+			return DerivativeGCPlan{}, fmt.Errorf("scanning embedding set candidate: %w", err)
+		}
+		plan.EmbeddingSets = append(plan.EmbeddingSets, candidate)
+	}
+	if err := embeddingRows.Err(); err != nil {
+		return DerivativeGCPlan{}, fmt.Errorf("planning embedding sets: %w", err)
+	}
+	if err := embeddingRows.Close(); err != nil {
+		return DerivativeGCPlan{}, fmt.Errorf("closing embedding set candidates: %w", err)
 	}
 	expiredRows, err := tx.QueryContext(ctx, `
 		SELECT root_id FROM current_rendition_roots

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -240,10 +240,13 @@ func (s *Store) PurgeDerivatives(
 		explicitBuilds := stringSet(request.BuildIDs)
 		requestedBuilds := stringSet(request.BuildIDs)
 		rootedEmbeddingAttachments := make(map[string]struct{})
-		var embeddingSuppressions []derivativePurgeSuppression
+		embeddingSuppressions, err := embeddingPurgeSuppressionsTx(ctx, tx, request, asOf)
+		if err != nil {
+			return err
+		}
 		embeddingPayloads, err := purgeEmbeddingCatalogTx(
 			ctx, tx, versionSet, attachmentSet, explicitBuilds, request.All,
-			asOf, &report, rootedEmbeddingAttachments, &embeddingSuppressions,
+			asOf, &report, rootedEmbeddingAttachments,
 		)
 		if err != nil {
 			return err
@@ -800,14 +803,11 @@ func validatePurgeRequest(request PurgeRequest) error {
 func purgeEmbeddingCatalogTx(
 	ctx context.Context, tx *sql.Tx, versionSet, attachmentSet, buildSet map[string]struct{},
 	all bool, asOf string, report *PurgeReport, rootedAttachments map[string]struct{},
-	suppressions *[]derivativePurgeSuppression,
 ) (_ []string, retErr error) {
 	rows, err := tx.QueryContext(ctx, `SELECT s.embedding_set_id,s.content_version_id,
 		s.input_generation_id,s.vector_set_id,v.payload_blob_hash,
-		COALESCE(g.attachment_id,''),COALESCE(a.build_id,''),
-		cv.blob_hash,s.profile_fingerprint,s.binding_id,s.input_kind
+		COALESCE(g.attachment_id,''),COALESCE(a.build_id,'')
 		FROM embedding_sets s
-		JOIN content_versions cv ON cv.version_id=s.content_version_id
 		JOIN embedding_input_generations g ON g.generation_id=s.input_generation_id
 		JOIN embedding_vector_sets v ON v.vector_set_id=s.vector_set_id
 		LEFT JOIN rendition_attachments a ON a.attachment_id=g.attachment_id
@@ -820,15 +820,13 @@ func purgeEmbeddingCatalogTx(
 		id, versionID, generationID, vectorSetID string
 		payload, attachmentID, buildID           string
 		explicit                                 bool
-		source, profile, binding, inputKind      string
 	}
 	var catalogSets []embeddingPurgeSet
 	for rows.Next() {
 		var candidate embeddingPurgeSet
 		if err := rows.Scan(&candidate.id, &candidate.versionID, &candidate.generationID,
 			&candidate.vectorSetID, &candidate.payload,
-			&candidate.attachmentID, &candidate.buildID, &candidate.source,
-			&candidate.profile, &candidate.binding, &candidate.inputKind); err != nil {
+			&candidate.attachmentID, &candidate.buildID); err != nil {
 			return nil, fmt.Errorf("scanning embedding set for derivative purge: %w", err)
 		}
 		_, versionSelected := versionSet[candidate.versionID]
@@ -837,14 +835,6 @@ func purgeEmbeddingCatalogTx(
 		candidate.explicit = all || versionSelected ||
 			(candidate.attachmentID != "" && attachmentSelected) ||
 			(candidate.buildID != "" && buildSelected)
-		if candidate.explicit {
-			*suppressions = append(*suppressions, derivativePurgeSuppression{
-				sourceSHA256: candidate.source, profileFingerprint: derivativeBuildSuppressionProfile,
-				buildID: embeddingPurgeScope(EmbeddingHeadKey{candidate.versionID, candidate.binding,
-					EmbeddingInputKind(candidate.inputKind)}, candidate.profile),
-				purgedAt: asOf, active: true,
-			})
-		}
 		catalogSets = append(catalogSets, candidate)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -240,7 +240,7 @@ func (s *Store) PurgeDerivatives(
 		explicitBuilds := stringSet(request.BuildIDs)
 		requestedBuilds := stringSet(request.BuildIDs)
 		rootedEmbeddingAttachments := make(map[string]struct{})
-		embeddingSuppressions, err := embeddingPurgeSuppressionsTx(ctx, tx, request, asOf)
+		embeddingSuppressions, err := prepareEmbeddingPurgeTx(ctx, tx, request, asOf)
 		if err != nil {
 			return err
 		}
@@ -930,18 +930,6 @@ func purgeEmbeddingCatalogTx(
 	report.RemovedEmbeddingVectorSets += collected.vectorSets
 	for _, payload := range collected.payloads {
 		payloads[payload] = struct{}{}
-	}
-	if all {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_failures`); err != nil {
-			return nil, fmt.Errorf("removing embedding failures: %w", err)
-		}
-	} else {
-		for versionID := range versionSet {
-			if _, err := tx.ExecContext(ctx,
-				`DELETE FROM embedding_failures WHERE content_version_id=?`, versionID); err != nil {
-				return nil, fmt.Errorf("removing embedding failure: %w", err)
-			}
-		}
 	}
 	return derivativeSortedKeys(payloads), nil
 }

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -242,7 +242,7 @@ func (s *Store) PurgeDerivatives(
 		rootedEmbeddingAttachments := make(map[string]struct{})
 		embeddingPayloads, err := purgeEmbeddingCatalogTx(
 			ctx, tx, versionSet, attachmentSet, explicitBuilds, request.All,
-			&report, rootedEmbeddingAttachments,
+			asOf, &report, rootedEmbeddingAttachments,
 		)
 		if err != nil {
 			return err
@@ -793,7 +793,7 @@ func validatePurgeRequest(request PurgeRequest) error {
 
 func purgeEmbeddingCatalogTx(
 	ctx context.Context, tx *sql.Tx, versionSet, attachmentSet, buildSet map[string]struct{},
-	all bool, report *PurgeReport, rootedAttachments map[string]struct{},
+	all bool, asOf string, report *PurgeReport, rootedAttachments map[string]struct{},
 ) (_ []string, retErr error) {
 	rows, err := tx.QueryContext(ctx, `SELECT s.embedding_set_id,s.content_version_id,
 		s.input_generation_id,s.vector_set_id,v.payload_blob_hash,
@@ -845,7 +845,7 @@ func purgeEmbeddingCatalogTx(
 				(r.target_kind='embedding_input_generation' AND r.target_id=?) OR
 				(r.target_kind='embedding_vector_set' AND r.target_id=?) OR
 				(r.target_kind='embedding_payload' AND r.target_id=?)
-			))`, nowRFC3339(), candidate.id, candidate.generationID,
+			))`, asOf, candidate.id, candidate.generationID,
 			candidate.vectorSetID, candidate.payload).Scan(&rooted); err != nil {
 			return nil, fmt.Errorf("checking embedding set roots: %w", err)
 		}
@@ -913,7 +913,7 @@ func purgeEmbeddingCatalogTx(
 		}
 		report.RemovedEmbeddingSets += count
 	}
-	collected, err := collectOrphanEmbeddingArtifactsTx(ctx, tx, nowRFC3339())
+	collected, err := collectOrphanEmbeddingArtifactsTx(ctx, tx, asOf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -240,9 +240,10 @@ func (s *Store) PurgeDerivatives(
 		explicitBuilds := stringSet(request.BuildIDs)
 		requestedBuilds := stringSet(request.BuildIDs)
 		rootedEmbeddingAttachments := make(map[string]struct{})
+		var embeddingSuppressions []derivativePurgeSuppression
 		embeddingPayloads, err := purgeEmbeddingCatalogTx(
 			ctx, tx, versionSet, attachmentSet, explicitBuilds, request.All,
-			asOf, &report, rootedEmbeddingAttachments,
+			asOf, &report, rootedEmbeddingAttachments, &embeddingSuppressions,
 		)
 		if err != nil {
 			return err
@@ -349,6 +350,11 @@ func (s *Store) PurgeDerivatives(
 			return err
 		}
 		suppressionChanges = append(suppressionChanges, jobSuppressionChanges...)
+		embeddingSuppressionChanges, err := installDerivativePurgeSuppressionRecordsTx(ctx, tx, embeddingSuppressions)
+		if err != nil {
+			return err
+		}
+		suppressionChanges = append(suppressionChanges, embeddingSuppressionChanges...)
 		legacyVersionSet := make(map[string]struct{}, len(versionSet)+len(selected))
 		for versionID := range versionSet {
 			legacyVersionSet[versionID] = struct{}{}
@@ -794,11 +800,14 @@ func validatePurgeRequest(request PurgeRequest) error {
 func purgeEmbeddingCatalogTx(
 	ctx context.Context, tx *sql.Tx, versionSet, attachmentSet, buildSet map[string]struct{},
 	all bool, asOf string, report *PurgeReport, rootedAttachments map[string]struct{},
+	suppressions *[]derivativePurgeSuppression,
 ) (_ []string, retErr error) {
 	rows, err := tx.QueryContext(ctx, `SELECT s.embedding_set_id,s.content_version_id,
 		s.input_generation_id,s.vector_set_id,v.payload_blob_hash,
-		COALESCE(g.attachment_id,''),COALESCE(a.build_id,'')
+		COALESCE(g.attachment_id,''),COALESCE(a.build_id,''),
+		cv.blob_hash,s.profile_fingerprint,s.binding_id,s.input_kind
 		FROM embedding_sets s
+		JOIN content_versions cv ON cv.version_id=s.content_version_id
 		JOIN embedding_input_generations g ON g.generation_id=s.input_generation_id
 		JOIN embedding_vector_sets v ON v.vector_set_id=s.vector_set_id
 		LEFT JOIN rendition_attachments a ON a.attachment_id=g.attachment_id
@@ -811,13 +820,15 @@ func purgeEmbeddingCatalogTx(
 		id, versionID, generationID, vectorSetID string
 		payload, attachmentID, buildID           string
 		explicit                                 bool
+		source, profile, binding, inputKind      string
 	}
 	var catalogSets []embeddingPurgeSet
 	for rows.Next() {
 		var candidate embeddingPurgeSet
 		if err := rows.Scan(&candidate.id, &candidate.versionID, &candidate.generationID,
 			&candidate.vectorSetID, &candidate.payload,
-			&candidate.attachmentID, &candidate.buildID); err != nil {
+			&candidate.attachmentID, &candidate.buildID, &candidate.source,
+			&candidate.profile, &candidate.binding, &candidate.inputKind); err != nil {
 			return nil, fmt.Errorf("scanning embedding set for derivative purge: %w", err)
 		}
 		_, versionSelected := versionSet[candidate.versionID]
@@ -826,6 +837,14 @@ func purgeEmbeddingCatalogTx(
 		candidate.explicit = all || versionSelected ||
 			(candidate.attachmentID != "" && attachmentSelected) ||
 			(candidate.buildID != "" && buildSelected)
+		if candidate.explicit {
+			*suppressions = append(*suppressions, derivativePurgeSuppression{
+				sourceSHA256: candidate.source, profileFingerprint: derivativeBuildSuppressionProfile,
+				buildID: embeddingPurgeScope(EmbeddingHeadKey{candidate.versionID, candidate.binding,
+					EmbeddingInputKind(candidate.inputKind)}, candidate.profile),
+				purgedAt: asOf, active: true,
+			})
+		}
 		catalogSets = append(catalogSets, candidate)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -446,7 +446,13 @@ func exportMetadataSnapshotWithVaultIdentity(
 	if err := exportProcessingMetadata(ctx, tx, write); err != nil {
 		return err
 	}
-	return exportEmbeddingMetadata(ctx, tx, write)
+	if err := exportEmbeddingMetadata(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportDurableCurrentRenditionRoots(ctx, tx, write); err != nil {
+		return err
+	}
+	return exportDerivativePurgeSuppressions(ctx, tx, write)
 }
 
 type metadataWrite func(any) error

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -277,6 +277,9 @@ WITH backup_authorized_blobs(hash) AS (
 	SELECT generation_blob_hash FROM embedding_input_generations
 	WHERE generation_blob_hash IS NOT NULL
 	UNION
+	SELECT evidence_fingerprint FROM embedding_input_generations
+	WHERE generation_blob_hash IS NOT NULL
+	UNION
 	SELECT payload_blob_hash FROM embedding_vector_sets
 	UNION
 	SELECT output_blob_hash FROM visual_preview_generations

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -23,7 +23,11 @@ import (
 
 const metadataFormatVersion = 1
 
-const metadataCreatedAtField = "created_at"
+const (
+	metadataCreatedAtField        = "created_at"
+	metadataGenerationIDField     = "generation_id"
+	metadataContentVersionIDField = "content_version_id"
+)
 
 // MetadataSnapshot owns a dedicated deferred read transaction. Store's normal
 // connections use BEGIN IMMEDIATE for mutations; using that pool here would
@@ -261,13 +265,19 @@ type metadataAuditMembership struct {
 }
 
 // BackupBlobAuthorityCTE is the complete blob closure for portable backup:
-// retained document versions, rendition artifacts, visual previews, staged
-// rendition sources, and no operational cursor or provider-staging rows.
+// retained document versions, rendition and embedding artifacts, visual
+// previews, staged rendition sources, and no operational cursor or
+// provider-staging rows.
 const BackupBlobAuthorityCTE = `
 WITH backup_authorized_blobs(hash) AS (
 	SELECT blob_hash FROM content_versions
 	UNION
 	SELECT blob_hash FROM rendition_artifacts
+	UNION
+	SELECT generation_blob_hash FROM embedding_input_generations
+	WHERE generation_blob_hash IS NOT NULL
+	UNION
+	SELECT payload_blob_hash FROM embedding_vector_sets
 	UNION
 	SELECT output_blob_hash FROM visual_preview_generations
 	WHERE output_blob_hash IS NOT NULL
@@ -433,7 +443,10 @@ func exportMetadataSnapshotWithVaultIdentity(
 	if !layout.hasDerivativeCatalog() {
 		return nil
 	}
-	return exportProcessingMetadata(ctx, tx, write)
+	if err := exportProcessingMetadata(ctx, tx, write); err != nil {
+		return err
+	}
+	return exportEmbeddingMetadata(ctx, tx, write)
 }
 
 type metadataWrite func(any) error
@@ -986,6 +999,14 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		    + (SELECT COUNT(*) FROM rendition_lexical_segments)
 		    + (SELECT COUNT(*) FROM rendition_attachments)
 		    + (SELECT COUNT(*) FROM rendition_heads)
+		    + (SELECT COUNT(*) FROM embedding_vector_spaces)
+		    + (SELECT COUNT(*) FROM embedding_input_generations)
+		    + (SELECT COUNT(*) FROM embedding_generation_inputs)
+		    + (SELECT COUNT(*) FROM embedding_vector_sets)
+		    + (SELECT COUNT(*) FROM embedding_vector_rows)
+		    + (SELECT COUNT(*) FROM embedding_sets)
+		    + (SELECT COUNT(*) FROM embedding_heads)
+		    + (SELECT COUNT(*) FROM embedding_failures)
 		    + (SELECT COUNT(*) FROM rendition_jobs)
 		    + (SELECT COUNT(*) FROM rendition_job_waiters)
 		    + (SELECT COUNT(*) FROM rendition_blob_staging)
@@ -1094,6 +1115,9 @@ func (s *Store) importMetadataRecord(
 	}
 	if isProcessingMetadataType(kind) {
 		return s.importProcessingMetadataRecord(ctx, tx, kind, raw)
+	}
+	if isEmbeddingMetadataType(kind) {
+		return importEmbeddingMetadataRecord(ctx, tx, kind, raw)
 	}
 	switch kind {
 	case "blob":
@@ -1365,10 +1389,10 @@ var metadataHeaderFields = []string{metadataTypeField, "format", "version", audi
 var metadataRequiredFields = map[string][]string{
 	"blob":                                 {metadataTypeField, "hash", metadataSizeField, metadataCreatedAtField},
 	metadataBlobChecksumType:               {metadataTypeField, "blob_sha256", "md5"},
-	metadataSourceMetadataGenerationType:   {metadataTypeField, "generation_id", columnSourceSHA256, "contract_version", "extractor_fingerprint", "canonical_json", "checksum", metadataCreatedAtField},
-	metadataSourceMetadataHeadType:         {metadataTypeField, columnSourceSHA256, "generation_id", "published_at"},
-	metadataVisualPreviewGenerationType:    {metadataTypeField, "generation_id", auditVaultIDField, "content_version_id", columnSourceSHA256, "contract_version", "recipe_fingerprint", "canonical_result", "checksum", metadataCreatedAtField},
-	metadataVisualPreviewHeadType:          {metadataTypeField, "content_version_id", "generation_id", "published_at"},
+	metadataSourceMetadataGenerationType:   {metadataTypeField, metadataGenerationIDField, columnSourceSHA256, "contract_version", "extractor_fingerprint", "canonical_json", "checksum", metadataCreatedAtField},
+	metadataSourceMetadataHeadType:         {metadataTypeField, columnSourceSHA256, metadataGenerationIDField, "published_at"},
+	metadataVisualPreviewGenerationType:    {metadataTypeField, metadataGenerationIDField, auditVaultIDField, metadataContentVersionIDField, columnSourceSHA256, "contract_version", "recipe_fingerprint", "canonical_result", "checksum", metadataCreatedAtField},
+	metadataVisualPreviewHeadType:          {metadataTypeField, metadataContentVersionIDField, metadataGenerationIDField, "published_at"},
 	"node":                                 {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", metadataCreatedAtField, "modified_at", "trashed_at", "trash_parent", "trash_name"},
 	"content_version":                      {metadataTypeField, "version_id", metadataNodeIDField, columnBlobHash, metadataSizeField, "mime_type", auditRecordedAtField, "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
 	metadataIngestType:                     {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
@@ -1396,6 +1420,14 @@ var metadataRequiredFields = map[string][]string{
 	metadataDerivativePurgeSuppressionType: processingMetadataRequiredFields[metadataDerivativePurgeSuppressionType],
 	metadataRenditionJobType:               processingMetadataRequiredFields[metadataRenditionJobType],
 	metadataRenditionJobWaiterType:         processingMetadataRequiredFields[metadataRenditionJobWaiterType],
+	metadataEmbeddingVectorSpaceType:       embeddingMetadataRequiredFields[metadataEmbeddingVectorSpaceType],
+	metadataEmbeddingGenerationType:        embeddingMetadataRequiredFields[metadataEmbeddingGenerationType],
+	metadataEmbeddingInputType:             embeddingMetadataRequiredFields[metadataEmbeddingInputType],
+	metadataEmbeddingVectorSetType:         embeddingMetadataRequiredFields[metadataEmbeddingVectorSetType],
+	metadataEmbeddingVectorRowType:         embeddingMetadataRequiredFields[metadataEmbeddingVectorRowType],
+	metadataEmbeddingSetType:               embeddingMetadataRequiredFields[metadataEmbeddingSetType],
+	metadataEmbeddingHeadType:              embeddingMetadataRequiredFields[metadataEmbeddingHeadType],
+	metadataEmbeddingFailureType:           embeddingMetadataRequiredFields[metadataEmbeddingFailureType],
 }
 
 var metadataNullableFields = map[string]map[string]bool{
@@ -1407,6 +1439,7 @@ var metadataNullableFields = map[string]map[string]bool{
 	metadataProvenanceType:             {"original_mtime": true, "supersedes": true},
 	"extracted_text":                   {"error": true, "text": true},
 	metadataCurrentRenditionRootType:   {"released_at": true},
+	metadataEmbeddingGenerationType:    {"attachment_id": true},
 	metadataProcessingConsentGrantType: {"expires_at": true},
 	metadataRenditionJobType: {
 		"execution_snapshot": true, "claim_owner": true, "lease_expires_at": true,
@@ -1766,6 +1799,9 @@ func validateMetadataStateWithVaultIdentity(
 	}
 	if layout.hasDerivativeCatalog() {
 		if err := validateProcessingMetadataState(ctx, tx); err != nil {
+			return err
+		}
+		if err := validateEmbeddingMetadataState(ctx, tx); err != nil {
 			return err
 		}
 		if err := validateVisualPreviewMetadataState(ctx, tx, vaultID); err != nil {

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -1703,6 +1703,9 @@ func verifyRenditionBlobCatalogAuthority(ctx context.Context, tx *sql.Tx) (retEr
 		SELECT generation_blob_hash FROM embedding_input_generations
 		WHERE generation_blob_hash IS NOT NULL
 		UNION
+		SELECT evidence_fingerprint FROM embedding_input_generations
+		WHERE generation_blob_hash IS NOT NULL
+		UNION
 		SELECT payload_blob_hash FROM embedding_vector_sets
 		ORDER BY source_sha256`)
 	if err != nil {
@@ -1824,6 +1827,17 @@ func verifyEmbeddingArtifacts(
 		}
 		if err := validateExactEmbeddingGenerationArtifact(record, data); err != nil {
 			return fmt.Errorf("validating E2 generation artifact %s: %w", id, err)
+		}
+		var evidenceSize int64
+		if err := tx.QueryRowContext(ctx, `SELECT size FROM blobs WHERE hash=?`, record.EvidenceFingerprint).Scan(&evidenceSize); err != nil {
+			return fmt.Errorf("reading E2 evidence blob size: %w", err)
+		}
+		evidence, err := read(ctx, record.EvidenceFingerprint, evidenceSize)
+		if err != nil {
+			return fmt.Errorf("reading E2 evidence artifact %s: %w", id, err)
+		}
+		if err := validateEmbeddingGenerationEvidence(record, data, evidence); err != nil {
+			return fmt.Errorf("validating E2 generation evidence %s: %w", id, err)
 		}
 		setIDs, err := stringColumnTx(ctx, tx, "embedding generation sets", `
 			SELECT embedding_set_id FROM embedding_sets
@@ -2157,7 +2171,7 @@ func validateProcessingBlobReferences(ctx context.Context, tx metadataQuerier) e
 		var dangling bool
 		if err := tx.QueryRowContext(ctx, `SELECT EXISTS(
 			SELECT 1 FROM `+reference.table+` r LEFT JOIN blobs b ON b.hash=r.`+reference.column+`
-			WHERE r.`+reference.column+` IS NOT NULL AND b.hash IS NULL)`).Scan(&dangling); err != nil {
+			WHERE r.`+reference.column+` IS NOT NULL AND b.hash IS NULL`+reference.conditionSQL()+`)`).Scan(&dangling); err != nil {
 			return fmt.Errorf("validating %s blob references: %w", reference.table, err)
 		}
 		if dangling {

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -360,13 +360,7 @@ func exportProcessingMetadata(ctx context.Context, tx metadataQuerier, write met
 	if err := exportRenditionJobs(ctx, tx, write); err != nil {
 		return err
 	}
-	if err := exportRenditionJobWaiters(ctx, tx, write); err != nil {
-		return err
-	}
-	if err := exportDurableCurrentRenditionRoots(ctx, tx, write); err != nil {
-		return err
-	}
-	return exportDerivativePurgeSuppressions(ctx, tx, write)
+	return exportRenditionJobWaiters(ctx, tx, write)
 }
 
 func exportRenditionJobs(ctx context.Context, tx metadataQuerier, write metadataWrite) error {

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -1619,9 +1619,9 @@ type RenditionBlobReader interface {
 	OpenStreamContext(ctx context.Context, hash string) (packstore.VerifiedReadCloser, int64, error)
 }
 
-// VerifyRenditionBlobBytes verifies every retained rendition source, artifact,
-// and ready visual preview through the restored mixed-storage catalog,
-// including builds that are staged but not attached to an active head.
+// VerifyRenditionBlobBytes verifies every retained rendition and embedding
+// artifact through the restored mixed-storage catalog, including builds that
+// are staged but not attached to an active head.
 func (s *Store) VerifyRenditionBlobBytes(ctx context.Context, reader RenditionBlobReader) error {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT b.source_sha256, source.size
@@ -1655,6 +1655,21 @@ func (s *Store) VerifyRenditionBlobBytes(ctx context.Context, reader RenditionBl
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterating retained rendition bytes: %w", err)
 	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing retained rendition bytes: %w", err)
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return fmt.Errorf("starting exact embedding artifact verification: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := verifyEmbeddingArtifacts(ctx, tx, func(
+		ctx context.Context, hash string, size int64,
+	) ([]byte, error) {
+		return readEmbeddingArtifact(ctx, reader, importedProcessingBlob{hash: hash, size: size})
+	}); err != nil {
+		return fmt.Errorf("verifying exact embedding artifacts: %w", err)
+	}
 	return nil
 }
 
@@ -1670,6 +1685,9 @@ func (s *Store) VerifyRenditionBlobAuthority(ctx context.Context) (retErr error)
 	defer func() { retErr = errors.Join(retErr, tx.Rollback()) }()
 	if err := validateProcessingMetadataState(ctx, tx); err != nil {
 		return fmt.Errorf("validating processing blob authority: %w", err)
+	}
+	if err := validateEmbeddingMetadataState(ctx, tx); err != nil {
+		return fmt.Errorf("validating embedding blob authority: %w", err)
 	}
 	if err := verifyRenditionBlobCatalogAuthority(ctx, tx); err != nil {
 		return fmt.Errorf("verifying processing blob authority: %w", err)
@@ -1687,6 +1705,11 @@ func verifyRenditionBlobCatalogAuthority(ctx context.Context, tx *sql.Tx) (retEr
 		WHERE output_blob_hash IS NOT NULL
 		UNION
 		SELECT source_sha256 FROM rendition_jobs
+		UNION
+		SELECT generation_blob_hash FROM embedding_input_generations
+		WHERE generation_blob_hash IS NOT NULL
+		UNION
+		SELECT payload_blob_hash FROM embedding_vector_sets
 		ORDER BY source_sha256`)
 	if err != nil {
 		return fmt.Errorf("reading processing blob catalog authority: %w", err)
@@ -1783,6 +1806,118 @@ func verifyRenditionBlob(
 		return fmt.Errorf("verifying restored rendition blob %s: %w", blob.hash, err)
 	}
 	return nil
+}
+
+type embeddingArtifactReader func(context.Context, string, int64) ([]byte, error)
+
+func verifyEmbeddingArtifacts(
+	ctx context.Context, tx *sql.Tx, read embeddingArtifactReader,
+) error {
+	generationIDs, err := loadProcessingMetadataIDs(ctx, tx, "embedding generation", `
+		SELECT generation_id FROM embedding_input_generations
+		WHERE generation_blob_hash IS NOT NULL ORDER BY generation_id`)
+	if err != nil {
+		return err
+	}
+	for _, id := range generationIDs {
+		record, err := loadInputGenerationTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		data, err := read(ctx, record.GenerationBlobHash, record.GenerationEncodedSize)
+		if err != nil {
+			return fmt.Errorf("reading E2 generation artifact %s: %w", id, err)
+		}
+		if err := validateExactEmbeddingGenerationArtifact(record, data); err != nil {
+			return fmt.Errorf("validating E2 generation artifact %s: %w", id, err)
+		}
+		setIDs, err := stringColumnTx(ctx, tx, "embedding generation sets", `
+			SELECT embedding_set_id FROM embedding_sets
+			WHERE input_generation_id=? ORDER BY embedding_set_id`, id)
+		if err != nil {
+			return err
+		}
+		for _, setID := range setIDs {
+			set, err := loadEmbeddingSetTx(ctx, tx, setID)
+			if err != nil {
+				return err
+			}
+			set.InputGeneration.GenerationJSON = data
+			binding, fingerprints, err := embeddingProfileBindingAuthority(
+				ctx, tx, set.ProcessingProfileFingerprint, set.BindingID,
+			)
+			if err != nil {
+				return err
+			}
+			if err := validateEmbeddingBindingAuthority(set, binding, fingerprints); err != nil {
+				return fmt.Errorf("validating E2 generation profile binding %s: %w", setID, err)
+			}
+		}
+	}
+	vectorSetIDs, err := loadProcessingMetadataIDs(ctx, tx, "embedding vector set", `
+		SELECT vector_set_id FROM embedding_vector_sets ORDER BY vector_set_id`)
+	if err != nil {
+		return err
+	}
+	for _, id := range vectorSetIDs {
+		vectorSet, err := loadVectorSetTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		var generationID string
+		if err := tx.QueryRowContext(ctx, `SELECT input_generation_id FROM embedding_sets
+			WHERE vector_set_id=? ORDER BY embedding_set_id LIMIT 1`, id).Scan(&generationID); err != nil {
+			return fmt.Errorf("finding vector-set generation %s: %w", id, err)
+		}
+		generation, err := loadInputGenerationTx(ctx, tx, generationID)
+		if err != nil {
+			return err
+		}
+		space, err := loadVectorSpaceTx(ctx, tx, vectorSet.VectorSpaceID)
+		if err != nil {
+			return err
+		}
+		data, err := read(ctx, vectorSet.PayloadBlobHash, vectorSet.PayloadSize)
+		if err != nil {
+			return fmt.Errorf("reading vector-set artifact %s: %w", id, err)
+		}
+		if err := validateExactEmbeddingVectorArtifact(vectorSet, space, generation, data); err != nil {
+			return fmt.Errorf("validating vector-set artifact %s: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func readEmbeddingArtifact(
+	ctx context.Context, reader RenditionBlobReader, blob importedProcessingBlob,
+) (data []byte, retErr error) {
+	if blob.size < 1 || blob.size > 64<<20 {
+		return nil, errors.New("embedding artifact size exceeds bounds")
+	}
+	stream, logicalSize, err := reader.OpenStreamContext(ctx, blob.hash)
+	if err != nil {
+		return nil, fmt.Errorf("opening restored embedding artifact %s: %w", blob.hash, err)
+	}
+	defer func() { retErr = errors.Join(retErr, stream.Close()) }()
+	if logicalSize != blob.size {
+		return nil, fmt.Errorf(
+			"restored embedding artifact %s size %d does not match catalog size %d",
+			blob.hash, logicalSize, blob.size,
+		)
+	}
+	data, err = io.ReadAll(io.LimitReader(stream, blob.size+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading restored embedding artifact %s: %w", blob.hash, err)
+	}
+	if int64(len(data)) != blob.size {
+		return nil, fmt.Errorf(
+			"restored embedding artifact %s read %d bytes, want %d", blob.hash, len(data), blob.size,
+		)
+	}
+	if err := stream.Verify(); err != nil {
+		return nil, fmt.Errorf("verifying restored embedding artifact %s: %w", blob.hash, err)
+	}
+	return data, nil
 }
 
 // validateImportedRenditionHead checks that a restored head resolves through
@@ -2487,6 +2622,22 @@ func validateCurrentRenditionRootState(ctx context.Context, tx metadataQuerier) 
 			err = tx.QueryRowContext(ctx, `SELECT EXISTS(
 				SELECT 1 FROM rendition_lexical_generations WHERE generation_id=?
 			)`, root.TargetID).Scan(&present)
+		case RenditionRootEmbeddingSet:
+			err = tx.QueryRowContext(ctx, `SELECT EXISTS(
+				SELECT 1 FROM embedding_sets WHERE embedding_set_id=?
+			)`, root.TargetID).Scan(&present)
+		case RenditionRootEmbeddingGeneration:
+			err = tx.QueryRowContext(ctx, `SELECT EXISTS(
+				SELECT 1 FROM embedding_input_generations WHERE generation_id=?
+			)`, root.TargetID).Scan(&present)
+		case RenditionRootEmbeddingVectorSet:
+			err = tx.QueryRowContext(ctx, `SELECT EXISTS(
+				SELECT 1 FROM embedding_vector_sets WHERE vector_set_id=?
+			)`, root.TargetID).Scan(&present)
+		case RenditionRootEmbeddingPayload:
+			err = tx.QueryRowContext(ctx, `SELECT EXISTS(
+				SELECT 1 FROM embedding_vector_sets WHERE payload_blob_hash=?
+			)`, root.TargetID).Scan(&present)
 		}
 		if err != nil {
 			return fmt.Errorf("validating current rendition root %s target: %w", root.ID, err)
@@ -2525,6 +2676,8 @@ func validateCurrentRenditionRootState(ctx context.Context, tx metadataQuerier) 
 						"current rendition job root %s does not match the job lexical generation", root.ID)
 				}
 				activeJobGenerationRoots[jobID] = true
+			default:
+				return fmt.Errorf("current rendition job root %s has invalid target kind %s", root.ID, root.TargetKind)
 			}
 		}
 	}

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -1864,15 +1864,6 @@ func verifyEmbeddingArtifacts(
 		if err != nil {
 			return err
 		}
-		var generationID string
-		if err := tx.QueryRowContext(ctx, `SELECT input_generation_id FROM embedding_sets
-			WHERE vector_set_id=? ORDER BY embedding_set_id LIMIT 1`, id).Scan(&generationID); err != nil {
-			return fmt.Errorf("finding vector-set generation %s: %w", id, err)
-		}
-		generation, err := loadInputGenerationTx(ctx, tx, generationID)
-		if err != nil {
-			return err
-		}
 		space, err := loadVectorSpaceTx(ctx, tx, vectorSet.VectorSpaceID)
 		if err != nil {
 			return err
@@ -1881,7 +1872,7 @@ func verifyEmbeddingArtifacts(
 		if err != nil {
 			return fmt.Errorf("reading vector-set artifact %s: %w", id, err)
 		}
-		if err := validateExactEmbeddingVectorArtifact(vectorSet, space, generation, data); err != nil {
+		if err := validateExactEmbeddingVectorArtifact(vectorSet, space, data); err != nil {
 			return fmt.Errorf("validating vector-set artifact %s: %w", id, err)
 		}
 	}

--- a/internal/store/rendition_delete.go
+++ b/internal/store/rendition_delete.go
@@ -18,6 +18,9 @@ func deleteRenditionAuthorityForVersionsTx(
 	if len(versionIDs) == 0 {
 		return nil
 	}
+	if err := deleteEmbeddingAuthorityForVersionsTx(ctx, tx, versionIDs); err != nil {
+		return err
+	}
 	deleteHeads, err := tx.PrepareContext(ctx,
 		`DELETE FROM rendition_heads WHERE content_version_id=?`)
 	if err != nil {
@@ -48,6 +51,28 @@ func deleteRenditionAuthorityForVersionsTx(
 		}
 	}
 	return reconcileRenditionJobsAfterWaiterDeletionTx(ctx, tx, nowRFC3339())
+}
+
+// deleteEmbeddingAuthorityForVersionsTx removes dependent derivative
+// authority before the owning version and its rendition attachment. Immutable
+// vector/generation authority remains for the shared derivative GC path, which
+// applies its roots independently after the version-owned sets are gone.
+func deleteEmbeddingAuthorityForVersionsTx(ctx context.Context, tx *sql.Tx, versionIDs []string) error {
+	for _, versionID := range versionIDs {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM current_rendition_roots WHERE
+			target_kind='embedding_set' AND target_id IN (
+				SELECT embedding_set_id FROM embedding_sets WHERE content_version_id=?)`,
+			versionID); err != nil {
+			return fmt.Errorf("releasing embedding roots for content version %s: %w", versionID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_heads WHERE content_version_id=?`, versionID); err != nil {
+			return fmt.Errorf("deleting embedding heads for content version %s: %w", versionID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_sets WHERE content_version_id=?`, versionID); err != nil {
+			return fmt.Errorf("deleting embedding sets for content version %s: %w", versionID, err)
+		}
+	}
+	return nil
 }
 
 // reconcileRenditionJobsAfterWaiterDeletionTx reselects or requeues shared

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -695,24 +695,24 @@ CREATE TABLE IF NOT EXISTS rendition_heads (
 CREATE TABLE IF NOT EXISTS embedding_vector_spaces (
     vector_space_id          TEXT PRIMARY KEY,
     contract_version         TEXT NOT NULL,
-    descriptor_json          BLOB NOT NULL CHECK (length(descriptor_json) BETWEEN 2 AND 65536),
-    provider_descriptor      TEXT NOT NULL CHECK (length(CAST(provider_descriptor AS BLOB)) BETWEEN 1 AND 1024),
-    provider_revision        TEXT NOT NULL CHECK (length(CAST(provider_revision AS BLOB)) BETWEEN 1 AND 1024),
+    descriptor_json          BLOB NOT NULL CHECK (length(descriptor_json) > 0),
+    provider_descriptor      TEXT NOT NULL CHECK (length(CAST(provider_descriptor AS BLOB)) > 0),
+    provider_revision        TEXT NOT NULL CHECK (length(CAST(provider_revision AS BLOB)) > 0),
     descriptor_fingerprint   TEXT NOT NULL,
-    compatibility_id         TEXT NOT NULL CHECK (length(CAST(compatibility_id AS BLOB)) BETWEEN 1 AND 1024),
-    dimensions               INTEGER NOT NULL CHECK (dimensions BETWEEN 1 AND 1048576),
-    metric                   TEXT NOT NULL CHECK (length(CAST(metric AS BLOB)) BETWEEN 1 AND 64),
-    normalization            TEXT NOT NULL CHECK (length(CAST(normalization AS BLOB)) BETWEEN 1 AND 64),
-    scalar_encoding          TEXT NOT NULL CHECK (length(CAST(scalar_encoding AS BLOB)) BETWEEN 1 AND 64),
-    document_formatter       TEXT NOT NULL CHECK (length(CAST(document_formatter AS BLOB)) BETWEEN 1 AND 1024),
-    query_formatter          TEXT NOT NULL CHECK (length(CAST(query_formatter AS BLOB)) BETWEEN 1 AND 1024),
+    compatibility_id         TEXT NOT NULL CHECK (length(CAST(compatibility_id AS BLOB)) > 0),
+    dimensions               INTEGER NOT NULL CHECK (dimensions > 0),
+    metric                   TEXT NOT NULL CHECK (length(CAST(metric AS BLOB)) > 0),
+    normalization            TEXT NOT NULL CHECK (length(CAST(normalization AS BLOB)) > 0),
+    scalar_encoding          TEXT NOT NULL CHECK (length(CAST(scalar_encoding AS BLOB)) > 0),
+    document_formatter       TEXT NOT NULL CHECK (length(CAST(document_formatter AS BLOB)) > 0),
+    query_formatter          TEXT NOT NULL CHECK (length(CAST(query_formatter AS BLOB)) > 0),
     model_input_fingerprint  TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS embedding_input_generations (
     generation_id                  TEXT PRIMARY KEY,
     generation_blob_hash           TEXT REFERENCES blobs(hash),
-    generation_encoded_size        INTEGER NOT NULL CHECK (generation_encoded_size BETWEEN 0 AND 67108864),
+    generation_encoded_size        INTEGER NOT NULL,
     generation_checksum            TEXT NOT NULL,
     source_version_id              TEXT NOT NULL,
     profile_fingerprint            TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
@@ -722,17 +722,17 @@ CREATE TABLE IF NOT EXISTS embedding_input_generations (
     formatter_fingerprint          TEXT NOT NULL,
     attachment_context_fingerprint TEXT NOT NULL,
     attachment_id                  TEXT,
-    input_count                    INTEGER NOT NULL CHECK (input_count BETWEEN 1 AND 100000),
+    input_count                    INTEGER NOT NULL CHECK (input_count > 0),
     created_at                     TEXT NOT NULL,
     CHECK (attachment_context_fingerprint = '' OR attachment_id IS NOT NULL),
     CHECK ((generation_blob_hash IS NULL AND generation_encoded_size = 0)
-        OR (generation_blob_hash IS NOT NULL AND generation_encoded_size >= 2))
+        OR (generation_blob_hash IS NOT NULL AND generation_encoded_size > 0))
 );
 
 CREATE TABLE IF NOT EXISTS embedding_generation_inputs (
     generation_id     TEXT NOT NULL REFERENCES embedding_input_generations(generation_id) ON DELETE CASCADE,
-    input_id          TEXT NOT NULL CHECK (length(CAST(input_id AS BLOB)) BETWEEN 1 AND 1024),
-    input_order       INTEGER NOT NULL CHECK (input_order BETWEEN 0 AND 99999),
+    input_id          TEXT NOT NULL CHECK (length(CAST(input_id AS BLOB)) > 0),
+    input_order       INTEGER NOT NULL CHECK (input_order >= 0),
     rendered_checksum TEXT NOT NULL,
     PRIMARY KEY (generation_id, input_id),
     UNIQUE (generation_id, input_order)
@@ -743,19 +743,19 @@ CREATE TABLE IF NOT EXISTS embedding_vector_sets (
     contract_version   TEXT NOT NULL,
     vector_space_id    TEXT NOT NULL REFERENCES embedding_vector_spaces(vector_space_id),
     payload_blob_hash  TEXT NOT NULL REFERENCES blobs(hash),
-    payload_size       INTEGER NOT NULL CHECK (payload_size BETWEEN 1 AND 67108864),
+    payload_size       INTEGER NOT NULL CHECK (payload_size > 0),
     payload_checksum   TEXT NOT NULL,
     manifest_checksum  TEXT NOT NULL,
-    row_count          INTEGER NOT NULL CHECK (row_count BETWEEN 1 AND 100000),
-    dimensions         INTEGER NOT NULL CHECK (dimensions BETWEEN 1 AND 1048576)
+    row_count          INTEGER NOT NULL CHECK (row_count > 0),
+    dimensions         INTEGER NOT NULL CHECK (dimensions > 0)
 );
 
 CREATE TABLE IF NOT EXISTS embedding_vector_rows (
     vector_set_id  TEXT NOT NULL REFERENCES embedding_vector_sets(vector_set_id) ON DELETE CASCADE,
-    row_id         TEXT NOT NULL CHECK (length(CAST(row_id AS BLOB)) BETWEEN 1 AND 1024),
-    row_order      INTEGER NOT NULL CHECK (row_order BETWEEN 0 AND 99999),
-    input_id       TEXT NOT NULL CHECK (length(CAST(input_id AS BLOB)) BETWEEN 1 AND 1024),
-    dimensions     INTEGER NOT NULL CHECK (dimensions BETWEEN 1 AND 1048576),
+    row_id         TEXT NOT NULL CHECK (length(CAST(row_id AS BLOB)) > 0),
+    row_order      INTEGER NOT NULL CHECK (row_order >= 0),
+    input_id       TEXT NOT NULL CHECK (length(CAST(input_id AS BLOB)) > 0),
+    dimensions     INTEGER NOT NULL CHECK (dimensions > 0),
     checksum       TEXT NOT NULL,
     PRIMARY KEY (vector_set_id, row_id),
     UNIQUE (vector_set_id, row_order),
@@ -768,7 +768,7 @@ CREATE INDEX IF NOT EXISTS embedding_vector_sets_payload
 CREATE TABLE IF NOT EXISTS embedding_sets (
     embedding_set_id             TEXT PRIMARY KEY,
     vault_uid                    TEXT NOT NULL REFERENCES vault_metadata(vault_uid),
-    binding_id                   TEXT NOT NULL CHECK (length(CAST(binding_id AS BLOB)) BETWEEN 1 AND 1024),
+    binding_id                   TEXT NOT NULL CHECK (length(CAST(binding_id AS BLOB)) > 0),
     input_kind                   TEXT NOT NULL,
     content_version_id           TEXT NOT NULL REFERENCES content_versions(version_id),
     profile_fingerprint          TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
@@ -807,7 +807,7 @@ CREATE INDEX IF NOT EXISTS embedding_heads_set
 CREATE TABLE IF NOT EXISTS embedding_failures (
     content_version_id   TEXT NOT NULL REFERENCES content_versions(version_id) ON DELETE CASCADE,
     profile_fingerprint  TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
-    binding_id           TEXT NOT NULL CHECK (length(CAST(binding_id AS BLOB)) BETWEEN 1 AND 1024),
+    binding_id           TEXT NOT NULL CHECK (length(CAST(binding_id AS BLOB)) > 0),
     input_kind           TEXT NOT NULL,
     failure_code         TEXT NOT NULL,
     failed_at            TEXT NOT NULL,

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -694,7 +694,7 @@ CREATE TABLE IF NOT EXISTS rendition_heads (
 -- checksums, membership, activation pointers, and provider-neutral failures.
 CREATE TABLE IF NOT EXISTS embedding_vector_spaces (
     vector_space_id          TEXT PRIMARY KEY,
-    contract_version         TEXT NOT NULL CHECK (contract_version = 'embedding-vector-space/v1'),
+    contract_version         TEXT NOT NULL,
     descriptor_json          BLOB NOT NULL CHECK (length(descriptor_json) BETWEEN 2 AND 65536),
     provider_descriptor      TEXT NOT NULL CHECK (length(CAST(provider_descriptor AS BLOB)) BETWEEN 1 AND 1024),
     provider_revision        TEXT NOT NULL CHECK (length(CAST(provider_revision AS BLOB)) BETWEEN 1 AND 1024),
@@ -740,7 +740,7 @@ CREATE TABLE IF NOT EXISTS embedding_generation_inputs (
 
 CREATE TABLE IF NOT EXISTS embedding_vector_sets (
     vector_set_id      TEXT PRIMARY KEY,
-    contract_version   TEXT NOT NULL CHECK (contract_version = 'vector-set/v1'),
+    contract_version   TEXT NOT NULL,
     vector_space_id    TEXT NOT NULL REFERENCES embedding_vector_spaces(vector_space_id),
     payload_blob_hash  TEXT NOT NULL REFERENCES blobs(hash),
     payload_size       INTEGER NOT NULL CHECK (payload_size BETWEEN 1 AND 67108864),
@@ -769,7 +769,7 @@ CREATE TABLE IF NOT EXISTS embedding_sets (
     embedding_set_id             TEXT PRIMARY KEY,
     vault_uid                    TEXT NOT NULL REFERENCES vault_metadata(vault_uid),
     binding_id                   TEXT NOT NULL CHECK (length(CAST(binding_id AS BLOB)) BETWEEN 1 AND 1024),
-    input_kind                   TEXT NOT NULL CHECK (input_kind IN ('rendition_chunk', 'original_file')),
+    input_kind                   TEXT NOT NULL,
     content_version_id           TEXT NOT NULL REFERENCES content_versions(version_id),
     profile_fingerprint          TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
     embedding_input_fingerprint  TEXT NOT NULL,
@@ -793,7 +793,7 @@ CREATE INDEX IF NOT EXISTS embedding_sets_vector_space
 CREATE TABLE IF NOT EXISTS embedding_heads (
     content_version_id   TEXT NOT NULL,
     binding_id           TEXT NOT NULL,
-    input_kind           TEXT NOT NULL CHECK (input_kind IN ('rendition_chunk', 'original_file')),
+    input_kind           TEXT NOT NULL,
     embedding_set_id     TEXT NOT NULL REFERENCES embedding_sets(embedding_set_id),
     vector_space_id      TEXT NOT NULL REFERENCES embedding_vector_spaces(vector_space_id),
     profile_fingerprint  TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
@@ -808,10 +808,8 @@ CREATE TABLE IF NOT EXISTS embedding_failures (
     content_version_id   TEXT NOT NULL REFERENCES content_versions(version_id) ON DELETE CASCADE,
     profile_fingerprint  TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
     binding_id           TEXT NOT NULL CHECK (length(CAST(binding_id AS BLOB)) BETWEEN 1 AND 1024),
-    input_kind           TEXT NOT NULL CHECK (input_kind IN ('rendition_chunk', 'original_file')),
-    failure_code         TEXT NOT NULL CHECK (failure_code IN (
-        'provider_unavailable','authorization','invalid_response','input_rejected','stale_authority'
-    )),
+    input_kind           TEXT NOT NULL,
+    failure_code         TEXT NOT NULL,
     failed_at            TEXT NOT NULL,
     PRIMARY KEY (content_version_id, profile_fingerprint, binding_id, input_kind)
 );

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -813,6 +813,7 @@ CREATE TABLE IF NOT EXISTS embedding_failures (
     failure_code         TEXT NOT NULL,
     failed_at            TEXT NOT NULL,
     fencing_token        INTEGER NOT NULL,
+    attachment_id        TEXT NOT NULL,
     PRIMARY KEY (content_version_id, profile_fingerprint, binding_id, input_kind)
 );
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -798,6 +798,7 @@ CREATE TABLE IF NOT EXISTS embedding_heads (
     vector_space_id      TEXT NOT NULL REFERENCES embedding_vector_spaces(vector_space_id),
     profile_fingerprint  TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
     published_at         TEXT NOT NULL,
+    fencing_token        INTEGER NOT NULL,
     PRIMARY KEY (content_version_id, profile_fingerprint, binding_id, input_kind)
 );
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -812,6 +812,7 @@ CREATE TABLE IF NOT EXISTS embedding_failures (
     input_kind           TEXT NOT NULL,
     failure_code         TEXT NOT NULL,
     failed_at            TEXT NOT NULL,
+    fencing_token        INTEGER NOT NULL,
     PRIMARY KEY (content_version_id, profile_fingerprint, binding_id, input_kind)
 );
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -689,6 +689,157 @@ CREATE TABLE IF NOT EXISTS rendition_heads (
         ) ON DELETE CASCADE
 );
 
+-- Embedding authority is normalized into immutable identities. Rendered text
+-- and vector bytes remain in bounded derivative payloads; SQLite retains only
+-- checksums, membership, activation pointers, and provider-neutral failures.
+CREATE TABLE IF NOT EXISTS embedding_vector_spaces (
+    vector_space_id          TEXT PRIMARY KEY,
+    contract_version         TEXT NOT NULL CHECK (contract_version = 'embedding-vector-space/v1'),
+    descriptor_json          BLOB NOT NULL CHECK (length(descriptor_json) BETWEEN 2 AND 65536),
+    provider_descriptor      TEXT NOT NULL CHECK (length(CAST(provider_descriptor AS BLOB)) BETWEEN 1 AND 1024),
+    provider_revision        TEXT NOT NULL CHECK (length(CAST(provider_revision AS BLOB)) BETWEEN 1 AND 1024),
+    descriptor_fingerprint   TEXT NOT NULL,
+    compatibility_id         TEXT NOT NULL CHECK (length(CAST(compatibility_id AS BLOB)) BETWEEN 1 AND 1024),
+    dimensions               INTEGER NOT NULL CHECK (dimensions BETWEEN 1 AND 1048576),
+    metric                   TEXT NOT NULL CHECK (length(CAST(metric AS BLOB)) BETWEEN 1 AND 64),
+    normalization            TEXT NOT NULL CHECK (length(CAST(normalization AS BLOB)) BETWEEN 1 AND 64),
+    scalar_encoding          TEXT NOT NULL CHECK (length(CAST(scalar_encoding AS BLOB)) BETWEEN 1 AND 64),
+    document_formatter       TEXT NOT NULL CHECK (length(CAST(document_formatter AS BLOB)) BETWEEN 1 AND 1024),
+    query_formatter          TEXT NOT NULL CHECK (length(CAST(query_formatter AS BLOB)) BETWEEN 1 AND 1024),
+    model_input_fingerprint  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS embedding_input_generations (
+    generation_id                  TEXT PRIMARY KEY,
+    generation_blob_hash           TEXT REFERENCES blobs(hash),
+    generation_encoded_size        INTEGER NOT NULL CHECK (generation_encoded_size BETWEEN 0 AND 67108864),
+    generation_checksum            TEXT NOT NULL,
+    source_version_id              TEXT NOT NULL,
+    profile_fingerprint            TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
+    evidence_fingerprint           TEXT NOT NULL,
+    tokenizer_fingerprint          TEXT NOT NULL,
+    chunk_policy_fingerprint       TEXT NOT NULL,
+    formatter_fingerprint          TEXT NOT NULL,
+    attachment_context_fingerprint TEXT NOT NULL,
+    attachment_id                  TEXT,
+    input_count                    INTEGER NOT NULL CHECK (input_count BETWEEN 1 AND 100000),
+    created_at                     TEXT NOT NULL,
+    CHECK (attachment_context_fingerprint = '' OR attachment_id IS NOT NULL),
+    CHECK ((generation_blob_hash IS NULL AND generation_encoded_size = 0)
+        OR (generation_blob_hash IS NOT NULL AND generation_encoded_size >= 2))
+);
+
+CREATE TABLE IF NOT EXISTS embedding_generation_inputs (
+    generation_id     TEXT NOT NULL REFERENCES embedding_input_generations(generation_id) ON DELETE CASCADE,
+    input_id          TEXT NOT NULL CHECK (length(CAST(input_id AS BLOB)) BETWEEN 1 AND 1024),
+    input_order       INTEGER NOT NULL CHECK (input_order BETWEEN 0 AND 99999),
+    rendered_checksum TEXT NOT NULL,
+    PRIMARY KEY (generation_id, input_id),
+    UNIQUE (generation_id, input_order)
+);
+
+CREATE TABLE IF NOT EXISTS embedding_vector_sets (
+    vector_set_id      TEXT PRIMARY KEY,
+    contract_version   TEXT NOT NULL CHECK (contract_version = 'vector-set/v1'),
+    vector_space_id    TEXT NOT NULL REFERENCES embedding_vector_spaces(vector_space_id),
+    payload_blob_hash  TEXT NOT NULL REFERENCES blobs(hash),
+    payload_size       INTEGER NOT NULL CHECK (payload_size BETWEEN 1 AND 67108864),
+    payload_checksum   TEXT NOT NULL,
+    manifest_checksum  TEXT NOT NULL,
+    row_count          INTEGER NOT NULL CHECK (row_count BETWEEN 1 AND 100000),
+    dimensions         INTEGER NOT NULL CHECK (dimensions BETWEEN 1 AND 1048576)
+);
+
+CREATE TABLE IF NOT EXISTS embedding_vector_rows (
+    vector_set_id  TEXT NOT NULL REFERENCES embedding_vector_sets(vector_set_id) ON DELETE CASCADE,
+    row_id         TEXT NOT NULL CHECK (length(CAST(row_id AS BLOB)) BETWEEN 1 AND 1024),
+    row_order      INTEGER NOT NULL CHECK (row_order BETWEEN 0 AND 99999),
+    input_id       TEXT NOT NULL CHECK (length(CAST(input_id AS BLOB)) BETWEEN 1 AND 1024),
+    dimensions     INTEGER NOT NULL CHECK (dimensions BETWEEN 1 AND 1048576),
+    checksum       TEXT NOT NULL,
+    PRIMARY KEY (vector_set_id, row_id),
+    UNIQUE (vector_set_id, row_order),
+    UNIQUE (vector_set_id, input_id)
+);
+
+CREATE INDEX IF NOT EXISTS embedding_vector_sets_payload
+    ON embedding_vector_sets(payload_blob_hash, vector_set_id);
+
+CREATE TABLE IF NOT EXISTS embedding_sets (
+    embedding_set_id             TEXT PRIMARY KEY,
+    vault_uid                    TEXT NOT NULL REFERENCES vault_metadata(vault_uid),
+    binding_id                   TEXT NOT NULL CHECK (length(CAST(binding_id AS BLOB)) BETWEEN 1 AND 1024),
+    input_kind                   TEXT NOT NULL CHECK (input_kind IN ('rendition_chunk', 'original_file')),
+    content_version_id           TEXT NOT NULL REFERENCES content_versions(version_id),
+    profile_fingerprint          TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
+    embedding_input_fingerprint  TEXT NOT NULL,
+    vector_space_id              TEXT NOT NULL REFERENCES embedding_vector_spaces(vector_space_id),
+    input_generation_id          TEXT NOT NULL REFERENCES embedding_input_generations(generation_id),
+    vector_set_id                TEXT NOT NULL REFERENCES embedding_vector_sets(vector_set_id),
+    created_at                   TEXT NOT NULL,
+    UNIQUE (vault_uid, content_version_id, binding_id, input_kind,
+            vector_space_id, input_generation_id, vector_set_id)
+);
+
+CREATE INDEX IF NOT EXISTS embedding_sets_content_version
+    ON embedding_sets(content_version_id, embedding_set_id);
+CREATE INDEX IF NOT EXISTS embedding_sets_input_generation
+    ON embedding_sets(input_generation_id, embedding_set_id);
+CREATE INDEX IF NOT EXISTS embedding_sets_vector_set
+    ON embedding_sets(vector_set_id, embedding_set_id);
+CREATE INDEX IF NOT EXISTS embedding_sets_vector_space
+    ON embedding_sets(vector_space_id, embedding_set_id);
+
+CREATE TABLE IF NOT EXISTS embedding_heads (
+    content_version_id   TEXT NOT NULL,
+    binding_id           TEXT NOT NULL,
+    input_kind           TEXT NOT NULL CHECK (input_kind IN ('rendition_chunk', 'original_file')),
+    embedding_set_id     TEXT NOT NULL REFERENCES embedding_sets(embedding_set_id),
+    vector_space_id      TEXT NOT NULL REFERENCES embedding_vector_spaces(vector_space_id),
+    profile_fingerprint  TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
+    published_at         TEXT NOT NULL,
+    PRIMARY KEY (content_version_id, profile_fingerprint, binding_id, input_kind)
+);
+
+CREATE INDEX IF NOT EXISTS embedding_heads_set
+    ON embedding_heads(embedding_set_id);
+
+CREATE TABLE IF NOT EXISTS embedding_failures (
+    content_version_id   TEXT NOT NULL REFERENCES content_versions(version_id) ON DELETE CASCADE,
+    profile_fingerprint  TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
+    binding_id           TEXT NOT NULL CHECK (length(CAST(binding_id AS BLOB)) BETWEEN 1 AND 1024),
+    input_kind           TEXT NOT NULL CHECK (input_kind IN ('rendition_chunk', 'original_file')),
+    failure_code         TEXT NOT NULL CHECK (failure_code IN (
+        'provider_unavailable','authorization','invalid_response','input_rejected','stale_authority'
+    )),
+    failed_at            TEXT NOT NULL,
+    PRIMARY KEY (content_version_id, profile_fingerprint, binding_id, input_kind)
+);
+
+CREATE TRIGGER IF NOT EXISTS embedding_vector_spaces_immutable_update
+BEFORE UPDATE ON embedding_vector_spaces BEGIN
+    SELECT RAISE(ABORT, 'embedding vector space records are immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS embedding_input_generations_immutable_update
+BEFORE UPDATE ON embedding_input_generations BEGIN
+    SELECT RAISE(ABORT, 'embedding input generation records are immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS embedding_generation_inputs_immutable_update
+BEFORE UPDATE ON embedding_generation_inputs BEGIN
+    SELECT RAISE(ABORT, 'embedding input records are immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS embedding_vector_sets_immutable_update
+BEFORE UPDATE ON embedding_vector_sets BEGIN
+    SELECT RAISE(ABORT, 'embedding vector set records are immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS embedding_vector_rows_immutable_update
+BEFORE UPDATE ON embedding_vector_rows BEGIN
+    SELECT RAISE(ABORT, 'embedding vector row records are immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS embedding_sets_immutable_update
+BEFORE UPDATE ON embedding_sets BEGIN
+    SELECT RAISE(ABORT, 'embedding set records are immutable');
+END;
 -- The lexical projection is rebuildable search state over immutable rendition
 -- builds. Segment text is indexed once per build in rendition_lexical_index;
 -- the FTS table is an external-content index over it. A generation names one

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1013,6 +1013,15 @@ func insertRenditionAttachmentAndHeadTx(
 		head.AttachmentID, head.PublishedAt); err != nil {
 		return fmt.Errorf("publishing rendition head: %w", err)
 	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_heads
+		WHERE content_version_id=? AND profile_fingerprint=? AND EXISTS (
+			SELECT 1 FROM embedding_sets s
+			JOIN embedding_input_generations g ON g.generation_id=s.input_generation_id
+			WHERE s.embedding_set_id=embedding_heads.embedding_set_id
+			  AND g.attachment_id IS NOT NULL AND g.attachment_id<>?
+		)`, head.ContentVersionID, head.ProcessingProfileFingerprint, head.AttachmentID); err != nil {
+		return fmt.Errorf("revoking stale chunk embedding heads: %w", err)
+	}
 	return nil
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1022,6 +1022,12 @@ func insertRenditionAttachmentAndHeadTx(
 		)`, head.ContentVersionID, head.ProcessingProfileFingerprint, head.AttachmentID); err != nil {
 		return fmt.Errorf("revoking stale chunk embedding heads: %w", err)
 	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_failures
+		WHERE content_version_id=? AND profile_fingerprint=?
+		  AND attachment_id<>'' AND attachment_id<>?`,
+		head.ContentVersionID, head.ProcessingProfileFingerprint, head.AttachmentID); err != nil {
+		return fmt.Errorf("clearing stale chunk embedding failures: %w", err)
+	}
 	return nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,7 +31,7 @@ type Store struct {
 // by this binary. It is intentionally independent of metadata JSONL's logical
 // format version: physical schema changes can rebuild through the same logical
 // format without changing that portable contract.
-const currentStorageSchemaVersion = 4
+const currentStorageSchemaVersion = 5
 
 // DefaultSQLiteDriver returns the build's standalone-compatible adapter: CGO
 // builds use mattn/go-sqlite3 and no-CGO builds use modernc.org/sqlite.
@@ -116,6 +116,9 @@ func (s *Store) bootstrapTx() error {
 	return s.withStorageTx(context.Background(), func(tx *sql.Tx) error {
 		if _, err := tx.Exec(schemaSQL); err != nil {
 			return fmt.Errorf("applying schema: %w", err)
+		}
+		if err := validateEmbeddingCatalogSchemaTx(context.Background(), tx); err != nil {
+			return err
 		}
 		var schemaVersion int
 		if err := tx.QueryRow(`

--- a/internal/store/upgrade.go
+++ b/internal/store/upgrade.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	v090BackupSuffix = ".v0.9.0.bak"
-	v2BackupSuffix   = ".schema-v2.bak"
-	v3BackupSuffix   = ".schema-v3.bak"
+	v090BackupSuffix                 = ".v0.9.0.bak"
+	v2BackupSuffix                   = ".schema-v2.bak"
+	v3BackupSuffix                   = ".schema-v3.bak"
+	lastReleasedStorageSchemaVersion = 3
 )
 
 type databaseSchema struct {
@@ -138,7 +139,7 @@ func validateReleasedStorageSchemas() error {
 		versions[source.version] = true
 		suffixes[source.backupSuffix] = true
 	}
-	for version := 1; version < currentStorageSchemaVersion; version++ {
+	for version := 1; version <= lastReleasedStorageSchemaVersion; version++ {
 		if !versions[version] {
 			return fmt.Errorf("released storage schema version %d adapter is missing", version)
 		}
@@ -259,7 +260,7 @@ func validateCurrentSchemaColumns(
 			)
 		}
 	}
-	return nil
+	return validateEmbeddingCatalogSchema(context.Background(), db)
 }
 
 func validateV2Schema(db *sql.DB, blobs, packs []string) error {

--- a/internal/store/upgrade_test.go
+++ b/internal/store/upgrade_test.go
@@ -282,7 +282,7 @@ func TestOpenCutsOverReleasedSchemaV3ThroughJSONL(t *testing.T) {
 			var schemaVersion int
 			require.NoError(t, s.db.QueryRow(`
 				SELECT schema_version FROM vault_metadata WHERE singleton=1`).Scan(&schemaVersion))
-			assert.Equal(t, 4, schemaVersion)
+			assert.Equal(t, currentStorageSchemaVersion, schemaVersion)
 			var upgraded bytes.Buffer
 			require.NoError(t, s.ExportMetadata(t.Context(), &upgraded))
 			assert.Equal(t, fixture.metadata, upgraded.Bytes())


### PR DESCRIPTION
Embedding generations and canonical vector sets are now durable store authority that each processing profile can activate independently. This PR is the child of #211 and has been rebuilt on current `main`.

The store derives vector-row metadata from the canonical payload, rejects payloads that diverge from their input generation, and performs the same deep catalog validation through snapshots, exports, backups, and restores. Head and failure identity includes the processing profile, so profiles that reuse a binding name cannot overwrite each other.

Version pruning removes version-owned sets and heads while leaving immutable generation and vector authority for the shared, root-aware derivative collection path. Reverse-reference indexes keep prune, purge, and GC lookups bounded as the catalog grows.

This layer intentionally stops at the authority downstream processing uses: staging and publishing embedding sets. Corpus manifests, the per-cell coverage query, the unused active-head reader, and embedding-only root aliases are omitted; downstream processing owns set-based coverage and vector-index generations.

Canonical vectors remain separate from physical indexes, so indexes stay rebuildable and non-authoritative.

Refs #176
