### PR TITLE
[F10–E12 17/25] Add explicit local OpenAI-compatible embeddings

### DIFF
--- a/document/openaiembed/client.go
+++ b/document/openaiembed/client.go
@@ -1,0 +1,596 @@
+// Package openaiembed implements one bounded OpenAI-compatible text embedding
+// endpoint for operator-controlled local deployments.
+package openaiembed
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	json "encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	// ProviderID is the fixed provider-neutral adapter identity.
+	ProviderID = "openai-compatible.embeddings-v1"
+	// DocumentFormatterV1 identifies the adapter's document formatting path.
+	DocumentFormatterV1 = "openai-compatible/document/v1"
+	// QueryFormatterV1 identifies the adapter's query formatting path.
+	QueryFormatterV1 = "openai-compatible/query/v1"
+	// ScalarEncodingFloat32 is the only scalar representation returned by the adapter.
+	ScalarEncodingFloat32 = "float32"
+
+	embeddingsPath  = "/v1/embeddings"
+	adapterContract = "docbank-openai-compatible-embeddings/v1"
+
+	defaultRequestTimeout   = 30 * time.Second
+	defaultMaxBatchItems    = 128
+	defaultMaxInputBytes    = int64(1 << 20)
+	defaultMaxRequestBytes  = int64(2 << 20)
+	defaultMaxResponseBytes = int64(32 << 20)
+
+	maxRequestTimeout   = 5 * time.Minute
+	maxBatchItems       = 10_000
+	maxInputBytes       = int64(1 << 30)
+	maxRequestBytes     = int64(1 << 30)
+	maxResponseBytes    = int64(1 << 30)
+	maxSecretBytes      = 64 << 10
+	maxIdentityBytes    = 128
+	unitLengthTolerance = 1e-4
+)
+
+var _ document.EmbeddingProvider = (*Client)(nil)
+
+// SecretResolver resolves only the optional credential binding named by a
+// profile. Secret values never enter profile or vector-space identity.
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, name string) (string, error)
+}
+
+// Profile freezes one OpenAI-compatible endpoint, explicit model-input
+// contract, immutable deployment identity, and all transport capacity bounds.
+// Exactly one of DeploymentEpoch and ProviderRevisionHeader is required.
+type Profile struct {
+	Origin                 string
+	Descriptor             document.EmbeddingDescriptor
+	ModelInput             document.ModelInputContract
+	SecretBinding          string
+	DeploymentEpoch        string
+	ProviderRevisionHeader string
+	RequestTimeout         time.Duration
+	MaxBatchItems          int
+	MaxInputBytes          int64
+	MaxRequestBytes        int64
+	MaxResponseBytes       int64
+}
+
+type policyIdentity struct {
+	AdapterContract        string                       `json:"adapter_contract"`
+	Origin                 string                       `json:"origin"`
+	Route                  string                       `json:"route"`
+	Descriptor             document.EmbeddingDescriptor `json:"descriptor"`
+	ModelInput             document.ModelInputContract  `json:"model_input"`
+	CredentialBinding      string                       `json:"credential_binding"`
+	DeploymentEpoch        string                       `json:"deployment_epoch,omitempty"`
+	ProviderRevisionHeader string                       `json:"provider_revision_header,omitempty"`
+	RequestTimeoutNanos    int64                        `json:"request_timeout_nanos"`
+	MaxBatchItems          int                          `json:"max_batch_items"`
+	MaxInputBytes          int64                        `json:"max_input_bytes"`
+	MaxRequestBytes        int64                        `json:"max_request_bytes"`
+	MaxResponseBytes       int64                        `json:"max_response_bytes"`
+}
+
+// Client calls exactly POST /v1/embeddings on the profile origin.
+type Client struct {
+	profile    Profile
+	descriptor document.EmbeddingDescriptor
+	secrets    SecretResolver
+	http       *http.Client
+}
+
+type wireRequest struct {
+	Input          []string `json:"input"`
+	Model          string   `json:"model"`
+	EncodingFormat string   `json:"encoding_format"`
+}
+
+type wireResponse struct {
+	Object string          `json:"object"`
+	Data   []wireEmbedding `json:"data"`
+	Model  string          `json:"model"`
+	Usage  *wireUsage      `json:"usage,omitempty"`
+}
+
+type wireEmbedding struct {
+	Object    string    `json:"object"`
+	Embedding []float32 `json:"embedding"`
+	Index     *int      `json:"index"`
+}
+
+type wireUsage struct {
+	PromptTokens int64 `json:"prompt_tokens"`
+	TotalTokens  int64 `json:"total_tokens"`
+}
+
+// PolicyFingerprint returns the canonical profile identity expected in the
+// embedding descriptor. Credential values and HTTP client state are excluded.
+func PolicyFingerprint(profile Profile) (string, error) {
+	normalized, descriptorIdentity, err := normalizeProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	identity := policyIdentity{
+		AdapterContract: adapterContract, Origin: normalized.Origin, Route: embeddingsPath,
+		Descriptor: descriptorIdentity, ModelInput: normalized.ModelInput,
+		CredentialBinding: normalized.SecretBinding, DeploymentEpoch: normalized.DeploymentEpoch,
+		ProviderRevisionHeader: normalized.ProviderRevisionHeader,
+		RequestTimeoutNanos:    int64(normalized.RequestTimeout), MaxBatchItems: normalized.MaxBatchItems,
+		MaxInputBytes: normalized.MaxInputBytes, MaxRequestBytes: normalized.MaxRequestBytes,
+		MaxResponseBytes: normalized.MaxResponseBytes,
+	}
+	encoded, err := json.Marshal(identity, json.Deterministic(true))
+	if err != nil {
+		return "", fmt.Errorf("openaiembed: encode policy identity: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// New validates an immutable profile and isolates the supplied HTTP client
+// from ambient cookies, timeouts, and redirect behavior. It performs no I/O.
+func New(profile Profile, secrets SecretResolver, httpClient *http.Client) (*Client, error) {
+	normalized, _, err := normalizeProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		if err == nil {
+			err = errors.New("descriptor is not canonical")
+		}
+		return nil, fmt.Errorf("openaiembed: invalid descriptor: %w", err)
+	}
+	fingerprint, err := PolicyFingerprint(profile)
+	if err != nil {
+		return nil, err
+	}
+	if descriptor.PolicyFingerprint != fingerprint {
+		return nil, errors.New("openaiembed: descriptor policy fingerprint does not match profile")
+	}
+	if normalized.SecretBinding == "" {
+		if !nilValue(secrets) {
+			return nil, errors.New("openaiembed: secret resolver requires a named binding")
+		}
+	} else if nilValue(secrets) {
+		return nil, errors.New("openaiembed: named secret binding requires a resolver")
+	}
+	if httpClient == nil {
+		return nil, errors.New("openaiembed: HTTP client is required")
+	}
+	isolate := *httpClient
+	isolate.CheckRedirect = providerhttp.RefuseRedirects
+	isolate.Jar = nil
+	isolate.Timeout = 0
+	normalized.Descriptor = cloneDescriptor(descriptor)
+	return &Client{profile: normalized, descriptor: cloneDescriptor(descriptor), secrets: secrets, http: &isolate}, nil
+}
+
+// Descriptor returns a defensive copy of the immutable provider contract.
+func (client *Client) Descriptor() document.EmbeddingDescriptor {
+	if client == nil {
+		return document.EmbeddingDescriptor{}
+	}
+	return cloneDescriptor(client.descriptor)
+}
+
+// Embed validates and formats one text batch, performs one bounded request,
+// and restores caller ordering from the response indices.
+func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	if client == nil {
+		return document.EmbeddingResult{}, errors.New("openaiembed: client is required")
+	}
+	if ctx == nil {
+		return document.EmbeddingResult{}, errors.New("openaiembed: context is required")
+	}
+	if err := document.ValidateEmbeddingProviderRequest(client, inputs, authorization); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if authorization.MaxBatchItems > client.profile.MaxBatchItems ||
+		authorization.MaxInputBytes > client.profile.MaxInputBytes ||
+		authorization.MaxResponseBytes > client.profile.MaxResponseBytes {
+		return document.EmbeddingResult{}, errors.New("openaiembed: embedding authorization exceeds profile capacity")
+	}
+	if err := ctx.Err(); err != nil {
+		return document.EmbeddingResult{}, fmt.Errorf("openaiembed: embedding canceled: %w", err)
+	}
+
+	rendered := make([]string, len(inputs))
+	var renderedBytes int64
+	for index, input := range inputs {
+		switch {
+		case input.Role == document.EmbeddingRoleDocument && input.Kind == document.EmbeddingInputRenditionChunk:
+			rendered[index] = client.profile.ModelInput.EncodeDocument(input.Text)
+		case input.Role == document.EmbeddingRoleQuery && input.Kind == document.EmbeddingInputQueryText:
+			rendered[index] = client.profile.ModelInput.EncodeQuery(input.Text)
+		default:
+			return document.EmbeddingResult{}, errors.New("openaiembed: unsupported non-text embedding input or role")
+		}
+		if int64(len(rendered[index])) > client.profile.MaxInputBytes-renderedBytes {
+			return document.EmbeddingResult{}, errors.New("openaiembed: embedding input exceeds profile byte capacity")
+		}
+		renderedBytes += int64(len(rendered[index]))
+	}
+	payload, err := json.Marshal(wireRequest{Input: rendered, Model: client.descriptor.Model, EncodingFormat: "float"})
+	if err != nil {
+		return document.EmbeddingResult{}, errors.New("openaiembed: could not encode embedding request")
+	}
+	if int64(len(payload)) > client.profile.MaxRequestBytes {
+		return document.EmbeddingResult{}, errors.New("openaiembed: embedding request byte limit exceeded")
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodPost, client.profile.Origin+embeddingsPath, bytes.NewReader(payload))
+	if err != nil {
+		return document.EmbeddingResult{}, errors.New("openaiembed: could not construct embedding request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	if client.profile.SecretBinding != "" {
+		secret, resolveErr := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
+		if resolveErr != nil {
+			if contextErr := requestCtx.Err(); contextErr != nil {
+				return document.EmbeddingResult{}, fmt.Errorf("openaiembed: credential resolution canceled: %w", contextErr)
+			}
+			return document.EmbeddingResult{}, errors.New("openaiembed: could not resolve credential")
+		}
+		if !validSecret(secret) {
+			return document.EmbeddingResult{}, errors.New("openaiembed: resolved credential is invalid")
+		}
+		request.Header.Set("Authorization", "Bearer "+secret)
+	}
+
+	response, err := client.http.Do(request)
+	if err != nil {
+		if contextErr := requestCtx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, fmt.Errorf("openaiembed: embedding request canceled: %w", contextErr)
+		}
+		return document.EmbeddingResult{}, errors.New("openaiembed: provider request failed")
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode >= 300 && response.StatusCode < 400 {
+		return document.EmbeddingResult{}, fmt.Errorf("openaiembed: provider redirect refused with HTTP status %d", response.StatusCode)
+	}
+	if response.StatusCode != http.StatusOK {
+		return document.EmbeddingResult{}, fmt.Errorf("openaiembed: provider returned HTTP status %d", response.StatusCode)
+	}
+	if err := validateResponseContentType(response.Header.Get("Content-Type")); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if err := client.validateRevisionEcho(response.Header); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	body, err := readBounded(requestCtx, response.Body, client.profile.MaxResponseBytes)
+	if err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	var decoded wireResponse
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
+		return document.EmbeddingResult{}, errors.New("openaiembed: provider response does not match the bounded embedding schema")
+	}
+	result, err := client.validateAndOrder(decoded, inputs)
+	if err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	return result, nil
+}
+
+func (client *Client) validateRevisionEcho(header http.Header) error {
+	if client.profile.ProviderRevisionHeader == "" {
+		return nil
+	}
+	values := header.Values(client.profile.ProviderRevisionHeader)
+	if len(values) != 1 || strings.TrimSpace(values[0]) != client.descriptor.ModelRevision {
+		return errors.New("openaiembed: provider revision echo does not match profile")
+	}
+	return nil
+}
+
+func (client *Client) validateAndOrder(response wireResponse, inputs []document.EmbeddingInput) (document.EmbeddingResult, error) {
+	if response.Object != "list" || response.Model != client.descriptor.Model {
+		return document.EmbeddingResult{}, errors.New("openaiembed: provider model or response contract drifted")
+	}
+	if response.Usage != nil && (response.Usage.PromptTokens < 0 || response.Usage.TotalTokens < response.Usage.PromptTokens) {
+		return document.EmbeddingResult{}, errors.New("openaiembed: provider usage is invalid")
+	}
+	if len(response.Data) != len(inputs) {
+		return document.EmbeddingResult{}, errors.New("openaiembed: provider response has a missing vector")
+	}
+	vectors := make([]document.EmbeddingVector, len(inputs))
+	seen := make([]bool, len(inputs))
+	for _, item := range response.Data {
+		if item.Object != "embedding" || item.Index == nil {
+			return document.EmbeddingResult{}, errors.New("openaiembed: provider response item contract drifted")
+		}
+		index := *item.Index
+		if index < 0 || index >= len(inputs) {
+			return document.EmbeddingResult{}, errors.New("openaiembed: provider response index is outside request bounds")
+		}
+		if seen[index] {
+			return document.EmbeddingResult{}, errors.New("openaiembed: provider response has a duplicate vector index")
+		}
+		seen[index] = true
+		if err := client.validateVector(item.Embedding); err != nil {
+			return document.EmbeddingResult{}, err
+		}
+		vectors[index] = document.EmbeddingVector{Key: inputs[index].Key, Values: slices.Clone(item.Embedding)}
+	}
+	if slices.Contains(seen, false) {
+		return document.EmbeddingResult{}, errors.New("openaiembed: provider response has a missing vector index")
+	}
+	return document.EmbeddingResult{Vectors: vectors}, nil
+}
+
+func (client *Client) validateVector(vector []float32) error {
+	if len(vector) != client.descriptor.Dimension {
+		return errors.New("openaiembed: provider vector dimension does not match profile")
+	}
+	var squaredNorm float64
+	for _, value := range vector {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return errors.New("openaiembed: provider vector contains a non-finite value")
+		}
+		squaredNorm += float64(value) * float64(value)
+	}
+	if squaredNorm == 0 {
+		return errors.New("openaiembed: provider returned a zero vector")
+	}
+	if client.descriptor.Normalization == document.VectorNormalizationUnitLength && math.Abs(squaredNorm-1) > unitLengthTolerance {
+		return errors.New("openaiembed: provider vector normalization does not match profile")
+	}
+	return nil
+}
+
+func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, error) {
+	origin, err := validateOrigin(profile.Origin)
+	if err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
+	profile.Origin = origin
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = defaultRequestTimeout
+	}
+	if profile.MaxBatchItems == 0 {
+		profile.MaxBatchItems = defaultMaxBatchItems
+	}
+	if profile.MaxInputBytes == 0 {
+		profile.MaxInputBytes = defaultMaxInputBytes
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = defaultMaxRequestBytes
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = defaultMaxResponseBytes
+	}
+	if profile.RequestTimeout <= 0 || profile.RequestTimeout > maxRequestTimeout ||
+		profile.MaxBatchItems < 1 || profile.MaxBatchItems > maxBatchItems ||
+		profile.MaxInputBytes < 1 || profile.MaxInputBytes > maxInputBytes ||
+		profile.MaxRequestBytes < 1 || profile.MaxRequestBytes > maxRequestBytes ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maxResponseBytes {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaiembed: execution bounds are invalid")
+	}
+	if profile.SecretBinding != "" && !validIdentityToken(profile.SecretBinding) {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaiembed: secret binding is invalid")
+	}
+
+	descriptorIdentity := profile.Descriptor
+	descriptorIdentity.PolicyFingerprint = strings.Repeat("0", sha256.Size*2)
+	descriptorIdentity.Fingerprint = ""
+	descriptorIdentity, err = document.NewEmbeddingDescriptor(descriptorIdentity)
+	if err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, fmt.Errorf("openaiembed: invalid descriptor identity: %w", err)
+	}
+	descriptorIdentity.PolicyFingerprint = ""
+	descriptorIdentity.Fingerprint = ""
+	if err := validateDescriptorContract(descriptorIdentity, profile.ModelInput); err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
+	if (profile.DeploymentEpoch == "") == (profile.ProviderRevisionHeader == "") {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaiembed: exactly one deployment epoch or provider revision header is required")
+	}
+	if profile.DeploymentEpoch != "" {
+		if !validIdentityToken(profile.DeploymentEpoch) || profile.DeploymentEpoch != descriptorIdentity.ModelRevision {
+			return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaiembed: deployment epoch must exactly match descriptor model revision")
+		}
+	} else if !validRevisionHeader(profile.ProviderRevisionHeader) {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaiembed: provider revision header is not a canonical safe response header")
+	}
+	return profile, descriptorIdentity, nil
+}
+
+func validateDescriptorContract(descriptor document.EmbeddingDescriptor, modelInput document.ModelInputContract) error {
+	if descriptor.ID != ProviderID || descriptor.TrustBoundary != document.EmbeddingTrustOperatorNetwork ||
+		descriptor.ScalarEncoding != ScalarEncodingFloat32 || descriptor.DocumentFormatter != DocumentFormatterV1 ||
+		descriptor.QueryFormatter != QueryFormatterV1 || !descriptor.SupportsTextQuery ||
+		!slices.Equal(descriptor.InputKinds, []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}) ||
+		!slices.Equal(descriptor.SupportedRequestModes, []document.ModelInputMode{document.ModelInputModeText}) {
+		return errors.New("openaiembed: descriptor does not match the text-only adapter contract")
+	}
+	if descriptor.ModelInput != modelInput || descriptor.CompatibilityID != modelInput.CompatibilityID {
+		return errors.New("openaiembed: descriptor and explicit model-input contract differ")
+	}
+	switch modelInput.Profile {
+	case document.ModelInputProfileNomic, document.ModelInputProfileE5,
+		document.ModelInputProfileBGEM3, document.ModelInputProfileGTE,
+		document.ModelInputProfileQwen3, document.ModelInputProfileQueryInstruction,
+		document.ModelInputProfileCustom:
+	default:
+		return errors.New("openaiembed: model-input contract must use a reviewed embedding family or complete custom profile")
+	}
+	return nil
+}
+
+func validateOrigin(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Opaque != "" || parsed.ForceQuery || parsed.Fragment != "" ||
+		(parsed.Path != "" && parsed.Path != "/") || parsed.RawPath != "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", errors.New("openaiembed: origin must be one HTTP(S) origin without credentials, non-root path, query, or fragment")
+	}
+	hostname := parsed.Hostname()
+	if hostname == "" || !asciiHost(hostname) || strings.ToLower(hostname) != hostname {
+		return "", errors.New("openaiembed: origin host is not canonical ASCII")
+	}
+	port := parsed.Port()
+	if port != "" {
+		value, parseErr := strconv.ParseUint(port, 10, 16)
+		if parseErr != nil || value == 0 {
+			return "", errors.New("openaiembed: origin port is invalid")
+		}
+	}
+	authority := hostname
+	if strings.Contains(hostname, ":") {
+		authority = "[" + hostname + "]"
+	}
+	if port != "" {
+		authority = net.JoinHostPort(hostname, port)
+	}
+	return parsed.Scheme + "://" + authority, nil
+}
+
+func asciiHost(host string) bool {
+	if address, err := netip.ParseAddr(host); err == nil {
+		return address.Zone() == "" && address.String() == host
+	}
+	if len(host) > 253 || strings.HasSuffix(host, ".") {
+		return false
+	}
+	for label := range strings.SplitSeq(host, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, character := range label {
+			if (character < 'a' || character > 'z') && (character < '0' || character > '9') && character != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func validIdentityToken(value string) bool {
+	return value != "" && len(value) <= maxIdentityBytes && value == strings.TrimSpace(value) && utf8.ValidString(value) && strings.IndexFunc(value, unicode.IsControl) < 0
+}
+
+func validRevisionHeader(name string) bool {
+	if name == "" || len(name) > maxIdentityBytes || http.CanonicalHeaderKey(name) != name {
+		return false
+	}
+	for _, character := range name {
+		if (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') || strings.ContainsRune("!#$%&'*+-.^_`|~", character) {
+			continue
+		}
+		return false
+	}
+	switch name {
+	case "Authorization", "Connection", "Content-Length", "Content-Type", "Cookie", "Date", "Location", "Server", "Set-Cookie", "Transfer-Encoding":
+		return false
+	default:
+		return true
+	}
+}
+
+func validSecret(secret string) bool {
+	if secret == "" || len(secret) > maxSecretBytes {
+		return false
+	}
+	padding := false
+	content := 0
+	for index := range len(secret) {
+		character := secret[index]
+		if character == '=' {
+			padding = true
+			continue
+		}
+		if padding || !validBearerCharacter(character) {
+			return false
+		}
+		content++
+	}
+	return content > 0
+}
+
+func validBearerCharacter(character byte) bool {
+	return character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
+		character >= '0' && character <= '9' || strings.ContainsRune("-._~+/", rune(character))
+}
+
+func validateResponseContentType(value string) error {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || mediaType != "application/json" {
+		return errors.New("openaiembed: provider response content type is not application/json")
+	}
+	if len(parameters) == 0 {
+		return nil
+	}
+	charset, ok := parameters["charset"]
+	if len(parameters) != 1 || !ok || !strings.EqualFold(charset, "utf-8") {
+		return errors.New("openaiembed: provider response content type has unsupported parameters")
+	}
+	return nil
+}
+
+func readBounded(ctx context.Context, reader io.Reader, maximum int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, fmt.Errorf("openaiembed: response read canceled: %w", contextErr)
+		}
+		return nil, errors.New("openaiembed: could not read provider response")
+	}
+	if int64(len(body)) > maximum {
+		return nil, errors.New("openaiembed: provider response byte limit exceeded")
+	}
+	return body, nil
+}
+
+func cloneDescriptor(descriptor document.EmbeddingDescriptor) document.EmbeddingDescriptor {
+	descriptor.InputKinds = slices.Clone(descriptor.InputKinds)
+	descriptor.SupportedRequestModes = slices.Clone(descriptor.SupportedRequestModes)
+	return descriptor
+}
+
+func nilValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/document/openaiembed/client_test.go
+++ b/document/openaiembed/client_test.go
@@ -1,0 +1,584 @@
+package openaiembed
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json/v2"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+)
+
+//go:embed testdata/success-indexed.json
+var successIndexedResponse []byte
+
+//go:embed testdata/schema-drift.json
+var schemaDriftResponse []byte
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+type testSecrets map[string]string
+
+func (secrets testSecrets) ResolveSecret(_ context.Context, name string) (string, error) {
+	value, ok := secrets[name]
+	if !ok {
+		return "", errors.New("missing synthetic secret")
+	}
+	return value, nil
+}
+
+type capturedRequest struct {
+	Input          []string `json:"input"`
+	Model          string   `json:"model"`
+	EncodingFormat string   `json:"encoding_format"`
+}
+
+func TestEmbedAppliesExplicitModelInputProfilesAndRestoresResponseIndices(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   document.ModelInputContractConfig
+		expected []string
+	}{
+		{name: "nomic", config: document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}, expected: []string{"search_document: passage", "search_query: question"}},
+		{name: "e5", config: document.ModelInputContractConfig{Profile: document.ModelInputProfileE5}, expected: []string{"passage: passage", "query: question"}},
+		{name: "bge-m3", config: document.ModelInputContractConfig{Profile: document.ModelInputProfileBGEM3}, expected: []string{"passage", "question"}},
+		{name: "gte", config: document.ModelInputContractConfig{Profile: document.ModelInputProfileGTE}, expected: []string{"passage", "question"}},
+		{name: "qwen3 prefix free", config: document.ModelInputContractConfig{Profile: document.ModelInputProfileQwen3}, expected: []string{"passage", "question"}},
+		{name: "qwen3 instruction", config: document.ModelInputContractConfig{Profile: document.ModelInputProfileQwen3, QueryInstruction: "Retrieve supporting passages"}, expected: []string{"passage", "Instruct: Retrieve supporting passages\nQuery:question"}},
+		{name: "query-only instruction", config: document.ModelInputContractConfig{Profile: document.ModelInputProfileQueryInstruction, QueryInstruction: "Find exact evidence"}, expected: []string{"passage", "Instruct: Find exact evidence\nQuery:question"}},
+		{name: "complete custom", config: document.ModelInputContractConfig{Profile: document.ModelInputProfileCustom, CompatibilityID: "synthetic/custom-v1", Document: document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "doc[{{content}}]"}, Query: document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "query[{{content}}]"}}, expected: []string{"doc[passage]", "query[question]"}},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			contract, err := document.NewModelInputContract(testCase.config)
+			require.NoError(t, err)
+			profile := testProfile(t, contract)
+			var seen capturedRequest
+			client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				require.Equal(t, http.MethodPost, request.Method)
+				assert.Equal(t, "/v1/embeddings", request.URL.Path)
+				assert.Empty(t, request.URL.RawQuery)
+				assert.Equal(t, "application/json", request.Header.Get("Content-Type"))
+				assert.Equal(t, "application/json", request.Header.Get("Accept"))
+				require.NoError(t, json.UnmarshalRead(request.Body, &seen, json.RejectUnknownMembers(true)))
+				return jsonResponse(request, http.StatusOK, successIndexedResponse), nil
+			}))
+
+			result, err := document.ExecuteEmbedding(t.Context(), client, testInputs(), testAuthorization(profile.Descriptor))
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, seen.Input)
+			assert.Equal(t, "synthetic-model", seen.Model)
+			assert.Equal(t, "float", seen.EncodingFormat)
+			require.Len(t, result.Vectors, 2)
+			assert.Equal(t, "document-1", result.Vectors[0].Key)
+			assert.Equal(t, []float32{1, 0, 0}, result.Vectors[0].Values)
+			assert.Nil(t, result.Vectors[0].Index)
+			assert.Equal(t, "query-1", result.Vectors[1].Key)
+			assert.Equal(t, []float32{0, 1, 0}, result.Vectors[1].Values)
+			assert.Nil(t, result.Vectors[1].Index)
+		})
+	}
+}
+
+func TestNewRequiresCanonicalProfileAndStableRevisionIdentity(t *testing.T) {
+	contract := modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic})
+	base := testProfile(t, contract)
+
+	for name, mutate := range map[string]func(Profile) Profile{
+		"credentials in origin":         func(profile Profile) Profile { profile.Origin = "http://user@127.0.0.1:11434"; return profile },
+		"query in origin":               func(profile Profile) Profile { profile.Origin += "?model=private"; return profile },
+		"fragment in origin":            func(profile Profile) Profile { profile.Origin += "#fragment"; return profile },
+		"non-root base path":            func(profile Profile) Profile { profile.Origin += "/api"; return profile },
+		"unsupported scheme":            func(profile Profile) Profile { profile.Origin = "file:///tmp/provider"; return profile },
+		"missing revision authority":    func(profile Profile) Profile { profile.DeploymentEpoch = ""; return profile },
+		"two revision authorities":      func(profile Profile) Profile { profile.ProviderRevisionHeader = "X-Model-Revision"; return profile },
+		"epoch differs from descriptor": func(profile Profile) Profile { profile.DeploymentEpoch = "epoch-other"; return profile },
+		"non-canonical revision header": func(profile Profile) Profile {
+			profile.DeploymentEpoch = ""
+			profile.ProviderRevisionHeader = "x-model-revision"
+			return profile
+		},
+		"unsafe revision header": func(profile Profile) Profile {
+			profile.DeploymentEpoch = ""
+			profile.ProviderRevisionHeader = "Authorization"
+			return profile
+		},
+		"different explicit input contract": func(profile Profile) Profile {
+			profile.ModelInput = modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileE5})
+			return profile
+		},
+		"non-canonical descriptor": func(profile Profile) Profile {
+			profile.Descriptor.Fingerprint = strings.Repeat("0", 64)
+			return profile
+		},
+		"wrong trust boundary": func(profile Profile) Profile {
+			profile.Descriptor = canonicalMutatedDescriptor(t, profile.Descriptor, func(descriptor *document.EmbeddingDescriptor) {
+				descriptor.TrustBoundary = document.EmbeddingTrustHostedProvider
+			})
+			return profile
+		},
+		"direct-file capability": func(profile Profile) Profile {
+			profile.Descriptor = canonicalMutatedDescriptor(t, profile.Descriptor, func(descriptor *document.EmbeddingDescriptor) {
+				descriptor.InputKinds = append(descriptor.InputKinds, document.EmbeddingInputOriginalFile)
+			})
+			return profile
+		},
+		"missing text query": func(profile Profile) Profile {
+			profile.Descriptor = canonicalMutatedDescriptor(t, profile.Descriptor, func(descriptor *document.EmbeddingDescriptor) { descriptor.SupportsTextQuery = false })
+			return profile
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := New(mutate(base), nil, &http.Client{Transport: staticSuccessTransport()})
+			require.Error(t, err)
+		})
+	}
+
+	for _, unsupported := range []document.ModelInputProfile{
+		document.ModelInputProfileOpenAICompatible, document.ModelInputProfileMistral,
+	} {
+		t.Run("unsupported input profile "+string(unsupported), func(t *testing.T) {
+			profile := base
+			profile.ModelInput = modelInput(t, document.ModelInputContractConfig{Profile: unsupported})
+			profile.Descriptor = canonicalMutatedDescriptor(t, profile.Descriptor, func(descriptor *document.EmbeddingDescriptor) {
+				descriptor.ModelInput = profile.ModelInput
+				descriptor.CompatibilityID = profile.ModelInput.CompatibilityID
+			})
+			_, err := New(profile, nil, &http.Client{Transport: staticSuccessTransport()})
+			require.ErrorContains(t, err, "model-input")
+		})
+	}
+
+	t.Run("empty input profile", func(t *testing.T) {
+		profile := base
+		profile.ModelInput = modelInput(t, document.ModelInputContractConfig{})
+		_, err := New(profile, nil, &http.Client{Transport: staticSuccessTransport()})
+		require.ErrorContains(t, err, "model-input")
+	})
+
+	t.Run("voyage request modes", func(t *testing.T) {
+		profile := base
+		profile.ModelInput = modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileVoyage})
+		profile.Descriptor = canonicalMutatedDescriptor(t, profile.Descriptor, func(descriptor *document.EmbeddingDescriptor) {
+			descriptor.ModelInput = profile.ModelInput
+			descriptor.CompatibilityID = profile.ModelInput.CompatibilityID
+			descriptor.SupportedRequestModes = []document.ModelInputMode{document.ModelInputModeDocument, document.ModelInputModeQuery}
+		})
+		_, err := New(profile, nil, &http.Client{Transport: staticSuccessTransport()})
+		require.ErrorContains(t, err, "text-only")
+	})
+
+	_, err := New(base, nil, nil)
+	require.ErrorContains(t, err, "HTTP client")
+}
+
+func TestProfilePolicyFingerprintCoversEndpointIdentityAndBounds(t *testing.T) {
+	base := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
+	want, err := PolicyFingerprint(base)
+	require.NoError(t, err)
+	assert.Equal(t, want, base.Descriptor.PolicyFingerprint)
+
+	mutations := map[string]func(*Profile){
+		"origin": func(profile *Profile) { profile.Origin = "http://127.0.0.1:11435" },
+		"deployment epoch": func(profile *Profile) {
+			profile.DeploymentEpoch = "epoch-other"
+			profile.Descriptor.ModelRevision = "epoch-other"
+		},
+		"credential binding": func(profile *Profile) { profile.SecretBinding = "other-secret" },
+		"batch capacity":     func(profile *Profile) { profile.MaxBatchItems++ },
+		"input capacity":     func(profile *Profile) { profile.MaxInputBytes++ },
+		"request bound":      func(profile *Profile) { profile.MaxRequestBytes++ },
+		"response bound":     func(profile *Profile) { profile.MaxResponseBytes++ },
+		"timeout":            func(profile *Profile) { profile.RequestTimeout++ },
+		"model":              func(profile *Profile) { profile.Descriptor.Model = "different-model" },
+		"dimension":          func(profile *Profile) { profile.Descriptor.Dimension++ },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			mutate(&changed)
+			fingerprint, err := PolicyFingerprint(changed)
+			require.NoError(t, err)
+			assert.NotEqual(t, want, fingerprint)
+			changed.Descriptor = canonicalMutatedDescriptor(t, changed.Descriptor, func(*document.EmbeddingDescriptor) {})
+			_, err = New(changed, nil, &http.Client{Transport: staticSuccessTransport()})
+			require.ErrorContains(t, err, "policy fingerprint")
+		})
+	}
+}
+
+func TestEmbedEnforcesProfileAuthorizationAndTextOnlyBoundsBeforeNetwork(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
+	profile.MaxBatchItems = 2
+	profile.MaxInputBytes = 64
+	profile.MaxRequestBytes = 256
+	profile.MaxResponseBytes = 4096
+	profile.Descriptor = descriptorFor(t, profile)
+	var requests atomic.Int64
+	client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return jsonResponse(request, http.StatusOK, successIndexedResponse), nil
+	}))
+
+	tests := []struct {
+		name          string
+		inputs        []document.EmbeddingInput
+		authorization document.EmbeddingAuthorization
+	}{
+		{name: "batch authority above profile", inputs: testInputs(), authorization: mutateAuthorization(testAuthorization(profile.Descriptor), func(value *document.EmbeddingAuthorization) { value.MaxBatchItems = 3 })},
+		{name: "input authority above profile", inputs: testInputs(), authorization: mutateAuthorization(testAuthorization(profile.Descriptor), func(value *document.EmbeddingAuthorization) { value.MaxInputBytes = 65 })},
+		{name: "response authority above profile", inputs: testInputs(), authorization: mutateAuthorization(testAuthorization(profile.Descriptor), func(value *document.EmbeddingAuthorization) { value.MaxResponseBytes = 4097 })},
+		{name: "direct file", inputs: []document.EmbeddingInput{{Key: "file", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile}}, authorization: testAuthorization(profile.Descriptor)},
+		{name: "too many items", inputs: append(testInputs(), document.EmbeddingInput{Key: "extra", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "extra"}), authorization: testAuthorization(profile.Descriptor)},
+		{name: "rendered text too large", inputs: []document.EmbeddingInput{{Key: "large", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: strings.Repeat("x", 64)}}, authorization: testAuthorization(profile.Descriptor)},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := client.Embed(t.Context(), testCase.inputs, testCase.authorization)
+			require.Error(t, err)
+		})
+	}
+	assert.Zero(t, requests.Load())
+}
+
+func TestEmbedUsesOptionalNamedBearerSecretWithoutAmbientCookies(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileGTE}))
+	profile.SecretBinding = "local-embedding-key"
+	profile.Descriptor = descriptorFor(t, profile)
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	var seenAuthorization string
+	base := &http.Client{Jar: jar, Timeout: time.Hour, CheckRedirect: func(*http.Request, []*http.Request) error { return nil }}
+	base.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		seenAuthorization = request.Header.Get("Authorization")
+		return jsonResponse(request, http.StatusOK, successIndexedResponse), nil
+	})
+	client, err := New(profile, testSecrets{"local-embedding-key": "synthetic-secret"}, base)
+	require.NoError(t, err)
+	assert.Nil(t, client.http.Jar)
+	assert.Zero(t, client.http.Timeout)
+	_, err = client.Embed(t.Context(), testInputs(), testAuthorization(profile.Descriptor))
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer synthetic-secret", seenAuthorization)
+
+	_, err = New(profile, nil, base)
+	require.ErrorContains(t, err, "resolver")
+	withoutBinding := profile
+	withoutBinding.SecretBinding = ""
+	withoutBinding.Descriptor = descriptorFor(t, withoutBinding)
+	_, err = New(withoutBinding, testSecrets{}, base)
+	require.ErrorContains(t, err, "binding")
+
+	for name, secret := range map[string]string{
+		"line break":        "bad\r\nvalue",
+		"space":             "bad value",
+		"tab":               "bad\tvalue",
+		"non-ASCII":         "bad-välue",
+		"unsupported colon": "bad:value",
+		"padding in middle": "bad=value",
+		"padding only":      "==",
+	} {
+		t.Run(name, func(t *testing.T) {
+			client = newTestClient(t, profile, testSecrets{"local-embedding-key": secret}, base.Transport)
+			_, err = client.Embed(t.Context(), testInputs(), testAuthorization(profile.Descriptor))
+			require.ErrorContains(t, err, "credential")
+			assert.NotContains(t, err.Error(), "bad")
+		})
+	}
+
+	for name, secret := range map[string]string{
+		"minimal":                   "a",
+		"full alphabet and padding": "aZ09-._~+/==",
+	} {
+		t.Run(name, func(t *testing.T) {
+			client = newTestClient(t, profile, testSecrets{"local-embedding-key": secret}, base.Transport)
+			_, err = client.Embed(t.Context(), testInputs(), testAuthorization(profile.Descriptor))
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestEmbedAcceptsJSONUTF8ContentType(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileGTE}))
+	for _, contentType := range []string{"application/json; charset=utf-8", "application/json; charset=Utf-8"} {
+		t.Run(contentType, func(t *testing.T) {
+			client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				response := jsonResponse(request, http.StatusOK, singleVectorResponse("synthetic-model", []float32{1, 0, 0}))
+				response.Header.Set("Content-Type", contentType)
+				return response, nil
+			}))
+			_, err := client.Embed(t.Context(), testInputs()[:1], testAuthorization(profile.Descriptor))
+			require.NoError(t, err)
+		})
+	}
+
+	for _, contentType := range []string{
+		"application/json; charset=iso-8859-1",
+		"application/json; profile=embedding",
+		"application/json; charset=utf-8; profile=embedding",
+	} {
+		t.Run(contentType, func(t *testing.T) {
+			client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				response := jsonResponse(request, http.StatusOK, singleVectorResponse("synthetic-model", []float32{1, 0, 0}))
+				response.Header.Set("Content-Type", contentType)
+				return response, nil
+			}))
+			_, err := client.Embed(t.Context(), testInputs()[:1], testAuthorization(profile.Descriptor))
+			require.ErrorContains(t, err, "content type")
+		})
+	}
+}
+
+func TestEmbedRequiresModelAndProviderRevisionEcho(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileBGEM3}))
+	profile.DeploymentEpoch = ""
+	profile.ProviderRevisionHeader = "X-Model-Revision"
+	profile.Descriptor = descriptorFor(t, profile)
+
+	for name, testCase := range map[string]struct {
+		body      []byte
+		revisions []string
+	}{
+		"missing revision":   {body: singleVectorResponse("synthetic-model", []float32{1, 0, 0})},
+		"wrong revision":     {body: singleVectorResponse("synthetic-model", []float32{1, 0, 0}), revisions: []string{"revision-other"}},
+		"multiple revisions": {body: singleVectorResponse("synthetic-model", []float32{1, 0, 0}), revisions: []string{"epoch-2026-08-26", "epoch-2026-08-26"}},
+		"wrong model":        {body: singleVectorResponse("alias-drift", []float32{1, 0, 0}), revisions: []string{"epoch-2026-08-26"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				response := jsonResponse(request, http.StatusOK, testCase.body)
+				if testCase.revisions != nil {
+					response.Header["X-Model-Revision"] = testCase.revisions
+				}
+				return response, nil
+			}))
+			_, err := client.Embed(t.Context(), testInputs()[:1], testAuthorization(profile.Descriptor))
+			require.Error(t, err)
+		})
+	}
+
+	client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		response := jsonResponse(request, http.StatusOK, singleVectorResponse("synthetic-model", []float32{1, 0, 0}))
+		response.Header.Set("X-Model-Revision", "  epoch-2026-08-26  ")
+		return response, nil
+	}))
+	_, err := client.Embed(t.Context(), testInputs()[:1], testAuthorization(profile.Descriptor))
+	require.NoError(t, err)
+}
+
+func TestEmbedRejectsSchemaVectorAndTransportDriftWithoutLeakingBodies(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
+	one := testInputs()[:1]
+	tests := []struct {
+		name        string
+		status      int
+		contentType string
+		body        []byte
+	}{
+		{name: "unknown response member", status: http.StatusOK, contentType: "application/json", body: schemaDriftResponse},
+		{name: "wrong media type", status: http.StatusOK, contentType: "text/plain", body: singleVectorResponse("synthetic-model", []float32{1, 0, 0})},
+		{name: "provider error body", status: http.StatusTooManyRequests, contentType: "application/json", body: []byte(`{"error":"private request text and vector [9,8,7]"}`)},
+		{name: "wrong list object", status: http.StatusOK, contentType: "application/json", body: []byte(`{"object":"embedding","data":[{"object":"embedding","embedding":[1,0,0],"index":0}],"model":"synthetic-model"}`)},
+		{name: "wrong item object", status: http.StatusOK, contentType: "application/json", body: []byte(`{"object":"list","data":[{"object":"vector","embedding":[1,0,0],"index":0}],"model":"synthetic-model"}`)},
+		{name: "duplicate index", status: http.StatusOK, contentType: "application/json", body: []byte(`{"object":"list","data":[{"object":"embedding","embedding":[1,0,0],"index":0},{"object":"embedding","embedding":[0,1,0],"index":0}],"model":"synthetic-model"}`)},
+		{name: "missing vector", status: http.StatusOK, contentType: "application/json", body: []byte(`{"object":"list","data":[],"model":"synthetic-model"}`)},
+		{name: "index outside batch", status: http.StatusOK, contentType: "application/json", body: []byte(`{"object":"list","data":[{"object":"embedding","embedding":[1,0,0],"index":2}],"model":"synthetic-model"}`)},
+		{name: "dimension drift", status: http.StatusOK, contentType: "application/json", body: singleVectorResponse("synthetic-model", []float32{1, 0})},
+		{name: "non-finite scalar", status: http.StatusOK, contentType: "application/json", body: []byte(`{"object":"list","data":[{"object":"embedding","embedding":[1e1000,0,0],"index":0}],"model":"synthetic-model"}`)},
+		{name: "zero vector", status: http.StatusOK, contentType: "application/json", body: singleVectorResponse("synthetic-model", []float32{0, 0, 0})},
+		{name: "normalization drift", status: http.StatusOK, contentType: "application/json", body: singleVectorResponse("synthetic-model", []float32{2, 0, 0})},
+		{name: "negative usage", status: http.StatusOK, contentType: "application/json", body: []byte(`{"object":"list","data":[{"object":"embedding","embedding":[1,0,0],"index":0}],"model":"synthetic-model","usage":{"prompt_tokens":-1,"total_tokens":-1}}`)},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				response := jsonResponse(request, testCase.status, testCase.body)
+				response.Header.Set("Content-Type", testCase.contentType)
+				return response, nil
+			}))
+			inputs := one
+			if testCase.name == "duplicate index" {
+				inputs = testInputs()
+			}
+			_, err := client.Embed(t.Context(), inputs, testAuthorization(profile.Descriptor))
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "private request text")
+			assert.NotContains(t, err.Error(), "[9,8,7]")
+		})
+	}
+
+	bounded := profile
+	bounded.MaxResponseBytes = 64
+	bounded.Descriptor = descriptorFor(t, bounded)
+	client := newTestClient(t, bounded, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return jsonResponse(request, http.StatusOK, []byte(strings.Repeat("x", 65))), nil
+	}))
+	_, err := client.Embed(t.Context(), one, mutateAuthorization(testAuthorization(bounded.Descriptor), func(value *document.EmbeddingAuthorization) { value.MaxResponseBytes = 64 }))
+	require.ErrorContains(t, err, "response byte")
+}
+
+func TestEmbedRefusesRedirectsAndHonorsCancellation(t *testing.T) {
+	contract := modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileGTE})
+	var redirected atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/elsewhere" {
+			redirected.Add(1)
+		}
+		http.Redirect(response, request, "/elsewhere", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(server.Close)
+	profile := testProfile(t, contract)
+	profile.Origin = server.URL
+	profile.Descriptor = descriptorFor(t, profile)
+	client, err := New(profile, nil, server.Client())
+	require.NoError(t, err)
+	_, err = client.Embed(t.Context(), testInputs(), testAuthorization(profile.Descriptor))
+	require.ErrorContains(t, err, "redirect")
+	assert.Zero(t, redirected.Load())
+
+	started := make(chan struct{})
+	canceledProfile := testProfile(t, contract)
+	canceledClient := newTestClient(t, canceledProfile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		close(started)
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	}))
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, embedErr := canceledClient.Embed(ctx, testInputs(), testAuthorization(canceledProfile.Descriptor))
+		done <- embedErr
+	}()
+	<-started
+	cancel()
+	err = <-done
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestEmbedBoundsRequestBodyAndPreservesDescriptorSnapshot(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileE5}))
+	profile.MaxRequestBytes = 128
+	profile.Descriptor = descriptorFor(t, profile)
+	var requests atomic.Int64
+	client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return jsonResponse(request, http.StatusOK, singleVectorResponse("synthetic-model", []float32{1, 0, 0})), nil
+	}))
+	input := []document.EmbeddingInput{{Key: "large", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: strings.Repeat("x", 100)}}
+	authorization := mutateAuthorization(testAuthorization(profile.Descriptor), func(value *document.EmbeddingAuthorization) { value.MaxInputBytes = 200 })
+	_, err := client.Embed(t.Context(), input, authorization)
+	require.ErrorContains(t, err, "request byte")
+	assert.Zero(t, requests.Load())
+
+	descriptor := client.Descriptor()
+	descriptor.InputKinds[0] = document.EmbeddingInputOriginalFile
+	descriptor.SupportedRequestModes[0] = document.ModelInputModeQuery
+	assert.Equal(t, []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}, client.Descriptor().InputKinds)
+	assert.Equal(t, []document.ModelInputMode{document.ModelInputModeText}, client.Descriptor().SupportedRequestModes)
+}
+
+func testProfile(t *testing.T, contract document.ModelInputContract) Profile {
+	t.Helper()
+	profile := Profile{
+		Origin: "http://127.0.0.1:11434", ModelInput: contract, DeploymentEpoch: "epoch-2026-08-26",
+		RequestTimeout: time.Second, MaxBatchItems: 8, MaxInputBytes: 4096,
+		MaxRequestBytes: 8192, MaxResponseBytes: 16384,
+		Descriptor: document.EmbeddingDescriptor{
+			ID: ProviderID, ContractVersion: document.EmbeddingProviderContractVersion,
+			TrustBoundary: document.EmbeddingTrustOperatorNetwork, Model: "synthetic-model",
+			ModelRevision: "epoch-2026-08-26", Dimension: 3, Metric: document.VectorMetricCosine,
+			Normalization: document.VectorNormalizationUnitLength, ScalarEncoding: ScalarEncodingFloat32,
+			DocumentFormatter: DocumentFormatterV1, QueryFormatter: QueryFormatterV1,
+			InputKinds:      []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk},
+			CompatibilityID: contract.CompatibilityID, SupportsTextQuery: true, ModelInput: contract,
+			SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeText},
+		},
+	}
+	profile.Descriptor = descriptorFor(t, profile)
+	return profile
+}
+
+func descriptorFor(t *testing.T, profile Profile) document.EmbeddingDescriptor {
+	t.Helper()
+	profile.Descriptor.PolicyFingerprint = ""
+	profile.Descriptor.Fingerprint = ""
+	fingerprint, err := PolicyFingerprint(profile)
+	require.NoError(t, err)
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	require.NoError(t, err)
+	return descriptor
+}
+
+func canonicalMutatedDescriptor(t *testing.T, descriptor document.EmbeddingDescriptor, mutate func(*document.EmbeddingDescriptor)) document.EmbeddingDescriptor {
+	t.Helper()
+	descriptor.Fingerprint = ""
+	mutate(&descriptor)
+	canonical, err := document.NewEmbeddingDescriptor(descriptor)
+	require.NoError(t, err)
+	return canonical
+}
+
+func modelInput(t *testing.T, config document.ModelInputContractConfig) document.ModelInputContract {
+	t.Helper()
+	contract, err := document.NewModelInputContract(config)
+	require.NoError(t, err)
+	return contract
+}
+
+func testInputs() []document.EmbeddingInput {
+	return []document.EmbeddingInput{
+		{Key: "document-1", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "passage"},
+		{Key: "query-1", Role: document.EmbeddingRoleQuery, Kind: document.EmbeddingInputQueryText, Text: "question"},
+	}
+}
+
+func testAuthorization(descriptor document.EmbeddingDescriptor) document.EmbeddingAuthorization {
+	return document.EmbeddingAuthorization{ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+		PolicyFingerprint: descriptor.PolicyFingerprint, MaxBatchItems: 2, MaxInputBytes: 64, MaxResponseBytes: 4096}
+}
+
+func mutateAuthorization(value document.EmbeddingAuthorization, mutate func(*document.EmbeddingAuthorization)) document.EmbeddingAuthorization {
+	mutate(&value)
+	return value
+}
+
+func newTestClient(t *testing.T, profile Profile, secrets SecretResolver, transport http.RoundTripper) *Client {
+	t.Helper()
+	client, err := New(profile, secrets, &http.Client{Transport: transport})
+	require.NoError(t, err)
+	return client
+}
+
+func staticSuccessTransport() http.RoundTripper {
+	return roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return jsonResponse(request, http.StatusOK, successIndexedResponse), nil
+	})
+}
+
+func jsonResponse(request *http.Request, status int, body []byte) *http.Response {
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(string(body))), Request: request}
+}
+
+func singleVectorResponse(model string, vector []float32) []byte {
+	body, err := json.Marshal(map[string]any{"object": "list", "data": []map[string]any{{"object": "embedding", "embedding": vector, "index": 0}}, "model": model})
+	if err != nil {
+		panic(err)
+	}
+	return body
+}

--- a/document/openaiembed/testdata/schema-drift.json
+++ b/document/openaiembed/testdata/schema-drift.json
@@ -1,0 +1,1 @@
+{"object":"list","data":[{"object":"embedding","embedding":[1,0,0],"index":0}],"model":"synthetic-model","usage":{"prompt_tokens":3,"total_tokens":3},"provider_private_extension":"must fail closed"}

--- a/document/openaiembed/testdata/success-indexed.json
+++ b/document/openaiembed/testdata/success-indexed.json
@@ -1,0 +1,1 @@
+{"object":"list","data":[{"object":"embedding","embedding":[0,1,0],"index":1},{"object":"embedding","embedding":[1,0,0],"index":0}],"model":"synthetic-model","usage":{"prompt_tokens":6,"total_tokens":6}}


### PR DESCRIPTION
## What changed

- Added a local OpenAI-compatible embedding adapter for Ollama, llama.cpp, LM Studio, and compatible operator-run endpoints through one fixed `POST /v1/embeddings` contract.
- Made the model-input contract explicit. Nomic, E5, BGE-M3, GTE, Qwen3, query-only instructions, and complete custom profiles are selected deliberately; model names never change formatting behavior.
- Pinned vector-space identity to either an operator-controlled deployment epoch or one exact provider-attested revision header. Responses must also echo the requested model and return one correctly indexed, finite vector of the declared dimension for every input.
- Bounded batches, rendered input, request and response bytes, timeouts, redirects, and credentials. Provider errors and malformed responses do not expose request text, vectors, secrets, or raw response bodies.

This PR is the child of #212 and adds the local embedding adapter on current `main`.

## Why

An OpenAI-compatible endpoint only standardizes the wire shape. It does not prove that a mutable model alias, document prefix, query instruction, dimension, or local deployment still represents the same vector space.

Making those choices explicit lets operators swap among compatible local servers without hidden model-name heuristics or silently mixing incompatible document and query vectors.

## Usage

Create an `openaiembed.Profile` with the endpoint origin, canonical embedding descriptor, explicit model-input contract, capacity bounds, and either a deployment epoch or revision header. Add a named bearer-secret binding only when the local endpoint requires one, then construct the provider with `openaiembed.New` and call it through `document.ExecuteEmbedding`.

No daemon or CLI surface is added in this layer; worker integration follows in E7.

Refs #176
