### PR TITLE
[F10–E12 18/25] Add bounded hosted Voyage and Mistral embeddings

### DIFF
--- a/document/internal/providerutil/embedding.go
+++ b/document/internal/providerutil/embedding.go
@@ -1,0 +1,15 @@
+package providerutil
+
+import (
+	json "encoding/json/v2"
+	"errors"
+)
+
+// UnmarshalEmbeddingFloat32 requires a JSON number. In particular, null must
+// not become a zero coordinate in an otherwise valid embedding vector.
+func UnmarshalEmbeddingFloat32(data []byte, value *float32) error {
+	if len(data) == 0 || (data[0] != '-' && (data[0] < '0' || data[0] > '9')) {
+		return errors.New("embedding element must be a number")
+	}
+	return json.Unmarshal(data, value)
+}

--- a/document/mistral/embedding.go
+++ b/document/mistral/embedding.go
@@ -1,0 +1,534 @@
+package mistral
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	json "encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/manifestjson"
+	"go.kenn.io/docbank/document/internal/providerutil"
+	"go.kenn.io/docbank/document/providerhttp"
+	"go.kenn.io/docbank/internal/canonical"
+)
+
+const (
+	EmbeddingProviderID          = "mistral.embeddings-v1"
+	EmbeddingDocumentFormatterV1 = "mistral/document/v1"
+	EmbeddingQueryFormatterV1    = "mistral/query/v1"
+	EmbeddingScalarFloat32       = "float32"
+	EmbeddingModel               = "mistral-embed"
+	EmbeddingHostedAliasRevision = "mutable-alias-export-only"
+
+	embeddingOrigin          = "https://api.mistral.ai"
+	embeddingPath            = "/v1/embeddings"
+	embeddingAdapterContract = "docbank-mistral-embeddings/v1"
+
+	defaultEmbeddingTimeout          = 30 * time.Second
+	defaultEmbeddingMaxBatchItems    = 128
+	defaultEmbeddingMaxInputBytes    = int64(1 << 20)
+	defaultEmbeddingMaxRequestBytes  = int64(2 << 20)
+	defaultEmbeddingMaxResponseBytes = int64(32 << 20)
+
+	maxEmbeddingBatchItems = 1000
+	// Match the core embedding limits and the OpenAI adapter's byte ceilings.
+	maxEmbeddingInputBytes       = int64(1 << 30)
+	maxEmbeddingRequestBytes     = int64(1 << 30)
+	maxEmbeddingResponseBytes    = int64(1 << 30)
+	maxEmbeddingSecretBytes      = 64 << 10
+	embeddingUnitLengthTolerance = 1e-4
+)
+
+type EmbeddingProfile struct {
+	Endpoint         string
+	EgressPolicy     providerhttp.EgressPolicy
+	Descriptor       document.EmbeddingDescriptor
+	ModelInput       document.ModelInputContract
+	SecretBinding    string
+	RequestTimeout   time.Duration
+	MaxRetries       int
+	MaxRetryDelay    time.Duration
+	MaxBatchItems    int
+	MaxInputBytes    int64
+	MaxRequestBytes  int64
+	MaxResponseBytes int64
+}
+
+type embeddingPolicyIdentity struct {
+	AdapterContract   string                       `json:"adapter_contract"`
+	Origin            string                       `json:"origin"`
+	Route             string                       `json:"route"`
+	Descriptor        document.EmbeddingDescriptor `json:"descriptor"`
+	ModelInput        document.ModelInputContract  `json:"model_input"`
+	CredentialBinding string                       `json:"credential_binding"`
+	Egress            embeddingEgressIdentity      `json:"egress"`
+	RequestTimeout    int64                        `json:"request_timeout_nanos"`
+	MaxRetries        int                          `json:"max_retries"`
+	MaxRetryDelay     int64                        `json:"max_retry_delay_nanos"`
+	MaxBatchItems     int                          `json:"max_batch_items"`
+	MaxInputBytes     int64                        `json:"max_input_bytes"`
+	MaxRequestBytes   int64                        `json:"max_request_bytes"`
+	MaxResponseBytes  int64                        `json:"max_response_bytes"`
+}
+
+type embeddingEgressIdentity struct {
+	Scheme              string   `json:"scheme"`
+	Host                string   `json:"host"`
+	Port                uint16   `json:"port"`
+	AllowedCIDRs        []string `json:"allowed_cidrs"`
+	ProxyMode           string   `json:"proxy_mode"`
+	ConnectTimeout      int64    `json:"connect_timeout_nanos"`
+	KeepAlive           int64    `json:"keep_alive_nanos"`
+	TLSHandshakeTimeout int64    `json:"tls_handshake_timeout_nanos"`
+	SPKISHA256          []string `json:"spki_sha256,omitempty"`
+}
+
+var ErrEmbeddingCapacity = errors.New("mistral embedding capacity exceeded")
+
+type EmbeddingClient struct {
+	profile    EmbeddingProfile
+	descriptor document.EmbeddingDescriptor
+	secrets    SecretResolver
+	http       *http.Client
+}
+
+var _ document.EmbeddingProvider = (*EmbeddingClient)(nil)
+
+type embeddingWireRequest struct {
+	Input          []string `json:"input"`
+	Model          string   `json:"model"`
+	EncodingFormat string   `json:"encoding_format"`
+}
+
+type embeddingWireResponse struct {
+	ID     string              `json:"id"`
+	Object string              `json:"object"`
+	Data   []embeddingWireItem `json:"data"`
+	Model  string              `json:"model"`
+	Usage  embeddingWireUsage  `json:"usage"`
+}
+
+type embeddingWireItem struct {
+	Object    string    `json:"object"`
+	Embedding []float32 `json:"embedding"`
+	Index     *int      `json:"index"`
+}
+
+type embeddingWireUsage struct {
+	PromptTokens        int64                  `json:"prompt_tokens"`
+	CompletionTokens    int64                  `json:"completion_tokens"`
+	TotalTokens         int64                  `json:"total_tokens"`
+	PromptAudioSeconds  *float64               `json:"prompt_audio_seconds"`
+	PromptTokensDetails *embeddingTokenDetails `json:"prompt_tokens_details,omitempty"`
+	PromptTokenDetails  *embeddingTokenDetails `json:"prompt_token_details,omitempty"`
+	NumCachedTokens     *int64                 `json:"num_cached_tokens,omitempty"`
+	ServiceTier         string                 `json:"service_tier,omitempty"`
+}
+
+type embeddingTokenDetails struct {
+	CachedTokens int64 `json:"cached_tokens"`
+}
+
+func EmbeddingPolicyFingerprint(profile EmbeddingProfile) (string, error) {
+	normalized, descriptorIdentity, err := normalizeEmbeddingProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := canonical.Marshal(embeddingPolicyIdentity{
+		AdapterContract: embeddingAdapterContract, Origin: normalized.Endpoint, Route: embeddingPath,
+		Descriptor: descriptorIdentity, ModelInput: normalized.ModelInput,
+		CredentialBinding: normalized.SecretBinding, Egress: embeddingEgressPolicyIdentity(normalized.EgressPolicy),
+		RequestTimeout: int64(normalized.RequestTimeout), MaxRetries: normalized.MaxRetries,
+		MaxRetryDelay: int64(normalized.MaxRetryDelay), MaxBatchItems: normalized.MaxBatchItems,
+		MaxInputBytes: normalized.MaxInputBytes, MaxRequestBytes: normalized.MaxRequestBytes,
+		MaxResponseBytes: normalized.MaxResponseBytes,
+	})
+	if err != nil {
+		return "", fmt.Errorf("mistral embedding: encode policy identity: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func NewEmbeddingProvider(profile EmbeddingProfile, secrets SecretResolver, resolver providerhttp.Resolver) (*EmbeddingClient, error) {
+	normalized, _, err := normalizeEmbeddingProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		if err == nil {
+			err = errors.New("descriptor is not canonical")
+		}
+		return nil, fmt.Errorf("mistral embedding: invalid descriptor: %w", err)
+	}
+	fingerprint, err := EmbeddingPolicyFingerprint(profile)
+	if err != nil {
+		return nil, err
+	}
+	if descriptor.PolicyFingerprint != fingerprint {
+		return nil, errors.New("mistral embedding: descriptor policy fingerprint does not match profile")
+	}
+	if descriptor.SupportsTextQuery {
+		return nil, errors.New("mistral embedding: hosted mutable alias is export-only")
+	}
+	if normalized.SecretBinding == "" || providerutil.IsNil(secrets) {
+		return nil, errors.New("mistral embedding: named secret binding and resolver are required")
+	}
+	transport, err := providerhttp.NewTransport(normalized.EgressPolicy, resolver)
+	if err != nil {
+		return nil, fmt.Errorf("mistral embedding: invalid sealed egress policy: %w", err)
+	}
+	normalized.Descriptor = cloneEmbeddingDescriptor(descriptor)
+	return &EmbeddingClient{profile: normalized, descriptor: cloneEmbeddingDescriptor(descriptor), secrets: secrets, http: &http.Client{Transport: transport, CheckRedirect: providerhttp.RefuseRedirects}}, nil
+}
+
+func (client *EmbeddingClient) Descriptor() document.EmbeddingDescriptor {
+	if client == nil {
+		return document.EmbeddingDescriptor{}
+	}
+	return cloneEmbeddingDescriptor(client.descriptor)
+}
+
+func (client *EmbeddingClient) Embed(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	if client == nil {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: client is required")
+	}
+	if ctx == nil {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: context is required")
+	}
+	if err := document.ValidateEmbeddingProviderRequest(client, inputs, authorization); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if authorization.MaxBatchItems > client.profile.MaxBatchItems || authorization.MaxInputBytes > client.profile.MaxInputBytes || authorization.MaxResponseBytes > client.profile.MaxResponseBytes {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: authorization exceeds profile capacity")
+	}
+	rendered := make([]string, len(inputs))
+	for index, input := range inputs {
+		if input.Role == document.EmbeddingRoleDocument {
+			rendered[index] = client.profile.ModelInput.EncodeDocument(input.Text)
+		} else {
+			rendered[index] = client.profile.ModelInput.EncodeQuery(input.Text)
+		}
+	}
+	payload, err := json.Marshal(embeddingWireRequest{Input: rendered, Model: client.descriptor.Model, EncodingFormat: "float"})
+	if err != nil {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: could not encode request")
+	}
+	if int64(len(payload)) > client.profile.MaxRequestBytes {
+		return document.EmbeddingResult{}, fmt.Errorf("%w: request byte limit", ErrEmbeddingCapacity)
+	}
+	started := time.Now()
+	metrics := RequestMetrics{}
+	for attempt := 1; ; attempt++ {
+		result, retryHeader, retry, requested, attemptErr := client.embeddingAttempt(ctx, payload, inputs)
+		if requested {
+			metrics.Requests++
+		}
+		if attemptErr == nil {
+			if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
+				return document.EmbeddingResult{}, err
+			}
+			return result, nil
+		}
+		if !retry || attempt >= client.profile.MaxRetries {
+			metrics.Latency = time.Since(started)
+			return document.EmbeddingResult{}, &processError{err: attemptErr, metrics: metrics}
+		}
+		metrics.Retries++
+		if waitErr := waitContext(ctx, retryAfter(retryHeader, attempt, client.profile.MaxRetryDelay)); waitErr != nil {
+			metrics.Latency = time.Since(started)
+			return document.EmbeddingResult{}, &processError{err: fmt.Errorf("mistral embedding: request canceled: %w", waitErr), metrics: metrics}
+		}
+	}
+}
+
+func (client *EmbeddingClient) embeddingAttempt(ctx context.Context, payload []byte, inputs []document.EmbeddingInput) (document.EmbeddingResult, string, bool, bool, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
+	defer cancel()
+	secret, err := client.secrets.ResolveSecret(attemptCtx, client.profile.SecretBinding)
+	if err != nil || !validEmbeddingSecret(secret) || attemptCtx.Err() != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, "", false, false, contextErr
+		}
+		if contextErr := attemptCtx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, "", true, false, fmt.Errorf("%w: attempt timeout: %w", ErrTransientResponse, contextErr)
+		}
+		return document.EmbeddingResult{}, "", false, false, fmt.Errorf("%w: credential unavailable", ErrPermanentResponse)
+	}
+	request, err := http.NewRequestWithContext(attemptCtx, http.MethodPost, client.profile.Endpoint+embeddingPath, bytes.NewReader(payload))
+	if err != nil {
+		return document.EmbeddingResult{}, "", false, false, fmt.Errorf("%w: request construction", ErrPermanentResponse)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+secret)
+	response, err := client.http.Do(request)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, "", false, true, contextErr
+		}
+		if contextErr := attemptCtx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, "", true, true, fmt.Errorf("%w: attempt timeout: %w", ErrTransientResponse, contextErr)
+		}
+		return document.EmbeddingResult{}, "", true, true, fmt.Errorf("%w: transport", ErrTransientResponse)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode >= 300 && response.StatusCode < 400 {
+		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: redirect HTTP %d", ErrPermanentResponse, response.StatusCode)
+	}
+	if response.StatusCode == http.StatusRequestEntityTooLarge {
+		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: HTTP %d", ErrEmbeddingCapacity, response.StatusCode)
+	}
+	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+		return document.EmbeddingResult{}, response.Header.Get("Retry-After"), true, true, fmt.Errorf("%w: HTTP %d", ErrTransientResponse, response.StatusCode)
+	}
+	if response.StatusCode != http.StatusOK {
+		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: HTTP %d", ErrPermanentResponse, response.StatusCode)
+	}
+	if err := validateEmbeddingContentType(response.Header.Get("Content-Type")); err != nil {
+		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: response content type", ErrPermanentResponse)
+	}
+	body, err := readEmbeddingBody(attemptCtx, response.Body, client.profile.MaxResponseBytes)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, "", false, true, contextErr
+		}
+		if contextErr := attemptCtx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, "", true, true, fmt.Errorf("%w: attempt timeout: %w", ErrTransientResponse, contextErr)
+		}
+		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: bounded response", ErrPermanentResponse)
+	}
+	if err := manifestjson.RejectDuplicateKeys(body, "mistral embedding response"); err != nil {
+		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: duplicate response member", ErrPermanentResponse)
+	}
+	var decoded embeddingWireResponse
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
+		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: malformed response", ErrPermanentResponse)
+	}
+	result, err := client.validateAndOrder(decoded, inputs)
+	if err != nil {
+		err = fmt.Errorf("%w: invalid response", ErrPermanentResponse)
+	}
+	return result, "", false, true, err
+}
+
+func (client *EmbeddingClient) validateAndOrder(response embeddingWireResponse, inputs []document.EmbeddingInput) (document.EmbeddingResult, error) {
+	if response.ID == "" || response.Object != "list" || response.Model != client.descriptor.Model {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: provider model or response contract drifted")
+	}
+	if response.Usage.PromptTokens < 0 || response.Usage.CompletionTokens < 0 || response.Usage.TotalTokens < response.Usage.PromptTokens+response.Usage.CompletionTokens {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: provider usage is invalid")
+	}
+	for _, details := range []*embeddingTokenDetails{response.Usage.PromptTokensDetails, response.Usage.PromptTokenDetails} {
+		if details != nil && (details.CachedTokens < 0 || details.CachedTokens > response.Usage.PromptTokens) {
+			return document.EmbeddingResult{}, errors.New("mistral embedding: provider usage is invalid")
+		}
+	}
+	if response.Usage.NumCachedTokens != nil && (*response.Usage.NumCachedTokens < 0 || *response.Usage.NumCachedTokens > response.Usage.PromptTokens) {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: provider usage is invalid")
+	}
+	if response.Usage.ServiceTier != "" && response.Usage.ServiceTier != "standard" && response.Usage.ServiceTier != "priority" {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: provider usage is invalid")
+	}
+	if len(response.Data) != len(inputs) {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: provider response has a missing vector")
+	}
+	vectors := make([]document.EmbeddingVector, len(inputs))
+	seen := make([]bool, len(inputs))
+	for _, item := range response.Data {
+		if item.Object != "embedding" || item.Index == nil || *item.Index < 0 || *item.Index >= len(inputs) || seen[*item.Index] {
+			return document.EmbeddingResult{}, errors.New("mistral embedding: provider response index contract drifted")
+		}
+		if err := client.validateVector(item.Embedding); err != nil {
+			return document.EmbeddingResult{}, err
+		}
+		seen[*item.Index] = true
+		vectors[*item.Index] = document.EmbeddingVector{Key: inputs[*item.Index].Key, Values: slices.Clone(item.Embedding)}
+	}
+	if slices.Contains(seen, false) {
+		return document.EmbeddingResult{}, errors.New("mistral embedding: provider response has a missing vector index")
+	}
+	return document.EmbeddingResult{Vectors: vectors}, nil
+}
+
+func (client *EmbeddingClient) validateVector(vector []float32) error {
+	if len(vector) != client.descriptor.Dimension {
+		return errors.New("mistral embedding: provider vector dimension does not match profile")
+	}
+	var norm float64
+	for _, value := range vector {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return errors.New("mistral embedding: provider vector contains a non-finite value")
+		}
+		norm += float64(value) * float64(value)
+	}
+	if norm == 0 {
+		return errors.New("mistral embedding: provider returned a zero vector")
+	}
+	if client.descriptor.Normalization == document.VectorNormalizationUnitLength && math.Abs(norm-1) > embeddingUnitLengthTolerance {
+		return errors.New("mistral embedding: provider vector normalization does not match profile")
+	}
+	return nil
+}
+
+func normalizeEmbeddingProfile(profile EmbeddingProfile) (EmbeddingProfile, document.EmbeddingDescriptor, error) {
+	if profile.Endpoint == "" {
+		profile.Endpoint = embeddingOrigin
+	}
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = defaultEmbeddingTimeout
+	}
+	if profile.MaxRetries == 0 {
+		profile.MaxRetries = DefaultMaxRetries
+	}
+	if profile.MaxRetryDelay == 0 {
+		profile.MaxRetryDelay = DefaultMaxRetryDelay
+	}
+	if profile.MaxBatchItems == 0 {
+		profile.MaxBatchItems = defaultEmbeddingMaxBatchItems
+	}
+	if profile.MaxInputBytes == 0 {
+		profile.MaxInputBytes = defaultEmbeddingMaxInputBytes
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = defaultEmbeddingMaxRequestBytes
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = defaultEmbeddingMaxResponseBytes
+	}
+	if profile.RequestTimeout <= 0 || profile.RequestTimeout > MaxTimeout || profile.MaxRetries < 1 || profile.MaxRetries > MaxRetries || profile.MaxRetryDelay <= 0 || profile.MaxRetryDelay > MaxRetryDelay || profile.MaxBatchItems < 1 || profile.MaxBatchItems > maxEmbeddingBatchItems ||
+		profile.MaxInputBytes < 1 || profile.MaxInputBytes > maxEmbeddingInputBytes ||
+		profile.MaxRequestBytes < 1 || profile.MaxRequestBytes > maxEmbeddingRequestBytes ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maxEmbeddingResponseBytes {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, errors.New("mistral embedding: execution bounds are invalid")
+	}
+	if !validEmbeddingBinding(profile.SecretBinding) {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, errors.New("mistral embedding: secret binding is invalid")
+	}
+	if err := normalizeAndValidateEmbeddingEgress(&profile); err != nil {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, err
+	}
+	descriptorIdentity := profile.Descriptor
+	descriptorIdentity.PolicyFingerprint = strings.Repeat("0", sha256.Size*2)
+	descriptorIdentity.Fingerprint = ""
+	var err error
+	descriptorIdentity, err = document.NewEmbeddingDescriptor(descriptorIdentity)
+	if err != nil {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, fmt.Errorf("mistral embedding: invalid descriptor identity: %w", err)
+	}
+	descriptorIdentity.PolicyFingerprint = ""
+	descriptorIdentity.Fingerprint = ""
+	if descriptorIdentity.SupportsTextQuery {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, errors.New("mistral embedding: hosted mutable alias is export-only")
+	}
+	if descriptorIdentity.ID != EmbeddingProviderID || descriptorIdentity.TrustBoundary != document.EmbeddingTrustHostedProvider || descriptorIdentity.Model != EmbeddingModel || descriptorIdentity.ModelRevision != EmbeddingHostedAliasRevision || descriptorIdentity.Dimension != 1024 || descriptorIdentity.ScalarEncoding != EmbeddingScalarFloat32 || descriptorIdentity.DocumentFormatter != EmbeddingDocumentFormatterV1 || descriptorIdentity.QueryFormatter != EmbeddingQueryFormatterV1 || !slices.Equal(descriptorIdentity.InputKinds, []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}) || !slices.Equal(descriptorIdentity.SupportedRequestModes, []document.ModelInputMode{document.ModelInputModeText}) || descriptorIdentity.ModelInput != profile.ModelInput || descriptorIdentity.CompatibilityID != profile.ModelInput.CompatibilityID || profile.ModelInput.Document.Mode != document.ModelInputModeText || profile.ModelInput.Query.Mode != document.ModelInputModeText {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, errors.New("mistral embedding: descriptor does not match text adapter contract")
+	}
+	return profile, descriptorIdentity, nil
+}
+
+func normalizeAndValidateEmbeddingEgress(profile *EmbeddingProfile) error {
+	if profile.EgressPolicy.ConnectTimeout == 0 {
+		profile.EgressPolicy.ConnectTimeout = providerhttp.DefaultConnectTimeout
+	}
+	if profile.EgressPolicy.KeepAlive == 0 {
+		profile.EgressPolicy.KeepAlive = providerhttp.DefaultKeepAlive
+	}
+	if profile.EgressPolicy.TLSHandshakeTimeout == 0 {
+		profile.EgressPolicy.TLSHandshakeTimeout = providerhttp.DefaultTLSHandshakeTimeout
+	}
+	if profile.EgressPolicy.ProxyMode == "" {
+		profile.EgressPolicy.ProxyMode = providerhttp.ProxyDisabled
+	}
+	if profile.EgressPolicy.TLS.RootCAs != nil {
+		return errors.New("mistral embedding: custom egress roots cannot enter canonical identity")
+	}
+	parsed, err := url.Parse(profile.Endpoint)
+	if err != nil || parsed.Scheme != "https" || parsed.User != nil || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("mistral embedding: endpoint must be an exact HTTPS provider origin")
+	}
+	port := parsed.Port()
+	if port == "" {
+		port = "443"
+	}
+	if parsed.Scheme != profile.EgressPolicy.Scheme || !strings.EqualFold(parsed.Hostname(), profile.EgressPolicy.Host) || port != strconv.FormatUint(uint64(profile.EgressPolicy.Port), 10) {
+		return errors.New("mistral embedding: endpoint and egress authority differ")
+	}
+	profile.Endpoint = strings.TrimSuffix(profile.Endpoint, "/")
+	slices.SortFunc(profile.EgressPolicy.AllowedCIDRs, func(a, b netip.Prefix) int { return strings.Compare(a.Masked().String(), b.Masked().String()) })
+	slices.Sort(profile.EgressPolicy.TLS.SPKISHA256)
+	return nil
+}
+
+func embeddingEgressPolicyIdentity(policy providerhttp.EgressPolicy) embeddingEgressIdentity {
+	cidrs := make([]string, len(policy.AllowedCIDRs))
+	for index, prefix := range policy.AllowedCIDRs {
+		cidrs[index] = prefix.Masked().String()
+	}
+	return embeddingEgressIdentity{Scheme: policy.Scheme, Host: strings.ToLower(policy.Host), Port: policy.Port, AllowedCIDRs: cidrs, ProxyMode: string(policy.ProxyMode), ConnectTimeout: int64(policy.ConnectTimeout), KeepAlive: int64(policy.KeepAlive), TLSHandshakeTimeout: int64(policy.TLSHandshakeTimeout), SPKISHA256: slices.Clone(policy.TLS.SPKISHA256)}
+}
+
+func readEmbeddingBody(ctx context.Context, reader io.Reader, maximum int64) ([]byte, error) {
+	// Validate before adding the sentinel byte, including for an overflowing bound.
+	if maximum < 1 || maximum > maxEmbeddingResponseBytes {
+		return nil, errors.New("mistral embedding: invalid response byte limit")
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, fmt.Errorf("mistral embedding: response read canceled: %w", contextErr)
+	}
+	if err != nil {
+		return nil, errors.New("mistral embedding: could not read provider response")
+	}
+	if int64(len(body)) > maximum {
+		return nil, errors.New("mistral embedding: provider response byte limit exceeded")
+	}
+	return body, nil
+}
+
+func validateEmbeddingContentType(value string) error {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || mediaType != "application/json" || (len(parameters) != 0 && (len(parameters) != 1 || !strings.EqualFold(parameters["charset"], "utf-8"))) {
+		return errors.New("mistral embedding: provider response content type is invalid")
+	}
+	return nil
+}
+
+func validEmbeddingSecret(secret string) bool {
+	if secret == "" || len(secret) > maxEmbeddingSecretBytes {
+		return false
+	}
+	for _, character := range secret {
+		if unicode.IsControl(character) || unicode.IsSpace(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validEmbeddingBinding(value string) bool {
+	return value != "" && len(value) <= 128 && value == strings.TrimSpace(value) && strings.IndexFunc(value, unicode.IsControl) < 0
+}
+
+func cloneEmbeddingDescriptor(value document.EmbeddingDescriptor) document.EmbeddingDescriptor {
+	value.InputKinds = slices.Clone(value.InputKinds)
+	value.SupportedRequestModes = slices.Clone(value.SupportedRequestModes)
+	return value
+}

--- a/document/mistral/embedding.go
+++ b/document/mistral/embedding.go
@@ -319,7 +319,7 @@ func (client *EmbeddingClient) embeddingAttempt(ctx context.Context, payload []b
 		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: duplicate response member", ErrPermanentResponse)
 	}
 	var decoded embeddingWireResponse
-	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true), json.WithUnmarshalers(json.UnmarshalFunc(providerutil.UnmarshalEmbeddingFloat32))); err != nil {
 		return document.EmbeddingResult{}, "", false, true, fmt.Errorf("%w: malformed response", ErrPermanentResponse)
 	}
 	result, err := client.validateAndOrder(decoded, inputs)

--- a/document/mistral/embedding_review_test.go
+++ b/document/mistral/embedding_review_test.go
@@ -1,0 +1,198 @@
+package mistral
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+type mistralEmbeddingResolver struct {
+	address     netip.Addr
+	certificate *x509.Certificate
+}
+
+func (resolver mistralEmbeddingResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return []netip.Addr{resolver.address}, nil
+}
+
+func mistralFixture(t *testing.T, handler http.Handler) (string, providerhttp.EgressPolicy, providerhttp.Resolver) {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	_, portText, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	port, err := strconv.ParseUint(portText, 10, 16)
+	require.NoError(t, err)
+	return server.URL, providerhttp.EgressPolicy{
+		Scheme: "https", Host: parsed.Hostname(), Port: uint16(port),
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}, ProxyMode: providerhttp.ProxyDisabled,
+	}, mistralEmbeddingResolver{address: netip.MustParseAddr("127.0.0.1"), certificate: server.Certificate()}
+}
+
+func newMistralEmbeddingTestProvider(t *testing.T, profile EmbeddingProfile, secrets SecretResolver, resolver providerhttp.Resolver) (*EmbeddingClient, error) {
+	t.Helper()
+	provider, err := NewEmbeddingProvider(profile, secrets, resolver)
+	if err != nil {
+		return nil, err
+	}
+	if fixture, ok := resolver.(mistralEmbeddingResolver); ok {
+		roots := x509.NewCertPool()
+		roots.AddCert(fixture.certificate)
+		transport, ok := provider.http.Transport.(*http.Transport)
+		require.True(t, ok)
+		// Trust only the fixture certificate after canonical profile validation.
+		transport.TLSClientConfig.RootCAs = roots
+	}
+	t.Cleanup(provider.http.CloseIdleConnections)
+	return provider, nil
+}
+
+func TestHostedMistralAliasIsAlwaysExportOnlyAndSealed(t *testing.T) {
+	endpoint, egress, resolver := mistralFixture(t, http.NotFoundHandler())
+	profile := testEmbeddingProfile(t)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	profile.Descriptor.SupportsTextQuery = true
+	_, err := NewEmbeddingProvider(profile, embeddingSecretMap{"credential:mistral-embed": "synthetic-secret"}, resolver)
+	require.ErrorContains(t, err, "export-only")
+}
+
+type embeddingSecretFunc func(context.Context, string) (string, error)
+
+func (resolve embeddingSecretFunc) ResolveSecret(ctx context.Context, binding string) (string, error) {
+	return resolve(ctx, binding)
+}
+
+func TestMistralEmbeddingAttemptTimeouts(t *testing.T) {
+	for _, stage := range []string{"credentials", "headers", "body"} {
+		for _, outcome := range []string{"recover", "exhaust", "caller_cancel"} {
+			t.Run(stage+"/"+outcome, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				var requests atomic.Int32
+				var resolutions int
+				response := mistralEmbeddingBody(t, []int{0})
+				endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					count := requests.Add(1)
+					_, _ = io.Copy(io.Discard, r.Body)
+					w.Header().Set("Content-Type", "application/json")
+					if stage != "credentials" && (outcome != "recover" || count < 3) {
+						if stage == "body" {
+							w.WriteHeader(http.StatusOK)
+							assert.NoError(t, http.NewResponseController(w).Flush())
+						}
+						if outcome == "caller_cancel" {
+							cancel()
+						}
+						select {
+						case <-r.Context().Done():
+						case <-time.After(2 * time.Second):
+						}
+						return
+					}
+					_, _ = w.Write(response)
+				}))
+				secrets := embeddingSecretFunc(func(attemptCtx context.Context, _ string) (string, error) {
+					resolutions++
+					if stage == "credentials" && (outcome != "recover" || resolutions < 3) {
+						if outcome == "caller_cancel" {
+							cancel()
+						}
+						<-attemptCtx.Done()
+						return "", attemptCtx.Err()
+					}
+					return "synthetic-secret", nil
+				})
+				profile := testEmbeddingProfile(t)
+				profile.Endpoint, profile.EgressPolicy = endpoint, egress
+				profile.RequestTimeout, profile.MaxRetries = 100*time.Millisecond, 3
+				profile.MaxRetryDelay = time.Nanosecond
+				recomputeMistralEmbeddingProfile(t, &profile)
+				provider, err := newMistralEmbeddingTestProvider(t, profile, secrets, resolver)
+				require.NoError(t, err)
+				result, err := provider.Embed(ctx, []document.EmbeddingInput{{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "first"}}, embeddingAuthorization(profile.Descriptor))
+				switch outcome {
+				case "recover":
+					require.NoError(t, err)
+					require.Len(t, result.Vectors, 1)
+					require.Equal(t, 3, resolutions)
+					require.NoError(t, ctx.Err())
+				case "exhaust":
+					require.ErrorIs(t, err, ErrTransientResponse)
+					require.ErrorIs(t, err, context.DeadlineExceeded)
+					require.NoError(t, ctx.Err())
+					require.Equal(t, 3, resolutions)
+					require.Equal(t, 2, MetricsFromError(err).Retries)
+				case "caller_cancel":
+					require.ErrorIs(t, err, context.Canceled)
+					require.NotErrorIs(t, err, ErrTransientResponse)
+					require.Equal(t, 1, resolutions)
+					require.Zero(t, MetricsFromError(err).Retries)
+				}
+				wantRequests := resolutions
+				if stage == "credentials" {
+					wantRequests = 0
+					if outcome == "recover" {
+						wantRequests = 1
+					}
+				}
+				require.EqualValues(t, wantRequests, requests.Load())
+				if err != nil {
+					require.Equal(t, wantRequests, MetricsFromError(err).Requests)
+				}
+			})
+		}
+	}
+}
+
+func TestMistralEmbeddingCapacityCeilings(t *testing.T) {
+	for _, field := range []string{"input", "request", "response", "batch"} {
+		for _, excess := range []int64{0, 1, math.MaxInt64} {
+			t.Run(fmt.Sprintf("%s/%d", field, excess), func(t *testing.T) {
+				profile := testEmbeddingProfile(t)
+				limit := int64(1 << 30)
+				if field == "batch" {
+					limit = 1000
+				}
+				value := excess
+				if excess != math.MaxInt64 {
+					value += limit
+				}
+				switch field {
+				case "input":
+					profile.MaxInputBytes = value
+				case "request":
+					profile.MaxRequestBytes = value
+				case "response":
+					profile.MaxResponseBytes = value
+				case "batch":
+					profile.MaxBatchItems = int(value)
+				}
+				_, err := EmbeddingPolicyFingerprint(profile)
+				if excess == 0 {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+				}
+			})
+		}
+	}
+}

--- a/document/mistral/embedding_test.go
+++ b/document/mistral/embedding_test.go
@@ -99,6 +99,9 @@ func TestMistralEmbeddingRejectsMalformedAndPartialResponsesPrivately(t *testing
 	}{
 		{"malformed", []byte(`{"object":`)}, {"unknown", []byte(`{"unknown":"PRIVATE_RAW_BODY"}`)}, {"duplicate", []byte(`{"model":"mistral-embed","model":"PRIVATE_RAW_BODY"}`)},
 		{"partial indices", valid([]int{0}, [][]float32{one})}, {"duplicate index", valid([]int{0, 0}, [][]float32{one, two})}, {"out of range", valid([]int{0, 2}, [][]float32{one, two})}, {"wrong dimension", valid([]int{0, 1}, [][]float32{one[:1023], two})},
+		{"null element", []byte(strings.Replace(string(valid([]int{0, 1}, [][]float32{one, two})), `,0`, `,null`, 1))},
+		{"string element", []byte(strings.Replace(string(valid([]int{0, 1}, [][]float32{one, two})), `,0`, `,"0"`, 1))},
+		{"boolean element", []byte(strings.Replace(string(valid([]int{0, 1}, [][]float32{one, two})), `,0`, `,false`, 1))},
 		{"zero vector", valid([]int{0, 1}, [][]float32{make([]float32, 1024), two})}, {"non finite", []byte(`{"id":"x","object":"list","data":[{"object":"embedding","embedding":[1e999],"index":0}],"model":"mistral-embed","usage":{"prompt_tokens":1,"completion_tokens":0,"total_tokens":1,"prompt_audio_seconds":null}}`)},
 	}
 	inputs := []document.EmbeddingInput{{Key: "a", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "PRIVATE_INPUT"}, {Key: "b", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "other"}}

--- a/document/mistral/embedding_test.go
+++ b/document/mistral/embedding_test.go
@@ -1,0 +1,350 @@
+package mistral
+
+import (
+	"context"
+	json "encoding/json/v2"
+	"errors"
+	"net/http"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+type embeddingSecretMap map[string]string
+
+func (secrets embeddingSecretMap) ResolveSecret(_ context.Context, name string) (string, error) {
+	return secrets[name], nil
+}
+
+func TestMistralEmbeddingRejectsHTTPOrigin(t *testing.T) {
+	for _, endpoint := range []string{"http://api.mistral.ai", "http://api.mistral.ai:80"} {
+		t.Run(endpoint, func(t *testing.T) {
+			profile := testEmbeddingProfile(t)
+			profile.Endpoint = endpoint
+			profile.EgressPolicy.Scheme = "http"
+			profile.EgressPolicy.Port = 80
+			_, err := EmbeddingPolicyFingerprint(profile)
+			require.ErrorContains(t, err, "HTTPS")
+			_, err = NewEmbeddingProvider(profile, embeddingSecretMap{"credential:mistral-embed": "synthetic-secret"}, nil)
+			require.ErrorContains(t, err, "HTTPS")
+		})
+	}
+}
+
+func TestEmbeddingProviderAppliesDocumentEnvelopeAndRestoresIndices(t *testing.T) {
+	var request struct {
+		Input          []string `json:"input"`
+		Model          string   `json:"model"`
+		EncodingFormat string   `json:"encoding_format"`
+	}
+	endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, incoming *http.Request) {
+		assert.Equal(t, "/v1/embeddings", incoming.URL.Path)
+		assert.Equal(t, "Bearer synthetic-secret", incoming.Header.Get("Authorization"))
+		assert.NoError(t, json.UnmarshalRead(incoming.Body, &request, json.RejectUnknownMembers(true)))
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write(mistralEmbeddingBody(t, []int{1, 0}))
+	}))
+	profile := testEmbeddingProfile(t)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	recomputeMistralEmbeddingProfile(t, &profile)
+	provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "synthetic-secret"}, resolver)
+	require.NoError(t, err)
+	inputs := []document.EmbeddingInput{
+		{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "passage"},
+		{Key: "second", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "second"},
+	}
+	result, err := document.ExecuteEmbedding(t.Context(), provider, inputs, embeddingAuthorization(profile.Descriptor))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"document envelope: passage", "document envelope: second"}, request.Input)
+	assert.Equal(t, []string{"first", "second"}, []string{result.Vectors[0].Key, result.Vectors[1].Key})
+}
+
+func TestMistralEmbeddingPolicyFingerprintCoversCompleteContractAndEgress(t *testing.T) {
+	profile := testEmbeddingProfile(t)
+	baseline, err := EmbeddingPolicyFingerprint(profile)
+	require.NoError(t, err)
+	changed := profile
+	changed.ModelInput = testMistralModelInput(t, "changed: {{content}}", "query envelope: {{content}}")
+	changed.Descriptor.ModelInput, changed.Descriptor.CompatibilityID = changed.ModelInput, changed.ModelInput.CompatibilityID
+	recomputeMistralEmbeddingProfile(t, &changed)
+	assert.NotEqual(t, baseline, changed.Descriptor.PolicyFingerprint)
+	changed = profile
+	changed.EgressPolicy.AllowedCIDRs = []netip.Prefix{netip.MustParsePrefix("198.51.100.0/24")}
+	recomputeMistralEmbeddingProfile(t, &changed)
+	assert.NotEqual(t, baseline, changed.Descriptor.PolicyFingerprint)
+}
+
+func TestMistralEmbeddingRejectsMalformedAndPartialResponsesPrivately(t *testing.T) {
+	one, two := mistralUnitEmbedding(0), mistralUnitEmbedding(1)
+	valid := func(indices []int, vectors [][]float32) []byte {
+		items := make([]map[string]any, len(indices))
+		for index := range indices {
+			items[index] = map[string]any{"object": "embedding", "embedding": vectors[index], "index": indices[index]}
+		}
+		body, err := json.Marshal(map[string]any{"id": "synthetic", "object": "list", "data": items, "model": EmbeddingModel, "usage": map[string]any{"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2, "prompt_audio_seconds": nil}})
+		require.NoError(t, err)
+		return body
+	}
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{"malformed", []byte(`{"object":`)}, {"unknown", []byte(`{"unknown":"PRIVATE_RAW_BODY"}`)}, {"duplicate", []byte(`{"model":"mistral-embed","model":"PRIVATE_RAW_BODY"}`)},
+		{"partial indices", valid([]int{0}, [][]float32{one})}, {"duplicate index", valid([]int{0, 0}, [][]float32{one, two})}, {"out of range", valid([]int{0, 2}, [][]float32{one, two})}, {"wrong dimension", valid([]int{0, 1}, [][]float32{one[:1023], two})},
+		{"zero vector", valid([]int{0, 1}, [][]float32{make([]float32, 1024), two})}, {"non finite", []byte(`{"id":"x","object":"list","data":[{"object":"embedding","embedding":[1e999],"index":0}],"model":"mistral-embed","usage":{"prompt_tokens":1,"completion_tokens":0,"total_tokens":1,"prompt_audio_seconds":null}}`)},
+	}
+	inputs := []document.EmbeddingInput{{Key: "a", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "PRIVATE_INPUT"}, {Key: "b", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "other"}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write(test.body)
+			}))
+			profile := testEmbeddingProfile(t)
+			profile.Endpoint, profile.EgressPolicy = endpoint, egress
+			recomputeMistralEmbeddingProfile(t, &profile)
+			provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "PRIVATE_SECRET"}, resolver)
+			require.NoError(t, err)
+			_, err = provider.Embed(t.Context(), inputs, embeddingAuthorization(profile.Descriptor))
+			require.ErrorIs(t, err, ErrPermanentResponse)
+			assert.NotContains(t, err.Error(), "PRIVATE")
+		})
+	}
+}
+
+func TestMistralEmbeddingClassifiesCapacityPermanentAndTransient(t *testing.T) {
+	input := []document.EmbeddingInput{{Key: "one", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "text"}}
+	for _, test := range []struct {
+		name   string
+		status int
+		kind   error
+	}{{"capacity", http.StatusRequestEntityTooLarge, ErrEmbeddingCapacity}, {"permanent", http.StatusBadRequest, ErrPermanentResponse}, {"rate limit", http.StatusTooManyRequests, ErrTransientResponse}, {"transient", http.StatusServiceUnavailable, ErrTransientResponse}} {
+		t.Run(test.name, func(t *testing.T) {
+			var calls atomic.Int32
+			endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				writer.WriteHeader(test.status)
+				_, _ = writer.Write([]byte("PRIVATE_BODY"))
+			}))
+			profile := testEmbeddingProfile(t)
+			profile.Endpoint, profile.EgressPolicy, profile.MaxRetries, profile.MaxRetryDelay = endpoint, egress, 2, time.Millisecond
+			recomputeMistralEmbeddingProfile(t, &profile)
+			provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "secret"}, resolver)
+			require.NoError(t, err)
+			_, err = provider.Embed(t.Context(), input, embeddingAuthorization(profile.Descriptor))
+			require.ErrorIs(t, err, test.kind)
+			assert.NotContains(t, err.Error(), "PRIVATE_BODY")
+			metrics := MetricsFromError(err)
+			assert.Equal(t, int(calls.Load()), metrics.Requests)
+			if errors.Is(test.kind, ErrTransientResponse) {
+				assert.Equal(t, 2, metrics.Requests)
+				assert.Equal(t, 1, metrics.Retries)
+			}
+		})
+	}
+}
+
+func TestMistralEmbeddingRejectsIdentityDrift(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*EmbeddingProfile)
+	}{
+		{"model", func(profile *EmbeddingProfile) { profile.Descriptor.Model = "mistral-embed-drift" }},
+		{"revision", func(profile *EmbeddingProfile) { profile.Descriptor.ModelRevision = "invented-revision" }},
+		{"compatibility", func(profile *EmbeddingProfile) { profile.Descriptor.CompatibilityID = "mistral/other-space/v1" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			profile := testEmbeddingProfile(t)
+			test.mutate(&profile)
+			_, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "secret"}, nil)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestMistralEmbeddingResponseLimitAndTransportExhaustion(t *testing.T) {
+	input := []document.EmbeddingInput{{Key: "one", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "text"}}
+	t.Run("response limit", func(t *testing.T) {
+		endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(strings.Repeat("x", 8193)))
+		}))
+		profile := testEmbeddingProfile(t)
+		profile.Endpoint, profile.EgressPolicy, profile.MaxResponseBytes = endpoint, egress, 8192
+		recomputeMistralEmbeddingProfile(t, &profile)
+		provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "secret"}, resolver)
+		require.NoError(t, err)
+		authorization := embeddingAuthorization(profile.Descriptor)
+		authorization.MaxResponseBytes = 8192
+		_, err = provider.Embed(t.Context(), input, authorization)
+		require.ErrorIs(t, err, ErrPermanentResponse)
+	})
+	t.Run("transport exhaustion", func(t *testing.T) {
+		profile := testEmbeddingProfile(t)
+		profile.MaxRetries, profile.MaxRetryDelay = 2, time.Millisecond
+		recomputeMistralEmbeddingProfile(t, &profile)
+		provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "secret"}, failingMistralEmbeddingResolver{})
+		require.NoError(t, err)
+		_, err = provider.Embed(t.Context(), input, embeddingAuthorization(profile.Descriptor))
+		require.ErrorIs(t, err, ErrTransientResponse)
+		assert.Equal(t, 2, MetricsFromError(err).Requests)
+	})
+}
+
+type failingMistralEmbeddingResolver struct{}
+
+func (failingMistralEmbeddingResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return nil, errors.New("synthetic DNS failure")
+}
+
+func TestMistralEmbeddingRequestBoundRedirectAndCancellation(t *testing.T) {
+	input := []document.EmbeddingInput{{Key: "one", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "text"}}
+	endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Location", "http://elsewhere.invalid/private")
+		writer.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	profile := testEmbeddingProfile(t)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	recomputeMistralEmbeddingProfile(t, &profile)
+	provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "secret"}, resolver)
+	require.NoError(t, err)
+	_, err = provider.Embed(t.Context(), input, embeddingAuthorization(profile.Descriptor))
+	require.ErrorIs(t, err, ErrPermanentResponse)
+	bounded := profile
+	bounded.MaxRequestBytes = 1
+	recomputeMistralEmbeddingProfile(t, &bounded)
+	provider, err = newMistralEmbeddingTestProvider(t, bounded, embeddingSecretMap{"credential:mistral-embed": "secret"}, resolver)
+	require.NoError(t, err)
+	_, err = provider.Embed(t.Context(), input, embeddingAuthorization(bounded.Descriptor))
+	require.ErrorIs(t, err, ErrEmbeddingCapacity)
+}
+
+func TestMistralEmbeddingAcceptsDocumentedOptionalUsageFields(t *testing.T) {
+	endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		body := mistralEmbeddingBody(t, []int{0})
+		body = []byte(strings.Replace(string(body), `"prompt_tokens":2`, `"prompt_tokens":2,"prompt_tokens_details":{"cached_tokens":1},"prompt_token_details":{"cached_tokens":1},"num_cached_tokens":1,"service_tier":"standard"`, 1))
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write(body)
+	}))
+	profile := testEmbeddingProfile(t)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	recomputeMistralEmbeddingProfile(t, &profile)
+	provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "secret"}, resolver)
+	require.NoError(t, err)
+	_, err = provider.Embed(t.Context(), []document.EmbeddingInput{{Key: "one", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "text"}}, embeddingAuthorization(profile.Descriptor))
+	require.NoError(t, err)
+}
+
+func TestMistralEmbeddingCancellationPreservesIdentityAndMetrics(t *testing.T) {
+	input := []document.EmbeddingInput{{Key: "one", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "text"}}
+	t.Run("retry wait", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+		endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.Header().Set("Retry-After", "60")
+			writer.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		profile := testEmbeddingProfile(t)
+		profile.Endpoint, profile.EgressPolicy = endpoint, egress
+		recomputeMistralEmbeddingProfile(t, &profile)
+		provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "secret"}, resolver)
+		require.NoError(t, err)
+		_, err = provider.Embed(ctx, input, embeddingAuthorization(profile.Descriptor))
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, RequestMetrics{Requests: 1, Retries: 1}, withoutLatency(MetricsFromError(err)))
+	})
+
+	t.Run("response read", func(t *testing.T) {
+		started := make(chan struct{})
+		endpoint, egress, resolver := mistralFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusOK)
+			flusher, ok := writer.(http.Flusher)
+			if !assert.True(t, ok) {
+				return
+			}
+			flusher.Flush()
+			close(started)
+			<-request.Context().Done()
+		}))
+		profile := testEmbeddingProfile(t)
+		profile.Endpoint, profile.EgressPolicy = endpoint, egress
+		recomputeMistralEmbeddingProfile(t, &profile)
+		provider, err := newMistralEmbeddingTestProvider(t, profile, embeddingSecretMap{"credential:mistral-embed": "secret"}, resolver)
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan error, 1)
+		go func() {
+			_, embedErr := provider.Embed(ctx, input, embeddingAuthorization(profile.Descriptor))
+			done <- embedErr
+		}()
+		<-started
+		cancel()
+		err = <-done
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, RequestMetrics{Requests: 1}, withoutLatency(MetricsFromError(err)))
+	})
+}
+
+func withoutLatency(metrics RequestMetrics) RequestMetrics { metrics.Latency = 0; return metrics }
+
+func recomputeMistralEmbeddingProfile(t *testing.T, profile *EmbeddingProfile) {
+	t.Helper()
+	profile.Descriptor.PolicyFingerprint = strings.Repeat("0", 64)
+	profile.Descriptor.Fingerprint = ""
+	profile.Descriptor, _ = document.NewEmbeddingDescriptor(profile.Descriptor)
+	fingerprint, err := EmbeddingPolicyFingerprint(*profile)
+	require.NoError(t, err)
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	profile.Descriptor.Fingerprint = ""
+	profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+	require.NoError(t, err)
+}
+
+func mistralUnitEmbedding(hot int) []float32 {
+	vector := make([]float32, 1024)
+	vector[hot] = 1
+	return vector
+}
+
+func testEmbeddingProfile(t *testing.T) EmbeddingProfile {
+	t.Helper()
+	modelInput := testMistralModelInput(t, "document envelope: {{content}}", "query envelope: {{content}}")
+	profile := EmbeddingProfile{Endpoint: embeddingOrigin, EgressPolicy: productionMistralEgress(), ModelInput: modelInput, SecretBinding: "credential:mistral-embed", MaxBatchItems: 8, MaxInputBytes: 4096, MaxRequestBytes: 8192, MaxResponseBytes: 1 << 20, Descriptor: document.EmbeddingDescriptor{ID: EmbeddingProviderID, ContractVersion: document.EmbeddingProviderContractVersion, PolicyFingerprint: strings.Repeat("0", 64), TrustBoundary: document.EmbeddingTrustHostedProvider, Model: EmbeddingModel, ModelRevision: EmbeddingHostedAliasRevision, Dimension: 1024, Metric: document.VectorMetricCosine, Normalization: document.VectorNormalizationUnitLength, ScalarEncoding: EmbeddingScalarFloat32, DocumentFormatter: EmbeddingDocumentFormatterV1, QueryFormatter: EmbeddingQueryFormatterV1, InputKinds: []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}, CompatibilityID: modelInput.CompatibilityID, ModelInput: modelInput, SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeText}}}
+	recomputeMistralEmbeddingProfile(t, &profile)
+	return profile
+}
+
+func productionMistralEgress() providerhttp.EgressPolicy {
+	return providerhttp.EgressPolicy{Scheme: "https", Host: "api.mistral.ai", Port: 443, AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0"), netip.MustParsePrefix("::/0")}, ProxyMode: providerhttp.ProxyDisabled}
+}
+
+func testMistralModelInput(t *testing.T, documentTemplate, queryTemplate string) document.ModelInputContract {
+	t.Helper()
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{Profile: document.ModelInputProfileCustom, CompatibilityID: "mistral/test-space/v1", Document: document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: documentTemplate}, Query: document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: queryTemplate}})
+	require.NoError(t, err)
+	return contract
+}
+
+func embeddingAuthorization(descriptor document.EmbeddingDescriptor) document.EmbeddingAuthorization {
+	return document.EmbeddingAuthorization{ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint, PolicyFingerprint: descriptor.PolicyFingerprint, MaxBatchItems: 8, MaxInputBytes: 4096, MaxResponseBytes: 1 << 20}
+}
+
+func mistralEmbeddingBody(t *testing.T, indices []int) []byte {
+	t.Helper()
+	items := make([]map[string]any, len(indices))
+	for position, index := range indices {
+		items[position] = map[string]any{"object": "embedding", "embedding": mistralUnitEmbedding(index + 1), "index": index}
+	}
+	body, err := json.Marshal(map[string]any{"id": "synthetic-response", "object": "list", "data": items, "model": EmbeddingModel, "usage": map[string]any{"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2, "prompt_audio_seconds": nil}})
+	require.NoError(t, err)
+	return body
+}

--- a/document/voyage/client.go
+++ b/document/voyage/client.go
@@ -16,6 +16,7 @@ import (
 
 	"go.kenn.io/docbank/document/internal/manifestjson"
 	"go.kenn.io/docbank/document/media"
+	"go.kenn.io/docbank/document/providerhttp"
 )
 
 const (
@@ -112,7 +113,7 @@ func NewClient(policy Policy, config ClientConfig) (*Client, error) {
 		clone := *config.HTTPClient
 		httpClient = &clone
 	}
-	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	httpClient.CheckRedirect = providerhttp.RefuseRedirects
 	return &Client{
 		policy: policy, apiKey: config.APIKey, timeout: config.Timeout, maxRetries: config.MaxRetries,
 		retryBaseDelay: config.RetryBaseDelay, http: httpClient, now: time.Now,

--- a/document/voyage/embedding.go
+++ b/document/voyage/embedding.go
@@ -1,0 +1,778 @@
+package voyage
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	json "encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/manifestjson"
+	"go.kenn.io/docbank/document/internal/providerutil"
+	"go.kenn.io/docbank/document/media"
+	"go.kenn.io/docbank/document/providerhttp"
+	"go.kenn.io/docbank/internal/canonical"
+)
+
+const (
+	EmbeddingProviderID          = "voyage.embeddings-v1"
+	EmbeddingDocumentFormatterV1 = "voyage/document/v1"
+	EmbeddingQueryFormatterV1    = "voyage/query/v1"
+	EmbeddingScalarFloat32       = "float32"
+	TextModel                    = "voyage-4"
+	ContextualModel              = "voyage-context-4"
+	HostedAliasRevision          = "mutable-alias-export-only"
+
+	textEmbeddingsPath       = "/embeddings"
+	contextualEmbeddingsPath = "/contextualizedembeddings"
+	embeddingAdapterContract = "docbank-voyage-embeddings/v1"
+
+	defaultEmbeddingMaxBatchItems    = 128
+	defaultEmbeddingMaxInputBytes    = int64(1 << 20)
+	defaultEmbeddingMaxRequestBytes  = int64(2 << 20)
+	defaultEmbeddingMaxResponseBytes = int64(32 << 20)
+
+	maxEmbeddingBatchItems = 1000
+	// Match the core embedding limits and the OpenAI adapter's byte ceilings.
+	maxEmbeddingInputBytes    = int64(1 << 30)
+	maxEmbeddingRequestBytes  = int64(1 << 30)
+	maxEmbeddingResponseBytes = int64(1 << 30)
+	maxEmbeddingSecretBytes   = 64 << 10
+	unitLengthTolerance       = 1e-4
+)
+
+type EmbeddingMode string
+
+const (
+	EmbeddingModeText       EmbeddingMode = "text"
+	EmbeddingModeContextual EmbeddingMode = "contextual"
+	EmbeddingModeDirectFile EmbeddingMode = "direct_file"
+)
+
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, name string) (string, error)
+}
+
+type EmbeddingProfile struct {
+	Mode               EmbeddingMode
+	Endpoint           string
+	EgressPolicy       providerhttp.EgressPolicy
+	Descriptor         document.EmbeddingDescriptor
+	ModelInput         document.ModelInputContract
+	SecretBinding      string
+	ChunkerVersion     string
+	RequestTimeout     time.Duration
+	MaxRetries         int
+	RetryBaseDelay     time.Duration
+	MaxBatchItems      int
+	MaxInputBytes      int64
+	MaxRequestBytes    int64
+	MaxResponseBytes   int64
+	Policy             Policy
+	CapabilityManifest CapabilityManifest
+}
+
+type embeddingPolicyIdentity struct {
+	AdapterContract   string                       `json:"adapter_contract"`
+	Endpoint          string                       `json:"endpoint"`
+	Route             string                       `json:"route"`
+	Mode              EmbeddingMode                `json:"mode"`
+	Descriptor        document.EmbeddingDescriptor `json:"descriptor"`
+	ModelInput        document.ModelInputContract  `json:"model_input"`
+	CredentialBinding string                       `json:"credential_binding"`
+	Egress            embeddingEgressIdentity      `json:"egress"`
+	ChunkerVersion    string                       `json:"chunker_version,omitempty"`
+	RequestTimeout    int64                        `json:"request_timeout_nanos"`
+	MaxRetries        int                          `json:"max_retries"`
+	RetryBaseDelay    int64                        `json:"retry_base_delay_nanos"`
+	MaxBatchItems     int                          `json:"max_batch_items"`
+	MaxInputBytes     int64                        `json:"max_input_bytes"`
+	MaxRequestBytes   int64                        `json:"max_request_bytes"`
+	MaxResponseBytes  int64                        `json:"max_response_bytes"`
+	CapabilityPolicy  string                       `json:"capability_policy,omitempty"`
+}
+
+type EmbeddingClient struct {
+	profile    EmbeddingProfile
+	descriptor document.EmbeddingDescriptor
+	secrets    SecretResolver
+	http       *http.Client
+	now        func() time.Time
+}
+
+var _ document.EmbeddingProvider = (*EmbeddingClient)(nil)
+
+type embeddingWireRequest struct {
+	Input           []string   `json:"input,omitempty"`
+	Inputs          [][]string `json:"inputs,omitempty"`
+	Model           string     `json:"model"`
+	InputType       string     `json:"input_type"`
+	Truncation      bool       `json:"truncation"`
+	OutputDimension int        `json:"output_dimension"`
+	OutputDType     string     `json:"output_dtype"`
+}
+
+type contextualWireRequest struct {
+	Inputs          [][]string `json:"inputs"`
+	Model           string     `json:"model"`
+	InputType       string     `json:"input_type"`
+	OutputDimension int        `json:"output_dimension"`
+	OutputDType     string     `json:"output_dtype"`
+}
+
+type embeddingWireItem struct {
+	Object    string    `json:"object"`
+	Embedding []float32 `json:"embedding"`
+	Index     *int      `json:"index"`
+}
+
+type embeddingWireResponse struct {
+	Object string              `json:"object"`
+	Data   []embeddingWireItem `json:"data"`
+	Model  string              `json:"model"`
+	Usage  *struct {
+		TotalTokens int64 `json:"total_tokens"`
+	} `json:"usage,omitempty"`
+}
+
+type contextualWireGroup struct {
+	Data  []contextualWireItem `json:"data"`
+	Index *int                 `json:"index"`
+}
+
+type contextualWireItem struct {
+	Embedding []float32 `json:"embedding"`
+	Index     *int      `json:"index"`
+	Text      string    `json:"text"`
+}
+
+type contextualWireResponse struct {
+	Data           []contextualWireGroup `json:"data"`
+	Model          string                `json:"model"`
+	ChunkerVersion string                `json:"chunker_version"`
+	Usage          *struct {
+		TotalTokens int64 `json:"total_tokens"`
+	} `json:"usage,omitempty"`
+}
+
+type embeddingEgressIdentity struct {
+	Scheme              string   `json:"scheme"`
+	Host                string   `json:"host"`
+	Port                uint16   `json:"port"`
+	AllowedCIDRs        []string `json:"allowed_cidrs"`
+	ProxyMode           string   `json:"proxy_mode"`
+	ConnectTimeout      int64    `json:"connect_timeout_nanos"`
+	KeepAlive           int64    `json:"keep_alive_nanos"`
+	TLSHandshakeTimeout int64    `json:"tls_handshake_timeout_nanos"`
+	SPKISHA256          []string `json:"spki_sha256,omitempty"`
+}
+
+func EmbeddingPolicyFingerprint(profile EmbeddingProfile) (string, error) {
+	normalized, descriptorIdentity, route, err := normalizeEmbeddingProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := canonical.Marshal(embeddingPolicyIdentity{
+		AdapterContract: embeddingAdapterContract, Endpoint: normalized.Endpoint, Route: route,
+		Mode: normalized.Mode, Descriptor: descriptorIdentity, ModelInput: normalized.ModelInput,
+		CredentialBinding: normalized.SecretBinding, Egress: embeddingEgressPolicyIdentity(normalized.EgressPolicy), ChunkerVersion: normalized.ChunkerVersion,
+		RequestTimeout: int64(normalized.RequestTimeout), MaxRetries: normalized.MaxRetries,
+		RetryBaseDelay: int64(normalized.RetryBaseDelay), MaxBatchItems: normalized.MaxBatchItems,
+		MaxInputBytes: normalized.MaxInputBytes, MaxRequestBytes: normalized.MaxRequestBytes,
+		MaxResponseBytes: normalized.MaxResponseBytes,
+		CapabilityPolicy: directCapabilityFingerprint(normalized),
+	})
+	if err != nil {
+		return "", fmt.Errorf("voyage embedding: encode policy identity: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func NewEmbeddingProvider(profile EmbeddingProfile, secrets SecretResolver, resolver providerhttp.Resolver) (*EmbeddingClient, error) {
+	normalized, _, _, err := normalizeEmbeddingProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		if err == nil {
+			err = errors.New("descriptor is not canonical")
+		}
+		return nil, fmt.Errorf("voyage embedding: invalid descriptor: %w", err)
+	}
+	fingerprint, err := EmbeddingPolicyFingerprint(profile)
+	if err != nil {
+		return nil, err
+	}
+	if descriptor.PolicyFingerprint != fingerprint {
+		return nil, errors.New("voyage embedding: descriptor policy fingerprint does not match profile")
+	}
+	if descriptor.SupportsTextQuery {
+		return nil, errors.New("voyage embedding: hosted mutable alias is export-only")
+	}
+	if normalized.SecretBinding == "" || providerutil.IsNil(secrets) {
+		return nil, errors.New("voyage embedding: named secret binding and resolver are required")
+	}
+	transport, err := providerhttp.NewTransport(normalized.EgressPolicy, resolver)
+	if err != nil {
+		return nil, fmt.Errorf("voyage embedding: invalid sealed egress policy: %w", err)
+	}
+	normalized.CapabilityManifest.Results = slices.Clone(normalized.CapabilityManifest.Results)
+	for index := range normalized.CapabilityManifest.Results {
+		if tokens := normalized.CapabilityManifest.Results[index].TotalTokens; tokens != nil {
+			normalized.CapabilityManifest.Results[index].TotalTokens = new(*tokens)
+		}
+	}
+	normalized.Descriptor = cloneEmbeddingDescriptor(descriptor)
+	return &EmbeddingClient{profile: normalized, descriptor: cloneEmbeddingDescriptor(descriptor), secrets: secrets, http: &http.Client{Transport: transport, CheckRedirect: providerhttp.RefuseRedirects}, now: time.Now}, nil
+}
+
+func (client *EmbeddingClient) Descriptor() document.EmbeddingDescriptor {
+	if client == nil {
+		return document.EmbeddingDescriptor{}
+	}
+	return cloneEmbeddingDescriptor(client.descriptor)
+}
+
+// Embed accepts one document's ordered chunks per contextual invocation.
+// Voyage embeds each chunk using the other chunks in that invocation as context.
+func (client *EmbeddingClient) Embed(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	if client == nil {
+		return document.EmbeddingResult{}, errors.New("voyage embedding: client is required")
+	}
+	if ctx == nil {
+		return document.EmbeddingResult{}, errors.New("voyage embedding: context is required")
+	}
+	if err := document.ValidateEmbeddingProviderRequest(client, inputs, authorization); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if authorization.MaxBatchItems > client.profile.MaxBatchItems || authorization.MaxInputBytes > client.profile.MaxInputBytes || authorization.MaxResponseBytes > client.profile.MaxResponseBytes {
+		return document.EmbeddingResult{}, errors.New("voyage embedding: authorization exceeds profile capacity")
+	}
+	if client.profile.Mode == EmbeddingModeDirectFile {
+		return client.embedDirectFiles(ctx, inputs, authorization)
+	}
+	result := document.EmbeddingResult{Vectors: make([]document.EmbeddingVector, len(inputs))}
+	for _, role := range []document.EmbeddingRole{document.EmbeddingRoleDocument, document.EmbeddingRoleQuery} {
+		positions := make([]int, 0, len(inputs))
+		rendered := make([]string, 0, len(inputs))
+		for index, input := range inputs {
+			if input.Role != role {
+				continue
+			}
+			positions = append(positions, index)
+			if role == document.EmbeddingRoleDocument {
+				rendered = append(rendered, client.profile.ModelInput.EncodeDocument(input.Text))
+			} else {
+				rendered = append(rendered, client.profile.ModelInput.EncodeQuery(input.Text))
+			}
+		}
+		if len(positions) == 0 {
+			continue
+		}
+		vectors, err := client.embedTextRole(ctx, rendered, string(role))
+		if err != nil {
+			return document.EmbeddingResult{}, err
+		}
+		for local, global := range positions {
+			result.Vectors[global] = document.EmbeddingVector{Key: inputs[global].Key, Values: vectors[local]}
+		}
+	}
+	if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	return result, nil
+}
+
+func (client *EmbeddingClient) embedDirectFiles(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	secretCtx, cancelSecret := context.WithTimeout(ctx, client.profile.RequestTimeout)
+	secret, err := client.secrets.ResolveSecret(secretCtx, client.profile.SecretBinding)
+	secretContextErr := secretCtx.Err()
+	cancelSecret()
+	if err != nil || !validEmbeddingSecret(secret) {
+		if secretContextErr != nil {
+			return document.EmbeddingResult{}, fmt.Errorf("voyage embedding: credential resolution canceled: %w", secretContextErr)
+		}
+		return document.EmbeddingResult{}, errors.New("voyage embedding: credential is unavailable")
+	}
+	values := client.profile.Policy.Values()
+	policy, err := NewPolicy(PolicyConfig{
+		Model: values.Model, Dimension: values.Dimension, Media: values.Media,
+		MaxBatchItems:    min(values.MaxBatchItems, client.profile.MaxBatchItems),
+		MaxRequestBytes:  min(values.MaxRequestBytes, client.profile.MaxRequestBytes),
+		MaxResponseBytes: min(values.MaxResponseBytes, client.profile.MaxResponseBytes),
+	})
+	if err != nil {
+		return document.EmbeddingResult{}, errors.New("voyage embedding: direct-file bounds are invalid")
+	}
+	legacy, err := NewClient(policy, ClientConfig{
+		APIKey: secret, Timeout: client.profile.RequestTimeout, MaxRetries: client.profile.MaxRetries,
+		RetryBaseDelay: client.profile.RetryBaseDelay, HTTPClient: client.http,
+	})
+	if err != nil {
+		return document.EmbeddingResult{}, errors.New("voyage embedding: direct-file client configuration failed")
+	}
+	authorities, err := policy.AuthorizeAll(client.profile.CapabilityManifest)
+	if err != nil {
+		return document.EmbeddingResult{}, errors.New("voyage embedding: direct-file capability authority is invalid")
+	}
+	direct := make([]Input, len(inputs))
+	for index, input := range inputs {
+		metadata := input.Source.Metadata()
+		stopInterrupt := context.AfterFunc(ctx, func() { _ = document.InterruptAuthorizedUpload(input.Source) })
+		data, readErr := providerutil.ReadAuthorizedUpload(ctx, input.Source, metadata, "voyage embedding")
+		stopInterrupt()
+		closeErr := input.Source.Close()
+		if contextErr := ctx.Err(); contextErr != nil {
+			clear(data)
+			return document.EmbeddingResult{}, contextErr
+		}
+		if readErr != nil || closeErr != nil || int64(len(data)) != metadata.ByteLength {
+			clear(data)
+			return document.EmbeddingResult{}, errors.New("voyage embedding: direct-file source could not be read exactly")
+		}
+		detected, detectErr := media.DetectBytes(data, metadata.MediaType)
+		if detectErr != nil || string(detected.Kind) != metadata.MediaFamily || detected.MediaType != metadata.MediaType {
+			clear(data)
+			return document.EmbeddingResult{}, errors.New("voyage embedding: direct-file media identity could not be verified")
+		}
+		direct[index] = Input{Parts: []Part{{Media: &Media{Metadata: detected, Bytes: data}}}}
+	}
+	defer func() {
+		for index := range direct {
+			clear(direct[index].Parts[0].Media.Bytes)
+		}
+	}()
+	providerResult, err := legacy.EmbedDocuments(ctx, direct, authorities)
+	if err != nil {
+		return document.EmbeddingResult{}, fmt.Errorf("voyage embedding: direct-file provider request failed: %w", err)
+	}
+	result := document.EmbeddingResult{Vectors: make([]document.EmbeddingVector, len(inputs))}
+	for index, vector := range providerResult.Vectors {
+		result.Vectors[index] = document.EmbeddingVector{Key: inputs[index].Key, Values: slices.Clone(vector)}
+	}
+	if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	return result, nil
+}
+
+func (client *EmbeddingClient) embedTextRole(ctx context.Context, rendered []string, inputType string) ([][]float32, error) {
+	route := textEmbeddingsPath
+	var payload []byte
+	var err error
+	if client.profile.Mode == EmbeddingModeContextual {
+		route = contextualEmbeddingsPath
+		payload, err = json.Marshal(contextualWireRequest{Inputs: [][]string{rendered}, Model: client.descriptor.Model, InputType: inputType, OutputDimension: client.descriptor.Dimension, OutputDType: "float"})
+	} else {
+		payload, err = json.Marshal(embeddingWireRequest{Input: rendered, Model: client.descriptor.Model, InputType: inputType, Truncation: false, OutputDimension: client.descriptor.Dimension, OutputDType: "float"})
+	}
+	if err != nil {
+		return nil, errors.New("voyage embedding: could not encode request")
+	}
+	if int64(len(payload)) > client.profile.MaxRequestBytes {
+		return nil, &ProviderError{Kind: ErrBatchTooLarge}
+	}
+	started := time.Now()
+	metrics := RequestMetrics{}
+	malformedRetried := false
+	for attempt := 1; ; attempt++ {
+		vectors, retryAfter, retry, requested, err := client.embeddingAttempt(ctx, route, payload, rendered)
+		if requested {
+			metrics.Requests++
+		}
+		if err == nil {
+			return vectors, nil
+		}
+		if errors.Is(err, ErrMalformedResponse) && !malformedRetried {
+			retry, malformedRetried = true, true
+		}
+		if !retry || attempt >= client.profile.MaxRetries {
+			if providerErr, ok := errors.AsType[*ProviderError](err); ok {
+				providerErr.Metrics = metrics
+				providerErr.Metrics.Latency = time.Since(started)
+			}
+			return nil, err
+		}
+		metrics.Retries++
+		delay := retryBackoffDelay(client.profile.RetryBaseDelay, attempt)
+		if retryAfter >= 0 {
+			delay = retryAfter
+		}
+		if waitErr := sleepContext(ctx, delay); waitErr != nil {
+			return nil, &ProviderError{Kind: waitErr, cause: waitErr, Metrics: RequestMetrics{Requests: metrics.Requests, Retries: metrics.Retries, Latency: time.Since(started)}}
+		}
+	}
+}
+
+func (client *EmbeddingClient) embeddingAttempt(ctx context.Context, route string, payload []byte, rendered []string) ([][]float32, time.Duration, bool, bool, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
+	defer cancel()
+	secret, err := client.secrets.ResolveSecret(attemptCtx, client.profile.SecretBinding)
+	if err != nil || !validEmbeddingSecret(secret) || attemptCtx.Err() != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, -1, false, false, &ProviderError{Kind: contextErr, cause: contextErr}
+		}
+		if contextErr := attemptCtx.Err(); contextErr != nil {
+			return nil, -1, true, false, &ProviderError{Kind: ErrTransientResponse, cause: contextErr}
+		}
+		return nil, -1, false, false, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	request, err := http.NewRequestWithContext(attemptCtx, http.MethodPost, client.profile.Endpoint+route, bytes.NewReader(payload))
+	if err != nil {
+		return nil, -1, false, false, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+secret)
+	response, err := client.http.Do(request)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, -1, false, true, &ProviderError{Kind: contextErr, cause: contextErr}
+		}
+		if contextErr := attemptCtx.Err(); contextErr != nil {
+			return nil, -1, true, true, &ProviderError{Kind: ErrTransientResponse, cause: contextErr}
+		}
+		return nil, -1, true, true, &ProviderError{Kind: ErrTransientResponse, cause: err}
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode >= 300 && response.StatusCode < 400 {
+		return nil, -1, false, true, &ProviderError{Kind: ErrPermanentResponse, StatusCode: response.StatusCode}
+	}
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
+		return nil, -1, false, true, &ProviderError{Kind: ErrUnauthorized, StatusCode: response.StatusCode}
+	}
+	if response.StatusCode == http.StatusRequestEntityTooLarge {
+		return nil, -1, false, true, &ProviderError{Kind: ErrBatchTooLarge, StatusCode: response.StatusCode}
+	}
+	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+		delay, set := parseRetryAfter(response.Header.Get("Retry-After"), client.now())
+		if !set {
+			delay = -1
+		}
+		providerErr := &ProviderError{Kind: ErrTransientResponse, StatusCode: response.StatusCode, RetryAfter: delay, RetrySet: delay >= 0}
+		return nil, delay, true, true, providerErr
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, -1, false, true, &ProviderError{Kind: ErrPermanentResponse, StatusCode: response.StatusCode}
+	}
+	if err := validateEmbeddingContentType(response.Header.Get("Content-Type")); err != nil {
+		return nil, -1, false, true, &ProviderError{Kind: ErrMalformedResponse}
+	}
+	body, err := readEmbeddingBody(attemptCtx, response.Body, client.profile.MaxResponseBytes)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, -1, false, true, &ProviderError{Kind: contextErr, cause: contextErr}
+		}
+		if contextErr := attemptCtx.Err(); contextErr != nil {
+			return nil, -1, true, true, &ProviderError{Kind: ErrTransientResponse, cause: contextErr}
+		}
+		return nil, -1, false, true, &ProviderError{Kind: ErrMalformedResponse, cause: err}
+	}
+	if err := manifestjson.RejectDuplicateKeys(body, "voyage embedding response"); err != nil {
+		return nil, -1, false, true, &ProviderError{Kind: ErrMalformedResponse}
+	}
+	if client.profile.Mode == EmbeddingModeContextual {
+		vectors, decodeErr := client.decodeContextual(body, rendered)
+		return vectors, -1, false, true, decodeErr
+	}
+	vectors, decodeErr := client.decodeText(body, len(rendered))
+	return vectors, -1, false, true, decodeErr
+}
+
+func (client *EmbeddingClient) decodeText(body []byte, want int) ([][]float32, error) {
+	var response embeddingWireResponse
+	if err := json.Unmarshal(body, &response, json.RejectUnknownMembers(true)); err != nil {
+		return nil, &ProviderError{Kind: ErrMalformedResponse}
+	}
+	vectors, err := client.orderItems(response.Object, response.Model, response.Data, want)
+	if err != nil {
+		err = &ProviderError{Kind: ErrMalformedResponse, cause: err}
+	}
+	return vectors, err
+}
+
+func (client *EmbeddingClient) decodeContextual(body []byte, rendered []string) ([][]float32, error) {
+	var response contextualWireResponse
+	if err := json.Unmarshal(body, &response, json.RejectUnknownMembers(true)); err != nil || response.Model != client.descriptor.Model || response.ChunkerVersion != client.profile.ChunkerVersion {
+		return nil, &ProviderError{Kind: ErrMalformedResponse}
+	}
+	if len(response.Data) != 1 || response.Data[0].Index == nil || *response.Data[0].Index != 0 || len(response.Data[0].Data) != len(rendered) {
+		return nil, &ProviderError{Kind: ErrMalformedResponse}
+	}
+	vectors := make([][]float32, len(rendered))
+	seen := make([]bool, len(rendered))
+	for _, item := range response.Data[0].Data {
+		if item.Index == nil || *item.Index < 0 || *item.Index >= len(rendered) || seen[*item.Index] || item.Text != rendered[*item.Index] || client.validateEmbeddingVector(item.Embedding) != nil {
+			return nil, &ProviderError{Kind: ErrMalformedResponse}
+		}
+		seen[*item.Index] = true
+		vectors[*item.Index] = slices.Clone(item.Embedding)
+	}
+	if slices.Contains(seen, false) {
+		return nil, &ProviderError{Kind: ErrMalformedResponse}
+	}
+	return vectors, nil
+}
+
+func (client *EmbeddingClient) orderItems(object, model string, items []embeddingWireItem, want int) ([][]float32, error) {
+	if object != "list" || model != client.descriptor.Model {
+		return nil, errors.New("voyage embedding: provider model or response contract drifted")
+	}
+	if len(items) != want {
+		return nil, errors.New("voyage embedding: provider response has a missing vector")
+	}
+	vectors := make([][]float32, want)
+	seen := make([]bool, want)
+	for _, item := range items {
+		if item.Object != "embedding" || item.Index == nil || *item.Index < 0 || *item.Index >= want || seen[*item.Index] {
+			return nil, errors.New("voyage embedding: provider response index contract drifted")
+		}
+		if err := client.validateEmbeddingVector(item.Embedding); err != nil {
+			return nil, err
+		}
+		seen[*item.Index] = true
+		vectors[*item.Index] = slices.Clone(item.Embedding)
+	}
+	if slices.Contains(seen, false) {
+		return nil, errors.New("voyage embedding: provider response has a missing vector index")
+	}
+	return vectors, nil
+}
+
+func (client *EmbeddingClient) validateEmbeddingVector(vector []float32) error {
+	if len(vector) != client.descriptor.Dimension {
+		return errors.New("voyage embedding: provider vector dimension does not match profile")
+	}
+	var norm float64
+	for _, value := range vector {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return errors.New("voyage embedding: provider vector contains a non-finite value")
+		}
+		norm += float64(value) * float64(value)
+	}
+	if norm == 0 {
+		return errors.New("voyage embedding: provider returned a zero vector")
+	}
+	if client.descriptor.Normalization == document.VectorNormalizationUnitLength && math.Abs(norm-1) > unitLengthTolerance {
+		return errors.New("voyage embedding: provider vector normalization does not match profile")
+	}
+	return nil
+}
+
+func normalizeEmbeddingProfile(profile EmbeddingProfile) (EmbeddingProfile, document.EmbeddingDescriptor, string, error) {
+	if profile.Endpoint == "" {
+		profile.Endpoint = DefaultEndpoint
+	}
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = DefaultTimeout
+	}
+	if profile.MaxRetries == 0 {
+		profile.MaxRetries = DefaultMaxRetries
+	}
+	if profile.RetryBaseDelay == 0 {
+		profile.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if profile.MaxBatchItems == 0 {
+		profile.MaxBatchItems = defaultEmbeddingMaxBatchItems
+	}
+	if profile.MaxInputBytes == 0 {
+		profile.MaxInputBytes = defaultEmbeddingMaxInputBytes
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = defaultEmbeddingMaxRequestBytes
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = defaultEmbeddingMaxResponseBytes
+	}
+	if profile.RequestTimeout <= 0 || profile.RequestTimeout > MaxTimeout || profile.MaxRetries < 1 || profile.MaxRetries > MaxRetries || profile.RetryBaseDelay < 0 || profile.RetryBaseDelay > maxRetryAfter || profile.MaxBatchItems < 1 || profile.MaxBatchItems > maxEmbeddingBatchItems ||
+		profile.MaxInputBytes < 1 || profile.MaxInputBytes > maxEmbeddingInputBytes ||
+		profile.MaxRequestBytes < 1 || profile.MaxRequestBytes > maxEmbeddingRequestBytes ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maxEmbeddingResponseBytes {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: execution bounds are invalid")
+	}
+	if !validEmbeddingToken(profile.SecretBinding) {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: binding is invalid")
+	}
+	if err := normalizeAndValidateEmbeddingEgress(&profile); err != nil {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", err
+	}
+	descriptorIdentity := profile.Descriptor
+	descriptorIdentity.PolicyFingerprint = strings.Repeat("0", sha256.Size*2)
+	descriptorIdentity.Fingerprint = ""
+	var err error
+	descriptorIdentity, err = document.NewEmbeddingDescriptor(descriptorIdentity)
+	if err != nil {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", fmt.Errorf("voyage embedding: invalid descriptor identity: %w", err)
+	}
+	descriptorIdentity.PolicyFingerprint = ""
+	descriptorIdentity.Fingerprint = ""
+	if descriptorIdentity.ID != EmbeddingProviderID || descriptorIdentity.TrustBoundary != document.EmbeddingTrustHostedProvider || descriptorIdentity.ScalarEncoding != EmbeddingScalarFloat32 || descriptorIdentity.DocumentFormatter != EmbeddingDocumentFormatterV1 || descriptorIdentity.QueryFormatter != EmbeddingQueryFormatterV1 || descriptorIdentity.ModelInput != profile.ModelInput || descriptorIdentity.CompatibilityID != profile.ModelInput.CompatibilityID {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: descriptor does not match adapter contract")
+	}
+	if profile.Mode != EmbeddingModeDirectFile && descriptorIdentity.SupportsTextQuery {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: hosted mutable alias is export-only")
+	}
+	if profile.Mode != EmbeddingModeDirectFile && (!slices.Equal(descriptorIdentity.SupportedRequestModes, []document.ModelInputMode{document.ModelInputModeDocument, document.ModelInputModeQuery}) || profile.ModelInput.Document.Mode != document.ModelInputModeDocument || profile.ModelInput.Query.Mode != document.ModelInputModeQuery) {
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: descriptor native role modes do not match document/query behavior")
+	}
+	route := textEmbeddingsPath
+	switch profile.Mode {
+	case EmbeddingModeText:
+		if !slices.Contains([]string{"voyage-4-large", TextModel, "voyage-4-lite"}, descriptorIdentity.Model) || descriptorIdentity.ModelRevision != HostedAliasRevision || descriptorIdentity.SupportsTextQuery || !slices.Contains([]int{2048, 1024, 512, 256}, descriptorIdentity.Dimension) || !slices.Equal(descriptorIdentity.InputKinds, []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}) || !slices.Equal(descriptorIdentity.SupportedRequestModes, []document.ModelInputMode{document.ModelInputModeDocument, document.ModelInputModeQuery}) || profile.ModelInput.Document.Mode != document.ModelInputModeDocument || profile.ModelInput.Query.Mode != document.ModelInputModeQuery {
+			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: descriptor is not a pinned Voyage 4 text profile")
+		}
+	case EmbeddingModeContextual:
+		route = contextualEmbeddingsPath
+		if !validEmbeddingToken(profile.ChunkerVersion) || descriptorIdentity.Model != ContextualModel || descriptorIdentity.ModelRevision != HostedAliasRevision || descriptorIdentity.SupportsTextQuery || !slices.Contains([]int{2048, 1024, 512, 256}, descriptorIdentity.Dimension) || !slices.Equal(descriptorIdentity.InputKinds, []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}) || !slices.Equal(descriptorIdentity.SupportedRequestModes, []document.ModelInputMode{document.ModelInputModeDocument, document.ModelInputModeQuery}) || profile.ModelInput.Document.Mode != document.ModelInputModeDocument || profile.ModelInput.Query.Mode != document.ModelInputModeQuery {
+			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: descriptor is not a pinned contextual profile")
+		}
+	case EmbeddingModeDirectFile:
+		if profile.ModelInput.Document.Mode != document.ModelInputModeDocument || !slices.Equal(descriptorIdentity.SupportedRequestModes, []document.ModelInputMode{document.ModelInputModeDocument}) {
+			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: direct-file native role must be document")
+		}
+		route = embeddingsPath
+		if !profile.Policy.valid() {
+			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: direct-file policy is invalid")
+		}
+		if profile.Endpoint != profile.Policy.values.Endpoint {
+			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: direct-file endpoint differs from capability policy")
+		}
+		if err := profile.CapabilityManifest.ValidateComplete(); err != nil {
+			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", fmt.Errorf("voyage embedding: direct-file capability evidence: %w", err)
+		}
+		capabilityFingerprint, err := profile.Policy.Fingerprint(profile.CapabilityManifest)
+		if err != nil {
+			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", fmt.Errorf("voyage embedding: direct-file capability policy: %w", err)
+		}
+		expectedRevision := "capability-" + capabilityFingerprint[:32]
+		if descriptorIdentity.Model != profile.Policy.values.Model || descriptorIdentity.Dimension != profile.Policy.values.Dimension || descriptorIdentity.ModelRevision != expectedRevision || descriptorIdentity.SupportsTextQuery || !slices.Equal(descriptorIdentity.InputKinds, []document.EmbeddingInputKind{document.EmbeddingInputOriginalFile}) || !slices.Contains(descriptorIdentity.SupportedRequestModes, document.ModelInputModeDocument) {
+			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: direct-file descriptor is not the exact capability-attested export profile")
+		}
+	default:
+		return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: mode is invalid")
+	}
+	return profile, descriptorIdentity, route, nil
+}
+
+func normalizeAndValidateEmbeddingEgress(profile *EmbeddingProfile) error {
+	if profile.EgressPolicy.ConnectTimeout == 0 {
+		profile.EgressPolicy.ConnectTimeout = providerhttp.DefaultConnectTimeout
+	}
+	if profile.EgressPolicy.KeepAlive == 0 {
+		profile.EgressPolicy.KeepAlive = providerhttp.DefaultKeepAlive
+	}
+	if profile.EgressPolicy.TLSHandshakeTimeout == 0 {
+		profile.EgressPolicy.TLSHandshakeTimeout = providerhttp.DefaultTLSHandshakeTimeout
+	}
+	if profile.EgressPolicy.ProxyMode == "" {
+		profile.EgressPolicy.ProxyMode = providerhttp.ProxyDisabled
+	}
+	if profile.EgressPolicy.TLS.RootCAs != nil {
+		return errors.New("voyage embedding: custom egress roots cannot enter canonical identity")
+	}
+	parsed, err := url.Parse(profile.Endpoint)
+	if err != nil || parsed.Scheme != "https" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || strings.TrimSuffix(parsed.Path, "/") != "/v1" {
+		return errors.New("voyage embedding: endpoint must be an exact HTTPS /v1 provider root")
+	}
+	port := parsed.Port()
+	if port == "" {
+		port = "443"
+	}
+	if parsed.Scheme != profile.EgressPolicy.Scheme || !strings.EqualFold(parsed.Hostname(), profile.EgressPolicy.Host) || port != strconv.FormatUint(uint64(profile.EgressPolicy.Port), 10) {
+		return errors.New("voyage embedding: endpoint and egress authority differ")
+	}
+	profile.Endpoint = strings.TrimSuffix(profile.Endpoint, "/")
+	slices.SortFunc(profile.EgressPolicy.AllowedCIDRs, func(a, b netip.Prefix) int { return strings.Compare(a.Masked().String(), b.Masked().String()) })
+	slices.Sort(profile.EgressPolicy.TLS.SPKISHA256)
+	return nil
+}
+
+func embeddingEgressPolicyIdentity(policy providerhttp.EgressPolicy) embeddingEgressIdentity {
+	cidrs := make([]string, len(policy.AllowedCIDRs))
+	for index, prefix := range policy.AllowedCIDRs {
+		cidrs[index] = prefix.Masked().String()
+	}
+	return embeddingEgressIdentity{Scheme: policy.Scheme, Host: strings.ToLower(policy.Host), Port: policy.Port, AllowedCIDRs: cidrs, ProxyMode: string(policy.ProxyMode), ConnectTimeout: int64(policy.ConnectTimeout), KeepAlive: int64(policy.KeepAlive), TLSHandshakeTimeout: int64(policy.TLSHandshakeTimeout), SPKISHA256: slices.Clone(policy.TLS.SPKISHA256)}
+}
+
+func DirectFileModelRevision(policy Policy, manifest CapabilityManifest) (string, error) {
+	fingerprint, err := policy.Fingerprint(manifest)
+	if err != nil {
+		return "", err
+	}
+	return "capability-" + fingerprint[:32], nil
+}
+
+func directCapabilityFingerprint(profile EmbeddingProfile) string {
+	if profile.Mode != EmbeddingModeDirectFile {
+		return ""
+	}
+	fingerprint, _ := profile.Policy.Fingerprint(profile.CapabilityManifest)
+	return fingerprint
+}
+
+func readEmbeddingBody(ctx context.Context, reader io.Reader, maximum int64) ([]byte, error) {
+	// Validate before adding the sentinel byte, including for an overflowing bound.
+	if maximum < 1 || maximum > maxEmbeddingResponseBytes {
+		return nil, errors.New("voyage embedding: invalid response byte limit")
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, fmt.Errorf("voyage embedding: response read canceled: %w", contextErr)
+	}
+	if err != nil {
+		return nil, errors.New("voyage embedding: could not read provider response")
+	}
+	if int64(len(body)) > maximum {
+		return nil, errors.New("voyage embedding: provider response byte limit exceeded")
+	}
+	return body, nil
+}
+
+func validateEmbeddingContentType(value string) error {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || mediaType != "application/json" || (len(parameters) != 0 && (len(parameters) != 1 || !strings.EqualFold(parameters["charset"], "utf-8"))) {
+		return errors.New("voyage embedding: provider response content type is invalid")
+	}
+	return nil
+}
+
+func validEmbeddingSecret(secret string) bool {
+	if secret == "" || len(secret) > maxEmbeddingSecretBytes {
+		return false
+	}
+	for _, character := range secret {
+		if unicode.IsControl(character) || unicode.IsSpace(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validEmbeddingToken(value string) bool {
+	return value != "" && len(value) <= 128 && value == strings.TrimSpace(value) && utf8.ValidString(value) && strings.IndexFunc(value, unicode.IsControl) < 0
+}
+
+func cloneEmbeddingDescriptor(value document.EmbeddingDescriptor) document.EmbeddingDescriptor {
+	value.InputKinds = slices.Clone(value.InputKinds)
+	value.SupportedRequestModes = slices.Clone(value.SupportedRequestModes)
+	return value
+}

--- a/document/voyage/embedding.go
+++ b/document/voyage/embedding.go
@@ -316,9 +316,9 @@ func (client *EmbeddingClient) embedDirectFiles(ctx context.Context, inputs []do
 	values := client.profile.Policy.Values()
 	policy, err := NewPolicy(PolicyConfig{
 		Model: values.Model, Dimension: values.Dimension, Media: values.Media,
-		MaxBatchItems:    min(values.MaxBatchItems, client.profile.MaxBatchItems),
-		MaxRequestBytes:  min(values.MaxRequestBytes, client.profile.MaxRequestBytes),
-		MaxResponseBytes: min(values.MaxResponseBytes, client.profile.MaxResponseBytes),
+		MaxBatchItems:    client.profile.MaxBatchItems,
+		MaxRequestBytes:  client.profile.MaxRequestBytes,
+		MaxResponseBytes: client.profile.MaxResponseBytes,
 	})
 	if err != nil {
 		return document.EmbeddingResult{}, errors.New("voyage embedding: direct-file bounds are invalid")
@@ -675,6 +675,11 @@ func normalizeEmbeddingProfile(profile EmbeddingProfile) (EmbeddingProfile, docu
 		if !profile.Policy.valid() {
 			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: direct-file policy is invalid")
 		}
+		// Fingerprinting, authorization, and the delegated client must share
+		// the same effective limits, including when defaults exceed Policy.
+		profile.MaxBatchItems = min(profile.MaxBatchItems, profile.Policy.values.MaxBatchItems)
+		profile.MaxRequestBytes = min(profile.MaxRequestBytes, profile.Policy.values.MaxRequestBytes)
+		profile.MaxResponseBytes = min(profile.MaxResponseBytes, profile.Policy.values.MaxResponseBytes)
 		if profile.Endpoint != profile.Policy.values.Endpoint {
 			return EmbeddingProfile{}, document.EmbeddingDescriptor{}, "", errors.New("voyage embedding: direct-file endpoint differs from capability policy")
 		}

--- a/document/voyage/embedding.go
+++ b/document/voyage/embedding.go
@@ -333,6 +333,13 @@ func (client *EmbeddingClient) embedDirectFiles(ctx context.Context, inputs []do
 	if err != nil {
 		return document.EmbeddingResult{}, errors.New("voyage embedding: direct-file capability authority is invalid")
 	}
+	// Refuse oversized sources before buffering any upload. The core already
+	// checks the batch's input authorization; direct-file policy may be tighter.
+	for _, input := range inputs {
+		if input.Source.Metadata().ByteLength > min(policy.MediaPolicy().MaxBytes, policy.values.MaxRequestBytes) {
+			return document.EmbeddingResult{}, &ProviderError{Kind: ErrBatchTooLarge}
+		}
+	}
 	direct := make([]Input, len(inputs))
 	for index, input := range inputs {
 		metadata := input.Source.Metadata()
@@ -366,6 +373,9 @@ func (client *EmbeddingClient) embedDirectFiles(ctx context.Context, inputs []do
 	}
 	result := document.EmbeddingResult{Vectors: make([]document.EmbeddingVector, len(inputs))}
 	for index, vector := range providerResult.Vectors {
+		if err := client.validateEmbeddingVector(vector); err != nil {
+			return document.EmbeddingResult{}, &ProviderError{Kind: ErrMalformedResponse}
+		}
 		result.Vectors[index] = document.EmbeddingVector{Key: inputs[index].Key, Values: slices.Clone(vector)}
 	}
 	if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
@@ -499,7 +509,7 @@ func (client *EmbeddingClient) embeddingAttempt(ctx context.Context, route strin
 
 func (client *EmbeddingClient) decodeText(body []byte, want int) ([][]float32, error) {
 	var response embeddingWireResponse
-	if err := json.Unmarshal(body, &response, json.RejectUnknownMembers(true)); err != nil {
+	if err := json.Unmarshal(body, &response, json.RejectUnknownMembers(true), json.WithUnmarshalers(json.UnmarshalFunc(providerutil.UnmarshalEmbeddingFloat32))); err != nil {
 		return nil, &ProviderError{Kind: ErrMalformedResponse}
 	}
 	vectors, err := client.orderItems(response.Object, response.Model, response.Data, want)
@@ -511,7 +521,7 @@ func (client *EmbeddingClient) decodeText(body []byte, want int) ([][]float32, e
 
 func (client *EmbeddingClient) decodeContextual(body []byte, rendered []string) ([][]float32, error) {
 	var response contextualWireResponse
-	if err := json.Unmarshal(body, &response, json.RejectUnknownMembers(true)); err != nil || response.Model != client.descriptor.Model || response.ChunkerVersion != client.profile.ChunkerVersion {
+	if err := json.Unmarshal(body, &response, json.RejectUnknownMembers(true), json.WithUnmarshalers(json.UnmarshalFunc(providerutil.UnmarshalEmbeddingFloat32))); err != nil || response.Model != client.descriptor.Model || response.ChunkerVersion != client.profile.ChunkerVersion {
 		return nil, &ProviderError{Kind: ErrMalformedResponse}
 	}
 	if len(response.Data) != 1 || response.Data[0].Index == nil || *response.Data[0].Index != 0 || len(response.Data[0].Data) != len(rendered) {

--- a/document/voyage/embedding.go
+++ b/document/voyage/embedding.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	json "encoding/json/v2"
 	"errors"
@@ -333,12 +334,24 @@ func (client *EmbeddingClient) embedDirectFiles(ctx context.Context, inputs []do
 	if err != nil {
 		return document.EmbeddingResult{}, errors.New("voyage embedding: direct-file capability authority is invalid")
 	}
-	// Refuse oversized sources before buffering any upload. The core already
-	// checks the batch's input authorization; direct-file policy may be tighter.
+	// Match estimatedRequestBytes for one media part per input, before buffering
+	// any upload. Charge against the remaining budget to avoid sum overflow.
+	remaining := policy.values.MaxRequestBytes - requestOverheadBytes
+	if remaining < 0 {
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrBatchTooLarge}
+	}
 	for _, input := range inputs {
-		if input.Source.Metadata().ByteLength > min(policy.MediaPolicy().MaxBytes, policy.values.MaxRequestBytes) {
+		size := input.Source.Metadata().ByteLength
+		if size > policy.MediaPolicy().MaxBytes {
 			return document.EmbeddingResult{}, &ProviderError{Kind: ErrBatchTooLarge}
 		}
+		// The validated media ceiling is at most 20 MiB, so EncodedLen and
+		// the input/part overhead fit even on 32-bit platforms.
+		encodedBytes := int64(base64.StdEncoding.EncodedLen(int(size))) + 2*partOverheadBytes
+		if encodedBytes > remaining {
+			return document.EmbeddingResult{}, &ProviderError{Kind: ErrBatchTooLarge}
+		}
+		remaining -= encodedBytes
 	}
 	direct := make([]Input, len(inputs))
 	for index, input := range inputs {

--- a/document/voyage/embedding_export_test.go
+++ b/document/voyage/embedding_export_test.go
@@ -1,0 +1,21 @@
+package voyage
+
+import (
+	"crypto/x509"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TrustEmbeddingTestCertificate adds fixture trust to the production transport
+// after profile validation; DNS/CIDR and certificate verification still run.
+func TrustEmbeddingTestCertificate(t *testing.T, client *EmbeddingClient, certificate *x509.Certificate) {
+	t.Helper()
+	transport, ok := client.http.Transport.(*http.Transport)
+	require.True(t, ok)
+	roots := x509.NewCertPool()
+	roots.AddCert(certificate)
+	transport.TLSClientConfig.RootCAs = roots
+	t.Cleanup(client.http.CloseIdleConnections)
+}

--- a/document/voyage/embedding_export_test.go
+++ b/document/voyage/embedding_export_test.go
@@ -19,3 +19,9 @@ func TrustEmbeddingTestCertificate(t *testing.T, client *EmbeddingClient, certif
 	transport.TLSClientConfig.RootCAs = roots
 	t.Cleanup(client.http.CloseIdleConnections)
 }
+
+// SetEmbeddingTestTransport substitutes only the HTTP exchange for direct-file
+// tests; profile, upload, request, and response validation still run.
+func SetEmbeddingTestTransport(client *EmbeddingClient, transport http.RoundTripper) {
+	client.http.Transport = transport
+}

--- a/document/voyage/embedding_review_test.go
+++ b/document/voyage/embedding_review_test.go
@@ -85,6 +85,9 @@ func TestContextualEmbeddingStrictlyRejectsDocumentedShapeDrift(t *testing.T) {
 		name string
 		body []byte
 	}{
+		{"null element", []byte(strings.Replace(string(valid), `,0`, `,null`, 1))},
+		{"string element", []byte(strings.Replace(string(valid), `,0`, `,"0"`, 1))},
+		{"boolean element", []byte(strings.Replace(string(valid), `,0`, `,false`, 1))},
 		{"unknown", []byte(strings.Replace(string(valid), `"chunker_version":`, `"unknown":"PRIVATE_RAW_BODY","chunker_version":`, 1))},
 		{"duplicate", []byte(strings.Replace(string(valid), `"model":`, `"model":"duplicate","model":`, 1))},
 		{"model drift", []byte(strings.Replace(string(valid), voyage.ContextualModel, "voyage-context-drift", 1))},

--- a/document/voyage/embedding_review_test.go
+++ b/document/voyage/embedding_review_test.go
@@ -1,0 +1,415 @@
+package voyage_test
+
+import (
+	"context"
+	"crypto/x509"
+	json "encoding/json/v2"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+	"go.kenn.io/docbank/document/voyage"
+	"go.kenn.io/docbank/document/voyage/voyagetest"
+)
+
+type embeddingResolver struct {
+	address     netip.Addr
+	certificate *x509.Certificate
+}
+
+func (resolver embeddingResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return []netip.Addr{resolver.address}, nil
+}
+
+func voyageFixture(t *testing.T, handler http.Handler) (string, providerhttp.EgressPolicy, providerhttp.Resolver) {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	_, portText, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	port, err := strconv.ParseUint(portText, 10, 16)
+	require.NoError(t, err)
+	return server.URL + "/v1", providerhttp.EgressPolicy{
+		Scheme: "https", Host: parsed.Hostname(), Port: uint16(port),
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+		ProxyMode:    providerhttp.ProxyDisabled,
+	}, embeddingResolver{address: netip.MustParseAddr("127.0.0.1"), certificate: server.Certificate()}
+}
+
+func TestContextualEmbeddingUsesDocumentedWireShape(t *testing.T) {
+	var request map[string]any
+	endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, incoming *http.Request) {
+		assert.NoError(t, json.UnmarshalRead(incoming.Body, &request))
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write(contextualOfficialBody(t, []string{"document envelope: first", "document envelope: second"}, []int{1, 0}))
+	}))
+	profile := voyageTextProfile(t, voyage.EmbeddingModeContextual)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	profile = refingerprintVoyageProfile(t, profile)
+	provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "synthetic-secret"}, resolver)
+	require.NoError(t, err)
+	inputs := []document.EmbeddingInput{
+		{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "first"},
+		{Key: "second", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "second"},
+	}
+	result, err := provider.Embed(t.Context(), inputs, voyageAuthorization(profile.Descriptor))
+	require.NoError(t, err)
+	assert.NotContains(t, request, "truncation")
+	assert.Equal(t, []any{[]any{"document envelope: first", "document envelope: second"}}, request["inputs"])
+	assert.InDelta(t, float32(1), result.Vectors[0].Values[1], 0)
+	assert.InDelta(t, float32(1), result.Vectors[1].Values[2], 0)
+}
+
+func TestContextualEmbeddingStrictlyRejectsDocumentedShapeDrift(t *testing.T) {
+	texts := []string{"document envelope: first", "document envelope: second"}
+	valid := contextualOfficialBody(t, texts, []int{0, 1})
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{"unknown", []byte(strings.Replace(string(valid), `"chunker_version":`, `"unknown":"PRIVATE_RAW_BODY","chunker_version":`, 1))},
+		{"duplicate", []byte(strings.Replace(string(valid), `"model":`, `"model":"duplicate","model":`, 1))},
+		{"model drift", []byte(strings.Replace(string(valid), voyage.ContextualModel, "voyage-context-drift", 1))},
+		{"chunker drift", []byte(strings.Replace(string(valid), `"1.0.0"`, `"2.0.0"`, 1))},
+		{"text drift", []byte(strings.Replace(string(valid), texts[0], "PRIVATE_RETURNED_TEXT", 1))},
+		{"partial indices", contextualOfficialBody(t, texts[:1], []int{0})},
+		{"duplicate index", contextualOfficialBody(t, []string{texts[0], texts[0]}, []int{0, 0})},
+	}
+	inputs := []document.EmbeddingInput{
+		{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "first"},
+		{Key: "second", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "second"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write(test.body)
+			}))
+			profile := voyageTextProfile(t, voyage.EmbeddingModeContextual)
+			profile.Endpoint, profile.EgressPolicy = endpoint, egress
+			profile = refingerprintVoyageProfile(t, profile)
+			provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "PRIVATE_SECRET"}, resolver)
+			require.NoError(t, err)
+			_, err = provider.Embed(t.Context(), inputs, voyageAuthorization(profile.Descriptor))
+			require.ErrorIs(t, err, voyage.ErrMalformedResponse)
+			assert.NotContains(t, err.Error(), "PRIVATE")
+		})
+	}
+}
+
+func TestHostedVoyageAliasIsAlwaysExportOnly(t *testing.T) {
+	endpoint, egress, resolver := voyageFixture(t, http.NotFoundHandler())
+	profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	profile.Descriptor.SupportsTextQuery = true
+	_, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "synthetic-secret"}, resolver)
+	require.ErrorContains(t, err, "export-only")
+}
+
+func TestVoyageRoleContractMustMatchNativeModes(t *testing.T) {
+	endpoint, egress, resolver := voyageFixture(t, http.NotFoundHandler())
+	profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	profile.Descriptor.SupportedRequestModes = []document.ModelInputMode{document.ModelInputModeDocument}
+	_, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "synthetic-secret"}, resolver)
+	require.ErrorContains(t, err, "native role")
+}
+
+func contextualOfficialBody(t *testing.T, texts []string, indices []int) []byte {
+	t.Helper()
+	items := make([]map[string]any, len(indices))
+	for position, index := range indices {
+		items[position] = map[string]any{"embedding": unitEmbedding(index + 1), "index": index, "text": texts[index]}
+	}
+	body, err := json.Marshal(map[string]any{
+		"data": []any{map[string]any{"data": items, "index": 0}}, "model": voyage.ContextualModel,
+		"usage": map[string]any{"total_tokens": 2}, "chunker_version": "1.0.0",
+	})
+	require.NoError(t, err)
+	return body
+}
+
+func refingerprintVoyageProfile(t *testing.T, profile voyage.EmbeddingProfile) voyage.EmbeddingProfile {
+	t.Helper()
+	profile.Descriptor.PolicyFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
+	profile.Descriptor.Fingerprint = ""
+	profile.Descriptor, _ = document.NewEmbeddingDescriptor(profile.Descriptor)
+	fingerprint, err := voyage.EmbeddingPolicyFingerprint(profile)
+	require.NoError(t, err)
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	profile.Descriptor.Fingerprint = ""
+	profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+	require.NoError(t, err)
+	return profile
+}
+
+func TestHostedVoyageEmbeddingRequiresHTTPS(t *testing.T) {
+	profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+	profile.Endpoint = "http://api.voyageai.com/v1"
+	profile.EgressPolicy.Scheme, profile.EgressPolicy.Port = "http", 80
+	_, err := voyage.EmbeddingPolicyFingerprint(profile)
+	require.ErrorContains(t, err, "HTTPS")
+	_, err = voyage.NewEmbeddingProvider(profile, embeddingSecrets{"credential:voyage": "secret"}, failingEmbeddingResolver{})
+	require.ErrorContains(t, err, "HTTPS")
+}
+
+func TestDirectFileEmbeddingRejectsNativeRoleMismatch(t *testing.T) {
+	policy := testPolicy(t)
+	manifest, err := voyagetest.SyntheticManifest(policy)
+	require.NoError(t, err)
+	profile := voyageDirectFileProfile(t, policy, manifest)
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{Profile: document.ModelInputProfileMistral})
+	require.NoError(t, err)
+	profile.ModelInput, profile.Descriptor.ModelInput = contract, contract
+	profile.Descriptor.CompatibilityID = contract.CompatibilityID
+	profile.Descriptor.SupportedRequestModes = []document.ModelInputMode{document.ModelInputModeDocument, document.ModelInputModeText}
+	_, err = voyage.EmbeddingPolicyFingerprint(profile)
+	require.ErrorContains(t, err, "native role")
+}
+
+func TestVoyageEmbeddingRetriesMalformedResponseOnce(t *testing.T) {
+	for _, mode := range []voyage.EmbeddingMode{voyage.EmbeddingModeText, voyage.EmbeddingModeContextual} {
+		for _, testCase := range []struct {
+			name            string
+			recoverResponse bool
+			attempts        int
+			wantRequests    int32
+		}{
+			{"recovered", true, 3, 2}, {"malformed_twice", false, 3, 2}, {"attempt_limit", true, 1, 1},
+		} {
+			t.Run(fmt.Sprintf("%s/%s", mode, testCase.name), func(t *testing.T) {
+				var calls atomic.Int32
+				endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					count := calls.Add(1)
+					w.Header().Set("Content-Type", "application/json")
+					if count == 1 || !testCase.recoverResponse {
+						_, _ = w.Write([]byte(`{"data":`))
+						return
+					}
+					if mode == voyage.EmbeddingModeContextual {
+						_, _ = w.Write(contextualOfficialBody(t, []string{"document envelope: passage"}, []int{0}))
+					} else {
+						_, _ = w.Write(voyageTextBody(t, voyage.TextModel, []int{0}, []int{1}))
+					}
+				}))
+				profile := voyageTextProfile(t, mode)
+				profile.Endpoint, profile.EgressPolicy = endpoint, egress
+				profile.MaxRetries, profile.RetryBaseDelay = testCase.attempts, time.Millisecond
+				profile = refingerprintVoyageProfile(t, profile)
+				provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "secret"}, resolver)
+				require.NoError(t, err)
+				result, err := document.ExecuteEmbedding(t.Context(), provider, []document.EmbeddingInput{{Key: "chunk", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "passage"}}, voyageAuthorization(profile.Descriptor))
+				require.Equal(t, testCase.wantRequests, calls.Load())
+				if testCase.recoverResponse && testCase.attempts > 1 {
+					require.NoError(t, err)
+					require.Len(t, result.Vectors, 1)
+					assert.Equal(t, "chunk", result.Vectors[0].Key)
+				} else {
+					require.ErrorIs(t, err, voyage.ErrMalformedResponse)
+					assert.Equal(t, int(testCase.wantRequests)-1, voyage.MetricsFromError(err).Retries)
+				}
+			})
+		}
+	}
+}
+
+type blockingEmbeddingUpload struct {
+	*io.PipeReader
+
+	started chan struct{}
+	once    sync.Once
+}
+
+func (upload *blockingEmbeddingUpload) Read(p []byte) (int, error) {
+	upload.once.Do(func() { close(upload.started) })
+	return upload.PipeReader.Read(p)
+}
+func (upload *blockingEmbeddingUpload) Metadata() document.AuthorizedUploadMetadata {
+	return document.AuthorizedUploadMetadata{MediaFamily: "image", MediaType: "image/png", ByteLength: 5, SHA256: strings.Repeat("a", 64), CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile}
+}
+
+func TestDirectFileEmbeddingCancellationInterruptsUpload(t *testing.T) {
+	for _, core := range []bool{false, true} {
+		t.Run(fmt.Sprintf("core_%t", core), func(t *testing.T) {
+			policy := testPolicy(t)
+			manifest, err := voyagetest.SyntheticManifest(policy)
+			require.NoError(t, err)
+			profile := voyageDirectFileProfile(t, policy, manifest)
+			provider, err := voyage.NewEmbeddingProvider(profile, embeddingSecrets{"credential:voyage": "secret"}, failingEmbeddingResolver{})
+			require.NoError(t, err)
+			reader, writer := io.Pipe()
+			defer func() { _ = reader.Close() }()
+			defer func() { _ = writer.Close() }()
+			source := &blockingEmbeddingUpload{PipeReader: reader, started: make(chan struct{})}
+			inputs := []document.EmbeddingInput{{Key: "file", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() {
+				var err error
+				if core {
+					_, err = document.ExecuteEmbedding(ctx, provider, inputs, voyageAuthorization(profile.Descriptor))
+				} else {
+					_, err = provider.Embed(ctx, inputs, voyageAuthorization(profile.Descriptor))
+				}
+				done <- err
+			}()
+			<-source.started
+			cancel()
+			select {
+			case err := <-done:
+				require.ErrorIs(t, err, context.Canceled)
+			case <-time.After(time.Second):
+				_ = reader.Close()
+				<-done
+				t.Fatal("embedding did not interrupt its blocked upload after cancellation")
+			}
+		})
+	}
+}
+
+func newVoyageEmbeddingTestProvider(t *testing.T, profile voyage.EmbeddingProfile, secrets voyage.SecretResolver, resolver providerhttp.Resolver) (*voyage.EmbeddingClient, error) {
+	t.Helper()
+	provider, err := voyage.NewEmbeddingProvider(profile, secrets, resolver)
+	if err != nil {
+		return nil, err
+	}
+	if fixture, ok := resolver.(embeddingResolver); ok && fixture.certificate != nil {
+		voyage.TrustEmbeddingTestCertificate(t, provider, fixture.certificate)
+	}
+	return provider, nil
+}
+
+func TestVoyageEmbeddingAttemptTimeouts(t *testing.T) {
+	for _, stage := range []string{"credentials", "headers", "body"} {
+		for _, outcome := range []string{"recover", "exhaust", "caller_cancel"} {
+			t.Run(stage+"/"+outcome, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				var requests atomic.Int32
+				var resolutions int
+				response := voyageTextBody(t, voyage.TextModel, []int{0}, []int{1})
+				endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					count := requests.Add(1)
+					_, _ = io.Copy(io.Discard, r.Body)
+					w.Header().Set("Content-Type", "application/json")
+					if stage != "credentials" && (outcome != "recover" || count < 3) {
+						if stage == "body" {
+							w.WriteHeader(http.StatusOK)
+							assert.NoError(t, http.NewResponseController(w).Flush())
+						}
+						if outcome == "caller_cancel" {
+							cancel()
+						}
+						select {
+						case <-r.Context().Done():
+						case <-time.After(2 * time.Second):
+						}
+						return
+					}
+					_, _ = w.Write(response)
+				}))
+				secrets := embeddingSecretFunc(func(attemptCtx context.Context, _ string) (string, error) {
+					resolutions++
+					if stage == "credentials" && (outcome != "recover" || resolutions < 3) {
+						if outcome == "caller_cancel" {
+							cancel()
+						}
+						<-attemptCtx.Done()
+						return "", attemptCtx.Err()
+					}
+					return "synthetic-secret", nil
+				})
+				profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+				profile.Endpoint, profile.EgressPolicy = endpoint, egress
+				profile.RequestTimeout, profile.MaxRetries = 100*time.Millisecond, 3
+				profile.RetryBaseDelay = time.Nanosecond
+				profile = refingerprintVoyageProfile(t, profile)
+				provider, err := newVoyageEmbeddingTestProvider(t, profile, secrets, resolver)
+				require.NoError(t, err)
+				result, err := provider.Embed(ctx, []document.EmbeddingInput{{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "first"}}, voyageAuthorization(profile.Descriptor))
+				switch outcome {
+				case "recover":
+					require.NoError(t, err)
+					require.Len(t, result.Vectors, 1)
+					require.Equal(t, 3, resolutions)
+					require.NoError(t, ctx.Err())
+				case "exhaust":
+					require.ErrorIs(t, err, voyage.ErrTransientResponse)
+					require.ErrorIs(t, err, context.DeadlineExceeded)
+					require.NoError(t, ctx.Err())
+					require.Equal(t, 3, resolutions)
+					require.Equal(t, 2, voyage.MetricsFromError(err).Retries)
+				case "caller_cancel":
+					require.ErrorIs(t, err, context.Canceled)
+					require.NotErrorIs(t, err, voyage.ErrTransientResponse)
+					require.Equal(t, 1, resolutions)
+					require.Zero(t, voyage.MetricsFromError(err).Retries)
+				}
+				wantRequests := resolutions
+				if stage == "credentials" {
+					wantRequests = 0
+					if outcome == "recover" {
+						wantRequests = 1
+					}
+				}
+				require.EqualValues(t, wantRequests, requests.Load())
+				if err != nil {
+					require.Equal(t, wantRequests, voyage.MetricsFromError(err).Requests)
+				}
+			})
+		}
+	}
+}
+
+func TestVoyageEmbeddingCapacityCeilings(t *testing.T) {
+	for _, field := range []string{"input", "request", "response", "batch"} {
+		for _, excess := range []int64{0, 1, math.MaxInt64} {
+			t.Run(fmt.Sprintf("%s/%d", field, excess), func(t *testing.T) {
+				profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+				limit := int64(1 << 30)
+				if field == "batch" {
+					limit = 1000
+				}
+				value := excess
+				if excess != math.MaxInt64 {
+					value += limit
+				}
+				switch field {
+				case "input":
+					profile.MaxInputBytes = value
+				case "request":
+					profile.MaxRequestBytes = value
+				case "response":
+					profile.MaxResponseBytes = value
+				case "batch":
+					profile.MaxBatchItems = int(value)
+				}
+				_, err := voyage.EmbeddingPolicyFingerprint(profile)
+				if excess == 0 {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+				}
+			})
+		}
+	}
+}

--- a/document/voyage/embedding_test.go
+++ b/document/voyage/embedding_test.go
@@ -8,8 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"image/color"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/netip"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -19,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media"
 	"go.kenn.io/docbank/document/media/mediatest"
 	"go.kenn.io/docbank/document/providerhttp"
 	"go.kenn.io/docbank/document/voyage"
@@ -106,6 +110,9 @@ func TestEmbeddingProviderRejectsMalformedIndexedResponsesPrivately(t *testing.T
 		{"duplicate index", valid([]int{0, 0}, [][]float32{one, two})},
 		{"out of range", valid([]int{0, 2}, [][]float32{one, two})},
 		{"wrong dimension", valid([]int{0, 1}, [][]float32{one[:255], two})},
+		{"null element", []byte(strings.Replace(string(valid([]int{0, 1}, [][]float32{one, two})), `,0`, `,null`, 1))},
+		{"string element", []byte(strings.Replace(string(valid([]int{0, 1}, [][]float32{one, two})), `,0`, `,"0"`, 1))},
+		{"boolean element", []byte(strings.Replace(string(valid([]int{0, 1}, [][]float32{one, two})), `,0`, `,false`, 1))},
 		{"zero vector", valid([]int{0, 1}, [][]float32{make([]float32, 256), two})},
 		{"non finite", []byte(`{"object":"list","data":[{"object":"embedding","embedding":[1e999],"index":0}],"model":"voyage-4"}`)},
 	}
@@ -419,4 +426,80 @@ type embeddingSecretFunc func(context.Context, string) (string, error)
 
 func (resolve embeddingSecretFunc) ResolveSecret(ctx context.Context, binding string) (string, error) {
 	return resolve(ctx, binding)
+}
+
+func TestDirectFileEmbeddingValidatesNormalization(t *testing.T) {
+	for _, scale := range []float32{1, 2} {
+		t.Run(fmt.Sprint(scale), func(t *testing.T) {
+			policy := testPolicy(t)
+			manifest, err := voyagetest.SyntheticManifest(policy)
+			require.NoError(t, err)
+			profile := voyageDirectFileProfile(t, policy, manifest)
+			provider, err := voyage.NewEmbeddingProvider(profile, embeddingSecrets{"credential:voyage": "synthetic-secret"}, failingEmbeddingResolver{})
+			require.NoError(t, err)
+			voyage.SetEmbeddingTestTransport(provider, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				response := httptest.NewRecorder()
+				writeVectors(t, response, [][]float32{unitVector(0, scale)}, 1)
+				return response.Result(), nil
+			}))
+			data := mediatest.PNG(2, 2, color.White)
+			source := &embeddingUpload{Reader: bytes.NewReader(data), metadata: document.AuthorizedUploadMetadata{
+				MediaFamily: "image", MediaType: "image/png", ByteLength: int64(len(data)), SHA256: fmt.Sprintf("%x", sha256.Sum256(data)),
+				CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile,
+			}}
+			result, err := document.ExecuteEmbedding(t.Context(), provider, []document.EmbeddingInput{{Key: "image", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}}, voyageAuthorization(profile.Descriptor))
+			if scale == 1 {
+				require.NoError(t, err)
+				require.Equal(t, unitVector(0, scale), result.Vectors[0].Values)
+			} else {
+				require.ErrorIs(t, err, voyage.ErrMalformedResponse)
+				require.Empty(t, result.Vectors)
+			}
+			require.True(t, source.closed)
+		})
+	}
+}
+
+func TestDirectFileEmbeddingRejectsOversizedUploadBeforeReading(t *testing.T) {
+	data := mediatest.PNG(2, 2, color.White)
+	for _, oversized := range []bool{false, true} {
+		t.Run(strconv.FormatBool(oversized), func(t *testing.T) {
+			mediaPolicy := media.DefaultPolicy()
+			mediaPolicy.MaxBytes = int64(len(data))
+			policy, err := voyage.NewPolicy(voyage.PolicyConfig{Media: mediaPolicy})
+			require.NoError(t, err)
+			manifest, err := voyagetest.SyntheticManifest(policy)
+			require.NoError(t, err)
+			profile := voyageDirectFileProfile(t, policy, manifest)
+			provider, err := voyage.NewEmbeddingProvider(profile, embeddingSecrets{"credential:voyage": "synthetic-secret"}, failingEmbeddingResolver{})
+			require.NoError(t, err)
+			requests := 0
+			voyage.SetEmbeddingTestTransport(provider, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				requests++
+				response := httptest.NewRecorder()
+				writeVectors(t, response, [][]float32{unitVector(0, 1)}, 1)
+				return response.Result(), nil
+			}))
+			input := append([]byte(nil), data...)
+			if oversized {
+				input = append(input, 0)
+			}
+			source := &embeddingUpload{Reader: bytes.NewReader(input), metadata: document.AuthorizedUploadMetadata{
+				MediaFamily: "image", MediaType: "image/png", ByteLength: int64(len(input)), SHA256: fmt.Sprintf("%x", sha256.Sum256(input)),
+				CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile,
+			}}
+			_, err = document.ExecuteEmbedding(t.Context(), provider, []document.EmbeddingInput{{Key: "image", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}}, voyageAuthorization(profile.Descriptor))
+			if oversized {
+				require.Error(t, err)
+				position, seekErr := source.Seek(0, io.SeekCurrent)
+				require.NoError(t, seekErr)
+				require.Zero(t, position, "oversized input must be refused before its first read")
+				require.Zero(t, requests)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, 1, requests)
+			}
+			require.True(t, source.closed)
+		})
+	}
 }

--- a/document/voyage/embedding_test.go
+++ b/document/voyage/embedding_test.go
@@ -533,3 +533,62 @@ func TestDirectFileEmbeddingRejectsOversizedUploadBeforeReading(t *testing.T) {
 		})
 	}
 }
+
+func TestDirectFileEmbeddingUsesEffectivePolicyLimits(t *testing.T) {
+	policy, err := voyage.NewPolicy(voyage.PolicyConfig{Media: media.DefaultPolicy(), MaxBatchItems: 2, MaxRequestBytes: 4096, MaxResponseBytes: 16 << 10})
+	require.NoError(t, err)
+	manifest, err := voyagetest.SyntheticManifest(policy)
+	require.NoError(t, err)
+	exact := voyageDirectFileProfile(t, policy, manifest)
+	exact.MaxBatchItems, exact.MaxRequestBytes, exact.MaxResponseBytes = 2, 4096, 16<<10
+	exact = refingerprintVoyageProfile(t, exact)
+	for _, defaults := range []bool{false, true} {
+		t.Run(strconv.FormatBool(defaults), func(t *testing.T) {
+			profile := voyageDirectFileProfile(t, policy, manifest)
+			if defaults {
+				profile.MaxBatchItems, profile.MaxRequestBytes, profile.MaxResponseBytes = 0, 0, 0
+			}
+			profile = refingerprintVoyageProfile(t, profile)
+			assert.Equal(t, exact.Descriptor.PolicyFingerprint, profile.Descriptor.PolicyFingerprint)
+			provider, err := voyage.NewEmbeddingProvider(profile, embeddingSecrets{"credential:voyage": "synthetic-secret"}, failingEmbeddingResolver{})
+			require.NoError(t, err)
+			requests := 0
+			voyage.SetEmbeddingTestTransport(provider, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				requests++
+				response := httptest.NewRecorder()
+				writeVectors(t, response, [][]float32{unitVector(0, 1)}, 1)
+				return response.Result(), nil
+			}))
+			for _, bound := range []string{"exact", "batch", "response"} {
+				t.Run(bound, func(t *testing.T) {
+					requests = 0
+					authorization := voyageAuthorization(profile.Descriptor)
+					authorization.MaxBatchItems, authorization.MaxResponseBytes = 2, 16<<10
+					if bound == "batch" {
+						authorization.MaxBatchItems++
+					}
+					if bound == "response" {
+						authorization.MaxResponseBytes++
+					}
+					data := mediatest.PNG(2, 2, color.White)
+					source := &embeddingUpload{Reader: bytes.NewReader(data), metadata: document.AuthorizedUploadMetadata{
+						MediaFamily: "image", MediaType: "image/png", ByteLength: int64(len(data)), SHA256: fmt.Sprintf("%x", sha256.Sum256(data)),
+						CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile,
+					}}
+					_, err := document.ExecuteEmbedding(t.Context(), provider, []document.EmbeddingInput{{Key: "image", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}}, authorization)
+					if bound == "exact" {
+						require.NoError(t, err)
+						require.Equal(t, 1, requests)
+					} else {
+						require.ErrorContains(t, err, "authorization exceeds profile capacity")
+						position, seekErr := source.Seek(0, io.SeekCurrent)
+						require.NoError(t, seekErr)
+						require.Zero(t, position)
+						require.Zero(t, requests)
+					}
+					require.True(t, source.closed)
+				})
+			}
+		})
+	}
+}

--- a/document/voyage/embedding_test.go
+++ b/document/voyage/embedding_test.go
@@ -1,0 +1,422 @@
+package voyage_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	json "encoding/json/v2"
+	"errors"
+	"fmt"
+	"image/color"
+	"net/http"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media/mediatest"
+	"go.kenn.io/docbank/document/providerhttp"
+	"go.kenn.io/docbank/document/voyage"
+	"go.kenn.io/docbank/document/voyage/voyagetest"
+)
+
+type embeddingSecrets map[string]string
+
+func (secrets embeddingSecrets) ResolveSecret(_ context.Context, name string) (string, error) {
+	return secrets[name], nil
+}
+
+type textEmbeddingRequest struct {
+	Input           []string   `json:"input"`
+	Inputs          [][]string `json:"inputs"`
+	Model           string     `json:"model"`
+	InputType       string     `json:"input_type"`
+	Truncation      *bool      `json:"truncation"`
+	OutputDimension int        `json:"output_dimension"`
+	OutputDType     string     `json:"output_dtype"`
+}
+
+func TestEmbeddingProviderSendsVoyageDocumentRoleAndEnvelope(t *testing.T) {
+	var decoded textEmbeddingRequest
+	endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "/v1/embeddings", request.URL.Path)
+		assert.Equal(t, "Bearer synthetic-secret", request.Header.Get("Authorization"))
+		assert.NoError(t, json.UnmarshalRead(request.Body, &decoded, json.RejectUnknownMembers(true)))
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write(voyageTextBody(t, voyage.TextModel, []int{0}, []int{1}))
+	}))
+	profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	profile = refingerprintVoyageProfile(t, profile)
+	provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "synthetic-secret"}, resolver)
+	require.NoError(t, err)
+	inputs := []document.EmbeddingInput{{Key: "doc", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "passage"}}
+	result, err := document.ExecuteEmbedding(t.Context(), provider, inputs, voyageAuthorization(profile.Descriptor))
+	require.NoError(t, err)
+	assert.Equal(t, "document", decoded.InputType)
+	assert.Equal(t, []string{"document envelope: passage"}, decoded.Input)
+	require.NotNil(t, decoded.Truncation)
+	assert.False(t, *decoded.Truncation)
+	assert.Equal(t, "doc", result.Vectors[0].Key)
+}
+
+func TestVoyageEmbeddingPolicyFingerprintCoversDisclosureAndRoleContract(t *testing.T) {
+	profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+	baseline, err := voyage.EmbeddingPolicyFingerprint(profile)
+	require.NoError(t, err)
+
+	changedEnvelope := profile
+	changedEnvelope.ModelInput = customVoyageInput(t, "changed: {{content}}", "query envelope: {{content}}")
+	changedEnvelope.Descriptor.ModelInput = changedEnvelope.ModelInput
+	changedEnvelope.Descriptor.CompatibilityID = changedEnvelope.ModelInput.CompatibilityID
+	changedEnvelope = refingerprintVoyageProfile(t, changedEnvelope)
+	assert.NotEqual(t, baseline, changedEnvelope.Descriptor.PolicyFingerprint)
+
+	changedEgress := profile
+	changedEgress.EgressPolicy.AllowedCIDRs = []netip.Prefix{netip.MustParsePrefix("198.51.100.0/24")}
+	changedEgress = refingerprintVoyageProfile(t, changedEgress)
+	assert.NotEqual(t, baseline, changedEgress.Descriptor.PolicyFingerprint)
+}
+
+func TestEmbeddingProviderRejectsMalformedIndexedResponsesPrivately(t *testing.T) {
+	profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+	one, two := unitEmbedding(0), unitEmbedding(1)
+	valid := func(indices []int, vectors [][]float32) []byte {
+		items := make([]map[string]any, len(indices))
+		for index := range indices {
+			items[index] = map[string]any{"object": "embedding", "embedding": vectors[index], "index": indices[index]}
+		}
+		body, err := json.Marshal(map[string]any{"object": "list", "data": items, "model": profile.Descriptor.Model, "usage": map[string]any{"total_tokens": 1}})
+		require.NoError(t, err)
+		return body
+	}
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{"malformed", []byte(`{"object":`)},
+		{"unknown", []byte(`{"object":"list","unknown":"PRIVATE_RAW_BODY","data":[],"model":"voyage-4"}`)},
+		{"duplicate key", []byte(`{"object":"list","model":"voyage-4","model":"PRIVATE_RAW_BODY","data":[]}`)},
+		{"partial indices", valid([]int{0}, [][]float32{one})},
+		{"duplicate index", valid([]int{0, 0}, [][]float32{one, two})},
+		{"out of range", valid([]int{0, 2}, [][]float32{one, two})},
+		{"wrong dimension", valid([]int{0, 1}, [][]float32{one[:255], two})},
+		{"zero vector", valid([]int{0, 1}, [][]float32{make([]float32, 256), two})},
+		{"non finite", []byte(`{"object":"list","data":[{"object":"embedding","embedding":[1e999],"index":0}],"model":"voyage-4"}`)},
+	}
+	inputs := []document.EmbeddingInput{
+		{Key: "a", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "PRIVATE_INPUT"},
+		{Key: "b", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "other"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write(test.body)
+			}))
+			local := profile
+			local.Endpoint, local.EgressPolicy = endpoint, egress
+			local = refingerprintVoyageProfile(t, local)
+			provider, err := newVoyageEmbeddingTestProvider(t, local, embeddingSecrets{"credential:voyage": "PRIVATE_SECRET"}, resolver)
+			require.NoError(t, err)
+			_, err = provider.Embed(t.Context(), inputs, voyageAuthorization(local.Descriptor))
+			require.ErrorIs(t, err, voyage.ErrMalformedResponse)
+			assert.NotContains(t, err.Error(), "PRIVATE")
+		})
+	}
+}
+
+func TestEmbeddingProviderClassifiesCapacityAndExhaustedTransient(t *testing.T) {
+	input := []document.EmbeddingInput{{Key: "one", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "text"}}
+	for _, test := range []struct {
+		name   string
+		status int
+		kind   error
+	}{
+		{"auth", http.StatusUnauthorized, voyage.ErrUnauthorized},
+		{"capacity", http.StatusRequestEntityTooLarge, voyage.ErrBatchTooLarge},
+		{"permanent", http.StatusBadRequest, voyage.ErrPermanentResponse},
+		{"rate limit", http.StatusTooManyRequests, voyage.ErrTransientResponse},
+		{"transient", http.StatusServiceUnavailable, voyage.ErrTransientResponse},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var calls atomic.Int32
+			endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				writer.WriteHeader(test.status)
+				_, _ = writer.Write([]byte("PRIVATE_BODY"))
+			}))
+			profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+			profile.Endpoint, profile.EgressPolicy, profile.MaxRetries, profile.RetryBaseDelay = endpoint, egress, 2, time.Millisecond
+			profile = refingerprintVoyageProfile(t, profile)
+			provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "secret"}, resolver)
+			require.NoError(t, err)
+			_, err = provider.Embed(t.Context(), input, voyageAuthorization(profile.Descriptor))
+			require.ErrorIs(t, err, test.kind)
+			assert.NotContains(t, err.Error(), "PRIVATE_BODY")
+			metrics := voyage.MetricsFromError(err)
+			assert.Equal(t, int(calls.Load()), metrics.Requests)
+			if errors.Is(test.kind, voyage.ErrTransientResponse) {
+				assert.Equal(t, 2, metrics.Requests)
+				assert.Equal(t, 1, metrics.Retries)
+			}
+		})
+	}
+}
+
+func TestVoyageEmbeddingRejectsIdentityDrift(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*voyage.EmbeddingProfile)
+	}{
+		{"model", func(profile *voyage.EmbeddingProfile) { profile.Descriptor.Model = "voyage-4-drift" }},
+		{"revision", func(profile *voyage.EmbeddingProfile) { profile.Descriptor.ModelRevision = "invented-revision" }},
+		{"compatibility", func(profile *voyage.EmbeddingProfile) { profile.Descriptor.CompatibilityID = "voyage/other-space/v1" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+			test.mutate(&profile)
+			_, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "secret"}, nil)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestVoyageEmbeddingResponseLimitCancellationAndTransportFailure(t *testing.T) {
+	input := []document.EmbeddingInput{{Key: "one", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "PRIVATE_INPUT"}}
+	t.Run("response limit", func(t *testing.T) {
+		endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(strings.Repeat("x", 4097)))
+		}))
+		profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+		profile.Endpoint, profile.EgressPolicy, profile.MaxResponseBytes = endpoint, egress, 4096
+		profile = refingerprintVoyageProfile(t, profile)
+		provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "secret"}, resolver)
+		require.NoError(t, err)
+		authorization := voyageAuthorization(profile.Descriptor)
+		authorization.MaxResponseBytes = 4096
+		_, err = provider.Embed(t.Context(), input, authorization)
+		require.ErrorIs(t, err, voyage.ErrMalformedResponse)
+	})
+	t.Run("cancellation", func(t *testing.T) {
+		endpoint, egress, resolver := voyageFixture(t, http.NotFoundHandler())
+		profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+		profile.Endpoint, profile.EgressPolicy = endpoint, egress
+		profile = refingerprintVoyageProfile(t, profile)
+		provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "secret"}, resolver)
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err = provider.Embed(ctx, input, voyageAuthorization(profile.Descriptor))
+		require.ErrorIs(t, err, context.Canceled)
+		assert.NotContains(t, err.Error(), "PRIVATE_INPUT")
+	})
+	t.Run("transport exhaustion", func(t *testing.T) {
+		profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+		profile.MaxRetries, profile.RetryBaseDelay = 2, time.Millisecond
+		profile = refingerprintVoyageProfile(t, profile)
+		provider, err := voyage.NewEmbeddingProvider(profile, embeddingSecrets{"credential:voyage": "secret"}, failingEmbeddingResolver{})
+		require.NoError(t, err)
+		_, err = provider.Embed(t.Context(), input, voyageAuthorization(profile.Descriptor))
+		require.ErrorIs(t, err, voyage.ErrTransientResponse)
+		assert.Equal(t, 2, voyage.MetricsFromError(err).Requests)
+	})
+}
+
+type failingEmbeddingResolver struct{}
+
+func (failingEmbeddingResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return nil, errors.New("synthetic DNS failure")
+}
+
+func TestEmbeddingProviderBoundsRequestBytesAndRefusesRedirect(t *testing.T) {
+	input := []document.EmbeddingInput{{Key: "one", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "text"}}
+	endpoint, egress, resolver := voyageFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Location", "http://elsewhere.invalid/private")
+		writer.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	profile := voyageTextProfile(t, voyage.EmbeddingModeText)
+	profile.Endpoint, profile.EgressPolicy = endpoint, egress
+	profile = refingerprintVoyageProfile(t, profile)
+	provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "secret"}, resolver)
+	require.NoError(t, err)
+	_, err = provider.Embed(t.Context(), input, voyageAuthorization(profile.Descriptor))
+	require.ErrorIs(t, err, voyage.ErrPermanentResponse)
+
+	bounded := profile
+	bounded.MaxRequestBytes = 1
+	bounded = refingerprintVoyageProfile(t, bounded)
+	provider, err = newVoyageEmbeddingTestProvider(t, bounded, embeddingSecrets{"credential:voyage": "secret"}, resolver)
+	require.NoError(t, err)
+	_, err = provider.Embed(t.Context(), input, voyageAuthorization(bounded.Descriptor))
+	require.ErrorIs(t, err, voyage.ErrBatchTooLarge)
+}
+
+func TestDirectFileProfileRemainsCapabilityAttestedExportOnly(t *testing.T) {
+	policy := testPolicy(t)
+	manifest, err := voyagetest.SyntheticManifest(policy)
+	require.NoError(t, err)
+	profile := voyageDirectFileProfile(t, policy, manifest)
+	provider, err := newVoyageEmbeddingTestProvider(t, profile, embeddingSecrets{"credential:voyage": "secret"}, embeddingResolver{address: netip.MustParseAddr("192.0.2.1")})
+	require.NoError(t, err)
+	assert.False(t, provider.Descriptor().SupportsTextQuery)
+}
+
+func unitEmbedding(hot int) []float32 {
+	vector := make([]float32, 256)
+	vector[hot] = 1
+	return vector
+}
+
+func voyageDirectFileProfile(t *testing.T, policy voyage.Policy, manifest voyage.CapabilityManifest) voyage.EmbeddingProfile {
+	t.Helper()
+	modelInput := customVoyageInput(t, "document envelope: {{content}}", "query envelope: {{content}}")
+	revision, err := voyage.DirectFileModelRevision(policy, manifest)
+	require.NoError(t, err)
+	profile := voyage.EmbeddingProfile{
+		Mode: voyage.EmbeddingModeDirectFile, Endpoint: voyage.DefaultEndpoint, EgressPolicy: productionVoyageEgress(), ModelInput: modelInput,
+		SecretBinding: "credential:voyage", MaxBatchItems: 8, MaxInputBytes: 1 << 20, MaxRequestBytes: voyage.MaxRequestBytes,
+		MaxResponseBytes: 1 << 20, Policy: policy, CapabilityManifest: manifest,
+		Descriptor: document.EmbeddingDescriptor{
+			ID: voyage.EmbeddingProviderID, ContractVersion: document.EmbeddingProviderContractVersion,
+			PolicyFingerprint: strings.Repeat("0", 64), TrustBoundary: document.EmbeddingTrustHostedProvider,
+			Model: voyage.DefaultModel, ModelRevision: revision, Dimension: voyage.DefaultDimension,
+			Metric: document.VectorMetricCosine, Normalization: document.VectorNormalizationUnitLength,
+			ScalarEncoding: voyage.EmbeddingScalarFloat32, DocumentFormatter: voyage.EmbeddingDocumentFormatterV1,
+			QueryFormatter: voyage.EmbeddingQueryFormatterV1, InputKinds: []document.EmbeddingInputKind{document.EmbeddingInputOriginalFile},
+			CompatibilityID: modelInput.CompatibilityID, ModelInput: modelInput,
+			SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeDocument},
+		},
+	}
+	return refingerprintVoyageProfile(t, profile)
+}
+
+func voyageTextProfile(t *testing.T, mode voyage.EmbeddingMode) voyage.EmbeddingProfile {
+	t.Helper()
+	model := voyage.TextModel
+	if mode == voyage.EmbeddingModeContextual {
+		model = voyage.ContextualModel
+	}
+	modelInput := customVoyageInput(t, "document envelope: {{content}}", "query envelope: {{content}}")
+	profile := voyage.EmbeddingProfile{
+		Mode: mode, Endpoint: voyage.DefaultEndpoint, EgressPolicy: productionVoyageEgress(), ModelInput: modelInput,
+		SecretBinding: "credential:voyage", ChunkerVersion: "1.0.0", MaxBatchItems: 8, MaxInputBytes: 4096,
+		MaxRequestBytes: 8192, MaxResponseBytes: 1 << 20,
+		Descriptor: document.EmbeddingDescriptor{
+			ID: voyage.EmbeddingProviderID, ContractVersion: document.EmbeddingProviderContractVersion,
+			PolicyFingerprint: strings.Repeat("0", 64), TrustBoundary: document.EmbeddingTrustHostedProvider,
+			Model: model, ModelRevision: voyage.HostedAliasRevision, Dimension: 256, Metric: document.VectorMetricCosine,
+			Normalization: document.VectorNormalizationUnitLength, ScalarEncoding: voyage.EmbeddingScalarFloat32,
+			DocumentFormatter: voyage.EmbeddingDocumentFormatterV1, QueryFormatter: voyage.EmbeddingQueryFormatterV1,
+			InputKinds: []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}, CompatibilityID: modelInput.CompatibilityID,
+			ModelInput: modelInput, SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeDocument, document.ModelInputModeQuery},
+		},
+	}
+	return refingerprintVoyageProfile(t, profile)
+}
+
+func productionVoyageEgress() providerhttp.EgressPolicy {
+	return providerhttp.EgressPolicy{Scheme: "https", Host: "api.voyageai.com", Port: 443, AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0"), netip.MustParsePrefix("::/0")}, ProxyMode: providerhttp.ProxyDisabled}
+}
+
+func customVoyageInput(t *testing.T, documentTemplate, queryTemplate string) document.ModelInputContract {
+	t.Helper()
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfileCustom, CompatibilityID: "voyage/test-space/v1",
+		Document: document.ModelInputEncoder{Mode: document.ModelInputModeDocument, Template: documentTemplate},
+		Query:    document.ModelInputEncoder{Mode: document.ModelInputModeQuery, Template: queryTemplate},
+	})
+	require.NoError(t, err)
+	return contract
+}
+
+func voyageAuthorization(descriptor document.EmbeddingDescriptor) document.EmbeddingAuthorization {
+	return document.EmbeddingAuthorization{ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint, PolicyFingerprint: descriptor.PolicyFingerprint, MaxBatchItems: 8, MaxInputBytes: 4096, MaxResponseBytes: 1 << 20}
+}
+
+func voyageTextBody(t *testing.T, model string, indices, hot []int) []byte {
+	t.Helper()
+	items := make([]map[string]any, len(indices))
+	for position, index := range indices {
+		items[position] = map[string]any{"object": "embedding", "embedding": unitEmbedding(hot[position]), "index": index}
+	}
+	body, err := json.Marshal(map[string]any{"object": "list", "data": items, "model": model, "usage": map[string]any{"total_tokens": 2}})
+	require.NoError(t, err)
+	return body
+}
+
+// The adapter must carry its tighter request bound into the direct-file client.
+func TestDirectFileEmbeddingHonorsRequestBound(t *testing.T) {
+	for _, mutateManifest := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mutate_manifest_%t", mutateManifest), func(t *testing.T) {
+			policy := testPolicy(t)
+			manifest, err := voyagetest.SyntheticManifest(policy)
+			require.NoError(t, err)
+			profile := voyageDirectFileProfile(t, policy, manifest)
+			profile.MaxRequestBytes = 1
+			profile.MaxRetries = 1
+			profile = refingerprintVoyageProfile(t, profile)
+			provider, err := voyage.NewEmbeddingProvider(profile, embeddingSecrets{"credential:voyage": "secret"}, failingEmbeddingResolver{})
+			require.NoError(t, err)
+			if mutateManifest {
+				profile.CapabilityManifest.Results[0].FixtureDigest = "invalid"
+			}
+			data := mediatest.PNG(2, 2, color.White)
+			source := &embeddingUpload{Reader: bytes.NewReader(data), metadata: document.AuthorizedUploadMetadata{
+				MediaFamily: "image", MediaType: "image/png", ByteLength: int64(len(data)), SHA256: fmt.Sprintf("%x", sha256.Sum256(data)),
+				CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile,
+			}}
+			inputs := []document.EmbeddingInput{{Key: "image", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}}
+			_, err = document.ExecuteEmbedding(t.Context(), provider, inputs, voyageAuthorization(profile.Descriptor))
+			require.ErrorIs(t, err, voyage.ErrBatchTooLarge)
+			require.True(t, source.closed)
+		})
+	}
+}
+
+type embeddingUpload struct {
+	*bytes.Reader
+
+	metadata document.AuthorizedUploadMetadata
+	closed   bool
+}
+
+func (upload *embeddingUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+func (upload *embeddingUpload) Close() error                                { upload.closed = true; return nil }
+
+func TestDirectFileEmbeddingBoundsCredentialResolution(t *testing.T) {
+	policy := testPolicy(t)
+	manifest, err := voyagetest.SyntheticManifest(policy)
+	require.NoError(t, err)
+	profile := voyageDirectFileProfile(t, policy, manifest)
+	profile.RequestTimeout = time.Second
+	profile = refingerprintVoyageProfile(t, profile)
+	var bounded bool
+	secrets := embeddingSecretFunc(func(ctx context.Context, _ string) (string, error) {
+		deadline, ok := ctx.Deadline()
+		bounded = ok && time.Until(deadline) <= time.Second
+		return "", errors.New("synthetic credential failure")
+	})
+	provider, err := newVoyageEmbeddingTestProvider(t, profile, secrets, failingEmbeddingResolver{})
+	require.NoError(t, err)
+	data := []byte("synthetic source")
+	source := &embeddingUpload{Reader: bytes.NewReader(data), metadata: document.AuthorizedUploadMetadata{
+		MediaFamily: "image", MediaType: "image/png", ByteLength: int64(len(data)), SHA256: fmt.Sprintf("%x", sha256.Sum256(data)),
+		CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile,
+	}}
+	_, err = document.ExecuteEmbedding(t.Context(), provider, []document.EmbeddingInput{{Key: "image", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}}, voyageAuthorization(profile.Descriptor))
+	require.ErrorContains(t, err, "credential")
+	require.True(t, bounded, "credential lookup must receive the adapter timeout")
+}
+
+type embeddingSecretFunc func(context.Context, string) (string, error)
+
+func (resolve embeddingSecretFunc) ResolveSecret(ctx context.Context, binding string) (string, error) {
+	return resolve(ctx, binding)
+}

--- a/document/voyage/embedding_test.go
+++ b/document/voyage/embedding_test.go
@@ -462,8 +462,21 @@ func TestDirectFileEmbeddingValidatesNormalization(t *testing.T) {
 
 func TestDirectFileEmbeddingRejectsOversizedUploadBeforeReading(t *testing.T) {
 	data := mediatest.PNG(2, 2, color.White)
-	for _, oversized := range []bool{false, true} {
-		t.Run(strconv.FormatBool(oversized), func(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		oversized    bool
+		count        int
+		requestBytes int64
+		wantError    bool
+	}{
+		{"media_at_limit", false, 1, voyage.MaxRequestBytes, false},
+		{"media_over_limit", true, 1, voyage.MaxRequestBytes, true},
+		{"request_envelope", false, 1, 100, true},
+		{"base64_expansion", false, 1, 790, true},
+		{"combined_batch", false, 2, 1000, true},
+		{"batch_fits", false, 2, 1200, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
 			mediaPolicy := media.DefaultPolicy()
 			mediaPolicy.MaxBytes = int64(len(data))
 			policy, err := voyage.NewPolicy(voyage.PolicyConfig{Media: mediaPolicy})
@@ -471,35 +484,52 @@ func TestDirectFileEmbeddingRejectsOversizedUploadBeforeReading(t *testing.T) {
 			manifest, err := voyagetest.SyntheticManifest(policy)
 			require.NoError(t, err)
 			profile := voyageDirectFileProfile(t, policy, manifest)
+			profile.MaxRequestBytes = test.requestBytes
+			profile = refingerprintVoyageProfile(t, profile)
 			provider, err := voyage.NewEmbeddingProvider(profile, embeddingSecrets{"credential:voyage": "synthetic-secret"}, failingEmbeddingResolver{})
 			require.NoError(t, err)
 			requests := 0
 			voyage.SetEmbeddingTestTransport(provider, roundTripFunc(func(*http.Request) (*http.Response, error) {
 				requests++
 				response := httptest.NewRecorder()
-				writeVectors(t, response, [][]float32{unitVector(0, 1)}, 1)
+				vectors := make([][]float32, test.count)
+				for index := range vectors {
+					vectors[index] = unitVector(index, 1)
+				}
+				writeVectors(t, response, vectors, 1)
 				return response.Result(), nil
 			}))
 			input := append([]byte(nil), data...)
-			if oversized {
+			if test.oversized {
 				input = append(input, 0)
 			}
-			source := &embeddingUpload{Reader: bytes.NewReader(input), metadata: document.AuthorizedUploadMetadata{
-				MediaFamily: "image", MediaType: "image/png", ByteLength: int64(len(input)), SHA256: fmt.Sprintf("%x", sha256.Sum256(input)),
-				CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile,
-			}}
-			_, err = document.ExecuteEmbedding(t.Context(), provider, []document.EmbeddingInput{{Key: "image", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}}, voyageAuthorization(profile.Descriptor))
-			if oversized {
-				require.Error(t, err)
-				position, seekErr := source.Seek(0, io.SeekCurrent)
-				require.NoError(t, seekErr)
-				require.Zero(t, position, "oversized input must be refused before its first read")
+			sources := make([]*embeddingUpload, test.count)
+			inputs := make([]document.EmbeddingInput, test.count)
+			for index := range sources {
+				source := &embeddingUpload{Reader: bytes.NewReader(input), metadata: document.AuthorizedUploadMetadata{
+					MediaFamily: "image", MediaType: "image/png", ByteLength: int64(len(input)), SHA256: fmt.Sprintf("%x", sha256.Sum256(input)),
+					CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile,
+				}}
+				sources[index] = source
+				inputs[index] = document.EmbeddingInput{Key: strconv.Itoa(index), Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}
+			}
+
+			_, err = document.ExecuteEmbedding(t.Context(), provider, inputs, voyageAuthorization(profile.Descriptor))
+			if test.wantError {
+				require.ErrorIs(t, err, voyage.ErrBatchTooLarge)
+				for _, source := range sources {
+					position, seekErr := source.Seek(0, io.SeekCurrent)
+					require.NoError(t, seekErr)
+					require.Zero(t, position, "oversized input must be refused before its first read")
+				}
 				require.Zero(t, requests)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, 1, requests)
 			}
-			require.True(t, source.closed)
+			for _, source := range sources {
+				require.True(t, source.closed)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Docbank can export and evaluate hosted embeddings through Voyage 4 text, Voyage contextual embeddings, Voyage direct-file inputs, and Mistral Embed. These hosted profiles remain export-only: a mutable model alias does not establish an immutable vector space suitable for retrieval activation.

Each profile requires HTTPS and pins its endpoint, network policy, input formatting, credential binding, and execution limits. Responses must match the expected model, dimensions, indices, and vector contract. Contextual invocations contain one document's ordered chunks so unrelated documents do not share context. Direct-file execution retains capability checks and the core's upload ownership and verification.

Construct a `voyage.EmbeddingProfile` or `mistral.EmbeddingProfile`, create its provider with `NewEmbeddingProvider`, and call it through `document.ExecuteEmbedding`. This layer adds no daemon or CLI surface.

Parent: #213 (merged). This PR contains only the hosted embedding changes on current `main`.

Refs #176

