### PR TITLE
[F10–E12 20/25] Publish embedding sets independently

### DIFF
--- a/cmd/docbank/daemon.go
+++ b/cmd/docbank/daemon.go
@@ -52,6 +52,36 @@ var daemonRunCmd = &cobra.Command{
 	},
 }
 
+type embeddingRuntimeReadiness interface{ Ready() bool }
+
+type embeddingJobRunner interface {
+	Run(ctx context.Context) error
+}
+
+type embeddingJobStarter interface {
+	Start(name string, run func(context.Context) error) error
+}
+
+// startEmbeddingWorkerIfReady preserves the daemon's normal supervisor-owned
+// cancellation and drain lifecycle. An empty runtime registry leaves durable
+// work untouched. A ready runtime must provide a real worker; configuration
+// failures are not converted into a no-op polling loop.
+func startEmbeddingWorkerIfReady(starter embeddingJobStarter, readiness embeddingRuntimeReadiness,
+	build func() (embeddingJobRunner, error),
+) error {
+	if readiness == nil || !readiness.Ready() {
+		return nil
+	}
+	worker, err := build()
+	if err != nil {
+		return err
+	}
+	if worker == nil {
+		return errors.New("embedding worker builder returned nil")
+	}
+	return starter.Start("process:embeddings", worker.Run)
+}
+
 func runServe(ctx context.Context) (retErr error) {
 	layout, err := home.Resolve()
 	if err != nil {
@@ -137,6 +167,9 @@ func runServe(ctx context.Context) (retErr error) {
 	}
 	defer func() { _ = blobs.Close() }()
 	// Exclusive lock holder: any stale tmp file is provably abandoned.
+	if err := recoverEmbeddingRuntimeSpool(sigCtx, layout.BlobTmpDir()); err != nil {
+		return err
+	}
 	if err := blobs.CleanTmp(); err != nil {
 		return err
 	}
@@ -152,6 +185,28 @@ func runServe(ctx context.Context) (retErr error) {
 	operationGate := api.NewOperationGate()
 	runtimeRegistry := processing.NewRenditionRuntimeRegistry()
 	if err := startProcessingJobs(jobSupervisor, s, blobs, runtimeRegistry, operationGate, logger); err != nil {
+		return err
+	}
+	embeddingRuntimeRegistry, err := configureEmbeddingRuntimes(cfg, blobs, layout.BlobTmpDir())
+	if err != nil {
+		return fmt.Errorf("configuring embedding runtimes: %w", err)
+	}
+	if err := startEmbeddingWorkerIfReady(jobSupervisor, embeddingRuntimeRegistry,
+		func() (embeddingJobRunner, error) {
+			worker, workerErr := processing.NewEmbeddingWorker(processing.EmbeddingWorkerConfig{
+				Catalog: s, Authority: s, Blobs: blobs, GenerationBlobs: blobs, Runtime: embeddingRuntimeRegistry,
+				Gate: operationGate, Owner: "daemon-embedding-worker",
+				LeaseDuration: 5 * time.Minute, IdleDelay: time.Second,
+				RetryLimit: 3, RetryBaseDelay: time.Second, MaxRetryDelay: 30 * time.Second,
+				AttemptLifetime: 30 * time.Minute, MaxRows: 100_000,
+				MaxDimensions: 1_048_576, MaxVectorBlobBytes: 64 << 20,
+				DescriptorFingerprints: embeddingRuntimeRegistry.Fingerprints(),
+			})
+			if workerErr != nil {
+				return nil, fmt.Errorf("configuring embedding worker: %w", workerErr)
+			}
+			return worker, nil
+		}); err != nil {
 		return err
 	}
 	placementRunner := blob.PlacementRunner{

--- a/cmd/docbank/daemon_embedding_worker_test.go
+++ b/cmd/docbank/daemon_embedding_worker_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media"
+	"go.kenn.io/docbank/document/openaiembed"
+	"go.kenn.io/docbank/document/voyage"
+	"go.kenn.io/docbank/document/voyage/voyagetest"
+	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/processing"
+)
+
+func TestStartEmbeddingWorkerIfReadySkipsMissingBindings(t *testing.T) {
+	starter := &fakeEmbeddingJobStarter{}
+	built := false
+	err := startEmbeddingWorkerIfReady(starter, embeddingReady(false), func() (embeddingJobRunner, error) {
+		built = true
+		return embeddingRunnerFunc(func(context.Context) error { return nil }), nil
+	})
+	require.NoError(t, err)
+	assert.False(t, built)
+	assert.Empty(t, starter.name)
+}
+
+func TestStartEmbeddingWorkerIfReadyUsesSupervisorCancellation(t *testing.T) {
+	starter := &fakeEmbeddingJobStarter{}
+	err := startEmbeddingWorkerIfReady(starter, embeddingReady(true), func() (embeddingJobRunner, error) {
+		return embeddingRunnerFunc(func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}), nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "process:embeddings", starter.name)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.ErrorIs(t, starter.run(ctx), context.Canceled)
+
+	want := errors.New("synthetic configuration failure")
+	err = startEmbeddingWorkerIfReady(&fakeEmbeddingJobStarter{}, embeddingReady(true), func() (embeddingJobRunner, error) {
+		return nil, want
+	})
+	require.ErrorIs(t, err, want)
+}
+
+func TestConfigureEmbeddingRuntimesRegistersSyntheticLoopbackOpenAI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(server.Close)
+	t.Setenv("DOCBANK_TEST_EMBEDDING_KEY", "synthetic-secret")
+	cfg := config.Default()
+	cfg.CredentialBindings["semantic"] = config.CredentialBindingConfig{EnvironmentVariable: "DOCBANK_TEST_EMBEDDING_KEY"}
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic})
+	require.NoError(t, err)
+	profile := config.EmbeddingProfileConfig{
+		Activation: string(document.EmbeddingRequired), AuthorizationFingerprint: strings.Repeat("1", 64),
+		CompatibilityID: contract.CompatibilityID, CredentialBinding: "credential:semantic",
+		DescriptorID: openaiembed.ProviderID, Dimensions: 2, DisclosureFingerprint: strings.Repeat("2", 64),
+		DocumentFormatter: openaiembed.DocumentFormatterV1, InputKind: string(document.EmbeddingInputRenditionChunk),
+		MaxInputTokens: 128, MaxBatchItems: 8, MaxInputBytes: 1 << 20, MaxResponseBytes: 1 << 20,
+		Metric: document.VectorMetricCosine, Model: "synthetic-model", Normalization: document.VectorNormalizationNone,
+		QueryFormatter: openaiembed.QueryFormatterV1, ScalarEncoding: openaiembed.ScalarEncodingFloat32,
+		TrustBoundary: string(document.EmbeddingTrustOperatorNetwork),
+		Chunk: config.EmbeddingChunkConfig{ContextFingerprint: strings.Repeat("3", 64), Formatter: "synthetic/v1",
+			MaxTokens: 128, OverlapTokens: 8, Tokenizer: "synthetic", TokenizerRevision: "v1", TruncationPolicy: string(document.TruncationPolicyReject)},
+		ModelInput: config.EmbeddingModelInputConfig{Profile: string(document.ModelInputProfileNomic)},
+		Runtime: &config.EmbeddingRuntimeConfig{AdapterContract: openAIEmbeddingAdapter, Endpoint: server.URL,
+			ModelRevision: "deployment-v1", DeploymentEpoch: "deployment-v1", RequestTimeout: config.Duration(time.Second),
+			MaxRequestBytes: 1 << 20, AllowedCIDRs: []string{"127.0.0.0/8"}, ProxyMode: "disabled",
+			ConnectTimeout: config.Duration(time.Second), KeepAlive: config.Duration(time.Second),
+			TLSHandshakeTimeout: config.Duration(time.Second)},
+	}
+	descriptor := configuredEmbeddingDescriptor(profile, contract)
+	final, _, err := finalizeOpenAIEmbeddingDescriptor(openaiembed.Profile{Origin: server.URL, Descriptor: descriptor,
+		ModelInput: contract, SecretBinding: profile.CredentialBinding, DeploymentEpoch: profile.Runtime.DeploymentEpoch,
+		RequestTimeout: profile.Runtime.RequestTimeout.Std(), MaxBatchItems: profile.MaxBatchItems,
+		MaxInputBytes: profile.MaxInputBytes, MaxRequestBytes: profile.Runtime.MaxRequestBytes,
+		MaxResponseBytes: profile.MaxResponseBytes, EgressPolicy: configuredEmbeddingEgress(*profile.Runtime)})
+	require.NoError(t, err)
+	profile.DescriptorFingerprint = final.Fingerprint
+	cfg.EmbeddingProfiles["semantic"] = profile
+	require.NoError(t, cfg.Validate())
+
+	duplicate := profile
+	duplicate.Chunk.MaxTokens = 64
+	cfg.EmbeddingProfiles["alternate-chunks"] = duplicate
+	require.NoError(t, cfg.Validate())
+	t.Setenv("DOCBANK_TEST_EMBEDDING_KEY", "")
+	registry, err := configureEmbeddingRuntimes(cfg, unavailableEmbeddingBlobs{}, t.TempDir())
+	require.NoError(t, err)
+	assert.True(t, registry.Ready())
+	assert.Equal(t, []string{final.Fingerprint}, registry.Fingerprints())
+	classification, _ := classifyOpenAIEmbeddingError(fmt.Errorf("%w: local request envelope", openaiembed.ErrCapacityResponse))
+	assert.Equal(t, processing.EmbeddingProviderCapacity, classification)
+}
+
+func TestConfigureEmbeddingRuntimesRegistersCapabilityAttestedVoyageOriginal(t *testing.T) {
+	t.Setenv("DOCBANK_TEST_VOYAGE_KEY", "synthetic-secret")
+	policy, err := voyage.NewPolicy(voyage.PolicyConfig{Model: voyage.DefaultModel, Dimension: voyage.DefaultDimension,
+		Media: media.Policy{MaxBytes: 1 << 20, AllowStill: true, AllowVideo: true}, MaxBatchItems: 8,
+		MaxRequestBytes: 1 << 20, MaxResponseBytes: 1 << 20})
+	require.NoError(t, err)
+	manifest, err := voyagetest.SyntheticManifest(policy, voyage.CapabilityImagePNG)
+	require.NoError(t, err)
+	var encoded bytes.Buffer
+	require.NoError(t, voyage.EncodeCapabilityManifest(&encoded, manifest))
+	manifestPath := filepath.Join(t.TempDir(), "voyage-capabilities.json")
+	require.NoError(t, os.WriteFile(manifestPath, encoded.Bytes(), 0o600))
+	revision, err := voyage.DirectFileModelRevision(policy, manifest)
+	require.NoError(t, err)
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfileCustom, CompatibilityID: "voyage/synthetic-direct/v1",
+		Document: document.ModelInputEncoder{Mode: document.ModelInputModeDocument, Template: "document: {{content}}"},
+		Query:    document.ModelInputEncoder{Mode: document.ModelInputModeQuery, Template: "query: {{content}}"},
+	})
+	require.NoError(t, err)
+	profile := config.EmbeddingProfileConfig{
+		Activation: string(document.EmbeddingRequired), AuthorizationFingerprint: strings.Repeat("1", 64),
+		CompatibilityID: contract.CompatibilityID, CredentialBinding: "credential:voyage",
+		DescriptorID: voyage.EmbeddingProviderID, Dimensions: voyage.DefaultDimension,
+		DisclosureFingerprint: strings.Repeat("2", 64), DocumentFormatter: voyage.EmbeddingDocumentFormatterV1,
+		InputKind: string(document.EmbeddingInputOriginalFile), MaxBatchItems: 8, MaxInputBytes: 1 << 20,
+		MaxResponseBytes: 1 << 20, Metric: document.VectorMetricCosine, Model: voyage.DefaultModel,
+		Normalization: document.VectorNormalizationUnitLength, QueryFormatter: voyage.EmbeddingQueryFormatterV1,
+		ScalarEncoding: voyage.EmbeddingScalarFloat32, TrustBoundary: string(document.EmbeddingTrustHostedProvider),
+		ModelInput: config.EmbeddingModelInputConfig{Profile: string(document.ModelInputProfileCustom),
+			CompatibilityID: contract.CompatibilityID,
+			Document:        config.EmbeddingModelInputEncoderConfig{Mode: string(document.ModelInputModeDocument), Template: "document: {{content}}"},
+			Query:           config.EmbeddingModelInputEncoderConfig{Mode: string(document.ModelInputModeQuery), Template: "query: {{content}}"}},
+		Runtime: &config.EmbeddingRuntimeConfig{AdapterContract: voyageEmbeddingAdapter, Endpoint: voyage.DefaultEndpoint,
+			ModelRevision: revision, CapabilityManifest: manifestPath, RequestTimeout: config.Duration(time.Second),
+			MaxRequestBytes: 1 << 20, AllowedCIDRs: []string{"0.0.0.0/0", "::/0"}, ProxyMode: "disabled",
+			ConnectTimeout: config.Duration(time.Second), KeepAlive: config.Duration(time.Second),
+			TLSHandshakeTimeout: config.Duration(time.Second)},
+	}
+	secrets := environmentEmbeddingSecrets{variables: map[string]string{"credential:voyage": "DOCBANK_TEST_VOYAGE_KEY"}}
+	_, final, err := configuredVoyageProvider(profile, contract, secrets)
+	require.NoError(t, err)
+	profile.DescriptorFingerprint = final.Fingerprint
+	cfg := config.Default()
+	cfg.CredentialBindings["voyage"] = config.CredentialBindingConfig{EnvironmentVariable: "DOCBANK_TEST_VOYAGE_KEY"}
+	cfg.EmbeddingProfiles["voyage"] = profile
+	require.NoError(t, cfg.Validate())
+
+	registry, err := configureEmbeddingRuntimes(cfg, unavailableEmbeddingBlobs{}, t.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, []string{final.Fingerprint}, registry.Fingerprints())
+}
+
+func TestRecoverEmbeddingRuntimeSpoolRemovesOnlyAbandonedUploadState(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, ".docbank-upload-synthetic")
+	require.NoError(t, os.Mkdir(stale, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(stale, "source"), []byte("partial"), 0o600))
+	unrelated := filepath.Join(root, "blob-partial")
+	require.NoError(t, os.WriteFile(unrelated, []byte("keep"), 0o600))
+
+	require.NoError(t, recoverEmbeddingRuntimeSpool(t.Context(), root))
+	_, err := os.Stat(stale)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(unrelated)
+	require.NoError(t, err)
+}
+
+type unavailableEmbeddingBlobs struct{}
+
+func (unavailableEmbeddingBlobs) OpenContext(context.Context, string) (io.ReadSeekCloser, error) {
+	return nil, errors.New("unexpected blob read")
+}
+
+type embeddingReady bool
+
+func (ready embeddingReady) Ready() bool { return bool(ready) }
+
+type fakeEmbeddingJobStarter struct {
+	name string
+	run  func(context.Context) error
+}
+
+func (starter *fakeEmbeddingJobStarter) Start(name string, run func(context.Context) error) error {
+	starter.name, starter.run = name, run
+	return nil
+}
+
+type embeddingRunnerFunc func(context.Context) error
+
+func (run embeddingRunnerFunc) Run(ctx context.Context) error { return run(ctx) }
+
+func TestEmbeddingRuntimeClassifiesAuthorizationFailures(t *testing.T) {
+	for _, err := range []error{openaiembed.ErrUnauthorized, &openaiembed.ProviderError{Kind: openaiembed.ErrUnauthorized, StatusCode: http.StatusUnauthorized}} {
+		classification, _ := classifyOpenAIEmbeddingError(err)
+		require.Equal(t, processing.EmbeddingProviderAuthorization, classification)
+	}
+	for _, err := range []error{voyage.ErrUnauthorized, &voyage.ProviderError{Kind: voyage.ErrUnauthorized, StatusCode: http.StatusForbidden}} {
+		classification, _ := classifyVoyageEmbeddingError(err)
+		require.Equal(t, processing.EmbeddingProviderAuthorization, classification)
+	}
+}
+
+func TestEmbeddingRuntimeClassifiesMalformedOpenAIResponses(t *testing.T) {
+	for _, err := range []error{openaiembed.ErrMalformedResponse, fmt.Errorf("schema mismatch: %w", openaiembed.ErrMalformedResponse)} {
+		classification, delay := classifyOpenAIEmbeddingError(err)
+		require.Equal(t, processing.EmbeddingProviderInvalidResponse, classification)
+		require.Zero(t, delay)
+	}
+}
+
+func TestEmbeddingRuntimeClassifiesMalformedVoyageResponses(t *testing.T) {
+	for _, err := range []error{voyage.ErrMalformedResponse, &voyage.ProviderError{Kind: voyage.ErrMalformedResponse}} {
+		kind, delay := classifyVoyageEmbeddingError(err)
+		require.Equal(t, processing.EmbeddingProviderInvalidResponse, kind)
+		require.Zero(t, delay)
+	}
+}

--- a/cmd/docbank/embedding_runtime.go
+++ b/cmd/docbank/embedding_runtime.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media"
+	"go.kenn.io/docbank/document/openaiembed"
+	"go.kenn.io/docbank/document/providerhttp"
+	"go.kenn.io/docbank/document/upload"
+	"go.kenn.io/docbank/document/voyage"
+	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/processing"
+)
+
+const (
+	openAIEmbeddingAdapter = "docbank-openai-compatible-embeddings/v1"
+	voyageEmbeddingAdapter = "docbank-voyage-embeddings/v1"
+)
+
+func recoverEmbeddingRuntimeSpool(ctx context.Context, spoolDirectory string) error {
+	_, err := upload.RecoverStale(ctx, spoolDirectory)
+	return err
+}
+
+type environmentEmbeddingSecrets struct{ variables map[string]string }
+
+func (resolver environmentEmbeddingSecrets) ResolveSecret(_ context.Context, name string) (string, error) {
+	variable, ok := resolver.variables[name]
+	if !ok {
+		return "", errors.New("embedding credential binding is unavailable")
+	}
+	value, ok := os.LookupEnv(variable)
+	if !ok || value == "" {
+		return "", errors.New("embedding credential environment variable is unavailable")
+	}
+	return value, nil
+}
+
+func configureEmbeddingRuntimes(cfg config.Config, blobs embeddingRuntimeBlobStore,
+	spoolDirectory string,
+) (*processing.EmbeddingRuntimeRegistry, error) {
+	registry := processing.NewEmbeddingRuntimeRegistry()
+	registered := make(map[string]struct{})
+	secrets := environmentEmbeddingSecrets{variables: make(map[string]string)}
+	for name, binding := range cfg.CredentialBindings {
+		portable := "credential:" + name
+		secrets.variables[portable] = binding.EnvironmentVariable
+	}
+	for name, configured := range cfg.EmbeddingProfiles {
+		if configured.Runtime == nil {
+			continue
+		}
+		_, ok := secrets.variables[configured.CredentialBinding]
+		if !ok {
+			return nil, fmt.Errorf("embedding credential %q is not configured", configured.CredentialBinding)
+		}
+		modelInput, err := cfg.EmbeddingModelInput(name)
+		if err != nil {
+			return nil, err
+		}
+		descriptor := configuredEmbeddingDescriptor(configured, modelInput)
+		var provider document.EmbeddingProvider
+		var classify func(error) (processing.EmbeddingProviderFailure, time.Duration)
+		switch configured.Runtime.AdapterContract {
+		case openAIEmbeddingAdapter:
+			profile := openaiembed.Profile{Origin: configured.Runtime.Endpoint, Descriptor: descriptor,
+				ModelInput: modelInput, SecretBinding: configured.CredentialBinding,
+				DeploymentEpoch:        configured.Runtime.DeploymentEpoch,
+				ProviderRevisionHeader: configured.Runtime.ProviderRevisionHeader,
+				RequestTimeout:         configured.Runtime.RequestTimeout.Std(), MaxBatchItems: configured.MaxBatchItems,
+				MaxInputBytes: configured.MaxInputBytes, MaxRequestBytes: configured.Runtime.MaxRequestBytes,
+				MaxResponseBytes: configured.MaxResponseBytes,
+				EgressPolicy:     configuredEmbeddingEgress(*configured.Runtime)}
+			descriptor, profile, err = finalizeOpenAIEmbeddingDescriptor(profile)
+			if err == nil {
+				profile.Descriptor = descriptor
+				provider, err = openaiembed.New(profile, secrets, &http.Client{})
+			}
+			classify = classifyOpenAIEmbeddingError
+		case voyageEmbeddingAdapter:
+			provider, descriptor, err = configuredVoyageProvider(configured, modelInput, secrets)
+			classify = classifyVoyageEmbeddingError
+		default:
+			err = errors.New("unsupported embedding runtime adapter")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("configuring embedding runtime %q: %w", name, err)
+		}
+		if descriptor.Fingerprint != configured.DescriptorFingerprint ||
+			descriptor.ID != configured.DescriptorID || descriptor.ModelRevision != configured.Runtime.ModelRevision {
+			return nil, fmt.Errorf("configuring embedding runtime %q: descriptor differs from portable binding", name)
+		}
+		// Every profile is validated above, including its complete provider policy.
+		// Chunking and activation may differ without requiring another provider.
+		if _, exists := registered[descriptor.Fingerprint]; exists {
+			continue
+		}
+		runtime, err := processing.NewProviderEmbeddingRuntime(provider, blobs, spoolDirectory, classify)
+		if err != nil {
+			return nil, err
+		}
+		if err := registry.Register(descriptor.Fingerprint, runtime); err != nil {
+			return nil, err
+		}
+		registered[descriptor.Fingerprint] = struct{}{}
+	}
+	return registry, nil
+}
+
+type embeddingRuntimeBlobStore interface {
+	OpenContext(ctx context.Context, hash string) (io.ReadSeekCloser, error)
+}
+
+func configuredEmbeddingDescriptor(profile config.EmbeddingProfileConfig, modelInput document.ModelInputContract) document.EmbeddingDescriptor {
+	runtime := profile.Runtime
+	modes := []document.ModelInputMode{modelInput.Document.Mode}
+	supportsQuery := runtime.AdapterContract == openAIEmbeddingAdapter
+	if supportsQuery && modelInput.Query.Mode != modelInput.Document.Mode {
+		modes = append(modes, modelInput.Query.Mode)
+	}
+	return document.EmbeddingDescriptor{ID: profile.DescriptorID,
+		ContractVersion: document.EmbeddingProviderContractVersion, PolicyFingerprint: strings.Repeat("0", 64),
+		TrustBoundary: document.EmbeddingTrustBoundary(profile.TrustBoundary), Model: profile.Model,
+		ModelRevision: runtime.ModelRevision, Dimension: profile.Dimensions, Metric: profile.Metric,
+		Normalization: profile.Normalization, ScalarEncoding: profile.ScalarEncoding,
+		DocumentFormatter: profile.DocumentFormatter, QueryFormatter: profile.QueryFormatter,
+		InputKinds:      []document.EmbeddingInputKind{document.EmbeddingInputKind(profile.InputKind)},
+		CompatibilityID: profile.CompatibilityID, SupportsTextQuery: supportsQuery,
+		ModelInput: modelInput, SupportedRequestModes: modes}
+}
+
+func finalizeOpenAIEmbeddingDescriptor(profile openaiembed.Profile) (document.EmbeddingDescriptor, openaiembed.Profile, error) {
+	temporary, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	if err != nil {
+		return document.EmbeddingDescriptor{}, profile, err
+	}
+	profile.Descriptor = temporary
+	fingerprint, err := openaiembed.PolicyFingerprint(profile)
+	if err != nil {
+		return document.EmbeddingDescriptor{}, profile, err
+	}
+	temporary.PolicyFingerprint, temporary.Fingerprint = fingerprint, ""
+	final, err := document.NewEmbeddingDescriptor(temporary)
+	return final, profile, err
+}
+
+func configuredVoyageProvider(profile config.EmbeddingProfileConfig, modelInput document.ModelInputContract,
+	secrets environmentEmbeddingSecrets,
+) (document.EmbeddingProvider, document.EmbeddingDescriptor, error) {
+	file, err := os.Open(profile.Runtime.CapabilityManifest)
+	if err != nil {
+		return nil, document.EmbeddingDescriptor{}, errors.New("voyage capability manifest is unavailable")
+	}
+	manifest, decodeErr := voyage.DecodeCapabilityManifest(file)
+	closeErr := file.Close()
+	if decodeErr != nil || closeErr != nil {
+		return nil, document.EmbeddingDescriptor{}, errors.Join(decodeErr, closeErr)
+	}
+	policy, err := voyage.NewPolicy(voyage.PolicyConfig{Model: profile.Model, Dimension: profile.Dimensions,
+		Media:         media.Policy{MaxBytes: profile.MaxInputBytes, AllowStill: true, AllowVideo: true},
+		MaxBatchItems: profile.MaxBatchItems, MaxRequestBytes: profile.Runtime.MaxRequestBytes,
+		MaxResponseBytes: profile.MaxResponseBytes})
+	if err != nil {
+		return nil, document.EmbeddingDescriptor{}, err
+	}
+	descriptor := configuredEmbeddingDescriptor(profile, modelInput)
+	configured := voyage.EmbeddingProfile{Mode: voyage.EmbeddingModeDirectFile,
+		Endpoint: profile.Runtime.Endpoint, EgressPolicy: configuredEmbeddingEgress(*profile.Runtime),
+		Descriptor: descriptor, ModelInput: modelInput, SecretBinding: profile.CredentialBinding,
+		RequestTimeout: profile.Runtime.RequestTimeout.Std(), MaxRetries: 1,
+		MaxBatchItems: profile.MaxBatchItems, MaxInputBytes: profile.MaxInputBytes,
+		MaxRequestBytes: profile.Runtime.MaxRequestBytes, MaxResponseBytes: profile.MaxResponseBytes,
+		Policy: policy, CapabilityManifest: manifest}
+	temporary, err := document.NewEmbeddingDescriptor(descriptor)
+	if err != nil {
+		return nil, document.EmbeddingDescriptor{}, err
+	}
+	configured.Descriptor = temporary
+	fingerprint, err := voyage.EmbeddingPolicyFingerprint(configured)
+	if err != nil {
+		return nil, document.EmbeddingDescriptor{}, err
+	}
+	temporary.PolicyFingerprint, temporary.Fingerprint = fingerprint, ""
+	final, err := document.NewEmbeddingDescriptor(temporary)
+	if err != nil {
+		return nil, document.EmbeddingDescriptor{}, err
+	}
+	configured.Descriptor = final
+	provider, err := voyage.NewEmbeddingProvider(configured, secrets, nil)
+	return provider, final, err
+}
+
+func configuredEmbeddingEgress(runtime config.EmbeddingRuntimeConfig) providerhttp.EgressPolicy {
+	parsed, _ := url.Parse(runtime.Endpoint)
+	port := uint16(443)
+	if parsed.Scheme == "http" {
+		port = 80
+	}
+	if parsed.Port() != "" {
+		value, _ := strconv.ParseUint(parsed.Port(), 10, 16)
+		port = uint16(value)
+	}
+	prefixes := make([]netip.Prefix, 0, len(runtime.AllowedCIDRs))
+	for _, value := range runtime.AllowedCIDRs {
+		prefix, _ := netip.ParsePrefix(value)
+		prefixes = append(prefixes, prefix)
+	}
+	return providerhttp.EgressPolicy{Scheme: parsed.Scheme, Host: parsed.Hostname(), Port: port,
+		AllowedCIDRs: prefixes, ProxyMode: providerhttp.ProxyDisabled,
+		ConnectTimeout: runtime.ConnectTimeout.Std(), KeepAlive: runtime.KeepAlive.Std(),
+		TLSHandshakeTimeout: runtime.TLSHandshakeTimeout.Std(),
+		TLS:                 providerhttp.TLSPolicy{SPKISHA256: runtime.SPKISHA256}}
+}
+
+func classifyOpenAIEmbeddingError(err error) (processing.EmbeddingProviderFailure, time.Duration) {
+	if errors.Is(err, openaiembed.ErrMalformedResponse) {
+		return processing.EmbeddingProviderInvalidResponse, 0
+	}
+	if errors.Is(err, openaiembed.ErrUnauthorized) {
+		return processing.EmbeddingProviderAuthorization, 0
+	}
+	if errors.Is(err, openaiembed.ErrCapacityResponse) {
+		return processing.EmbeddingProviderCapacity, 0
+	}
+	if errors.Is(err, openaiembed.ErrTransientResponse) {
+		delay, _ := openaiembed.RetryAfter(err)
+		return processing.EmbeddingProviderTransient, delay
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return processing.EmbeddingProviderTransient, 0
+	}
+	return processing.EmbeddingProviderPermanent, 0
+}
+
+func classifyVoyageEmbeddingError(err error) (processing.EmbeddingProviderFailure, time.Duration) {
+	if errors.Is(err, voyage.ErrUnauthorized) {
+		return processing.EmbeddingProviderAuthorization, 0
+	}
+	if errors.Is(err, voyage.ErrBatchTooLarge) {
+		return processing.EmbeddingProviderCapacity, 0
+	}
+	if errors.Is(err, voyage.ErrMalformedResponse) {
+		return processing.EmbeddingProviderInvalidResponse, 0
+	}
+	if voyage.IsRetryable(err) {
+		delay, _ := voyage.RetryAfter(err)
+		return processing.EmbeddingProviderTransient, delay
+	}
+	return processing.EmbeddingProviderPermanent, 0
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,8 @@ to serialize daemon launch before the launcher owns or creates the vault root.
 
 `$DOCBANK_HOME/config.toml` is read once, at daemon startup (`docbank
 daemon run` / `daemon start`). It's optional. There are no general per-field
-environment overrides; the only environment knob remains `DOCBANK_HOME`.
+environment overrides. `DOCBANK_HOME` selects the vault, and named credential
+bindings can read explicitly configured environment variables.
 Backup commands can override their configured repository with `--repo`. An
 unrecognized key is treated as a typo and rejected at startup rather than
 silently ignored.
@@ -239,6 +240,86 @@ watch name, relative path, stable node mapping, and last accepted content
 identity are preserved in portable metadata. The watcher does not pack content
 itself. Configure `[storage] pack_interval` when accumulated loose content
 should be packed automatically; GC and repack remain explicit.
+
+### Embedding workers and credentials
+
+The daemon executes retained embedding work for configured providers. Each
+binding publishes independently: a failed provider does not remove another
+binding's completed vectors. Configuring a provider does not create input
+generations or apply a processing profile to newly imported documents. Work
+requires an existing input generation, a matching processing profile and
+provider descriptor, and current disclosure consent. After restore, the daemon
+recreates jobs from retained inputs once those requirements are met again.
+
+`[processing_profiles.<name>]` selects embedding bindings by name in its
+`embeddings` array. `[embedding_profiles.<name>]` defines each binding's model,
+input kind, dimensions, formatters, compatibility identity, descriptor and
+disclosure fingerprints, byte limits, and `optional` or `required` activation.
+Chunk bindings also pin their tokenizer and chunk policy in `.chunk`. Use the
+fingerprints from the exact provisioned profile and deployment; arbitrary
+fingerprints or an endpoint's model alias do not establish compatibility.
+
+Credentials are referenced by name, never stored as values in a processing
+profile. This fragment connects an existing `semantic` binding to a secret in
+the daemon's environment:
+
+```toml
+[credential_bindings.embedding-primary]
+environment_variable = "DOCBANK_EMBEDDING_PRIMARY_KEY"
+
+[embedding_profiles.semantic]
+credential_binding = "credential:embedding-primary"
+# The remaining pinned profile fields are also required.
+```
+
+A missing or empty secret does not prevent daemon startup or ordinary document
+operations. Affected embedding jobs record an authorization failure and remain
+eligible for recovery. Secrets are resolved for each request from the running
+daemon's environment. Exporting a variable in another shell does not update
+that environment: set the variable for the daemon and restart it. An undefined
+credential binding, invalid runtime configuration, or mismatched descriptor
+still fails startup.
+
+#### Runtime settings
+
+An optional `[embedding_profiles.<name>.runtime]` section makes a binding
+executable on this machine. Without it, the daemon does not claim that binding's
+work. Runtime configuration and environment-variable mappings are machine-local
+and must be supplied separately after restoring a vault.
+
+| Fields | Meaning |
+| --- | --- |
+| `adapter_contract` | `docbank-openai-compatible-embeddings/v1` for rendition chunks, or `docbank-voyage-embeddings/v1` for original files. |
+| `endpoint`, `model_revision` | Exact provider endpoint and pinned revision. OpenAI-compatible endpoints are origins without a path; Voyage uses `https://api.voyageai.com/v1`. |
+| `deployment_epoch`, `provider_revision_header` | OpenAI-compatible runtimes require exactly one. The epoch must equal `model_revision`; a revision header must echo the pinned revision in every response. |
+| `capability_manifest` | Voyage requires an absolute path to a capability manifest matching its model, media policy, and descriptor. |
+| `request_timeout`, `max_request_bytes` | Bound each provider request. The profile's `max_batch_items`, `max_input_bytes`, and `max_response_bytes` supply the other request/response limits. |
+| `allowed_cidrs`, `spki_sha256`, `proxy_mode` | Explicit destination CIDRs, optional TLS public-key pins, and `proxy_mode = "disabled"`. The provider connection enforces this policy. |
+| `connect_timeout`, `keep_alive`, `tls_handshake_timeout` | Required positive transport durations, each at most five minutes. |
+
+Request timeouts must also be positive and at most five minutes. Retry policy
+belongs to the worker, so runtime configuration has no retry-count or retry-delay
+fields. The worker handles transient failures and capacity-driven batch splits;
+malformed responses are recorded separately from rejected document input.
+
+#### Model input
+
+`[embedding_profiles.<name>.model_input]` pins how document and query inputs are
+formatted. Its `profile` selects a named contract such as `nomic/v1`, `bge-m3/v1`,
+`e5/v1`, or `gte/v1`; it is not an arbitrary provider model name. The resulting
+contract must match the binding's `compatibility_id` and provider descriptor.
+For `custom/v1`, supply `compatibility_id` and explicit `.document` and `.query`
+encoders, each with `mode` and `template`. Templates use `{{content}}`; contract
+validation checks the supported roles and formatting rules. `query_instruction`
+is available only to contracts that support it.
+
+Discovery uses bounded pages and waits one minute between complete passes.
+Existing queued work is still checked on the normal one-second idle cadence.
+Missing or invalid generation bytes are skipped during discovery so later
+candidates can proceed; a later pass retries discovery. Database failures retain
+their separate bounded storage-retry behavior. Terminal jobs do not retain
+superseded generations after their last embedding set is collected, while
+queued/running jobs and explicit retention roots keep their inputs.
 
 ### Store bindings
 

--- a/document/embedding.go
+++ b/document/embedding.go
@@ -249,6 +249,10 @@ func ValidateEmbeddingProviderResult(descriptor EmbeddingDescriptor, inputs []Em
 	return nil
 }
 
+// ErrEmbeddingInvalidResult identifies a provider result or consumed source that
+// does not match the authorized request.
+var ErrEmbeddingInvalidResult = errors.New("embedding result does not match authorized input")
+
 // ExecuteEmbedding is the validated execution entry point for core callers.
 // It takes ownership of original-file uploads and closes them before returning.
 // The provider receives its own copy of the validated inputs; the result is
@@ -312,12 +316,12 @@ func ExecuteEmbedding(
 		return EmbeddingResult{}, err
 	}
 	if err := ValidateEmbeddingProviderResult(descriptor, authorized, authorization, result); err != nil {
-		return EmbeddingResult{}, err
+		return EmbeddingResult{}, errors.Join(ErrEmbeddingInvalidResult, err)
 	}
 	result = cloneEmbeddingResult(result)
 	for _, upload := range sealedUploads {
 		if err := upload.verify(ctx); err != nil {
-			return EmbeddingResult{}, err
+			return EmbeddingResult{}, errors.Join(ErrEmbeddingInvalidResult, err)
 		}
 	}
 	return result, nil

--- a/document/openaiembed/client.go
+++ b/document/openaiembed/client.go
@@ -81,6 +81,34 @@ type Profile struct {
 	MaxInputBytes          int64
 	MaxRequestBytes        int64
 	MaxResponseBytes       int64
+	EgressPolicy           providerhttp.EgressPolicy
+}
+
+var (
+	ErrMalformedResponse = errors.New("openaiembed: malformed provider response")
+	ErrUnauthorized      = errors.New("openaiembed: credential is unavailable or unauthorized")
+	ErrTransientResponse = errors.New("openaiembed: transient provider response")
+	ErrCapacityResponse  = errors.New("openaiembed: provider capacity exceeded")
+	ErrPermanentResponse = errors.New("openaiembed: permanent provider response")
+)
+
+type ProviderError struct {
+	Kind       error
+	StatusCode int
+	RetryDelay time.Duration
+	RetrySet   bool
+}
+
+func (err *ProviderError) Error() string {
+	return fmt.Sprintf("openaiembed: HTTP %d: %v", err.StatusCode, err.Kind)
+}
+func (err *ProviderError) Unwrap() error { return err.Kind }
+func RetryAfter(err error) (time.Duration, bool) {
+	providerErr, ok := errors.AsType[*ProviderError](err)
+	if !ok || !providerErr.RetrySet {
+		return 0, false
+	}
+	return providerErr.RetryDelay, true
 }
 
 type policyIdentity struct {
@@ -97,6 +125,19 @@ type policyIdentity struct {
 	MaxInputBytes          int64                        `json:"max_input_bytes"`
 	MaxRequestBytes        int64                        `json:"max_request_bytes"`
 	MaxResponseBytes       int64                        `json:"max_response_bytes"`
+	Egress                 *openAIEgressIdentity        `json:"egress,omitempty"`
+}
+
+type openAIEgressIdentity struct {
+	Scheme              string   `json:"scheme"`
+	Host                string   `json:"host"`
+	Port                uint16   `json:"port"`
+	AllowedCIDRs        []string `json:"allowed_cidrs"`
+	ProxyMode           string   `json:"proxy_mode"`
+	ConnectTimeout      int64    `json:"connect_timeout_nanos"`
+	KeepAlive           int64    `json:"keep_alive_nanos"`
+	TLSHandshakeTimeout int64    `json:"tls_handshake_timeout_nanos"`
+	SPKISHA256          []string `json:"spki_sha256,omitempty"`
 }
 
 // Client calls exactly POST /v1/embeddings on the profile origin.
@@ -146,6 +187,7 @@ func PolicyFingerprint(profile Profile) (string, error) {
 		RequestTimeoutNanos:    int64(normalized.RequestTimeout), MaxBatchItems: normalized.MaxBatchItems,
 		MaxInputBytes: normalized.MaxInputBytes, MaxRequestBytes: normalized.MaxRequestBytes,
 		MaxResponseBytes: normalized.MaxResponseBytes,
+		Egress:           openAIEgressPolicyIdentity(normalized.EgressPolicy),
 	}
 	encoded, err := json.Marshal(identity, json.Deterministic(true))
 	if err != nil {
@@ -156,7 +198,8 @@ func PolicyFingerprint(profile Profile) (string, error) {
 }
 
 // New validates an immutable profile and isolates the supplied HTTP client
-// from ambient cookies, timeouts, and redirect behavior. It performs no I/O.
+// from ambient cookies, timeouts, and redirect behavior. A configured egress
+// policy owns the transport and replaces any supplied transport. It performs no I/O.
 func New(profile Profile, secrets SecretResolver, httpClient *http.Client) (*Client, error) {
 	normalized, _, err := normalizeProfile(profile)
 	if err != nil {
@@ -187,6 +230,13 @@ func New(profile Profile, secrets SecretResolver, httpClient *http.Client) (*Cli
 		return nil, errors.New("openaiembed: HTTP client is required")
 	}
 	isolate := *httpClient
+	if normalized.EgressPolicy.Scheme != "" {
+		transport, err := providerhttp.NewTransport(normalized.EgressPolicy, nil)
+		if err != nil {
+			return nil, err
+		}
+		isolate.Transport = transport
+	}
 	isolate.CheckRedirect = providerhttp.RefuseRedirects
 	isolate.Jar = nil
 	isolate.Timeout = 0
@@ -244,7 +294,7 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 		return document.EmbeddingResult{}, errors.New("openaiembed: could not encode embedding request")
 	}
 	if int64(len(payload)) > client.profile.MaxRequestBytes {
-		return document.EmbeddingResult{}, errors.New("openaiembed: embedding request byte limit exceeded")
+		return document.EmbeddingResult{}, fmt.Errorf("%w: embedding request byte limit exceeded", ErrCapacityResponse)
 	}
 
 	requestCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
@@ -261,10 +311,10 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 			if contextErr := requestCtx.Err(); contextErr != nil {
 				return document.EmbeddingResult{}, fmt.Errorf("openaiembed: credential resolution canceled: %w", contextErr)
 			}
-			return document.EmbeddingResult{}, errors.New("openaiembed: could not resolve credential")
+			return document.EmbeddingResult{}, ErrUnauthorized
 		}
 		if !validSecret(secret) {
-			return document.EmbeddingResult{}, errors.New("openaiembed: resolved credential is invalid")
+			return document.EmbeddingResult{}, ErrUnauthorized
 		}
 		request.Header.Set("Authorization", "Bearer "+secret)
 	}
@@ -274,20 +324,32 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 		if contextErr := requestCtx.Err(); contextErr != nil {
 			return document.EmbeddingResult{}, fmt.Errorf("openaiembed: embedding request canceled: %w", contextErr)
 		}
-		return document.EmbeddingResult{}, errors.New("openaiembed: provider request failed")
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrTransientResponse}
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode >= 300 && response.StatusCode < 400 {
-		return document.EmbeddingResult{}, fmt.Errorf("openaiembed: provider redirect refused with HTTP status %d", response.StatusCode)
+		return document.EmbeddingResult{}, fmt.Errorf("openaiembed: provider redirect refused: %w",
+			&ProviderError{Kind: ErrPermanentResponse, StatusCode: response.StatusCode})
+	}
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrUnauthorized, StatusCode: response.StatusCode}
+	}
+	if response.StatusCode == http.StatusRequestEntityTooLarge {
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrCapacityResponse, StatusCode: response.StatusCode}
+	}
+	if response.StatusCode == http.StatusRequestTimeout || response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+		delay, set := openAIRetryAfter(response.Header.Get("Retry-After"), time.Now().UTC())
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrTransientResponse, StatusCode: response.StatusCode,
+			RetryDelay: delay, RetrySet: set}
 	}
 	if response.StatusCode != http.StatusOK {
-		return document.EmbeddingResult{}, fmt.Errorf("openaiembed: provider returned HTTP status %d", response.StatusCode)
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse, StatusCode: response.StatusCode}
 	}
 	if err := validateResponseContentType(response.Header.Get("Content-Type")); err != nil {
-		return document.EmbeddingResult{}, err
+		return document.EmbeddingResult{}, errors.Join(ErrMalformedResponse, err)
 	}
 	if err := client.validateRevisionEcho(response.Header); err != nil {
-		return document.EmbeddingResult{}, err
+		return document.EmbeddingResult{}, errors.Join(ErrMalformedResponse, err)
 	}
 	body, err := readBounded(requestCtx, response.Body, client.profile.MaxResponseBytes)
 	if err != nil {
@@ -295,14 +357,14 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 	}
 	var decoded wireResponse
 	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
-		return document.EmbeddingResult{}, errors.New("openaiembed: provider response does not match the bounded embedding schema")
+		return document.EmbeddingResult{}, fmt.Errorf("openaiembed: provider response does not match the bounded embedding schema: %w", ErrMalformedResponse)
 	}
 	result, err := client.validateAndOrder(decoded, inputs)
 	if err != nil {
-		return document.EmbeddingResult{}, err
+		return document.EmbeddingResult{}, errors.Join(ErrMalformedResponse, err)
 	}
 	if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
-		return document.EmbeddingResult{}, err
+		return document.EmbeddingResult{}, errors.Join(ErrMalformedResponse, err)
 	}
 	return result, nil
 }
@@ -374,6 +436,12 @@ func (client *Client) validateVector(vector []float32) error {
 }
 
 func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, error) {
+	// CertPool does not expose certificate contents for a canonical identity.
+	// A subject-only hash would conflate distinct trust roots.
+	if profile.EgressPolicy.TLS.RootCAs != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("embedding policy does not support custom trust roots")
+	}
+
 	origin, err := validateOrigin(profile.Origin)
 	if err != nil {
 		return Profile{}, document.EmbeddingDescriptor{}, err
@@ -404,6 +472,38 @@ func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, e
 	if profile.SecretBinding != "" && !validIdentityToken(profile.SecretBinding) {
 		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaiembed: secret binding is invalid")
 	}
+	if profile.EgressPolicy.Scheme != "" {
+		if profile.EgressPolicy.ConnectTimeout == 0 {
+			profile.EgressPolicy.ConnectTimeout = providerhttp.DefaultConnectTimeout
+		}
+		if profile.EgressPolicy.KeepAlive == 0 {
+			profile.EgressPolicy.KeepAlive = providerhttp.DefaultKeepAlive
+		}
+		if profile.EgressPolicy.TLSHandshakeTimeout == 0 {
+			profile.EgressPolicy.TLSHandshakeTimeout = providerhttp.DefaultTLSHandshakeTimeout
+		}
+		if profile.EgressPolicy.ProxyMode == "" {
+			profile.EgressPolicy.ProxyMode = providerhttp.ProxyDisabled
+		}
+		if _, err := providerhttp.NewTransport(profile.EgressPolicy, nil); err != nil {
+			return Profile{}, document.EmbeddingDescriptor{}, fmt.Errorf("openaiembed: invalid sealed egress policy: %w", err)
+		}
+		parsed, _ := url.Parse(profile.Origin)
+		port := parsed.Port()
+		if port == "" {
+			if parsed.Scheme == "https" {
+				port = "443"
+			} else {
+				port = "80"
+			}
+		}
+		if profile.EgressPolicy.Scheme != parsed.Scheme || !strings.EqualFold(profile.EgressPolicy.Host, parsed.Hostname()) ||
+			strconv.Itoa(int(profile.EgressPolicy.Port)) != port || profile.EgressPolicy.ProxyMode != providerhttp.ProxyDisabled {
+			return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaiembed: origin and sealed egress authority differ")
+		}
+		slices.SortFunc(profile.EgressPolicy.AllowedCIDRs, func(a, b netip.Prefix) int { return strings.Compare(a.Masked().String(), b.Masked().String()) })
+		slices.Sort(profile.EgressPolicy.TLS.SPKISHA256)
+	}
 
 	descriptorIdentity := profile.Descriptor
 	descriptorIdentity.PolicyFingerprint = strings.Repeat("0", sha256.Size*2)
@@ -428,6 +528,32 @@ func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, e
 		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaiembed: provider revision header is not a canonical safe response header")
 	}
 	return profile, descriptorIdentity, nil
+}
+
+func openAIEgressPolicyIdentity(policy providerhttp.EgressPolicy) *openAIEgressIdentity {
+	if policy.Scheme == "" {
+		return nil
+	}
+	cidrs := make([]string, len(policy.AllowedCIDRs))
+	for index, prefix := range policy.AllowedCIDRs {
+		cidrs[index] = prefix.Masked().String()
+	}
+	return &openAIEgressIdentity{Scheme: policy.Scheme, Host: strings.ToLower(policy.Host), Port: policy.Port,
+		AllowedCIDRs: cidrs, ProxyMode: string(policy.ProxyMode), ConnectTimeout: int64(policy.ConnectTimeout),
+		KeepAlive: int64(policy.KeepAlive), TLSHandshakeTimeout: int64(policy.TLSHandshakeTimeout),
+		SPKISHA256: slices.Clone(policy.TLS.SPKISHA256)}
+}
+
+func openAIRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+		return min(time.Duration(seconds)*time.Second, time.Hour), true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	return min(max(when.Sub(now), 0), time.Hour), true
 }
 
 func validateDescriptorContract(descriptor document.EmbeddingDescriptor, modelInput document.ModelInputContract) error {
@@ -568,10 +694,10 @@ func readBounded(ctx context.Context, reader io.Reader, maximum int64) ([]byte, 
 		if contextErr := ctx.Err(); contextErr != nil {
 			return nil, fmt.Errorf("openaiembed: response read canceled: %w", contextErr)
 		}
-		return nil, errors.New("openaiembed: could not read provider response")
+		return nil, fmt.Errorf("openaiembed: could not read provider response: %w", ErrTransientResponse)
 	}
 	if int64(len(body)) > maximum {
-		return nil, errors.New("openaiembed: provider response byte limit exceeded")
+		return nil, fmt.Errorf("openaiembed: provider response byte limit exceeded: %w", ErrMalformedResponse)
 	}
 	return body, nil
 }

--- a/document/openaiembed/client_test.go
+++ b/document/openaiembed/client_test.go
@@ -2,6 +2,7 @@ package openaiembed
 
 import (
 	"context"
+	"crypto/x509"
 	_ "embed"
 	"encoding/json/v2"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -18,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
 )
 
 //go:embed testdata/success-indexed.json
@@ -222,6 +225,77 @@ func TestProfilePolicyFingerprintCoversEndpointIdentityAndBounds(t *testing.T) {
 	}
 }
 
+func TestProfilePolicyFingerprintCoversExactEgressAuthority(t *testing.T) {
+	base := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
+	base.EgressPolicy = providerhttp.EgressPolicy{
+		Scheme: "http", Host: "127.0.0.1", Port: 11434,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+		ProxyMode:    providerhttp.ProxyDisabled,
+	}
+	want, err := PolicyFingerprint(base)
+	require.NoError(t, err)
+	changed := base
+	changed.EgressPolicy.AllowedCIDRs = []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	got, err := PolicyFingerprint(changed)
+	require.NoError(t, err)
+	assert.NotEqual(t, want, got)
+
+	mismatched := base
+	mismatched.EgressPolicy.Port++
+	_, err = PolicyFingerprint(mismatched)
+	require.ErrorContains(t, err, "origin")
+}
+
+func TestProfileRejectsCustomTrustRoots(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
+	profile.Origin = "https://embedding.example:443"
+	profile.EgressPolicy = providerhttp.EgressPolicy{
+		Scheme: "https", Host: "embedding.example", Port: 443,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("192.0.2.0/24")},
+		ProxyMode:    providerhttp.ProxyDisabled,
+	}
+	_, err := PolicyFingerprint(profile)
+	require.NoError(t, err)
+	profile.EgressPolicy.TLS.RootCAs = x509.NewCertPool()
+	_, err = PolicyFingerprint(profile)
+	require.ErrorContains(t, err, "custom trust roots")
+}
+
+func TestEmbedReturnsClassifiedProviderFailures(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
+	tests := []struct {
+		name      string
+		status    int
+		want      error
+		retry     string
+		wantDelay time.Duration
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized, want: ErrUnauthorized},
+		{name: "forbidden", status: http.StatusForbidden, want: ErrUnauthorized},
+		{name: "capacity", status: http.StatusRequestEntityTooLarge, want: ErrCapacityResponse},
+		{name: "permanent", status: http.StatusBadRequest, want: ErrPermanentResponse},
+		{name: "transient", status: http.StatusServiceUnavailable, want: ErrTransientResponse},
+		{name: "request timeout", status: http.StatusRequestTimeout, want: ErrTransientResponse, retry: "1", wantDelay: time.Second},
+		{name: "retry after", status: http.StatusTooManyRequests, want: ErrTransientResponse, retry: "2", wantDelay: 2 * time.Second},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := newTestClient(t, profile, nil, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				response := jsonResponse(request, testCase.status, []byte(`{"error":"synthetic"}`))
+				if testCase.retry != "" {
+					response.Header.Set("Retry-After", testCase.retry)
+				}
+				return response, nil
+			}))
+			_, err := client.Embed(t.Context(), testInputs()[:1], testAuthorization(profile.Descriptor))
+			require.ErrorIs(t, err, testCase.want)
+			delay, set := RetryAfter(err)
+			assert.Equal(t, testCase.retry != "", set)
+			assert.Equal(t, testCase.wantDelay, delay)
+		})
+	}
+}
+
 func TestEmbedEnforcesProfileAuthorizationAndTextOnlyBoundsBeforeNetwork(t *testing.T) {
 	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
 	profile.MaxBatchItems = 2
@@ -296,7 +370,7 @@ func TestEmbedUsesOptionalNamedBearerSecretWithoutAmbientCookies(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			client = newTestClient(t, profile, testSecrets{"local-embedding-key": secret}, base.Transport)
 			_, err = client.Embed(t.Context(), testInputs(), testAuthorization(profile.Descriptor))
-			require.ErrorContains(t, err, "credential")
+			require.ErrorIs(t, err, ErrUnauthorized)
 			assert.NotContains(t, err.Error(), "bad")
 		})
 	}
@@ -368,7 +442,7 @@ func TestEmbedRequiresModelAndProviderRevisionEcho(t *testing.T) {
 				return response, nil
 			}))
 			_, err := client.Embed(t.Context(), testInputs()[:1], testAuthorization(profile.Descriptor))
-			require.Error(t, err)
+			require.ErrorIs(t, err, ErrMalformedResponse)
 		})
 	}
 
@@ -416,7 +490,12 @@ func TestEmbedRejectsSchemaVectorAndTransportDriftWithoutLeakingBodies(t *testin
 				inputs = testInputs()
 			}
 			_, err := client.Embed(t.Context(), inputs, testAuthorization(profile.Descriptor))
-			require.Error(t, err)
+			if testCase.status == http.StatusOK {
+				require.ErrorIs(t, err, ErrMalformedResponse)
+			} else {
+				require.NotErrorIs(t, err, ErrMalformedResponse)
+				require.Error(t, err)
+			}
 			assert.NotContains(t, err.Error(), "private request text")
 			assert.NotContains(t, err.Error(), "[9,8,7]")
 		})
@@ -430,6 +509,7 @@ func TestEmbedRejectsSchemaVectorAndTransportDriftWithoutLeakingBodies(t *testin
 	}))
 	_, err := client.Embed(t.Context(), one, mutateAuthorization(testAuthorization(bounded.Descriptor), func(value *document.EmbeddingAuthorization) { value.MaxResponseBytes = 64 }))
 	require.ErrorContains(t, err, "response byte")
+	require.ErrorIs(t, err, ErrMalformedResponse)
 }
 
 func TestEmbedRefusesRedirectsAndHonorsCancellation(t *testing.T) {
@@ -482,6 +562,7 @@ func TestEmbedBoundsRequestBodyAndPreservesDescriptorSnapshot(t *testing.T) {
 	input := []document.EmbeddingInput{{Key: "large", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: strings.Repeat("x", 100)}}
 	authorization := mutateAuthorization(testAuthorization(profile.Descriptor), func(value *document.EmbeddingAuthorization) { value.MaxInputBytes = 200 })
 	_, err := client.Embed(t.Context(), input, authorization)
+	require.ErrorIs(t, err, ErrCapacityResponse)
 	require.ErrorContains(t, err, "request byte")
 	assert.Zero(t, requests.Load())
 
@@ -581,4 +662,54 @@ func singleVectorResponse(model string, vector []float32) []byte {
 		panic(err)
 	}
 	return body
+}
+
+func TestNewEnforcesConfiguredEgress(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(singleVectorResponse("synthetic-model", []float32{1, 0, 0}))
+	}))
+	t.Cleanup(server.Close)
+	address, err := netip.ParseAddrPort(strings.TrimPrefix(server.URL, "http://"))
+	require.NoError(t, err)
+	for _, allowed := range []bool{true, false} {
+		profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileGTE}))
+		cidr := "192.0.2.0/24"
+		if allowed {
+			cidr = "127.0.0.0/8"
+		}
+		profile.Origin = server.URL
+		profile.EgressPolicy = providerhttp.EgressPolicy{Scheme: "http", Host: address.Addr().String(), Port: address.Port(), AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix(cidr)}, ProxyMode: providerhttp.ProxyDisabled}
+		profile.Descriptor = descriptorFor(t, profile)
+		before := requests.Load()
+		client, err := New(profile, nil, server.Client())
+		require.NoError(t, err)
+		_, err = client.Embed(t.Context(), testInputs()[:1], testAuthorization(profile.Descriptor))
+		if allowed {
+			require.NoError(t, err)
+			require.Equal(t, before+1, requests.Load())
+		} else {
+			require.Error(t, err)
+			require.Equal(t, before, requests.Load(), "denied destination must receive no request")
+		}
+	}
+}
+
+func TestEmbedClassifiesTruncatedHTTPResponseAsTransient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "1000")
+		_, _ = io.WriteString(w, `{"object":"list"`)
+	}))
+	t.Cleanup(server.Close)
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
+	profile.Origin = server.URL
+	profile.Descriptor = descriptorFor(t, profile)
+	client, err := New(profile, nil, server.Client())
+	require.NoError(t, err)
+	_, err = client.Embed(t.Context(), testInputs()[:1], testAuthorization(profile.Descriptor))
+	require.ErrorIs(t, err, ErrTransientResponse)
+	require.NotErrorIs(t, err, ErrMalformedResponse)
 }

--- a/document/voyage/embedding.go
+++ b/document/voyage/embedding.go
@@ -311,7 +311,7 @@ func (client *EmbeddingClient) embedDirectFiles(ctx context.Context, inputs []do
 		if secretContextErr != nil {
 			return document.EmbeddingResult{}, fmt.Errorf("voyage embedding: credential resolution canceled: %w", secretContextErr)
 		}
-		return document.EmbeddingResult{}, errors.New("voyage embedding: credential is unavailable")
+		return document.EmbeddingResult{}, ErrUnauthorized
 	}
 	values := client.profile.Policy.Values()
 	policy, err := NewPolicy(PolicyConfig{
@@ -456,7 +456,7 @@ func (client *EmbeddingClient) embeddingAttempt(ctx context.Context, route strin
 		if contextErr := attemptCtx.Err(); contextErr != nil {
 			return nil, -1, true, false, &ProviderError{Kind: ErrTransientResponse, cause: contextErr}
 		}
-		return nil, -1, false, false, &ProviderError{Kind: ErrPermanentResponse}
+		return nil, -1, false, false, &ProviderError{Kind: ErrUnauthorized}
 	}
 	request, err := http.NewRequestWithContext(attemptCtx, http.MethodPost, client.profile.Endpoint+route, bytes.NewReader(payload))
 	if err != nil {
@@ -485,7 +485,7 @@ func (client *EmbeddingClient) embeddingAttempt(ctx context.Context, route strin
 	if response.StatusCode == http.StatusRequestEntityTooLarge {
 		return nil, -1, false, true, &ProviderError{Kind: ErrBatchTooLarge, StatusCode: response.StatusCode}
 	}
-	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+	if response.StatusCode == http.StatusRequestTimeout || response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
 		delay, set := parseRetryAfter(response.Header.Get("Retry-After"), client.now())
 		if !set {
 			delay = -1

--- a/document/voyage/embedding_test.go
+++ b/document/voyage/embedding_test.go
@@ -150,6 +150,7 @@ func TestEmbeddingProviderClassifiesCapacityAndExhaustedTransient(t *testing.T) 
 		{"permanent", http.StatusBadRequest, voyage.ErrPermanentResponse},
 		{"rate limit", http.StatusTooManyRequests, voyage.ErrTransientResponse},
 		{"transient", http.StatusServiceUnavailable, voyage.ErrTransientResponse},
+		{"request timeout", http.StatusRequestTimeout, voyage.ErrTransientResponse},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			var calls atomic.Int32
@@ -418,7 +419,7 @@ func TestDirectFileEmbeddingBoundsCredentialResolution(t *testing.T) {
 		CapabilityRecordChecksum: strings.Repeat("b", 64), ProviderMetadataChecksum: strings.Repeat("c", 64), InputKind: document.RenditionInputOriginalFile,
 	}}
 	_, err = document.ExecuteEmbedding(t.Context(), provider, []document.EmbeddingInput{{Key: "image", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: source}}, voyageAuthorization(profile.Descriptor))
-	require.ErrorContains(t, err, "credential")
+	require.ErrorIs(t, err, voyage.ErrUnauthorized)
 	require.True(t, bounded, "credential lookup must receive the adapter timeout")
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -131,30 +132,66 @@ type EmbeddingChunkConfig struct {
 	TruncationPolicy   string `toml:"truncation_policy"`
 }
 
+type EmbeddingModelInputEncoderConfig struct {
+	Mode     string `toml:"mode"`
+	Template string `toml:"template"`
+}
+
+type EmbeddingModelInputConfig struct {
+	Profile          string                           `toml:"profile"`
+	CompatibilityID  string                           `toml:"compatibility_id"`
+	Document         EmbeddingModelInputEncoderConfig `toml:"document"`
+	Query            EmbeddingModelInputEncoderConfig `toml:"query"`
+	QueryInstruction string                           `toml:"query_instruction"`
+}
+
+type EmbeddingRuntimeConfig struct {
+	AdapterContract        string   `toml:"adapter_contract"`
+	Endpoint               string   `toml:"endpoint"`
+	ModelRevision          string   `toml:"model_revision"`
+	DeploymentEpoch        string   `toml:"deployment_epoch"`
+	ProviderRevisionHeader string   `toml:"provider_revision_header"`
+	CapabilityManifest     string   `toml:"capability_manifest"`
+	RequestTimeout         Duration `toml:"request_timeout"`
+	MaxRequestBytes        int64    `toml:"max_request_bytes"`
+	AllowedCIDRs           []string `toml:"allowed_cidrs"`
+	SPKISHA256             []string `toml:"spki_sha256"`
+	ProxyMode              string   `toml:"proxy_mode"`
+	ConnectTimeout         Duration `toml:"connect_timeout"`
+	KeepAlive              Duration `toml:"keep_alive"`
+	TLSHandshakeTimeout    Duration `toml:"tls_handshake_timeout"`
+}
+
+type CredentialBindingConfig struct {
+	EnvironmentVariable string `toml:"environment_variable"`
+}
+
 // EmbeddingProfileConfig names a deployment binding for one pinned embedding
 // descriptor and semantic input kind.
 type EmbeddingProfileConfig struct {
-	Activation               string               `toml:"activation"`
-	AuthorizationFingerprint string               `toml:"authorization_fingerprint"`
-	Chunk                    EmbeddingChunkConfig `toml:"chunk"`
-	CompatibilityID          string               `toml:"compatibility_id"`
-	CredentialBinding        string               `toml:"credential_binding"`
-	DescriptorID             string               `toml:"descriptor_id"`
-	DescriptorFingerprint    string               `toml:"descriptor_fingerprint"`
-	Dimensions               int                  `toml:"dimensions"`
-	DisclosureFingerprint    string               `toml:"disclosure_fingerprint"`
-	DocumentFormatter        string               `toml:"document_formatter"`
-	InputKind                string               `toml:"input_kind"`
-	MaxBatchItems            int                  `toml:"max_batch_items"`
-	MaxInputBytes            int64                `toml:"max_input_bytes"`
-	MaxInputTokens           int                  `toml:"max_input_tokens"`
-	MaxResponseBytes         int64                `toml:"max_response_bytes"`
-	Metric                   string               `toml:"metric"`
-	Model                    string               `toml:"model"`
-	Normalization            string               `toml:"normalization"`
-	QueryFormatter           string               `toml:"query_formatter"`
-	ScalarEncoding           string               `toml:"scalar_encoding"`
-	TrustBoundary            string               `toml:"trust_boundary"`
+	Activation               string                    `toml:"activation"`
+	AuthorizationFingerprint string                    `toml:"authorization_fingerprint"`
+	Chunk                    EmbeddingChunkConfig      `toml:"chunk"`
+	CompatibilityID          string                    `toml:"compatibility_id"`
+	CredentialBinding        string                    `toml:"credential_binding"`
+	DescriptorID             string                    `toml:"descriptor_id"`
+	DescriptorFingerprint    string                    `toml:"descriptor_fingerprint"`
+	Dimensions               int                       `toml:"dimensions"`
+	DisclosureFingerprint    string                    `toml:"disclosure_fingerprint"`
+	DocumentFormatter        string                    `toml:"document_formatter"`
+	InputKind                string                    `toml:"input_kind"`
+	MaxBatchItems            int                       `toml:"max_batch_items"`
+	MaxInputBytes            int64                     `toml:"max_input_bytes"`
+	MaxInputTokens           int                       `toml:"max_input_tokens"`
+	MaxResponseBytes         int64                     `toml:"max_response_bytes"`
+	Metric                   string                    `toml:"metric"`
+	Model                    string                    `toml:"model"`
+	Normalization            string                    `toml:"normalization"`
+	QueryFormatter           string                    `toml:"query_formatter"`
+	ScalarEncoding           string                    `toml:"scalar_encoding"`
+	TrustBoundary            string                    `toml:"trust_boundary"`
+	ModelInput               EmbeddingModelInputConfig `toml:"model_input"`
+	Runtime                  *EmbeddingRuntimeConfig   `toml:"runtime"`
 }
 
 // RetrievalProfileConfig contains bounded candidate limits for one named
@@ -207,6 +244,7 @@ type Config struct {
 	StoreBindings      map[string]StoreBindingConfig      `toml:"store_bindings"`
 	RenditionProfiles  map[string]RenditionProfileConfig  `toml:"rendition_profiles"`
 	EmbeddingProfiles  map[string]EmbeddingProfileConfig  `toml:"embedding_profiles"`
+	CredentialBindings map[string]CredentialBindingConfig `toml:"credential_bindings"`
 	RetrievalProfiles  map[string]RetrievalProfileConfig  `toml:"retrieval_profiles"`
 	ProcessingProfiles map[string]ProcessingProfileConfig `toml:"processing_profiles"`
 	Watches            []WatchConfig                      `toml:"watch"`
@@ -223,6 +261,7 @@ func Default() Config {
 		Storage:            StorageConfig{PackMaxBytes: 256 << 20},
 		RenditionProfiles:  make(map[string]RenditionProfileConfig),
 		EmbeddingProfiles:  make(map[string]EmbeddingProfileConfig),
+		CredentialBindings: make(map[string]CredentialBindingConfig),
 		RetrievalProfiles:  make(map[string]RetrievalProfileConfig),
 		ProcessingProfiles: make(map[string]ProcessingProfileConfig),
 	}
@@ -259,6 +298,13 @@ func Load(root string) (Config, error) {
 	}
 	if err := resolveWatches(&c); err != nil {
 		return Config{}, fmt.Errorf("loading %s: %w", path, err)
+	}
+	for name, profile := range c.EmbeddingProfiles {
+		if profile.Runtime == nil || profile.Runtime.CapabilityManifest == "" || filepath.IsAbs(profile.Runtime.CapabilityManifest) {
+			continue
+		}
+		profile.Runtime.CapabilityManifest = filepath.Clean(filepath.Join(root, profile.Runtime.CapabilityManifest))
+		c.EmbeddingProfiles[name] = profile
 	}
 	return c, nil
 }
@@ -422,8 +468,17 @@ var storeBindingNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,62}$`)
 
 var lowercaseSHA256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
 var credentialReferencePattern = regexp.MustCompile(`^credential:[a-z][a-z0-9_-]{0,62}$`)
+var environmentVariablePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 func validateProcessingProfiles(c Config) error {
+	for name, binding := range c.CredentialBindings {
+		if err := validateProfileName(name, fmt.Sprintf("[credential_bindings.%s]", name)); err != nil {
+			return err
+		}
+		if !environmentVariablePattern.MatchString(binding.EnvironmentVariable) {
+			return fmt.Errorf("[credential_bindings.%s] environment_variable must be a variable name", name)
+		}
+	}
 	for name, profile := range c.RenditionProfiles {
 		prefix := fmt.Sprintf("[rendition_profiles.%s]", name)
 		if err := validateProfileName(name, prefix); err != nil {
@@ -440,6 +495,12 @@ func validateProcessingProfiles(c Config) error {
 		}
 		if err := validateEmbeddingProfileConfig(profile, prefix); err != nil {
 			return err
+		}
+		if profile.Runtime != nil {
+			credentialName := strings.TrimPrefix(profile.CredentialBinding, "credential:")
+			if _, ok := c.CredentialBindings[credentialName]; !ok {
+				return fmt.Errorf("%s runtime credential binding %q is not defined", prefix, profile.CredentialBinding)
+			}
 		}
 	}
 	for name, profile := range c.RetrievalProfiles {
@@ -585,7 +646,80 @@ func validateEmbeddingProfileConfig(profile EmbeddingProfileConfig, prefix strin
 	} else if profile.Chunk != (EmbeddingChunkConfig{}) || profile.MaxInputTokens != 0 {
 		return fmt.Errorf("%s original_file input must not define chunk policy or max input tokens", prefix)
 	}
+	if profile.Runtime != nil {
+		runtime := profile.Runtime
+		if runtime.AdapterContract != "docbank-openai-compatible-embeddings/v1" &&
+			runtime.AdapterContract != "docbank-voyage-embeddings/v1" {
+			return fmt.Errorf("%s runtime adapter_contract is unsupported", prefix)
+		}
+		parsed, err := url.Parse(runtime.Endpoint)
+		if err != nil || parsed.User != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+			return fmt.Errorf("%s runtime endpoint must be exact and credential-free", prefix)
+		}
+		if runtime.ModelRevision == "" || runtime.ModelRevision != strings.TrimSpace(runtime.ModelRevision) {
+			return fmt.Errorf("%s runtime model_revision is required", prefix)
+		}
+		if runtime.ConnectTimeout.Std() <= 0 || runtime.ConnectTimeout.Std() > 5*time.Minute ||
+			runtime.KeepAlive.Std() <= 0 || runtime.KeepAlive.Std() > 5*time.Minute ||
+			runtime.TLSHandshakeTimeout.Std() <= 0 || runtime.TLSHandshakeTimeout.Std() > 5*time.Minute {
+			return fmt.Errorf("%s runtime transport time bounds are invalid", prefix)
+		}
+		if runtime.MaxRequestBytes < 1 || runtime.MaxRequestBytes > 1<<30 || runtime.RequestTimeout.Std() <= 0 ||
+			runtime.RequestTimeout.Std() > 5*time.Minute {
+			return fmt.Errorf("%s runtime request bounds are invalid", prefix)
+		}
+		if runtime.ProxyMode != "disabled" || len(runtime.AllowedCIDRs) == 0 {
+			return fmt.Errorf("%s runtime egress must be proxy-disabled with allowed CIDRs", prefix)
+		}
+		for _, value := range runtime.AllowedCIDRs {
+			if _, err := netip.ParsePrefix(value); err != nil {
+				return fmt.Errorf("%s runtime allowed CIDR %q is invalid", prefix, value)
+			}
+		}
+		for _, value := range runtime.SPKISHA256 {
+			if !lowercaseSHA256Pattern.MatchString(value) {
+				return fmt.Errorf("%s runtime SPKI pin must be lowercase SHA-256", prefix)
+			}
+		}
+		contract, err := embeddingModelInputContract(profile.ModelInput)
+		if err != nil || contract.CompatibilityID != profile.CompatibilityID {
+			return fmt.Errorf("%s model_input is invalid or incompatible", prefix)
+		}
+		switch runtime.AdapterContract {
+		case "docbank-openai-compatible-embeddings/v1":
+			if profile.InputKind != string(document.EmbeddingInputRenditionChunk) || runtime.CapabilityManifest != "" ||
+				(parsed.Path != "" && parsed.Path != "/") || (runtime.DeploymentEpoch == "") == (runtime.ProviderRevisionHeader == "") {
+				return fmt.Errorf("%s OpenAI-compatible runtime authority is invalid", prefix)
+			}
+			if runtime.DeploymentEpoch != "" && runtime.DeploymentEpoch != runtime.ModelRevision {
+				return fmt.Errorf("%s OpenAI-compatible deployment epoch differs from model revision", prefix)
+			}
+		case "docbank-voyage-embeddings/v1":
+			if profile.InputKind != string(document.EmbeddingInputOriginalFile) ||
+				runtime.Endpoint != "https://api.voyageai.com/v1" || runtime.CapabilityManifest == "" ||
+				!filepath.IsAbs(runtime.CapabilityManifest) || runtime.DeploymentEpoch != "" || runtime.ProviderRevisionHeader != "" {
+				return fmt.Errorf("%s Voyage runtime authority is invalid", prefix)
+			}
+		}
+	}
 	return nil
+}
+
+func embeddingModelInputContract(config EmbeddingModelInputConfig) (document.ModelInputContract, error) {
+	return document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfile(config.Profile), CompatibilityID: config.CompatibilityID,
+		Document:         document.ModelInputEncoder{Mode: document.ModelInputMode(config.Document.Mode), Template: config.Document.Template},
+		Query:            document.ModelInputEncoder{Mode: document.ModelInputMode(config.Query.Mode), Template: config.Query.Template},
+		QueryInstruction: config.QueryInstruction,
+	})
+}
+
+func (c Config) EmbeddingModelInput(name string) (document.ModelInputContract, error) {
+	profile, ok := c.EmbeddingProfiles[name]
+	if !ok {
+		return document.ModelInputContract{}, fmt.Errorf("embedding profile %q is not defined", name)
+	}
+	return embeddingModelInputContract(profile.ModelInput)
 }
 
 // ProcessingProfile assembles one named portable profile and its deployment
@@ -697,6 +831,10 @@ func renditionDocumentBinding(name string, profile RenditionProfileConfig) *docu
 }
 
 func embeddingDocumentBinding(name string, profile EmbeddingProfileConfig) document.EmbeddingBindingV1 {
+	var modelInput document.ModelInputContract
+	if profile.ModelInput != (EmbeddingModelInputConfig{}) {
+		modelInput, _ = embeddingModelInputContract(profile.ModelInput)
+	}
 	result := document.EmbeddingBindingV1{
 		Activation: document.EmbeddingActivation(profile.Activation), AuthorizationFingerprint: profile.AuthorizationFingerprint,
 		CompatibilityID: profile.CompatibilityID, CredentialBinding: profile.CredentialBinding,
@@ -707,6 +845,7 @@ func embeddingDocumentBinding(name string, profile EmbeddingProfileConfig) docum
 		MaxResponseBytes: profile.MaxResponseBytes,
 		Metric:           profile.Metric, Model: profile.Model, Name: name, Normalization: profile.Normalization,
 		QueryFormatter: profile.QueryFormatter, ScalarEncoding: profile.ScalarEncoding, TrustBoundary: profile.TrustBoundary,
+		ModelInput: modelInput,
 	}
 	if profile.InputKind == string(document.EmbeddingInputRenditionChunk) {
 		result.Chunk = &document.EmbeddingChunkPolicyV1{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -282,6 +283,92 @@ func TestProcessingProfilesRejectInvalidReferencesAndPolicies(t *testing.T) {
 			cfg := validProcessingConfig()
 			test.mutate(&cfg)
 			require.ErrorContains(t, cfg.Validate(), test.want)
+		})
+	}
+}
+
+func TestEmbeddingRuntimeConfigIsExactBoundedAndPortable(t *testing.T) {
+	cfg := validProcessingConfig()
+	cfg.CredentialBindings = map[string]CredentialBindingConfig{
+		"embedding-primary": {EnvironmentVariable: "DOCBANK_EMBEDDING_PRIMARY_KEY"},
+	}
+	profile := cfg.EmbeddingProfiles["semantic"]
+	profile.ModelInput = EmbeddingModelInputConfig{Profile: string(document.ModelInputProfileNomic)}
+	profile.CompatibilityID = "nomic/search/v1"
+	profile.DescriptorID = "openai-compatible.embeddings-v1"
+	profile.Runtime = &EmbeddingRuntimeConfig{
+		AdapterContract: "docbank-openai-compatible-embeddings/v1", Endpoint: "https://embedding.example.invalid",
+		ModelRevision: "deployment-v1", DeploymentEpoch: "deployment-v1",
+		RequestTimeout: Duration(time.Second), MaxRequestBytes: 1 << 20,
+		AllowedCIDRs: []string{"192.0.2.0/24"}, SPKISHA256: []string{strings.Repeat("a", 64)},
+		ProxyMode: "disabled", ConnectTimeout: Duration(time.Second), KeepAlive: Duration(time.Second),
+		TLSHandshakeTimeout: Duration(time.Second),
+	}
+	cfg.EmbeddingProfiles["semantic"] = profile
+	require.NoError(t, cfg.Validate())
+	portable, err := cfg.ProcessingProfile("archive")
+	require.NoError(t, err)
+	require.Len(t, portable.Document.Embeddings, 1)
+	assert.Equal(t, profile.CredentialBinding, portable.Document.Embeddings[0].CredentialBinding)
+	assert.Equal(t, "nomic/search/v1", portable.Document.Embeddings[0].ModelInput.CompatibilityID)
+
+	for name, mutate := range map[string]func(*Config){
+		"undefined credential": func(value *Config) { value.CredentialBindings = nil },
+		"credential value instead of name": func(value *Config) {
+			value.CredentialBindings["embedding-primary"] = CredentialBindingConfig{EnvironmentVariable: "synthetic secret"}
+		},
+		"ambient proxy": func(value *Config) {
+			changed := value.EmbeddingProfiles["semantic"]
+			changed.Runtime.ProxyMode = "environment"
+			value.EmbeddingProfiles["semantic"] = changed
+		},
+		"credential in endpoint": func(value *Config) {
+			changed := value.EmbeddingProfiles["semantic"]
+			changed.Runtime.Endpoint = "https://secret@embedding.example.invalid"
+			value.EmbeddingProfiles["semantic"] = changed
+		},
+		"portable model input differs": func(value *Config) {
+			changed := value.EmbeddingProfiles["semantic"]
+			changed.ModelInput = EmbeddingModelInputConfig{Profile: string(document.ModelInputProfileE5)}
+			value.EmbeddingProfiles["semantic"] = changed
+		},
+		"openai endpoint path": func(value *Config) {
+			changed := value.EmbeddingProfiles["semantic"]
+			changed.Runtime.Endpoint += "/api"
+			value.EmbeddingProfiles["semantic"] = changed
+		},
+		"two revision authorities": func(value *Config) {
+			changed := value.EmbeddingProfiles["semantic"]
+			changed.Runtime.ProviderRevisionHeader = "X-Model-Revision"
+			value.EmbeddingProfiles["semantic"] = changed
+		},
+		"unbounded connect": func(value *Config) {
+			changed := value.EmbeddingProfiles["semantic"]
+			changed.Runtime.ConnectTimeout = 0
+			value.EmbeddingProfiles["semantic"] = changed
+		},
+		"openai original file": func(value *Config) {
+			changed := value.EmbeddingProfiles["semantic"]
+			changed.InputKind = string(document.EmbeddingInputOriginalFile)
+			changed.Chunk = EmbeddingChunkConfig{}
+			value.EmbeddingProfiles["semantic"] = changed
+		},
+		"voyage missing capability manifest": func(value *Config) {
+			changed := value.EmbeddingProfiles["semantic"]
+			changed.Runtime.AdapterContract = "docbank-voyage-embeddings/v1"
+			changed.Runtime.Endpoint = "https://api.voyageai.com/v1"
+			changed.Runtime.DeploymentEpoch = ""
+			changed.InputKind = string(document.EmbeddingInputOriginalFile)
+			changed.Chunk = EmbeddingChunkConfig{}
+			value.EmbeddingProfiles["semantic"] = changed
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := cfg
+			changed.CredentialBindings = maps.Clone(cfg.CredentialBindings)
+			changed.EmbeddingProfiles = maps.Clone(cfg.EmbeddingProfiles)
+			mutate(&changed)
+			require.Error(t, changed.Validate())
 		})
 	}
 }

--- a/internal/processing/embedding_runtime.go
+++ b/internal/processing/embedding_runtime.go
@@ -1,0 +1,179 @@
+package processing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media"
+	"go.kenn.io/docbank/document/upload"
+	"go.kenn.io/docbank/internal/store"
+)
+
+type embeddingRuntimeBlobs interface {
+	OpenContext(ctx context.Context, hash string) (io.ReadSeekCloser, error)
+}
+
+// ProviderEmbeddingRuntime reconstructs exact transient inputs from cataloged
+// blob authority for one already-validated provider descriptor.
+type ProviderEmbeddingRuntime struct {
+	provider       document.EmbeddingProvider
+	blobs          embeddingRuntimeBlobs
+	spoolDirectory string
+	classify       func(error) (EmbeddingProviderFailure, time.Duration)
+}
+
+// NewProviderEmbeddingRuntime binds one provider to exact blob reopening. A
+// non-empty absolute spool directory is required for direct-file authority.
+func NewProviderEmbeddingRuntime(provider document.EmbeddingProvider, blobs embeddingRuntimeBlobs,
+	spoolDirectory string, classify func(error) (EmbeddingProviderFailure, time.Duration),
+) (*ProviderEmbeddingRuntime, error) {
+	if embeddingInterfaceNil(provider) || embeddingInterfaceNil(blobs) || classify == nil {
+		return nil, errors.New("embedding provider runtime dependencies are invalid")
+	}
+	if !filepath.IsAbs(spoolDirectory) {
+		return nil, errors.New("embedding provider runtime spool directory must be absolute")
+	}
+	return &ProviderEmbeddingRuntime{provider: provider, blobs: blobs, spoolDirectory: spoolDirectory, classify: classify}, nil
+}
+
+func (runtime *ProviderEmbeddingRuntime) Ready() bool {
+	return runtime != nil && !embeddingInterfaceNil(runtime.provider) && !embeddingInterfaceNil(runtime.blobs) && runtime.classify != nil
+}
+
+func (runtime *ProviderEmbeddingRuntime) Classify(err error) (EmbeddingProviderFailure, time.Duration) {
+	if runtime == nil || runtime.classify == nil {
+		return EmbeddingProviderPermanent, 0
+	}
+	return runtime.classify(err)
+}
+
+func (runtime *ProviderEmbeddingRuntime) Prepare(ctx context.Context, work EmbeddingWork) (EmbeddingExecution, error) {
+	if !runtime.Ready() || !reflect.DeepEqual(runtime.provider.Descriptor(), work.Descriptor) {
+		return EmbeddingExecution{}, ErrEmbeddingRuntimeUnavailable
+	}
+	switch work.Binding.InputKind {
+	case document.EmbeddingInputRenditionChunk:
+		hydrated, err := hydrateEmbeddingGeneration(ctx, runtime.blobs, work.InputGeneration)
+		if err != nil {
+			return EmbeddingExecution{}, err
+		}
+		data := hydrated.GenerationJSON
+		generation, err := document.DecodeEmbeddingInputGeneration(data, document.EmbeddingInputGenerationDecodeBounds{
+			MaxEncodedBytes: hydrated.GenerationEncodedSize, MaxInputs: len(hydrated.Inputs),
+		})
+		if err != nil {
+			return EmbeddingExecution{}, errors.Join(ErrEmbeddingInputRejected, err)
+		}
+		inputs, err := generation.ToEmbeddingInputs(work.Descriptor.ModelInput)
+		if err != nil {
+			return EmbeddingExecution{}, errors.Join(ErrEmbeddingInputRejected, err)
+		}
+		return EmbeddingExecution{Provider: runtime.provider, Inputs: inputs,
+			InputGenerationJSON: data, EvidenceJSON: hydrated.EvidenceJSON, Classify: runtime.classify}, nil
+	case document.EmbeddingInputOriginalFile:
+		if mediaType, _, err := mime.ParseMediaType(work.SourceMediaType); err != nil || mediaType == "" {
+			return EmbeddingExecution{}, fmt.Errorf("embedding original-file media type is invalid: %w", ErrEmbeddingInputRejected)
+		}
+		if work.SourceBytes < 1 || work.Binding.MaxInputBytes < 1 || work.SourceBytes > work.Binding.MaxInputBytes {
+			return EmbeddingExecution{}, fmt.Errorf("embedding original-file byte authority is invalid: %w", ErrEmbeddingInputRejected)
+		}
+		reader, err := runtime.blobs.OpenContext(ctx, work.SourceBlobHash)
+		if err != nil {
+			return EmbeddingExecution{}, err
+		}
+		policy := directEmbeddingInspectionPolicy(work)
+		capability, err := media.InspectCapability(reader, policy)
+		if err != nil {
+			_ = reader.Close()
+			return EmbeddingExecution{}, err
+		}
+		if !capability.Eligible {
+			_ = reader.Close()
+			return EmbeddingExecution{}, fmt.Errorf("embedding source capability %s: %w", capability.Reason, ErrEmbeddingInputRejected)
+		}
+		if _, err := reader.Seek(0, io.SeekStart); err != nil {
+			_ = reader.Close()
+			return EmbeddingExecution{}, err
+		}
+		authorized, err := upload.Authorize(ctx, upload.Source{Reader: reader, Directory: runtime.spoolDirectory},
+			capability, upload.UploadMetadata{Filename: work.SourceFilename})
+		if err != nil {
+			return EmbeddingExecution{}, err
+		}
+		return EmbeddingExecution{Provider: runtime.provider, Inputs: []document.EmbeddingInput{{
+			Key: work.ContentVersionID, Role: document.EmbeddingRoleDocument,
+			Kind: document.EmbeddingInputOriginalFile, Source: authorized,
+		}}, Classify: runtime.classify}, nil
+	default:
+		return EmbeddingExecution{}, ErrEmbeddingRuntimeUnavailable
+	}
+}
+
+func hydrateEmbeddingGeneration(ctx context.Context, blobs embeddingRuntimeBlobs,
+	record store.EmbeddingInputGenerationRecord,
+) (store.EmbeddingInputGenerationRecord, error) {
+	data, err := readExactEmbeddingBlob(ctx, blobs, record.GenerationBlobHash, record.GenerationEncodedSize)
+	if err != nil {
+		return store.EmbeddingInputGenerationRecord{}, err
+	}
+	reader, err := blobs.OpenContext(ctx, record.EvidenceFingerprint)
+	if err != nil {
+		return store.EmbeddingInputGenerationRecord{}, err
+	}
+	defer func() { _ = reader.Close() }()
+	evidence, err := io.ReadAll(io.LimitReader(reader, (64<<20)+1))
+	if err != nil {
+		return store.EmbeddingInputGenerationRecord{}, err
+	}
+	if len(evidence) > 64<<20 {
+		return store.EmbeddingInputGenerationRecord{}, fmt.Errorf("embedding evidence exceeds byte limit: %w", ErrEmbeddingInputRejected)
+	}
+	hydrated, err := store.HydrateEmbeddingInputGeneration(record, data, evidence)
+	if err != nil {
+		return store.EmbeddingInputGenerationRecord{}, errors.Join(ErrEmbeddingInputRejected, err)
+	}
+	return hydrated, nil
+}
+
+func readExactEmbeddingBlob(ctx context.Context, blobs embeddingRuntimeBlobs, hash string, size int64) ([]byte, error) {
+	if hash == "" || size < 1 || size > 64<<20 {
+		return nil, fmt.Errorf("embedding generation blob authority is invalid: %w", ErrEmbeddingInputRejected)
+	}
+	reader, err := blobs.OpenContext(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = reader.Close() }()
+	data, err := io.ReadAll(io.LimitReader(reader, size+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) != size {
+		return nil, fmt.Errorf("embedding generation blob could not be read exactly: %w", ErrEmbeddingInputRejected)
+	}
+	return data, nil
+}
+
+func directEmbeddingInspectionPolicy(work EmbeddingWork) media.InspectionPolicy {
+	maximum := work.Binding.MaxInputBytes
+	return media.InspectionPolicy{
+		Filename: work.SourceFilename, DeclaredMediaType: work.SourceMediaType,
+		ExpectedBytes: work.SourceBytes, ExpectedSHA256: work.SourceBlobHash,
+		DescriptorFingerprint: work.Descriptor.Fingerprint,
+		ProfileFingerprint:    work.ProcessingProfile.Fingerprint,
+		DisclosureFingerprint: work.Binding.DisclosureFingerprint,
+		InputKind:             document.RenditionInputOriginalFile, MaxSourceBytes: maximum,
+		MaxExpandedBytes: maximum, MaxEntryBytes: maximum, MaxEntries: 100_000, MaxNestingDepth: 1,
+		MaxTextLines: 10_000_000, MaxCharacters: 1_000_000_000, MaxRecords: 10_000_000,
+		MaxPages: 1_000_000, MaxSlides: 1_000_000, MaxSheets: 1_000_000, MaxCells: 100_000_000,
+		MaxSpineItems: 1_000_000, MaxResources: 1_000_000, MaxPixels: 1_000_000_000,
+		MaxFrames: 1_000_000, MaxDurationMS: 24 * 60 * 60 * 1000,
+	}
+}

--- a/internal/processing/embedding_worker.go
+++ b/internal/processing/embedding_worker.go
@@ -1,0 +1,853 @@
+package processing
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"sync"
+	"time"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/store"
+)
+
+var (
+	// ErrEmbeddingInputRejected identifies input that cannot satisfy its binding.
+	ErrEmbeddingInputRejected = errors.New("embedding input does not satisfy binding")
+	// ErrEmbeddingWorkFenced means an expired or superseded attempt lost its
+	// lease or an immutable source/profile/input fence.
+	ErrEmbeddingWorkFenced = errors.New("embedding work is fenced")
+	// ErrEmbeddingPersistence is deliberately body-free: storage errors may
+	// contain private paths or provider-derived values and must not escape the
+	// worker boundary.
+	ErrEmbeddingPersistence = errors.New("embedding persistence failed")
+	// ErrEmbeddingRuntimeUnavailable means no executable adapter is registered
+	// for the work's exact descriptor fingerprint.
+	ErrEmbeddingRuntimeUnavailable = errors.New("embedding runtime is unavailable")
+)
+
+// EmbeddingWorkClaim is the store-owned durable claim authority.
+type EmbeddingWorkClaim = store.EmbeddingJobClaim
+
+// EmbeddingWork is the store-owned durable execution authority.
+type EmbeddingWork = store.EmbeddingJobWork
+
+// EmbeddingAttemptReceipt is the store-owned sanitized attempt receipt.
+type EmbeddingAttemptReceipt = store.EmbeddingAttemptReceipt
+
+type embeddingWorkerCatalog interface {
+	ReconcileEmbeddingJobs(ctx context.Context, request store.EmbeddingReconcileRequest) (store.EmbeddingReconcileResult, error)
+	ClaimNextEmbeddingWork(ctx context.Context, owner string, at time.Time, lease time.Duration, fingerprints []string) (EmbeddingWorkClaim, EmbeddingWork, bool, error)
+	RenewEmbeddingWork(ctx context.Context, claim EmbeddingWorkClaim, at time.Time, lease time.Duration) (EmbeddingWorkClaim, error)
+	ValidateEmbeddingWork(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork, at time.Time) error
+	BeginEmbeddingProviderEgress(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork, prior *store.ProviderOperationAuthorization, at time.Time) (store.ProviderOperationAuthorization, *store.ProviderEgressFence, error)
+	AbandonEmbeddingWork(ctx context.Context, claim EmbeddingWorkClaim, at time.Time) error
+	FailEmbeddingWork(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork, code store.EmbeddingFailureCode, receipt EmbeddingAttemptReceipt, at time.Time) error
+}
+
+type embeddingWorkerAuthority interface {
+	RecordRenditionBlob(ctx context.Context, hash string, size int64, physical store.BlobPhysical) error
+	StageEmbeddingSetWithLease(ctx context.Context, record store.EmbeddingSetRecord, rootID string, fencingToken int64, at time.Time) error
+	PublishEmbeddingWork(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork,
+		head store.EmbeddingHeadRecord, prior store.ProviderOperationAuthorization, receipt EmbeddingAttemptReceipt, at time.Time) error
+}
+
+// EmbeddingExecution contains only transient provider material.
+type EmbeddingExecution struct {
+	Provider            document.EmbeddingProvider
+	Inputs              []document.EmbeddingInput
+	InputGenerationJSON []byte
+	EvidenceJSON        []byte
+	Classify            func(error) (EmbeddingProviderFailure, time.Duration)
+}
+
+// EmbeddingProviderFailure is a provider-neutral retry classification.
+type EmbeddingProviderFailure string
+
+const (
+	EmbeddingProviderAuthorization   EmbeddingProviderFailure = "authorization"
+	EmbeddingProviderTransient       EmbeddingProviderFailure = "transient"
+	EmbeddingProviderPermanent       EmbeddingProviderFailure = "permanent"
+	EmbeddingProviderCapacity        EmbeddingProviderFailure = "capacity"
+	EmbeddingProviderInvalidResponse EmbeddingProviderFailure = "invalid_response"
+)
+
+// EmbeddingRuntime reconstructs transient inputs and provider clients from an
+// exact work item. Classify must never return or persist a provider body.
+type EmbeddingRuntime interface {
+	Ready() bool
+	Prepare(ctx context.Context, work EmbeddingWork) (EmbeddingExecution, error)
+	Classify(err error) (EmbeddingProviderFailure, time.Duration)
+}
+
+// EmbeddingRuntimeRegistry resolves exact immutable descriptor fingerprints.
+type EmbeddingRuntimeRegistry struct {
+	mu       sync.RWMutex
+	runtimes map[string]EmbeddingRuntime
+}
+
+func (registry *EmbeddingRuntimeRegistry) Fingerprints() []string {
+	if registry == nil {
+		return nil
+	}
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	values := make([]string, 0, len(registry.runtimes))
+	for value := range registry.runtimes {
+		values = append(values, value)
+	}
+	slices.Sort(values)
+	return values
+}
+
+func NewEmbeddingRuntimeRegistry() *EmbeddingRuntimeRegistry {
+	return &EmbeddingRuntimeRegistry{runtimes: make(map[string]EmbeddingRuntime)}
+}
+
+func (registry *EmbeddingRuntimeRegistry) Ready() bool {
+	if registry == nil {
+		return false
+	}
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	return len(registry.runtimes) != 0
+}
+
+func (registry *EmbeddingRuntimeRegistry) Register(fingerprint string, runtime EmbeddingRuntime) error {
+	if registry == nil || len(fingerprint) != sha256.Size*2 || embeddingInterfaceNil(runtime) || !runtime.Ready() {
+		return errors.New("embedding runtime registration is invalid")
+	}
+	if _, err := hex.DecodeString(fingerprint); err != nil {
+		return errors.New("embedding runtime descriptor fingerprint is invalid")
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if _, exists := registry.runtimes[fingerprint]; exists {
+		return errors.New("embedding runtime descriptor is already registered")
+	}
+	registry.runtimes[fingerprint] = runtime
+	return nil
+}
+
+func (registry *EmbeddingRuntimeRegistry) Prepare(ctx context.Context, work EmbeddingWork) (EmbeddingExecution, error) {
+	if registry == nil {
+		return EmbeddingExecution{}, ErrEmbeddingRuntimeUnavailable
+	}
+	registry.mu.RLock()
+	runtime := registry.runtimes[work.Descriptor.Fingerprint]
+	registry.mu.RUnlock()
+	if embeddingInterfaceNil(runtime) {
+		return EmbeddingExecution{}, ErrEmbeddingRuntimeUnavailable
+	}
+	execution, err := runtime.Prepare(ctx, work)
+	if err == nil {
+		execution.Classify = runtime.Classify
+	}
+	return execution, err
+}
+
+func (registry *EmbeddingRuntimeRegistry) Classify(err error) (EmbeddingProviderFailure, time.Duration) {
+	// Registry preparation binds classification to the selected execution.
+	// There is no safe cross-runtime classification for an unbound error.
+	return EmbeddingProviderPermanent, 0
+}
+
+// EmbeddingWorkerConfig binds the provider-neutral worker to one vault.
+type EmbeddingWorkerConfig struct {
+	Catalog                embeddingWorkerCatalog
+	Authority              embeddingWorkerAuthority
+	Blobs                  renditionBlobWriter
+	GenerationBlobs        embeddingRuntimeBlobs
+	Runtime                EmbeddingRuntime
+	Gate                   RenditionMutationGate
+	Owner                  string
+	LeaseDuration          time.Duration
+	IdleDelay              time.Duration
+	RetryLimit             int
+	RetryBaseDelay         time.Duration
+	MaxRetryDelay          time.Duration
+	AttemptLifetime        time.Duration
+	MaxRows                int
+	MaxDimensions          int
+	MaxVectorBlobBytes     int64
+	Clock                  func() time.Time
+	Wait                   func(context.Context, time.Duration) error
+	DescriptorFingerprints []string
+}
+
+// EmbeddingWorker publishes each binding head independently.
+type EmbeddingWorker struct {
+	catalog                                        embeddingWorkerCatalog
+	authority                                      embeddingWorkerAuthority
+	blobs                                          renditionBlobWriter
+	generationBlobs                                embeddingRuntimeBlobs
+	runtime                                        EmbeddingRuntime
+	gate                                           RenditionMutationGate
+	owner                                          string
+	leaseDuration, idleDelay                       time.Duration
+	retryLimit                                     int
+	retryBaseDelay, maxRetryDelay, attemptLifetime time.Duration
+	maxRows, maxDimensions                         int
+	maxVectorBlobBytes                             int64
+	clock                                          func() time.Time
+	wait                                           func(context.Context, time.Duration) error
+	descriptorFingerprints                         []string
+	reconcileAfter                                 string
+	reconcileAt                                    time.Time
+}
+
+func NewEmbeddingWorker(config EmbeddingWorkerConfig) (*EmbeddingWorker, error) {
+	if embeddingInterfaceNil(config.Catalog) || embeddingInterfaceNil(config.Authority) || embeddingInterfaceNil(config.Blobs) ||
+		embeddingInterfaceNil(config.GenerationBlobs) ||
+		embeddingInterfaceNil(config.Runtime) || !config.Runtime.Ready() || embeddingInterfaceNil(config.Gate) {
+		return nil, errors.New("embedding worker requires catalog, blob store, ready runtime, and operation gate")
+	}
+	if config.Owner == "" || len(config.Owner) > 128 {
+		return nil, errors.New("embedding worker owner is invalid")
+	}
+	if config.LeaseDuration < 3*time.Second || config.LeaseDuration > time.Hour ||
+		config.IdleDelay <= 0 || config.IdleDelay > time.Minute {
+		return nil, errors.New("embedding worker lease or idle delay is invalid")
+	}
+	if config.RetryLimit < 1 || config.RetryLimit > 10 || config.RetryBaseDelay < 0 ||
+		config.MaxRetryDelay <= 0 || config.MaxRetryDelay > time.Minute ||
+		config.RetryBaseDelay > config.MaxRetryDelay {
+		return nil, errors.New("embedding worker retry policy is invalid")
+	}
+	if config.AttemptLifetime < config.LeaseDuration || config.AttemptLifetime > 24*time.Hour ||
+		config.MaxRows < 1 || config.MaxRows > 100_000 || config.MaxDimensions < 1 ||
+		config.MaxDimensions > 1_048_576 || config.MaxVectorBlobBytes < 1 || config.MaxVectorBlobBytes > 64<<20 {
+		return nil, errors.New("embedding worker attempt or payload bounds are invalid")
+	}
+	if len(config.DescriptorFingerprints) == 0 {
+		return nil, errors.New("embedding worker requires executable descriptor fingerprints")
+	}
+	if config.Clock == nil {
+		config.Clock = func() time.Time { return time.Now().UTC() }
+	}
+	if config.Wait == nil {
+		config.Wait = waitEmbeddingWorker
+	}
+	return &EmbeddingWorker{
+		catalog: config.Catalog, authority: config.Authority, blobs: config.Blobs,
+		generationBlobs: config.GenerationBlobs, runtime: config.Runtime, gate: config.Gate,
+		owner: config.Owner, leaseDuration: config.LeaseDuration, idleDelay: config.IdleDelay,
+		retryLimit: config.RetryLimit, retryBaseDelay: config.RetryBaseDelay,
+		maxRetryDelay: config.MaxRetryDelay, attemptLifetime: config.AttemptLifetime,
+		maxRows: config.MaxRows, maxDimensions: config.MaxDimensions,
+		maxVectorBlobBytes: config.MaxVectorBlobBytes, clock: config.Clock, wait: config.Wait,
+		descriptorFingerprints: slices.Clone(config.DescriptorFingerprints),
+	}, nil
+}
+
+// Run retries storage failures with bounded backoff. Claims whose outcome could
+// not be written remain reclaimable after their leases expire.
+func (worker *EmbeddingWorker) Run(ctx context.Context) error {
+	if worker == nil {
+		return errors.New("embedding worker is nil")
+	}
+	storageFailures := 0
+	for {
+		processed, err := worker.ScanOnce(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			storageFailures++
+			if !errors.Is(err, ErrEmbeddingPersistence) || storageFailures >= worker.retryLimit {
+				return err
+			}
+			delay := min(max(worker.retryBaseDelay, worker.idleDelay)*(1<<(storageFailures-1)), worker.maxRetryDelay)
+			if err := worker.wait(ctx, delay); err != nil {
+				return err
+			}
+			continue
+		}
+		storageFailures = 0
+		if processed == 0 {
+			if err := worker.wait(ctx, worker.idleDelay); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// ScanOnce drains the currently eligible queue snapshot. Each claim is a
+// separate publication unit; one failed binding cannot roll back a sibling.
+func (worker *EmbeddingWorker) ScanOnce(ctx context.Context) (int, error) {
+	if worker == nil {
+		return 0, errors.New("embedding worker is nil")
+	}
+	processed := 0
+	reconciled := false
+	for {
+		if err := ctx.Err(); err != nil {
+			return processed, err
+		}
+		var claim EmbeddingWorkClaim
+		var work EmbeddingWork
+		found := false
+
+		if !reconciled && !worker.clock().Before(worker.reconcileAt) {
+			result, err := worker.catalog.ReconcileEmbeddingJobs(ctx, store.EmbeddingReconcileRequest{
+				Mutate: worker.gate.MutateContext,
+				After:  worker.reconcileAfter, Limit: 100, At: worker.clock().UTC(),
+				DescriptorFingerprints: worker.descriptorFingerprints,
+				HydrateGeneration: func(ctx context.Context, generation store.EmbeddingInputGenerationRecord) (store.EmbeddingInputGenerationRecord, error) {
+					return hydrateEmbeddingGeneration(ctx, worker.generationBlobs, generation)
+				},
+			})
+			if err != nil {
+				if ctx.Err() != nil {
+					return processed, ctx.Err()
+				}
+				return processed, ErrEmbeddingPersistence
+			}
+			worker.reconcileAfter = result.Next
+			if result.Next == "" {
+				worker.reconcileAt = worker.clock().Add(time.Minute)
+			}
+			reconciled = true
+		}
+		if err := worker.gate.MutateContext(ctx, func() error {
+			var err error
+			claim, work, found, err = worker.catalog.ClaimNextEmbeddingWork(
+				ctx, worker.owner, worker.clock().UTC(), worker.leaseDuration, worker.descriptorFingerprints)
+			if err != nil {
+				return ErrEmbeddingPersistence
+			}
+			return nil
+		}); err != nil {
+			if ctx.Err() != nil {
+				return processed, ctx.Err()
+			}
+			return processed, err
+		}
+		if !found {
+			return processed, nil
+		}
+		processed++
+		if err := worker.processClaim(ctx, claim, work); err != nil {
+			if ctx.Err() != nil {
+				return processed, ctx.Err()
+			}
+			if errors.Is(err, ErrEmbeddingPersistence) || !isEmbeddingWorkFence(err) {
+				return processed, err
+			}
+			if err := worker.gate.MutateContext(ctx, func() error {
+				return worker.catalog.AbandonEmbeddingWork(ctx, claim, worker.clock().UTC())
+			}); err != nil {
+				return processed, fmt.Errorf("abandoning embedding work: %w", ErrEmbeddingPersistence)
+			}
+		}
+	}
+}
+
+func (worker *EmbeddingWorker) processClaim(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork) (retErr error) {
+	started := worker.clock().UTC()
+	receipt := EmbeddingAttemptReceipt{AttemptID: claim.AttemptID, ProviderFingerprint: work.Descriptor.Fingerprint,
+		ProfileFingerprint: work.ProcessingProfile.Fingerprint, BindingID: work.Binding.Name,
+		InputKind: work.Binding.InputKind, Rows: len(work.InputGeneration.Inputs), Dimensions: work.Descriptor.Dimension}
+	leaseCtx, stopLease := worker.keepEmbeddingLease(ctx, claim)
+	attemptCtx, cancelAttempt := context.WithTimeout(leaseCtx, worker.attemptLifetime)
+	defer func() {
+		// The provider's time budget must not cancel the context needed to
+		// persist its outcome. Keep renewing the claim through that write.
+		if retErr != nil && ctx.Err() == nil &&
+			errors.Is(context.Cause(attemptCtx), context.DeadlineExceeded) {
+			retErr = worker.failClaim(leaseCtx, claim, work, store.EmbeddingFailureProviderUnavailable, &receipt, started)
+		}
+		cancelAttempt()
+		retErr = errors.Join(retErr, stopLease())
+	}()
+	if err := validateEmbeddingWork(work, worker.maxRows, worker.maxDimensions); err != nil || int64(len(work.InputGeneration.Inputs))*int64(work.Descriptor.Dimension)*4 > worker.maxVectorBlobBytes {
+		return worker.failClaim(attemptCtx, claim, work, store.EmbeddingFailureStaleAuthority, &receipt, started)
+	}
+
+	materializedGeneration := work.InputGeneration
+	result, authorization, code, err := worker.executeBatches(attemptCtx, claim, work, &materializedGeneration, &receipt, started)
+	if err != nil {
+		if isEmbeddingWorkFence(err) {
+			return ErrEmbeddingWorkFenced
+		}
+		if attemptCtx.Err() != nil {
+			return fmt.Errorf("embedding provider work canceled: %w", context.Cause(attemptCtx))
+		}
+		if code == "" {
+			return ErrEmbeddingPersistence
+		}
+		return worker.failClaim(attemptCtx, claim, work, code, &receipt, started)
+	}
+	if err := worker.catalog.ValidateEmbeddingWork(attemptCtx, claim, work, worker.clock().UTC()); err != nil {
+		if isEmbeddingWorkFence(err) {
+			return ErrEmbeddingWorkFenced
+		}
+		return ErrEmbeddingPersistence
+	}
+	materializedWork := work
+	materializedWork.InputGeneration = materializedGeneration
+	record, payload, err := buildEmbeddingSet(materializedWork, result, worker.clock().UTC())
+	if err != nil || int64(len(payload)) > worker.maxVectorBlobBytes {
+		return worker.failClaim(attemptCtx, claim, work, store.EmbeddingFailureInvalidResponse, &receipt, started)
+	}
+	err = worker.gate.MutateContext(attemptCtx, func() error {
+		return worker.persistEmbeddingSet(attemptCtx, claim, record, payload)
+	})
+	if err != nil {
+		if isEmbeddingWorkFence(err) {
+			return ErrEmbeddingWorkFenced
+		}
+		if attemptCtx.Err() != nil {
+			return fmt.Errorf("embedding persistence canceled: %w", context.Cause(attemptCtx))
+		}
+		if errors.Is(err, errEmbeddingReceiptMismatch) {
+			return worker.failClaim(attemptCtx, claim, work, store.EmbeddingFailureInvalidResponse, &receipt, started)
+		}
+		return ErrEmbeddingPersistence
+	}
+	head := store.EmbeddingHeadRecord{Key: store.EmbeddingHeadKey{ContentVersionID: work.ContentVersionID,
+		BindingID: work.Binding.Name, InputKind: work.Binding.InputKind}, SetID: record.ID,
+		VectorSpaceID: work.VectorSpaceID, ProcessingProfileFingerprint: work.ProcessingProfile.Fingerprint,
+		PublishedAt: metadataEmbeddingTime(worker.clock().UTC()), FencingToken: claim.Epoch}
+	receipt.Elapsed = worker.clock().UTC().Sub(started)
+	if err := worker.gate.MutateContext(attemptCtx, func() error {
+		return worker.authority.PublishEmbeddingWork(attemptCtx, claim, work, head, authorization, receipt, worker.clock().UTC())
+	}); err != nil {
+		if isEmbeddingWorkFence(err) {
+			return ErrEmbeddingWorkFenced
+		}
+		if isEmbeddingConsentFailure(err) {
+			return worker.failClaim(attemptCtx, claim, work, store.EmbeddingFailureAuthorization, &receipt, started)
+		}
+		return ErrEmbeddingPersistence
+	}
+	return nil
+}
+
+func (worker *EmbeddingWorker) executeBatches(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork,
+	materializedGeneration *store.EmbeddingInputGenerationRecord, receipt *EmbeddingAttemptReceipt, started time.Time,
+) (document.EmbeddingResult, store.ProviderOperationAuthorization, store.EmbeddingFailureCode, error) {
+	batchSize := min(work.Binding.MaxBatchItems, worker.maxRows)
+	result := document.EmbeddingResult{Vectors: make([]document.EmbeddingVector, 0, len(work.InputGeneration.Inputs))}
+	var prior store.ProviderOperationAuthorization
+	var execution EmbeddingExecution
+	for offset := 0; offset < len(work.InputGeneration.Inputs); {
+		end := min(offset+batchSize, len(work.InputGeneration.Inputs))
+		var batchResult document.EmbeddingResult
+		transientAttempts := 0
+		for {
+			if worker.clock().UTC().Sub(started) > worker.attemptLifetime {
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureProviderUnavailable, errors.New("attempt expired")
+			}
+			if err := worker.catalog.ValidateEmbeddingWork(ctx, claim, work, worker.clock().UTC()); err != nil {
+				return document.EmbeddingResult{}, prior, "", err
+			}
+			var err error
+			if execution.Provider == nil || work.Binding.InputKind == document.EmbeddingInputOriginalFile {
+				execution, err = worker.runtime.Prepare(ctx, work)
+				if err != nil {
+					closeEmbeddingInputs(execution.Inputs)
+					switch {
+					case isEmbeddingWorkFence(err):
+						return document.EmbeddingResult{}, prior, "", err
+					case isEmbeddingConsentFailure(err):
+						return document.EmbeddingResult{}, prior, store.EmbeddingFailureAuthorization, err
+					case errors.Is(err, ErrEmbeddingInputRejected):
+						return document.EmbeddingResult{}, prior, store.EmbeddingFailureInputRejected, err
+					case errors.Is(err, ErrEmbeddingRuntimeUnavailable):
+						return document.EmbeddingResult{}, prior, store.EmbeddingFailureProviderUnavailable, err
+					default:
+						return document.EmbeddingResult{}, prior, "", err
+					}
+				}
+				if embeddingInterfaceNil(execution.Provider) {
+					closeEmbeddingInputs(execution.Inputs)
+					return document.EmbeddingResult{}, prior, store.EmbeddingFailureProviderUnavailable, ErrEmbeddingRuntimeUnavailable
+				}
+				hydrated, err := validateEmbeddingExecution(work, execution)
+				if err != nil {
+					closeEmbeddingInputs(execution.Inputs)
+					return document.EmbeddingResult{}, prior, store.EmbeddingFailureInvalidResponse, err
+				}
+				*materializedGeneration = hydrated
+			}
+			end, err = boundedEmbeddingBatchEnd(execution.Provider, work, execution.Inputs, offset, end)
+			if err != nil {
+				closeEmbeddingInputs(execution.Inputs)
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureInputRejected, err
+			}
+			batch := execution.Inputs[offset:end]
+			priorPtr := (*store.ProviderOperationAuthorization)(nil)
+			if prior.GrantID != "" {
+				priorPtr = &prior
+			}
+			authorization := document.EmbeddingAuthorization{ProviderID: work.Descriptor.ID,
+				DescriptorFingerprint: work.Descriptor.Fingerprint, PolicyFingerprint: work.Descriptor.PolicyFingerprint,
+				MaxBatchItems: min(work.Binding.MaxBatchItems, len(batch)), MaxInputBytes: work.Binding.MaxInputBytes,
+				MaxResponseBytes: work.Binding.MaxResponseBytes}
+			if err := document.ValidateEmbeddingProviderRequest(execution.Provider, batch, authorization); err != nil {
+				closeEmbeddingInputs(execution.Inputs)
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureInputRejected, err
+			}
+			authorized, fence, err := worker.catalog.BeginEmbeddingProviderEgress(ctx, claim, work, priorPtr, worker.clock().UTC())
+			if err != nil {
+				closeEmbeddingInputs(execution.Inputs)
+				if isEmbeddingConsentFailure(err) {
+					return document.EmbeddingResult{}, prior, store.EmbeddingFailureAuthorization, err
+				}
+				return document.EmbeddingResult{}, prior, "", err
+			}
+			prior = authorized
+			receipt.ProviderCalls++
+			batchResult, err = func() (document.EmbeddingResult, error) {
+				defer fence.Close()
+				return document.ExecuteEmbedding(ctx, execution.Provider, batch, authorization)
+			}()
+			closeEmbeddingInputs(execution.Inputs)
+			if err == nil {
+				batchResult = normalizeEmbeddingProviderResult(batch, batchResult)
+				break
+			}
+			if ctx.Err() != nil {
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureProviderUnavailable, ctx.Err()
+			}
+			if errors.Is(err, document.ErrEmbeddingInvalidResult) {
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureInvalidResponse, err
+			}
+			classification, retryAfter := execution.Classify(err)
+			if classification == EmbeddingProviderInvalidResponse {
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureInvalidResponse, err
+			}
+			if classification == EmbeddingProviderCapacity {
+				if len(batch) > 1 {
+					batchSize = max(1, len(batch)/2)
+					end = offset + batchSize
+					receipt.Retries++
+					continue
+				}
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureInputRejected, err
+			}
+			if classification == EmbeddingProviderAuthorization {
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureAuthorization, err
+			}
+			if classification != EmbeddingProviderTransient {
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureInputRejected, err
+			}
+			transientAttempts++
+			if transientAttempts == worker.retryLimit {
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureProviderUnavailable, err
+			}
+			receipt.Retries++
+			delay := min(worker.retryBaseDelay*(1<<(transientAttempts-1)), worker.maxRetryDelay)
+			if retryAfter > 0 {
+				delay = min(retryAfter, worker.maxRetryDelay)
+			}
+			if err := worker.wait(ctx, delay); err != nil {
+				return document.EmbeddingResult{}, prior, store.EmbeddingFailureProviderUnavailable, err
+			}
+		}
+		result.Vectors = append(result.Vectors, batchResult.Vectors...)
+		offset = end
+	}
+	return result, prior, "", nil
+}
+
+func boundedEmbeddingBatchEnd(provider document.EmbeddingProvider, work EmbeddingWork,
+	inputs []document.EmbeddingInput, offset, upper int,
+) (int, error) {
+	vectorBytes := int64(work.Descriptor.Dimension) * 4
+	if vectorBytes < 1 || work.Binding.MaxResponseBytes < vectorBytes {
+		return 0, errors.New("embedding response byte authority cannot hold one vector")
+	}
+	upper = min(upper, offset+int(work.Binding.MaxResponseBytes/vectorBytes))
+	if upper <= offset {
+		return 0, errors.New("embedding batch response authority is invalid")
+	}
+	valid := func(end int) error {
+		authorization := document.EmbeddingAuthorization{ProviderID: work.Descriptor.ID,
+			DescriptorFingerprint: work.Descriptor.Fingerprint, PolicyFingerprint: work.Descriptor.PolicyFingerprint,
+			MaxBatchItems: end - offset, MaxInputBytes: work.Binding.MaxInputBytes,
+			MaxResponseBytes: work.Binding.MaxResponseBytes}
+		return document.ValidateEmbeddingProviderRequest(provider, inputs[offset:end], authorization)
+	}
+	if err := valid(offset + 1); err != nil {
+		return 0, err
+	}
+	low := offset + 1
+	for high := upper; low < high; {
+		middle := low + (high-low+1)/2
+		if err := valid(middle); err != nil {
+			high = middle - 1
+		} else {
+			low = middle
+		}
+	}
+	return low, nil
+}
+
+func normalizeEmbeddingProviderResult(inputs []document.EmbeddingInput, result document.EmbeddingResult) document.EmbeddingResult {
+	if len(result.Vectors) == 0 || result.Vectors[0].Index == nil {
+		return result
+	}
+	ordered := make([]document.EmbeddingVector, len(inputs))
+	for _, vector := range result.Vectors {
+		ordered[*vector.Index] = vector
+	}
+	result.Vectors = ordered
+	return result
+}
+
+var errEmbeddingReceiptMismatch = errors.New("embedding blob receipt mismatch")
+
+func (worker *EmbeddingWorker) persistEmbeddingSet(ctx context.Context, claim EmbeddingWorkClaim,
+	record store.EmbeddingSetRecord, payload []byte,
+) error {
+	return worker.blobs.WithMutation(ctx, func() error {
+		receipt, writeErr := worker.blobs.WriteDetailedContext(ctx, bytes.NewReader(payload))
+		if writeErr != nil {
+			return writeErr
+		}
+		if receipt.Hash != record.VectorSet.PayloadBlobHash || receipt.Size != int64(len(payload)) {
+			return errEmbeddingReceiptMismatch
+		}
+		encoding, err := receipt.EncodingName()
+		if err != nil {
+			return err
+		}
+		physical := store.BlobPhysical{Encoding: encoding, StoredBytes: receipt.StoredSize,
+			PackEligible: receipt.PackEligible, Created: receipt.Created}
+		if err := worker.authority.RecordRenditionBlob(ctx, receipt.Hash, receipt.Size, physical); err != nil {
+			return err
+		}
+		return worker.authority.StageEmbeddingSetWithLease(ctx, record,
+			claim.AttemptID, claim.Epoch, worker.clock().UTC())
+	})
+}
+
+func (worker *EmbeddingWorker) failClaim(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork,
+	code store.EmbeddingFailureCode, receipt *EmbeddingAttemptReceipt, started time.Time,
+) error {
+	receipt.FailureCode = string(code)
+	receipt.Elapsed = worker.clock().UTC().Sub(started)
+	if err := worker.gate.MutateContext(ctx, func() error {
+		return worker.catalog.FailEmbeddingWork(ctx, claim, work, code, *receipt, worker.clock().UTC())
+	}); err != nil {
+		if isEmbeddingWorkFence(err) {
+			return ErrEmbeddingWorkFenced
+		}
+		if ctx.Err() != nil {
+			return fmt.Errorf("embedding failure recording canceled: %w", context.Cause(ctx))
+		}
+		return ErrEmbeddingPersistence
+	}
+	return nil
+}
+
+func isEmbeddingConsentFailure(err error) bool {
+	return errors.Is(err, store.ErrProcessingConsentRequired) ||
+		errors.Is(err, store.ErrProcessingConsentRevoked) || errors.Is(err, store.ErrProcessingConsentExpired)
+}
+
+func isEmbeddingWorkFence(err error) bool {
+	return errors.Is(err, ErrEmbeddingWorkFenced) ||
+		errors.Is(err, store.ErrEmbeddingJobFenced) ||
+		errors.Is(err, store.ErrEmbeddingAuthorityStale) ||
+		errors.Is(err, store.ErrCurrentRenditionRootFenced)
+}
+
+func (worker *EmbeddingWorker) keepEmbeddingLease(ctx context.Context, claim EmbeddingWorkClaim) (context.Context, func() error) {
+	leaseCtx, cancel := context.WithCancelCause(ctx)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	interval := max(worker.leaseDuration/3, time.Second)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				done <- nil
+				return
+			case <-leaseCtx.Done():
+				done <- nil
+				return
+			case <-ticker.C:
+				err := worker.gate.MutateContext(leaseCtx, func() error {
+					_, err := worker.catalog.RenewEmbeddingWork(leaseCtx, claim, worker.clock().UTC(), worker.leaseDuration)
+					return err
+				})
+				if leaseCtx.Err() != nil {
+					done <- nil
+					return
+				}
+				if err != nil {
+					cause := ErrEmbeddingPersistence
+					if isEmbeddingWorkFence(err) {
+						cause = ErrEmbeddingWorkFenced
+					}
+					cancel(cause)
+					done <- cause
+					return
+				}
+			}
+		}
+	}()
+	var once sync.Once
+	var result error
+	return leaseCtx, func() error {
+		once.Do(func() {
+			close(stop)
+			cancel(nil)
+			result = <-done
+		})
+		return result
+	}
+}
+
+func validateEmbeddingWork(work EmbeddingWork, maxRows, maxDimensions int) error {
+	descriptor, err := document.NewEmbeddingDescriptor(work.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, work.Descriptor) {
+		return errors.New("embedding descriptor is not canonical")
+	}
+	if descriptor.Dimension > maxDimensions || len(work.InputGeneration.Inputs) > maxRows ||
+		len(work.InputGeneration.Inputs) == 0 || descriptor.Fingerprint != work.Binding.Descriptor.Fingerprint ||
+		descriptor.ID != work.Binding.Descriptor.ID || descriptor.Dimension != work.Binding.Dimensions ||
+		descriptor.CompatibilityID != work.Binding.CompatibilityID || descriptor.Model != work.Binding.Model ||
+		descriptor.Metric != work.Binding.Metric || descriptor.Normalization != work.Binding.Normalization ||
+		descriptor.ScalarEncoding != work.Binding.ScalarEncoding || descriptor.ModelInput.Fingerprint != work.Binding.ModelInput.Fingerprint {
+		return errors.New("embedding descriptor does not match binding")
+	}
+	var profile document.ProcessingProfileV1
+	if err := json.Unmarshal(work.ProcessingProfile.CanonicalProfile, &profile); err != nil {
+		return errors.New("embedding processing profile is invalid")
+	}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	if err != nil || !bytes.Equal(canonical, work.ProcessingProfile.CanonicalProfile) ||
+		fingerprints.Profile != work.ProcessingProfile.Fingerprint || fingerprints.VectorSpace[work.Binding.Name] != work.VectorSpaceID {
+		return errors.New("embedding processing profile authority drifted")
+	}
+	found := false
+	for _, binding := range profile.Embeddings {
+		if binding.Name == work.Binding.Name && reflect.DeepEqual(binding, work.Binding) {
+			found = true
+		}
+	}
+	if !found || work.InputGeneration.SourceVersionID != work.ContentVersionID ||
+		work.InputGeneration.ProcessingProfileFingerprint != work.ProcessingProfile.Fingerprint {
+		return errors.New("embedding binding or generation authority drifted")
+	}
+	return nil
+}
+
+func validateEmbeddingExecution(work EmbeddingWork, execution EmbeddingExecution) (store.EmbeddingInputGenerationRecord, error) {
+	if len(execution.Inputs) != len(work.InputGeneration.Inputs) ||
+		!reflect.DeepEqual(execution.Provider.Descriptor(), work.Descriptor) || execution.Classify == nil {
+		return store.EmbeddingInputGenerationRecord{}, errors.New("embedding execution does not match work")
+	}
+	for index, input := range execution.Inputs {
+		reference := work.InputGeneration.Inputs[index]
+		if input.Key != reference.ID || input.Kind != work.Binding.InputKind || input.Role != document.EmbeddingRoleDocument {
+			return store.EmbeddingInputGenerationRecord{}, errors.New("embedding execution input order or role drifted")
+		}
+		if input.Kind == document.EmbeddingInputRenditionChunk {
+			if workerHashString(work.Binding.ModelInput.EncodeDocument(input.Text)) != reference.RenderedChecksum {
+				return store.EmbeddingInputGenerationRecord{}, errors.New("embedding execution text checksum drifted")
+			}
+		} else if embeddingInterfaceNil(input.Source) || input.Source.Metadata().SHA256 != reference.RenderedChecksum {
+			return store.EmbeddingInputGenerationRecord{}, errors.New("embedding execution original checksum drifted")
+		}
+	}
+	if work.Binding.InputKind != document.EmbeddingInputRenditionChunk || work.InputGeneration.GenerationBlobHash == "" {
+		return work.InputGeneration, nil
+	}
+	hydrated, err := store.HydrateEmbeddingInputGeneration(work.InputGeneration, execution.InputGenerationJSON, execution.EvidenceJSON)
+	if err != nil {
+		return store.EmbeddingInputGenerationRecord{}, err
+	}
+	return hydrated, nil
+}
+
+func buildEmbeddingSet(work EmbeddingWork, result document.EmbeddingResult, now time.Time) (store.EmbeddingSetRecord, []byte, error) {
+	keys := make([]string, len(work.InputGeneration.Inputs))
+	checksums := make([]string, len(keys))
+	values := make([][]float64, len(keys))
+	for index, input := range work.InputGeneration.Inputs {
+		keys[index], checksums[index] = input.ID, input.RenderedChecksum
+		values[index] = make([]float64, len(result.Vectors[index].Values))
+		for column, value := range result.Vectors[index].Values {
+			values[index][column] = float64(value)
+		}
+	}
+	set, err := document.NewVectorSetV1(document.VectorSetV1Input{VectorSpaceFingerprint: work.VectorSpaceID,
+		Metric: work.Descriptor.Metric, Normalization: work.Descriptor.Normalization,
+		Dimension: work.Descriptor.Dimension, InputKeys: keys, InputChecksums: checksums, Values: values})
+	if err != nil {
+		return store.EmbeddingSetRecord{}, nil, err
+	}
+	payload, checksum, err := document.EncodeVectorSetV1(set)
+	if err != nil {
+		return store.EmbeddingSetRecord{}, nil, err
+	}
+	space := store.EmbeddingVectorSpaceRecord{ID: work.VectorSpaceID,
+		ContractVersion: store.EmbeddingVectorSpaceContractV1, Descriptor: work.Descriptor}
+	vectorSet := store.EmbeddingVectorSetRecord{ID: checksum, ContractVersion: store.EmbeddingVectorSetContractV1,
+		VectorSpaceID: work.VectorSpaceID, PayloadBlobHash: workerHashBytes(payload), PayloadSize: int64(len(payload)),
+		PayloadChecksum: checksum, Payload: payload}
+	setID := workerHashString("embedding-set/v1\x00" + work.VaultID + "\x00" + work.ContentVersionID + "\x00" +
+		work.ProcessingProfile.Fingerprint + "\x00" + work.Binding.Name + "\x00" + string(work.Binding.InputKind) + "\x00" +
+		work.InputGeneration.ID + "\x00" + checksum)
+	record := store.EmbeddingSetRecord{ID: setID, VaultID: work.VaultID, BindingID: work.Binding.Name,
+		InputKind: work.Binding.InputKind, ContentVersionID: work.ContentVersionID,
+		ProcessingProfileFingerprint: work.ProcessingProfile.Fingerprint,
+		EmbeddingInputFingerprint:    work.EmbeddingInputFingerprint,
+		VectorSpace:                  space, InputGeneration: work.InputGeneration, VectorSet: vectorSet, CreatedAt: metadataEmbeddingTime(now)}
+	return record, payload, nil
+}
+
+func metadataEmbeddingTime(value time.Time) string {
+	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
+}
+func workerHashString(value string) string { return workerHashBytes([]byte(value)) }
+func workerHashBytes(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}
+
+func waitEmbeddingWorker(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func closeEmbeddingInputs(inputs []document.EmbeddingInput) {
+	seen := make(map[document.AuthorizedUpload]struct{})
+	for _, input := range inputs {
+		if embeddingInterfaceNil(input.Source) {
+			continue
+		}
+		if _, exists := seen[input.Source]; exists {
+			continue
+		}
+		seen[input.Source] = struct{}{}
+		_ = input.Source.Close()
+	}
+}
+
+func embeddingInterfaceNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	return reflected.Kind() == reflect.Pointer && reflected.IsNil()
+}

--- a/internal/processing/embedding_worker_test.go
+++ b/internal/processing/embedding_worker_test.go
@@ -1,0 +1,1834 @@
+package processing
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"image/color"
+	"io"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/packstore"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media/mediatest"
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestEmbeddingWorkerPublishesBindingsAndInputKindsIndependently(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	chunk := fixture.work("chunks-a", document.EmbeddingInputRenditionChunk, "chunk-a")
+	second := fixture.work("chunks-b", document.EmbeddingInputRenditionChunk, "chunk-b")
+	direct := fixture.work("direct", document.EmbeddingInputOriginalFile, "original")
+	fixture.catalog.enqueue(chunk, second, direct)
+
+	worker := fixture.worker(t)
+	processed, err := worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 3, processed)
+	assert.Equal(t, []string{"chunk-a", "chunk-b", "original"}, fixture.catalog.publishedBindings())
+	assert.Len(t, fixture.catalog.heads, 3)
+	assert.NotEqual(t, fixture.catalog.heads[headKey(chunk)].SetID, fixture.catalog.heads[headKey(second)].SetID)
+	assert.Equal(t, 3, fixture.runtime.calls())
+}
+
+func TestEmbeddingWorkerFailureDoesNotDisturbSiblingPublication(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	good := fixture.work("good", document.EmbeddingInputRenditionChunk, "good")
+	retrying := fixture.work("retry", document.EmbeddingInputRenditionChunk, "retry")
+	terminal := fixture.work("terminal", document.EmbeddingInputOriginalFile, "terminal")
+	fixture.runtime.failures[retrying.Binding.Name] = []error{embeddingTransientError{retryAfter: 2 * time.Millisecond}}
+	fixture.runtime.failures[terminal.Binding.Name] = []error{embeddingPermanentError{}}
+	fixture.catalog.enqueue(good, retrying, terminal)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 3, processed)
+	assert.Contains(t, fixture.catalog.heads, headKey(good))
+	assert.Contains(t, fixture.catalog.heads, headKey(retrying))
+	assert.NotContains(t, fixture.catalog.heads, headKey(terminal))
+	assert.Equal(t, store.EmbeddingFailureInputRejected, fixture.catalog.failures[headKey(terminal)])
+	assert.Equal(t, 2, fixture.runtime.callCount(retrying.Binding.Name))
+}
+
+func TestEmbeddingWorkerRejectsMalformedProviderResultsWithoutPublishing(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(document.EmbeddingResult) document.EmbeddingResult
+	}{
+		{"missing", func(value document.EmbeddingResult) document.EmbeddingResult {
+			value.Vectors = value.Vectors[:1]
+			return value
+		}},
+		{"duplicate", func(value document.EmbeddingResult) document.EmbeddingResult {
+			value.Vectors[1].Key = value.Vectors[0].Key
+			return value
+		}},
+		{"reordered", func(value document.EmbeddingResult) document.EmbeddingResult {
+			value.Vectors[0], value.Vectors[1] = value.Vectors[1], value.Vectors[0]
+			return value
+		}},
+		{"wrong dimension", func(value document.EmbeddingResult) document.EmbeddingResult {
+			value.Vectors[0].Values = value.Vectors[0].Values[:1]
+			return value
+		}},
+		{"non finite", func(value document.EmbeddingResult) document.EmbeddingResult {
+			value.Vectors[0].Values[0] = float32(math.NaN())
+			return value
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			work := fixture.work(test.name, document.EmbeddingInputRenditionChunk, "semantic")
+			fixture.runtime.mutate[work.Binding.Name] = test.mutate
+			fixture.catalog.enqueue(work)
+			processed, err := fixture.worker(t).ScanOnce(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, 1, processed)
+			assert.Empty(t, fixture.catalog.heads)
+			assert.Equal(t, store.EmbeddingFailureInvalidResponse, fixture.catalog.failures[headKey(work)])
+		})
+	}
+}
+
+func TestEmbeddingWorkerRejectsMissingExactE2ArtifactBeforeProviderCall(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("missing-e2-artifact", document.EmbeddingInputRenditionChunk, "semantic")
+	work.InputGeneration.GenerationBlobHash = workerHash("canonical-e2-artifact")
+	work.InputGeneration.GenerationEncodedSize = 128
+	fixture.catalog.enqueue(work)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	assert.Zero(t, fixture.runtime.callCount(work.Binding.Name))
+	assert.Empty(t, fixture.catalog.staged)
+	assert.Equal(t, store.EmbeddingFailureInvalidResponse, fixture.catalog.failures[headKey(work)])
+}
+
+func TestEmbeddingWorkerNormalizesValidIndexedResultsIntoInputOrder(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("indexed-order", document.EmbeddingInputRenditionChunk, "semantic")
+	fixture.runtime.mutate[work.Binding.Name] = func(value document.EmbeddingResult) document.EmbeddingResult {
+		zero, one := 0, 1
+		value.Vectors[0].Index = &zero
+		value.Vectors[1].Index = &one
+		value.Vectors[0], value.Vectors[1] = value.Vectors[1], value.Vectors[0]
+		return value
+	}
+	fixture.catalog.enqueue(work)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	set := fixture.catalog.onlyStaged(t)
+	decoded, _, err := document.DecodeVectorSetV1(set.VectorSet.Payload, document.VectorBounds{
+		MaxRows: 2, MaxDimension: work.Descriptor.Dimension, MaxBytes: len(set.VectorSet.Payload),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, work.InputGeneration.Inputs[0].ID, decoded.InputKeys[0])
+	assert.Equal(t, []float32{1, 2}, decoded.Vectors[0])
+	assert.Equal(t, work.InputGeneration.Inputs[1].ID, decoded.InputKeys[1])
+	assert.Equal(t, []float32{2, 2}, decoded.Vectors[1])
+}
+
+func TestEmbeddingWorkerAttemptDeadlineCoversProviderAndPersistence(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("deadline", document.EmbeddingInputRenditionChunk, "semantic")
+	fixture.catalog.enqueue(work)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	assert.True(t, fixture.runtime.sawDeadline())
+	assert.True(t, fixture.blobs.sawDeadline())
+}
+
+func TestEmbeddingWorkerReopensAuthorizedOriginalForEveryRetry(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("direct-retry", document.EmbeddingInputOriginalFile, "direct")
+	fixture.runtime.failures[work.Binding.Name] = []error{embeddingTransientError{}}
+	fixture.runtime.reopenOriginal = true
+	fixture.runtime.consumeOriginal = true
+	fixture.catalog.enqueue(work)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	assert.Equal(t, 2, fixture.runtime.callCount(work.Binding.Name))
+	assert.Equal(t, 2, fixture.runtime.prepareCount(work.Binding.Name))
+	assert.Contains(t, fixture.catalog.heads, headKey(work))
+}
+
+func TestProviderEmbeddingRuntimeReopensAndReauthorizesOriginalEveryPrepare(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("production-direct", document.EmbeddingInputOriginalFile, "direct")
+	data := mediatest.PNG(2, 2, color.White)
+	work.SourceBlobHash = workerHashBytes(data)
+	work.SourceBytes = int64(len(data))
+	work.SourceFilename = "synthetic.png"
+	work.SourceMediaType = "image/png"
+	blobs := &embeddingRuntimeTestBlobs{data: data}
+	provider := &embeddingWorkerProvider{runtime: fixture.runtime, binding: work.Binding.Name, descriptor: work.Descriptor}
+	runtime, err := NewProviderEmbeddingRuntime(provider, blobs, t.TempDir(), fixture.runtime.Classify)
+	require.NoError(t, err)
+
+	first, err := runtime.Prepare(t.Context(), work)
+	require.NoError(t, err)
+	require.Len(t, first.Inputs, 1)
+	assert.Equal(t, work.SourceBlobHash, first.Inputs[0].Source.Metadata().SHA256)
+	require.NoError(t, first.Inputs[0].Source.Close())
+	second, err := runtime.Prepare(t.Context(), work)
+	require.NoError(t, err)
+	require.NoError(t, second.Inputs[0].Source.Close())
+	assert.Equal(t, 2, blobs.opens)
+}
+
+func TestProviderEmbeddingRuntimeRejectsUnboundedOriginalAuthority(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("production-direct-bound", document.EmbeddingInputOriginalFile, "direct")
+	data := mediatest.PNG(2, 2, color.White)
+	work.SourceBlobHash = workerHashBytes(data)
+	work.SourceBytes = work.Binding.MaxInputBytes + 1
+	work.SourceFilename = "synthetic.png"
+	work.SourceMediaType = "image/png"
+	blobs := &embeddingRuntimeTestBlobs{data: data}
+	provider := &embeddingWorkerProvider{runtime: fixture.runtime, binding: work.Binding.Name, descriptor: work.Descriptor}
+
+	_, err := NewProviderEmbeddingRuntime(provider, blobs, "relative-spool", fixture.runtime.Classify)
+	require.ErrorContains(t, err, "absolute")
+	runtime, err := NewProviderEmbeddingRuntime(provider, blobs, t.TempDir(), fixture.runtime.Classify)
+	require.NoError(t, err)
+	_, err = runtime.Prepare(t.Context(), work)
+	require.ErrorContains(t, err, "byte authority")
+	assert.Zero(t, blobs.opens)
+}
+
+func TestEmbeddingWorkerFencesLeaseConsentAndAuthorityDrift(t *testing.T) {
+	tests := []struct {
+		name string
+		hook func(*embeddingWorkerFakeCatalog)
+	}{
+		{"consent before call", func(c *embeddingWorkerFakeCatalog) { c.failAuthorizeAt = 1 }},
+		{"consent before retry", func(c *embeddingWorkerFakeCatalog) { c.failAuthorizeAt = 2 }},
+		{"source drift before stage", func(c *embeddingWorkerFakeCatalog) { c.failValidateAt = 2 }},
+		{"consent before publish", func(c *embeddingWorkerFakeCatalog) { c.failPublish = store.ErrProcessingConsentRevoked }},
+		{"stale attempt loses", func(c *embeddingWorkerFakeCatalog) { c.failPublish = ErrEmbeddingWorkFenced }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			work := fixture.work(test.name, document.EmbeddingInputRenditionChunk, "semantic")
+			if test.name == "consent before retry" {
+				fixture.runtime.failures[work.Binding.Name] = []error{embeddingTransientError{}}
+			}
+			test.hook(fixture.catalog)
+			fixture.catalog.enqueue(work)
+			processed, err := fixture.worker(t).ScanOnce(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, 1, processed)
+			assert.Empty(t, fixture.catalog.heads)
+			assert.NotContains(t, fixture.catalog.receiptsText(), "synthetic input")
+		})
+	}
+}
+
+func TestEmbeddingWorkerContinuesAfterClaimLosesPublicationFence(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	first := fixture.work("lost-publication-fence", document.EmbeddingInputRenditionChunk, "first")
+	second := fixture.work("after-lost-publication-fence", document.EmbeddingInputRenditionChunk, "second")
+	fixture.catalog.failPublish = store.ErrEmbeddingJobFenced
+	fixture.catalog.failFailure = store.ErrEmbeddingJobFenced
+	fixture.catalog.enqueue(first, second)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, processed)
+	assert.NotContains(t, fixture.catalog.heads, headKey(first))
+	assert.Contains(t, fixture.catalog.heads, headKey(second))
+}
+
+func TestEmbeddingWorkerContinuesAfterClaimLosesStageOrFinishFence(t *testing.T) {
+	for _, phase := range []string{"stage", "finish"} {
+		t.Run(phase, func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			first := fixture.work("lost-"+phase+"-fence", document.EmbeddingInputRenditionChunk, "first")
+			second := fixture.work("after-"+phase+"-fence", document.EmbeddingInputRenditionChunk, "second")
+			if phase == "stage" {
+				fixture.catalog.failStage = store.ErrCurrentRenditionRootFenced
+			} else {
+				fixture.catalog.failFinish = store.ErrEmbeddingJobFenced
+			}
+			fixture.catalog.enqueue(first, second)
+
+			processed, err := fixture.worker(t).ScanOnce(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, 2, processed)
+			assert.Contains(t, fixture.catalog.heads, headKey(second))
+			assert.NotContains(t, fixture.catalog.heads, headKey(first))
+		})
+	}
+}
+
+func TestEmbeddingWorkerResumesAfterLeaseExpiryAndDeduplicatesScan(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("resume", document.EmbeddingInputRenditionChunk, "semantic")
+	fixture.catalog.enqueue(work, work)
+	first := fixture.worker(t)
+	second := fixture.worker(t)
+
+	processed, err := first.ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	processed, err = second.ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, processed)
+	assert.Len(t, fixture.catalog.heads, 1)
+	assert.Equal(t, 1, fixture.runtime.callCount(work.Binding.Name))
+}
+
+func TestEmbeddingWorkerBoundsRetriesAndRejectsCapacity(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	retry := fixture.work("retry-bounds", document.EmbeddingInputRenditionChunk, "retry")
+	capacity := fixture.work("capacity", document.EmbeddingInputRenditionChunk, "capacity")
+	capacity.Inputs = capacity.Inputs[:1]
+	capacity.InputGeneration.Inputs = capacity.InputGeneration.Inputs[:1]
+	fixture.runtime.failures[retry.Binding.Name] = []error{
+		embeddingTransientError{retryAfter: time.Hour}, embeddingTransientError{}, embeddingTransientError{},
+	}
+	fixture.runtime.failures[capacity.Binding.Name] = []error{embeddingCapacityError{}}
+	fixture.catalog.enqueue(retry, capacity)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, processed)
+	assert.Equal(t, 3, fixture.runtime.callCount(retry.Binding.Name))
+	assert.Equal(t, store.EmbeddingFailureProviderUnavailable, fixture.catalog.failures[headKey(retry)])
+	assert.Equal(t, store.EmbeddingFailureInputRejected, fixture.catalog.failures[headKey(capacity)])
+	assert.LessOrEqual(t, fixture.totalWait, 15*time.Millisecond)
+}
+
+func TestEmbeddingWorkerSplitsBatchesByBytesAndMultiItemCapacity(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	bytesWork := fixture.work("byte-batches", document.EmbeddingInputRenditionChunk, "byte-batches")
+	bytesWork = mutateEmbeddingWorkerBinding(t, bytesWork, func(binding *document.EmbeddingBindingV1) {
+		binding.MaxInputBytes = 40
+	})
+	capacityWork := fixture.work("capacity-bisect", document.EmbeddingInputRenditionChunk, "capacity-bisect")
+	fixture.runtime.failures[capacityWork.Binding.Name] = []error{embeddingCapacityError{}}
+	fixture.catalog.enqueue(bytesWork, capacityWork)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, processed)
+	assert.Equal(t, []int{1, 1}, fixture.runtime.batchSizes(bytesWork.Binding.Name))
+	assert.Equal(t, []int{2, 1, 1}, fixture.runtime.batchSizes(capacityWork.Binding.Name))
+	assert.Equal(t, 1, fixture.runtime.prepareCount(bytesWork.Binding.Name))
+	assert.Equal(t, 1, fixture.runtime.prepareCount(capacityWork.Binding.Name))
+	assert.Contains(t, fixture.catalog.heads, headKey(bytesWork))
+	assert.Contains(t, fixture.catalog.heads, headKey(capacityWork))
+}
+
+func TestEmbeddingWorkerCapacityBisectionReachesSingleItemBatch(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("capacity-deep-bisect", document.EmbeddingInputRenditionChunk, "capacity-deep-bisect")
+	work.Inputs = nil
+	work.InputGeneration.Inputs = nil
+	for index := range 8 {
+		text := fmt.Sprintf("synthetic capacity item %d", index)
+		inputID := workerHash(fmt.Sprintf("capacity-item-%d", index))
+		work.Inputs = append(work.Inputs, document.EmbeddingInput{
+			Key: inputID, Role: document.EmbeddingRoleDocument,
+			Kind: document.EmbeddingInputRenditionChunk, Text: text,
+		})
+		work.InputGeneration.Inputs = append(work.InputGeneration.Inputs, store.EmbeddingInputReference{
+			ID: inputID, RenderedChecksum: workerHash(work.Binding.ModelInput.EncodeDocument(text)),
+		})
+	}
+	fixture.runtime.capacityAbove[work.Binding.Name] = 1
+	fixture.catalog.enqueue(work)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	assert.Contains(t, fixture.catalog.heads, headKey(work))
+	assert.Equal(t, []int{8, 4, 2, 1, 1, 1, 1, 1, 1, 1, 1}, fixture.runtime.batchSizes(work.Binding.Name))
+}
+
+func TestEmbeddingWorkerCancellationDuringProviderAndPersistenceIsPrompt(t *testing.T) {
+	for _, phase := range []string{"provider", "persistence"} {
+		t.Run(phase, func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			work := fixture.work(phase, document.EmbeddingInputRenditionChunk, "semantic")
+			fixture.catalog.enqueue(work)
+			ctx, cancel := context.WithCancel(t.Context())
+			if phase == "provider" {
+				fixture.runtime.block = true
+				fixture.runtime.onBlock = cancel
+			} else {
+				fixture.blobs.block = true
+				fixture.blobs.onBlock = cancel
+			}
+			started := time.Now()
+			_, err := fixture.worker(t).ScanOnce(ctx)
+			require.ErrorIs(t, err, context.Canceled)
+			assert.Less(t, time.Since(started), time.Second)
+			assert.Empty(t, fixture.catalog.heads)
+		})
+	}
+}
+
+func TestEmbeddingWorkerRejectsCorruptOrPartiallyPersistedVectorSet(t *testing.T) {
+	for _, phase := range []string{"checksum", "blob", "catalog"} {
+		t.Run(phase, func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			work := fixture.work(phase, document.EmbeddingInputRenditionChunk, "semantic")
+			fixture.catalog.enqueue(work)
+			switch phase {
+			case "checksum":
+				fixture.blobs.corruptReceipt = true
+			case "blob":
+				fixture.blobs.writeErr = errors.New("private vector write token=secret")
+			case "catalog":
+				fixture.catalog.failStage = errors.New("private catalog token=secret")
+			}
+			_, err := fixture.worker(t).ScanOnce(t.Context())
+			if phase == "checksum" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.NotContains(t, err.Error(), "token=secret")
+			}
+			assert.Empty(t, fixture.catalog.heads)
+		})
+	}
+}
+
+func TestEmbeddingRuntimeRegistryAndRunLifecycle(t *testing.T) {
+	registry := NewEmbeddingRuntimeRegistry()
+	assert.False(t, registry.Ready())
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("registry", document.EmbeddingInputRenditionChunk, "semantic")
+	require.NoError(t, registry.Register(work.Descriptor.Fingerprint, fixture.runtime))
+	assert.True(t, registry.Ready())
+	fixture.catalog.enqueue(work)
+	fixture.runtimeRegistry = registry
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	worker := fixture.worker(t)
+	go func() { done <- worker.Run(ctx) }()
+	require.Eventually(t, func() bool { return fixture.catalog.headCount() == 1 }, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestEmbeddingWorkerClaimsOnlyAfterMutationGateAdmission(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("gate-admission", document.EmbeddingInputRenditionChunk, "semantic")
+	fixture.catalog.enqueue(work)
+	held := make(chan struct{})
+	release := make(chan struct{})
+	maintenanceDone := make(chan error, 1)
+	go func() {
+		maintenanceDone <- fixture.gate.MaintainContext(t.Context(), func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	worker := fixture.worker(t)
+	go func() {
+		_, err := worker.ScanOnce(ctx)
+		done <- err
+	}()
+	require.Never(t, func() bool { return fixture.catalog.claimCount() != 0 }, 100*time.Millisecond, 5*time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	close(release)
+	require.NoError(t, <-maintenanceDone)
+}
+
+func TestEmbeddingWorkerReconcilesDurableAuthorityBeforeClaim(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	fixture.catalog.enqueue(fixture.work("reconcile-before-claim", document.EmbeddingInputRenditionChunk, "semantic"))
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	assert.Equal(t, []string{"reconcile", "claim", "claim"}, fixture.catalog.catalogEvents())
+}
+
+func TestEmbeddingRuntimeRegistryClassifiesWithExactExecutingRuntime(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("exact-classifier", document.EmbeddingInputRenditionChunk, "semantic")
+	fixture.runtime.failures[work.Binding.Name] = []error{embeddingPermanentError{}}
+	registry := NewEmbeddingRuntimeRegistry()
+	require.NoError(t, registry.Register(work.Descriptor.Fingerprint, fixture.runtime))
+	require.NoError(t, registry.Register(workerHash("misleading-runtime"), embeddingTransientClassifierRuntime{}))
+	fixture.runtimeRegistry = registry
+	fixture.catalog.enqueue(work)
+
+	processed, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	assert.Equal(t, 1, fixture.runtime.callCount(work.Binding.Name))
+	assert.Equal(t, store.EmbeddingFailureInputRejected, fixture.catalog.failures[headKey(work)])
+}
+
+type embeddingWorkerFixture struct {
+	t               *testing.T
+	now             time.Time
+	descriptor      document.EmbeddingDescriptor
+	profile         store.ProcessingProfileRecord
+	catalog         *embeddingWorkerFakeCatalog
+	blobs           *embeddingWorkerFakeBlobs
+	runtime         *embeddingWorkerFakeRuntime
+	runtimeRegistry EmbeddingRuntime
+	gate            *api.OperationGate
+	totalWait       time.Duration
+}
+
+func newEmbeddingWorkerFixture(t *testing.T) *embeddingWorkerFixture {
+	t.Helper()
+	descriptor := embeddingWorkerDescriptor(t)
+	profile := embeddingWorkerProfile(t, descriptor)
+	fixture := &embeddingWorkerFixture{
+		t: t, now: time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC), descriptor: descriptor,
+		profile: profile, catalog: newEmbeddingWorkerFakeCatalog(), blobs: &embeddingWorkerFakeBlobs{},
+		runtime: &embeddingWorkerFakeRuntime{failures: map[string][]error{}, capacityAbove: map[string]int{}, mutate: map[string]func(document.EmbeddingResult) document.EmbeddingResult{}, callsByBinding: map[string]int{}, preparesByBinding: map[string]int{}, batchesByBinding: map[string][]int{}},
+		gate:    api.NewOperationGate(),
+	}
+	fixture.runtimeRegistry = fixture.runtime
+	return fixture
+}
+
+func (fixture *embeddingWorkerFixture) worker(t *testing.T) *EmbeddingWorker {
+	t.Helper()
+	worker, err := NewEmbeddingWorker(EmbeddingWorkerConfig{
+		Catalog: fixture.catalog, Authority: fixture.catalog, Blobs: fixture.blobs,
+		GenerationBlobs: &embeddingRuntimeTestBlobs{data: []byte("unused")}, Runtime: fixture.runtimeRegistry,
+		Gate: fixture.gate, Owner: "embedding-worker-test", LeaseDuration: 3 * time.Second,
+		IdleDelay: time.Millisecond, RetryLimit: 3, RetryBaseDelay: time.Millisecond,
+		MaxRetryDelay: 5 * time.Millisecond, AttemptLifetime: time.Minute,
+		MaxRows: 100, MaxDimensions: 16, MaxVectorBlobBytes: 1 << 20,
+		DescriptorFingerprints: []string{fixture.descriptor.Fingerprint},
+		Clock:                  func() time.Time { return fixture.now },
+		Wait: func(ctx context.Context, delay time.Duration) error {
+			fixture.totalWait += delay
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				return nil
+			}
+		},
+	})
+	require.NoError(t, err)
+	return worker
+}
+
+func (fixture *embeddingWorkerFixture) work(seed string, kind document.EmbeddingInputKind, binding string) EmbeddingWork {
+	fixture.t.Helper()
+	versionID := "00000000-0000-4000-8000-" + workerHex(seed)[:12]
+	inputRefs := []store.EmbeddingInputReference{
+		{ID: workerHash(seed + "-1"), RenderedChecksum: workerHash("document: synthetic input one")},
+		{ID: workerHash(seed + "-2"), RenderedChecksum: workerHash("document: synthetic input two")},
+	}
+	inputs := []document.EmbeddingInput{
+		{Key: inputRefs[0].ID, Role: document.EmbeddingRoleDocument, Kind: kind, Text: "synthetic input one"},
+		{Key: inputRefs[1].ID, Role: document.EmbeddingRoleDocument, Kind: kind, Text: "synthetic input two"},
+	}
+	if kind == document.EmbeddingInputOriginalFile {
+		inputs = []document.EmbeddingInput{{Key: versionID, Role: document.EmbeddingRoleDocument, Kind: kind, Source: &embeddingWorkerUpload{data: []byte("synthetic original")}}}
+		inputRefs = []store.EmbeddingInputReference{{ID: versionID, RenderedChecksum: workerHash("synthetic original")}}
+	}
+	var selected document.EmbeddingBindingV1
+	var profile document.ProcessingProfileV1
+	require.NoError(fixture.t, jsonUnmarshalProfile(fixture.profile.CanonicalProfile, &profile))
+	for _, candidate := range profile.Embeddings {
+		if candidate.InputKind == kind {
+			selected = candidate
+			break
+		}
+	}
+	selected.Name = binding
+	profile.Embeddings = []document.EmbeddingBindingV1{selected}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	require.NoError(fixture.t, err)
+	processingProfile := store.ProcessingProfileRecord{
+		Fingerprint: fingerprints.Profile, CanonicalProfile: canonical,
+		RenditionRequestFingerprint:    fingerprints.RenditionRequest,
+		EvidenceLexicalFingerprint:     fingerprints.EvidenceLexical,
+		RetentionDisclosureFingerprint: fingerprints.RetentionDisclosure,
+		AttachmentPolicyFingerprint:    profile.RetentionDisclosure.AttachmentPolicyFingerprint,
+		ConsentFingerprint:             profile.RetentionDisclosure.ConsentFingerprint,
+		TrustBoundary:                  profile.RetentionDisclosure.TrustBoundary,
+	}
+	return EmbeddingWork{
+		VaultID: "00000000-0000-4000-8000-000000000001", ContentVersionID: versionID,
+		ProcessingProfile: processingProfile, Binding: selected, Descriptor: fixture.descriptor,
+		VectorSpaceID: fingerprints.VectorSpace[binding], EmbeddingInputFingerprint: fingerprints.EmbeddingInput[binding], Inputs: inputs,
+		InputGeneration: store.EmbeddingInputGenerationRecord{
+			ID: workerHash(seed + "-generation"), SourceVersionID: versionID,
+			ProcessingProfileFingerprint: processingProfile.Fingerprint,
+			EvidenceFingerprint:          workerHash(seed + "-evidence"), TokenizerFingerprint: workerHash(seed + "-tokenizer"),
+			ChunkPolicyFingerprint: workerHash(seed + "-chunk"), FormatterFingerprint: workerHash(seed + "-formatter"),
+			GenerationChecksum: workerHash(seed + "-generation-checksum"), Inputs: inputRefs,
+			CreatedAt: fixture.now.Format("2006-01-02T15:04:05.000000000Z"),
+		},
+		Consent: store.ProviderOperationAuthorizationRequest{
+			Principal: "operator:synthetic", Scope: "embedding:" + binding,
+			ProfileFingerprint: processingProfile.Fingerprint, DisclosureFingerprint: selected.DisclosureFingerprint,
+			InputClasses: []string{string(kind)}, RetainedArtifactClasses: []string{"embedding_vector_set"},
+		},
+	}
+}
+
+func mutateEmbeddingWorkerBinding(t *testing.T, work EmbeddingWork,
+	mutate func(*document.EmbeddingBindingV1),
+) EmbeddingWork {
+	t.Helper()
+	var profile document.ProcessingProfileV1
+	require.NoError(t, json.Unmarshal(work.ProcessingProfile.CanonicalProfile, &profile))
+	require.Len(t, profile.Embeddings, 1)
+	mutate(&profile.Embeddings[0])
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	require.NoError(t, err)
+	work.Binding = profile.Embeddings[0]
+	work.ProcessingProfile = store.ProcessingProfileRecord{Fingerprint: fingerprints.Profile,
+		CanonicalProfile: canonical, RenditionRequestFingerprint: fingerprints.RenditionRequest,
+		EvidenceLexicalFingerprint:     fingerprints.EvidenceLexical,
+		RetentionDisclosureFingerprint: fingerprints.RetentionDisclosure,
+		AttachmentPolicyFingerprint:    profile.RetentionDisclosure.AttachmentPolicyFingerprint,
+		ConsentFingerprint:             profile.RetentionDisclosure.ConsentFingerprint,
+		TrustBoundary:                  profile.RetentionDisclosure.TrustBoundary}
+	work.VectorSpaceID = fingerprints.VectorSpace[work.Binding.Name]
+	work.EmbeddingInputFingerprint = fingerprints.EmbeddingInput[work.Binding.Name]
+	work.InputGeneration.ProcessingProfileFingerprint = fingerprints.Profile
+	work.Consent.ProfileFingerprint = fingerprints.Profile
+	return work
+}
+
+// The rest of this file is a deterministic authority harness. Assertions are
+// made on worker-visible catalog state, never on fake call existence alone.
+type embeddingWorkerFakeCatalog struct {
+	reconcileError                  func() error
+	mu                              sync.Mutex
+	queue                           []EmbeddingWork
+	nextEpoch                       int64
+	heads                           map[string]store.EmbeddingHeadRecord
+	failures                        map[string]store.EmbeddingFailureCode
+	staged                          map[string]store.EmbeddingSetRecord
+	receipts                        []EmbeddingAttemptReceipt
+	authorizeCalls, validateCalls   int
+	failAuthorizeAt, failValidateAt int
+	failPublish, failStage          error
+	failFinish                      error
+	failFailure                     error
+	events                          []string
+}
+
+func newEmbeddingWorkerFakeCatalog() *embeddingWorkerFakeCatalog {
+	return &embeddingWorkerFakeCatalog{heads: map[string]store.EmbeddingHeadRecord{}, failures: map[string]store.EmbeddingFailureCode{}, staged: map[string]store.EmbeddingSetRecord{}}
+}
+
+func (c *embeddingWorkerFakeCatalog) enqueue(work ...EmbeddingWork) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.queue = append(c.queue, work...)
+}
+func (c *embeddingWorkerFakeCatalog) ReconcileEmbeddingJobs(context.Context, store.EmbeddingReconcileRequest) (store.EmbeddingReconcileResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, "reconcile")
+	if c.reconcileError != nil {
+		if err := c.reconcileError(); err != nil {
+			return store.EmbeddingReconcileResult{}, err
+		}
+	}
+	return store.EmbeddingReconcileResult{}, nil
+}
+func (c *embeddingWorkerFakeCatalog) ClaimNextEmbeddingWork(_ context.Context, owner string, now time.Time, lease time.Duration, fingerprints []string) (EmbeddingWorkClaim, EmbeddingWork, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, "claim")
+	for len(c.queue) > 0 {
+		work := c.queue[0]
+		c.queue = c.queue[1:]
+		key := headKey(work)
+		if _, done := c.heads[key]; done {
+			continue
+		}
+		c.nextEpoch++
+		return EmbeddingWorkClaim{AttemptID: workerHash(key), Owner: owner, Epoch: c.nextEpoch, LeaseExpiresAt: now.Add(lease)}, work, true, nil
+	}
+	return EmbeddingWorkClaim{}, EmbeddingWork{}, false, nil
+}
+func (c *embeddingWorkerFakeCatalog) catalogEvents() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.events)
+}
+func (c *embeddingWorkerFakeCatalog) RenewEmbeddingWork(_ context.Context, claim EmbeddingWorkClaim, now time.Time, lease time.Duration) (EmbeddingWorkClaim, error) {
+	claim.LeaseExpiresAt = now.Add(lease)
+	return claim, nil
+}
+func (c *embeddingWorkerFakeCatalog) ValidateEmbeddingWork(_ context.Context, _ EmbeddingWorkClaim, _ EmbeddingWork, _ time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.validateCalls++
+	if c.validateCalls == c.failValidateAt {
+		return ErrEmbeddingWorkFenced
+	}
+	return nil
+}
+func (c *embeddingWorkerFakeCatalog) BeginEmbeddingProviderEgress(_ context.Context, _ EmbeddingWorkClaim, work EmbeddingWork, prior *store.ProviderOperationAuthorization, now time.Time) (store.ProviderOperationAuthorization, *store.ProviderEgressFence, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.authorizeCalls++
+	if c.authorizeCalls == c.failAuthorizeAt {
+		return store.ProviderOperationAuthorization{}, nil, store.ErrProcessingConsentRevoked
+	}
+	return store.ProviderOperationAuthorization{GrantID: "00000000-0000-4000-8000-000000000002", ProcessingIncarnationID: "00000000-0000-4000-8000-000000000003", RevocationFence: 0, AuthorizedAt: now}, nil, nil
+}
+func (c *embeddingWorkerFakeCatalog) RecordRenditionBlob(_ context.Context, hash string, size int64, _ store.BlobPhysical) error {
+	if hash == "" || size == 0 {
+		return errors.New("invalid receipt")
+	}
+	return nil
+}
+func (c *embeddingWorkerFakeCatalog) StageEmbeddingSetWithLease(_ context.Context, record store.EmbeddingSetRecord, _ string, _ int64, _ time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.failStage != nil {
+		err := c.failStage
+		c.failStage = nil
+		return err
+	}
+	c.staged[record.ID] = record
+	return nil
+}
+func (c *embeddingWorkerFakeCatalog) PublishEmbeddingWork(_ context.Context, _ EmbeddingWorkClaim, _ EmbeddingWork,
+	head store.EmbeddingHeadRecord, _ store.ProviderOperationAuthorization, receipt EmbeddingAttemptReceipt, _ time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.failPublish != nil {
+		err := c.failPublish
+		c.failPublish = nil
+		return err
+	}
+	if c.failFinish != nil {
+		err := c.failFinish
+		c.failFinish = nil
+		return err
+	}
+	c.heads[headKeyParts(head.Key.ContentVersionID, head.Key.BindingID, head.Key.InputKind)] = head
+	c.receipts = append(c.receipts, receipt)
+	return nil
+}
+
+func (c *embeddingWorkerFakeCatalog) FailEmbeddingWork(_ context.Context, _ EmbeddingWorkClaim, work EmbeddingWork, code store.EmbeddingFailureCode, receipt EmbeddingAttemptReceipt, _ time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.failFailure != nil {
+		err := c.failFailure
+		c.failFailure = nil
+		return err
+	}
+	c.failures[headKey(work)] = code
+	c.receipts = append(c.receipts, receipt)
+	return nil
+}
+func (c *embeddingWorkerFakeCatalog) publishedBindings() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]string, 0, len(c.heads))
+	for _, head := range c.heads {
+		result = append(result, head.Key.BindingID)
+	}
+	slicesSort(result)
+	return result
+}
+func (c *embeddingWorkerFakeCatalog) receiptsText() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return receiptText(c.receipts)
+}
+
+func (c *embeddingWorkerFakeCatalog) headCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.heads)
+}
+
+func (c *embeddingWorkerFakeCatalog) claimCount() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.nextEpoch
+}
+
+func (c *embeddingWorkerFakeCatalog) onlyStaged(t *testing.T) store.EmbeddingSetRecord {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	require.Len(t, c.staged, 1)
+	for _, value := range c.staged {
+		return value
+	}
+	return store.EmbeddingSetRecord{}
+}
+
+type embeddingWorkerFakeRuntime struct {
+	mu                sync.Mutex
+	failures          map[string][]error
+	capacityAbove     map[string]int
+	mutate            map[string]func(document.EmbeddingResult) document.EmbeddingResult
+	callsByBinding    map[string]int
+	preparesByBinding map[string]int
+	block             bool
+	onBlock           func()
+	reopenOriginal    bool
+	inspectInputs     func([]document.EmbeddingInput)
+	consumeOriginal   bool
+	deadlineSeen      bool
+	batchesByBinding  map[string][]int
+}
+
+func (r *embeddingWorkerFakeRuntime) Ready() bool { return true }
+func (r *embeddingWorkerFakeRuntime) Prepare(_ context.Context, work EmbeddingWork) (EmbeddingExecution, error) {
+	r.mu.Lock()
+	r.preparesByBinding[work.Binding.Name]++
+	reopen := r.reopenOriginal
+	r.mu.Unlock()
+	inputs := slices.Clone(work.Inputs)
+	if reopen {
+		for index := range inputs {
+			if upload, ok := inputs[index].Source.(*embeddingWorkerUpload); ok {
+				inputs[index].Source = &embeddingWorkerUpload{data: slices.Clone(upload.data)}
+			}
+		}
+	}
+	return EmbeddingExecution{Provider: &embeddingWorkerProvider{runtime: r, binding: work.Binding.Name, descriptor: work.Descriptor},
+		Inputs: inputs, InputGenerationJSON: slices.Clone(work.InputGeneration.GenerationJSON), EvidenceJSON: slices.Clone(work.InputGeneration.EvidenceJSON), Classify: r.Classify}, nil
+}
+func (r *embeddingWorkerFakeRuntime) Classify(err error) (EmbeddingProviderFailure, time.Duration) {
+	var transient embeddingTransientError
+	switch {
+	case errors.As(err, &transient):
+		return EmbeddingProviderTransient, transient.retryAfter
+	case errors.As(err, &embeddingCapacityError{}):
+		return EmbeddingProviderCapacity, 0
+	default:
+		return EmbeddingProviderPermanent, 0
+	}
+}
+func (r *embeddingWorkerFakeRuntime) calls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	total := 0
+	for _, n := range r.callsByBinding {
+		total += n
+	}
+	return total
+}
+func (r *embeddingWorkerFakeRuntime) callCount(binding string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.callsByBinding[binding]
+}
+func (r *embeddingWorkerFakeRuntime) prepareCount(binding string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.preparesByBinding[binding]
+}
+func (r *embeddingWorkerFakeRuntime) sawDeadline() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.deadlineSeen
+}
+
+func (r *embeddingWorkerFakeRuntime) batchSizes(binding string) []int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.batchesByBinding[binding])
+}
+
+type embeddingTransientClassifierRuntime struct{}
+
+func (embeddingTransientClassifierRuntime) Ready() bool { return true }
+func (embeddingTransientClassifierRuntime) Prepare(context.Context, EmbeddingWork) (EmbeddingExecution, error) {
+	return EmbeddingExecution{}, errors.New("misleading runtime must never prepare exact work")
+}
+func (embeddingTransientClassifierRuntime) Classify(error) (EmbeddingProviderFailure, time.Duration) {
+	return EmbeddingProviderTransient, 0
+}
+
+type embeddingWorkerProvider struct {
+	runtime    *embeddingWorkerFakeRuntime
+	binding    string
+	descriptor document.EmbeddingDescriptor
+}
+
+func (p *embeddingWorkerProvider) Descriptor() document.EmbeddingDescriptor { return p.descriptor }
+func (p *embeddingWorkerProvider) Embed(ctx context.Context, inputs []document.EmbeddingInput, _ document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	p.runtime.mu.Lock()
+	p.runtime.callsByBinding[p.binding]++
+	p.runtime.batchesByBinding[p.binding] = append(p.runtime.batchesByBinding[p.binding], len(inputs))
+	call := p.runtime.callsByBinding[p.binding]
+	block, onBlock := p.runtime.block, p.runtime.onBlock
+	failures := p.runtime.failures[p.binding]
+	capacityAbove := p.runtime.capacityAbove[p.binding]
+	mutate := p.runtime.mutate[p.binding]
+	inspectInputs := p.runtime.inspectInputs
+	consumeOriginal := p.runtime.consumeOriginal
+	_, p.runtime.deadlineSeen = ctx.Deadline()
+	p.runtime.mu.Unlock()
+	if block {
+		if onBlock != nil {
+			onBlock()
+		}
+		<-ctx.Done()
+		return document.EmbeddingResult{}, ctx.Err()
+	}
+	if inspectInputs != nil {
+		inspectInputs(inputs)
+	}
+	if consumeOriginal {
+		for _, input := range inputs {
+			if input.Source == nil {
+				continue
+			}
+			data, err := io.ReadAll(input.Source)
+			_ = input.Source.Close()
+			if err != nil || len(data) == 0 {
+				return document.EmbeddingResult{}, embeddingPermanentError{}
+			}
+		}
+	}
+	if capacityAbove > 0 && len(inputs) > capacityAbove {
+		return document.EmbeddingResult{}, embeddingCapacityError{}
+	}
+	if call <= len(failures) {
+		return document.EmbeddingResult{}, failures[call-1]
+	}
+	result := document.EmbeddingResult{Vectors: make([]document.EmbeddingVector, len(inputs))}
+	for i, input := range inputs {
+		result.Vectors[i] = document.EmbeddingVector{Key: input.Key, Values: []float32{float32(i + 1), 2}}
+	}
+	if mutate != nil {
+		result = mutate(result)
+	}
+	return result, nil
+}
+
+type embeddingWorkerFakeBlobs struct {
+	block          bool
+	onBlock        func()
+	corruptReceipt bool
+	writeErr       error
+	deadlineSeen   bool
+}
+
+type embeddingRuntimeTestBlobs struct {
+	data    []byte
+	openErr error
+	opens   int
+}
+
+func (blobs *embeddingRuntimeTestBlobs) OpenContext(context.Context, string) (io.ReadSeekCloser, error) {
+	blobs.opens++
+	if blobs.openErr != nil {
+		return nil, blobs.openErr
+	}
+	return &embeddingRuntimeReadSeekCloser{Reader: bytes.NewReader(blobs.data)}, nil
+}
+
+type embeddingRuntimeReadSeekCloser struct{ *bytes.Reader }
+
+func (*embeddingRuntimeReadSeekCloser) Close() error { return nil }
+
+func (b *embeddingWorkerFakeBlobs) WithMutation(_ context.Context, fn func() error) error {
+	return fn()
+}
+func (b *embeddingWorkerFakeBlobs) WriteDetailedContext(ctx context.Context, reader io.Reader) (blob.WriteReceipt, error) {
+	_, b.deadlineSeen = ctx.Deadline()
+	if b.block {
+		if b.onBlock != nil {
+			b.onBlock()
+		}
+		<-ctx.Done()
+		return blob.WriteReceipt{}, ctx.Err()
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return blob.WriteReceipt{}, err
+	}
+	hash := workerHashBytes(data)
+	if b.corruptReceipt {
+		hash = workerHash("corrupt")
+	}
+	return blob.WriteReceipt{Hash: hash, Size: int64(len(data)), StoredSize: int64(len(data)), Encoding: packstore.LooseEncodingRaw, Created: true}, b.writeErr
+}
+func (b *embeddingWorkerFakeBlobs) sawDeadline() bool { return b.deadlineSeen }
+
+type embeddingWorkerUpload struct {
+	closed bool
+	data   []byte
+	offset int
+}
+
+func (u *embeddingWorkerUpload) Read(p []byte) (int, error) {
+	if u.offset >= len(u.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, u.data[u.offset:])
+	u.offset += n
+	return n, nil
+}
+func (u *embeddingWorkerUpload) Close() error { u.closed = true; return nil }
+func (u *embeddingWorkerUpload) Metadata() document.AuthorizedUploadMetadata {
+	return document.AuthorizedUploadMetadata{Filename: "synthetic.pdf", MediaFamily: "pdf", MediaType: "application/pdf",
+		ByteLength: int64(len(u.data)), SHA256: workerHashBytes(u.data), CapabilityRecordChecksum: workerHash("capability"),
+		ProviderMetadataChecksum: workerHash("provider-metadata"), InputKind: document.RenditionInputOriginalFile}
+}
+
+type embeddingTransientError struct{ retryAfter time.Duration }
+
+func (e embeddingTransientError) Error() string { return "synthetic transient" }
+
+type embeddingPermanentError struct{}
+
+func (embeddingPermanentError) Error() string { return "synthetic permanent" }
+
+type embeddingCapacityError struct{}
+
+func (embeddingCapacityError) Error() string { return "synthetic capacity" }
+
+func headKey(work EmbeddingWork) string {
+	return headKeyParts(work.ContentVersionID, work.Binding.Name, work.Binding.InputKind)
+}
+func headKeyParts(version, binding string, kind document.EmbeddingInputKind) string {
+	return version + "\x00" + binding + "\x00" + string(kind)
+}
+func workerHash(value string) string { return workerHashBytes([]byte(value)) }
+func workerHex(value string) string  { return workerHash(value) }
+
+func embeddingWorkerDescriptor(t *testing.T) document.EmbeddingDescriptor {
+	t.Helper()
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{Profile: document.ModelInputProfileCustom, CompatibilityID: "synthetic-space", Document: document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "document: {{content}}"}, Query: document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "query: {{content}}"}})
+	require.NoError(t, err)
+	descriptor, err := document.NewEmbeddingDescriptor(document.EmbeddingDescriptor{ID: "synthetic", ContractVersion: document.EmbeddingProviderContractVersion, PolicyFingerprint: workerHash("policy"), TrustBoundary: document.EmbeddingTrustLocalProcess, Model: "synthetic", ModelRevision: "v1", Dimension: 2, Metric: document.VectorMetricCosine, Normalization: document.VectorNormalizationNone, ScalarEncoding: "float32", DocumentFormatter: "document/v1", QueryFormatter: "query/v1", InputKinds: []document.EmbeddingInputKind{document.EmbeddingInputOriginalFile, document.EmbeddingInputRenditionChunk}, CompatibilityID: "synthetic-space", SupportsTextQuery: true, ModelInput: contract, SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeText}})
+	require.NoError(t, err)
+	return descriptor
+}
+
+func embeddingWorkerProfile(t *testing.T, descriptor document.EmbeddingDescriptor) store.ProcessingProfileRecord {
+	t.Helper()
+	makeBinding := func(name string, kind document.EmbeddingInputKind) document.EmbeddingBindingV1 {
+		binding := document.EmbeddingBindingV1{Activation: document.EmbeddingOptional, AuthorizationFingerprint: workerHash("auth"), CompatibilityID: descriptor.CompatibilityID, CredentialBinding: "credential:synthetic", Descriptor: document.ProviderDescriptorV1{ID: descriptor.ID, Fingerprint: descriptor.Fingerprint}, Dimensions: descriptor.Dimension, DisclosureFingerprint: workerHash("disclosure"), DocumentFormatter: descriptor.DocumentFormatter, InputKind: kind, MaxBatchItems: 8, MaxInputBytes: 1 << 20, MaxResponseBytes: 1 << 20, Metric: descriptor.Metric, ModelInput: descriptor.ModelInput, Model: descriptor.Model, Name: name, Normalization: descriptor.Normalization, QueryFormatter: descriptor.QueryFormatter, ScalarEncoding: descriptor.ScalarEncoding, TrustBoundary: string(descriptor.TrustBoundary)}
+		if kind == document.EmbeddingInputRenditionChunk {
+			binding.MaxInputTokens = 128
+			binding.Chunk = &document.EmbeddingChunkPolicyV1{ContextFingerprint: workerHash("context"), Formatter: "synthetic/v1", MaxTokens: 128, OverlapTokens: 8, Tokenizer: "synthetic", TokenizerRevision: "v1", TruncationPolicy: document.TruncationPolicyReject}
+		}
+		return binding
+	}
+	profile := document.ProcessingProfileV1{ContractVersion: document.ProcessingProfileContractV1,
+		Rendition: &document.RenditionBindingV1{AdapterContract: "synthetic/v1", AuthorizationFingerprint: workerHash("rendition-auth"),
+			CredentialBinding: "credential:synthetic", DeploymentFingerprint: workerHash("deployment"),
+			Descriptor:            document.ProviderDescriptorV1{ID: "synthetic-rendition", Fingerprint: workerHash("rendition-descriptor")},
+			DisclosureFingerprint: workerHash("rendition-disclosure"), MaxDocumentBytes: 1 << 20, MaxResponseBytes: 1 << 20,
+			MaxUnits: 100, Name: "synthetic", RequestedArtifacts: []document.EvidenceArtifactRole{document.EvidenceArtifactStructured},
+			TrustBoundary: "local_process", UploadOptionsFingerprint: workerHash("upload-options")},
+		EvidenceLexical: document.EvidenceLexicalPolicyV1{MaxDocumentChars: 10000, CompletenessFingerprint: workerHash("complete"), LexicalSegmenterFingerprint: workerHash("lexical"), MaxSegmentRunes: 1000, MaxUnitRunes: 1000, NormalizedEvidenceContract: document.NormalizedEvidenceContractV1, NormalizerFingerprint: workerHash("normalizer"), RenditionContract: document.RenditionContractV1, SanitizerFingerprint: workerHash("sanitizer"), SourceEvidenceContract: document.SourceEvidenceContractV1}, RetentionDisclosure: document.RetentionDisclosurePolicyV1{AttachmentPolicyFingerprint: workerHash("attachment"), ConsentFingerprint: workerHash("consent"), TrustBoundary: string(document.EmbeddingTrustLocalProcess)}, Retrieval: document.RetrievalPolicyV1{LexicalLimit: 10, VectorLimit: 10}, Embeddings: []document.EmbeddingBindingV1{makeBinding("chunk", document.EmbeddingInputRenditionChunk), makeBinding("direct", document.EmbeddingInputOriginalFile)}}
+	canonical, fingerprints, err := document.CanonicalProfile(profile)
+	require.NoError(t, err)
+	return store.ProcessingProfileRecord{Fingerprint: fingerprints.Profile, CanonicalProfile: canonical, EvidenceLexicalFingerprint: fingerprints.EvidenceLexical, RetentionDisclosureFingerprint: fingerprints.RetentionDisclosure, AttachmentPolicyFingerprint: profile.RetentionDisclosure.AttachmentPolicyFingerprint, ConsentFingerprint: profile.RetentionDisclosure.ConsentFingerprint, TrustBoundary: profile.RetentionDisclosure.TrustBoundary}
+}
+
+func jsonUnmarshalProfile(data []byte, profile *document.ProcessingProfileV1) error {
+	return json.Unmarshal(data, profile)
+}
+func slicesSort(values []string) { slices.Sort(values) }
+func receiptText(receipts []EmbeddingAttemptReceipt) string {
+	var buffer bytes.Buffer
+	for _, receipt := range receipts {
+		buffer.WriteString(receipt.AttemptID)
+		buffer.WriteString(receipt.ProviderFingerprint)
+		buffer.WriteString(receipt.FailureCode)
+	}
+	return buffer.String()
+}
+
+func TestEmbeddingWorkerPublishesThroughRealCatalogAndBlobStore(t *testing.T) {
+	for _, kind := range []document.EmbeddingInputKind{document.EmbeddingInputOriginalFile, document.EmbeddingInputRenditionChunk} {
+		t.Run(string(kind), func(t *testing.T) {
+			fixture, fake, worker, request := newRealEmbeddingWorker(t, kind)
+			generation := request.InputGeneration
+			processed, err := worker.ScanOnce(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 1, processed)
+			require.Positive(t, fake.runtime.calls())
+			if kind == document.EmbeddingInputRenditionChunk {
+				require.Greater(t, fake.runtime.calls(), 1)
+			}
+			var metadata bytes.Buffer
+			require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+			var heads int
+			for line := range bytes.SplitSeq(metadata.Bytes(), []byte{'\n'}) {
+				if len(line) == 0 {
+					continue
+				}
+				var record struct {
+					Type             string `json:"type"`
+					ContentVersionID string `json:"content_version_id"`
+					FencingToken     int64  `json:"fencing_token"`
+				}
+				require.NoError(t, json.Unmarshal(line, &record))
+				if record.Type == "embedding_head" {
+					heads++
+					assert.Equal(t, generation.SourceVersionID, record.ContentVersionID)
+					assert.Equal(t, int64(1), record.FencingToken)
+				}
+			}
+			require.Equal(t, 1, heads)
+			require.NoError(t, fixture.catalog.VerifyRenditionBlobBytes(t.Context(), fixture.blobs))
+			processed, err = worker.ScanOnce(t.Context())
+			require.NoError(t, err)
+			require.Zero(t, processed, "published work must not be sent to the provider again")
+		})
+	}
+}
+
+type embeddingIntegrationTokenizer struct{}
+
+func (embeddingIntegrationTokenizer) Identity() document.TokenizerIdentity {
+	return document.TokenizerIdentity{Name: "synthetic", Revision: "v1"}
+}
+func (embeddingIntegrationTokenizer) PrefixTokenCountsMonotonic() bool { return true }
+func (embeddingIntegrationTokenizer) Tokenize(text string, limit int) ([]document.TokenBoundary, error) {
+	runes := []rune(text)
+	if len(runes) > limit {
+		return nil, document.ErrTokenizerLimit
+	}
+	result := make([]document.TokenBoundary, len(runes))
+	for index := range result {
+		result[index] = document.TokenBoundary{Start: index, End: index + 1}
+	}
+	return result, nil
+}
+
+func newRealEmbeddingWorker(t *testing.T, kind document.EmbeddingInputKind) (publicationFixture, *embeddingWorkerFixture, *EmbeddingWorker, store.EmbeddingJobRequest) {
+	t.Helper()
+	fixture := newPublicationFixture(t)
+	fake := newEmbeddingWorkerFixture(t)
+	var portable, embeddingProfile document.ProcessingProfileV1
+	require.NoError(t, json.Unmarshal(fixture.profile.CanonicalProfile, &portable))
+	require.NoError(t, json.Unmarshal(fake.profile.CanonicalProfile, &embeddingProfile))
+	var binding document.EmbeddingBindingV1
+	for _, candidate := range embeddingProfile.Embeddings {
+		if candidate.InputKind == kind {
+			binding = candidate
+		}
+	}
+	binding.MaxBatchItems = 1
+	portable.Embeddings = []document.EmbeddingBindingV1{binding}
+	canonical, fingerprints, err := document.CanonicalProfile(portable)
+	require.NoError(t, err)
+	fixture.profile.CanonicalProfile, fixture.profile.Fingerprint = canonical, fingerprints.Profile
+	fixture.profile.RetentionDisclosureFingerprint = fingerprints.RetentionDisclosure
+	generation := store.EmbeddingInputGenerationRecord{
+		ID: workerHash("integration-generation"), ProcessingProfileFingerprint: fixture.profile.Fingerprint,
+		EvidenceFingerprint: workerHash("evidence"), TokenizerFingerprint: workerHash("tokenizer"),
+		ChunkPolicyFingerprint: workerHash("chunk"), FormatterFingerprint: workerHash("formatter"),
+		CreatedAt: metadataEmbeddingTime(time.Now()),
+	}
+	if kind == document.EmbeddingInputOriginalFile {
+		data := mediatest.PNG(2, 2, color.White)
+		receipt, err := fixture.blobs.WriteDetailedContext(t.Context(), bytes.NewReader(data))
+		require.NoError(t, err)
+		node, err := fixture.catalog.CreateFile(t.Context(), fixture.catalog.RootID(), "synthetic.png", receipt.Hash, receipt.Size,
+			"image/png", processingBlobPhysical(t, receipt))
+		require.NoError(t, err)
+		generation.SourceVersionID = node.CurrentVersionID
+		generation.GenerationChecksum = receipt.Hash
+		generation.Inputs = []store.EmbeddingInputReference{{ID: node.CurrentVersionID, RenderedChecksum: receipt.Hash}}
+	} else {
+		staged := fixture.stage(t, publicationIDs{"b8", "58", "98"}, strings.Repeat("synthetic chunk evidence ", 12), "Example")
+		publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+		require.NoError(t, err)
+		_, err = publisher.PublishRendition(t.Context(), staged)
+		require.NoError(t, err)
+		artifact := staged.Build.Artifacts[0]
+		evidenceJSON, err := readExactEmbeddingBlob(t.Context(), fixture.blobs, artifact.BlobHash, artifact.Size)
+		require.NoError(t, err)
+		var evidence document.NormalizedEvidenceV1
+		require.NoError(t, json.Unmarshal(evidenceJSON, &evidence))
+		evidence.Checksum = artifact.BlobHash
+		policy, err := document.NewInputPolicy(binding, embeddingIntegrationTokenizer{}, fingerprints.EvidenceLexical, nil)
+		require.NoError(t, err)
+		generated, err := document.BuildEmbeddingInputs(evidence, policy, document.GenerationLimits{
+			MaxInputs: 100, MaxTotalContentTokens: 10000, MaxTotalRenderedTokens: 10000,
+			MaxTotalContentBytes: 1 << 20, MaxTotalRenderedBytes: 1 << 20, MaxFittingWorkTokens: 100000, MaxFittingWorkBytes: 1 << 20,
+		})
+		require.NoError(t, err)
+		generation.GenerationJSON, err = document.MarshalEmbeddingInputGeneration(generated)
+		require.NoError(t, err)
+		receipt, err := fixture.blobs.WriteDetailedContext(t.Context(), bytes.NewReader(generation.GenerationJSON))
+		require.NoError(t, err)
+		require.NoError(t, fixture.catalog.RecordRenditionBlob(t.Context(), receipt.Hash, receipt.Size, processingBlobPhysical(t, receipt)))
+		generation.SourceVersionID, generation.AttachmentID = fixture.versionID, staged.Attachment.ID
+		generation.ID = workerHash("embedding-generation-attachment/v1\x00" + generated.Checksum + "\x00" + generation.AttachmentID)
+		generation.GenerationBlobHash, generation.GenerationEncodedSize = receipt.Hash, receipt.Size
+		generation.GenerationChecksum, generation.EvidenceFingerprint = generated.Checksum, generated.EvidenceChecksum
+		generation.TokenizerFingerprint = workerHash(binding.Chunk.Tokenizer + "\x00" + binding.Chunk.TokenizerRevision)
+		generation.ChunkPolicyFingerprint, generation.FormatterFingerprint = generated.PolicyFingerprint, workerHash(binding.Chunk.Formatter)
+		generation.EvidenceJSON = evidenceJSON
+		for _, input := range generated.Inputs {
+			generation.Inputs = append(generation.Inputs, store.EmbeddingInputReference{ID: input.Key, RenderedChecksum: input.Checksum})
+		}
+	}
+	consent := store.ProviderOperationAuthorizationRequest{Principal: "operator:integration", Scope: "embedding:integration",
+		ProfileFingerprint: fixture.profile.Fingerprint, DisclosureFingerprint: binding.DisclosureFingerprint,
+		InputClasses: []string{string(kind)}, RetainedArtifactClasses: []string{"embedding_vector_set"},
+	}
+	// Enqueue installs the profile before checking consent. Register it through
+	// the existing source-authority path for direct input, which has no rendition.
+	if kind == document.EmbeddingInputOriginalFile {
+		staged := fixture.stage(t, publicationIDs{"b9", "59", "99"}, "synthetic evidence", "Example")
+		publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+		require.NoError(t, err)
+		_, err = publisher.PublishRendition(t.Context(), staged)
+		require.NoError(t, err)
+	}
+	_, err = fixture.catalog.GrantConsent(t.Context(), store.ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses, RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	request := store.EmbeddingJobRequest{
+		ContentVersionID: generation.SourceVersionID, Profile: fixture.profile, BindingID: binding.Name,
+		Descriptor: fake.descriptor, InputGeneration: generation, Authorization: consent,
+	}
+	_, err = fixture.catalog.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	runtime, err := NewProviderEmbeddingRuntime(&embeddingWorkerProvider{runtime: fake.runtime, binding: binding.Name, descriptor: fake.descriptor}, fixture.blobs, t.TempDir(), fake.runtime.Classify)
+	require.NoError(t, err)
+	worker, err := NewEmbeddingWorker(EmbeddingWorkerConfig{Catalog: fixture.catalog, Authority: fixture.catalog,
+		Blobs: fixture.blobs, GenerationBlobs: fixture.blobs, Runtime: runtime, Gate: api.NewOperationGate(), Owner: "integration-worker",
+		LeaseDuration: 3 * time.Second, IdleDelay: time.Millisecond, RetryLimit: 3, MaxRetryDelay: time.Second,
+		AttemptLifetime: time.Minute, MaxRows: 100, MaxDimensions: 8, MaxVectorBlobBytes: 1 << 20,
+		DescriptorFingerprints: []string{fake.descriptor.Fingerprint},
+	})
+	require.NoError(t, err)
+	return fixture, fake, worker, request
+}
+
+func TestEmbeddingWorkerReleasesMaintenanceGateDuringProviderCall(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	fixture.catalog.enqueue(fixture.work("maintenance", document.EmbeddingInputRenditionChunk, "semantic"))
+	started := make(chan struct{})
+	fixture.runtime.block = true
+	fixture.runtime.onBlock = func() { close(started) }
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	worker := fixture.worker(t)
+	go func() { _, err := worker.ScanOnce(ctx); done <- err }()
+	<-started
+	maintenanceCtx, stop := context.WithTimeout(t.Context(), time.Second)
+	defer stop()
+	err := fixture.gate.MaintainContext(maintenanceCtx, func() error { return nil })
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.NoError(t, err, "maintenance must finish while the provider is still running")
+}
+
+type observedEmbeddingCatalog struct {
+	*store.Store
+
+	afterAuthorize func()
+}
+
+func (catalog *observedEmbeddingCatalog) BeginEmbeddingProviderEgress(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork, prior *store.ProviderOperationAuthorization, at time.Time) (store.ProviderOperationAuthorization, *store.ProviderEgressFence, error) {
+	auth, fence, err := catalog.Store.BeginEmbeddingProviderEgress(ctx, claim, work, prior, at)
+	if err == nil && catalog.afterAuthorize != nil {
+		catalog.afterAuthorize()
+	}
+	return auth, fence, err
+}
+
+func TestEmbeddingWorkerFencesConsentThroughProviderCall(t *testing.T) {
+	fixture, fake, worker, request := newRealEmbeddingWorker(t, document.EmbeddingInputOriginalFile)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	authorized, proceed, started := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	fake.runtime.block = true
+	fake.runtime.onBlock = func() { close(started) }
+	worker.catalog = &observedEmbeddingCatalog{Store: fixture.catalog, afterAuthorize: func() {
+		close(authorized)
+		select {
+		case <-proceed:
+		case <-ctx.Done():
+		}
+	}}
+	done := make(chan error, 1)
+	go func() { _, err := worker.ScanOnce(ctx); done <- err }()
+	<-authorized
+	revoked := make(chan error, 1)
+	go func() {
+		_, err := fixture.catalog.RevokeConsent(t.Context(), store.ProcessingConsentRevocationRequest{Principal: request.Authorization.Principal, Scope: request.Authorization.Scope})
+		revoked <- err
+	}()
+	select {
+	case err := <-revoked:
+		cancel()
+		<-done
+		t.Fatalf("revocation crossed authorized provider boundary: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(proceed)
+	<-started
+	select {
+	case err := <-revoked:
+		cancel()
+		<-done
+		t.Fatalf("revocation crossed active provider call: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.NoError(t, <-revoked)
+}
+
+func TestEmbeddingWorkerRejectsConsentRevokedBeforeProviderCall(t *testing.T) {
+	fixture, fake, worker, request := newRealEmbeddingWorker(t, document.EmbeddingInputOriginalFile)
+	_, err := fixture.catalog.RevokeConsent(t.Context(), store.ProcessingConsentRevocationRequest{Principal: request.Authorization.Principal, Scope: request.Authorization.Scope})
+	require.NoError(t, err)
+	_, err = worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, fake.runtime.calls())
+}
+
+type afterEmbeddingPrepare struct {
+	EmbeddingRuntime
+
+	after func() error
+}
+
+func (runtime afterEmbeddingPrepare) Prepare(ctx context.Context, work EmbeddingWork) (EmbeddingExecution, error) {
+	execution, err := runtime.EmbeddingRuntime.Prepare(ctx, work)
+	if err != nil {
+		return execution, err
+	}
+	return execution, runtime.after()
+}
+
+func TestEmbeddingWorkerAbandonsReplacedRendition(t *testing.T) {
+	for _, duringProvider := range []bool{false, true} {
+		t.Run(fmt.Sprintf("during-provider=%t", duringProvider), func(t *testing.T) {
+			fixture, fake, worker, request := newRealEmbeddingWorker(t, document.EmbeddingInputRenditionChunk)
+			staged := fixture.stage(t, publicationIDs{"ba", "5a", "9a"}, "replacement evidence", "Example")
+			// A distinct captured-artifact policy permits a new immutable build for
+			// the same source and processing profile.
+			staged.Build.CapturedArtifactPolicy = []byte(`{"roles":[{"max_count":2,"min_count":1,"role":"normalized_evidence"},{"max_count":1,"min_count":1,"role":"sanitized_markdown"}],"version":1}`)
+			staged.Build.CapturedArtifactPolicyFingerprint = workerHashBytes(staged.Build.CapturedArtifactPolicy)
+			publisher, err := NewArtifactPublisher(fixture.catalog, fixture.blobs)
+			require.NoError(t, err)
+			publications := 0
+			publish := func() error {
+				_, err := publisher.PublishRendition(t.Context(), staged)
+				require.NoError(t, err)
+				publications++
+				return err
+			}
+			if duringProvider {
+				fake.runtime.mutate[request.BindingID] = func(document.EmbeddingResult) document.EmbeddingResult {
+					require.NoError(t, publish())
+					return document.EmbeddingResult{}
+				}
+			} else {
+				worker.runtime = afterEmbeddingPrepare{EmbeddingRuntime: worker.runtime, after: publish}
+			}
+
+			processed, err := worker.ScanOnce(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 1, processed)
+			require.Equal(t, 1, publications)
+			if duringProvider {
+				require.Equal(t, 1, fake.runtime.calls())
+			} else {
+				require.Zero(t, fake.runtime.calls())
+			}
+			_, _, claimed, err := fixture.catalog.ClaimNextEmbeddingWork(t.Context(), "next-worker", time.Now().Add(time.Hour), time.Minute, worker.descriptorFingerprints)
+			require.NoError(t, err)
+			require.False(t, claimed, "abandoned work must not remain running until lease expiry")
+			var metadata bytes.Buffer
+			require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+			for line := range bytes.SplitSeq(metadata.Bytes(), []byte{'\n'}) {
+				if len(line) == 0 {
+					continue
+				}
+				var record struct {
+					Type string `json:"type"`
+				}
+				require.NoError(t, json.Unmarshal(line, &record))
+				require.NotEqual(t, "embedding_failure", record.Type, "stale work cannot publish a failure against its replacement")
+			}
+		})
+	}
+}
+
+func (c *embeddingWorkerFakeCatalog) AbandonEmbeddingWork(context.Context, EmbeddingWorkClaim, time.Time) error {
+	return nil
+}
+
+func TestEmbeddingWorkerReleasesMaintenanceGateDuringRetryDelay(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("retry-maintenance", document.EmbeddingInputRenditionChunk, "semantic")
+	fixture.catalog.enqueue(work)
+	fixture.runtime.failures[work.Binding.Name] = []error{embeddingTransientError{}}
+	worker := fixture.worker(t)
+	worker.wait = func(ctx context.Context, _ time.Duration) error {
+		maintenanceCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		return fixture.gate.MaintainContext(maintenanceCtx, func() error { return nil })
+	}
+	processed, err := worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	require.Equal(t, 2, fixture.runtime.calls())
+	require.Contains(t, fixture.catalog.heads, headKey(work))
+}
+
+func TestEmbeddingWorkerRetriesTimedOutAttemptAndPublishesSibling(t *testing.T) {
+	fixture, fake, worker, request := newRealEmbeddingWorker(t, document.EmbeddingInputOriginalFile)
+	worker.attemptLifetime = 3 * time.Second
+	// Only the first provider call waits for its attempt deadline.
+	fake.runtime.block = true
+	fake.runtime.onBlock = func() {
+		fake.runtime.mu.Lock()
+		fake.runtime.block = false
+		fake.runtime.mu.Unlock()
+	}
+	data := mediatest.PNG(3, 3, color.Black)
+	receipt, err := fixture.blobs.WriteDetailedContext(t.Context(), bytes.NewReader(data))
+	require.NoError(t, err)
+	node, err := fixture.catalog.CreateFile(t.Context(), fixture.catalog.RootID(), "sibling.png", receipt.Hash, receipt.Size, "image/png", processingBlobPhysical(t, receipt))
+	require.NoError(t, err)
+	sibling := request
+	sibling.ContentVersionID = node.CurrentVersionID
+	sibling.InputGeneration.ID = workerHash("sibling-generation")
+	sibling.InputGeneration.SourceVersionID = node.CurrentVersionID
+	sibling.InputGeneration.GenerationChecksum = receipt.Hash
+	sibling.InputGeneration.Inputs = []store.EmbeddingInputReference{{ID: node.CurrentVersionID, RenderedChecksum: receipt.Hash}}
+	_, err = fixture.catalog.EnqueueEmbeddingJob(t.Context(), sibling)
+	require.NoError(t, err)
+	processed, err := worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 2, processed)
+	require.NoError(t, t.Context().Err())
+	require.Equal(t, 2, fake.runtime.calls())
+	var metadata bytes.Buffer
+	require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+	var published []string
+	for line := range bytes.SplitSeq(metadata.Bytes(), []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var record struct {
+			Type             string `json:"type"`
+			ContentVersionID string `json:"content_version_id"`
+		}
+		require.NoError(t, json.Unmarshal(line, &record))
+		if record.Type == "embedding_head" {
+			published = append(published, record.ContentVersionID)
+		}
+	}
+	require.Equal(t, []string{node.CurrentVersionID}, published)
+	processed, err = worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, processed, "timed-out work must wait for its retry delay")
+	claim, retry, found, err := fixture.catalog.ClaimNextEmbeddingWork(t.Context(), "retry-worker", time.Now().Add(2*time.Minute), time.Minute, worker.descriptorFingerprints)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, request.ContentVersionID, retry.ContentVersionID)
+	require.Equal(t, int64(2), claim.Epoch)
+}
+
+type afterEmbeddingStageAuthority struct {
+	embeddingWorkerAuthority
+
+	after func()
+}
+
+func (a afterEmbeddingStageAuthority) StageEmbeddingSetWithLease(ctx context.Context, record store.EmbeddingSetRecord, rootID string, token int64, at time.Time) error {
+	if err := a.embeddingWorkerAuthority.StageEmbeddingSetWithLease(ctx, record, rootID, token, at); err != nil {
+		return err
+	}
+	a.after()
+	return nil
+}
+func TestEmbeddingWorkerRecoversConsentRevokedBeforePublication(t *testing.T) {
+	for _, revoke := range []bool{false, true} {
+		t.Run(strconv.FormatBool(revoke), func(t *testing.T) {
+			fixture, _, worker, request := newRealEmbeddingWorker(t, document.EmbeddingInputOriginalFile)
+			worker.authority = afterEmbeddingStageAuthority{embeddingWorkerAuthority: worker.authority, after: func() {
+				if revoke {
+					_, err := fixture.catalog.RevokeConsent(t.Context(), store.ProcessingConsentRevocationRequest{Principal: request.Authorization.Principal, Scope: request.Authorization.Scope})
+					require.NoError(t, err)
+				}
+			}}
+			n, err := worker.ScanOnce(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 1, n)
+			var metadata bytes.Buffer
+			require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+			code := ""
+			for line := range bytes.SplitSeq(metadata.Bytes(), []byte{'\n'}) {
+				if len(line) == 0 {
+					continue
+				}
+				var record struct {
+					Type string `json:"type"`
+					Code string `json:"failure_code"`
+				}
+				require.NoError(t, json.Unmarshal(line, &record))
+				if record.Type == "embedding_failure" {
+					code = record.Code
+				}
+			}
+			if !revoke {
+				require.Empty(t, code)
+				return
+			}
+			require.Equal(t, "authorization", code)
+			auth := request.Authorization
+			_, err = fixture.catalog.GrantConsent(t.Context(), store.ProcessingConsentGrantRequest{Principal: auth.Principal, Scope: auth.Scope, ProfileFingerprint: auth.ProfileFingerprint, DisclosureFingerprint: auth.DisclosureFingerprint, InputClasses: auth.InputClasses, RetainedArtifactClasses: auth.RetainedArtifactClasses})
+			require.NoError(t, err)
+			_, err = fixture.catalog.EnqueueEmbeddingJob(t.Context(), request)
+			require.NoError(t, err)
+			worker.authority = fixture.catalog
+			n, err = worker.ScanOnce(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 1, n)
+			metadata.Reset()
+			require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+			require.Contains(t, metadata.String(), `"type":"embedding_head"`)
+			require.NotContains(t, metadata.String(), `"type":"embedding_failure"`)
+		})
+	}
+}
+
+// Inject errors at the worker/store boundary while retaining real claim state.
+type unavailableEmbeddingStore struct {
+	*store.Store
+
+	validateErr, renewErr, publishErr error
+}
+
+func (s *unavailableEmbeddingStore) ValidateEmbeddingWork(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork, at time.Time) error {
+	if s.validateErr != nil {
+		err := s.validateErr
+		s.validateErr = nil
+		return err
+	}
+	return s.Store.ValidateEmbeddingWork(ctx, claim, work, at)
+}
+func (s *unavailableEmbeddingStore) RenewEmbeddingWork(ctx context.Context, claim EmbeddingWorkClaim, at time.Time, lease time.Duration) (EmbeddingWorkClaim, error) {
+	if s.renewErr != nil {
+		return claim, s.renewErr
+	}
+	return s.Store.RenewEmbeddingWork(ctx, claim, at, lease)
+}
+func (s *unavailableEmbeddingStore) PublishEmbeddingWork(ctx context.Context, claim EmbeddingWorkClaim, work EmbeddingWork,
+	head store.EmbeddingHeadRecord, prior store.ProviderOperationAuthorization, receipt EmbeddingAttemptReceipt, at time.Time) error {
+	if s.publishErr != nil {
+		err := s.publishErr
+		s.publishErr = nil
+		return err
+	}
+	return s.Store.PublishEmbeddingWork(ctx, claim, work, head, prior, receipt, at)
+}
+
+func TestEmbeddingWorkerStorageErrorsLeaveClaimsRecoverable(t *testing.T) {
+	for _, phase := range []string{"validation", "renewal", "publication"} {
+		t.Run(phase, func(t *testing.T) {
+			fixture, fake, worker, _ := newRealEmbeddingWorker(t, document.EmbeddingInputOriginalFile)
+			catalog := &unavailableEmbeddingStore{Store: fixture.catalog}
+			unavailable := errors.New("synthetic storage outage")
+			switch phase {
+			case "validation":
+				catalog.validateErr = unavailable
+			case "renewal":
+				catalog.renewErr = unavailable
+				fake.runtime.block = true
+			case "publication":
+				catalog.publishErr = unavailable
+			}
+			worker.catalog, worker.authority = catalog, catalog
+			_, err := worker.ScanOnce(t.Context())
+			require.ErrorIs(t, err, ErrEmbeddingPersistence)
+			require.NotErrorIs(t, err, ErrEmbeddingWorkFenced)
+			var metadata bytes.Buffer
+			require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+			require.NotContains(t, metadata.String(), `"type":"embedding_failure"`)
+			worker.catalog, worker.authority = fixture.catalog, fixture.catalog
+			fake.runtime.block = false
+			now := time.Now().Add(time.Minute)
+			worker.clock = func() time.Time { return now }
+			processed, err := worker.ScanOnce(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 1, processed, "storage errors must not abandon the job")
+			metadata.Reset()
+			require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+			require.Contains(t, metadata.String(), `"type":"embedding_head"`)
+		})
+	}
+}
+func TestEmbeddingWorkerBoundsStorageRetries(t *testing.T) {
+	for _, recover := range []bool{false, true} {
+		t.Run(strconv.FormatBool(recover), func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			worker := fixture.worker(t)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			calls, waits := 0, 0
+			fixture.catalog.reconcileError = func() error {
+				calls++
+				if !recover || calls == 1 {
+					return errors.New("synthetic storage outage")
+				}
+				cancel()
+				return nil
+			}
+			worker.wait = func(ctx context.Context, _ time.Duration) error {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				waits++
+				return nil
+			}
+			err := worker.Run(ctx)
+			if recover {
+				require.ErrorIs(t, err, context.Canceled)
+				require.Equal(t, 2, calls)
+				require.Equal(t, 1, waits)
+			} else {
+				require.ErrorIs(t, err, ErrEmbeddingPersistence)
+				require.Equal(t, worker.retryLimit, calls)
+				require.Equal(t, worker.retryLimit-1, waits)
+			}
+		})
+	}
+}
+func TestEmbeddingWorkerRecoversProviderAuthorization(t *testing.T) {
+	fixture, fake, worker, request := newRealEmbeddingWorker(t, document.EmbeddingInputOriginalFile)
+	fake.runtime.failures[request.BindingID] = []error{errors.New("synthetic credential unavailable")}
+	runtime, err := NewProviderEmbeddingRuntime(&embeddingWorkerProvider{runtime: fake.runtime, binding: request.BindingID, descriptor: fake.descriptor}, fixture.blobs, t.TempDir(), func(error) (EmbeddingProviderFailure, time.Duration) { return EmbeddingProviderAuthorization, 0 })
+	require.NoError(t, err)
+	worker.runtime = runtime
+	processed, err := worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	var metadata bytes.Buffer
+	require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+	require.Contains(t, metadata.String(), `"failure_code":"authorization"`)
+	worker.clock = func() time.Time { return worker.reconcileAt }
+	processed, err = worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	metadata.Reset()
+	require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+	require.Contains(t, metadata.String(), `"type":"embedding_head"`)
+}
+
+func TestEmbeddingWorkerRetainsAuthorizedInputsWhenProviderMutatesBatch(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("input-ownership", document.EmbeddingInputRenditionChunk, "chunks")
+	fixture.catalog.enqueue(work)
+	fixture.runtime.inspectInputs = func(inputs []document.EmbeddingInput) {
+		inputs[0].Key = "provider-replacement"
+	}
+	_, err := fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, fixture.catalog.heads)
+	assert.Equal(t, store.EmbeddingFailureInvalidResponse, fixture.catalog.failures[headKey(work)])
+}
+
+func TestEmbeddingWorkerSealsUploadsAndClosesOriginalAfterProviderReplacesInput(t *testing.T) {
+	for _, corruptSource := range []bool{false, true} {
+		t.Run(strconv.FormatBool(corruptSource), func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			work := fixture.work("upload-ownership", document.EmbeddingInputOriginalFile, "original")
+			original, ok := work.Inputs[0].Source.(*embeddingWorkerUpload)
+			require.True(t, ok)
+			fixture.catalog.enqueue(work)
+			var filename string
+			fixture.runtime.inspectInputs = func(inputs []document.EmbeddingInput) {
+				filename = inputs[0].Source.Metadata().Filename
+				inputs[0].Source = nil
+				if corruptSource {
+					original.data[0] ^= 1
+				}
+			}
+			_, err := fixture.worker(t).ScanOnce(t.Context())
+			require.NoError(t, err)
+			assert.Empty(t, filename)
+			assert.True(t, original.closed)
+			if corruptSource {
+				assert.Empty(t, fixture.catalog.heads)
+				assert.Equal(t, store.EmbeddingFailureInvalidResponse, fixture.catalog.failures[headKey(work)])
+			} else {
+				assert.Contains(t, fixture.catalog.heads, headKey(work))
+			}
+		})
+	}
+}
+
+func TestEmbeddingWorkerRejectsOversizedInputBeforeProvider(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	work := fixture.work("oversized-original", document.EmbeddingInputOriginalFile, "direct")
+	work = mutateEmbeddingWorkerBinding(t, work, func(binding *document.EmbeddingBindingV1) { binding.MaxInputBytes = 1 })
+	data := mediatest.PNG(2, 2, color.White)
+	work.SourceBlobHash, work.SourceBytes = workerHashBytes(data), int64(len(data))
+	work.SourceFilename, work.SourceMediaType = "synthetic.png", "image/png"
+	work.InputGeneration.GenerationChecksum = work.SourceBlobHash
+	work.InputGeneration.Inputs[0].RenderedChecksum = work.SourceBlobHash
+	provider := &embeddingWorkerProvider{runtime: fixture.runtime, binding: work.Binding.Name, descriptor: work.Descriptor}
+	runtime, err := NewProviderEmbeddingRuntime(provider, &embeddingRuntimeTestBlobs{data: data}, t.TempDir(), fixture.runtime.Classify)
+	require.NoError(t, err)
+	fixture.runtimeRegistry = runtime
+	fixture.catalog.enqueue(work)
+	_, err = fixture.worker(t).ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, fixture.runtime.calls())
+	require.Equal(t, store.EmbeddingFailureInputRejected, fixture.catalog.failures[headKey(work)])
+}
+
+func TestEmbeddingWorkerPreservesPreparationFailureKinds(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		preparation error
+		failure     store.EmbeddingFailureCode
+		persistence bool
+	}{
+		{name: "consent", preparation: store.ErrProcessingConsentRevoked, failure: store.EmbeddingFailureAuthorization},
+		{name: "storage", preparation: errors.New("synthetic blob read failure"), persistence: true},
+		{name: "runtime", preparation: ErrEmbeddingRuntimeUnavailable, failure: store.EmbeddingFailureProviderUnavailable},
+		{name: "fenced", preparation: store.ErrEmbeddingJobFenced},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			work := fixture.work("prepare-"+test.name, document.EmbeddingInputRenditionChunk, "chunks")
+			fixture.catalog.enqueue(work)
+			fixture.runtimeRegistry = afterEmbeddingPrepare{EmbeddingRuntime: fixture.runtime, after: func() error { return test.preparation }}
+			_, err := fixture.worker(t).ScanOnce(t.Context())
+			if test.persistence {
+				require.ErrorIs(t, err, ErrEmbeddingPersistence)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Zero(t, fixture.runtime.calls())
+			if test.failure == "" {
+				require.Empty(t, fixture.catalog.failures)
+			} else {
+				require.Equal(t, test.failure, fixture.catalog.failures[headKey(work)])
+			}
+		})
+	}
+}
+
+func TestEmbeddingWorkerClassifiesOriginalMetadataAndBlobErrors(t *testing.T) {
+	for _, test := range []struct {
+		name, mediaType string
+		blobErr         error
+	}{
+		{name: "missing MIME"},
+		{name: "malformed MIME", mediaType: "image/png; invalid"},
+		{name: "blob unavailable", mediaType: "image/png", blobErr: errors.New("synthetic blob unavailable")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newEmbeddingWorkerFixture(t)
+			work := fixture.work("original-metadata", document.EmbeddingInputOriginalFile, "direct")
+			data := mediatest.PNG(2, 2, color.White)
+			work.SourceBlobHash, work.SourceBytes = workerHashBytes(data), int64(len(data))
+			work.SourceFilename, work.SourceMediaType = "synthetic.png", test.mediaType
+			work.InputGeneration.GenerationChecksum = work.SourceBlobHash
+			work.InputGeneration.Inputs[0].RenderedChecksum = work.SourceBlobHash
+			blobs := &embeddingRuntimeTestBlobs{data: data, openErr: test.blobErr}
+			provider := &embeddingWorkerProvider{runtime: fixture.runtime, binding: work.Binding.Name, descriptor: work.Descriptor}
+			runtime, err := NewProviderEmbeddingRuntime(provider, blobs, t.TempDir(), fixture.runtime.Classify)
+			require.NoError(t, err)
+			fixture.runtimeRegistry = runtime
+			fixture.catalog.enqueue(work)
+			_, err = fixture.worker(t).ScanOnce(t.Context())
+			if test.blobErr != nil {
+				require.ErrorIs(t, err, ErrEmbeddingPersistence)
+				require.Empty(t, fixture.catalog.failures)
+				require.Equal(t, 1, blobs.opens)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, store.EmbeddingFailureInputRejected, fixture.catalog.failures[headKey(work)])
+				require.Zero(t, blobs.opens)
+			}
+			require.Zero(t, fixture.runtime.calls())
+		})
+	}
+}
+
+func TestEmbeddingWorkerRecordsClassifiedInvalidProviderResponse(t *testing.T) {
+	fixture, fake, worker, request := newRealEmbeddingWorker(t, document.EmbeddingInputOriginalFile)
+	fake.runtime.failures[request.BindingID] = []error{errors.New("synthetic malformed provider response")}
+	runtime, err := NewProviderEmbeddingRuntime(&embeddingWorkerProvider{runtime: fake.runtime, binding: request.BindingID, descriptor: fake.descriptor}, fixture.blobs, t.TempDir(), func(error) (EmbeddingProviderFailure, time.Duration) { return EmbeddingProviderInvalidResponse, 0 })
+	require.NoError(t, err)
+	worker.runtime = runtime
+	_, err = worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	var metadata bytes.Buffer
+	require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+	require.Contains(t, metadata.String(), `"failure_code":"invalid_response"`)
+	require.NotContains(t, metadata.String(), `"type":"embedding_head"`)
+	require.Equal(t, 1, fake.runtime.calls())
+}
+
+func TestEmbeddingWorkerSpacesReconciliationWithoutDelayingQueuedWork(t *testing.T) {
+	fixture := newEmbeddingWorkerFixture(t)
+	worker := fixture.worker(t)
+	now := time.Now().UTC()
+	worker.clock = func() time.Time { return now }
+	passes := 0
+	fixture.catalog.reconcileError = func() error {
+		passes++
+		// Discovery must not exclude exclusive maintenance.
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		return fixture.gate.MaintainContext(ctx, func() error { return nil })
+	}
+	_, err := worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	fixture.catalog.enqueue(fixture.work("late-queued", document.EmbeddingInputOriginalFile, "direct"))
+	now = now.Add(time.Second)
+	processed, err := worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	require.Equal(t, 1, passes)
+	now = now.Add(time.Minute)
+	_, err = worker.ScanOnce(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 2, passes)
+}

--- a/internal/processing/rendition_worker.go
+++ b/internal/processing/rendition_worker.go
@@ -175,7 +175,7 @@ type renditionWorkerCatalog interface {
 		store.RenditionJobClaim, error)
 	BeginRenditionProviderEgress(ctx context.Context, claim store.RenditionJobClaim, waiterID string,
 		at time.Time, snapshots ...document.RenditionExecutionSnapshotV1) (
-		store.ProviderOperationAuthorization, *store.RenditionProviderEgressFence, error)
+		store.ProviderOperationAuthorization, *store.ProviderEgressFence, error)
 	CheckpointRenditionProvider(ctx context.Context, claim store.RenditionJobClaim,
 		handle string, at time.Time) error
 	MarkRenditionJobRetry(ctx context.Context, claim store.RenditionJobClaim,
@@ -390,7 +390,7 @@ func (worker *RenditionWorker) runOne(ctx context.Context) (
 
 	var execution RenditionExecution
 	var snapshot document.RenditionExecutionSnapshotV1
-	var egressFence *store.RenditionProviderEgressFence
+	var egressFence *store.ProviderEgressFence
 	var durableResume atomic.Bool
 	workerOwnsUpload := false
 	resuming := claim.ResumeHandle != ""
@@ -1096,11 +1096,11 @@ func renditionBytesSHA256(value []byte) string {
 
 type renditionEgressFencedProvider struct {
 	provider document.RenditionProvider
-	fence    *store.RenditionProviderEgressFence
+	fence    *store.ProviderEgressFence
 }
 
 func renditionProviderWithEgressFence(
-	provider document.RenditionProvider, fence *store.RenditionProviderEgressFence,
+	provider document.RenditionProvider, fence *store.ProviderEgressFence,
 ) document.RenditionProvider {
 	if resumable, ok := provider.(document.ResumableRenditionProvider); ok {
 		return &renditionEgressFencedResumableProvider{

--- a/internal/processing/rendition_worker_test.go
+++ b/internal/processing/rendition_worker_test.go
@@ -1380,7 +1380,7 @@ func (catalog *transientRenditionCatalog) RenditionJobWorkByClaim(
 func (catalog *transientRenditionCatalog) BeginRenditionProviderEgress(
 	ctx context.Context, claim store.RenditionJobClaim, waiterID string, at time.Time,
 	snapshots ...document.RenditionExecutionSnapshotV1,
-) (store.ProviderOperationAuthorization, *store.RenditionProviderEgressFence, error) {
+) (store.ProviderOperationAuthorization, *store.ProviderEgressFence, error) {
 	var hookErr error
 	catalog.beforeBeginOnce.Do(func() {
 		if catalog.beforeBegin != nil {

--- a/internal/store/consent.go
+++ b/internal/store/consent.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 )
@@ -79,8 +80,8 @@ type ProviderOperationAuthorizationRequest struct {
 	DisclosureFingerprint   string
 	InputClasses            []string
 	RetainedArtifactClasses []string
-	// PriorAuthorization is set only for atomic publication. A later replacement
-	// grant cannot revive work authorized below an earlier revocation fence.
+	// PriorAuthorization binds atomic publication and fenced provider retries
+	// to the original grant. A replacement grant cannot revive revoked work.
 	PriorAuthorization *ProviderOperationAuthorization
 }
 
@@ -205,8 +206,8 @@ func (s *Store) GrantConsent(
 func (s *Store) RevokeConsent(
 	ctx context.Context, request ProcessingConsentRevocationRequest,
 ) (ProcessingConsentRevocation, error) {
-	s.renditionEgressMu.Lock()
-	defer s.renditionEgressMu.Unlock()
+	s.providerEgressMu.Lock()
+	defer s.providerEgressMu.Unlock()
 
 	principal, err := normalizeConsentLabel("principal", request.Principal)
 	if err != nil {
@@ -446,4 +447,19 @@ func normalizeConsentClasses(subject string, values []string, required bool) ([]
 		return nil, "", fmt.Errorf("encoding processing consent %s classes: %w", subject, err)
 	}
 	return result, string(encoded), nil
+}
+
+// ProviderEgressFence orders consent revocation against provider
+// execution. Close releases the fence after the provider call finishes or
+// when an invocation never reaches the provider boundary.
+type ProviderEgressFence struct {
+	once    sync.Once
+	release func()
+}
+
+// Close releases a provider-egress fence.
+func (fence *ProviderEgressFence) Close() {
+	if fence != nil {
+		fence.once.Do(fence.release)
+	}
 }

--- a/internal/store/embedding_catalog.go
+++ b/internal/store/embedding_catalog.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.kenn.io/docbank/document"
 )
@@ -27,6 +28,9 @@ const (
 	maxEmbeddingCatalogIDBytes = 1 << 10
 	maxEmbeddingDescriptorJSON = 1 << 16
 )
+
+// ErrEmbeddingAuthorityStale identifies a superseded source, attachment, or publication token.
+var ErrEmbeddingAuthorityStale = errors.New("embedding authority is stale")
 
 // EmbeddingInputKind is the canonical E1 evidence-kind vocabulary. Keep the
 // alias so store callers do not need to translate a document contract token.
@@ -172,66 +176,63 @@ const (
 // StageEmbeddingSet atomically records or exactly reuses every immutable
 // authority named by a completed embedding set.
 func (s *Store) StageEmbeddingSet(ctx context.Context, record EmbeddingSetRecord) error {
-	var err error
-	record, err = normalizeEmbeddingSetRecord(record)
+	record, err := s.prepareEmbeddingSetRecord(record)
 	if err != nil {
-		return fmt.Errorf("staging embedding set: %w", err)
-	}
-	if err := validateEmbeddingSetRecord(record); err != nil {
-		return fmt.Errorf("staging embedding set: %w", err)
-	}
-	if record.VaultID != s.vaultID {
-		return errors.New("staging embedding set: vault identity does not match store")
+		return err
 	}
 	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		if err := validateEmbeddingSetFencesTx(ctx, tx, record); err != nil {
-			return err
-		}
-		if err := requireEmbeddingPurgeAuthorityTx(ctx, tx, record); err != nil {
-			return err
-		}
-		if err := requireEmbeddingPhysicalAuthorityTx(ctx, tx, record); err != nil {
-			return err
-		}
-		// Payload bytes are validated before the transaction writes catalog
-		// authority. SQLite retains only the immutable blob reference and the
-		// canonical row projection derived from those bytes.
-		record.VectorSet.Payload = nil
-		record.InputGeneration.GenerationJSON = nil
-		record.InputGeneration.EvidenceJSON = nil
-		if err := insertVectorSpaceTx(ctx, tx, record.VectorSpace); err != nil {
-			return err
-		}
-		if err := insertInputGenerationTx(ctx, tx, record.InputGeneration); err != nil {
-			return err
-		}
-		if err := insertVectorSetTx(ctx, tx, record.VectorSet); err != nil {
-			return err
-		}
-		result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO embedding_sets(
-			embedding_set_id,vault_uid,binding_id,input_kind,content_version_id,
-			profile_fingerprint,embedding_input_fingerprint,vector_space_id,input_generation_id,vector_set_id,created_at
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?)`, record.ID, record.VaultID, record.BindingID,
-			record.InputKind, record.ContentVersionID, record.ProcessingProfileFingerprint,
-			record.EmbeddingInputFingerprint, record.VectorSpace.ID, record.InputGeneration.ID, record.VectorSet.ID, record.CreatedAt)
-		if err != nil {
-			return fmt.Errorf("inserting embedding set %s: %w", record.ID, err)
-		}
-		inserted, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("checking embedding set insertion: %w", err)
-		}
-		if inserted == 0 {
-			stored, err := loadEmbeddingSetTx(ctx, tx, record.ID)
-			if err != nil {
-				return err
-			}
-			if !reflect.DeepEqual(stored, record) {
-				return fmt.Errorf("embedding set %s names different immutable authority", record.ID)
-			}
-		}
-		return nil
+		return stageEmbeddingSetTx(ctx, tx, record)
 	})
+}
+
+func stageEmbeddingSetTx(ctx context.Context, tx *sql.Tx, record EmbeddingSetRecord) error {
+	if err := validateEmbeddingSetFencesTx(ctx, tx, record); err != nil {
+		return err
+	}
+	if err := requireEmbeddingPurgeAuthorityTx(ctx, tx, record); err != nil {
+		return err
+	}
+	if err := requireEmbeddingPhysicalAuthorityTx(ctx, tx, record); err != nil {
+		return err
+	}
+	// Payload bytes are validated before the transaction writes catalog
+	// authority. SQLite retains only the immutable blob reference and the
+	// canonical row projection derived from those bytes.
+	record.VectorSet.Payload = nil
+	record.InputGeneration.GenerationJSON = nil
+	record.InputGeneration.EvidenceJSON = nil
+	if err := insertVectorSpaceTx(ctx, tx, record.VectorSpace); err != nil {
+		return err
+	}
+	if err := insertInputGenerationTx(ctx, tx, record.InputGeneration); err != nil {
+		return err
+	}
+	if err := insertVectorSetTx(ctx, tx, record.VectorSet); err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO embedding_sets(
+		embedding_set_id,vault_uid,binding_id,input_kind,content_version_id,
+		profile_fingerprint,embedding_input_fingerprint,vector_space_id,input_generation_id,vector_set_id,created_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?)`, record.ID, record.VaultID, record.BindingID,
+		record.InputKind, record.ContentVersionID, record.ProcessingProfileFingerprint,
+		record.EmbeddingInputFingerprint, record.VectorSpace.ID, record.InputGeneration.ID, record.VectorSet.ID, record.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("inserting embedding set %s: %w", record.ID, err)
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking embedding set insertion: %w", err)
+	}
+	if inserted == 0 {
+		stored, err := loadEmbeddingSetTx(ctx, tx, record.ID)
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(stored, record) {
+			return fmt.Errorf("embedding set %s names different immutable authority", record.ID)
+		}
+	}
+	return nil
 }
 
 func normalizeEmbeddingSetRecord(record EmbeddingSetRecord) (EmbeddingSetRecord, error) {
@@ -469,68 +470,72 @@ func (s *Store) PublishEmbeddingHead(ctx context.Context, record EmbeddingHeadRe
 		return fmt.Errorf("publishing embedding head: %w", err)
 	}
 	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		set, err := loadEmbeddingSetTx(ctx, tx, record.SetID)
-		if err != nil {
-			return fmt.Errorf("publishing embedding head: %w", err)
-		}
-		if set.ContentVersionID != record.Key.ContentVersionID || set.BindingID != record.Key.BindingID ||
-			set.InputKind != record.Key.InputKind || set.VectorSpace.ID != record.VectorSpaceID ||
-			set.ProcessingProfileFingerprint != record.ProcessingProfileFingerprint {
-			return errors.New("publishing embedding head: stale source, profile, binding, or vector-space fence")
-		}
-		if err := requireEmbeddingPurgeAuthorityTx(ctx, tx, set); err != nil {
-			return err
-		}
-		if err := requireEmbeddingPhysicalAuthorityTx(ctx, tx, set); err != nil {
-			return err
-		}
-		eligible, err := embeddingSetEligibleTx(ctx, tx, set)
-		if err != nil {
-			return err
-		}
-		if !eligible {
-			return errors.New("publishing embedding head: source or attachment is not eligible")
-		}
-		var newerFailure bool
-		if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM embedding_failures
-			WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?
-			AND fencing_token>=?)`, record.Key.ContentVersionID, record.ProcessingProfileFingerprint,
-			record.Key.BindingID, record.Key.InputKind, record.FencingToken).Scan(&newerFailure); err != nil {
-			return fmt.Errorf("checking embedding failure fence: %w", err)
-		}
-		if newerFailure {
-			return errors.New("publishing embedding head: stale or reused fencing token")
-		}
-		result, err := tx.ExecContext(ctx, `INSERT INTO embedding_heads(
-			content_version_id,binding_id,input_kind,embedding_set_id,vector_space_id,
-			profile_fingerprint,published_at,fencing_token
-		) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
-		DO UPDATE SET embedding_set_id=excluded.embedding_set_id,
-		vector_space_id=excluded.vector_space_id,profile_fingerprint=excluded.profile_fingerprint,
-		published_at=excluded.published_at,fencing_token=excluded.fencing_token
-		WHERE excluded.fencing_token>embedding_heads.fencing_token OR (
-			excluded.fencing_token=embedding_heads.fencing_token AND
-			excluded.embedding_set_id=embedding_heads.embedding_set_id AND
-			excluded.published_at=embedding_heads.published_at
-		)`, record.Key.ContentVersionID, record.Key.BindingID,
-			record.Key.InputKind, record.SetID, record.VectorSpaceID,
-			record.ProcessingProfileFingerprint, record.PublishedAt, record.FencingToken)
-		if err != nil {
-			return fmt.Errorf("publishing embedding head: %w", err)
-		}
-		changed, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("checking embedding publication: %w", err)
-		}
-		if changed != 1 {
-			return errors.New("publishing embedding head: stale or reused fencing token")
-		}
-		_, err = tx.ExecContext(ctx, `DELETE FROM embedding_failures
-			WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?`,
-			record.Key.ContentVersionID, record.ProcessingProfileFingerprint,
-			record.Key.BindingID, record.Key.InputKind)
-		return err
+		return publishEmbeddingHeadTx(ctx, tx, record)
 	})
+}
+
+func publishEmbeddingHeadTx(ctx context.Context, tx *sql.Tx, record EmbeddingHeadRecord) error {
+	set, err := loadEmbeddingSetTx(ctx, tx, record.SetID)
+	if err != nil {
+		return fmt.Errorf("publishing embedding head: %w", err)
+	}
+	if set.ContentVersionID != record.Key.ContentVersionID || set.BindingID != record.Key.BindingID ||
+		set.InputKind != record.Key.InputKind || set.VectorSpace.ID != record.VectorSpaceID ||
+		set.ProcessingProfileFingerprint != record.ProcessingProfileFingerprint {
+		return fmt.Errorf("publishing embedding head: stale source, profile, binding, or vector-space fence: %w", ErrEmbeddingAuthorityStale)
+	}
+	if err := requireEmbeddingPurgeAuthorityTx(ctx, tx, set); err != nil {
+		return err
+	}
+	if err := requireEmbeddingPhysicalAuthorityTx(ctx, tx, set); err != nil {
+		return err
+	}
+	eligible, err := embeddingSetEligibleTx(ctx, tx, set)
+	if err != nil {
+		return err
+	}
+	if !eligible {
+		return fmt.Errorf("publishing embedding head: source or attachment is not eligible: %w", ErrEmbeddingAuthorityStale)
+	}
+	var newerFailure bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM embedding_failures
+		WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?
+		AND fencing_token>=?)`, record.Key.ContentVersionID, record.ProcessingProfileFingerprint,
+		record.Key.BindingID, record.Key.InputKind, record.FencingToken).Scan(&newerFailure); err != nil {
+		return fmt.Errorf("checking embedding failure fence: %w", err)
+	}
+	if newerFailure {
+		return fmt.Errorf("publishing embedding head: stale or reused fencing token: %w", ErrEmbeddingAuthorityStale)
+	}
+	result, err := tx.ExecContext(ctx, `INSERT INTO embedding_heads(
+		content_version_id,binding_id,input_kind,embedding_set_id,vector_space_id,
+		profile_fingerprint,published_at,fencing_token
+	) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
+	DO UPDATE SET embedding_set_id=excluded.embedding_set_id,
+	vector_space_id=excluded.vector_space_id,profile_fingerprint=excluded.profile_fingerprint,
+	published_at=excluded.published_at,fencing_token=excluded.fencing_token
+	WHERE excluded.fencing_token>embedding_heads.fencing_token OR (
+		excluded.fencing_token=embedding_heads.fencing_token AND
+		excluded.embedding_set_id=embedding_heads.embedding_set_id AND
+		excluded.published_at=embedding_heads.published_at
+	)`, record.Key.ContentVersionID, record.Key.BindingID,
+		record.Key.InputKind, record.SetID, record.VectorSpaceID,
+		record.ProcessingProfileFingerprint, record.PublishedAt, record.FencingToken)
+	if err != nil {
+		return fmt.Errorf("publishing embedding head: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking embedding publication: %w", err)
+	}
+	if changed != 1 {
+		return fmt.Errorf("publishing embedding head: stale or reused fencing token: %w", ErrEmbeddingAuthorityStale)
+	}
+	_, err = tx.ExecContext(ctx, `DELETE FROM embedding_failures
+		WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?`,
+		record.Key.ContentVersionID, record.ProcessingProfileFingerprint,
+		record.Key.BindingID, record.Key.InputKind)
+	return err
 }
 
 // RecordEmbeddingFailure records provider-neutral plan status without
@@ -540,56 +545,58 @@ func (s *Store) RecordEmbeddingFailure(ctx context.Context, record EmbeddingFail
 	if err := validateEmbeddingFailureRecord(record); err != nil {
 		return err
 	}
-	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		if err := validateEmbeddingFailureBinding(ctx, tx, record); err != nil {
-			return err
-		}
-		var count int
-		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_versions v
-			JOIN processing_profiles p ON p.profile_fingerprint=? WHERE v.version_id=?`,
-			record.ProcessingProfileFingerprint, record.ContentVersionID).Scan(&count); err != nil {
-			return err
-		}
-		if count != 1 {
-			return ErrNotFound
-		}
-		suppression, err := loadEmbeddingPurgeSuppressionTx(ctx, tx,
-			EmbeddingHeadKey{record.ContentVersionID, record.BindingID, record.InputKind},
-			record.ProcessingProfileFingerprint)
-		if err != nil && !errors.Is(err, ErrNotFound) {
-			return fmt.Errorf("checking embedding failure purge suppression: %w", err)
-		}
-		if err == nil && suppression.active {
-			return errors.New("embedding failure binding has an active purge suppression")
-		}
-		if err := validateEmbeddingFailureEligibility(ctx, tx, record); err != nil {
-			return err
-		}
-		result, err := tx.ExecContext(ctx, `INSERT INTO embedding_failures(
-			content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at,fencing_token,attachment_id
-		) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
-		DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at,
-		fencing_token=excluded.fencing_token,attachment_id=excluded.attachment_id
-		WHERE excluded.fencing_token>embedding_failures.fencing_token OR (
-			excluded.fencing_token=embedding_failures.fencing_token AND
-			excluded.failure_code=embedding_failures.failure_code AND
-			excluded.attachment_id=embedding_failures.attachment_id AND
-			excluded.failed_at=embedding_failures.failed_at
-		)`, record.ContentVersionID,
-			record.ProcessingProfileFingerprint, record.BindingID, record.InputKind,
-			record.FailureCode, record.FailedAt, record.FencingToken, record.AttachmentID)
-		if err != nil {
-			return fmt.Errorf("recording embedding failure: %w", err)
-		}
-		changed, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("checking embedding failure write: %w", err)
-		}
-		if changed != 1 {
-			return errors.New("recording embedding failure: stale or reused fencing token")
-		}
-		return nil
-	})
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error { return recordEmbeddingFailureTx(ctx, tx, record) })
+}
+
+func recordEmbeddingFailureTx(ctx context.Context, tx *sql.Tx, record EmbeddingFailureRecord) error {
+	if err := validateEmbeddingFailureBinding(ctx, tx, record); err != nil {
+		return err
+	}
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM content_versions v
+		JOIN processing_profiles p ON p.profile_fingerprint=? WHERE v.version_id=?`,
+		record.ProcessingProfileFingerprint, record.ContentVersionID).Scan(&count); err != nil {
+		return err
+	}
+	if count != 1 {
+		return ErrNotFound
+	}
+	suppression, err := loadEmbeddingPurgeSuppressionTx(ctx, tx,
+		EmbeddingHeadKey{record.ContentVersionID, record.BindingID, record.InputKind},
+		record.ProcessingProfileFingerprint)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return fmt.Errorf("checking embedding failure purge suppression: %w", err)
+	}
+	if err == nil && suppression.active {
+		return errors.New("embedding failure binding has an active purge suppression")
+	}
+	if err := validateEmbeddingFailureEligibility(ctx, tx, record); err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `INSERT INTO embedding_failures(
+		content_version_id,profile_fingerprint,binding_id,input_kind,failure_code,failed_at,fencing_token,attachment_id
+	) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(content_version_id,profile_fingerprint,binding_id,input_kind)
+	DO UPDATE SET failure_code=excluded.failure_code,failed_at=excluded.failed_at,
+	fencing_token=excluded.fencing_token,attachment_id=excluded.attachment_id
+	WHERE excluded.fencing_token>embedding_failures.fencing_token OR (
+		excluded.fencing_token=embedding_failures.fencing_token AND
+		excluded.failure_code=embedding_failures.failure_code AND
+		excluded.attachment_id=embedding_failures.attachment_id AND
+		excluded.failed_at=embedding_failures.failed_at
+	)`, record.ContentVersionID,
+		record.ProcessingProfileFingerprint, record.BindingID, record.InputKind,
+		record.FailureCode, record.FailedAt, record.FencingToken, record.AttachmentID)
+	if err != nil {
+		return fmt.Errorf("recording embedding failure: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking embedding failure write: %w", err)
+	}
+	if changed != 1 {
+		return errors.New("recording embedding failure: stale or reused fencing token")
+	}
+	return nil
 }
 
 func validateEmbeddingFailureEligibility(ctx context.Context, query metadataQuerier, record EmbeddingFailureRecord) error {
@@ -1482,4 +1489,115 @@ func embeddingCatalogSchemaColumns(
 		return nil, err
 	}
 	return columns, nil
+}
+
+func (s *Store) prepareEmbeddingSetRecord(record EmbeddingSetRecord) (EmbeddingSetRecord, error) {
+	record, err := normalizeEmbeddingSetRecord(record)
+	if err != nil {
+		return EmbeddingSetRecord{}, fmt.Errorf("staging embedding set: %w", err)
+	}
+	if err := validateEmbeddingSetRecord(record); err != nil {
+		return EmbeddingSetRecord{}, fmt.Errorf("staging embedding set: %w", err)
+	}
+	if record.VaultID != s.vaultID {
+		return EmbeddingSetRecord{}, errors.New("staging embedding set: vault identity does not match store")
+	}
+	return record, nil
+}
+
+func (s *Store) StageEmbeddingSetWithLease(ctx context.Context, record EmbeddingSetRecord,
+	rootID string, fencingToken int64, at time.Time,
+) error {
+	record, err := s.prepareEmbeddingSetRecord(record)
+	if err != nil {
+		return err
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if err := requireEmbeddingWorkerLeaseTx(ctx, tx, rootID, fencingToken,
+			record.InputGeneration.ID, at); err != nil {
+			return err
+		}
+		// Retrying publication may stage the same content again. Its first
+		// creation time remains authoritative; every other immutable field is
+		// still compared by stageEmbeddingSetTx.
+		var createdAt string
+		err := tx.QueryRowContext(ctx, `SELECT created_at FROM embedding_sets WHERE embedding_set_id=?`, record.ID).Scan(&createdAt)
+		if err == nil {
+			record.CreatedAt = createdAt
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return stageEmbeddingSetTx(ctx, tx, record)
+	})
+}
+
+func HydrateEmbeddingInputGeneration(record EmbeddingInputGenerationRecord, data, evidence []byte) (EmbeddingInputGenerationRecord, error) {
+	if err := validateExactEmbeddingGenerationArtifact(record, data); err != nil {
+		return EmbeddingInputGenerationRecord{}, fmt.Errorf("hydrating exact artifact: %w", err)
+	}
+	if err := validateEmbeddingGenerationEvidence(record, data, evidence); err != nil {
+		return EmbeddingInputGenerationRecord{}, err
+	}
+	record.GenerationJSON = bytes.Clone(data)
+	record.EvidenceJSON = bytes.Clone(evidence)
+	return record, nil
+}
+
+func (s *Store) PublishEmbeddingHeadWithLease(ctx context.Context, record EmbeddingHeadRecord,
+	consent ProviderOperationAuthorizationRequest, prior ProviderOperationAuthorization,
+	rootID string, fencingToken int64, at time.Time,
+) (ProviderOperationAuthorization, error) {
+	if err := validateEmbeddingHeadRecord(record); err != nil {
+		return ProviderOperationAuthorization{}, fmt.Errorf("publishing leased embedding head: %w", err)
+	}
+	var authorization ProviderOperationAuthorization
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		authorization, err = publishEmbeddingHeadWithLeaseTx(ctx, tx, s.vaultID, record, consent, prior, rootID, fencingToken, at)
+		return err
+	})
+	return authorization, err
+}
+
+func publishEmbeddingHeadWithLeaseTx(ctx context.Context, tx *sql.Tx, vaultID string, record EmbeddingHeadRecord,
+	consent ProviderOperationAuthorizationRequest, prior ProviderOperationAuthorization,
+	rootID string, fencingToken int64, at time.Time,
+) (ProviderOperationAuthorization, error) {
+	set, err := loadEmbeddingSetTx(ctx, tx, record.SetID)
+	if err != nil {
+		return ProviderOperationAuthorization{}, err
+	}
+	if err := requireEmbeddingWorkerLeaseTx(ctx, tx, rootID, fencingToken, set.InputGeneration.ID, at); err != nil {
+		return ProviderOperationAuthorization{}, err
+	}
+	consent.PriorAuthorization = &prior
+	authorization, err := authorizeProviderOperationTx(ctx, tx, vaultID, consent, at.UTC())
+	if err != nil {
+		return ProviderOperationAuthorization{}, err
+	}
+	return authorization, publishEmbeddingHeadTx(ctx, tx, record)
+}
+
+func requireEmbeddingWorkerLeaseTx(ctx context.Context, tx *sql.Tx, rootID string,
+	fencingToken int64, generationID string, at time.Time,
+) error {
+	if rootID == "" || fencingToken <= 0 || generationID == "" || at.IsZero() {
+		return ErrCurrentRenditionRootFenced
+	}
+	var expiresAt string
+	err := tx.QueryRowContext(ctx, `SELECT expires_at FROM current_rendition_roots
+		WHERE root_id=? AND root_kind=? AND target_kind=? AND target_id=?
+		  AND fencing_token=? AND active=1`, rootID, RenditionRootWorkerLease,
+		RenditionRootEmbeddingGeneration, generationID, fencingToken).Scan(&expiresAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrCurrentRenditionRootFenced
+	}
+	if err != nil {
+		return fmt.Errorf("checking embedding worker lease: %w", err)
+	}
+	expires, err := time.Parse(timestampLayout, expiresAt)
+	if err != nil || !expires.After(at.UTC()) {
+		return ErrCurrentRenditionRootFenced
+	}
+	return nil
 }

--- a/internal/store/embedding_catalog_test.go
+++ b/internal/store/embedding_catalog_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,6 +74,447 @@ func TestEmbeddingCatalogDeduplicatesExactSetsButFencesAttachmentContext(t *test
 	assert.NotEqual(t, record.InputGeneration.ID, second.InputGeneration.ID)
 	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_input_generations`).Scan(&generations))
 	assert.Equal(t, 2, generations, "attachment identities must not share catalog generation authority")
+}
+
+func TestHydrateEmbeddingInputGenerationRequiresExactCanonicalArtifact(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	record, err := normalizeEmbeddingSetRecord(record)
+	require.NoError(t, err)
+	projection := record.InputGeneration
+	artifact := append([]byte(nil), projection.GenerationJSON...)
+	projection.GenerationJSON = nil
+
+	hydrated, err := HydrateEmbeddingInputGeneration(projection, artifact, record.InputGeneration.EvidenceJSON)
+	require.NoError(t, err)
+	assert.Equal(t, record.InputGeneration, hydrated)
+
+	corrupt := append([]byte(nil), artifact...)
+	corrupt[len(corrupt)-1] ^= 1
+	_, err = HydrateEmbeddingInputGeneration(projection, corrupt, record.InputGeneration.EvidenceJSON)
+	require.ErrorContains(t, err, "exact artifact")
+}
+
+func TestEmbeddingCatalogLeasedStageAndPublishAreAtomicallyFenced(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+
+	root := CurrentRenditionRoot{
+		ID: "embedding-worker-attempt", Kind: RenditionRootWorkerLease,
+		TargetKind: RenditionRootEmbeddingGeneration, TargetID: record.InputGeneration.ID,
+		FencingToken: 1, RecordedAt: embeddingCatalogTime,
+		ExpiresAt: "2099-08-25T10:00:00.000000000Z",
+	}
+	require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), root))
+	at := time.Now().UTC()
+	require.ErrorIs(t, s.StageEmbeddingSetWithLease(
+		t.Context(), record, root.ID, root.FencingToken+1, at),
+		ErrCurrentRenditionRootFenced)
+	require.NoError(t, s.StageEmbeddingSetWithLease(
+		t.Context(), record, root.ID, root.FencingToken, at))
+
+	consent := ProviderOperationAuthorizationRequest{
+		Principal: "operator:embedding-worker", Scope: "embedding:optional",
+		ProfileFingerprint:      profile.Fingerprint,
+		DisclosureFingerprint:   workerOptionalEmbeddingBinding(t, profile).DisclosureFingerprint,
+		InputClasses:            []string{string(document.EmbeddingInputOriginalFile)},
+		RetainedArtifactClasses: []string{"embedding_vector_set"},
+	}
+	_, err := s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope,
+		ProfileFingerprint:      consent.ProfileFingerprint,
+		DisclosureFingerprint:   consent.DisclosureFingerprint,
+		InputClasses:            consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	prior, err := s.AuthorizeProviderOperation(t.Context(), consent)
+	require.NoError(t, err)
+	head := EmbeddingHeadRecord{
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID, InputKind: record.InputKind},
+		SetID:        record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}
+	_, err = s.PublishEmbeddingHeadWithLease(t.Context(), head, consent, prior,
+		root.ID, root.FencingToken+1, at)
+	require.ErrorIs(t, err, ErrCurrentRenditionRootFenced)
+	var count int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_heads`).Scan(&count))
+	require.Zero(t, count)
+
+	_, err = s.PublishEmbeddingHeadWithLease(t.Context(), head, consent, prior,
+		root.ID, root.FencingToken, at)
+	require.NoError(t, err)
+	assert.Equal(t, record.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, record.BindingID, record.InputKind))
+
+	_, err = s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{
+		Principal: consent.Principal, Scope: consent.Scope,
+	})
+	require.NoError(t, err)
+	_, err = s.PublishEmbeddingHeadWithLease(t.Context(), head, consent, prior,
+		root.ID, root.FencingToken, at.Add(time.Second))
+	require.ErrorIs(t, err, ErrProcessingConsentRevoked)
+	assert.Equal(t, record.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, record.BindingID, record.InputKind))
+}
+
+func TestEmbeddingJobCatalogClaimsRetriesAndResumesDurably(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	binding := workerOptionalEmbeddingBinding(t, profile)
+	consent := ProviderOperationAuthorizationRequest{
+		Principal: "operator:embedding-worker", Scope: "embedding:optional",
+		ProfileFingerprint: profile.Fingerprint, DisclosureFingerprint: binding.DisclosureFingerprint,
+		InputClasses: []string{string(binding.InputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"},
+	}
+	_, err := s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	job, err := s.EnqueueEmbeddingJob(t.Context(), EmbeddingJobRequest{
+		ContentVersionID: versionID, Profile: profile, BindingID: binding.Name,
+		Descriptor: record.VectorSpace.Descriptor, InputGeneration: record.InputGeneration,
+		Authorization: consent,
+	})
+	require.NoError(t, err)
+
+	at := time.Now().UTC()
+	_, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "unconfigured-worker", at, 5*time.Minute, []string{fakeHash("different-runtime")})
+	require.NoError(t, err)
+	require.False(t, found, "unconfigured runtimes must leave queued jobs untouched")
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-a", at, 5*time.Minute, []string{record.VectorSpace.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, job.ID, claim.AttemptID)
+	assert.Equal(t, record.InputGeneration.ID, work.InputGeneration.ID)
+	_, _, found, err = s.ClaimNextEmbeddingWork(t.Context(), "worker-b", at, 5*time.Minute, []string{record.VectorSpace.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	assert.False(t, found, "a live lease must exclude a concurrent worker")
+
+	_, err = s.RenewEmbeddingWork(t.Context(), EmbeddingJobClaim{
+		AttemptID: claim.AttemptID, Owner: claim.Owner, Epoch: claim.Epoch + 1,
+	}, at.Add(time.Minute), 5*time.Minute)
+	require.ErrorIs(t, err, ErrEmbeddingJobFenced)
+	require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work,
+		EmbeddingFailureProviderUnavailable, EmbeddingAttemptReceipt{AttemptID: claim.AttemptID,
+			ProviderFingerprint: work.Descriptor.Fingerprint, ProfileFingerprint: profile.Fingerprint,
+			BindingID: binding.Name, InputKind: binding.InputKind, Rows: 1, Dimensions: binding.Dimensions,
+			ProviderCalls: 3, Retries: 2, Elapsed: time.Second, FailureCode: string(EmbeddingFailureProviderUnavailable)}, at.Add(time.Minute)))
+
+	_, _, found, err = s.ClaimNextEmbeddingWork(t.Context(), "worker-b", at.Add(time.Minute), 5*time.Minute, []string{record.VectorSpace.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	assert.False(t, found, "durable retry delay must prevent a hot loop")
+	resumed, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-b", at.Add(2*time.Minute), 5*time.Minute, []string{record.VectorSpace.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Greater(t, resumed.Epoch, claim.Epoch)
+
+	restored, err := Open(s.path, s.driver)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	_, _, found, err = restored.ClaimNextEmbeddingWork(t.Context(), "worker-c", at.Add(6*time.Minute), 5*time.Minute, []string{record.VectorSpace.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	assert.False(t, found, "the unexpired resumed lease must survive daemon restart")
+}
+
+func TestEmbeddingJobsRebuildFromPortableAuthorityAfterMetadataRestore(t *testing.T) {
+	source, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(source, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	binding := workerOptionalEmbeddingBinding(t, profile)
+	consent := ProviderOperationAuthorizationRequest{
+		Principal: "operator:embedding-rebuild", Scope: "embedding:optional",
+		ProfileFingerprint: profile.Fingerprint, DisclosureFingerprint: binding.DisclosureFingerprint,
+		InputClasses: []string{string(binding.InputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"},
+	}
+	_, err := source.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	request := EmbeddingJobRequest{ContentVersionID: versionID, Profile: profile, BindingID: binding.Name,
+		Descriptor: record.VectorSpace.Descriptor, InputGeneration: record.InputGeneration, Authorization: consent}
+	_, err = source.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	_, _, found, err := source.ClaimNextEmbeddingWork(t.Context(), "worker-before-backup", at, 5*time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	var metadata bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &metadata))
+	assert.NotContains(t, metadata.String(), `"type":"embedding_job"`,
+		"jobs are rebuildable operational state, not portable authority")
+	target, err := Open(filepath.Join(t.TempDir(), "embedding-job-restore.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(metadata.Bytes())))
+	var jobs int
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM embedding_jobs`).Scan(&jobs))
+	assert.Zero(t, jobs)
+	_, err = target.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err, "restore starts a new consent incarnation before jobs may rebuild")
+	reconciled, err := target.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation,
+		At: time.Now().UTC(), Limit: 100,
+		DescriptorFingerprints: []string{request.Descriptor.Fingerprint},
+	})
+	require.NoError(t, err)
+	assert.Positive(t, reconciled.Enqueued)
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM embedding_jobs`).Scan(&jobs))
+	assert.Equal(t, reconciled.Enqueued, jobs, "reconciliation deterministically rebuilds operational jobs")
+	resumed, _, found, err := target.ClaimNextEmbeddingWork(t.Context(), "worker-after-restore", at.Add(6*time.Minute), 5*time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Positive(t, resumed.Epoch,
+		"restore rebuilds both the operational job and its vault-local lease sequence")
+}
+
+func TestEmbeddingJobReconciliationRequiresCurrentAuthorityAndFreshConsent(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "reconcile")
+	job, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`DELETE FROM embedding_jobs WHERE job_id=?`, job.ID)
+	require.NoError(t, err)
+
+	result, err := s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation,
+		At: time.Now().UTC(), Limit: 1,
+		DescriptorFingerprints: []string{request.Descriptor.Fingerprint},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Examined)
+	assert.Equal(t, 2, result.Enqueued)
+
+	_, err = s.db.Exec(`DELETE FROM embedding_jobs`)
+	require.NoError(t, err)
+	_, err = s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{
+		Principal: request.Authorization.Principal, Scope: request.Authorization.Scope,
+	})
+	require.NoError(t, err)
+	result, err = s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation,
+		At: time.Now().UTC(), Limit: 1,
+		DescriptorFingerprints: []string{request.Descriptor.Fingerprint},
+	})
+	require.NoError(t, err)
+	assert.Zero(t, result.Enqueued)
+}
+
+func TestEmbeddingJobReconciliationRequiresExactChunkBindingPolicy(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	var err error
+	record, err = normalizeEmbeddingSetRecord(record)
+	require.NoError(t, err)
+	binding := workerProfileEmbeddingBinding(t, profile, "chunk")
+	consent := ProviderOperationAuthorizationRequest{
+		Principal: "operator:chunk-reconcile", Scope: "embedding:chunk",
+		ProfileFingerprint: profile.Fingerprint, DisclosureFingerprint: binding.DisclosureFingerprint,
+		InputClasses: []string{string(binding.InputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"},
+	}
+	_, err = s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	_, err = s.EnqueueEmbeddingJob(t.Context(), EmbeddingJobRequest{ContentVersionID: versionID,
+		Profile: profile, BindingID: binding.Name, Descriptor: record.VectorSpace.Descriptor,
+		InputGeneration: record.InputGeneration, Authorization: consent})
+	require.NoError(t, err)
+	_, err = s.db.Exec(`DELETE FROM embedding_jobs`)
+	require.NoError(t, err)
+
+	result, err := s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation,
+		At: time.Now().UTC(), Limit: 100,
+		DescriptorFingerprints: []string{record.VectorSpace.Descriptor.Fingerprint},
+		HydrateGeneration: func(_ context.Context, generation EmbeddingInputGenerationRecord) (EmbeddingInputGenerationRecord, error) {
+			return HydrateEmbeddingInputGeneration(generation, record.InputGeneration.GenerationJSON, record.InputGeneration.EvidenceJSON)
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Enqueued)
+	var bindingID string
+	require.NoError(t, s.db.QueryRow(`SELECT binding_id FROM embedding_jobs`).Scan(&bindingID))
+	assert.Equal(t, "chunk", bindingID)
+
+	// Purge can also win after discovery, while the caller hydrates E2 bytes.
+	_, err = s.db.Exec(`DELETE FROM embedding_jobs`)
+	require.NoError(t, err)
+	hydrated := false
+	result, err = s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation,
+		At: time.Now().UTC(), Limit: 100, DescriptorFingerprints: []string{record.VectorSpace.Descriptor.Fingerprint},
+		HydrateGeneration: func(ctx context.Context, generation EmbeddingInputGenerationRecord) (EmbeddingInputGenerationRecord, error) {
+			hydrated = true
+			_, err := s.PurgeDerivatives(ctx, PurgeRequest{ContentVersionIDs: []string{versionID}})
+			if err != nil {
+				return EmbeddingInputGenerationRecord{}, err
+			}
+			return HydrateEmbeddingInputGeneration(generation, record.InputGeneration.GenerationJSON, record.InputGeneration.EvidenceJSON)
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, hydrated)
+	require.Zero(t, result.Enqueued)
+}
+
+func TestEmbeddingJobLeaseCannotRenewAfterExpiry(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "lease-expiry")
+	_, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-expiry", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	_, err = s.RenewEmbeddingWork(t.Context(), claim, at.Add(time.Minute), time.Minute)
+	require.ErrorIs(t, err, ErrEmbeddingJobFenced)
+	err = s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureInputRejected,
+		EmbeddingAttemptReceipt{AttemptID: claim.AttemptID}, at.Add(time.Minute))
+	require.ErrorIs(t, err, ErrEmbeddingJobFenced)
+	resumed, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-resume", at.Add(time.Minute), time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Greater(t, resumed.Epoch, claim.Epoch)
+}
+
+func TestEmbeddingJobProviderUnavailableRetryBudgetIsDurable(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "durable-retry-budget")
+	_, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	for attempt := 1; attempt <= embeddingJobMaxClaims; attempt++ {
+		claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-budget", at, time.Minute, []string{request.Descriptor.Fingerprint})
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, int64(attempt), claim.Epoch)
+		require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work,
+			EmbeddingFailureProviderUnavailable, EmbeddingAttemptReceipt{
+				AttemptID: claim.AttemptID, ProviderFingerprint: work.Descriptor.Fingerprint,
+				ProfileFingerprint: profile.Fingerprint, BindingID: work.Binding.Name,
+				InputKind: work.Binding.InputKind, ProviderCalls: 3, Retries: 2,
+				FailureCode: string(EmbeddingFailureProviderUnavailable),
+			}, at.Add(30*time.Second)))
+		at = at.Add(2 * time.Minute)
+	}
+	_, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-budget", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	assert.False(t, found)
+	var state string
+	require.NoError(t, s.db.QueryRow(`SELECT state FROM embedding_jobs`).Scan(&state))
+	assert.Equal(t, "failed", state)
+}
+
+func TestEmbeddingJobExistingStaleHeadDoesNotSuppressReplacement(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	old := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), old))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		FencingToken: 1,
+		Key:          EmbeddingHeadKey{ContentVersionID: versionID, BindingID: old.BindingID, InputKind: old.InputKind},
+		SetID:        old.ID, VectorSpaceID: old.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+	request := embeddingJobTestRequest(t, s, versionID, profile, "replacement-generation")
+	_, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-replacement",
+		time.Now().UTC(), time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, request.InputGeneration.ID, work.InputGeneration.ID)
+	require.Greater(t, claim.Epoch, int64(1))
+	require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureProviderUnavailable,
+		EmbeddingAttemptReceipt{AttemptID: claim.AttemptID}, time.Now().UTC()))
+	assert.Equal(t, old.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, old.BindingID, old.InputKind))
+}
+
+func TestVersionPruneRemovesQueuedEmbeddingJobGenerationAndRoot(t *testing.T) {
+	s, firstVersion, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, firstVersion, profile, "queued-prune")
+	job, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	_, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-prune",
+		time.Now().UTC(), time.Hour, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	var nodeID, revision int64
+	require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, firstVersion).Scan(&nodeID, &revision))
+	replacementHash := fakeHash("embedding-job-prune-replacement")
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, replacementHash, 24)
+	}))
+	updated, _, err := s.ReplaceContent(t.Context(), nodeID, revision, replacementHash, 24, "application/pdf")
+	require.NoError(t, err)
+	_, err = s.PruneContentVersions(t.Context(), nodeID, updated.Revision,
+		VersionPruneSelector{VersionIDs: []string{firstVersion}}, true)
+	require.NoError(t, err)
+	_, err = s.PurgeDerivatives(t.Context(), PurgeRequest{})
+	require.NoError(t, err)
+	var remaining int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM embedding_jobs WHERE job_id=?) +
+		(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?) +
+		(SELECT COUNT(*) FROM current_rendition_roots WHERE root_id=?)`,
+		job.ID, request.InputGeneration.ID, job.ID).Scan(&remaining))
+	assert.Zero(t, remaining)
+}
+
+func embeddingJobTestRequest(t *testing.T, s *Store, versionID string,
+	profile ProcessingProfileRecord, generationSeed string,
+) EmbeddingJobRequest {
+	t.Helper()
+	const bindingID = "optional"
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, bindingID, "")
+	record.InputGeneration.ID = testSHA256([]byte(generationSeed))
+	binding := workerOptionalEmbeddingBinding(t, profile)
+	consent := ProviderOperationAuthorizationRequest{
+		Principal: "operator:" + generationSeed, Scope: "embedding:" + bindingID,
+		ProfileFingerprint: profile.Fingerprint, DisclosureFingerprint: binding.DisclosureFingerprint,
+		InputClasses: []string{string(binding.InputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"},
+	}
+	_, err := s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	return EmbeddingJobRequest{ContentVersionID: versionID, Profile: profile, BindingID: bindingID,
+		Descriptor: record.VectorSpace.Descriptor, InputGeneration: record.InputGeneration, Authorization: consent}
+}
+
+func workerOptionalEmbeddingBinding(t *testing.T, profile ProcessingProfileRecord) document.EmbeddingBindingV1 {
+	t.Helper()
+	return workerProfileEmbeddingBinding(t, profile, "optional")
+}
+
+func workerProfileEmbeddingBinding(t *testing.T, profile ProcessingProfileRecord, name string) document.EmbeddingBindingV1 {
+	t.Helper()
+	var canonical document.ProcessingProfileV1
+	require.NoError(t, json.Unmarshal(profile.CanonicalProfile, &canonical))
+	for _, binding := range canonical.Embeddings {
+		if binding.Name == name {
+			return binding
+		}
+	}
+	t.Fatalf("embedding binding %q not found", name)
+	return document.EmbeddingBindingV1{}
 }
 
 func TestEmbeddingCatalogRejectsInvalidRowsAndPublicationFences(t *testing.T) {
@@ -712,7 +1154,9 @@ func embeddingCatalogProfile(t *testing.T) ProcessingProfileRecord {
 		makeBinding("optional", document.EmbeddingOptional, document.EmbeddingInputOriginalFile),
 		makeBinding("required", document.EmbeddingRequired, document.EmbeddingInputOriginalFile),
 		makeBinding("chunk", document.EmbeddingOptional, document.EmbeddingInputRenditionChunk),
+		makeBinding("chunk-alt", document.EmbeddingOptional, document.EmbeddingInputRenditionChunk),
 	}
+	profile.Embeddings[3].Chunk.MaxTokens = 64
 	canonical, fingerprints, err := document.CanonicalProfile(profile)
 	require.NoError(t, err)
 	return ProcessingProfileRecord{
@@ -779,4 +1223,564 @@ func cloneEmbeddingSetRecord(value EmbeddingSetRecord) EmbeddingSetRecord {
 	clone.VectorSet.Payload = append([]byte(nil), value.VectorSet.Payload...)
 	clone.VectorSet.rows = append([]EmbeddingVectorRowRecord(nil), value.VectorSet.rows...)
 	return clone
+}
+
+func TestEmbeddingJobsRetainQueuedInputsUntilExplicitPurge(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "queued-retention")
+	job, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	_, err = s.PurgeDerivatives(t.Context(), PurgeRequest{})
+	require.NoError(t, err)
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "retention-worker", time.Now().UTC(), time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found, "ordinary collection must retain queued work and its vector space")
+	_, err = s.PurgeDerivatives(t.Context(), PurgeRequest{ContentVersionIDs: []string{versionID}})
+	require.NoError(t, err)
+	var remaining int
+	require.NoError(t, s.db.QueryRow(`SELECT
+  (SELECT COUNT(*) FROM embedding_jobs WHERE job_id=?) +
+  (SELECT COUNT(*) FROM current_rendition_roots WHERE root_id=?) +
+  (SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?)`, job.ID, claim.AttemptID, request.InputGeneration.ID).Scan(&remaining))
+	require.Zero(t, remaining)
+	require.ErrorIs(t, s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureProviderUnavailable,
+		EmbeddingAttemptReceipt{AttemptID: claim.AttemptID}, time.Now().UTC()), ErrEmbeddingJobFenced)
+	require.NoError(t, s.AbandonEmbeddingWork(t.Context(), claim, time.Now().UTC()))
+	_, err = s.EnqueueEmbeddingJob(t.Context(), request)
+	require.ErrorIs(t, err, ErrEmbeddingJobFenced, "purged intent must not be resubmitted to a provider")
+}
+
+func TestEmbeddingJobAbandonmentPreservesSuccessorClaim(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "abandonment")
+	_, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	first, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "first-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	at = at.Add(2 * time.Minute)
+	require.NoError(t, s.AbandonEmbeddingWork(t.Context(), first, at))
+	successor, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "successor-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, s.AbandonEmbeddingWork(t.Context(), first, at))
+	require.NoError(t, s.ValidateEmbeddingWork(t.Context(), successor, work, at))
+	require.NoError(t, s.AbandonEmbeddingWork(t.Context(), successor, at))
+	require.ErrorIs(t, s.ValidateEmbeddingWork(t.Context(), successor, work, at), ErrEmbeddingJobFenced)
+	var state string
+	require.NoError(t, s.db.QueryRow(`SELECT state FROM embedding_jobs WHERE job_id=?`, successor.AttemptID).Scan(&state))
+	require.Equal(t, "abandoned", state)
+	var failures int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_failures`).Scan(&failures))
+	require.Zero(t, failures)
+}
+
+func TestEmbeddingEgressKeepsOriginalConsentAcrossBatches(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "egress-consent")
+	_, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "embedding-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	first, fence, err := s.BeginEmbeddingProviderEgress(t.Context(), claim, work, nil, at)
+	require.NoError(t, err)
+	fence.Close()
+	second, fence, err := s.BeginEmbeddingProviderEgress(t.Context(), claim, work, &first, at)
+	require.NoError(t, err)
+	fence.Close()
+	require.Equal(t, first.GrantID, second.GrantID)
+	consent := request.Authorization
+	_, err = s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{Principal: consent.Principal, Scope: consent.Scope})
+	require.NoError(t, err)
+	_, err = s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	_, fence, err = s.BeginEmbeddingProviderEgress(t.Context(), claim, work, &second, at)
+	require.ErrorIs(t, err, ErrProcessingConsentRevoked)
+	require.Nil(t, fence)
+	// Fresh work can use the replacement grant after a failed prior check.
+	fresh, fence, err := s.BeginEmbeddingProviderEgress(t.Context(), claim, work, nil, at)
+	require.NoError(t, err)
+	fence.Close()
+	require.NotEqual(t, first.GrantID, fresh.GrantID)
+}
+
+func TestEmbeddingJobReplacementConsentPreservesClaimsAndRetryBudget(t *testing.T) {
+	for _, state := range []string{"queued", "running", "retry_wait", "authorization_failed", "exhausted"} {
+		t.Run(state, func(t *testing.T) {
+			s, version, profile, _ := newEmbeddingCatalogFixture(t)
+			request := embeddingJobTestRequest(t, s, version, profile, "replacement-consent")
+			job, err := s.EnqueueEmbeddingJob(t.Context(), request)
+			require.NoError(t, err)
+			at := time.Now().UTC()
+			var claim EmbeddingJobClaim
+			var work EmbeddingJobWork
+			count := 0
+			if state != "queued" {
+				attempts := 1
+				if state == "exhausted" {
+					attempts = embeddingJobMaxClaims
+				}
+				for range attempts {
+					var found bool
+					claim, work, found, err = s.ClaimNextEmbeddingWork(t.Context(), "worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+					require.NoError(t, err)
+					require.True(t, found)
+					count++
+					if state != "running" {
+						code := EmbeddingFailureProviderUnavailable
+						if state == "authorization_failed" {
+							code = EmbeddingFailureAuthorization
+						}
+						require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work, code, EmbeddingAttemptReceipt{AttemptID: claim.AttemptID}, at))
+					}
+					if state == "exhausted" {
+						at = at.Add(2 * time.Minute)
+					}
+				}
+			}
+			_, err = s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{Principal: request.Authorization.Principal, Scope: request.Authorization.Scope})
+			require.NoError(t, err)
+			replacement := request
+			replacement.Authorization.Principal = "operator:replacement"
+			replacement.Authorization.Scope = "embedding:replacement"
+			consent := replacement.Authorization
+			_, err = s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint, DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses, RetainedArtifactClasses: consent.RetainedArtifactClasses})
+			require.NoError(t, err)
+			same, err := s.EnqueueEmbeddingJob(t.Context(), replacement)
+			require.NoError(t, err)
+			require.Equal(t, job.ID, same.ID)
+			var claims int
+			require.NoError(t, s.db.QueryRow(`SELECT claim_count FROM embedding_jobs WHERE job_id=?`, job.ID).Scan(&claims))
+			require.Equal(t, count, claims)
+			if state == "running" {
+				require.NoError(t, s.ValidateEmbeddingWork(t.Context(), claim, work, at))
+				_, fence, err := s.BeginEmbeddingProviderEgress(t.Context(), claim, work, nil, at)
+				fence.Close()
+				require.ErrorIs(t, err, ErrProcessingConsentRevoked)
+				require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureAuthorization, EmbeddingAttemptReceipt{AttemptID: claim.AttemptID}, at))
+				_, err = s.EnqueueEmbeddingJob(t.Context(), replacement)
+				require.NoError(t, err)
+			}
+			if state == "retry_wait" {
+				_, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "early-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+				require.NoError(t, err)
+				require.False(t, found, "replacement consent must preserve retry delay")
+			}
+			at = at.Add(2 * time.Minute)
+			next, rebound, found, err := s.ClaimNextEmbeddingWork(t.Context(), "next-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+			require.NoError(t, err)
+			if state == "exhausted" {
+				require.False(t, found, "replacement consent must not restart exhausted provider retries")
+				return
+			}
+			require.True(t, found)
+			require.Equal(t, consent.Principal, rebound.Consent.Principal)
+			require.Equal(t, consent.Scope, rebound.Consent.Scope)
+			_, fence, err := s.BeginEmbeddingProviderEgress(t.Context(), next, rebound, nil, at)
+			require.NoError(t, err)
+			fence.Close()
+		})
+	}
+}
+
+func TestEmbeddingJobReconciliationRecoversFreshGrantForSameScope(t *testing.T) {
+	s, version, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, version, profile, "fresh-grant")
+	job, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	consent := request.Authorization
+	_, err = s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{Principal: consent.Principal, Scope: consent.Scope})
+	require.NoError(t, err)
+	require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureAuthorization, EmbeddingAttemptReceipt{AttemptID: claim.AttemptID}, at))
+	_, err = s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint, DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses, RetainedArtifactClasses: consent.RetainedArtifactClasses})
+	require.NoError(t, err)
+	_, err = s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation, At: time.Now().UTC(), Limit: 100, DescriptorFingerprints: []string{request.Descriptor.Fingerprint}})
+	require.NoError(t, err)
+	recovered := false
+	for {
+		next, rebound, found, err := s.ClaimNextEmbeddingWork(t.Context(), "next-worker", time.Now().UTC(), time.Minute, []string{request.Descriptor.Fingerprint})
+		require.NoError(t, err)
+		if !found {
+			break
+		}
+		if next.AttemptID != job.ID {
+			continue
+		}
+		_, fence, err := s.BeginEmbeddingProviderEgress(t.Context(), next, rebound, nil, time.Now().UTC())
+		require.NoError(t, err)
+		fence.Close()
+		recovered = true
+	}
+	require.True(t, recovered, "reconciliation must revive the original authorization-failed job")
+}
+
+func TestEmbeddingValidationPreservesReadErrors(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "validation-read-error")
+	_, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "worker-read-error", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	err = s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		readErr := requireEmbeddingWorkerLeaseTx(ctx, tx, claim.AttemptID, claim.Epoch, work.InputGeneration.ID, at)
+		require.ErrorIs(t, readErr, context.Canceled)
+		classified := validateEmbeddingWorkTx(ctx, tx, s.vaultID, claim, work, at)
+		require.NotErrorIs(t, classified, ErrEmbeddingJobFenced)
+		require.ErrorIs(t, classified, context.Canceled)
+		require.NoError(t, validateEmbeddingWorkTx(t.Context(), tx, s.vaultID, claim, work, at))
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestEmbeddingGCReleasesTerminalJobArtifacts(t *testing.T) {
+	for _, state := range []string{"completed", "failed", "abandoned", "queued", "retry_wait", "running", "failed_without_set", "abandoned_without_set"} {
+		t.Run(state, func(t *testing.T) {
+			hasSet := !strings.HasSuffix(state, "_without_set")
+			state = strings.TrimSuffix(state, "_without_set")
+			s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+			record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+			normalized, normalizeErr := normalizeEmbeddingSetRecord(record)
+			require.NoError(t, normalizeErr)
+			record = normalized
+			binding := workerProfileEmbeddingBinding(t, profile, "chunk")
+			consent := ProviderOperationAuthorizationRequest{Principal: "operator:gc-probe", Scope: "embedding:chunk", ProfileFingerprint: profile.Fingerprint, DisclosureFingerprint: binding.DisclosureFingerprint, InputClasses: []string{string(binding.InputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"}}
+			_, err := s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint, DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses, RetainedArtifactClasses: consent.RetainedArtifactClasses})
+			require.NoError(t, err)
+			job, err := s.EnqueueEmbeddingJob(t.Context(), EmbeddingJobRequest{ContentVersionID: versionID, Profile: profile, BindingID: binding.Name, Descriptor: record.VectorSpace.Descriptor, InputGeneration: record.InputGeneration, Authorization: consent})
+			require.NoError(t, err)
+			at := time.Now().UTC()
+			claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "gc-worker", at, time.Minute, []string{record.VectorSpace.Descriptor.Fingerprint})
+			require.NoError(t, err)
+			require.True(t, found)
+			if hasSet {
+				require.NoError(t, s.StageEmbeddingSetWithLease(t.Context(), record, claim.AttemptID, claim.Epoch, at))
+			}
+			switch state {
+			case "completed":
+				auth, err := s.AuthorizeProviderOperation(t.Context(), consent)
+				require.NoError(t, err)
+				require.NoError(t, s.PublishEmbeddingWork(t.Context(), claim, work,
+					EmbeddingHeadRecord{Key: EmbeddingHeadKey{versionID, binding.Name, binding.InputKind}, SetID: record.ID, VectorSpaceID: record.VectorSpace.ID, ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime, FencingToken: claim.Epoch},
+					auth, EmbeddingAttemptReceipt{AttemptID: job.ID}, at))
+			case "failed":
+				require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureInputRejected, EmbeddingAttemptReceipt{AttemptID: job.ID}, at))
+			case "abandoned":
+				require.NoError(t, s.AbandonEmbeddingWork(t.Context(), claim, at))
+			case "retry_wait":
+				require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureProviderUnavailable, EmbeddingAttemptReceipt{AttemptID: job.ID}, at))
+			case "queued":
+				require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureAuthorization, EmbeddingAttemptReceipt{AttemptID: job.ID}, at))
+				_, err = s.EnqueueEmbeddingJob(t.Context(), EmbeddingJobRequest{ContentVersionID: versionID, Profile: profile, BindingID: binding.Name, Descriptor: record.VectorSpace.Descriptor, InputGeneration: record.InputGeneration, Authorization: consent})
+				require.NoError(t, err)
+			}
+			if !hasSet {
+				_, err = s.PurgeDerivatives(t.Context(), PurgeRequest{})
+				require.NoError(t, err)
+				var retained int
+				require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_jobs WHERE job_id=?`, job.ID).Scan(&retained))
+				require.Equal(t, 1, retained, "current source must retain its terminal work")
+			}
+			build := catalogRenditionBuild(s, profile)
+			build.ID = testSHA256([]byte("gc-probe-replacement-build"))
+			build.CapturedArtifactPolicy = []byte(`{"roles":[{"max_count":1,"min_count":1,"role":"normalized_evidence"},{"max_count":1,"min_count":0,"role":"provider_markdown"},{"max_count":1,"min_count":1,"role":"sanitized_markdown"}],"version":1}`)
+			build.CapturedArtifactPolicyFingerprint = testSHA256(build.CapturedArtifactPolicy)
+			require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+			buildID := build.ID
+			replacement := RenditionAttachmentRecord{ID: testSHA256([]byte("gc-probe-replacement-attachment")), VaultID: s.VaultID(), ContentVersionID: versionID, BuildID: buildID, Profile: profile, AttachedAt: embeddingCatalogTime}
+			require.NoError(t, publishRenditionForTest(t, s, replacement, embeddingCatalogTime, testSHA256([]byte("gc-probe-replacement-lexical"))))
+			report, err := s.PurgeDerivatives(t.Context(), PurgeRequest{})
+			require.NoError(t, err)
+			if state == "running" || !hasSet {
+				require.Zero(t, report.RemovedEmbeddingSets)
+			} else {
+				require.Equal(t, 1, report.RemovedEmbeddingSets)
+			}
+			var jobs, generations, spaces int
+			require.NoError(t, s.db.QueryRow(`SELECT (SELECT COUNT(*) FROM embedding_jobs WHERE job_id=?),(SELECT COUNT(*) FROM embedding_input_generations WHERE generation_id=?),(SELECT COUNT(*) FROM embedding_vector_spaces WHERE vector_space_id=?)`, job.ID, record.InputGeneration.ID, record.VectorSpace.ID).Scan(&jobs, &generations, &spaces))
+			if state == "queued" || state == "retry_wait" || state == "running" {
+				require.Equal(t, 1, jobs)
+				require.Equal(t, 1, generations)
+				require.Equal(t, 1, spaces)
+			} else {
+				require.Zero(t, jobs)
+				require.Zero(t, generations)
+				require.Zero(t, spaces)
+			}
+		})
+	}
+}
+
+func TestEmbeddingJobsResumeAfterSourceRestoration(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "restore-abandoned")
+	_, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "first-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	var nodeID, revision int64
+	require.NoError(t, s.db.QueryRow(`SELECT id,revision FROM nodes WHERE current_version_id=?`, versionID).Scan(&nodeID, &revision))
+	trashed, _, err := s.Trash(t.Context(), nodeID, revision)
+	require.NoError(t, err)
+	require.ErrorIs(t, s.ValidateEmbeddingWork(t.Context(), claim, work, at), ErrEmbeddingJobFenced)
+	require.NoError(t, s.AbandonEmbeddingWork(t.Context(), claim, at))
+	reconciled, err := s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation, At: time.Now().UTC(), Limit: 100, DescriptorFingerprints: []string{request.Descriptor.Fingerprint}})
+	require.NoError(t, err)
+	require.Zero(t, reconciled.Enqueued, "trashed sources must not reopen jobs")
+	_, _, err = s.Restore(t.Context(), trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	_, err = s.RevokeConsent(t.Context(), ProcessingConsentRevocationRequest{Principal: request.Authorization.Principal, Scope: request.Authorization.Scope})
+	require.NoError(t, err)
+	reconciled, err = s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation, At: time.Now().UTC(), Limit: 100, DescriptorFingerprints: []string{request.Descriptor.Fingerprint}})
+	require.NoError(t, err)
+	require.Zero(t, reconciled.Enqueued, "restoration alone must not replace consent")
+	request = embeddingJobTestRequest(t, s, versionID, profile, "restore-abandoned")
+	reconciled, err = s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation, At: time.Now().UTC(), Limit: 100, DescriptorFingerprints: []string{request.Descriptor.Fingerprint}})
+	require.NoError(t, err)
+	require.Positive(t, reconciled.Enqueued)
+	resumed := false
+	for i := range 10 {
+		next, _, available, err := s.ClaimNextEmbeddingWork(t.Context(), "restored-worker", time.Now().UTC(), time.Minute, []string{request.Descriptor.Fingerprint})
+		require.NoError(t, err)
+		if !available {
+			break
+		}
+		if next.AttemptID == claim.AttemptID {
+			resumed = true
+			require.Greater(t, next.Epoch, claim.Epoch)
+		}
+		require.Less(t, i, 9)
+	}
+	require.True(t, resumed, "restored source with fresh consent must resume its existing job")
+	require.ErrorIs(t, s.ValidateEmbeddingWork(t.Context(), claim, work, time.Now().UTC()), ErrEmbeddingJobFenced)
+}
+
+func TestEmbeddingReconciliationSkipsSuppressedRetainedGeneration(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "suppressed-retained")
+	_, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	require.NoError(t, s.PutCurrentRenditionRoot(t.Context(), CurrentRenditionRoot{
+		ID: "retained-input", Kind: RenditionRootRetention, TargetKind: RenditionRootEmbeddingGeneration,
+		TargetID: request.InputGeneration.ID, FencingToken: 1, RecordedAt: embeddingCatalogTime,
+	}))
+	var siblingVersion string
+	require.NoError(t, s.db.QueryRow(`SELECT version_id FROM content_versions WHERE version_id<>? LIMIT 1`, versionID).Scan(&siblingVersion))
+	sibling := embeddingJobTestRequest(t, s, siblingVersion, profile, "other-source")
+	_, err = s.EnqueueEmbeddingJob(t.Context(), sibling)
+	require.NoError(t, err)
+	_, err = s.PurgeDerivatives(t.Context(), PurgeRequest{ContentVersionIDs: []string{versionID}})
+	require.NoError(t, err)
+	for pass := range 3 {
+		result, err := s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{Mutate: embeddingTestMutation, At: time.Now().UTC(), Limit: 100, DescriptorFingerprints: []string{request.Descriptor.Fingerprint}})
+		require.NoError(t, err)
+		if pass > 0 {
+			require.Zero(t, result.Enqueued, "existing sibling jobs do not need enqueueing again")
+		}
+	}
+	_, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "sibling-worker", time.Now().UTC(), time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, siblingVersion, work.ContentVersionID)
+}
+
+func TestEmbeddingPublicationAndJobCompletionAreAtomic(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, versionID, profile, "atomic-completion")
+	job, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "atomic-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, request.BindingID, "")
+	record.InputGeneration = request.InputGeneration
+	require.NoError(t, s.StageEmbeddingSetWithLease(t.Context(), record, claim.AttemptID, claim.Epoch, at))
+	prior, err := s.AuthorizeProviderOperation(t.Context(), request.Authorization)
+	require.NoError(t, err)
+	head := EmbeddingHeadRecord{Key: EmbeddingHeadKey{versionID, request.BindingID, document.EmbeddingInputOriginalFile}, SetID: record.ID,
+		VectorSpaceID: work.VectorSpaceID, ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: at.Format(timestampLayout), FencingToken: claim.Epoch}
+	receipt := EmbeddingAttemptReceipt{AttemptID: job.ID}
+	_, err = s.db.Exec(`CREATE TEMP TRIGGER reject_embedding_completion BEFORE UPDATE OF state ON embedding_jobs
+  WHEN NEW.state='completed' BEGIN SELECT RAISE(ABORT,'synthetic completion failure'); END`)
+	require.NoError(t, err)
+	require.Error(t, s.PublishEmbeddingWork(t.Context(), claim, work, head, prior, receipt, at))
+	var heads int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM embedding_heads WHERE content_version_id=?`, versionID).Scan(&heads))
+	require.Zero(t, heads, "completion failure must roll back publication")
+	var state string
+	require.NoError(t, s.db.QueryRow(`SELECT state FROM embedding_jobs WHERE job_id=?`, job.ID).Scan(&state))
+	require.Equal(t, "running", state)
+	_, err = s.db.Exec(`DROP TRIGGER reject_embedding_completion`)
+	require.NoError(t, err)
+	require.NoError(t, s.PublishEmbeddingWork(t.Context(), claim, work, head, prior, receipt, at))
+	require.NoError(t, s.db.QueryRow(`SELECT state FROM embedding_jobs WHERE job_id=?`, job.ID).Scan(&state))
+	require.Equal(t, "completed", state)
+	require.Equal(t, record.ID, embeddingHeadSetIDForTest(t, s, versionID, profile.Fingerprint, request.BindingID, document.EmbeddingInputOriginalFile))
+	var active bool
+	require.NoError(t, s.db.QueryRow(`SELECT active FROM current_rendition_roots WHERE root_id=?`, claim.AttemptID).Scan(&active))
+	require.False(t, active)
+}
+
+func embeddingTestMutation(_ context.Context, fn func() error) error { return fn() }
+
+func TestEmbeddingReconciliationSkipsExistingTerminalJob(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	var err error
+	record, err = normalizeEmbeddingSetRecord(record)
+	require.NoError(t, err)
+	binding := workerProfileEmbeddingBinding(t, profile, "chunk")
+	consent := ProviderOperationAuthorizationRequest{
+		Principal: "operator:chunk-reconcile", Scope: "embedding:chunk",
+		ProfileFingerprint: profile.Fingerprint, DisclosureFingerprint: binding.DisclosureFingerprint,
+		InputClasses: []string{string(binding.InputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"},
+	}
+	_, err = s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	_, err = s.EnqueueEmbeddingJob(t.Context(), EmbeddingJobRequest{ContentVersionID: versionID,
+		Profile: profile, BindingID: binding.Name, Descriptor: record.VectorSpace.Descriptor,
+		InputGeneration: record.InputGeneration, Authorization: consent})
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	claim, work, found, err := s.ClaimNextEmbeddingWork(t.Context(), "failed-worker", at, time.Minute, []string{record.VectorSpace.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, s.FailEmbeddingWork(t.Context(), claim, work, EmbeddingFailureInputRejected, EmbeddingAttemptReceipt{AttemptID: claim.AttemptID}, at))
+	for range 2 {
+		mutations := 0
+		result, err := s.ReconcileEmbeddingJobs(t.Context(), EmbeddingReconcileRequest{
+			At: at, Limit: 100, DescriptorFingerprints: []string{record.VectorSpace.Descriptor.Fingerprint},
+			Mutate: func(_ context.Context, fn func() error) error { mutations++; return fn() },
+			HydrateGeneration: func(_ context.Context, g EmbeddingInputGenerationRecord) (EmbeddingInputGenerationRecord, error) {
+				return HydrateEmbeddingInputGeneration(g, record.InputGeneration.GenerationJSON, record.InputGeneration.EvidenceJSON)
+			},
+		})
+		require.NoError(t, err)
+		require.Zero(t, result.Enqueued)
+		require.Zero(t, mutations)
+	}
+}
+
+func TestEmbeddingReconciliationAdvancesPastUnreadableGeneration(t *testing.T) {
+	s, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
+	var err error
+	record, err = normalizeEmbeddingSetRecord(record)
+	require.NoError(t, err)
+	binding := workerProfileEmbeddingBinding(t, profile, "chunk")
+	consent := ProviderOperationAuthorizationRequest{
+		Principal: "operator:chunk-reconcile", Scope: "embedding:chunk",
+		ProfileFingerprint: profile.Fingerprint, DisclosureFingerprint: binding.DisclosureFingerprint,
+		InputClasses: []string{string(binding.InputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"},
+	}
+	_, err = s.GrantConsent(t.Context(), ProcessingConsentGrantRequest{
+		Principal: consent.Principal, Scope: consent.Scope, ProfileFingerprint: consent.ProfileFingerprint,
+		DisclosureFingerprint: consent.DisclosureFingerprint, InputClasses: consent.InputClasses,
+		RetainedArtifactClasses: consent.RetainedArtifactClasses,
+	})
+	require.NoError(t, err)
+	_, err = s.EnqueueEmbeddingJob(t.Context(), EmbeddingJobRequest{ContentVersionID: versionID,
+		Profile: profile, BindingID: binding.Name, Descriptor: record.VectorSpace.Descriptor,
+		InputGeneration: record.InputGeneration, Authorization: consent})
+	require.NoError(t, err)
+	sibling := embeddingJobTestRequest(t, s, versionID, profile, "after-unreadable")
+	sibling.InputGeneration.ID = strings.Repeat("f", 64)
+	_, err = s.EnqueueEmbeddingJob(t.Context(), sibling)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`DELETE FROM embedding_jobs`)
+	require.NoError(t, err)
+	inMutation := false
+	request := EmbeddingReconcileRequest{At: time.Now().UTC(), Limit: 1, DescriptorFingerprints: []string{record.VectorSpace.Descriptor.Fingerprint},
+		Mutate: func(_ context.Context, fn func() error) error {
+			inMutation = true
+			defer func() { inMutation = false }()
+			return fn()
+		},
+		HydrateGeneration: func(_ context.Context, g EmbeddingInputGenerationRecord) (EmbeddingInputGenerationRecord, error) {
+			require.False(t, inMutation, "blob reads must not hold the mutation gate")
+			// An exact-size mismatch is a durable generation error from real validation.
+			return HydrateEmbeddingInputGeneration(g, []byte("synthetic invalid generation"), record.InputGeneration.EvidenceJSON)
+		},
+	}
+	first, err := s.ReconcileEmbeddingJobs(t.Context(), request)
+	require.NoError(t, err)
+	require.Positive(t, first.Skipped)
+	require.NotEmpty(t, first.Next)
+	request.After = first.Next
+	second, err := s.ReconcileEmbeddingJobs(t.Context(), request)
+	require.NoError(t, err)
+	require.Positive(t, second.Enqueued)
+	require.Empty(t, second.Next)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	request.After = ""
+	request.HydrateGeneration = func(context.Context, EmbeddingInputGenerationRecord) (EmbeddingInputGenerationRecord, error) {
+		cancel()
+		return EmbeddingInputGenerationRecord{}, context.Canceled
+	}
+	_, err = s.ReconcileEmbeddingJobs(ctx, request)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestEmbeddingJobExpiredClaimsExhaustBudget(t *testing.T) {
+	s, version, profile, _ := newEmbeddingCatalogFixture(t)
+	request := embeddingJobTestRequest(t, s, version, profile, "expired-budget")
+	job, err := s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	at := time.Now().UTC()
+	var last EmbeddingJobClaim
+	for range 3 {
+		claim, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "crashed-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+		require.NoError(t, err)
+		require.True(t, found)
+		last = claim
+		// A live claim must not be retired, even on its last allowed attempt.
+		_, _, found, err = s.ClaimNextEmbeddingWork(t.Context(), "other-worker", at.Add(time.Second), time.Minute, []string{request.Descriptor.Fingerprint})
+		require.NoError(t, err)
+		require.False(t, found)
+		at = at.Add(time.Minute)
+	}
+	_, _, found, err := s.ClaimNextEmbeddingWork(t.Context(), "fourth-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.False(t, found, "expired running jobs must not get a fourth claim")
+	var state, code string
+	var count int
+	require.NoError(t, s.db.QueryRow(`SELECT state,failure_code,claim_count FROM embedding_jobs WHERE job_id=?`, job.ID).Scan(&state, &code, &count))
+	require.Equal(t, "failed", state)
+	require.Equal(t, string(EmbeddingFailureProviderUnavailable), code)
+	require.Equal(t, 3, count)
+	var active bool
+	require.NoError(t, s.db.QueryRow(`SELECT active FROM current_rendition_roots WHERE root_id=? AND fencing_token=?`, job.ID, last.Epoch).Scan(&active))
+	require.False(t, active)
+	_, err = s.RenewEmbeddingWork(t.Context(), last, at, time.Minute)
+	require.ErrorIs(t, err, ErrEmbeddingJobFenced)
+	_, err = s.EnqueueEmbeddingJob(t.Context(), request)
+	require.NoError(t, err)
+	_, _, found, err = s.ClaimNextEmbeddingWork(t.Context(), "reconciled-worker", at, time.Minute, []string{request.Descriptor.Fingerprint})
+	require.NoError(t, err)
+	require.False(t, found, "enqueue must not reopen exhausted work")
 }

--- a/internal/store/embedding_jobs.go
+++ b/internal/store/embedding_jobs.go
@@ -1,0 +1,570 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"go.kenn.io/docbank/document"
+)
+
+var ErrEmbeddingJobFenced = errors.New("embedding job claim is fenced")
+
+const embeddingJobMaxClaims = 3
+
+type EmbeddingJobRequest struct {
+	ContentVersionID string
+	Profile          ProcessingProfileRecord
+	BindingID        string
+	Descriptor       document.EmbeddingDescriptor
+	InputGeneration  EmbeddingInputGenerationRecord
+	Authorization    ProviderOperationAuthorizationRequest
+}
+
+type EmbeddingJob struct{ ID string }
+
+type EmbeddingJobClaim struct {
+	AttemptID      string
+	Owner          string
+	Epoch          int64
+	LeaseExpiresAt time.Time
+}
+
+type EmbeddingJobWork struct {
+	VaultID                   string
+	ContentVersionID          string
+	ProcessingProfile         ProcessingProfileRecord
+	Binding                   document.EmbeddingBindingV1
+	Descriptor                document.EmbeddingDescriptor
+	VectorSpaceID             string
+	EmbeddingInputFingerprint string
+	InputGeneration           EmbeddingInputGenerationRecord
+	Inputs                    []document.EmbeddingInput
+	Consent                   ProviderOperationAuthorizationRequest
+	SourceBlobHash            string
+	SourceBytes               int64
+	SourceFilename            string
+	SourceMediaType           string
+}
+
+type EmbeddingAttemptReceipt struct {
+	AttemptID           string
+	ProviderFingerprint string
+	ProfileFingerprint  string
+	BindingID           string
+	InputKind           document.EmbeddingInputKind
+	Rows                int
+	Dimensions          int
+	ProviderCalls       int
+	Retries             int
+	Elapsed             time.Duration
+	FailureCode         string
+}
+
+func (s *Store) EnqueueEmbeddingJob(ctx context.Context, request EmbeddingJobRequest) (EmbeddingJob, error) {
+	profile, err := normalizeProcessingProfileRecord(request.Profile)
+	if err != nil {
+		return EmbeddingJob{}, fmt.Errorf("enqueueing embedding job: %w", err)
+	}
+	descriptor, err := document.NewEmbeddingDescriptor(request.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, request.Descriptor) {
+		return EmbeddingJob{}, errors.New("enqueueing embedding job: descriptor is not canonical")
+	}
+	binding, fingerprints, err := embeddingBindingFromProfile(profile, request.BindingID)
+	if err != nil {
+		return EmbeddingJob{}, err
+	}
+	if binding.Descriptor.Fingerprint != descriptor.Fingerprint || binding.Descriptor.ID != descriptor.ID ||
+		request.InputGeneration.SourceVersionID != request.ContentVersionID ||
+		request.InputGeneration.ProcessingProfileFingerprint != profile.Fingerprint {
+		return EmbeddingJob{}, errors.New("enqueueing embedding job: immutable authority does not match binding")
+	}
+	authority, err := normalizeConsentAuthority(request.Authorization)
+	if err != nil || authority.profile != profile.Fingerprint || authority.disclosure != binding.DisclosureFingerprint {
+		return EmbeddingJob{}, errors.New("enqueueing embedding job: consent does not match binding")
+	}
+	space := EmbeddingVectorSpaceRecord{ID: fingerprints.VectorSpace[binding.Name],
+		ContractVersion: EmbeddingVectorSpaceContractV1, Descriptor: descriptor,
+		ProviderDescriptor: descriptor.ID, ProviderRevision: descriptor.ModelRevision,
+		DescriptorFingerprint: descriptor.Fingerprint, CompatibilityID: descriptor.CompatibilityID,
+		Dimensions: descriptor.Dimension, Metric: descriptor.Metric, Normalization: descriptor.Normalization,
+		ScalarEncoding: descriptor.ScalarEncoding, DocumentFormatter: descriptor.DocumentFormatter,
+		QueryFormatter: descriptor.QueryFormatter, ModelInputFingerprint: descriptor.ModelInput.Fingerprint}
+	if binding.InputKind == document.EmbeddingInputRenditionChunk {
+		if len(request.InputGeneration.GenerationJSON) == 0 {
+			return EmbeddingJob{}, errors.New("enqueueing embedding job: exact E2 generation is required")
+		}
+		record := EmbeddingSetRecord{BindingID: binding.Name, InputKind: binding.InputKind,
+			ProcessingProfileFingerprint: profile.Fingerprint,
+			EmbeddingInputFingerprint:    fingerprints.EmbeddingInput[binding.Name],
+			VectorSpace:                  space, InputGeneration: request.InputGeneration}
+		if err := validateEmbeddingBindingAuthority(record, binding, fingerprints); err != nil {
+			return EmbeddingJob{}, fmt.Errorf("enqueueing embedding job: %w", err)
+		}
+	}
+	now := time.Now().UTC().Format(timestampLayout)
+	generationProjection := request.InputGeneration
+	generationProjection.GenerationJSON = nil
+	generationProjection.EvidenceJSON = nil
+	jobID := embeddingJobID(s.vaultID, request.ContentVersionID, profile.Fingerprint,
+		binding.Name, binding.InputKind, request.InputGeneration.ID)
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		suppression, suppressionErr := loadEmbeddingPurgeSuppressionTx(ctx, tx,
+			EmbeddingHeadKey{request.ContentVersionID, binding.Name, binding.InputKind}, profile.Fingerprint)
+		if suppressionErr != nil && !errors.Is(suppressionErr, ErrNotFound) {
+			return suppressionErr
+		}
+		if suppressionErr == nil && suppression.active {
+			return ErrEmbeddingJobFenced
+		}
+		if err := ensureProcessingProfileTx(ctx, tx, profile); err != nil {
+			return err
+		}
+		if err := validateEmbeddingInputGeneration(request.InputGeneration); err != nil {
+			return err
+		}
+		if err := insertVectorSpaceTx(ctx, tx, space); err != nil {
+			return err
+		}
+		if err := validateEmbeddingJobGenerationTx(ctx, tx, binding, request.InputGeneration); err != nil {
+			return err
+		}
+		if err := insertInputGenerationTx(ctx, tx, generationProjection); err != nil {
+			return err
+		}
+		if _, err := authorizeProviderOperationTx(ctx, tx, s.vaultID, request.Authorization, time.Now().UTC()); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO embedding_jobs(
+			job_id,vault_uid,content_version_id,profile_fingerprint,binding_id,input_kind,
+			generation_id,vector_space_id,principal,scope,state,available_at,created_at,updated_at
+		) VALUES(?,?,?,?,?,?,?,?,?,?,'queued',?,?,?) ON CONFLICT(job_id) DO NOTHING`,
+			jobID, s.vaultID, request.ContentVersionID, profile.Fingerprint, binding.Name,
+			binding.InputKind, request.InputGeneration.ID, space.ID, authority.principal,
+			authority.scope, now, now, now)
+		if err != nil {
+			return err
+		}
+		// Abandonment fences an attempt, not the retained intent. Reopen only
+		// after rechecking current source authority in this transaction; consent
+		// and the exact generation were validated above. Keep claim epochs and
+		// retry counts so old workers stay fenced and retry budgets stay bounded.
+		if _, err := tx.ExecContext(ctx, `UPDATE embedding_jobs SET state='queued',
+			principal=?,scope=?,failure_code=NULL,updated_at=? WHERE job_id=? AND state='abandoned'
+			AND EXISTS(SELECT 1 FROM content_versions v JOIN nodes n ON n.id=v.node_id
+			  AND n.current_version_id=v.version_id AND n.trashed_at IS NULL WHERE v.version_id=?)`,
+			authority.principal, authority.scope, now, jobID, request.ContentVersionID); err != nil {
+			return err
+		}
+		// Consent was checked above. Rebind idle work without resetting provider
+		// retry counts or delays. Only an authorization failure becomes runnable
+		// again; running claims keep their original authority until they finish.
+		if _, err := tx.ExecContext(ctx, `UPDATE embedding_jobs SET principal=?,scope=?,
+			state=CASE WHEN state='failed' AND failure_code=? THEN 'queued' ELSE state END,
+			failure_code=CASE WHEN state='failed' AND failure_code=? THEN NULL ELSE failure_code END,
+			updated_at=? WHERE job_id=? AND state IN ('queued','retry_wait','failed')
+			AND (principal<>? OR scope<>? OR (state='failed' AND failure_code=?))`,
+			authority.principal, authority.scope, EmbeddingFailureAuthorization, EmbeddingFailureAuthorization,
+			now, jobID, authority.principal, authority.scope, EmbeddingFailureAuthorization); err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE embedding_jobs SET claim_epoch=max(claim_epoch,
+			COALESCE((SELECT MAX(fencing_token) FROM current_rendition_roots WHERE root_id=?),0))
+			WHERE job_id=?`, jobID, jobID)
+		return err
+	})
+	return EmbeddingJob{ID: jobID}, err
+}
+
+func (s *Store) ClaimNextEmbeddingWork(ctx context.Context, owner string, at time.Time, lease time.Duration, fingerprints []string) (EmbeddingJobClaim, EmbeddingJobWork, bool, error) {
+	if !validRenditionWorkerOwner(owner) || at.IsZero() || lease <= 0 || len(fingerprints) == 0 {
+		return EmbeddingJobClaim{}, EmbeddingJobWork{}, false, errors.New("embedding claim is invalid")
+	}
+	var claim EmbeddingJobClaim
+	var work EmbeddingJobWork
+	found := false
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		var jobID string
+		args := make([]any, 0, len(fingerprints)+3)
+		for _, fingerprint := range fingerprints {
+			args = append(args, fingerprint)
+		}
+		args = append(args, at.UTC().Format(timestampLayout), at.UTC().Format(timestampLayout), at.UTC().Format(timestampLayout))
+		for {
+			var state string
+			var count int
+			var expiredEpoch int64
+			err := tx.QueryRowContext(ctx, `SELECT j.job_id,j.state,j.claim_count,j.claim_epoch FROM embedding_jobs j
+			JOIN embedding_vector_spaces vs ON vs.vector_space_id=j.vector_space_id
+			WHERE vs.descriptor_fingerprint IN (`+placeholders(len(fingerprints))+`)
+			AND j.state IN ('queued','retry_wait','running') AND j.available_at<=?
+			AND (j.state<>'running' OR j.lease_expires_at<=?)
+			  AND NOT EXISTS(SELECT 1 FROM embedding_heads h
+			    JOIN embedding_sets s ON s.embedding_set_id=h.embedding_set_id
+			    WHERE h.content_version_id=j.content_version_id AND h.binding_id=j.binding_id
+			      AND h.input_kind=j.input_kind AND s.profile_fingerprint=j.profile_fingerprint
+			      AND s.input_generation_id=j.generation_id AND s.vector_space_id=j.vector_space_id)
+			  AND NOT EXISTS(SELECT 1 FROM current_rendition_roots r WHERE r.root_id=j.job_id
+			    AND r.active=1 AND r.expires_at>?)
+			ORDER BY j.available_at,j.job_id LIMIT 1`, args...).Scan(&jobID, &state, &count, &expiredEpoch)
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if state != "running" || count < embeddingJobMaxClaims {
+				break
+			}
+			// No live attempt remains to report a result. Retire only the
+			// disposable job; an expired lease cannot publish catalog failure
+			// authority or fabricate a receipt for an interrupted provider call.
+			if _, err := tx.ExecContext(ctx, `UPDATE embedding_jobs
+				SET state='failed',failure_code=?,claim_owner=NULL,lease_expires_at=NULL,updated_at=?
+				WHERE job_id=? AND state='running' AND claim_epoch=?`,
+				EmbeddingFailureProviderUnavailable, at.UTC().Format(timestampLayout), jobID, expiredEpoch); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `UPDATE current_rendition_roots SET active=0,released_at=?
+				WHERE root_id=? AND fencing_token=? AND active=1`, at.UTC().Format(timestampLayout), jobID, expiredEpoch); err != nil {
+				return err
+			}
+		}
+
+		var epoch int64
+		if err := tx.QueryRowContext(ctx, `SELECT 1+max(j.claim_epoch,
+            COALESCE((SELECT max(claim_epoch) FROM embedding_jobs WHERE content_version_id=j.content_version_id AND profile_fingerprint=j.profile_fingerprint AND binding_id=j.binding_id AND input_kind=j.input_kind),0),
+            COALESCE((SELECT fencing_token FROM embedding_heads WHERE content_version_id=j.content_version_id AND profile_fingerprint=j.profile_fingerprint AND binding_id=j.binding_id AND input_kind=j.input_kind),0),
+            COALESCE((SELECT fencing_token FROM embedding_failures WHERE content_version_id=j.content_version_id AND profile_fingerprint=j.profile_fingerprint AND binding_id=j.binding_id AND input_kind=j.input_kind),0))
+            FROM embedding_jobs j WHERE job_id=?`, jobID).Scan(&epoch); err != nil {
+			return err
+		}
+		expires := at.UTC().Add(lease)
+		if _, err := tx.ExecContext(ctx, `UPDATE embedding_jobs SET state='running',claim_count=claim_count+1,claim_owner=?,claim_epoch=?,lease_expires_at=?,updated_at=? WHERE job_id=?`,
+			owner, epoch, expires.Format(timestampLayout), at.UTC().Format(timestampLayout), jobID); err != nil {
+			return err
+		}
+		var err error
+		work, err = loadEmbeddingJobWorkTx(ctx, tx, s.vaultID, jobID)
+		if err != nil {
+			return err
+		}
+		root := CurrentRenditionRoot{ID: jobID, Kind: RenditionRootWorkerLease,
+			TargetKind: RenditionRootEmbeddingGeneration, TargetID: work.InputGeneration.ID,
+			FencingToken: epoch, RecordedAt: at.UTC().Format(timestampLayout), ExpiresAt: expires.Format(timestampLayout)}
+		if err := putCurrentRenditionRootTx(ctx, tx, root); err != nil {
+			return err
+		}
+		claim = EmbeddingJobClaim{AttemptID: jobID, Owner: owner, Epoch: epoch, LeaseExpiresAt: expires}
+		found = true
+		return nil
+	})
+	return claim, work, found, err
+}
+
+func (s *Store) RenewEmbeddingWork(ctx context.Context, claim EmbeddingJobClaim, at time.Time, lease time.Duration) (EmbeddingJobClaim, error) {
+	expires := at.UTC().Add(lease)
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		result, err := tx.ExecContext(ctx, `UPDATE embedding_jobs SET lease_expires_at=?,updated_at=?
+			WHERE job_id=? AND state='running' AND claim_owner=? AND claim_epoch=? AND lease_expires_at>?`, expires.Format(timestampLayout),
+			at.UTC().Format(timestampLayout), claim.AttemptID, claim.Owner, claim.Epoch, at.UTC().Format(timestampLayout))
+		if err != nil {
+			return err
+		}
+		count, _ := result.RowsAffected()
+		if count != 1 {
+			return ErrEmbeddingJobFenced
+		}
+		result, err = tx.ExecContext(ctx, `UPDATE current_rendition_roots SET expires_at=?,recorded_at=?
+			WHERE root_id=? AND root_kind=? AND fencing_token=? AND active=1 AND expires_at>?`, expires.Format(timestampLayout),
+			at.UTC().Format(timestampLayout), claim.AttemptID, RenditionRootWorkerLease, claim.Epoch,
+			at.UTC().Format(timestampLayout))
+		if err != nil {
+			return err
+		}
+		count, _ = result.RowsAffected()
+		if count != 1 {
+			return ErrEmbeddingJobFenced
+		}
+		return nil
+	})
+	claim.LeaseExpiresAt = expires
+	return claim, err
+}
+
+func (s *Store) ValidateEmbeddingWork(ctx context.Context, claim EmbeddingJobClaim, work EmbeddingJobWork, at time.Time) error {
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		return validateEmbeddingWorkTx(ctx, tx, s.vaultID, claim, work, at)
+	})
+}
+
+func validateEmbeddingWorkTx(ctx context.Context, tx *sql.Tx, vaultID string, claim EmbeddingJobClaim, work EmbeddingJobWork, at time.Time) error {
+	if err := requireEmbeddingWorkerLeaseTx(ctx, tx, claim.AttemptID, claim.Epoch, work.InputGeneration.ID, at); err != nil {
+		if errors.Is(err, ErrCurrentRenditionRootFenced) {
+			return ErrEmbeddingJobFenced
+		}
+		return err
+	}
+	current, err := loadEmbeddingJobWorkTx(ctx, tx, vaultID, claim.AttemptID)
+	if errors.Is(err, sql.ErrNoRows) || errors.Is(err, ErrNotFound) {
+		return ErrEmbeddingJobFenced
+	}
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(current, work) {
+		return ErrEmbeddingJobFenced
+	}
+	var eligible bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM content_versions v
+		JOIN nodes n ON n.id=v.node_id AND n.current_version_id=v.version_id AND n.trashed_at IS NULL
+		WHERE v.version_id=?)`, work.ContentVersionID).Scan(&eligible); err != nil {
+		return err
+	}
+	if !eligible {
+		return ErrEmbeddingJobFenced
+	}
+	eligible, err = embeddingGenerationCurrentTx(ctx, tx, work.InputGeneration, work.ProcessingProfile.Fingerprint)
+	if err != nil {
+		return err
+	}
+	if !eligible {
+		return ErrEmbeddingJobFenced
+	}
+	return nil
+}
+
+// BeginEmbeddingProviderEgress rechecks the claim and consent under the shared
+// provider fence. The caller must close the fence when Embed returns.
+func (s *Store) BeginEmbeddingProviderEgress(ctx context.Context, claim EmbeddingJobClaim, work EmbeddingJobWork, prior *ProviderOperationAuthorization, at time.Time) (ProviderOperationAuthorization, *ProviderEgressFence, error) {
+	s.providerEgressMu.RLock()
+	fence := &ProviderEgressFence{release: s.providerEgressMu.RUnlock}
+	var auth ProviderOperationAuthorization
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if err := validateEmbeddingWorkTx(ctx, tx, s.vaultID, claim, work, at); err != nil {
+			return err
+		}
+		request := work.Consent
+		request.PriorAuthorization = prior
+		var err error
+		auth, err = authorizeProviderOperationTx(ctx, tx, s.vaultID, request, time.Now().UTC())
+		return err
+	})
+	if err != nil {
+		fence.Close()
+		return ProviderOperationAuthorization{}, nil, err
+	}
+	return auth, fence, nil
+}
+
+// AbandonEmbeddingWork retires disposable work without publishing a failure
+// against authority that no longer belongs to this claim. A successor claim
+// (or an expired or already completed job) is never changed.
+func (s *Store) AbandonEmbeddingWork(ctx context.Context, claim EmbeddingJobClaim, at time.Time) error {
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		result, err := tx.ExecContext(ctx, `UPDATE embedding_jobs
+			SET state='abandoned',claim_owner=NULL,lease_expires_at=NULL,updated_at=?
+			WHERE job_id=? AND state='running' AND claim_owner=? AND claim_epoch=? AND lease_expires_at>?`,
+			at.UTC().Format(timestampLayout), claim.AttemptID, claim.Owner, claim.Epoch, at.UTC().Format(timestampLayout))
+		if err != nil {
+			return err
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed == 0 {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE current_rendition_roots SET active=0,released_at=?
+			WHERE root_id=? AND fencing_token=? AND active=1`, at.UTC().Format(timestampLayout), claim.AttemptID, claim.Epoch)
+		return err
+	})
+}
+
+func (s *Store) FailEmbeddingWork(ctx context.Context, claim EmbeddingJobClaim, work EmbeddingJobWork, code EmbeddingFailureCode, receipt EmbeddingAttemptReceipt, at time.Time) error {
+	state, available := "failed", at.UTC()
+	var claims int
+	if err := s.db.QueryRowContext(ctx, `SELECT claim_count FROM embedding_jobs WHERE job_id=?`, claim.AttemptID).Scan(&claims); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrEmbeddingJobFenced
+		}
+		return err
+	}
+	if code == EmbeddingFailureProviderUnavailable && claims < embeddingJobMaxClaims {
+		state, available = "retry_wait", at.UTC().Add(time.Minute)
+	}
+	return s.finishEmbeddingWork(ctx, claim, work, state, code, receipt, at, available)
+}
+
+// PublishEmbeddingWork publishes the exact claimed set and completes its job in
+// one transaction. Neither the visible head nor completed state can stand alone.
+func (s *Store) PublishEmbeddingWork(ctx context.Context, claim EmbeddingJobClaim, work EmbeddingJobWork,
+	head EmbeddingHeadRecord, prior ProviderOperationAuthorization, receipt EmbeddingAttemptReceipt, at time.Time,
+) error {
+	if err := validateEmbeddingHeadRecord(head); err != nil {
+		return err
+	}
+	if head.Key != (EmbeddingHeadKey{work.ContentVersionID, work.Binding.Name, work.Binding.InputKind}) ||
+		head.ProcessingProfileFingerprint != work.ProcessingProfile.Fingerprint || head.VectorSpaceID != work.VectorSpaceID ||
+		head.FencingToken != claim.Epoch {
+		return ErrEmbeddingJobFenced
+	}
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if err := validateEmbeddingWorkTx(ctx, tx, s.vaultID, claim, work, at); err != nil {
+			return err
+		}
+		if _, err := publishEmbeddingHeadWithLeaseTx(ctx, tx, s.vaultID, head, work.Consent, prior, claim.AttemptID, claim.Epoch, at); err != nil {
+			return err
+		}
+		return finishEmbeddingWorkTx(ctx, tx, s.vaultID, claim, work, "completed", "", receipt, at, at)
+	})
+}
+
+func (s *Store) finishEmbeddingWork(ctx context.Context, claim EmbeddingJobClaim, work EmbeddingJobWork, state string,
+	code EmbeddingFailureCode, receipt EmbeddingAttemptReceipt, at, available time.Time,
+) error {
+	return s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		return finishEmbeddingWorkTx(ctx, tx, s.vaultID, claim, work, state, code, receipt, at, available)
+	})
+}
+
+func finishEmbeddingWorkTx(ctx context.Context, tx *sql.Tx, vaultID string, claim EmbeddingJobClaim, work EmbeddingJobWork, state string,
+	code EmbeddingFailureCode, receipt EmbeddingAttemptReceipt, at, available time.Time,
+) error {
+	encoded, err := json.Marshal(struct {
+		AttemptID, ProviderFingerprint, ProfileFingerprint, BindingID, InputKind, FailureCode string
+		Rows, Dimensions, ProviderCalls, Retries                                              int
+		ElapsedNanoseconds                                                                    int64
+	}{receipt.AttemptID, receipt.ProviderFingerprint, receipt.ProfileFingerprint, receipt.BindingID,
+		string(receipt.InputKind), receipt.FailureCode, receipt.Rows, receipt.Dimensions,
+		receipt.ProviderCalls, receipt.Retries, receipt.Elapsed.Nanoseconds()})
+	if err != nil {
+		return err
+	}
+	if code != "" {
+		if err := validateEmbeddingWorkTx(ctx, tx, vaultID, claim, work, at); err != nil {
+			return err
+		}
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE embedding_jobs SET state=?,claim_owner=NULL,lease_expires_at=NULL,
+			available_at=?,failure_code=NULLIF(?,''),receipt_json=?,updated_at=?
+			WHERE job_id=? AND state='running' AND claim_owner=? AND claim_epoch=? AND lease_expires_at>?`, state,
+		available.UTC().Format(timestampLayout), code, string(encoded), at.UTC().Format(timestampLayout),
+		claim.AttemptID, claim.Owner, claim.Epoch, at.UTC().Format(timestampLayout))
+	if err != nil {
+		return err
+	}
+	count, _ := result.RowsAffected()
+	if count != 1 {
+		return ErrEmbeddingJobFenced
+	}
+	if code != "" {
+		failure := EmbeddingFailureRecord{ContentVersionID: work.ContentVersionID,
+			ProcessingProfileFingerprint: work.ProcessingProfile.Fingerprint, BindingID: work.Binding.Name,
+			InputKind: work.Binding.InputKind, FailureCode: code, FailedAt: at.UTC().Format(timestampLayout),
+			FencingToken: claim.Epoch, AttachmentID: work.InputGeneration.AttachmentID}
+		if err := validateEmbeddingFailureRecord(failure); err != nil {
+			return err
+		}
+		if err := recordEmbeddingFailureTx(ctx, tx, failure); err != nil {
+			return err
+		}
+	}
+	_, err = tx.ExecContext(ctx, `UPDATE current_rendition_roots SET active=0,released_at=?
+			WHERE root_id=? AND fencing_token=? AND active=1`, at.UTC().Format(timestampLayout), claim.AttemptID, claim.Epoch)
+	return err
+}
+
+func loadEmbeddingJobWorkTx(ctx context.Context, tx *sql.Tx, vaultID, jobID string) (EmbeddingJobWork, error) {
+	var versionID, profileID, bindingID, generationID, spaceID, principal, scope string
+	err := tx.QueryRowContext(ctx, `SELECT content_version_id,profile_fingerprint,binding_id,generation_id,vector_space_id,principal,scope
+		FROM embedding_jobs WHERE job_id=?`, jobID).Scan(&versionID, &profileID, &bindingID, &generationID, &spaceID, &principal, &scope)
+	if err != nil {
+		return EmbeddingJobWork{}, err
+	}
+	profile, err := loadProcessingProfile(ctx, tx, profileID)
+	if err != nil {
+		return EmbeddingJobWork{}, err
+	}
+	binding, fingerprints, err := embeddingBindingFromProfile(profile, bindingID)
+	if err != nil {
+		return EmbeddingJobWork{}, err
+	}
+	generation, err := loadInputGenerationTx(ctx, tx, generationID)
+	if err != nil {
+		return EmbeddingJobWork{}, err
+	}
+	space, err := loadVectorSpaceTx(ctx, tx, spaceID)
+	if err != nil {
+		return EmbeddingJobWork{}, err
+	}
+	var sourceHash, filename, mediaType string
+	var sourceBytes int64
+	if err := tx.QueryRowContext(ctx, `SELECT v.blob_hash,v.size,n.name,COALESCE(v.mime_type,'')
+		FROM content_versions v JOIN nodes n ON n.id=v.node_id WHERE v.version_id=?`, versionID).
+		Scan(&sourceHash, &sourceBytes, &filename, &mediaType); err != nil {
+		return EmbeddingJobWork{}, err
+	}
+	return EmbeddingJobWork{VaultID: vaultID, ContentVersionID: versionID, ProcessingProfile: profile,
+		Binding: binding, Descriptor: space.Descriptor, VectorSpaceID: spaceID,
+		EmbeddingInputFingerprint: fingerprints.EmbeddingInput[binding.Name], InputGeneration: generation,
+		SourceBlobHash: sourceHash, SourceBytes: sourceBytes, SourceFilename: filename, SourceMediaType: mediaType,
+		Consent: ProviderOperationAuthorizationRequest{Principal: principal, Scope: scope,
+			ProfileFingerprint: profileID, DisclosureFingerprint: binding.DisclosureFingerprint,
+			InputClasses: []string{string(binding.InputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"}}}, nil
+}
+
+func embeddingBindingFromProfile(profile ProcessingProfileRecord, name string) (document.EmbeddingBindingV1, document.FingerprintSet, error) {
+	var value document.ProcessingProfileV1
+	if err := json.Unmarshal(profile.CanonicalProfile, &value); err != nil {
+		return document.EmbeddingBindingV1{}, document.FingerprintSet{}, err
+	}
+	_, fingerprints, err := document.CanonicalProfile(value)
+	if err != nil {
+		return document.EmbeddingBindingV1{}, document.FingerprintSet{}, err
+	}
+	for _, binding := range value.Embeddings {
+		if binding.Name == name {
+			return binding, fingerprints, nil
+		}
+	}
+	return document.EmbeddingBindingV1{}, document.FingerprintSet{}, ErrNotFound
+}
+
+func validateEmbeddingJobGenerationTx(ctx context.Context, tx *sql.Tx, binding document.EmbeddingBindingV1, generation EmbeddingInputGenerationRecord) error {
+	var sourceHash string
+	if err := tx.QueryRowContext(ctx, `SELECT blob_hash FROM content_versions WHERE version_id=?`, generation.SourceVersionID).Scan(&sourceHash); err != nil {
+		return err
+	}
+	if binding.InputKind == document.EmbeddingInputOriginalFile {
+		if generation.GenerationChecksum != sourceHash || len(generation.Inputs) != 1 ||
+			generation.Inputs[0] != (EmbeddingInputReference{ID: generation.SourceVersionID, RenderedChecksum: sourceHash}) {
+			return errors.New("direct embedding generation does not name exact source")
+		}
+		return nil
+	}
+	if generation.AttachmentID == "" || generation.GenerationBlobHash == "" {
+		return errors.New("chunk embedding generation is not materialized")
+	}
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM rendition_attachments a
+		JOIN rendition_heads h ON h.content_version_id=a.content_version_id
+		 AND h.profile_fingerprint=a.profile_fingerprint AND h.attachment_id=a.attachment_id
+		WHERE a.attachment_id=? AND a.content_version_id=? AND a.profile_fingerprint=?`,
+		generation.AttachmentID, generation.SourceVersionID, generation.ProcessingProfileFingerprint).Scan(&count); err != nil || count != 1 {
+		return errors.New("chunk embedding generation attachment is stale")
+	}
+	return nil
+}
+
+func embeddingJobID(values ...any) string {
+	hash := sha256.New()
+	for _, value := range values {
+		_, _ = fmt.Fprint(hash, value, "\x00")
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/internal/store/embedding_lifecycle.go
+++ b/internal/store/embedding_lifecycle.go
@@ -20,8 +20,22 @@ func collectOrphanEmbeddingArtifactsTx(
 	ctx context.Context, tx *sql.Tx, asOf string,
 ) (_ embeddingOrphanCollection, retErr error) {
 	var result embeddingOrphanCollection
+	// Failed attempts may never stage a set. Once their source authority is
+	// superseded, their terminal rows must not keep orphan inputs alive.
+	// A current but trashed version remains restorable, so trash alone is
+	// deliberately not a reason to discard its work.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_jobs AS j
+		WHERE j.state IN ('completed','failed','abandoned')
+		AND EXISTS (SELECT 1 FROM embedding_input_generations g WHERE g.generation_id=j.generation_id
+		    AND NOT EXISTS (SELECT 1 FROM embedding_sets s WHERE s.input_generation_id=g.generation_id)
+		    AND NOT EXISTS (SELECT 1 FROM content_versions v JOIN nodes n ON n.current_version_id=v.version_id
+		        WHERE v.version_id=g.source_version_id AND (g.attachment_id IS NULL OR EXISTS (
+		            SELECT 1 FROM rendition_heads h WHERE h.content_version_id=g.source_version_id
+		            AND h.profile_fingerprint=g.profile_fingerprint AND h.attachment_id=g.attachment_id))))`); err != nil {
+		return result, fmt.Errorf("collecting superseded terminal embedding jobs: %w", err)
+	}
 	generationRows, err := tx.QueryContext(ctx, `DELETE FROM embedding_input_generations AS g
-		WHERE NOT EXISTS (
+		WHERE NOT EXISTS (SELECT 1 FROM embedding_jobs j WHERE j.generation_id=g.generation_id) AND NOT EXISTS (
 			SELECT 1 FROM embedding_sets s WHERE s.input_generation_id=g.generation_id
 		) AND NOT EXISTS (
 			SELECT 1 FROM current_rendition_roots r
@@ -79,7 +93,8 @@ func collectOrphanEmbeddingArtifactsTx(
 	}
 
 	if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_vector_spaces AS v
-		WHERE NOT EXISTS (SELECT 1 FROM embedding_sets s WHERE s.vector_space_id=v.vector_space_id)
+		WHERE NOT EXISTS (SELECT 1 FROM embedding_jobs j WHERE j.vector_space_id=v.vector_space_id)
+		  AND NOT EXISTS (SELECT 1 FROM embedding_sets s WHERE s.vector_space_id=v.vector_space_id)
 		  AND NOT EXISTS (SELECT 1 FROM embedding_vector_sets s WHERE s.vector_space_id=v.vector_space_id)`); err != nil {
 		return result, fmt.Errorf("collecting orphan embedding vector spaces: %w", err)
 	}

--- a/internal/store/embedding_reconcile.go
+++ b/internal/store/embedding_reconcile.go
@@ -1,0 +1,263 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/docbank/document"
+)
+
+// EmbeddingReconcileRequest bounds one durable discovery page. Descriptor
+// fingerprints are process-local executable authority, never catalog intent.
+type EmbeddingReconcileRequest struct {
+	After                  string
+	Limit                  int
+	At                     time.Time
+	DescriptorFingerprints []string
+	HydrateGeneration      func(context.Context, EmbeddingInputGenerationRecord) (EmbeddingInputGenerationRecord, error)
+	// Mutate guards only enqueue mutations; discovery and blob reads run outside it.
+	Mutate func(context.Context, func() error) error
+}
+
+// EmbeddingReconcileResult reports work materialized from existing portable
+// authority. Next is empty when the scan reached the end.
+type EmbeddingReconcileResult struct {
+	Next     string
+	Examined int
+	Enqueued int
+	Skipped  int
+}
+
+type embeddingReconcileCandidate struct {
+	request      EmbeddingJobRequest
+	binding      document.EmbeddingBindingV1
+	fingerprints document.FingerprintSet
+	space        EmbeddingVectorSpaceRecord
+}
+
+// ReconcileEmbeddingJobs discovers only already-materialized E1/E2 or direct
+// generations for current versions. It never creates input authority, grants
+// consent, or contacts a provider.
+func (s *Store) ReconcileEmbeddingJobs(ctx context.Context, request EmbeddingReconcileRequest) (EmbeddingReconcileResult, error) {
+	if request.Limit < 1 || request.Limit > 1000 || request.At.IsZero() || len(request.DescriptorFingerprints) == 0 || request.Mutate == nil {
+		return EmbeddingReconcileResult{}, errors.New("embedding reconciliation request is invalid")
+	}
+	executable := make(map[string]struct{}, len(request.DescriptorFingerprints))
+	for _, fingerprint := range request.DescriptorFingerprints {
+		if err := validateCatalogSHA256(fingerprint, "embedding runtime descriptor fingerprint"); err != nil {
+			return EmbeddingReconcileResult{}, err
+		}
+		executable[fingerprint] = struct{}{}
+	}
+	var generationIDs []string
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		generationIDs, err = stringColumnTx(ctx, tx, "embedding reconciliation generations", `
+			SELECT g.generation_id FROM embedding_input_generations g
+			JOIN content_versions v ON v.version_id=g.source_version_id
+			JOIN nodes n ON n.id=v.node_id AND n.current_version_id=v.version_id AND n.trashed_at IS NULL
+			WHERE g.generation_id>? ORDER BY g.generation_id LIMIT ?`, request.After, request.Limit+1)
+		return err
+	})
+	if err != nil {
+		return EmbeddingReconcileResult{}, err
+	}
+	result := EmbeddingReconcileResult{}
+	more := len(generationIDs) > request.Limit
+	if more {
+		generationIDs = generationIDs[:request.Limit]
+	}
+	var candidates []embeddingReconcileCandidate
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		for _, generationID := range generationIDs {
+			generation, err := loadInputGenerationTx(ctx, tx, generationID)
+			if err != nil {
+				return err
+			}
+			profile, err := loadProcessingProfile(ctx, tx, generation.ProcessingProfileFingerprint)
+			if err != nil {
+				return err
+			}
+			var portable document.ProcessingProfileV1
+			if err := json.Unmarshal(profile.CanonicalProfile, &portable); err != nil {
+				return err
+			}
+			_, fingerprints, err := document.CanonicalProfile(portable)
+			if err != nil {
+				return err
+			}
+			for _, binding := range portable.Embeddings {
+				if (binding.InputKind == document.EmbeddingInputRenditionChunk) != (generation.GenerationBlobHash != "") {
+					continue
+				}
+				space, err := loadVectorSpaceTx(ctx, tx, fingerprints.VectorSpace[binding.Name])
+				if errors.Is(err, ErrNotFound) {
+					continue
+				}
+				if err != nil {
+					return err
+				}
+				if _, ok := executable[space.Descriptor.Fingerprint]; !ok ||
+					space.Descriptor.Fingerprint != binding.Descriptor.Fingerprint {
+					continue
+				}
+				eligible, err := embeddingGenerationCurrentTx(ctx, tx, generation, profile.Fingerprint)
+				if err != nil {
+					return err
+				}
+				if !eligible {
+					continue
+				}
+				satisfied, err := exactEmbeddingHeadExistsTx(ctx, tx, generation.SourceVersionID,
+					profile.Fingerprint, binding, generation.ID, space.ID)
+				if err != nil {
+					return err
+				}
+				if satisfied {
+					continue
+				}
+				suppression, err := loadEmbeddingPurgeSuppressionTx(ctx, tx,
+					EmbeddingHeadKey{generation.SourceVersionID, binding.Name, binding.InputKind}, profile.Fingerprint)
+				if err != nil && !errors.Is(err, ErrNotFound) {
+					return err
+				}
+				if err == nil && suppression.active {
+					continue
+				}
+				consent, found, err := embeddingReconcileConsentTx(ctx, tx, s.vaultID, profile.Fingerprint,
+					binding.DisclosureFingerprint, binding.InputKind, request.At.UTC())
+				if err != nil {
+					return err
+				}
+				if !found {
+					continue
+				}
+				var state, failure, principal, scope string
+				err = tx.QueryRowContext(ctx, `SELECT state,COALESCE(failure_code,''),principal,scope
+					FROM embedding_jobs WHERE job_id=?`, embeddingJobID(s.vaultID, generation.SourceVersionID,
+					profile.Fingerprint, binding.Name, binding.InputKind, generation.ID)).Scan(&state, &failure, &principal, &scope)
+				if err != nil && !errors.Is(err, sql.ErrNoRows) {
+					return err
+				}
+				if err == nil {
+					reauthorize := state == "failed" && failure == string(EmbeddingFailureAuthorization)
+					rebind := (state == "queued" || state == "retry_wait") && (principal != consent.Principal || scope != consent.Scope)
+					if state != "abandoned" && !reauthorize && !rebind {
+						continue
+					}
+				}
+				candidates = append(candidates, embeddingReconcileCandidate{request: EmbeddingJobRequest{
+					ContentVersionID: generation.SourceVersionID, Profile: profile, BindingID: binding.Name,
+					Descriptor: space.Descriptor, InputGeneration: generation, Authorization: consent,
+				}, binding: binding, fingerprints: fingerprints, space: space})
+			}
+			result.Examined++
+		}
+		return nil
+	})
+	if err != nil {
+		return EmbeddingReconcileResult{}, err
+	}
+	for _, candidate := range candidates {
+		if candidate.binding.InputKind == document.EmbeddingInputRenditionChunk {
+			if request.HydrateGeneration == nil {
+				return EmbeddingReconcileResult{}, errors.New("embedding reconciliation requires exact E2 hydration")
+			}
+			hydrated, err := request.HydrateGeneration(ctx, candidate.request.InputGeneration)
+			if err != nil {
+				if ctx.Err() != nil {
+					return EmbeddingReconcileResult{}, ctx.Err()
+				}
+				// A damaged or temporarily unreadable candidate must not block
+				// later generations. Revisit it on a subsequent discovery pass.
+				result.Skipped++
+				continue
+			}
+			candidate.request.InputGeneration = hydrated
+			record := EmbeddingSetRecord{BindingID: candidate.binding.Name, InputKind: candidate.binding.InputKind,
+				ProcessingProfileFingerprint: candidate.request.Profile.Fingerprint,
+				EmbeddingInputFingerprint:    candidate.fingerprints.EmbeddingInput[candidate.binding.Name],
+				VectorSpace:                  candidate.space, InputGeneration: hydrated}
+			if err := validateEmbeddingBindingAuthority(record, candidate.binding, candidate.fingerprints); err != nil {
+				continue
+			}
+		}
+		if err := request.Mutate(ctx, func() error {
+			_, err := s.EnqueueEmbeddingJob(ctx, candidate.request)
+			return err
+		}); err != nil {
+			// Purge can win after the discovery transaction or during hydration.
+			if errors.Is(err, ErrEmbeddingJobFenced) {
+				continue
+			}
+			return EmbeddingReconcileResult{}, fmt.Errorf("reconciling embedding job: %w", err)
+		}
+		result.Enqueued++
+	}
+	if more && len(generationIDs) != 0 {
+		result.Next = generationIDs[len(generationIDs)-1]
+	}
+	return result, nil
+}
+
+func embeddingGenerationCurrentTx(ctx context.Context, tx *sql.Tx, generation EmbeddingInputGenerationRecord, profile string) (bool, error) {
+	if generation.GenerationBlobHash == "" {
+		return generation.AttachmentID == "", nil
+	}
+	var current string
+	err := tx.QueryRowContext(ctx, `SELECT h.attachment_id FROM rendition_heads h
+		WHERE h.content_version_id=? AND h.profile_fingerprint=?`, generation.SourceVersionID, profile).Scan(&current)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return current == generation.AttachmentID, err
+}
+
+func exactEmbeddingHeadExistsTx(ctx context.Context, tx *sql.Tx, versionID, profile string,
+	binding document.EmbeddingBindingV1, generationID, spaceID string,
+) (bool, error) {
+	var exists bool
+	err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM embedding_heads h
+		JOIN embedding_sets s ON s.embedding_set_id=h.embedding_set_id
+		WHERE h.content_version_id=? AND h.binding_id=? AND h.input_kind=?
+		AND s.profile_fingerprint=? AND s.input_generation_id=? AND s.vector_space_id=?)`,
+		versionID, binding.Name, binding.InputKind, profile, generationID, spaceID).Scan(&exists)
+	return exists, err
+}
+
+func embeddingReconcileConsentTx(ctx context.Context, tx *sql.Tx, vaultID, profile, disclosure string,
+	inputKind document.EmbeddingInputKind, at time.Time,
+) (ProviderOperationAuthorizationRequest, bool, error) {
+	inputs, _ := json.Marshal([]string{string(inputKind)})
+	retained, _ := json.Marshal([]string{"embedding_vector_set"})
+	rows, err := tx.QueryContext(ctx, `SELECT g.principal,g.scope FROM processing_consent_grants g
+		JOIN current_processing_incarnation c ON c.incarnation_id=g.incarnation_id
+		WHERE g.vault_uid=? AND g.profile_fingerprint=? AND g.disclosure_fingerprint=?
+		AND g.input_classes_json=? AND g.retained_classes_json=?
+		AND (g.expires_at IS NULL OR g.expires_at>?)
+		ORDER BY g.issued_at DESC,g.grant_id DESC`, vaultID, profile, disclosure,
+		string(inputs), string(retained), at.Format(timestampLayout))
+	if err != nil {
+		return ProviderOperationAuthorizationRequest{}, false, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var principal, scope string
+		if err := rows.Scan(&principal, &scope); err != nil {
+			return ProviderOperationAuthorizationRequest{}, false, err
+		}
+		candidate := ProviderOperationAuthorizationRequest{Principal: principal, Scope: scope,
+			ProfileFingerprint: profile, DisclosureFingerprint: disclosure,
+			InputClasses: []string{string(inputKind)}, RetainedArtifactClasses: []string{"embedding_vector_set"}}
+		if _, err := authorizeProviderOperationTx(ctx, tx, vaultID, candidate, at); err == nil {
+			return candidate, true, nil
+		} else if !errors.Is(err, ErrProcessingConsentRequired) && !errors.Is(err, ErrProcessingConsentExpired) && !errors.Is(err, ErrProcessingConsentRevoked) {
+			return ProviderOperationAuthorizationRequest{}, false, err
+		}
+	}
+	return ProviderOperationAuthorizationRequest{}, false, rows.Err()
+}

--- a/internal/store/embedding_suppression.go
+++ b/internal/store/embedding_suppression.go
@@ -73,6 +73,15 @@ func prepareEmbeddingPurgeTx(
 				versionID, fingerprint, binding.Name, binding.InputKind); err != nil {
 				return nil, fmt.Errorf("clearing purged embedding failures: %w", err)
 			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM current_rendition_roots WHERE root_kind=? AND root_id IN (
+                SELECT job_id FROM embedding_jobs WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?)`,
+				RenditionRootWorkerLease, versionID, fingerprint, binding.Name, binding.InputKind); err != nil {
+				return nil, err
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_jobs WHERE content_version_id=? AND profile_fingerprint=? AND binding_id=? AND input_kind=?`,
+				versionID, fingerprint, binding.Name, binding.InputKind); err != nil {
+				return nil, err
+			}
 			result = append(result, derivativePurgeSuppression{
 				sourceSHA256: source, profileFingerprint: derivativeBuildSuppressionProfile,
 				buildID:  embeddingPurgeScope(EmbeddingHeadKey{versionID, binding.Name, binding.InputKind}, fingerprint),
@@ -142,7 +151,7 @@ func requireEmbeddingPurgeAuthorityTx(ctx context.Context, tx *sql.Tx, set Embed
 		return fmt.Errorf("checking embedding purge suppression: %w", err)
 	}
 	if suppression.active || suppression.supersedingBuildID != set.ID {
-		return errors.New("embedding binding has a purge suppression without authorization for this set")
+		return fmt.Errorf("embedding binding has a purge suppression without authorization for this set: %w", ErrEmbeddingAuthorityStale)
 	}
 	return nil
 }

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -911,6 +911,19 @@ func purgeEmbeddingCatalogTx(
 			return nil, err
 		}
 		report.RemovedEmbeddingHeads += count
+		// A collected set no longer needs its terminal execution record. Pending
+		// work still owns its inputs, including jobs waiting to retry.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_jobs
+			WHERE generation_id=? AND state IN ('completed','failed','abandoned') AND EXISTS (
+				SELECT 1 FROM embedding_sets s WHERE s.embedding_set_id=?
+				  AND s.content_version_id=embedding_jobs.content_version_id
+				  AND s.profile_fingerprint=embedding_jobs.profile_fingerprint
+				  AND s.binding_id=embedding_jobs.binding_id AND s.input_kind=embedding_jobs.input_kind
+				  AND s.input_generation_id=embedding_jobs.generation_id
+				  AND s.vector_space_id=embedding_jobs.vector_space_id
+			)`, candidate.generationID, candidate.id); err != nil {
+			return nil, fmt.Errorf("removing collected embedding jobs: %w", err)
+		}
 		result, err = tx.ExecContext(ctx,
 			`DELETE FROM embedding_sets WHERE embedding_set_id=?`, candidate.id)
 		if err != nil {

--- a/internal/store/rendition_delete.go
+++ b/internal/store/rendition_delete.go
@@ -59,6 +59,13 @@ func deleteRenditionAuthorityForVersionsTx(
 // applies its roots independently after the version-owned sets are gone.
 func deleteEmbeddingAuthorityForVersionsTx(ctx context.Context, tx *sql.Tx, versionIDs []string) error {
 	for _, versionID := range versionIDs {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM current_rendition_roots WHERE root_kind=? AND root_id IN (
+            SELECT job_id FROM embedding_jobs WHERE content_version_id=?)`, RenditionRootWorkerLease, versionID); err != nil {
+			return fmt.Errorf("releasing embedding job roots: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM embedding_jobs WHERE content_version_id=?`, versionID); err != nil {
+			return fmt.Errorf("deleting embedding jobs: %w", err)
+		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM current_rendition_roots WHERE
 			target_kind='embedding_set' AND target_id IN (
 				SELECT embedding_set_id FROM embedding_sets WHERE content_version_id=?)`,

--- a/internal/store/rendition_jobs.go
+++ b/internal/store/rendition_jobs.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -867,29 +866,14 @@ func (s *Store) BeginRenditionProvider(
 	return authorization, nil
 }
 
-// RenditionProviderEgressFence orders consent revocation against provider
-// execution. Close releases the fence after the provider call finishes or
-// when an invocation never reaches the provider boundary.
-type RenditionProviderEgressFence struct {
-	once    sync.Once
-	release func()
-}
-
-// Close releases a provider-egress fence.
-func (fence *RenditionProviderEgressFence) Close() {
-	if fence != nil {
-		fence.once.Do(fence.release)
-	}
-}
-
 // BeginRenditionProviderEgress rechecks durable authority while holding a
 // narrow fence that the caller must release after provider execution.
 func (s *Store) BeginRenditionProviderEgress(
 	ctx context.Context, claim RenditionJobClaim, waiterID string, at time.Time,
 	snapshots ...document.RenditionExecutionSnapshotV1,
-) (ProviderOperationAuthorization, *RenditionProviderEgressFence, error) {
-	s.renditionEgressMu.RLock()
-	fence := &RenditionProviderEgressFence{release: s.renditionEgressMu.RUnlock}
+) (ProviderOperationAuthorization, *ProviderEgressFence, error) {
+	s.providerEgressMu.RLock()
+	fence := &ProviderEgressFence{release: s.providerEgressMu.RUnlock}
 	authorization, err := s.BeginRenditionProvider(ctx, claim, waiterID, at, snapshots...)
 	if err != nil {
 		fence.Close()

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -731,6 +731,42 @@ CREATE TABLE IF NOT EXISTS embedding_input_generations (
         OR (generation_blob_hash IS NOT NULL AND generation_encoded_size > 0))
 );
 
+-- Embedding jobs are rebuildable operational state. Immutable input
+-- generations, vector spaces, consent grants, failures, and published heads
+-- remain the portable authority; this table only resumes bounded execution.
+CREATE TABLE IF NOT EXISTS embedding_jobs (
+    job_id              TEXT PRIMARY KEY,
+    vault_uid           TEXT NOT NULL,
+    content_version_id  TEXT NOT NULL REFERENCES content_versions(version_id) ON DELETE CASCADE,
+    profile_fingerprint TEXT NOT NULL REFERENCES processing_profiles(profile_fingerprint),
+    binding_id          TEXT NOT NULL,
+    input_kind          TEXT NOT NULL,
+    generation_id       TEXT NOT NULL REFERENCES embedding_input_generations(generation_id) ON DELETE CASCADE,
+    vector_space_id     TEXT NOT NULL REFERENCES embedding_vector_spaces(vector_space_id) ON DELETE CASCADE,
+    principal           TEXT NOT NULL,
+    scope               TEXT NOT NULL,
+    state               TEXT NOT NULL,
+    claim_owner         TEXT,
+    claim_epoch         INTEGER NOT NULL DEFAULT 0 CHECK (claim_epoch >= 0),
+    claim_count         INTEGER NOT NULL DEFAULT 0,
+    lease_expires_at    TEXT,
+    available_at        TEXT NOT NULL,
+    failure_code        TEXT,
+    receipt_json        TEXT,
+    created_at          TEXT NOT NULL,
+    updated_at          TEXT NOT NULL,
+    UNIQUE (content_version_id,profile_fingerprint,binding_id,input_kind,generation_id)
+);
+
+CREATE INDEX IF NOT EXISTS embedding_jobs_ready
+    ON embedding_jobs(state,available_at,job_id);
+
+CREATE INDEX IF NOT EXISTS embedding_jobs_generation
+    ON embedding_jobs(generation_id);
+
+CREATE INDEX IF NOT EXISTS embedding_jobs_vector_space
+    ON embedding_jobs(vector_space_id);
+
 CREATE TABLE IF NOT EXISTS embedding_generation_inputs (
     generation_id     TEXT NOT NULL REFERENCES embedding_input_generations(generation_id) ON DELETE CASCADE,
     input_id          TEXT NOT NULL CHECK (length(CAST(input_id AS BLOB)) > 0),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,13 +18,13 @@ var schemaSQL string
 
 // Store is the single access path to the docbank database.
 type Store struct {
-	db                *sql.DB
-	path              string
-	rootID            int64
-	vaultID           string
-	primaryStoreID    string
-	driver            docsqlite.Driver
-	renditionEgressMu sync.RWMutex
+	db               *sql.DB
+	path             string
+	rootID           int64
+	vaultID          string
+	primaryStoreID   string
+	driver           docsqlite.Driver
+	providerEgressMu sync.RWMutex
 }
 
 // currentStorageSchemaVersion identifies the canonical SQLite layout created


### PR DESCRIPTION
Docbank runs queued embedding jobs and publishes each binding independently, so a provider failure leaves other completed sets usable. The daemon supports OpenAI-compatible chunk embeddings and Voyage original-file embeddings with named credential bindings and validated runtime descriptors.

Jobs remain disposable runtime state. After restore, the worker rebuilds them from retained input generations and fresh consent. Publication uses the existing profile-scoped catalog, source and attachment checks, monotonic fencing tokens, and purge rules. Claims select only runtimes configured in the daemon.

Chunk input is hydrated once per attempt; original files are reopened for every provider retry. The worker does not create input generations or apply profiles to new documents.

Parent: #215 (merged). Refs #176.
