### PR TITLE
Report cloud placeholders in preflight and explain hydration failures

### DIFF
--- a/cmd/docbank/add.go
+++ b/cmd/docbank/add.go
@@ -142,6 +142,11 @@ func printIngestPreflight(cmd *cobra.Command, rep api.IngestPreflightReport) {
 		rep.LooseOnly.Files, formatBackupBytes(rep.LooseOnly.Bytes))
 	_, _ = fmt.Fprintf(out, "rejected: %d file(s), %s\n",
 		rep.Rejected.Files, formatBackupBytes(rep.Rejected.Bytes))
+	if rep.CloudPlaceholders.Files > 0 {
+		_, _ = fmt.Fprintf(out, "cloud placeholders (not present locally): %d file(s), %s — "+
+			"ingest downloads these through the provider, or fails those it will not serve to the daemon\n",
+			rep.CloudPlaceholders.Files, formatBackupBytes(rep.CloudPlaceholders.Bytes))
+	}
 	_, _ = fmt.Fprintf(out, "excluded: %d  skipped non-regular: %d  errors: %d\n",
 		rep.Excluded, rep.Skipped, rep.Errors)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -120,7 +120,9 @@ never modified or deleted.
   interrupted bulk import can simply be re-run. See
   [Importing Documents](usage/importing.md).
 
-Run `--preflight` before a large import. It reports regular-file and directory
+Run `--preflight` before a large import. On macOS the report also names how
+many regular files are cloud placeholders whose bytes are not present locally;
+importing them downloads the content through the provider. It reports regular-file and directory
 counts, logical bytes, pack-eligible files, larger loose-only files, files over
 the ingest ceiling, exclusions, skipped non-regular entries, filesystem errors,
 and the largest extension groups. The scan reads filesystem metadata only: it

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -60,7 +60,17 @@ Preflight is metadata-only. In particular, it does not open cloud-provider
 placeholder content merely to estimate the import. That avoids an inventory
 silently hydrating an entire cloud tree, but it also means successful preflight
 cannot promise that every file will remain readable when the later import
-opens it. Re-run preflight after changing exclusions, then pass the exact same
+opens it. It does report how much of the tree is in that state: on macOS,
+`cloud placeholders` counts the regular files whose bytes are not present
+locally (iCloud Drive, Google Drive for Desktop, and similar dataless files),
+so a source that is mostly placeholders is visible before the import spends
+network time on it. Those files are also counted in the size classes above.
+
+A provider may decline to hydrate a placeholder for the process that opens it —
+a daemon started by launchd as a background job is the usual case, while an
+interactive session succeeds. Docbank reports that failure for the individual
+file, names the cause, and suggests opening the file once from a user session
+(or marking it available offline) before retrying the import. Re-run preflight after changing exclusions, then pass the exact same
 `--exclude` flags to the real `docbank add` command.
 
 Filesystem names and provenance paths must currently be valid UTF-8. On POSIX

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -383,10 +383,11 @@ func validateIngestPaths(paths []string) error {
 func ingestPreflightReport(report ingest.PreflightReport) IngestPreflightReport {
 	out := IngestPreflightReport{
 		Files: report.Files, Directories: report.Directories, LogicalBytes: report.LogicalBytes,
-		PackEligible: ingestSizeClass(report.PackEligible),
-		LooseOnly:    ingestSizeClass(report.LooseOnly),
-		Rejected:     ingestSizeClass(report.Rejected),
-		Excluded:     report.Excluded, Skipped: report.Skipped, Errors: report.Errors,
+		PackEligible:      ingestSizeClass(report.PackEligible),
+		LooseOnly:         ingestSizeClass(report.LooseOnly),
+		Rejected:          ingestSizeClass(report.Rejected),
+		CloudPlaceholders: ingestSizeClass(report.CloudPlaceholders),
+		Excluded:          report.Excluded, Skipped: report.Skipped, Errors: report.Errors,
 		OtherFileTypes:     ingestSizeClass(report.OtherFileTypes),
 		FileTypesTruncated: report.FileTypesTruncated, FindingsTruncated: report.FindingsTruncated,
 		FileTypes: make([]IngestFileType, 0, len(report.FileTypes)),

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -551,6 +551,12 @@ type IngestPreflightReport struct {
 	PackEligible IngestSizeClass `json:"pack_eligible"`
 	LooseOnly    IngestSizeClass `json:"loose_only"`
 	Rejected     IngestSizeClass `json:"rejected"`
+	// CloudPlaceholders are regular files whose content is not present
+	// locally (macOS dataless files from iCloud Drive, Google Drive for
+	// Desktop, and similar). Ingest hydrates them through the provider at
+	// network speed, or fails each one the provider will not serve to the
+	// daemon. Zero on other platforms.
+	CloudPlaceholders IngestSizeClass `json:"cloud_placeholders"`
 
 	Excluded int64 `json:"excluded"`
 	Skipped  int64 `json:"skipped"`

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -645,10 +645,16 @@ func TestBackupCreateStreamRoundTripAndTypedError(t *testing.T) {
 	require.Error(t, err)
 	_, err = os.Stat(filepath.Join(cancelledTarget, "docbank.db"))
 	require.ErrorIs(t, err, os.ErrNotExist, "cancelled restore must not publish its database")
+	// The shared repo lock is released only after the aborted restore fully
+	// unwinds (target lease, staged files, durability passes) — on Windows CI
+	// that unwinding has taken tens of seconds. The wait bounds a leaked
+	// lock, not abort latency. AcquireExclusiveLock itself blocks up to 60s
+	// while a fresh shared lock exists, so one call may consume most of the
+	// window.
 	require.Eventually(t, func() bool {
 		lock, lockErr = repo.AcquireExclusiveLock("restore-cancel-test", false)
 		return lockErr == nil
-	}, 5*time.Second, 10*time.Millisecond,
+	}, 90*time.Second, 10*time.Millisecond,
 		"server-side cancellation must release the restore repository lock")
 	require.NoError(t, lock.Release())
 

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "61"
+	daemonProtocolVersion = "62"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -712,6 +712,9 @@ func (ing *Ingester) readLocalFileWith(
 	// must hold for the file actually read, not the one classified.
 	f, err := open()
 	if err != nil {
+		if hint := placeholderReadHint(err); hint != "" {
+			return result, fmt.Errorf("opening %s: %w (%s)", sourcePath, err, hint)
+		}
 		return result, fmt.Errorf("opening %s: %w", sourcePath, err)
 	}
 	defer func() { _ = f.Close() }()
@@ -731,6 +734,9 @@ func (ing *Ingester) readLocalFileWith(
 	head := make([]byte, 512)
 	n, err := io.ReadFull(f, head)
 	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		if hint := placeholderReadHint(err); hint != "" {
+			return result, fmt.Errorf("reading %s: %w (%s)", sourcePath, err, hint)
+		}
 		return result, fmt.Errorf("reading %s: %w", sourcePath, err)
 	}
 	head = head[:n]

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -631,14 +631,29 @@ func TestPreflightInventoriesWithoutMutatingVault(t *testing.T) {
 func TestPreflightSizePolicyBoundaries(t *testing.T) {
 	var report PreflightReport
 	types := make(map[string]FileType)
-	report.addFile("packed.bin", blob.MaxPackedBlobBytes, types)
-	report.addFile("loose.bin", blob.MaxPackedBlobBytes+1, types)
-	report.addFile("limit.bin", blob.MaxIngestBytes, types)
-	report.addFile("rejected.bin", blob.MaxIngestBytes+1, types)
+	report.addFile("packed.bin", blob.MaxPackedBlobBytes, false, types)
+	report.addFile("loose.bin", blob.MaxPackedBlobBytes+1, false, types)
+	report.addFile("limit.bin", blob.MaxIngestBytes, false, types)
+	report.addFile("rejected.bin", blob.MaxIngestBytes+1, false, types)
 
 	assert.Equal(t, int64(1), report.PackEligible.Files)
 	assert.Equal(t, int64(2), report.LooseOnly.Files)
 	assert.Equal(t, int64(1), report.Rejected.Files)
+	assert.Equal(t, int64(0), report.CloudPlaceholders.Files)
+}
+
+// A cloud placeholder is counted separately and still belongs to its size
+// class: the report describes the same file from two angles.
+func TestPreflightCountsCloudPlaceholders(t *testing.T) {
+	var report PreflightReport
+	types := make(map[string]FileType)
+	report.addFile("local.bin", 1024, false, types)
+	report.addFile("dataless.bin", 4096, true, types)
+
+	assert.Equal(t, int64(2), report.Files)
+	assert.Equal(t, int64(2), report.PackEligible.Files)
+	assert.Equal(t, int64(1), report.CloudPlaceholders.Files)
+	assert.Equal(t, int64(4096), report.CloudPlaceholders.Bytes)
 }
 
 func TestAddPathsHonorsPreflightExclusions(t *testing.T) {

--- a/internal/ingest/placeholder_darwin.go
+++ b/internal/ingest/placeholder_darwin.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+package ingest
+
+import (
+	"errors"
+	"io/fs"
+	"syscall"
+)
+
+// sfDataless is the BSD file flag macOS sets on a cloud-provider placeholder
+// whose bytes are not present locally (File Provider / iCloud Drive / Google
+// Drive for Desktop). The syscall package does not export it.
+const sfDataless = 0x40000000
+
+// isCloudPlaceholder reports whether info describes a dataless file: metadata
+// is present, but opening it makes the cloud provider fetch the content, or
+// refuse to for the calling process.
+func isCloudPlaceholder(info fs.FileInfo) bool {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	return ok && st.Flags&sfDataless != 0
+}
+
+// placeholderReadHint explains a read failure that macOS reports when a cloud
+// provider declines to hydrate a placeholder for the reading process. A daemon
+// launched by launchd as a background job typically sees this; the same file
+// opens fine from an interactive session, after which the content is cached
+// and a retried ingest succeeds.
+func placeholderReadHint(err error) string {
+	if errors.Is(err, syscall.EDEADLK) {
+		return "the cloud provider did not hydrate this placeholder for the daemon; " +
+			"open the file once from a user session (or make it available offline), then retry"
+	}
+	return ""
+}

--- a/internal/ingest/placeholder_darwin_test.go
+++ b/internal/ingest/placeholder_darwin_test.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package ingest
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An ordinary local file is never a placeholder: SF_DATALESS is set by the
+// provider, and no test may depend on a real cloud mount.
+func TestIsCloudPlaceholderFalseForLocalFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local.bin")
+	require.NoError(t, os.WriteFile(path, []byte("bytes"), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.False(t, isCloudPlaceholder(info))
+}
+
+func TestPlaceholderReadHint(t *testing.T) {
+	assert.Contains(t, placeholderReadHint(syscall.EDEADLK), "hydrate")
+	assert.Contains(t, placeholderReadHint(&os.PathError{Err: syscall.EDEADLK}), "hydrate")
+	assert.Empty(t, placeholderReadHint(errors.New("boom")))
+	assert.Empty(t, placeholderReadHint(os.ErrPermission))
+}

--- a/internal/ingest/placeholder_other.go
+++ b/internal/ingest/placeholder_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package ingest
+
+import "io/fs"
+
+func isCloudPlaceholder(fs.FileInfo) bool { return false }
+
+func placeholderReadHint(error) string { return "" }

--- a/internal/ingest/placeholder_other_test.go
+++ b/internal/ingest/placeholder_other_test.go
@@ -1,0 +1,24 @@
+//go:build !darwin
+
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Other platforms have no dataless-file concept: preflight reports zero
+// placeholders and ingest adds no hint.
+func TestCloudPlaceholderIsInertOffDarwin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local.bin")
+	require.NoError(t, os.WriteFile(path, []byte("bytes"), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.False(t, isCloudPlaceholder(info))
+	assert.Empty(t, placeholderReadHint(syscall.EDEADLK))
+}

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -63,6 +63,14 @@ type PreflightReport struct {
 	LooseOnly    SizeClass
 	Rejected     SizeClass
 
+	// CloudPlaceholders counts regular files whose bytes are not present
+	// locally (macOS dataless files from iCloud Drive, Google Drive for
+	// Desktop, and similar). Preflight never opens them; a real ingest will
+	// either hydrate each one through the provider at network speed or, for a
+	// daemon the provider will not serve, fail that file. They are also
+	// counted in the size classes above.
+	CloudPlaceholders SizeClass
+
 	Excluded int64
 	Skipped  int64
 	Errors   int64
@@ -190,7 +198,7 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 			}
 		}
 		if info.Mode().IsRegular() {
-			report.addFile(source, info.Size(), types)
+			report.addFile(source, info.Size(), isCloudPlaceholder(info), types)
 			continue
 		}
 		if !info.IsDir() {
@@ -255,7 +263,7 @@ func preflightTree(
 				report.addFinding(sourcePath, "error", err.Error())
 				return nil
 			}
-			report.addFile(sourcePath, info.Size(), types)
+			report.addFile(sourcePath, info.Size(), isCloudPlaceholder(info), types)
 		default:
 			report.addFinding(sourcePath, "skipped", "not a regular file (symlinks are skipped)")
 		}
@@ -263,9 +271,13 @@ func preflightTree(
 	})
 }
 
-func (r *PreflightReport) addFile(path string, size int64, types map[string]FileType) {
+func (r *PreflightReport) addFile(path string, size int64, placeholder bool, types map[string]FileType) {
 	r.Files++
 	r.LogicalBytes += size
+	if placeholder {
+		r.CloudPlaceholders.Files++
+		r.CloudPlaceholders.Bytes += size
+	}
 	switch {
 	case size <= blob.MaxPackedBlobBytes:
 		r.PackEligible.Files++


### PR DESCRIPTION
Closes half of #197 (the placeholder half; the glob include/exclude request there is untouched).

Preflight already refuses to open cloud-provider placeholders, which is the right call — but it also said nothing about how many of them a source contains, so a tree that looks like a quick import can turn into hours of provider downloads. Preflight now counts them:

```
files: 15525  directories: 2052  logical size: 2.9 TiB
pack eligible: 13043 file(s), 36.9 GiB
loose only: 2374 file(s), 1.9 TiB
rejected: 108 file(s), 1.0 TiB
cloud placeholders (not present locally): 9871 file(s), 2.4 TiB — ingest downloads these through the provider, or fails those it will not serve to the daemon
```

The count appears in the CLI report, `--json`, and `IngestPreflightReport` (`cloud_placeholders`). Placeholders stay counted in their size classes too: the report describes the same file from two angles.

The second half is the error message. When a provider declines to hydrate a placeholder for the process opening it, macOS returns `EDEADLK` and the ingest failure read as:

```
reading /Users/.../My Drive/Talks/JoiIto.pdf: resource deadlock avoided
```

which is hard to act on. It now names the cause and the fix (open the file once from a user session, or mark it available offline, then retry). In my case the daemon runs as a launchd background job and the provider serves an interactive session but not that daemon — the same file imported fine after one `cat` from a shell.

Detection is `SF_DATALESS` on darwin; other platforms compile to no-ops and report zero, with tests on both paths.

Found while running docbank as the document system of record over a vault and two Google Drive accounts (~11.5k document nodes). Happy to adjust the wording or the field name.