### PR TITLE
[F10–E12 22/25] Add explained hybrid document search

### DIFF
--- a/internal/processing/embedding_worker_test.go
+++ b/internal/processing/embedding_worker_test.go
@@ -1132,7 +1132,7 @@ func (embeddingIntegrationTokenizer) Tokenize(text string, limit int) ([]documen
 	return result, nil
 }
 
-func newRealEmbeddingWorker(t *testing.T, kind document.EmbeddingInputKind) (publicationFixture, *embeddingWorkerFixture, *EmbeddingWorker, store.EmbeddingJobRequest) {
+func newRealEmbeddingWorker(t *testing.T, kind document.EmbeddingInputKind, additionalBindings ...string) (publicationFixture, *embeddingWorkerFixture, *EmbeddingWorker, store.EmbeddingJobRequest) {
 	t.Helper()
 	fixture := newPublicationFixture(t)
 	fake := newEmbeddingWorkerFixture(t)
@@ -1147,6 +1147,11 @@ func newRealEmbeddingWorker(t *testing.T, kind document.EmbeddingInputKind) (pub
 	}
 	binding.MaxBatchItems = 1
 	portable.Embeddings = []document.EmbeddingBindingV1{binding}
+	for _, name := range additionalBindings {
+		additional := binding
+		additional.Name = name
+		portable.Embeddings = append(portable.Embeddings, additional)
+	}
 	canonical, fingerprints, err := document.CanonicalProfile(portable)
 	require.NoError(t, err)
 	fixture.profile.CanonicalProfile, fixture.profile.Fingerprint = canonical, fingerprints.Profile

--- a/internal/processing/retrieval_test.go
+++ b/internal/processing/retrieval_test.go
@@ -1,0 +1,90 @@
+package processing
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/retrieval"
+	"go.kenn.io/docbank/internal/store"
+	"go.kenn.io/docbank/internal/vectorworker"
+)
+
+func TestHybridSearcherUsesRealStoreBindingAuthority(t *testing.T) {
+	fixture, fake, embedding, request := newRealEmbeddingWorker(t, document.EmbeddingInputOriginalFile, "alternate")
+	_, err := embedding.ScanOnce(t.Context())
+	require.NoError(t, err)
+	var metadata bytes.Buffer
+	require.NoError(t, fixture.catalog.ExportMetadata(t.Context(), &metadata))
+	heads := make(map[string]string)
+	for line := range bytes.SplitSeq(metadata.Bytes(), []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var head struct {
+			Type    string `json:"type"`
+			Binding string `json:"binding_id"`
+			Set     string `json:"embedding_set_id"`
+		}
+		require.NoError(t, json.Unmarshal(line, &head))
+		if head.Type == "embedding_head" {
+			heads[head.Binding] = head.Set
+		}
+	}
+	require.Len(t, heads, 2)
+	require.NotEqual(t, heads[request.BindingID], heads["alternate"])
+	spaces, err := fixture.catalog.ListVectorIndexSpaces(t.Context())
+	require.NoError(t, err)
+	require.Len(t, spaces, 1)
+	index, err := vectorworker.NewIndexWorker(vectorworker.IndexWorkerConfig{
+		Catalog: fixture.catalog, Mutate: api.NewOperationGate().MutateContext,
+		Owner: "retrieval-test", BuildLease: time.Minute, ReaderLease: time.Minute, IdleDelay: time.Millisecond,
+		ReadVectorSet: func(ctx context.Context, member store.VectorIndexMember) ([]byte, error) {
+			return fixture.catalog.ReadVectorIndexVectorSet(ctx, fixture.blobs, member)
+		},
+	})
+	require.NoError(t, err)
+	_, err = index.Rebuild(t.Context(), spaces[0])
+	require.NoError(t, err)
+	provider := &embeddingWorkerProvider{runtime: fake.runtime, binding: "query", descriptor: fake.descriptor}
+	searcher, err := retrieval.NewSearcher(retrieval.SearcherConfig{
+		Backend: fixture.catalog, Encoders: provider, Owner: "retrieval-test", LeaseDuration: time.Minute,
+	})
+	require.NoError(t, err)
+	for _, binding := range []string{request.BindingID, "alternate"} {
+		t.Run(binding, func(t *testing.T) {
+			report, err := searcher.Search(t.Context(), retrieval.Query{
+				Text: "synthetic", Mode: retrieval.ModeHybrid, Limit: 1,
+				Scope:                        store.SearchOptions{MIMEType: "image/png"},
+				ProcessingProfileFingerprint: request.Profile.Fingerprint, BindingID: binding,
+				Authorization: document.EmbeddingAuthorization{
+					ProviderID: fake.descriptor.ID, DescriptorFingerprint: fake.descriptor.Fingerprint,
+					PolicyFingerprint: fake.descriptor.PolicyFingerprint,
+					MaxBatchItems:     1, MaxInputBytes: 1 << 20, MaxResponseBytes: 1 << 20,
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, report.Results, 1)
+			result := report.Results[0]
+			assert.Equal(t, "/synthetic.png", result.Path)
+			assert.Equal(t, request.ContentVersionID, result.Document.ContentVersionID)
+			assert.Equal(t, 1, result.LexicalRank)
+			assert.Equal(t, 1, result.SemanticRank)
+			assert.Equal(t, 1, report.Coverage.CompleteDocuments)
+			require.Len(t, result.Evidence, 2)
+			assert.Equal(t, "embedding", result.Evidence[1].Kind)
+			assert.Equal(t, heads[binding], result.Evidence[1].EmbeddingSetID)
+		})
+	}
+}
+
+func (p *embeddingWorkerProvider) ResolveQueryEncoder(context.Context, document.EmbeddingDescriptor) (document.EmbeddingProvider, error) {
+	return p, nil
+}

--- a/internal/retrieval/fusion.go
+++ b/internal/retrieval/fusion.go
@@ -1,0 +1,119 @@
+package retrieval
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+)
+
+func FuseReciprocalRank(lexical, semantic []Candidate, limit int) ([]Result, bool, error) {
+	if limit < 1 || limit > MaxCandidateLimit {
+		return nil, false, fmt.Errorf("retrieval candidate limit must be between 1 and %d", MaxCandidateLimit)
+	}
+	if err := validateOneSemanticVectorSpace(semantic); err != nil {
+		return nil, false, err
+	}
+	byDocument := make(map[DocumentIdentity]*Result, len(lexical)+len(semantic))
+	if err := addLane(byDocument, lexical, LaneLexical); err != nil {
+		return nil, false, fmt.Errorf("lexical lane: %w", err)
+	}
+	if err := addLane(byDocument, semantic, LaneSemantic); err != nil {
+		return nil, false, fmt.Errorf("semantic lane: %w", err)
+	}
+	results := make([]Result, 0, len(byDocument))
+	for _, result := range byDocument {
+		results = append(results, *result)
+	}
+	slices.SortFunc(results, compareResults)
+	for index := range results {
+		results[index].Rank = index + 1
+	}
+	truncated := len(results) > limit
+	if truncated {
+		results = results[:limit]
+	}
+	return results, truncated, nil
+}
+
+func validateOneSemanticVectorSpace(candidates []Candidate) error {
+	vectorSpaceID := ""
+	for _, candidate := range candidates {
+		if candidate.VectorSpaceID == "" {
+			return errors.New("semantic candidates require one active vector space")
+		}
+		if vectorSpaceID == "" {
+			vectorSpaceID = candidate.VectorSpaceID
+		} else if candidate.VectorSpaceID != vectorSpaceID {
+			return errors.New("semantic candidates must belong to one active vector space")
+		}
+		for _, evidence := range candidate.Evidence {
+			if evidence.VectorSpaceID != candidate.VectorSpaceID {
+				return errors.New("semantic evidence must belong to one active vector space")
+			}
+		}
+	}
+	return nil
+}
+
+func addLane(results map[DocumentIdentity]*Result, candidates []Candidate, lane Lane) error {
+	lastRank := 0
+	seen := make(map[DocumentIdentity]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.Lane != lane || candidate.Rank <= lastRank {
+			return errors.New("candidate lane and ranks must be ordered and exact")
+		}
+		if candidate.Document.VaultID == "" || candidate.Document.NodeID <= 0 || candidate.Document.ContentVersionID == "" {
+			return errors.New("candidate document identity is incomplete")
+		}
+		if _, duplicate := seen[candidate.Document]; duplicate {
+			return errors.New("candidate document identity is duplicated within one lane")
+		}
+		seen[candidate.Document] = struct{}{}
+		lastRank = candidate.Rank
+		result := results[candidate.Document]
+		if result == nil {
+			result = &Result{Document: candidate.Document, Path: candidate.Path}
+			results[candidate.Document] = result
+		} else if result.Path != "" && candidate.Path != "" && result.Path != candidate.Path {
+			return errors.New("candidate lanes disagree on the stable document path")
+		} else if result.Path == "" {
+			result.Path = candidate.Path
+		}
+		contribution := 1 / float64(ReciprocalRankK+candidate.Rank)
+		result.Score += contribution
+		result.Explanation = append(result.Explanation, Contribution{
+			Lane: lane, Rank: candidate.Rank, Contribution: contribution,
+		})
+		if lane == LaneLexical {
+			result.LexicalRank = candidate.Rank
+			result.Excerpt = candidate.Excerpt
+		} else {
+			result.SemanticRank = candidate.Rank
+		}
+		result.Evidence = append(result.Evidence, candidate.Evidence...)
+	}
+	return nil
+}
+
+func compareResults(left, right Result) int {
+	switch {
+	case left.Score > right.Score:
+		return -1
+	case left.Score < right.Score:
+		return 1
+	case left.Document.VaultID < right.Document.VaultID:
+		return -1
+	case left.Document.VaultID > right.Document.VaultID:
+		return 1
+	case left.Document.NodeID < right.Document.NodeID:
+		return -1
+	case left.Document.NodeID > right.Document.NodeID:
+		return 1
+	case left.Document.ContentVersionID < right.Document.ContentVersionID:
+		return -1
+	case left.Document.ContentVersionID > right.Document.ContentVersionID:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/retrieval/fusion.go
+++ b/internal/retrieval/fusion.go
@@ -1,15 +1,15 @@
 package retrieval
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"slices"
+
+	"go.kenn.io/docbank/document/embedding"
 )
 
 func FuseReciprocalRank(lexical, semantic []Candidate, limit int) ([]Result, bool, error) {
-	if limit < 1 || limit > MaxCandidateLimit {
-		return nil, false, fmt.Errorf("retrieval candidate limit must be between 1 and %d", MaxCandidateLimit)
-	}
 	if err := validateOneSemanticVectorSpace(semantic); err != nil {
 		return nil, false, err
 	}
@@ -20,19 +20,55 @@ func FuseReciprocalRank(lexical, semantic []Candidate, limit int) ([]Result, boo
 	if err := addLane(byDocument, semantic, LaneSemantic); err != nil {
 		return nil, false, fmt.Errorf("semantic lane: %w", err)
 	}
-	results := make([]Result, 0, len(byDocument))
-	for _, result := range byDocument {
-		results = append(results, *result)
+	identities := make([]DocumentIdentity, 0, len(byDocument))
+	for identity := range byDocument {
+		identities = append(identities, identity)
 	}
-	slices.SortFunc(results, compareResults)
-	for index := range results {
-		results[index].Rank = index + 1
+	slices.SortFunc(identities, func(left, right DocumentIdentity) int {
+		return cmp.Or(cmp.Compare(left.VaultID, right.VaultID),
+			cmp.Compare(left.NodeID, right.NodeID), cmp.Compare(left.ContentVersionID, right.ContentVersionID))
+	})
+	// Shared fusion orders string keys before truncation. Ordinals preserve
+	// the document order, including numeric node IDs, without encoding evidence.
+	keys := make(map[DocumentIdentity]string, len(identities))
+	metadata := make(map[string]*Result, len(identities))
+	for index, identity := range identities {
+		key := fmt.Sprintf("%020d", index)
+		keys[identity], metadata[key] = key, byDocument[identity]
 	}
-	truncated := len(results) > limit
-	if truncated {
-		results = results[:limit]
+	rankLane := func(candidates []Candidate) embedding.ScopedCandidates {
+		lane := embedding.ScopedCandidates{Candidates: make([]embedding.RankedCandidate, len(candidates))}
+		for index, candidate := range candidates {
+			lane.Candidates[index] = embedding.RankedCandidate{
+				Key: keys[candidate.Document], Rank: candidate.Rank, Score: candidate.Score,
+			}
+		}
+		return lane
 	}
-	return results, truncated, nil
+	fused, err := embedding.FuseReciprocalRank(embedding.FusionInput{
+		Lexical: rankLane(lexical), Semantic: rankLane(semantic),
+	}, limit)
+	if err != nil {
+		return nil, false, err
+	}
+	results := make([]Result, len(fused.Candidates))
+	for index, candidate := range fused.Candidates {
+		result := *metadata[candidate.Key]
+		result.Rank, result.Score = candidate.Rank, candidate.Score
+		for _, signal := range []struct {
+			lane   Lane
+			signal *embedding.CandidateSignal
+		}{{LaneLexical, candidate.Lexical}, {LaneSemantic, candidate.Semantic}} {
+			if signal.signal != nil {
+				result.Explanation = append(result.Explanation, Contribution{
+					Lane: signal.lane, Rank: signal.signal.Rank,
+					Contribution: 1 / float64(ReciprocalRankK+signal.signal.Rank),
+				})
+			}
+		}
+		results[index] = result
+	}
+	return results, fused.Truncated, nil
 }
 
 func validateOneSemanticVectorSpace(candidates []Candidate) error {
@@ -56,20 +92,13 @@ func validateOneSemanticVectorSpace(candidates []Candidate) error {
 }
 
 func addLane(results map[DocumentIdentity]*Result, candidates []Candidate, lane Lane) error {
-	lastRank := 0
-	seen := make(map[DocumentIdentity]struct{}, len(candidates))
 	for _, candidate := range candidates {
-		if candidate.Lane != lane || candidate.Rank <= lastRank {
-			return errors.New("candidate lane and ranks must be ordered and exact")
+		if candidate.Lane != lane {
+			return errors.New("candidate belongs to the wrong lane")
 		}
 		if candidate.Document.VaultID == "" || candidate.Document.NodeID <= 0 || candidate.Document.ContentVersionID == "" {
 			return errors.New("candidate document identity is incomplete")
 		}
-		if _, duplicate := seen[candidate.Document]; duplicate {
-			return errors.New("candidate document identity is duplicated within one lane")
-		}
-		seen[candidate.Document] = struct{}{}
-		lastRank = candidate.Rank
 		result := results[candidate.Document]
 		if result == nil {
 			result = &Result{Document: candidate.Document, Path: candidate.Path}
@@ -79,11 +108,6 @@ func addLane(results map[DocumentIdentity]*Result, candidates []Candidate, lane 
 		} else if result.Path == "" {
 			result.Path = candidate.Path
 		}
-		contribution := 1 / float64(ReciprocalRankK+candidate.Rank)
-		result.Score += contribution
-		result.Explanation = append(result.Explanation, Contribution{
-			Lane: lane, Rank: candidate.Rank, Contribution: contribution,
-		})
 		if lane == LaneLexical {
 			result.LexicalRank = candidate.Rank
 			result.Excerpt = candidate.Excerpt
@@ -93,27 +117,4 @@ func addLane(results map[DocumentIdentity]*Result, candidates []Candidate, lane 
 		result.Evidence = append(result.Evidence, candidate.Evidence...)
 	}
 	return nil
-}
-
-func compareResults(left, right Result) int {
-	switch {
-	case left.Score > right.Score:
-		return -1
-	case left.Score < right.Score:
-		return 1
-	case left.Document.VaultID < right.Document.VaultID:
-		return -1
-	case left.Document.VaultID > right.Document.VaultID:
-		return 1
-	case left.Document.NodeID < right.Document.NodeID:
-		return -1
-	case left.Document.NodeID > right.Document.NodeID:
-		return 1
-	case left.Document.ContentVersionID < right.Document.ContentVersionID:
-		return -1
-	case left.Document.ContentVersionID > right.Document.ContentVersionID:
-		return 1
-	default:
-		return 0
-	}
 }

--- a/internal/retrieval/search.go
+++ b/internal/retrieval/search.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/embedding"
 	"go.kenn.io/docbank/internal/store"
 	"go.kenn.io/docbank/internal/vectorindex"
 )
@@ -74,13 +75,13 @@ func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, erro
 	requested := query.Mode
 	switch requested {
 	case ModeLexical, ModeAuto:
-		return searcher.lexical(ctx, query, requested, DegradationNone, Coverage{State: CoverageUnknown})
+		return searcher.lexical(ctx, query, requested, Coverage{State: CoverageUnknown})
 	case ModeSemantic:
 		semantic, coverage, truncated, err := searcher.semantic(ctx, query)
 		if err != nil {
 			return Report{}, err
 		}
-		return laneReport(requested, ModeSemantic, coverage, DegradationNone, semantic, truncated), nil
+		return laneReport(requested, ModeSemantic, coverage, semantic, truncated), nil
 	case ModeHybrid:
 		return searcher.hybrid(ctx, query, requested)
 	}
@@ -215,18 +216,14 @@ func normalizeQuery(query Query) (Query, error) {
 	if query.Text == "" {
 		return Query{}, errors.New("retrieval query text is required")
 	}
-	if query.Mode == "" || query.Mode == ModeAuto {
-		query.Mode = ModeLexical
+	options, err := embedding.NormalizeSearchOptions(embedding.SearchOptions{
+		Mode: embedding.SearchMode(query.Mode), CandidateLimit: query.Limit,
+	})
+	if err != nil {
+		return Query{}, err
 	}
-	if query.Mode != ModeLexical && query.Mode != ModeSemantic && query.Mode != ModeHybrid {
-		return Query{}, fmt.Errorf("unsupported retrieval mode %q", query.Mode)
-	}
-	if query.Limit == 0 {
-		query.Limit = DefaultCandidateLimit
-	}
-	if query.Limit < 1 || query.Limit > MaxCandidateLimit {
-		return Query{}, fmt.Errorf("retrieval candidate limit must be between 1 and %d", MaxCandidateLimit)
-	}
+	query.Mode, query.Limit = Mode(options.Mode), options.CandidateLimit
+
 	return query, nil
 }
 
@@ -247,7 +244,7 @@ func (searcher *Searcher) collectLexical(ctx context.Context, query Query) ([]Ca
 	return candidates, truncated, nil
 }
 
-func laneReport(requested, actual Mode, coverage Coverage, degradation Degradation,
+func laneReport(requested, actual Mode, coverage Coverage,
 	candidates []Candidate, truncated bool,
 ) Report {
 	results := make([]Result, len(candidates))
@@ -269,7 +266,7 @@ func laneReport(requested, actual Mode, coverage Coverage, degradation Degradati
 		traceCode = TraceSemanticCandidates
 	}
 	return Report{RequestedMode: requested, ActualMode: actual, Coverage: coverage,
-		Degradation: degradation, Results: results, Truncated: truncated,
+		Results: results, Truncated: truncated,
 		Trace: []TraceEvent{{Code: traceCode, Count: len(results)}}}
 }
 
@@ -288,11 +285,11 @@ func makeHybridReport(requested Mode, coverage Coverage, lexical, semantic []Can
 }
 
 func (searcher *Searcher) lexical(ctx context.Context, query Query, requested Mode,
-	degradation Degradation, coverage Coverage,
+	coverage Coverage,
 ) (Report, error) {
 	candidates, truncated, err := searcher.collectLexical(ctx, query)
 	if err != nil {
 		return Report{}, err
 	}
-	return laneReport(requested, ModeLexical, coverage, degradation, candidates, truncated), nil
+	return laneReport(requested, ModeLexical, coverage, candidates, truncated), nil
 }

--- a/internal/retrieval/search.go
+++ b/internal/retrieval/search.go
@@ -73,39 +73,18 @@ func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, erro
 	}
 	requested := query.Mode
 	switch requested {
-	case ModeLexical:
+	case ModeLexical, ModeAuto:
 		return searcher.lexical(ctx, query, requested, DegradationNone, Coverage{State: CoverageUnknown})
 	case ModeSemantic:
-		semantic, coverage, truncated, err := searcher.semantic(ctx, query, false)
+		semantic, coverage, truncated, err := searcher.semantic(ctx, query)
 		if err != nil {
 			return Report{}, err
 		}
 		return laneReport(requested, ModeSemantic, coverage, DegradationNone, semantic, truncated), nil
 	case ModeHybrid:
 		return searcher.hybrid(ctx, query, requested)
-	case ModeAuto:
-		semantic, coverage, semanticTruncated, semanticErr := searcher.semantic(ctx, query, true)
-		if semanticErr != nil {
-			degradable := &semanticDegradationError{}
-			ok := errors.As(semanticErr, &degradable)
-			if !ok {
-				return Report{}, semanticErr
-			}
-			return searcher.lexical(ctx, query, requested, degradable.degradation, coverage)
-		}
-		lexical, lexicalTruncated, err := searcher.collectLexical(ctx, query)
-		if err != nil {
-			return Report{}, err
-		}
-		return makeHybridReport(requested, coverage, lexical, semantic,
-			lexicalTruncated || semanticTruncated, query.Limit)
 	}
 	return Report{}, errors.New("unreachable retrieval mode")
-}
-
-type semanticDegradationError struct {
-	degradation Degradation
-	cause       error
 }
 
 type semanticReleaseError struct {
@@ -119,19 +98,12 @@ func (failure *semanticReleaseError) Error() string {
 
 func (failure *semanticReleaseError) Unwrap() error { return failure.release }
 
-func (failure *semanticDegradationError) Error() string { return failure.cause.Error() }
-func (failure *semanticDegradationError) Unwrap() error { return failure.cause }
-
-func degradableSemanticFailure(degradation Degradation, cause error) error {
-	return &semanticDegradationError{degradation: degradation, cause: cause}
-}
-
 func (searcher *Searcher) hybrid(ctx context.Context, query Query, requested Mode) (Report, error) {
 	lexical, lexicalTruncated, err := searcher.collectLexical(ctx, query)
 	if err != nil {
 		return Report{}, err
 	}
-	semantic, coverage, semanticTruncated, err := searcher.semantic(ctx, query, false)
+	semantic, coverage, semanticTruncated, err := searcher.semantic(ctx, query)
 	if err != nil {
 		return Report{}, err
 	}
@@ -139,22 +111,15 @@ func (searcher *Searcher) hybrid(ctx context.Context, query Query, requested Mod
 		lexicalTruncated || semanticTruncated, query.Limit)
 }
 
-func (searcher *Searcher) semantic(ctx context.Context, query Query,
-	degradeIncompleteRequired bool,
-) (_ []Candidate, coverage Coverage, truncated bool, retErr error) {
+func (searcher *Searcher) semantic(ctx context.Context, query Query) (_ []Candidate, coverage Coverage, truncated bool, retErr error) {
 	backend, ok := searcher.backend.(SemanticBackend)
 	if !ok || searcher.encoders == nil {
-		return nil, Coverage{State: CoverageUnknown}, false, degradableSemanticFailure(
-			DegradationSemanticUnavailable, errors.New("semantic retrieval is not configured"))
+		return nil, Coverage{State: CoverageUnknown}, false, errors.New("semantic retrieval is not configured")
 	}
 	authority, err := backend.AcquireSemanticSearchAuthority(ctx,
 		query.ProcessingProfileFingerprint, query.BindingID, searcher.owner,
 		searcher.clock().UTC(), searcher.leaseDuration, query.Scope)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return nil, Coverage{State: CoverageUnknown}, false, degradableSemanticFailure(
-				DegradationSemanticUnavailable, err)
-		}
 		return nil, Coverage{State: CoverageUnknown}, false, err
 	}
 	defer func() {
@@ -163,8 +128,6 @@ func (searcher *Searcher) semantic(ctx context.Context, query Query,
 			if retErr == nil {
 				retErr = releaseErr
 			} else {
-				// A failed release makes the whole operation non-degradable even
-				// when the earlier provider stage could have fallen back safely.
 				retErr = &semanticReleaseError{operation: retErr, release: releaseErr}
 			}
 		}
@@ -174,18 +137,13 @@ func (searcher *Searcher) semantic(ctx context.Context, query Query,
 		State: CoverageComplete}
 	if authority.CompleteDocuments != authority.ScopedDocuments {
 		coverage.State = CoverageIncomplete
-		if authority.BindingRequired && degradeIncompleteRequired {
-			return nil, coverage, false, degradableSemanticFailure(DegradationIncompleteCoverage,
-				errors.New("required semantic coverage is incomplete"))
-		}
 	}
 	provider, err := searcher.encoders.ResolveQueryEncoder(ctx, authority.VectorSpace.Descriptor)
 	if err != nil {
-		return nil, coverage, false, degradableSemanticFailure(DegradationProviderUnavailable, err)
+		return nil, coverage, false, err
 	}
 	if provider == nil {
-		return nil, coverage, false, degradableSemanticFailure(DegradationSemanticUnavailable,
-			errors.New("query encoder runtime is unavailable"))
+		return nil, coverage, false, errors.New("query encoder runtime is unavailable")
 	}
 	if !reflect.DeepEqual(provider.Descriptor(), authority.VectorSpace.Descriptor) {
 		return nil, coverage, false, errors.New("query encoder does not reproduce the active vector-space descriptor")
@@ -201,7 +159,7 @@ func (searcher *Searcher) semantic(ctx context.Context, query Query,
 	}
 	embedded, err := document.ExecuteEmbedding(ctx, provider, inputs, query.Authorization)
 	if err != nil {
-		return nil, coverage, false, degradableSemanticFailure(DegradationProviderUnavailable, err)
+		return nil, coverage, false, err
 	}
 	stored := authority.Lease.Generation
 	generation, err := vectorindex.OpenGeneration(bytes.NewReader(stored.Bytes), int64(len(stored.Bytes)))
@@ -233,10 +191,6 @@ func (searcher *Searcher) semantic(ctx context.Context, query Query,
 	coverage.State = CoverageComplete
 	if coverage.CompleteDocuments != coverage.ScopedDocuments {
 		coverage.State = CoverageIncomplete
-		if authority.BindingRequired && degradeIncompleteRequired {
-			return nil, coverage, false, degradableSemanticFailure(DegradationIncompleteCoverage,
-				errors.New("required semantic coverage became incomplete during retrieval"))
-		}
 	}
 	resolved := resolution.Candidates
 	candidates := make([]Candidate, len(resolved))
@@ -261,10 +215,10 @@ func normalizeQuery(query Query) (Query, error) {
 	if query.Text == "" {
 		return Query{}, errors.New("retrieval query text is required")
 	}
-	if query.Mode == "" {
-		query.Mode = ModeAuto
+	if query.Mode == "" || query.Mode == ModeAuto {
+		query.Mode = ModeLexical
 	}
-	if query.Mode != ModeAuto && query.Mode != ModeLexical && query.Mode != ModeSemantic && query.Mode != ModeHybrid {
+	if query.Mode != ModeLexical && query.Mode != ModeSemantic && query.Mode != ModeHybrid {
 		return Query{}, fmt.Errorf("unsupported retrieval mode %q", query.Mode)
 	}
 	if query.Limit == 0 {

--- a/internal/retrieval/search.go
+++ b/internal/retrieval/search.go
@@ -1,0 +1,344 @@
+package retrieval
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/store"
+	"go.kenn.io/docbank/internal/vectorindex"
+)
+
+type Backend interface {
+	VaultID() string
+	SearchExplainedLexicalCandidates(ctx context.Context, query string, limit int,
+		options store.SearchOptions) ([]store.ExplainedLexicalCandidate, bool, error)
+}
+
+type SemanticBackend interface {
+	AcquireSemanticSearchAuthority(ctx context.Context, profile, binding, owner string, at time.Time,
+		duration time.Duration, options store.SearchOptions) (store.SemanticSearchAuthority, error)
+	ResolveSemanticCandidates(ctx context.Context, profile, binding string, inputKind document.EmbeddingInputKind,
+		vectorSpace, sourceManifest string, neighbors []vectorindex.Neighbor, limit int,
+		options store.SearchOptions) (store.SemanticSearchResolution, error)
+	ReleaseVectorIndexGeneration(ctx context.Context, leaseID string, fencingToken int64, at time.Time) error
+}
+
+type QueryEncoderResolver interface {
+	ResolveQueryEncoder(ctx context.Context, descriptor document.EmbeddingDescriptor) (document.EmbeddingProvider, error)
+}
+
+type SearcherConfig struct {
+	Backend       Backend
+	Encoders      QueryEncoderResolver
+	Owner         string
+	LeaseDuration time.Duration
+	Clock         func() time.Time
+}
+
+type Searcher struct {
+	backend       Backend
+	encoders      QueryEncoderResolver
+	owner         string
+	leaseDuration time.Duration
+	clock         func() time.Time
+}
+
+func NewSearcher(config SearcherConfig) (*Searcher, error) {
+	if config.Backend == nil {
+		return nil, errors.New("retrieval backend is required")
+	}
+	if config.Owner == "" {
+		return nil, errors.New("retrieval owner is required")
+	}
+	if config.LeaseDuration <= 0 {
+		return nil, errors.New("retrieval vector lease duration must be positive")
+	}
+	if config.Clock == nil {
+		config.Clock = time.Now
+	}
+	return &Searcher{backend: config.Backend, encoders: config.Encoders, owner: config.Owner,
+		leaseDuration: config.LeaseDuration, clock: config.Clock}, nil
+}
+
+func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, error) {
+	query, err := normalizeQuery(query)
+	if err != nil {
+		return Report{}, err
+	}
+	requested := query.Mode
+	switch requested {
+	case ModeLexical:
+		return searcher.lexical(ctx, query, requested, DegradationNone, Coverage{State: CoverageUnknown})
+	case ModeSemantic:
+		semantic, coverage, truncated, err := searcher.semantic(ctx, query, false)
+		if err != nil {
+			return Report{}, err
+		}
+		return laneReport(requested, ModeSemantic, coverage, DegradationNone, semantic, truncated), nil
+	case ModeHybrid:
+		return searcher.hybrid(ctx, query, requested)
+	case ModeAuto:
+		semantic, coverage, semanticTruncated, semanticErr := searcher.semantic(ctx, query, true)
+		if semanticErr != nil {
+			degradable := &semanticDegradationError{}
+			ok := errors.As(semanticErr, &degradable)
+			if !ok {
+				return Report{}, semanticErr
+			}
+			return searcher.lexical(ctx, query, requested, degradable.degradation, coverage)
+		}
+		lexical, lexicalTruncated, err := searcher.collectLexical(ctx, query)
+		if err != nil {
+			return Report{}, err
+		}
+		return makeHybridReport(requested, coverage, lexical, semantic,
+			lexicalTruncated || semanticTruncated, query.Limit)
+	}
+	return Report{}, errors.New("unreachable retrieval mode")
+}
+
+type semanticDegradationError struct {
+	degradation Degradation
+	cause       error
+}
+
+type semanticReleaseError struct {
+	operation error
+	release   error
+}
+
+func (failure *semanticReleaseError) Error() string {
+	return fmt.Sprintf("%v; releasing semantic generation: %v", failure.operation, failure.release)
+}
+
+func (failure *semanticReleaseError) Unwrap() error { return failure.release }
+
+func (failure *semanticDegradationError) Error() string { return failure.cause.Error() }
+func (failure *semanticDegradationError) Unwrap() error { return failure.cause }
+
+func degradableSemanticFailure(degradation Degradation, cause error) error {
+	return &semanticDegradationError{degradation: degradation, cause: cause}
+}
+
+func (searcher *Searcher) hybrid(ctx context.Context, query Query, requested Mode) (Report, error) {
+	lexical, lexicalTruncated, err := searcher.collectLexical(ctx, query)
+	if err != nil {
+		return Report{}, err
+	}
+	semantic, coverage, semanticTruncated, err := searcher.semantic(ctx, query, false)
+	if err != nil {
+		return Report{}, err
+	}
+	return makeHybridReport(requested, coverage, lexical, semantic,
+		lexicalTruncated || semanticTruncated, query.Limit)
+}
+
+func (searcher *Searcher) semantic(ctx context.Context, query Query,
+	degradeIncompleteRequired bool,
+) (_ []Candidate, coverage Coverage, truncated bool, retErr error) {
+	backend, ok := searcher.backend.(SemanticBackend)
+	if !ok || searcher.encoders == nil {
+		return nil, Coverage{State: CoverageUnknown}, false, degradableSemanticFailure(
+			DegradationSemanticUnavailable, errors.New("semantic retrieval is not configured"))
+	}
+	authority, err := backend.AcquireSemanticSearchAuthority(ctx,
+		query.ProcessingProfileFingerprint, query.BindingID, searcher.owner,
+		searcher.clock().UTC(), searcher.leaseDuration, query.Scope)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, Coverage{State: CoverageUnknown}, false, degradableSemanticFailure(
+				DegradationSemanticUnavailable, err)
+		}
+		return nil, Coverage{State: CoverageUnknown}, false, err
+	}
+	defer func() {
+		if releaseErr := backend.ReleaseVectorIndexGeneration(context.WithoutCancel(ctx), authority.Lease.ID,
+			authority.Lease.FencingToken, searcher.clock().UTC()); releaseErr != nil {
+			if retErr == nil {
+				retErr = releaseErr
+			} else {
+				// A failed release makes the whole operation non-degradable even
+				// when the earlier provider stage could have fallen back safely.
+				retErr = &semanticReleaseError{operation: retErr, release: releaseErr}
+			}
+		}
+	}()
+	coverage = Coverage{BindingRequired: authority.BindingRequired,
+		ScopedDocuments: authority.ScopedDocuments, CompleteDocuments: authority.CompleteDocuments,
+		State: CoverageComplete}
+	if authority.CompleteDocuments != authority.ScopedDocuments {
+		coverage.State = CoverageIncomplete
+		if authority.BindingRequired && degradeIncompleteRequired {
+			return nil, coverage, false, degradableSemanticFailure(DegradationIncompleteCoverage,
+				errors.New("required semantic coverage is incomplete"))
+		}
+	}
+	provider, err := searcher.encoders.ResolveQueryEncoder(ctx, authority.VectorSpace.Descriptor)
+	if err != nil {
+		return nil, coverage, false, degradableSemanticFailure(DegradationProviderUnavailable, err)
+	}
+	if provider == nil {
+		return nil, coverage, false, degradableSemanticFailure(DegradationSemanticUnavailable,
+			errors.New("query encoder runtime is unavailable"))
+	}
+	if !reflect.DeepEqual(provider.Descriptor(), authority.VectorSpace.Descriptor) {
+		return nil, coverage, false, errors.New("query encoder does not reproduce the active vector-space descriptor")
+	}
+	if err := document.ValidateEmbeddingQueryCompatibility(authority.VectorSpace.Descriptor,
+		provider.Descriptor()); err != nil {
+		return nil, coverage, false, err
+	}
+	inputs := []document.EmbeddingInput{{Key: "query", Role: document.EmbeddingRoleQuery,
+		Kind: document.EmbeddingInputQueryText, Text: query.Text}}
+	if err := document.ValidateEmbeddingProviderRequest(provider, inputs, query.Authorization); err != nil {
+		return nil, coverage, false, err
+	}
+	embedded, err := document.ExecuteEmbedding(ctx, provider, inputs, query.Authorization)
+	if err != nil {
+		return nil, coverage, false, degradableSemanticFailure(DegradationProviderUnavailable, err)
+	}
+	stored := authority.Lease.Generation
+	generation, err := vectorindex.OpenGeneration(bytes.NewReader(stored.Bytes), int64(len(stored.Bytes)))
+	if err != nil {
+		return nil, coverage, false, err
+	}
+	metadata := generation.Metadata()
+	descriptor := authority.VectorSpace.Descriptor
+	if metadata.VectorSpaceID != authority.VectorSpace.ID || metadata.Dimension != descriptor.Dimension ||
+		metadata.Metric != descriptor.Metric || metadata.Normalization != descriptor.Normalization ||
+		metadata.Manifest.Checksum != stored.IndexManifestChecksum || metadata.RowCount != stored.RowCount {
+		return nil, coverage, false, errors.New("leased vector generation is incompatible with active query authority")
+	}
+	neighbors, err := generation.Search(embedded.Vectors[0].Values, metadata.RowCount)
+	if err != nil {
+		return nil, coverage, false, err
+	}
+	resolution, err := backend.ResolveSemanticCandidates(ctx, query.ProcessingProfileFingerprint,
+		query.BindingID, authority.InputKind, authority.VectorSpace.ID, stored.SourceManifestChecksum,
+		neighbors, query.Limit, query.Scope)
+	if err != nil {
+		return nil, coverage, false, err
+	}
+	if resolution.SourceManifestChecksum != stored.SourceManifestChecksum {
+		return nil, coverage, false, store.ErrVectorIndexSourceStale
+	}
+	coverage.ScopedDocuments = resolution.ScopedDocuments
+	coverage.CompleteDocuments = resolution.CompleteDocuments
+	coverage.State = CoverageComplete
+	if coverage.CompleteDocuments != coverage.ScopedDocuments {
+		coverage.State = CoverageIncomplete
+		if authority.BindingRequired && degradeIncompleteRequired {
+			return nil, coverage, false, degradableSemanticFailure(DegradationIncompleteCoverage,
+				errors.New("required semantic coverage became incomplete during retrieval"))
+		}
+	}
+	resolved := resolution.Candidates
+	candidates := make([]Candidate, len(resolved))
+	for index, item := range resolved {
+		if item.VectorSpaceID != authority.VectorSpace.ID {
+			return nil, coverage, false, errors.New("semantic result escaped the active vector space")
+		}
+		candidates[index] = Candidate{Document: DocumentIdentity{VaultID: item.VaultID,
+			NodeID: item.NodeID, ContentVersionID: item.ContentVersionID}, Lane: LaneSemantic,
+			Rank: index + 1, Score: item.Score, Path: item.Path, VectorSpaceID: item.VectorSpaceID,
+			Evidence: []EvidenceReference{{Kind: "embedding", VaultID: item.VaultID,
+				NodeID: item.NodeID, ContentVersionID: item.ContentVersionID,
+				VectorSpaceID: item.VectorSpaceID, EmbeddingSetID: item.EmbeddingSetID,
+				InputGenerationID: item.InputGenerationID, InputID: item.InputID,
+				InputKind: item.InputKind}}}
+	}
+	return candidates, coverage, resolution.Truncated, nil
+}
+
+func normalizeQuery(query Query) (Query, error) {
+	query.Text = strings.TrimSpace(query.Text)
+	if query.Text == "" {
+		return Query{}, errors.New("retrieval query text is required")
+	}
+	if query.Mode == "" {
+		query.Mode = ModeAuto
+	}
+	if query.Mode != ModeAuto && query.Mode != ModeLexical && query.Mode != ModeSemantic && query.Mode != ModeHybrid {
+		return Query{}, fmt.Errorf("unsupported retrieval mode %q", query.Mode)
+	}
+	if query.Limit == 0 {
+		query.Limit = DefaultCandidateLimit
+	}
+	if query.Limit < 1 || query.Limit > MaxCandidateLimit {
+		return Query{}, fmt.Errorf("retrieval candidate limit must be between 1 and %d", MaxCandidateLimit)
+	}
+	return query, nil
+}
+
+func (searcher *Searcher) collectLexical(ctx context.Context, query Query) ([]Candidate, bool, error) {
+	hits, truncated, err := searcher.backend.SearchExplainedLexicalCandidates(ctx, query.Text, query.Limit, query.Scope)
+	if err != nil {
+		return nil, false, err
+	}
+	candidates := make([]Candidate, len(hits))
+	for index, hit := range hits {
+		candidates[index] = Candidate{Document: DocumentIdentity{VaultID: searcher.backend.VaultID(),
+			NodeID: hit.Node.ID, ContentVersionID: hit.Node.CurrentVersionID}, Lane: LaneLexical,
+			Rank: index + 1, Path: hit.Path, Excerpt: hit.Excerpt,
+			Evidence: []EvidenceReference{{Kind: hit.EvidenceKind, VaultID: searcher.backend.VaultID(),
+				NodeID: hit.Node.ID, ContentVersionID: hit.Node.CurrentVersionID,
+				BuildID: hit.BuildID, SegmentID: hit.SegmentID, BlobHash: hit.BlobHash}}}
+	}
+	return candidates, truncated, nil
+}
+
+func laneReport(requested, actual Mode, coverage Coverage, degradation Degradation,
+	candidates []Candidate, truncated bool,
+) Report {
+	results := make([]Result, len(candidates))
+	for index, candidate := range candidates {
+		contribution := 1 / float64(ReciprocalRankK+candidate.Rank)
+		result := Result{Document: candidate.Document, Rank: index + 1, Score: contribution,
+			Path: candidate.Path, Excerpt: candidate.Excerpt, Evidence: candidate.Evidence,
+			Explanation: []Contribution{{Lane: candidate.Lane, Rank: candidate.Rank,
+				Contribution: contribution}}}
+		if candidate.Lane == LaneLexical {
+			result.LexicalRank = candidate.Rank
+		} else {
+			result.SemanticRank = candidate.Rank
+		}
+		results[index] = result
+	}
+	traceCode := TraceLexicalCandidates
+	if actual == ModeSemantic {
+		traceCode = TraceSemanticCandidates
+	}
+	return Report{RequestedMode: requested, ActualMode: actual, Coverage: coverage,
+		Degradation: degradation, Results: results, Truncated: truncated,
+		Trace: []TraceEvent{{Code: traceCode, Count: len(results)}}}
+}
+
+func makeHybridReport(requested Mode, coverage Coverage, lexical, semantic []Candidate,
+	upstreamTruncated bool, limit int,
+) (Report, error) {
+	results, fusedTruncated, err := FuseReciprocalRank(lexical, semantic, limit)
+	if err != nil {
+		return Report{}, err
+	}
+	return Report{RequestedMode: requested, ActualMode: ModeHybrid, Coverage: coverage,
+		Results: results, Truncated: upstreamTruncated || fusedTruncated,
+		Trace: []TraceEvent{{Code: TraceLexicalCandidates, Count: len(lexical)},
+			{Code: TraceSemanticCandidates, Count: len(semantic)},
+			{Code: TraceFusedCandidates, Count: len(results)}}}, nil
+}
+
+func (searcher *Searcher) lexical(ctx context.Context, query Query, requested Mode,
+	degradation Degradation, coverage Coverage,
+) (Report, error) {
+	candidates, truncated, err := searcher.collectLexical(ctx, query)
+	if err != nil {
+		return Report{}, err
+	}
+	return laneReport(requested, ModeLexical, coverage, degradation, candidates, truncated), nil
+}

--- a/internal/retrieval/search_test.go
+++ b/internal/retrieval/search_test.go
@@ -314,6 +314,8 @@ func retrievalSearcherFixture(t *testing.T, required bool, scoped int) (
 }
 
 type retrievalBackendStub struct {
+	lexicalTruncated       bool
+	semanticTruncated      bool
 	vaultID                string
 	lexical                []store.ExplainedLexicalCandidate
 	authority              store.SemanticSearchAuthority
@@ -349,6 +351,7 @@ func (backend *retrievalBackendStub) ResolveSemanticCandidates(_ context.Context
 		scoped, complete = backend.authority.ScopedDocuments, backend.authority.CompleteDocuments
 	}
 	return store.SemanticSearchResolution{
+		Truncated:              backend.semanticTruncated,
 		SourceManifestChecksum: sourceManifest,
 		Candidates:             append([]store.SemanticSearchCandidate(nil), backend.semantic...),
 		ScopedDocuments:        scoped, CompleteDocuments: complete,
@@ -449,7 +452,46 @@ func (backend *retrievalBackendStub) SearchExplainedLexicalCandidates(context.Co
 	store.SearchOptions,
 ) ([]store.ExplainedLexicalCandidate, bool, error) {
 	backend.lexicalCalls++
-	return append([]store.ExplainedLexicalCandidate(nil), backend.lexical...), false, nil
+	return append([]store.ExplainedLexicalCandidate(nil), backend.lexical...), backend.lexicalTruncated, nil
+}
+
+func TestSearcherHybridReportsLaneAndFusionTruncation(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		lexical, semantic bool
+		limit             int
+	}{
+		{"lexical lane", true, false, 3},
+		{"semantic lane", false, true, 3},
+		{"fused union", false, false, 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
+			backend.lexicalTruncated, backend.semanticTruncated = test.lexical, test.semantic
+			backend.lexical = []store.ExplainedLexicalCandidate{{
+				Node: store.Node{ID: 5, CurrentVersionID: "version-lexical"}, Path: "/notes.pdf",
+			}}
+			report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeHybrid,
+				Limit: test.limit, Authorization: retrievalAuthorization(descriptor)})
+			require.NoError(t, err)
+			assert.True(t, report.Truncated)
+			assert.Len(t, report.Results, min(test.limit, 2))
+		})
+	}
+}
+
+func TestFuseReciprocalRankTruncatesAfterNumericIdentityTieBreak(t *testing.T) {
+	results, truncated, err := FuseReciprocalRank([]Candidate{{
+		Document: DocumentIdentity{VaultID: "vault", NodeID: 10, ContentVersionID: "version-a"},
+		Lane:     LaneLexical, Rank: 1,
+	}}, []Candidate{{
+		Document: DocumentIdentity{VaultID: "vault", NodeID: 2, ContentVersionID: "version-b"},
+		Lane:     LaneSemantic, Rank: 1, VectorSpaceID: "space",
+	}}, 1)
+	require.NoError(t, err)
+	assert.True(t, truncated)
+	require.Len(t, results, 1)
+	assert.Equal(t, int64(2), results[0].Document.NodeID)
 }
 
 func TestFuseReciprocalRankPreservesExactLaneContributions(t *testing.T) {

--- a/internal/retrieval/search_test.go
+++ b/internal/retrieval/search_test.go
@@ -15,6 +15,35 @@ import (
 	"go.kenn.io/docbank/internal/vectorindex"
 )
 
+func TestSearcherEmbedsQueryOnlyForExplicitSemanticModes(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []Mode{"", ModeAuto, ModeLexical, ModeSemantic, ModeHybrid} {
+		t.Run(string(mode), func(t *testing.T) {
+			searcher, backend, provider, descriptor := retrievalSearcherFixture(t, true, 1)
+			backend.lexical = []store.ExplainedLexicalCandidate{{
+				Node: store.Node{ID: 5, CurrentVersionID: "version-lexical", Name: "notes.pdf"},
+				Path: "/notes.pdf", EvidenceKind: "node_name", Excerpt: "notes.pdf",
+			}}
+			report, err := searcher.Search(t.Context(), Query{Text: "synthetic query", Mode: mode,
+				ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+				Authorization: retrievalAuthorization(descriptor)})
+			require.NoError(t, err)
+			if mode == ModeSemantic || mode == ModeHybrid {
+				assert.Equal(t, 1, provider.calls)
+				assert.Equal(t, descriptor.ModelInput.EncodeQuery("synthetic query"), provider.rendered)
+				assert.Equal(t, mode, report.ActualMode)
+			} else {
+				assert.Zero(t, provider.calls)
+				assert.Empty(t, provider.rendered)
+				assert.True(t, backend.acquiredAt.IsZero(), "lexical requests must not acquire semantic authority")
+				assert.Equal(t, ModeLexical, report.ActualMode)
+				require.Len(t, report.Results, 1)
+				assert.Equal(t, "/notes.pdf", report.Results[0].Path)
+			}
+		})
+	}
+}
+
 func TestSearcherLexicalModePreservesStoreOrderAndStableEvidence(t *testing.T) {
 	t.Parallel()
 	backend := &retrievalBackendStub{vaultID: "vault", lexical: []store.ExplainedLexicalCandidate{
@@ -134,22 +163,7 @@ func TestSearcherHybridUsesRRFWithoutComparingRawScores(t *testing.T) {
 	assert.InDelta(t, 2.0/61.0, report.Results[0].Score, 1e-12)
 }
 
-func TestSearcherAutoDegradesRequiredCoverageBeforeProvider(t *testing.T) {
-	t.Parallel()
-	searcher, backend, provider, descriptor := retrievalSearcherFixture(t, true, 2)
-	backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 5,
-		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
-		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
-	report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
-		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
-		Authorization: retrievalAuthorization(descriptor)})
-	require.NoError(t, err)
-	assert.Equal(t, ModeLexical, report.ActualMode)
-	assert.Equal(t, DegradationIncompleteCoverage, report.Degradation)
-	assert.Zero(t, provider.calls)
-}
-
-func TestSearcherAutoDegradesProviderOutageButOptionalIncompleteCanHybrid(t *testing.T) {
+func TestSearcherExplicitSemanticModesReportProviderFailureAndCoverage(t *testing.T) {
 	t.Parallel()
 	t.Run("provider outage", func(t *testing.T) {
 		searcher, backend, provider, descriptor := retrievalSearcherFixture(t, true, 1)
@@ -157,16 +171,14 @@ func TestSearcherAutoDegradesProviderOutageButOptionalIncompleteCanHybrid(t *tes
 		backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 5,
 			CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
 			Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
-		report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+		_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeSemantic, Limit: 3,
 			ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
 			Authorization: retrievalAuthorization(descriptor)})
-		require.NoError(t, err)
-		assert.Equal(t, ModeLexical, report.ActualMode)
-		assert.Equal(t, DegradationProviderUnavailable, report.Degradation)
+		require.ErrorIs(t, err, provider.err)
 	})
 	t.Run("optional incomplete", func(t *testing.T) {
 		searcher, _, provider, descriptor := retrievalSearcherFixture(t, false, 2)
-		report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+		report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeHybrid, Limit: 3,
 			ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "optional",
 			Authorization: retrievalAuthorization(descriptor)})
 		require.NoError(t, err)
@@ -176,7 +188,7 @@ func TestSearcherAutoDegradesProviderOutageButOptionalIncompleteCanHybrid(t *tes
 	})
 }
 
-func TestSearcherAutoPropagatesCorruptLeasedIndex(t *testing.T) {
+func TestSearcherSemanticPropagatesCorruptLeasedIndex(t *testing.T) {
 	t.Parallel()
 	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
 	backend.authority.Lease.Generation.Bytes = []byte("corrupt-index")
@@ -184,7 +196,7 @@ func TestSearcherAutoPropagatesCorruptLeasedIndex(t *testing.T) {
 		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
 		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
 
-	_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+	_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeSemantic, Limit: 3,
 		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
 		Authorization: retrievalAuthorization(descriptor)})
 
@@ -192,7 +204,7 @@ func TestSearcherAutoPropagatesCorruptLeasedIndex(t *testing.T) {
 	assert.Zero(t, backend.lexicalCalls, "local index corruption must not be hidden by lexical degradation")
 }
 
-func TestSearcherAutoPropagatesLeaseReleaseFailure(t *testing.T) {
+func TestSearcherSemanticPropagatesLeaseReleaseFailure(t *testing.T) {
 	t.Parallel()
 	searcher, backend, provider, descriptor := retrievalSearcherFixture(t, true, 1)
 	provider.err = errors.New("synthetic provider outage")
@@ -201,7 +213,7 @@ func TestSearcherAutoPropagatesLeaseReleaseFailure(t *testing.T) {
 		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
 		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
 
-	_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+	_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeSemantic, Limit: 3,
 		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
 		Authorization: retrievalAuthorization(descriptor)})
 
@@ -236,7 +248,7 @@ func TestSearcherRejectsWrongStoredIndexManifestBeforeSearch(t *testing.T) {
 	assert.Zero(t, backend.neighborCount)
 }
 
-func TestSearcherAutoDegradesAbsentSemanticAuthority(t *testing.T) {
+func TestSearcherSemanticReportsAbsentAuthority(t *testing.T) {
 	t.Parallel()
 	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
 	backend.acquireErr = store.ErrNotFound
@@ -244,16 +256,15 @@ func TestSearcherAutoDegradesAbsentSemanticAuthority(t *testing.T) {
 		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
 		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
 
-	report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+	_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeSemantic, Limit: 3,
 		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
 		Authorization: retrievalAuthorization(descriptor)})
 
-	require.NoError(t, err)
-	assert.Equal(t, ModeLexical, report.ActualMode)
-	assert.Equal(t, DegradationSemanticUnavailable, report.Degradation)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	assert.Zero(t, backend.lexicalCalls)
 }
 
-func TestSearcherAutoDegradesWhenFinalCoverageBecomesIncomplete(t *testing.T) {
+func TestSearcherSemanticReportsFinalCoverage(t *testing.T) {
 	t.Parallel()
 	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
 	backend.finalScopedDocuments = 2
@@ -263,13 +274,13 @@ func TestSearcherAutoDegradesWhenFinalCoverageBecomesIncomplete(t *testing.T) {
 		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
 		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
 
-	report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+	report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeSemantic, Limit: 3,
 		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
 		Authorization: retrievalAuthorization(descriptor)})
 
 	require.NoError(t, err)
-	assert.Equal(t, ModeLexical, report.ActualMode)
-	assert.Equal(t, DegradationIncompleteCoverage, report.Degradation)
+	assert.Equal(t, ModeSemantic, report.ActualMode)
+	assert.Equal(t, CoverageIncomplete, report.Coverage.State)
 	assert.Equal(t, 2, report.Coverage.ScopedDocuments)
 	assert.Equal(t, 1, report.Coverage.CompleteDocuments)
 }

--- a/internal/retrieval/search_test.go
+++ b/internal/retrieval/search_test.go
@@ -1,0 +1,481 @@
+package retrieval
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/store"
+	"go.kenn.io/docbank/internal/vectorindex"
+)
+
+func TestSearcherLexicalModePreservesStoreOrderAndStableEvidence(t *testing.T) {
+	t.Parallel()
+	backend := &retrievalBackendStub{vaultID: "vault", lexical: []store.ExplainedLexicalCandidate{
+		{Node: store.Node{ID: 4, CurrentVersionID: "version-name", Name: "alpha.pdf"},
+			Path: "/alpha.pdf", Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "alpha.pdf"},
+		{Node: store.Node{ID: 2, CurrentVersionID: "version-content", Name: "notes.pdf"},
+			Path: "/notes.pdf", Match: store.SearchMatchContent, EvidenceKind: "rendition_segment",
+			BuildID: "build", SegmentID: "segment", Excerpt: "alpha excerpt"},
+	}}
+	searcher, err := NewSearcher(SearcherConfig{Backend: backend, Owner: "retrieval-test",
+		LeaseDuration: time.Minute, Clock: time.Now})
+	require.NoError(t, err)
+	report, err := searcher.Search(t.Context(), Query{Text: "alpha", Mode: ModeLexical, Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, ModeLexical, report.ActualMode)
+	require.Len(t, report.Results, 2)
+	assert.Equal(t, int64(4), report.Results[0].Document.NodeID)
+	assert.Equal(t, "alpha.pdf", report.Results[0].Excerpt)
+	assert.Equal(t, "version-content", report.Results[1].Evidence[0].ContentVersionID)
+	assert.Equal(t, "build", report.Results[1].Evidence[0].BuildID)
+	assert.Equal(t, "segment", report.Results[1].Evidence[0].SegmentID)
+	assert.Equal(t, "alpha excerpt", report.Results[1].Excerpt)
+}
+
+func TestSearcherSemanticUsesExactDescriptorAndExhaustsLeasedGeneration(t *testing.T) {
+	t.Parallel()
+	descriptor, generation := retrievalVectorFixture(t)
+	backend := &retrievalBackendStub{vaultID: "vault", authority: store.SemanticSearchAuthority{
+		VectorSpace: store.EmbeddingVectorSpaceRecord{ID: generation.Metadata().VectorSpaceID, Descriptor: descriptor},
+		Lease: store.VectorIndexReaderLease{ID: "lease", FencingToken: 4,
+			Generation: store.VectorIndexGenerationRecord{ID: strings.Repeat("1", 64),
+				VectorSpaceID: generation.Metadata().VectorSpaceID, Bytes: generation.Bytes(),
+				SourceManifestChecksum: strings.Repeat("c", 64),
+				IndexManifestChecksum:  generation.Metadata().Manifest.Checksum,
+				RowCount:               generation.Metadata().RowCount}},
+		InputKind: document.EmbeddingInputOriginalFile, BindingRequired: true,
+		ScopedDocuments: 1, CompleteDocuments: 1,
+	}, semantic: []store.SemanticSearchCandidate{{VaultID: "vault", NodeID: 8,
+		ContentVersionID: "version-semantic", Path: "/semantic.pdf",
+		VectorSpaceID: generation.Metadata().VectorSpaceID, EmbeddingSetID: "set",
+		InputGenerationID: "generation", InputID: "input",
+		InputKind: document.EmbeddingInputOriginalFile, Score: 0.9}}}
+	provider := &retrievalProvider{descriptor: descriptor, vector: []float32{1, 0}}
+	resolver := &retrievalResolver{provider: provider}
+	clockCalls := 0
+	start := time.Date(2026, 8, 26, 13, 0, 0, 0, time.UTC)
+	searcher, err := NewSearcher(SearcherConfig{Backend: backend, Encoders: resolver,
+		Owner: "retrieval-test", LeaseDuration: time.Minute, Clock: func() time.Time {
+			clockCalls++
+			return start.Add(time.Duration(clockCalls) * time.Second)
+		}})
+	require.NoError(t, err)
+	report, err := searcher.Search(t.Context(), Query{Text: "semantic query", Mode: ModeSemantic,
+		Limit: 1, ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+	require.NoError(t, err)
+	assert.Equal(t, descriptor, resolver.requested)
+	assert.Equal(t, descriptor.ModelInput.EncodeQuery("semantic query"), provider.rendered)
+	assert.Equal(t, backend.authority.Lease.Generation.SourceManifestChecksum, backend.sourceManifest)
+	assert.Equal(t, generation.Metadata().RowCount, backend.neighborCount)
+	assert.True(t, backend.releasedAt.After(backend.acquiredAt))
+	assert.Equal(t, ModeSemantic, report.ActualMode)
+	require.Len(t, report.Results, 1)
+	assert.Empty(t, report.Results[0].Excerpt)
+	assert.Equal(t, document.EmbeddingInputOriginalFile, report.Results[0].Evidence[0].InputKind)
+}
+
+func TestSearcherRejectsChangedQueryModelInputBeforeProviderOrIndex(t *testing.T) {
+	t.Parallel()
+	persisted, generation := retrievalVectorFixture(t)
+	changedContract, err := document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfileCustom, CompatibilityID: persisted.CompatibilityID,
+		Document: persisted.ModelInput.Document,
+		Query:    document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "changed: {{content}}"},
+	})
+	require.NoError(t, err)
+	changed := persisted
+	changed.ModelInput, changed.Fingerprint = changedContract, ""
+	changed, err = document.NewEmbeddingDescriptor(changed)
+	require.NoError(t, err)
+	backend := &retrievalBackendStub{vaultID: "vault", authority: store.SemanticSearchAuthority{
+		VectorSpace: store.EmbeddingVectorSpaceRecord{ID: generation.Metadata().VectorSpaceID, Descriptor: persisted},
+		Lease: store.VectorIndexReaderLease{ID: "lease", FencingToken: 1,
+			Generation: store.VectorIndexGenerationRecord{ID: strings.Repeat("4", 64),
+				VectorSpaceID: generation.Metadata().VectorSpaceID, Bytes: generation.Bytes(),
+				SourceManifestChecksum: strings.Repeat("c", 64),
+				IndexManifestChecksum:  generation.Metadata().Manifest.Checksum,
+				RowCount:               generation.Metadata().RowCount}},
+		ScopedDocuments: 1, CompleteDocuments: 1}}
+	provider := &retrievalProvider{descriptor: changed, vector: []float32{1, 0}}
+	searcher, err := NewSearcher(SearcherConfig{Backend: backend,
+		Encoders: &retrievalResolver{provider: provider}, Owner: "retrieval-test",
+		LeaseDuration: time.Minute, Clock: time.Now})
+	require.NoError(t, err)
+	_, err = searcher.Search(t.Context(), Query{Text: "query", Mode: ModeSemantic, Limit: 1,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(persisted)})
+	require.ErrorContains(t, err, "does not reproduce")
+	assert.Zero(t, provider.calls)
+	assert.Zero(t, backend.neighborCount)
+}
+
+func TestSearcherHybridUsesRRFWithoutComparingRawScores(t *testing.T) {
+	t.Parallel()
+	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
+	backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 8,
+		CurrentVersionID: "version-semantic", Name: "semantic.pdf"}, Path: "/semantic.pdf",
+		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "semantic.pdf"}}
+	report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeHybrid, Limit: 3,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+	require.NoError(t, err)
+	assert.Equal(t, ModeHybrid, report.ActualMode)
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, 1, report.Results[0].LexicalRank)
+	assert.Equal(t, 1, report.Results[0].SemanticRank)
+	assert.InDelta(t, 2.0/61.0, report.Results[0].Score, 1e-12)
+}
+
+func TestSearcherAutoDegradesRequiredCoverageBeforeProvider(t *testing.T) {
+	t.Parallel()
+	searcher, backend, provider, descriptor := retrievalSearcherFixture(t, true, 2)
+	backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 5,
+		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
+		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
+	report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+	require.NoError(t, err)
+	assert.Equal(t, ModeLexical, report.ActualMode)
+	assert.Equal(t, DegradationIncompleteCoverage, report.Degradation)
+	assert.Zero(t, provider.calls)
+}
+
+func TestSearcherAutoDegradesProviderOutageButOptionalIncompleteCanHybrid(t *testing.T) {
+	t.Parallel()
+	t.Run("provider outage", func(t *testing.T) {
+		searcher, backend, provider, descriptor := retrievalSearcherFixture(t, true, 1)
+		provider.err = errors.New("synthetic outage")
+		backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 5,
+			CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
+			Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
+		report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+			ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+			Authorization: retrievalAuthorization(descriptor)})
+		require.NoError(t, err)
+		assert.Equal(t, ModeLexical, report.ActualMode)
+		assert.Equal(t, DegradationProviderUnavailable, report.Degradation)
+	})
+	t.Run("optional incomplete", func(t *testing.T) {
+		searcher, _, provider, descriptor := retrievalSearcherFixture(t, false, 2)
+		report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+			ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "optional",
+			Authorization: retrievalAuthorization(descriptor)})
+		require.NoError(t, err)
+		assert.Equal(t, ModeHybrid, report.ActualMode)
+		assert.Equal(t, CoverageIncomplete, report.Coverage.State)
+		assert.Equal(t, 1, provider.calls)
+	})
+}
+
+func TestSearcherAutoPropagatesCorruptLeasedIndex(t *testing.T) {
+	t.Parallel()
+	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
+	backend.authority.Lease.Generation.Bytes = []byte("corrupt-index")
+	backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 5,
+		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
+		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
+
+	_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+
+	require.Error(t, err)
+	assert.Zero(t, backend.lexicalCalls, "local index corruption must not be hidden by lexical degradation")
+}
+
+func TestSearcherAutoPropagatesLeaseReleaseFailure(t *testing.T) {
+	t.Parallel()
+	searcher, backend, provider, descriptor := retrievalSearcherFixture(t, true, 1)
+	provider.err = errors.New("synthetic provider outage")
+	backend.releaseErr = errors.New("synthetic lease release failure")
+	backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 5,
+		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
+		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
+
+	_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+
+	require.ErrorContains(t, err, "lease release failure")
+	assert.Zero(t, backend.lexicalCalls, "a lease failure must not be hidden by lexical degradation")
+}
+
+func TestSearcherReleasesLeaseAfterCallerCancellation(t *testing.T) {
+	t.Parallel()
+	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := searcher.Search(ctx, Query{Text: "query", Mode: ModeSemantic, Limit: 3,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NoError(t, backend.releaseContextErr)
+}
+
+func TestSearcherRejectsWrongStoredIndexManifestBeforeSearch(t *testing.T) {
+	t.Parallel()
+	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
+	backend.authority.Lease.Generation.IndexManifestChecksum = strings.Repeat("d", 64)
+
+	_, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeSemantic, Limit: 3,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+
+	require.ErrorContains(t, err, "leased vector generation is incompatible")
+	assert.Zero(t, backend.neighborCount)
+}
+
+func TestSearcherAutoDegradesAbsentSemanticAuthority(t *testing.T) {
+	t.Parallel()
+	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
+	backend.acquireErr = store.ErrNotFound
+	backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 5,
+		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
+		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
+
+	report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+
+	require.NoError(t, err)
+	assert.Equal(t, ModeLexical, report.ActualMode)
+	assert.Equal(t, DegradationSemanticUnavailable, report.Degradation)
+}
+
+func TestSearcherAutoDegradesWhenFinalCoverageBecomesIncomplete(t *testing.T) {
+	t.Parallel()
+	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
+	backend.finalScopedDocuments = 2
+	backend.finalCompleteDocuments = 1
+	backend.finalCoverageSet = true
+	backend.lexical = []store.ExplainedLexicalCandidate{{Node: store.Node{ID: 5,
+		CurrentVersionID: "version-lexical", Name: "lexical.pdf"}, Path: "/lexical.pdf",
+		Match: store.SearchMatchName, EvidenceKind: "node_name", Excerpt: "lexical.pdf"}}
+
+	report, err := searcher.Search(t.Context(), Query{Text: "query", Mode: ModeAuto, Limit: 3,
+		ProcessingProfileFingerprint: strings.Repeat("a", 64), BindingID: "required",
+		Authorization: retrievalAuthorization(descriptor)})
+
+	require.NoError(t, err)
+	assert.Equal(t, ModeLexical, report.ActualMode)
+	assert.Equal(t, DegradationIncompleteCoverage, report.Degradation)
+	assert.Equal(t, 2, report.Coverage.ScopedDocuments)
+	assert.Equal(t, 1, report.Coverage.CompleteDocuments)
+}
+
+func retrievalSearcherFixture(t *testing.T, required bool, scoped int) (
+	*Searcher, *retrievalBackendStub, *retrievalProvider, document.EmbeddingDescriptor,
+) {
+	t.Helper()
+	descriptor, generation := retrievalVectorFixture(t)
+	backend := &retrievalBackendStub{vaultID: "vault", authority: store.SemanticSearchAuthority{
+		VectorSpace: store.EmbeddingVectorSpaceRecord{ID: generation.Metadata().VectorSpaceID, Descriptor: descriptor},
+		Lease: store.VectorIndexReaderLease{ID: "lease", FencingToken: 1,
+			Generation: store.VectorIndexGenerationRecord{ID: strings.Repeat("5", 64),
+				VectorSpaceID: generation.Metadata().VectorSpaceID, Bytes: generation.Bytes(),
+				SourceManifestChecksum: strings.Repeat("c", 64),
+				IndexManifestChecksum:  generation.Metadata().Manifest.Checksum,
+				RowCount:               generation.Metadata().RowCount}},
+		BindingRequired: required,
+		ScopedDocuments: scoped, CompleteDocuments: 1,
+	}, semantic: []store.SemanticSearchCandidate{{VaultID: "vault", NodeID: 8,
+		ContentVersionID: "version-semantic", Path: "/semantic.pdf",
+		VectorSpaceID: generation.Metadata().VectorSpaceID, EmbeddingSetID: "set",
+		InputGenerationID: "generation", InputID: "input",
+		InputKind: document.EmbeddingInputOriginalFile, Score: 999}}}
+	provider := &retrievalProvider{descriptor: descriptor, vector: []float32{1, 0}}
+	searcher, err := NewSearcher(SearcherConfig{Backend: backend,
+		Encoders: &retrievalResolver{provider: provider}, Owner: "retrieval-test",
+		LeaseDuration: time.Minute, Clock: time.Now})
+	require.NoError(t, err)
+	return searcher, backend, provider, descriptor
+}
+
+type retrievalBackendStub struct {
+	vaultID                string
+	lexical                []store.ExplainedLexicalCandidate
+	authority              store.SemanticSearchAuthority
+	semantic               []store.SemanticSearchCandidate
+	acquireErr             error
+	neighborCount          int
+	sourceManifest         string
+	acquiredAt             time.Time
+	releasedAt             time.Time
+	lexicalCalls           int
+	releaseErr             error
+	releaseContextErr      error
+	finalScopedDocuments   int
+	finalCompleteDocuments int
+	finalCoverageSet       bool
+}
+
+func (backend *retrievalBackendStub) AcquireSemanticSearchAuthority(_ context.Context, _, _, _ string,
+	at time.Time, _ time.Duration, _ store.SearchOptions,
+) (store.SemanticSearchAuthority, error) {
+	backend.acquiredAt = at
+	return backend.authority, backend.acquireErr
+}
+
+func (backend *retrievalBackendStub) ResolveSemanticCandidates(_ context.Context, _, _ string,
+	_ document.EmbeddingInputKind, _, sourceManifest string, neighbors []vectorindex.Neighbor,
+	_ int, _ store.SearchOptions,
+) (store.SemanticSearchResolution, error) {
+	backend.neighborCount = len(neighbors)
+	backend.sourceManifest = sourceManifest
+	scoped, complete := backend.finalScopedDocuments, backend.finalCompleteDocuments
+	if !backend.finalCoverageSet {
+		scoped, complete = backend.authority.ScopedDocuments, backend.authority.CompleteDocuments
+	}
+	return store.SemanticSearchResolution{
+		SourceManifestChecksum: sourceManifest,
+		Candidates:             append([]store.SemanticSearchCandidate(nil), backend.semantic...),
+		ScopedDocuments:        scoped, CompleteDocuments: complete,
+	}, nil
+}
+
+func (backend *retrievalBackendStub) ReleaseVectorIndexGeneration(ctx context.Context, _ string,
+	_ int64, at time.Time,
+) error {
+	backend.releasedAt = at
+	backend.releaseContextErr = ctx.Err()
+	return backend.releaseErr
+}
+
+type retrievalResolver struct {
+	provider  document.EmbeddingProvider
+	err       error
+	requested document.EmbeddingDescriptor
+}
+
+func (resolver *retrievalResolver) ResolveQueryEncoder(_ context.Context,
+	descriptor document.EmbeddingDescriptor,
+) (document.EmbeddingProvider, error) {
+	resolver.requested = descriptor
+	return resolver.provider, resolver.err
+}
+
+type retrievalProvider struct {
+	descriptor document.EmbeddingDescriptor
+	vector     []float32
+	err        error
+	calls      int
+	rendered   string
+}
+
+func (provider *retrievalProvider) Descriptor() document.EmbeddingDescriptor {
+	return provider.descriptor
+}
+
+func (provider *retrievalProvider) Embed(_ context.Context, inputs []document.EmbeddingInput,
+	_ document.EmbeddingAuthorization,
+) (document.EmbeddingResult, error) {
+	provider.calls++
+	provider.rendered = provider.descriptor.ModelInput.EncodeQuery(inputs[0].Text)
+	if provider.err != nil {
+		return document.EmbeddingResult{}, provider.err
+	}
+	return document.EmbeddingResult{Vectors: []document.EmbeddingVector{{
+		Key: inputs[0].Key, Values: append([]float32(nil), provider.vector...),
+	}}}, nil
+}
+
+func retrievalAuthorization(descriptor document.EmbeddingDescriptor) document.EmbeddingAuthorization {
+	return document.EmbeddingAuthorization{ProviderID: descriptor.ID,
+		DescriptorFingerprint: descriptor.Fingerprint, PolicyFingerprint: descriptor.PolicyFingerprint,
+		MaxBatchItems: 1, MaxInputBytes: 1 << 20, MaxResponseBytes: 1 << 20}
+}
+
+func retrievalVectorFixture(t *testing.T) (document.EmbeddingDescriptor, *vectorindex.Generation) {
+	t.Helper()
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfileCustom, CompatibilityID: "retrieval-test-space",
+		Document: document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "document: {{content}}"},
+		Query:    document.ModelInputEncoder{Mode: document.ModelInputModeText, Template: "query: {{content}}"},
+	})
+	require.NoError(t, err)
+	descriptor, err := document.NewEmbeddingDescriptor(document.EmbeddingDescriptor{
+		ID: "retrieval-test", ContractVersion: document.EmbeddingProviderContractVersion,
+		PolicyFingerprint: strings.Repeat("a", 64), TrustBoundary: document.EmbeddingTrustLocalProcess,
+		Model: "synthetic", ModelRevision: "v1", Dimension: 2, Metric: document.VectorMetricCosine,
+		Normalization: document.VectorNormalizationUnitLength, ScalarEncoding: "float32",
+		DocumentFormatter: "document/v1", QueryFormatter: "query/v1",
+		InputKinds:      []document.EmbeddingInputKind{document.EmbeddingInputOriginalFile},
+		CompatibilityID: contract.CompatibilityID, SupportsTextQuery: true, ModelInput: contract,
+		SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeText},
+	})
+	require.NoError(t, err)
+	space := strings.Repeat("b", 64)
+	set := document.VectorSetV1{VectorSpaceFingerprint: space, Metric: descriptor.Metric,
+		Normalization: descriptor.Normalization, Dimension: 2,
+		InputKeys:      []string{"one", "two", "three"},
+		InputChecksums: []string{strings.Repeat("1", 64), strings.Repeat("2", 64), strings.Repeat("3", 64)},
+		Vectors:        [][]float32{{1, 0}, {0, 1}, {-1, 0}}}
+	_, setID, err := document.EncodeVectorSetV1(set)
+	require.NoError(t, err)
+	manifest, err := vectorindex.NewManifest([]string{setID})
+	require.NoError(t, err)
+	generation, err := vectorindex.BuildGeneration(manifest, []document.VectorSetV1{set}, vectorindex.Options{})
+	require.NoError(t, err)
+	opened, err := vectorindex.OpenGeneration(bytes.NewReader(generation.Bytes()), int64(len(generation.Bytes())))
+	require.NoError(t, err)
+	return descriptor, opened
+}
+
+func (backend *retrievalBackendStub) VaultID() string { return backend.vaultID }
+
+func (backend *retrievalBackendStub) SearchExplainedLexicalCandidates(context.Context, string, int,
+	store.SearchOptions,
+) ([]store.ExplainedLexicalCandidate, bool, error) {
+	backend.lexicalCalls++
+	return append([]store.ExplainedLexicalCandidate(nil), backend.lexical...), false, nil
+}
+
+func TestFuseReciprocalRankPreservesExactLaneContributions(t *testing.T) {
+	t.Parallel()
+
+	shared := DocumentIdentity{VaultID: "vault", NodeID: 7, ContentVersionID: "version-a"}
+	lexicalOnly := DocumentIdentity{VaultID: "vault", NodeID: 13, ContentVersionID: "version-b"}
+	semanticOnly := DocumentIdentity{VaultID: "vault", NodeID: 9, ContentVersionID: "version-c"}
+	results, truncated, err := FuseReciprocalRank([]Candidate{
+		{Document: shared, Lane: LaneLexical, Rank: 1},
+		{Document: lexicalOnly, Lane: LaneLexical, Rank: 2},
+	}, []Candidate{
+		{Document: semanticOnly, Lane: LaneSemantic, Rank: 1, VectorSpaceID: "space"},
+		{Document: shared, Lane: LaneSemantic, Rank: 2, VectorSpaceID: "space"},
+	}, 3)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, results, 3)
+	assert.Equal(t, shared, results[0].Document)
+	assert.Equal(t, 1, results[0].LexicalRank)
+	assert.Equal(t, 2, results[0].SemanticRank)
+	assert.InDelta(t, 1.0/61.0, results[0].Explanation[0].Contribution, 1e-12)
+	assert.InDelta(t, 1.0/62.0, results[0].Explanation[1].Contribution, 1e-12)
+	assert.Equal(t, semanticOnly, results[1].Document,
+		"equal RRF scores use stable document identity, never raw lane score")
+}
+
+func TestFuseReciprocalRankRejectsMixedSemanticVectorSpaces(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := FuseReciprocalRank(nil, []Candidate{
+		{Document: DocumentIdentity{VaultID: "vault", NodeID: 1, ContentVersionID: "version-a"},
+			Lane: LaneSemantic, Rank: 1, VectorSpaceID: "space-a",
+			Evidence: []EvidenceReference{{Kind: "embedding", VectorSpaceID: "space-a"}}},
+		{Document: DocumentIdentity{VaultID: "vault", NodeID: 2, ContentVersionID: "version-b"},
+			Lane: LaneSemantic, Rank: 2, VectorSpaceID: "space-b",
+			Evidence: []EvidenceReference{{Kind: "embedding", VectorSpaceID: "space-b"}}},
+	}, 2)
+	require.ErrorContains(t, err, "one active vector space")
+}

--- a/internal/retrieval/types.go
+++ b/internal/retrieval/types.go
@@ -1,0 +1,135 @@
+package retrieval
+
+import (
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/store"
+)
+
+const (
+	DefaultCandidateLimit = 100
+	MaxCandidateLimit     = document.MaxRetrievalCandidateLimit
+	ReciprocalRankK       = 60
+)
+
+type Mode string
+
+const (
+	ModeAuto     Mode = "auto"
+	ModeLexical  Mode = "lexical"
+	ModeSemantic Mode = "semantic"
+	ModeHybrid   Mode = "hybrid"
+)
+
+type Lane string
+
+const (
+	LaneLexical  Lane = "lexical"
+	LaneSemantic Lane = "semantic"
+)
+
+type DocumentIdentity struct {
+	VaultID          string
+	NodeID           int64
+	ContentVersionID string
+}
+
+type EvidenceReference struct {
+	Kind              string
+	VaultID           string
+	NodeID            int64
+	ContentVersionID  string
+	VectorSpaceID     string
+	EmbeddingSetID    string
+	InputGenerationID string
+	InputID           string
+	InputKind         document.EmbeddingInputKind
+	BuildID           string
+	SegmentID         string
+	BlobHash          string
+}
+
+type Candidate struct {
+	Document      DocumentIdentity
+	Lane          Lane
+	Rank          int
+	Score         float64
+	VectorSpaceID string
+	Path          string
+	Excerpt       string
+	Evidence      []EvidenceReference
+}
+
+type Contribution struct {
+	Lane         Lane
+	Rank         int
+	Contribution float64
+}
+
+type Result struct {
+	Document     DocumentIdentity
+	Rank         int
+	Score        float64
+	Path         string
+	Excerpt      string
+	LexicalRank  int
+	SemanticRank int
+	Evidence     []EvidenceReference
+	Explanation  []Contribution
+}
+
+type CoverageState string
+
+const (
+	CoverageUnknown    CoverageState = "unknown"
+	CoverageComplete   CoverageState = "complete"
+	CoverageIncomplete CoverageState = "incomplete"
+)
+
+type Coverage struct {
+	BindingRequired   bool
+	ScopedDocuments   int
+	CompleteDocuments int
+	State             CoverageState
+}
+
+type Degradation string
+
+const (
+	DegradationNone                Degradation = ""
+	DegradationIncompleteCoverage  Degradation = "incomplete_semantic_coverage"
+	DegradationProviderUnavailable Degradation = "query_provider_unavailable"
+	DegradationSemanticUnavailable Degradation = "semantic_authority_unavailable"
+)
+
+type TraceCode string
+
+const (
+	TraceLexicalCandidates  TraceCode = "lexical_candidates"
+	TraceSemanticCandidates TraceCode = "semantic_candidates"
+	TraceFusedCandidates    TraceCode = "fused_candidates"
+)
+
+type TraceEvent struct {
+	Code  TraceCode
+	Count int
+}
+
+type Report struct {
+	RequestedMode Mode
+	ActualMode    Mode
+	Coverage      Coverage
+	Degradation   Degradation
+	Results       []Result
+	Truncated     bool
+	Trace         []TraceEvent
+}
+
+type Query struct {
+	Text                         string
+	Mode                         Mode
+	Limit                        int
+	Scope                        store.SearchOptions
+	ProcessingProfileFingerprint string
+	BindingID                    string
+	Authorization                document.EmbeddingAuthorization
+}

--- a/internal/retrieval/types.go
+++ b/internal/retrieval/types.go
@@ -2,13 +2,14 @@ package retrieval
 
 import (
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/embedding"
 	"go.kenn.io/docbank/internal/store"
 )
 
 const (
-	DefaultCandidateLimit = 100
-	MaxCandidateLimit     = document.MaxRetrievalCandidateLimit
-	ReciprocalRankK       = 60
+	DefaultCandidateLimit = embedding.DefaultCandidateLimit
+	MaxCandidateLimit     = embedding.MaxCandidateLimit
+	ReciprocalRankK       = embedding.DefaultReciprocalRankConstant
 )
 
 type Mode string
@@ -92,15 +93,6 @@ type Coverage struct {
 	State             CoverageState
 }
 
-type Degradation string
-
-const (
-	DegradationNone                Degradation = ""
-	DegradationIncompleteCoverage  Degradation = "incomplete_semantic_coverage"
-	DegradationProviderUnavailable Degradation = "query_provider_unavailable"
-	DegradationSemanticUnavailable Degradation = "semantic_authority_unavailable"
-)
-
 type TraceCode string
 
 const (
@@ -118,7 +110,6 @@ type Report struct {
 	RequestedMode Mode
 	ActualMode    Mode
 	Coverage      Coverage
-	Degradation   Degradation
 	Results       []Result
 	Truncated     bool
 	Trace         []TraceEvent

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -29,7 +29,7 @@ type SearchHit struct {
 }
 
 // ExplainedLexicalCandidate adds stable evidence identity and a bounded
-// display excerpt without changing the established SearchHit ordering.
+// display excerpt for files, preserving name-before-content ordering.
 type ExplainedLexicalCandidate struct {
 	Node         Node
 	Path         string
@@ -43,7 +43,7 @@ type ExplainedLexicalCandidate struct {
 
 const maxExplainedSearchExcerptRunes = 512
 
-// SearchExplainedLexicalCandidates preserves SearchPageWithOptions ordering.
+// SearchExplainedLexicalCandidates preserves SearchPageWithOptions file ordering.
 // Content selection and evidence resolution share one lexical-generation read.
 func (s *Store) SearchExplainedLexicalCandidates(ctx context.Context, query string, limit int,
 	opts SearchOptions,
@@ -229,8 +229,7 @@ func SearchNeedsQuery(query string, opts SearchOptions) bool {
 }
 
 // SemanticSearchCandidate is one vector neighbor reduced to a current,
-// scope-eligible document. Excerpt is intentionally empty: only an independent
-// lexical lane may supply text to an explained retrieval report.
+// scope-eligible document. Only the lexical lane supplies excerpts.
 type SemanticSearchCandidate struct {
 	VaultID           string
 	NodeID            int64
@@ -242,8 +241,6 @@ type SemanticSearchCandidate struct {
 	InputID           string
 	InputKind         document.EmbeddingInputKind
 	Score             float64
-	Distance          float64
-	Excerpt           string
 }
 
 // SemanticSearchResolution binds ranked candidates and coverage to the same
@@ -411,6 +408,13 @@ func (s *Store) ResolveSemanticCandidates(ctx context.Context, profileFingerprin
 		}
 		result.Candidates, result.Truncated = reduceSemanticCandidates(s.vaultID, vectorSpaceID,
 			neighbors, limit, eligible)
+		for index := range result.Candidates {
+			candidate := &result.Candidates[index]
+			candidate.Path, err = pathOf(ctx, tx, candidate.NodeID)
+			if err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {
@@ -425,27 +429,16 @@ type semanticEligibilityKey struct {
 	InputChecksum string
 }
 
-type semanticEligibility struct {
-	Node      Node
-	Path      string
-	Candidate SemanticSearchCandidate
-}
-
 // loadSemanticEligibility performs the only catalog query needed while the
 // exact index's ordered neighbors are reduced. Its result is bounded by the
 // active vector-space catalog (at most one million rows), not by neighbor rank.
 func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, profileFingerprint, bindingID string,
 	inputKind document.EmbeddingInputKind, vectorSpaceID, filterSQL string, filterArgs []any,
-) (_ map[semanticEligibilityKey]semanticEligibility, retErr error) {
+) (_ map[semanticEligibilityKey]SemanticSearchCandidate, retErr error) {
 	args := append([]any{vectorSpaceID, profileFingerprint, bindingID, inputKind}, filterArgs...)
-	rows, err := tx.QueryContext(ctx, `WITH RECURSIVE node_paths(id,path) AS (
-		SELECT id,'' FROM nodes WHERE parent_id IS NULL
-		UNION ALL
-		SELECT child.id,parent.path || '/' || child.name
-		FROM nodes child JOIN node_paths parent ON child.parent_id=parent.id
-	)
-		SELECT `+nodeCols+`,es.embedding_set_id,es.input_generation_id,es.input_kind,
-			evr.vector_set_id,evr.input_id,evr.checksum,COALESCE(NULLIF(node_paths.path,''),'/')
+	rows, err := tx.QueryContext(ctx, `SELECT n.id,n.current_version_id,
+			es.embedding_set_id,es.input_generation_id,es.input_kind,
+			evr.vector_set_id,evr.input_id,evr.checksum
 		FROM `+nodeFrom+`
 		JOIN embedding_sets es ON es.content_version_id=cv.version_id
 		JOIN embedding_heads eh ON eh.content_version_id=es.content_version_id
@@ -456,7 +449,6 @@ func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, profileFin
 		JOIN embedding_generation_inputs egi ON egi.generation_id=es.input_generation_id
 		 AND egi.input_id=evr.input_id AND egi.rendered_checksum=evr.checksum
 		JOIN embedding_input_generations eig ON eig.generation_id=es.input_generation_id
-		JOIN node_paths ON node_paths.id=n.id
 		WHERE es.vector_space_id=?
 		  AND es.profile_fingerprint=? AND es.binding_id=? AND es.input_kind=?
 		  AND n.current_version_id=es.content_version_id AND n.trashed_at IS NULL
@@ -471,25 +463,23 @@ func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, profileFin
 		return nil, err
 	}
 	defer func() { retErr = errors.Join(retErr, rows.Close()) }()
-	eligible := make(map[semanticEligibilityKey]semanticEligibility)
+	eligible := make(map[semanticEligibilityKey]SemanticSearchCandidate)
 	for rows.Next() {
 		var (
-			entry semanticEligibility
+			entry SemanticSearchCandidate
 			key   semanticEligibilityKey
 		)
-		node, scanErr := scanSemanticCandidate(rows, &entry.Candidate,
-			&key.VectorSetID, &key.InputID, &key.InputChecksum, &entry.Path)
-		if scanErr != nil {
-			return nil, scanErr
+		if err := rows.Scan(&entry.NodeID, &entry.ContentVersionID, &entry.EmbeddingSetID,
+			&entry.InputGenerationID, &entry.InputKind, &key.VectorSetID, &key.InputID, &key.InputChecksum); err != nil {
+			return nil, err
 		}
-		entry.Node = node
 		eligible[key] = entry
 	}
 	return eligible, rows.Err()
 }
 
 func reduceSemanticCandidates(vaultID, vectorSpaceID string, neighbors []vectorindex.Neighbor,
-	limit int, eligible map[semanticEligibilityKey]semanticEligibility,
+	limit int, eligible map[semanticEligibilityKey]SemanticSearchCandidate,
 ) ([]SemanticSearchCandidate, bool) {
 	seen := make(map[int64]struct{}, limit+1)
 	candidates := make([]SemanticSearchCandidate, 0, min(limit+1, len(eligible)))
@@ -499,42 +489,21 @@ func reduceSemanticCandidates(vaultID, vectorSpaceID string, neighbors []vectori
 		if !ok {
 			continue
 		}
-		if _, duplicate := seen[entry.Node.ID]; duplicate {
+		if _, duplicate := seen[entry.NodeID]; duplicate {
 			continue
 		}
-		seen[entry.Node.ID] = struct{}{}
-		candidate := entry.Candidate
+		seen[entry.NodeID] = struct{}{}
+		candidate := entry
 		candidate.VaultID = vaultID
-		candidate.NodeID = entry.Node.ID
-		candidate.ContentVersionID = entry.Node.CurrentVersionID
 		candidate.VectorSpaceID = vectorSpaceID
 		candidate.InputID = neighbor.InputKey
-		candidate.Score, candidate.Distance = neighbor.Score, neighbor.Distance
-		candidate.Path = entry.Path
+		candidate.Score = neighbor.Score
 		candidates = append(candidates, candidate)
 		if len(candidates) == limit+1 {
 			return candidates[:limit], true
 		}
 	}
 	return candidates, false
-}
-
-func scanSemanticCandidate(row interface{ Scan(dest ...any) error }, candidate *SemanticSearchCandidate,
-	dest ...any,
-) (Node, error) {
-	var node Node
-	fields := []any{&node.ID, &node.ParentID, &node.Name, &node.Kind,
-		&node.CurrentVersionID, &node.BlobHash, &node.MD5, &node.Size, &node.MimeType,
-		&node.Revision, &node.CreatedAt, &node.ModifiedAt, &node.TrashedAt,
-		&candidate.EmbeddingSetID, &candidate.InputGenerationID, &candidate.InputKind}
-	err := row.Scan(append(fields, dest...)...)
-	if errors.Is(err, sql.ErrNoRows) {
-		return Node{}, ErrNotFound
-	}
-	if err != nil {
-		return Node{}, fmt.Errorf("scanning semantic search candidate: %w", err)
-	}
-	return node, nil
 }
 
 const (

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -404,7 +404,8 @@ func (s *Store) ResolveSemanticCandidates(ctx context.Context, profileFingerprin
 		if err != nil {
 			return err
 		}
-		eligible, loadErr := loadSemanticEligibility(ctx, tx, vectorSpaceID, filterSQL, filterArgs)
+		eligible, loadErr := loadSemanticEligibility(ctx, tx, profileFingerprint, bindingID,
+			inputKind, vectorSpaceID, filterSQL, filterArgs)
 		if loadErr != nil {
 			return loadErr
 		}
@@ -433,10 +434,10 @@ type semanticEligibility struct {
 // loadSemanticEligibility performs the only catalog query needed while the
 // exact index's ordered neighbors are reduced. Its result is bounded by the
 // active vector-space catalog (at most one million rows), not by neighbor rank.
-func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, vectorSpaceID, filterSQL string,
-	filterArgs []any,
+func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, profileFingerprint, bindingID string,
+	inputKind document.EmbeddingInputKind, vectorSpaceID, filterSQL string, filterArgs []any,
 ) (_ map[semanticEligibilityKey]semanticEligibility, retErr error) {
-	args := append([]any{vectorSpaceID}, filterArgs...)
+	args := append([]any{vectorSpaceID, profileFingerprint, bindingID, inputKind}, filterArgs...)
 	rows, err := tx.QueryContext(ctx, `WITH RECURSIVE node_paths(id,path) AS (
 		SELECT id,'' FROM nodes WHERE parent_id IS NULL
 		UNION ALL
@@ -457,6 +458,7 @@ func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, vectorSpac
 		JOIN embedding_input_generations eig ON eig.generation_id=es.input_generation_id
 		JOIN node_paths ON node_paths.id=n.id
 		WHERE es.vector_space_id=?
+		  AND es.profile_fingerprint=? AND es.binding_id=? AND es.input_kind=?
 		  AND n.current_version_id=es.content_version_id AND n.trashed_at IS NULL
 		  AND (es.input_kind='original_file' OR EXISTS(
 		    SELECT 1 FROM rendition_heads rh

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/vectorindex"
 )
 
 // SearchHit is a search result with its display path.
@@ -25,6 +26,185 @@ type SearchHit struct {
 	Node  Node
 	Path  string
 	Match string
+}
+
+// ExplainedLexicalCandidate adds stable evidence identity and a bounded
+// display excerpt without changing the established SearchHit ordering.
+type ExplainedLexicalCandidate struct {
+	Node         Node
+	Path         string
+	Match        string
+	EvidenceKind string
+	BuildID      string
+	SegmentID    string
+	BlobHash     string
+	Excerpt      string
+}
+
+const maxExplainedSearchExcerptRunes = 512
+
+// SearchExplainedLexicalCandidates preserves SearchPageWithOptions ordering.
+// Content selection and evidence resolution share one lexical-generation read.
+func (s *Store) SearchExplainedLexicalCandidates(ctx context.Context, query string, limit int,
+	opts SearchOptions,
+) ([]ExplainedLexicalCandidate, bool, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var err error
+	opts, err = s.normalizeSearchOptions(ctx, opts)
+	if err != nil {
+		return nil, false, err
+	}
+	fq := ftsQuery(query)
+	if fq == "" {
+		return nil, false, nil
+	}
+	filterSQL, filterArgs := searchFilterSQL(opts)
+	nameArgs := append([]any{fq}, filterArgs...)
+	nameArgs = append(nameArgs, fq, limit+1)
+	rows, err := s.db.QueryContext(ctx, `SELECT `+nodeCols+` FROM `+nodeFrom+`
+		WHERE n.id IN (SELECT rowid FROM nodes_fts WHERE nodes_fts MATCH ?)
+		  AND n.kind='file' AND cv.version_id IS NOT NULL AND n.trashed_at IS NULL `+filterSQL+`
+		ORDER BY (SELECT rank FROM nodes_fts WHERE rowid=n.id AND nodes_fts MATCH ?),n.name,n.id
+		LIMIT ?`, nameArgs...)
+	if err != nil {
+		return nil, false, err
+	}
+	nameHits, err := scanSearchRows(rows, SearchMatchName, query)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(nameHits) > limit {
+		nameHits = nameHits[:limit]
+		if err := s.addSearchPaths(ctx, nameHits); err != nil {
+			return nil, false, err
+		}
+		return explainedNameCandidates(nameHits), true, nil
+	}
+	if err := s.addSearchPaths(ctx, nameHits); err != nil {
+		return nil, false, err
+	}
+	remaining := limit - len(nameHits)
+	nameSeen := make(map[int64]struct{}, len(nameHits))
+	for _, hit := range nameHits {
+		nameSeen[hit.Node.ID] = struct{}{}
+	}
+	var content []ExplainedLexicalCandidate
+	queryContent := func(queryer metadataQuerier, generationID string) (retErr error) {
+		args := []any{fq}
+		contentQuery := `SELECT ` + nodeCols + `,'' AS build_id,'' AS segment_id,
+			 snippet(content_fts,2,char(1),char(2),' … ',24) AS excerpt
+			FROM content_fts JOIN content_versions matched_cv ON matched_cv.blob_hash=content_fts.blob_hash
+			JOIN nodes n ON n.id=matched_cv.node_id AND n.current_version_id=matched_cv.version_id
+			JOIN content_versions cv ON cv.version_id=matched_cv.version_id
+			JOIN text_searchable_versions tsv ON tsv.version_id=matched_cv.version_id
+			WHERE content_fts MATCH ? AND n.trashed_at IS NULL ` + filterSQL + `
+			ORDER BY content_fts.rank,n.name,n.id,content_fts.rowid`
+		if generationID != "" {
+			contentQuery = `SELECT ` + nodeCols + `,rendition_lexical_fts.build_id,
+				 rendition_lexical_fts.segment_id,snippet(rendition_lexical_fts,2,char(1),char(2),' … ',24)
+				FROM rendition_lexical_fts
+				JOIN rendition_lexical_generation_builds gb
+				 ON gb.build_id=rendition_lexical_fts.build_id
+				JOIN rendition_attachments a ON a.build_id=rendition_lexical_fts.build_id
+				JOIN rendition_heads rh ON rh.content_version_id=a.content_version_id
+				 AND rh.profile_fingerprint=a.profile_fingerprint AND rh.attachment_id=a.attachment_id
+				JOIN content_versions cv ON cv.version_id=a.content_version_id
+				JOIN nodes n ON n.id=cv.node_id AND n.current_version_id=cv.version_id
+				WHERE rendition_lexical_fts MATCH ? AND gb.generation_id=?
+				 AND n.trashed_at IS NULL ` + filterSQL + `
+				ORDER BY rendition_lexical_fts.rank,n.name,n.id,
+				 rendition_lexical_fts.build_id,rendition_lexical_fts.segment_id`
+			args = append(args, generationID)
+		}
+		args = append(args, filterArgs...)
+		rows, err := queryer.QueryContext(ctx, contentQuery, args...)
+		if err != nil {
+			return err
+		}
+		defer func() { retErr = errors.Join(retErr, rows.Close()) }()
+		seenContent := make(map[int64]struct{}, remaining+1)
+		for rows.Next() {
+			var candidate ExplainedLexicalCandidate
+			node, err := scanExplainedLexicalRow(rows, &candidate)
+			if err != nil {
+				return err
+			}
+			candidate.Node, candidate.Match = node, SearchMatchContent
+			if _, duplicate := nameSeen[node.ID]; duplicate {
+				continue
+			}
+			if _, duplicate := seenContent[node.ID]; duplicate {
+				continue
+			}
+			seenContent[node.ID] = struct{}{}
+			if generationID == "" {
+				candidate.EvidenceKind = "content_blob"
+				candidate.BlobHash = node.BlobHash
+			} else {
+				candidate.EvidenceKind = "rendition_segment"
+			}
+			candidate.Path, err = pathOf(ctx, queryer, node.ID)
+			if err != nil {
+				return err
+			}
+			content = append(content, candidate)
+			if len(content) == remaining+1 {
+				break
+			}
+		}
+		return rows.Err()
+	}
+	err = s.withLexicalGenerationRead(ctx, func(queryer metadataQuerier, generation LexicalGeneration) error {
+		return queryContent(queryer, generation.ID)
+	})
+	if errors.Is(err, ErrNotFound) {
+		err = queryContent(s.db, "")
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	truncated := len(content) > remaining
+	if truncated {
+		content = content[:remaining]
+	}
+	result := explainedNameCandidates(nameHits)
+	result = append(result, content...)
+	return result, truncated, nil
+}
+
+func explainedNameCandidates(hits []SearchHit) []ExplainedLexicalCandidate {
+	result := make([]ExplainedLexicalCandidate, len(hits))
+	for index, hit := range hits {
+		result[index] = ExplainedLexicalCandidate{Node: hit.Node, Path: hit.Path,
+			Match: SearchMatchName, EvidenceKind: "node_name", Excerpt: hit.Node.Name}
+	}
+	return result
+}
+
+func scanExplainedLexicalRow(row interface{ Scan(dest ...any) error }, candidate *ExplainedLexicalCandidate) (Node, error) {
+	var node Node
+	if err := row.Scan(&node.ID, &node.ParentID, &node.Name, &node.Kind,
+		&node.CurrentVersionID, &node.BlobHash, &node.MD5, &node.Size, &node.MimeType,
+		&node.Revision, &node.CreatedAt, &node.ModifiedAt, &node.TrashedAt,
+		&candidate.BuildID, &candidate.SegmentID, &candidate.Excerpt); err != nil {
+		return Node{}, err
+	}
+	candidate.Excerpt = boundedExplainedSearchExcerpt(candidate.Excerpt)
+	return node, nil
+}
+
+func boundedExplainedSearchExcerpt(value string) string {
+	runes := []rune(value)
+	if len(runes) > maxExplainedSearchExcerptRunes {
+		match := max(slices.Index(runes, rune(1)), 0)
+		start := max(0, min(match-maxExplainedSearchExcerptRunes/2,
+			len(runes)-maxExplainedSearchExcerptRunes))
+		runes = runes[start : start+maxExplainedSearchExcerptRunes]
+	}
+	runes = slices.DeleteFunc(runes, func(value rune) bool { return value == 1 || value == 2 })
+	return string(runes)
 }
 
 // SearchOptions selects a filter-only page or narrows ranked search without
@@ -46,6 +226,313 @@ type SearchOptions struct {
 func SearchNeedsQuery(query string, opts SearchOptions) bool {
 	return ftsQuery(query) == "" && opts.TagID == "" &&
 		opts.ModifiedSince == "" && opts.ModifiedBefore == ""
+}
+
+// SemanticSearchCandidate is one vector neighbor reduced to a current,
+// scope-eligible document. Excerpt is intentionally empty: only an independent
+// lexical lane may supply text to an explained retrieval report.
+type SemanticSearchCandidate struct {
+	VaultID           string
+	NodeID            int64
+	ContentVersionID  string
+	Path              string
+	VectorSpaceID     string
+	EmbeddingSetID    string
+	InputGenerationID string
+	InputID           string
+	InputKind         document.EmbeddingInputKind
+	Score             float64
+	Distance          float64
+	Excerpt           string
+}
+
+// SemanticSearchResolution binds ranked candidates and coverage to the same
+// current-head snapshot after query embedding and vector search complete.
+type SemanticSearchResolution struct {
+	SourceManifestChecksum string
+	Candidates             []SemanticSearchCandidate
+	Truncated              bool
+	ScopedDocuments        int
+	CompleteDocuments      int
+}
+
+// SemanticSearchAuthority pins the exact persisted vector-space descriptor and
+// one active local index generation for a query. Required and Complete count
+// current documents after applying the operator scope.
+type SemanticSearchAuthority struct {
+	VectorSpace       EmbeddingVectorSpaceRecord
+	Lease             VectorIndexReaderLease
+	InputKind         document.EmbeddingInputKind
+	BindingRequired   bool
+	ScopedDocuments   int
+	CompleteDocuments int
+}
+
+// AcquireSemanticSearchAuthority resolves the query contract from durable E1
+// authority, never from a runtime default, and leases one exact active index.
+func (s *Store) AcquireSemanticSearchAuthority(ctx context.Context, profileFingerprint,
+	bindingID, owner string, at time.Time, duration time.Duration, opts SearchOptions,
+) (SemanticSearchAuthority, error) {
+	normalized, err := s.normalizeSearchOptions(ctx, opts)
+	if err != nil {
+		return SemanticSearchAuthority{}, err
+	}
+	binding, fingerprints, err := embeddingProfileBindingAuthority(ctx, s.db, profileFingerprint, bindingID)
+	if err != nil {
+		return SemanticSearchAuthority{}, err
+	}
+	vectorSpaceID := fingerprints.VectorSpace[bindingID]
+	var space EmbeddingVectorSpaceRecord
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		var loadErr error
+		space, loadErr = loadVectorSpaceTx(ctx, tx, vectorSpaceID)
+		return loadErr
+	})
+	if err != nil {
+		return SemanticSearchAuthority{}, err
+	}
+	if space.ID != vectorSpaceID || space.DescriptorFingerprint != binding.Descriptor.Fingerprint ||
+		space.CompatibilityID != binding.CompatibilityID || space.Dimensions != binding.Dimensions ||
+		space.Metric != binding.Metric || space.Normalization != binding.Normalization ||
+		space.ScalarEncoding != binding.ScalarEncoding || space.DocumentFormatter != binding.DocumentFormatter ||
+		space.QueryFormatter != binding.QueryFormatter || space.ModelInputFingerprint != binding.ModelInput.Fingerprint {
+		return SemanticSearchAuthority{}, errors.New("semantic search vector space does not match profile binding authority")
+	}
+	lease, err := s.AcquireVectorIndexGeneration(ctx, vectorSpaceID, owner, at, duration)
+	if err != nil {
+		return SemanticSearchAuthority{}, err
+	}
+	release := func() {
+		_ = s.ReleaseVectorIndexGeneration(context.WithoutCancel(ctx), lease.ID, lease.FencingToken, at)
+	}
+	current, err := s.CaptureVectorIndexSource(ctx, vectorSpaceID)
+	if err != nil || current.ManifestChecksum != lease.Generation.SourceManifestChecksum {
+		release()
+		if err != nil {
+			return SemanticSearchAuthority{}, err
+		}
+		return SemanticSearchAuthority{}, ErrVectorIndexSourceStale
+	}
+	required, complete, err := s.semanticSearchCoverage(ctx, profileFingerprint,
+		bindingID, binding.InputKind, vectorSpaceID, normalized)
+	if err != nil {
+		release()
+		return SemanticSearchAuthority{}, err
+	}
+	return SemanticSearchAuthority{VectorSpace: space, Lease: lease, InputKind: binding.InputKind,
+		BindingRequired: binding.Activation == document.EmbeddingRequired,
+		ScopedDocuments: required, CompleteDocuments: complete}, nil
+}
+
+func (s *Store) semanticSearchCoverage(ctx context.Context, profileFingerprint, bindingID string,
+	inputKind document.EmbeddingInputKind, vectorSpaceID string, opts SearchOptions,
+) (required, complete int, retErr error) {
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		var coverageErr error
+		required, complete, coverageErr = semanticSearchCoverageTx(ctx, tx, profileFingerprint,
+			bindingID, inputKind, vectorSpaceID, opts)
+		return coverageErr
+	})
+	return required, complete, err
+}
+
+func semanticSearchCoverageTx(ctx context.Context, tx metadataQuerier, profileFingerprint, bindingID string,
+	inputKind document.EmbeddingInputKind, vectorSpaceID string, opts SearchOptions,
+) (required, complete int, retErr error) {
+	filterSQL, filterArgs := searchFilterSQL(opts)
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+nodeFrom+`
+		WHERE n.kind='file' AND n.trashed_at IS NULL AND cv.version_id IS NOT NULL `+filterSQL,
+		filterArgs...).Scan(&required); err != nil {
+		return 0, 0, err
+	}
+	args := []any{profileFingerprint, bindingID, inputKind, vectorSpaceID}
+	args = append(args, filterArgs...)
+	err := tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT n.id) FROM `+nodeFrom+`
+		JOIN embedding_heads eh ON eh.content_version_id=cv.version_id
+		JOIN embedding_sets es ON es.embedding_set_id=eh.embedding_set_id
+		 AND es.content_version_id=eh.content_version_id AND es.binding_id=eh.binding_id
+		 AND es.input_kind=eh.input_kind AND es.vector_space_id=eh.vector_space_id
+		 AND es.profile_fingerprint=eh.profile_fingerprint
+		JOIN embedding_input_generations eig ON eig.generation_id=es.input_generation_id
+		WHERE n.kind='file' AND n.trashed_at IS NULL
+		  AND eh.profile_fingerprint=? AND eh.binding_id=? AND eh.input_kind=?
+		  AND eh.vector_space_id=?
+		  AND (eh.input_kind='original_file' OR EXISTS(
+		    SELECT 1 FROM rendition_heads rh
+		    WHERE rh.content_version_id=eh.content_version_id
+		      AND rh.profile_fingerprint=eh.profile_fingerprint
+		      AND rh.attachment_id=eig.attachment_id
+		  )) `+filterSQL, args...).Scan(&complete)
+	return required, complete, err
+}
+
+// ResolveSemanticCandidates applies current-version, live-head, and operator
+// scope fencing before reducing ordered vector rows to bounded documents.
+func (s *Store) ResolveSemanticCandidates(ctx context.Context, profileFingerprint, bindingID string,
+	inputKind document.EmbeddingInputKind, vectorSpaceID, expectedSourceManifest string,
+	neighbors []vectorindex.Neighbor, limit int, opts SearchOptions,
+) (_ SemanticSearchResolution, retErr error) {
+	if err := validateCatalogSHA256(vectorSpaceID, "semantic search vector-space ID"); err != nil {
+		return SemanticSearchResolution{}, err
+	}
+	if err := validateCatalogSHA256(expectedSourceManifest, "semantic search source manifest"); err != nil {
+		return SemanticSearchResolution{}, err
+	}
+	if limit < 1 || limit > document.MaxRetrievalCandidateLimit {
+		return SemanticSearchResolution{}, fmt.Errorf("semantic search limit must be between 1 and %d", document.MaxRetrievalCandidateLimit)
+	}
+	normalized, err := s.normalizeSearchOptions(ctx, opts)
+	if err != nil {
+		return SemanticSearchResolution{}, err
+	}
+	filterSQL, filterArgs := searchFilterSQL(normalized)
+	var result SemanticSearchResolution
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		current, captureErr := captureVectorIndexSourceTx(ctx, tx, vectorSpaceID)
+		if captureErr != nil {
+			if errors.Is(captureErr, ErrNotFound) {
+				return ErrVectorIndexSourceStale
+			}
+			return captureErr
+		}
+		if current.ManifestChecksum != expectedSourceManifest {
+			return ErrVectorIndexSourceStale
+		}
+		result.SourceManifestChecksum = current.ManifestChecksum
+		result.ScopedDocuments, result.CompleteDocuments, err = semanticSearchCoverageTx(ctx, tx,
+			profileFingerprint, bindingID, inputKind, vectorSpaceID, normalized)
+		if err != nil {
+			return err
+		}
+		eligible, loadErr := loadSemanticEligibility(ctx, tx, vectorSpaceID, filterSQL, filterArgs)
+		if loadErr != nil {
+			return loadErr
+		}
+		result.Candidates, result.Truncated = reduceSemanticCandidates(s.vaultID, vectorSpaceID,
+			neighbors, limit, eligible)
+		return nil
+	})
+	if err != nil {
+		return SemanticSearchResolution{}, err
+	}
+	return result, nil
+}
+
+type semanticEligibilityKey struct {
+	VectorSetID   string
+	InputID       string
+	InputChecksum string
+}
+
+type semanticEligibility struct {
+	Node      Node
+	Path      string
+	Candidate SemanticSearchCandidate
+}
+
+// loadSemanticEligibility performs the only catalog query needed while the
+// exact index's ordered neighbors are reduced. Its result is bounded by the
+// active vector-space catalog (at most one million rows), not by neighbor rank.
+func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, vectorSpaceID, filterSQL string,
+	filterArgs []any,
+) (_ map[semanticEligibilityKey]semanticEligibility, retErr error) {
+	args := append([]any{vectorSpaceID}, filterArgs...)
+	rows, err := tx.QueryContext(ctx, `WITH RECURSIVE node_paths(id,path) AS (
+		SELECT id,'' FROM nodes WHERE parent_id IS NULL
+		UNION ALL
+		SELECT child.id,parent.path || '/' || child.name
+		FROM nodes child JOIN node_paths parent ON child.parent_id=parent.id
+	)
+		SELECT `+nodeCols+`,es.embedding_set_id,es.input_generation_id,es.input_kind,
+			evr.vector_set_id,evr.input_id,evr.checksum,COALESCE(NULLIF(node_paths.path,''),'/')
+		FROM `+nodeFrom+`
+		JOIN embedding_sets es ON es.content_version_id=cv.version_id
+		JOIN embedding_heads eh ON eh.content_version_id=es.content_version_id
+		 AND eh.binding_id=es.binding_id AND eh.input_kind=es.input_kind
+		 AND eh.embedding_set_id=es.embedding_set_id AND eh.vector_space_id=es.vector_space_id
+		 AND eh.profile_fingerprint=es.profile_fingerprint
+		JOIN embedding_vector_rows evr ON evr.vector_set_id=es.vector_set_id
+		JOIN embedding_generation_inputs egi ON egi.generation_id=es.input_generation_id
+		 AND egi.input_id=evr.input_id AND egi.rendered_checksum=evr.checksum
+		JOIN embedding_input_generations eig ON eig.generation_id=es.input_generation_id
+		JOIN node_paths ON node_paths.id=n.id
+		WHERE es.vector_space_id=?
+		  AND n.current_version_id=es.content_version_id AND n.trashed_at IS NULL
+		  AND (es.input_kind='original_file' OR EXISTS(
+		    SELECT 1 FROM rendition_heads rh
+		    WHERE rh.content_version_id=es.content_version_id
+		      AND rh.profile_fingerprint=es.profile_fingerprint
+		      AND rh.attachment_id=eig.attachment_id
+		  ))
+		  `+filterSQL, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { retErr = errors.Join(retErr, rows.Close()) }()
+	eligible := make(map[semanticEligibilityKey]semanticEligibility)
+	for rows.Next() {
+		var (
+			entry semanticEligibility
+			key   semanticEligibilityKey
+		)
+		node, scanErr := scanSemanticCandidate(rows, &entry.Candidate,
+			&key.VectorSetID, &key.InputID, &key.InputChecksum, &entry.Path)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		entry.Node = node
+		eligible[key] = entry
+	}
+	return eligible, rows.Err()
+}
+
+func reduceSemanticCandidates(vaultID, vectorSpaceID string, neighbors []vectorindex.Neighbor,
+	limit int, eligible map[semanticEligibilityKey]semanticEligibility,
+) ([]SemanticSearchCandidate, bool) {
+	seen := make(map[int64]struct{}, limit+1)
+	candidates := make([]SemanticSearchCandidate, 0, min(limit+1, len(eligible)))
+	for _, neighbor := range neighbors {
+		entry, ok := eligible[semanticEligibilityKey{VectorSetID: neighbor.SetID,
+			InputID: neighbor.InputKey, InputChecksum: neighbor.InputChecksum}]
+		if !ok {
+			continue
+		}
+		if _, duplicate := seen[entry.Node.ID]; duplicate {
+			continue
+		}
+		seen[entry.Node.ID] = struct{}{}
+		candidate := entry.Candidate
+		candidate.VaultID = vaultID
+		candidate.NodeID = entry.Node.ID
+		candidate.ContentVersionID = entry.Node.CurrentVersionID
+		candidate.VectorSpaceID = vectorSpaceID
+		candidate.InputID = neighbor.InputKey
+		candidate.Score, candidate.Distance = neighbor.Score, neighbor.Distance
+		candidate.Path = entry.Path
+		candidates = append(candidates, candidate)
+		if len(candidates) == limit+1 {
+			return candidates[:limit], true
+		}
+	}
+	return candidates, false
+}
+
+func scanSemanticCandidate(row interface{ Scan(dest ...any) error }, candidate *SemanticSearchCandidate,
+	dest ...any,
+) (Node, error) {
+	var node Node
+	fields := []any{&node.ID, &node.ParentID, &node.Name, &node.Kind,
+		&node.CurrentVersionID, &node.BlobHash, &node.MD5, &node.Size, &node.MimeType,
+		&node.Revision, &node.CreatedAt, &node.ModifiedAt, &node.TrashedAt,
+		&candidate.EmbeddingSetID, &candidate.InputGenerationID, &candidate.InputKind}
+	err := row.Scan(append(fields, dest...)...)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Node{}, ErrNotFound
+	}
+	if err != nil {
+		return Node{}, fmt.Errorf("scanning semantic search candidate: %w", err)
+	}
+	return node, nil
 }
 
 const (
@@ -1134,40 +1621,11 @@ func (s *Store) SearchPageWithOptions(
 	if limit <= 0 {
 		limit = 50
 	}
-	if opts.TagID != "" {
-		if _, err := s.TagByID(ctx, opts.TagID); err != nil {
-			return nil, false, fmt.Errorf("search tag %q: %w", opts.TagID, err)
-		}
-	}
-	normalizedMIME, err := NormalizeSearchMIMEType(opts.MIMEType)
+	var err error
+	opts, err = s.normalizeSearchOptions(ctx, opts)
 	if err != nil {
 		return nil, false, err
 	}
-	opts.MIMEType = normalizedMIME
-	if opts.UnderNodeID < 0 {
-		return nil, false, errors.New("search directory node ID must be positive")
-	}
-	if opts.UnderNodeID != 0 {
-		directory, err := s.NodeByID(ctx, opts.UnderNodeID)
-		if err != nil {
-			return nil, false, fmt.Errorf("search directory node %d: %w", opts.UnderNodeID, err)
-		}
-		if directory.TrashedAt != nil {
-			return nil, false, fmt.Errorf("search directory node %d is trashed: %w",
-				opts.UnderNodeID, ErrNotFound)
-		}
-		if !directory.IsDir() {
-			return nil, false, fmt.Errorf("search scope node %d: %w", opts.UnderNodeID, ErrNotDir)
-		}
-	}
-	modifiedSince, modifiedBefore, err := NormalizeSearchTimeBounds(
-		opts.ModifiedSince, opts.ModifiedBefore,
-	)
-	if err != nil {
-		return nil, false, err
-	}
-	opts.ModifiedSince = modifiedSince
-	opts.ModifiedBefore = modifiedBefore
 	fq := ftsQuery(query)
 	if SearchNeedsQuery(query, opts) {
 		return nil, false, ErrSearchQueryRequired
@@ -1292,6 +1750,44 @@ func (s *Store) SearchPageWithOptions(
 		return nil, false, err
 	}
 	return hits, truncated, nil
+}
+
+func (s *Store) normalizeSearchOptions(ctx context.Context, opts SearchOptions) (SearchOptions, error) {
+	if opts.TagID != "" {
+		if _, err := s.TagByID(ctx, opts.TagID); err != nil {
+			return SearchOptions{}, fmt.Errorf("search tag %q: %w", opts.TagID, err)
+		}
+	}
+	normalizedMIME, err := NormalizeSearchMIMEType(opts.MIMEType)
+	if err != nil {
+		return SearchOptions{}, err
+	}
+	opts.MIMEType = normalizedMIME
+	if opts.UnderNodeID < 0 {
+		return SearchOptions{}, errors.New("search directory node ID must be positive")
+	}
+	if opts.UnderNodeID != 0 {
+		directory, err := s.NodeByID(ctx, opts.UnderNodeID)
+		if err != nil {
+			return SearchOptions{}, fmt.Errorf("search directory node %d: %w", opts.UnderNodeID, err)
+		}
+		if directory.TrashedAt != nil {
+			return SearchOptions{}, fmt.Errorf("search directory node %d is trashed: %w",
+				opts.UnderNodeID, ErrNotFound)
+		}
+		if !directory.IsDir() {
+			return SearchOptions{}, fmt.Errorf("search scope node %d: %w", opts.UnderNodeID, ErrNotDir)
+		}
+	}
+	modifiedSince, modifiedBefore, err := NormalizeSearchTimeBounds(
+		opts.ModifiedSince, opts.ModifiedBefore,
+	)
+	if err != nil {
+		return SearchOptions{}, err
+	}
+	opts.ModifiedSince = modifiedSince
+	opts.ModifiedBefore = modifiedBefore
+	return opts, nil
 }
 
 // searchFilterPage selects the limited page before walking its ancestry, so

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -59,6 +59,56 @@ func TestResolveSemanticCandidatesReturnsOnlyCurrentScopedHeads(t *testing.T) {
 	assert.Empty(t, filtered.Candidates, "scope filters apply before the semantic document cutoff")
 }
 
+func TestResolveSemanticCandidatesIsolatesSharedVectorSpace(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	otherProfile := embeddingCatalogProfileVariant(t)
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		return ensureProcessingProfileTx(t.Context(), tx, otherProfile)
+	}))
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		FencingToken: 1,
+		Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID,
+			InputKind: record.InputKind}, SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+	source, err := s.CaptureVectorIndexSource(t.Context(), record.VectorSpace.ID)
+	require.NoError(t, err)
+	for _, test := range []struct {
+		name    string
+		profile string
+		binding string
+		kind    document.EmbeddingInputKind
+		want    bool
+	}{
+		{"matching authority", profile.Fingerprint, "optional", document.EmbeddingInputOriginalFile, true},
+		{"other profile", otherProfile.Fingerprint, "optional", document.EmbeddingInputOriginalFile, false},
+		{"other binding", profile.Fingerprint, "required", document.EmbeddingInputOriginalFile, false},
+		{"other input kind", profile.Fingerprint, "chunk", document.EmbeddingInputRenditionChunk, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, fingerprints, err := embeddingProfileBindingAuthority(t.Context(), s.db, test.profile, test.binding)
+			require.NoError(t, err)
+			require.Equal(t, record.VectorSpace.ID, fingerprints.VectorSpace[test.binding])
+			result, err := s.ResolveSemanticCandidates(t.Context(), test.profile, test.binding, test.kind,
+				record.VectorSpace.ID, source.ManifestChecksum, []vectorindex.Neighbor{{
+					SetID: record.VectorSet.ID, InputKey: versionID,
+					InputChecksum: record.InputGeneration.Inputs[0].RenderedChecksum, Score: 0.9,
+				}}, 1, SearchOptions{})
+			require.NoError(t, err)
+			if test.want {
+				require.Len(t, result.Candidates, 1)
+				assert.Equal(t, record.ID, result.Candidates[0].EmbeddingSetID)
+			} else {
+				assert.Zero(t, result.CompleteDocuments)
+				assert.Empty(t, result.Candidates)
+			}
+		})
+	}
+}
+
 func TestResolveSemanticCandidatesRejectsStaleSourceManifest(t *testing.T) {
 	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
 	record := embeddingSetFixture(s, versionID, profile.Fingerprint,

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json/jsontext"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,7 +13,205 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/vectorindex"
 )
+
+func TestResolveSemanticCandidatesReturnsOnlyCurrentScopedHeads(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		FencingToken: 1,
+		Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID,
+			InputKind: record.InputKind}, SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+	source, err := s.CaptureVectorIndexSource(t.Context(), record.VectorSpace.ID)
+	require.NoError(t, err)
+	_, err = s.CreateFile(t.Context(), s.RootID(), "late-unembedded.pdf",
+		fakeHash("late-unembedded"), 1, "application/pdf")
+	require.NoError(t, err)
+
+	resolution, err := s.ResolveSemanticCandidates(t.Context(), profile.Fingerprint, record.BindingID,
+		record.InputKind, record.VectorSpace.ID, source.ManifestChecksum,
+		[]vectorindex.Neighbor{{
+			SetID: record.VectorSet.ID, InputKey: versionID,
+			InputChecksum: record.InputGeneration.Inputs[0].RenderedChecksum, Score: 0.9}},
+		10, SearchOptions{MIMEType: "application/pdf"})
+	require.NoError(t, err)
+	assert.False(t, resolution.Truncated)
+	assert.Equal(t, 3, resolution.ScopedDocuments)
+	assert.Equal(t, 1, resolution.CompleteDocuments)
+	require.Len(t, resolution.Candidates, 1)
+	assert.Equal(t, versionID, resolution.Candidates[0].ContentVersionID)
+	assert.Equal(t, record.ID, resolution.Candidates[0].EmbeddingSetID)
+	assert.Equal(t, document.EmbeddingInputOriginalFile, resolution.Candidates[0].InputKind)
+	assert.Empty(t, resolution.Candidates[0].Excerpt, "direct-file semantic evidence cannot fabricate text")
+
+	filtered, err := s.ResolveSemanticCandidates(t.Context(), profile.Fingerprint, record.BindingID,
+		record.InputKind, record.VectorSpace.ID, source.ManifestChecksum,
+		[]vectorindex.Neighbor{{
+			SetID: record.VectorSet.ID, InputKey: versionID,
+			InputChecksum: record.InputGeneration.Inputs[0].RenderedChecksum, Score: 0.9}},
+		10, SearchOptions{MIMEType: "text/plain"})
+	require.NoError(t, err)
+	assert.Empty(t, filtered.Candidates, "scope filters apply before the semantic document cutoff")
+}
+
+func TestResolveSemanticCandidatesRejectsStaleSourceManifest(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		FencingToken: 1,
+		Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID,
+			InputKind: record.InputKind}, SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+
+	_, err := s.ResolveSemanticCandidates(t.Context(), profile.Fingerprint, record.BindingID,
+		record.InputKind, record.VectorSpace.ID, strings.Repeat("f", 64), nil, 10, SearchOptions{})
+
+	require.ErrorIs(t, err, ErrVectorIndexSourceStale)
+}
+
+func TestReduceSemanticCandidatesExhaustsNeighborsWithoutDatabaseWork(t *testing.T) {
+	const missed = 10_000
+	neighbors := make([]vectorindex.Neighbor, missed+1)
+	for index := range missed {
+		neighbors[index] = vectorindex.Neighbor{
+			SetID: "filtered", InputKey: fmt.Sprintf("filtered-%d", index), InputChecksum: fakeHash("filtered"),
+		}
+	}
+	neighbors[missed] = vectorindex.Neighbor{
+		SetID: "eligible", InputKey: "eligible-input", InputChecksum: fakeHash("eligible"), Score: 0.75,
+	}
+	key := semanticEligibilityKey{
+		VectorSetID: "eligible", InputID: "eligible-input", InputChecksum: fakeHash("eligible"),
+	}
+	eligible := map[semanticEligibilityKey]semanticEligibility{
+		key: {Node: Node{ID: 42, CurrentVersionID: "version-42"}, Path: "/later.pdf",
+			Candidate: SemanticSearchCandidate{EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
+				InputKind: document.EmbeddingInputOriginalFile}},
+	}
+
+	candidates, truncated := reduceSemanticCandidates("vault", fakeHash("space"), neighbors, 10, eligible)
+
+	assert.False(t, truncated)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, int64(42), candidates[0].NodeID)
+	assert.InDelta(t, 0.75, candidates[0].Score, 1e-12)
+}
+
+func TestReduceSemanticCandidatesKeepsBestChunkPerDocument(t *testing.T) {
+	spaceID := fakeHash("space")
+	firstKey := semanticEligibilityKey{VectorSetID: "set", InputID: "chunk-1", InputChecksum: fakeHash("chunk-1")}
+	secondKey := semanticEligibilityKey{VectorSetID: "set", InputID: "chunk-2", InputChecksum: fakeHash("chunk-2")}
+	eligible := map[semanticEligibilityKey]semanticEligibility{
+		firstKey: {Node: Node{ID: 42, CurrentVersionID: "version-42"}, Path: "/chunked.pdf",
+			Candidate: SemanticSearchCandidate{EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
+				InputKind: document.EmbeddingInputRenditionChunk}},
+		secondKey: {Node: Node{ID: 42, CurrentVersionID: "version-42"}, Path: "/chunked.pdf",
+			Candidate: SemanticSearchCandidate{EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
+				InputKind: document.EmbeddingInputRenditionChunk}},
+	}
+
+	candidates, truncated := reduceSemanticCandidates("vault", spaceID, []vectorindex.Neighbor{
+		{SetID: firstKey.VectorSetID, InputKey: firstKey.InputID, InputChecksum: firstKey.InputChecksum, Score: 0.9},
+		{SetID: secondKey.VectorSetID, InputKey: secondKey.InputID, InputChecksum: secondKey.InputChecksum, Score: 0.8},
+	}, 10, eligible)
+
+	assert.False(t, truncated)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "chunk-1", candidates[0].InputID)
+	assert.InDelta(t, 0.9, candidates[0].Score, 1e-12)
+}
+
+func TestAcquireSemanticSearchAuthorityUsesStoredDescriptorAndCoverage(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		FencingToken: 1,
+		Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID,
+			InputKind: record.InputKind}, SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime,
+	}))
+	set, _, err := document.DecodeVectorSetV1(record.VectorSet.Payload, document.VectorBounds{
+		MaxRows: 100, MaxDimension: record.VectorSpace.Descriptor.Dimension,
+		MaxBytes: len(record.VectorSet.Payload),
+	})
+	require.NoError(t, err)
+	manifest, err := vectorindex.NewManifest([]string{record.VectorSet.ID})
+	require.NoError(t, err)
+	generation, err := vectorindex.BuildGeneration(manifest, []document.VectorSetV1{set}, vectorindex.Options{})
+	require.NoError(t, err)
+	source, err := s.CaptureVectorIndexSource(t.Context(), record.VectorSpace.ID)
+	require.NoError(t, err)
+	stored := VectorIndexGenerationRecord{ID: hashVectorIndexTest("semantic-search-generation"),
+		VectorSpaceID: record.VectorSpace.ID, SourceManifestChecksum: source.ManifestChecksum,
+		IndexManifestChecksum: generation.Metadata().Manifest.Checksum, Bytes: generation.Bytes(),
+		RowCount: generation.Metadata().RowCount, BuiltAt: embeddingCatalogTime}
+	require.NoError(t, putVectorIndexGenerationForTest(t, s, stored))
+
+	now := time.Now().UTC()
+	authority, err := s.AcquireSemanticSearchAuthority(t.Context(), profile.Fingerprint,
+		record.BindingID, "retrieval-test", now, time.Minute, SearchOptions{MIMEType: "application/pdf"})
+	require.NoError(t, err)
+	assert.Equal(t, record.VectorSpace.Descriptor, authority.VectorSpace.Descriptor)
+	assert.False(t, authority.BindingRequired)
+	assert.Equal(t, 2, authority.ScopedDocuments)
+	assert.Equal(t, 1, authority.CompleteDocuments)
+	assert.Equal(t, stored.ID, authority.Lease.Generation.ID)
+	require.NoError(t, s.ReleaseVectorIndexGeneration(t.Context(), authority.Lease.ID,
+		authority.Lease.FencingToken, now))
+}
+
+func TestSearchExplainedLexicalCandidatesCitesActiveRenditionSegment(t *testing.T) {
+	s, versions := newRenditionCatalogFixture(t)
+	profile := catalogProcessingProfile(t, false)
+	build := lexicalSearchBuild(s, profile, catalogBuildID,
+		strings.Repeat("x", 2048)+" mercury bounded evidence excerpt")
+	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+	generation, err := s.StageLexicalGeneration(t.Context(), hashVectorIndexTest("e9-lexical"))
+	require.NoError(t, err)
+	attachment := RenditionAttachmentRecord{ID: catalogAttachmentFirst, VaultID: s.VaultID(),
+		ContentVersionID: versions[0], BuildID: build.ID, Profile: profile,
+		AttachedAt: embeddingCatalogTime}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(t.Context(), attachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: attachment.ID, PublishedAt: embeddingCatalogTime}, generation.ID))
+
+	candidates, truncated, err := s.SearchExplainedLexicalCandidates(t.Context(), "mercury", 10, SearchOptions{})
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, build.ID, candidates[0].BuildID)
+	assert.Equal(t, build.LexicalSegments[0].ID, candidates[0].SegmentID)
+	assert.Contains(t, candidates[0].Excerpt, "mercury")
+	assert.LessOrEqual(t, len([]rune(candidates[0].Excerpt)), maxExplainedSearchExcerptRunes)
+	assert.Equal(t, versions[0], candidates[0].Node.CurrentVersionID)
+}
+
+func TestSearchExplainedLexicalCandidatesIncludesNamePath(t *testing.T) {
+	s := newTestStore(t)
+	docs, err := s.Mkdir(t.Context(), s.RootID(), "docs")
+	require.NoError(t, err)
+	_, err = s.Mkdir(t.Context(), s.RootID(), "alpha-folder")
+	require.NoError(t, err)
+	_, err = s.CreateFile(t.Context(), docs.ID, "alpha.pdf", fakeHash("alpha"), 1, "application/pdf")
+	require.NoError(t, err)
+
+	candidates, truncated, err := s.SearchExplainedLexicalCandidates(t.Context(), "alpha", 10, SearchOptions{})
+
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "/docs/alpha.pdf", candidates[0].Path)
+}
 
 func TestSearchFindsLiveNodesOnly(t *testing.T) {
 	s := newTestStore(t)

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -47,7 +47,6 @@ func TestResolveSemanticCandidatesReturnsOnlyCurrentScopedHeads(t *testing.T) {
 	assert.Equal(t, versionID, resolution.Candidates[0].ContentVersionID)
 	assert.Equal(t, record.ID, resolution.Candidates[0].EmbeddingSetID)
 	assert.Equal(t, document.EmbeddingInputOriginalFile, resolution.Candidates[0].InputKind)
-	assert.Empty(t, resolution.Candidates[0].Excerpt, "direct-file semantic evidence cannot fabricate text")
 
 	filtered, err := s.ResolveSemanticCandidates(t.Context(), profile.Fingerprint, record.BindingID,
 		record.InputKind, record.VectorSpace.ID, source.ManifestChecksum,
@@ -141,10 +140,9 @@ func TestReduceSemanticCandidatesExhaustsNeighborsWithoutDatabaseWork(t *testing
 	key := semanticEligibilityKey{
 		VectorSetID: "eligible", InputID: "eligible-input", InputChecksum: fakeHash("eligible"),
 	}
-	eligible := map[semanticEligibilityKey]semanticEligibility{
-		key: {Node: Node{ID: 42, CurrentVersionID: "version-42"}, Path: "/later.pdf",
-			Candidate: SemanticSearchCandidate{EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
-				InputKind: document.EmbeddingInputOriginalFile}},
+	eligible := map[semanticEligibilityKey]SemanticSearchCandidate{
+		key: {NodeID: 42, ContentVersionID: "version-42", EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
+			InputKind: document.EmbeddingInputOriginalFile},
 	}
 
 	candidates, truncated := reduceSemanticCandidates("vault", fakeHash("space"), neighbors, 10, eligible)
@@ -159,13 +157,11 @@ func TestReduceSemanticCandidatesKeepsBestChunkPerDocument(t *testing.T) {
 	spaceID := fakeHash("space")
 	firstKey := semanticEligibilityKey{VectorSetID: "set", InputID: "chunk-1", InputChecksum: fakeHash("chunk-1")}
 	secondKey := semanticEligibilityKey{VectorSetID: "set", InputID: "chunk-2", InputChecksum: fakeHash("chunk-2")}
-	eligible := map[semanticEligibilityKey]semanticEligibility{
-		firstKey: {Node: Node{ID: 42, CurrentVersionID: "version-42"}, Path: "/chunked.pdf",
-			Candidate: SemanticSearchCandidate{EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
-				InputKind: document.EmbeddingInputRenditionChunk}},
-		secondKey: {Node: Node{ID: 42, CurrentVersionID: "version-42"}, Path: "/chunked.pdf",
-			Candidate: SemanticSearchCandidate{EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
-				InputKind: document.EmbeddingInputRenditionChunk}},
+	eligible := map[semanticEligibilityKey]SemanticSearchCandidate{
+		firstKey: {NodeID: 42, ContentVersionID: "version-42", EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
+			InputKind: document.EmbeddingInputRenditionChunk},
+		secondKey: {NodeID: 42, ContentVersionID: "version-42", EmbeddingSetID: "embedding-set", InputGenerationID: "generation",
+			InputKind: document.EmbeddingInputRenditionChunk},
 	}
 
 	candidates, truncated := reduceSemanticCandidates("vault", spaceID, []vectorindex.Neighbor{


### PR DESCRIPTION
Docbank can run lexical, semantic, or hybrid document search and explain where each result came from. Omitted mode and `auto` stay lexical; only explicit `semantic` or `hybrid` requests send query text to an embedding provider.

Semantic search uses the query contract recorded with the active vector space and returns candidates only from the requested processing profile, binding, and input kind. Chunk matches reduce to one result per document, and hybrid search combines lexical and semantic ranks with deterministic reciprocal-rank fusion.

Results include bounded lexical excerpts, stable rendition or embedding evidence, coverage, the actual mode used, and a compact trace. Explicit semantic searches report provider, catalog, index, and lease failures rather than silently changing modes.

Semantic search currently scans all indexed vectors for exact results; it resolves paths only for the selected documents.

Parent: #217 (merged). Refs #176.
