### PR TITLE
[F10–E12 23/25] Add optional expansion and reranking to search

### DIFF
--- a/internal/retrieval/egress_test.go
+++ b/internal/retrieval/egress_test.go
@@ -1,0 +1,159 @@
+package retrieval
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestProviderStagesHoldConsentThroughExecution(t *testing.T) {
+	for _, stage := range []ProviderStage{ProviderStageExpansion, ProviderStageReranking} {
+		for _, outcome := range []string{"success", "failure", "canceled"} {
+			t.Run(string(stage)+"/"+outcome, func(t *testing.T) {
+				catalog, err := store.Open(filepath.Join(t.TempDir(), "consent.db"))
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, catalog.Close()) })
+				_, err = catalog.CreateFile(t.Context(), catalog.RootID(), "needle.txt", strings.Repeat("a", 64), 1, "text/plain")
+				require.NoError(t, err)
+				request := store.ProviderOperationAuthorizationRequest{
+					Principal: "search-user", Scope: "search", ProfileFingerprint: strings.Repeat("b", 64),
+					DisclosureFingerprint: strings.Repeat("c", 64), InputClasses: []string{"query_text"},
+				}
+				if stage == ProviderStageReranking {
+					request.InputClasses = []string{"query_text_and_excerpt"}
+				}
+				_, err = catalog.GrantConsent(t.Context(), store.ProcessingConsentGrantRequest{
+					Principal: request.Principal, Scope: request.Scope, ProfileFingerprint: request.ProfileFingerprint,
+					DisclosureFingerprint: request.DisclosureFingerprint, InputClasses: request.InputClasses,
+				})
+				require.NoError(t, err)
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				authorized, proceed := make(chan struct{}), make(chan struct{})
+				started, finish := make(chan struct{}), make(chan struct{})
+				authorizer := &consentStageAuthorizer{catalog: catalog, request: request,
+					afterAuthorize: func() {
+						close(authorized)
+						select {
+						case <-proceed:
+						case <-ctx.Done():
+						}
+					}}
+				provider := &blockingStageProvider{started: started, finish: finish}
+				if outcome == "failure" {
+					provider.err = errors.New("provider failed")
+				}
+				config := SearcherConfig{Backend: catalog, Owner: "search-test", LeaseDuration: time.Minute}
+				if stage == ProviderStageExpansion {
+					config.Expansion = ExpansionConfig{Enabled: true, Profile: ExpansionProfile{ID: "expansion", MaxVariants: 1},
+						Provider: provider, Authorizer: authorizer, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+				} else {
+					config.Reranking = RerankingConfig{Enabled: true, Profile: RerankingProfile{ID: "reranking", MaxCandidates: 1},
+						Provider: provider, Authorizer: authorizer, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+				}
+				searcher, err := NewSearcher(config)
+				require.NoError(t, err)
+				done := make(chan error, 1)
+				go func() { _, err := searcher.Search(ctx, Query{Text: "needle", Mode: ModeLexical}); done <- err }()
+				<-authorized
+				revoked := make(chan error, 1)
+				go func() {
+					_, err := catalog.RevokeConsent(t.Context(), store.ProcessingConsentRevocationRequest{Principal: request.Principal, Scope: request.Scope})
+					revoked <- err
+				}()
+				early := false
+				select {
+				case err := <-revoked:
+					t.Errorf("revocation completed between authorization and provider execution: %v", err)
+					early = true
+				case <-time.After(20 * time.Millisecond):
+				}
+				close(proceed)
+				<-started
+				if !early {
+					select {
+					case err := <-revoked:
+						t.Errorf("revocation completed during provider execution: %v", err)
+						early = true
+					case <-time.After(20 * time.Millisecond):
+					}
+				}
+				if outcome == "canceled" {
+					cancel()
+				} else {
+					close(finish)
+				}
+				searchErr := <-done
+				switch outcome {
+				case "success":
+					require.NoError(t, searchErr)
+				case "canceled":
+					require.ErrorIs(t, searchErr, context.Canceled)
+				case "failure":
+					require.Error(t, searchErr)
+				}
+				if !early {
+					require.NoError(t, <-revoked)
+				}
+				authorizer.afterAuthorize = nil
+				_, err = searcher.Search(t.Context(), Query{Text: "needle", Mode: ModeLexical})
+				require.Error(t, err, "revoked consent must reject the next provider call")
+			})
+		}
+	}
+}
+
+type consentStageAuthorizer struct {
+	catalog        *store.Store
+	request        store.ProviderOperationAuthorizationRequest
+	afterAuthorize func()
+}
+
+func (authorizer *consentStageAuthorizer) AuthorizeExpansion(ctx context.Context, _ ProviderOperation) (ProviderEgressLease, error) {
+	_, fence, err := authorizer.catalog.BeginProviderEgress(ctx, authorizer.request)
+	if err == nil && authorizer.afterAuthorize != nil {
+		authorizer.afterAuthorize()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return fence, nil
+}
+
+func (authorizer *consentStageAuthorizer) AuthorizeReranking(ctx context.Context, operation ProviderOperation) (ProviderEgressLease, error) {
+	return authorizer.AuthorizeExpansion(ctx, operation)
+}
+
+type blockingStageProvider struct {
+	started, finish chan struct{}
+	err             error
+}
+
+func (provider *blockingStageProvider) Expand(ctx context.Context, _ ExpansionRequest) ([]string, error) {
+	close(provider.started)
+	select {
+	case <-provider.finish:
+		return nil, provider.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (provider *blockingStageProvider) Rerank(ctx context.Context, request RerankingRequest) ([]RerankScore, error) {
+	close(provider.started)
+	select {
+	case <-provider.finish:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if provider.err != nil {
+		return nil, provider.err
+	}
+	return []RerankScore{{Document: request.Candidates[0].Document, Score: 1}}, nil
+}

--- a/internal/retrieval/providers.go
+++ b/internal/retrieval/providers.go
@@ -1,0 +1,452 @@
+package retrieval
+
+import (
+	"context"
+	"errors"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+const (
+	maxQueryExpansionVariants      = 8
+	maxRerankingExcerptBytes       = 4 << 10
+	maxProviderQueryBytes          = 4 << 10
+	maxRerankingEvidenceReferences = 32
+	maxRerankingEvidenceBytes      = 32 << 10
+)
+
+var (
+	// ErrQueryExpansionFailed is returned when a fail-closed expansion stage cannot complete.
+	ErrQueryExpansionFailed = errors.New("query expansion stage failed")
+	// ErrRerankingFailed is returned when a fail-closed reranking stage cannot complete.
+	ErrRerankingFailed = errors.New("reranking stage failed")
+)
+
+type ProviderFailurePolicy string
+
+const (
+	ProviderFailureDegrade    ProviderFailurePolicy = "degrade"
+	ProviderFailureFailClosed ProviderFailurePolicy = "fail_closed"
+)
+
+type ProviderStage string
+
+const (
+	ProviderStageExpansion ProviderStage = "query_expansion"
+	ProviderStageReranking ProviderStage = "reranking"
+)
+
+type ProviderOutcome string
+
+const (
+	ProviderOutcomeApplied             ProviderOutcome = "applied"
+	ProviderOutcomeAuthorizationDenied ProviderOutcome = "authorization_denied"
+	ProviderOutcomeTimedOut            ProviderOutcome = "timed_out"
+	ProviderOutcomeMalformed           ProviderOutcome = "malformed_output"
+	ProviderOutcomeUnavailable         ProviderOutcome = "unavailable"
+)
+
+// ProviderReceipt records a provider-stage outcome without retaining any query,
+// document, provider-response, or credential material.
+type ProviderReceipt struct {
+	Stage          ProviderStage
+	Outcome        ProviderOutcome
+	VariantCount   int
+	CandidateCount int
+}
+
+// ExpansionProfile identifies the bounded expansion behavior independently of
+// the provider, authorization, deadline, and failure policy.
+type ExpansionProfile struct {
+	ID          string
+	MaxVariants int
+}
+
+// RerankingProfile identifies the bounded reranking behavior independently of
+// the provider, authorization, deadline, and failure policy.
+type RerankingProfile struct {
+	ID            string
+	MaxCandidates int
+}
+
+type ExpansionRequest struct {
+	Query       string
+	MaxVariants int
+}
+
+type RerankingRequest struct {
+	Query      string
+	Candidates []RerankingCandidate
+}
+
+// RerankingCandidate is a bounded, already-authorized retrieval result. It
+// never carries a document body; providers receive only its stable identity,
+// bounded lexical excerpt, and provenance references.
+type RerankingCandidate struct {
+	Document DocumentIdentity
+	Excerpt  string
+	Evidence []EvidenceReference
+}
+
+type ProviderInputClass string
+
+const (
+	ProviderInputQueryText       ProviderInputClass = "query_text"
+	ProviderInputQueryAndExcerpt ProviderInputClass = "query_text_and_excerpt"
+)
+
+// ProviderOperation is immutable typed authorization metadata. It deliberately
+// excludes query, excerpt, document, provider-response, and credential text.
+type ProviderOperation struct {
+	Stage                          ProviderStage
+	ProfileID                      string
+	Scope                          store.SearchOptions
+	InputClass                     ProviderInputClass
+	VariantLimit                   int
+	CandidateCount                 int
+	QueryBytes                     int
+	QueryByteLimit                 int
+	ExcerptBytes                   int
+	ExcerptBytesPerCandidateLimit  int
+	ExcerptBytesTotalLimit         int
+	EvidenceCount                  int
+	EvidencePerCandidateLimit      int
+	EvidenceTotalLimit             int
+	EvidenceBytes                  int
+	EvidenceBytesPerCandidateLimit int
+	EvidenceBytesTotalLimit        int
+}
+
+type QueryExpansionProvider interface {
+	Expand(ctx context.Context, request ExpansionRequest) ([]string, error)
+}
+
+type RerankingProvider interface {
+	Rerank(ctx context.Context, request RerankingRequest) ([]RerankScore, error)
+}
+
+// ExpansionAuthorizer is the separate consent/authorization boundary for one
+// expansion operation. Implementations must authorize before provider egress.
+type ExpansionAuthorizer interface {
+	AuthorizeExpansion(ctx context.Context, operation ProviderOperation) error
+}
+
+// RerankingAuthorizer is the separate consent/authorization boundary for one
+// reranking operation. Implementations must authorize before provider egress.
+type RerankingAuthorizer interface {
+	AuthorizeReranking(ctx context.Context, operation ProviderOperation) error
+}
+
+type ExpansionConfig struct {
+	Enabled       bool
+	Profile       ExpansionProfile
+	Provider      QueryExpansionProvider
+	Authorizer    ExpansionAuthorizer
+	Deadline      time.Duration
+	FailurePolicy ProviderFailurePolicy
+}
+
+type RerankingConfig struct {
+	Enabled       bool
+	Profile       RerankingProfile
+	Provider      RerankingProvider
+	Authorizer    RerankingAuthorizer
+	Deadline      time.Duration
+	FailurePolicy ProviderFailurePolicy
+}
+
+// RerankScore is one provider score for an already-authorized document.
+type RerankScore struct {
+	Document DocumentIdentity
+	Score    float64
+}
+
+func validateExpansionConfig(config ExpansionConfig) error {
+	if !config.Enabled {
+		return nil
+	}
+	if config.Profile.ID == "" || config.Profile.MaxVariants < 1 ||
+		config.Profile.MaxVariants > maxQueryExpansionVariants || config.Provider == nil ||
+		config.Authorizer == nil || config.Deadline <= 0 || !validProviderFailurePolicy(config.FailurePolicy) {
+		return errors.New("query expansion configuration is invalid")
+	}
+	return nil
+}
+
+func validateRerankingConfig(config RerankingConfig) error {
+	if !config.Enabled {
+		return nil
+	}
+	if config.Profile.ID == "" || config.Profile.MaxCandidates < 1 ||
+		config.Profile.MaxCandidates > MaxCandidateLimit || config.Provider == nil ||
+		config.Authorizer == nil || config.Deadline <= 0 || !validProviderFailurePolicy(config.FailurePolicy) {
+		return errors.New("reranking configuration is invalid")
+	}
+	return nil
+}
+
+func validProviderFailurePolicy(policy ProviderFailurePolicy) bool {
+	return policy == ProviderFailureDegrade || policy == ProviderFailureFailClosed
+}
+
+func (searcher *Searcher) expand(ctx context.Context, query Query) ([]string, *ProviderReceipt, Degradation, error) {
+	config := searcher.expansion
+	if !config.Enabled {
+		return nil, nil, DegradationNone, nil
+	}
+	stageCtx, cancel := context.WithTimeout(ctx, config.Deadline)
+	defer cancel()
+	if len(query.Text) > maxProviderQueryBytes {
+		return searcher.expandFailure(config, ProviderOutcomeMalformed)
+	}
+	operation := ProviderOperation{Stage: ProviderStageExpansion, ProfileID: config.Profile.ID,
+		Scope: query.Scope, InputClass: ProviderInputQueryText, VariantLimit: config.Profile.MaxVariants,
+		QueryBytes: len(query.Text), QueryByteLimit: maxProviderQueryBytes}
+	if err := config.Authorizer.AuthorizeExpansion(stageCtx, operation); err != nil {
+		if ctx.Err() != nil {
+			return nil, nil, DegradationNone, ctx.Err()
+		}
+		return searcher.expandFailure(config, ProviderOutcomeAuthorizationDenied)
+	}
+	if err := stageCtx.Err(); err != nil {
+		if ctx.Err() != nil {
+			return nil, nil, DegradationNone, ctx.Err()
+		}
+		return searcher.expandFailure(config, stageOutcome(stageCtx))
+	}
+	variants, err := config.Provider.Expand(stageCtx, ExpansionRequest{Query: query.Text,
+		MaxVariants: config.Profile.MaxVariants})
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, nil, DegradationNone, ctx.Err()
+		}
+		return searcher.expandFailure(config, stageOutcome(stageCtx))
+	}
+	if err := stageCtx.Err(); err != nil {
+		if ctx.Err() != nil {
+			return nil, nil, DegradationNone, ctx.Err()
+		}
+		return searcher.expandFailure(config, stageOutcome(stageCtx))
+	}
+	variants, err = validateExpansionVariants(query.Text, variants, config.Profile.MaxVariants)
+	if err != nil {
+		return searcher.expandFailure(config, ProviderOutcomeMalformed)
+	}
+	return variants, &ProviderReceipt{Stage: ProviderStageExpansion,
+		Outcome: ProviderOutcomeApplied, VariantCount: len(variants)}, DegradationNone, nil
+}
+
+func (searcher *Searcher) expandFailure(config ExpansionConfig, outcome ProviderOutcome) ([]string, *ProviderReceipt, Degradation, error) {
+	if config.FailurePolicy == ProviderFailureFailClosed {
+		return nil, nil, DegradationNone, ErrQueryExpansionFailed
+	}
+	return nil, &ProviderReceipt{Stage: ProviderStageExpansion,
+		Outcome: outcome}, DegradationExpansionDegraded, nil
+}
+
+func (searcher *Searcher) rerank(ctx context.Context, query Query, report Report) (Report, *ProviderReceipt, Degradation, error) {
+	config := searcher.reranking
+	if !config.Enabled || len(report.Results) == 0 {
+		return report, nil, DegradationNone, nil
+	}
+	candidates := rerankingCandidates(report.Results, config.Profile.MaxCandidates)
+	allowed := make([]DocumentIdentity, len(candidates))
+	for index, candidate := range candidates {
+		allowed[index] = candidate.Document
+	}
+	stageCtx, cancel := context.WithTimeout(ctx, config.Deadline)
+	defer cancel()
+	if len(query.Text) > maxProviderQueryBytes {
+		return searcher.rerankFailure(config, report, ProviderOutcomeMalformed, len(candidates))
+	}
+	excerptBytes, evidenceCount, evidenceBytes := rerankingPayloadBounds(candidates)
+	operation := ProviderOperation{Stage: ProviderStageReranking, ProfileID: config.Profile.ID,
+		Scope: query.Scope, InputClass: ProviderInputQueryAndExcerpt, CandidateCount: len(candidates),
+		QueryBytes: len(query.Text), QueryByteLimit: maxProviderQueryBytes,
+		ExcerptBytes: excerptBytes, ExcerptBytesPerCandidateLimit: maxRerankingExcerptBytes,
+		ExcerptBytesTotalLimit: boundedProviderTotal(maxRerankingExcerptBytes, len(candidates)),
+		EvidenceCount:          evidenceCount, EvidencePerCandidateLimit: maxRerankingEvidenceReferences,
+		EvidenceTotalLimit: boundedProviderTotal(maxRerankingEvidenceReferences, len(candidates)),
+		EvidenceBytes:      evidenceBytes, EvidenceBytesPerCandidateLimit: maxRerankingEvidenceBytes,
+		EvidenceBytesTotalLimit: boundedProviderTotal(maxRerankingEvidenceBytes, len(candidates))}
+	if err := config.Authorizer.AuthorizeReranking(stageCtx, operation); err != nil {
+		if ctx.Err() != nil {
+			return Report{}, nil, DegradationNone, ctx.Err()
+		}
+		return searcher.rerankFailure(config, report, ProviderOutcomeAuthorizationDenied, len(candidates))
+	}
+	if err := stageCtx.Err(); err != nil {
+		if ctx.Err() != nil {
+			return Report{}, nil, DegradationNone, ctx.Err()
+		}
+		return searcher.rerankFailure(config, report, stageOutcome(stageCtx), len(candidates))
+	}
+	scores, err := config.Provider.Rerank(stageCtx, RerankingRequest{Query: query.Text,
+		Candidates: slices.Clone(candidates)})
+	if err != nil {
+		if ctx.Err() != nil {
+			return Report{}, nil, DegradationNone, ctx.Err()
+		}
+		return searcher.rerankFailure(config, report, stageOutcome(stageCtx), len(candidates))
+	}
+	if err := stageCtx.Err(); err != nil {
+		if ctx.Err() != nil {
+			return Report{}, nil, DegradationNone, ctx.Err()
+		}
+		return searcher.rerankFailure(config, report, stageOutcome(stageCtx), len(candidates))
+	}
+	if err := validateRerankScores(allowed, scores); err != nil {
+		return searcher.rerankFailure(config, report, ProviderOutcomeMalformed, len(candidates))
+	}
+	byDocument := make(map[DocumentIdentity]float64, len(scores))
+	for _, score := range scores {
+		byDocument[score.Document] = score.Score
+	}
+	for index := range report.Results[:len(candidates)] {
+		report.Results[index].Score = byDocument[report.Results[index].Document]
+	}
+	slices.SortFunc(report.Results[:len(candidates)], compareResults)
+	for index := range report.Results {
+		report.Results[index].Rank = index + 1
+	}
+	report.Trace = append(report.Trace, TraceEvent{Code: TraceRerankedCandidates, Count: len(candidates)})
+	return report, &ProviderReceipt{Stage: ProviderStageReranking,
+		Outcome: ProviderOutcomeApplied, CandidateCount: len(candidates)}, DegradationNone, nil
+}
+
+func rerankingCandidates(results []Result, limit int) []RerankingCandidate {
+	count := min(len(results), limit)
+	candidates := make([]RerankingCandidate, count)
+	for index, result := range results[:count] {
+		evidence := boundedRerankingEvidence(result.Evidence)
+		candidates[index] = RerankingCandidate{Document: result.Document,
+			Excerpt: boundedRerankingExcerpt(result.Excerpt), Evidence: evidence}
+	}
+	return candidates
+}
+
+func rerankingPayloadBounds(candidates []RerankingCandidate) (int, int, int) {
+	var excerpts, evidence, evidenceBytes int
+	for _, candidate := range candidates {
+		excerpts += len(candidate.Excerpt)
+		evidence += len(candidate.Evidence)
+		for _, reference := range candidate.Evidence {
+			evidenceBytes += rerankingEvidenceBytes(reference)
+		}
+	}
+	return excerpts, evidence, evidenceBytes
+}
+
+func boundedRerankingEvidence(references []EvidenceReference) []EvidenceReference {
+	bounded := make([]EvidenceReference, 0, min(len(references), maxRerankingEvidenceReferences))
+	bytes := 0
+	for _, reference := range references {
+		size := rerankingEvidenceBytes(reference)
+		if len(bounded) == maxRerankingEvidenceReferences || size > maxRerankingEvidenceBytes-bytes {
+			break
+		}
+		bounded = append(bounded, reference)
+		bytes += size
+	}
+	return bounded
+}
+
+func rerankingEvidenceBytes(reference EvidenceReference) int {
+	return len(reference.Kind) + len(reference.VaultID) + len(reference.ContentVersionID) +
+		len(strconv.FormatInt(reference.NodeRevision, 10)) +
+		len(reference.VectorSpaceID) + len(reference.EmbeddingSetID) + len(reference.InputGenerationID) +
+		len(reference.InputID) + len(reference.InputKind) + len(reference.BuildID) + len(reference.SegmentID) +
+		len(reference.BlobHash) + len(reference.SourceManifestChecksum)
+}
+
+func boundedProviderTotal(perCandidate, candidateCount int) int {
+	if perCandidate <= 0 || candidateCount <= 0 {
+		return 0
+	}
+	if candidateCount > math.MaxInt/perCandidate {
+		return math.MaxInt
+	}
+	return perCandidate * candidateCount
+}
+
+func boundedRerankingExcerpt(excerpt string) string {
+	excerpt = strings.ToValidUTF8(excerpt, "")
+	if len(excerpt) <= maxRerankingExcerptBytes {
+		return excerpt
+	}
+	end := maxRerankingExcerptBytes
+	for end > 0 && !utf8.RuneStart(excerpt[end]) {
+		end--
+	}
+	return excerpt[:end]
+}
+
+func (searcher *Searcher) rerankFailure(config RerankingConfig, report Report, outcome ProviderOutcome,
+	candidateCount int,
+) (Report, *ProviderReceipt, Degradation, error) {
+	if config.FailurePolicy == ProviderFailureFailClosed {
+		return Report{}, nil, DegradationNone, ErrRerankingFailed
+	}
+	return report, &ProviderReceipt{Stage: ProviderStageReranking,
+		Outcome: outcome, CandidateCount: candidateCount}, DegradationRerankingDegraded, nil
+}
+
+func stageOutcome(ctx context.Context) ProviderOutcome {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return ProviderOutcomeTimedOut
+	}
+	return ProviderOutcomeUnavailable
+}
+
+func validateExpansionVariants(query string, variants []string, limit int) ([]string, error) {
+	if limit < 1 || len(variants) > limit {
+		return nil, errors.New("query expansion provider returned an invalid variant count")
+	}
+	seen := make(map[string]struct{}, len(variants))
+	for _, variant := range variants {
+		variant = strings.TrimSpace(variant)
+		if variant == "" || variant == query || len(variant) > maxProviderQueryBytes || !utf8.ValidString(variant) {
+			return nil, errors.New("query expansion provider returned an invalid variant")
+		}
+		if _, duplicate := seen[variant]; duplicate {
+			return nil, errors.New("query expansion provider returned duplicate variants")
+		}
+		seen[variant] = struct{}{}
+	}
+	result := make([]string, 0, len(seen))
+	for variant := range seen {
+		result = append(result, variant)
+	}
+	slices.Sort(result)
+	return result, nil
+}
+
+func validateRerankScores(allowed []DocumentIdentity, scores []RerankScore) error {
+	if len(scores) != len(allowed) {
+		return errors.New("reranking provider returned an invalid score count")
+	}
+	expected := make(map[DocumentIdentity]struct{}, len(allowed))
+	for _, document := range allowed {
+		expected[document] = struct{}{}
+	}
+	seen := make(map[DocumentIdentity]struct{}, len(scores))
+	for _, score := range scores {
+		if _, allowed := expected[score.Document]; !allowed {
+			return errors.New("reranking provider returned an unknown document score")
+		}
+		if _, duplicate := seen[score.Document]; duplicate {
+			return errors.New("reranking provider returned duplicate document scores")
+		}
+		if math.IsNaN(score.Score) || math.IsInf(score.Score, 0) {
+			return errors.New("reranking provider returned a non-finite score")
+		}
+		seen[score.Document] = struct{}{}
+	}
+	return nil
+}

--- a/internal/retrieval/providers.go
+++ b/internal/retrieval/providers.go
@@ -131,16 +131,22 @@ type RerankingProvider interface {
 	Rerank(ctx context.Context, request RerankingRequest) ([]RerankScore, error)
 }
 
-// ExpansionAuthorizer is the separate consent/authorization boundary for one
-// expansion operation. Implementations must authorize before provider egress.
-type ExpansionAuthorizer interface {
-	AuthorizeExpansion(ctx context.Context, operation ProviderOperation) error
+// ProviderEgressLease keeps authorization valid until the provider returns.
+// Revocation must acquire the corresponding exclusive fence. Close only releases
+// the lease and must not fail.
+type ProviderEgressLease interface {
+	Close()
 }
 
-// RerankingAuthorizer is the separate consent/authorization boundary for one
-// reranking operation. Implementations must authorize before provider egress.
+// ExpansionAuthorizer authorizes while acquiring an egress lease. Success must
+// return a non-nil lease; failure must release any acquired resources.
+type ExpansionAuthorizer interface {
+	AuthorizeExpansion(ctx context.Context, operation ProviderOperation) (ProviderEgressLease, error)
+}
+
+// RerankingAuthorizer has the same lease contract as ExpansionAuthorizer.
 type RerankingAuthorizer interface {
-	AuthorizeReranking(ctx context.Context, operation ProviderOperation) error
+	AuthorizeReranking(ctx context.Context, operation ProviderOperation) (ProviderEgressLease, error)
 }
 
 type ExpansionConfig struct {
@@ -208,12 +214,14 @@ func (searcher *Searcher) expand(ctx context.Context, query Query) ([]string, *P
 	operation := ProviderOperation{Stage: ProviderStageExpansion, ProfileID: config.Profile.ID,
 		Scope: query.Scope, InputClass: ProviderInputQueryText, VariantLimit: config.Profile.MaxVariants,
 		QueryBytes: len(query.Text), QueryByteLimit: maxProviderQueryBytes}
-	if err := config.Authorizer.AuthorizeExpansion(stageCtx, operation); err != nil {
+	lease, err := config.Authorizer.AuthorizeExpansion(stageCtx, operation)
+	if err != nil || lease == nil {
 		if ctx.Err() != nil {
 			return nil, nil, DegradationNone, ctx.Err()
 		}
 		return searcher.expandFailure(config, ProviderOutcomeAuthorizationDenied)
 	}
+	defer lease.Close()
 	if err := stageCtx.Err(); err != nil {
 		if ctx.Err() != nil {
 			return nil, nil, DegradationNone, ctx.Err()
@@ -275,12 +283,14 @@ func (searcher *Searcher) rerank(ctx context.Context, query Query, report Report
 		EvidenceTotalLimit: boundedProviderTotal(maxRerankingEvidenceReferences, len(candidates)),
 		EvidenceBytes:      evidenceBytes, EvidenceBytesPerCandidateLimit: maxRerankingEvidenceBytes,
 		EvidenceBytesTotalLimit: boundedProviderTotal(maxRerankingEvidenceBytes, len(candidates))}
-	if err := config.Authorizer.AuthorizeReranking(stageCtx, operation); err != nil {
+	lease, err := config.Authorizer.AuthorizeReranking(stageCtx, operation)
+	if err != nil || lease == nil {
 		if ctx.Err() != nil {
 			return Report{}, nil, DegradationNone, ctx.Err()
 		}
 		return searcher.rerankFailure(config, report, ProviderOutcomeAuthorizationDenied, len(candidates))
 	}
+	defer lease.Close()
 	if err := stageCtx.Err(); err != nil {
 		if ctx.Err() != nil {
 			return Report{}, nil, DegradationNone, ctx.Err()

--- a/internal/retrieval/providers_test.go
+++ b/internal/retrieval/providers_test.go
@@ -1,0 +1,68 @@
+package retrieval
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateExpansionVariantsRejectsMalformedProviderOutput(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		variants []string
+	}{
+		{name: "empty", variants: []string{" "}},
+		{name: "duplicate", variants: []string{"expanded", "expanded"}},
+		{name: "original query", variants: []string{"original"}},
+		{name: "over limit", variants: []string{"one", "two", "three"}},
+		{name: "oversized text", variants: []string{strings.Repeat("x", maxProviderQueryBytes+1)}},
+		{name: "invalid UTF-8", variants: []string{string([]byte{0xff})}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := validateExpansionVariants("original", test.variants, 2)
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "original")
+			assert.NotContains(t, err.Error(), "expanded")
+		})
+	}
+}
+
+func TestValidateExpansionVariantsSortsBoundedVariants(t *testing.T) {
+	t.Parallel()
+
+	variants, err := validateExpansionVariants("original", []string{"zeta", "alpha"}, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "zeta"}, variants)
+}
+
+func TestValidateRerankingScoresRequiresOneFiniteScoreForEveryAllowedCandidate(t *testing.T) {
+	t.Parallel()
+
+	first := DocumentIdentity{VaultID: "vault", NodeID: 1, ContentVersionID: "version-one"}
+	second := DocumentIdentity{VaultID: "vault", NodeID: 2, ContentVersionID: "version-two"}
+	unknown := DocumentIdentity{VaultID: "vault", NodeID: 3, ContentVersionID: "version-three"}
+	for _, test := range []struct {
+		name   string
+		scores []RerankScore
+	}{
+		{name: "missing", scores: []RerankScore{{Document: first, Score: 1}}},
+		{name: "duplicate", scores: []RerankScore{{Document: first, Score: 1}, {Document: first, Score: 2}}},
+		{name: "unknown", scores: []RerankScore{{Document: first, Score: 1}, {Document: unknown, Score: 2}}},
+		{name: "not a number", scores: []RerankScore{{Document: first, Score: 1}, {Document: second, Score: math.NaN()}}},
+		{name: "infinite", scores: []RerankScore{{Document: first, Score: 1}, {Document: second, Score: math.Inf(1)}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateRerankScores([]DocumentIdentity{first, second}, test.scores)
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "version-one")
+			assert.NotContains(t, err.Error(), "version-two")
+		})
+	}
+}

--- a/internal/retrieval/search.go
+++ b/internal/retrieval/search.go
@@ -2,10 +2,12 @@ package retrieval
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -20,6 +22,14 @@ type Backend interface {
 	SearchExplainedLexicalCandidates(ctx context.Context, query string, limit int,
 		options store.SearchOptions) ([]store.ExplainedLexicalCandidate, bool, error)
 }
+
+type CandidateRevalidationBackend interface {
+	RevalidateSearchCandidates(ctx context.Context, candidates []store.SearchCandidateIdentity,
+		options store.SearchOptions, semanticProfileFingerprint,
+		semanticBindingID string) (store.SearchCandidateRevalidation, error)
+}
+
+var ErrExpandedSearchFailed = errors.New("expanded retrieval stage failed")
 
 type SemanticBackend interface {
 	AcquireSemanticSearchAuthority(ctx context.Context, profile, binding, owner string, at time.Time,
@@ -40,6 +50,8 @@ type SearcherConfig struct {
 	Owner         string
 	LeaseDuration time.Duration
 	Clock         func() time.Time
+	Expansion     ExpansionConfig
+	Reranking     RerankingConfig
 }
 
 type Searcher struct {
@@ -48,6 +60,8 @@ type Searcher struct {
 	owner         string
 	leaseDuration time.Duration
 	clock         func() time.Time
+	expansion     ExpansionConfig
+	reranking     RerankingConfig
 }
 
 func NewSearcher(config SearcherConfig) (*Searcher, error) {
@@ -60,11 +74,18 @@ func NewSearcher(config SearcherConfig) (*Searcher, error) {
 	if config.LeaseDuration <= 0 {
 		return nil, errors.New("retrieval vector lease duration must be positive")
 	}
+	if err := validateExpansionConfig(config.Expansion); err != nil {
+		return nil, err
+	}
+	if err := validateRerankingConfig(config.Reranking); err != nil {
+		return nil, err
+	}
 	if config.Clock == nil {
 		config.Clock = time.Now
 	}
 	return &Searcher{backend: config.Backend, encoders: config.Encoders, owner: config.Owner,
-		leaseDuration: config.LeaseDuration, clock: config.Clock}, nil
+		leaseDuration: config.LeaseDuration, clock: config.Clock, expansion: config.Expansion,
+		reranking: config.Reranking}, nil
 }
 
 func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, error) {
@@ -72,6 +93,127 @@ func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, erro
 	if err != nil {
 		return Report{}, err
 	}
+	variants, expansionReceipt, expansionDegradation, err := searcher.expand(ctx, query)
+	if err != nil {
+		return Report{}, err
+	}
+	reports := make([]Report, 0, len(variants)+1)
+	for _, text := range append([]string{query.Text}, variants...) {
+		variant := query
+		variant.Text = text
+		report, err := searcher.searchBase(ctx, variant)
+		if err != nil {
+			if searcher.expansion.Enabled {
+				if ctx.Err() != nil {
+					return Report{}, ctx.Err()
+				}
+				return Report{}, ErrExpandedSearchFailed
+			}
+			return Report{}, err
+		}
+		reports = append(reports, report)
+	}
+	report, err := mergeVariantReports(reports, query.Limit)
+	if err != nil {
+		return Report{}, err
+	}
+	if expansionReceipt != nil {
+		report.Receipts = append(report.Receipts, *expansionReceipt)
+	}
+	if expansionDegradation != DegradationNone {
+		report.Degradations = append(report.Degradations, expansionDegradation)
+	}
+	if searcher.expansion.Enabled {
+		revalidated, err := searcher.revalidateExpandedReport(ctx, query, report)
+		if err != nil {
+			if ctx.Err() != nil {
+				return Report{}, ctx.Err()
+			}
+			return Report{}, ErrExpandedSearchFailed
+		}
+		report = revalidated
+	}
+	report, rerankingReceipt, rerankingDegradation, err := searcher.rerank(ctx, query, report)
+	if err != nil {
+		return Report{}, err
+	}
+	if rerankingReceipt != nil {
+		report.Receipts = append(report.Receipts, *rerankingReceipt)
+	}
+	if rerankingDegradation != DegradationNone {
+		report.Degradations = append(report.Degradations, rerankingDegradation)
+	}
+	return report, nil
+}
+
+func (searcher *Searcher) revalidateExpandedReport(ctx context.Context, query Query, report Report) (Report, error) {
+	backend, ok := searcher.backend.(CandidateRevalidationBackend)
+	if !ok {
+		return Report{}, errors.New("expanded retrieval revalidation is unavailable")
+	}
+	requested := make([]store.SearchCandidateIdentity, len(report.Results))
+	for i, result := range report.Results {
+		evidence := make([]store.SearchEvidenceIdentity, len(result.Evidence))
+		var nodeRevision int64
+		for j, reference := range result.Evidence {
+			if nodeRevision == 0 {
+				nodeRevision = reference.NodeRevision
+			}
+			if reference.NodeRevision != nodeRevision {
+				return Report{}, errors.New("search result evidence spans node revisions")
+			}
+			evidence[j] = store.SearchEvidenceIdentity{Kind: reference.Kind,
+				VectorSpaceID: reference.VectorSpaceID, EmbeddingSetID: reference.EmbeddingSetID,
+				InputGenerationID: reference.InputGenerationID, InputID: reference.InputID,
+				InputKind: reference.InputKind, BuildID: reference.BuildID, SegmentID: reference.SegmentID,
+				BlobHash: reference.BlobHash, SourceManifestChecksum: reference.SourceManifestChecksum}
+		}
+		requested[i] = store.SearchCandidateIdentity{NodeID: result.Document.NodeID, NodeRevision: nodeRevision,
+			ContentVersionID: result.Document.ContentVersionID, Evidence: evidence}
+	}
+	semanticProfile, semanticBinding := "", ""
+	if report.ActualMode == ModeSemantic || report.ActualMode == ModeHybrid {
+		semanticProfile, semanticBinding = query.ProcessingProfileFingerprint, query.BindingID
+	}
+	revalidation, err := backend.RevalidateSearchCandidates(ctx, requested, query.Scope,
+		semanticProfile, semanticBinding)
+	if err != nil {
+		return Report{}, err
+	}
+	if revalidation.Coverage != nil {
+		report.Coverage.ScopedDocuments = revalidation.Coverage.ScopedDocuments
+		report.Coverage.CompleteDocuments = revalidation.Coverage.CompleteDocuments
+		report.Coverage.State = CoverageComplete
+		if report.Coverage.ScopedDocuments != report.Coverage.CompleteDocuments {
+			report.Coverage.State = CoverageIncomplete
+		}
+	}
+	type documentKey struct {
+		nodeID  int64
+		version string
+	}
+	set := make(map[documentKey]struct{}, len(revalidation.Candidates))
+	for _, candidate := range revalidation.Candidates {
+		set[documentKey{nodeID: candidate.NodeID, version: candidate.ContentVersionID}] = struct{}{}
+	}
+	results := report.Results[:0]
+	for _, result := range report.Results {
+		if _, ok := set[documentKey{nodeID: result.Document.NodeID,
+			version: result.Document.ContentVersionID}]; ok {
+			results = append(results, result)
+		}
+	}
+	if len(results) != len(report.Results) {
+		report.Truncated = true
+	}
+	for i := range results {
+		results[i].Rank = i + 1
+	}
+	report.Results = results
+	return report, nil
+}
+
+func (searcher *Searcher) searchBase(ctx context.Context, query Query) (Report, error) {
 	requested := query.Mode
 	switch requested {
 	case ModeLexical, ModeAuto:
@@ -86,6 +228,86 @@ func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, erro
 		return searcher.hybrid(ctx, query, requested)
 	}
 	return Report{}, errors.New("unreachable retrieval mode")
+}
+
+func mergeVariantReports(reports []Report, limit int) (Report, error) {
+	if len(reports) == 0 {
+		return Report{}, errors.New("retrieval requires one query report")
+	}
+	if len(reports) == 1 {
+		return reports[0], nil
+	}
+	merged := reports[0]
+	merged.Coverage = conservativeCoverage(reports)
+	byDocument := make(map[DocumentIdentity]*Result)
+	for _, report := range reports {
+		if report.RequestedMode != merged.RequestedMode || report.ActualMode != merged.ActualMode {
+			return Report{}, errors.New("query variants returned inconsistent retrieval modes")
+		}
+		if !slices.Equal(report.Degradations, merged.Degradations) {
+			return Report{}, errors.New("query variants returned incompatible degradations")
+		}
+		merged.Truncated = merged.Truncated || report.Truncated
+		for _, result := range report.Results {
+			current := byDocument[result.Document]
+			if current == nil {
+				mergedResult := result
+				mergedResult.Explanation = slices.Clone(result.Explanation)
+				mergedResult.Evidence = slices.Clone(result.Evidence)
+				byDocument[result.Document] = &mergedResult
+				continue
+			}
+			current.Score += result.Score
+			current.Explanation = append(current.Explanation, result.Explanation...)
+			current.Evidence = append(current.Evidence, result.Evidence...)
+		}
+	}
+	merged.Results = make([]Result, 0, len(byDocument))
+	for _, result := range byDocument {
+		merged.Results = append(merged.Results, *result)
+	}
+	slices.SortFunc(merged.Results, compareResults)
+	if len(merged.Results) > limit {
+		merged.Results = merged.Results[:limit]
+		merged.Truncated = true
+	}
+	for index := range merged.Results {
+		merged.Results[index].Rank = index + 1
+	}
+	return merged, nil
+}
+
+func compareResults(left, right Result) int {
+	return cmp.Or(cmp.Compare(right.Score, left.Score),
+		cmp.Compare(left.Document.VaultID, right.Document.VaultID),
+		cmp.Compare(left.Document.NodeID, right.Document.NodeID),
+		cmp.Compare(left.Document.ContentVersionID, right.Document.ContentVersionID))
+}
+
+func conservativeCoverage(reports []Report) Coverage {
+	coverage := reports[0].Coverage
+	complete := coverage.CompleteDocuments
+	unknown, incomplete := coverage.State == CoverageUnknown, coverage.State == CoverageIncomplete
+	for _, report := range reports[1:] {
+		coverage.BindingRequired = coverage.BindingRequired || report.Coverage.BindingRequired
+		coverage.ScopedDocuments = max(coverage.ScopedDocuments, report.Coverage.ScopedDocuments)
+		complete = min(complete, report.Coverage.CompleteDocuments)
+		unknown = unknown || report.Coverage.State == CoverageUnknown
+		incomplete = incomplete || report.Coverage.State == CoverageIncomplete
+	}
+	if unknown {
+		coverage.ScopedDocuments = 0
+		coverage.CompleteDocuments = 0
+		coverage.State = CoverageUnknown
+		return coverage
+	}
+	coverage.CompleteDocuments = complete
+	if incomplete || coverage.CompleteDocuments != coverage.ScopedDocuments {
+		coverage.State = CoverageIncomplete
+		return coverage
+	}
+	coverage.State = CoverageComplete
+	return coverage
 }
 
 type semanticReleaseError struct {
@@ -194,6 +416,10 @@ func (searcher *Searcher) semantic(ctx context.Context, query Query) (_ []Candid
 		coverage.State = CoverageIncomplete
 	}
 	resolved := resolution.Candidates
+	if len(resolved) > query.Limit {
+		resolved = resolved[:query.Limit]
+		truncated = true
+	}
 	candidates := make([]Candidate, len(resolved))
 	for index, item := range resolved {
 		if item.VectorSpaceID != authority.VectorSpace.ID {
@@ -203,12 +429,12 @@ func (searcher *Searcher) semantic(ctx context.Context, query Query) (_ []Candid
 			NodeID: item.NodeID, ContentVersionID: item.ContentVersionID}, Lane: LaneSemantic,
 			Rank: index + 1, Score: item.Score, Path: item.Path, VectorSpaceID: item.VectorSpaceID,
 			Evidence: []EvidenceReference{{Kind: "embedding", VaultID: item.VaultID,
-				NodeID: item.NodeID, ContentVersionID: item.ContentVersionID,
+				NodeID: item.NodeID, NodeRevision: item.NodeRevision, ContentVersionID: item.ContentVersionID,
 				VectorSpaceID: item.VectorSpaceID, EmbeddingSetID: item.EmbeddingSetID,
 				InputGenerationID: item.InputGenerationID, InputID: item.InputID,
-				InputKind: item.InputKind}}}
+				InputKind: item.InputKind, SourceManifestChecksum: resolution.SourceManifestChecksum}}}
 	}
-	return candidates, coverage, resolution.Truncated, nil
+	return candidates, coverage, truncated || resolution.Truncated, nil
 }
 
 func normalizeQuery(query Query) (Query, error) {
@@ -232,13 +458,17 @@ func (searcher *Searcher) collectLexical(ctx context.Context, query Query) ([]Ca
 	if err != nil {
 		return nil, false, err
 	}
+	if len(hits) > query.Limit {
+		hits = hits[:query.Limit]
+		truncated = true
+	}
 	candidates := make([]Candidate, len(hits))
 	for index, hit := range hits {
 		candidates[index] = Candidate{Document: DocumentIdentity{VaultID: searcher.backend.VaultID(),
 			NodeID: hit.Node.ID, ContentVersionID: hit.Node.CurrentVersionID}, Lane: LaneLexical,
 			Rank: index + 1, Path: hit.Path, Excerpt: hit.Excerpt,
 			Evidence: []EvidenceReference{{Kind: hit.EvidenceKind, VaultID: searcher.backend.VaultID(),
-				NodeID: hit.Node.ID, ContentVersionID: hit.Node.CurrentVersionID,
+				NodeID: hit.Node.ID, NodeRevision: hit.Node.Revision, ContentVersionID: hit.Node.CurrentVersionID,
 				BuildID: hit.BuildID, SegmentID: hit.SegmentID, BlobHash: hit.BlobHash}}}
 	}
 	return candidates, truncated, nil

--- a/internal/retrieval/search.go
+++ b/internal/retrieval/search.go
@@ -128,13 +128,16 @@ func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, erro
 	if expansionDegradation != DegradationNone {
 		report.Degradations = append(report.Degradations, expansionDegradation)
 	}
-	if searcher.expansion.Enabled {
-		revalidated, err := searcher.revalidateExpandedReport(ctx, query, report)
+	if searcher.expansion.Enabled || searcher.reranking.Enabled {
+		revalidated, err := searcher.revalidateReport(ctx, query, report)
 		if err != nil {
 			if ctx.Err() != nil {
 				return Report{}, ctx.Err()
 			}
-			return Report{}, ErrExpandedSearchFailed
+			if searcher.expansion.Enabled {
+				return Report{}, ErrExpandedSearchFailed
+			}
+			return Report{}, ErrRerankingFailed
 		}
 		report = revalidated
 	}
@@ -151,10 +154,10 @@ func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, erro
 	return report, nil
 }
 
-func (searcher *Searcher) revalidateExpandedReport(ctx context.Context, query Query, report Report) (Report, error) {
+func (searcher *Searcher) revalidateReport(ctx context.Context, query Query, report Report) (Report, error) {
 	backend, ok := searcher.backend.(CandidateRevalidationBackend)
 	if !ok {
-		return Report{}, errors.New("expanded retrieval revalidation is unavailable")
+		return Report{}, errors.New("retrieval candidate revalidation is unavailable")
 	}
 	requested := make([]store.SearchCandidateIdentity, len(report.Results))
 	for i, result := range report.Results {

--- a/internal/retrieval/search.go
+++ b/internal/retrieval/search.go
@@ -192,14 +192,15 @@ func (searcher *Searcher) revalidateExpandedReport(ctx context.Context, query Qu
 		nodeID  int64
 		version string
 	}
-	set := make(map[documentKey]struct{}, len(revalidation.Candidates))
+	set := make(map[documentKey]string, len(revalidation.Candidates))
 	for _, candidate := range revalidation.Candidates {
-		set[documentKey{nodeID: candidate.NodeID, version: candidate.ContentVersionID}] = struct{}{}
+		set[documentKey{nodeID: candidate.NodeID, version: candidate.ContentVersionID}] = candidate.Path
 	}
 	results := report.Results[:0]
 	for _, result := range report.Results {
-		if _, ok := set[documentKey{nodeID: result.Document.NodeID,
+		if currentPath, ok := set[documentKey{nodeID: result.Document.NodeID,
 			version: result.Document.ContentVersionID}]; ok {
+			result.Path = currentPath
 			results = append(results, result)
 		}
 	}

--- a/internal/retrieval/search.go
+++ b/internal/retrieval/search.go
@@ -19,6 +19,7 @@ import (
 
 type Backend interface {
 	VaultID() string
+	NormalizeSearchOptions(ctx context.Context, options store.SearchOptions) (store.SearchOptions, error)
 	SearchExplainedLexicalCandidates(ctx context.Context, query string, limit int,
 		options store.SearchOptions) ([]store.ExplainedLexicalCandidate, bool, error)
 }
@@ -90,6 +91,10 @@ func NewSearcher(config SearcherConfig) (*Searcher, error) {
 
 func (searcher *Searcher) Search(ctx context.Context, query Query) (Report, error) {
 	query, err := normalizeQuery(query)
+	if err != nil {
+		return Report{}, err
+	}
+	query.Scope, err = searcher.backend.NormalizeSearchOptions(ctx, query.Scope)
 	if err != nil {
 		return Report{}, err
 	}

--- a/internal/retrieval/search_stages_test.go
+++ b/internal/retrieval/search_stages_test.go
@@ -1,0 +1,514 @@
+package retrieval
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestSearcherOptionalProviderStagesAreDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	expander := &stageExpander{variants: []string{"replacement"}}
+	reranker := &stageReranker{}
+	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Profile: ExpansionProfile{ID: "expansion", MaxVariants: 1},
+			Provider: expander, Authorizer: &stageAuthorizer{}, Deadline: time.Second,
+			FailurePolicy: ProviderFailureDegrade}
+		config.Reranking = RerankingConfig{Profile: RerankingProfile{ID: "reranking", MaxCandidates: 1},
+			Provider: reranker, Authorizer: &stageAuthorizer{}, Deadline: time.Second,
+			FailurePolicy: ProviderFailureDegrade}
+	})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "original", Mode: ModeLexical, Limit: 1})
+	require.NoError(t, err)
+	assert.Zero(t, expander.calls)
+	assert.Zero(t, reranker.calls)
+	assert.Equal(t, []string{"original"}, backend.queries)
+	assert.Empty(t, report.Receipts)
+	assert.Empty(t, report.Degradations)
+}
+
+func TestSearcherExpansionAuthorizesBeforeProviderAndDegradesSafely(t *testing.T) {
+	t.Parallel()
+
+	denied := &stageAuthorizer{err: errors.New("private query: denied")}
+	expander := &stageExpander{variants: []string{"replacement"}}
+	searcher, _ := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Enabled: true,
+			Profile:  ExpansionProfile{ID: "expansion", MaxVariants: 1},
+			Provider: expander, Authorizer: denied, Deadline: time.Second,
+			FailurePolicy: ProviderFailureDegrade}
+	})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "private query", Mode: ModeLexical, Limit: 1})
+	require.NoError(t, err)
+	assert.Zero(t, expander.calls)
+	assert.Equal(t, []Degradation{DegradationExpansionDegraded}, report.Degradations)
+	require.Equal(t, []ProviderReceipt{{Stage: ProviderStageExpansion,
+		Outcome: ProviderOutcomeAuthorizationDenied}}, report.Receipts)
+	assert.NotContains(t, fmt.Sprintf("%#v", report), "private query")
+}
+
+func TestSearcherExpansionUsesVariantsWithoutBroadeningScope(t *testing.T) {
+	t.Parallel()
+
+	expander := &stageExpander{variants: []string{"zeta", "alpha"}}
+	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Enabled: true,
+			Profile: ExpansionProfile{ID: "expansion", MaxVariants: 2}, Provider: expander,
+			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureDegrade}
+	})
+	scope := store.SearchOptions{TagID: "tag", MIMEType: "text/plain", UnderNodeID: 7,
+		ModifiedSince: "2026-01-01T00:00:00Z", ModifiedBefore: "2026-12-31T00:00:00Z"}
+
+	report, err := searcher.Search(t.Context(), Query{Text: "original", Mode: ModeLexical, Limit: 2, Scope: scope})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"original", "alpha", "zeta"}, backend.queries)
+	assert.Equal(t, []store.SearchOptions{scope, scope, scope}, backend.scopes)
+	assert.LessOrEqual(t, len(report.Results), 2)
+	assert.Equal(t, []ProviderReceipt{{Stage: ProviderStageExpansion,
+		Outcome: ProviderOutcomeApplied, VariantCount: 2}}, report.Receipts)
+}
+
+func TestSearcherRerankingTimesOutAndReportsNamedDegradation(t *testing.T) {
+	t.Parallel()
+
+	reranker := &stageReranker{wait: true}
+	searcher, _ := stageSearcher(t, func(config *SearcherConfig) {
+		config.Reranking = RerankingConfig{Enabled: true,
+			Profile: RerankingProfile{ID: "reranking", MaxCandidates: 1}, Provider: reranker,
+			Authorizer: &stageAuthorizer{}, Deadline: time.Millisecond, FailurePolicy: ProviderFailureDegrade}
+	})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "private query", Mode: ModeLexical, Limit: 1})
+	require.NoError(t, err)
+	assert.Equal(t, []Degradation{DegradationRerankingDegraded}, report.Degradations)
+	assert.Equal(t, []ProviderReceipt{{Stage: ProviderStageReranking,
+		Outcome: ProviderOutcomeTimedOut, CandidateCount: 1}}, report.Receipts)
+	assert.NotContains(t, fmt.Sprintf("%#v", report), "private query")
+}
+
+func TestSearcherRejectsExpansionResponseReturnedAfterDeadline(t *testing.T) {
+	t.Parallel()
+
+	expander := &stageExpander{variants: []string{"replacement"}, waitThenSucceed: true}
+	searcher, _ := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Enabled: true,
+			Profile: ExpansionProfile{ID: "expansion", MaxVariants: 1}, Provider: expander,
+			Authorizer: &stageAuthorizer{}, Deadline: time.Millisecond, FailurePolicy: ProviderFailureDegrade}
+	})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "private query", Mode: ModeLexical, Limit: 1})
+	require.NoError(t, err)
+	assert.Equal(t, []Degradation{DegradationExpansionDegraded}, report.Degradations)
+	assert.Equal(t, []ProviderReceipt{{Stage: ProviderStageExpansion,
+		Outcome: ProviderOutcomeTimedOut}}, report.Receipts)
+}
+
+func TestSearcherFailClosedProviderFailureIsSanitized(t *testing.T) {
+	t.Parallel()
+
+	searcher, _ := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Enabled: true,
+			Profile:    ExpansionProfile{ID: "expansion", MaxVariants: 1},
+			Provider:   &stageExpander{err: errors.New("private query; provider body; credential")},
+			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+	})
+
+	_, err := searcher.Search(t.Context(), Query{Text: "private query", Mode: ModeLexical, Limit: 1})
+	require.ErrorIs(t, err, ErrQueryExpansionFailed)
+	assert.NotContains(t, err.Error(), "private query")
+	assert.NotContains(t, err.Error(), "provider body")
+	assert.NotContains(t, err.Error(), "credential")
+}
+
+func TestSearcherProviderReceiptDoesNotRetainProfileText(t *testing.T) {
+	t.Parallel()
+
+	searcher, _ := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Enabled: true,
+			Profile:    ExpansionProfile{ID: "credential: private-profile", MaxVariants: 1},
+			Provider:   &stageExpander{err: errors.New("expanded text; document text; excerpt; provider body; credential")},
+			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureDegrade}
+	})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "private query", Mode: ModeLexical, Limit: 1})
+	require.NoError(t, err)
+	receipt := fmt.Sprintf("%#v", report.Receipts)
+	for _, sensitive := range []string{"credential: private-profile", "expanded text", "document text", "excerpt", "provider body", "credential"} {
+		assert.NotContains(t, receipt, sensitive)
+	}
+}
+
+func TestSearcherRerankingReordersOnlyAuthorizedCandidates(t *testing.T) {
+	t.Parallel()
+
+	reranker := &stageReranker{scores: []RerankScore{
+		{Document: DocumentIdentity{VaultID: "vault", NodeID: 1, ContentVersionID: "version-1"}, Score: 1},
+		{Document: DocumentIdentity{VaultID: "vault", NodeID: 2, ContentVersionID: "version-2"}, Score: 2},
+	}}
+	searcher, _ := stageSearcher(t, func(config *SearcherConfig) {
+		config.Reranking = RerankingConfig{Enabled: true,
+			Profile: RerankingProfile{ID: "reranking", MaxCandidates: 2}, Provider: reranker,
+			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+	})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "original", Mode: ModeLexical, Limit: 2})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), report.Results[0].Document.NodeID)
+	assert.Equal(t, int64(1), report.Results[1].Document.NodeID)
+	assert.Equal(t, []RerankingCandidate{
+		{Document: DocumentIdentity{VaultID: "vault", NodeID: 1, ContentVersionID: "version-1"}, Evidence: []EvidenceReference{{Kind: "node_name", VaultID: "vault", NodeID: 1, ContentVersionID: "version-1"}}},
+		{Document: DocumentIdentity{VaultID: "vault", NodeID: 2, ContentVersionID: "version-2"}, Evidence: []EvidenceReference{{Kind: "node_name", VaultID: "vault", NodeID: 2, ContentVersionID: "version-2"}}},
+	}, reranker.candidates)
+}
+
+func TestSearcherRerankingReceivesOnlyBoundedAuthorizedCandidatePayload(t *testing.T) {
+	t.Parallel()
+
+	authorizer := &stageAuthorizer{}
+	reranker := &stageReranker{}
+	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {
+		config.Reranking = RerankingConfig{Enabled: true,
+			Profile: RerankingProfile{ID: "reranking", MaxCandidates: MaxCandidateLimit}, Provider: reranker,
+			Authorizer: authorizer, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+	})
+	backend.hits = []store.ExplainedLexicalCandidate{
+		{Node: store.Node{ID: 1, CurrentVersionID: "version-1", Name: "one"}, Path: "/one",
+			EvidenceKind: "rendition_segment", BuildID: "build-1", SegmentID: "segment-1",
+			Excerpt: strings.Repeat("x", maxRerankingExcerptBytes+1)},
+		{Node: store.Node{ID: 2, CurrentVersionID: "version-2", Name: "two"}, Path: "/two",
+			EvidenceKind: "rendition_segment", BuildID: "build-2", SegmentID: "segment-2", Excerpt: "out-of-scope"},
+	}
+	scope := store.SearchOptions{TagID: "tag", UnderNodeID: 7}
+
+	_, err := searcher.Search(t.Context(), Query{Text: "private query", Mode: ModeLexical, Limit: 1, Scope: scope})
+	require.NoError(t, err)
+	require.Len(t, reranker.candidates, 1)
+	assert.Equal(t, DocumentIdentity{VaultID: "vault", NodeID: 1, ContentVersionID: "version-1"}, reranker.candidates[0].Document)
+	assert.Len(t, reranker.candidates[0].Excerpt, maxRerankingExcerptBytes)
+	assert.Equal(t, []EvidenceReference{{Kind: "rendition_segment", VaultID: "vault", NodeID: 1,
+		ContentVersionID: "version-1", BuildID: "build-1", SegmentID: "segment-1"}}, reranker.candidates[0].Evidence)
+	require.Len(t, authorizer.operations, 1)
+	assert.Equal(t, ProviderOperation{Stage: ProviderStageReranking, ProfileID: "reranking", Scope: scope,
+		InputClass: ProviderInputQueryAndExcerpt, CandidateCount: 1,
+		QueryBytes: len("private query"), QueryByteLimit: maxProviderQueryBytes,
+		ExcerptBytes: maxRerankingExcerptBytes, ExcerptBytesPerCandidateLimit: maxRerankingExcerptBytes,
+		ExcerptBytesTotalLimit: maxRerankingExcerptBytes,
+		EvidenceCount:          1, EvidencePerCandidateLimit: maxRerankingEvidenceReferences,
+		EvidenceTotalLimit:             maxRerankingEvidenceReferences,
+		EvidenceBytes:                  rerankingEvidenceBytes(reranker.candidates[0].Evidence[0]),
+		EvidenceBytesPerCandidateLimit: maxRerankingEvidenceBytes,
+		EvidenceBytesTotalLimit:        maxRerankingEvidenceBytes}, authorizer.operations[0])
+}
+
+func TestSearcherRerankingAuthorizationBindsPerCandidateAndTotalPayloadLimits(t *testing.T) {
+	t.Parallel()
+
+	authorizer := &stageAuthorizer{}
+	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {
+		config.Reranking = RerankingConfig{Enabled: true,
+			Profile: RerankingProfile{ID: "reranking", MaxCandidates: 2}, Provider: &stageReranker{},
+			Authorizer: authorizer, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+	})
+	backend.hits = []store.ExplainedLexicalCandidate{
+		{Node: store.Node{ID: 1, CurrentVersionID: "version-1", Name: "one"}, Path: "/one",
+			EvidenceKind: "rendition_segment", BuildID: "build-1", SegmentID: "segment-1",
+			Excerpt: strings.Repeat("a", maxRerankingExcerptBytes+1)},
+		{Node: store.Node{ID: 2, CurrentVersionID: "version-2", Name: "two"}, Path: "/two",
+			EvidenceKind: "rendition_segment", BuildID: "build-2", SegmentID: "segment-2",
+			Excerpt: strings.Repeat("b", maxRerankingExcerptBytes+1)},
+	}
+
+	_, err := searcher.Search(t.Context(), Query{Text: "private query", Mode: ModeLexical, Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, authorizer.operations, 1)
+	operation := authorizer.operations[0]
+	assert.Equal(t, 2*maxRerankingExcerptBytes, operation.ExcerptBytes)
+	assert.Equal(t, maxRerankingExcerptBytes, operation.ExcerptBytesPerCandidateLimit)
+	assert.Equal(t, 2*maxRerankingExcerptBytes, operation.ExcerptBytesTotalLimit)
+	assert.Equal(t, 2, operation.EvidenceCount)
+	assert.Equal(t, maxRerankingEvidenceReferences, operation.EvidencePerCandidateLimit)
+	assert.Equal(t, 2*maxRerankingEvidenceReferences, operation.EvidenceTotalLimit)
+	assert.Positive(t, operation.EvidenceBytes)
+	assert.Equal(t, maxRerankingEvidenceBytes, operation.EvidenceBytesPerCandidateLimit)
+	assert.Equal(t, 2*maxRerankingEvidenceBytes, operation.EvidenceBytesTotalLimit)
+}
+
+func TestSearcherRerankingAuthorizationPrecedesProviderEgress(t *testing.T) {
+	t.Parallel()
+
+	authorizer := &stageAuthorizer{err: errors.New("denied")}
+	reranker := &stageReranker{}
+	searcher, _ := stageSearcher(t, func(config *SearcherConfig) {
+		config.Reranking = RerankingConfig{Enabled: true,
+			Profile: RerankingProfile{ID: "reranking", MaxCandidates: 1}, Provider: reranker,
+			Authorizer: authorizer, Deadline: time.Second, FailurePolicy: ProviderFailureDegrade}
+	})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "private query", Mode: ModeLexical, Limit: 1,
+		Scope: store.SearchOptions{MIMEType: "text/plain"}})
+	require.NoError(t, err)
+	assert.Zero(t, reranker.calls)
+	require.Len(t, authorizer.operations, 1)
+	assert.Equal(t, ProviderInputQueryAndExcerpt, authorizer.operations[0].InputClass)
+	assert.Equal(t, DegradationRerankingDegraded, report.Degradations[0])
+}
+
+func TestMergeVariantReportsConservativelyAggregatesCoverage(t *testing.T) {
+	t.Parallel()
+
+	first := Report{RequestedMode: ModeSemantic, ActualMode: ModeSemantic,
+		Coverage: Coverage{BindingRequired: true, ScopedDocuments: 1, CompleteDocuments: 1, State: CoverageComplete}}
+	second := Report{RequestedMode: ModeSemantic, ActualMode: ModeSemantic,
+		Coverage: Coverage{BindingRequired: true, ScopedDocuments: 2, CompleteDocuments: 1, State: CoverageIncomplete}}
+
+	merged, err := mergeVariantReports([]Report{first, second}, 1)
+	require.NoError(t, err)
+	assert.Equal(t, Coverage{BindingRequired: true, ScopedDocuments: 2, CompleteDocuments: 1,
+		State: CoverageIncomplete}, merged.Coverage)
+}
+
+func TestMergeVariantReportsRejectsIncompatibleDegradation(t *testing.T) {
+	t.Parallel()
+
+	_, err := mergeVariantReports([]Report{
+		{RequestedMode: ModeLexical, ActualMode: ModeLexical, Degradations: nil},
+		{RequestedMode: ModeLexical, ActualMode: ModeLexical, Degradations: []Degradation{DegradationExpansionDegraded}},
+	}, 1)
+	require.Error(t, err)
+}
+
+func TestSearcherExpandedVariantsRevalidateCurrentScopeBeforeReranking(t *testing.T) {
+	t.Parallel()
+
+	expander := &stageExpander{variants: []string{"expanded"}}
+	reranker := &stageReranker{}
+	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Enabled: true,
+			Profile: ExpansionProfile{ID: "expansion", MaxVariants: 1}, Provider: expander,
+			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+		config.Reranking = RerankingConfig{Enabled: true,
+			Profile: RerankingProfile{ID: "reranking", MaxCandidates: 2}, Provider: reranker,
+			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+	})
+	backend.revalidated = []store.SearchCandidateIdentity{{NodeID: 1, ContentVersionID: "version-1"}}
+
+	report, err := searcher.Search(t.Context(), Query{Text: "original", Mode: ModeLexical, Limit: 2,
+		Scope: store.SearchOptions{TagID: "tag"}})
+	require.NoError(t, err)
+	assert.Len(t, report.Results, 1)
+	assert.Len(t, reranker.candidates, 1)
+	assert.Equal(t, int64(1), reranker.candidates[0].Document.NodeID)
+	assert.Equal(t, 1, backend.revalidationCalls)
+}
+
+func TestExpandedSemanticSearchReportsCoverageChangesAtFinalFence(t *testing.T) {
+	t.Parallel()
+
+	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {})
+	backend.revalidated = []store.SearchCandidateIdentity{{NodeID: 1, ContentVersionID: "version-1"}}
+	backend.revalidationCoverage = &store.SearchCoverageSnapshot{ScopedDocuments: 2, CompleteDocuments: 1}
+	report := Report{RequestedMode: ModeSemantic, ActualMode: ModeSemantic,
+		Coverage: Coverage{BindingRequired: true, ScopedDocuments: 1, CompleteDocuments: 1,
+			State: CoverageComplete},
+		Results: []Result{{Document: DocumentIdentity{VaultID: "vault", NodeID: 1,
+			ContentVersionID: "version-1"}, Evidence: []EvidenceReference{{Kind: "node_name"}}}}}
+
+	revalidated, err := searcher.revalidateExpandedReport(t.Context(), Query{
+		ProcessingProfileFingerprint: "profile", BindingID: "required"}, report)
+
+	require.NoError(t, err)
+	assert.Equal(t, Coverage{BindingRequired: true, ScopedDocuments: 2, CompleteDocuments: 1,
+		State: CoverageIncomplete}, revalidated.Coverage)
+}
+
+func TestSearcherSanitizesExpandedSearchFailure(t *testing.T) {
+	t.Parallel()
+
+	expander := &stageExpander{variants: []string{"expanded secret"}}
+	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Enabled: true,
+			Profile: ExpansionProfile{ID: "expansion", MaxVariants: 1}, Provider: expander,
+			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+	})
+	backend.errForQuery = map[string]error{"expanded secret": errors.New("original secret / expanded secret")}
+
+	_, err := searcher.Search(t.Context(), Query{Text: "original secret", Mode: ModeLexical, Limit: 1})
+	require.ErrorIs(t, err, ErrExpandedSearchFailed)
+	assert.NotContains(t, err.Error(), "original secret")
+	assert.NotContains(t, err.Error(), "expanded secret")
+}
+
+func TestSearcherPreservesParentCancellationDuringExpandedSearch(t *testing.T) {
+	t.Parallel()
+
+	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {
+		config.Expansion = ExpansionConfig{Enabled: true,
+			Profile:  ExpansionProfile{ID: "expansion", MaxVariants: 1},
+			Provider: &stageExpander{variants: []string{"expanded"}}, Authorizer: &stageAuthorizer{},
+			Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	backend.cancelForQuery, backend.cancel = "expanded", cancel
+
+	_, err := searcher.Search(ctx, Query{Text: "original", Mode: ModeLexical, Limit: 1})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSearcherBoundsRerankingToTheRequestedCandidateLimit(t *testing.T) {
+	t.Parallel()
+
+	reranker := &stageReranker{}
+	searcher, _ := stageSearcher(t, func(config *SearcherConfig) {
+		config.Reranking = RerankingConfig{Enabled: true,
+			Profile: RerankingProfile{ID: "reranking", MaxCandidates: MaxCandidateLimit}, Provider: reranker,
+			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
+	})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "original", Mode: ModeLexical, Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, []RerankingCandidate{{Document: DocumentIdentity{VaultID: "vault", NodeID: 1, ContentVersionID: "version-1"},
+		Evidence: []EvidenceReference{{Kind: "node_name", VaultID: "vault", NodeID: 1, ContentVersionID: "version-1"}}}}, reranker.candidates)
+}
+
+func TestSearcherBoundsSemanticCandidatesToTheRequestedLimit(t *testing.T) {
+	t.Parallel()
+
+	searcher, backend, _, descriptor := retrievalSearcherFixture(t, true, 1)
+	backend.semantic = append(backend.semantic, store.SemanticSearchCandidate{VaultID: "vault", NodeID: 9,
+		ContentVersionID: "version-extra", Path: "/extra", VectorSpaceID: backend.authority.VectorSpace.ID,
+		EmbeddingSetID: "set-extra", InputGenerationID: "generation-extra", InputID: "input-extra",
+		InputKind: document.EmbeddingInputOriginalFile, Score: 0.5})
+
+	report, err := searcher.Search(t.Context(), Query{Text: "original", Mode: ModeSemantic, Limit: 1,
+		ProcessingProfileFingerprint: "profile", BindingID: "required", Authorization: retrievalAuthorization(descriptor)})
+	require.NoError(t, err)
+	assert.Len(t, report.Results, 1)
+	assert.True(t, report.Truncated)
+}
+
+type stageBackend struct {
+	queries              []string
+	scopes               []store.SearchOptions
+	hits                 []store.ExplainedLexicalCandidate
+	revalidated          []store.SearchCandidateIdentity
+	revalidationCoverage *store.SearchCoverageSnapshot
+	revalidationCalls    int
+	errForQuery          map[string]error
+	cancelForQuery       string
+	cancel               context.CancelFunc
+}
+
+func (backend *stageBackend) VaultID() string { return "vault" }
+
+func (backend *stageBackend) SearchExplainedLexicalCandidates(_ context.Context, query string, _ int,
+	scope store.SearchOptions,
+) ([]store.ExplainedLexicalCandidate, bool, error) {
+	if query == backend.cancelForQuery {
+		backend.cancel()
+		return nil, false, context.Canceled
+	}
+	if err := backend.errForQuery[query]; err != nil {
+		return nil, false, err
+	}
+	backend.queries = append(backend.queries, query)
+	backend.scopes = append(backend.scopes, scope)
+	hits := backend.hits
+	if hits == nil {
+		hits = []store.ExplainedLexicalCandidate{
+			{Node: store.Node{ID: 1, CurrentVersionID: "version-1", Name: "one"}, Path: "/one", EvidenceKind: "node_name"},
+			{Node: store.Node{ID: 2, CurrentVersionID: "version-2", Name: "two"}, Path: "/two", EvidenceKind: "node_name"},
+		}
+	}
+	return hits, false, nil
+}
+
+func (backend *stageBackend) RevalidateSearchCandidates(_ context.Context,
+	_ []store.SearchCandidateIdentity, _ store.SearchOptions, _, _ string,
+) (store.SearchCandidateRevalidation, error) {
+	backend.revalidationCalls++
+	if backend.revalidated != nil {
+		return store.SearchCandidateRevalidation{Candidates: backend.revalidated,
+			Coverage: backend.revalidationCoverage}, nil
+	}
+	return store.SearchCandidateRevalidation{Candidates: []store.SearchCandidateIdentity{
+		{NodeID: 1, ContentVersionID: "version-1"}, {NodeID: 2, ContentVersionID: "version-2"}},
+		Coverage: backend.revalidationCoverage}, nil
+}
+
+func stageSearcher(t *testing.T, configure func(*SearcherConfig)) (*Searcher, *stageBackend) {
+	t.Helper()
+	backend := &stageBackend{}
+	config := SearcherConfig{Backend: backend, Owner: "retrieval-test", LeaseDuration: time.Minute, Clock: time.Now}
+	configure(&config)
+	searcher, err := NewSearcher(config)
+	require.NoError(t, err)
+	return searcher, backend
+}
+
+type stageAuthorizer struct {
+	err        error
+	operations []ProviderOperation
+}
+
+func (authorizer *stageAuthorizer) AuthorizeExpansion(_ context.Context, operation ProviderOperation) error {
+	authorizer.operations = append(authorizer.operations, operation)
+	return authorizer.err
+}
+
+func (authorizer *stageAuthorizer) AuthorizeReranking(_ context.Context, operation ProviderOperation) error {
+	authorizer.operations = append(authorizer.operations, operation)
+	return authorizer.err
+}
+
+type stageExpander struct {
+	variants        []string
+	err             error
+	waitThenSucceed bool
+	calls           int
+}
+
+func (provider *stageExpander) Expand(ctx context.Context, _ ExpansionRequest) ([]string, error) {
+	provider.calls++
+	if provider.waitThenSucceed {
+		<-ctx.Done()
+		return provider.variants, nil
+	}
+	return provider.variants, provider.err
+}
+
+type stageReranker struct {
+	scores     []RerankScore
+	candidates []RerankingCandidate
+	wait       bool
+	calls      int
+}
+
+func (provider *stageReranker) Rerank(ctx context.Context, request RerankingRequest) ([]RerankScore, error) {
+	provider.calls++
+	provider.candidates = append([]RerankingCandidate(nil), request.Candidates...)
+	if provider.wait {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if provider.scores != nil {
+		return provider.scores, nil
+	}
+	scores := make([]RerankScore, len(request.Candidates))
+	for index, candidate := range request.Candidates {
+		scores[index] = RerankScore{Document: candidate.Document, Score: float64(len(scores) - index)}
+	}
+	return scores, nil
+}

--- a/internal/retrieval/search_stages_test.go
+++ b/internal/retrieval/search_stages_test.go
@@ -463,14 +463,20 @@ type stageAuthorizer struct {
 	operations []ProviderOperation
 }
 
-func (authorizer *stageAuthorizer) AuthorizeExpansion(_ context.Context, operation ProviderOperation) error {
+func (authorizer *stageAuthorizer) AuthorizeExpansion(_ context.Context, operation ProviderOperation) (ProviderEgressLease, error) {
 	authorizer.operations = append(authorizer.operations, operation)
-	return authorizer.err
+	if authorizer.err != nil {
+		return nil, authorizer.err
+	}
+	return authorizer, nil
 }
 
-func (authorizer *stageAuthorizer) AuthorizeReranking(_ context.Context, operation ProviderOperation) error {
+func (authorizer *stageAuthorizer) AuthorizeReranking(_ context.Context, operation ProviderOperation) (ProviderEgressLease, error) {
 	authorizer.operations = append(authorizer.operations, operation)
-	return authorizer.err
+	if authorizer.err != nil {
+		return nil, authorizer.err
+	}
+	return authorizer, nil
 }
 
 type stageExpander struct {
@@ -516,3 +522,5 @@ func (provider *stageReranker) Rerank(ctx context.Context, request RerankingRequ
 func (backend *stageBackend) NormalizeSearchOptions(_ context.Context, options store.SearchOptions) (store.SearchOptions, error) {
 	return options, nil
 }
+
+func (authorizer *stageAuthorizer) Close() {}

--- a/internal/retrieval/search_stages_test.go
+++ b/internal/retrieval/search_stages_test.go
@@ -324,7 +324,7 @@ func TestExpandedSemanticSearchReportsCoverageChangesAtFinalFence(t *testing.T) 
 		Results: []Result{{Document: DocumentIdentity{VaultID: "vault", NodeID: 1,
 			ContentVersionID: "version-1"}, Evidence: []EvidenceReference{{Kind: "node_name"}}}}}
 
-	revalidated, err := searcher.revalidateExpandedReport(t.Context(), Query{
+	revalidated, err := searcher.revalidateReport(t.Context(), Query{
 		ProcessingProfileFingerprint: "profile", BindingID: "required"}, report)
 
 	require.NoError(t, err)

--- a/internal/retrieval/search_stages_test.go
+++ b/internal/retrieval/search_stages_test.go
@@ -512,3 +512,7 @@ func (provider *stageReranker) Rerank(ctx context.Context, request RerankingRequ
 	}
 	return scores, nil
 }
+
+func (backend *stageBackend) NormalizeSearchOptions(_ context.Context, options store.SearchOptions) (store.SearchOptions, error) {
+	return options, nil
+}

--- a/internal/retrieval/search_stages_test.go
+++ b/internal/retrieval/search_stages_test.go
@@ -301,7 +301,7 @@ func TestSearcherExpandedVariantsRevalidateCurrentScopeBeforeReranking(t *testin
 			Profile: RerankingProfile{ID: "reranking", MaxCandidates: 2}, Provider: reranker,
 			Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}
 	})
-	backend.revalidated = []store.SearchCandidateIdentity{{NodeID: 1, ContentVersionID: "version-1"}}
+	backend.revalidated = []store.RevalidatedSearchCandidate{{NodeID: 1, ContentVersionID: "version-1"}}
 
 	report, err := searcher.Search(t.Context(), Query{Text: "original", Mode: ModeLexical, Limit: 2,
 		Scope: store.SearchOptions{TagID: "tag"}})
@@ -316,7 +316,7 @@ func TestExpandedSemanticSearchReportsCoverageChangesAtFinalFence(t *testing.T) 
 	t.Parallel()
 
 	searcher, backend := stageSearcher(t, func(config *SearcherConfig) {})
-	backend.revalidated = []store.SearchCandidateIdentity{{NodeID: 1, ContentVersionID: "version-1"}}
+	backend.revalidated = []store.RevalidatedSearchCandidate{{NodeID: 1, ContentVersionID: "version-1"}}
 	backend.revalidationCoverage = &store.SearchCoverageSnapshot{ScopedDocuments: 2, CompleteDocuments: 1}
 	report := Report{RequestedMode: ModeSemantic, ActualMode: ModeSemantic,
 		Coverage: Coverage{BindingRequired: true, ScopedDocuments: 1, CompleteDocuments: 1,
@@ -403,7 +403,7 @@ type stageBackend struct {
 	queries              []string
 	scopes               []store.SearchOptions
 	hits                 []store.ExplainedLexicalCandidate
-	revalidated          []store.SearchCandidateIdentity
+	revalidated          []store.RevalidatedSearchCandidate
 	revalidationCoverage *store.SearchCoverageSnapshot
 	revalidationCalls    int
 	errForQuery          map[string]error
@@ -443,7 +443,7 @@ func (backend *stageBackend) RevalidateSearchCandidates(_ context.Context,
 		return store.SearchCandidateRevalidation{Candidates: backend.revalidated,
 			Coverage: backend.revalidationCoverage}, nil
 	}
-	return store.SearchCandidateRevalidation{Candidates: []store.SearchCandidateIdentity{
+	return store.SearchCandidateRevalidation{Candidates: []store.RevalidatedSearchCandidate{
 		{NodeID: 1, ContentVersionID: "version-1"}, {NodeID: 2, ContentVersionID: "version-2"}},
 		Coverage: backend.revalidationCoverage}, nil
 }

--- a/internal/retrieval/search_store_test.go
+++ b/internal/retrieval/search_store_test.go
@@ -40,3 +40,48 @@ func TestExpandedSearchRefreshesPathsAfterAncestorMove(t *testing.T) {
 	require.Len(t, revalidated.Results, 1)
 	assert.Equal(t, "/after/needle.txt", revalidated.Results[0].Path)
 }
+
+func TestExpansionValidatesScopeBeforeAuthorizationAndProvider(t *testing.T) {
+	catalog, err := store.Open(filepath.Join(t.TempDir(), "search.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, catalog.Close()) })
+	file, err := catalog.CreateFile(t.Context(), catalog.RootID(), "needle.txt", strings.Repeat("a", 64), 1, "text/plain")
+	require.NoError(t, err)
+	for _, scope := range []store.SearchOptions{
+		{TagID: "missing-tag"},
+		{MIMEType: "text/*"},
+		{MIMEType: "text/plain; charset=utf-8"},
+		{UnderNodeID: -1},
+		{UnderNodeID: file.ID},
+		{UnderNodeID: 99999},
+		{ModifiedSince: "yesterday"},
+	} {
+		authorizer := &stageAuthorizer{}
+		provider := &stageExpander{}
+		searcher, err := NewSearcher(SearcherConfig{Backend: catalog, Owner: "search-test", LeaseDuration: time.Minute,
+			Expansion: ExpansionConfig{Enabled: true, Profile: ExpansionProfile{ID: "expansion", MaxVariants: 1},
+				Provider: provider, Authorizer: authorizer, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}})
+		require.NoError(t, err)
+
+		_, err = searcher.Search(t.Context(), Query{Text: "needle", Mode: ModeLexical, Scope: scope})
+		require.Error(t, err)
+		assert.Empty(t, authorizer.operations, "invalid scope: %+v", scope)
+		assert.Zero(t, provider.calls, "invalid scope: %+v", scope)
+	}
+
+	authorizer := &stageAuthorizer{}
+	provider := &stageExpander{}
+	searcher, err := NewSearcher(SearcherConfig{Backend: catalog, Owner: "search-test", LeaseDuration: time.Minute,
+		Expansion: ExpansionConfig{Enabled: true, Profile: ExpansionProfile{ID: "expansion", MaxVariants: 1},
+			Provider: provider, Authorizer: authorizer, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}})
+	require.NoError(t, err)
+	report, err := searcher.Search(t.Context(), Query{Text: "needle", Mode: ModeLexical,
+		Scope: store.SearchOptions{MIMEType: "Text/Plain", UnderNodeID: catalog.RootID(),
+			ModifiedSince: "2026-01-01T01:00:00+01:00"}})
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, 1, provider.calls)
+	require.Len(t, authorizer.operations, 1)
+	assert.Equal(t, store.SearchOptions{MIMEType: "text/plain", UnderNodeID: catalog.RootID(),
+		ModifiedSince: "2026-01-01T00:00:00.000000000Z"}, authorizer.operations[0].Scope)
+}

--- a/internal/retrieval/search_store_test.go
+++ b/internal/retrieval/search_store_test.go
@@ -1,6 +1,7 @@
 package retrieval
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,6 +11,73 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/docbank/internal/store"
 )
+
+func TestRerankingOnlyRevalidatesCurrentCandidates(t *testing.T) {
+	for _, change := range []string{"unchanged", "ancestor moved", "moved outside scope", "trashed", "content changed"} {
+		t.Run(change, func(t *testing.T) {
+			catalog, err := store.Open(filepath.Join(t.TempDir(), "search.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, catalog.Close()) })
+			ancestor, err := catalog.Mkdir(t.Context(), catalog.RootID(), "before")
+			require.NoError(t, err)
+			file, err := catalog.CreateFile(t.Context(), ancestor.ID, "needle.txt", strings.Repeat("a", 64), 1, "text/plain")
+			require.NoError(t, err)
+			backend := &changingSearchBackend{Store: catalog, afterSearch: func() {
+				switch change {
+				case "ancestor moved":
+					ancestor, err = catalog.NodeByID(t.Context(), ancestor.ID)
+					require.NoError(t, err)
+					_, _, err = catalog.Move(t.Context(), ancestor.ID, catalog.RootID(), "after", ancestor.Revision)
+				case "moved outside scope":
+					_, _, err = catalog.Move(t.Context(), file.ID, catalog.RootID(), file.Name, file.Revision)
+				case "trashed":
+					_, _, err = catalog.Trash(t.Context(), file.ID, file.Revision)
+				case "content changed":
+					_, _, err = catalog.ReplaceContent(t.Context(), file.ID, file.Revision, strings.Repeat("b", 64), 2, "text/plain")
+				}
+				require.NoError(t, err)
+			}}
+			provider := &stageReranker{}
+			searcher, err := NewSearcher(SearcherConfig{Backend: backend, Owner: "search-test", LeaseDuration: time.Minute,
+				Reranking: RerankingConfig{Enabled: true, Profile: RerankingProfile{ID: "reranking", MaxCandidates: 10},
+					Provider: provider, Authorizer: &stageAuthorizer{}, Deadline: time.Second, FailurePolicy: ProviderFailureFailClosed}})
+			require.NoError(t, err)
+			report, err := searcher.Search(t.Context(), Query{Text: "needle", Mode: ModeLexical,
+				Scope: store.SearchOptions{UnderNodeID: ancestor.ID}})
+			require.NoError(t, err)
+			if change == "unchanged" || change == "ancestor moved" {
+				require.Len(t, report.Results, 1)
+				require.Len(t, provider.candidates, 1)
+				assert.Equal(t, file.ID, provider.candidates[0].Document.NodeID)
+				wantPath := "/before/needle.txt"
+				if change == "ancestor moved" {
+					wantPath = "/after/needle.txt"
+				}
+				assert.Equal(t, wantPath, report.Results[0].Path)
+			} else {
+				assert.Empty(t, provider.candidates)
+				assert.Empty(t, report.Results)
+				assert.True(t, report.Truncated)
+			}
+		})
+	}
+}
+
+type changingSearchBackend struct {
+	*store.Store
+
+	afterSearch func()
+}
+
+func (backend *changingSearchBackend) SearchExplainedLexicalCandidates(ctx context.Context, query string, limit int,
+	options store.SearchOptions,
+) ([]store.ExplainedLexicalCandidate, bool, error) {
+	candidates, truncated, err := backend.Store.SearchExplainedLexicalCandidates(ctx, query, limit, options)
+	if err == nil {
+		backend.afterSearch()
+	}
+	return candidates, truncated, err
+}
 
 func TestExpandedSearchRefreshesPathsAfterAncestorMove(t *testing.T) {
 	catalog, err := store.Open(filepath.Join(t.TempDir(), "search.db"))
@@ -35,7 +103,7 @@ func TestExpandedSearchRefreshesPathsAfterAncestorMove(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, file.Revision, current.Revision)
 
-	revalidated, err := searcher.revalidateExpandedReport(t.Context(), query, report)
+	revalidated, err := searcher.revalidateReport(t.Context(), query, report)
 	require.NoError(t, err)
 	require.Len(t, revalidated.Results, 1)
 	assert.Equal(t, "/after/needle.txt", revalidated.Results[0].Path)

--- a/internal/retrieval/search_store_test.go
+++ b/internal/retrieval/search_store_test.go
@@ -1,0 +1,42 @@
+package retrieval
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestExpandedSearchRefreshesPathsAfterAncestorMove(t *testing.T) {
+	catalog, err := store.Open(filepath.Join(t.TempDir(), "search.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, catalog.Close()) })
+	ancestor, err := catalog.Mkdir(t.Context(), catalog.RootID(), "before")
+	require.NoError(t, err)
+	file, err := catalog.CreateFile(t.Context(), ancestor.ID, "needle.txt", strings.Repeat("a", 64), 1, "text/plain")
+	require.NoError(t, err)
+	searcher, err := NewSearcher(SearcherConfig{Backend: catalog, Owner: "search-test", LeaseDuration: time.Minute})
+	require.NoError(t, err)
+	query := Query{Text: "needle", Mode: ModeLexical, Limit: 10}
+	report, err := searcher.Search(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, "/before/needle.txt", report.Results[0].Path)
+
+	ancestor, err = catalog.NodeByID(t.Context(), ancestor.ID)
+	require.NoError(t, err)
+	_, _, err = catalog.Move(t.Context(), ancestor.ID, catalog.RootID(), "after", ancestor.Revision)
+	require.NoError(t, err)
+	current, err := catalog.NodeByID(t.Context(), file.ID)
+	require.NoError(t, err)
+	require.Equal(t, file.Revision, current.Revision)
+
+	revalidated, err := searcher.revalidateExpandedReport(t.Context(), query, report)
+	require.NoError(t, err)
+	require.Len(t, revalidated.Results, 1)
+	assert.Equal(t, "/after/needle.txt", revalidated.Results[0].Path)
+}

--- a/internal/retrieval/search_test.go
+++ b/internal/retrieval/search_test.go
@@ -532,3 +532,7 @@ func TestFuseReciprocalRankRejectsMixedSemanticVectorSpaces(t *testing.T) {
 	}, 2)
 	require.ErrorContains(t, err, "one active vector space")
 }
+
+func (backend *retrievalBackendStub) NormalizeSearchOptions(_ context.Context, options store.SearchOptions) (store.SearchOptions, error) {
+	return options, nil
+}

--- a/internal/retrieval/types.go
+++ b/internal/retrieval/types.go
@@ -35,18 +35,20 @@ type DocumentIdentity struct {
 }
 
 type EvidenceReference struct {
-	Kind              string
-	VaultID           string
-	NodeID            int64
-	ContentVersionID  string
-	VectorSpaceID     string
-	EmbeddingSetID    string
-	InputGenerationID string
-	InputID           string
-	InputKind         document.EmbeddingInputKind
-	BuildID           string
-	SegmentID         string
-	BlobHash          string
+	Kind                   string
+	VaultID                string
+	NodeID                 int64
+	NodeRevision           int64
+	ContentVersionID       string
+	VectorSpaceID          string
+	EmbeddingSetID         string
+	InputGenerationID      string
+	InputID                string
+	InputKind              document.EmbeddingInputKind
+	BuildID                string
+	SegmentID              string
+	BlobHash               string
+	SourceManifestChecksum string
 }
 
 type Candidate struct {
@@ -93,12 +95,21 @@ type Coverage struct {
 	State             CoverageState
 }
 
+type Degradation string
+
+const (
+	DegradationNone              Degradation = ""
+	DegradationExpansionDegraded Degradation = "query_expansion_degraded"
+	DegradationRerankingDegraded Degradation = "reranking_degraded"
+)
+
 type TraceCode string
 
 const (
 	TraceLexicalCandidates  TraceCode = "lexical_candidates"
 	TraceSemanticCandidates TraceCode = "semantic_candidates"
 	TraceFusedCandidates    TraceCode = "fused_candidates"
+	TraceRerankedCandidates TraceCode = "reranked_candidates"
 )
 
 type TraceEvent struct {
@@ -113,6 +124,8 @@ type Report struct {
 	Results       []Result
 	Truncated     bool
 	Trace         []TraceEvent
+	Degradations  []Degradation
+	Receipts      []ProviderReceipt
 }
 
 type Query struct {

--- a/internal/store/consent.go
+++ b/internal/store/consent.go
@@ -250,6 +250,19 @@ func (s *Store) RevokeConsent(
 	return result, nil
 }
 
+// BeginProviderEgress checks durable consent while holding the shared revocation
+// fence. The caller must close the returned fence after provider execution.
+func (s *Store) BeginProviderEgress(ctx context.Context, request ProviderOperationAuthorizationRequest) (ProviderOperationAuthorization, *ProviderEgressFence, error) {
+	s.providerEgressMu.RLock()
+	fence := &ProviderEgressFence{release: s.providerEgressMu.RUnlock}
+	authorization, err := s.AuthorizeProviderOperation(ctx, request)
+	if err != nil {
+		fence.Close()
+		return ProviderOperationAuthorization{}, nil, err
+	}
+	return authorization, fence, nil
+}
+
 func (s *Store) AuthorizeProviderOperation(
 	ctx context.Context, request ProviderOperationAuthorizationRequest,
 ) (ProviderOperationAuthorization, error) {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -228,11 +229,236 @@ func SearchNeedsQuery(query string, opts SearchOptions) bool {
 		opts.ModifiedSince == "" && opts.ModifiedBefore == ""
 }
 
+// SearchCandidateIdentity identifies one current scoped head for a final
+// retrieval fence without retaining any query or document text.
+type SearchCandidateIdentity struct {
+	NodeID           int64
+	NodeRevision     int64
+	ContentVersionID string
+	Evidence         []SearchEvidenceIdentity
+}
+
+// SearchCoverageSnapshot is the current semantic coverage captured with the
+// final candidate/evidence fence.
+type SearchCoverageSnapshot struct {
+	ScopedDocuments   int
+	CompleteDocuments int
+}
+
+// SearchCandidateRevalidation returns allowed candidates and, when semantic
+// authority was supplied, coverage from the same storage snapshot.
+type SearchCandidateRevalidation struct {
+	Candidates []SearchCandidateIdentity
+	Coverage   *SearchCoverageSnapshot
+}
+
+// SearchEvidenceIdentity is the text-free stable authority needed to prove
+// that one result still cites current serving evidence.
+type SearchEvidenceIdentity struct {
+	Kind                   string                      `json:"kind"`
+	VectorSpaceID          string                      `json:"vector_space_id,omitempty"`
+	EmbeddingSetID         string                      `json:"embedding_set_id,omitempty"`
+	InputGenerationID      string                      `json:"input_generation_id,omitempty"`
+	InputID                string                      `json:"input_id,omitempty"`
+	InputKind              document.EmbeddingInputKind `json:"input_kind,omitempty"`
+	BuildID                string                      `json:"build_id,omitempty"`
+	SegmentID              string                      `json:"segment_id,omitempty"`
+	BlobHash               string                      `json:"blob_hash,omitempty"`
+	SourceManifestChecksum string                      `json:"source_manifest_checksum,omitempty"`
+}
+
+type searchCandidateRevalidationJSON struct {
+	NodeID           int64                    `json:"node_id"`
+	NodeRevision     int64                    `json:"node_revision"`
+	ContentVersionID string                   `json:"version_id"`
+	Evidence         []SearchEvidenceIdentity `json:"evidence"`
+}
+
+// RevalidateSearchCandidates retains only supplied identities that remain live,
+// current, and inside the operator scope at this final check.
+func (s *Store) RevalidateSearchCandidates(ctx context.Context, candidates []SearchCandidateIdentity,
+	opts SearchOptions, semanticProfileFingerprint, semanticBindingID string,
+) (SearchCandidateRevalidation, error) {
+	if len(candidates) > document.MaxRetrievalCandidateLimit {
+		return SearchCandidateRevalidation{}, errors.New("search candidate revalidation exceeds the retrieval limit")
+	}
+	normalized, err := s.normalizeSearchOptions(ctx, opts)
+	if err != nil {
+		return SearchCandidateRevalidation{}, err
+	}
+	if len(candidates) == 0 && semanticProfileFingerprint == "" && semanticBindingID == "" {
+		return SearchCandidateRevalidation{}, nil
+	}
+	payload := make([]searchCandidateRevalidationJSON, len(candidates))
+	semanticSpace, semanticSource := "", ""
+	hasRenditionEvidence := false
+	for i, candidate := range candidates {
+		if len(candidate.Evidence) == 0 || len(candidate.Evidence) > 32 {
+			return SearchCandidateRevalidation{}, errors.New("search candidate evidence is invalid")
+		}
+		payload[i] = searchCandidateRevalidationJSON(candidate)
+		for _, evidence := range candidate.Evidence {
+			if evidence.Kind == "rendition_segment" {
+				hasRenditionEvidence = true
+			}
+			if evidence.Kind != "embedding" {
+				continue
+			}
+			if evidence.VectorSpaceID == "" || evidence.SourceManifestChecksum == "" {
+				return SearchCandidateRevalidation{}, errors.New("semantic search evidence authority is incomplete")
+			}
+			if semanticSpace == "" {
+				semanticSpace, semanticSource = evidence.VectorSpaceID, evidence.SourceManifestChecksum
+			}
+			if semanticSpace != evidence.VectorSpaceID || semanticSource != evidence.SourceManifestChecksum {
+				return SearchCandidateRevalidation{}, errors.New("semantic search evidence authority is incompatible")
+			}
+		}
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return SearchCandidateRevalidation{}, err
+	}
+	filterSQL, filterArgs := searchFilterSQL(normalized)
+	var result SearchCandidateRevalidation
+	var allowedPositions []int
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if semanticProfileFingerprint != "" || semanticBindingID != "" {
+			if semanticProfileFingerprint == "" || semanticBindingID == "" {
+				return errors.New("semantic search coverage authority is incomplete")
+			}
+			binding, fingerprints, authorityErr := embeddingProfileBindingAuthority(ctx, tx,
+				semanticProfileFingerprint, semanticBindingID)
+			if authorityErr != nil {
+				return authorityErr
+			}
+			expectedSpace := fingerprints.VectorSpace[semanticBindingID]
+			if semanticSpace != "" && semanticSpace != expectedSpace {
+				return errors.New("semantic search evidence does not match coverage authority")
+			}
+			semanticSpace = expectedSpace
+			scoped, complete, coverageErr := semanticSearchCoverageTx(ctx, tx,
+				semanticProfileFingerprint, semanticBindingID, binding.InputKind, semanticSpace, normalized)
+			if coverageErr != nil {
+				return coverageErr
+			}
+			result.Coverage = &SearchCoverageSnapshot{ScopedDocuments: scoped, CompleteDocuments: complete}
+		} else if semanticSpace != "" {
+			return errors.New("semantic search evidence lacks coverage authority")
+		}
+		renditionEvidenceSQL := `WHEN 'rendition_segment' THEN 1`
+		if hasRenditionEvidence {
+			var lexicalProjection bool
+			if schemaErr := tx.QueryRowContext(ctx, `SELECT EXISTS(
+				SELECT 1 FROM sqlite_schema WHERE type='table' AND name='rendition_lexical_heads'
+			)`).Scan(&lexicalProjection); schemaErr != nil {
+				return schemaErr
+			}
+			if lexicalProjection {
+				renditionEvidenceSQL = `WHEN 'rendition_segment' THEN NOT EXISTS (
+					SELECT 1 FROM rendition_lexical_heads lh
+					JOIN rendition_lexical_generation_builds gb ON gb.generation_id=lh.generation_id
+					JOIN rendition_lexical_segments ls ON ls.build_id=gb.build_id
+					JOIN rendition_attachments ra ON ra.build_id=ls.build_id
+					JOIN rendition_heads rh ON rh.content_version_id=ra.content_version_id
+					 AND rh.profile_fingerprint=ra.profile_fingerprint AND rh.attachment_id=ra.attachment_id
+					WHERE lh.singleton=1 AND ra.content_version_id=scoped.version_id
+					 AND ls.build_id=json_extract(evidence.value,'$.build_id')
+					 AND ls.segment_id=json_extract(evidence.value,'$.segment_id'))`
+			}
+		}
+		if semanticSource != "" {
+			current, captureErr := captureVectorIndexSourceTx(ctx, tx, semanticSpace)
+			if captureErr != nil {
+				if errors.Is(captureErr, ErrNotFound) {
+					return ErrVectorIndexSourceStale
+				}
+				return captureErr
+			}
+			if current.ManifestChecksum != semanticSource {
+				return ErrVectorIndexSourceStale
+			}
+		}
+		args := append([]any{string(encoded)}, filterArgs...)
+		args = append(args, semanticProfileFingerprint, semanticBindingID)
+		rows, queryErr := tx.QueryContext(ctx, `WITH requested AS (
+			SELECT CAST(key AS INTEGER) AS position,
+			       CAST(json_extract(value,'$.node_id') AS INTEGER) AS node_id,
+			       CAST(json_extract(value,'$.node_revision') AS INTEGER) AS node_revision,
+			       json_extract(value,'$.version_id') AS version_id,
+			       json_extract(value,'$.evidence') AS evidence
+			FROM json_each(?)
+		), scoped AS (
+			SELECT requested.position,requested.node_id,requested.version_id,requested.evidence,cv.blob_hash
+			FROM requested JOIN nodes n ON n.id=requested.node_id
+			JOIN content_versions cv ON cv.node_id=n.id AND cv.version_id=n.current_version_id
+			 AND cv.version_id=requested.version_id
+			WHERE n.kind='file' AND n.revision=requested.node_revision AND n.trashed_at IS NULL `+filterSQL+`
+		)
+		SELECT scoped.position FROM scoped
+		WHERE NOT EXISTS (
+			SELECT 1 FROM json_each(scoped.evidence) evidence
+			WHERE CASE json_extract(evidence.value,'$.kind')
+			WHEN 'node_name' THEN 0
+			WHEN 'content_blob' THEN NOT (
+				json_extract(evidence.value,'$.blob_hash')<>'' AND
+				json_extract(evidence.value,'$.blob_hash')=scoped.blob_hash)
+			`+renditionEvidenceSQL+`
+			WHEN 'embedding' THEN NOT EXISTS (
+				SELECT 1 FROM embedding_heads eh
+				JOIN embedding_sets es ON es.embedding_set_id=eh.embedding_set_id
+				 AND es.content_version_id=eh.content_version_id AND es.binding_id=eh.binding_id
+				 AND es.input_kind=eh.input_kind AND es.vector_space_id=eh.vector_space_id
+				 AND es.profile_fingerprint=eh.profile_fingerprint
+				JOIN embedding_vector_rows evr ON evr.vector_set_id=es.vector_set_id
+				JOIN embedding_generation_inputs egi ON egi.generation_id=es.input_generation_id
+				 AND egi.input_id=evr.input_id AND egi.rendered_checksum=evr.checksum
+				JOIN embedding_input_generations eig ON eig.generation_id=es.input_generation_id
+				WHERE eh.content_version_id=scoped.version_id
+				 AND eh.vector_space_id=json_extract(evidence.value,'$.vector_space_id')
+				 AND eh.embedding_set_id=json_extract(evidence.value,'$.embedding_set_id')
+				 AND eh.input_kind=json_extract(evidence.value,'$.input_kind')
+				 AND es.profile_fingerprint=? AND es.binding_id=?
+				 AND es.input_generation_id=json_extract(evidence.value,'$.input_generation_id')
+				 AND evr.input_id=json_extract(evidence.value,'$.input_id')
+				 AND (es.input_kind='original_file' OR EXISTS (
+					SELECT 1 FROM rendition_heads current_rh
+					WHERE current_rh.content_version_id=es.content_version_id
+					 AND current_rh.profile_fingerprint=es.profile_fingerprint
+					 AND current_rh.attachment_id=eig.attachment_id)))
+			ELSE 1 END
+		) ORDER BY scoped.position`, args...)
+		if queryErr != nil {
+			return queryErr
+		}
+		return func() (retErr error) {
+			defer func() { retErr = errors.Join(retErr, rows.Close()) }()
+			for rows.Next() {
+				var position int
+				if scanErr := rows.Scan(&position); scanErr != nil {
+					return scanErr
+				}
+				allowedPositions = append(allowedPositions, position)
+			}
+			return rows.Err()
+		}()
+	})
+	if err != nil {
+		return SearchCandidateRevalidation{}, err
+	}
+	result.Candidates = make([]SearchCandidateIdentity, 0, len(allowedPositions))
+	for _, position := range allowedPositions {
+		result.Candidates = append(result.Candidates, candidates[position])
+	}
+	return result, nil
+}
+
 // SemanticSearchCandidate is one vector neighbor reduced to a current,
 // scope-eligible document. Only the lexical lane supplies excerpts.
 type SemanticSearchCandidate struct {
 	VaultID           string
 	NodeID            int64
+	NodeRevision      int64
 	ContentVersionID  string
 	Path              string
 	VectorSpaceID     string
@@ -436,7 +662,7 @@ func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, profileFin
 	inputKind document.EmbeddingInputKind, vectorSpaceID, filterSQL string, filterArgs []any,
 ) (_ map[semanticEligibilityKey]SemanticSearchCandidate, retErr error) {
 	args := append([]any{vectorSpaceID, profileFingerprint, bindingID, inputKind}, filterArgs...)
-	rows, err := tx.QueryContext(ctx, `SELECT n.id,n.current_version_id,
+	rows, err := tx.QueryContext(ctx, `SELECT n.id,n.revision,n.current_version_id,
 			es.embedding_set_id,es.input_generation_id,es.input_kind,
 			evr.vector_set_id,evr.input_id,evr.checksum
 		FROM `+nodeFrom+`
@@ -469,7 +695,7 @@ func loadSemanticEligibility(ctx context.Context, tx metadataQuerier, profileFin
 			entry SemanticSearchCandidate
 			key   semanticEligibilityKey
 		)
-		if err := rows.Scan(&entry.NodeID, &entry.ContentVersionID, &entry.EmbeddingSetID,
+		if err := rows.Scan(&entry.NodeID, &entry.NodeRevision, &entry.ContentVersionID, &entry.EmbeddingSetID,
 			&entry.InputGenerationID, &entry.InputKind, &key.VectorSetID, &key.InputID, &key.InputChecksum); err != nil {
 			return nil, err
 		}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -53,7 +53,7 @@ func (s *Store) SearchExplainedLexicalCandidates(ctx context.Context, query stri
 		limit = 50
 	}
 	var err error
-	opts, err = s.normalizeSearchOptions(ctx, opts)
+	opts, err = s.NormalizeSearchOptions(ctx, opts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -289,7 +289,7 @@ func (s *Store) RevalidateSearchCandidates(ctx context.Context, candidates []Sea
 	if len(candidates) > document.MaxRetrievalCandidateLimit {
 		return SearchCandidateRevalidation{}, errors.New("search candidate revalidation exceeds the retrieval limit")
 	}
-	normalized, err := s.normalizeSearchOptions(ctx, opts)
+	normalized, err := s.NormalizeSearchOptions(ctx, opts)
 	if err != nil {
 		return SearchCandidateRevalidation{}, err
 	}
@@ -514,7 +514,7 @@ type SemanticSearchAuthority struct {
 func (s *Store) AcquireSemanticSearchAuthority(ctx context.Context, profileFingerprint,
 	bindingID, owner string, at time.Time, duration time.Duration, opts SearchOptions,
 ) (SemanticSearchAuthority, error) {
-	normalized, err := s.normalizeSearchOptions(ctx, opts)
+	normalized, err := s.NormalizeSearchOptions(ctx, opts)
 	if err != nil {
 		return SemanticSearchAuthority{}, err
 	}
@@ -622,7 +622,7 @@ func (s *Store) ResolveSemanticCandidates(ctx context.Context, profileFingerprin
 	if limit < 1 || limit > document.MaxRetrievalCandidateLimit {
 		return SemanticSearchResolution{}, fmt.Errorf("semantic search limit must be between 1 and %d", document.MaxRetrievalCandidateLimit)
 	}
-	normalized, err := s.normalizeSearchOptions(ctx, opts)
+	normalized, err := s.NormalizeSearchOptions(ctx, opts)
 	if err != nil {
 		return SemanticSearchResolution{}, err
 	}
@@ -1837,7 +1837,7 @@ func (s *Store) SearchPageWithOptions(
 		limit = 50
 	}
 	var err error
-	opts, err = s.normalizeSearchOptions(ctx, opts)
+	opts, err = s.NormalizeSearchOptions(ctx, opts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1967,7 +1967,8 @@ func (s *Store) SearchPageWithOptions(
 	return hits, truncated, nil
 }
 
-func (s *Store) normalizeSearchOptions(ctx context.Context, opts SearchOptions) (SearchOptions, error) {
+// NormalizeSearchOptions validates scope identities and returns canonical filters.
+func (s *Store) NormalizeSearchOptions(ctx context.Context, opts SearchOptions) (SearchOptions, error) {
 	if opts.TagID != "" {
 		if _, err := s.TagByID(ctx, opts.TagID); err != nil {
 			return SearchOptions{}, fmt.Errorf("search tag %q: %w", opts.TagID, err)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -408,7 +408,7 @@ func (s *Store) RevalidateSearchCandidates(ctx context.Context, candidates []Sea
 			WHERE CASE json_extract(evidence.value,'$.kind')
 			WHEN 'node_name' THEN 0
 			WHEN 'content_blob' THEN NOT (
-				json_extract(evidence.value,'$.blob_hash')<>'' AND
+				COALESCE(json_extract(evidence.value,'$.blob_hash'),'')<>'' AND
 				json_extract(evidence.value,'$.blob_hash')=scoped.blob_hash)
 			`+renditionEvidenceSQL+`
 			WHEN 'embedding' THEN NOT EXISTS (

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -248,8 +248,15 @@ type SearchCoverageSnapshot struct {
 // SearchCandidateRevalidation returns allowed candidates and, when semantic
 // authority was supplied, coverage from the same storage snapshot.
 type SearchCandidateRevalidation struct {
-	Candidates []SearchCandidateIdentity
+	Candidates []RevalidatedSearchCandidate
 	Coverage   *SearchCoverageSnapshot
+}
+
+// RevalidatedSearchCandidate includes the current path captured with its evidence.
+type RevalidatedSearchCandidate struct {
+	SearchCandidateIdentity
+
+	Path string
 }
 
 // SearchEvidenceIdentity is the text-free stable authority needed to prove
@@ -431,7 +438,7 @@ func (s *Store) RevalidateSearchCandidates(ctx context.Context, candidates []Sea
 		if queryErr != nil {
 			return queryErr
 		}
-		return func() (retErr error) {
+		err = func() (retErr error) {
 			defer func() { retErr = errors.Join(retErr, rows.Close()) }()
 			for rows.Next() {
 				var position int
@@ -442,13 +449,24 @@ func (s *Store) RevalidateSearchCandidates(ctx context.Context, candidates []Sea
 			}
 			return rows.Err()
 		}()
+		if err != nil {
+			return err
+		}
+		result.Candidates = make([]RevalidatedSearchCandidate, 0, len(allowedPositions))
+		for _, position := range allowedPositions {
+			candidate := candidates[position]
+			currentPath, pathErr := pathOf(ctx, tx, candidate.NodeID)
+			if pathErr != nil {
+				return pathErr
+			}
+			result.Candidates = append(result.Candidates, RevalidatedSearchCandidate{
+				SearchCandidateIdentity: candidate, Path: currentPath,
+			})
+		}
+		return nil
 	})
 	if err != nil {
 		return SearchCandidateRevalidation{}, err
-	}
-	result.Candidates = make([]SearchCandidateIdentity, 0, len(allowedPositions))
-	for _, position := range allowedPositions {
-		result.Candidates = append(result.Candidates, candidates[position])
 	}
 	return result, nil
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -177,6 +177,11 @@ func TestRevalidateSearchCandidatesAppliesCurrentScopeAndBlobEvidence(t *testing
 	require.NoError(t, err)
 	require.Len(t, revalidation.Candidates, 1)
 	assert.Equal(t, text.ID, revalidation.Candidates[0].NodeID)
+	requested[1].Evidence[0].BlobHash = ""
+	revalidation, err = s.RevalidateSearchCandidates(t.Context(), requested, SearchOptions{}, "", "")
+	require.NoError(t, err)
+	require.Len(t, revalidation.Candidates, 1, "content evidence without a hash must be discarded")
+	assert.Equal(t, text.ID, revalidation.Candidates[0].NodeID)
 	_, _, err = s.Move(t.Context(), text.ID, s.RootID(), "renamed.txt", text.Revision)
 	require.NoError(t, err)
 	revalidation, err = s.RevalidateSearchCandidates(t.Context(), requested[:1], SearchOptions{}, "", "")

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -126,6 +126,130 @@ func TestResolveSemanticCandidatesRejectsStaleSourceManifest(t *testing.T) {
 	require.ErrorIs(t, err, ErrVectorIndexSourceStale)
 }
 
+func TestRevalidateSearchCandidatesPreservesOrderAtTheCandidateLimit(t *testing.T) {
+	s := newTestStore(t)
+	first, err := s.CreateFile(t.Context(), s.RootID(), "first.txt", fakeHash("first"), 5, "text/plain")
+	require.NoError(t, err)
+	second, err := s.CreateFile(t.Context(), s.RootID(), "second.txt", fakeHash("second"), 6, "text/plain")
+	require.NoError(t, err)
+	requested := make([]SearchCandidateIdentity, document.MaxRetrievalCandidateLimit)
+	for i := range requested {
+		node := first
+		if i%2 == 0 {
+			node = second
+		}
+		requested[i] = SearchCandidateIdentity{NodeID: node.ID, NodeRevision: node.Revision,
+			ContentVersionID: node.CurrentVersionID,
+			Evidence:         []SearchEvidenceIdentity{{Kind: "node_name"}}}
+	}
+
+	revalidation, err := s.RevalidateSearchCandidates(t.Context(), requested, SearchOptions{}, "", "")
+
+	require.NoError(t, err)
+	require.Len(t, revalidation.Candidates, len(requested))
+	for i := range requested {
+		assert.Equal(t, requested[i].NodeID, revalidation.Candidates[i].NodeID)
+		assert.Equal(t, requested[i].ContentVersionID, revalidation.Candidates[i].ContentVersionID)
+	}
+}
+
+func TestRevalidateSearchCandidatesAppliesCurrentScopeAndBlobEvidence(t *testing.T) {
+	s := newTestStore(t)
+	text, err := s.CreateFile(t.Context(), s.RootID(), "text.txt", fakeHash("text"), 4, "text/plain")
+	require.NoError(t, err)
+	pdf, err := s.CreateFile(t.Context(), s.RootID(), "paper.pdf", fakeHash("pdf"), 3, "application/pdf")
+	require.NoError(t, err)
+	requested := []SearchCandidateIdentity{
+		{NodeID: text.ID, NodeRevision: text.Revision, ContentVersionID: text.CurrentVersionID,
+			Evidence: []SearchEvidenceIdentity{{Kind: "content_blob", BlobHash: text.BlobHash}}},
+		{NodeID: pdf.ID, NodeRevision: pdf.Revision, ContentVersionID: pdf.CurrentVersionID,
+			Evidence: []SearchEvidenceIdentity{{Kind: "content_blob", BlobHash: pdf.BlobHash}}},
+	}
+
+	revalidation, err := s.RevalidateSearchCandidates(t.Context(), requested,
+		SearchOptions{MIMEType: "application/pdf"}, "", "")
+
+	require.NoError(t, err)
+	require.Len(t, revalidation.Candidates, 1)
+	assert.Equal(t, pdf.ID, revalidation.Candidates[0].NodeID)
+	requested[1].Evidence[0].BlobHash = fakeHash("stale-pdf")
+	revalidation, err = s.RevalidateSearchCandidates(t.Context(), requested, SearchOptions{}, "", "")
+	require.NoError(t, err)
+	require.Len(t, revalidation.Candidates, 1)
+	assert.Equal(t, text.ID, revalidation.Candidates[0].NodeID)
+	_, _, err = s.Move(t.Context(), text.ID, s.RootID(), "renamed.txt", text.Revision)
+	require.NoError(t, err)
+	revalidation, err = s.RevalidateSearchCandidates(t.Context(), requested[:1], SearchOptions{}, "", "")
+	require.NoError(t, err)
+	assert.Empty(t, revalidation.Candidates, "a rename must fence the stale name/path snapshot")
+}
+
+func TestRevalidateSearchCandidatesRequiresCurrentActiveRenditionEvidence(t *testing.T) {
+	s, versions := newRenditionCatalogFixture(t)
+	profile := catalogProcessingProfile(t, false)
+	build := lexicalSearchBuild(s, profile, catalogBuildID, "current evidence")
+	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+	generation, err := s.StageLexicalGeneration(t.Context(), hashVectorIndexTest("revalidation-lexical"))
+	require.NoError(t, err)
+	attachment := RenditionAttachmentRecord{ID: catalogAttachmentFirst, VaultID: s.VaultID(),
+		ContentVersionID: versions[0], BuildID: build.ID, Profile: profile, AttachedAt: embeddingCatalogTime}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(t.Context(), attachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: attachment.ID, PublishedAt: embeddingCatalogTime}, generation.ID))
+	var nodeID, nodeRevision int64
+	require.NoError(t, s.db.QueryRow(`SELECT n.id,n.revision FROM nodes n JOIN content_versions cv
+		ON cv.node_id=n.id WHERE cv.version_id=?`, versions[0]).Scan(&nodeID, &nodeRevision))
+	requested := []SearchCandidateIdentity{{NodeID: nodeID, NodeRevision: nodeRevision, ContentVersionID: versions[0],
+		Evidence: []SearchEvidenceIdentity{{Kind: "rendition_segment", BuildID: build.ID,
+			SegmentID: build.LexicalSegments[0].ID}}}}
+
+	revalidation, err := s.RevalidateSearchCandidates(t.Context(), requested, SearchOptions{}, "", "")
+	require.NoError(t, err)
+	require.Len(t, revalidation.Candidates, 1)
+
+	_, err = s.db.Exec(`DELETE FROM rendition_lexical_heads`)
+	require.NoError(t, err)
+	revalidation, err = s.RevalidateSearchCandidates(t.Context(), requested, SearchOptions{}, "", "")
+	require.NoError(t, err)
+	assert.Empty(t, revalidation.Candidates)
+}
+
+func TestRevalidateSearchCandidatesRejectsStaleSemanticSourceAndHead(t *testing.T) {
+	s, versionID, profile, _ := newEmbeddingCatalogFixture(t)
+	record := embeddingSetFixture(s, versionID, profile.Fingerprint,
+		document.EmbeddingInputOriginalFile, "optional", "")
+	require.NoError(t, s.StageEmbeddingSet(t.Context(), record))
+	require.NoError(t, s.PublishEmbeddingHead(t.Context(), EmbeddingHeadRecord{
+		Key: EmbeddingHeadKey{ContentVersionID: versionID, BindingID: record.BindingID,
+			InputKind: record.InputKind}, SetID: record.ID, VectorSpaceID: record.VectorSpace.ID,
+		ProcessingProfileFingerprint: profile.Fingerprint, PublishedAt: embeddingCatalogTime, FencingToken: 1,
+	}))
+	source, err := s.CaptureVectorIndexSource(t.Context(), record.VectorSpace.ID)
+	require.NoError(t, err)
+	var nodeID, nodeRevision int64
+	require.NoError(t, s.db.QueryRow(`SELECT n.id,n.revision FROM nodes n JOIN content_versions cv
+		ON cv.node_id=n.id WHERE cv.version_id=?`, versionID).Scan(&nodeID, &nodeRevision))
+	requested := []SearchCandidateIdentity{{NodeID: nodeID, NodeRevision: nodeRevision, ContentVersionID: versionID,
+		Evidence: []SearchEvidenceIdentity{{Kind: "embedding", VectorSpaceID: record.VectorSpace.ID,
+			EmbeddingSetID: record.ID, InputGenerationID: record.InputGeneration.ID,
+			InputID: record.InputGeneration.Inputs[0].ID, InputKind: record.InputKind,
+			SourceManifestChecksum: source.ManifestChecksum}}}}
+
+	revalidation, err := s.RevalidateSearchCandidates(t.Context(), requested, SearchOptions{},
+		profile.Fingerprint, record.BindingID)
+	require.NoError(t, err)
+	require.Len(t, revalidation.Candidates, 1)
+	require.NotNil(t, revalidation.Coverage)
+	assert.Equal(t, 2, revalidation.Coverage.ScopedDocuments)
+	assert.Equal(t, 1, revalidation.Coverage.CompleteDocuments)
+
+	_, err = s.db.Exec(`DELETE FROM embedding_heads WHERE embedding_set_id=?`, record.ID)
+	require.NoError(t, err)
+	_, err = s.RevalidateSearchCandidates(t.Context(), requested, SearchOptions{},
+		profile.Fingerprint, record.BindingID)
+	require.ErrorIs(t, err, ErrVectorIndexSourceStale)
+}
+
 func TestReduceSemanticCandidatesExhaustsNeighborsWithoutDatabaseWork(t *testing.T) {
 	const missed = 10_000
 	neighbors := make([]vectorindex.Neighbor, missed+1)


### PR DESCRIPTION
## What changed

Search can now add separately configured query expansion and reranking stages without making either one part of the default retrieval path. Expansion returns a small bounded set of variants; reranking can only reorder the already-authorized candidate set and receives bounded excerpts and provenance rather than document bodies.

Each stage has its own profile, authorization, deadline, failure policy, named degradation, and sanitized receipt. Search scope is validated and canonicalized before provider authorization. Both expanded searches and reranking-only searches recheck candidates against current scope, node revision, rendition or embedding evidence, vector source, and final semantic coverage. Revalidation refreshes current paths and discards invalid candidates before reranking.

Parent: #220 (merged). This PR contains only the optional expansion and reranking changes.

## Why

Expansion and reranking are useful only when they cannot quietly widen access, send unbounded content, or turn stale evidence into a current result. Keeping them optional and independently authorized makes the extra quality/latency/privacy tradeoff explicit, while the base lexical, semantic, hybrid, and automatic modes remain available with both stages disabled.

## Usage

Add an `ExpansionConfig`, a `RerankingConfig`, or both when constructing the retrieval `Searcher`. Each enabled stage needs its own typed provider, authorizer, profile limits, deadline, and `degrade` or `fail_closed` policy. Successful authorization must return a non-nil `ProviderEgressLease`, which retrieval holds through provider completion and closes on success, failure, or cancellation. Consent revocation must acquire the corresponding exclusive fence; the store’s `BeginProviderEgress` helper coordinates with its existing revocation lock. Leave both configs disabled to keep expansion and reranking disabled.

Refs #176