### PR TITLE
feat: expose embedded exact-version ranges

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -191,6 +191,32 @@ disagrees with metadata. Metadata lookup failures retain their existing
 physical open can match both `context.Canceled` and `ErrContentUnavailable`, so
 callers that distinguish cancellation should check the context error first.
 
+`OpenVersionContentRange` selects a non-empty decoded logical byte range from
+one exact immutable version. Offsets and lengths address the same logical bytes
+described by `ContentVersion.BlobHash` and `Size`, regardless of whether current
+physical authority is raw loose, zstd-compressed loose, packed, or secondary:
+
+```go
+part, err := vault.OpenVersionContentRange(ctx, versionID,
+    docbank.ContentRangeOptions{Offset: 1 << 20, Length: 256 << 10},
+)
+if err != nil {
+    return err
+}
+defer part.Reader.Close()
+_, err = io.Copy(dst, part.Reader)
+```
+
+Raw loose content uses native filesystem offsets. Compressed loose and packed
+content may materialize a seekable representation or decode from the beginning,
+so applications should not infer constant-time physical seeking from the public
+range contract. The reader returns exactly the requested length or an error and
+holds the vault lifecycle lease until `Close`. A successful partial read proves
+catalog authorization, decoded size, and range bounds; it is not whole-object
+integrity verification. Use `OpenVersionContent` to consume and verify the full
+stream, or a maintenance verification operation when full integrity evidence is
+required.
+
 ## Traverse and mutate the tree
 
 `Children` exposes the live virtual tree without materializing an unbounded

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -677,15 +677,24 @@ func (s *Store) Open(hash string) (io.ReadSeekCloser, error) {
 
 // OpenContext is Open with cancellation for daemon request paths.
 func (s *Store) OpenContext(ctx context.Context, hash string) (io.ReadSeekCloser, error) {
+	reader, _, err := s.OpenSeekableContext(ctx, hash)
+	return reader, err
+}
+
+// OpenSeekableContext opens catalog-authorized decoded logical content and
+// preserves its logical size for range consumers.
+func (s *Store) OpenSeekableContext(
+	ctx context.Context, hash string,
+) (io.ReadSeekCloser, int64, error) {
 	parsed, err := packstore.ParseHash(hash)
 	if err != nil {
-		return nil, fmt.Errorf("blob hash %q: %w", hash, ErrInvalidHash)
+		return nil, 0, fmt.Errorf("blob hash %q: %w", hash, ErrInvalidHash)
 	}
-	reader, _, err := s.reader.Open(ctx, parsed)
+	reader, size, err := s.reader.Open(ctx, parsed)
 	if err != nil {
-		return nil, fmt.Errorf("opening blob %s: %w", hash, err)
+		return nil, 0, fmt.Errorf("opening blob %s: %w", hash, err)
 	}
-	return reader, nil
+	return reader, size, nil
 }
 
 // OpenStream returns catalog-authorized loose or packed content without

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -309,6 +309,18 @@ func TestWriteAndReadBack(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
+func TestOpenSeekableContextReturnsLogicalSize(t *testing.T) {
+	bs := newTestBlobStore(t)
+	content := []byte("seekable logical content")
+	receipt, err := bs.WriteDetailedContext(t.Context(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	reader, size, err := bs.OpenSeekableContext(t.Context(), receipt.Hash)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	require.Equal(t, int64(len(content)), size)
+}
+
 func TestOpenStreamRequiresTerminalVerification(t *testing.T) {
 	bs := newTestBlobStore(t)
 	content := "stream me completely"

--- a/internal/blob/placement_test.go
+++ b/internal/blob/placement_test.go
@@ -58,6 +58,16 @@ func TestPlacementRunnerCopiesVerifiesAndRetiresLooseSource(t *testing.T) {
 	require.NoError(t, stream.Close())
 	assert.Equal(t, int64(len(content)), size)
 	assert.Equal(t, content, got)
+
+	reader, size, err := blobs.OpenSeekableContext(t.Context(), hash)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	require.Equal(t, int64(len(content)), size)
+	_, err = reader.Seek(3, io.SeekStart)
+	require.NoError(t, err)
+	suffix, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, content[3:], suffix)
 }
 
 func TestPlacementRunnerRejectsDestinationRemovedBeforeCatalogCommit(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -262,6 +262,21 @@ type VersionContent struct {
 	Reader  VerifiedReadCloser
 }
 
+// ContentRangeOptions selects a non-empty decoded logical byte range.
+type ContentRangeOptions struct {
+	Offset int64
+	Length int64
+}
+
+// VersionContentRange binds a bounded logical byte stream to one immutable
+// content version. Reader must be closed to release its vault lease.
+type VersionContentRange struct {
+	Version ContentVersion
+	Offset  int64
+	Length  int64
+	Reader  io.ReadCloser
+}
+
 func fromStoreNode(node store.Node) Node {
 	return Node{
 		ID: node.ID, ParentID: node.ParentID, Name: node.Name, Kind: node.Kind,

--- a/vault.go
+++ b/vault.go
@@ -42,6 +42,9 @@ var (
 	// ErrContentConflict means immutable creation targeted an existing path
 	// with different bytes, size, media type, provenance, or node kind.
 	ErrContentConflict = errors.New("docbank immutable content conflict")
+	// ErrInvalidContentRange means a requested logical byte range falls
+	// outside its exact immutable content version.
+	ErrInvalidContentRange = errors.New("docbank invalid content range")
 
 	ErrNotFound                 = store.ErrNotFound
 	ErrExists                   = store.ErrExists
@@ -1008,6 +1011,100 @@ func (v *Vault) OpenVersionContent(ctx context.Context, versionID string) (*Vers
 		Version: fromStoreVersion(version),
 		Reader:  &leasedReader{VerifiedReadCloser: reader, release: v.lifecycle.RUnlock},
 	}, nil
+}
+
+// OpenVersionContentRange opens a bounded decoded logical byte range from one
+// exact immutable content version. Raw loose content uses native offsets;
+// compressed loose and packed content may decode or materialize from the
+// beginning. A partial range proves catalog authorization and slice bounds,
+// not whole-object integrity.
+func (v *Vault) OpenVersionContentRange(
+	ctx context.Context, versionID string, opts ContentRangeOptions,
+) (*VersionContentRange, error) {
+	if err := v.begin(); err != nil {
+		return nil, err
+	}
+	version, err := v.metadata.ContentVersionByID(ctx, versionID)
+	if err != nil {
+		v.lifecycle.RUnlock()
+		return nil, err
+	}
+	if opts.Offset < 0 || opts.Length <= 0 ||
+		opts.Offset > version.Size ||
+		opts.Length > version.Size-opts.Offset {
+		v.lifecycle.RUnlock()
+		return nil, fmt.Errorf(
+			"version %q offset=%d length=%d size=%d: %w",
+			versionID, opts.Offset, opts.Length, version.Size,
+			ErrInvalidContentRange,
+		)
+	}
+	reader, size, err := v.blobs.OpenSeekableContext(ctx, version.BlobHash)
+	if err != nil {
+		v.lifecycle.RUnlock()
+		return nil, fmt.Errorf(
+			"opening content version range %q: %w: %w",
+			versionID, ErrContentUnavailable, err,
+		)
+	}
+	if size != version.Size {
+		closeErr := reader.Close()
+		v.lifecycle.RUnlock()
+		return nil, errors.Join(fmt.Errorf(
+			"physical size %d does not match version size %d: %w",
+			size, version.Size, ErrContentUnavailable,
+		), closeErr)
+	}
+	if _, err := reader.Seek(opts.Offset, io.SeekStart); err != nil {
+		closeErr := reader.Close()
+		v.lifecycle.RUnlock()
+		return nil, errors.Join(fmt.Errorf(
+			"seeking content version range %q: %w: %w",
+			versionID, ErrContentUnavailable, err,
+		), closeErr)
+	}
+	return &VersionContentRange{
+		Version: fromStoreVersion(version),
+		Offset:  opts.Offset,
+		Length:  opts.Length,
+		Reader: newLeasedLimitedReader(
+			reader, opts.Length, v.lifecycle.RUnlock,
+		),
+	}, nil
+}
+
+type leasedLimitedReader struct {
+	source   io.ReadSeekCloser
+	limited  *io.LimitedReader
+	release  func()
+	once     sync.Once
+	closeErr error
+}
+
+func newLeasedLimitedReader(
+	source io.ReadSeekCloser, length int64, release func(),
+) *leasedLimitedReader {
+	return &leasedLimitedReader{
+		source:  source,
+		limited: &io.LimitedReader{R: source, N: length},
+		release: release,
+	}
+}
+
+func (r *leasedLimitedReader) Read(p []byte) (int, error) {
+	n, err := r.limited.Read(p)
+	if errors.Is(err, io.EOF) && r.limited.N > 0 {
+		err = io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+func (r *leasedLimitedReader) Close() error {
+	r.once.Do(func() {
+		r.closeErr = r.source.Close()
+		r.release()
+	})
+	return r.closeErr
 }
 
 func closeContentReader(reader packstore.VerifiedReadCloser) error {

--- a/vault_external_test.go
+++ b/vault_external_test.go
@@ -6,10 +6,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -20,6 +23,234 @@ func TestRootPackageConstructor(t *testing.T) {
 	vault, err := docbank.New(context.Background(), docbank.Config{Root: t.TempDir()})
 	require.NoError(t, err)
 	require.NoError(t, vault.Close())
+}
+
+func createRangeFixture(
+	t *testing.T, vault *docbank.Vault, virtualPath string, content []byte,
+) docbank.PutReceipt {
+	t.Helper()
+	sum := sha256.Sum256(content)
+	receipt, err := vault.Create(
+		t.Context(), virtualPath, bytes.NewReader(content),
+		docbank.CreateOptions{
+			MediaType: "application/octet-stream",
+			Expected: docbank.ContentIdentity{
+				SHA256: hex.EncodeToString(sum[:]),
+				Size:   int64(len(content)),
+			},
+		},
+	)
+	require.NoError(t, err)
+	return receipt
+}
+
+func TestOpenVersionContentRangeRejectsInvalidSlices(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	receipt := createRangeFixture(
+		t, vault, "/ranges/value.bin", []byte("0123456789"),
+	)
+
+	cases := []docbank.ContentRangeOptions{
+		{Offset: -1, Length: 1},
+		{Offset: 0, Length: 0},
+		{Offset: 0, Length: -1},
+		{Offset: 10, Length: 1},
+		{Offset: 9, Length: 2},
+		{Offset: math.MaxInt64, Length: math.MaxInt64},
+	}
+	for _, opts := range cases {
+		_, err := vault.OpenVersionContentRange(t.Context(), receipt.Version.ID, opts)
+		require.ErrorIs(t, err, docbank.ErrInvalidContentRange)
+	}
+}
+
+func TestOpenVersionContentRangeMissingVersion(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	_, err = vault.OpenVersionContentRange(
+		t.Context(), "00000000-0000-4000-8000-000000000000",
+		docbank.ContentRangeOptions{Offset: 0, Length: 1},
+	)
+	require.ErrorIs(t, err, docbank.ErrNotFound)
+}
+
+func TestOpenVersionContentRangeRawLoose(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	receipt := createRangeFixture(
+		t, vault, "/ranges/raw.bin", []byte("0123456789"),
+	)
+
+	got, err := vault.OpenVersionContentRange(
+		t.Context(), receipt.Version.ID,
+		docbank.ContentRangeOptions{Offset: 2, Length: 4},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, got.Reader.Close()) })
+	body, err := io.ReadAll(got.Reader)
+	require.NoError(t, err)
+	require.Equal(t, []byte("2345"), body)
+	require.Equal(t, receipt.Version, got.Version)
+	require.Equal(t, int64(2), got.Offset)
+	require.Equal(t, int64(4), got.Length)
+}
+
+func TestOpenVersionContentRangeHistoricalVersion(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	path := "/ranges/history.bin"
+	first := createRangeFixture(t, vault, path, []byte("abcdefghij"))
+	_, err = vault.Put(
+		t.Context(), path, bytes.NewReader([]byte("ABCDEFGHIJ")),
+		docbank.PutOptions{MediaType: "application/octet-stream"},
+	)
+	require.NoError(t, err)
+
+	got, err := vault.OpenVersionContentRange(
+		t.Context(), first.Version.ID,
+		docbank.ContentRangeOptions{Offset: 1, Length: 3},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, got.Reader.Close()) })
+	body, err := io.ReadAll(got.Reader)
+	require.NoError(t, err)
+	require.Equal(t, []byte("bcd"), body)
+	require.Equal(t, first.Version.ID, got.Version.ID)
+}
+
+func TestOpenVersionContentRangeCompressedLoose(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{
+		Root: t.TempDir(),
+		LooseCompression: docbank.LooseCompressionOptions{
+			Enabled: true, MinBytes: 1, MinSavingsPercent: 0,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	content := []byte(strings.Repeat("compressed logical range\n", 128))
+	receipt := createRangeFixture(t, vault, "/ranges/compressed.bin", content)
+	require.Equal(t, "loose", receipt.Physical.Kind)
+	require.Equal(t, "zstd", receipt.Physical.Encoding)
+
+	got, err := vault.OpenVersionContentRange(
+		t.Context(), receipt.Version.ID,
+		docbank.ContentRangeOptions{Offset: 11, Length: 17},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, got.Reader.Close()) })
+	body, err := io.ReadAll(got.Reader)
+	require.NoError(t, err)
+	require.Equal(t, content[11:28], body)
+}
+
+func TestOpenVersionContentRangePacked(t *testing.T) {
+	root := t.TempDir()
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: root})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	content := []byte("packed logical range content")
+	receipt := createRangeFixture(t, vault, "/ranges/packed.bin", content)
+	report, err := vault.Pack(t.Context(), docbank.PackOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, report.BlobsPacked)
+	require.NoFileExists(t, looseBlobPath(root, receipt.Computed.SHA256))
+
+	got, err := vault.OpenVersionContentRange(
+		t.Context(), receipt.Version.ID,
+		docbank.ContentRangeOptions{Offset: 7, Length: 7},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, got.Reader.Close()) })
+	body, err := io.ReadAll(got.Reader)
+	require.NoError(t, err)
+	require.Equal(t, content[7:14], body)
+}
+
+func TestOpenVersionContentRangeUnavailable(t *testing.T) {
+	tests := []struct {
+		name    string
+		corrupt func(*testing.T, string)
+	}{
+		{
+			name: "missing authority",
+			corrupt: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.Remove(path))
+			},
+		},
+		{
+			name: "physical size mismatch",
+			corrupt: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(path, []byte("short"), 0o600))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			vault, err := docbank.New(t.Context(), docbank.Config{Root: root})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, vault.Close()) })
+			content := []byte("physical authority bytes")
+			receipt := createRangeFixture(t, vault, "/ranges/unavailable.bin", content)
+			test.corrupt(t, looseBlobPath(root, receipt.Computed.SHA256))
+
+			_, err = vault.OpenVersionContentRange(
+				t.Context(), receipt.Version.ID,
+				docbank.ContentRangeOptions{Offset: 0, Length: 1},
+			)
+			require.ErrorIs(t, err, docbank.ErrContentUnavailable)
+		})
+	}
+}
+
+func TestOpenVersionContentRangeHoldsVaultLease(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	receipt := createRangeFixture(t, vault, "/ranges/lease.bin", []byte("lease bytes"))
+	opened, err := vault.OpenVersionContentRange(
+		t.Context(), receipt.Version.ID,
+		docbank.ContentRangeOptions{Offset: 0, Length: 1},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, opened.Reader.Close()) })
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- vault.Close() }()
+	select {
+	case err := <-closeDone:
+		require.FailNow(t, "vault closed while a range held its lifecycle lease", "error: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NoError(t, opened.Reader.Close())
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "vault did not close after the range released its lease")
+	}
+}
+
+func TestOpenVersionContentRangeClosedVault(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	receipt := createRangeFixture(t, vault, "/ranges/closed.bin", []byte("closed bytes"))
+	require.NoError(t, vault.Close())
+
+	_, err = vault.OpenVersionContentRange(
+		t.Context(), receipt.Version.ID,
+		docbank.ContentRangeOptions{Offset: 0, Length: 1},
+	)
+	require.ErrorIs(t, err, docbank.ErrClosed)
 }
 
 func TestEmbeddedImmutableCreate(t *testing.T) {

--- a/vault_test.go
+++ b/vault_test.go
@@ -90,6 +90,22 @@ func TestVaultCreateIsImmutableAndIdempotent(t *testing.T) {
 	require.Equal(created.Computed.SHA256, after.BlobHash)
 }
 
+func TestLeasedLimitedReaderShortRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "short.bin")
+	require.NoError(t, os.WriteFile(path, []byte("12"), 0o600))
+	source, err := os.Open(path)
+	require.NoError(t, err)
+	releases := 0
+	reader := newLeasedLimitedReader(source, 4, func() { releases++ })
+
+	body, err := io.ReadAll(reader)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.Equal(t, []byte("12"), body)
+	require.NoError(t, reader.Close())
+	require.NoError(t, reader.Close())
+	require.Equal(t, 1, releases)
+}
+
 func TestNewRecoversInterruptedRestoreBeforeOpeningMetadata(t *testing.T) {
 	root := t.TempDir()
 	digest := ""


### PR DESCRIPTION
Embedded Go owners can now open a bounded logical byte range from one exact
immutable content version. The same call returns decoded bytes when authority
is raw loose, zstd-compressed loose, packed, or available only from a secondary
store, so consumers do not need physical-storage knowledge.

`OpenVersionContentRange` validates non-empty offset and length bounds without
overflow, resolves the version through catalog authority, and holds the vault
lifecycle lease until the returned reader closes. Invalid slices,
missing versions, and unavailable or size-mismatched physical content retain
distinct error identities.

This is intentionally a range contract, not a whole-object verification claim.
Raw loose content uses native filesystem offsets; compressed and packed content
may decode or materialize from the beginning. The reader must return exactly
the requested logical length or an error, but a successful partial read does
not prove bytes outside that slice. Consumers that need complete integrity
evidence still use the verified full-version stream or maintenance verification.
