### PR TITLE
[F10–E12 24/25] Add a standard embedding provider bridge

### DIFF
--- a/cmd/docbank/daemon_test.go
+++ b/cmd/docbank/daemon_test.go
@@ -109,6 +109,8 @@ func TestServeRecoversInterruptedRestoreBeforeInitializingVault(t *testing.T) {
 		}
 	})
 	healthClient := &http.Client{Timeout: time.Second}
+	// Recovery and fresh SQLite initialization can exceed ten seconds on
+	// Windows CI. This checks recovery ordering, not startup performance.
 	require.Eventually(t, func() bool {
 		records, listErr := client.RuntimeStore(dir).List()
 		if listErr != nil || len(records) != 1 {
@@ -122,7 +124,7 @@ func TestServeRecoversInterruptedRestoreBeforeInitializingVault(t *testing.T) {
 		}
 		_ = response.Body.Close()
 		return response.StatusCode == http.StatusOK
-	}, 10*time.Second, 50*time.Millisecond)
+	}, time.Minute, 50*time.Millisecond)
 	pending, err := blob.PrimaryRestoreHandoffPending(filepath.Join(dir, "blobs"))
 	require.NoError(t, err)
 	assert.False(t, pending)

--- a/document/embeddingbridge/client.go
+++ b/document/embeddingbridge/client.go
@@ -133,7 +133,10 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 	}
 
 	response, doErr := client.http.Do(request)
-	_ = bodyReader.Close()
+	// The transport may still be checking the request body for EOF after
+	// response headers arrive. Close the writer so that check sees EOF,
+	// rather than a reader-close error that tears down the response connection.
+	_ = bodyWriter.Close()
 	sourceGate.Cancel()
 	writeErr := <-writerDone
 	if requestCtx.Err() != nil {

--- a/document/embeddingbridge/client.go
+++ b/document/embeddingbridge/client.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	unitLengthTolerance  = 1e-4
-	maxHeadingCharacters = 8192
+	unitLengthTolerance      = 1e-4
+	maxHeadingCharacters     = 8192
+	maxConsecutiveEmptyReads = 100
 )
 
 var (
@@ -59,8 +60,7 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 	if err := document.ValidateEmbeddingProviderRequest(client, frozenInputs, authorization); err != nil {
 		return document.EmbeddingResult{}, err
 	}
-	if authorization.MaxBatchItems > client.maxBatchItems || authorization.MaxInputBytes > client.maxInputBytes ||
-		authorization.MaxResponseBytes > client.maxResponseBytes {
+	if authorization.MaxBatchItems > client.maxBatchItems || authorization.MaxInputBytes > client.maxInputBytes {
 		return document.EmbeddingResult{}, classified(ErrorCapacity, 0)
 	}
 	manifest, encoded, err := client.buildManifest(frozenInputs, authorization)
@@ -68,7 +68,7 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 		return document.EmbeddingResult{}, err
 	}
 	boundary := "docbank-embedding-" + manifest.RequestChecksum[:32]
-	contentLength, err := multipartLength(boundary, encoded, frozenInputs)
+	contentLength, err := multipartLength(ctx, boundary, encoded, frozenInputs)
 	if err != nil || contentLength > client.maxRequestBytes {
 		return document.EmbeddingResult{}, classified(ErrorCapacity, 0)
 	}
@@ -107,7 +107,7 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 			writerDone <- err
 			return
 		}
-		writeErr := writeMultipart(multipartWriter, encoded, frozenInputs, true, sourceGate)
+		writeErr := writeMultipart(requestCtx, multipartWriter, encoded, frozenInputs, true, sourceGate)
 		if closeErr := multipartWriter.Close(); writeErr == nil {
 			writeErr = closeErr
 		}
@@ -281,13 +281,13 @@ func hasOriginalInput(inputs []document.EmbeddingInput) bool {
 	})
 }
 
-func multipartLength(boundary string, manifest []byte, inputs []document.EmbeddingInput) (int64, error) {
+func multipartLength(ctx context.Context, boundary string, manifest []byte, inputs []document.EmbeddingInput) (int64, error) {
 	counter := new(countingWriter)
 	writer := multipart.NewWriter(counter)
 	if err := writer.SetBoundary(boundary); err != nil {
 		return 0, errors.New("embedding bridge: deterministic multipart boundary is invalid")
 	}
-	if err := writeMultipart(writer, manifest, inputs, false, nil); err != nil {
+	if err := writeMultipart(ctx, writer, manifest, inputs, false, nil); err != nil {
 		return 0, err
 	}
 	if err := writer.Close(); err != nil {
@@ -305,7 +305,7 @@ func multipartLength(boundary string, manifest []byte, inputs []document.Embeddi
 	return total, nil
 }
 
-func writeMultipart(writer *multipart.Writer, manifest []byte, inputs []document.EmbeddingInput, writeFiles bool, sourceGate *activeSourceGate) error {
+func writeMultipart(ctx context.Context, writer *multipart.Writer, manifest []byte, inputs []document.EmbeddingInput, writeFiles bool, sourceGate *activeSourceGate) error {
 	manifestHeader := make(textproto.MIMEHeader)
 	manifestHeader.Set("Content-Disposition", `form-data; name="`+manifestPartName+`"`)
 	manifestHeader.Set("Content-Type", manifestMediaType)
@@ -335,7 +335,7 @@ func writeMultipart(writer *multipart.Writer, manifest []byte, inputs []document
 		if !ok {
 			return errTransferStopped
 		}
-		copyErr := copyAuthorizedFile(part, input.Source, metadata.ByteLength, metadata.SHA256)
+		copyErr := copyAuthorizedFile(ctx, part, input.Source, metadata.ByteLength, metadata.SHA256)
 		sourceGate.End(token)
 		if copyErr != nil {
 			return copyErr
@@ -344,7 +344,8 @@ func writeMultipart(writer *multipart.Writer, manifest []byte, inputs []document
 	return nil
 }
 
-func copyAuthorizedFile(destination io.Writer, source io.Reader, expectedLength int64, expectedSHA256 string) error {
+func copyAuthorizedFile(ctx context.Context, destination io.Writer, source io.Reader, expectedLength int64, expectedSHA256 string) error {
+	source = progressReader{ctx: ctx, source: source}
 	digest := sha256.New()
 	written, err := io.Copy(io.MultiWriter(destination, digest), io.LimitReader(source, expectedLength))
 	if err != nil {
@@ -360,6 +361,26 @@ func copyAuthorizedFile(destination io.Writer, source io.Reader, expectedLength 
 		return errSourceTransferFailed
 	}
 	return nil
+}
+
+// progressReader bounds empty reads in both the file copy and overflow probe.
+// The source gate remains responsible for interrupting a blocked source.Read.
+type progressReader struct {
+	ctx    context.Context
+	source io.Reader
+}
+
+func (reader progressReader) Read(value []byte) (int, error) {
+	for range maxConsecutiveEmptyReads {
+		if err := reader.ctx.Err(); err != nil {
+			return 0, err
+		}
+		n, err := reader.source.Read(value)
+		if n != 0 || err != nil {
+			return n, err
+		}
+	}
+	return 0, io.ErrNoProgress
 }
 
 func (client *Client) validateResponse(envelope Response, manifest RequestManifest, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {

--- a/document/embeddingbridge/client.go
+++ b/document/embeddingbridge/client.go
@@ -167,12 +167,15 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 	if err := requireResponseMediaType(response.Header.Get("Content-Type")); err != nil {
 		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
 	}
-	body, err := readBounded(response.Body, client.maxResponseBytes)
-	if err != nil {
+	body, err := io.ReadAll(io.LimitReader(response.Body, client.maxResponseBytes+1))
+	if err != nil || int64(len(body)) > client.maxResponseBytes {
 		if requestCtx.Err() != nil {
 			return document.EmbeddingResult{}, requestContextError(ctx)
 		}
-		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
+		if int64(len(body)) > client.maxResponseBytes {
+			return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
+		}
+		return document.EmbeddingResult{}, classified(ErrorAmbiguousSubmission, response.StatusCode)
 	}
 	if err := manifestjson.RejectDuplicateKeys(body, "embedding bridge response"); err != nil {
 		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
@@ -417,14 +420,6 @@ func requireResponseMediaType(value string) error {
 		return errors.New("response media type mismatch")
 	}
 	return nil
-}
-
-func readBounded(reader io.Reader, maximum int64) ([]byte, error) {
-	value, err := io.ReadAll(io.LimitReader(reader, maximum+1))
-	if err != nil || int64(len(value)) > maximum {
-		return nil, errors.New("bounded response read failed")
-	}
-	return value, nil
 }
 
 type countingWriter struct{ written int64 }

--- a/document/embeddingbridge/client.go
+++ b/document/embeddingbridge/client.go
@@ -23,7 +23,10 @@ import (
 	"go.kenn.io/docbank/document/internal/manifestjson"
 )
 
-const unitLengthTolerance = 1e-4
+const (
+	unitLengthTolerance  = 1e-4
+	maxHeadingCharacters = 8192
+)
 
 var (
 	_                       document.EmbeddingProvider = (*Client)(nil)
@@ -189,6 +192,11 @@ func freezeInputMetadata(inputs []document.EmbeddingInput, discloseFilename bool
 	for index := range frozen {
 		input := &frozen[index]
 		input.HeadingPath = slices.Clone(input.HeadingPath)
+		for _, heading := range input.HeadingPath {
+			if utf8.RuneCountInString(heading) > maxHeadingCharacters {
+				return nil, classified(ErrorPermanent, 0)
+			}
+		}
 		input.SourceSpans = slices.Clone(input.SourceSpans)
 		if input.Kind != document.EmbeddingInputOriginalFile || nilInterface(input.Source) {
 			continue
@@ -371,6 +379,9 @@ func (client *Client) validateResponse(envelope Response, manifest RequestManife
 				return document.EmbeddingResult{}, errors.New("response non-finite vector")
 			}
 			squaredNorm += float64(value) * float64(value)
+		}
+		if client.descriptor.Metric == document.VectorMetricCosine && squaredNorm == 0 {
+			return document.EmbeddingResult{}, errors.New("response cosine vector is zero")
 		}
 		if client.descriptor.Normalization == document.VectorNormalizationUnitLength && math.Abs(squaredNorm-1) > unitLengthTolerance {
 			return document.EmbeddingResult{}, errors.New("response vector normalization mismatch")

--- a/document/embeddingbridge/client.go
+++ b/document/embeddingbridge/client.go
@@ -1,0 +1,471 @@
+package embeddingbridge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"hash"
+	"io"
+	"math"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"slices"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/manifestjson"
+)
+
+var (
+	_                       document.EmbeddingProvider = (*Client)(nil)
+	errSourceChanged                                   = errors.New("embedding bridge source changed")
+	errSourceTransferFailed                            = errors.New("embedding bridge source transfer failed")
+	errTransferStopped                                 = errors.New("embedding bridge transfer stopped")
+)
+
+// Descriptor returns an immutable copy of the configured vector-space identity.
+func (client *Client) Descriptor() document.EmbeddingDescriptor {
+	if client == nil {
+		return document.EmbeddingDescriptor{}
+	}
+	return cloneDescriptor(client.descriptor)
+}
+
+// Embed performs one bounded synchronous request against the fixed same-origin route.
+func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	if client == nil {
+		return document.EmbeddingResult{}, classified(ErrorPermanent, 0)
+	}
+	if ctx == nil {
+		return document.EmbeddingResult{}, classified(ErrorPermanent, 0)
+	}
+	frozenInputs, err := freezeInputMetadata(inputs)
+	if err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if err := document.ValidateEmbeddingProviderRequest(client, frozenInputs, authorization); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if authorization.MaxBatchItems > client.maxBatchItems || authorization.MaxInputBytes > client.maxInputBytes ||
+		authorization.MaxResponseBytes > client.maxResponseBytes {
+		return document.EmbeddingResult{}, classified(ErrorCapacity, 0)
+	}
+	manifest, encoded, err := client.buildManifest(frozenInputs, authorization)
+	if err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	boundary := "docbank-embedding-" + manifest.RequestChecksum[:32]
+	contentLength, err := multipartLength(boundary, encoded, frozenInputs)
+	if err != nil || contentLength > client.maxRequestBytes {
+		return document.EmbeddingResult{}, classified(ErrorCapacity, 0)
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+	sourceGate := newActiveSourceGate()
+	closeFinished := make(chan struct{})
+	stopClose := context.AfterFunc(requestCtx, func() {
+		sourceGate.Cancel()
+		close(closeFinished)
+	})
+	defer func() {
+		if !stopClose() {
+			<-closeFinished
+		}
+	}()
+	secret := ""
+	if client.secretBinding != "" {
+		var resolveErr error
+		secret, resolveErr = client.secrets.ResolveSecret(requestCtx, client.secretBinding)
+		if resolveErr != nil || !validSecret(secret) {
+			if contextErr := requestCtx.Err(); contextErr != nil {
+				return document.EmbeddingResult{}, contextErr
+			}
+			return document.EmbeddingResult{}, classified(ErrorAuthentication, 0)
+		}
+	}
+
+	bodyReader, bodyWriter := io.Pipe()
+	writerDone := make(chan error, 1)
+	go func() {
+		multipartWriter := multipart.NewWriter(bodyWriter)
+		if err := multipartWriter.SetBoundary(boundary); err != nil {
+			_ = bodyWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		writeErr := writeMultipart(multipartWriter, encoded, frozenInputs, true, sourceGate)
+		if closeErr := multipartWriter.Close(); writeErr == nil {
+			writeErr = closeErr
+		}
+		_ = bodyWriter.CloseWithError(writeErr)
+		writerDone <- writeErr
+	}()
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodPost, client.origin+embeddingsPath, bodyReader)
+	if err != nil {
+		_ = bodyReader.Close()
+		<-writerDone
+		return document.EmbeddingResult{}, classified(ErrorPermanent, 0)
+	}
+	request.ContentLength = contentLength
+	request.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	request.Header.Set("Accept", responseMediaType)
+	if secret != "" {
+		request.Header.Set("Authorization", "Bearer "+secret)
+	}
+	request.Header.Set("Idempotency-Key", manifest.RequestChecksum)
+	request.Header.Set("Docbank-Request-Checksum", manifest.RequestChecksum)
+	if hasOriginalInput(frozenInputs) {
+		request.Header.Set("Expect", "100-continue")
+	}
+
+	response, doErr := client.http.Do(request)
+	_ = bodyReader.Close()
+	sourceGate.Cancel()
+	writeErr := <-writerDone
+	if contextErr := requestCtx.Err(); contextErr != nil {
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		return document.EmbeddingResult{}, contextErr
+	}
+	if errors.Is(writeErr, errSourceChanged) {
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		return document.EmbeddingResult{}, classified(ErrorSourceChanged, 0)
+	}
+	if doErr != nil {
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		if contextErr := requestCtx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, contextErr
+		}
+		return document.EmbeddingResult{}, classified(ErrorAmbiguousSubmission, 0)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return document.EmbeddingResult{}, statusError(response.StatusCode)
+	}
+	if writeErr != nil {
+		return document.EmbeddingResult{}, classified(ErrorAmbiguousSubmission, 0)
+	}
+	if err := requireResponseMediaType(response.Header.Get("Content-Type")); err != nil {
+		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
+	}
+	body, err := readBounded(response.Body, client.maxResponseBytes)
+	if err != nil {
+		if contextErr := requestCtx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, contextErr
+		}
+		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
+	}
+	if err := manifestjson.RejectDuplicateKeys(body, "embedding bridge response"); err != nil {
+		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
+	}
+	var envelope Response
+	if err := json.Unmarshal(body, &envelope, json.RejectUnknownMembers(true)); err != nil {
+		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
+	}
+	result, err := client.validateResponse(envelope, manifest, frozenInputs, authorization)
+	if err != nil {
+		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
+	}
+	return result, nil
+}
+
+func freezeInputMetadata(inputs []document.EmbeddingInput) ([]document.EmbeddingInput, error) {
+	frozen := slices.Clone(inputs)
+	for index := range frozen {
+		input := &frozen[index]
+		input.HeadingPath = slices.Clone(input.HeadingPath)
+		input.SourceSpans = slices.Clone(input.SourceSpans)
+		if input.Kind != document.EmbeddingInputOriginalFile || nilInterface(input.Source) {
+			continue
+		}
+		metadata := input.Source.Metadata()
+		if !safeMultipartFilename(metadata.Filename) {
+			return nil, classified(ErrorPermanent, 0)
+		}
+		input.Source = frozenUpload{AuthorizedUpload: input.Source, metadata: metadata}
+	}
+	return frozen, nil
+}
+
+func (client *Client) buildManifest(inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (RequestManifest, []byte, error) {
+	manifest := RequestManifest{
+		ContractVersion: ContractVersion, DescriptorFingerprint: client.descriptor.Fingerprint,
+		PolicyFingerprint: client.descriptor.PolicyFingerprint, Authorization: authorization,
+		Inputs: make([]ManifestInput, len(inputs)),
+	}
+	fileIndex := 0
+	for index, input := range inputs {
+		entry := ManifestInput{
+			Index: index, Key: input.Key, Role: input.Role, Kind: input.Kind,
+			HeadingPath: slices.Clone(input.HeadingPath), SourceSpans: manifestSpans(input.SourceSpans),
+		}
+		if input.Kind == document.EmbeddingInputOriginalFile {
+			metadata := input.Source.Metadata()
+			entry.ByteLength = metadata.ByteLength
+			entry.SHA256 = metadata.SHA256
+			entry.Upload = new(metadata)
+			entry.FilePart = filePartName
+			entry.FileIndex = new(fileIndex)
+			fileIndex++
+		} else {
+			if input.Role == document.EmbeddingRoleDocument {
+				entry.Text = client.descriptor.ModelInput.EncodeDocument(input.Text)
+			} else {
+				entry.Text = client.descriptor.ModelInput.EncodeQuery(input.Text)
+			}
+			entry.ByteLength = int64(len(entry.Text))
+			entry.SHA256 = sha256Hex([]byte(entry.Text))
+		}
+		manifest.Inputs[index] = entry
+	}
+	identity, err := json.Marshal(manifest, json.Deterministic(true))
+	if err != nil {
+		return RequestManifest{}, nil, classified(ErrorPermanent, 0)
+	}
+	manifest.RequestChecksum = sha256Hex(identity)
+	encoded, err := json.Marshal(manifest, json.Deterministic(true))
+	if err != nil {
+		return RequestManifest{}, nil, classified(ErrorPermanent, 0)
+	}
+	return manifest, encoded, nil
+}
+
+func manifestSpans(values []document.ChunkSpan) []ManifestSpan {
+	if values == nil {
+		return nil
+	}
+	result := make([]ManifestSpan, len(values))
+	for index, value := range values {
+		result[index] = ManifestSpan{UnitIndex: value.UnitIndex, CharStart: value.CharStart, CharEnd: value.CharEnd}
+	}
+	return result
+}
+
+func hasOriginalInput(inputs []document.EmbeddingInput) bool {
+	return slices.ContainsFunc(inputs, func(input document.EmbeddingInput) bool {
+		return input.Kind == document.EmbeddingInputOriginalFile
+	})
+}
+
+func multipartLength(boundary string, manifest []byte, inputs []document.EmbeddingInput) (int64, error) {
+	counter := new(countingWriter)
+	writer := multipart.NewWriter(counter)
+	if err := writer.SetBoundary(boundary); err != nil {
+		return 0, errors.New("embedding bridge: deterministic multipart boundary is invalid")
+	}
+	if err := writeMultipart(writer, manifest, inputs, false, nil); err != nil {
+		return 0, err
+	}
+	if err := writer.Close(); err != nil {
+		return 0, errors.New("embedding bridge: multipart measurement failed")
+	}
+	total := counter.written
+	for _, input := range inputs {
+		if input.Kind == document.EmbeddingInputOriginalFile {
+			if input.Source.Metadata().ByteLength > maxRequestBytes-total {
+				return 0, errors.New("multipart request length overflow")
+			}
+			total += input.Source.Metadata().ByteLength
+		}
+	}
+	return total, nil
+}
+
+func writeMultipart(writer *multipart.Writer, manifest []byte, inputs []document.EmbeddingInput, writeFiles bool, sourceGate *activeSourceGate) error {
+	manifestHeader := make(textproto.MIMEHeader)
+	manifestHeader.Set("Content-Disposition", `form-data; name="`+manifestPartName+`"`)
+	manifestHeader.Set("Content-Type", manifestMediaType)
+	part, err := writer.CreatePart(manifestHeader)
+	if err != nil {
+		return errors.New("embedding bridge: manifest multipart part failed")
+	}
+	if _, err := part.Write(manifest); err != nil {
+		return err
+	}
+	for _, input := range inputs {
+		if input.Kind != document.EmbeddingInputOriginalFile {
+			continue
+		}
+		metadata := input.Source.Metadata()
+		fileHeader := make(textproto.MIMEHeader)
+		fileHeader.Set("Content-Disposition", multipart.FileContentDisposition(filePartName, metadata.Filename))
+		fileHeader.Set("Content-Type", metadata.MediaType)
+		part, err := writer.CreatePart(fileHeader)
+		if err != nil {
+			return errors.New("embedding bridge: file multipart part failed")
+		}
+		if !writeFiles {
+			continue
+		}
+		token, ok := sourceGate.Begin(input.Source)
+		if !ok {
+			return errTransferStopped
+		}
+		copyErr := copyAuthorizedFile(part, input.Source, metadata.ByteLength, metadata.SHA256)
+		sourceGate.End(token)
+		if copyErr != nil {
+			return copyErr
+		}
+	}
+	return nil
+}
+
+func copyAuthorizedFile(destination io.Writer, source io.Reader, expectedLength int64, expectedSHA256 string) error {
+	digest := sha256.New()
+	written, err := io.Copy(io.MultiWriter(destination, digest), io.LimitReader(source, expectedLength+1))
+	if err != nil {
+		return errSourceTransferFailed
+	}
+	if written != expectedLength || !strings.EqualFold(hexDigest(digest), expectedSHA256) {
+		return errSourceChanged
+	}
+	return nil
+}
+
+func (client *Client) validateResponse(envelope Response, manifest RequestManifest, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	if envelope.ContractVersion != ContractVersion || envelope.DescriptorFingerprint != client.descriptor.Fingerprint ||
+		envelope.PolicyFingerprint != client.descriptor.PolicyFingerprint || envelope.RequestChecksum != manifest.RequestChecksum ||
+		len(envelope.Vectors) != len(inputs) {
+		return document.EmbeddingResult{}, errors.New("response identity mismatch")
+	}
+	vectors := make([]document.EmbeddingVector, len(inputs))
+	seenKeys := make(map[string]struct{}, len(inputs))
+	for position, vector := range envelope.Vectors {
+		if vector.Index == nil || *vector.Index != position || vector.Key != inputs[position].Key {
+			return document.EmbeddingResult{}, errors.New("response order mismatch")
+		}
+		if _, exists := seenKeys[vector.Key]; exists {
+			return document.EmbeddingResult{}, errors.New("response duplicate key")
+		}
+		seenKeys[vector.Key] = struct{}{}
+		if len(vector.Values) != client.descriptor.Dimension {
+			return document.EmbeddingResult{}, errors.New("response dimension mismatch")
+		}
+		for _, value := range vector.Values {
+			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+				return document.EmbeddingResult{}, errors.New("response non-finite vector")
+			}
+		}
+		vectors[position] = document.EmbeddingVector{Key: vector.Key, Values: slices.Clone(vector.Values)}
+	}
+	result := document.EmbeddingResult{Vectors: vectors}
+	if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	return result, nil
+}
+
+func statusError(status int) error {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return classified(ErrorAuthentication, status)
+	case http.StatusRequestEntityTooLarge:
+		return classified(ErrorCapacity, status)
+	case http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError,
+		http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return classified(ErrorTransient, status)
+	default:
+		return classified(ErrorPermanent, status)
+	}
+}
+
+func requireResponseMediaType(value string) error {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || mediaType != "application/vnd.docbank.embedding-result+json" || len(parameters) != 1 || parameters["version"] != "1" {
+		return errors.New("response media type mismatch")
+	}
+	return nil
+}
+
+func readBounded(reader io.Reader, maximum int64) ([]byte, error) {
+	value, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if err != nil || int64(len(value)) > maximum {
+		return nil, errors.New("bounded response read failed")
+	}
+	return value, nil
+}
+
+type countingWriter struct{ written int64 }
+
+func (writer *countingWriter) Write(value []byte) (int, error) {
+	if int64(len(value)) > maxRequestBytes-writer.written {
+		return 0, errors.New("multipart request length overflow")
+	}
+	writer.written += int64(len(value))
+	return len(value), nil
+}
+
+func hexDigest(value hash.Hash) string { return hex.EncodeToString(value.Sum(nil)) }
+
+type frozenUpload struct {
+	document.AuthorizedUpload
+
+	metadata document.AuthorizedUploadMetadata
+}
+
+func (upload frozenUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+func safeMultipartFilename(value string) bool {
+	return utf8.ValidString(value) && strings.IndexFunc(value, unicode.IsControl) < 0
+}
+
+type activeSourceGate struct {
+	mu          sync.Mutex
+	canceled    bool
+	nextToken   uint64
+	activeToken uint64
+	active      document.AuthorizedUpload
+}
+
+func newActiveSourceGate() *activeSourceGate { return new(activeSourceGate) }
+
+func (gate *activeSourceGate) Begin(source document.AuthorizedUpload) (uint64, bool) {
+	gate.mu.Lock()
+	defer gate.mu.Unlock()
+	if gate.canceled {
+		return 0, false
+	}
+	gate.nextToken++
+	gate.activeToken = gate.nextToken
+	gate.active = source
+	return gate.activeToken, true
+}
+
+func (gate *activeSourceGate) End(token uint64) {
+	gate.mu.Lock()
+	defer gate.mu.Unlock()
+	if gate.activeToken != token {
+		return
+	}
+	gate.active = nil
+	gate.activeToken = 0
+}
+
+func (gate *activeSourceGate) Cancel() {
+	gate.mu.Lock()
+	if gate.canceled {
+		gate.mu.Unlock()
+		return
+	}
+	gate.canceled = true
+	active := gate.active
+	gate.active = nil
+	gate.activeToken = 0
+	gate.mu.Unlock()
+	if !nilInterface(active) {
+		_ = active.Close()
+	}
+}

--- a/document/embeddingbridge/client.go
+++ b/document/embeddingbridge/client.go
@@ -23,6 +23,8 @@ import (
 	"go.kenn.io/docbank/document/internal/manifestjson"
 )
 
+const unitLengthTolerance = 1e-4
+
 var (
 	_                       document.EmbeddingProvider = (*Client)(nil)
 	errSourceChanged                                   = errors.New("embedding bridge source changed")
@@ -46,7 +48,7 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 	if ctx == nil {
 		return document.EmbeddingResult{}, classified(ErrorPermanent, 0)
 	}
-	frozenInputs, err := freezeInputMetadata(inputs)
+	frozenInputs, err := freezeInputMetadata(inputs, authorization.DiscloseFilename)
 	if err != nil {
 		return document.EmbeddingResult{}, err
 	}
@@ -182,7 +184,7 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 	return result, nil
 }
 
-func freezeInputMetadata(inputs []document.EmbeddingInput) ([]document.EmbeddingInput, error) {
+func freezeInputMetadata(inputs []document.EmbeddingInput, discloseFilename bool) ([]document.EmbeddingInput, error) {
 	frozen := slices.Clone(inputs)
 	for index := range frozen {
 		input := &frozen[index]
@@ -194,6 +196,9 @@ func freezeInputMetadata(inputs []document.EmbeddingInput) ([]document.Embedding
 		metadata := input.Source.Metadata()
 		if !safeMultipartFilename(metadata.Filename) {
 			return nil, classified(ErrorPermanent, 0)
+		}
+		if !discloseFilename {
+			metadata.Filename = ""
 		}
 		input.Source = frozenUpload{AuthorizedUpload: input.Source, metadata: metadata}
 	}
@@ -325,12 +330,18 @@ func writeMultipart(writer *multipart.Writer, manifest []byte, inputs []document
 
 func copyAuthorizedFile(destination io.Writer, source io.Reader, expectedLength int64, expectedSHA256 string) error {
 	digest := sha256.New()
-	written, err := io.Copy(io.MultiWriter(destination, digest), io.LimitReader(source, expectedLength+1))
+	written, err := io.Copy(io.MultiWriter(destination, digest), io.LimitReader(source, expectedLength))
 	if err != nil {
 		return errSourceTransferFailed
 	}
 	if written != expectedLength || !strings.EqualFold(hexDigest(digest), expectedSHA256) {
 		return errSourceChanged
+	}
+	var probe [1]byte
+	if n, err := io.ReadFull(source, probe[:]); n != 0 {
+		return errSourceChanged
+	} else if !errors.Is(err, io.EOF) {
+		return errSourceTransferFailed
 	}
 	return nil
 }
@@ -354,10 +365,15 @@ func (client *Client) validateResponse(envelope Response, manifest RequestManife
 		if len(vector.Values) != client.descriptor.Dimension {
 			return document.EmbeddingResult{}, errors.New("response dimension mismatch")
 		}
+		var squaredNorm float64
 		for _, value := range vector.Values {
 			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
 				return document.EmbeddingResult{}, errors.New("response non-finite vector")
 			}
+			squaredNorm += float64(value) * float64(value)
+		}
+		if client.descriptor.Normalization == document.VectorNormalizationUnitLength && math.Abs(squaredNorm-1) > unitLengthTolerance {
+			return document.EmbeddingResult{}, errors.New("response vector normalization mismatch")
 		}
 		vectors[position] = document.EmbeddingVector{Key: vector.Key, Values: slices.Clone(vector.Values)}
 	}

--- a/document/embeddingbridge/client.go
+++ b/document/embeddingbridge/client.go
@@ -87,8 +87,8 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 		var resolveErr error
 		secret, resolveErr = client.secrets.ResolveSecret(requestCtx, client.secretBinding)
 		if resolveErr != nil || !validSecret(secret) {
-			if contextErr := requestCtx.Err(); contextErr != nil {
-				return document.EmbeddingResult{}, contextErr
+			if requestCtx.Err() != nil {
+				return document.EmbeddingResult{}, requestContextError(ctx)
 			}
 			return document.EmbeddingResult{}, classified(ErrorAuthentication, 0)
 		}
@@ -132,11 +132,11 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 	_ = bodyReader.Close()
 	sourceGate.Cancel()
 	writeErr := <-writerDone
-	if contextErr := requestCtx.Err(); contextErr != nil {
+	if requestCtx.Err() != nil {
 		if response != nil {
 			_ = response.Body.Close()
 		}
-		return document.EmbeddingResult{}, contextErr
+		return document.EmbeddingResult{}, requestContextError(ctx)
 	}
 	if errors.Is(writeErr, errSourceChanged) {
 		if response != nil {
@@ -148,10 +148,10 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 		if response != nil {
 			_ = response.Body.Close()
 		}
-		if contextErr := requestCtx.Err(); contextErr != nil {
-			return document.EmbeddingResult{}, contextErr
+		if requestCtx.Err() != nil {
+			return document.EmbeddingResult{}, requestContextError(ctx)
 		}
-		return document.EmbeddingResult{}, classified(ErrorAmbiguousSubmission, 0)
+		return document.EmbeddingResult{}, transportError(doErr)
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
@@ -165,8 +165,8 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 	}
 	body, err := readBounded(response.Body, client.maxResponseBytes)
 	if err != nil {
-		if contextErr := requestCtx.Err(); contextErr != nil {
-			return document.EmbeddingResult{}, contextErr
+		if requestCtx.Err() != nil {
+			return document.EmbeddingResult{}, requestContextError(ctx)
 		}
 		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
 	}

--- a/document/embeddingbridge/client.go
+++ b/document/embeddingbridge/client.go
@@ -21,6 +21,7 @@ import (
 
 	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/document/internal/manifestjson"
+	"go.kenn.io/docbank/document/internal/providerutil"
 )
 
 const (
@@ -177,7 +178,8 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
 	}
 	var envelope Response
-	if err := json.Unmarshal(body, &envelope, json.RejectUnknownMembers(true)); err != nil {
+	if err := json.Unmarshal(body, &envelope, json.RejectUnknownMembers(true),
+		json.WithUnmarshalers(json.UnmarshalFunc(providerutil.UnmarshalEmbeddingFloat32))); err != nil {
 		return document.EmbeddingResult{}, classified(ErrorMalformedResponse, response.StatusCode)
 	}
 	result, err := client.validateResponse(envelope, manifest, frozenInputs, authorization)
@@ -444,6 +446,12 @@ type frozenUpload struct {
 }
 
 func (upload frozenUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+func (upload frozenUpload) Close() error {
+	// The source gate closes only abandoned uploads. Interrupt the underlying
+	// source before a sealed upload waits for the mutex held by an active read.
+	return document.InterruptAuthorizedUpload(upload.AuthorizedUpload)
+}
 
 func safeMultipartFilename(value string) bool {
 	return utf8.ValidString(value) && strings.IndexFunc(value, unicode.IsControl) < 0

--- a/document/embeddingbridge/client_internal_test.go
+++ b/document/embeddingbridge/client_internal_test.go
@@ -1,0 +1,17 @@
+package embeddingbridge
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyAuthorizedFileDoesNotTransmitOverflowProbe(t *testing.T) {
+	var destination bytes.Buffer
+	err := copyAuthorizedFile(&destination, strings.NewReader("abcd"), 3, sha256Hex([]byte("abc")))
+	require.ErrorIs(t, err, errSourceChanged)
+	assert.Equal(t, "abc", destination.String())
+}

--- a/document/embeddingbridge/client_internal_test.go
+++ b/document/embeddingbridge/client_internal_test.go
@@ -2,6 +2,7 @@ package embeddingbridge
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
@@ -11,7 +12,44 @@ import (
 
 func TestCopyAuthorizedFileDoesNotTransmitOverflowProbe(t *testing.T) {
 	var destination bytes.Buffer
-	err := copyAuthorizedFile(&destination, strings.NewReader("abcd"), 3, sha256Hex([]byte("abc")))
+	err := copyAuthorizedFile(t.Context(), &destination, strings.NewReader("abcd"), 3, sha256Hex([]byte("abc")))
 	require.ErrorIs(t, err, errSourceChanged)
 	assert.Equal(t, "abc", destination.String())
 }
+
+func TestCopyAuthorizedFileChecksCancellationBetweenReads(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	reads := 0
+	source := uploadReadFunc(func([]byte) (int, error) {
+		reads++
+		cancel()
+		return 0, nil
+	})
+	var destination bytes.Buffer
+	err := copyAuthorizedFile(ctx, &destination, source, 1, sha256Hex([]byte("a")))
+	require.ErrorIs(t, err, errSourceTransferFailed)
+	assert.Equal(t, 1, reads)
+	assert.Empty(t, destination.Bytes())
+}
+
+func TestCopyAuthorizedFileAllowsIntermittentEmptyReads(t *testing.T) {
+	content := strings.NewReader("abc")
+	reads := 0
+	source := uploadReadFunc(func(value []byte) (int, error) {
+		reads++
+		if reads%100 != 0 {
+			return 0, nil
+		}
+		return content.Read(value[:1])
+	})
+	var destination bytes.Buffer
+	err := copyAuthorizedFile(t.Context(), &destination, source, 3, sha256Hex([]byte("abc")))
+	require.NoError(t, err)
+	assert.Equal(t, "abc", destination.String())
+	assert.Greater(t, reads, 100, "progress resets the consecutive-empty-read limit")
+}
+
+type uploadReadFunc func([]byte) (int, error)
+
+func (read uploadReadFunc) Read(value []byte) (int, error) { return read(value) }

--- a/document/embeddingbridge/client_test.go
+++ b/document/embeddingbridge/client_test.go
@@ -1,0 +1,1105 @@
+package embeddingbridge_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/netip"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/embeddingbridge"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+type secretMap map[string]string
+
+func (values secretMap) ResolveSecret(_ context.Context, binding string) (string, error) {
+	value, ok := values[binding]
+	if !ok {
+		return "", errors.New("synthetic resolver detail")
+	}
+	return value, nil
+}
+
+type fixedResolver struct{ address netip.Addr }
+
+func (resolver fixedResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return []netip.Addr{resolver.address}, nil
+}
+
+type bridgeFixture struct {
+	t          *testing.T
+	server     *http.Server
+	listener   net.Listener
+	origin     string
+	resolver   fixedResolver
+	profile    embeddingbridge.Profile
+	descriptor document.EmbeddingDescriptor
+	client     *embeddingbridge.Client
+}
+
+func newBridgeFixture(t *testing.T, handler http.Handler) bridgeFixture {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	server := &http.Server{Handler: handler, ReadHeaderTimeout: time.Second}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		require.NoError(t, server.Shutdown(context.Background()))
+	})
+	tcpAddress, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	port := tcpAddress.Port
+	origin := "http://embedding.invalid:" + strconv.Itoa(port)
+	modelInput, err := document.NewModelInputContract(document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic})
+	require.NoError(t, err)
+	descriptor := document.EmbeddingDescriptor{
+		ID: "synthetic.embedding-bridge", ContractVersion: document.EmbeddingProviderContractVersion,
+		PolicyFingerprint: strings.Repeat("0", 64), TrustBoundary: document.EmbeddingTrustOperatorNetwork,
+		Model: "synthetic-embed", ModelRevision: "immutable-r1", Dimension: 2,
+		Metric: document.VectorMetricCosine, Normalization: document.VectorNormalizationNone,
+		ScalarEncoding: "float32", DocumentFormatter: "synthetic/document-v1",
+		QueryFormatter:  "synthetic/query-v1",
+		InputKinds:      []document.EmbeddingInputKind{document.EmbeddingInputOriginalFile, document.EmbeddingInputRenditionChunk},
+		CompatibilityID: modelInput.CompatibilityID, SupportsTextQuery: true, ModelInput: modelInput,
+		SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeText},
+	}
+	descriptor, err = document.NewEmbeddingDescriptor(descriptor)
+	require.NoError(t, err)
+	profile := embeddingbridge.Profile{
+		Origin: origin, Descriptor: descriptor, SecretBinding: "credential:synthetic-bridge",
+		EgressPolicy: providerhttp.EgressPolicy{
+			Scheme: "http", Host: "embedding.invalid", Port: uint16(port),
+			AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")},
+			ProxyMode:    providerhttp.ProxyDisabled,
+		},
+		RequestTimeout: time.Second, MaxBatchItems: 8, MaxInputBytes: 4096,
+		MaxRequestBytes: 16 << 10, MaxResponseBytes: 16 << 10,
+	}
+	fingerprint, err := embeddingbridge.PolicyFingerprint(profile)
+	require.NoError(t, err)
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+	require.NoError(t, err)
+	descriptor = profile.Descriptor
+	httpClient := &http.Client{}
+	client, err := embeddingbridge.New(profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, fixedResolver{netip.MustParseAddr("127.0.0.1")}, httpClient)
+	require.NoError(t, err)
+	return bridgeFixture{t: t, server: server, listener: listener, origin: origin, resolver: fixedResolver{netip.MustParseAddr("127.0.0.1")}, profile: profile, descriptor: descriptor, client: client}
+}
+
+func (fixture bridgeFixture) authorization(items int) document.EmbeddingAuthorization {
+	return document.EmbeddingAuthorization{
+		ProviderID: fixture.descriptor.ID, DescriptorFingerprint: fixture.descriptor.Fingerprint,
+		PolicyFingerprint: fixture.descriptor.PolicyFingerprint, MaxBatchItems: items,
+		MaxInputBytes: 4096, MaxResponseBytes: 4096,
+	}
+}
+
+type requestManifest struct {
+	ContractVersion       string                          `json:"contract_version"`
+	DescriptorFingerprint string                          `json:"descriptor_fingerprint"`
+	PolicyFingerprint     string                          `json:"policy_fingerprint"`
+	Authorization         document.EmbeddingAuthorization `json:"authorization"`
+	Inputs                []manifestInput                 `json:"inputs"`
+	RequestChecksum       string                          `json:"request_checksum,omitempty"`
+}
+
+type manifestInput struct {
+	Index       int                                `json:"index"`
+	Key         string                             `json:"key"`
+	Role        document.EmbeddingRole             `json:"role"`
+	Kind        document.EmbeddingInputKind        `json:"kind"`
+	ByteLength  int64                              `json:"byte_length"`
+	SHA256      string                             `json:"sha256"`
+	Text        string                             `json:"text,omitempty"`
+	HeadingPath []string                           `json:"heading_path,omitempty"`
+	SourceSpans []manifestSpan                     `json:"source_spans,omitempty"`
+	Upload      *document.AuthorizedUploadMetadata `json:"upload,omitempty"`
+	FilePart    string                             `json:"file_part,omitempty"`
+	FileIndex   *int                               `json:"file_index,omitempty"`
+}
+
+type manifestSpan struct {
+	UnitIndex int `json:"unit_index"`
+	CharStart int `json:"char_start"`
+	CharEnd   int `json:"char_end"`
+}
+
+type responseEnvelope struct {
+	ContractVersion       string                     `json:"contract_version"`
+	DescriptorFingerprint string                     `json:"descriptor_fingerprint"`
+	PolicyFingerprint     string                     `json:"policy_fingerprint"`
+	RequestChecksum       string                     `json:"request_checksum"`
+	Vectors               []document.EmbeddingVector `json:"vectors"`
+}
+
+func readBridgeRequest(t *testing.T, request *http.Request) (requestManifest, [][]byte) {
+	t.Helper()
+	mediaType, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	require.Equal(t, "multipart/form-data", mediaType)
+	reader := multipart.NewReader(request.Body, parameters["boundary"])
+	var manifest requestManifest
+	var files [][]byte
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		payload, err := io.ReadAll(part)
+		require.NoError(t, err)
+		switch part.FormName() {
+		case "manifest":
+			require.Equal(t, "application/vnd.docbank.embedding-manifest+json;version=1", part.Header.Get("Content-Type"))
+			require.NoError(t, json.Unmarshal(payload, &manifest, json.RejectUnknownMembers(true)))
+		case "file":
+			files = append(files, payload)
+		default:
+			t.Fatalf("unexpected multipart field %q", part.FormName())
+		}
+	}
+	return manifest, files
+}
+
+func writeSuccess(t *testing.T, writer http.ResponseWriter, manifest requestManifest, vectors []document.EmbeddingVector) {
+	t.Helper()
+	writer.Header().Set("Content-Type", "application/vnd.docbank.embedding-result+json;version=1")
+	payload, err := json.Marshal(responseEnvelope{
+		ContractVersion:       embeddingbridge.ContractVersion,
+		DescriptorFingerprint: manifest.DescriptorFingerprint,
+		PolicyFingerprint:     manifest.PolicyFingerprint,
+		RequestChecksum:       manifest.RequestChecksum,
+		Vectors:               vectors,
+	})
+	require.NoError(t, err)
+	_, err = writer.Write(payload)
+	require.NoError(t, err)
+}
+
+func TestTextDocumentAndQueryManifestBindsExactRenderedBytesAndChecksum(t *testing.T) {
+	var captured requestManifest
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "/docbank-embedding/v1/embeddings", request.URL.Path)
+		assert.Equal(t, "Bearer synthetic-secret", request.Header.Get("Authorization"))
+		assert.Equal(t, request.Header.Get("Idempotency-Key"), request.Header.Get("Docbank-Request-Checksum"))
+		manifest, files := readBridgeRequest(t, request)
+		captured = manifest
+		assert.Empty(t, files)
+		zero, one := 0, 1
+		writeSuccess(t, writer, manifest, []document.EmbeddingVector{
+			{Key: "chunk-a", Index: &zero, Values: []float32{0.25, 0.5}},
+			{Key: "query-a", Index: &one, Values: []float32{0.75, 1}},
+		})
+	}))
+	inputs := []document.EmbeddingInput{
+		{
+			Key: "chunk-a", Role: document.EmbeddingRoleDocument,
+			Kind: document.EmbeddingInputRenditionChunk, Text: "alpha",
+			HeadingPath: []string{"Overview"},
+			SourceSpans: []document.ChunkSpan{{UnitIndex: 0, CharStart: 0, CharEnd: 5}},
+		},
+		{Key: "query-a", Role: document.EmbeddingRoleQuery, Kind: document.EmbeddingInputQueryText, Text: "beta"},
+	}
+	authorization := fixture.authorization(2)
+	result, err := fixture.client.Embed(context.Background(), inputs, authorization)
+	require.NoError(t, err)
+	require.Len(t, result.Vectors, 2)
+	assert.Equal(t, []float32{0.25, 0.5}, result.Vectors[0].Values)
+	assert.Nil(t, result.Vectors[0].Index, "the provider result is normalized to request order")
+
+	assert.Equal(t, embeddingbridge.ContractVersion, captured.ContractVersion)
+	assert.Equal(t, fixture.descriptor.Fingerprint, captured.DescriptorFingerprint)
+	assert.Equal(t, fixture.descriptor.PolicyFingerprint, captured.PolicyFingerprint)
+	assert.Equal(t, authorization, captured.Authorization)
+	require.Len(t, captured.Inputs, 2)
+	assert.Equal(t, "search_document: alpha", captured.Inputs[0].Text)
+	assert.Equal(t, int64(22), captured.Inputs[0].ByteLength)
+	assert.Equal(t, sha256Text("search_document: alpha"), captured.Inputs[0].SHA256)
+	assert.Equal(t, []string{"Overview"}, captured.Inputs[0].HeadingPath)
+	assert.Equal(t, []manifestSpan{{UnitIndex: 0, CharStart: 0, CharEnd: 5}}, captured.Inputs[0].SourceSpans)
+	assert.Equal(t, "search_query: beta", captured.Inputs[1].Text)
+	assert.Equal(t, int64(18), captured.Inputs[1].ByteLength)
+	assert.Equal(t, sha256Text("search_query: beta"), captured.Inputs[1].SHA256)
+	assert.Equal(t, exactManifestChecksum(t, captured), captured.RequestChecksum)
+	assert.NotContains(t, mustJSON(t, captured), "node_id")
+	assert.NotContains(t, mustJSON(t, captured), "tags")
+	assert.NotContains(t, mustJSON(t, captured), "vault")
+	assert.Contains(t, mustJSON(t, captured), `"unit_index":0`)
+}
+
+func TestExplicitNoAuthProfileUsesNoResolverOrAuthorizationHeader(t *testing.T) {
+	var requests atomic.Int32
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		assert.Empty(t, request.Header.Get("Authorization"))
+		manifest, _ := readBridgeRequest(t, request)
+		zero := 0
+		writeSuccess(t, writer, manifest, []document.EmbeddingVector{{Key: "first", Index: &zero, Values: []float32{1, 2}}})
+	}))
+	profile := fixture.profile
+	profile.SecretBinding = ""
+	fingerprint, err := embeddingbridge.PolicyFingerprint(profile)
+	require.NoError(t, err)
+	assert.NotEqual(t, fixture.descriptor.PolicyFingerprint, fingerprint)
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+	require.NoError(t, err)
+	client, err := embeddingbridge.New(profile, nil, fixture.resolver, &http.Client{})
+	require.NoError(t, err)
+	_, err = client.Embed(context.Background(), oneTextInput("alpha"), document.EmbeddingAuthorization{
+		ProviderID: profile.Descriptor.ID, DescriptorFingerprint: profile.Descriptor.Fingerprint,
+		PolicyFingerprint: profile.Descriptor.PolicyFingerprint, MaxBatchItems: 1,
+		MaxInputBytes: 4096, MaxResponseBytes: 4096,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), requests.Load())
+
+	_, err = embeddingbridge.New(profile, secretMap{}, fixture.resolver, &http.Client{})
+	require.Error(t, err, "an empty binding cannot carry an ambient resolver")
+	_, err = embeddingbridge.New(fixture.profile, nil, fixture.resolver, &http.Client{})
+	require.Error(t, err, "a named binding requires its narrow resolver")
+	hosted := profile
+	hosted.Descriptor.TrustBoundary = document.EmbeddingTrustHostedProvider
+	_, err = embeddingbridge.PolicyFingerprint(hosted)
+	require.Error(t, err, "anonymous profiles are operator-network only")
+}
+
+func TestMixedTextAndDirectFileRequestStreamsOnlyAuthorizedBytes(t *testing.T) {
+	source := []byte("synthetic direct file")
+	metadata := uploadMetadata(source)
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	parsed, err := url.Parse("http://embedding.invalid")
+	require.NoError(t, err)
+	jar.SetCookies(parsed, []*http.Cookie{{ //nolint:gosec // Deliberately ambient insecure test cookie; isolation must strip it.
+		Name: "ambient", Value: "PRIVATE_COOKIE",
+	}})
+	var manifest requestManifest
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Empty(t, request.Header.Get("Cookie"))
+		var files [][]byte
+		manifest, files = readBridgeRequest(t, request)
+		assert.Equal(t, [][]byte{source}, files)
+		zero, one := 0, 1
+		writeSuccess(t, writer, manifest, []document.EmbeddingVector{
+			{Key: "source-a", Index: &zero, Values: []float32{1, 2}},
+			{Key: "query-a", Index: &one, Values: []float32{3, 4}},
+		})
+	}))
+	client, err := embeddingbridge.New(fixture.profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, fixture.resolver, &http.Client{Jar: jar})
+	require.NoError(t, err)
+	upload := &testUpload{Reader: bytes.NewReader(source), metadata: metadata}
+	result, err := client.Embed(context.Background(), []document.EmbeddingInput{
+		{Key: "source-a", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: upload},
+		{Key: "query-a", Role: document.EmbeddingRoleQuery, Kind: document.EmbeddingInputQueryText, Text: "needle"},
+	}, fixture.authorization(2))
+	require.NoError(t, err)
+	require.Len(t, result.Vectors, 2)
+	require.Len(t, manifest.Inputs, 2)
+	assert.Equal(t, &metadata, manifest.Inputs[0].Upload)
+	assert.Equal(t, "file", manifest.Inputs[0].FilePart)
+	require.NotNil(t, manifest.Inputs[0].FileIndex)
+	assert.Zero(t, *manifest.Inputs[0].FileIndex)
+	assert.Empty(t, manifest.Inputs[0].Text)
+	assert.Equal(t, int64(len(source)), manifest.Inputs[0].ByteLength)
+	assert.Equal(t, metadata.SHA256, manifest.Inputs[0].SHA256)
+}
+
+func TestResponseContractFailsClosed(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        func(requestManifest) string
+		category    embeddingbridge.ErrorCategory
+	}{
+		{name: "wrong media type", contentType: "application/json", body: validResponseBody, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "unknown major", contentType: "application/vnd.docbank.embedding-result+json;version=2", body: func(manifest requestManifest) string {
+			return strings.Replace(validResponseBody(manifest), embeddingbridge.ContractVersion, "docbank-embedding/v2", 1)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "descriptor drift", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			manifest.DescriptorFingerprint = strings.Repeat("d", 64)
+			return validResponseBody(manifest)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "policy drift", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			manifest.PolicyFingerprint = strings.Repeat("e", 64)
+			return validResponseBody(manifest)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "request drift", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			manifest.RequestChecksum = strings.Repeat("f", 64)
+			return validResponseBody(manifest)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "wrong order", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"second","index":1,"values":[1,2]},{"key":"first","index":0,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "wrong index", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":1,"values":[1,2]},{"key":"second","index":0,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "dimension", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1]},{"key":"second","index":1,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "non finite", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1e1000,2]},{"key":"second","index":1,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "duplicate key", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,2]},{"key":"first","index":1,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "missing key", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,2]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "extra key", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,2]},{"key":"second","index":1,"values":[3,4]},{"key":"extra","index":2,"values":[5,6]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "unknown field", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return strings.TrimSuffix(validResponseBody(manifest), "}") + `,"provider_body":"PRIVATE_RESPONSE"}`
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "trailing JSON", contentType: responseMediaType(), body: func(manifest requestManifest) string { return validResponseBody(manifest) + `{}` }, category: embeddingbridge.ErrorMalformedResponse},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				manifest, _ := readBridgeRequest(t, request)
+				writer.Header().Set("Content-Type", test.contentType)
+				_, _ = io.WriteString(writer, test.body(manifest))
+			}))
+			_, err := fixture.client.Embed(context.Background(), twoTextInputs(), fixture.authorization(2))
+			require.Error(t, err)
+			assert.Equal(t, test.category, embeddingbridge.Category(err))
+			assert.NotContains(t, err.Error(), "PRIVATE_RESPONSE")
+		})
+	}
+}
+
+func TestResponseByteLimitIsEnforcedBeforeDecode(t *testing.T) {
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = readBridgeRequest(t, request)
+		writer.Header().Set("Content-Type", responseMediaType())
+		_, _ = writer.Write(bytes.Repeat([]byte("x"), 16<<10+1))
+	}))
+	_, err := fixture.client.Embed(context.Background(), twoTextInputs(), fixture.authorization(2))
+	require.Error(t, err)
+	assert.Equal(t, embeddingbridge.ErrorMalformedResponse, embeddingbridge.Category(err))
+}
+
+func TestProfileFingerprintFreezesDescriptorModelOriginEgressBindingAndBounds(t *testing.T) {
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		_, _ = io.Copy(io.Discard, request.Body)
+	}))
+	mutations := []struct {
+		name   string
+		mutate func(*embeddingbridge.Profile)
+	}{
+		{"model revision", func(profile *embeddingbridge.Profile) { profile.Descriptor.ModelRevision = "immutable-r2" }},
+		{"model input", func(profile *embeddingbridge.Profile) {
+			profile.Descriptor.ModelInput.Query.Template = "query: {{content}}"
+		}},
+		{"compatibility", func(profile *embeddingbridge.Profile) { profile.Descriptor.CompatibilityID = "changed/v1" }},
+		{"binding", func(profile *embeddingbridge.Profile) { profile.SecretBinding = "credential:other" }},
+		{"origin", func(profile *embeddingbridge.Profile) { profile.Origin += "/other" }},
+		{"egress", func(profile *embeddingbridge.Profile) {
+			profile.EgressPolicy.AllowedCIDRs = []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+		}},
+		{"bounds", func(profile *embeddingbridge.Profile) { profile.MaxBatchItems-- }},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			profile := fixture.profile
+			profile.EgressPolicy.AllowedCIDRs = slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+			mutation.mutate(&profile)
+			_, err := embeddingbridge.New(profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, fixture.resolver, &http.Client{})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSecretResolutionRedirectCancellationAndAmbiguousSubmission(t *testing.T) {
+	t.Run("secret resolution", func(t *testing.T) {
+		var requests int
+		fixture := newBridgeFixture(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+		client, err := embeddingbridge.New(fixture.profile, secretMap{}, fixture.resolver, &http.Client{})
+		require.NoError(t, err)
+		_, err = client.Embed(context.Background(), oneTextInput("private input"), fixture.authorization(1))
+		require.Error(t, err)
+		assert.Equal(t, embeddingbridge.ErrorAuthentication, embeddingbridge.Category(err))
+		assert.Zero(t, requests)
+		assert.NotContains(t, err.Error(), "synthetic resolver detail")
+		assert.NotContains(t, err.Error(), "private input")
+	})
+	t.Run("redirect", func(t *testing.T) {
+		var redirected int
+		mux := http.NewServeMux()
+		mux.HandleFunc("/docbank-embedding/v1/embeddings", func(writer http.ResponseWriter, request *http.Request) {
+			http.Redirect(writer, request, "/redirected", http.StatusTemporaryRedirect)
+		})
+		mux.HandleFunc("/redirected", func(http.ResponseWriter, *http.Request) { redirected++ })
+		fixture := newBridgeFixture(t, mux)
+		_, err := fixture.client.Embed(context.Background(), oneTextInput("alpha"), fixture.authorization(1))
+		require.Error(t, err)
+		assert.Zero(t, redirected)
+		assert.Equal(t, embeddingbridge.ErrorPermanent, embeddingbridge.Category(err))
+	})
+	t.Run("cancellation", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		fixture := newBridgeFixture(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			close(started)
+			<-release
+		}))
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			_, err := fixture.client.Embed(ctx, oneTextInput("alpha"), fixture.authorization(1))
+			done <- err
+		}()
+		<-started
+		cancel()
+		err := <-done
+		close(release)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+	t.Run("ambiguous submission", func(t *testing.T) {
+		fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = readBridgeRequest(t, request)
+			hijacker, ok := writer.(http.Hijacker)
+			if !assert.True(t, ok) {
+				return
+			}
+			connection, _, err := hijacker.Hijack()
+			if !assert.NoError(t, err) {
+				return
+			}
+			_ = connection.Close()
+		}))
+		_, err := fixture.client.Embed(context.Background(), oneTextInput("alpha"), fixture.authorization(1))
+		require.Error(t, err)
+		assert.Equal(t, embeddingbridge.ErrorAmbiguousSubmission, embeddingbridge.Category(err))
+		assert.True(t, embeddingbridge.IsRetryable(err))
+	})
+}
+
+func TestDirectFileTerminalLengthAndChecksumAreProven(t *testing.T) {
+	expected := []byte("12345")
+	tests := []struct {
+		name     string
+		actual   []byte
+		metadata document.AuthorizedUploadMetadata
+	}{
+		{name: "short", actual: []byte("1234"), metadata: uploadMetadata(expected)},
+		{name: "long", actual: []byte("123456"), metadata: uploadMetadata(expected)},
+		{name: "substituted", actual: []byte("abcde"), metadata: uploadMetadata(expected)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				_, _ = io.Copy(io.Discard, request.Body)
+				writer.Header().Set("Content-Type", responseMediaType())
+				_, _ = io.WriteString(writer, `{}`)
+			}))
+			upload := &testUpload{Reader: bytes.NewReader(test.actual), metadata: test.metadata}
+			_, err := fixture.client.Embed(context.Background(), []document.EmbeddingInput{{
+				Key: "source", Role: document.EmbeddingRoleDocument,
+				Kind: document.EmbeddingInputOriginalFile, Source: upload,
+			}}, fixture.authorization(1))
+			require.Error(t, err)
+			assert.Equal(t, embeddingbridge.ErrorSourceChanged, embeddingbridge.Category(err))
+			assert.NotContains(t, err.Error(), string(test.actual))
+		})
+	}
+}
+
+func TestUploadMetadataIsFrozenOnceBeforeValidationAndTransmission(t *testing.T) {
+	source := []byte("immutable synthetic source")
+	upload := &countingUpload{Reader: bytes.NewReader(source), metadata: uploadMetadata(source)}
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		manifest, files := readBridgeRequest(t, request)
+		assert.Equal(t, [][]byte{source}, files)
+		zero := 0
+		writeSuccess(t, writer, manifest, []document.EmbeddingVector{{Key: "source", Index: &zero, Values: []float32{1, 2}}})
+	}))
+	_, err := fixture.client.Embed(context.Background(), []document.EmbeddingInput{{
+		Key: "source", Role: document.EmbeddingRoleDocument,
+		Kind: document.EmbeddingInputOriginalFile, Source: upload,
+	}}, fixture.authorization(1))
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), upload.calls.Load())
+}
+
+func TestDirectFileRejectsHeaderUnsafeFilenameBeforeRequest(t *testing.T) {
+	var requests atomic.Int32
+	source := []byte("synthetic source")
+	metadata := uploadMetadata(source)
+	metadata.Filename = "synthetic.bin\r\nX-Injected: private"
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	_, err := fixture.client.Embed(context.Background(), []document.EmbeddingInput{{
+		Key: "source", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile,
+		Source: &testUpload{Reader: bytes.NewReader(source), metadata: metadata},
+	}}, fixture.authorization(1))
+	require.Error(t, err)
+	assert.Equal(t, embeddingbridge.ErrorPermanent, embeddingbridge.Category(err))
+	assert.Zero(t, requests.Load())
+	assert.NotContains(t, err.Error(), "X-Injected")
+}
+
+func TestCancellationClosesBlockedDirectFileAndReturns(t *testing.T) {
+	source := []byte("synthetic blocked source")
+	upload := newBlockingUpload(uploadMetadata(source))
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		_, _ = io.Copy(io.Discard, request.Body)
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := fixture.client.Embed(ctx, []document.EmbeddingInput{{
+			Key: "source", Role: document.EmbeddingRoleDocument,
+			Kind: document.EmbeddingInputOriginalFile, Source: upload,
+		}}, fixture.authorization(1))
+		done <- err
+	}()
+	<-upload.started
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(250 * time.Millisecond):
+		_ = upload.Close()
+		err := <-done
+		assert.Fail(t, "embedding bridge did not close the blocked authorized upload", "eventual error: %v", err)
+	}
+	assert.Positive(t, upload.closes.Load())
+}
+
+func TestCancellationBeforeSecretResolutionLeavesUnreadSourceOpen(t *testing.T) {
+	source := []byte("synthetic unread source")
+	upload := newObservedUpload(source, uploadMetadata(source))
+	resolver := &cancelBlockingSecretResolver{started: make(chan struct{})}
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("request reached server before secret resolution completed")
+	}))
+	client, err := embeddingbridge.New(fixture.profile, resolver, fixture.resolver, &http.Client{})
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, embedErr := client.Embed(ctx, []document.EmbeddingInput{{
+			Key: "unread", Role: document.EmbeddingRoleDocument,
+			Kind: document.EmbeddingInputOriginalFile, Source: upload,
+		}}, fixture.authorization(1))
+		done <- embedErr
+	}()
+	<-resolver.started
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	assert.Zero(t, upload.reads.Load())
+	assert.Zero(t, upload.closes.Load(), "the worker retains ownership until a source read begins")
+}
+
+func TestMultiFileCancellationClosesOnlyActiveSource(t *testing.T) {
+	firstBytes := []byte("synthetic first source")
+	secondBytes := []byte("synthetic blocked second source")
+	thirdBytes := []byte("synthetic unread third source")
+	first := newObservedUpload(firstBytes, uploadMetadata(firstBytes))
+	second := newBlockingUpload(uploadMetadata(secondBytes))
+	third := newObservedUpload(thirdBytes, uploadMetadata(thirdBytes))
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		_, _ = io.Copy(io.Discard, request.Body)
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, embedErr := fixture.client.Embed(ctx, []document.EmbeddingInput{
+			{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: first},
+			{Key: "second", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: second},
+			{Key: "third", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: third},
+		}, fixture.authorization(3))
+		done <- embedErr
+	}()
+	<-second.started
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(250 * time.Millisecond):
+		_ = second.Close()
+		err := <-done
+		assert.Fail(t, "embedding bridge did not close the active source", "eventual error: %v", err)
+	}
+	assert.Zero(t, first.closes.Load(), "a completed source is no longer owned by the bridge")
+	assert.Positive(t, second.closes.Load(), "the active blocked source must be closed")
+	assert.Zero(t, third.reads.Load(), "later sources must remain unread")
+	assert.Zero(t, third.closes.Load(), "later unread sources remain worker-owned")
+}
+
+func TestCancellationWithNonComparableActiveSourceDoesNotPanic(t *testing.T) {
+	source := []byte("synthetic non-comparable source")
+	state := newBlockingUpload(uploadMetadata(source))
+	upload := nonComparableUpload{state}
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		_, _ = io.Copy(io.Discard, request.Body)
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, embedErr := fixture.client.Embed(ctx, []document.EmbeddingInput{{
+			Key: "source", Role: document.EmbeddingRoleDocument,
+			Kind: document.EmbeddingInputOriginalFile, Source: upload,
+		}}, fixture.authorization(1))
+		done <- embedErr
+	}()
+	<-state.started
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(250 * time.Millisecond):
+		_ = state.Close()
+		err := <-done
+		assert.Fail(t, "embedding bridge did not close the active non-comparable source", "eventual error: %v", err)
+	}
+}
+
+func TestPolicyFingerprintDoesNotMutateCallerEgressOrder(t *testing.T) {
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	profile := fixture.profile
+	profile.EgressPolicy.AllowedCIDRs = []netip.Prefix{
+		netip.MustParsePrefix("127.0.0.2/32"),
+		netip.MustParsePrefix("127.0.0.0/24"),
+	}
+	original := slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	fingerprint, err := embeddingbridge.PolicyFingerprint(profile)
+	require.NoError(t, err)
+	assert.Equal(t, original, profile.EgressPolicy.AllowedCIDRs)
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+	require.NoError(t, err)
+	_, err = embeddingbridge.New(profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, fixture.resolver, &http.Client{})
+	require.NoError(t, err)
+	assert.Equal(t, original, profile.EgressPolicy.AllowedCIDRs)
+}
+
+func TestHTTPFailuresAreClassifiedWithoutProviderBodiesOrSecrets(t *testing.T) {
+	tests := []struct {
+		status   int
+		category embeddingbridge.ErrorCategory
+		retry    bool
+	}{
+		{http.StatusUnauthorized, embeddingbridge.ErrorAuthentication, false},
+		{http.StatusRequestEntityTooLarge, embeddingbridge.ErrorCapacity, false},
+		{http.StatusTooManyRequests, embeddingbridge.ErrorTransient, true},
+		{http.StatusServiceUnavailable, embeddingbridge.ErrorTransient, true},
+		{http.StatusBadRequest, embeddingbridge.ErrorPermanent, false},
+	}
+	for _, test := range tests {
+		t.Run(strconv.Itoa(test.status), func(t *testing.T) {
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				_, _ = readBridgeRequest(t, request)
+				writer.WriteHeader(test.status)
+				_, _ = io.WriteString(writer, "PRIVATE_RESPONSE synthetic-secret private-input")
+			}))
+			_, err := fixture.client.Embed(context.Background(), oneTextInput("private-input"), fixture.authorization(1))
+			require.Error(t, err)
+			assert.Equal(t, test.category, embeddingbridge.Category(err))
+			assert.Equal(t, test.retry, embeddingbridge.IsRetryable(err))
+			assert.NotContains(t, err.Error(), "PRIVATE_RESPONSE")
+			assert.NotContains(t, err.Error(), "synthetic-secret")
+			assert.NotContains(t, err.Error(), "private-input")
+		})
+	}
+}
+
+func TestEarlyHTTPRejectionDoesNotReadDirectFileAndKeepsStatusClassification(t *testing.T) {
+	source := []byte("synthetic early rejection")
+	upload := newBlockingUpload(uploadMetadata(source))
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "100-continue", request.Header.Get("Expect"))
+		writer.WriteHeader(http.StatusRequestEntityTooLarge)
+	}))
+	done := make(chan error, 1)
+	go func() {
+		_, err := fixture.client.Embed(context.Background(), []document.EmbeddingInput{{
+			Key: "source", Role: document.EmbeddingRoleDocument,
+			Kind: document.EmbeddingInputOriginalFile, Source: upload,
+		}}, fixture.authorization(1))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Equal(t, embeddingbridge.ErrorCapacity, embeddingbridge.Category(err))
+	case <-time.After(time.Second):
+		_ = upload.Close()
+		<-done
+		assert.Fail(t, "early rejection did not return within the request bound")
+	}
+	assert.Zero(t, upload.closes.Load(), "the worker retains ownership when no source read starts")
+	select {
+	case <-upload.started:
+		assert.Fail(t, "early rejection read the direct-file source")
+	default:
+	}
+}
+
+func TestDirectFileConnectionLossAfterPartHeaderIsAmbiguous(t *testing.T) {
+	source := []byte("synthetic ambiguous source")
+	upload := newGatedUpload(source, uploadMetadata(source))
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		defer upload.Release()
+		mediaType, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+		if !assert.NoError(t, err) || !assert.Equal(t, "multipart/form-data", mediaType) {
+			return
+		}
+		reader := multipart.NewReader(request.Body, parameters["boundary"])
+		manifestPart, err := reader.NextPart()
+		if !assert.NoError(t, err) {
+			return
+		}
+		_, err = io.Copy(io.Discard, manifestPart)
+		if !assert.NoError(t, err) {
+			return
+		}
+		filePart, err := reader.NextPart()
+		if !assert.NoError(t, err) || !assert.Equal(t, "file", filePart.FormName()) {
+			return
+		}
+		hijacker, ok := writer.(http.Hijacker)
+		if !assert.True(t, ok) {
+			return
+		}
+		connection, _, err := hijacker.Hijack()
+		if !assert.NoError(t, err) {
+			return
+		}
+		_ = connection.Close()
+	}))
+	_, err := fixture.client.Embed(context.Background(), []document.EmbeddingInput{{
+		Key: "source", Role: document.EmbeddingRoleDocument,
+		Kind: document.EmbeddingInputOriginalFile, Source: upload,
+	}}, fixture.authorization(1))
+	require.Error(t, err)
+	assert.Equal(t, embeddingbridge.ErrorAmbiguousSubmission, embeddingbridge.Category(err))
+	assert.True(t, embeddingbridge.IsRetryable(err))
+}
+
+func TestDirectFileConnectionLossDuringBlockedReadIsAmbiguous(t *testing.T) {
+	source := []byte("synthetic blocked connection-loss source")
+	upload := newBlockingUpload(uploadMetadata(source))
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		mediaType, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+		if !assert.NoError(t, err) || !assert.Equal(t, "multipart/form-data", mediaType) {
+			return
+		}
+		reader := multipart.NewReader(request.Body, parameters["boundary"])
+		manifestPart, err := reader.NextPart()
+		if !assert.NoError(t, err) {
+			return
+		}
+		_, err = io.Copy(io.Discard, manifestPart)
+		if !assert.NoError(t, err) {
+			return
+		}
+		filePart, err := reader.NextPart()
+		if !assert.NoError(t, err) || !assert.Equal(t, "file", filePart.FormName()) {
+			return
+		}
+		<-upload.started
+		writer.Header().Set("Content-Type", responseMediaType())
+		writer.Header().Set("Content-Length", "64")
+		writer.WriteHeader(http.StatusOK)
+		flusher, ok := writer.(http.Flusher)
+		if !assert.True(t, ok) {
+			return
+		}
+		flusher.Flush()
+		hijacker, ok := writer.(http.Hijacker)
+		if !assert.True(t, ok) {
+			return
+		}
+		connection, _, err := hijacker.Hijack()
+		if !assert.NoError(t, err) {
+			return
+		}
+		_ = connection.Close()
+	}))
+	_, err := fixture.client.Embed(context.Background(), []document.EmbeddingInput{{
+		Key: "source", Role: document.EmbeddingRoleDocument,
+		Kind: document.EmbeddingInputOriginalFile, Source: upload,
+	}}, fixture.authorization(1))
+	require.Error(t, err)
+	assert.Equal(t, embeddingbridge.ErrorAmbiguousSubmission, embeddingbridge.Category(err))
+	assert.True(t, embeddingbridge.IsRetryable(err))
+	assert.NotContains(t, err.Error(), "synthetic blocked reader closed")
+}
+
+func TestKnownHTTPStatusDuringBlockedUploadWinsWriterError(t *testing.T) {
+	source := []byte("synthetic blocked rejected source")
+	upload := newBlockingUpload(uploadMetadata(source))
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		mediaType, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+		if !assert.NoError(t, err) || !assert.Equal(t, "multipart/form-data", mediaType) {
+			return
+		}
+		reader := multipart.NewReader(request.Body, parameters["boundary"])
+		manifestPart, err := reader.NextPart()
+		if !assert.NoError(t, err) {
+			return
+		}
+		_, err = io.Copy(io.Discard, manifestPart)
+		if !assert.NoError(t, err) {
+			return
+		}
+		filePart, err := reader.NextPart()
+		if !assert.NoError(t, err) || !assert.Equal(t, "file", filePart.FormName()) {
+			return
+		}
+		<-upload.started
+		writer.WriteHeader(http.StatusRequestEntityTooLarge)
+	}))
+	_, err := fixture.client.Embed(context.Background(), []document.EmbeddingInput{{
+		Key: "source", Role: document.EmbeddingRoleDocument,
+		Kind: document.EmbeddingInputOriginalFile, Source: upload,
+	}}, fixture.authorization(1))
+	require.Error(t, err)
+	assert.Equal(t, embeddingbridge.ErrorCapacity, embeddingbridge.Category(err))
+	assert.False(t, embeddingbridge.IsRetryable(err))
+	assert.NotContains(t, err.Error(), "synthetic blocked reader closed")
+	assert.Positive(t, upload.closes.Load())
+}
+
+func TestConcurrentRequestsDoNotShareSecretsOrState(t *testing.T) {
+	var mu sync.Mutex
+	checksums := make(map[string]bool)
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		manifest, _ := readBridgeRequest(t, request)
+		mu.Lock()
+		checksums[manifest.RequestChecksum] = true
+		mu.Unlock()
+		zero := 0
+		writeSuccess(t, writer, manifest, []document.EmbeddingVector{{Key: manifest.Inputs[0].Key, Index: &zero, Values: []float32{1, 2}}})
+	}))
+	var wait sync.WaitGroup
+	errorsSeen := make(chan error, 2)
+	for _, value := range []string{"alpha", "beta"} {
+		wait.Go(func() {
+			_, err := fixture.client.Embed(context.Background(), oneTextInput(value), fixture.authorization(1))
+			errorsSeen <- err
+		})
+	}
+	wait.Wait()
+	close(errorsSeen)
+	for err := range errorsSeen {
+		require.NoError(t, err)
+	}
+	assert.Len(t, checksums, 2)
+}
+
+type testUpload struct {
+	io.Reader
+
+	metadata document.AuthorizedUploadMetadata
+}
+
+func (upload *testUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+func (upload *testUpload) Close() error { return nil }
+
+type countingUpload struct {
+	io.Reader
+
+	metadata document.AuthorizedUploadMetadata
+	calls    atomic.Int32
+}
+
+func (upload *countingUpload) Metadata() document.AuthorizedUploadMetadata {
+	upload.calls.Add(1)
+	return upload.metadata
+}
+
+func (upload *countingUpload) Close() error { return nil }
+
+type blockingUpload struct {
+	metadata document.AuthorizedUploadMetadata
+	started  chan struct{}
+	closed   chan struct{}
+	start    sync.Once
+	close    sync.Once
+	closes   atomic.Int32
+}
+
+type observedUpload struct {
+	reader   *bytes.Reader
+	metadata document.AuthorizedUploadMetadata
+	reads    atomic.Int32
+	closes   atomic.Int32
+}
+
+type cancelBlockingSecretResolver struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+type nonComparableUpload []*blockingUpload
+
+func (upload nonComparableUpload) Read(value []byte) (int, error) {
+	return upload[0].Read(value)
+}
+
+func (upload nonComparableUpload) Metadata() document.AuthorizedUploadMetadata {
+	return upload[0].Metadata()
+}
+
+func (upload nonComparableUpload) Close() error { return upload[0].Close() }
+
+type gatedUpload struct {
+	reader      *bytes.Reader
+	metadata    document.AuthorizedUploadMetadata
+	release     chan struct{}
+	releaseOnce sync.Once
+	waitOnce    sync.Once
+}
+
+func newGatedUpload(source []byte, metadata document.AuthorizedUploadMetadata) *gatedUpload {
+	return &gatedUpload{reader: bytes.NewReader(source), metadata: metadata, release: make(chan struct{})}
+}
+
+func (upload *gatedUpload) Read(value []byte) (int, error) {
+	upload.waitOnce.Do(func() { <-upload.release })
+	read, err := upload.reader.Read(value)
+	if errors.Is(err, io.EOF) {
+		return read, io.EOF
+	}
+	if err != nil {
+		return read, fmt.Errorf("gated upload read: %w", err)
+	}
+	return read, nil
+}
+
+func (upload *gatedUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+func (upload *gatedUpload) Release() { upload.releaseOnce.Do(func() { close(upload.release) }) }
+
+func (upload *gatedUpload) Close() error {
+	upload.Release()
+	return nil
+}
+
+func newBlockingUpload(metadata document.AuthorizedUploadMetadata) *blockingUpload {
+	return &blockingUpload{metadata: metadata, started: make(chan struct{}), closed: make(chan struct{})}
+}
+
+func newObservedUpload(source []byte, metadata document.AuthorizedUploadMetadata) *observedUpload {
+	return &observedUpload{reader: bytes.NewReader(source), metadata: metadata}
+}
+
+func (upload *observedUpload) Read(value []byte) (int, error) {
+	upload.reads.Add(1)
+	read, err := upload.reader.Read(value)
+	if errors.Is(err, io.EOF) {
+		return read, io.EOF
+	}
+	if err != nil {
+		return read, fmt.Errorf("observed upload read: %w", err)
+	}
+	return read, nil
+}
+
+func (upload *observedUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+func (upload *observedUpload) Close() error {
+	upload.closes.Add(1)
+	return nil
+}
+
+func (resolver *cancelBlockingSecretResolver) ResolveSecret(ctx context.Context, _ string) (string, error) {
+	resolver.once.Do(func() { close(resolver.started) })
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+func (upload *blockingUpload) Read([]byte) (int, error) {
+	upload.start.Do(func() { close(upload.started) })
+	<-upload.closed
+	return 0, errors.New("synthetic blocked reader closed")
+}
+
+func (upload *blockingUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+func (upload *blockingUpload) Close() error {
+	upload.closes.Add(1)
+	upload.close.Do(func() { close(upload.closed) })
+	return nil
+}
+
+func uploadMetadata(source []byte) document.AuthorizedUploadMetadata {
+	return document.AuthorizedUploadMetadata{
+		Filename: "synthetic.bin", MediaFamily: "binary", MediaType: "application/octet-stream",
+		ByteLength: int64(len(source)), SHA256: sha256Bytes(source),
+		CapabilityRecordChecksum: strings.Repeat("a", 64), ProviderMetadataChecksum: strings.Repeat("b", 64),
+		InputKind: document.RenditionInputOriginalFile,
+	}
+}
+
+func oneTextInput(text string) []document.EmbeddingInput {
+	return []document.EmbeddingInput{{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: text}}
+}
+
+func twoTextInputs() []document.EmbeddingInput {
+	return []document.EmbeddingInput{
+		{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "alpha"},
+		{Key: "second", Role: document.EmbeddingRoleQuery, Kind: document.EmbeddingInputQueryText, Text: "beta"},
+	}
+}
+
+func validResponseBody(manifest requestManifest) string {
+	return responseBody(manifest, `[{"key":"first","index":0,"values":[1,2]},{"key":"second","index":1,"values":[3,4]}]`)
+}
+
+func responseBody(manifest requestManifest, vectors string) string {
+	return fmt.Sprintf(`{"contract_version":%q,"descriptor_fingerprint":%q,"policy_fingerprint":%q,"request_checksum":%q,"vectors":%s}`,
+		embeddingbridge.ContractVersion, manifest.DescriptorFingerprint, manifest.PolicyFingerprint, manifest.RequestChecksum, vectors)
+}
+
+func responseMediaType() string { return "application/vnd.docbank.embedding-result+json;version=1" }
+
+func exactManifestChecksum(t *testing.T, manifest requestManifest) string {
+	t.Helper()
+	manifest.RequestChecksum = ""
+	encoded, err := json.Marshal(manifest, json.Deterministic(true))
+	require.NoError(t, err)
+	return sha256Bytes(encoded)
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value, json.Deterministic(true))
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func sha256Text(value string) string { return sha256Bytes([]byte(value)) }
+
+func sha256Bytes(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}

--- a/document/embeddingbridge/client_test.go
+++ b/document/embeddingbridge/client_test.go
@@ -418,6 +418,26 @@ func TestResponseByteLimitIsEnforcedBeforeDecode(t *testing.T) {
 	_, err := fixture.client.Embed(context.Background(), twoTextInputs(), fixture.authorization(2))
 	require.Error(t, err)
 	assert.Equal(t, embeddingbridge.ErrorMalformedResponse, embeddingbridge.Category(err))
+	assert.False(t, embeddingbridge.IsRetryable(err))
+}
+
+func TestTruncatedResponseIsRetryable(t *testing.T) {
+	fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		manifest, _ := readBridgeRequest(t, request)
+		body := validResponseBody(manifest)
+		writer.Header().Set("Content-Type", responseMediaType())
+		// Even valid JSON is incomplete when the connection ends before the
+		// declared body length. The HTTP transport reports unexpected EOF.
+		writer.Header().Set("Content-Length", strconv.Itoa(len(body)+1))
+		_, err := io.WriteString(writer, body)
+		assert.NoError(t, err)
+	}))
+	result, err := fixture.client.Embed(t.Context(), twoTextInputs(), fixture.authorization(2))
+	require.Error(t, err)
+	assert.Empty(t, result.Vectors)
+	assert.Equal(t, embeddingbridge.ErrorAmbiguousSubmission, embeddingbridge.Category(err))
+	assert.True(t, embeddingbridge.IsRetryable(err))
+	assert.EqualError(t, err, "embedding bridge: ambiguous_submission (HTTP 200)")
 }
 
 func TestProfileFingerprintFreezesDescriptorModelOriginEgressBindingAndBounds(t *testing.T) {

--- a/document/embeddingbridge/client_test.go
+++ b/document/embeddingbridge/client_test.go
@@ -318,7 +318,10 @@ func TestMixedTextAndDirectFileRequestStreamsOnlyAuthorizedBytes(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Vectors, 2)
 	require.Len(t, manifest.Inputs, 2)
-	assert.Equal(t, &metadata, manifest.Inputs[0].Upload)
+	expectedMetadata := metadata
+	expectedMetadata.Filename = ""
+	assert.Equal(t, &expectedMetadata, manifest.Inputs[0].Upload)
+	assert.Equal(t, metadata, upload.metadata)
 	assert.Equal(t, "file", manifest.Inputs[0].FilePart)
 	require.NotNil(t, manifest.Inputs[0].FileIndex)
 	assert.Zero(t, *manifest.Inputs[0].FileIndex)
@@ -1102,4 +1105,48 @@ func sha256Text(value string) string { return sha256Bytes([]byte(value)) }
 func sha256Bytes(value []byte) string {
 	digest := sha256.Sum256(value)
 	return hex.EncodeToString(digest[:])
+}
+
+func TestResponseHonorsDescriptorNormalization(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		normalization string
+		values        []float32
+		wantError     bool
+	}{
+		{"zero unit", document.VectorNormalizationUnitLength, []float32{0, 0}, true},
+		{"non-unit", document.VectorNormalizationUnitLength, []float32{1, 1}, true},
+		{"unit", document.VectorNormalizationUnitLength, []float32{0.6, 0.8}, false},
+		{"rounding", document.VectorNormalizationUnitLength, []float32{1.00001, 0}, false},
+		{"unnormalized", document.VectorNormalizationNone, []float32{1, 2}, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				manifest, _ := readBridgeRequest(t, request)
+				writeSuccess(t, writer, manifest, []document.EmbeddingVector{{Key: "first", Index: new(0), Values: test.values}})
+			}))
+			profile := fixture.profile
+			profile.Descriptor.Normalization = test.normalization
+			fingerprint, err := embeddingbridge.PolicyFingerprint(profile)
+			require.NoError(t, err)
+			profile.Descriptor.PolicyFingerprint = fingerprint
+			profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+			require.NoError(t, err)
+			client, err := embeddingbridge.New(profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, fixture.resolver, &http.Client{})
+			require.NoError(t, err)
+			authorization := fixture.authorization(1)
+			authorization.DescriptorFingerprint = profile.Descriptor.Fingerprint
+			authorization.PolicyFingerprint = profile.Descriptor.PolicyFingerprint
+			result, err := client.Embed(t.Context(), oneTextInput("alpha"), authorization)
+			if test.wantError {
+				require.Error(t, err)
+				assert.Equal(t, embeddingbridge.ErrorMalformedResponse, embeddingbridge.Category(err))
+				assert.Empty(t, result.Vectors)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, result.Vectors, 1)
+				assert.Equal(t, test.values, result.Vectors[0].Values)
+			}
+		})
+	}
 }

--- a/document/embeddingbridge/client_test.go
+++ b/document/embeddingbridge/client_test.go
@@ -1150,3 +1150,80 @@ func TestResponseHonorsDescriptorNormalization(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestTimeoutClassification(t *testing.T) {
+	for _, stage := range []string{"secret", "headers", "body"} {
+		for _, callerDeadline := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/caller=%t", stage, callerDeadline), func(t *testing.T) {
+				fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					_, _ = io.Copy(io.Discard, request.Body)
+					if stage == "body" {
+						writer.Header().Set("Content-Type", responseMediaType())
+						writer.WriteHeader(http.StatusOK)
+						assert.NoError(t, http.NewResponseController(writer).Flush())
+					}
+					<-request.Context().Done()
+				}))
+				profile := fixture.profile
+				profile.RequestTimeout = 100 * time.Millisecond
+				fingerprint, err := embeddingbridge.PolicyFingerprint(profile)
+				require.NoError(t, err)
+				profile.Descriptor.PolicyFingerprint = fingerprint
+				profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+				require.NoError(t, err)
+				var secrets embeddingbridge.SecretResolver = secretMap{"credential:synthetic-bridge": "synthetic-secret"}
+				if stage == "secret" {
+					secrets = &cancelBlockingSecretResolver{started: make(chan struct{})}
+				}
+				client, err := embeddingbridge.New(profile, secrets, fixture.resolver, &http.Client{})
+				require.NoError(t, err)
+				authorization := fixture.authorization(1)
+				authorization.DescriptorFingerprint = profile.Descriptor.Fingerprint
+				authorization.PolicyFingerprint = profile.Descriptor.PolicyFingerprint
+				ctx := t.Context()
+				if callerDeadline {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, 20*time.Millisecond)
+					defer cancel()
+				}
+				_, err = client.Embed(ctx, oneTextInput("alpha"), authorization)
+				require.Error(t, err)
+				if callerDeadline {
+					require.ErrorIs(t, err, context.DeadlineExceeded)
+				} else {
+					require.NoError(t, ctx.Err())
+					assert.Equal(t, embeddingbridge.ErrorTransient, embeddingbridge.Category(err))
+					assert.True(t, embeddingbridge.IsRetryable(err))
+				}
+			})
+		}
+	}
+}
+
+func TestConnectionFailuresDistinguishPolicyFromUnavailability(t *testing.T) {
+	for _, denied := range []bool{false, true} {
+		t.Run(fmt.Sprintf("denied=%t", denied), func(t *testing.T) {
+			var requests atomic.Int32
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				requests.Add(1)
+			}))
+			resolver := fixture.resolver
+			category := embeddingbridge.ErrorTransient
+			if denied {
+				resolver.address = netip.MustParseAddr("192.0.2.1")
+				category = embeddingbridge.ErrorPermanent
+			} else {
+				require.NoError(t, fixture.server.Close())
+			}
+			client, err := embeddingbridge.New(fixture.profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, resolver, &http.Client{})
+			require.NoError(t, err)
+			_, err = client.Embed(t.Context(), oneTextInput("alpha"), fixture.authorization(1))
+			require.Error(t, err)
+			assert.Equal(t, category, embeddingbridge.Category(err))
+			assert.Equal(t, !denied, embeddingbridge.IsRetryable(err))
+			assert.Zero(t, requests.Load())
+			assert.NotContains(t, err.Error(), "192.0.2.1")
+			assert.NotContains(t, err.Error(), fixture.origin)
+		})
+	}
+}

--- a/document/embeddingbridge/client_test.go
+++ b/document/embeddingbridge/client_test.go
@@ -1107,18 +1107,22 @@ func sha256Bytes(value []byte) string {
 	return hex.EncodeToString(digest[:])
 }
 
-func TestResponseHonorsDescriptorNormalization(t *testing.T) {
+func TestResponseHonorsDescriptorMetricAndNormalization(t *testing.T) {
 	for _, test := range []struct {
 		name          string
+		metric        string
 		normalization string
 		values        []float32
 		wantError     bool
 	}{
-		{"zero unit", document.VectorNormalizationUnitLength, []float32{0, 0}, true},
-		{"non-unit", document.VectorNormalizationUnitLength, []float32{1, 1}, true},
-		{"unit", document.VectorNormalizationUnitLength, []float32{0.6, 0.8}, false},
-		{"rounding", document.VectorNormalizationUnitLength, []float32{1.00001, 0}, false},
-		{"unnormalized", document.VectorNormalizationNone, []float32{1, 2}, false},
+		{"zero unit", document.VectorMetricCosine, document.VectorNormalizationUnitLength, []float32{0, 0}, true},
+		{"non-unit", document.VectorMetricCosine, document.VectorNormalizationUnitLength, []float32{1, 1}, true},
+		{"unit", document.VectorMetricCosine, document.VectorNormalizationUnitLength, []float32{0.6, 0.8}, false},
+		{"rounding", document.VectorMetricCosine, document.VectorNormalizationUnitLength, []float32{1.00001, 0}, false},
+		{"unnormalized", document.VectorMetricCosine, document.VectorNormalizationNone, []float32{1, 2}, false},
+		{"zero cosine", document.VectorMetricCosine, document.VectorNormalizationNone, []float32{0, 0}, true},
+		{"zero L2", document.VectorMetricL2, document.VectorNormalizationNone, []float32{0, 0}, false},
+		{"zero dot product", document.VectorMetricDotProduct, document.VectorNormalizationNone, []float32{0, 0}, false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -1126,6 +1130,7 @@ func TestResponseHonorsDescriptorNormalization(t *testing.T) {
 				writeSuccess(t, writer, manifest, []document.EmbeddingVector{{Key: "first", Index: new(0), Values: test.values}})
 			}))
 			profile := fixture.profile
+			profile.Descriptor.Metric = test.metric
 			profile.Descriptor.Normalization = test.normalization
 			fingerprint, err := embeddingbridge.PolicyFingerprint(profile)
 			require.NoError(t, err)

--- a/document/embeddingbridge/client_test.go
+++ b/document/embeddingbridge/client_test.go
@@ -51,6 +51,7 @@ type bridgeFixture struct {
 	t          *testing.T
 	server     *http.Server
 	listener   net.Listener
+	serveDone  <-chan struct{}
 	origin     string
 	resolver   fixedResolver
 	profile    embeddingbridge.Profile
@@ -63,7 +64,11 @@ func newBridgeFixture(t *testing.T, handler http.Handler) bridgeFixture {
 	listener, err := net.Listen("tcp4", "127.0.0.1:0")
 	require.NoError(t, err)
 	server := &http.Server{Handler: handler, ReadHeaderTimeout: time.Second}
-	go func() { _ = server.Serve(listener) }()
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		_ = server.Serve(listener)
+	}()
 	t.Cleanup(func() {
 		require.NoError(t, server.Shutdown(context.Background()))
 	})
@@ -105,7 +110,7 @@ func newBridgeFixture(t *testing.T, handler http.Handler) bridgeFixture {
 	httpClient := &http.Client{}
 	client, err := embeddingbridge.New(profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, fixedResolver{netip.MustParseAddr("127.0.0.1")}, httpClient)
 	require.NoError(t, err)
-	return bridgeFixture{t: t, server: server, listener: listener, origin: origin, resolver: fixedResolver{netip.MustParseAddr("127.0.0.1")}, profile: profile, descriptor: descriptor, client: client}
+	return bridgeFixture{t: t, server: server, listener: listener, serveDone: serveDone, origin: origin, resolver: fixedResolver{netip.MustParseAddr("127.0.0.1")}, profile: profile, descriptor: descriptor, client: client}
 }
 
 func (fixture bridgeFixture) authorization(items int) document.EmbeddingAuthorization {
@@ -1417,7 +1422,10 @@ func TestConnectionFailuresDistinguishPolicyFromUnavailability(t *testing.T) {
 				resolver.address = netip.MustParseAddr("192.0.2.1")
 				category = embeddingbridge.ErrorPermanent
 			} else {
-				require.NoError(t, fixture.server.Close())
+				// Serve may not have registered the listener yet. Close the socket
+				// directly so the request must fail to connect.
+				require.NoError(t, fixture.listener.Close())
+				<-fixture.serveDone
 			}
 			client, err := embeddingbridge.New(fixture.profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, resolver, &http.Client{})
 			require.NoError(t, err)

--- a/document/embeddingbridge/client_test.go
+++ b/document/embeddingbridge/client_test.go
@@ -365,6 +365,21 @@ func TestResponseContractFailsClosed(t *testing.T) {
 		{name: "non finite", contentType: responseMediaType(), body: func(manifest requestManifest) string {
 			return responseBody(manifest, `[{"key":"first","index":0,"values":[1e1000,2]},{"key":"second","index":1,"values":[3,4]}]`)
 		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "null coordinate", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,null]},{"key":"second","index":1,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "string coordinate", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,"0"]},{"key":"second","index":1,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "boolean coordinate", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,false]},{"key":"second","index":1,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "array coordinate", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,[]]},{"key":"second","index":1,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
+		{name: "object coordinate", contentType: responseMediaType(), body: func(manifest requestManifest) string {
+			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,{}]},{"key":"second","index":1,"values":[3,4]}]`)
+		}, category: embeddingbridge.ErrorMalformedResponse},
 		{name: "duplicate key", contentType: responseMediaType(), body: func(manifest requestManifest) string {
 			return responseBody(manifest, `[{"key":"first","index":0,"values":[1,2]},{"key":"first","index":1,"values":[3,4]}]`)
 		}, category: embeddingbridge.ErrorMalformedResponse},
@@ -888,6 +903,71 @@ func TestKnownHTTPStatusDuringBlockedUploadWinsWriterError(t *testing.T) {
 	assert.False(t, embeddingbridge.IsRetryable(err))
 	assert.NotContains(t, err.Error(), "synthetic blocked reader closed")
 	assert.Positive(t, upload.closes.Load())
+}
+
+func TestExecuteEmbeddingInterruptsBlockedUpload(t *testing.T) {
+	for _, earlyResponse := range []bool{false, true} {
+		t.Run(fmt.Sprintf("early_response=%t", earlyResponse), func(t *testing.T) {
+			upload := newBlockingUpload(uploadMetadata([]byte("synthetic blocked sealed source")))
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				reader, err := request.MultipartReader()
+				if !assert.NoError(t, err) {
+					return
+				}
+				manifestPart, err := reader.NextPart()
+				if !assert.NoError(t, err) {
+					return
+				}
+				_, err = io.Copy(io.Discard, manifestPart)
+				if !assert.NoError(t, err) {
+					return
+				}
+				filePart, err := reader.NextPart()
+				if !assert.NoError(t, err) || !assert.Equal(t, "file", filePart.FormName()) {
+					return
+				}
+				<-upload.started
+				if earlyResponse {
+					controller := http.NewResponseController(writer)
+					if !assert.NoError(t, controller.EnableFullDuplex()) {
+						return
+					}
+					writer.WriteHeader(http.StatusRequestEntityTooLarge)
+					assert.NoError(t, controller.Flush())
+				}
+				_, _ = io.Copy(io.Discard, filePart)
+			}))
+			// Release the blocked reader even when testing a broken cancellation path.
+			t.Cleanup(func() { _ = upload.Close() })
+			done := make(chan error, 1)
+			go func() {
+				_, err := document.ExecuteEmbedding(t.Context(), fixture.client, []document.EmbeddingInput{{
+					Key: "source", Role: document.EmbeddingRoleDocument,
+					Kind: document.EmbeddingInputOriginalFile, Source: upload,
+				}}, fixture.authorization(1))
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				require.Error(t, err)
+				require.NoError(t, t.Context().Err())
+				category := embeddingbridge.ErrorTransient
+				if earlyResponse {
+					category = embeddingbridge.ErrorCapacity
+				}
+				assert.Equal(t, category, embeddingbridge.Category(err))
+				assert.Positive(t, upload.closes.Load())
+			case <-time.After(3 * time.Second):
+				_ = upload.Close()
+				select {
+				case <-done:
+				case <-time.After(time.Second):
+					t.Error("embedding did not return after releasing the source")
+				}
+				t.Fatal("embedding cancellation blocked on a sealed upload read")
+			}
+		})
+	}
 }
 
 func TestConcurrentRequestsDoNotShareSecretsOrState(t *testing.T) {

--- a/document/embeddingbridge/client_test.go
+++ b/document/embeddingbridge/client_test.go
@@ -440,6 +440,105 @@ func TestTruncatedResponseIsRetryable(t *testing.T) {
 	assert.EqualError(t, err, "embedding bridge: ambiguous_submission (HTTP 200)")
 }
 
+func TestResponseBudgetsAreIndependent(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		semantic  int64
+		wire      int64
+		malformed bool
+	}{
+		{name: "exact vector footprint", semantic: 27, wire: 1024},
+		{name: "authorization exceeds wire cap", semantic: 4096, wire: 1024},
+		{name: "wire cap includes envelope", semantic: 27, wire: 27, malformed: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				manifest, _ := readBridgeRequest(t, request)
+				writer.Header().Set("Content-Type", responseMediaType())
+				_, _ = io.WriteString(writer, validResponseBody(manifest))
+			}))
+			profile := fixture.profile
+			profile.MaxResponseBytes = test.wire
+			fingerprint, err := embeddingbridge.PolicyFingerprint(profile)
+			require.NoError(t, err)
+			profile.Descriptor.PolicyFingerprint = fingerprint
+			profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+			require.NoError(t, err)
+			client, err := embeddingbridge.New(profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, fixture.resolver, &http.Client{})
+			require.NoError(t, err)
+			authorization := fixture.authorization(2)
+			authorization.DescriptorFingerprint = profile.Descriptor.Fingerprint
+			authorization.PolicyFingerprint = profile.Descriptor.PolicyFingerprint
+			authorization.MaxResponseBytes = test.semantic
+			result, err := client.Embed(t.Context(), twoTextInputs(), authorization)
+			if test.malformed {
+				require.Error(t, err)
+				assert.Equal(t, embeddingbridge.ErrorMalformedResponse, embeddingbridge.Category(err))
+			} else {
+				require.NoError(t, err)
+				assert.Len(t, result.Vectors, 2)
+			}
+		})
+	}
+}
+
+func TestEmptyUploadReadsDoNotBlockEmbed(t *testing.T) {
+	for _, probe := range []bool{false, true} {
+		t.Run(fmt.Sprintf("probe=%t", probe), func(t *testing.T) {
+			upload := &emptyReadUpload{reader: bytes.NewReader(nil), stop: make(chan struct{})}
+			if probe {
+				upload.reader = bytes.NewReader([]byte("a"))
+			}
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+				_, _ = io.Copy(io.Discard, request.Body)
+			}))
+			done := make(chan error, 1)
+			go func() {
+				_, err := fixture.client.Embed(t.Context(), []document.EmbeddingInput{{
+					Key: "source", Role: document.EmbeddingRoleDocument,
+					Kind: document.EmbeddingInputOriginalFile, Source: upload,
+				}}, fixture.authorization(1))
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				close(upload.stop)
+				require.Error(t, err)
+				assert.Equal(t, embeddingbridge.ErrorAmbiguousSubmission, embeddingbridge.Category(err))
+			case <-time.After(2 * time.Second):
+				close(upload.stop)
+				select {
+				case <-done:
+				case <-time.After(time.Second):
+					t.Error("embedding did not return after releasing the source")
+				}
+				t.Fatal("empty reads kept Embed blocked after its request deadline")
+			}
+		})
+	}
+}
+
+type emptyReadUpload struct {
+	reader *bytes.Reader
+	stop   chan struct{}
+}
+
+func (upload *emptyReadUpload) Read(value []byte) (int, error) {
+	select {
+	case <-upload.stop:
+		return 0, io.EOF
+	default:
+	}
+	n, _ := upload.reader.Read(value)
+	return n, nil
+}
+
+func (*emptyReadUpload) Metadata() document.AuthorizedUploadMetadata {
+	return uploadMetadata([]byte("a"))
+}
+
+func (*emptyReadUpload) Close() error { return nil }
+
 func TestProfileFingerprintFreezesDescriptorModelOriginEgressBindingAndBounds(t *testing.T) {
 	fixture := newBridgeFixture(t, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
 		_, _ = io.Copy(io.Discard, request.Body)

--- a/document/embeddingbridge/contract_test.go
+++ b/document/embeddingbridge/contract_test.go
@@ -1,0 +1,459 @@
+package embeddingbridge_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	stdjson "encoding/json"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/embeddingbridge"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed openapi.yaml
+var openAPIContract []byte
+
+//go:embed embedding-request-v1.schema.json
+var requestSchema []byte
+
+//go:embed embedding-response-v1.schema.json
+var responseSchema []byte
+
+func TestNormativeEmbeddingContractIsFixedStrictAndVersioned(t *testing.T) {
+	var openAPI map[string]any
+	require.NoError(t, yaml.Unmarshal(openAPIContract, &openAPI))
+	assert.Equal(t, "3.1.0", openAPI["openapi"])
+	paths, ok := openAPI["paths"].(map[string]any)
+	require.True(t, ok)
+	assert.Len(t, paths, 1)
+	assert.Contains(t, paths, "/docbank-embedding/v1/embeddings")
+	for _, forbidden := range []string{"{{", "result_url", "callback", "status_url", "cancel_url"} {
+		assert.NotContains(t, string(openAPIContract), forbidden)
+	}
+	for name, schema := range map[string][]byte{"request": requestSchema, "response": responseSchema} {
+		t.Run(name, func(t *testing.T) {
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(schema, &decoded))
+			assert.Equal(t, "https://json-schema.org/draft/2020-12/schema", decoded["$schema"])
+			assert.Equal(t, false, decoded["additionalProperties"])
+			assert.True(t, bytes.Contains(schema, []byte(`"docbank-embedding/v1"`)))
+		})
+	}
+	assert.Equal(t, "docbank-embedding/v1", embeddingbridge.ContractVersion)
+	for _, field := range []string{`"heading_path"`, `"source_spans"`, `"unit_index"`, `"char_start"`, `"char_end"`} {
+		assert.Contains(t, string(requestSchema), field)
+	}
+	var requestContract struct {
+		Canonicalization canonicalizationContract `json:"x-docbank-canonicalization"`
+	}
+	require.NoError(t, json.Unmarshal(requestSchema, &requestContract))
+	assert.Equal(t, "docbank-json-v1", requestContract.Canonicalization.Name)
+	assert.Equal(t, "UTF-8 without a byte-order mark", requestContract.Canonicalization.CharacterEncoding)
+	assert.NotEmpty(t, requestContract.Canonicalization.Whitespace)
+	assert.NotEmpty(t, requestContract.Canonicalization.Arrays)
+	assert.NotEmpty(t, requestContract.Canonicalization.Integers)
+	assert.NotEmpty(t, requestContract.Canonicalization.Strings)
+	assert.NotEmpty(t, requestContract.Canonicalization.OptionalMembers)
+	assert.NotEmpty(t, requestContract.Canonicalization.Checksum)
+	assert.Equal(t, []string{
+		"contract_version", "descriptor_fingerprint", "policy_fingerprint", "authorization", "inputs", "request_checksum",
+	}, requestContract.Canonicalization.ObjectMemberOrder["$"])
+	require.NotEmpty(t, requestContract.Canonicalization.ChecksumVectors)
+	for _, vector := range requestContract.Canonicalization.ChecksumVectors {
+		_, wire, identity, err := canonicalizeIndependentManifest([]byte(vector.CanonicalManifest), requestContract.Canonicalization)
+		require.NoError(t, err)
+		assert.Equal(t, vector.CanonicalManifest, string(wire))
+		assert.Equal(t, vector.CanonicalManifest, string(identity))
+		digest := sha256.Sum256([]byte(vector.CanonicalManifest))
+		assert.Equal(t, vector.SHA256, hex.EncodeToString(digest[:]))
+		assert.NotContains(t, vector.CanonicalManifest, `"request_checksum"`)
+	}
+}
+
+type canonicalizationContract struct {
+	Name              string              `json:"name"`
+	CharacterEncoding string              `json:"character_encoding"`
+	Whitespace        string              `json:"whitespace"`
+	ObjectMemberOrder map[string][]string `json:"object_member_order"`
+	Arrays            string              `json:"arrays"`
+	Integers          string              `json:"integers"`
+	Strings           string              `json:"strings"`
+	OptionalMembers   string              `json:"optional_members"`
+	Checksum          string              `json:"checksum"`
+	ChecksumVectors   []struct {
+		CanonicalManifest string `json:"canonical_manifest"`
+		SHA256            string `json:"sha256"`
+	} `json:"checksum_vectors"`
+}
+
+func TestIndependentSyntheticServerImplementsPublishedSchema(t *testing.T) {
+	for _, testCase := range []struct {
+		name         string
+		disclose     bool
+		wantFilename string
+	}{
+		{name: "withheld"},
+		{name: "disclosed", disclose: true, wantFilename: "contract.bin"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			requestValidator := compileContractSchema(t, "https://docbank.invalid/contracts/docbank-embedding/v1/request.schema.json", requestSchema)
+			responseValidator := compileContractSchema(t, "https://docbank.invalid/contracts/docbank-embedding/v1/response.schema.json", responseSchema)
+			var requestContract struct {
+				Canonicalization canonicalizationContract `json:"x-docbank-canonicalization"`
+			}
+			require.NoError(t, json.Unmarshal(requestSchema, &requestContract))
+			serverErrors := make(chan error, 1)
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if err := serveIndependentContractRequest(writer, request, requestValidator, responseValidator, requestContract.Canonicalization, testCase.wantFilename); err != nil {
+					select {
+					case serverErrors <- err:
+					default:
+					}
+					http.Error(writer, "synthetic contract failure", http.StatusInternalServerError)
+				}
+			}))
+			source := []byte("synthetic independent file")
+			sourceDigest := sha256.Sum256(source)
+			upload := &contractUpload{
+				reader: bytes.NewReader(source),
+				metadata: document.AuthorizedUploadMetadata{
+					Filename: "contract.bin", MediaFamily: "binary", MediaType: "application/octet-stream",
+					ByteLength: int64(len(source)), SHA256: hex.EncodeToString(sourceDigest[:]),
+					CapabilityRecordChecksum: strings.Repeat("a", 64), ProviderMetadataChecksum: strings.Repeat("b", 64),
+					InputKind: document.RenditionInputOriginalFile,
+				},
+			}
+			authorization := fixture.authorization(2)
+			authorization.DiscloseFilename = testCase.disclose
+			result, err := document.ExecuteEmbedding(context.Background(), fixture.client, []document.EmbeddingInput{
+				{
+					Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk,
+					Text: "synthetic contract fixture", HeadingPath: []string{"Synthetic"},
+					SourceSpans: []document.ChunkSpan{{UnitIndex: 0, CharStart: 0, CharEnd: 9}},
+				},
+				{Key: "second", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputOriginalFile, Source: upload},
+			}, authorization)
+			select {
+			case serverErr := <-serverErrors:
+				require.NoError(t, serverErr)
+			default:
+			}
+			require.NoError(t, err)
+			assert.Equal(t, document.EmbeddingResult{Vectors: []document.EmbeddingVector{
+				{Key: "first", Values: []float32{0.5, 0.25}},
+				{Key: "second", Values: []float32{1.5, 1.25}},
+			}}, result)
+		})
+	}
+}
+
+type contractUpload struct {
+	reader   *bytes.Reader
+	metadata document.AuthorizedUploadMetadata
+}
+
+func (upload *contractUpload) Read(value []byte) (int, error) {
+	read, err := upload.reader.Read(value)
+	if errors.Is(err, io.EOF) {
+		return read, io.EOF
+	}
+	if err != nil {
+		return read, fmt.Errorf("contract upload read: %w", err)
+	}
+	return read, nil
+}
+
+func (upload *contractUpload) Metadata() document.AuthorizedUploadMetadata { return upload.metadata }
+
+func (*contractUpload) Close() error { return nil }
+
+type independentFilePart struct {
+	filename  string
+	mediaType string
+	payload   []byte
+}
+
+func compileContractSchema(t *testing.T, location string, document []byte) *jsonschema.Schema {
+	t.Helper()
+	compiler := jsonschema.NewCompiler()
+	compiler.Draft = jsonschema.Draft2020
+	require.NoError(t, compiler.AddResource(location, bytes.NewReader(document)))
+	compiled, err := compiler.Compile(location)
+	require.NoError(t, err)
+	return compiled
+}
+
+func serveIndependentContractRequest(
+	writer http.ResponseWriter,
+	request *http.Request,
+	requestValidator *jsonschema.Schema,
+	responseValidator *jsonschema.Schema,
+	canonicalization canonicalizationContract,
+	wantFilename string,
+) error {
+	mediaType, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil || mediaType != "multipart/form-data" || parameters["boundary"] == "" {
+		return errors.New("independent server: multipart content type")
+	}
+	reader := multipart.NewReader(request.Body, parameters["boundary"])
+	var manifestBytes []byte
+	var files []independentFilePart
+	for {
+		part, nextErr := reader.NextPart()
+		if errors.Is(nextErr, io.EOF) {
+			break
+		}
+		if nextErr != nil {
+			return fmt.Errorf("independent server: next part: %w", nextErr)
+		}
+		payload, readErr := io.ReadAll(part)
+		if readErr != nil {
+			return fmt.Errorf("independent server: read part: %w", readErr)
+		}
+		switch part.FormName() {
+		case "manifest":
+			if part.Header.Get("Content-Type") != "application/vnd.docbank.embedding-manifest+json;version=1" || manifestBytes != nil {
+				return errors.New("independent server: manifest part contract")
+			}
+			manifestBytes = payload
+		case "file":
+			files = append(files, independentFilePart{filename: part.FileName(), mediaType: part.Header.Get("Content-Type"), payload: payload})
+		default:
+			return errors.New("independent server: unknown multipart part")
+		}
+	}
+	if manifestBytes == nil {
+		return errors.New("independent server: unexpected multipart shape")
+	}
+	var schemaValue any
+	if err := stdjson.Unmarshal(manifestBytes, &schemaValue); err != nil {
+		return fmt.Errorf("independent server: decode request schema value: %w", err)
+	}
+	if err := requestValidator.Validate(schemaValue); err != nil {
+		return fmt.Errorf("independent server: request schema: %w", err)
+	}
+	manifest, wireCanonical, identityCanonical, err := canonicalizeIndependentManifest(manifestBytes, canonicalization)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(manifestBytes, wireCanonical) {
+		return errors.New("independent server: request is not canonical docbank-json-v1")
+	}
+	checksum, ok := manifest["request_checksum"].(string)
+	if !ok {
+		return errors.New("independent server: request checksum type")
+	}
+	digest := sha256.Sum256(identityCanonical)
+	if checksum != hex.EncodeToString(digest[:]) || request.Header.Get("Idempotency-Key") != checksum || request.Header.Get("Docbank-Request-Checksum") != checksum {
+		return errors.New("independent server: request checksum mismatch")
+	}
+	descriptorFingerprint, descriptorOK := manifest["descriptor_fingerprint"].(string)
+	policyFingerprint, policyOK := manifest["policy_fingerprint"].(string)
+	inputs, inputsOK := manifest["inputs"].([]any)
+	if !descriptorOK || !policyOK || !inputsOK || len(inputs) == 0 {
+		return errors.New("independent server: manifest identity")
+	}
+	keys := make([]string, len(inputs))
+	usedFiles := make([]bool, len(files))
+	for index, rawInput := range inputs {
+		input, inputOK := rawInput.(map[string]any)
+		key, keyOK := input["key"].(string)
+		kind, kindOK := input["kind"].(string)
+		if !inputOK || !keyOK || !kindOK {
+			return errors.New("independent server: input identity")
+		}
+		keys[index] = key
+		if kind != "original_file" {
+			continue
+		}
+		fileIndex, indexErr := independentInteger(input["file_index"])
+		upload, uploadOK := input["upload"].(map[string]any)
+		if indexErr != nil || !uploadOK || fileIndex < 0 || fileIndex >= int64(len(files)) || usedFiles[fileIndex] {
+			return errors.New("independent server: file index")
+		}
+		usedFiles[fileIndex] = true
+		length, lengthErr := independentInteger(upload["byte_length"])
+		checksum, checksumOK := upload["sha256"].(string)
+		filename, filenameOK := upload["filename"].(string)
+		fileMediaType, mediaTypeOK := upload["media_type"].(string)
+		file := files[fileIndex]
+		fileDigest := sha256.Sum256(file.payload)
+		if lengthErr != nil || !checksumOK || !filenameOK || !mediaTypeOK || length != int64(len(file.payload)) ||
+			checksum != hex.EncodeToString(fileDigest[:]) || filename != file.filename || filename != wantFilename || fileMediaType != file.mediaType {
+			return errors.New("independent server: file binding")
+		}
+	}
+	for _, used := range usedFiles {
+		if !used {
+			return errors.New("independent server: unbound file")
+		}
+	}
+	vectors := make([]any, len(keys))
+	for index, key := range keys {
+		vectors[index] = map[string]any{
+			"key": key, "index": float64(index), "values": []any{float64(index) + 0.5, float64(index) + 0.25},
+		}
+	}
+	response := map[string]any{
+		"contract_version":       "docbank-embedding/v1",
+		"descriptor_fingerprint": descriptorFingerprint,
+		"policy_fingerprint":     policyFingerprint,
+		"request_checksum":       checksum,
+		"vectors":                vectors,
+	}
+	responseBytes, err := stdjson.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("independent server: encode response: %w", err)
+	}
+	var responseWire any
+	if err := stdjson.Unmarshal(responseBytes, &responseWire); err != nil {
+		return fmt.Errorf("independent server: decode response wire: %w", err)
+	}
+	if err := responseValidator.Validate(responseWire); err != nil {
+		return fmt.Errorf("independent server: response schema: %w", err)
+	}
+	writer.Header().Set("Content-Type", "application/vnd.docbank.embedding-result+json;version=1")
+	if _, err := writer.Write(responseBytes); err != nil {
+		return fmt.Errorf("independent server: write response: %w", err)
+	}
+	return nil
+}
+
+func canonicalizeIndependentManifest(payload []byte, contract canonicalizationContract) (map[string]any, []byte, []byte, error) {
+	decoder := stdjson.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, nil, nil, fmt.Errorf("independent server: decode canonical manifest: %w", err)
+	}
+	if err := requireIndependentJSONEOF(decoder); err != nil {
+		return nil, nil, nil, err
+	}
+	manifest, ok := decoded.(map[string]any)
+	if !ok {
+		return nil, nil, nil, errors.New("independent server: manifest root")
+	}
+	wire, err := appendIndependentCanonical(nil, manifest, "$", contract.ObjectMemberOrder)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	identityManifest := maps.Clone(manifest)
+	delete(identityManifest, "request_checksum")
+	identity, err := appendIndependentCanonical(nil, identityManifest, "$", contract.ObjectMemberOrder)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return manifest, wire, identity, nil
+}
+
+func requireIndependentJSONEOF(decoder *stdjson.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return errors.New("independent server: trailing manifest JSON")
+	}
+	return nil
+}
+
+func appendIndependentCanonical(destination []byte, value any, path string, orders map[string][]string) ([]byte, error) {
+	switch value := value.(type) {
+	case map[string]any:
+		order, ok := orders[path]
+		if !ok {
+			return nil, fmt.Errorf("independent server: no member order for %s", path)
+		}
+		destination = append(destination, '{')
+		members := 0
+		for _, name := range order {
+			member, exists := value[name]
+			if !exists {
+				continue
+			}
+			if members > 0 {
+				destination = append(destination, ',')
+			}
+			var err error
+			destination, err = jsontext.AppendQuote(destination, name)
+			if err != nil {
+				return nil, fmt.Errorf("independent server: quote member: %w", err)
+			}
+			destination = append(destination, ':')
+			destination, err = appendIndependentCanonical(destination, member, path+"."+name, orders)
+			if err != nil {
+				return nil, err
+			}
+			members++
+		}
+		if members != len(value) {
+			return nil, fmt.Errorf("independent server: unordered member at %s", path)
+		}
+		return append(destination, '}'), nil
+	case []any:
+		destination = append(destination, '[')
+		for index, member := range value {
+			if index > 0 {
+				destination = append(destination, ',')
+			}
+			var err error
+			destination, err = appendIndependentCanonical(destination, member, path+"[]", orders)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return append(destination, ']'), nil
+	case string:
+		encoded, err := jsontext.AppendQuote(destination, value)
+		if err != nil {
+			return nil, fmt.Errorf("independent server: quote value: %w", err)
+		}
+		return encoded, nil
+	case bool:
+		return strconv.AppendBool(destination, value), nil
+	case stdjson.Number:
+		if !isCanonicalUnsignedInteger(value.String()) {
+			return nil, errors.New("independent server: non-canonical request integer")
+		}
+		return append(destination, value.String()...), nil
+	default:
+		return nil, fmt.Errorf("independent server: unsupported canonical value %T", value)
+	}
+}
+
+func isCanonicalUnsignedInteger(value string) bool {
+	if value == "0" {
+		return true
+	}
+	if value == "" || value[0] < '1' || value[0] > '9' {
+		return false
+	}
+	return strings.IndexFunc(value[1:], func(character rune) bool { return character < '0' || character > '9' }) < 0
+}
+
+func independentInteger(value any) (int64, error) {
+	number, ok := value.(stdjson.Number)
+	if !ok || !isCanonicalUnsignedInteger(number.String()) {
+		return 0, errors.New("independent server: integer type")
+	}
+	parsed, err := strconv.ParseInt(number.String(), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("independent server: parse integer: %w", err)
+	}
+	return parsed, nil
+}

--- a/document/embeddingbridge/contract_test.go
+++ b/document/embeddingbridge/contract_test.go
@@ -109,9 +109,12 @@ func TestIndependentSyntheticServerImplementsPublishedSchema(t *testing.T) {
 		name         string
 		disclose     bool
 		wantFilename string
+		direct       bool
 	}{
 		{name: "withheld"},
 		{name: "disclosed", disclose: true, wantFilename: "contract.bin"},
+		{name: "direct-withheld", direct: true},
+		{name: "direct-disclosed", direct: true, disclose: true, wantFilename: "contract.bin"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			requestValidator := compileContractSchema(t, "https://docbank.invalid/contracts/docbank-embedding/v1/request.schema.json", requestSchema)
@@ -143,7 +146,13 @@ func TestIndependentSyntheticServerImplementsPublishedSchema(t *testing.T) {
 			}
 			authorization := fixture.authorization(2)
 			authorization.DiscloseFilename = testCase.disclose
-			result, err := document.ExecuteEmbedding(context.Background(), fixture.client, []document.EmbeddingInput{
+			embed := fixture.client.Embed
+			if !testCase.direct {
+				embed = func(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+					return document.ExecuteEmbedding(ctx, fixture.client, inputs, authorization)
+				}
+			}
+			result, err := embed(context.Background(), []document.EmbeddingInput{
 				{
 					Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk,
 					Text: "synthetic contract fixture", HeadingPath: []string{"Synthetic"},

--- a/document/embeddingbridge/contract_test.go
+++ b/document/embeddingbridge/contract_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
@@ -465,4 +466,59 @@ func independentInteger(value any) (int64, error) {
 		return 0, fmt.Errorf("independent server: parse integer: %w", err)
 	}
 	return parsed, nil
+}
+
+func TestHeadingLengthMatchesPublishedSchemaBeforeTransmission(t *testing.T) {
+	validator := compileContractSchema(t, "https://docbank.invalid/contracts/docbank-embedding/v1/request.schema.json", requestSchema)
+	for _, test := range []struct {
+		name     string
+		heading  string
+		rejected bool
+	}{
+		{"ASCII limit", strings.Repeat("a", 8192), false},
+		{"ASCII overflow", strings.Repeat("a", 8193), true},
+		{"Unicode limit", strings.Repeat("é", 8192), false},
+		{"Unicode overflow", strings.Repeat("é", 8193), true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var requests atomic.Int32
+			fixture := newBridgeFixture(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				requests.Add(1)
+				manifest, _ := readBridgeRequest(t, request)
+				var wire any
+				if !assert.NoError(t, json.Unmarshal([]byte(mustJSON(t, manifest)), &wire)) {
+					return
+				}
+				if err := validator.Validate(wire); err != nil {
+					writer.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				writeSuccess(t, writer, manifest, []document.EmbeddingVector{{Key: "first", Index: new(0), Values: []float32{1, 0}}})
+			}))
+			profile := fixture.profile
+			profile.MaxRequestBytes = 64 << 10
+			fingerprint, err := embeddingbridge.PolicyFingerprint(profile)
+			require.NoError(t, err)
+			profile.Descriptor.PolicyFingerprint = fingerprint
+			profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+			require.NoError(t, err)
+			client, err := embeddingbridge.New(profile, secretMap{"credential:synthetic-bridge": "synthetic-secret"}, fixture.resolver, &http.Client{})
+			require.NoError(t, err)
+			authorization := fixture.authorization(1)
+			authorization.DescriptorFingerprint = profile.Descriptor.Fingerprint
+			authorization.PolicyFingerprint = profile.Descriptor.PolicyFingerprint
+			inputs := oneTextInput("alpha")
+			inputs[0].HeadingPath = []string{test.heading}
+			require.NoError(t, document.ValidateEmbeddingProviderRequest(client, inputs, authorization))
+			_, err = client.Embed(t.Context(), inputs, authorization)
+			if test.rejected {
+				require.Error(t, err)
+				assert.Equal(t, embeddingbridge.ErrorPermanent, embeddingbridge.Category(err))
+				assert.Zero(t, requests.Load())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, int32(1), requests.Load())
+			}
+		})
+	}
 }

--- a/document/embeddingbridge/embedding-request-v1.schema.json
+++ b/document/embeddingbridge/embedding-request-v1.schema.json
@@ -82,7 +82,7 @@
         "policy_fingerprint": {"$ref": "#/$defs/sha256"},
         "max_batch_items": {"type": "integer", "minimum": 1, "maximum": 10000},
         "max_input_bytes": {"type": "integer", "minimum": 1, "maximum": 1073741824},
-        "max_response_bytes": {"type": "integer", "minimum": 1, "maximum": 1073741824},
+        "max_response_bytes": {"type": "integer", "minimum": 1, "maximum": 1073741824, "description": "Semantic result budget: the UTF-8 bytes of all vector keys plus four bytes per float32 coordinate. The client's independent wire-byte cap must also allow for the JSON envelope, key escaping, and encoded numbers."},
         "disclose_filename": {"type": "boolean", "description": "Whether the execution boundary permits the original filename to be disclosed."}
       }
     },

--- a/document/embeddingbridge/embedding-request-v1.schema.json
+++ b/document/embeddingbridge/embedding-request-v1.schema.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docbank.invalid/contracts/docbank-embedding/v1/request.schema.json",
+  "title": "Docbank embedding request manifest v1",
+  "x-docbank-canonicalization": {
+    "name": "docbank-json-v1",
+    "character_encoding": "UTF-8 without a byte-order mark",
+    "whitespace": "No insignificant whitespace before or after tokens.",
+    "object_member_order": {
+      "$": ["contract_version", "descriptor_fingerprint", "policy_fingerprint", "authorization", "inputs", "request_checksum"],
+      "$.authorization": ["provider_id", "descriptor_fingerprint", "policy_fingerprint", "max_batch_items", "max_input_bytes", "max_response_bytes", "disclose_filename"],
+      "$.inputs[]": ["index", "key", "role", "kind", "byte_length", "sha256", "text", "heading_path", "source_spans", "upload", "file_part", "file_index"],
+      "$.inputs[].source_spans[]": ["unit_index", "char_start", "char_end"],
+      "$.inputs[].upload": ["filename", "media_family", "media_type", "byte_length", "sha256", "capability_record_checksum", "provider_metadata_checksum", "input_kind"]
+    },
+    "arrays": "Preserve manifest array order exactly.",
+    "booleans": "Emit the lowercase JSON literals true or false.",
+    "integers": "Base-10 ASCII digits with a leading minus only for negative values; no leading zero except the value zero. This schema permits no negative request integers.",
+    "strings": "Use JSON quotation marks. Escape quotation mark and reverse solidus. Escape U+0000 through U+001F using \\b, \\f, \\n, \\r, or \\t where applicable and lowercase \\u00xx otherwise. Emit every other Unicode scalar as its UTF-8 bytes without escaping.",
+    "optional_members": "Omit absent optional members. Never emit null. Emit present members in the order defined for their object after skipping absent members.",
+    "checksum": "Omit request_checksum entirely, serialize the remaining manifest with these docbank-json-v1 rules, compute SHA-256 over those exact UTF-8 bytes, encode the digest as 64 lowercase hexadecimal characters, then append request_checksum as the final root member for transmission.",
+    "checksum_vectors": [
+      {
+        "canonical_manifest": "{\"contract_version\":\"docbank-embedding/v1\",\"descriptor_fingerprint\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"policy_fingerprint\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"authorization\":{\"provider_id\":\"synthetic.vector\",\"descriptor_fingerprint\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"policy_fingerprint\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"max_batch_items\":1,\"max_input_bytes\":64,\"max_response_bytes\":16,\"disclose_filename\":false},\"inputs\":[{\"index\":0,\"key\":\"vector-a\",\"role\":\"document\",\"kind\":\"rendition_chunk\",\"byte_length\":22,\"sha256\":\"5aa0924b94846dd796a2130bbb9a63f21721793169cedd7547b1666050dacc12\",\"text\":\"search_document: alpha\",\"heading_path\":[\"Overview\"],\"source_spans\":[{\"unit_index\":0,\"char_start\":0,\"char_end\":5}]}]}",
+        "sha256": "c04f1e50948f890f1dba9e7a7a44f75fef599c30b26150df5922e5aa40eefa73"
+      },
+      {
+        "canonical_manifest": "{\"contract_version\":\"docbank-embedding/v1\",\"descriptor_fingerprint\":\"2222222222222222222222222222222222222222222222222222222222222222\",\"policy_fingerprint\":\"3333333333333333333333333333333333333333333333333333333333333333\",\"authorization\":{\"provider_id\":\"synthetic.query\",\"descriptor_fingerprint\":\"2222222222222222222222222222222222222222222222222222222222222222\",\"policy_fingerprint\":\"3333333333333333333333333333333333333333333333333333333333333333\",\"max_batch_items\":1,\"max_input_bytes\":64,\"max_response_bytes\":16,\"disclose_filename\":false},\"inputs\":[{\"index\":0,\"key\":\"vector-b\",\"role\":\"query\",\"kind\":\"query_text\",\"byte_length\":20,\"sha256\":\"1ccc4c7d34c3c140b5a067a8fca62cd86244ba8b39fa4e3b2b85c578558b5020\",\"text\":\"search_query: <β>&\\n\"}]}",
+        "sha256": "bd524889925d6817f42366afd0d95413d0d05e611e839e2840d10c94cadb9168"
+      }
+    ]
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "descriptor_fingerprint",
+    "policy_fingerprint",
+    "authorization",
+    "inputs",
+    "request_checksum"
+  ],
+  "properties": {
+    "contract_version": {"const": "docbank-embedding/v1"},
+    "descriptor_fingerprint": {"$ref": "#/$defs/sha256"},
+    "policy_fingerprint": {"$ref": "#/$defs/sha256"},
+    "authorization": {"$ref": "#/$defs/authorization"},
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 10000,
+      "items": {"$ref": "#/$defs/input"}
+    },
+    "request_checksum": {
+      "description": "SHA-256 of the docbank-json-v1 canonical UTF-8 manifest with request_checksum omitted, as defined by x-docbank-canonicalization.",
+      "$ref": "#/$defs/sha256"
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "stable_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9._-]+$"
+    },
+    "authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "descriptor_fingerprint",
+        "policy_fingerprint",
+        "max_batch_items",
+        "max_input_bytes",
+        "max_response_bytes",
+        "disclose_filename"
+      ],
+      "properties": {
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "descriptor_fingerprint": {"$ref": "#/$defs/sha256"},
+        "policy_fingerprint": {"$ref": "#/$defs/sha256"},
+        "max_batch_items": {"type": "integer", "minimum": 1, "maximum": 10000},
+        "max_input_bytes": {"type": "integer", "minimum": 1, "maximum": 1073741824},
+        "max_response_bytes": {"type": "integer", "minimum": 1, "maximum": 1073741824},
+        "disclose_filename": {"type": "boolean", "description": "Whether the execution boundary permits the original filename to be disclosed."}
+      }
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index", "key", "role", "kind", "byte_length", "sha256"],
+      "properties": {
+        "index": {"type": "integer", "minimum": 0, "maximum": 9999},
+        "key": {"$ref": "#/$defs/stable_id"},
+        "role": {"enum": ["document", "query"]},
+        "kind": {"enum": ["rendition_chunk", "query_text", "original_file"]},
+        "byte_length": {"type": "integer", "minimum": 1, "maximum": 1073741824},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "text": {"type": "string", "minLength": 1},
+        "heading_path": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1024,
+          "items": {"type": "string", "minLength": 1, "maxLength": 8192}
+        },
+        "source_spans": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1024,
+          "items": {"$ref": "#/$defs/source_span"}
+        },
+        "upload": {"$ref": "#/$defs/upload"},
+        "file_part": {"const": "file"},
+        "file_index": {"type": "integer", "minimum": 0, "maximum": 9999}
+      },
+      "oneOf": [
+        {
+          "required": ["text"],
+          "not": {"anyOf": [{"required": ["upload"]}, {"required": ["file_part"]}, {"required": ["file_index"]}]},
+          "properties": {
+            "role": {"const": "document"},
+            "kind": {"const": "rendition_chunk"}
+          }
+        },
+        {
+          "required": ["text"],
+          "not": {
+            "anyOf": [
+              {"required": ["heading_path"]},
+              {"required": ["source_spans"]},
+              {"required": ["upload"]},
+              {"required": ["file_part"]},
+              {"required": ["file_index"]}
+            ]
+          },
+          "properties": {
+            "role": {"const": "query"},
+            "kind": {"const": "query_text"}
+          }
+        },
+        {
+          "required": ["upload", "file_part", "file_index"],
+          "not": {
+            "anyOf": [
+              {"required": ["text"]},
+              {"required": ["heading_path"]},
+              {"required": ["source_spans"]}
+            ]
+          },
+          "properties": {
+            "role": {"const": "document"},
+            "kind": {"const": "original_file"}
+          }
+        }
+      ]
+    },
+    "source_span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["unit_index", "char_start", "char_end"],
+      "properties": {
+        "unit_index": {"type": "integer", "minimum": 0, "maximum": 999999},
+        "char_start": {"type": "integer", "minimum": 0, "maximum": 268435455},
+        "char_end": {"type": "integer", "minimum": 1, "maximum": 268435456}
+      }
+    },
+    "upload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "filename",
+        "media_family",
+        "media_type",
+        "byte_length",
+        "sha256",
+        "capability_record_checksum",
+        "provider_metadata_checksum",
+        "input_kind"
+      ],
+      "properties": {
+        "filename": {
+          "description": "Empty when the execution boundary withholds the original filename.",
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 255,
+          "pattern": "^[^/\\\\\\x00-\\x1f\\x7f]*$"
+        },
+        "media_family": {"type": "string", "minLength": 1, "maxLength": 63},
+        "media_type": {"type": "string", "minLength": 3, "maxLength": 255},
+        "byte_length": {"type": "integer", "minimum": 1},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "capability_record_checksum": {"$ref": "#/$defs/sha256"},
+        "provider_metadata_checksum": {"$ref": "#/$defs/sha256"},
+        "input_kind": {"const": "original_file"}
+      }
+    }
+  }
+}

--- a/document/embeddingbridge/embedding-response-v1.schema.json
+++ b/document/embeddingbridge/embedding-response-v1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docbank.invalid/contracts/docbank-embedding/v1/response.schema.json",
+  "title": "Docbank embedding response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "descriptor_fingerprint",
+    "policy_fingerprint",
+    "request_checksum",
+    "vectors"
+  ],
+  "properties": {
+    "contract_version": {"const": "docbank-embedding/v1"},
+    "descriptor_fingerprint": {"$ref": "#/$defs/sha256"},
+    "policy_fingerprint": {"$ref": "#/$defs/sha256"},
+    "request_checksum": {"$ref": "#/$defs/sha256"},
+    "vectors": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 10000,
+      "description": "Exactly one item per request input, in request order; index equals its zero-based array position.",
+      "items": {"$ref": "#/$defs/vector"}
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "stable_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9._-]+$"
+    },
+    "vector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "index", "values"],
+      "properties": {
+        "key": {"$ref": "#/$defs/stable_id"},
+        "index": {"type": "integer", "minimum": 0, "maximum": 9999},
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1000000,
+          "items": {"type": "number"}
+        }
+      }
+    }
+  }
+}

--- a/document/embeddingbridge/errors.go
+++ b/document/embeddingbridge/errors.go
@@ -1,0 +1,51 @@
+package embeddingbridge
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrorCategory is a stable, content-free worker classification.
+type ErrorCategory string
+
+const (
+	ErrorAuthentication      ErrorCategory = "authentication"
+	ErrorCapacity            ErrorCategory = "capacity"
+	ErrorTransient           ErrorCategory = "transient"
+	ErrorPermanent           ErrorCategory = "permanent"
+	ErrorMalformedResponse   ErrorCategory = "malformed_response"
+	ErrorAmbiguousSubmission ErrorCategory = "ambiguous_submission"
+	ErrorSourceChanged       ErrorCategory = "source_changed"
+)
+
+// ProviderError contains only a stable category and optional HTTP status.
+// Provider bodies, transport messages, secrets, and inputs are never retained.
+type ProviderError struct {
+	category ErrorCategory
+	status   int
+}
+
+func (err *ProviderError) Error() string {
+	if err.status != 0 {
+		return fmt.Sprintf("embedding bridge: %s (HTTP %d)", err.category, err.status)
+	}
+	return "embedding bridge: " + string(err.category)
+}
+
+// Category returns the stable category for err. Unknown errors are permanent.
+func Category(err error) ErrorCategory {
+	if providerError, ok := errors.AsType[*ProviderError](err); ok {
+		return providerError.category
+	}
+	return ErrorPermanent
+}
+
+// IsRetryable reports whether retrying the same idempotency checksum is safe.
+func IsRetryable(err error) bool {
+	category := Category(err)
+	return category == ErrorTransient || category == ErrorAmbiguousSubmission
+}
+
+func classified(category ErrorCategory, status int) error {
+	return &ProviderError{category: category, status: status}
+}

--- a/document/embeddingbridge/errors.go
+++ b/document/embeddingbridge/errors.go
@@ -1,8 +1,12 @@
 package embeddingbridge
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
+
+	"go.kenn.io/docbank/document/providerhttp"
 )
 
 // ErrorCategory is a stable, content-free worker classification.
@@ -48,4 +52,28 @@ func IsRetryable(err error) bool {
 
 func classified(category ErrorCategory, status int) error {
 	return &ProviderError{category: category, status: status}
+}
+
+// requestContextError is called after the bridge's request context ends.
+// Caller cancellation stays identifiable; the bridge's own deadline is retryable.
+func requestContextError(parent context.Context) error {
+	if err := parent.Err(); err != nil {
+		return err
+	}
+	return classified(ErrorTransient, 0)
+}
+
+func transportError(err error) error {
+	if errors.Is(err, providerhttp.ErrDestinationDenied) ||
+		errors.Is(err, providerhttp.ErrAddressDenied) ||
+		errors.Is(err, providerhttp.ErrCertificatePin) {
+		return classified(ErrorPermanent, 0)
+	}
+	if dialErr, ok := errors.AsType[*net.OpError](err); ok && dialErr.Op == "dial" {
+		return classified(ErrorTransient, 0)
+	}
+	if _, ok := errors.AsType[*net.DNSError](err); ok {
+		return classified(ErrorTransient, 0)
+	}
+	return classified(ErrorAmbiguousSubmission, 0)
 }

--- a/document/embeddingbridge/openapi.yaml
+++ b/document/embeddingbridge/openapi.yaml
@@ -1,0 +1,77 @@
+openapi: 3.1.0
+info:
+  title: Docbank Embedding Bridge
+  version: 1.0.0
+  description: >-
+    Fixed synchronous provider-neutral embedding protocol. Implementations accept
+    one deterministic manifest and zero or more authorization-held files at one
+    same-origin route. The complete result is returned by that request.
+paths:
+  /docbank-embedding/v1/embeddings:
+    post:
+      operationId: embedDocbankInputs
+      security:
+        - bearerAuth: []
+        - {}
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema: {$ref: '#/components/schemas/SHA256'}
+        - name: Docbank-Request-Checksum
+          in: header
+          required: true
+          schema: {$ref: '#/components/schemas/SHA256'}
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [manifest]
+              properties:
+                manifest: {$ref: './embedding-request-v1.schema.json'}
+                file:
+                  type: array
+                  description: >-
+                    Original files in ascending manifest file_index order. Every
+                    element uses the repeated fixed multipart part name file.
+                    The filename is empty when the execution boundary withholds it;
+                    authorization.disclose_filename records the disclosure grant.
+                  maxItems: 10000
+                  items: {type: string, format: binary}
+            encoding:
+              manifest:
+                contentType: application/vnd.docbank.embedding-manifest+json;version=1
+              file:
+                explode: true
+      responses:
+        '200':
+          description: One ordered, indexed vector for every manifest input.
+          content:
+            application/vnd.docbank.embedding-result+json;version=1:
+              schema: {$ref: './embedding-response-v1.schema.json'}
+        '400': {$ref: '#/components/responses/EmptyError'}
+        '401': {$ref: '#/components/responses/EmptyError'}
+        '403': {$ref: '#/components/responses/EmptyError'}
+        '413': {$ref: '#/components/responses/EmptyError'}
+        '429': {$ref: '#/components/responses/EmptyError'}
+        '500': {$ref: '#/components/responses/EmptyError'}
+        '502': {$ref: '#/components/responses/EmptyError'}
+        '503': {$ref: '#/components/responses/EmptyError'}
+        '504': {$ref: '#/components/responses/EmptyError'}
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  responses:
+    EmptyError:
+      description: >-
+        Error responses have no protocol body. Clients classify only the status
+        and never retain provider response bytes or upstream messages.
+  schemas:
+    SHA256:
+      type: string
+      pattern: '^[0-9a-f]{64}$'

--- a/document/embeddingbridge/profile.go
+++ b/document/embeddingbridge/profile.go
@@ -1,0 +1,316 @@
+package embeddingbridge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	defaultRequestTimeout   = 30 * time.Second
+	defaultMaxBatchItems    = 128
+	defaultMaxInputBytes    = int64(16 << 20)
+	defaultMaxRequestBytes  = int64(32 << 20)
+	defaultMaxResponseBytes = int64(64 << 20)
+	maxRequestTimeout       = 10 * time.Minute
+	maxBatchItems           = 10_000
+	maxInputBytes           = int64(1 << 30)
+	maxRequestBytes         = int64(2 << 30)
+	maxResponseBytes        = int64(1 << 30)
+	maxSecretBytes          = 64 << 10
+)
+
+type policyIdentity struct {
+	AdapterContract   string                       `json:"adapter_contract"`
+	Origin            string                       `json:"origin"`
+	Route             string                       `json:"route"`
+	Descriptor        document.EmbeddingDescriptor `json:"descriptor"`
+	ModelInput        document.ModelInputContract  `json:"model_input"`
+	CredentialBinding string                       `json:"credential_binding"`
+	Egress            egressIdentity               `json:"egress"`
+	RequestTimeout    int64                        `json:"request_timeout_nanos"`
+	MaxBatchItems     int                          `json:"max_batch_items"`
+	MaxInputBytes     int64                        `json:"max_input_bytes"`
+	MaxRequestBytes   int64                        `json:"max_request_bytes"`
+	MaxResponseBytes  int64                        `json:"max_response_bytes"`
+}
+
+type egressIdentity struct {
+	Scheme              string   `json:"scheme"`
+	Host                string   `json:"host"`
+	Port                uint16   `json:"port"`
+	AllowedCIDRs        []string `json:"allowed_cidrs"`
+	ProxyMode           string   `json:"proxy_mode"`
+	ConnectTimeout      int64    `json:"connect_timeout_nanos"`
+	KeepAlive           int64    `json:"keep_alive_nanos"`
+	TLSHandshakeTimeout int64    `json:"tls_handshake_timeout_nanos"`
+	SPKISHA256          []string `json:"spki_sha256,omitempty"`
+}
+
+// PolicyFingerprint returns the canonical profile fingerprint. Credential
+// values and supplied HTTP client state are deliberately excluded.
+func PolicyFingerprint(profile Profile) (string, error) {
+	normalized, descriptorIdentity, err := normalizeProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(policyIdentity{
+		AdapterContract: adapterContract, Origin: normalized.Origin, Route: embeddingsPath,
+		Descriptor: descriptorIdentity, ModelInput: descriptorIdentity.ModelInput,
+		CredentialBinding: normalized.SecretBinding, Egress: profileEgressIdentity(normalized.EgressPolicy),
+		RequestTimeout: int64(normalized.RequestTimeout), MaxBatchItems: normalized.MaxBatchItems,
+		MaxInputBytes: normalized.MaxInputBytes, MaxRequestBytes: normalized.MaxRequestBytes,
+		MaxResponseBytes: normalized.MaxResponseBytes,
+	}, json.Deterministic(true))
+	if err != nil {
+		return "", errors.New("embedding bridge: profile identity encoding failed")
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// New validates a canonical profile and returns an isolated client using the
+// repository egress transport. All mutable supplied client authority is removed.
+func New(profile Profile, secrets SecretResolver, resolver providerhttp.Resolver, supplied *http.Client) (*Client, error) {
+	if supplied == nil {
+		return nil, errors.New("embedding bridge: HTTP client is required")
+	}
+	normalized, _, err := normalizeProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		return nil, errors.New("embedding bridge: descriptor is not canonical")
+	}
+	fingerprint, err := PolicyFingerprint(profile)
+	if err != nil {
+		return nil, err
+	}
+	if descriptor.PolicyFingerprint != fingerprint {
+		return nil, errors.New("embedding bridge: descriptor policy fingerprint does not match profile")
+	}
+	if normalized.SecretBinding == "" {
+		if !nilInterface(secrets) {
+			return nil, errors.New("embedding bridge: resolver is not allowed without a named secret binding")
+		}
+	} else if nilInterface(secrets) {
+		return nil, errors.New("embedding bridge: named secret resolver is required")
+	}
+	transport, err := providerhttp.NewTransport(normalized.EgressPolicy, resolver)
+	if err != nil {
+		return nil, errors.New("embedding bridge: sealed egress policy is invalid")
+	}
+	isolated := *supplied
+	isolated.Transport = transport
+	isolated.CheckRedirect = providerhttp.RefuseRedirects
+	isolated.Jar = nil
+	isolated.Timeout = 0
+	return &Client{
+		origin: normalized.Origin, descriptor: cloneDescriptor(descriptor),
+		secretBinding: normalized.SecretBinding, secrets: secrets, http: &isolated,
+		requestTimeout: normalized.RequestTimeout, maxBatchItems: normalized.MaxBatchItems,
+		maxInputBytes: normalized.MaxInputBytes, maxRequestBytes: normalized.MaxRequestBytes,
+		maxResponseBytes: normalized.MaxResponseBytes,
+	}, nil
+}
+
+func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, error) {
+	profile.EgressPolicy.AllowedCIDRs = slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	profile.EgressPolicy.TLS.SPKISHA256 = slices.Clone(profile.EgressPolicy.TLS.SPKISHA256)
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = defaultRequestTimeout
+	}
+	if profile.MaxBatchItems == 0 {
+		profile.MaxBatchItems = defaultMaxBatchItems
+	}
+	if profile.MaxInputBytes == 0 {
+		profile.MaxInputBytes = defaultMaxInputBytes
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = defaultMaxRequestBytes
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = defaultMaxResponseBytes
+	}
+	if profile.RequestTimeout <= 0 || profile.RequestTimeout > maxRequestTimeout ||
+		profile.MaxBatchItems < 1 || profile.MaxBatchItems > maxBatchItems ||
+		profile.MaxInputBytes < 1 || profile.MaxInputBytes > maxInputBytes ||
+		profile.MaxRequestBytes < 1 || profile.MaxRequestBytes > maxRequestBytes ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maxResponseBytes {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("embedding bridge: execution bounds are invalid")
+	}
+	if profile.SecretBinding != "" && !validBinding(profile.SecretBinding) {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("embedding bridge: secret binding is invalid")
+	}
+	if profile.SecretBinding == "" && profile.Descriptor.TrustBoundary != document.EmbeddingTrustOperatorNetwork {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("embedding bridge: anonymous access is operator-network only")
+	}
+	origin, err := normalizeOrigin(profile.Origin, profile.Descriptor.TrustBoundary)
+	if err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
+	profile.Origin = origin
+	if err := normalizeEgress(&profile); err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
+	descriptorIdentity := cloneDescriptor(profile.Descriptor)
+	descriptorIdentity.PolicyFingerprint = strings.Repeat("0", sha256.Size*2)
+	descriptorIdentity.Fingerprint = ""
+	descriptorIdentity, err = document.NewEmbeddingDescriptor(descriptorIdentity)
+	if err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("embedding bridge: descriptor identity is invalid")
+	}
+	descriptorIdentity.PolicyFingerprint = ""
+	descriptorIdentity.Fingerprint = ""
+	return profile, descriptorIdentity, nil
+}
+
+func normalizeOrigin(raw string, trust document.EmbeddingTrustBoundary) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Opaque != "" ||
+		parsed.ForceQuery || parsed.Fragment != "" || (parsed.Path != "" && parsed.Path != "/") {
+		return "", errors.New("embedding bridge: origin must be one absolute origin without path, credentials, query, or fragment")
+	}
+	if parsed.Scheme != "https" && (parsed.Scheme != "http" || trust != document.EmbeddingTrustOperatorNetwork) {
+		return "", errors.New("embedding bridge: hosted origins require HTTPS; HTTP is operator-network only")
+	}
+	if trust != document.EmbeddingTrustOperatorNetwork && trust != document.EmbeddingTrustHostedProvider {
+		return "", errors.New("embedding bridge: network origin requires an operator-network or hosted trust boundary")
+	}
+	port := parsed.Port()
+	if port == "" {
+		if parsed.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	if _, err := strconv.ParseUint(port, 10, 16); err != nil {
+		return "", errors.New("embedding bridge: origin port is invalid")
+	}
+	host := strings.ToLower(parsed.Hostname())
+	authority := host
+	if strings.Contains(host, ":") {
+		authority = "[" + host + "]"
+	}
+	if (parsed.Scheme != "https" || port != "443") && (parsed.Scheme != "http" || port != "80") {
+		authority = net.JoinHostPort(host, port)
+	}
+	return parsed.Scheme + "://" + authority, nil
+}
+
+func normalizeEgress(profile *Profile) error {
+	policy := &profile.EgressPolicy
+	if policy.ConnectTimeout == 0 {
+		policy.ConnectTimeout = providerhttp.DefaultConnectTimeout
+	}
+	if policy.KeepAlive == 0 {
+		policy.KeepAlive = providerhttp.DefaultKeepAlive
+	}
+	if policy.TLSHandshakeTimeout == 0 {
+		policy.TLSHandshakeTimeout = providerhttp.DefaultTLSHandshakeTimeout
+	}
+	if policy.ProxyMode == "" {
+		policy.ProxyMode = providerhttp.ProxyDisabled
+	}
+	if policy.TLS.RootCAs != nil {
+		return errors.New("embedding bridge: custom egress roots cannot enter canonical identity")
+	}
+	parsed, err := url.Parse(profile.Origin)
+	if err != nil {
+		return errors.New("embedding bridge: origin is invalid")
+	}
+	port := parsed.Port()
+	if port == "" {
+		if parsed.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	if parsed.Scheme != policy.Scheme || !strings.EqualFold(parsed.Hostname(), policy.Host) ||
+		port != strconv.FormatUint(uint64(policy.Port), 10) {
+		return errors.New("embedding bridge: origin and egress authority differ")
+	}
+	policy.Host = strings.ToLower(policy.Host)
+	for index := range policy.AllowedCIDRs {
+		policy.AllowedCIDRs[index] = policy.AllowedCIDRs[index].Masked()
+	}
+	slices.SortFunc(policy.AllowedCIDRs, func(left, right netip.Prefix) int {
+		return strings.Compare(left.String(), right.String())
+	})
+	for index := 1; index < len(policy.AllowedCIDRs); index++ {
+		if policy.AllowedCIDRs[index] == policy.AllowedCIDRs[index-1] {
+			return errors.New("embedding bridge: egress policy has a duplicate CIDR")
+		}
+	}
+	for index := range policy.TLS.SPKISHA256 {
+		policy.TLS.SPKISHA256[index] = strings.ToLower(policy.TLS.SPKISHA256[index])
+	}
+	slices.Sort(policy.TLS.SPKISHA256)
+	return nil
+}
+
+func profileEgressIdentity(policy providerhttp.EgressPolicy) egressIdentity {
+	cidrs := make([]string, len(policy.AllowedCIDRs))
+	for index, prefix := range policy.AllowedCIDRs {
+		cidrs[index] = prefix.String()
+	}
+	return egressIdentity{
+		Scheme: policy.Scheme, Host: policy.Host, Port: policy.Port, AllowedCIDRs: cidrs,
+		ProxyMode: string(policy.ProxyMode), ConnectTimeout: int64(policy.ConnectTimeout),
+		KeepAlive: int64(policy.KeepAlive), TLSHandshakeTimeout: int64(policy.TLSHandshakeTimeout),
+		SPKISHA256: slices.Clone(policy.TLS.SPKISHA256),
+	}
+}
+
+func validBinding(value string) bool {
+	return value != "" && len(value) <= 128 && utf8.ValidString(value) && value == strings.TrimSpace(value) &&
+		strings.IndexFunc(value, func(character rune) bool { return unicode.IsControl(character) || unicode.IsSpace(character) }) < 0
+}
+
+func validSecret(value string) bool {
+	return value != "" && len(value) <= maxSecretBytes && strings.IndexFunc(value, func(character rune) bool {
+		return unicode.IsControl(character) || unicode.IsSpace(character)
+	}) < 0
+}
+
+func nilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func cloneDescriptor(value document.EmbeddingDescriptor) document.EmbeddingDescriptor {
+	value.InputKinds = slices.Clone(value.InputKinds)
+	value.SupportedRequestModes = slices.Clone(value.SupportedRequestModes)
+	return value
+}
+
+func sha256Hex(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}

--- a/document/embeddingbridge/source_gate_test.go
+++ b/document/embeddingbridge/source_gate_test.go
@@ -1,0 +1,40 @@
+package embeddingbridge
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+)
+
+func TestActiveSourceCancellationBetweenFilesLeavesBothSourcesOpen(t *testing.T) {
+	first := &gateTestUpload{}
+	second := &gateTestUpload{}
+	gate := newActiveSourceGate()
+
+	firstToken, ok := gate.Begin(first)
+	require.True(t, ok)
+	gate.End(firstToken)
+	gate.Cancel()
+	_, ok = gate.Begin(second)
+	assert.False(t, ok)
+	assert.Zero(t, first.closes.Load())
+	assert.Zero(t, second.closes.Load())
+}
+
+type gateTestUpload struct {
+	closes atomic.Int32
+}
+
+func (*gateTestUpload) Read([]byte) (int, error) { return 0, nil }
+
+func (*gateTestUpload) Metadata() document.AuthorizedUploadMetadata {
+	return document.AuthorizedUploadMetadata{}
+}
+
+func (upload *gateTestUpload) Close() error {
+	upload.closes.Add(1)
+	return nil
+}

--- a/document/embeddingbridge/types.go
+++ b/document/embeddingbridge/types.go
@@ -1,0 +1,103 @@
+// Package embeddingbridge implements the fixed synchronous docbank-embedding/v1
+// provider-neutral embedding protocol.
+package embeddingbridge
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	// ContractVersion is the only protocol version this package accepts.
+	ContractVersion = "docbank-embedding/v1"
+
+	embeddingsPath    = "/docbank-embedding/v1/embeddings"
+	manifestPartName  = "manifest"
+	filePartName      = "file"
+	manifestMediaType = "application/vnd.docbank.embedding-manifest+json;version=1"
+	responseMediaType = "application/vnd.docbank.embedding-result+json;version=1"
+	adapterContract   = "docbank-standard-embedding-bridge/v1"
+)
+
+// SecretResolver resolves only the configured named credential binding.
+// Values are runtime-only and never enter protocol manifests or fingerprints.
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, binding string) (string, error)
+}
+
+// Profile freezes the bridge origin, vector-space identity, credential name,
+// egress authority, and synchronous execution bounds.
+type Profile struct {
+	Origin           string
+	Descriptor       document.EmbeddingDescriptor
+	SecretBinding    string
+	EgressPolicy     providerhttp.EgressPolicy
+	RequestTimeout   time.Duration
+	MaxBatchItems    int
+	MaxInputBytes    int64
+	MaxRequestBytes  int64
+	MaxResponseBytes int64
+}
+
+// Client implements document.EmbeddingProvider through docbank-embedding/v1.
+type Client struct {
+	origin           string
+	descriptor       document.EmbeddingDescriptor
+	secretBinding    string
+	secrets          SecretResolver
+	http             *http.Client
+	requestTimeout   time.Duration
+	maxBatchItems    int
+	maxInputBytes    int64
+	maxRequestBytes  int64
+	maxResponseBytes int64
+}
+
+// RequestManifest is the deterministic authorization and input identity sent
+// as the first multipart part. RequestChecksum is SHA-256 over the canonical
+// manifest with that field omitted.
+type RequestManifest struct {
+	ContractVersion       string                          `json:"contract_version"`
+	DescriptorFingerprint string                          `json:"descriptor_fingerprint"`
+	PolicyFingerprint     string                          `json:"policy_fingerprint"`
+	Authorization         document.EmbeddingAuthorization `json:"authorization"`
+	Inputs                []ManifestInput                 `json:"inputs"`
+	RequestChecksum       string                          `json:"request_checksum,omitempty"`
+}
+
+// ManifestInput binds one exact request position and its rendered text or
+// authorization-held original file.
+type ManifestInput struct {
+	Index       int                                `json:"index"`
+	Key         string                             `json:"key"`
+	Role        document.EmbeddingRole             `json:"role"`
+	Kind        document.EmbeddingInputKind        `json:"kind"`
+	ByteLength  int64                              `json:"byte_length"`
+	SHA256      string                             `json:"sha256"`
+	Text        string                             `json:"text,omitempty"`
+	HeadingPath []string                           `json:"heading_path,omitempty"`
+	SourceSpans []ManifestSpan                     `json:"source_spans,omitempty"`
+	Upload      *document.AuthorizedUploadMetadata `json:"upload,omitempty"`
+	FilePart    string                             `json:"file_part,omitempty"`
+	FileIndex   *int                               `json:"file_index,omitempty"`
+}
+
+// ManifestSpan is the closed wire form of one canonical source span.
+type ManifestSpan struct {
+	UnitIndex int `json:"unit_index"`
+	CharStart int `json:"char_start"`
+	CharEnd   int `json:"char_end"`
+}
+
+// Response is the strict synchronous result envelope.
+type Response struct {
+	ContractVersion       string                     `json:"contract_version"`
+	DescriptorFingerprint string                     `json:"descriptor_fingerprint"`
+	PolicyFingerprint     string                     `json:"policy_fingerprint"`
+	RequestChecksum       string                     `json:"request_checksum"`
+	Vectors               []document.EmbeddingVector `json:"vectors"`
+}

--- a/document/embeddingbridge/types.go
+++ b/document/embeddingbridge/types.go
@@ -31,6 +31,9 @@ type SecretResolver interface {
 
 // Profile freezes the bridge origin, vector-space identity, credential name,
 // egress authority, and synchronous execution bounds.
+// MaxResponseBytes caps the complete JSON response body, including the
+// envelope, escaped keys, and encoded numbers. Configure this independently
+// of EmbeddingAuthorization.MaxResponseBytes, which counts keys and float32s.
 type Profile struct {
 	Origin           string
 	Descriptor       document.EmbeddingDescriptor

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mattn/go-sqlite3 v1.14.47
 	github.com/pdfcpu/pdfcpu v0.15.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=
 github.com/shirou/gopsutil/v4 v4.26.6/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=


### PR DESCRIPTION
## What changed

- Adds one fixed, synchronous `docbank-embedding/v1` endpoint for document text, query text, and exact authorized original-file uploads.
- Publishes strict OpenAPI and JSON Schema contracts, including deterministic request manifests and checksums that bind the provider, vector space, authorization, inputs, headings, and source spans.
- Binds origin, egress, authentication, model-input policy, and execution limits into the provider identity. Named bearer credentials are supported, while no-auth profiles are limited to an explicit operator-network deployment.
- Rejects redirects, schema drift, oversized or malformed responses, non-finite or wrong-size vectors, and changed source bytes. Provider and transport failures stay classified without exposing request text, files, credentials, or vectors.
- Parent: #221 (merged). This PR contains only the standard embedding bridge.

## Why

Hosted and self-hosted providers currently need a bespoke adapter inside Docbank. This gives them one bounded protocol to implement without exposing arbitrary request templates or weakening the vector-space and source-version guarantees that retrieval depends on.

## Usage

Implement `POST /docbank-embedding/v1/embeddings` from the shipped OpenAPI and JSON Schema contracts. Configure a canonical embedding descriptor, the exact service origin and egress policy, execution limits, and either a named credential binding or an explicit operator-network no-auth profile, then call the client through Docbank's embedding execution boundary.

Refs #176

