### PR TITLE
[F10–E12 25/25] Add fixed hosted OpenAI embeddings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $zip = Join-Path $env:RUNNER_TEMP 'llvm-mingw.zip'
           $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$env:LLVM_MINGW_VERSION/$env:LLVM_MINGW_NAME.zip"
-          Invoke-WebRequest -Uri $url -OutFile $zip
+          Invoke-WebRequest -Uri $url -OutFile $zip -MaximumRetryCount 3 -RetryIntervalSec 5
           $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
           if ($actual -ne $env:LLVM_MINGW_SHA256) {
             throw "Checksum mismatch for $url`n  expected $env:LLVM_MINGW_SHA256`n  actual   $actual"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $zip = Join-Path $env:RUNNER_TEMP 'llvm-mingw.zip'
           $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$env:LLVM_MINGW_VERSION/$env:LLVM_MINGW_NAME.zip"
-          Invoke-WebRequest -Uri $url -OutFile $zip
+          Invoke-WebRequest -Uri $url -OutFile $zip -MaximumRetryCount 3 -RetryIntervalSec 5
           $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
           if ($actual -ne $env:LLVM_MINGW_SHA256) {
             throw "Checksum mismatch for $url`n  expected $env:LLVM_MINGW_SHA256`n  actual   $actual"

--- a/document/openaihosted/client.go
+++ b/document/openaihosted/client.go
@@ -1,0 +1,221 @@
+package openaihosted
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	maxSecretBytes      = 64 << 10
+	unitLengthTolerance = 1e-4
+)
+
+var _ document.EmbeddingProvider = (*Client)(nil)
+
+type wireRequest struct {
+	Input          []string `json:"input"`
+	Model          string   `json:"model"`
+	Dimensions     int      `json:"dimensions"`
+	EncodingFormat string   `json:"encoding_format"`
+}
+
+type wireResponse struct {
+	Object string          `json:"object"`
+	Data   []wireEmbedding `json:"data"`
+	Model  string          `json:"model"`
+	Usage  *wireUsage      `json:"usage"`
+}
+
+type wireEmbedding struct {
+	Object    string    `json:"object"`
+	Embedding []float32 `json:"embedding"`
+	Index     *int      `json:"index"`
+}
+
+type wireUsage struct {
+	PromptTokens *int64 `json:"prompt_tokens"`
+	TotalTokens  *int64 `json:"total_tokens"`
+}
+
+// Embed sends one bounded text-only request to the fixed hosted endpoint.
+func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	if client == nil || ctx == nil {
+		return document.EmbeddingResult{}, errors.New("openaihosted: client and context are required")
+	}
+	if err := document.ValidateEmbeddingProviderRequest(client, inputs, authorization); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if authorization.MaxBatchItems > client.profile.MaxBatchItems || authorization.MaxInputBytes > client.profile.MaxInputBytes ||
+		authorization.MaxResponseBytes > client.profile.MaxResponseBytes {
+		return document.EmbeddingResult{}, errors.New("openaihosted: embedding authorization exceeds profile capacity")
+	}
+	rendered := make([]string, len(inputs))
+	var total int64
+	for index, input := range inputs {
+		if input.Role == document.EmbeddingRoleDocument {
+			rendered[index] = client.descriptor.ModelInput.EncodeDocument(input.Text)
+		} else {
+			rendered[index] = client.descriptor.ModelInput.EncodeQuery(input.Text)
+		}
+		length := int64(len(rendered[index]))
+		if length > client.profile.MaxInputItemBytes {
+			return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse}
+		}
+		if length > client.profile.MaxInputBytes-total {
+			return document.EmbeddingResult{}, &ProviderError{Kind: ErrCapacityResponse}
+		}
+		total += length
+	}
+	payload, err := json.Marshal(wireRequest{Input: rendered, Model: Model, Dimensions: client.descriptor.Dimension, EncodingFormat: "float"})
+	if err != nil {
+		return document.EmbeddingResult{}, errors.New("openaihosted: request encoding failed")
+	}
+	if int64(len(payload)) > client.profile.MaxRequestBytes {
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrCapacityResponse}
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
+	defer cancel()
+	secret, err := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
+	if err != nil || !validSecret(secret) {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, fmt.Errorf("openaihosted: credential resolution canceled: %w", contextErr)
+		}
+		if requestCtx.Err() != nil {
+			return document.EmbeddingResult{}, &ProviderError{Kind: ErrTransientResponse}
+		}
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrUnauthorized}
+	}
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodPost, origin+embeddingsPath, bytes.NewReader(payload))
+	if err != nil {
+		return document.EmbeddingResult{}, errors.New("openaihosted: request construction failed")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+secret)
+	response, err := client.http.Do(request)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return document.EmbeddingResult{}, fmt.Errorf("openaihosted: request canceled: %w", contextErr)
+		}
+		if errors.Is(err, providerhttp.ErrCertificatePin) || errors.Is(err, providerhttp.ErrDestinationDenied) ||
+			errors.Is(err, providerhttp.ErrAddressDenied) {
+			return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse}
+		}
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrTransientResponse}
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return document.EmbeddingResult{}, statusError(response.StatusCode, response.Header.Get("Retry-After"), time.Now().UTC())
+	}
+	if err := requireJSONContentType(response.Header.Get("Content-Type")); err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	body, err := readBounded(ctx, response.Body, client.profile.MaxResponseBytes)
+	if err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	var decoded wireResponse
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	result, err := client.validateAndOrder(decoded, inputs)
+	if err != nil {
+		return document.EmbeddingResult{}, err
+	}
+	if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	return result, nil
+}
+
+func (client *Client) validateAndOrder(response wireResponse, inputs []document.EmbeddingInput) (document.EmbeddingResult, error) {
+	if response.Object != "list" || response.Model != Model || response.Usage == nil ||
+		response.Usage.PromptTokens == nil || response.Usage.TotalTokens == nil ||
+		*response.Usage.PromptTokens < 0 || *response.Usage.TotalTokens < *response.Usage.PromptTokens || len(response.Data) != len(inputs) {
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	vectors := make([]document.EmbeddingVector, len(inputs))
+	seen := make([]bool, len(inputs))
+	for _, item := range response.Data {
+		if item.Object != "embedding" || item.Index == nil || *item.Index < 0 || *item.Index >= len(inputs) || seen[*item.Index] {
+			return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse}
+		}
+		if err := client.validateVector(item.Embedding); err != nil {
+			return document.EmbeddingResult{}, err
+		}
+		seen[*item.Index] = true
+		vectors[*item.Index] = document.EmbeddingVector{Key: inputs[*item.Index].Key, Values: slices.Clone(item.Embedding)}
+	}
+	if slices.Contains(seen, false) {
+		return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	return document.EmbeddingResult{Vectors: vectors}, nil
+}
+
+func (client *Client) validateVector(vector []float32) error {
+	if len(vector) != client.descriptor.Dimension {
+		return &ProviderError{Kind: ErrPermanentResponse}
+	}
+	var norm float64
+	for _, value := range vector {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return &ProviderError{Kind: ErrPermanentResponse}
+		}
+		norm += float64(value) * float64(value)
+	}
+	if math.Abs(norm-1) > unitLengthTolerance {
+		return &ProviderError{Kind: ErrPermanentResponse}
+	}
+	return nil
+}
+
+func validSecret(value string) bool {
+	return value != "" && len(value) <= maxSecretBytes && utf8.ValidString(value) && strings.IndexFunc(value, func(character rune) bool {
+		return unicode.IsControl(character) || unicode.IsSpace(character)
+	}) < 0
+}
+
+func requireJSONContentType(value string) error {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || mediaType != "application/json" {
+		return &ProviderError{Kind: ErrPermanentResponse}
+	}
+	if len(parameters) == 0 {
+		return nil
+	}
+	charset, ok := parameters["charset"]
+	if len(parameters) != 1 || !ok || !strings.EqualFold(charset, "utf-8") {
+		return &ProviderError{Kind: ErrPermanentResponse}
+	}
+	return nil
+}
+
+func readBounded(ctx context.Context, reader io.Reader, maximum int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, fmt.Errorf("openaihosted: response read canceled: %w", contextErr)
+		}
+		return nil, &ProviderError{Kind: ErrTransientResponse}
+	}
+	if int64(len(body)) > maximum {
+		return nil, &ProviderError{Kind: ErrCapacityResponse}
+	}
+	return body, nil
+}

--- a/document/openaihosted/client_test.go
+++ b/document/openaihosted/client_test.go
@@ -1,0 +1,383 @@
+package openaihosted
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+func TestEmbedRejectsStrictHostedResponseDrift(t *testing.T) {
+	valid := `{"object":"list","data":[{"object":"embedding","embedding":[1,0,0],"index":0},{"object":"embedding","embedding":[0,1,0],"index":1}],"model":"text-embedding-3-large","usage":{"prompt_tokens":2,"total_tokens":2}}`
+	tests := map[string]string{
+		"root object":          strings.Replace(valid, `"object":"list"`, `"object":"collection"`, 1),
+		"item object":          strings.Replace(valid, `"object":"embedding"`, `"object":"vector"`, 1),
+		"model echo":           strings.Replace(valid, Model, "text-embedding-3-small", 1),
+		"usage missing":        strings.Replace(valid, `,"usage":{"prompt_tokens":2,"total_tokens":2}`, "", 1),
+		"prompt usage missing": strings.Replace(valid, `"prompt_tokens":2,`, "", 1),
+		"total usage missing":  strings.Replace(valid, `,"total_tokens":2`, "", 1),
+		"usage negative":       strings.Replace(valid, `"prompt_tokens":2`, `"prompt_tokens":-1`, 1),
+		"usage inconsistent":   strings.Replace(valid, `"total_tokens":2`, `"total_tokens":1`, 1),
+		"missing index":        strings.Replace(valid, `,"index":0`, "", 1),
+		"duplicate index":      strings.Replace(valid, `"index":1`, `"index":0`, 1),
+		"outside index":        strings.Replace(valid, `"index":1`, `"index":2`, 1),
+		"missing vector":       strings.Replace(valid, `,{"object":"embedding","embedding":[0,1,0],"index":1}`, "", 1),
+		"extra vector":         strings.Replace(valid, `],"model"`, `,{"object":"embedding","embedding":[0,0,1],"index":2}],"model"`, 1),
+		"wrong dimension":      strings.Replace(valid, `[1,0,0]`, `[1,0]`, 1),
+		"non finite":           strings.Replace(valid, `[1,0,0]`, `[1e1000,0,0]`, 1),
+		"non unit":             strings.Replace(valid, `[1,0,0]`, `[1,1,0]`, 1),
+		"base64 vector":        strings.Replace(valid, `[1,0,0]`, `"AQID"`, 1),
+		"unknown root":         strings.Replace(valid, `"usage":`, `"future":true,"usage":`, 1),
+		"unknown item":         strings.Replace(valid, `"index":0`, `"future":true,"index":0`, 1),
+		"unknown usage":        strings.Replace(valid, `"prompt_tokens":2`, `"future":true,"prompt_tokens":2`, 1),
+		"duplicate member":     strings.Replace(valid, `"object":"list"`, `"object":"list","object":"list"`, 1),
+		"trailing JSON":        valid + `{}`,
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := hostedClientReturning(t, http.StatusOK, "application/json", body)
+			_, err := client.Embed(context.Background(), twoHostedInputs(), hostedAuthorization(client.descriptor, 2))
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrPermanentResponse)
+			assert.NotContains(t, err.Error(), "alpha")
+			assert.NotContains(t, err.Error(), "AQID")
+		})
+	}
+
+	client := hostedClientReturning(t, http.StatusOK, "text/plain", valid)
+	_, err := client.Embed(context.Background(), twoHostedInputs(), hostedAuthorization(client.descriptor, 2))
+	require.ErrorIs(t, err, ErrPermanentResponse)
+}
+
+func TestEmbedEnforcesItemTotalRequestResponseAndBatchBounds(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutateProfile func(*Profile)
+		inputs        []document.EmbeddingInput
+		authorization func(document.EmbeddingDescriptor) document.EmbeddingAuthorization
+		response      string
+		wantRequest   bool
+		want          error
+	}{
+		{
+			name: "per item", mutateProfile: func(profile *Profile) { profile.MaxInputItemBytes = 10 },
+			inputs: []document.EmbeddingInput{{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "xx"}},
+			want:   ErrPermanentResponse,
+		},
+		{
+			name: "total input", mutateProfile: func(profile *Profile) { profile.MaxInputItemBytes = 10; profile.MaxInputBytes = 15 },
+			inputs: []document.EmbeddingInput{
+				{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "a"},
+				{Key: "second", Role: document.EmbeddingRoleQuery, Kind: document.EmbeddingInputQueryText, Text: "b"},
+			},
+		},
+		{
+			name: "request bytes", mutateProfile: func(profile *Profile) { profile.MaxRequestBytes = 64 },
+			inputs: []document.EmbeddingInput{{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "a"}},
+			want:   ErrCapacityResponse,
+		},
+		{
+			name: "batch", mutateProfile: func(profile *Profile) { profile.MaxBatchItems = 1 },
+			inputs: twoHostedInputs(),
+		},
+		{
+			name: "response bytes", mutateProfile: func(profile *Profile) { profile.MaxResponseBytes = 64 },
+			inputs: []document.EmbeddingInput{{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "a"}},
+			authorization: func(descriptor document.EmbeddingDescriptor) document.EmbeddingAuthorization {
+				authorization := hostedAuthorization(descriptor, 1)
+				authorization.MaxResponseBytes = 64
+				return authorization
+			},
+			response: strings.Repeat("x", 65), wantRequest: true,
+			want: ErrCapacityResponse,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile := hostedTestProfile(t)
+			test.mutateProfile(&profile)
+			profile.Descriptor = hostedDescriptorFor(t, profile)
+			var requests atomic.Int32
+			client := newHostedTestClient(t, profile, hostedSecrets{"secret:openai": "sk-synthetic"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				requests.Add(1)
+				return hostedJSONResponse(request, http.StatusOK, test.response), nil
+			}))
+			authorization := hostedAuthorization(client.descriptor, len(test.inputs))
+			authorization.MaxInputBytes = profile.MaxInputBytes
+			authorization.MaxResponseBytes = profile.MaxResponseBytes
+			if test.authorization != nil {
+				authorization = test.authorization(client.descriptor)
+			}
+			_, err := client.Embed(context.Background(), test.inputs, authorization)
+			require.Error(t, err)
+			if test.want != nil {
+				require.ErrorIs(t, err, test.want)
+			} else {
+				require.NotErrorIs(t, err, ErrCapacityResponse)
+			}
+			if test.wantRequest {
+				assert.Equal(t, int32(1), requests.Load())
+			} else {
+				assert.Zero(t, requests.Load())
+			}
+		})
+	}
+}
+
+func TestEmbedRejectsAuthorizationBeyondProfile(t *testing.T) {
+	for name, expand := range map[string]func(*document.EmbeddingAuthorization){
+		"batch":    func(value *document.EmbeddingAuthorization) { value.MaxBatchItems++ },
+		"input":    func(value *document.EmbeddingAuthorization) { value.MaxInputBytes++ },
+		"response": func(value *document.EmbeddingAuthorization) { value.MaxResponseBytes++ },
+	} {
+		t.Run(name, func(t *testing.T) {
+			profile := hostedTestProfile(t)
+			client := newHostedTestClient(t, profile, hostedSecrets{"secret:openai": "sk-synthetic"}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("invalid authorization reached the provider")
+				return nil, errors.New("unexpected provider request")
+			}))
+			authorization := hostedAuthorization(client.descriptor, profile.MaxBatchItems)
+			authorization.MaxInputBytes = profile.MaxInputBytes
+			authorization.MaxResponseBytes = profile.MaxResponseBytes
+			expand(&authorization)
+			_, err := client.Embed(context.Background(), oneHostedInput(), authorization)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, ErrCapacityResponse)
+		})
+	}
+}
+
+func TestEmbedRequiresValidNamedAPIKeyWithoutLeakingResolverDetails(t *testing.T) {
+	profile := hostedTestProfile(t)
+	tests := map[string]SecretResolver{
+		"empty":         hostedSecrets{"secret:openai": ""},
+		"whitespace":    hostedSecrets{"secret:openai": "sk synthetic"},
+		"control":       hostedSecrets{"secret:openai": "sk-synthetic\nPRIVATE"},
+		"invalid UTF-8": hostedSecrets{"secret:openai": string([]byte{'s', 'k', '-', 0xff})},
+		"resolver": secretResolverFunc(func(context.Context, string) (string, error) {
+			return "", errors.New("PRIVATE_RESOLVER_DETAIL")
+		}),
+	}
+	for name, resolver := range tests {
+		t.Run(name, func(t *testing.T) {
+			var requests atomic.Int32
+			client := newHostedTestClient(t, profile, resolver, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				requests.Add(1)
+				return hostedJSONResponse(request, http.StatusInternalServerError, "PRIVATE_BODY"), nil
+			}))
+			_, err := client.Embed(context.Background(), oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+			require.ErrorIs(t, err, ErrUnauthorized)
+			assert.Zero(t, requests.Load())
+			assert.NotContains(t, err.Error(), "PRIVATE")
+			assert.NotContains(t, err.Error(), "synthetic")
+		})
+	}
+}
+
+func TestEmbedClassifiesHTTPAndTransportFailuresWithoutLeakingBodies(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		retryAfter string
+		want       error
+		delay      time.Duration
+		delaySet   bool
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized, want: ErrUnauthorized},
+		{name: "forbidden", status: http.StatusForbidden, want: ErrUnauthorized},
+		{name: "request timeout", status: http.StatusRequestTimeout, want: ErrTransientResponse},
+		{name: "rate limit", status: http.StatusTooManyRequests, retryAfter: "7200", want: ErrTransientResponse, delay: time.Hour, delaySet: true},
+		{name: "server", status: http.StatusInternalServerError, want: ErrTransientResponse},
+		{name: "capacity", status: http.StatusRequestEntityTooLarge, want: ErrCapacityResponse},
+		{name: "permanent", status: http.StatusBadRequest, want: ErrPermanentResponse},
+		{name: "redirect", status: http.StatusTemporaryRedirect, want: ErrPermanentResponse},
+		{name: "nonstandard 600", status: 600, want: ErrPermanentResponse},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile := hostedTestProfile(t)
+			client := newHostedTestClient(t, profile, hostedSecrets{"secret:openai": "sk-PRIVATE"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				response := hostedJSONResponse(request, test.status, "PRIVATE_PROVIDER_BODY")
+				response.Header.Set("Retry-After", test.retryAfter)
+				if test.status == http.StatusTemporaryRedirect {
+					response.Header.Set("Location", "https://example.com/steal")
+				}
+				return response, nil
+			}))
+			_, err := client.Embed(context.Background(), oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+			require.ErrorIs(t, err, test.want)
+			assert.NotContains(t, err.Error(), "PRIVATE")
+			delay, set := RetryAfter(err)
+			assert.Equal(t, test.delaySet, set)
+			assert.Equal(t, test.delay, delay)
+		})
+	}
+
+	transportErr := errors.New("PRIVATE_TRANSPORT_DETAIL")
+	client := newHostedTestClient(t, hostedTestProfile(t), hostedSecrets{"secret:openai": "sk-PRIVATE"}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, transportErr
+	}))
+	_, err := client.Embed(context.Background(), oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+	require.ErrorIs(t, err, ErrTransientResponse)
+	assert.NotContains(t, err.Error(), "PRIVATE")
+
+	client = newHostedTestClient(t, hostedTestProfile(t), hostedSecrets{"secret:openai": "sk-PRIVATE"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+			Body: &failingBody{err: errors.New("PRIVATE_RESPONSE_READ_DETAIL")}, Request: request,
+		}, nil
+	}))
+	_, err = client.Embed(context.Background(), oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+	require.ErrorIs(t, err, ErrTransientResponse)
+	assert.NotContains(t, err.Error(), "PRIVATE")
+}
+
+func TestEmbedClassifiesSealedPolicyFailuresAsPermanent(t *testing.T) {
+	for _, policyErr := range []error{providerhttp.ErrAddressDenied, providerhttp.ErrCertificatePin, providerhttp.ErrDestinationDenied} {
+		t.Run(policyErr.Error(), func(t *testing.T) {
+			client := newHostedTestClient(t, hostedTestProfile(t), hostedSecrets{"secret:openai": "sk-synthetic"}, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("PRIVATE_TRANSPORT_DETAIL: %w", policyErr)
+			}))
+			_, err := client.Embed(context.Background(), oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+			require.ErrorIs(t, err, ErrPermanentResponse)
+			require.NotErrorIs(t, err, ErrTransientResponse)
+			assert.NotContains(t, err.Error(), "PRIVATE")
+		})
+	}
+}
+
+func TestEmbedDistinguishesRequestTimeoutFromCallerCancellation(t *testing.T) {
+	for _, phase := range []string{"credential", "request", "response"} {
+		for _, cause := range []string{"request timeout", "caller deadline", "caller cancellation"} {
+			t.Run(phase+"/"+cause, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if cause == "caller deadline" {
+						var cancelDeadline context.CancelFunc
+						ctx, cancelDeadline = context.WithTimeout(ctx, time.Millisecond)
+						defer cancelDeadline()
+					}
+					waitForContext := func(requestCtx context.Context) error {
+						if cause == "caller cancellation" {
+							cancel()
+						}
+						<-requestCtx.Done()
+						return requestCtx.Err()
+					}
+					secrets := secretResolverFunc(func(requestCtx context.Context, _ string) (string, error) {
+						if phase == "credential" {
+							return "", waitForContext(requestCtx)
+						}
+						return "sk-synthetic", nil
+					})
+					var bodyDone chan struct{}
+					client := newHostedTestClient(t, hostedTestProfile(t), secrets, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+						if phase == "request" {
+							return nil, waitForContext(request.Context())
+						}
+						reader, writer := io.Pipe()
+						bodyDone = make(chan struct{})
+						go func() {
+							defer close(bodyDone)
+							_ = writer.CloseWithError(waitForContext(request.Context()))
+						}()
+						response := hostedJSONResponse(request, http.StatusOK, "")
+						response.Body = reader
+						return response, nil
+					}))
+					_, err := client.Embed(ctx, oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+					if bodyDone != nil {
+						<-bodyDone
+					}
+					switch cause {
+					case "request timeout":
+						require.ErrorIs(t, err, ErrTransientResponse)
+						require.NoError(t, ctx.Err())
+					case "caller deadline":
+						require.ErrorIs(t, err, context.DeadlineExceeded)
+						require.NotErrorIs(t, err, ErrTransientResponse)
+					case "caller cancellation":
+						require.ErrorIs(t, err, context.Canceled)
+						require.NotErrorIs(t, err, ErrTransientResponse)
+					}
+				})
+			})
+		}
+	}
+}
+
+func TestEmbedPreservesCancellationAndRefusesRedirectReplay(t *testing.T) {
+	started := make(chan struct{})
+	client := newHostedTestClient(t, hostedTestProfile(t), hostedSecrets{"secret:openai": "sk-synthetic"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		close(started)
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Embed(ctx, oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+		done <- err
+	}()
+	<-started
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+
+	var calls atomic.Int32
+	client = newHostedTestClient(t, hostedTestProfile(t), hostedSecrets{"secret:openai": "sk-synthetic"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusTemporaryRedirect,
+			Header:     http.Header{"Location": []string{"https://example.com/steal"}},
+			Body:       io.NopCloser(strings.NewReader("PRIVATE_REDIRECT_BODY")), Request: request,
+		}, nil
+	}))
+	_, err := client.Embed(context.Background(), oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+	require.ErrorIs(t, err, ErrPermanentResponse)
+	assert.Equal(t, int32(1), calls.Load())
+	assert.NotContains(t, err.Error(), "PRIVATE")
+}
+
+func hostedClientReturning(t *testing.T, status int, mediaType, body string) *Client {
+	t.Helper()
+	return newHostedTestClient(t, hostedTestProfile(t), hostedSecrets{"secret:openai": "sk-synthetic"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		response := hostedJSONResponse(request, status, body)
+		response.Header.Set("Content-Type", mediaType)
+		return response, nil
+	}))
+}
+
+func oneHostedInput() []document.EmbeddingInput {
+	return []document.EmbeddingInput{{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "alpha"}}
+}
+
+func twoHostedInputs() []document.EmbeddingInput {
+	return []document.EmbeddingInput{
+		{Key: "first", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "alpha"},
+		{Key: "second", Role: document.EmbeddingRoleQuery, Kind: document.EmbeddingInputQueryText, Text: "beta"},
+	}
+}
+
+type secretResolverFunc func(context.Context, string) (string, error)
+
+func (resolver secretResolverFunc) ResolveSecret(ctx context.Context, binding string) (string, error) {
+	return resolver(ctx, binding)
+}
+
+type failingBody struct{ err error }
+
+func (body *failingBody) Read([]byte) (int, error) { return 0, body.err }
+
+func (*failingBody) Close() error { return nil }

--- a/document/openaihosted/errors.go
+++ b/document/openaihosted/errors.go
@@ -1,0 +1,76 @@
+package openaihosted
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	// ErrUnauthorized identifies an unavailable or rejected API key.
+	ErrUnauthorized = errors.New("openaihosted: credential is unavailable or unauthorized")
+	// ErrTransientResponse identifies retryable transport, 408, 429, and 5xx failures.
+	ErrTransientResponse = errors.New("openaihosted: transient provider response")
+	// ErrCapacityResponse identifies request or response capacity failures.
+	ErrCapacityResponse = errors.New("openaihosted: provider capacity exceeded")
+	// ErrPermanentResponse identifies non-retryable provider or schema failures.
+	ErrPermanentResponse = errors.New("openaihosted: permanent provider response")
+)
+
+// ProviderError contains only stable classification and bounded retry metadata.
+type ProviderError struct {
+	Kind       error
+	StatusCode int
+	RetryDelay time.Duration
+	RetrySet   bool
+}
+
+func (err *ProviderError) Error() string {
+	if err.StatusCode != 0 {
+		return fmt.Sprintf("openaihosted: HTTP %d: %v", err.StatusCode, err.Kind)
+	}
+	return err.Kind.Error()
+}
+
+func (err *ProviderError) Unwrap() error { return err.Kind }
+
+// RetryAfter returns bounded provider retry guidance when one was valid.
+func RetryAfter(err error) (time.Duration, bool) {
+	providerErr, ok := errors.AsType[*ProviderError](err)
+	if !ok || !providerErr.RetrySet {
+		return 0, false
+	}
+	return providerErr.RetryDelay, true
+}
+
+func statusError(status int, retryAfter string, now time.Time) error {
+	switch {
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return &ProviderError{Kind: ErrUnauthorized, StatusCode: status}
+	case status == http.StatusRequestEntityTooLarge:
+		return &ProviderError{Kind: ErrCapacityResponse, StatusCode: status}
+	case status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= 500 && status <= 599:
+		delay, set := parseRetryAfter(retryAfter, now)
+		return &ProviderError{Kind: ErrTransientResponse, StatusCode: status, RetryDelay: delay, RetrySet: set}
+	default:
+		return &ProviderError{Kind: ErrPermanentResponse, StatusCode: status}
+	}
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+		if seconds >= int64(time.Hour/time.Second) {
+			return time.Hour, true
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	return min(max(when.Sub(now), 0), time.Hour), true
+}

--- a/document/openaihosted/profile.go
+++ b/document/openaihosted/profile.go
@@ -1,0 +1,324 @@
+// Package openaihosted implements the fixed hosted OpenAI embeddings contract.
+package openaihosted
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"net/http"
+	"net/netip"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	// ProviderID is the fixed E1 adapter identity for hosted OpenAI embeddings.
+	ProviderID = "openai.hosted.text-embedding-3-large-v1"
+	// Model is the only currently documented hosted model alias admitted here.
+	Model = "text-embedding-3-large"
+	// DocumentFormatterV1 identifies the document rendering path.
+	DocumentFormatterV1 = "openai-hosted/document/v1"
+	// QueryFormatterV1 identifies the query rendering path.
+	QueryFormatterV1 = "openai-hosted/query/v1"
+	// ScalarEncodingFloat32 is the only response representation admitted here.
+	ScalarEncodingFloat32 = "float32"
+
+	host              = "api.openai.com"
+	origin            = "https://api.openai.com"
+	embeddingsPath    = "/v1/embeddings"
+	adapterContract   = "docbank-openai-hosted-embeddings/v1"
+	defaultTimeout    = 30 * time.Second
+	defaultBatch      = 128
+	defaultItemBytes  = int64(1 << 20)
+	defaultInputBytes = int64(16 << 20)
+	defaultRequest    = int64(32 << 20)
+	defaultResponse   = int64(64 << 20)
+	maximumTimeout    = 5 * time.Minute
+	maximumBatch      = 2_048
+	maximumDimension  = 3_072
+	maximumBytes      = int64(1 << 30)
+	maximumTokenBytes = 128
+)
+
+// SecretResolver resolves only the configured named OpenAI API-key binding.
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, binding string) (string, error)
+}
+
+// Profile freezes the exact hosted contract and its execution bounds.
+// Zero limits use a 128-item batch and a 64 MiB response budget. Larger batches
+// or dimensions may require a larger MaxResponseBytes, which bounds encoded
+// JSON including number text and metadata.
+type Profile struct {
+	Descriptor         document.EmbeddingDescriptor
+	CompatibilityEpoch string
+	SecretBinding      string
+	RequestTimeout     time.Duration
+	MaxBatchItems      int
+	MaxInputItemBytes  int64
+	MaxInputBytes      int64
+	MaxRequestBytes    int64
+	MaxResponseBytes   int64
+	EgressPolicy       providerhttp.EgressPolicy
+}
+
+// Client calls only the fixed hosted OpenAI embeddings endpoint.
+type Client struct {
+	profile    Profile
+	descriptor document.EmbeddingDescriptor
+	secrets    SecretResolver
+	http       *http.Client
+}
+
+type policyIdentity struct {
+	AdapterContract    string                       `json:"adapter_contract"`
+	Origin             string                       `json:"origin"`
+	Route              string                       `json:"route"`
+	Descriptor         document.EmbeddingDescriptor `json:"descriptor"`
+	CompatibilityEpoch string                       `json:"compatibility_epoch"`
+	SecretBinding      string                       `json:"secret_binding"`
+	RequestTimeout     int64                        `json:"request_timeout_nanos"`
+	MaxBatchItems      int                          `json:"max_batch_items"`
+	MaxInputItemBytes  int64                        `json:"max_input_item_bytes"`
+	MaxInputBytes      int64                        `json:"max_input_bytes"`
+	MaxRequestBytes    int64                        `json:"max_request_bytes"`
+	MaxResponseBytes   int64                        `json:"max_response_bytes"`
+	Egress             egressIdentity               `json:"egress"`
+}
+
+type egressIdentity struct {
+	Scheme              string   `json:"scheme"`
+	Host                string   `json:"host"`
+	Port                uint16   `json:"port"`
+	AllowedCIDRs        []string `json:"allowed_cidrs"`
+	ProxyMode           string   `json:"proxy_mode"`
+	ConnectTimeout      int64    `json:"connect_timeout_nanos"`
+	KeepAlive           int64    `json:"keep_alive_nanos"`
+	TLSHandshakeTimeout int64    `json:"tls_handshake_timeout_nanos"`
+	SPKISHA256          []string `json:"spki_sha256,omitempty"`
+}
+
+// PolicyFingerprint returns the canonical hosted profile identity.
+func PolicyFingerprint(profile Profile) (string, error) {
+	normalized, descriptorIdentity, err := normalizeProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(policyIdentity{
+		AdapterContract: adapterContract, Origin: origin, Route: embeddingsPath,
+		Descriptor: descriptorIdentity, CompatibilityEpoch: normalized.CompatibilityEpoch,
+		SecretBinding: normalized.SecretBinding, RequestTimeout: int64(normalized.RequestTimeout),
+		MaxBatchItems: normalized.MaxBatchItems, MaxInputItemBytes: normalized.MaxInputItemBytes,
+		MaxInputBytes: normalized.MaxInputBytes, MaxRequestBytes: normalized.MaxRequestBytes,
+		MaxResponseBytes: normalized.MaxResponseBytes, Egress: profileEgressIdentity(normalized.EgressPolicy),
+	}, json.Deterministic(true))
+	if err != nil {
+		return "", errors.New("openaihosted: policy identity encoding failed")
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// New validates the fixed hosted profile and replaces every supplied transport
+// authority with the sealed provider HTTP transport.
+func New(profile Profile, secrets SecretResolver, resolver providerhttp.Resolver, supplied *http.Client) (*Client, error) {
+	if supplied == nil {
+		return nil, errors.New("openaihosted: HTTP client settings source is required")
+	}
+	normalized, _, err := normalizeProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		return nil, errors.New("openaihosted: descriptor is not canonical")
+	}
+	fingerprint, err := PolicyFingerprint(profile)
+	if err != nil {
+		return nil, err
+	}
+	if descriptor.PolicyFingerprint != fingerprint {
+		return nil, errors.New("openaihosted: descriptor policy fingerprint does not match profile")
+	}
+	if nilInterface(secrets) {
+		return nil, errors.New("openaihosted: named API-key resolver is required")
+	}
+	transport, err := providerhttp.NewTransport(normalized.EgressPolicy, resolver)
+	if err != nil {
+		return nil, errors.New("openaihosted: sealed egress policy is invalid")
+	}
+	isolated := *supplied
+	isolated.Transport = transport
+	isolated.CheckRedirect = providerhttp.RefuseRedirects
+	isolated.Jar = nil
+	isolated.Timeout = 0
+	normalized.Descriptor = cloneDescriptor(descriptor)
+	return &Client{profile: normalized, descriptor: cloneDescriptor(descriptor), secrets: secrets, http: &isolated}, nil
+}
+
+// Descriptor returns an immutable copy of the exact vector-space contract.
+func (client *Client) Descriptor() document.EmbeddingDescriptor {
+	if client == nil {
+		return document.EmbeddingDescriptor{}
+	}
+	return cloneDescriptor(client.descriptor)
+}
+
+func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, error) {
+	profile.EgressPolicy.AllowedCIDRs = slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	profile.EgressPolicy.TLS.SPKISHA256 = slices.Clone(profile.EgressPolicy.TLS.SPKISHA256)
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = defaultTimeout
+	}
+	if profile.MaxBatchItems == 0 {
+		profile.MaxBatchItems = defaultBatch
+	}
+	if profile.MaxInputItemBytes == 0 {
+		profile.MaxInputItemBytes = defaultItemBytes
+	}
+	if profile.MaxInputBytes == 0 {
+		profile.MaxInputBytes = defaultInputBytes
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = defaultRequest
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = defaultResponse
+	}
+	if profile.RequestTimeout <= 0 || profile.RequestTimeout > maximumTimeout ||
+		profile.MaxBatchItems < 1 || profile.MaxBatchItems > maximumBatch ||
+		profile.MaxInputItemBytes < 1 || profile.MaxInputItemBytes > maximumBytes ||
+		profile.MaxInputBytes < profile.MaxInputItemBytes || profile.MaxInputBytes > maximumBytes ||
+		profile.MaxRequestBytes < 1 || profile.MaxRequestBytes > maximumBytes ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maximumBytes {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaihosted: execution bounds are invalid")
+	}
+	if !validToken(profile.CompatibilityEpoch) || profile.Descriptor.ModelRevision != profile.CompatibilityEpoch {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaihosted: compatibility epoch must exactly match descriptor model revision")
+	}
+	if !validToken(profile.SecretBinding) {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaihosted: named API-key binding is required")
+	}
+	if err := normalizeEgress(&profile.EgressPolicy); err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
+	descriptorIdentity := cloneDescriptor(profile.Descriptor)
+	descriptorIdentity.PolicyFingerprint = strings.Repeat("0", sha256.Size*2)
+	descriptorIdentity.Fingerprint = ""
+	var err error
+	descriptorIdentity, err = document.NewEmbeddingDescriptor(descriptorIdentity)
+	if err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaihosted: descriptor identity is invalid")
+	}
+	descriptorIdentity.PolicyFingerprint = ""
+	descriptorIdentity.Fingerprint = ""
+	if err := validateDescriptorContract(descriptorIdentity, profile.CompatibilityEpoch); err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
+	return profile, descriptorIdentity, nil
+}
+
+func validateDescriptorContract(descriptor document.EmbeddingDescriptor, epoch string) error {
+	if descriptor.ID != ProviderID || descriptor.ContractVersion != document.EmbeddingProviderContractVersion ||
+		descriptor.TrustBoundary != document.EmbeddingTrustHostedProvider || descriptor.Model != Model ||
+		descriptor.ModelRevision != epoch || descriptor.Dimension < 1 || descriptor.Dimension > maximumDimension ||
+		descriptor.Metric != document.VectorMetricCosine ||
+		descriptor.Normalization != document.VectorNormalizationUnitLength || descriptor.ScalarEncoding != ScalarEncodingFloat32 ||
+		descriptor.DocumentFormatter != DocumentFormatterV1 || descriptor.QueryFormatter != QueryFormatterV1 ||
+		!descriptor.SupportsTextQuery || !slices.Equal(descriptor.InputKinds, []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}) ||
+		!slices.Equal(descriptor.SupportedRequestModes, []document.ModelInputMode{document.ModelInputModeText}) ||
+		descriptor.ModelInput.Document.Mode != document.ModelInputModeText || descriptor.ModelInput.Query.Mode != document.ModelInputModeText ||
+		descriptor.CompatibilityID != descriptor.ModelInput.CompatibilityID {
+		return errors.New("openaihosted: descriptor does not match the fixed hosted text contract")
+	}
+	return nil
+}
+
+func normalizeEgress(policy *providerhttp.EgressPolicy) error {
+	if policy.ConnectTimeout == 0 {
+		policy.ConnectTimeout = providerhttp.DefaultConnectTimeout
+	}
+	if policy.KeepAlive == 0 {
+		policy.KeepAlive = providerhttp.DefaultKeepAlive
+	}
+	if policy.TLSHandshakeTimeout == 0 {
+		policy.TLSHandshakeTimeout = providerhttp.DefaultTLSHandshakeTimeout
+	}
+	if policy.ProxyMode == "" {
+		policy.ProxyMode = providerhttp.ProxyDisabled
+	}
+	if policy.Scheme != "https" || policy.Host != host || policy.Port != 443 ||
+		policy.ProxyMode != providerhttp.ProxyDisabled || policy.TLS.RootCAs != nil {
+		return errors.New("openaihosted: egress authority must be exactly api.openai.com:443 with system roots and no proxy")
+	}
+	for index := range policy.AllowedCIDRs {
+		policy.AllowedCIDRs[index] = policy.AllowedCIDRs[index].Masked()
+	}
+	slices.SortFunc(policy.AllowedCIDRs, func(left, right netip.Prefix) int {
+		return strings.Compare(left.String(), right.String())
+	})
+	for index := 1; index < len(policy.AllowedCIDRs); index++ {
+		if policy.AllowedCIDRs[index] == policy.AllowedCIDRs[index-1] {
+			return errors.New("openaihosted: egress policy has a duplicate CIDR")
+		}
+	}
+	for index := range policy.TLS.SPKISHA256 {
+		policy.TLS.SPKISHA256[index] = strings.ToLower(policy.TLS.SPKISHA256[index])
+	}
+	slices.Sort(policy.TLS.SPKISHA256)
+	for index := 1; index < len(policy.TLS.SPKISHA256); index++ {
+		if policy.TLS.SPKISHA256[index] == policy.TLS.SPKISHA256[index-1] {
+			return errors.New("openaihosted: egress policy has a duplicate SPKI pin")
+		}
+	}
+	if _, err := providerhttp.NewTransport(*policy, nil); err != nil {
+		return errors.New("openaihosted: sealed egress policy is invalid")
+	}
+	return nil
+}
+
+func profileEgressIdentity(policy providerhttp.EgressPolicy) egressIdentity {
+	cidrs := make([]string, len(policy.AllowedCIDRs))
+	for index, prefix := range policy.AllowedCIDRs {
+		cidrs[index] = prefix.String()
+	}
+	return egressIdentity{
+		Scheme: policy.Scheme, Host: policy.Host, Port: policy.Port, AllowedCIDRs: cidrs,
+		ProxyMode: string(policy.ProxyMode), ConnectTimeout: int64(policy.ConnectTimeout),
+		KeepAlive: int64(policy.KeepAlive), TLSHandshakeTimeout: int64(policy.TLSHandshakeTimeout),
+		SPKISHA256: slices.Clone(policy.TLS.SPKISHA256),
+	}
+}
+
+func validToken(value string) bool {
+	return value != "" && len(value) <= maximumTokenBytes && utf8.ValidString(value) && value == strings.TrimSpace(value) &&
+		strings.IndexFunc(value, func(character rune) bool { return unicode.IsControl(character) || unicode.IsSpace(character) }) < 0
+}
+
+func cloneDescriptor(value document.EmbeddingDescriptor) document.EmbeddingDescriptor {
+	value.InputKinds = slices.Clone(value.InputKinds)
+	value.SupportedRequestModes = slices.Clone(value.SupportedRequestModes)
+	return value
+}
+
+func nilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/document/openaihosted/profile_test.go
+++ b/document/openaihosted/profile_test.go
@@ -1,0 +1,333 @@
+package openaihosted
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net/http"
+	"net/netip"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+func TestNewRequiresTheFixedHostedDescriptorEpochAndCredential(t *testing.T) {
+	profile := hostedTestProfile(t)
+	resolver := hostedSecrets{"secret:openai": "sk-synthetic"}
+
+	client, err := New(profile, resolver, staticResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+	require.NoError(t, err)
+	assert.Equal(t, profile.Descriptor, client.Descriptor())
+
+	tests := map[string]func(*Profile){
+		"provider id":        func(value *Profile) { value.Descriptor.ID = "openai-compatible.embeddings-v1" },
+		"contract version":   func(value *Profile) { value.Descriptor.ContractVersion++ },
+		"hosted trust":       func(value *Profile) { value.Descriptor.TrustBoundary = document.EmbeddingTrustOperatorNetwork },
+		"fixed model":        func(value *Profile) { value.Descriptor.Model = "text-embedding-3-small" },
+		"positive dimension": func(value *Profile) { value.Descriptor.Dimension = 0 },
+		"metric":             func(value *Profile) { value.Descriptor.Metric = document.VectorMetricL2 },
+		"normalization":      func(value *Profile) { value.Descriptor.Normalization = document.VectorNormalizationNone },
+		"scalar":             func(value *Profile) { value.Descriptor.ScalarEncoding = "float64" },
+		"document formatter": func(value *Profile) { value.Descriptor.DocumentFormatter = "custom" },
+		"query formatter":    func(value *Profile) { value.Descriptor.QueryFormatter = "custom" },
+		"input kinds": func(value *Profile) {
+			value.Descriptor.InputKinds = []document.EmbeddingInputKind{document.EmbeddingInputOriginalFile}
+		},
+		"request modes": func(value *Profile) {
+			value.Descriptor.SupportedRequestModes = []document.ModelInputMode{document.ModelInputModeDocument}
+		},
+		"query support":      func(value *Profile) { value.Descriptor.SupportsTextQuery = false },
+		"compatibility":      func(value *Profile) { value.Descriptor.CompatibilityID = "forged-space" },
+		"revision epoch":     func(value *Profile) { value.Descriptor.ModelRevision = "different-epoch" },
+		"missing epoch":      func(value *Profile) { value.CompatibilityEpoch = "" },
+		"missing binding":    func(value *Profile) { value.SecretBinding = "" },
+		"whitespace binding": func(value *Profile) { value.SecretBinding = "secret: openai" },
+		"control binding":    func(value *Profile) { value.SecretBinding = "secret:openai\n" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			changed := hostedTestProfile(t)
+			changed.Descriptor.Fingerprint = ""
+			mutate(&changed)
+			_, err := PolicyFingerprint(changed)
+			require.Error(t, err, "the hosted contract must reject the profile independently of its stored fingerprint")
+			if changed.Descriptor.Dimension > 0 {
+				changed.Descriptor = canonicalDescriptorWithoutPolicyCheck(t, changed.Descriptor)
+			}
+			_, err = New(changed, resolver, staticResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+			require.Error(t, err)
+		})
+	}
+
+	_, err = New(profile, nil, staticResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+	require.Error(t, err, "a named API-key binding always requires a resolver")
+	_, err = New(profile, resolver, staticResolver{netip.MustParseAddr("192.0.2.10")}, nil)
+	require.Error(t, err, "the harmless client settings source is explicit")
+}
+
+func TestHostedDimensionBounds(t *testing.T) {
+	for _, dimension := range []int{1, 3072} {
+		profile := hostedTestProfile(t)
+		profile.Descriptor.Dimension = dimension
+		profile.Descriptor = hostedDescriptorFor(t, profile)
+		_, err := New(profile, hostedSecrets{"secret:openai": "sk-synthetic"}, nil, &http.Client{})
+		require.NoError(t, err)
+	}
+	profile := hostedTestProfile(t)
+	profile.Descriptor.Dimension = 3073
+	_, err := PolicyFingerprint(profile)
+	require.Error(t, err)
+}
+
+func TestHostedBatchLimitAccepts2048AndRejects2049BeforeRequestAuthority(t *testing.T) {
+	accepted := hostedTestProfile(t)
+	accepted.MaxBatchItems = 2048
+	accepted.Descriptor = hostedDescriptorFor(t, accepted)
+
+	_, err := New(accepted, hostedSecrets{"secret:openai": "sk-synthetic"}, staticResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+	require.NoError(t, err)
+
+	rejected := accepted
+	rejected.MaxBatchItems = 2049
+	_, _, err = normalizeProfile(rejected)
+	require.Error(t, err)
+}
+
+func TestPolicyFingerprintCoversFixedContractBoundsAndExactEgressWithoutMutatingCaller(t *testing.T) {
+	profile := hostedTestProfile(t)
+	originalCIDRs := slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	originalPins := slices.Clone(profile.EgressPolicy.TLS.SPKISHA256)
+	base, err := PolicyFingerprint(profile)
+	require.NoError(t, err)
+
+	mutations := map[string]func(*Profile){
+		"epoch": func(value *Profile) {
+			value.CompatibilityEpoch = "hosted-epoch-2"
+			value.Descriptor.ModelRevision = "hosted-epoch-2"
+		},
+		"secret binding": func(value *Profile) { value.SecretBinding = "secret:other" },
+		"dimension":      func(value *Profile) { value.Descriptor.Dimension++ },
+		"model input": func(value *Profile) {
+			contract, contractErr := document.NewModelInputContract(document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic})
+			require.NoError(t, contractErr)
+			value.Descriptor.ModelInput = contract
+			value.Descriptor.CompatibilityID = contract.CompatibilityID
+		},
+		"batch":       func(value *Profile) { value.MaxBatchItems++ },
+		"per item":    func(value *Profile) { value.MaxInputItemBytes++ },
+		"total input": func(value *Profile) { value.MaxInputBytes++ },
+		"request":     func(value *Profile) { value.MaxRequestBytes++ },
+		"response":    func(value *Profile) { value.MaxResponseBytes++ },
+		"timeout":     func(value *Profile) { value.RequestTimeout += time.Second },
+		"CIDR": func(value *Profile) {
+			value.EgressPolicy.AllowedCIDRs = []netip.Prefix{netip.MustParsePrefix("198.51.100.0/24")}
+		},
+		"SPKI": func(value *Profile) {
+			value.EgressPolicy.TLS.SPKISHA256 = []string{"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			changed := hostedTestProfile(t)
+			mutate(&changed)
+			fingerprint, fingerprintErr := PolicyFingerprint(changed)
+			require.NoError(t, fingerprintErr)
+			assert.NotEqual(t, base, fingerprint)
+		})
+	}
+	assert.Equal(t, originalCIDRs, profile.EgressPolicy.AllowedCIDRs)
+	assert.Equal(t, originalPins, profile.EgressPolicy.TLS.SPKISHA256)
+
+	invalid := hostedTestProfile(t)
+	invalid.EgressPolicy.Host = "example.com"
+	_, err = PolicyFingerprint(invalid)
+	require.Error(t, err)
+	invalid = hostedTestProfile(t)
+	invalid.EgressPolicy.Port = 8443
+	_, err = PolicyFingerprint(invalid)
+	require.Error(t, err)
+	invalid = hostedTestProfile(t)
+	invalid.EgressPolicy.TLS.RootCAs = x509.NewCertPool()
+	_, err = PolicyFingerprint(invalid)
+	require.Error(t, err, "custom roots expand hosted trust authority")
+}
+
+func TestNewReplacesCallerTransportJarRedirectAndTimeoutAuthority(t *testing.T) {
+	profile := hostedTestProfile(t)
+	originalCIDRs := slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	originalPins := slices.Clone(profile.EgressPolicy.TLS.SPKISHA256)
+	ambient := &countingTransport{}
+	client, err := New(profile, hostedSecrets{"secret:openai": "sk-synthetic"},
+		staticResolver{netip.MustParseAddr("203.0.113.7")},
+		&http.Client{Transport: ambient, CheckRedirect: func(*http.Request, []*http.Request) error { return nil }, Timeout: time.Hour})
+	require.NoError(t, err)
+	assert.Equal(t, originalCIDRs, profile.EgressPolicy.AllowedCIDRs)
+	assert.Equal(t, originalPins, profile.EgressPolicy.TLS.SPKISHA256)
+	assert.NotSame(t, ambient, client.http.Transport)
+	assert.Zero(t, client.http.Timeout)
+	assert.Nil(t, client.http.Jar)
+	require.NotNil(t, client.http.CheckRedirect)
+	require.ErrorIs(t, client.http.CheckRedirect(new(http.Request), nil), http.ErrUseLastResponse)
+	_, err = client.Embed(context.Background(), oneHostedInput(), hostedAuthorization(client.descriptor, 1))
+	require.ErrorIs(t, err, ErrPermanentResponse)
+	assert.Zero(t, ambient.calls, "the caller transport must never receive hosted authority")
+}
+
+func TestEmbedSendsExactHostedRequestAndRestoresReturnedIndices(t *testing.T) {
+	profile := hostedTestProfile(t)
+	inputs := []document.EmbeddingInput{
+		{Key: "document-a", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "alpha"},
+		{Key: "query-a", Role: document.EmbeddingRoleQuery, Kind: document.EmbeddingInputQueryText, Text: "beta"},
+	}
+	originalInputs := slices.Clone(inputs)
+	var calls int
+	client := newHostedTestClient(t, profile, hostedSecrets{"secret:openai": "sk-synthetic"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		calls++
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "https://api.openai.com/v1/embeddings", request.URL.String())
+		assert.Equal(t, "api.openai.com", request.URL.Host)
+		assert.Equal(t, "application/json", request.Header.Get("Accept"))
+		assert.Equal(t, "application/json", request.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer sk-synthetic", request.Header.Get("Authorization"))
+		assert.Empty(t, request.Header.Get("Cookie"))
+		payload, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"input":["passage: alpha","query: beta"],
+			"model":"text-embedding-3-large",
+			"dimensions":3,
+			"encoding_format":"float"
+		}`, string(payload))
+		return hostedJSONResponse(request, http.StatusOK, `{
+			"object":"list",
+			"data":[
+				{"object":"embedding","embedding":[0,1,0],"index":1},
+				{"object":"embedding","embedding":[1,0,0],"index":0}
+			],
+			"model":"text-embedding-3-large",
+			"usage":{"prompt_tokens":2,"total_tokens":2}
+		}`), nil
+	}))
+
+	result, err := client.Embed(context.Background(), inputs, hostedAuthorization(profile.Descriptor, 2))
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, originalInputs, inputs, "embedding must not mutate caller slices")
+	assert.Equal(t, document.EmbeddingResult{Vectors: []document.EmbeddingVector{
+		{Key: "document-a", Values: []float32{1, 0, 0}},
+		{Key: "query-a", Values: []float32{0, 1, 0}},
+	}}, result)
+}
+
+func hostedTestProfile(t *testing.T) Profile {
+	t.Helper()
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{Profile: document.ModelInputProfileE5})
+	require.NoError(t, err)
+	profile := Profile{
+		Descriptor: document.EmbeddingDescriptor{
+			ID: ProviderID, ContractVersion: document.EmbeddingProviderContractVersion,
+			TrustBoundary: document.EmbeddingTrustHostedProvider, Model: Model,
+			ModelRevision: "hosted-epoch-1", Dimension: 3, Metric: document.VectorMetricCosine,
+			Normalization: document.VectorNormalizationUnitLength, ScalarEncoding: ScalarEncodingFloat32,
+			DocumentFormatter: DocumentFormatterV1, QueryFormatter: QueryFormatterV1,
+			InputKinds:      []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk},
+			CompatibilityID: contract.CompatibilityID, SupportsTextQuery: true, ModelInput: contract,
+			SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeText},
+		},
+		CompatibilityEpoch: "hosted-epoch-1", SecretBinding: "secret:openai",
+		RequestTimeout: time.Second, MaxBatchItems: 8, MaxInputItemBytes: 2048,
+		MaxInputBytes: 4096, MaxRequestBytes: 8192, MaxResponseBytes: 16384,
+		EgressPolicy: providerhttp.EgressPolicy{
+			Scheme: "https", Host: "api.openai.com", Port: 443,
+			AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("198.51.100.0/24"), netip.MustParsePrefix("192.0.2.0/24")},
+			ProxyMode:    providerhttp.ProxyDisabled, ConnectTimeout: time.Second,
+			KeepAlive: time.Second, TLSHandshakeTimeout: time.Second,
+			TLS: providerhttp.TLSPolicy{SPKISHA256: []string{
+				"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			}},
+		},
+	}
+	profile.Descriptor = hostedDescriptorFor(t, profile)
+	return profile
+}
+
+func hostedDescriptorFor(t *testing.T, profile Profile) document.EmbeddingDescriptor {
+	t.Helper()
+	profile.Descriptor.PolicyFingerprint = ""
+	profile.Descriptor.Fingerprint = ""
+	fingerprint, err := PolicyFingerprint(profile)
+	require.NoError(t, err)
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	require.NoError(t, err)
+	return descriptor
+}
+
+func canonicalDescriptorWithoutPolicyCheck(t *testing.T, value document.EmbeddingDescriptor) document.EmbeddingDescriptor {
+	t.Helper()
+	canonical, err := document.NewEmbeddingDescriptor(value)
+	if err != nil {
+		return value
+	}
+	return canonical
+}
+
+type hostedSecrets map[string]string
+
+func (secrets hostedSecrets) ResolveSecret(_ context.Context, name string) (string, error) {
+	value, ok := secrets[name]
+	if !ok {
+		return "", errors.New("synthetic secret missing")
+	}
+	return value, nil
+}
+
+type staticResolver []netip.Addr
+
+func (resolver staticResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return slices.Clone(resolver), nil
+}
+
+type countingTransport struct{ calls int }
+
+func (transport *countingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	transport.calls++
+	return nil, errors.New("ambient transport must not run")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func newHostedTestClient(t *testing.T, profile Profile, secrets SecretResolver, transport http.RoundTripper) *Client {
+	t.Helper()
+	client, err := New(profile, secrets, staticResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+	require.NoError(t, err)
+	client.http.Transport = transport
+	return client
+}
+
+func hostedAuthorization(descriptor document.EmbeddingDescriptor, batch int) document.EmbeddingAuthorization {
+	return document.EmbeddingAuthorization{
+		ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+		PolicyFingerprint: descriptor.PolicyFingerprint, MaxBatchItems: batch,
+		MaxInputBytes: 4096, MaxResponseBytes: 4096,
+	}
+}
+
+func hostedJSONResponse(request *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(bytes.NewBufferString(body)), Request: request,
+	}
+}


### PR DESCRIPTION
Go applications can generate document and query embeddings through a dedicated hosted OpenAI adapter. It calls only `https://api.openai.com/v1/embeddings`, uses `text-embedding-3-large`, and requires an explicit dimension from 1 to 3,072. The model-input policy and an operator-controlled compatibility epoch are part of vector-space identity.

Profiles require a named API-key resolver and sealed `api.openai.com:443` egress. Requests have independent item, batch, input, request, response, and timeout limits. Responses must contain complete unique indices, the expected model and usage fields, and finite unit-length vectors of the configured dimension. Unknown response members remain rejected as part of the strict hosted contract.

Errors distinguish unavailable or rejected credentials, transient failures, capacity limits, and permanent failures without exposing provider bodies or secrets. Adapter timeouts are transient; caller cancellation stays identifiable. Egress-policy failures and oversized individual inputs are permanent, while an authorization that exceeds the profile is rejected locally.

Use `openaihosted.New` with a canonical profile, then call `document.ExecuteEmbedding`. Zero limits select a 128-item batch and a 64 MiB response budget. Larger batches or dimensions may need a larger response budget, which measures encoded JSON including number text and metadata.

This PR adds the public Go package. CLI/daemon configuration and worker error-classifier registration remain follow-up work; the daemon currently dispatches only to the OpenAI-compatible and Voyage adapters.

Parent: #223 (merged). This PR contains only the hosted OpenAI adapter.

Refs #176
