### PR TITLE
[E13–S9 03/15] Add ZeroEntropy embedding and reranking

### DIFF
--- a/document/zeroentropy/client.go
+++ b/document/zeroentropy/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
 	"go.kenn.io/docbank/document/providerhttp"
 )
 
@@ -174,6 +175,8 @@ func (client *Client) prepareRequests(inputs []document.EmbeddingInput) ([]prepa
 		if len(group.positions) == 0 {
 			continue
 		}
+		// Provider input accounting adds 150 bytes per item; MaxRequestBytes
+		// separately bounds serialized JSON. See https://docs.zeroentropy.dev/api-reference/models/embed.
 		var providerBytes int64
 		for _, value := range group.values {
 			if int64(len(value))+150 > providerPayloadMax-providerBytes {
@@ -255,7 +258,8 @@ func (client *Client) execute(ctx, requestCtx context.Context, payload []byte, e
 func (client *Client) decodeVector(raw jsonv1.RawMessage) ([]float32, error) {
 	var values []float32
 	if client.profile.EncodingFormat == EncodingFloat {
-		if err := json.Unmarshal(raw, &values, json.RejectUnknownMembers(true)); err != nil {
+		if err := json.Unmarshal(raw, &values, json.RejectUnknownMembers(true),
+			json.WithUnmarshalers(json.UnmarshalFunc(providerutil.UnmarshalEmbeddingFloat32))); err != nil {
 			return nil, err
 		}
 	} else {

--- a/document/zeroentropy/client.go
+++ b/document/zeroentropy/client.go
@@ -1,0 +1,308 @@
+package zeroentropy
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	jsonv1 "encoding/json"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net/http"
+	"slices"
+	"time"
+
+	"go.kenn.io/docbank/document"
+)
+
+const (
+	maximumSecretBytes = 64 << 10
+	maximumUsage       = int64(1 << 50)
+	providerPayloadMax = int64(5_000_000)
+)
+
+var _ document.EmbeddingProvider = (*Client)(nil)
+
+type wireRequest struct {
+	Model          string         `json:"model"`
+	InputType      string         `json:"input_type"`
+	Input          []string       `json:"input"`
+	Dimensions     int            `json:"dimensions"`
+	EncodingFormat EncodingFormat `json:"encoding_format"`
+	Latency        Latency        `json:"latency,omitempty"`
+}
+
+type wireResponse struct {
+	Results []wireResult `json:"results"`
+	Usage   *wireUsage   `json:"usage"`
+}
+
+type wireResult struct {
+	Embedding jsonv1.RawMessage `json:"embedding"`
+}
+
+type wireUsage struct {
+	TotalBytes  *int64 `json:"total_bytes"`
+	TotalTokens *int64 `json:"total_tokens"`
+}
+
+type preparedRequest struct {
+	positions []int
+	payload   []byte
+}
+
+type Receipt struct {
+	ProviderID            string
+	DescriptorFingerprint string
+	PolicyFingerprint     string
+	Model                 string
+	ModelRevision         string
+	EncodingFormat        EncodingFormat
+	RequestedLatency      Latency
+	RequestCount          int
+	TotalBytes            int64
+	TotalTokens           int64
+}
+
+type Execution struct {
+	Result  document.EmbeddingResult
+	Receipt Receipt
+}
+
+func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (document.EmbeddingResult, error) {
+	execution, err := client.embed(ctx, inputs, authorization, false)
+	return execution.Result, err
+}
+
+func (client *Client) EmbedWithReceipt(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization) (Execution, error) {
+	return client.embed(ctx, inputs, authorization, true)
+}
+
+func (client *Client) embed(ctx context.Context, inputs []document.EmbeddingInput, authorization document.EmbeddingAuthorization, includeReceipt bool) (Execution, error) {
+	if client == nil || ctx == nil {
+		return Execution{}, errors.New("zeroentropy embed: client and context are required")
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
+	defer cancel()
+	if err := document.ValidateEmbeddingProviderRequest(client, inputs, authorization); err != nil {
+		return Execution{}, err
+	}
+	if authorization.MaxBatchItems > client.profile.MaxBatchItems || authorization.MaxInputBytes > client.profile.MaxInputBytes ||
+		authorization.MaxResponseBytes > client.profile.MaxResponseBytes {
+		return Execution{}, &ProviderError{Kind: ErrCapacityResponse}
+	}
+	prepared, err := client.prepareRequests(inputs)
+	if err != nil {
+		return Execution{}, err
+	}
+	defer func() {
+		for index := range prepared {
+			clear(prepared[index].payload)
+		}
+	}()
+	secret, err := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
+	if err != nil || !validSecret(secret) {
+		if contextErr := requestCtx.Err(); contextErr != nil {
+			return Execution{}, fmt.Errorf("zeroentropy embed: credential resolution canceled: %w", contextErr)
+		}
+		return Execution{}, errors.New("zeroentropy embed: API-key resolution failed")
+	}
+	result := document.EmbeddingResult{Vectors: make([]document.EmbeddingVector, len(inputs))}
+	receipt := Receipt{ProviderID: ProviderID, DescriptorFingerprint: client.descriptor.Fingerprint,
+		PolicyFingerprint: client.descriptor.PolicyFingerprint, Model: Model, ModelRevision: client.descriptor.ModelRevision,
+		EncodingFormat: client.profile.EncodingFormat, RequestedLatency: client.profile.Latency}
+	for _, request := range prepared {
+		vectors, usage, executeErr := client.execute(requestCtx, request.payload, len(request.positions), secret)
+		if executeErr != nil {
+			return Execution{}, executeErr
+		}
+		for local, global := range request.positions {
+			result.Vectors[global] = document.EmbeddingVector{Key: inputs[global].Key, Values: vectors[local]}
+		}
+		receipt.RequestCount++
+		if receipt.TotalBytes > maximumUsage-*usage.TotalBytes || receipt.TotalTokens > maximumUsage-*usage.TotalTokens {
+			return Execution{}, &ProviderError{Kind: ErrPermanentResponse}
+		}
+		receipt.TotalBytes += *usage.TotalBytes
+		receipt.TotalTokens += *usage.TotalTokens
+	}
+	if err := document.ValidateEmbeddingProviderResult(client.descriptor, inputs, authorization, result); err != nil {
+		return Execution{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	execution := Execution{Result: result}
+	if includeReceipt {
+		execution.Receipt = receipt
+	}
+	return execution, nil
+}
+
+func (client *Client) prepareRequests(inputs []document.EmbeddingInput) ([]preparedRequest, error) {
+	documentPositions, queryPositions := []int{}, []int{}
+	documents, queries := []string{}, []string{}
+	for index, input := range inputs {
+		var rendered string
+		var target *[]string
+		var positions *[]int
+		switch input.Role {
+		case document.EmbeddingRoleDocument:
+			rendered, target, positions = client.descriptor.ModelInput.EncodeDocument(input.Text), &documents, &documentPositions
+		case document.EmbeddingRoleQuery:
+			rendered, target, positions = client.descriptor.ModelInput.EncodeQuery(input.Text), &queries, &queryPositions
+		default:
+			return nil, &ProviderError{Kind: ErrPermanentResponse}
+		}
+		if int64(len(rendered)) > client.profile.MaxInputItemBytes {
+			return nil, &ProviderError{Kind: ErrCapacityResponse}
+		}
+		*target = append(*target, rendered)
+		*positions = append(*positions, index)
+	}
+	requests := make([]preparedRequest, 0, 2)
+	for _, group := range []struct {
+		positions []int
+		values    []string
+		inputType string
+	}{{documentPositions, documents, "document"}, {queryPositions, queries, "query"}} {
+		if len(group.positions) == 0 {
+			continue
+		}
+		var providerBytes int64
+		for _, value := range group.values {
+			if int64(len(value))+150 > providerPayloadMax-providerBytes {
+				return nil, &ProviderError{Kind: ErrCapacityResponse}
+			}
+			providerBytes += int64(len(value)) + 150
+		}
+		latency := client.profile.Latency
+		if latency == LatencyAuto {
+			latency = ""
+		}
+		payload, err := json.Marshal(wireRequest{Model: Model, InputType: group.inputType, Input: group.values,
+			Dimensions: client.descriptor.Dimension, EncodingFormat: client.profile.EncodingFormat, Latency: latency})
+		if err != nil {
+			return nil, errors.New("zeroentropy embed: request encoding failed")
+		}
+		if int64(len(payload)) > client.profile.MaxRequestBytes {
+			clear(payload)
+			return nil, &ProviderError{Kind: ErrCapacityResponse}
+		}
+		requests = append(requests, preparedRequest{positions: slices.Clone(group.positions), payload: payload})
+	}
+	return requests, nil
+}
+
+func (client *Client) execute(ctx context.Context, payload []byte, expected int, secret string) ([][]float32, wireUsage, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, origin+embedPath, bytes.NewReader(payload))
+	if err != nil {
+		return nil, wireUsage{}, errors.New("zeroentropy embed: request construction failed")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+secret)
+	response, err := client.http.Do(request)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, wireUsage{}, fmt.Errorf("zeroentropy embed: request canceled: %w", contextErr)
+		}
+		return nil, wireUsage{}, &ProviderError{Kind: ErrTransientResponse}
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return nil, wireUsage{}, statusError(response.StatusCode, response.Header.Get("Retry-After"), time.Now().UTC())
+	}
+	if !isJSONContentType(response.Header.Get("Content-Type")) {
+		return nil, wireUsage{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	body, readErr := readBounded(response.Body, client.profile.MaxResponseBytes)
+	defer clear(body)
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, wireUsage{}, fmt.Errorf("zeroentropy embed: response read canceled: %w", contextErr)
+	}
+	if readErr != nil {
+		if errors.Is(readErr, errCapacity) {
+			return nil, wireUsage{}, &ProviderError{Kind: ErrCapacityResponse}
+		}
+		return nil, wireUsage{}, &ProviderError{Kind: ErrTransientResponse}
+	}
+	var decoded wireResponse
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil ||
+		len(decoded.Results) != expected || !validUsage(decoded.Usage) {
+		return nil, wireUsage{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	vectors := make([][]float32, expected)
+	for index, result := range decoded.Results {
+		vector, decodeErr := client.decodeVector(result.Embedding)
+		if decodeErr != nil {
+			return nil, wireUsage{}, &ProviderError{Kind: ErrPermanentResponse}
+		}
+		vectors[index] = vector
+	}
+	return vectors, *decoded.Usage, nil
+}
+
+func (client *Client) decodeVector(raw jsonv1.RawMessage) ([]float32, error) {
+	var values []float32
+	if client.profile.EncodingFormat == EncodingFloat {
+		if err := json.Unmarshal(raw, &values, json.RejectUnknownMembers(true)); err != nil {
+			return nil, err
+		}
+	} else {
+		var encoded string
+		if err := json.Unmarshal(raw, &encoded); err != nil || base64.StdEncoding.DecodedLen(len(encoded)) < client.descriptor.Dimension*4 {
+			return nil, errors.New("invalid base64 vector")
+		}
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil || len(decoded) != client.descriptor.Dimension*4 {
+			clear(decoded)
+			return nil, errors.New("invalid base64 vector")
+		}
+		defer clear(decoded)
+		values = make([]float32, client.descriptor.Dimension)
+		for index := range values {
+			values[index] = math.Float32frombits(binary.LittleEndian.Uint32(decoded[index*4:]))
+		}
+	}
+	if len(values) != client.descriptor.Dimension {
+		return nil, errors.New("invalid vector dimension")
+	}
+	for _, value := range values {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return nil, errors.New("non-finite vector")
+		}
+	}
+	return values, nil
+}
+
+func validUsage(usage *wireUsage) bool {
+	return usage != nil && usage.TotalBytes != nil && usage.TotalTokens != nil &&
+		*usage.TotalBytes >= 0 && *usage.TotalBytes <= maximumUsage &&
+		*usage.TotalTokens >= 0 && *usage.TotalTokens <= maximumUsage
+}
+
+var errCapacity = errors.New("response capacity exceeded")
+
+func readBounded(reader io.Reader, maximum int64) ([]byte, error) {
+	limited := io.LimitReader(reader, maximum+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maximum {
+		clear(body)
+		return nil, errCapacity
+	}
+	return body, nil
+}
+
+func isJSONContentType(value string) bool {
+	mediaType, _, err := mime.ParseMediaType(value)
+	return err == nil && (mediaType == "application/json" || len(mediaType) > 5 && mediaType[len(mediaType)-5:] == "+json")
+}
+
+func validSecret(value string) bool {
+	return len(value) <= maximumSecretBytes && validToken(value)
+}

--- a/document/zeroentropy/client.go
+++ b/document/zeroentropy/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
 )
 
 const (
@@ -207,6 +208,10 @@ func (client *Client) execute(ctx context.Context, payload []byte, expected int,
 	if err != nil {
 		if contextErr := ctx.Err(); contextErr != nil {
 			return nil, wireUsage{}, fmt.Errorf("zeroentropy embed: request canceled: %w", contextErr)
+		}
+		if errors.Is(err, providerhttp.ErrAddressDenied) || errors.Is(err, providerhttp.ErrDestinationDenied) ||
+			errors.Is(err, providerhttp.ErrCertificatePin) {
+			return nil, wireUsage{}, &ProviderError{Kind: ErrPermanentResponse}
 		}
 		return nil, wireUsage{}, &ProviderError{Kind: ErrTransientResponse}
 	}

--- a/document/zeroentropy/client.go
+++ b/document/zeroentropy/client.go
@@ -107,8 +107,11 @@ func (client *Client) embed(ctx context.Context, inputs []document.EmbeddingInpu
 	}()
 	secret, err := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
 	if err != nil || !validSecret(secret) {
-		if contextErr := requestCtx.Err(); contextErr != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
 			return Execution{}, fmt.Errorf("zeroentropy embed: credential resolution canceled: %w", contextErr)
+		}
+		if requestCtx.Err() != nil {
+			return Execution{}, &ProviderError{Kind: ErrTransientResponse}
 		}
 		return Execution{}, errors.New("zeroentropy embed: API-key resolution failed")
 	}
@@ -117,7 +120,7 @@ func (client *Client) embed(ctx context.Context, inputs []document.EmbeddingInpu
 		PolicyFingerprint: client.descriptor.PolicyFingerprint, Model: Model, ModelRevision: client.descriptor.ModelRevision,
 		EncodingFormat: client.profile.EncodingFormat, RequestedLatency: client.profile.Latency}
 	for _, request := range prepared {
-		vectors, usage, executeErr := client.execute(requestCtx, request.payload, len(request.positions), secret)
+		vectors, usage, executeErr := client.execute(ctx, requestCtx, request.payload, len(request.positions), secret)
 		if executeErr != nil {
 			return Execution{}, executeErr
 		}
@@ -196,8 +199,8 @@ func (client *Client) prepareRequests(inputs []document.EmbeddingInput) ([]prepa
 	return requests, nil
 }
 
-func (client *Client) execute(ctx context.Context, payload []byte, expected int, secret string) ([][]float32, wireUsage, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, origin+embedPath, bytes.NewReader(payload))
+func (client *Client) execute(ctx, requestCtx context.Context, payload []byte, expected int, secret string) ([][]float32, wireUsage, error) {
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodPost, origin+embedPath, bytes.NewReader(payload))
 	if err != nil {
 		return nil, wireUsage{}, errors.New("zeroentropy embed: request construction failed")
 	}

--- a/document/zeroentropy/client_test.go
+++ b/document/zeroentropy/client_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json/v2"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
 )
 
 func TestEmbedSeparatesInputTypesAndPreservesInputOrder(t *testing.T) {
@@ -216,3 +218,35 @@ func (body *contextBody) Read([]byte) (int, error) {
 }
 
 func (*contextBody) Close() error { return nil }
+
+func TestEmbedClassifiesDeniedDNSAsPermanent(t *testing.T) {
+	client, err := New(testProfile(t, 40, EncodingFloat, LatencyAuto), testSecrets{"secret:zeroentropy": "synthetic-key"},
+		testResolver{netip.MustParseAddr("198.51.100.10")}, &http.Client{})
+	require.NoError(t, err)
+
+	_, err = client.Embed(context.Background(), oneInput(), authorization(client.descriptor, 1))
+	require.ErrorIs(t, err, ErrPermanentResponse)
+}
+
+func TestEmbedClassifiesTransportFailures(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		failure error
+		want    error
+	}{
+		{"address denied", providerhttp.ErrAddressDenied, ErrPermanentResponse},
+		{"destination denied", providerhttp.ErrDestinationDenied, ErrPermanentResponse},
+		{"certificate pin", providerhttp.ErrCertificatePin, ErrPermanentResponse},
+		{"connection failure", assert.AnError, ErrTransientResponse},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := testClient(t, testProfile(t, 40, EncodingFloat, LatencyAuto), testSecrets{"secret:zeroentropy": "synthetic-key"},
+				roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return nil, fmt.Errorf("provider transport: %w", test.failure)
+				}))
+
+			_, err := client.Embed(context.Background(), oneInput(), authorization(client.descriptor, 1))
+			require.ErrorIs(t, err, test.want)
+		})
+	}
+}

--- a/document/zeroentropy/client_test.go
+++ b/document/zeroentropy/client_test.go
@@ -105,6 +105,7 @@ func TestEmbedRejectsResponseDriftAndInvalidVectors(t *testing.T) {
 	tests := map[string]string{
 		"missing result":  `{"results":[],"usage":{"total_bytes":155,"total_tokens":2}}`,
 		"wrong dimension": strings.Replace(valid, validVector, "0,0", 1),
+		"null coordinate": strings.Replace(valid, "0,", "null,", 1),
 		"non finite":      strings.Replace(valid, "0,", "1e1000,", 1),
 		"missing usage":   strings.Replace(valid, `,"usage":{"total_bytes":155,"total_tokens":2}`, "", 1),
 		"negative usage":  strings.Replace(valid, `"total_tokens":2`, `"total_tokens":-1`, 1),

--- a/document/zeroentropy/client_test.go
+++ b/document/zeroentropy/client_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -249,4 +250,71 @@ func TestEmbedClassifiesTransportFailures(t *testing.T) {
 			require.ErrorIs(t, err, test.want)
 		})
 	}
+}
+
+func TestEmbedDistinguishesAdapterTimeoutFromCallerCancellation(t *testing.T) {
+	for _, phase := range []string{"credential", "request", "response"} {
+		for _, cause := range []string{"adapter timeout", "caller deadline", "caller cancellation"} {
+			t.Run(phase+"/"+cause, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if cause == "caller deadline" {
+						var cancelDeadline context.CancelFunc
+						ctx, cancelDeadline = context.WithTimeout(ctx, time.Millisecond)
+						defer cancelDeadline()
+					}
+					waitForContext := func(requestCtx context.Context) error {
+						if cause == "caller cancellation" {
+							cancel()
+						}
+						<-requestCtx.Done()
+						return requestCtx.Err()
+					}
+					secrets := secretResolverFunc(func(requestCtx context.Context, _ string) (string, error) {
+						if phase == "credential" {
+							return "", waitForContext(requestCtx)
+						}
+						return "synthetic-key", nil
+					})
+					var bodyDone chan struct{}
+					client := testClient(t, testProfile(t, 40, EncodingFloat, LatencyAuto), secrets, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+						if phase == "request" {
+							return nil, waitForContext(request.Context())
+						}
+						reader, writer := io.Pipe()
+						bodyDone = make(chan struct{})
+						go func() {
+							defer close(bodyDone)
+							_ = writer.CloseWithError(waitForContext(request.Context()))
+						}()
+						return &http.Response{StatusCode: http.StatusOK,
+							Header: http.Header{"Content-Type": []string{"application/json"}}, Body: reader, Request: request}, nil
+					}))
+					_, err := client.Embed(ctx, oneInput(), authorization(client.descriptor, 1))
+					if bodyDone != nil {
+						<-bodyDone
+					}
+					switch cause {
+					case "adapter timeout":
+						require.ErrorIs(t, err, ErrTransientResponse)
+						require.NotErrorIs(t, err, context.DeadlineExceeded)
+						require.NoError(t, ctx.Err())
+					case "caller deadline":
+						require.ErrorIs(t, err, context.DeadlineExceeded)
+						require.NotErrorIs(t, err, ErrTransientResponse)
+					case "caller cancellation":
+						require.ErrorIs(t, err, context.Canceled)
+						require.NotErrorIs(t, err, ErrTransientResponse)
+					}
+				})
+			})
+		}
+	}
+}
+
+type secretResolverFunc func(context.Context, string) (string, error)
+
+func (resolve secretResolverFunc) ResolveSecret(ctx context.Context, binding string) (string, error) {
+	return resolve(ctx, binding)
 }

--- a/document/zeroentropy/client_test.go
+++ b/document/zeroentropy/client_test.go
@@ -1,0 +1,218 @@
+package zeroentropy
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json/v2"
+	"io"
+	"math"
+	"net/http"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+)
+
+func TestEmbedSeparatesInputTypesAndPreservesInputOrder(t *testing.T) {
+	profile := testProfile(t, 40, EncodingFloat, LatencyFast)
+	var calls atomic.Int32
+	client := testClient(t, profile, testSecrets{"secret:zeroentropy": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		assert.Equal(t, "https://api.zeroentropy.dev/v1/models/embed", request.URL.String())
+		assert.Equal(t, "Bearer synthetic-key", request.Header.Get("Authorization"))
+		body, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		var payload struct {
+			Model          string         `json:"model"`
+			InputType      string         `json:"input_type"`
+			Input          []string       `json:"input"`
+			Dimensions     int            `json:"dimensions"`
+			EncodingFormat EncodingFormat `json:"encoding_format"`
+			Latency        Latency        `json:"latency"`
+		}
+		require.NoError(t, json.Unmarshal(body, &payload, json.RejectUnknownMembers(true)))
+		assert.Equal(t, Model, payload.Model)
+		assert.Equal(t, 40, payload.Dimensions)
+		assert.Equal(t, EncodingFloat, payload.EncodingFormat)
+		assert.Equal(t, LatencyFast, payload.Latency)
+		value := float64(calls.Add(1))
+		vector := make([]float64, 40)
+		vector[0] = value
+		response, err := json.Marshal(map[string]any{
+			"results": []any{map[string]any{"embedding": vector}},
+			"usage":   map[string]any{"total_bytes": 155, "total_tokens": 2},
+		})
+		require.NoError(t, err)
+		if payload.InputType == "document" {
+			assert.Equal(t, []string{"first passage"}, payload.Input)
+		} else {
+			assert.Equal(t, "query", payload.InputType)
+			assert.Equal(t, []string{"search words"}, payload.Input)
+		}
+		return jsonResponse(request, http.StatusOK, response), nil
+	}))
+	inputs := []document.EmbeddingInput{
+		{Key: "document", Role: document.EmbeddingRoleDocument, Kind: document.EmbeddingInputRenditionChunk, Text: "first passage"},
+		{Key: "query", Role: document.EmbeddingRoleQuery, Kind: document.EmbeddingInputQueryText, Text: "search words"},
+	}
+
+	execution, err := client.EmbedWithReceipt(context.Background(), inputs, authorization(client.descriptor, 2))
+	require.NoError(t, err)
+	require.Len(t, execution.Result.Vectors, 2)
+	assert.Equal(t, "document", execution.Result.Vectors[0].Key)
+	assert.InDelta(t, 1, execution.Result.Vectors[0].Values[0], 0)
+	assert.Equal(t, "query", execution.Result.Vectors[1].Key)
+	assert.InDelta(t, 2, execution.Result.Vectors[1].Values[0], 0)
+	assert.Equal(t, Receipt{ProviderID: ProviderID, DescriptorFingerprint: client.descriptor.Fingerprint,
+		PolicyFingerprint: client.descriptor.PolicyFingerprint, Model: Model, ModelRevision: profile.Descriptor.ModelRevision,
+		EncodingFormat: EncodingFloat, RequestedLatency: LatencyFast, RequestCount: 2,
+		TotalBytes: 310, TotalTokens: 4}, execution.Receipt)
+}
+
+func TestEmbedDecodesExactLittleEndianBase64(t *testing.T) {
+	profile := testProfile(t, 40, EncodingBase64, LatencyAuto)
+	raw := make([]byte, 40*4)
+	for index := range 40 {
+		binary.LittleEndian.PutUint32(raw[index*4:], math.Float32bits(float32(index)+0.25))
+	}
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	client := testClient(t, profile, testSecrets{"secret:zeroentropy": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		assert.NotContains(t, string(body), `"latency"`)
+		return jsonResponse(request, http.StatusOK, []byte(`{"results":[{"embedding":"`+encoded+`"}],"usage":{"total_bytes":155,"total_tokens":2}}`)), nil
+	}))
+
+	result, err := client.Embed(context.Background(), oneInput(), authorization(client.descriptor, 1))
+	require.NoError(t, err)
+	require.Len(t, result.Vectors, 1)
+	assert.InDelta(t, 0.25, result.Vectors[0].Values[0], 0)
+	assert.InDelta(t, 39.25, result.Vectors[0].Values[39], 0)
+}
+
+func TestEmbedRejectsResponseDriftAndInvalidVectors(t *testing.T) {
+	validVector := strings.TrimSuffix(strings.Repeat("0,", 40), ",")
+	valid := `{"results":[{"embedding":[` + validVector + `]}],"usage":{"total_bytes":155,"total_tokens":2}}`
+	tests := map[string]string{
+		"missing result":  `{"results":[],"usage":{"total_bytes":155,"total_tokens":2}}`,
+		"wrong dimension": strings.Replace(valid, validVector, "0,0", 1),
+		"non finite":      strings.Replace(valid, "0,", "1e1000,", 1),
+		"missing usage":   strings.Replace(valid, `,"usage":{"total_bytes":155,"total_tokens":2}`, "", 1),
+		"negative usage":  strings.Replace(valid, `"total_tokens":2`, `"total_tokens":-1`, 1),
+		"unknown field":   strings.Replace(valid, `"usage":`, `"private":true,"usage":`, 1),
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			profile := testProfile(t, 40, EncodingFloat, LatencySlow)
+			client := testClient(t, profile, testSecrets{"secret:zeroentropy": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				return jsonResponse(request, http.StatusOK, []byte(body)), nil
+			}))
+			_, err := client.Embed(context.Background(), oneInput(), authorization(client.descriptor, 1))
+			require.ErrorIs(t, err, ErrPermanentResponse)
+			assert.NotContains(t, err.Error(), "private")
+		})
+	}
+}
+
+func TestEmbedRejectsProviderPayloadLimitBeforeSecretsOrEgress(t *testing.T) {
+	profile := testProfile(t, 40, EncodingFloat, LatencyFast)
+	profile.MaxInputItemBytes = maximumInputBytes
+	profile.MaxInputBytes = maximumInputBytes
+	profile.Descriptor = descriptorFor(t, profile)
+	secrets := &countingSecrets{value: "synthetic-key"}
+	var requests atomic.Int32
+	client := testClient(t, profile, secrets, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return nil, assert.AnError
+	}))
+	input := oneInput()
+	input[0].Text = strings.Repeat("a", int(maximumInputBytes-100))
+	authorization := authorization(client.descriptor, 1)
+	authorization.MaxInputBytes = maximumInputBytes
+
+	_, err := client.Embed(context.Background(), input, authorization)
+	require.ErrorIs(t, err, ErrCapacityResponse)
+	assert.Zero(t, secrets.calls.Load())
+	assert.Zero(t, requests.Load())
+}
+
+func TestEmbedPreservesCancellationDuringResponseRead(t *testing.T) {
+	started := make(chan struct{})
+	profile := testProfile(t, 40, EncodingFloat, LatencyFast)
+	client := testClient(t, profile, testSecrets{"secret:zeroentropy": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		close(started)
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+			Body: &contextBody{ctx: request.Context()}, Request: request}, nil
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Embed(ctx, oneInput(), authorization(client.descriptor, 1))
+		done <- err
+	}()
+	<-started
+	cancel()
+	assert.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRetryAfterClampsBeforeDurationConversion(t *testing.T) {
+	err := statusError(http.StatusTooManyRequests, "9223372036854775807", time.Now().UTC())
+	delay, ok := RetryAfter(err)
+	assert.True(t, ok)
+	assert.Equal(t, time.Hour, delay)
+}
+
+func oneInput() []document.EmbeddingInput {
+	return []document.EmbeddingInput{{Key: "document", Role: document.EmbeddingRoleDocument,
+		Kind: document.EmbeddingInputRenditionChunk, Text: "alpha"}}
+}
+
+func authorization(descriptor document.EmbeddingDescriptor, batch int) document.EmbeddingAuthorization {
+	return document.EmbeddingAuthorization{ProviderID: descriptor.ID, DescriptorFingerprint: descriptor.Fingerprint,
+		PolicyFingerprint: descriptor.PolicyFingerprint, MaxBatchItems: batch, MaxInputBytes: 4096,
+		MaxResponseBytes: int64(batch*descriptor.Dimension*4 + 1024)}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func testClient(t *testing.T, profile Profile, secrets SecretResolver, transport http.RoundTripper) *Client {
+	t.Helper()
+	client, err := New(profile, secrets, testResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+	require.NoError(t, err)
+	client.http.Transport = transport
+	return client
+}
+
+func jsonResponse(request *http.Request, status int, body []byte) *http.Response {
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(bytes.NewReader(body)), Request: request}
+}
+
+type countingSecrets struct {
+	value string
+	calls atomic.Int32
+}
+
+func (resolver *countingSecrets) ResolveSecret(context.Context, string) (string, error) {
+	resolver.calls.Add(1)
+	return resolver.value, nil
+}
+
+type contextBody struct{ ctx context.Context }
+
+func (body *contextBody) Read([]byte) (int, error) {
+	<-body.ctx.Done()
+	return 0, body.ctx.Err()
+}
+
+func (*contextBody) Close() error { return nil }

--- a/document/zeroentropy/errors.go
+++ b/document/zeroentropy/errors.go
@@ -1,0 +1,70 @@
+package zeroentropy
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrTransientResponse = errors.New("zeroentropy embed: transient provider response")
+	ErrCapacityResponse  = errors.New("zeroentropy embed: provider capacity exceeded")
+	ErrPermanentResponse = errors.New("zeroentropy embed: permanent provider response")
+)
+
+type ProviderError struct {
+	Kind       error
+	StatusCode int
+	RetryDelay time.Duration
+	RetrySet   bool
+}
+
+func (failure *ProviderError) Error() string {
+	if failure.StatusCode != 0 {
+		return fmt.Sprintf("zeroentropy embed: HTTP %d: %v", failure.StatusCode, failure.Kind)
+	}
+	return failure.Kind.Error()
+}
+
+func (failure *ProviderError) Unwrap() error { return failure.Kind }
+
+func RetryAfter(err error) (time.Duration, bool) {
+	failure, ok := errors.AsType[*ProviderError](err)
+	if !ok || !failure.RetrySet {
+		return 0, false
+	}
+	return failure.RetryDelay, true
+}
+
+func statusError(status int, retryAfter string, now time.Time) error {
+	kind := ErrPermanentResponse
+	switch {
+	case status == http.StatusRequestEntityTooLarge:
+		kind = ErrCapacityResponse
+	case status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= 500 && status <= 599:
+		kind = ErrTransientResponse
+	}
+	delay, set := parseRetryAfter(retryAfter, now)
+	if !errors.Is(kind, ErrTransientResponse) {
+		delay, set = 0, false
+	}
+	return &ProviderError{Kind: kind, StatusCode: status, RetryDelay: delay, RetrySet: set}
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+		if seconds >= int64(time.Hour/time.Second) {
+			return time.Hour, true
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	return min(max(when.Sub(now), 0), time.Hour), true
+}

--- a/document/zeroentropy/profile.go
+++ b/document/zeroentropy/profile.go
@@ -1,0 +1,360 @@
+// Package zeroentropy implements the fixed hosted ZeroEntropy zembed-1 contract.
+package zeroentropy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"net/http"
+	"net/netip"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	ProviderID            = "zeroentropy.hosted.zembed-1-v1"
+	Model                 = "zembed-1"
+	DocumentFormatterV1   = "zeroentropy-zembed-1/document/v1"
+	QueryFormatterV1      = "zeroentropy-zembed-1/query/v1"
+	ScalarEncodingFloat32 = "float32"
+	TransformNone         = "none"
+
+	host                 = "api.zeroentropy.dev"
+	origin               = "https://api.zeroentropy.dev"
+	embedPath            = "/v1/models/embed"
+	adapterContract      = "docbank-zeroentropy-zembed-1/v1"
+	compatibilityID      = "zeroentropy/zembed-1/retrieval/v1"
+	defaultTimeout       = 30 * time.Second
+	maximumTimeout       = 5 * time.Minute
+	defaultBatch         = 128
+	maximumBatch         = 2048
+	defaultItemBytes     = int64(1 << 20)
+	defaultInputBytes    = int64(4 << 20)
+	maximumInputBytes    = int64(5_000_000)
+	defaultRequestBytes  = int64(8 << 20)
+	maximumRequestBytes  = int64(16 << 20)
+	defaultResponseBytes = int64(32 << 20)
+	maximumResponseBytes = int64(128 << 20)
+	maximumTokenBytes    = 128
+)
+
+var supportedDimensions = []int{40, 80, 160, 320, 640, 1280, 2560}
+
+type EncodingFormat string
+
+const (
+	EncodingFloat  EncodingFormat = "float"
+	EncodingBase64 EncodingFormat = "base64"
+)
+
+type Latency string
+
+const (
+	LatencyAuto Latency = "auto"
+	LatencyFast Latency = "fast"
+	LatencySlow Latency = "slow"
+)
+
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, binding string) (string, error)
+}
+
+type Profile struct {
+	Descriptor         document.EmbeddingDescriptor
+	CompatibilityEpoch string
+	SecretBinding      string
+	EncodingFormat     EncodingFormat
+	Latency            Latency
+	ClientTransform    string
+	RequestTimeout     time.Duration
+	MaxBatchItems      int
+	MaxInputItemBytes  int64
+	MaxInputBytes      int64
+	MaxRequestBytes    int64
+	MaxResponseBytes   int64
+	EgressPolicy       providerhttp.EgressPolicy
+}
+
+type Client struct {
+	profile    Profile
+	descriptor document.EmbeddingDescriptor
+	secrets    SecretResolver
+	http       *http.Client
+}
+
+type policyIdentity struct {
+	AdapterContract    string                       `json:"adapter_contract"`
+	Origin             string                       `json:"origin"`
+	Route              string                       `json:"route"`
+	Descriptor         document.EmbeddingDescriptor `json:"descriptor"`
+	CompatibilityEpoch string                       `json:"compatibility_epoch"`
+	SecretBinding      string                       `json:"secret_binding"`
+	EncodingFormat     EncodingFormat               `json:"encoding_format"`
+	Latency            Latency                      `json:"latency"`
+	ClientTransform    string                       `json:"client_transform"`
+	RequestTimeout     int64                        `json:"request_timeout_nanos"`
+	MaxBatchItems      int                          `json:"max_batch_items"`
+	MaxInputItemBytes  int64                        `json:"max_input_item_bytes"`
+	MaxInputBytes      int64                        `json:"max_input_bytes"`
+	MaxRequestBytes    int64                        `json:"max_request_bytes"`
+	MaxResponseBytes   int64                        `json:"max_response_bytes"`
+	Egress             egressIdentity               `json:"egress"`
+}
+
+type egressIdentity struct {
+	Scheme              string   `json:"scheme"`
+	Host                string   `json:"host"`
+	Port                uint16   `json:"port"`
+	AllowedCIDRs        []string `json:"allowed_cidrs"`
+	ProxyMode           string   `json:"proxy_mode"`
+	ConnectTimeout      int64    `json:"connect_timeout_nanos"`
+	KeepAlive           int64    `json:"keep_alive_nanos"`
+	TLSHandshakeTimeout int64    `json:"tls_handshake_timeout_nanos"`
+	SPKISHA256          []string `json:"spki_sha256,omitempty"`
+}
+
+func PolicyFingerprint(profile Profile) (string, error) {
+	normalized, descriptor, err := normalizeProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(policyIdentity{
+		AdapterContract: adapterContract, Origin: origin, Route: embedPath, Descriptor: descriptor,
+		CompatibilityEpoch: normalized.CompatibilityEpoch, SecretBinding: normalized.SecretBinding,
+		EncodingFormat: normalized.EncodingFormat, Latency: normalized.Latency,
+		ClientTransform: normalized.ClientTransform, RequestTimeout: int64(normalized.RequestTimeout),
+		MaxBatchItems: normalized.MaxBatchItems, MaxInputItemBytes: normalized.MaxInputItemBytes,
+		MaxInputBytes: normalized.MaxInputBytes, MaxRequestBytes: normalized.MaxRequestBytes,
+		MaxResponseBytes: normalized.MaxResponseBytes, Egress: profileEgressIdentity(normalized.EgressPolicy),
+	}, json.Deterministic(true))
+	if err != nil {
+		return "", errors.New("zeroentropy embed: policy identity encoding failed")
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func New(profile Profile, secrets SecretResolver, resolver providerhttp.Resolver, supplied *http.Client) (*Client, error) {
+	if supplied == nil {
+		return nil, errors.New("zeroentropy embed: HTTP client settings source is required")
+	}
+	normalized, _, err := normalizeProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	if err != nil || !reflect.DeepEqual(descriptor, profile.Descriptor) {
+		return nil, errors.New("zeroentropy embed: descriptor is not canonical")
+	}
+	fingerprint, err := PolicyFingerprint(profile)
+	if err != nil {
+		return nil, err
+	}
+	if descriptor.PolicyFingerprint != fingerprint {
+		return nil, errors.New("zeroentropy embed: descriptor policy fingerprint does not match profile")
+	}
+	if nilInterface(secrets) {
+		return nil, errors.New("zeroentropy embed: named API-key resolver is required")
+	}
+	transport, err := providerhttp.NewTransport(normalized.EgressPolicy, resolver)
+	if err != nil {
+		return nil, errors.New("zeroentropy embed: sealed egress policy is invalid")
+	}
+	isolated := *supplied
+	isolated.Transport = transport
+	isolated.CheckRedirect = providerhttp.RefuseRedirects
+	isolated.Jar = nil
+	isolated.Timeout = 0
+	normalized.Descriptor = cloneDescriptor(descriptor)
+	return &Client{profile: normalized, descriptor: cloneDescriptor(descriptor), secrets: secrets, http: &isolated}, nil
+}
+
+func (client *Client) Descriptor() document.EmbeddingDescriptor {
+	if client == nil {
+		return document.EmbeddingDescriptor{}
+	}
+	return cloneDescriptor(client.descriptor)
+}
+
+func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, error) {
+	profile.EgressPolicy.AllowedCIDRs = slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	profile.EgressPolicy.TLS.SPKISHA256 = slices.Clone(profile.EgressPolicy.TLS.SPKISHA256)
+	if profile.EncodingFormat == "" {
+		profile.EncodingFormat = EncodingFloat
+	}
+	if profile.Latency == "" {
+		profile.Latency = LatencyAuto
+	}
+	if profile.ClientTransform == "" {
+		profile.ClientTransform = TransformNone
+	}
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = defaultTimeout
+	}
+	if profile.MaxBatchItems == 0 {
+		profile.MaxBatchItems = defaultBatch
+	}
+	if profile.MaxInputItemBytes == 0 {
+		profile.MaxInputItemBytes = defaultItemBytes
+	}
+	if profile.MaxInputBytes == 0 {
+		profile.MaxInputBytes = defaultInputBytes
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = defaultRequestBytes
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = defaultResponseBytes
+	}
+	if !slices.Contains(supportedDimensions, profile.Descriptor.Dimension) ||
+		(profile.EncodingFormat != EncodingFloat && profile.EncodingFormat != EncodingBase64) ||
+		(profile.Latency != LatencyAuto && profile.Latency != LatencyFast && profile.Latency != LatencySlow) ||
+		profile.ClientTransform != TransformNone || profile.RequestTimeout <= 0 || profile.RequestTimeout > maximumTimeout ||
+		profile.MaxBatchItems < 1 || profile.MaxBatchItems > maximumBatch ||
+		profile.MaxInputItemBytes < 1 || profile.MaxInputItemBytes > maximumInputBytes ||
+		profile.MaxInputBytes < profile.MaxInputItemBytes || profile.MaxInputBytes > maximumInputBytes ||
+		profile.MaxRequestBytes < 1 || profile.MaxRequestBytes > maximumRequestBytes ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maximumResponseBytes {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("zeroentropy embed: profile bounds or execution policy are invalid")
+	}
+	if !validToken(profile.CompatibilityEpoch) || profile.Descriptor.ModelRevision != profile.CompatibilityEpoch {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("zeroentropy embed: compatibility epoch must match descriptor revision")
+	}
+	if !validToken(profile.SecretBinding) {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("zeroentropy embed: named API-key binding is required")
+	}
+	if err := normalizeEgress(&profile.EgressPolicy); err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
+	descriptor := cloneDescriptor(profile.Descriptor)
+	descriptor.PolicyFingerprint = strings.Repeat("0", sha256.Size*2)
+	descriptor.Fingerprint = ""
+	var err error
+	descriptor, err = document.NewEmbeddingDescriptor(descriptor)
+	if err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, errors.New("zeroentropy embed: descriptor identity is invalid")
+	}
+	descriptor.PolicyFingerprint, descriptor.Fingerprint = "", ""
+	if err := validateDescriptor(descriptor, profile.CompatibilityEpoch); err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
+	return profile, descriptor, nil
+}
+
+func validateDescriptor(descriptor document.EmbeddingDescriptor, epoch string) error {
+	expected, err := modelInputContract()
+	if err != nil {
+		return errors.New("zeroentropy embed: fixed model-input contract is invalid")
+	}
+	if descriptor.ID != ProviderID || descriptor.ContractVersion != document.EmbeddingProviderContractVersion ||
+		descriptor.TrustBoundary != document.EmbeddingTrustHostedProvider || descriptor.Model != Model ||
+		descriptor.ModelRevision != epoch || !slices.Contains(supportedDimensions, descriptor.Dimension) ||
+		descriptor.Metric != document.VectorMetricCosine || descriptor.Normalization != document.VectorNormalizationNone ||
+		descriptor.ScalarEncoding != ScalarEncodingFloat32 || descriptor.DocumentFormatter != DocumentFormatterV1 ||
+		descriptor.QueryFormatter != QueryFormatterV1 || !descriptor.SupportsTextQuery ||
+		!reflect.DeepEqual(descriptor.ModelInput, expected) || descriptor.CompatibilityID != compatibilityID ||
+		!slices.Equal(descriptor.InputKinds, []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk}) ||
+		!slices.Equal(descriptor.SupportedRequestModes, []document.ModelInputMode{document.ModelInputModeDocument, document.ModelInputModeQuery}) {
+		return errors.New("zeroentropy embed: descriptor does not match the fixed hosted zembed-1 contract")
+	}
+	return nil
+}
+
+func modelInputContract() (document.ModelInputContract, error) {
+	return document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfileCustom, CompatibilityID: compatibilityID,
+		Document: document.ModelInputEncoder{Mode: document.ModelInputModeDocument, Template: "{{content}}"},
+		Query:    document.ModelInputEncoder{Mode: document.ModelInputModeQuery, Template: "{{content}}"},
+	})
+}
+
+func normalizeEgress(policy *providerhttp.EgressPolicy) error {
+	if policy.ConnectTimeout == 0 {
+		policy.ConnectTimeout = providerhttp.DefaultConnectTimeout
+	}
+	if policy.KeepAlive == 0 {
+		policy.KeepAlive = providerhttp.DefaultKeepAlive
+	}
+	if policy.TLSHandshakeTimeout == 0 {
+		policy.TLSHandshakeTimeout = providerhttp.DefaultTLSHandshakeTimeout
+	}
+	if policy.ProxyMode == "" {
+		policy.ProxyMode = providerhttp.ProxyDisabled
+	}
+	if policy.Scheme != "https" || policy.Host != host || policy.Port != 443 ||
+		policy.ProxyMode != providerhttp.ProxyDisabled || policy.TLS.RootCAs != nil {
+		return errors.New("zeroentropy embed: egress authority must be exactly api.zeroentropy.dev:443")
+	}
+	for index := range policy.AllowedCIDRs {
+		policy.AllowedCIDRs[index] = policy.AllowedCIDRs[index].Masked()
+	}
+	slices.SortFunc(policy.AllowedCIDRs, func(left, right netip.Prefix) int { return strings.Compare(left.String(), right.String()) })
+	for index := 1; index < len(policy.AllowedCIDRs); index++ {
+		if policy.AllowedCIDRs[index] == policy.AllowedCIDRs[index-1] {
+			return errors.New("zeroentropy embed: duplicate egress CIDR")
+		}
+	}
+	for index := range policy.TLS.SPKISHA256 {
+		policy.TLS.SPKISHA256[index] = strings.ToLower(policy.TLS.SPKISHA256[index])
+	}
+	slices.Sort(policy.TLS.SPKISHA256)
+	for index := 1; index < len(policy.TLS.SPKISHA256); index++ {
+		if policy.TLS.SPKISHA256[index] == policy.TLS.SPKISHA256[index-1] {
+			return errors.New("zeroentropy embed: duplicate SPKI pin")
+		}
+	}
+	if _, err := providerhttp.NewTransport(*policy, nil); err != nil {
+		return errors.New("zeroentropy embed: sealed egress policy is invalid")
+	}
+	return nil
+}
+
+func profileEgressIdentity(policy providerhttp.EgressPolicy) egressIdentity {
+	cidrs := make([]string, len(policy.AllowedCIDRs))
+	for index, prefix := range policy.AllowedCIDRs {
+		cidrs[index] = prefix.String()
+	}
+	return egressIdentity{Scheme: policy.Scheme, Host: policy.Host, Port: policy.Port, AllowedCIDRs: cidrs,
+		ProxyMode: string(policy.ProxyMode), ConnectTimeout: int64(policy.ConnectTimeout), KeepAlive: int64(policy.KeepAlive),
+		TLSHandshakeTimeout: int64(policy.TLSHandshakeTimeout), SPKISHA256: slices.Clone(policy.TLS.SPKISHA256)}
+}
+
+func cloneDescriptor(descriptor document.EmbeddingDescriptor) document.EmbeddingDescriptor {
+	descriptor.InputKinds = slices.Clone(descriptor.InputKinds)
+	descriptor.SupportedRequestModes = slices.Clone(descriptor.SupportedRequestModes)
+	return descriptor
+}
+
+func validToken(value string) bool {
+	if value == "" || len(value) > maximumTokenBytes || !utf8.ValidString(value) || value != strings.TrimSpace(value) {
+		return false
+	}
+	for _, current := range value {
+		if unicode.IsControl(current) {
+			return false
+		}
+	}
+	return true
+}
+
+func nilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/document/zeroentropy/profile_test.go
+++ b/document/zeroentropy/profile_test.go
@@ -1,0 +1,142 @@
+package zeroentropy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/netip"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+func TestNewRequiresFixedZembedProfile(t *testing.T) {
+	for _, dimension := range []int{2560, 1280, 640, 320, 160, 80, 40} {
+		for _, encoding := range []EncodingFormat{EncodingFloat, EncodingBase64} {
+			profile := testProfile(t, dimension, encoding, LatencyAuto)
+			client, err := New(profile, testSecrets{"secret:zeroentropy": "synthetic-key"},
+				testResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+			require.NoError(t, err)
+			assert.Equal(t, profile.Descriptor, client.Descriptor())
+		}
+	}
+
+	mutations := map[string]func(*Profile){
+		"model":     func(value *Profile) { value.Descriptor.Model = "zembed-2" },
+		"dimension": func(value *Profile) { value.Descriptor.Dimension = 768 },
+		"epoch":     func(value *Profile) { value.CompatibilityEpoch = "other" },
+		"encoding":  func(value *Profile) { value.EncodingFormat = "json" },
+		"latency":   func(value *Profile) { value.Latency = "instant" },
+		"transform": func(value *Profile) { value.ClientTransform = "truncate" },
+		"secret":    func(value *Profile) { value.SecretBinding = "" },
+		"host":      func(value *Profile) { value.EgressPolicy.Host = "example.com" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			profile := testProfile(t, 640, EncodingBase64, LatencyFast)
+			mutate(&profile)
+			_, err := PolicyFingerprint(profile)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestPolicyFingerprintBindsZembedExecutionIdentityWithoutMutatingProfile(t *testing.T) {
+	profile := testProfile(t, 640, EncodingBase64, LatencyFast)
+	original := slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	base, err := PolicyFingerprint(profile)
+	require.NoError(t, err)
+	mutations := map[string]func(*Profile){
+		"dimension": func(value *Profile) { value.Descriptor.Dimension = 320 },
+		"epoch": func(value *Profile) {
+			value.CompatibilityEpoch, value.Descriptor.ModelRevision = "deployment-2026-09", "deployment-2026-09"
+		},
+		"encoding": func(value *Profile) { value.EncodingFormat = EncodingFloat },
+		"latency":  func(value *Profile) { value.Latency = LatencySlow },
+		"binding":  func(value *Profile) { value.SecretBinding = "secret:other" },
+		"batch":    func(value *Profile) { value.MaxBatchItems-- },
+		"item":     func(value *Profile) { value.MaxInputItemBytes-- },
+		"input":    func(value *Profile) { value.MaxInputBytes-- },
+		"request":  func(value *Profile) { value.MaxRequestBytes-- },
+		"response": func(value *Profile) { value.MaxResponseBytes-- },
+		"timeout":  func(value *Profile) { value.RequestTimeout += time.Second },
+		"egress": func(value *Profile) {
+			value.EgressPolicy.AllowedCIDRs = []netip.Prefix{netip.MustParsePrefix("198.51.100.0/24")}
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			changed := profile
+			mutate(&changed)
+			fingerprint, fingerprintErr := PolicyFingerprint(changed)
+			require.NoError(t, fingerprintErr)
+			assert.NotEqual(t, base, fingerprint)
+		})
+	}
+	assert.Equal(t, original, profile.EgressPolicy.AllowedCIDRs)
+}
+
+func testProfile(t *testing.T, dimension int, encoding EncodingFormat, latency Latency) Profile {
+	t.Helper()
+	contract, err := document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfileCustom, CompatibilityID: "zeroentropy/zembed-1/retrieval/v1",
+		Document: document.ModelInputEncoder{Mode: document.ModelInputModeDocument, Template: "{{content}}"},
+		Query:    document.ModelInputEncoder{Mode: document.ModelInputModeQuery, Template: "{{content}}"},
+	})
+	require.NoError(t, err)
+	profile := Profile{
+		Descriptor: document.EmbeddingDescriptor{
+			ID: ProviderID, ContractVersion: document.EmbeddingProviderContractVersion,
+			TrustBoundary: document.EmbeddingTrustHostedProvider, Model: Model,
+			ModelRevision: "deployment-2026-08", Dimension: dimension, Metric: document.VectorMetricCosine,
+			Normalization: document.VectorNormalizationNone, ScalarEncoding: ScalarEncodingFloat32,
+			DocumentFormatter: DocumentFormatterV1, QueryFormatter: QueryFormatterV1,
+			InputKinds:      []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk},
+			CompatibilityID: contract.CompatibilityID, SupportsTextQuery: true, ModelInput: contract,
+			SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeDocument, document.ModelInputModeQuery},
+		},
+		CompatibilityEpoch: "deployment-2026-08", SecretBinding: "secret:zeroentropy",
+		EncodingFormat: encoding, Latency: latency, ClientTransform: TransformNone,
+		RequestTimeout: time.Second, MaxBatchItems: 128, MaxInputItemBytes: 1 << 20,
+		MaxInputBytes: 4 << 20, MaxRequestBytes: 8 << 20, MaxResponseBytes: 32 << 20,
+		EgressPolicy: providerhttp.EgressPolicy{Scheme: "https", Host: "api.zeroentropy.dev", Port: 443,
+			AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("192.0.2.0/24")},
+			ProxyMode:    providerhttp.ProxyDisabled, ConnectTimeout: time.Second,
+			KeepAlive: time.Second, TLSHandshakeTimeout: time.Second},
+	}
+	profile.Descriptor = descriptorFor(t, profile)
+	return profile
+}
+
+func descriptorFor(t *testing.T, profile Profile) document.EmbeddingDescriptor {
+	t.Helper()
+	profile.Descriptor.PolicyFingerprint = ""
+	profile.Descriptor.Fingerprint = ""
+	fingerprint, err := PolicyFingerprint(profile)
+	require.NoError(t, err)
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	descriptor, err := document.NewEmbeddingDescriptor(profile.Descriptor)
+	require.NoError(t, err)
+	return descriptor
+}
+
+type testSecrets map[string]string
+
+func (secrets testSecrets) ResolveSecret(_ context.Context, binding string) (string, error) {
+	value, ok := secrets[binding]
+	if !ok {
+		return "", errors.New("missing synthetic secret")
+	}
+	return value, nil
+}
+
+type testResolver []netip.Addr
+
+func (resolver testResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return append([]netip.Addr(nil), resolver...), nil
+}

--- a/internal/retrieval/zeroentropy/client.go
+++ b/internal/retrieval/zeroentropy/client.go
@@ -1,0 +1,241 @@
+package zeroentropy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/internal/retrieval"
+)
+
+const (
+	maximumSecretBytes    = 64 << 10
+	maximumUsage          = int64(1 << 50)
+	maximumLatencySeconds = float64(24 * 60 * 60)
+	providerPayloadMax    = int64(5_000_000)
+)
+
+var _ retrieval.RerankingProvider = (*Client)(nil)
+
+type wireRequest struct {
+	Model     string   `json:"model"`
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+	TopN      int      `json:"top_n"`
+	Latency   Latency  `json:"latency,omitempty"`
+}
+
+type wireResponse struct {
+	Results           []wireResult `json:"results"`
+	TotalBytes        *int64       `json:"total_bytes"`
+	TotalTokens       *int64       `json:"total_tokens"`
+	ActualLatencyMode Latency      `json:"actual_latency_mode"`
+	E2ELatency        *float64     `json:"e2e_latency"`
+	InferenceLatency  *float64     `json:"inference_latency"`
+}
+
+type wireResult struct {
+	Index          *int     `json:"index"`
+	RelevanceScore *float64 `json:"relevance_score"`
+}
+
+type Receipt struct {
+	PolicyFingerprint       string
+	Model                   string
+	ModelRevision           string
+	RequestedLatency        Latency
+	ActualLatency           Latency
+	CandidateCount          int
+	TotalBytes              int64
+	TotalTokens             int64
+	E2ELatencySeconds       float64
+	InferenceLatencySeconds float64
+}
+
+type Execution struct {
+	Scores  []retrieval.RerankScore
+	Receipt Receipt
+}
+
+func (client *Client) Rerank(ctx context.Context, request retrieval.RerankingRequest) ([]retrieval.RerankScore, error) {
+	execution, err := client.rerank(ctx, request, false)
+	return execution.Scores, err
+}
+
+func (client *Client) RerankWithReceipt(ctx context.Context, request retrieval.RerankingRequest) (Execution, error) {
+	return client.rerank(ctx, request, true)
+}
+
+func (client *Client) rerank(ctx context.Context, request retrieval.RerankingRequest, includeReceipt bool) (Execution, error) {
+	if client == nil || ctx == nil {
+		return Execution{}, errors.New("zeroentropy rerank: client and context are required")
+	}
+	if err := client.validateRequest(request); err != nil {
+		return Execution{}, err
+	}
+	documents := make([]string, len(request.Candidates))
+	for index, candidate := range request.Candidates {
+		documents[index] = candidate.Excerpt
+	}
+	latency := client.profile.Latency
+	if latency == LatencyAuto {
+		latency = ""
+	}
+	payload, err := json.Marshal(wireRequest{Model: Model, Query: request.Query, Documents: documents,
+		TopN: len(documents), Latency: latency})
+	if err != nil {
+		return Execution{}, errors.New("zeroentropy rerank: request encoding failed")
+	}
+	defer clear(payload)
+	if int64(len(payload)) > client.profile.MaxRequestBytes {
+		return Execution{}, &ProviderError{Kind: ErrCapacityResponse}
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
+	defer cancel()
+	secret, err := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
+	if err != nil || !validSecret(secret) {
+		if contextErr := requestCtx.Err(); contextErr != nil {
+			return Execution{}, fmt.Errorf("zeroentropy rerank: credential resolution canceled: %w", contextErr)
+		}
+		return Execution{}, errors.New("zeroentropy rerank: API-key resolution failed")
+	}
+	httpRequest, err := http.NewRequestWithContext(requestCtx, http.MethodPost, origin+rerankPath, bytes.NewReader(payload))
+	if err != nil {
+		return Execution{}, errors.New("zeroentropy rerank: request construction failed")
+	}
+	httpRequest.Header.Set("Accept", "application/json")
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Authorization", "Bearer "+secret)
+	response, err := client.http.Do(httpRequest)
+	if err != nil {
+		if contextErr := requestCtx.Err(); contextErr != nil {
+			return Execution{}, fmt.Errorf("zeroentropy rerank: request canceled: %w", contextErr)
+		}
+		return Execution{}, &ProviderError{Kind: ErrTransientResponse}
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return Execution{}, statusError(response.StatusCode, response.Header.Get("Retry-After"), time.Now().UTC())
+	}
+	if !isJSONContentType(response.Header.Get("Content-Type")) {
+		return Execution{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	body, readErr := readBounded(response.Body, client.profile.MaxResponseBytes)
+	defer clear(body)
+	if contextErr := requestCtx.Err(); contextErr != nil {
+		return Execution{}, fmt.Errorf("zeroentropy rerank: response read canceled: %w", contextErr)
+	}
+	if readErr != nil {
+		if errors.Is(readErr, errCapacity) {
+			return Execution{}, &ProviderError{Kind: ErrCapacityResponse}
+		}
+		return Execution{}, &ProviderError{Kind: ErrTransientResponse}
+	}
+	var decoded wireResponse
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil || !client.validResponse(decoded, len(request.Candidates)) {
+		return Execution{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	scores := make([]retrieval.RerankScore, len(request.Candidates))
+	seen := make([]bool, len(request.Candidates))
+	for _, result := range decoded.Results {
+		if result.Index == nil || result.RelevanceScore == nil || *result.Index < 0 || *result.Index >= len(request.Candidates) ||
+			seen[*result.Index] || math.IsNaN(*result.RelevanceScore) || math.IsInf(*result.RelevanceScore, 0) ||
+			*result.RelevanceScore < 0 || *result.RelevanceScore > 1 {
+			return Execution{}, &ProviderError{Kind: ErrPermanentResponse}
+		}
+		seen[*result.Index] = true
+		scores[*result.Index] = retrieval.RerankScore{Document: request.Candidates[*result.Index].Document, Score: *result.RelevanceScore}
+	}
+	if slices.Contains(seen, false) {
+		return Execution{}, &ProviderError{Kind: ErrPermanentResponse}
+	}
+	execution := Execution{Scores: scores}
+	if includeReceipt {
+		execution.Receipt = Receipt{PolicyFingerprint: client.fingerprint, Model: Model,
+			ModelRevision: client.profile.ModelRevision, RequestedLatency: client.profile.Latency,
+			ActualLatency: decoded.ActualLatencyMode, CandidateCount: len(request.Candidates),
+			TotalBytes: *decoded.TotalBytes, TotalTokens: *decoded.TotalTokens,
+			E2ELatencySeconds: *decoded.E2ELatency, InferenceLatencySeconds: *decoded.InferenceLatency}
+	}
+	return execution, nil
+}
+
+func (client *Client) validateRequest(request retrieval.RerankingRequest) error {
+	if strings.TrimSpace(request.Query) == "" || !utf8.ValidString(request.Query) {
+		return &ProviderError{Kind: ErrPermanentResponse}
+	}
+	if len(request.Query) > client.profile.MaxQueryBytes || len(request.Candidates) == 0 || len(request.Candidates) > client.profile.MaxCandidates {
+		return &ProviderError{Kind: ErrCapacityResponse}
+	}
+	seen := make(map[retrieval.DocumentIdentity]struct{}, len(request.Candidates))
+	var excerptBytes, providerBytes int64
+	for _, candidate := range request.Candidates {
+		if candidate.Document.VaultID == "" || candidate.Document.NodeID <= 0 || candidate.Document.ContentVersionID == "" {
+			return &ProviderError{Kind: ErrPermanentResponse}
+		}
+		if !utf8.ValidString(candidate.Excerpt) || len(candidate.Excerpt) > client.profile.MaxExcerptBytes ||
+			int64(len(candidate.Excerpt)) > client.profile.MaxTotalExcerptBytes-excerptBytes {
+			return &ProviderError{Kind: ErrCapacityResponse}
+		}
+		excerptBytes += int64(len(candidate.Excerpt))
+		increment := int64(150 + len(request.Query) + len(candidate.Excerpt))
+		if increment > providerPayloadMax-providerBytes {
+			return &ProviderError{Kind: ErrCapacityResponse}
+		}
+		providerBytes += increment
+		if _, duplicate := seen[candidate.Document]; duplicate {
+			return &ProviderError{Kind: ErrPermanentResponse}
+		}
+		seen[candidate.Document] = struct{}{}
+	}
+	return nil
+}
+
+func (client *Client) validResponse(response wireResponse, candidates int) bool {
+	if len(response.Results) != candidates || response.TotalBytes == nil || response.TotalTokens == nil ||
+		*response.TotalBytes < 0 || *response.TotalBytes > maximumUsage || *response.TotalTokens < 0 || *response.TotalTokens > maximumUsage ||
+		(response.ActualLatencyMode != LatencyFast && response.ActualLatencyMode != LatencySlow) ||
+		response.E2ELatency == nil || response.InferenceLatency == nil {
+		return false
+	}
+	if client.profile.Latency != LatencyAuto && response.ActualLatencyMode != client.profile.Latency {
+		return false
+	}
+	for _, value := range []float64{*response.E2ELatency, *response.InferenceLatency} {
+		if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || value > maximumLatencySeconds {
+			return false
+		}
+	}
+	return *response.InferenceLatency <= *response.E2ELatency
+}
+
+var errCapacity = errors.New("response capacity exceeded")
+
+func readBounded(reader io.Reader, maximum int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maximum {
+		clear(body)
+		return nil, errCapacity
+	}
+	return body, nil
+}
+
+func isJSONContentType(value string) bool {
+	mediaType, _, err := mime.ParseMediaType(value)
+	return err == nil && (mediaType == "application/json" || len(mediaType) > 5 && mediaType[len(mediaType)-5:] == "+json")
+}
+
+func validSecret(value string) bool { return len(value) <= maximumSecretBytes && validToken(value) }

--- a/internal/retrieval/zeroentropy/client.go
+++ b/internal/retrieval/zeroentropy/client.go
@@ -196,6 +196,8 @@ func (client *Client) validateRequest(request retrieval.RerankingRequest) error 
 			return &ProviderError{Kind: ErrCapacityResponse}
 		}
 		excerptBytes += int64(len(candidate.Excerpt))
+		// Provider input accounting counts the query and 150 bytes per document;
+		// MaxRequestBytes separately bounds JSON. See https://docs.zeroentropy.dev/api-reference/models/rerank.
 		increment := int64(150 + len(request.Query) + len(candidate.Excerpt))
 		if increment > providerPayloadMax-providerBytes {
 			return &ProviderError{Kind: ErrCapacityResponse}

--- a/internal/retrieval/zeroentropy/client.go
+++ b/internal/retrieval/zeroentropy/client.go
@@ -105,8 +105,11 @@ func (client *Client) rerank(ctx context.Context, request retrieval.RerankingReq
 	defer cancel()
 	secret, err := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
 	if err != nil || !validSecret(secret) {
-		if contextErr := requestCtx.Err(); contextErr != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
 			return Execution{}, fmt.Errorf("zeroentropy rerank: credential resolution canceled: %w", contextErr)
+		}
+		if requestCtx.Err() != nil {
+			return Execution{}, &ProviderError{Kind: ErrTransientResponse}
 		}
 		return Execution{}, errors.New("zeroentropy rerank: API-key resolution failed")
 	}
@@ -119,7 +122,7 @@ func (client *Client) rerank(ctx context.Context, request retrieval.RerankingReq
 	httpRequest.Header.Set("Authorization", "Bearer "+secret)
 	response, err := client.http.Do(httpRequest)
 	if err != nil {
-		if contextErr := requestCtx.Err(); contextErr != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
 			return Execution{}, fmt.Errorf("zeroentropy rerank: request canceled: %w", contextErr)
 		}
 		if errors.Is(err, providerhttp.ErrAddressDenied) || errors.Is(err, providerhttp.ErrDestinationDenied) ||
@@ -137,7 +140,7 @@ func (client *Client) rerank(ctx context.Context, request retrieval.RerankingReq
 	}
 	body, readErr := readBounded(response.Body, client.profile.MaxResponseBytes)
 	defer clear(body)
-	if contextErr := requestCtx.Err(); contextErr != nil {
+	if contextErr := ctx.Err(); contextErr != nil {
 		return Execution{}, fmt.Errorf("zeroentropy rerank: response read canceled: %w", contextErr)
 	}
 	if readErr != nil {

--- a/internal/retrieval/zeroentropy/client.go
+++ b/internal/retrieval/zeroentropy/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"go.kenn.io/docbank/document/providerhttp"
 	"go.kenn.io/docbank/internal/retrieval"
 )
 
@@ -120,6 +121,10 @@ func (client *Client) rerank(ctx context.Context, request retrieval.RerankingReq
 	if err != nil {
 		if contextErr := requestCtx.Err(); contextErr != nil {
 			return Execution{}, fmt.Errorf("zeroentropy rerank: request canceled: %w", contextErr)
+		}
+		if errors.Is(err, providerhttp.ErrAddressDenied) || errors.Is(err, providerhttp.ErrDestinationDenied) ||
+			errors.Is(err, providerhttp.ErrCertificatePin) {
+			return Execution{}, &ProviderError{Kind: ErrPermanentResponse}
 		}
 		return Execution{}, &ProviderError{Kind: ErrTransientResponse}
 	}

--- a/internal/retrieval/zeroentropy/client_test.go
+++ b/internal/retrieval/zeroentropy/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json/v2"
+	"fmt"
 	"io"
 	"net/http"
 	"net/netip"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document/providerhttp"
 	"go.kenn.io/docbank/internal/retrieval"
 )
 
@@ -214,3 +216,35 @@ func (body *contextBody) Read([]byte) (int, error) {
 }
 
 func (*contextBody) Close() error { return nil }
+
+func TestRerankClassifiesDeniedDNSAsPermanent(t *testing.T) {
+	client, err := New(testProfile(LatencyAuto), testSecrets{"secret:zeroentropy-rerank": "synthetic-key"},
+		testResolver{netip.MustParseAddr("198.51.100.10")}, &http.Client{})
+	require.NoError(t, err)
+
+	_, err = client.Rerank(context.Background(), rerankingRequest())
+	require.ErrorIs(t, err, ErrPermanentResponse)
+}
+
+func TestRerankClassifiesTransportFailures(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		failure error
+		want    error
+	}{
+		{"address denied", providerhttp.ErrAddressDenied, ErrPermanentResponse},
+		{"destination denied", providerhttp.ErrDestinationDenied, ErrPermanentResponse},
+		{"certificate pin", providerhttp.ErrCertificatePin, ErrPermanentResponse},
+		{"connection failure", assert.AnError, ErrTransientResponse},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := testClient(t, testProfile(LatencyAuto), testSecrets{"secret:zeroentropy-rerank": "synthetic-key"},
+				roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return nil, fmt.Errorf("provider transport: %w", test.failure)
+				}))
+
+			_, err := client.Rerank(context.Background(), rerankingRequest())
+			require.ErrorIs(t, err, test.want)
+		})
+	}
+}

--- a/internal/retrieval/zeroentropy/client_test.go
+++ b/internal/retrieval/zeroentropy/client_test.go
@@ -1,0 +1,216 @@
+package zeroentropy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"io"
+	"net/http"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/retrieval"
+)
+
+func TestRerankSendsOnlyScopedExcerptsAndMapsEveryStableID(t *testing.T) {
+	profile := testProfile(LatencyFast)
+	client := testClient(t, profile, testSecrets{"secret:zeroentropy-rerank": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		assert.Equal(t, "https://api.zeroentropy.dev/v1/models/rerank", request.URL.String())
+		assert.Equal(t, "Bearer synthetic-key", request.Header.Get("Authorization"))
+		body, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		for _, localOnly := range []string{"vault-private", "version-private", "build-private", "segment-private"} {
+			assert.NotContains(t, string(body), localOnly)
+		}
+		var payload struct {
+			Model     string   `json:"model"`
+			Query     string   `json:"query"`
+			Documents []string `json:"documents"`
+			TopN      int      `json:"top_n"`
+			Latency   Latency  `json:"latency"`
+		}
+		require.NoError(t, json.Unmarshal(body, &payload, json.RejectUnknownMembers(true)))
+		assert.Equal(t, Model, payload.Model)
+		assert.Equal(t, "private query", payload.Query)
+		assert.Equal(t, []string{"first excerpt", "second excerpt"}, payload.Documents)
+		assert.Equal(t, 2, payload.TopN)
+		assert.Equal(t, LatencyFast, payload.Latency)
+		response := []byte(`{"results":[{"index":1,"relevance_score":0.9},{"index":0,"relevance_score":0.2}],"total_bytes":360,"total_tokens":12,"actual_latency_mode":"fast","e2e_latency":0.25,"inference_latency":0.2}`)
+		return rerankJSONResponse(request, http.StatusOK, response), nil
+	}))
+	request := rerankingRequest()
+
+	execution, err := client.RerankWithReceipt(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, []retrieval.RerankScore{
+		{Document: request.Candidates[0].Document, Score: 0.2},
+		{Document: request.Candidates[1].Document, Score: 0.9},
+	}, execution.Scores)
+	assert.Equal(t, Receipt{PolicyFingerprint: client.PolicyFingerprint(), Model: Model,
+		ModelRevision: profile.ModelRevision, RequestedLatency: LatencyFast, ActualLatency: LatencyFast,
+		CandidateCount: 2, TotalBytes: 360, TotalTokens: 12, E2ELatencySeconds: 0.25,
+		InferenceLatencySeconds: 0.2}, execution.Receipt)
+}
+
+func TestRerankOmitsAutoLatencyAndRejectsIncompleteOrInvalidResults(t *testing.T) {
+	valid := `{"results":[{"index":0,"relevance_score":0.2},{"index":1,"relevance_score":0.9}],"total_bytes":360,"total_tokens":12,"actual_latency_mode":"slow","e2e_latency":12.5,"inference_latency":11.5}`
+	tests := map[string]string{
+		"missing":            strings.Replace(valid, `,{"index":1,"relevance_score":0.9}`, "", 1),
+		"duplicate":          strings.Replace(valid, `"index":1`, `"index":0`, 1),
+		"outside":            strings.Replace(valid, `"index":1`, `"index":2`, 1),
+		"negative":           strings.Replace(valid, `0.2`, `-0.2`, 1),
+		"non finite latency": strings.Replace(valid, `12.5`, `1e1000`, 1),
+		"unknown":            strings.Replace(valid, `"total_bytes":`, `"private":true,"total_bytes":`, 1),
+	}
+	for name, response := range tests {
+		t.Run(name, func(t *testing.T) {
+			profile := testProfile(LatencyAuto)
+			client := testClient(t, profile, testSecrets{"secret:zeroentropy-rerank": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				body, err := io.ReadAll(request.Body)
+				require.NoError(t, err)
+				assert.NotContains(t, string(body), `"latency"`)
+				return rerankJSONResponse(request, http.StatusOK, []byte(response)), nil
+			}))
+			_, err := client.Rerank(context.Background(), rerankingRequest())
+			require.ErrorIs(t, err, ErrPermanentResponse)
+			assert.NotContains(t, err.Error(), "private")
+		})
+	}
+}
+
+func TestRerankRejectsDuplicateStableIDsAndProviderPayloadBeforeSecrets(t *testing.T) {
+	profile := testProfile(LatencySlow)
+	secrets := &countingSecrets{value: "synthetic-key"}
+	var requests atomic.Int32
+	client := testClient(t, profile, secrets, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return nil, assert.AnError
+	}))
+	request := rerankingRequest()
+	request.Candidates[1].Document = request.Candidates[0].Document
+	_, err := client.Rerank(context.Background(), request)
+	require.ErrorIs(t, err, ErrPermanentResponse)
+	assert.Zero(t, secrets.calls.Load())
+
+	request = rerankingRequest()
+	request.Query = strings.Repeat("q", profile.MaxQueryBytes)
+	request.Candidates[0].Excerpt = strings.Repeat("d", int(profile.MaxTotalExcerptBytes/2))
+	request.Candidates[1].Excerpt = strings.Repeat("d", int(profile.MaxTotalExcerptBytes/2))
+	_, err = client.Rerank(context.Background(), request)
+	require.ErrorIs(t, err, ErrCapacityResponse)
+	assert.Zero(t, secrets.calls.Load())
+	assert.Zero(t, requests.Load())
+}
+
+func TestRerankRejectsIncompleteStableIDsBeforeSecretsOrEgress(t *testing.T) {
+	tests := map[string]func(*retrieval.DocumentIdentity){
+		"vault":   func(value *retrieval.DocumentIdentity) { value.VaultID = "" },
+		"node":    func(value *retrieval.DocumentIdentity) { value.NodeID = 0 },
+		"version": func(value *retrieval.DocumentIdentity) { value.ContentVersionID = "" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			secrets := &countingSecrets{value: "synthetic-key"}
+			var requests atomic.Int32
+			client := testClient(t, testProfile(LatencyFast), secrets, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				requests.Add(1)
+				return nil, assert.AnError
+			}))
+			request := rerankingRequest()
+			mutate(&request.Candidates[0].Document)
+
+			_, err := client.Rerank(context.Background(), request)
+			require.ErrorIs(t, err, ErrPermanentResponse)
+			assert.Zero(t, secrets.calls.Load())
+			assert.Zero(t, requests.Load())
+		})
+	}
+}
+
+func TestRerankRequiresExplicitLatencyToMatchProviderMode(t *testing.T) {
+	profile := testProfile(LatencyFast)
+	client := testClient(t, profile, testSecrets{"secret:zeroentropy-rerank": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		response := []byte(`{"results":[{"index":0,"relevance_score":0.2},{"index":1,"relevance_score":0.9}],"total_bytes":360,"total_tokens":12,"actual_latency_mode":"slow","e2e_latency":12.5,"inference_latency":11.5}`)
+		return rerankJSONResponse(request, http.StatusOK, response), nil
+	}))
+
+	_, err := client.Rerank(context.Background(), rerankingRequest())
+	require.ErrorIs(t, err, ErrPermanentResponse)
+}
+
+func TestRerankPreservesCancellationDuringResponseRead(t *testing.T) {
+	started := make(chan struct{})
+	client := testClient(t, testProfile(LatencyFast), testSecrets{"secret:zeroentropy-rerank": "synthetic-key"}, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		close(started)
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+			Body: &contextBody{ctx: request.Context()}, Request: request}, nil
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Rerank(ctx, rerankingRequest())
+		done <- err
+	}()
+	<-started
+	cancel()
+	assert.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRetryAfterClampsBeforeDurationConversion(t *testing.T) {
+	err := statusError(http.StatusTooManyRequests, "9223372036854775807", time.Now().UTC())
+	delay, ok := RetryAfter(err)
+	assert.True(t, ok)
+	assert.Equal(t, time.Hour, delay)
+}
+
+func rerankingRequest() retrieval.RerankingRequest {
+	return retrieval.RerankingRequest{Query: "private query", Candidates: []retrieval.RerankingCandidate{
+		{Document: retrieval.DocumentIdentity{VaultID: "vault-private", NodeID: 1, ContentVersionID: "version-private-1"},
+			Excerpt: "first excerpt", Evidence: []retrieval.EvidenceReference{{Kind: "rendition_segment", BuildID: "build-private", SegmentID: "segment-private"}}},
+		{Document: retrieval.DocumentIdentity{VaultID: "vault-private", NodeID: 2, ContentVersionID: "version-private-2"},
+			Excerpt: "second excerpt"},
+	}}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func testClient(t *testing.T, profile Profile, secrets SecretResolver, transport http.RoundTripper) *Client {
+	t.Helper()
+	client, err := New(profile, secrets, testResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+	require.NoError(t, err)
+	client.http.Transport = transport
+	return client
+}
+
+func rerankJSONResponse(request *http.Request, status int, body []byte) *http.Response {
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(bytes.NewReader(body)), Request: request}
+}
+
+type countingSecrets struct {
+	value string
+	calls atomic.Int32
+}
+
+func (resolver *countingSecrets) ResolveSecret(context.Context, string) (string, error) {
+	resolver.calls.Add(1)
+	return resolver.value, nil
+}
+
+type contextBody struct{ ctx context.Context }
+
+func (body *contextBody) Read([]byte) (int, error) {
+	<-body.ctx.Done()
+	return 0, body.ctx.Err()
+}
+
+func (*contextBody) Close() error { return nil }

--- a/internal/retrieval/zeroentropy/client_test.go
+++ b/internal/retrieval/zeroentropy/client_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -247,4 +248,71 @@ func TestRerankClassifiesTransportFailures(t *testing.T) {
 			require.ErrorIs(t, err, test.want)
 		})
 	}
+}
+
+func TestRerankDistinguishesAdapterTimeoutFromCallerCancellation(t *testing.T) {
+	for _, phase := range []string{"credential", "request", "response"} {
+		for _, cause := range []string{"adapter timeout", "caller deadline", "caller cancellation"} {
+			t.Run(phase+"/"+cause, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if cause == "caller deadline" {
+						var cancelDeadline context.CancelFunc
+						ctx, cancelDeadline = context.WithTimeout(ctx, time.Millisecond)
+						defer cancelDeadline()
+					}
+					waitForContext := func(requestCtx context.Context) error {
+						if cause == "caller cancellation" {
+							cancel()
+						}
+						<-requestCtx.Done()
+						return requestCtx.Err()
+					}
+					secrets := secretResolverFunc(func(requestCtx context.Context, _ string) (string, error) {
+						if phase == "credential" {
+							return "", waitForContext(requestCtx)
+						}
+						return "synthetic-key", nil
+					})
+					var bodyDone chan struct{}
+					client := testClient(t, testProfile(LatencyAuto), secrets, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+						if phase == "request" {
+							return nil, waitForContext(request.Context())
+						}
+						reader, writer := io.Pipe()
+						bodyDone = make(chan struct{})
+						go func() {
+							defer close(bodyDone)
+							_ = writer.CloseWithError(waitForContext(request.Context()))
+						}()
+						return &http.Response{StatusCode: http.StatusOK,
+							Header: http.Header{"Content-Type": []string{"application/json"}}, Body: reader, Request: request}, nil
+					}))
+					_, err := client.Rerank(ctx, rerankingRequest())
+					if bodyDone != nil {
+						<-bodyDone
+					}
+					switch cause {
+					case "adapter timeout":
+						require.ErrorIs(t, err, ErrTransientResponse)
+						require.NotErrorIs(t, err, context.DeadlineExceeded)
+						require.NoError(t, ctx.Err())
+					case "caller deadline":
+						require.ErrorIs(t, err, context.DeadlineExceeded)
+						require.NotErrorIs(t, err, ErrTransientResponse)
+					case "caller cancellation":
+						require.ErrorIs(t, err, context.Canceled)
+						require.NotErrorIs(t, err, ErrTransientResponse)
+					}
+				})
+			})
+		}
+	}
+}
+
+type secretResolverFunc func(context.Context, string) (string, error)
+
+func (resolve secretResolverFunc) ResolveSecret(ctx context.Context, binding string) (string, error) {
+	return resolve(ctx, binding)
 }

--- a/internal/retrieval/zeroentropy/errors.go
+++ b/internal/retrieval/zeroentropy/errors.go
@@ -1,0 +1,70 @@
+package zeroentropy
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrTransientResponse = errors.New("zeroentropy rerank: transient provider response")
+	ErrCapacityResponse  = errors.New("zeroentropy rerank: provider capacity exceeded")
+	ErrPermanentResponse = errors.New("zeroentropy rerank: permanent provider response")
+)
+
+type ProviderError struct {
+	Kind       error
+	StatusCode int
+	RetryDelay time.Duration
+	RetrySet   bool
+}
+
+func (failure *ProviderError) Error() string {
+	if failure.StatusCode != 0 {
+		return fmt.Sprintf("zeroentropy rerank: HTTP %d: %v", failure.StatusCode, failure.Kind)
+	}
+	return failure.Kind.Error()
+}
+
+func (failure *ProviderError) Unwrap() error { return failure.Kind }
+
+func RetryAfter(err error) (time.Duration, bool) {
+	failure, ok := errors.AsType[*ProviderError](err)
+	if !ok || !failure.RetrySet {
+		return 0, false
+	}
+	return failure.RetryDelay, true
+}
+
+func statusError(status int, retryAfter string, now time.Time) error {
+	kind := ErrPermanentResponse
+	switch {
+	case status == http.StatusRequestEntityTooLarge:
+		kind = ErrCapacityResponse
+	case status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= 500 && status <= 599:
+		kind = ErrTransientResponse
+	}
+	delay, set := parseRetryAfter(retryAfter, now)
+	if !errors.Is(kind, ErrTransientResponse) {
+		delay, set = 0, false
+	}
+	return &ProviderError{Kind: kind, StatusCode: status, RetryDelay: delay, RetrySet: set}
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+		if seconds >= int64(time.Hour/time.Second) {
+			return time.Hour, true
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	return min(max(when.Sub(now), 0), time.Hour), true
+}

--- a/internal/retrieval/zeroentropy/profile.go
+++ b/internal/retrieval/zeroentropy/profile.go
@@ -1,0 +1,289 @@
+// Package zeroentropy implements the fixed hosted ZeroEntropy zerank-2 contract.
+package zeroentropy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"net/http"
+	"net/netip"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	Model                = "zerank-2"
+	host                 = "api.zeroentropy.dev"
+	origin               = "https://api.zeroentropy.dev"
+	rerankPath           = "/v1/models/rerank"
+	adapterContract      = "docbank-zeroentropy-zerank-2/v1"
+	maximumCandidates    = 2048
+	maximumQueryBytes    = 64 << 10
+	maximumExcerptBytes  = 1 << 20
+	maximumTotalExcerpts = int64(5_000_000)
+	maximumRequestBytes  = int64(16 << 20)
+	maximumResponseBytes = int64(64 << 20)
+	maximumTimeout       = 5 * time.Minute
+	maximumTokenBytes    = 128
+)
+
+type Latency string
+
+const (
+	LatencyAuto Latency = "auto"
+	LatencyFast Latency = "fast"
+	LatencySlow Latency = "slow"
+)
+
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, binding string) (string, error)
+}
+
+type Profile struct {
+	ID                   string
+	Model                string
+	CompatibilityEpoch   string
+	ModelRevision        string
+	SecretBinding        string
+	Latency              Latency
+	RequestTimeout       time.Duration
+	MaxCandidates        int
+	MaxQueryBytes        int
+	MaxExcerptBytes      int
+	MaxTotalExcerptBytes int64
+	MaxRequestBytes      int64
+	MaxResponseBytes     int64
+	EgressPolicy         providerhttp.EgressPolicy
+}
+
+type Client struct {
+	profile     Profile
+	fingerprint string
+	secrets     SecretResolver
+	http        *http.Client
+}
+
+type policyIdentity struct {
+	AdapterContract      string         `json:"adapter_contract"`
+	Origin               string         `json:"origin"`
+	Route                string         `json:"route"`
+	ID                   string         `json:"id"`
+	Model                string         `json:"model"`
+	CompatibilityEpoch   string         `json:"compatibility_epoch"`
+	ModelRevision        string         `json:"model_revision"`
+	SecretBinding        string         `json:"secret_binding"`
+	Latency              Latency        `json:"latency"`
+	RequestTimeout       int64          `json:"request_timeout_nanos"`
+	MaxCandidates        int            `json:"max_candidates"`
+	MaxQueryBytes        int            `json:"max_query_bytes"`
+	MaxExcerptBytes      int            `json:"max_excerpt_bytes"`
+	MaxTotalExcerptBytes int64          `json:"max_total_excerpt_bytes"`
+	MaxRequestBytes      int64          `json:"max_request_bytes"`
+	MaxResponseBytes     int64          `json:"max_response_bytes"`
+	Egress               egressIdentity `json:"egress"`
+}
+
+type egressIdentity struct {
+	Scheme              string   `json:"scheme"`
+	Host                string   `json:"host"`
+	Port                uint16   `json:"port"`
+	AllowedCIDRs        []string `json:"allowed_cidrs"`
+	ProxyMode           string   `json:"proxy_mode"`
+	ConnectTimeout      int64    `json:"connect_timeout_nanos"`
+	KeepAlive           int64    `json:"keep_alive_nanos"`
+	TLSHandshakeTimeout int64    `json:"tls_handshake_timeout_nanos"`
+	SPKISHA256          []string `json:"spki_sha256,omitempty"`
+}
+
+func PolicyFingerprint(profile Profile) (string, error) {
+	normalized, err := normalizeProfile(profile)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(policyIdentity{AdapterContract: adapterContract, Origin: origin, Route: rerankPath,
+		ID: normalized.ID, Model: normalized.Model, CompatibilityEpoch: normalized.CompatibilityEpoch,
+		ModelRevision: normalized.ModelRevision, SecretBinding: normalized.SecretBinding, Latency: normalized.Latency,
+		RequestTimeout: int64(normalized.RequestTimeout), MaxCandidates: normalized.MaxCandidates,
+		MaxQueryBytes: normalized.MaxQueryBytes, MaxExcerptBytes: normalized.MaxExcerptBytes,
+		MaxTotalExcerptBytes: normalized.MaxTotalExcerptBytes, MaxRequestBytes: normalized.MaxRequestBytes,
+		MaxResponseBytes: normalized.MaxResponseBytes, Egress: profileEgressIdentity(normalized.EgressPolicy)}, json.Deterministic(true))
+	if err != nil {
+		return "", errors.New("zeroentropy rerank: policy identity encoding failed")
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func New(profile Profile, secrets SecretResolver, resolver providerhttp.Resolver, supplied *http.Client) (*Client, error) {
+	if supplied == nil {
+		return nil, errors.New("zeroentropy rerank: HTTP client settings source is required")
+	}
+	normalized, err := normalizeProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	if nilInterface(secrets) {
+		return nil, errors.New("zeroentropy rerank: named API-key resolver is required")
+	}
+	fingerprint, err := PolicyFingerprint(profile)
+	if err != nil {
+		return nil, err
+	}
+	transport, err := providerhttp.NewTransport(normalized.EgressPolicy, resolver)
+	if err != nil {
+		return nil, errors.New("zeroentropy rerank: sealed egress policy is invalid")
+	}
+	isolated := *supplied
+	isolated.Transport = transport
+	isolated.CheckRedirect = providerhttp.RefuseRedirects
+	isolated.Jar = nil
+	isolated.Timeout = 0
+	return &Client{profile: normalized, fingerprint: fingerprint, secrets: secrets, http: &isolated}, nil
+}
+
+func (client *Client) ProfileID() string {
+	if client == nil {
+		return ""
+	}
+	return client.profile.ID
+}
+func (client *Client) Model() string {
+	if client == nil {
+		return ""
+	}
+	return client.profile.Model
+}
+func (client *Client) PolicyFingerprint() string {
+	if client == nil {
+		return ""
+	}
+	return client.fingerprint
+}
+
+func normalizeProfile(profile Profile) (Profile, error) {
+	profile.EgressPolicy.AllowedCIDRs = slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	profile.EgressPolicy.TLS.SPKISHA256 = slices.Clone(profile.EgressPolicy.TLS.SPKISHA256)
+	if profile.Latency == "" {
+		profile.Latency = LatencyAuto
+	}
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = 30 * time.Second
+	}
+	if profile.MaxCandidates == 0 {
+		profile.MaxCandidates = 100
+	}
+	if profile.MaxQueryBytes == 0 {
+		profile.MaxQueryBytes = 4096
+	}
+	if profile.MaxExcerptBytes == 0 {
+		profile.MaxExcerptBytes = 64 << 10
+	}
+	if profile.MaxTotalExcerptBytes == 0 {
+		profile.MaxTotalExcerptBytes = 4 << 20
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = 8 << 20
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = 8 << 20
+	}
+	if !validToken(profile.ID) || profile.Model != Model || !validToken(profile.CompatibilityEpoch) ||
+		profile.ModelRevision != profile.CompatibilityEpoch || !validToken(profile.SecretBinding) ||
+		(profile.Latency != LatencyAuto && profile.Latency != LatencyFast && profile.Latency != LatencySlow) ||
+		profile.RequestTimeout <= 0 || profile.RequestTimeout > maximumTimeout ||
+		profile.MaxCandidates < 1 || profile.MaxCandidates > maximumCandidates ||
+		profile.MaxQueryBytes < 1 || profile.MaxQueryBytes > maximumQueryBytes ||
+		profile.MaxExcerptBytes < 1 || profile.MaxExcerptBytes > maximumExcerptBytes ||
+		profile.MaxTotalExcerptBytes < int64(profile.MaxExcerptBytes) || profile.MaxTotalExcerptBytes > maximumTotalExcerpts ||
+		profile.MaxRequestBytes < 1 || profile.MaxRequestBytes > maximumRequestBytes ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maximumResponseBytes {
+		return Profile{}, errors.New("zeroentropy rerank: profile is invalid")
+	}
+	if err := normalizeEgress(&profile.EgressPolicy); err != nil {
+		return Profile{}, err
+	}
+	return profile, nil
+}
+
+func normalizeEgress(policy *providerhttp.EgressPolicy) error {
+	if policy.ConnectTimeout == 0 {
+		policy.ConnectTimeout = providerhttp.DefaultConnectTimeout
+	}
+	if policy.KeepAlive == 0 {
+		policy.KeepAlive = providerhttp.DefaultKeepAlive
+	}
+	if policy.TLSHandshakeTimeout == 0 {
+		policy.TLSHandshakeTimeout = providerhttp.DefaultTLSHandshakeTimeout
+	}
+	if policy.ProxyMode == "" {
+		policy.ProxyMode = providerhttp.ProxyDisabled
+	}
+	if policy.Scheme != "https" || policy.Host != host || policy.Port != 443 || policy.ProxyMode != providerhttp.ProxyDisabled || policy.TLS.RootCAs != nil {
+		return errors.New("zeroentropy rerank: egress authority must be exactly api.zeroentropy.dev:443")
+	}
+	for index := range policy.AllowedCIDRs {
+		policy.AllowedCIDRs[index] = policy.AllowedCIDRs[index].Masked()
+	}
+	slices.SortFunc(policy.AllowedCIDRs, func(left, right netip.Prefix) int { return strings.Compare(left.String(), right.String()) })
+	for index := 1; index < len(policy.AllowedCIDRs); index++ {
+		if policy.AllowedCIDRs[index] == policy.AllowedCIDRs[index-1] {
+			return errors.New("zeroentropy rerank: duplicate egress CIDR")
+		}
+	}
+	for index := range policy.TLS.SPKISHA256 {
+		policy.TLS.SPKISHA256[index] = strings.ToLower(policy.TLS.SPKISHA256[index])
+	}
+	slices.Sort(policy.TLS.SPKISHA256)
+	for index := 1; index < len(policy.TLS.SPKISHA256); index++ {
+		if policy.TLS.SPKISHA256[index] == policy.TLS.SPKISHA256[index-1] {
+			return errors.New("zeroentropy rerank: duplicate SPKI pin")
+		}
+	}
+	if _, err := providerhttp.NewTransport(*policy, nil); err != nil {
+		return errors.New("zeroentropy rerank: sealed egress policy is invalid")
+	}
+	return nil
+}
+
+func profileEgressIdentity(policy providerhttp.EgressPolicy) egressIdentity {
+	cidrs := make([]string, len(policy.AllowedCIDRs))
+	for index, prefix := range policy.AllowedCIDRs {
+		cidrs[index] = prefix.String()
+	}
+	return egressIdentity{Scheme: policy.Scheme, Host: policy.Host, Port: policy.Port, AllowedCIDRs: cidrs,
+		ProxyMode: string(policy.ProxyMode), ConnectTimeout: int64(policy.ConnectTimeout), KeepAlive: int64(policy.KeepAlive),
+		TLSHandshakeTimeout: int64(policy.TLSHandshakeTimeout), SPKISHA256: slices.Clone(policy.TLS.SPKISHA256)}
+}
+
+func validToken(value string) bool {
+	if value == "" || len(value) > maximumTokenBytes || !utf8.ValidString(value) || value != strings.TrimSpace(value) {
+		return false
+	}
+	for _, current := range value {
+		if unicode.IsControl(current) {
+			return false
+		}
+	}
+	return true
+}
+
+func nilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/internal/retrieval/zeroentropy/profile_test.go
+++ b/internal/retrieval/zeroentropy/profile_test.go
@@ -1,0 +1,104 @@
+package zeroentropy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/netip"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+func TestNewRequiresIndependentFixedZerankProfile(t *testing.T) {
+	for _, latency := range []Latency{LatencyAuto, LatencyFast, LatencySlow} {
+		profile := testProfile(latency)
+		client, err := New(profile, testSecrets{"secret:zeroentropy-rerank": "synthetic-key"},
+			testResolver{netip.MustParseAddr("192.0.2.10")}, &http.Client{})
+		require.NoError(t, err)
+		assert.Equal(t, profile.ID, client.ProfileID())
+		assert.Equal(t, Model, client.Model())
+	}
+
+	mutations := map[string]func(*Profile){
+		"id":         func(value *Profile) { value.ID = "" },
+		"model":      func(value *Profile) { value.Model = "zerank-1" },
+		"epoch":      func(value *Profile) { value.CompatibilityEpoch = "other" },
+		"latency":    func(value *Profile) { value.Latency = "instant" },
+		"binding":    func(value *Profile) { value.SecretBinding = "" },
+		"candidates": func(value *Profile) { value.MaxCandidates = 2049 },
+		"host":       func(value *Profile) { value.EgressPolicy.Host = "example.com" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			profile := testProfile(LatencyFast)
+			mutate(&profile)
+			_, err := PolicyFingerprint(profile)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestPolicyFingerprintBindsZerankAuthorityWithoutMutatingProfile(t *testing.T) {
+	profile := testProfile(LatencyFast)
+	original := slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	base, err := PolicyFingerprint(profile)
+	require.NoError(t, err)
+	mutations := map[string]func(*Profile){
+		"epoch":      func(value *Profile) { value.CompatibilityEpoch, value.ModelRevision = "next", "next" },
+		"latency":    func(value *Profile) { value.Latency = LatencySlow },
+		"binding":    func(value *Profile) { value.SecretBinding = "secret:other" },
+		"timeout":    func(value *Profile) { value.RequestTimeout += time.Second },
+		"candidates": func(value *Profile) { value.MaxCandidates-- },
+		"query":      func(value *Profile) { value.MaxQueryBytes-- },
+		"excerpt":    func(value *Profile) { value.MaxExcerptBytes-- },
+		"total":      func(value *Profile) { value.MaxTotalExcerptBytes-- },
+		"request":    func(value *Profile) { value.MaxRequestBytes-- },
+		"response":   func(value *Profile) { value.MaxResponseBytes-- },
+		"egress": func(value *Profile) {
+			value.EgressPolicy.AllowedCIDRs = []netip.Prefix{netip.MustParsePrefix("198.51.100.0/24")}
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			changed := profile
+			mutate(&changed)
+			fingerprint, fingerprintErr := PolicyFingerprint(changed)
+			require.NoError(t, fingerprintErr)
+			assert.NotEqual(t, base, fingerprint)
+		})
+	}
+	assert.Equal(t, original, profile.EgressPolicy.AllowedCIDRs)
+}
+
+func testProfile(latency Latency) Profile {
+	return Profile{ID: "zeroentropy-rerank", Model: Model, CompatibilityEpoch: "deployment-2026-08",
+		ModelRevision: "deployment-2026-08", SecretBinding: "secret:zeroentropy-rerank", Latency: latency,
+		RequestTimeout: time.Second, MaxCandidates: 2048, MaxQueryBytes: 4096,
+		MaxExcerptBytes: 64 << 10, MaxTotalExcerptBytes: 4 << 20,
+		MaxRequestBytes: 8 << 20, MaxResponseBytes: 8 << 20,
+		EgressPolicy: providerhttp.EgressPolicy{Scheme: "https", Host: "api.zeroentropy.dev", Port: 443,
+			AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("192.0.2.0/24")},
+			ProxyMode:    providerhttp.ProxyDisabled, ConnectTimeout: time.Second,
+			KeepAlive: time.Second, TLSHandshakeTimeout: time.Second}}
+}
+
+type testSecrets map[string]string
+
+func (secrets testSecrets) ResolveSecret(_ context.Context, binding string) (string, error) {
+	value, ok := secrets[binding]
+	if !ok {
+		return "", errors.New("missing synthetic secret")
+	}
+	return value, nil
+}
+
+type testResolver []netip.Addr
+
+func (resolver testResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return append([]netip.Addr(nil), resolver...), nil
+}


### PR DESCRIPTION
Go applications can generate document and query embeddings with ZeroEntropy `zembed-1` through `document/zeroentropy`. Profiles support 40, 80, 160, 320, 640, 1280, and 2560 dimensions, float or base64 encoding, and auto, fast, or slow latency. Document and query inputs are sent separately and results retain the input order.

The separate `internal/retrieval/zeroentropy` adapter adds `zerank-2` reranking. It sends bounded queries and candidate excerpts, requires a complete set of finite scores, and maps provider indices back to local document identities. Both adapters use independent profiles, named credentials, fixed ZeroEntropy egress, and bounded requests and responses. Optional receipts record usage and latency settings without document text.

This PR adds the adapter packages. CLI/daemon configuration and runtime wiring are not included.

Parent: #226 (merged).

Refs #176
