### PR TITLE
[E13–S9 04/15] Add self-hosted BGE-M3 and Qwen3 profiles

### DIFF
--- a/document/openaicompat/client.go
+++ b/document/openaicompat/client.go
@@ -73,6 +73,7 @@ type Profile struct {
 	Origin                 string
 	Descriptor             document.EmbeddingDescriptor
 	ModelInput             document.ModelInputContract
+	DeploymentContract     *DeploymentContract
 	SecretBinding          string
 	DeploymentEpoch        string
 	ProviderRevisionHeader string
@@ -117,6 +118,7 @@ type policyIdentity struct {
 	Route                  string                       `json:"route"`
 	Descriptor             document.EmbeddingDescriptor `json:"descriptor"`
 	ModelInput             document.ModelInputContract  `json:"model_input"`
+	DeploymentContract     *DeploymentContract          `json:"deployment_contract,omitempty"`
 	CredentialBinding      string                       `json:"credential_binding"`
 	DeploymentEpoch        string                       `json:"deployment_epoch,omitempty"`
 	ProviderRevisionHeader string                       `json:"provider_revision_header,omitempty"`
@@ -182,7 +184,8 @@ func PolicyFingerprint(profile Profile) (string, error) {
 	identity := policyIdentity{
 		AdapterContract: adapterContract, Origin: normalized.Origin, Route: embeddingsPath,
 		Descriptor: descriptorIdentity, ModelInput: normalized.ModelInput,
-		CredentialBinding: normalized.SecretBinding, DeploymentEpoch: normalized.DeploymentEpoch,
+		DeploymentContract: normalized.DeploymentContract,
+		CredentialBinding:  normalized.SecretBinding, DeploymentEpoch: normalized.DeploymentEpoch,
 		ProviderRevisionHeader: normalized.ProviderRevisionHeader,
 		RequestTimeoutNanos:    int64(normalized.RequestTimeout), MaxBatchItems: normalized.MaxBatchItems,
 		MaxInputBytes: normalized.MaxInputBytes, MaxRequestBytes: normalized.MaxRequestBytes,
@@ -436,6 +439,11 @@ func (client *Client) validateVector(vector []float32) error {
 }
 
 func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, error) {
+	if profile.DeploymentContract != nil {
+		contract := *profile.DeploymentContract
+		profile.DeploymentContract = &contract
+	}
+	profile.EgressPolicy = cloneEgressPolicy(profile.EgressPolicy)
 	// CertPool does not expose certificate contents for a canonical identity.
 	// A subject-only hash would conflate distinct trust roots.
 	if profile.EgressPolicy.TLS.RootCAs != nil {
@@ -517,6 +525,9 @@ func normalizeProfile(profile Profile) (Profile, document.EmbeddingDescriptor, e
 	if err := validateDescriptorContract(descriptorIdentity, profile.ModelInput); err != nil {
 		return Profile{}, document.EmbeddingDescriptor{}, err
 	}
+	if err := validateDeploymentContract(profile.DeploymentContract, descriptorIdentity, profile.ModelInput); err != nil {
+		return Profile{}, document.EmbeddingDescriptor{}, err
+	}
 	if (profile.DeploymentEpoch == "") == (profile.ProviderRevisionHeader == "") {
 		return Profile{}, document.EmbeddingDescriptor{}, errors.New("openaicompat: exactly one deployment epoch or provider revision header is required")
 	}
@@ -542,6 +553,12 @@ func openAIEgressPolicyIdentity(policy providerhttp.EgressPolicy) *openAIEgressI
 		AllowedCIDRs: cidrs, ProxyMode: string(policy.ProxyMode), ConnectTimeout: int64(policy.ConnectTimeout),
 		KeepAlive: int64(policy.KeepAlive), TLSHandshakeTimeout: int64(policy.TLSHandshakeTimeout),
 		SPKISHA256: slices.Clone(policy.TLS.SPKISHA256)}
+}
+
+func cloneEgressPolicy(policy providerhttp.EgressPolicy) providerhttp.EgressPolicy {
+	policy.AllowedCIDRs = slices.Clone(policy.AllowedCIDRs)
+	policy.TLS.SPKISHA256 = slices.Clone(policy.TLS.SPKISHA256)
+	return policy
 }
 
 func openAIRetryAfter(value string, now time.Time) (time.Duration, bool) {

--- a/document/openaicompat/profiles.go
+++ b/document/openaicompat/profiles.go
@@ -1,0 +1,193 @@
+package openaicompat
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	bgeM3Model = "BAAI/bge-m3"
+
+	// PoolingCLS selects the first-token vector used by BGE-M3.
+	PoolingCLS = "cls"
+	// PoolingLastToken selects the final non-padding token used by Qwen3.
+	PoolingLastToken = "last_token"
+
+	// OutputDenseSingleVector excludes sparse and multi-vector outputs.
+	OutputDenseSingleVector = "dense_single_vector"
+	// DimensionTransformNone requires the deployment's native output width.
+	DimensionTransformNone = "none"
+)
+
+// DeploymentContract pins the model-side behavior that an
+// OpenAI-compatible transport cannot report or enforce itself.
+type DeploymentContract struct {
+	ModelFamily        string `json:"model_family"`
+	WeightsRevision    string `json:"weights_revision"`
+	Tokenizer          string `json:"tokenizer"`
+	TokenizerRevision  string `json:"tokenizer_revision"`
+	Pooling            string `json:"pooling"`
+	MaxSequenceTokens  int    `json:"max_sequence_tokens"`
+	OutputMode         string `json:"output_mode"`
+	DimensionTransform string `json:"dimension_transform"`
+}
+
+// ReviewedProfileConfig supplies deployment-specific identity and transport
+// bounds for a reviewed self-hosted embedding profile.
+type ReviewedProfileConfig struct {
+	Origin            string
+	ServedModel       string
+	DeploymentEpoch   string
+	WeightsRevision   string
+	TokenizerRevision string
+	SecretBinding     string
+	RequestTimeout    time.Duration
+	MaxBatchItems     int
+	MaxInputBytes     int64
+	MaxRequestBytes   int64
+	MaxResponseBytes  int64
+	EgressPolicy      providerhttp.EgressPolicy
+}
+
+// Qwen3Model identifies one reviewed Qwen3 Embedding model size.
+type Qwen3Model string
+
+const (
+	// Qwen3Embedding06B is the 0.6B model with a native 1024-dimensional output.
+	Qwen3Embedding06B Qwen3Model = "Qwen/Qwen3-Embedding-0.6B"
+	// Qwen3Embedding4B is the 4B model with a native 2560-dimensional output.
+	Qwen3Embedding4B Qwen3Model = "Qwen/Qwen3-Embedding-4B"
+	// Qwen3Embedding8B is the 8B model with a native 4096-dimensional output.
+	Qwen3Embedding8B Qwen3Model = "Qwen/Qwen3-Embedding-8B"
+)
+
+// Qwen3ProfileConfig adds the model size and required retrieval instruction.
+type Qwen3ProfileConfig struct {
+	ReviewedProfileConfig
+
+	Model            Qwen3Model
+	QueryInstruction string
+}
+
+// BGEM3Profile builds the reviewed dense-only BGE-M3 profile.
+func BGEM3Profile(config ReviewedProfileConfig) (Profile, error) {
+	input, err := document.NewModelInputContract(document.ModelInputContractConfig{Profile: document.ModelInputProfileBGEM3})
+	if err != nil {
+		return Profile{}, fmt.Errorf("openaicompat: build BGE-M3 input contract: %w", err)
+	}
+	return reviewedProfile(config, input, 1024, DeploymentContract{
+		ModelFamily: bgeM3Model, WeightsRevision: config.WeightsRevision,
+		Tokenizer: bgeM3Model, TokenizerRevision: config.TokenizerRevision,
+		Pooling: PoolingCLS, MaxSequenceTokens: 8192,
+		OutputMode: OutputDenseSingleVector, DimensionTransform: DimensionTransformNone,
+	})
+}
+
+// Qwen3Profile builds one reviewed dense-only Qwen3 Embedding profile at its
+// native output dimension.
+func Qwen3Profile(config Qwen3ProfileConfig) (Profile, error) {
+	if strings.TrimSpace(config.QueryInstruction) == "" {
+		return Profile{}, errors.New("openaicompat: Qwen3 query instruction is required")
+	}
+	dimension := map[Qwen3Model]int{
+		Qwen3Embedding06B: 1024,
+		Qwen3Embedding4B:  2560,
+		Qwen3Embedding8B:  4096,
+	}[config.Model]
+	if dimension == 0 {
+		return Profile{}, fmt.Errorf("openaicompat: unsupported Qwen3 embedding model %q", config.Model)
+	}
+	input, err := document.NewModelInputContract(document.ModelInputContractConfig{
+		Profile: document.ModelInputProfileQwen3, QueryInstruction: config.QueryInstruction,
+	})
+	if err != nil {
+		return Profile{}, fmt.Errorf("openaicompat: build Qwen3 input contract: %w", err)
+	}
+	model := string(config.Model)
+	return reviewedProfile(config.ReviewedProfileConfig, input, dimension, DeploymentContract{
+		ModelFamily: model, WeightsRevision: config.WeightsRevision,
+		Tokenizer: model, TokenizerRevision: config.TokenizerRevision,
+		Pooling: PoolingLastToken, MaxSequenceTokens: 32768,
+		OutputMode: OutputDenseSingleVector, DimensionTransform: DimensionTransformNone,
+	})
+}
+
+func reviewedProfile(config ReviewedProfileConfig, input document.ModelInputContract, dimension int, deployment DeploymentContract) (Profile, error) {
+	profile := Profile{
+		Origin: config.Origin, ModelInput: input, DeploymentContract: &deployment,
+		SecretBinding: config.SecretBinding, DeploymentEpoch: config.DeploymentEpoch,
+		RequestTimeout: config.RequestTimeout, MaxBatchItems: config.MaxBatchItems,
+		MaxInputBytes: config.MaxInputBytes, MaxRequestBytes: config.MaxRequestBytes,
+		MaxResponseBytes: config.MaxResponseBytes, EgressPolicy: cloneEgressPolicy(config.EgressPolicy),
+		Descriptor: document.EmbeddingDescriptor{
+			ID: ProviderID, ContractVersion: document.EmbeddingProviderContractVersion,
+			TrustBoundary: document.EmbeddingTrustOperatorNetwork, Model: config.ServedModel,
+			ModelRevision: config.DeploymentEpoch, Dimension: dimension, Metric: document.VectorMetricCosine,
+			Normalization: document.VectorNormalizationUnitLength, ScalarEncoding: ScalarEncodingFloat32,
+			DocumentFormatter: DocumentFormatterV1, QueryFormatter: QueryFormatterV1,
+			InputKinds:      []document.EmbeddingInputKind{document.EmbeddingInputRenditionChunk},
+			CompatibilityID: input.CompatibilityID, SupportsTextQuery: true, ModelInput: input,
+			SupportedRequestModes: []document.ModelInputMode{document.ModelInputModeText},
+		},
+	}
+	fingerprint, err := PolicyFingerprint(profile)
+	if err != nil {
+		return Profile{}, err
+	}
+	profile.Descriptor.PolicyFingerprint = fingerprint
+	profile.Descriptor, err = document.NewEmbeddingDescriptor(profile.Descriptor)
+	if err != nil {
+		return Profile{}, fmt.Errorf("openaicompat: build reviewed descriptor: %w", err)
+	}
+	return profile, nil
+}
+
+func validateDeploymentContract(contract *DeploymentContract, descriptor document.EmbeddingDescriptor, input document.ModelInputContract) error {
+	if contract == nil {
+		return nil
+	}
+	if !immutableGitRevision(contract.WeightsRevision) || !immutableGitRevision(contract.TokenizerRevision) {
+		return errors.New("openaicompat: reviewed deployment revisions must be lowercase 40-character Git commits")
+	}
+	if contract.OutputMode != OutputDenseSingleVector || contract.DimensionTransform != DimensionTransformNone {
+		return errors.New("openaicompat: reviewed deployment must return one native dense vector")
+	}
+	if descriptor.Metric != document.VectorMetricCosine || descriptor.Normalization != document.VectorNormalizationUnitLength {
+		return errors.New("openaicompat: reviewed deployment requires cosine metric and unit-length vectors")
+	}
+	switch input.Profile {
+	case document.ModelInputProfileBGEM3:
+		if contract.ModelFamily != bgeM3Model || contract.Tokenizer != bgeM3Model ||
+			contract.Pooling != PoolingCLS || contract.MaxSequenceTokens != 8192 || descriptor.Dimension != 1024 {
+			return errors.New("openaicompat: deployment does not match the reviewed BGE-M3 dense contract")
+		}
+	case document.ModelInputProfileQwen3:
+		dimension := map[string]int{string(Qwen3Embedding06B): 1024, string(Qwen3Embedding4B): 2560, string(Qwen3Embedding8B): 4096}[contract.ModelFamily]
+		if dimension == 0 || contract.Tokenizer != contract.ModelFamily || contract.Pooling != PoolingLastToken ||
+			contract.MaxSequenceTokens != 32768 || descriptor.Dimension != dimension || input.QueryInstruction == "" {
+			return errors.New("openaicompat: deployment does not match a reviewed Qwen3 dense contract")
+		}
+	default:
+		return errors.New("openaicompat: deployment contract requires a reviewed BGE-M3 or Qwen3 input profile")
+	}
+	return nil
+}
+
+func immutableGitRevision(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, character := range value {
+		if character < '0' || character > '9' {
+			if character < 'a' || character > 'f' {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/document/openaicompat/profiles_test.go
+++ b/document/openaicompat/profiles_test.go
@@ -1,0 +1,170 @@
+package openaicompat
+
+import (
+	"net/http"
+	"net/netip"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+)
+
+const (
+	testWeightsRevision   = "0123456789abcdef0123456789abcdef01234567"
+	testTokenizerRevision = "89abcdef0123456789abcdef0123456789abcdef"
+)
+
+func TestBGEM3ProfilePinsReviewedDenseContract(t *testing.T) {
+	profile, err := BGEM3Profile(reviewedProfileConfig())
+	require.NoError(t, err)
+	assert.Equal(t, "BAAI/bge-m3", profile.DeploymentContract.ModelFamily)
+	assert.Equal(t, "BAAI/bge-m3", profile.DeploymentContract.Tokenizer)
+	assert.Equal(t, PoolingCLS, profile.DeploymentContract.Pooling)
+	assert.Equal(t, 8192, profile.DeploymentContract.MaxSequenceTokens)
+	assert.Equal(t, OutputDenseSingleVector, profile.DeploymentContract.OutputMode)
+	assert.Equal(t, DimensionTransformNone, profile.DeploymentContract.DimensionTransform)
+	assert.Equal(t, 1024, profile.Descriptor.Dimension)
+	assert.Equal(t, document.VectorNormalizationUnitLength, profile.Descriptor.Normalization)
+	assert.Equal(t, "passage", profile.ModelInput.EncodeDocument("passage"))
+	assert.Equal(t, "question", profile.ModelInput.EncodeQuery("question"))
+	_, err = New(profile, nil, &http.Client{})
+	require.NoError(t, err)
+}
+
+func TestQwen3ProfilePinsReviewedDenseContracts(t *testing.T) {
+	for _, testCase := range []struct {
+		model     Qwen3Model
+		dimension int
+	}{
+		{Qwen3Embedding06B, 1024},
+		{Qwen3Embedding4B, 2560},
+		{Qwen3Embedding8B, 4096},
+	} {
+		t.Run(string(testCase.model), func(t *testing.T) {
+			profile, err := Qwen3Profile(Qwen3ProfileConfig{
+				ReviewedProfileConfig: reviewedProfileConfig(), Model: testCase.model,
+				QueryInstruction: "Retrieve supporting passages",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, string(testCase.model), profile.DeploymentContract.ModelFamily)
+			assert.Equal(t, string(testCase.model), profile.DeploymentContract.Tokenizer)
+			assert.Equal(t, PoolingLastToken, profile.DeploymentContract.Pooling)
+			assert.Equal(t, 32768, profile.DeploymentContract.MaxSequenceTokens)
+			assert.Equal(t, testCase.dimension, profile.Descriptor.Dimension)
+			assert.Equal(t, "passage", profile.ModelInput.EncodeDocument("passage"))
+			assert.Equal(t, "Instruct: Retrieve supporting passages\nQuery:question", profile.ModelInput.EncodeQuery("question"))
+			_, err = New(profile, nil, &http.Client{})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestReviewedProfilesRejectAmbiguousOrMutableIdentity(t *testing.T) {
+	for name, build := range map[string]func() error{
+		"mutable weights": func() error {
+			config := reviewedProfileConfig()
+			config.WeightsRevision = "main"
+			_, err := BGEM3Profile(config)
+			return err
+		},
+		"mutable tokenizer": func() error {
+			config := reviewedProfileConfig()
+			config.TokenizerRevision = "main"
+			_, err := BGEM3Profile(config)
+			return err
+		},
+		"missing qwen instruction": func() error {
+			_, err := Qwen3Profile(Qwen3ProfileConfig{ReviewedProfileConfig: reviewedProfileConfig(), Model: Qwen3Embedding06B})
+			return err
+		},
+		"unknown qwen model": func() error {
+			_, err := Qwen3Profile(Qwen3ProfileConfig{ReviewedProfileConfig: reviewedProfileConfig(), Model: "Qwen/Qwen3-Embedding-2B", QueryInstruction: "Retrieve passages"})
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) { require.Error(t, build()) })
+	}
+}
+
+func TestDeploymentContractIsFingerprintBoundAndDenseOnly(t *testing.T) {
+	base, err := BGEM3Profile(reviewedProfileConfig())
+	require.NoError(t, err)
+	baseFingerprint := base.Descriptor.PolicyFingerprint
+
+	changed := reviewedProfileConfig()
+	changed.TokenizerRevision = "fedcba9876543210fedcba9876543210fedcba98"
+	profile, err := BGEM3Profile(changed)
+	require.NoError(t, err)
+	assert.NotEqual(t, baseFingerprint, profile.Descriptor.PolicyFingerprint)
+
+	for name, mutate := range map[string]func(*DeploymentContract){
+		"sparse output":       func(contract *DeploymentContract) { contract.OutputMode = "sparse" },
+		"multi-vector output": func(contract *DeploymentContract) { contract.OutputMode = "multi_vector" },
+		"wrong pooling":       func(contract *DeploymentContract) { contract.Pooling = PoolingLastToken },
+		"dimension transform": func(contract *DeploymentContract) { contract.DimensionTransform = "truncate" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			mutated := base
+			contract := *base.DeploymentContract
+			mutate(&contract)
+			mutated.DeploymentContract = &contract
+			_, err := PolicyFingerprint(mutated)
+			require.Error(t, err)
+		})
+	}
+
+	for name, mutate := range map[string]func(*document.EmbeddingDescriptor){
+		"metric": func(descriptor *document.EmbeddingDescriptor) { descriptor.Metric = document.VectorMetricDotProduct },
+		"normalization": func(descriptor *document.EmbeddingDescriptor) {
+			descriptor.Normalization = document.VectorNormalizationNone
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mutated := base
+			mutated.Descriptor = canonicalMutatedDescriptor(t, base.Descriptor, mutate)
+			_, err := PolicyFingerprint(mutated)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestReviewedProfileDoesNotAliasCallerEgressPolicy(t *testing.T) {
+	config := reviewedProfileConfig()
+	config.Origin = "https://model.local"
+	config.EgressPolicy = providerhttp.EgressPolicy{
+		Scheme: "https", Host: "model.local", Port: 443,
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("10.1.0.0/16"), netip.MustParsePrefix("10.0.0.0/8")},
+		TLS:          providerhttp.TLSPolicy{SPKISHA256: []string{strings.Repeat("b", 64), strings.Repeat("a", 64)}},
+	}
+	wantCIDRs := slices.Clone(config.EgressPolicy.AllowedCIDRs)
+	wantPins := slices.Clone(config.EgressPolicy.TLS.SPKISHA256)
+
+	profile, err := BGEM3Profile(config)
+	require.NoError(t, err)
+	assert.Equal(t, wantCIDRs, config.EgressPolicy.AllowedCIDRs)
+	assert.Equal(t, wantPins, config.EgressPolicy.TLS.SPKISHA256)
+
+	config.EgressPolicy.AllowedCIDRs[0] = netip.MustParsePrefix("192.0.2.0/24")
+	config.EgressPolicy.TLS.SPKISHA256[0] = strings.Repeat("c", 64)
+	assert.NotEqual(t, config.EgressPolicy.AllowedCIDRs, profile.EgressPolicy.AllowedCIDRs)
+	assert.NotEqual(t, config.EgressPolicy.TLS.SPKISHA256, profile.EgressPolicy.TLS.SPKISHA256)
+	_, err = New(profile, nil, &http.Client{})
+	require.NoError(t, err)
+}
+
+func TestLegacyGenericProfileFingerprintIsStable(t *testing.T) {
+	profile := testProfile(t, modelInput(t, document.ModelInputContractConfig{Profile: document.ModelInputProfileNomic}))
+	assert.Equal(t, "8c5ca6d380549ccb86894384cd006d136481968ea3b84a5a762d3054c1d46848", profile.Descriptor.PolicyFingerprint)
+}
+
+func reviewedProfileConfig() ReviewedProfileConfig {
+	return ReviewedProfileConfig{
+		Origin: "http://127.0.0.1:11434", ServedModel: "operator-model", DeploymentEpoch: "deployment-2026-08-28",
+		WeightsRevision: testWeightsRevision, TokenizerRevision: testTokenizerRevision,
+	}
+}


### PR DESCRIPTION
## What changed

- Adds reviewed dense-only BGE-M3 and Qwen3 profiles to the existing operator-controlled OpenAI-compatible adapter.
- Pins immutable model and tokenizer commits, pooling, context window, native dimension, cosine metric, unit-length normalization, and query/document formatting into vector-space identity.
- Keeps BGE sparse and multi-vector output, plus Qwen dimension transforms, outside `vector-set/v1`; caller-owned egress policy storage is also isolated before use.

## Why

A self-hosted endpoint exposes a generic API, but that API does not prove how the deployment produces its vectors. These profiles make the hidden model-side contract durable, so changing weights, tokenization, pooling, or output shape cannot silently mix incompatible vector spaces.

## Usage

Use `openaicompat.BGEM3Profile` for `BAAI/bge-m3`, or `openaicompat.Qwen3Profile` with the 0.6B, 4B, or 8B model and a required retrieval instruction. Supply the exact 40-character model and tokenizer Git revisions plus the operator deployment epoch. BGE-M3 uses its native 1024 dimensions; Qwen3 uses 1024, 2560, or 4096 dimensions by model size. Both profiles are dense-only.

Refs #176

Parent: #227 (merged).