### PR TITLE
[E13–S9 06/15] Use operator-hosted QMD without trusting its index

### DIFF
--- a/internal/qmdexport/export.go
+++ b/internal/qmdexport/export.go
@@ -71,6 +71,7 @@ type Options struct {
 	MaxDocuments     int
 	MaxDocumentBytes int64
 	MaxTotalBytes    int64
+	MaxManifestBytes int64
 }
 
 type publishHooks struct {
@@ -234,6 +235,9 @@ func publish(ctx context.Context, root, collection string, sources []Source, cat
 	if err != nil {
 		return Receipt{}, fmt.Errorf("encode qmd export manifest: %w", err)
 	}
+	if int64(len(manifestBytes)+1) > bounds.MaxManifestBytes {
+		return Receipt{}, errors.New("qmd export manifest exceeds bound")
+	}
 	manifestBytes = append(manifestBytes, '\n')
 	if _, err := writePrivateFile(filepath.Join(stage, "manifest.json"), bytes.NewReader(manifestBytes)); err != nil {
 		return Receipt{}, err
@@ -380,9 +384,13 @@ func normalizeOptions(options Options) (Options, error) {
 	if options.MaxTotalBytes == 0 {
 		options.MaxTotalBytes = defaultMaxTotalBytes
 	}
+	if options.MaxManifestBytes == 0 {
+		options.MaxManifestBytes = maxManifestBytes
+	}
 	if options.MaxDocuments < 1 || options.MaxDocuments > defaultMaxDocuments ||
 		options.MaxDocumentBytes < 1 || options.MaxDocumentBytes > defaultMaxDocumentBytes ||
-		options.MaxTotalBytes < 1 || options.MaxTotalBytes > defaultMaxTotalBytes {
+		options.MaxTotalBytes < 1 || options.MaxTotalBytes > defaultMaxTotalBytes ||
+		options.MaxManifestBytes < 1 || options.MaxManifestBytes > maxManifestBytes {
 		return Options{}, errors.New("qmd export bounds are invalid")
 	}
 	return options, nil

--- a/internal/qmdexport/export_test.go
+++ b/internal/qmdexport/export_test.go
@@ -543,3 +543,41 @@ func TestPublishActiveCatalogErrorReleasesLock(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestLoadCurrentReturnsOnlySelfConsistentManifest(t *testing.T) {
+	root := privateExportTestDir(t)
+	item, markdown := source(1, "00000000-0000-4000-8000-000000000001", "# One\n")
+	published, err := Publish(t.Context(), root, "docbank", []Source{item}, fakeReader{item.BlobSHA256: markdown}, Options{})
+	require.NoError(t, err)
+
+	loaded, err := LoadCurrent(root)
+	require.NoError(t, err)
+	assert.Equal(t, published.GenerationID, loaded.GenerationID)
+	assert.Equal(t, published.Manifest, loaded.Manifest)
+	assert.Equal(t, published.CollectionPath, loaded.CollectionPath)
+
+	manifestPath := filepath.Join(root, "generations", published.GenerationID, "manifest.json")
+	manifest := published.Manifest
+	manifest.Entries[0].AttachmentID = "drifted"
+	encoded, err := json.Marshal(manifest, json.Deterministic(true))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, append(encoded, '\n'), 0o600))
+	_, err = LoadCurrent(root)
+	require.ErrorContains(t, err, "identity")
+}
+
+func TestLoadCurrentRejectsUnsafePointer(t *testing.T) {
+	root := privateExportTestDir(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CURRENT"), []byte("../private\n"), 0o600))
+	_, err := LoadCurrent(root)
+	require.ErrorContains(t, err, "CURRENT")
+	volumeRoot := filepath.VolumeName(t.TempDir()) + string(filepath.Separator)
+	_, err = LoadCurrent(volumeRoot)
+	require.ErrorContains(t, err, "root")
+}
+
+func TestPublishRejectsManifestAbovePublicationBound(t *testing.T) {
+	item, markdown := source(1, "00000000-0000-4000-8000-000000000001", "---\nprivate: "+strings.Repeat("x", 256)+"\n---\nbody\n")
+	_, err := Publish(t.Context(), privateExportTestDir(t), "docbank", []Source{item}, fakeReader{item.BlobSHA256: markdown}, Options{MaxManifestBytes: 128})
+	require.ErrorContains(t, err, "manifest")
+}

--- a/internal/qmdexport/load.go
+++ b/internal/qmdexport/load.go
@@ -15,19 +15,35 @@ import (
 
 const maxManifestBytes = int64(256 << 20)
 
-// LoadCurrent reads and validates the exact manifest selected by CURRENT.
-func LoadCurrent(root string) (Receipt, error) {
+// CurrentGeneration reads the generation identity selected by CURRENT without
+// loading its manifest. A generation identity is the manifest checksum, so an
+// unchanged identity means an unchanged manifest.
+func CurrentGeneration(root string) (string, error) {
+	_, generationID, err := currentPointer(root)
+	return generationID, err
+}
+
+func currentPointer(root string) (string, string, error) {
 	absolute, err := filepath.Abs(root)
 	if err != nil || filepath.Dir(absolute) == absolute {
-		return Receipt{}, errors.New("qmd export root is invalid")
+		return "", "", errors.New("qmd export root is invalid")
 	}
 	current, err := readRegularBounded(filepath.Join(absolute, "CURRENT"), sha256.Size*2+1)
 	if err != nil || len(current) != sha256.Size*2+1 || current[len(current)-1] != '\n' {
-		return Receipt{}, errors.New("qmd export CURRENT pointer is invalid")
+		return "", "", errors.New("qmd export CURRENT pointer is invalid")
 	}
 	generationID := string(current[:len(current)-1])
 	if !validChecksum(generationID) {
-		return Receipt{}, errors.New("qmd export CURRENT pointer is invalid")
+		return "", "", errors.New("qmd export CURRENT pointer is invalid")
+	}
+	return absolute, generationID, nil
+}
+
+// LoadCurrent reads and validates the exact manifest selected by CURRENT.
+func LoadCurrent(root string) (Receipt, error) {
+	absolute, generationID, err := currentPointer(root)
+	if err != nil {
+		return Receipt{}, err
 	}
 	generationRoot := filepath.Join(absolute, "generations", generationID)
 	if err := verifyDirectory(generationRoot); err != nil {

--- a/internal/qmdexport/load.go
+++ b/internal/qmdexport/load.go
@@ -1,0 +1,103 @@
+package qmdexport
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	json "encoding/json/v2"
+)
+
+const maxManifestBytes = int64(256 << 20)
+
+// LoadCurrent reads and validates the exact manifest selected by CURRENT.
+func LoadCurrent(root string) (Receipt, error) {
+	absolute, err := filepath.Abs(root)
+	if err != nil || filepath.Dir(absolute) == absolute {
+		return Receipt{}, errors.New("qmd export root is invalid")
+	}
+	current, err := readRegularBounded(filepath.Join(absolute, "CURRENT"), sha256.Size*2+1)
+	if err != nil || len(current) != sha256.Size*2+1 || current[len(current)-1] != '\n' {
+		return Receipt{}, errors.New("qmd export CURRENT pointer is invalid")
+	}
+	generationID := string(current[:len(current)-1])
+	if !validChecksum(generationID) {
+		return Receipt{}, errors.New("qmd export CURRENT pointer is invalid")
+	}
+	generationRoot := filepath.Join(absolute, "generations", generationID)
+	if err := verifyDirectory(generationRoot); err != nil {
+		return Receipt{}, fmt.Errorf("load qmd export generation: %w", err)
+	}
+	collectionPath := filepath.Join(generationRoot, "collection")
+	if err := verifyDirectory(collectionPath); err != nil {
+		return Receipt{}, fmt.Errorf("load qmd export collection: %w", err)
+	}
+	encoded, err := readRegularBounded(filepath.Join(generationRoot, "manifest.json"), maxManifestBytes)
+	if err != nil {
+		return Receipt{}, fmt.Errorf("load qmd export manifest: %w", err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(encoded, &manifest, json.RejectUnknownMembers(true)); err != nil {
+		return Receipt{}, errors.New("qmd export manifest encoding is invalid")
+	}
+	if err := validateManifest(manifest, generationID); err != nil {
+		return Receipt{}, err
+	}
+	return Receipt{GenerationID: generationID, CollectionPath: collectionPath, Manifest: manifest}, nil
+}
+
+func validateManifest(manifest Manifest, generationID string) error {
+	if manifest.Format != ManifestFormatV1 || !validCollection(manifest.Collection) ||
+		manifest.Checksum != generationID || len(manifest.Entries) > defaultMaxDocuments {
+		return errors.New("qmd export manifest identity is invalid")
+	}
+	checksum, err := manifestChecksum(manifest)
+	if err != nil || checksum != generationID {
+		return errors.New("qmd export manifest identity is invalid")
+	}
+	if !slices.IsSortedFunc(manifest.Entries, func(a, b Entry) int { return strings.Compare(a.URI, b.URI) }) {
+		return errors.New("qmd export manifest entries are not canonical")
+	}
+	for index, entry := range manifest.Entries {
+		source := Source{VaultUID: entry.VaultUID, NodeID: entry.NodeID,
+			ContentVersionID: entry.ContentVersionID, ProcessingProfileFingerprint: entry.ProcessingProfileFingerprint,
+			AttachmentID: entry.AttachmentID, BuildID: entry.BuildID, ArtifactID: entry.ArtifactID,
+			BlobSHA256: entry.BlobSHA256, BlobSize: entry.BlobSize,
+			ArtifactChecksum: entry.ArtifactChecksum, MarkdownChecksum: entry.MarkdownChecksum}
+		identity := sourcePathIdentity(source)
+		relative := "documents/" + identity[:2] + "/" + identity + ".md"
+		if err := validateSource(source); err != nil || entry.ExportedMarkdownSHA256 != entry.BlobSHA256 ||
+			entry.RelativePath != relative || entry.URI != "qmd://"+manifest.Collection+"/"+relative {
+			return errors.New("qmd export manifest entry identity is invalid")
+		}
+		if index > 0 && manifest.Entries[index-1].URI == entry.URI {
+			return errors.New("qmd export manifest contains duplicate entries")
+		}
+	}
+	return nil
+}
+
+func readRegularBounded(path string, maximum int64) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Size() < 0 || info.Size() > maximum {
+		return nil, errors.New("expected a bounded regular file")
+	}
+	file, err := openPrivateFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	content, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil || int64(len(content)) != info.Size() {
+		return nil, errors.New("bounded file read failed")
+	}
+	return content, nil
+}

--- a/internal/retrieval/qmdbridge/client.go
+++ b/internal/retrieval/qmdbridge/client.go
@@ -1,0 +1,269 @@
+package qmdbridge
+
+import (
+	"bytes"
+	"context"
+	json "encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/internal/qmdexport"
+	"go.kenn.io/docbank/internal/retrieval"
+	"go.kenn.io/docbank/internal/store"
+)
+
+var (
+	ErrInvalidResponse = errors.New("QMD bridge response is invalid")
+	ErrResponseBound   = errors.New("QMD bridge response exceeds bound")
+	ErrStaleGeneration = errors.New("QMD export generation changed during query")
+)
+
+type SearchType string
+
+const (
+	SearchLexical SearchType = "lex"
+	SearchVector  SearchType = "vec"
+	SearchHyDE    SearchType = "hyde"
+)
+
+type Search struct {
+	Type  SearchType `json:"type"`
+	Query string     `json:"query"`
+}
+
+type Request struct {
+	Searches []Search
+	Intent   string
+	Limit    int
+	MinScore float64
+	Rerank   *bool
+	Scope    store.SearchOptions
+}
+
+type Operation struct {
+	ProfileID          string
+	CompatibilityEpoch string
+	Collection         string
+	GenerationID       string
+	ManifestChecksum   string
+	Scope              store.SearchOptions
+	QueryCount         int
+	CandidateLimit     int
+	DisclosedBytes     int
+}
+
+type Result struct {
+	Document         retrieval.DocumentIdentity
+	NodeRevision     int64
+	Path             string
+	Score            float64
+	Excerpt          string
+	QMDURI           string
+	GenerationID     string
+	ManifestChecksum string
+	AttachmentID     string
+	BuildID          string
+	ArtifactID       string
+}
+
+type wireRequest struct {
+	Searches    []Search `json:"searches"`
+	Limit       int      `json:"limit"`
+	MinScore    float64  `json:"minScore"`
+	Collections []string `json:"collections"`
+	Intent      string   `json:"intent,omitempty"`
+	Rerank      *bool    `json:"rerank,omitempty"`
+}
+
+type wireResponse struct {
+	Results []wireResult `json:"results"`
+}
+
+type wireResult struct {
+	DocID   string  `json:"docid"`
+	File    string  `json:"file"`
+	Title   string  `json:"title"`
+	Score   float64 `json:"score"`
+	Context *string `json:"context"`
+	Snippet string  `json:"snippet"`
+}
+
+func (client *Client) Search(ctx context.Context, request Request) ([]Result, error) {
+	if client == nil || ctx == nil {
+		return nil, errors.New("qmd bridge client and context are required")
+	}
+	disclosed, err := client.validateRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	normalizedScope, err := client.authority.NormalizeSearchOptions(ctx, request.Scope)
+	if err != nil {
+		return nil, fmt.Errorf("normalize QMD search scope: %w", err)
+	}
+	before, err := qmdexport.LoadCurrent(client.root)
+	if err != nil {
+		return nil, fmt.Errorf("load active QMD export: %w", err)
+	}
+	payload, err := json.Marshal(wireRequest{Searches: slices.Clone(request.Searches), Limit: request.Limit,
+		MinScore: request.MinScore, Collections: []string{before.Manifest.Collection}, Intent: request.Intent,
+		Rerank: request.Rerank}, json.Deterministic(true))
+	if err != nil || int64(len(payload)) > client.profile.MaxRequestBytes {
+		return nil, errors.New("qmd bridge request exceeds bound")
+	}
+	defer clear(payload)
+	requestCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
+	defer cancel()
+	secret, err := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
+	if err != nil || !validToken(secret) {
+		return nil, errors.New("qmd bridge named authentication resolution failed")
+	}
+	operation := Operation{ProfileID: client.profile.ID, CompatibilityEpoch: client.profile.CompatibilityEpoch,
+		Collection: before.Manifest.Collection, GenerationID: before.GenerationID,
+		ManifestChecksum: before.Manifest.Checksum, Scope: normalizedScope, QueryCount: len(request.Searches),
+		CandidateLimit: request.Limit, DisclosedBytes: disclosed}
+	if err := client.authorizer.AuthorizeQMDQuery(requestCtx, operation); err != nil {
+		return nil, fmt.Errorf("authorize QMD query: %w", err)
+	}
+	if err := requestCtx.Err(); err != nil {
+		return nil, err
+	}
+	httpRequest, err := http.NewRequestWithContext(requestCtx, http.MethodPost, client.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, errors.New("qmd bridge request construction failed")
+	}
+	httpRequest.Header.Set("Accept", "application/json")
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Authorization", "Bearer "+secret)
+	response, err := client.http.Do(httpRequest)
+	if err != nil {
+		if requestCtx.Err() != nil {
+			return nil, fmt.Errorf("qmd bridge request canceled: %w", requestCtx.Err())
+		}
+		return nil, errors.New("qmd bridge request failed")
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK || !jsonContentType(response.Header.Get("Content-Type")) {
+		return nil, ErrInvalidResponse
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, client.profile.MaxResponseBytes+1))
+	defer clear(body)
+	if err != nil {
+		if requestCtx.Err() != nil {
+			return nil, fmt.Errorf("qmd bridge response read canceled: %w", requestCtx.Err())
+		}
+		return nil, errors.New("qmd bridge response read failed")
+	}
+	if int64(len(body)) > client.profile.MaxResponseBytes {
+		return nil, ErrResponseBound
+	}
+	var decoded wireResponse
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
+		return nil, ErrInvalidResponse
+	}
+	mapped, entries, err := client.mapResults(decoded.Results, before, request.Limit)
+	if err != nil {
+		return nil, err
+	}
+	after, err := qmdexport.LoadCurrent(client.root)
+	if err != nil || after.GenerationID != before.GenerationID || after.Manifest.Checksum != before.Manifest.Checksum {
+		return nil, ErrStaleGeneration
+	}
+	live, err := client.authority.RevalidateQMDExportCandidates(requestCtx, entries, normalizedScope)
+	if err != nil {
+		return nil, fmt.Errorf("revalidate QMD result authority: %w", err)
+	}
+	if len(live) != len(mapped) {
+		return nil, store.ErrQMDExportAuthorityStale
+	}
+	final, err := qmdexport.LoadCurrent(client.root)
+	if err != nil || final.GenerationID != before.GenerationID || final.Manifest.Checksum != before.Manifest.Checksum {
+		return nil, ErrStaleGeneration
+	}
+	results := make([]Result, len(mapped))
+	for index := range mapped {
+		if live[index].NodeID != entries[index].NodeID || live[index].ContentVersionID != entries[index].ContentVersionID {
+			return nil, store.ErrQMDExportAuthorityStale
+		}
+		results[index] = Result{Document: retrieval.DocumentIdentity{VaultID: entries[index].VaultUID,
+			NodeID: live[index].NodeID, ContentVersionID: live[index].ContentVersionID},
+			NodeRevision: live[index].NodeRevision, Path: live[index].Path, Score: mapped[index].Score,
+			Excerpt: mapped[index].Snippet, QMDURI: mapped[index].File, GenerationID: before.GenerationID,
+			ManifestChecksum: before.Manifest.Checksum, AttachmentID: entries[index].AttachmentID,
+			BuildID: entries[index].BuildID, ArtifactID: entries[index].ArtifactID}
+	}
+	return results, nil
+}
+
+func (client *Client) validateRequest(request Request) (int, error) {
+	if len(request.Searches) < 1 || len(request.Searches) > maximumQueries ||
+		request.Limit < 1 || request.Limit > client.profile.MaxCandidates || !finiteUnit(request.MinScore) ||
+		!utf8.ValidString(request.Intent) || len(request.Intent) > client.profile.MaxIntentBytes {
+		return 0, errors.New("qmd bridge request is invalid")
+	}
+	total := len(request.Intent)
+	for _, search := range request.Searches {
+		if search.Type != SearchLexical && search.Type != SearchVector && search.Type != SearchHyDE ||
+			strings.TrimSpace(search.Query) == "" || !utf8.ValidString(search.Query) ||
+			len(search.Query) > client.profile.MaxQueryBytes-total {
+			return 0, errors.New("qmd bridge request is invalid")
+		}
+		total += len(search.Query)
+	}
+	return total, nil
+}
+
+func (client *Client) mapResults(items []wireResult, snapshot qmdexport.Receipt, limit int) ([]wireResult, []store.QMDExportSource, error) {
+	if len(items) > limit || len(items) > client.profile.MaxCandidates {
+		return nil, nil, ErrInvalidResponse
+	}
+	manifest := make(map[string]qmdexport.Entry, len(snapshot.Manifest.Entries))
+	for _, entry := range snapshot.Manifest.Entries {
+		manifest[entry.URI] = entry
+	}
+	seenURI := make(map[string]struct{}, len(items))
+	seenNode := make(map[int64]struct{}, len(items))
+	entries := make([]store.QMDExportSource, len(items))
+	for index, item := range items {
+		entry, exists := manifest[item.File]
+		if !exists || !validWireResult(item, client.profile.MaxSnippetBytes) {
+			return nil, nil, ErrInvalidResponse
+		}
+		if _, duplicate := seenURI[item.File]; duplicate {
+			return nil, nil, ErrInvalidResponse
+		}
+		if _, duplicate := seenNode[entry.NodeID]; duplicate {
+			return nil, nil, ErrInvalidResponse
+		}
+		seenURI[item.File], seenNode[entry.NodeID] = struct{}{}, struct{}{}
+		entries[index] = store.QMDExportSource{VaultUID: entry.VaultUID, NodeID: entry.NodeID,
+			ContentVersionID: entry.ContentVersionID, ProcessingProfileFingerprint: entry.ProcessingProfileFingerprint,
+			AttachmentID: entry.AttachmentID, BuildID: entry.BuildID, ArtifactID: entry.ArtifactID,
+			BlobSHA256: entry.BlobSHA256, BlobSize: entry.BlobSize,
+			ArtifactChecksum: entry.ArtifactChecksum, MarkdownChecksum: entry.MarkdownChecksum}
+	}
+	return items, entries, nil
+}
+
+func validWireResult(item wireResult, maxSnippet int) bool {
+	if !validToken(item.DocID) || item.File == "" || len(item.File) > 2048 ||
+		!utf8.ValidString(item.File) || len(item.Title) > 4096 || !utf8.ValidString(item.Title) ||
+		len(item.Snippet) > maxSnippet || !utf8.ValidString(item.Snippet) || !finiteUnit(item.Score) {
+		return false
+	}
+	return item.Context == nil || len(*item.Context) <= 4096 && utf8.ValidString(*item.Context)
+}
+
+func jsonContentType(value string) bool {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || mediaType != "application/json" {
+		return false
+	}
+	charset, ok := parameters["charset"]
+	return len(parameters) == 0 || len(parameters) == 1 && ok && strings.EqualFold(charset, "utf-8")
+}

--- a/internal/retrieval/qmdbridge/client.go
+++ b/internal/retrieval/qmdbridge/client.go
@@ -121,10 +121,13 @@ func (client *Client) Search(ctx context.Context, request Request) (Report, erro
 	payload, err := json.Marshal(wireRequest{Searches: slices.Clone(request.Searches), Limit: client.profile.MaxCandidates,
 		MinScore: request.MinScore, Collections: []string{before.Manifest.Collection}, Intent: request.Intent,
 		Rerank: request.Rerank}, json.Deterministic(true))
-	if err != nil || int64(len(payload)) > client.profile.MaxRequestBytes {
-		return Report{}, errors.New("qmd bridge request exceeds bound")
+	if err != nil {
+		return Report{}, errors.New("qmd bridge request encoding failed")
 	}
 	defer clear(payload)
+	if int64(len(payload)) > client.profile.MaxRequestBytes {
+		return Report{}, errors.New("qmd bridge request exceeds bound")
+	}
 	requestCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
 	defer cancel()
 	secret, err := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
@@ -146,46 +149,16 @@ func (client *Client) Search(ctx context.Context, request Request) (Report, erro
 	if err := requestCtx.Err(); err != nil {
 		return Report{}, err
 	}
-	httpRequest, err := http.NewRequestWithContext(requestCtx, http.MethodPost, client.endpoint, bytes.NewReader(payload))
-	if err != nil {
-		return Report{}, errors.New("qmd bridge request construction failed")
-	}
-	httpRequest.Header.Set("Accept", "application/json")
-	httpRequest.Header.Set("Content-Type", "application/json")
-	httpRequest.Header.Set("Authorization", "Bearer "+secret)
-	response, err := client.http.Do(httpRequest)
-	if err != nil {
-		if requestCtx.Err() != nil {
-			return Report{}, fmt.Errorf("qmd bridge request canceled: %w", requestCtx.Err())
-		}
-		return Report{}, errors.New("qmd bridge request failed")
-	}
-	defer func() { _ = response.Body.Close() }()
-	if response.StatusCode != http.StatusOK || !jsonContentType(response.Header.Get("Content-Type")) {
-		return Report{}, ErrInvalidResponse
-	}
-	body, err := io.ReadAll(io.LimitReader(response.Body, client.profile.MaxResponseBytes+1))
-	defer clear(body)
-	if err != nil {
-		if requestCtx.Err() != nil {
-			return Report{}, fmt.Errorf("qmd bridge response read canceled: %w", requestCtx.Err())
-		}
-		return Report{}, errors.New("qmd bridge response read failed")
-	}
-	if int64(len(body)) > client.profile.MaxResponseBytes {
-		return Report{}, ErrResponseBound
-	}
-	var decoded wireResponse
-	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
-		return Report{}, ErrInvalidResponse
-	}
-	mapped, entries, err := client.mapResults(decoded.Results, before)
+	items, err := client.exchange(requestCtx, payload, secret)
 	if err != nil {
 		return Report{}, err
 	}
-	after, err := qmdexport.LoadCurrent(client.root)
-	if err != nil || after.GenerationID != before.GenerationID || after.Manifest.Checksum != before.Manifest.Checksum {
-		return Report{}, ErrStaleGeneration
+	mapped, entries, err := client.mapResults(items, before)
+	if err != nil {
+		return Report{}, err
+	}
+	if err := client.fenceGeneration(before.GenerationID); err != nil {
+		return Report{}, err
 	}
 	live, err := client.authority.RevalidateQMDExportCandidates(requestCtx, entries, normalizedScope)
 	if err != nil {
@@ -194,9 +167,8 @@ func (client *Client) Search(ctx context.Context, request Request) (Report, erro
 	if len(live) != len(mapped) {
 		return Report{}, store.ErrQMDExportAuthorityStale
 	}
-	final, err := qmdexport.LoadCurrent(client.root)
-	if err != nil || final.GenerationID != before.GenerationID || final.Manifest.Checksum != before.Manifest.Checksum {
-		return Report{}, ErrStaleGeneration
+	if err := client.fenceGeneration(before.GenerationID); err != nil {
+		return Report{}, err
 	}
 	results := make([]Result, 0, len(mapped))
 	for index := range mapped {
@@ -213,8 +185,57 @@ func (client *Client) Search(ctx context.Context, request Request) (Report, erro
 			ManifestChecksum: before.Manifest.Checksum, AttachmentID: entries[index].AttachmentID,
 			BuildID: entries[index].BuildID, ArtifactID: entries[index].ArtifactID})
 	}
-	truncated := len(decoded.Results) == client.profile.MaxCandidates || len(results) > request.Limit
+	truncated := len(items) == client.profile.MaxCandidates || len(results) > request.Limit
 	return Report{Results: results[:min(len(results), request.Limit)], Truncated: truncated}, nil
+}
+
+// fenceGeneration fails when CURRENT no longer selects the generation the
+// results were mapped through. The identity is the manifest checksum, so the
+// pointer alone proves the manifest is unchanged.
+func (client *Client) fenceGeneration(generationID string) error {
+	current, err := qmdexport.CurrentGeneration(client.root)
+	if err != nil || current != generationID {
+		return ErrStaleGeneration
+	}
+	return nil
+}
+
+// exchange performs the authorized HTTP request and returns the decoded, bounded response.
+func (client *Client) exchange(ctx context.Context, payload []byte, secret string) ([]wireResult, error) {
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, client.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, errors.New("qmd bridge request construction failed")
+	}
+	httpRequest.Header.Set("Accept", "application/json")
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Authorization", "Bearer "+secret)
+	response, err := client.http.Do(httpRequest)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("qmd bridge request canceled: %w", ctx.Err())
+		}
+		return nil, errors.New("qmd bridge request failed")
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK || !jsonContentType(response.Header.Get("Content-Type")) {
+		return nil, ErrInvalidResponse
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, client.profile.MaxResponseBytes+1))
+	defer clear(body)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("qmd bridge response read canceled: %w", ctx.Err())
+		}
+		return nil, errors.New("qmd bridge response read failed")
+	}
+	if int64(len(body)) > client.profile.MaxResponseBytes {
+		return nil, ErrResponseBound
+	}
+	var decoded wireResponse
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
+		return nil, ErrInvalidResponse
+	}
+	return decoded.Results, nil
 }
 
 func (client *Client) validateRequest(request Request) (int, error) {

--- a/internal/retrieval/qmdbridge/client.go
+++ b/internal/retrieval/qmdbridge/client.go
@@ -72,6 +72,14 @@ type Result struct {
 	ArtifactID       string
 }
 
+// Report contains scoped, distinct documents in QMD rank order.
+type Report struct {
+	Results []Result
+	// Truncated means results were omitted or the upstream candidate cap was reached;
+	// additional in-scope matches may exist, even when Results is empty.
+	Truncated bool
+}
+
 type wireRequest struct {
 	Searches    []Search `json:"searches"`
 	Limit       int      `json:"limit"`
@@ -94,48 +102,53 @@ type wireResult struct {
 	Snippet string  `json:"snippet"`
 }
 
-func (client *Client) Search(ctx context.Context, request Request) ([]Result, error) {
+func (client *Client) Search(ctx context.Context, request Request) (Report, error) {
 	if client == nil || ctx == nil {
-		return nil, errors.New("qmd bridge client and context are required")
+		return Report{}, errors.New("qmd bridge client and context are required")
 	}
 	disclosed, err := client.validateRequest(request)
 	if err != nil {
-		return nil, err
+		return Report{}, err
 	}
 	normalizedScope, err := client.authority.NormalizeSearchOptions(ctx, request.Scope)
 	if err != nil {
-		return nil, fmt.Errorf("normalize QMD search scope: %w", err)
+		return Report{}, fmt.Errorf("normalize QMD search scope: %w", err)
 	}
 	before, err := qmdexport.LoadCurrent(client.root)
 	if err != nil {
-		return nil, fmt.Errorf("load active QMD export: %w", err)
+		return Report{}, fmt.Errorf("load active QMD export: %w", err)
 	}
-	payload, err := json.Marshal(wireRequest{Searches: slices.Clone(request.Searches), Limit: request.Limit,
+	payload, err := json.Marshal(wireRequest{Searches: slices.Clone(request.Searches), Limit: client.profile.MaxCandidates,
 		MinScore: request.MinScore, Collections: []string{before.Manifest.Collection}, Intent: request.Intent,
 		Rerank: request.Rerank}, json.Deterministic(true))
 	if err != nil || int64(len(payload)) > client.profile.MaxRequestBytes {
-		return nil, errors.New("qmd bridge request exceeds bound")
+		return Report{}, errors.New("qmd bridge request exceeds bound")
 	}
 	defer clear(payload)
 	requestCtx, cancel := context.WithTimeout(ctx, client.profile.RequestTimeout)
 	defer cancel()
 	secret, err := client.secrets.ResolveSecret(requestCtx, client.profile.SecretBinding)
 	if err != nil || !validToken(secret) {
-		return nil, errors.New("qmd bridge named authentication resolution failed")
+		return Report{}, errors.New("qmd bridge named authentication resolution failed")
 	}
 	operation := Operation{ProfileID: client.profile.ID, CompatibilityEpoch: client.profile.CompatibilityEpoch,
 		Collection: before.Manifest.Collection, GenerationID: before.GenerationID,
 		ManifestChecksum: before.Manifest.Checksum, Scope: normalizedScope, QueryCount: len(request.Searches),
-		CandidateLimit: request.Limit, DisclosedBytes: disclosed}
-	if err := client.authorizer.AuthorizeQMDQuery(requestCtx, operation); err != nil {
-		return nil, fmt.Errorf("authorize QMD query: %w", err)
+		CandidateLimit: client.profile.MaxCandidates, DisclosedBytes: disclosed}
+	lease, err := client.authorizer.AuthorizeQMDQuery(requestCtx, operation)
+	if err != nil {
+		return Report{}, fmt.Errorf("authorize QMD query: %w", err)
 	}
+	if nilInterface(lease) {
+		return Report{}, errors.New("qmd bridge authorization returned no egress lease")
+	}
+	defer lease.Close()
 	if err := requestCtx.Err(); err != nil {
-		return nil, err
+		return Report{}, err
 	}
 	httpRequest, err := http.NewRequestWithContext(requestCtx, http.MethodPost, client.endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return nil, errors.New("qmd bridge request construction failed")
+		return Report{}, errors.New("qmd bridge request construction failed")
 	}
 	httpRequest.Header.Set("Accept", "application/json")
 	httpRequest.Header.Set("Content-Type", "application/json")
@@ -143,61 +156,65 @@ func (client *Client) Search(ctx context.Context, request Request) ([]Result, er
 	response, err := client.http.Do(httpRequest)
 	if err != nil {
 		if requestCtx.Err() != nil {
-			return nil, fmt.Errorf("qmd bridge request canceled: %w", requestCtx.Err())
+			return Report{}, fmt.Errorf("qmd bridge request canceled: %w", requestCtx.Err())
 		}
-		return nil, errors.New("qmd bridge request failed")
+		return Report{}, errors.New("qmd bridge request failed")
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK || !jsonContentType(response.Header.Get("Content-Type")) {
-		return nil, ErrInvalidResponse
+		return Report{}, ErrInvalidResponse
 	}
 	body, err := io.ReadAll(io.LimitReader(response.Body, client.profile.MaxResponseBytes+1))
 	defer clear(body)
 	if err != nil {
 		if requestCtx.Err() != nil {
-			return nil, fmt.Errorf("qmd bridge response read canceled: %w", requestCtx.Err())
+			return Report{}, fmt.Errorf("qmd bridge response read canceled: %w", requestCtx.Err())
 		}
-		return nil, errors.New("qmd bridge response read failed")
+		return Report{}, errors.New("qmd bridge response read failed")
 	}
 	if int64(len(body)) > client.profile.MaxResponseBytes {
-		return nil, ErrResponseBound
+		return Report{}, ErrResponseBound
 	}
 	var decoded wireResponse
 	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
-		return nil, ErrInvalidResponse
+		return Report{}, ErrInvalidResponse
 	}
-	mapped, entries, err := client.mapResults(decoded.Results, before, request.Limit)
+	mapped, entries, err := client.mapResults(decoded.Results, before)
 	if err != nil {
-		return nil, err
+		return Report{}, err
 	}
 	after, err := qmdexport.LoadCurrent(client.root)
 	if err != nil || after.GenerationID != before.GenerationID || after.Manifest.Checksum != before.Manifest.Checksum {
-		return nil, ErrStaleGeneration
+		return Report{}, ErrStaleGeneration
 	}
 	live, err := client.authority.RevalidateQMDExportCandidates(requestCtx, entries, normalizedScope)
 	if err != nil {
-		return nil, fmt.Errorf("revalidate QMD result authority: %w", err)
+		return Report{}, fmt.Errorf("revalidate QMD result authority: %w", err)
 	}
 	if len(live) != len(mapped) {
-		return nil, store.ErrQMDExportAuthorityStale
+		return Report{}, store.ErrQMDExportAuthorityStale
 	}
 	final, err := qmdexport.LoadCurrent(client.root)
 	if err != nil || final.GenerationID != before.GenerationID || final.Manifest.Checksum != before.Manifest.Checksum {
-		return nil, ErrStaleGeneration
+		return Report{}, ErrStaleGeneration
 	}
-	results := make([]Result, len(mapped))
+	results := make([]Result, 0, len(mapped))
 	for index := range mapped {
 		if live[index].NodeID != entries[index].NodeID || live[index].ContentVersionID != entries[index].ContentVersionID {
-			return nil, store.ErrQMDExportAuthorityStale
+			return Report{}, store.ErrQMDExportAuthorityStale
 		}
-		results[index] = Result{Document: retrieval.DocumentIdentity{VaultID: entries[index].VaultUID,
+		if !live[index].InScope {
+			continue
+		}
+		results = append(results, Result{Document: retrieval.DocumentIdentity{VaultID: entries[index].VaultUID,
 			NodeID: live[index].NodeID, ContentVersionID: live[index].ContentVersionID},
 			NodeRevision: live[index].NodeRevision, Path: live[index].Path, Score: mapped[index].Score,
 			Excerpt: mapped[index].Snippet, QMDURI: mapped[index].File, GenerationID: before.GenerationID,
 			ManifestChecksum: before.Manifest.Checksum, AttachmentID: entries[index].AttachmentID,
-			BuildID: entries[index].BuildID, ArtifactID: entries[index].ArtifactID}
+			BuildID: entries[index].BuildID, ArtifactID: entries[index].ArtifactID})
 	}
-	return results, nil
+	truncated := len(decoded.Results) == client.profile.MaxCandidates || len(results) > request.Limit
+	return Report{Results: results[:min(len(results), request.Limit)], Truncated: truncated}, nil
 }
 
 func (client *Client) validateRequest(request Request) (int, error) {
@@ -218,8 +235,8 @@ func (client *Client) validateRequest(request Request) (int, error) {
 	return total, nil
 }
 
-func (client *Client) mapResults(items []wireResult, snapshot qmdexport.Receipt, limit int) ([]wireResult, []store.QMDExportSource, error) {
-	if len(items) > limit || len(items) > client.profile.MaxCandidates {
+func (client *Client) mapResults(items []wireResult, snapshot qmdexport.Receipt) ([]wireResult, []store.QMDExportSource, error) {
+	if len(items) > client.profile.MaxCandidates {
 		return nil, nil, ErrInvalidResponse
 	}
 	manifest := make(map[string]qmdexport.Entry, len(snapshot.Manifest.Entries))
@@ -228,8 +245,9 @@ func (client *Client) mapResults(items []wireResult, snapshot qmdexport.Receipt,
 	}
 	seenURI := make(map[string]struct{}, len(items))
 	seenNode := make(map[int64]struct{}, len(items))
-	entries := make([]store.QMDExportSource, len(items))
-	for index, item := range items {
+	entries := make([]store.QMDExportSource, 0, len(items))
+	mapped := make([]wireResult, 0, len(items))
+	for _, item := range items {
 		entry, exists := manifest[item.File]
 		if !exists || !validWireResult(item, client.profile.MaxSnippetBytes) {
 			return nil, nil, ErrInvalidResponse
@@ -237,17 +255,20 @@ func (client *Client) mapResults(items []wireResult, snapshot qmdexport.Receipt,
 		if _, duplicate := seenURI[item.File]; duplicate {
 			return nil, nil, ErrInvalidResponse
 		}
+		seenURI[item.File] = struct{}{}
+		// Keep the first (highest-ranked) QMD hit across active profiles.
 		if _, duplicate := seenNode[entry.NodeID]; duplicate {
-			return nil, nil, ErrInvalidResponse
+			continue
 		}
-		seenURI[item.File], seenNode[entry.NodeID] = struct{}{}, struct{}{}
-		entries[index] = store.QMDExportSource{VaultUID: entry.VaultUID, NodeID: entry.NodeID,
+		seenNode[entry.NodeID] = struct{}{}
+		mapped = append(mapped, item)
+		entries = append(entries, store.QMDExportSource{VaultUID: entry.VaultUID, NodeID: entry.NodeID,
 			ContentVersionID: entry.ContentVersionID, ProcessingProfileFingerprint: entry.ProcessingProfileFingerprint,
 			AttachmentID: entry.AttachmentID, BuildID: entry.BuildID, ArtifactID: entry.ArtifactID,
 			BlobSHA256: entry.BlobSHA256, BlobSize: entry.BlobSize,
-			ArtifactChecksum: entry.ArtifactChecksum, MarkdownChecksum: entry.MarkdownChecksum}
+			ArtifactChecksum: entry.ArtifactChecksum, MarkdownChecksum: entry.MarkdownChecksum})
 	}
-	return items, entries, nil
+	return mapped, entries, nil
 }
 
 func validWireResult(item wireResult, maxSnippet int) bool {

--- a/internal/retrieval/qmdbridge/client_test.go
+++ b/internal/retrieval/qmdbridge/client_test.go
@@ -1,0 +1,298 @@
+package qmdbridge
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	json "encoding/json/v2"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document/providerhttp"
+	"go.kenn.io/docbank/internal/qmdexport"
+	"go.kenn.io/docbank/internal/store"
+	"go.kenn.io/kit/packstore"
+)
+
+func TestSearchMapsOnlyCurrentManifestResultsThroughLiveAuthority(t *testing.T) {
+	root, source, receipt := exportFixture(t)
+	normalizedScope := store.SearchOptions{MIMEType: "application/pdf"}
+	authority := &authorityStub{normalized: &normalizedScope, live: []store.QMDExportLiveCandidate{{NodeID: 7, NodeRevision: 4,
+		ContentVersionID: source.ContentVersionID, Path: "/live/document.pdf"}}}
+	authorizer := &authorizerStub{}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		assert.Equal(t, "Bearer synthetic-secret", request.Header.Get("Authorization"))
+		assert.Equal(t, "/query", request.URL.Path)
+		var payload wireRequest
+		if !assert.NoError(t, json.UnmarshalRead(request.Body, &payload, json.RejectUnknownMembers(true))) {
+			writer.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, []string{"docbank"}, payload.Collections)
+		assert.NotContains(t, string(mustJSON(t, payload)), "Searchable")
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"results":[{"docid":"#abc123","file":"` + receipt.Manifest.Entries[0].URI + `","title":"Result","score":0.75,"context":null,"snippet":"1: bounded match"}]}`))
+	}))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server, root, authorizer, authority, 1<<20)
+
+	results, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "private terms"}},
+		Intent: "find the relevant document", Limit: 5})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 1, requests)
+	assert.Equal(t, int64(7), results[0].Document.NodeID)
+	assert.Equal(t, source.ContentVersionID, results[0].Document.ContentVersionID)
+	assert.Equal(t, "/live/document.pdf", results[0].Path)
+	assert.Equal(t, receipt.Manifest.Entries[0].URI, results[0].QMDURI)
+	assert.Equal(t, receipt.GenerationID, results[0].GenerationID)
+	assert.Equal(t, receipt.Manifest.Checksum, results[0].ManifestChecksum)
+	assert.Equal(t, "1: bounded match", results[0].Excerpt)
+	require.Len(t, authority.got, 1)
+	assert.Equal(t, source, authority.got[0])
+	assert.Equal(t, receipt.GenerationID, authorizer.operation.GenerationID)
+	assert.Equal(t, normalizedScope, authorizer.operation.Scope)
+	assert.Equal(t, normalizedScope, authority.scope)
+	assert.Equal(t, len("private terms")+len("find the relevant document"), authorizer.operation.DisclosedBytes)
+}
+
+func TestSearchAuthorizesImmediatelyBeforeEgress(t *testing.T) {
+	root, _, _ := exportFixture(t)
+	authorizer := &authorizerStub{err: errors.New("denied")}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server, root, authorizer, &authorityStub{}, 1<<20)
+
+	_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "private"}}, Limit: 5})
+	require.ErrorContains(t, err, "authorize")
+	assert.Zero(t, requests)
+}
+
+func TestSearchRejectsInvalidScopeBeforeEgress(t *testing.T) {
+	root, _, _ := exportFixture(t)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server, root, &authorizerStub{}, &authorityStub{normalizeErr: errors.New("invalid scope")}, 1<<20)
+
+	_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "private"}},
+		Limit: 5, Scope: store.SearchOptions{UnderNodeID: -1}})
+	require.ErrorContains(t, err, "scope")
+	assert.Zero(t, requests)
+}
+
+func TestSearchPreservesResponseBodyDeadline(t *testing.T) {
+	root, _, _ := exportFixture(t)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		if flusher, ok := writer.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-request.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server, root, &authorizerStub{}, &authorityStub{}, 1<<20)
+	client.profile.RequestTimeout = 25 * time.Millisecond
+
+	_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "private"}}, Limit: 5})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestSearchRejectsUnknownDuplicateOversizedAndStaleResults(t *testing.T) {
+	t.Run("unknown URI", func(t *testing.T) {
+		root, _, _ := exportFixture(t)
+		server := qmdServer(t, `{"results":[{"docid":"#abc","file":"qmd://docbank/documents/ff/unknown.md","title":"x","score":0.5,"context":null,"snippet":"x"}]}`, nil)
+		client := newTestClient(t, server, root, &authorizerStub{}, &authorityStub{}, 1<<20)
+		_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchVector, Query: "private"}}, Limit: 5})
+		require.ErrorIs(t, err, ErrInvalidResponse)
+	})
+
+	t.Run("duplicate URI", func(t *testing.T) {
+		root, _, receipt := exportFixture(t)
+		item := `{"docid":"#abc","file":"` + receipt.Manifest.Entries[0].URI + `","title":"x","score":0.5,"context":null,"snippet":"x"}`
+		server := qmdServer(t, `{"results":[`+item+`,`+item+`]}`, nil)
+		client := newTestClient(t, server, root, &authorizerStub{}, &authorityStub{}, 1<<20)
+		_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchVector, Query: "private"}}, Limit: 5})
+		require.ErrorIs(t, err, ErrInvalidResponse)
+	})
+
+	t.Run("bounded response", func(t *testing.T) {
+		root, _, _ := exportFixture(t)
+		server := qmdServer(t, `{"results":[],"padding":"`+strings.Repeat("x", 2048)+`"}`, nil)
+		client := newTestClient(t, server, root, &authorizerStub{}, &authorityStub{}, 512)
+		_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchVector, Query: "private"}}, Limit: 5})
+		require.ErrorIs(t, err, ErrResponseBound)
+	})
+
+	t.Run("generation changes during query", func(t *testing.T) {
+		root, _, receipt := exportFixture(t)
+		server := qmdServer(t, `{"results":[{"docid":"#abc","file":"`+receipt.Manifest.Entries[0].URI+`","title":"x","score":0.5,"context":null,"snippet":"x"}]}`, func() {
+			other, body := qmdSource(8, "# Different\n")
+			_, err := qmdexport.Publish(t.Context(), root, "docbank", []store.QMDExportSource{other}, blobReader{other.BlobSHA256: body}, qmdexport.Options{})
+			require.NoError(t, err)
+		})
+		client := newTestClient(t, server, root, &authorizerStub{}, &authorityStub{}, 1<<20)
+		_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchVector, Query: "private"}}, Limit: 5})
+		require.ErrorIs(t, err, ErrStaleGeneration)
+	})
+
+	t.Run("generation changes during live fence", func(t *testing.T) {
+		root, source, receipt := exportFixture(t)
+		server := qmdServer(t, `{"results":[{"docid":"#abc","file":"`+receipt.Manifest.Entries[0].URI+`","title":"x","score":0.5,"context":null,"snippet":"x"}]}`, nil)
+		authority := &authorityStub{live: []store.QMDExportLiveCandidate{{NodeID: 7, NodeRevision: 4,
+			ContentVersionID: source.ContentVersionID, Path: "/live/document.pdf"}}, before: func() {
+			other, body := qmdSource(8, "# Different\n")
+			_, err := qmdexport.Publish(t.Context(), root, "docbank", []store.QMDExportSource{other}, blobReader{other.BlobSHA256: body}, qmdexport.Options{})
+			require.NoError(t, err)
+		}}
+		client := newTestClient(t, server, root, &authorizerStub{}, authority, 1<<20)
+		_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchVector, Query: "private"}}, Limit: 5})
+		require.ErrorIs(t, err, ErrStaleGeneration)
+	})
+}
+
+func newTestClient(t *testing.T, server *httptest.Server, root string, authorizer Authorizer, authority Authority, responseBytes int64) *Client {
+	t.Helper()
+	_, portText, err := net.SplitHostPort(server.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	client, err := New(Profile{ID: "qmd-test", CompatibilityEpoch: "qmd-current", SecretBinding: "secret:qmd",
+		EndpointPath: "/query", RequestTimeout: time.Second, MaxResponseBytes: responseBytes,
+		EgressPolicy: providerhttp.EgressPolicy{Scheme: "http", Host: "qmd.test", Port: uint16(port),
+			AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}, ProxyMode: providerhttp.ProxyDisabled}},
+		secretStub{}, authorizer, authority, root, resolverStub{}, &http.Client{})
+	require.NoError(t, err)
+	return client
+}
+
+func qmdServer(t *testing.T, response string, beforeResponse func()) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		if beforeResponse != nil {
+			beforeResponse()
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(response))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+type secretStub struct{}
+
+func (secretStub) ResolveSecret(context.Context, string) (string, error) {
+	return "synthetic-secret", nil
+}
+
+type authorizerStub struct {
+	operation Operation
+	err       error
+}
+
+func (stub *authorizerStub) AuthorizeQMDQuery(_ context.Context, operation Operation) error {
+	stub.operation = operation
+	return stub.err
+}
+
+type authorityStub struct {
+	got          []store.QMDExportSource
+	live         []store.QMDExportLiveCandidate
+	err          error
+	before       func()
+	normalized   *store.SearchOptions
+	normalizeErr error
+	scope        store.SearchOptions
+}
+
+func (stub *authorityStub) NormalizeSearchOptions(_ context.Context, scope store.SearchOptions) (store.SearchOptions, error) {
+	if stub.normalized != nil {
+		return *stub.normalized, stub.normalizeErr
+	}
+	return scope, stub.normalizeErr
+}
+
+func (stub *authorityStub) RevalidateQMDExportCandidates(_ context.Context, candidates []store.QMDExportSource, scope store.SearchOptions) ([]store.QMDExportLiveCandidate, error) {
+	stub.got = append([]store.QMDExportSource(nil), candidates...)
+	stub.scope = scope
+	if stub.before != nil {
+		stub.before()
+	}
+	return append([]store.QMDExportLiveCandidate(nil), stub.live...), stub.err
+}
+
+type resolverStub struct{}
+
+func (resolverStub) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+}
+
+type blobReader map[string][]byte
+
+func (reader blobReader) OpenStreamContext(_ context.Context, hash string) (packstore.VerifiedReadCloser, int64, error) {
+	content, ok := reader[hash]
+	if !ok {
+		return nil, 0, os.ErrNotExist
+	}
+	return &verifiedReader{Reader: bytes.NewReader(content)}, int64(len(content)), nil
+}
+
+type verifiedReader struct{ *bytes.Reader }
+
+func (*verifiedReader) Close() error   { return nil }
+func (*verifiedReader) Verify() error  { return nil }
+func (*verifiedReader) Verified() bool { return true }
+
+func exportFixture(t *testing.T) (string, store.QMDExportSource, qmdexport.Receipt) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "qmd")
+	source, body := qmdSource(7, "# Searchable\n")
+	receipt, err := qmdexport.Publish(t.Context(), root, "docbank", []store.QMDExportSource{source}, blobReader{source.BlobSHA256: body}, qmdexport.Options{})
+	require.NoError(t, err)
+	return root, source, receipt
+}
+
+func qmdSource(nodeID int64, markdown string) (store.QMDExportSource, []byte) {
+	digest := sha256.Sum256([]byte(markdown))
+	checksum := hex.EncodeToString(digest[:])
+	version := "00000000-0000-4000-8000-" + fmtNode(nodeID)
+	return store.QMDExportSource{VaultUID: "00000000-0000-4000-8000-000000000001", NodeID: nodeID,
+		ContentVersionID: version, ProcessingProfileFingerprint: strings.Repeat("a", 64),
+		AttachmentID: "attachment-" + version, BuildID: strings.Repeat("b", 64), ArtifactID: "markdown",
+		BlobSHA256: checksum, BlobSize: int64(len(markdown)), ArtifactChecksum: checksum, MarkdownChecksum: checksum}, []byte(markdown)
+}
+
+func fmtNode(nodeID int64) string {
+	return strings.Repeat("0", 12-len(strconv.FormatInt(nodeID, 10))) + strconv.FormatInt(nodeID, 10)
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value, json.Deterministic(true))
+	require.NoError(t, err)
+	return encoded
+}
+
+var _ providerhttp.Resolver = resolverStub{}
+
+func TestFilesystemRootIsVolumeAware(t *testing.T) {
+	volumeRoot := filepath.VolumeName(t.TempDir()) + string(filepath.Separator)
+	assert.True(t, filesystemRoot(volumeRoot))
+}

--- a/internal/retrieval/qmdbridge/client_test.go
+++ b/internal/retrieval/qmdbridge/client_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.kenn.io/docbank/document/providerhttp"
 	"go.kenn.io/docbank/internal/qmdexport"
+	"go.kenn.io/docbank/internal/retrieval"
 	"go.kenn.io/docbank/internal/store"
 	"go.kenn.io/kit/packstore"
 )
@@ -30,7 +31,7 @@ import (
 func TestSearchMapsOnlyCurrentManifestResultsThroughLiveAuthority(t *testing.T) {
 	root, source, receipt := exportFixture(t)
 	normalizedScope := store.SearchOptions{MIMEType: "application/pdf"}
-	authority := &authorityStub{normalized: &normalizedScope, live: []store.QMDExportLiveCandidate{{NodeID: 7, NodeRevision: 4,
+	authority := &authorityStub{normalized: &normalizedScope, live: []store.QMDExportLiveCandidate{{InScope: true, NodeID: 7, NodeRevision: 4,
 		ContentVersionID: source.ContentVersionID, Path: "/live/document.pdf"}}}
 	authorizer := &authorizerStub{}
 	requests := 0
@@ -51,9 +52,10 @@ func TestSearchMapsOnlyCurrentManifestResultsThroughLiveAuthority(t *testing.T) 
 	t.Cleanup(server.Close)
 	client := newTestClient(t, server, root, authorizer, authority, 1<<20)
 
-	results, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "private terms"}},
+	report, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "private terms"}},
 		Intent: "find the relevant document", Limit: 5})
 	require.NoError(t, err)
+	results := report.Results
 	require.Len(t, results, 1)
 	assert.Equal(t, 1, requests)
 	assert.Equal(t, int64(7), results[0].Document.NodeID)
@@ -156,7 +158,7 @@ func TestSearchRejectsUnknownDuplicateOversizedAndStaleResults(t *testing.T) {
 	t.Run("generation changes during live fence", func(t *testing.T) {
 		root, source, receipt := exportFixture(t)
 		server := qmdServer(t, `{"results":[{"docid":"#abc","file":"`+receipt.Manifest.Entries[0].URI+`","title":"x","score":0.5,"context":null,"snippet":"x"}]}`, nil)
-		authority := &authorityStub{live: []store.QMDExportLiveCandidate{{NodeID: 7, NodeRevision: 4,
+		authority := &authorityStub{live: []store.QMDExportLiveCandidate{{InScope: true, NodeID: 7, NodeRevision: 4,
 			ContentVersionID: source.ContentVersionID, Path: "/live/document.pdf"}}, before: func() {
 			other, body := qmdSource(8, "# Different\n")
 			_, err := qmdexport.Publish(t.Context(), root, "docbank", []store.QMDExportSource{other}, blobReader{other.BlobSHA256: body}, qmdexport.Options{})
@@ -207,10 +209,15 @@ type authorizerStub struct {
 	err       error
 }
 
-func (stub *authorizerStub) AuthorizeQMDQuery(_ context.Context, operation Operation) error {
+func (stub *authorizerStub) AuthorizeQMDQuery(_ context.Context, operation Operation) (retrieval.ProviderEgressLease, error) {
 	stub.operation = operation
-	return stub.err
+	if stub.err != nil {
+		return nil, stub.err
+	}
+	return stub, nil
 }
+
+func (*authorizerStub) Close() {}
 
 type authorityStub struct {
 	got          []store.QMDExportSource
@@ -295,4 +302,199 @@ var _ providerhttp.Resolver = resolverStub{}
 func TestFilesystemRootIsVolumeAware(t *testing.T) {
 	volumeRoot := filepath.VolumeName(t.TempDir()) + string(filepath.Separator)
 	assert.True(t, filesystemRoot(volumeRoot))
+}
+
+func TestSearchAcceptsDistinctActiveProfiles(t *testing.T) {
+	root, source, _ := exportFixture(t)
+	alternate := source
+	alternate.ProcessingProfileFingerprint = strings.Repeat("c", 64)
+	alternate.AttachmentID += "-alternate"
+	receipt, err := qmdexport.Publish(t.Context(), root, "docbank", []store.QMDExportSource{source, alternate},
+		blobReader{source.BlobSHA256: []byte("# Searchable\n")}, qmdexport.Options{})
+	require.NoError(t, err)
+	items := []wireResult{
+		{DocID: "first", File: receipt.Manifest.Entries[0].URI, Score: 0.9},
+		{DocID: "second", File: receipt.Manifest.Entries[1].URI, Score: 0.8},
+	}
+	server := qmdServer(t, string(mustJSON(t, wireResponse{Results: items})), nil)
+	authority := &authorityStub{live: []store.QMDExportLiveCandidate{{InScope: true, NodeID: source.NodeID,
+		ContentVersionID: source.ContentVersionID, Path: "/live/document.pdf"}}}
+	client := newTestClient(t, server, root, &authorizerStub{}, authority, 1<<20)
+	report, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "searchable"}}, Limit: 1})
+	require.NoError(t, err, "two active profiles must not invalidate a document")
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, items[0].File, report.Results[0].QMDURI)
+	assert.False(t, report.Truncated)
+	require.Len(t, authority.got, 1)
+	assert.Equal(t, receipt.Manifest.Entries[0].AttachmentID, authority.got[0].AttachmentID)
+}
+
+func TestSearchHoldsConsentThroughEgress(t *testing.T) {
+	for _, outcome := range []string{"success", "invalid response", "canceled"} {
+		t.Run(outcome, func(t *testing.T) {
+			root, _, _ := exportFixture(t)
+			catalog, err := store.Open(filepath.Join(t.TempDir(), "consent.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, catalog.Close()) })
+			authorizer := &consentAuthorizer{catalog: catalog, request: store.ProviderOperationAuthorizationRequest{
+				Principal: "search-user", Scope: "search", ProfileFingerprint: strings.Repeat("b", 64),
+				DisclosureFingerprint: strings.Repeat("c", 64), InputClasses: []string{"query_text"},
+			}, authorized: make(chan struct{}), proceed: make(chan struct{})}
+			_, err = catalog.GrantConsent(t.Context(), store.ProcessingConsentGrantRequest{
+				Principal: authorizer.request.Principal, Scope: authorizer.request.Scope,
+				ProfileFingerprint: authorizer.request.ProfileFingerprint, DisclosureFingerprint: authorizer.request.DisclosureFingerprint,
+				InputClasses: authorizer.request.InputClasses,
+			})
+			require.NoError(t, err)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			started, finish := make(chan struct{}), make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+				_ = http.NewResponseController(writer).Flush()
+				close(started)
+				select {
+				case <-finish:
+					if outcome == "invalid response" {
+						_, _ = writer.Write([]byte(`invalid`))
+					} else {
+						_, _ = writer.Write([]byte(`{"results":[]}`))
+					}
+				case <-request.Context().Done():
+				}
+			}))
+			t.Cleanup(server.Close)
+			client := newTestClient(t, server, root, authorizer, &authorityStub{}, 1<<20)
+			done := make(chan error, 1)
+			query := Request{Searches: []Search{{Type: SearchLexical, Query: "private"}}, Limit: 5}
+			go func() { _, err := client.Search(ctx, query); done <- err }()
+			<-authorizer.authorized
+			revoked := make(chan error, 1)
+			go func() {
+				_, err := catalog.RevokeConsent(t.Context(), store.ProcessingConsentRevocationRequest{Principal: "search-user", Scope: "search"})
+				revoked <- err
+			}()
+			early := false
+			select {
+			case err := <-revoked:
+				t.Errorf("revocation completed before the authorized HTTP request: %v", err)
+				early = true
+			case <-time.After(20 * time.Millisecond):
+			}
+			close(authorizer.proceed)
+			<-started
+			if !early {
+				select {
+				case err := <-revoked:
+					t.Errorf("revocation completed while reading the response: %v", err)
+					early = true
+				case <-time.After(20 * time.Millisecond):
+				}
+			}
+			if outcome == "canceled" {
+				cancel()
+			} else {
+				close(finish)
+			}
+			searchErr := <-done
+			switch outcome {
+			case "success":
+				require.NoError(t, searchErr)
+			case "invalid response":
+				require.ErrorIs(t, searchErr, ErrInvalidResponse)
+			case "canceled":
+				require.ErrorIs(t, searchErr, context.Canceled)
+			}
+			if !early {
+				select {
+				case err := <-revoked:
+					require.NoError(t, err)
+				case <-time.After(time.Second):
+					t.Fatal("search did not release its consent lease")
+				}
+			}
+			_, err = client.Search(t.Context(), query)
+			require.ErrorIs(t, err, store.ErrProcessingConsentRevoked)
+		})
+	}
+}
+
+type consentAuthorizer struct {
+	catalog             *store.Store
+	request             store.ProviderOperationAuthorizationRequest
+	authorized, proceed chan struct{}
+}
+
+func (authorizer *consentAuthorizer) AuthorizeQMDQuery(ctx context.Context, _ Operation) (retrieval.ProviderEgressLease, error) {
+	_, fence, err := authorizer.catalog.BeginProviderEgress(ctx, authorizer.request)
+	if err == nil {
+		close(authorizer.authorized)
+		select {
+		case <-authorizer.proceed:
+		case <-ctx.Done():
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return fence, nil
+}
+
+func TestSearchFiltersScopeAndReportsTruncation(t *testing.T) {
+	root, first, _ := exportFixture(t)
+	second, body := qmdSource(8, "# Another\n")
+	receipt, err := qmdexport.Publish(t.Context(), root, "docbank", []store.QMDExportSource{first, second},
+		blobReader{first.BlobSHA256: []byte("# Searchable\n"), second.BlobSHA256: body}, qmdexport.Options{})
+	require.NoError(t, err)
+	uris := make(map[int64]string)
+	for _, entry := range receipt.Manifest.Entries {
+		uris[entry.NodeID] = entry.URI
+	}
+	for _, test := range []struct {
+		name      string
+		cap       int
+		inScope   bool
+		truncated bool
+	}{
+		{name: "complete", cap: 3, inScope: true},
+		{name: "candidate cap", cap: 2, inScope: true, truncated: true},
+		{name: "candidate cap without scoped matches", cap: 2, truncated: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			payload := wireResponse{Results: []wireResult{
+				{DocID: "outside", File: uris[first.NodeID], Score: 0.9},
+				{DocID: "inside", File: uris[second.NodeID], Score: 0.8},
+			}}
+			encoded := mustJSON(t, payload)
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				var query wireRequest
+				if !assert.NoError(t, json.UnmarshalRead(request.Body, &query)) {
+					return
+				}
+				assert.Equal(t, test.cap, query.Limit)
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write(encoded)
+			}))
+			t.Cleanup(server.Close)
+			authority := &authorityStub{live: []store.QMDExportLiveCandidate{
+				{NodeID: first.NodeID, ContentVersionID: first.ContentVersionID},
+				{NodeID: second.NodeID, ContentVersionID: second.ContentVersionID, InScope: test.inScope},
+			}}
+			authorizer := &authorizerStub{}
+			client := newTestClient(t, server, root, authorizer, authority, 1<<20)
+			client.profile.MaxCandidates = test.cap
+			report, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "text"}},
+				Limit: 1, Scope: store.SearchOptions{MIMEType: "application/pdf"}})
+			require.NoError(t, err)
+			assert.Equal(t, test.cap, authorizer.operation.CandidateLimit)
+			assert.Equal(t, test.truncated, report.Truncated)
+			if test.inScope {
+				require.Len(t, report.Results, 1)
+				assert.Equal(t, second.NodeID, report.Results[0].Document.NodeID)
+			} else {
+				assert.Empty(t, report.Results)
+			}
+		})
+	}
 }

--- a/internal/retrieval/qmdbridge/client_test.go
+++ b/internal/retrieval/qmdbridge/client_test.go
@@ -498,3 +498,51 @@ func TestSearchFiltersScopeAndReportsTruncation(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchRejectsInvalidRequestsBeforeEgress(t *testing.T) {
+	root, _, _ := exportFixture(t)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server, root, &authorizerStub{}, &authorityStub{}, 1<<20)
+	client.profile.MaxQueryBytes = 16
+	lexical := []Search{{Type: SearchLexical, Query: "private"}}
+	for name, request := range map[string]Request{
+		"no searches":          {Limit: 1},
+		"unknown search type":  {Searches: []Search{{Type: "fuzzy", Query: "private"}}, Limit: 1},
+		"blank query":          {Searches: []Search{{Type: SearchLexical, Query: " \t"}}, Limit: 1},
+		"zero limit":           {Searches: lexical},
+		"limit above cap":      {Searches: lexical, Limit: client.profile.MaxCandidates + 1},
+		"score outside unit":   {Searches: lexical, Limit: 1, MinScore: 1.5},
+		"query and intent sum": {Searches: lexical, Intent: strings.Repeat("i", 10), Limit: 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := client.Search(t.Context(), request)
+			require.ErrorContains(t, err, "invalid")
+		})
+	}
+	assert.Zero(t, requests)
+}
+
+func TestSearchRejectsNonJSONOrFailedResponses(t *testing.T) {
+	for name, handler := range map[string]http.HandlerFunc{
+		"error status": func(writer http.ResponseWriter, _ *http.Request) {
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusInternalServerError)
+			_, _ = writer.Write([]byte(`{"results":[]}`))
+		},
+		"html body": func(writer http.ResponseWriter, _ *http.Request) {
+			writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = writer.Write([]byte(`{"results":[]}`))
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			root, _, _ := exportFixture(t)
+			server := httptest.NewServer(handler)
+			t.Cleanup(server.Close)
+			client := newTestClient(t, server, root, &authorizerStub{}, &authorityStub{}, 1<<20)
+			_, err := client.Search(t.Context(), Request{Searches: []Search{{Type: SearchLexical, Query: "private"}}, Limit: 1})
+			require.ErrorIs(t, err, ErrInvalidResponse)
+		})
+	}
+}

--- a/internal/retrieval/qmdbridge/profile.go
+++ b/internal/retrieval/qmdbridge/profile.go
@@ -20,6 +20,7 @@ import (
 
 	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/document/providerhttp"
+	"go.kenn.io/docbank/internal/retrieval"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -38,8 +39,10 @@ type SecretResolver interface {
 	ResolveSecret(ctx context.Context, binding string) (string, error)
 }
 
+// Authorizer holds consent against revocation until the returned lease closes.
+// Success must return a non-nil lease; failure must release acquired resources.
 type Authorizer interface {
-	AuthorizeQMDQuery(ctx context.Context, operation Operation) error
+	AuthorizeQMDQuery(ctx context.Context, operation Operation) (retrieval.ProviderEgressLease, error)
 }
 
 type Authority interface {

--- a/internal/retrieval/qmdbridge/profile.go
+++ b/internal/retrieval/qmdbridge/profile.go
@@ -1,0 +1,186 @@
+// Package qmdbridge connects an operator-hosted QMD query endpoint to exact
+// current Docbank export and rendition authority.
+package qmdbridge
+
+import (
+	"context"
+	"errors"
+	"math"
+	"net"
+	"net/http"
+	"path"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/providerhttp"
+	"go.kenn.io/docbank/internal/store"
+)
+
+const (
+	maximumQueries       = 10
+	maximumQueryBytes    = 64 << 10
+	maximumIntentBytes   = 64 << 10
+	maximumRequestBytes  = int64(8 << 20)
+	maximumResponseBytes = int64(64 << 20)
+	maximumSnippetBytes  = 64 << 10
+	maximumTimeout       = 5 * time.Minute
+	maximumTokenBytes    = 1024
+)
+
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, binding string) (string, error)
+}
+
+type Authorizer interface {
+	AuthorizeQMDQuery(ctx context.Context, operation Operation) error
+}
+
+type Authority interface {
+	NormalizeSearchOptions(ctx context.Context, scope store.SearchOptions) (store.SearchOptions, error)
+	RevalidateQMDExportCandidates(ctx context.Context, candidates []store.QMDExportSource,
+		scope store.SearchOptions) ([]store.QMDExportLiveCandidate, error)
+}
+
+type Profile struct {
+	ID                 string
+	CompatibilityEpoch string
+	SecretBinding      string
+	EndpointPath       string
+	RequestTimeout     time.Duration
+	MaxQueryBytes      int
+	MaxIntentBytes     int
+	MaxCandidates      int
+	MaxSnippetBytes    int
+	MaxRequestBytes    int64
+	MaxResponseBytes   int64
+	EgressPolicy       providerhttp.EgressPolicy
+}
+
+type Client struct {
+	profile    Profile
+	secrets    SecretResolver
+	authorizer Authorizer
+	authority  Authority
+	root       string
+	endpoint   string
+	http       *http.Client
+}
+
+func New(profile Profile, secrets SecretResolver, authorizer Authorizer, authority Authority,
+	root string, resolver providerhttp.Resolver, supplied *http.Client,
+) (*Client, error) {
+	if supplied == nil || nilInterface(secrets) || nilInterface(authorizer) || nilInterface(authority) {
+		return nil, errors.New("qmd bridge requires HTTP settings, named secret, authorization, and live authority")
+	}
+	normalized, err := normalizeProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil || filesystemRoot(absolute) {
+		return nil, errors.New("qmd bridge export root is invalid")
+	}
+	transport, err := providerhttp.NewTransport(normalized.EgressPolicy, resolver)
+	if err != nil {
+		return nil, errors.New("qmd bridge egress policy is invalid")
+	}
+	isolated := *supplied
+	isolated.Transport = transport
+	isolated.CheckRedirect = providerhttp.RefuseRedirects
+	isolated.Jar = nil
+	isolated.Timeout = 0
+	authorityHost := net.JoinHostPort(normalized.EgressPolicy.Host, strconv.Itoa(int(normalized.EgressPolicy.Port)))
+	endpoint := normalized.EgressPolicy.Scheme + "://" + authorityHost + normalized.EndpointPath
+	return &Client{profile: normalized, secrets: secrets, authorizer: authorizer,
+		authority: authority, root: absolute, endpoint: endpoint, http: &isolated}, nil
+}
+
+func filesystemRoot(value string) bool {
+	volume := filepath.VolumeName(value)
+	return filepath.Clean(value) == filepath.Clean(volume+string(filepath.Separator))
+}
+
+func normalizeProfile(profile Profile) (Profile, error) {
+	profile.EgressPolicy.AllowedCIDRs = slices.Clone(profile.EgressPolicy.AllowedCIDRs)
+	profile.EgressPolicy.TLS.SPKISHA256 = slices.Clone(profile.EgressPolicy.TLS.SPKISHA256)
+	if profile.RequestTimeout == 0 {
+		profile.RequestTimeout = 30 * time.Second
+	}
+	if profile.MaxQueryBytes == 0 {
+		profile.MaxQueryBytes = 4096
+	}
+	if profile.MaxIntentBytes == 0 {
+		profile.MaxIntentBytes = 4096
+	}
+	if profile.MaxCandidates == 0 {
+		profile.MaxCandidates = 100
+	}
+	if profile.MaxSnippetBytes == 0 {
+		profile.MaxSnippetBytes = 4096
+	}
+	if profile.MaxRequestBytes == 0 {
+		profile.MaxRequestBytes = 1 << 20
+	}
+	if profile.MaxResponseBytes == 0 {
+		profile.MaxResponseBytes = 8 << 20
+	}
+	if profile.EgressPolicy.ConnectTimeout == 0 {
+		profile.EgressPolicy.ConnectTimeout = providerhttp.DefaultConnectTimeout
+	}
+	if profile.EgressPolicy.KeepAlive == 0 {
+		profile.EgressPolicy.KeepAlive = providerhttp.DefaultKeepAlive
+	}
+	if profile.EgressPolicy.TLSHandshakeTimeout == 0 {
+		profile.EgressPolicy.TLSHandshakeTimeout = providerhttp.DefaultTLSHandshakeTimeout
+	}
+	if profile.EgressPolicy.ProxyMode == "" {
+		profile.EgressPolicy.ProxyMode = providerhttp.ProxyDisabled
+	}
+	if !validToken(profile.ID) || !validToken(profile.CompatibilityEpoch) || !validToken(profile.SecretBinding) ||
+		!validEndpointPath(profile.EndpointPath) || profile.RequestTimeout <= 0 || profile.RequestTimeout > maximumTimeout ||
+		profile.MaxQueryBytes < 1 || profile.MaxQueryBytes > maximumQueryBytes ||
+		profile.MaxIntentBytes < 1 || profile.MaxIntentBytes > maximumIntentBytes ||
+		profile.MaxCandidates < 1 || profile.MaxCandidates > document.MaxRetrievalCandidateLimit ||
+		profile.MaxSnippetBytes < 1 || profile.MaxSnippetBytes > maximumSnippetBytes ||
+		profile.MaxRequestBytes < 1 || profile.MaxRequestBytes > maximumRequestBytes ||
+		profile.MaxResponseBytes < 1 || profile.MaxResponseBytes > maximumResponseBytes {
+		return Profile{}, errors.New("qmd bridge profile is invalid")
+	}
+	return profile, nil
+}
+
+func validEndpointPath(value string) bool {
+	return value != "" && len(value) <= 256 && strings.HasPrefix(value, "/") &&
+		path.Clean(value) == value && !strings.ContainsAny(value, "?#\\") && utf8.ValidString(value)
+}
+
+func validToken(value string) bool {
+	return value != "" && len(value) <= maximumTokenBytes && utf8.ValidString(value) &&
+		value == strings.TrimSpace(value) && strings.IndexFunc(value, func(character rune) bool {
+		return unicode.IsControl(character) || unicode.IsSpace(character)
+	}) < 0
+}
+
+func nilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func finiteUnit(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= 0 && value <= 1
+}

--- a/internal/store/qmd_export.go
+++ b/internal/store/qmd_export.go
@@ -38,6 +38,7 @@ type QMDExportSource struct {
 type QMDExportLiveCandidate struct {
 	NodeID           int64
 	NodeRevision     int64
+	InScope          bool
 	ContentVersionID string
 	Path             string
 }
@@ -86,8 +87,8 @@ func (s *Store) QMDExportSources(ctx context.Context, limit int) (_ []QMDExportS
 }
 
 // RevalidateQMDExportCandidates rejects the batch unless every supplied
-// manifest identity remains exact, live, current, and inside the operator
-// scope in one storage snapshot.
+// manifest identity remains exact, live, and current. InScope reports each
+// candidate's scope membership in the same storage snapshot.
 func (s *Store) RevalidateQMDExportCandidates(ctx context.Context, candidates []QMDExportSource,
 	opts SearchOptions,
 ) ([]QMDExportLiveCandidate, error) {
@@ -117,9 +118,9 @@ func (s *Store) RevalidateQMDExportCandidates(ctx context.Context, candidates []
 				candidate.VaultUID, candidate.BuildID, candidate.ArtifactID,
 				candidate.BlobSHA256, candidate.BlobSize, candidate.ArtifactChecksum,
 				candidate.MarkdownChecksum}
-			args = append(args, filterArgs...)
+			args = append(append([]any(nil), filterArgs...), args...)
 			var live QMDExportLiveCandidate
-			err := tx.QueryRowContext(ctx, `SELECT n.id,n.revision,cv.version_id
+			err := tx.QueryRowContext(ctx, `SELECT n.id,n.revision,cv.version_id,CASE WHEN 1=1 `+filterSQL+` THEN 1 ELSE 0 END
 				FROM nodes n
 				JOIN content_versions cv ON cv.node_id=n.id AND cv.version_id=n.current_version_id
 				JOIN rendition_heads h ON h.content_version_id=cv.version_id
@@ -131,8 +132,8 @@ func (s *Store) RevalidateQMDExportCandidates(ctx context.Context, candidates []
 					AND a.vault_uid=? AND a.build_id=? AND artifact.artifact_id=?
 					AND artifact.role='sanitized_markdown'
 					AND artifact.blob_hash=? AND artifact.size=? AND artifact.checksum=?
-					AND b.markdown_checksum=? AND n.kind='file' AND n.trashed_at IS NULL `+filterSQL,
-				args...).Scan(&live.NodeID, &live.NodeRevision, &live.ContentVersionID)
+					AND b.markdown_checksum=? AND n.kind='file' AND n.trashed_at IS NULL `,
+				args...).Scan(&live.NodeID, &live.NodeRevision, &live.ContentVersionID, &live.InScope)
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrQMDExportAuthorityStale
 			}

--- a/internal/store/qmd_export.go
+++ b/internal/store/qmd_export.go
@@ -2,11 +2,20 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/document"
 )
 
 const maxQMDExportSources = 100_000
+
+// ErrQMDExportAuthorityStale means an exported identity no longer names the
+// exact live node, content version, rendition head, and verified artifact.
+var ErrQMDExportAuthorityStale = errors.New("QMD export authority is stale")
 
 // QMDExportSource is one active live-node rendition head's retained
 // sanitized-Markdown artifact. Original vault paths are intentionally absent.
@@ -22,6 +31,15 @@ type QMDExportSource struct {
 	BlobSize                     int64
 	ArtifactChecksum             string
 	MarkdownChecksum             string
+}
+
+// QMDExportLiveCandidate is the current Docbank identity rejoined after an
+// external QMD result has been mapped through one exact export manifest.
+type QMDExportLiveCandidate struct {
+	NodeID           int64
+	NodeRevision     int64
+	ContentVersionID string
+	Path             string
 }
 
 // QMDExportSources lists a bounded, deterministic snapshot of active retained
@@ -65,4 +83,95 @@ func (s *Store) QMDExportSources(ctx context.Context, limit int) (_ []QMDExportS
 		return nil, fmt.Errorf("listing QMD export sources: %w", err)
 	}
 	return sources, nil
+}
+
+// RevalidateQMDExportCandidates rejects the batch unless every supplied
+// manifest identity remains exact, live, current, and inside the operator
+// scope in one storage snapshot.
+func (s *Store) RevalidateQMDExportCandidates(ctx context.Context, candidates []QMDExportSource,
+	opts SearchOptions,
+) ([]QMDExportLiveCandidate, error) {
+	if len(candidates) > document.MaxRetrievalCandidateLimit {
+		return nil, errors.New("QMD candidate revalidation exceeds the retrieval limit")
+	}
+	normalized, err := s.NormalizeSearchOptions(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[int64]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if !validQMDExportSource(candidate) {
+			return nil, errors.New("QMD candidate authority is invalid")
+		}
+		if _, duplicate := seen[candidate.NodeID]; duplicate {
+			return nil, errors.New("QMD candidate authority is duplicated")
+		}
+		seen[candidate.NodeID] = struct{}{}
+	}
+	result := make([]QMDExportLiveCandidate, 0, len(candidates))
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		filterSQL, filterArgs := searchFilterSQL(normalized)
+		for _, candidate := range candidates {
+			args := []any{candidate.NodeID, candidate.ContentVersionID,
+				candidate.ProcessingProfileFingerprint, candidate.AttachmentID,
+				candidate.VaultUID, candidate.BuildID, candidate.ArtifactID,
+				candidate.BlobSHA256, candidate.BlobSize, candidate.ArtifactChecksum,
+				candidate.MarkdownChecksum}
+			args = append(args, filterArgs...)
+			var live QMDExportLiveCandidate
+			err := tx.QueryRowContext(ctx, `SELECT n.id,n.revision,cv.version_id
+				FROM nodes n
+				JOIN content_versions cv ON cv.node_id=n.id AND cv.version_id=n.current_version_id
+				JOIN rendition_heads h ON h.content_version_id=cv.version_id
+				JOIN rendition_attachments a ON a.attachment_id=h.attachment_id
+					AND a.content_version_id=h.content_version_id AND a.profile_fingerprint=h.profile_fingerprint
+				JOIN rendition_builds b ON b.build_id=a.build_id AND b.vault_uid=a.vault_uid
+				JOIN rendition_artifacts artifact ON artifact.build_id=b.build_id
+				WHERE n.id=? AND cv.version_id=? AND h.profile_fingerprint=? AND h.attachment_id=?
+					AND a.vault_uid=? AND a.build_id=? AND artifact.artifact_id=?
+					AND artifact.role='sanitized_markdown'
+					AND artifact.blob_hash=? AND artifact.size=? AND artifact.checksum=?
+					AND b.markdown_checksum=? AND n.kind='file' AND n.trashed_at IS NULL `+filterSQL,
+				args...).Scan(&live.NodeID, &live.NodeRevision, &live.ContentVersionID)
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrQMDExportAuthorityStale
+			}
+			if err != nil {
+				return err
+			}
+			live.Path, err = pathOf(ctx, tx, live.NodeID)
+			if err != nil {
+				return err
+			}
+			result = append(result, live)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func validQMDExportSource(source QMDExportSource) bool {
+	if source.NodeID < 1 || source.BlobSize < 0 || source.BlobSHA256 != source.ArtifactChecksum ||
+		source.BlobSHA256 != source.MarkdownChecksum {
+		return false
+	}
+	for _, value := range []string{source.VaultUID, source.ContentVersionID,
+		source.ProcessingProfileFingerprint, source.AttachmentID, source.BuildID,
+		source.ArtifactID, source.BlobSHA256, source.ArtifactChecksum, source.MarkdownChecksum} {
+		if value == "" || len(value) > 1024 || !utf8.ValidString(value) || strings.ContainsRune(value, 0) {
+			return false
+		}
+	}
+	for _, value := range []string{source.ProcessingProfileFingerprint, source.BuildID,
+		source.BlobSHA256, source.ArtifactChecksum, source.MarkdownChecksum} {
+		if len(value) != 64 || strings.IndexFunc(value, func(r rune) bool {
+			return r < '0' || r > '9' && r < 'a' || r > 'f'
+		}) >= 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/store/qmd_export_test.go
+++ b/internal/store/qmd_export_test.go
@@ -114,10 +114,16 @@ func TestRevalidateQMDExportCandidatesRequiresExactLiveAttachment(t *testing.T) 
 	assert.Equal(t, versions[0], allowed[0].ContentVersionID)
 	assert.Equal(t, "/synthetic-source-a.pdf", allowed[0].Path)
 	assert.Positive(t, allowed[0].NodeRevision)
+	assert.True(t, allowed[0].InScope)
+
+	excluded, err := s.RevalidateQMDExportCandidates(t.Context(), sources, SearchOptions{MIMEType: "text/plain"})
+	require.NoError(t, err, "an out-of-scope live document is not stale authority")
+	require.Len(t, excluded, 1)
+	assert.False(t, excluded[0].InScope)
 
 	drifted := sources[0]
 	drifted.AttachmentID = "different-attachment"
-	_, err = s.RevalidateQMDExportCandidates(t.Context(), []QMDExportSource{drifted}, SearchOptions{})
+	_, err = s.RevalidateQMDExportCandidates(t.Context(), []QMDExportSource{drifted}, SearchOptions{MIMEType: "text/plain"})
 	require.ErrorIs(t, err, ErrQMDExportAuthorityStale)
 
 	file, err := s.NodeViewByPath(t.Context(), "/synthetic-source-a.pdf")
@@ -126,4 +132,24 @@ func TestRevalidateQMDExportCandidatesRequiresExactLiveAttachment(t *testing.T) 
 	require.NoError(t, err)
 	_, err = s.RevalidateQMDExportCandidates(t.Context(), sources, SearchOptions{})
 	require.ErrorIs(t, err, ErrQMDExportAuthorityStale)
+}
+
+func TestRevalidateQMDExportCandidatesFiltersUnknownMIME(t *testing.T) {
+	s, _ := newRenditionCatalogFixture(t)
+	file, err := s.CreateFile(t.Context(), s.RootID(), "unknown-format", catalogSourceHash, 20, "")
+	require.NoError(t, err)
+	profile := catalogProcessingProfile(t, false)
+	build := catalogRenditionBuild(s, profile)
+	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+	require.NoError(t, publishAttachmentForTest(t, s, RenditionAttachmentRecord{
+		ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: file.CurrentVersionID,
+		BuildID: build.ID, Profile: profile, AttachedAt: nowRFC3339(),
+	}))
+	sources, err := s.QMDExportSources(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	live, err := s.RevalidateQMDExportCandidates(t.Context(), sources, SearchOptions{MIMEType: "application/pdf"})
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	assert.False(t, live[0].InScope)
 }

--- a/internal/store/qmd_export_test.go
+++ b/internal/store/qmd_export_test.go
@@ -95,3 +95,35 @@ func TestQMDExportSourcesKeepsSeparateProfilesAndEnforcesMembershipLimit(t *test
 	require.ErrorContains(t, err, "membership exceeds limit")
 	assert.Nil(t, sources)
 }
+
+func TestRevalidateQMDExportCandidatesRequiresExactLiveAttachment(t *testing.T) {
+	s, versions := newRenditionCatalogFixture(t)
+	profile := catalogProcessingProfile(t, false)
+	build := catalogRenditionBuild(s, profile)
+	require.NoError(t, s.StageRenditionBuild(t.Context(), build))
+	attachment := RenditionAttachmentRecord{ID: catalogAttachmentFirst, VaultID: s.VaultID(), ContentVersionID: versions[0], BuildID: build.ID, Profile: profile, AttachedAt: nowRFC3339()}
+	require.NoError(t, publishAttachmentForTest(t, s, attachment))
+	sources, err := s.QMDExportSources(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	allowed, err := s.RevalidateQMDExportCandidates(t.Context(), sources, SearchOptions{})
+	require.NoError(t, err)
+	require.Len(t, allowed, 1)
+	assert.Equal(t, sources[0].NodeID, allowed[0].NodeID)
+	assert.Equal(t, versions[0], allowed[0].ContentVersionID)
+	assert.Equal(t, "/synthetic-source-a.pdf", allowed[0].Path)
+	assert.Positive(t, allowed[0].NodeRevision)
+
+	drifted := sources[0]
+	drifted.AttachmentID = "different-attachment"
+	_, err = s.RevalidateQMDExportCandidates(t.Context(), []QMDExportSource{drifted}, SearchOptions{})
+	require.ErrorIs(t, err, ErrQMDExportAuthorityStale)
+
+	file, err := s.NodeViewByPath(t.Context(), "/synthetic-source-a.pdf")
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), file.Node.ID, file.Node.Revision)
+	require.NoError(t, err)
+	_, err = s.RevalidateQMDExportCandidates(t.Context(), sources, SearchOptions{})
+	require.ErrorIs(t, err, ErrQMDExportAuthorityStale)
+}


### PR DESCRIPTION
Search an operator-hosted QMD collection and return only results that still match current Docbank documents. The internal bridge checks each result against the active export manifest, document version, and rendition. Stale entries or a generation change during the query cause the request to fail.

Scoped searches fetch candidates within a configured limit, remove out-of-scope hits, and keep the highest-ranked hit for each document across active rendition profiles. The result reports when limits may hide additional matches, including when no scoped matches were found.

Queries hold a consent lease through the HTTP request and response, use a named bearer credential, and apply configured network limits and deadlines. The bridge sends query text and search controls; it does not upload original files or retained Markdown. CLI and daemon wiring remain outside this PR.

Refs #176. Parent: #229 (merged).
