### PR TITLE
Prevent stale embedded writes from replacing newer content

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -65,7 +65,10 @@ func StoreSession(ctx context.Context, root string, sessionID string, jsonl []by
 type converges on the current version; changed bytes append an immutable content
 version while preserving the node ID. Supply `PutOptions.Expected` when the
 caller already knows the SHA-256 and byte count and wants Docbank to reject a
-mismatched stream before granting metadata authority.
+mismatched stream before granting metadata authority. Supply a positive
+`PutOptions.IfRevision` when replacing content derived from an earlier read.
+Docbank rejects the write with `ErrStaleRevision` if the file has changed since
+that revision, including when the new bytes happen to match the current head.
 
 Use `Create` when an application owns an immutable key and must never replace
 different content already stored there. It requires the expected SHA-256 and

--- a/vault.go
+++ b/vault.go
@@ -356,10 +356,12 @@ func (v *Vault) Versions(
 
 // PutOptions controls one embedded content write. Expected is optional; when
 // present, no node or version authority is granted unless both fields match
-// the independently computed durable bytes.
+// the independently computed durable bytes. A positive IfRevision requires an
+// existing file at that exact revision and rejects stale replacement attempts.
 type PutOptions struct {
-	MediaType string
-	Expected  *ContentIdentity
+	MediaType  string
+	Expected   *ContentIdentity
+	IfRevision int64
 }
 
 // CreateOptions controls one immutable content creation. Expected is required;
@@ -374,7 +376,9 @@ type CreateOptions struct {
 
 // Put stores a reader at an absolute virtual file path. Missing parent
 // directories are created. An unchanged retry converges on the current
-// version; changed bytes create a new immutable version on the same node.
+// version; changed bytes create a new immutable version on the same node. A
+// positive IfRevision makes both unchanged and changed writes conditional on
+// the existing file's current node revision.
 func (v *Vault) Put(
 	ctx context.Context, virtualPath string, content io.Reader, opts PutOptions,
 ) (PutReceipt, error) {
@@ -718,9 +722,27 @@ func (v *Vault) write(
 			return PutReceipt{}, errors.New("expected content size must not be negative")
 		}
 	}
+	if opts.IfRevision < 0 {
+		return PutReceipt{}, errors.New("docbank put revision must not be negative")
+	}
 
 	v.mutation.Lock()
 	defer v.mutation.Unlock()
+	if opts.IfRevision > 0 {
+		existing, lookupErr := v.metadata.NodeByPath(ctx, canonicalPath)
+		if lookupErr != nil {
+			return PutReceipt{}, lookupErr
+		}
+		if existing.IsDir() {
+			return PutReceipt{}, fmt.Errorf("virtual path %q: %w", canonicalPath, store.ErrNotFile)
+		}
+		if existing.Revision != opts.IfRevision {
+			return PutReceipt{}, fmt.Errorf(
+				"virtual path %q at revision %d, expected %d: %w",
+				canonicalPath, existing.Revision, opts.IfRevision, ErrStaleRevision,
+			)
+		}
+	}
 	var receipt PutReceipt
 	var physicalCreated bool
 	err = v.blobs.WithMutation(ctx, func() (resultErr error) {
@@ -770,6 +792,9 @@ func (v *Vault) write(
 		existing, lookupErr := v.metadata.NodeByPath(ctx, canonicalPath)
 		switch {
 		case errors.Is(lookupErr, store.ErrNotFound):
+			if opts.IfRevision > 0 {
+				return lookupErr
+			}
 			var created store.ContentWriteReceipt
 			var createErr error
 			if provenance == nil {
@@ -807,11 +832,15 @@ func (v *Vault) write(
 			}
 			return fmt.Errorf("virtual path %q: %w", canonicalPath, store.ErrNotFile)
 		case existing.BlobHash == hash && existing.Size == size && existing.MimeType == opts.MediaType:
+			revision := existing.Revision
+			if opts.IfRevision > 0 {
+				revision = opts.IfRevision
+			}
 			var confirmed store.ContentWriteReceipt
 			var confirmErr error
 			if provenance == nil {
 				confirmed, confirmErr = v.metadata.ConfirmContentWithReceipt(
-					ctx, existing.ID, existing.Revision, hash, size, opts.MediaType, physical,
+					ctx, existing.ID, revision, hash, size, opts.MediaType, physical,
 				)
 			} else {
 				confirmed, confirmErr = v.metadata.ConfirmIngestedContentWithReceipt(
@@ -836,8 +865,12 @@ func (v *Vault) write(
 				return fmt.Errorf("virtual path %q already has different content or media type: %w",
 					canonicalPath, ErrContentConflict)
 			}
+			revision := existing.Revision
+			if opts.IfRevision > 0 {
+				revision = opts.IfRevision
+			}
 			updated, replaceErr := v.metadata.ReplaceContentWithReceipt(
-				ctx, existing.ID, existing.Revision, hash, size, opts.MediaType, physical,
+				ctx, existing.ID, revision, hash, size, opts.MediaType, physical,
 			)
 			if replaceErr != nil {
 				return replaceErr

--- a/vault_external_test.go
+++ b/vault_external_test.go
@@ -268,6 +268,49 @@ func TestEmbeddedImmutableCreate(t *testing.T) {
 	require.True(t, receipt.Created)
 }
 
+func TestEmbeddedPutRequiresCurrentRevision(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	created, err := vault.Put(
+		t.Context(), "/external.txt", strings.NewReader("first\n"),
+		docbank.PutOptions{MediaType: "text/plain"},
+	)
+	require.NoError(t, err)
+
+	unchanged, err := vault.Put(
+		t.Context(), "/external.txt", strings.NewReader("first\n"),
+		docbank.PutOptions{MediaType: "text/plain", IfRevision: created.Node.Revision},
+	)
+	require.NoError(t, err)
+	require.Equal(t, created.Version.ID, unchanged.Version.ID)
+	require.Equal(t, created.Node.Revision, unchanged.Node.Revision)
+
+	replaced, err := vault.Put(
+		t.Context(), "/external.txt", strings.NewReader("second\n"),
+		docbank.PutOptions{MediaType: "text/plain", IfRevision: created.Node.Revision},
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, created.Version.ID, replaced.Version.ID)
+
+	_, err = vault.Put(
+		t.Context(), "/external.txt", strings.NewReader("third\n"),
+		docbank.PutOptions{MediaType: "text/plain", IfRevision: created.Node.Revision},
+	)
+	require.ErrorIs(t, err, docbank.ErrStaleRevision)
+
+	current, err := vault.Stat(t.Context(), "/external.txt")
+	require.NoError(t, err)
+	require.Equal(t, replaced.Version.ID, current.CurrentVersionID)
+
+	_, err = vault.Put(
+		t.Context(), "/external.txt", strings.NewReader("invalid\n"),
+		docbank.PutOptions{MediaType: "text/plain", IfRevision: -1},
+	)
+	require.Error(t, err)
+}
+
 func TestVaultMoveTrashRestoreExternalAPI(t *testing.T) {
 	vault, err := docbank.New(t.Context(), docbank.Config{Root: t.TempDir()})
 	require.NoError(t, err)


### PR DESCRIPTION
Embedded applications can now replace content only when the file is still at
the revision they read. If another writer changes it first, Docbank returns
`ErrStaleRevision` and preserves the newer version.

Callers opt into this behavior with `PutOptions.IfRevision`. Existing callers
keep unconditional `Put` behavior, and conditional writes can still require an
expected SHA-256 and byte count.
