### PR TITLE
Let embedded applications read extracted source metadata

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -126,6 +126,29 @@ until the external-reference contract is implemented.
 whether those bytes are stored raw, zstd-compressed, or in a pack. SHA-256 is
 the canonical logical identity, not a digest of a physical storage file.
 
+## Read extracted source metadata
+
+`SourceMetadata` returns Docbank's typed metadata for one immutable content
+version. The result carries the complete `ContentVersion`, so callers can bind
+the facts to the exact SHA-256 and node version they describe:
+
+```go
+metadata, err := vault.SourceMetadata(ctx, receipt.Version.ID)
+if err != nil {
+    return err
+}
+for _, field := range metadata.Fields {
+    // Interpret fields by namespace, key, and typed value.
+    _ = field
+}
+```
+
+If Docbank has not published metadata for the version's bytes, the method
+returns `ErrNotFound`. Opening an embedded vault does not start processing
+workers. The embedded API returns all local fields, including fields marked
+sensitive. The embedding application must decide what it may disclose to its
+own users and transports.
+
 Both write receipts include `Physical`, which distinguishes logical bytes from
 their current raw, zstd, or packed representation. Most applications should
 treat that field as operational evidence rather than document identity.

--- a/internal/store/source_metadata.go
+++ b/internal/store/source_metadata.go
@@ -50,6 +50,7 @@ type SourceMetadataAttachmentFacts struct {
 // SourceMetadataView combines immutable byte-derived evidence with the
 // attachment facts appropriate to the requested content version.
 type SourceMetadataView struct {
+	Version    ContentVersion
 	Generation SourceMetadataGeneration
 	Metadata   document.SourceMetadataV1
 	Attachment SourceMetadataAttachmentFacts
@@ -249,7 +250,9 @@ func sourceMetadataViewForVersion(
 			return SourceMetadataView{}, fmt.Errorf("reading source-metadata provenance: %w", err)
 		}
 	}
-	return SourceMetadataView{Generation: generation, Metadata: metadata, Attachment: facts}, nil
+	return SourceMetadataView{
+		Version: version, Generation: generation, Metadata: metadata, Attachment: facts,
+	}, nil
 }
 
 // NodeSourceMetadataViewByID returns one node detail from a single read snapshot.

--- a/types.go
+++ b/types.go
@@ -6,6 +6,7 @@ import (
 
 	"go.kenn.io/kit/packstore"
 
+	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/internal/store"
 )
 
@@ -45,6 +46,33 @@ type ContentVersion struct {
 	IntroducedOperationID string  `json:"introduced_operation_id"`
 	TransitionKind        string  `json:"transition_kind"`
 	SourceVersionID       *string `json:"source_version_id,omitempty"`
+}
+
+// SourceMetadataAttachment contains path and ingest facts joined to source
+// metadata for one exact content version. Path-derived fields are present only
+// when the requested version is the live node head.
+type SourceMetadataAttachment struct {
+	NodeID           int64  `json:"node_id"`
+	ContentVersionID string `json:"content_version_id"`
+	Filename         string `json:"filename,omitempty"`
+	Extension        string `json:"extension,omitempty"`
+	Path             string `json:"path,omitempty"`
+	SourcePath       string `json:"source_path,omitempty"`
+	IngestedAt       string `json:"ingested_at,omitempty"`
+	FilesystemMTime  string `json:"filesystem_mtime,omitempty"`
+}
+
+// SourceMetadata is immutable evidence extracted from one exact content
+// version, plus attachment facts joined for that version. Fields include
+// sensitive local evidence; the embedding application owns disclosure policy.
+type SourceMetadata struct {
+	Version              ContentVersion                     `json:"version"`
+	ContractVersion      string                             `json:"contract_version"`
+	ExtractorFingerprint string                             `json:"extractor_fingerprint"`
+	Checksum             string                             `json:"checksum"`
+	Fields               []document.SourceMetadataFieldV1   `json:"fields"`
+	Warnings             []document.SourceMetadataWarningV1 `json:"warnings"`
+	Attachment           SourceMetadataAttachment           `json:"attachment"`
 }
 
 // ProvenanceSource describes an application-neutral origin for one immutable
@@ -295,6 +323,24 @@ func fromStoreVersion(version store.ContentVersion) ContentVersion {
 		NodeRevision:          version.NodeRevision,
 		IntroducedOperationID: version.IntroducedOperationID,
 		TransitionKind:        version.TransitionKind, SourceVersionID: version.SourceVersionID,
+	}
+}
+
+func fromStoreSourceMetadata(view store.SourceMetadataView) SourceMetadata {
+	attachment := view.Attachment
+	return SourceMetadata{
+		Version:              fromStoreVersion(view.Version),
+		ContractVersion:      view.Metadata.ContractVersion,
+		ExtractorFingerprint: view.Generation.ExtractorFingerprint,
+		Checksum:             view.Generation.Checksum,
+		Fields:               view.Metadata.Fields,
+		Warnings:             view.Metadata.Warnings,
+		Attachment: SourceMetadataAttachment{
+			NodeID: attachment.NodeID, ContentVersionID: attachment.ContentVersionID,
+			Filename: attachment.Filename, Extension: attachment.Extension,
+			Path: attachment.Path, SourcePath: attachment.SourcePath,
+			IngestedAt: attachment.IngestedAt, FilesystemMTime: attachment.FilesystemMTime,
+		},
 	}
 }
 

--- a/vault.go
+++ b/vault.go
@@ -354,6 +354,21 @@ func (v *Vault) Versions(
 	return page, nil
 }
 
+// SourceMetadata returns durable metadata extracted from the original bytes
+// of one exact immutable content version. The result includes sensitive local
+// fields; the embedding application is responsible for disclosure policy.
+func (v *Vault) SourceMetadata(ctx context.Context, versionID string) (SourceMetadata, error) {
+	if err := v.begin(); err != nil {
+		return SourceMetadata{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	view, err := v.metadata.ContentVersionSourceMetadata(ctx, versionID)
+	if err != nil {
+		return SourceMetadata{}, err
+	}
+	return fromStoreSourceMetadata(view), nil
+}
+
 // PutOptions controls one embedded content write. Expected is optional; when
 // present, no node or version authority is granted unless both fields match
 // the independently computed durable bytes. A positive IfRevision requires an

--- a/vault_test.go
+++ b/vault_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/packstore"
 
+	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/store"
 	docsqlite "go.kenn.io/docbank/sqlite"
@@ -89,6 +90,49 @@ func TestVaultCreateIsImmutableAndIdempotent(t *testing.T) {
 	require.NoError(err)
 	require.Equal(int64(1), after.Revision)
 	require.Equal(created.Computed.SHA256, after.BlobHash)
+}
+
+func TestVaultSourceMetadataReturnsExactVersionEvidence(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	content := []byte("photo bytes")
+	receipt, err := vault.Create(t.Context(), "/photos/image.jpg", bytes.NewReader(content), CreateOptions{
+		MediaType: "image/jpeg", Expected: contentIdentity(content),
+	})
+	require.NoError(t, err)
+	_, err = vault.SourceMetadata(t.Context(), receipt.Version.ID)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	latitude := 41.8781
+	canonical, checksum, err := document.MarshalSourceMetadataV1(document.SourceMetadataV1{
+		ContractVersion: document.SourceMetadataContractV1,
+		Fields: []document.SourceMetadataFieldV1{{
+			Key: "image.exif.gps_latitude", Namespace: "image.exif", SourceField: "GPSLatitude", Sensitive: true,
+			Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataNumber, Number: &latitude},
+		}},
+	})
+	require.NoError(t, err)
+	fingerprint := contentIdentity([]byte("test extractor")).SHA256
+	_, err = vault.metadata.PublishSourceMetadata(
+		t.Context(), receipt.Version.BlobHash, fingerprint, canonical,
+	)
+	require.NoError(t, err)
+
+	metadata, err := vault.SourceMetadata(t.Context(), receipt.Version.ID)
+	require.NoError(t, err)
+	assert.Equal(t, receipt.Version, metadata.Version)
+	assert.Equal(t, document.SourceMetadataContractV1, metadata.ContractVersion)
+	assert.Equal(t, fingerprint, metadata.ExtractorFingerprint)
+	assert.Equal(t, checksum, metadata.Checksum)
+	require.Len(t, metadata.Fields, 1)
+	assert.True(t, metadata.Fields[0].Sensitive)
+	assert.InDelta(t, latitude, *metadata.Fields[0].Value.Number, 0.0000001)
+	assert.Equal(t, receipt.Node.ID, metadata.Attachment.NodeID)
+	assert.Equal(t, receipt.Version.ID, metadata.Attachment.ContentVersionID)
+	assert.Equal(t, "image.jpg", metadata.Attachment.Filename)
+	assert.Equal(t, "/photos/image.jpg", metadata.Attachment.Path)
 }
 
 func TestLeasedLimitedReaderShortRead(t *testing.T) {


### PR DESCRIPTION
Applications that embed Docbank can now read typed source metadata for an exact immutable content version. The response includes the full version record, extraction fingerprint and checksum, typed fields and warnings, and attachment facts. This lets embedded applications use Docbank's existing metadata intelligence instead of building a separate extraction pipeline.

The API returns all local fields, including sensitive fields such as GPS coordinates, because embedded callers are trusted application code. Each application remains responsible for what it exposes. If metadata has not been published, the method returns `ErrNotFound`.

Opening an embedded vault still does not start processing workers. Embedded processing orchestration remains separate work.
