### PR TITLE
Read camera and media facts from original files

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -147,6 +147,11 @@ repacking is worthwhile. [Editing & Versions](editing-and-versions.md) and
 [Trash, GC, Repack & Verify](../usage/trash-and-gc.md) give the command-level
 contracts.
 
+Metadata extracted from original file formats is separate from this authority
+chain. It is immutable evidence tied to a content digest and exact version, not
+a replacement for the original. [Source Metadata](source-metadata.md) explains
+the typed field contract, supported media formats, and current size limit.
+
 ## One logical content store can use several physical locations
 
 New content is published as a loose, digest-named file. Packing later combines

--- a/docs/architecture/source-metadata.md
+++ b/docs/architecture/source-metadata.md
@@ -1,0 +1,58 @@
+---
+title: Source Metadata
+description: How Docbank records bounded facts found inside original files.
+---
+
+# Source metadata
+
+Docbank extracts metadata from verified original bytes and stores it as local,
+immutable evidence. The evidence belongs to the content SHA-256, not to a
+filename or current path. A content version joins that evidence with its node
+and attachment facts when it is read.
+
+Source metadata does not change document identity and is not user-authored
+annotation. Embedded values can be incomplete, incorrect, or sensitive. They
+are useful evidence, not authority over the original bytes.
+
+## Typed fields
+
+Every field has a canonical key, a source namespace and label, a typed value,
+and a sensitive flag. The current contract supports strings, string lists,
+integers, numbers, booleans, and timestamps that preserve the precision and
+timezone stated by the source.
+
+Photo and video facts use two namespaces:
+
+- `media.container.*` contains format, media kind, pixel dimensions, image
+  frame count, animation state, and known video duration.
+- `image.exif.*` contains camera and lens names, orientation, ISO, exposure
+  time, aperture, exposure bias, focal length, EXIF pixel dimensions, and GPS.
+
+GPS fields are marked sensitive. The embedded API returns them because its
+caller is trusted application code. Browser-session reads remove sensitive
+fields; other callers must enforce their own disclosure boundary.
+
+## Current format boundary
+
+Container facts are available for JPEG, PNG, WebP, GIF, and MP4 files through
+20 MiB. JPEG APP1 EXIF and TIFF-based images provide EXIF facts. The TIFF path
+also covers camera RAW formats that retain a standard TIFF header and EXIF
+directories; formats with proprietary container headers need their own bounded
+parser.
+
+The source-metadata worker currently loads originals through 64 MiB for local
+parsing. Larger originals are fully verified but receive an `input_too_large`
+warning instead of extracted fields. Supporting large RAW and video files
+requires a bounded seekable parser rather than a larger memory allowance.
+
+## Generations and reads
+
+An extractor fingerprint identifies the complete local parser bundle. A parser
+change creates a new immutable generation and moves the active head for that
+content SHA-256; old generations remain evidence. Retrying the same generation
+is idempotent.
+
+The HTTP node and content-version detail surfaces return the active generation.
+Embedded applications call `Vault.SourceMetadata` with an immutable content
+version ID. Both surfaces bind fields to the requested version and keep
+filename, path, ingest time, and filesystem time in separate attachment facts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -187,6 +187,7 @@ documents: files you still organize, retrieve, and build workflows around.
 - [Troubleshooting](troubleshooting.md): diagnose failures without risking the vault
 - [CLI Reference](cli-reference.md): every command, flag, and output format
 - [How Docbank Works](architecture/overview.md): the architecture, guided
+- [Source Metadata](architecture/source-metadata.md): typed facts extracted from verified originals
 
 ## License
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -44,6 +44,7 @@ Every documentation page is also published as raw Markdown at the same path with
 
 ## How It Works
 - [How Docbank Works](https://docbank.ai/architecture/overview.md): A guided model of vaults, document identity, immutable content, storage authority, deletion, and recovery.
+- [Source Metadata](https://docbank.ai/architecture/source-metadata.md): How Docbank records bounded facts found inside original files.
 - [Storage](https://docbank.ai/architecture/storage.md): The SQLite schema, blob store layout, durability discipline, and enforced invariants.
 - [Loose & Packed Content](https://docbank.ai/architecture/packed-storage.md): The shared Kit packed-CAS layer and docbank's application-owned authority boundary.
 - [Editing & Versions](https://docbank.ai/architecture/editing-and-versions.md): Stable content-version identity, retrieval, replacement, reversion, and retention over immutable content.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -47,6 +47,7 @@ nav = [
   ]},
   {"How It Works" = [
     {"How Docbank Works" = "architecture/overview.md"},
+    {"Source Metadata" = "architecture/source-metadata.md"},
     {"Storage" = "architecture/storage.md"},
     {"Loose & Packed Content" = "architecture/packed-storage.md"},
     {"Editing & Versions" = "architecture/editing-and-versions.md"},

--- a/internal/processing/source_metadata.go
+++ b/internal/processing/source_metadata.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"mime/multipart"
 	"net/mail"
@@ -40,7 +41,7 @@ var (
 	// SourceMetadataExtractorFingerprint is the stable identity of the local
 	// parser bundle. Any semantic parser change must change the descriptor.
 	SourceMetadataExtractorFingerprint = fingerprintSourceMetadataExtractor(
-		"docbank-source-metadata:pdfcpu-info+xmp+pages,ooxml-core+custom,rfc5322,ical,jpeg-exif,media-id3:v8")
+		"docbank-source-metadata:pdfcpu-info+xmp+pages,ooxml-core+custom,rfc5322,ical,visual-container+jpeg-tiff-exif,media-id3:v9")
 )
 
 func fingerprintSourceMetadataExtractor(descriptor string) string {
@@ -143,8 +144,10 @@ func ExtractSourceMetadata(data []byte) document.SourceMetadataV1 {
 		collector.extractCalendar(data)
 	case bytes.HasPrefix(data, []byte("ID3")):
 		collector.extractID3(data)
-	case bytes.HasPrefix(data, []byte{0xff, 0xd8}):
-		collector.extractImage(data)
+	case visualContainerSignature(data):
+		collector.extractVisual(data)
+	case exifTIFFSignature(data):
+		collector.extractTIFFVisual(data)
 	default:
 		if message, err := mail.ReadMessage(bytes.NewReader(data)); err == nil {
 			collector.extractEmail(message)
@@ -282,6 +285,37 @@ func (c *metadataCollector) integer(key, namespace, source string, value int64) 
 	c.seen[key] = true
 	c.record.Fields = append(c.record.Fields, document.SourceMetadataFieldV1{Key: key, Namespace: namespace, SourceField: source,
 		Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataInteger, Integer: &value}})
+}
+func (c *metadataCollector) exifNumber(key, source string, value float64) {
+	const namespace = "image.exif"
+	if c.seen[key] || math.IsNaN(value) || math.IsInf(value, 0) {
+		return
+	}
+	if !c.fieldLabelsAllowed(key, namespace, source) {
+		return
+	}
+	if len(c.record.Fields) >= document.MaxSourceMetadataFields {
+		c.warn("field_limit", namespace, source, "additional embedded fields were omitted")
+		return
+	}
+	c.seen[key] = true
+	c.record.Fields = append(c.record.Fields, document.SourceMetadataFieldV1{Key: key, Namespace: namespace, SourceField: source,
+		Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataNumber, Number: &value}})
+}
+func (c *metadataCollector) boolean(key, namespace, source string, value bool) {
+	if c.seen[key] {
+		return
+	}
+	if !c.fieldLabelsAllowed(key, namespace, source) {
+		return
+	}
+	if len(c.record.Fields) >= document.MaxSourceMetadataFields {
+		c.warn("field_limit", namespace, source, "additional embedded fields were omitted")
+		return
+	}
+	c.seen[key] = true
+	c.record.Fields = append(c.record.Fields, document.SourceMetadataFieldV1{Key: key, Namespace: namespace, SourceField: source,
+		Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataBoolean, Boolean: &value}})
 }
 func (c *metadataCollector) timestamp(key, namespace, source, raw string) {
 	raw = strings.TrimSpace(raw)
@@ -924,7 +958,42 @@ func (c *metadataCollector) addID3Frame(frame, value string) {
 	}
 }
 
-func (c *metadataCollector) extractImage(data []byte) {
+func visualContainerSignature(data []byte) bool {
+	return bytes.HasPrefix(data, []byte{0xff, 0xd8}) ||
+		bytes.HasPrefix(data, []byte("\x89PNG\r\n\x1a\n")) ||
+		len(data) >= 12 && string(data[:4]) == "RIFF" && string(data[8:12]) == "WEBP" ||
+		bytes.HasPrefix(data, []byte("GIF87a")) || bytes.HasPrefix(data, []byte("GIF89a")) ||
+		len(data) >= 12 && string(data[4:8]) == "ftyp"
+}
+
+func exifTIFFSignature(data []byte) bool {
+	return len(data) >= 4 && (bytes.Equal(data[:4], []byte{'I', 'I', 42, 0}) ||
+		bytes.Equal(data[:4], []byte{'M', 'M', 0, 42}))
+}
+
+func (c *metadataCollector) extractVisual(data []byte) {
+	metadata, err := documentmedia.DetectBytes(data, "")
+	if err != nil {
+		c.warn("unparseable_metadata", "media.container", "header", "visual container metadata is malformed or unsupported")
+	} else {
+		c.string("media.container.format", "media.container", "Format", string(metadata.Format), false)
+		c.string("media.container.kind", "media.container", "Kind", string(metadata.Kind), false)
+		c.integer("media.container.width_px", "media.container", "Width", metadata.Width)
+		c.integer("media.container.height_px", "media.container", "Height", metadata.Height)
+		if metadata.FrameCount > 0 {
+			c.integer("media.container.frame_count", "media.container", "FrameCount", int64(metadata.FrameCount))
+			c.boolean("media.container.animated", "media.container", "Animated", metadata.Animated)
+		}
+		if metadata.DurationKnown {
+			c.integer("media.container.duration_ms", "media.container", "DurationMS", metadata.DurationMS)
+		}
+	}
+	if bytes.HasPrefix(data, []byte{0xff, 0xd8}) {
+		c.extractJPEGExif(data)
+	}
+}
+
+func (c *metadataCollector) extractJPEGExif(data []byte) {
 	for offset := 2; offset+4 <= len(data); {
 		if data[offset] != 0xff {
 			offset++
@@ -951,6 +1020,21 @@ func (c *metadataCollector) extractImage(data []byte) {
 	if len(c.record.Fields) == 0 {
 		c.warn("unparseable_metadata", "image.exif", "APP1", "image contained no supported metadata values")
 	}
+}
+
+func (c *metadataCollector) extractTIFFVisual(data []byte) {
+	c.string("media.container.format", "media.container", "Format", "tiff", false)
+	c.string("media.container.kind", "media.container", "Kind", "image", false)
+	if reader, ok := newExifReader(data); ok {
+		root := reader.entries(reader.u32(4))
+		if width, found := exifUnsigned(reader, root[0x0100]); found && width > 0 {
+			c.integer("media.container.width_px", "media.container", "ImageWidth", width)
+		}
+		if height, found := exifUnsigned(reader, root[0x0101]); found && height > 0 {
+			c.integer("media.container.height_px", "media.container", "ImageLength", height)
+		}
+	}
+	c.extractExifTIFF(data)
 }
 
 type exifReader struct {
@@ -1002,8 +1086,8 @@ func (r exifReader) entries(offset uint32) map[uint16][]byte {
 		}
 		kind, _ := r.u16(base + 2)
 		items := r.u32(base + 4)
-		width := map[uint16]uint32{1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 7: 1, 9: 4, 10: 8}[kind]
-		size := items * width
+		width := map[uint16]uint64{1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 7: 1, 9: 4, 10: 8}[kind]
+		size := uint64(items) * width
 		if width == 0 || size > 1<<20 {
 			continue
 		}
@@ -1012,16 +1096,51 @@ func (r exifReader) entries(offset uint32) map[uint16][]byte {
 			pointer := r.u32(base + 8)
 			start = int(pointer)
 		}
-		if start < 0 || start+int(size) > len(r.data) {
+		sizeInt := int(size)
+		if start < 0 || start > len(r.data) || sizeInt > len(r.data)-start {
 			continue
 		}
-		result[tag] = r.data[start : start+int(size)]
+		result[tag] = r.data[start : start+sizeInt]
 	}
 	return result
 }
 func exifASCII(value []byte) string {
 	return strings.TrimSpace(strings.TrimRight(string(value), "\x00"))
 }
+
+func exifUnsigned(reader exifReader, value []byte) (int64, bool) {
+	switch len(value) {
+	case 1:
+		return int64(value[0]), true
+	case 2:
+		return int64(reader.order.Uint16(value)), true
+	case 4:
+		return int64(reader.order.Uint32(value)), true
+	default:
+		return 0, false
+	}
+}
+
+func exifRational(reader exifReader, value []byte, signed bool) (float64, bool) {
+	if len(value) != 8 {
+		return 0, false
+	}
+	if signed {
+		numerator := int64(int32(reader.order.Uint32(value[:4])))   //nolint:gosec // EXIF SRATIONAL stores signed bits in an unsigned read buffer.
+		denominator := int64(int32(reader.order.Uint32(value[4:]))) //nolint:gosec // EXIF SRATIONAL stores signed bits in an unsigned read buffer.
+		if denominator == 0 {
+			return 0, false
+		}
+		return float64(numerator) / float64(denominator), true
+	}
+	numerator := reader.order.Uint32(value[:4])
+	denominator := reader.order.Uint32(value[4:])
+	if denominator == 0 {
+		return 0, false
+	}
+	return float64(numerator) / float64(denominator), true
+}
+
 func (c *metadataCollector) extractExifTIFF(data []byte) {
 	reader, ok := newExifReader(data)
 	if !ok {
@@ -1030,7 +1149,12 @@ func (c *metadataCollector) extractExifTIFF(data []byte) {
 	}
 	rootOffset := reader.u32(4)
 	root := reader.entries(rootOffset)
+	c.string("image.exif.camera_make", "image.exif", "Make", exifASCII(root[0x010f]), false)
+	c.string("image.exif.camera_model", "image.exif", "Model", exifASCII(root[0x0110]), false)
 	c.string("description", "image.exif", "ImageDescription", exifASCII(root[0x010e]), false)
+	if orientation, found := exifUnsigned(reader, root[0x0112]); found && orientation >= 1 && orientation <= 8 {
+		c.integer("image.exif.orientation", "image.exif", "Orientation", orientation)
+	}
 	if artist := exifASCII(root[0x013b]); artist != "" {
 		c.strings("creators", "image.exif", "Artist", splitValues(artist))
 	}
@@ -1042,6 +1166,29 @@ func (c *metadataCollector) extractExifTIFF(data []byte) {
 		exif := reader.entries(offset)
 		if stamp := exifASCII(exif[0x9003]); stamp != "" {
 			c.timestamp("created", "image.exif", "DateTimeOriginal", stamp)
+		}
+		if iso, found := exifUnsigned(reader, exif[0x8827]); found && iso > 0 {
+			c.integer("image.exif.iso", "image.exif", "PhotographicSensitivity", iso)
+		}
+		if exposure, found := exifRational(reader, exif[0x829a], false); found && exposure > 0 {
+			c.exifNumber("image.exif.exposure_time_seconds", "ExposureTime", exposure)
+		}
+		if aperture, found := exifRational(reader, exif[0x829d], false); found && aperture > 0 {
+			c.exifNumber("image.exif.f_number", "FNumber", aperture)
+		}
+		if bias, found := exifRational(reader, exif[0x9204], true); found {
+			c.exifNumber("image.exif.exposure_bias_ev", "ExposureBiasValue", bias)
+		}
+		if focalLength, found := exifRational(reader, exif[0x920a], false); found && focalLength > 0 {
+			c.exifNumber("image.exif.focal_length_mm", "FocalLength", focalLength)
+		}
+		c.string("image.exif.lens_make", "image.exif", "LensMake", exifASCII(exif[0xa433]), false)
+		c.string("image.exif.lens_model", "image.exif", "LensModel", exifASCII(exif[0xa434]), false)
+		if width, found := exifUnsigned(reader, exif[0xa002]); found && width > 0 {
+			c.integer("image.exif.pixel_width", "image.exif", "PixelXDimension", width)
+		}
+		if height, found := exifUnsigned(reader, exif[0xa003]); found && height > 0 {
+			c.integer("image.exif.pixel_height", "image.exif", "PixelYDimension", height)
 		}
 	}
 	if raw := root[0x8825]; len(raw) >= 4 {

--- a/internal/processing/source_metadata_test.go
+++ b/internal/processing/source_metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"image/color"
 	"io"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media/mediatest"
 	"go.kenn.io/docbank/internal/store"
 	"go.kenn.io/kit/packstore"
 )
@@ -30,7 +32,7 @@ func TestExtractSourceMetadataFromSyntheticFormats(t *testing.T) {
 		{name: "OOXML core, app, and custom", payload: ooxml, keys: []string{"created", "office.core.word_count", "office.custom.matter_number", "page_count", "title"}},
 		{name: "RFC 5322 email", payload: []byte("From: Ada <ada@example.test>\r\nTo: Grace <grace@example.test>\r\nBcc: Private <private@example.test>\r\nSubject: Synthetic mail\r\nDate: Tue, 2 Jan 2024 03:04:05 -0700\r\n\r\nbody"), keys: []string{"email.bcc", "email.from", "email.sent", "email.subject", "email.to"}, sensitive: "email.bcc"},
 		{name: "iCalendar", payload: []byte("BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nSUMMARY:Synthetic meeting\r\nDTSTART:20240102T030405\r\nDTEND:20240102T040405\r\nEND:VEVENT\r\nEND:VCALENDAR"), keys: []string{"calendar.end", "calendar.start", "title"}},
-		{name: "JPEG EXIF", payload: syntheticExifJPEG(), keys: []string{"creators", "description"}},
+		{name: "JPEG EXIF", payload: syntheticExifJPEG(), keys: []string{"creators", "description", "media.container.animated", "media.container.format", "media.container.frame_count", "media.container.height_px", "media.container.kind", "media.container.width_px"}},
 		{name: "ID3 media tags", payload: syntheticID3Tag(4,
 			syntheticID3Frame{id: "TIT2", encoding: 3, text: []byte("Synthetic song")},
 			syntheticID3Frame{id: "TPE1", encoding: 3, text: []byte("Ada")},
@@ -54,6 +56,91 @@ func TestExtractSourceMetadataFromSyntheticFormats(t *testing.T) {
 			assert.NotContains(t, string(canonical), "source_path")
 		})
 	}
+}
+
+func TestExtractSourceMetadataReadsVisualContainerFacts(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		payload    []byte
+		kind       string
+		width      int64
+		height     int64
+		frames     int64
+		durationMS int64
+		animated   bool
+	}{
+		{name: "PNG", payload: mediatest.PNG(12, 8, color.Black), kind: "image", width: 12, height: 8, frames: 1},
+		{name: "animated GIF", payload: mediatest.GIF(16, 10, 2), kind: "image", width: 16, height: 10, frames: 2, animated: true},
+		{name: "WebP", payload: mediatest.WebP(20, 14), kind: "image", width: 20, height: 14, frames: 1},
+		{name: "MP4", payload: mediatest.MP4(640, 368, 3500), kind: "video", width: 640, height: 368, durationMS: 3500},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			metadata := ExtractSourceMetadata(testCase.payload)
+			kind, found := sourceMetadataString(metadata, "media.container.kind")
+			require.True(t, found)
+			assert.Equal(t, testCase.kind, kind)
+			width, found := sourceMetadataInteger(metadata, "media.container.width_px")
+			require.True(t, found)
+			assert.Equal(t, testCase.width, width)
+			height, found := sourceMetadataInteger(metadata, "media.container.height_px")
+			require.True(t, found)
+			assert.Equal(t, testCase.height, height)
+			if testCase.frames > 0 {
+				frames, found := sourceMetadataInteger(metadata, "media.container.frame_count")
+				require.True(t, found)
+				assert.Equal(t, testCase.frames, frames)
+				animated, found := sourceMetadataBoolean(metadata, "media.container.animated")
+				require.True(t, found)
+				assert.Equal(t, testCase.animated, animated)
+			}
+			if testCase.durationMS > 0 {
+				duration, found := sourceMetadataInteger(metadata, "media.container.duration_ms")
+				require.True(t, found)
+				assert.Equal(t, testCase.durationMS, duration)
+			}
+		})
+	}
+}
+
+func TestExtractSourceMetadataReadsTIFFPhotoFacts(t *testing.T) {
+	metadata := ExtractSourceMetadata(syntheticRichExifTIFF())
+	for key, want := range map[string]string{
+		"media.container.format":  "tiff",
+		"media.container.kind":    "image",
+		"image.exif.camera_make":  "Fiction Camera Co.",
+		"image.exif.camera_model": "Model One",
+		"image.exif.lens_make":    "Fiction Lens Co.",
+		"image.exif.lens_model":   "Prime 50mm",
+	} {
+		value, found := sourceMetadataString(metadata, key)
+		require.True(t, found, key)
+		assert.Equal(t, want, value, key)
+	}
+	for key, want := range map[string]int64{
+		"media.container.width_px":  6000,
+		"media.container.height_px": 4000,
+		"image.exif.orientation":    6,
+		"image.exif.iso":            800,
+		"image.exif.pixel_width":    6000,
+		"image.exif.pixel_height":   4000,
+	} {
+		value, found := sourceMetadataInteger(metadata, key)
+		require.True(t, found, key)
+		assert.Equal(t, want, value, key)
+	}
+	for key, want := range map[string]float64{
+		"image.exif.exposure_time_seconds": 0.004,
+		"image.exif.f_number":              2.8,
+		"image.exif.exposure_bias_ev":      -1.0 / 3.0,
+		"image.exif.focal_length_mm":       50,
+	} {
+		value, found := sourceMetadataNumber(metadata, key)
+		require.True(t, found, key)
+		assert.InDelta(t, want, value, 0.0000001, key)
+	}
+	created, found := sourceMetadataTimestamp(metadata, "created")
+	require.True(t, found)
+	assert.Equal(t, "2024:01:02 03:04:05", created.Raw)
 }
 
 func TestExtractSourceMetadataReadsOOXMLAppProperties(t *testing.T) {
@@ -308,6 +395,24 @@ func sourceMetadataInteger(metadata document.SourceMetadataV1, key string) (int6
 	return 0, false
 }
 
+func sourceMetadataNumber(metadata document.SourceMetadataV1, key string) (float64, bool) {
+	for _, field := range metadata.Fields {
+		if field.Key == key && field.Value.Number != nil {
+			return *field.Value.Number, true
+		}
+	}
+	return 0, false
+}
+
+func sourceMetadataBoolean(metadata document.SourceMetadataV1, key string) (bool, bool) {
+	for _, field := range metadata.Fields {
+		if field.Key == key && field.Value.Boolean != nil {
+			return *field.Value.Boolean, true
+		}
+	}
+	return false, false
+}
+
 func sourceMetadataString(metadata document.SourceMetadataV1, key string) (string, bool) {
 	for _, field := range metadata.Fields {
 		if field.Key == key && field.Value.Kind == document.SourceMetadataString {
@@ -419,10 +524,113 @@ func syntheticExifJPEG() []byte {
 		copy(tiff[entry.start:], entry.value)
 	}
 	segment := append([]byte("Exif\x00\x00"), tiff...)
-	jpeg := []byte{0xff, 0xd8, 0xff, 0xe1, 0, 0}
-	binary.BigEndian.PutUint16(jpeg[4:6], uint16(len(segment)+2))
-	jpeg = append(jpeg, segment...)
-	return append(jpeg, 0xff, 0xd9)
+	app1 := []byte{0xff, 0xe1, 0, 0}
+	binary.BigEndian.PutUint16(app1[2:4], uint16(len(segment)+2))
+	jpeg := mediatest.JPEG(40, 30, color.Black)
+	result := append([]byte{}, jpeg[:2]...)
+	result = append(result, app1...)
+	result = append(result, segment...)
+	return append(result, jpeg[2:]...)
+}
+
+type syntheticTIFFEntry struct {
+	tag   uint16
+	kind  uint16
+	value []byte
+}
+
+func syntheticRichExifTIFF() []byte {
+	return syntheticTIFF(
+		[]syntheticTIFFEntry{
+			tiffLong(0x0100, 6000),
+			tiffLong(0x0101, 4000),
+			tiffASCII(0x010f, "Fiction Camera Co."),
+			tiffASCII(0x0110, "Model One"),
+			tiffShort(0x0112, 6),
+		},
+		[]syntheticTIFFEntry{
+			tiffRational(0x829a, 1, 250, false),
+			tiffRational(0x829d, 28, 10, false),
+			tiffShort(0x8827, 800),
+			tiffASCII(0x9003, "2024:01:02 03:04:05"),
+			tiffRational(0x9204, -1, 3, true),
+			tiffRational(0x920a, 50, 1, false),
+			tiffLong(0xa002, 6000),
+			tiffLong(0xa003, 4000),
+			tiffASCII(0xa433, "Fiction Lens Co."),
+			tiffASCII(0xa434, "Prime 50mm"),
+		},
+	)
+}
+
+func syntheticTIFF(root, exif []syntheticTIFFEntry) []byte {
+	const headerSize = 8
+	rootEntries := append([]syntheticTIFFEntry{}, root...)
+	rootIFDSize := 2 + (len(rootEntries)+1)*12 + 4
+	exifOffset := headerSize + rootIFDSize
+	pointer := make([]byte, 4)
+	binary.LittleEndian.PutUint32(pointer, uint32(exifOffset))
+	rootEntries = append(rootEntries, syntheticTIFFEntry{tag: 0x8769, kind: 4, value: pointer})
+	exifIFDSize := 2 + len(exif)*12 + 4
+	externalSize := 0
+	for _, entry := range append(append([]syntheticTIFFEntry{}, rootEntries...), exif...) {
+		if len(entry.value) > 4 {
+			externalSize += len(entry.value)
+		}
+	}
+	tiff := make([]byte, exifOffset+exifIFDSize+externalSize)
+	copy(tiff, "II")
+	binary.LittleEndian.PutUint16(tiff[2:4], 42)
+	binary.LittleEndian.PutUint32(tiff[4:8], headerSize)
+	externalOffset := exifOffset + exifIFDSize
+	writeSyntheticTIFFIFD(tiff, headerSize, rootEntries, &externalOffset)
+	writeSyntheticTIFFIFD(tiff, exifOffset, exif, &externalOffset)
+	return tiff
+}
+
+func writeSyntheticTIFFIFD(data []byte, offset int, entries []syntheticTIFFEntry, externalOffset *int) {
+	binary.LittleEndian.PutUint16(data[offset:], uint16(len(entries)))
+	for index, entry := range entries {
+		base := offset + 2 + index*12
+		binary.LittleEndian.PutUint16(data[base:], entry.tag)
+		binary.LittleEndian.PutUint16(data[base+2:], entry.kind)
+		width := map[uint16]int{2: 1, 3: 2, 4: 4, 5: 8, 10: 8}[entry.kind]
+		binary.LittleEndian.PutUint32(data[base+4:], uint32(len(entry.value)/width))
+		if len(entry.value) <= 4 {
+			copy(data[base+8:base+12], entry.value)
+			continue
+		}
+		binary.LittleEndian.PutUint32(data[base+8:], uint32(*externalOffset))
+		copy(data[*externalOffset:], entry.value)
+		*externalOffset += len(entry.value)
+	}
+}
+
+func tiffASCII(tag uint16, value string) syntheticTIFFEntry {
+	return syntheticTIFFEntry{tag: tag, kind: 2, value: append([]byte(value), 0)}
+}
+
+func tiffShort(tag, value uint16) syntheticTIFFEntry {
+	encoded := make([]byte, 2)
+	binary.LittleEndian.PutUint16(encoded, value)
+	return syntheticTIFFEntry{tag: tag, kind: 3, value: encoded}
+}
+
+func tiffLong(tag uint16, value uint32) syntheticTIFFEntry {
+	encoded := make([]byte, 4)
+	binary.LittleEndian.PutUint32(encoded, value)
+	return syntheticTIFFEntry{tag: tag, kind: 4, value: encoded}
+}
+
+func tiffRational(tag uint16, numerator, denominator int32, signed bool) syntheticTIFFEntry {
+	encoded := make([]byte, 8)
+	binary.LittleEndian.PutUint32(encoded, uint32(numerator))
+	binary.LittleEndian.PutUint32(encoded[4:], uint32(denominator))
+	kind := uint16(5)
+	if signed {
+		kind = 10
+	}
+	return syntheticTIFFEntry{tag: tag, kind: kind, value: encoded}
 }
 
 type syntheticID3Frame struct {


### PR DESCRIPTION
Docbank now records reusable photo and video facts as typed source metadata. JPEG, PNG, WebP, and GIF files report dimensions and animation state. MP4 files report dimensions and duration when known. JPEG and TIFF-based photos report common camera, lens, orientation, ISO, exposure, aperture, focal-length, capture-time, and GPS fields. Camera RAW files with standard TIFF headers use the same parser.

This keeps media intelligence tied to the exact original bytes, so embedded applications do not need their own EXIF database. The extractor fingerprint advances, which lets existing originals receive a new metadata generation.

The current limits remain explicit: container inspection reads files through 20 MiB, and the source-metadata worker buffers originals through 64 MiB. Larger files and proprietary RAW containers need a bounded seekable parser in follow-up work.
