### PR TITLE
Read camera metadata from ORF and RW2 files

### DIFF
--- a/docs/architecture/source-metadata.md
+++ b/docs/architecture/source-metadata.md
@@ -36,9 +36,9 @@ fields; other callers must enforce their own disclosure boundary.
 
 Container facts are available for JPEG, PNG, WebP, GIF, and MP4 files within
 the 20 MiB general inspection limit. JPEG APP1 EXIF and TIFF-based images
-provide EXIF facts. The TIFF path also covers camera RAW formats that retain a
-standard TIFF header and EXIF directories; formats with proprietary container
-headers need their own bounded parser.
+provide EXIF facts. The TIFF path also covers camera RAW formats that retain
+the standard TIFF header, plus the TIFF-derived Olympus ORF and Panasonic RW2
+headers. Other proprietary container headers need their own bounded parser.
 
 The source-metadata worker keeps the general in-memory parser for originals
 through 64 MiB. JPEG, TIFF-based, and MP4 originals beyond the general

--- a/internal/processing/source_metadata.go
+++ b/internal/processing/source_metadata.go
@@ -43,7 +43,7 @@ var (
 	// SourceMetadataExtractorFingerprint is the stable identity of the local
 	// parser bundle. Any semantic parser change must change the descriptor.
 	SourceMetadataExtractorFingerprint = fingerprintSourceMetadataExtractor(
-		"docbank-source-metadata:pdfcpu-info+xmp+pages,ooxml-core+custom,rfc5322,ical,visual-container+jpeg-tiff-exif,media-id3:v10")
+		"docbank-source-metadata:pdfcpu-info+xmp+pages,ooxml-core+custom,rfc5322,ical,visual-container+jpeg-tiff-exif,media-id3:v11")
 
 	// errSourceMetadataMP4Malformed marks deterministic MP4 structure defects
 	// in verified bytes, which become durable warnings rather than retryable
@@ -1217,8 +1217,33 @@ func visualContainerSignature(data []byte) bool {
 }
 
 func exifTIFFSignature(data []byte) bool {
-	return len(data) >= 4 && (bytes.Equal(data[:4], []byte{'I', 'I', 42, 0}) ||
-		bytes.Equal(data[:4], []byte{'M', 'M', 0, 42}))
+	_, _, ok := exifTIFFHeader(data)
+	return ok
+}
+
+func exifTIFFHeader(data []byte) (binary.ByteOrder, string, bool) {
+	if len(data) < 4 {
+		return nil, "", false
+	}
+	var order binary.ByteOrder
+	switch string(data[:2]) {
+	case "II":
+		order = binary.LittleEndian
+	case "MM":
+		order = binary.BigEndian
+	default:
+		return nil, "", false
+	}
+	switch order.Uint16(data[2:4]) {
+	case 42:
+		return order, "tiff", true
+	case 0x4f52, 0x5352:
+		return order, "orf", true
+	case 0x0055:
+		return order, "rw2", true
+	default:
+		return nil, "", false
+	}
 }
 
 func (c *metadataCollector) extractVisual(data []byte) {
@@ -1273,9 +1298,9 @@ func (c *metadataCollector) extractJPEGExif(data []byte) {
 }
 
 func (c *metadataCollector) extractTIFFVisual(data []byte) {
-	c.string("media.container.format", "media.container", "Format", "tiff", false)
-	c.string("media.container.kind", "media.container", "Kind", "image", false)
 	if reader, ok := newExifReader(data); ok {
+		c.string("media.container.format", "media.container", "Format", reader.format, false)
+		c.string("media.container.kind", "media.container", "Kind", "image", false)
 		root := reader.entries(reader.u32(4))
 		if width, found := exifUnsigned(reader, root[0x0100]); found && width > 0 {
 			c.integer("media.container.width_px", "media.container", "ImageWidth", width)
@@ -1288,27 +1313,20 @@ func (c *metadataCollector) extractTIFFVisual(data []byte) {
 }
 
 type exifReader struct {
-	data  []byte
-	order binary.ByteOrder
+	data   []byte
+	order  binary.ByteOrder
+	format string
 }
 
 func newExifReader(data []byte) (exifReader, bool) {
 	if len(data) < 8 {
 		return exifReader{}, false
 	}
-	var order binary.ByteOrder
-	switch string(data[:2]) {
-	case "II":
-		order = binary.LittleEndian
-	case "MM":
-		order = binary.BigEndian
-	default:
+	order, format, ok := exifTIFFHeader(data)
+	if !ok {
 		return exifReader{}, false
 	}
-	if order.Uint16(data[2:4]) != 42 {
-		return exifReader{}, false
-	}
-	return exifReader{data: data, order: order}, true
+	return exifReader{data: data, order: order, format: format}, true
 }
 func (r exifReader) u16(offset int) (uint16, bool) {
 	if offset < 0 || offset+2 > len(r.data) {
@@ -1411,6 +1429,7 @@ func (c *metadataCollector) extractExifTIFF(data []byte) {
 	if stamp := exifASCII(root[0x0132]); stamp != "" {
 		c.timestamp("modified", "image.exif", "DateTime", stamp)
 	}
+	isoFound := false
 	if raw := root[0x8769]; len(raw) >= 4 {
 		offset := reader.order.Uint32(raw)
 		exif := reader.entries(offset)
@@ -1419,6 +1438,7 @@ func (c *metadataCollector) extractExifTIFF(data []byte) {
 		}
 		if iso, found := exifUnsigned(reader, exif[0x8827]); found && iso > 0 {
 			c.integer("image.exif.iso", "image.exif", "PhotographicSensitivity", iso)
+			isoFound = true
 		}
 		if exposure, found := exifRational(reader, exif[0x829a], false); found && exposure > 0 {
 			c.exifNumber("image.exif.exposure_time_seconds", "ExposureTime", exposure)
@@ -1439,6 +1459,11 @@ func (c *metadataCollector) extractExifTIFF(data []byte) {
 		}
 		if height, found := exifUnsigned(reader, exif[0xa003]); found && height > 0 {
 			c.integer("image.exif.pixel_height", "image.exif", "PixelYDimension", height)
+		}
+	}
+	if !isoFound && reader.format == "rw2" {
+		if iso, found := exifUnsigned(reader, root[0x0017]); found && iso > 0 {
+			c.integer("image.exif.iso", "image.exif", "ISO", iso)
 		}
 	}
 	if raw := root[0x8825]; len(raw) >= 4 {

--- a/internal/processing/source_metadata_test.go
+++ b/internal/processing/source_metadata_test.go
@@ -145,6 +145,47 @@ func TestExtractSourceMetadataReadsTIFFPhotoFacts(t *testing.T) {
 	assert.Equal(t, "2024:01:02 03:04:05", created.Raw)
 }
 
+func TestExtractSourceMetadataReadsRawTIFFVariants(t *testing.T) {
+	for _, testCase := range []struct {
+		name, format string
+		magic        uint16
+		standardISO  uint16
+		rw2ISO       uint16
+		wantISO      int64
+	}{
+		{name: "ORF original signature", format: "orf", magic: 0x4f52, standardISO: 640, wantISO: 640},
+		{name: "ORF later signature", format: "orf", magic: 0x5352, standardISO: 640, wantISO: 640},
+		{name: "RW2 fallback ISO", format: "rw2", magic: 0x0055, rw2ISO: 1250, wantISO: 1250},
+		{name: "RW2 standard ISO wins", format: "rw2", magic: 0x0055, standardISO: 800, rw2ISO: 1250, wantISO: 800},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := []syntheticTIFFEntry{
+				tiffLong(0x0100, 6000),
+				tiffLong(0x0101, 4000),
+				tiffASCII(0x010f, "Synthetic Camera Co."),
+				tiffASCII(0x0110, "Model Raw"),
+			}
+			var exif []syntheticTIFFEntry
+			if testCase.standardISO > 0 {
+				exif = append(exif, tiffShort(0x8827, testCase.standardISO))
+			}
+			if testCase.rw2ISO > 0 {
+				root = append(root, tiffShort(0x0017, testCase.rw2ISO))
+			}
+			metadata := ExtractSourceMetadata(syntheticTIFF(testCase.magic, root, exif))
+			format, found := sourceMetadataString(metadata, "media.container.format")
+			require.True(t, found)
+			assert.Equal(t, testCase.format, format)
+			model, found := sourceMetadataString(metadata, "image.exif.camera_model")
+			require.True(t, found)
+			assert.Equal(t, "Model Raw", model)
+			iso, found := sourceMetadataInteger(metadata, "image.exif.iso")
+			require.True(t, found)
+			assert.Equal(t, testCase.wantISO, iso)
+		})
+	}
+}
+
 func TestExtractSourceMetadataReadsOOXMLAppProperties(t *testing.T) {
 	metadata := ExtractSourceMetadata(syntheticOOXML(t))
 	pages, found := sourceMetadataInteger(metadata, "page_count")
@@ -542,7 +583,7 @@ type syntheticTIFFEntry struct {
 }
 
 func syntheticRichExifTIFF() []byte {
-	return syntheticTIFF(
+	return syntheticTIFF(42,
 		[]syntheticTIFFEntry{
 			tiffLong(0x0100, 6000),
 			tiffLong(0x0101, 4000),
@@ -565,7 +606,7 @@ func syntheticRichExifTIFF() []byte {
 	)
 }
 
-func syntheticTIFF(root, exif []syntheticTIFFEntry) []byte {
+func syntheticTIFF(magic uint16, root, exif []syntheticTIFFEntry) []byte {
 	const headerSize = 8
 	rootEntries := append([]syntheticTIFFEntry{}, root...)
 	rootIFDSize := 2 + (len(rootEntries)+1)*12 + 4
@@ -582,7 +623,7 @@ func syntheticTIFF(root, exif []syntheticTIFFEntry) []byte {
 	}
 	tiff := make([]byte, exifOffset+exifIFDSize+externalSize)
 	copy(tiff, "II")
-	binary.LittleEndian.PutUint16(tiff[2:4], 42)
+	binary.LittleEndian.PutUint16(tiff[2:4], magic)
 	binary.LittleEndian.PutUint32(tiff[4:8], headerSize)
 	externalOffset := exifOffset + exifIFDSize
 	writeSyntheticTIFFIFD(tiff, headerSize, rootEntries, &externalOffset)


### PR DESCRIPTION
Docbank now reads the same camera, exposure, dimensions, orientation, and GPS facts from Olympus ORF and Panasonic RW2 originals that it already reads from TIFF-based photos.

Both formats reuse the bounded local TIFF/EXIF parser, so metadata stays attached to the exact original bytes and does not require a vendor service. RW2 files use their primary-directory ISO value only when the standard EXIF sensitivity field is absent.

This does not add RAF or CR3 support; those formats need separate container parsers.
