### PR TITLE
Read camera metadata from Fujifilm RAF files

### DIFF
--- a/docs/architecture/source-metadata.md
+++ b/docs/architecture/source-metadata.md
@@ -38,7 +38,9 @@ Container facts are available for JPEG, PNG, WebP, GIF, and MP4 files within
 the 20 MiB general inspection limit. JPEG APP1 EXIF and TIFF-based images
 provide EXIF facts. The TIFF path also covers camera RAW formats that retain
 the standard TIFF header, plus the TIFF-derived Olympus ORF and Panasonic RW2
-headers. Other proprietary container headers need their own bounded parser.
+headers. Fujifilm RAF files provide EXIF facts through their embedded JPEG and
+the original image dimensions through their RAF raw-metadata directory. Other
+proprietary container headers need their own bounded parser.
 
 The source-metadata worker keeps the general in-memory parser for originals
 through 64 MiB. JPEG, TIFF-based, and MP4 originals beyond the general
@@ -51,8 +53,11 @@ For larger MP4 files, the worker verifies the complete content identity, scans
 the top-level box headers, skips media payload boxes, and reads only bounded
 file-type and movie metadata. Malformed or oversized MP4 metadata produces a
 durable warning. Storage and read failures remain retryable errors. Other
-formats larger than 64 MiB still receive `input_too_large` until they have a
-bounded parser.
+large RAF files similarly read only the fixed header, a bounded embedded-JPEG
+metadata window, and a bounded raw-metadata directory after full verification.
+Malformed RAF structure produces a durable warning; storage and read failures
+remain retryable. Other formats larger than 64 MiB still receive
+`input_too_large` until they have a bounded parser.
 
 ## Generations and reads
 

--- a/internal/processing/source_metadata.go
+++ b/internal/processing/source_metadata.go
@@ -30,8 +30,14 @@ const (
 	maxSourceMetadataOriginalBytes       = 64 << 20
 	maxSourceMetadataWindowBytes         = documentmedia.MaxBytes
 	maxSourceMetadataFTYPBytes           = 1 << 20
+	maxSourceMetadataRAFDirectoryBytes   = 1 << 20
 	maxSourceMetadataAggregateValueBytes = 1 << 20
 	maxSourceMetadataXMLDepth            = 64
+	sourceMetadataRAFHeaderBytes         = 160
+	sourceMetadataRAFJPEGOffset          = 84
+	sourceMetadataRAFCFAOffset           = 92
+	sourceMetadataRAFImageSizeTag        = 0x0111
+	sourceMetadataRAFSignature           = "FUJIFILMCCD-RAW"
 	rdfNamespace                         = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlNamespace                         = "http://www.w3.org/XML/1998/namespace"
 	xmpBasicNamespace                    = "http://ns.adobe.com/xap/1.0/"
@@ -43,7 +49,7 @@ var (
 	// SourceMetadataExtractorFingerprint is the stable identity of the local
 	// parser bundle. Any semantic parser change must change the descriptor.
 	SourceMetadataExtractorFingerprint = fingerprintSourceMetadataExtractor(
-		"docbank-source-metadata:pdfcpu-info+xmp+pages,ooxml-core+custom,rfc5322,ical,visual-container+jpeg-tiff-exif,media-id3:v11")
+		"docbank-source-metadata:pdfcpu-info+xmp+pages,ooxml-core+custom,rfc5322,ical,visual-container+jpeg-tiff-raf-exif,media-id3:v12")
 
 	// errSourceMetadataMP4Malformed marks deterministic MP4 structure defects
 	// in verified bytes, which become durable warnings rather than retryable
@@ -200,11 +206,13 @@ func (r *seekReaderAt) ReadAt(target []byte, offset int64) (int, error) {
 }
 
 func extractLargeSourceMetadata(reader io.ReaderAt, size int64) (document.SourceMetadataV1, error) {
-	header, err := readSourceMetadataRange(reader, 0, min(size, 12))
+	header, err := readSourceMetadataRange(reader, 0, min(size, sourceMetadataRAFHeaderBytes))
 	if err != nil {
 		return document.SourceMetadataV1{}, fmt.Errorf("reading media signature: %w", err)
 	}
 	switch {
+	case isSourceMetadataRAF(header):
+		return extractRAFSourceMetadata(reader, size)
 	case bytes.HasPrefix(header, []byte{0xff, 0xd8}), exifTIFFSignature(header):
 		window, readErr := readSourceMetadataRange(reader, 0, min(size, maxSourceMetadataWindowBytes))
 		if readErr != nil {
@@ -236,8 +244,122 @@ func extractLargeSourceMetadata(reader io.ReaderAt, size int64) (document.Source
 }
 
 func boundedLargeMediaSignature(data []byte) bool {
-	return bytes.HasPrefix(data, []byte{0xff, 0xd8}) || exifTIFFSignature(data) ||
+	return isSourceMetadataRAF(data) || bytes.HasPrefix(data, []byte{0xff, 0xd8}) || exifTIFFSignature(data) ||
 		len(data) >= 12 && string(data[4:8]) == "ftyp"
+}
+
+func isSourceMetadataRAF(data []byte) bool {
+	return bytes.HasPrefix(data, []byte(sourceMetadataRAFSignature))
+}
+
+func extractRAFSourceMetadata(reader io.ReaderAt, size int64) (document.SourceMetadataV1, error) {
+	metadata := emptySourceMetadata()
+	collector := metadataCollector{record: &metadata, seen: map[string]bool{}}
+	collector.string("media.container.format", "media.container", "Format", "raf", false)
+	collector.string("media.container.kind", "media.container", "Kind", "image", false)
+
+	header, err := readSourceMetadataRange(reader, 0, min(size, sourceMetadataRAFHeaderBytes))
+	if err != nil {
+		return document.SourceMetadataV1{}, fmt.Errorf("reading RAF header: %w", err)
+	}
+	if len(header) < sourceMetadataRAFHeaderBytes || !isSourceMetadataRAF(header) {
+		collector.warn("unparseable_metadata", "media.container", "RAF", "RAF header is malformed")
+		return canonicalSourceMetadataResult(metadata), nil
+	}
+
+	jpegOffset := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFJPEGOffset:]))
+	jpegLength := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFJPEGOffset+4:]))
+	cfaOffset := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFCFAOffset:]))
+	if jpegOffset < sourceMetadataRAFHeaderBytes || cfaOffset < sourceMetadataRAFHeaderBytes ||
+		!sourceMetadataRangeWithin(jpegOffset, jpegLength, size) || cfaOffset > size-4 {
+		collector.warn("unparseable_metadata", "media.container", "RAF", "RAF metadata offsets are invalid")
+		return canonicalSourceMetadataResult(metadata), nil
+	}
+
+	jpegReadLength := min(jpegLength, maxSourceMetadataWindowBytes)
+	jpeg, err := readSourceMetadataRange(reader, jpegOffset, jpegReadLength)
+	if err != nil {
+		return document.SourceMetadataV1{}, fmt.Errorf("reading RAF embedded JPEG: %w", err)
+	}
+	if !bytes.HasPrefix(jpeg, []byte{0xff, 0xd8}) {
+		collector.warn("unparseable_metadata", "media.container", "RAF", "RAF embedded JPEG is malformed")
+	} else {
+		collector.extractJPEGExif(jpeg)
+	}
+	if jpegReadLength < jpegLength {
+		collector.warn("metadata_window_limited", "media.container", "JPEG",
+			"only the bounded RAF JPEG metadata window was inspected")
+	}
+
+	limited, err := collector.extractRAFDimensions(reader, cfaOffset, size)
+	if err != nil {
+		return document.SourceMetadataV1{}, err
+	}
+	if limited {
+		collector.warn("metadata_window_limited", "media.container", "CFA",
+			"only the bounded RAF raw-metadata directory was inspected")
+	}
+	return canonicalSourceMetadataResult(metadata), nil
+}
+
+func sourceMetadataRangeWithin(offset, length, size int64) bool {
+	return offset >= 0 && length > 0 && offset <= size && length <= size-offset
+}
+
+func (c *metadataCollector) extractRAFDimensions(reader io.ReaderAt, offset, sourceSize int64) (bool, error) {
+	header, err := readSourceMetadataRange(reader, offset, 4)
+	if err != nil {
+		return false, fmt.Errorf("reading RAF raw-metadata directory: %w", err)
+	}
+	entryCount := int64(binary.BigEndian.Uint32(header))
+	position := offset + 4
+	limit := min(sourceSize, offset+maxSourceMetadataRAFDirectoryBytes)
+	for range entryCount {
+		if position > sourceSize-4 {
+			c.warn("unparseable_metadata", "media.container", "CFA", "RAF raw-metadata directory is malformed")
+			return false, nil
+		}
+		if position > limit-4 {
+			return true, nil
+		}
+		entryHeader, readErr := readSourceMetadataRange(reader, position, 4)
+		if readErr != nil {
+			return false, fmt.Errorf("reading RAF raw-metadata entry: %w", readErr)
+		}
+		tag := binary.BigEndian.Uint16(entryHeader)
+		length := int64(binary.BigEndian.Uint16(entryHeader[2:]))
+		position += 4
+		if length > sourceSize-position {
+			c.warn("unparseable_metadata", "media.container", "CFA", "RAF raw-metadata entry is malformed")
+			return false, nil
+		}
+		if tag == sourceMetadataRAFImageSizeTag {
+			if length < 4 {
+				c.warn("unparseable_metadata", "media.container", "CFA", "RAF image-size entry is malformed")
+				return false, nil
+			}
+			if position > limit-4 {
+				return true, nil
+			}
+			dimensions, readErr := readSourceMetadataRange(reader, position, 4)
+			if readErr != nil {
+				return false, fmt.Errorf("reading RAF image dimensions: %w", readErr)
+			}
+			height := int64(binary.BigEndian.Uint16(dimensions))
+			width := int64(binary.BigEndian.Uint16(dimensions[2:]))
+			if width > 0 && height > 0 {
+				c.integer("media.container.width_px", "media.container", "RAFImageWidth", width)
+				c.integer("media.container.height_px", "media.container", "RAFImageLength", height)
+			}
+			return false, nil
+		}
+		if position > math.MaxInt64-length {
+			c.warn("unparseable_metadata", "media.container", "CFA", "RAF raw-metadata offsets overflow")
+			return false, nil
+		}
+		position += length
+	}
+	return false, nil
 }
 
 func readSourceMetadataRange(reader io.ReaderAt, offset, length int64) ([]byte, error) {
@@ -394,6 +516,14 @@ func ExtractSourceMetadata(data []byte) document.SourceMetadataV1 {
 		collector.extractCalendar(data)
 	case bytes.HasPrefix(data, []byte("ID3")):
 		collector.extractID3(data)
+	case isSourceMetadataRAF(data):
+		metadata, err := extractRAFSourceMetadata(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			result.Warnings = append(result.Warnings, sourceWarning(
+				"unparseable_metadata", "media.container", "RAF", "RAF metadata could not be read"))
+			return canonicalSourceMetadataResult(result)
+		}
+		return metadata
 	case visualContainerSignature(data):
 		collector.extractVisual(data)
 	case exifTIFFSignature(data):

--- a/internal/processing/source_metadata.go
+++ b/internal/processing/source_metadata.go
@@ -35,7 +35,8 @@ const (
 	maxSourceMetadataXMLDepth            = 64
 	sourceMetadataRAFHeaderBytes         = 160
 	sourceMetadataRAFJPEGOffset          = 84
-	sourceMetadataRAFCFAOffset           = 92
+	sourceMetadataRAFDirectoryOffset     = 92
+	sourceMetadataRAFDirectoryLength     = 96
 	sourceMetadataRAFImageSizeTag        = 0x0111
 	sourceMetadataRAFSignature           = "FUJIFILMCCD-RAW"
 	rdfNamespace                         = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -269,9 +270,12 @@ func extractRAFSourceMetadata(reader io.ReaderAt, size int64) (document.SourceMe
 
 	jpegOffset := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFJPEGOffset:]))
 	jpegLength := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFJPEGOffset+4:]))
-	cfaOffset := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFCFAOffset:]))
-	if jpegOffset < sourceMetadataRAFHeaderBytes || cfaOffset < sourceMetadataRAFHeaderBytes ||
-		!sourceMetadataRangeWithin(jpegOffset, jpegLength, size) || cfaOffset > size-4 {
+	directoryOffset := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFDirectoryOffset:]))
+	directoryLength := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFDirectoryLength:]))
+	if jpegOffset < sourceMetadataRAFHeaderBytes || directoryOffset < sourceMetadataRAFHeaderBytes ||
+		!sourceMetadataRangeWithin(jpegOffset, jpegLength, size) ||
+		!sourceMetadataRangeWithin(directoryOffset, directoryLength, size) ||
+		sourceMetadataRangesOverlap(jpegOffset, jpegLength, directoryOffset, directoryLength) {
 		collector.warn("unparseable_metadata", "media.container", "RAF", "RAF metadata offsets are invalid")
 		return canonicalSourceMetadataResult(metadata), nil
 	}
@@ -291,7 +295,7 @@ func extractRAFSourceMetadata(reader io.ReaderAt, size int64) (document.SourceMe
 			"only the bounded RAF JPEG metadata window was inspected")
 	}
 
-	limited, err := collector.extractRAFDimensions(reader, cfaOffset, size)
+	limited, err := collector.extractRAFDimensions(reader, directoryOffset, directoryLength)
 	if err != nil {
 		return document.SourceMetadataV1{}, err
 	}
@@ -306,16 +310,25 @@ func sourceMetadataRangeWithin(offset, length, size int64) bool {
 	return offset >= 0 && length > 0 && offset <= size && length <= size-offset
 }
 
-func (c *metadataCollector) extractRAFDimensions(reader io.ReaderAt, offset, sourceSize int64) (bool, error) {
+func sourceMetadataRangesOverlap(leftOffset, leftLength, rightOffset, rightLength int64) bool {
+	return leftOffset < rightOffset+rightLength && rightOffset < leftOffset+leftLength
+}
+
+func (c *metadataCollector) extractRAFDimensions(reader io.ReaderAt, offset, length int64) (bool, error) {
+	if length < 4 {
+		c.warn("unparseable_metadata", "media.container", "CFA", "RAF raw-metadata directory is malformed")
+		return false, nil
+	}
 	header, err := readSourceMetadataRange(reader, offset, 4)
 	if err != nil {
 		return false, fmt.Errorf("reading RAF raw-metadata directory: %w", err)
 	}
 	entryCount := int64(binary.BigEndian.Uint32(header))
 	position := offset + 4
-	limit := min(sourceSize, offset+maxSourceMetadataRAFDirectoryBytes)
+	directoryEnd := offset + length
+	limit := min(directoryEnd, offset+maxSourceMetadataRAFDirectoryBytes)
 	for range entryCount {
-		if position > sourceSize-4 {
+		if position > directoryEnd-4 {
 			c.warn("unparseable_metadata", "media.container", "CFA", "RAF raw-metadata directory is malformed")
 			return false, nil
 		}
@@ -329,7 +342,7 @@ func (c *metadataCollector) extractRAFDimensions(reader io.ReaderAt, offset, sou
 		tag := binary.BigEndian.Uint16(entryHeader)
 		length := int64(binary.BigEndian.Uint16(entryHeader[2:]))
 		position += 4
-		if length > sourceSize-position {
+		if length > directoryEnd-position {
 			c.warn("unparseable_metadata", "media.container", "CFA", "RAF raw-metadata entry is malformed")
 			return false, nil
 		}

--- a/internal/processing/source_metadata_test.go
+++ b/internal/processing/source_metadata_test.go
@@ -186,6 +186,41 @@ func TestExtractSourceMetadataReadsRawTIFFVariants(t *testing.T) {
 	}
 }
 
+func TestExtractSourceMetadataReadsRAFPhotoFacts(t *testing.T) {
+	metadata := ExtractSourceMetadata(syntheticRAF())
+	for key, want := range map[string]string{
+		"media.container.format":  "raf",
+		"media.container.kind":    "image",
+		"image.exif.camera_make":  "Fiction Camera Co.",
+		"image.exif.camera_model": "Model One",
+	} {
+		value, found := sourceMetadataString(metadata, key)
+		require.True(t, found, key)
+		assert.Equal(t, want, value, key)
+	}
+	for key, want := range map[string]int64{
+		"media.container.width_px":  6240,
+		"media.container.height_px": 4160,
+		"image.exif.iso":            800,
+	} {
+		value, found := sourceMetadataInteger(metadata, key)
+		require.True(t, found, key)
+		assert.Equal(t, want, value, key)
+	}
+	assert.Empty(t, metadata.Warnings)
+}
+
+func TestExtractSourceMetadataWarnsForMalformedRAFOffsets(t *testing.T) {
+	payload := syntheticRAF()
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFCFAOffset:], uint32(len(payload)+1))
+
+	metadata := ExtractSourceMetadata(payload)
+	assert.Contains(t, sourceMetadataWarningCodes(metadata), "unparseable_metadata")
+	format, found := sourceMetadataString(metadata, "media.container.format")
+	require.True(t, found)
+	assert.Equal(t, "raf", format)
+}
+
 func TestExtractSourceMetadataReadsOOXMLAppProperties(t *testing.T) {
 	metadata := ExtractSourceMetadata(syntheticOOXML(t))
 	pages, found := sourceMetadataInteger(metadata, "page_count")
@@ -576,6 +611,37 @@ func syntheticExifJPEG() []byte {
 	return append(result, jpeg[2:]...)
 }
 
+func syntheticRAF() []byte {
+	tiff := syntheticRichExifTIFF()
+	segment := append([]byte("Exif\x00\x00"), tiff...)
+	app1 := []byte{0xff, 0xe1, 0, 0}
+	binary.BigEndian.PutUint16(app1[2:4], uint16(len(segment)+2))
+	baseJPEG := mediatest.JPEG(40, 30, color.Black)
+	jpeg := append([]byte{}, baseJPEG[:2]...)
+	jpeg = append(jpeg, app1...)
+	jpeg = append(jpeg, segment...)
+	jpeg = append(jpeg, baseJPEG[2:]...)
+
+	cfa := make([]byte, 12)
+	binary.BigEndian.PutUint32(cfa[:4], 1)
+	binary.BigEndian.PutUint16(cfa[4:6], sourceMetadataRAFImageSizeTag)
+	binary.BigEndian.PutUint16(cfa[6:8], 4)
+	binary.BigEndian.PutUint16(cfa[8:10], 4160)
+	binary.BigEndian.PutUint16(cfa[10:12], 6240)
+
+	jpegOffset := sourceMetadataRAFHeaderBytes
+	cfaOffset := jpegOffset + len(jpeg)
+	payload := make([]byte, cfaOffset+len(cfa))
+	copy(payload, sourceMetadataRAFSignature)
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFJPEGOffset:], uint32(jpegOffset))
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFJPEGOffset+4:], uint32(len(jpeg)))
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFCFAOffset:], uint32(cfaOffset))
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFCFAOffset+4:], uint32(len(cfa)))
+	copy(payload[jpegOffset:], jpeg)
+	copy(payload[cfaOffset:], cfa)
+	return payload
+}
+
 type syntheticTIFFEntry struct {
 	tag   uint16
 	kind  uint16
@@ -826,6 +892,31 @@ func TestLargeMP4SourceMetadataMalformedBoxWarnsInsteadOfRetrying(t *testing.T) 
 	assert.Empty(t, metadata.Fields)
 }
 
+func TestLargeRAFSourceMetadataUsesBoundedContainerReads(t *testing.T) {
+	reader := syntheticSparseLargeRAF()
+	hasher := sha256.New()
+	_, err := io.Copy(hasher, reader.clone())
+	require.NoError(t, err)
+	blobs := &largeSourceMetadataReaderStub{reader: reader}
+
+	metadata, err := sourceMetadataForTarget(t.Context(), blobs, store.SourceMetadataTarget{
+		SourceSHA256: hex.EncodeToString(hasher.Sum(nil)), Size: reader.size,
+	})
+	require.NoError(t, err)
+	assert.Zero(t, blobs.streamCalls)
+	assert.Equal(t, 1, blobs.seekCalls)
+	format, found := sourceMetadataString(metadata, "media.container.format")
+	require.True(t, found)
+	assert.Equal(t, "raf", format)
+	width, found := sourceMetadataInteger(metadata, "media.container.width_px")
+	require.True(t, found)
+	assert.Equal(t, int64(6240), width)
+	model, found := sourceMetadataString(metadata, "image.exif.camera_model")
+	require.True(t, found)
+	assert.Equal(t, "Model One", model)
+	assert.NotContains(t, sourceMetadataWarningCodes(metadata), "input_too_large")
+}
+
 type sourceMetadataCatalogStub struct {
 	targets   []store.SourceMetadataTarget
 	published int
@@ -909,6 +1000,16 @@ func syntheticSparseLargeMP4() *sparseSourceMetadataReader {
 			{offset: 0, data: ftyp},
 			{offset: int64(len(ftyp)), data: mdatHeader},
 			{offset: moovOffset, data: moov},
+		},
+	}
+}
+
+func syntheticSparseLargeRAF() *sparseSourceMetadataReader {
+	payload := syntheticRAF()
+	return &sparseSourceMetadataReader{
+		size: maxSourceMetadataOriginalBytes + 1024,
+		segments: []sparseSourceMetadataSegment{
+			{offset: 0, data: payload},
 		},
 	}
 }

--- a/internal/processing/source_metadata_test.go
+++ b/internal/processing/source_metadata_test.go
@@ -212,13 +212,38 @@ func TestExtractSourceMetadataReadsRAFPhotoFacts(t *testing.T) {
 
 func TestExtractSourceMetadataWarnsForMalformedRAFOffsets(t *testing.T) {
 	payload := syntheticRAF()
-	binary.BigEndian.PutUint32(payload[sourceMetadataRAFCFAOffset:], uint32(len(payload)+1))
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFDirectoryOffset:], uint32(len(payload)+1))
 
 	metadata := ExtractSourceMetadata(payload)
 	assert.Contains(t, sourceMetadataWarningCodes(metadata), "unparseable_metadata")
 	format, found := sourceMetadataString(metadata, "media.container.format")
 	require.True(t, found)
 	assert.Equal(t, "raf", format)
+}
+
+func TestExtractSourceMetadataKeepsRAFDirectoryInsideDeclaredBounds(t *testing.T) {
+	payload := syntheticRAF()
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFDirectoryLength:], 4)
+
+	metadata := ExtractSourceMetadata(payload)
+	assert.Contains(t, sourceMetadataWarningCodes(metadata), "unparseable_metadata")
+	_, found := sourceMetadataInteger(metadata, "media.container.width_px")
+	assert.False(t, found)
+}
+
+func TestExtractSourceMetadataRejectsOverlappingRAFMetadataRegions(t *testing.T) {
+	payload := syntheticRAF()
+	jpegOffset := int(binary.BigEndian.Uint32(payload[sourceMetadataRAFJPEGOffset:]))
+	directoryOffset := jpegOffset + 2
+	directory := append([]byte(nil), payload[len(payload)-12:]...)
+	copy(payload[directoryOffset:], directory)
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFDirectoryOffset:], uint32(directoryOffset))
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFDirectoryLength:], uint32(len(directory)))
+
+	metadata := ExtractSourceMetadata(payload)
+	assert.Contains(t, sourceMetadataWarningCodes(metadata), "unparseable_metadata")
+	_, found := sourceMetadataInteger(metadata, "media.container.width_px")
+	assert.False(t, found)
 }
 
 func TestExtractSourceMetadataReadsOOXMLAppProperties(t *testing.T) {
@@ -635,8 +660,8 @@ func syntheticRAF() []byte {
 	copy(payload, sourceMetadataRAFSignature)
 	binary.BigEndian.PutUint32(payload[sourceMetadataRAFJPEGOffset:], uint32(jpegOffset))
 	binary.BigEndian.PutUint32(payload[sourceMetadataRAFJPEGOffset+4:], uint32(len(jpeg)))
-	binary.BigEndian.PutUint32(payload[sourceMetadataRAFCFAOffset:], uint32(cfaOffset))
-	binary.BigEndian.PutUint32(payload[sourceMetadataRAFCFAOffset+4:], uint32(len(cfa)))
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFDirectoryOffset:], uint32(cfaOffset))
+	binary.BigEndian.PutUint32(payload[sourceMetadataRAFDirectoryLength:], uint32(len(cfa)))
 	copy(payload[jpegOffset:], jpeg)
 	copy(payload[cfaOffset:], cfa)
 	return payload

--- a/internal/processing/source_metadata_test.go
+++ b/internal/processing/source_metadata_test.go
@@ -919,17 +919,10 @@ func TestLargeMP4SourceMetadataMalformedBoxWarnsInsteadOfRetrying(t *testing.T) 
 
 func TestLargeRAFSourceMetadataUsesBoundedContainerReads(t *testing.T) {
 	reader := syntheticSparseLargeRAF()
-	hasher := sha256.New()
-	_, err := io.Copy(hasher, reader.clone())
-	require.NoError(t, err)
-	blobs := &largeSourceMetadataReaderStub{reader: reader}
+	require.Greater(t, reader.size, int64(maxSourceMetadataOriginalBytes))
 
-	metadata, err := sourceMetadataForTarget(t.Context(), blobs, store.SourceMetadataTarget{
-		SourceSHA256: hex.EncodeToString(hasher.Sum(nil)), Size: reader.size,
-	})
+	metadata, err := extractLargeSourceMetadata(reader, reader.size)
 	require.NoError(t, err)
-	assert.Zero(t, blobs.streamCalls)
-	assert.Equal(t, 1, blobs.seekCalls)
 	format, found := sourceMetadataString(metadata, "media.container.format")
 	require.True(t, found)
 	assert.Equal(t, "raf", format)


### PR DESCRIPTION
Docbank can now read camera, lens, exposure, capture-time, and GPS facts from Fujifilm RAF originals. It also records the original RAW image dimensions instead of reporting the embedded preview size.

RAF uses a container structure rather than the TIFF-style header used by many other camera RAW formats. Docbank reads EXIF from the container's embedded JPEG and dimensions from its raw-metadata directory. Large RAF files remain bounded: Docbank verifies the complete original, then reads only the fixed header and bounded metadata regions.

Malformed verified containers produce durable warnings. Storage read failures remain retryable. Canon CR3 remains outside this change because it uses a different media-container structure.
