### PR TITLE
Add durable visual preview storage and reads

### DIFF
--- a/cmd/docbank/versions.go
+++ b/cmd/docbank/versions.go
@@ -201,7 +201,7 @@ var versionsPruneCmd = &cobra.Command{
 
 func writeVersionPruneReport(cmd *cobra.Command, report api.VersionPruneReport) {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-		"%d version(s) selected, %d logical byte(s), %d unique blob(s)\n",
+		"%d version(s) selected, %d logical byte(s), %d unique affected blob(s)\n",
 		len(report.Candidates), report.LogicalBytes, report.UniqueBlobs)
 	if report.Cutoff != "" {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "age cutoff: %s\n", report.Cutoff)

--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -1,0 +1,60 @@
+---
+title: Visual Previews
+description: How Docbank identifies and retains canonical visual derivatives.
+---
+
+# Visual previews
+
+Docbank has a separate catalog for visual previews of images, camera RAW files,
+and video. A preview is a retained derivative of one immutable content version.
+It does not replace the original and does not change document identity.
+
+The catalog is deliberately separate from document renditions. Document
+renditions describe normalized evidence, text, and provider artifacts. A visual
+preview is a single display-oriented image that another application can resize
+for grids, detail views, or search results without decoding the original again.
+
+## Recipe identity
+
+Every preview records the complete recipe that can affect its bytes:
+
+- the maximum output edge;
+- output image format;
+- orientation, color, and frame-selection policy; and
+- a processor fingerprint covering the decoder, scaler, color conversion, and
+  encoder implementations.
+
+The canonical recipe bytes produce a stable fingerprint. Changing any of these
+choices creates a new immutable generation instead of rewriting an earlier
+result.
+
+## Durable outcomes
+
+A generation has one of three terminal states:
+
+- `ready` records the output SHA-256, byte size, media type, and dimensions;
+- `unsupported` records that the recipe does not support the source format; or
+- `failed` records a deterministic source or decoding failure.
+
+Temporary read, storage, and cancellation failures are not durable outcomes.
+They remain retryable and must not be mistaken for evidence about the source.
+
+The active head belongs to an exact content version. Deleting that version
+removes its preview generations. Content-addressed storage still deduplicates
+identical preview bytes across versions, and garbage collection retains an
+output while any generation references it.
+
+## Backup and embedded reads
+
+Preview generations, active heads, and ready output blobs are included in
+normal backups. Restore validates the canonical generation identity before it
+recreates the catalog.
+
+Embedded applications use `Vault.VisualPreview` to inspect the active result
+and `Vault.OpenVisualPreview` to stream a ready output through the verified
+reader contract. Unsupported and failed results remain queryable but do not
+open as content.
+
+Docbank does not yet produce previews automatically. The catalog and read
+boundary are in place so format-specific producers can be added without
+changing preview identity, retention, backup, or application integration.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -149,6 +149,34 @@ workers. The embedded API returns all local fields, including fields marked
 sensitive. The embedding application must decide what it may disclose to its
 own users and transports.
 
+## Read canonical visual previews
+
+`VisualPreview` returns the active result for one immutable content version.
+Ready results identify exact preview bytes and dimensions; unsupported and
+failed results carry a stable failure code without pretending that content is
+available.
+
+```go
+preview, err := vault.VisualPreview(ctx, versionID)
+if err != nil {
+    return err
+}
+if preview.State == document.VisualPreviewReady {
+    content, err := vault.OpenVisualPreview(ctx, versionID)
+    if err != nil {
+        return err
+    }
+    defer content.Reader.Close()
+    // Reach EOF or call Verify before trusting the bytes.
+}
+```
+
+`OpenVisualPreview` uses the same verified-reader contract as original
+content. It returns `ErrVisualPreviewUnavailable` for a cataloged unsupported
+or failed result and `ErrNotFound` when no preview result exists. Opening an
+embedded vault does not start a preview producer; applications can read results
+after a processing owner has published them.
+
 Both write receipts include `Physical`, which distinguishes logical bytes from
 their current raw, zstd, or packed representation. Most applications should
 treat that field as operational evidence rather than document identity.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -45,6 +45,7 @@ Every documentation page is also published as raw Markdown at the same path with
 ## How It Works
 - [How Docbank Works](https://docbank.ai/architecture/overview.md): A guided model of vaults, document identity, immutable content, storage authority, deletion, and recovery.
 - [Source Metadata](https://docbank.ai/architecture/source-metadata.md): How Docbank records bounded facts found inside original files.
+- [Visual Previews](https://docbank.ai/architecture/visual-previews.md): How Docbank identifies and retains canonical visual derivatives.
 - [Storage](https://docbank.ai/architecture/storage.md): The SQLite schema, blob store layout, durability discipline, and enforced invariants.
 - [Loose & Packed Content](https://docbank.ai/architecture/packed-storage.md): The shared Kit packed-CAS layer and docbank's application-owned authority boundary.
 - [Editing & Versions](https://docbank.ai/architecture/editing-and-versions.md): Stable content-version identity, retrieval, replacement, reversion, and retention over immutable content.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -48,6 +48,7 @@ nav = [
   {"How It Works" = [
     {"How Docbank Works" = "architecture/overview.md"},
     {"Source Metadata" = "architecture/source-metadata.md"},
+    {"Visual Previews" = "architecture/visual-previews.md"},
     {"Storage" = "architecture/storage.md"},
     {"Loose & Packed Content" = "architecture/packed-storage.md"},
     {"Editing & Versions" = "architecture/editing-and-versions.md"},

--- a/document/visual_preview.go
+++ b/document/visual_preview.go
@@ -1,0 +1,61 @@
+package document
+
+const (
+	// VisualPreviewContractV1 identifies one canonical visual derivative of an
+	// exact retained source version.
+	VisualPreviewContractV1 = "visual-preview/v1"
+
+	MaxVisualPreviewEdgePixels  = 32768
+	MaxVisualPreviewFailureCode = 128
+	MaxVisualPreviewFailureText = 4096
+)
+
+// VisualPreviewState describes the durable outcome of one deterministic
+// preview recipe. Transient I/O and storage failures are not cataloged.
+type VisualPreviewState string
+
+const (
+	VisualPreviewReady       VisualPreviewState = "ready"
+	VisualPreviewUnsupported VisualPreviewState = "unsupported"
+	VisualPreviewFailed      VisualPreviewState = "failed"
+)
+
+// VisualPreviewRecipeV1 is the complete identity of preview-producing
+// behavior. ProcessorFingerprint covers decoder, frame-selection, scaling,
+// color, and encoder implementations that can affect the exact output bytes.
+type VisualPreviewRecipeV1 struct {
+	ColorPolicy          string `json:"color_policy"`
+	ContractVersion      string `json:"contract_version"`
+	FramePolicy          string `json:"frame_policy"`
+	MaxEdgePixels        int    `json:"max_edge_pixels"`
+	OrientationPolicy    string `json:"orientation_policy"`
+	OutputMediaType      string `json:"output_media_type"`
+	ProcessorFingerprint string `json:"processor_fingerprint"`
+}
+
+// VisualPreviewOutputV1 identifies the exact retained preview bytes.
+type VisualPreviewOutputV1 struct {
+	BlobSHA256 string `json:"blob_sha256"`
+	Height     int    `json:"height"`
+	MediaType  string `json:"media_type"`
+	Size       int64  `json:"size"`
+	Width      int    `json:"width"`
+}
+
+// VisualPreviewFailureV1 is a deterministic terminal result. Detail is for
+// operators; Code is the stable machine-readable classification.
+type VisualPreviewFailureV1 struct {
+	Code   string `json:"code"`
+	Detail string `json:"detail"`
+}
+
+// VisualPreviewV1 is the canonical result for one exact source and recipe.
+// Exactly one of Output and Failure is populated according to State.
+type VisualPreviewV1 struct {
+	ContractVersion string                  `json:"contract_version"`
+	Failure         *VisualPreviewFailureV1 `json:"failure,omitempty"`
+	Output          *VisualPreviewOutputV1  `json:"output,omitempty"`
+	Recipe          VisualPreviewRecipeV1   `json:"recipe"`
+	SourceSHA256    string                  `json:"source_sha256"`
+	State           VisualPreviewState      `json:"state"`
+}

--- a/document/visual_preview_codec.go
+++ b/document/visual_preview_codec.go
@@ -1,0 +1,170 @@
+package document
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+var visualPreviewFailureCodePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// MarshalVisualPreviewRecipeV1 validates and fingerprints one recipe.
+func MarshalVisualPreviewRecipeV1(value VisualPreviewRecipeV1) ([]byte, string, error) {
+	canonical, err := canonicalVisualPreviewRecipeV1(value)
+	if err != nil {
+		return nil, "", err
+	}
+	encoded, err := json.Marshal(canonical, json.Deterministic(true))
+	if err != nil {
+		return nil, "", fmt.Errorf("encoding visual preview recipe: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return encoded, hex.EncodeToString(digest[:]), nil
+}
+
+// DecodeVisualPreviewRecipeV1 accepts only the exact canonical v1 encoding.
+func DecodeVisualPreviewRecipeV1(encoded []byte) (VisualPreviewRecipeV1, string, error) {
+	var value VisualPreviewRecipeV1
+	if err := json.Unmarshal(encoded, &value, json.RejectUnknownMembers(true)); err != nil {
+		return VisualPreviewRecipeV1{}, "", fmt.Errorf("decoding visual preview recipe: %w", err)
+	}
+	canonical, fingerprint, err := MarshalVisualPreviewRecipeV1(value)
+	if err != nil {
+		return VisualPreviewRecipeV1{}, "", err
+	}
+	if !slices.Equal(encoded, canonical) {
+		return VisualPreviewRecipeV1{}, "", errors.New("visual preview recipe bytes are not canonical")
+	}
+	return value, fingerprint, nil
+}
+
+// MarshalVisualPreviewV1 validates, canonicalizes, and hashes one result.
+func MarshalVisualPreviewV1(value VisualPreviewV1) ([]byte, string, error) {
+	canonical, err := canonicalVisualPreviewV1(value)
+	if err != nil {
+		return nil, "", err
+	}
+	encoded, err := json.Marshal(canonical, json.Deterministic(true))
+	if err != nil {
+		return nil, "", fmt.Errorf("encoding visual preview: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return encoded, hex.EncodeToString(digest[:]), nil
+}
+
+// DecodeVisualPreviewV1 accepts only the exact canonical v1 encoding.
+func DecodeVisualPreviewV1(encoded []byte) (VisualPreviewV1, string, error) {
+	var value VisualPreviewV1
+	if err := json.Unmarshal(encoded, &value, json.RejectUnknownMembers(true)); err != nil {
+		return VisualPreviewV1{}, "", fmt.Errorf("decoding visual preview: %w", err)
+	}
+	canonical, checksum, err := MarshalVisualPreviewV1(value)
+	if err != nil {
+		return VisualPreviewV1{}, "", err
+	}
+	if !slices.Equal(encoded, canonical) {
+		return VisualPreviewV1{}, "", errors.New("visual preview bytes are not canonical")
+	}
+	return value, checksum, nil
+}
+
+func canonicalVisualPreviewRecipeV1(value VisualPreviewRecipeV1) (VisualPreviewRecipeV1, error) {
+	if value.ContractVersion != VisualPreviewContractV1 {
+		return VisualPreviewRecipeV1{}, fmt.Errorf(
+			"visual preview recipe contract version must be %q", VisualPreviewContractV1)
+	}
+	if value.MaxEdgePixels < 1 || value.MaxEdgePixels > MaxVisualPreviewEdgePixels {
+		return VisualPreviewRecipeV1{}, fmt.Errorf(
+			"visual preview maximum edge must be between 1 and %d pixels", MaxVisualPreviewEdgePixels)
+	}
+	if value.OrientationPolicy != "apply" {
+		return VisualPreviewRecipeV1{}, errors.New("visual preview orientation policy must be apply")
+	}
+	if value.ColorPolicy != "srgb" {
+		return VisualPreviewRecipeV1{}, errors.New("visual preview color policy must be srgb")
+	}
+	if value.FramePolicy != "primary" && value.FramePolicy != "representative" {
+		return VisualPreviewRecipeV1{}, errors.New(
+			"visual preview frame policy must be primary or representative")
+	}
+	switch value.OutputMediaType {
+	case "image/jpeg", "image/png", "image/webp":
+	default:
+		return VisualPreviewRecipeV1{}, errors.New("visual preview output media type is unsupported")
+	}
+	if !canonicalSHA256(value.ProcessorFingerprint) {
+		return VisualPreviewRecipeV1{}, errors.New("visual preview processor fingerprint is invalid")
+	}
+	return value, nil
+}
+
+func canonicalVisualPreviewV1(value VisualPreviewV1) (VisualPreviewV1, error) {
+	if value.ContractVersion != VisualPreviewContractV1 {
+		return VisualPreviewV1{}, fmt.Errorf(
+			"visual preview contract version must be %q", VisualPreviewContractV1)
+	}
+	recipe, err := canonicalVisualPreviewRecipeV1(value.Recipe)
+	if err != nil {
+		return VisualPreviewV1{}, err
+	}
+	value.Recipe = recipe
+	if !canonicalSHA256(value.SourceSHA256) {
+		return VisualPreviewV1{}, errors.New("visual preview source SHA-256 is invalid")
+	}
+	switch value.State {
+	case VisualPreviewReady:
+		if value.Output == nil || value.Failure != nil {
+			return VisualPreviewV1{}, errors.New("ready visual preview requires output and no failure")
+		}
+		output := *value.Output
+		value.Output = &output
+		if !canonicalSHA256(value.Output.BlobSHA256) {
+			return VisualPreviewV1{}, errors.New("visual preview output SHA-256 is invalid")
+		}
+		if value.Output.Size < 1 {
+			return VisualPreviewV1{}, errors.New("visual preview output size must be positive")
+		}
+		if value.Output.MediaType != recipe.OutputMediaType {
+			return VisualPreviewV1{}, errors.New("visual preview output media type does not match recipe")
+		}
+		if value.Output.Width < 1 || value.Output.Height < 1 ||
+			value.Output.Width > recipe.MaxEdgePixels || value.Output.Height > recipe.MaxEdgePixels {
+			return VisualPreviewV1{}, errors.New("visual preview dimensions exceed the recipe")
+		}
+	case VisualPreviewUnsupported, VisualPreviewFailed:
+		if value.Output != nil || value.Failure == nil {
+			return VisualPreviewV1{}, errors.New("terminal visual preview requires failure and no output")
+		}
+		failure := *value.Failure
+		value.Failure = &failure
+		value.Failure.Code = strings.TrimSpace(value.Failure.Code)
+		value.Failure.Detail = norm.NFC.String(strings.TrimSpace(value.Failure.Detail))
+		if len(value.Failure.Code) > MaxVisualPreviewFailureCode ||
+			!visualPreviewFailureCodePattern.MatchString(value.Failure.Code) {
+			return VisualPreviewV1{}, errors.New("visual preview failure code is invalid")
+		}
+		if value.Failure.Detail == "" || len(value.Failure.Detail) > MaxVisualPreviewFailureText ||
+			!utf8.ValidString(value.Failure.Detail) {
+			return VisualPreviewV1{}, errors.New("visual preview failure detail is invalid")
+		}
+	default:
+		return VisualPreviewV1{}, errors.New("visual preview state is invalid")
+	}
+	return value, nil
+}
+
+func canonicalSHA256(value string) bool {
+	if len(value) != sha256.Size*2 || strings.ToLower(value) != value {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size
+}

--- a/document/visual_preview_test.go
+++ b/document/visual_preview_test.go
@@ -1,0 +1,77 @@
+package document
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVisualPreviewV1CanonicalRoundTrip(t *testing.T) {
+	recipe := testVisualPreviewRecipe()
+	value := VisualPreviewV1{
+		ContractVersion: VisualPreviewContractV1, SourceSHA256: visualPreviewTestHash("11"),
+		Recipe: recipe, State: VisualPreviewReady,
+		Output: &VisualPreviewOutputV1{BlobSHA256: visualPreviewTestHash("22"),
+			Size: 123, MediaType: "image/jpeg", Width: 1600, Height: 900},
+	}
+	encoded, checksum, err := MarshalVisualPreviewV1(value)
+	require.NoError(t, err)
+	decoded, decodedChecksum, err := DecodeVisualPreviewV1(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, value, decoded)
+	assert.Equal(t, checksum, decodedChecksum)
+
+	recipeBytes, fingerprint, err := MarshalVisualPreviewRecipeV1(recipe)
+	require.NoError(t, err)
+	decodedRecipe, decodedFingerprint, err := DecodeVisualPreviewRecipeV1(recipeBytes)
+	require.NoError(t, err)
+	assert.Equal(t, recipe, decodedRecipe)
+	assert.Equal(t, fingerprint, decodedFingerprint)
+}
+
+func TestVisualPreviewV1RejectsInconsistentOutcomes(t *testing.T) {
+	base := VisualPreviewV1{ContractVersion: VisualPreviewContractV1,
+		SourceSHA256: visualPreviewTestHash("11"), Recipe: testVisualPreviewRecipe()}
+	tests := []struct {
+		name  string
+		value VisualPreviewV1
+	}{
+		{name: "ready without output", value: func() VisualPreviewV1 {
+			v := base
+			v.State = VisualPreviewReady
+			return v
+		}()},
+		{name: "failure with output", value: func() VisualPreviewV1 {
+			v := base
+			v.State = VisualPreviewFailed
+			v.Output = &VisualPreviewOutputV1{BlobSHA256: visualPreviewTestHash("22"),
+				Size: 1, MediaType: "image/jpeg", Width: 1, Height: 1}
+			v.Failure = &VisualPreviewFailureV1{Code: "decode_failed", Detail: "bad bytes"}
+			return v
+		}()},
+		{name: "oversized dimensions", value: func() VisualPreviewV1 {
+			v := base
+			v.State = VisualPreviewReady
+			v.Output = &VisualPreviewOutputV1{BlobSHA256: visualPreviewTestHash("22"),
+				Size: 1, MediaType: "image/jpeg", Width: v.Recipe.MaxEdgePixels + 1, Height: 1}
+			return v
+		}()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := MarshalVisualPreviewV1(test.value)
+			require.Error(t, err)
+		})
+	}
+}
+
+func testVisualPreviewRecipe() VisualPreviewRecipeV1 {
+	return VisualPreviewRecipeV1{ContractVersion: VisualPreviewContractV1,
+		MaxEdgePixels: 2048, OutputMediaType: "image/jpeg", OrientationPolicy: "apply",
+		ColorPolicy: "srgb", FramePolicy: "primary",
+		ProcessorFingerprint: visualPreviewTestHash("33")}
+}
+
+func visualPreviewTestHash(suffix string) string { return strings.Repeat("0", 64-len(suffix)) + suffix }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -154,7 +154,8 @@ type VersionPruneRequest struct {
 }
 
 // VersionPruneReport distinguishes released logical history from physical
-// bytes that only a later GC/repack can reclaim.
+// bytes that only a later GC/repack can reclaim. Blob counts include visual
+// preview outputs owned by the selected content versions.
 type VersionPruneReport struct {
 	Node                         Node             `json:"node"`
 	Candidates                   []ContentVersion `json:"candidates"`

--- a/internal/backupapp/metadata.go
+++ b/internal/backupapp/metadata.go
@@ -105,6 +105,48 @@ func computeDerivativeAuthorityStats(ctx context.Context, q rowQuerier) (*Deriva
 	}
 
 	if err := func() error {
+		var present bool
+		if err := q.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master
+			WHERE type='table' AND name='visual_preview_generations')`).Scan(&present); err != nil {
+			return fmt.Errorf("detecting visual preview catalog: %w", err)
+		}
+		if !present {
+			return nil
+		}
+		rows, err := q.QueryContext(ctx, `
+			SELECT generation_id,output_blob_hash,output_size,checksum
+			FROM visual_preview_generations
+			WHERE state='ready'
+			ORDER BY generation_id`)
+		if err != nil {
+			return fmt.Errorf("listing visual previews: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var generationID, blobHash, checksum string
+			var size int64
+			if err := rows.Scan(&generationID, &blobHash, &size, &checksum); err != nil {
+				return fmt.Errorf("scanning visual preview: %w", err)
+			}
+			item := get("included", "visual_preview")
+			if err := addDerivativeClassBytes(&item.LogicalBytes, size); err != nil {
+				return fmt.Errorf("visual preview: %w", err)
+			}
+			item.Count++
+			item.blobs[blobHash] = struct{}{}
+			for _, field := range []string{generationID, blobHash, checksum, strconv.FormatInt(size, 10)} {
+				writeDerivativeClassField(item.checksum, field)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterating visual previews: %w", err)
+		}
+		return nil
+	}(); err != nil {
+		return nil, false, fmt.Errorf("backupapp: %w", err)
+	}
+
+	if err := func() error {
 		rows, err := q.QueryContext(ctx, `
 			SELECT build_id,segment_id,checksum,text
 			FROM rendition_lexical_segments
@@ -147,6 +189,7 @@ func computeDerivativeAuthorityStats(ctx context.Context, q rowQuerier) (*Deriva
 		string(document.EvidenceArtifactMarkdown),
 		string(document.EvidenceArtifactStructured),
 		string(document.EvidenceArtifactTranscript),
+		"visual_preview",
 		"lexical_projection",
 	}
 	result := &DerivativeAuthorityStats{

--- a/internal/backupapp/metadata_test.go
+++ b/internal/backupapp/metadata_test.go
@@ -23,6 +23,10 @@ func TestDerivativeAuthorityStatsAcceptEveryCatalogArtifactRole(t *testing.T) {
 		);
 		CREATE TABLE rendition_lexical_segments (
 			build_id TEXT, segment_id TEXT, checksum TEXT, text TEXT, segment_order INTEGER
+		);
+		CREATE TABLE visual_preview_generations (
+			generation_id TEXT, output_blob_hash TEXT, output_size INTEGER,
+			checksum TEXT, state TEXT
 		);`)
 	require.NoError(t, err)
 	roles := []string{
@@ -36,6 +40,10 @@ func TestDerivativeAuthorityStatsAcceptEveryCatalogArtifactRole(t *testing.T) {
 		) VALUES(?,?,?,?,?,?)`, role, "build", role, role+"-blob", index+1, role+"-checksum")
 		require.NoError(t, err)
 	}
+	_, err = db.Exec(`INSERT INTO visual_preview_generations(
+		generation_id,output_blob_hash,output_size,checksum,state
+	) VALUES('preview-generation','preview-blob',17,'preview-checksum','ready')`)
+	require.NoError(t, err)
 
 	stats, present, err := computeDerivativeAuthorityStats(t.Context(), db)
 	require.NoError(t, err)
@@ -45,5 +53,5 @@ func TestDerivativeAuthorityStatsAcceptEveryCatalogArtifactRole(t *testing.T) {
 	for index, class := range stats.Classes {
 		classes[index] = class.Class
 	}
-	assert.Equal(t, roles, classes)
+	assert.Equal(t, append(roles, "visual_preview"), classes)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -620,7 +620,7 @@ func validateVersionPruneVersions(report api.VersionPruneReport, nodeID int64, r
 			return err
 		}
 	}
-	if report.LogicalBytes != logicalBytes || report.UniqueBlobs != len(uniqueBlobs) {
+	if report.LogicalBytes != logicalBytes || report.UniqueBlobs < len(uniqueBlobs) {
 		return errors.New("version-prune receipt has inconsistent logical inventory")
 	}
 	if !run && report.CheckpointRequired && !checkpointPreviewIncludesCurrent {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1159,7 +1159,7 @@ func TestContentVersionPruneAllPriorCheckpointsCurrentRevert(t *testing.T) {
 	assert.Equal(t, receipt.Checkpoint.ID, versions.Items[0].ID)
 }
 
-func TestContentVersionPruneRejectsUnprovenReceipt(t *testing.T) {
+func TestContentVersionPruneValidatesReceipt(t *testing.T) {
 	const (
 		currentID = "11111111-1111-4111-8111-111111111111"
 		oldID     = "22222222-2222-4222-8222-222222222222"
@@ -1175,6 +1175,23 @@ func TestContentVersionPruneRejectsUnprovenReceipt(t *testing.T) {
 		LogicalBytes:       12, UniqueBlobs: 1, ReleasableBlobs: 1,
 		ReleasableBytes: 12, LooseBlobsPendingGC: 1, LooseBytesPendingGC: 12,
 	}
+	t.Run("visual preview outputs", func(t *testing.T) {
+		report := base
+		report.UniqueBlobs = 2
+		report.ReleasableBlobs = 2
+		report.ReleasableBytes = 20
+		report.LooseBlobsPendingGC = 2
+		report.LooseBytesPendingGC = 20
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("ETag", `"4"`)
+			_ = json.MarshalWrite(w, report)
+		}))
+		t.Cleanup(ts.Close)
+		_, err := client.New(ts.URL, "key").PruneContentVersions(
+			t.Context(), 7, 4, api.VersionPruneRequest{AllPrior: true},
+		)
+		require.NoError(t, err)
+	})
 	tests := map[string]func(*api.VersionPruneReport){
 		"node":     func(r *api.VersionPruneReport) { r.Node.ID++ },
 		"revision": func(r *api.VersionPruneReport) { r.Node.Revision++ },

--- a/internal/store/gc.go
+++ b/internal/store/gc.go
@@ -600,8 +600,9 @@ func (s *Store) PurgeDerivatives(
 			if err := tx.QueryRowContext(ctx, `SELECT
 				EXISTS(SELECT 1 FROM content_versions WHERE blob_hash=?) OR
 				EXISTS(SELECT 1 FROM rendition_artifacts WHERE blob_hash=?) OR
-				EXISTS(SELECT 1 FROM rendition_builds WHERE source_sha256=?)`,
-				hash, hash, hash).Scan(&reachable); err != nil {
+				EXISTS(SELECT 1 FROM rendition_builds WHERE source_sha256=?) OR
+				EXISTS(SELECT 1 FROM visual_preview_generations WHERE output_blob_hash=?)`,
+				hash, hash, hash, hash).Scan(&reachable); err != nil {
 				return fmt.Errorf("checking purged derivative blob %s reachability: %w", hash, err)
 			}
 			if !reachable {
@@ -614,7 +615,9 @@ func (s *Store) PurgeDerivatives(
 		if _, err := tx.ExecContext(ctx, `DELETE FROM derivative_blob_purge_pending
 			WHERE EXISTS (SELECT 1 FROM content_versions v WHERE v.blob_hash=derivative_blob_purge_pending.blob_hash)
 			   OR EXISTS (SELECT 1 FROM rendition_artifacts a WHERE a.blob_hash=derivative_blob_purge_pending.blob_hash)
-			   OR EXISTS (SELECT 1 FROM rendition_builds r WHERE r.source_sha256=derivative_blob_purge_pending.blob_hash)`); err != nil {
+			   OR EXISTS (SELECT 1 FROM rendition_builds r WHERE r.source_sha256=derivative_blob_purge_pending.blob_hash)
+			   OR EXISTS (SELECT 1 FROM visual_preview_generations p
+			             WHERE p.output_blob_hash=derivative_blob_purge_pending.blob_hash)`); err != nil {
 			return fmt.Errorf("reconciling derivative blob purge targets: %w", err)
 		}
 		if err := func() (retErr error) {
@@ -1212,19 +1215,21 @@ func scanBlobInfos(rows *sql.Rows, op string) ([]BlobInfo, error) {
 	return out, nil
 }
 
-// UnreachableBlobs lists blobs referenced by no original content version or
-// retained rendition artifact. Every current file head is itself a content
-// version, as are retained prior versions. These are the gc candidates. Callers that go
-// on to delete blob files must serialize against concurrent writers (the
-// daemon's maintenance gate does this): with writers running, a concurrent
-// ingest can dedup against a candidate's file between this query and the
-// deletion, leaving a live node pointing at a removed blob.
+// UnreachableBlobs lists blobs referenced by no original content version,
+// retained rendition artifact, or visual preview. Every current file head is
+// itself a content version, as are retained prior versions. These are the GC
+// candidates. Callers that go on to delete blob files must serialize against
+// concurrent writers (the daemon's maintenance gate does this). With writers
+// running, a concurrent ingest can dedup against a candidate's file between
+// this query and deletion, leaving a live node pointing at a removed blob.
 func (s *Store) UnreachableBlobs(ctx context.Context) ([]BlobInfo, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT b.hash, b.size FROM blobs b
 		WHERE NOT EXISTS (SELECT 1 FROM content_versions v WHERE v.blob_hash = b.hash)
 		  AND NOT EXISTS (SELECT 1 FROM rendition_builds r WHERE r.source_sha256 = b.hash)
 		  AND NOT EXISTS (SELECT 1 FROM rendition_artifacts a WHERE a.blob_hash = b.hash)
+		  AND NOT EXISTS (SELECT 1 FROM visual_preview_generations p
+		                  WHERE p.output_blob_hash = b.hash)
 		  AND NOT EXISTS (SELECT 1 FROM derivative_blob_purge_pending p
 		                  WHERE p.blob_hash = b.hash)
 		ORDER BY b.hash`)
@@ -1245,6 +1250,8 @@ func (s *Store) UnreachableDerivativePurgeBlobs(ctx context.Context) ([]BlobInfo
 		WHERE NOT EXISTS (SELECT 1 FROM content_versions v WHERE v.blob_hash = b.hash)
 		  AND NOT EXISTS (SELECT 1 FROM rendition_builds r WHERE r.source_sha256 = b.hash)
 		  AND NOT EXISTS (SELECT 1 FROM rendition_artifacts a WHERE a.blob_hash = b.hash)
+		  AND NOT EXISTS (SELECT 1 FROM visual_preview_generations p
+		                  WHERE p.output_blob_hash = b.hash)
 		ORDER BY b.hash`)
 	if err != nil {
 		return nil, fmt.Errorf("finding pending derivative purge blobs: %w", err)
@@ -1317,6 +1324,8 @@ const unreachableBlobsStartPageSQL = `
 	       NOT EXISTS (SELECT 1 FROM content_versions v WHERE v.blob_hash = p.hash)
 	       AND NOT EXISTS (SELECT 1 FROM rendition_builds r WHERE r.source_sha256 = p.hash)
 	       AND NOT EXISTS (SELECT 1 FROM rendition_artifacts a WHERE a.blob_hash = p.hash)
+	       AND NOT EXISTS (SELECT 1 FROM visual_preview_generations v
+	                       WHERE v.output_blob_hash = p.hash)
 	       AND NOT EXISTS (SELECT 1 FROM derivative_blob_purge_pending d
 	                       WHERE d.blob_hash = p.hash)
 	FROM raw_page p ORDER BY p.hash`
@@ -1335,6 +1344,8 @@ const unreachableBlobsResumePageSQL = `
 	       NOT EXISTS (SELECT 1 FROM content_versions v WHERE v.blob_hash = p.hash)
 	       AND NOT EXISTS (SELECT 1 FROM rendition_builds r WHERE r.source_sha256 = p.hash)
 	       AND NOT EXISTS (SELECT 1 FROM rendition_artifacts a WHERE a.blob_hash = p.hash)
+	       AND NOT EXISTS (SELECT 1 FROM visual_preview_generations v
+	                       WHERE v.output_blob_hash = p.hash)
 	       AND NOT EXISTS (SELECT 1 FROM derivative_blob_purge_pending d
 	                       WHERE d.blob_hash = p.hash)
 	FROM raw_page p ORDER BY p.hash`

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -1803,6 +1803,16 @@ func validateVisualPreviewMetadataState(
 	if mismatch {
 		return errors.New("visual preview generation does not match its vault or content version")
 	}
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM visual_preview_generations g
+		LEFT JOIN blobs b ON b.hash=g.output_blob_hash
+		WHERE g.state='ready' AND (b.hash IS NULL OR b.size<>g.output_size)
+	)`).Scan(&mismatch); err != nil {
+		return fmt.Errorf("validating visual preview output blob: %w", err)
+	}
+	if mismatch {
+		return errors.New("visual preview output size does not match its cataloged blob")
+	}
 	if err := exportVisualPreviews(ctx, tx, func(any) error { return nil }); err != nil {
 		return fmt.Errorf("validating visual preview metadata: %w", err)
 	}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -128,6 +128,26 @@ type metadataSourceMetadataHead struct {
 	PublishedAt  string `json:"published_at"`
 }
 
+type metadataVisualPreviewGeneration struct {
+	Type              string `json:"type"`
+	GenerationID      string `json:"generation_id"`
+	VaultID           string `json:"vault_id"`
+	ContentVersionID  string `json:"content_version_id"`
+	SourceSHA256      string `json:"source_sha256"`
+	ContractVersion   string `json:"contract_version"`
+	RecipeFingerprint string `json:"recipe_fingerprint"`
+	CanonicalResult   []byte `json:"canonical_result" format:"byte"`
+	Checksum          string `json:"checksum"`
+	CreatedAt         string `json:"created_at"`
+}
+
+type metadataVisualPreviewHead struct {
+	Type             string `json:"type"`
+	ContentVersionID string `json:"content_version_id"`
+	GenerationID     string `json:"generation_id"`
+	PublishedAt      string `json:"published_at"`
+}
+
 type metadataNode struct {
 	Type             string  `json:"type"`
 	ID               int64   `json:"id"`
@@ -241,13 +261,16 @@ type metadataAuditMembership struct {
 }
 
 // BackupBlobAuthorityCTE is the complete blob closure for portable backup:
-// retained document versions, rendition artifacts, staged rendition sources,
-// and no operational cursor or provider-staging rows.
+// retained document versions, rendition artifacts, visual previews, staged
+// rendition sources, and no operational cursor or provider-staging rows.
 const BackupBlobAuthorityCTE = `
 WITH backup_authorized_blobs(hash) AS (
 	SELECT blob_hash FROM content_versions
 	UNION
 	SELECT blob_hash FROM rendition_artifacts
+	UNION
+	SELECT output_blob_hash FROM visual_preview_generations
+	WHERE output_blob_hash IS NOT NULL
 	UNION
 	SELECT source_sha256 FROM rendition_builds
 )
@@ -346,6 +369,9 @@ func exportMetadataSnapshotWithVaultIdentity(
 		return err
 	}
 	if err := exportContentVersions(ctx, tx, write); err != nil {
+		return err
+	}
+	if err := exportVisualPreviews(ctx, tx, write); err != nil {
 		return err
 	}
 	if err := exportProvenance(ctx, tx, write); err != nil {
@@ -532,6 +558,103 @@ func validateSourceMetadataGenerationRecord(record metadataSourceMetadataGenerat
 	if metadata.ContractVersion != record.ContractVersion || checksum != record.Checksum ||
 		sourceMetadataGenerationID(record.SourceSHA256, record.ContractVersion, record.ExtractorFingerprint, record.Checksum) != record.GenerationID {
 		return errors.New("source metadata generation identity or checksum does not match canonical evidence")
+	}
+	return nil
+}
+
+func exportVisualPreviews(ctx context.Context, tx metadataQuerier, write metadataWrite) error {
+	var present bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master
+		WHERE type='table' AND name='visual_preview_generations')`).Scan(&present); err != nil {
+		return fmt.Errorf("detecting visual preview schema: %w", err)
+	}
+	if !present {
+		return nil
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT generation_id,vault_uid,content_version_id,
+		source_sha256,contract_version,recipe_fingerprint,canonical_result,checksum,created_at,
+		state,output_blob_hash,output_size,output_media_type,output_width,output_height,
+		failure_code,failure_detail
+		FROM visual_preview_generations ORDER BY generation_id`)
+	if err != nil {
+		return fmt.Errorf("exporting visual preview generations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		record := metadataVisualPreviewGeneration{Type: metadataVisualPreviewGenerationType}
+		var state string
+		var outputHash, outputMediaType, failureCode, failureDetail sql.NullString
+		var outputSize, outputWidth, outputHeight sql.NullInt64
+		if err := rows.Scan(&record.GenerationID, &record.VaultID, &record.ContentVersionID,
+			&record.SourceSHA256, &record.ContractVersion, &record.RecipeFingerprint,
+			&record.CanonicalResult, &record.Checksum, &record.CreatedAt, &state,
+			&outputHash, &outputSize, &outputMediaType, &outputWidth, &outputHeight,
+			&failureCode, &failureDetail); err != nil {
+			return fmt.Errorf("scanning visual preview generation: %w", err)
+		}
+		if err := validateVisualPreviewGenerationRecord(record); err != nil {
+			return fmt.Errorf("validating visual preview generation for export: %w", err)
+		}
+		preview, _, err := document.DecodeVisualPreviewV1(record.CanonicalResult)
+		if err != nil {
+			return fmt.Errorf("validating visual preview generation for export: %w", err)
+		}
+		if err := validateVisualPreviewStorage(preview, record.SourceSHA256,
+			record.ContractVersion, state, outputHash, outputSize, outputMediaType,
+			outputWidth, outputHeight, failureCode, failureDetail); err != nil {
+			return fmt.Errorf("validating visual preview generation for export: %w", err)
+		}
+		if err := write(record); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("exporting visual preview generations: %w", err)
+	}
+	heads, err := tx.QueryContext(ctx, `SELECT content_version_id,generation_id,published_at
+		FROM visual_preview_heads ORDER BY content_version_id`)
+	if err != nil {
+		return fmt.Errorf("exporting visual preview heads: %w", err)
+	}
+	defer func() { _ = heads.Close() }()
+	for heads.Next() {
+		record := metadataVisualPreviewHead{Type: metadataVisualPreviewHeadType}
+		if err := heads.Scan(&record.ContentVersionID, &record.GenerationID, &record.PublishedAt); err != nil {
+			return fmt.Errorf("scanning visual preview head: %w", err)
+		}
+		if err := write(record); err != nil {
+			return err
+		}
+	}
+	return rowsError("visual preview head", heads)
+}
+
+func validateVisualPreviewGenerationRecord(record metadataVisualPreviewGeneration) error {
+	if record.Type != metadataVisualPreviewGenerationType ||
+		record.ContractVersion != document.VisualPreviewContractV1 {
+		return errors.New("invalid visual preview generation record")
+	}
+	if err := validateUUIDv4(record.VaultID); err != nil {
+		return fmt.Errorf("invalid visual preview vault identity: %w", err)
+	}
+	if err := validateUUIDv4(record.ContentVersionID); err != nil {
+		return fmt.Errorf("invalid visual preview content version: %w", err)
+	}
+	if err := validateMetadataTime("visual preview created_at", record.CreatedAt); err != nil {
+		return err
+	}
+	preview, checksum, err := document.DecodeVisualPreviewV1(record.CanonicalResult)
+	if err != nil {
+		return err
+	}
+	_, recipeFingerprint, err := document.MarshalVisualPreviewRecipeV1(preview.Recipe)
+	if err != nil {
+		return err
+	}
+	if preview.SourceSHA256 != record.SourceSHA256 || checksum != record.Checksum ||
+		recipeFingerprint != record.RecipeFingerprint ||
+		visualPreviewGenerationID(record.ContentVersionID, recipeFingerprint, checksum) != record.GenerationID {
+		return errors.New("visual preview generation identity does not match canonical result")
 	}
 	return nil
 }
@@ -833,6 +956,8 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		    + (SELECT COUNT(*) FROM blob_checksums)
 		    + (SELECT COUNT(*) FROM source_metadata_generations)
 		    + (SELECT COUNT(*) FROM source_metadata_heads)
+		    + (SELECT COUNT(*) FROM visual_preview_generations)
+		    + (SELECT COUNT(*) FROM visual_preview_heads)
 		    + (SELECT COUNT(*) FROM ingests) + (SELECT COUNT(*) FROM provenance)
 		    + (SELECT COUNT(*) FROM watch_sources)
 		    + (SELECT COUNT(*) FROM tags) + (SELECT COUNT(*) FROM node_tags)
@@ -1018,6 +1143,47 @@ func (s *Store) importMetadataRecord(
 		_, err := tx.ExecContext(ctx, `INSERT INTO source_metadata_heads(source_sha256,generation_id,published_at)
 			VALUES(?,?,?)`, v.SourceSHA256, v.GenerationID, v.PublishedAt)
 		return err
+	case metadataVisualPreviewGenerationType:
+		var v metadataVisualPreviewGeneration
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		if err := validateVisualPreviewGenerationRecord(v); err != nil {
+			return err
+		}
+		preview, _, err := document.DecodeVisualPreviewV1(v.CanonicalResult)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO visual_preview_generations(
+			generation_id,vault_uid,content_version_id,source_sha256,contract_version,
+			recipe_fingerprint,canonical_result,checksum,state,output_blob_hash,output_size,
+			output_media_type,output_width,output_height,failure_code,failure_detail,created_at
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, v.GenerationID, v.VaultID,
+			v.ContentVersionID, v.SourceSHA256, v.ContractVersion, v.RecipeFingerprint,
+			v.CanonicalResult, v.Checksum, preview.State, previewOutputHash(preview),
+			previewOutputSize(preview), previewOutputMediaType(preview), previewOutputWidth(preview),
+			previewOutputHeight(preview), previewFailureCode(preview), previewFailureDetail(preview),
+			v.CreatedAt)
+		return err
+	case metadataVisualPreviewHeadType:
+		var v metadataVisualPreviewHead
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		if err := validateUUIDv4(v.ContentVersionID); err != nil {
+			return fmt.Errorf("invalid visual preview head content version: %w", err)
+		}
+		if err := validateCatalogSHA256(v.GenerationID, "visual preview head generation ID"); err != nil {
+			return err
+		}
+		if err := validateMetadataTime("visual preview head published_at", v.PublishedAt); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO visual_preview_heads(
+			content_version_id,generation_id,published_at) VALUES(?,?,?)`,
+			v.ContentVersionID, v.GenerationID, v.PublishedAt)
+		return err
 	case "node":
 		var v metadataNode
 		if err := decodeMetadataRecord(raw, &v); err != nil {
@@ -1176,6 +1342,8 @@ const (
 	metadataBlobChecksumType              = "blob_checksum"
 	metadataSourceMetadataGenerationType  = "source_metadata_generation"
 	metadataSourceMetadataHeadType        = "source_metadata_head"
+	metadataVisualPreviewGenerationType   = "visual_preview_generation"
+	metadataVisualPreviewHeadType         = "visual_preview_head"
 )
 
 var metadataHeaderFields = []string{metadataTypeField, "format", "version", auditVaultIDField, "node_sequence"}
@@ -1185,6 +1353,8 @@ var metadataRequiredFields = map[string][]string{
 	metadataBlobChecksumType:               {metadataTypeField, "blob_sha256", "md5"},
 	metadataSourceMetadataGenerationType:   {metadataTypeField, "generation_id", "source_sha256", "contract_version", "extractor_fingerprint", "canonical_json", "checksum", metadataCreatedAtField},
 	metadataSourceMetadataHeadType:         {metadataTypeField, "source_sha256", "generation_id", "published_at"},
+	metadataVisualPreviewGenerationType:    {metadataTypeField, "generation_id", auditVaultIDField, "content_version_id", "source_sha256", "contract_version", "recipe_fingerprint", "canonical_result", "checksum", metadataCreatedAtField},
+	metadataVisualPreviewHeadType:          {metadataTypeField, "content_version_id", "generation_id", "published_at"},
 	"node":                                 {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", metadataCreatedAtField, "modified_at", "trashed_at", "trash_parent", "trash_name"},
 	"content_version":                      {metadataTypeField, "version_id", metadataNodeIDField, "blob_hash", metadataSizeField, "mime_type", auditRecordedAtField, "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
 	metadataIngestType:                     {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
@@ -1574,6 +1744,9 @@ func validateMetadataStateWithVaultIdentity(
 	if err := validateProcessingMetadataState(ctx, tx); err != nil {
 		return err
 	}
+	if err := validateVisualPreviewMetadataState(ctx, tx, vaultID); err != nil {
+		return err
+	}
 	topology, err := loadAuditTopologyRows(ctx, tx)
 	if err != nil {
 		return err
@@ -1606,6 +1779,34 @@ func validateMetadataStateWithVaultIdentity(
 		return fmt.Errorf("metadata violates foreign key %s[%v] constraint %d", table, rowID, fk)
 	}
 	return rows.Err()
+}
+
+func validateVisualPreviewMetadataState(
+	ctx context.Context, tx metadataQuerier, vaultID string,
+) error {
+	var present bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master
+		WHERE type='table' AND name='visual_preview_generations')`).Scan(&present); err != nil {
+		return fmt.Errorf("detecting visual preview metadata: %w", err)
+	}
+	if !present {
+		return nil
+	}
+	var mismatch bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM visual_preview_generations g
+		JOIN content_versions v ON v.version_id=g.content_version_id
+		WHERE g.vault_uid<>? OR g.source_sha256<>v.blob_hash
+	)`, vaultID).Scan(&mismatch); err != nil {
+		return fmt.Errorf("validating visual preview attachment: %w", err)
+	}
+	if mismatch {
+		return errors.New("visual preview generation does not match its vault or content version")
+	}
+	if err := exportVisualPreviews(ctx, tx, func(any) error { return nil }); err != nil {
+		return fmt.Errorf("validating visual preview metadata: %w", err)
+	}
+	return nil
 }
 
 func readVaultIdentity(ctx context.Context, tx metadataQuerier, legacyV090 bool) (string, error) {

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -1195,9 +1195,9 @@ type RenditionBlobReader interface {
 	OpenStreamContext(ctx context.Context, hash string) (packstore.VerifiedReadCloser, int64, error)
 }
 
-// VerifyRenditionBlobBytes verifies every retained rendition source and
-// artifact through the restored mixed-storage catalog, including builds that
-// are staged but not attached to an active head.
+// VerifyRenditionBlobBytes verifies every retained rendition source, artifact,
+// and ready visual preview through the restored mixed-storage catalog,
+// including builds that are staged but not attached to an active head.
 func (s *Store) VerifyRenditionBlobBytes(ctx context.Context, reader RenditionBlobReader) error {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT b.source_sha256, source.size
@@ -1206,6 +1206,10 @@ func (s *Store) VerifyRenditionBlobBytes(ctx context.Context, reader RenditionBl
 		UNION
 		SELECT artifact.blob_hash, artifact.size
 		FROM rendition_artifacts artifact
+		UNION
+		SELECT preview.output_blob_hash, preview.output_size
+		FROM visual_preview_generations preview
+		WHERE preview.state='ready'
 		ORDER BY 1, 2`)
 	if err != nil {
 		return fmt.Errorf("listing retained rendition bytes: %w", err)

--- a/internal/store/processing_metadata.go
+++ b/internal/store/processing_metadata.go
@@ -1250,6 +1250,9 @@ func verifyRenditionBlobCatalogAuthority(ctx context.Context, tx *sql.Tx) (retEr
 		SELECT source_sha256 FROM rendition_builds
 		UNION
 		SELECT blob_hash FROM rendition_artifacts
+		UNION
+		SELECT output_blob_hash FROM visual_preview_generations
+		WHERE output_blob_hash IS NOT NULL
 		ORDER BY source_sha256`)
 	if err != nil {
 		return fmt.Errorf("reading processing blob catalog authority: %w", err)

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -794,6 +794,69 @@ CREATE INDEX IF NOT EXISTS content_versions_node
     ON content_versions(node_id, node_revision DESC);
 CREATE INDEX IF NOT EXISTS content_versions_blob ON content_versions(blob_hash);
 
+-- Visual previews are immutable exact-version derivatives selected by a small
+-- mutable head. The content version owns their lifecycle; deleting the version
+-- removes its preview catalog, after which ordinary blob GC may reclaim bytes
+-- no other version or derivative retains.
+CREATE TABLE IF NOT EXISTS visual_preview_generations (
+    generation_id         TEXT PRIMARY KEY,
+    vault_uid             TEXT NOT NULL REFERENCES vault_metadata(vault_uid),
+    content_version_id    TEXT NOT NULL REFERENCES content_versions(version_id) ON DELETE CASCADE,
+    source_sha256         TEXT NOT NULL REFERENCES blobs(hash),
+    contract_version      TEXT NOT NULL,
+    recipe_fingerprint    TEXT NOT NULL,
+    canonical_result      BLOB NOT NULL
+        CHECK (length(canonical_result) BETWEEN 2 AND 65536),
+    checksum              TEXT NOT NULL,
+    state                 TEXT NOT NULL CHECK (state IN ('ready', 'unsupported', 'failed')),
+    output_blob_hash      TEXT REFERENCES blobs(hash),
+    output_size           INTEGER,
+    output_media_type     TEXT,
+    output_width          INTEGER,
+    output_height         INTEGER,
+    failure_code          TEXT,
+    failure_detail        TEXT,
+    created_at            TEXT NOT NULL,
+    UNIQUE (content_version_id, recipe_fingerprint),
+    UNIQUE (content_version_id, generation_id),
+    CHECK (
+        (state = 'ready'
+         AND output_blob_hash IS NOT NULL
+         AND output_size > 0
+         AND output_media_type IS NOT NULL
+         AND output_width > 0
+         AND output_height > 0
+         AND failure_code IS NULL
+         AND failure_detail IS NULL)
+        OR
+        (state IN ('unsupported', 'failed')
+         AND output_blob_hash IS NULL
+         AND output_size IS NULL
+         AND output_media_type IS NULL
+         AND output_width IS NULL
+         AND output_height IS NULL
+         AND failure_code IS NOT NULL
+         AND failure_detail IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS visual_preview_generations_output
+    ON visual_preview_generations(output_blob_hash, generation_id)
+    WHERE output_blob_hash IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS visual_preview_heads (
+    content_version_id TEXT PRIMARY KEY REFERENCES content_versions(version_id) ON DELETE CASCADE,
+    generation_id      TEXT NOT NULL UNIQUE,
+    published_at       TEXT NOT NULL,
+    FOREIGN KEY (content_version_id, generation_id)
+        REFERENCES visual_preview_generations(content_version_id, generation_id) ON DELETE CASCADE
+);
+
+CREATE TRIGGER IF NOT EXISTS visual_preview_generations_immutable_update
+BEFORE UPDATE ON visual_preview_generations BEGIN
+    SELECT RAISE(ABORT, 'visual preview generation records are immutable');
+END;
+
 CREATE TABLE IF NOT EXISTS ingests (
     id          TEXT PRIMARY KEY NOT NULL,
     started_at  TEXT NOT NULL,

--- a/internal/store/version_prune.go
+++ b/internal/store/version_prune.go
@@ -28,10 +28,12 @@ type VersionPruneSelector struct {
 
 // VersionPruneResult is the complete dry-run inventory or execution receipt.
 // LogicalBytes counts version references and may count a deduplicated blob
-// more than once. ReleasableBytes counts unique blobs that become eligible for
-// a later GC; pruning itself never reports physical bytes as reclaimed. Loose
-// and packed maintenance counts may overlap when one blob has both location
-// kinds across stores; MixedBlobsPendingMaintenance names that intersection.
+// more than once. UniqueBlobs includes both selected content blobs and visual
+// preview outputs owned by the selected versions. ReleasableBytes counts
+// unique blobs that become eligible for a later GC; pruning itself never
+// reports physical bytes as reclaimed. Loose and packed maintenance counts may
+// overlap when one blob has both location kinds across stores;
+// MixedBlobsPendingMaintenance names that intersection.
 type VersionPruneResult struct {
 	Node                         Node
 	Candidates                   []ContentVersion
@@ -347,8 +349,13 @@ func populateVersionPruneBlobStats(
 	tx *sql.Tx, result *VersionPruneResult, checkpointRequired bool,
 ) error {
 	selectedByHash := make(map[string]int)
+	versionIDs := make([]string, 0, len(result.Candidates))
 	for _, version := range result.Candidates {
 		selectedByHash[version.BlobHash]++
+		versionIDs = append(versionIDs, version.ID)
+	}
+	if err := addVersionPruneVisualPreviewRefsTx(tx, versionIDs, selectedByHash); err != nil {
+		return err
 	}
 	result.UniqueBlobs = len(selectedByHash)
 	if len(selectedByHash) == 0 {
@@ -366,7 +373,7 @@ func populateVersionPruneBlobStats(
 	for hash, selected := range selectedByHash {
 		item, ok := stats[hash]
 		if !ok {
-			return fmt.Errorf("candidate content blob %s lacks catalog authority", hash)
+			return fmt.Errorf("candidate blob %s lacks catalog authority", hash)
 		}
 		retained := item.refs - selected
 		if checkpointRequired && hash == result.Node.BlobHash {
@@ -384,7 +391,7 @@ func populateVersionPruneBlobStats(
 		hasLoose := item.looseLocations > 0
 		hasPacked := item.packedLocations > 0
 		if !hasLoose && !hasPacked {
-			return fmt.Errorf("candidate content blob %s lacks physical authority", hash)
+			return fmt.Errorf("candidate blob %s lacks physical authority", hash)
 		}
 		if hasLoose {
 			result.LooseBlobsPendingGC++
@@ -403,6 +410,57 @@ func populateVersionPruneBlobStats(
 		if hasLoose && hasPacked {
 			result.MixedBlobsPendingMaintenance++
 		}
+	}
+	return nil
+}
+
+func addVersionPruneVisualPreviewRefsTx(
+	tx *sql.Tx, versionIDs []string, selectedByHash map[string]int,
+) error {
+	const batchSize = 500
+	for start := 0; start < len(versionIDs); start += batchSize {
+		end := min(start+batchSize, len(versionIDs))
+		if err := addVersionPruneVisualPreviewRefsBatchTx(
+			tx, versionIDs[start:end], selectedByHash,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addVersionPruneVisualPreviewRefsBatchTx(
+	tx *sql.Tx, versionIDs []string, selectedByHash map[string]int,
+) (retErr error) {
+	args := make([]any, len(versionIDs))
+	for index, id := range versionIDs {
+		args[index] = id
+	}
+	rows, err := tx.Query(`
+		SELECT output_blob_hash, COUNT(*)
+		FROM visual_preview_generations
+		WHERE content_version_id IN (`+placeholders(len(args))+`)
+		  AND output_blob_hash IS NOT NULL
+		GROUP BY output_blob_hash`, args...)
+	if err != nil {
+		return fmt.Errorf("inventorying version-prune visual previews: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			retErr = errors.Join(retErr,
+				fmt.Errorf("closing version-prune visual preview inventory: %w", err))
+		}
+	}()
+	for rows.Next() {
+		var hash string
+		var refs int
+		if err := rows.Scan(&hash, &refs); err != nil {
+			return fmt.Errorf("inventorying version-prune visual previews: %w", err)
+		}
+		selectedByHash[hash] += refs
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("inventorying version-prune visual previews: %w", err)
 	}
 	return nil
 }
@@ -427,11 +485,17 @@ func versionPruneBlobStatsBatchTx(
 		args[index] = hash
 	}
 	rows, err := tx.Query(`
-			SELECT v.blob_hash, COUNT(*), b.size
-			FROM content_versions v
-			JOIN blobs b ON b.hash = v.blob_hash
-			WHERE v.blob_hash IN (`+placeholders(len(hashes))+`)
-			GROUP BY v.blob_hash, b.size`, args...)
+			SELECT refs.blob_hash, COUNT(*), b.size
+			FROM (
+				SELECT blob_hash FROM content_versions
+				UNION ALL
+				SELECT output_blob_hash AS blob_hash
+				FROM visual_preview_generations
+				WHERE output_blob_hash IS NOT NULL
+			) refs
+			JOIN blobs b ON b.hash = refs.blob_hash
+			WHERE refs.blob_hash IN (`+placeholders(len(hashes))+`)
+			GROUP BY refs.blob_hash, b.size`, args...)
 	if err != nil {
 		return fmt.Errorf("inventorying version-prune blobs: %w", err)
 	}

--- a/internal/store/version_prune_test.go
+++ b/internal/store/version_prune_test.go
@@ -176,6 +176,58 @@ func TestPruneContentVersionsRemovesRenditionAttachment(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestPruneContentVersionsAccountsForVisualPreviewOutputs(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	created, err := s.CreateFile(ctx, s.RootID(), "photo.jpg", fakeHash("91"), 10, "image/jpeg")
+	require.NoError(t, err)
+	_, err = s.PublishVisualPreview(ctx, created.CurrentVersionID,
+		readyVisualPreview(t, created.BlobHash, fakeHash("92"), 8),
+		&BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 8})
+	require.NoError(t, err)
+
+	replaced, historical, err := s.ReplaceContent(
+		ctx, created.ID, created.Revision, fakeHash("93"), 20, "image/jpeg",
+	)
+	require.NoError(t, err)
+	_, err = s.PublishVisualPreview(ctx, historical.ID,
+		readyVisualPreview(t, historical.BlobHash, fakeHash("94"), 9),
+		&BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 9})
+	require.NoError(t, err)
+
+	current, currentVersion, err := s.ReplaceContent(
+		ctx, created.ID, replaced.Revision, fakeHash("95"), 30, "image/jpeg",
+	)
+	require.NoError(t, err)
+	_, err = s.PublishVisualPreview(ctx, currentVersion.ID,
+		readyVisualPreview(t, currentVersion.BlobHash, fakeHash("94"), 9),
+		&BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 9})
+	require.NoError(t, err)
+
+	preview, err := s.PruneContentVersions(ctx, created.ID, current.Revision,
+		VersionPruneSelector{KeepNewest: 1}, false)
+	require.NoError(t, err)
+	assert.Equal(t, 4, preview.UniqueBlobs)
+	assert.Equal(t, 1, preview.SharedBlobs)
+	assert.Equal(t, 3, preview.ReleasableBlobs)
+	assert.Equal(t, int64(38), preview.ReleasableBytes)
+	assert.Equal(t, 3, preview.LooseBlobsPendingGC)
+	assert.Equal(t, int64(38), preview.LooseBytesPendingGC)
+
+	receipt, err := s.PruneContentVersions(ctx, created.ID, current.Revision,
+		VersionPruneSelector{KeepNewest: 1}, true)
+	require.NoError(t, err)
+	assert.Equal(t, preview.UniqueBlobs, receipt.UniqueBlobs)
+	assert.Equal(t, preview.SharedBlobs, receipt.SharedBlobs)
+	assert.Equal(t, preview.ReleasableBlobs, receipt.ReleasableBlobs)
+	assert.Equal(t, preview.ReleasableBytes, receipt.ReleasableBytes)
+
+	unreachable, err := s.UnreachableBlobs(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, unreachable, BlobInfo{Hash: fakeHash("92"), Size: 8})
+	assert.NotContains(t, unreachable, BlobInfo{Hash: fakeHash("94"), Size: 9})
+}
+
 func TestPruneContentVersionsReportsPackedAndSharedConsequences(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/visual_preview.go
+++ b/internal/store/visual_preview.go
@@ -1,0 +1,281 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/document"
+)
+
+// VisualPreviewGeneration is one immutable result for an exact content
+// version and complete recipe identity.
+type VisualPreviewGeneration struct {
+	GenerationID      string
+	VaultID           string
+	ContentVersionID  string
+	RecipeFingerprint string
+	CanonicalResult   []byte
+	Checksum          string
+	Preview           document.VisualPreviewV1
+	CreatedAt         string
+}
+
+// VisualPreviewView is the active preview result joined to its exact source
+// version and publication time.
+type VisualPreviewView struct {
+	Version     ContentVersion
+	Generation  VisualPreviewGeneration
+	PublishedAt string
+}
+
+func visualPreviewGenerationID(versionID, recipeFingerprint, checksum string) string {
+	h := sha256.New()
+	for _, value := range []string{versionID, recipeFingerprint, checksum} {
+		_, _ = fmt.Fprintf(h, "%d:%s", len(value), value)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// PublishVisualPreview validates and atomically publishes one exact-version
+// result. Ready results also commit the already-durable output blob receipt.
+// Retrying the identical publication is idempotent.
+func (s *Store) PublishVisualPreview(
+	ctx context.Context, versionID string, canonical []byte, physical *BlobPhysical,
+) (VisualPreviewGeneration, error) {
+	if err := validateUUIDv4(versionID); err != nil {
+		return VisualPreviewGeneration{}, fmt.Errorf("content version %q: %w", versionID, ErrNotFound)
+	}
+	preview, checksum, err := document.DecodeVisualPreviewV1(canonical)
+	if err != nil {
+		return VisualPreviewGeneration{}, fmt.Errorf("validating visual preview: %w", err)
+	}
+	_, recipeFingerprint, err := document.MarshalVisualPreviewRecipeV1(preview.Recipe)
+	if err != nil {
+		return VisualPreviewGeneration{}, fmt.Errorf("fingerprinting visual preview recipe: %w", err)
+	}
+	if preview.State == document.VisualPreviewReady && physical == nil {
+		return VisualPreviewGeneration{}, errors.New("ready visual preview requires physical blob authority")
+	}
+	if preview.State != document.VisualPreviewReady && physical != nil {
+		return VisualPreviewGeneration{}, errors.New("non-ready visual preview must not carry physical blob authority")
+	}
+	generation := VisualPreviewGeneration{
+		GenerationID: visualPreviewGenerationID(versionID, recipeFingerprint, checksum),
+		VaultID:      s.vaultID, ContentVersionID: versionID, RecipeFingerprint: recipeFingerprint,
+		CanonicalResult: append([]byte(nil), canonical...), Checksum: checksum,
+		Preview: preview, CreatedAt: nowRFC3339(),
+	}
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		version, readErr := scanContentVersion(tx.QueryRowContext(ctx,
+			`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id=?`, versionID))
+		if readErr != nil {
+			return fmt.Errorf("reading visual preview source version: %w", readErr)
+		}
+		if version.BlobHash != preview.SourceSHA256 {
+			return errors.New("visual preview source does not match content version")
+		}
+		if preview.State == document.VisualPreviewReady {
+			if err := s.EnsureBlobTx(tx, preview.Output.BlobSHA256, preview.Output.Size, *physical); err != nil {
+				return fmt.Errorf("recording visual preview output: %w", err)
+			}
+		}
+		if _, execErr := tx.ExecContext(ctx, `INSERT INTO visual_preview_generations(
+			generation_id,vault_uid,content_version_id,source_sha256,contract_version,
+			recipe_fingerprint,canonical_result,checksum,state,output_blob_hash,output_size,
+			output_media_type,output_width,output_height,failure_code,failure_detail,created_at
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(content_version_id,recipe_fingerprint) DO NOTHING`,
+			generation.GenerationID, generation.VaultID, versionID, preview.SourceSHA256,
+			preview.ContractVersion, recipeFingerprint, canonical, checksum, preview.State,
+			previewOutputHash(preview), previewOutputSize(preview), previewOutputMediaType(preview),
+			previewOutputWidth(preview), previewOutputHeight(preview), previewFailureCode(preview),
+			previewFailureDetail(preview), generation.CreatedAt); execErr != nil {
+			return fmt.Errorf("recording visual preview generation: %w", execErr)
+		}
+		stored, readErr := visualPreviewGenerationByRecipeTx(ctx, tx, versionID, recipeFingerprint)
+		if readErr != nil {
+			return readErr
+		}
+		if stored.GenerationID != generation.GenerationID || stored.Checksum != checksum ||
+			!bytes.Equal(stored.CanonicalResult, canonical) {
+			return errors.New("visual preview recipe already has a different result")
+		}
+		generation = stored
+		_, execErr := tx.ExecContext(ctx, `INSERT INTO visual_preview_heads(
+			content_version_id,generation_id,published_at
+		) VALUES(?,?,?) ON CONFLICT(content_version_id) DO UPDATE SET
+			generation_id=excluded.generation_id,published_at=excluded.published_at`,
+			versionID, generation.GenerationID, nowRFC3339())
+		return execErr
+	})
+	return generation, err
+}
+
+// ContentVersionVisualPreview returns the active result for one exact content
+// version, including deterministic unsupported and failed outcomes.
+func (s *Store) ContentVersionVisualPreview(
+	ctx context.Context, versionID string,
+) (VisualPreviewView, error) {
+	if err := validateUUIDv4(versionID); err != nil {
+		return VisualPreviewView{}, fmt.Errorf("content version %q: %w", versionID, ErrNotFound)
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return VisualPreviewView{}, fmt.Errorf("starting visual preview snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	version, err := scanContentVersion(tx.QueryRowContext(ctx,
+		`SELECT `+contentVersionCols+` FROM content_versions WHERE version_id=?`, versionID))
+	if err != nil {
+		return VisualPreviewView{}, fmt.Errorf("content version %q: %w", versionID, err)
+	}
+	var publishedAt string
+	var recipeFingerprint string
+	err = tx.QueryRowContext(ctx, `SELECT g.recipe_fingerprint,h.published_at
+		FROM visual_preview_heads h JOIN visual_preview_generations g
+		ON g.generation_id=h.generation_id WHERE h.content_version_id=?`, versionID).
+		Scan(&recipeFingerprint, &publishedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return VisualPreviewView{}, ErrNotFound
+	}
+	if err != nil {
+		return VisualPreviewView{}, fmt.Errorf("reading visual preview head: %w", err)
+	}
+	generation, err := visualPreviewGenerationByRecipeTx(ctx, tx, versionID, recipeFingerprint)
+	if err != nil {
+		return VisualPreviewView{}, err
+	}
+	if generation.VaultID != s.vaultID {
+		return VisualPreviewView{}, errors.New("stored visual preview belongs to another vault")
+	}
+	if generation.Preview.SourceSHA256 != version.BlobHash {
+		return VisualPreviewView{}, errors.New("stored visual preview source does not match content version")
+	}
+	if err := tx.Commit(); err != nil {
+		return VisualPreviewView{}, fmt.Errorf("closing visual preview snapshot: %w", err)
+	}
+	return VisualPreviewView{Version: version, Generation: generation, PublishedAt: publishedAt}, nil
+}
+
+func visualPreviewGenerationByRecipeTx(
+	ctx context.Context, q metadataQuerier, versionID, recipeFingerprint string,
+) (VisualPreviewGeneration, error) {
+	var generation VisualPreviewGeneration
+	var sourceSHA256, contractVersion, state string
+	var outputHash, outputMediaType, failureCode, failureDetail sql.NullString
+	var outputSize, outputWidth, outputHeight sql.NullInt64
+	err := q.QueryRowContext(ctx, `SELECT generation_id,vault_uid,content_version_id,
+		recipe_fingerprint,canonical_result,checksum,created_at,source_sha256,contract_version,
+		state,output_blob_hash,output_size,output_media_type,output_width,output_height,
+		failure_code,failure_detail
+		FROM visual_preview_generations WHERE content_version_id=? AND recipe_fingerprint=?`,
+		versionID, recipeFingerprint).Scan(&generation.GenerationID, &generation.VaultID,
+		&generation.ContentVersionID, &generation.RecipeFingerprint, &generation.CanonicalResult,
+		&generation.Checksum, &generation.CreatedAt, &sourceSHA256, &contractVersion, &state,
+		&outputHash, &outputSize, &outputMediaType, &outputWidth, &outputHeight,
+		&failureCode, &failureDetail)
+	if errors.Is(err, sql.ErrNoRows) {
+		return VisualPreviewGeneration{}, ErrNotFound
+	}
+	if err != nil {
+		return VisualPreviewGeneration{}, fmt.Errorf("reading visual preview generation: %w", err)
+	}
+	preview, checksum, err := document.DecodeVisualPreviewV1(generation.CanonicalResult)
+	if err != nil || checksum != generation.Checksum ||
+		visualPreviewGenerationID(versionID, recipeFingerprint, checksum) != generation.GenerationID {
+		return VisualPreviewGeneration{}, errors.New("stored visual preview failed canonical identity validation")
+	}
+	_, fingerprint, err := document.MarshalVisualPreviewRecipeV1(preview.Recipe)
+	if err != nil || fingerprint != recipeFingerprint {
+		return VisualPreviewGeneration{}, errors.New("stored visual preview recipe fingerprint is invalid")
+	}
+	if err := validateVisualPreviewStorage(preview, sourceSHA256, contractVersion, state,
+		outputHash, outputSize, outputMediaType, outputWidth, outputHeight,
+		failureCode, failureDetail); err != nil {
+		return VisualPreviewGeneration{}, err
+	}
+	generation.Preview = preview
+	return generation, nil
+}
+
+func validateVisualPreviewStorage(
+	preview document.VisualPreviewV1, sourceSHA256, contractVersion, state string,
+	outputHash sql.NullString, outputSize sql.NullInt64, outputMediaType sql.NullString,
+	outputWidth, outputHeight sql.NullInt64, failureCode, failureDetail sql.NullString,
+) error {
+	if sourceSHA256 != preview.SourceSHA256 || contractVersion != preview.ContractVersion ||
+		state != string(preview.State) {
+		return errors.New("stored visual preview columns do not match canonical result")
+	}
+	if preview.Output != nil {
+		if !outputHash.Valid || outputHash.String != preview.Output.BlobSHA256 ||
+			!outputSize.Valid || outputSize.Int64 != preview.Output.Size ||
+			!outputMediaType.Valid || outputMediaType.String != preview.Output.MediaType ||
+			!outputWidth.Valid || outputWidth.Int64 != int64(preview.Output.Width) ||
+			!outputHeight.Valid || outputHeight.Int64 != int64(preview.Output.Height) ||
+			failureCode.Valid || failureDetail.Valid {
+			return errors.New("stored visual preview output does not match canonical result")
+		}
+		return nil
+	}
+	if outputHash.Valid || outputSize.Valid || outputMediaType.Valid || outputWidth.Valid || outputHeight.Valid ||
+		!failureCode.Valid || failureCode.String != preview.Failure.Code ||
+		!failureDetail.Valid || failureDetail.String != preview.Failure.Detail {
+		return errors.New("stored visual preview failure does not match canonical result")
+	}
+	return nil
+}
+
+func previewOutputHash(value document.VisualPreviewV1) any {
+	if value.Output == nil {
+		return nil
+	}
+	return value.Output.BlobSHA256
+}
+
+func previewOutputSize(value document.VisualPreviewV1) any {
+	if value.Output == nil {
+		return nil
+	}
+	return value.Output.Size
+}
+
+func previewOutputMediaType(value document.VisualPreviewV1) any {
+	if value.Output == nil {
+		return nil
+	}
+	return value.Output.MediaType
+}
+
+func previewOutputWidth(value document.VisualPreviewV1) any {
+	if value.Output == nil {
+		return nil
+	}
+	return value.Output.Width
+}
+
+func previewOutputHeight(value document.VisualPreviewV1) any {
+	if value.Output == nil {
+		return nil
+	}
+	return value.Output.Height
+}
+
+func previewFailureCode(value document.VisualPreviewV1) any {
+	if value.Failure == nil {
+		return nil
+	}
+	return value.Failure.Code
+}
+
+func previewFailureDetail(value document.VisualPreviewV1) any {
+	if value.Failure == nil {
+		return nil
+	}
+	return value.Failure.Detail
+}

--- a/internal/store/visual_preview_test.go
+++ b/internal/store/visual_preview_test.go
@@ -1,0 +1,121 @@
+package store
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+)
+
+func TestVisualPreviewPublicationIsExactVersionAndIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	node, err := s.CreateFile(t.Context(), s.RootID(), "photo.raw", fakeHash("11"), 12, "image/x-raw")
+	require.NoError(t, err)
+	canonical := readyVisualPreview(t, node.BlobHash, fakeHash("22"), 9)
+	physical := &BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 9}
+
+	first, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, canonical, physical)
+	require.NoError(t, err)
+	retry, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, canonical, physical)
+	require.NoError(t, err)
+	assert.Equal(t, first.GenerationID, retry.GenerationID)
+
+	view, err := s.ContentVersionVisualPreview(t.Context(), node.CurrentVersionID)
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, view.Generation.Preview.State)
+	assert.Equal(t, fakeHash("22"), view.Generation.Preview.Output.BlobSHA256)
+
+	unreachable, err := s.UnreachableBlobs(t.Context())
+	require.NoError(t, err)
+	for _, blob := range unreachable {
+		assert.NotEqual(t, fakeHash("22"), blob.Hash)
+	}
+
+	changed := readyVisualPreview(t, node.BlobHash, fakeHash("23"), 9)
+	_, err = s.PublishVisualPreview(t.Context(), node.CurrentVersionID, changed, physical)
+	require.ErrorContains(t, err, "already has a different result")
+	_, err = s.BlobInfo(t.Context(), fakeHash("23"))
+	require.ErrorIs(t, err, ErrNotFound, "conflicting output membership must roll back")
+}
+
+func TestVisualPreviewMetadataRoundTrip(t *testing.T) {
+	source := newTestStore(t)
+	node, err := source.CreateFile(t.Context(), source.RootID(), "image.jpg", fakeHash("31"), 12, "image/jpeg")
+	require.NoError(t, err)
+	canonical := readyVisualPreview(t, node.BlobHash, fakeHash("32"), 7)
+	_, err = source.PublishVisualPreview(t.Context(), node.CurrentVersionID, canonical,
+		&BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 7})
+	require.NoError(t, err)
+
+	var exported bytes.Buffer
+	snapshot, err := source.BeginMetadataSnapshot(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, snapshot.ExportBackup(t.Context(), &exported))
+	require.NoError(t, snapshot.Close())
+	target := newTestStore(t)
+	require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	view, err := target.ContentVersionVisualPreview(t.Context(), node.CurrentVersionID)
+	require.NoError(t, err)
+	assert.Equal(t, fakeHash("32"), view.Generation.Preview.Output.BlobSHA256)
+}
+
+func TestVisualPreviewRecordsDeterministicFailureWithoutBlobAuthority(t *testing.T) {
+	s := newTestStore(t)
+	node, err := s.CreateFile(t.Context(), s.RootID(), "notes.txt", fakeHash("41"), 5, "text/plain")
+	require.NoError(t, err)
+	recipe := visualPreviewRecipe()
+	canonical, _, err := document.MarshalVisualPreviewV1(document.VisualPreviewV1{
+		ContractVersion: document.VisualPreviewContractV1, SourceSHA256: node.BlobHash,
+		Recipe: recipe, State: document.VisualPreviewUnsupported,
+		Failure: &document.VisualPreviewFailureV1{Code: "unsupported_media_type", Detail: "text/plain is not visual media"},
+	})
+	require.NoError(t, err)
+	_, err = s.PublishVisualPreview(t.Context(), node.CurrentVersionID, canonical, nil)
+	require.NoError(t, err)
+	view, err := s.ContentVersionVisualPreview(t.Context(), node.CurrentVersionID)
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewUnsupported, view.Generation.Preview.State)
+}
+
+func TestVisualPreviewLifecycleFollowsExactContentVersion(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.CreateFile(t.Context(), s.RootID(), "image.jpg", fakeHash("61"), 6, "image/jpeg")
+	require.NoError(t, err)
+	canonical := readyVisualPreview(t, created.BlobHash, fakeHash("62"), 8)
+	_, err = s.PublishVisualPreview(t.Context(), created.CurrentVersionID, canonical,
+		&BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 8})
+	require.NoError(t, err)
+	priorVersionID := created.CurrentVersionID
+	updated, _, err := s.ReplaceContent(t.Context(), created.ID, created.Revision,
+		fakeHash("63"), 7, "image/jpeg")
+	require.NoError(t, err)
+	_, err = s.PruneContentVersions(t.Context(), created.ID, updated.Revision,
+		VersionPruneSelector{VersionIDs: []string{priorVersionID}}, true)
+	require.NoError(t, err)
+
+	_, err = s.ContentVersionVisualPreview(t.Context(), priorVersionID)
+	require.ErrorIs(t, err, ErrNotFound)
+	unreachable, err := s.UnreachableBlobs(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, unreachable, BlobInfo{Hash: fakeHash("62"), Size: 8})
+}
+
+func readyVisualPreview(t *testing.T, source, output string, size int64) []byte {
+	t.Helper()
+	canonical, _, err := document.MarshalVisualPreviewV1(document.VisualPreviewV1{
+		ContractVersion: document.VisualPreviewContractV1, SourceSHA256: source,
+		Recipe: visualPreviewRecipe(), State: document.VisualPreviewReady,
+		Output: &document.VisualPreviewOutputV1{BlobSHA256: output, Size: size,
+			MediaType: "image/jpeg", Width: 1600, Height: 900},
+	})
+	require.NoError(t, err)
+	return canonical
+}
+
+func visualPreviewRecipe() document.VisualPreviewRecipeV1 {
+	return document.VisualPreviewRecipeV1{ContractVersion: document.VisualPreviewContractV1,
+		MaxEdgePixels: 2048, OutputMediaType: "image/jpeg", OrientationPolicy: "apply",
+		ColorPolicy: "srgb", FramePolicy: "primary", ProcessorFingerprint: fakeHash("51")}
+}

--- a/internal/store/visual_preview_test.go
+++ b/internal/store/visual_preview_test.go
@@ -2,11 +2,14 @@ package store
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/kit/packstore"
 )
 
 func TestVisualPreviewPublicationIsExactVersionAndIdempotent(t *testing.T) {
@@ -101,6 +104,61 @@ func TestVisualPreviewLifecycleFollowsExactContentVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, unreachable, BlobInfo{Hash: fakeHash("62"), Size: 8})
 }
+
+func TestRestoreByteVerificationIncludesReadyVisualPreview(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.CreateFile(t.Context(), s.RootID(), "image.jpg", fakeHash("71"), 6, "image/jpeg")
+	require.NoError(t, err)
+	canonical := readyVisualPreview(t, created.BlobHash, fakeHash("72"), 8)
+	_, err = s.PublishVisualPreview(t.Context(), created.CurrentVersionID, canonical,
+		&BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 8})
+	require.NoError(t, err)
+
+	corrupt := errors.New("corrupt preview bytes")
+	reader := &visualPreviewRestoreReader{payload: bytes.Repeat([]byte{'p'}, 8), verifyErr: corrupt}
+	err = s.VerifyRenditionBlobBytes(t.Context(), reader)
+	require.ErrorIs(t, err, corrupt)
+	assert.Equal(t, []string{fakeHash("72")}, reader.opened)
+}
+
+func TestVisualPreviewMetadataRejectsOutputBlobSizeMismatch(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.CreateFile(t.Context(), s.RootID(), "image.jpg", fakeHash("81"), 6, "image/jpeg")
+	require.NoError(t, err)
+	canonical := readyVisualPreview(t, created.BlobHash, fakeHash("82"), 8)
+	_, err = s.PublishVisualPreview(t.Context(), created.CurrentVersionID, canonical,
+		&BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 8})
+	require.NoError(t, err)
+	_, err = s.db.Exec(`UPDATE blobs SET size=9 WHERE hash=?`, fakeHash("82"))
+	require.NoError(t, err)
+
+	err = s.ValidateMetadata(t.Context())
+	require.ErrorContains(t, err, "visual preview output size does not match its cataloged blob")
+}
+
+type visualPreviewRestoreReader struct {
+	payload   []byte
+	verifyErr error
+	opened    []string
+}
+
+func (r *visualPreviewRestoreReader) OpenStreamContext(
+	_ context.Context, hash string,
+) (packstore.VerifiedReadCloser, int64, error) {
+	r.opened = append(r.opened, hash)
+	return &visualPreviewVerifiedReader{Reader: bytes.NewReader(r.payload), verifyErr: r.verifyErr},
+		int64(len(r.payload)), nil
+}
+
+type visualPreviewVerifiedReader struct {
+	*bytes.Reader
+
+	verifyErr error
+}
+
+func (r *visualPreviewVerifiedReader) Close() error   { return nil }
+func (r *visualPreviewVerifiedReader) Verified() bool { return r.verifyErr == nil }
+func (r *visualPreviewVerifiedReader) Verify() error  { return r.verifyErr }
 
 func readyVisualPreview(t *testing.T, source, output string, size int64) []byte {
 	t.Helper()

--- a/types.go
+++ b/types.go
@@ -75,6 +75,22 @@ type SourceMetadata struct {
 	Attachment           SourceMetadataAttachment           `json:"attachment"`
 }
 
+// VisualPreview is the active deterministic preview result for one exact
+// content version. Output is populated only when State is ready; Failure is
+// populated for unsupported and failed results.
+type VisualPreview struct {
+	Version           ContentVersion                   `json:"version"`
+	GenerationID      string                           `json:"generation_id"`
+	RecipeFingerprint string                           `json:"recipe_fingerprint"`
+	Checksum          string                           `json:"checksum"`
+	State             document.VisualPreviewState      `json:"state"`
+	Recipe            document.VisualPreviewRecipeV1   `json:"recipe"`
+	Output            *document.VisualPreviewOutputV1  `json:"output,omitempty"`
+	Failure           *document.VisualPreviewFailureV1 `json:"failure,omitempty"`
+	CreatedAt         string                           `json:"created_at"`
+	PublishedAt       string                           `json:"published_at"`
+}
+
 // ProvenanceSource describes an application-neutral origin for one immutable
 // document creation. Reference may be a URI, archive key, filesystem path, or
 // another stable source-local identifier; Docbank does not interpret it.
@@ -292,6 +308,13 @@ type VersionContent struct {
 	Reader  VerifiedReadCloser
 }
 
+// VisualPreviewContent binds verified preview bytes to their exact cataloged
+// source version and recipe result.
+type VisualPreviewContent struct {
+	Preview VisualPreview
+	Reader  VerifiedReadCloser
+}
+
 // ContentRangeOptions selects a non-empty decoded logical byte range.
 type ContentRangeOptions struct {
 	Offset int64
@@ -341,6 +364,17 @@ func fromStoreSourceMetadata(view store.SourceMetadataView) SourceMetadata {
 			Path: attachment.Path, SourcePath: attachment.SourcePath,
 			IngestedAt: attachment.IngestedAt, FilesystemMTime: attachment.FilesystemMTime,
 		},
+	}
+}
+
+func fromStoreVisualPreview(view store.VisualPreviewView) VisualPreview {
+	generation := view.Generation
+	return VisualPreview{
+		Version: fromStoreVersion(view.Version), GenerationID: generation.GenerationID,
+		RecipeFingerprint: generation.RecipeFingerprint, Checksum: generation.Checksum,
+		State: generation.Preview.State, Recipe: generation.Preview.Recipe,
+		Output: generation.Preview.Output, Failure: generation.Preview.Failure,
+		CreatedAt: generation.CreatedAt, PublishedAt: view.PublishedAt,
 	}
 }
 

--- a/vault.go
+++ b/vault.go
@@ -18,6 +18,7 @@ import (
 
 	"go.kenn.io/kit/packstore"
 
+	"go.kenn.io/docbank/document"
 	"go.kenn.io/docbank/internal/backupapp"
 	"go.kenn.io/docbank/internal/blob"
 	internalconfig "go.kenn.io/docbank/internal/config"
@@ -45,6 +46,9 @@ var (
 	// ErrInvalidContentRange means a requested logical byte range falls
 	// outside its exact immutable content version.
 	ErrInvalidContentRange = errors.New("docbank invalid content range")
+	// ErrVisualPreviewUnavailable means the exact version has a cataloged
+	// unsupported or failed preview result rather than readable preview bytes.
+	ErrVisualPreviewUnavailable = errors.New("docbank visual preview is unavailable")
 
 	ErrNotFound                 = store.ErrNotFound
 	ErrExists                   = store.ErrExists
@@ -367,6 +371,61 @@ func (v *Vault) SourceMetadata(ctx context.Context, versionID string) (SourceMet
 		return SourceMetadata{}, err
 	}
 	return fromStoreSourceMetadata(view), nil
+}
+
+// VisualPreview returns the active canonical preview result for one exact
+// immutable content version, including unsupported and failed outcomes.
+func (v *Vault) VisualPreview(ctx context.Context, versionID string) (VisualPreview, error) {
+	if err := v.begin(); err != nil {
+		return VisualPreview{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	view, err := v.metadata.ContentVersionVisualPreview(ctx, versionID)
+	if err != nil {
+		return VisualPreview{}, err
+	}
+	return fromStoreVisualPreview(view), nil
+}
+
+// OpenVisualPreview opens verified canonical preview bytes for one exact
+// immutable content version. Call VisualPreview to inspect terminal failures.
+func (v *Vault) OpenVisualPreview(ctx context.Context, versionID string) (*VisualPreviewContent, error) {
+	if err := v.begin(); err != nil {
+		return nil, err
+	}
+	view, err := v.metadata.ContentVersionVisualPreview(ctx, versionID)
+	if err != nil {
+		v.lifecycle.RUnlock()
+		return nil, err
+	}
+	preview := fromStoreVisualPreview(view)
+	if view.Generation.Preview.State != document.VisualPreviewReady {
+		v.lifecycle.RUnlock()
+		return nil, fmt.Errorf("visual preview for version %q is %s: %w",
+			versionID, view.Generation.Preview.State, ErrVisualPreviewUnavailable)
+	}
+	output := view.Generation.Preview.Output
+	reader, size, err := v.blobs.OpenStreamContext(ctx, output.BlobSHA256)
+	if err != nil {
+		closeErr := closeContentReader(reader)
+		v.lifecycle.RUnlock()
+		return nil, errors.Join(fmt.Errorf(
+			"opening visual preview for version %q: %w: %w",
+			versionID, ErrContentUnavailable, err,
+		), closeErr)
+	}
+	if size != output.Size {
+		closeErr := reader.Close()
+		v.lifecycle.RUnlock()
+		return nil, errors.Join(fmt.Errorf(
+			"visual preview catalog size %d does not match physical size %d: %w",
+			output.Size, size, ErrContentUnavailable,
+		), closeErr)
+	}
+	return &VisualPreviewContent{
+		Preview: preview,
+		Reader:  &leasedReader{VerifiedReadCloser: reader, release: v.lifecycle.RUnlock},
+	}, nil
 }
 
 // PutOptions controls one embedded content write. Expected is optional; when

--- a/vault_test.go
+++ b/vault_test.go
@@ -135,6 +135,48 @@ func TestVaultSourceMetadataReturnsExactVersionEvidence(t *testing.T) {
 	assert.Equal(t, "/photos/image.jpg", metadata.Attachment.Path)
 }
 
+func TestVaultOpensVerifiedVisualPreviewForExactVersion(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	source := []byte("camera original")
+	created, err := vault.Create(t.Context(), "/photos/image.raw", bytes.NewReader(source), CreateOptions{
+		MediaType: "image/x-raw", Expected: contentIdentity(source),
+	})
+	require.NoError(t, err)
+	previewBytes := []byte("synthetic jpeg preview")
+	written, err := vault.blobs.WriteDetailedContext(t.Context(), bytes.NewReader(previewBytes))
+	require.NoError(t, err)
+	physical, err := blobPhysical(written)
+	require.NoError(t, err)
+	recipe := document.VisualPreviewRecipeV1{ContractVersion: document.VisualPreviewContractV1,
+		MaxEdgePixels: 2048, OutputMediaType: "image/jpeg", OrientationPolicy: "apply",
+		ColorPolicy: "srgb", FramePolicy: "primary", ProcessorFingerprint: strings.Repeat("4", 64)}
+	canonical, _, err := document.MarshalVisualPreviewV1(document.VisualPreviewV1{
+		ContractVersion: document.VisualPreviewContractV1, SourceSHA256: created.Version.BlobHash,
+		Recipe: recipe, State: document.VisualPreviewReady,
+		Output: &document.VisualPreviewOutputV1{BlobSHA256: written.Hash, Size: written.Size,
+			MediaType: "image/jpeg", Width: 1600, Height: 900},
+	})
+	require.NoError(t, err)
+	_, err = vault.metadata.PublishVisualPreview(t.Context(), created.Version.ID, canonical, &physical)
+	require.NoError(t, err)
+
+	status, err := vault.VisualPreview(t.Context(), created.Version.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.Version.ID, status.Version.ID)
+	assert.Equal(t, document.VisualPreviewReady, status.State)
+
+	content, err := vault.OpenVisualPreview(t.Context(), created.Version.ID)
+	require.NoError(t, err)
+	data, err := io.ReadAll(content.Reader)
+	require.NoError(t, err)
+	require.NoError(t, content.Reader.Verify())
+	require.NoError(t, content.Reader.Close())
+	assert.Equal(t, previewBytes, data)
+}
+
 func TestLeasedLimitedReaderShortRead(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "short.bin")
 	require.NoError(t, os.WriteFile(path, []byte("12"), 0o600))


### PR DESCRIPTION
Docbank can now retain a canonical visual preview result for an exact content version and let embedded applications inspect or stream it. This gives photo and video applications one shared derivative identity and lifecycle instead of forcing each application to build its own preview catalog.

A ready result records the exact output bytes, media type, and dimensions. Unsupported formats and deterministic decoding failures remain queryable outcomes without pretending that preview content exists. The complete recipe is fingerprinted so decoder, scaling, color, orientation, frame-selection, or encoder changes create a new immutable result.

Preview metadata and bytes participate in backup and restore, integrity validation, derivative reporting, and garbage collection. Deleting the source content version releases its preview catalog, while content-addressed storage still deduplicates identical preview bytes across versions.

The embedded API now exposes preview status and verified preview reads. This change establishes the storage contract only; automatic image, camera RAW, and video producers will follow separately.