### PR TITLE
Process source metadata through the embedded API

### DIFF
--- a/docs/architecture/source-metadata.md
+++ b/docs/architecture/source-metadata.md
@@ -82,7 +82,10 @@ Embedded applications call `Vault.EnsureSourceMetadata` with an immutable
 content version ID to run the current local extractor synchronously for those
 exact bytes, or `Vault.SourceMetadata` for a read-only lookup. Ensuring an
 already-current generation is idempotent and does not start the daemon worker
-or scan unrelated content. Missing or corrupt physical source bytes retain the
-embedded API's `ErrContentUnavailable` identity. All read surfaces bind fields
-to the requested version and keep filename, path, ingest time, and filesystem
-time in separate attachment facts.
+or scan unrelated content. The ensure operation shares the vault mutation gate
+with content writes and physical maintenance, so its exact-version lookup,
+verified read, publication, and final result cannot straddle an authority
+change. Missing or corrupt physical source bytes retain the embedded API's
+`ErrContentUnavailable` identity. All read surfaces bind fields to the
+requested version and keep filename, path, ingest time, and filesystem time in
+separate attachment facts.

--- a/docs/architecture/source-metadata.md
+++ b/docs/architecture/source-metadata.md
@@ -78,6 +78,11 @@ content SHA-256; old generations remain evidence. Retrying the same generation
 is idempotent.
 
 The HTTP node and content-version detail surfaces return the active generation.
-Embedded applications call `Vault.SourceMetadata` with an immutable content
-version ID. Both surfaces bind fields to the requested version and keep
-filename, path, ingest time, and filesystem time in separate attachment facts.
+Embedded applications call `Vault.EnsureSourceMetadata` with an immutable
+content version ID to run the current local extractor synchronously for those
+exact bytes, or `Vault.SourceMetadata` for a read-only lookup. Ensuring an
+already-current generation is idempotent and does not start the daemon worker
+or scan unrelated content. Missing or corrupt physical source bytes retain the
+embedded API's `ErrContentUnavailable` identity. All read surfaces bind fields
+to the requested version and keep filename, path, ingest time, and filesystem
+time in separate attachment facts.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -126,14 +126,15 @@ until the external-reference contract is implemented.
 whether those bytes are stored raw, zstd-compressed, or in a pack. SHA-256 is
 the canonical logical identity, not a digest of a physical storage file.
 
-## Read extracted source metadata
+## Extract and read source metadata
 
-`SourceMetadata` returns Docbank's typed metadata for one immutable content
-version. The result carries the complete `ContentVersion`, so callers can bind
-the facts to the exact SHA-256 and node version they describe:
+`EnsureSourceMetadata` verifies and processes one immutable content version
+with Docbank's current local extractor, then returns its typed metadata. The
+result carries the complete `ContentVersion`, so callers can bind the facts to
+the exact SHA-256 and node version they describe:
 
 ```go
-metadata, err := vault.SourceMetadata(ctx, receipt.Version.ID)
+metadata, err := vault.EnsureSourceMetadata(ctx, receipt.Version.ID)
 if err != nil {
     return err
 }
@@ -143,11 +144,14 @@ for _, field := range metadata.Fields {
 }
 ```
 
-If Docbank has not published metadata for the version's bytes, the method
-returns `ErrNotFound`. Opening an embedded vault does not start processing
-workers. The embedded API returns all local fields, including fields marked
-sensitive. The embedding application must decide what it may disclose to its
-own users and transports.
+The operation is synchronous, local, and scoped to the requested version. It
+reuses the current extractor generation when one already exists and does not
+start background workers or process other content. It returns
+`ErrContentUnavailable` when the cataloged source bytes cannot be opened or
+verified. `SourceMetadata` remains a read-only lookup and returns `ErrNotFound`
+when no generation has been published. Both methods return all local fields,
+including fields marked sensitive. The embedding application must decide what
+it may disclose to its own users and transports.
 
 ## Read canonical visual previews
 

--- a/internal/processing/source_metadata.go
+++ b/internal/processing/source_metadata.go
@@ -58,12 +58,19 @@ var (
 	// in verified bytes, which become durable warnings rather than retryable
 	// storage errors.
 	errSourceMetadataBMFFMalformed = errors.New("malformed ISO base media file structure")
+	errSourceContentUnavailable    = errors.New("source content unavailable")
 
 	sourceMetadataCanonUUID = [16]byte{
 		0x85, 0xc0, 0xb6, 0x87, 0x82, 0x0f, 0x11, 0xe0,
 		0x81, 0x11, 0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48,
 	}
 )
+
+// IsSourceContentUnavailable reports whether source metadata processing could
+// not open or verify the catalog-authorized source bytes.
+func IsSourceContentUnavailable(err error) bool {
+	return errors.Is(err, errSourceContentUnavailable)
+}
 
 func fingerprintSourceMetadataExtractor(descriptor string) string {
 	digest := sha256.Sum256([]byte(descriptor))
@@ -127,19 +134,21 @@ func sourceMetadataForTarget(
 	if target.Size <= maxSourceMetadataOriginalBytes {
 		stream, size, err := blobs.OpenStreamContext(ctx, target.SourceSHA256)
 		if err != nil {
-			return document.SourceMetadataV1{}, fmt.Errorf("opening verified stream: %w", err)
+			return document.SourceMetadataV1{}, sourceContentUnavailable(
+				fmt.Errorf("opening verified stream: %w", err))
 		}
 		if size != target.Size {
-			return document.SourceMetadataV1{}, errors.Join(
-				fmt.Errorf("size changed: catalog=%d opened=%d", target.Size, size), stream.Close())
+			return document.SourceMetadataV1{}, sourceContentUnavailable(errors.Join(
+				fmt.Errorf("size changed: catalog=%d opened=%d", target.Size, size), stream.Close()))
 		}
 		data, readErr := io.ReadAll(io.LimitReader(stream, size+1))
 		if err := errors.Join(readErr, stream.Close()); err != nil {
-			return document.SourceMetadataV1{}, fmt.Errorf("verifying stream: %w", err)
+			return document.SourceMetadataV1{}, sourceContentUnavailable(
+				fmt.Errorf("verifying stream: %w", err))
 		}
 		if int64(len(data)) != size {
-			return document.SourceMetadataV1{}, fmt.Errorf(
-				"length changed: catalog=%d read=%d", size, len(data))
+			return document.SourceMetadataV1{}, sourceContentUnavailable(fmt.Errorf(
+				"length changed: catalog=%d read=%d", size, len(data)))
 		}
 		if size > maxSourceMetadataWindowBytes && boundedLargeMediaSignature(data) {
 			return extractLargeSourceMetadata(bytes.NewReader(data), size)
@@ -149,17 +158,23 @@ func sourceMetadataForTarget(
 
 	reader, size, err := blobs.OpenSeekableContext(ctx, target.SourceSHA256)
 	if err != nil {
-		return document.SourceMetadataV1{}, fmt.Errorf("opening seekable content: %w", err)
+		return document.SourceMetadataV1{}, sourceContentUnavailable(
+			fmt.Errorf("opening seekable content: %w", err))
 	}
 	if size != target.Size {
-		return document.SourceMetadataV1{}, errors.Join(
-			fmt.Errorf("size changed: catalog=%d opened=%d", target.Size, size), reader.Close())
+		return document.SourceMetadataV1{}, sourceContentUnavailable(errors.Join(
+			fmt.Errorf("size changed: catalog=%d opened=%d", target.Size, size), reader.Close()))
 	}
 	if err := verifySeekableSource(ctx, reader, target.SourceSHA256, size); err != nil {
-		return document.SourceMetadataV1{}, errors.Join(fmt.Errorf("verifying seekable content: %w", err), reader.Close())
+		return document.SourceMetadataV1{}, sourceContentUnavailable(errors.Join(
+			fmt.Errorf("verifying seekable content: %w", err), reader.Close()))
 	}
 	metadata, extractErr := extractLargeSourceMetadata(&seekReaderAt{seeker: reader}, size)
 	return metadata, errors.Join(extractErr, reader.Close())
+}
+
+func sourceContentUnavailable(err error) error {
+	return errors.Join(errSourceContentUnavailable, err)
 }
 
 func emptySourceMetadata() document.SourceMetadataV1 {

--- a/vault.go
+++ b/vault.go
@@ -125,6 +125,9 @@ type Vault struct {
 	// testAfterWriteCommit exercises receipt completion after a Put or Create
 	// metadata mutation commits. Production constructors leave it nil.
 	testAfterWriteCommit func()
+	// testAfterSourceMetadataPublication exercises mutation ownership between
+	// metadata publication and the final exact-version read.
+	testAfterSourceMetadataPublication func()
 }
 
 // New creates or opens one embedded vault and holds its exclusive hierarchy
@@ -383,6 +386,11 @@ func (v *Vault) EnsureSourceMetadata(ctx context.Context, versionID string) (Sou
 		return SourceMetadata{}, err
 	}
 	defer v.lifecycle.RUnlock()
+	v.mutation.Lock()
+	defer v.mutation.Unlock()
+	if err := ctx.Err(); err != nil {
+		return SourceMetadata{}, err
+	}
 	version, err := v.metadata.ContentVersionByID(ctx, versionID)
 	if err != nil {
 		return SourceMetadata{}, err
@@ -406,6 +414,9 @@ func (v *Vault) EnsureSourceMetadata(ctx context.Context, versionID string) (Sou
 			)
 		}
 		return SourceMetadata{}, fmt.Errorf("ensuring source metadata for content version %q: %w", versionID, err)
+	}
+	if v.testAfterSourceMetadataPublication != nil {
+		v.testAfterSourceMetadataPublication()
 	}
 	view, err = v.metadata.ContentVersionSourceMetadata(ctx, versionID)
 	if err != nil {

--- a/vault.go
+++ b/vault.go
@@ -24,6 +24,7 @@ import (
 	internalconfig "go.kenn.io/docbank/internal/config"
 	"go.kenn.io/docbank/internal/home"
 	internalmaintenance "go.kenn.io/docbank/internal/maintenance"
+	internalprocessing "go.kenn.io/docbank/internal/processing"
 	"go.kenn.io/docbank/internal/store"
 	docsqlite "go.kenn.io/docbank/sqlite"
 )
@@ -367,6 +368,46 @@ func (v *Vault) SourceMetadata(ctx context.Context, versionID string) (SourceMet
 	}
 	defer v.lifecycle.RUnlock()
 	view, err := v.metadata.ContentVersionSourceMetadata(ctx, versionID)
+	if err != nil {
+		return SourceMetadata{}, err
+	}
+	return fromStoreSourceMetadata(view), nil
+}
+
+// EnsureSourceMetadata returns current local metadata for one exact immutable
+// content version. When the current extractor has not processed those bytes,
+// it verifies and processes them synchronously before returning. Retrying the
+// same version and extractor generation is idempotent.
+func (v *Vault) EnsureSourceMetadata(ctx context.Context, versionID string) (SourceMetadata, error) {
+	if err := v.begin(); err != nil {
+		return SourceMetadata{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	version, err := v.metadata.ContentVersionByID(ctx, versionID)
+	if err != nil {
+		return SourceMetadata{}, err
+	}
+	view, err := v.metadata.ContentVersionSourceMetadata(ctx, versionID)
+	if err == nil && view.Generation.ExtractorFingerprint == internalprocessing.SourceMetadataExtractorFingerprint {
+		return fromStoreSourceMetadata(view), nil
+	}
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return SourceMetadata{}, err
+	}
+	_, err = internalprocessing.BackfillSourceMetadataTargets(ctx, v.metadata, v.blobs, []store.SourceMetadataTarget{{
+		SourceSHA256: version.BlobHash,
+		Size:         version.Size,
+	}})
+	if err != nil {
+		if internalprocessing.IsSourceContentUnavailable(err) {
+			return SourceMetadata{}, fmt.Errorf(
+				"ensuring source metadata for content version %q: %w: %w",
+				versionID, ErrContentUnavailable, err,
+			)
+		}
+		return SourceMetadata{}, fmt.Errorf("ensuring source metadata for content version %q: %w", versionID, err)
+	}
+	view, err = v.metadata.ContentVersionSourceMetadata(ctx, versionID)
 	if err != nil {
 		return SourceMetadata{}, err
 	}

--- a/vault_external_test.go
+++ b/vault_external_test.go
@@ -484,6 +484,43 @@ func TestOpenVersionContentClassifiesPhysicalContentFailures(t *testing.T) {
 	}
 }
 
+func TestEnsureSourceMetadataClassifiesPhysicalContentFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		corrupt func(*testing.T, string)
+	}{
+		{
+			name: "missing blob",
+			corrupt: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.Remove(path))
+			},
+		},
+		{
+			name: "corrupt blob",
+			corrupt: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(path, []byte("corrupt"), 0o600))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			vault, err := docbank.New(t.Context(), docbank.Config{Root: root})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+			receipt := createRangeFixture(t, vault, "/source.bin", []byte("source metadata bytes"))
+			test.corrupt(t, looseBlobPath(root, receipt.Computed.SHA256))
+
+			_, err = vault.EnsureSourceMetadata(t.Context(), receipt.Version.ID)
+			require.ErrorIs(t, err, docbank.ErrContentUnavailable)
+		})
+	}
+}
+
 func TestContentMetadataErrorsRemainDistinctFromPhysicalUnavailability(t *testing.T) {
 	root := t.TempDir()
 	vault, err := docbank.New(t.Context(), docbank.Config{Root: root})

--- a/vault_test.go
+++ b/vault_test.go
@@ -135,6 +135,82 @@ func TestVaultSourceMetadataReturnsExactVersionEvidence(t *testing.T) {
 	assert.Equal(t, "/photos/image.jpg", metadata.Attachment.Path)
 }
 
+func TestVaultEnsureSourceMetadataProcessesExactVersion(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	firstContent := []byte("BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nSUMMARY:First event\r\nDTSTART:20240102T030405Z\r\nEND:VEVENT\r\nEND:VCALENDAR")
+	first, err := vault.Create(t.Context(), "/calendar.ics", bytes.NewReader(firstContent), CreateOptions{
+		MediaType: "text/calendar", Expected: contentIdentity(firstContent),
+	})
+	require.NoError(t, err)
+	secondContent := []byte("BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nSUMMARY:Second event\r\nDTSTART:20240203T040506Z\r\nEND:VEVENT\r\nEND:VCALENDAR")
+	_, err = vault.Put(t.Context(), "/calendar.ics", bytes.NewReader(secondContent), PutOptions{
+		MediaType: "text/calendar", Expected: new(contentIdentity(secondContent)),
+	})
+	require.NoError(t, err)
+
+	metadata, err := vault.EnsureSourceMetadata(t.Context(), first.Version.ID)
+	require.NoError(t, err)
+	assert.Equal(t, first.Version.ID, metadata.Version.ID)
+	assert.Empty(t, metadata.Attachment.Path)
+	var title string
+	for _, field := range metadata.Fields {
+		if field.Key == "title" {
+			title = field.Value.String
+		}
+	}
+	assert.Equal(t, "First event", title)
+
+	retry, err := vault.EnsureSourceMetadata(t.Context(), first.Version.ID)
+	require.NoError(t, err)
+	assert.Equal(t, metadata, retry)
+}
+
+func TestVaultEnsureSourceMetadataRefreshesOldExtractorGeneration(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	content := []byte("BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nSUMMARY:Current event\r\nEND:VEVENT\r\nEND:VCALENDAR")
+	receipt, err := vault.Create(t.Context(), "/calendar.ics", bytes.NewReader(content), CreateOptions{
+		MediaType: "text/calendar", Expected: contentIdentity(content),
+	})
+	require.NoError(t, err)
+	staleCanonical, _, err := document.MarshalSourceMetadataV1(document.SourceMetadataV1{
+		ContractVersion: document.SourceMetadataContractV1,
+		Fields: []document.SourceMetadataFieldV1{{
+			Key: "title", Namespace: "calendar", SourceField: "SUMMARY",
+			Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataString, String: "Stale event"},
+		}},
+	})
+	require.NoError(t, err)
+	staleFingerprint := contentIdentity([]byte("old extractor")).SHA256
+	_, err = vault.metadata.PublishSourceMetadata(t.Context(), receipt.Version.BlobHash, staleFingerprint, staleCanonical)
+	require.NoError(t, err)
+
+	metadata, err := vault.EnsureSourceMetadata(t.Context(), receipt.Version.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, staleFingerprint, metadata.ExtractorFingerprint)
+	var title string
+	for _, field := range metadata.Fields {
+		if field.Key == "title" {
+			title = field.Value.String
+		}
+	}
+	assert.Equal(t, "Current event", title)
+}
+
+func TestVaultEnsureSourceMetadataRejectsUnknownVersion(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	_, err = vault.EnsureSourceMetadata(t.Context(), "00000000-0000-4000-8000-000000000000")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestVaultOpensVerifiedVisualPreviewForExactVersion(t *testing.T) {
 	vault, err := New(t.Context(), Config{Root: t.TempDir()})
 	require.NoError(t, err)

--- a/vault_test.go
+++ b/vault_test.go
@@ -211,6 +211,112 @@ func TestVaultEnsureSourceMetadataRejectsUnknownVersion(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestVaultEnsureSourceMetadataWaitsForActiveMutation(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	source := []byte("source metadata bytes")
+	receipt, err := vault.Create(t.Context(), "/source.bin", bytes.NewReader(source), CreateOptions{
+		MediaType: "application/octet-stream", Expected: contentIdentity(source),
+	})
+	require.NoError(t, err)
+
+	mutationActive := make(chan struct{})
+	releaseMutation := make(chan struct{})
+	vault.testAfterWriteCommit = func() {
+		close(mutationActive)
+		<-releaseMutation
+	}
+	putDone := make(chan error, 1)
+	go func() {
+		other := []byte("other bytes")
+		_, putErr := vault.Put(t.Context(), "/other.bin", bytes.NewReader(other), PutOptions{
+			MediaType: "application/octet-stream", Expected: new(contentIdentity(other)),
+		})
+		putDone <- putErr
+	}()
+	<-mutationActive
+
+	ensureDone := make(chan error, 1)
+	go func() {
+		_, ensureErr := vault.EnsureSourceMetadata(t.Context(), receipt.Version.ID)
+		ensureDone <- ensureErr
+	}()
+	timer := time.NewTimer(100 * time.Millisecond)
+	var earlyErr error
+	returnedEarly := false
+	select {
+	case earlyErr = <-ensureDone:
+		returnedEarly = true
+	case <-timer.C:
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	close(releaseMutation)
+	require.NoError(t, <-putDone)
+	require.False(t, returnedEarly,
+		"source metadata processing returned during an active mutation: %v", earlyErr)
+	require.NoError(t, <-ensureDone)
+}
+
+func TestVaultEnsureSourceMetadataHoldsMutationThroughFinalRead(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	source := []byte("source metadata bytes")
+	receipt, err := vault.Create(t.Context(), "/source.bin", bytes.NewReader(source), CreateOptions{
+		MediaType: "application/octet-stream", Expected: contentIdentity(source),
+	})
+	require.NoError(t, err)
+
+	metadataPublished := make(chan struct{})
+	releaseEnsure := make(chan struct{})
+	vault.testAfterSourceMetadataPublication = func() {
+		close(metadataPublished)
+		<-releaseEnsure
+	}
+	ensureDone := make(chan error, 1)
+	go func() {
+		_, ensureErr := vault.EnsureSourceMetadata(t.Context(), receipt.Version.ID)
+		ensureDone <- ensureErr
+	}()
+	<-metadataPublished
+
+	putDone := make(chan error, 1)
+	go func() {
+		other := []byte("other bytes")
+		_, putErr := vault.Put(t.Context(), "/other.bin", bytes.NewReader(other), PutOptions{
+			MediaType: "application/octet-stream", Expected: new(contentIdentity(other)),
+		})
+		putDone <- putErr
+	}()
+	timer := time.NewTimer(100 * time.Millisecond)
+	var earlyErr error
+	returnedEarly := false
+	select {
+	case earlyErr = <-putDone:
+		returnedEarly = true
+	case <-timer.C:
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	close(releaseEnsure)
+	require.NoError(t, <-ensureDone)
+	require.False(t, returnedEarly,
+		"content write returned before source metadata's final read: %v", earlyErr)
+	require.NoError(t, <-putDone)
+}
+
 func TestVaultOpensVerifiedVisualPreviewForExactVersion(t *testing.T) {
 	vault, err := New(t.Context(), Config{Root: t.TempDir()})
 	require.NoError(t, err)


### PR DESCRIPTION
Applications that embed Docbank can now extract current source metadata for one exact content version in the same call that returns it. A current generation returns immediately; otherwise Docbank verifies and processes only the requested immutable bytes without starting background workers or scanning the vault.

Processing shares the vault mutation boundary used by content writes and storage maintenance, so the version lookup, verified read, publication, and returned result see one stable authority. Missing or corrupt source bytes return the same unavailable-content error used by embedded content reads. The existing read-only metadata method remains available when callers do not want processing.
