### PR TITLE
Produce canonical previews for JPEG originals

### DIFF
--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -55,6 +55,22 @@ and `Vault.OpenVisualPreview` to stream a ready output through the verified
 reader contract. Unsupported and failed results remain queryable but do not
 open as content.
 
-Docbank does not yet produce previews automatically. The catalog and read
-boundary are in place so format-specific producers can be added without
-changing preview identity, retention, backup, or application integration.
+`Vault.EnsureVisualPreview` synchronously produces the current preview for one
+exact version when no matching generation exists. It verifies the complete
+source before decoding and holds the vault mutation boundary through
+publication, so callers either observe a complete generation or a retryable
+error.
+
+The built-in producer currently accepts grayscale and three-component JPEG
+originals with absent or explicitly sRGB color metadata and no embedded ICC
+profile. It rejects CMYK and YCCK rather than applying an unmanaged color
+conversion. Accepted images have EXIF orientation applied, scale without
+upscaling to a 2048-pixel maximum edge, and encode as a quality-90 JPEG.
+Malformed JPEG bytes become a durable `failed` result; unsupported media types,
+JPEG features, and color profiles become a durable `unsupported` result. Read,
+verification, storage, and cancellation failures are retryable.
+
+Preview production is application-driven: opening a vault does not start a
+worker. Other still-image formats, camera RAW files, video frames, and color
+conversion require additional producers, but they use the same generation,
+retention, backup, and read contracts.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -155,13 +155,13 @@ it may disclose to its own users and transports.
 
 ## Read canonical visual previews
 
-`VisualPreview` returns the active result for one immutable content version.
-Ready results identify exact preview bytes and dimensions; unsupported and
-failed results carry a stable failure code without pretending that content is
-available.
+`EnsureVisualPreview` synchronously produces or reuses the current built-in
+preview for one immutable content version. Ready results identify exact preview
+bytes and dimensions; unsupported and failed results carry a stable failure
+code without pretending that content is available.
 
 ```go
-preview, err := vault.VisualPreview(ctx, versionID)
+preview, err := vault.EnsureVisualPreview(ctx, versionID)
 if err != nil {
     return err
 }
@@ -177,9 +177,10 @@ if preview.State == document.VisualPreviewReady {
 
 `OpenVisualPreview` uses the same verified-reader contract as original
 content. It returns `ErrVisualPreviewUnavailable` for a cataloged unsupported
-or failed result and `ErrNotFound` when no preview result exists. Opening an
-embedded vault does not start a preview producer; applications can read results
-after a processing owner has published them.
+or failed result and `ErrNotFound` when no preview result exists.
+`VisualPreview` remains a read-only lookup. Opening an embedded vault does not
+start a preview worker; applications choose when to call the synchronous
+producer.
 
 Both write receipts include `Physical`, which distinguishes logical bytes from
 their current raw, zstd, or packed representation. Most applications should

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/tdewolff/parse/v2 v2.8.16
 	github.com/yuin/goldmark v1.7.17
 	go.kenn.io/kit v0.17.1
+	golang.org/x/image v0.44.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
@@ -83,7 +84,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/image v0.44.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.73.4 // indirect

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -1,0 +1,346 @@
+package processing
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/jpeg"
+	"io"
+	"runtime"
+
+	xdraw "golang.org/x/image/draw"
+
+	"go.kenn.io/docbank/document"
+)
+
+const (
+	visualPreviewMaxEdgePixels   = 2048
+	visualPreviewMaxSourcePixels = 100_000_000
+	visualPreviewJPEGQuality     = 90
+	visualPreviewMaxJPEGSegments = 1024
+)
+
+var visualPreviewRecipe = document.VisualPreviewRecipeV1{
+	ContractVersion:   document.VisualPreviewContractV1,
+	MaxEdgePixels:     visualPreviewMaxEdgePixels,
+	OutputMediaType:   "image/jpeg",
+	OrientationPolicy: "apply",
+	ColorPolicy:       "srgb",
+	FramePolicy:       "primary",
+	ProcessorFingerprint: fingerprintVisualPreviewProcessor(
+		"docbank-visual-preview:jpeg-stdlib-" + runtime.Version() +
+			"+x-image-draw-v0.44.0:max-edge=2048:quality=90:v1"),
+}
+
+// VisualPreviewTarget identifies one exact immutable source to process.
+type VisualPreviewTarget struct {
+	SourceSHA256 string
+	Size         int64
+	MediaType    string
+}
+
+// VisualPreviewProduct is one canonical result and any ready output bytes.
+type VisualPreviewProduct struct {
+	Preview document.VisualPreviewV1
+	Output  []byte
+}
+
+// CurrentVisualPreviewRecipe returns the complete built-in preview identity.
+func CurrentVisualPreviewRecipe() document.VisualPreviewRecipeV1 {
+	return visualPreviewRecipe
+}
+
+// ProduceVisualPreview verifies and processes one exact source. Deterministic
+// source failures become terminal results; storage and verification failures
+// remain retryable errors.
+func ProduceVisualPreview(
+	ctx context.Context, source io.ReadSeeker, target VisualPreviewTarget,
+) (VisualPreviewProduct, error) {
+	base := document.VisualPreviewV1{
+		ContractVersion: document.VisualPreviewContractV1,
+		SourceSHA256:    target.SourceSHA256,
+		Recipe:          CurrentVisualPreviewRecipe(),
+	}
+	if err := verifySeekableSource(ctx, source, target.SourceSHA256, target.Size); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("verifying visual preview source: %w", err))
+	}
+	if target.MediaType != "image/jpeg" {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_media_type", Detail: "the built-in preview producer supports JPEG originals",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	orientation, unsupportedColor, malformed, err := inspectVisualPreviewJPEG(ctx, source)
+	if err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("inspecting visual preview JPEG: %w", err))
+	}
+	if malformed {
+		return failedVisualPreview(base, "decode_failed", "the verified JPEG header is malformed"), nil
+	}
+	if unsupportedColor {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_color_profile", Detail: "the built-in preview producer requires sRGB JPEG originals",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("seeking visual preview source: %w", err))
+	}
+	config, err := jpeg.DecodeConfig(source)
+	if err != nil {
+		return visualPreviewJPEGDecodeResult(base, "the verified JPEG header is malformed", err)
+	}
+	if !visualPreviewJPEGColorModelSupported(config.ColorModel) {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_color_profile", Detail: "the built-in preview producer requires sRGB JPEG originals",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if config.Width < 1 || config.Height < 1 ||
+		int64(config.Width)*int64(config.Height) > visualPreviewMaxSourcePixels {
+		return failedVisualPreview(base, "source_dimensions_exceed_limit",
+			"the JPEG dimensions exceed the built-in preview limit"), nil
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("seeking visual preview source: %w", err))
+	}
+	decoded, err := jpeg.Decode(source)
+	if err != nil {
+		return visualPreviewJPEGDecodeResult(base, "the verified JPEG cannot be decoded", err)
+	}
+	if decoded.Bounds().Dx() != config.Width || decoded.Bounds().Dy() != config.Height {
+		return failedVisualPreview(base, "decode_failed", "the JPEG dimensions changed during decoding"), nil
+	}
+	orientedWidth, orientedHeight := visualPreviewOrientedDimensions(config.Width, config.Height, orientation)
+	width, height := boundedVisualPreviewDimensions(orientedWidth, orientedHeight)
+	resizeWidth, resizeHeight := width, height
+	if visualPreviewOrientationSwapsDimensions(orientation) {
+		resizeWidth, resizeHeight = height, width
+	}
+	resized := image.NewNRGBA(image.Rect(0, 0, resizeWidth, resizeHeight))
+	if resizeWidth == config.Width && resizeHeight == config.Height {
+		draw.Draw(resized, resized.Bounds(), decoded, decoded.Bounds().Min, draw.Src)
+	} else {
+		xdraw.CatmullRom.Scale(resized, resized.Bounds(), decoded, decoded.Bounds(), draw.Src, nil)
+	}
+	preview := applyVisualPreviewOrientation(resized, orientation)
+	var encoded bytes.Buffer
+	if err := jpeg.Encode(&encoded, preview, &jpeg.Options{Quality: visualPreviewJPEGQuality}); err != nil {
+		return VisualPreviewProduct{}, fmt.Errorf("encoding visual preview: %w", err)
+	}
+	output := encoded.Bytes()
+	digest := sha256.Sum256(output)
+	base.State = document.VisualPreviewReady
+	base.Output = &document.VisualPreviewOutputV1{
+		BlobSHA256: hex.EncodeToString(digest[:]), Size: int64(len(output)),
+		MediaType: "image/jpeg", Width: width, Height: height,
+	}
+	return VisualPreviewProduct{Preview: base, Output: output}, nil
+}
+
+func inspectVisualPreviewJPEG(
+	ctx context.Context, source io.ReadSeeker,
+) (orientation int, unsupportedColor, malformed bool, err error) {
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return 0, false, false, err
+	}
+	var signature [2]byte
+	if _, err := io.ReadFull(source, signature[:]); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return 0, false, true, nil
+		}
+		return 0, false, false, err
+	}
+	if signature != [2]byte{0xff, 0xd8} {
+		return 0, false, true, nil
+	}
+	orientation = 1
+	for range visualPreviewMaxJPEGSegments {
+		if err := ctx.Err(); err != nil {
+			return 0, false, false, err
+		}
+		marker, markerErr := readVisualPreviewJPEGMarker(source)
+		if markerErr != nil {
+			if errors.Is(markerErr, io.EOF) || errors.Is(markerErr, io.ErrUnexpectedEOF) {
+				return 0, false, true, nil
+			}
+			return 0, false, false, markerErr
+		}
+		if marker == 0xd9 || marker == 0xda {
+			return orientation, unsupportedColor, false, nil
+		}
+		if marker == 0x01 || marker >= 0xd0 && marker <= 0xd7 {
+			continue
+		}
+		var lengthBytes [2]byte
+		if _, err := io.ReadFull(source, lengthBytes[:]); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				return 0, false, true, nil
+			}
+			return 0, false, false, err
+		}
+		length := int(binary.BigEndian.Uint16(lengthBytes[:]))
+		if length < 2 {
+			return 0, false, true, nil
+		}
+		payload := make([]byte, length-2)
+		if _, err := io.ReadFull(source, payload); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				return 0, false, true, nil
+			}
+			return 0, false, false, err
+		}
+		switch {
+		case marker == 0xe1 && bytes.HasPrefix(payload, []byte("Exif\x00\x00")):
+			if exifOrientation, colorSpace, found := visualPreviewEXIF(payload[6:]); found {
+				orientation = exifOrientation
+				unsupportedColor = unsupportedColor || colorSpace != 0 && colorSpace != 1
+			}
+		case marker == 0xe2 && bytes.HasPrefix(payload, []byte("ICC_PROFILE\x00")):
+			unsupportedColor = true
+		}
+	}
+	return 0, false, true, nil
+}
+
+func readVisualPreviewJPEGMarker(source io.Reader) (byte, error) {
+	var value [1]byte
+	for {
+		if _, err := io.ReadFull(source, value[:]); err != nil {
+			return 0, err
+		}
+		if value[0] != 0xff {
+			return 0, io.ErrUnexpectedEOF
+		}
+		for value[0] == 0xff {
+			if _, err := io.ReadFull(source, value[:]); err != nil {
+				return 0, err
+			}
+		}
+		if value[0] != 0x00 {
+			return value[0], nil
+		}
+	}
+}
+
+func visualPreviewEXIF(data []byte) (orientation, colorSpace int, found bool) {
+	reader, root, ok := sourceMetadataTIFFRoot(data)
+	if !ok {
+		return 1, 0, false
+	}
+	orientation = 1
+	if value, ok := exifUnsigned(reader, root[0x0112]); ok && value >= 1 && value <= 8 {
+		orientation = int(value)
+	}
+	if raw := root[0x8769]; len(raw) >= 4 {
+		exif := reader.entries(reader.order.Uint32(raw))
+		if value, ok := exifUnsigned(reader, exif[0xa001]); ok {
+			colorSpace = int(value)
+		}
+	}
+	return orientation, colorSpace, true
+}
+
+func visualPreviewJPEGColorModelSupported(model color.Model) bool {
+	_, cmyk := model.Convert(color.Black).(color.CMYK)
+	return !cmyk
+}
+
+func visualPreviewJPEGDecodeResult(
+	base document.VisualPreviewV1, malformedDetail string, err error,
+) (VisualPreviewProduct, error) {
+	if _, ok := errors.AsType[jpeg.UnsupportedError](err); ok {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_jpeg_feature", Detail: "the JPEG uses a feature unavailable to the built-in decoder",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if _, ok := errors.AsType[jpeg.FormatError](err); ok {
+		return failedVisualPreview(base, "decode_failed", malformedDetail), nil
+	}
+	return VisualPreviewProduct{}, sourceContentUnavailable(
+		fmt.Errorf("reading visual preview JPEG: %w", err))
+}
+
+func visualPreviewOrientationSwapsDimensions(orientation int) bool {
+	return orientation >= 5 && orientation <= 8
+}
+
+func visualPreviewOrientedDimensions(width, height, orientation int) (int, int) {
+	if visualPreviewOrientationSwapsDimensions(orientation) {
+		return height, width
+	}
+	return width, height
+}
+
+func applyVisualPreviewOrientation(source *image.NRGBA, orientation int) *image.NRGBA {
+	if orientation == 1 {
+		return source
+	}
+	width, height := source.Bounds().Dx(), source.Bounds().Dy()
+	outputWidth, outputHeight := visualPreviewOrientedDimensions(width, height, orientation)
+	output := image.NewNRGBA(image.Rect(0, 0, outputWidth, outputHeight))
+	for y := range outputHeight {
+		for x := range outputWidth {
+			sourceX, sourceY := x, y
+			switch orientation {
+			case 2:
+				sourceX = width - 1 - x
+			case 3:
+				sourceX, sourceY = width-1-x, height-1-y
+			case 4:
+				sourceY = height - 1 - y
+			case 5:
+				sourceX, sourceY = y, x
+			case 6:
+				sourceX, sourceY = y, height-1-x
+			case 7:
+				sourceX, sourceY = width-1-y, height-1-x
+			case 8:
+				sourceX, sourceY = width-1-y, x
+			}
+			output.SetNRGBA(x, y, source.NRGBAAt(sourceX, sourceY))
+		}
+	}
+	return output
+}
+
+func fingerprintVisualPreviewProcessor(descriptor string) string {
+	digest := sha256.Sum256([]byte(descriptor))
+	return hex.EncodeToString(digest[:])
+}
+
+func failedVisualPreview(
+	base document.VisualPreviewV1, code, detail string,
+) VisualPreviewProduct {
+	base.State = document.VisualPreviewFailed
+	base.Failure = &document.VisualPreviewFailureV1{Code: code, Detail: detail}
+	return VisualPreviewProduct{Preview: base}
+}
+
+func boundedVisualPreviewDimensions(width, height int) (int, int) {
+	if width <= visualPreviewMaxEdgePixels && height <= visualPreviewMaxEdgePixels {
+		return width, height
+	}
+	if width >= height {
+		return visualPreviewMaxEdgePixels,
+			max(1, (height*visualPreviewMaxEdgePixels+width/2)/width)
+	}
+	return max(1, (width*visualPreviewMaxEdgePixels+height/2)/height),
+		visualPreviewMaxEdgePixels
+}

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -13,6 +13,7 @@ import (
 	"image/draw"
 	"image/jpeg"
 	"io"
+	"mime"
 	"runtime"
 
 	xdraw "golang.org/x/image/draw"
@@ -72,7 +73,7 @@ func ProduceVisualPreview(
 		return VisualPreviewProduct{}, sourceContentUnavailable(
 			fmt.Errorf("verifying visual preview source: %w", err))
 	}
-	if target.MediaType != "image/jpeg" {
+	if !visualPreviewSupportsMediaType(target.MediaType) {
 		base.State = document.VisualPreviewUnsupported
 		base.Failure = &document.VisualPreviewFailureV1{
 			Code: "unsupported_media_type", Detail: "the built-in preview producer supports JPEG originals",
@@ -150,6 +151,11 @@ func ProduceVisualPreview(
 		MediaType: "image/jpeg", Width: width, Height: height,
 	}
 	return VisualPreviewProduct{Preview: base, Output: output}, nil
+}
+
+func visualPreviewSupportsMediaType(value string) bool {
+	mediaType, _, err := mime.ParseMediaType(value)
+	return err == nil && mediaType == "image/jpeg"
 }
 
 func inspectVisualPreviewJPEG(

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -270,7 +270,8 @@ func visualPreviewJPEGDecodeResult(
 		}
 		return VisualPreviewProduct{Preview: base}, nil
 	}
-	if _, ok := errors.AsType[jpeg.FormatError](err); ok {
+	if _, ok := errors.AsType[jpeg.FormatError](err); ok ||
+		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return failedVisualPreview(base, "decode_failed", malformedDetail), nil
 	}
 	return VisualPreviewProduct{}, sourceContentUnavailable(

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -59,6 +59,20 @@ func TestProduceVisualPreviewRejectsEmbeddedICCProfile(t *testing.T) {
 	assert.Empty(t, product.Output)
 }
 
+func TestProduceVisualPreviewAcceptsJPEGMediaTypeParameters(t *testing.T) {
+	source := mediatest.JPEG(3, 2, color.White)
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)),
+		MediaType: "IMAGE/JPEG; charset=utf-8",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, "image/jpeg", product.Preview.Output.MediaType)
+}
+
 func TestProduceVisualPreviewRecordsMalformedJPEGFailure(t *testing.T) {
 	source := []byte{0xff, 0xd8, 0xff, 0xd9}
 	digest := sha256.Sum256(source)

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -73,6 +73,21 @@ func TestProduceVisualPreviewRecordsMalformedJPEGFailure(t *testing.T) {
 	assert.Empty(t, product.Output)
 }
 
+func TestProduceVisualPreviewRecordsTruncatedJPEGFailure(t *testing.T) {
+	complete := mediatest.JPEG(64, 48, color.RGBA{R: 220, G: 40, B: 20, A: 255})
+	source := complete[:len(complete)-1]
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/jpeg",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewFailed, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "decode_failed", product.Preview.Failure.Code)
+	assert.Empty(t, product.Output)
+}
+
 func TestVisualPreviewJPEGColorPolicyRejectsCMYK(t *testing.T) {
 	assert.True(t, visualPreviewJPEGColorModelSupported(color.GrayModel))
 	assert.True(t, visualPreviewJPEGColorModelSupported(color.YCbCrModel))

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -1,0 +1,152 @@
+package processing
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media/mediatest"
+)
+
+func TestProduceVisualPreviewAppliesEXIFOrientation(t *testing.T) {
+	tiff := syntheticTIFF(42,
+		[]syntheticTIFFEntry{tiffShort(0x0112, 6)},
+		[]syntheticTIFFEntry{tiffShort(0xa001, 1)},
+	)
+	source := syntheticJPEGSegment(t, mediatest.JPEG(3, 2, color.White), 0xe1,
+		append([]byte("Exif\x00\x00"), tiff...))
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/jpeg",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 2, product.Preview.Output.Width)
+	assert.Equal(t, 3, product.Preview.Output.Height)
+	decoded, err := jpeg.Decode(bytes.NewReader(product.Output))
+	require.NoError(t, err)
+	assert.Equal(t, 2, decoded.Bounds().Dx())
+	assert.Equal(t, 3, decoded.Bounds().Dy())
+}
+
+func TestProduceVisualPreviewRejectsEmbeddedICCProfile(t *testing.T) {
+	tiff := syntheticTIFF(42, nil, []syntheticTIFFEntry{tiffShort(0xa001, 1)})
+	source := syntheticJPEGSegment(t, mediatest.JPEG(3, 2, color.White), 0xe1,
+		append([]byte("Exif\x00\x00"), tiff...))
+	source = syntheticJPEGSegment(t, source, 0xe2,
+		[]byte("ICC_PROFILE\x00\x01\x01profile"))
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/jpeg",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewUnsupported, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "unsupported_color_profile", product.Preview.Failure.Code)
+	assert.Empty(t, product.Output)
+}
+
+func TestProduceVisualPreviewRecordsMalformedJPEGFailure(t *testing.T) {
+	source := []byte{0xff, 0xd8, 0xff, 0xd9}
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/jpeg",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewFailed, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "decode_failed", product.Preview.Failure.Code)
+	assert.Empty(t, product.Output)
+}
+
+func TestVisualPreviewJPEGColorPolicyRejectsCMYK(t *testing.T) {
+	assert.True(t, visualPreviewJPEGColorModelSupported(color.GrayModel))
+	assert.True(t, visualPreviewJPEGColorModelSupported(color.YCbCrModel))
+	assert.True(t, visualPreviewJPEGColorModelSupported(color.RGBAModel))
+	assert.False(t, visualPreviewJPEGColorModelSupported(color.CMYKModel))
+}
+
+func TestProduceVisualPreviewKeepsJPEGReadErrorsRetryable(t *testing.T) {
+	source := mediatest.JPEG(3, 2, color.White)
+	digest := sha256.Sum256(source)
+	readErr := errors.New("injected read failure")
+	for _, test := range []struct {
+		name       string
+		failAtSeek int
+	}{
+		{name: "header", failAtSeek: 3},
+		{name: "pixels", failAtSeek: 4},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reader := &failingVisualPreviewReadSeeker{
+				Reader: bytes.NewReader(source), failAtSeek: test.failAtSeek, err: readErr,
+			}
+
+			_, err := ProduceVisualPreview(t.Context(), reader, VisualPreviewTarget{
+				SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/jpeg",
+			})
+			require.Error(t, err)
+			assert.True(t, IsSourceContentUnavailable(err))
+			assert.ErrorIs(t, err, readErr)
+		})
+	}
+}
+
+func TestVisualPreviewJPEGUnsupportedFeatureIsTerminal(t *testing.T) {
+	product, err := visualPreviewJPEGDecodeResult(
+		document.VisualPreviewV1{}, "malformed", jpeg.UnsupportedError("test feature"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewUnsupported, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "unsupported_jpeg_feature", product.Preview.Failure.Code)
+}
+
+func syntheticJPEGSegment(t *testing.T, source []byte, marker byte, payload []byte) []byte {
+	t.Helper()
+	require.LessOrEqual(t, len(payload)+2, int(^uint16(0)))
+	header := []byte{0xff, marker, 0, 0}
+	binary.BigEndian.PutUint16(header[2:], uint16(len(payload)+2))
+	result := make([]byte, 0, len(source)+len(header)+len(payload))
+	result = append(result, source[:2]...)
+	result = append(result, header...)
+	result = append(result, payload...)
+	return append(result, source[2:]...)
+}
+
+type failingVisualPreviewReadSeeker struct {
+	*bytes.Reader
+
+	err        error
+	failAtSeek int
+	startSeeks int
+}
+
+func (r *failingVisualPreviewReadSeeker) Read(target []byte) (int, error) {
+	if r.startSeeks == r.failAtSeek {
+		return 0, r.err
+	}
+	return r.Reader.Read(target) //nolint:wrapcheck // The test double preserves Reader error identity.
+}
+
+func (r *failingVisualPreviewReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	position, err := r.Reader.Seek(offset, whence)
+	if err == nil && offset == 0 && whence == io.SeekStart {
+		r.startSeeks++
+	}
+	return position, err //nolint:wrapcheck // The test double preserves Seeker error identity.
+}

--- a/vault.go
+++ b/vault.go
@@ -5,6 +5,7 @@
 package docbank
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -437,6 +438,114 @@ func (v *Vault) VisualPreview(ctx context.Context, versionID string) (VisualPrev
 		return VisualPreview{}, err
 	}
 	return fromStoreVisualPreview(view), nil
+}
+
+// EnsureVisualPreview returns the current built-in preview for one exact
+// immutable content version, producing and publishing it synchronously when
+// the current recipe has not processed those bytes.
+func (v *Vault) EnsureVisualPreview(ctx context.Context, versionID string) (VisualPreview, error) {
+	if err := v.begin(); err != nil {
+		return VisualPreview{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	v.mutation.Lock()
+	defer v.mutation.Unlock()
+	if err := ctx.Err(); err != nil {
+		return VisualPreview{}, err
+	}
+	version, err := v.metadata.ContentVersionByID(ctx, versionID)
+	if err != nil {
+		return VisualPreview{}, err
+	}
+	recipe := internalprocessing.CurrentVisualPreviewRecipe()
+	_, recipeFingerprint, err := document.MarshalVisualPreviewRecipeV1(recipe)
+	if err != nil {
+		return VisualPreview{}, err
+	}
+	view, err := v.metadata.ContentVersionVisualPreview(ctx, versionID)
+	if err == nil && view.Generation.RecipeFingerprint == recipeFingerprint {
+		return fromStoreVisualPreview(view), nil
+	}
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return VisualPreview{}, err
+	}
+	reader, size, err := v.blobs.OpenSeekableContext(ctx, version.BlobHash)
+	if err != nil {
+		return VisualPreview{}, fmt.Errorf(
+			"opening visual preview source version %q: %w: %w",
+			versionID, ErrContentUnavailable, err,
+		)
+	}
+	if size != version.Size {
+		closeErr := reader.Close()
+		return VisualPreview{}, errors.Join(fmt.Errorf(
+			"visual preview source size %d does not match version size %d: %w",
+			size, version.Size, ErrContentUnavailable,
+		), closeErr)
+	}
+	product, produceErr := internalprocessing.ProduceVisualPreview(ctx, reader,
+		internalprocessing.VisualPreviewTarget{
+			SourceSHA256: version.BlobHash, Size: version.Size, MediaType: version.MimeType,
+		})
+	closeErr := reader.Close()
+	if err := errors.Join(produceErr, closeErr); err != nil {
+		if internalprocessing.IsSourceContentUnavailable(err) || closeErr != nil {
+			return VisualPreview{}, fmt.Errorf(
+				"producing visual preview for content version %q: %w: %w",
+				versionID, ErrContentUnavailable, err,
+			)
+		}
+		return VisualPreview{}, fmt.Errorf("producing visual preview for content version %q: %w", versionID, err)
+	}
+	canonical, _, err := document.MarshalVisualPreviewV1(product.Preview)
+	if err != nil {
+		return VisualPreview{}, err
+	}
+	if product.Preview.State == document.VisualPreviewReady {
+		err = v.publishReadyVisualPreview(ctx, versionID, canonical, product)
+	} else {
+		_, err = v.metadata.PublishVisualPreview(ctx, versionID, canonical, nil)
+	}
+	if err != nil {
+		return VisualPreview{}, err
+	}
+	view, err = v.metadata.ContentVersionVisualPreview(ctx, versionID)
+	if err != nil {
+		return VisualPreview{}, err
+	}
+	return fromStoreVisualPreview(view), nil
+}
+
+func (v *Vault) publishReadyVisualPreview(
+	ctx context.Context, versionID string, canonical []byte,
+	product internalprocessing.VisualPreviewProduct,
+) error {
+	return v.blobs.WithMutation(ctx, func() (retErr error) {
+		written, err := v.blobs.WriteDetailedContext(ctx, bytes.NewReader(product.Output))
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if retErr != nil {
+				retErr = errors.Join(retErr, v.removeUnrecordedLoose(written.Hash))
+				return
+			}
+			if authority, authorityErr := v.metadata.PhysicalContent(ctx, written.Hash); authorityErr == nil && authority.Kind == "packed" {
+				// Publication is durable. Redundant loose cleanup is maintenance
+				// and must not turn committed success into failure.
+				_ = v.blobs.Remove(written.Hash)
+			}
+		}()
+		if written.Hash != product.Preview.Output.BlobSHA256 || written.Size != product.Preview.Output.Size {
+			return errors.New("visual preview output identity changed before publication")
+		}
+		physical, err := blobPhysical(written)
+		if err != nil {
+			return err
+		}
+		_, err = v.metadata.PublishVisualPreview(ctx, versionID, canonical, &physical)
+		return err
+	})
 }
 
 // OpenVisualPreview opens verified canonical preview bytes for one exact

--- a/vault_test.go
+++ b/vault_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"image/color"
+	"image/jpeg"
 	"io"
 	"os"
 	"path/filepath"
@@ -21,6 +23,7 @@ import (
 	"go.kenn.io/kit/packstore"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media/mediatest"
 	"go.kenn.io/docbank/internal/blob"
 	"go.kenn.io/docbank/internal/store"
 	docsqlite "go.kenn.io/docbank/sqlite"
@@ -357,6 +360,70 @@ func TestVaultOpensVerifiedVisualPreviewForExactVersion(t *testing.T) {
 	require.NoError(t, content.Reader.Verify())
 	require.NoError(t, content.Reader.Close())
 	assert.Equal(t, previewBytes, data)
+}
+
+func TestVaultEnsureVisualPreviewProducesBoundedJPEG(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	source := mediatest.JPEG(2050, 2, color.RGBA{R: 220, G: 40, B: 20, A: 255})
+	receipt, err := vault.Create(t.Context(), "/photo.jpg", bytes.NewReader(source), CreateOptions{
+		MediaType: "image/jpeg", Expected: contentIdentity(source),
+	})
+	require.NoError(t, err)
+
+	preview, err := vault.EnsureVisualPreview(t.Context(), receipt.Version.ID)
+	require.NoError(t, err)
+	require.NotNil(t, preview.Output)
+	assert.Equal(t, document.VisualPreviewReady, preview.State)
+	assert.Equal(t, "image/jpeg", preview.Output.MediaType)
+	assert.Equal(t, 2048, preview.Output.Width)
+	assert.Equal(t, 2, preview.Output.Height)
+	assert.Equal(t, receipt.Version.ID, preview.Version.ID)
+
+	retry, err := vault.EnsureVisualPreview(t.Context(), receipt.Version.ID)
+	require.NoError(t, err)
+	assert.Equal(t, preview, retry)
+
+	opened, err := vault.OpenVisualPreview(t.Context(), receipt.Version.ID)
+	require.NoError(t, err)
+	encoded, err := io.ReadAll(opened.Reader)
+	require.NoError(t, err)
+	require.NoError(t, opened.Reader.Close())
+	decoded, err := jpeg.Decode(bytes.NewReader(encoded))
+	require.NoError(t, err)
+	assert.Equal(t, 2048, decoded.Bounds().Dx())
+	assert.Equal(t, 2, decoded.Bounds().Dy())
+}
+
+func TestVaultEnsureVisualPreviewRemovesLooseDuplicateOfPackedOutput(t *testing.T) {
+	root := t.TempDir()
+	vault, err := New(t.Context(), Config{Root: root})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	source := mediatest.JPEG(3, 2, color.White)
+	first, err := vault.Create(t.Context(), "/first.jpg", bytes.NewReader(source), CreateOptions{
+		MediaType: "image/jpeg", Expected: contentIdentity(source),
+	})
+	require.NoError(t, err)
+	preview, err := vault.EnsureVisualPreview(t.Context(), first.Version.ID)
+	require.NoError(t, err)
+	require.NotNil(t, preview.Output)
+	_, err = vault.Pack(t.Context(), PackOptions{})
+	require.NoError(t, err)
+
+	second, err := vault.Create(t.Context(), "/second.jpg", bytes.NewReader(source), CreateOptions{
+		MediaType: "image/jpeg", Expected: contentIdentity(source),
+	})
+	require.NoError(t, err)
+	_, err = vault.EnsureVisualPreview(t.Context(), second.Version.ID)
+	require.NoError(t, err)
+
+	rawPath := filepath.Join(root, "blobs", preview.Output.BlobSHA256[:2], preview.Output.BlobSHA256)
+	assert.NoFileExists(t, rawPath)
+	assert.NoFileExists(t, rawPath+".zst")
 }
 
 func TestLeasedLimitedReaderShortRead(t *testing.T) {


### PR DESCRIPTION
Embedded applications can now ask Docbank to produce or reuse a canonical JPEG preview for an exact immutable content version. Preview bytes use the existing content-addressed storage and preview catalog, so they share the same deduplication, backup, restore, verification, and pruning lifecycle.

The first built-in producer is deliberately narrow. It applies EXIF orientation, scales without upscaling to a 2048-pixel maximum edge, and writes a quality-90 JPEG. It accepts grayscale and three-component JPEGs with absent or sRGB color metadata, while rejecting embedded ICC profiles, CMYK/YCCK images, and unsupported JPEG features instead of applying an unmanaged conversion. Verified malformed files become durable failures; read and storage failures remain retryable.

Production is synchronous and version-specific. Opening a vault does not start a background preview worker.
