### PR TITLE
Read creation time from MP4 files

### DIFF
--- a/docs/architecture/source-metadata.md
+++ b/docs/architecture/source-metadata.md
@@ -58,7 +58,8 @@ omitted.
 
 For larger MP4 files, the worker verifies the complete content identity, scans
 the top-level box headers, skips media payload boxes, and reads only bounded
-file-type and movie metadata. Malformed or oversized MP4 metadata produces a
+file-type and movie metadata, including the movie-header creation time when
+present. Malformed or oversized MP4 metadata produces a
 durable warning. Storage and read failures remain retryable errors. Other
 large RAF files similarly read only the fixed header, a bounded embedded-JPEG
 metadata window, and a bounded raw-metadata directory after full verification.

--- a/document/media/detect.go
+++ b/document/media/detect.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"math/bits"
+	"time"
 
 	_ "image/jpeg" // Register the JPEG decoder used by image.DecodeConfig.
 	_ "image/png"  // Register the PNG decoder used by image.DecodeConfig.
@@ -103,6 +104,7 @@ func sniff(data []byte) (Metadata, error) {
 			Format: FormatMP4, Kind: KindVideo, MediaType: "video/mp4",
 			Width: info.width, Height: info.height,
 			DurationMS: info.durationMS, DurationKnown: info.durationKnown,
+			CreatedAt: info.createdAt,
 		}, nil
 	default:
 		return Metadata{}, ErrUnsupportedMedia
@@ -418,6 +420,7 @@ type mp4Info struct {
 	trackDurations       []uint64
 	mediaDurations       []mp4Duration
 	unknownDuration      bool
+	createdAt            *time.Time
 }
 
 type mp4Duration struct {
@@ -588,6 +591,7 @@ func parseMVHD(payload []byte, info *mp4Info) bool {
 	// Full box: version(1) flags(3) creation modification timescale duration.
 	switch payload[0] {
 	case 0:
+		info.createdAt = mp4CreationTime(uint64(binary.BigEndian.Uint32(payload[4:8])), math.MaxUint32)
 		info.timescale = uint64(binary.BigEndian.Uint32(payload[12:16]))
 		info.movieDuration = uint64(binary.BigEndian.Uint32(payload[16:20]))
 		if info.movieDuration == math.MaxUint32 {
@@ -598,6 +602,7 @@ func parseMVHD(payload []byte, info *mp4Info) bool {
 		if len(payload) < 32 {
 			return false
 		}
+		info.createdAt = mp4CreationTime(binary.BigEndian.Uint64(payload[4:12]), math.MaxUint64)
 		info.timescale = uint64(binary.BigEndian.Uint32(payload[20:24]))
 		info.movieDuration = binary.BigEndian.Uint64(payload[24:32])
 		if info.movieDuration == math.MaxUint64 {
@@ -607,6 +612,18 @@ func parseMVHD(payload []byte, info *mp4Info) bool {
 	default:
 		return false
 	}
+}
+
+func mp4CreationTime(seconds, unknown uint64) *time.Time {
+	if seconds == 0 || seconds == unknown || seconds > math.MaxInt64 {
+		return nil
+	}
+	const mp4EpochToUnix = int64(2_082_844_800)
+	created := time.Unix(int64(seconds)-mp4EpochToUnix, 0).UTC()
+	if created.Year() < 1 || created.Year() > 9999 {
+		return nil
+	}
+	return &created
 }
 
 // parseTKHD records a track's duration in movie-timescale units and its

--- a/document/media/detect_test.go
+++ b/document/media/detect_test.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,6 +84,20 @@ func TestDetectBytesRecognizesSupportedContainers(t *testing.T) {
 			assert.Equal(t, tt.width*tt.height, got.Pixels())
 		})
 	}
+}
+
+func TestDetectBytesReadsMP4CreationTime(t *testing.T) {
+	payload := mediatest.MP4(640, 368, 3500)
+	mvhd := bytes.Index(payload, []byte("mvhd"))
+	require.GreaterOrEqual(t, mvhd, 4)
+	want := time.Date(2024, 6, 15, 14, 30, 22, 0, time.UTC)
+	const mp4EpochToUnix = int64(2_082_844_800)
+	binary.BigEndian.PutUint32(payload[mvhd+8:mvhd+12], uint32(want.Unix()+mp4EpochToUnix))
+
+	metadata, err := media.DetectBytes(payload, "video/mp4")
+	require.NoError(t, err)
+	require.NotNil(t, metadata.CreatedAt)
+	assert.Equal(t, want, *metadata.CreatedAt)
 }
 
 func TestDetectBytesRejectsUnsupportedAndMalformedInput(t *testing.T) {

--- a/document/media/types.go
+++ b/document/media/types.go
@@ -3,6 +3,7 @@ package media
 import (
 	"errors"
 	"math"
+	"time"
 )
 
 // Format identifies a detected media container.
@@ -48,6 +49,9 @@ type Metadata struct {
 	// DurationKnown reports that the container declared a measurable
 	// duration. Fragmented or header-only video leaves it false.
 	DurationKnown bool `json:"duration_known,omitzero"`
+	// CreatedAt is the MP4 movie-header creation time when it is present and
+	// representable as an RFC 3339 timestamp.
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 	// Animated reports a multi-frame image.
 	Animated bool `json:"animated,omitzero"`
 }

--- a/internal/processing/source_metadata.go
+++ b/internal/processing/source_metadata.go
@@ -52,7 +52,7 @@ var (
 	// SourceMetadataExtractorFingerprint is the stable identity of the local
 	// parser bundle. Any semantic parser change must change the descriptor.
 	SourceMetadataExtractorFingerprint = fingerprintSourceMetadataExtractor(
-		"docbank-source-metadata:pdfcpu-info+xmp+pages,ooxml-core+custom,rfc5322,ical,visual-container+jpeg-tiff-raf-cr3-exif,media-id3:v14")
+		"docbank-source-metadata:pdfcpu-info+xmp+pages,ooxml-core+custom,rfc5322,ical,visual-container+jpeg-tiff-raf-cr3-exif+mp4-created,media-id3:v15")
 
 	// errSourceMetadataBMFFMalformed marks deterministic box structure defects
 	// in verified bytes, which become durable warnings rather than retryable
@@ -1653,6 +1653,9 @@ func (c *metadataCollector) extractVisual(data []byte) {
 		}
 		if metadata.DurationKnown {
 			c.integer("media.container.duration_ms", "media.container", "DurationMS", metadata.DurationMS)
+		}
+		if metadata.CreatedAt != nil {
+			c.timestamp("created", "media.container", "mvhd.CreationTime", metadata.CreatedAt.Format(time.RFC3339))
 		}
 	}
 	if bytes.HasPrefix(data, []byte{0xff, 0xd8}) {

--- a/internal/processing/source_metadata_test.go
+++ b/internal/processing/source_metadata_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,21 @@ func TestExtractSourceMetadataReadsVisualContainerFacts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtractSourceMetadataReadsMP4CreationTime(t *testing.T) {
+	payload := mediatest.MP4(640, 368, 3500)
+	mvhd := bytes.Index(payload, []byte("mvhd"))
+	require.GreaterOrEqual(t, mvhd, 4)
+	want := time.Date(2024, 6, 15, 14, 30, 22, 0, time.UTC)
+	const mp4EpochToUnix = int64(2_082_844_800)
+	binary.BigEndian.PutUint32(payload[mvhd+8:mvhd+12], uint32(want.Unix()+mp4EpochToUnix))
+
+	metadata := ExtractSourceMetadata(payload)
+	created, found := sourceMetadataTimestamp(metadata, "created")
+	require.True(t, found)
+	assert.Equal(t, want.Format(time.RFC3339), created.Normalized)
+	assert.Equal(t, document.SourceMetadataTimezoneUTC, created.Timezone)
 }
 
 func TestExtractSourceMetadataReadsTIFFPhotoFacts(t *testing.T) {
@@ -1112,6 +1128,9 @@ func TestLargeMP4SourceMetadataSkipsPayloadWithoutBufferingIt(t *testing.T) {
 	duration, found := sourceMetadataInteger(metadata, "media.container.duration_ms")
 	require.True(t, found)
 	assert.Equal(t, int64(3500), duration)
+	created, found := sourceMetadataTimestamp(metadata, "created")
+	require.True(t, found)
+	assert.Equal(t, "2024-06-15T14:30:22Z", created.Normalized)
 	assert.NotContains(t, sourceMetadataWarningCodes(metadata), "input_too_large")
 }
 
@@ -1237,6 +1256,10 @@ type sparseSourceMetadataReader struct {
 
 func syntheticSparseLargeMP4() *sparseSourceMetadataReader {
 	metadata := mediatest.MP4(640, 368, 3500)
+	mvhd := bytes.Index(metadata, []byte("mvhd"))
+	const mp4EpochToUnix = int64(2_082_844_800)
+	binary.BigEndian.PutUint32(metadata[mvhd+8:mvhd+12], uint32(
+		time.Date(2024, 6, 15, 14, 30, 22, 0, time.UTC).Unix()+mp4EpochToUnix))
 	ftypSize := int(binary.BigEndian.Uint32(metadata[:4]))
 	ftyp := append([]byte(nil), metadata[:ftypSize]...)
 	moov := append([]byte(nil), metadata[ftypSize:]...)


### PR DESCRIPTION
Docbank now records the creation time declared by an MP4 movie header as canonical source metadata. Embedded applications can use the original video chronology without maintaining another container parser.

The public media detector validates and exposes the timestamp, and source-metadata extraction publishes it as the standard `created` fact. Missing, sentinel, and unrepresentable values stay absent.
