### PR TITLE
Produce canonical previews for PNG originals

### DIFF
--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -61,16 +61,18 @@ source before decoding and holds the vault mutation boundary through
 publication, so callers either observe a complete generation or a retryable
 error.
 
-The built-in producer currently accepts grayscale and three-component JPEG
-originals with absent or explicitly sRGB color metadata and no embedded ICC
-profile. It rejects CMYK and YCCK rather than applying an unmanaged color
-conversion. Accepted images have EXIF orientation applied, scale without
-upscaling to a 2048-pixel maximum edge, and encode as a quality-90 JPEG.
-Malformed JPEG bytes become a durable `failed` result; unsupported media types,
-JPEG features, and color profiles become a durable `unsupported` result. Read,
-verification, storage, and cancellation failures are retryable.
+The built-in producer currently accepts JPEG and PNG originals. JPEG inputs
+may be grayscale or three-component images; CMYK, YCCK, and embedded ICC
+profiles remain unsupported rather than receiving an unmanaged color
+conversion. PNG inputs apply bounded EXIF orientation, reject embedded ICC
+profiles, and composite transparency onto white because the canonical output
+is JPEG. Accepted images scale without upscaling to a 2048-pixel maximum edge
+and encode as a quality-90 JPEG. Malformed source bytes become a durable
+`failed` result; unsupported media types, decoder features, and color profiles
+become a durable `unsupported` result. Read, verification, storage, and
+cancellation failures are retryable.
 
 Preview production is application-driven: opening a vault does not start a
-worker. Other still-image formats, camera RAW files, video frames, and color
-conversion require additional producers, but they use the same generation,
-retention, backup, and read contracts.
+worker. Other still-image formats, camera RAW files, video frames, and managed
+color conversion require additional producers, but they use the same
+generation, retention, backup, and read contracts.

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -12,6 +12,7 @@ import (
 	"image/color"
 	"image/draw"
 	"image/jpeg"
+	"image/png"
 	"io"
 	"mime"
 	"runtime"
@@ -26,6 +27,8 @@ const (
 	visualPreviewMaxSourcePixels = 100_000_000
 	visualPreviewJPEGQuality     = 90
 	visualPreviewMaxJPEGSegments = 1024
+	visualPreviewMaxPNGChunks    = 1024
+	visualPreviewMaxPNGEXIFBytes = 1 << 20
 )
 
 var visualPreviewRecipe = document.VisualPreviewRecipeV1{
@@ -36,8 +39,8 @@ var visualPreviewRecipe = document.VisualPreviewRecipeV1{
 	ColorPolicy:       "srgb",
 	FramePolicy:       "primary",
 	ProcessorFingerprint: fingerprintVisualPreviewProcessor(
-		"docbank-visual-preview:jpeg-stdlib-" + runtime.Version() +
-			"+x-image-draw-v0.44.0:max-edge=2048:quality=90:v1"),
+		"docbank-visual-preview:jpeg+png-stdlib-" + runtime.Version() +
+			"+x-image-draw-v0.44.0:max-edge=2048:quality=90:alpha=white:v2"),
 }
 
 // VisualPreviewTarget identifies one exact immutable source to process.
@@ -73,13 +76,24 @@ func ProduceVisualPreview(
 		return VisualPreviewProduct{}, sourceContentUnavailable(
 			fmt.Errorf("verifying visual preview source: %w", err))
 	}
-	if !visualPreviewSupportsMediaType(target.MediaType) {
+	mediaType := visualPreviewSourceMediaType(target.MediaType)
+	switch mediaType {
+	case "image/jpeg":
+		return produceVisualPreviewJPEG(ctx, source, base)
+	case "image/png":
+		return produceVisualPreviewPNG(ctx, source, target.Size, base)
+	default:
 		base.State = document.VisualPreviewUnsupported
 		base.Failure = &document.VisualPreviewFailureV1{
-			Code: "unsupported_media_type", Detail: "the built-in preview producer supports JPEG originals",
+			Code: "unsupported_media_type", Detail: "the built-in preview producer supports JPEG and PNG originals",
 		}
 		return VisualPreviewProduct{Preview: base}, nil
 	}
+}
+
+func produceVisualPreviewJPEG(
+	ctx context.Context, source io.ReadSeeker, base document.VisualPreviewV1,
+) (VisualPreviewProduct, error) {
 	orientation, unsupportedColor, malformed, err := inspectVisualPreviewJPEG(ctx, source)
 	if err != nil {
 		return VisualPreviewProduct{}, sourceContentUnavailable(
@@ -110,8 +124,7 @@ func ProduceVisualPreview(
 		}
 		return VisualPreviewProduct{Preview: base}, nil
 	}
-	if config.Width < 1 || config.Height < 1 ||
-		int64(config.Width)*int64(config.Height) > visualPreviewMaxSourcePixels {
+	if !visualPreviewDimensionsAllowed(config.Width, config.Height) {
 		return failedVisualPreview(base, "source_dimensions_exceed_limit",
 			"the JPEG dimensions exceed the built-in preview limit"), nil
 	}
@@ -126,21 +139,84 @@ func ProduceVisualPreview(
 	if decoded.Bounds().Dx() != config.Width || decoded.Bounds().Dy() != config.Height {
 		return failedVisualPreview(base, "decode_failed", "the JPEG dimensions changed during decoding"), nil
 	}
-	orientedWidth, orientedHeight := visualPreviewOrientedDimensions(config.Width, config.Height, orientation)
+	return encodeVisualPreview(base, decoded, config.Width, config.Height, orientation)
+}
+
+func produceVisualPreviewPNG(
+	ctx context.Context, source io.ReadSeeker, sourceSize int64, base document.VisualPreviewV1,
+) (VisualPreviewProduct, error) {
+	orientation, unsupportedColor, unsupportedMetadata, malformed, err :=
+		inspectVisualPreviewPNG(ctx, source, sourceSize)
+	if err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("inspecting visual preview PNG: %w", err))
+	}
+	if malformed {
+		return failedVisualPreview(base, "decode_failed", "the verified PNG header is malformed"), nil
+	}
+	if unsupportedColor {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_color_profile", Detail: "the built-in preview producer requires sRGB PNG originals",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if unsupportedMetadata {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_png_metadata", Detail: "the PNG EXIF metadata exceeds the built-in preview limit",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("seeking visual preview source: %w", err))
+	}
+	config, err := png.DecodeConfig(source)
+	if err != nil {
+		return visualPreviewPNGDecodeResult(base, "the verified PNG header is malformed", err)
+	}
+	if !visualPreviewDimensionsAllowed(config.Width, config.Height) {
+		return failedVisualPreview(base, "source_dimensions_exceed_limit",
+			"the PNG dimensions exceed the built-in preview limit"), nil
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("seeking visual preview source: %w", err))
+	}
+	decoded, err := png.Decode(source)
+	if err != nil {
+		return visualPreviewPNGDecodeResult(base, "the verified PNG cannot be decoded", err)
+	}
+	if decoded.Bounds().Dx() != config.Width || decoded.Bounds().Dy() != config.Height {
+		return failedVisualPreview(base, "decode_failed", "the PNG dimensions changed during decoding"), nil
+	}
+	return encodeVisualPreview(base, decoded, config.Width, config.Height, orientation)
+}
+
+func encodeVisualPreview(
+	base document.VisualPreviewV1,
+	decoded image.Image,
+	sourceWidth, sourceHeight, orientation int,
+) (VisualPreviewProduct, error) {
+	orientedWidth, orientedHeight := visualPreviewOrientedDimensions(sourceWidth, sourceHeight, orientation)
 	width, height := boundedVisualPreviewDimensions(orientedWidth, orientedHeight)
 	resizeWidth, resizeHeight := width, height
 	if visualPreviewOrientationSwapsDimensions(orientation) {
 		resizeWidth, resizeHeight = height, width
 	}
 	resized := image.NewNRGBA(image.Rect(0, 0, resizeWidth, resizeHeight))
-	if resizeWidth == config.Width && resizeHeight == config.Height {
+	if resizeWidth == sourceWidth && resizeHeight == sourceHeight {
 		draw.Draw(resized, resized.Bounds(), decoded, decoded.Bounds().Min, draw.Src)
 	} else {
 		xdraw.CatmullRom.Scale(resized, resized.Bounds(), decoded, decoded.Bounds(), draw.Src, nil)
 	}
 	preview := applyVisualPreviewOrientation(resized, orientation)
+	matte := image.NewRGBA(preview.Bounds())
+	draw.Draw(matte, matte.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
+	draw.Draw(matte, matte.Bounds(), preview, preview.Bounds().Min, draw.Over)
 	var encoded bytes.Buffer
-	if err := jpeg.Encode(&encoded, preview, &jpeg.Options{Quality: visualPreviewJPEGQuality}); err != nil {
+	if err := jpeg.Encode(&encoded, matte, &jpeg.Options{Quality: visualPreviewJPEGQuality}); err != nil {
 		return VisualPreviewProduct{}, fmt.Errorf("encoding visual preview: %w", err)
 	}
 	output := encoded.Bytes()
@@ -153,9 +229,83 @@ func ProduceVisualPreview(
 	return VisualPreviewProduct{Preview: base, Output: output}, nil
 }
 
-func visualPreviewSupportsMediaType(value string) bool {
+func visualPreviewSourceMediaType(value string) string {
 	mediaType, _, err := mime.ParseMediaType(value)
-	return err == nil && mediaType == "image/jpeg"
+	if err != nil {
+		return ""
+	}
+	return mediaType
+}
+
+func inspectVisualPreviewPNG(
+	ctx context.Context, source io.ReadSeeker, sourceSize int64,
+) (orientation int, unsupportedColor, unsupportedMetadata, malformed bool, err error) {
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return 0, false, false, false, err
+	}
+	var signature [8]byte
+	if _, err := io.ReadFull(source, signature[:]); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return 0, false, false, true, nil
+		}
+		return 0, false, false, false, err
+	}
+	if signature != [8]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'} {
+		return 0, false, false, true, nil
+	}
+	orientation = 1
+	offset := int64(len(signature))
+	for range visualPreviewMaxPNGChunks {
+		if err := ctx.Err(); err != nil {
+			return 0, false, false, false, err
+		}
+		if offset > sourceSize-12 {
+			return 0, false, false, true, nil
+		}
+		var header [8]byte
+		if _, err := io.ReadFull(source, header[:]); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return 0, false, false, true, nil
+			}
+			return 0, false, false, false, err
+		}
+		length := int64(binary.BigEndian.Uint32(header[:4]))
+		chunkType := string(header[4:])
+		if length > sourceSize-offset-12 {
+			return 0, false, false, true, nil
+		}
+		if chunkType == "IDAT" {
+			return orientation, unsupportedColor, unsupportedMetadata, false, nil
+		}
+		switch chunkType {
+		case "iCCP":
+			unsupportedColor = true
+		case "eXIf":
+			if length > visualPreviewMaxPNGEXIFBytes {
+				unsupportedMetadata = true
+				break
+			}
+			payload := make([]byte, length)
+			if _, err := io.ReadFull(source, payload); err != nil {
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+					return 0, false, false, true, nil
+				}
+				return 0, false, false, false, err
+			}
+			if value, colorSpace, found := visualPreviewEXIF(payload); found {
+				orientation = value
+				unsupportedColor = unsupportedColor || colorSpace != 0 && colorSpace != 1
+			}
+			length = 0
+		case "IEND":
+			return 0, false, false, true, nil
+		}
+		if _, err := source.Seek(length+4, io.SeekCurrent); err != nil {
+			return 0, false, false, false, err
+		}
+		offset += 12 + int64(binary.BigEndian.Uint32(header[:4]))
+	}
+	return 0, false, false, true, nil
 }
 
 func inspectVisualPreviewJPEG(
@@ -284,6 +434,24 @@ func visualPreviewJPEGDecodeResult(
 		fmt.Errorf("reading visual preview JPEG: %w", err))
 }
 
+func visualPreviewPNGDecodeResult(
+	base document.VisualPreviewV1, malformedDetail string, err error,
+) (VisualPreviewProduct, error) {
+	if _, ok := errors.AsType[png.UnsupportedError](err); ok {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_png_feature", Detail: "the PNG uses a feature unavailable to the built-in decoder",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if _, ok := errors.AsType[png.FormatError](err); ok ||
+		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return failedVisualPreview(base, "decode_failed", malformedDetail), nil
+	}
+	return VisualPreviewProduct{}, sourceContentUnavailable(
+		fmt.Errorf("reading visual preview PNG: %w", err))
+}
+
 func visualPreviewOrientationSwapsDimensions(orientation int) bool {
 	return orientation >= 5 && orientation <= 8
 }
@@ -338,6 +506,11 @@ func failedVisualPreview(
 	base.State = document.VisualPreviewFailed
 	base.Failure = &document.VisualPreviewFailureV1{Code: code, Detail: detail}
 	return VisualPreviewProduct{Preview: base}
+}
+
+func visualPreviewDimensionsAllowed(width, height int) bool {
+	return width > 0 && height > 0 &&
+		int64(width) <= visualPreviewMaxSourcePixels/int64(height)
 }
 
 func boundedVisualPreviewDimensions(width, height int) (int, int) {

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -2,6 +2,8 @@ package processing
 
 import (
 	"bytes"
+	"compress/flate"
+	"compress/zlib"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
@@ -445,7 +447,12 @@ func visualPreviewPNGDecodeResult(
 		return VisualPreviewProduct{Preview: base}, nil
 	}
 	if _, ok := errors.AsType[png.FormatError](err); ok ||
+		errors.Is(err, zlib.ErrHeader) || errors.Is(err, zlib.ErrDictionary) ||
+		errors.Is(err, zlib.ErrChecksum) ||
 		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return failedVisualPreview(base, "decode_failed", malformedDetail), nil
+	}
+	if _, ok := errors.AsType[flate.CorruptInputError](err); ok {
 		return failedVisualPreview(base, "decode_failed", malformedDetail), nil
 	}
 	return VisualPreviewProduct{}, sourceContentUnavailable(

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -6,8 +6,11 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"hash/crc32"
+	"image"
 	"image/color"
 	"image/jpeg"
+	"image/png"
 	"io"
 	"testing"
 
@@ -71,6 +74,102 @@ func TestProduceVisualPreviewAcceptsJPEGMediaTypeParameters(t *testing.T) {
 	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
 	require.NotNil(t, product.Preview.Output)
 	assert.Equal(t, "image/jpeg", product.Preview.Output.MediaType)
+}
+
+func TestProduceVisualPreviewAcceptsPNGAndFlattensTransparency(t *testing.T) {
+	canvas := image.NewNRGBA(image.Rect(0, 0, 64, 32))
+	for y := range 32 {
+		for x := range 64 {
+			if x < 32 {
+				canvas.SetNRGBA(x, y, color.NRGBA{R: 255})
+			} else {
+				canvas.SetNRGBA(x, y, color.NRGBA{A: 255})
+			}
+		}
+	}
+	var encoded bytes.Buffer
+	require.NoError(t, png.Encode(&encoded, canvas))
+	source := encoded.Bytes()
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)),
+		MediaType: "IMAGE/PNG; charset=utf-8",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 64, product.Preview.Output.Width)
+	assert.Equal(t, 32, product.Preview.Output.Height)
+	preview, err := jpeg.Decode(bytes.NewReader(product.Output))
+	require.NoError(t, err)
+	transparentRed, transparentGreen, transparentBlue, _ := preview.At(8, 16).RGBA()
+	opaqueRed, opaqueGreen, opaqueBlue, _ := preview.At(56, 16).RGBA()
+	assert.Greater(t, transparentRed, uint32(0xf000))
+	assert.Greater(t, transparentGreen, uint32(0xf000))
+	assert.Greater(t, transparentBlue, uint32(0xf000))
+	assert.Less(t, opaqueRed, uint32(0x1000))
+	assert.Less(t, opaqueGreen, uint32(0x1000))
+	assert.Less(t, opaqueBlue, uint32(0x1000))
+}
+
+func TestProduceVisualPreviewAppliesPNGEXIFOrientation(t *testing.T) {
+	source := syntheticPNGChunk(t, mediatest.PNG(3, 2, color.White), "eXIf",
+		syntheticTIFF(42, []syntheticTIFFEntry{tiffShort(0x0112, 6)}, nil))
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/png",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 2, product.Preview.Output.Width)
+	assert.Equal(t, 3, product.Preview.Output.Height)
+}
+
+func TestProduceVisualPreviewRejectsPNGICCProfile(t *testing.T) {
+	source := syntheticPNGChunk(t, mediatest.PNG(3, 2, color.White), "iCCP", []byte("profile"))
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/png",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewUnsupported, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "unsupported_color_profile", product.Preview.Failure.Code)
+}
+
+func TestProduceVisualPreviewRecordsTruncatedPNGFailure(t *testing.T) {
+	complete := mediatest.PNG(64, 48, color.White)
+	source := complete[:len(complete)-1]
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/png",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewFailed, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "decode_failed", product.Preview.Failure.Code)
+	assert.Empty(t, product.Output)
+}
+
+func TestProduceVisualPreviewRejectsOversizedPNGDimensionsBeforeDecode(t *testing.T) {
+	source := mediatest.PNG(1, 1, color.White)
+	binary.BigEndian.PutUint32(source[16:20], 10001)
+	binary.BigEndian.PutUint32(source[20:24], 10001)
+	binary.BigEndian.PutUint32(source[29:33], crc32.ChecksumIEEE(source[12:29]))
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/png",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewFailed, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "source_dimensions_exceed_limit", product.Preview.Failure.Code)
 }
 
 func TestProduceVisualPreviewRecordsMalformedJPEGFailure(t *testing.T) {
@@ -155,6 +254,20 @@ func syntheticJPEGSegment(t *testing.T, source []byte, marker byte, payload []by
 	result = append(result, header...)
 	result = append(result, payload...)
 	return append(result, source[2:]...)
+}
+
+func syntheticPNGChunk(t *testing.T, source []byte, chunkType string, payload []byte) []byte {
+	t.Helper()
+	require.Len(t, chunkType, 4)
+	require.GreaterOrEqual(t, len(source), 33)
+	chunk := make([]byte, 12+len(payload))
+	binary.BigEndian.PutUint32(chunk[:4], uint32(len(payload)))
+	copy(chunk[4:8], chunkType)
+	copy(chunk[8:], payload)
+	binary.BigEndian.PutUint32(chunk[len(chunk)-4:], crc32.ChecksumIEEE(chunk[4:len(chunk)-4]))
+	result := append([]byte{}, source[:33]...)
+	result = append(result, chunk...)
+	return append(result, source[33:]...)
 }
 
 type failingVisualPreviewReadSeeker struct {

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -156,6 +156,34 @@ func TestProduceVisualPreviewRecordsTruncatedPNGFailure(t *testing.T) {
 	assert.Empty(t, product.Output)
 }
 
+func TestProduceVisualPreviewRecordsCorruptPNGCompressionFailure(t *testing.T) {
+	source := mediatest.PNG(4, 3, color.White)
+	corrupted := false
+	for offset := 8; offset+12 <= len(source); {
+		length := int(binary.BigEndian.Uint32(source[offset : offset+4]))
+		end := offset + 12 + length
+		require.LessOrEqual(t, end, len(source))
+		if string(source[offset+4:offset+8]) == "IDAT" {
+			require.GreaterOrEqual(t, length, 2)
+			source[offset+8], source[offset+9] = 0, 0
+			binary.BigEndian.PutUint32(source[end-4:end], crc32.ChecksumIEEE(source[offset+4:end-4]))
+			corrupted = true
+			break
+		}
+		offset = end
+	}
+	require.True(t, corrupted)
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/png",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewFailed, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "decode_failed", product.Preview.Failure.Code)
+}
+
 func TestProduceVisualPreviewRejectsOversizedPNGDimensionsBeforeDecode(t *testing.T) {
 	source := mediatest.PNG(1, 1, color.White)
 	binary.BigEndian.PutUint32(source[16:20], 10001)
@@ -208,28 +236,40 @@ func TestVisualPreviewJPEGColorPolicyRejectsCMYK(t *testing.T) {
 	assert.False(t, visualPreviewJPEGColorModelSupported(color.CMYKModel))
 }
 
-func TestProduceVisualPreviewKeepsJPEGReadErrorsRetryable(t *testing.T) {
-	source := mediatest.JPEG(3, 2, color.White)
-	digest := sha256.Sum256(source)
+func TestProduceVisualPreviewKeepsImageReadErrorsRetryable(t *testing.T) {
 	readErr := errors.New("injected read failure")
-	for _, test := range []struct {
+	sources := []struct {
+		name, mediaType string
+		data            []byte
+	}{
+		{name: "jpeg", mediaType: "image/jpeg", data: mediatest.JPEG(3, 2, color.White)},
+		{name: "png", mediaType: "image/png", data: mediatest.PNG(3, 2, color.White)},
+	}
+	phases := []struct {
 		name       string
 		failAtSeek int
 	}{
 		{name: "header", failAtSeek: 3},
 		{name: "pixels", failAtSeek: 4},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			reader := &failingVisualPreviewReadSeeker{
-				Reader: bytes.NewReader(source), failAtSeek: test.failAtSeek, err: readErr,
-			}
+	}
+	for _, source := range sources {
+		t.Run(source.name, func(t *testing.T) {
+			digest := sha256.Sum256(source.data)
+			for _, phase := range phases {
+				t.Run(phase.name, func(t *testing.T) {
+					reader := &failingVisualPreviewReadSeeker{
+						Reader: bytes.NewReader(source.data), failAtSeek: phase.failAtSeek, err: readErr,
+					}
 
-			_, err := ProduceVisualPreview(t.Context(), reader, VisualPreviewTarget{
-				SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/jpeg",
-			})
-			require.Error(t, err)
-			assert.True(t, IsSourceContentUnavailable(err))
-			assert.ErrorIs(t, err, readErr)
+					_, err := ProduceVisualPreview(t.Context(), reader, VisualPreviewTarget{
+						SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source.data)),
+						MediaType: source.mediaType,
+					})
+					require.Error(t, err)
+					assert.True(t, IsSourceContentUnavailable(err))
+					assert.ErrorIs(t, err, readErr)
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
Docbank can now produce its canonical JPEG preview from PNG originals. Embedded applications get the same exact-version preview identity, verified reads, and storage lifecycle already available for JPEG sources.

PNG previews apply EXIF orientation and enforce the existing pixel bound. Transparent pixels are composited onto white because the canonical output is JPEG, while embedded ICC profiles remain unsupported until Docbank has managed color conversion. The updated processor identity causes an earlier unsupported PNG result to be processed again when requested.
