### PR TITLE
Preserve high-density detail in canonical previews

### DIFF
--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -66,7 +66,7 @@ may be grayscale or three-component images; CMYK, YCCK, and embedded ICC
 profiles remain unsupported rather than receiving an unmanaged color
 conversion. PNG inputs apply bounded EXIF orientation, reject embedded ICC
 profiles, and composite transparency onto white because the canonical output
-is JPEG. Accepted images scale without upscaling to a 2048-pixel maximum edge
+is JPEG. Accepted images scale without upscaling to a 4096-pixel maximum edge
 and encode as a quality-90 JPEG. Malformed source bytes become a durable
 `failed` result; unsupported media types, decoder features, and color profiles
 become a durable `unsupported` result. Read, verification, storage, and

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	visualPreviewMaxEdgePixels   = 2048
+	visualPreviewMaxEdgePixels   = 4096
 	visualPreviewMaxSourcePixels = 100_000_000
 	visualPreviewJPEGQuality     = 90
 	visualPreviewMaxJPEGSegments = 1024
@@ -42,7 +42,7 @@ var visualPreviewRecipe = document.VisualPreviewRecipeV1{
 	FramePolicy:       "primary",
 	ProcessorFingerprint: fingerprintVisualPreviewProcessor(
 		"docbank-visual-preview:jpeg+png-stdlib-" + runtime.Version() +
-			"+x-image-draw-v0.44.0:max-edge=2048:quality=90:alpha=white:v2"),
+			"+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v3"),
 }
 
 // VisualPreviewTarget identifies one exact immutable source to process.

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -44,6 +44,14 @@ func TestProduceVisualPreviewAppliesEXIFOrientation(t *testing.T) {
 	assert.Equal(t, 3, decoded.Bounds().Dy())
 }
 
+func TestVisualPreviewPreservesHighDensityDetail(t *testing.T) {
+	recipe := CurrentVisualPreviewRecipe()
+	assert.Equal(t, 4096, recipe.MaxEdgePixels)
+	width, height := boundedVisualPreviewDimensions(6000, 4000)
+	assert.Equal(t, 4096, width)
+	assert.Equal(t, 2731, height)
+}
+
 func TestProduceVisualPreviewRejectsEmbeddedICCProfile(t *testing.T) {
 	tiff := syntheticTIFF(42, nil, []syntheticTIFFEntry{tiffShort(0xa001, 1)})
 	source := syntheticJPEGSegment(t, mediatest.JPEG(3, 2, color.White), 0xe1,

--- a/vault_test.go
+++ b/vault_test.go
@@ -367,7 +367,7 @@ func TestVaultEnsureVisualPreviewProducesBoundedJPEG(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, vault.Close()) })
 
-	source := mediatest.JPEG(2050, 2, color.RGBA{R: 220, G: 40, B: 20, A: 255})
+	source := mediatest.JPEG(4100, 2, color.RGBA{R: 220, G: 40, B: 20, A: 255})
 	receipt, err := vault.Create(t.Context(), "/photo.jpg", bytes.NewReader(source), CreateOptions{
 		MediaType: "image/jpeg", Expected: contentIdentity(source),
 	})
@@ -378,7 +378,7 @@ func TestVaultEnsureVisualPreviewProducesBoundedJPEG(t *testing.T) {
 	require.NotNil(t, preview.Output)
 	assert.Equal(t, document.VisualPreviewReady, preview.State)
 	assert.Equal(t, "image/jpeg", preview.Output.MediaType)
-	assert.Equal(t, 2048, preview.Output.Width)
+	assert.Equal(t, 4096, preview.Output.Width)
 	assert.Equal(t, 2, preview.Output.Height)
 	assert.Equal(t, receipt.Version.ID, preview.Version.ID)
 
@@ -393,7 +393,7 @@ func TestVaultEnsureVisualPreviewProducesBoundedJPEG(t *testing.T) {
 	require.NoError(t, opened.Reader.Close())
 	decoded, err := jpeg.Decode(bytes.NewReader(encoded))
 	require.NoError(t, err)
-	assert.Equal(t, 2048, decoded.Bounds().Dx())
+	assert.Equal(t, 4096, decoded.Bounds().Dx())
 	assert.Equal(t, 2, decoded.Bounds().Dy())
 }
 


### PR DESCRIPTION
Canonical previews now retain up to 4096 pixels on their longest edge, giving embedded applications enough detail for high-density image and document views without decoding the original again.

The processor identity changes with the limit. Existing lower-resolution generations therefore regenerate on demand, while smaller sources still avoid upscaling.
