### PR TITLE
Produce canonical previews for GIF originals

### DIFF
--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -61,12 +61,13 @@ source before decoding and holds the vault mutation boundary through
 publication, so callers either observe a complete generation or a retryable
 error.
 
-The built-in producer currently accepts JPEG and PNG originals. JPEG inputs
+The built-in producer currently accepts JPEG, PNG, and GIF originals. JPEG inputs
 may be grayscale or three-component images; CMYK, YCCK, and embedded ICC
 profiles remain unsupported rather than receiving an unmanaged color
 conversion. PNG inputs apply bounded EXIF orientation, reject embedded ICC
 profiles, and composite transparency onto white because the canonical output
-is JPEG. Accepted images scale without upscaling to a 4096-pixel maximum edge
+is JPEG. GIF inputs use their primary frame, including for animated sources.
+Accepted images scale without upscaling to a 4096-pixel maximum edge
 and encode as a quality-90 JPEG. Malformed source bytes become a durable
 `failed` result; unsupported media types, decoder features, and color profiles
 become a durable `unsupported` result. Read, verification, storage, and

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -13,6 +13,7 @@ import (
 	"image"
 	"image/color"
 	"image/draw"
+	"image/gif"
 	"image/jpeg"
 	"image/png"
 	"io"
@@ -41,8 +42,8 @@ var visualPreviewRecipe = document.VisualPreviewRecipeV1{
 	ColorPolicy:       "srgb",
 	FramePolicy:       "primary",
 	ProcessorFingerprint: fingerprintVisualPreviewProcessor(
-		"docbank-visual-preview:jpeg+png-stdlib-" + runtime.Version() +
-			"+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v3"),
+		"docbank-visual-preview:jpeg+png+gif-stdlib-" + runtime.Version() +
+			"+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v4"),
 }
 
 // VisualPreviewTarget identifies one exact immutable source to process.
@@ -84,13 +85,46 @@ func ProduceVisualPreview(
 		return produceVisualPreviewJPEG(ctx, source, base)
 	case "image/png":
 		return produceVisualPreviewPNG(ctx, source, target.Size, base)
+	case "image/gif":
+		return produceVisualPreviewGIF(source, base)
 	default:
 		base.State = document.VisualPreviewUnsupported
 		base.Failure = &document.VisualPreviewFailureV1{
-			Code: "unsupported_media_type", Detail: "the built-in preview producer supports JPEG and PNG originals",
+			Code:   "unsupported_media_type",
+			Detail: "the built-in preview producer supports JPEG, PNG, and GIF originals",
 		}
 		return VisualPreviewProduct{Preview: base}, nil
 	}
+}
+
+func produceVisualPreviewGIF(
+	source io.ReadSeeker, base document.VisualPreviewV1,
+) (VisualPreviewProduct, error) {
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("seeking visual preview source: %w", err))
+	}
+	configReader := &visualPreviewReadErrorRecorder{reader: source}
+	config, err := gif.DecodeConfig(configReader)
+	if err != nil {
+		return visualPreviewGIFDecodeResult(base, "the verified GIF header is malformed", configReader.err)
+	}
+	if !visualPreviewDimensionsAllowed(config.Width, config.Height) {
+		return failedVisualPreview(base, "source_dimensions_exceed_limit",
+			"the GIF dimensions exceed the built-in preview limit"), nil
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("seeking visual preview source: %w", err))
+	}
+	pixelReader := &visualPreviewReadErrorRecorder{reader: source}
+	decoded, err := gif.Decode(pixelReader)
+	if err != nil {
+		return visualPreviewGIFDecodeResult(base, "the verified GIF cannot be decoded", pixelReader.err)
+	}
+	canvas := image.NewNRGBA(image.Rect(0, 0, config.Width, config.Height))
+	draw.Draw(canvas, decoded.Bounds(), decoded, decoded.Bounds().Min, draw.Src)
+	return encodeVisualPreview(base, canvas, config.Width, config.Height, 1)
 }
 
 func produceVisualPreviewJPEG(
@@ -457,6 +491,29 @@ func visualPreviewPNGDecodeResult(
 	}
 	return VisualPreviewProduct{}, sourceContentUnavailable(
 		fmt.Errorf("reading visual preview PNG: %w", err))
+}
+
+func visualPreviewGIFDecodeResult(
+	base document.VisualPreviewV1, malformedDetail string, readErr error,
+) (VisualPreviewProduct, error) {
+	if readErr != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("reading visual preview GIF: %w", readErr))
+	}
+	return failedVisualPreview(base, "decode_failed", malformedDetail), nil
+}
+
+type visualPreviewReadErrorRecorder struct {
+	reader io.Reader
+	err    error
+}
+
+func (reader *visualPreviewReadErrorRecorder) Read(target []byte) (int, error) {
+	read, err := reader.reader.Read(target)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) && reader.err == nil {
+		reader.err = err
+	}
+	return read, err
 }
 
 func visualPreviewOrientationSwapsDimensions(orientation int) bool {

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -9,6 +9,7 @@ import (
 	"hash/crc32"
 	"image"
 	"image/color"
+	"image/gif"
 	"image/jpeg"
 	"image/png"
 	"io"
@@ -136,6 +137,42 @@ func TestProduceVisualPreviewAppliesPNGEXIFOrientation(t *testing.T) {
 	assert.Equal(t, 3, product.Preview.Output.Height)
 }
 
+func TestProduceVisualPreviewUsesGIFPrimaryFrame(t *testing.T) {
+	palette := color.Palette{color.Black, color.White}
+	primary := image.NewPaletted(image.Rect(16, 8, 48, 24), palette)
+	later := image.NewPaletted(image.Rect(0, 0, 64, 32), palette)
+	for index := range later.Pix {
+		later.Pix[index] = 1
+	}
+	var encoded bytes.Buffer
+	require.NoError(t, gif.EncodeAll(&encoded, &gif.GIF{
+		Image: []*image.Paletted{primary, later}, Delay: []int{10, 10},
+		Config: image.Config{ColorModel: palette, Width: 64, Height: 32},
+	}))
+	source := encoded.Bytes()
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)),
+		MediaType: "IMAGE/GIF; charset=utf-8",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 64, product.Preview.Output.Width)
+	assert.Equal(t, 32, product.Preview.Output.Height)
+	preview, err := jpeg.Decode(bytes.NewReader(product.Output))
+	require.NoError(t, err)
+	primaryRed, primaryGreen, primaryBlue, _ := preview.At(32, 16).RGBA()
+	assert.Less(t, primaryRed, uint32(0x1000))
+	assert.Less(t, primaryGreen, uint32(0x1000))
+	assert.Less(t, primaryBlue, uint32(0x1000))
+	canvasRed, canvasGreen, canvasBlue, _ := preview.At(8, 4).RGBA()
+	assert.Greater(t, canvasRed, uint32(0xf000))
+	assert.Greater(t, canvasGreen, uint32(0xf000))
+	assert.Greater(t, canvasBlue, uint32(0xf000))
+}
+
 func TestProduceVisualPreviewRejectsPNGICCProfile(t *testing.T) {
 	source := syntheticPNGChunk(t, mediatest.PNG(3, 2, color.White), "iCCP", []byte("profile"))
 	digest := sha256.Sum256(source)
@@ -237,6 +274,20 @@ func TestProduceVisualPreviewRecordsTruncatedJPEGFailure(t *testing.T) {
 	assert.Empty(t, product.Output)
 }
 
+func TestProduceVisualPreviewRecordsMalformedGIFFailure(t *testing.T) {
+	source := []byte("GIF89a")
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/gif",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewFailed, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "decode_failed", product.Preview.Failure.Code)
+	assert.Empty(t, product.Output)
+}
+
 func TestVisualPreviewJPEGColorPolicyRejectsCMYK(t *testing.T) {
 	assert.True(t, visualPreviewJPEGColorModelSupported(color.GrayModel))
 	assert.True(t, visualPreviewJPEGColorModelSupported(color.YCbCrModel))
@@ -249,24 +300,25 @@ func TestProduceVisualPreviewKeepsImageReadErrorsRetryable(t *testing.T) {
 	sources := []struct {
 		name, mediaType string
 		data            []byte
+		failAtSeeks     [2]int
 	}{
-		{name: "jpeg", mediaType: "image/jpeg", data: mediatest.JPEG(3, 2, color.White)},
-		{name: "png", mediaType: "image/png", data: mediatest.PNG(3, 2, color.White)},
+		{name: "jpeg", mediaType: "image/jpeg", data: mediatest.JPEG(3, 2, color.White), failAtSeeks: [2]int{3, 4}},
+		{name: "png", mediaType: "image/png", data: mediatest.PNG(3, 2, color.White), failAtSeeks: [2]int{3, 4}},
+		{name: "gif", mediaType: "image/gif", data: mediatest.GIF(3, 2, 1), failAtSeeks: [2]int{2, 3}},
 	}
 	phases := []struct {
-		name       string
-		failAtSeek int
+		name string
 	}{
-		{name: "header", failAtSeek: 3},
-		{name: "pixels", failAtSeek: 4},
+		{name: "header"},
+		{name: "pixels"},
 	}
 	for _, source := range sources {
 		t.Run(source.name, func(t *testing.T) {
 			digest := sha256.Sum256(source.data)
-			for _, phase := range phases {
+			for index, phase := range phases {
 				t.Run(phase.name, func(t *testing.T) {
 					reader := &failingVisualPreviewReadSeeker{
-						Reader: bytes.NewReader(source.data), failAtSeek: phase.failAtSeek, err: readErr,
+						Reader: bytes.NewReader(source.data), failAtSeek: source.failAtSeeks[index], err: readErr,
 					}
 
 					_, err := ProduceVisualPreview(t.Context(), reader, VisualPreviewTarget{


### PR DESCRIPTION
Docbank can now produce its canonical JPEG preview from still and animated GIF originals. Embedded applications get the same exact-version identity, verified reads, and storage lifecycle already available for JPEG and PNG sources.

Animated GIFs deliberately use their primary frame. A partial primary frame is placed on the logical canvas, and transparency is composited onto white before scaling. Malformed GIFs become durable failures, while source-read failures remain retryable. The changed processor identity causes earlier unsupported GIF results to be produced again when requested.
