### PR TITLE
Produce canonical previews for WebP images

### DIFF
--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -61,12 +61,14 @@ source before decoding and holds the vault mutation boundary through
 publication, so callers either observe a complete generation or a retryable
 error.
 
-The built-in producer currently accepts JPEG, PNG, and GIF originals. JPEG inputs
+The built-in producer currently accepts JPEG, PNG, GIF, and still WebP originals. JPEG inputs
 may be grayscale or three-component images; CMYK, YCCK, and embedded ICC
 profiles remain unsupported rather than receiving an unmanaged color
 conversion. PNG inputs apply bounded EXIF orientation, reject embedded ICC
 profiles, and composite transparency onto white because the canonical output
 is JPEG. GIF inputs use their primary frame, including for animated sources.
+WebP inputs apply bounded EXIF orientation and reject embedded ICC profiles;
+animated WebP remains unsupported by the built-in decoder.
 Accepted images scale without upscaling to a 4096-pixel maximum edge
 and encode as a quality-90 JPEG. Malformed source bytes become a durable
 `failed` result; unsupported media types, decoder features, and color profiles

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 
 	xdraw "golang.org/x/image/draw"
+	"golang.org/x/image/webp"
 
 	"go.kenn.io/docbank/document"
 )
@@ -31,7 +32,11 @@ const (
 	visualPreviewJPEGQuality     = 90
 	visualPreviewMaxJPEGSegments = 1024
 	visualPreviewMaxPNGChunks    = 1024
-	visualPreviewMaxPNGEXIFBytes = 1 << 20
+	visualPreviewMaxWebPChunks   = 1024
+	visualPreviewMaxEXIFBytes    = 1 << 20
+	visualPreviewWebPAnimation   = 1 << 1
+	visualPreviewWebPEXIF        = 1 << 3
+	visualPreviewWebPICCProfile  = 1 << 5
 )
 
 var visualPreviewRecipe = document.VisualPreviewRecipeV1{
@@ -43,7 +48,7 @@ var visualPreviewRecipe = document.VisualPreviewRecipeV1{
 	FramePolicy:       "primary",
 	ProcessorFingerprint: fingerprintVisualPreviewProcessor(
 		"docbank-visual-preview:jpeg+png+gif-stdlib-" + runtime.Version() +
-			"+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v4"),
+			"+webp+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v5"),
 }
 
 // VisualPreviewTarget identifies one exact immutable source to process.
@@ -87,11 +92,13 @@ func ProduceVisualPreview(
 		return produceVisualPreviewPNG(ctx, source, target.Size, base)
 	case "image/gif":
 		return produceVisualPreviewGIF(source, base)
+	case "image/webp":
+		return produceVisualPreviewWebP(ctx, source, target.Size, base)
 	default:
 		base.State = document.VisualPreviewUnsupported
 		base.Failure = &document.VisualPreviewFailureV1{
 			Code:   "unsupported_media_type",
-			Detail: "the built-in preview producer supports JPEG, PNG, and GIF originals",
+			Detail: "the built-in preview producer supports JPEG, PNG, GIF, and WebP originals",
 		}
 		return VisualPreviewProduct{Preview: base}, nil
 	}
@@ -125,6 +132,67 @@ func produceVisualPreviewGIF(
 	canvas := image.NewNRGBA(image.Rect(0, 0, config.Width, config.Height))
 	draw.Draw(canvas, decoded.Bounds(), decoded, decoded.Bounds().Min, draw.Src)
 	return encodeVisualPreview(base, canvas, config.Width, config.Height, 1)
+}
+
+func produceVisualPreviewWebP(
+	ctx context.Context, source io.ReadSeeker, sourceSize int64, base document.VisualPreviewV1,
+) (VisualPreviewProduct, error) {
+	orientation, unsupportedColor, unsupportedMetadata, animated, malformed, err :=
+		inspectVisualPreviewWebP(ctx, source, sourceSize)
+	if err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("inspecting visual preview WebP: %w", err))
+	}
+	if malformed {
+		return failedVisualPreview(base, "decode_failed", "the verified WebP container is malformed"), nil
+	}
+	if animated {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_webp_animation", Detail: "the built-in preview producer requires a still WebP original",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if unsupportedColor {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_color_profile", Detail: "the built-in preview producer requires an sRGB WebP original",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if unsupportedMetadata {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code: "unsupported_webp_metadata", Detail: "the WebP metadata exceeds the built-in preview limit",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("seeking visual preview source: %w", err))
+	}
+	configReader := &visualPreviewReadErrorRecorder{reader: source}
+	config, err := webp.DecodeConfig(configReader)
+	if err != nil {
+		return visualPreviewWebPDecodeResult(base, "the verified WebP header is malformed", configReader.err)
+	}
+	if !visualPreviewDimensionsAllowed(config.Width, config.Height) {
+		return failedVisualPreview(base, "source_dimensions_exceed_limit",
+			"the WebP dimensions exceed the built-in preview limit"), nil
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("seeking visual preview source: %w", err))
+	}
+	pixelReader := &visualPreviewReadErrorRecorder{reader: source}
+	decoded, err := webp.Decode(pixelReader)
+	if err != nil {
+		return visualPreviewWebPDecodeResult(base, "the verified WebP cannot be decoded", pixelReader.err)
+	}
+	if decoded.Bounds().Dx() != config.Width || decoded.Bounds().Dy() != config.Height {
+		return failedVisualPreview(base, "decode_failed", "the WebP dimensions changed during decoding"), nil
+	}
+	return encodeVisualPreview(base, decoded, config.Width, config.Height, orientation)
 }
 
 func produceVisualPreviewJPEG(
@@ -317,7 +385,7 @@ func inspectVisualPreviewPNG(
 		case "iCCP":
 			unsupportedColor = true
 		case "eXIf":
-			if length > visualPreviewMaxPNGEXIFBytes {
+			if length > visualPreviewMaxEXIFBytes {
 				unsupportedMetadata = true
 				break
 			}
@@ -342,6 +410,94 @@ func inspectVisualPreviewPNG(
 		offset += 12 + int64(binary.BigEndian.Uint32(header[:4]))
 	}
 	return 0, false, false, true, nil
+}
+
+func inspectVisualPreviewWebP(
+	ctx context.Context, source io.ReadSeeker, sourceSize int64,
+) (orientation int, unsupportedColor, unsupportedMetadata, animated, malformed bool, err error) {
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return 0, false, false, false, false, err
+	}
+	var header [12]byte
+	if _, err := io.ReadFull(source, header[:]); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return 0, false, false, false, true, nil
+		}
+		return 0, false, false, false, false, err
+	}
+	if sourceSize < int64(len(header)) || string(header[:4]) != "RIFF" || string(header[8:]) != "WEBP" ||
+		uint64(binary.LittleEndian.Uint32(header[4:8]))+8 != uint64(sourceSize) {
+		return 0, false, false, false, true, nil
+	}
+	orientation = 1
+	offset := int64(len(header))
+	for range visualPreviewMaxWebPChunks {
+		if err := ctx.Err(); err != nil {
+			return 0, false, false, false, false, err
+		}
+		if offset == sourceSize {
+			return orientation, unsupportedColor, unsupportedMetadata, animated, false, nil
+		}
+		if offset > sourceSize-8 {
+			return 0, false, false, false, true, nil
+		}
+		var chunkHeader [8]byte
+		if _, err := io.ReadFull(source, chunkHeader[:]); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return 0, false, false, false, true, nil
+			}
+			return 0, false, false, false, false, err
+		}
+		length := int64(binary.LittleEndian.Uint32(chunkHeader[4:]))
+		paddedLength := length + length%2
+		if paddedLength > sourceSize-offset-8 {
+			return 0, false, false, false, true, nil
+		}
+		seekLength := paddedLength
+		switch string(chunkHeader[:4]) {
+		case "VP8X":
+			if length != 10 {
+				return 0, false, false, false, true, nil
+			}
+			var flags [1]byte
+			if _, err := io.ReadFull(source, flags[:]); err != nil {
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+					return 0, false, false, false, true, nil
+				}
+				return 0, false, false, false, false, err
+			}
+			animated = animated || flags[0]&visualPreviewWebPAnimation != 0
+			unsupportedColor = unsupportedColor || flags[0]&visualPreviewWebPICCProfile != 0
+			seekLength--
+		case "ICCP":
+			unsupportedColor = true
+		case "ANIM", "ANMF":
+			animated = true
+		case "EXIF":
+			if length > visualPreviewMaxEXIFBytes {
+				unsupportedMetadata = true
+				break
+			}
+			payload := make([]byte, length)
+			if _, err := io.ReadFull(source, payload); err != nil {
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+					return 0, false, false, false, true, nil
+				}
+				return 0, false, false, false, false, err
+			}
+			payload = bytes.TrimPrefix(payload, []byte("Exif\x00\x00"))
+			if value, colorSpace, found := visualPreviewEXIF(payload); found {
+				orientation = value
+				unsupportedColor = unsupportedColor || colorSpace != 0 && colorSpace != 1
+			}
+			seekLength = length % 2
+		}
+		if _, err := source.Seek(seekLength, io.SeekCurrent); err != nil {
+			return 0, false, false, false, false, err
+		}
+		offset += 8 + paddedLength
+	}
+	return 0, false, true, false, false, nil
 }
 
 func inspectVisualPreviewJPEG(
@@ -499,6 +655,16 @@ func visualPreviewGIFDecodeResult(
 	if readErr != nil {
 		return VisualPreviewProduct{}, sourceContentUnavailable(
 			fmt.Errorf("reading visual preview GIF: %w", readErr))
+	}
+	return failedVisualPreview(base, "decode_failed", malformedDetail), nil
+}
+
+func visualPreviewWebPDecodeResult(
+	base document.VisualPreviewV1, malformedDetail string, readErr error,
+) (VisualPreviewProduct, error) {
+	if readErr != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("reading visual preview WebP: %w", readErr))
 	}
 	return failedVisualPreview(base, "decode_failed", malformedDetail), nil
 }

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -3,6 +3,7 @@ package processing
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -173,6 +174,54 @@ func TestProduceVisualPreviewUsesGIFPrimaryFrame(t *testing.T) {
 	assert.Greater(t, canvasBlue, uint32(0xf000))
 }
 
+func TestProduceVisualPreviewAcceptsWebP(t *testing.T) {
+	source := mustDecodeWebP(t)
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)),
+		MediaType: "IMAGE/WEBP; charset=utf-8",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 75, product.Preview.Output.Width)
+	assert.Equal(t, 100, product.Preview.Output.Height)
+}
+
+func TestProduceVisualPreviewAppliesWebPEXIFOrientation(t *testing.T) {
+	source := mustDecodeWebP(t)
+	source = syntheticExtendedWebP(t, source, 75, 100, visualPreviewWebPEXIF, "EXIF",
+		syntheticTIFF(42, []syntheticTIFFEntry{tiffShort(0x0112, 6)}, nil))
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/webp",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 100, product.Preview.Output.Width)
+	assert.Equal(t, 75, product.Preview.Output.Height)
+}
+
+func TestProduceVisualPreviewRejectsWebPICCProfile(t *testing.T) {
+	source, err := base64.StdEncoding.DecodeString(
+		"UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA",
+	)
+	require.NoError(t, err)
+	source = syntheticExtendedWebP(t, source, 1, 1, visualPreviewWebPICCProfile, "ICCP", []byte("profile"))
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/webp",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewUnsupported, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "unsupported_color_profile", product.Preview.Failure.Code)
+}
+
 func TestProduceVisualPreviewRejectsPNGICCProfile(t *testing.T) {
 	source := syntheticPNGChunk(t, mediatest.PNG(3, 2, color.White), "iCCP", []byte("profile"))
 	digest := sha256.Sum256(source)
@@ -288,6 +337,19 @@ func TestProduceVisualPreviewRecordsMalformedGIFFailure(t *testing.T) {
 	assert.Empty(t, product.Output)
 }
 
+func TestProduceVisualPreviewRecordsMalformedWebPFailure(t *testing.T) {
+	source := []byte("RIFF\x04\x00\x00\x00WEBP")
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/webp",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewFailed, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "decode_failed", product.Preview.Failure.Code)
+}
+
 func TestVisualPreviewJPEGColorPolicyRejectsCMYK(t *testing.T) {
 	assert.True(t, visualPreviewJPEGColorModelSupported(color.GrayModel))
 	assert.True(t, visualPreviewJPEGColorModelSupported(color.YCbCrModel))
@@ -305,6 +367,7 @@ func TestProduceVisualPreviewKeepsImageReadErrorsRetryable(t *testing.T) {
 		{name: "jpeg", mediaType: "image/jpeg", data: mediatest.JPEG(3, 2, color.White), failAtSeeks: [2]int{3, 4}},
 		{name: "png", mediaType: "image/png", data: mediatest.PNG(3, 2, color.White), failAtSeeks: [2]int{3, 4}},
 		{name: "gif", mediaType: "image/gif", data: mediatest.GIF(3, 2, 1), failAtSeeks: [2]int{2, 3}},
+		{name: "webp", mediaType: "image/webp", data: mustDecodeWebP(t), failAtSeeks: [2]int{3, 4}},
 	}
 	phases := []struct {
 		name string
@@ -368,6 +431,46 @@ func syntheticPNGChunk(t *testing.T, source []byte, chunkType string, payload []
 	result := append([]byte{}, source[:33]...)
 	result = append(result, chunk...)
 	return append(result, source[33:]...)
+}
+
+func mustDecodeWebP(t *testing.T) []byte {
+	t.Helper()
+	source, err := base64.StdEncoding.DecodeString(
+		"UklGRrIBAABXRUJQVlA4TKUBAAAvSsAYAA8w//M///MfeJAkbXvaSG7m8Q3GfYSBJekwQztm/IcZlgwnmWImn2BK7aFmBtnVir6q//8VOkFE/xm4baTIu8c48ArEo6+B3zFKYln3pqClSCKX0begFTAXFOLXHSyF8cCNcZEG4OywuA4KVVfJCiArU7GAgJI8+lJP/OKMT/fBAjevg1cYB7YVkFuWga2lyPi5I0HFy5YTpWIHg0RZpkniRVW9odHAKOwosWuOGdxIyn2OvaCDvhg/we6TwadPBPbqBV58MsLmMJ8yZnOWk8SRz4N+QoyPL+MnamzMvcE1rHNEr91F9GKZPVUcS9w7PhhH36suB9qPeYb/oLk6cuTiJ0wOK3m5h1cKjW6EVZCYMK7dxcKCBdgP9HkKr9gkAO2P8GKZGWVdIAatQa+1IDpt6qyorVwdy01xdW8Jkfk6xjEXmVQQ+HQdFr6OKhIN34dXWq0+0qr6EJSCeeVLH9+gvGTLyqM65PQ44ihzlTXxQKjKbAvshXgir7Lil9w4L2bvMycmjQcqXaMCO6BlY28i+FOLzbfI1vEqxAhotocAAA==",
+	)
+	require.NoError(t, err)
+	return source
+}
+
+func syntheticExtendedWebP(
+	t *testing.T, source []byte, width, height int, flags byte, chunkType string, payload []byte,
+) []byte {
+	t.Helper()
+	require.GreaterOrEqual(t, len(source), 12)
+	require.Equal(t, "RIFF", string(source[:4]))
+	require.Equal(t, "WEBP", string(source[8:12]))
+	require.Len(t, chunkType, 4)
+
+	vp8x := make([]byte, 18)
+	copy(vp8x[:4], "VP8X")
+	binary.LittleEndian.PutUint32(vp8x[4:8], 10)
+	vp8x[8] = flags
+	w, h := width-1, height-1
+	vp8x[12], vp8x[13], vp8x[14] = byte(w), byte(w>>8), byte(w>>16)
+	vp8x[15], vp8x[16], vp8x[17] = byte(h), byte(h>>8), byte(h>>16)
+	chunk := make([]byte, 8+len(payload)+len(payload)%2)
+	copy(chunk[:4], chunkType)
+	binary.LittleEndian.PutUint32(chunk[4:8], uint32(len(payload)))
+	copy(chunk[8:], payload)
+	body := make([]byte, 0, len(vp8x)+len(source)-12+len(chunk))
+	body = append(body, vp8x...)
+	body = append(body, source[12:]...)
+	body = append(body, chunk...)
+	result := make([]byte, 12, 12+len(body))
+	copy(result[:4], "RIFF")
+	binary.LittleEndian.PutUint32(result[4:8], uint32(4+len(body)))
+	copy(result[8:12], "WEBP")
+	return append(result, body...)
 }
 
 type failingVisualPreviewReadSeeker struct {


### PR DESCRIPTION
Docbank can now turn still WebP originals into the same retained JPEG preview it provides for JPEG, PNG, and GIF. Embedded applications can display these images without decoding authoritative originals themselves.

WebP previews honor EXIF orientation, flatten transparency onto white, and enforce the existing pixel and metadata limits. Files with embedded ICC color profiles remain unsupported until Docbank has managed color conversion. Animated WebP is also reported as unsupported instead of producing an incorrect still.

The processor identity changes with WebP support, so earlier unsupported results are produced again when requested.
