### PR TITLE
Produce canonical previews for camera RAW files

### DIFF
--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -61,10 +61,16 @@ source before decoding and holds the vault mutation boundary through
 publication, so callers either observe a complete generation or a retryable
 error.
 
-The built-in producer currently accepts JPEG, PNG, GIF, and still WebP originals. JPEG inputs
-may be grayscale or three-component images; CMYK, YCCK, and embedded ICC
-profiles remain unsupported rather than receiving an unmanaged color
-conversion. PNG inputs apply bounded EXIF orientation, reject embedded ICC
+The built-in producer accepts JPEG, PNG, GIF, still WebP, and camera RAW
+originals that contain a supported embedded JPEG preview. Camera RAW support
+covers Fujifilm RAF and TIFF-family Sony ARW, Adobe DNG, Canon CR2, and Nikon
+NEF files. It reads only bounded container metadata and the embedded preview;
+the complete original is still verified before decoding. A well-formed RAW file
+without a supported embedded preview records an `unsupported` result.
+
+JPEG inputs may be grayscale or three-component images; CMYK, YCCK, and
+embedded ICC profiles remain unsupported rather than receiving an unmanaged
+color conversion. PNG inputs apply bounded EXIF orientation, reject embedded ICC
 profiles, and composite transparency onto white because the canonical output
 is JPEG. GIF inputs use their primary frame, including for animated sources.
 WebP inputs apply bounded EXIF orientation and reject embedded ICC profiles;
@@ -76,6 +82,6 @@ become a durable `unsupported` result. Read, verification, storage, and
 cancellation failures are retryable.
 
 Preview production is application-driven: opening a vault does not start a
-worker. Other still-image formats, camera RAW files, video frames, and managed
-color conversion require additional producers, but they use the same
-generation, retention, backup, and read contracts.
+worker. Other still-image formats, RAW containers without a supported embedded
+JPEG, video frames, and managed color conversion require additional producers,
+but they use the same generation, retention, backup, and read contracts.

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -48,7 +48,7 @@ var visualPreviewRecipe = document.VisualPreviewRecipeV1{
 	FramePolicy:       "primary",
 	ProcessorFingerprint: fingerprintVisualPreviewProcessor(
 		"docbank-visual-preview:jpeg+png+gif-stdlib-" + runtime.Version() +
-			"+webp+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v5"),
+			"+webp+embedded-camera-raw+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v6"),
 }
 
 // VisualPreviewTarget identifies one exact immutable source to process.
@@ -94,11 +94,14 @@ func ProduceVisualPreview(
 		return produceVisualPreviewGIF(source, base)
 	case "image/webp":
 		return produceVisualPreviewWebP(ctx, source, target.Size, base)
+	case "image/x-sony-arw", "image/x-adobe-dng", "image/x-canon-cr2", "image/x-nikon-nef",
+		"image/x-fuji-raf":
+		return produceVisualPreviewCameraRAW(ctx, source, target.Size, mediaType, base)
 	default:
 		base.State = document.VisualPreviewUnsupported
 		base.Failure = &document.VisualPreviewFailureV1{
 			Code:   "unsupported_media_type",
-			Detail: "the built-in preview producer supports JPEG, PNG, GIF, and WebP originals",
+			Detail: "the built-in preview producer does not support this original's media type",
 		}
 		return VisualPreviewProduct{Preview: base}, nil
 	}
@@ -198,6 +201,12 @@ func produceVisualPreviewWebP(
 func produceVisualPreviewJPEG(
 	ctx context.Context, source io.ReadSeeker, base document.VisualPreviewV1,
 ) (VisualPreviewProduct, error) {
+	return produceVisualPreviewJPEGWithOrientation(ctx, source, base, 0)
+}
+
+func produceVisualPreviewJPEGWithOrientation(
+	ctx context.Context, source io.ReadSeeker, base document.VisualPreviewV1, containerOrientation int,
+) (VisualPreviewProduct, error) {
 	orientation, unsupportedColor, malformed, err := inspectVisualPreviewJPEG(ctx, source)
 	if err != nil {
 		return VisualPreviewProduct{}, sourceContentUnavailable(
@@ -212,6 +221,9 @@ func produceVisualPreviewJPEG(
 			Code: "unsupported_color_profile", Detail: "the built-in preview producer requires sRGB JPEG originals",
 		}
 		return VisualPreviewProduct{Preview: base}, nil
+	}
+	if containerOrientation >= 1 && containerOrientation <= 8 {
+		orientation = containerOrientation
 	}
 	if _, err := source.Seek(0, io.SeekStart); err != nil {
 		return VisualPreviewProduct{}, sourceContentUnavailable(

--- a/internal/processing/visual_preview_raw.go
+++ b/internal/processing/visual_preview_raw.go
@@ -1,0 +1,265 @@
+package processing
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"go.kenn.io/docbank/document"
+)
+
+const (
+	visualPreviewRAWMaxIFDs        = 64
+	visualPreviewRAWMaxIFDEntries  = 1024
+	visualPreviewRAWSubIFDsTag     = 0x014a
+	visualPreviewRAWOffsetTag      = 0x0201
+	visualPreviewRAWLengthTag      = 0x0202
+	visualPreviewRAWOrientationTag = 0x0112
+)
+
+type visualPreviewRAWLocation struct {
+	offset      int64
+	length      int64
+	orientation int
+}
+
+func produceVisualPreviewCameraRAW(
+	ctx context.Context,
+	source io.ReadSeeker,
+	sourceSize int64,
+	mediaType string,
+	base document.VisualPreviewV1,
+) (VisualPreviewProduct, error) {
+	readerAt := &seekReaderAt{seeker: source}
+	var location visualPreviewRAWLocation
+	var found, malformed bool
+	var err error
+	if mediaType == "image/x-fuji-raf" {
+		location, found, malformed, err = inspectVisualPreviewRAF(readerAt, sourceSize)
+	} else {
+		location, found, malformed, err = inspectVisualPreviewTIFFRAW(readerAt, sourceSize)
+	}
+	if err != nil {
+		return VisualPreviewProduct{}, sourceContentUnavailable(
+			fmt.Errorf("inspecting camera RAW preview: %w", err))
+	}
+	if malformed {
+		return failedVisualPreview(base, "decode_failed",
+			"the verified camera RAW preview metadata is malformed"), nil
+	}
+	if !found {
+		base.State = document.VisualPreviewUnsupported
+		base.Failure = &document.VisualPreviewFailureV1{
+			Code:   "embedded_preview_unavailable",
+			Detail: "the camera RAW original has no supported embedded JPEG preview",
+		}
+		return VisualPreviewProduct{Preview: base}, nil
+	}
+	preview := io.NewSectionReader(readerAt, location.offset, location.length)
+	return produceVisualPreviewJPEGWithOrientation(ctx, preview, base, location.orientation)
+}
+
+func inspectVisualPreviewRAF(
+	reader io.ReaderAt, sourceSize int64,
+) (visualPreviewRAWLocation, bool, bool, error) {
+	header, err := readSourceMetadataRange(reader, 0, min(sourceSize, sourceMetadataRAFHeaderBytes))
+	if err != nil {
+		return visualPreviewRAWLocation{}, false, false, err
+	}
+	if len(header) < sourceMetadataRAFHeaderBytes || !isSourceMetadataRAF(header) {
+		return visualPreviewRAWLocation{}, false, true, nil
+	}
+	offset := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFJPEGOffset:]))
+	length := int64(binary.BigEndian.Uint32(header[sourceMetadataRAFJPEGOffset+4:]))
+	if offset < sourceMetadataRAFHeaderBytes || !sourceMetadataRangeWithin(offset, length, sourceSize) {
+		return visualPreviewRAWLocation{}, false, true, nil
+	}
+	return visualPreviewRAWLocation{offset: offset, length: length}, true, false, nil
+}
+
+func inspectVisualPreviewTIFFRAW(
+	reader io.ReaderAt, sourceSize int64,
+) (visualPreviewRAWLocation, bool, bool, error) {
+	header, err := readSourceMetadataRange(reader, 0, min(sourceSize, int64(8)))
+	if err != nil {
+		return visualPreviewRAWLocation{}, false, false, err
+	}
+	order, format, ok := exifTIFFHeader(header)
+	if !ok || format != "tiff" || len(header) < 8 {
+		return visualPreviewRAWLocation{}, false, true, nil
+	}
+	rootOffset := int64(order.Uint32(header[4:8]))
+	if rootOffset < 8 || rootOffset >= sourceSize {
+		return visualPreviewRAWLocation{}, false, true, nil
+	}
+
+	queue := []int64{rootOffset}
+	seen := make(map[int64]struct{}, visualPreviewRAWMaxIFDs)
+	orientation := 0
+	best := visualPreviewRAWLocation{}
+	malformed := false
+	for len(queue) > 0 {
+		offset := queue[0]
+		queue = queue[1:]
+		if offset == 0 {
+			continue
+		}
+		if _, duplicate := seen[offset]; duplicate {
+			continue
+		}
+		if len(seen) >= visualPreviewRAWMaxIFDs {
+			return visualPreviewRAWLocation{}, false, true, nil
+		}
+		seen[offset] = struct{}{}
+
+		entries, next, subIFDs, valid, readErr := readVisualPreviewRAWIFD(reader, sourceSize, order, offset)
+		if readErr != nil {
+			return visualPreviewRAWLocation{}, false, false, readErr
+		}
+		if !valid {
+			malformed = true
+			continue
+		}
+		if value, found := entries[visualPreviewRAWOrientationTag]; orientation == 0 && found && value >= 1 && value <= 8 {
+			orientation = int(value)
+		}
+		previewOffset, hasOffset := entries[visualPreviewRAWOffsetTag]
+		previewLength, hasLength := entries[visualPreviewRAWLengthTag]
+		if hasOffset != hasLength {
+			malformed = true
+		} else if hasOffset {
+			candidate := visualPreviewRAWLocation{
+				offset: int64(previewOffset), length: int64(previewLength), orientation: orientation,
+			}
+			if !sourceMetadataRangeWithin(candidate.offset, candidate.length, sourceSize) {
+				malformed = true
+			} else if candidate.length > best.length {
+				best = candidate
+			}
+		}
+		queue = append(queue, subIFDs...)
+		if next != 0 {
+			queue = append(queue, next)
+		}
+	}
+	if best.length > 0 {
+		return best, true, false, nil
+	}
+	return visualPreviewRAWLocation{}, false, malformed, nil
+}
+
+func readVisualPreviewRAWIFD(
+	reader io.ReaderAt,
+	sourceSize int64,
+	order binary.ByteOrder,
+	offset int64,
+) (map[uint16]uint32, int64, []int64, bool, error) {
+	if !sourceMetadataRangeWithin(offset, 2, sourceSize) {
+		return nil, 0, nil, false, nil
+	}
+	countBytes, err := readSourceMetadataRange(reader, offset, 2)
+	if err != nil {
+		return nil, 0, nil, false, err
+	}
+	count := int64(order.Uint16(countBytes))
+	if count > visualPreviewRAWMaxIFDEntries {
+		return nil, 0, nil, false, nil
+	}
+	tableLength := count*12 + 4
+	if !sourceMetadataRangeWithin(offset+2, tableLength, sourceSize) {
+		return nil, 0, nil, false, nil
+	}
+	table, err := readSourceMetadataRange(reader, offset+2, tableLength)
+	if err != nil {
+		return nil, 0, nil, false, err
+	}
+	values := make(map[uint16]uint32, 3)
+	seenValues := make(map[uint16]struct{}, 3)
+	var subIFDs []int64
+	for index := range count {
+		entry := table[index*12 : index*12+12]
+		tag := order.Uint16(entry)
+		kind := order.Uint16(entry[2:])
+		items := order.Uint32(entry[4:])
+		if tag == visualPreviewRAWSubIFDsTag {
+			offsets, valid, readErr := readVisualPreviewRAWSubIFDs(
+				reader, sourceSize, order, kind, items, entry[8:12])
+			if readErr != nil {
+				return nil, 0, nil, false, readErr
+			}
+			if !valid {
+				return nil, 0, nil, false, nil
+			}
+			subIFDs = append(subIFDs, offsets...)
+			continue
+		}
+		if tag != visualPreviewRAWOffsetTag && tag != visualPreviewRAWLengthTag &&
+			tag != visualPreviewRAWOrientationTag {
+			continue
+		}
+		if _, duplicate := seenValues[tag]; duplicate {
+			return nil, 0, nil, false, nil
+		}
+		seenValues[tag] = struct{}{}
+		value, valid := visualPreviewRAWScalar(order, kind, items, entry[8:12])
+		if !valid {
+			return nil, 0, nil, false, nil
+		}
+		values[tag] = value
+	}
+	next := int64(order.Uint32(table[count*12:]))
+	if next >= sourceSize {
+		return nil, 0, nil, false, nil
+	}
+	return values, next, subIFDs, true, nil
+}
+
+func readVisualPreviewRAWSubIFDs(
+	reader io.ReaderAt,
+	sourceSize int64,
+	order binary.ByteOrder,
+	kind uint16,
+	items uint32,
+	inline []byte,
+) ([]int64, bool, error) {
+	if kind != 4 || items == 0 || items > visualPreviewRAWMaxIFDs {
+		return nil, false, nil
+	}
+	values := inline
+	if items > 1 {
+		offset := int64(order.Uint32(inline))
+		length := int64(items) * 4
+		if !sourceMetadataRangeWithin(offset, length, sourceSize) {
+			return nil, false, nil
+		}
+		var err error
+		values, err = readSourceMetadataRange(reader, offset, length)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	offsets := make([]int64, 0, items)
+	for index := range items {
+		offset := int64(order.Uint32(values[index*4:]))
+		if offset == 0 || offset >= sourceSize {
+			return nil, false, nil
+		}
+		offsets = append(offsets, offset)
+	}
+	return offsets, true, nil
+}
+
+func visualPreviewRAWScalar(order binary.ByteOrder, kind uint16, items uint32, inline []byte) (uint32, bool) {
+	if items != 1 {
+		return 0, false
+	}
+	switch kind {
+	case 3:
+		return uint32(order.Uint16(inline)), true
+	case 4:
+		return order.Uint32(inline), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/processing/visual_preview_raw.go
+++ b/internal/processing/visual_preview_raw.go
@@ -121,7 +121,7 @@ func inspectVisualPreviewTIFFRAW(
 
 	queue := []int64{rootOffset}
 	seen := make(map[int64]struct{}, visualPreviewRAWMaxIFDs)
-	orientation := 0
+	rootOrientation := 0
 	var candidates []visualPreviewRAWLocation
 	malformed := false
 	for len(queue) > 0 {
@@ -146,8 +146,12 @@ func inspectVisualPreviewTIFFRAW(
 			malformed = true
 			continue
 		}
-		if value, found := entries[visualPreviewRAWOrientationTag]; orientation == 0 && found && value >= 1 && value <= 8 {
-			orientation = int(value)
+		if value, found := entries[visualPreviewRAWOrientationTag]; offset == rootOffset && found && value >= 1 && value <= 8 {
+			rootOrientation = int(value)
+		}
+		candidateOrientation := rootOrientation
+		if value, found := entries[visualPreviewRAWOrientationTag]; found && value >= 1 && value <= 8 {
+			candidateOrientation = int(value)
 		}
 		previewOffset, hasOffset := entries[visualPreviewRAWOffsetTag]
 		previewLength, hasLength := entries[visualPreviewRAWLengthTag]
@@ -155,7 +159,7 @@ func inspectVisualPreviewTIFFRAW(
 			malformed = true
 		} else if hasOffset {
 			candidate := visualPreviewRAWLocation{
-				offset: int64(previewOffset), length: int64(previewLength), orientation: orientation,
+				offset: int64(previewOffset), length: int64(previewLength), orientation: candidateOrientation,
 			}
 			if !sourceMetadataRangeWithin(candidate.offset, candidate.length, sourceSize) {
 				malformed = true

--- a/internal/processing/visual_preview_raw.go
+++ b/internal/processing/visual_preview_raw.go
@@ -1,10 +1,12 @@
 package processing
 
 import (
+	"cmp"
 	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
+	"slices"
 
 	"go.kenn.io/docbank/document"
 )
@@ -32,13 +34,17 @@ func produceVisualPreviewCameraRAW(
 	base document.VisualPreviewV1,
 ) (VisualPreviewProduct, error) {
 	readerAt := &seekReaderAt{seeker: source}
-	var location visualPreviewRAWLocation
-	var found, malformed bool
+	var locations []visualPreviewRAWLocation
+	var malformed bool
 	var err error
 	if mediaType == "image/x-fuji-raf" {
-		location, found, malformed, err = inspectVisualPreviewRAF(readerAt, sourceSize)
+		location, found, invalid, inspectErr := inspectVisualPreviewRAF(readerAt, sourceSize)
+		if found {
+			locations = append(locations, location)
+		}
+		malformed, err = invalid, inspectErr
 	} else {
-		location, found, malformed, err = inspectVisualPreviewTIFFRAW(readerAt, sourceSize)
+		locations, malformed, err = inspectVisualPreviewTIFFRAW(readerAt, sourceSize)
 	}
 	if err != nil {
 		return VisualPreviewProduct{}, sourceContentUnavailable(
@@ -48,7 +54,7 @@ func produceVisualPreviewCameraRAW(
 		return failedVisualPreview(base, "decode_failed",
 			"the verified camera RAW preview metadata is malformed"), nil
 	}
-	if !found {
+	if len(locations) == 0 {
 		base.State = document.VisualPreviewUnsupported
 		base.Failure = &document.VisualPreviewFailureV1{
 			Code:   "embedded_preview_unavailable",
@@ -56,8 +62,27 @@ func produceVisualPreviewCameraRAW(
 		}
 		return VisualPreviewProduct{Preview: base}, nil
 	}
-	preview := io.NewSectionReader(readerAt, location.offset, location.length)
-	return produceVisualPreviewJPEGWithOrientation(ctx, preview, base, location.orientation)
+	slices.SortFunc(locations, func(left, right visualPreviewRAWLocation) int {
+		if byLength := cmp.Compare(right.length, left.length); byLength != 0 {
+			return byLength
+		}
+		return cmp.Compare(left.offset, right.offset)
+	})
+	var firstTerminal VisualPreviewProduct
+	for index, location := range locations {
+		preview := io.NewSectionReader(readerAt, location.offset, location.length)
+		product, produceErr := produceVisualPreviewJPEGWithOrientation(ctx, preview, base, location.orientation)
+		if produceErr != nil {
+			return VisualPreviewProduct{}, produceErr
+		}
+		if product.Preview.State == document.VisualPreviewReady {
+			return product, nil
+		}
+		if index == 0 {
+			firstTerminal = product
+		}
+	}
+	return firstTerminal, nil
 }
 
 func inspectVisualPreviewRAF(
@@ -80,24 +105,24 @@ func inspectVisualPreviewRAF(
 
 func inspectVisualPreviewTIFFRAW(
 	reader io.ReaderAt, sourceSize int64,
-) (visualPreviewRAWLocation, bool, bool, error) {
+) ([]visualPreviewRAWLocation, bool, error) {
 	header, err := readSourceMetadataRange(reader, 0, min(sourceSize, int64(8)))
 	if err != nil {
-		return visualPreviewRAWLocation{}, false, false, err
+		return nil, false, err
 	}
 	order, format, ok := exifTIFFHeader(header)
 	if !ok || format != "tiff" || len(header) < 8 {
-		return visualPreviewRAWLocation{}, false, true, nil
+		return nil, true, nil
 	}
 	rootOffset := int64(order.Uint32(header[4:8]))
 	if rootOffset < 8 || rootOffset >= sourceSize {
-		return visualPreviewRAWLocation{}, false, true, nil
+		return nil, true, nil
 	}
 
 	queue := []int64{rootOffset}
 	seen := make(map[int64]struct{}, visualPreviewRAWMaxIFDs)
 	orientation := 0
-	best := visualPreviewRAWLocation{}
+	var candidates []visualPreviewRAWLocation
 	malformed := false
 	for len(queue) > 0 {
 		offset := queue[0]
@@ -109,13 +134,13 @@ func inspectVisualPreviewTIFFRAW(
 			continue
 		}
 		if len(seen) >= visualPreviewRAWMaxIFDs {
-			return visualPreviewRAWLocation{}, false, true, nil
+			return nil, true, nil
 		}
 		seen[offset] = struct{}{}
 
 		entries, next, subIFDs, valid, readErr := readVisualPreviewRAWIFD(reader, sourceSize, order, offset)
 		if readErr != nil {
-			return visualPreviewRAWLocation{}, false, false, readErr
+			return nil, false, readErr
 		}
 		if !valid {
 			malformed = true
@@ -134,8 +159,8 @@ func inspectVisualPreviewTIFFRAW(
 			}
 			if !sourceMetadataRangeWithin(candidate.offset, candidate.length, sourceSize) {
 				malformed = true
-			} else if candidate.length > best.length {
-				best = candidate
+			} else {
+				candidates = append(candidates, candidate)
 			}
 		}
 		queue = append(queue, subIFDs...)
@@ -143,10 +168,10 @@ func inspectVisualPreviewTIFFRAW(
 			queue = append(queue, next)
 		}
 	}
-	if best.length > 0 {
-		return best, true, false, nil
+	if len(candidates) > 0 {
+		return candidates, false, nil
 	}
-	return visualPreviewRAWLocation{}, false, malformed, nil
+	return nil, malformed, nil
 }
 
 func readVisualPreviewRAWIFD(

--- a/internal/processing/visual_preview_raw.go
+++ b/internal/processing/visual_preview_raw.go
@@ -12,12 +12,16 @@ import (
 )
 
 const (
-	visualPreviewRAWMaxIFDs        = 64
-	visualPreviewRAWMaxIFDEntries  = 1024
-	visualPreviewRAWSubIFDsTag     = 0x014a
-	visualPreviewRAWOffsetTag      = 0x0201
-	visualPreviewRAWLengthTag      = 0x0202
-	visualPreviewRAWOrientationTag = 0x0112
+	visualPreviewRAWMaxIFDs            = 64
+	visualPreviewRAWMaxIFDEntries      = 1024
+	visualPreviewRAWCompressionTag     = 0x0103
+	visualPreviewRAWJPEGCompression    = 7
+	visualPreviewRAWStripOffsetsTag    = 0x0111
+	visualPreviewRAWStripByteCountsTag = 0x0117
+	visualPreviewRAWSubIFDsTag         = 0x014a
+	visualPreviewRAWOffsetTag          = 0x0201
+	visualPreviewRAWLengthTag          = 0x0202
+	visualPreviewRAWOrientationTag     = 0x0112
 )
 
 type visualPreviewRAWLocation struct {
@@ -167,6 +171,20 @@ func inspectVisualPreviewTIFFRAW(
 				candidates = append(candidates, candidate)
 			}
 		}
+		stripOffset, hasStripOffset := entries[visualPreviewRAWStripOffsetsTag]
+		stripLength, hasStripLength := entries[visualPreviewRAWStripByteCountsTag]
+		if hasStripOffset != hasStripLength {
+			malformed = true
+		} else if hasStripOffset && entries[visualPreviewRAWCompressionTag] == visualPreviewRAWJPEGCompression {
+			candidate := visualPreviewRAWLocation{
+				offset: int64(stripOffset), length: int64(stripLength), orientation: candidateOrientation,
+			}
+			if !sourceMetadataRangeWithin(candidate.offset, candidate.length, sourceSize) {
+				malformed = true
+			} else {
+				candidates = append(candidates, candidate)
+			}
+		}
 		queue = append(queue, subIFDs...)
 		if next != 0 {
 			queue = append(queue, next)
@@ -203,8 +221,8 @@ func readVisualPreviewRAWIFD(
 	if err != nil {
 		return nil, 0, nil, false, err
 	}
-	values := make(map[uint16]uint32, 3)
-	seenValues := make(map[uint16]struct{}, 3)
+	values := make(map[uint16]uint32, 7)
+	seenValues := make(map[uint16]struct{}, 7)
 	var subIFDs []int64
 	for index := range count {
 		entry := table[index*12 : index*12+12]
@@ -223,7 +241,9 @@ func readVisualPreviewRAWIFD(
 			subIFDs = append(subIFDs, offsets...)
 			continue
 		}
-		if tag != visualPreviewRAWOffsetTag && tag != visualPreviewRAWLengthTag &&
+		if tag != visualPreviewRAWCompressionTag &&
+			tag != visualPreviewRAWStripOffsetsTag && tag != visualPreviewRAWStripByteCountsTag &&
+			tag != visualPreviewRAWOffsetTag && tag != visualPreviewRAWLengthTag &&
 			tag != visualPreviewRAWOrientationTag {
 			continue
 		}
@@ -233,6 +253,10 @@ func readVisualPreviewRAWIFD(
 		seenValues[tag] = struct{}{}
 		value, valid := visualPreviewRAWScalar(order, kind, items, entry[8:12])
 		if !valid {
+			if (tag == visualPreviewRAWStripOffsetsTag || tag == visualPreviewRAWStripByteCountsTag) &&
+				(kind == 3 || kind == 4) && items > 1 {
+				continue
+			}
 			return nil, 0, nil, false, nil
 		}
 		values[tag] = value

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -191,7 +191,7 @@ func TestProduceVisualPreviewAcceptsWebP(t *testing.T) {
 
 func TestProduceVisualPreviewAcceptsTIFFCameraRAW(t *testing.T) {
 	preview := mediatest.JPEG(3, 2, color.White)
-	source := syntheticRAWPreviewTIFF(preview, 6)
+	source := syntheticRAWPreviewTIFF(6, preview)
 	digest := sha256.Sum256(source)
 
 	for _, mediaType := range []string{
@@ -211,6 +211,22 @@ func TestProduceVisualPreviewAcceptsTIFFCameraRAW(t *testing.T) {
 			assert.Equal(t, 3, product.Preview.Output.Height)
 		})
 	}
+}
+
+func TestProduceVisualPreviewFallsBackToSmallerUsableCameraRAWPreview(t *testing.T) {
+	preview := mediatest.JPEG(3, 2, color.White)
+	invalid := make([]byte, len(preview)+1)
+	source := syntheticRAWPreviewTIFF(1, preview, invalid)
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/x-nikon-nef",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 3, product.Preview.Output.Width)
+	assert.Equal(t, 2, product.Preview.Output.Height)
 }
 
 func TestProduceVisualPreviewAcceptsRAF(t *testing.T) {
@@ -241,7 +257,7 @@ func TestProduceVisualPreviewRecordsMissingCameraRAWPreview(t *testing.T) {
 }
 
 func TestProduceVisualPreviewRecordsInvalidCameraRAWPreviewRange(t *testing.T) {
-	source := syntheticRAWPreviewTIFF(mediatest.JPEG(3, 2, color.White), 1)
+	source := syntheticRAWPreviewTIFF(1, mediatest.JPEG(3, 2, color.White))
 	previewIFD := int(binary.LittleEndian.Uint32(source[22:26]))
 	binary.LittleEndian.PutUint32(source[previewIFD+10:previewIFD+14], uint32(len(source)+1))
 	digest := sha256.Sum256(source)
@@ -465,7 +481,7 @@ func TestProduceVisualPreviewKeepsImageReadErrorsRetryable(t *testing.T) {
 
 func TestProduceVisualPreviewKeepsCameraRAWReadErrorsRetryable(t *testing.T) {
 	readErr := errors.New("injected read failure")
-	source := syntheticRAWPreviewTIFF(mediatest.JPEG(3, 2, color.White), 1)
+	source := syntheticRAWPreviewTIFF(1, mediatest.JPEG(3, 2, color.White))
 	digest := sha256.Sum256(source)
 	reader := &failingVisualPreviewReadSeeker{
 		Reader: bytes.NewReader(source), failAtSeek: 2, err: readErr,
@@ -501,7 +517,7 @@ func syntheticJPEGSegment(t *testing.T, source []byte, marker byte, payload []by
 	return append(result, source[2:]...)
 }
 
-func syntheticRAWPreviewTIFF(preview []byte, orientation uint16) []byte {
+func syntheticRAWPreviewTIFF(orientation uint16, previews ...[]byte) []byte {
 	const (
 		headerSize       = 8
 		rootEntries      = 1
@@ -509,9 +525,13 @@ func syntheticRAWPreviewTIFF(preview []byte, orientation uint16) []byte {
 		rootIFDSize      = 2 + rootEntries*12 + 4
 		previewIFDSize   = 2 + previewEntries*12 + 4
 		previewIFDOffset = headerSize + rootIFDSize
-		previewOffset    = previewIFDOffset + previewIFDSize
 	)
-	source := make([]byte, previewOffset+len(preview))
+	previewOffset := previewIFDOffset + len(previews)*previewIFDSize
+	totalSize := previewOffset
+	for _, preview := range previews {
+		totalSize += len(preview)
+	}
+	source := make([]byte, totalSize)
 	copy(source, "II")
 	binary.LittleEndian.PutUint16(source[2:4], 42)
 	binary.LittleEndian.PutUint32(source[4:8], headerSize)
@@ -521,16 +541,23 @@ func syntheticRAWPreviewTIFF(preview []byte, orientation uint16) []byte {
 	binary.LittleEndian.PutUint32(source[14:18], 1)
 	binary.LittleEndian.PutUint16(source[18:20], orientation)
 	binary.LittleEndian.PutUint32(source[22:26], previewIFDOffset)
-	binary.LittleEndian.PutUint16(source[previewIFDOffset:previewIFDOffset+2], previewEntries)
-	binary.LittleEndian.PutUint16(source[previewIFDOffset+2:previewIFDOffset+4], visualPreviewRAWOffsetTag)
-	binary.LittleEndian.PutUint16(source[previewIFDOffset+4:previewIFDOffset+6], 4)
-	binary.LittleEndian.PutUint32(source[previewIFDOffset+6:previewIFDOffset+10], 1)
-	binary.LittleEndian.PutUint32(source[previewIFDOffset+10:previewIFDOffset+14], previewOffset)
-	binary.LittleEndian.PutUint16(source[previewIFDOffset+14:previewIFDOffset+16], visualPreviewRAWLengthTag)
-	binary.LittleEndian.PutUint16(source[previewIFDOffset+16:previewIFDOffset+18], 4)
-	binary.LittleEndian.PutUint32(source[previewIFDOffset+18:previewIFDOffset+22], 1)
-	binary.LittleEndian.PutUint32(source[previewIFDOffset+22:previewIFDOffset+26], uint32(len(preview)))
-	copy(source[previewOffset:], preview)
+	for index, preview := range previews {
+		ifdOffset := previewIFDOffset + index*previewIFDSize
+		binary.LittleEndian.PutUint16(source[ifdOffset:ifdOffset+2], previewEntries)
+		binary.LittleEndian.PutUint16(source[ifdOffset+2:ifdOffset+4], visualPreviewRAWOffsetTag)
+		binary.LittleEndian.PutUint16(source[ifdOffset+4:ifdOffset+6], 4)
+		binary.LittleEndian.PutUint32(source[ifdOffset+6:ifdOffset+10], 1)
+		binary.LittleEndian.PutUint32(source[ifdOffset+10:ifdOffset+14], uint32(previewOffset))
+		binary.LittleEndian.PutUint16(source[ifdOffset+14:ifdOffset+16], visualPreviewRAWLengthTag)
+		binary.LittleEndian.PutUint16(source[ifdOffset+16:ifdOffset+18], 4)
+		binary.LittleEndian.PutUint32(source[ifdOffset+18:ifdOffset+22], 1)
+		binary.LittleEndian.PutUint32(source[ifdOffset+22:ifdOffset+26], uint32(len(preview)))
+		if index+1 < len(previews) {
+			binary.LittleEndian.PutUint32(source[ifdOffset+26:ifdOffset+30], uint32(ifdOffset+previewIFDSize))
+		}
+		copy(source[previewOffset:], preview)
+		previewOffset += len(preview)
+	}
 	return source
 }
 

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -213,6 +213,23 @@ func TestProduceVisualPreviewAcceptsTIFFCameraRAW(t *testing.T) {
 	}
 }
 
+func TestProduceVisualPreviewAcceptsSingleStripDNGPreview(t *testing.T) {
+	preview := mediatest.JPEG(3, 2, color.White)
+	source := syntheticRAWPreviewTIFFCandidates(1, syntheticRAWPreviewCandidate{
+		data: preview, singleStrip: true,
+	})
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/x-adobe-dng",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 3, product.Preview.Output.Width)
+	assert.Equal(t, 2, product.Preview.Output.Height)
+}
+
 func TestProduceVisualPreviewFallsBackToSmallerUsableCameraRAWPreview(t *testing.T) {
 	preview := mediatest.JPEG(3, 2, color.White)
 	invalid := make([]byte, len(preview)+1)
@@ -545,6 +562,7 @@ func syntheticRAWPreviewTIFF(orientation uint16, previews ...[]byte) []byte {
 type syntheticRAWPreviewCandidate struct {
 	data        []byte
 	orientation uint16
+	singleStrip bool
 }
 
 func syntheticRAWPreviewTIFFCandidates(
@@ -561,6 +579,9 @@ func syntheticRAWPreviewTIFFCandidates(
 	for index, preview := range previews {
 		ifdOffsets[index] = previewOffset
 		entries := 2
+		if preview.singleStrip {
+			entries++
+		}
 		if preview.orientation != 0 {
 			entries++
 		}
@@ -582,10 +603,18 @@ func syntheticRAWPreviewTIFFCandidates(
 	}
 	for index, preview := range previews {
 		ifdOffset := ifdOffsets[index]
-		entries := []syntheticTIFFEntry{
-			tiffLong(visualPreviewRAWOffsetTag, uint32(previewOffset)),
-			tiffLong(visualPreviewRAWLengthTag, uint32(len(preview.data))),
+		offsetTag := uint16(visualPreviewRAWOffsetTag)
+		lengthTag := uint16(visualPreviewRAWLengthTag)
+		var entries []syntheticTIFFEntry
+		if preview.singleStrip {
+			offsetTag = visualPreviewRAWStripOffsetsTag
+			lengthTag = visualPreviewRAWStripByteCountsTag
+			entries = append(entries, tiffShort(visualPreviewRAWCompressionTag, visualPreviewRAWJPEGCompression))
 		}
+		entries = append(entries,
+			tiffLong(offsetTag, uint32(previewOffset)),
+			tiffLong(lengthTag, uint32(len(preview.data))),
+		)
 		if preview.orientation != 0 {
 			entries = append(entries, tiffShort(visualPreviewRAWOrientationTag, preview.orientation))
 		}

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -229,6 +229,23 @@ func TestProduceVisualPreviewFallsBackToSmallerUsableCameraRAWPreview(t *testing
 	assert.Equal(t, 2, product.Preview.Output.Height)
 }
 
+func TestProduceVisualPreviewUsesCandidateCameraRAWOrientation(t *testing.T) {
+	preview := mediatest.JPEG(4, 3, color.White)
+	source := syntheticRAWPreviewTIFFCandidates(6, syntheticRAWPreviewCandidate{
+		data: preview, orientation: 1,
+	})
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/x-nikon-nef",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 4, product.Preview.Output.Width)
+	assert.Equal(t, 3, product.Preview.Output.Height)
+}
+
 func TestProduceVisualPreviewAcceptsRAF(t *testing.T) {
 	source := syntheticRAF()
 	digest := sha256.Sum256(source)
@@ -518,45 +535,67 @@ func syntheticJPEGSegment(t *testing.T, source []byte, marker byte, payload []by
 }
 
 func syntheticRAWPreviewTIFF(orientation uint16, previews ...[]byte) []byte {
+	candidates := make([]syntheticRAWPreviewCandidate, len(previews))
+	for index, preview := range previews {
+		candidates[index].data = preview
+	}
+	return syntheticRAWPreviewTIFFCandidates(orientation, candidates...)
+}
+
+type syntheticRAWPreviewCandidate struct {
+	data        []byte
+	orientation uint16
+}
+
+func syntheticRAWPreviewTIFFCandidates(
+	rootOrientation uint16, previews ...syntheticRAWPreviewCandidate,
+) []byte {
 	const (
-		headerSize       = 8
-		rootEntries      = 1
-		previewEntries   = 2
-		rootIFDSize      = 2 + rootEntries*12 + 4
-		previewIFDSize   = 2 + previewEntries*12 + 4
-		previewIFDOffset = headerSize + rootIFDSize
+		headerSize     = 8
+		rootEntries    = 1
+		rootIFDSize    = 2 + rootEntries*12 + 4
+		firstIFDOffset = headerSize + rootIFDSize
 	)
-	previewOffset := previewIFDOffset + len(previews)*previewIFDSize
+	ifdOffsets := make([]int, len(previews))
+	previewOffset := firstIFDOffset
+	for index, preview := range previews {
+		ifdOffsets[index] = previewOffset
+		entries := 2
+		if preview.orientation != 0 {
+			entries++
+		}
+		previewOffset += 2 + entries*12 + 4
+	}
 	totalSize := previewOffset
 	for _, preview := range previews {
-		totalSize += len(preview)
+		totalSize += len(preview.data)
 	}
 	source := make([]byte, totalSize)
 	copy(source, "II")
 	binary.LittleEndian.PutUint16(source[2:4], 42)
 	binary.LittleEndian.PutUint32(source[4:8], headerSize)
-	binary.LittleEndian.PutUint16(source[8:10], rootEntries)
-	binary.LittleEndian.PutUint16(source[10:12], visualPreviewRAWOrientationTag)
-	binary.LittleEndian.PutUint16(source[12:14], 3)
-	binary.LittleEndian.PutUint32(source[14:18], 1)
-	binary.LittleEndian.PutUint16(source[18:20], orientation)
-	binary.LittleEndian.PutUint32(source[22:26], previewIFDOffset)
+	externalOffset := totalSize
+	writeSyntheticTIFFIFD(source, headerSize,
+		[]syntheticTIFFEntry{tiffShort(visualPreviewRAWOrientationTag, rootOrientation)}, &externalOffset)
+	if len(ifdOffsets) > 0 {
+		binary.LittleEndian.PutUint32(source[22:26], uint32(ifdOffsets[0]))
+	}
 	for index, preview := range previews {
-		ifdOffset := previewIFDOffset + index*previewIFDSize
-		binary.LittleEndian.PutUint16(source[ifdOffset:ifdOffset+2], previewEntries)
-		binary.LittleEndian.PutUint16(source[ifdOffset+2:ifdOffset+4], visualPreviewRAWOffsetTag)
-		binary.LittleEndian.PutUint16(source[ifdOffset+4:ifdOffset+6], 4)
-		binary.LittleEndian.PutUint32(source[ifdOffset+6:ifdOffset+10], 1)
-		binary.LittleEndian.PutUint32(source[ifdOffset+10:ifdOffset+14], uint32(previewOffset))
-		binary.LittleEndian.PutUint16(source[ifdOffset+14:ifdOffset+16], visualPreviewRAWLengthTag)
-		binary.LittleEndian.PutUint16(source[ifdOffset+16:ifdOffset+18], 4)
-		binary.LittleEndian.PutUint32(source[ifdOffset+18:ifdOffset+22], 1)
-		binary.LittleEndian.PutUint32(source[ifdOffset+22:ifdOffset+26], uint32(len(preview)))
-		if index+1 < len(previews) {
-			binary.LittleEndian.PutUint32(source[ifdOffset+26:ifdOffset+30], uint32(ifdOffset+previewIFDSize))
+		ifdOffset := ifdOffsets[index]
+		entries := []syntheticTIFFEntry{
+			tiffLong(visualPreviewRAWOffsetTag, uint32(previewOffset)),
+			tiffLong(visualPreviewRAWLengthTag, uint32(len(preview.data))),
 		}
-		copy(source[previewOffset:], preview)
-		previewOffset += len(preview)
+		if preview.orientation != 0 {
+			entries = append(entries, tiffShort(visualPreviewRAWOrientationTag, preview.orientation))
+		}
+		writeSyntheticTIFFIFD(source, ifdOffset, entries, &externalOffset)
+		if index+1 < len(previews) {
+			nextOffset := ifdOffset + 2 + len(entries)*12
+			binary.LittleEndian.PutUint32(source[nextOffset:nextOffset+4], uint32(ifdOffsets[index+1]))
+		}
+		copy(source[previewOffset:], preview.data)
+		previewOffset += len(preview.data)
 	}
 	return source
 }

--- a/internal/processing/visual_preview_test.go
+++ b/internal/processing/visual_preview_test.go
@@ -189,6 +189,72 @@ func TestProduceVisualPreviewAcceptsWebP(t *testing.T) {
 	assert.Equal(t, 100, product.Preview.Output.Height)
 }
 
+func TestProduceVisualPreviewAcceptsTIFFCameraRAW(t *testing.T) {
+	preview := mediatest.JPEG(3, 2, color.White)
+	source := syntheticRAWPreviewTIFF(preview, 6)
+	digest := sha256.Sum256(source)
+
+	for _, mediaType := range []string{
+		"image/x-sony-arw",
+		"image/x-adobe-dng",
+		"image/x-canon-cr2",
+		"image/x-nikon-nef",
+	} {
+		t.Run(mediaType, func(t *testing.T) {
+			product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+				SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: mediaType,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+			require.NotNil(t, product.Preview.Output)
+			assert.Equal(t, 2, product.Preview.Output.Width)
+			assert.Equal(t, 3, product.Preview.Output.Height)
+		})
+	}
+}
+
+func TestProduceVisualPreviewAcceptsRAF(t *testing.T) {
+	source := syntheticRAF()
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/x-fuji-raf",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	require.NotNil(t, product.Preview.Output)
+	assert.Equal(t, 30, product.Preview.Output.Width)
+	assert.Equal(t, 40, product.Preview.Output.Height)
+}
+
+func TestProduceVisualPreviewRecordsMissingCameraRAWPreview(t *testing.T) {
+	source := syntheticTIFFRoot([]syntheticTIFFEntry{tiffShort(0x0112, 1)})
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/x-nikon-nef",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewUnsupported, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "embedded_preview_unavailable", product.Preview.Failure.Code)
+}
+
+func TestProduceVisualPreviewRecordsInvalidCameraRAWPreviewRange(t *testing.T) {
+	source := syntheticRAWPreviewTIFF(mediatest.JPEG(3, 2, color.White), 1)
+	previewIFD := int(binary.LittleEndian.Uint32(source[22:26]))
+	binary.LittleEndian.PutUint32(source[previewIFD+10:previewIFD+14], uint32(len(source)+1))
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/x-nikon-nef",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewFailed, product.Preview.State)
+	require.NotNil(t, product.Preview.Failure)
+	assert.Equal(t, "decode_failed", product.Preview.Failure.Code)
+}
+
 func TestProduceVisualPreviewAppliesWebPEXIFOrientation(t *testing.T) {
 	source := mustDecodeWebP(t)
 	source = syntheticExtendedWebP(t, source, 75, 100, visualPreviewWebPEXIF, "EXIF",
@@ -397,6 +463,22 @@ func TestProduceVisualPreviewKeepsImageReadErrorsRetryable(t *testing.T) {
 	}
 }
 
+func TestProduceVisualPreviewKeepsCameraRAWReadErrorsRetryable(t *testing.T) {
+	readErr := errors.New("injected read failure")
+	source := syntheticRAWPreviewTIFF(mediatest.JPEG(3, 2, color.White), 1)
+	digest := sha256.Sum256(source)
+	reader := &failingVisualPreviewReadSeeker{
+		Reader: bytes.NewReader(source), failAtSeek: 2, err: readErr,
+	}
+
+	_, err := ProduceVisualPreview(t.Context(), reader, VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]), Size: int64(len(source)), MediaType: "image/x-nikon-nef",
+	})
+	require.Error(t, err)
+	assert.True(t, IsSourceContentUnavailable(err))
+	assert.ErrorIs(t, err, readErr)
+}
+
 func TestVisualPreviewJPEGUnsupportedFeatureIsTerminal(t *testing.T) {
 	product, err := visualPreviewJPEGDecodeResult(
 		document.VisualPreviewV1{}, "malformed", jpeg.UnsupportedError("test feature"),
@@ -417,6 +499,39 @@ func syntheticJPEGSegment(t *testing.T, source []byte, marker byte, payload []by
 	result = append(result, header...)
 	result = append(result, payload...)
 	return append(result, source[2:]...)
+}
+
+func syntheticRAWPreviewTIFF(preview []byte, orientation uint16) []byte {
+	const (
+		headerSize       = 8
+		rootEntries      = 1
+		previewEntries   = 2
+		rootIFDSize      = 2 + rootEntries*12 + 4
+		previewIFDSize   = 2 + previewEntries*12 + 4
+		previewIFDOffset = headerSize + rootIFDSize
+		previewOffset    = previewIFDOffset + previewIFDSize
+	)
+	source := make([]byte, previewOffset+len(preview))
+	copy(source, "II")
+	binary.LittleEndian.PutUint16(source[2:4], 42)
+	binary.LittleEndian.PutUint32(source[4:8], headerSize)
+	binary.LittleEndian.PutUint16(source[8:10], rootEntries)
+	binary.LittleEndian.PutUint16(source[10:12], visualPreviewRAWOrientationTag)
+	binary.LittleEndian.PutUint16(source[12:14], 3)
+	binary.LittleEndian.PutUint32(source[14:18], 1)
+	binary.LittleEndian.PutUint16(source[18:20], orientation)
+	binary.LittleEndian.PutUint32(source[22:26], previewIFDOffset)
+	binary.LittleEndian.PutUint16(source[previewIFDOffset:previewIFDOffset+2], previewEntries)
+	binary.LittleEndian.PutUint16(source[previewIFDOffset+2:previewIFDOffset+4], visualPreviewRAWOffsetTag)
+	binary.LittleEndian.PutUint16(source[previewIFDOffset+4:previewIFDOffset+6], 4)
+	binary.LittleEndian.PutUint32(source[previewIFDOffset+6:previewIFDOffset+10], 1)
+	binary.LittleEndian.PutUint32(source[previewIFDOffset+10:previewIFDOffset+14], previewOffset)
+	binary.LittleEndian.PutUint16(source[previewIFDOffset+14:previewIFDOffset+16], visualPreviewRAWLengthTag)
+	binary.LittleEndian.PutUint16(source[previewIFDOffset+16:previewIFDOffset+18], 4)
+	binary.LittleEndian.PutUint32(source[previewIFDOffset+18:previewIFDOffset+22], 1)
+	binary.LittleEndian.PutUint32(source[previewIFDOffset+22:previewIFDOffset+26], uint32(len(preview)))
+	copy(source[previewOffset:], preview)
+	return source
 }
 
 func syntheticPNGChunk(t *testing.T, source []byte, chunkType string, payload []byte) []byte {


### PR DESCRIPTION
Docbank can now produce retained JPEG previews for Fujifilm RAF and TIFF-family Sony ARW, Adobe DNG, Canon CR2, and Nikon NEF originals that contain an embedded JPEG. Embedded applications can display exact-version camera RAW content through the same preview API they use for ordinary images.

The producer verifies the complete original, reads bounded container metadata, and streams only the embedded JPEG through the existing orientation, color, and size policy. A well-formed RAW file without a supported embedded preview is reported as unsupported; malformed preview metadata is recorded as a durable failure. CR3 and RAW containers without an embedded JPEG remain outside this producer.
