### PR TITLE
feat(ingest): add glob selection to local ingest

### DIFF
--- a/cmd/docbank/add.go
+++ b/cmd/docbank/add.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	addDest      string
+	addInclude   []string
 	addExclude   []string
 	addPreflight bool
 	addJSON      bool
@@ -48,7 +49,7 @@ var addCmd = &cobra.Command{
 			return err
 		}
 		if addPreflight {
-			rep, err := c.PreflightIngest(cmd.Context(), abs, addExclude)
+			rep, err := c.PreflightIngest(cmd.Context(), abs, addInclude, addExclude)
 			if err != nil {
 				return err
 			}
@@ -68,7 +69,7 @@ var addCmd = &cobra.Command{
 		}
 		var rep api.IngestReport
 		if addJSON {
-			rep, err = c.IngestWithOptions(cmd.Context(), abs, addDest, addExclude)
+			rep, err = c.IngestWithOptions(cmd.Context(), abs, addDest, addInclude, addExclude)
 		} else {
 			mode, modeErr := progressModeFromFlag("add", addProgress)
 			if modeErr != nil {
@@ -76,7 +77,7 @@ var addCmd = &cobra.Command{
 			}
 			renderer := newIngestProgressRenderer(cmd.ErrOrStderr(), mode)
 			defer renderer.finish()
-			rep, err = c.IngestStream(cmd.Context(), abs, addDest, addExclude, renderer.handle)
+			rep, err = c.IngestStream(cmd.Context(), abs, addDest, addInclude, addExclude, renderer.handle)
 		}
 		if err != nil {
 			return err
@@ -102,8 +103,10 @@ var addCmd = &cobra.Command{
 
 func init() {
 	addCmd.Flags().StringVar(&addDest, "dest", "/inbox", "virtual destination directory")
+	addCmd.Flags().StringArrayVar(&addInclude, "include", nil,
+		"include files matching a basename or source-relative path pattern (repeatable)")
 	addCmd.Flags().StringArrayVar(&addExclude, "exclude", nil,
-		"exclude an entry name anywhere or a relative path within each source (repeatable)")
+		"exclude files or directories matching a basename or source-relative path pattern (repeatable)")
 	addCmd.Flags().BoolVar(&addPreflight, "preflight", false,
 		"inventory sources without opening content or changing the vault")
 	addCmd.Flags().BoolVar(&addJSON, "json", false,

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -912,6 +912,28 @@ func TestAddExcludeCommaIsLiteral(t *testing.T) {
 	assert.Zero(t, report.Excluded)
 }
 
+func TestAddIncludeUsesDaemonSelectionAndReportsCounts(t *testing.T) {
+	_ = setupVaultHome(t)
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "keep.txt"), []byte("keep"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "skip.txt"), []byte("skip"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "skip.md"), []byte("skip"), 0o600))
+
+	out, err := runCLI(t, "add", src, "--preflight", "--include", "*.txt", "--exclude", "skip.txt", "--json")
+	require.NoError(t, err)
+	var report api.IngestPreflightReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.Equal(t, int64(1), report.Files)
+	assert.Equal(t, int64(2), report.Excluded)
+
+	out, err = runCLI(t, "add", src, "--include", "*.txt", "--exclude", "skip.txt", "--json")
+	require.NoError(t, err)
+	var ingestReport api.IngestReport
+	require.NoError(t, json.Unmarshal([]byte(out), &ingestReport))
+	assert.Equal(t, 1, ingestReport.Added)
+	assert.Equal(t, 2, ingestReport.Excluded)
+}
+
 func TestAddMissingSourceFails(t *testing.T) {
 	_ = setupVaultHome(t)
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -86,8 +86,9 @@ non-goals.
 ## Common agent workflows
 
 - **File local material:** preflight large server-side trees with the intended
-  exclusions, require no errors or over-limit files, then ingest with the same
-  selection and inspect every added, skipped, excluded, and failed result.
+  include and exclude patterns, require no errors or over-limit files, then
+  ingest with the same selection and inspect every added, skipped, excluded,
+  and failed result.
 - **Write from another machine:** upload one file with declared SHA-256, size,
   name, and destination directory ID; accept success only when the returned
   server-computed identity matches.

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -599,12 +599,13 @@ Inspect `added`, `skipped`, `excluded`, and every member of `failed`. Repeating 
 ingest after fixing a partial failure is safe; successful content converges to
 `skipped` rather than another copy.
 
-Include and exclude values use Go's `path.Match` grammar on slash-normalized
-source-relative paths. A pattern without `/` matches basenames at any depth;
+Include and exclude values use Go's `path.Match` grammar on slash-separated
+source-relative paths. Use `/` separators on every platform; backslashes are
+rejected. A pattern without `/` matches basenames at any depth;
 exclusions win, and include patterns do not prune directories. Invalid patterns
-are rejected before traversal. Rules are slash-normalized, so use bracket
-expressions such as `report[[]1].txt` for literal metacharacters instead of
-backslash escaping. Watched-inbox exclusions remain literal.
+are rejected before traversal. Use bracket expressions such as
+`report[[]1].txt` for literal metacharacters instead of backslash escaping.
+Watched-inbox exclusions remain literal.
 
 For an interactive or long-running local integration, send the same body to
 `POST /api/v1/ingest/stream` with `Accept: application/x-ndjson`. Read every

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -602,7 +602,9 @@ ingest after fixing a partial failure is safe; successful content converges to
 Include and exclude values use Go's `path.Match` grammar on slash-normalized
 source-relative paths. A pattern without `/` matches basenames at any depth;
 exclusions win, and include patterns do not prune directories. Invalid patterns
-are rejected before traversal. Watched-inbox exclusions remain literal.
+are rejected before traversal. Rules are slash-normalized, so use bracket
+expressions such as `report[[]1].txt` for literal metacharacters instead of
+backslash escaping. Watched-inbox exclusions remain literal.
 
 For an interactive or long-running local integration, send the same body to
 `POST /api/v1/ingest/stream` with `Accept: application/x-ndjson`. Read every

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -577,13 +577,13 @@ filesystem metadata but does not open file content or mutate the vault:
 curl --fail-with-body -X POST \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'Content-Type: application/json' \
-  --data '{"paths":["/Users/me/Dropbox"],"exclude":[".git",".Trash"]}' \
+  --data '{"paths":["/Users/me/Dropbox"],"include":["*.pdf"],"exclude":[".git",".Trash"]}' \
   "$DOCBANK_URL/api/v1/ingest/preflight"
 ```
 
 Require `errors == 0` and `rejected.files == 0`, inspect every returned
-finding, and retain the exact exclusion list for ingest. Findings and extension
-groups are bounded; their count and truncation fields say when the detailed
+finding, and retain the exact include and exclusion lists for ingest. Findings
+and extension groups are bounded; their count and truncation fields say when the detailed
 arrays are samples rather than complete lists. A non-UTF-8 filesystem entry is
 an error with an escaped printable path and is never opened or imported.
 
@@ -591,13 +591,18 @@ an error with an escaped printable path and is never opened or imported.
 curl --fail-with-body -X POST \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'Content-Type: application/json' \
-  --data '{"paths":["/Users/me/Downloads/receipt.pdf"],"dest":"/receipts","exclude":[]}' \
+  --data '{"paths":["/Users/me/Downloads/receipt.pdf"],"dest":"/receipts","include":[],"exclude":[]}' \
   "$DOCBANK_URL/api/v1/ingest"
 ```
 
 Inspect `added`, `skipped`, `excluded`, and every member of `failed`. Repeating the same
 ingest after fixing a partial failure is safe; successful content converges to
 `skipped` rather than another copy.
+
+Include and exclude values use Go's `path.Match` grammar on slash-normalized
+source-relative paths. A pattern without `/` matches basenames at any depth;
+exclusions win, and include patterns do not prune directories. Invalid patterns
+are rejected before traversal. Watched-inbox exclusions remain literal.
 
 For an interactive or long-running local integration, send the same body to
 `POST /api/v1/ingest/stream` with `Accept: application/x-ndjson`. Read every

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -307,6 +307,9 @@ absolute-path validation, explicit root-directory-symlink behavior, exclusion
 rules, loopback fence, and timeout exemption as the real ingest. Findings are
 observations rather than a snapshot lock: sources can still change before
 ingest, and metadata-only scanning cannot prove later content readability.
+Include and exclude patterns use `/` separators on every platform; a backslash
+in a pattern is rejected. Entries filtered by a rule are excluded without
+failure, while selected non-regular entries are reported as skipped findings.
 
 `POST /ingest` takes **server-side local paths** — `{paths: [...],
 dest: "/inbox", include: [...], exclude: [...]}` — and returns an `IngestReport` (`added`, `skipped`, `excluded`,

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -338,15 +338,16 @@ to the loopback-bound daemon still terminates through the configured SSH/VPN
 tunnel.
 
 Each include or exclude pattern uses Go's `path.Match` grammar over a
-slash-normalized source-relative path. A pattern without `/` matches a basename
+slash-separated source-relative path. Use `/` separators on every platform;
+backslashes are rejected. A pattern without `/` matches a basename
 at any depth; a pattern containing `/` matches the relative path. `*` and `?`
 do not cross `/`, and `**` has no recursive globstar behavior. An include filters
 regular files only, while a matching exclusion wins and prunes a directory's
 subtree. The preflight and ingest implementations share this compiler so
 reviewed selection and actual selection cannot drift. Patterns must be relative;
-invalid syntax and parent traversal are rejected before filesystem access. Rules
-are slash-normalized, so use bracket expressions such as `report[[]1].txt` for
-literal metacharacters instead of backslash escaping.
+invalid syntax and parent traversal are rejected before filesystem access. Use
+bracket expressions such as `report[[]1].txt` for literal metacharacters instead
+of backslash escaping.
 Watched-inbox exclusions are a separate literal contract.
 
 ## Addendum: `POST /uploads`

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -298,7 +298,7 @@ transparency log are outside docbank's current trust model.
 
 ## Addendum: `POST /ingest`, `POST /ingest/stream`, and `POST /ingest/preflight`
 
-`POST /ingest/preflight` takes `{paths: [...], exclude: [...]}` and performs a
+`POST /ingest/preflight` takes `{paths: [...], include: [...], exclude: [...]}` and performs a
 metadata-only source inventory. It opens no regular-file content and writes no
 vault metadata or blobs. Its report includes file/directory/logical-byte totals,
 pack-eligible, loose-only, and rejected size classes, exclusion/skip/error
@@ -309,7 +309,7 @@ observations rather than a snapshot lock: sources can still change before
 ingest, and metadata-only scanning cannot prove later content readability.
 
 `POST /ingest` takes **server-side local paths** — `{paths: [...],
-dest: "/inbox", exclude: [...]}` — and returns an `IngestReport` (`added`, `skipped`, `excluded`,
+dest: "/inbox", include: [...], exclude: [...]}` — and returns an `IngestReport` (`added`, `skipped`, `excluded`,
 per-path `failed` entries), backing `docbank add`. Paths must be
 **absolute**: the long-lived daemon's working directory is meaningless,
 so a relative path is rejected with `422`. The CLI resolves `docbank
@@ -334,10 +334,15 @@ capability on this route: remote bytes use `POST /uploads`, while remote access
 to the loopback-bound daemon still terminates through the configured SSH/VPN
 tunnel.
 
-Each exclusion is either a bare entry name, matched at any depth, or a relative
-path containing `/`, matched within every supplied source. Matching a directory
-prunes its subtree. The preflight and ingest implementations share this matcher
-so reviewed selection and actual selection cannot drift.
+Each include or exclude pattern uses Go's `path.Match` grammar over a
+slash-normalized source-relative path. A pattern without `/` matches a basename
+at any depth; a pattern containing `/` matches the relative path. `*` and `?`
+do not cross `/`, and `**` has no recursive globstar behavior. An include filters
+regular files only, while a matching exclusion wins and prunes a directory's
+subtree. The preflight and ingest implementations share this compiler so
+reviewed selection and actual selection cannot drift. Patterns must be relative;
+invalid syntax and parent traversal are rejected before filesystem access.
+Watched-inbox exclusions are a separate literal contract.
 
 ## Addendum: `POST /uploads`
 

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -341,7 +341,9 @@ do not cross `/`, and `**` has no recursive globstar behavior. An include filter
 regular files only, while a matching exclusion wins and prunes a directory's
 subtree. The preflight and ingest implementations share this compiler so
 reviewed selection and actual selection cannot drift. Patterns must be relative;
-invalid syntax and parent traversal are rejected before filesystem access.
+invalid syntax and parent traversal are rejected before filesystem access. Rules
+are slash-normalized, so use bracket expressions such as `report[[]1].txt` for
+literal metacharacters instead of backslash escaping.
 Watched-inbox exclusions are a separate literal contract.
 
 ## Addendum: `POST /uploads`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,8 +92,8 @@ than translating process exits back into HTTP status.
 ## docbank add
 
 ```
-docbank add <path>... [--dest <virtual-dir>] [--exclude <rule>]... [--progress auto|bar|plain] [--json]
-docbank add <path>... --preflight [--exclude <rule>]... [--json]
+docbank add <path>... [--dest <virtual-dir>] [--include <pattern>]... [--exclude <pattern>]... [--progress auto|bar|plain] [--json]
+docbank add <path>... --preflight [--include <pattern>]... [--exclude <pattern>]... [--json]
 ```
 
 Imports files or directory trees into the vault. Sources are copied,
@@ -102,7 +102,8 @@ never modified or deleted.
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `--dest` | `/inbox` | Virtual destination directory; created (with parents) if missing |
-| `--exclude` | none | Prune a matching entry name anywhere, or a relative path within each source; repeatable |
+| `--include` | none | Select files matching a basename or source-relative `path.Match` pattern; repeatable |
+| `--exclude` | none | Exclude files or prune directories matching a basename or source-relative `path.Match` pattern; repeatable |
 | `--preflight` | false | Inventory source metadata without opening file content or changing the vault |
 | `--json` | false | Emit only the terminal preflight or ingest report as JSON; suppress progress |
 | `--progress` | `auto` | Human ingest progress: `auto`, `bar`, or durable `plain` lines |
@@ -130,14 +131,14 @@ does not open cloud placeholders, create the destination, record an ingest, or
 write blobs. `--json` retains a bounded set of detailed findings and file-type
 groups for agents and scripts.
 
-Exclusion rules are deliberately simple and shared by preflight and import. A
-bare entry name such as `.git` or `node_modules` matches at any depth. A path
-containing `/`, such as `project/cache`, matches that relative path and its
-descendants within every supplied source. Rules are not shell globs and must be
-relative; absolute paths and `..` escapes are rejected. Rule form is preserved:
-`cache` is a name at any depth, while `cache/` and `./cache` mean only the
-root-relative `cache` entry. Each `--exclude` value is literal and commas are
-ordinary filename characters; repeat the flag to supply multiple rules.
+Selection rules are shared by preflight and import. A pattern without `/`, such
+as `*.pdf`, matches a basename at any depth. A pattern with `/`, such as
+`project/*.pdf`, matches the source-relative path; `*` and `?` do not cross `/`,
+and `**` is not a recursive globstar. Include rules filter regular files but do
+not prune directories. Exclusions win and matching directories prune their
+subtrees. Patterns must be relative and valid; absolute paths and `..` escapes
+are rejected. Commas are ordinary pattern characters; repeat each flag. Watch
+configuration keeps its separate literal exclusion rules.
 
 An ordinary import first scans source metadata for file and byte totals, then
 shows ingest progress on stderr. `auto` uses a redrawable bar on a terminal and

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -112,8 +112,11 @@ never modified or deleted.
   directory under `--dest` and relative structure is preserved.
 - An explicitly named symlink to a directory is followed as the import root;
   its supplied basename and provenance spelling are retained. Symlinks inside
-  that tree, symlinks to files, and other non-regular files are skipped and
-  reported as failures; they do not abort the run.
+  that tree, symlinks to files, and other selected non-regular files are skipped
+  and reported as failures; include-filtered entries are excluded without
+  failure, and neither case aborts the run.
+- Include and exclude patterns use `/` separators on every platform; a
+  backslash in a pattern is rejected.
 - Name collisions with different content auto-suffix:
   `report.pdf` → `report (2).pdf`.
 - Re-running an import converges: a file whose content already exists

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -152,6 +152,10 @@ added: 12  skipped: 3  excluded: 2  failed: 1
 failed: /src/broken.pdf: opening /src/broken.pdf: permission denied
 ```
 
+The `added` count includes a changed local source reconciled onto an existing
+node, because the operation adds a new immutable content version rather than a
+new node.
+
 Exit is non-zero if any file failed. A missing or unreadable top-level
 source is reported as a failure and the command continues with remaining
 source arguments, just as it does for failures inside a directory tree.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -139,6 +139,7 @@ not prune directories. Exclusions win and matching directories prune their
 subtrees. Patterns must be relative and valid; absolute paths and `..` escapes
 are rejected. Commas are ordinary pattern characters; repeat each flag. Watch
 configuration keeps its separate literal exclusion rules.
+Patterns are case-sensitive on every platform, including Windows.
 
 An ordinary import first scans source metadata for file and byte totals, then
 shows ingest progress on stderr. `auto` uses a redrawable bar on a terminal and

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -152,10 +152,6 @@ added: 12  skipped: 3  excluded: 2  failed: 1
 failed: /src/broken.pdf: opening /src/broken.pdf: permission denied
 ```
 
-The `added` count includes a changed local source reconciled onto an existing
-node, because the operation adds a new immutable content version rather than a
-new node.
-
 Exit is non-zero if any file failed. A missing or unreadable top-level
 source is reported as a failure and the command continues with remaining
 source arguments, just as it does for failures inside a directory tree.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,8 +170,9 @@ explicit operator choices.
 Each `[[watch]]` entry makes the daemon poll one local directory recursively.
 `source` must be absolute or begin with `~/`; `destination` is an absolute path
 in Docbank's virtual tree. Symlinks and other non-regular entries inside the
-source are ignored. `exclude` uses the same literal name-or-relative-path rules
-as repeated `docbank add --exclude` flags; it is not glob syntax.
+source are ignored. `exclude` remains a literal name-or-relative-path rule. It
+is independent of the glob include and exclude patterns accepted by
+`docbank add`.
 
 Traversal stays on the source's filesystem mount. It does not enter symlinks,
 Windows directory reparse points, or nested mounts; configure another

--- a/docs/internal/daemon-api-design.md
+++ b/docs/internal/daemon-api-design.md
@@ -143,7 +143,10 @@ must never enter logs or error strings.
 `POST /ingest` names absolute paths on the daemon host. Relative paths are
 meaningless to a long-lived process, and non-loopback callers are rejected even
 with a valid key because the capability reads daemon-host files. This is not a
-remote upload endpoint.
+remote upload endpoint. Its optional `include` and `exclude` arrays select
+source files with one compiled `path.Match`-based policy; exclusion wins and
+include rules never prune directories. The streamed and preflight routes carry
+the same fields and policy.
 
 The CLI resolves user arguments to absolute paths before sending the request,
 preserving shell-relative ergonomics. Partial source failures are returned in

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -233,10 +233,15 @@ problems converges without discarding prior progress. The destination directory
 is ID-based once resolved so a concurrent move cannot cause later files to
 recreate an old path.
 
-Preflight and import share one exclusion matcher and explicit-root-symlink
-model. Preflight stops at filesystem metadata: it never opens a regular file,
-hydrates cloud content, creates a destination, records an ingest, or writes a
-blob. It therefore predicts selection and size-policy outcomes, not future
+Preflight and import share one request-scoped source-selection compiler and
+explicit-root-symlink model. Include and exclude patterns use Go's
+`path.Match` grammar over slash-normalized source-relative paths; a pattern
+without `/` matches basenames at any depth, and exclusions win. Include rules
+filter regular files only, so a directory remains traversable when a descendant
+may match. Preflight stops at filesystem metadata: it never opens a regular
+file, hydrates cloud content, creates a destination, records an ingest, or
+writes a blob. Watched-inbox exclusions use a separate literal matcher. The
+report therefore predicts selection and size-policy outcomes, not future
 readability. Detailed findings and extension groups are bounded while their
 aggregate counts remain complete, preventing an adversarial tree from creating
 an unbounded API response.

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -92,7 +92,8 @@ Watched-inbox exclusions remain literal and do not use this glob syntax.
 Existing `--exclude` values on `docbank add` now use glob matching. Rules are
 slash-normalized for cross-platform parity, so backslash escaping is not
 available; match a literal `[`, `?`, or `*` with a bracket expression such as
-`report[[]1].txt`.
+`report[[]1].txt`. Matching is case-sensitive on every platform, including
+Windows.
 
 When the source argument is one explicit file, a basename rule such as `*.pdf`
 matches it; a path-form rule such as `reports/*.pdf` applies to a directory

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -89,6 +89,13 @@ include rules leave directories traversable. Rules must be relative and valid;
 empty rules, parent traversal, and malformed patterns are rejected before the
 walk. Commas are literal pattern characters, not separators; repeat each flag.
 Watched-inbox exclusions remain literal and do not use this glob syntax.
+Existing `--exclude` values on `docbank add` now use glob matching, so a
+literal filename containing `[`, `?`, or `*` needs an escaped pattern to
+preserve the old match.
+
+When the source argument is one explicit file, a basename rule such as `*.pdf`
+matches it; a path-form rule such as `reports/*.pdf` applies to a directory
+source's relative paths.
 
 ## Follow a long import
 

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -37,7 +37,8 @@ ordinary platform layouts such as `~/Dropbox` on macOS: docbank resolves that
 one root link, retains `Dropbox` as the virtual directory name, and records
 provenance using the path the user supplied. Symlinks encountered *inside* the
 tree remain skipped and reported, and an explicitly named symlink to a file is
-not imported.
+not imported. Entries filtered by an include or exclude rule are excluded
+without failure; selected non-regular entries are reported as failures.
 
 ## Preflight a large tree
 
@@ -89,9 +90,9 @@ include rules leave directories traversable. Rules must be relative and valid;
 empty rules, parent traversal, and malformed patterns are rejected before the
 walk. Commas are literal pattern characters, not separators; repeat each flag.
 Watched-inbox exclusions remain literal and do not use this glob syntax.
-Existing `--exclude` values on `docbank add` now use glob matching. Rules are
-slash-normalized for cross-platform parity, so backslash escaping is not
-available; match a literal `[`, `?`, or `*` with a bracket expression such as
+Existing `--exclude` values on `docbank add` now use glob matching. Rules must
+use `/` separators on every platform; backslashes are rejected, so backslash
+escaping is not available; match a literal `[`, `?`, or `*` with a bracket expression such as
 `report[[]1].txt`. Matching is case-sensitive on every platform, including
 Windows.
 

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -89,9 +89,10 @@ include rules leave directories traversable. Rules must be relative and valid;
 empty rules, parent traversal, and malformed patterns are rejected before the
 walk. Commas are literal pattern characters, not separators; repeat each flag.
 Watched-inbox exclusions remain literal and do not use this glob syntax.
-Existing `--exclude` values on `docbank add` now use glob matching, so a
-literal filename containing `[`, `?`, or `*` needs an escaped pattern to
-preserve the old match.
+Existing `--exclude` values on `docbank add` now use glob matching. Rules are
+slash-normalized for cross-platform parity, so backslash escaping is not
+available; match a literal `[`, `?`, or `*` with a bracket expression such as
+`report[[]1].txt`.
 
 When the source argument is one explicit file, a basename rule such as `*.pdf`
 matches it; a path-form rule such as `reports/*.pdf` applies to a directory

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -45,6 +45,7 @@ Inventory a source before Docbank opens any file content or changes the vault:
 
 ```bash
 docbank add ~/Dropbox --preflight \
+  --include '*.pdf' \
   --exclude .git \
   --exclude .Trash \
   --exclude project/cache
@@ -70,23 +71,24 @@ A provider may decline to hydrate a placeholder for the process that opens it â€
 a daemon started by launchd as a background job is the usual case, while an
 interactive session succeeds. Docbank reports that failure for the individual
 file, names the cause, and suggests opening the file once from a user session
-(or marking it available offline) before retrying the import. Re-run preflight after changing exclusions, then pass the exact same
-`--exclude` flags to the real `docbank add` command.
+(or marking it available offline) before retrying the import. Re-run preflight
+after changing selection, then pass the exact same `--include` and `--exclude`
+flags to the real `docbank add` command.
 
 Filesystem names and provenance paths must currently be valid UTF-8. On POSIX
 filesystems that permit other byte sequences, preflight and ingest report each
 such entry with an escaped, printable path; Docbank does not open or import it,
 continues with the rest of the tree, and never alters the source.
 
-A bare exclusion such as `.git` prunes that entry name wherever it occurs. A
-relative path such as `project/cache` prunes that path and its descendants
-within each supplied source. Exclusions do not use glob syntax. A pruned
-directory counts as one excluded entry because Docbank deliberately does not
-walk it to count hidden descendants. A trailing slash or leading `./` keeps a
-single-component rule path-shaped: `cache` matches that name anywhere, whereas
-`cache/` and `./cache` match only the source root's `cache` entry. Commas are
-literal filename characters, not rule separators; pass `--exclude` repeatedly
-for multiple rules.
+Include and exclude rules use Go's `path.Match` grammar over slash-normalized
+paths within each source. A rule without `/`, such as `*.pdf`, matches a
+basename at any depth; a rule with `/`, such as `reports/*.pdf`, matches that
+source-relative path. `*` and `?` do not cross `/`, and `**` is not a recursive
+globstar. Exclusions win, and matching directories prune their subtrees while
+include rules leave directories traversable. Rules must be relative and valid;
+empty rules, parent traversal, and malformed patterns are rejected before the
+walk. Commas are literal pattern characters, not separators; repeat each flag.
+Watched-inbox exclusions remain literal and do not use this glob syntax.
 
 ## Follow a long import
 

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -38,6 +38,11 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 		block := openAPISchemaBlock(t, doc, schema)
 		assert.Contains(t, block, "        include:")
 		assert.Contains(t, block, "        exclude:")
+		if schema == "IngestRequest" {
+			assert.Contains(t, block, "        dest:")
+		} else {
+			assert.NotContains(t, block, "        dest:")
+		}
 	}
 }
 
@@ -49,6 +54,10 @@ func openAPISchemaBlock(t *testing.T, doc, schema string) string {
 	block := doc[start+len(marker):]
 	for offset := strings.Index(block, "\n"); offset >= 0; {
 		line := block[offset+1:]
+		if line != "" && !strings.HasPrefix(line, "      ") {
+			block = block[:offset]
+			break
+		}
 		if strings.HasPrefix(line, "    ") && len(line) > 4 && line[4] != ' ' {
 			block = block[:offset]
 			break

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -33,9 +34,32 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	assert.Contains(t, doc, api.ContentVersionHeader)
 	assert.Contains(t, doc, "Content-Digest")
 	assert.Contains(t, doc, "computed_hash")
-	assert.Contains(t, doc, "IngestRequest:")
-	assert.Contains(t, doc, "        include:")
-	assert.Contains(t, doc, "        exclude:")
+	for _, schema := range []string{"IngestPreflightRequest", "IngestRequest"} {
+		block := openAPISchemaBlock(t, doc, schema)
+		assert.Contains(t, block, "        include:")
+		assert.Contains(t, block, "        exclude:")
+	}
+}
+
+func openAPISchemaBlock(t *testing.T, doc, schema string) string {
+	t.Helper()
+	marker := "\n    " + schema + ":\n"
+	start := strings.Index(doc, marker)
+	require.NotEqual(t, -1, start, "schema missing from OpenAPI document")
+	block := doc[start+len(marker):]
+	for offset := strings.Index(block, "\n"); offset >= 0; {
+		line := block[offset+1:]
+		if strings.HasPrefix(line, "    ") && len(line) > 4 && line[4] != ' ' {
+			block = block[:offset]
+			break
+		}
+		next := strings.Index(line, "\n")
+		if next < 0 {
+			break
+		}
+		offset += next + 1
+	}
+	return block
 }
 
 func TestOpenAPIDeclaresSecurity(t *testing.T) {

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -33,8 +33,9 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	assert.Contains(t, doc, api.ContentVersionHeader)
 	assert.Contains(t, doc, "Content-Digest")
 	assert.Contains(t, doc, "computed_hash")
-	assert.Contains(t, doc, "include")
-	assert.Contains(t, doc, "exclude")
+	assert.Contains(t, doc, "IngestRequest:")
+	assert.Contains(t, doc, "        include:")
+	assert.Contains(t, doc, "        exclude:")
 }
 
 func TestOpenAPIDeclaresSecurity(t *testing.T) {

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -33,6 +33,8 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	assert.Contains(t, doc, api.ContentVersionHeader)
 	assert.Contains(t, doc, "Content-Digest")
 	assert.Contains(t, doc, "computed_hash")
+	assert.Contains(t, doc, "include")
+	assert.Contains(t, doc, "exclude")
 }
 
 func TestOpenAPIDeclaresSecurity(t *testing.T) {

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -97,15 +97,12 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		OperationID: "preflightIngest", Method: http.MethodPost, Path: "/api/v1/ingest/preflight",
 		Summary: "Inventory server-side files without opening content or mutating the vault",
 	}, func(ctx context.Context, in *struct {
-		Body struct {
-			Paths   []string `json:"paths" minItems:"1"`
-			Exclude []string `json:"exclude,omitempty"`
-		}
+		Body IngestPreflightRequest
 	}) (*ingestPreflightOutput, error) {
 		if err := validateIngestPaths(in.Body.Paths); err != nil {
 			return nil, err
 		}
-		opts := ingest.Options{Exclude: in.Body.Exclude}
+		opts := ingest.Options{Include: in.Body.Include, Exclude: in.Body.Exclude}
 		if err := ingest.ValidateOptions(opts); err != nil {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 		}
@@ -120,7 +117,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 		OperationID: "ingest", Method: http.MethodPost, Path: "/api/v1/ingest",
 		Summary: "Import server-side files or directory trees (loopback callers only)",
 	}, func(ctx context.Context, in *struct {
-		Body ingestRequest
+		Body IngestRequest
 	}) (*ingestOutput, error) {
 		dest, opts, err := ingestParams(in.Body)
 		if err != nil {
@@ -146,7 +143,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 			},
 		},
 	}, func(_ context.Context, in *struct {
-		Body ingestRequest
+		Body IngestRequest
 	}) (*huma.StreamResponse, error) {
 		dest, opts, err := ingestParams(in.Body)
 		if err != nil {
@@ -303,17 +300,11 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 	})
 }
 
-type ingestRequest struct {
-	Paths   []string `json:"paths" minItems:"1"`
-	Dest    string   `json:"dest" default:"/inbox"`
-	Exclude []string `json:"exclude,omitempty"`
-}
-
-func ingestParams(body ingestRequest) (string, ingest.Options, error) {
+func ingestParams(body IngestRequest) (string, ingest.Options, error) {
 	if err := validateIngestPaths(body.Paths); err != nil {
 		return "", ingest.Options{}, err
 	}
-	opts := ingest.Options{Exclude: body.Exclude}
+	opts := ingest.Options{Include: body.Include, Exclude: body.Exclude}
 	if err := ingest.ValidateOptions(opts); err != nil {
 		return "", ingest.Options{}, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 	}

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -103,10 +103,11 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 			return nil, err
 		}
 		opts := ingest.Options{Include: in.Body.Include, Exclude: in.Body.Exclude}
-		if err := ingest.ValidateOptions(opts); err != nil {
+		selection, err := ingest.CompileSelection(opts)
+		if err != nil {
 			return nil, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 		}
-		report, err := ingest.Preflight(ctx, in.Body.Paths, opts)
+		report, err := ingest.PreflightWithSelection(ctx, in.Body.Paths, selection)
 		if err != nil {
 			return nil, FromStoreError(err)
 		}
@@ -119,11 +120,11 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 	}, func(ctx context.Context, in *struct {
 		Body IngestRequest
 	}) (*ingestOutput, error) {
-		dest, opts, err := ingestParams(in.Body)
+		dest, opts, selection, err := ingestParams(in.Body)
 		if err != nil {
 			return nil, err
 		}
-		report, err := runIngest(ctx, d, g, in.Body.Paths, dest, opts)
+		report, err := runIngest(ctx, d, g, in.Body.Paths, dest, opts, selection)
 		return &ingestOutput{Body: report}, err
 	})
 
@@ -145,7 +146,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 	}, func(_ context.Context, in *struct {
 		Body IngestRequest
 	}) (*huma.StreamResponse, error) {
-		dest, opts, err := ingestParams(in.Body)
+		dest, opts, selection, err := ingestParams(in.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -156,7 +157,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 			defer cancel()
 			stream := newEventStreamWriter[IngestEvent](hctx.BodyWriter(), cancel)
 			stream.send(IngestEvent{Type: "progress", Progress: &IngestProgress{Stage: "scan"}})
-			preflight, scanErr := ingest.Preflight(runCtx, in.Body.Paths, opts)
+			preflight, scanErr := ingest.PreflightWithSelection(runCtx, in.Body.Paths, selection)
 			if stream.err() != nil {
 				return
 			}
@@ -182,7 +183,7 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 					Failed: event.Failed, Final: event.Final,
 				}})
 			}
-			report, ingestErr := runIngest(runCtx, d, g, in.Body.Paths, dest, opts)
+			report, ingestErr := runIngest(runCtx, d, g, in.Body.Paths, dest, opts, selection)
 			if stream.err() != nil {
 				return
 			}
@@ -300,13 +301,14 @@ func registerOpsRoutes(api huma.API, d Deps, g *gate) {
 	})
 }
 
-func ingestParams(body IngestRequest) (string, ingest.Options, error) {
+func ingestParams(body IngestRequest) (string, ingest.Options, ingest.Selection, error) {
 	if err := validateIngestPaths(body.Paths); err != nil {
-		return "", ingest.Options{}, err
+		return "", ingest.Options{}, ingest.Selection{}, err
 	}
 	opts := ingest.Options{Include: body.Include, Exclude: body.Exclude}
-	if err := ingest.ValidateOptions(opts); err != nil {
-		return "", ingest.Options{}, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
+	selection, err := ingest.CompileSelection(opts)
+	if err != nil {
+		return "", ingest.Options{}, ingest.Selection{}, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 	}
 	// The schema default covers an absent dest, not an explicit ""
 	// (which MkdirAll would treat as the vault root).
@@ -315,10 +317,10 @@ func ingestParams(body IngestRequest) (string, ingest.Options, error) {
 		dest = "/inbox"
 	}
 	if !strings.HasPrefix(dest, "/") {
-		return "", ingest.Options{}, NewError(http.StatusUnprocessableEntity, "validation",
+		return "", ingest.Options{}, ingest.Selection{}, NewError(http.StatusUnprocessableEntity, "validation",
 			fmt.Sprintf("dest %q must be an absolute virtual path (start with /)", dest))
 	}
-	return dest, opts, nil
+	return dest, opts, selection, nil
 }
 
 func runIngest(
@@ -328,12 +330,13 @@ func runIngest(
 	paths []string,
 	dest string,
 	opts ingest.Options,
+	selection ingest.Selection,
 ) (IngestReport, error) {
 	var out IngestReport
 	err := g.mutate(func() error {
 		return d.Blobs.WithMutation(ctx, func() error {
 			ing := &ingest.Ingester{Store: d.Store, Blobs: d.Blobs}
-			rep, err := ing.AddPathsWithOptions(ctx, paths, dest, opts)
+			rep, err := ing.AddPathsWithSelection(ctx, paths, dest, opts, selection)
 			if err != nil {
 				return FromStoreError(err)
 			}

--- a/internal/api/routes_ops_test.go
+++ b/internal/api/routes_ops_test.go
@@ -151,6 +151,53 @@ func TestIngestPreflightIsReadOnlyAndSharesExclusions(t *testing.T) {
 	assert.Contains(t, body, `"code":"validation"`)
 }
 
+func TestIngestRoutesCarryIncludeAndExcludeSelection(t *testing.T) {
+	source := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(source, "keep.txt"), []byte("keep"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(source, "skip.txt"), []byte("skip"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(source, "nested"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(source, "nested", "note.md"), []byte("note"), 0o600))
+
+	for _, route := range []string{
+		"/api/v1/ingest/preflight", "/api/v1/ingest", "/api/v1/ingest/stream",
+	} {
+		t.Run(route, func(t *testing.T) {
+			ts, s := newTestServer(t, nil)
+			request := map[string]any{
+				"paths": []string{source}, "include": []string{"*.txt"},
+				"exclude": []string{"skip.txt"},
+			}
+			if route != "/api/v1/ingest/preflight" {
+				request["dest"] = "/inbox"
+			}
+			resp, body := do(t, ts, http.MethodPost, route, nil, request)
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			if route == "/api/v1/ingest/preflight" {
+				var report api.IngestPreflightReport
+				require.NoError(t, json.Unmarshal([]byte(body), &report))
+				assert.Equal(t, int64(1), report.Files)
+				assert.Equal(t, int64(2), report.Excluded)
+				_, err := s.NodeByPath(t.Context(), "/inbox")
+				require.ErrorIs(t, err, store.ErrNotFound)
+				return
+			}
+			if route == "/api/v1/ingest/stream" {
+				lines := strings.Split(strings.TrimSpace(body), "\n")
+				var event api.IngestEvent
+				require.NoError(t, json.Unmarshal([]byte(lines[len(lines)-1]), &event))
+				require.NotNil(t, event.Report)
+				assert.Equal(t, 1, event.Report.Added)
+				assert.Equal(t, 2, event.Report.Excluded)
+				return
+			}
+			var report api.IngestReport
+			require.NoError(t, json.Unmarshal([]byte(body), &report))
+			assert.Equal(t, 1, report.Added)
+			assert.Equal(t, 2, report.Excluded)
+		})
+	}
+}
+
 func TestIngestRejectsNonLoopback(t *testing.T) {
 	// httptest.NewRequest-style direct handler invocation with a non-loopback
 	// RemoteAddr proves the middleware fence without real remote networking.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -514,6 +514,22 @@ type IngestReport struct {
 	Failed   []IngestFailure `json:"failed,omitempty"`
 }
 
+// IngestPreflightRequest inventories server-side paths without opening
+// regular-file content or mutating the vault.
+type IngestPreflightRequest struct {
+	Paths   []string `json:"paths" minItems:"1"`
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+// IngestRequest imports server-side paths with optional source selection.
+type IngestRequest struct {
+	Paths   []string `json:"paths" minItems:"1"`
+	Dest    string   `json:"dest" default:"/inbox"`
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
 // IngestProgress is one structured update from a server-side import. Scan
 // establishes totals without opening content; ingest counts bytes actually
 // read and files whose individual import attempt has completed.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1992,20 +1992,21 @@ func canonicalDirectoryPath(path string) (string, error) {
 }
 
 func (c *Client) Ingest(ctx context.Context, paths []string, dest string) (api.IngestReport, error) {
-	return c.IngestWithOptions(ctx, paths, dest, nil)
+	return c.IngestWithOptions(ctx, paths, dest, nil, nil)
 }
 
-// IngestWithOptions imports server-side paths with the same exclusion rules
+// IngestWithOptions imports server-side paths with the same selection rules
 // accepted by PreflightIngest.
 func (c *Client) IngestWithOptions(
 	ctx context.Context,
 	paths []string,
 	dest string,
+	include []string,
 	exclude []string,
 ) (api.IngestReport, error) {
 	var rep api.IngestReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/ingest", nil,
-		map[string]any{"paths": paths, "dest": dest, "exclude": exclude}, &rep)
+		map[string]any{"paths": paths, "dest": dest, "include": include, "exclude": exclude}, &rep)
 	return rep, err
 }
 
@@ -2016,11 +2017,12 @@ func (c *Client) IngestStream(
 	ctx context.Context,
 	paths []string,
 	dest string,
+	include []string,
 	exclude []string,
 	progress func(api.IngestProgress),
 ) (api.IngestReport, error) {
 	body, err := marshalJSONRequest(map[string]any{
-		"paths": paths, "dest": dest, "exclude": exclude,
+		"paths": paths, "dest": dest, "include": include, "exclude": exclude,
 	})
 	if err != nil {
 		return api.IngestReport{}, fmt.Errorf("encoding ingest request: %w", err)
@@ -2091,11 +2093,12 @@ func (c *Client) IngestStream(
 func (c *Client) PreflightIngest(
 	ctx context.Context,
 	paths []string,
+	include []string,
 	exclude []string,
 ) (api.IngestPreflightReport, error) {
 	var rep api.IngestPreflightReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/ingest/preflight", nil,
-		map[string]any{"paths": paths, "exclude": exclude}, &rep)
+		map[string]any{"paths": paths, "include": include, "exclude": exclude}, &rep)
 	return rep, err
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -452,7 +452,7 @@ func TestIngestStreamRoundTrip(t *testing.T) {
 	require.NoError(t, os.WriteFile(src, content, 0o600))
 
 	var events []api.IngestProgress
-	report, err := c.IngestStream(t.Context(), []string{src}, "/inbox", nil,
+	report, err := c.IngestStream(t.Context(), []string{src}, "/inbox", nil, nil,
 		func(event api.IngestProgress) { events = append(events, event) })
 	require.NoError(t, err)
 	assert.Equal(t, 1, report.Added)
@@ -471,6 +471,40 @@ func TestIngestStreamRoundTrip(t *testing.T) {
 	assert.Equal(t, int64(len(content)), finalStages["ingest"].BytesDone)
 }
 
+func TestIngestClientCarriesSelectionRulesToEveryRoute(t *testing.T) {
+	var bodies []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		bodies = append(bodies, string(body))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/ingest/stream" {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_ = json.MarshalWrite(w, api.IngestEvent{Type: "result", Report: &api.IngestReport{}})
+			return
+		}
+		_ = json.MarshalWrite(w, map[string]any{})
+	}))
+	t.Cleanup(ts.Close)
+	c := client.New(ts.URL, "key")
+	include := []string{"*.txt"}
+	exclude := []string{"skip.txt"}
+	_, err := c.PreflightIngest(t.Context(), []string{"/source"}, include, exclude)
+	require.NoError(t, err)
+	_, err = c.IngestWithOptions(t.Context(), []string{"/source"}, "/inbox", include, exclude)
+	require.NoError(t, err)
+	_, err = c.IngestStream(t.Context(), []string{"/source"}, "/inbox", include, exclude, nil)
+	require.NoError(t, err)
+	require.Len(t, bodies, 3)
+	for _, body := range bodies {
+		assert.Contains(t, body, `"include":["*.txt"]`)
+		assert.Contains(t, body, `"exclude":["skip.txt"]`)
+	}
+}
+
 func TestProgressStreamPreservesProblemCode(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/x-ndjson")
@@ -482,7 +516,7 @@ func TestProgressStreamPreservesProblemCode(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	_, err := client.New(ts.URL, "key").IngestStream(
-		t.Context(), []string{"/source"}, "/inbox", nil, nil)
+		t.Context(), []string{"/source"}, "/inbox", nil, nil, nil)
 	require.Error(t, err)
 	code, ok := client.ProblemCode(err)
 	assert.True(t, ok)
@@ -523,15 +557,15 @@ func TestJSONMethodsRejectInvalidUTF8BeforeRequest(t *testing.T) {
 		call func() error
 	}{
 		{name: "ordinary", call: func() error {
-			_, err := c.IngestWithOptions(t.Context(), []string{invalidPath}, "/inbox", nil)
+			_, err := c.IngestWithOptions(t.Context(), []string{invalidPath}, "/inbox", nil, nil)
 			return err
 		}},
 		{name: "stream", call: func() error {
-			_, err := c.IngestStream(t.Context(), []string{invalidPath}, "/inbox", nil, nil)
+			_, err := c.IngestStream(t.Context(), []string{invalidPath}, "/inbox", nil, nil, nil)
 			return err
 		}},
 		{name: "preflight", call: func() error {
-			_, err := c.PreflightIngest(t.Context(), []string{invalidPath}, nil)
+			_, err := c.PreflightIngest(t.Context(), []string{invalidPath}, nil, nil)
 			return err
 		}},
 		{name: "mkdir name", call: func() error {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "62"
+	daemonProtocolVersion = "63"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -580,7 +580,12 @@ func (ing *Ingester) addTree(
 				ctx, dirIDs, destDirID, topName, walkRoot, filepath.Dir(p),
 			)
 			if err != nil {
-				return err
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				rep.Failed = append(rep.Failed, FileError{Path: reportPath(sourcePath), Err: err})
+				progress.report(*rep, false)
+				return fs.SkipDir
 			}
 			if err := ing.addOne(ctx, rep, ingestRun, parentID, p, sourcePath, progress); err != nil {
 				return err

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -548,6 +548,9 @@ func (ing *Ingester) addTree(
 		}
 		switch {
 		case d.IsDir():
+			if len(selection.include) > 0 {
+				return nil
+			}
 			parentID, name := destDirID, topName
 			if p != walkRoot {
 				pid, ok := dirIDs[filepath.Dir(p)]
@@ -573,9 +576,11 @@ func (ing *Ingester) addTree(
 				progress.report(*rep, false)
 				return nil
 			}
-			parentID, ok := dirIDs[filepath.Dir(p)]
-			if !ok {
-				return fmt.Errorf("internal: no virtual dir recorded for %s", filepath.Dir(p))
+			parentID, err := ing.ensureSourceDir(
+				ctx, dirIDs, destDirID, topName, walkRoot, filepath.Dir(p),
+			)
+			if err != nil {
+				return err
 			}
 			if err := ing.addOne(ctx, rep, ingestRun, parentID, p, sourcePath, progress); err != nil {
 				return err
@@ -588,6 +593,31 @@ func (ing *Ingester) addTree(
 		return nil
 	})
 	return walkErr
+}
+
+func (ing *Ingester) ensureSourceDir(
+	ctx context.Context, dirIDs map[string]int64, destDirID int64, topName, walkRoot, dirPath string,
+) (int64, error) {
+	if id, ok := dirIDs[dirPath]; ok {
+		return id, nil
+	}
+	parentID, name := destDirID, topName
+	if dirPath != walkRoot {
+		var err error
+		parentID, err = ing.ensureSourceDir(
+			ctx, dirIDs, destDirID, topName, walkRoot, filepath.Dir(dirPath),
+		)
+		if err != nil {
+			return 0, err
+		}
+		name = filepath.Base(dirPath)
+	}
+	dir, err := ing.Store.EnsureDir(ctx, parentID, name)
+	if err != nil {
+		return 0, fmt.Errorf("creating virtual dir %q under node %d: %w", name, parentID, err)
+	}
+	dirIDs[dirPath] = dir.ID
+	return dir.ID, nil
 }
 
 func sourceTreePath(sourceRoot, walkRoot, walkPath string) string {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -459,6 +459,11 @@ func (ing *Ingester) AddPathsWithOptions(
 				continue
 			}
 			if !target.IsDir() {
+				if !selection.included(src, src) {
+					rep.Excluded++
+					progress.report(rep, false)
+					continue
+				}
 				rep.Failed = append(rep.Failed, FileError{Path: src,
 					Err: errors.New("explicit symlink source does not resolve to a directory")})
 				progress.report(rep, false)
@@ -468,6 +473,11 @@ func (ing *Ingester) AddPathsWithOptions(
 				return rep, err
 			}
 		default:
+			if !selection.included(src, src) {
+				rep.Excluded++
+				progress.report(rep, false)
+				continue
+			}
 			rep.Failed = append(rep.Failed, FileError{Path: src,
 				Err: errors.New("not a regular file or directory (symlinks are skipped)")})
 			progress.report(rep, false)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -520,6 +520,7 @@ func (ing *Ingester) addTree(
 	// destDirID — a concurrent move or trash of the destination would make
 	// that path re-create (even resurrect) a tree somewhere else.
 	dirIDs := map[string]int64{} // source dir path -> virtual dir node id
+	dirErrs := map[string]error{} // source dir path -> reported creation failure
 	walkErr := filepath.WalkDir(walkRoot, func(p string, d fs.DirEntry, err error) error {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
@@ -577,7 +578,7 @@ func (ing *Ingester) addTree(
 				return nil
 			}
 			parentID, err := ing.ensureSourceDir(
-				ctx, dirIDs, destDirID, topName, walkRoot, filepath.Dir(p),
+				ctx, dirIDs, dirErrs, destDirID, topName, walkRoot, filepath.Dir(p),
 			)
 			if err != nil {
 				if ctxErr := ctx.Err(); ctxErr != nil {
@@ -585,6 +586,9 @@ func (ing *Ingester) addTree(
 				}
 				rep.Failed = append(rep.Failed, FileError{Path: reportPath(sourcePath), Err: err})
 				progress.report(*rep, false)
+				if _, rootFailed := dirErrs[walkRoot]; rootFailed {
+					return fs.SkipAll
+				}
 				return fs.SkipDir
 			}
 			if err := ing.addOne(ctx, rep, ingestRun, parentID, p, sourcePath, progress); err != nil {
@@ -601,25 +605,32 @@ func (ing *Ingester) addTree(
 }
 
 func (ing *Ingester) ensureSourceDir(
-	ctx context.Context, dirIDs map[string]int64, destDirID int64, topName, walkRoot, dirPath string,
+	ctx context.Context, dirIDs map[string]int64, dirErrs map[string]error,
+	destDirID int64, topName, walkRoot, dirPath string,
 ) (int64, error) {
 	if id, ok := dirIDs[dirPath]; ok {
 		return id, nil
+	}
+	if err, ok := dirErrs[dirPath]; ok {
+		return 0, err
 	}
 	parentID, name := destDirID, topName
 	if dirPath != walkRoot {
 		var err error
 		parentID, err = ing.ensureSourceDir(
-			ctx, dirIDs, destDirID, topName, walkRoot, filepath.Dir(dirPath),
+			ctx, dirIDs, dirErrs, destDirID, topName, walkRoot, filepath.Dir(dirPath),
 		)
 		if err != nil {
+			dirErrs[dirPath] = err
 			return 0, err
 		}
 		name = filepath.Base(dirPath)
 	}
 	dir, err := ing.Store.EnsureDir(ctx, parentID, name)
 	if err != nil {
-		return 0, fmt.Errorf("creating virtual dir %q under node %d: %w", name, parentID, err)
+		err = fmt.Errorf("creating virtual dir %q under node %d: %w", name, parentID, err)
+		dirErrs[dirPath] = err
+		return 0, err
 	}
 	dirIDs[dirPath] = dir.ID
 	return dir.ID, nil

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -651,9 +651,14 @@ func (ing *Ingester) ensureSourceDir(
 	if err, ok := dirErrs[dirPath]; ok {
 		return 0, err
 	}
+	rel, err := filepath.Rel(walkRoot, dirPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		err = fmt.Errorf("source directory %q is outside traversal root %q", dirPath, walkRoot)
+		dirErrs[dirPath] = err
+		return 0, err
+	}
 	parentID, name := destDirID, topName
 	if dirPath != walkRoot {
-		var err error
 		parentID, err = ing.ensureSourceDir(
 			ctx, dirIDs, dirErrs, destDirID, topName, walkRoot, filepath.Dir(dirPath),
 		)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -381,7 +381,7 @@ func (ing *Ingester) AddPaths(ctx context.Context, sources []string, destPath st
 }
 
 // AddPathsWithOptions ingests the selected parts of files and directory trees
-// under the virtual destPath. Exclusions have the same semantics as Preflight.
+// under the virtual destPath. Selection has the same semantics as Preflight.
 func (ing *Ingester) AddPathsWithOptions(
 	ctx context.Context,
 	sources []string,
@@ -393,7 +393,7 @@ func (ing *Ingester) AddPathsWithOptions(
 	if err := ctx.Err(); err != nil {
 		return rep, err
 	}
-	excludes, err := compileExclusions(opts.Exclude)
+	selection, err := compileSourceSelection(opts)
 	if err != nil {
 		return rep, err
 	}
@@ -424,18 +424,23 @@ func (ing *Ingester) AddPathsWithOptions(
 			progress.report(rep, false)
 			continue
 		}
-		if excludes.match(src, src) {
+		if selection.excluded(src, src) {
 			rep.Excluded++
 			progress.report(rep, false)
 			continue
 		}
 		switch {
 		case info.Mode().IsRegular():
+			if !selection.included(src, src) {
+				rep.Excluded++
+				progress.report(rep, false)
+				continue
+			}
 			if err := ing.addOne(ctx, &rep, ingestID, dest.ID, src, src, progress); err != nil {
 				return rep, err
 			}
 		case info.IsDir():
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, excludes, progress); err != nil {
+			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, selection, progress); err != nil {
 				return rep, err
 			}
 		case info.Mode()&fs.ModeSymlink != 0:
@@ -459,7 +464,7 @@ func (ing *Ingester) AddPathsWithOptions(
 				progress.report(rep, false)
 				continue
 			}
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, walkRoot, excludes, progress); err != nil {
+			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, walkRoot, selection, progress); err != nil {
 				return rep, err
 			}
 		default:
@@ -489,7 +494,7 @@ func (ing *Ingester) addTree(
 	ingestRun store.IngestRun,
 	destDirID int64,
 	sourceRoot, walkRoot string,
-	excludes exclusions,
+	selection sourceSelection,
 	progress *progressTracker,
 ) error {
 	// Absolutize first. WalkDir hands back the root spelled exactly as given
@@ -533,7 +538,7 @@ func (ing *Ingester) addTree(
 			}
 			return nil
 		}
-		if excludes.match(sourceRoot, sourcePath) {
+		if selection.excluded(sourceRoot, sourcePath) {
 			rep.Excluded++
 			progress.report(*rep, false)
 			if d.IsDir() {
@@ -563,6 +568,11 @@ func (ing *Ingester) addTree(
 			}
 			dirIDs[p] = dir.ID
 		case d.Type().IsRegular():
+			if !selection.included(sourceRoot, sourcePath) {
+				rep.Excluded++
+				progress.report(*rep, false)
+				return nil
+			}
 			parentID, ok := dirIDs[filepath.Dir(p)]
 			if !ok {
 				return fmt.Errorf("internal: no virtual dir recorded for %s", filepath.Dir(p))

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -388,13 +388,25 @@ func (ing *Ingester) AddPathsWithOptions(
 	destPath string,
 	opts Options,
 ) (rep Report, err error) {
+	selection, err := CompileSelection(opts)
+	if err != nil {
+		return rep, err
+	}
+	return ing.AddPathsWithSelection(ctx, sources, destPath, opts, selection)
+}
+
+// AddPathsWithSelection imports sources using a previously compiled request
+// selection shared with preflight.
+func (ing *Ingester) AddPathsWithSelection(
+	ctx context.Context,
+	sources []string,
+	destPath string,
+	opts Options,
+	selection Selection,
+) (rep Report, err error) {
 	progress := newProgressTracker(opts.Progress)
 	progress.report(rep, false)
 	if err := ctx.Err(); err != nil {
-		return rep, err
-	}
-	selection, err := compileSourceSelection(opts)
-	if err != nil {
 		return rep, err
 	}
 	dest, err := ing.Store.MkdirAll(ctx, destPath)
@@ -446,6 +458,11 @@ func (ing *Ingester) AddPathsWithOptions(
 		case info.Mode()&fs.ModeSymlink != 0:
 			walkRoot, err := filepath.EvalSymlinks(src)
 			if err != nil {
+				if !selection.included(src, src) {
+					rep.Excluded++
+					progress.report(rep, false)
+					continue
+				}
 				rep.Failed = append(rep.Failed, FileError{Path: src,
 					Err: fmt.Errorf("resolving explicitly named directory symlink: %w", err)})
 				progress.report(rep, false)
@@ -453,6 +470,11 @@ func (ing *Ingester) AddPathsWithOptions(
 			}
 			target, err := os.Stat(walkRoot)
 			if err != nil {
+				if !selection.included(src, src) {
+					rep.Excluded++
+					progress.report(rep, false)
+					continue
+				}
 				rep.Failed = append(rep.Failed, FileError{Path: src,
 					Err: fmt.Errorf("checking explicitly named directory symlink: %w", err)})
 				progress.report(rep, false)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -519,7 +519,7 @@ func (ing *Ingester) addTree(
 	// the resolved id of its parent, never by re-deriving a path from
 	// destDirID — a concurrent move or trash of the destination would make
 	// that path re-create (even resurrect) a tree somewhere else.
-	dirIDs := map[string]int64{} // source dir path -> virtual dir node id
+	dirIDs := map[string]int64{}  // source dir path -> virtual dir node id
 	dirErrs := map[string]error{} // source dir path -> reported creation failure
 	walkErr := filepath.WalkDir(walkRoot, func(p string, d fs.DirEntry, err error) error {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -595,6 +595,11 @@ func (ing *Ingester) addTree(
 				return err
 			}
 		default:
+			if !selection.included(sourceRoot, sourcePath) {
+				rep.Excluded++
+				progress.report(*rep, false)
+				return nil
+			}
 			rep.Failed = append(rep.Failed, FileError{Path: sourcePath,
 				Err: errors.New("not a regular file (symlinks are skipped)")})
 			progress.report(*rep, false)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -623,7 +623,9 @@ func TestIncludeSkipsNonRegularEntries(t *testing.T) {
 	ing := newTestIngester(t)
 	ctx := t.Context()
 	src := writeTree(t, map[string]string{"keep.txt": "keep", "target.bin": "target"})
-	require.NoError(t, os.Symlink(filepath.Join(src, "keep.txt"), filepath.Join(src, "skip.link")))
+	if err := os.Symlink(filepath.Join(src, "keep.txt"), filepath.Join(src, "skip.link")); err != nil {
+		t.Skipf("creating a symlink requires additional platform permission: %v", err)
+	}
 
 	preflight, err := Preflight(ctx, []string{src}, Options{Include: []string{"*.txt"}})
 	require.NoError(t, err)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -619,6 +619,25 @@ func TestAddTreeStaleDestinationDefaultSelectionDoesNotResurrect(t *testing.T) {
 	assert.ErrorIs(t, err, store.ErrNotFound, "trashed destination must stay trashed")
 }
 
+func TestIncludeSkipsNonRegularEntries(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	src := writeTree(t, map[string]string{"keep.txt": "keep", "target.bin": "target"})
+	require.NoError(t, os.Symlink(filepath.Join(src, "keep.txt"), filepath.Join(src, "skip.link")))
+
+	preflight, err := Preflight(ctx, []string{src}, Options{Include: []string{"*.txt"}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), preflight.Files)
+	assert.Equal(t, int64(2), preflight.Excluded)
+	assert.Zero(t, preflight.Skipped)
+
+	report, err := ing.AddPathsWithOptions(ctx, []string{src}, "/inbox", Options{Include: []string{"*.txt"}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Added)
+	assert.Equal(t, 2, report.Excluded)
+	assert.Empty(t, report.Failed)
+}
+
 func TestPreflightInventoriesWithoutMutatingVault(t *testing.T) {
 	ing := newTestIngester(t)
 	src := writeTree(t, map[string]string{

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -600,6 +600,25 @@ func TestAddTreeStaleDestinationIsNotResurrected(t *testing.T) {
 	assert.ErrorIs(t, err, store.ErrNotFound, "trashed destination must stay trashed")
 }
 
+func TestAddTreeStaleDestinationDefaultSelectionDoesNotResurrect(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	src := writeTree(t, map[string]string{"sub/a.txt": "x"})
+
+	dest, err := ing.Store.MkdirAll(ctx, "/inbox")
+	require.NoError(t, err)
+	_, _, err = ing.Store.Trash(ctx, dest.ID, store.UnconditionalRev)
+	require.NoError(t, err)
+	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
+	require.NoError(t, err)
+	var rep Report
+	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, sourceSelection{}, nil))
+	assert.NotEmpty(t, rep.Failed)
+	assert.Zero(t, rep.Added)
+	_, err = ing.Store.NodeByPath(ctx, "/inbox")
+	assert.ErrorIs(t, err, store.ErrNotFound, "trashed destination must stay trashed")
+}
+
 func TestPreflightInventoriesWithoutMutatingVault(t *testing.T) {
 	ing := newTestIngester(t)
 	src := writeTree(t, map[string]string{

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -716,7 +716,7 @@ func TestPreflightAndImportShareGlobSelection(t *testing.T) {
 
 func TestPreflightIncludeDoesNotHideLaterErrors(t *testing.T) {
 	root := t.TempDir()
-	for i := 0; i < maxPreflightFindings+10; i++ {
+	for i := range maxPreflightFindings + 10 {
 		path := filepath.Join(root, fmt.Sprintf("skip-%03d.txt", i))
 		require.NoError(t, os.WriteFile(path, []byte("skip"), 0o600))
 	}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -636,6 +636,12 @@ func TestIncludeSkipsNonRegularEntries(t *testing.T) {
 	assert.Equal(t, 1, report.Added)
 	assert.Equal(t, 2, report.Excluded)
 	assert.Empty(t, report.Failed)
+
+	explicit, err := Preflight(ctx, []string{filepath.Join(src, "target.bin")}, Options{Include: []string{"*.txt"}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), explicit.Excluded)
+	require.Len(t, explicit.Findings, 1)
+	assert.Equal(t, "excluded", explicit.Findings[0].Kind)
 }
 
 func TestPreflightInventoriesWithoutMutatingVault(t *testing.T) {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -617,6 +618,27 @@ func TestAddTreeStaleDestinationDefaultSelectionDoesNotResurrect(t *testing.T) {
 	assert.Zero(t, rep.Added)
 	_, err = ing.Store.NodeByPath(ctx, "/inbox")
 	assert.ErrorIs(t, err, store.ErrNotFound, "trashed destination must stay trashed")
+}
+
+func TestEnsureSourceDirRejectsPathOutsideWalkRoot(t *testing.T) {
+	const childEnv = "DOCBANK_TEST_ENSURE_SOURCE_DIR_OUTSIDE_ROOT"
+	if os.Getenv(childEnv) == "1" {
+		ing := newTestIngester(t)
+		walkRoot := filepath.Join(t.TempDir(), "root")
+		dirPath := filepath.Join(filepath.Dir(walkRoot), "outside", "nested")
+		_, err := ing.ensureSourceDir(
+			t.Context(), map[string]int64{}, map[string]error{}, ing.Store.RootID(),
+			"source", walkRoot, dirPath,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside traversal root")
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestEnsureSourceDirRejectsPathOutsideWalkRoot$", "-test.count=1") //nolint:gosec // os.Args[0] is the trusted current test executable.
+	cmd.Env = append(os.Environ(), childEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
 }
 
 func TestIncludeSkipsNonRegularEntries(t *testing.T) {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -687,25 +687,44 @@ func TestAddPathsHonorsPreflightExclusions(t *testing.T) {
 func TestPreflightAndImportShareGlobSelection(t *testing.T) {
 	ing := newTestIngester(t)
 	src := writeTree(t, map[string]string{
-		"docs/keep.txt": "keep",
-		"docs/skip.txt": "skip",
-		"docs/skip.md":  "skip",
-		"root.txt":      "root",
+		"docs/keep.txt":  "keep",
+		"docs/skip.txt":  "skip",
+		"docs/skip.md":   "skip",
+		"empty/skip.bin": "skip",
+		"root.txt":       "root",
 	})
 	opts := Options{Include: []string{"docs/*.txt"}, Exclude: []string{"docs/skip.txt"}}
 
 	preflight, err := Preflight(t.Context(), []string{src}, opts)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), preflight.Files)
-	assert.Equal(t, int64(3), preflight.Excluded)
+	assert.Equal(t, int64(4), preflight.Excluded)
 
 	report, err := ing.AddPathsWithOptions(t.Context(), []string{src}, "/inbox", opts)
 	require.NoError(t, err)
 	assert.Equal(t, 1, report.Added)
-	assert.Equal(t, 3, report.Excluded)
+	assert.Equal(t, 4, report.Excluded)
 	assert.Empty(t, report.Failed)
 	_, err = ing.Store.NodeByPath(t.Context(), "/inbox/"+filepath.Base(src)+"/docs/keep.txt")
 	require.NoError(t, err)
+	_, err = ing.Store.NodeByPath(t.Context(), "/inbox/"+filepath.Base(src)+"/empty")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestPreflightIncludeDoesNotHideLaterErrors(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < maxPreflightFindings+10; i++ {
+		path := filepath.Join(root, fmt.Sprintf("skip-%03d.txt", i))
+		require.NoError(t, os.WriteFile(path, []byte("skip"), 0o600))
+	}
+	report, err := Preflight(t.Context(), []string{root, filepath.Join(root, "missing")}, Options{
+		Include: []string{"*.pdf"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(maxPreflightFindings+10), report.Excluded)
+	assert.Equal(t, int64(1), report.Errors)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, "error", report.Findings[0].Kind)
 }
 
 func TestPreflightRejectsUnsafeExclusionRules(t *testing.T) {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -590,7 +590,7 @@ func TestAddTreeStaleDestinationIsNotResurrected(t *testing.T) {
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
 	var rep Report
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, exclusions{}, nil))
+	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, sourceSelection{}, nil))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 
@@ -682,6 +682,30 @@ func TestAddPathsHonorsPreflightExclusions(t *testing.T) {
 	require.ErrorIs(t, err, store.ErrNotFound)
 	_, err = ing.Store.NodeByPath(t.Context(), top+"/project/cache")
 	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestPreflightAndImportShareGlobSelection(t *testing.T) {
+	ing := newTestIngester(t)
+	src := writeTree(t, map[string]string{
+		"docs/keep.txt": "keep",
+		"docs/skip.txt": "skip",
+		"docs/skip.md":  "skip",
+		"root.txt":      "root",
+	})
+	opts := Options{Include: []string{"docs/*.txt"}, Exclude: []string{"docs/skip.txt"}}
+
+	preflight, err := Preflight(t.Context(), []string{src}, opts)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), preflight.Files)
+	assert.Equal(t, int64(3), preflight.Excluded)
+
+	report, err := ing.AddPathsWithOptions(t.Context(), []string{src}, "/inbox", opts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Added)
+	assert.Equal(t, 3, report.Excluded)
+	assert.Empty(t, report.Failed)
+	_, err = ing.Store.NodeByPath(t.Context(), "/inbox/"+filepath.Base(src)+"/docs/keep.txt")
+	require.NoError(t, err)
 }
 
 func TestPreflightRejectsUnsafeExclusionRules(t *testing.T) {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -590,7 +590,9 @@ func TestAddTreeStaleDestinationIsNotResurrected(t *testing.T) {
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
 	var rep Report
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, sourceSelection{}, nil))
+	selection, err := compileSourceSelection(Options{Include: []string{"*.txt"}})
+	require.NoError(t, err)
+	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, selection, nil))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 
@@ -699,6 +701,7 @@ func TestPreflightAndImportShareGlobSelection(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), preflight.Files)
 	assert.Equal(t, int64(4), preflight.Excluded)
+	assert.Equal(t, int64(2), preflight.Directories)
 
 	report, err := ing.AddPathsWithOptions(t.Context(), []string{src}, "/inbox", opts)
 	require.NoError(t, err)

--- a/internal/ingest/ingest_unix_test.go
+++ b/internal/ingest/ingest_unix_test.go
@@ -131,6 +131,27 @@ func TestExcludedBrokenRootSymlinkDoesNotResolve(t *testing.T) {
 	assert.Empty(t, rep.Failed)
 }
 
+func TestIncludeSkipsExplicitNonRegularSource(t *testing.T) {
+	ing := newTestIngester(t)
+	root := t.TempDir()
+	file := filepath.Join(root, "real.txt")
+	link := filepath.Join(root, "skip.link")
+	require.NoError(t, os.WriteFile(file, []byte("content"), 0o600))
+	require.NoError(t, os.Symlink(file, link))
+	opts := Options{Include: []string{"*.pdf"}}
+
+	preflight, err := Preflight(t.Context(), []string{link}, opts)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), preflight.Excluded)
+	assert.Zero(t, preflight.Skipped)
+	assert.Empty(t, preflight.Errors)
+
+	rep, err := ing.AddPathsWithOptions(t.Context(), []string{link}, "/archive", opts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Excluded)
+	assert.Empty(t, rep.Failed)
+}
+
 func TestPreflightExplicitDirectorySymlinkUsesAliasAndSkipsNestedLinks(t *testing.T) {
 	target := writeTree(t, map[string]string{"nested/session.jsonl": "{\"ok\":true}\n"})
 	alias := filepath.Join(t.TempDir(), "Agent Sessions")

--- a/internal/ingest/ingest_unix_test.go
+++ b/internal/ingest/ingest_unix_test.go
@@ -131,6 +131,23 @@ func TestExcludedBrokenRootSymlinkDoesNotResolve(t *testing.T) {
 	assert.Empty(t, rep.Failed)
 }
 
+func TestIncludeSkipsBrokenRootSymlink(t *testing.T) {
+	ing := newTestIngester(t)
+	alias := filepath.Join(t.TempDir(), "skip.link")
+	require.NoError(t, os.Symlink(filepath.Join(t.TempDir(), "missing"), alias))
+	opts := Options{Include: []string{"*.pdf"}}
+
+	report, err := Preflight(t.Context(), []string{alias}, opts)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), report.Excluded)
+	assert.Zero(t, report.Errors)
+
+	rep, err := ing.AddPathsWithOptions(t.Context(), []string{alias}, "/archive", opts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Excluded)
+	assert.Empty(t, rep.Failed)
+}
+
 func TestIncludeSkipsExplicitNonRegularSource(t *testing.T) {
 	ing := newTestIngester(t)
 	root := t.TempDir()

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -294,11 +294,6 @@ func preflightTree(
 				report.Excluded++
 				return nil
 			}
-			info, err := entry.Info()
-			if err != nil {
-				report.addFinding(sourcePath, "error", err.Error())
-				return nil
-			}
 			if len(selection.include) > 0 {
 				for dir := filepath.Dir(path); ; dir = filepath.Dir(dir) {
 					if _, seen := materializedDirs[dir]; !seen {
@@ -313,6 +308,11 @@ func preflightTree(
 						break
 					}
 				}
+			}
+			info, err := entry.Info()
+			if err != nil {
+				report.addFinding(sourcePath, "error", err.Error())
+				return nil
 			}
 			report.addFile(sourcePath, info.Size(), isCloudPlaceholder(info), types)
 		default:

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -238,6 +238,7 @@ func preflightTree(
 	if filepath.Base(sourceRoot) == string(filepath.Separator) || filepath.Base(walkRoot) == string(filepath.Separator) {
 		return fmt.Errorf("cannot scan filesystem root %q", sourceRoot)
 	}
+	materializedDirs := make(map[string]struct{})
 	return filepath.WalkDir(walkRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -263,7 +264,9 @@ func preflightTree(
 		}
 		switch {
 		case entry.IsDir():
-			report.Directories++
+			if len(selection.include) == 0 {
+				report.Directories++
+			}
 		case entry.Type().IsRegular():
 			if !selection.included(sourceRoot, sourcePath) {
 				report.Excluded++
@@ -273,6 +276,21 @@ func preflightTree(
 			if err != nil {
 				report.addFinding(sourcePath, "error", err.Error())
 				return nil
+			}
+			if len(selection.include) > 0 {
+				for dir := filepath.Dir(path); ; dir = filepath.Dir(dir) {
+					if _, seen := materializedDirs[dir]; !seen {
+						materializedDirs[dir] = struct{}{}
+						report.Directories++
+					}
+					if dir == walkRoot {
+						break
+					}
+					parent := filepath.Dir(dir)
+					if parent == dir {
+						break
+					}
+				}
 			}
 			report.addFile(sourcePath, info.Size(), isCloudPlaceholder(info), types)
 		default:

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -159,11 +159,17 @@ func ValidateOptions(opts Options) error {
 // semantics as AddPathsWithOptions. It uses directory metadata only: cloud
 // placeholders are not opened or hydrated merely to estimate an import.
 func Preflight(ctx context.Context, sources []string, opts Options) (PreflightReport, error) {
-	var report PreflightReport
-	selection, err := compileSourceSelection(opts)
+	selection, err := CompileSelection(opts)
 	if err != nil {
-		return report, err
+		return PreflightReport{}, err
 	}
+	return PreflightWithSelection(ctx, sources, selection)
+}
+
+// PreflightWithSelection inventories sources using a previously compiled
+// request selection, so callers can share it with the real import.
+func PreflightWithSelection(ctx context.Context, sources []string, selection Selection) (PreflightReport, error) {
+	var report PreflightReport
 	types := make(map[string]FileType)
 	for _, rawSource := range sources {
 		if err := ctx.Err(); err != nil {
@@ -187,11 +193,19 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 		if info.Mode()&fs.ModeSymlink != 0 {
 			walkRoot, err = filepath.EvalSymlinks(source)
 			if err != nil {
+				if !selection.included(source, source) {
+					report.addFinding(source, "excluded", "did not match an include pattern")
+					continue
+				}
 				report.addFinding(source, "error", "resolving explicitly named directory symlink: "+err.Error())
 				continue
 			}
 			info, err = os.Stat(walkRoot)
 			if err != nil {
+				if !selection.included(source, source) {
+					report.addFinding(source, "excluded", "did not match an include pattern")
+					continue
+				}
 				report.addFinding(source, "error", "checking explicitly named directory symlink: "+err.Error())
 				continue
 			}

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -83,6 +83,8 @@ type PreflightReport struct {
 	FindingsTruncated  bool
 }
 
+// exclusionRule is retained for watched-inbox configuration, whose patterns
+// are literal by contract and must not use request-scoped glob selection.
 type exclusionRule struct {
 	name string
 	path string
@@ -200,7 +202,7 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 		}
 		if info.Mode().IsRegular() {
 			if !selection.included(source, source) {
-				report.addFinding(source, "excluded", "did not match an include rule")
+				report.Excluded++
 				continue
 			}
 			report.addFile(source, info.Size(), isCloudPlaceholder(info), types)
@@ -264,7 +266,7 @@ func preflightTree(
 			report.Directories++
 		case entry.Type().IsRegular():
 			if !selection.included(sourceRoot, sourcePath) {
-				report.addFinding(sourcePath, "excluded", "did not match an include rule")
+				report.Excluded++
 				return nil
 			}
 			info, err := entry.Info()

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -20,9 +20,10 @@ const (
 )
 
 // Options controls source selection for both preflight and the real import.
-// A rule without a slash matches that entry name anywhere. A relative path
-// rule matches that entry and its descendants within each supplied source.
+// Patterns use path.Match syntax over source-relative slash paths. A pattern
+// without a slash matches a basename anywhere; exclusions take precedence.
 type Options struct {
+	Include []string
 	Exclude []string
 	// Progress receives bounded updates while a real ingest reads and commits
 	// files. Preflight ignores it because it never opens file content.
@@ -148,7 +149,7 @@ func (e exclusions) matchNameAndRelative(name, rel string) bool {
 // ValidateOptions checks source-selection rules without touching the
 // filesystem. API handlers use it to return a validation error before work.
 func ValidateOptions(opts Options) error {
-	_, err := compileExclusions(opts.Exclude)
+	_, err := compileSourceSelection(opts)
 	return err
 }
 
@@ -157,7 +158,7 @@ func ValidateOptions(opts Options) error {
 // placeholders are not opened or hydrated merely to estimate an import.
 func Preflight(ctx context.Context, sources []string, opts Options) (PreflightReport, error) {
 	var report PreflightReport
-	excludes, err := compileExclusions(opts.Exclude)
+	selection, err := compileSourceSelection(opts)
 	if err != nil {
 		return report, err
 	}
@@ -176,7 +177,7 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 			report.addFinding(source, "error", err.Error())
 			continue
 		}
-		if excludes.match(source, source) {
+		if selection.excluded(source, source) {
 			report.addFinding(source, "excluded", "matched an exclusion rule")
 			continue
 		}
@@ -198,6 +199,10 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 			}
 		}
 		if info.Mode().IsRegular() {
+			if !selection.included(source, source) {
+				report.addFinding(source, "excluded", "did not match an include rule")
+				continue
+			}
 			report.addFile(source, info.Size(), isCloudPlaceholder(info), types)
 			continue
 		}
@@ -205,7 +210,7 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 			report.addFinding(source, "skipped", "not a regular file or directory")
 			continue
 		}
-		if err := preflightTree(ctx, &report, types, excludes, source, walkRoot); err != nil {
+		if err := preflightTree(ctx, &report, types, selection, source, walkRoot); err != nil {
 			return report, err
 		}
 	}
@@ -217,7 +222,7 @@ func preflightTree(
 	ctx context.Context,
 	report *PreflightReport,
 	types map[string]FileType,
-	excludes exclusions,
+	selection sourceSelection,
 	sourceRoot, walkRoot string,
 ) error {
 	sourceRoot, err := filepath.Abs(sourceRoot)
@@ -247,7 +252,7 @@ func preflightTree(
 			}
 			return nil
 		}
-		if excludes.match(sourceRoot, sourcePath) {
+		if selection.excluded(sourceRoot, sourcePath) {
 			report.addFinding(sourcePath, "excluded", "matched an exclusion rule")
 			if entry.IsDir() {
 				return fs.SkipDir
@@ -258,6 +263,10 @@ func preflightTree(
 		case entry.IsDir():
 			report.Directories++
 		case entry.Type().IsRegular():
+			if !selection.included(sourceRoot, sourcePath) {
+				report.addFinding(sourcePath, "excluded", "did not match an include rule")
+				return nil
+			}
 			info, err := entry.Info()
 			if err != nil {
 				report.addFinding(sourcePath, "error", err.Error())

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -196,6 +196,10 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 				continue
 			}
 			if !info.IsDir() {
+				if !selection.included(source, source) {
+					report.addFinding(source, "excluded", "did not match an include pattern")
+					continue
+				}
 				report.addFinding(source, "skipped", "explicit symlink source does not resolve to a directory")
 				continue
 			}
@@ -209,6 +213,10 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 			continue
 		}
 		if !info.IsDir() {
+			if !selection.included(source, source) {
+				report.addFinding(source, "excluded", "did not match an include pattern")
+				continue
+			}
 			report.addFinding(source, "skipped", "not a regular file or directory")
 			continue
 		}

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -202,7 +202,7 @@ func Preflight(ctx context.Context, sources []string, opts Options) (PreflightRe
 		}
 		if info.Mode().IsRegular() {
 			if !selection.included(source, source) {
-				report.Excluded++
+				report.addFinding(source, "excluded", "did not match an include pattern")
 				continue
 			}
 			report.addFile(source, info.Size(), isCloudPlaceholder(info), types)
@@ -294,6 +294,10 @@ func preflightTree(
 			}
 			report.addFile(sourcePath, info.Size(), isCloudPlaceholder(info), types)
 		default:
+			if !selection.included(sourceRoot, sourcePath) {
+				report.Excluded++
+				return nil
+			}
 			report.addFinding(sourcePath, "skipped", "not a regular file (symlinks are skipped)")
 		}
 		return nil

--- a/internal/ingest/selection.go
+++ b/internal/ingest/selection.go
@@ -1,0 +1,97 @@
+package ingest
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// sourceSelection is the request-scoped source matcher. Its patterns use
+// path.Match syntax and are evaluated against source-root-relative slash paths.
+type sourceSelection struct {
+	include []sourceRule
+	exclude []sourceRule
+}
+
+type sourceRule struct {
+	pattern  string
+	basename bool
+}
+
+func compileSourceSelection(opts Options) (sourceSelection, error) {
+	include, err := compileSourceRules("include", opts.Include)
+	if err != nil {
+		return sourceSelection{}, err
+	}
+	exclude, err := compileSourceRules("exclude", opts.Exclude)
+	if err != nil {
+		return sourceSelection{}, err
+	}
+	return sourceSelection{include: include, exclude: exclude}, nil
+}
+
+func compileSourceRules(kind string, values []string) ([]sourceRule, error) {
+	rules := make([]sourceRule, 0, len(values))
+	for _, raw := range values {
+		if raw == "" {
+			return nil, fmt.Errorf("%s rule must not be empty", kind)
+		}
+		if path.IsAbs(raw) || filepath.IsAbs(raw) || !filepath.IsLocal(filepath.FromSlash(raw)) {
+			return nil, fmt.Errorf("%s rule %q must be relative", kind, raw)
+		}
+		segments := strings.FieldsFunc(raw, func(r rune) bool {
+			return r == '/' || r == '\\'
+		})
+		if slices.Contains(segments, "..") {
+			return nil, fmt.Errorf("%s rule %q must not contain parent traversal", kind, raw)
+		}
+		pattern := path.Clean(raw)
+		if pattern == "." {
+			return nil, fmt.Errorf("%s rule %q must name an entry within each source", kind, raw)
+		}
+		if _, err := path.Match(pattern, ""); err != nil {
+			return nil, fmt.Errorf("%s rule %q is invalid: %w", kind, raw, err)
+		}
+		rules = append(rules, sourceRule{
+			pattern:  pattern,
+			basename: !strings.ContainsRune(raw, '/'),
+		})
+	}
+	return rules, nil
+}
+
+func (s sourceSelection) excluded(sourceRoot, sourcePath string) bool {
+	return s.matches(sourceRoot, sourcePath, s.exclude)
+}
+
+func (s sourceSelection) included(sourceRoot, sourcePath string) bool {
+	if len(s.include) == 0 {
+		return true
+	}
+	return s.matches(sourceRoot, sourcePath, s.include)
+}
+
+func (s sourceSelection) matches(sourceRoot, sourcePath string, rules []sourceRule) bool {
+	rel, err := filepath.Rel(sourceRoot, sourcePath)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		rel = ""
+	}
+	name := filepath.Base(sourcePath)
+	for _, rule := range rules {
+		subject := rel
+		if rule.basename {
+			subject = name
+		}
+		matched, err := path.Match(rule.pattern, subject)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ingest/selection.go
+++ b/internal/ingest/selection.go
@@ -39,8 +39,7 @@ func compileSourceRules(kind string, values []string) ([]sourceRule, error) {
 			return nil, fmt.Errorf("%s rule must not be empty", kind)
 		}
 		normalized := filepath.ToSlash(raw)
-		if path.IsAbs(normalized) || filepath.IsAbs(filepath.FromSlash(normalized)) ||
-			!filepath.IsLocal(filepath.FromSlash(normalized)) {
+		if !filepath.IsLocal(filepath.FromSlash(normalized)) {
 			return nil, fmt.Errorf("%s rule %q must be relative", kind, raw)
 		}
 		segments := strings.Split(normalized, "/")

--- a/internal/ingest/selection.go
+++ b/internal/ingest/selection.go
@@ -38,6 +38,9 @@ func compileSourceRules(kind string, values []string) ([]sourceRule, error) {
 		if raw == "" {
 			return nil, fmt.Errorf("%s rule must not be empty", kind)
 		}
+		if strings.ContainsRune(raw, '\\') {
+			return nil, fmt.Errorf("%s rule %q must use '/' separators", kind, raw)
+		}
 		normalized := filepath.ToSlash(raw)
 		if !filepath.IsLocal(filepath.FromSlash(normalized)) {
 			return nil, fmt.Errorf("%s rule %q must be relative", kind, raw)

--- a/internal/ingest/selection.go
+++ b/internal/ingest/selection.go
@@ -15,6 +15,14 @@ type sourceSelection struct {
 	exclude []sourceRule
 }
 
+// Selection is the request-scoped compiled include and exclude matcher.
+type Selection = sourceSelection
+
+// CompileSelection validates and compiles one request's selection rules.
+func CompileSelection(opts Options) (Selection, error) {
+	return compileSourceSelection(opts)
+}
+
 type sourceRule struct {
 	pattern  string
 	basename bool

--- a/internal/ingest/selection.go
+++ b/internal/ingest/selection.go
@@ -38,16 +38,16 @@ func compileSourceRules(kind string, values []string) ([]sourceRule, error) {
 		if raw == "" {
 			return nil, fmt.Errorf("%s rule must not be empty", kind)
 		}
-		if path.IsAbs(raw) || filepath.IsAbs(raw) || !filepath.IsLocal(filepath.FromSlash(raw)) {
+		normalized := filepath.ToSlash(raw)
+		if path.IsAbs(normalized) || filepath.IsAbs(filepath.FromSlash(normalized)) ||
+			!filepath.IsLocal(filepath.FromSlash(normalized)) {
 			return nil, fmt.Errorf("%s rule %q must be relative", kind, raw)
 		}
-		segments := strings.FieldsFunc(raw, func(r rune) bool {
-			return r == '/' || r == '\\'
-		})
+		segments := strings.Split(normalized, "/")
 		if slices.Contains(segments, "..") {
 			return nil, fmt.Errorf("%s rule %q must not contain parent traversal", kind, raw)
 		}
-		pattern := path.Clean(raw)
+		pattern := path.Clean(normalized)
 		if pattern == "." {
 			return nil, fmt.Errorf("%s rule %q must name an entry within each source", kind, raw)
 		}
@@ -56,7 +56,7 @@ func compileSourceRules(kind string, values []string) ([]sourceRule, error) {
 		}
 		rules = append(rules, sourceRule{
 			pattern:  pattern,
-			basename: !strings.ContainsRune(raw, '/'),
+			basename: !strings.ContainsRune(normalized, '/'),
 		})
 	}
 	return rules, nil

--- a/internal/ingest/selection_test.go
+++ b/internal/ingest/selection_test.go
@@ -35,15 +35,9 @@ func TestSourceSelectionUsesPathMatchEscapingAndLimits(t *testing.T) {
 		"path-form rules do not match an explicitly named file's empty relative path")
 }
 
-func TestSourceSelectionNormalizesWindowsSeparators(t *testing.T) {
-	if filepath.Separator != '\\' {
-		t.Skip("Windows path separator behavior")
-	}
-	slash, err := compileSourceSelection(Options{Include: []string{"project/cache"}})
-	require.NoError(t, err)
-	backslash, err := compileSourceSelection(Options{Include: []string{`project\cache`}})
-	require.NoError(t, err)
-	assert.Equal(t, slash, backslash)
+func TestSourceSelectionRequiresSlashSeparators(t *testing.T) {
+	_, err := compileSourceSelection(Options{Include: []string{`project\cache`}})
+	assert.Error(t, err)
 }
 
 func TestSourceSelectionRejectsUnsafeAndInvalidRules(t *testing.T) {

--- a/internal/ingest/selection_test.go
+++ b/internal/ingest/selection_test.go
@@ -20,7 +20,7 @@ func TestCompileSourceSelectionMatchesBasenamesAndRelativePaths(t *testing.T) {
 
 func TestSourceSelectionUsesPathMatchEscapingAndLimits(t *testing.T) {
 	root := filepath.FromSlash("/source")
-	escaped, err := compileSourceSelection(Options{Include: []string{`report\[1\].txt`}})
+	escaped, err := compileSourceSelection(Options{Include: []string{"report[[]1].txt"}})
 	require.NoError(t, err)
 	assert.True(t, escaped.included(root, filepath.Join(root, "report[1].txt")))
 	assert.False(t, escaped.included(root, filepath.Join(root, "report1.txt")))
@@ -29,6 +29,21 @@ func TestSourceSelectionUsesPathMatchEscapingAndLimits(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, doubleStar.included(root, filepath.Join(root, "file.txt")))
 	assert.True(t, doubleStar.included(root, filepath.Join(root, "nested", "file.txt")))
+	explicit, err := compileSourceSelection(Options{Include: []string{"docs/*.txt"}})
+	require.NoError(t, err)
+	assert.False(t, explicit.included(root, filepath.Join(root, "report.txt")),
+		"path-form rules do not match an explicitly named file's empty relative path")
+}
+
+func TestSourceSelectionNormalizesWindowsSeparators(t *testing.T) {
+	if filepath.Separator != '\\' {
+		t.Skip("Windows path separator behavior")
+	}
+	slash, err := compileSourceSelection(Options{Include: []string{"project/cache"}})
+	require.NoError(t, err)
+	backslash, err := compileSourceSelection(Options{Include: []string{`project\cache`}})
+	require.NoError(t, err)
+	assert.Equal(t, slash, backslash)
 }
 
 func TestSourceSelectionRejectsUnsafeAndInvalidRules(t *testing.T) {

--- a/internal/ingest/selection_test.go
+++ b/internal/ingest/selection_test.go
@@ -1,0 +1,68 @@
+package ingest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileSourceSelectionMatchesBasenamesAndRelativePaths(t *testing.T) {
+	selection, err := compileSourceSelection(Options{Include: []string{"*.txt", "docs/*.md"}})
+	require.NoError(t, err)
+	root := filepath.FromSlash("/source")
+	assert.True(t, selection.included(root, filepath.Join(root, "nested", "note.txt")))
+	assert.True(t, selection.included(root, filepath.Join(root, "docs", "guide.md")))
+	assert.False(t, selection.included(root, filepath.Join(root, "docs", "nested", "guide.md")))
+	assert.False(t, selection.included(root, filepath.Join(root, "nested", "note.md")))
+}
+
+func TestSourceSelectionUsesPathMatchEscapingAndLimits(t *testing.T) {
+	root := filepath.FromSlash("/source")
+	escaped, err := compileSourceSelection(Options{Include: []string{`report\[1\].txt`}})
+	require.NoError(t, err)
+	assert.True(t, escaped.included(root, filepath.Join(root, "report[1].txt")))
+	assert.False(t, escaped.included(root, filepath.Join(root, "report1.txt")))
+
+	doubleStar, err := compileSourceSelection(Options{Include: []string{"**/*.txt"}})
+	require.NoError(t, err)
+	assert.False(t, doubleStar.included(root, filepath.Join(root, "file.txt")))
+	assert.True(t, doubleStar.included(root, filepath.Join(root, "nested", "file.txt")))
+}
+
+func TestSourceSelectionRejectsUnsafeAndInvalidRules(t *testing.T) {
+	for _, opts := range []Options{
+		{Include: []string{""}},
+		{Include: []string{"../outside"}},
+		{Include: []string{"["}},
+		{Exclude: []string{""}},
+		{Exclude: []string{"inside/../outside"}},
+		{Exclude: []string{"["}},
+	} {
+		assert.Error(t, ValidateOptions(opts))
+	}
+}
+
+func TestSourceSelectionEmptyRulesPreserveDefaultBehavior(t *testing.T) {
+	selection, err := compileSourceSelection(Options{Include: []string{}, Exclude: []string{}})
+	require.NoError(t, err)
+	root := filepath.FromSlash("/source")
+	assert.True(t, selection.included(root, filepath.Join(root, "nested", "file.bin")))
+	assert.False(t, selection.excluded(root, filepath.Join(root, "nested", "file.bin")))
+}
+
+func TestSourceSelectionExclusionWinsAndDoesNotPruneDirectoriesByInclude(t *testing.T) {
+	selection, err := compileSourceSelection(Options{
+		Include: []string{"*.txt"}, Exclude: []string{"secret.txt"},
+	})
+	require.NoError(t, err)
+	root := filepath.FromSlash("/source")
+	secret := filepath.Join(root, "nested", "secret.txt")
+	keep := filepath.Join(root, "nested", "keep.txt")
+	assert.True(t, selection.excluded(root, secret))
+	assert.True(t, selection.included(root, secret))
+	assert.False(t, selection.excluded(root, keep))
+	assert.True(t, selection.included(root, keep))
+	assert.False(t, selection.excluded(root, filepath.Join(root, "nested")))
+}

--- a/internal/ingest/watcher_test.go
+++ b/internal/ingest/watcher_test.go
@@ -132,6 +132,23 @@ func TestWatcherWaitsForStabilityAndUpdatesTheSameMovedNode(t *testing.T) {
 	assert.Equal(t, expectedUpdatedContent, sourceBytes)
 }
 
+func TestWatcherWildcardExclusionRemainsLiteral(t *testing.T) {
+	ing := newTestIngester(t)
+	source := writeTree(t, map[string]string{"keep.tmp": "watch me"})
+	watcher, err := NewWatcher(ing, t.TempDir(), config.WatchConfig{
+		Name: "literal", Source: source, Destination: "/archive",
+		SettleTime: config.Duration(time.Second), ScanInterval: config.Duration(time.Second),
+		Exclude: []string{"*.tmp"},
+	}, runTestMutation, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	root := openWatcherRoot(t, watcher)
+	at := time.Unix(1_700_000_000, 0)
+	require.NoError(t, scanWatcherAt(t.Context(), watcher, root, at))
+	require.NoError(t, scanWatcherAt(t.Context(), watcher, root, at.Add(time.Second)))
+	_, err = ing.Store.NodeByPath(t.Context(), "/archive/keep.tmp")
+	require.NoError(t, err)
+}
+
 func TestWatcherDoesNotCountTraversalTimeTowardSettle(t *testing.T) {
 	ing := newTestIngester(t)
 	source := writeTree(t, map[string]string{


### PR DESCRIPTION
Ingest can now select files from a mixed source tree with include and exclude patterns. Preflight, ordinary ingest, streamed ingest, and the command-line report use the same selection rules, so a matching file is counted and imported consistently.

Exclusions take precedence, directories remain traversable when only a descendant can match, and empty include rules preserve the current behavior. Patterns use the standard path-matching grammar and stay scoped to the requested source tree; watched-inbox exclusions remain literal. Existing `--exclude` values now use glob matching; use bracket expressions such as `report[[]1].txt` for literal metacharacters.

The issue report came from a workflow that had to enumerate exclusions in a mixed tree to keep one import report and provenance record. This change covers glob source selection only; the separate per-file size budget and add replacement behavior remain outside the scope.

Refs #197.
