### PR TITLE
feat(store): append provenance after ingest

### DIFF
--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -539,6 +539,22 @@ Provenance is evidence, not ownership of the external source. Reading it does
 not open or modify that source, and it does not make a content version a
 retention root.
 
+To record an origin learned after ingest, send the node revision returned by a
+prior read:
+
+```bash
+curl --fail-with-body -X POST \
+  -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'If-Match: "7"' \
+  -H 'Content-Type: application/json' \
+  --data '{"source_kind":"agent","source_description":"triage","original_path":"opaque://laptop/report.txt"}' \
+  "$DOCBANK_URL/api/v1/nodes/42/provenance"
+```
+
+The response is `201` with the appended fact, resulting node revision, path,
+and ETag. `original_path` remains opaque evidence. To correct an active fact,
+include its `identity` as `supersedes`; the earlier fact remains in history.
+
 ## Create and ingest safely
 
 For a one-shot instruction tied to an exact virtual coordinate, create the

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -552,8 +552,13 @@ curl --fail-with-body -X POST \
 ```
 
 The response is `201` with the appended fact, resulting node revision, path,
-and ETag. `original_path` remains opaque evidence. To correct an active fact,
-include its `identity` as `supersedes`; the earlier fact remains in history.
+and ETag. `original_path` remains opaque evidence. To correct an active
+caller-supplied fact on the same node, include its `identity` as `supersedes`;
+the earlier fact remains in history. Operational facts recorded by CLI or
+watched-folder ingest cannot be superseded, because they keep re-ingest
+idempotent. Add the newly learned origin alongside them instead.
+If supplied, `original_mtime` must use canonical UTC RFC3339Nano, for example
+`2026-08-26T12:00:00Z`; timestamps with a numeric offset are rejected.
 
 ## Create and ingest safely
 

--- a/docs/architecture/audited-history.md
+++ b/docs/architecture/audited-history.md
@@ -632,10 +632,11 @@ required field are rejected transactionally.
 
 Each provenance fact has a stable identity derived from its canonical immutable
 fields, including that ingest UUID, and may carry an immutable `supersedes`
-identity. A correction appends a new fact that supersedes the currently active
-fact for the same node,
-backed by a new ingest record when its source description changes; it never
-updates or erases the old row. The superseded fact remains visible in history,
+identity. A correction appends a new fact that supersedes an active
+caller-supplied fact for the same node, backed by a new ingest record; it never
+updates or erases the old row. Operational CLI and watched-folder ingest facts
+cannot be superseded, because they keep re-ingest idempotent. Store writes and
+replay enforce this restriction. The superseded fact remains visible in history,
 while the current provenance projection selects the unsuperseded leaves.
 Constraints require the target to exist on the same node, permit at most one
 direct successor, and reject cycles. Replay applies the supersession edge, and

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -34,6 +34,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /nodes/{id}/revert` | create a new head from a prior version of the same file | Implemented |
 | `GET /nodes/{id}/versions` | list immutable content versions newest-first, paginated (`limit`/`offset`) | Implemented |
 | `GET /nodes/{id}/provenance` | inspect immutable ingest-origin facts newest-first, paginated (`limit`/`offset`) | Implemented |
+| `POST /nodes/{id}/provenance` | append an immutable origin fact under the node revision | Implemented |
 | `GET /versions/{version_id}` · `GET /versions/{version_id}/content` | inspect or stream one immutable version by stable UUID | Implemented |
 | `GET /content-references?sha256=&limit=&offset=` | find every stable node/version pair retaining a content hash | Implemented |
 | `GET\|POST /tags` · `GET /tags/by-name` · `GET\|PATCH\|DELETE /tags/{tag_id}` | list, resolve, create, rename, or delete stable tag definitions | Implemented |
@@ -271,6 +272,15 @@ optional superseded-fact identity. A trashed node remains inspectable by ID but
 has no live `path`. The route is observation only: it neither accesses the
 source nor changes retention authority.
 
+`POST /nodes/{id}/provenance` accepts `source_kind`, `source_description`,
+`original_path`, an optional RFC3339Nano `original_mtime`, and an optional
+`supersedes` identity. The caller supplies the node's current revision in
+`If-Match`; a successful response is `201`, advances that node revision once,
+returns the appended fact and its ETag, and records a generic ingest alongside
+the fact. `original_path` is opaque evidence and is never opened. A
+supersession must point to an active fact on the same node, while the old fact
+stays visible and immutable.
+
 `GET /content-references` is the inverse identity lookup. It accepts one
 canonical lowercase SHA-256 and returns only logical `content_versions`
 references backed by blob-catalog authority; it never infers a match from a
@@ -493,10 +503,12 @@ transaction. This is stronger than a separate path lookup followed by the
 ID-addressed endpoint: moving an ancestor changes a descendant's path without
 changing that descendant's revision.
 
-Ingest provenance is currently filesystem-shaped: each import records the
-source's original path and mtime in the store's `provenance` table. The path is
-a record, never node identity. Non-file origin fields and lookup by content
-hash are not part of the current API.
+Ingest provenance is filesystem-shaped: each import records the source's
+original path and mtime in the store's `provenance` table. Authenticated clients
+can also append a post-ingest fact with a source kind, description, opaque
+original path, optional mtime, and optional supersession, fenced by the node's
+`If-Match` revision. The append records evidence and never opens the supplied
+path or looks up a node by content hash.
 
 ## Maintenance gate
 
@@ -569,6 +581,8 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `invalid_audit_cursor` | 422 | the history cursor is malformed or belongs to another stable node or scope |
 | `invalid_batch_move` | 422 | a batch has no moves, too many moves, ambiguous selectors, or an invalid final-state plan |
 | `stale_revision` | 412 | `store.ErrStaleRevision` — `If-Match` didn't match the current revision |
+| `provenance_mismatch` | 409 | the requested predecessor is missing, belongs to another node, or is already superseded |
+| `invalid_provenance_time` | 422 | optional `original_mtime` parses as RFC3339 but is not canonical UTC RFC3339Nano (a value that is not a date-time at all fails schema validation as `validation` instead) |
 | `not_dir` / `not_file` / `invalid_name` / `invalid_tag` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrInvalidTag` / `ErrNotTrashed` / `ErrIsRoot` |
 | `validation` | 400, 415, or 422 | malformed request (bad `If-Match`, paths, media type, multipart envelope, or generated validation) |
 | `precondition_required` | 428 | required `If-Match` header missing |

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -281,6 +281,8 @@ the fact. `original_path` is opaque evidence and is never opened. A
 supersession must point to an active fact on the same node, while the old fact
 stays visible and immutable.
 
+The encoded request body must be smaller than 1 MiB (1,048,576 bytes). A body at or above that limit receives `413` before the append runs.
+
 `GET /content-references` is the inverse identity lookup. It accepts one
 canonical lowercase SHA-256 and returns only logical `content_versions`
 references backed by blob-catalog authority; it never infers a match from a

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -273,13 +273,16 @@ has no live `path`. The route is observation only: it neither accesses the
 source nor changes retention authority.
 
 `POST /nodes/{id}/provenance` accepts `source_kind`, `source_description`,
-`original_path`, an optional RFC3339Nano `original_mtime`, and an optional
+`original_path`, an optional canonical UTC RFC3339Nano `original_mtime` (for
+example, `2026-08-26T12:00:00Z`), and an optional
 `supersedes` identity. The caller supplies the node's current revision in
 `If-Match`; a successful response is `201`, advances that node revision once,
 returns the appended fact and its ETag, and records a generic ingest alongside
 the fact. `original_path` is opaque evidence and is never opened. A
-supersession must point to an active fact on the same node, while the old fact
-stays visible and immutable.
+supersession must point to an active caller-supplied fact on the same node,
+while the old fact stays visible and immutable. Operational CLI and
+watched-folder ingest facts cannot be superseded: they keep re-ingest
+idempotent. Record a newly learned origin as an additional fact instead.
 
 The encoded request body must be smaller than 1 MiB (1,048,576 bytes). A body at or above that limit receives `413` before the append runs.
 
@@ -583,7 +586,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `invalid_audit_cursor` | 422 | the history cursor is malformed or belongs to another stable node or scope |
 | `invalid_batch_move` | 422 | a batch has no moves, too many moves, ambiguous selectors, or an invalid final-state plan |
 | `stale_revision` | 412 | `store.ErrStaleRevision` — `If-Match` didn't match the current revision |
-| `provenance_mismatch` | 409 | the requested predecessor is missing, belongs to another node, or is already superseded |
+| `provenance_mismatch` | 409 | the requested predecessor is missing, belongs to another node, is already superseded, or is an operational ingest fact |
 | `invalid_provenance_time` | 422 | optional `original_mtime` parses as RFC3339 but is not canonical UTC RFC3339Nano (a value that is not a date-time at all fails schema validation as `validation` instead) |
 | `not_dir` / `not_file` / `invalid_name` / `invalid_tag` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrInvalidTag` / `ErrNotTrashed` / `ErrIsRoot` |
 | `validation` | 400, 415, or 422 | malformed request (bad `If-Match`, paths, media type, multipart envelope, or generated validation) |

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -61,6 +61,25 @@ func StoreSession(ctx context.Context, root string, sessionID string, jsonl []by
 }
 ```
 
+An embedded application can append an origin learned after ingestion with the
+same immutable fact model:
+
+```go
+appended, err := vault.AppendProvenance(ctx, receipt.Node.ID,
+    docbank.ProvenanceAppendOptions{
+        IfRevision: receipt.Node.Revision,
+        Source: docbank.ProvenanceSource{
+            Kind: "agent", Description: "triage", Reference: "opaque://laptop/report.txt",
+        },
+    })
+```
+
+The append returns the resulting node, live path, fact, and revision-bound
+receipt. A zero `IfRevision` is an unconditional embedded operation; a
+positive value fences a caller's earlier read. Set `Supersedes` to an active
+same-node fact identity to add a correction. The source reference is opaque
+evidence and is never opened by Docbank.
+
 `Put` creates missing virtual directories. Repeating the same bytes and media
 type converges on the current version; changed bytes append an immutable content
 version while preserving the node ID. Supply `PutOptions.Expected` when the

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -77,7 +77,7 @@ appended, err := vault.AppendProvenance(ctx, receipt.Node.ID,
 The append returns the resulting node, live path, fact, and revision-bound
 receipt. A zero `IfRevision` is an unconditional embedded operation; a
 positive value fences a caller's earlier read. Set `Supersedes` to an active
-same-node fact identity to add a correction. The source reference is opaque
+caller-supplied fact identity on the same node to add a correction. The source reference is opaque
 evidence and is never opened by Docbank.
 
 `Put` creates missing virtual directories. Repeating the same bytes and media
@@ -119,8 +119,16 @@ For a newly created document, the node, first content version, ingest record,
 and provenance fact commit as one metadata transaction. If any part fails,
 none gains authority. An exact `Create` retry succeeds only when its active
 provenance also matches, so a caller cannot accidentally claim source evidence
-that was never recorded. Use `Provenance` to inspect the bounded newest-first
-history:
+that was never recorded. Superseding that matching fact makes the original
+request return `ErrContentConflict` unless another active fact still matches.
+A request matching the corrected provenance remains idempotent when the
+content and media type are unchanged.
+
+`AppendProvenance` may supersede active caller-supplied facts on the same node,
+including facts supplied through `CreateOptions.Provenance`. Operational CLI
+and watched-folder ingest facts cannot be superseded, because they keep
+re-ingest idempotent; append newly learned origins alongside them instead.
+Use `Provenance` to inspect the bounded newest-first history:
 
 ```go
 page, err := vault.Provenance(ctx, receipt.Node.ID, docbank.ProvenanceOptions{

--- a/docs/internal/daemon-api-design.md
+++ b/docs/internal/daemon-api-design.md
@@ -73,6 +73,13 @@ Do not add a path mutation that resolves through a separate preflight query.
 Use an ID plus revision for read-modify-write or add a transactional store
 operation for one-shot path intent.
 
+`POST /api/v1/nodes/{id}/provenance` is an ID-addressed metadata mutation. It
+requires the node revision in `If-Match`, runs on the fast HTTP mutation side of
+the operation gate, and appends an immutable fact plus a generic ingest in one
+store transaction. `original_path` is opaque evidence, so the daemon never
+opens it or treats it as retained content. An optional `supersedes` value must
+identify an active fact on the same node; the earlier fact remains immutable.
+
 File-node wire representations expose the catalog's lowercase SHA-256
 `blob_hash`; stable node identity and immutable content identity are separate
 on purpose. A content response sends that expected identity before the body

--- a/docs/internal/daemon-api-design.md
+++ b/docs/internal/daemon-api-design.md
@@ -78,7 +78,10 @@ requires the node revision in `If-Match`, runs on the fast HTTP mutation side of
 the operation gate, and appends an immutable fact plus a generic ingest in one
 store transaction. `original_path` is opaque evidence, so the daemon never
 opens it or treats it as retained content. An optional `supersedes` value must
-identify an active fact on the same node; the earlier fact remains immutable.
+identify an active caller-supplied fact on the same node; the earlier fact
+remains immutable. Operational ingest facts cannot be superseded because
+re-ingest uses them for idempotency. Store writes and audit replay enforce
+the same restriction.
 
 File-node wire representations expose the catalog's lowercase SHA-256
 `blob_hash`; stable node identity and immutable content identity are separate

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -423,8 +423,10 @@ only relational constraints; append-only semantics, canonical mutation
 construction, chain advancement, and independent replay remain backend-neutral
 Go logic. Implemented guarded transitions cover content replacement and revert,
 inherited node creation, move, trash, restore, creation of an unassigned tag,
-and assignment or removal of an existing tag. Physical pack maintenance and
-read-only backup/export remain available.
+assignment or removal of an existing tag, and post-ingest provenance append.
+Each append records its generic ingest and immutable provenance attachment in
+one transaction. Physical pack maintenance and read-only backup/export remain
+available.
 
 !!! info "Planned — audited mutations"
     Public audit enablement, the remaining guarded mutation classes,

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -65,6 +65,8 @@ var storeErrCodes = []struct {
 	{store.ErrExists, http.StatusConflict, "exists"},
 	{store.ErrCycle, http.StatusConflict, "cycle"},
 	{store.ErrStaleRevision, http.StatusPreconditionFailed, "stale_revision"},
+	{store.ErrProvenanceMismatch, http.StatusConflict, "provenance_mismatch"},
+	{store.ErrInvalidProvenanceTime, http.StatusUnprocessableEntity, "invalid_provenance_time"},
 	{store.ErrNotDir, http.StatusUnprocessableEntity, "not_dir"},
 	{store.ErrNotFile, http.StatusUnprocessableEntity, "not_file"},
 	{store.ErrInvalidName, http.StatusUnprocessableEntity, "invalid_name"},

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -23,7 +23,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 		"assignTagPath", "unassignTagPath",
 		"previewAuditEnrollment", "enableAudit", "auditStatus", "auditNodeHistory", "verifyAudit",
 		"search", "createNode", "moveNode", "movePath", "trashNode", "trashPath", "restoreNode",
-		"storageStatus", "storagePack", "storageRepack", "ingest", "uploadFile", "listTrash", "emptyTrash", "gc", "verify",
+		"storageStatus", "storagePack", "storageRepack", "ingest", "uploadFile", "listTrash", "emptyTrash", "gc", "verify", "appendNodeProvenance",
 		"initBackupRepository", "createBackupSnapshot", "listBackupSnapshots", "listJobs"} {
 		assert.Contains(t, doc, op, "operation missing from OpenAPI doc")
 	}
@@ -126,6 +126,7 @@ func TestOpenAPIDeclaresMutationPreconditions(t *testing.T) {
 		doc.Paths["/api/v1/nodes/{id}/verify"].Post,
 		doc.Paths["/api/v1/nodes/{id}/revert"].Post,
 		doc.Paths["/api/v1/nodes/{id}/versions/prune"].Post,
+		doc.Paths["/api/v1/nodes/{id}/provenance"].Post,
 		doc.Paths["/api/v1/nodes/{id}/tags/{tag_id}"].Put,
 		doc.Paths["/api/v1/nodes/{id}/tags/{tag_id}"].Delete,
 		doc.Paths["/api/v1/tags/{tag_id}"].Patch,
@@ -141,4 +142,15 @@ func TestOpenAPIDeclaresMutationPreconditions(t *testing.T) {
 	create := doc.Paths["/api/v1/tags"].Post
 	require.NotNil(t, create)
 	assert.NotNil(t, create.Responses["201"])
+}
+
+func TestOpenAPIProvenanceMTimeUsesDateTimeFormat(t *testing.T) {
+	doc := api.NewOfflineServer().API().OpenAPI()
+	for _, name := range []string{"ProvenanceAppendRequest", "ProvenanceFact"} {
+		schema := doc.Components.Schemas.Map()[name]
+		require.NotNil(t, schema)
+		mtime := schema.Properties["original_mtime"]
+		require.NotNil(t, mtime)
+		assert.Equal(t, "date-time", mtime.Format)
+	}
 }

--- a/internal/api/routes_provenance.go
+++ b/internal/api/routes_provenance.go
@@ -2,14 +2,22 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/docbank/internal/store"
 )
 
 type provenancePageOutput struct{ Body ProvenancePage }
+type provenanceAppendOutput struct {
+	ETag string `header:"ETag"`
+	Body ProvenanceAppendReceipt
+}
 
-func registerProvenanceRoutes(api huma.API, d Deps) {
+func registerProvenanceRoutes(api huma.API, d Deps, g *gate) {
 	huma.Register(api, huma.Operation{
 		OperationID: "listNodeProvenance", Method: http.MethodGet,
 		Path:    "/api/v1/nodes/{id}/provenance",
@@ -34,5 +42,39 @@ func registerProvenanceRoutes(api huma.API, d Deps) {
 			out.Body.Items = append(out.Body.Items, fromStoreProvenanceFact(fact))
 		}
 		return out, nil
+	})
+	huma.Register(api, huma.Operation{
+		OperationID: "appendNodeProvenance", Method: http.MethodPost,
+		Path:    "/api/v1/nodes/{id}/provenance",
+		Summary: "Append an immutable origin fact to a file node",
+		Description: "Adds post-ingest provenance under the node's If-Match revision. " +
+			"The original path remains opaque evidence and is never opened by the daemon.",
+		DefaultStatus: http.StatusCreated,
+	}, func(ctx context.Context, in *struct {
+		ID      int64  `path:"id" minimum:"1"`
+		IfMatch string `header:"If-Match"`
+		Body    ProvenanceAppendRequest
+	}) (*provenanceAppendOutput, error) {
+		revision, err := parseIfMatch(in.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+		var result *provenanceAppendOutput
+		err = g.mutate(func() error {
+			appended, appendErr := d.Store.AppendNodeProvenance(ctx, store.ProvenanceAppendInput{
+				NodeID: in.ID, IfRevision: revision, SourceKind: in.Body.SourceKind,
+				SourceDescription: in.Body.SourceDescription, OriginalPath: in.Body.OriginalPath,
+				OriginalMTime: in.Body.OriginalMTime, Supersedes: in.Body.Supersedes,
+			})
+			if appendErr != nil {
+				return FromStoreError(appendErr)
+			}
+			result = &provenanceAppendOutput{
+				ETag: fmt.Sprintf("%q", strconv.FormatInt(appended.Node.Revision, 10)),
+				Body: fromStoreProvenanceAppend(appended),
+			}
+			return nil
+		})
+		return result, err
 	})
 }

--- a/internal/api/routes_provenance.go
+++ b/internal/api/routes_provenance.go
@@ -50,6 +50,7 @@ func registerProvenanceRoutes(api huma.API, d Deps, g *gate) {
 		Description: "Adds post-ingest provenance under the node's If-Match revision. " +
 			"The original path remains opaque evidence and is never opened by the daemon.",
 		DefaultStatus: http.StatusCreated,
+		MaxBodyBytes:  1 << 20,
 	}, func(ctx context.Context, in *struct {
 		ID      int64  `path:"id" minimum:"1"`
 		IfMatch string `header:"If-Match"`

--- a/internal/api/routes_provenance_test.go
+++ b/internal/api/routes_provenance_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,4 +61,131 @@ func TestNodeProvenanceEndpointMapsInvalidTargets(t *testing.T) {
 
 	_, err := s.NodeProvenance(t.Context(), s.RootID(), 10, 0)
 	require.ErrorIs(t, err, store.ErrNotFile)
+}
+
+func TestAppendNodeProvenanceEndpointFencesAndReturnsReceipt(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	node := createFileWithContent(t, ts, s, "/report.txt", "report")
+	request := api.ProvenanceAppendRequest{
+		SourceKind: "agent", SourceDescription: "triage", OriginalPath: "opaque://laptop/report",
+	}
+	resp, body := do(t, ts, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID),
+		map[string]string{"If-Match": `"1"`}, request)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	assert.Equal(t, `"2"`, resp.Header.Get("ETag"))
+	var receipt api.ProvenanceAppendReceipt
+	require.NoError(t, json.Unmarshal([]byte(body), &receipt))
+	assert.Equal(t, node.ID, receipt.Node.ID)
+	assert.Equal(t, int64(2), receipt.Node.Revision)
+	assert.Equal(t, "/report.txt", receipt.Path)
+	assert.Equal(t, request.SourceKind, receipt.Fact.SourceKind)
+	assert.Equal(t, request.OriginalPath, receipt.Fact.OriginalPath)
+
+	resp, body = do(t, ts, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID), nil, request)
+	assert.Equal(t, http.StatusPreconditionRequired, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"precondition_required"`)
+	resp, body = do(t, ts, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID),
+		map[string]string{"If-Match": `"1"`}, request)
+	assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"stale_revision"`)
+}
+
+func TestAppendNodeProvenanceEndpointMapsProvenanceMismatch(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	node := createFileWithContent(t, ts, s, "/report.txt", "report")
+	missing := strings.Repeat("ef", 32)
+	request := api.ProvenanceAppendRequest{
+		SourceKind: "agent", SourceDescription: "triage",
+		OriginalPath: "opaque://laptop/report", Supersedes: &missing,
+	}
+	resp, body := do(t, ts, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID),
+		map[string]string{"If-Match": `"1"`}, request)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"provenance_mismatch"`)
+}
+
+func TestAppendNodeProvenanceEndpointRejectsInvalidOriginalMTime(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	node := createFileWithContent(t, ts, s, "/report.txt", "report")
+	for _, test := range []struct {
+		value, code string
+	}{
+		{value: "not-a-time", code: "validation"},
+		{value: "2026-08-26T14:00:00+02:00", code: "invalid_provenance_time"},
+	} {
+		request := api.ProvenanceAppendRequest{
+			SourceKind: "agent", SourceDescription: "triage", OriginalPath: "opaque://report",
+			OriginalMTime: &test.value,
+		}
+		resp, body := do(t, ts, http.MethodPost,
+			fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID),
+			map[string]string{"If-Match": `"1"`}, request)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+		assert.Contains(t, body, fmt.Sprintf(`"code":"%s"`, test.code))
+	}
+	current, err := s.NodeByID(t.Context(), node.ID)
+	require.NoError(t, err)
+	assert.Equal(t, node.Revision, current.Revision)
+}
+
+func TestAppendNodeProvenanceEndpointRejectsMaintenanceAndBrowserSessions(t *testing.T) {
+	gate := api.NewOperationGate()
+	ts, s := newTestServer(t, func(d *api.Deps) { d.Gate = gate })
+	node := createFileWithContent(t, ts, s, "/report.txt", "report")
+	request := api.ProvenanceAppendRequest{
+		SourceKind: "agent", SourceDescription: "triage", OriginalPath: "opaque://report",
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- gate.Maintain(func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+	resp, body := do(t, ts, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID),
+		map[string]string{"If-Match": `"1"`}, request)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"maintenance_busy"`)
+	close(release)
+	require.NoError(t, <-done)
+
+	webSession, webBody := do(t, ts, http.MethodPost, "/api/daemon/web-session", nil, nil)
+	require.Equal(t, http.StatusCreated, webSession.StatusCode, webBody)
+	var issued struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(webBody), &issued))
+	resp, body = do(t, ts, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID),
+		map[string]string{"X-Api-Key": "", api.WebSessionHeader: issued.Token}, request)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"web_session_read_only"`)
+}
+
+func TestAppendNodeProvenanceEndpointRejectsOversizedRequestBody(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	node := createFileWithContent(t, ts, s, "/report.txt", "report")
+	request := map[string]any{
+		"source_kind":        "agent",
+		"source_description": "triage",
+		"original_path":      "opaque://report",
+		"padding":            strings.Repeat("x", 2<<20),
+	}
+	resp, body := do(t, ts, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID),
+		map[string]string{"If-Match": `"1"`}, request)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode, body)
+	current, err := s.NodeByID(t.Context(), node.ID)
+	require.NoError(t, err)
+	assert.Equal(t, node.Revision, current.Revision)
 }

--- a/internal/api/routes_provenance_test.go
+++ b/internal/api/routes_provenance_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"encoding/json/v2"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -172,20 +173,33 @@ func TestAppendNodeProvenanceEndpointRejectsMaintenanceAndBrowserSessions(t *tes
 	assert.Contains(t, body, `"code":"web_session_read_only"`)
 }
 
-func TestAppendNodeProvenanceEndpointRejectsOversizedRequestBody(t *testing.T) {
-	ts, s := newTestServer(t, nil)
-	node := createFileWithContent(t, ts, s, "/report.txt", "report")
-	request := map[string]any{
-		"source_kind":        "agent",
-		"source_description": "triage",
-		"original_path":      "opaque://report",
-		"padding":            strings.Repeat("x", 2<<20),
+func TestAppendNodeProvenanceEndpointRequestBodyLimit(t *testing.T) {
+	for _, size := range []int{(1 << 20) - 1, 1 << 20, (1 << 20) + 1} {
+		t.Run(fmt.Sprintf("%d bytes", size), func(t *testing.T) {
+			ts, s := newTestServer(t, nil)
+			node := createFileWithContent(t, ts, s, "/report.txt", "report")
+			body := `{"source_kind":"agent","source_description":"triage","original_path":"opaque://report"}`
+			body += strings.Repeat(" ", size-len(body))
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+				fmt.Sprintf("%s/api/v1/nodes/%d/provenance", ts.URL, node.ID), strings.NewReader(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("If-Match", `"1"`)
+			resp, err := ts.Client().Do(req)
+			require.NoError(t, err)
+			responseBody, err := io.ReadAll(resp.Body)
+			require.NoError(t, resp.Body.Close())
+			require.NoError(t, err)
+			wantStatus := http.StatusRequestEntityTooLarge
+			wantRevision := node.Revision
+			if size < 1<<20 {
+				wantStatus = http.StatusCreated
+				wantRevision++
+			}
+			assert.Equal(t, wantStatus, resp.StatusCode, string(responseBody))
+			current, err := s.NodeByID(t.Context(), node.ID)
+			require.NoError(t, err)
+			assert.Equal(t, wantRevision, current.Revision)
+		})
 	}
-	resp, body := do(t, ts, http.MethodPost,
-		fmt.Sprintf("/api/v1/nodes/%d/provenance", node.ID),
-		map[string]string{"If-Match": `"1"`}, request)
-	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode, body)
-	current, err := s.NodeByID(t.Context(), node.ID)
-	require.NoError(t, err)
-	assert.Equal(t, node.Revision, current.Revision)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -138,7 +138,7 @@ func NewServer(d Deps) *Server {
 	registerContentWriteRoute(mux, humaAPI, d, g)
 	registerContentRevertRoute(humaAPI, d, g)
 	registerContentPruneRoute(humaAPI, d, g)
-	registerProvenanceRoutes(humaAPI, d)
+	registerProvenanceRoutes(humaAPI, d, g)
 	registerTagRoutes(humaAPI, d, g)
 	registerAuditRoutes(humaAPI, d, g, s.auditPreviews)
 	clearLongRunningBodyReadDeadlines(humaAPI)
@@ -197,6 +197,7 @@ func markRevisionPreconditionsRequired(api huma.API) {
 		{"/api/v1/nodes/{id}/verify", http.MethodPost},
 		{"/api/v1/nodes/{id}/revert", http.MethodPost},
 		{"/api/v1/nodes/{id}/versions/prune", http.MethodPost},
+		{"/api/v1/nodes/{id}/provenance", http.MethodPost},
 		{"/api/v1/nodes/{id}/tags/{tag_id}", http.MethodPut},
 		{"/api/v1/nodes/{id}/tags/{tag_id}", http.MethodDelete},
 		{"/api/v1/tags/{tag_id}", http.MethodPatch},

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -542,6 +542,28 @@ func TestWebSessionIsScopedRevocableAndDaemonLocal(t *testing.T) {
 		"browser sessions cannot upload through reconnectable HTTP")
 	require.NoError(t, resp.Body.Close())
 
+	provenanceRequest := api.ProvenanceAppendRequest{
+		SourceKind: "agent", SourceDescription: "triage", OriginalPath: "opaque://browser",
+	}
+	provenanceBody, err := json.Marshal(provenanceRequest)
+	require.NoError(t, err)
+	provenanceHTTP, err := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/provenance",
+		bytes.NewReader(provenanceBody),
+	)
+	require.NoError(t, err)
+	provenanceHTTP.Header["X-Api-Key"] = []string{""}
+	provenanceHTTP.Header.Set(api.WebSessionHeader, issued.Token)
+	provenanceHTTP.Header.Set("Content-Type", "application/json")
+	resp, err = ts.Client().Do(provenanceHTTP)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	provenanceResponseBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Contains(t, string(provenanceResponseBody), `"code":"web_session_read_only"`)
+
 	trashRequest, err := http.NewRequest(
 		http.MethodPost,
 		ts.URL+"/api/v1/nodes/"+strconv.FormatInt(document.ID, 10)+"/trash",

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -128,9 +128,26 @@ type ProvenanceFact struct {
 	SourceKind        string  `json:"source_kind" minLength:"1"`
 	SourceDescription string  `json:"source_description" minLength:"1"`
 	OriginalPath      string  `json:"original_path" minLength:"1"`
-	OriginalMTime     *string `json:"original_mtime,omitempty"`
+	OriginalMTime     *string `json:"original_mtime,omitempty" format:"date-time"`
 	Supersedes        *string `json:"supersedes,omitempty" pattern:"^[0-9a-f]{64}$"`
 	Active            bool    `json:"active"`
+}
+
+// ProvenanceAppendRequest is the wire form of one post-ingest origin fact.
+// OriginalPath is evidence only; the daemon never opens or resolves it.
+type ProvenanceAppendRequest struct {
+	SourceKind        string  `json:"source_kind" minLength:"1"`
+	SourceDescription string  `json:"source_description" minLength:"1"`
+	OriginalPath      string  `json:"original_path" minLength:"1"`
+	OriginalMTime     *string `json:"original_mtime,omitempty" format:"date-time"`
+	Supersedes        *string `json:"supersedes,omitempty" pattern:"^[0-9a-f]{64}$"`
+}
+
+// ProvenanceAppendReceipt binds the new immutable fact to the resulting node.
+type ProvenanceAppendReceipt struct {
+	Node Node           `json:"node"`
+	Path string         `json:"path,omitzero"`
+	Fact ProvenanceFact `json:"fact"`
 }
 
 // ProvenancePage binds a bounded origin history to one authoritative node
@@ -983,6 +1000,13 @@ func fromStoreProvenanceFact(fact store.ProvenanceFact) ProvenanceFact {
 		IngestStartedAt: fact.IngestStartedAt, SourceKind: fact.SourceKind,
 		SourceDescription: fact.SourceDescription, OriginalPath: fact.OriginalPath,
 		OriginalMTime: fact.OriginalMTime, Supersedes: fact.Supersedes, Active: fact.Active,
+	}
+}
+
+func fromStoreProvenanceAppend(result store.ProvenanceAppendResult) ProvenanceAppendReceipt {
+	return ProvenanceAppendReceipt{
+		Node: fromStoreNode(result.Node), Path: result.Path,
+		Fact: fromStoreProvenanceFact(result.Fact),
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -273,6 +273,8 @@ var codeToTypedErr = map[string]error{
 	"stale_revision":               store.ErrStaleRevision,
 	"not_dir":                      store.ErrNotDir,
 	"not_file":                     store.ErrNotFile,
+	"provenance_mismatch":          store.ErrProvenanceMismatch,
+	"invalid_provenance_time":      store.ErrInvalidProvenanceTime,
 	"invalid_name":                 store.ErrInvalidName,
 	"invalid_tag":                  store.ErrInvalidTag,
 	"invalid_batch_move":           store.ErrInvalidBatchMove,
@@ -479,6 +481,71 @@ func (c *Client) Provenance(
 		return api.ProvenancePage{}, err
 	}
 	return page, nil
+}
+
+// AppendProvenance appends one origin fact to a file node under the caller's
+// inspected node revision.
+func (c *Client) AppendProvenance(
+	ctx context.Context, nodeID, revision int64, request api.ProvenanceAppendRequest,
+) (api.ProvenanceAppendReceipt, error) {
+	var receipt api.ProvenanceAppendReceipt
+	if nodeID < 1 {
+		return receipt, errors.New("provenance node ID must be positive")
+	}
+	if revision < 1 {
+		return receipt, errors.New("provenance revision must be positive")
+	}
+	if request.SourceKind == "" || request.SourceDescription == "" || request.OriginalPath == "" {
+		return receipt, errors.New("provenance source kind, description, and path are required")
+	}
+	headers, err := c.doWithHeaders(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v1/nodes/%d/provenance", nodeID), ifMatch(revision), request, &receipt)
+	if err != nil {
+		return api.ProvenanceAppendReceipt{}, err
+	}
+	if err := validateProvenanceAppendReceipt(receipt, headers.Get("ETag"), nodeID, revision, request); err != nil {
+		return api.ProvenanceAppendReceipt{}, err
+	}
+	return receipt, nil
+}
+
+// validateProvenanceAppendReceipt checks that the receipt binds the node and
+// fact to the request and that the response ETag carries the advanced node
+// revision, mirroring validateVersionPruneBinding. The daemon owns the fact
+// identity; only structural binding is verified here.
+func validateProvenanceAppendReceipt(
+	receipt api.ProvenanceAppendReceipt, etag string, nodeID, revision int64,
+	request api.ProvenanceAppendRequest,
+) error {
+	if receipt.Node.ID != nodeID || receipt.Fact.NodeID != nodeID {
+		return errors.New("provenance receipt does not bind its node")
+	}
+	if receipt.Node.Revision != revision+1 {
+		return fmt.Errorf("provenance receipt node revision %d, expected %d",
+			receipt.Node.Revision, revision+1)
+	}
+	if etag != strconv.Quote(strconv.FormatInt(receipt.Node.Revision, 10)) {
+		return fmt.Errorf("provenance response ETag %q disagrees with node revision %d",
+			etag, receipt.Node.Revision)
+	}
+	if receipt.Fact.SourceKind != request.SourceKind ||
+		receipt.Fact.SourceDescription != request.SourceDescription ||
+		receipt.Fact.OriginalPath != request.OriginalPath ||
+		!equalOptionalString(receipt.Fact.OriginalMTime, request.OriginalMTime) ||
+		!equalOptionalString(receipt.Fact.Supersedes, request.Supersedes) {
+		return errors.New("provenance receipt fact does not bind its request")
+	}
+	if !receipt.Fact.Active {
+		return errors.New("provenance receipt fact is not active")
+	}
+	return nil
+}
+
+func equalOptionalString(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return a == nil || *a == *b
 }
 
 // Version returns immutable version metadata by stable ID.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -960,6 +960,122 @@ func TestContentReplacementRoundTrip(t *testing.T) {
 	assert.Equal(t, 2, versions.Total)
 }
 
+func TestProvenanceAppendRoundTrip(t *testing.T) {
+	c, s := newClient(t, serverKey)
+	content := []byte("provenance client")
+	hash := sha256.Sum256(content)
+	created, err := c.Upload(t.Context(), s.RootID(), "provenance.txt", "text/plain",
+		hex.EncodeToString(hash[:]), int64(len(content)), bytes.NewReader(content))
+	require.NoError(t, err)
+	request := api.ProvenanceAppendRequest{
+		SourceKind: "agent", SourceDescription: "triage", OriginalPath: "opaque://client/source",
+	}
+	receipt, err := c.AppendProvenance(t.Context(), created.Node.ID, created.Node.Revision, request)
+	require.NoError(t, err)
+	assert.Equal(t, created.Node.ID, receipt.Node.ID)
+	assert.Equal(t, created.Node.Revision+1, receipt.Node.Revision)
+	assert.Equal(t, "/provenance.txt", receipt.Path)
+	assert.Equal(t, request.OriginalPath, receipt.Fact.OriginalPath)
+	assert.Equal(t, receipt.Fact.NodeID, receipt.Node.ID)
+	_, err = c.AppendProvenance(t.Context(), created.Node.ID, 0, request)
+	assert.ErrorContains(t, err, "revision must be positive")
+}
+
+func TestProvenanceAppendMapsInvalidTimeError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.MarshalWrite(w, api.Error{Status: http.StatusUnprocessableEntity,
+			Code: "invalid_provenance_time", Detail: "invalid provenance original_mtime"})
+	}))
+	t.Cleanup(ts.Close)
+	_, err := client.New(ts.URL, serverKey).AppendProvenance(t.Context(), 7, 3,
+		api.ProvenanceAppendRequest{SourceKind: "agent", SourceDescription: "triage", OriginalPath: "opaque://source"})
+	require.ErrorIs(t, err, store.ErrInvalidProvenanceTime)
+}
+
+func TestProvenanceAppendMapsMismatchError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.MarshalWrite(w, api.Error{Status: http.StatusConflict,
+			Code: "provenance_mismatch", Detail: "provenance predecessor was not found"})
+	}))
+	t.Cleanup(ts.Close)
+	_, err := client.New(ts.URL, serverKey).AppendProvenance(t.Context(), 7, 3,
+		api.ProvenanceAppendRequest{SourceKind: "agent", SourceDescription: "triage", OriginalPath: "opaque://source"})
+	require.ErrorIs(t, err, store.ErrProvenanceMismatch)
+}
+
+func TestProvenanceAppendRejectsUnboundReceipt(t *testing.T) {
+	mtime := "2026-08-26T12:00:00Z"
+	request := api.ProvenanceAppendRequest{
+		SourceKind: "agent", SourceDescription: "triage", OriginalPath: "opaque://client/source",
+		OriginalMTime: &mtime,
+	}
+	goodFact := api.ProvenanceFact{
+		Identity: strings.Repeat("ab", 32), NodeID: 7,
+		IngestID: "0e5edbcd-3a0e-4fbe-9a3c-0d1a4a7e21aa", IngestStartedAt: "2026-09-05T00:00:00Z",
+		SourceKind: "agent", SourceDescription: "triage",
+		OriginalPath: "opaque://client/source", OriginalMTime: &mtime, Active: true,
+	}
+	cases := []struct {
+		name    string
+		mutate  func(receipt *api.ProvenanceAppendReceipt, etag *string)
+		wantErr string
+	}{
+		{"wrong node id", func(r *api.ProvenanceAppendReceipt, _ *string) {
+			r.Node.ID = 8
+		}, "does not bind its node"},
+		{"wrong fact node id", func(r *api.ProvenanceAppendReceipt, _ *string) {
+			r.Fact.NodeID = 8
+		}, "does not bind its node"},
+		{"unadvanced revision", func(r *api.ProvenanceAppendReceipt, e *string) {
+			r.Node.Revision = 3
+			*e = `"3"`
+		}, "node revision 3, expected 4"},
+		{"missing etag", func(_ *api.ProvenanceAppendReceipt, e *string) {
+			*e = ""
+		}, "ETag"},
+		{"etag revision mismatch", func(_ *api.ProvenanceAppendReceipt, e *string) {
+			*e = `"9"`
+		}, "disagrees with node revision"},
+		{"foreign fact", func(r *api.ProvenanceAppendReceipt, _ *string) {
+			r.Fact.OriginalPath = "opaque://other/source"
+		}, "does not bind its request"},
+		{"changed mtime", func(r *api.ProvenanceAppendReceipt, _ *string) {
+			other := "2026-08-27T12:00:00Z"
+			r.Fact.OriginalMTime = &other
+		}, "does not bind its request"},
+		{"dropped mtime", func(r *api.ProvenanceAppendReceipt, _ *string) {
+			r.Fact.OriginalMTime = nil
+		}, "does not bind its request"},
+		{"inactive fact", func(r *api.ProvenanceAppendReceipt, _ *string) {
+			r.Fact.Active = false
+		}, "not active"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			receipt := api.ProvenanceAppendReceipt{
+				Node: api.Node{ID: 7, Name: "provenance.txt", Kind: "file", Revision: 4},
+				Path: "/provenance.txt", Fact: goodFact,
+			}
+			etag := `"4"`
+			tc.mutate(&receipt, &etag)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if etag != "" {
+					w.Header().Set("ETag", etag)
+				}
+				w.WriteHeader(http.StatusCreated)
+				_ = json.MarshalWrite(w, receipt)
+			}))
+			t.Cleanup(ts.Close)
+			_, err := client.New(ts.URL, serverKey).AppendProvenance(t.Context(), 7, 3, request)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
 func TestContentReplacementRejectsUnprovenReceipt(t *testing.T) {
 	content := []byte("replacement")
 	hash := sha256.Sum256(content)

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -390,6 +390,15 @@ func validateAuditedHistory(
 						vaultID, mutation, allocation, mutationScopeIDs, scopeEntries,
 						attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
 					)
+				} else if kind == metadataProvenanceType {
+					if len(mutationScopeIDs) != 1 {
+						err = errors.New("cross-scope provenance mutation is unsupported")
+					} else {
+						err = replay.applyProvenanceAppend(
+							vaultID, mutation, allocation, scopeEntry,
+							attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
+						)
+					}
 				} else if len(mutationScopeIDs) != 1 {
 					err = errors.New("cross-scope attached-metadata mutation is unsupported")
 				} else {

--- a/internal/store/audit_provenance.go
+++ b/internal/store/audit_provenance.go
@@ -1,0 +1,703 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+const (
+	auditCurrentVersionIDField = "current_version_id"
+	auditNodeRevisionField     = "node_revision"
+	auditPathEffectCountField  = "path_effect_count"
+)
+
+func persistAuditedProvenanceAppend(
+	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
+	nodeSequence int64, authority auditAuthorityState, scopes []auditScopeState,
+	priorNode, resultingNode Node, ingest metadataIngest, provenance metadataProvenance,
+) error {
+	sequence, err := nextAuditInteger("operation sequence", authority.sequence)
+	if err != nil {
+		return err
+	}
+	values, err := makeAuditedMutationValues(vaultID, authority.lineageID, operationID, recordedAt)
+	if err != nil {
+		return err
+	}
+	provenanceRecord, err := provenanceAuditRecord(
+		provenance.Identity, provenance.NodeID, provenance.IngestID,
+		provenance.OriginalPath, nullString(provenance.OriginalMTime), nullString(provenance.Supersedes),
+	)
+	if err != nil {
+		return err
+	}
+	var priorProvenance *audit.Record
+	if provenance.Supersedes != nil {
+		prior, err := provenanceAuditRecordByIdentity(ctx, tx, *provenance.Supersedes)
+		if err != nil {
+			return err
+		}
+		priorProvenance = &prior
+	}
+	ingestRecord, err := ingestAuditRecord(ingest)
+	if err != nil {
+		return err
+	}
+	provenanceChange, err := makeAttachedMetadataAddition(provenanceRecord)
+	if err != nil {
+		return err
+	}
+	// The ingest row and its provenance row are one logical assertion. Both
+	// become auditable attachments in the same mutation delta.
+	ingestChange, err := makeAttachedMetadataAddition(ingestRecord)
+	if err != nil {
+		return err
+	}
+	delta, deltaDigest, err := makeAttachedMetadataDelta(
+		values.operationID, []audit.Record{ingestChange, provenanceChange},
+	)
+	if err != nil {
+		return err
+	}
+	events := make([]audit.Record, len(scopes))
+	eventKind := "provenance_add"
+	if provenance.Supersedes != nil {
+		eventKind = "provenance_supersede"
+	}
+	for index, scope := range scopes {
+		events[index], err = makeAuditedProvenanceEvent(
+			values, scope.scopeID, uint64(index), priorNode, resultingNode,
+			priorProvenance, provenanceRecord, eventKind,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	stateChange, err := makeAuditMemberStateChange(priorNode, resultingNode)
+	if err != nil {
+		return err
+	}
+	mutation, err := makeAuditedMemberStateMutation(values, sequence, events, stateChange)
+	if err != nil {
+		return err
+	}
+	mutation, err = replaceAuditRecordField(
+		mutation, auditAttachedMetadataChangeCountField, audit.Unsigned(2),
+	)
+	if err != nil {
+		return err
+	}
+	mutation, err = replaceAuditRecordField(mutation, "attached_metadata_change_digest", deltaDigest.value)
+	if err != nil {
+		return err
+	}
+	mutationDigest, err := hashAuditRecord(mutation)
+	if err != nil {
+		return err
+	}
+	if err := insertAuditRecord(ctx, tx, delta); err != nil {
+		return err
+	}
+	for _, event := range events {
+		if err := insertAuditRecord(ctx, tx, audit.Record{
+			Kind: auditEventField, Fields: []audit.Field{{Name: auditEventField, Value: audit.Nested(event)}},
+		}); err != nil {
+			return err
+		}
+	}
+	if err := insertAuditRecord(ctx, tx, mutation); err != nil {
+		return err
+	}
+	if err := advanceAuditedMutationScopes(ctx, tx, values, scopes, mutationDigest.value); err != nil {
+		return err
+	}
+	allocation, err := makeAuditAllocationEntry(
+		values, sequence, nodeSequence, authority.allocationHead, mutationDigest.value,
+	)
+	if err != nil {
+		return err
+	}
+	allocation, err = addAttachedMetadataToAllocation(allocation, 2, deltaDigest.value)
+	if err != nil {
+		return err
+	}
+	return advanceAuditAuthority(ctx, tx, authority, sequence, allocation)
+}
+
+func provenanceAuditRecordByIdentity(
+	ctx context.Context, tx *sql.Tx, identity string,
+) (audit.Record, error) {
+	var nodeID int64
+	var ingestID, originalPath string
+	var originalMTime, supersedes sql.NullString
+	if err := tx.QueryRowContext(ctx, `SELECT node_id,ingest_id,original_path,
+		original_mtime,supersedes FROM provenance WHERE identity=?`, identity).Scan(
+		&nodeID, &ingestID, &originalPath, &originalMTime, &supersedes,
+	); err != nil {
+		return audit.Record{}, fmt.Errorf("reading superseded provenance %s: %w", identity, err)
+	}
+	return provenanceAuditRecord(identity, nodeID, ingestID, originalPath, originalMTime, supersedes)
+}
+
+func makeAuditedProvenanceEvent(
+	values auditedMutationValues, scopeID string, ordinal uint64,
+	priorNode, resultingNode Node, priorProvenance *audit.Record,
+	provenance audit.Record, eventKind string,
+) (audit.Record, error) {
+	if priorNode.ID != resultingNode.ID {
+		return audit.Record{}, errors.New("audited provenance changes node identity")
+	}
+	nodeID, err := positiveAuditNodeID(priorNode.ID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	priorRevision, err := positiveAuditRevision(priorNode.Revision)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	resultingRevision, err := positiveAuditRevision(resultingNode.Revision)
+	if err != nil || resultingRevision != priorRevision+1 {
+		return audit.Record{}, errors.New("audited provenance has an invalid revision transition")
+	}
+	scopeValue, err := audit.UUID(scopeID)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	identity, err := attachedAuditIdentity(provenance)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	eventID, err := hashAuditRecord(audit.Record{Kind: auditEventIdentityKind, Fields: []audit.Field{
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+	}})
+	if err != nil {
+		return audit.Record{}, err
+	}
+	eventKindValue, err := audit.Text(eventKind)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	attachmentKind, err := audit.Text(metadataProvenanceType)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	priorVersion, err := auditNodeCurrentVersion(priorNode)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	resultingVersion, err := auditNodeCurrentVersion(resultingNode)
+	if err != nil {
+		return audit.Record{}, err
+	}
+	pre := audit.Absent()
+	if priorProvenance != nil {
+		pre = audit.Nested(*priorProvenance)
+	}
+	return audit.Record{Kind: "audit_event", Fields: []audit.Field{
+		{Name: "event_id", Value: eventID.value},
+		{Name: auditOperationIDField, Value: values.operationID},
+		{Name: metadataNodeIDField, Value: audit.Unsigned(nodeID)},
+		{Name: "event_kind", Value: eventKindValue},
+		{Name: auditScopeIDField, Value: scopeValue},
+		{Name: auditTargetNodeIDField, Value: audit.Absent()},
+		{Name: "attachment_kind", Value: attachmentKind},
+		{Name: "attachment_identity", Value: audit.Nested(identity)},
+		{Name: auditSourceVersionIDField, Value: audit.Absent()},
+		{Name: auditEventOrdinalField, Value: audit.Unsigned(ordinal)},
+		{Name: auditRecordedAtField, Value: values.recordedAt},
+		{Name: "prior_node_revision", Value: audit.Unsigned(priorRevision)},
+		{Name: "resulting_node_revision", Value: audit.Unsigned(resultingRevision)},
+		{Name: "prior_current_version_id", Value: priorVersion},
+		{Name: "resulting_current_version_id", Value: resultingVersion},
+		{Name: auditOriginField, Value: values.origin},
+		{Name: auditAgentLabelField, Value: audit.Absent()},
+		{Name: auditPreField, Value: pre},
+		{Name: auditPostField, Value: audit.Nested(provenance)},
+		{Name: auditTopologyDeltaField, Value: audit.Absent()},
+		{Name: auditBaselineDigestField, Value: audit.Absent()},
+	}}, nil
+}
+
+type replayedProvenanceAppend struct {
+	nodeID     uint64
+	ingest     audit.Record
+	provenance audit.Record
+	change     audit.Record
+	digest     string
+}
+
+func (replay *auditedHistoryReplay) applyProvenanceAppend(
+	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
+	deltaRecords, eventRecords map[string]storedAuditRecord,
+	usedDeltas, usedEvents map[string]bool,
+) error {
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	if err != nil {
+		return err
+	}
+	sequence := replay.allocationCount + 1
+	if err := requireAuditUUID(mutation.record, auditVaultIDField, vaultID); err != nil {
+		return err
+	}
+	auditSequence, err := positiveAuditInteger("operation sequence", sequence)
+	if err != nil {
+		return err
+	}
+	if err := requireAuditUnsigned(mutation.record, "operation_sequence", auditSequence); err != nil {
+		return err
+	}
+	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
+		return err
+	}
+	transition, err := replay.validateProvenanceAppendDelta(
+		mutation.record, operationID, deltaRecords, usedDeltas,
+	)
+	if err != nil {
+		return err
+	}
+	if err := replay.validateProvenanceAppendEvent(
+		operationID, mutation.record, transition, eventRecords, usedEvents,
+	); err != nil {
+		return err
+	}
+	if err := replay.validateMemberStateChanges(mutation.record, []uint64{transition.nodeID}); err != nil {
+		return err
+	}
+	bindings, err := auditRecordListField(mutation.record, "baselines")
+	if err != nil {
+		return err
+	}
+	if len(bindings) != 0 {
+		return errors.New("provenance mutation cannot bind an enrollment baseline")
+	}
+	if err := requireAuditAbsentFields(
+		mutation.record, auditTopologyDeltaField, "path_effect_digest", "witness_change_digest",
+	); err != nil {
+		return err
+	}
+	for _, field := range []string{auditPathEffectCountField, auditWitnessChangeCountField} {
+		if err := requireAuditUnsigned(mutation.record, field, 0); err != nil {
+			return err
+		}
+	}
+	if err := requireAuditUnsigned(mutation.record, auditAttachedMetadataChangeCountField, 2); err != nil {
+		return err
+	}
+	if err := requireAuditDigest(mutation.record, "attached_metadata_change_digest", transition.digest); err != nil {
+		return err
+	}
+	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
+		return err
+	}
+	if err := replay.advanceAllocation(vaultID, operationID, mutation, allocation, transition.digest, 2); err != nil {
+		return err
+	}
+	return replay.applyProvenanceAppendState(transition, mutation.record)
+}
+
+func (replay *auditedHistoryReplay) validateProvenanceAppendDelta(
+	mutation audit.Record, operationID string,
+	deltaRecords map[string]storedAuditRecord, usedDeltas map[string]bool,
+) (replayedProvenanceAppend, error) {
+	digest, err := auditDigestField(mutation, "attached_metadata_change_digest")
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	delta, ok := deltaRecords[digest]
+	if !ok || usedDeltas[digest] {
+		return replayedProvenanceAppend{}, errors.New("provenance mutation lacks one unique attached-metadata delta")
+	}
+	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil || len(changes) != 2 {
+		return replayedProvenanceAppend{}, errors.New("provenance mutation must contain ingest and provenance changes")
+	}
+	var change, ingestChange audit.Record
+	for _, candidate := range changes {
+		kind, kindErr := auditTextField(candidate, "record_kind")
+		if kindErr != nil {
+			return replayedProvenanceAppend{}, kindErr
+		}
+		_, hasPre, preErr := optionalNestedAuditRecord(candidate, auditPreField)
+		if preErr != nil || hasPre {
+			return replayedProvenanceAppend{}, errors.New("provenance mutation changes an existing attachment")
+		}
+		_, hasPost, postErr := optionalNestedAuditRecord(candidate, auditPostField)
+		if postErr != nil || !hasPost {
+			return replayedProvenanceAppend{}, errors.New("provenance mutation lacks an added attachment")
+		}
+		switch kind {
+		case metadataProvenanceType:
+			if change.Kind != "" {
+				return replayedProvenanceAppend{}, errors.New("provenance mutation repeats its fact change")
+			}
+			change = candidate
+		case metadataIngestType:
+			if ingestChange.Kind != "" {
+				return replayedProvenanceAppend{}, errors.New("provenance mutation repeats its ingest change")
+			}
+			ingestChange = candidate
+		default:
+			return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation carries unsupported attachment %q", kind)
+		}
+	}
+	if change.Kind == "" || ingestChange.Kind == "" {
+		return replayedProvenanceAppend{}, errors.New("provenance mutation must add one ingest and one fact")
+	}
+	ingestPost, err := validateAuditedIngestAddition(ingestChange)
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	ingestKey, err := attachedAuditKey(ingestPost)
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	if _, exists := replay.attachments[ingestKey]; exists {
+		return replayedProvenanceAppend{}, errors.New("provenance mutation reuses ingest identity")
+	}
+	post, _, err := optionalNestedAuditRecord(change, auditPostField)
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	ingestID, err := auditUUIDField(ingestPost, "ingest_id")
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	if err := validateReplayedIngest(ingestPost); err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	if err := validateReplayedProvenance(post, replay, ingestID); err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	provenanceIngestID, err := auditUUIDField(post, "ingest_id")
+	if err != nil || provenanceIngestID != ingestID {
+		return replayedProvenanceAppend{}, errors.New("provenance fact does not bind its new ingest")
+	}
+	identity, err := attachedAuditIdentity(post)
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	storedIdentity, err := auditNestedField(change, "stable_identity")
+	if err != nil || !auditRecordEqual(storedIdentity, identity) {
+		return replayedProvenanceAppend{}, errors.New("provenance delta identity does not match its record")
+	}
+	nodeID, err := auditUnsignedField(post, metadataNodeIDField)
+	if err != nil || !replay.memberSet[nodeID] {
+		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation targets unaudited node %d", nodeID)
+	}
+	provenanceID, err := auditDigestField(post, "identity")
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	key, err := attachedAuditKey(post)
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	if _, exists := replay.attachments[key]; exists {
+		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation reuses identity %s", provenanceID)
+	}
+	supersedes, err := auditOptionalDigestField(post, "supersedes")
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	if supersedes != nil {
+		if err := replay.requireActiveProvenance(nodeID, *supersedes); err != nil {
+			return replayedProvenanceAppend{}, err
+		}
+	}
+	usedDeltas[digest] = true
+	return replayedProvenanceAppend{
+		nodeID: nodeID, provenance: post, change: change, digest: digest,
+		ingest: ingestPost,
+	}, nil
+}
+
+func validateReplayedProvenance(record audit.Record, replay *auditedHistoryReplay, additionalIngest string) error {
+	if record.Kind != metadataProvenanceType {
+		return errors.New("provenance attachment has the wrong record kind")
+	}
+	nodeID, err := auditUnsignedField(record, metadataNodeIDField)
+	if err != nil {
+		return err
+	}
+	ingestID, err := auditUUIDField(record, "ingest_id")
+	if err != nil {
+		return err
+	}
+	path, ok := auditFieldBytes(record, "original_path")
+	if !ok || len(path) == 0 || !utf8.Valid(path) {
+		return errors.New("provenance attachment has invalid original path")
+	}
+	mtime, err := auditOptionalTimestampField(record, "original_mtime")
+	if err != nil {
+		return err
+	}
+	supersedes, err := auditOptionalDigestField(record, "supersedes")
+	if err != nil {
+		return err
+	}
+	identity, err := auditDigestField(record, "identity")
+	if err != nil {
+		return err
+	}
+	ingestValue, err := audit.UUID(ingestID)
+	if err != nil {
+		return err
+	}
+	identityRecord := audit.Record{Kind: "provenance_identity", Fields: []audit.Field{
+		{Name: "node_id", Value: audit.Unsigned(nodeID)},
+		{Name: "ingest_id", Value: ingestValue},
+		{Name: "original_path", Value: audit.Bytes(path)},
+		{Name: "original_mtime", Value: audit.Absent()},
+		{Name: "supersedes", Value: audit.Absent()},
+	}}
+	if mtime != nil {
+		identityRecord.Fields[3].Value, err = audit.Timestamp(*mtime)
+		if err != nil {
+			return err
+		}
+	}
+	if supersedes != nil {
+		identityRecord.Fields[4].Value, err = audit.DigestHex(*supersedes)
+		if err != nil {
+			return err
+		}
+	}
+	digest, err := hashAuditRecord(identityRecord)
+	if err != nil {
+		return err
+	}
+	if digest.text != identity {
+		return errors.New("provenance attachment identity does not match its immutable fields")
+	}
+	if !replay.hasIngest(ingestID) && ingestID != additionalIngest {
+		return fmt.Errorf("provenance attachment references missing ingest %s", ingestID)
+	}
+	return nil
+}
+
+func auditFieldBytes(record audit.Record, name string) ([]byte, bool) {
+	value, err := auditField(record, name)
+	if err != nil {
+		return nil, false
+	}
+	bytes, ok := value.BytesValue()
+	return bytes, ok
+}
+
+func (replay *auditedHistoryReplay) hasIngest(id string) bool {
+	for _, record := range replay.attachments {
+		if record.Kind != metadataIngestType {
+			continue
+		}
+		candidate, err := auditUUIDField(record, "ingest_id")
+		if err == nil && candidate == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (replay *auditedHistoryReplay) requireActiveProvenance(nodeID uint64, identity string) error {
+	_, err := replay.activeProvenanceRecord(nodeID, identity)
+	return err
+}
+
+func (replay *auditedHistoryReplay) activeProvenanceRecord(
+	nodeID uint64, identity string,
+) (audit.Record, error) {
+	var found bool
+	var result audit.Record
+	for _, record := range replay.attachments {
+		if record.Kind != metadataProvenanceType {
+			continue
+		}
+		candidateID, err := auditDigestField(record, "identity")
+		if err != nil {
+			return audit.Record{}, err
+		}
+		candidateNode, err := auditUnsignedField(record, metadataNodeIDField)
+		if err != nil {
+			return audit.Record{}, err
+		}
+		if candidateID == identity {
+			if candidateNode != nodeID {
+				return audit.Record{}, errors.New("provenance predecessor belongs to another node")
+			}
+			found = true
+			result = record
+		}
+		superseded, err := auditOptionalDigestField(record, "supersedes")
+		if err != nil {
+			return audit.Record{}, err
+		}
+		if superseded != nil && *superseded == identity {
+			return audit.Record{}, errors.New("provenance predecessor is already superseded")
+		}
+	}
+	if !found {
+		return audit.Record{}, errors.New("provenance predecessor is missing")
+	}
+	return result, nil
+}
+
+func (replay *auditedHistoryReplay) validateProvenanceAppendEvent(
+	operationID string, mutation audit.Record, transition replayedProvenanceAppend,
+	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
+) error {
+	events, err := auditRecordListField(mutation, "events")
+	if err != nil || len(events) != 1 {
+		return errors.New("provenance mutation must contain one scope event")
+	}
+	event := events[0]
+	if err := validateAuditEventWrapper(operationID, 0, event, eventRecords, usedEvents); err != nil {
+		return err
+	}
+	nodeID := transition.nodeID
+	identity, err := attachedAuditIdentity(transition.provenance)
+	if err != nil {
+		return err
+	}
+	storedIdentity, err := auditNestedField(event, "attachment_identity")
+	if err != nil || !auditRecordEqual(storedIdentity, identity) {
+		return errors.New("provenance event identity does not match its attachment")
+	}
+	eventKind := "provenance_add"
+	if supersedes, err := auditOptionalDigestField(transition.provenance, "supersedes"); err != nil {
+		return err
+	} else if supersedes != nil {
+		eventKind = "provenance_supersede"
+	}
+	var expectedPre audit.Record
+	if eventKind == "provenance_supersede" {
+		supersedes, err := auditOptionalDigestField(transition.provenance, "supersedes")
+		if err != nil || supersedes == nil {
+			return errors.New("provenance supersession lacks its predecessor")
+		}
+		expectedPre, err = replay.activeProvenanceRecord(nodeID, *supersedes)
+		if err != nil {
+			return err
+		}
+	}
+	state := replay.states[nodeID]
+	priorRevision, err := auditUnsignedField(state, auditNodeRevisionField)
+	if err != nil {
+		return err
+	}
+	current, err := auditOptionalUUIDField(state, auditCurrentVersionIDField)
+	if err != nil {
+		return err
+	}
+	checks := []func() error{
+		func() error { return requireAuditUUID(event, auditOperationIDField, operationID) },
+		func() error { return requireAuditUnsigned(event, metadataNodeIDField, nodeID) },
+		func() error { return requireAuditText(event, "event_kind", eventKind) },
+		func() error { return requireAuditUUID(event, auditScopeIDField, replay.scopeID) },
+		func() error { return requireAuditText(event, "attachment_kind", metadataProvenanceType) },
+		func() error { return requireAuditUnsigned(event, auditEventOrdinalField, 0) },
+		func() error { return requireAuditUnsigned(event, "prior_node_revision", priorRevision) },
+		func() error { return requireAuditUnsigned(event, "resulting_node_revision", priorRevision+1) },
+		func() error { return requireAuditOptionalUUID(event, "prior_current_version_id", current) },
+		func() error { return requireAuditOptionalUUID(event, "resulting_current_version_id", current) },
+		func() error { return requireMatchingEventEnvelope(mutation, event) },
+		func() error {
+			return requireAuditAbsentFields(event, "target_node_id", "source_version_id", auditTopologyDeltaField, "baseline_digest")
+		},
+		func() error {
+			pre, hasPre, err := optionalNestedAuditRecord(event, auditPreField)
+			if err != nil {
+				return err
+			}
+			if eventKind == "provenance_supersede" {
+				if !hasPre || !auditRecordEqual(pre, expectedPre) {
+					return errors.New("provenance event pre-state does not match its predecessor")
+				}
+				return nil
+			}
+			if hasPre {
+				return errors.New("provenance-add event unexpectedly has a pre-state")
+			}
+			return nil
+		},
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	post, err := auditNestedField(event, auditPostField)
+	if err != nil || !auditRecordEqual(post, transition.provenance) {
+		return errors.New("provenance event post-state does not match its delta")
+	}
+	return nil
+}
+
+func (replay *auditedHistoryReplay) applyProvenanceAppendState(
+	transition replayedProvenanceAppend, mutation audit.Record,
+) error {
+	key, err := attachedAuditKey(transition.provenance)
+	if err != nil {
+		return err
+	}
+	replay.attachments[key] = transition.provenance
+	ingestKey, err := attachedAuditKey(transition.ingest)
+	if err != nil {
+		return err
+	}
+	replay.attachments[ingestKey] = transition.ingest
+	state := replay.states[transition.nodeID]
+	revision, err := auditUnsignedField(state, auditNodeRevisionField)
+	if err != nil {
+		return err
+	}
+	current, err := auditField(state, auditCurrentVersionIDField)
+	if err != nil {
+		return err
+	}
+	replay.states[transition.nodeID] = audit.Record{Kind: "member_state", Fields: []audit.Field{
+		{Name: metadataNodeIDField, Value: audit.Unsigned(transition.nodeID)},
+		{Name: auditNodeRevisionField, Value: audit.Unsigned(revision + 1)},
+		{Name: auditCurrentVersionIDField, Value: current},
+	}}
+	index, ok := replay.topologyIndex[transition.nodeID]
+	if !ok {
+		return fmt.Errorf("audited node %d is absent from topology replay", transition.nodeID)
+	}
+	modifiedAt, err := auditField(mutation, auditRecordedAtField)
+	if err != nil {
+		return err
+	}
+	replay.topology[index], err = replaceAuditRecordField(replay.topology[index], "modified_at", modifiedAt)
+	return err
+}
+
+func validateReplayedIngest(record audit.Record) error {
+	if record.Kind != metadataIngestType {
+		return errors.New("provenance mutation ingest has the wrong record kind")
+	}
+	if _, err := auditUUIDField(record, "ingest_id"); err != nil {
+		return err
+	}
+	if _, err := auditTimestampField(record, "started_at"); err != nil {
+		return err
+	}
+	if _, err := auditTextField(record, "source_kind"); err != nil {
+		return err
+	}
+	description, err := auditField(record, "source_desc")
+	if err != nil {
+		return err
+	}
+	if value, ok := description.BytesValue(); !ok || len(value) == 0 || !utf8.Valid(value) {
+		return errors.New("provenance mutation ingest has invalid source description")
+	}
+	return nil
+}

--- a/internal/store/audit_provenance.go
+++ b/internal/store/audit_provenance.go
@@ -393,6 +393,17 @@ func (replay *auditedHistoryReplay) validateProvenanceAppendDelta(
 	if err != nil || !replay.memberSet[nodeID] {
 		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation targets unaudited node %d", nodeID)
 	}
+	topologyIndex, ok := replay.topologyIndex[nodeID]
+	if !ok {
+		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation target %d is absent from topology", nodeID)
+	}
+	nodeKind, err := auditTextField(replay.topology[topologyIndex], "node_kind")
+	if err != nil {
+		return replayedProvenanceAppend{}, err
+	}
+	if nodeKind != nodeKindFile {
+		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation targets non-file node %d", nodeID)
+	}
 	provenanceID, err := auditDigestField(post, "identity")
 	if err != nil {
 		return replayedProvenanceAppend{}, err

--- a/internal/store/audit_provenance.go
+++ b/internal/store/audit_provenance.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"unicode/utf8"
 
 	"go.kenn.io/docbank/internal/audit"
@@ -374,12 +375,8 @@ func (replay *auditedHistoryReplay) validateProvenanceAppendDelta(
 	if err := validateReplayedIngest(ingestPost); err != nil {
 		return replayedProvenanceAppend{}, err
 	}
-	if err := validateReplayedProvenance(post, replay, ingestID); err != nil {
+	if err := validateReplayedProvenance(post, ingestID); err != nil {
 		return replayedProvenanceAppend{}, err
-	}
-	provenanceIngestID, err := auditUUIDField(post, "ingest_id")
-	if err != nil || provenanceIngestID != ingestID {
-		return replayedProvenanceAppend{}, errors.New("provenance fact does not bind its new ingest")
 	}
 	identity, err := attachedAuditIdentity(post)
 	if err != nil {
@@ -420,7 +417,7 @@ func (replay *auditedHistoryReplay) validateProvenanceAppendDelta(
 		return replayedProvenanceAppend{}, err
 	}
 	if supersedes != nil {
-		if err := replay.requireActiveProvenance(nodeID, *supersedes); err != nil {
+		if err := replay.requireSupersedableProvenance(nodeID, *supersedes); err != nil {
 			return replayedProvenanceAppend{}, err
 		}
 	}
@@ -431,7 +428,7 @@ func (replay *auditedHistoryReplay) validateProvenanceAppendDelta(
 	}, nil
 }
 
-func validateReplayedProvenance(record audit.Record, replay *auditedHistoryReplay, additionalIngest string) error {
+func validateReplayedProvenance(record audit.Record, newIngest string) error {
 	if record.Kind != metadataProvenanceType {
 		return errors.New("provenance attachment has the wrong record kind")
 	}
@@ -442,6 +439,9 @@ func validateReplayedProvenance(record audit.Record, replay *auditedHistoryRepla
 	ingestID, err := auditUUIDField(record, "ingest_id")
 	if err != nil {
 		return err
+	}
+	if ingestID != newIngest {
+		return errors.New("provenance fact does not bind its new ingest")
 	}
 	path, ok := auditFieldBytes(record, "original_path")
 	if !ok || len(path) == 0 || !utf8.Valid(path) {
@@ -489,9 +489,6 @@ func validateReplayedProvenance(record audit.Record, replay *auditedHistoryRepla
 	if digest.text != identity {
 		return errors.New("provenance attachment identity does not match its immutable fields")
 	}
-	if !replay.hasIngest(ingestID) && ingestID != additionalIngest {
-		return fmt.Errorf("provenance attachment references missing ingest %s", ingestID)
-	}
 	return nil
 }
 
@@ -504,22 +501,33 @@ func auditFieldBytes(record audit.Record, name string) ([]byte, bool) {
 	return bytes, ok
 }
 
-func (replay *auditedHistoryReplay) hasIngest(id string) bool {
-	for _, record := range replay.attachments {
-		if record.Kind != metadataIngestType {
-			continue
-		}
-		candidate, err := auditUUIDField(record, "ingest_id")
-		if err == nil && candidate == id {
-			return true
-		}
+func (replay *auditedHistoryReplay) requireSupersedableProvenance(nodeID uint64, identity string) error {
+	predecessor, err := replay.activeProvenanceRecord(nodeID, identity)
+	if err != nil {
+		return err
 	}
-	return false
-}
-
-func (replay *auditedHistoryReplay) requireActiveProvenance(nodeID uint64, identity string) error {
-	_, err := replay.activeProvenanceRecord(nodeID, identity)
-	return err
+	ingestID, err := auditField(predecessor, "ingest_id")
+	if err != nil {
+		return err
+	}
+	key, err := attachedAuditKey(audit.Record{Kind: metadataIngestType, Fields: []audit.Field{
+		{Name: "ingest_id", Value: ingestID},
+	}})
+	if err != nil {
+		return err
+	}
+	ingest, ok := replay.attachments[key]
+	if !ok {
+		return errors.New("provenance predecessor references missing ingest")
+	}
+	sourceKind, err := auditTextField(ingest, "source_kind")
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(sourceKind, callerSuppliedSourceKindPrefix) {
+		return errors.New("operational ingest provenance cannot be superseded")
+	}
+	return nil
 }
 
 func (replay *auditedHistoryReplay) activeProvenanceRecord(

--- a/internal/store/audit_provenance.go
+++ b/internal/store/audit_provenance.go
@@ -708,8 +708,12 @@ func validateReplayedIngest(record audit.Record) error {
 	if _, err := auditTimestampField(record, "started_at"); err != nil {
 		return err
 	}
-	if _, err := auditTextField(record, "source_kind"); err != nil {
+	sourceKind, err := auditTextField(record, "source_kind")
+	if err != nil {
 		return err
+	}
+	if kind, supplied := strings.CutPrefix(sourceKind, callerSuppliedSourceKindPrefix); !supplied || kind == "" {
+		return errors.New("provenance mutation ingest requires a non-empty caller-supplied source kind")
 	}
 	description, err := auditField(record, "source_desc")
 	if err != nil {

--- a/internal/store/audit_provenance_test.go
+++ b/internal/store/audit_provenance_test.go
@@ -1,0 +1,248 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedProvenanceAppendAndSupersessionRoundTrip(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	node, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+
+	mtime := "2026-08-26T12:00:00Z"
+	first, err := s.AppendNodeProvenance(t.Context(), ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+		SourceDescription: "triage", OriginalPath: "opaque://report", OriginalMTime: &mtime,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, node.Revision+1, first.Node.Revision)
+	assert.Equal(t, "provenance_add", auditEventKindForSequence(t, s, 2))
+
+	second, err := s.AppendNodeProvenance(t.Context(), ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: first.Node.Revision, SourceKind: "agent",
+		SourceDescription: "reconcile", OriginalPath: "opaque://report-corrected",
+		Supersedes: &first.Fact.Identity,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, first.Node.Revision+1, second.Node.Revision)
+	assert.Equal(t, "provenance_supersede", auditEventKindForSequence(t, s, 3))
+	page, err := s.NodeProvenance(t.Context(), node.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 3)
+	assert.False(t, findProvenanceFact(page.Items, first.Fact.Identity).Active)
+	assert.True(t, findProvenanceFact(page.Items, second.Fact.Identity).Active)
+	history, err := s.AuditHistory(t.Context(), node.ID, 10, "")
+	require.NoError(t, err)
+	var supersession AuditEvent
+	for _, event := range history.Items {
+		if event.Kind == "provenance_supersede" {
+			supersession = event
+			break
+		}
+	}
+	require.NotNil(t, supersession.Attachment)
+	require.NotNil(t, supersession.Attachment.Before)
+	require.NotNil(t, supersession.Attachment.After)
+	assert.Equal(t, first.Fact.Identity, supersession.Attachment.Before.ProvenanceID)
+	assert.Equal(t, second.Fact.Identity, supersession.Attachment.After.ProvenanceID)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+}
+
+func TestAuditedProvenanceAppendRollsBackAllMetadata(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	node, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	require.NoError(t, createAuditScopeFailureTrigger(s))
+
+	_, err = s.AppendNodeProvenance(t.Context(), ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+		SourceDescription: "rollback", OriginalPath: "opaque://rollback",
+	})
+	require.ErrorContains(t, err, "forced audited provenance failure")
+	unchanged, err := s.NodeByID(t.Context(), node.ID)
+	require.NoError(t, err)
+	assert.Equal(t, node.Revision, unchanged.Revision)
+	var ingests, provenance, sequence int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM ingests WHERE source_desc=?),
+		(SELECT COUNT(*) FROM provenance WHERE original_path=?),
+		(SELECT operation_sequence_high_water FROM audit_authority)`,
+		"rollback", "opaque://rollback").Scan(&ingests, &provenance, &sequence))
+	assert.Zero(t, ingests)
+	assert.Zero(t, provenance)
+	assert.Equal(t, int64(1), sequence)
+}
+
+func TestAuditedProvenanceReplayRejectsTamperedIngestIdentity(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	node, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	_, err = s.AppendNodeProvenance(t.Context(), ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+		SourceDescription: "tamper", OriginalPath: "opaque://source",
+	})
+	require.NoError(t, err)
+
+	authority, auditScope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, auditScope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, auditScope, initial)
+	require.NoError(t, err)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	mutation := mutations[2]
+	deltas := auditRecordsByDigest(records["attached_metadata_delta"])
+	digest, err := auditDigestField(mutation.record, "attached_metadata_change_digest")
+	require.NoError(t, err)
+	delta := deltas[digest]
+	changes, err := auditRecordListField(delta.record, "changes")
+	require.NoError(t, err)
+	var appendedIngest audit.Record
+	for _, change := range changes {
+		kind, kindErr := auditTextField(change, "record_kind")
+		require.NoError(t, kindErr)
+		if kind == metadataIngestType {
+			appendedIngest, err = validateAuditedIngestAddition(change)
+			require.NoError(t, err)
+		}
+	}
+	ingestKey, err := attachedAuditKey(appendedIngest)
+	require.NoError(t, err)
+	replay.attachments[ingestKey] = appendedIngest
+	used := map[string]bool{}
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	require.NoError(t, err)
+	_, err = replay.validateProvenanceAppendDelta(mutation.record, operationID, deltas, used)
+	require.ErrorContains(t, err, "provenance mutation reuses ingest identity")
+	delete(replay.attachments, ingestKey)
+	for index, change := range changes {
+		kind, kindErr := auditTextField(change, "record_kind")
+		require.NoError(t, kindErr)
+		if kind != metadataIngestType {
+			continue
+		}
+		tampered, tamperErr := replaceAuditRecordField(change, "stable_identity", audit.Nested(audit.Record{
+			Kind: "tampered_identity",
+		}))
+		require.NoError(t, tamperErr)
+		changes[index] = tampered
+	}
+	delta.record, err = replaceAuditRecordField(delta.record, "changes", audit.List(auditNestedValues(changes)...))
+	require.NoError(t, err)
+	deltas[digest] = delta
+	used = map[string]bool{}
+	_, err = replay.validateProvenanceAppendDelta(mutation.record, operationID, deltas, used)
+	require.ErrorContains(t, err, "audited ingest attachment identity does not match its post record")
+}
+
+func TestAuditedProvenanceImportRejectsTamperedFact(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	node, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	_, err = s.AppendNodeProvenance(t.Context(), ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+		SourceDescription: "tamper", OriginalPath: "opaque://original",
+	})
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	malformed := rewriteAppendedProvenancePath(t, exported.Bytes(), node.ID)
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	err = restored.ImportMetadata(t.Context(), bytes.NewReader(malformed))
+	require.ErrorContains(t, err, "replayed audit attachments do not match current metadata")
+	var auditRows int64
+	require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&auditRows))
+	assert.Zero(t, auditRows)
+}
+
+func findProvenanceFact(facts []ProvenanceFact, identity string) ProvenanceFact {
+	for _, fact := range facts {
+		if fact.Identity == identity {
+			return fact
+		}
+	}
+	return ProvenanceFact{}
+}
+
+func createAuditScopeFailureTrigger(s *Store) error {
+	_, err := s.db.Exec(`CREATE TRIGGER reject_provenance_scope_advance
+		BEFORE UPDATE ON audit_scopes BEGIN
+		SELECT RAISE(ABORT, 'forced audited provenance failure'); END`)
+	return err
+}
+
+func rewriteAppendedProvenancePath(t *testing.T, input []byte, nodeID int64) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	found := false
+	for index, line := range lines {
+		var header struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &header))
+		if header.Type != metadataProvenanceType {
+			continue
+		}
+		var provenance metadataProvenance
+		require.NoError(t, json.Unmarshal(line, &provenance))
+		if provenance.NodeID == nodeID && provenance.OriginalPath == "opaque://original" {
+			provenance.OriginalPath = "opaque://tampered"
+			var err error
+			provenance.Identity, err = provenanceIdentity(provenance)
+			require.NoError(t, err)
+			lines[index], err = json.Marshal(provenance)
+			require.NoError(t, err)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+	return append(bytes.Join(lines, []byte{'\n'}), '\n')
+}

--- a/internal/store/audit_provenance_test.go
+++ b/internal/store/audit_provenance_test.go
@@ -262,6 +262,94 @@ func TestAuditedProvenanceImportRejectsTamperedFact(t *testing.T) {
 	assert.Zero(t, auditRows)
 }
 
+func TestAuditedProvenanceImportRequiresCallerSuppliedIngest(t *testing.T) {
+	for _, test := range []struct {
+		kind  string
+		valid bool
+	}{
+		{kind: "cli"},
+		{kind: "watch"},
+		{kind: "embedded:"},
+		{kind: "embedded:agent", valid: true},
+		{kind: "embedded:watch", valid: true},
+	} {
+		t.Run(test.kind, func(t *testing.T) {
+			s := newTestStore(t)
+			ctx := t.Context()
+			node, err := s.CreateFile(ctx, s.RootID(), "report.txt", fakeHash("a1"), 7, "text/plain")
+			require.NoError(t, err)
+			seedInitialAuditAuthority(t, s, s.RootID())
+			run, err := s.BeginIngest(ctx, test.kind, "source")
+			require.NoError(t, err)
+
+			// Build a correctly hashed append with the supplied stored kind,
+			// bypassing the writer that always adds the caller-supplied prefix.
+			require.NoError(t, s.withStorageTx(ctx, func(tx *sql.Tx) error {
+				if _, err := ensureIngestRunTx(ctx, tx, run); err != nil {
+					return err
+				}
+				fact := metadataProvenance{
+					Type: metadataProvenanceType, NodeID: node.ID, IngestID: run.ID(),
+					OriginalPath: "report.txt",
+				}
+				fact.Identity, err = provenanceIdentity(fact)
+				if err != nil {
+					return err
+				}
+				if _, err := tx.ExecContext(ctx, `INSERT INTO provenance(identity,node_id,ingest_id,original_path) VALUES(?,?,?,?)`,
+					fact.Identity, fact.NodeID, fact.IngestID, fact.OriginalPath); err != nil {
+					return err
+				}
+				if test.kind == "watch" {
+					if err := insertWatchSourceTx(tx, "source", fact.OriginalPath, node.ID, node.BlobHash, node.Size); err != nil {
+						return err
+					}
+				}
+				if err := bumpRevisionTx(tx, node.ID, run.record.StartedAt); err != nil {
+					return err
+				}
+				resulting, err := nodeByIDTx(tx, node.ID)
+				if err != nil {
+					return err
+				}
+				authority, scopes, sequence, err := loadAuditedNodeAuthority(ctx, tx, node.ID)
+				if err != nil {
+					return err
+				}
+				return persistAuditedProvenanceAppend(ctx, tx, s.vaultID, run.ID(), run.record.StartedAt,
+					sequence, authority, scopes, node, resulting, run.record, fact)
+			}))
+
+			// Export the fixture's populated tables directly: ExportMetadata
+			// itself validates replay and would reject the malformed source.
+			var exported bytes.Buffer
+			write := newMetadataJSONWriter(&exported)
+			require.NoError(t, write(metadataHeader{
+				Type: "meta", Format: "docbank-metadata", Version: metadataFormatVersion,
+				VaultID: s.VaultID(), NodeSequence: node.ID,
+			}))
+			require.NoError(t, exportBlobs(ctx, s.db, write, false))
+			require.NoError(t, exportNodes(ctx, s.db, write))
+			require.NoError(t, exportIngests(ctx, s.db, write))
+			require.NoError(t, exportContentVersions(ctx, s.db, write))
+			require.NoError(t, exportProvenance(ctx, s.db, write))
+			require.NoError(t, exportWatchSources(ctx, s.db, write))
+			require.NoError(t, exportAuditMetadata(ctx, s.db, write))
+
+			restored := newTestStore(t)
+			err = restored.ImportMetadata(ctx, bytes.NewReader(exported.Bytes()))
+			if test.valid {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, "provenance mutation ingest requires a non-empty caller-supplied source kind")
+			var auditRows int
+			require.NoError(t, restored.db.QueryRow(`SELECT COUNT(*) FROM audit_records`).Scan(&auditRows))
+			assert.Zero(t, auditRows, "rejected import must roll back audit history")
+		})
+	}
+}
+
 func findProvenanceFact(facts []ProvenanceFact, identity string) ProvenanceFact {
 	for _, fact := range facts {
 		if fact.Identity == identity {

--- a/internal/store/audit_provenance_test.go
+++ b/internal/store/audit_provenance_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json/v2"
 	"path/filepath"
 	"testing"
@@ -245,4 +246,56 @@ func rewriteAppendedProvenancePath(t *testing.T, input []byte, nodeID int64) []b
 	}
 	require.True(t, found)
 	return append(bytes.Join(lines, []byte{'\n'}), '\n')
+}
+
+func TestAuditedProvenanceReplayRejectsDirectoryTarget(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	seedMetadataRoundTrip(t, s)
+	dir, err := s.NodeByPath(ctx, "/Projects")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, dir.ID)
+	_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: dir.ID, IfRevision: dir.Revision, SourceKind: "agent",
+		SourceDescription: "synthetic directory replay", OriginalPath: "opaque://directory",
+	})
+	require.ErrorIs(t, err, ErrNotFile)
+	run, err := s.BeginCallerSuppliedIngest(ctx, "agent", "synthetic directory replay")
+	require.NoError(t, err)
+	require.NoError(t, s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		prior, err := nodeByIDTx(tx, dir.ID)
+		if err != nil {
+			return err
+		}
+		if _, err = ensureIngestRunTx(ctx, tx, run); err != nil {
+			return err
+		}
+		fact := metadataProvenance{
+			Type: metadataProvenanceType, NodeID: dir.ID, IngestID: run.record.ID,
+			OriginalPath: "opaque://directory",
+		}
+		fact.Identity, err = provenanceIdentity(fact)
+		if err != nil {
+			return err
+		}
+		if _, err = tx.ExecContext(ctx, `INSERT INTO provenance(identity,node_id,ingest_id,original_path) VALUES(?,?,?,?)`,
+			fact.Identity, fact.NodeID, fact.IngestID, fact.OriginalPath); err != nil {
+			return err
+		}
+		if err = bumpRevisionTx(tx, dir.ID, run.record.StartedAt); err != nil {
+			return err
+		}
+		resulting, err := nodeByIDTx(tx, dir.ID)
+		if err != nil {
+			return err
+		}
+		authority, scopes, sequence, err := loadAuditedNodeAuthority(ctx, tx, dir.ID)
+		if err != nil {
+			return err
+		}
+		return persistAuditedProvenanceAppend(ctx, tx, s.vaultID, run.record.ID, run.record.StartedAt,
+			sequence, authority, scopes, prior, resulting, run.record, fact)
+	}))
+	err = s.ValidateMetadata(ctx)
+	require.ErrorContains(t, err, "provenance mutation targets non-file node")
 }

--- a/internal/store/audit_provenance_test.go
+++ b/internal/store/audit_provenance_test.go
@@ -103,6 +103,65 @@ func TestAuditedProvenanceAppendRollsBackAllMetadata(t *testing.T) {
 	assert.Equal(t, int64(1), sequence)
 }
 
+func TestAuditedProvenanceReplayRejectsOperationalPredecessor(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	run, err := s.BeginCallerSuppliedIngest(ctx, "agent", "source")
+	require.NoError(t, err)
+	node, err := s.IngestFileExact(ctx, run, s.RootID(), "report.txt", fakeHash("a1"),
+		7, "text/plain", "/source/report.txt", "")
+	require.NoError(t, err)
+	page, err := s.NodeProvenance(ctx, node.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	seedInitialAuditAuthority(t, s, s.RootID())
+	_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+		SourceDescription: "correction", OriginalPath: "opaque://corrected",
+		Supersedes: &page.Items[0].Identity,
+	})
+	require.NoError(t, err)
+
+	authority, scope, err := loadInitialAuditProjection(ctx, s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(ctx, s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	replay, err := newAuditedHistoryReplay(authority, scope, initial)
+	require.NoError(t, err)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	mutation := mutations[2]
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	require.NoError(t, err)
+	deltas := auditRecordsByDigest(records["attached_metadata_delta"])
+	_, err = replay.validateProvenanceAppendDelta(mutation.record, operationID, deltas, map[string]bool{})
+	require.NoError(t, err)
+
+	// Keep the same predecessor identity and supersession delta, but make
+	// its baseline ingest operational. Replay must enforce the write policy.
+	operationalKind, err := audit.Text("cli")
+	require.NoError(t, err)
+	changed := false
+	for key, record := range replay.attachments {
+		if record.Kind != metadataIngestType {
+			continue
+		}
+		ingestID, err := auditUUIDField(record, "ingest_id")
+		require.NoError(t, err)
+		if ingestID != run.ID() {
+			continue
+		}
+		replay.attachments[key], err = replaceAuditRecordField(record, "source_kind", operationalKind)
+		require.NoError(t, err)
+		changed = true
+	}
+	require.True(t, changed)
+	_, err = replay.validateProvenanceAppendDelta(mutation.record, operationID, deltas, map[string]bool{})
+	require.ErrorContains(t, err, "operational ingest provenance cannot be superseded")
+}
+
 func TestAuditedProvenanceReplayRejectsTamperedIngestIdentity(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
 	require.NoError(t, err)

--- a/internal/store/audit_tag_definition_validate.go
+++ b/internal/store/audit_tag_definition_validate.go
@@ -75,6 +75,20 @@ func attachedMutationKind(
 	if len(changes) == 1 {
 		return auditTextField(changes[0], "record_kind")
 	}
+	if len(changes) == 2 {
+		var hasIngest, hasProvenance bool
+		for _, change := range changes {
+			kind, err := auditTextField(change, "record_kind")
+			if err != nil {
+				return "", err
+			}
+			hasIngest = hasIngest || kind == metadataIngestType
+			hasProvenance = hasProvenance || kind == metadataProvenanceType
+		}
+		if hasIngest && hasProvenance {
+			return metadataProvenanceType, nil
+		}
+	}
 	return "", errors.New("attached-metadata mutation has unsupported mixed changes")
 }
 

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -33,6 +33,9 @@ var (
 	// ErrProvenanceMismatch means an immutable retry named source evidence
 	// that is not an active fact on the existing document.
 	ErrProvenanceMismatch = errors.New("provenance does not match existing content")
+	// ErrInvalidProvenanceTime means an optional original modification time is
+	// missing, malformed, or not canonical UTC RFC3339Nano.
+	ErrInvalidProvenanceTime = errors.New("invalid provenance original_mtime")
 	// ErrInvalidVersionPrune means a history-pruning selector is absent,
 	// contradictory, or otherwise unsafe to execute.
 	ErrInvalidVersionPrune = errors.New("invalid version-prune selector")

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 )
 
-const embeddedSourceKindPrefix = "embedded:"
+// Keep the stored prefix compatible with existing provenance records.
+const callerSuppliedSourceKindPrefix = "embedded:"
 
 func publicProvenanceSourceKind(kind string) string {
-	if embedded, ok := strings.CutPrefix(kind, embeddedSourceKindPrefix); ok {
-		return embedded
+	if supplied, ok := strings.CutPrefix(kind, callerSuppliedSourceKindPrefix); ok {
+		return supplied
 	}
 	return kind
 }
@@ -36,18 +37,18 @@ func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) 
 	return s.beginIngest(ctx, sourceKind, sourceDesc, sourceKind == "watch")
 }
 
-// BeginEmbeddedIngest prepares generic provenance without interpreting any
+// BeginCallerSuppliedIngest prepares generic provenance without interpreting any
 // source kind as daemon-owned operational state.
-func (s *Store) BeginEmbeddedIngest(
+func (s *Store) BeginCallerSuppliedIngest(
 	ctx context.Context, sourceKind, sourceDesc string,
 ) (IngestRun, error) {
 	if sourceKind == "" {
-		return IngestRun{}, errors.New("embedded provenance source kind is required")
+		return IngestRun{}, errors.New("caller-supplied provenance source kind is required")
 	}
-	if err := validateUTF8Field("embedded provenance source kind", sourceKind); err != nil {
+	if err := validateUTF8Field("caller-supplied provenance source kind", sourceKind); err != nil {
 		return IngestRun{}, err
 	}
-	return s.beginIngest(ctx, embeddedSourceKindPrefix+sourceKind, sourceDesc, false)
+	return s.beginIngest(ctx, callerSuppliedSourceKindPrefix+sourceKind, sourceDesc, false)
 }
 
 func (s *Store) beginIngest(
@@ -267,7 +268,7 @@ func sameOriginTx(
 			return false, fmt.Errorf("scanning provenance of node %d: %w", nodeID, err)
 		}
 		sawProvenance = true
-		if strings.HasPrefix(storedSourceKind, embeddedSourceKindPrefix) {
+		if strings.HasPrefix(storedSourceKind, callerSuppliedSourceKindPrefix) {
 			continue
 		}
 		if storedSourceKind != sourceKind {

--- a/internal/store/ingest_test.go
+++ b/internal/store/ingest_test.go
@@ -78,7 +78,7 @@ func TestIngestFileIdempotency(t *testing.T) {
 func TestFilesystemIngestDoesNotAdoptEmbeddedOpaqueReference(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
-	embedded, err := s.BeginEmbeddedIngest(ctx, "cli", "application archive")
+	embedded, err := s.BeginCallerSuppliedIngest(ctx, "cli", "application archive")
 	require.NoError(t, err)
 	embeddedNode, err := s.IngestFileExact(
 		ctx, embedded, s.RootID(), "archived.pdf", fakeHash("a1"), 10,
@@ -101,7 +101,7 @@ func TestFilesystemIngestDoesNotAdoptEmbeddedOpaqueReference(t *testing.T) {
 func TestEmbeddedWatchKindIsPortableProvenanceNotOperationalState(t *testing.T) {
 	ctx := t.Context()
 	source := newTestStore(t)
-	run, err := source.BeginEmbeddedIngest(ctx, "watch", "application archive")
+	run, err := source.BeginCallerSuppliedIngest(ctx, "watch", "application archive")
 	require.NoError(t, err)
 	node, err := source.IngestFileExact(
 		ctx, run, source.RootID(), "record.jsonl", fakeHash("a1"), 10,

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -1736,10 +1736,10 @@ func validateMetadataTime(field, value string) error {
 func validateProvenanceTime(value string) error {
 	parsed, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {
-		return fmt.Errorf("invalid provenance original_mtime: %w", err)
+		return fmt.Errorf("%w: %w", ErrInvalidProvenanceTime, err)
 	}
 	if value != parsed.UTC().Format(time.RFC3339Nano) {
-		return errors.New("invalid provenance original_mtime: timestamp is not canonical UTC RFC3339Nano")
+		return fmt.Errorf("%w: timestamp is not canonical UTC RFC3339Nano", ErrInvalidProvenanceTime)
 	}
 	return nil
 }

--- a/internal/store/provenance_write.go
+++ b/internal/store/provenance_write.go
@@ -1,0 +1,163 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ProvenanceAppendInput describes one post-ingest origin assertion. A positive
+// IfRevision is required; UnconditionalRev is reserved for embedded callers
+// that have already serialized the operation through their own lifecycle.
+type ProvenanceAppendInput struct {
+	NodeID            int64
+	IfRevision        int64
+	SourceKind        string
+	SourceDescription string
+	OriginalPath      string
+	OriginalMTime     *string
+	Supersedes        *string
+}
+
+// ProvenanceAppendResult is the authority committed by AppendNodeProvenance.
+type ProvenanceAppendResult struct {
+	Node Node
+	Path string
+	Fact ProvenanceFact
+}
+
+// AppendNodeProvenance appends one immutable origin assertion and advances
+// the target node revision in the same metadata transaction.
+func (s *Store) AppendNodeProvenance(
+	ctx context.Context, input ProvenanceAppendInput,
+) (ProvenanceAppendResult, error) {
+	if input.NodeID < 1 {
+		return ProvenanceAppendResult{}, fmt.Errorf("provenance node ID must be positive: %w", ErrNotFound)
+	}
+	if input.IfRevision < 1 && input.IfRevision != UnconditionalRev {
+		return ProvenanceAppendResult{}, errors.New("provenance revision must be positive")
+	}
+	mtime := ""
+	if input.OriginalMTime != nil {
+		if *input.OriginalMTime == "" {
+			return ProvenanceAppendResult{}, fmt.Errorf("%w: timestamp must not be empty", ErrInvalidProvenanceTime)
+		}
+		mtime = *input.OriginalMTime
+	}
+	if err := validateProvenanceSourceFields(
+		input.SourceKind, input.SourceDescription, input.OriginalPath, mtime,
+	); err != nil {
+		return ProvenanceAppendResult{}, err
+	}
+	if input.Supersedes != nil && *input.Supersedes == "" {
+		return ProvenanceAppendResult{}, fmt.Errorf("superseded provenance identity is empty: %w", ErrProvenanceMismatch)
+	}
+	run, err := s.beginIngest(ctx, embeddedSourceKindPrefix+input.SourceKind, input.SourceDescription, false)
+	if err != nil {
+		return ProvenanceAppendResult{}, err
+	}
+	var result ProvenanceAppendResult
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		prior, err := nodeByIDTx(tx, input.NodeID)
+		if err != nil {
+			return err
+		}
+		if prior.IsDir() {
+			return fmt.Errorf("node %d: %w", input.NodeID, ErrNotFile)
+		}
+		if input.IfRevision != UnconditionalRev && prior.Revision != input.IfRevision {
+			return fmt.Errorf("node %d at revision %d, expected %d: %w",
+				input.NodeID, prior.Revision, input.IfRevision, ErrStaleRevision)
+		}
+		if input.Supersedes != nil {
+			if err := validateProvenancePredecessorTx(ctx, tx, input.NodeID, *input.Supersedes); err != nil {
+				return err
+			}
+		}
+		activeAudit, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if _, err := ensureIngestRunTx(ctx, tx, run); err != nil {
+			return err
+		}
+		provenance := metadataProvenance{
+			Type: metadataProvenanceType, NodeID: input.NodeID, IngestID: run.record.ID,
+			OriginalPath: input.OriginalPath, OriginalMTime: input.OriginalMTime,
+			Supersedes: input.Supersedes,
+		}
+		provenance.Identity, err = provenanceIdentity(provenance)
+		if err != nil {
+			return fmt.Errorf("identifying appended provenance: %w", err)
+		}
+		if err := validateProvenanceRecord(provenance); err != nil {
+			return fmt.Errorf("validating appended provenance: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO provenance(
+			identity,node_id,ingest_id,original_path,original_mtime,supersedes)
+			VALUES(?,?,?,?,?,?)`, provenance.Identity, provenance.NodeID, provenance.IngestID,
+			provenance.OriginalPath, nullString(provenance.OriginalMTime), nullString(provenance.Supersedes)); err != nil {
+			return fmt.Errorf("recording appended provenance: %w", err)
+		}
+		if err := bumpRevisionTx(tx, input.NodeID, run.record.StartedAt); err != nil {
+			return err
+		}
+		result.Node, err = nodeByIDTx(tx, input.NodeID)
+		if err != nil {
+			return err
+		}
+		if result.Node.TrashedAt == nil {
+			result.Path, err = pathOf(ctx, tx, input.NodeID)
+			if err != nil {
+				return err
+			}
+		}
+		result.Fact = ProvenanceFact{
+			Identity: provenance.Identity, NodeID: provenance.NodeID, IngestID: run.record.ID,
+			IngestStartedAt: run.record.StartedAt, SourceKind: input.SourceKind,
+			SourceDescription: input.SourceDescription, OriginalPath: input.OriginalPath,
+			OriginalMTime: input.OriginalMTime, Supersedes: input.Supersedes, Active: true,
+		}
+		if !activeAudit {
+			return nil
+		}
+		authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, input.NodeID)
+		if err != nil {
+			return err
+		}
+		return persistAuditedProvenanceAppend(ctx, tx, s.vaultID, run.record.ID,
+			run.record.StartedAt, nodeSequence, authority, scopes, prior, result.Node, run.record, provenance)
+	})
+	if err != nil {
+		return ProvenanceAppendResult{}, err
+	}
+	return result, nil
+}
+
+func validateProvenancePredecessorTx(
+	ctx context.Context, tx *sql.Tx, nodeID int64, identity string,
+) error {
+	var predecessorNode int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT node_id FROM provenance WHERE identity=?`, identity,
+	).Scan(&predecessorNode); errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("provenance predecessor %s was not found: %w", identity, ErrProvenanceMismatch)
+	} else if err != nil {
+		return fmt.Errorf("reading provenance predecessor %s: %w", identity, err)
+	}
+	if predecessorNode != nodeID {
+		return fmt.Errorf("provenance predecessor %s belongs to node %d, not %d: %w",
+			identity, predecessorNode, nodeID, ErrProvenanceMismatch)
+	}
+	var successor int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM provenance WHERE supersedes=?)`, identity,
+	).Scan(&successor); err != nil {
+		return fmt.Errorf("checking provenance predecessor %s: %w", identity, err)
+	}
+	if successor != 0 {
+		return fmt.Errorf("provenance predecessor %s is already superseded: %w", identity, ErrProvenanceMismatch)
+	}
+	return nil
+}

--- a/internal/store/provenance_write.go
+++ b/internal/store/provenance_write.go
@@ -53,7 +53,7 @@ func (s *Store) AppendNodeProvenance(
 	if input.Supersedes != nil && *input.Supersedes == "" {
 		return ProvenanceAppendResult{}, fmt.Errorf("superseded provenance identity is empty: %w", ErrProvenanceMismatch)
 	}
-	run, err := s.beginIngest(ctx, embeddedSourceKindPrefix+input.SourceKind, input.SourceDescription, false)
+	run, err := s.BeginCallerSuppliedIngest(ctx, input.SourceKind, input.SourceDescription)
 	if err != nil {
 		return ProvenanceAppendResult{}, err
 	}

--- a/internal/store/provenance_write.go
+++ b/internal/store/provenance_write.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // ProvenanceAppendInput describes one post-ingest origin assertion. A positive
@@ -139,9 +140,11 @@ func validateProvenancePredecessorTx(
 	ctx context.Context, tx *sql.Tx, nodeID int64, identity string,
 ) error {
 	var predecessorNode int64
+	var sourceKind string
 	if err := tx.QueryRowContext(ctx,
-		`SELECT node_id FROM provenance WHERE identity=?`, identity,
-	).Scan(&predecessorNode); errors.Is(err, sql.ErrNoRows) {
+		`SELECT p.node_id, i.source_kind
+		 FROM provenance p JOIN ingests i ON i.id=p.ingest_id WHERE p.identity=?`, identity,
+	).Scan(&predecessorNode, &sourceKind); errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("provenance predecessor %s was not found: %w", identity, ErrProvenanceMismatch)
 	} else if err != nil {
 		return fmt.Errorf("reading provenance predecessor %s: %w", identity, err)
@@ -149,6 +152,11 @@ func validateProvenancePredecessorTx(
 	if predecessorNode != nodeID {
 		return fmt.Errorf("provenance predecessor %s belongs to node %d, not %d: %w",
 			identity, predecessorNode, nodeID, ErrProvenanceMismatch)
+	}
+	// Operational facts anchor re-ingest idempotency. Corrections may retire
+	// caller-supplied evidence, but must leave those ingest observations active.
+	if !strings.HasPrefix(sourceKind, callerSuppliedSourceKindPrefix) {
+		return fmt.Errorf("operational ingest provenance cannot be superseded: %w", ErrProvenanceMismatch)
 	}
 	var successor int
 	if err := tx.QueryRowContext(ctx,

--- a/internal/store/provenance_write_test.go
+++ b/internal/store/provenance_write_test.go
@@ -1,0 +1,200 @@
+package store
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendNodeProvenanceAppendsAndFencesHistory(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	run, err := s.BeginIngest(ctx, "cli", "/source")
+	require.NoError(t, err)
+	node, err := s.IngestFileExact(ctx, run, s.RootID(), "report.txt", fakeHash("a1"),
+		7, "text/plain", "/source/report.txt", "")
+	require.NoError(t, err)
+
+	mtime := "2026-08-26T12:00:00Z"
+	first, err := s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+		SourceDescription: "triage", OriginalPath: "laptop/Downloads/report.txt",
+		OriginalMTime: &mtime,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, node.Revision+1, first.Node.Revision)
+	assert.Equal(t, "/report.txt", first.Path)
+	assert.Equal(t, "agent", first.Fact.SourceKind)
+	assert.True(t, first.Fact.Active)
+
+	second, err := s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: first.Node.Revision, SourceKind: "agent",
+		SourceDescription: "reconcile", OriginalPath: "drive/report.txt",
+		Supersedes: &first.Fact.Identity,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, first.Node.Revision+1, second.Node.Revision)
+	assert.Equal(t, &first.Fact.Identity, second.Fact.Supersedes)
+
+	page, err := s.NodeProvenance(ctx, node.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 3)
+	active := make(map[string]bool, len(page.Items))
+	for _, item := range page.Items {
+		active[item.Identity] = item.Active
+	}
+	assert.True(t, active[second.Fact.Identity])
+	assert.False(t, active[first.Fact.Identity])
+	_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: first.Node.Revision, SourceKind: "agent",
+		SourceDescription: "stale", OriginalPath: "stale",
+	})
+	require.ErrorIs(t, err, ErrStaleRevision)
+	_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: second.Node.Revision, SourceKind: "agent",
+		SourceDescription: "bad", OriginalPath: "bad", Supersedes: &first.Fact.Identity,
+	})
+	require.ErrorIs(t, err, ErrProvenanceMismatch)
+	_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: s.RootID(), IfRevision: 1, SourceKind: "agent",
+		SourceDescription: "dir", OriginalPath: "dir",
+	})
+	require.ErrorIs(t, err, ErrNotFile)
+	other, err := s.CreateFile(ctx, s.RootID(), "other.txt", fakeHash("b2"), 7, "text/plain")
+	require.NoError(t, err)
+	_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: other.ID, IfRevision: other.Revision, SourceKind: "agent",
+		SourceDescription: "cross-node", OriginalPath: "other", Supersedes: &second.Fact.Identity,
+	})
+	require.ErrorIs(t, err, ErrProvenanceMismatch)
+	_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: 99999, IfRevision: 1, SourceKind: "agent",
+		SourceDescription: "missing", OriginalPath: "missing",
+	})
+	require.ErrorIs(t, err, ErrNotFound)
+	require.NoError(t, s.ValidateMetadata(ctx))
+}
+
+// TestAppendNodeProvenanceWatchKindStaysEvidenceOnly pins the generic-source
+// negative space: appending a fact whose caller-supplied kind is "watch"
+// records the evidence string and nothing operational; no watch_sources row
+// appears, because the internal ingest run is namespaced under "embedded:".
+func TestAppendNodeProvenanceWatchKindStaysEvidenceOnly(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	run, err := s.BeginIngest(ctx, "cli", "/source")
+	require.NoError(t, err)
+	node, err := s.IngestFileExact(ctx, run, s.RootID(), "watched.txt", fakeHash("w1"),
+		4, "text/plain", "/source/watched.txt", "")
+	require.NoError(t, err)
+
+	appended, err := s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "watch",
+		SourceDescription: "inbox sweep", OriginalPath: "inbox/watched.txt",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "watch", appended.Fact.SourceKind, "the evidence string reads back verbatim")
+
+	var watchRows int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM watch_sources`).Scan(&watchRows))
+	assert.Zero(t, watchRows, "a watch-kind fact must not create operational watch state")
+}
+
+func TestAppendNodeProvenanceRejectsMissingPredecessor(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	// CreateFile leaves the node with no provenance facts at all, so the
+	// supersedes target cannot exist anywhere; the append must fail before
+	// writing and leave node revision and history untouched.
+	node, err := s.CreateFile(ctx, s.RootID(), "bare.txt", fakeHash("c3"), 5, "text/plain")
+	require.NoError(t, err)
+	missing := fakeHash("no-such-fact")
+	_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+		SourceDescription: "orphan correction", OriginalPath: "laptop/bare.txt",
+		Supersedes: &missing,
+	})
+	require.ErrorIs(t, err, ErrProvenanceMismatch)
+	require.ErrorContains(t, err, "was not found")
+
+	refreshed, err := s.NodeByID(ctx, node.ID)
+	require.NoError(t, err)
+	assert.Equal(t, node.Revision, refreshed.Revision, "failed append must not advance the revision")
+	page, err := s.NodeProvenance(ctx, node.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Empty(t, page.Items, "failed append must not record a fact")
+}
+
+func TestAppendNodeProvenanceReturnsEmptyPathForTrashedNodes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	trashRoot, err := s.CreateFile(ctx, s.RootID(), "trash-root.txt", fakeHash("a1"), 1, "text/plain")
+	require.NoError(t, err)
+	trashedRoot, _, err := s.Trash(ctx, trashRoot.ID, trashRoot.Revision)
+	require.NoError(t, err)
+	appendedRoot, err := s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: trashedRoot.ID, IfRevision: trashedRoot.Revision, SourceKind: "agent",
+		SourceDescription: "trash-root", OriginalPath: "opaque://trash-root",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, appendedRoot.Path)
+	assert.NotNil(t, appendedRoot.Node.TrashedAt)
+
+	directory, err := s.Mkdir(ctx, s.RootID(), "trash-parent")
+	require.NoError(t, err)
+	child, err := s.CreateFile(ctx, directory.ID, "child.txt", fakeHash("b2"), 1, "text/plain")
+	require.NoError(t, err)
+	directory, err = s.NodeByID(ctx, directory.ID)
+	require.NoError(t, err)
+	_, _, err = s.Trash(ctx, directory.ID, directory.Revision)
+	require.NoError(t, err)
+	trashedChild, err := s.NodeByID(ctx, child.ID)
+	require.NoError(t, err)
+	appendedChild, err := s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: trashedChild.ID, IfRevision: trashedChild.Revision, SourceKind: "agent",
+		SourceDescription: "trash-child", OriginalPath: "opaque://trash-child",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, appendedChild.Path)
+	assert.NotNil(t, appendedChild.Node.TrashedAt)
+}
+
+func TestAppendNodeProvenanceRejectsInvalidOriginalMTime(t *testing.T) {
+	s := newTestStore(t)
+	node, err := s.CreateFile(t.Context(), s.RootID(), "report.txt", fakeHash("a1"), 1, "text/plain")
+	require.NoError(t, err)
+	for _, value := range []string{"not-a-time", "2026-08-26T14:00:00+02:00", ""} {
+		_, err = s.AppendNodeProvenance(t.Context(), ProvenanceAppendInput{
+			NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+			SourceDescription: "invalid-time", OriginalPath: "opaque://report", OriginalMTime: &value,
+		})
+		require.ErrorIs(t, err, ErrInvalidProvenanceTime)
+	}
+}
+
+func TestAppendNodeProvenanceAuditedRoundTrips(t *testing.T) {
+	s := newTestStore(t)
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	target, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+
+	appended, err := s.AppendNodeProvenance(t.Context(), ProvenanceAppendInput{
+		NodeID: target.ID, IfRevision: target.Revision, SourceKind: "agent",
+		SourceDescription: "reconcile", OriginalPath: "opaque://report",
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored := newTestStore(t)
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	require.NoError(t, restored.ValidateMetadata(t.Context()))
+	page, err := restored.NodeProvenance(t.Context(), target.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, appended.Fact.Identity, page.Items[0].Identity)
+}

--- a/internal/store/provenance_write_test.go
+++ b/internal/store/provenance_write_test.go
@@ -127,6 +127,61 @@ func TestAppendNodeProvenanceRejectsMissingPredecessor(t *testing.T) {
 	assert.Empty(t, page.Items, "failed append must not record a fact")
 }
 
+func TestAppendNodeProvenancePreservesOperationalIngest(t *testing.T) {
+	for _, kind := range []string{"cli", "watch"} {
+		t.Run(kind, func(t *testing.T) {
+			s := newTestStore(t)
+			ctx := t.Context()
+			run, err := s.BeginIngest(ctx, kind, "source")
+			require.NoError(t, err)
+			originalPath := "/source/report.txt"
+			if kind == "watch" {
+				originalPath = "report.txt"
+			}
+			node, added, err := s.IngestFile(ctx, run, s.RootID(), "report.txt", fakeHash("a1"),
+				7, "text/plain", originalPath, "")
+			require.NoError(t, err)
+			require.True(t, added)
+			seedInitialAuditAuthority(t, s, s.RootID())
+			page, err := s.NodeProvenance(ctx, node.ID, 10, 0)
+			require.NoError(t, err)
+			require.Len(t, page.Items, 1)
+			var before bytes.Buffer
+			require.NoError(t, s.ExportMetadata(ctx, &before))
+
+			_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+				NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+				SourceDescription: "reconcile", OriginalPath: "opaque://report",
+				Supersedes: &page.Items[0].Identity,
+			})
+			require.ErrorIs(t, err, ErrProvenanceMismatch)
+			var after bytes.Buffer
+			require.NoError(t, s.ExportMetadata(ctx, &after))
+			assert.Equal(t, before.String(), after.String(), "rejection must leave all metadata unchanged")
+
+			appended, err := s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+				NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+				SourceDescription: "reconcile", OriginalPath: "opaque://report",
+			})
+			require.NoError(t, err)
+			_, err = s.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+				NodeID: node.ID, IfRevision: appended.Node.Revision, SourceKind: "agent",
+				SourceDescription: "correction", OriginalPath: "opaque://corrected",
+				Supersedes: &appended.Fact.Identity,
+			})
+			require.NoError(t, err)
+			retryRun, err := s.BeginIngest(ctx, kind, "source")
+			require.NoError(t, err)
+			retry, added, err := s.IngestFile(ctx, retryRun, s.RootID(), "report.txt", fakeHash("a1"),
+				7, "text/plain", originalPath, "")
+			require.NoError(t, err)
+			assert.False(t, added)
+			assert.Equal(t, node.ID, retry.ID)
+			require.NoError(t, s.ValidateMetadata(ctx))
+		})
+	}
+}
+
 func TestAppendNodeProvenanceReturnsEmptyPathForTrashedNodes(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -267,7 +267,7 @@ func (s *Store) ConfirmIngestedContentWithReceipt(
 	); err != nil {
 		return ContentWriteReceipt{}, err
 	}
-	storedSourceKind := embeddedSourceKindPrefix + sourceKind
+	storedSourceKind := callerSuppliedSourceKindPrefix + sourceKind
 	var receipt ContentWriteReceipt
 	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		n, err := nodeByIDTx(tx, nodeID)

--- a/types.go
+++ b/types.go
@@ -138,6 +138,23 @@ type ProvenancePage struct {
 	Offset int              `json:"offset"`
 }
 
+// ProvenanceAppendOptions describes one origin assertion added after ingest.
+// A zero IfRevision is unconditional for embedded callers; a positive value
+// must match the node's current revision.
+type ProvenanceAppendOptions struct {
+	Source     ProvenanceSource
+	Supersedes *string
+	IfRevision int64
+}
+
+// ProvenanceAppendReceipt binds the appended fact to the resulting node and
+// its transactionally captured path.
+type ProvenanceAppendReceipt struct {
+	Node Node           `json:"node"`
+	Path string         `json:"path,omitzero"`
+	Fact ProvenanceFact `json:"fact"`
+}
+
 // PutReceipt proves the computed identity and resulting logical authority.
 type PutReceipt struct {
 	Node            Node            `json:"node"`

--- a/types.go
+++ b/types.go
@@ -141,6 +141,8 @@ type ProvenancePage struct {
 // ProvenanceAppendOptions describes one origin assertion added after ingest.
 // A zero IfRevision is unconditional for embedded callers; a positive value
 // must match the node's current revision.
+// Supersedes may name an active caller-supplied fact on the same node,
+// including create-time provenance, but never an operational ingest fact.
 type ProvenanceAppendOptions struct {
 	Source     ProvenanceSource
 	Supersedes *string

--- a/vault.go
+++ b/vault.go
@@ -63,6 +63,9 @@ var (
 	ErrNotTrashed               = store.ErrNotTrashed
 	ErrIsRoot                   = store.ErrIsRoot
 	ErrAuditMutationUnsupported = store.ErrAuditMutationUnsupported
+	// ErrProvenanceMismatch reports a provenance correction whose predecessor
+	// is missing, belongs to another node, or is already superseded.
+	ErrProvenanceMismatch = store.ErrProvenanceMismatch
 )
 
 const (
@@ -663,6 +666,51 @@ func (v *Vault) Provenance(
 		result.Items = append(result.Items, fromStoreProvenance(fact))
 	}
 	return result, nil
+}
+
+// AppendProvenance adds one immutable origin fact under the node revision
+// precondition and returns the resulting node, fact, and live path.
+func (v *Vault) AppendProvenance(
+	ctx context.Context, nodeID int64, opts ProvenanceAppendOptions,
+) (ProvenanceAppendReceipt, error) {
+	if err := v.begin(); err != nil {
+		return ProvenanceAppendReceipt{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	if err := validateProvenanceSource(opts.Source); err != nil {
+		return ProvenanceAppendReceipt{}, err
+	}
+	if opts.IfRevision < 0 {
+		return ProvenanceAppendReceipt{}, errors.New("docbank provenance revision must not be negative")
+	}
+	ifRevision := store.UnconditionalRev
+	if opts.IfRevision > 0 {
+		ifRevision = opts.IfRevision
+	}
+	v.mutation.Lock()
+	defer v.mutation.Unlock()
+	if err := ctx.Err(); err != nil {
+		return ProvenanceAppendReceipt{}, err
+	}
+	result, err := v.metadata.AppendNodeProvenance(ctx, store.ProvenanceAppendInput{
+		NodeID: nodeID, IfRevision: ifRevision, SourceKind: opts.Source.Kind,
+		SourceDescription: opts.Source.Description, OriginalPath: opts.Source.Reference,
+		OriginalMTime: provenanceStringPtr(opts.Source.ModifiedAt), Supersedes: opts.Supersedes,
+	})
+	if err != nil {
+		return ProvenanceAppendReceipt{}, err
+	}
+	return ProvenanceAppendReceipt{
+		Node: fromStoreNode(result.Node), Path: result.Path, Fact: fromStoreProvenance(result.Fact),
+	}, nil
+}
+
+func provenanceStringPtr(value *time.Time) *string {
+	if value == nil {
+		return nil
+	}
+	result := value.UTC().Format(time.RFC3339Nano)
+	return &result
 }
 
 // MovePath renames or reparents one live path and returns its canonical new

--- a/vault.go
+++ b/vault.go
@@ -1092,7 +1092,7 @@ func (v *Vault) write(
 					ctx, parent.ID, name, hash, size, opts.MediaType, physical,
 				)
 			} else {
-				run, beginErr := v.metadata.BeginEmbeddedIngest(
+				run, beginErr := v.metadata.BeginCallerSuppliedIngest(
 					ctx, provenance.Kind, provenance.Description,
 				)
 				if beginErr != nil {

--- a/vault_test.go
+++ b/vault_test.go
@@ -482,6 +482,113 @@ func TestEmbeddedCreateRecordsGenericProvenance(t *testing.T) {
 	}
 }
 
+func TestEmbeddedAppendProvenanceReturnsRevisionBoundReceipt(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	content := []byte("embedded provenance")
+	created, err := vault.Create(t.Context(), "/report.txt", bytes.NewReader(content), CreateOptions{
+		MediaType: "text/plain", Expected: contentIdentity(content),
+	})
+	require.NoError(t, err)
+	receipt, err := vault.AppendProvenance(t.Context(), created.Node.ID, ProvenanceAppendOptions{
+		IfRevision: created.Node.Revision,
+		Source:     ProvenanceSource{Kind: "agent", Description: "triage", Reference: "opaque://embedded"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, created.Node.ID, receipt.Node.ID)
+	assert.Equal(t, created.Node.Revision+1, receipt.Node.Revision)
+	assert.Equal(t, "/report.txt", receipt.Path)
+	assert.Equal(t, "opaque://embedded", receipt.Fact.SourceReference)
+}
+
+// TestEmbeddedAppendProvenanceCoversAdapterBranches exercises the embedded
+// adapter's own branches: mtime conversion to canonical UTC, unconditional
+// and negative revision handling, supersession, stale-revision conflict, and
+// the empty live path for a trashed node, on both SQLite drivers.
+func TestEmbeddedAppendProvenanceCoversAdapterBranches(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver docsqlite.Driver
+	}{
+		{name: "build default"},
+		{name: "pure Go", driver: modernc.Driver{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			testEmbeddedAppendProvenanceAdapterBranches(t, test.driver)
+		})
+	}
+}
+
+func testEmbeddedAppendProvenanceAdapterBranches(t *testing.T, driver docsqlite.Driver) {
+	t.Helper()
+	vault, err := New(t.Context(), Config{Root: t.TempDir(), SQLite: driver})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	content := []byte("adapter branches")
+	created, err := vault.Create(t.Context(), "/branches.txt", bytes.NewReader(content), CreateOptions{
+		MediaType: "text/plain", Expected: contentIdentity(content),
+	})
+	require.NoError(t, err)
+
+	_, err = vault.AppendProvenance(t.Context(), created.Node.ID, ProvenanceAppendOptions{
+		IfRevision: -1,
+		Source:     ProvenanceSource{Kind: "agent", Description: "triage", Reference: "opaque://x"},
+	})
+	require.ErrorContains(t, err, "revision must not be negative")
+
+	// Non-UTC ModifiedAt converts to canonical UTC RFC3339Nano; IfRevision 0
+	// takes the unconditional branch.
+	modified := time.Date(2026, time.July, 20, 15, 4, 5, 0, time.FixedZone("source", -5*60*60))
+	first, err := vault.AppendProvenance(t.Context(), created.Node.ID, ProvenanceAppendOptions{
+		Source: ProvenanceSource{Kind: "agent", Description: "triage",
+			Reference: "opaque://laptop/branches.txt", ModifiedAt: &modified},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, first.Fact.SourceModifiedAt)
+	assert.Equal(t, modified.UTC().Format(time.RFC3339Nano), *first.Fact.SourceModifiedAt,
+		"mtime converts to canonical UTC RFC3339Nano without losing the instant")
+	assert.True(t, first.Fact.Active)
+
+	// A stale revision conflicts instead of appending.
+	_, err = vault.AppendProvenance(t.Context(), created.Node.ID, ProvenanceAppendOptions{
+		IfRevision: created.Node.Revision,
+		Source:     ProvenanceSource{Kind: "agent", Description: "late", Reference: "opaque://stale"},
+	})
+	require.ErrorIs(t, err, store.ErrStaleRevision)
+
+	// A correction supersedes the active fact and keeps it addressable.
+	second, err := vault.AppendProvenance(t.Context(), created.Node.ID, ProvenanceAppendOptions{
+		IfRevision: first.Node.Revision,
+		Source: ProvenanceSource{Kind: "agent", Description: "corrected",
+			Reference: "opaque://desktop/branches.txt"},
+		Supersedes: &first.Fact.Identity,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, second.Fact.Supersedes)
+	assert.Equal(t, first.Fact.Identity, *second.Fact.Supersedes)
+
+	// A correction naming a missing predecessor classifies through the
+	// public sentinel.
+	missing := strings.Repeat("cd", 32)
+	_, err = vault.AppendProvenance(t.Context(), created.Node.ID, ProvenanceAppendOptions{
+		Source:     ProvenanceSource{Kind: "agent", Description: "orphan", Reference: "opaque://o"},
+		Supersedes: &missing,
+	})
+	require.ErrorIs(t, err, ErrProvenanceMismatch)
+
+	// A trashed node still accepts appends but reports no live path.
+	_, err = vault.TrashPath(t.Context(), "/branches.txt", RevisionOptions{})
+	require.NoError(t, err)
+	trashed, err := vault.AppendProvenance(t.Context(), created.Node.ID, ProvenanceAppendOptions{
+		Source: ProvenanceSource{Kind: "agent", Description: "post-trash", Reference: "opaque://t"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, trashed.Path, "a trashed node has no live path in the receipt")
+}
+
 func testEmbeddedCreateRecordsGenericProvenance(t *testing.T, driver docsqlite.Driver) {
 	t.Helper()
 	vault, err := New(t.Context(), Config{Root: t.TempDir(), SQLite: driver})

--- a/vault_test.go
+++ b/vault_test.go
@@ -645,6 +645,24 @@ func testEmbeddedCreateRecordsGenericProvenance(t *testing.T, driver docsqlite.D
 		t.Context(), "/sessions/01K123.jsonl", bytes.NewReader(content), different,
 	)
 	require.ErrorIs(t, err, ErrContentConflict)
+
+	_, err = vault.AppendProvenance(t.Context(), created.Node.ID, ProvenanceAppendOptions{
+		IfRevision: created.Node.Revision, Source: *different.Provenance,
+		Supersedes: &fact.Identity,
+	})
+	require.NoError(t, err)
+	// A retry must match active evidence, even if its original fact remains
+	// in history. Supersession does not create a new content version.
+	_, err = vault.Create(
+		t.Context(), "/sessions/01K123.jsonl", bytes.NewReader(content), opts,
+	)
+	require.ErrorIs(t, err, ErrContentConflict)
+	retry, err = vault.Create(
+		t.Context(), "/sessions/01K123.jsonl", bytes.NewReader(content), different,
+	)
+	require.NoError(t, err)
+	require.False(t, retry.Created)
+	require.Equal(t, created.Version.ID, retry.Version.ID)
 }
 
 func TestEmbeddedAuditedCreateRecordsProvenance(t *testing.T) {


### PR DESCRIPTION
After Docbank imports a file from a Google Drive mount, a filing agent can now add its original laptop location to the document's provenance through the HTTP or embedded Go API. Previously, provenance recorded only what was known at ingest, leaving agents to keep later evidence in tags or a separate journal.

Each append preserves document content and advances the node revision once. HTTP callers supply the current revision in `If-Match`; embedded callers can omit that check. When auditing is active, the fact and its audit records commit together. Source references remain evidence that Docbank stores without opening.

Corrections append a successor to an active caller-supplied fact on the same document and preserve the earlier fact in history. CLI and watched-folder ingest facts stay active so subsequent imports recognize the existing document. Correcting provenance supplied through embedded `Create` makes the original request return `ErrContentConflict` unless another active fact still matches.

Refs #218
