### PR TITLE
feat(ingest): add a replace mode to local add

### DIFF
--- a/cmd/docbank/add.go
+++ b/cmd/docbank/add.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json/jsontext"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -19,6 +20,7 @@ var (
 	addDest      string
 	addInclude   []string
 	addExclude   []string
+	addReplace   bool
 	addPreflight bool
 	addJSON      bool
 	addProgress  string
@@ -44,6 +46,10 @@ var addCmd = &cobra.Command{
 			}
 			abs[i] = p
 		}
+		if addPreflight && addReplace {
+			return usageError(errors.New("--replace cannot be used with --preflight"))
+		}
+		opts := client.IngestOptions{Include: addInclude, Exclude: addExclude, Replace: addReplace}
 		c, err := client.Ensure(cmd.Context())
 		if err != nil {
 			return err
@@ -69,7 +75,7 @@ var addCmd = &cobra.Command{
 		}
 		var rep api.IngestReport
 		if addJSON {
-			rep, err = c.IngestWithOptions(cmd.Context(), abs, addDest, addInclude, addExclude)
+			rep, err = c.IngestWithOptions(cmd.Context(), abs, addDest, opts)
 		} else {
 			mode, modeErr := progressModeFromFlag("add", addProgress)
 			if modeErr != nil {
@@ -77,7 +83,7 @@ var addCmd = &cobra.Command{
 			}
 			renderer := newIngestProgressRenderer(cmd.ErrOrStderr(), mode)
 			defer renderer.finish()
-			rep, err = c.IngestStream(cmd.Context(), abs, addDest, addInclude, addExclude, renderer.handle)
+			rep, err = c.IngestStream(cmd.Context(), abs, addDest, opts, renderer.handle)
 		}
 		if err != nil {
 			return err
@@ -107,6 +113,8 @@ func init() {
 		"include files matching a basename or source-relative path pattern (repeatable)")
 	addCmd.Flags().StringArrayVar(&addExclude, "exclude", nil,
 		"exclude files or directories matching a basename or source-relative path pattern (repeatable)")
+	addCmd.Flags().BoolVar(&addReplace, "replace", false,
+		"version the file already at each destination path instead of adding a suffixed sibling")
 	addCmd.Flags().BoolVar(&addPreflight, "preflight", false,
 		"inventory sources without opening content or changing the vault")
 	addCmd.Flags().BoolVar(&addJSON, "json", false,

--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -177,6 +177,33 @@ func TestAddLsTreeCat(t *testing.T) {
 	assert.Equal(t, "hello vault", out)
 }
 
+func TestAddReplaceVersionsExactDestination(t *testing.T) {
+	_ = setupVaultHome(t)
+	src := writeSourceFile(t, "notes.txt", "first draft")
+	_, err := runCLI(t, "add", src, "--dest", "/inbox")
+	require.NoError(t, err)
+	c, err := client.Ensure(t.Context())
+	require.NoError(t, err)
+	before, err := c.Stat(t.Context(), "/inbox/notes.txt")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(src, []byte("second draft"), 0o644))
+
+	_, err = runCLI(t, "add", src, "--dest", "/inbox", "--replace")
+	require.NoError(t, err)
+	after, err := c.Stat(t.Context(), "/inbox/notes.txt")
+	require.NoError(t, err)
+	assert.Equal(t, before.ID, after.ID)
+	assert.Equal(t, before.Revision+1, after.Revision)
+	_, err = c.Stat(t.Context(), "/inbox/notes (2).txt")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestAddReplaceRejectsPreflightBeforeEnsure(t *testing.T) {
+	src := writeSourceFile(t, "notes.txt", "synthetic")
+	_, err := runCLI(t, "add", src, "--preflight", "--replace")
+	require.ErrorContains(t, err, "--replace cannot be used with --preflight")
+}
+
 func TestTreeBoundsAndReportsOmissions(t *testing.T) {
 	_ = setupVaultHome(t)
 	c, err := client.Ensure(context.Background())

--- a/docs/agents/integration.md
+++ b/docs/agents/integration.md
@@ -615,13 +615,19 @@ an error with an escaped printable path and is never opened or imported.
 curl --fail-with-body -X POST \
   -H "X-Api-Key: $DOCBANK_API_KEY" \
   -H 'Content-Type: application/json' \
-  --data '{"paths":["/Users/me/Downloads/receipt.pdf"],"dest":"/receipts","include":[],"exclude":[]}' \
+  --data '{"paths":["/Users/me/Downloads/receipt.pdf"],"dest":"/receipts","include":[],"exclude":[],"replace":true}' \
   "$DOCBANK_URL/api/v1/ingest"
 ```
 
 Inspect `added`, `skipped`, `excluded`, and every member of `failed`. Repeating the same
 ingest after fixing a partial failure is safe; successful content converges to
-`skipped` rather than another copy.
+`skipped` rather than another copy. Set `replace` to `true` on either ingest
+form when the exact destination file represents one changing source. The
+daemon checks the destination node and revision before reading source bytes,
+versions changed content in place, skips equal hash and size without changing
+stored MIME or history, and fails directories, stale revisions, and exact-name
+create races without falling back to a suffix. Omit the field for ordinary
+suffixing.
 
 Include and exclude values use Go's `path.Match` grammar on slash-separated
 source-relative paths. Use `/` separators on every platform; backslashes are

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -328,15 +328,22 @@ in a pattern is rejected. Entries filtered by a rule are excluded without
 failure, while selected non-regular entries are reported as skipped findings.
 
 `POST /ingest` takes **server-side local paths** — `{paths: [...],
-dest: "/inbox", include: [...], exclude: [...]}` — and returns an `IngestReport` (`added`, `skipped`, `excluded`,
+dest: "/inbox", include: [...], exclude: [...], replace: false}` — and returns an `IngestReport` (`added`, `skipped`, `excluded`,
 per-path `failed` entries), backing `docbank add`. Paths must be
 **absolute**: the long-lived daemon's working directory is meaningless,
 so a relative path is rejected with `422`. The CLI resolves `docbank
 add`'s arguments to absolute paths before calling, so the command-line
 UX still accepts relative and `cwd`-relative sources. Collisions resolve by the
-same suffixing rules as other imports.
+same suffixing rules as other imports when `replace` is false or omitted.
 
-`POST /ingest/stream` accepts the same body and returns
+With `replace: true`, the daemon resolves the exact destination name and
+records its node revision before reading source content. Changed bytes create
+a new version on that node, while equal hash and size skip without changing
+the stored MIME type or version history. A live directory fails before source
+I/O. A stale revision or exact-name create race fails the file and never falls
+back to a suffix.
+
+`POST /ingest/stream` accepts the same body, including `replace`, and returns
 `application/x-ndjson`. A metadata-only `scan` stage establishes advisory file
 and byte totals, followed by `ingest` progress for bytes read and file outcomes.
 Exactly one `result` carrying `IngestReport` or `error` terminates the stream;

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,7 +92,7 @@ than translating process exits back into HTTP status.
 ## docbank add
 
 ```
-docbank add <path>... [--dest <virtual-dir>] [--include <pattern>]... [--exclude <pattern>]... [--progress auto|bar|plain] [--json]
+docbank add <path>... [--dest <virtual-dir>] [--include <pattern>]... [--exclude <pattern>]... [--replace] [--progress auto|bar|plain] [--json]
 docbank add <path>... --preflight [--include <pattern>]... [--exclude <pattern>]... [--json]
 ```
 
@@ -104,6 +104,7 @@ never modified or deleted.
 | `--dest` | `/inbox` | Virtual destination directory; created (with parents) if missing |
 | `--include` | none | Select files matching a basename or source-relative `path.Match` pattern; repeatable |
 | `--exclude` | none | Exclude files or prune directories matching a basename or source-relative `path.Match` pattern; repeatable |
+| `--replace` | false | Replace the live file at each destination path, or skip it when its bytes are unchanged |
 | `--preflight` | false | Inventory source metadata without opening file content or changing the vault |
 | `--json` | false | Emit only the terminal preflight or ingest report as JSON; suppress progress |
 | `--progress` | `auto` | Human ingest progress: `auto`, `bar`, or durable `plain` lines |
@@ -119,6 +120,12 @@ never modified or deleted.
   backslash in a pattern is rejected.
 - Name collisions with different content auto-suffix:
   `report.pdf` → `report (2).pdf`.
+- `--replace` records the destination node revision before reading the source,
+  then replaces that exact live file when the bytes differ.
+- `--replace` skips unchanged bytes without changing the stored MIME type or
+  creating a content version. A live directory fails the file. A destination
+  that appears after the pre-read fails with an exact-name conflict instead of
+  using a suffix. Without `--replace`, ordinary suffixing remains unchanged.
 - Re-running an import converges: a file whose content already exists
   under any candidate name in the destination is skipped, so an
   interrupted bulk import can simply be re-run. See

--- a/docs/internal/daemon-api-design.md
+++ b/docs/internal/daemon-api-design.md
@@ -152,6 +152,13 @@ The CLI resolves user arguments to absolute paths before sending the request,
 preserving shell-relative ergonomics. Partial source failures are returned in
 the report while other sources continue.
 
+The ingest request may carry `replace: true` for an opt-in exact destination
+policy. The daemon records the destination node revision before reading the
+source. Changed bytes create a content version on the same node, equal hash
+and size skip without changing stored MIME or history, a live directory fails
+before source I/O, and stale or exact-name create races fail the file without
+suffixing. The omitted and false values retain ordinary suffixing.
+
 `POST /uploads` is the remote counterpart, but it is deliberately one file per
 request. `parent_id` and normalized `name` identify the destination; required
 hash/size headers describe the sole multipart `file` part. File granularity

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -145,6 +145,23 @@ Two different files arriving at the same virtual name don't conflict —
 the newcomer is suffixed (`scan.pdf` → `scan (2).pdf`). The provenance
 record preserves where each one actually came from.
 
+## Replace a changing local file
+
+Use `--replace` when a repeated local add represents one changing source:
+
+```bash
+docbank add ~/reports/summary.pdf --dest /archive --replace
+```
+
+Docbank resolves the exact destination name and records its node revision
+before reading the source. Different bytes become a new content version on the
+same node, while unchanged bytes skip without changing the revision, stored
+MIME type, provenance, or version count. A live directory fails that file
+before source content is opened. If an absent destination is claimed while
+the source is read, the exact create reports a conflict and never chooses a
+suffix. A stale observed revision reports a conflict and leaves the newer
+content current. Omit `--replace` for ordinary collision suffixing.
+
 ## Inspect where a document came from
 
 Docbank keeps provenance as durable metadata rather than leaving it hidden in

--- a/document/reducto/client_test.go
+++ b/document/reducto/client_test.go
@@ -751,19 +751,23 @@ func TestClientDistinguishesPreEgressContextFailures(t *testing.T) {
 	})
 
 	t.Run("wall timeout resolving secret", func(t *testing.T) {
-		fixture := newFixture(t, "pdf", "application/pdf", "synthetic.pdf", []byte("secret wall source"))
-		fixture.profile.MaxWallTime = time.Millisecond
-		client, err := NewProvider(fixture.profile, blockingSecrets{}, completedTransport(t))
-		require.NoError(t, err)
-		descriptor := client.Descriptor()
-		fixture.authorization.ProviderID = descriptor.ID
-		fixture.authorization.DescriptorFingerprint = descriptor.Fingerprint
-		fixture.authorization.PolicyFingerprint = descriptor.PolicyFingerprint
-		fixture.authorization.AllowedArtifactRoles = nil
-		fixture.authorization.MaxArtifacts = 0
-		fixture.authorization.MaxArtifactBytes = 0
-		_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
-		assertCode(t, err, document.RenditionErrorAuthentication)
+		// Advance time only once credential resolution blocks, so source reading
+		// cannot consume the deadline on a busy runner.
+		synctest.Test(t, func(t *testing.T) {
+			fixture := newFixture(t, "pdf", "application/pdf", "synthetic.pdf", []byte("secret wall source"))
+			fixture.profile.MaxWallTime = time.Millisecond
+			client, err := NewProvider(fixture.profile, blockingSecrets{}, completedTransport(t))
+			require.NoError(t, err)
+			descriptor := client.Descriptor()
+			fixture.authorization.ProviderID = descriptor.ID
+			fixture.authorization.DescriptorFingerprint = descriptor.Fingerprint
+			fixture.authorization.PolicyFingerprint = descriptor.PolicyFingerprint
+			fixture.authorization.AllowedArtifactRoles = nil
+			fixture.authorization.MaxArtifacts = 0
+			fixture.authorization.MaxArtifactBytes = 0
+			_, err = client.Render(t.Context(), fixture.upload(), fixture.authorization)
+			assertCode(t, err, document.RenditionErrorAuthentication)
+		})
 	})
 
 	t.Run("caller cancellation resolving secret", func(t *testing.T) {

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -305,7 +305,7 @@ func ingestParams(body IngestRequest) (string, ingest.Options, ingest.Selection,
 	if err := validateIngestPaths(body.Paths); err != nil {
 		return "", ingest.Options{}, ingest.Selection{}, err
 	}
-	opts := ingest.Options{Include: body.Include, Exclude: body.Exclude}
+	opts := ingest.Options{Include: body.Include, Exclude: body.Exclude, Replace: body.Replace}
 	selection, err := ingest.CompileSelection(opts)
 	if err != nil {
 		return "", ingest.Options{}, ingest.Selection{}, NewError(http.StatusUnprocessableEntity, "validation", err.Error())

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -524,6 +524,7 @@ type IngestPreflightRequest struct {
 
 // IngestRequest imports server-side paths with optional source selection.
 type IngestRequest struct {
+	Replace bool     `json:"replace,omitempty"`
 	Paths   []string `json:"paths" minItems:"1"`
 	Dest    string   `json:"dest" default:"/inbox"`
 	Include []string `json:"include,omitempty"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1992,22 +1992,34 @@ func canonicalDirectoryPath(path string) (string, error) {
 	return "/" + strings.Join(segments, "/"), nil
 }
 
-func (c *Client) Ingest(ctx context.Context, paths []string, dest string) (api.IngestReport, error) {
-	return c.IngestWithOptions(ctx, paths, dest, nil, nil)
+// IngestOptions selects source filters and the destination policy for a
+// server-side import. The zero value keeps ordinary suffixing semantics.
+type IngestOptions struct {
+	Include []string
+	Exclude []string
+	Replace bool
 }
 
-// IngestWithOptions imports server-side paths with the same selection rules
-// accepted by PreflightIngest.
+func (o IngestOptions) requestBody(paths []string, dest string) map[string]any {
+	return map[string]any{
+		"paths": paths, "dest": dest, "include": o.Include, "exclude": o.Exclude, "replace": o.Replace,
+	}
+}
+
+func (c *Client) Ingest(ctx context.Context, paths []string, dest string) (api.IngestReport, error) {
+	return c.IngestWithOptions(ctx, paths, dest, IngestOptions{})
+}
+
+// IngestWithOptions imports server-side paths under the selected options.
 func (c *Client) IngestWithOptions(
 	ctx context.Context,
 	paths []string,
 	dest string,
-	include []string,
-	exclude []string,
+	opts IngestOptions,
 ) (api.IngestReport, error) {
 	var rep api.IngestReport
 	err := c.do(ctx, http.MethodPost, "/api/v1/ingest", nil,
-		map[string]any{"paths": paths, "dest": dest, "include": include, "exclude": exclude}, &rep)
+		opts.requestBody(paths, dest), &rep)
 	return rep, err
 }
 
@@ -2018,13 +2030,10 @@ func (c *Client) IngestStream(
 	ctx context.Context,
 	paths []string,
 	dest string,
-	include []string,
-	exclude []string,
+	opts IngestOptions,
 	progress func(api.IngestProgress),
 ) (api.IngestReport, error) {
-	body, err := marshalJSONRequest(map[string]any{
-		"paths": paths, "dest": dest, "include": include, "exclude": exclude,
-	})
+	body, err := marshalJSONRequest(opts.requestBody(paths, dest))
 	if err != nil {
 		return api.IngestReport{}, fmt.Errorf("encoding ingest request: %w", err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -462,7 +462,7 @@ func TestIngestStreamRoundTrip(t *testing.T) {
 	require.NoError(t, os.WriteFile(src, content, 0o600))
 
 	var events []api.IngestProgress
-	report, err := c.IngestStream(t.Context(), []string{src}, "/inbox", nil, nil,
+	report, err := c.IngestStream(t.Context(), []string{src}, "/inbox", client.IngestOptions{},
 		func(event api.IngestProgress) { events = append(events, event) })
 	require.NoError(t, err)
 	assert.Equal(t, 1, report.Added)
@@ -504,15 +504,52 @@ func TestIngestClientCarriesSelectionRulesToEveryRoute(t *testing.T) {
 	exclude := []string{"skip.txt"}
 	_, err := c.PreflightIngest(t.Context(), []string{"/source"}, include, exclude)
 	require.NoError(t, err)
-	_, err = c.IngestWithOptions(t.Context(), []string{"/source"}, "/inbox", include, exclude)
+	_, err = c.IngestWithOptions(t.Context(), []string{"/source"}, "/inbox", client.IngestOptions{Include: include, Exclude: exclude})
 	require.NoError(t, err)
-	_, err = c.IngestStream(t.Context(), []string{"/source"}, "/inbox", include, exclude, nil)
+	_, err = c.IngestStream(t.Context(), []string{"/source"}, "/inbox", client.IngestOptions{Include: include, Exclude: exclude}, nil)
 	require.NoError(t, err)
 	require.Len(t, bodies, 3)
 	for _, body := range bodies {
 		assert.Contains(t, body, `"include":["*.txt"]`)
 		assert.Contains(t, body, `"exclude":["skip.txt"]`)
 	}
+}
+
+func TestIngestOptionsSendReplaceToJSONAndStream(t *testing.T) {
+	var bodies []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		bodies = append(bodies, string(body))
+		if r.URL.Path == "/api/v1/ingest/stream" {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_ = json.MarshalWrite(w, api.IngestEvent{Type: "result", Report: &api.IngestReport{}})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.MarshalWrite(w, api.IngestReport{})
+	}))
+	t.Cleanup(ts.Close)
+
+	c := client.New(ts.URL, serverKey)
+	opts := client.IngestOptions{Exclude: []string{"cache"}, Replace: true}
+	_, err := c.IngestWithOptions(t.Context(), []string{"/source"}, "/inbox", opts)
+	require.NoError(t, err)
+	_, err = c.IngestStream(t.Context(), []string{"/source"}, "/inbox", opts, nil)
+	require.NoError(t, err)
+	require.Len(t, bodies, 2)
+	for _, body := range bodies {
+		assert.Contains(t, body, `"replace":true`)
+		assert.Contains(t, body, `"exclude":["cache"]`)
+	}
+}
+
+func TestNewRecordAdvertisesProtocol65(t *testing.T) {
+	record := client.NewRecord("127.0.0.1:7486", "key", "token", "")
+	assert.Equal(t, "65", record.Metadata["protocol_version"])
 }
 
 func TestProgressStreamPreservesProblemCode(t *testing.T) {
@@ -526,7 +563,7 @@ func TestProgressStreamPreservesProblemCode(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	_, err := client.New(ts.URL, "key").IngestStream(
-		t.Context(), []string{"/source"}, "/inbox", nil, nil, nil)
+		t.Context(), []string{"/source"}, "/inbox", client.IngestOptions{}, nil)
 	require.Error(t, err)
 	code, ok := client.ProblemCode(err)
 	assert.True(t, ok)
@@ -567,11 +604,11 @@ func TestJSONMethodsRejectInvalidUTF8BeforeRequest(t *testing.T) {
 		call func() error
 	}{
 		{name: "ordinary", call: func() error {
-			_, err := c.IngestWithOptions(t.Context(), []string{invalidPath}, "/inbox", nil, nil)
+			_, err := c.IngestWithOptions(t.Context(), []string{invalidPath}, "/inbox", client.IngestOptions{})
 			return err
 		}},
 		{name: "stream", call: func() error {
-			_, err := c.IngestStream(t.Context(), []string{invalidPath}, "/inbox", nil, nil, nil)
+			_, err := c.IngestStream(t.Context(), []string{invalidPath}, "/inbox", client.IngestOptions{}, nil)
 			return err
 		}},
 		{name: "preflight", call: func() error {

--- a/internal/client/runtime.go
+++ b/internal/client/runtime.go
@@ -24,7 +24,7 @@ const (
 	metaWebAddress      = "web_address"
 	// Bump whenever a newer CLI cannot safely use an older daemon's HTTP or
 	// runtime-record contract, even when both binaries report the same version.
-	daemonProtocolVersion = "64"
+	daemonProtocolVersion = "65"
 )
 
 // EnsureResult reports what EnsureDaemon found or did.

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -448,11 +448,13 @@ func (ing *Ingester) AddPathsWithSelection(
 				progress.report(rep, false)
 				continue
 			}
-			if err := ing.addOne(ctx, &rep, ingestID, dest.ID, src, src, progress); err != nil {
+			if err := ing.addOne(ctx, &rep, ingestID, dest.ID, src, src, opts.Replace, progress); err != nil {
 				return rep, err
 			}
 		case info.IsDir():
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, selection, progress); err != nil {
+			if err := ing.addTree(
+				ctx, &rep, ingestID, dest.ID, src, src, selection, opts.Replace, progress,
+			); err != nil {
 				return rep, err
 			}
 		case info.Mode()&fs.ModeSymlink != 0:
@@ -491,7 +493,9 @@ func (ing *Ingester) AddPathsWithSelection(
 				progress.report(rep, false)
 				continue
 			}
-			if err := ing.addTree(ctx, &rep, ingestID, dest.ID, src, walkRoot, selection, progress); err != nil {
+			if err := ing.addTree(
+				ctx, &rep, ingestID, dest.ID, src, walkRoot, selection, opts.Replace, progress,
+			); err != nil {
 				return rep, err
 			}
 		default:
@@ -527,6 +531,7 @@ func (ing *Ingester) addTree(
 	destDirID int64,
 	sourceRoot, walkRoot string,
 	selection sourceSelection,
+	replace bool,
 	progress *progressTracker,
 ) error {
 	// Absolutize first. WalkDir hands back the root spelled exactly as given
@@ -623,7 +628,7 @@ func (ing *Ingester) addTree(
 				}
 				return fs.SkipDir
 			}
-			if err := ing.addOne(ctx, rep, ingestRun, parentID, p, sourcePath, progress); err != nil {
+			if err := ing.addOne(ctx, rep, ingestRun, parentID, p, sourcePath, replace, progress); err != nil {
 				return err
 			}
 		default:
@@ -693,9 +698,10 @@ func (ing *Ingester) addOne(
 	ingestRun store.IngestRun,
 	parentID int64,
 	openPath, sourcePath string,
+	replace bool,
 	progress *progressTracker,
 ) error {
-	added, err := ing.importFile(ctx, ingestRun, parentID, openPath, sourcePath, progress)
+	added, err := ing.importFile(ctx, ingestRun, parentID, openPath, sourcePath, replace, progress)
 	switch {
 	case err != nil:
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -716,10 +722,34 @@ func (ing *Ingester) importFile(
 	ingestRun store.IngestRun,
 	parentID int64,
 	openPath, sourcePath string,
+	replace bool,
 	progress *progressTracker,
 ) (added bool, retErr error) {
 	if err := validateSourcePath(sourcePath); err != nil {
 		return false, err
+	}
+	var observed struct {
+		node    store.Node
+		present bool
+	}
+	var name string
+	var err error
+	if replace {
+		name, err = store.NormalizeName(filepath.Base(sourcePath))
+		if err != nil {
+			return false, fmt.Errorf("normalizing destination name for %s: %w", sourcePath, err)
+		}
+		observed.node, err = ing.Store.ChildByName(ctx, parentID, name)
+		switch {
+		case err == nil:
+			observed.present = true
+			if observed.node.IsDir() {
+				return false, fmt.Errorf("destination %s: %w", sourcePath, store.ErrNotFile)
+			}
+		case errors.Is(err, store.ErrNotFound):
+		default:
+			return false, fmt.Errorf("resolving destination %s: %w", sourcePath, err)
+		}
 	}
 	content, err := ing.readLocalFile(ctx, openPath, sourcePath, progress, nil)
 	if err != nil {
@@ -728,6 +758,31 @@ func (ing *Ingester) importFile(
 	defer func() {
 		retErr = mutationCleanupResult(retErr, ing.cleanupLoose(content.hash))
 	}()
+	if replace {
+		if observed.present {
+			if content.hash == observed.node.BlobHash && content.size == observed.node.Size {
+				_, err = ing.Store.ConfirmContentWithReceipt(ctx, observed.node.ID,
+					observed.node.Revision, content.hash, content.size, observed.node.MimeType,
+					content.physical)
+				if err != nil {
+					return false, fmt.Errorf("recording %s: %w", sourcePath, err)
+				}
+				return false, nil
+			}
+			_, _, err = ing.Store.ReplaceContent(ctx, observed.node.ID, observed.node.Revision,
+				content.hash, content.size, content.mimeType, content.physical)
+			if err != nil {
+				return false, fmt.Errorf("recording %s: %w", sourcePath, err)
+			}
+			return true, nil
+		}
+		_, err = ing.Store.IngestFileExact(ctx, ingestRun, parentID, filepath.Base(sourcePath), content.hash,
+			content.size, content.mimeType, sourcePath, content.mtime, content.physical)
+		if err != nil {
+			return false, fmt.Errorf("recording %s: %w", sourcePath, err)
+		}
+		return true, nil
+	}
 	_, added, err = ing.Store.IngestFile(ctx, ingestRun, parentID,
 		filepath.Base(sourcePath), content.hash, content.size, content.mimeType,
 		sourcePath, content.mtime, content.physical)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -170,6 +170,237 @@ func TestAddCancellationDoesNotAuthorizeIncompleteFile(t *testing.T) {
 		"cancellation during blob reading must not grant node authority")
 }
 
+func rewriteSource(t *testing.T, path string, content []byte) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+}
+
+func fakeIngestHash(seed string) string {
+	return strings.Repeat("0", 64-len(seed)) + seed
+}
+
+func TestAddReplaceVersionsDestinationWithoutSuffix(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	src := writeTree(t, map[string]string{"notes.txt": "first draft"})
+	path := filepath.Join(src, "notes.txt")
+
+	rep, err := ing.AddPaths(ctx, []string{path}, "/inbox")
+	require.NoError(t, err)
+	require.Equal(t, 1, rep.Added)
+	original, err := ing.Store.NodeByPath(ctx, "/inbox/notes.txt")
+	require.NoError(t, err)
+	rewriteSource(t, path, []byte("second draft"))
+
+	rep, err = ing.AddPathsWithOptions(ctx, []string{path}, "/inbox", Options{Replace: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Added)
+	assert.Empty(t, rep.Failed)
+	updated, err := ing.Store.NodeByPath(ctx, "/inbox/notes.txt")
+	require.NoError(t, err)
+	assert.Equal(t, original.ID, updated.ID)
+	assert.Equal(t, original.Revision+1, updated.Revision)
+	_, err = ing.Store.NodeByPath(ctx, "/inbox/notes (2).txt")
+	require.ErrorIs(t, err, store.ErrNotFound)
+	versions, total, err := ing.Store.ContentVersions(ctx, original.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Equal(t, "content_replace", versions[0].TransitionKind)
+}
+
+func TestAddWithoutReplaceStillSuffixesChangedContent(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	src := writeTree(t, map[string]string{"notes.txt": "first draft"})
+	path := filepath.Join(src, "notes.txt")
+
+	_, err := ing.AddPaths(ctx, []string{path}, "/inbox")
+	require.NoError(t, err)
+	rewriteSource(t, path, []byte("second draft"))
+	rep, err := ing.AddPaths(ctx, []string{path}, "/inbox")
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Added)
+	_, err = ing.Store.NodeByPath(ctx, "/inbox/notes (2).txt")
+	require.NoError(t, err)
+}
+
+func TestAddReplaceSkipsUnchangedBytesAndStoredMIME(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	content := []byte("same bytes")
+	src := filepath.Join(t.TempDir(), "notes.bin")
+	require.NoError(t, os.WriteFile(src, content, 0o644))
+	written, err := ing.Blobs.WriteDetailedContext(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+	original, err := ing.Store.CreateFile(ctx, ing.Store.RootID(), "notes.bin",
+		written.Hash, written.Size, "application/octet-stream")
+	require.NoError(t, err)
+
+	rep, err := ing.AddPathsWithOptions(ctx, []string{src}, "/", Options{Replace: true})
+	require.NoError(t, err)
+	assert.Zero(t, rep.Added)
+	assert.Equal(t, 1, rep.Skipped)
+	assert.Empty(t, rep.Failed)
+	unchanged, err := ing.Store.NodeByID(ctx, original.ID)
+	require.NoError(t, err)
+	assert.Equal(t, original.Revision, unchanged.Revision)
+	assert.Equal(t, "application/octet-stream", unchanged.MimeType)
+	_, total, err := ing.Store.ContentVersions(ctx, original.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+}
+
+func TestAddReplaceFailsBeforeSourceReadForDirectory(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	_, err := ing.Store.Mkdir(ctx, ing.Store.RootID(), "notes.txt")
+	require.NoError(t, err)
+	run, err := ing.Store.BeginIngest(ctx, "cli", "test")
+	require.NoError(t, err)
+	_, err = ing.importFile(ctx, run, ing.Store.RootID(), filepath.Join(t.TempDir(), "missing"),
+		"/synthetic/missing/notes.txt", true, nil)
+	assert.ErrorIs(t, err, store.ErrNotFile)
+}
+
+func TestAddReplaceReusesTrashOnlyName(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	trashed, err := ing.Store.CreateFile(ctx, ing.Store.RootID(), "notes.txt",
+		fakeIngestHash("trash-name"), 1, "text/plain")
+	require.NoError(t, err)
+	_, _, err = ing.Store.Trash(ctx, trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	src := writeTree(t, map[string]string{"notes.txt": "new bytes"})
+
+	rep, err := ing.AddPathsWithOptions(ctx, []string{filepath.Join(src, "notes.txt")}, "/",
+		Options{Replace: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Added)
+	live, err := ing.Store.NodeByPath(ctx, "/notes.txt")
+	require.NoError(t, err)
+	assert.NotEqual(t, trashed.ID, live.ID)
+	trashed, err = ing.Store.NodeByID(ctx, trashed.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, trashed.TrashedAt)
+	page, err := ing.Store.NodeProvenance(ctx, live.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, page.Items, 1)
+}
+
+func TestAddReplaceRejectsRacesAgainstObservedRevisionAndExactCreate(t *testing.T) {
+	tests := []struct {
+		name  string
+		claim func(t *testing.T, ing *Ingester, node store.Node, parentID int64, name string)
+		check func(t *testing.T, ing *Ingester, node store.Node)
+	}{
+		{
+			name: "changed live file",
+			claim: func(t *testing.T, ing *Ingester, node store.Node, _ int64, _ string) {
+				t.Helper()
+				_, _, err := ing.Store.ReplaceContent(t.Context(), node.ID, node.Revision,
+					fakeIngestHash("concurrent"), 11, "text/plain")
+				require.NoError(t, err)
+			},
+			check: func(t *testing.T, ing *Ingester, node store.Node) {
+				t.Helper()
+				current, err := ing.Store.NodeByID(t.Context(), node.ID)
+				require.NoError(t, err)
+				assert.Equal(t, fakeIngestHash("concurrent"), current.BlobHash)
+			},
+		},
+		{
+			name: "unchanged bytes with changed MIME",
+			claim: func(t *testing.T, ing *Ingester, node store.Node, _ int64, _ string) {
+				t.Helper()
+				_, _, err := ing.Store.ReplaceContent(t.Context(), node.ID, node.Revision,
+					node.BlobHash, node.Size, "application/octet-stream")
+				require.NoError(t, err)
+			},
+			check: func(t *testing.T, ing *Ingester, node store.Node) {
+				t.Helper()
+				current, err := ing.Store.NodeByID(t.Context(), node.ID)
+				require.NoError(t, err)
+				assert.Equal(t, "application/octet-stream", current.MimeType)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ing := newTestIngester(t)
+			ctx := t.Context()
+			large := bytes.Repeat([]byte("r"), progressByteInterval+1)
+			src := filepath.Join(t.TempDir(), "race.txt")
+			require.NoError(t, os.WriteFile(src, large, 0o644))
+			initial, err := ing.AddPathsWithOptions(ctx, []string{src}, "/", Options{})
+			require.NoError(t, err)
+			require.Equal(t, 1, initial.Added)
+			node, err := ing.Store.NodeByPath(ctx, "/race.txt")
+			require.NoError(t, err)
+			var claimed bool
+			rep, err := ing.AddPathsWithOptions(ctx, []string{src}, "/", Options{
+				Replace: true,
+				Progress: func(event ProgressEvent) {
+					if !claimed && event.BytesRead >= progressByteInterval {
+						claimed = true
+						tc.claim(t, ing, node, ing.Store.RootID(), "race.txt")
+					}
+				},
+			})
+			require.NoError(t, err)
+			assert.True(t, claimed)
+			require.Len(t, rep.Failed, 1)
+			require.ErrorIs(t, rep.Failed[0].Err, store.ErrStaleRevision)
+			_, err = ing.Store.NodeByPath(ctx, "/race (2).txt")
+			require.ErrorIs(t, err, store.ErrNotFound)
+			tc.check(t, ing, node)
+		})
+	}
+}
+
+func TestAddReplaceRejectsAbsentFileAndDirectoryClaims(t *testing.T) {
+	for _, directory := range []bool{false, true} {
+		t.Run(map[bool]string{false: "file", true: "directory"}[directory], func(t *testing.T) {
+			ing := newTestIngester(t)
+			ctx := t.Context()
+			large := bytes.Repeat([]byte("a"), progressByteInterval+1)
+			src := filepath.Join(t.TempDir(), "claimed.txt")
+			require.NoError(t, os.WriteFile(src, large, 0o644))
+			var claimed bool
+			rep, err := ing.AddPathsWithOptions(ctx, []string{src}, "/", Options{
+				Replace: true,
+				Progress: func(event ProgressEvent) {
+					if claimed || event.BytesRead < progressByteInterval {
+						return
+					}
+					claimed = true
+					if directory {
+						_, claimErr := ing.Store.Mkdir(ctx, ing.Store.RootID(), "claimed.txt")
+						require.NoError(t, claimErr)
+					} else {
+						_, claimErr := ing.Store.CreateFile(ctx, ing.Store.RootID(), "claimed.txt",
+							fakeIngestHash("claim"), 1, "text/plain")
+						require.NoError(t, claimErr)
+					}
+				},
+			})
+			require.NoError(t, err)
+			assert.True(t, claimed)
+			require.Len(t, rep.Failed, 1)
+			require.ErrorIs(t, rep.Failed[0].Err, store.ErrExists)
+			_, err = ing.Store.NodeByPath(ctx, "/claimed (2).txt")
+			require.ErrorIs(t, err, store.ErrNotFound)
+			claimant, err := ing.Store.NodeByPath(ctx, "/claimed.txt")
+			require.NoError(t, err)
+			if directory {
+				assert.True(t, claimant.IsDir())
+			} else {
+				assert.Equal(t, fakeIngestHash("claim"), claimant.BlobHash)
+				assert.Equal(t, int64(1), claimant.Size)
+			}
+		})
+	}
+}
+
 type cancelingContentReader struct {
 	cancel context.CancelFunc
 	sent   bool
@@ -593,7 +824,7 @@ func TestAddTreeStaleDestinationIsNotResurrected(t *testing.T) {
 	var rep Report
 	selection, err := compileSourceSelection(Options{Include: []string{"*.txt"}})
 	require.NoError(t, err)
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, selection, nil))
+	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, selection, false, nil))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 
@@ -613,7 +844,7 @@ func TestAddTreeStaleDestinationDefaultSelectionDoesNotResurrect(t *testing.T) {
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
 	var rep Report
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, sourceSelection{}, nil))
+	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, sourceSelection{}, false, nil))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 	_, err = ing.Store.NodeByPath(ctx, "/inbox")

--- a/internal/ingest/ingest_unix_test.go
+++ b/internal/ingest/ingest_unix_test.go
@@ -27,7 +27,7 @@ func TestImportRefusesSymlinkAtOpen(t *testing.T) {
 	// are skipped" has to hold at the point the file is opened for reading.
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
-	_, err = ing.importFile(ctx, ingestID, ing.Store.RootID(), link, link, nil)
+	_, err = ing.importFile(ctx, ingestID, ing.Store.RootID(), link, link, false, nil)
 	require.Error(t, err)
 }
 
@@ -42,7 +42,7 @@ func TestAddOneRejectsNonUTF8SourcePathWithoutPoisoningMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	var rep Report
-	require.NoError(t, ing.addOne(t.Context(), &rep, ingestID, ing.Store.RootID(), openPath, badPath, nil))
+	require.NoError(t, ing.addOne(t.Context(), &rep, ingestID, ing.Store.RootID(), openPath, badPath, false, nil))
 	assert.Zero(t, rep.Added)
 	require.Len(t, rep.Failed, 1)
 	assert.Equal(t, strconv.QuoteToASCII(badPath), rep.Failed[0].Path)

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -25,6 +25,10 @@ const (
 type Options struct {
 	Include []string
 	Exclude []string
+	// Replace versions the live file already at a source's destination path
+	// instead of importing the source under an auto-suffixed name. Preflight
+	// ignores it because it never resolves a destination.
+	Replace bool
 	// Progress receives bounded updates while a real ingest reads and commits
 	// files. Preflight ignores it because it never opens file content.
 	Progress func(ProgressEvent)

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -76,6 +76,24 @@ func TestMkdirAndLookup(t *testing.T) {
 	assert.Equal(t, "/docs", p)
 }
 
+func TestChildByNameNormalizesAndExcludesTrash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	created, err := s.Mkdir(ctx, s.RootID(), "café")
+	require.NoError(t, err)
+
+	got, err := s.ChildByName(ctx, s.RootID(), "cafe\u0301")
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+
+	trashed, err := s.CreateFile(ctx, s.RootID(), "old.txt", fakeHash("child-trash"), 1, "text/plain")
+	require.NoError(t, err)
+	_, _, err = s.Trash(ctx, trashed.ID, trashed.Revision)
+	require.NoError(t, err)
+	_, err = s.ChildByName(ctx, s.RootID(), "old.txt")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestPathOnMissingNodeReturnsNotFound(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -176,6 +176,15 @@ func (s *Store) mkdirTx(
 	return nodeByIDTx(tx, id)
 }
 
+// ChildByName returns the live child of parentID named name.
+func (s *Store) ChildByName(ctx context.Context, parentID int64, name string) (Node, error) {
+	name, err := NormalizeName(name)
+	if err != nil {
+		return Node{}, err
+	}
+	return s.childByName(ctx, parentID, name)
+}
+
 // childByName returns the live child of dirID named name (name must already
 // be normalized).
 func (s *Store) childByName(ctx context.Context, dirID int64, name string) (Node, error) {


### PR DESCRIPTION
`docbank add --replace` now makes a file whose destination path already exists a new version of the existing document, instead of dropping a second copy beside it as `notes (2).pdf`. That suffixing quietly split a document's history when an import ran nightly against a changing tree; with `--replace`, unchanged bytes are still skipped by hash and the change is fenced by the node revision so a concurrent edit fails cleanly.

Suffixing stays the default, since two files sharing a name in a bulk import are usually different documents. HTTP integrations get the same option as `"replace": true`. This is the first half of #200; listing documents by time window with no query is separate work.

Refs #200
