### PR TITLE
docs: fix stale pkg references in internal docs

### DIFF
--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -16,7 +16,7 @@ developers update the right layer and preserve cross-layer contracts.
 | `internal/home` | vault layout, privacy, and portable vault/tree locking | data operations |
 | `internal/config` | strict config parsing and security validation | runtime discovery |
 | `cmd/docbank` | Cobra ergonomics and human output | store business logic |
-| `pkg` | lifecycle and bounded public operations for one exclusively owned embedded vault | standalone CLI paths or a second storage implementation |
+| root package `docbank` | lifecycle and bounded public operations for one exclusively owned embedded vault | standalone CLI paths or a second storage implementation |
 
 ## Common change paths
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -513,4 +513,4 @@ Unreleased development layouts are disposable; there is no speculative
 - Standalone pack and repack commands remain daemon/API operations; no CLI path
   may open the physical store directly. An application that exclusively owns
   an embedded vault may enter the same coordinated pack maintenance through
-  `pkg.Vault.Pack`.
+  `docbank.Vault.Pack`.


### PR DESCRIPTION
`docs/internal/development.md` and `docs/internal/storage-design.md` both point at a `pkg` package that no longer exists. The embedded API lives at the module root (package `docbank`: `vault.go`, `types.go`, `walk.go`, `maintenance.go`, `vault_reset*.go`), and `Vault.Pack` is defined in `vault.go`.

- development.md package-ownership table: `pkg` → root package `docbank`
- storage-design.md: `pkg.Vault.Pack` → `docbank.Vault.Pack`

Docs-only. Contributors following the ownership table were being sent to a package that isn't there.

Closes #265