### PR TITLE
docs: correct locking.md mutation return codes

### DIFF
--- a/docs/architecture/locking.md
+++ b/docs/architecture/locking.md
@@ -109,8 +109,9 @@ With one process holding the vault lock for its whole run, `gc --run`,
 serializes maintenance against regular mutations: ordinary mutating API handlers
 take the read side (concurrent with each other), and
 `gc --run`/`trash empty`/`verify` take the write side, giving them the same
-"observe a quiescent vault" guarantee as an exclusive per-command lock. Requests
-queue rather than fail. See
+"observe a quiescent vault" guarantee as an exclusive per-command lock. Once
+maintenance is running or queued, a new mutation fails immediately with
+`503 maintenance_busy` rather than blocking. See
 [HTTP API: maintenance gate](http-api.md#maintenance-gate) for the
 request-handling detail.
 


### PR DESCRIPTION
`docs/architecture/locking.md` (line 113) said requests *queue* rather than fail while maintenance holds the write side. The code does the opposite: `OperationGate.mutate` (`internal/api/gate.go:79-83`) checks `g.maintenance > 0` and returns `503 maintenance_busy` immediately. `docs/architecture/http-api.md` (line 511) already documents the 503 behavior, so locking.md contradicted both the code and its sibling doc.

Docs-only, one sentence: the maintenance-contended case now reads "a new mutation fails immediately with `503 maintenance_busy` rather than blocking."

Opened as draft only because of the 6-PR limit; ready to review.

Closes #263
