### PR TITLE
Stabilize visual preview processor fingerprints

### DIFF
--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -26,7 +26,14 @@ Every preview records the complete recipe that can affect its bytes:
 
 The canonical recipe bytes produce a stable fingerprint. Changing any of these
 choices creates a new immutable generation instead of rewriting an earlier
-result.
+result. The processor fingerprint is a maintained descriptor independent of
+the Go runtime. Changing a byte-producing implementation or policy requires a
+deliberate descriptor revision.
+
+A Go upgrade alone does not invalidate existing previews. If a standard-library
+decoder or encoder change affects preview output, maintainers must revise the
+descriptor to trigger regeneration. Without that revision, matching previews
+are reused; publishing a different result under the same recipe is rejected.
 
 ## Durable outcomes
 

--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -28,6 +28,11 @@ and provider-request authorization remain separate policy checks. The
 `rendition_artifacts.role` column remains unconstrained text; unknown values
 fail closed in Go.
 
+Visual-preview generations use the canonical recipe fingerprint. The local
+processor descriptor names byte-producing choices without treating the ambient
+Go runtime version as identity; a descriptor revision is the deliberate
+re-render signal.
+
 Stable node IDs are document identity. Paths are derived from parent/name rows
 and can change or be reused. Blob hashes are content identity. Two nodes may
 share a blob without sharing document identity.

--- a/internal/processing/visual_preview.go
+++ b/internal/processing/visual_preview.go
@@ -18,7 +18,6 @@ import (
 	"image/png"
 	"io"
 	"mime"
-	"runtime"
 
 	xdraw "golang.org/x/image/draw"
 	"golang.org/x/image/webp"
@@ -37,18 +36,18 @@ const (
 	visualPreviewWebPAnimation   = 1 << 1
 	visualPreviewWebPEXIF        = 1 << 3
 	visualPreviewWebPICCProfile  = 1 << 5
+	// Bump the descriptor revision when any byte-producing choice changes.
+	visualPreviewProcessorDescriptor = "docbank-visual-preview:jpeg+png+gif-stdlib+webp+embedded-camera-raw+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v7"
 )
 
 var visualPreviewRecipe = document.VisualPreviewRecipeV1{
-	ContractVersion:   document.VisualPreviewContractV1,
-	MaxEdgePixels:     visualPreviewMaxEdgePixels,
-	OutputMediaType:   "image/jpeg",
-	OrientationPolicy: "apply",
-	ColorPolicy:       "srgb",
-	FramePolicy:       "primary",
-	ProcessorFingerprint: fingerprintVisualPreviewProcessor(
-		"docbank-visual-preview:jpeg+png+gif-stdlib-" + runtime.Version() +
-			"+webp+embedded-camera-raw+x-image-draw-v0.44.0:max-edge=4096:quality=90:alpha=white:v6"),
+	ContractVersion:      document.VisualPreviewContractV1,
+	MaxEdgePixels:        visualPreviewMaxEdgePixels,
+	OutputMediaType:      "image/jpeg",
+	OrientationPolicy:    "apply",
+	ColorPolicy:          "srgb",
+	FramePolicy:          "primary",
+	ProcessorFingerprint: fingerprintVisualPreviewProcessor(visualPreviewProcessorDescriptor),
 }
 
 // VisualPreviewTarget identifies one exact immutable source to process.

--- a/internal/processing/visual_preview_fingerprint_test.go
+++ b/internal/processing/visual_preview_fingerprint_test.go
@@ -1,0 +1,70 @@
+package processing
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"image/color"
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/media/mediatest"
+)
+
+const (
+	pinnedVisualPreviewProcessorFingerprint = "6391e667d07b0aab1622d2b4167ffe66496fe7d336beb603401d96cd8a11a641"
+	pinnedVisualPreviewRecipeFingerprint    = "03f89b744cc013004c89b1babe6d779ee043652519c586453bcde761bd7a4b04"
+)
+
+func TestVisualPreviewProcessorFingerprintIsPinned(t *testing.T) {
+	assert.Equal(t, pinnedVisualPreviewProcessorFingerprint,
+		CurrentVisualPreviewRecipe().ProcessorFingerprint)
+}
+
+func TestVisualPreviewRecipeFingerprintIsPinned(t *testing.T) {
+	_, fingerprint, err := document.MarshalVisualPreviewRecipeV1(CurrentVisualPreviewRecipe())
+	require.NoError(t, err)
+	assert.Equal(t, pinnedVisualPreviewRecipeFingerprint, fingerprint)
+}
+
+func TestProducedVisualPreviewCarriesPinnedRecipe(t *testing.T) {
+	source := mediatest.JPEG(3, 2, color.White)
+	digest := sha256.Sum256(source)
+
+	product, err := ProduceVisualPreview(t.Context(), bytes.NewReader(source), VisualPreviewTarget{
+		SourceSHA256: hex.EncodeToString(digest[:]),
+		Size:         int64(len(source)),
+		MediaType:    "image/jpeg",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, document.VisualPreviewReady, product.Preview.State)
+	assert.Equal(t, CurrentVisualPreviewRecipe(), product.Preview.Recipe)
+	assert.Equal(t, pinnedVisualPreviewProcessorFingerprint,
+		product.Preview.Recipe.ProcessorFingerprint)
+	_, fingerprint, err := document.MarshalVisualPreviewRecipeV1(product.Preview.Recipe)
+	require.NoError(t, err)
+	assert.Equal(t, pinnedVisualPreviewRecipeFingerprint, fingerprint)
+}
+
+func TestVisualPreviewDescriptorTracksLinkedDependenciesAndPolicy(t *testing.T) {
+	info, ok := debug.ReadBuildInfo()
+	require.True(t, ok)
+
+	var xImageVersion string
+	for _, dependency := range info.Deps {
+		if dependency.Path == "golang.org/x/image" {
+			xImageVersion = dependency.Version
+			break
+		}
+	}
+	require.NotEmpty(t, xImageVersion)
+	descriptor := ":" + visualPreviewProcessorDescriptor + ":"
+	assert.Contains(t, descriptor, "+x-image-draw-"+xImageVersion+":")
+	assert.Contains(t, descriptor, ":"+fmt.Sprintf("max-edge=%d", visualPreviewMaxEdgePixels)+":")
+	assert.Contains(t, descriptor, ":"+fmt.Sprintf("quality=%d", visualPreviewJPEGQuality)+":")
+}

--- a/vault_test.go
+++ b/vault_test.go
@@ -420,6 +420,10 @@ func TestVaultEnsureVisualPreviewProducesBoundedJPEG(t *testing.T) {
 	assert.Equal(t, 4096, preview.Output.Width)
 	assert.Equal(t, 2, preview.Output.Height)
 	assert.Equal(t, receipt.Version.ID, preview.Version.ID)
+	assert.Equal(t, "6391e667d07b0aab1622d2b4167ffe66496fe7d336beb603401d96cd8a11a641",
+		preview.Recipe.ProcessorFingerprint)
+	assert.Equal(t, "03f89b744cc013004c89b1babe6d779ee043652519c586453bcde761bd7a4b04",
+		preview.RecipeFingerprint)
 
 	retry, err := vault.EnsureVisualPreview(t.Context(), receipt.Version.ID)
 	require.NoError(t, err)


### PR DESCRIPTION
Visual preview recipe identity now stays stable across Go toolchain upgrades, so upgrading the toolchain no longer regenerates every document's preview on next access. The fingerprint used to embed the runtime version, which changed it for every document and orphaned the old generation rows. It now changes only when something that actually affects the output changes, like the drawing implementation or the preview policy.

Preview head ordering and generation cleanup remain separate work (#270).

Refs #270
