### PR TITLE
fix(bridge): align schema limits with evidence validation

### DIFF
--- a/document/bridge/contract_test.go
+++ b/document/bridge/contract_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
 	"gopkg.in/yaml.v3"
 )
 
@@ -87,6 +88,117 @@ func TestBridgeContractNormativeDocumentsAreStrictAndVersioned(t *testing.T) {
 	assert.NotContains(t, locatorKinds, "time_range")
 	assert.Equal(t, "#/$defs/locator",
 		contractObject(t, schema, "$defs", "omission", "properties", "locator")["$ref"])
+}
+
+func TestBridgeContractNormativeDocumentsSourceEvidenceBoundsMatchValidator(t *testing.T) {
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(sourceEvidenceSchema, &schema))
+
+	tests := []struct {
+		name     string
+		path     []string
+		want     int
+		setItems func(*document.SourceEvidenceV1, int)
+	}{
+		{
+			name: "heading_path", path: []string{"$defs", "unit", "properties", "heading_path"},
+			want: 64,
+			setItems: func(source *document.SourceEvidenceV1, count int) {
+				source.Units[0].HeadingPath = make([]string, count)
+				for index := range source.Units[0].HeadingPath {
+					source.Units[0].HeadingPath[index] = "heading"
+				}
+			},
+		},
+		{
+			name: "geometry boxes", path: []string{"$defs", "geometry", "properties", "boxes"},
+			want: 10_000,
+			setItems: func(source *document.SourceEvidenceV1, count int) {
+				geometry := source.Units[0].Regions[0].Geometry
+				geometry.Boxes = make([]document.EvidenceBoxV1, count)
+				for index := range geometry.Boxes {
+					geometry.Boxes[index] = document.EvidenceBoxV1{Left: 1, Top: 1, Right: 2, Bottom: 2}
+				}
+			},
+		},
+		{
+			name: "geometry polygons", path: []string{"$defs", "geometry", "properties", "polygons"},
+			want: 10_000,
+			setItems: func(source *document.SourceEvidenceV1, count int) {
+				geometry := source.Units[0].Regions[0].Geometry
+				geometry.Polygons = make([]document.EvidencePolygonV1, count)
+				for index := range geometry.Polygons {
+					geometry.Polygons[index] = document.EvidencePolygonV1{Points: []document.EvidencePointV1{
+						{X: 1, Y: 1}, {X: 2, Y: 1}, {X: 1, Y: 2},
+					}}
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, contractMaxItems(t, schema, test.path...))
+
+			for _, boundary := range []struct {
+				name    string
+				count   int
+				wantErr bool
+			}{
+				{name: "at limit", count: test.want},
+				{name: "over limit", count: test.want + 1, wantErr: true},
+			} {
+				t.Run(boundary.name, func(t *testing.T) {
+					source := contractSourceEvidence()
+					test.setItems(&source, boundary.count)
+					err := document.ValidateSourceEvidenceV1(source)
+					if boundary.wantErr {
+						require.Error(t, err)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+	}
+}
+
+func contractMaxItems(t *testing.T, schema map[string]any, path ...string) int {
+	t.Helper()
+	value, ok := contractObject(t, schema, path...)["maxItems"].(float64)
+	require.True(t, ok, "contract path %v has no numeric maxItems", path)
+	return int(value)
+}
+
+func contractSourceEvidence() document.SourceEvidenceV1 {
+	return document.SourceEvidenceV1{
+		ContractVersion: document.SourceEvidenceContractV1,
+		Completeness:    document.EvidenceComplete,
+		Family:          "pdf",
+		UnitKind:        document.EvidenceUnitPage,
+		Units: []document.SourceEvidenceUnitV1{{
+			Order: 0,
+			Locator: document.SourceEvidenceLocatorV1{
+				Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginOne,
+				Start: 1, End: 1,
+			},
+			Regions: []document.SourceEvidenceRegionV1{{
+				Kind: document.EvidenceRegionParagraph, Order: 0,
+				ProviderID: "synthetic-region",
+				TextRange:  document.EvidenceTextRangeV1{Start: 0, End: 1},
+				Geometry: &document.SourceEvidenceGeometryV1{
+					CoordinateOrigin: document.EvidenceCoordinateTopLeft,
+					CoordinateSpace:  document.EvidenceCoordinatePage,
+					Height:           100,
+					Orientation:      0,
+					Scale:            1,
+					Unit:             document.EvidenceGeometryPixel,
+					Width:            100,
+				},
+			}},
+			Text: "synthetic evidence",
+		}},
+	}
 }
 
 func contractObject(t *testing.T, value any, path ...string) map[string]any {

--- a/document/bridge/contract_test.go
+++ b/document/bridge/contract_test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,12 +98,12 @@ func TestBridgeContractNormativeDocumentsSourceEvidenceBoundsMatchValidator(t *t
 	tests := []struct {
 		name     string
 		path     []string
-		want     int
+		wantErr  string
 		setItems func(*document.SourceEvidenceV1, int)
 	}{
 		{
 			name: "heading_path", path: []string{"$defs", "unit", "properties", "heading_path"},
-			want: 64,
+			wantErr: "heading depth",
 			setItems: func(source *document.SourceEvidenceV1, count int) {
 				source.Units[0].HeadingPath = make([]string, count)
 				for index := range source.Units[0].HeadingPath {
@@ -112,7 +113,7 @@ func TestBridgeContractNormativeDocumentsSourceEvidenceBoundsMatchValidator(t *t
 		},
 		{
 			name: "geometry boxes", path: []string{"$defs", "geometry", "properties", "boxes"},
-			want: 10_000,
+			wantErr: "too many boxes",
 			setItems: func(source *document.SourceEvidenceV1, count int) {
 				geometry := source.Units[0].Regions[0].Geometry
 				geometry.Boxes = make([]document.EvidenceBoxV1, count)
@@ -123,7 +124,7 @@ func TestBridgeContractNormativeDocumentsSourceEvidenceBoundsMatchValidator(t *t
 		},
 		{
 			name: "geometry polygons", path: []string{"$defs", "geometry", "properties", "polygons"},
-			want: 10_000,
+			wantErr: "too many polygons",
 			setItems: func(source *document.SourceEvidenceV1, count int) {
 				geometry := source.Units[0].Regions[0].Geometry
 				geometry.Polygons = make([]document.EvidencePolygonV1, count)
@@ -134,26 +135,35 @@ func TestBridgeContractNormativeDocumentsSourceEvidenceBoundsMatchValidator(t *t
 				}
 			},
 		},
+		{
+			name: "polygon points", path: []string{"$defs", "polygon", "properties", "points"},
+			wantErr: "too many polygon points",
+			setItems: func(source *document.SourceEvidenceV1, count int) {
+				source.Units[0].Regions[0].Geometry.Polygons = []document.EvidencePolygonV1{{
+					Points: make([]document.EvidencePointV1, count),
+				}}
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, contractMaxItems(t, schema, test.path...))
+			limit := contractMaxItems(t, schema, test.path...)
 
 			for _, boundary := range []struct {
 				name    string
 				count   int
 				wantErr bool
 			}{
-				{name: "at limit", count: test.want},
-				{name: "over limit", count: test.want + 1, wantErr: true},
+				{name: "at limit", count: limit},
+				{name: "over limit", count: limit + 1, wantErr: true},
 			} {
 				t.Run(boundary.name, func(t *testing.T) {
 					source := contractSourceEvidence()
 					test.setItems(&source, boundary.count)
 					err := document.ValidateSourceEvidenceV1(source)
 					if boundary.wantErr {
-						require.Error(t, err)
+						require.ErrorContains(t, err, test.wantErr)
 						return
 					}
 					require.NoError(t, err)
@@ -161,6 +171,139 @@ func TestBridgeContractNormativeDocumentsSourceEvidenceBoundsMatchValidator(t *t
 			}
 		})
 	}
+}
+
+func TestBridgeContractNormativeDocumentsScalarBoundsMatchValidator(t *testing.T) {
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(sourceEvidenceSchema, &schema))
+	type scalarBound struct {
+		definition string
+		field      string
+		wantErr    string
+		set        func(*document.SourceEvidenceV1, float64)
+	}
+	tests := []scalarBound{
+		{"geometry", "width", "geometry frame", func(s *document.SourceEvidenceV1, n float64) { s.Units[0].Regions[0].Geometry.Width = int64(n) }},
+		{"geometry", "height", "geometry frame", func(s *document.SourceEvidenceV1, n float64) { s.Units[0].Regions[0].Geometry.Height = int64(n) }},
+		{"geometry", "scale", "geometry frame", func(s *document.SourceEvidenceV1, n float64) { s.Units[0].Regions[0].Geometry.Scale = int64(n) }},
+		{"table", "rows", "invalid dimensions", func(s *document.SourceEvidenceV1, n float64) {
+			s.Units[0].Tables = []document.SourceEvidenceTableV1{{ProviderID: "table", Rows: int(n), Columns: 1, Cells: []document.SourceEvidenceTableCellV1{}}}
+		}},
+		{"table", "columns", "invalid dimensions", func(s *document.SourceEvidenceV1, n float64) {
+			s.Units[0].Tables = []document.SourceEvidenceTableV1{{ProviderID: "table", Rows: 1, Columns: int(n), Cells: []document.SourceEvidenceTableCellV1{}}}
+		}},
+		{"locator", "end", "invalid range", func(s *document.SourceEvidenceV1, n float64) {
+			s.Family = "text"
+			s.UnitKind = document.EvidenceUnitLine
+			s.Units[0].Locator.Kind = document.EvidenceLocatorLine
+			s.Units[0].Locator.IndexOrigin = document.EvidenceIndexOriginZero
+			s.Units[0].Locator.Start = 0
+			s.Units[0].Locator.End = int64(n)
+		}},
+		{"locator", "start", "invalid range", func(s *document.SourceEvidenceV1, n float64) {
+			s.Completeness = document.EvidencePartial
+			s.Units[0].Locator.Start = int64(n)
+			s.Units[0].Locator.End = int64(n)
+			s.Omissions = []document.SourceEvidenceOmissionV1{{Kind: document.EvidenceOmissionUnit, Reason: "omitted pages", Locator: &document.SourceEvidenceLocatorV1{
+				Kind: document.EvidenceLocatorPage, IndexOrigin: document.EvidenceIndexOriginZero, Start: 0, End: max(0, int64(n)-1),
+			}}}
+			s.Units[0].Locator.IndexOrigin = document.EvidenceIndexOriginZero
+			if n == 0 {
+				s.Completeness = document.EvidenceComplete
+				s.Omissions = nil
+			}
+		}},
+	}
+	for _, field := range []string{"minimum", "maximum", "value"} {
+		tests = append(tests, scalarBound{"confidence", field, "confidence is invalid", func(s *document.SourceEvidenceV1, n float64) {
+			c := &document.SourceEvidenceConfidenceV1{Interpretation: document.EvidenceConfidenceHigherIsBetter, Minimum: -1000000, Maximum: 1000000}
+			switch field {
+			case "minimum":
+				c.Minimum = n
+				c.Value = n
+			case "maximum":
+				c.Maximum = n
+				c.Value = n
+			case "value":
+				c.Value = n
+			}
+			s.Units[0].Confidence = c
+		}})
+	}
+	for _, test := range tests {
+		t.Run(test.definition+"/"+test.field, func(t *testing.T) {
+			field := contractObject(t, schema, "$defs", test.definition, "properties", test.field)
+			for _, bound := range []string{"minimum", "maximum"} {
+				limit, ok := field[bound].(float64)
+				require.True(t, ok, "missing %s", bound)
+				// Confidence scales need distinct endpoints, so the minimum cannot
+				// equal the largest endpoint, nor the maximum the smallest.
+				invalidEndpoint := test.definition == "confidence" &&
+					(test.field == "minimum" && bound == "maximum" || test.field == "maximum" && bound == "minimum")
+				t.Run(bound, func(t *testing.T) {
+					source := contractSourceEvidence()
+					test.set(&source, limit)
+					if invalidEndpoint {
+						require.ErrorContains(t, document.ValidateSourceEvidenceV1(source), test.wantErr)
+					} else {
+						require.NoError(t, document.ValidateSourceEvidenceV1(source))
+					}
+					step := 1.0
+					if bound == "minimum" {
+						step = -1
+					}
+					test.set(&source, limit+step)
+					require.ErrorContains(t, document.ValidateSourceEvidenceV1(source), test.wantErr)
+				})
+			}
+		})
+	}
+}
+
+func TestBridgeContractNormativeDocumentsAggregateAndByteLimits(t *testing.T) {
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(sourceEvidenceSchema, &schema))
+	t.Run("polygon point budget spans polygons", func(t *testing.T) {
+		limit := contractMaxItems(t, schema, "$defs", "polygon", "properties", "points")
+		source := contractSourceEvidence()
+		geometry := source.Units[0].Regions[0].Geometry
+		geometry.Polygons = []document.EvidencePolygonV1{
+			{Points: make([]document.EvidencePointV1, limit/2)},
+			{Points: make([]document.EvidencePointV1, limit-limit/2)},
+		}
+		require.NoError(t, document.ValidateSourceEvidenceV1(source))
+		geometry.Polygons[1].Points = append(geometry.Polygons[1].Points, document.EvidencePointV1{})
+		require.ErrorContains(t, document.ValidateSourceEvidenceV1(source), "too many polygon points")
+	})
+	t.Run("heading byte budget spans units", func(t *testing.T) {
+		value, ok := contractObject(t, schema, "$defs", "unit", "properties", "heading_path", "items")["maxLength"].(float64)
+		require.True(t, ok)
+		limit := int(value)
+		source := contractSourceEvidence()
+		source.Units[0].HeadingPath = []string{strings.Repeat("h", limit)}
+		require.NoError(t, document.ValidateSourceEvidenceV1(source))
+		source.Units[0].HeadingPath[0] += "h"
+		require.ErrorContains(t, document.ValidateSourceEvidenceV1(source), "heading bytes")
+		source.Units[0].HeadingPath[0] = strings.Repeat("h", limit/2)
+		second := source.Units[0]
+		second.Order = 1
+		second.Locator.Start, second.Locator.End = 2, 2
+		second.HeadingPath = []string{strings.Repeat("h", limit-limit/2)}
+		source.Units = append(source.Units, second)
+		require.NoError(t, document.ValidateSourceEvidenceV1(source))
+		source.Units[1].HeadingPath[0] += "h"
+		require.ErrorContains(t, document.ValidateSourceEvidenceV1(source), "heading bytes")
+	})
+	t.Run("identifier limit counts UTF-8 bytes", func(t *testing.T) {
+		value, ok := contractObject(t, schema, "$defs", "region", "properties", "provider_id")["maxLength"].(float64)
+		require.True(t, ok)
+		limit := int(value)
+		source := contractSourceEvidence()
+		source.Units[0].Regions[0].ProviderID = strings.Repeat("界", limit/3) + strings.Repeat("x", limit%3)
+		require.NoError(t, document.ValidateSourceEvidenceV1(source))
+		source.Units[0].Regions[0].ProviderID += "x"
+		require.ErrorContains(t, document.ValidateSourceEvidenceV1(source), "provider ID")
+	})
 }
 
 func contractMaxItems(t *testing.T, schema map[string]any, path ...string) int {

--- a/document/bridge/source-evidence-v1.schema.json
+++ b/document/bridge/source-evidence-v1.schema.json
@@ -44,12 +44,12 @@
       "type": "object", "additionalProperties": false,
       "required": ["coordinate_origin", "coordinate_space", "height", "orientation", "scale", "unit", "width"],
       "properties": {
-        "boxes": {"type": "array", "maxItems": 1000000, "items": {"$ref": "#/$defs/box"}},
+        "boxes": {"type": "array", "maxItems": 10000, "items": {"$ref": "#/$defs/box"}},
         "coordinate_origin": {"enum": ["bottom_left", "top_left"]},
         "coordinate_space": {"enum": ["image", "page", "unit"]},
         "height": {"type": "integer", "minimum": 0},
         "orientation": {"type": "integer"},
-        "polygons": {"type": "array", "maxItems": 1000000, "items": {"$ref": "#/$defs/polygon"}},
+        "polygons": {"type": "array", "maxItems": 10000, "items": {"$ref": "#/$defs/polygon"}},
         "scale": {"type": "integer", "minimum": 1},
         "unit": {"enum": ["normalized", "pixel", "point"]},
         "width": {"type": "integer", "minimum": 0}
@@ -141,7 +141,7 @@
       "required": ["locator", "order", "text"],
       "properties": {
         "confidence": {"$ref": "#/$defs/confidence"},
-        "heading_path": {"type": "array", "maxItems": 256, "items": {"type": "string", "minLength": 1}},
+        "heading_path": {"type": "array", "maxItems": 64, "items": {"type": "string", "minLength": 1}},
         "locator": {"$ref": "#/$defs/locator"},
         "omissions": {"type": "array", "maxItems": 100000, "items": {"$ref": "#/$defs/omission"}},
         "order": {"type": "integer", "minimum": 0},

--- a/document/bridge/source-evidence-v1.schema.json
+++ b/document/bridge/source-evidence-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://docbank.dev/schemas/source-evidence-v1.schema.json",
   "title": "Docbank source-evidence/v1",
-  "description": "Wire-shape schema. document.ValidateSourceEvidenceV1 is authoritative for semantic, aggregate, sequence, normalization, and referential constraints.",
+  "description": "Wire-shape schema. document.ValidateSourceEvidenceV1 is authoritative for semantic, aggregate, sequence, normalization, and referential constraints. String limits in Go count UTF-8 bytes; JSON Schema maxLength counts Unicode code points and is only a necessary bound. Non-ASCII strings may pass this schema and exceed the byte limit in Go.",
   "type": "object",
   "additionalProperties": false,
   "required": ["contract_version", "completeness", "family", "unit_kind", "units"],
@@ -30,7 +30,7 @@
     "polygon": {
       "type": "object", "additionalProperties": false,
       "required": ["points"],
-      "properties": {"points": {"type": "array", "minItems": 3, "maxItems": 10000, "items": {"$ref": "#/$defs/point"}}}
+      "properties": {"points": {"type": "array", "minItems": 3, "maxItems": 100000, "items": {"$ref": "#/$defs/point"}}}
     },
     "box": {
       "type": "object", "additionalProperties": false,
@@ -47,12 +47,12 @@
         "boxes": {"type": "array", "maxItems": 10000, "items": {"$ref": "#/$defs/box"}},
         "coordinate_origin": {"enum": ["bottom_left", "top_left"]},
         "coordinate_space": {"enum": ["image", "page", "unit"]},
-        "height": {"type": "integer", "minimum": 0},
+        "height": {"type": "integer", "minimum": 1, "maximum": 1000000000000000},
         "orientation": {"type": "integer"},
-        "polygons": {"type": "array", "maxItems": 10000, "items": {"$ref": "#/$defs/polygon"}},
-        "scale": {"type": "integer", "minimum": 1},
+        "polygons": {"description": "Go enforces a total of at most 100,000 points across all polygons in this geometry.", "type": "array", "maxItems": 10000, "items": {"$ref": "#/$defs/polygon"}},
+        "scale": {"type": "integer", "minimum": 1, "maximum": 1000000000},
         "unit": {"enum": ["normalized", "pixel", "point"]},
-        "width": {"type": "integer", "minimum": 0}
+        "width": {"type": "integer", "minimum": 1, "maximum": 1000000000000000}
       }
     },
     "confidence": {
@@ -60,7 +60,7 @@
       "required": ["interpretation", "maximum", "minimum", "value"],
       "properties": {
         "interpretation": {"enum": ["higher_is_better", "lower_is_better", "probability"]},
-        "maximum": {"type": "number"}, "minimum": {"type": "number"}, "value": {"type": "number"}
+        "maximum": {"type": "number", "minimum": -1000000, "maximum": 1000000}, "minimum": {"type": "number", "minimum": -1000000, "maximum": 1000000}, "value": {"type": "number", "minimum": -1000000, "maximum": 1000000}
       }
     },
     "artifact": {
@@ -89,11 +89,11 @@
       "type": "object", "additionalProperties": false,
       "required": ["end", "index_origin", "kind", "start"],
       "properties": {
-        "end": {"type": "integer", "minimum": 0},
+        "end": {"type": "integer", "minimum": 0, "maximum": 1000000000000000},
         "index_origin": {"enum": ["none", "one", "zero"]},
         "kind": {"enum": ["generic", "line", "message", "page", "record", "section", "sheet", "slide", "spine"]},
         "name": {"type": "string", "maxLength": 1024},
-        "start": {"type": "integer", "minimum": 0}
+        "start": {"type": "integer", "minimum": 0, "maximum": 1000000000000000}
       }
     },
     "region": {
@@ -129,11 +129,11 @@
       "required": ["cells", "columns", "order", "provider_id", "rows"],
       "properties": {
         "cells": {"type": "array", "maxItems": 1000000, "items": {"$ref": "#/$defs/table_cell"}},
-        "columns": {"type": "integer", "minimum": 1},
+        "columns": {"type": "integer", "minimum": 1, "maximum": 1000000},
         "order": {"type": "integer", "minimum": 0},
         "provider_id": {"type": "string", "minLength": 1, "maxLength": 1024},
         "region_provider_id": {"type": "string", "maxLength": 1024},
-        "rows": {"type": "integer", "minimum": 1}
+        "rows": {"type": "integer", "minimum": 1, "maximum": 1000000}
       }
     },
     "unit": {
@@ -141,7 +141,7 @@
       "required": ["locator", "order", "text"],
       "properties": {
         "confidence": {"$ref": "#/$defs/confidence"},
-        "heading_path": {"type": "array", "maxItems": 64, "items": {"type": "string", "minLength": 1}},
+        "heading_path": {"description": "Go enforces a document-wide budget of 1,048,576 UTF-8 bytes across all heading strings.", "type": "array", "maxItems": 64, "items": {"type": "string", "minLength": 1, "maxLength": 1048576}},
         "locator": {"$ref": "#/$defs/locator"},
         "omissions": {"type": "array", "maxItems": 100000, "items": {"$ref": "#/$defs/omission"}},
         "order": {"type": "integer", "minimum": 0},

--- a/internal/blob/placement_test.go
+++ b/internal/blob/placement_test.go
@@ -594,23 +594,25 @@ func TestPlacementRunnerReschedulesFailedPhysicalCleanup(t *testing.T) {
 	operationID := createPlacementOperation(t, metadata, retirePlan)
 	runner.RetryDelay = 100 * time.Millisecond
 	supervisor := jobs.New(t.Context(), nil)
-	t.Cleanup(supervisor.Stop)
+	t.Cleanup(func() { require.NoError(t, supervisor.Shutdown(context.Background())) })
 	require.NoError(t, runner.Start(supervisor, operationID))
 
 	select {
 	case <-failing.failed:
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("cleanup failure was not observed")
 	}
-	require.Eventually(t, func() bool {
-		operation, operationErr := metadata.StorageOperation(t.Context(), operationID)
-		return operationErr == nil && operation.State == store.StorageOperationQueued &&
-			operation.Error != ""
-	}, time.Second, time.Millisecond)
-	require.Eventually(t, func() bool {
-		operation, operationErr := metadata.StorageOperation(t.Context(), operationID)
-		return operationErr == nil && operation.State == store.StorageOperationCompleted
-	}, time.Second, 10*time.Millisecond)
+	// The synchronous retry test below checks the persisted queued state.
+	// Here, wait for automatic completion without racing the retry timer or
+	// imposing a one-second disk-I/O budget on Windows runners.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		snapshots := supervisor.Snapshot()
+		require.Len(c, snapshots, 1)
+		require.Equal(c, jobs.StatusCompleted, snapshots[0].Status, "%+v", snapshots[0])
+	}, 30*time.Second, 10*time.Millisecond)
+	operation, err := metadata.StorageOperation(t.Context(), operationID)
+	require.NoError(t, err)
+	assert.Equal(t, store.StorageOperationCompleted, operation.State)
 }
 
 func TestPlacementRunnerRecordsCommittedProgressBeforeCleanupRetry(t *testing.T) {


### PR DESCRIPTION
The published bridge schema now matches the Go validator's limits on heading depth, geometry counts, and scalar bounds, so a provider that validates its evidence against the schema gets the same answer Docbank will. A 20,000-point polygon is accepted, and zero-sized frames or over-limit values are refused by the schema itself. The schema used to allow wider numbers than the validator, so a provider could build payloads Docbank then rejected.

A few limits still need Go validation, so the schema states them plainly: 100,000 total polygon points per geometry, a 1 MiB heading budget, and UTF-8 byte limits, since JSON Schema counts code points, not bytes.

Closes #266
