### PR TITLE
fix(backup): render blob authority from the shared reachability list

### DIFF
--- a/docs/internal/storage-design.md
+++ b/docs/internal/storage-design.md
@@ -262,8 +262,10 @@ that physical rewrite into logical deletion.
 Trashed nodes retain their content versions. Permanent node deletion cascades
 through those versions and may make a blob row a GC candidate, but it does not
 itself claim disk space. GC treats every `content_versions` row—current or
-historical—as a reachability root; new logical reference types must be added to
-reachability before their schema is usable.
+historical—as a reachability root, and backup capture uses the same shared root
+list for portable blob authority. GC-only holds stay outside portable backup
+authority; new logical reference types must be added to reachability before
+their schema is usable.
 
 !!! info "Planned — full-audit maintenance"
     Full-audit membership is sticky and protected historical versions remain

--- a/internal/backupapp/app.go
+++ b/internal/backupapp/app.go
@@ -41,16 +41,16 @@ type rowQuerier interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
-const authorizedContentRowsQuery = store.BackupBlobAuthorityCTE + `
+var authorizedContentRowsQuery = store.BackupBlobAuthorityCTE() + `
 SELECT b.hash,b.size FROM blobs b
 JOIN backup_authorized_blobs a ON a.hash=b.hash
 ORDER BY b.hash`
 
-const authorizedContentStatsQuery = store.BackupBlobAuthorityCTE + `
+var authorizedContentStatsQuery = store.BackupBlobAuthorityCTE() + `
 SELECT COUNT(*),COALESCE(SUM(b.size),0) FROM blobs b
 JOIN backup_authorized_blobs a ON a.hash=b.hash`
 
-const authorizedExtractedTextStatsQuery = store.BackupBlobAuthorityCTE + `
+var authorizedExtractedTextStatsQuery = store.BackupBlobAuthorityCTE() + `
 SELECT COUNT(*) FROM extracted_text e
 JOIN backup_authorized_blobs a ON a.hash=e.blob_hash`
 

--- a/internal/backupapp/placement.go
+++ b/internal/backupapp/placement.go
@@ -65,7 +65,7 @@ func (s *metadataSnapshot) AuxiliaryArtifacts(
 }
 
 func encodePlacementManifest(ctx context.Context, q rowQuerier) ([]byte, error) {
-	rows, err := q.QueryContext(ctx, store.BackupBlobAuthorityCTE+`
+	rows, err := q.QueryContext(ctx, store.BackupBlobAuthorityCTE()+`
 		SELECT s.store_id, s.name, s.kind, s.role,
 		       COUNT(l.blob_hash), COALESCE(SUM(b.size), 0)
 		FROM blob_stores s
@@ -100,7 +100,7 @@ func encodePlacementManifest(ctx context.Context, q rowQuerier) ([]byte, error) 
 		return nil, fmt.Errorf("backupapp: closing placement stores: %w", err)
 	}
 
-	rows, err = q.QueryContext(ctx, store.BackupBlobAuthorityCTE+`
+	rows, err = q.QueryContext(ctx, store.BackupBlobAuthorityCTE()+`
 		SELECT b.hash, l.store_id
 		FROM blobs b JOIN backup_authorized_blobs a ON a.hash = b.hash
 		LEFT JOIN blob_locations l ON l.blob_hash = b.hash

--- a/internal/processing/artifacts_test.go
+++ b/internal/processing/artifacts_test.go
@@ -213,7 +213,7 @@ func TestPublishRenditionRejectsArtifactReceiptMismatchBeforeCatalogAuthority(t 
 	snapshot, err := fixture.catalog.BeginMetadataSnapshot(t.Context())
 	require.NoError(t, err)
 	var authorized int
-	require.NoError(t, snapshot.QueryRowContext(t.Context(), store.BackupBlobAuthorityCTE+
+	require.NoError(t, snapshot.QueryRowContext(t.Context(), store.BackupBlobAuthorityCTE()+
 		`SELECT COUNT(*) FROM backup_authorized_blobs WHERE hash=?`, actualHash).Scan(&authorized))
 	require.NoError(t, snapshot.Close())
 	assert.Zero(t, authorized, "a rejected receipt must remain non-backup staging")

--- a/internal/store/backup_blob_authority_repro_test.go
+++ b/internal/store/backup_blob_authority_repro_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"bytes"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
+)
+
+func TestBackupCaptureFollowsBlobRootReferences(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	probe := fakeHash("267")
+	require.NoError(t, s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		return s.EnsureBlobTx(tx, probe, 7)
+	}))
+
+	canonical, _, err := document.MarshalSourceMetadataV1(document.SourceMetadataV1{
+		ContractVersion: document.SourceMetadataContractV1,
+	})
+	require.NoError(t, err)
+	_, err = s.PublishSourceMetadata(ctx, probe, fakeHash("f1"), canonical)
+	require.NoError(t, err)
+	_, err = s.PublishSourceMetadata(ctx, probe, fakeHash("f2"), canonical)
+	require.NoError(t, err)
+
+	originalRoots := blobRootReferences
+	blobRootReferences = append([]blobReference{{
+		table: "source_metadata_generations", column: "source_sha256",
+	}}, originalRoots...)
+	t.Cleanup(func() { blobRootReferences = originalRoots })
+
+	unreachable, err := s.UnreachableBlobs(ctx)
+	require.NoError(t, err)
+	assert.NotContains(t, blobHashes(unreachable), probe,
+		"the synthetic sixth root must keep its blob reachable")
+
+	var exported bytes.Buffer
+	snapshot, err := s.BeginMetadataSnapshot(ctx)
+	require.NoError(t, err)
+	require.NoError(t, snapshot.ExportBackup(ctx, &exported))
+	require.NoError(t, snapshot.Close())
+
+	blobRecord := `"type":"blob","hash":"` + probe + `"`
+	assert.Equal(t, 1, strings.Count(exported.String(), blobRecord),
+		"duplicate root rows must produce one exported blob record")
+}

--- a/internal/store/blob_roots.go
+++ b/internal/store/blob_roots.go
@@ -25,10 +25,10 @@ func (reference blobReference) conditionSQL() string {
 
 // blobRootReferences is the single definition of "something still needs
 // these bytes" shared by garbage collection, version pruning, derivative
-// purge, and verification. A blob referenced by any of these rows is
-// reachable; a blob referenced by none is a collection candidate. Visual
-// preview sources are omitted because the Go writer binds them to the same
-// hash as their content version, which is already listed.
+// purge, verification, and backup capture. A blob referenced by any of these
+// rows is reachable; a blob referenced by none is a collection candidate.
+// Visual preview sources are omitted because the Go writer binds them to the
+// same hash as their content version, which is already listed.
 var blobRootReferences = []blobReference{
 	{table: "content_versions", column: columnBlobHash},
 	{table: "rendition_builds", column: columnSourceSHA256},
@@ -86,4 +86,22 @@ func blobReferenceRowsSQL(references ...[]blobReference) string {
 		}
 	}
 	return strings.Join(selects, "\n\t\t\tUNION ALL\n\t\t\t")
+}
+
+// blobReferenceSetSQL returns a distinct set of non-NULL blob hashes from the
+// listed references, preserving the order of the reference list.
+func blobReferenceSetSQL(references []blobReference) string {
+	selects := make([]string, 0, len(references))
+	for _, reference := range references {
+		selects = append(selects, "SELECT r."+reference.column+" FROM "+reference.table+
+			" r WHERE r."+reference.column+" IS NOT NULL"+reference.conditionSQL())
+	}
+	return strings.Join(selects, "\n\tUNION\n\t")
+}
+
+// BackupBlobAuthorityCTE renders the complete blob closure for portable
+// backup. GC-only holds intentionally remain outside this authority.
+func BackupBlobAuthorityCTE() string {
+	return "WITH backup_authorized_blobs(hash) AS (\n\t" +
+		blobReferenceSetSQL(blobRootReferences) + "\n)\n"
 }

--- a/internal/store/blob_roots_test.go
+++ b/internal/store/blob_roots_test.go
@@ -2,16 +2,33 @@ package store
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestBlobReferenceSetSQL(t *testing.T) {
+	query := blobReferenceSetSQL([]blobReference{
+		{table: "first_roots", column: "first_hash"},
+		{table: "second_roots", column: "second_hash"},
+	})
+
+	assert.Equal(t, "SELECT r.first_hash FROM first_roots r WHERE r.first_hash IS NOT NULL\n\tUNION\n\tSELECT r.second_hash FROM second_roots r WHERE r.second_hash IS NOT NULL", query)
+	assert.NotContains(t, query, "UNION ALL")
+	assert.Less(t, strings.Index(query, "first_roots"), strings.Index(query, "second_roots"))
+
+	cte := BackupBlobAuthorityCTE()
+	assert.Contains(t, cte, "WITH backup_authorized_blobs(hash) AS (")
+	assert.NotContains(t, cte, "rendition_blob_staging")
+}
+
 // Every consumer of blob reachability must agree on one rule: GC candidates,
-// the derivative purge inventory, and version-prune reference counts all read
-// blobRootReferences. This fixture holds one blob per root kind, one blob per
-// GC hold, and one orphan, and checks each consumer against the same answer.
+// the derivative purge inventory, version-prune reference counts, and backup
+// capture all read blobRootReferences. This fixture holds one blob per root
+// kind, one blob per GC hold, and one orphan, and checks each consumer against
+// the same answer.
 func TestBlobReachabilityRuleAgreesAcrossConsumers(t *testing.T) {
 	s, versions := newRenditionCatalogFixture(t)
 	ctx := t.Context()
@@ -68,6 +85,26 @@ func TestBlobReachabilityRuleAgreesAcrossConsumers(t *testing.T) {
 	}
 	for _, unrooted := range []string{staged, orphan, purgePending} {
 		assert.Zero(t, references[unrooted], "%s must not count as referenced", unrooted)
+	}
+
+	authorized := make(map[string]struct{})
+	authorizedRows, err := s.db.QueryContext(ctx, BackupBlobAuthorityCTE()+
+		`SELECT hash FROM backup_authorized_blobs`)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, authorizedRows.Close()) }()
+	for authorizedRows.Next() {
+		var hash string
+		require.NoError(t, authorizedRows.Scan(&hash))
+		authorized[hash] = struct{}{}
+	}
+	require.NoError(t, authorizedRows.Err())
+	expected := make(map[string]struct{}, len(references))
+	for hash := range references {
+		expected[hash] = struct{}{}
+	}
+	assert.Equal(t, expected, authorized)
+	for _, excluded := range []string{staged, orphan, purgePending} {
+		assert.NotContains(t, authorized, excluded, "%s must not enter backup authority", excluded)
 	}
 
 	purgeTargets, err := s.UnreachableDerivativePurgeBlobs(ctx)

--- a/internal/store/embedding_catalog_authority_test.go
+++ b/internal/store/embedding_catalog_authority_test.go
@@ -332,6 +332,8 @@ func TestEmbeddingCatalogBackupRestoreVerifiesLooseAndPackedArtifacts(t *testing
 			source, versionID, profile, attachmentID := newEmbeddingCatalogFixture(t)
 			record := embeddingSetFixture(source, versionID, profile.Fingerprint, document.EmbeddingInputRenditionChunk, "chunk", attachmentID)
 			require.NoError(t, source.StageEmbeddingSet(t.Context(), record))
+			direct := embeddingSetFixture(source, versionID, profile.Fingerprint, document.EmbeddingInputOriginalFile, "optional", "")
+			require.NoError(t, source.StageEmbeddingSet(t.Context(), direct))
 			snapshot, err := source.BeginMetadataSnapshot(t.Context())
 			require.NoError(t, err)
 			defer func() { require.NoError(t, snapshot.Close()) }()
@@ -346,12 +348,13 @@ func TestEmbeddingCatalogBackupRestoreVerifiesLooseAndPackedArtifacts(t *testing
 				record.InputGeneration.GenerationBlobHash:       record.InputGeneration.GenerationJSON,
 				testSHA256(record.InputGeneration.EvidenceJSON): record.InputGeneration.EvidenceJSON,
 				record.VectorSet.PayloadBlobHash:                record.VectorSet.Payload,
+				direct.VectorSet.PayloadBlobHash:                direct.VectorSet.Payload,
 			}
 			// Copy only the bytes selected by the portable backup closure, not
 			// every fixture blob. The embedding evidence has no rendition-artifact
 			// reference to bring it into the backup on the generation's behalf.
 			require.NotEqual(t, catalogEvidenceBlobHash, testSHA256(record.InputGeneration.EvidenceJSON))
-			rows, err := snapshot.QueryContext(t.Context(), BackupBlobAuthorityCTE+
+			rows, err := snapshot.QueryContext(t.Context(), BackupBlobAuthorityCTE()+
 				`SELECT hash FROM backup_authorized_blobs`)
 			require.NoError(t, err)
 			defer func() { require.NoError(t, rows.Close()) }()

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -264,33 +264,6 @@ type metadataAuditMembership struct {
 	BaselineDigest string `json:"baseline_digest"`
 }
 
-// BackupBlobAuthorityCTE is the complete blob closure for portable backup:
-// retained document versions, rendition and embedding artifacts, visual
-// previews, staged rendition sources, and no operational cursor or
-// provider-staging rows.
-const BackupBlobAuthorityCTE = `
-WITH backup_authorized_blobs(hash) AS (
-	SELECT blob_hash FROM content_versions
-	UNION
-	SELECT blob_hash FROM rendition_artifacts
-	UNION
-	SELECT generation_blob_hash FROM embedding_input_generations
-	WHERE generation_blob_hash IS NOT NULL
-	UNION
-	SELECT evidence_fingerprint FROM embedding_input_generations
-	WHERE generation_blob_hash IS NOT NULL
-	UNION
-	SELECT payload_blob_hash FROM embedding_vector_sets
-	UNION
-	SELECT output_blob_hash FROM visual_preview_generations
-	WHERE output_blob_hash IS NOT NULL
-	UNION
-	SELECT source_sha256 FROM rendition_builds
-	UNION
-	SELECT source_sha256 FROM rendition_jobs
-)
-`
-
 // ExportMetadata writes a deterministic JSONL description of Docbank's
 // logical state. Rebuildable FTS data and physical pack authority are omitted.
 func (s *Store) ExportMetadata(ctx context.Context, w io.Writer) error {
@@ -478,7 +451,7 @@ func exportBlobs(
 ) error {
 	query := `SELECT hash, size, created_at FROM blobs ORDER BY hash`
 	if backupScoped {
-		query = BackupBlobAuthorityCTE + `
+		query = BackupBlobAuthorityCTE() + `
 SELECT b.hash, b.size, b.created_at
 FROM blobs b JOIN backup_authorized_blobs a ON a.hash = b.hash
 ORDER BY b.hash`
@@ -508,7 +481,7 @@ func exportBlobChecksums(
 ) error {
 	query := `SELECT blob_sha256,md5 FROM blob_checksums ORDER BY blob_sha256`
 	if backupScoped {
-		query = BackupBlobAuthorityCTE + `
+		query = BackupBlobAuthorityCTE() + `
 SELECT c.blob_sha256,c.md5 FROM blob_checksums c
 JOIN backup_authorized_blobs a ON a.hash=c.blob_sha256
 ORDER BY c.blob_sha256`
@@ -539,7 +512,7 @@ func exportSourceMetadata(ctx context.Context, tx metadataQuerier, write metadat
 	query := `SELECT generation_id,source_sha256,contract_version,extractor_fingerprint,
 		canonical_json,checksum,created_at FROM source_metadata_generations ORDER BY generation_id`
 	if backupScoped {
-		query = BackupBlobAuthorityCTE + `
+		query = BackupBlobAuthorityCTE() + `
 SELECT g.generation_id,g.source_sha256,g.contract_version,g.extractor_fingerprint,
 g.canonical_json,g.checksum,g.created_at FROM source_metadata_generations g
 JOIN backup_authorized_blobs a ON a.hash=g.source_sha256 ORDER BY g.generation_id`
@@ -567,7 +540,7 @@ JOIN backup_authorized_blobs a ON a.hash=g.source_sha256 ORDER BY g.generation_i
 	}
 	headQuery := `SELECT source_sha256,generation_id,published_at FROM source_metadata_heads ORDER BY source_sha256`
 	if backupScoped {
-		headQuery = BackupBlobAuthorityCTE + `
+		headQuery = BackupBlobAuthorityCTE() + `
 SELECT h.source_sha256,h.generation_id,h.published_at FROM source_metadata_heads h
 JOIN backup_authorized_blobs a ON a.hash=h.source_sha256 ORDER BY h.source_sha256`
 	}
@@ -874,7 +847,7 @@ func exportExtractedText(
 		SELECT blob_hash, extractor, extractor_version, status, error, attempts, text, extracted_at
 		FROM extracted_text ORDER BY blob_hash, extractor`
 	if backupScoped {
-		query = BackupBlobAuthorityCTE + `
+		query = BackupBlobAuthorityCTE() + `
 		SELECT e.blob_hash, e.extractor, e.extractor_version, e.status,
 		       e.error, e.attempts, e.text, e.extracted_at
 		FROM extracted_text e

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -112,7 +112,7 @@ func TestBackupExcludesUncommittedProviderStaging(t *testing.T) {
 	snapshot, err := s.BeginMetadataSnapshot(t.Context())
 	require.NoError(t, err)
 	var authorized int
-	require.NoError(t, snapshot.QueryRowContext(t.Context(), BackupBlobAuthorityCTE+
+	require.NoError(t, snapshot.QueryRowContext(t.Context(), BackupBlobAuthorityCTE()+
 		`SELECT COUNT(*) FROM backup_authorized_blobs WHERE hash=?`, staged).Scan(&authorized))
 	require.Zero(t, authorized)
 	require.NoError(t, snapshot.ExportBackup(t.Context(), &exported))
@@ -163,7 +163,7 @@ func TestBackupExcludesCrashPendingDerivativeErasureAcrossMetadataRoundTrip(t *t
 	snapshot, err := s.BeginMetadataSnapshot(t.Context())
 	require.NoError(t, err)
 	var authorized int
-	require.NoError(t, snapshot.QueryRowContext(t.Context(), BackupBlobAuthorityCTE+
+	require.NoError(t, snapshot.QueryRowContext(t.Context(), BackupBlobAuthorityCTE()+
 		`SELECT COUNT(*) FROM backup_authorized_blobs WHERE hash=?`, pending).Scan(&authorized))
 	require.Zero(t, authorized)
 	var exported bytes.Buffer


### PR DESCRIPTION
Backups now use the same list as storage cleanup to identify content Docbank needs to keep, including document versions, previews, and embeddings. Previously, developers had to update two separate lists when adding a new kind of stored content. Updating only the cleanup list could leave content in the vault but omit it from backups.

This change removes the duplicate list. Backups still include shared content only once and exclude unfinished processing output and content awaiting permanent deletion.

Closes #267
