### PR TITLE
test: preserve source metadata across extractor rollbacks

### DIFF
--- a/docs/architecture/source-metadata.md
+++ b/docs/architecture/source-metadata.md
@@ -89,6 +89,15 @@ is idempotent. Because the fingerprint covers every parser, any change to it
 makes the daemon re-read and re-extract every retained original in every
 vault; a test pins the fingerprint so that cost is taken deliberately.
 
+The active head follows the last successful publication, including publication
+of an already-recorded generation. Fingerprints identify parser bundles; they
+do not order extractors by age. After switching binaries, an explicit ensure
+reactivates the running binary's evidence even if another extractor published
+more recently. The first ensure re-reads and re-extracts the original; subsequent
+ensures reuse that active generation. The daemon backfill only processes
+originals missing a generation for its fingerprint, so it does not reactivate
+already-recorded evidence by itself.
+
 The HTTP node and content-version detail surfaces return the active generation.
 Embedded applications call `Vault.EnsureSourceMetadata` with an immutable
 content version ID to run the current local extractor synchronously for those

--- a/internal/store/source_metadata.go
+++ b/internal/store/source_metadata.go
@@ -78,7 +78,8 @@ func sourceMetadataGenerationID(source, contract, fingerprint, checksum string) 
 }
 
 // PublishSourceMetadata validates and atomically publishes one immutable
-// generation. Retrying the identical publication is idempotent.
+// generation. Retrying the identical publication is idempotent; an older
+// stored generation cannot move the active head backward.
 func (s *Store) PublishSourceMetadata(
 	ctx context.Context, sourceSHA256, extractorFingerprint string, canonical []byte,
 ) (SourceMetadataGeneration, error) {
@@ -102,13 +103,19 @@ func (s *Store) PublishSourceMetadata(
 	generation.GenerationID = sourceMetadataGenerationID(sourceSHA256, metadata.ContractVersion,
 		extractorFingerprint, checksum)
 	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		if _, execErr := tx.ExecContext(ctx, `INSERT INTO source_metadata_generations(
+		result, execErr := tx.ExecContext(ctx, `INSERT INTO source_metadata_generations(
 			generation_id,source_sha256,contract_version,extractor_fingerprint,canonical_json,checksum,created_at
 		) VALUES(?,?,?,?,?,?,?) ON CONFLICT(source_sha256,contract_version,extractor_fingerprint) DO NOTHING`,
 			generation.GenerationID, sourceSHA256, metadata.ContractVersion, extractorFingerprint,
-			canonical, checksum, generation.CreatedAt); execErr != nil {
+			canonical, checksum, generation.CreatedAt)
+		if execErr != nil {
 			return fmt.Errorf("recording source metadata: %w", execErr)
 		}
+		inserted, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return fmt.Errorf("recording source metadata: %w", rowsErr)
+		}
+		recorded := inserted > 0
 		var stored SourceMetadataGeneration
 		if scanErr := tx.QueryRowContext(ctx, `SELECT generation_id,source_sha256,contract_version,
 			extractor_fingerprint,canonical_json,checksum,created_at FROM source_metadata_generations
@@ -123,10 +130,11 @@ func (s *Store) PublishSourceMetadata(
 			return errors.New("source metadata extractor identity already has different evidence")
 		}
 		generation = stored
-		_, execErr := tx.ExecContext(ctx, `INSERT INTO source_metadata_heads(source_sha256,generation_id,published_at)
+		_, execErr = tx.ExecContext(ctx, `INSERT INTO source_metadata_heads(source_sha256,generation_id,published_at)
 			VALUES(?,?,?) ON CONFLICT(source_sha256) DO UPDATE SET
-			generation_id=excluded.generation_id,published_at=excluded.published_at`,
-			sourceSHA256, generation.GenerationID, nowRFC3339())
+			generation_id=excluded.generation_id,published_at=excluded.published_at
+			WHERE ? OR source_metadata_heads.generation_id=excluded.generation_id`,
+			sourceSHA256, generation.GenerationID, nowRFC3339(), recorded)
 		return execErr
 	})
 	return generation, err

--- a/internal/store/source_metadata.go
+++ b/internal/store/source_metadata.go
@@ -78,8 +78,8 @@ func sourceMetadataGenerationID(source, contract, fingerprint, checksum string) 
 }
 
 // PublishSourceMetadata validates and atomically publishes one immutable
-// generation. Retrying the identical publication is idempotent; an older
-// stored generation cannot move the active head backward.
+// generation and selects it as the active head, including on republication.
+// Fingerprints identify extractors but do not order them by age.
 func (s *Store) PublishSourceMetadata(
 	ctx context.Context, sourceSHA256, extractorFingerprint string, canonical []byte,
 ) (SourceMetadataGeneration, error) {
@@ -103,19 +103,13 @@ func (s *Store) PublishSourceMetadata(
 	generation.GenerationID = sourceMetadataGenerationID(sourceSHA256, metadata.ContractVersion,
 		extractorFingerprint, checksum)
 	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
-		result, execErr := tx.ExecContext(ctx, `INSERT INTO source_metadata_generations(
+		if _, execErr := tx.ExecContext(ctx, `INSERT INTO source_metadata_generations(
 			generation_id,source_sha256,contract_version,extractor_fingerprint,canonical_json,checksum,created_at
 		) VALUES(?,?,?,?,?,?,?) ON CONFLICT(source_sha256,contract_version,extractor_fingerprint) DO NOTHING`,
 			generation.GenerationID, sourceSHA256, metadata.ContractVersion, extractorFingerprint,
-			canonical, checksum, generation.CreatedAt)
-		if execErr != nil {
+			canonical, checksum, generation.CreatedAt); execErr != nil {
 			return fmt.Errorf("recording source metadata: %w", execErr)
 		}
-		inserted, rowsErr := result.RowsAffected()
-		if rowsErr != nil {
-			return fmt.Errorf("recording source metadata: %w", rowsErr)
-		}
-		recorded := inserted > 0
 		var stored SourceMetadataGeneration
 		if scanErr := tx.QueryRowContext(ctx, `SELECT generation_id,source_sha256,contract_version,
 			extractor_fingerprint,canonical_json,checksum,created_at FROM source_metadata_generations
@@ -130,11 +124,10 @@ func (s *Store) PublishSourceMetadata(
 			return errors.New("source metadata extractor identity already has different evidence")
 		}
 		generation = stored
-		_, execErr = tx.ExecContext(ctx, `INSERT INTO source_metadata_heads(source_sha256,generation_id,published_at)
+		_, execErr := tx.ExecContext(ctx, `INSERT INTO source_metadata_heads(source_sha256,generation_id,published_at)
 			VALUES(?,?,?) ON CONFLICT(source_sha256) DO UPDATE SET
-			generation_id=excluded.generation_id,published_at=excluded.published_at
-			WHERE ? OR source_metadata_heads.generation_id=excluded.generation_id`,
-			sourceSHA256, generation.GenerationID, nowRFC3339(), recorded)
+			generation_id=excluded.generation_id,published_at=excluded.published_at`,
+			sourceSHA256, generation.GenerationID, nowRFC3339())
 		return execErr
 	})
 	return generation, err

--- a/internal/store/source_metadata_test.go
+++ b/internal/store/source_metadata_test.go
@@ -56,6 +56,77 @@ func TestSourceMetadataGenerationsAreImmutableAndAttachmentFactsStayJoined(t *te
 	require.Error(t, err, "a head must not select another original's evidence")
 }
 
+// Coverage guard: this exercises the immutable-insert provenance used by the
+// source-metadata head conflict predicate.
+func TestSourceMetadataHeadAdvancesOnFirstRecordingAndHoldsOnRepublication(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	sourceSHA256 := fakeHash("a1")
+	_, err := s.CreateFile(ctx, s.RootID(), "source-a.pdf", sourceSHA256, 1, "application/pdf")
+	require.NoError(t, err)
+	metadataA := document.SourceMetadataV1{ContractVersion: document.SourceMetadataContractV1,
+		Fields: []document.SourceMetadataFieldV1{{Key: "title", Namespace: "pdf.info", SourceField: "Title",
+			Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataString, String: new("A")}}}}
+	canonicalA, _, err := document.MarshalSourceMetadataV1(metadataA)
+	require.NoError(t, err)
+	generationA, err := s.PublishSourceMetadata(ctx, sourceSHA256, fakeHash("f1"), canonicalA)
+	require.NoError(t, err)
+
+	metadataB := document.SourceMetadataV1{ContractVersion: document.SourceMetadataContractV1,
+		Fields: []document.SourceMetadataFieldV1{{Key: "title", Namespace: "pdf.info", SourceField: "Title",
+			Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataString, String: new("B")}}}}
+	canonicalB, _, err := document.MarshalSourceMetadataV1(metadataB)
+	require.NoError(t, err)
+	generationB, err := s.PublishSourceMetadata(ctx, sourceSHA256, fakeHash("f2"), canonicalB)
+	require.NoError(t, err)
+
+	active, activeMetadata, err := s.ActiveSourceMetadata(ctx, sourceSHA256)
+	require.NoError(t, err)
+	assert.Equal(t, generationB.GenerationID, active.GenerationID)
+	assert.Equal(t, "B", *activeMetadata.Fields[0].Value.String)
+
+	currentRetry, err := s.PublishSourceMetadata(ctx, sourceSHA256, fakeHash("f2"), canonicalB)
+	require.NoError(t, err)
+	assert.Equal(t, generationB.GenerationID, currentRetry.GenerationID)
+
+	replayed, err := s.PublishSourceMetadata(ctx, sourceSHA256, fakeHash("f1"), canonicalA)
+	require.NoError(t, err)
+	assert.Equal(t, generationA.GenerationID, replayed.GenerationID)
+
+	active, activeMetadata, err = s.ActiveSourceMetadata(ctx, sourceSHA256)
+	require.NoError(t, err)
+	assert.Equal(t, generationB.GenerationID, active.GenerationID)
+	assert.Equal(t, "B", *activeMetadata.Fields[0].Value.String)
+	var generationCount int
+	require.NoError(t, s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM source_metadata_generations WHERE source_sha256=?`, sourceSHA256).Scan(&generationCount))
+	assert.Equal(t, 2, generationCount)
+}
+
+func TestSourceMetadataHeadAppearsWhenMissingForRecordedEvidence(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	sourceSHA256 := fakeHash("a1")
+	_, err := s.CreateFile(ctx, s.RootID(), "source-a.pdf", sourceSHA256, 1, "application/pdf")
+	require.NoError(t, err)
+	canonical, _, err := document.MarshalSourceMetadataV1(document.SourceMetadataV1{
+		ContractVersion: document.SourceMetadataContractV1,
+		Fields: []document.SourceMetadataFieldV1{{Key: "title", Namespace: "pdf.info", SourceField: "Title",
+			Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataString, String: new("A")}}}})
+	require.NoError(t, err)
+	generation, err := s.PublishSourceMetadata(ctx, sourceSHA256, fakeHash("f1"), canonical)
+	require.NoError(t, err)
+	_, err = s.db.ExecContext(ctx, `DELETE FROM source_metadata_heads WHERE source_sha256=?`, sourceSHA256)
+	require.NoError(t, err)
+
+	republished, err := s.PublishSourceMetadata(ctx, sourceSHA256, fakeHash("f1"), canonical)
+	require.NoError(t, err)
+	assert.Equal(t, generation.GenerationID, republished.GenerationID)
+	active, _, err := s.ActiveSourceMetadata(ctx, sourceSHA256)
+	require.NoError(t, err)
+	assert.Equal(t, generation.GenerationID, active.GenerationID)
+}
+
 func TestHistoricalSourceMetadataOmitsCurrentAttachmentFacts(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()

--- a/internal/store/source_metadata_test.go
+++ b/internal/store/source_metadata_test.go
@@ -56,9 +56,7 @@ func TestSourceMetadataGenerationsAreImmutableAndAttachmentFactsStayJoined(t *te
 	require.Error(t, err, "a head must not select another original's evidence")
 }
 
-// Coverage guard: this exercises the immutable-insert provenance used by the
-// source-metadata head conflict predicate.
-func TestSourceMetadataHeadAdvancesOnFirstRecordingAndHoldsOnRepublication(t *testing.T) {
+func TestSourceMetadataRepublicationSelectsRecordedGeneration(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
 	sourceSHA256 := fakeHash("a1")
@@ -95,8 +93,8 @@ func TestSourceMetadataHeadAdvancesOnFirstRecordingAndHoldsOnRepublication(t *te
 
 	active, activeMetadata, err = s.ActiveSourceMetadata(ctx, sourceSHA256)
 	require.NoError(t, err)
-	assert.Equal(t, generationB.GenerationID, active.GenerationID)
-	assert.Equal(t, "B", *activeMetadata.Fields[0].Value.String)
+	assert.Equal(t, generationA.GenerationID, active.GenerationID)
+	assert.Equal(t, "A", *activeMetadata.Fields[0].Value.String)
 	var generationCount int
 	require.NoError(t, s.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM source_metadata_generations WHERE source_sha256=?`, sourceSHA256).Scan(&generationCount))

--- a/vault.go
+++ b/vault.go
@@ -379,8 +379,8 @@ func (v *Vault) SourceMetadata(ctx context.Context, versionID string) (SourceMet
 }
 
 // EnsureSourceMetadata returns current local metadata for one exact immutable
-// content version. When the current extractor has not processed those bytes,
-// it verifies and processes them synchronously before returning. Retrying the
+// content version. When no metadata is active for the current extractor,
+// it verifies and processes the bytes synchronously before returning. Retrying the
 // same version and extractor generation is idempotent. The call holds the
 // vault mutation lock for the whole extraction, so writes and maintenance
 // wait behind it.

--- a/vault_test.go
+++ b/vault_test.go
@@ -205,6 +205,45 @@ func TestVaultEnsureSourceMetadataRefreshesOldExtractorGeneration(t *testing.T) 
 	assert.Equal(t, "Current event", title)
 }
 
+func TestVaultEnsureSourceMetadataRestoresPreviouslyRecordedExtractorGeneration(t *testing.T) {
+	vault, err := New(t.Context(), Config{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	content := []byte("BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nSUMMARY:Current event\r\nEND:VEVENT\r\nEND:VCALENDAR")
+	receipt, err := vault.Create(t.Context(), "/calendar.ics", bytes.NewReader(content), CreateOptions{
+		MediaType: "text/calendar", Expected: contentIdentity(content),
+	})
+	require.NoError(t, err)
+	current, err := vault.EnsureSourceMetadata(t.Context(), receipt.Version.ID)
+	require.NoError(t, err)
+
+	// Model a vault reopened after another binary published its own evidence.
+	otherCanonical, _, err := document.MarshalSourceMetadataV1(document.SourceMetadataV1{
+		ContractVersion: document.SourceMetadataContractV1,
+		Fields: []document.SourceMetadataFieldV1{{
+			Key: "title", Namespace: "calendar", SourceField: "SUMMARY",
+			Value: document.SourceMetadataValueV1{Kind: document.SourceMetadataString, String: new("Other event")},
+		}},
+	})
+	require.NoError(t, err)
+	otherFingerprint := contentIdentity([]byte("other extractor")).SHA256
+	_, err = vault.metadata.PublishSourceMetadata(t.Context(), receipt.Version.BlobHash, otherFingerprint, otherCanonical)
+	require.NoError(t, err)
+	other, err := vault.SourceMetadata(t.Context(), receipt.Version.ID)
+	require.NoError(t, err)
+	require.Equal(t, otherFingerprint, other.ExtractorFingerprint)
+
+	publications := 0
+	vault.testAfterSourceMetadataPublication = func() { publications++ }
+	for range 3 {
+		metadata, err := vault.EnsureSourceMetadata(t.Context(), receipt.Version.ID)
+		require.NoError(t, err)
+		assert.Equal(t, current, metadata)
+	}
+	assert.Equal(t, 1, publications, "only the first ensure should reprocess the original")
+}
+
 func TestVaultEnsureSourceMetadataRejectsUnknownVersion(t *testing.T) {
 	vault, err := New(t.Context(), Config{Root: t.TempDir()})
 	require.NoError(t, err)


### PR DESCRIPTION
Rolling an extractor back to an earlier version reactivates that extractor's metadata generation, and later runs reuse it instead of reprocessing. This documents that last-publication-wins behavior and adds tests for it, since it had neither before and a change could have altered it unnoticed.

Enforcing recency stays out of scope. Fingerprints identify a parser bundle but do not order bundles by age, so blocking an extractor downgrade would need an ordered version and a separate storage-contract decision (#270).

Refs #270
