### PR TITLE
fix(store): keep visual-preview heads from moving to older generations

### DIFF
--- a/docs/architecture/visual-previews.md
+++ b/docs/architecture/visual-previews.md
@@ -44,6 +44,12 @@ removes its preview generations. Content-addressed storage still deduplicates
 identical preview bytes across versions, and garbage collection retains an
 output while any generation references it.
 
+Recording a new recipe advances the head. Replaying a recorded generation
+does not replace a different active generation. Recipes have no age ordering,
+so a recipe from an older binary still becomes active if it has never been
+recorded for that version. When a head is missing, the first publication,
+including a replay, recreates it.
+
 ## Backup and embedded reads
 
 Preview generations, active heads, and ready output blobs are included in
@@ -55,11 +61,14 @@ and `Vault.OpenVisualPreview` to stream a ready output through the verified
 reader contract. Unsupported and failed results remain queryable but do not
 open as content.
 
-`Vault.EnsureVisualPreview` synchronously produces the current preview for one
-exact version when no matching generation exists. It verifies the complete
-source before decoding and holds the vault mutation boundary through
-publication, so callers either observe a complete generation or a retryable
-error.
+`Vault.EnsureVisualPreview` synchronously produces a preview with the current
+built-in recipe when no matching generation exists, then returns the active
+result. If that recipe already has a recorded outcome and a head exists, ensure
+skips production and returns the head even if another recipe published it.
+This keeps ensure consistent with `Vault.VisualPreview` and
+`Vault.OpenVisualPreview`. Production verifies the complete source before
+decoding and holds the vault mutation boundary through publication, so callers
+either observe a complete generation or a retryable error.
 
 The built-in producer accepts JPEG, PNG, GIF, still WebP, and camera RAW
 originals that contain a supported embedded JPEG preview. Camera RAW support

--- a/internal/store/visual_preview.go
+++ b/internal/store/visual_preview.go
@@ -43,7 +43,8 @@ func visualPreviewGenerationID(versionID, recipeFingerprint, checksum string) st
 
 // PublishVisualPreview validates and atomically publishes one exact-version
 // result. Ready results also commit the already-durable output blob receipt.
-// Retrying the identical publication is idempotent.
+// The active head advances only when recording a new generation or retrying
+// the current head. Retrying the identical publication is idempotent.
 func (s *Store) PublishVisualPreview(
 	ctx context.Context, versionID string, canonical []byte, physical *BlobPhysical,
 ) (VisualPreviewGeneration, error) {
@@ -84,7 +85,7 @@ func (s *Store) PublishVisualPreview(
 				return fmt.Errorf("recording visual preview output: %w", err)
 			}
 		}
-		if _, execErr := tx.ExecContext(ctx, `INSERT INTO visual_preview_generations(
+		result, execErr := tx.ExecContext(ctx, `INSERT INTO visual_preview_generations(
 			generation_id,vault_uid,content_version_id,source_sha256,contract_version,
 			recipe_fingerprint,canonical_result,checksum,state,output_blob_hash,output_size,
 			output_media_type,output_width,output_height,failure_code,failure_detail,created_at
@@ -94,8 +95,13 @@ func (s *Store) PublishVisualPreview(
 			preview.ContractVersion, recipeFingerprint, canonical, checksum, preview.State,
 			previewOutputHash(preview), previewOutputSize(preview), previewOutputMediaType(preview),
 			previewOutputWidth(preview), previewOutputHeight(preview), previewFailureCode(preview),
-			previewFailureDetail(preview), generation.CreatedAt); execErr != nil {
+			previewFailureDetail(preview), generation.CreatedAt)
+		if execErr != nil {
 			return fmt.Errorf("recording visual preview generation: %w", execErr)
+		}
+		inserted, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return fmt.Errorf("checking visual preview generation insertion: %w", rowsErr)
 		}
 		stored, readErr := visualPreviewGenerationByRecipeTx(ctx, tx, versionID, recipeFingerprint)
 		if readErr != nil {
@@ -106,11 +112,12 @@ func (s *Store) PublishVisualPreview(
 			return errors.New("visual preview recipe already has a different result")
 		}
 		generation = stored
-		_, execErr := tx.ExecContext(ctx, `INSERT INTO visual_preview_heads(
+		_, execErr = tx.ExecContext(ctx, `INSERT INTO visual_preview_heads(
 			content_version_id,generation_id,published_at
 		) VALUES(?,?,?) ON CONFLICT(content_version_id) DO UPDATE SET
-			generation_id=excluded.generation_id,published_at=excluded.published_at`,
-			versionID, generation.GenerationID, nowRFC3339())
+			generation_id=excluded.generation_id,published_at=excluded.published_at
+			WHERE ? != 0 OR visual_preview_heads.generation_id=excluded.generation_id`,
+			versionID, generation.GenerationID, nowRFC3339(), inserted)
 		return execErr
 	})
 	return generation, err

--- a/internal/store/visual_preview.go
+++ b/internal/store/visual_preview.go
@@ -169,6 +169,17 @@ func (s *Store) ContentVersionVisualPreview(
 	return VisualPreviewView{Version: version, Generation: generation, PublishedAt: publishedAt}, nil
 }
 
+// VisualPreviewGenerationByRecipe returns the recorded result for one exact
+// content version and recipe, whether or not it is the active head.
+func (s *Store) VisualPreviewGenerationByRecipe(
+	ctx context.Context, versionID, recipeFingerprint string,
+) (VisualPreviewGeneration, error) {
+	if err := validateUUIDv4(versionID); err != nil {
+		return VisualPreviewGeneration{}, fmt.Errorf("content version %q: %w", versionID, ErrNotFound)
+	}
+	return visualPreviewGenerationByRecipeTx(ctx, s.db, versionID, recipeFingerprint)
+}
+
 func visualPreviewGenerationByRecipeTx(
 	ctx context.Context, q metadataQuerier, versionID, recipeFingerprint string,
 ) (VisualPreviewGeneration, error) {

--- a/internal/store/visual_preview_test.go
+++ b/internal/store/visual_preview_test.go
@@ -43,6 +43,57 @@ func TestVisualPreviewPublicationIsExactVersionAndIdempotent(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound, "conflicting output membership must roll back")
 }
 
+func TestVisualPreviewHeadAdvancesOnFirstRecordingAndHoldsOnRepublication(t *testing.T) {
+	s := newTestStore(t)
+	node, err := s.CreateFile(t.Context(), s.RootID(), "photo.raw", fakeHash("91"), 12, "image/x-raw")
+	require.NoError(t, err)
+	physical := &BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 9}
+
+	previewA := readyVisualPreview(t, node.BlobHash, fakeHash("92"), 9)
+	first, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, previewA, physical)
+	require.NoError(t, err)
+	view, err := s.ContentVersionVisualPreview(t.Context(), node.CurrentVersionID)
+	require.NoError(t, err)
+	assert.Equal(t, first.GenerationID, view.Generation.GenerationID)
+
+	recipeB := visualPreviewRecipe()
+	recipeB.ProcessorFingerprint = fakeHash("93")
+	previewB := readyVisualPreviewWithRecipe(t, node.BlobHash, fakeHash("94"), 9, recipeB)
+	second, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, previewB, physical)
+	require.NoError(t, err)
+	assert.NotEqual(t, first.GenerationID, second.GenerationID)
+
+	replayed, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, previewA, physical)
+	require.NoError(t, err)
+	assert.Equal(t, first.GenerationID, replayed.GenerationID)
+
+	view, err = s.ContentVersionVisualPreview(t.Context(), node.CurrentVersionID)
+	require.NoError(t, err)
+	assert.Equal(t, second.GenerationID, view.Generation.GenerationID)
+	assert.Equal(t, fakeHash("94"), view.Generation.Preview.Output.BlobSHA256)
+}
+
+func TestVisualPreviewHeadAppearsWhenMissingForRecordedGeneration(t *testing.T) {
+	s := newTestStore(t)
+	node, err := s.CreateFile(t.Context(), s.RootID(), "photo.raw", fakeHash("95"), 12, "image/x-raw")
+	require.NoError(t, err)
+	canonical := readyVisualPreview(t, node.BlobHash, fakeHash("96"), 9)
+	physical := &BlobPhysical{Encoding: looseEncodingRaw, StoredBytes: 9}
+
+	first, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, canonical, physical)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`DELETE FROM visual_preview_heads WHERE content_version_id=?`, node.CurrentVersionID)
+	require.NoError(t, err)
+
+	recovered, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, canonical, physical)
+	require.NoError(t, err)
+	assert.Equal(t, first.GenerationID, recovered.GenerationID)
+
+	view, err := s.ContentVersionVisualPreview(t.Context(), node.CurrentVersionID)
+	require.NoError(t, err)
+	assert.Equal(t, first.GenerationID, view.Generation.GenerationID)
+}
+
 func TestVisualPreviewMetadataRoundTrip(t *testing.T) {
 	source := newTestStore(t)
 	node, err := source.CreateFile(t.Context(), source.RootID(), "image.jpg", fakeHash("31"), 12, "image/jpeg")
@@ -162,9 +213,16 @@ func (r *visualPreviewVerifiedReader) Verify() error  { return r.verifyErr }
 
 func readyVisualPreview(t *testing.T, source, output string, size int64) []byte {
 	t.Helper()
+	return readyVisualPreviewWithRecipe(t, source, output, size, visualPreviewRecipe())
+}
+
+func readyVisualPreviewWithRecipe(
+	t *testing.T, source, output string, size int64, recipe document.VisualPreviewRecipeV1,
+) []byte {
+	t.Helper()
 	canonical, _, err := document.MarshalVisualPreviewV1(document.VisualPreviewV1{
 		ContractVersion: document.VisualPreviewContractV1, SourceSHA256: source,
-		Recipe: visualPreviewRecipe(), State: document.VisualPreviewReady,
+		Recipe: recipe, State: document.VisualPreviewReady,
 		Output: &document.VisualPreviewOutputV1{BlobSHA256: output, Size: size,
 			MediaType: "image/jpeg", Width: 1600, Height: 900},
 	})

--- a/internal/store/visual_preview_test.go
+++ b/internal/store/visual_preview_test.go
@@ -94,6 +94,44 @@ func TestVisualPreviewHeadAppearsWhenMissingForRecordedGeneration(t *testing.T) 
 	assert.Equal(t, first.GenerationID, view.Generation.GenerationID)
 }
 
+func TestVisualPreviewTerminalHeadsHoldOnRepublication(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		state document.VisualPreviewState
+		code  string
+	}{
+		{name: "unsupported", state: document.VisualPreviewUnsupported, code: "unsupported_media_type"},
+		{name: "failed", state: document.VisualPreviewFailed, code: "decode_failed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := newTestStore(t)
+			node, err := s.CreateFile(t.Context(), s.RootID(), "photo.raw", fakeHash("97"), 12, "image/x-raw")
+			require.NoError(t, err)
+
+			recipeA := visualPreviewRecipe()
+			previewA := terminalVisualPreviewWithRecipe(t, node.BlobHash, recipeA, test.state, test.code)
+			first, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, previewA, nil)
+			require.NoError(t, err)
+
+			recipeB := recipeA
+			recipeB.ProcessorFingerprint = fakeHash("98")
+			previewB := terminalVisualPreviewWithRecipe(t, node.BlobHash, recipeB, test.state, test.code)
+			second, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, previewB, nil)
+			require.NoError(t, err)
+			assert.NotEqual(t, first.GenerationID, second.GenerationID)
+
+			replayed, err := s.PublishVisualPreview(t.Context(), node.CurrentVersionID, previewA, nil)
+			require.NoError(t, err)
+			assert.Equal(t, first.GenerationID, replayed.GenerationID)
+
+			view, err := s.ContentVersionVisualPreview(t.Context(), node.CurrentVersionID)
+			require.NoError(t, err)
+			assert.Equal(t, second.GenerationID, view.Generation.GenerationID)
+			assert.Equal(t, test.state, view.Generation.Preview.State)
+		})
+	}
+}
+
 func TestVisualPreviewMetadataRoundTrip(t *testing.T) {
 	source := newTestStore(t)
 	node, err := source.CreateFile(t.Context(), source.RootID(), "image.jpg", fakeHash("31"), 12, "image/jpeg")
@@ -225,6 +263,20 @@ func readyVisualPreviewWithRecipe(
 		Recipe: recipe, State: document.VisualPreviewReady,
 		Output: &document.VisualPreviewOutputV1{BlobSHA256: output, Size: size,
 			MediaType: "image/jpeg", Width: 1600, Height: 900},
+	})
+	require.NoError(t, err)
+	return canonical
+}
+
+func terminalVisualPreviewWithRecipe(
+	t *testing.T, source string, recipe document.VisualPreviewRecipeV1,
+	state document.VisualPreviewState, code string,
+) []byte {
+	t.Helper()
+	canonical, _, err := document.MarshalVisualPreviewV1(document.VisualPreviewV1{
+		ContractVersion: document.VisualPreviewContractV1, SourceSHA256: source,
+		Recipe: recipe, State: state,
+		Failure: &document.VisualPreviewFailureV1{Code: code, Detail: "deterministic preview outcome"},
 	})
 	require.NoError(t, err)
 	return canonical

--- a/vault.go
+++ b/vault.go
@@ -442,9 +442,10 @@ func (v *Vault) VisualPreview(ctx context.Context, versionID string) (VisualPrev
 	return fromStoreVisualPreview(view), nil
 }
 
-// EnsureVisualPreview returns the current built-in preview for one exact
-// immutable content version, producing and publishing it synchronously when
-// the current recipe has not processed those bytes.
+// EnsureVisualPreview returns the active preview for one exact immutable
+// content version, producing and publishing it synchronously when the current
+// built-in recipe has not processed those bytes. A recorded recipe is reused
+// without replacing a head published by another recipe.
 func (v *Vault) EnsureVisualPreview(ctx context.Context, versionID string) (VisualPreview, error) {
 	if err := v.begin(); err != nil {
 		return VisualPreview{}, err
@@ -465,11 +466,17 @@ func (v *Vault) EnsureVisualPreview(ctx context.Context, versionID string) (Visu
 		return VisualPreview{}, err
 	}
 	view, err := v.metadata.ContentVersionVisualPreview(ctx, versionID)
-	if err == nil && view.Generation.RecipeFingerprint == recipeFingerprint {
-		return fromStoreVisualPreview(view), nil
-	}
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return VisualPreview{}, err
+	}
+	if err == nil {
+		_, err = v.metadata.VisualPreviewGenerationByRecipe(ctx, versionID, recipeFingerprint)
+		if err == nil {
+			return fromStoreVisualPreview(view), nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return VisualPreview{}, err
+		}
 	}
 	reader, size, err := v.blobs.OpenSeekableContext(ctx, version.BlobHash)
 	if err != nil {

--- a/vault_test.go
+++ b/vault_test.go
@@ -397,6 +397,58 @@ func TestVaultEnsureVisualPreviewProducesBoundedJPEG(t *testing.T) {
 	assert.Equal(t, 2, decoded.Bounds().Dy())
 }
 
+func TestVaultEnsureVisualPreviewReusesRecordedRecipeAfterHeadAdvances(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		source    []byte
+		mediaType string
+		state     document.VisualPreviewState
+	}{
+		{"ready", mediatest.JPEG(3, 2, color.White), "image/jpeg", document.VisualPreviewReady},
+		{"unsupported", []byte("plain text"), "text/plain", document.VisualPreviewUnsupported},
+		{"failed", []byte("malformed jpeg"), "image/jpeg", document.VisualPreviewFailed},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			vault, err := New(t.Context(), Config{Root: t.TempDir()})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, vault.Close()) })
+			receipt, err := vault.Create(t.Context(), "/source", bytes.NewReader(test.source), CreateOptions{
+				MediaType: test.mediaType, Expected: contentIdentity(test.source),
+			})
+			require.NoError(t, err)
+			current, err := vault.EnsureVisualPreview(t.Context(), receipt.Version.ID)
+			require.NoError(t, err)
+			require.Equal(t, test.state, current.State)
+
+			otherRecipe := current.Recipe
+			otherRecipe.ProcessorFingerprint = strings.Repeat("4", 64)
+			canonical, _, err := document.MarshalVisualPreviewV1(document.VisualPreviewV1{
+				ContractVersion: document.VisualPreviewContractV1, SourceSHA256: receipt.Version.BlobHash,
+				Recipe: otherRecipe, State: document.VisualPreviewUnsupported,
+				Failure: &document.VisualPreviewFailureV1{Code: "unsupported_media_type", Detail: "unsupported by this producer"},
+			})
+			require.NoError(t, err)
+			other, err := vault.metadata.PublishVisualPreview(t.Context(), receipt.Version.ID, canonical, nil)
+			require.NoError(t, err)
+			require.NotEqual(t, current.GenerationID, other.GenerationID)
+			head, err := vault.VisualPreview(t.Context(), receipt.Version.ID)
+			require.NoError(t, err)
+			require.Equal(t, other.GenerationID, head.GenerationID)
+
+			// An already processed recipe must not need to reopen the source.
+			require.NoError(t, vault.blobs.Remove(receipt.Version.BlobHash))
+			for range 3 {
+				retry, err := vault.EnsureVisualPreview(t.Context(), receipt.Version.ID)
+				require.NoError(t, err)
+				assert.Equal(t, head, retry)
+			}
+			active, err := vault.VisualPreview(t.Context(), receipt.Version.ID)
+			require.NoError(t, err)
+			assert.Equal(t, head, active)
+		})
+	}
+}
+
 func TestVaultEnsureVisualPreviewRemovesLooseDuplicateOfPackedOutput(t *testing.T) {
 	root := t.TempDir()
 	vault, err := New(t.Context(), Config{Root: root})


### PR DESCRIPTION
Docbank keeps the active visual preview when a previously recorded preview is published again. For example, after recipes A and B have both run, replaying A returns its stored result without replacing B as the active preview.

Ensure checks whether its built-in recipe already has a recorded outcome, so returning to recipe A does not repeatedly decode and encode the source. It returns the active head, keeping it consistent with preview inspection and streaming.

This prevents replay from replacing a different head; it does not rank recipes by age. A previously unseen recipe still becomes active, even from an older binary. The first publication recreates a missing head, and retrying the current head still refreshes its publication time. Source-metadata ordering and runtime-dependent recipe fingerprints remain outside this change, so #270 stays open.

Refs #270
