### PR TITLE
Let embedded applications create and restore backups

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -1,0 +1,359 @@
+package docbank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/kit/backup"
+
+	"go.kenn.io/docbank/internal/backupapp"
+	"go.kenn.io/docbank/internal/home"
+	"go.kenn.io/docbank/internal/version"
+)
+
+var (
+	// ErrBackupRepositoryLocked means another writer owns the snapshot repository.
+	ErrBackupRepositoryLocked = backup.ErrRepoLocked
+	// ErrBackupRestoreTargetActive means another vault or restore owns an overlapping root.
+	ErrBackupRestoreTargetActive = backupapp.ErrRestoreTargetActive
+	// ErrBackupRestoreTargetChanged means the target path stopped naming the held directory.
+	ErrBackupRestoreTargetChanged = backupapp.ErrRestoreTargetChanged
+	// ErrBackupRestoreTargetNotEmpty means overwrite was required for an existing target payload.
+	ErrBackupRestoreTargetNotEmpty = backupapp.ErrRestoreTargetNotEmpty
+	// ErrBackupRestoreTargetOverlap means the target or repository overlaps protected vault storage.
+	ErrBackupRestoreTargetOverlap = backupapp.ErrRestoreTargetOverlap
+)
+
+// BackupRepository is one initialized immutable snapshot repository.
+type BackupRepository struct {
+	repo *backup.Repo
+}
+
+// BackupOptions controls one embedded vault snapshot.
+type BackupOptions struct {
+	Tag         string
+	ZstdLevel   int
+	Jobs        int
+	ForceUnlock bool
+	Progress    func(BackupProgress)
+}
+
+// BackupVerifyOptions controls repository verification. SnapshotID selects
+// the latest snapshot when empty. All and SnapshotID are mutually exclusive.
+type BackupVerifyOptions struct {
+	SnapshotID  string
+	All         bool
+	Quick       bool
+	Jobs        int
+	ForceUnlock bool
+	Progress    func(BackupProgress)
+}
+
+// BackupRestoreOptions controls restore into a separate vault root.
+type BackupRestoreOptions struct {
+	SnapshotID  string
+	Target      string
+	Overwrite   bool
+	Jobs        int
+	ForceUnlock bool
+	Progress    func(BackupProgress)
+}
+
+// BackupProgress reports one structured stage update.
+type BackupProgress struct {
+	Stage      string
+	Done       int64
+	Total      int64
+	BytesDone  int64
+	BytesTotal int64
+	Final      bool
+}
+
+// BackupSnapshot summarizes one immutable recovery point.
+type BackupSnapshot struct {
+	ID              string
+	ParentID        string
+	CreatedAt       string
+	Tag             string
+	MetadataFormat  string
+	Nodes           int64
+	Files           int64
+	Blobs           int64
+	BlobBytes       int64
+	PacksAdded      int
+	BytesAdded      int64
+	DurationSeconds float64
+}
+
+// BackupVerifyProblem identifies one repository-integrity finding.
+type BackupVerifyProblem struct {
+	SnapshotID string
+	Detail     string
+}
+
+// BackupVerifyReport summarizes a completed repository verification pass.
+type BackupVerifyReport struct {
+	Snapshots    []string
+	BlobsChecked int64
+	BytesRead    int64
+	Problems     []BackupVerifyProblem
+}
+
+// BackupRestoreProof states the checks completed before restore publication.
+type BackupRestoreProof struct {
+	ContentVerified bool
+	SQLiteIntegrity bool
+	ManifestStats   bool
+}
+
+// BackupRestoreReport summarizes a completely materialized restored vault.
+type BackupRestoreReport struct {
+	SnapshotID      string
+	Target          string
+	DatabasePath    string
+	DatabaseBytes   int64
+	ContentBlobs    int64
+	ContentBytes    int64
+	PackedBlobs     int64
+	LooseBlobs      int64
+	Packs           int
+	ExtrasFiles     int
+	DurationSeconds float64
+	Proof           BackupRestoreProof
+}
+
+// InitBackupRepository initializes an empty immutable snapshot repository.
+func InitBackupRepository(root string) (*BackupRepository, error) {
+	canonical, err := home.CanonicalRoot(root)
+	if err != nil {
+		return nil, fmt.Errorf("initializing backup repository: %w", err)
+	}
+	repo, err := backup.Init(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("initializing backup repository: %w", err)
+	}
+	return &BackupRepository{repo: repo}, nil
+}
+
+// OpenBackupRepository opens an existing compatible snapshot repository.
+func OpenBackupRepository(root string) (*BackupRepository, error) {
+	canonical, err := home.CanonicalRoot(root)
+	if err != nil {
+		return nil, fmt.Errorf("opening backup repository: %w", err)
+	}
+	repo, err := backup.Open(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("opening backup repository: %w", err)
+	}
+	return &BackupRepository{repo: repo}, nil
+}
+
+// ID returns the repository's stable identity.
+func (r *BackupRepository) ID() string {
+	if r == nil || r.repo == nil {
+		return ""
+	}
+	return r.repo.Config().RepoID
+}
+
+// Root returns the repository's canonical filesystem root.
+func (r *BackupRepository) Root() string {
+	if r == nil || r.repo == nil {
+		return ""
+	}
+	return r.repo.Root()
+}
+
+// Snapshots lists immutable recovery points from oldest to newest.
+func (r *BackupRepository) Snapshots() ([]BackupSnapshot, error) {
+	if r == nil || r.repo == nil {
+		return nil, errors.New("docbank backup repository is required")
+	}
+	manifests, err := r.repo.ListSnapshots()
+	if err != nil {
+		return nil, fmt.Errorf("listing backup snapshots: %w", err)
+	}
+	snapshots := make([]BackupSnapshot, 0, len(manifests))
+	for _, manifest := range manifests {
+		snapshot, err := backupSnapshot(manifest)
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	return snapshots, nil
+}
+
+// CreateBackup captures a coherent logical snapshot. The metadata freeze is
+// short; ordinary appends resume while physical maintenance remains fenced.
+func (v *Vault) CreateBackup(
+	ctx context.Context, repository *BackupRepository, opts BackupOptions,
+) (BackupSnapshot, error) {
+	if err := v.begin(); err != nil {
+		return BackupSnapshot{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	if repository == nil || repository.repo == nil {
+		return BackupSnapshot{}, errors.New("docbank backup repository is required")
+	}
+	if err := backupapp.ValidateDisjointRoots(v.root.Name(), repository.repo.Root()); err != nil {
+		return BackupSnapshot{}, err
+	}
+	v.preservation.RLock()
+	defer v.preservation.RUnlock()
+	manifest, err := backupapp.Create(ctx, repository.repo, version.Version, v.metadata, v.blobs,
+		backup.CreateOptions{
+			Tag: opts.Tag, ZstdLevel: opts.ZstdLevel, Jobs: opts.Jobs,
+			ForceUnlock: opts.ForceUnlock, Progress: backupProgressCallback(opts.Progress),
+			Freezer: &vaultBackupFreezer{vault: v},
+		})
+	if err != nil {
+		return BackupSnapshot{}, fmt.Errorf("creating backup snapshot: %w", err)
+	}
+	return backupSnapshot(manifest)
+}
+
+// Verify checks repository structure and, unless Quick is set, every selected
+// content blob.
+func (r *BackupRepository) Verify(
+	ctx context.Context, opts BackupVerifyOptions,
+) (BackupVerifyReport, error) {
+	if r == nil || r.repo == nil {
+		return BackupVerifyReport{}, errors.New("docbank backup repository is required")
+	}
+	if opts.All && opts.SnapshotID != "" {
+		return BackupVerifyReport{}, errors.New("docbank backup snapshot ID and all are mutually exclusive")
+	}
+	result, err := backup.Verify(ctx, r.repo, backupapp.New(version.Version), backup.VerifyOptions{
+		SnapshotID: opts.SnapshotID, All: opts.All, Quick: opts.Quick, Jobs: opts.Jobs,
+		ForceUnlock: opts.ForceUnlock, Progress: backupProgressCallback(opts.Progress),
+	})
+	if err != nil {
+		return BackupVerifyReport{}, fmt.Errorf("verifying backup repository: %w", err)
+	}
+	report := BackupVerifyReport{
+		Snapshots: result.Snapshots, BlobsChecked: result.BlobsChecked,
+		BytesRead: result.BytesRead,
+		Problems:  make([]BackupVerifyProblem, 0, len(result.Problems)),
+	}
+	for _, problem := range result.Problems {
+		report.Problems = append(report.Problems, BackupVerifyProblem{
+			SnapshotID: problem.SnapshotID, Detail: problem.Detail,
+		})
+	}
+	return report, nil
+}
+
+// RestoreBackup materializes and proves a snapshot in a root disjoint from
+// both the live vault and repository. It never replaces the open vault.
+func (v *Vault) RestoreBackup(
+	ctx context.Context, repository *BackupRepository, opts BackupRestoreOptions,
+) (report BackupRestoreReport, retErr error) {
+	if err := v.begin(); err != nil {
+		return BackupRestoreReport{}, err
+	}
+	defer v.lifecycle.RUnlock()
+	if repository == nil || repository.repo == nil {
+		return BackupRestoreReport{}, errors.New("docbank backup repository is required")
+	}
+	if opts.Target == "" {
+		return BackupRestoreReport{}, errors.New("docbank backup restore target is required")
+	}
+	target, err := home.CanonicalRoot(opts.Target)
+	if err != nil {
+		return BackupRestoreReport{}, fmt.Errorf("resolving backup restore target: %w", err)
+	}
+	if err := backupapp.ValidateDisjointRoots(target, repository.repo.Root(), v.root.Name()); err != nil {
+		return BackupRestoreReport{}, err
+	}
+	coordinator := backupapp.NewRestoreTargetCoordinator(
+		target, repository.repo.Root(), v.root.Name(), opts.Overwrite,
+	)
+	if err := coordinator.Prepare(ctx); err != nil {
+		return BackupRestoreReport{}, fmt.Errorf("preparing backup restore target: %w", err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, coordinator.ReleasePreparation())
+	}()
+	result, err := backupapp.RestoreWithDriver(
+		ctx, repository.repo, version.Version, v.metadata.SQLiteDriver(), backup.RestoreOptions{
+			SnapshotID: opts.SnapshotID, TargetDir: target, Overwrite: true,
+			Jobs: opts.Jobs, ForceUnlock: opts.ForceUnlock,
+			Progress:          backupProgressCallback(opts.Progress),
+			TargetCoordinator: coordinator,
+		})
+	if err != nil {
+		return BackupRestoreReport{}, fmt.Errorf("restoring backup snapshot: %w", err)
+	}
+	return BackupRestoreReport{
+		SnapshotID: result.SnapshotID, Target: target, DatabasePath: result.DBPath,
+		DatabaseBytes: result.DBBytes, ContentBlobs: result.AttachmentBlobs,
+		ContentBytes: result.AttachmentBytes, PackedBlobs: result.PackedAttachmentBlobs,
+		LooseBlobs: result.LooseAttachmentBlobs, Packs: result.AttachmentPacks,
+		ExtrasFiles: result.ExtrasFiles, DurationSeconds: result.Duration.Seconds(),
+		Proof: BackupRestoreProof{
+			ContentVerified: true, SQLiteIntegrity: result.DatabaseIntegrityChecked,
+			ManifestStats: true,
+		},
+	}, nil
+}
+
+type vaultBackupFreezer struct {
+	vault *Vault
+	held  bool
+}
+
+func (f *vaultBackupFreezer) Begin(ctx context.Context) error {
+	if f.held {
+		return errors.New("docbank backup freeze is already held")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	f.vault.mutation.Lock()
+	f.held = true
+	return nil
+}
+
+func (f *vaultBackupFreezer) End(context.Context) error {
+	if !f.held {
+		return errors.New("docbank backup freeze is not held")
+	}
+	f.held = false
+	f.vault.mutation.Unlock()
+	return nil
+}
+
+func backupProgressCallback(callback func(BackupProgress)) func(backup.ProgressEvent) {
+	if callback == nil {
+		return nil
+	}
+	return func(event backup.ProgressEvent) {
+		callback(BackupProgress{
+			Stage: string(event.Stage), Done: event.Done, Total: event.Total,
+			BytesDone: event.BytesDone, BytesTotal: event.BytesTotal, Final: event.Final,
+		})
+	}
+}
+
+func backupSnapshot(manifest *backup.Manifest) (BackupSnapshot, error) {
+	if manifest == nil {
+		return BackupSnapshot{}, errors.New("docbank backup manifest is nil")
+	}
+	stats, err := backupapp.ParseStats(manifest.Stats)
+	if err != nil {
+		return BackupSnapshot{}, fmt.Errorf("reading backup snapshot %s: %w", manifest.SnapshotID, err)
+	}
+	metadataFormat := "sqlite-page-map"
+	if manifest.Metadata != nil {
+		metadataFormat = manifest.Metadata.Format
+	}
+	return BackupSnapshot{
+		ID: manifest.SnapshotID, ParentID: manifest.ParentID, CreatedAt: manifest.CreatedAt,
+		Tag: manifest.Options.Tag, MetadataFormat: metadataFormat,
+		Nodes: stats.Nodes, Files: stats.Files, Blobs: stats.Blobs, BlobBytes: stats.BlobBytes,
+		PacksAdded: len(manifest.NewPacks), BytesAdded: manifest.BytesAdded,
+		DurationSeconds: manifest.DurationSeconds,
+	}, nil
+}

--- a/backup_external_test.go
+++ b/backup_external_test.go
@@ -1,0 +1,177 @@
+package docbank_test
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	docbank "go.kenn.io/docbank"
+)
+
+func TestEmbeddedBackupRoundTrip(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+
+	content := []byte("embedded backup content\n")
+	created := createRangeFixture(t, vault, "/archive/photo.txt", content)
+
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+	snapshot, err := vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{Tag: "before-edit"})
+	require.NoError(t, err)
+	require.NotEmpty(t, snapshot.ID)
+	require.Equal(t, "before-edit", snapshot.Tag)
+
+	snapshots, err := repository.Snapshots()
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	require.Equal(t, snapshot.ID, snapshots[0].ID)
+
+	verified, err := repository.Verify(t.Context(), docbank.BackupVerifyOptions{SnapshotID: snapshot.ID})
+	require.NoError(t, err)
+	require.Equal(t, []string{snapshot.ID}, verified.Snapshots)
+	require.Empty(t, verified.Problems)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	restored, err := vault.RestoreBackup(t.Context(), repository, docbank.BackupRestoreOptions{
+		SnapshotID: snapshot.ID,
+		Target:     target,
+	})
+	require.NoError(t, err)
+	require.Equal(t, snapshot.ID, restored.SnapshotID)
+	require.True(t, restored.Proof.ContentVerified)
+	require.True(t, restored.Proof.SQLiteIntegrity)
+	require.True(t, restored.Proof.ManifestStats)
+
+	restoredVault, err := docbank.New(t.Context(), docbank.Config{Root: target})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restoredVault.Close()) })
+	opened, err := restoredVault.OpenVersionContent(t.Context(), created.Version.ID)
+	require.NoError(t, err)
+	got, err := io.ReadAll(opened.Reader)
+	require.NoError(t, err)
+	require.NoError(t, opened.Reader.Verify())
+	require.NoError(t, opened.Reader.Close())
+	require.Equal(t, content, got)
+}
+
+func TestEmbeddedBackupFencesPhysicalMaintenance(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	createRangeFixture(t, vault, "/archive/photo.txt", []byte("backup fence content\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+
+	paused := make(chan struct{})
+	resume := make(chan struct{})
+	var pauseOnce sync.Once
+	var resumeOnce sync.Once
+	t.Cleanup(func() { resumeOnce.Do(func() { close(resume) }) })
+	backupDone := make(chan error, 1)
+	go func() {
+		_, err := vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{
+			Progress: func(progress docbank.BackupProgress) {
+				if progress.Stage == "freeze" && progress.Final {
+					pauseOnce.Do(func() { close(paused) })
+					<-resume
+				}
+			},
+		})
+		backupDone <- err
+	}()
+	select {
+	case <-paused:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "backup did not reach its post-freeze capture")
+	}
+
+	packDone := make(chan error, 1)
+	go func() {
+		_, err := vault.Pack(t.Context(), docbank.PackOptions{})
+		packDone <- err
+	}()
+	select {
+	case err := <-packDone:
+		require.FailNow(t, "physical maintenance completed during backup capture", "error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	resumeOnce.Do(func() { close(resume) })
+	require.NoError(t, <-backupDone)
+	require.NoError(t, <-packDone)
+}
+
+func TestEmbeddedBackupAllowsAppendsAfterFreeze(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	createRangeFixture(t, vault, "/archive/photo.txt", []byte("snapshot content\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+
+	paused := make(chan struct{})
+	resume := make(chan struct{})
+	var pauseOnce sync.Once
+	var resumeOnce sync.Once
+	t.Cleanup(func() { resumeOnce.Do(func() { close(resume) }) })
+	backupDone := make(chan error, 1)
+	go func() {
+		_, err := vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{
+			Progress: func(progress docbank.BackupProgress) {
+				if progress.Stage == "freeze" && progress.Final {
+					pauseOnce.Do(func() { close(paused) })
+					<-resume
+				}
+			},
+		})
+		backupDone <- err
+	}()
+	select {
+	case <-paused:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "backup did not reach its post-freeze capture")
+	}
+
+	putDone := make(chan error, 1)
+	go func() {
+		_, err := vault.Put(t.Context(), "/archive/later.txt", bytes.NewBufferString("later\n"), docbank.PutOptions{
+			MediaType: "text/plain",
+		})
+		putDone <- err
+	}()
+	select {
+	case err := <-putDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		resumeOnce.Do(func() { close(resume) })
+		require.FailNow(t, "append remained blocked after the backup freeze ended")
+	}
+
+	resumeOnce.Do(func() { close(resume) })
+	require.NoError(t, <-backupDone)
+}
+
+func TestEmbeddedRestoreRejectsLiveVaultOverlap(t *testing.T) {
+	liveRoot := filepath.Join(t.TempDir(), "live")
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: liveRoot})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	createRangeFixture(t, vault, "/archive/photo.txt", []byte("overlap content\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+	snapshot, err := vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{})
+	require.NoError(t, err)
+
+	_, err = vault.RestoreBackup(t.Context(), repository, docbank.BackupRestoreOptions{
+		SnapshotID: snapshot.ID,
+		Target:     filepath.Join(liveRoot, "restore"),
+	})
+	require.ErrorIs(t, err, docbank.ErrBackupRestoreTargetOverlap)
+}

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -5,9 +5,11 @@ description: Docbank's JSONL-native Kit snapshot and restore architecture.
 
 # Backup and recovery
 
-`docbank backup init`, `backup create`, `backup list`, `backup verify`, and
-`backup restore` are implemented over the authenticated daemon API; see the
-[Backup user guide](../usage/backup.md).
+Standalone `docbank backup init`, `backup create`, `backup list`, `backup
+verify`, and `backup restore` use the authenticated daemon API; see the
+[Backup user guide](../usage/backup.md). Applications that own an embedded
+vault use `BackupRepository`, `Vault.CreateBackup`, and `Vault.RestoreBackup`
+directly; see [Embedding Docbank](../embedding.md#back-up-and-restore-an-embedded-vault).
 A coherent local-state filesystem snapshot remains available by stopping the
 daemon before copying the vault, but it is not a topology-independent backup;
 see [Vault Lifecycle](../usage/lifecycle.md#take-a-coherent-backup).
@@ -25,10 +27,10 @@ runtime records are not archive state. A restored copy is not trusted until
 
 The internal `backupapp` adapter supplies Kit with Docbank's frozen logical
 view: every authoritative `blobs` row, representation-neutral fidelity stats,
-and mixed loose/packed content reads. A short daemon freeze opens and pins one
-deferred SQLite read transaction; the freeze then ends, writers resume into the
-WAL, and metadata, content membership, and fidelity statistics continue to see
-the same point-in-time state.
+and mixed loose/packed content reads. A short operation-owner freeze opens and
+pins one deferred SQLite read transaction; the freeze then ends, writers resume
+into the WAL, and metadata, content membership, and fidelity statistics
+continue to see the same point-in-time state.
 
 The same pinned transaction emits a separate deterministic
 `docbank-placement-v1` artifact. It names source store UUIDs, display names,
@@ -117,18 +119,19 @@ reporting success. The human CLI renders the same events as terminal bars or
 plain log lines. Machine-readable CLI output uses the non-streaming endpoint so
 stdout remains one JSON document.
 
-Repository verification is daemon-mediated even though it reads the backup
-repository rather than the live vault. The authenticated JSON endpoint returns
-one complete typed report; the NDJSON endpoint carries Kit's verification
-progress followed by exactly one terminal report or error. Quick mode proves
-structure and references without reading document content. Full mode reads and
-hash-verifies referenced content, deduplicating shared objects across selected
-snapshots, and returns every finding rather than stopping at the first damaged
-object. Kit's shared repository lock permits concurrent verifies and restores
-while excluding repository writers.
+Standalone repository verification is daemon-mediated, while embedded owners
+call `BackupRepository.Verify` directly. Quick mode proves structure and
+references without reading document content. Full mode reads and hash-verifies
+referenced content, deduplicating shared objects across selected snapshots, and
+returns every finding rather than stopping at the first damaged object. Kit's
+shared repository lock permits concurrent verifies and restores while excluding
+repository writers. The daemon's authenticated JSON endpoint returns one
+complete typed report; its NDJSON endpoint carries progress followed by exactly
+one terminal report or error.
 
-Restore is likewise daemon-mediated but never mutates the running store. Before
-Kit receives a target, Docbank canonicalizes its existing path prefix and
+Standalone restore is daemon-mediated; embedded restore is invoked through the
+open vault but never mutates that running store. Before Kit receives a target,
+Docbank canonicalizes its existing path prefix and
 rejects any parent, descendant, or symlink alias overlapping the live vault or
 repository. Filesystem identity supplements those lexical checks for case- or
 normalization-equivalent aliases. Kit then opens the target without following a

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -369,6 +369,47 @@ final tree; an existing directory does not mean “move into.” The complete fi
 tree is validated before any change, so embedded applications can express file
 or directory swaps and nested moves without temporary names or partial completion.
 
+## Back up and restore an embedded vault
+
+An application that owns a vault in-process can use the same portable,
+topology-independent backup format as the daemon:
+
+```go
+repository, err := docbank.InitBackupRepository(backupRoot)
+if err != nil {
+    return err
+}
+snapshot, err := vault.CreateBackup(ctx, repository, docbank.BackupOptions{
+    Tag: "before-import",
+})
+if err != nil {
+    return err
+}
+proof, err := repository.Verify(ctx, docbank.BackupVerifyOptions{
+    SnapshotID: snapshot.ID,
+})
+if err != nil {
+	return err
+}
+if len(proof.Problems) != 0 {
+	return fmt.Errorf("backup verification found %d problems", len(proof.Problems))
+}
+_, err = vault.RestoreBackup(ctx, repository, docbank.BackupRestoreOptions{
+    SnapshotID: snapshot.ID,
+    Target:     restoreRoot,
+})
+return err
+```
+
+Use `OpenBackupRepository` after process restart. `Snapshots` lists immutable
+recovery points in chronological order. Capture holds a preservation lease for
+the complete snapshot, but ordinary appends resume after Docbank pins the short
+SQLite metadata view. Physical maintenance waits until the manifest is
+published. Restore always targets a separate root, rejects overlap with the
+live vault or repository, and proves content, SQLite integrity, and manifest
+statistics before publication. The embedded restore path reconstructs a fresh
+fixed primary; deployment-specific secondary-store placement is not restored.
+
 ## Maintain physical storage
 
 Ordinary `Put` calls publish loose content. Call `Pack` explicitly when the

--- a/internal/api/restore_lock.go
+++ b/internal/api/restore_lock.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"os"
-	"time"
 
 	"go.kenn.io/kit/backup"
 
-	"go.kenn.io/docbank/internal/home"
+	"go.kenn.io/docbank/internal/backupapp"
 )
 
 type restoreTargetCoordinator interface {
@@ -54,161 +52,44 @@ func newRestoreTargetCoordinator(
 	target, repoRoot, vaultRoot string, overwrite bool,
 ) restoreTargetCoordinator {
 	return &platformRestoreTargetCoordinator{
-		target: target, repoRoot: repoRoot, vaultRoot: vaultRoot, overwrite: overwrite,
+		inner: backupapp.NewRestoreTargetCoordinator(target, repoRoot, vaultRoot, overwrite),
 	}
 }
 
 type platformRestoreTargetCoordinator struct {
-	target    string
-	repoRoot  string
-	vaultRoot string
-	overwrite bool
-	launch    *home.Lock
-	ancestors *home.Lock
+	inner *backupapp.RestoreTargetCoordinator
 }
 
 func (c *platformRestoreTargetCoordinator) Prepare(ctx context.Context) error {
-	for {
-		launch, err := (home.Layout{Root: c.target}).TryLockLaunch()
-		if err == nil {
-			c.launch = launch
-			break
-		}
-		if !errors.Is(err, home.ErrVaultLocked) {
-			return c.lockError("serializing backup restore target creation", err)
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(100 * time.Millisecond):
-		}
-	}
-	ancestors, err := (home.Layout{Root: c.target}).TryLockExistingAncestors()
-	if err != nil {
-		_ = c.ReleasePreparation()
-		return c.lockError("locking backup restore target ancestors", err)
-	}
-	c.ancestors = ancestors
-	return nil
+	return restoreTargetProblem("preparing backup restore target", c.inner.Prepare(ctx))
 }
 
 func (c *platformRestoreTargetCoordinator) ReleasePreparation() error {
-	err := c.releaseAncestors()
-	err = errors.Join(err, c.releaseLaunch())
-	return err
-}
-
-func (c *platformRestoreTargetCoordinator) releaseAncestors() error {
-	var err error
-	if c.ancestors != nil {
-		err = c.ancestors.Release()
-		c.ancestors = nil
-	}
-	return err
-}
-
-func (c *platformRestoreTargetCoordinator) releaseLaunch() error {
-	var err error
-	if c.launch != nil {
-		err = c.launch.Release()
-		c.launch = nil
-	}
-	return err
+	return restoreTargetProblem("releasing backup restore target preparation", c.inner.ReleasePreparation())
 }
 
 func (c *platformRestoreTargetCoordinator) AcquireRestoreTarget(
 	ctx context.Context, root *os.Root,
 ) (backup.RestoreTargetLease, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	if err := c.validate(root); err != nil {
-		return nil, err
-	}
-	// Preparation holds shared ancestry while Kit opens or creates the pinned
-	// target. Retain the global creation mutex while replacing those shared
-	// locks with exclusive target ownership so no coordinated starter can enter
-	// the transition gap.
-	if err := c.releaseAncestors(); err != nil {
-		return nil, NewError(http.StatusInternalServerError, "backup_failed",
-			fmt.Sprintf("releasing backup restore ancestor preparation: %v", err))
-	}
-	lock, err := (home.Layout{Root: c.target}).TryLockExclusiveRoot(root)
-	if err != nil {
-		return nil, c.lockError("locking backup restore target", err)
-	}
-	if err := c.validate(root); err != nil {
-		_ = lock.Release()
-		return nil, err
-	}
-	if err := c.releaseLaunch(); err != nil {
-		_ = lock.Release()
-		return nil, NewError(http.StatusInternalServerError, "backup_failed",
-			fmt.Sprintf("releasing backup restore target preparation: %v", err))
-	}
-	return lock, nil
+	lease, err := c.inner.AcquireRestoreTarget(ctx, root)
+	return lease, restoreTargetProblem("acquiring backup restore target", err)
 }
 
-func (c *platformRestoreTargetCoordinator) lockError(action string, err error) error {
-	if errors.Is(err, home.ErrVaultLocked) {
+func restoreTargetProblem(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, backupapp.ErrRestoreTargetActive) {
 		return NewError(http.StatusConflict, "backup_restore_target_active",
 			"backup restore target overlaps another restore or running docbank daemon")
 	}
-	return NewError(http.StatusInternalServerError, "backup_failed",
-		fmt.Sprintf("%s: %v", action, err))
-}
-
-func (c *platformRestoreTargetCoordinator) validate(root *os.Root) error {
-	leaf, err := os.Lstat(c.target)
-	if err != nil {
-		return NewError(http.StatusUnprocessableEntity, "validation",
-			fmt.Sprintf("checking backup restore target: %v", err))
+	if errors.Is(err, backupapp.ErrRestoreTargetNotEmpty) {
+		return NewError(http.StatusConflict, "backup_restore_target_not_empty",
+			"backup restore target is not empty; set overwrite to merge into it")
 	}
-	if leaf.Mode()&os.ModeSymlink != 0 {
-		return NewError(http.StatusUnprocessableEntity, "validation",
-			"backup restore target was replaced with a symlink")
+	if errors.Is(err, backupapp.ErrRestoreTargetChanged) ||
+		errors.Is(err, backupapp.ErrRestoreTargetOverlap) {
+		return NewError(http.StatusUnprocessableEntity, "validation", err.Error())
 	}
-	held, err := root.Stat(".")
-	if err != nil {
-		return NewError(http.StatusInternalServerError, "backup_failed",
-			fmt.Sprintf("checking held backup restore target: %v", err))
-	}
-	if !os.SameFile(leaf, held) {
-		return NewError(http.StatusUnprocessableEntity, "validation",
-			"backup restore target was replaced while acquiring coordination")
-	}
-	for _, protected := range []struct {
-		path    string
-		detail  string
-		failure string
-	}{
-		{c.repoRoot, "backup restore target must be disjoint from the backup repository",
-			"checking backup repository overlap"},
-		{c.vaultRoot, "backup restore target must be disjoint from the running vault",
-			"checking live vault overlap"},
-	} {
-		if protected.path == "" {
-			continue
-		}
-		overlaps, overlapErr := pathsOverlap(c.target, protected.path)
-		if overlapErr != nil {
-			return NewError(http.StatusUnprocessableEntity, "validation",
-				fmt.Sprintf("%s: %v", protected.failure, overlapErr))
-		}
-		if overlaps {
-			return NewError(http.StatusUnprocessableEntity, "validation", protected.detail)
-		}
-	}
-	if !c.overwrite {
-		entries, err := fs.ReadDir(root.FS(), ".")
-		if err != nil {
-			return NewError(http.StatusUnprocessableEntity, "validation",
-				fmt.Sprintf("reading held backup restore target: %v", err))
-		}
-		if restoreTargetHasPayload(entries) {
-			return NewError(http.StatusConflict, "backup_restore_target_not_empty",
-				"backup restore target is not empty; set overwrite to merge into it")
-		}
-	}
-	return nil
+	return NewError(http.StatusInternalServerError, "backup_failed", fmt.Sprintf("%s: %v", action, err))
 }

--- a/internal/backupapp/restore_target.go
+++ b/internal/backupapp/restore_target.go
@@ -1,0 +1,227 @@
+package backupapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.kenn.io/kit/backup"
+
+	"go.kenn.io/docbank/internal/home"
+)
+
+var (
+	ErrRestoreTargetActive   = errors.New("backup restore target is active")
+	ErrRestoreTargetChanged  = errors.New("backup restore target changed")
+	ErrRestoreTargetNotEmpty = errors.New("backup restore target is not empty")
+	ErrRestoreTargetOverlap  = errors.New("backup restore target overlaps protected storage")
+)
+
+// RestoreTargetCoordinator confines a restore to a stable target disjoint
+// from the live vault and repository while coordinating with other vault and
+// restore owners through the shared hierarchy locks.
+type RestoreTargetCoordinator struct {
+	target         string
+	repositoryRoot string
+	vaultRoot      string
+	overwrite      bool
+	launch         *home.Lock
+	ancestors      *home.Lock
+}
+
+func NewRestoreTargetCoordinator(
+	target, repositoryRoot, vaultRoot string, overwrite bool,
+) *RestoreTargetCoordinator {
+	return &RestoreTargetCoordinator{
+		target: target, repositoryRoot: repositoryRoot, vaultRoot: vaultRoot,
+		overwrite: overwrite,
+	}
+}
+
+func (c *RestoreTargetCoordinator) Prepare(ctx context.Context) error {
+	for {
+		launch, err := (home.Layout{Root: c.target}).TryLockLaunch()
+		if err == nil {
+			c.launch = launch
+			break
+		}
+		if !errors.Is(err, home.ErrVaultLocked) {
+			return fmt.Errorf("serializing backup restore target creation: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	ancestors, err := (home.Layout{Root: c.target}).TryLockExistingAncestors()
+	if err != nil {
+		_ = c.ReleasePreparation()
+		if errors.Is(err, home.ErrVaultLocked) {
+			return fmt.Errorf("locking backup restore target ancestors: %w", ErrRestoreTargetActive)
+		}
+		return fmt.Errorf("locking backup restore target ancestors: %w", err)
+	}
+	c.ancestors = ancestors
+	return nil
+}
+
+func (c *RestoreTargetCoordinator) ReleasePreparation() error {
+	var result error
+	if c.ancestors != nil {
+		result = c.ancestors.Release()
+		c.ancestors = nil
+	}
+	if c.launch != nil {
+		result = errors.Join(result, c.launch.Release())
+		c.launch = nil
+	}
+	return result
+}
+
+func (c *RestoreTargetCoordinator) AcquireRestoreTarget(
+	ctx context.Context, root *os.Root,
+) (backup.RestoreTargetLease, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := c.validate(root); err != nil {
+		return nil, err
+	}
+	if c.ancestors != nil {
+		if err := c.ancestors.Release(); err != nil {
+			return nil, fmt.Errorf("releasing backup restore ancestor preparation: %w", err)
+		}
+		c.ancestors = nil
+	}
+	lock, err := (home.Layout{Root: c.target}).TryLockExclusiveRoot(root)
+	if err != nil {
+		if errors.Is(err, home.ErrVaultLocked) {
+			return nil, fmt.Errorf("locking backup restore target: %w", ErrRestoreTargetActive)
+		}
+		return nil, fmt.Errorf("locking backup restore target: %w", err)
+	}
+	if err := c.validate(root); err != nil {
+		return nil, errors.Join(err, lock.Release())
+	}
+	if c.launch != nil {
+		if err := c.launch.Release(); err != nil {
+			return nil, errors.Join(fmt.Errorf(
+				"releasing backup restore target preparation: %w", err), lock.Release())
+		}
+		c.launch = nil
+	}
+	return lock, nil
+}
+
+func (c *RestoreTargetCoordinator) validate(root *os.Root) error {
+	leaf, err := os.Lstat(c.target)
+	if err != nil {
+		return fmt.Errorf("checking backup restore target: %w", err)
+	}
+	if leaf.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("backup restore target was replaced with a symlink: %w", ErrRestoreTargetChanged)
+	}
+	held, err := root.Stat(".")
+	if err != nil {
+		return fmt.Errorf("checking held backup restore target: %w", err)
+	}
+	if !os.SameFile(leaf, held) {
+		return fmt.Errorf("backup restore target was replaced while acquiring coordination: %w",
+			ErrRestoreTargetChanged)
+	}
+	if err := ValidateDisjointRoots(c.target, c.repositoryRoot, c.vaultRoot); err != nil {
+		return err
+	}
+	if !c.overwrite {
+		entries, err := fs.ReadDir(root.FS(), ".")
+		if err != nil {
+			return fmt.Errorf("reading held backup restore target: %w", err)
+		}
+		for _, entry := range entries {
+			if entry.Name() != "vault.lock" {
+				return ErrRestoreTargetNotEmpty
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateDisjointRoots rejects lexical, symlink, case-equivalent, and
+// filesystem-identity aliases between root and protected storage.
+func ValidateDisjointRoots(root string, protected ...string) error {
+	canonicalRoot, err := home.CanonicalRoot(root)
+	if err != nil {
+		return err
+	}
+	for _, candidate := range protected {
+		if candidate == "" {
+			continue
+		}
+		canonicalProtected, err := home.CanonicalRoot(candidate)
+		if err != nil {
+			return err
+		}
+		overlaps, err := restorePathsOverlap(canonicalRoot, canonicalProtected)
+		if err != nil {
+			return err
+		}
+		if overlaps {
+			return fmt.Errorf("backup roots %q and %q overlap: %w",
+				canonicalRoot, canonicalProtected, ErrRestoreTargetOverlap)
+		}
+	}
+	return nil
+}
+
+func restorePathsOverlap(a, b string) (bool, error) {
+	if restorePathContains(a, b) || restorePathContains(b, a) {
+		return true, nil
+	}
+	for _, pair := range [][2]string{{a, b}, {b, a}} {
+		matched, err := restoreExistingAncestorMatches(pair[0], pair[1])
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func restoreExistingAncestorMatches(path, protected string) (bool, error) {
+	protectedInfo, err := os.Stat(protected)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	for current := path; ; current = filepath.Dir(current) {
+		info, err := os.Stat(current)
+		if err == nil && os.SameFile(info, protectedInfo) {
+			return true, nil
+		}
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return false, err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return false, nil
+		}
+	}
+}
+
+func restorePathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/maintenance.go
+++ b/maintenance.go
@@ -95,6 +95,8 @@ func (v *Vault) GarbageCollect(ctx context.Context, opts GCOptions) (GCReport, e
 		return GCReport{}, err
 	}
 	defer v.lifecycle.RUnlock()
+	v.preservation.Lock()
+	defer v.preservation.Unlock()
 	v.mutation.Lock()
 	defer v.mutation.Unlock()
 	var report internalmaintenance.GCReport
@@ -114,6 +116,8 @@ func (v *Vault) Verify(ctx context.Context, opts VerifyOptions) (VerifyReport, e
 		return VerifyReport{}, err
 	}
 	defer v.lifecycle.RUnlock()
+	v.preservation.Lock()
+	defer v.preservation.Unlock()
 	v.mutation.Lock()
 	defer v.mutation.Unlock()
 	report, err := internalmaintenance.Verify(ctx, v.metadata, v.blobs,
@@ -128,6 +132,8 @@ func (v *Vault) Repack(ctx context.Context, opts RepackOptions) (RepackReport, e
 		return RepackReport{}, err
 	}
 	defer v.lifecycle.RUnlock()
+	v.preservation.Lock()
+	defer v.preservation.Unlock()
 	v.mutation.Lock()
 	defer v.mutation.Unlock()
 	report, err := internalmaintenance.Repack(ctx, v.metadata, v.blobs,

--- a/vault.go
+++ b/vault.go
@@ -116,9 +116,10 @@ type Vault struct {
 	metadata *store.Store
 	blobs    *blob.Store
 
-	lifecycle sync.RWMutex
-	mutation  sync.Mutex
-	closed    bool
+	lifecycle    sync.RWMutex
+	mutation     sync.Mutex
+	preservation sync.RWMutex
+	closed       bool
 
 	// testAfterRepairPublication exercises the non-cancelable authority handoff
 	// after durable physical publication. Production constructors leave it nil.
@@ -805,6 +806,8 @@ func (v *Vault) EmptyTrash(
 	if maxRoots == 0 {
 		maxRoots = DefaultTrashEmptyMaxRoots
 	}
+	v.preservation.Lock()
+	defer v.preservation.Unlock()
 	v.mutation.Lock()
 	defer v.mutation.Unlock()
 	if err := ctx.Err(); err != nil {
@@ -843,6 +846,8 @@ func (v *Vault) RepairContent(
 		return RepairReceipt{}, errors.New("repair content size must not be negative")
 	}
 
+	v.preservation.Lock()
+	defer v.preservation.Unlock()
 	v.mutation.Lock()
 	defer v.mutation.Unlock()
 	var receipt RepairReceipt
@@ -1394,6 +1399,8 @@ func (v *Vault) Pack(ctx context.Context, opts PackOptions) (PackReport, error) 
 		return PackReport{}, err
 	}
 	defer v.lifecycle.RUnlock()
+	v.preservation.Lock()
+	defer v.preservation.Unlock()
 	v.mutation.Lock()
 	defer v.mutation.Unlock()
 	report, err := internalmaintenance.Pack(ctx, v.metadata, v.blobs, opts.MaxBytes)


### PR DESCRIPTION
Applications that embed Docbank can now create, list, verify, and restore complete recovery points without starting a second daemon. Restores always land in a separate vault and are verified before publication.

Snapshot capture pauses writes only long enough to pin the metadata view. New content can continue while the backup streams, but operations that could remove or replace referenced bytes wait until the snapshot manifest is published. Embedded and daemon restores share the same directory ownership and storage-overlap checks.
