### PR TITLE
Protect application storage during embedded restore

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -52,12 +52,15 @@ type BackupVerifyOptions struct {
 
 // BackupRestoreOptions controls restore into a separate vault root.
 type BackupRestoreOptions struct {
-	SnapshotID  string
-	Target      string
-	Overwrite   bool
-	Jobs        int
-	ForceUnlock bool
-	Progress    func(BackupProgress)
+	SnapshotID string
+	Target     string
+	// ProtectedRoots are host-owned storage trees that the restore target must
+	// not equal, contain, or be contained by.
+	ProtectedRoots []string
+	Overwrite      bool
+	Jobs           int
+	ForceUnlock    bool
+	Progress       func(BackupProgress)
 }
 
 // BackupProgress reports one structured stage update.
@@ -264,11 +267,12 @@ func (v *Vault) RestoreBackup(
 	if err != nil {
 		return BackupRestoreReport{}, fmt.Errorf("resolving backup restore target: %w", err)
 	}
-	if err := backupapp.ValidateDisjointRoots(target, repository.repo.Root(), v.root.Name()); err != nil {
+	protectedRoots := append([]string{repository.repo.Root(), v.root.Name()}, opts.ProtectedRoots...)
+	if err := backupapp.ValidateDisjointRoots(target, protectedRoots...); err != nil {
 		return BackupRestoreReport{}, err
 	}
 	coordinator := backupapp.NewRestoreTargetCoordinator(
-		target, repository.repo.Root(), v.root.Name(), opts.Overwrite,
+		target, repository.repo.Root(), v.root.Name(), opts.ProtectedRoots, opts.Overwrite,
 	)
 	if err := coordinator.Prepare(ctx); err != nil {
 		return BackupRestoreReport{}, fmt.Errorf("preparing backup restore target: %w", err)

--- a/backup_external_test.go
+++ b/backup_external_test.go
@@ -3,6 +3,7 @@ package docbank_test
 import (
 	"bytes"
 	"io"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -174,4 +175,43 @@ func TestEmbeddedRestoreRejectsLiveVaultOverlap(t *testing.T) {
 		Target:     filepath.Join(liveRoot, "restore"),
 	})
 	require.ErrorIs(t, err, docbank.ErrBackupRestoreTargetOverlap)
+}
+
+func TestEmbeddedRestoreRejectsHostProtectedRoot(t *testing.T) {
+	liveRoot := filepath.Join(t.TempDir(), "live")
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: liveRoot})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	createRangeFixture(t, vault, "/archive/photo.txt", []byte("protected content\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+	snapshot, err := vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{})
+	require.NoError(t, err)
+
+	protectedRoot := t.TempDir()
+	t.Run("direct missing target", func(t *testing.T) {
+		target := filepath.Join(protectedRoot, "missing-restore-target")
+		_, restoreErr := vault.RestoreBackup(t.Context(), repository, docbank.BackupRestoreOptions{
+			SnapshotID:     snapshot.ID,
+			Target:         target,
+			ProtectedRoots: []string{protectedRoot},
+		})
+		require.ErrorIs(t, restoreErr, docbank.ErrBackupRestoreTargetOverlap)
+		require.NoDirExists(t, target)
+	})
+
+	t.Run("symlink alias with missing target", func(t *testing.T) {
+		alias := filepath.Join(t.TempDir(), "protected-alias")
+		if err := os.Symlink(protectedRoot, alias); err != nil {
+			t.Skipf("symlink creation unavailable: %v", err)
+		}
+		target := filepath.Join(alias, "missing-restore-target")
+		_, restoreErr := vault.RestoreBackup(t.Context(), repository, docbank.BackupRestoreOptions{
+			SnapshotID:     snapshot.ID,
+			Target:         target,
+			ProtectedRoots: []string{protectedRoot},
+		})
+		require.ErrorIs(t, restoreErr, docbank.ErrBackupRestoreTargetOverlap)
+		require.NoDirExists(t, filepath.Join(protectedRoot, "missing-restore-target"))
+	})
 }

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -133,7 +133,8 @@ Standalone restore is daemon-mediated; embedded restore is invoked through the
 open vault but never mutates that running store. Before Kit receives a target,
 Docbank canonicalizes its existing path prefix and
 rejects any parent, descendant, or symlink alias overlapping the live vault or
-repository. Filesystem identity supplements those lexical checks for case- or
+repository, plus any additional roots protected by an embedding application.
+Filesystem identity supplements those lexical checks for case- or
 normalization-equivalent aliases. Kit then opens the target without following a
 final symlink and passes that same held `os.Root` to Docbank's coordinator
 before cleanup or publication. The coordinator repeats the identity, overlap,

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -395,8 +395,9 @@ if len(proof.Problems) != 0 {
 	return fmt.Errorf("backup verification found %d problems", len(proof.Problems))
 }
 _, err = vault.RestoreBackup(ctx, repository, docbank.BackupRestoreOptions{
-    SnapshotID: snapshot.ID,
-    Target:     restoreRoot,
+	SnapshotID:    snapshot.ID,
+	Target:        restoreRoot,
+	ProtectedRoots: applicationStorageRoots,
 })
 return err
 ```
@@ -407,8 +408,11 @@ the complete snapshot, but ordinary appends resume after Docbank pins the short
 SQLite metadata view. Physical maintenance waits until the manifest is
 published. Restore always targets a separate root, rejects overlap with the
 live vault or repository, and proves content, SQLite integrity, and manifest
-statistics before publication. The embedded restore path reconstructs a fresh
-fixed primary; deployment-specific secondary-store placement is not restored.
+statistics before publication. An embedding application supplies any additional
+storage it owns through `ProtectedRoots`; Docbank applies the same canonical,
+filesystem-aware exclusion before restore cleanup. The embedded restore path
+reconstructs a fresh fixed primary; deployment-specific secondary-store
+placement is not restored.
 
 ## Maintain physical storage
 

--- a/internal/api/restore_lock.go
+++ b/internal/api/restore_lock.go
@@ -52,7 +52,7 @@ func newRestoreTargetCoordinator(
 	target, repoRoot, vaultRoot string, overwrite bool,
 ) restoreTargetCoordinator {
 	return &platformRestoreTargetCoordinator{
-		inner: backupapp.NewRestoreTargetCoordinator(target, repoRoot, vaultRoot, overwrite),
+		inner: backupapp.NewRestoreTargetCoordinator(target, repoRoot, vaultRoot, nil, overwrite),
 	}
 }
 

--- a/internal/backupapp/restore_target.go
+++ b/internal/backupapp/restore_target.go
@@ -29,17 +29,18 @@ type RestoreTargetCoordinator struct {
 	target         string
 	repositoryRoot string
 	vaultRoot      string
+	protectedRoots []string
 	overwrite      bool
 	launch         *home.Lock
 	ancestors      *home.Lock
 }
 
 func NewRestoreTargetCoordinator(
-	target, repositoryRoot, vaultRoot string, overwrite bool,
+	target, repositoryRoot, vaultRoot string, protectedRoots []string, overwrite bool,
 ) *RestoreTargetCoordinator {
 	return &RestoreTargetCoordinator{
 		target: target, repositoryRoot: repositoryRoot, vaultRoot: vaultRoot,
-		overwrite: overwrite,
+		protectedRoots: append([]string(nil), protectedRoots...), overwrite: overwrite,
 	}
 }
 
@@ -135,7 +136,8 @@ func (c *RestoreTargetCoordinator) validate(root *os.Root) error {
 		return fmt.Errorf("backup restore target was replaced while acquiring coordination: %w",
 			ErrRestoreTargetChanged)
 	}
-	if err := ValidateDisjointRoots(c.target, c.repositoryRoot, c.vaultRoot); err != nil {
+	protectedRoots := append([]string{c.repositoryRoot, c.vaultRoot}, c.protectedRoots...)
+	if err := ValidateDisjointRoots(c.target, protectedRoots...); err != nil {
 		return err
 	}
 	if !c.overwrite {


### PR DESCRIPTION
Embedded applications can now tell Docbank which host-owned storage roots must remain untouched during restore.\n\nDocbank canonicalizes those roots and checks them before restore setup and again against the retained target directory. An overwrite restore therefore cannot be directed into application-owned archives or caches. Standalone daemon behavior is unchanged.