### PR TITLE
Capture host files in embedded backups

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -331,13 +331,19 @@ func (f *vaultBackupFreezer) Begin(ctx context.Context) error {
 	}
 	f.vault.mutation.Lock()
 	f.held = true
-	if f.prepare != nil {
-		if err := f.prepare(ctx); err != nil {
+	prepared := false
+	defer func() {
+		if !prepared {
 			f.held = false
 			f.vault.mutation.Unlock()
+		}
+	}()
+	if f.prepare != nil {
+		if err := f.prepare(ctx); err != nil {
 			return fmt.Errorf("preparing host backup files: %w", err)
 		}
 	}
+	prepared = true
 	return nil
 }
 

--- a/backup.go
+++ b/backup.go
@@ -35,6 +35,9 @@ type BackupRepository struct {
 type BackupExtraFile struct {
 	Path     string
 	RecordAs string
+	// Sensitive requires an encrypted repository or an explicit plaintext
+	// override for this backup.
+	Sensitive bool
 }
 
 // BackupOptions controls one embedded vault snapshot.
@@ -43,7 +46,10 @@ type BackupOptions struct {
 	ZstdLevel   int
 	Jobs        int
 	ForceUnlock bool
-	Progress    func(BackupProgress)
+	// AllowPlaintextSecrets permits ExtraFiles marked Sensitive to be stored
+	// in the current plaintext backup repository.
+	AllowPlaintextSecrets bool
+	Progress              func(BackupProgress)
 	// Prepare runs while Docbank holds its short metadata freeze. It may
 	// create immutable host-owned files named by ExtraFiles; those files must
 	// remain unchanged until CreateBackup returns.
@@ -221,8 +227,9 @@ func (v *Vault) CreateBackup(
 		backup.CreateOptions{
 			Tag: opts.Tag, ZstdLevel: opts.ZstdLevel, Jobs: opts.Jobs,
 			ForceUnlock: opts.ForceUnlock, Progress: backupProgressCallback(opts.Progress),
-			Freezer: &vaultBackupFreezer{vault: v, prepare: opts.Prepare},
-			Extras:  backup.ExtrasSpec{Files: backupExtraFiles(opts.ExtraFiles)},
+			AllowPlaintextSecrets: opts.AllowPlaintextSecrets,
+			Freezer:               &vaultBackupFreezer{vault: v, prepare: opts.Prepare},
+			Extras:                backup.ExtrasSpec{Files: backupExtraFiles(opts.ExtraFiles)},
 		})
 	if err != nil {
 		return BackupSnapshot{}, fmt.Errorf("creating backup snapshot: %w", err)
@@ -374,7 +381,9 @@ func backupExtraFiles(files []BackupExtraFile) []backup.ExtrasFileSpec {
 	}
 	extraFiles := make([]backup.ExtrasFileSpec, len(files))
 	for i, file := range files {
-		extraFiles[i] = backup.ExtrasFileSpec{Path: file.Path, RecordAs: file.RecordAs}
+		extraFiles[i] = backup.ExtrasFileSpec{
+			Path: file.Path, RecordAs: file.RecordAs, Sensitive: file.Sensitive,
+		}
 	}
 	return extraFiles
 }

--- a/backup.go
+++ b/backup.go
@@ -30,6 +30,13 @@ type BackupRepository struct {
 	repo *backup.Repo
 }
 
+// BackupExtraFile is one host-owned file captured in the snapshot and
+// restored beneath the target root at RecordAs.
+type BackupExtraFile struct {
+	Path     string
+	RecordAs string
+}
+
 // BackupOptions controls one embedded vault snapshot.
 type BackupOptions struct {
 	Tag         string
@@ -37,6 +44,11 @@ type BackupOptions struct {
 	Jobs        int
 	ForceUnlock bool
 	Progress    func(BackupProgress)
+	// Prepare runs while Docbank holds its short metadata freeze. It may
+	// create immutable host-owned files named by ExtraFiles; those files must
+	// remain unchanged until CreateBackup returns.
+	Prepare    func(context.Context) error
+	ExtraFiles []BackupExtraFile
 }
 
 // BackupVerifyOptions controls repository verification. SnapshotID selects
@@ -209,7 +221,8 @@ func (v *Vault) CreateBackup(
 		backup.CreateOptions{
 			Tag: opts.Tag, ZstdLevel: opts.ZstdLevel, Jobs: opts.Jobs,
 			ForceUnlock: opts.ForceUnlock, Progress: backupProgressCallback(opts.Progress),
-			Freezer: &vaultBackupFreezer{vault: v},
+			Freezer: &vaultBackupFreezer{vault: v, prepare: opts.Prepare},
+			Extras:  backup.ExtrasSpec{Files: backupExtraFiles(opts.ExtraFiles)},
 		})
 	if err != nil {
 		return BackupSnapshot{}, fmt.Errorf("creating backup snapshot: %w", err)
@@ -304,8 +317,9 @@ func (v *Vault) RestoreBackup(
 }
 
 type vaultBackupFreezer struct {
-	vault *Vault
-	held  bool
+	vault   *Vault
+	prepare func(context.Context) error
+	held    bool
 }
 
 func (f *vaultBackupFreezer) Begin(ctx context.Context) error {
@@ -317,6 +331,13 @@ func (f *vaultBackupFreezer) Begin(ctx context.Context) error {
 	}
 	f.vault.mutation.Lock()
 	f.held = true
+	if f.prepare != nil {
+		if err := f.prepare(ctx); err != nil {
+			f.held = false
+			f.vault.mutation.Unlock()
+			return fmt.Errorf("preparing host backup files: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -339,6 +360,17 @@ func backupProgressCallback(callback func(BackupProgress)) func(backup.ProgressE
 			BytesDone: event.BytesDone, BytesTotal: event.BytesTotal, Final: event.Final,
 		})
 	}
+}
+
+func backupExtraFiles(files []BackupExtraFile) []backup.ExtrasFileSpec {
+	if len(files) == 0 {
+		return nil
+	}
+	extraFiles := make([]backup.ExtrasFileSpec, len(files))
+	for i, file := range files {
+		extraFiles[i] = backup.ExtrasFileSpec{Path: file.Path, RecordAs: file.RecordAs}
+	}
+	return extraFiles
 }
 
 func backupSnapshot(manifest *backup.Manifest) (BackupSnapshot, error) {

--- a/backup_external_test.go
+++ b/backup_external_test.go
@@ -116,6 +116,38 @@ func TestEmbeddedBackupPreparationFailureReleasesMutationGate(t *testing.T) {
 	}
 }
 
+func TestEmbeddedBackupPreparationPanicReleasesMutationGate(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	createRangeFixture(t, vault, "/archive/photo.txt", []byte("snapshot content\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		_, _ = vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{
+			Prepare: func(context.Context) error { panic("prepare host snapshot") },
+		})
+	}()
+	require.Equal(t, "prepare host snapshot", recovered)
+
+	putDone := make(chan error, 1)
+	go func() {
+		_, putErr := vault.Put(t.Context(), "/archive/later.txt", bytes.NewBufferString("later\n"), docbank.PutOptions{
+			MediaType: "text/plain",
+		})
+		putDone <- putErr
+	}()
+	select {
+	case putErr := <-putDone:
+		require.NoError(t, putErr)
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "content mutation remained blocked after preparation panicked")
+	}
+}
+
 func TestEmbeddedBackupRoundTrip(t *testing.T) {
 	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})
 	require.NoError(t, err)

--- a/backup_external_test.go
+++ b/backup_external_test.go
@@ -36,6 +36,7 @@ func TestEmbeddedBackupCapturesHostFilePreparedInsideFreeze(t *testing.T) {
 	backupDone := make(chan backupResult, 1)
 	go func() {
 		snapshot, createErr := vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{
+			AllowPlaintextSecrets: true,
 			Prepare: func(ctx context.Context) error {
 				close(prepared)
 				select {
@@ -46,7 +47,7 @@ func TestEmbeddedBackupCapturesHostFilePreparedInsideFreeze(t *testing.T) {
 				return os.WriteFile(extraPath, []byte("host catalog\n"), 0o600)
 			},
 			ExtraFiles: []docbank.BackupExtraFile{{
-				Path: extraPath, RecordAs: "host/catalog.sqlite",
+				Path: extraPath, RecordAs: "host/catalog.sqlite", Sensitive: true,
 			}},
 		})
 		backupDone <- backupResult{snapshot: snapshot, err: createErr}
@@ -85,6 +86,27 @@ func TestEmbeddedBackupCapturesHostFilePreparedInsideFreeze(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(target, "host", "catalog.sqlite"))
 	require.NoError(t, err)
 	require.Equal(t, "host catalog\n", string(got))
+}
+
+func TestEmbeddedBackupRefusesSensitiveHostFileWithoutPlaintextOptIn(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	createRangeFixture(t, vault, "/archive/photo.txt", []byte("snapshot content\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+
+	secretPath := filepath.Join(t.TempDir(), "credentials.json")
+	require.NoError(t, os.WriteFile(secretPath, []byte("synthetic secret\n"), 0o600))
+	_, err = vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{
+		ExtraFiles: []docbank.BackupExtraFile{{
+			Path: secretPath, RecordAs: "host/credentials.json", Sensitive: true,
+		}},
+	})
+	require.ErrorContains(t, err, "requires an encrypted repository")
+	snapshots, listErr := repository.Snapshots()
+	require.NoError(t, listErr)
+	require.Empty(t, snapshots)
 }
 
 func TestEmbeddedBackupPreparationFailureReleasesMutationGate(t *testing.T) {

--- a/backup_external_test.go
+++ b/backup_external_test.go
@@ -2,6 +2,8 @@ package docbank_test
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,6 +15,106 @@ import (
 
 	docbank "go.kenn.io/docbank"
 )
+
+func TestEmbeddedBackupCapturesHostFilePreparedInsideFreeze(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	createRangeFixture(t, vault, "/archive/photo.txt", []byte("snapshot content\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+
+	extraPath := filepath.Join(t.TempDir(), "catalog.sqlite")
+	prepared := make(chan struct{})
+	resume := make(chan struct{})
+	var resumeOnce sync.Once
+	t.Cleanup(func() { resumeOnce.Do(func() { close(resume) }) })
+	type backupResult struct {
+		snapshot docbank.BackupSnapshot
+		err      error
+	}
+	backupDone := make(chan backupResult, 1)
+	go func() {
+		snapshot, createErr := vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{
+			Prepare: func(ctx context.Context) error {
+				close(prepared)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-resume:
+				}
+				return os.WriteFile(extraPath, []byte("host catalog\n"), 0o600)
+			},
+			ExtraFiles: []docbank.BackupExtraFile{{
+				Path: extraPath, RecordAs: "host/catalog.sqlite",
+			}},
+		})
+		backupDone <- backupResult{snapshot: snapshot, err: createErr}
+	}()
+	select {
+	case <-prepared:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "backup preparation did not begin")
+	}
+
+	putDone := make(chan error, 1)
+	go func() {
+		_, putErr := vault.Put(t.Context(), "/archive/later.txt", bytes.NewBufferString("later\n"), docbank.PutOptions{
+			MediaType: "text/plain",
+		})
+		putDone <- putErr
+	}()
+	select {
+	case putErr := <-putDone:
+		require.FailNow(t, "content mutation completed during host preparation", "error: %v", putErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	resumeOnce.Do(func() { close(resume) })
+	result := <-backupDone
+	require.NoError(t, result.err)
+	require.NoError(t, <-putDone)
+
+	target := filepath.Join(t.TempDir(), "restored")
+	restored, err := vault.RestoreBackup(t.Context(), repository, docbank.BackupRestoreOptions{
+		SnapshotID: result.snapshot.ID,
+		Target:     target,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, restored.ExtrasFiles)
+	got, err := os.ReadFile(filepath.Join(target, "host", "catalog.sqlite"))
+	require.NoError(t, err)
+	require.Equal(t, "host catalog\n", string(got))
+}
+
+func TestEmbeddedBackupPreparationFailureReleasesMutationGate(t *testing.T) {
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, vault.Close()) })
+	createRangeFixture(t, vault, "/archive/photo.txt", []byte("snapshot content\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "backups"))
+	require.NoError(t, err)
+
+	prepareErr := errors.New("prepare host snapshot")
+	_, err = vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{
+		Prepare: func(context.Context) error { return prepareErr },
+	})
+	require.ErrorIs(t, err, prepareErr)
+
+	putDone := make(chan error, 1)
+	go func() {
+		_, putErr := vault.Put(t.Context(), "/archive/later.txt", bytes.NewBufferString("later\n"), docbank.PutOptions{
+			MediaType: "text/plain",
+		})
+		putDone <- putErr
+	}()
+	select {
+	case putErr := <-putDone:
+		require.NoError(t, putErr)
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "content mutation remained blocked after preparation failed")
+	}
+}
 
 func TestEmbeddedBackupRoundTrip(t *testing.T) {
 	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "live")})

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -115,7 +115,9 @@ Embedded owners may run one host preparation callback inside the same short
 mutation freeze and declare immutable host files for Kit to capture as extras.
 This lets one manifest bind an application's catalog snapshot to Docbank's
 logical snapshot without extending the freeze across repository preparation or
-content streaming.
+content streaming. Credential-bearing extras retain Kit's sensitivity marker;
+the current plaintext repository refuses them unless the embedding application
+explicitly permits plaintext secret capture for that backup.
 
 Kit's structured progress events remain structured across the daemon boundary.
 The streaming create endpoint emits NDJSON stage updates followed by one

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -111,6 +111,11 @@ held for the complete capture. Maintenance takes that side exclusively, so GC,
 trash empty, verification, pack, and repack cannot remove or replace content
 authority still named by the pinned snapshot. The repository's exclusive lock
 independently prevents concurrent writers to the same snapshot repository.
+Embedded owners may run one host preparation callback inside the same short
+mutation freeze and declare immutable host files for Kit to capture as extras.
+This lets one manifest bind an application's catalog snapshot to Docbank's
+logical snapshot without extending the freeze across repository preparation or
+content streaming.
 
 Kit's structured progress events remain structured across the daemon boundary.
 The streaming create endpoint emits NDJSON stage updates followed by one

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -381,6 +381,12 @@ if err != nil {
 }
 snapshot, err := vault.CreateBackup(ctx, repository, docbank.BackupOptions{
     Tag: "before-import",
+	Prepare: func(ctx context.Context) error {
+		return snapshotApplicationCatalog(ctx, catalogSnapshot)
+	},
+	ExtraFiles: []docbank.BackupExtraFile{{
+		Path: catalogSnapshot, RecordAs: "application/catalog.sqlite",
+	}},
 })
 if err != nil {
     return err
@@ -405,14 +411,17 @@ return err
 Use `OpenBackupRepository` after process restart. `Snapshots` lists immutable
 recovery points in chronological order. Capture holds a preservation lease for
 the complete snapshot, but ordinary appends resume after Docbank pins the short
-SQLite metadata view. Physical maintenance waits until the manifest is
-published. Restore always targets a separate root, rejects overlap with the
-live vault or repository, and proves content, SQLite integrity, and manifest
-statistics before publication. An embedding application supplies any additional
-storage it owns through `ProtectedRoots`; Docbank applies the same canonical,
-filesystem-aware exclusion before restore cleanup. The embedded restore path
-reconstructs a fresh fixed primary; deployment-specific secondary-store
-placement is not restored.
+SQLite metadata view. An embedding application may use `Prepare` to create an
+immutable snapshot of its own catalog while that freeze is held, then declare
+the file in `ExtraFiles` so the same manifest covers both authorities. Prepared
+files must remain unchanged until `CreateBackup` returns. Physical maintenance
+waits until the manifest is published. Restore always targets a separate root,
+rejects overlap with the live vault or repository, and proves content, SQLite
+integrity, and manifest statistics before publication. An embedding application
+supplies any additional storage it owns through `ProtectedRoots`; Docbank
+applies the same canonical, filesystem-aware exclusion before restore cleanup.
+The embedded restore path reconstructs a fresh fixed primary;
+deployment-specific secondary-store placement is not restored.
 
 ## Maintain physical storage
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -414,14 +414,17 @@ the complete snapshot, but ordinary appends resume after Docbank pins the short
 SQLite metadata view. An embedding application may use `Prepare` to create an
 immutable snapshot of its own catalog while that freeze is held, then declare
 the file in `ExtraFiles` so the same manifest covers both authorities. Prepared
-files must remain unchanged until `CreateBackup` returns. Physical maintenance
-waits until the manifest is published. Restore always targets a separate root,
-rejects overlap with the live vault or repository, and proves content, SQLite
-integrity, and manifest statistics before publication. An embedding application
-supplies any additional storage it owns through `ProtectedRoots`; Docbank
-applies the same canonical, filesystem-aware exclusion before restore cleanup.
-The embedded restore path reconstructs a fresh fixed primary;
-deployment-specific secondary-store placement is not restored.
+files must remain unchanged until `CreateBackup` returns. Mark an extra file
+`Sensitive` when it contains credentials or tokens. Docbank refuses to put a
+sensitive file in its plaintext backup repository unless the application sets
+`AllowPlaintextSecrets` for that backup. Physical maintenance waits until the
+manifest is published. Restore always targets a separate root, rejects overlap
+with the live vault or repository, and proves content, SQLite integrity, and
+manifest statistics before publication. An embedding application supplies any
+additional storage it owns through `ProtectedRoots`; Docbank applies the same
+canonical, filesystem-aware exclusion before restore cleanup. The embedded
+restore path reconstructs a fresh fixed primary; deployment-specific
+secondary-store placement is not restored.
 
 ## Maintain physical storage
 


### PR DESCRIPTION
Applications that embed Docbank can now include their own catalog snapshot in the same recovery point as the vault. Docbank runs the host snapshot callback during its existing short write freeze, then captures the declared files in the same manifest. This avoids separate archives that can drift while keeping repository preparation and content streaming outside the write pause.

A failed host snapshot aborts publication and releases waiting writers. Files containing credentials or tokens can be marked sensitive; Docbank refuses to put them in its plaintext backup repository unless the application explicitly permits that choice. Standalone daemon backups are unchanged.
