### PR TITLE
Restore backups after losing the original vault

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -9,7 +9,9 @@ import (
 
 	"go.kenn.io/docbank/internal/backupapp"
 	"go.kenn.io/docbank/internal/home"
+	"go.kenn.io/docbank/internal/store"
 	"go.kenn.io/docbank/internal/version"
+	docsqlite "go.kenn.io/docbank/sqlite"
 )
 
 var (
@@ -68,7 +70,7 @@ type BackupVerifyOptions struct {
 	Progress    func(BackupProgress)
 }
 
-// BackupRestoreOptions controls restore into a separate vault root.
+// BackupRestoreOptions controls restore into a target vault root.
 type BackupRestoreOptions struct {
 	SnapshotID string
 	Target     string
@@ -272,12 +274,28 @@ func (r *BackupRepository) Verify(
 // both the live vault and repository. It never replaces the open vault.
 func (v *Vault) RestoreBackup(
 	ctx context.Context, repository *BackupRepository, opts BackupRestoreOptions,
-) (report BackupRestoreReport, retErr error) {
+) (BackupRestoreReport, error) {
 	if err := v.begin(); err != nil {
 		return BackupRestoreReport{}, err
 	}
 	defer v.lifecycle.RUnlock()
-	if repository == nil || repository.repo == nil {
+	opts.ProtectedRoots = append([]string{v.root.Name()}, opts.ProtectedRoots...)
+	return repository.restore(ctx, opts, v.metadata.SQLiteDriver())
+}
+
+// Restore materializes and verifies a snapshot without opening the original
+// vault. It uses the default SQLite driver for this build. The target must be
+// disjoint from the repository and ProtectedRoots; active vault targets are
+// rejected by the shared vault lock. Callers must declare any other storage
+// roots they want preserved, including an offline source vault.
+func (r *BackupRepository) Restore(ctx context.Context, opts BackupRestoreOptions) (BackupRestoreReport, error) {
+	return r.restore(ctx, opts, store.DefaultSQLiteDriver())
+}
+
+func (r *BackupRepository) restore(
+	ctx context.Context, opts BackupRestoreOptions, driver docsqlite.Driver,
+) (report BackupRestoreReport, retErr error) {
+	if r == nil || r.repo == nil {
 		return BackupRestoreReport{}, errors.New("docbank backup repository is required")
 	}
 	if opts.Target == "" {
@@ -287,12 +305,12 @@ func (v *Vault) RestoreBackup(
 	if err != nil {
 		return BackupRestoreReport{}, fmt.Errorf("resolving backup restore target: %w", err)
 	}
-	protectedRoots := append([]string{repository.repo.Root(), v.root.Name()}, opts.ProtectedRoots...)
+	protectedRoots := append([]string{r.repo.Root()}, opts.ProtectedRoots...)
 	if err := backupapp.ValidateDisjointRoots(target, protectedRoots...); err != nil {
 		return BackupRestoreReport{}, err
 	}
 	coordinator := backupapp.NewRestoreTargetCoordinator(
-		target, repository.repo.Root(), v.root.Name(), opts.ProtectedRoots, opts.Overwrite,
+		target, r.repo.Root(), "", opts.ProtectedRoots, opts.Overwrite,
 	)
 	if err := coordinator.Prepare(ctx); err != nil {
 		return BackupRestoreReport{}, fmt.Errorf("preparing backup restore target: %w", err)
@@ -301,7 +319,7 @@ func (v *Vault) RestoreBackup(
 		retErr = errors.Join(retErr, coordinator.ReleasePreparation())
 	}()
 	result, err := backupapp.RestoreWithDriver(
-		ctx, repository.repo, version.Version, v.metadata.SQLiteDriver(), backup.RestoreOptions{
+		ctx, r.repo, version.Version, driver, backup.RestoreOptions{
 			SnapshotID: opts.SnapshotID, TargetDir: target, Overwrite: true,
 			Jobs: opts.Jobs, ForceUnlock: opts.ForceUnlock,
 			Progress:          backupProgressCallback(opts.Progress),

--- a/backup_repository_restore_test.go
+++ b/backup_repository_restore_test.go
@@ -1,0 +1,90 @@
+package docbank_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	docbank "go.kenn.io/docbank"
+)
+
+func TestRepositoryRestoreAfterSourceLoss(t *testing.T) {
+	r := require.New(t)
+	source := filepath.Join(t.TempDir(), "source")
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: source})
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(vault.Close()) })
+	body := []byte("synthetic archived content\n")
+	createRangeFixture(t, vault, "/archive/document.txt", body)
+	repositoryPath := filepath.Join(t.TempDir(), "repository")
+	repository, err := docbank.InitBackupRepository(repositoryPath)
+	r.NoError(err)
+	extra := filepath.Join(t.TempDir(), "catalog.txt")
+	r.NoError(os.WriteFile(extra, []byte("synthetic host catalog\n"), 0o600))
+	snapshot, err := vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{
+		ExtraFiles: []docbank.BackupExtraFile{{Path: extra, RecordAs: "host/catalog.txt"}},
+	})
+	r.NoError(err)
+	r.NoError(vault.Close())
+	r.NoError(os.RemoveAll(source))
+	r.NoError(os.Remove(extra))
+	repository, err = docbank.OpenBackupRepository(repositoryPath)
+	r.NoError(err)
+	report, err := repository.Restore(t.Context(), docbank.BackupRestoreOptions{
+		SnapshotID: snapshot.ID, Target: filepath.Join(t.TempDir(), "recovered"),
+	})
+	r.NoError(err)
+	r.NoDirExists(source)
+	r.True(report.Proof.ContentVerified)
+	r.True(report.Proof.SQLiteIntegrity)
+	r.Equal(1, report.ExtrasFiles)
+	recovered, err := docbank.New(t.Context(), docbank.Config{Root: report.Target})
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(recovered.Close()) })
+	reader, err := recovered.OpenContent(t.Context(), "/archive/document.txt")
+	r.NoError(err)
+	got, err := io.ReadAll(reader.Reader)
+	r.NoError(err)
+	r.NoError(reader.Reader.Verify())
+	r.NoError(reader.Reader.Close())
+	r.Equal(body, got)
+	host, err := os.ReadFile(filepath.Join(report.Target, "host", "catalog.txt"))
+	r.NoError(err)
+	r.Equal("synthetic host catalog\n", string(host))
+}
+
+func TestRepositoryRestoreEnforcesTargetBoundaries(t *testing.T) {
+	r := require.New(t)
+	vault, err := docbank.New(t.Context(), docbank.Config{Root: filepath.Join(t.TempDir(), "source")})
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(vault.Close()) })
+	createRangeFixture(t, vault, "/archive/document.txt", []byte("archived\n"))
+	repository, err := docbank.InitBackupRepository(filepath.Join(t.TempDir(), "repository"))
+	r.NoError(err)
+	_, err = vault.CreateBackup(t.Context(), repository, docbank.BackupOptions{})
+	r.NoError(err)
+	protected := t.TempDir()
+	activeRoot := filepath.Join(t.TempDir(), "active")
+	active, err := docbank.New(t.Context(), docbank.Config{Root: activeRoot})
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(active.Close()) })
+	for _, test := range []struct {
+		name   string
+		target string
+		want   error
+	}{
+		{"repository", repository.Root(), docbank.ErrBackupRestoreTargetOverlap},
+		{"protected", filepath.Join(protected, "target"), docbank.ErrBackupRestoreTargetOverlap},
+		{"active", activeRoot, docbank.ErrBackupRestoreTargetActive},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := repository.Restore(t.Context(), docbank.BackupRestoreOptions{
+				Target: test.target, ProtectedRoots: []string{protected}, Overwrite: true,
+			})
+			require.ErrorIs(t, err, test.want)
+		})
+	}
+}

--- a/docs/architecture/backup.md
+++ b/docs/architecture/backup.md
@@ -10,6 +10,12 @@ verify`, and `backup restore` use the authenticated daemon API; see the
 [Backup user guide](../usage/backup.md). Applications that own an embedded
 vault use `BackupRepository`, `Vault.CreateBackup`, and `Vault.RestoreBackup`
 directly; see [Embedding Docbank](../embedding.md#back-up-and-restore-an-embedded-vault).
+`BackupRepository.Restore` recovers without a source vault and uses the build's
+default SQLite driver. Both embedded entry points share one restore path,
+including repository and protected-root exclusion, target hierarchy locks,
+host-file restoration, and verification before publication. The vault method
+adds its source root to the protected set and supplies its configured driver;
+repository callers explicitly declare any offline storage to preserve.
 A coherent local-state filesystem snapshot remains available by stopping the
 daemon before copying the vault, but it is not a topology-independent backup;
 see [Vault Lifecycle](../usage/lifecycle.md#take-a-coherent-backup).

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -426,6 +426,29 @@ canonical, filesystem-aware exclusion before restore cleanup. The embedded
 restore path reconstructs a fresh fixed primary; deployment-specific
 secondary-store placement is not restored.
 
+If the original vault is unavailable, open the backup repository and restore
+directly without initializing or opening a source vault:
+
+```go
+repository, err := docbank.OpenBackupRepository(backupRoot)
+if err != nil {
+    return err
+}
+_, err = repository.Restore(ctx, docbank.BackupRestoreOptions{
+    Target: restoreRoot,
+    ProtectedRoots: applicationStorageRoots,
+})
+return err
+```
+
+An omitted snapshot ID selects the latest recovery point. Repository restore
+uses the build's default SQLite driver and restores declared host files along
+with vault content. It rejects the repository, declared protected roots, and
+targets held by another vault. Include any offline source or application
+storage you want to preserve in `ProtectedRoots`: the repository cannot infer
+their current locations. `Vault.RestoreBackup` also protects its open vault
+automatically and retains that vault's configured SQLite driver.
+
 ## Maintain physical storage
 
 Ordinary `Put` calls publish loose content. Call `Pack` explicitly when the


### PR DESCRIPTION
Embedded applications can now restore a backup after the original vault has been lost. Open the backup repository and call `Restore`; recovery no longer requires opening or creating a source vault.

The operation uses the existing verified restore engine and target locks. It rejects the repository and explicitly protected storage as destinations. The existing vault-owned method continues to protect its source automatically and retain its configured SQLite driver. No storage format or migration changes are included.
