### PR TITLE
Fix two intermittent Windows test failures

### DIFF
--- a/cmd/docbank/daemon_test.go
+++ b/cmd/docbank/daemon_test.go
@@ -99,17 +99,30 @@ func TestServeRecoversInterruptedRestoreBeforeInitializingVault(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- runServe(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			require.Fail(t, "daemon did not shut down")
+		}
+	})
+	healthClient := &http.Client{Timeout: time.Second}
 	require.Eventually(t, func() bool {
 		records, listErr := client.RuntimeStore(dir).List()
-		return listErr == nil && len(records) == 1
+		if listErr != nil || len(records) != 1 {
+			return false
+		}
+		// Discovery is published before worker registration finishes. Wait for
+		// serving readiness before asking a successfully started daemon to stop.
+		response, err := healthClient.Get("http://" + records[0].Address + "/health")
+		if err != nil {
+			return false
+		}
+		_ = response.Body.Close()
+		return response.StatusCode == http.StatusOK
 	}, 10*time.Second, 50*time.Millisecond)
-	cancel()
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(10 * time.Second):
-		t.Fatal("daemon did not shut down")
-	}
 	pending, err := blob.PrimaryRestoreHandoffPending(filepath.Join(dir, "blobs"))
 	require.NoError(t, err)
 	assert.False(t, pending)

--- a/document/reducto/client_test.go
+++ b/document/reducto/client_test.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -837,24 +838,28 @@ func TestClientClosesBlockedUploadOnWallTimeout(t *testing.T) {
 }
 
 func TestClientAppliesWallDeadlineAfterCompletedResultProcessing(t *testing.T) {
-	fixture := newFixture(t, "pdf", "application/pdf", "synthetic.pdf", []byte("final wall"))
-	fixture.profile.MaxWallTime = 10 * time.Millisecond
-	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
-		switch request.URL.Path {
-		case uploadPath:
-			return response(request, http.StatusOK, `{"file_id":"`+testFileID+`","presigned_url":null}`), nil
-		case parsePath:
-			return response(request, http.StatusOK, `{"job_id":"`+testJobID+`"}`), nil
-		case jobPath(testJobID):
-			time.Sleep(20 * time.Millisecond)
-			return response(request, http.StatusOK, completedBody()), nil
-		default:
-			return nil, errors.New("unexpected route")
-		}
+	// Advance fake time so the timeout fires before the completed response;
+	// a real sleep does not guarantee the cancellation callback has run.
+	synctest.Test(t, func(t *testing.T) {
+		fixture := newFixture(t, "pdf", "application/pdf", "synthetic.pdf", []byte("final wall"))
+		fixture.profile.MaxWallTime = 10 * time.Millisecond
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			switch request.URL.Path {
+			case uploadPath:
+				return response(request, http.StatusOK, `{"file_id":"`+testFileID+`","presigned_url":null}`), nil
+			case parsePath:
+				return response(request, http.StatusOK, `{"job_id":"`+testJobID+`"}`), nil
+			case jobPath(testJobID):
+				time.Sleep(20 * time.Millisecond)
+				return response(request, http.StatusOK, completedBody()), nil
+			default:
+				return nil, errors.New("unexpected route")
+			}
+		})
+		_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
+			fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
+		assertCode(t, err, document.RenditionErrorAmbiguousSubmission)
 	})
-	_, err := document.RenderRenditionWithResume(t.Context(), fixture.client(t, transport),
-		fixture.upload(), fixture.authorization, nil, func(document.RenditionResumeHandle) error { return nil })
-	assertCode(t, err, document.RenditionErrorAmbiguousSubmission)
 }
 
 func TestProviderRequiresFrozenNamedProfileAndHardenedTransport(t *testing.T) {


### PR DESCRIPTION
Removes two timing races behind intermittent Windows test failures. The restore test now waits until the daemon answers a health request before shutting it down. The Reducto timeout test uses a controlled clock so its deadline reliably occurs before the response.

Only test code changes; daemon and provider behavior stay unchanged.
