### PR TITLE
feat(document): build evidence from supplied transcripts

### DIFF
--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -54,6 +54,35 @@ shorter document therefore cannot share an identity with a longer document
 whose retained evidence or remaining units were truncated by a normalization
 bound.
 
+## Build evidence from a supplied transcript
+
+Applications that already have transcript text can pass it through the same
+evidence and rendition contracts as other document families:
+
+```go
+evidencePolicy, err := document.NewEvidencePolicy(100_000)
+if err != nil {
+	return err
+}
+evidence, artifact, err := document.BuildTranscriptEvidenceV1(
+	document.SuppliedTranscript{Provider: "beeper", Text: transcript}, evidencePolicy,
+)
+if err != nil {
+	return err
+}
+_ = artifact // retain the provider transcript with the source record
+```
+
+The provider value must be a lowercase identifier. Docbank keeps the exact
+provider and transcript text in the `supplied-transcript/v1` JSON artifact,
+while normalized evidence and the rendition apply their existing Unicode,
+Markdown, and character limits. The evidence uses the `audio` family with a
+generic unit and `degraded_provenance` completeness because supplied text has
+no timing or speaker data. The caller still associates the transcript with the
+audio source and its source version. This operation does not inspect audio,
+run speech recognition, verify provider identity, or create ingestion and
+search records.
+
 ## Run Mistral OCR safely
 
 Mistral uploads fail closed until an operator has produced and supplied a

--- a/docs/document-understanding.md
+++ b/docs/document-understanding.md
@@ -56,8 +56,7 @@ bound.
 
 ## Build evidence from a supplied transcript
 
-Applications that already have transcript text can pass it through the same
-evidence and rendition contracts as other document families:
+Applications that already have transcript text can pass it through the same evidence and rendition contracts as other document families:
 
 ```go
 evidencePolicy, err := document.NewEvidencePolicy(100_000)
@@ -73,15 +72,7 @@ if err != nil {
 _ = artifact // retain the provider transcript with the source record
 ```
 
-The provider value must be a lowercase identifier. Docbank keeps the exact
-provider and transcript text in the `supplied-transcript/v1` JSON artifact,
-while normalized evidence and the rendition apply their existing Unicode,
-Markdown, and character limits. The evidence uses the `audio` family with a
-generic unit and `degraded_provenance` completeness because supplied text has
-no timing or speaker data. The caller still associates the transcript with the
-audio source and its source version. This operation does not inspect audio,
-run speech recognition, verify provider identity, or create ingestion and
-search records.
+The provider value must be a lowercase identifier. Docbank keeps the exact provider and transcript text in the `supplied-transcript/v1` JSON artifact, while normalized evidence and the rendition apply their existing Unicode, Markdown, and character limits. The evidence uses the `audio` family with a generic unit and `degraded_provenance` completeness because supplied text has no timing or speaker data. The caller still associates the transcript with the audio source and its source version. This operation does not inspect audio, run speech recognition, verify provider identity, or create ingestion and search records.
 
 ## Run Mistral OCR safely
 

--- a/document/transcript.go
+++ b/document/transcript.go
@@ -1,0 +1,93 @@
+package document
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+
+	"go.kenn.io/docbank/internal/canonical"
+)
+
+const suppliedTranscriptContractV1 = "supplied-transcript/v1"
+
+// SuppliedTranscript is caller-provided transcript text attributed to the
+// provider that produced it. The attribution records a caller claim; this
+// type does not verify provider identity or transcript authenticity.
+type SuppliedTranscript struct {
+	Provider string
+	Text     string
+}
+
+type suppliedTranscriptArtifactV1 struct {
+	ContractVersion string `json:"contract_version"`
+	Provider        string `json:"provider"`
+	Text            string `json:"text"`
+}
+
+// BuildTranscriptEvidenceV1 turns supplied transcript text into the existing
+// provider-neutral evidence and retained transcript artifact contracts.
+// Transcript text has generic audio provenance because this operation does
+// not inspect audio or infer timing, speakers, or authenticity.
+func BuildTranscriptEvidenceV1(
+	transcript SuppliedTranscript, policy EvidencePolicy,
+) (NormalizedEvidenceV1, RenditionArtifact, error) {
+	if err := policy.validate(); err != nil {
+		return NormalizedEvidenceV1{}, RenditionArtifact{}, err
+	}
+	if err := validateEvidenceIdentifier(transcript.Provider, "transcript provider"); err != nil {
+		return NormalizedEvidenceV1{}, RenditionArtifact{}, err
+	}
+	if err := validateEvidenceText(transcript.Text, "transcript text"); err != nil {
+		return NormalizedEvidenceV1{}, RenditionArtifact{}, err
+	}
+	if strings.TrimSpace(transcript.Text) == "" {
+		return NormalizedEvidenceV1{}, RenditionArtifact{}, errors.New("transcript text must contain non-whitespace text")
+	}
+
+	source := SourceEvidenceV1{
+		ContractVersion: SourceEvidenceContractV1,
+		Completeness:    EvidenceDegradedProvenance,
+		Family:          "audio",
+		Omissions: []SourceEvidenceOmissionV1{{
+			Field: "natural_provenance", Kind: EvidenceOmissionField,
+			Reason: "supplied transcript has no timing or speaker provenance",
+		}},
+		UnitKind: EvidenceUnitGeneric,
+		Units: []SourceEvidenceUnitV1{{
+			Order: 0, Text: transcript.Text,
+			Locator: SourceEvidenceLocatorV1{
+				Kind: EvidenceLocatorGeneric, IndexOrigin: EvidenceIndexOriginNone,
+			},
+		}},
+	}
+	if err := policy.validateSource(source); err != nil {
+		return NormalizedEvidenceV1{}, RenditionArtifact{}, err
+	}
+	if _, err := validateSourceEvidenceV1(source, policy.maxDocumentChars); err != nil {
+		return NormalizedEvidenceV1{}, RenditionArtifact{}, err
+	}
+
+	payload, err := canonical.Marshal(suppliedTranscriptArtifactV1{
+		ContractVersion: suppliedTranscriptContractV1,
+		Provider:        transcript.Provider,
+		Text:            transcript.Text,
+	})
+	if err != nil {
+		return NormalizedEvidenceV1{}, RenditionArtifact{}, err
+	}
+	digest := sha256.Sum256(payload)
+	checksum := hex.EncodeToString(digest[:])
+	source.Artifacts = []SourceEvidenceArtifactV1{{
+		Pointer: "transcript.json", ProviderID: "transcript",
+		Role: EvidenceArtifactTranscript, SHA256: checksum,
+	}}
+	evidence, err := NormalizeEvidenceV1(source, policy)
+	if err != nil {
+		return NormalizedEvidenceV1{}, RenditionArtifact{}, err
+	}
+	return evidence, RenditionArtifact{
+		Role: EvidenceArtifactTranscript, MediaType: "application/json",
+		Payload: payload, SHA256: checksum,
+	}, nil
+}

--- a/document/transcript_example_test.go
+++ b/document/transcript_example_test.go
@@ -1,0 +1,26 @@
+package document_test
+
+import (
+	"fmt"
+
+	"go.kenn.io/docbank/document"
+)
+
+func ExampleBuildTranscriptEvidenceV1() {
+	evidencePolicy, _ := document.NewEvidencePolicy(10_000)
+	evidence, artifact, _ := document.BuildTranscriptEvidenceV1(document.SuppliedTranscript{
+		Provider: "beeper",
+		Text:     "The package arrived at dock seven",
+	}, evidencePolicy)
+	renditionPolicy, _ := document.NewRenditionPolicy(document.RenditionLimits{
+		MaxDocumentChars: 10_000,
+		MaxUnitRunes:     10_000,
+		MaxSegmentRunes:  2_000,
+	})
+	rendition, _ := document.BuildRenditionV1(evidence, renditionPolicy)
+	fmt.Println(rendition.LexicalSegments[0].Text)
+	fmt.Println(artifact.Role, artifact.MediaType)
+	// Output:
+	// The package arrived at dock seven
+	// provider_transcript application/json
+}

--- a/document/transcript_test.go
+++ b/document/transcript_test.go
@@ -1,0 +1,104 @@
+package document
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTranscriptEvidenceV1(t *testing.T) {
+	policy, err := NewEvidencePolicy(100)
+	require.NoError(t, err)
+
+	evidence, artifact, err := BuildTranscriptEvidenceV1(SuppliedTranscript{
+		Provider: "beeper",
+		Text:     "The shipment arrives at dock seven.",
+	}, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, EvidenceDegradedProvenance, evidence.Completeness)
+	assert.Equal(t, "audio", evidence.Family)
+	assert.Equal(t, EvidenceUnitGeneric, evidence.UnitKind)
+	require.Len(t, evidence.Units, 1)
+	assert.Equal(t, "The shipment arrives at dock seven.", evidence.Units[0].Text)
+	require.Len(t, evidence.Omissions, 1)
+	assert.Equal(t, "natural_provenance", evidence.Omissions[0].Field)
+	assert.Contains(t, evidence.Omissions[0].Reason, "timing")
+	require.Len(t, evidence.Artifacts, 1)
+	assert.Equal(t, artifact.SHA256, evidence.Artifacts[0].SHA256)
+	assert.Equal(t, "transcript.json", evidence.Artifacts[0].Pointer)
+
+	var payload struct {
+		ContractVersion string `json:"contract_version"`
+		Provider        string `json:"provider"`
+		Text            string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(artifact.Payload, &payload))
+	assert.Equal(t, "supplied-transcript/v1", payload.ContractVersion)
+	assert.Equal(t, "beeper", payload.Provider)
+	assert.Equal(t, "The shipment arrives at dock seven.", payload.Text)
+}
+
+func TestBuildTranscriptEvidenceV1UsesCanonicalPolicyBoundary(t *testing.T) {
+	policy, err := NewEvidencePolicy(4)
+	require.NoError(t, err)
+
+	evidence, artifact, err := BuildTranscriptEvidenceV1(SuppliedTranscript{
+		Provider: "beeper", Text: "Café",
+	}, policy)
+	require.NoError(t, err)
+	assert.Equal(t, "Café", evidence.Units[0].Text)
+	assert.Contains(t, string(artifact.Payload), "Café")
+
+	_, _, err = BuildTranscriptEvidenceV1(SuppliedTranscript{
+		Provider: "beeper", Text: "Café!",
+	}, policy)
+	require.ErrorContains(t, err, "character budget")
+}
+
+func TestBuildTranscriptEvidenceV1RejectsInvalidInput(t *testing.T) {
+	policy, err := NewEvidencePolicy(4)
+	require.NoError(t, err)
+
+	for name, input := range map[string]SuppliedTranscript{
+		"blank":            {Provider: "beeper", Text: " \n\t"},
+		"invalid provider": {Provider: "Beeper", Text: "words"},
+		"invalid UTF-8":    {Provider: "beeper", Text: string([]byte{0xff})},
+		"NUL":              {Provider: "beeper", Text: "a\x00b"},
+		"over policy":      {Provider: "beeper", Text: "12345"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			evidence, artifact, err := BuildTranscriptEvidenceV1(input, policy)
+			require.Error(t, err)
+			assert.Empty(t, evidence)
+			assert.Empty(t, artifact)
+		})
+	}
+}
+
+func TestBuildTranscriptEvidenceV1KeepsArtifactIdentitySeparateFromNormalizedText(t *testing.T) {
+	policy, err := NewEvidencePolicy(100)
+	require.NoError(t, err)
+
+	first, firstArtifact, err := BuildTranscriptEvidenceV1(SuppliedTranscript{
+		Provider: "beeper", Text: "Cafe\u0301\r\narrival",
+	}, policy)
+	require.NoError(t, err)
+	second, secondArtifact, err := BuildTranscriptEvidenceV1(SuppliedTranscript{
+		Provider: "other", Text: "Café\narrival",
+	}, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Café\narrival", first.Units[0].Text)
+	assert.NotEqual(t, firstArtifact.SHA256, secondArtifact.SHA256)
+	assert.NotEqual(t, first.Checksum, second.Checksum)
+	var payload struct {
+		Provider string `json:"provider"`
+		Text     string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(firstArtifact.Payload, &payload))
+	assert.Equal(t, "beeper", payload.Provider)
+	assert.Equal(t, "Café\r\narrival", payload.Text)
+}

--- a/document/transcript_test.go
+++ b/document/transcript_test.go
@@ -1,6 +1,8 @@
 package document_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"testing"
 
@@ -72,7 +74,7 @@ func TestBuildTranscriptEvidenceV1RejectsInvalidInput(t *testing.T) {
 
 	for name, input := range map[string]document.SuppliedTranscript{
 		"blank":            {Provider: "beeper", Text: " \n\t"},
-		"invalid provider": {Provider: "Beeper", Text: "words"},
+		"invalid provider": {Provider: "Beeper", Text: "word"},
 		"invalid UTF-8":    {Provider: "beeper", Text: string([]byte{0xff})},
 		"NUL":              {Provider: "beeper", Text: "a\x00b"},
 		"over policy":      {Provider: "beeper", Text: "12345"},
@@ -108,6 +110,8 @@ func TestBuildTranscriptEvidenceV1KeepsArtifactIdentitySeparateFromNormalizedTex
 	assert.Equal(t, first.Checksum, repeat.Checksum)
 	assert.NotEqual(t, firstArtifact.SHA256, secondArtifact.SHA256)
 	assert.NotEqual(t, first.Checksum, second.Checksum)
+	digest := sha256.Sum256(firstArtifact.Payload)
+	assert.Equal(t, hex.EncodeToString(digest[:]), firstArtifact.SHA256)
 	var payload struct {
 		Provider string `json:"provider"`
 		Text     string `json:"text"`

--- a/document/transcript_test.go
+++ b/document/transcript_test.go
@@ -1,4 +1,4 @@
-package document
+package document_test
 
 import (
 	"encoding/json"
@@ -6,21 +6,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/document"
 )
 
 func TestBuildTranscriptEvidenceV1(t *testing.T) {
-	policy, err := NewEvidencePolicy(100)
+	policy, err := document.NewEvidencePolicy(100)
 	require.NoError(t, err)
 
-	evidence, artifact, err := BuildTranscriptEvidenceV1(SuppliedTranscript{
+	evidence, artifact, err := document.BuildTranscriptEvidenceV1(document.SuppliedTranscript{
 		Provider: "beeper",
 		Text:     "The shipment arrives at dock seven.",
 	}, policy)
 	require.NoError(t, err)
 
-	assert.Equal(t, EvidenceDegradedProvenance, evidence.Completeness)
+	assert.Equal(t, document.EvidenceDegradedProvenance, evidence.Completeness)
 	assert.Equal(t, "audio", evidence.Family)
-	assert.Equal(t, EvidenceUnitGeneric, evidence.UnitKind)
+	assert.Equal(t, document.EvidenceUnitGeneric, evidence.UnitKind)
 	require.Len(t, evidence.Units, 1)
 	assert.Equal(t, "The shipment arrives at dock seven.", evidence.Units[0].Text)
 	require.Len(t, evidence.Omissions, 1)
@@ -42,27 +43,34 @@ func TestBuildTranscriptEvidenceV1(t *testing.T) {
 }
 
 func TestBuildTranscriptEvidenceV1UsesCanonicalPolicyBoundary(t *testing.T) {
-	policy, err := NewEvidencePolicy(4)
+	policy, err := document.NewEvidencePolicy(4)
 	require.NoError(t, err)
 
-	evidence, artifact, err := BuildTranscriptEvidenceV1(SuppliedTranscript{
+	evidence, artifact, err := document.BuildTranscriptEvidenceV1(document.SuppliedTranscript{
 		Provider: "beeper", Text: "Café",
 	}, policy)
 	require.NoError(t, err)
 	assert.Equal(t, "Café", evidence.Units[0].Text)
 	assert.Contains(t, string(artifact.Payload), "Café")
 
-	_, _, err = BuildTranscriptEvidenceV1(SuppliedTranscript{
+	_, _, err = document.BuildTranscriptEvidenceV1(document.SuppliedTranscript{
 		Provider: "beeper", Text: "Café!",
 	}, policy)
 	require.ErrorContains(t, err, "character budget")
 }
 
 func TestBuildTranscriptEvidenceV1RejectsInvalidInput(t *testing.T) {
-	policy, err := NewEvidencePolicy(4)
+	evidence, artifact, err := document.BuildTranscriptEvidenceV1(document.SuppliedTranscript{
+		Provider: "beeper", Text: "words",
+	}, document.EvidencePolicy{})
+	require.ErrorContains(t, err, "use NewEvidencePolicy")
+	assert.Empty(t, evidence)
+	assert.Empty(t, artifact)
+
+	policy, err := document.NewEvidencePolicy(4)
 	require.NoError(t, err)
 
-	for name, input := range map[string]SuppliedTranscript{
+	for name, input := range map[string]document.SuppliedTranscript{
 		"blank":            {Provider: "beeper", Text: " \n\t"},
 		"invalid provider": {Provider: "Beeper", Text: "words"},
 		"invalid UTF-8":    {Provider: "beeper", Text: string([]byte{0xff})},
@@ -70,7 +78,7 @@ func TestBuildTranscriptEvidenceV1RejectsInvalidInput(t *testing.T) {
 		"over policy":      {Provider: "beeper", Text: "12345"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			evidence, artifact, err := BuildTranscriptEvidenceV1(input, policy)
+			evidence, artifact, err := document.BuildTranscriptEvidenceV1(input, policy)
 			require.Error(t, err)
 			assert.Empty(t, evidence)
 			assert.Empty(t, artifact)
@@ -79,19 +87,25 @@ func TestBuildTranscriptEvidenceV1RejectsInvalidInput(t *testing.T) {
 }
 
 func TestBuildTranscriptEvidenceV1KeepsArtifactIdentitySeparateFromNormalizedText(t *testing.T) {
-	policy, err := NewEvidencePolicy(100)
+	policy, err := document.NewEvidencePolicy(100)
 	require.NoError(t, err)
 
-	first, firstArtifact, err := BuildTranscriptEvidenceV1(SuppliedTranscript{
+	first, firstArtifact, err := document.BuildTranscriptEvidenceV1(document.SuppliedTranscript{
 		Provider: "beeper", Text: "Cafe\u0301\r\narrival",
 	}, policy)
 	require.NoError(t, err)
-	second, secondArtifact, err := BuildTranscriptEvidenceV1(SuppliedTranscript{
+	repeat, repeatArtifact, err := document.BuildTranscriptEvidenceV1(document.SuppliedTranscript{
+		Provider: "beeper", Text: "Cafe\u0301\r\narrival",
+	}, policy)
+	require.NoError(t, err)
+	second, secondArtifact, err := document.BuildTranscriptEvidenceV1(document.SuppliedTranscript{
 		Provider: "other", Text: "Café\narrival",
 	}, policy)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Café\narrival", first.Units[0].Text)
+	assert.Equal(t, firstArtifact.SHA256, repeatArtifact.SHA256)
+	assert.Equal(t, first.Checksum, repeat.Checksum)
 	assert.NotEqual(t, firstArtifact.SHA256, secondArtifact.SHA256)
 	assert.NotEqual(t, first.Checksum, second.Checksum)
 	var payload struct {


### PR DESCRIPTION
A messaging provider's existing transcript can now become Docbank evidence, keeping the provider's exact wording and attribution. Msgvault needs this to make stored voice notes searchable, and its first attempt (msgvault #783) was closed because Docbank had no way to accept the audio or its transcript.

The new operation reuses Docbank's existing evidence policy, normalizer, and rendition builder, so the transcript gets the same validation and lexical segmentation as other evidence, and the original provider text stays in a JSON artifact even after the readable text is normalized. Generating a transcript from the audio, public ingestion, and search over this evidence remain follow-up work under #240.

Refs #294
