### PR TITLE
fix(openaihosted): reject nonnumeric embedding coordinates

### DIFF
--- a/document/openaihosted/client.go
+++ b/document/openaihosted/client.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"go.kenn.io/docbank/document"
+	"go.kenn.io/docbank/document/internal/providerutil"
 	"go.kenn.io/docbank/document/providerhttp"
 )
 
@@ -131,7 +132,8 @@ func (client *Client) Embed(ctx context.Context, inputs []document.EmbeddingInpu
 		return document.EmbeddingResult{}, err
 	}
 	var decoded wireResponse
-	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true)); err != nil {
+	if err := json.Unmarshal(body, &decoded, json.RejectUnknownMembers(true),
+		json.WithUnmarshalers(json.UnmarshalFunc(providerutil.UnmarshalEmbeddingFloat32))); err != nil {
 		return document.EmbeddingResult{}, &ProviderError{Kind: ErrPermanentResponse}
 	}
 	result, err := client.validateAndOrder(decoded, inputs)

--- a/document/openaihosted/client_test.go
+++ b/document/openaihosted/client_test.go
@@ -35,6 +35,9 @@ func TestEmbedRejectsStrictHostedResponseDrift(t *testing.T) {
 		"missing vector":       strings.Replace(valid, `,{"object":"embedding","embedding":[0,1,0],"index":1}`, "", 1),
 		"extra vector":         strings.Replace(valid, `],"model"`, `,{"object":"embedding","embedding":[0,0,1],"index":2}],"model"`, 1),
 		"wrong dimension":      strings.Replace(valid, `[1,0,0]`, `[1,0]`, 1),
+		"null coordinate":      strings.Replace(valid, `[1,0,0]`, `[1,null,0]`, 1),
+		"string coordinate":    strings.Replace(valid, `[1,0,0]`, `[1,"0",0]`, 1),
+		"boolean coordinate":   strings.Replace(valid, `[1,0,0]`, `[1,false,0]`, 1),
 		"non finite":           strings.Replace(valid, `[1,0,0]`, `[1e1000,0,0]`, 1),
 		"non unit":             strings.Replace(valid, `[1,0,0]`, `[1,1,0]`, 1),
 		"base64 vector":        strings.Replace(valid, `[1,0,0]`, `"AQID"`, 1),
@@ -47,9 +50,10 @@ func TestEmbedRejectsStrictHostedResponseDrift(t *testing.T) {
 	for name, body := range tests {
 		t.Run(name, func(t *testing.T) {
 			client := hostedClientReturning(t, http.StatusOK, "application/json", body)
-			_, err := client.Embed(context.Background(), twoHostedInputs(), hostedAuthorization(client.descriptor, 2))
+			result, err := client.Embed(context.Background(), twoHostedInputs(), hostedAuthorization(client.descriptor, 2))
 			require.Error(t, err)
 			require.ErrorIs(t, err, ErrPermanentResponse)
+			assert.Equal(t, document.EmbeddingResult{}, result)
 			assert.NotContains(t, err.Error(), "alpha")
 			assert.NotContains(t, err.Error(), "AQID")
 		})


### PR DESCRIPTION
## What changed

- Hosted OpenAI embeddings now reject nonnumeric coordinates, including `null`. Real numeric zeros still work.

## Why

A response containing `[1,null,0]` was silently decoded as `[1,0,0]` and accepted as a valid vector. We should reject the malformed response instead of using a vector the provider didn't actually return.

## Usage

No usage change.

This is a focused follow-up to #224. It does not change the OpenAI-compatible client or the remaining component PRs.

Refs #176
