### PR TITLE
feat(web): color and group tags by identity

### DIFF
--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -34,6 +34,12 @@ const tagCatalogScreenshotPath = path.join(
   "screenshots",
   "web-tag-catalog.png",
 );
+const tagFilterScreenshotPath = path.join(
+  repositoryRoot,
+  ".superpowers",
+  "screenshots",
+  "web-tag-filter.png",
+);
 const auditEvidenceScreenshotPath = path.join(
   repositoryRoot,
   ".superpowers",
@@ -147,6 +153,7 @@ test.describe("Docbank web screenshots", () => {
     await rm(restoreScreenshotPath, { force: true });
     await rm(tagAssignmentScreenshotPath, { force: true });
     await rm(tagCatalogScreenshotPath, { force: true });
+    await rm(tagFilterScreenshotPath, { force: true });
     await rm(auditEvidenceScreenshotPath, { force: true });
     await rm(storageScreenshotPath, { force: true });
     await rm(tuiStorageScreenshotPath, { force: true });
@@ -200,7 +207,9 @@ test.describe("Docbank web screenshots", () => {
       "plain",
     ]);
     await runDocbank(["tag", "create", "tax"]);
-    await runDocbank(["tag", "create", "reviewed"]);
+    await runDocbank(["tag", "create", "matter/acme/reviewed"]);
+    await runDocbank(["tag", "create", "matter/acme/privileged"]);
+    await runDocbank(["tag", "create", "matter/zephyr/hold"]);
     await runDocbank([
       "tag",
       "assign",
@@ -351,7 +360,7 @@ test.describe("Docbank web screenshots", () => {
     });
     await expect(report).toBeVisible();
     await report.click();
-    await expect(page.getByText("tax", { exact: true })).toBeVisible();
+    await expect(page.getByTitle(/^tax · /)).toBeVisible();
     await expect(page.getByText("Protected", { exact: true })).toBeVisible();
     await page.screenshot({
       path: vaultBrowserScreenshotPath,
@@ -454,6 +463,11 @@ test.describe("Docbank web screenshots", () => {
     });
     await expect(catalog).toContainText("tax");
     await expect(catalog).toContainText("reviewed");
+    await expect(catalog).toContainText("matter/acme");
+    await expect(catalog).toContainText("matter/zephyr");
+    await expect(
+      catalog.getByTitle("matter/acme/reviewed", { exact: true }),
+    ).toMatchAriaSnapshot(`- text: matter/acme/reviewed`);
     await catalog.getByRole("textbox", { name: "New tag name" }).fill("archived");
     await catalog.getByRole("button", { name: "Create" }).click();
     await expect(catalog).toContainText("Created archived.");
@@ -463,6 +477,20 @@ test.describe("Docbank web screenshots", () => {
       animations: "disabled",
     });
     await catalog.getByRole("button", { name: "Done" }).click();
+
+    const tagFilter = page.getByRole("combobox", {
+      name: "Browse or filter by tag: All tags",
+    });
+    await tagFilter.click();
+    await expect(
+      page.getByRole("option", { name: "matter/acme/reviewed (0)" }),
+    ).toBeVisible();
+    await page.screenshot({
+      path: tagFilterScreenshotPath,
+      fullPage: true,
+      animations: "disabled",
+    });
+    await page.getByRole("option", { name: "All tags" }).click();
 
     await page.getByRole("cell", { name: "Reports", exact: true }).dblclick();
     const selectedReport = page.getByRole("cell", {
@@ -478,9 +506,13 @@ test.describe("Docbank web screenshots", () => {
     });
     await expect(tags).toContainText("tax");
     await tags.getByRole("combobox", { name: "Tag to assign: Choose a tag…" }).click();
-    await tags.getByRole("option", { name: "reviewed (0)" }).click();
+    await tags
+      .getByRole("option", { name: "matter/acme/reviewed (0)" })
+      .click();
     await tags.getByRole("button", { name: "Add tag" }).click();
-    await expect(tags).toContainText("Added reviewed.");
+    await expect(tags).toContainText("Added matter/acme/reviewed.");
+    await expect(tags.getByRole("status", { name: "Loading" })).toHaveCount(0);
+    await expect(page.getByRole("status", { name: "Loading" })).toHaveCount(0);
     await page.screenshot({
       path: tagAssignmentScreenshotPath,
       fullPage: true,

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -25,13 +25,11 @@
     EmptyState,
     IconButton,
     SearchInput,
-    SelectDropdown,
     Spinner,
     Table,
     TableHeaderCell,
     ThemeToggle,
     TopBar,
-    type SelectDropdownOption,
     type SortDirection,
   } from "@kenn-io/kit-ui";
   import AuditEvidenceDrawer from "./AuditEvidenceDrawer.svelte";
@@ -45,6 +43,8 @@
   import TagCatalogModal, {
     type TagDefinitionChange,
   } from "./TagCatalogModal.svelte";
+  import TagLabel from "./TagLabel.svelte";
+  import TagPicker from "./TagPicker.svelte";
   import TrashDrawer from "./TrashDrawer.svelte";
   import TrashNodeModal from "./TrashNodeModal.svelte";
   import UploadDrawer from "./UploadDrawer.svelte";
@@ -69,6 +69,7 @@
   } from "./api.js";
   import { basename, formatBytes, formatDate } from "./format.js";
   import { orderRows, reconcileSearchView, type SortField } from "./rows.js";
+  import { sortTags } from "./tagPresentation.js";
   import { VerifiedUploadChannel } from "./upload.js";
 
   type Row = { node: Node; path: string; match?: "name" | "content" };
@@ -139,14 +140,13 @@
 
   const selected = $derived(rows.find((row) => row.node.id === selectedID));
   const membership = $derived(selectedAudit?.membership);
-  const tagOptions = $derived<SelectDropdownOption[]>([
-    { value: "", label: "All tags" },
-    ...tagCatalog.map((tag) => ({
-      value: tag.id,
-      label: `${tag.name} (${tag.assignment_count})`,
-      triggerLabel: tag.name,
-    })),
-  ]);
+  const tagPickerTitle = $derived(
+    tagCatalogError
+      ? `Tags unavailable: ${tagCatalogError}`
+      : tagCatalogTotal > tagCatalogListed
+        ? `Browse or filter: showing ${tagCatalogListed} of ${tagCatalogTotal} tags`
+        : "Browse or filter by tag",
+  );
   const activeTag = $derived(tagCatalog.find((tag) => tag.id === activeTagID));
   const tagBrowse = $derived(activeTagID !== "" && activeQuery === "");
   const sortedRows = $derived(
@@ -484,7 +484,7 @@
         }
       }
       if (request !== tagCatalogGeneration || session !== webSession) return;
-      tagCatalog = selectedTagID === tagFilterID ? items : page.items;
+      tagCatalog = sortTags(selectedTagID === tagFilterID ? items : page.items);
       tagCatalogTotal = page.total;
       tagCatalogListed = page.items.length;
       if (selectedMissing && tagFilterID === selectedTagID) {
@@ -517,7 +517,7 @@
     try {
       const page = await nodeTags(session, nodeID);
       if (request !== tagGeneration || session !== webSession || selectedID !== nodeID) return;
-      selectedTags = page.items;
+      selectedTags = sortTags(page.items);
       selectedTagsTotal = page.total;
     } catch (cause) {
       if (request !== tagGeneration || session !== webSession || selectedID !== nodeID) return;
@@ -641,10 +641,10 @@
     );
     if (selectedChanged) {
       if (assigned) {
-        selectedTags = [
+        selectedTags = sortTags([
           ...selectedTags.filter((tag) => tag.id !== receipt.tag.id),
           receipt.tag,
-        ].sort((left, right) => left.name.localeCompare(right.name));
+        ]);
         if (receipt.changed) selectedTagsTotal += 1;
       } else {
         selectedTags = selectedTags.filter((tag) => tag.id !== receipt.tag.id);
@@ -692,12 +692,16 @@
   function handleTagDefinitionChanged(change: TagDefinitionChange): void {
     const changedTag = change.tag;
     if (change.kind === "renamed") {
-      tagCatalog = tagCatalog
-        .map((tag) => (tag.id === changedTag.id ? changedTag : tag))
-        .sort((left, right) => left.name.localeCompare(right.name));
-      selectedTags = selectedTags
-        .map((tag) => (tag.id === changedTag.id ? changedTag : tag))
-        .sort((left, right) => left.name.localeCompare(right.name));
+      tagCatalog = sortTags(
+        tagCatalog.map((tag) =>
+          tag.id === changedTag.id ? changedTag : tag,
+        ),
+      );
+      selectedTags = sortTags(
+        selectedTags.map((tag) =>
+          tag.id === changedTag.id ? changedTag : tag,
+        ),
+      );
     } else if (change.kind === "deleted") {
       tagCatalog = tagCatalog.filter((tag) => tag.id !== changedTag.id);
       tagCatalogTotal = Math.max(0, tagCatalogTotal - 1);
@@ -960,14 +964,12 @@
             </div>
           </div>
           <div class="toolbar-actions">
-            <SelectDropdown
+            <TagPicker
               value={tagFilterID}
-              options={tagOptions}
-              title={tagCatalogError
-                ? `Tags unavailable: ${tagCatalogError}`
-                : tagCatalogTotal > tagCatalogListed
-                  ? `Browse or filter: showing ${tagCatalogListed} of ${tagCatalogTotal} tags`
-                  : "Browse or filter by tag"}
+              tags={tagCatalog}
+              title={tagPickerTitle}
+              placeholder="All tags"
+              includeAll
               disabled={!directory || tagCatalog.length === 0}
               onchange={changeTagFilter}
             />
@@ -1215,14 +1217,11 @@
                     ariaLabel="Assigned tags"
                   >
                     {#snippet chip(tag)}
-                      <Chip
+                      <TagLabel
+                        {tag}
                         size="sm"
-                        tone="workspace"
-                        uppercase={false}
-                        title={`${tag.assignment_count} total assignment${tag.assignment_count === 1 ? "" : "s"} · ${tag.id}`}
-                      >
-                        {tag.name}
-                      </Chip>
+                        title={`${tag.name} · ${tag.assignment_count} total assignment${tag.assignment_count === 1 ? "" : "s"} · ${tag.id}`}
+                      />
                     {/snippet}
                   </ChipStack>
                   {#if selectedTags.length < selectedTagsTotal}

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -128,6 +128,12 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
                   revision: 1,
                   assignment_count: 3,
                 },
+                {
+                  id: "11111111-1111-4111-8111-111111111111",
+                  name: "matter/acme/reviewed",
+                  revision: 1,
+                  assignment_count: 6,
+                },
               ]
             : [
                 {
@@ -137,7 +143,7 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
                   assignment_count: 7,
                 },
               ],
-        total: tagCatalogReads === 1 ? 1 : 1001,
+        total: tagCatalogReads === 1 ? 2 : 1001,
         limit: 1000,
         offset: 0,
       });
@@ -248,6 +254,15 @@ it("supersedes an in-flight search when its tag filter changes", async () => {
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }),
   );
+  expect(screen.getByText("matter/acme")).toBeTruthy();
+  const groupedOption = screen.getByRole("option", {
+    name: "matter/acme/reviewed (6)",
+  });
+  expect(groupedOption.textContent).not.toContain("matter/acme/reviewed");
+  expect(
+    groupedOption.querySelector<HTMLElement>("[data-tag-swatch]")?.style
+      .backgroundColor,
+  ).toBe("rgb(188, 76, 0)");
   await fireEvent.click(screen.getByRole("option", { name: "tax (3)" }));
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Browse or filter by tag: tax" }),
@@ -435,7 +450,7 @@ it.each(["browse", "search"] as const)(
     };
     const reviewed = {
       id: "44444444-4444-4444-8444-444444444444",
-      name: "reviewed",
+      name: "matter/acme/reviewed",
       revision: 1,
       assignment_count: 1,
     };
@@ -632,6 +647,15 @@ it.each(["browse", "search"] as const)(
     }
 
     await screen.findByText("2 assigned");
+    const reviewedName = screen.getByText("matter/acme/reviewed");
+    const reviewedLabel = reviewedName.parentElement as HTMLElement;
+    const reviewedVisual = reviewedLabel.querySelector<HTMLElement>(
+      "[aria-hidden='true']",
+    );
+    expect(reviewedVisual?.textContent).toBe("reviewed");
+    expect(
+      (reviewedVisual?.firstElementChild as HTMLElement).style.backgroundColor,
+    ).toBe("rgb(130, 80, 223)");
     await fireEvent.click(screen.getByRole("button", { name: "Refresh current view" }));
     const manage = screen.getByRole("button", { name: "Manage" });
     expect(manage.hasAttribute("disabled")).toBe(true);
@@ -709,7 +733,7 @@ it.each(["browse", "search"] as const)(
     await fireEvent.click(screen.getByRole("button", { name: "Add tag" }));
     await waitFor(() => expect(searchReads).toBe(4));
     const removeReviewed = screen.getByRole("button", {
-      name: "Remove tag reviewed",
+      name: "Remove tag matter/acme/reviewed",
     });
     expect(removeReviewed.hasAttribute("disabled")).toBe(true);
     await fireEvent.click(removeReviewed);

--- a/frontend/src/ManageTagsModal.svelte
+++ b/frontend/src/ManageTagsModal.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
   import { untrack } from "svelte";
   import PlusIcon from "@lucide/svelte/icons/plus";
-  import TagIcon from "@lucide/svelte/icons/tag";
   import XIcon from "@lucide/svelte/icons/x";
   import {
     Button,
-    Chip,
     IconButton,
     Modal,
-    SelectDropdown,
     Spinner,
-    type SelectDropdownOption,
   } from "@kenn-io/kit-ui";
   import {
     APIError,
@@ -19,6 +15,9 @@
     type Tag,
     type TagAssignmentReceipt,
   } from "./api.js";
+  import TagLabel from "./TagLabel.svelte";
+  import TagPicker from "./TagPicker.svelte";
+  import { groupTags, sortTags } from "./tagPresentation.js";
 
   interface Props {
     session: string;
@@ -47,7 +46,7 @@
   }: Props = $props();
 
   let currentNode = $state(untrack(() => node));
-  let assigned = $state(untrack(() => [...assignedTags]));
+  let assigned = $state(untrack(() => sortTags(assignedTags)));
   let currentAssignedTotal = $state(untrack(() => assignedTotal));
   let selectedTagID = $state("");
   let pendingTagID = $state("");
@@ -57,14 +56,7 @@
   const available = $derived(
     catalog.filter((tag) => !assigned.some((item) => item.id === tag.id)),
   );
-  const options = $derived<SelectDropdownOption[]>([
-    { value: "", label: available.length ? "Choose a tag…" : "No available tags" },
-    ...available.map((tag) => ({
-      value: tag.id,
-      label: `${tag.name} (${tag.assignment_count})`,
-      triggerLabel: tag.name,
-    })),
-  ]);
+  const assignedGroups = $derived(groupTags(assigned));
 
   function close(): void {
     if (!pendingTagID) onclose();
@@ -85,10 +77,10 @@
       );
       currentNode = receipt.node;
       if (assign) {
-        assigned = [
+        assigned = sortTags([
           ...assigned.filter((item) => item.id !== tag.id),
           receipt.tag,
-        ].sort((left, right) => left.name.localeCompare(right.name));
+        ]);
         if (receipt.changed) currentAssignedTotal += 1;
         notice = receipt.changed
           ? `Added ${receipt.tag.name}.`
@@ -131,32 +123,21 @@
   closeOnOverlayClick={!pendingTagID}
 >
   <div class="manage-tags">
-    <header class="target">
-      <TagIcon size="19" aria-hidden="true" />
-      <div>
-        <strong>{node.name || "/"}</strong>
-        <span>Stable node id:{currentNode.id} · revision {currentNode.revision}</span>
-      </div>
-    </header>
+    <p class="target">{node.name || "/"}</p>
 
-    <section aria-labelledby="assigned-tags-heading">
-      <div class="section-heading">
-        <div>
-          <span>ASSIGNED TAGS</span>
-          <strong id="assigned-tags-heading">{assigned.length} visible</strong>
-        </div>
-        {#if currentAssignedTotal > assigned.length}
-          <small>First {assigned.length} of {currentAssignedTotal}</small>
-        {/if}
-      </div>
-      {#if assigned.length === 0}
-        <p class="empty">No tags are assigned to this node.</p>
-      {:else}
-        <div class="assigned-list">
-          {#each assigned as tag (tag.id)}
+    {#if assigned.length === 0}
+      <p class="empty">No tags assigned.</p>
+    {:else}
+      <div class="assigned-list" role="group" aria-label="Assigned tags">
+        {#each assignedGroups as group}
+          {#if group.name}
+            <div class="assigned-group-heading">{group.name}</div>
+          {/if}
+          {#each group.tags as item (item.tag.id)}
+            {@const tag = item.tag}
             <div class="assigned-tag">
               <div>
-                <Chip size="sm" tone="workspace" uppercase={false}>{tag.name}</Chip>
+                <TagLabel {tag} size="sm" />
                 <small>{tag.assignment_count} total assignment{tag.assignment_count === 1 ? "" : "s"}</small>
               </div>
               <IconButton
@@ -174,56 +155,43 @@
               </IconButton>
             </div>
           {/each}
-        </div>
-      {/if}
-    </section>
+        {/each}
+      </div>
+    {/if}
+    {#if currentAssignedTotal > assigned.length}
+      <p class="bounded">Showing the first {assigned.length} of {currentAssignedTotal} assigned tags.</p>
+    {/if}
 
-    <section aria-labelledby="add-tag-heading">
-      <div class="section-heading">
-        <div>
-          <span>ADD AN EXISTING TAG</span>
-          <strong id="add-tag-heading">Choose from the vault catalog</strong>
-        </div>
-      </div>
-      <div class="add-row">
-        <SelectDropdown
-          value={selectedTagID}
-          {options}
-          title="Tag to assign"
-          disabled={disabled || pendingTagID !== "" || available.length === 0}
-          onchange={(value) => (selectedTagID = value)}
-        />
-        <Button
-          size="sm"
-          tone="info"
-          surface="solid"
-          disabled={disabled || !selectedTagID || pendingTagID !== ""}
-          onclick={addSelected}
-        >
-          {#if pendingTagID === selectedTagID}
-            <Spinner size={13} />
-          {:else}
-            <PlusIcon size="14" aria-hidden="true" />
-          {/if}
-          Add tag
-        </Button>
-      </div>
-      {#if catalogTotal > catalog.length}
-        <p class="bounded">
-          Showing the first {catalog.length} of {catalogTotal} tag definitions.
-          Use the CLI or API for definitions outside this catalog page.
-        </p>
-      {/if}
-    </section>
+    <div class="add-row">
+      <TagPicker
+        value={selectedTagID}
+        tags={available}
+        title="Tag to assign"
+        placeholder={available.length ? "Choose a tag…" : "No available tags"}
+        disabled={disabled || pendingTagID !== "" || available.length === 0}
+        onchange={(value) => (selectedTagID = value)}
+      />
+      <Button
+        size="sm"
+        tone="info"
+        surface="solid"
+        disabled={disabled || !selectedTagID || pendingTagID !== ""}
+        onclick={addSelected}
+      >
+        {#if pendingTagID !== "" && pendingTagID === selectedTagID}
+          <Spinner size={13} />
+        {:else}
+          <PlusIcon size="14" aria-hidden="true" />
+        {/if}
+        Add tag
+      </Button>
+    </div>
+    {#if catalogTotal > catalog.length}
+      <p class="bounded">Showing the first {catalog.length} of {catalogTotal} tags.</p>
+    {/if}
 
     {#if notice}<p class="notice" role="status">{notice}</p>{/if}
     {#if failure}<p class="failure" role="alert">{failure}</p>{/if}
-
-    <p class="boundary">
-      This changes only the selected node’s tag assignments. Creating,
-      renaming, deleting, or bulk-applying tag definitions remains a CLI or
-      authenticated API workflow.
-    </p>
   </div>
   {#snippet footer()}
     <Button surface="soft" disabled={pendingTagID !== ""} onclick={close}>Done</Button>
@@ -233,74 +201,34 @@
 <style>
   .manage-tags {
     display: grid;
-    gap: var(--space-5);
+    gap: var(--space-4);
   }
 
   .target {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: start;
-    gap: var(--space-3);
-    padding: var(--space-4);
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-md);
-    background: var(--bg-inset);
-  }
-
-  .target > :global(svg) {
-    margin-top: 2px;
-    color: var(--accent-teal);
-  }
-
-  .target > div {
-    display: grid;
-    min-width: 0;
-    gap: var(--space-1);
-  }
-
-  .target strong {
+    margin: 0;
     overflow-wrap: anywhere;
     color: var(--text-primary);
+    font-weight: var(--font-weight-semibold, 600);
   }
 
-  .target span,
   small {
     color: var(--text-muted);
     font-size: var(--font-size-xs);
   }
 
-  section {
-    display: grid;
-    gap: var(--space-3);
-  }
-
-  .section-heading {
-    display: flex;
-    align-items: end;
-    justify-content: space-between;
-    gap: var(--space-3);
-  }
-
-  .section-heading > div {
-    display: grid;
-    gap: 1px;
-  }
-
-  .section-heading span {
-    color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-bold);
-    letter-spacing: var(--letter-spacing-label, 0.04em);
-  }
-
-  .section-heading strong {
-    color: var(--text-secondary);
-    font-size: var(--font-size-sm);
-  }
-
   .assigned-list {
     display: grid;
     gap: var(--space-2);
+  }
+
+  .assigned-group-heading {
+    padding: var(--space-1) var(--space-2) 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-2xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0.05em;
+    overflow-wrap: anywhere;
+    text-transform: uppercase;
   }
 
   .assigned-tag {
@@ -330,7 +258,6 @@
 
   .empty,
   .bounded,
-  .boundary,
   .notice,
   .failure {
     margin: 0;
@@ -339,8 +266,7 @@
   }
 
   .empty,
-  .bounded,
-  .boundary {
+  .bounded {
     color: var(--text-muted);
   }
 
@@ -360,11 +286,6 @@
     border: 1px solid color-mix(in srgb, var(--accent-red) 35%, transparent);
     background: color-mix(in srgb, var(--accent-red) 8%, transparent);
     color: var(--accent-red);
-  }
-
-  .boundary {
-    padding-top: var(--space-4);
-    border-top: 1px solid var(--border-subtle);
   }
 
   @media (max-width: 640px) {

--- a/frontend/src/ManageTagsModal.test.ts
+++ b/frontend/src/ManageTagsModal.test.ts
@@ -38,7 +38,7 @@ const tax = {
 };
 const reviewed = {
   id: "22222222-2222-4222-8222-222222222222",
-  name: "reviewed",
+  name: "matter/acme/reviewed",
   revision: 1,
   assignment_count: 2,
 };
@@ -94,9 +94,20 @@ it("adds and removes existing tags under consecutive node revisions", async () =
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Tag to assign: Choose a tag…" }),
   );
-  await fireEvent.click(screen.getByRole("option", { name: "reviewed (2)" }));
+  expect(screen.getByText("matter/acme")).toBeTruthy();
+  const reviewedOption = screen.getByRole("option", {
+    name: "matter/acme/reviewed (2)",
+  });
+  expect(reviewedOption.textContent).not.toContain("matter/acme/reviewed");
+  await fireEvent.click(reviewedOption);
   await fireEvent.click(screen.getByRole("button", { name: "Add tag" }));
-  expect(await screen.findByText("Added reviewed.")).toBeTruthy();
+  expect(await screen.findByText("Added matter/acme/reviewed.")).toBeTruthy();
+  expect(screen.queryByRole("status", { name: "Loading" })).toBeNull();
+  const assignedName = screen.getByText("matter/acme/reviewed");
+  expect(
+    assignedName.parentElement?.querySelector<HTMLElement>("[aria-hidden='true']")
+      ?.textContent,
+  ).toBe("reviewed");
 
   await fireEvent.click(screen.getByRole("button", { name: "Remove tag tax" }));
   expect(await screen.findByText("Removed tax.")).toBeTruthy();
@@ -157,7 +168,9 @@ it("keeps a stale assignment decision visible for refresh", async () => {
   await fireEvent.click(
     screen.getByRole("combobox", { name: "Tag to assign: Choose a tag…" }),
   );
-  await fireEvent.click(screen.getByRole("option", { name: "reviewed (2)" }));
+  await fireEvent.click(
+    screen.getByRole("option", { name: "matter/acme/reviewed (2)" }),
+  );
   await fireEvent.click(screen.getByRole("button", { name: "Add tag" }));
 
   expect(

--- a/frontend/src/TagCatalogModal.svelte
+++ b/frontend/src/TagCatalogModal.svelte
@@ -14,12 +14,10 @@
   import CheckIcon from "@lucide/svelte/icons/check";
   import PencilIcon from "@lucide/svelte/icons/pencil";
   import PlusIcon from "@lucide/svelte/icons/plus";
-  import TagIcon from "@lucide/svelte/icons/tag";
   import Trash2Icon from "@lucide/svelte/icons/trash-2";
   import XIcon from "@lucide/svelte/icons/x";
   import {
     Button,
-    Chip,
     IconButton,
     Modal,
     Spinner,
@@ -32,6 +30,8 @@
     renameTag,
     type Tag,
   } from "./api.js";
+  import TagLabel from "./TagLabel.svelte";
+  import { groupTags, sortTags } from "./tagPresentation.js";
 
   let {
     session,
@@ -51,7 +51,7 @@
     onauthfailure: (cause: unknown) => void;
   } = $props();
 
-  let current = $state(untrack(() => [...catalog]));
+  let current = $state(untrack(() => sortTags(catalog)));
   let currentTotal = $state(untrack(() => catalogTotal));
   let newName = $state("");
   let editingID = $state("");
@@ -60,6 +60,7 @@
   let pending = $state(false);
   let failure = $state("");
   let notice = $state("");
+  const currentGroups = $derived(groupTags(current));
 
   function close(): void {
     if (!pending) onclose();
@@ -93,9 +94,7 @@
     notice = "";
     try {
       const tag = await createTag(session, newName);
-      current = [...current, tag].sort((left, right) =>
-        left.name.localeCompare(right.name),
-      );
+      current = sortTags([...current, tag]);
       currentTotal += 1;
       newName = "";
       notice = `Created ${tag.name}.`;
@@ -115,9 +114,9 @@
     notice = "";
     try {
       const renamed = await renameTag(session, tag.id, tag.revision, editName);
-      current = current
-        .map((item) => (item.id === renamed.id ? renamed : item))
-        .sort((left, right) => left.name.localeCompare(right.name));
+      current = sortTags(
+        current.map((item) => (item.id === renamed.id ? renamed : item)),
+      );
       editingID = "";
       editName = "";
       notice = `Renamed tag to ${renamed.name}.`;
@@ -187,63 +186,42 @@
     </div>
   {:else}
     <div class="tag-catalog">
-      <header class="catalog-heading">
-        <TagIcon size="20" aria-hidden="true" />
-        <div>
-          <strong>Organize the vault’s shared vocabulary</strong>
-          <span>
-            Names can change; stable tag IDs continue to identify the same definition.
-          </span>
-        </div>
-      </header>
-
-      <section aria-labelledby="create-tag-heading">
-        <div class="section-heading">
-          <div>
-            <span>NEW DEFINITION</span>
-            <strong id="create-tag-heading">Create a tag</strong>
-          </div>
-        </div>
-        <form
-          class="create-row"
-          onsubmit={(event) => {
-            event.preventDefault();
-            void create();
-          }}
+      <form
+        class="create-row"
+        onsubmit={(event) => {
+          event.preventDefault();
+          void create();
+        }}
+      >
+        <TextInput
+          bind:value={newName}
+          block
+          ariaLabel="New tag name"
+          placeholder="New tag name"
+          disabled={disabled || pending}
+        />
+        <Button
+          size="sm"
+          tone="info"
+          surface="solid"
+          disabled={disabled || pending || newName === ""}
+          onclick={() => void create()}
         >
-          <TextInput
-            bind:value={newName}
-            block
-            ariaLabel="New tag name"
-            placeholder="e.g. reviewed"
-            disabled={disabled || pending}
-          />
-          <Button
-            size="sm"
-            tone="info"
-            surface="solid"
-            disabled={disabled || pending || newName === ""}
-            onclick={() => void create()}
-          >
-            {#if pending && !editingID}<Spinner size={13} />{:else}<PlusIcon size="14" />{/if}
-            Create
-          </Button>
-        </form>
-      </section>
+          {#if pending && !editingID}<Spinner size={13} />{:else}<PlusIcon size="14" />{/if}
+          Create
+        </Button>
+      </form>
 
-      <section aria-labelledby="tag-definitions-heading">
-        <div class="section-heading">
-          <div>
-            <span>TAG DEFINITIONS</span>
-            <strong id="tag-definitions-heading">{current.length} visible</strong>
-          </div>
-          <small>{currentTotal} total</small>
-        </div>
-        {#if current.length === 0}
-          <p class="empty">No tags have been defined yet.</p>
-        {:else}
-          <div class="definition-list">
-            {#each current as tag (tag.id)}
+      {#if current.length === 0}
+        <p class="empty">No tags yet.</p>
+      {:else}
+        <div class="definition-list" role="group" aria-label="Tags">
+          {#each currentGroups as group}
+            {#if group.name}
+              <div class="definition-group-heading">{group.name}</div>
+            {/if}
+            {#each group.tags as item (item.tag.id)}
+              {@const tag = item.tag}
               <div class="definition-row">
                 {#if editingID === tag.id}
                   <div class="rename-row">
@@ -282,7 +260,7 @@
                 {:else}
                   <div class="definition-authority">
                     <div>
-                      <Chip size="sm" tone="workspace" uppercase={false}>{tag.name}</Chip>
+                      <TagLabel {tag} size="sm" />
                       <span>{tag.assignment_count} assignment{tag.assignment_count === 1 ? "" : "s"}</span>
                     </div>
                     <code>{tag.id}</code>
@@ -315,15 +293,12 @@
                 {/if}
               </div>
             {/each}
-          </div>
-        {/if}
-        {#if currentTotal > current.length}
-          <p class="bounded">
-            Showing the first {current.length} of {currentTotal} definitions.
-            Use the CLI or API for definitions outside this bounded catalog.
-          </p>
-        {/if}
-      </section>
+          {/each}
+        </div>
+      {/if}
+      {#if currentTotal > current.length}
+        <p class="bounded">Showing the first {current.length} of {currentTotal} tags.</p>
+      {/if}
 
       {#if notice}<p class="notice" role="status">{notice}</p>{/if}
       {#if failure}<p class="failure" role="alert">{failure}</p>{/if}
@@ -352,10 +327,9 @@
   .tag-catalog,
   .delete-confirmation {
     display: grid;
-    gap: var(--space-5);
+    gap: var(--space-4);
   }
 
-  .catalog-heading,
   .delete-target {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
@@ -367,58 +341,21 @@
     background: var(--bg-inset);
   }
 
-  .catalog-heading > :global(svg) {
-    margin-top: 2px;
-    color: var(--accent-cyan);
-  }
-
-  .catalog-heading > div,
   .delete-target > div {
     display: grid;
     min-width: 0;
     gap: var(--space-1);
   }
 
-  .catalog-heading strong,
   .delete-target strong {
     color: var(--text-primary);
     font-size: var(--font-size-md);
   }
 
-  .catalog-heading span,
   .delete-target span {
     color: var(--text-muted);
     font-size: var(--font-size-xs);
     line-height: 1.4;
-  }
-
-  section {
-    display: grid;
-    gap: var(--space-3);
-  }
-
-  .section-heading {
-    display: flex;
-    align-items: end;
-    justify-content: space-between;
-    gap: var(--space-3);
-  }
-
-  .section-heading > div {
-    display: grid;
-    gap: 2px;
-  }
-
-  .section-heading span,
-  .section-heading small {
-    color: var(--text-muted);
-    font-size: 10px;
-    letter-spacing: 0.08em;
-  }
-
-  .section-heading strong {
-    color: var(--text-primary);
-    font-size: var(--font-size-sm);
   }
 
   .create-row,
@@ -450,6 +387,18 @@
 
   .definition-row:last-child {
     border-bottom: 0;
+  }
+
+  .definition-group-heading {
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+    background: color-mix(in srgb, var(--bg-surface) 55%, transparent);
+    color: var(--text-muted);
+    font-size: var(--font-size-2xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0.05em;
+    overflow-wrap: anywhere;
+    text-transform: uppercase;
   }
 
   .definition-authority {

--- a/frontend/src/TagCatalogModal.test.ts
+++ b/frontend/src/TagCatalogModal.test.ts
@@ -177,3 +177,58 @@ it("keeps a stale rename visible without losing the inspected definition", async
     expect(screen.getByRole("textbox", { name: "Rename tax" })).toBeTruthy(),
   );
 });
+
+it("keeps an identity color while a rename moves the tag between groups", async () => {
+  const groupedTax = { ...tax, name: "matter/acme/tax" };
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        ...groupedTax,
+        name: "archive/complete",
+        revision: 3,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+
+  render(TagCatalogModal, {
+    session: "short-lived",
+    catalog: [groupedTax],
+    catalogTotal: 1,
+    disabled: false,
+    onclose: vi.fn(),
+    onchanged: vi.fn(),
+    onauthfailure: vi.fn(),
+  });
+
+  expect(screen.getByText("matter/acme")).toBeTruthy();
+  const beforeName = screen.getByText("matter/acme/tax");
+  const before = beforeName.parentElement as HTMLElement;
+  const beforeVisual = before.querySelector<HTMLElement>("[aria-hidden='true']");
+  expect(beforeVisual?.textContent).toBe("tax");
+  expect((beforeVisual?.firstElementChild as HTMLElement).style.backgroundColor).toBe(
+    "rgb(188, 76, 0)",
+  );
+
+  await fireEvent.click(
+    screen.getByRole("button", { name: "Rename tag matter/acme/tax" }),
+  );
+  await fireEvent.input(
+    screen.getByRole("textbox", { name: "Rename matter/acme/tax" }),
+    { target: { value: "archive/complete" } },
+  );
+  await fireEvent.click(
+    screen.getByRole("button", {
+      name: "Save renamed tag matter/acme/tax",
+    }),
+  );
+
+  expect(await screen.findByText("archive")).toBeTruthy();
+  const afterName = screen.getByText("archive/complete");
+  const after = afterName.parentElement as HTMLElement;
+  const afterVisual = after.querySelector<HTMLElement>("[aria-hidden='true']");
+  expect(afterVisual?.textContent).toBe("complete");
+  expect((afterVisual?.firstElementChild as HTMLElement).style.backgroundColor).toBe(
+    "rgb(188, 76, 0)",
+  );
+});

--- a/frontend/src/TagLabel.svelte
+++ b/frontend/src/TagLabel.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { ColorLabel, type ColorLabelSize } from "@kenn-io/kit-ui";
+  import type { Tag } from "./api.js";
+  import { presentTag } from "./tagPresentation.js";
+
+  let {
+    tag,
+    size = "md",
+    title,
+  }: {
+    tag: Tag;
+    size?: ColorLabelSize;
+    title?: string;
+  } = $props();
+
+  const presented = $derived(presentTag(tag));
+</script>
+
+<span
+  class="tag-label"
+  title={title ?? tag.name}
+>
+  <span class="tag-label__visual" aria-hidden="true">
+    <ColorLabel
+      name={presented.label}
+      color={presented.color}
+      {size}
+    />
+  </span>
+  <span class="kit-sr-only">{tag.name}</span>
+</span>
+
+<style>
+  .tag-label {
+    display: inline-flex;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .tag-label__visual {
+    display: inline-flex;
+    min-width: 0;
+    max-width: 100%;
+  }
+</style>

--- a/frontend/src/TagPicker.svelte
+++ b/frontend/src/TagPicker.svelte
@@ -1,0 +1,425 @@
+<script lang="ts">
+  import CheckIcon from "@lucide/svelte/icons/check";
+  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
+  import {
+    autoReposition,
+    dismissable,
+    floatingPopoverStyle,
+  } from "@kenn-io/kit-ui";
+  import { tick } from "svelte";
+  import type { Tag } from "./api.js";
+  import { groupTags } from "./tagPresentation.js";
+
+  interface PickerOption {
+    id: string;
+    label: string;
+    fullName: string;
+    count?: number;
+    color?: string;
+    tag?: Tag;
+  }
+
+  interface Props {
+    value: string;
+    tags: readonly Tag[];
+    title: string;
+    placeholder: string;
+    onchange: (value: string) => void;
+    includeAll?: boolean;
+    disabled?: boolean;
+    tooltip?: string;
+    align?: "start" | "end";
+    class?: string;
+  }
+
+  let {
+    value,
+    tags,
+    title,
+    placeholder,
+    onchange,
+    includeAll = false,
+    disabled = false,
+    tooltip,
+    align = "start",
+    class: className = "",
+  }: Props = $props();
+
+  let open = $state(false);
+  let highlightedIndex = $state(0);
+  let containerEl = $state<HTMLDivElement>();
+  let buttonEl = $state<HTMLButtonElement>();
+  let listEl = $state<HTMLDivElement>();
+  let listStyle = $state("");
+
+  const dropdownID = $props.id();
+  const listboxID = `${dropdownID}-listbox`;
+  const groups = $derived(groupTags(tags));
+  const options = $derived.by(() => {
+    const items: PickerOption[] = includeAll
+      ? [{ id: "", label: placeholder, fullName: placeholder }]
+      : [];
+    for (const group of groups) {
+      for (const item of group.tags) {
+        items.push({
+          id: item.tag.id,
+          label: item.label,
+          fullName: item.tag.name,
+          count: item.tag.assignment_count,
+          color: item.color,
+          tag: item.tag,
+        });
+      }
+    }
+    return items;
+  });
+  const optionIndexes = $derived(
+    new Map(options.map((option, index) => [option.id, index])),
+  );
+  const selected = $derived(options.find((option) => option.id === value));
+  const triggerText = $derived(selected?.label ?? placeholder);
+  const triggerFullName = $derived(selected?.fullName ?? placeholder);
+  const trulyDisabled = $derived(disabled || options.length === 0);
+
+  $effect(() => {
+    if (!open) return;
+    const cleanups = [
+      dismissable({
+        owners: () => [containerEl],
+        dismiss: close,
+        escapeFocus: () => buttonEl,
+      }),
+      autoReposition(() => listEl, positionList),
+    ];
+    return () => cleanups.forEach((cleanup) => cleanup());
+  });
+
+  $effect(() => {
+    if (trulyDisabled && open) close();
+  });
+
+  function optionID(index: number): string {
+    return `${dropdownID}-option-${index}`;
+  }
+
+  function positionList(): void {
+    if (!buttonEl || !listEl) return;
+    const trigger = buttonEl.getBoundingClientRect();
+    const width = Math.max(listEl.offsetWidth, trigger.width);
+    listStyle = `${floatingPopoverStyle({
+      trigger,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      popoverWidth: width,
+      popoverHeight: listEl.offsetHeight,
+      align,
+      triggerGap: 2,
+    })}; min-width: ${Math.round(trigger.width)}px`;
+  }
+
+  function close(): void {
+    open = false;
+  }
+
+  async function show(): Promise<void> {
+    if (trulyDisabled) return;
+    open = true;
+    highlightedIndex = Math.max(0, optionIndexes.get(value) ?? 0);
+    await tick();
+    positionList();
+    document
+      .getElementById(optionID(highlightedIndex))
+      ?.scrollIntoView({ block: "nearest" });
+  }
+
+  function toggle(): void {
+    if (open) close();
+    else void show();
+  }
+
+  function select(option: PickerOption): void {
+    if (trulyDisabled) return;
+    onchange(option.id);
+    close();
+    buttonEl?.focus();
+  }
+
+  function moveHighlight(delta: number): void {
+    if (options.length === 0) return;
+    highlightedIndex =
+      (highlightedIndex + delta + options.length) % options.length;
+    document
+      .getElementById(optionID(highlightedIndex))
+      ?.scrollIntoView({ block: "nearest" });
+  }
+
+  function onFocusout(event: FocusEvent): void {
+    const nextTarget = event.relatedTarget as Node | null;
+    if (nextTarget && containerEl?.contains(nextTarget)) return;
+    close();
+  }
+
+  function onButtonKeydown(event: KeyboardEvent): void {
+    if (event.key === "Tab") {
+      close();
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (!open) void show();
+      else moveHighlight(event.key === "ArrowDown" ? 1 : -1);
+      return;
+    }
+    if (open && (event.key === "Home" || event.key === "End")) {
+      event.preventDefault();
+      highlightedIndex = event.key === "Home" ? 0 : options.length - 1;
+      document
+        .getElementById(optionID(highlightedIndex))
+        ?.scrollIntoView({ block: "nearest" });
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (!open) {
+        void show();
+        return;
+      }
+      const option = options[highlightedIndex];
+      if (option) select(option);
+    }
+  }
+</script>
+
+{#snippet optionRow(option: PickerOption, index: number)}
+  <button
+    id={optionID(index)}
+    type="button"
+    tabindex="-1"
+    class="tag-picker__option"
+    class:highlighted={index === highlightedIndex}
+    class:selected={option.id === value}
+    role="option"
+    aria-label={option.count === undefined
+      ? option.fullName
+      : `${option.fullName} (${option.count})`}
+    aria-selected={option.id === value}
+    title={option.tag ? option.fullName : undefined}
+    onclick={() => select(option)}
+    onmouseenter={() => (highlightedIndex = index)}
+  >
+    {#if option.color}
+      <span
+        class="tag-picker__swatch"
+        data-tag-swatch
+        style:background-color={option.color}
+        aria-hidden="true"
+      ></span>
+    {:else}
+      <span class="tag-picker__swatch-placeholder" aria-hidden="true"></span>
+    {/if}
+    <span class="tag-picker__option-label">{option.label}</span>
+    {#if option.count !== undefined}
+      <span class="tag-picker__count">{option.count}</span>
+    {/if}
+    <span class="tag-picker__check">
+      {#if option.id === value}
+        <CheckIcon size="12" strokeWidth="2.2" aria-hidden="true" />
+      {/if}
+    </span>
+  </button>
+{/snippet}
+
+<div
+  class={["tag-picker", className]}
+  bind:this={containerEl}
+  onfocusout={onFocusout}
+>
+  <!-- kit-ui-check-ignore: pinned kit dropdowns cannot render each inactive tag's color. -->
+  <button role="combobox"
+    bind:this={buttonEl}
+    class="tag-picker__trigger"
+    type="button"
+    onclick={toggle}
+    onkeydown={onButtonKeydown}
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    aria-controls={listboxID}
+    aria-activedescendant={open ? optionID(highlightedIndex) : undefined}
+    aria-label={`${title}: ${triggerFullName}`}
+    title={tooltip ?? `${title}: ${triggerFullName}`}
+    disabled={trulyDisabled}
+  >
+    {#if selected?.color}
+      <span
+        class="tag-picker__swatch"
+        data-tag-swatch
+        style:background-color={selected.color}
+        aria-hidden="true"
+      ></span>
+    {/if}
+    <span class="tag-picker__value">{triggerText}</span>
+    <ChevronDownIcon
+      class="tag-picker__chevron"
+      size="12"
+      strokeWidth="2"
+      aria-hidden="true"
+    />
+  </button>
+
+  {#if open}
+    <!-- kit-ui-check-ignore: paired with the scoped color-aware combobox above. -->
+    <div role="listbox"
+      id={listboxID}
+      class="tag-picker__list kit-popover-card"
+      style={listStyle}
+      bind:this={listEl}
+    >
+      {#if includeAll && options[0]}
+        {@render optionRow(options[0], 0)}
+      {/if}
+      {#each groups as group}
+        <div
+          class="tag-picker__group"
+          role="group"
+          aria-label={group.name ?? "Ungrouped tags"}
+        >
+          {#if group.name}
+            <div class="tag-picker__group-heading">{group.name}</div>
+          {/if}
+          {#each group.tags as item (item.tag.id)}
+            {@const index = optionIndexes.get(item.tag.id) ?? 0}
+            {@render optionRow(options[index]!, index)}
+          {/each}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .tag-picker {
+    position: relative;
+    min-width: 150px;
+  }
+
+  /* kit-ui-check-ignore: the pinned select cannot render arbitrary tag swatches. */
+  .tag-picker__trigger {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    height: 26px;
+    padding: 0 8px;
+    border: var(--border-width) solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-inset);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold, 600);
+    text-align: left;
+  }
+
+  .tag-picker__trigger:hover:not(:disabled),
+  .tag-picker__trigger[aria-expanded="true"] {
+    border-color: var(--border-default);
+    color: var(--text-primary);
+  }
+
+  .tag-picker__trigger:disabled {
+    cursor: default;
+    opacity: var(--opacity-disabled);
+  }
+
+  .tag-picker__value,
+  .tag-picker__option-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.tag-picker__chevron) {
+    flex-shrink: 0;
+    opacity: 0.55;
+  }
+
+  .tag-picker__list {
+    position: fixed;
+    z-index: var(--z-popover);
+    width: max-content;
+    max-width: min(340px, calc(100vw - 16px));
+    max-height: min(360px, calc(100vh - 16px));
+    overflow-y: auto;
+    padding: 2px;
+  }
+
+  .tag-picker__group + .tag-picker__group {
+    border-top: 1px solid var(--border-muted);
+  }
+
+  .tag-picker__group-heading {
+    padding: 6px 8px 3px;
+    color: var(--text-muted);
+    font-size: var(--font-size-2xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0.05em;
+    overflow-wrap: anywhere;
+    text-transform: uppercase;
+  }
+
+  .tag-picker__option {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    padding: 5px 8px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--font-size-xs);
+    text-align: left;
+  }
+
+  .tag-picker__option.highlighted,
+  .tag-picker__option:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .tag-picker__option.selected {
+    color: var(--accent-blue);
+    font-weight: var(--font-weight-semibold, 600);
+  }
+
+  .tag-picker__swatch,
+  .tag-picker__swatch-placeholder {
+    width: 8px;
+    height: 8px;
+    flex: 0 0 8px;
+    border-radius: var(--radius-dot, 50%);
+  }
+
+  .tag-picker__swatch {
+    box-shadow: 0 0 0 1px color-mix(in srgb, currentColor 18%, transparent);
+  }
+
+  .tag-picker__count {
+    color: var(--text-muted);
+    font-size: var(--font-size-2xs);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .tag-picker__check {
+    display: inline-flex;
+    width: 12px;
+    flex: 0 0 12px;
+    color: currentColor;
+  }
+</style>

--- a/frontend/src/TagPicker.test.ts
+++ b/frontend/src/TagPicker.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import TagPicker from "./TagPicker.svelte";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+});
+
+const tags = [
+  {
+    id: "22222222-2222-4222-8222-222222222222",
+    name: "matter/zeta/hold",
+    revision: 1,
+    assignment_count: 2,
+  },
+  {
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "matter/acme/reviewed",
+    revision: 1,
+    assignment_count: 7,
+  },
+  {
+    id: "33333333-3333-4333-8333-333333333333",
+    name: "important",
+    revision: 1,
+    assignment_count: 4,
+  },
+];
+
+it("shows grouped leaf labels with full accessible names and identity colors", async () => {
+  const onchange = vi.fn();
+  const rendered = render(TagPicker, {
+    value: "",
+    tags,
+    title: "Tag to assign",
+    placeholder: "Choose a tag…",
+    onchange,
+  });
+
+  const trigger = screen.getByRole("combobox", {
+    name: "Tag to assign: Choose a tag…",
+  });
+  await fireEvent.click(trigger);
+
+  expect(screen.getByText("matter/acme")).toBeTruthy();
+  expect(screen.getByText("matter/zeta")).toBeTruthy();
+  const reviewed = screen.getByRole("option", {
+    name: "matter/acme/reviewed (7)",
+  });
+  const hold = screen.getByRole("option", {
+    name: "matter/zeta/hold (2)",
+  });
+  expect(reviewed.textContent).toContain("reviewed");
+  expect(reviewed.textContent).not.toContain("matter/acme/reviewed");
+  expect(reviewed.querySelector<HTMLElement>("[data-tag-swatch]")?.style.backgroundColor).toBe(
+    "rgb(188, 76, 0)",
+  );
+  expect(hold.querySelector<HTMLElement>("[data-tag-swatch]")?.style.backgroundColor).toBe(
+    "rgb(87, 96, 106)",
+  );
+
+  await fireEvent.click(reviewed);
+  expect(onchange).toHaveBeenCalledWith(tags[1]?.id);
+  await rendered.rerender({
+    value: tags[1]!.id,
+    tags,
+    title: "Tag to assign",
+    placeholder: "Choose a tag…",
+    onchange,
+  });
+  expect(trigger.getAttribute("aria-label")).toBe(
+    "Tag to assign: matter/acme/reviewed",
+  );
+  expect(document.activeElement).toBe(trigger);
+});
+
+it("selects by arrows, Home, End, and Enter and restores focus on Escape", async () => {
+  const onchange = vi.fn();
+  render(TagPicker, {
+    value: "",
+    tags,
+    title: "Browse or filter by tag",
+    placeholder: "All tags",
+    includeAll: true,
+    onchange,
+  });
+
+  const trigger = screen.getByRole("combobox", {
+    name: "Browse or filter by tag: All tags",
+  });
+  trigger.focus();
+  await fireEvent.keyDown(trigger, { key: "ArrowDown" });
+  expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  await fireEvent.keyDown(trigger, { key: "End" });
+  expect(trigger.getAttribute("aria-activedescendant")).toBe(
+    screen.getByRole("option", { name: "matter/zeta/hold (2)" }).id,
+  );
+  await fireEvent.keyDown(trigger, { key: "Home" });
+  expect(trigger.getAttribute("aria-activedescendant")).toBe(
+    screen.getByRole("option", { name: "All tags" }).id,
+  );
+  await fireEvent.keyDown(trigger, { key: "ArrowUp" });
+  await fireEvent.keyDown(trigger, { key: "Enter" });
+  expect(onchange).toHaveBeenCalledWith(tags[0]?.id);
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+  await fireEvent.keyDown(trigger, { key: "ArrowDown" });
+  await fireEvent.keyDown(document, { key: "Escape" });
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  expect(document.activeElement).toBe(trigger);
+
+  await fireEvent.keyDown(trigger, { key: "ArrowDown" });
+  await fireEvent.mouseDown(document.body);
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+});
+
+it("closes on Tab without preventing the browser focus move", async () => {
+  render(TagPicker, {
+    value: "",
+    tags,
+    title: "Tag to assign",
+    placeholder: "Choose a tag…",
+    onchange: vi.fn(),
+  });
+  const trigger = screen.getByRole("combobox", {
+    name: "Tag to assign: Choose a tag…",
+  });
+  await fireEvent.keyDown(trigger, { key: "ArrowDown" });
+  const notCanceled = await fireEvent.keyDown(trigger, { key: "Tab" });
+
+  expect(notCanceled).toBe(true);
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+});
+
+it("does not open or select while disabled", async () => {
+  const onchange = vi.fn();
+  render(TagPicker, {
+    value: "",
+    tags,
+    title: "Tag to assign",
+    placeholder: "Choose a tag…",
+    disabled: true,
+    onchange,
+  });
+  const trigger = screen.getByRole("combobox", {
+    name: "Tag to assign: Choose a tag…",
+  });
+
+  expect(trigger.hasAttribute("disabled")).toBe(true);
+  await fireEvent.click(trigger);
+  await fireEvent.keyDown(trigger, { key: "ArrowDown" });
+  expect(screen.queryByRole("listbox")).toBeNull();
+  expect(onchange).not.toHaveBeenCalled();
+});

--- a/frontend/src/tagPresentation.test.ts
+++ b/frontend/src/tagPresentation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupTags,
+  splitTagName,
+  tagColor,
+  type PresentedTag,
+} from "./tagPresentation.js";
+import type { Tag } from "./api.js";
+
+const tag = (id: string, name: string): Tag => ({
+  id,
+  name,
+  revision: 1,
+  assignment_count: 0,
+});
+
+describe("tagColor", () => {
+  it("derives a stable hex color from tag identity instead of its name", () => {
+    const first = tag("11111111-1111-4111-8111-111111111111", "reviewed");
+    const renamed = { ...first, name: "matter/acme/reviewed" };
+    const differentIdentity = tag(
+      "22222222-2222-4222-8222-222222222222",
+      "reviewed",
+    );
+
+    expect(tagColor(first)).toBe("#bc4c00");
+    expect(tagColor(renamed)).toBe("#bc4c00");
+    expect(tagColor(differentIdentity)).toBe("#57606a");
+  });
+
+  it("returns a ColorLabel-compatible neutral hex for a missing identity", () => {
+    expect(tagColor({ id: "" })).toBe("#6e7781");
+  });
+});
+
+describe("splitTagName", () => {
+  it.each([
+    ["reviewed", null, "reviewed"],
+    ["matter/reviewed", "matter", "reviewed"],
+    ["matter/acme/reviewed", "matter/acme", "reviewed"],
+    ["/reviewed", null, "/reviewed"],
+    ["matter/", null, "matter/"],
+    ["matter//reviewed", null, "matter//reviewed"],
+  ])("splits %s without discarding malformed full names", (name, group, label) => {
+    expect(splitTagName(name)).toEqual({ group, label });
+  });
+});
+
+describe("groupTags", () => {
+  it("sorts ungrouped tags and complete-prefix groups without mutating input", () => {
+    const input = [
+      tag("5", "matter/zeta/hold"),
+      tag("4", "zulu"),
+      tag("3", "matter/acme/reviewed"),
+      tag("2", "alpha"),
+      tag("1", "matter/acme/important"),
+    ];
+    const original = [...input];
+
+    const groups = groupTags(input);
+
+    expect(input).toEqual(original);
+    expect(
+      groups.map((group) => ({
+        name: group.name,
+        tags: group.tags.map((item: PresentedTag) => item.tag.name),
+      })),
+    ).toEqual([
+      { name: null, tags: ["alpha", "zulu"] },
+      {
+        name: "matter/acme",
+        tags: ["matter/acme/important", "matter/acme/reviewed"],
+      },
+      { name: "matter/zeta", tags: ["matter/zeta/hold"] },
+    ]);
+  });
+});

--- a/frontend/src/tagPresentation.ts
+++ b/frontend/src/tagPresentation.ts
@@ -1,0 +1,90 @@
+import type { Tag } from "./api.js";
+import { hashColor } from "@kenn-io/kit-ui";
+
+const NEUTRAL_TAG_COLOR = "#6e7781";
+
+// ColorLabel accepts hex colors only. Keep this palette explicit so the same
+// tag identity renders consistently in every theme and component.
+const TAG_COLOR_PALETTE = [
+  "#0969da",
+  "#bf8700",
+  "#1a7f37",
+  "#cf222e",
+  "#8250df",
+  "#1b7c83",
+  "#bf3989",
+  "#4f46e5",
+  "#bc4c00",
+  "#0576b9",
+  "#9a6700",
+  "#57606a",
+  "#d1242f",
+] as const;
+
+export interface PresentedTag {
+  tag: Tag;
+  group: string | null;
+  label: string;
+  color: string;
+}
+
+export interface TagGroup {
+  name: string | null;
+  tags: PresentedTag[];
+}
+
+export function tagColor(tag: Pick<Tag, "id">): string {
+  return tag.id ? hashColor(tag.id, TAG_COLOR_PALETTE) : NEUTRAL_TAG_COLOR;
+}
+
+export function splitTagName(name: string): Pick<PresentedTag, "group" | "label"> {
+  const segments = name.split("/");
+  if (segments.length < 2 || segments.some((segment) => segment === "")) {
+    return { group: null, label: name };
+  }
+  return {
+    group: segments.slice(0, -1).join("/"),
+    label: segments.at(-1) ?? name,
+  };
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function comparePresentedTags(left: PresentedTag, right: PresentedTag): number {
+  return (
+    compareText(left.label, right.label) ||
+    compareText(left.tag.name, right.tag.name) ||
+    compareText(left.tag.id, right.tag.id)
+  );
+}
+
+export function presentTag(tag: Tag): PresentedTag {
+  return { tag, ...splitTagName(tag.name), color: tagColor(tag) };
+}
+
+export function groupTags(tags: readonly Tag[]): TagGroup[] {
+  const grouped = new Map<string | null, PresentedTag[]>();
+  for (const tag of tags) {
+    const presented = presentTag(tag);
+    const current = grouped.get(presented.group) ?? [];
+    current.push(presented);
+    grouped.set(presented.group, current);
+  }
+
+  return [...grouped.entries()]
+    .sort(([left], [right]) => {
+      if (left === null) return right === null ? 0 : -1;
+      if (right === null) return 1;
+      return compareText(left, right);
+    })
+    .map(([name, items]) => ({
+      name,
+      tags: [...items].sort(comparePresentedTags),
+    }));
+}
+
+export function sortTags(tags: readonly Tag[]): Tag[] {
+  return groupTags(tags).flatMap((group) => group.tags.map((item) => item.tag));
+}


### PR DESCRIPTION
## What changed

- Tags use the same ID-derived color in the catalog, filters, and assigned tags. Renaming a tag keeps its color.
- Slash-separated names appear under their shared prefix. For example, `matter/acme/reviewed` appears as `reviewed` under `matter/acme`; its full name remains available to assistive technology and in the tooltip.
- The tag picker supports grouped options, keyboard navigation, and a swatch for each tag. The Add tag spinner clears after assignment succeeds.
- The tag dialogs keep their controls and remove redundant headings and explanatory copy.

## Why

A flat catalog makes related tags harder to find. Consistent colors and visible groups make the same tag easier to recognize while browsing and assigning documents.

## Usage

Use slash-separated names to organize tags, or keep existing names. Colors and groups appear automatically; there is no new tag metadata to manage.

Closes #298

![Grouped tag catalog](https://raw.githubusercontent.com/salmonumbrella/docbank/746b6ef6e9a301409680ce76b1c365af3c4eac8a/screenshots/db01-tag-colors/web-tag-catalog.png)

![Tag filter with consistent colors](https://raw.githubusercontent.com/salmonumbrella/docbank/746b6ef6e9a301409680ce76b1c365af3c4eac8a/screenshots/db01-tag-colors/web-tag-filter.png)

![Assigned tags grouped by name](https://raw.githubusercontent.com/salmonumbrella/docbank/746b6ef6e9a301409680ce76b1c365af3c4eac8a/screenshots/db01-tag-colors/web-tag-assignment.png)
