### PR TITLE
feat: browse and label document import collections

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -193,7 +193,7 @@ func TestAddReplaceVersionsExactDestination(t *testing.T) {
 	after, err := c.Stat(t.Context(), "/inbox/notes.txt")
 	require.NoError(t, err)
 	assert.Equal(t, before.ID, after.ID)
-	assert.Equal(t, before.Revision+1, after.Revision)
+	assert.Equal(t, before.Revision+2, after.Revision)
 	_, err = c.Stat(t.Context(), "/inbox/notes (2).txt")
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -1,7 +1,7 @@
 ---
-last_edited: 2026-09-09
 title: HTTP API
 description: The agent-first HTTP API — filesystem-shaped endpoints, revision preconditions, and the daemon's error contract.
+last_edited: 2026-09-10
 ---
 
 # HTTP API
@@ -54,6 +54,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET /search?q=&tag_id=&mime_type=&under_node_id=&modified_since=&modified_before=&limit=` | bounded name and extracted-content search (FTS5), optionally restricted by stable tag identity, current base media type, descendants of a live directory, and current node modification time, with match source and explicit `truncated` status | Implemented |
 | `POST /nodes` · `POST /path/mkdir` | create a directory beneath a stable parent ID or at one exact virtual coordinate | Implemented |
 | `POST /ingest` · `POST /ingest/stream` · `POST /ingest/preflight` | import with JSON or streamed progress / inventory server-side paths — see [addendum](#addendum-post-ingest-post-ingeststream-and-post-ingestpreflight) | Implemented |
+| `GET /collections` · `GET /collections/{id}` · `GET /collections/{id}/members` · `GET\|PUT /collections/{id}/label` | browse live ingest-run membership and inspect, set, or clear its revision-fenced label | Implemented |
 | `POST /uploads?parent_id=&name=` | stream one digest-checked remote file — see [addendum](#addendum-post-uploads) | Implemented |
 | `PATCH /nodes/{id}` | move and/or rename, including resolving an absolute `dest_path` transactionally | Implemented |
 | `POST /path/move` · `POST /path/trash` | move / trash by virtual path, resolved and mutated in one store transaction | Implemented |
@@ -438,8 +439,10 @@ in a pattern is rejected. Entries filtered by a rule are excluded without
 failure, while selected non-regular entries are reported as skipped findings.
 
 `POST /ingest` takes **server-side local paths** — `{paths: [...],
-dest: "/inbox", include: [...], exclude: [...], replace: false}` — and returns an `IngestReport` (`added`, `skipped`, `excluded`,
-per-path `failed` entries), backing `docbank add`. Paths must be
+dest: "/inbox", include: [...], exclude: [...], replace: false,
+collection_label: "Review set"}` — and returns an `IngestReport` (`ingest_id`,
+`added`, `skipped`, `excluded`, per-path `failed` entries), backing `docbank
+add`. `collection_label` is optional. Paths must be
 **absolute**: the long-lived daemon's working directory is meaningless,
 so a relative path is rejected with `422`. The CLI resolves `docbank
 add`'s arguments to absolute paths before calling, so the command-line
@@ -462,6 +465,26 @@ request context used by traversal, blob writing, and metadata transactions.
 Already completed files remain valid and converge on retry, while an
 incomplete blob never receives node authority.
 
+One request is one logical ingest run. Its `ingest_id` appears only after at
+least one document observation commits. A partial import therefore returns the
+run that owns its successful files alongside the individual failures. A scan,
+an excluded-only request, or an all-failed request returns no `ingest_id` and
+creates no collection or label authority. An initial label collision, or an
+initial label attempted after permanent audit enrollment, is reported through
+the same per-file failure protocol; other files in the request still follow
+the established partial-import behavior.
+
+Repeating a logical filesystem import creates a new run and records the
+existing same-content node as a member without creating a content version.
+That new provenance advances the node revision, even when `collection_label`
+and `replace` are omitted or `replace: true` finds identical bytes. A client
+holding the previous ETag must read the node again before writing; the old
+`If-Match` returns `412 stale_revision`. Within one run, the same observation
+is idempotent. The separate unkeyed
+`POST /uploads` retry contract is unchanged: an equal retry returns the
+existing node without changing its revision and does not expose an unused run
+identifier.
+
 Because they grant "read any daemon-readable local path," `POST /ingest` and
 `POST /ingest/stream` are checked per-request against `RemoteAddr` and
 **restricted to loopback callers** regardless of bind address or API key — a
@@ -482,6 +505,71 @@ invalid syntax and parent traversal are rejected before filesystem access. Use
 bracket expressions such as `report[[]1].txt` for literal metacharacters instead
 of backslash escaping.
 Watched-inbox exclusions are a separate literal contract.
+
+## Addendum: ingest-run collections
+
+A collection is an immutable ingest-run identity with live document
+membership. It is not a folder: moving or renaming a member leaves its run
+identity intact. Membership excludes caller-supplied `embedded:` provenance,
+superseded provenance, directories, and trashed files. Counts and byte totals
+deduplicate nodes within a run and describe each member's current version;
+they are browsing observations rather than an export snapshot.
+
+Lists default to 100 results and accept `limit=1..1000` and a nonnegative
+`offset`. They are ordered by `started_at` descending, then ingest ID. Member
+pages use the same bounds and return current `Node` representations with live
+paths. The list hides empty runs. A directly addressed run remains readable
+when it has retained label authority, even after its final member is trashed or
+purged.
+
+```console
+$ curl -sS -H "X-Api-Key: $DOCBANK_API_KEY" \
+    'http://127.0.0.1:43210/api/v1/collections?limit=100&offset=0'
+{"items":[{"id":"5ca58787-4608-4f69-8e67-8d5794970f77","source_kind":"cli","source_description":"/srv/import/review","started_at":"2026-09-10T09:30:00Z","file_count":2,"total_bytes":31,"label":"Review set","label_revision":1,"label_updated_at":"2026-09-10T09:30:00Z"}],"total":1,"limit":100,"offset":0}
+
+$ curl -sS -H "X-Api-Key: $DOCBANK_API_KEY" \
+    'http://127.0.0.1:43210/api/v1/collections/5ca58787-4608-4f69-8e67-8d5794970f77/members?limit=100&offset=0'
+```
+
+Labels have their own resource and revision. Read that resource for its ETag,
+then send the quoted positive revision in `If-Match`. The PUT body contains
+exactly one required `label` member. A string sets the label; explicit `null`
+clears it. Unknown fields and server-owned fields such as `revision` are
+rejected.
+
+```console
+$ curl -i -H "X-Api-Key: $DOCBANK_API_KEY" \
+    http://127.0.0.1:43210/api/v1/collections/5ca58787-4608-4f69-8e67-8d5794970f77/label
+HTTP/1.1 200 OK
+ETag: "1"
+
+{"ingest_id":"5ca58787-4608-4f69-8e67-8d5794970f77","label":"Review set","revision":1,"updated_at":"2026-09-10T09:30:00Z"}
+
+$ curl -sS -X PUT -H "X-Api-Key: $DOCBANK_API_KEY" \
+    -H 'Content-Type: application/json' -H 'If-Match: "1"' \
+    -d '{"label":"Filed set"}' \
+    http://127.0.0.1:43210/api/v1/collections/5ca58787-4608-4f69-8e67-8d5794970f77/label
+
+$ curl -sS -X PUT -H "X-Api-Key: $DOCBANK_API_KEY" \
+    -H 'Content-Type: application/json' -H 'If-Match: "2"' \
+    -d '{"label":null}' \
+    http://127.0.0.1:43210/api/v1/collections/5ca58787-4608-4f69-8e67-8d5794970f77/label
+```
+
+Labels are case-sensitive NFC strings of 1–256 UTF-8 bytes, with no control
+characters and at least one non-whitespace character. Intentional surrounding
+spaces are preserved. Non-null labels are unique across all retained label
+records, including empty collections, so trash and restore cannot transfer a
+name between runs. Clearing retains the revision fence. A stale fence returns
+`412 stale_revision`; a collision returns `409 exists`; an invalid name returns
+`422 invalid_collection_label`.
+
+Permanent audit authority currently records ingest and membership changes but
+has no event for label mutation. Once audit is enabled, label PUTs therefore
+fail closed with `409 audit_mutation_unsupported`, including clears and no-op
+requests. Existing labels remain readable and portable. Backup readers that
+predate collection labels or the `ingest_observe` audit kind reject that added
+authority explicitly instead of silently dropping it.
 
 ## Addendum: `POST /uploads`
 
@@ -714,6 +802,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `audit_not_enrolled` | 422 | the selected node exists but is outside every permanent audit scope |
 | `invalid_audit_cursor` | 422 | the history cursor is malformed or belongs to another stable node or scope |
 | `invalid_batch_move` | 422 | a batch has no moves, too many moves, ambiguous selectors, or an invalid final-state plan |
+| `invalid_collection_label` | 422 | a collection label violates the canonical UTF-8, NFC, length, control-character, or non-whitespace policy |
 | `stale_revision` | 412 | `store.ErrStaleRevision` — `If-Match` didn't match the current revision |
 | `provenance_mismatch` | 409 | the requested predecessor is missing, belongs to another node, is already superseded, or is an operational ingest fact |
 | `invalid_provenance_time` | 422 | optional `original_mtime` parses as RFC3339 but is not canonical UTC RFC3339Nano (a value that is not a date-time at all fails schema validation as `validation` instead) |

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -1,6 +1,7 @@
 ---
 title: Importing Documents
 description: Import folders, preview large sources, retry partial imports, and keep changing files up to date.
+last_edited: 2026-09-10
 ---
 
 # Importing Documents
@@ -109,6 +110,49 @@ When the source argument is one explicit file, a basename rule such as `*.pdf`
 matches it; a path-form rule such as `reports/*.pdf` applies to a directory
 source's relative paths.
 
+## Label and browse one import run
+
+The HTTP ingest body can attach an optional label to the logical run. The
+label publishes atomically with the first committed document observation:
+
+```bash
+curl -sS -X POST -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"paths":["/srv/import/review"],"dest":"/archive","collection_label":"Review set"}' \
+  http://127.0.0.1:43210/api/v1/ingest
+```
+
+For streamed progress, send the same field to the streaming route:
+
+```bash
+curl -sS -N -X POST -H "X-Api-Key: $DOCBANK_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"paths":["/srv/import/receipts"],"dest":"/archive","collection_label":"Receipt batch"}' \
+  http://127.0.0.1:43210/api/v1/ingest/stream
+```
+
+The terminal report includes `ingest_id` when at least one file committed. Use
+that ID with `GET /api/v1/collections/{id}` and
+`GET /api/v1/collections/{id}/members`; list current nonempty runs with
+`GET /api/v1/collections`. Collection membership follows the documents as they
+move within the vault and reports current paths, sizes, and versions. Trashed
+files and superseded provenance disappear from live membership. Caller-supplied
+`embedded:` provenance never creates a collection.
+
+The label has a separate ETag and edit route. Read
+`GET /api/v1/collections/{id}/label`, then PUT exactly `{"label":"New name"}`
+or `{"label":null}` to the same path with its quoted revision in `If-Match`.
+Non-null labels stay unique even while a collection is empty. After permanent
+audit is enabled, label changes fail with HTTP 409 and
+`audit_mutation_unsupported`; the existing label and collection remain
+readable.
+
+If only some files succeed, the receipt names the real run and lists failures
+beside it. If nothing commits, the receipt omits `ingest_id` and no collection
+or label is created. Label collisions and audit restrictions on an initial
+label use this same per-file failure list instead of turning the whole batch
+into one transport error.
+
 ## Follow a long import
 
 Human-mode `docbank add` performs a metadata-only scan to establish file and
@@ -148,6 +192,17 @@ Repeating the same source import does not create extra copies of its entries.
 Two differently named source files with identical bytes still import as two
 file entries. They share stored content but have distinct version UUIDs.
 
+Each explicit filesystem re-run is still a new logical ingest run. When bytes
+already match a destination node, Docbank adds that existing node to the new
+run without creating a content version. Recording this new membership advances
+the node revision, even without a collection label or any flags. This also
+applies to `--replace` when the bytes are identical. API clients holding the
+old ETag must refresh it before their next write; otherwise `If-Match` returns
+`412 stale_revision`. Repeating the same observation within one run is a no-op.
+
+Digest-checked `POST /uploads` retries keep their existing behavior: an equal retry returns the existing node with an unchanged revision
+and does not return an unused ingest identity.
+
 ## Collisions
 
 Two different files arriving at the same virtual name don't conflict —
@@ -164,11 +219,12 @@ docbank add ~/reports/summary.pdf --dest /archive --replace
 
 Docbank resolves the exact destination name and records its node revision
 before reading the source. Different bytes become a new content version on the
-same node, while unchanged bytes skip without changing the revision, stored
-MIME type, provenance, or version count. A live directory fails that file
-before source content is opened. If an absent destination is claimed while
-the source is read, the exact create reports a conflict and never chooses a
-suffix. A stale observed revision reports a conflict and leaves the newer
+same node. Unchanged bytes count as skipped and keep the stored MIME type and
+version history, while the new run membership advances the node revision as
+[described above](#what-happens-when-i-run-the-import-again). A live directory
+fails that file before source content is opened. If an absent destination is
+claimed while the source is read, the exact create reports a conflict and never
+chooses a suffix. A stale observed revision reports a conflict and leaves the newer
 content current. Omit `--replace` for ordinary collision suffixing.
 
 ## Inspect where a document came from
@@ -233,6 +289,11 @@ computes both independently while streaming, and creates no node or blob
 authority when either differs. See the [HTTP API](../architecture/http-api.md#addendum-post-uploads)
 and [Agent Integration Guide](../agents/integration.md#create-and-ingest-safely)
 for the exact contract.
+
+Backups include collection labels, their revision fences, run membership, and
+the audit history for repeated operational observations. Older readers that do
+not understand this added authority reject such a snapshot explicitly instead
+of restoring it without the collection records.
 
 ## Continuously ingest a local inbox
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -73,6 +73,7 @@ var storeErrCodes = []struct {
 	{store.ErrInvalidName, http.StatusUnprocessableEntity, "invalid_name"},
 	{store.ErrInvalidTag, http.StatusUnprocessableEntity, "invalid_tag"},
 	{store.ErrInvalidSavedQuery, http.StatusUnprocessableEntity, "invalid_saved_query"},
+	{store.ErrInvalidCollectionLabel, http.StatusUnprocessableEntity, "invalid_collection_label"},
 	{store.ErrInvalidBatchMove, http.StatusUnprocessableEntity, "invalid_batch_move"},
 	{store.ErrNotTrashed, http.StatusUnprocessableEntity, "not_trashed"},
 	{store.ErrIsRoot, http.StatusUnprocessableEntity, "is_root"},

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -19,6 +19,7 @@ func TestOpenAPIDocumentOffline(t *testing.T) {
 	for _, op := range []string{"getNode", "resolvePath", "listChildren", "getNodeContent", "verifyNodeContent",
 		"listContentVersions", "getContentVersion", "getContentVersionBytes", "pruneNodeContentVersions",
 		"lookupContentReferences",
+		"listCollections", "getCollection", "listCollectionMembers", "getCollectionLabel", "setCollectionLabel",
 		"listTags", "resolveTagByName", "getTag", "listTagNodes", "listNodeTags",
 		"createTag", "renameTag", "deleteTag", "assignTag", "unassignTag",
 		"assignTagPath", "unassignTagPath",
@@ -300,6 +301,7 @@ func TestOpenAPIDeclaresMutationPreconditions(t *testing.T) {
 	require.NotNil(t, keepNewest.Minimum)
 	assert.InDelta(t, 1, *keepNewest.Minimum, 0)
 	for _, operation := range []*huma.Operation{
+		doc.Paths["/api/v1/collections/{id}/label"].Put,
 		doc.Paths["/api/v1/nodes/{id}"].Patch,
 		doc.Paths["/api/v1/nodes/{id}/trash"].Post,
 		doc.Paths["/api/v1/nodes/{id}/restore"].Post,
@@ -322,6 +324,55 @@ func TestOpenAPIDeclaresMutationPreconditions(t *testing.T) {
 	create := doc.Paths["/api/v1/tags"].Post
 	require.NotNil(t, create)
 	assert.NotNil(t, create.Responses["201"])
+}
+
+func TestOpenAPICollectionContractIsBoundedAndLabelSpecific(t *testing.T) {
+	doc := api.NewOfflineServer().API().OpenAPI()
+	list := doc.Paths["/api/v1/collections"].Get
+	members := doc.Paths["/api/v1/collections/{id}/members"].Get
+	for _, operation := range []*huma.Operation{list, members} {
+		require.NotNil(t, operation)
+		parameters := map[string]*huma.Schema{}
+		for _, parameter := range operation.Parameters {
+			parameters[parameter.Name] = parameter.Schema
+		}
+		require.NotNil(t, parameters["limit"])
+		require.NotNil(t, parameters["limit"].Minimum)
+		require.NotNil(t, parameters["limit"].Maximum)
+		assert.InDelta(t, 1, *parameters["limit"].Minimum, 0)
+		assert.InDelta(t, 1000, *parameters["limit"].Maximum, 0)
+		require.NotNil(t, parameters["offset"])
+		require.NotNil(t, parameters["offset"].Minimum)
+		assert.InDelta(t, 0, *parameters["offset"].Minimum, 0)
+	}
+
+	schemas := doc.Components.Schemas.Map()
+	collection := schemas["Collection"]
+	require.NotNil(t, collection)
+	for _, field := range []string{
+		"id", "source_kind", "source_description", "started_at", "file_count",
+		"total_bytes", "label", "label_revision", "label_updated_at",
+	} {
+		assert.Contains(t, collection.Properties, field)
+	}
+	assert.NotContains(t, collection.Properties, "quality")
+	assert.NotContains(t, collection.Properties, "coverage")
+
+	request := schemas["SetCollectionLabelRequest"]
+	require.NotNil(t, request)
+	assert.Equal(t, []string{"label"}, request.Required)
+	assert.Len(t, request.Properties, 2, "only label plus Huma's read-only $schema member")
+	assert.NotContains(t, request.Properties, "revision")
+	assert.NotContains(t, request.Properties, "ingest_id")
+	assert.NotContains(t, request.Properties, "updated_at")
+	label := request.Properties["label"]
+	require.NotNil(t, label)
+	assert.True(t, label.Nullable)
+
+	operation := doc.Paths["/api/v1/collections/{id}/label"].Put
+	require.NotNil(t, operation)
+	require.NotNil(t, operation.Responses["200"])
+	assert.Contains(t, operation.Responses["200"].Headers, "ETag")
 }
 
 func TestOpenAPIProvenanceMTimeUsesDateTimeFormat(t *testing.T) {

--- a/internal/api/routes_audit_test.go
+++ b/internal/api/routes_audit_test.go
@@ -135,6 +135,24 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	require.NotNil(t, provenanceEvent.Attachment.After)
 	assert.Equal(t, "/source/taxes/receipt.txt",
 		*provenanceEvent.Attachment.After.OriginalPath)
+	secondRun, err := s.BeginIngest(t.Context(), "cli", "/source/taxes-second")
+	require.NoError(t, err)
+	observed, added, err := s.IngestFileWithMembership(
+		t.Context(), secondRun, taxes.ID, "receipt.txt", testHash("audit provenance"), 7,
+		"text/plain", "/source/taxes-second/receipt.txt", "2026-07-19T12:00:00Z",
+	)
+	require.NoError(t, err)
+	assert.False(t, added)
+	assert.Equal(t, ingested.ID, observed.ID)
+	observationHistory, err := c.AuditHistory(t.Context(), "", ingested.ID, 10, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, observationHistory.Items)
+	observationEvent := observationHistory.Items[0]
+	assert.Equal(t, "ingest_observe", observationEvent.Kind)
+	require.NotNil(t, observationEvent.Attachment)
+	require.NotNil(t, observationEvent.Attachment.After)
+	assert.Equal(t, ingested.ID, observationEvent.Attachment.After.NodeID)
+	assert.Equal(t, observed.CurrentVersionID, *observationEvent.ResultingCurrentVersionID)
 
 	scopeHistory, err := c.AuditScopeHistory(t.Context(), preview.ScopeID, 2, "")
 	require.NoError(t, err)
@@ -144,6 +162,7 @@ func TestAuditPreviewEnableAndStatusLifecycle(t *testing.T) {
 	assert.Greater(t, scopeHistory.Total, 2)
 	require.Len(t, scopeHistory.Items, 2)
 	require.NotEmpty(t, scopeHistory.NextCursor)
+	assert.Equal(t, "ingest_observe", scopeHistory.Items[0].Kind)
 	for _, event := range scopeHistory.Items {
 		assert.Equal(t, preview.ScopeID, event.ScopeID)
 	}

--- a/internal/api/routes_collections.go
+++ b/internal/api/routes_collections.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/docbank/internal/store"
+)
+
+type collectionOutput struct{ Body Collection }
+type collectionPageOutput struct{ Body CollectionPage }
+type collectionMemberPageOutput struct{ Body CollectionMemberPage }
+type collectionLabelOutput struct {
+	ETag string `header:"ETag"`
+	Body CollectionLabel
+}
+
+func registerCollectionRoutes(api huma.API, d Deps, g *gate) {
+	huma.Register(api, huma.Operation{
+		OperationID: "listCollections", Method: http.MethodGet, Path: "/api/v1/collections",
+		Summary:     "List document-bearing ingest runs, newest first",
+		Description: "Counts and bytes describe current live members. Empty runs remain directly accessible only when they retain label authority.",
+	}, func(ctx context.Context, in *struct {
+		Limit  int `query:"limit" default:"100" minimum:"1" maximum:"1000"`
+		Offset int `query:"offset" default:"0" minimum:"0"`
+	}) (*collectionPageOutput, error) {
+		collections, total, err := d.Store.Collections(ctx, in.Limit, in.Offset)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		out := &collectionPageOutput{Body: CollectionPage{
+			Items: []Collection{}, Total: total, Limit: in.Limit, Offset: in.Offset,
+		}}
+		for _, collection := range collections {
+			out.Body.Items = append(out.Body.Items, fromStoreCollection(collection))
+		}
+		return out, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getCollection", Method: http.MethodGet, Path: "/api/v1/collections/{id}",
+		Summary: "Inspect one ingest run and its current live summary",
+	}, func(ctx context.Context, in *struct {
+		ID string `path:"id"`
+	}) (*collectionOutput, error) {
+		collection, err := d.Store.CollectionByID(ctx, in.ID)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return &collectionOutput{Body: fromStoreCollection(collection)}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "listCollectionMembers", Method: http.MethodGet,
+		Path:    "/api/v1/collections/{id}/members",
+		Summary: "List a collection's current live file members",
+	}, func(ctx context.Context, in *struct {
+		ID     string `path:"id"`
+		Limit  int    `query:"limit" default:"100" minimum:"1" maximum:"1000"`
+		Offset int    `query:"offset" default:"0" minimum:"0"`
+	}) (*collectionMemberPageOutput, error) {
+		page, err := d.Store.CollectionMembers(ctx, in.ID, in.Limit, in.Offset)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		out := &collectionMemberPageOutput{Body: CollectionMemberPage{
+			Collection: fromStoreCollection(page.Collection), Items: []Node{},
+			Total: page.Total, Limit: in.Limit, Offset: in.Offset,
+		}}
+		for _, member := range page.Items {
+			node := fromStoreNode(member.Node)
+			node.Path = member.Path
+			out.Body.Items = append(out.Body.Items, node)
+		}
+		return out, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getCollectionLabel", Method: http.MethodGet,
+		Path:    "/api/v1/collections/{id}/label",
+		Summary: "Read a collection's independently revisioned label",
+	}, func(ctx context.Context, in *struct {
+		ID string `path:"id"`
+	}) (*collectionLabelOutput, error) {
+		label, err := d.Store.CollectionLabel(ctx, in.ID)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return collectionLabelResponse(label), nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "setCollectionLabel", Method: http.MethodPut,
+		Path:        "/api/v1/collections/{id}/label",
+		Summary:     "Set or clear a collection label under its label revision",
+		Description: "Requires If-Match from the dedicated label resource. Label changes are unavailable after permanent audit authority is enabled.",
+	}, func(ctx context.Context, in *struct {
+		ID      string `path:"id"`
+		IfMatch string `header:"If-Match"`
+		Body    struct {
+			Label *string `json:"label" required:"true"`
+		}
+	}) (*collectionLabelOutput, error) {
+		revision, err := parseIfMatch(in.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+		var out *collectionLabelOutput
+		err = g.mutate(func() error {
+			label, setErr := d.Store.SetCollectionLabel(ctx, in.ID, revision, in.Body.Label)
+			if setErr != nil {
+				return FromStoreError(setErr)
+			}
+			out = collectionLabelResponse(label)
+			return nil
+		})
+		return out, err
+	})
+}
+
+func collectionLabelResponse(label store.CollectionLabel) *collectionLabelOutput {
+	return &collectionLabelOutput{
+		ETag: collectionLabelETag(label.Revision), Body: fromStoreCollectionLabel(label),
+	}
+}
+
+func collectionLabelETag(revision int64) string {
+	return fmt.Sprintf("%q", strconv.FormatInt(revision, 10))
+}

--- a/internal/api/routes_collections_backup_test.go
+++ b/internal/api/routes_collections_backup_test.go
@@ -1,0 +1,178 @@
+package api_test
+
+import (
+	"encoding/json/v2"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/blob"
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/config"
+	"go.kenn.io/docbank/internal/store"
+	docsqlite "go.kenn.io/docbank/sqlite"
+	"go.kenn.io/docbank/sqlite/modernc"
+)
+
+func collectionBackupDrivers() []docsqlite.Driver {
+	drivers := []docsqlite.Driver{store.DefaultSQLiteDriver(), modernc.Driver{}}
+	seen := make(map[string]bool)
+	unique := make([]docsqlite.Driver, 0, len(drivers))
+	for _, driver := range drivers {
+		if !seen[driver.Name()] {
+			seen[driver.Name()] = true
+			unique = append(unique, driver)
+		}
+	}
+	return unique
+}
+
+func newCollectionBackupServer(
+	t *testing.T, driver docsqlite.Driver, repoPath string,
+) (*httptest.Server, *testStore) {
+	t.Helper()
+	vaultRoot := t.TempDir()
+	dbPath := filepath.Join(vaultRoot, "docbank.db")
+	s, err := store.Open(dbPath, driver)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	blobsDir := filepath.Join(vaultRoot, "blobs")
+	require.NoError(t, os.MkdirAll(filepath.Join(blobsDir, "tmp"), 0o700))
+	blobs, err := blob.New(store.NewPackCatalog(s), blobsDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, blobs.Close()) })
+	cfg := config.Default()
+	cfg.Server.APIKey = testAPIKey
+	cfg.Backup.Repo = repoPath
+	server := api.NewServer(api.Deps{
+		Store: s, Blobs: blobs, VaultRoot: vaultRoot, Cfg: cfg,
+		Logger: slog.New(slog.DiscardHandler), WebURL: testWebURL,
+	})
+	t.Cleanup(server.Close)
+	ts := httptest.NewServer(server.Handler())
+	t.Cleanup(ts.Close)
+	ts.Client().Transport = &apiKeyTransport{key: testAPIKey, next: ts.Client().Transport}
+	return ts, &testStore{
+		Store: s, Blobs: blobs, BlobsDir: blobsDir, DBPath: dbPath, Server: server,
+	}
+}
+
+func TestCollectionAuthoritySurvivesPhysicalBackupRestore(t *testing.T) {
+	for _, driver := range collectionBackupDrivers() {
+		t.Run(driver.Name(), func(t *testing.T) {
+			repoPath := filepath.Join(t.TempDir(), "repo")
+			ts, live := newCollectionBackupServer(t, driver, repoPath)
+			label := "Audit archive"
+			source := filepath.Join(t.TempDir(), "record.txt")
+			content := []byte("synthetic archived collection bytes")
+			require.NoError(t, os.WriteFile(source, content, 0o600))
+
+			resp, body := do(t, ts, http.MethodPost, "/api/v1/ingest", nil, map[string]any{
+				"paths": []string{source}, "dest": "/inbox", "collection_label": label,
+			})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			var first api.IngestReport
+			require.NoError(t, json.Unmarshal([]byte(body), &first))
+			require.NotEmpty(t, first.IngestID)
+			firstLabel, err := live.CollectionLabel(t.Context(), first.IngestID)
+			require.NoError(t, err)
+			require.NotNil(t, firstLabel.Label)
+
+			c := client.New(ts.URL, testAPIKey)
+			preview, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{
+				NodeID: live.RootID(), AgentLabel: "physical-backup-test",
+			})
+			require.NoError(t, err)
+			_, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
+			require.NoError(t, err)
+
+			resp, body = do(t, ts, http.MethodPost, "/api/v1/ingest", nil, map[string]any{
+				"paths": []string{source}, "dest": "/inbox",
+			})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			var second api.IngestReport
+			require.NoError(t, json.Unmarshal([]byte(body), &second))
+			require.NotEmpty(t, second.IngestID)
+			assert.NotEqual(t, first.IngestID, second.IngestID)
+			assert.Zero(t, second.Added)
+			assert.Equal(t, 1, second.Skipped)
+
+			resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/init", nil, map[string]any{})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/snapshots", nil,
+				map[string]any{"tag": "collection-authority", "jobs": 1})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			var snapshot api.BackupSnapshot
+			require.NoError(t, json.Unmarshal([]byte(body), &snapshot))
+
+			target := filepath.Join(t.TempDir(), "restored")
+			resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/restore/stream", nil,
+				map[string]any{"target": target, "snapshot_id": snapshot.ID, "jobs": 1})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			events := decodeBackupRestoreEvents(t, body)
+			require.NotEmpty(t, events)
+			terminal := events[len(events)-1]
+			require.Equal(t, "result", terminal.Type)
+			require.NotNil(t, terminal.Report)
+			assert.True(t, terminal.Report.Proof.ContentVerified)
+
+			func() {
+				restoredStore, err := store.Open(filepath.Join(target, "docbank.db"), driver)
+				require.NoError(t, err)
+				defer func() { require.NoError(t, restoredStore.Close()) }()
+				restoredBlobs, err := blob.New(
+					store.NewPackCatalog(restoredStore), filepath.Join(target, "blobs"),
+				)
+				require.NoError(t, err)
+				defer func() { require.NoError(t, restoredBlobs.Close()) }()
+
+				firstRestored, err := restoredStore.CollectionByID(t.Context(), first.IngestID)
+				require.NoError(t, err)
+				require.NotNil(t, firstRestored.Label)
+				assert.Equal(t, *firstLabel.Label, *firstRestored.Label)
+				assert.Equal(t, firstLabel.Revision, firstRestored.LabelRevision)
+				secondRestored, err := restoredStore.CollectionByID(t.Context(), second.IngestID)
+				require.NoError(t, err)
+				assert.Nil(t, secondRestored.Label)
+
+				firstMembers, err := restoredStore.CollectionMembers(t.Context(), first.IngestID, 10, 0)
+				require.NoError(t, err)
+				secondMembers, err := restoredStore.CollectionMembers(t.Context(), second.IngestID, 10, 0)
+				require.NoError(t, err)
+				require.Len(t, firstMembers.Items, 1)
+				require.Len(t, secondMembers.Items, 1)
+				assert.Equal(t, firstMembers.Items[0].Node.ID, secondMembers.Items[0].Node.ID)
+
+				history, err := restoredStore.AuditHistory(
+					t.Context(), firstMembers.Items[0].Node.ID, 50, "",
+				)
+				require.NoError(t, err)
+				kinds := make([]string, 0, len(history.Items))
+				for _, event := range history.Items {
+					kinds = append(kinds, event.Kind)
+				}
+				assert.Contains(t, kinds, "ingest_observe")
+				verification, err := restoredStore.VerifyAudit(t.Context(), nil)
+				require.NoError(t, err)
+				assert.True(t, verification.Evidence.Enabled)
+
+				reader, err := restoredBlobs.OpenContext(
+					t.Context(), firstMembers.Items[0].Node.BlobHash,
+				)
+				require.NoError(t, err)
+				restoredContent, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.NoError(t, reader.Close())
+				assert.Equal(t, content, restoredContent)
+			}()
+		})
+	}
+}

--- a/internal/api/routes_collections_test.go
+++ b/internal/api/routes_collections_test.go
@@ -1,0 +1,378 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func importCollection(
+	t *testing.T, tsURL string, client *http.Client, filename, content string, label *string,
+) api.IngestReport {
+	t.Helper()
+	source := filepath.Join(t.TempDir(), filename)
+	require.NoError(t, os.WriteFile(source, []byte(content), 0o600))
+	body := map[string]any{"paths": []string{source}, "dest": "/inbox"}
+	if label != nil {
+		body["collection_label"] = *label
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, tsURL+"/api/v1/ingest", bytes.NewReader(raw))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var report api.IngestReport
+	require.NoError(t, json.UnmarshalRead(resp.Body, &report))
+	require.NotEmpty(t, report.IngestID)
+	return report
+}
+
+func TestCollectionsHTTPListsDetailsAndMembers(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	firstLabel := "First import"
+	sourceDir := t.TempDir()
+	alpha := filepath.Join(sourceDir, "alpha.txt")
+	gamma := filepath.Join(sourceDir, "gamma.txt")
+	require.NoError(t, os.WriteFile(alpha, []byte("alpha"), 0o600))
+	require.NoError(t, os.WriteFile(gamma, []byte("gamma"), 0o600))
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/ingest", nil, map[string]any{
+		"paths": []string{gamma, alpha}, "dest": "/inbox", "collection_label": firstLabel,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var first api.IngestReport
+	require.NoError(t, json.Unmarshal([]byte(body), &first))
+	require.NotEmpty(t, first.IngestID)
+	second := importCollection(t, ts.URL, ts.Client(), "beta.txt", "longer beta", nil)
+
+	embedded, err := s.BeginCallerSuppliedIngest(t.Context(), "agent", "synthetic assertion")
+	require.NoError(t, err)
+	_, _, err = s.IngestFile(t.Context(), embedded, s.RootID(), "embedded.txt",
+		testHash("embedded"), int64(len("embedded")), "text/plain",
+		"opaque://synthetic/embedded.txt", "")
+	require.NoError(t, err)
+
+	resp, body = get(t, ts, "/api/v1/collections?limit=1&offset=0", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var firstPage api.CollectionPage
+	require.NoError(t, json.Unmarshal([]byte(body), &firstPage))
+	assert.Equal(t, 2, firstPage.Total)
+	assert.Equal(t, 1, firstPage.Limit)
+	assert.Zero(t, firstPage.Offset)
+	require.Len(t, firstPage.Items, 1)
+
+	resp, body = get(t, ts, "/api/v1/collections?limit=1&offset=1", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var secondPage api.CollectionPage
+	require.NoError(t, json.Unmarshal([]byte(body), &secondPage))
+	assert.Equal(t, 2, secondPage.Total)
+	assert.Equal(t, 1, secondPage.Limit)
+	assert.Equal(t, 1, secondPage.Offset)
+	require.Len(t, secondPage.Items, 1)
+	assert.NotEqual(t, firstPage.Items[0].ID, secondPage.Items[0].ID)
+	listed := map[string]api.Collection{
+		firstPage.Items[0].ID: firstPage.Items[0], secondPage.Items[0].ID: secondPage.Items[0],
+	}
+	require.Contains(t, listed, first.IngestID)
+	require.Contains(t, listed, second.IngestID)
+	assert.Equal(t, "cli", listed[first.IngestID].SourceKind)
+	assert.NotEmpty(t, listed[first.IngestID].SourceDescription)
+	assert.Equal(t, int64(2), listed[first.IngestID].FileCount)
+	assert.Equal(t, int64(len("alpha")+len("gamma")), listed[first.IngestID].TotalBytes)
+	require.NotNil(t, listed[first.IngestID].Label)
+	assert.Equal(t, firstLabel, *listed[first.IngestID].Label)
+	assert.Equal(t, int64(1), listed[first.IngestID].LabelRevision)
+	assert.NotEmpty(t, listed[first.IngestID].StartedAt)
+	assert.NotEmpty(t, listed[first.IngestID].LabelUpdatedAt)
+
+	resp, body = get(t, ts, "/api/v1/collections/"+first.IngestID, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var detail api.Collection
+	require.NoError(t, json.Unmarshal([]byte(body), &detail))
+	assert.Equal(t, listed[first.IngestID], detail)
+	assert.Empty(t, resp.Header.Get("ETag"), "membership observations do not fence the label")
+
+	resp, body = get(t, ts, "/api/v1/collections/"+first.IngestID+"/members?limit=1&offset=0", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var members api.CollectionMemberPage
+	require.NoError(t, json.Unmarshal([]byte(body), &members))
+	assert.Equal(t, detail, members.Collection)
+	assert.Equal(t, 2, members.Total)
+	assert.Equal(t, 1, members.Limit)
+	assert.Zero(t, members.Offset)
+	require.Len(t, members.Items, 1)
+	assert.Equal(t, "/inbox/alpha.txt", members.Items[0].Path)
+	assert.Equal(t, "alpha.txt", members.Items[0].Name)
+	assert.Equal(t, int64(len("alpha")), members.Items[0].Size)
+
+	resp, body = get(t, ts, "/api/v1/collections/"+first.IngestID+"/members?limit=1&offset=1", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var nextMembers api.CollectionMemberPage
+	require.NoError(t, json.Unmarshal([]byte(body), &nextMembers))
+	assert.Equal(t, detail, nextMembers.Collection)
+	assert.Equal(t, 2, nextMembers.Total)
+	require.Len(t, nextMembers.Items, 1)
+	assert.Equal(t, "/inbox/gamma.txt", nextMembers.Items[0].Path)
+}
+
+func TestCollectionsHTTPValidatesAuthIdentityAndPageBounds(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	for name, key := range map[string]string{"missing": "", "wrong": "wrong-key"} {
+		t.Run(name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/collections", nil)
+			require.NoError(t, err)
+			req.Header["X-Api-Key"] = []string{key}
+			resp, err := ts.Client().Do(req)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		})
+	}
+
+	for _, path := range []string{
+		"/api/v1/collections?limit=0", "/api/v1/collections?limit=1001",
+		"/api/v1/collections?offset=-1", "/api/v1/collections/not-a-uuid",
+		"/api/v1/collections/not-a-uuid/members", "/api/v1/collections/not-a-uuid/label",
+	} {
+		resp, body := get(t, ts, path, nil)
+		if path == "/api/v1/collections?limit=0" || path == "/api/v1/collections?limit=1001" ||
+			path == "/api/v1/collections?offset=-1" {
+			assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+		} else {
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode, body)
+		}
+	}
+}
+
+func TestCollectionHTTPRetainsDirectLabelAccessWhenMembershipEmpties(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	label := "Reserved name"
+	report := importCollection(t, ts.URL, ts.Client(), "retained.txt", "retained", &label)
+	page, err := s.CollectionMembers(t.Context(), report.IngestID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	_, _, err = s.Trash(t.Context(), page.Items[0].Node.ID, page.Items[0].Node.Revision)
+	require.NoError(t, err)
+
+	resp, body := get(t, ts, "/api/v1/collections", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var list api.CollectionPage
+	require.NoError(t, json.Unmarshal([]byte(body), &list))
+	assert.Zero(t, list.Total)
+	assert.Empty(t, list.Items)
+
+	resp, body = get(t, ts, "/api/v1/collections/"+report.IngestID, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var collection api.Collection
+	require.NoError(t, json.Unmarshal([]byte(body), &collection))
+	assert.Zero(t, collection.FileCount)
+	assert.Zero(t, collection.TotalBytes)
+	require.NotNil(t, collection.Label)
+	assert.Equal(t, label, *collection.Label)
+
+	resp, body = get(t, ts, "/api/v1/collections/"+report.IngestID+"/members", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var members api.CollectionMemberPage
+	require.NoError(t, json.Unmarshal([]byte(body), &members))
+	assert.Zero(t, members.Total)
+	assert.Empty(t, members.Items)
+	assert.Equal(t, 100, members.Limit)
+
+	resp, body = get(t, ts, "/api/v1/collections/"+report.IngestID+"/label", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Equal(t, `"1"`, resp.Header.Get("ETag"))
+	var current api.CollectionLabel
+	require.NoError(t, json.Unmarshal([]byte(body), &current))
+	assert.NotContains(t, body, "file_count")
+	assert.NotContains(t, body, "label_revision")
+	assert.Equal(t, report.IngestID, current.IngestID)
+	require.NotNil(t, current.Label)
+	assert.Equal(t, label, *current.Label)
+	assert.Equal(t, int64(1), current.Revision)
+	assert.NotEmpty(t, current.UpdatedAt)
+}
+
+func TestCollectionLabelHTTPRevisionLifecycleAndValidation(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	report := importCollection(t, ts.URL, ts.Client(), "note.txt", "synthetic", nil)
+	path := "/api/v1/collections/" + report.IngestID + "/label"
+
+	resp, body := get(t, ts, path, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Equal(t, `"1"`, resp.Header.Get("ETag"))
+	var initial api.CollectionLabel
+	require.NoError(t, json.Unmarshal([]byte(body), &initial))
+	assert.Nil(t, initial.Label)
+	assert.Equal(t, int64(1), initial.Revision)
+
+	resp, body = do(t, ts, http.MethodPut, path, map[string]string{"If-Match": `"1"`},
+		map[string]any{"label": nil})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Equal(t, `"1"`, resp.Header.Get("ETag"))
+
+	resp, body = do(t, ts, http.MethodPut, path, map[string]string{"If-Match": `"1"`},
+		map[string]any{"label": "Review set"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Equal(t, `"2"`, resp.Header.Get("ETag"))
+
+	resp, body = do(t, ts, http.MethodPut, path, map[string]string{"If-Match": `"2"`},
+		map[string]any{"label": "Review set"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Equal(t, `"2"`, resp.Header.Get("ETag"))
+
+	resp, body = do(t, ts, http.MethodPut, path, map[string]string{"If-Match": `"1"`},
+		map[string]any{"label": "Different set"})
+	assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode, body)
+	current, err := s.CollectionLabel(t.Context(), report.IngestID)
+	require.NoError(t, err)
+	require.NotNil(t, current.Label)
+	assert.Equal(t, "Review set", *current.Label)
+
+	resp, body = do(t, ts, http.MethodPut, path, map[string]string{"If-Match": `"2"`},
+		map[string]any{"label": nil})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Equal(t, `"3"`, resp.Header.Get("ETag"))
+	var cleared api.CollectionLabel
+	require.NoError(t, json.Unmarshal([]byte(body), &cleared))
+	assert.Nil(t, cleared.Label)
+	assert.Equal(t, int64(3), cleared.Revision)
+
+	resp, body = do(t, ts, http.MethodPut, path, map[string]string{"If-Match": `"3"`},
+		map[string]any{"label": nil})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	assert.Equal(t, `"3"`, resp.Header.Get("ETag"))
+
+	for name, headers := range map[string]map[string]string{
+		"missing": nil,
+		"invalid": {"If-Match": `"bad"`},
+		"zero":    {"If-Match": "0"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, body := do(t, ts, http.MethodPut, path, headers, map[string]any{"label": "Next"})
+			if name == "missing" {
+				assert.Equal(t, http.StatusPreconditionRequired, resp.StatusCode, body)
+			} else {
+				assert.Equal(t, http.StatusBadRequest, resp.StatusCode, body)
+			}
+		})
+	}
+
+	for name, request := range map[string]map[string]any{
+		"missing label":    {},
+		"unknown field":    {"label": "Next", "extra": true},
+		"server revision":  {"label": "Next", "revision": 3},
+		"server ingest id": {"label": "Next", "ingest_id": report.IngestID},
+		"server timestamp": {"label": "Next", "updated_at": initial.UpdatedAt},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, body := do(t, ts, http.MethodPut, path,
+				map[string]string{"If-Match": `"3"`}, request)
+			assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+		})
+	}
+
+	resp, body = do(t, ts, http.MethodPut, path, map[string]string{"If-Match": `"3"`},
+		map[string]any{"label": "\t"})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"invalid_collection_label"`)
+}
+
+func TestCollectionLabelHTTPCollisionAndAuditRestriction(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	reserved := "Reserved"
+	first := importCollection(t, ts.URL, ts.Client(), "first.txt", "first", &reserved)
+	second := importCollection(t, ts.URL, ts.Client(), "second.txt", "second", nil)
+	secondPath := "/api/v1/collections/" + second.IngestID + "/label"
+	firstMembers, err := s.CollectionMembers(t.Context(), first.IngestID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, firstMembers.Items, 1)
+	_, _, err = s.Trash(
+		t.Context(), firstMembers.Items[0].Node.ID, firstMembers.Items[0].Node.Revision,
+	)
+	require.NoError(t, err)
+
+	resp, body := do(t, ts, http.MethodPut, secondPath,
+		map[string]string{"If-Match": `"1"`}, map[string]any{"label": reserved})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"exists"`)
+
+	plan, err := s.PreviewInitialAudit(t.Context(), s.RootID(), "api", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+
+	resp, body = do(t, ts, http.MethodPut, secondPath,
+		map[string]string{"If-Match": `"1"`}, map[string]any{"label": "Blocked"})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"audit_mutation_unsupported"`)
+}
+
+func TestCollectionRoutesHaveExactBrowserSessionAllowList(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	report := importCollection(t, ts.URL, ts.Client(), "browser.txt", "browser", nil)
+	resp, body := do(t, ts, http.MethodPost, "/api/daemon/web-session", nil, nil)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	var issued struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &issued))
+
+	request := func(method, path string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(method, ts.URL+path, nil)
+		require.NoError(t, err)
+		req.Header["X-Api-Key"] = []string{""}
+		req.Header.Set(api.WebSessionHeader, issued.Token)
+		response, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		return response
+	}
+
+	base := "/api/v1/collections/" + report.IngestID
+	for _, path := range []string{
+		"/api/v1/collections?limit=100&offset=0", base, base + "/members?limit=100&offset=0",
+		base + "/label",
+	} {
+		resp := request(http.MethodGet, path)
+		assert.Equal(t, http.StatusOK, resp.StatusCode, path)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	putBody := bytes.NewBufferString(`{"label":"Browser label"}`)
+	req, err := http.NewRequest(http.MethodPut, ts.URL+base+"/label", putBody)
+	require.NoError(t, err)
+	req.Header["X-Api-Key"] = []string{""}
+	req.Header.Set(api.WebSessionHeader, issued.Token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("If-Match", `"1"`)
+	resp, err = ts.Client().Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	for _, denied := range []struct{ method, path string }{
+		{http.MethodPost, "/api/v1/collections"},
+		{http.MethodDelete, base + "/label"},
+		{http.MethodPatch, base + "/label"},
+		{http.MethodPut, base + "/label?force=true"},
+		{http.MethodPut, base + "/members"},
+		{http.MethodGet, base + "/"},
+		{http.MethodGet, base + "/label/extra"},
+		{http.MethodGet, "/api/v1/collections/not/a/collection"},
+	} {
+		resp := request(denied.method, denied.path)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode, "%s %s", denied.method, denied.path)
+		require.NoError(t, resp.Body.Close())
+	}
+}

--- a/internal/api/routes_ingest_collection_test.go
+++ b/internal/api/routes_ingest_collection_test.go
@@ -1,0 +1,349 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestIngestLabelReceiptNamesCommittedRun(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	source := filepath.Join(t.TempDir(), "note.txt")
+	require.NoError(t, os.WriteFile(source, []byte("synthetic"), 0o600))
+
+	report := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{source}, "dest": "/inbox", "collection_label": "Review set",
+	})
+	require.Equal(t, 1, report.Added)
+	require.NotEmpty(t, report.IngestID)
+
+	collection, err := s.CollectionByID(t.Context(), report.IngestID)
+	require.NoError(t, err)
+	require.NotNil(t, collection.Label)
+	assert.Equal(t, "Review set", *collection.Label)
+	assert.Equal(t, int64(1), collection.FileCount)
+	page, err := s.CollectionMembers(t.Context(), report.IngestID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "/inbox/note.txt", page.Items[0].Path)
+}
+
+func TestIngestReceiptRecordsRepeatedAndReplacementMembership(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	source := filepath.Join(t.TempDir(), "record.txt")
+	require.NoError(t, os.WriteFile(source, []byte("first"), 0o600))
+
+	first := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{source}, "dest": "/inbox", "collection_label": "First pass",
+	})
+	require.NotEmpty(t, first.IngestID)
+	before, err := s.NodeByPath(t.Context(), "/inbox/record.txt")
+	require.NoError(t, err)
+
+	repeated := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{source}, "dest": "/inbox", "collection_label": "Second pass",
+	})
+	assert.Zero(t, repeated.Added)
+	assert.Equal(t, 1, repeated.Skipped)
+	require.NotEmpty(t, repeated.IngestID)
+	assert.NotEqual(t, first.IngestID, repeated.IngestID)
+	repeatedCollection, err := s.CollectionByID(t.Context(), repeated.IngestID)
+	require.NoError(t, err)
+	require.NotNil(t, repeatedCollection.Label)
+	assert.Equal(t, "Second pass", *repeatedCollection.Label)
+	repeatedMembers, err := s.CollectionMembers(t.Context(), repeated.IngestID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, repeatedMembers.Items, 1)
+	assert.Equal(t, before.ID, repeatedMembers.Items[0].Node.ID)
+	afterRepeated, err := s.NodeByID(t.Context(), before.ID)
+	require.NoError(t, err)
+	assert.Equal(t, before.Revision+1, afterRepeated.Revision)
+
+	require.NoError(t, os.WriteFile(source, []byte("replacement"), 0o600))
+	replacement := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{source}, "dest": "/inbox", "replace": true,
+		"collection_label": "Replacement pass",
+	})
+	assert.Equal(t, 1, replacement.Added)
+	require.NotEmpty(t, replacement.IngestID)
+	replacementCollection, err := s.CollectionByID(t.Context(), replacement.IngestID)
+	require.NoError(t, err)
+	require.NotNil(t, replacementCollection.Label)
+	assert.Equal(t, "Replacement pass", *replacementCollection.Label)
+	replacementMembers, err := s.CollectionMembers(t.Context(), replacement.IngestID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, replacementMembers.Items, 1)
+	assert.Equal(t, before.ID, replacementMembers.Items[0].Node.ID)
+}
+
+func TestIngestRepeatedPathWithinRunKeepsOneObservation(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	source := filepath.Join(t.TempDir(), "repeated.txt")
+	require.NoError(t, os.WriteFile(source, []byte("one observation"), 0o600))
+
+	report := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{source, source}, "dest": "/inbox",
+		"collection_label": "One run",
+	})
+	assert.Equal(t, 1, report.Added)
+	assert.Equal(t, 1, report.Skipped)
+	require.NotEmpty(t, report.IngestID)
+	collection, err := s.CollectionByID(t.Context(), report.IngestID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), collection.FileCount)
+	node, err := s.NodeByPath(t.Context(), "/inbox/repeated.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), node.Revision)
+}
+
+func TestIngestLabelCollisionRollsBackRunAndDocument(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	dir := t.TempDir()
+	firstSource := filepath.Join(dir, "first.txt")
+	conflictSource := filepath.Join(dir, "conflict.txt")
+	require.NoError(t, os.WriteFile(firstSource, []byte("first"), 0o600))
+	require.NoError(t, os.WriteFile(conflictSource, []byte("conflict"), 0o600))
+
+	first := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{firstSource}, "dest": "/inbox", "collection_label": "Claimed",
+	})
+	require.NotEmpty(t, first.IngestID)
+	beforeIngests, beforeLabels := ingestAuthorityCounts(t, s)
+
+	conflict := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{conflictSource}, "dest": "/inbox", "collection_label": "Claimed",
+	})
+	assert.Empty(t, conflict.IngestID)
+	assert.Zero(t, conflict.Added)
+	require.Len(t, conflict.Failed, 1)
+	assert.Contains(t, conflict.Failed[0].Error, "already exists")
+	_, err := s.NodeByPath(t.Context(), "/inbox/conflict.txt")
+	require.ErrorIs(t, err, store.ErrNotFound)
+	afterIngests, afterLabels := ingestAuthorityCounts(t, s)
+	assert.Equal(t, beforeIngests, afterIngests)
+	assert.Equal(t, beforeLabels, afterLabels)
+}
+
+func TestIngestReceiptsRequireCommittedDocumentAuthority(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	dir := t.TempDir()
+	valid := filepath.Join(dir, "valid.txt")
+	missing := filepath.Join(dir, "missing.txt")
+	require.NoError(t, os.WriteFile(valid, []byte("valid"), 0o600))
+
+	partial := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{missing, valid}, "dest": "/inbox", "collection_label": "Partial set",
+	})
+	assert.Equal(t, 1, partial.Added)
+	require.Len(t, partial.Failed, 1)
+	require.NotEmpty(t, partial.IngestID)
+	partialCollection, err := s.CollectionByID(t.Context(), partial.IngestID)
+	require.NoError(t, err)
+	require.NotNil(t, partialCollection.Label)
+	assert.Equal(t, "Partial set", *partialCollection.Label)
+	assert.Equal(t, int64(1), partialCollection.FileCount)
+
+	beforeIngests, beforeLabels := ingestAuthorityCounts(t, s)
+	excluded := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{valid}, "dest": "/inbox", "include": []string{"*.md"},
+		"collection_label": "Empty set",
+	})
+	assert.Empty(t, excluded.IngestID)
+	assert.Equal(t, 1, excluded.Excluded)
+	assert.Empty(t, excluded.Failed)
+	afterIngests, afterLabels := ingestAuthorityCounts(t, s)
+	assert.Equal(t, beforeIngests, afterIngests)
+	assert.Equal(t, beforeLabels, afterLabels)
+
+	missingOnly := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+		"paths": []string{missing}, "dest": "/inbox", "collection_label": "Rejected first",
+	})
+	assert.Empty(t, missingOnly.IngestID)
+	require.Len(t, missingOnly.Failed, 1)
+	afterIngests, afterLabels = ingestAuthorityCounts(t, s)
+	assert.Equal(t, beforeIngests, afterIngests)
+	assert.Equal(t, beforeLabels, afterLabels)
+}
+
+func TestIngestStreamTerminalReceiptNamesPartialCommittedRun(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	dir := t.TempDir()
+	valid := filepath.Join(dir, "stream.txt")
+	missing := filepath.Join(dir, "missing.txt")
+	require.NoError(t, os.WriteFile(valid, []byte("stream"), 0o600))
+
+	report := requestIngestCollection(t, ts, "/api/v1/ingest/stream", map[string]any{
+		"paths": []string{missing, valid}, "dest": "/inbox", "collection_label": "Stream set",
+	})
+	assert.Equal(t, 1, report.Added)
+	require.Len(t, report.Failed, 1)
+	require.NotEmpty(t, report.IngestID)
+	collection, err := s.CollectionByID(t.Context(), report.IngestID)
+	require.NoError(t, err)
+	require.NotNil(t, collection.Label)
+	assert.Equal(t, "Stream set", *collection.Label)
+	assert.Equal(t, int64(1), collection.FileCount)
+}
+
+func TestIngestRejectsInvalidLabelWithoutAuthority(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	source := filepath.Join(t.TempDir(), "invalid.txt")
+	require.NoError(t, os.WriteFile(source, []byte("invalid label"), 0o600))
+	beforeIngests, beforeLabels := ingestAuthorityCounts(t, s)
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/ingest", nil, map[string]any{
+		"paths": []string{source}, "dest": "/new/inbox", "collection_label": "   ",
+	})
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	assert.Contains(t, body, `"code":"invalid_collection_label"`)
+	assert.Contains(t, body, "all whitespace")
+	afterIngests, afterLabels := ingestAuthorityCounts(t, s)
+	assert.Equal(t, beforeIngests, afterIngests)
+	assert.Equal(t, beforeLabels, afterLabels)
+	_, err := s.NodeByPath(t.Context(), "/new")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestIngestStreamRejectsInvalidLabelWithoutAuthority(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	source := filepath.Join(t.TempDir(), "invalid.txt")
+	require.NoError(t, os.WriteFile(source, []byte("invalid label"), 0o600))
+	beforeIngests, beforeLabels := ingestAuthorityCounts(t, s)
+
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/ingest/stream", nil, map[string]any{
+		"paths": []string{source}, "dest": "/new/inbox", "collection_label": "   ",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	require.NotEmpty(t, lines)
+	var terminal api.IngestEvent
+	require.NoError(t, json.Unmarshal([]byte(lines[len(lines)-1]), &terminal))
+	assert.Equal(t, "error", terminal.Type)
+	require.NotNil(t, terminal.Error)
+	assert.Equal(t, "invalid_collection_label", terminal.Error.Code)
+	assert.Contains(t, terminal.Error.Detail, "all whitespace")
+	afterIngests, afterLabels := ingestAuthorityCounts(t, s)
+	assert.Equal(t, beforeIngests, afterIngests)
+	assert.Equal(t, beforeLabels, afterLabels)
+	_, err := s.NodeByPath(t.Context(), "/new")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestIngestInitialLabelAuditRejectionHasNoReceiptOrAuthority(t *testing.T) {
+	for _, route := range []string{"/api/v1/ingest", "/api/v1/ingest/stream"} {
+		t.Run(route, func(t *testing.T) {
+			ts, s := newTestServer(t, nil)
+			plan, err := s.PreviewInitialAudit(t.Context(), s.RootID(), "api", nil)
+			require.NoError(t, err)
+			_, err = s.EnableInitialAudit(t.Context(), plan)
+			require.NoError(t, err)
+			source := filepath.Join(t.TempDir(), "audited-tree")
+			require.NoError(t, os.MkdirAll(filepath.Join(source, "sub"), 0o700))
+			require.NoError(t, os.WriteFile(filepath.Join(source, "sub", "audited.txt"), []byte("audited"), 0o600))
+			beforeIngests, beforeLabels := ingestAuthorityCounts(t, s)
+
+			report := requestIngestCollection(t, ts, route, map[string]any{
+				"paths": []string{source}, "dest": "/new/inbox", "collection_label": "Audited set",
+			})
+			assert.Empty(t, report.IngestID)
+			assert.Zero(t, report.Added)
+			require.Len(t, report.Failed, 1)
+			assert.Contains(t, report.Failed[0].Error, store.ErrAuditMutationUnsupported.Error())
+			_, err = s.NodeByPath(t.Context(), "/new")
+			require.ErrorIs(t, err, store.ErrNotFound)
+			afterIngests, afterLabels := ingestAuthorityCounts(t, s)
+			assert.Equal(t, beforeIngests, afterIngests)
+			assert.Equal(t, beforeLabels, afterLabels)
+		})
+	}
+}
+
+func TestIngestLabelCollisionLeavesMissingDestinationAndSourceTreeAbsent(t *testing.T) {
+	for _, route := range []string{"/api/v1/ingest", "/api/v1/ingest/stream"} {
+		t.Run(route, func(t *testing.T) {
+			ts, s := newTestServer(t, nil)
+			winnerSource := filepath.Join(t.TempDir(), "winner.txt")
+			require.NoError(t, os.WriteFile(winnerSource, []byte("winner"), 0o600))
+			winner := requestIngestCollection(t, ts, "/api/v1/ingest", map[string]any{
+				"paths": []string{winnerSource}, "dest": "/existing", "collection_label": "Claimed",
+			})
+			require.NotEmpty(t, winner.IngestID)
+
+			source := filepath.Join(t.TempDir(), "conflict-tree")
+			require.NoError(t, os.MkdirAll(filepath.Join(source, "sub"), 0o700))
+			require.NoError(t, os.WriteFile(filepath.Join(source, "sub", "note.txt"), []byte("conflict"), 0o600))
+			beforeRoot, err := s.NodeByID(t.Context(), s.RootID())
+			require.NoError(t, err)
+			beforeIngests, beforeLabels := ingestAuthorityCounts(t, s)
+
+			report := requestIngestCollection(t, ts, route, map[string]any{
+				"paths": []string{source}, "dest": "/new/inbox", "collection_label": "Claimed",
+			})
+			assert.Empty(t, report.IngestID)
+			assert.Zero(t, report.Added)
+			require.Len(t, report.Failed, 1)
+			assert.Contains(t, report.Failed[0].Error, "already exists")
+			_, err = s.NodeByPath(t.Context(), "/new")
+			require.ErrorIs(t, err, store.ErrNotFound)
+			afterRoot, err := s.NodeByID(t.Context(), s.RootID())
+			require.NoError(t, err)
+			assert.Equal(t, beforeRoot, afterRoot)
+			afterIngests, afterLabels := ingestAuthorityCounts(t, s)
+			assert.Equal(t, beforeIngests, afterIngests)
+			assert.Equal(t, beforeLabels, afterLabels)
+		})
+	}
+}
+
+func requestIngestCollection(
+	t *testing.T, ts *httptest.Server, route string, request map[string]any,
+) api.IngestReport {
+	t.Helper()
+	resp, body := do(t, ts, http.MethodPost, route, nil, request)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	if route == "/api/v1/ingest/stream" {
+		lines := strings.Split(strings.TrimSpace(body), "\n")
+		require.NotEmpty(t, lines)
+		var terminal struct {
+			Type   string            `json:"type"`
+			Report *api.IngestReport `json:"report"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(lines[len(lines)-1]), &terminal))
+		require.Equal(t, "result", terminal.Type)
+		require.NotNil(t, terminal.Report)
+		return *terminal.Report
+	}
+	var report api.IngestReport
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+	return report
+}
+
+func ingestAuthorityCounts(t *testing.T, s *testStore) (ingests, labels int) {
+	t.Helper()
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	for line := range strings.SplitSeq(strings.TrimSpace(exported.String()), "\n") {
+		var record struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(line), &record), line)
+		switch record.Type {
+		case "ingest":
+			ingests++
+		case "collection_label":
+			labels++
+		}
+	}
+	return ingests, labels
+}

--- a/internal/api/routes_ops.go
+++ b/internal/api/routes_ops.go
@@ -305,7 +305,10 @@ func ingestParams(body IngestRequest) (string, ingest.Options, ingest.Selection,
 	if err := validateIngestPaths(body.Paths); err != nil {
 		return "", ingest.Options{}, ingest.Selection{}, err
 	}
-	opts := ingest.Options{Include: body.Include, Exclude: body.Exclude, Replace: body.Replace}
+	opts := ingest.Options{
+		Include: body.Include, Exclude: body.Exclude, Replace: body.Replace,
+		CollectionLabel: body.CollectionLabel,
+	}
 	selection, err := ingest.CompileSelection(opts)
 	if err != nil {
 		return "", ingest.Options{}, ingest.Selection{}, NewError(http.StatusUnprocessableEntity, "validation", err.Error())
@@ -340,7 +343,10 @@ func runIngest(
 			if err != nil {
 				return FromStoreError(err)
 			}
-			out = IngestReport{Added: rep.Added, Skipped: rep.Skipped, Excluded: rep.Excluded}
+			out = IngestReport{
+				IngestID: rep.IngestID, Added: rep.Added,
+				Skipped: rep.Skipped, Excluded: rep.Excluded,
+			}
 			for _, failure := range rep.Failed {
 				out.Failed = append(out.Failed, IngestFailure{
 					Path: failure.Path, Error: failure.Err.Error(),

--- a/internal/api/routes_upload_test.go
+++ b/internal/api/routes_upload_test.go
@@ -83,6 +83,7 @@ func TestUploadCreatesReceiptAndIdempotentRetry(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
 	var added api.UploadReceipt
 	require.NoError(t, json.Unmarshal([]byte(body), &added))
+	assert.NotContains(t, body, `"ingest_id"`)
 	assert.Equal(t, "added", added.Status)
 	assert.Equal(t, in.expectedHash, added.ComputedHash)
 	assert.Equal(t, in.expectedSize, added.ComputedSize)
@@ -97,6 +98,7 @@ func TestUploadCreatesReceiptAndIdempotentRetry(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, body)
 	var skipped api.UploadReceipt
 	require.NoError(t, json.Unmarshal([]byte(body), &skipped))
+	assert.NotContains(t, body, `"ingest_id"`)
 	assert.Equal(t, "skipped", skipped.Status)
 	assert.Equal(t, added.Node.ID, skipped.Node.ID)
 	assert.Equal(t, added.Node.Revision, skipped.Node.Revision)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -126,6 +126,7 @@ func NewServer(d Deps) *Server {
 	}
 
 	registerReadRoutes(humaAPI, d) // Task 5 (stat-by-id lands in this task)
+	registerCollectionRoutes(humaAPI, d, g)
 	registerInfoRoute(humaAPI, d)
 	registerMutateRoutes(humaAPI, d, g) // Task 6
 	registerOpsRoutes(humaAPI, d, g)    // Task 7
@@ -193,6 +194,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 func markRevisionPreconditionsRequired(api huma.API) {
 	for _, route := range []struct{ path, method string }{
 		{"/api/v1/nodes/{id}", http.MethodPatch},
+		{"/api/v1/collections/{id}/label", http.MethodPut},
 		{"/api/v1/nodes/{id}/trash", http.MethodPost},
 		{"/api/v1/nodes/{id}/restore", http.MethodPost},
 		{"/api/v1/nodes/{id}/verify", http.MethodPost},

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -525,6 +525,7 @@ type IngestFailure struct {
 
 // IngestReport summarizes an ingest run.
 type IngestReport struct {
+	IngestID string          `json:"ingest_id,omitempty"`
 	Added    int             `json:"added"`
 	Skipped  int             `json:"skipped"`
 	Excluded int             `json:"excluded"`
@@ -541,11 +542,12 @@ type IngestPreflightRequest struct {
 
 // IngestRequest imports server-side paths with optional source selection.
 type IngestRequest struct {
-	Replace bool     `json:"replace,omitempty"`
-	Paths   []string `json:"paths" minItems:"1"`
-	Dest    string   `json:"dest" default:"/inbox"`
-	Include []string `json:"include,omitempty"`
-	Exclude []string `json:"exclude,omitempty"`
+	Replace         bool     `json:"replace,omitempty"`
+	Paths           []string `json:"paths" minItems:"1"`
+	Dest            string   `json:"dest" default:"/inbox"`
+	Include         []string `json:"include,omitempty"`
+	Exclude         []string `json:"exclude,omitempty"`
+	CollectionLabel *string  `json:"collection_label,omitempty"`
 }
 
 // IngestProgress is one structured update from a server-side import. Scan

--- a/internal/api/types_collections.go
+++ b/internal/api/types_collections.go
@@ -1,0 +1,61 @@
+package api
+
+import "go.kenn.io/docbank/internal/store"
+
+// Collection is one document-bearing ingest run and its current live summary.
+// LabelRevision advances independently of member observations.
+type Collection struct {
+	ID                string  `json:"id" format:"uuid"`
+	SourceKind        string  `json:"source_kind" minLength:"1"`
+	SourceDescription string  `json:"source_description" minLength:"1"`
+	StartedAt         string  `json:"started_at" format:"date-time"`
+	FileCount         int64   `json:"file_count" minimum:"0"`
+	TotalBytes        int64   `json:"total_bytes" minimum:"0"`
+	Label             *string `json:"label"`
+	LabelRevision     int64   `json:"label_revision" minimum:"1"`
+	LabelUpdatedAt    string  `json:"label_updated_at" format:"date-time"`
+}
+
+// CollectionPage is one bounded, newest-first page of nonempty collections.
+type CollectionPage struct {
+	Items  []Collection `json:"items"`
+	Total  int          `json:"total" minimum:"0"`
+	Limit  int          `json:"limit" minimum:"1" maximum:"1000"`
+	Offset int          `json:"offset" minimum:"0"`
+}
+
+// CollectionMemberPage binds live members and the collection summary to one
+// read snapshot. Each member carries its current live path.
+type CollectionMemberPage struct {
+	Collection Collection `json:"collection"`
+	Items      []Node     `json:"items"`
+	Total      int        `json:"total" minimum:"0"`
+	Limit      int        `json:"limit" minimum:"1" maximum:"1000"`
+	Offset     int        `json:"offset" minimum:"0"`
+}
+
+// CollectionLabel is the independently revisioned label authority for one
+// ingest run. A nil Label is the explicit cleared state.
+type CollectionLabel struct {
+	IngestID  string  `json:"ingest_id" format:"uuid"`
+	Label     *string `json:"label"`
+	Revision  int64   `json:"revision" minimum:"1"`
+	UpdatedAt string  `json:"updated_at" format:"date-time"`
+}
+
+func fromStoreCollection(collection store.Collection) Collection {
+	return Collection{
+		ID: collection.ID, SourceKind: collection.SourceKind,
+		SourceDescription: collection.SourceDescription, StartedAt: collection.StartedAt,
+		FileCount: collection.FileCount, TotalBytes: collection.TotalBytes,
+		Label: collection.Label, LabelRevision: collection.LabelRevision,
+		LabelUpdatedAt: collection.LabelUpdatedAt,
+	}
+}
+
+func fromStoreCollectionLabel(label store.CollectionLabel) CollectionLabel {
+	return CollectionLabel{
+		IngestID: label.IngestID, Label: label.Label,
+		Revision: label.Revision, UpdatedAt: label.UpdatedAt,
+	}
+}

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -181,6 +181,12 @@ func webSessionRequestAllowed(r *http.Request) bool {
 			((method == http.MethodPatch || method == http.MethodDelete) &&
 				r.URL.RawQuery == "")
 	}
+	if method == http.MethodPut && r.URL.RawQuery == "" {
+		if collectionID, resource, ok := collectionResourcePath(path); ok &&
+			collectionID != "" && resource == "label" {
+			return true
+		}
+	}
 	if method == http.MethodPost && path == webDownloadPreparePath {
 		return true
 	}
@@ -229,6 +235,12 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	if method != http.MethodGet {
 		return false
 	}
+	if path == "/api/v1/collections" {
+		return true
+	}
+	if collectionID, resource, ok := collectionResourcePath(path); ok && collectionID != "" {
+		return resource == "" || resource == "members" || resource == "label"
+	}
 	if path == "/api/v1/trash" {
 		// The master API retains the released unbounded form, but a browser
 		// session may request only the UI's fixed bounded page.
@@ -265,6 +277,22 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	return len(parts) == 1 || parts[1] == "children" ||
 		parts[1] == "versions" || parts[1] == "provenance" ||
 		parts[1] == "tags"
+}
+
+func collectionResourcePath(path string) (collectionID, resource string, ok bool) {
+	const prefix = "/api/v1/collections/"
+	after, ok := strings.CutPrefix(path, prefix)
+	if !ok {
+		return "", "", false
+	}
+	parts := strings.Split(after, "/")
+	if len(parts) == 1 {
+		return parts[0], "", true
+	}
+	if len(parts) == 2 && parts[1] != "" {
+		return parts[0], parts[1], true
+	}
+	return "", "", false
 }
 
 func registerWebSession(

--- a/internal/audit/registry.go
+++ b/internal/audit/registry.go
@@ -507,7 +507,7 @@ func eventPayloadRule() valueRule {
 func eventKindRule() valueRule {
 	return textEnum(
 		"audit_enroll", "audit_inherit", "content_create", "content_replace", "content_revert",
-		"node_create", "node_path", "provenance_add", "provenance_supersede", "tag_assign",
+		"ingest_observe", "node_create", "node_path", "provenance_add", "provenance_supersede", "tag_assign",
 		"tag_define", "tag_delete", "tag_rename", "tag_unassign",
 	)
 }

--- a/internal/client/audit_ingest_observation_test.go
+++ b/internal/client/audit_ingest_observation_test.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestValidateAuditIngestObservation(t *testing.T) {
+	event := validAuditIngestObservation()
+	require.NoError(t, validateAuditEvent(event, event.NodeID))
+}
+
+func TestValidateAuditIngestObservationRejectsMalformedEvent(t *testing.T) {
+	tests := map[string]func(*api.AuditEvent){
+		"missing attachment": func(event *api.AuditEvent) {
+			event.Attachment = nil
+		},
+		"wrong attachment": func(event *api.AuditEvent) {
+			event.Attachment.Kind = "tag_assignment"
+		},
+		"identity mismatch": func(event *api.AuditEvent) {
+			event.Attachment.Identity.ProvenanceID = auditTestHash("c")
+		},
+		"node mismatch": func(event *api.AuditEvent) {
+			event.Attachment.After.NodeID++
+		},
+		"forbidden predecessor": func(event *api.AuditEvent) {
+			predecessor := auditTestHash("d")
+			event.Attachment.After.Supersedes = &predecessor
+		},
+		"zero prior revision": func(event *api.AuditEvent) {
+			event.PriorNodeRevision = 0
+			event.ResultingNodeRevision = 1
+		},
+		"revision jump": func(event *api.AuditEvent) {
+			event.ResultingNodeRevision++
+		},
+		"missing prior version": func(event *api.AuditEvent) {
+			event.PriorCurrentVersionID = nil
+		},
+		"changed version": func(event *api.AuditEvent) {
+			changed := "22222222-2222-4222-8222-222222222222"
+			event.ResultingCurrentVersionID = &changed
+		},
+		"source version transition": func(event *api.AuditEvent) {
+			source := "33333333-3333-4333-8333-333333333333"
+			event.SourceVersionID = &source
+		},
+		"target node transition": func(event *api.AuditEvent) {
+			target := int64(8)
+			event.TargetNodeID = &target
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			event := validAuditIngestObservation()
+			mutate(&event)
+			require.Error(t, validateAuditEvent(event, event.NodeID))
+		})
+	}
+}
+
+func validAuditIngestObservation() api.AuditEvent {
+	versionID := "11111111-1111-4111-8111-111111111111"
+	provenanceID := auditTestHash("b")
+	return api.AuditEvent{
+		ID:                        auditTestHash("a"),
+		OperationID:               "44444444-4444-4444-8444-444444444444",
+		OperationSequence:         1,
+		NodeID:                    7,
+		Kind:                      "ingest_observe",
+		ScopeID:                   "55555555-5555-4555-8555-555555555555",
+		RecordedAt:                "2026-09-10T00:00:00Z",
+		Origin:                    "cli",
+		PriorNodeRevision:         2,
+		ResultingNodeRevision:     3,
+		PriorCurrentVersionID:     &versionID,
+		ResultingCurrentVersionID: &versionID,
+		Attachment: &api.AuditAttachmentChange{
+			Kind: "provenance",
+			Identity: api.AuditAttachmentIdentity{
+				ProvenanceID: provenanceID,
+			},
+			After: &api.AuditAttachmentState{
+				NodeID:       7,
+				ProvenanceID: provenanceID,
+				IngestID:     "66666666-6666-4666-8666-666666666666",
+			},
+		},
+	}
+}
+
+func auditTestHash(digit string) string {
+	return strings.Repeat(digit, 64)
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1244,7 +1244,13 @@ func validateAuditEvent(event api.AuditEvent, nodeID int64) error {
 	} else if event.OldPath != nil || event.NewPath != nil {
 		return errors.New("non-path event contains path states")
 	}
-	return validateAuditAttachment(event.Kind, event.Attachment)
+	if err := validateAuditAttachment(event.Kind, event.Attachment); err != nil {
+		return err
+	}
+	if event.Kind == "ingest_observe" {
+		return validateAuditIngestObservation(event)
+	}
+	return nil
 }
 
 func validateAuditAttachment(eventKind string, change *api.AuditAttachmentChange) error {
@@ -1254,7 +1260,7 @@ func validateAuditAttachment(eventKind string, change *api.AuditAttachmentChange
 		wantKind = "tag_definition"
 	case "tag_assign", "tag_unassign":
 		wantKind = "tag_assignment"
-	case "provenance_add", "provenance_supersede":
+	case "ingest_observe", "provenance_add", "provenance_supersede":
 		wantKind = "provenance"
 	}
 	if wantKind == "" {
@@ -1287,9 +1293,9 @@ func validateAuditAttachment(eventKind string, change *api.AuditAttachmentChange
 		if change.Before != nil && change.After == nil {
 			return nil
 		}
-	case "tag_define", "tag_assign", "provenance_add":
+	case "tag_define", "tag_assign", "ingest_observe", "provenance_add":
 		if change.Before == nil && change.After != nil &&
-			(eventKind != "provenance_add" ||
+			((eventKind != "ingest_observe" && eventKind != "provenance_add") ||
 				change.After.ProvenanceID == change.Identity.ProvenanceID) {
 			return nil
 		}
@@ -1302,6 +1308,22 @@ func validateAuditAttachment(eventKind string, change *api.AuditAttachmentChange
 		}
 	}
 	return errors.New("audit attachment has an invalid transition shape")
+}
+
+func validateAuditIngestObservation(event api.AuditEvent) error {
+	change := event.Attachment
+	if event.PriorNodeRevision < 1 ||
+		event.ResultingNodeRevision != event.PriorNodeRevision+1 ||
+		event.PriorCurrentVersionID == nil || event.ResultingCurrentVersionID == nil ||
+		*event.PriorCurrentVersionID != *event.ResultingCurrentVersionID ||
+		event.SourceVersionID != nil || event.TargetNodeID != nil ||
+		change == nil || change.Before != nil || change.After == nil ||
+		change.After.NodeID != event.NodeID ||
+		change.After.ProvenanceID != change.Identity.ProvenanceID ||
+		change.After.Supersedes != nil {
+		return errors.New("ingest observation has an invalid authority transition")
+	}
+	return nil
 }
 
 func validateAuditAttachmentIdentity(kind string, identity api.AuditAttachmentIdentity) error {
@@ -2258,18 +2280,24 @@ func canonicalDirectoryPath(path string) (string, error) {
 	return "/" + strings.Join(segments, "/"), nil
 }
 
-// IngestOptions selects source filters and the destination policy for a
-// server-side import. The zero value keeps ordinary suffixing semantics.
+// IngestOptions selects source filters, destination policy, and an optional
+// initial collection label for a server-side import. The zero value keeps
+// ordinary suffixing semantics without a label.
 type IngestOptions struct {
-	Include []string
-	Exclude []string
-	Replace bool
+	Include         []string
+	Exclude         []string
+	Replace         bool
+	CollectionLabel *string
 }
 
 func (o IngestOptions) requestBody(paths []string, dest string) map[string]any {
-	return map[string]any{
+	body := map[string]any{
 		"paths": paths, "dest": dest, "include": o.Include, "exclude": o.Exclude, "replace": o.Replace,
 	}
+	if o.CollectionLabel != nil {
+		body["collection_label"] = *o.CollectionLabel
+	}
+	return body
 }
 
 func (c *Client) Ingest(ctx context.Context, paths []string, dest string) (api.IngestReport, error) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -526,24 +526,32 @@ func TestIngestOptionsSendReplaceToJSONAndStream(t *testing.T) {
 		bodies = append(bodies, string(body))
 		if r.URL.Path == "/api/v1/ingest/stream" {
 			w.Header().Set("Content-Type", "application/x-ndjson")
-			_ = json.MarshalWrite(w, api.IngestEvent{Type: "result", Report: &api.IngestReport{}})
+			_ = json.MarshalWrite(w, api.IngestEvent{
+				Type: "result", Report: &api.IngestReport{IngestID: "stream-run"},
+			})
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.MarshalWrite(w, api.IngestReport{})
+		_ = json.MarshalWrite(w, api.IngestReport{IngestID: "json-run"})
 	}))
 	t.Cleanup(ts.Close)
 
 	c := client.New(ts.URL, serverKey)
-	opts := client.IngestOptions{Exclude: []string{"cache"}, Replace: true}
-	_, err := c.IngestWithOptions(t.Context(), []string{"/source"}, "/inbox", opts)
+	label := "Review set"
+	opts := client.IngestOptions{
+		Exclude: []string{"cache"}, Replace: true, CollectionLabel: &label,
+	}
+	jsonReport, err := c.IngestWithOptions(t.Context(), []string{"/source"}, "/inbox", opts)
 	require.NoError(t, err)
-	_, err = c.IngestStream(t.Context(), []string{"/source"}, "/inbox", opts, nil)
+	assert.Equal(t, "json-run", jsonReport.IngestID)
+	streamReport, err := c.IngestStream(t.Context(), []string{"/source"}, "/inbox", opts, nil)
 	require.NoError(t, err)
+	assert.Equal(t, "stream-run", streamReport.IngestID)
 	require.Len(t, bodies, 2)
 	for _, body := range bodies {
 		assert.Contains(t, body, `"replace":true`)
 		assert.Contains(t, body, `"exclude":["cache"]`)
+		assert.Contains(t, body, `"collection_label":"Review set"`)
 	}
 }
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -67,6 +67,7 @@ func describeSources(sources []string) string {
 
 // Report summarizes an ingest run.
 type Report struct {
+	IngestID string
 	Added    int
 	Skipped  int
 	Excluded int
@@ -409,13 +410,31 @@ func (ing *Ingester) AddPathsWithSelection(
 	if err := ctx.Err(); err != nil {
 		return rep, err
 	}
-	dest, err := ing.Store.MkdirAll(ctx, destPath)
-	if err != nil {
-		return rep, fmt.Errorf("resolving destination %q: %w", destPath, err)
-	}
-	ingestID, err := ing.Store.BeginIngest(ctx, "cli", describeSources(sources))
-	if err != nil {
-		return rep, err
+	dest := &ingestDirectory{sourcePath: destPath}
+	files := &filesystemIngest{ing: ing, destination: dest}
+	if opts.CollectionLabel == nil {
+		directory, err := ing.Store.MkdirAll(ctx, destPath)
+		if err != nil {
+			return rep, fmt.Errorf("resolving destination %q: %w", destPath, err)
+		}
+		dest.id = directory.ID
+		files.run, err = ing.Store.BeginIngest(ctx, "cli", describeSources(sources))
+		if err != nil {
+			return rep, err
+		}
+	} else {
+		files.run, err = ing.Store.BeginIngestWithLabel(
+			ctx, "cli", describeSources(sources), opts.CollectionLabel,
+		)
+		if err != nil {
+			return rep, err
+		}
+		destPlan, planErr := ing.Store.PrepareIngestDirectory(ctx, destPath)
+		if planErr != nil {
+			return rep, fmt.Errorf("resolving destination %q: %w", destPath, planErr)
+		}
+		dest.plan = &destPlan
+		files.directories = append(files.directories, dest)
 	}
 
 	for _, rawSource := range sources {
@@ -448,12 +467,12 @@ func (ing *Ingester) AddPathsWithSelection(
 				progress.report(rep, false)
 				continue
 			}
-			if err := ing.addOne(ctx, &rep, ingestID, dest.ID, src, src, opts.Replace, progress); err != nil {
+			if err := files.addOne(ctx, &rep, dest, src, src, opts.Replace, progress); err != nil {
 				return rep, err
 			}
 		case info.IsDir():
-			if err := ing.addTree(
-				ctx, &rep, ingestID, dest.ID, src, src, selection, opts.Replace, progress,
+			if err := files.addTree(
+				ctx, &rep, src, src, selection, opts.Replace, progress,
 			); err != nil {
 				return rep, err
 			}
@@ -493,8 +512,8 @@ func (ing *Ingester) AddPathsWithSelection(
 				progress.report(rep, false)
 				continue
 			}
-			if err := ing.addTree(
-				ctx, &rep, ingestID, dest.ID, src, walkRoot, selection, opts.Replace, progress,
+			if err := files.addTree(
+				ctx, &rep, src, walkRoot, selection, opts.Replace, progress,
 			); err != nil {
 				return rep, err
 			}
@@ -509,12 +528,39 @@ func (ing *Ingester) AddPathsWithSelection(
 			progress.report(rep, false)
 		}
 	}
+	if err := files.finalize(ctx, &rep, progress); err != nil {
+		return rep, err
+	}
 	progress.report(rep, true)
 	return rep, nil
 }
 
+// ingestDirectory keeps parentage anchored to a node ID. Labeled imports defer
+// missing directories in plan until the label can be admitted atomically.
+type ingestDirectory struct {
+	sourcePath string
+	id         int64
+	plan       *store.IngestDirectoryPlan
+}
+
+type filesystemIngest struct {
+	ing               *Ingester
+	run               store.IngestRun
+	destination       *ingestDirectory
+	directories       []*ingestDirectory // Deferred plans, including the destination.
+	admissionRejected bool
+}
+
+func (files *filesystemIngest) applyResolution(
+	resolution store.IngestDirectoryResolution,
+) {
+	for _, directory := range files.directories {
+		*directory.plan = resolution.Rebase(*directory.plan)
+	}
+}
+
 // addTree imports walkRoot recursively; sourceRoot's basename becomes a
-// directory under destDirID and relative structure is preserved. The roots
+// directory under the destination and relative structure is preserved. The roots
 // differ only when the user explicitly supplied a symlink to a directory:
 // traversal uses its resolved target while provenance retains the supplied
 // spelling.
@@ -524,21 +570,15 @@ func (ing *Ingester) AddPathsWithSelection(
 // accepted — docbank is single-user and imports the user's own trees, so a
 // process able to race the walk already runs as the user; importFile's
 // no-follow open covers the accidental symlink case.
-func (ing *Ingester) addTree(
+func (files *filesystemIngest) addTree(
 	ctx context.Context,
 	rep *Report,
-	ingestRun store.IngestRun,
-	destDirID int64,
 	sourceRoot, walkRoot string,
 	selection sourceSelection,
 	replace bool,
 	progress *progressTracker,
 ) error {
-	// Absolutize first. WalkDir hands back the root spelled exactly as given
-	// while children come from filepath.Join, which cleans — dirIDs keys must
-	// use one spelling. And a source spelled "." or ".." has no usable
-	// basename: a ".." topName would climb out of the destination when
-	// joined into the virtual path below.
+	// Use one absolute spelling for map keys and a real basename for "."/"..".
 	sourceRoot, err := filepath.Abs(sourceRoot)
 	if err != nil {
 		return fmt.Errorf("resolving source %s: %w", sourceRoot, err)
@@ -552,13 +592,9 @@ func (ing *Ingester) addTree(
 		return fmt.Errorf("cannot import filesystem root %q", sourceRoot)
 	}
 
-	// Parentage stays ID-based throughout: every directory is created under
-	// the resolved id of its parent, never by re-deriving a path from
-	// destDirID — a concurrent move or trash of the destination would make
-	// that path re-create (even resurrect) a tree somewhere else.
-	dirIDs := map[string]int64{}  // source dir path -> virtual dir node id
-	dirErrs := map[string]error{} // source dir path -> reported creation failure
-	walkErr := filepath.WalkDir(walkRoot, func(p string, d fs.DirEntry, err error) error {
+	directories := map[string]*ingestDirectory{}
+	directoryErrors := map[string]error{}
+	return filepath.WalkDir(walkRoot, func(p string, d fs.DirEntry, err error) error {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
@@ -589,33 +625,25 @@ func (ing *Ingester) addTree(
 			if len(selection.include) > 0 {
 				return nil
 			}
-			parentID, name := destDirID, topName
-			if p != walkRoot {
-				pid, ok := dirIDs[filepath.Dir(p)]
-				if !ok {
-					return fmt.Errorf("internal: no virtual dir recorded for %s", filepath.Dir(p))
-				}
-				parentID, name = pid, d.Name()
-			}
-			dir, err := ing.Store.EnsureDir(ctx, parentID, name)
+			_, err := files.ensureSourceDirectory(
+				ctx, directories, directoryErrors, topName, sourceRoot, walkRoot, p,
+			)
 			if err != nil {
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					return ctxErr
 				}
-				rep.Failed = append(rep.Failed, FileError{Path: sourcePath,
-					Err: fmt.Errorf("creating virtual dir %q under node %d: %w", name, parentID, err)})
+				rep.Failed = append(rep.Failed, FileError{Path: sourcePath, Err: err})
 				progress.report(*rep, false)
 				return fs.SkipDir
 			}
-			dirIDs[p] = dir.ID
 		case d.Type().IsRegular():
 			if !selection.included(sourceRoot, sourcePath) {
 				rep.Excluded++
 				progress.report(*rep, false)
 				return nil
 			}
-			parentID, err := ing.ensureSourceDir(
-				ctx, dirIDs, dirErrs, destDirID, topName, walkRoot, filepath.Dir(p),
+			parent, err := files.ensureSourceDirectory(
+				ctx, directories, directoryErrors, topName, sourceRoot, walkRoot, filepath.Dir(p),
 			)
 			if err != nil {
 				if ctxErr := ctx.Err(); ctxErr != nil {
@@ -623,12 +651,14 @@ func (ing *Ingester) addTree(
 				}
 				rep.Failed = append(rep.Failed, FileError{Path: reportPath(sourcePath), Err: err})
 				progress.report(*rep, false)
-				if _, rootFailed := dirErrs[walkRoot]; rootFailed {
+				if _, rootFailed := directoryErrors[walkRoot]; rootFailed {
 					return fs.SkipAll
 				}
 				return fs.SkipDir
 			}
-			if err := ing.addOne(ctx, rep, ingestRun, parentID, p, sourcePath, replace, progress); err != nil {
+			if err := files.addOne(
+				ctx, rep, parent, p, sourcePath, replace, progress,
+			); err != nil {
 				return err
 			}
 		default:
@@ -643,44 +673,217 @@ func (ing *Ingester) addTree(
 		}
 		return nil
 	})
-	return walkErr
 }
 
-func (ing *Ingester) ensureSourceDir(
-	ctx context.Context, dirIDs map[string]int64, dirErrs map[string]error,
-	destDirID int64, topName, walkRoot, dirPath string,
-) (int64, error) {
-	if id, ok := dirIDs[dirPath]; ok {
-		return id, nil
+func (files *filesystemIngest) prepareSourceDirectory(
+	ctx context.Context, parent *ingestDirectory, name, sourcePath string,
+) (*ingestDirectory, error) {
+	if parent.plan == nil {
+		directory, err := files.ing.Store.EnsureDir(ctx, parent.id, name)
+		if err != nil {
+			return nil, fmt.Errorf("creating virtual dir %q under node %d: %w", name, parent.id, err)
+		}
+		return &ingestDirectory{sourcePath: sourcePath, id: directory.ID}, nil
 	}
-	if err, ok := dirErrs[dirPath]; ok {
-		return 0, err
+	plan, err := files.ing.Store.ExtendIngestDirectory(ctx, *parent.plan, name)
+	if err != nil {
+		return nil, fmt.Errorf("preparing virtual dir %q: %w", name, err)
 	}
-	rel, err := filepath.Rel(walkRoot, dirPath)
+	directory := &ingestDirectory{sourcePath: sourcePath, plan: &plan}
+	files.directories = append(files.directories, directory)
+	return directory, nil
+}
+
+func (files *filesystemIngest) ensureSourceDirectory(
+	ctx context.Context,
+	directories map[string]*ingestDirectory,
+	directoryErrors map[string]error,
+	topName, sourceRoot, walkRoot, directoryPath string,
+) (*ingestDirectory, error) {
+	if directory, ok := directories[directoryPath]; ok {
+		return directory, nil
+	}
+	if err, ok := directoryErrors[directoryPath]; ok {
+		return nil, err
+	}
+	rel, err := filepath.Rel(walkRoot, directoryPath)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		err = fmt.Errorf("source directory %q is outside traversal root %q", dirPath, walkRoot)
-		dirErrs[dirPath] = err
-		return 0, err
+		err = fmt.Errorf("source directory %q is outside traversal root %q", directoryPath, walkRoot)
+		directoryErrors[directoryPath] = err
+		return nil, err
 	}
-	parentID, name := destDirID, topName
-	if dirPath != walkRoot {
-		parentID, err = ing.ensureSourceDir(
-			ctx, dirIDs, dirErrs, destDirID, topName, walkRoot, filepath.Dir(dirPath),
+	parent, name := files.destination, topName
+	if directoryPath != walkRoot {
+		parent, err = files.ensureSourceDirectory(
+			ctx, directories, directoryErrors, topName, sourceRoot, walkRoot, filepath.Dir(directoryPath),
 		)
 		if err != nil {
-			dirErrs[dirPath] = err
-			return 0, err
+			directoryErrors[directoryPath] = err
+			return nil, err
 		}
-		name = filepath.Base(dirPath)
+		name = filepath.Base(directoryPath)
 	}
-	dir, err := ing.Store.EnsureDir(ctx, parentID, name)
+	directory, err := files.prepareSourceDirectory(
+		ctx, parent, name, sourceTreePath(sourceRoot, walkRoot, directoryPath),
+	)
 	if err != nil {
-		err = fmt.Errorf("creating virtual dir %q under node %d: %w", name, parentID, err)
-		dirErrs[dirPath] = err
-		return 0, err
+		directoryErrors[directoryPath] = err
+		return nil, err
 	}
-	dirIDs[dirPath] = dir.ID
-	return dir.ID, nil
+	directories[directoryPath] = directory
+	return directory, nil
+}
+
+func (files *filesystemIngest) addOne(
+	ctx context.Context,
+	rep *Report,
+	parent *ingestDirectory,
+	openPath, sourcePath string,
+	replace bool,
+	progress *progressTracker,
+) error {
+	added, resolution, err := files.importFile(
+		ctx, parent, openPath, sourcePath, replace, progress,
+	)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if store.IsInitialIngestAdmissionError(err) {
+			files.admissionRejected = true
+		}
+		rep.Failed = append(rep.Failed, FileError{Path: reportPath(sourcePath), Err: err})
+	} else {
+		files.applyResolution(resolution)
+		rep.IngestID = files.run.ID()
+		if added {
+			rep.Added++
+		} else {
+			rep.Skipped++
+		}
+	}
+	progress.report(*rep, false)
+	return nil
+}
+
+func (files *filesystemIngest) importFile(
+	ctx context.Context,
+	parent *ingestDirectory,
+	openPath, sourcePath string,
+	replace bool,
+	progress *progressTracker,
+) (added bool, resolution store.IngestDirectoryResolution, retErr error) {
+	if err := validateSourcePath(sourcePath); err != nil {
+		return false, resolution, err
+	}
+	var observed struct {
+		node    store.Node
+		present bool
+	}
+	var name string
+	if replace {
+		var err error
+		name, err = store.NormalizeName(filepath.Base(sourcePath))
+		if err != nil {
+			return false, resolution, fmt.Errorf("normalizing destination name for %s: %w", sourcePath, err)
+		}
+		parentID, resolved := parent.id, true
+		if parent.plan != nil {
+			parentID, resolved = parent.plan.ResolvedID()
+		}
+		if resolved {
+			observed.node, err = files.ing.Store.ChildByName(ctx, parentID, name)
+			switch {
+			case err == nil:
+				observed.present = true
+				if observed.node.IsDir() {
+					return false, resolution, fmt.Errorf("destination %s: %w", sourcePath, store.ErrNotFile)
+				}
+			case errors.Is(err, store.ErrNotFound):
+			default:
+				return false, resolution, fmt.Errorf("resolving destination %s: %w", sourcePath, err)
+			}
+		}
+	}
+	content, err := files.ing.readLocalFile(ctx, openPath, sourcePath, progress, nil)
+	if err != nil {
+		return false, resolution, err
+	}
+	defer func() {
+		retErr = mutationCleanupResult(retErr, files.ing.cleanupLoose(content.hash))
+	}()
+	if replace {
+		if observed.present {
+			_, added, err = files.ing.Store.ReplaceContentForIngest(
+				ctx, files.run, observed.node.ID, observed.node.Revision,
+				content.hash, content.size, content.mimeType, sourcePath, content.mtime,
+				content.physical,
+			)
+			if err != nil {
+				return false, resolution, fmt.Errorf("recording %s: %w", sourcePath, err)
+			}
+			return added, resolution, nil
+		}
+		if parent.plan == nil {
+			_, err = files.ing.Store.IngestFileExact(
+				ctx, files.run, parent.id, filepath.Base(sourcePath), content.hash,
+				content.size, content.mimeType, sourcePath, content.mtime, content.physical,
+			)
+		} else {
+			_, resolution, err = files.ing.Store.IngestFileExactPlanned(
+				ctx, files.run, *parent.plan, filepath.Base(sourcePath), content.hash,
+				content.size, content.mimeType, sourcePath, content.mtime, content.physical,
+			)
+		}
+		if err != nil {
+			return false, resolution, fmt.Errorf("recording %s: %w", sourcePath, err)
+		}
+		return true, resolution, nil
+	}
+	if parent.plan == nil {
+		_, added, err = files.ing.Store.IngestFileWithMembership(
+			ctx, files.run, parent.id, filepath.Base(sourcePath), content.hash, content.size,
+			content.mimeType, sourcePath, content.mtime, content.physical,
+		)
+	} else {
+		_, added, resolution, err = files.ing.Store.IngestFileWithMembershipPlanned(
+			ctx, files.run, *parent.plan, filepath.Base(sourcePath), content.hash, content.size,
+			content.mimeType, sourcePath, content.mtime, content.physical,
+		)
+	}
+	if err != nil {
+		return false, resolution, fmt.Errorf("recording %s: %w", sourcePath, err)
+	}
+	return added, resolution, nil
+}
+
+func (files *filesystemIngest) finalize(
+	ctx context.Context, rep *Report, progress *progressTracker,
+) error {
+	if files.destination.plan == nil || files.admissionRejected && rep.IngestID == "" {
+		return nil
+	}
+	plans := make([]store.IngestDirectoryPlan, len(files.directories))
+	for i, directory := range files.directories {
+		plans[i] = *directory.plan
+	}
+	resolutions, err := files.ing.Store.FinalizeIngestDirectories(ctx, files.run, plans)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		path := files.destination.sourcePath
+		if directoryErr, ok := errors.AsType[*store.IngestDirectoryError](err); ok {
+			path = files.directories[directoryErr.Index].sourcePath
+		}
+		rep.Failed = append(rep.Failed, FileError{Path: reportPath(path), Err: err})
+		progress.report(*rep, false)
+		return nil
+	}
+	for _, resolution := range resolutions {
+		files.applyResolution(resolution)
+	}
+	return nil
 }
 
 func sourceTreePath(sourceRoot, walkRoot, walkPath string) string {
@@ -689,107 +892,6 @@ func sourceTreePath(sourceRoot, walkRoot, walkPath string) string {
 		return sourceRoot
 	}
 	return filepath.Join(sourceRoot, rel)
-}
-
-// addOne imports a single regular file; failures land in the report.
-func (ing *Ingester) addOne(
-	ctx context.Context,
-	rep *Report,
-	ingestRun store.IngestRun,
-	parentID int64,
-	openPath, sourcePath string,
-	replace bool,
-	progress *progressTracker,
-) error {
-	added, err := ing.importFile(ctx, ingestRun, parentID, openPath, sourcePath, replace, progress)
-	switch {
-	case err != nil:
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
-		rep.Failed = append(rep.Failed, FileError{Path: reportPath(sourcePath), Err: err})
-	case added:
-		rep.Added++
-	default:
-		rep.Skipped++
-	}
-	progress.report(*rep, false)
-	return nil
-}
-
-func (ing *Ingester) importFile(
-	ctx context.Context,
-	ingestRun store.IngestRun,
-	parentID int64,
-	openPath, sourcePath string,
-	replace bool,
-	progress *progressTracker,
-) (added bool, retErr error) {
-	if err := validateSourcePath(sourcePath); err != nil {
-		return false, err
-	}
-	var observed struct {
-		node    store.Node
-		present bool
-	}
-	var name string
-	var err error
-	if replace {
-		name, err = store.NormalizeName(filepath.Base(sourcePath))
-		if err != nil {
-			return false, fmt.Errorf("normalizing destination name for %s: %w", sourcePath, err)
-		}
-		observed.node, err = ing.Store.ChildByName(ctx, parentID, name)
-		switch {
-		case err == nil:
-			observed.present = true
-			if observed.node.IsDir() {
-				return false, fmt.Errorf("destination %s: %w", sourcePath, store.ErrNotFile)
-			}
-		case errors.Is(err, store.ErrNotFound):
-		default:
-			return false, fmt.Errorf("resolving destination %s: %w", sourcePath, err)
-		}
-	}
-	content, err := ing.readLocalFile(ctx, openPath, sourcePath, progress, nil)
-	if err != nil {
-		return false, err
-	}
-	defer func() {
-		retErr = mutationCleanupResult(retErr, ing.cleanupLoose(content.hash))
-	}()
-	if replace {
-		if observed.present {
-			if content.hash == observed.node.BlobHash && content.size == observed.node.Size {
-				_, err = ing.Store.ConfirmContentWithReceipt(ctx, observed.node.ID,
-					observed.node.Revision, content.hash, content.size, observed.node.MimeType,
-					content.physical)
-				if err != nil {
-					return false, fmt.Errorf("recording %s: %w", sourcePath, err)
-				}
-				return false, nil
-			}
-			_, _, err = ing.Store.ReplaceContent(ctx, observed.node.ID, observed.node.Revision,
-				content.hash, content.size, content.mimeType, content.physical)
-			if err != nil {
-				return false, fmt.Errorf("recording %s: %w", sourcePath, err)
-			}
-			return true, nil
-		}
-		_, err = ing.Store.IngestFileExact(ctx, ingestRun, parentID, filepath.Base(sourcePath), content.hash,
-			content.size, content.mimeType, sourcePath, content.mtime, content.physical)
-		if err != nil {
-			return false, fmt.Errorf("recording %s: %w", sourcePath, err)
-		}
-		return true, nil
-	}
-	_, added, err = ing.Store.IngestFile(ctx, ingestRun, parentID,
-		filepath.Base(sourcePath), content.hash, content.size, content.mimeType,
-		sourcePath, content.mtime, content.physical)
-	if err != nil {
-		return false, fmt.Errorf("recording %s: %w", sourcePath, err)
-	}
-	return added, nil
 }
 
 type localFileContent struct {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -195,17 +195,21 @@ func TestAddReplaceVersionsDestinationWithoutSuffix(t *testing.T) {
 	rep, err = ing.AddPathsWithOptions(ctx, []string{path}, "/inbox", Options{Replace: true})
 	require.NoError(t, err)
 	assert.Equal(t, 1, rep.Added)
+	require.NotEmpty(t, rep.IngestID)
 	assert.Empty(t, rep.Failed)
 	updated, err := ing.Store.NodeByPath(ctx, "/inbox/notes.txt")
 	require.NoError(t, err)
 	assert.Equal(t, original.ID, updated.ID)
-	assert.Equal(t, original.Revision+1, updated.Revision)
+	assert.Equal(t, original.Revision+2, updated.Revision)
 	_, err = ing.Store.NodeByPath(ctx, "/inbox/notes (2).txt")
 	require.ErrorIs(t, err, store.ErrNotFound)
 	versions, total, err := ing.Store.ContentVersions(ctx, original.ID, 10, 0)
 	require.NoError(t, err)
 	assert.Equal(t, 2, total)
 	assert.Equal(t, "content_replace", versions[0].TransitionKind)
+	collection, err := ing.Store.CollectionByID(ctx, rep.IngestID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), collection.FileCount)
 }
 
 func TestAddWithoutReplaceStillSuffixesChangedContent(t *testing.T) {
@@ -228,11 +232,11 @@ func TestAddReplaceSkipsUnchangedBytesAndStoredMIME(t *testing.T) {
 	ing := newTestIngester(t)
 	ctx := t.Context()
 	content := []byte("same bytes")
-	src := filepath.Join(t.TempDir(), "notes.bin")
+	src := filepath.Join(t.TempDir(), "notes.txt")
 	require.NoError(t, os.WriteFile(src, content, 0o644))
 	written, err := ing.Blobs.WriteDetailedContext(ctx, bytes.NewReader(content))
 	require.NoError(t, err)
-	original, err := ing.Store.CreateFile(ctx, ing.Store.RootID(), "notes.bin",
+	original, err := ing.Store.CreateFile(ctx, ing.Store.RootID(), "notes.txt",
 		written.Hash, written.Size, "application/octet-stream")
 	require.NoError(t, err)
 
@@ -240,14 +244,123 @@ func TestAddReplaceSkipsUnchangedBytesAndStoredMIME(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, rep.Added)
 	assert.Equal(t, 1, rep.Skipped)
+	require.NotEmpty(t, rep.IngestID)
 	assert.Empty(t, rep.Failed)
 	unchanged, err := ing.Store.NodeByID(ctx, original.ID)
 	require.NoError(t, err)
-	assert.Equal(t, original.Revision, unchanged.Revision)
+	assert.Equal(t, original.Revision+1, unchanged.Revision)
 	assert.Equal(t, "application/octet-stream", unchanged.MimeType)
 	_, total, err := ing.Store.ContentVersions(ctx, original.ID, 10, 0)
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
+	collection, err := ing.Store.CollectionByID(ctx, rep.IngestID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), collection.FileCount)
+}
+
+func TestLabeledEmptyTreeCreatesDirectoriesWithoutReceipt(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	source := filepath.Join(t.TempDir(), "empty-source")
+	require.NoError(t, os.MkdirAll(filepath.Join(source, "nested", "empty"), 0o755))
+	label := "Empty tree"
+
+	rep, err := ing.AddPathsWithOptions(ctx, []string{source}, "/new/inbox", Options{
+		CollectionLabel: &label,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, rep.IngestID)
+	assert.Zero(t, rep.Added)
+	assert.Empty(t, rep.Failed)
+	_, err = ing.Store.NodeByPath(ctx, "/new/inbox/empty-source/nested/empty")
+	require.NoError(t, err)
+	var metadata bytes.Buffer
+	require.NoError(t, ing.Store.ExportMetadata(ctx, &metadata))
+	assert.NotContains(t, metadata.String(), `"type":"collection_label"`)
+	assert.NotContains(t, metadata.String(), `"source_desc":`)
+}
+
+func TestLabeledEmptyTreeAdmissionFailureLeavesNoDirectories(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		setup func(*testing.T, *Ingester, *string)
+		want  error
+	}{
+		{
+			name: "label collision",
+			setup: func(t *testing.T, ing *Ingester, label *string) {
+				t.Helper()
+				run, err := ing.Store.BeginIngestWithLabel(t.Context(), "cli", "winner", label)
+				require.NoError(t, err)
+				_, _, err = ing.Store.IngestFileWithMembership(
+					t.Context(), run, ing.Store.RootID(), "winner.txt", fakeIngestHash("a1"), 1,
+					"text/plain", "/synthetic/winner.txt", "",
+				)
+				require.NoError(t, err)
+			},
+			want: store.ErrExists,
+		},
+		{
+			name: "active audit",
+			setup: func(t *testing.T, ing *Ingester, _ *string) {
+				t.Helper()
+				plan, err := ing.Store.PreviewInitialAudit(t.Context(), ing.Store.RootID(), "api", nil)
+				require.NoError(t, err)
+				_, err = ing.Store.EnableInitialAudit(t.Context(), plan)
+				require.NoError(t, err)
+			},
+			want: store.ErrAuditMutationUnsupported,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ing := newTestIngester(t)
+			label := "Empty rejection"
+			test.setup(t, ing, &label)
+			source := filepath.Join(t.TempDir(), "empty-source")
+			require.NoError(t, os.MkdirAll(filepath.Join(source, "nested"), 0o755))
+
+			rep, err := ing.AddPathsWithOptions(
+				t.Context(), []string{source}, "/new/inbox", Options{CollectionLabel: &label},
+			)
+			require.NoError(t, err)
+			assert.Empty(t, rep.IngestID)
+			require.Len(t, rep.Failed, 1)
+			require.ErrorIs(t, rep.Failed[0].Err, test.want)
+			assert.Equal(t, "/new/inbox", rep.Failed[0].Path)
+			_, err = ing.Store.NodeByPath(t.Context(), "/new")
+			require.ErrorIs(t, err, store.ErrNotFound)
+		})
+	}
+}
+
+func TestFinalizeDirectoriesReportsTheFailingSource(t *testing.T) {
+	ing := newTestIngester(t)
+	ctx := t.Context()
+	first, err := ing.Store.Mkdir(ctx, ing.Store.RootID(), "first")
+	require.NoError(t, err)
+	later, err := ing.Store.Mkdir(ctx, ing.Store.RootID(), "later")
+	require.NoError(t, err)
+	destination, err := ing.Store.PrepareIngestDirectory(ctx, "/")
+	require.NoError(t, err)
+	run, err := ing.Store.BeginIngestWithLabel(ctx, "cli", "empty trees", new("Empty trees"))
+	require.NoError(t, err)
+	planned := &filesystemIngest{
+		ing: ing, run: run,
+		destination: &ingestDirectory{sourcePath: "/", plan: &destination},
+	}
+	planned.directories = append(planned.directories, planned.destination)
+	_, err = planned.prepareSourceDirectory(ctx, planned.destination, first.Name, "/synthetic/first")
+	require.NoError(t, err)
+	_, err = planned.prepareSourceDirectory(ctx, planned.destination, later.Name, "/synthetic/later")
+	require.NoError(t, err)
+	_, _, err = ing.Store.Trash(ctx, later.ID, later.Revision)
+	require.NoError(t, err)
+
+	var rep Report
+	require.NoError(t, planned.finalize(ctx, &rep, nil))
+	require.Len(t, rep.Failed, 1)
+	require.ErrorIs(t, rep.Failed[0].Err, store.ErrNotFound)
+	assert.Equal(t, "/synthetic/later", rep.Failed[0].Path)
 }
 
 func TestAddReplaceFailsBeforeSourceReadForDirectory(t *testing.T) {
@@ -257,7 +370,8 @@ func TestAddReplaceFailsBeforeSourceReadForDirectory(t *testing.T) {
 	require.NoError(t, err)
 	run, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
-	_, err = ing.importFile(ctx, run, ing.Store.RootID(), filepath.Join(t.TempDir(), "missing"),
+	files := &filesystemIngest{ing: ing, run: run}
+	_, _, err = files.importFile(ctx, &ingestDirectory{id: ing.Store.RootID()}, filepath.Join(t.TempDir(), "missing"),
 		"/synthetic/missing/notes.txt", true, nil)
 	assert.ErrorIs(t, err, store.ErrNotFile)
 }
@@ -824,7 +938,8 @@ func TestAddTreeStaleDestinationIsNotResurrected(t *testing.T) {
 	var rep Report
 	selection, err := compileSourceSelection(Options{Include: []string{"*.txt"}})
 	require.NoError(t, err)
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, selection, false, nil))
+	files := &filesystemIngest{ing: ing, run: ingestID, destination: &ingestDirectory{id: dest.ID}}
+	require.NoError(t, files.addTree(ctx, &rep, src, src, selection, false, nil))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 
@@ -844,7 +959,8 @@ func TestAddTreeStaleDestinationDefaultSelectionDoesNotResurrect(t *testing.T) {
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
 	var rep Report
-	require.NoError(t, ing.addTree(ctx, &rep, ingestID, dest.ID, src, src, sourceSelection{}, false, nil))
+	files := &filesystemIngest{ing: ing, run: ingestID, destination: &ingestDirectory{id: dest.ID}}
+	require.NoError(t, files.addTree(ctx, &rep, src, src, sourceSelection{}, false, nil))
 	assert.NotEmpty(t, rep.Failed)
 	assert.Zero(t, rep.Added)
 	_, err = ing.Store.NodeByPath(ctx, "/inbox")
@@ -857,9 +973,10 @@ func TestEnsureSourceDirRejectsPathOutsideWalkRoot(t *testing.T) {
 		ing := newTestIngester(t)
 		walkRoot := filepath.Join(t.TempDir(), "root")
 		dirPath := filepath.Join(filepath.Dir(walkRoot), "outside", "nested")
-		_, err := ing.ensureSourceDir(
-			t.Context(), map[string]int64{}, map[string]error{}, ing.Store.RootID(),
-			"source", walkRoot, dirPath,
+		files := &filesystemIngest{ing: ing, destination: &ingestDirectory{id: ing.Store.RootID()}}
+		_, err := files.ensureSourceDirectory(
+			t.Context(), map[string]*ingestDirectory{}, map[string]error{},
+			"source", walkRoot, walkRoot, dirPath,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "outside traversal root")

--- a/internal/ingest/ingest_unix_test.go
+++ b/internal/ingest/ingest_unix_test.go
@@ -27,7 +27,8 @@ func TestImportRefusesSymlinkAtOpen(t *testing.T) {
 	// are skipped" has to hold at the point the file is opened for reading.
 	ingestID, err := ing.Store.BeginIngest(ctx, "cli", "test")
 	require.NoError(t, err)
-	_, err = ing.importFile(ctx, ingestID, ing.Store.RootID(), link, link, false, nil)
+	files := &filesystemIngest{ing: ing, run: ingestID}
+	_, _, err = files.importFile(ctx, &ingestDirectory{id: ing.Store.RootID()}, link, link, false, nil)
 	require.Error(t, err)
 }
 
@@ -42,7 +43,8 @@ func TestAddOneRejectsNonUTF8SourcePathWithoutPoisoningMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	var rep Report
-	require.NoError(t, ing.addOne(t.Context(), &rep, ingestID, ing.Store.RootID(), openPath, badPath, false, nil))
+	files := &filesystemIngest{ing: ing, run: ingestID}
+	require.NoError(t, files.addOne(t.Context(), &rep, &ingestDirectory{id: ing.Store.RootID()}, openPath, badPath, false, nil))
 	assert.Zero(t, rep.Added)
 	require.Len(t, rep.Failed, 1)
 	assert.Equal(t, strconv.QuoteToASCII(badPath), rep.Failed[0].Path)

--- a/internal/ingest/preflight.go
+++ b/internal/ingest/preflight.go
@@ -23,8 +23,9 @@ const (
 // Patterns use path.Match syntax over source-relative slash paths. A pattern
 // without a slash matches a basename anywhere; exclusions take precedence.
 type Options struct {
-	Include []string
-	Exclude []string
+	Include         []string
+	Exclude         []string
+	CollectionLabel *string
 	// Replace versions the live file already at a source's destination path
 	// instead of importing the source under an auto-suffixed name. Preflight
 	// ignores it because it never resolves a destination.

--- a/internal/store/audit_history_validate.go
+++ b/internal/store/audit_history_validate.go
@@ -394,7 +394,7 @@ func validateAuditedHistory(
 					if len(mutationScopeIDs) != 1 {
 						err = errors.New("cross-scope provenance mutation is unsupported")
 					} else {
-						err = replay.applyProvenanceAppend(
+						err = replay.applyProvenanceMutation(
 							vaultID, mutation, allocation, scopeEntry,
 							attachmentDeltas, events, usedAttachmentDeltas, usedEvents,
 						)

--- a/internal/store/audit_ingest_observation.go
+++ b/internal/store/audit_ingest_observation.go
@@ -1,0 +1,184 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"unicode/utf8"
+
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func persistAuditedIngestObservation(
+	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
+	nodeSequence int64, authority auditAuthorityState, scopes []auditScopeState,
+	priorNode, resultingNode Node, ingest metadataIngest, provenance metadataProvenance,
+	ingestAdded bool,
+) error {
+	if sourceKindIsEmbedded(ingest.SourceKind) {
+		return errors.New("audited ingest observation requires an operational source kind")
+	}
+	if provenance.Supersedes != nil {
+		return errors.New("audited ingest observation cannot supersede provenance")
+	}
+	if priorNode.ID != resultingNode.ID || priorNode.CurrentVersionID != resultingNode.CurrentVersionID {
+		return errors.New("audited ingest observation changes content identity")
+	}
+	return persistAuditedProvenanceMutation(
+		ctx, tx, vaultID, operationID, recordedAt, nodeSequence, authority, scopes,
+		priorNode, resultingNode, ingest, provenance, "ingest_observe", ingestAdded,
+	)
+}
+
+func auditedMutationFirstEventKind(mutation audit.Record) (string, error) {
+	events, err := auditRecordListField(mutation, "events")
+	if err != nil || len(events) == 0 {
+		return "", errors.New("attached-metadata mutation must contain an event")
+	}
+	return auditTextField(events[0], "event_kind")
+}
+
+func (replay *auditedHistoryReplay) validateIngestObservationDelta(
+	mutation audit.Record, operationID string,
+	deltaRecords map[string]storedAuditRecord, usedDeltas map[string]bool,
+) (replayedProvenanceMutation, error) {
+	digest, err := auditDigestField(mutation, "attached_metadata_change_digest")
+	if err != nil {
+		return replayedProvenanceMutation{}, err
+	}
+	delta, ok := deltaRecords[digest]
+	if !ok || usedDeltas[digest] {
+		return replayedProvenanceMutation{}, errors.New("ingest observation lacks one unique attached-metadata delta")
+	}
+	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
+		return replayedProvenanceMutation{}, err
+	}
+	changes, err := auditRecordListField(delta.record, "changes")
+	if err != nil || len(changes) < 1 || len(changes) > 2 {
+		return replayedProvenanceMutation{}, errors.New("ingest observation must contain one fact and an optional ingest")
+	}
+	var provenance, ingest audit.Record
+	for _, change := range changes {
+		post, err := validateAuditedIngestAddition(change)
+		if err != nil {
+			return replayedProvenanceMutation{}, err
+		}
+		switch post.Kind {
+		case metadataProvenanceType:
+			if provenance.Kind != "" {
+				return replayedProvenanceMutation{}, errors.New("ingest observation repeats its fact change")
+			}
+			provenance = post
+		case metadataIngestType:
+			if ingest.Kind != "" {
+				return replayedProvenanceMutation{}, errors.New("ingest observation repeats its ingest change")
+			}
+			ingest = post
+		default:
+			return replayedProvenanceMutation{}, fmt.Errorf(
+				"ingest observation carries unsupported attachment %q", post.Kind,
+			)
+		}
+	}
+	if provenance.Kind == "" {
+		return replayedProvenanceMutation{}, errors.New("ingest observation lacks its fact change")
+	}
+	ingestID, err := auditUUIDField(provenance, "ingest_id")
+	if err != nil {
+		return replayedProvenanceMutation{}, err
+	}
+	ingestAdded := ingest.Kind != ""
+	if ingestAdded {
+		if err := requireAuditUUID(ingest, "ingest_id", ingestID); err != nil {
+			return replayedProvenanceMutation{}, err
+		}
+		key, err := attachedAuditKey(ingest)
+		if err != nil {
+			return replayedProvenanceMutation{}, err
+		}
+		if _, exists := replay.attachments[key]; exists {
+			return replayedProvenanceMutation{}, errors.New("ingest observation reuses ingest identity")
+		}
+	} else {
+		ingest, err = replay.ingestAttachment(ingestID)
+		if err != nil {
+			return replayedProvenanceMutation{}, err
+		}
+	}
+	if err := validateReplayedOperationalIngest(ingest); err != nil {
+		return replayedProvenanceMutation{}, err
+	}
+	if err := validateReplayedProvenance(provenance, ingestID); err != nil {
+		return replayedProvenanceMutation{}, err
+	}
+	if supersedes, err := auditOptionalDigestField(provenance, "supersedes"); err != nil {
+		return replayedProvenanceMutation{}, err
+	} else if supersedes != nil {
+		return replayedProvenanceMutation{}, errors.New("ingest observation cannot supersede provenance")
+	}
+	nodeID, err := auditUnsignedField(provenance, metadataNodeIDField)
+	if err != nil || !replay.memberSet[nodeID] {
+		return replayedProvenanceMutation{}, fmt.Errorf("ingest observation targets unaudited node %d", nodeID)
+	}
+	topologyIndex, ok := replay.topologyIndex[nodeID]
+	if !ok {
+		return replayedProvenanceMutation{}, fmt.Errorf("ingest observation target %d is absent from topology", nodeID)
+	}
+	topology := replay.topology[topologyIndex]
+	state, err := auditTextField(topology, auditStateField)
+	if err != nil {
+		return replayedProvenanceMutation{}, err
+	}
+	if state != auditNodeStateLive {
+		return replayedProvenanceMutation{}, fmt.Errorf(
+			"ingest observation targets non-live node %d", nodeID,
+		)
+	}
+	nodeKind, err := auditTextField(topology, "node_kind")
+	if err != nil {
+		return replayedProvenanceMutation{}, err
+	}
+	if nodeKind != nodeKindFile {
+		return replayedProvenanceMutation{}, fmt.Errorf("ingest observation targets non-file node %d", nodeID)
+	}
+	key, err := attachedAuditKey(provenance)
+	if err != nil {
+		return replayedProvenanceMutation{}, err
+	}
+	if _, exists := replay.attachments[key]; exists {
+		return replayedProvenanceMutation{}, errors.New("ingest observation reuses provenance identity")
+	}
+	usedDeltas[digest] = true
+	return replayedProvenanceMutation{
+		nodeID: nodeID, ingest: ingest, provenance: provenance,
+		digest: digest, ingestAdded: ingestAdded, eventKind: "ingest_observe",
+	}, nil
+}
+
+func validateReplayedOperationalIngest(record audit.Record) error {
+	if record.Kind != metadataIngestType {
+		return errors.New("ingest observation has the wrong ingest record kind")
+	}
+	if _, err := auditUUIDField(record, "ingest_id"); err != nil {
+		return err
+	}
+	if _, err := auditTimestampField(record, "started_at"); err != nil {
+		return err
+	}
+	sourceKind, err := auditTextField(record, "source_kind")
+	if err != nil {
+		return err
+	}
+	if sourceKind == "" || sourceKindIsEmbedded(sourceKind) {
+		return errors.New("ingest observation requires an operational source kind")
+	}
+	description, err := auditField(record, "source_desc")
+	if err != nil {
+		return err
+	}
+	if value, ok := description.BytesValue(); !ok || len(value) == 0 || !utf8.Valid(value) {
+		return errors.New("ingest observation has invalid source description")
+	}
+	return nil
+}

--- a/internal/store/audit_ingest_observation_test.go
+++ b/internal/store/audit_ingest_observation_test.go
@@ -1,0 +1,423 @@
+package store
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/audit"
+)
+
+func TestAuditedOperationalObservationsReplayOneOrTwoAttachments(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	priorRun, err := s.BeginIngest(t.Context(), "filesystem", "First synthetic import")
+	require.NoError(t, err)
+	priorSecond, added, err := s.IngestFile(
+		t.Context(), priorRun, scope.ID, "second.txt", fakeHash("c3"), 9,
+		"text/plain", "/synthetic/second.txt", "",
+	)
+	require.NoError(t, err)
+	require.True(t, added)
+	seedInitialAuditAuthority(t, s, scope.ID)
+
+	run, err := s.BeginIngest(t.Context(), "filesystem", "Second synthetic import")
+	require.NoError(t, err)
+	_, added, err = s.IngestFileWithMembership(
+		t.Context(), run, scope.ID, "report.txt", metadataHashCurrent, 12,
+		"text/plain", "/synthetic/report.txt", "",
+	)
+	require.NoError(t, err)
+	assert.False(t, added)
+	assert.Equal(t, "ingest_observe", auditEventKindForSequence(t, s, 2))
+
+	second, added, err := s.IngestFileWithMembership(
+		t.Context(), run, scope.ID, "second.txt", fakeHash("c3"), 9,
+		"text/plain", "/synthetic/second.txt", "",
+	)
+	require.NoError(t, err)
+	assert.False(t, added)
+	assert.Equal(t, priorSecond.ID, second.ID)
+	assert.Equal(t, priorSecond.CurrentVersionID, second.CurrentVersionID)
+	assert.Equal(t, priorSecond.Revision+1, second.Revision)
+	assert.Equal(t, "ingest_observe", auditEventKindForSequence(t, s, 3))
+
+	var sequence int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`,
+	).Scan(&sequence))
+	assert.Equal(t, int64(3), sequence)
+	assert.Equal(t, []uint64{2, 1}, auditAttachmentCountsAfterEnrollment(t, s, 3))
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, exported.Bytes(), roundTrip.Bytes())
+}
+
+func auditAttachmentCountsAfterEnrollment(t *testing.T, s *Store, sequence int64) []uint64 {
+	t.Helper()
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], sequence)
+	require.NoError(t, err)
+	result := make([]uint64, 0, sequence-1)
+	for current := int64(2); current <= sequence; current++ {
+		count, err := auditUnsignedField(
+			mutations[current].record, auditAttachedMetadataChangeCountField,
+		)
+		require.NoError(t, err)
+		result = append(result, count)
+	}
+	return result
+}
+
+func TestOperationalObservationRejectsCallerSuppliedSource(t *testing.T) {
+	s := newTestStore(t)
+	run, err := s.BeginCallerSuppliedIngest(t.Context(), "agent", "Synthetic assertion")
+	require.NoError(t, err)
+	_, _, err = s.IngestFileWithMembership(
+		t.Context(), run, s.RootID(), "note.txt", fakeHash("a1"), 4,
+		"text/plain", "opaque://note", "",
+	)
+	require.ErrorContains(t, err, "rejects source kind")
+	var ingests int64
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM ingests WHERE id=?`, run.ID()).Scan(&ingests))
+	assert.Zero(t, ingests)
+}
+
+func TestAuditedReplacementForIngestRecordsBothTransitions(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	file, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	run, err := s.BeginIngest(t.Context(), "filesystem", "Replacement import")
+	require.NoError(t, err)
+
+	receipt, changed, err := s.ReplaceContentForIngest(
+		t.Context(), run, file.ID, file.Revision, fakeHash("b2"), 8,
+		"text/markdown", "/synthetic/report.txt", "",
+	)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, file.Revision+2, receipt.Node.Revision)
+	assert.Equal(t, []string{"content_replace", "ingest_observe"},
+		auditEventKindsAfterEnrollment(t, s, 3))
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func auditEventKindsAfterEnrollment(t *testing.T, s *Store, sequence int64) []string {
+	t.Helper()
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], sequence)
+	require.NoError(t, err)
+	result := make([]string, 0, sequence-1)
+	for current := int64(2); current <= sequence; current++ {
+		events, err := auditRecordListField(mutations[current].record, "events")
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+		kind, err := auditTextField(events[0], "event_kind")
+		require.NoError(t, err)
+		result = append(result, kind)
+	}
+	return result
+}
+
+func TestAuditedObservationRejectsInitialLabelWithoutChangingAuthority(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	file, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	label := "Forbidden label"
+	run, err := s.BeginIngestWithLabel(t.Context(), "filesystem", "Labeled import", &label)
+	require.NoError(t, err)
+
+	_, _, err = s.IngestFileWithMembership(
+		t.Context(), run, scope.ID, "report.txt", metadataHashCurrent, 12,
+		"text/plain", "/synthetic/report.txt", "",
+	)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	unchanged, err := s.NodeByID(t.Context(), file.ID)
+	require.NoError(t, err)
+	assert.Equal(t, file, unchanged)
+	var sequence, ingests int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM ingests WHERE id=?)`, run.ID()).Scan(&sequence, &ingests))
+	assert.Equal(t, int64(1), sequence)
+	assert.Zero(t, ingests)
+}
+
+func TestAuditedObservationRollsBackRunFactAndRevision(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scope, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	file, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scope.ID)
+	run, err := s.BeginIngest(t.Context(), "filesystem", "Rollback import")
+	require.NoError(t, err)
+	require.NoError(t, createAuditScopeFailureTrigger(s))
+
+	_, _, err = s.IngestFileWithMembership(
+		t.Context(), run, scope.ID, "report.txt", metadataHashCurrent, 12,
+		"text/plain", "/synthetic/report.txt", "",
+	)
+	require.ErrorContains(t, err, "forced audited provenance failure")
+	unchanged, err := s.NodeByID(t.Context(), file.ID)
+	require.NoError(t, err)
+	assert.Equal(t, file, unchanged)
+	var sequence, ingests, facts int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM ingests WHERE id=?),
+		(SELECT COUNT(*) FROM provenance WHERE ingest_id=?)`, run.ID(), run.ID()).Scan(
+		&sequence, &ingests, &facts,
+	))
+	assert.Equal(t, int64(1), sequence)
+	assert.Zero(t, ingests)
+	assert.Zero(t, facts)
+}
+
+func TestIngestObservationReplayRejectsTampering(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "source.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	seedMetadataRoundTrip(t, s)
+	scopeNode, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	observedNode, err := s.NodeByPath(t.Context(), "/Projects/report.txt")
+	require.NoError(t, err)
+	seedInitialAuditAuthority(t, s, scopeNode.ID)
+	run, err := s.BeginIngest(t.Context(), "filesystem", "Synthetic replay")
+	require.NoError(t, err)
+	_, _, err = s.IngestFileWithMembership(
+		t.Context(), run, scopeNode.ID, "report.txt", metadataHashCurrent, 12,
+		"text/plain", "/synthetic/report.txt", "",
+	)
+	require.NoError(t, err)
+
+	authority, scope, err := loadInitialAuditProjection(t.Context(), s.db)
+	require.NoError(t, err)
+	records, err := loadInitialAuditRecords(t.Context(), s.db)
+	require.NoError(t, err)
+	initial, err := selectInitialAuditRecords(authority, scope, records)
+	require.NoError(t, err)
+	mutations, err := auditRecordsByOptionalSequence(records["canonical_mutation"], authority.sequence)
+	require.NoError(t, err)
+	mutation := mutations[2]
+	operationID, err := auditUUIDField(mutation.record, auditOperationIDField)
+	require.NoError(t, err)
+	deltas := auditRecordsByDigest(records["attached_metadata_delta"])
+	digest, err := auditDigestField(mutation.record, "attached_metadata_change_digest")
+	require.NoError(t, err)
+	delta := deltas[digest]
+	changes, err := auditRecordListField(delta.record, "changes")
+	require.NoError(t, err)
+
+	t.Run("trashed target", func(t *testing.T) {
+		allocations, err := auditRecordsBySequence(records["allocation_entry"], authority.sequence)
+		require.NoError(t, err)
+		entries, err := auditScopeRecordsByScope(
+			records["scope_chain_entry"], []initialAuditScope{scope},
+		)
+		require.NoError(t, err)
+		events := mustAuditEventRecordsByID(t, records[auditEventField])
+
+		liveReplay, err := newAuditedHistoryReplay(authority, scope, initial)
+		require.NoError(t, err)
+		require.NoError(t, liveReplay.applyProvenanceMutation(
+			s.VaultID(), mutation, allocations[2], entries[scope.scopeID][2],
+			deltas, events, map[string]bool{}, map[string]bool{},
+		))
+
+		trashReplay, err := newAuditedHistoryReplay(authority, scope, initial)
+		require.NoError(t, err)
+		nodeID := uint64(observedNode.ID)
+		index, ok := trashReplay.topologyIndex[nodeID]
+		require.True(t, ok)
+		trashState, err := audit.Text(auditNodeStateTrash)
+		require.NoError(t, err)
+		trashReplay.topology[index] = mustReplaceAuditRecordField(
+			t, trashReplay.topology[index], auditStateField, trashState,
+		)
+		priorState := trashReplay.states[nodeID]
+		priorTopology := trashReplay.topology[index]
+		priorScopeHead := trashReplay.scopeHead
+		priorAllocationHead := trashReplay.allocationHead
+		priorScopeCount := trashReplay.scopeEntryCount
+		priorAllocationCount := trashReplay.allocationCount
+		priorAttachmentCount := len(trashReplay.attachments)
+		usedDeltas, usedEvents := map[string]bool{}, map[string]bool{}
+
+		err = trashReplay.applyProvenanceMutation(
+			s.VaultID(), mutation, allocations[2], entries[scope.scopeID][2],
+			deltas, events, usedDeltas, usedEvents,
+		)
+		require.ErrorContains(t, err, "targets non-live node")
+		assert.Equal(t, priorState, trashReplay.states[nodeID])
+		assert.Equal(t, priorTopology, trashReplay.topology[index])
+		assert.Equal(t, priorScopeHead, trashReplay.scopeHead)
+		assert.Equal(t, priorAllocationHead, trashReplay.allocationHead)
+		assert.Equal(t, priorScopeCount, trashReplay.scopeEntryCount)
+		assert.Equal(t, priorAllocationCount, trashReplay.allocationCount)
+		assert.Len(t, trashReplay.attachments, priorAttachmentCount)
+		assert.False(t, usedDeltas[digest])
+		assert.Empty(t, usedEvents)
+	})
+
+	t.Run("source kind", func(t *testing.T) {
+		tampered := append([]audit.Record(nil), changes...)
+		for index, change := range tampered {
+			kind, err := auditTextField(change, "record_kind")
+			require.NoError(t, err)
+			if kind != metadataIngestType {
+				continue
+			}
+			post, err := auditNestedField(change, auditPostField)
+			require.NoError(t, err)
+			post = mustReplaceAuditRecordField(t, post, "source_kind", mustAuditText(t, "embedded:filesystem"))
+			tampered[index] = mustReplaceAuditRecordField(t, change, auditPostField, audit.Nested(post))
+		}
+		tamperedDelta := delta
+		tamperedDelta.record = mustReplaceAuditRecordField(
+			t, delta.record, "changes", audit.List(auditNestedValues(tampered)...),
+		)
+		replay, err := newAuditedHistoryReplay(authority, scope, initial)
+		require.NoError(t, err)
+		_, err = replay.validateIngestObservationDelta(
+			mutation.record, operationID,
+			map[string]storedAuditRecord{digest: tamperedDelta}, map[string]bool{},
+		)
+		require.ErrorContains(t, err, "requires an operational source kind")
+	})
+
+	for _, testCase := range []struct {
+		name  string
+		field string
+		value audit.Value
+	}{
+		{name: "node identity", field: metadataNodeIDField, value: audit.Unsigned(999)},
+		{name: "supersedes", field: "supersedes", value: mustAuditDigest(t, fakeHash("abcd"))},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			tampered := append([]audit.Record(nil), changes...)
+			for index, change := range tampered {
+				kind, err := auditTextField(change, "record_kind")
+				require.NoError(t, err)
+				if kind != metadataProvenanceType {
+					continue
+				}
+				post, err := auditNestedField(change, auditPostField)
+				require.NoError(t, err)
+				post = mustReplaceAuditRecordField(t, post, testCase.field, testCase.value)
+				tampered[index] = mustReplaceAuditRecordField(t, change, auditPostField, audit.Nested(post))
+			}
+			tamperedDelta := delta
+			tamperedDelta.record = mustReplaceAuditRecordField(
+				t, delta.record, "changes", audit.List(auditNestedValues(tampered)...),
+			)
+			replay, err := newAuditedHistoryReplay(authority, scope, initial)
+			require.NoError(t, err)
+			_, err = replay.validateIngestObservationDelta(
+				mutation.record, operationID,
+				map[string]storedAuditRecord{digest: tamperedDelta}, map[string]bool{},
+			)
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("revision and version transition", func(t *testing.T) {
+		for _, testCase := range []struct {
+			name  string
+			field string
+			value audit.Value
+		}{
+			{name: "revision", field: "resulting_node_revision", value: audit.Unsigned(99)},
+			{name: "version", field: "resulting_current_version_id", value: mustAuditUUID(t, "99999999-9999-4999-8999-999999999999")},
+		} {
+			t.Run(testCase.name, func(t *testing.T) {
+				replay, err := newAuditedHistoryReplay(authority, scope, initial)
+				require.NoError(t, err)
+				transition, err := replay.validateIngestObservationDelta(
+					mutation.record, operationID, deltas, map[string]bool{},
+				)
+				require.NoError(t, err)
+				events, err := auditRecordListField(mutation.record, "events")
+				require.NoError(t, err)
+				tamperedEvent := mustReplaceAuditRecordField(t, events[0], testCase.field, testCase.value)
+				tamperedMutation := mustReplaceAuditRecordField(
+					t, mutation.record, "events", audit.List(audit.Nested(tamperedEvent)),
+				)
+				eventID, err := auditDigestField(tamperedEvent, "event_id")
+				require.NoError(t, err)
+				wrappers := map[string]storedAuditRecord{eventID: {record: audit.Record{
+					Kind:   auditEventField,
+					Fields: []audit.Field{{Name: auditEventField, Value: audit.Nested(tamperedEvent)}},
+				}}}
+				err = replay.validateProvenanceMutationEvent(
+					operationID, tamperedMutation, transition, wrappers, map[string]bool{},
+				)
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("attached record count", func(t *testing.T) {
+		replay, err := newAuditedHistoryReplay(authority, scope, initial)
+		require.NoError(t, err)
+		allocations, err := auditRecordsBySequence(records["allocation_entry"], authority.sequence)
+		require.NoError(t, err)
+		entries, err := auditScopeRecordsByScope(records["scope_chain_entry"], []initialAuditScope{scope})
+		require.NoError(t, err)
+		tampered := mutation
+		tampered.record = mustReplaceAuditRecordField(
+			t, mutation.record, auditAttachedMetadataChangeCountField, audit.Unsigned(1),
+		)
+		err = replay.applyProvenanceMutation(
+			s.VaultID(), tampered, allocations[2], entries[scope.scopeID][2],
+			deltas, mustAuditEventRecordsByID(t, records[auditEventField]), map[string]bool{}, map[string]bool{},
+		)
+		require.Error(t, err)
+	})
+}
+
+func mustAuditEventRecordsByID(t *testing.T, records []storedAuditRecord) map[string]storedAuditRecord {
+	t.Helper()
+	result, err := auditEventRecordsByID(records)
+	require.NoError(t, err)
+	return result
+}
+
+func mustAuditText(t *testing.T, value string) audit.Value {
+	t.Helper()
+	result, err := audit.Text(value)
+	require.NoError(t, err)
+	return result
+}

--- a/internal/store/audit_provenance.go
+++ b/internal/store/audit_provenance.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"unicode/utf8"
 
 	"go.kenn.io/docbank/internal/audit"
@@ -21,6 +20,22 @@ func persistAuditedProvenanceAppend(
 	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
 	nodeSequence int64, authority auditAuthorityState, scopes []auditScopeState,
 	priorNode, resultingNode Node, ingest metadataIngest, provenance metadataProvenance,
+) error {
+	eventKind := "provenance_add"
+	if provenance.Supersedes != nil {
+		eventKind = "provenance_supersede"
+	}
+	return persistAuditedProvenanceMutation(
+		ctx, tx, vaultID, operationID, recordedAt, nodeSequence, authority, scopes,
+		priorNode, resultingNode, ingest, provenance, eventKind, true,
+	)
+}
+
+func persistAuditedProvenanceMutation(
+	ctx context.Context, tx *sql.Tx, vaultID, operationID, recordedAt string,
+	nodeSequence int64, authority auditAuthorityState, scopes []auditScopeState,
+	priorNode, resultingNode Node, ingest metadataIngest, provenance metadataProvenance,
+	eventKind string, ingestAdded bool,
 ) error {
 	sequence, err := nextAuditInteger("operation sequence", authority.sequence)
 	if err != nil {
@@ -53,23 +68,20 @@ func persistAuditedProvenanceAppend(
 	if err != nil {
 		return err
 	}
-	// The ingest row and its provenance row are one logical assertion. Both
-	// become auditable attachments in the same mutation delta.
-	ingestChange, err := makeAttachedMetadataAddition(ingestRecord)
-	if err != nil {
-		return err
+	changes := make([]audit.Record, 0, 2)
+	if ingestAdded {
+		ingestChange, err := makeAttachedMetadataAddition(ingestRecord)
+		if err != nil {
+			return err
+		}
+		changes = append(changes, ingestChange)
 	}
-	delta, deltaDigest, err := makeAttachedMetadataDelta(
-		values.operationID, []audit.Record{ingestChange, provenanceChange},
-	)
+	changes = append(changes, provenanceChange)
+	delta, deltaDigest, err := makeAttachedMetadataDelta(values.operationID, changes)
 	if err != nil {
 		return err
 	}
 	events := make([]audit.Record, len(scopes))
-	eventKind := "provenance_add"
-	if provenance.Supersedes != nil {
-		eventKind = "provenance_supersede"
-	}
 	for index, scope := range scopes {
 		events[index], err = makeAuditedProvenanceEvent(
 			values, scope.scopeID, uint64(index), priorNode, resultingNode,
@@ -88,7 +100,7 @@ func persistAuditedProvenanceAppend(
 		return err
 	}
 	mutation, err = replaceAuditRecordField(
-		mutation, auditAttachedMetadataChangeCountField, audit.Unsigned(2),
+		mutation, auditAttachedMetadataChangeCountField, audit.Unsigned(uint64(len(changes))),
 	)
 	if err != nil {
 		return err
@@ -123,7 +135,7 @@ func persistAuditedProvenanceAppend(
 	if err != nil {
 		return err
 	}
-	allocation, err = addAttachedMetadataToAllocation(allocation, 2, deltaDigest.value)
+	allocation, err = addAttachedMetadataToAllocation(allocation, uint64(len(changes)), deltaDigest.value)
 	if err != nil {
 		return err
 	}
@@ -225,15 +237,16 @@ func makeAuditedProvenanceEvent(
 	}}, nil
 }
 
-type replayedProvenanceAppend struct {
-	nodeID     uint64
-	ingest     audit.Record
-	provenance audit.Record
-	change     audit.Record
-	digest     string
+type replayedProvenanceMutation struct {
+	nodeID      uint64
+	ingest      audit.Record
+	provenance  audit.Record
+	digest      string
+	eventKind   string
+	ingestAdded bool
 }
 
-func (replay *auditedHistoryReplay) applyProvenanceAppend(
+func (replay *auditedHistoryReplay) applyProvenanceMutation(
 	vaultID string, mutation, allocation, scopeEntry storedAuditRecord,
 	deltaRecords, eventRecords map[string]storedAuditRecord,
 	usedDeltas, usedEvents map[string]bool,
@@ -256,13 +269,24 @@ func (replay *auditedHistoryReplay) applyProvenanceAppend(
 	if err := requireAuditAbsent(mutation.record, "grouping_id"); err != nil {
 		return err
 	}
-	transition, err := replay.validateProvenanceAppendDelta(
-		mutation.record, operationID, deltaRecords, usedDeltas,
-	)
+	eventKind, err := auditedMutationFirstEventKind(mutation.record)
 	if err != nil {
 		return err
 	}
-	if err := replay.validateProvenanceAppendEvent(
+	var transition replayedProvenanceMutation
+	if eventKind == "ingest_observe" {
+		transition, err = replay.validateIngestObservationDelta(
+			mutation.record, operationID, deltaRecords, usedDeltas,
+		)
+	} else {
+		transition, err = replay.validateProvenanceAppendDelta(
+			mutation.record, operationID, deltaRecords, usedDeltas,
+		)
+	}
+	if err != nil {
+		return err
+	}
+	if err := replay.validateProvenanceMutationEvent(
 		operationID, mutation.record, transition, eventRecords, usedEvents,
 	); err != nil {
 		return err
@@ -287,7 +311,11 @@ func (replay *auditedHistoryReplay) applyProvenanceAppend(
 			return err
 		}
 	}
-	if err := requireAuditUnsigned(mutation.record, auditAttachedMetadataChangeCountField, 2); err != nil {
+	changeCount := uint64(1)
+	if transition.ingestAdded {
+		changeCount = 2
+	}
+	if err := requireAuditUnsigned(mutation.record, auditAttachedMetadataChangeCountField, changeCount); err != nil {
 		return err
 	}
 	if err := requireAuditDigest(mutation.record, "attached_metadata_change_digest", transition.digest); err != nil {
@@ -296,135 +324,139 @@ func (replay *auditedHistoryReplay) applyProvenanceAppend(
 	if err := replay.advanceScope(vaultID, mutation, scopeEntry); err != nil {
 		return err
 	}
-	if err := replay.advanceAllocation(vaultID, operationID, mutation, allocation, transition.digest, 2); err != nil {
+	if err := replay.advanceAllocation(vaultID, operationID, mutation, allocation, transition.digest, changeCount); err != nil {
 		return err
 	}
-	return replay.applyProvenanceAppendState(transition, mutation.record)
+	return replay.applyProvenanceMutationState(transition, mutation.record)
 }
 
 func (replay *auditedHistoryReplay) validateProvenanceAppendDelta(
 	mutation audit.Record, operationID string,
 	deltaRecords map[string]storedAuditRecord, usedDeltas map[string]bool,
-) (replayedProvenanceAppend, error) {
+) (replayedProvenanceMutation, error) {
 	digest, err := auditDigestField(mutation, "attached_metadata_change_digest")
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	delta, ok := deltaRecords[digest]
 	if !ok || usedDeltas[digest] {
-		return replayedProvenanceAppend{}, errors.New("provenance mutation lacks one unique attached-metadata delta")
+		return replayedProvenanceMutation{}, errors.New("provenance mutation lacks one unique attached-metadata delta")
 	}
 	if err := requireAuditUUID(delta.record, auditOperationIDField, operationID); err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	changes, err := auditRecordListField(delta.record, "changes")
 	if err != nil || len(changes) != 2 {
-		return replayedProvenanceAppend{}, errors.New("provenance mutation must contain ingest and provenance changes")
+		return replayedProvenanceMutation{}, errors.New("provenance mutation must contain ingest and provenance changes")
 	}
 	var change, ingestChange audit.Record
 	for _, candidate := range changes {
 		kind, kindErr := auditTextField(candidate, "record_kind")
 		if kindErr != nil {
-			return replayedProvenanceAppend{}, kindErr
+			return replayedProvenanceMutation{}, kindErr
 		}
 		_, hasPre, preErr := optionalNestedAuditRecord(candidate, auditPreField)
 		if preErr != nil || hasPre {
-			return replayedProvenanceAppend{}, errors.New("provenance mutation changes an existing attachment")
+			return replayedProvenanceMutation{}, errors.New("provenance mutation changes an existing attachment")
 		}
 		_, hasPost, postErr := optionalNestedAuditRecord(candidate, auditPostField)
 		if postErr != nil || !hasPost {
-			return replayedProvenanceAppend{}, errors.New("provenance mutation lacks an added attachment")
+			return replayedProvenanceMutation{}, errors.New("provenance mutation lacks an added attachment")
 		}
 		switch kind {
 		case metadataProvenanceType:
 			if change.Kind != "" {
-				return replayedProvenanceAppend{}, errors.New("provenance mutation repeats its fact change")
+				return replayedProvenanceMutation{}, errors.New("provenance mutation repeats its fact change")
 			}
 			change = candidate
 		case metadataIngestType:
 			if ingestChange.Kind != "" {
-				return replayedProvenanceAppend{}, errors.New("provenance mutation repeats its ingest change")
+				return replayedProvenanceMutation{}, errors.New("provenance mutation repeats its ingest change")
 			}
 			ingestChange = candidate
 		default:
-			return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation carries unsupported attachment %q", kind)
+			return replayedProvenanceMutation{}, fmt.Errorf("provenance mutation carries unsupported attachment %q", kind)
 		}
 	}
 	if change.Kind == "" || ingestChange.Kind == "" {
-		return replayedProvenanceAppend{}, errors.New("provenance mutation must add one ingest and one fact")
+		return replayedProvenanceMutation{}, errors.New("provenance mutation must add one ingest and one fact")
 	}
 	ingestPost, err := validateAuditedIngestAddition(ingestChange)
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	ingestKey, err := attachedAuditKey(ingestPost)
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	if _, exists := replay.attachments[ingestKey]; exists {
-		return replayedProvenanceAppend{}, errors.New("provenance mutation reuses ingest identity")
+		return replayedProvenanceMutation{}, errors.New("provenance mutation reuses ingest identity")
 	}
 	post, _, err := optionalNestedAuditRecord(change, auditPostField)
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	ingestID, err := auditUUIDField(ingestPost, "ingest_id")
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	if err := validateReplayedIngest(ingestPost); err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	if err := validateReplayedProvenance(post, ingestID); err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	identity, err := attachedAuditIdentity(post)
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	storedIdentity, err := auditNestedField(change, "stable_identity")
 	if err != nil || !auditRecordEqual(storedIdentity, identity) {
-		return replayedProvenanceAppend{}, errors.New("provenance delta identity does not match its record")
+		return replayedProvenanceMutation{}, errors.New("provenance delta identity does not match its record")
 	}
 	nodeID, err := auditUnsignedField(post, metadataNodeIDField)
 	if err != nil || !replay.memberSet[nodeID] {
-		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation targets unaudited node %d", nodeID)
+		return replayedProvenanceMutation{}, fmt.Errorf("provenance mutation targets unaudited node %d", nodeID)
 	}
 	topologyIndex, ok := replay.topologyIndex[nodeID]
 	if !ok {
-		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation target %d is absent from topology", nodeID)
+		return replayedProvenanceMutation{}, fmt.Errorf("provenance mutation target %d is absent from topology", nodeID)
 	}
 	nodeKind, err := auditTextField(replay.topology[topologyIndex], "node_kind")
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	if nodeKind != nodeKindFile {
-		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation targets non-file node %d", nodeID)
+		return replayedProvenanceMutation{}, fmt.Errorf("provenance mutation targets non-file node %d", nodeID)
 	}
 	provenanceID, err := auditDigestField(post, "identity")
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	key, err := attachedAuditKey(post)
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	if _, exists := replay.attachments[key]; exists {
-		return replayedProvenanceAppend{}, fmt.Errorf("provenance mutation reuses identity %s", provenanceID)
+		return replayedProvenanceMutation{}, fmt.Errorf("provenance mutation reuses identity %s", provenanceID)
 	}
 	supersedes, err := auditOptionalDigestField(post, "supersedes")
 	if err != nil {
-		return replayedProvenanceAppend{}, err
+		return replayedProvenanceMutation{}, err
 	}
 	if supersedes != nil {
 		if err := replay.requireSupersedableProvenance(nodeID, *supersedes); err != nil {
-			return replayedProvenanceAppend{}, err
+			return replayedProvenanceMutation{}, err
 		}
 	}
+	eventKind := "provenance_add"
+	if supersedes != nil {
+		eventKind = "provenance_supersede"
+	}
 	usedDeltas[digest] = true
-	return replayedProvenanceAppend{
-		nodeID: nodeID, provenance: post, change: change, digest: digest,
-		ingest: ingestPost,
+	return replayedProvenanceMutation{
+		nodeID: nodeID, provenance: post, digest: digest,
+		ingest: ingestPost, ingestAdded: true, eventKind: eventKind,
 	}, nil
 }
 
@@ -524,7 +556,7 @@ func (replay *auditedHistoryReplay) requireSupersedableProvenance(nodeID uint64,
 	if err != nil {
 		return err
 	}
-	if !strings.HasPrefix(sourceKind, callerSuppliedSourceKindPrefix) {
+	if !sourceKindIsEmbedded(sourceKind) {
 		return errors.New("operational ingest provenance cannot be superseded")
 	}
 	return nil
@@ -568,8 +600,8 @@ func (replay *auditedHistoryReplay) activeProvenanceRecord(
 	return result, nil
 }
 
-func (replay *auditedHistoryReplay) validateProvenanceAppendEvent(
-	operationID string, mutation audit.Record, transition replayedProvenanceAppend,
+func (replay *auditedHistoryReplay) validateProvenanceMutationEvent(
+	operationID string, mutation audit.Record, transition replayedProvenanceMutation,
 	eventRecords map[string]storedAuditRecord, usedEvents map[string]bool,
 ) error {
 	events, err := auditRecordListField(mutation, "events")
@@ -589,12 +621,7 @@ func (replay *auditedHistoryReplay) validateProvenanceAppendEvent(
 	if err != nil || !auditRecordEqual(storedIdentity, identity) {
 		return errors.New("provenance event identity does not match its attachment")
 	}
-	eventKind := "provenance_add"
-	if supersedes, err := auditOptionalDigestField(transition.provenance, "supersedes"); err != nil {
-		return err
-	} else if supersedes != nil {
-		eventKind = "provenance_supersede"
-	}
+	eventKind := transition.eventKind
 	var expectedPre audit.Record
 	if eventKind == "provenance_supersede" {
 		supersedes, err := auditOptionalDigestField(transition.provenance, "supersedes")
@@ -642,7 +669,7 @@ func (replay *auditedHistoryReplay) validateProvenanceAppendEvent(
 				return nil
 			}
 			if hasPre {
-				return errors.New("provenance-add event unexpectedly has a pre-state")
+				return errors.New("provenance event unexpectedly has a pre-state")
 			}
 			return nil
 		},
@@ -659,19 +686,21 @@ func (replay *auditedHistoryReplay) validateProvenanceAppendEvent(
 	return nil
 }
 
-func (replay *auditedHistoryReplay) applyProvenanceAppendState(
-	transition replayedProvenanceAppend, mutation audit.Record,
+func (replay *auditedHistoryReplay) applyProvenanceMutationState(
+	transition replayedProvenanceMutation, mutation audit.Record,
 ) error {
 	key, err := attachedAuditKey(transition.provenance)
 	if err != nil {
 		return err
 	}
 	replay.attachments[key] = transition.provenance
-	ingestKey, err := attachedAuditKey(transition.ingest)
-	if err != nil {
-		return err
+	if transition.ingestAdded {
+		ingestKey, err := attachedAuditKey(transition.ingest)
+		if err != nil {
+			return err
+		}
+		replay.attachments[ingestKey] = transition.ingest
 	}
-	replay.attachments[ingestKey] = transition.ingest
 	state := replay.states[transition.nodeID]
 	revision, err := auditUnsignedField(state, auditNodeRevisionField)
 	if err != nil {
@@ -712,7 +741,7 @@ func validateReplayedIngest(record audit.Record) error {
 	if err != nil {
 		return err
 	}
-	if kind, supplied := strings.CutPrefix(sourceKind, callerSuppliedSourceKindPrefix); !supplied || kind == "" {
+	if !sourceKindIsEmbedded(sourceKind) || len(sourceKind) == len(callerSuppliedSourceKindPrefix) {
 		return errors.New("provenance mutation ingest requires a non-empty caller-supplied source kind")
 	}
 	description, err := auditField(record, "source_desc")

--- a/internal/store/audit_provenance_test.go
+++ b/internal/store/audit_provenance_test.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json/v2"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -445,4 +447,93 @@ func TestAuditedProvenanceReplayRejectsDirectoryTarget(t *testing.T) {
 	}))
 	err = s.ValidateMetadata(ctx)
 	require.ErrorContains(t, err, "provenance mutation targets non-file node")
+}
+
+// These digests bind the complete canonical record stream for caller-supplied
+// provenance and operational observations.
+func TestAuditedProvenanceCanonicalRecords(t *testing.T) {
+	for operation, want := range map[string]string{
+		"append":           "a9ad4987c066f3fca86e36ff69c9c55e74b342cece6f79944dc38a75ef880b34",
+		"supersede":        "a83dec2c0d2295f015e1e4154587fcaa8e15423c095ab1d0f151bbc55e2b90c7",
+		"observe new":      "a7cb0b9617b42dc1ee0ccbfbcc9ef27ae3828365fc698dcd57bf2d6a7da6fd68",
+		"observe existing": "4f1b5d32845ab9cb0fb7e0e98b90b22277b4c7eb583db733a7f202cec6f8a3cb",
+	} {
+		t.Run(operation, func(t *testing.T) {
+			s := newTestStore(t)
+			ctx := t.Context()
+			seedMetadataRoundTrip(t, s)
+			s.vaultID = "99999999-9999-4999-8999-999999999999"
+			_, err := s.db.Exec("UPDATE vault_metadata SET vault_uid=?", s.vaultID)
+			require.NoError(t, err)
+			node, err := s.NodeByPath(ctx, "/Projects/report.txt")
+			require.NoError(t, err)
+			var predecessor string
+			if operation == "supersede" {
+				const priorIngest = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+				_, err = s.db.Exec("INSERT INTO ingests(id,started_at,source_kind,source_desc) VALUES(?,?,'embedded:agent','Synthetic predecessor')",
+					priorIngest, testAuditTimestamp)
+				require.NoError(t, err)
+				prior := metadataProvenance{Type: metadataProvenanceType, NodeID: node.ID, IngestID: priorIngest, OriginalPath: "/synthetic/prior.txt"}
+				predecessor, err = provenanceIdentity(prior)
+				require.NoError(t, err)
+				_, err = s.db.Exec("INSERT INTO provenance(identity,node_id,ingest_id,original_path) VALUES(?,?,?,?)",
+					predecessor, prior.NodeID, prior.IngestID, prior.OriginalPath)
+				require.NoError(t, err)
+			}
+			seedInitialAuditAuthority(t, s, *node.ParentID)
+			run := IngestRun{record: metadataIngest{
+				Type: metadataIngestType, ID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				StartedAt: testAuditTimestamp, SourceKind: "embedded:agent", SourceDesc: "Synthetic canonical assertion",
+			}}
+			observation := operation == "observe new" || operation == "observe existing"
+			if observation {
+				run.record.SourceKind = "filesystem"
+			}
+			if operation == "observe existing" {
+				require.NoError(t, s.db.QueryRow("SELECT id,started_at,source_kind,source_desc FROM ingests WHERE id=?", metadataIngestID).
+					Scan(&run.record.ID, &run.record.StartedAt, &run.record.SourceKind, &run.record.SourceDesc))
+			}
+			require.NoError(t, s.withStorageTx(ctx, func(tx *sql.Tx) error {
+				ingestAdded, err := ensureIngestRunTx(ctx, tx, run)
+				if err != nil {
+					return err
+				}
+				fact := metadataProvenance{Type: metadataProvenanceType, NodeID: node.ID,
+					IngestID: run.ID(), OriginalPath: "/synthetic/assertion.txt"}
+				if predecessor != "" {
+					fact.Supersedes = &predecessor
+				}
+				fact.Identity, err = provenanceIdentity(fact)
+				if err != nil {
+					return err
+				}
+				if _, err = tx.Exec("INSERT INTO provenance(identity,node_id,ingest_id,original_path,supersedes) VALUES(?,?,?,?,?)",
+					fact.Identity, fact.NodeID, fact.IngestID, fact.OriginalPath, fact.Supersedes); err != nil {
+					return err
+				}
+				if err = bumpRevisionTx(tx, node.ID, testAuditTimestamp); err != nil {
+					return err
+				}
+				resulting, err := nodeByIDTx(tx, node.ID)
+				if err != nil {
+					return err
+				}
+				authority, scopes, sequence, err := loadAuditedNodeAuthority(ctx, tx, node.ID)
+				if err != nil {
+					return err
+				}
+				const operationID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+				if observation {
+					return persistAuditedIngestObservation(ctx, tx, s.vaultID, operationID, testAuditTimestamp,
+						sequence, authority, scopes, node, resulting, run.record, fact, ingestAdded)
+				}
+				return persistAuditedProvenanceAppend(ctx, tx, s.vaultID, operationID, testAuditTimestamp,
+					sequence, authority, scopes, node, resulting, run.record, fact)
+			}))
+			require.NoError(t, s.ValidateMetadata(ctx))
+			var records bytes.Buffer
+			require.NoError(t, exportAuditRecords(ctx, s.db, newMetadataJSONWriter(&records)))
+			assert.Equal(t, want, fmt.Sprintf("%x", sha256.Sum256(records.Bytes())))
+		})
+	}
 }

--- a/internal/store/collection.go
+++ b/internal/store/collection.go
@@ -1,0 +1,208 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// CollectionMembershipCTE is the shared active-file membership relation used
+// by every collection summary and member read. It intentionally omits WITH so
+// callers can compose it with other CTEs.
+const CollectionMembershipCTE = `collection_members AS (
+    SELECT DISTINCT p.ingest_id, p.node_id
+    FROM provenance p
+    JOIN ingests i ON i.id = p.ingest_id
+    JOIN nodes n ON n.id = p.node_id
+    WHERE i.source_kind NOT LIKE 'embedded:%'
+      AND n.kind = 'file' AND n.trashed_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM provenance later WHERE later.supersedes = p.identity)
+)`
+
+// Collection is one document-bearing operational ingest and its current
+// membership summary. LabelRevision advances independently of membership.
+type Collection struct {
+	ID, SourceKind, SourceDescription, StartedAt string
+	FileCount, TotalBytes                        int64
+	Label                                        *string
+	LabelRevision                                int64
+	LabelUpdatedAt                               string
+}
+
+// CollectionMemberPage binds one collection summary and member page to the
+// same read snapshot.
+type CollectionMemberPage struct {
+	Collection Collection
+	Items      []NodeView
+	Total      int
+}
+
+const collectionColumns = `i.id, i.source_kind, i.source_desc, i.started_at,
+	COUNT(cm.node_id), COALESCE(SUM(cv.size), 0), l.label,
+	COALESCE(l.revision, 1), COALESCE(l.updated_at, i.started_at)`
+
+func scanCollection(row interface{ Scan(args ...any) error }) (Collection, error) {
+	var collection Collection
+	var label sql.NullString
+	err := row.Scan(&collection.ID, &collection.SourceKind,
+		&collection.SourceDescription, &collection.StartedAt,
+		&collection.FileCount, &collection.TotalBytes, &label,
+		&collection.LabelRevision, &collection.LabelUpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Collection{}, ErrNotFound
+	}
+	if err != nil {
+		return Collection{}, fmt.Errorf("scanning collection: %w", err)
+	}
+	collection.Label = stringPtr(label)
+	return collection, nil
+}
+
+func collectionSummaryByID(
+	ctx context.Context, q rowQuerier, id string,
+) (Collection, error) {
+	collection, err := scanCollection(q.QueryRowContext(ctx, `WITH `+CollectionMembershipCTE+`
+		SELECT `+collectionColumns+`
+		FROM ingests i
+		LEFT JOIN collection_members cm ON cm.ingest_id=i.id
+		LEFT JOIN nodes n ON n.id=cm.node_id
+		LEFT JOIN content_versions cv ON cv.version_id=n.current_version_id
+		LEFT JOIN collection_labels l ON l.ingest_id=i.id
+		WHERE i.id=? AND i.source_kind NOT LIKE 'embedded:%'
+		GROUP BY i.id, i.source_kind, i.source_desc, i.started_at,
+			l.ingest_id, l.label, l.revision, l.updated_at
+		HAVING COUNT(cm.node_id)>0 OR l.ingest_id IS NOT NULL`, id))
+	if err != nil {
+		return Collection{}, fmt.Errorf("collection %q: %w", id, err)
+	}
+	return collection, nil
+}
+
+// Collections lists current nonempty operational collections and the total
+// number of such runs. The limit must be between 1 and 1000.
+func (s *Store) Collections(
+	ctx context.Context, limit, offset int,
+) ([]Collection, int, error) {
+	if err := validatePage(limit, offset); err != nil {
+		return nil, 0, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, 0, fmt.Errorf("starting collection snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var total int
+	if err := tx.QueryRowContext(ctx, `WITH `+CollectionMembershipCTE+`
+		SELECT COUNT(DISTINCT ingest_id) FROM collection_members`).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("counting collections: %w", err)
+	}
+	rows, err := tx.QueryContext(ctx, `WITH `+CollectionMembershipCTE+`
+		SELECT `+collectionColumns+`
+		FROM ingests i
+		JOIN collection_members cm ON cm.ingest_id=i.id
+		JOIN nodes n ON n.id=cm.node_id
+		JOIN content_versions cv ON cv.version_id=n.current_version_id
+		LEFT JOIN collection_labels l ON l.ingest_id=i.id
+		GROUP BY i.id, i.source_kind, i.source_desc, i.started_at,
+			l.label, l.revision, l.updated_at
+		ORDER BY i.started_at DESC, i.id
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing collections: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	collections := make([]Collection, 0)
+	for rows.Next() {
+		collection, scanErr := scanCollection(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return nil, 0, scanErr
+		}
+		collections = append(collections, collection)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, 0, fmt.Errorf("listing collections: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, fmt.Errorf("closing collections: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, 0, fmt.Errorf("closing collection snapshot: %w", err)
+	}
+	return collections, total, nil
+}
+
+// CollectionByID returns one current operational collection. Retained label
+// authority keeps direct access available when current membership is empty.
+func (s *Store) CollectionByID(ctx context.Context, id string) (Collection, error) {
+	if err := validateUUIDv4(id); err != nil {
+		return Collection{}, fmt.Errorf("collection %q: %w", id, ErrNotFound)
+	}
+	return collectionSummaryByID(ctx, s.db, id)
+}
+
+// CollectionMembers returns one current member page and collection summary
+// from the same read transaction.
+func (s *Store) CollectionMembers(
+	ctx context.Context, id string, limit, offset int,
+) (CollectionMemberPage, error) {
+	if err := validateUUIDv4(id); err != nil {
+		return CollectionMemberPage{}, fmt.Errorf("collection %q: %w", id, ErrNotFound)
+	}
+	if err := validatePage(limit, offset); err != nil {
+		return CollectionMemberPage{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return CollectionMemberPage{}, fmt.Errorf("starting collection member snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	collection, err := collectionSummaryByID(ctx, tx, id)
+	if err != nil {
+		return CollectionMemberPage{}, err
+	}
+	rows, err := tx.QueryContext(ctx, `WITH `+CollectionMembershipCTE+`
+		SELECT `+nodeCols+`
+		FROM `+nodeFrom+`
+		JOIN collection_members cm ON cm.node_id=n.id
+		WHERE cm.ingest_id=?
+		ORDER BY n.name, n.id
+		LIMIT ? OFFSET ?`, id, limit, offset)
+	if err != nil {
+		return CollectionMemberPage{}, fmt.Errorf("listing collection %q members: %w", id, err)
+	}
+	defer func() { _ = rows.Close() }()
+	nodes := make([]Node, 0)
+	for rows.Next() {
+		node, scanErr := scanNode(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return CollectionMemberPage{}, scanErr
+		}
+		nodes = append(nodes, node)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return CollectionMemberPage{}, fmt.Errorf("listing collection %q members: %w", id, err)
+	}
+	if err := rows.Close(); err != nil {
+		return CollectionMemberPage{}, fmt.Errorf("closing collection %q members: %w", id, err)
+	}
+	items := make([]NodeView, 0, len(nodes))
+	for _, node := range nodes {
+		path, pathErr := pathOf(ctx, tx, node.ID)
+		if pathErr != nil {
+			return CollectionMemberPage{}, pathErr
+		}
+		items = append(items, NodeView{Node: node, Path: path})
+	}
+	if err := tx.Commit(); err != nil {
+		return CollectionMemberPage{}, fmt.Errorf("closing collection member snapshot: %w", err)
+	}
+	return CollectionMemberPage{
+		Collection: collection, Items: items, Total: int(collection.FileCount),
+	}, nil
+}

--- a/internal/store/collection_label.go
+++ b/internal/store/collection_label.go
@@ -1,0 +1,159 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidCollectionLabel reports a label outside the canonical name policy.
+var ErrInvalidCollectionLabel = errors.New("invalid collection label")
+
+// CollectionLabel is the separately revisioned mutable name authority for one
+// operational ingest collection.
+type CollectionLabel struct {
+	IngestID  string
+	Label     *string
+	Revision  int64
+	UpdatedAt string
+}
+
+func normalizeOptionalCollectionLabel(label *string) (string, bool, error) {
+	if label == nil {
+		return "", false, nil
+	}
+	normalized, err := normalizeLabelName(*label, ErrInvalidCollectionLabel)
+	if err != nil {
+		return "", false, err
+	}
+	return normalized, true, nil
+}
+
+func collectionLabelTx(
+	ctx context.Context, q rowQuerier, ingestID string,
+) (CollectionLabel, bool, error) {
+	var startedAt string
+	var label, updatedAt, retained sql.NullString
+	var revision sql.NullInt64
+	err := q.QueryRowContext(ctx, `WITH `+CollectionMembershipCTE+`
+		SELECT i.started_at, l.label, l.revision, l.updated_at, l.ingest_id
+		FROM ingests i LEFT JOIN collection_labels l ON l.ingest_id=i.id
+		WHERE i.id=? AND i.source_kind NOT LIKE 'embedded:%'
+		  AND (l.ingest_id IS NOT NULL OR EXISTS(
+			SELECT 1 FROM collection_members cm WHERE cm.ingest_id=i.id
+		  ))`, ingestID).Scan(&startedAt, &label, &revision, &updatedAt, &retained)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CollectionLabel{}, false, ErrNotFound
+	}
+	if err != nil {
+		return CollectionLabel{}, false, fmt.Errorf("reading collection label %q: %w", ingestID, err)
+	}
+	result := CollectionLabel{
+		IngestID: ingestID, Label: stringPtr(label), Revision: 1, UpdatedAt: startedAt,
+	}
+	if retained.Valid {
+		result.Revision = revision.Int64
+		result.UpdatedAt = updatedAt.String
+	}
+	return result, retained.Valid, nil
+}
+
+// CollectionLabel returns the current label fence. Eligible unlabeled runs
+// expose a virtual null label at revision one and their immutable start time.
+func (s *Store) CollectionLabel(ctx context.Context, id string) (CollectionLabel, error) {
+	if err := validateUUIDv4(id); err != nil {
+		return CollectionLabel{}, fmt.Errorf("collection %q: %w", id, ErrNotFound)
+	}
+	label, _, err := collectionLabelTx(ctx, s.db, id)
+	return label, err
+}
+
+// SetCollectionLabel applies one revision-fenced label mutation. Clearing a
+// retained label preserves its row and revision history.
+func (s *Store) SetCollectionLabel(
+	ctx context.Context, id string, revision int64, label *string,
+) (CollectionLabel, error) {
+	if err := validateUUIDv4(id); err != nil {
+		return CollectionLabel{}, fmt.Errorf("collection %q: %w", id, ErrNotFound)
+	}
+	normalizedValue, hasLabel, err := normalizeOptionalCollectionLabel(label)
+	if err != nil {
+		return CollectionLabel{}, err
+	}
+	var normalized *string
+	if hasLabel {
+		normalized = &normalizedValue
+	}
+	var result CollectionLabel
+	err = s.withLogicalTx(ctx, func(tx *sql.Tx) error {
+		current, retained, err := collectionLabelTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if revision != current.Revision {
+			return fmt.Errorf("collection label %q at revision %d, expected %d: %w",
+				id, current.Revision, revision, ErrStaleRevision)
+		}
+		if equalOptionalStrings(current.Label, normalized) {
+			result = current
+			return nil
+		}
+		updatedAt := monotonicCollectionLabelTime(current.UpdatedAt)
+		if !retained {
+			_, err = tx.ExecContext(ctx, `INSERT INTO collection_labels(
+				ingest_id,label,revision,updated_at
+			) VALUES(?,?,2,?)`, id, normalized, updatedAt)
+		} else {
+			_, err = tx.ExecContext(ctx, `UPDATE collection_labels
+				SET label=?, revision=revision+1, updated_at=?
+				WHERE ingest_id=?`, normalized, updatedAt, id)
+		}
+		if err != nil {
+			if s.driver.IsUniqueViolation(err) {
+				return fmt.Errorf("collection label %q: %w", optionalString(normalized), ErrExists)
+			}
+			return fmt.Errorf("updating collection label %q: %w", id, err)
+		}
+		result, _, err = collectionLabelTx(ctx, tx, id)
+		return err
+	})
+	if err != nil {
+		return CollectionLabel{}, err
+	}
+	return result, nil
+}
+
+func equalOptionalStrings(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func optionalString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func monotonicCollectionLabelTime(prior string) string {
+	now := nowRFC3339()
+	if now < prior {
+		return prior
+	}
+	return now
+}
+
+func insertInitialCollectionLabelTx(
+	ctx context.Context, tx *sql.Tx, run IngestRun,
+) error {
+	if run.initialLabel == nil {
+		return nil
+	}
+	_, err := tx.ExecContext(ctx, `INSERT INTO collection_labels(
+		ingest_id,label,revision,updated_at
+	) VALUES(?,?,1,?)`, run.ID(), run.initialLabel, run.record.StartedAt)
+	return err
+}

--- a/internal/store/collection_label_test.go
+++ b/internal/store/collection_label_test.go
@@ -1,0 +1,310 @@
+package store
+
+import (
+	"database/sql"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionLabelFence(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	run, err := s.BeginIngest(ctx, "cli", "Synthetic import")
+	require.NoError(t, err)
+	_, _, err = s.IngestFile(ctx, run, s.RootID(), "note.txt", fakeHash("a1"),
+		4, "text/plain", "/synthetic/note.txt", "")
+	require.NoError(t, err)
+
+	initial, err := s.CollectionLabel(ctx, run.ID())
+	require.NoError(t, err)
+	assert.Equal(t, CollectionLabel{
+		IngestID: run.ID(), Revision: 1, UpdatedAt: run.record.StartedAt,
+	}, initial)
+
+	name := "Review set"
+	label, err := s.SetCollectionLabel(ctx, run.ID(), 1, &name)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), label.Revision)
+	other := "Changed set"
+	_, err = s.SetCollectionLabel(ctx, run.ID(), 1, &other)
+	require.ErrorIs(t, err, ErrStaleRevision)
+	current, err := s.CollectionLabel(ctx, run.ID())
+	require.NoError(t, err)
+	require.Equal(t, label, current)
+}
+
+func TestCollectionLabelValidationAndCaseSensitiveUniqueness(t *testing.T) {
+	s := newTestStore(t)
+	first := createCollectionRun(t, s, "first.txt", "a1")
+	second := createCollectionRun(t, s, "second.txt", "b2")
+
+	for _, test := range []struct {
+		name  string
+		label string
+	}{
+		{name: "empty", label: ""},
+		{name: "whitespace", label: " \t "},
+		{name: "control", label: "bad\nlabel"},
+		{name: "too many bytes", label: string(make([]byte, 257))},
+		{name: "invalid UTF-8", label: string([]byte{0xff})},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := s.SetCollectionLabel(t.Context(), first.ID(), 1, &test.label)
+			require.Error(t, err)
+		})
+	}
+
+	nfd := "Cafe\u0301 records"
+	got, err := s.SetCollectionLabel(t.Context(), first.ID(), 1, &nfd)
+	require.NoError(t, err)
+	require.NotNil(t, got.Label)
+	assert.Equal(t, "Café records", *got.Label)
+
+	differentCase := "CAFÉ records"
+	_, err = s.SetCollectionLabel(t.Context(), second.ID(), 1, &differentCase)
+	require.NoError(t, err)
+	collision := "Café records"
+	_, err = s.SetCollectionLabel(t.Context(), second.ID(), 2, &collision)
+	require.ErrorIs(t, err, ErrExists)
+
+	spaced := "  kept spaces  "
+	cleared, err := s.SetCollectionLabel(t.Context(), first.ID(), 2, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), cleared.Revision)
+	spacedLabel, err := s.SetCollectionLabel(t.Context(), first.ID(), 3, &spaced)
+	require.NoError(t, err)
+	require.Equal(t, spaced, *spacedLabel.Label)
+}
+
+func TestCollectionLabelNoOpClearAndRetainedEmptyAuthority(t *testing.T) {
+	s := newTestStore(t)
+	run := createCollectionRun(t, s, "note.txt", "a1")
+
+	virtual, err := s.SetCollectionLabel(t.Context(), run.ID(), 1, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), virtual.Revision)
+	var rows int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM collection_labels`).Scan(&rows))
+	assert.Zero(t, rows)
+
+	name := "Review set"
+	created, err := s.SetCollectionLabel(t.Context(), run.ID(), 1, &name)
+	require.NoError(t, err)
+	unchanged, err := s.SetCollectionLabel(t.Context(), run.ID(), created.Revision, &name)
+	require.NoError(t, err)
+	assert.Equal(t, created, unchanged)
+
+	page, err := s.CollectionMembers(t.Context(), run.ID(), 10, 0)
+	require.NoError(t, err)
+	_, _, err = s.Trash(t.Context(), page.Items[0].Node.ID, UnconditionalRev)
+	require.NoError(t, err)
+	collections, total, err := s.Collections(t.Context(), 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, collections)
+	assert.Zero(t, total)
+	empty, err := s.CollectionByID(t.Context(), run.ID())
+	require.NoError(t, err)
+	assert.Zero(t, empty.FileCount)
+	assert.Equal(t, created.Revision, empty.LabelRevision)
+	other := createCollectionRun(t, s, "other.txt", "b2")
+	_, err = s.SetCollectionLabel(t.Context(), other.ID(), 1, &name)
+	require.ErrorIs(t, err, ErrExists,
+		"a retained empty collection keeps its non-null label unique")
+
+	cleared, err := s.SetCollectionLabel(t.Context(), run.ID(), created.Revision, nil)
+	require.NoError(t, err)
+	assert.Equal(t, created.Revision+1, cleared.Revision)
+	assert.Nil(t, cleared.Label)
+	again, err := s.SetCollectionLabel(t.Context(), run.ID(), cleared.Revision, nil)
+	require.NoError(t, err)
+	assert.Equal(t, cleared, again)
+	reused, err := s.SetCollectionLabel(t.Context(), other.ID(), 1, &name)
+	require.NoError(t, err)
+	require.Equal(t, name, *reused.Label)
+	_, err = s.CollectionLabel(t.Context(), "not-a-uuid")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCollectionLabelRejectsArbitraryEmptyIngest(t *testing.T) {
+	s := newTestStore(t)
+	run, err := s.BeginIngest(t.Context(), "cli", "No committed documents")
+	require.NoError(t, err)
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		_, err := ensureIngestRunTx(t.Context(), tx, run)
+		return err
+	}))
+
+	_, err = s.CollectionLabel(t.Context(), run.ID())
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.SetCollectionLabel(t.Context(), run.ID(), 1, new("Invented"))
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCollectionLabelTimestampNeverMovesBackward(t *testing.T) {
+	s := newTestStore(t)
+	run := createCollectionRun(t, s, "note.txt", "a1")
+	created, err := s.SetCollectionLabel(t.Context(), run.ID(), 1, new("First"))
+	require.NoError(t, err)
+	const future = "2099-01-02T03:04:05.000000000Z"
+	_, err = s.db.Exec(`UPDATE collection_labels SET updated_at=? WHERE ingest_id=?`, future, run.ID())
+	require.NoError(t, err)
+
+	updated, err := s.SetCollectionLabel(t.Context(), run.ID(), created.Revision, new("Second"))
+	require.NoError(t, err)
+	assert.Equal(t, future, updated.UpdatedAt)
+}
+
+func TestCollectionLabelFirstWriteRaceHasOneWinner(t *testing.T) {
+	s := newTestStore(t)
+	run := createCollectionRun(t, s, "note.txt", "a1")
+	names := []string{"First", "Second"}
+	errs := make([]error, 2)
+	labels := make([]CollectionLabel, 2)
+	var start sync.WaitGroup
+	start.Add(1)
+	var workers sync.WaitGroup
+	for i := range names {
+		workers.Add(1)
+		go func(i int) {
+			defer workers.Done()
+			start.Wait()
+			labels[i], errs[i] = s.SetCollectionLabel(t.Context(), run.ID(), 1, &names[i])
+		}(i)
+	}
+	start.Done()
+	workers.Wait()
+
+	winners := 0
+	stale := 0
+	for i := range errs {
+		if errs[i] == nil {
+			winners++
+			assert.Equal(t, int64(2), labels[i].Revision)
+		} else if assert.ErrorIs(t, errs[i], ErrStaleRevision) {
+			stale++
+		}
+	}
+	assert.Equal(t, 1, winners)
+	assert.Equal(t, 1, stale)
+}
+
+func TestBeginIngestWithLabelPublishesAtomically(t *testing.T) {
+	s := newTestStore(t)
+	first := createCollectionRun(t, s, "first.txt", "a1")
+	name := "Shared label"
+	_, err := s.SetCollectionLabel(t.Context(), first.ID(), 1, &name)
+	require.NoError(t, err)
+
+	second, err := s.BeginIngestWithLabel(t.Context(), "cli", "Collision", &name)
+	require.NoError(t, err)
+	var unpublished int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM ingests WHERE id=?`, second.ID()).Scan(&unpublished))
+	assert.Zero(t, unpublished, "preparing a labeled run grants no database authority")
+	_, _, err = s.IngestFile(t.Context(), second, s.RootID(), "second.txt", fakeHash("b2"),
+		8, "text/plain", "/synthetic/second.txt", "")
+	require.ErrorIs(t, err, ErrExists)
+	var ingests, nodes, blobs int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM ingests WHERE id=?),
+		(SELECT COUNT(*) FROM nodes WHERE name='second.txt'),
+		(SELECT COUNT(*) FROM blobs WHERE hash=?)`, second.ID(), fakeHash("b2")).Scan(&ingests, &nodes, &blobs))
+	assert.Zero(t, ingests)
+	assert.Zero(t, nodes)
+	assert.Zero(t, blobs)
+
+	initialName := "Initial label"
+	third, err := s.BeginIngestWithLabel(t.Context(), "cli", "Initial", &initialName)
+	require.NoError(t, err)
+	_, _, err = s.IngestFile(t.Context(), third, s.RootID(), "third.txt", fakeHash("c3"),
+		9, "text/plain", "/synthetic/third.txt", "")
+	require.NoError(t, err)
+	label, err := s.CollectionLabel(t.Context(), third.ID())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), label.Revision)
+	assert.Equal(t, third.record.StartedAt, label.UpdatedAt)
+	require.Equal(t, initialName, *label.Label)
+
+	edited := "Edited label"
+	updated, err := s.SetCollectionLabel(t.Context(), third.ID(), 1, &edited)
+	require.NoError(t, err)
+	_, _, err = s.IngestFile(t.Context(), third, s.RootID(), "fourth.txt", fakeHash("d4"),
+		10, "text/plain", "/synthetic/fourth.txt", "")
+	require.NoError(t, err)
+	current, err := s.CollectionLabel(t.Context(), third.ID())
+	require.NoError(t, err)
+	assert.Equal(t, updated, current)
+}
+
+func TestBeginIngestWithLabelRejectsCallerSuppliedSourceKind(t *testing.T) {
+	s := newTestStore(t)
+	for _, sourceKind := range []string{"embedded:cli", "EMBEDDED:cli", "EmBeDdEd:watch"} {
+		t.Run(sourceKind, func(t *testing.T) {
+			_, err := s.BeginIngestWithLabel(
+				t.Context(), sourceKind, "Opaque", new("Hidden"),
+			)
+			require.ErrorIs(t, err, ErrInvalidCollectionLabel)
+			var ingests, labels int
+			require.NoError(t, s.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM ingests),
+				(SELECT COUNT(*) FROM collection_labels)`).Scan(&ingests, &labels))
+			require.Zero(t, ingests)
+			require.Zero(t, labels)
+		})
+	}
+}
+
+func TestCollectionLabelsRejectAllMutationsUnderAudit(t *testing.T) {
+	s := newTestStore(t)
+	retained := createCollectionRun(t, s, "retained.txt", "a1")
+	name := "Retained"
+	_, err := s.SetCollectionLabel(t.Context(), retained.ID(), 1, &name)
+	require.NoError(t, err)
+	unlabeled := createCollectionRun(t, s, "unlabeled.txt", "b2")
+	plan, err := s.PreviewInitialAudit(t.Context(), s.RootID(), "api", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(t.Context(), plan)
+	require.NoError(t, err)
+
+	for _, mutation := range []struct {
+		name     string
+		ingestID string
+		revision int64
+		label    *string
+	}{
+		{name: "create", ingestID: unlabeled.ID(), revision: 1, label: new("New")},
+		{name: "edit", ingestID: retained.ID(), revision: 2, label: new("Changed")},
+		{name: "clear", ingestID: retained.ID(), revision: 2},
+		{name: "no-op", ingestID: retained.ID(), revision: 2, label: &name},
+	} {
+		t.Run(mutation.name, func(t *testing.T) {
+			_, err := s.SetCollectionLabel(t.Context(), mutation.ingestID, mutation.revision, mutation.label)
+			require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+		})
+	}
+
+	initial := "Rejected initial"
+	run, err := s.BeginIngestWithLabel(t.Context(), "cli", "Audited", &initial)
+	require.NoError(t, err)
+	_, _, err = s.IngestFile(t.Context(), run, s.RootID(), "rejected.txt", fakeHash("c3"),
+		3, "text/plain", "/synthetic/rejected.txt", "")
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	var authority int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM ingests WHERE id=?`, run.ID()).Scan(&authority))
+	assert.Zero(t, authority)
+	current, err := s.CollectionLabel(t.Context(), retained.ID())
+	require.NoError(t, err)
+	require.Equal(t, name, *current.Label)
+}
+
+func createCollectionRun(t *testing.T, s *Store, fileName, hashSeed string) IngestRun {
+	t.Helper()
+	run, err := s.BeginIngest(t.Context(), "cli", "Synthetic "+fileName)
+	require.NoError(t, err)
+	_, _, err = s.IngestFile(t.Context(), run, s.RootID(), fileName, fakeHash(hashSeed),
+		4, "text/plain", "/synthetic/"+fileName, "")
+	require.NoError(t, err)
+	return run
+}

--- a/internal/store/collection_metadata.go
+++ b/internal/store/collection_metadata.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+const metadataCollectionLabelType = "collection_label"
+
+type metadataCollectionLabel struct {
+	Type      string  `json:"type"`
+	IngestID  string  `json:"ingest_id"`
+	Label     *string `json:"label"`
+	Revision  int64   `json:"revision"`
+	UpdatedAt string  `json:"updated_at"`
+}
+
+func exportCollectionLabels(
+	ctx context.Context, tx metadataQuerier, write metadataWrite,
+) error {
+	rows, err := tx.QueryContext(ctx, `SELECT ingest_id,label,revision,updated_at
+		FROM collection_labels ORDER BY ingest_id`)
+	if err != nil {
+		return fmt.Errorf("exporting collection labels: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		record := metadataCollectionLabel{Type: metadataCollectionLabelType}
+		var label sql.NullString
+		if err := rows.Scan(&record.IngestID, &label, &record.Revision, &record.UpdatedAt); err != nil {
+			return fmt.Errorf("scanning collection label metadata: %w", err)
+		}
+		record.Label = stringPtr(label)
+		if err := validateCollectionLabelRecord(record); err != nil {
+			return fmt.Errorf("validating collection label metadata for export: %w", err)
+		}
+		if err := write(record); err != nil {
+			return err
+		}
+	}
+	return rowsError(metadataCollectionLabelType, rows)
+}
+
+func validateCollectionLabelRecord(record metadataCollectionLabel) error {
+	if record.Type != metadataCollectionLabelType || record.Revision < 1 {
+		return errors.New("invalid collection label record")
+	}
+	if record.Revision == 1 && record.Label == nil {
+		return errors.New("collection label revision one must carry its initial label")
+	}
+	if err := validateUUIDv4(record.IngestID); err != nil {
+		return fmt.Errorf("invalid collection label ingest ID: %w", err)
+	}
+	if record.Label != nil {
+		normalized, err := normalizeLabelName(*record.Label, ErrInvalidCollectionLabel)
+		if err != nil {
+			return err
+		}
+		if normalized != *record.Label {
+			return errors.New("collection label is not canonical NFC")
+		}
+	}
+	return validateMetadataTime("collection label updated_at", record.UpdatedAt)
+}
+
+func importCollectionLabel(
+	ctx context.Context, tx *sql.Tx, record metadataCollectionLabel,
+) error {
+	if err := validateCollectionLabelRecord(record); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `INSERT INTO collection_labels(
+		ingest_id,label,revision,updated_at
+	) VALUES(?,?,?,?)`, record.IngestID, record.Label, record.Revision, record.UpdatedAt)
+	return err
+}
+
+func validateCollectionLabelMetadataState(ctx context.Context, tx metadataQuerier) error {
+	if err := exportCollectionLabels(ctx, tx, func(any) error { return nil }); err != nil {
+		return err
+	}
+	checks := []struct {
+		message string
+		query   string
+	}{
+		{
+			message: "collection label references a caller-supplied ingest",
+			query: `SELECT EXISTS(SELECT 1 FROM collection_labels l
+				JOIN ingests i ON i.id=l.ingest_id
+				WHERE i.source_kind LIKE 'embedded:%')`,
+		},
+		{
+			message: "collection label timestamp precedes ingest start",
+			query: `SELECT EXISTS(SELECT 1 FROM collection_labels l
+				JOIN ingests i ON i.id=l.ingest_id WHERE l.updated_at<i.started_at)`,
+		},
+		{
+			message: "initial collection label timestamp differs from ingest start",
+			query: `SELECT EXISTS(SELECT 1 FROM collection_labels l
+				JOIN ingests i ON i.id=l.ingest_id
+				WHERE l.revision=1 AND l.updated_at<>i.started_at)`,
+		},
+	}
+	for _, check := range checks {
+		var failed bool
+		if err := tx.QueryRowContext(ctx, check.query).Scan(&failed); err != nil {
+			return fmt.Errorf("validating metadata (%s): %w", check.message, err)
+		}
+		if failed {
+			return errors.New(check.message)
+		}
+	}
+	return nil
+}

--- a/internal/store/collection_metadata_test.go
+++ b/internal/store/collection_metadata_test.go
@@ -1,0 +1,216 @@
+package store
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionLabelMetadataRoundTripsNullAndNonNull(t *testing.T) {
+	source := newTestStore(t)
+	named := createCollectionRun(t, source, "named.txt", "a1")
+	cleared := createCollectionRun(t, source, "cleared.txt", "b2")
+	name := "Portable label"
+	_, err := source.SetCollectionLabel(t.Context(), named.ID(), 1, &name)
+	require.NoError(t, err)
+	set, err := source.SetCollectionLabel(t.Context(), cleared.ID(), 1, new("Temporary"))
+	require.NoError(t, err)
+	_, err = source.SetCollectionLabel(t.Context(), cleared.ID(), set.Revision, nil)
+	require.NoError(t, err)
+
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	assert.Contains(t, exported.String(), `{"type":"collection_label","ingest_id":"`+named.ID()+`","label":"Portable label","revision":2,`)
+	assert.Contains(t, exported.String(), `{"type":"collection_label","ingest_id":"`+cleared.ID()+`","label":null,"revision":3,`)
+
+	target := newTestStore(t)
+	require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	namedLabel, err := target.CollectionLabel(t.Context(), named.ID())
+	require.NoError(t, err)
+	require.Equal(t, name, *namedLabel.Label)
+	clearedLabel, err := target.CollectionLabel(t.Context(), cleared.ID())
+	require.NoError(t, err)
+	assert.Nil(t, clearedLabel.Label)
+	assert.Equal(t, int64(3), clearedLabel.Revision)
+	var restored bytes.Buffer
+	require.NoError(t, target.ExportMetadata(t.Context(), &restored))
+	assert.Equal(t, exported.Bytes(), restored.Bytes())
+}
+
+func TestCollectionLabelMetadataRoundTripsAfterFinalMemberPurge(t *testing.T) {
+	source := newTestStore(t)
+	named := createCollectionRun(t, source, "named-purge.txt", "c1")
+	cleared := createCollectionRun(t, source, "cleared-purge.txt", "d2")
+	namedLabel, err := source.SetCollectionLabel(
+		t.Context(), named.ID(), 1, new("Retained after purge"),
+	)
+	require.NoError(t, err)
+	temporary, err := source.SetCollectionLabel(
+		t.Context(), cleared.ID(), 1, new("Clear before purge"),
+	)
+	require.NoError(t, err)
+	clearedLabel, err := source.SetCollectionLabel(
+		t.Context(), cleared.ID(), temporary.Revision, nil,
+	)
+	require.NoError(t, err)
+
+	for _, ingestID := range []string{named.ID(), cleared.ID()} {
+		page, pageErr := source.CollectionMembers(t.Context(), ingestID, 10, 0)
+		require.NoError(t, pageErr)
+		require.Len(t, page.Items, 1)
+		_, _, trashErr := source.Trash(
+			t.Context(), page.Items[0].Node.ID, UnconditionalRev,
+		)
+		require.NoError(t, trashErr)
+	}
+	emptied, err := source.TrashEmpty(t.Context(), 0, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), emptied.Deleted)
+	var provenance int
+	require.NoError(t, source.db.QueryRow(`SELECT COUNT(*) FROM provenance
+		WHERE ingest_id IN (?,?)`, named.ID(), cleared.ID()).Scan(&provenance))
+	require.Zero(t, provenance)
+	require.Equal(t, namedLabel, mustCollectionLabel(t, source, named.ID()))
+	require.Equal(t, clearedLabel, mustCollectionLabel(t, source, cleared.ID()))
+
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	require.Contains(t, exported.String(),
+		`"type":"collection_label","ingest_id":"`+named.ID()+`"`)
+	require.Contains(t, exported.String(),
+		`"type":"collection_label","ingest_id":"`+cleared.ID()+`"`)
+	var backup bytes.Buffer
+	snapshot, err := source.BeginMetadataSnapshot(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, snapshot.ExportBackup(t.Context(), &backup))
+	require.NoError(t, snapshot.Close())
+	require.Contains(t, backup.String(),
+		`"type":"collection_label","ingest_id":"`+named.ID()+`"`)
+	require.Contains(t, backup.String(),
+		`"type":"collection_label","ingest_id":"`+cleared.ID()+`"`)
+	target := newTestStore(t)
+	require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(backup.Bytes())))
+	require.Equal(t, namedLabel, mustCollectionLabel(t, target, named.ID()))
+	require.Equal(t, clearedLabel, mustCollectionLabel(t, target, cleared.ID()))
+	collections, total, err := target.Collections(t.Context(), 100, 0)
+	require.NoError(t, err)
+	require.Empty(t, collections)
+	require.Zero(t, total)
+}
+
+func TestCollectionLabelMetadataRejectsMalformedAndCollidingRecordsAtomically(t *testing.T) {
+	source := newTestStore(t)
+	first := createCollectionRun(t, source, "first.txt", "a1")
+	second := createCollectionRun(t, source, "second.txt", "b2")
+	label := "First label"
+	_, err := source.SetCollectionLabel(t.Context(), first.ID(), 1, &label)
+	require.NoError(t, err)
+	other := "Second label"
+	_, err = source.SetCollectionLabel(t.Context(), second.ID(), 1, &other)
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+
+	tests := []struct {
+		name   string
+		mutate func(string) string
+	}{
+		{name: "noncanonical NFC", mutate: func(input string) string {
+			return strings.Replace(input, `"label":"First label"`, `"label":"Cafe\u0301"`, 1)
+		}},
+		{name: "zero revision", mutate: func(input string) string {
+			return strings.Replace(input, `"label":"First label","revision":2`, `"label":"First label","revision":0`, 1)
+		}},
+		{name: "invalid time", mutate: func(input string) string {
+			return strings.Replace(input, `"updated_at":"`, `"updated_at":"invalid`, 1)
+		}},
+		{name: "label collision", mutate: func(input string) string {
+			return strings.Replace(input, `"label":"Second label"`, `"label":"First label"`, 1)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target := newTestStore(t)
+			err := target.ImportMetadata(t.Context(), strings.NewReader(test.mutate(exported.String())))
+			require.Error(t, err)
+			var ingests, labels int
+			require.NoError(t, target.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM ingests), (SELECT COUNT(*) FROM collection_labels)`).Scan(&ingests, &labels))
+			assert.Zero(t, ingests)
+			assert.Zero(t, labels)
+		})
+	}
+}
+
+func TestCollectionLabelMetadataRejectsMaterializedVirtualState(t *testing.T) {
+	source := newTestStore(t)
+	run := createCollectionRun(t, source, "note.txt", "a1")
+	_, err := source.SetCollectionLabel(t.Context(), run.ID(), 1, new("Temporary"))
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	malformed := strings.Replace(exported.String(),
+		`"label":"Temporary","revision":2`, `"label":null,"revision":1`, 1)
+	require.NotEqual(t, exported.String(), malformed)
+
+	target := newTestStore(t)
+	err = target.ImportMetadata(t.Context(), strings.NewReader(malformed))
+	require.Error(t, err)
+	var labels int
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM collection_labels`).Scan(&labels))
+	assert.Zero(t, labels)
+}
+
+func TestReleasedMetadataWithoutCollectionLabelsImports(t *testing.T) {
+	source := newTestStore(t)
+	createCollectionRun(t, source, "note.txt", "a1")
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	lines := bytes.Split(bytes.TrimSpace(exported.Bytes()), []byte{'\n'})
+	filtered := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		if !bytes.Contains(line, []byte(`"type":"collection_label"`)) {
+			filtered = append(filtered, line)
+		}
+	}
+	legacy := append(bytes.Join(filtered, []byte{'\n'}), '\n')
+	target, err := Open(filepath.Join(t.TempDir(), "legacy-target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	require.NoError(t, target.ImportMetadata(t.Context(), bytes.NewReader(legacy)))
+	var labels int
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM collection_labels`).Scan(&labels))
+	assert.Zero(t, labels)
+}
+
+func TestVersion7MetadataPreservesSavedQueriesWithoutCollectionLabels(t *testing.T) {
+	source := newTestStore(t)
+	ctx := t.Context()
+	query, err := source.CreateSavedQuery(ctx, "Synthetic query", "", SavedQueryKindQuery,
+		[]byte(`{"text":"example"}`))
+	require.NoError(t, err)
+	_, err = source.db.Exec(`DROP TABLE collection_labels`)
+	require.NoError(t, err)
+	_, err = source.db.Exec(`UPDATE vault_metadata SET schema_version=7 WHERE singleton=1`)
+	require.NoError(t, err)
+
+	var exported bytes.Buffer
+	require.NoError(t, exportMetadataSnapshotWithVaultIdentity(ctx, source.db, &exported,
+		metadataSourceLayout{schemaVersion: 7}))
+	target := newTestStore(t)
+	require.NoError(t, target.ImportMetadata(ctx, bytes.NewReader(exported.Bytes())))
+	restored, err := target.SavedQueryByID(ctx, query.ID)
+	require.NoError(t, err)
+	assert.Equal(t, query, restored)
+}
+
+func mustCollectionLabel(t *testing.T, s *Store, ingestID string) CollectionLabel {
+	t.Helper()
+	label, err := s.CollectionLabel(t.Context(), ingestID)
+	require.NoError(t, err)
+	return label
+}

--- a/internal/store/collection_test.go
+++ b/internal/store/collection_test.go
@@ -1,0 +1,170 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionsExposeActiveOperationalMembership(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	first, err := s.BeginIngest(ctx, "cli", "First synthetic import")
+	require.NoError(t, err)
+	firstNode, added, err := s.IngestFile(ctx, first, s.RootID(), "b.txt", fakeHash("a1"),
+		4, "text/plain", "/synthetic/b.txt", "")
+	require.NoError(t, err)
+	require.True(t, added)
+	secondNode, added, err := s.IngestFile(ctx, first, s.RootID(), "a.txt", fakeHash("b2"),
+		6, "text/plain", "/synthetic/a.txt", "")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	second, err := s.BeginIngest(ctx, "watch", "Second synthetic import")
+	require.NoError(t, err)
+	thirdNode, err := s.IngestFileExact(ctx, second, s.RootID(), "c.txt", fakeHash("c3"),
+		8, "text/plain", "c.txt", "")
+	require.NoError(t, err)
+
+	// One node may belong to multiple active operational runs, while repeated
+	// facts within a run must not inflate its current counts.
+	addCollectionMembership(t, s, second, firstNode.ID, "/other/b.txt", nil)
+	addCollectionMembership(t, s, first, firstNode.ID, "/duplicate/b.txt", nil)
+
+	embedded, err := s.BeginCallerSuppliedIngest(ctx, "cli", "Application assertion")
+	require.NoError(t, err)
+	_, err = s.IngestFileExact(ctx, embedded, s.RootID(), "private.txt", fakeHash("d4"),
+		10, "text/plain", "opaque/private.txt", "")
+	require.NoError(t, err)
+
+	collections, total, err := s.Collections(ctx, 100, 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, total)
+	require.Len(t, collections, 2)
+	assert.Equal(t, second.ID(), collections[0].ID)
+	assert.Equal(t, int64(2), collections[0].FileCount)
+	assert.Equal(t, int64(12), collections[0].TotalBytes)
+	assert.Equal(t, first.ID(), collections[1].ID)
+	assert.Equal(t, int64(2), collections[1].FileCount)
+	assert.Equal(t, int64(10), collections[1].TotalBytes)
+	assert.Nil(t, collections[1].Label)
+	assert.Equal(t, int64(1), collections[1].LabelRevision)
+	assert.Equal(t, first.record.StartedAt, collections[1].LabelUpdatedAt)
+
+	page, err := s.CollectionMembers(ctx, first.ID(), 1, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, page.Total)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, secondNode.ID, page.Items[0].Node.ID)
+	assert.Equal(t, "/a.txt", page.Items[0].Path)
+	assert.Equal(t, collections[1], page.Collection)
+
+	page, err = s.CollectionMembers(ctx, first.ID(), 1, 1)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, firstNode.ID, page.Items[0].Node.ID)
+	assert.Equal(t, "/b.txt", page.Items[0].Path)
+
+	detail, err := s.CollectionByID(ctx, second.ID())
+	require.NoError(t, err)
+	assert.Equal(t, thirdNode.Size+firstNode.Size, detail.TotalBytes)
+	_, err = s.CollectionByID(ctx, embedded.ID())
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.CollectionMembers(ctx, embedded.ID(), 10, 0)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCollectionMembershipFollowsSupersessionAndTrash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	dir, err := s.Mkdir(ctx, s.RootID(), "records")
+	require.NoError(t, err)
+	run, err := s.BeginIngest(ctx, "cli", "Synthetic import")
+	require.NoError(t, err)
+	node, added, err := s.IngestFile(ctx, run, dir.ID, "note.txt", fakeHash("a1"),
+		4, "text/plain", "/synthetic/note.txt", "")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	collection, err := s.CollectionByID(ctx, run.ID())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), collection.FileCount)
+
+	_, _, err = s.Trash(ctx, dir.ID, UnconditionalRev)
+	require.NoError(t, err)
+	_, err = s.CollectionByID(ctx, run.ID())
+	require.ErrorIs(t, err, ErrNotFound)
+	collections, total, err := s.Collections(ctx, 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, collections)
+	assert.Zero(t, total)
+
+	_, _, err = s.Restore(ctx, dir.ID, UnconditionalRev)
+	require.NoError(t, err)
+	collection, err = s.CollectionByID(ctx, run.ID())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), collection.FileCount)
+
+	var prior string
+	require.NoError(t, s.db.QueryRow(`SELECT identity FROM provenance WHERE node_id=?`, node.ID).Scan(&prior))
+	correction, err := s.BeginCallerSuppliedIngest(ctx, "correction", "Synthetic correction")
+	require.NoError(t, err)
+	addCollectionMembership(t, s, correction, node.ID, "opaque/corrected.txt", &prior)
+	_, err = s.CollectionByID(ctx, run.ID())
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCollectionReadBounds(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	run, err := s.BeginIngest(ctx, "cli", "Synthetic import")
+	require.NoError(t, err)
+	_, _, err = s.IngestFile(ctx, run, s.RootID(), "note.txt", fakeHash("a1"),
+		4, "text/plain", "/synthetic/note.txt", "")
+	require.NoError(t, err)
+
+	collections, total, err := s.Collections(ctx, 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, collections, 1)
+	assert.Equal(t, 1, total)
+	_, _, err = s.Collections(ctx, 0, 0)
+	require.Error(t, err)
+	_, _, err = s.Collections(ctx, 1001, 0)
+	require.Error(t, err)
+	_, _, err = s.Collections(ctx, 10, -1)
+	require.Error(t, err)
+	_, err = s.CollectionMembers(ctx, run.ID(), 1001, 0)
+	require.Error(t, err)
+	_, err = s.CollectionMembers(ctx, run.ID(), 10, -1)
+	require.Error(t, err)
+}
+
+func addCollectionMembership(
+	t *testing.T, s *Store, run IngestRun, nodeID int64, originalPath string, supersedes *string,
+) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		if _, err := ensureIngestRunTx(ctx, tx, run); err != nil {
+			return err
+		}
+		fact := metadataProvenance{
+			Type: metadataProvenanceType, NodeID: nodeID, IngestID: run.ID(),
+			OriginalPath: originalPath, Supersedes: supersedes,
+		}
+		identity, err := provenanceIdentity(fact)
+		if err != nil {
+			return err
+		}
+		fact.Identity = identity
+		_, err = tx.Exec(`INSERT INTO provenance(
+			identity,node_id,ingest_id,original_path,original_mtime,supersedes
+		) VALUES(?,?,?,?,?,?)`, fact.Identity, fact.NodeID, fact.IngestID,
+			fact.OriginalPath, fact.OriginalMTime, fact.Supersedes)
+		return err
+	}))
+}

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -12,9 +12,14 @@ import (
 // Keep the stored prefix compatible with existing provenance records.
 const callerSuppliedSourceKindPrefix = "embedded:"
 
+func sourceKindIsEmbedded(kind string) bool {
+	return len(kind) >= len(callerSuppliedSourceKindPrefix) &&
+		strings.EqualFold(kind[:len(callerSuppliedSourceKindPrefix)], callerSuppliedSourceKindPrefix)
+}
+
 func publicProvenanceSourceKind(kind string) string {
-	if supplied, ok := strings.CutPrefix(kind, callerSuppliedSourceKindPrefix); ok {
-		return supplied
+	if sourceKindIsEmbedded(kind) {
+		return kind[len(callerSuppliedSourceKindPrefix):]
 	}
 	return kind
 }
@@ -25,6 +30,7 @@ func publicProvenanceSourceKind(kind string) string {
 type IngestRun struct {
 	record           metadataIngest
 	operationalWatch bool
+	initialLabel     *string
 }
 
 // ID returns the stable ingest identity.
@@ -34,7 +40,33 @@ func (r IngestRun) ID() string { return r.record.ID }
 // atomically with the first file that actually imports, so audited vaults never
 // contain a run whose provenance was committed in a separate transaction.
 func (s *Store) BeginIngest(ctx context.Context, sourceKind, sourceDesc string) (IngestRun, error) {
-	return s.beginIngest(ctx, sourceKind, sourceDesc, sourceKind == "watch")
+	return s.BeginIngestWithLabel(ctx, sourceKind, sourceDesc, nil)
+}
+
+// BeginIngestWithLabel prepares an authority-free ingest run carrying an
+// optional initial collection label. The run and label publish atomically with
+// its first committed document observation.
+func (s *Store) BeginIngestWithLabel(
+	ctx context.Context, sourceKind, sourceDesc string, label *string,
+) (IngestRun, error) {
+	normalizedValue, hasLabel, err := normalizeOptionalCollectionLabel(label)
+	if err != nil {
+		return IngestRun{}, err
+	}
+	if hasLabel && sourceKindIsEmbedded(sourceKind) {
+		return IngestRun{}, fmt.Errorf(
+			"%w: caller-supplied provenance cannot define a collection label",
+			ErrInvalidCollectionLabel,
+		)
+	}
+	run, err := s.beginIngest(ctx, sourceKind, sourceDesc, sourceKind == "watch")
+	if err != nil {
+		return IngestRun{}, err
+	}
+	if hasLabel {
+		run.initialLabel = &normalizedValue
+	}
+	return run, nil
 }
 
 // BeginCallerSuppliedIngest prepares generic provenance without interpreting any
@@ -136,6 +168,21 @@ func ensureIngestRunTx(ctx context.Context, tx *sql.Tx, run IngestRun) (bool, er
 	if err := validateIngestRecord(run.record); err != nil {
 		return false, fmt.Errorf("validating ingest run: %w", err)
 	}
+	var alreadyStored bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM ingests WHERE id=?)`, run.record.ID,
+	).Scan(&alreadyStored); err != nil {
+		return false, fmt.Errorf("checking ingest run %s: %w", run.record.ID, err)
+	}
+	if run.initialLabel != nil && !alreadyStored {
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return false, err
+		}
+		if active {
+			return false, ErrAuditMutationUnsupported
+		}
+	}
 	result, err := tx.ExecContext(ctx,
 		`INSERT OR IGNORE INTO ingests (id, started_at, source_kind, source_desc)
 		 VALUES (?, ?, ?, ?)`,
@@ -158,6 +205,11 @@ func ensureIngestRunTx(ctx context.Context, tx *sql.Tx, run IngestRun) (bool, er
 	if stored.ID != run.record.ID || stored.StartedAt != run.record.StartedAt ||
 		stored.SourceKind != run.record.SourceKind || stored.SourceDesc != run.record.SourceDesc {
 		return false, fmt.Errorf("ingest identity %s names different immutable metadata", run.record.ID)
+	}
+	if inserted == 1 {
+		if err := insertInitialCollectionLabelTx(ctx, tx, run); err != nil {
+			return false, err
+		}
 	}
 	return inserted == 1, nil
 }
@@ -268,7 +320,7 @@ func sameOriginTx(
 			return false, fmt.Errorf("scanning provenance of node %d: %w", nodeID, err)
 		}
 		sawProvenance = true
-		if strings.HasPrefix(storedSourceKind, callerSuppliedSourceKindPrefix) {
+		if sourceKindIsEmbedded(storedSourceKind) {
 			continue
 		}
 		if storedSourceKind != sourceKind {
@@ -292,8 +344,8 @@ func sameOriginTx(
 // applying the idempotency rule and recording provenance. Returns
 // added=false when the content is already present under a candidate name.
 func (s *Store) IngestFile(ctx context.Context, run IngestRun, parentID int64, name, blobHash string, size int64, mimeType, originalPath, originalMtime string, physical ...BlobPhysical) (Node, bool, error) {
-	receipt, added, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
-		originalPath, originalMtime, false, false, physical...)
+	receipt, added, _, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
+		originalPath, originalMtime, ingestFileOptions{}, physical...)
 	return receipt.Node, added, err
 }
 
@@ -301,8 +353,8 @@ func (s *Store) IngestFile(ctx context.Context, run IngestRun, parentID int64, n
 // bulk migration it never suffixes or adopts an existing same-content node;
 // a watched source needs its configured source identity to remain one-to-one.
 func (s *Store) IngestFileExact(ctx context.Context, run IngestRun, parentID int64, name, blobHash string, size int64, mimeType, originalPath, originalMtime string, physical ...BlobPhysical) (Node, error) {
-	receipt, _, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
-		originalPath, originalMtime, true, false, physical...)
+	receipt, _, _, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
+		originalPath, originalMtime, ingestFileOptions{exact: true}, physical...)
 	return receipt.Node, err
 }
 
@@ -313,22 +365,34 @@ func (s *Store) IngestFileExactWithReceipt(
 	ctx context.Context, run IngestRun, parentID int64, name, blobHash string,
 	size int64, mimeType, originalPath, originalMtime string, physical ...BlobPhysical,
 ) (ContentWriteReceipt, error) {
-	receipt, _, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
-		originalPath, originalMtime, true, true, physical...)
+	receipt, _, _, err := s.ingestFile(ctx, run, parentID, name, blobHash, size, mimeType,
+		originalPath, originalMtime, ingestFileOptions{exact: true, completeReceipt: true}, physical...)
 	return receipt, err
+}
+
+type ingestFileOptions struct {
+	exact             bool
+	completeReceipt   bool
+	observeMembership bool
+	directoryPlan     *IngestDirectoryPlan
 }
 
 func (s *Store) ingestFile(
 	ctx context.Context, run IngestRun, parentID int64, name, blobHash string,
-	size int64, mimeType, originalPath, originalMtime string, exact, completeReceipt bool,
+	size int64, mimeType, originalPath, originalMtime string, options ingestFileOptions,
 	physical ...BlobPhysical,
-) (ContentWriteReceipt, bool, error) {
+) (ContentWriteReceipt, bool, IngestDirectoryResolution, error) {
 	name, err := NormalizeName(name)
 	if err != nil {
-		return ContentWriteReceipt{}, false, err
+		return ContentWriteReceipt{}, false, IngestDirectoryResolution{}, err
 	}
 	if err := validateIngestRecord(run.record); err != nil {
-		return ContentWriteReceipt{}, false, fmt.Errorf("validating ingest run: %w", err)
+		return ContentWriteReceipt{}, false, IngestDirectoryResolution{}, fmt.Errorf("validating ingest run: %w", err)
+	}
+	if options.directoryPlan != nil {
+		if err := validateIngestDirectoryPlan(*options.directoryPlan); err != nil {
+			return ContentWriteReceipt{}, false, IngestDirectoryResolution{}, err
+		}
 	}
 	var recordedMtime *string
 	if originalMtime != "" {
@@ -339,15 +403,31 @@ func (s *Store) ingestFile(
 		OriginalPath: originalPath, OriginalMTime: recordedMtime,
 	}
 	if err := validateProvenanceFields(provenance); err != nil {
-		return ContentWriteReceipt{}, false, fmt.Errorf("validating ingest provenance: %w", err)
+		return ContentWriteReceipt{}, false, IngestDirectoryResolution{}, fmt.Errorf("validating ingest provenance: %w", err)
 	}
 	var (
-		receipt ContentWriteReceipt
-		added   bool
+		receipt    ContentWriteReceipt
+		added      bool
+		resolution IngestDirectoryResolution
 	)
 	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		ingestAdded := false
+		if options.directoryPlan != nil || options.observeMembership {
+			ingestAdded, err = s.ensureIngestRunForMutationTx(ctx, tx, run)
+			if err != nil {
+				return err
+			}
+		}
+		if options.directoryPlan != nil {
+			leaf, resolved, err := s.ensureIngestDirectoryTx(ctx, tx, *options.directoryPlan)
+			if err != nil {
+				return err
+			}
+			parentID = leaf.ID
+			resolution = resolved
+		}
 		finalName := name
-		if exact {
+		if options.exact {
 			var existingID int64
 			err := tx.QueryRow(
 				`SELECT id FROM nodes WHERE parent_id = ? AND name = ? AND trashed_at IS NULL`,
@@ -378,7 +458,20 @@ func (s *Store) ingestFile(
 				if err != nil {
 					return fmt.Errorf("reading idempotent ingest node %d: %w", existingID, err)
 				}
-				if !completeReceipt {
+				if options.observeMembership {
+					provenance.NodeID = receipt.Node.ID
+					provenance.Identity, err = provenanceIdentity(provenance)
+					if err != nil {
+						return fmt.Errorf("identifying ingest observation for %q: %w", name, err)
+					}
+					receipt.Node, err = s.observeOperationalIngestTx(
+						ctx, tx, run, receipt.Node, provenance, ingestAdded,
+					)
+					if err != nil {
+						return err
+					}
+				}
+				if !options.completeReceipt {
 					return nil
 				}
 				receipt.Version, err = scanContentVersion(tx.QueryRow(
@@ -414,9 +507,11 @@ func (s *Store) ingestFile(
 				return err
 			}
 		}
-		ingestAdded, err := ensureIngestRunTx(ctx, tx, run)
-		if err != nil {
-			return err
+		if options.directoryPlan == nil && !options.observeMembership {
+			ingestAdded, err = s.ensureIngestRunForMutationTx(ctx, tx, run)
+			if err != nil {
+				return err
+			}
 		}
 		operation, err := newContentVersionOperation()
 		if err != nil {
@@ -472,7 +567,7 @@ func (s *Store) ingestFile(
 				return err
 			}
 		}
-		if completeReceipt {
+		if options.completeReceipt {
 			receipt.Physical, err = authorizedPhysicalContentTx(tx, blobHash)
 			if err != nil {
 				return err
@@ -482,9 +577,9 @@ func (s *Store) ingestFile(
 		return nil
 	})
 	if err != nil {
-		return ContentWriteReceipt{}, false, err
+		return ContentWriteReceipt{}, false, IngestDirectoryResolution{}, err
 	}
-	return receipt, added, nil
+	return receipt, added, resolution, nil
 }
 
 func insertWatchSourceTx(

--- a/internal/store/ingest_directory.go
+++ b/internal/store/ingest_directory.go
@@ -1,0 +1,294 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// IngestDirectoryPlan is an authority-free directory coordinate anchored at
+// the deepest live directory identity observed during preparation.
+type IngestDirectoryPlan struct {
+	anchorID int64
+	segments []string
+}
+
+// IngestDirectoryResolution identifies the directory prefixes resolved by one
+// committed ingest mutation.
+type IngestDirectoryResolution struct {
+	anchorID int64
+	segments []string
+	nodeIDs  []int64
+}
+
+// ResolvedID returns the stable directory identity when the whole plan was
+// already resolved.
+func (p IngestDirectoryPlan) ResolvedID() (int64, bool) {
+	return p.anchorID, len(p.segments) == 0
+}
+
+// Rebase anchors plan at the deepest directory identity shared with this
+// committed resolution and retains any still-unresolved suffix.
+func (r IngestDirectoryResolution) Rebase(plan IngestDirectoryPlan) IngestDirectoryPlan {
+	if len(plan.segments) == 0 || plan.anchorID != r.anchorID {
+		return plan
+	}
+	common := 0
+	for common < len(plan.segments) && common < len(r.segments) &&
+		plan.segments[common] == r.segments[common] {
+		common++
+	}
+	if common == 0 {
+		return plan
+	}
+	return IngestDirectoryPlan{
+		anchorID: r.nodeIDs[common-1],
+		segments: append([]string(nil), plan.segments[common:]...),
+	}
+}
+
+// PrepareIngestDirectory resolves as much of path as currently exists without
+// creating metadata authority.
+func (s *Store) PrepareIngestDirectory(
+	ctx context.Context, path string,
+) (IngestDirectoryPlan, error) {
+	segments, err := normalizeIngestDirectorySegments(path, splitPath(path))
+	if err != nil {
+		return IngestDirectoryPlan{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return IngestDirectoryPlan{}, fmt.Errorf("beginning ingest directory snapshot: %w", err)
+	}
+	plan, err := prepareIngestDirectoryTx(ctx, tx, s.rootID, segments)
+	if err != nil {
+		_ = tx.Rollback()
+		return IngestDirectoryPlan{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return IngestDirectoryPlan{}, fmt.Errorf("closing ingest directory snapshot: %w", err)
+	}
+	return plan, nil
+}
+
+// ExtendIngestDirectory resolves existing child names beneath a stable plan
+// without creating metadata authority.
+func (s *Store) ExtendIngestDirectory(
+	ctx context.Context, plan IngestDirectoryPlan, names ...string,
+) (IngestDirectoryPlan, error) {
+	normalized, err := normalizeIngestDirectorySegments("ingest child", names)
+	if err != nil {
+		return IngestDirectoryPlan{}, err
+	}
+	if err := validateIngestDirectoryPlan(plan); err != nil {
+		return IngestDirectoryPlan{}, err
+	}
+	if len(plan.segments) != 0 {
+		plan.segments = append(append([]string(nil), plan.segments...), normalized...)
+		return plan, nil
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return IngestDirectoryPlan{}, fmt.Errorf("beginning ingest directory snapshot: %w", err)
+	}
+	extended, err := prepareIngestDirectoryTx(ctx, tx, plan.anchorID, normalized)
+	if err != nil {
+		_ = tx.Rollback()
+		return IngestDirectoryPlan{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return IngestDirectoryPlan{}, fmt.Errorf("closing ingest directory snapshot: %w", err)
+	}
+	return extended, nil
+}
+
+func normalizeIngestDirectorySegments(path string, segments []string) ([]string, error) {
+	normalized := make([]string, len(segments))
+	for i, segment := range segments {
+		name, err := NormalizeName(segment)
+		if err != nil {
+			return nil, fmt.Errorf("path %q: %w", path, err)
+		}
+		normalized[i] = name
+	}
+	return normalized, nil
+}
+
+func validateIngestDirectoryPlan(plan IngestDirectoryPlan) error {
+	if plan.anchorID <= 0 {
+		return errors.New("ingest directory plan has no anchor")
+	}
+	for _, segment := range plan.segments {
+		if _, err := NormalizeName(segment); err != nil {
+			return fmt.Errorf("invalid ingest directory plan: %w", err)
+		}
+	}
+	return nil
+}
+
+func prepareIngestDirectoryTx(
+	ctx context.Context, tx *sql.Tx, anchorID int64, segments []string,
+) (IngestDirectoryPlan, error) {
+	anchor, err := liveDirTx(tx, anchorID)
+	if err != nil {
+		return IngestDirectoryPlan{}, err
+	}
+	for i, segment := range segments {
+		next, err := childByName(ctx, tx, anchor.ID, segment)
+		switch {
+		case err == nil:
+			if !next.IsDir() {
+				return IngestDirectoryPlan{}, fmt.Errorf("path segment %q: %w", segment, ErrNotDir)
+			}
+			anchor = next
+		case errors.Is(err, ErrNotFound):
+			return IngestDirectoryPlan{
+				anchorID: anchor.ID,
+				segments: append([]string(nil), segments[i:]...),
+			}, nil
+		default:
+			return IngestDirectoryPlan{}, err
+		}
+	}
+	return IngestDirectoryPlan{anchorID: anchor.ID}, nil
+}
+
+func (s *Store) ensureIngestDirectoryTx(
+	ctx context.Context, tx *sql.Tx, plan IngestDirectoryPlan,
+) (Node, IngestDirectoryResolution, error) {
+	if err := validateIngestDirectoryPlan(plan); err != nil {
+		return Node{}, IngestDirectoryResolution{}, err
+	}
+	leaf, err := liveDirTx(tx, plan.anchorID)
+	if err != nil {
+		return Node{}, IngestDirectoryResolution{}, err
+	}
+	resolution := IngestDirectoryResolution{
+		anchorID: plan.anchorID,
+		segments: append([]string(nil), plan.segments...),
+		nodeIDs:  make([]int64, 0, len(plan.segments)),
+	}
+	for _, segment := range plan.segments {
+		next, childErr := childByName(ctx, tx, leaf.ID, segment)
+		switch {
+		case childErr == nil:
+			if !next.IsDir() {
+				return Node{}, IngestDirectoryResolution{}, fmt.Errorf(
+					"path segment %q: %w", segment, ErrNotDir,
+				)
+			}
+		case errors.Is(childErr, ErrNotFound):
+			next, childErr = s.mkdirNodeTx(ctx, tx, leaf.ID, segment)
+			if childErr != nil {
+				return Node{}, IngestDirectoryResolution{}, childErr
+			}
+		default:
+			return Node{}, IngestDirectoryResolution{}, childErr
+		}
+		leaf = next
+		resolution.nodeIDs = append(resolution.nodeIDs, leaf.ID)
+	}
+	return leaf, resolution, nil
+}
+
+type initialIngestAdmissionError struct{ cause error }
+
+func (e initialIngestAdmissionError) Error() string { return e.cause.Error() }
+func (e initialIngestAdmissionError) Unwrap() error { return e.cause }
+
+// IsInitialIngestAdmissionError reports whether err rejected the run's initial
+// label before the surrounding ingest mutation could publish authority.
+func IsInitialIngestAdmissionError(err error) bool {
+	var admission initialIngestAdmissionError
+	return errors.As(err, &admission)
+}
+
+func (s *Store) ensureIngestRunForMutationTx(
+	ctx context.Context, tx *sql.Tx, run IngestRun,
+) (bool, error) {
+	inserted, err := ensureIngestRunTx(ctx, tx, run)
+	if err == nil || run.initialLabel == nil {
+		return inserted, err
+	}
+	if s.driver.IsUniqueViolation(err) {
+		return false, initialIngestAdmissionError{cause: fmt.Errorf(
+			"collection label %q: %w", *run.initialLabel, ErrExists,
+		)}
+	}
+	if errors.Is(err, ErrAuditMutationUnsupported) {
+		return false, initialIngestAdmissionError{cause: err}
+	}
+	return false, err
+}
+
+// IngestDirectoryError identifies the failed plan in a finalization batch.
+type IngestDirectoryError struct {
+	Index int
+	Err   error
+}
+
+func (e *IngestDirectoryError) Error() string { return e.Err.Error() }
+func (e *IngestDirectoryError) Unwrap() error { return e.Err }
+
+// FinalizeIngestDirectories commits a labeled filesystem import's remaining
+// directories. A zero-document run is admitted inside the transaction and
+// removed again before commit, so no collection receipt is published.
+func (s *Store) FinalizeIngestDirectories(
+	ctx context.Context, run IngestRun, plans []IngestDirectoryPlan,
+) ([]IngestDirectoryResolution, error) {
+	if run.initialLabel == nil {
+		return nil, errors.New("finalizing ingest directories requires an initial label")
+	}
+	for index, plan := range plans {
+		if err := validateIngestDirectoryPlan(plan); err != nil {
+			return nil, &IngestDirectoryError{Index: index, Err: err}
+		}
+	}
+	resolutions := make([]IngestDirectoryResolution, 0, len(plans))
+	err := s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		inserted, err := s.ensureIngestRunForMutationTx(ctx, tx, run)
+		if err != nil {
+			return err
+		}
+		for index, plan := range plans {
+			_, resolution, err := s.ensureIngestDirectoryTx(ctx, tx, plan)
+			if err != nil {
+				return &IngestDirectoryError{Index: index, Err: err}
+			}
+			resolutions = append(resolutions, resolution)
+		}
+		if !inserted {
+			return nil
+		}
+		labelResult, err := tx.ExecContext(ctx,
+			`DELETE FROM collection_labels WHERE ingest_id=?`, run.ID(),
+		)
+		if err != nil {
+			return fmt.Errorf("removing zero-document collection label: %w", err)
+		}
+		labelRows, err := labelResult.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("checking zero-document collection label removal: %w", err)
+		}
+		if labelRows != 1 {
+			return fmt.Errorf("removing zero-document collection label changed %d rows", labelRows)
+		}
+		runResult, err := tx.ExecContext(ctx, `DELETE FROM ingests WHERE id=?`, run.ID())
+		if err != nil {
+			return fmt.Errorf("removing zero-document ingest: %w", err)
+		}
+		runRows, err := runResult.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("checking zero-document ingest removal: %w", err)
+		}
+		if runRows != 1 {
+			return fmt.Errorf("removing zero-document ingest changed %d rows", runRows)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resolutions, nil
+}

--- a/internal/store/ingest_directory_test.go
+++ b/internal/store/ingest_directory_test.go
@@ -1,0 +1,293 @@
+package store
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlannedIngestRejectsConcurrentLabelWithoutDirectoryAuthority(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	label := "Synthetic review"
+	plan, err := s.PrepareIngestDirectory(ctx, "/new/inbox/sub")
+	require.NoError(t, err)
+
+	winner, err := s.BeginIngestWithLabel(ctx, "cli", "winner", &label)
+	require.NoError(t, err)
+	_, _, err = s.IngestFileWithMembership(
+		ctx, winner, s.RootID(), "winner.txt", fakeHash("a1"), 1,
+		"text/plain", "/synthetic/winner.txt", "",
+	)
+	require.NoError(t, err)
+	beforeRoot, err := s.NodeByID(ctx, s.RootID())
+	require.NoError(t, err)
+	before := exportStoreMetadata(t, s)
+
+	loser, err := s.BeginIngestWithLabel(ctx, "cli", "loser", &label)
+	require.NoError(t, err)
+	var resolution IngestDirectoryResolution
+	_, _, resolution, err = s.IngestFileWithMembershipPlanned(
+		ctx, loser, plan, "note.txt", fakeHash("b2"), 1,
+		"text/plain", "/synthetic/sub/note.txt", "",
+	)
+	require.ErrorIs(t, err, ErrExists)
+	assert.Zero(t, resolution)
+	assert.True(t, IsInitialIngestAdmissionError(err))
+	assert.Equal(t, before, exportStoreMetadata(t, s))
+	afterRoot, err := s.NodeByID(ctx, s.RootID())
+	require.NoError(t, err)
+	assert.Equal(t, beforeRoot, afterRoot)
+	_, err = s.NodeByPath(ctx, "/new")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestPlannedIngestRejectsAuditActivatedAfterPreparation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	label := "Synthetic audited review"
+	plan, err := s.PrepareIngestDirectory(ctx, "/new/inbox/sub")
+	require.NoError(t, err)
+	baseline, err := s.PreviewInitialAudit(ctx, s.RootID(), "api", nil)
+	require.NoError(t, err)
+	_, err = s.EnableInitialAudit(ctx, baseline)
+	require.NoError(t, err)
+	beforeRoot, err := s.NodeByID(ctx, s.RootID())
+	require.NoError(t, err)
+	before := exportStoreMetadata(t, s)
+
+	run, err := s.BeginIngestWithLabel(ctx, "cli", "audited", &label)
+	require.NoError(t, err)
+	var resolution IngestDirectoryResolution
+	_, _, resolution, err = s.IngestFileWithMembershipPlanned(
+		ctx, run, plan, "note.txt", fakeHash("a1"), 1,
+		"text/plain", "/synthetic/sub/note.txt", "",
+	)
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	assert.Zero(t, resolution)
+	assert.True(t, IsInitialIngestAdmissionError(err))
+	assert.Equal(t, before, exportStoreMetadata(t, s))
+	afterRoot, err := s.NodeByID(ctx, s.RootID())
+	require.NoError(t, err)
+	assert.Equal(t, beforeRoot, afterRoot)
+	_, err = s.NodeByPath(ctx, "/new")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestPlannedIngestKeepsResolvedDirectoryIdentity(t *testing.T) {
+	t.Run("rename", func(t *testing.T) {
+		s := newTestStore(t)
+		ctx := t.Context()
+		dest, err := s.Mkdir(ctx, s.RootID(), "inbox")
+		require.NoError(t, err)
+		child, err := s.Mkdir(ctx, dest.ID, "observed-child")
+		require.NoError(t, err)
+		plan, err := s.PrepareIngestDirectory(ctx, "/inbox/observed-child")
+		require.NoError(t, err)
+		moved, _, err := s.Move(ctx, child.ID, s.RootID(), "renamed", child.Revision)
+		require.NoError(t, err)
+		label := "Renamed destination"
+		run, err := s.BeginIngestWithLabel(ctx, "cli", "rename", &label)
+		require.NoError(t, err)
+		node, _, _, err := s.IngestFileWithMembershipPlanned(
+			ctx, run, plan, "note.txt", fakeHash("a1"), 1,
+			"text/plain", "/synthetic/note.txt", "",
+		)
+		require.NoError(t, err)
+		require.NotNil(t, node.ParentID)
+		assert.Equal(t, moved.ID, *node.ParentID)
+		_, err = s.NodeByPath(ctx, "/inbox/observed-child")
+		require.ErrorIs(t, err, ErrNotFound)
+		_, err = s.NodeByPath(ctx, "/renamed/note.txt")
+		require.NoError(t, err)
+	})
+
+	t.Run("trash", func(t *testing.T) {
+		s := newTestStore(t)
+		ctx := t.Context()
+		dest, err := s.Mkdir(ctx, s.RootID(), "inbox")
+		require.NoError(t, err)
+		plan, err := s.PrepareIngestDirectory(ctx, "/inbox/sub")
+		require.NoError(t, err)
+		_, _, err = s.Trash(ctx, dest.ID, dest.Revision)
+		require.NoError(t, err)
+		before := exportStoreMetadata(t, s)
+		label := "Trashed destination"
+		run, err := s.BeginIngestWithLabel(ctx, "cli", "trash", &label)
+		require.NoError(t, err)
+		_, _, _, err = s.IngestFileWithMembershipPlanned(
+			ctx, run, plan, "note.txt", fakeHash("a1"), 1,
+			"text/plain", "/synthetic/note.txt", "",
+		)
+		require.ErrorIs(t, err, ErrNotFound)
+		assert.Equal(t, before, exportStoreMetadata(t, s))
+		_, err = s.NodeByPath(ctx, "/inbox")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
+func TestFinalizePlannedIngestDirectoriesLeavesNoZeroDocumentReceipt(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	label := "Empty synthetic tree"
+	run, err := s.BeginIngestWithLabel(ctx, "cli", "empty", &label)
+	require.NoError(t, err)
+	plan, err := s.PrepareIngestDirectory(ctx, "/new/inbox/empty")
+	require.NoError(t, err)
+
+	_, err = s.FinalizeIngestDirectories(ctx, run, []IngestDirectoryPlan{plan})
+	require.NoError(t, err)
+	_, err = s.NodeByPath(ctx, "/new/inbox/empty")
+	require.NoError(t, err)
+	_, err = s.CollectionByID(ctx, run.ID())
+	require.ErrorIs(t, err, ErrNotFound)
+	var ingests, labels, provenance int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM ingests),
+		(SELECT COUNT(*) FROM collection_labels),
+		(SELECT COUNT(*) FROM provenance)`).Scan(&ingests, &labels, &provenance))
+	assert.Zero(t, ingests)
+	assert.Zero(t, labels)
+	assert.Zero(t, provenance)
+}
+
+func TestFinalizePlannedIngestDirectoriesRejectsEmptyOnlyAdmission(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		setup func(*testing.T, *Store, *string)
+		want  error
+	}{
+		{
+			name: "label collision",
+			setup: func(t *testing.T, s *Store, label *string) {
+				t.Helper()
+				run, err := s.BeginIngestWithLabel(t.Context(), "cli", "winner", label)
+				require.NoError(t, err)
+				_, _, err = s.IngestFileWithMembership(
+					t.Context(), run, s.RootID(), "winner.txt", fakeHash("a1"), 1,
+					"text/plain", "/synthetic/winner.txt", "",
+				)
+				require.NoError(t, err)
+			},
+			want: ErrExists,
+		},
+		{
+			name: "active audit",
+			setup: func(t *testing.T, s *Store, _ *string) {
+				t.Helper()
+				plan, err := s.PreviewInitialAudit(t.Context(), s.RootID(), "api", nil)
+				require.NoError(t, err)
+				_, err = s.EnableInitialAudit(t.Context(), plan)
+				require.NoError(t, err)
+			},
+			want: ErrAuditMutationUnsupported,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := newTestStore(t)
+			label := "Empty admission"
+			plan, err := s.PrepareIngestDirectory(t.Context(), "/new/inbox/empty")
+			require.NoError(t, err)
+			test.setup(t, s, &label)
+			before := exportStoreMetadata(t, s)
+			run, err := s.BeginIngestWithLabel(t.Context(), "cli", "empty loser", &label)
+			require.NoError(t, err)
+
+			_, err = s.FinalizeIngestDirectories(
+				t.Context(), run, []IngestDirectoryPlan{plan},
+			)
+			require.ErrorIs(t, err, test.want)
+			assert.True(t, IsInitialIngestAdmissionError(err))
+			assert.Equal(t, before, exportStoreMetadata(t, s))
+			_, err = s.NodeByPath(t.Context(), "/new")
+			require.ErrorIs(t, err, ErrNotFound)
+		})
+	}
+}
+
+func TestPlannedExactConflictIsNotLabelAdmissionRejection(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	plan, err := s.PrepareIngestDirectory(ctx, "/new/inbox")
+	require.NoError(t, err)
+	parent, err := s.MkdirAll(ctx, "/new/inbox")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, parent.ID, "note.txt", fakeHash("a1"), 1, "text/plain")
+	require.NoError(t, err)
+	label := "Exact create"
+	run, err := s.BeginIngestWithLabel(ctx, "cli", "exact", &label)
+	require.NoError(t, err)
+
+	_, _, err = s.IngestFileExactPlanned(
+		ctx, run, plan, "note.txt", fakeHash("b2"), 1,
+		"text/plain", "/synthetic/note.txt", "",
+	)
+	require.ErrorIs(t, err, ErrExists)
+	assert.False(t, IsInitialIngestAdmissionError(err))
+	_, err = s.NodeByPath(ctx, "/new/inbox/note (2).txt")
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.CollectionByID(ctx, run.ID())
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestIngestDirectoryResolutionKeepsSharedParentIdentity(t *testing.T) {
+	for _, mutation := range []string{"move", "trash"} {
+		t.Run(mutation, func(t *testing.T) {
+			s := newTestStore(t)
+			ctx := t.Context()
+			parentPlan, err := s.PrepareIngestDirectory(ctx, "/new/inbox/source")
+			require.NoError(t, err)
+			emptyPlan, err := s.ExtendIngestDirectory(ctx, parentPlan, "a-empty")
+			require.NoError(t, err)
+			siblingPlan, err := s.ExtendIngestDirectory(ctx, parentPlan, "sibling")
+			require.NoError(t, err)
+			label := "Common prefix " + mutation
+			run, err := s.BeginIngestWithLabel(ctx, "cli", mutation, &label)
+			require.NoError(t, err)
+			_, _, resolution, err := s.IngestFileWithMembershipPlanned(
+				ctx, run, parentPlan, "note.txt", fakeHash("a1"), 1,
+				"text/plain", "/synthetic/note.txt", "",
+			)
+			require.NoError(t, err)
+			resolvedParent := resolution.Rebase(parentPlan)
+			parentID, ok := resolvedParent.ResolvedID()
+			require.True(t, ok)
+			emptyPlan = resolution.Rebase(emptyPlan)
+			siblingPlan = resolution.Rebase(siblingPlan)
+			parent, err := s.NodeByID(ctx, parentID)
+			require.NoError(t, err)
+			if mutation == "move" {
+				_, _, err = s.Move(ctx, parent.ID, s.RootID(), "moved-source", parent.Revision)
+			} else {
+				_, _, err = s.Trash(ctx, parent.ID, parent.Revision)
+			}
+			require.NoError(t, err)
+			beforeFinalize := exportStoreMetadata(t, s)
+
+			_, err = s.FinalizeIngestDirectories(
+				ctx, run, []IngestDirectoryPlan{emptyPlan, siblingPlan},
+			)
+			if mutation == "move" {
+				require.NoError(t, err)
+				_, err = s.NodeByPath(ctx, "/moved-source/a-empty")
+				require.NoError(t, err)
+				_, err = s.NodeByPath(ctx, "/moved-source/sibling")
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, ErrNotFound)
+				assert.Equal(t, beforeFinalize, exportStoreMetadata(t, s))
+			}
+			_, err = s.NodeByPath(ctx, "/new/inbox/source")
+			require.ErrorIs(t, err, ErrNotFound)
+		})
+	}
+}
+
+func exportStoreMetadata(t *testing.T, s *Store) string {
+	t.Helper()
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	return exported.String()
+}

--- a/internal/store/ingest_observation.go
+++ b/internal/store/ingest_observation.go
@@ -1,0 +1,133 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// IngestFileWithMembership performs one logical operational import. When the
+// bytes already identify an existing node, it records that node as a member of
+// run without creating a content version or reporting added content.
+func (s *Store) IngestFileWithMembership(
+	ctx context.Context, run IngestRun, parentID int64,
+	name, blobHash string, size int64, mimeType, originalPath, originalMtime string,
+	physical ...BlobPhysical,
+) (Node, bool, error) {
+	if err := requireOperationalIngestRun(run); err != nil {
+		return Node{}, false, err
+	}
+	receipt, added, _, err := s.ingestFile(
+		ctx, run, parentID, name, blobHash, size, mimeType, originalPath, originalMtime,
+		ingestFileOptions{observeMembership: true}, physical...,
+	)
+	return receipt.Node, added, err
+}
+
+// IngestFileWithMembershipPlanned binds directory resolution and creation to
+// the transaction that publishes the labeled filesystem observation.
+func (s *Store) IngestFileWithMembershipPlanned(
+	ctx context.Context, run IngestRun, plan IngestDirectoryPlan,
+	name, blobHash string, size int64, mimeType, originalPath, originalMtime string,
+	physical ...BlobPhysical,
+) (Node, bool, IngestDirectoryResolution, error) {
+	if err := requireOperationalIngestRun(run); err != nil {
+		return Node{}, false, IngestDirectoryResolution{}, err
+	}
+	if run.initialLabel == nil {
+		return Node{}, false, IngestDirectoryResolution{},
+			errors.New("planned filesystem ingest requires an initial label")
+	}
+	receipt, added, resolution, err := s.ingestFile(
+		ctx, run, 0, name, blobHash, size, mimeType, originalPath, originalMtime,
+		ingestFileOptions{observeMembership: true, directoryPlan: &plan}, physical...,
+	)
+	return receipt.Node, added, resolution, err
+}
+
+// IngestFileExactPlanned is the exact-create form of a planned labeled
+// filesystem import.
+func (s *Store) IngestFileExactPlanned(
+	ctx context.Context, run IngestRun, plan IngestDirectoryPlan,
+	name, blobHash string, size int64, mimeType, originalPath, originalMtime string,
+	physical ...BlobPhysical,
+) (Node, IngestDirectoryResolution, error) {
+	if err := requireOperationalIngestRun(run); err != nil {
+		return Node{}, IngestDirectoryResolution{}, err
+	}
+	if run.initialLabel == nil {
+		return Node{}, IngestDirectoryResolution{},
+			errors.New("planned filesystem ingest requires an initial label")
+	}
+	receipt, _, resolution, err := s.ingestFile(
+		ctx, run, 0, name, blobHash, size, mimeType, originalPath, originalMtime,
+		ingestFileOptions{exact: true, directoryPlan: &plan}, physical...,
+	)
+	return receipt.Node, resolution, err
+}
+
+func requireOperationalIngestRun(run IngestRun) error {
+	// Watch imports require the dedicated APIs that maintain source cursors.
+	if run.operationalWatch || sourceKindIsEmbedded(run.record.SourceKind) {
+		return fmt.Errorf("operational ingest observation rejects source kind %q", run.record.SourceKind)
+	}
+	return nil
+}
+
+// observeOperationalIngestTx publishes one operational membership fact and
+// advances the node observation. The caller admits the run in this transaction.
+// Identical facts are idempotent within a run.
+func (s *Store) observeOperationalIngestTx(
+	ctx context.Context, tx *sql.Tx, run IngestRun, prior Node, fact metadataProvenance, ingestAdded bool,
+) (Node, error) {
+	if err := requireOperationalIngestRun(run); err != nil {
+		return Node{}, err
+	}
+	if err := validateProvenanceRecord(fact); err != nil {
+		return Node{}, fmt.Errorf("validating operational ingest observation: %w", err)
+	}
+	var exists bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM provenance WHERE identity=?)`, fact.Identity,
+	).Scan(&exists); err != nil {
+		return Node{}, fmt.Errorf("checking operational ingest observation: %w", err)
+	}
+	if exists {
+		return prior, nil
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO provenance(
+		identity,node_id,ingest_id,original_path,original_mtime,supersedes
+	) VALUES(?,?,?,?,?,NULL)`, fact.Identity, fact.NodeID, fact.IngestID,
+		fact.OriginalPath, fact.OriginalMTime); err != nil {
+		return Node{}, fmt.Errorf("recording operational ingest observation: %w", err)
+	}
+	operation, err := newContentVersionOperation()
+	if err != nil {
+		return Node{}, err
+	}
+	if err := bumpRevisionTx(tx, prior.ID, operation.recordedAt); err != nil {
+		return Node{}, err
+	}
+	resulting, err := nodeByIDTx(tx, prior.ID)
+	if err != nil {
+		return Node{}, err
+	}
+	active, err := auditAuthorityActiveTx(ctx, tx)
+	if err != nil {
+		return Node{}, err
+	}
+	if active {
+		authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, prior.ID)
+		if err != nil {
+			return Node{}, err
+		}
+		if err := persistAuditedIngestObservation(
+			ctx, tx, s.vaultID, operation.operationID, operation.recordedAt,
+			nodeSequence, authority, scopes, prior, resulting, run.record, fact, ingestAdded,
+		); err != nil {
+			return Node{}, err
+		}
+	}
+	return resulting, nil
+}

--- a/internal/store/ingest_observation_test.go
+++ b/internal/store/ingest_observation_test.go
@@ -1,0 +1,188 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperationalReimportKeepsVersionAndAddsMembership(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	firstRun, err := s.BeginIngest(ctx, "cli", "First synthetic import")
+	require.NoError(t, err)
+	first, _, err := s.IngestFile(ctx, firstRun, s.RootID(), "note.txt", fakeHash("a1"),
+		4, "text/plain", "/synthetic/note.txt", "")
+	require.NoError(t, err)
+	secondRun, err := s.BeginIngest(ctx, "cli", "Second synthetic import")
+	require.NoError(t, err)
+	second, added, err := s.IngestFileWithMembership(ctx, secondRun, s.RootID(), "note.txt",
+		fakeHash("a1"), 4, "text/plain", "/synthetic/note.txt", "")
+	require.NoError(t, err)
+	require.False(t, added)
+	require.Equal(t, first.ID, second.ID)
+	require.Equal(t, first.CurrentVersionID, second.CurrentVersionID)
+	require.Equal(t, first.BlobHash, second.BlobHash)
+	require.Equal(t, first.Revision+1, second.Revision)
+	for _, id := range []string{firstRun.ID(), secondRun.ID()} {
+		collection, err := s.CollectionByID(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), collection.FileCount)
+	}
+
+	replayed, replayAdded, err := s.IngestFileWithMembership(ctx, secondRun, s.RootID(), "note.txt",
+		fakeHash("a1"), 4, "text/plain", "/synthetic/note.txt", "")
+	require.NoError(t, err)
+	assert.False(t, replayAdded)
+	assert.Equal(t, second.Revision, replayed.Revision)
+	var facts int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT COUNT(*) FROM provenance WHERE node_id=? AND ingest_id=?`, second.ID, secondRun.ID(),
+	).Scan(&facts))
+	assert.Equal(t, int64(1), facts)
+}
+
+func TestMembershipIngestSourceKinds(t *testing.T) {
+	for _, kind := range []string{"cli", "upload", "filesystem", "custom-source", "watch"} {
+		for _, operation := range []string{"create", "reimport", "replace", "planned", "planned exact"} {
+			t.Run(kind+"/"+operation, func(t *testing.T) {
+				s := newTestStore(t)
+				ctx := t.Context()
+				seed, err := s.BeginIngest(ctx, kind, "synthetic-initial-import")
+				require.NoError(t, err)
+				prior, _, err := s.IngestFile(ctx, seed, s.RootID(), "note.txt", fakeHash("a1"),
+					4, "text/plain", "note.txt", "")
+				require.NoError(t, err)
+				var label *string
+				if operation == "planned" || operation == "planned exact" {
+					label = new("Synthetic import")
+				}
+				run, err := s.BeginIngestWithLabel(ctx, kind, "synthetic-import", label)
+				require.NoError(t, err)
+				plan, err := s.PrepareIngestDirectory(ctx, "/new")
+				require.NoError(t, err)
+				before := exportStoreMetadata(t, s)
+				switch operation {
+				case "create":
+					_, _, err = s.IngestFileWithMembership(ctx, run, s.RootID(), "new.txt",
+						fakeHash("b2"), 8, "text/plain", "new.txt", "")
+				case "reimport":
+					_, _, err = s.IngestFileWithMembership(ctx, run, s.RootID(), "note.txt",
+						fakeHash("a1"), 4, "text/plain", "note.txt", "")
+				case "replace":
+					_, _, err = s.ReplaceContentForIngest(ctx, run, prior.ID, prior.Revision,
+						fakeHash("b2"), 8, "text/plain", "note.txt", "")
+				case "planned":
+					_, _, _, err = s.IngestFileWithMembershipPlanned(ctx, run, plan, "new.txt",
+						fakeHash("b2"), 8, "text/plain", "new.txt", "")
+				case "planned exact":
+					_, _, err = s.IngestFileExactPlanned(ctx, run, plan, "new.txt",
+						fakeHash("b2"), 8, "text/plain", "new.txt", "")
+				}
+				require.NoError(t, s.ValidateMetadata(ctx))
+				if kind == "watch" {
+					require.ErrorContains(t, err, "rejects source kind")
+					assert.Equal(t, before, exportStoreMetadata(t, s))
+				} else {
+					require.NoError(t, err)
+					collection, err := s.CollectionByID(ctx, run.ID())
+					require.NoError(t, err)
+					assert.Equal(t, int64(1), collection.FileCount)
+				}
+			})
+		}
+	}
+}
+
+func TestReplaceContentForIngestPublishesContentAndMembershipAtomically(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	firstRun, err := s.BeginIngest(ctx, "cli", "First synthetic import")
+	require.NoError(t, err)
+	first, _, err := s.IngestFile(ctx, firstRun, s.RootID(), "note.txt", fakeHash("a1"),
+		4, "text/plain", "/synthetic/note.txt", "")
+	require.NoError(t, err)
+
+	secondRun, err := s.BeginIngest(ctx, "cli", "Replacement import")
+	require.NoError(t, err)
+	receipt, changed, err := s.ReplaceContentForIngest(
+		ctx, secondRun, first.ID, first.Revision, fakeHash("b2"), 8,
+		"text/markdown", "/synthetic/note.txt", "",
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	assert.Equal(t, fakeHash("b2"), receipt.Node.BlobHash)
+	assert.Equal(t, receipt.Version.ID, receipt.Node.CurrentVersionID)
+	assert.Equal(t, first.Revision+2, receipt.Node.Revision)
+
+	thirdRun, err := s.BeginIngest(ctx, "cli", "Unchanged import")
+	require.NoError(t, err)
+	confirmed, changed, err := s.ReplaceContentForIngest(
+		ctx, thirdRun, first.ID, receipt.Node.Revision, fakeHash("b2"), 8,
+		"text/markdown", "/synthetic/note.txt", "",
+	)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Equal(t, receipt.Version.ID, confirmed.Version.ID)
+	assert.Equal(t, receipt.Node.Revision+1, confirmed.Node.Revision)
+}
+
+func TestReplaceContentForIngestRollsBackOnLabelConflict(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	label := "Synthetic batch"
+	firstRun, err := s.BeginIngestWithLabel(ctx, "cli", "First", &label)
+	require.NoError(t, err)
+	first, _, err := s.IngestFileWithMembership(
+		ctx, firstRun, s.RootID(), "note.txt", fakeHash("a1"), 4,
+		"text/plain", "/synthetic/note.txt", "",
+	)
+	require.NoError(t, err)
+	conflictRun, err := s.BeginIngestWithLabel(ctx, "cli", "Conflict", &label)
+	require.NoError(t, err)
+
+	_, _, err = s.ReplaceContentForIngest(
+		ctx, conflictRun, first.ID, first.Revision, fakeHash("b2"), 8,
+		"text/markdown", "/synthetic/note.txt", "",
+	)
+	require.ErrorIs(t, err, ErrExists)
+	unchanged, err := s.NodeByID(ctx, first.ID)
+	require.NoError(t, err)
+	assert.Equal(t, first, unchanged)
+	var versions, ingests int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM content_versions WHERE node_id=?),
+		(SELECT COUNT(*) FROM ingests WHERE id=?)`, first.ID, conflictRun.ID()).Scan(&versions, &ingests))
+	assert.Equal(t, int64(1), versions)
+	assert.Zero(t, ingests)
+}
+
+func TestReplaceContentForIngestRejectsStaleRevisionBeforePublishingRun(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	firstRun, err := s.BeginIngest(ctx, "cli", "First")
+	require.NoError(t, err)
+	first, _, err := s.IngestFile(
+		ctx, firstRun, s.RootID(), "note.txt", fakeHash("a1"), 4,
+		"text/plain", "/synthetic/note.txt", "",
+	)
+	require.NoError(t, err)
+	run, err := s.BeginIngest(ctx, "cli", "Stale")
+	require.NoError(t, err)
+
+	_, _, err = s.ReplaceContentForIngest(
+		ctx, run, first.ID, first.Revision-1, fakeHash("b2"), 8,
+		"text/markdown", "/synthetic/note.txt", "",
+	)
+	require.ErrorIs(t, err, ErrStaleRevision)
+	unchanged, err := s.NodeByID(ctx, first.ID)
+	require.NoError(t, err)
+	assert.Equal(t, first, unchanged)
+	var ingests, facts int64
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM ingests WHERE id=?),
+		(SELECT COUNT(*) FROM provenance WHERE ingest_id=?)`, run.ID(), run.ID()).Scan(&ingests, &facts))
+	assert.Zero(t, ingests)
+	assert.Zero(t, facts)
+}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -330,6 +330,10 @@ func (layout metadataSourceLayout) hasDerivativeCatalog() bool {
 	return layout.schemaVersion >= 4
 }
 
+func (layout metadataSourceLayout) hasCollectionLabels() bool {
+	return layout.schemaVersion >= 8
+}
+
 func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer) error {
 	return exportMetadataSnapshotWithVaultIdentity(ctx, tx, w, currentMetadataLayout())
 }
@@ -389,6 +393,11 @@ func exportMetadataSnapshotWithVaultIdentity(
 	}
 	if err := exportIngests(ctx, tx, write); err != nil {
 		return err
+	}
+	if layout.hasCollectionLabels() {
+		if err := exportCollectionLabels(ctx, tx, write); err != nil {
+			return err
+		}
 	}
 	if err := exportContentVersions(ctx, tx, write); err != nil {
 		return err
@@ -969,6 +978,7 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		    + (SELECT COUNT(*) FROM visual_preview_generations)
 		    + (SELECT COUNT(*) FROM visual_preview_heads)
 		    + (SELECT COUNT(*) FROM ingests) + (SELECT COUNT(*) FROM provenance)
+		    + (SELECT COUNT(*) FROM collection_labels)
 		    + (SELECT COUNT(*) FROM watch_sources)
 		    + (SELECT COUNT(*) FROM tags) + (SELECT COUNT(*) FROM node_tags)
 		    + (SELECT COUNT(*) FROM extracted_text)
@@ -1254,6 +1264,12 @@ func (s *Store) importMetadataRecord(
 		}
 		_, err := tx.ExecContext(ctx, `INSERT INTO ingests(id,started_at,source_kind,source_desc) VALUES(?,?,?,?)`, v.ID, v.StartedAt, v.SourceKind, v.SourceDesc)
 		return err
+	case metadataCollectionLabelType:
+		var v metadataCollectionLabel
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		return importCollectionLabel(ctx, tx, v)
 	case metadataProvenanceType:
 		var v metadataProvenance
 		if err := decodeMetadataRecord(raw, &v); err != nil {
@@ -1396,6 +1412,7 @@ var metadataRequiredFields = map[string][]string{
 	"node":                                 {metadataTypeField, "id", "parent_id", "name", "kind", "current_version_id", "revision", metadataCreatedAtField, "modified_at", "trashed_at", "trash_parent", "trash_name"},
 	"content_version":                      {metadataTypeField, "version_id", metadataNodeIDField, columnBlobHash, metadataSizeField, "mime_type", auditRecordedAtField, "node_revision", "introduced_operation_id", "transition_kind", "source_version_id"},
 	metadataIngestType:                     {metadataTypeField, "ingest_id", "started_at", "source_kind", "source_desc"},
+	metadataCollectionLabelType:            {metadataTypeField, "ingest_id", "label", "revision", "updated_at"},
 	metadataProvenanceType:                 {metadataTypeField, "identity", metadataNodeIDField, "ingest_id", "original_path", "original_mtime", "supersedes"},
 	metadataWatchSourceType:                {metadataTypeField, "watch_name", "source_ref", metadataNodeIDField, columnBlobHash, metadataSizeField},
 	"tag":                                  {metadataTypeField, "tag_id", "name", "revision"},
@@ -1438,6 +1455,7 @@ var metadataNullableFields = map[string]map[string]bool{
 	},
 	"content_version":                  {"mime_type": true, "source_version_id": true},
 	metadataProvenanceType:             {"original_mtime": true, "supersedes": true},
+	metadataCollectionLabelType:        {"label": true},
 	"extracted_text":                   {"error": true, "text": true},
 	metadataCurrentRenditionRootType:   {"released_at": true},
 	metadataEmbeddingGenerationType:    {"attachment_id": true},
@@ -1797,6 +1815,11 @@ func validateMetadataStateWithVaultIdentity(
 	}
 	if err := validateWatchSourceRelations(ctx, tx); err != nil {
 		return err
+	}
+	if layout.hasCollectionLabels() {
+		if err := validateCollectionLabelMetadataState(ctx, tx); err != nil {
+			return err
+		}
 	}
 	if layout.hasDerivativeCatalog() {
 		if err := validateProcessingMetadataState(ctx, tx); err != nil {

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -169,10 +169,7 @@ func nodeByPath(ctx context.Context, q rowQuerier, rootID int64, path string) (N
 		if err != nil {
 			return Node{}, fmt.Errorf("path %q: %w", path, err)
 		}
-		row := q.QueryRowContext(ctx,
-			`SELECT `+nodeCols+` FROM `+nodeFrom+`
-			 WHERE n.parent_id = ? AND n.name = ? AND n.trashed_at IS NULL`, n.ID, seg)
-		n, err = scanNode(row)
+		n, err = childByName(ctx, q, n.ID, seg)
 		if err != nil {
 			return Node{}, fmt.Errorf("path %q: %w", path, err)
 		}

--- a/internal/store/provenance_write.go
+++ b/internal/store/provenance_write.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 )
 
 // ProvenanceAppendInput describes one post-ingest origin assertion. A positive
@@ -155,7 +154,7 @@ func validateProvenancePredecessorTx(
 	}
 	// Operational facts anchor re-ingest idempotency. Corrections may retire
 	// caller-supplied evidence, but must leave those ingest observations active.
-	if !strings.HasPrefix(sourceKind, callerSuppliedSourceKindPrefix) {
+	if !sourceKindIsEmbedded(sourceKind) {
 		return fmt.Errorf("operational ingest provenance cannot be superseded: %w", ErrProvenanceMismatch)
 	}
 	var successor int

--- a/internal/store/provenance_write_test.go
+++ b/internal/store/provenance_write_test.go
@@ -253,3 +253,31 @@ func TestAppendNodeProvenanceAuditedRoundTrips(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, appended.Fact.Identity, page.Items[0].Identity)
 }
+
+func TestImportedMixedCaseEmbeddedProvenanceCanBeCorrected(t *testing.T) {
+	ctx := t.Context()
+	source := newTestStore(t)
+	run, err := source.BeginIngest(ctx, "Embedded:agent", "Synthetic application evidence")
+	require.NoError(t, err)
+	node, err := source.IngestFileExact(ctx, run, source.RootID(), "report.txt", fakeHash("a1"),
+		7, "text/plain", "/synthetic/report.txt", "")
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(ctx, &exported))
+	target := newTestStore(t)
+	require.NoError(t, target.ImportMetadata(ctx, bytes.NewReader(exported.Bytes())))
+	seedInitialAuditAuthority(t, target, target.RootID())
+	_, err = target.CollectionByID(ctx, run.ID())
+	require.ErrorIs(t, err, ErrNotFound)
+	page, err := target.NodeProvenance(ctx, node.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "agent", page.Items[0].SourceKind)
+	_, err = target.AppendNodeProvenance(ctx, ProvenanceAppendInput{
+		NodeID: node.ID, IfRevision: node.Revision, SourceKind: "agent",
+		SourceDescription: "Synthetic correction", OriginalPath: "opaque://corrected",
+		Supersedes: &page.Items[0].Identity,
+	})
+	require.NoError(t, err)
+	require.NoError(t, target.ValidateMetadata(ctx))
+}

--- a/internal/store/saved_query.go
+++ b/internal/store/saved_query.go
@@ -20,8 +20,7 @@ const (
 	// SavedQueryKindHighlightSet identifies a canonical HighlightSetV1 payload.
 	SavedQueryKindHighlightSet = "highlight_set"
 
-	maxSavedQueryPageSize         = 1000
-	maxSavedQueryNameBytes        = 256
+	maxLabelNameBytes             = 256
 	maxSavedQueryDescriptionBytes = 4096
 )
 
@@ -52,7 +51,7 @@ type SavedQueryPatch struct {
 func (s *Store) CreateSavedQuery(
 	ctx context.Context, name, description, kind string, payload []byte,
 ) (SavedQuery, error) {
-	name, err := normalizeSavedQueryName(name)
+	name, err := normalizeLabelName(name, ErrInvalidSavedQuery)
 	if err != nil {
 		return SavedQuery{}, err
 	}
@@ -163,7 +162,7 @@ func (s *Store) UpdateSavedQuery(
 	}
 	var normalizedName *string
 	if patch.Name != nil {
-		name, err := normalizeSavedQueryName(*patch.Name)
+		name, err := normalizeLabelName(*patch.Name, ErrInvalidSavedQuery)
 		if err != nil {
 			return SavedQuery{}, err
 		}
@@ -300,20 +299,20 @@ func checkSavedQueryRevision(record SavedQuery, expected int64) error {
 	return nil
 }
 
-func normalizeSavedQueryName(name string) (string, error) {
+func normalizeLabelName(name string, invalid error) (string, error) {
 	if !utf8.ValidString(name) {
-		return "", fmt.Errorf("%w: name is not valid UTF-8", ErrInvalidSavedQuery)
+		return "", fmt.Errorf("%w: name is not valid UTF-8", invalid)
 	}
 	name = norm.NFC.String(name)
-	if len(name) < 1 || len(name) > maxSavedQueryNameBytes {
+	if len(name) < 1 || len(name) > maxLabelNameBytes {
 		return "", fmt.Errorf("%w: name must contain 1 to %d UTF-8 bytes",
-			ErrInvalidSavedQuery, maxSavedQueryNameBytes)
+			invalid, maxLabelNameBytes)
 	}
 	if strings.TrimFunc(name, unicode.IsSpace) == "" {
-		return "", fmt.Errorf("%w: name must not be all whitespace", ErrInvalidSavedQuery)
+		return "", fmt.Errorf("%w: name must not be all whitespace", invalid)
 	}
 	if strings.ContainsFunc(name, unicode.IsControl) {
-		return "", fmt.Errorf("%w: name contains a control character", ErrInvalidSavedQuery)
+		return "", fmt.Errorf("%w: name contains a control character", invalid)
 	}
 	return name, nil
 }
@@ -373,11 +372,8 @@ func validateSavedQueryPage(kind string, limit, offset int) error {
 	if kind != "" && kind != SavedQueryKindQuery && kind != SavedQueryKindHighlightSet {
 		return fmt.Errorf("%w: unknown kind %q", ErrInvalidSavedQuery, kind)
 	}
-	if limit < 1 || limit > maxSavedQueryPageSize {
-		return fmt.Errorf("%w: limit must be between 1 and %d", ErrInvalidSavedQuery, maxSavedQueryPageSize)
-	}
-	if offset < 0 {
-		return fmt.Errorf("%w: offset must not be negative", ErrInvalidSavedQuery)
+	if err := validatePage(limit, offset); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidSavedQuery, err)
 	}
 	return nil
 }

--- a/internal/store/saved_query_metadata.go
+++ b/internal/store/saved_query_metadata.go
@@ -67,7 +67,7 @@ func validateSavedQueryMetadataRecord(record metadataSavedQuery) error {
 	if err := validateUUIDv4(record.ID); err != nil {
 		return fmt.Errorf("invalid saved query ID: %w", err)
 	}
-	name, err := normalizeSavedQueryName(record.Name)
+	name, err := normalizeLabelName(record.Name, ErrInvalidSavedQuery)
 	if err != nil {
 		return err
 	}

--- a/internal/store/saved_query_metadata_test.go
+++ b/internal/store/saved_query_metadata_test.go
@@ -293,7 +293,7 @@ func TestSavedQueryOldestReleasedSchemaUpgradeCreatesEmptyAuthority(t *testing.T
 			t.Cleanup(func() { require.NoError(t, s.Close()) })
 			var schemaVersion int
 			require.NoError(t, s.db.QueryRow(`SELECT schema_version FROM vault_metadata WHERE singleton=1`).Scan(&schemaVersion))
-			assert.Equal(t, 7, schemaVersion)
+			assert.Equal(t, currentStorageSchemaVersion, schemaVersion)
 			rows, total, err := s.SavedQueries(t.Context(), "", 10, 0)
 			require.NoError(t, err)
 			assert.Zero(t, total)
@@ -323,19 +323,23 @@ func TestSavedQueryCurrentSchemaRejectsMissingAuthorityTable(t *testing.T) {
 
 func TestSavedQuerySchemaRejectsPriorUnreleasedLayout(t *testing.T) {
 	for _, test := range v090UpgradeDrivers() {
-		t.Run(test.name, func(t *testing.T) {
-			dbPath := filepath.Join(t.TempDir(), "docbank.db")
-			s, err := Open(dbPath, test.driver)
-			require.NoError(t, err)
-			_, err = s.db.Exec(`UPDATE vault_metadata SET schema_version=6 WHERE singleton=1`)
-			require.NoError(t, err)
-			require.NoError(t, s.Close())
+		for _, version := range []int{6, 7} {
+			t.Run(fmt.Sprintf("%s/v%d", test.name, version), func(t *testing.T) {
+				dbPath := filepath.Join(t.TempDir(), "docbank.db")
+				s, err := Open(dbPath, test.driver)
+				require.NoError(t, err)
+				_, err = s.db.Exec(`DROP TABLE collection_labels`)
+				require.NoError(t, err)
+				_, err = s.db.Exec(`UPDATE vault_metadata SET schema_version=? WHERE singleton=1`, version)
+				require.NoError(t, err)
+				require.NoError(t, s.Close())
 
-			reopened, err := Open(dbPath, test.driver)
-			if reopened != nil {
-				require.NoError(t, reopened.Close())
-			}
-			require.ErrorContains(t, err, "schema version 6 has no supported JSONL cutover")
-		})
+				reopened, err := Open(dbPath, test.driver)
+				if reopened != nil {
+					require.NoError(t, reopened.Close())
+				}
+				require.ErrorContains(t, err, fmt.Sprintf("schema version %d has no supported JSONL cutover", version))
+			})
+		}
 	}
 }

--- a/internal/store/saved_query_test.go
+++ b/internal/store/saved_query_test.go
@@ -145,7 +145,7 @@ func TestSavedQueriesAreBoundedFilteredAndNameSorted(t *testing.T) {
 		limit, offset int
 	}{
 		{limit: 0},
-		{limit: maxSavedQueryPageSize + 1},
+		{limit: maxPageSize + 1},
 		{limit: 1, offset: -1},
 		{kind: "unknown", limit: 1},
 	} {

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -423,6 +423,15 @@ CREATE TABLE IF NOT EXISTS ingests (
     source_desc TEXT NOT NULL
 );
 
+-- Mutable collection labels are separate from immutable ingest identity.
+-- A cleared label retains its row so optimistic-concurrency fences never reset.
+CREATE TABLE IF NOT EXISTS collection_labels (
+    ingest_id  TEXT PRIMARY KEY REFERENCES ingests(id),
+    label      TEXT UNIQUE,
+    revision   INTEGER NOT NULL CHECK (revision >= 1),
+    updated_at TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS provenance (
     identity       TEXT PRIMARY KEY NOT NULL,
     node_id        INTEGER NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,7 +31,7 @@ type Store struct {
 // by this binary. It is intentionally independent of metadata JSONL's logical
 // format version: physical schema changes can rebuild through the same logical
 // format without changing that portable contract.
-const currentStorageSchemaVersion = 7
+const currentStorageSchemaVersion = 8
 
 // DefaultSQLiteDriver returns the build's standalone-compatible adapter: CGO
 // builds use mattn/go-sqlite3 and no-CGO builds use modernc.org/sqlite.

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-const maxTagPageSize = 1000
+const maxPageSize = 1000
 
 // Tag is one stable organization label. Name is mutable; ID is permanent and
 // never reused. AssignmentCount is the current number of tagged nodes.
@@ -133,7 +133,7 @@ func (s *Store) TagByName(ctx context.Context, name string) (Tag, error) {
 
 // Tags lists one name-sorted page and the total number of definitions.
 func (s *Store) Tags(ctx context.Context, limit, offset int) ([]Tag, int, error) {
-	if err := validateTagPage(limit, offset); err != nil {
+	if err := validatePage(limit, offset); err != nil {
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx, `
@@ -453,7 +453,7 @@ func changeTagAssignmentTx(
 
 // NodeTags lists one name-sorted page of tags assigned to a node.
 func (s *Store) NodeTags(ctx context.Context, nodeID int64, limit, offset int) ([]Tag, int, error) {
-	if err := validateTagPage(limit, offset); err != nil {
+	if err := validatePage(limit, offset); err != nil {
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx, `
@@ -514,7 +514,7 @@ func (s *Store) LiveTaggedNodes(
 func (s *Store) taggedNodes(
 	ctx context.Context, tagID string, limit, offset int, liveOnly bool,
 ) ([]TaggedNode, int, int, error) {
-	if err := validateTagPage(limit, offset); err != nil {
+	if err := validatePage(limit, offset); err != nil {
 		return nil, 0, 0, err
 	}
 	if err := validateUUIDv4(tagID); err != nil {
@@ -627,12 +627,12 @@ func touchTaggedNodesTx(tx *sql.Tx, tagID, timestamp string) error {
 	return nil
 }
 
-func validateTagPage(limit, offset int) error {
-	if limit < 1 || limit > maxTagPageSize {
-		return fmt.Errorf("tag limit must be between 1 and %d", maxTagPageSize)
+func validatePage(limit, offset int) error {
+	if limit < 1 || limit > maxPageSize {
+		return fmt.Errorf("limit must be between 1 and %d", maxPageSize)
 	}
 	if offset < 0 {
-		return errors.New("tag offset must not be negative")
+		return errors.New("offset must not be negative")
 	}
 	return nil
 }

--- a/internal/store/upgrade.go
+++ b/internal/store/upgrade.go
@@ -73,7 +73,7 @@ var (
 
 var currentSchemaTables = [...]string{
 	"blobs", "blob_packs", "vault_metadata", "blob_stores", "blob_locations", "blob_pack_entries",
-	"saved_queries",
+	"saved_queries", "collection_labels",
 	"vector_index_generations", "vector_index_heads", "vector_index_build_jobs",
 	"vector_index_reader_leases", "vector_index_unavailable_coverage",
 }
@@ -239,7 +239,7 @@ func validateCurrentSchemaColumns(
 	}
 	for _, table := range []string{
 		"blob_stores", "blob_locations", "blob_pack_entries",
-		"saved_queries",
+		"saved_queries", "collection_labels",
 		"vector_index_generations", "vector_index_heads", "vector_index_build_jobs",
 		"vector_index_reader_leases", "vector_index_unavailable_coverage",
 	} {

--- a/internal/store/upgrade_test.go
+++ b/internal/store/upgrade_test.go
@@ -68,6 +68,9 @@ func TestOpenCutsOverReleasedV090ThroughJSONL(t *testing.T) {
 			require.NoError(t, s.db.QueryRow(`
 				SELECT schema_version FROM vault_metadata WHERE singleton = 1`).Scan(&schemaVersion))
 			assert.Equal(t, currentStorageSchemaVersion, schemaVersion)
+			var collectionLabels int
+			require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM collection_labels`).Scan(&collectionLabels))
+			assert.Zero(t, collectionLabels, "released metadata predates collection labels")
 			var upgraded bytes.Buffer
 			require.NoError(t, s.ExportMetadata(t.Context(), &upgraded))
 			assertReleasedMetadataWithEmptyLexicalHead(t, fixture.metadata, upgraded.Bytes())

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -298,6 +298,83 @@ func (s *Store) ConfirmIngestedContentWithReceipt(
 	return receipt, nil
 }
 
+// ReplaceContentForIngest applies a logical operational import to an existing
+// file. A changed head and its collection membership commit together; an
+// identical head records only the new observation and reports changed=false.
+func (s *Store) ReplaceContentForIngest(
+	ctx context.Context, run IngestRun, nodeID, ifRev int64,
+	blobHash string, size int64, mimeType, originalPath, originalMtime string,
+	physical ...BlobPhysical,
+) (ContentWriteReceipt, bool, error) {
+	if size < 0 {
+		return ContentWriteReceipt{}, false, errors.New("content size must not be negative")
+	}
+	if err := validateUTF8Field("content MIME type", mimeType); err != nil {
+		return ContentWriteReceipt{}, false, err
+	}
+	if err := validateIngestRecord(run.record); err != nil {
+		return ContentWriteReceipt{}, false, fmt.Errorf("validating ingest run: %w", err)
+	}
+	if err := requireOperationalIngestRun(run); err != nil {
+		return ContentWriteReceipt{}, false, err
+	}
+	var recordedMtime *string
+	if originalMtime != "" {
+		recordedMtime = &originalMtime
+	}
+	fact := metadataProvenance{
+		Type: metadataProvenanceType, NodeID: nodeID, IngestID: run.ID(),
+		OriginalPath: originalPath, OriginalMTime: recordedMtime,
+	}
+	if err := validateProvenanceFields(fact); err != nil {
+		return ContentWriteReceipt{}, false, fmt.Errorf("validating ingest provenance: %w", err)
+	}
+	identity, err := provenanceIdentity(fact)
+	if err != nil {
+		return ContentWriteReceipt{}, false, fmt.Errorf("identifying ingest observation: %w", err)
+	}
+	fact.Identity = identity
+	var (
+		receipt ContentWriteReceipt
+		changed bool
+	)
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		prior, err := nodeByIDTx(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		if prior.BlobHash == blobHash && prior.Size == size {
+			receipt, err = s.confirmContentWithReceiptTx(
+				tx, prior, ifRev, blobHash, size, prior.MimeType, physical...,
+			)
+		} else {
+			receipt.Node, receipt.Version, err = s.replaceContentTx(
+				ctx, tx, prior, ifRev, blobHash, size, mimeType, physical...,
+			)
+			changed = err == nil
+		}
+		if err != nil {
+			return err
+		}
+		ingestAdded, err := s.ensureIngestRunForMutationTx(ctx, tx, run)
+		if err != nil {
+			return err
+		}
+		receipt.Node, err = s.observeOperationalIngestTx(
+			ctx, tx, run, receipt.Node, fact, ingestAdded,
+		)
+		if err != nil {
+			return err
+		}
+		receipt.Physical, err = authorizedPhysicalContentTx(tx, blobHash)
+		return err
+	})
+	if err != nil {
+		return ContentWriteReceipt{}, false, err
+	}
+	return receipt, changed, nil
+}
+
 func (s *Store) confirmContentWithReceiptTx(
 	tx *sql.Tx, n Node, ifRev int64, blobHash string, size int64, mimeType string,
 	physical ...BlobPhysical,

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -188,7 +188,11 @@ func (s *Store) ChildByName(ctx context.Context, parentID int64, name string) (N
 // childByName returns the live child of dirID named name (name must already
 // be normalized).
 func (s *Store) childByName(ctx context.Context, dirID int64, name string) (Node, error) {
-	row := s.db.QueryRowContext(ctx,
+	return childByName(ctx, s.db, dirID, name)
+}
+
+func childByName(ctx context.Context, q rowQuerier, dirID int64, name string) (Node, error) {
+	row := q.QueryRowContext(ctx,
 		`SELECT `+nodeCols+` FROM `+nodeFrom+`
 		 WHERE n.parent_id = ? AND n.name = ? AND n.trashed_at IS NULL`, dirID, name)
 	return scanNode(row)


### PR DESCRIPTION
API clients can browse document imports as collections and label each run. Reimporting the same file adds it to the new run without copying content or creating another content version. Counts, sizes and paths follow the current live documents.

Each filesystem import is a new run. Recording its membership advances the node revision, including a plain reimport with no label or flags and an identical-content `replace: true`. Clients must refresh an earlier ETag before their next write or receive `412 stale_revision`. Repeating the same observation within one run remains a no-op, and equal `POST /uploads` retries keep their revision.

An optional `collection_label` publishes with the first successful document. The response returns the committed `ingest_id`; partial imports retain successful members and report individual failures. For example:

```sh
curl -sS -H "X-Api-Key: $DOCBANK_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"paths":["/srv/import/review"],"dest":"/archive","collection_label":"Review set"}' \
  http://127.0.0.1:43210/api/v1/ingest
```

Use the returned ID with `/api/v1/collections/{id}/members`. Read the run's `/label` resource, then use its ETag to set or clear the label. Retained names remain unique even when a collection becomes empty.

Collections and existing labels remain readable after audit enrollment. Repeated unlabeled imports record membership in the audit history. Label changes return `409 audit_mutation_unsupported`. Caller-supplied provenance stays outside collection membership. Collection labels use storage schema v8; saved-query metadata remains available from v7 onward.

A physical backup/restore test exercises both SQLite drivers: label an import, enable audit, import the same document again, then restore and verify both memberships, the label revision, audit observation and original bytes.

Closes #307
