### PR TITLE
feat(web): manage saved queries and highlight sets

### DIFF
--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -133,6 +133,9 @@ Save a named search definition when several clients need to reuse it. The
 HTTP API stores the definition with the vault's metadata. It does not run the
 search. Saved definitions survive backup and restore.
 
+The [web management screen](web.md#saved-queries-and-highlights) also manages
+saved definitions.
+
 A query payload uses `QueryV1`: a JSON object with version `v: 1`, search text,
 filters, and optional syntax, mode, and sort choices. A saved mode such as
 `hybrid` describes intent; it does not enable that mode in `docbank search`.
@@ -202,8 +205,8 @@ revision rules as a query.
 
 ### What are the saved-definition limits?
 
-The CLI, web application, and TUI have no saved-definition management screen
-or command. The HTTP endpoints do not execute saved queries, render
+The CLI and TUI have no saved-definition management command or screen.
+The HTTP endpoints do not execute saved queries, render
 highlights, or return result counts.
 
 Once permanent audit history is enabled anywhere in the vault, create, update,

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -1,4 +1,5 @@
 ---
+last_edited: 2026-09-10
 title: Web application
 description: Upload, browse, search, and organize the local vault in a responsive, authenticated web interface.
 ---
@@ -126,6 +127,38 @@ change assignment rules.
 The catalog shows the first 1,000 name-sorted definitions and discloses the
 complete count. Use `docbank tag`, the paginated HTTP API, or an embedded client
 for exhaustive definition management and bulk assignment.
+
+## Saved queries and highlights
+
+Open the bookmark button in the top bar to manage saved queries and highlight
+sets. A new query starts with the current search text, selected tag and display
+sort. The complete query editor preserves the expression, filters, mode and sort
+together. Choose **Save as new** to name a definition, or **Edit** and **Save
+changes** to update one. The catalog is paginated in groups of 100.
+
+**Keep query draft** retains the complete query in the tab and URL fragment.
+The fragment contains query text and filters, so treat copied URLs as private.
+It does not contain browser-session credentials. Saving a definition does not
+replace the kept draft or change the URL. **Discard query draft**, locking the
+tab, or an expired or rejected session clears the draft and its URL fragment.
+Drafts do not carry over when you open a new session with `docbank web`; save a
+named definition before reloading or leaving the session if you need it later.
+
+Saved queries are definitions, not frozen result sets. Saved-query execution is
+unavailable because the live-search adapter cannot honor the complete query
+contract. Keeping or saving a draft does not run it or change the current live
+results. Unknown fields are rejected, not silently dropped.
+
+Highlight sets hold 1–64 unique literal terms, each up to 256 Unicode characters,
+with lowercase `#rrggbb` colors. They cannot run as queries, and the document
+viewer does not apply them yet. Neither result rows nor document bodies are
+stored in browser preferences.
+
+Edits and deletions use the definition's inspected revision. A stale response
+remains visible without automatically retrying against newer state. Reload the
+definitions and reopen the item before deciding again. Deletion requires a
+separate confirmation naming the definition, ID and revision; it never deletes
+documents or discards the kept query draft.
 
 ## Move a node to recoverable trash
 
@@ -459,9 +492,7 @@ accepts that credential for the following operations:
 | Create, rename, or delete a tag definition | Rename and delete require the inspected tag revision; deletion reports the removed assignment count. |
 | Read and manage saved query or highlight definitions | Edit and delete require the saved definition's revision. Permanent audit history blocks these writes. |
 
-The API permits saved-definition management with a browser session, but the
-current application has no controls for it. See
-[Saved queries and highlight sets](searching.md#save-complete-query-intent-over-http).
+Use the bookmark button to [manage saved queries and highlights](#saved-queries-and-highlights).
 
 Upload uses a separate WebSocket: a connection that never reconnects during the
 session. The browser must prove it holds the upload secret before sending any

--- a/frontend/screenshots/saved-queries.screenshot.ts
+++ b/frontend/screenshots/saved-queries.screenshot.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const exec = promisify(execFile);
+const repository = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const screenshots = path.join(repository, ".superpowers/screenshots");
+
+test("saved queries and literal highlight management", async ({ page }) => {
+  const workspace = await mkdtemp(path.join(tmpdir(), "docbank-saved-query-"));
+  const vault = path.join(workspace, "vault");
+  const run = async (...args: string[]) => (await exec(path.join(repository, "docbank"), args, {
+    cwd: repository, env: { ...process.env, DOCBANK_HOME: vault }, timeout: 60_000,
+  })).stdout.trim();
+  try {
+    await mkdir(screenshots, { recursive: true, mode: 0o700 });
+    const source = path.join(workspace, "review-notes.txt");
+    await writeFile(source, "Synthetic notes: compare alpha and beta proposals.\n", { mode: 0o600 });
+    await run("add", source, "--dest", "/");
+    const webURL = await run("web", "--no-browser");
+    await page.goto(webURL);
+    await page.getByRole("button", { name: "Saved queries and highlights", exact: true }).click();
+    const drawer = page.getByRole("dialog", { name: "Saved queries and highlights" });
+    await expect(drawer).toBeVisible();
+    const query = { v: 1, text: "alpha OR beta", syntax: "advanced", mode: "lexical", filters: { extensions: ["pdf", "txt"], no_tags: true }, sort: { field: "size", direction: "desc" } };
+    await drawer.getByLabel("Definition name").fill("Unreviewed proposals");
+    await drawer.getByLabel("Definition description").fill("Compare proposals without changing the current live results.");
+    await drawer.getByLabel("Complete query JSON").fill(JSON.stringify(query, null, 2));
+    await drawer.getByRole("button", { name: "Save as new", exact: true }).click();
+    await expect(drawer.getByText("Saved Unreviewed proposals.", { exact: true })).toBeVisible();
+    await expect(drawer.getByRole("button", { name: "Edit Unreviewed proposals", exact: true })).toBeVisible();
+    await expect(drawer.getByText(/Saved-query execution is unavailable/)).toBeVisible();
+    expect(new URL(page.url()).hash).toBe("");
+    await drawer.getByRole("button", { name: "Keep query draft" }).click();
+    const savedURL = new URL(page.url());
+    const restored = JSON.parse(new URLSearchParams(savedURL.hash.slice(1)).get("query")!);
+    expect(restored).toEqual(query);
+    expect(savedURL.hash).not.toContain("web_session");
+    expect(savedURL.hash).not.toContain("web_upload_secret");
+    expect(await page.evaluate(() => Object.keys(localStorage).filter((key) => /query|highlight|session/i.test(key)))).toEqual([]);
+    const updatedQuery = { ...query, text: "alpha AND beta" };
+    await drawer.getByLabel("Complete query JSON").fill(JSON.stringify(updatedQuery, null, 2));
+    await drawer.getByLabel("Definition name").fill("Proposal review");
+    await drawer.getByRole("button", { name: "Save changes", exact: true }).click();
+    await expect(drawer.getByText("Saved Proposal review.", { exact: true })).toBeVisible();
+    await drawer.getByRole("button", { name: "Edit Proposal review", exact: true }).click();
+    expect(JSON.parse(await drawer.getByLabel("Complete query JSON").inputValue())).toEqual(updatedQuery);
+    expect(page.url()).toBe(savedURL.href);
+    await drawer.getByLabel("Complete query JSON").scrollIntoViewIfNeeded();
+    await drawer.getByLabel("Complete query JSON").evaluate((editor) => { editor.scrollTop = 0; });
+    await page.screenshot({ path: path.join(screenshots, "web-saved-queries.png") });
+
+    await drawer.getByRole("button", { name: "New highlight set" }).click();
+    await drawer.getByLabel("Definition name").fill("Proposal terms");
+    await drawer.getByLabel("Term 1", { exact: true }).fill("alpha");
+    await drawer.getByRole("button", { name: "Add term" }).click();
+    await drawer.getByLabel("Term 2", { exact: true }).fill("beta");
+    await drawer.getByLabel("Color 2", { exact: true }).fill("#88ccff");
+    await drawer.getByRole("button", { name: "Save as new", exact: true }).click();
+    await expect(drawer.getByText("Saved Proposal terms.", { exact: true })).toBeVisible();
+    await expect(drawer.getByRole("button", { name: /run/i })).toHaveCount(0);
+    await page.screenshot({ path: path.join(screenshots, "web-highlight-sets.png") });
+    await drawer.getByRole("button", { name: "Delete Proposal terms", exact: true }).click();
+    await expect(drawer.getByText(/Revision 1/)).toBeVisible();
+    await drawer.getByRole("button", { name: "Confirm deletion" }).click();
+    await expect(drawer.getByText("Deleted Proposal terms. Documents were not changed.", { exact: true })).toBeVisible();
+    await expect(drawer.getByRole("button", { name: "Edit Proposal terms", exact: true })).toHaveCount(0);
+    await drawer.getByRole("button", { name: "Close", exact: true }).click();
+    await page.getByRole("button", { name: "Lock web session" }).click();
+    await expect(page.getByText("Open your Docbank", { exact: true })).toBeVisible();
+    expect(new URL(page.url()).hash).toBe("");
+  } finally {
+    await run("daemon", "stop");
+    const status = JSON.parse(await run("daemon", "status", "--json"));
+    if (status.running !== false) throw new Error("Synthetic saved-query daemon did not stop; workspace retained.");
+    await rm(workspace, { recursive: true, force: true });
+  }
+});

--- a/frontend/src/App.savedQueries.test.ts
+++ b/frontend/src/App.savedQueries.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import App from "./App.svelte";
+
+afterEach(() => { cleanup(); history.replaceState(null, "", "/"); Reflect.deleteProperty(Element.prototype, "scrollIntoView"); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+it("restores a full query beside sign-in without running it as empty-text folder browsing", async () => {
+  const query = { v: 1, text: "", syntax: "advanced", mode: "hybrid", filters: { extensions: ["pdf"], no_tags: true }, sort: { field: "size", direction: "desc" } };
+  history.replaceState(null, "", `/#web_session=secret&web_upload_secret=proof&query=${encodeURIComponent(JSON.stringify(query))}`);
+  vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+  Object.defineProperty(Element.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
+  const root = { id: 1, name: "", kind: "dir", path: "/", revision: 1, size: 0, created_at: "2026-01-01T00:00:00Z", modified_at: "2026-01-01T00:00:00Z" };
+  const tag = { id: "11111111-1111-4111-8111-111111111111", name: "review", revision: 1, assignment_count: 0 };
+  const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    const value = url.includes("/path?") ? root : url.includes("/children?") ? { directory: root, items: [], total: 0, limit: 1000, offset: 0 }
+      : url === "/api/v1/tags?limit=1000&offset=0" ? { items: [tag], total: 1, limit: 1000, offset: 0 }
+      : url.includes("/nodes?") ? { items: [], total: 0, limit: 1000, offset: 0, omitted_trashed: 0 }
+      : { items: [], total: 0, limit: url.includes("saved-queries") ? 100 : 1000, offset: 0 };
+    return new Response(JSON.stringify(value));
+  });
+  render(App);
+  await screen.findByRole("dialog", { name: "Saved queries and highlights" });
+  expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value)).toEqual(query);
+  expect(location.hash).not.toContain("web_session");
+  expect(location.hash).not.toContain("proof");
+  expect(fetch.mock.calls.some(([url]) => String(url).includes("/search"))).toBe(false);
+  await fireEvent.click(screen.getByRole("button", { name: "Close" }));
+  await fireEvent.click(screen.getByRole("button", { name: "Saved queries and highlights" }));
+  expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value)).toEqual(query);
+  const kept = { ...query, text: "new draft" };
+  await fireEvent.input(screen.getByLabelText("Complete query JSON"), { target: { value: JSON.stringify(kept) } });
+  await fireEvent.click(screen.getByRole("button", { name: "Keep query draft" }));
+  await fireEvent.click(screen.getByRole("button", { name: "New query" }));
+  expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value)).toEqual(kept);
+  await fireEvent.click(screen.getByRole("button", { name: "Close" }));
+  await fireEvent.click(screen.getByRole("button", { name: "Discard query draft" }));
+  await fireEvent.input(screen.getByRole("searchbox", { name: "Search documents" }), { target: { value: "x".repeat(8193) } });
+  await fireEvent.click(screen.getByRole("button", { name: "Saved queries and highlights" }));
+  await screen.findByRole("dialog", { name: "Saved queries and highlights" });
+  expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value).text).toBe("x".repeat(8193));
+  await fireEvent.click(screen.getByRole("button", { name: "Keep query draft" }));
+  expect((await screen.findByRole("alert")).textContent).toContain("8192");
+  await fireEvent.click(screen.getByRole("button", { name: "New highlight set" }));
+  expect(screen.getByLabelText("Term 1")).toBeTruthy();
+  await fireEvent.click(screen.getByRole("button", { name: "Close" }));
+  await fireEvent.input(screen.getByRole("searchbox", { name: "Search documents" }), { target: { value: "" } });
+  await fireEvent.click(screen.getByRole("combobox", { name: "Browse or filter by tag: All tags" }));
+  await fireEvent.click(screen.getByRole("option", { name: "review (0)" }));
+  await screen.findByText("Documents tagged");
+  await fireEvent.click(screen.getByRole("button", { name: "Saved queries and highlights" }));
+  expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value).sort).toEqual({ field: "path", direction: "asc" });
+});
+
+it("shows malformed query fragments on the sign-in screen", async () => {
+  history.replaceState(null, "", "/#query=%7Bbad");
+  render(App);
+  expect((await screen.findByRole("alert")).textContent).toContain("Query URL");
+});

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import MapPinIcon from "@lucide/svelte/icons/map-pin";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import SearchIcon from "@lucide/svelte/icons/search";
+  import BookmarkIcon from "@lucide/svelte/icons/bookmark";
   import ShieldCheckIcon from "@lucide/svelte/icons/shield-check";
   import TagIcon from "@lucide/svelte/icons/tag";
   import TagsIcon from "@lucide/svelte/icons/tags";
@@ -42,6 +43,9 @@
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import SelectionDock from "./SelectionDock.svelte";
   import StorageDrawer from "./StorageDrawer.svelte";
+  import SavedQueriesDrawer from "./SavedQueriesDrawer.svelte";
+  import { parseQuery, type Query } from "./query.js";
+  import { queryFromFragment, replaceQueryURL } from "./queryURL.js";
   import TagCatalogModal, {
     type TagDefinitionChange,
   } from "./TagCatalogModal.svelte";
@@ -138,6 +142,10 @@
   let auditEvidenceOpen = $state(false);
   let storageOpen = $state(false);
   let backupsOpen = $state(false);
+  let savedQueriesOpen = $state(false);
+  let savedQueryDraft = $state<Query | null>(null);
+  let queryEditorInitial = $state<Query>(parseQuery("{}"));
+  let queryURLError = $state("");
   let trashOpen = $state(false);
   let manageTagsTarget = $state<Row | null>(null);
   let tagCatalogOpen = $state(false);
@@ -172,9 +180,13 @@
   );
 
   onMount(() => {
+    try { savedQueryDraft = queryFromFragment(location.hash); }
+    catch (cause) { queryURLError = cause instanceof Error ? cause.message : String(cause); }
     const session = takeFragmentSession();
+    if (savedQueryDraft) replaceQueryURL(savedQueryDraft);
     if (session) {
       webSession = session.token;
+      if (savedQueryDraft) openSavedQueries();
       void loadRoot();
       void loadTagCatalog();
       const channel = new VerifiedUploadChannel(session, undefined, () => {
@@ -229,6 +241,9 @@
 
   function handleFailure(cause: unknown): void {
     if (cause instanceof APIError && cause.status === 401) {
+      savedQueriesOpen = false;
+      savedQueryDraft = null;
+      replaceQueryURL(null);
       uploadChannel?.close();
       webSession = "";
       uploadChannel = null;
@@ -811,6 +826,9 @@
   }
 
   async function lock(): Promise<void> {
+    savedQueriesOpen = false;
+    savedQueryDraft = null;
+    replaceQueryURL(null);
     generation += 1;
     auditGeneration += 1;
     tagGeneration += 1;
@@ -863,6 +881,28 @@
       // in-memory session disappears with it.
     }
   }
+
+  function currentQueryDraft(): Query {
+    if (savedQueryDraft) return savedQueryDraft;
+    return {
+      ...parseQuery("{}"),
+      text: searchQuery,
+      filters: tagFilterID ? { tag_ids: [tagFilterID] } : {},
+      sort: { field: sortField === "modified" ? "modified_at" : sortField === "name" && (activeQuery !== "" || tagBrowse) ? "path" : sortField, direction: sortDirection },
+    };
+  }
+
+  function keepQueryDraft(query: Query): void {
+    replaceQueryURL(query);
+    savedQueryDraft = query;
+    queryEditorInitial = query;
+    queryURLError = "";
+  }
+
+  function openSavedQueries(): void {
+    queryEditorInitial = currentQueryDraft();
+    savedQueriesOpen = true;
+  }
 </script>
 
 {#if !webSession}
@@ -874,6 +914,7 @@
           The vault API key is never stored in the browser.
         </p>
         {#if error}<p class="error" role="alert">{error}</p>{/if}
+        {#if queryURLError}<p class="error" role="alert">Query URL could not be loaded: {queryURLError}</p>{/if}
       </div>
     </Card>
   </main>
@@ -907,6 +948,9 @@
         </form>
       {/snippet}
       {#snippet right()}
+        <IconButton size="sm" ariaLabel="Saved queries and highlights" onclick={openSavedQueries}>
+          <BookmarkIcon size="14" aria-hidden="true" />
+        </IconButton>
         <IconButton
           size="sm"
           ariaLabel="Recoverable trash"
@@ -1000,6 +1044,15 @@
         </IconButton>
       {/snippet}
     </TopBar>
+
+    {#if queryURLError}<p class="error" role="alert">Query URL could not be loaded: {queryURLError}</p>{/if}
+    {#if savedQueryDraft}
+      <div class="query-draft-notice">
+        <span>Query draft retained · not applied to live results</span>
+        <Button size="sm" onclick={openSavedQueries}>Edit query draft</Button>
+        <Button size="sm" onclick={() => { savedQueryDraft = null; replaceQueryURL(null); }}>Discard query draft</Button>
+      </div>
+    {/if}
 
     <main class="workspace">
       <Card class="browser" level="raised" padding="none" ariaLabel="Vault browser">
@@ -1522,6 +1575,15 @@
       <AuditEvidenceDrawer
         session={webSession}
         onclose={() => (auditEvidenceOpen = false)}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if savedQueriesOpen}
+      <SavedQueriesDrawer
+        session={webSession}
+        initialQuery={queryEditorInitial}
+        onload={keepQueryDraft}
+        onclose={() => (savedQueriesOpen = false)}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/SavedQueriesDrawer.svelte
+++ b/frontend/src/SavedQueriesDrawer.svelte
@@ -1,0 +1,238 @@
+<script lang="ts">
+  import { onMount, untrack } from "svelte";
+  import { Button, DetailDrawer, Spinner, TextInput } from "@kenn-io/kit-ui";
+  import { APIError } from "./api.js";
+  import { canonicalQuery, parseHighlightSet, parseQuery, type HighlightTerm, type Query } from "./query.js";
+  import { createSavedQuery, deleteSavedQuery, listSavedQueries, SavedQueryReceiptError, updateSavedQuery, type Definition, type SavedQuery, type SavedQueryKind } from "./savedQueries.js";
+
+  let { session, initialQuery, onload, onclose, onauthfailure }: {
+    session: string;
+    initialQuery: Query;
+    onload: (query: Query) => void;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  } = $props();
+
+  let items = $state<SavedQuery[]>([]);
+  let total = $state(0);
+  let offset = $state(0);
+  let loading = $state(true);
+  let pending = $state(false);
+  let failure = $state("");
+  let receiptFailed = $state(false);
+  let notice = $state("");
+  let selected = $state<SavedQuery | null>(null);
+  let deleting = $state<SavedQuery | null>(null);
+  let kind = $state<SavedQueryKind>("query");
+  let name = $state("");
+  let description = $state("");
+  let rawQuery = $state(untrack(() => JSON.stringify(initialQuery, null, 2)));
+  let terms = $state<HighlightTerm[]>([{ text: "", color: "#ffcc00" }]);
+  let generation = 0;
+  let alive = true;
+
+  onMount(() => {
+    void refresh(0);
+    return () => { alive = false; generation++; };
+  });
+
+  function fail(cause: unknown): void {
+    if (!alive) return;
+    if (cause instanceof APIError && cause.status === 401) onauthfailure(cause);
+    else failure = cause instanceof Error ? cause.message : String(cause);
+  }
+
+  async function refresh(nextOffset = offset): Promise<void> {
+    const request = ++generation;
+    loading = true;
+    failure = "";
+    try {
+      const page = await listSavedQueries(session, undefined, nextOffset);
+      if (request !== generation) return;
+      items = page.items;
+      total = page.total;
+      offset = page.offset;
+    } catch (cause) {
+      if (request === generation) fail(cause);
+    } finally {
+      if (request === generation) loading = false;
+    }
+  }
+
+  function edit(item: SavedQuery): void {
+    receiptFailed = false;
+    selected = item;
+    deleting = null;
+    kind = item.kind;
+    name = item.name;
+    description = item.description;
+    if (item.kind === "query") rawQuery = JSON.stringify(item.payload, null, 2);
+    else terms = item.payload.terms.map((term) => ({ ...term }));
+    failure = "";
+    notice = "";
+  }
+
+  function fresh(nextKind: SavedQueryKind): void {
+    receiptFailed = false;
+    selected = null;
+    deleting = null;
+    kind = nextKind;
+    name = "";
+    description = "";
+    rawQuery = JSON.stringify(initialQuery, null, 2);
+    terms = [{ text: "", color: "#ffcc00" }];
+    failure = "";
+    notice = "";
+  }
+
+  function definition(): Definition {
+    return kind === "query" ? { kind, payload: parseQuery(rawQuery) }
+      : { kind, payload: parseHighlightSet(JSON.stringify({ v: 1, terms })) };
+  }
+
+  function keepDraft(): void {
+    failure = "";
+    notice = "";
+    try {
+      const query = parseQuery(rawQuery);
+      onload(query);
+      rawQuery = JSON.stringify(JSON.parse(canonicalQuery(query)), null, 2);
+      notice = "Query draft kept in this tab and URL. It has not been executed.";
+    } catch (cause) { fail(cause); }
+  }
+
+  async function save(asNew: boolean): Promise<void> {
+    if (pending || receiptFailed || (!asNew && !selected)) return;
+    failure = "";
+    notice = "";
+    pending = true;
+    try {
+      const value = definition();
+      const saved = asNew
+        ? await createSavedQuery(session, { ...value, name, description })
+        : await updateSavedQuery(session, selected!, { name, description, payload: value.payload });
+      if (!alive) return;
+      edit(saved);
+      notice = `Saved ${saved.name}.`;
+      await refresh(0);
+    } catch (cause) { await mutationFailed(cause); }
+    finally { if (alive) pending = false; }
+  }
+
+  async function remove(): Promise<void> {
+    if (!deleting || pending) return;
+    pending = true;
+    failure = "";
+    notice = "";
+    try {
+      const removed = await deleteSavedQuery(session, deleting);
+      if (!alive) return;
+      if (selected?.id === removed.id) fresh("query");
+      deleting = null;
+      notice = `Deleted ${removed.name}. Documents were not changed.`;
+      await refresh(0);
+    } catch (cause) { await mutationFailed(cause); }
+    finally { if (alive) pending = false; }
+  }
+
+  async function mutationFailed(cause: unknown): Promise<void> {
+    if (!alive) return;
+    if (cause instanceof SavedQueryReceiptError) {
+      receiptFailed = true;
+      deleting = null;
+      items = [];
+      await refresh();
+    }
+    fail(cause);
+  }
+</script>
+
+<DetailDrawer title="Saved queries & highlights" ariaLabel="Saved queries and highlights" width="min(760px, 100vw)" onclose={() => { if (!pending) onclose(); }} closeOnOverlayClick={!pending}>
+  <div class="workspace">
+    <p class="boundary">Save search intent and reusable literal highlights. Definitions contain no result rows or document bodies.</p>
+    {#if failure}<p class="failure" role="alert">{failure}</p>{/if}
+    {#if notice}<p class="notice" role="status">{notice}</p>{/if}
+
+    {#if deleting}
+      <section aria-label="Delete saved definition" class="editor">
+        <h3>Delete {deleting.name}?</h3>
+        <p>Revision {deleting.revision} · <code>{deleting.id}</code></p>
+        <p>This permanently removes only this saved definition. Documents, other saved definitions and the kept query draft are unchanged.</p>
+        <div class="actions">
+          <Button tone="danger" disabled={pending} onclick={() => void remove()}>Confirm deletion</Button>
+          <Button disabled={pending} onclick={() => { deleting = null; failure = ""; }}>Cancel</Button>
+        </div>
+      </section>
+    {:else}
+      <div class="actions">
+        <Button disabled={pending} onclick={() => fresh("query")}>New query</Button>
+        <Button disabled={pending} onclick={() => fresh("highlight_set")}>New highlight set</Button>
+        <Button disabled={pending || loading} onclick={() => void refresh()}>Reload definitions</Button>
+      </div>
+      <section aria-label="Saved definitions" class="catalog">
+        {#if loading}<span><Spinner size={14} /> Loading definitions…</span>{/if}
+        {#each items as item (item.id)}
+          <div class="definition-row">
+            <div><strong>{item.name}</strong><small>{item.kind === "query" ? "Query" : "Highlight set"} · revision {item.revision}</small></div>
+            <Button size="sm" disabled={pending} onclick={() => edit(item)} ariaLabel={`Edit ${item.name}`}>Edit</Button>
+            <Button size="sm" disabled={pending} onclick={() => { deleting = item; failure = ""; notice = ""; }} ariaLabel={`Delete ${item.name}`}>Delete</Button>
+          </div>
+        {:else}
+          {#if !loading}<p>No saved definitions on this page.</p>{/if}
+        {/each}
+        <div class="actions">
+          <span>{items.length} shown · {total} total</span>
+          <Button size="sm" disabled={pending || loading || offset === 0} onclick={() => void refresh(Math.max(0, offset - 100))}>Previous</Button>
+          <Button size="sm" disabled={pending || loading || offset + 100 >= total} onclick={() => void refresh(offset + 100)}>Next</Button>
+        </div>
+      </section>
+
+      <section class="editor" aria-label="Definition editor">
+        <h3>{selected ? `Edit ${selected.name}` : kind === "query" ? "New query" : "New highlight set"}</h3>
+        {#if selected}<small>Revision {selected.revision} · {selected.id}</small>{/if}
+        <label for="definition-name">Name</label>
+        <TextInput id="definition-name" ariaLabel="Definition name" bind:value={name} disabled={pending} block />
+        <label for="definition-description">Description</label>
+        <textarea id="definition-description" aria-label="Definition description" bind:value={description} disabled={pending} rows="2" maxlength="4096"></textarea>
+        {#if kind === "query"}
+          <label for="query-json">Complete query JSON</label>
+          <p class="boundary">Expression, facets, mode and sort stay together. Unsupported or unknown fields are never silently removed.</p>
+          <textarea id="query-json" aria-label="Complete query JSON" bind:value={rawQuery} disabled={pending} rows="13" maxlength="131072" spellcheck="false"></textarea>
+          <p class="boundary">Saved-query execution is unavailable: the current live-search adapter cannot honor the complete query contract. Keeping or saving this draft does not change live results.</p>
+        {:else}
+          <p class="boundary">Literal terms only: 1–64 unique terms, up to 256 characters each, with lowercase #rrggbb colors. Highlight rendering is not available in the document viewer.</p>
+          {#each terms as term, index}
+            <div class="term-row">
+              <TextInput ariaLabel={`Term ${index + 1}`} bind:value={term.text} disabled={pending} block />
+              <TextInput ariaLabel={`Color ${index + 1}`} bind:value={term.color} disabled={pending} />
+              <Button size="sm" ariaLabel={`Remove term ${index + 1}`} disabled={pending || terms.length === 1} onclick={() => { terms = terms.filter((_, i) => i !== index); }}>Remove</Button>
+            </div>
+          {/each}
+          <Button size="sm" disabled={pending || terms.length >= 64} onclick={() => { terms = [...terms, { text: "", color: "#ffcc00" }]; }}>Add term</Button>
+        {/if}
+        <div class="actions">
+          <Button tone="info" surface="solid" disabled={pending || receiptFailed || !name} onclick={() => void save(true)}>Save as new</Button>
+          {#if selected}<Button disabled={pending || receiptFailed || !name} onclick={() => void save(false)}>Save changes</Button>{/if}
+          {#if kind === "query"}<Button disabled={pending} onclick={keepDraft}>Keep query draft</Button>{/if}
+        </div>
+      </section>
+    {/if}
+  </div>
+</DetailDrawer>
+
+<style>
+  .workspace { display: flex; flex-direction: column; gap: var(--space-4); padding: var(--space-5); }
+  .boundary, small { color: var(--text-muted); font-size: var(--font-size-sm); }
+  .actions { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
+  .catalog, .editor { display: flex; flex-direction: column; gap: var(--space-3); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-4); }
+  .definition-row { display: flex; align-items: center; gap: var(--space-2); }
+  .definition-row > div { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+  .definition-row small { display: block; }
+  .term-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(80px, 120px) auto; gap: var(--space-2); }
+  textarea { width: 100%; box-sizing: border-box; resize: vertical; padding: var(--space-3); border: 1px solid var(--border-default); border-radius: var(--radius-md); background: var(--bg-surface); color: var(--text-primary); font: inherit; }
+  #query-json { font-family: var(--font-mono); font-size: var(--font-size-sm); }
+  .failure { color: var(--accent-red); }
+  .notice { color: var(--accent-green); }
+  h3, p { margin: 0; }
+  code, small { overflow-wrap: anywhere; }
+</style>

--- a/frontend/src/SavedQueriesDrawer.test.ts
+++ b/frontend/src/SavedQueriesDrawer.test.ts
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import SavedQueriesDrawer from "./SavedQueriesDrawer.svelte";
+import { parseQuery } from "./query.js";
+
+const canonical = '{"filters":{"extensions":["pdf"],"no_tags":true},"mode":"hybrid","sort":{"direction":"desc","field":"size"},"syntax":"advanced","text":"alpha OR beta","v":1}';
+const record = {
+  id: "11111111-1111-4111-8111-111111111111", name: "Review PDFs", description: "Synthetic query",
+  kind: "query", payload: JSON.parse(canonical), revision: 2,
+  fingerprint: `sha256:${createHash("sha256").update(canonical).digest("hex")}`,
+  created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z",
+};
+const json = (value: unknown, revision = 2) => new Response(JSON.stringify(value), { headers: { ETag: `"${revision}"` } });
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+function open(onload = vi.fn()) {
+  render(SavedQueriesDrawer, { session: "session", initialQuery: parseQuery("{}"), onload, onclose: vi.fn(), onauthfailure: vi.fn() });
+  return onload;
+}
+
+it("loads a complete definition and saves it without silently executing it", async () => {
+  const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, request) => {
+    if (request?.method === "POST") {
+      const body = JSON.parse(String(request.body));
+      expect(body.payload).toEqual(JSON.parse(canonical));
+      return json({ ...record, ...body, revision: 1 }, 1);
+    }
+    return json({ items: [record], total: 1, limit: 100, offset: 0 });
+  });
+  const onload = open();
+  await fireEvent.click(await screen.findByRole("button", { name: "Edit Review PDFs" }));
+  expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value)).toEqual(JSON.parse(canonical));
+  await fireEvent.click(screen.getByRole("button", { name: "Keep query draft" }));
+  expect(onload).toHaveBeenCalledWith(parseQuery(canonical));
+  onload.mockClear();
+  expect(screen.getByText(/Saved-query execution is unavailable/)).toBeTruthy();
+  await fireEvent.input(screen.getByLabelText("Definition name"), { target: { value: "Copy of review" } });
+  await fireEvent.click(screen.getByRole("button", { name: "Save as new" }));
+  await screen.findByText(/Saved Copy of review/);
+  expect(onload).not.toHaveBeenCalled();
+  expect(fetch.mock.calls.some(([url]) => String(url).includes("/search"))).toBe(false);
+});
+
+it("preserves an unrelated unsaved editor when deleting a definition", async () => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, request) =>
+    request?.method === "DELETE" ? json(record)
+      : json({ items: [record], total: 1, limit: 100, offset: 0 }));
+  open();
+  await fireEvent.input(screen.getByLabelText("Definition name"), { target: { value: "Unfinished query" } });
+  await fireEvent.input(screen.getByLabelText("Complete query JSON"), { target: { value: canonical } });
+  await fireEvent.click(await screen.findByRole("button", { name: "Delete Review PDFs" }));
+  await fireEvent.click(screen.getByRole("button", { name: "Confirm deletion" }));
+  await screen.findByText(/^Deleted Review PDFs/);
+  expect((screen.getByLabelText("Definition name") as HTMLInputElement).value).toBe("Unfinished query");
+  expect((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value).toBe(canonical);
+});
+
+it.each(["Save as new", "Save changes"])("reloads committed NFC-divergent names after %s before another save", async (action) => {
+  let current = record;
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, request) => {
+    if (request?.method) {
+      current = { ...record, name: "\u1ea0", revision: action === "Save as new" ? 1 : 3 };
+      return json(current, current.revision);
+    }
+    return json({ items: [current], total: 1, limit: 100, offset: 0 });
+  });
+  open();
+  await fireEvent.click(await screen.findByRole("button", { name: "Edit Review PDFs" }));
+  await fireEvent.input(screen.getByLabelText("Definition name"), { target: { value: "\u{20041}\u0323" } });
+  await fireEvent.click(screen.getByRole("button", { name: action }));
+  await screen.findByRole("alert");
+  await screen.findByRole("button", { name: "Edit \u1ea0" });
+  expect((screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement).disabled).toBe(true);
+  expect((screen.getByRole("button", { name: "Save as new" }) as HTMLButtonElement).disabled).toBe(true);
+  await fireEvent.click(screen.getByRole("button", { name: "Edit \u1ea0" }));
+  expect((screen.getByLabelText("Definition name") as HTMLInputElement).value).toBe("\u1ea0");
+  expect(screen.getByText(new RegExp(`Revision ${current.revision} ·`))).toBeTruthy();
+  expect((screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement).disabled).toBe(false);
+});
+
+it("keeps stale rename and named revision-bound deletion failures visible", async () => {
+  const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, request) => {
+    if (request?.method) return new Response(JSON.stringify({ detail: "Changed elsewhere; reload the definition", code: "stale_revision" }), { status: 412 });
+    return json({ items: [record], total: 1, limit: 100, offset: 0 });
+  });
+  open();
+  await fireEvent.click(await screen.findByRole("button", { name: "Edit Review PDFs" }));
+  await fireEvent.input(screen.getByLabelText("Definition name"), { target: { value: "Renamed" } });
+  await fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  expect((await screen.findByRole("alert")).textContent).toContain("Changed elsewhere");
+  await fireEvent.click(screen.getByRole("button", { name: "Delete Review PDFs" }));
+  expect(screen.getByText(/Revision 2/)).toBeTruthy();
+  await fireEvent.click(screen.getByRole("button", { name: "Confirm deletion" }));
+  expect((await screen.findByRole("alert")).textContent).toContain("Changed elsewhere");
+  expect(screen.queryByText(/^Deleted /)).toBeNull();
+  const mutations = fetch.mock.calls.filter(([, request]) => request?.method);
+  expect(mutations).toHaveLength(2);
+  expect(new Headers(mutations[1][1]?.headers).get("If-Match")).toBe('"2"');
+});
+
+it("edits bounded highlight terms without offering execution", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(json({ items: [], total: 0, limit: 100, offset: 0 }));
+  open();
+  await fireEvent.click(screen.getByRole("button", { name: "New highlight set" }));
+  await fireEvent.input(screen.getByLabelText("Definition name"), { target: { value: "Key terms" } });
+  await fireEvent.input(screen.getByLabelText("Term 1"), { target: { value: "alpha" } });
+  await fireEvent.input(screen.getByLabelText("Color 1"), { target: { value: "red" } });
+  await fireEvent.click(screen.getByRole("button", { name: "Save as new" }));
+  expect((await screen.findByRole("alert")).textContent).toContain("#rrggbb");
+  expect(screen.queryByRole("button", { name: /run/i })).toBeNull();
+  expect(screen.queryByRole("button", { name: "Keep query draft" })).toBeNull();
+});

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -37,6 +37,16 @@ code {
   min-height: 100vh;
 }
 
+.query-draft-notice {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
 .brand {
   display: flex;
   align-items: center;

--- a/frontend/src/queryURL.test.ts
+++ b/frontend/src/queryURL.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, it } from "vitest";
+import { takeFragmentSession } from "./api.js";
+import { queryFromFragment, replaceQueryURL } from "./queryURL.js";
+import { parseQuery } from "./query.js";
+
+afterEach(() => history.replaceState(null, "", "/"));
+const query = parseQuery('{"text":"α OR beta","syntax":"advanced","mode":"hybrid","filters":{"extensions":["pdf"],"no_tags":true},"sort":{"field":"size","direction":"desc"}}');
+
+it("round-trips the full query without serializing session credentials", () => {
+  history.replaceState(null, "", "/#web_session=secret&web_upload_secret=proof");
+  replaceQueryURL(query);
+  expect(queryFromFragment(location.hash)).toEqual(query);
+  expect(location.hash).not.toContain("secret");
+  expect(location.hash).not.toContain("proof");
+  expect(sessionStorage.length).toBe(0);
+});
+
+it("allows query restoration before consuming a combined sign-in fragment", () => {
+  history.replaceState(null, "", `/#web_session=secret&web_upload_secret=proof&query=${encodeURIComponent(JSON.stringify(query))}`);
+  const restored = queryFromFragment(location.hash);
+  expect(takeFragmentSession()).toEqual({ token: "secret", uploadSecret: "proof" });
+  expect(location.hash).toBe("");
+  replaceQueryURL(restored);
+  expect(queryFromFragment(location.hash)).toEqual(query);
+  expect(location.hash).not.toContain("web_session");
+});
+
+it("rejects ambiguous, oversized and unknown query state", () => {
+  expect(() => queryFromFragment("#query={}&query={}")).toThrow();
+  expect(() => queryFromFragment(`#query=${"x".repeat(400000)}`)).toThrow();
+  expect(() => queryFromFragment("#query=%7B%22future%22%3Atrue%7D")).toThrow();
+  expect(queryFromFragment("#unrelated=value")).toBeNull();
+});
+
+it("removes the draft URL explicitly", () => {
+  replaceQueryURL(query);
+  replaceQueryURL(null);
+  expect(location.hash).toBe("");
+});

--- a/frontend/src/queryURL.ts
+++ b/frontend/src/queryURL.ts
@@ -1,0 +1,15 @@
+import { canonicalQuery, parseQuery, type Query } from "./query.js";
+
+// Query state stays in the fragment (never sent to the daemon). Authentication
+// is consumed independently; only the validated query is written back.
+export function queryFromFragment(hash: string): Query | null {
+  if (hash.length > 256 * 1024) throw new Error("Query URL exceeds its size limit.");
+  const values = new URLSearchParams(hash.replace(/^#/, "")).getAll("query");
+  if (values.length > 1) throw new Error("Query URL contains multiple definitions.");
+  return values.length ? parseQuery(values[0]) : null;
+}
+
+export function replaceQueryURL(query: Query | null): void {
+  const fragment = query ? `#query=${encodeURIComponent(canonicalQuery(query))}` : "";
+  history.replaceState(null, "", `${location.pathname}${location.search}${fragment}`);
+}

--- a/frontend/src/savedQueries.test.ts
+++ b/frontend/src/savedQueries.test.ts
@@ -1,0 +1,118 @@
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { APIError } from "./api.js";
+import { createSavedQuery, deleteSavedQuery, getSavedQuery, listSavedQueries, updateSavedQuery } from "./savedQueries.js";
+
+const id = "00000000-0000-4000-8000-000000000001";
+const canonical = '{"filters":{"extensions":["pdf"],"no_tags":true},"mode":"hybrid","sort":{"direction":"desc","field":"size"},"syntax":"advanced","text":"alpha OR β","v":1}';
+const payload = JSON.parse(canonical);
+const record = {
+  id, name: "Review", description: "Synthetic definition", kind: "query" as const,
+  payload, fingerprint: `sha256:${createHash("sha256").update(canonical).digest("hex")}`,
+  revision: 3, created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-02T00:00:00Z",
+};
+function respond(value: unknown, etag = '"3"') {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response(JSON.stringify(value), {
+    headers: { ETag: etag, "Content-Type": "application/json" },
+  }));
+}
+afterEach(() => vi.restoreAllMocks());
+
+describe("saved definition receipts", () => {
+  it("lists, edits and deletes server-accepted names without applying browser whitespace rules", async () => {
+    const saved = { ...record, name: "\ufeff" };
+    const fetch = respond({ items: [saved], total: 1, limit: 100, offset: 0 });
+    const page = await listSavedQueries("session");
+    expect(page.items[0].name).toBe("\ufeff");
+    fetch.mockResolvedValueOnce(new Response(JSON.stringify(saved), { headers: { ETag: '"3"' } }));
+    expect((await updateSavedQuery("session", page.items[0], { name: "\ufeff" })).name).toBe("\ufeff");
+    fetch.mockResolvedValueOnce(new Response(JSON.stringify(saved), { headers: { ETag: '"3"' } }));
+    expect((await deleteSavedQuery("session", page.items[0])).id).toBe(id);
+  });
+
+  it("loads the complete expression, unsupported facets, mode and sort", async () => {
+    respond(record);
+    const loaded = await getSavedQuery("session", id);
+    expect(loaded.payload).toEqual(payload);
+    expect(loaded.revision).toBe(3);
+  });
+
+  it.each([
+    ["identity", { id: "00000000-0000-4000-8000-000000000002" }],
+    ["fingerprint", { fingerprint: `sha256:${"0".repeat(64)}` }],
+    ["revision", { revision: 0 }],
+    ["kind", { kind: "highlight_set" }],
+    ["unknown query field", { payload: { ...payload, unknown: true } }],
+  ])("rejects a wrong %s", async (_name, change) => {
+    respond({ ...record, ...change });
+    await expect(getSavedQuery("session", id)).rejects.toThrow();
+  });
+
+  it("binds the ETag to the payload revision", async () => {
+    respond(record, '"4"');
+    await expect(getSavedQuery("session", id)).rejects.toThrow(/receipt/i);
+  });
+
+  it("validates list selectors, totals and distinct identities", async () => {
+    const fetch = respond({ items: [record], total: 1, limit: 100, offset: 0 });
+    expect((await listSavedQueries("session", "query")).items[0].payload).toEqual(payload);
+    expect(String(fetch.mock.calls[0][0])).toContain("kind=query");
+    fetch.mockResolvedValueOnce(new Response(JSON.stringify({ items: [record, record], total: 2, limit: 100, offset: 0 })));
+    await expect(listSavedQueries("session", "query")).rejects.toThrow(/receipt/i);
+    fetch.mockResolvedValueOnce(new Response(JSON.stringify({ items: [record], total: 1, limit: 100, offset: 0 })));
+    await expect(listSavedQueries("session", "highlight_set")).rejects.toThrow(/receipt/i);
+  });
+
+  it("creates without changing the full definition and checks the returned content", async () => {
+    const fetch = respond({ ...record, revision: 1 }, '"1"');
+    await createSavedQuery("session", { name: record.name, description: record.description, kind: "query", payload });
+    expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).toEqual({ name: record.name, description: record.description, kind: "query", payload });
+    fetch.mockResolvedValueOnce(new Response(JSON.stringify({ ...record, name: "Wrong", revision: 1 }), { headers: { ETag: '"1"' } }));
+    await expect(createSavedQuery("session", { name: record.name, description: record.description, kind: "query", payload })).rejects.toThrow(/receipt/i);
+  });
+
+  it("fences a rename and preserves omitted fields", async () => {
+    const fetch = respond({ ...record, name: "Renamed", revision: 4 }, '"4"');
+    const updated = await updateSavedQuery("session", record, { name: "Renamed" });
+    expect(updated.payload).toEqual(payload);
+    expect(new Headers(fetch.mock.calls[0][1]?.headers).get("If-Match")).toBe('"3"');
+    expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).toEqual({ name: "Renamed" });
+  });
+
+  it("accepts an unchanged revision only for a no-op", async () => {
+    respond(record);
+    expect((await updateSavedQuery("session", record, { name: "Review" })).revision).toBe(3);
+    await expect(updateSavedQuery("session", record, { name: "Renamed" })).rejects.toThrow(/receipt/i);
+  });
+
+  it("rejects null patches and unsafe fences before sending", async () => {
+    const fetch = respond(record);
+    await expect(updateSavedQuery("session", record, { description: null } as never)).rejects.toThrow();
+    await expect(deleteSavedQuery("session", { ...record, revision: 0 })).rejects.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a stale mutation or claim deletion", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ code: "stale_revision", detail: "Changed elsewhere" }), { status: 412 }));
+    await expect(deleteSavedQuery("session", record)).rejects.toEqual(new APIError("Changed elsewhere", 412, "stale_revision"));
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds the deletion receipt to the entire observed definition", async () => {
+    const fetch = respond(record);
+    expect((await deleteSavedQuery("session", record)).id).toBe(id);
+    expect(new Headers(fetch.mock.calls[0][1]?.headers).get("If-Match")).toBe('"3"');
+    fetch.mockResolvedValueOnce(new Response(JSON.stringify({ ...record, name: "Someone else" }), { headers: { ETag: '"3"' } }));
+    await expect(deleteSavedQuery("session", record)).rejects.toThrow(/receipt/i);
+  });
+
+  it("saves bounded literal highlights separately from executable queries", async () => {
+    const highlight = { v: 1, terms: [{ text: "alpha", color: "#ffcc00" }] };
+    const fingerprint = `sha256:${createHash("sha256").update('{"terms":[{"color":"#ffcc00","text":"alpha"}],"v":1}').digest("hex")}`;
+    const fetch = respond({ ...record, kind: "highlight_set", payload: highlight, fingerprint, revision: 1 }, '"1"');
+    expect((await createSavedQuery("session", { name: record.name, description: record.description, kind: "highlight_set", payload: highlight })).kind).toBe("highlight_set");
+    fetch.mockClear();
+    await expect(createSavedQuery("session", { name: "Bad", kind: "highlight_set", payload: { v: 1, terms: [{ text: "x", color: "red" }] } })).rejects.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/savedQueries.ts
+++ b/frontend/src/savedQueries.ts
@@ -1,0 +1,188 @@
+import { requestJSON, requestResponse } from "./api.js";
+import {
+  canonicalHighlightSet, canonicalQuery, highlightSetFingerprint,
+  parseHighlightSet, parseQuery, queryFingerprint,
+  type HighlightSet, type Query,
+} from "./query.js";
+
+export type Definition =
+  | { kind: "query"; payload: Query }
+  | { kind: "highlight_set"; payload: HighlightSet };
+export type SavedQueryKind = Definition["kind"];
+export type SavedQuery = Definition & {
+  id: string;
+  name: string;
+  description: string;
+  fingerprint: string;
+  revision: number;
+  created_at: string;
+  updated_at: string;
+};
+export interface SavedQueryPage {
+  items: SavedQuery[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+export type SavedQueryCreate = Definition & { name: string; description?: string };
+export interface SavedQueryPatch {
+  name?: string;
+  description?: string;
+  payload?: Query | HighlightSet;
+}
+
+const route = "/api/v1/saved-queries";
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const encoder = new TextEncoder();
+
+export class SavedQueryReceiptError extends Error {
+  constructor() {
+    super("Saved definition receipt does not match the request. Reload definitions and reopen the item before continuing.");
+  }
+}
+
+function requireReceipt(valid: unknown): asserts valid {
+  if (!valid) throw new SavedQueryReceiptError();
+}
+
+function object(value: unknown): Record<string, unknown> {
+  requireReceipt(value !== null && typeof value === "object" && !Array.isArray(value));
+  return value as Record<string, unknown>;
+}
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function validString(value: unknown, maxBytes: number): value is string {
+  return typeof value === "string" && !/[\uD800-\uDFFF]/u.test(value) && encoder.encode(value).length <= maxBytes;
+}
+
+function nameValue(value: unknown): string {
+  if (typeof value !== "string") throw new Error("A saved definition needs a name.");
+  const name = value.normalize("NFC");
+  if (!validString(name, 256) || !/\P{White_Space}/u.test(name) || /[\p{Cc}]/u.test(name)) {
+    throw new Error("Name must contain 1–256 UTF-8 bytes and no control characters.");
+  }
+  return name;
+}
+
+function descriptionValue(value: unknown): string {
+  if (typeof value !== "string") throw new Error("Description must be text.");
+  const description = value.replaceAll("\r\n", "\n");
+  if (!validString(description, 4096) || /[\p{Cc}]/u.test(description.replace(/[\t\n]/g, ""))) {
+    throw new Error("Description exceeds 4096 UTF-8 bytes or contains control characters.");
+  }
+  return description;
+}
+
+function definition(kind: unknown, payload: unknown): Definition {
+  if (kind === "query") return { kind, payload: parseQuery(JSON.stringify(payload)) };
+  if (kind === "highlight_set") return { kind, payload: parseHighlightSet(JSON.stringify(payload)) };
+  throw new Error("Unknown saved definition kind.");
+}
+
+function canonical(value: Definition): string {
+  return value.kind === "query" ? canonicalQuery(value.payload) : canonicalHighlightSet(value.payload);
+}
+
+async function receipt(value: unknown): Promise<SavedQuery> {
+  const raw = object(value);
+  requireReceipt(typeof raw.id === "string" && uuid.test(raw.id) && positiveInteger(raw.revision));
+  requireReceipt(typeof raw.created_at === "string" && Number.isFinite(Date.parse(raw.created_at)) &&
+    typeof raw.updated_at === "string" && Number.isFinite(Date.parse(raw.updated_at)));
+  // The server owns name normalization; browser Unicode tables can differ.
+  requireReceipt(validString(raw.name, 256) && raw.name.length > 0);
+  const name = raw.name;
+  const description = descriptionValue(raw.description);
+  requireReceipt(description === raw.description);
+  const decoded = definition(raw.kind, raw.payload);
+  const fingerprint = decoded.kind === "query"
+    ? await queryFingerprint(decoded.payload) : await highlightSetFingerprint(decoded.payload);
+  requireReceipt(raw.fingerprint === fingerprint);
+  return {
+    ...decoded, id: raw.id, name, description, fingerprint,
+    revision: raw.revision, created_at: raw.created_at, updated_at: raw.updated_at,
+  };
+}
+
+function path(id: string): string {
+  if (!uuid.test(id)) throw new Error("Invalid saved definition ID.");
+  return `${route}/${id}`;
+}
+
+function fence(value: SavedQuery): HeadersInit {
+  if (!positiveInteger(value.revision)) throw new Error("A positive saved definition revision is required.");
+  return { "Content-Type": "application/json", "If-Match": `"${value.revision}"` };
+}
+
+async function readResponse(response: Response): Promise<SavedQuery> {
+  try {
+    const saved = await receipt(await response.json());
+    requireReceipt(response.headers.get("ETag") === `"${saved.revision}"`);
+    return saved;
+  } catch {
+    throw new SavedQueryReceiptError();
+  }
+}
+
+export async function listSavedQueries(
+  session: string, kind?: SavedQueryKind, offset = 0, limit = 100,
+): Promise<SavedQueryPage> {
+  if (!Number.isSafeInteger(offset) || offset < 0 || !positiveInteger(limit) || limit > 1000 ||
+    kind !== undefined && kind !== "query" && kind !== "highlight_set") throw new Error("Invalid saved definition page.");
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  if (kind) params.set("kind", kind);
+  const page = object(await requestJSON<unknown>(`${route}?${params}`, session));
+  requireReceipt(page.limit === limit && page.offset === offset &&
+    typeof page.total === "number" && Number.isSafeInteger(page.total) && page.total >= 0 && Array.isArray(page.items));
+  requireReceipt(page.items.length === Math.min(limit, Math.max(0, page.total - offset)));
+  const items = await Promise.all(page.items.map(receipt));
+  requireReceipt(new Set(items.map((item) => item.id)).size === items.length && items.every((item) => !kind || item.kind === kind));
+  return { items, total: page.total, limit, offset };
+}
+
+export async function getSavedQuery(session: string, id: string): Promise<SavedQuery> {
+  const saved = await readResponse(await requestResponse(path(id), session));
+  requireReceipt(saved.id === id);
+  return saved;
+}
+
+export async function createSavedQuery(session: string, input: SavedQueryCreate): Promise<SavedQuery> {
+  const expected = { ...definition(input.kind, input.payload), name: nameValue(input.name), description: descriptionValue(input.description ?? "") };
+  const saved = await readResponse(await requestResponse(route, session, {
+    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(expected),
+  }));
+  requireReceipt(saved.revision === 1 && sameDefinition(saved, expected));
+  return saved;
+}
+
+function sameDefinition(left: SavedQuery, right: Definition & { name: string; description: string }): boolean {
+  return left.kind === right.kind && left.name === right.name && left.description === right.description && canonical(left) === canonical(right);
+}
+
+export async function updateSavedQuery(session: string, observed: SavedQuery, patch: SavedQueryPatch): Promise<SavedQuery> {
+  const headers = fence(observed);
+  if (Object.keys(patch).some((key) => !["name", "description", "payload"].includes(key))) throw new Error("Unknown saved definition patch field.");
+  const body: SavedQueryPatch = {};
+  if (patch.name !== undefined) body.name = nameValue(patch.name);
+  if (patch.description !== undefined) body.description = descriptionValue(patch.description);
+  if (patch.payload !== undefined) body.payload = definition(observed.kind, patch.payload).payload;
+  if (!Object.keys(body).length) throw new Error("No changes supplied.");
+  const expected = {
+    ...definition(observed.kind, body.payload ?? observed.payload),
+    name: body.name ?? observed.name, description: body.description ?? observed.description,
+  };
+  const revision = observed.revision + (sameDefinition(observed, expected) ? 0 : 1);
+  requireReceipt(Number.isSafeInteger(revision));
+  const saved = await readResponse(await requestResponse(path(observed.id), session, { method: "PATCH", headers, body: JSON.stringify(body) }));
+  requireReceipt(saved.id === observed.id && saved.revision === revision && saved.created_at === observed.created_at && sameDefinition(saved, expected));
+  return saved;
+}
+
+export async function deleteSavedQuery(session: string, observed: SavedQuery): Promise<SavedQuery> {
+  const saved = await readResponse(await requestResponse(path(observed.id), session, { method: "DELETE", headers: fence(observed) }));
+  requireReceipt(saved.id === observed.id && saved.revision === observed.revision &&
+    saved.created_at === observed.created_at && saved.updated_at === observed.updated_at && sameDefinition(saved, observed));
+  return saved;
+}


### PR DESCRIPTION
Manage saved queries and reusable highlight sets from the web app's bookmark button. Create, edit, rename, and deliberately delete definitions using the saved-definition API from #306.

**Keep query draft** retains the complete expression, filters, mode, and sort in the tab and URL fragment. Saving or deleting another definition leaves that draft alone. Query URLs contain search text and filters, so treat them as private. Locking or a rejected session clears the draft; save a named definition before opening a new session if you need it later.

Edits and deletions use the inspected revision. Stale writes remain visible without automatic retries. If a successful mutation returns a receipt the browser cannot verify, the catalog reloads and the editor requires a fresh selection before another save. Server-accepted Unicode names remain accessible in the catalog.

Saved-query execution and highlight rendering remain unavailable. Keeping or saving a definition does not change live results. Highlight sets contain literal terms and lowercase hex colors. No schema changes or new query executor.

![Saved-query editor in the actual web app, using synthetic proposals.](https://raw.githubusercontent.com/kenn-io/docbank/b9c7cffd7459c25362a73983ab4ab898707c3fe2/screenshots/pr-310-review/web-saved-queries.png)

![Reusable literal highlight terms in the actual web app, using synthetic data.](https://raw.githubusercontent.com/kenn-io/docbank/b9c7cffd7459c25362a73983ab4ab898707c3fe2/screenshots/pr-310-review/web-highlight-sets.png)
