### PR TITLE
feat(web): browse and label import collections

### DIFF
--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -473,6 +473,28 @@ still readable. Run `docbank backup verify` to independently prove repository
 integrity, and periodically restore into a separate vault to rehearse the
 complete recovery path.
 
+## Browse import collections
+
+Choose **Import collections** in the top bar to browse the vault's import groups.
+Each card shows its label or source description, ingest time, current live
+file count, and logical bytes. Select a collection to browse its current
+live members and inspect a document by its stable node identity. Counts are
+current membership, not a historical import total. The browser refresh time
+is separate from the ingest time.
+
+Labels belong to the import group, not its documents. Rename or clear a label
+under its inspected revision; if another client changes it first, the drawer
+keeps your draft and reports the conflict. Reload the label before deciding
+whether to save again. Label changes are unavailable once permanent audit
+authority has been enabled.
+
+Collection and member lists show at most 100 entries each. Empty groups,
+failed reads, and truncated lists are reported separately; use the paginated
+HTTP API to browse beyond that limit. This is direct member browsing, not
+a collection-filtered text search. Processing quality and coverage are
+unavailable here; the drawer does not treat missing coverage as zero failures
+or complete processing.
+
 ## Browser authentication
 
 When Docbank opens the browser, it writes a small launch page beside the
@@ -507,6 +529,8 @@ accepts that credential for the following operations:
 | Add or remove a tag assignment | Requires the selected stable node ID and its current revision. |
 | Create, rename, or delete a tag definition | Rename and delete require the inspected tag revision; deletion reports the removed assignment count. |
 | Read and manage saved query or highlight definitions | Edit and delete require the saved definition's revision. Permanent audit history blocks these writes. |
+| Read collections and their members | Returns bounded lists of live import membership. |
+| Set or clear a collection label | Requires the inspected collection-label revision. |
 
 Use the bookmark button to [manage saved queries and highlights](#saved-queries-and-highlights).
 

--- a/frontend/screenshots/README.md
+++ b/frontend/screenshots/README.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-09-11
+---
+
 # Web screenshots
 
 This Playwright harness captures the actual daemon-served Docbank interface
@@ -41,3 +45,19 @@ DOCBANK_SCREENSHOT_DIR="$(mktemp -d)" node node_modules/@playwright/test/cli.js 
   --config screenshots/playwright.config.ts --project chromium \
   --grep "trash confirmation"
 ```
+
+The collection case runs separately until both images are included in a complete
+published, pinned `docs-assets` set. `make docs-screenshots` excludes it until
+then. It imports two synthetic documents and exercises label rename, a concurrent
+label conflict, clearing, and document navigation:
+
+```sh
+make build
+DOCBANK_SCREENSHOT_DIR="$PWD/.superpowers/collection-screenshots" \
+  node frontend/node_modules/@playwright/test/cli.js test \
+  --config frontend/screenshots/playwright.config.ts --project chromium \
+  --grep "import collections"
+```
+
+It captures the member browser and the preserved draft after a label conflict
+as `web-collections.png` and `web-collection-label-conflict.png`.

--- a/frontend/screenshots/collections.screenshot.ts
+++ b/frontend/screenshots/collections.screenshot.ts
@@ -79,6 +79,19 @@ test("import collections, label conflicts and stable document navigation", async
     await expect(drawer.getByRole("button", { name: "Clear label", exact: true })).toBeEnabled();
     await drawer.getByRole("button", { name: "Clear label", exact: true }).click();
     await expect.poll(async () => (await (await api(labelRoute)).json()).label).toBeNull();
+
+    // Move the member after its path check, before the directory request completes.
+    await page.route("**/api/v1/nodes/*/children?*", async (route) => {
+      await run("mv", "/Discovery/review-notes.txt", "/review-notes.txt");
+      await route.continue();
+    }, { times: 1 });
+    await drawer.getByRole("button", { name: "Open document /Discovery/review-notes.txt", exact: true }).click();
+    await expect(drawer).not.toBeVisible();
+    await expect(page.getByRole("alert")).toBeVisible();
+    await expect(page.getByRole("cell", { name: "review-notes.txt", exact: true })).toHaveCount(0);
+    await run("mv", "/review-notes.txt", "/Discovery/review-notes.txt");
+    await page.getByRole("button", { name: "Import collections", exact: true }).click();
+    await drawer.getByRole("button", { name: `Browse collection Unlabeled import ${collectionID.slice(0, 8)}`, exact: true }).click();
     await drawer.getByRole("button", { name: "Open document /Discovery/review-notes.txt", exact: true }).click();
     await expect(drawer).not.toBeVisible();
     await expect(page.getByRole("cell", { name: "review-notes.txt", exact: true })).toBeVisible();

--- a/frontend/screenshots/collections.screenshot.ts
+++ b/frontend/screenshots/collections.screenshot.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const exec = promisify(execFile);
+const repository = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const screenshots = process.env.DOCBANK_SCREENSHOT_DIR;
+if (!screenshots) throw new Error("DOCBANK_SCREENSHOT_DIR is required");
+
+test("import collections, label conflicts and stable document navigation", async ({ page }) => {
+  const workspace = await mkdtemp(path.join(tmpdir(), "docbank-collections-"));
+  const vault = path.join(workspace, "vault");
+  const run = async (...args: string[]) => (await exec(path.join(repository, "docbank"), args, {
+    cwd: repository, env: { ...process.env, DOCBANK_HOME: vault }, timeout: 60_000,
+  })).stdout.trim();
+  try {
+    await mkdir(screenshots, { recursive: true, mode: 0o700 });
+    const source = path.join(workspace, "Discovery");
+    await mkdir(source, { mode: 0o700 });
+    await writeFile(path.join(source, "review-notes.txt"), "Synthetic notes: compare alpha and beta proposals.\n", { mode: 0o600 });
+    await writeFile(path.join(source, "meeting-summary.txt"), "Synthetic meeting: review the two proposals on Friday.\n", { mode: 0o600 });
+    await run("add", source, "--dest", "/");
+    const webURL = new URL(await run("web", "--no-browser"));
+    if (webURL.protocol !== "http:" || !/^docbank-[0-9a-f]{32}\.localhost$/.test(webURL.hostname) ||
+      !webURL.port || webURL.pathname !== "/" || webURL.username || webURL.password || webURL.search) {
+      throw new Error("Unexpected synthetic browser origin");
+    }
+    const session = new URLSearchParams(webURL.hash.slice(1)).get("web_session");
+    if (!session) throw new Error("Missing synthetic browser session");
+    // Keep scoped credentials in memory; neither URLs nor headers are printed.
+    const api = async (route: string, init: RequestInit = {}) => {
+      const response = await fetch(`http://127.0.0.1:${webURL.port}${route}`, {
+        ...init, headers: { Host: webURL.host, "X-Docbank-Web-Session": session, ...init.headers },
+      });
+      if (!response.ok) throw new Error(`Synthetic collection request failed: ${response.status}`);
+      return response;
+    };
+    const listed = await (await api("/api/v1/collections?limit=100&offset=0")).json() as { items: { id: string }[] };
+    expect(listed.items).toHaveLength(1);
+    const collectionID = listed.items[0]!.id;
+    const labelRoute = `/api/v1/collections/${collectionID}/label`;
+    const initial = await api(labelRoute);
+    await api(labelRoute, {
+      method: "PUT", headers: { "Content-Type": "application/json", "If-Match": initial.headers.get("ETag")! },
+      body: JSON.stringify({ label: "Discovery batch" }),
+    });
+
+    await page.addInitScript(() => localStorage.setItem("docbank-theme", "dark"));
+    await page.goto(webURL.toString()).catch(() => {
+      throw new Error("Synthetic browser navigation failed");
+    });
+    await page.getByRole("button", { name: "Import collections", exact: true }).click();
+    const drawer = page.getByRole("dialog", { name: "Import collections" });
+    await drawer.getByRole("button", { name: "Browse collection Discovery batch", exact: true }).click();
+    await expect(drawer.getByRole("button", { name: "Open document /Discovery/review-notes.txt", exact: true })).toBeVisible();
+    await expect(drawer.getByText(/Quality.*unavailable/i)).toBeVisible();
+    await drawer.getByRole("textbox", { name: "Collection label", exact: true }).fill("Proposal review");
+    await drawer.getByRole("button", { name: "Save label", exact: true }).click();
+    await expect(drawer.getByRole("button", { name: "Browse collection Proposal review", exact: true })).toBeVisible();
+    expect(new URL(page.url()).hash).not.toContain("web_session");
+    await page.screenshot({ path: path.join(screenshots, "web-collections.png"), animations: "disabled" });
+
+    // An independent API writer advances the same label revision.
+    const beforeConflict = await api(labelRoute);
+    await api(labelRoute, {
+      method: "PUT", headers: { "Content-Type": "application/json", "If-Match": beforeConflict.headers.get("ETag")! },
+      body: JSON.stringify({ label: "Externally labeled" }),
+    });
+    await drawer.getByRole("textbox", { name: "Collection label", exact: true }).fill("Keep this draft");
+    await drawer.getByRole("button", { name: "Save label", exact: true }).click();
+    await expect(drawer.getByRole("alert")).toBeVisible();
+    await expect(drawer.getByRole("textbox", { name: "Collection label", exact: true })).toHaveValue("Keep this draft");
+    await page.screenshot({ path: path.join(screenshots, "web-collection-label-conflict.png"), animations: "disabled" });
+    await drawer.getByRole("button", { name: "Reload label", exact: true }).click();
+    await expect(drawer.getByRole("button", { name: "Clear label", exact: true })).toBeEnabled();
+    await drawer.getByRole("button", { name: "Clear label", exact: true }).click();
+    await expect.poll(async () => (await (await api(labelRoute)).json()).label).toBeNull();
+    await drawer.getByRole("button", { name: "Open document /Discovery/review-notes.txt", exact: true }).click();
+    await expect(drawer).not.toBeVisible();
+    await expect(page.getByRole("cell", { name: "review-notes.txt", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "review-notes.txt", exact: true })).toBeVisible();
+  } finally {
+    await run("daemon", "stop");
+    const status = JSON.parse(await run("daemon", "status", "--json"));
+    if (status.running !== false) throw new Error("Synthetic collections daemon did not stop; workspace retained.");
+    await rm(workspace, { recursive: true, force: true });
+  }
+});

--- a/frontend/screenshots/run.mjs
+++ b/frontend/screenshots/run.mjs
@@ -39,6 +39,9 @@ const result = spawnSync(
     path.join(here, "playwright.config.ts"),
     "--project",
     "chromium",
+    // Remove this exclusion when collection images join the published, pinned set.
+    "--grep-invert",
+    "import collections",
     ...process.argv.slice(2),
   ],
   {

--- a/frontend/src/App.collections.test.ts
+++ b/frontend/src/App.collections.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import App from "./App.svelte";
+
+afterEach(() => {
+  cleanup();
+  history.replaceState(null, "", "/");
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+  vi.restoreAllMocks();
+});
+
+it("opens the exact collection member when its bounded parent page omits it", async () => {
+  history.replaceState(null, "", "/#web_session=short-lived&web_upload_secret=proof");
+  vi.stubGlobal("ResizeObserver", class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+
+  const root = {
+    id: 1, name: "", kind: "dir", size: 0, revision: 1,
+    created_at: "2026-09-09T12:00:00Z", modified_at: "2026-09-09T12:00:00Z", path: "/",
+  };
+  const archive = { ...root, id: 7, parent_id: 1, name: "Archive", path: "/Archive" };
+  const member = {
+    id: 42, parent_id: 7, name: "report.txt", kind: "file", path: "/Archive/report.txt",
+    current_version_id: "22222222-2222-4222-8222-222222222222",
+    blob_hash: "a".repeat(64), size: 2048, revision: 5,
+    created_at: "2026-09-09T14:30:00Z", modified_at: "2026-09-09T14:30:00Z",
+  };
+  const oldPageOccupant = {
+    ...member, id: 9, name: "first.txt", path: "/Archive/first.txt",
+    current_version_id: "33333333-3333-4333-8333-333333333333",
+    blob_hash: "b".repeat(64),
+  };
+  const collectionID = "11111111-1111-4111-8111-111111111111";
+  const collection = {
+    id: collectionID, source_kind: "cli", source_description: "/synthetic/drop",
+    started_at: "2026-09-09T14:30:00Z", file_count: 1, total_bytes: 2048,
+    label: "Discovery batch", label_revision: 3, label_updated_at: "2026-09-09T14:31:00Z",
+  };
+  const json = (value: unknown, etag?: string) => new Response(JSON.stringify(value), {
+    headers: { "Content-Type": "application/json", ...(etag ? { ETag: etag } : {}) },
+  });
+  let replaceMemberPath = false;
+  let deferMemberRead = false;
+  let resolveMemberRead!: (response: Response) => void;
+  const deferredMemberRead = new Promise<Response>((resolve) => {
+    resolveMemberRead = resolve;
+  });
+  let parentReads = 0;
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url === "/api/v1/path?path=%2F") return json(root);
+    if (url === "/api/v1/nodes/1/children?limit=1000&offset=0") {
+      return json({ directory: root, items: [], total: 0, limit: 1000, offset: 0 });
+    }
+    if (url === "/api/v1/tags?limit=1000&offset=0") {
+      return json({ items: [], total: 0, limit: 1000, offset: 0 });
+    }
+    if (url === "/api/v1/collections?limit=100&offset=0") {
+      return json({ items: [collection], total: 1, limit: 100, offset: 0 });
+    }
+    if (url === `/api/v1/collections/${collectionID}/members?limit=100&offset=0`) {
+      return json({ collection, items: [member], total: 1, limit: 100, offset: 0 });
+    }
+    if (url === `/api/v1/collections/${collectionID}/label`) {
+      return json({ ingest_id: collectionID, label: collection.label, revision: 3, updated_at: collection.label_updated_at }, '"3"');
+    }
+    if (url === "/api/v1/path?path=%2FArchive%2Freport.txt") {
+      if (deferMemberRead) return deferredMemberRead;
+      return json(replaceMemberPath ? { ...member, id: 99 } : member);
+    }
+    if (url === "/api/v1/path?path=%2FArchive") {
+      parentReads += 1;
+      return json(archive);
+    }
+    if (url === "/api/v1/nodes/7/children?limit=1000&offset=0") {
+      return json({ directory: archive, items: [oldPageOccupant], total: 2, limit: 1000, offset: 0 });
+    }
+    if (url === "/api/v1/audit/status?node_id=42") return json({ enabled: false, scopes: [] });
+    if (url === "/api/v1/nodes/42/tags?limit=1000&offset=0") {
+      return json({ items: [], total: 0, limit: 1000, offset: 0 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  });
+
+  render(App);
+  await screen.findByText("This folder is empty");
+  await fireEvent.click(screen.getByRole("button", { name: "Import collections" }));
+  const drawer = await screen.findByRole("dialog", { name: "Import collections" });
+  await fireEvent.click(await within(drawer).findByRole("button", { name: "Browse collection Discovery batch" }));
+  await fireEvent.click(await within(drawer).findByRole("button", { name: "Open document /Archive/report.txt" }));
+
+  expect(await screen.findByRole("cell", { name: "report.txt" })).toBeTruthy();
+  expect(screen.queryByRole("dialog", { name: "Import collections" })).toBeNull();
+  expect(screen.getByRole("heading", { name: "report.txt" })).toBeTruthy();
+  expect(screen.queryByRole("heading", { name: "first.txt" })).toBeNull();
+
+  await fireEvent.click(screen.getByRole("button", { name: "Import collections" }));
+  const reopened = await screen.findByRole("dialog", { name: "Import collections" });
+  await fireEvent.click(await within(reopened).findByRole("button", { name: "Browse collection Discovery batch" }));
+  replaceMemberPath = true;
+  await fireEvent.click(await within(reopened).findByRole("button", { name: "Open document /Archive/report.txt" }));
+  expect((await within(reopened).findByRole("alert")).textContent).toContain("old path now belongs to another document");
+  expect(parentReads).toBe(1);
+
+  replaceMemberPath = false;
+  deferMemberRead = true;
+  await fireEvent.click(within(reopened).getByRole("button", { name: "Open document /Archive/report.txt" }));
+  await fireEvent.click(within(reopened).getByRole("button", { name: "Close import collections" }));
+  resolveMemberRead(json(member));
+  await waitFor(() => expect(screen.queryByRole("dialog", { name: "Import collections" })).toBeNull());
+  await Promise.resolve();
+  expect(parentReads).toBe(1);
+});

--- a/frontend/src/App.collections.test.ts
+++ b/frontend/src/App.collections.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-it("opens the exact collection member when its bounded parent page omits it", async () => {
+it.each(["%2FArchive%2Freport.txt", "%2FArchive"])("opens the exact collection member and locks on a 401 from %s", async (expiredPath) => {
   history.replaceState(null, "", "/#web_session=short-lived&web_upload_secret=proof");
   vi.stubGlobal("ResizeObserver", class {
     observe() {}
@@ -54,9 +54,13 @@ it("opens the exact collection member when its bounded parent page omits it", as
     resolveMemberRead = resolve;
   });
   let parentReads = 0;
+  let expireSession = false;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = String(input);
+    if (expireSession && url === `/api/v1/path?path=${expiredPath}`) {
+      return new Response("session expired", { status: 401 });
+    }
     if (url === "/api/v1/path?path=%2F") return json(root);
     if (url === "/api/v1/nodes/1/children?limit=1000&offset=0") {
       return json({ directory: root, items: [], total: 0, limit: 1000, offset: 0 });
@@ -119,4 +123,13 @@ it("opens the exact collection member when its bounded parent page omits it", as
   await waitFor(() => expect(screen.queryByRole("dialog", { name: "Import collections" })).toBeNull());
   await Promise.resolve();
   expect(parentReads).toBe(1);
+
+  deferMemberRead = false;
+  await fireEvent.click(screen.getByRole("button", { name: "Import collections" }));
+  const expired = await screen.findByRole("dialog", { name: "Import collections" });
+  await fireEvent.click(await within(expired).findByRole("button", { name: "Browse collection Discovery batch" }));
+  expireSession = true;
+  await fireEvent.click(await within(expired).findByRole("button", { name: "Open document /Archive/report.txt" }));
+  expect(await screen.findByText("Open your Docbank")).toBeTruthy();
+  expect(screen.queryByRole("dialog", { name: "Import collections" })).toBeNull();
 });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@
   import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
   import FileIcon from "@lucide/svelte/icons/file";
   import FolderIcon from "@lucide/svelte/icons/folder";
+  import FoldersIcon from "@lucide/svelte/icons/folders";
   import HardDriveIcon from "@lucide/svelte/icons/hard-drive";
   import LogOutIcon from "@lucide/svelte/icons/log-out";
   import MapPinIcon from "@lucide/svelte/icons/map-pin";
@@ -37,6 +38,7 @@
   import AuditEvidenceDrawer from "./AuditEvidenceDrawer.svelte";
   import AuditHistoryDrawer from "./AuditHistoryDrawer.svelte";
   import BackupDrawer from "./BackupDrawer.svelte";
+  import CollectionsDrawer from "./CollectionsDrawer.svelte";
   import DownloadButton from "./DownloadButton.svelte";
   import JobsDrawer from "./JobsDrawer.svelte";
   import ManageTagsModal from "./ManageTagsModal.svelte";
@@ -150,6 +152,7 @@
   let savedQueryDraft = $state<Query | null>(null);
   let queryEditorInitial = $state<Query>(parseQuery("{}"));
   let queryURLError = $state("");
+  let collectionsOpen = $state(false);
   let trashOpen = $state(false);
   let manageTagsTarget = $state<Row | null>(null);
   let batchTagsTargets = $state<SelectionTarget[] | null>(null);
@@ -260,6 +263,7 @@
       auditEvidenceOpen = false;
       storageOpen = false;
       backupsOpen = false;
+      collectionsOpen = false;
       trashOpen = false;
       tagCatalogOpen = false;
       uploadTarget = null;
@@ -299,6 +303,7 @@
     remember: boolean,
     preferredSelectedID?: number,
     preserveSort = false,
+    preferredRow?: Row,
   ): Promise<void> {
     const refreshing = !remember && directory?.id === nodeID && !activeQuery && !activeTagID;
     const request = ++generation;
@@ -331,21 +336,31 @@
       directory = page.directory;
       const path = page.directory.path;
       if (!path) throw new Error("The selected directory is no longer live.");
-      replaceRows(page.items.map((item) => ({
+      const nextRows = page.items.map((item) => ({
         node: item,
         path: path === "/" ? `/${item.name}` : `${path}/${item.name}`,
-      })), refreshing);
+      }));
+      if (
+        preferredRow &&
+        preferredRow.node.id === preferredSelectedID &&
+        !nextRows.some((row) => row.node.id === preferredRow.node.id)
+      ) {
+        nextRows.push(preferredRow);
+      }
+      replaceRows(nextRows, refreshing);
       selectNode(
         rows.some((row) => row.node.id === preferredSelectedID)
           ? preferredSelectedID
-          : rows[0]?.node.id,
+          : preferredSelectedID === undefined
+            ? rows[0]?.node.id
+            : undefined,
       );
       activeQuery = "";
       activeTagID = "";
       taggedInspected = 0;
       taggedTotal = 0;
       taggedTrashed = 0;
-      truncated = page.total > page.items.length;
+      truncated = page.total > rows.length;
       if (!preserveSort) {
         sortField = "name";
         sortDirection = "asc";
@@ -657,6 +672,34 @@
     if (selectedID !== undefined) void loadSelectedTags(selectedID);
   }
 
+  async function openCollectionMember(
+    member: Node,
+    current: () => boolean,
+  ): Promise<void> {
+    const path = member.path;
+    if (!path || !path.startsWith("/") || path === "/") {
+      throw new Error("This collection member no longer has a live document path.");
+    }
+    const session = webSession;
+    const exact = await statPath(session, path);
+    if (session !== webSession || !current()) return;
+    if (exact.id !== member.id || exact.kind !== "file") {
+      throw new Error(
+        "This collection member moved or its old path now belongs to another document. Reload the collection before opening it.",
+      );
+    }
+    const split = path.lastIndexOf("/");
+    const parentPath = split === 0 ? "/" : path.slice(0, split);
+    const parent = await statPath(session, parentPath);
+    if (session !== webSession || !current()) return;
+    if (parent.kind !== "dir") {
+      throw new Error("The collection member's parent is no longer a live directory.");
+    }
+    if (!current()) return;
+    collectionsOpen = false;
+    await loadDirectory(parent.id, true, exact.id, false, { node: exact, path });
+  }
+
   function handleTrashed(_receipt: Node): void {
     trashTarget = null;
     selectNode(undefined);
@@ -878,6 +921,7 @@
     auditEvidenceOpen = false;
     storageOpen = false;
     backupsOpen = false;
+    collectionsOpen = false;
     trashOpen = false;
     manageTagsTarget = null;
     batchTagsTargets = null;
@@ -969,6 +1013,25 @@
       {#snippet right()}
         <IconButton size="sm" ariaLabel="Saved queries and highlights" onclick={openSavedQueries}>
           <BookmarkIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton
+          size="sm"
+          ariaLabel="Import collections"
+          onclick={() => {
+            historyOpen = false;
+            versionsOpen = false;
+            provenanceOpen = false;
+            jobsOpen = false;
+            auditEvidenceOpen = false;
+            storageOpen = false;
+            backupsOpen = false;
+            trashOpen = false;
+            uploadTarget = null;
+            trashTarget = null;
+            collectionsOpen = true;
+          }}
+        >
+          <FoldersIcon size="14" aria-hidden="true" />
         </IconButton>
         <IconButton
           size="sm"
@@ -1590,6 +1653,14 @@
         session={webSession}
         onclose={() => (jobsOpen = false)}
         onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if collectionsOpen}
+      <CollectionsDrawer
+        session={webSession}
+        onclose={() => (collectionsOpen = false)}
+        onauthfailure={handleFailure}
+        onopenmember={openCollectionMember}
       />
     {/if}
     {#if auditEvidenceOpen}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -313,6 +313,18 @@
     try {
       const page = await children(webSession, nodeID);
       if (request !== generation) return;
+      if (preferredRow && !page.items.some((item) => item.id === preferredSelectedID)) {
+        const current = await statPath(webSession, preferredRow.path);
+        if (request !== generation) return;
+        if (
+          current.id !== preferredSelectedID || current.parent_id !== nodeID ||
+          current.path !== preferredRow.path ||
+          current.path !== `${page.directory.path === "/" ? "" : page.directory.path}/${current.name}`
+        ) {
+          throw new Error("This collection member changed while opening. Reload the collection.");
+        }
+        preferredRow = { node: current, path: preferredRow.path };
+      }
       if (remember && directory) {
         stack = [
           ...stack,
@@ -343,7 +355,7 @@
       if (
         preferredRow &&
         preferredRow.node.id === preferredSelectedID &&
-        !nextRows.some((row) => row.node.id === preferredRow.node.id)
+        !nextRows.some((row) => row.node.id === preferredSelectedID)
       ) {
         nextRows.push(preferredRow);
       }
@@ -370,7 +382,9 @@
         if (cause instanceof APIError && cause.status === 404) {
           replaceRows([], false);
           selectedID = undefined;
-          error = "This directory was moved to trash or removed. Go back or reload the vault.";
+          error = preferredRow
+            ? "This collection member moved or was removed. Reload the collection."
+            : "This directory was moved to trash or removed. Go back or reload the vault.";
         } else {
           handleFailure(cause);
         }

--- a/frontend/src/CollectionsDrawer.svelte
+++ b/frontend/src/CollectionsDrawer.svelte
@@ -1,0 +1,590 @@
+<script lang="ts">
+  import ArchiveIcon from "@lucide/svelte/icons/archive";
+  import FileIcon from "@lucide/svelte/icons/file";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import XIcon from "@lucide/svelte/icons/x";
+  import {
+    Button,
+    Card,
+    Chip,
+    DetailDrawer,
+    EmptyState,
+    IconButton,
+    Spinner,
+    TextInput,
+  } from "@kenn-io/kit-ui";
+  import { APIError, type Node } from "./api.js";
+  import {
+    collectionMembers,
+    collectionLabel,
+    collections,
+    setCollectionLabel,
+    type Collection,
+    type CollectionLabel,
+  } from "./collections.js";
+  import { formatBytes, formatDate } from "./format.js";
+
+  interface Props {
+    session: string;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+    onopenmember: (node: Node, current: () => boolean) => void | Promise<void>;
+  }
+
+  let { session, onclose, onauthfailure, onopenmember }: Props = $props();
+
+  let items = $state<Collection[]>([]);
+  let total = $state(0);
+  let selected = $state<Collection | null>(null);
+  let members = $state<Node[]>([]);
+  let memberTotal = $state(0);
+  let loading = $state(true);
+  let memberLoading = $state(false);
+  let error = $state("");
+  let memberError = $state("");
+  let observedLabel = $state<CollectionLabel | null>(null);
+  let labelDraft = $state("");
+  let labelLoading = $state(false);
+  let labelPending = $state(false);
+  let labelError = $state("");
+  let labelNotice = $state("");
+  let openingMemberID = $state<number | null>(null);
+  let openError = $state("");
+  let refreshedAt = $state("");
+  let loadedSession = "";
+  let generation = 0;
+  let memberGeneration = 0;
+  let labelGeneration = 0;
+  let openGeneration = 0;
+
+  $effect(() => {
+    const currentSession = session;
+    void refresh(currentSession);
+    return () => {
+      generation += 1;
+      memberGeneration += 1;
+      labelGeneration += 1;
+      openGeneration += 1;
+    };
+  });
+
+  function message(cause: unknown): string {
+    return cause instanceof Error ? cause.message : String(cause);
+  }
+
+  function authFailure(cause: unknown): boolean {
+    if (!(cause instanceof APIError) || cause.status !== 401) return false;
+    onauthfailure(cause);
+    onclose();
+    return true;
+  }
+
+  function close(): void {
+    openGeneration += 1;
+    onclose();
+  }
+
+  async function refresh(currentSession = session): Promise<void> {
+    const request = ++generation;
+    memberGeneration += 1;
+    labelGeneration += 1;
+    openGeneration += 1;
+    loading = true;
+    error = "";
+    if (currentSession !== loadedSession) {
+      items = [];
+      total = 0;
+      refreshedAt = "";
+    }
+    selected = null;
+    members = [];
+    memberTotal = 0;
+    memberError = "";
+    observedLabel = null;
+    labelDraft = "";
+    labelError = "";
+    labelNotice = "";
+    openingMemberID = null;
+    openError = "";
+    try {
+      const page = await collections(currentSession);
+      if (request !== generation || currentSession !== session) return;
+      items = page.items;
+      total = page.total;
+      loadedSession = currentSession;
+      refreshedAt = new Date().toISOString();
+    } catch (cause) {
+      if (request !== generation || currentSession !== session) return;
+      if (!authFailure(cause)) error = message(cause);
+    } finally {
+      if (request === generation && currentSession === session) loading = false;
+    }
+  }
+
+  async function browse(collection: Collection): Promise<void> {
+    const request = ++memberGeneration;
+    openGeneration += 1;
+    const currentSession = session;
+    selected = collection;
+    members = [];
+    memberTotal = 0;
+    memberError = "";
+    memberLoading = true;
+    openingMemberID = null;
+    openError = "";
+    observedLabel = null;
+    labelDraft = collection.label ?? "";
+    labelError = "";
+    labelNotice = "";
+    void reloadLabel(collection);
+    try {
+      const page = await collectionMembers(currentSession, collection.id);
+      if (
+        request !== memberGeneration ||
+        currentSession !== session ||
+        selected?.id !== collection.id
+      ) return;
+      selected = page.collection;
+      members = page.items;
+      memberTotal = page.total;
+    } catch (cause) {
+      if (
+        request !== memberGeneration ||
+        currentSession !== session ||
+        selected?.id !== collection.id
+      ) return;
+      if (!authFailure(cause)) memberError = message(cause);
+    } finally {
+      if (request === memberGeneration) memberLoading = false;
+    }
+  }
+
+  function applyLabel(label: CollectionLabel): void {
+    const update = (collection: Collection): Collection =>
+      collection.id === label.ingest_id
+        ? {
+            ...collection,
+            label: label.label,
+            label_revision: label.revision,
+            label_updated_at: label.updated_at,
+          }
+        : collection;
+    items = items.map(update);
+    if (selected?.id === label.ingest_id) selected = update(selected);
+  }
+
+  async function reloadLabel(collection = selected): Promise<void> {
+    if (!collection) return;
+    const request = ++labelGeneration;
+    const currentSession = session;
+    labelLoading = true;
+    labelPending = false;
+    labelError = "";
+    labelNotice = "";
+    try {
+      const label = await collectionLabel(currentSession, collection.id);
+      if (
+        request !== labelGeneration ||
+        currentSession !== session ||
+        selected?.id !== collection.id
+      ) return;
+      observedLabel = label;
+      labelDraft = label.label ?? "";
+      applyLabel(label);
+    } catch (cause) {
+      if (
+        request !== labelGeneration ||
+        currentSession !== session ||
+        selected?.id !== collection.id
+      ) return;
+      if (!authFailure(cause)) labelError = message(cause);
+    } finally {
+      if (request === labelGeneration) labelLoading = false;
+    }
+  }
+
+  async function saveLabel(value: string | null): Promise<void> {
+    if (!observedLabel || !selected) return;
+    const collectionID = selected.id;
+    const request = ++labelGeneration;
+    const currentSession = session;
+    const fence = observedLabel;
+    labelPending = true;
+    labelError = "";
+    labelNotice = "";
+    try {
+      const label = await setCollectionLabel(currentSession, fence, value);
+      if (
+        request !== labelGeneration ||
+        currentSession !== session ||
+        selected?.id !== collectionID
+      ) return;
+      observedLabel = label;
+      labelDraft = label.label ?? "";
+      applyLabel(label);
+      labelNotice = label.label === null ? "Collection label cleared." : "Collection label saved.";
+    } catch (cause) {
+      if (
+        request !== labelGeneration ||
+        currentSession !== session ||
+        selected?.id !== collectionID
+      ) return;
+      if (!authFailure(cause)) labelError = message(cause);
+    } finally {
+      if (request === labelGeneration) labelPending = false;
+    }
+  }
+
+  async function openMember(member: Node): Promise<void> {
+    const request = ++openGeneration;
+    const currentSession = session;
+    const collectionID = selected?.id;
+    const current = () =>
+      request === openGeneration &&
+      currentSession === session &&
+      selected?.id === collectionID;
+    openingMemberID = member.id;
+    openError = "";
+    try {
+      await onopenmember(member, current);
+    } catch (cause) {
+      if (current()) openError = message(cause);
+    } finally {
+      if (current()) openingMemberID = null;
+    }
+  }
+
+  function displayName(collection: Collection): string {
+    return collection.label ?? `Unlabeled import ${collection.id.slice(0, 8)}`;
+  }
+</script>
+
+<DetailDrawer width="min(760px, 100vw)" ariaLabel="Import collections" onclose={close}>
+  {#snippet header()}
+    <div class="drawer-heading">
+      <div>
+        <span>IMPORT RUNS</span>
+        <strong>Import collections</strong>
+        <small>
+          {total} collection{total === 1 ? "" : "s"}
+          {#if refreshedAt} · Refreshed {formatDate(refreshedAt)}{/if}
+        </small>
+      </div>
+      <div class="drawer-actions">
+        <IconButton
+          size="sm"
+          ariaLabel="Refresh import collections"
+          disabled={loading}
+          onclick={() => void refresh()}
+        >
+          <RefreshCwIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton size="sm" ariaLabel="Close import collections" onclick={close}>
+          <XIcon size="14" aria-hidden="true" />
+        </IconButton>
+      </div>
+    </div>
+  {/snippet}
+
+  <div class="collections-browser">
+    {#if loading && items.length === 0}
+      <div class="loading"><Spinner size={16} /> Loading import collections…</div>
+    {:else if error && items.length === 0}
+      <div class="load-error">
+        <p role="alert">{error}</p>
+        <Button size="sm" onclick={() => void refresh()}>Try again</Button>
+      </div>
+    {:else if items.length === 0}
+      <EmptyState
+        title="No import collections"
+        description="Collections appear after a filesystem import records at least one document."
+      >
+        {#snippet icon()}<ArchiveIcon size="22" />{/snippet}
+      </EmptyState>
+    {:else}
+      {#if error}<p class="error" role="alert">{error}</p>{/if}
+      <section aria-labelledby="collections-heading">
+        <div class="section-heading">
+          <div>
+            <span>COLLECTIONS</span>
+            <strong id="collections-heading">Import history</strong>
+          </div>
+          <small>{items.length} shown</small>
+        </div>
+        <div class="collection-list">
+          {#each items as collection (collection.id)}
+            <Card
+              level="default"
+              padding="sm"
+              eyebrow={`${collection.source_kind} import`}
+              title={displayName(collection)}
+              selected={selected?.id === collection.id}
+              ariaLabel={`Browse collection ${displayName(collection)}`}
+              onclick={() => void browse(collection)}
+            >
+              <div class="collection-facts">
+                <p>{collection.source_description}</p>
+                <div>
+                  <Chip size="xs" tone="neutral">
+                    {collection.file_count} document{collection.file_count === 1 ? "" : "s"}
+                  </Chip>
+                  <Chip size="xs" tone="neutral">{formatBytes(collection.total_bytes)}</Chip>
+                  <span>Imported {formatDate(collection.started_at)}</span>
+                </div>
+              </div>
+            </Card>
+          {/each}
+        </div>
+        {#if total > items.length}
+          <p class="bounded">Showing the first {items.length} of {total} collections.</p>
+        {/if}
+      </section>
+
+      {#if selected}
+        <section class="label-editor" aria-labelledby="collection-label-heading">
+          <div class="section-heading">
+            <div>
+              <span>LABEL</span>
+              <strong id="collection-label-heading">Collection label</strong>
+            </div>
+            {#if observedLabel}<small>Revision {observedLabel.revision}</small>{/if}
+          </div>
+          {#if labelLoading && !observedLabel}
+            <div class="loading"><Spinner size={16} /> Reading label revision…</div>
+          {:else}
+            <div class="label-controls">
+              <TextInput
+                bind:value={labelDraft}
+                block
+                ariaLabel="Collection label"
+                placeholder="Unlabeled import"
+                disabled={labelLoading || labelPending || !observedLabel}
+                invalid={Boolean(labelError)}
+              />
+              <Button
+                size="sm"
+                tone="info"
+                surface="solid"
+                disabled={labelLoading || labelPending || !observedLabel || labelDraft === ""}
+                onclick={() => void saveLabel(labelDraft)}
+              >{labelPending ? "Saving…" : "Save label"}</Button>
+              <Button
+                size="sm"
+                surface="soft"
+                disabled={labelLoading || labelPending || !observedLabel || observedLabel.label === null}
+                onclick={() => void saveLabel(null)}
+              >Clear label</Button>
+              <Button
+                size="sm"
+                surface="soft"
+                disabled={labelLoading || labelPending}
+                onclick={() => void reloadLabel()}
+              >Reload label</Button>
+            </div>
+          {/if}
+          <p class="quality-note">Quality counters are unavailable for direct collection browsing.</p>
+          {#if labelError}<p class="error" role="alert">{labelError}</p>{/if}
+          {#if labelNotice}<p class="notice" role="status">{labelNotice}</p>{/if}
+        </section>
+
+        <section aria-labelledby="collection-members-heading">
+          <div class="section-heading">
+            <div>
+              <span>DIRECT MEMBERSHIP</span>
+              <strong id="collection-members-heading">Documents in this collection</strong>
+            </div>
+            <small>{displayName(selected)}</small>
+          </div>
+          {#if memberLoading}
+            <div class="loading"><Spinner size={16} /> Loading direct members…</div>
+          {:else if memberError}
+            <div class="load-error">
+              <p role="alert">{memberError}</p>
+              <Button
+                size="sm"
+                onclick={() => {
+                  if (selected) void browse(selected);
+                }}
+              >Try again</Button>
+            </div>
+          {:else if members.length === 0}
+            <EmptyState
+              title="No live documents"
+              description="This retained collection currently has no live document members."
+            >
+              {#snippet icon()}<FileIcon size="22" />{/snippet}
+            </EmptyState>
+          {:else}
+            <p class="member-summary">
+              {#if memberTotal > members.length}
+                Showing {members.length} of {memberTotal} direct members.
+              {:else}
+                {memberTotal} direct member{memberTotal === 1 ? "" : "s"}
+              {/if}
+              This list browses collection membership directly; it is not a search filter.
+            </p>
+            <div class="member-list">
+              {#each members as member (member.id)}
+                <Card level="inset" padding="sm" title={member.name} meta={formatBytes(member.size)}>
+                  <div class="member-row">
+                    <code>{member.path}</code>
+                    <Button
+                      size="sm"
+                      tone="info"
+                      surface="soft"
+                      disabled={openingMemberID !== null}
+                      onclick={() => void openMember(member)}
+                      ariaLabel={`Open document ${member.path}`}
+                    >{openingMemberID === member.id ? "Opening…" : "Open"}</Button>
+                  </div>
+                </Card>
+              {/each}
+            </div>
+            {#if openError}<p class="error" role="alert">{openError}</p>{/if}
+          {/if}
+        </section>
+      {/if}
+    {/if}
+  </div>
+</DetailDrawer>
+
+<style>
+  .drawer-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .drawer-heading > div:first-child,
+  .section-heading > div {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .drawer-heading span,
+  .section-heading span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--letter-spacing-label, 0.04em);
+  }
+
+  .drawer-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-lg);
+  }
+
+  .drawer-heading small,
+  .section-heading small {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .drawer-actions,
+  .collection-facts > div,
+  .member-row,
+  .label-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .collections-browser {
+    display: grid;
+    gap: var(--space-6);
+    padding: var(--space-5);
+  }
+
+  section,
+  .collection-list,
+  .member-list {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .section-heading {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: var(--space-4);
+  }
+
+  .section-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+  }
+
+  .collection-facts {
+    display: grid;
+    gap: var(--space-3);
+    min-width: 0;
+  }
+
+  .collection-facts p,
+  .member-summary,
+  .bounded,
+  .quality-note,
+  .notice,
+  .load-error p,
+  .error {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .collection-facts p,
+  .member-row code {
+    overflow-wrap: anywhere;
+  }
+
+  .collection-facts span,
+  .member-summary,
+  .bounded,
+  .quality-note,
+  .notice {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .member-row {
+    justify-content: space-between;
+  }
+
+  .label-controls {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .label-controls :global(.kit-text-input) {
+    flex: 1 1 240px;
+  }
+
+  .member-row code {
+    min-width: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .load-error {
+    display: grid;
+    justify-items: start;
+    gap: var(--space-3);
+  }
+
+  .load-error p,
+  .error {
+    color: var(--accent-red);
+  }
+</style>

--- a/frontend/src/CollectionsDrawer.svelte
+++ b/frontend/src/CollectionsDrawer.svelte
@@ -248,7 +248,7 @@
     try {
       await onopenmember(member, current);
     } catch (cause) {
-      if (current()) openError = message(cause);
+      if (current() && !authFailure(cause)) openError = message(cause);
     } finally {
       if (current()) openingMemberID = null;
     }

--- a/frontend/src/CollectionsDrawer.test.ts
+++ b/frontend/src/CollectionsDrawer.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/svelte";
+import CollectionsDrawer from "./CollectionsDrawer.svelte";
+
+const collectionID = "11111111-1111-4111-8111-111111111111";
+const versionID = "22222222-2222-4222-8222-222222222222";
+const collection = {
+  id: collectionID,
+  source_kind: "cli",
+  source_description: "/synthetic/drop/discovery",
+  started_at: "2026-09-09T14:30:00Z",
+  file_count: 2,
+  total_bytes: 4096,
+  label: "Discovery batch",
+  label_revision: 3,
+  label_updated_at: "2026-09-09T14:31:00Z",
+};
+const member = {
+  id: 42,
+  parent_id: 7,
+  name: "report.txt",
+  kind: "file" as const,
+  path: "/Archive/report.txt",
+  current_version_id: versionID,
+  blob_hash: "a".repeat(64),
+  size: 2048,
+  revision: 5,
+  created_at: "2026-09-09T14:30:00Z",
+  modified_at: "2026-09-09T14:30:00Z",
+};
+const members = [
+  member,
+  {
+    ...member,
+    id: 43,
+    name: "notes.txt",
+    path: "/Archive/notes.txt",
+    current_version_id: "33333333-3333-4333-8333-333333333333",
+    blob_hash: "b".repeat(64),
+    size: 1024,
+  },
+];
+
+function json(value: unknown, etag?: string): Response {
+  return new Response(JSON.stringify(value), {
+    headers: {
+      "Content-Type": "application/json",
+      ...(etag ? { ETag: etag } : {}),
+    },
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("collections drawer", () => {
+  it("shows supported collection facts and opens an exact direct member", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === "/api/v1/collections?limit=100&offset=0") {
+        return json({ items: [collection], total: 1, limit: 100, offset: 0 });
+      }
+      if (
+        url ===
+        `/api/v1/collections/${collectionID}/members?limit=100&offset=0`
+      ) {
+        return json({
+          collection,
+          items: members,
+          total: 2,
+          limit: 100,
+          offset: 0,
+        });
+      }
+      if (url === `/api/v1/collections/${collectionID}/label`) {
+        return json(
+          {
+            ingest_id: collectionID,
+            label: collection.label,
+            revision: collection.label_revision,
+            updated_at: collection.label_updated_at,
+          },
+          '"3"',
+        );
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+    const openMember = vi.fn();
+
+    render(CollectionsDrawer, {
+      session: "short-lived",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+      onopenmember: openMember,
+    });
+
+    const card = await screen.findByRole("button", {
+      name: "Browse collection Discovery batch",
+    });
+    expect(within(card).getByText("2 documents")).toBeTruthy();
+    expect(within(card).getByText("4.00 KiB")).toBeTruthy();
+    expect(within(card).getByText("/synthetic/drop/discovery")).toBeTruthy();
+    expect(within(card).getByText(/Imported /)).toBeTruthy();
+    expect(screen.queryByText(/successful/i)).toBeNull();
+
+    await fireEvent.click(card);
+    expect(await screen.findByText("Documents in this collection")).toBeTruthy();
+    expect(await screen.findByText(/^2 direct members/)).toBeTruthy();
+    const open = await screen.findByRole("button", {
+      name: "Open document /Archive/report.txt",
+    });
+    await fireEvent.click(open);
+    expect(openMember.mock.calls[0]?.[0]).toEqual(member);
+  });
+
+  it("keeps a conflicting label draft until an explicit reload and clear", async () => {
+    const requests: RequestInit[] = [];
+    let labelReads = 0;
+    let labelWrites = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init = {}) => {
+      const url = String(input);
+      if (url === "/api/v1/collections?limit=100&offset=0") {
+        return json({ items: [collection], total: 1, limit: 100, offset: 0 });
+      }
+      if (url.endsWith("/members?limit=100&offset=0")) {
+        return json({ collection, items: members, total: 2, limit: 100, offset: 0 });
+      }
+      if (url.endsWith("/label") && init.method === "PUT") {
+        requests.push(init);
+        labelWrites += 1;
+        if (labelWrites === 1) {
+          return new Response(
+            JSON.stringify({ code: "stale_revision", detail: "Label changed elsewhere" }),
+            { status: 412, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return json(
+          {
+            ingest_id: collectionID,
+            label: null,
+            revision: 5,
+            updated_at: "2026-09-09T15:00:00Z",
+          },
+          '"5"',
+        );
+      }
+      if (url.endsWith("/label")) {
+        labelReads += 1;
+        return labelReads === 1
+          ? json(
+              {
+                ingest_id: collectionID,
+                label: "Discovery batch",
+                revision: 3,
+                updated_at: collection.label_updated_at,
+              },
+              '"3"',
+            )
+          : json(
+              {
+                ingest_id: collectionID,
+                label: "Externally labeled",
+                revision: 4,
+                updated_at: "2026-09-09T14:45:00Z",
+              },
+              '"4"',
+            );
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    render(CollectionsDrawer, {
+      session: "short-lived",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+      onopenmember: vi.fn(),
+    });
+    await fireEvent.click(
+      await screen.findByRole("button", { name: "Browse collection Discovery batch" }),
+    );
+    const input = await screen.findByRole("textbox", { name: "Collection label" });
+    await fireEvent.input(input, { target: { value: "Keep this draft" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Save label" }));
+
+    expect((await screen.findByRole("alert")).textContent).toContain("Label changed elsewhere");
+    expect((input as HTMLInputElement).value).toBe("Keep this draft");
+    expect(labelWrites).toBe(1);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Reload label" }));
+    expect(await screen.findByDisplayValue("Externally labeled")).toBeTruthy();
+    await fireEvent.click(screen.getByRole("button", { name: "Clear label" }));
+    expect(
+      await screen.findByRole("button", {
+        name: `Browse collection Unlabeled import ${collectionID.slice(0, 8)}`,
+      }),
+    ).toBeTruthy();
+    expect(new Headers(requests[1]?.headers).get("If-Match")).toBe('"4"');
+    expect(JSON.parse(String(requests[1]?.body))).toEqual({ label: null });
+  });
+
+  it("removes the previous session's collection while the new session loads", async () => {
+    let resolveFresh!: (response: Response) => void;
+    const fresh = new Promise<Response>((resolve) => {
+      resolveFresh = resolve;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      const session = new Headers(init?.headers).get("X-Docbank-Web-Session");
+      if (session === "old-session") {
+        return json({ items: [collection], total: 1, limit: 100, offset: 0 });
+      }
+      if (session === "fresh-session") return fresh;
+      throw new Error(`unexpected session: ${session}`);
+    });
+
+    const view = render(CollectionsDrawer, {
+      session: "old-session",
+      onclose: vi.fn(),
+      onauthfailure: vi.fn(),
+      onopenmember: vi.fn(),
+    });
+    await screen.findByRole("button", { name: "Browse collection Discovery batch" });
+
+    await view.rerender({ session: "fresh-session" });
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Browse collection Discovery batch" })).toBeNull();
+    });
+    expect(screen.getByText("Loading import collections…")).toBeTruthy();
+
+    resolveFresh(json({ items: [], total: 0, limit: 100, offset: 0 }));
+    expect(await screen.findByText("No import collections")).toBeTruthy();
+  });
+});

--- a/frontend/src/collections.test.ts
+++ b/frontend/src/collections.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { APIError } from "./api.js";
+import { collectionByID, collectionLabel, collectionMembers, collections, setCollectionLabel } from "./collections.js";
+
+const id = "11111111-1111-4111-8111-111111111111";
+const otherID = "22222222-2222-4222-8222-222222222222";
+const collection = {
+  id, source_kind: "cli", source_description: "Synthetic proposals", started_at: "2026-01-01T00:00:00Z",
+  file_count: 2, total_bytes: 12, label: "Proposals", label_revision: 3, label_updated_at: "2026-01-02T00:00:00Z",
+};
+const label = { ingest_id: id, label: "Proposals", revision: 3, updated_at: "2026-01-02T00:00:00Z" };
+const node = {
+  id: 2, parent_id: 1, name: "alpha.txt", kind: "file", path: "/alpha.txt", current_version_id: otherID,
+  blob_hash: "a".repeat(64), size: 5, revision: 1, created_at: "2026-01-01T00:00:00Z", modified_at: "2026-01-01T00:00:00Z",
+};
+function respond(value: unknown, etag = '"3"') {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response(JSON.stringify(value), { headers: { ETag: etag } }));
+}
+afterEach(() => vi.restoreAllMocks());
+
+it("lists a bounded page without replacing collection totals with page counts", async () => {
+  const fetch = respond({ items: [collection], total: 3, limit: 1, offset: 1 });
+  const page = await collections("session", 1, 1);
+  expect(page.total).toBe(3);
+  expect(page.items[0].file_count).toBe(2);
+  expect(page.items[0].total_bytes).toBe(12);
+  expect(String(fetch.mock.calls[0][0])).toBe("/api/v1/collections?limit=1&offset=1");
+});
+
+it.each([
+  { file_count: -1 }, { total_bytes: Number.MAX_SAFE_INTEGER + 1 }, { label_revision: 0 }, { label: "" }, { id: otherID },
+])("rejects invalid or mismatched collection authority %j", async (change) => {
+  respond({ ...collection, ...change });
+  await expect(collectionByID("session", id)).rejects.toThrow();
+});
+
+it("keeps retained empty collections distinct from missing ones", async () => {
+  respond({ ...collection, file_count: 0, total_bytes: 0 });
+  expect((await collectionByID("session", id)).file_count).toBe(0);
+});
+
+it("binds members to the collection snapshot and preserves exact content identity", async () => {
+  respond({ collection, items: [node], total: 2, limit: 1, offset: 0 });
+  const page = await collectionMembers("session", id, 0, 1);
+  expect(page.items[0]).toEqual(node);
+  expect(page.total).toBe(2);
+  expect(page.collection.total_bytes).toBe(12);
+});
+
+it.each([
+  { collection: { ...collection, id: otherID } },
+  { total: 3 },
+  { items: [{ ...node, path: undefined }] },
+  { items: [{ ...node, kind: "dir" }] },
+  { items: [{ ...node, blob_hash: "wrong" }] },
+])("rejects inconsistent member receipts %j", async (change) => {
+  respond({ collection, items: [node], total: 2, limit: 1, offset: 0, ...change });
+  await expect(collectionMembers("session", id, 0, 1)).rejects.toThrow();
+});
+
+it("checks the dedicated label ETag", async () => {
+  respond(label, '"4"');
+  await expect(collectionLabel("session", id)).rejects.toThrow(/receipt/i);
+});
+
+it("fences normalized renames and explicit clearing with the inspected label revision", async () => {
+  const fetch = respond({ ...label, label: "Café", revision: 4 }, '"4"');
+  expect((await setCollectionLabel("session", label, "Cafe\u0301")).label).toBe("Café");
+  const request = fetch.mock.calls[0][1];
+  expect(request?.method).toBe("PUT");
+  expect(new Headers(request?.headers).get("If-Match")).toBe('"3"');
+  expect(JSON.parse(String(request?.body))).toEqual({ label: "Café" });
+  fetch.mockResolvedValueOnce(new Response(JSON.stringify({ ...label, label: null, revision: 4 }), { headers: { ETag: '"4"' } }));
+  expect((await setCollectionLabel("session", label, null)).label).toBeNull();
+  expect(JSON.parse(String(fetch.mock.calls[1][1]?.body))).toEqual({ label: null });
+});
+
+it("accepts no-op revisions but rejects wrong returned label or revision", async () => {
+  respond(label);
+  expect((await setCollectionLabel("session", label, "Proposals")).revision).toBe(3);
+  await expect(setCollectionLabel("session", label, "New label")).rejects.toThrow(/receipt/i);
+});
+
+it("rejects invalid labels and fences before sending", async () => {
+  const fetch = respond(label);
+  await expect(setCollectionLabel("session", { ...label, revision: 0 }, "Name")).rejects.toThrow();
+  await expect(setCollectionLabel("session", label, "é".repeat(129))).rejects.toThrow();
+  await expect(setCollectionLabel("session", label, "\ud800")).rejects.toThrow();
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+it("surfaces stale or audit-fenced changes without automatic retries", async () => {
+  const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ code: "stale_revision", detail: "Label changed elsewhere" }), { status: 412 }));
+  await expect(setCollectionLabel("session", label, "New label")).rejects.toEqual(new APIError("Label changed elsewhere", 412, "stale_revision"));
+  expect(fetch).toHaveBeenCalledTimes(1);
+});

--- a/frontend/src/collections.ts
+++ b/frontend/src/collections.ts
@@ -1,0 +1,154 @@
+import { requestJSON, requestResponse, type Node } from "./api.js";
+
+export interface Collection {
+  id: string;
+  source_kind: string;
+  source_description: string;
+  started_at: string;
+  file_count: number;
+  total_bytes: number;
+  label: string | null;
+  label_revision: number;
+  label_updated_at: string;
+}
+
+export interface CollectionPage {
+  items: Collection[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface CollectionMemberPage {
+  collection: Collection;
+  items: Node[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface CollectionLabel {
+  ingest_id: string;
+  label: string | null;
+  revision: number;
+  updated_at: string;
+}
+
+const route = "/api/v1/collections";
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const encoder = new TextEncoder();
+
+function check(valid: unknown): asserts valid {
+  if (!valid) throw new Error("Collection receipt does not match the requested identity, page or revision. Reload before continuing.");
+}
+
+function object(value: unknown): Record<string, unknown> {
+  check(value !== null && typeof value === "object" && !Array.isArray(value));
+  return value as Record<string, unknown>;
+}
+
+function integer(value: unknown, min = 0): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= min;
+}
+
+function timestamp(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function normalizeLabel(value: unknown): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string") throw new Error("A collection label must be text or null.");
+  const normalized = value.normalize("NFC");
+  if (!normalized.trim() || /[\p{Cc}\uD800-\uDFFF]/u.test(normalized) || encoder.encode(normalized).length > 256) {
+    throw new Error("A collection label must contain 1–256 UTF-8 bytes without control characters.");
+  }
+  return normalized;
+}
+
+function path(id: string): string {
+  if (!uuid.test(id)) throw new Error("Invalid collection ID.");
+  return `${route}/${id}`;
+}
+
+function pageParams(offset: number, limit: number): string {
+  if (!integer(offset) || !integer(limit, 1) || limit > 1000) throw new Error("Invalid collection page.");
+  return new URLSearchParams({ limit: String(limit), offset: String(offset) }).toString();
+}
+
+function readCollection(value: unknown): Collection {
+  const record = object(value);
+  check(typeof record.id === "string" && uuid.test(record.id));
+  check(typeof record.source_kind === "string" && record.source_kind.length > 0 &&
+    typeof record.source_description === "string" && record.source_description.length > 0);
+  check(timestamp(record.started_at) && timestamp(record.label_updated_at));
+  check(integer(record.file_count) && integer(record.total_bytes) && integer(record.label_revision, 1));
+  check(record.label === normalizeLabel(record.label));
+  return record as unknown as Collection;
+}
+
+function readPage(value: unknown, offset: number, limit: number) {
+  const page = object(value);
+  check(page.offset === offset && page.limit === limit && integer(page.total) && Array.isArray(page.items));
+  check(page.items.length === Math.min(limit, Math.max(0, page.total - offset)));
+  return { items: page.items as unknown[], total: page.total, limit, offset };
+}
+
+export async function collections(session: string, offset = 0, limit = 100): Promise<CollectionPage> {
+  const raw = await requestJSON<unknown>(`${route}?${pageParams(offset, limit)}`, session);
+  const page = readPage(raw, offset, limit);
+  const items = page.items.map(readCollection);
+  check(new Set(items.map((item) => item.id)).size === items.length && items.every((item) => item.file_count > 0));
+  return { ...page, items };
+}
+
+export async function collectionByID(session: string, id: string): Promise<Collection> {
+  const result = readCollection(await requestJSON<unknown>(path(id), session));
+  check(result.id === id);
+  return result;
+}
+
+export async function collectionMembers(session: string, id: string, offset = 0, limit = 100): Promise<CollectionMemberPage> {
+  const raw = object(await requestJSON<unknown>(`${path(id)}/members?${pageParams(offset, limit)}`, session));
+  const collection = readCollection(raw.collection);
+  const page = readPage(raw, offset, limit);
+  check(collection.id === id && page.total === collection.file_count);
+  const items = page.items.map((value) => {
+    const node = object(value);
+    check(integer(node.id, 1) && integer(node.revision, 1) && integer(node.size) && node.kind === "file" && !node.trashed_at);
+    check(typeof node.name === "string" && node.name.length > 0 && typeof node.path === "string" && node.path.startsWith("/") &&
+      !node.path.includes("\0") && node.path.slice(1).split("/").every((segment) => segment && segment !== "." && segment !== ".."));
+    check(typeof node.current_version_id === "string" && uuid.test(node.current_version_id) &&
+      typeof node.blob_hash === "string" && /^[0-9a-f]{64}$/.test(node.blob_hash));
+    check(timestamp(node.created_at) && timestamp(node.modified_at));
+    return node as unknown as Node;
+  });
+  check(new Set(items.map((item) => item.id)).size === items.length);
+  check(items.reduce((sum, item) => sum + item.size, 0) <= collection.total_bytes);
+  return { ...page, collection, items };
+}
+
+async function readLabel(response: Response, id: string): Promise<CollectionLabel> {
+  const label = object(await response.json());
+  check(label.ingest_id === id && integer(label.revision, 1) && timestamp(label.updated_at));
+  check(label.label === normalizeLabel(label.label));
+  check(response.headers.get("ETag") === `"${label.revision}"`);
+  return label as unknown as CollectionLabel;
+}
+
+export async function collectionLabel(session: string, id: string): Promise<CollectionLabel> {
+  return readLabel(await requestResponse(`${path(id)}/label`, session), id);
+}
+
+export async function setCollectionLabel(session: string, observed: CollectionLabel, value: string | null): Promise<CollectionLabel> {
+  if (!integer(observed.revision, 1)) throw new Error("A positive label revision is required.");
+  const label = normalizeLabel(value);
+  const expectedRevision = observed.revision + (label === observed.label ? 0 : 1);
+  check(Number.isSafeInteger(expectedRevision));
+  const response = await requestResponse(`${path(observed.ingest_id)}/label`, session, {
+    method: "PUT", headers: { "Content-Type": "application/json", "If-Match": `"${observed.revision}"` },
+    body: JSON.stringify({ label }),
+  });
+  const result = await readLabel(response, observed.ingest_id);
+  check(result.label === label && result.revision === expectedRevision && Date.parse(result.updated_at) >= Date.parse(observed.updated_at));
+  return result;
+}


### PR DESCRIPTION
## What changed

- Browse import collections and their current documents from the web app. Each collection shows its label, import time, live document count, and logical bytes.
- Rename or clear collection labels without changing documents. A conflicting edit keeps your draft and asks you to reload instead of overwriting another client's change.
- Open a member by its inspected document identity. Collection lists and member lists show the first 100 entries and explicitly report when more are available.

## Why

Import collections are available through the API, but browser users need a way to find and label a group of imported documents without switching tools.

## Usage

Choose **Import collections** in the top bar, select a collection, and open a document or edit its label. Label writes are unavailable after permanent audit authority is enabled.

This browses collection membership directly; it does not filter text search. Processing quality and coverage remain explicitly unavailable. Use the paginated HTTP API for entries beyond the browser's limit.

Built on #308. No schema changes.

![Import collection members in the actual web app, using synthetic documents.](https://raw.githubusercontent.com/salmonumbrella/docbank/3ef1502b8162846c1151ce5b6228cbba71512804/screenshots/db09-collection-browser/web-collections.png)

![A conflicting label edit preserves the draft in the actual web app.](https://raw.githubusercontent.com/salmonumbrella/docbank/3ef1502b8162846c1151ce5b6228cbba71512804/screenshots/db09-collection-browser/web-collection-label-conflict.png)
