### PR TITLE
feat(search): compile field and Boolean expressions

### DIFF
--- a/cmd/docbank/daemon_test.go
+++ b/cmd/docbank/daemon_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -117,35 +118,8 @@ func TestServeRecoversInterruptedRestoreBeforeInitializingVault(t *testing.T) {
 	require.NoError(t, handoff.Prepare(t.Context()))
 	t.Setenv("DOCBANK_HOME", dir)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- runServe(ctx) }()
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case err := <-done:
-			require.NoError(t, err)
-		case <-time.After(10 * time.Second):
-			require.Fail(t, "daemon did not shut down")
-		}
-	})
-	healthClient := &http.Client{Timeout: time.Second}
-	// Recovery and fresh SQLite initialization can exceed ten seconds on
-	// Windows CI. This checks recovery ordering, not startup performance.
-	require.Eventually(t, func() bool {
-		records, listErr := client.RuntimeStore(dir).List()
-		if listErr != nil || len(records) != 1 {
-			return false
-		}
-		// Discovery is published before worker registration finishes. Wait for
-		// serving readiness before asking a successfully started daemon to stop.
-		response, err := healthClient.Get("http://" + records[0].Address + "/health")
-		if err != nil {
-			return false
-		}
-		_ = response.Body.Close()
-		return response.StatusCode == http.StatusOK
-	}, time.Minute, 50*time.Millisecond)
+	startServe(t)
+	waitForDaemon(t, dir)
 	pending, err := blob.PrimaryRestoreHandoffPending(filepath.Join(dir, "blobs"))
 	require.NoError(t, err)
 	assert.False(t, pending)
@@ -191,26 +165,9 @@ func TestServeServesAndShutsDownGracefully(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("DOCBANK_HOME", dir)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	done := make(chan error, 1)
-	go func() { done <- runServe(ctx) }()
-
+	stop := startServe(t)
 	// Discover via the runtime record like a real client would.
-	var rec kitdaemon.RuntimeRecord
-	require.Eventually(t, func() bool {
-		recs, err := client.RuntimeStore(dir).List()
-		if err != nil || len(recs) == 0 {
-			return false
-		}
-		rec = recs[0]
-		resp, err := http.Get("http://" + rec.Address + "/health")
-		if err != nil {
-			return false
-		}
-		_ = resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
-	}, 10*time.Second, 50*time.Millisecond)
+	waitForDaemon(t, dir)
 
 	// Second daemon on the same vault must refuse.
 	err := runServe(context.Background())
@@ -224,13 +181,7 @@ func TestServeServesAndShutsDownGracefully(t *testing.T) {
 	}
 	require.ErrorIs(t, err, docbank.ErrProcessingSpoolLocked)
 
-	cancel()
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(10 * time.Second):
-		t.Fatal("daemon did not shut down")
-	}
+	stop()
 	// Record removed on shutdown.
 	recs, err := client.RuntimeStore(dir).List()
 	require.NoError(t, err)
@@ -249,25 +200,8 @@ func TestServeRequiresKeyEvenWhenConfigIsKeyless(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("DOCBANK_HOME", dir)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	done := make(chan error, 1)
-	go func() { done <- runServe(ctx) }()
-
-	var rec kitdaemon.RuntimeRecord
-	require.Eventually(t, func() bool {
-		recs, err := client.RuntimeStore(dir).List()
-		if err != nil || len(recs) == 0 {
-			return false
-		}
-		rec = recs[0]
-		resp, err := http.Get("http://" + rec.Address + "/health")
-		if err != nil {
-			return false
-		}
-		_ = resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
-	}, 10*time.Second, 50*time.Millisecond)
+	startServe(t)
+	rec := waitForDaemon(t, dir)
 
 	// No X-Api-Key at all: any local OS user reaching the loopback port
 	// without a key must be refused, not silently served.
@@ -287,12 +221,54 @@ func TestServeRequiresKeyEvenWhenConfigIsKeyless(t *testing.T) {
 	require.NoError(t, err)
 	_ = resp.Body.Close()
 	assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+}
 
-	cancel()
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(10 * time.Second):
-		t.Fatal("daemon did not shut down")
-	}
+// Fresh SQLite initialization and shutdown can each exceed ten seconds on busy
+// Windows CI runners. These tests check daemon behavior, not performance.
+const (
+	daemonStartTimeout    = time.Minute
+	daemonShutdownTimeout = 30 * time.Second
+)
+
+// startServe runs the daemon until stop or test cleanup, whichever comes first,
+// and waits for it to exit so TempDir removal never races a live daemon.
+func startServe(t *testing.T) (stop func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runServe(ctx) }()
+	stop = sync.OnceFunc(func() {
+		cancel()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(daemonShutdownTimeout):
+			require.Fail(t, "daemon did not shut down")
+		}
+	})
+	t.Cleanup(stop)
+	return stop
+}
+
+// waitForDaemon discovers the daemon through its runtime record like a real
+// client and waits until it serves health checks, since discovery is published
+// before worker registration finishes.
+func waitForDaemon(t *testing.T, dir string) kitdaemon.RuntimeRecord {
+	t.Helper()
+	healthClient := &http.Client{Timeout: time.Second}
+	var rec kitdaemon.RuntimeRecord
+	require.Eventually(t, func() bool {
+		recs, err := client.RuntimeStore(dir).List()
+		if err != nil || len(recs) != 1 {
+			return false
+		}
+		rec = recs[0]
+		resp, err := healthClient.Get("http://" + rec.Address + "/health")
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, daemonStartTimeout, 50*time.Millisecond)
+	return rec
 }

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -47,6 +47,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `GET\|POST /tags` · `GET /tags/by-name` · `GET\|PATCH\|DELETE /tags/{tag_id}` | list, resolve, create, rename, or delete stable tag definitions | Implemented |
 | `GET /nodes/{id}/tags` · `GET /tags/{tag_id}/nodes` · `PUT\|DELETE /nodes/{id}/tags/{tag_id}` · `PUT\|DELETE /path/tags/{tag_id}` | inspect and change tag assignments | Implemented |
 | `GET\|POST /saved-queries` · `GET\|PATCH\|DELETE /saved-queries/{saved_query_id}` | list, create, inspect, edit, or delete named query and literal highlight definitions | Implemented |
+| `POST /queries/parse` | validate complete QueryV1 intent and resolve dependency revisions without executing a search | Implemented |
 | `POST /audit/preview` · `POST /audit/enable` · `GET /audit/status` | review permanent first-scope retention, enable the exact reviewed plan, and inspect authority or membership | Implemented |
 | `GET /audit/history?path=&node_id=&limit=&cursor=` | read one audited node's canonical newest-first event timeline with a stable continuation cursor | Implemented |
 | `GET /audit/scopes/{scope_id}/history?limit=&cursor=` | read canonical newest-first events across every member of one permanent scope | Implemented |
@@ -84,6 +85,22 @@ work before reaching `limit`. The normal `limit` and `truncated` contract
 remains in force, without a cursor. If `truncated` is true, the page is
 incomplete. Narrowing time bounds cannot split a group with identical
 modification timestamps, such as nodes restored together.
+
+### Query compilation preview
+
+`POST /queries/parse` accepts one QueryV1 object and returns its canonical
+`query`, `query_fingerprint`, and `dependencies` (`kind`, stable `id`, and
+observed `revision`). Definition reads share one read transaction. No result
+rows, membership snapshot, or executable SQL are returned. The endpoint is
+available to authenticated API clients and browser sessions; browser requests
+must use POST without query parameters.
+
+The compiler preserves expression scope and separate structured filters.
+Missing references, including negative tag and collection operands, fail with
+`422 invalid_query`; expression errors include a `position` object with
+half-open UTF-8 byte `offset` and `end`. Backend failures remain server errors.
+See [query grammar and limits](../usage/searching.md#preview-a-field-aware-query).
+Existing `/search` requests do not gain advanced syntax through this endpoint.
 
 ### Saved query and highlight definitions
 
@@ -843,8 +860,9 @@ requires the key.
 
 ## Error mapping
 
-Errors are RFC 7807 problem-JSON with one extension member, `code`, a
-machine-readable string clients branch on instead of parsing `detail`:
+Errors are RFC 7807 problem-JSON with a `code` extension, a machine-readable
+string clients branch on instead of parsing `detail`. Query errors may also
+include a `position` span:
 
 ```json
 {
@@ -874,6 +892,7 @@ machine-readable string clients branch on instead of parsing `detail`:
 | `provenance_mismatch` | 409 | the requested predecessor is missing, belongs to another node, is already superseded, or is an operational ingest fact |
 | `invalid_provenance_time` | 422 | optional `original_mtime` parses as RFC3339 but is not canonical UTC RFC3339Nano (a value that is not a date-time at all fails schema validation as `validation` instead) |
 | `invalid_saved_query` | 422 | saved name, description, kind, payload, or patch violates the saved-definition contract |
+| `invalid_query` | 422 | invalid or unsupported expression, missing reference, or query compilation bound exceeded |
 | `not_dir` / `not_file` / `invalid_name` / `invalid_tag` / `not_trashed` / `is_root` | 422 | `store.ErrNotDir` / `ErrNotFile` / `ErrInvalidName` / `ErrInvalidTag` / `ErrNotTrashed` / `ErrIsRoot` |
 | `search_query_required` | 422 | blank search without a tag or modification-time filter |
 | `validation` | 400, 415, or 422 | malformed request (bad `If-Match`, paths, media type, multipart envelope, or generated validation) |

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -214,6 +214,70 @@ and delete return `409 audit_mutation_unsupported`. Listing and reading still
 work. See [Permanent audited history](audited-history.md) before enabling it
 in a vault that needs editable saved definitions.
 
+## Preview a field-aware query
+
+`POST /api/v1/queries/parse` validates a QueryV1 expression and resolves its
+references. It returns `query`, `query_fingerprint`, and `dependencies`, each
+with a `kind`, stable `id`, and observed `revision`. It does not return search
+results, change saved definitions, or expose SQL. The CLI and `/search` retain
+the simple search behavior described above.
+
+For example, submit this JSON to preview a name expression with a separate
+size filter:
+
+```json
+{
+  "text": "name:(budget OR forecast) AND NOT extension:tmp",
+  "syntax": "advanced",
+  "filters": {"size_min": 100}
+}
+```
+
+The response retains the complete entered text. Expression fields are not
+removed from it or copied into hidden filters.
+
+Advanced syntax supports exact terms, quoted phrases, a trailing `*` for
+prefix matching, parentheses, and uppercase `AND`, `OR`, and `NOT`. Whitespace
+between operands means `AND`. Precedence is `NOT`, then `NEAR`, then `AND`,
+then `OR`. A backslash escapes the next character: `note\:draft` is literal
+text, and `\AND` is not an operator. Simple syntax treats these operators as
+literal prefix terms, as the CLI does.
+
+`alpha NEAR/5 beta` requires the two terms or phrases to occur within five
+tokens in the same indexed source. Bare `NEAR` uses ten; distances range from
+zero to 1,000. Chained NEAR expressions and Boolean operands inside NEAR are
+rejected. `name:(alpha NEAR/0 beta)` restricts the match to the filename.
+
+| Field | Meaning |
+| --- | --- |
+| `name` | Filename text, including phrases and prefixes |
+| `path` | Exact case-sensitive virtual path or its descendants; quote paths containing spaces |
+| `tag`, `collection`, `saved` | Exact name or stable UUID; grouped Boolean choices are supported, prefixes and NEAR are not |
+| `mime`, `extension`, `media_family` | Current MIME essence, filename extension, or shared media family |
+| `modified_after`, `modified_before` | Inclusive lower and exclusive upper RFC3339 time bounds; quote timestamps |
+| `size_min`, `size_max` | Inclusive nonnegative byte bounds |
+
+Reference names are case-sensitive and Unicode-normalized. A canonical UUID
+selects an ID, without falling back to a name. Unknown references fail even
+under `NOT`. A saved reference expands as a grouped expression with its own
+filters, so `name:budget OR saved:Review` does not apply Review's filters to
+the name branch. Nested field overrides such as `name:(tag:urgent)` are not
+supported.
+
+Structured filter dimensions combine with `AND`. Values within one include
+list combine with `OR`; an exclude list removes that union. Paths are subtree
+constraints, not wildcard patterns. Collection unions do not duplicate files.
+Time comparisons retain nanosecond precision. Preview supports lexical mode;
+semantic/hybrid mode, relevance ordering, duplicate constraints, and text
+coverage constraints return explicit errors instead of being ignored.
+
+Expression errors return `422 invalid_query` with `position.offset` and
+`position.end`: a half-open UTF-8 byte span in the submitted text. Database
+failures remain server errors. Preview limits include 8,192 text code points,
+512 parsed nodes, 32 levels of syntactic nesting, and 16 nested saved
+references. Larger expansions and compiled predicates have additional bounds.
+Dependency revisions describe this preview, not a permanent result snapshot.
+
 ## Text extraction
 
 The daemon's `extract:plain-text` background job indexes UTF-8 content whose

--- a/document/mistral/rendition_test.go
+++ b/document/mistral/rendition_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -280,7 +281,6 @@ func TestRenditionClientResolvesSecretPerAttemptAndStopsAtExpiry(t *testing.T) {
 	manifest := syntheticManifest(t, policy, true)
 	descriptor := renditionDescriptor(t, policy, manifest, "pdf")
 	fixture := renditionFixture(t, descriptor, testPDF("expiry"))
-	fixture.authorization.ExpiresAt = time.Now().UTC().Add(20 * time.Millisecond).Format("2006-01-02T15:04:05.000000000Z")
 	secrets := &countingSecrets{}
 	var requests atomic.Int64
 	client := newRenditionTestClient(t, policy, manifest, descriptor, secrets,
@@ -293,10 +293,17 @@ func TestRenditionClientResolvesSecretPerAttemptAndStopsAtExpiry(t *testing.T) {
 			}, nil
 		}))
 
-	_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
-	assertRenditionCode(t, err, document.RenditionErrorPolicyRejected)
-	assert.Equal(t, int64(1), requests.Load())
-	assert.Equal(t, int64(1), secrets.calls.Load(), "expired retry must not resolve another credential")
+	now := time.Now()
+	synctest.Test(t, func(t *testing.T) {
+		// Keep the dated capability manifest valid on the simulated clock.
+		time.Sleep(time.Until(now))
+		fixture.authorization.ExpiresAt = time.Now().UTC().Add(20 * time.Millisecond).Format("2006-01-02T15:04:05.000000000Z")
+
+		_, err := client.Render(t.Context(), fixture.upload(), fixture.authorization)
+		assertRenditionCode(t, err, document.RenditionErrorPolicyRejected)
+		assert.Equal(t, int64(1), requests.Load())
+		assert.Equal(t, int64(1), secrets.calls.Load(), "expired retry must not resolve another credential")
+	})
 }
 
 func TestRenditionClientExpiryCancelsInFlightUpload(t *testing.T) {

--- a/frontend/src/query.ts
+++ b/frontend/src/query.ts
@@ -527,7 +527,7 @@ export function classifyMedia(mediaType: string, filename: string): MediaFamily 
   }
   const base = filename.slice(Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\")) + 1);
   const dot = base.lastIndexOf(".");
-  if (dot < 0 || dot === base.length - 1) return "unknown";
+  if (dot <= 0 || dot === base.length - 1) return "unknown";
   const extension = lowerASCII(base.slice(dot + 1));
   return extension === null ? "unknown" : queryFamilyByExtension.get(extension) ?? "unknown";
 }

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -16,11 +16,18 @@ import (
 // "code" extension member. Code is the contract clients branch on; Detail is
 // for humans and may change freely.
 type Error struct {
-	Title  string   `json:"title"`
-	Status int      `json:"status"`
-	Detail string   `json:"detail,omitzero"`
-	Code   string   `json:"code,omitzero"`
-	Errors []string `json:"errors,omitempty"`
+	Title    string         `json:"title"`
+	Status   int            `json:"status"`
+	Detail   string         `json:"detail,omitzero"`
+	Code     string         `json:"code,omitzero"`
+	Errors   []string       `json:"errors,omitempty"`
+	Position *ErrorPosition `json:"position,omitempty"`
+}
+
+// ErrorPosition is a half-open UTF-8 byte span in the submitted query text.
+type ErrorPosition struct {
+	Offset int `json:"offset"`
+	End    int `json:"end"`
 }
 
 func (e *Error) Error() string  { return e.Detail }

--- a/internal/api/routes_query_compile.go
+++ b/internal/api/routes_query_compile.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/docbank/internal/query"
+)
+
+// QueryPayload preserves raw JSON until the strict shared QueryV1 codec reads
+// it, including duplicate-member and numeric-lexeme validation.
+type QueryPayload SavedQueryPayload
+
+func (p QueryPayload) MarshalJSON() ([]byte, error) { return SavedQueryPayload(p).MarshalJSON() }
+
+func (p *QueryPayload) UnmarshalJSON(raw []byte) error {
+	var value SavedQueryPayload
+	if err := value.UnmarshalJSON(raw); err != nil {
+		return err
+	}
+	*p = QueryPayload(value)
+	return nil
+}
+
+func (QueryPayload) Schema(r huma.Registry) *huma.Schema {
+	return r.Schema(reflect.TypeFor[savedQueryV1Schema](), true, "")
+}
+
+// QueryDependency identifies the immutable identity and observed definition
+// revision used by a preview. It does not claim a result membership snapshot.
+type QueryDependency struct {
+	Kind     string `json:"kind"`
+	ID       string `json:"id"`
+	Revision int64  `json:"revision"`
+}
+
+// QueryPreview contains canonical intent, not executable SQL or result rows.
+type QueryPreview struct {
+	Query            QueryPayload      `json:"query"`
+	QueryFingerprint string            `json:"query_fingerprint"`
+	Dependencies     []QueryDependency `json:"dependencies"`
+}
+
+func registerQueryCompileRoutes(api huma.API, d Deps) {
+	huma.Register(api, huma.Operation{
+		OperationID: "parseQuery", Method: http.MethodPost, Path: "/api/v1/queries/parse",
+		Summary:      "Validate a search expression and resolve its saved references",
+		Description:  "Returns canonical query intent and observed dependency revisions, without executing a search.",
+		MaxBodyBytes: query.MaxInputBytes,
+	}, func(ctx context.Context, in *struct{ Body QueryPayload }) (*struct{ Body QueryPreview }, error) {
+		value, err := query.Parse(in.Body)
+		if err != nil {
+			return nil, NewError(http.StatusUnprocessableEntity, "invalid_query", err.Error())
+		}
+		compiled, err := d.Store.CompileQuery(ctx, value)
+		if err != nil {
+			if positioned, ok := errors.AsType[*query.ExpressionError](err); ok {
+				problem := NewError(http.StatusUnprocessableEntity, "invalid_query", positioned.Message)
+				if positioned.End > positioned.Offset {
+					problem.Position = &ErrorPosition{Offset: positioned.Offset, End: positioned.End}
+				}
+				return nil, problem
+			}
+			return nil, NewError(http.StatusInternalServerError, "internal", "Could not compile query")
+		}
+		canonical, fingerprint, err := query.CanonicalWithFingerprint(compiled.Query)
+		if err != nil {
+			return nil, NewError(http.StatusInternalServerError, "internal", "Could not encode query")
+		}
+		preview := QueryPreview{Query: QueryPayload(canonical), QueryFingerprint: fingerprint, Dependencies: []QueryDependency{}}
+		for _, dependency := range compiled.Dependencies {
+			preview.Dependencies = append(preview.Dependencies, QueryDependency{
+				Kind: string(dependency.Kind), ID: dependency.ID, Revision: dependency.Revision,
+			})
+		}
+		return &struct{ Body QueryPreview }{Body: preview}, nil
+	})
+}

--- a/internal/api/routes_query_compile_test.go
+++ b/internal/api/routes_query_compile_test.go
@@ -1,0 +1,119 @@
+package api_test
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/api"
+)
+
+const queryParsePath = "/api/v1/queries/parse"
+
+func TestQueryCompilePreviewRetainsIntentAndDependencies(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	saved, _ := createSavedQuery(t, ts.URL, "Choice", `{"syntax":"advanced","text":"alpha OR beta"}`)
+	resp, body := rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath,
+		map[string]string{"X-Api-Key": testAPIKey},
+		`{"syntax":"advanced","text":"  name:gamma OR saved:Choice  ","filters":{"size_min":7}}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var preview struct {
+		Query struct {
+			Text    string         `json:"text"`
+			Filters map[string]any `json:"filters"`
+		} `json:"query"`
+		Fingerprint  string `json:"query_fingerprint"`
+		Dependencies []struct {
+			Kind     string `json:"kind"`
+			ID       string `json:"id"`
+			Revision int64  `json:"revision"`
+		} `json:"dependencies"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &preview))
+	require.Equal(t, "  name:gamma OR saved:Choice  ", preview.Query.Text)
+	require.Len(t, preview.Query.Filters, 1)
+	require.InDelta(t, float64(7), preview.Query.Filters["size_min"], 0)
+	require.True(t, strings.HasPrefix(preview.Fingerprint, "sha256:"))
+	require.Len(t, preview.Dependencies, 1)
+	require.Equal(t, saved.ID, preview.Dependencies[0].ID)
+	require.Equal(t, int64(1), preview.Dependencies[0].Revision)
+	require.Equal(t, "saved", preview.Dependencies[0].Kind)
+	require.NotContains(t, body, "SELECT ")
+}
+
+func TestQueryCompilePreviewErrorsAndAuthentication(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	resp, body := rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath, nil, `{}`)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, body)
+	for _, text := range []string{`{"syntax":"advanced","text":"😀 AND"}`, `{"syntax":"advanced","text":"NOT tag:missing"}`} {
+		resp, body = rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath,
+			map[string]string{"X-Api-Key": testAPIKey}, text)
+		require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+		var problem struct {
+			Code     string `json:"code"`
+			Position *struct {
+				Offset int `json:"offset"`
+				End    int `json:"end"`
+			} `json:"position"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(body), &problem))
+		require.Equal(t, "invalid_query", problem.Code)
+		require.NotNil(t, problem.Position)
+		require.Greater(t, problem.Position.End, problem.Position.Offset)
+		if strings.Contains(text, "😀") {
+			require.Equal(t, 5, problem.Position.Offset)
+			require.Equal(t, 8, problem.Position.End)
+		}
+	}
+	for _, input := range []string{`{"text":"a","text":"b"}`, `{"filters":{"invented":true}}`} {
+		resp, body = rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath,
+			map[string]string{"X-Api-Key": testAPIKey}, input)
+		require.GreaterOrEqual(t, resp.StatusCode, 400, body)
+		require.Less(t, resp.StatusCode, 500, body)
+	}
+	resp, body = rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath,
+		map[string]string{"X-Api-Key": testAPIKey}, "{"+strings.Repeat(" ", 128<<10)+"}")
+	require.GreaterOrEqual(t, resp.StatusCode, 400, body)
+	require.Less(t, resp.StatusCode, 500, body)
+	require.NoError(t, s.Close())
+	resp, body = rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath,
+		map[string]string{"X-Api-Key": testAPIKey}, `{"syntax":"advanced","text":"tag:known"}`)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode, body)
+	require.Equal(t, "internal", decodeProblem(t, body).Code)
+}
+
+func TestQueryCompilePreviewFilterErrorsHaveNoExpressionPosition(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	for _, field := range []string{"tag_ids", "exclude_tag_ids", "collection_ids", "exclude_collection_ids"} {
+		for _, text := range []string{"alpha", ""} {
+			t.Run(field+"/"+text, func(t *testing.T) {
+				resp, body := rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath,
+					map[string]string{"X-Api-Key": testAPIKey}, fmt.Sprintf(
+						`{"text":%q,"filters":{%q:["11111111-1111-4111-8111-111111111111"]}}`, text, field))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+				var problem api.Error
+				require.NoError(t, json.Unmarshal([]byte(body), &problem))
+				require.Equal(t, "invalid_query", problem.Code)
+				require.Nil(t, problem.Position, body)
+			})
+		}
+	}
+}
+
+func TestQueryCompilePreviewBrowserCapability(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := do(t, ts, http.MethodPost, "/api/daemon/web-session", nil, nil)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	var session struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &session))
+	headers := map[string]string{api.WebSessionHeader: session.Token}
+	resp, body = rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath, headers, `{"text":"alpha"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	resp, body = rawJSONRequest(t, ts.URL, http.MethodPost, queryParsePath+"?unrecognized=1", headers, `{}`)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, body)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -144,6 +144,7 @@ func NewServer(d Deps) *Server {
 	registerTagRoutes(humaAPI, d, g)
 	registerBatchTagRoutes(humaAPI, d, g)
 	registerSavedQueryRoutes(humaAPI, d, g)
+	registerQueryCompileRoutes(humaAPI, d)
 	registerAuditRoutes(humaAPI, d, g, s.auditPreviews)
 	clearLongRunningBodyReadDeadlines(humaAPI)
 	markRevisionPreconditionsRequired(humaAPI)

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -175,6 +175,9 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	if path == "/api/v1/batch/tags" || path == "/api/v1/batch/tags/preview" {
 		return method == http.MethodPost && r.URL.RawQuery == ""
 	}
+	if path == "/api/v1/queries/parse" {
+		return method == http.MethodPost && r.URL.RawQuery == ""
+	}
 	if path == "/api/v1/saved-queries" {
 		return method == http.MethodGet ||
 			(method == http.MethodPost && r.URL.RawQuery == "")

--- a/internal/extract/worker_test.go
+++ b/internal/extract/worker_test.go
@@ -124,17 +124,18 @@ func TestWorkerRetriesTransientOpenFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
 	go func() { done <- w.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		runErr := <-done
+		if runErr != nil {
+			// Cancellation can reach either the idle wait or a catalog query.
+			assert.ErrorIs(t, runErr, context.Canceled)
+		}
+		assert.GreaterOrEqual(t, reader.calls, 2)
+	})
+	// This exercises real storage; busy CI runners can take more than a second.
 	require.Eventually(t, func() bool {
 		hits, _, searchErr := s.SearchPage(t.Context(), "nebula", 10)
 		return searchErr == nil && len(hits) == 1
-	}, time.Second, 5*time.Millisecond)
-	cancel()
-	runErr := <-done
-	if runErr != nil {
-		// Cancellation can reach either the idle wait (which returns nil) or an
-		// in-flight catalog query. The daemon supervisor treats both outcomes as
-		// a clean cancelled job.
-		require.ErrorIs(t, runErr, context.Canceled)
-	}
-	assert.GreaterOrEqual(t, reader.calls, 2)
+	}, 30*time.Second, 10*time.Millisecond)
 }

--- a/internal/query/expression.go
+++ b/internal/query/expression.go
@@ -1,0 +1,574 @@
+package query
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	maxExpressionNodes = 512
+	maxExpressionDepth = 32
+)
+
+// ExpressionKind identifies one node in a parsed search expression.
+type ExpressionKind string
+
+const (
+	ExpressionAll    ExpressionKind = "all"
+	ExpressionTerm   ExpressionKind = "term"
+	ExpressionPhrase ExpressionKind = "phrase"
+	ExpressionAnd    ExpressionKind = "and"
+	ExpressionOr     ExpressionKind = "or"
+	ExpressionNot    ExpressionKind = "not"
+	ExpressionNear   ExpressionKind = "near"
+	ExpressionField  ExpressionKind = "field"
+)
+
+// Expression is a bounded syntax tree whose spans refer to the original text.
+type Expression struct {
+	Kind     ExpressionKind
+	Start    int
+	End      int
+	Value    string
+	Prefix   bool
+	Field    string
+	Distance int
+	Children []*Expression
+}
+
+// ExpressionError reports a half-open byte span in the original text.
+type ExpressionError struct {
+	Offset  int
+	End     int
+	Message string
+}
+
+func (e *ExpressionError) Error() string {
+	return fmt.Sprintf("expression bytes %d:%d: %s", e.Offset, e.End, e.Message)
+}
+
+// ParseExpression parses one bounded simple or advanced search expression.
+func ParseExpression(text, syntax string) (*Expression, error) {
+	if syntax != "simple" && syntax != "advanced" {
+		return nil, expressionError(0, 0, "unknown syntax mode")
+	}
+	if !utf8.ValidString(text) {
+		return nil, expressionError(0, len(text), "expression is not valid UTF-8")
+	}
+	if utf8.RuneCountInString(text) > maxTextRunes {
+		return nil, expressionError(0, len(text), "expression exceeds 8192 Unicode code points")
+	}
+	if syntax == "simple" {
+		return parseSimpleExpression(text)
+	}
+
+	parser := expressionParser{lexer: expressionLexer{text: text}, textLen: len(text)}
+	if err := parser.advance(); err != nil {
+		return nil, err
+	}
+	if parser.current.kind == expressionTokenEOF {
+		return &Expression{Kind: ExpressionAll, Start: 0, End: len(text)}, nil
+	}
+	expr, err := parser.parseOr(0)
+	if err != nil {
+		return nil, err
+	}
+	if parser.current.kind != expressionTokenEOF {
+		return nil, expressionError(parser.current.start, parser.current.end, "unexpected token")
+	}
+	return expr, nil
+}
+
+func parseSimpleExpression(text string) (*Expression, error) {
+	var root *Expression
+	nodes := 0
+	termStart := -1
+	appendTerm := func(end int) error {
+		if nodes >= maxExpressionNodes {
+			return expressionError(termStart, end, "expression exceeds 512 AST nodes")
+		}
+		term := &Expression{
+			Kind: ExpressionTerm, Start: termStart, End: end,
+			Value: text[termStart:end], Prefix: true,
+		}
+		nodes++
+		if root == nil {
+			root = term
+			return nil
+		}
+		if nodes >= maxExpressionNodes {
+			return expressionError(root.Start, end, "expression exceeds 512 AST nodes")
+		}
+		root = &Expression{
+			Kind: ExpressionAnd, Start: root.Start, End: end,
+			Children: []*Expression{root, term},
+		}
+		nodes++
+		return nil
+	}
+
+	for offset := 0; offset < len(text); {
+		r, size := utf8.DecodeRuneInString(text[offset:])
+		if unicode.IsSpace(r) {
+			if termStart >= 0 {
+				if err := appendTerm(offset); err != nil {
+					return nil, err
+				}
+				termStart = -1
+			}
+		} else if termStart < 0 {
+			termStart = offset
+		}
+		offset += size
+	}
+	if termStart >= 0 {
+		if err := appendTerm(len(text)); err != nil {
+			return nil, err
+		}
+	}
+	if root == nil {
+		return &Expression{Kind: ExpressionAll, Start: 0, End: len(text)}, nil
+	}
+	return root, nil
+}
+
+type expressionTokenKind uint8
+
+const (
+	expressionTokenEOF expressionTokenKind = iota
+	expressionTokenWord
+	expressionTokenPhrase
+	expressionTokenLeftParen
+	expressionTokenRightParen
+	expressionTokenColon
+	expressionTokenAnd
+	expressionTokenOr
+	expressionTokenNot
+	expressionTokenNear
+)
+
+type expressionToken struct {
+	kind     expressionTokenKind
+	start    int
+	end      int
+	value    string
+	prefix   bool
+	distance int
+}
+
+type expressionLexer struct {
+	text string
+	pos  int
+}
+
+func (lexer *expressionLexer) next() (expressionToken, error) {
+	for lexer.pos < len(lexer.text) {
+		r, size := utf8.DecodeRuneInString(lexer.text[lexer.pos:])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		lexer.pos += size
+	}
+	if lexer.pos == len(lexer.text) {
+		return expressionToken{kind: expressionTokenEOF, start: lexer.pos, end: lexer.pos}, nil
+	}
+
+	start := lexer.pos
+	switch lexer.text[lexer.pos] {
+	case '(':
+		lexer.pos++
+		return expressionToken{kind: expressionTokenLeftParen, start: start, end: lexer.pos}, nil
+	case ')':
+		lexer.pos++
+		return expressionToken{kind: expressionTokenRightParen, start: start, end: lexer.pos}, nil
+	case ':':
+		lexer.pos++
+		return expressionToken{kind: expressionTokenColon, start: start, end: lexer.pos}, nil
+	case '"':
+		return lexer.phrase()
+	case '*':
+		lexer.pos++
+		return expressionToken{}, expressionError(start, lexer.pos, "star requires a preceding term or phrase")
+	default:
+		return lexer.word()
+	}
+}
+
+func (lexer *expressionLexer) phrase() (expressionToken, error) {
+	start := lexer.pos
+	lexer.pos++
+	var value strings.Builder
+	for lexer.pos < len(lexer.text) {
+		r, size := utf8.DecodeRuneInString(lexer.text[lexer.pos:])
+		if r == '"' {
+			lexer.pos += size
+			prefix := false
+			if lexer.pos < len(lexer.text) && lexer.text[lexer.pos] == '*' {
+				prefix = true
+				lexer.pos++
+				if lexer.pos < len(lexer.text) && lexer.text[lexer.pos] == '*' {
+					return expressionToken{}, expressionError(lexer.pos, lexer.pos+1, "repeated star is invalid")
+				}
+				if !lexer.atTokenBoundary() {
+					_, size := utf8.DecodeRuneInString(lexer.text[lexer.pos:])
+					return expressionToken{}, expressionError(lexer.pos, lexer.pos+size, "star must be a trailing suffix")
+				}
+			}
+			return expressionToken{
+				kind: expressionTokenPhrase, start: start, end: lexer.pos,
+				value: value.String(), prefix: prefix,
+			}, nil
+		}
+		if r == '\\' {
+			escapeStart := lexer.pos
+			lexer.pos += size
+			if lexer.pos == len(lexer.text) {
+				return expressionToken{}, expressionError(escapeStart, lexer.pos, "escape requires a following code point")
+			}
+			r, size = utf8.DecodeRuneInString(lexer.text[lexer.pos:])
+		}
+		value.WriteRune(r)
+		lexer.pos += size
+	}
+	return expressionToken{}, expressionError(start, len(lexer.text), "unclosed quoted phrase")
+}
+
+func (lexer *expressionLexer) word() (expressionToken, error) {
+	start := lexer.pos
+	escaped := false
+	var value strings.Builder
+	for lexer.pos < len(lexer.text) {
+		r, size := utf8.DecodeRuneInString(lexer.text[lexer.pos:])
+		if unicode.IsSpace(r) || isExpressionDelimiter(r) {
+			break
+		}
+		if r == '\\' {
+			escaped = true
+			escapeStart := lexer.pos
+			lexer.pos += size
+			if lexer.pos == len(lexer.text) {
+				return expressionToken{}, expressionError(escapeStart, lexer.pos, "escape requires a following code point")
+			}
+			r, size = utf8.DecodeRuneInString(lexer.text[lexer.pos:])
+			value.WriteRune(r)
+			lexer.pos += size
+			continue
+		}
+		if r == '*' {
+			if value.Len() == 0 {
+				lexer.pos += size
+				return expressionToken{}, expressionError(start, lexer.pos, "star requires a preceding term")
+			}
+			lexer.pos += size
+			if !lexer.atTokenBoundary() {
+				end := min(lexer.pos+1, len(lexer.text))
+				return expressionToken{}, expressionError(lexer.pos, end, "star must be a single trailing suffix")
+			}
+			return expressionToken{
+				kind: expressionTokenWord, start: start, end: lexer.pos,
+				value: value.String(), prefix: true,
+			}, nil
+		}
+		value.WriteRune(r)
+		lexer.pos += size
+	}
+	if value.Len() == 0 {
+		return expressionToken{}, expressionError(start, lexer.pos, "term is empty")
+	}
+	token := expressionToken{
+		kind: expressionTokenWord, start: start, end: lexer.pos, value: value.String(),
+	}
+	if escaped {
+		return token, nil
+	}
+	switch token.value {
+	case "AND":
+		token.kind = expressionTokenAnd
+	case "OR":
+		token.kind = expressionTokenOr
+	case "NOT":
+		token.kind = expressionTokenNot
+	case "NEAR":
+		token.kind = expressionTokenNear
+		token.distance = 10
+	default:
+		if after, ok := strings.CutPrefix(token.value, "NEAR/"); ok {
+			distance, err := strconv.Atoi(after)
+			if err != nil || strings.Trim(after, "0123456789") != "" || distance > 1000 {
+				return expressionToken{}, expressionError(start, lexer.pos, "NEAR distance must be an integer from 0 through 1000")
+			}
+			token.kind = expressionTokenNear
+			token.distance = distance
+		}
+	}
+	return token, nil
+}
+
+func (lexer *expressionLexer) atTokenBoundary() bool {
+	if lexer.pos == len(lexer.text) {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(lexer.text[lexer.pos:])
+	return unicode.IsSpace(r) || r == '(' || r == ')'
+}
+
+func isExpressionDelimiter(r rune) bool {
+	return r == '(' || r == ')' || r == ':' || r == '"'
+}
+
+type expressionParser struct {
+	lexer   expressionLexer
+	current expressionToken
+	textLen int
+	nodes   int
+}
+
+func (parser *expressionParser) advance() error {
+	next, err := parser.lexer.next()
+	if err != nil {
+		return err
+	}
+	parser.current = next
+	return nil
+}
+
+func (parser *expressionParser) parseOr(depth int) (*Expression, error) {
+	left, err := parser.parseAnd(depth)
+	if err != nil {
+		return nil, err
+	}
+	for parser.current.kind == expressionTokenOr {
+		operator := parser.current
+		if err := parser.advance(); err != nil {
+			return nil, err
+		}
+		if !expressionTokenStartsOperand(parser.current.kind) {
+			return nil, expressionError(operator.start, operator.end, "OR requires a right operand")
+		}
+		right, err := parser.parseAnd(depth)
+		if err != nil {
+			return nil, err
+		}
+		left, err = parser.node(&Expression{
+			Kind: ExpressionOr, Start: left.Start, End: right.End,
+			Children: []*Expression{left, right},
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return left, nil
+}
+
+func (parser *expressionParser) parseAnd(depth int) (*Expression, error) {
+	left, err := parser.parseNear(depth)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		explicit := parser.current.kind == expressionTokenAnd
+		if explicit {
+			operator := parser.current
+			if err := parser.advance(); err != nil {
+				return nil, err
+			}
+			if !expressionTokenStartsOperand(parser.current.kind) {
+				return nil, expressionError(operator.start, operator.end, "AND requires a right operand")
+			}
+		} else if !expressionTokenStartsOperand(parser.current.kind) {
+			break
+		}
+		right, err := parser.parseNear(depth)
+		if err != nil {
+			return nil, err
+		}
+		left, err = parser.node(&Expression{
+			Kind: ExpressionAnd, Start: left.Start, End: right.End,
+			Children: []*Expression{left, right},
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return left, nil
+}
+
+func (parser *expressionParser) parseNear(depth int) (*Expression, error) {
+	left, err := parser.parseUnary(depth)
+	if err != nil {
+		return nil, err
+	}
+	for parser.current.kind == expressionTokenNear {
+		operator := parser.current
+		if err := parser.advance(); err != nil {
+			return nil, err
+		}
+		if !expressionTokenStartsOperand(parser.current.kind) {
+			return nil, expressionError(operator.start, operator.end, "NEAR requires a right operand")
+		}
+		right, err := parser.parseUnary(depth)
+		if err != nil {
+			return nil, err
+		}
+		left, err = parser.node(&Expression{
+			Kind: ExpressionNear, Start: left.Start, End: right.End,
+			Distance: operator.distance, Children: []*Expression{left, right},
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return left, nil
+}
+
+func (parser *expressionParser) parseUnary(depth int) (*Expression, error) {
+	if parser.current.kind != expressionTokenNot {
+		return parser.parsePrimary(depth)
+	}
+	operator := parser.current
+	if depth >= maxExpressionDepth {
+		return nil, expressionError(operator.start, operator.end, "expression nesting exceeds 32")
+	}
+	if err := parser.advance(); err != nil {
+		return nil, err
+	}
+	if !expressionTokenStartsOperand(parser.current.kind) {
+		return nil, expressionError(operator.start, operator.end, "NOT requires an operand")
+	}
+	child, err := parser.parseUnary(depth + 1)
+	if err != nil {
+		return nil, err
+	}
+	return parser.node(&Expression{
+		Kind: ExpressionNot, Start: operator.start, End: child.End,
+		Children: []*Expression{child},
+	})
+}
+
+func (parser *expressionParser) parsePrimary(depth int) (*Expression, error) {
+	token := parser.current
+	switch token.kind {
+	case expressionTokenWord:
+		if err := parser.advance(); err != nil {
+			return nil, err
+		}
+		if parser.current.kind == expressionTokenColon {
+			return parser.parseField(token, depth)
+		}
+		return parser.node(&Expression{
+			Kind: ExpressionTerm, Start: token.start, End: token.end,
+			Value: token.value, Prefix: token.prefix,
+		})
+	case expressionTokenPhrase:
+		if err := parser.advance(); err != nil {
+			return nil, err
+		}
+		return parser.node(&Expression{
+			Kind: ExpressionPhrase, Start: token.start, End: token.end,
+			Value: token.value, Prefix: token.prefix,
+		})
+	case expressionTokenLeftParen:
+		return parser.parseGroup(depth)
+	case expressionTokenEOF:
+		return nil, expressionError(parser.textLen, parser.textLen, "missing operand")
+	default:
+		return nil, expressionError(token.start, token.end, "expected an operand")
+	}
+}
+
+func (parser *expressionParser) parseGroup(depth int) (*Expression, error) {
+	open := parser.current
+	if depth >= maxExpressionDepth {
+		return nil, expressionError(open.start, open.end, "expression nesting exceeds 32")
+	}
+	if err := parser.advance(); err != nil {
+		return nil, err
+	}
+	if parser.current.kind == expressionTokenRightParen {
+		return nil, expressionError(open.start, parser.current.end, "group cannot be empty")
+	}
+	child, err := parser.parseOr(depth + 1)
+	if err != nil {
+		return nil, err
+	}
+	if parser.current.kind != expressionTokenRightParen {
+		return nil, expressionError(parser.current.start, parser.current.end, "group is missing a closing parenthesis")
+	}
+	child.Start = open.start
+	child.End = parser.current.end
+	if err := parser.advance(); err != nil {
+		return nil, err
+	}
+	return child, nil
+}
+
+func (parser *expressionParser) parseField(name expressionToken, depth int) (*Expression, error) {
+	colon := parser.current
+	if name.prefix {
+		return nil, expressionError(name.start, colon.end, "field name cannot have a prefix suffix")
+	}
+	if _, ok := expressionFields[name.value]; !ok {
+		return nil, expressionError(name.start, colon.end, "unknown expression field")
+	}
+	if err := parser.advance(); err != nil {
+		return nil, err
+	}
+	var child *Expression
+	var err error
+	switch parser.current.kind {
+	case expressionTokenWord:
+		operand := parser.current
+		if err = parser.advance(); err == nil {
+			child, err = parser.node(&Expression{
+				Kind: ExpressionTerm, Start: operand.start, End: operand.end,
+				Value: operand.value, Prefix: operand.prefix,
+			})
+		}
+	case expressionTokenPhrase:
+		operand := parser.current
+		if err = parser.advance(); err == nil {
+			child, err = parser.node(&Expression{
+				Kind: ExpressionPhrase, Start: operand.start, End: operand.end,
+				Value: operand.value, Prefix: operand.prefix,
+			})
+		}
+	case expressionTokenLeftParen:
+		child, err = parser.parseGroup(depth)
+	default:
+		return nil, expressionError(colon.start, colon.end, "field requires a term, phrase, or grouped expression")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return parser.node(&Expression{
+		Kind: ExpressionField, Start: name.start, End: child.End, Field: name.value,
+		Children: []*Expression{child},
+	})
+}
+
+func (parser *expressionParser) node(expr *Expression) (*Expression, error) {
+	if parser.nodes >= maxExpressionNodes {
+		return nil, expressionError(expr.Start, expr.End, "expression exceeds 512 AST nodes")
+	}
+	parser.nodes++
+	return expr, nil
+}
+
+func expressionTokenStartsOperand(kind expressionTokenKind) bool {
+	return kind == expressionTokenWord || kind == expressionTokenPhrase ||
+		kind == expressionTokenLeftParen || kind == expressionTokenNot
+}
+
+var expressionFields = map[string]struct{}{
+	"name": {}, "path": {}, "tag": {}, "collection": {}, "saved": {},
+	"mime": {}, "extension": {}, "media_family": {},
+	"modified_after": {}, "modified_before": {}, "size_min": {}, "size_max": {},
+	"text_coverage": {}, "has_duplicates": {},
+}
+
+func expressionError(start, end int, message string) *ExpressionError {
+	return &ExpressionError{Offset: start, End: end, Message: message}
+}

--- a/internal/query/expression_test.go
+++ b/internal/query/expression_test.go
@@ -1,0 +1,306 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseExpressionSimplePreservesLiteralTermsAndByteSpans(t *testing.T) {
+	expr, err := ParseExpression("  name:alpha\tOR βeta!  ", "simple")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionAnd, expr.Kind)
+	require.Len(t, expr.Children, 2)
+	assert.Equal(t, ExpressionAnd, expr.Children[0].Kind)
+	assert.Equal(t, &Expression{
+		Kind: ExpressionTerm, Start: 2, End: 12, Value: "name:alpha", Prefix: true,
+	}, expr.Children[0].Children[0])
+	assert.Equal(t, &Expression{
+		Kind: ExpressionTerm, Start: 13, End: 15, Value: "OR", Prefix: true,
+	}, expr.Children[0].Children[1])
+	assert.Equal(t, &Expression{
+		Kind: ExpressionTerm, Start: 16, End: 22, Value: "βeta!", Prefix: true,
+	}, expr.Children[1])
+	assert.Equal(t, 2, expr.Start)
+	assert.Equal(t, 22, expr.End)
+
+	expr, err = ParseExpression(`"a:b" AND* \word`, "simple")
+	require.NoError(t, err)
+	assert.Equal(t, `"a:b"`, expr.Children[0].Children[0].Value)
+	assert.Equal(t, `AND*`, expr.Children[0].Children[1].Value)
+	assert.Equal(t, `\word`, expr.Children[1].Value)
+	assert.True(t, expr.Children[0].Children[0].Prefix)
+	assert.True(t, expr.Children[0].Children[1].Prefix)
+	assert.True(t, expr.Children[1].Prefix)
+}
+
+func TestParseExpressionEmptyInputMatchesEverything(t *testing.T) {
+	for _, syntax := range []string{"simple", "advanced"} {
+		for _, text := range []string{"", " \t\n"} {
+			expr, err := ParseExpression(text, syntax)
+			require.NoError(t, err)
+			assert.Equal(t, &Expression{Kind: ExpressionAll, Start: 0, End: len(text)}, expr)
+		}
+	}
+}
+
+func TestParseExpressionAdvancedPreservesFieldAndBooleanScope(t *testing.T) {
+	text := `name:(alpha OR "beta gamma") AND NOT tag:closed`
+	expr, err := ParseExpression(text, "advanced")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionAnd, expr.Kind)
+	require.Len(t, expr.Children, 2)
+
+	name := expr.Children[0]
+	require.Equal(t, ExpressionField, name.Kind)
+	assert.Equal(t, "name", name.Field)
+	assert.Equal(t, 0, name.Start)
+	assert.Equal(t, 28, name.End)
+	require.Len(t, name.Children, 1)
+	assert.Equal(t, ExpressionOr, name.Children[0].Kind)
+	assert.Equal(t, 5, name.Children[0].Start)
+	assert.Equal(t, 28, name.Children[0].End)
+
+	not := expr.Children[1]
+	require.Equal(t, ExpressionNot, not.Kind)
+	require.Len(t, not.Children, 1)
+	assert.Equal(t, ExpressionField, not.Children[0].Kind)
+	assert.Equal(t, "tag", not.Children[0].Field)
+	assert.Equal(t, 33, not.Start)
+	assert.Equal(t, len(text), not.End)
+}
+
+func TestParseExpressionAdvancedUsesDocumentedPrecedence(t *testing.T) {
+	expr, err := ParseExpression(`a OR b AND c`, "advanced")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionOr, expr.Kind)
+	assert.Equal(t, ExpressionTerm, expr.Children[0].Kind)
+	assert.Equal(t, ExpressionAnd, expr.Children[1].Kind)
+
+	expr, err = ParseExpression(`a NOT b`, "advanced")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionAnd, expr.Kind)
+	assert.Equal(t, ExpressionTerm, expr.Children[0].Kind)
+	assert.Equal(t, ExpressionNot, expr.Children[1].Kind)
+
+	expr, err = ParseExpression(`and ORbit NEARby`, "advanced")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionAnd, expr.Kind)
+	assert.Equal(t, "NEARby", expr.Children[1].Value)
+}
+
+func TestParseExpressionAdvancedPhraseNearAndEscapes(t *testing.T) {
+	expr, err := ParseExpression(`"alpha beta"* NEAR/5 gamma`, "advanced")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionNear, expr.Kind)
+	assert.Equal(t, 5, expr.Distance)
+	assert.Equal(t, 0, expr.Start)
+	assert.Equal(t, 26, expr.End)
+	assert.Equal(t, &Expression{
+		Kind: ExpressionPhrase, Start: 0, End: 13, Value: "alpha beta", Prefix: true,
+	}, expr.Children[0])
+	assert.Equal(t, &Expression{
+		Kind: ExpressionTerm, Start: 21, End: 26, Value: "gamma",
+	}, expr.Children[1])
+
+	expr, err = ParseExpression(`foo\:bar \AND`, "advanced")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionAnd, expr.Kind)
+	assert.Equal(t, "foo:bar", expr.Children[0].Value)
+	assert.Equal(t, "AND", expr.Children[1].Value)
+
+	expr, err = ParseExpression(`alpha NEAR beta`, "advanced")
+	require.NoError(t, err)
+	assert.Equal(t, 10, expr.Distance)
+
+	expr, err = ParseExpression(`alpha NEAR/0 beta`, "advanced")
+	require.NoError(t, err)
+	assert.Equal(t, 0, expr.Distance)
+}
+
+func TestParseExpressionAdvancedDecodesOnlyEscapedSyntax(t *testing.T) {
+	tests := []struct {
+		text   string
+		kind   ExpressionKind
+		value  string
+		prefix bool
+	}{
+		{text: `alpha*`, kind: ExpressionTerm, value: "alpha", prefix: true},
+		{text: `foo\*`, kind: ExpressionTerm, value: "foo*"},
+		{text: `\NEAR\/5`, kind: ExpressionTerm, value: "NEAR/5"},
+		{text: `"a  b\ c"`, kind: ExpressionPhrase, value: "a  b c"},
+		{text: `"alpha"*`, kind: ExpressionPhrase, value: "alpha", prefix: true},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.text, func(t *testing.T) {
+			expr, err := ParseExpression(testCase.text, "advanced")
+			require.NoError(t, err)
+			assert.Equal(t, testCase.kind, expr.Kind)
+			assert.Equal(t, testCase.value, expr.Value)
+			assert.Equal(t, testCase.prefix, expr.Prefix)
+			assert.Equal(t, 0, expr.Start)
+			assert.Equal(t, len(testCase.text), expr.End)
+		})
+	}
+}
+
+func TestParseExpressionAdvancedRecognizesExactFieldNames(t *testing.T) {
+	fields := []string{
+		"name", "path", "tag", "collection", "saved", "mime", "extension",
+		"media_family", "modified_after", "modified_before", "size_min", "size_max",
+		"text_coverage", "has_duplicates",
+	}
+	for _, field := range fields {
+		t.Run(field, func(t *testing.T) {
+			text := field + ":value"
+			expr, err := ParseExpression(text, "advanced")
+			require.NoError(t, err)
+			assert.Equal(t, ExpressionField, expr.Kind)
+			assert.Equal(t, field, expr.Field)
+			assert.Equal(t, 0, expr.Start)
+			assert.Equal(t, len(text), expr.End)
+		})
+	}
+
+	for _, text := range []string{`Name:value`, `unknown:value`, `unknown\:value`} {
+		expr, err := ParseExpression(text, "advanced")
+		if text == `unknown\:value` {
+			require.NoError(t, err)
+			assert.Equal(t, "unknown:value", expr.Value)
+			continue
+		}
+		_ = requireExpressionError(t, text, err)
+	}
+}
+
+func TestParseExpressionAdvancedRetainsSeparateFieldScopes(t *testing.T) {
+	expr, err := ParseExpression(`name:alpha OR tag:closed`, "advanced")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionOr, expr.Kind)
+	assert.Equal(t, "name", expr.Children[0].Field)
+	assert.Equal(t, "tag", expr.Children[1].Field)
+
+	expr, err = ParseExpression(`saved:"Case review"`, "advanced")
+	require.NoError(t, err)
+	require.Equal(t, ExpressionField, expr.Kind)
+	assert.Equal(t, "saved", expr.Field)
+	require.Len(t, expr.Children, 1)
+	assert.Equal(t, ExpressionPhrase, expr.Children[0].Kind)
+	assert.Equal(t, "Case review", expr.Children[0].Value)
+}
+
+func TestParseExpressionRejectsMalformedAdvancedSyntax(t *testing.T) {
+	tests := map[string]string{
+		"unknown field":         `unknown:value`,
+		"dangling escape":       `alpha\`,
+		"unclosed phrase":       `"alpha`,
+		"embedded star":         `al*pha`,
+		"repeated star":         `alpha**`,
+		"phrase embedded star":  `"alpha"*beta`,
+		"bare star":             `*`,
+		"empty group":           `()`,
+		"unmatched open group":  `(alpha`,
+		"unmatched close group": `alpha)`,
+		"missing field operand": `name:`,
+		"nested field operand":  `name:tag:closed`,
+		"leading operator":      `OR alpha`,
+		"trailing operator":     `alpha AND`,
+		"missing near operand":  `alpha NEAR`,
+		"negative near":         `alpha NEAR/-1 beta`,
+		"signed near":           `alpha NEAR/+1 beta`,
+		"invalid near":          `alpha NEAR/x beta`,
+		"large near":            `alpha NEAR/1001 beta`,
+	}
+	for name, text := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseExpression(text, "advanced")
+			_ = requireExpressionError(t, text, err)
+		})
+	}
+}
+
+func TestParseExpressionReportsUTF8ByteOffsets(t *testing.T) {
+	text := `😀 alpha AND`
+	_, err := ParseExpression(text, "advanced")
+	expressionErr := requireExpressionError(t, text, err)
+	assert.Equal(t, 11, expressionErr.Offset)
+	assert.Equal(t, 14, expressionErr.End)
+}
+
+func TestParseExpressionEnforcesInputDepthAndNodeBounds(t *testing.T) {
+	_, err := ParseExpression(string([]byte{0xff}), "advanced")
+	_ = requireExpressionError(t, string([]byte{0xff}), err)
+
+	_, err = ParseExpression(strings.Repeat("😀", maxTextRunes+1), "advanced")
+	_ = requireExpressionError(t, strings.Repeat("😀", maxTextRunes+1), err)
+
+	_, err = ParseExpression(strings.Repeat("(", 33)+"x"+strings.Repeat(")", 33), "advanced")
+	_ = requireExpressionError(t, strings.Repeat("(", 33)+"x"+strings.Repeat(")", 33), err)
+
+	_, err = ParseExpression(strings.Repeat("x ", 257), "advanced")
+	_ = requireExpressionError(t, strings.Repeat("x ", 257), err)
+
+	_, err = ParseExpression("x", "future")
+	_ = requireExpressionError(t, "x", err)
+}
+
+func TestParseExpressionAcceptsExactInputDepthAndNodeBounds(t *testing.T) {
+	text := strings.Repeat("x", maxTextRunes)
+	expr, err := ParseExpression(text, "advanced")
+	require.NoError(t, err)
+	assert.Equal(t, len(text), expr.End)
+
+	text = strings.Repeat("(", 32) + "x" + strings.Repeat(")", 32)
+	expr, err = ParseExpression(text, "advanced")
+	require.NoError(t, err)
+	assert.Equal(t, 0, expr.Start)
+	assert.Equal(t, len(text), expr.End)
+
+	text = strings.Repeat("x ", 256)
+	expr, err = ParseExpression(text, "advanced")
+	require.NoError(t, err)
+	assert.Equal(t, ExpressionAnd, expr.Kind)
+}
+
+func FuzzParseExpression(f *testing.F) {
+	for _, seed := range []string{"", `name:(alpha OR "beta gamma")`, `😀 alpha AND`, `foo\:bar`, `alpha**`} {
+		f.Add(seed, "advanced")
+	}
+	f.Add("name:alpha OR beta", "simple")
+	f.Fuzz(func(t *testing.T, text, syntax string) {
+		expr, err := ParseExpression(text, syntax)
+		if err != nil {
+			var expressionErr *ExpressionError
+			require.ErrorAs(t, err, &expressionErr)
+			assert.GreaterOrEqual(t, expressionErr.Offset, 0)
+			assert.GreaterOrEqual(t, expressionErr.End, expressionErr.Offset)
+			assert.LessOrEqual(t, expressionErr.End, len(text))
+			return
+		}
+		assertExpressionSpans(t, expr, len(text))
+	})
+}
+
+func requireExpressionError(t *testing.T, text string, err error) *ExpressionError {
+	t.Helper()
+	require.Error(t, err)
+	var expressionErr *ExpressionError
+	require.ErrorAs(t, err, &expressionErr, "error type: %T", err)
+	assert.GreaterOrEqual(t, expressionErr.Offset, 0)
+	assert.GreaterOrEqual(t, expressionErr.End, expressionErr.Offset)
+	assert.LessOrEqual(t, expressionErr.End, len(text))
+	return expressionErr
+}
+
+func assertExpressionSpans(t *testing.T, expr *Expression, textLen int) {
+	t.Helper()
+	require.NotNil(t, expr)
+	assert.GreaterOrEqual(t, expr.Start, 0)
+	assert.GreaterOrEqual(t, expr.End, expr.Start)
+	assert.LessOrEqual(t, expr.End, textLen)
+	for _, child := range expr.Children {
+		assertExpressionSpans(t, child, textLen)
+	}
+}

--- a/internal/query/media.go
+++ b/internal/query/media.go
@@ -156,7 +156,7 @@ func filenameExtension(filename string) string {
 	baseStart := strings.LastIndexAny(filename, `/\\`) + 1
 	base := filename[baseStart:]
 	dot := strings.LastIndexByte(base, '.')
-	if dot < 0 || dot == len(base)-1 {
+	if dot <= 0 || dot == len(base)-1 {
 		return ""
 	}
 	extension, ok := lowerASCII(base[dot+1:])

--- a/internal/query/operand.go
+++ b/internal/query/operand.go
@@ -1,0 +1,44 @@
+package query
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// ValidateTextOperand applies the QueryV1 filter rules to an expression operand.
+func ValidateTextOperand(field, value string) error {
+	var valid bool
+	switch field {
+	case "path":
+		valid = validVirtualPath(value)
+	case "mime":
+		valid = validConcreteMIME(value)
+	case "extension":
+		valid = extensionPattern.MatchString(value)
+	case "media_family":
+		valid = validMediaFamily(value)
+	default:
+		return fmt.Errorf("unsupported text field %q", field)
+	}
+	if !utf8.ValidString(value) || !valid {
+		return fmt.Errorf("invalid %s operand", field)
+	}
+	return nil
+}
+
+// ParseSizeOperand reads a decimal operand within the QueryV1 size bounds.
+func ParseSizeOperand(value string) (int64, error) {
+	if value == "" || strings.IndexFunc(value, func(r rune) bool { return r < '0' || r > '9' }) >= 0 {
+		return 0, errors.New("size operand must be a decimal nonnegative safe integer")
+	}
+	bound, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || !validSizeBound(bound) {
+		return 0, errors.New("size operand must be a decimal nonnegative safe integer")
+	}
+	return bound, nil
+}
+
+func validSizeBound(value int64) bool { return value >= 0 && value <= maxSafeInteger }

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -157,40 +157,46 @@ func Parse(raw []byte) (Query, error) {
 			value.Sort.Direction = *input.Sort.Direction
 		}
 	}
-	normalized, err := normalizeQuery(value)
-	if err != nil {
-		return Query{}, err
-	}
-	if _, err := Canonical(normalized); err != nil {
-		return Query{}, err
-	}
-	return normalized, nil
+	normalized, _, err := normalizeCanonical(value)
+	return normalized, err
 }
 
 // Canonical validates value and returns its one canonical QueryV1 encoding.
 func Canonical(value Query) ([]byte, error) {
+	_, encoded, err := normalizeCanonical(value)
+	return encoded, err
+}
+
+// normalizeCanonical owns validation, defensive copying, and the encoded size bound.
+func normalizeCanonical(value Query) (Query, []byte, error) {
 	normalized, err := normalizeQuery(value)
 	if err != nil {
-		return nil, err
+		return Query{}, nil, err
 	}
 	encoded, err := canonical.Marshal(normalized)
 	if err != nil {
-		return nil, fmt.Errorf("encode query: %w", err)
+		return Query{}, nil, fmt.Errorf("encode query: %w", err)
 	}
 	if len(encoded) > maxCanonicalBytes {
-		return nil, errors.New("canonical query exceeds 64 KiB")
+		return Query{}, nil, errors.New("canonical query exceeds 64 KiB")
 	}
-	return encoded, nil
+	return normalized, encoded, nil
+}
+
+// CanonicalWithFingerprint returns canonical QueryV1 bytes and their SHA-256 identity.
+func CanonicalWithFingerprint(value Query) ([]byte, string, error) {
+	encoded, err := Canonical(value)
+	if err != nil {
+		return nil, "", err
+	}
+	digest := sha256.Sum256(encoded)
+	return encoded, "sha256:" + hex.EncodeToString(digest[:]), nil
 }
 
 // Fingerprint returns the domain-neutral SHA-256 identity of canonical query bytes.
 func Fingerprint(value Query) (string, error) {
-	encoded, err := Canonical(value)
-	if err != nil {
-		return "", err
-	}
-	digest := sha256.Sum256(encoded)
-	return "sha256:" + hex.EncodeToString(digest[:]), nil
+	_, fingerprint, err := CanonicalWithFingerprint(value)
+	return fingerprint, err
 }
 
 func (input filtersInput) value() Filters {
@@ -322,12 +328,14 @@ func normalizeFilters(value Filters) (Filters, error) {
 			return Filters{}, errors.New("modified_after must precede modified_before")
 		}
 	}
-	if value.SizeMin < 0 || value.SizeMin > maxSafeInteger ||
-		(value.SizeMax != nil && (*value.SizeMax < 0 || *value.SizeMax > maxSafeInteger)) {
+	if !validSizeBound(value.SizeMin) || (value.SizeMax != nil && !validSizeBound(*value.SizeMax)) {
 		return Filters{}, errors.New("query size bounds must be safe nonnegative integers")
 	}
-	if value.SizeMax != nil && value.SizeMin > *value.SizeMax {
-		return Filters{}, errors.New("size_min exceeds size_max")
+	if value.SizeMax != nil {
+		if value.SizeMin > *value.SizeMax {
+			return Filters{}, errors.New("size_min exceeds size_max")
+		}
+		value.SizeMax = new(*value.SizeMax)
 	}
 	return value, nil
 }
@@ -405,26 +413,34 @@ func normalizeTimestamp(value, field string) (string, error) {
 	if value == "" {
 		return "", nil
 	}
+	parsed, err := parseTimestamp(value, field)
+	if err != nil {
+		return "", err
+	}
+	return parsed.Format(time.RFC3339Nano), nil
+}
+
+func parseTimestamp(value, field string) (time.Time, error) {
 	if !rfc3339NanoPattern.MatchString(value) {
-		return "", fmt.Errorf("%s is not strict RFC3339Nano", field)
+		return time.Time{}, fmt.Errorf("%s is not strict RFC3339Nano", field)
 	}
 	if value[len(value)-1] != 'Z' {
 		zone := value[len(value)-6:]
 		zoneHour := int(zone[1]-'0')*10 + int(zone[2]-'0')
 		zoneMinute := int(zone[4]-'0')*10 + int(zone[5]-'0')
 		if zoneHour > 23 || zoneMinute > 59 {
-			return "", fmt.Errorf("%s has an invalid RFC3339 offset", field)
+			return time.Time{}, fmt.Errorf("%s has an invalid RFC3339 offset", field)
 		}
 	}
 	parsed, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {
-		return "", fmt.Errorf("%s is not RFC3339: %w", field, err)
+		return time.Time{}, fmt.Errorf("%s is not RFC3339: %w", field, err)
 	}
 	utc := parsed.UTC()
 	if utc.Year() < 0 || utc.Year() > 9999 {
-		return "", fmt.Errorf("%s normalizes outside RFC3339", field)
+		return time.Time{}, fmt.Errorf("%s normalizes outside RFC3339", field)
 	}
-	return utc.Format(time.RFC3339Nano), nil
+	return utc, nil
 }
 
 func oneOf(value string, allowed ...string) bool { return slices.Contains(allowed, value) }

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -62,11 +62,9 @@ func TestQueryIdentityVectors(t *testing.T) {
 		t.Run(vector.Name, func(t *testing.T) {
 			value, err := Parse([]byte(vector.InputJSON))
 			require.NoError(t, err)
-			encoded, err := Canonical(value)
+			encoded, fingerprint, err := CanonicalWithFingerprint(value)
 			require.NoError(t, err)
 			assert.Equal(t, vector.CanonicalUTF8, string(encoded))
-			fingerprint, err := Fingerprint(value)
-			require.NoError(t, err)
 			assert.Equal(t, vector.Fingerprint, fingerprint)
 		})
 	}

--- a/internal/query/resolution.go
+++ b/internal/query/resolution.go
@@ -1,0 +1,395 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+)
+
+const (
+	maxResolvedExpressionNodes = 4096
+	maxSavedReferenceDepth     = 16
+	maxResolvedDependencies    = 256
+	maxResolvedCanonicalBytes  = 256 << 10
+)
+
+// ReferenceKind identifies an externally resolved query operand.
+type ReferenceKind string
+
+const (
+	ReferenceTag        ReferenceKind = "tag"
+	ReferenceCollection ReferenceKind = "collection"
+	ReferenceSaved      ReferenceKind = "saved"
+)
+
+// ErrUnknownReference identifies a recognized reference value which does not
+// exist. ResolveQuery turns it into an ExpressionError.
+var ErrUnknownReference = errors.New("unknown query reference")
+
+// Dependency identifies the stable revision used while resolving a query.
+type Dependency struct {
+	Kind     ReferenceKind
+	ID       string
+	Revision int64
+}
+
+// Reference is the validated result of one resolver lookup. Query is required
+// only for saved-query references.
+type Reference struct {
+	Dependency Dependency
+	Query      *Query
+}
+
+// Resolver resolves either an exact stable ID or a decoded display name.
+type Resolver interface {
+	Resolve(ctx context.Context, kind ReferenceKind, key string, byID bool) (Reference, error)
+}
+
+// ResolvedExpression mirrors a parsed expression and decorates reference
+// leaves with stable dependencies and saved-query expansions.
+type ResolvedExpression struct {
+	Syntax     *Expression
+	Children   []*ResolvedExpression
+	Dependency *Dependency
+	Saved      *ResolvedQuery
+}
+
+// ResolvedQuery retains one normalized query and its scope-local expansion.
+type ResolvedQuery struct {
+	Query        Query
+	Expression   *ResolvedExpression
+	Dependencies []Dependency
+}
+
+type dependencyKey struct {
+	kind ReferenceKind
+	id   string
+}
+
+type resolutionState struct {
+	resolver        Resolver
+	activeSaved     map[string]struct{}
+	revisions       map[dependencyKey]int64
+	expressionNodes int
+	canonicalBytes  int
+}
+
+// ResolveQuery normalizes a defensive copy and expands all references without
+// changing the query's entered text or lifting nested saved-query filters.
+func ResolveQuery(ctx context.Context, value Query, resolver Resolver) (ResolvedQuery, error) {
+	if err := ctx.Err(); err != nil {
+		return ResolvedQuery{}, err
+	}
+	normalized, canonical, err := normalizeCanonical(value)
+	if err != nil {
+		return ResolvedQuery{}, expressionError(0, len(value.Text), err.Error())
+	}
+	state := resolutionState{
+		resolver:       resolver,
+		activeSaved:    make(map[string]struct{}),
+		revisions:      make(map[dependencyKey]int64),
+		canonicalBytes: len(canonical),
+	}
+	return state.resolveQuery(ctx, normalized, 0)
+}
+
+func (state *resolutionState) resolveQuery(ctx context.Context, value Query, savedDepth int) (ResolvedQuery, error) {
+	if err := ctx.Err(); err != nil {
+		return ResolvedQuery{}, err
+	}
+	if value.Mode != "lexical" {
+		return ResolvedQuery{}, expressionError(0, len(value.Text), "reference expansion requires lexical query mode")
+	}
+	syntax, err := ParseExpression(value.Text, value.Syntax)
+	if err != nil {
+		return ResolvedQuery{}, err
+	}
+	expression, expressionDependencies, err := state.resolveExpression(ctx, syntax, "", savedDepth)
+	if err != nil {
+		return ResolvedQuery{}, err
+	}
+	facetDependencies, err := state.resolveFacets(ctx, value)
+	if err != nil {
+		return ResolvedQuery{}, err
+	}
+	return ResolvedQuery{
+		Query:        value,
+		Expression:   expression,
+		Dependencies: sortedDependencies(expressionDependencies, facetDependencies),
+	}, nil
+}
+
+func (state *resolutionState) resolveExpression(
+	ctx context.Context,
+	syntax *Expression,
+	field string,
+	savedDepth int,
+) (*ResolvedExpression, []Dependency, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	state.expressionNodes++
+	if state.expressionNodes > maxResolvedExpressionNodes {
+		return nil, nil, expressionError(syntax.Start, syntax.End, "expanded expression exceeds 4096 AST nodes")
+	}
+
+	resolved := &ResolvedExpression{Syntax: syntax}
+	if syntax.Kind == ExpressionField {
+		if field != "" {
+			return nil, nil, expressionError(syntax.Start, syntax.End, "nested field overrides are not supported")
+		}
+		children, dependencies, err := state.resolveChildren(ctx, syntax, syntax.Field, savedDepth)
+		if err != nil {
+			return nil, nil, err
+		}
+		resolved.Children = children
+		return resolved, dependencies, nil
+	}
+
+	if kind, isReference := referenceKindForField(field); isReference {
+		switch syntax.Kind {
+		case ExpressionTerm, ExpressionPhrase:
+			if syntax.Prefix {
+				return nil, nil, expressionError(syntax.Start, syntax.End, "reference operands cannot use prefix matching")
+			}
+			dependency, saved, dependencies, err := state.resolveLeaf(ctx, kind, syntax, savedDepth)
+			if err != nil {
+				return nil, nil, err
+			}
+			resolved.Dependency = dependency
+			resolved.Saved = saved
+			return resolved, dependencies, nil
+		case ExpressionAnd, ExpressionOr, ExpressionNot:
+			children, dependencies, err := state.resolveChildren(ctx, syntax, field, savedDepth)
+			if err != nil {
+				return nil, nil, err
+			}
+			resolved.Children = children
+			return resolved, dependencies, nil
+		case ExpressionNear:
+			return nil, nil, expressionError(syntax.Start, syntax.End, "reference operands cannot use NEAR")
+		default:
+			return nil, nil, expressionError(syntax.Start, syntax.End, "reference field requires exact term or phrase operands")
+		}
+	}
+
+	children, dependencies, err := state.resolveChildren(ctx, syntax, field, savedDepth)
+	if err != nil {
+		return nil, nil, err
+	}
+	resolved.Children = children
+	return resolved, dependencies, nil
+}
+
+func (state *resolutionState) resolveChildren(
+	ctx context.Context,
+	syntax *Expression,
+	field string,
+	savedDepth int,
+) ([]*ResolvedExpression, []Dependency, error) {
+	if len(syntax.Children) == 0 {
+		return nil, nil, nil
+	}
+	children := make([]*ResolvedExpression, 0, len(syntax.Children))
+	var dependencies []Dependency
+	for _, childSyntax := range syntax.Children {
+		child, childDependencies, err := state.resolveExpression(ctx, childSyntax, field, savedDepth)
+		if err != nil {
+			return nil, nil, err
+		}
+		children = append(children, child)
+		dependencies = append(dependencies, childDependencies...)
+	}
+	return children, dependencies, nil
+}
+
+func (state *resolutionState) resolveLeaf(
+	ctx context.Context,
+	kind ReferenceKind,
+	syntax *Expression,
+	savedDepth int,
+) (*Dependency, *ResolvedQuery, []Dependency, error) {
+	if kind == ReferenceSaved && savedDepth >= maxSavedReferenceDepth {
+		return nil, nil, nil, expressionError(syntax.Start, syntax.End, "saved reference nesting exceeds 16")
+	}
+	ref, err := state.lookup(ctx, kind, syntax.Value, validUUIDv4(syntax.Value), syntax.Start, syntax.End)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	dependency := ref.Dependency
+	dependencies := []Dependency{dependency}
+	if kind != ReferenceSaved {
+		return &dependency, nil, dependencies, nil
+	}
+
+	if _, active := state.activeSaved[dependency.ID]; active {
+		return nil, nil, nil, expressionError(syntax.Start, syntax.End, "saved reference cycle detected")
+	}
+	nested, canonical, err := normalizeCanonical(*ref.Query)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("normalize saved query %s: %w", dependency.ID, err)
+	}
+	if len(canonical) > maxResolvedCanonicalBytes-state.canonicalBytes {
+		return nil, nil, nil, expressionError(syntax.Start, syntax.End, "expanded queries exceed 256 KiB")
+	}
+	state.canonicalBytes += len(canonical)
+	state.activeSaved[dependency.ID] = struct{}{}
+	nestedResolved, err := state.resolveQuery(ctx, nested, savedDepth+1)
+	delete(state.activeSaved, dependency.ID)
+	if err != nil {
+		if nestedExpressionErr, ok := errors.AsType[*ExpressionError](err); ok {
+			return nil, nil, nil, expressionError(syntax.Start, syntax.End, nestedExpressionErr.Message)
+		}
+		return nil, nil, nil, err
+	}
+	dependencies = append(dependencies, nestedResolved.Dependencies...)
+	return &dependency, &nestedResolved, dependencies, nil
+}
+
+func (state *resolutionState) resolveFacets(ctx context.Context, value Query) ([]Dependency, error) {
+	type facet struct {
+		kind   ReferenceKind
+		values []string
+	}
+	facets := []facet{
+		{kind: ReferenceCollection, values: value.Filters.CollectionIDs},
+		{kind: ReferenceCollection, values: value.Filters.ExcludeCollectionIDs},
+		{kind: ReferenceTag, values: value.Filters.TagIDs},
+		{kind: ReferenceTag, values: value.Filters.ExcludeTagIDs},
+	}
+	var dependencies []Dependency
+	for _, facet := range facets {
+		for _, id := range facet.values {
+			// Structured filters have no span in the query text.
+			ref, err := state.lookup(ctx, facet.kind, id, true, 0, 0)
+			if err != nil {
+				return nil, err
+			}
+			dependencies = append(dependencies, ref.Dependency)
+		}
+	}
+	return dependencies, nil
+}
+
+func (state *resolutionState) lookup(
+	ctx context.Context,
+	kind ReferenceKind,
+	key string,
+	byID bool,
+	start int,
+	end int,
+) (Reference, error) {
+	if err := ctx.Err(); err != nil {
+		return Reference{}, err
+	}
+	if state.resolver == nil {
+		return Reference{}, errors.New("query resolver is required for references")
+	}
+	ref, err := state.resolver.Resolve(ctx, kind, key, byID)
+	if err != nil {
+		if errors.Is(err, ErrUnknownReference) {
+			return Reference{}, expressionError(start, end, fmt.Sprintf("unknown %s reference", kind))
+		}
+		return Reference{}, fmt.Errorf("resolve %s reference: %w", kind, err)
+	}
+	if err := validateReference(ref, kind, key, byID); err != nil {
+		return Reference{}, err
+	}
+	if err := state.recordDependency(ref.Dependency); err != nil {
+		if limitErr, ok := errors.AsType[*dependencyLimitError](err); ok {
+			return Reference{}, expressionError(start, end, limitErr.Error())
+		}
+		return Reference{}, err
+	}
+	return ref, nil
+}
+
+func validateReference(ref Reference, kind ReferenceKind, key string, byID bool) error {
+	dependency := ref.Dependency
+	if dependency.Kind != kind {
+		return fmt.Errorf("resolver returned %q kind for %q reference", dependency.Kind, kind)
+	}
+	if !validUUIDv4(dependency.ID) {
+		return fmt.Errorf("resolver returned invalid stable ID for %s reference", kind)
+	}
+	if byID && dependency.ID != key {
+		return fmt.Errorf("resolver returned stable ID %q for exact ID %q", dependency.ID, key)
+	}
+	if dependency.Revision <= 0 {
+		return fmt.Errorf("resolver returned nonpositive revision for %s reference", kind)
+	}
+	if kind == ReferenceSaved && ref.Query == nil {
+		return errors.New("resolver returned saved reference without a query")
+	}
+	return nil
+}
+
+type dependencyLimitError struct{}
+
+func (*dependencyLimitError) Error() string {
+	return "expanded query exceeds 256 distinct dependencies"
+}
+
+func (state *resolutionState) recordDependency(dependency Dependency) error {
+	key := dependencyKey{kind: dependency.Kind, id: dependency.ID}
+	if revision, exists := state.revisions[key]; exists {
+		if revision != dependency.Revision {
+			return fmt.Errorf(
+				"resolver returned conflicting revisions %d and %d for %s %s",
+				revision, dependency.Revision, dependency.Kind, dependency.ID,
+			)
+		}
+		return nil
+	}
+	if len(state.revisions) >= maxResolvedDependencies {
+		return &dependencyLimitError{}
+	}
+	state.revisions[key] = dependency.Revision
+	return nil
+}
+
+func referenceKindForField(field string) (ReferenceKind, bool) {
+	switch field {
+	case string(ReferenceTag):
+		return ReferenceTag, true
+	case string(ReferenceCollection):
+		return ReferenceCollection, true
+	case string(ReferenceSaved):
+		return ReferenceSaved, true
+	default:
+		return "", false
+	}
+}
+
+func sortedDependencies(groups ...[]Dependency) []Dependency {
+	byKey := make(map[dependencyKey]Dependency)
+	for _, dependencies := range groups {
+		for _, dependency := range dependencies {
+			byKey[dependencyKey{kind: dependency.Kind, id: dependency.ID}] = dependency
+		}
+	}
+	result := make([]Dependency, 0, len(byKey))
+	for _, dependency := range byKey {
+		result = append(result, dependency)
+	}
+	slices.SortFunc(result, func(left, right Dependency) int {
+		if left.Kind < right.Kind {
+			return -1
+		}
+		if left.Kind > right.Kind {
+			return 1
+		}
+		if left.ID < right.ID {
+			return -1
+		}
+		if left.ID > right.ID {
+			return 1
+		}
+		return 0
+	})
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/internal/query/resolution_test.go
+++ b/internal/query/resolution_test.go
@@ -1,0 +1,357 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tagID        = "11111111-1111-4111-8111-111111111111"
+	otherTagID   = "22222222-2222-4222-8222-222222222222"
+	collectionID = "33333333-3333-4333-8333-333333333333"
+	savedID      = "44444444-4444-4444-8444-444444444444"
+	otherSavedID = "55555555-5555-4555-8555-555555555555"
+)
+
+type resolverCall struct {
+	kind ReferenceKind
+	key  string
+	byID bool
+}
+
+type resolverFunc func(context.Context, ReferenceKind, string, bool) (Reference, error)
+
+func (fn resolverFunc) Resolve(ctx context.Context, kind ReferenceKind, key string, byID bool) (Reference, error) {
+	return fn(ctx, kind, key, byID)
+}
+
+func TestResolveQueryExpandsFieldScopedReferencesWithoutLosingBooleanScope(t *testing.T) {
+	var calls []resolverCall
+	resolver := resolverFunc(func(_ context.Context, kind ReferenceKind, key string, byID bool) (Reference, error) {
+		calls = append(calls, resolverCall{kind: kind, key: key, byID: byID})
+		ids := map[string]string{"red": tagID, "blue team": otherTagID, collectionID: collectionID}
+		return Reference{Dependency: Dependency{Kind: kind, ID: ids[key], Revision: 7}}, nil
+	})
+
+	text := `tag:(red OR NOT "blue team") AND collection:` + collectionID
+	resolved, err := ResolveQuery(context.Background(), lexicalQuery(text), resolver)
+	require.NoError(t, err)
+
+	assert.Equal(t, []resolverCall{
+		{kind: ReferenceTag, key: "red", byID: false},
+		{kind: ReferenceTag, key: "blue team", byID: false},
+		{kind: ReferenceCollection, key: collectionID, byID: true},
+	}, calls)
+	require.Equal(t, ExpressionAnd, resolved.Expression.Syntax.Kind)
+	tagField := resolved.Expression.Children[0]
+	require.Equal(t, ExpressionField, tagField.Syntax.Kind)
+	require.Equal(t, ExpressionOr, tagField.Children[0].Syntax.Kind)
+	assert.Equal(t, &Dependency{Kind: ReferenceTag, ID: tagID, Revision: 7}, tagField.Children[0].Children[0].Dependency)
+	notBlue := tagField.Children[0].Children[1]
+	require.Equal(t, ExpressionNot, notBlue.Syntax.Kind)
+	assert.Equal(t, &Dependency{Kind: ReferenceTag, ID: otherTagID, Revision: 7}, notBlue.Children[0].Dependency)
+	assert.Equal(t, "blue team", notBlue.Children[0].Syntax.Value)
+	collectionLeaf := resolved.Expression.Children[1].Children[0]
+	assert.Equal(t, &Dependency{Kind: ReferenceCollection, ID: collectionID, Revision: 7}, collectionLeaf.Dependency)
+	assert.Equal(t, []Dependency{
+		{Kind: ReferenceCollection, ID: collectionID, Revision: 7},
+		{Kind: ReferenceTag, ID: tagID, Revision: 7},
+		{Kind: ReferenceTag, ID: otherTagID, Revision: 7},
+	}, resolved.Dependencies)
+}
+
+func TestResolveQuerySavedReferenceRetainsNestedASTAndFacetScope(t *testing.T) {
+	nested := lexicalQuery(`tag:red OR beta`)
+	nested.Filters.TagIDs = []string{otherTagID}
+	nested.Filters.ExcludeCollectionIDs = []string{collectionID}
+	root := lexicalQuery(`alpha AND saved:"Case review"`)
+	root.Filters.TagIDs = []string{tagID}
+
+	resolver := resolverFunc(func(_ context.Context, kind ReferenceKind, key string, byID bool) (Reference, error) {
+		switch {
+		case kind == ReferenceSaved && key == "Case review" && !byID:
+			return Reference{Dependency: Dependency{Kind: kind, ID: savedID, Revision: 9}, Query: &nested}, nil
+		case kind == ReferenceTag && key == "red" && !byID:
+			return Reference{Dependency: Dependency{Kind: kind, ID: tagID, Revision: 2}}, nil
+		case kind == ReferenceTag && key == tagID && byID:
+			return Reference{Dependency: Dependency{Kind: kind, ID: tagID, Revision: 2}}, nil
+		case kind == ReferenceTag && key == otherTagID && byID:
+			return Reference{Dependency: Dependency{Kind: kind, ID: otherTagID, Revision: 3}}, nil
+		case kind == ReferenceCollection && key == collectionID && byID:
+			return Reference{Dependency: Dependency{Kind: kind, ID: collectionID, Revision: 4}}, nil
+		default:
+			return Reference{}, fmt.Errorf("unexpected resolution: %s %q %v", kind, key, byID)
+		}
+	})
+
+	resolved, err := ResolveQuery(context.Background(), root, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, root.Text, resolved.Query.Text)
+	assert.Equal(t, []string{tagID}, resolved.Query.Filters.TagIDs)
+
+	savedLeaf := resolved.Expression.Children[1].Children[0]
+	require.NotNil(t, savedLeaf.Saved)
+	assert.Equal(t, &Dependency{Kind: ReferenceSaved, ID: savedID, Revision: 9}, savedLeaf.Dependency)
+	assert.Equal(t, nested.Text, savedLeaf.Saved.Query.Text)
+	assert.Equal(t, []string{otherTagID}, savedLeaf.Saved.Query.Filters.TagIDs)
+	assert.Equal(t, []string{collectionID}, savedLeaf.Saved.Query.Filters.ExcludeCollectionIDs)
+	require.Equal(t, ExpressionOr, savedLeaf.Saved.Expression.Syntax.Kind)
+	assert.Equal(t, &Dependency{Kind: ReferenceTag, ID: tagID, Revision: 2}, savedLeaf.Saved.Expression.Children[0].Children[0].Dependency)
+	assert.Equal(t, []Dependency{
+		{Kind: ReferenceCollection, ID: collectionID, Revision: 4},
+		{Kind: ReferenceTag, ID: tagID, Revision: 2},
+		{Kind: ReferenceTag, ID: otherTagID, Revision: 3},
+	}, savedLeaf.Saved.Dependencies)
+	assert.Equal(t, []Dependency{
+		{Kind: ReferenceCollection, ID: collectionID, Revision: 4},
+		{Kind: ReferenceSaved, ID: savedID, Revision: 9},
+		{Kind: ReferenceTag, ID: tagID, Revision: 2},
+		{Kind: ReferenceTag, ID: otherTagID, Revision: 3},
+	}, resolved.Dependencies)
+}
+
+func TestResolveQueryNormalizesCopyWithoutMutatingInput(t *testing.T) {
+	sizeMax := int64(20)
+	input := lexicalQuery("alpha")
+	input.Filters.TagIDs = []string{otherTagID, tagID, tagID}
+	input.Filters.SizeMax = &sizeMax
+	originalIDs := append([]string(nil), input.Filters.TagIDs...)
+
+	resolved, err := ResolveQuery(context.Background(), input, resolverFunc(func(_ context.Context, kind ReferenceKind, key string, byID bool) (Reference, error) {
+		return Reference{Dependency: Dependency{Kind: kind, ID: key, Revision: 1}}, nil
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, originalIDs, input.Filters.TagIDs)
+	assert.Equal(t, []string{tagID, otherTagID}, resolved.Query.Filters.TagIDs)
+	*resolved.Query.Filters.SizeMax = 10
+	assert.Equal(t, int64(20), *input.Filters.SizeMax)
+}
+
+func TestResolveQueryUnknownReferencesPositionOnlyExpressionOperands(t *testing.T) {
+	resolver := resolverFunc(func(context.Context, ReferenceKind, string, bool) (Reference, error) {
+		return Reference{}, fmt.Errorf("lookup: %w", ErrUnknownReference)
+	})
+	for _, testCase := range []struct {
+		name  string
+		query Query
+		start int
+		end   int
+	}{
+		{name: "negative tag", query: lexicalQuery(`tag:(NOT missing)`), start: 9, end: 16},
+		{name: "deleted saved", query: lexicalQuery(`saved:gone`), start: 6, end: 10},
+		{name: "negative collection facet", query: queryWithExcludedCollection("root", collectionID)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := ResolveQuery(context.Background(), testCase.query, resolver)
+			expressionErr := requireExpressionError(t, testCase.query.Text, err)
+			assert.Equal(t, testCase.start, expressionErr.Offset)
+			assert.Equal(t, testCase.end, expressionErr.End)
+		})
+	}
+}
+
+func TestResolveQueryPropagatesBackendErrorIdentity(t *testing.T) {
+	backendErr := errors.New("backend unavailable")
+	_, err := ResolveQuery(context.Background(), lexicalQuery(`tag:red`), resolverFunc(func(context.Context, ReferenceKind, string, bool) (Reference, error) {
+		return Reference{}, backendErr
+	}))
+	require.ErrorIs(t, err, backendErr)
+	var expressionErr *ExpressionError
+	assert.NotErrorAs(t, err, &expressionErr)
+}
+
+func TestResolveQueryRejectsCyclesByStableSavedIDAcrossAliases(t *testing.T) {
+	first := lexicalQuery(`saved:second-alias`)
+	second := lexicalQuery(`saved:first-alias`)
+	resolver := resolverFunc(func(_ context.Context, kind ReferenceKind, key string, _ bool) (Reference, error) {
+		switch key {
+		case "first-alias":
+			return Reference{Dependency: Dependency{Kind: kind, ID: savedID, Revision: 1}, Query: &first}, nil
+		case "second-alias":
+			return Reference{Dependency: Dependency{Kind: kind, ID: otherSavedID, Revision: 1}, Query: &second}, nil
+		default:
+			return Reference{}, ErrUnknownReference
+		}
+	})
+
+	text := `saved:first-alias`
+	_, err := ResolveQuery(context.Background(), lexicalQuery(text), resolver)
+	expressionErr := requireExpressionError(t, text, err)
+	assert.Equal(t, 6, expressionErr.Offset)
+	assert.Equal(t, len(text), expressionErr.End)
+	assert.Contains(t, expressionErr.Message, "cycle")
+}
+
+func TestResolveQueryAllowsRepeatedConsistentReferencesAndRejectsRevisionConflicts(t *testing.T) {
+	t.Run("consistent", func(t *testing.T) {
+		resolved, err := ResolveQuery(context.Background(), lexicalQuery(`tag:red OR tag:red`), resolverFunc(func(_ context.Context, kind ReferenceKind, _ string, _ bool) (Reference, error) {
+			return Reference{Dependency: Dependency{Kind: kind, ID: tagID, Revision: 3}}, nil
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, []Dependency{{Kind: ReferenceTag, ID: tagID, Revision: 3}}, resolved.Dependencies)
+	})
+
+	t.Run("conflict is backend error", func(t *testing.T) {
+		calls := 0
+		_, err := ResolveQuery(context.Background(), lexicalQuery(`tag:red OR tag:red`), resolverFunc(func(_ context.Context, kind ReferenceKind, _ string, _ bool) (Reference, error) {
+			calls++
+			return Reference{Dependency: Dependency{Kind: kind, ID: tagID, Revision: int64(calls)}}, nil
+		}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicting")
+		var expressionErr *ExpressionError
+		assert.NotErrorAs(t, err, &expressionErr)
+	})
+}
+
+func TestResolveQueryRejectsMalformedResolverResultsAsBackendErrors(t *testing.T) {
+	savedQuery := lexicalQuery("alpha")
+	tests := map[string]Reference{
+		"wrong kind":     {Dependency: Dependency{Kind: ReferenceCollection, ID: tagID, Revision: 1}},
+		"invalid id":     {Dependency: Dependency{Kind: ReferenceTag, ID: "not-an-id", Revision: 1}},
+		"wrong exact id": {Dependency: Dependency{Kind: ReferenceTag, ID: otherTagID, Revision: 1}},
+		"zero revision":  {Dependency: Dependency{Kind: ReferenceTag, ID: tagID, Revision: 0}},
+	}
+	for name, result := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ResolveQuery(context.Background(), lexicalQuery(`tag:`+tagID), resolverFunc(func(context.Context, ReferenceKind, string, bool) (Reference, error) {
+				return result, nil
+			}))
+			require.Error(t, err)
+			var expressionErr *ExpressionError
+			assert.NotErrorAs(t, err, &expressionErr)
+		})
+	}
+
+	for name, saved := range map[string]*Query{"nil query": nil, "valid control": &savedQuery} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ResolveQuery(context.Background(), lexicalQuery(`saved:one`), resolverFunc(func(context.Context, ReferenceKind, string, bool) (Reference, error) {
+				return Reference{Dependency: Dependency{Kind: ReferenceSaved, ID: savedID, Revision: 1}, Query: saved}, nil
+			}))
+			if name == "valid control" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestResolveQueryRejectsUnsupportedReferenceFieldOperandsAndNestedFields(t *testing.T) {
+	for _, text := range []string{
+		`tag:red*`,
+		`tag:(red NEAR blue)`,
+		`tag:(collection:blue)`,
+		`name:(tag:red)`,
+	} {
+		t.Run(text, func(t *testing.T) {
+			_, err := ResolveQuery(context.Background(), lexicalQuery(text), nil)
+			_ = requireExpressionError(t, text, err)
+		})
+	}
+}
+
+func TestResolveQueryRejectsNonLexicalNestedQueriesAtOuterOperandSpan(t *testing.T) {
+	nested := lexicalQuery("alpha")
+	nested.Mode = "semantic"
+	text := `saved:semantic`
+	_, err := ResolveQuery(context.Background(), lexicalQuery(text), resolverFunc(func(context.Context, ReferenceKind, string, bool) (Reference, error) {
+		return Reference{Dependency: Dependency{Kind: ReferenceSaved, ID: savedID, Revision: 1}, Query: &nested}, nil
+	}))
+	expressionErr := requireExpressionError(t, text, err)
+	assert.Equal(t, 6, expressionErr.Offset)
+	assert.Equal(t, len(text), expressionErr.End)
+}
+
+func TestResolveQueryHonorsContextAndNilResolver(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := ResolveQuery(ctx, lexicalQuery(`tag:red`), resolverFunc(func(context.Context, ReferenceKind, string, bool) (Reference, error) {
+		t.Fatal("resolver called after cancellation")
+		return Reference{}, nil
+	}))
+	require.ErrorIs(t, err, context.Canceled)
+
+	resolved, err := ResolveQuery(context.Background(), lexicalQuery("alpha"), nil)
+	require.NoError(t, err)
+	assert.Empty(t, resolved.Dependencies)
+
+	_, err = ResolveQuery(context.Background(), lexicalQuery(`tag:red`), nil)
+	require.Error(t, err)
+	var expressionErr *ExpressionError
+	assert.NotErrorAs(t, err, &expressionErr)
+}
+
+func TestResolveQueryEnforcesSavedDepthNodeByteAndDependencyBounds(t *testing.T) {
+	t.Run("saved depth", func(t *testing.T) {
+		resolver := resolverFunc(func(_ context.Context, kind ReferenceKind, key string, _ bool) (Reference, error) {
+			var index int
+			_, err := fmt.Sscanf(key, "level-%d", &index)
+			require.NoError(t, err)
+			next := lexicalQuery(fmt.Sprintf("saved:level-%d", index+1))
+			id := fmt.Sprintf("%08x-0000-4000-8000-%012x", index+1, index+1)
+			return Reference{Dependency: Dependency{Kind: kind, ID: id, Revision: 1}, Query: &next}, nil
+		})
+		text := "saved:level-0"
+		_, err := ResolveQuery(context.Background(), lexicalQuery(text), resolver)
+		_ = requireExpressionError(t, text, err)
+	})
+
+	t.Run("expanded nodes", func(t *testing.T) {
+		large := lexicalQuery(strings.TrimSpace(strings.Repeat("x ", 256)))
+		resolver := resolverFunc(func(_ context.Context, kind ReferenceKind, _ string, _ bool) (Reference, error) {
+			return Reference{Dependency: Dependency{Kind: kind, ID: savedID, Revision: 1}, Query: &large}, nil
+		})
+		text := strings.TrimSuffix(strings.Repeat("saved:large OR ", 8), " OR ")
+		_, err := ResolveQuery(context.Background(), lexicalQuery(text), resolver)
+		_ = requireExpressionError(t, text, err)
+	})
+
+	t.Run("expanded bytes", func(t *testing.T) {
+		large := lexicalQuery(strings.Repeat("x", 8192))
+		resolver := resolverFunc(func(_ context.Context, kind ReferenceKind, _ string, _ bool) (Reference, error) {
+			return Reference{Dependency: Dependency{Kind: kind, ID: savedID, Revision: 1}, Query: &large}, nil
+		})
+		text := strings.TrimSuffix(strings.Repeat("saved:large OR ", 32), " OR ")
+		_, err := ResolveQuery(context.Background(), lexicalQuery(text), resolver)
+		_ = requireExpressionError(t, text, err)
+	})
+
+	t.Run("distinct dependencies", func(t *testing.T) {
+		query := lexicalQuery(`tag:overflow`)
+		for index := range 64 {
+			query.Filters.TagIDs = append(query.Filters.TagIDs, boundedUUID(index, 1))
+			query.Filters.ExcludeTagIDs = append(query.Filters.ExcludeTagIDs, boundedUUID(index+64, 2))
+			query.Filters.CollectionIDs = append(query.Filters.CollectionIDs, boundedUUID(index+128, 3))
+			query.Filters.ExcludeCollectionIDs = append(query.Filters.ExcludeCollectionIDs, boundedUUID(index+192, 4))
+		}
+		resolver := resolverFunc(func(_ context.Context, kind ReferenceKind, key string, byID bool) (Reference, error) {
+			if !byID {
+				return Reference{Dependency: Dependency{Kind: kind, ID: tagID, Revision: 1}}, nil
+			}
+			return Reference{Dependency: Dependency{Kind: kind, ID: key, Revision: 1}}, nil
+		})
+		_, err := ResolveQuery(context.Background(), query, resolver)
+		_ = requireExpressionError(t, query.Text, err)
+	})
+}
+
+func lexicalQuery(text string) Query {
+	return Query{V: 1, Text: text, Syntax: "advanced", Mode: "lexical", Sort: Sort{Field: "name", Direction: "asc"}}
+}
+
+func queryWithExcludedCollection(text, id string) Query {
+	query := lexicalQuery(text)
+	query.Filters.ExcludeCollectionIDs = []string{id}
+	return query
+}
+
+func boundedUUID(index, group int) string {
+	return fmt.Sprintf("%08x-%04x-4000-8000-%012x", index+1, group, index+1)
+}

--- a/internal/query/testdata/identity-vectors.json
+++ b/internal/query/testdata/identity-vectors.json
@@ -104,6 +104,10 @@
     "oversized_highlight_astral_scalars": 254
   },
   "media_cases": [
+    {"name": "bare_dotfile_generic_mime", "media_type": "application/octet-stream", "filename": ".pdf", "family": "unknown"},
+    {"name": "bare_dotfile_missing_mime", "media_type": "", "filename": ".PDF", "family": "unknown"},
+    {"name": "hidden_file_with_extension", "media_type": "application/octet-stream", "filename": ".report.PDF", "family": "document"},
+    {"name": "bare_dotfile_declared_mime", "media_type": "application/pdf", "filename": ".pdf", "family": "document"},
     {"name": "extended_parameter", "media_type": "image/png; name*=utf-8''synthetic.png", "filename": "message.eml", "family": "image"},
     {"name": "apostrophe_parameter_value", "media_type": "image/png; name=a'b", "filename": "message.eml", "family": "image"},
     {"name": "wildcard_is_not_concrete", "media_type": "image/*", "filename": "scan.png", "family": "unknown"},

--- a/internal/query/timestamp.go
+++ b/internal/query/timestamp.go
@@ -1,0 +1,11 @@
+package query
+
+// TimestampKey returns an exact, fixed-width UTC key for SQL time comparisons.
+// It uses the same strict timestamp rules as QueryV1 filters.
+func TimestampKey(value string) (string, error) {
+	parsed, err := parseTimestamp(value, "query timestamp")
+	if err != nil {
+		return "", err
+	}
+	return parsed.Format("2006-01-02T15:04:05.000000000Z"), nil
+}

--- a/internal/query/timestamp_test.go
+++ b/internal/query/timestamp_test.go
@@ -1,0 +1,22 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Variable-width fractions and zone offsets must not reverse time ordering.
+func TestTimestampKeyPreservesNanosecondOrdering(t *testing.T) {
+	for _, test := range []struct{ input, want string }{
+		{"2026-01-02T03:04:05Z", "2026-01-02T03:04:05.000000000Z"},
+		{"2026-01-02T03:04:05.000000001Z", "2026-01-02T03:04:05.000000001Z"},
+		{"2026-01-02T04:04:05.1+01:00", "2026-01-02T03:04:05.100000000Z"},
+	} {
+		got, err := TimestampKey(test.input)
+		require.NoError(t, err)
+		require.Equal(t, test.want, got)
+	}
+	_, err := TimestampKey("not-a-time")
+	require.Error(t, err)
+}

--- a/internal/store/query_compile.go
+++ b/internal/store/query_compile.go
@@ -1,0 +1,487 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/docbank/internal/query"
+)
+
+const (
+	maxCompiledQuerySQL  = 256 << 10
+	maxCompiledQueryArgs = 4096
+	compiledNameField    = "name"
+)
+
+type compiledGenerationArgument struct{}
+
+type compiledQueryFragment struct {
+	sql  string
+	args []any
+}
+
+// CompiledQuery is one resolved QueryV1 value compiled into an internal,
+// parameterized document-membership predicate.
+type CompiledQuery struct {
+	Query        query.Query
+	Dependencies []query.Dependency
+
+	predicate compiledQueryFragment
+}
+
+// compileQuery resolves references and compiles one bounded query without
+// selecting a lexical generation or accessing SQLite.
+func compileQuery(
+	ctx context.Context, value query.Query, resolver query.Resolver,
+) (CompiledQuery, error) {
+	resolved, err := query.ResolveQuery(ctx, value, resolver)
+	if err != nil {
+		return CompiledQuery{}, err
+	}
+	predicate, err := compileResolvedQuery(resolved)
+	if err != nil {
+		return CompiledQuery{}, err
+	}
+	compiled := CompiledQuery{
+		Query: resolved.Query, Dependencies: resolved.Dependencies,
+		predicate: predicate,
+	}
+	if _, _, err := compiled.Bind(""); err != nil {
+		return CompiledQuery{}, err
+	}
+	return compiled, nil
+}
+
+func compileResolvedQuery(resolved query.ResolvedQuery) (compiledQueryFragment, error) {
+	if resolved.Query.Sort.Field == "relevance" {
+		return compiledQueryFragment{},
+			compileExpressionError(0, len(resolved.Query.Text), "relevance sort is not supported by bound queries")
+	}
+	if len(resolved.Query.Filters.TextCoverage) != 0 {
+		return compiledQueryFragment{},
+			compileExpressionError(0, len(resolved.Query.Text), "text_coverage is not supported by bound queries")
+	}
+	if resolved.Query.Filters.HasDuplicates {
+		return compiledQueryFragment{},
+			compileExpressionError(0, len(resolved.Query.Text), "has_duplicates is not supported by bound queries")
+	}
+	if resolved.Query.Filters.CollapseDuplicates {
+		return compiledQueryFragment{},
+			compileExpressionError(0, len(resolved.Query.Text), "duplicate collapsing is not supported by bound queries")
+	}
+
+	var expression compiledQueryFragment
+	var err error
+	if resolved.Query.Syntax == "simple" {
+		fts := ftsQuery(resolved.Query.Text)
+		if fts == "" {
+			expression = trueCompiledFragment()
+		} else {
+			expression = compileLexicalPredicate(fts, true)
+		}
+	} else {
+		expression, err = compileResolvedExpression(resolved.Expression, "")
+		if err != nil {
+			return compiledQueryFragment{}, err
+		}
+	}
+	filters, err := compileQueryFilters(resolved.Query.Filters, 0, len(resolved.Query.Text))
+	if err != nil {
+		return compiledQueryFragment{}, err
+	}
+	return joinCompiledFragments([]compiledQueryFragment{expression, filters}, ` AND `), nil
+}
+
+// Bind renders the predicate for one caller-selected lexical generation.
+func (compiled CompiledQuery) Bind(generationID string) (string, []any, error) {
+	predicate := joinCompiledFragments([]compiledQueryFragment{{
+		sql: `n.kind='file' AND n.trashed_at IS NULL AND cv.node_id=n.id AND cv.version_id=n.current_version_id`,
+	}, compiled.predicate}, ` AND `)
+	args := make([]any, len(predicate.args))
+	for index, arg := range predicate.args {
+		if _, marker := arg.(compiledGenerationArgument); marker {
+			args[index] = generationID
+		} else {
+			args[index] = arg
+		}
+	}
+	if len(predicate.sql) > maxCompiledQuerySQL || len(args) > maxCompiledQueryArgs {
+		return "", nil, compileExpressionError(
+			0, len(compiled.Query.Text), "compiled query exceeds 256 KiB or 4096 arguments",
+		)
+	}
+	return predicate.sql, args, nil
+}
+
+func compileResolvedExpression(expression *query.ResolvedExpression, field string) (compiledQueryFragment, error) {
+	if expression == nil || expression.Syntax == nil {
+		return compiledQueryFragment{}, errors.New("resolved query contains an empty expression")
+	}
+	syntax := expression.Syntax
+	switch syntax.Kind {
+	case query.ExpressionAll:
+		if field != "" {
+			return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, "field operand cannot be empty")
+		}
+		return trueCompiledFragment(), nil
+	case query.ExpressionField:
+		if len(expression.Children) != 1 {
+			return compiledQueryFragment{}, errors.New("resolved field expression has invalid children")
+		}
+		return compileResolvedExpression(expression.Children[0], syntax.Field)
+	case query.ExpressionAnd, query.ExpressionOr:
+		parts, err := compileAssociativeChildren(expression, field, syntax.Kind)
+		if err != nil {
+			return compiledQueryFragment{}, err
+		}
+		operator := ` AND `
+		if syntax.Kind == query.ExpressionOr {
+			operator = ` OR `
+		}
+		return joinCompiledFragments(parts, operator), nil
+	case query.ExpressionNot:
+		if len(expression.Children) != 1 {
+			return compiledQueryFragment{}, errors.New("resolved NOT expression has invalid children")
+		}
+		child, err := compileResolvedExpression(expression.Children[0], field)
+		if err != nil {
+			return compiledQueryFragment{}, err
+		}
+		return compiledQueryFragment{sql: `NOT (` + child.sql + `)`, args: child.args}, nil
+	case query.ExpressionNear:
+		return compileNearExpression(expression, field)
+	case query.ExpressionTerm, query.ExpressionPhrase:
+		return compileExpressionLeaf(expression, field)
+	default:
+		return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, "unsupported expression operand")
+	}
+}
+
+func compileAssociativeChildren(
+	expression *query.ResolvedExpression, field string, kind query.ExpressionKind,
+) ([]compiledQueryFragment, error) {
+	var parts []compiledQueryFragment
+	for _, child := range expression.Children {
+		if child.Syntax.Kind == kind {
+			nested, err := compileAssociativeChildren(child, field, kind)
+			if err != nil {
+				return nil, err
+			}
+			parts = append(parts, nested...)
+			continue
+		}
+		part, err := compileResolvedExpression(child, field)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, part)
+	}
+	return parts, nil
+}
+
+func compileExpressionLeaf(expression *query.ResolvedExpression, field string) (compiledQueryFragment, error) {
+	syntax := expression.Syntax
+	if syntax.Value == "" {
+		return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, "field operand cannot be empty")
+	}
+	switch field {
+	case "":
+		return compileLexicalPredicate(quoteFTSOperand(syntax.Value, syntax.Prefix), true), nil
+	case compiledNameField:
+		return compileLexicalPredicate(quoteFTSOperand(syntax.Value, syntax.Prefix), false), nil
+	case "path":
+		if syntax.Prefix {
+			return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, "path operands cannot use prefix matching")
+		}
+		if err := query.ValidateTextOperand(field, syntax.Value); err != nil {
+			return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, err.Error())
+		}
+		return compilePathPredicate(syntax.Value), nil
+	case "tag":
+		if expression.Dependency == nil {
+			return compiledQueryFragment{}, errors.New("resolved tag operand lacks a dependency")
+		}
+		return compileTagPredicate(expression.Dependency.ID), nil
+	case "collection":
+		if expression.Dependency == nil {
+			return compiledQueryFragment{}, errors.New("resolved collection operand lacks a dependency")
+		}
+		return compileCollectionPredicate(expression.Dependency.ID), nil
+	case "saved":
+		if expression.Saved == nil {
+			return compiledQueryFragment{}, errors.New("resolved saved operand lacks its query")
+		}
+		return compileSavedPredicate(expression)
+	case "mime", "extension", "media_family", "modified_after", "modified_before", "size_min", "size_max":
+		if syntax.Prefix {
+			return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, "scalar operands cannot use prefix matching")
+		}
+		return compileScalarPredicate(field, syntax.Value, syntax.Start, syntax.End)
+	case "text_coverage", "has_duplicates":
+		return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, field+" fields are not supported by bound queries")
+	default:
+		return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, "unsupported expression field")
+	}
+}
+
+func compileNearExpression(expression *query.ResolvedExpression, field string) (compiledQueryFragment, error) {
+	syntax := expression.Syntax
+	if field != "" && field != compiledNameField {
+		return compiledQueryFragment{}, compileExpressionError(syntax.Start, syntax.End, "NEAR is supported only for text and name operands")
+	}
+	if len(expression.Children) != 2 {
+		return compiledQueryFragment{}, errors.New("resolved NEAR expression has invalid children")
+	}
+	operands := make([]string, 2)
+	for index, child := range expression.Children {
+		kind := child.Syntax.Kind
+		if kind != query.ExpressionTerm && kind != query.ExpressionPhrase || child.Syntax.Value == "" {
+			return compiledQueryFragment{}, compileExpressionError(
+				child.Syntax.Start, child.Syntax.End, "NEAR requires two direct term or phrase operands",
+			)
+		}
+		operands[index] = quoteFTSOperand(child.Syntax.Value, child.Syntax.Prefix)
+	}
+	fts := `NEAR(` + operands[0] + ` ` + operands[1] + `,` + strconv.Itoa(syntax.Distance) + `)`
+	return compileLexicalPredicate(fts, field == ""), nil
+}
+
+func compileSavedPredicate(expression *query.ResolvedExpression) (compiledQueryFragment, error) {
+	nested, err := compileResolvedQuery(*expression.Saved)
+	if err != nil {
+		if expressionErr, ok := errors.AsType[*query.ExpressionError](err); ok {
+			return compiledQueryFragment{}, compileExpressionError(
+				expression.Syntax.Start, expression.Syntax.End, expressionErr.Message,
+			)
+		}
+		return compiledQueryFragment{}, err
+	}
+	return nested, nil
+}
+
+func compileScalarPredicate(field, value string, start, end int) (compiledQueryFragment, error) {
+	switch field {
+	case "mime", "extension", "media_family":
+		if err := query.ValidateTextOperand(field, value); err != nil {
+			return compiledQueryFragment{}, compileExpressionError(start, end, err.Error())
+		}
+		switch field {
+		case "mime":
+			return compileMIMEPredicate(value), nil
+		case "extension":
+			return compileExtensionPredicate(value), nil
+		default:
+			return compileMediaFamilyPredicate(value), nil
+		}
+	case "modified_after", "modified_before":
+		key, err := query.TimestampKey(value)
+		if err != nil {
+			return compiledQueryFragment{}, compileExpressionError(start, end, err.Error())
+		}
+		operator := `>=`
+		if field == "modified_before" {
+			operator = `<`
+		}
+		return compiledQueryFragment{
+			sql: `n.modified_at ` + operator + ` ?`, args: []any{key},
+		}, nil
+	case "size_min", "size_max":
+		bound, err := query.ParseSizeOperand(value)
+		if err != nil {
+			return compiledQueryFragment{}, compileExpressionError(start, end, err.Error())
+		}
+		return compileSizePredicate(field, bound), nil
+	default:
+		return compiledQueryFragment{}, compileExpressionError(start, end, "unsupported scalar field")
+	}
+}
+
+func compileQueryFilters(filters query.Filters, start, end int) (compiledQueryFragment, error) {
+	parts := []compiledQueryFragment{
+		compileValuePredicates(filters.Paths, compilePathPredicate),
+		negateCompiledFragment(compileValuePredicates(filters.ExcludePaths, compilePathPredicate)),
+		compileValuePredicates(filters.CollectionIDs, compileCollectionPredicate),
+		negateCompiledFragment(compileValuePredicates(filters.ExcludeCollectionIDs, compileCollectionPredicate)),
+		compileValuePredicates(filters.TagIDs, compileTagPredicate),
+		negateCompiledFragment(compileValuePredicates(filters.ExcludeTagIDs, compileTagPredicate)),
+	}
+	if filters.NoTags {
+		parts = append(parts, compiledQueryFragment{sql: `NOT EXISTS (SELECT 1 FROM node_tags nt WHERE nt.node_id=n.id)`})
+	}
+	parts = append(parts,
+		compileValuePredicates(filters.MediaFamilies, compileMediaFamilyPredicate),
+		compileValuePredicates(filters.MIMETypes, compileMIMEPredicate),
+		compileValuePredicates(filters.Extensions, compileExtensionPredicate),
+	)
+	for _, bound := range []struct{ field, value string }{
+		{"modified_after", filters.ModifiedAfter},
+		{"modified_before", filters.ModifiedBefore},
+	} {
+		if bound.value == "" {
+			continue
+		}
+		part, err := compileScalarPredicate(bound.field, bound.value, start, end)
+		if err != nil {
+			return compiledQueryFragment{}, err
+		}
+		parts = append(parts, part)
+	}
+	if filters.SizeMin > 0 {
+		parts = append(parts, compileSizePredicate("size_min", filters.SizeMin))
+	}
+	if filters.SizeMax != nil {
+		parts = append(parts, compileSizePredicate("size_max", *filters.SizeMax))
+	}
+	return joinCompiledFragments(parts, ` AND `), nil
+}
+
+func compileSizePredicate(field string, bound int64) compiledQueryFragment {
+	operator := `>=`
+	if field == "size_max" {
+		operator = `<=`
+	}
+	return compiledQueryFragment{sql: `cv.size ` + operator + ` ?`, args: []any{bound}}
+}
+
+func compileValuePredicates(
+	values []string, compile func(string) compiledQueryFragment,
+) compiledQueryFragment {
+	parts := make([]compiledQueryFragment, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, compile(value))
+	}
+	return joinCompiledFragments(parts, ` OR `)
+}
+
+func compilePathPredicate(path string) compiledQueryFragment {
+	if path == "/" {
+		return trueCompiledFragment()
+	}
+	return compiledQueryFragment{
+		sql: `EXISTS (
+			WITH RECURSIVE query_ancestry(id,parent_id,path) AS (
+				SELECT n.id,n.parent_id,n.name
+				UNION ALL
+				SELECT parent.id,parent.parent_id,
+					CASE WHEN parent.parent_id IS NULL THEN '/' || child.path
+					ELSE parent.name || '/' || child.path END
+				FROM nodes parent JOIN query_ancestry child ON parent.id=child.parent_id
+				WHERE parent.trashed_at IS NULL
+			)
+			SELECT 1 FROM query_ancestry
+			WHERE parent_id IS NULL
+			  AND (path=? OR substr(path,1,length(?)+1)=? || '/')
+		)`,
+		args: []any{path, path, path},
+	}
+}
+
+func compileTagPredicate(id string) compiledQueryFragment {
+	return compiledQueryFragment{
+		sql:  `EXISTS (SELECT 1 FROM node_tags nt WHERE nt.node_id=n.id AND nt.tag_id=?)`,
+		args: []any{id},
+	}
+}
+
+func compileCollectionPredicate(id string) compiledQueryFragment {
+	return compiledQueryFragment{
+		sql: `EXISTS (WITH ` + CollectionMembershipCTE + `
+			SELECT 1 FROM collection_members cm WHERE cm.node_id=n.id AND cm.ingest_id=?)`,
+		args: []any{id},
+	}
+}
+
+func compileMIMEPredicate(value string) compiledQueryFragment {
+	return compiledQueryFragment{
+		sql: `lower(trim(CASE WHEN instr(cv.mime_type,';')=0 THEN cv.mime_type
+			ELSE substr(cv.mime_type,1,instr(cv.mime_type,';')-1) END))=?`,
+		args: []any{value},
+	}
+}
+
+func compileExtensionPredicate(value string) compiledQueryFragment {
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(value)
+	// Require a basename before the extension dot: .pdf has no extension.
+	return compiledQueryFragment{
+		sql: `lower(n.name) LIKE ? ESCAPE '\'`, args: []any{`_%.` + escaped},
+	}
+}
+
+func compileMediaFamilyPredicate(value string) compiledQueryFragment {
+	return compiledQueryFragment{
+		sql: `docbank_query_media_family_v1(COALESCE(cv.mime_type,''),n.name)=?`, args: []any{value},
+	}
+}
+
+func compileLexicalPredicate(fts string, includeContent bool) compiledQueryFragment {
+	name := compiledQueryFragment{
+		sql: `n.id IN (SELECT rowid FROM nodes_fts WHERE nodes_fts MATCH ?)`, args: []any{fts},
+	}
+	if !includeContent {
+		return name
+	}
+	marker := compiledGenerationArgument{}
+	content := compiledQueryFragment{
+		sql: `(
+			(?='' AND EXISTS (
+				SELECT 1 FROM content_fts
+				JOIN text_searchable_versions tsv ON tsv.version_id=cv.version_id
+				WHERE content_fts.blob_hash=cv.blob_hash AND content_fts MATCH ?
+			))
+			OR (?<>'' AND EXISTS (
+				SELECT 1 FROM rendition_lexical_fts
+				JOIN rendition_attachments a ON a.build_id=rendition_lexical_fts.build_id
+				JOIN rendition_heads rh
+				  ON rh.content_version_id=a.content_version_id
+				 AND rh.profile_fingerprint=a.profile_fingerprint
+				 AND rh.attachment_id=a.attachment_id
+				WHERE a.content_version_id=cv.version_id
+				  AND rendition_lexical_fts MATCH ?
+				  AND EXISTS (
+					SELECT 1 FROM rendition_lexical_generation_builds gb
+					WHERE gb.generation_id=? AND gb.build_id=rendition_lexical_fts.build_id
+				  )
+			))
+		)`,
+		args: []any{marker, fts, marker, fts, marker},
+	}
+	return joinCompiledFragments([]compiledQueryFragment{name, content}, ` OR `)
+}
+
+func quoteFTSOperand(value string, prefix bool) string {
+	quoted := `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+	if prefix {
+		quoted += `*`
+	}
+	return quoted
+}
+
+func negateCompiledFragment(fragment compiledQueryFragment) compiledQueryFragment {
+	if fragment.sql == "" {
+		return compiledQueryFragment{}
+	}
+	return compiledQueryFragment{sql: `NOT (` + fragment.sql + `)`, args: fragment.args}
+}
+
+func trueCompiledFragment() compiledQueryFragment {
+	return compiledQueryFragment{sql: `1`}
+}
+
+func joinCompiledFragments(parts []compiledQueryFragment, operator string) compiledQueryFragment {
+	var sqlParts []string
+	var args []any
+	for _, part := range parts {
+		if part.sql == "" {
+			continue
+		}
+		sqlParts = append(sqlParts, `(`+part.sql+`)`)
+		args = append(args, part.args...)
+	}
+	return compiledQueryFragment{sql: strings.Join(sqlParts, operator), args: args}
+}
+
+func compileExpressionError(start, end int, message string) *query.ExpressionError {
+	return &query.ExpressionError{Offset: start, End: end, Message: message}
+}

--- a/internal/store/query_compile_integration_test.go
+++ b/internal/store/query_compile_integration_test.go
@@ -1,0 +1,196 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/query"
+)
+
+func compileFixtureQuery(t *testing.T, s *Store, text string, filters query.Filters) CompiledQuery {
+	t.Helper()
+	value, err := query.Parse([]byte(`{"syntax":"advanced"}`))
+	require.NoError(t, err)
+	value.Text, value.Filters = text, filters
+	compiled, err := compileQuery(t.Context(), value, queryResolver{q: s.db})
+	require.NoError(t, err)
+	return compiled
+}
+
+func compiledFixtureIDs(t *testing.T, q metadataQuerier, compiled CompiledQuery, generation string) []int64 {
+	t.Helper()
+	predicate, args, err := compiled.Bind(generation)
+	require.NoError(t, err)
+	rows, err := q.QueryContext(t.Context(), `SELECT n.id FROM `+nodeFrom+` WHERE `+predicate+` ORDER BY n.id`, args...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	ids := []int64{}
+	for rows.Next() {
+		var id int64
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+	return ids
+}
+
+// Hoisting saved facets or flattening a mixed-field OR changes these members.
+func TestCompiledQuerySQLiteReferenceAndFacetScopes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	alpha, err := s.CreateFile(ctx, s.RootID(), "alpha.txt", fakeHash("a1"), 10, "text/plain")
+	require.NoError(t, err)
+	beta, err := s.CreateFile(ctx, s.RootID(), "beta.pdf", fakeHash("b2"), 20, "application/pdf")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, s.RootID(), "gamma.txt", fakeHash("c3"), 5, "text/plain")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(ctx, "urgent")
+	require.NoError(t, err)
+	_, err = s.AssignTag(ctx, tag.ID, beta.ID, beta.Revision)
+	require.NoError(t, err)
+	_, err = s.CreateSavedQuery(ctx, "Choice", "", SavedQueryKindQuery,
+		[]byte(`{"syntax":"advanced","text":"name:(alpha OR beta)","filters":{"size_max":15}}`))
+	require.NoError(t, err)
+	compiled := compileFixtureQuery(t, s, `saved:Choice OR tag:urgent`, query.Filters{MIMETypes: []string{"application/pdf"}})
+	require.Equal(t, []int64{beta.ID}, compiledFixtureIDs(t, s.db, compiled, ""))
+	compiled = compileFixtureQuery(t, s, `saved:Choice OR tag:urgent`, query.Filters{})
+	require.Equal(t, []int64{alpha.ID, beta.ID}, compiledFixtureIDs(t, s.db, compiled, ""))
+	compiled = compileFixtureQuery(t, s, `saved:Choice`, query.Filters{SizeMin: 11})
+	require.Empty(t, compiledFixtureIDs(t, s.db, compiled, ""))
+	compiled = compileFixtureQuery(t, s, `saved:Choice`, query.Filters{})
+	require.Equal(t, []int64{alpha.ID}, compiledFixtureIDs(t, s.db, compiled, ""))
+	compiled = compileFixtureQuery(t, s, `name:alpha OR NOT tag:urgent`, query.Filters{})
+	require.Len(t, compiledFixtureIDs(t, s.db, compiled, ""), 2)
+}
+
+func TestCompiledQuerySQLiteCollectionUnionDeduplicatesMembership(t *testing.T) {
+	s := newTestStore(t)
+	first := createCollectionRun(t, s, "first.txt", "a1")
+	second := createCollectionRun(t, s, "second.txt", "b2")
+	node, err := s.NodeByPath(t.Context(), "/first.txt")
+	require.NoError(t, err)
+	addCollectionMembership(t, s, second, node.ID, "/synthetic/other/first.txt", nil)
+	addCollectionMembership(t, s, first, node.ID, "/synthetic/duplicate/first.txt", nil)
+	_, err = s.SetCollectionLabel(t.Context(), first.ID(), 1, new("First"))
+	require.NoError(t, err)
+	_, err = s.SetCollectionLabel(t.Context(), second.ID(), 1, new("Second"))
+	require.NoError(t, err)
+	compiled := compileFixtureQuery(t, s, `collection:(First OR Second)`, query.Filters{})
+	require.Len(t, compiledFixtureIDs(t, s.db, compiled, ""), 2)
+	compiled = compileFixtureQuery(t, s, `collection:First`, query.Filters{ExcludeCollectionIDs: []string{second.ID()}})
+	require.Empty(t, compiledFixtureIDs(t, s.db, compiled, ""))
+	compiled = compileFixtureQuery(t, s, `collection:First`, query.Filters{})
+	require.Equal(t, []int64{node.ID}, compiledFixtureIDs(t, s.db, compiled, ""))
+}
+
+// Match paths at a separator boundary and compare fractional times exactly.
+func TestCompiledQuerySQLitePathMediaAndTime(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	dir, err := s.Mkdir(ctx, s.RootID(), "case_1")
+	require.NoError(t, err)
+	otherDir, err := s.Mkdir(ctx, s.RootID(), "caseX1")
+	require.NoError(t, err)
+	inside, err := s.CreateFile(ctx, dir.ID, "REPORT.PDF", fakeHash("d4"), 10, "application/octet-stream")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, otherDir.ID, "REPORT.PDF", fakeHash("e5"), 10, "application/pdf")
+	require.NoError(t, err)
+	_, err = s.db.ExecContext(ctx, `UPDATE nodes SET modified_at=? WHERE id=?`, "2026-01-02T03:04:05.000000001Z", inside.ID)
+	require.NoError(t, err)
+	compiled := compileFixtureQuery(t, s, `path:/case_1 AND media_family:document AND extension:pdf`, query.Filters{
+		ModifiedAfter: "2026-01-02T04:04:05+01:00", ModifiedBefore: "2026-01-02T04:04:05.000000002+01:00",
+	})
+	require.Equal(t, []int64{inside.ID}, compiledFixtureIDs(t, s.db, compiled, ""))
+	compiled = compileFixtureQuery(t, s, `path:/case_1`, query.Filters{ModifiedBefore: "2026-01-02T03:04:05.000000001Z"})
+	require.Empty(t, compiledFixtureIDs(t, s.db, compiled, ""))
+	compiled = compileFixtureQuery(t, s, `path:/`, query.Filters{ExcludePaths: []string{"/case_1"}})
+	require.Len(t, compiledFixtureIDs(t, s.db, compiled, ""), 1)
+}
+
+func TestCompiledQuerySQLiteExtensionRequiresBasename(t *testing.T) {
+	s := newTestStore(t)
+	want := []int64{}
+	for _, name := range []string{".pdf", ".PDF", "README", "report.", "report.pdf", ".report.pdf", "REPORT.PDF"} {
+		node, err := s.CreateFile(t.Context(), s.RootID(), name, fakeHash("a1"), 10, "application/octet-stream")
+		require.NoError(t, err)
+		if name == "report.pdf" || name == ".report.pdf" || name == "REPORT.PDF" {
+			want = append(want, node.ID)
+		}
+	}
+	for _, testCase := range []struct {
+		name    string
+		text    string
+		filters query.Filters
+	}{
+		{name: "expression", text: "extension:pdf"},
+		{name: "filter", filters: query.Filters{Extensions: []string{"pdf"}}},
+		{name: "media family", text: "media_family:document"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			compiled := compileFixtureQuery(t, s, testCase.text, testCase.filters)
+			require.Equal(t, want, compiledFixtureIDs(t, s.db, compiled, ""))
+		})
+	}
+}
+
+func TestCompiledQuerySQLitePhrasesNearAndSimpleSourceSemantics(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	adjacent, err := s.CreateFile(ctx, s.RootID(), "alpha beta.txt", fakeHash("f6"), 10, "text/plain")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, s.RootID(), "alpha distant distant beta.txt", fakeHash("a7"), 10, "text/plain")
+	require.NoError(t, err)
+	seedCompiledLegacyText(t, s, adjacent, "gamma")
+	for _, text := range []string{`name:"alpha beta"`, `name:(alpha NEAR/0 beta)`, `name:alpha AND gamma`} {
+		compiled := compileFixtureQuery(t, s, text, query.Filters{})
+		require.Equal(t, []int64{adjacent.ID}, compiledFixtureIDs(t, s.db, compiled, ""), text)
+	}
+	value, err := query.Parse([]byte(`{"text":"alpha gamma"}`))
+	require.NoError(t, err)
+	compiled, err := compileQuery(ctx, value, queryResolver{q: s.db})
+	require.NoError(t, err)
+	require.Empty(t, compiledFixtureIDs(t, s.db, compiled, ""), "simple mode retains same-source implicit AND")
+	compiled = compileFixtureQuery(t, s, `name:"' OR 1=1 --"`, query.Filters{})
+	require.Empty(t, compiledFixtureIDs(t, s.db, compiled, ""), "entered text must remain an FTS value, never SQL")
+}
+
+func seedCompiledLegacyText(t *testing.T, s *Store, node Node, text string) {
+	t.Helper()
+	_, err := s.db.ExecContext(t.Context(), `INSERT INTO content_fts(blob_hash,extractor,text) VALUES(?,?,?)`, node.BlobHash, "synthetic-test", text)
+	require.NoError(t, err)
+	_, err = s.db.ExecContext(t.Context(), `INSERT OR IGNORE INTO text_searchable_versions(version_id) VALUES(?)`, node.CurrentVersionID)
+	require.NoError(t, err)
+}
+
+// A selected rendition generation makes the legacy cache non-serving, and
+// historical attachment text must not match a replacement current version.
+func TestCompiledQuerySQLiteCurrentRenditionGeneration(t *testing.T) {
+	s, versions := newRenditionCatalogFixture(t)
+	ctx := t.Context()
+	profile := catalogProcessingProfile(t, false)
+	build := lexicalSearchBuild(s, profile, catalogBuildID, "mercury phrase")
+	require.NoError(t, s.StageRenditionBuild(ctx, build))
+	generation, err := s.StageLexicalGeneration(ctx, fakeHash("a9"))
+	require.NoError(t, err)
+	attachment := RenditionAttachmentRecord{ID: catalogAttachmentFirst, VaultID: s.VaultID(),
+		ContentVersionID: versions[0], BuildID: build.ID, Profile: profile, AttachedAt: embeddingCatalogTime}
+	require.NoError(t, s.PublishRenditionAndLexicalHeads(ctx, attachment, RenditionHeadRecord{
+		ContentVersionID: versions[0], ProcessingProfileFingerprint: profile.Fingerprint,
+		AttachmentID: attachment.ID, PublishedAt: embeddingCatalogTime}, generation.ID))
+	legacy, err := s.CreateFile(ctx, s.RootID(), "legacy.txt", fakeHash("b8"), 10, "text/plain")
+	require.NoError(t, err)
+	seedCompiledLegacyText(t, s, legacy, "mercury phrase")
+	node, err := s.NodeByPath(ctx, "/synthetic-source-a.pdf")
+	require.NoError(t, err)
+	compiled := compileFixtureQuery(t, s, `"mercury phrase"`, query.Filters{})
+	require.NoError(t, s.withLexicalGenerationRead(ctx, func(q metadataQuerier, selected LexicalGeneration) error {
+		require.Equal(t, []int64{node.ID}, compiledFixtureIDs(t, q, compiled, selected.ID))
+		return nil
+	}))
+	_, _, err = s.ReplaceContent(ctx, node.ID, node.Revision, fakeHash("c8"), 11, "application/pdf")
+	require.NoError(t, err)
+	require.NoError(t, s.withLexicalGenerationRead(ctx, func(q metadataQuerier, selected LexicalGeneration) error {
+		require.Empty(t, compiledFixtureIDs(t, q, compiled, selected.ID))
+		return nil
+	}))
+}

--- a/internal/store/query_compile_test.go
+++ b/internal/store/query_compile_test.go
@@ -1,0 +1,297 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/query"
+)
+
+const (
+	compilerTagID        = "11111111-1111-4111-8111-111111111111"
+	compilerCollectionID = "22222222-2222-4222-8222-222222222222"
+	compilerSavedID      = "33333333-3333-4333-8333-333333333333"
+	compilerOtherTagID   = "44444444-4444-4444-8444-444444444444"
+	compilerOtherCollID  = "55555555-5555-4555-8555-555555555555"
+)
+
+type compilerResolverFunc func(context.Context, query.ReferenceKind, string, bool) (query.Reference, error)
+
+func (fn compilerResolverFunc) Resolve(
+	ctx context.Context, kind query.ReferenceKind, key string, byID bool,
+) (query.Reference, error) {
+	return fn(ctx, kind, key, byID)
+}
+
+func compilerQuery(t *testing.T, text string) query.Query {
+	t.Helper()
+	value, err := query.Parse([]byte(`{"syntax":"advanced"}`))
+	require.NoError(t, err)
+	value.Text = text
+	return value
+}
+
+func TestCompileQueryPreservesNormalizedQueryAndDependencies(t *testing.T) {
+	value := compilerQuery(t, `tag:urgent AND "alpha beta"*`)
+	compiled, err := compileQuery(t.Context(), value, compilerResolverFunc(func(
+		_ context.Context, kind query.ReferenceKind, key string, byID bool,
+	) (query.Reference, error) {
+		require.Equal(t, query.ReferenceTag, kind)
+		require.Equal(t, "urgent", key)
+		require.False(t, byID)
+		return query.Reference{Dependency: query.Dependency{
+			Kind: kind, ID: compilerTagID, Revision: 7,
+		}}, nil
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, value, compiled.Query)
+	assert.Equal(t, []query.Dependency{{
+		Kind: query.ReferenceTag, ID: compilerTagID, Revision: 7,
+	}}, compiled.Dependencies)
+	predicate, args, err := compiled.Bind("")
+	require.NoError(t, err)
+	assert.NotEmpty(t, predicate)
+	assert.Contains(t, args, compilerTagID)
+	assert.Contains(t, args, `"alpha beta"*`)
+}
+
+func TestCompiledQueryBindsSimpleAndAdvancedLexicalPredicates(t *testing.T) {
+	t.Run("simple is one same-source FTS expression", func(t *testing.T) {
+		value, err := query.Parse([]byte(`{"text":"alpha  beta"}`))
+		require.NoError(t, err)
+		compiled, err := compileQuery(t.Context(), value, nil)
+		require.NoError(t, err)
+		_, args, err := compiled.Bind("")
+		require.NoError(t, err)
+		assert.Equal(t, 3, countArgument(args, `"alpha"* "beta"*`))
+		assert.Zero(t, countArgument(args, `"alpha"*`))
+	})
+
+	t.Run("advanced preserves source scope and quotes FTS values", func(t *testing.T) {
+		value := compilerQuery(t, `name:"a\"b"* OR (alpha NEAR/4 beta)`)
+		compiled, err := compileQuery(t.Context(), value, nil)
+		require.NoError(t, err)
+		sql, args, err := compiled.Bind("generation-a")
+		require.NoError(t, err)
+		assert.NotContains(t, sql, `a"b`)
+		assert.Contains(t, args, `"a""b"*`)
+		assert.Contains(t, args, `NEAR("alpha" "beta",4)`)
+		assert.Contains(t, args, "generation-a")
+		assert.Contains(t, sql, "content_fts")
+		assert.Contains(t, sql, "rendition_lexical_fts")
+	})
+}
+
+func TestCompiledQueryBindClonesGenerationArguments(t *testing.T) {
+	compiled, err := compileQuery(t.Context(), compilerQuery(t, "alpha"), nil)
+	require.NoError(t, err)
+	_, first, err := compiled.Bind("generation-a")
+	require.NoError(t, err)
+	_, second, err := compiled.Bind("generation-b")
+	require.NoError(t, err)
+	assert.Contains(t, first, "generation-a")
+	assert.NotContains(t, first, "generation-b")
+	assert.Contains(t, second, "generation-b")
+	assert.NotContains(t, second, "generation-a")
+}
+
+func TestCompileQuerySupportsEveryBoundExpressionField(t *testing.T) {
+	resolver := compilerResolver(nil)
+	tests := []struct {
+		name string
+		text string
+		want any
+	}{
+		{name: "name", text: `name:"alpha beta"*`, want: `"alpha beta"*`},
+		{name: "path", text: `path:/case_1`, want: "/case_1"},
+		{name: "tag", text: `tag:urgent`, want: compilerTagID},
+		{name: "collection", text: `collection:batch`, want: compilerCollectionID},
+		{name: "mime", text: `mime:application/pdf`, want: "application/pdf"},
+		{name: "extension", text: `extension:tar_gz`, want: `_%.tar\_gz`},
+		{name: "media family", text: `media_family:document`, want: "document"},
+		{name: "modified after", text: `modified_after:"2026-01-02T03:04:05.1+02:00"`, want: "2026-01-02T01:04:05.100000000Z"},
+		{name: "modified before", text: `modified_before:"2026-01-02T03:04:05.000000002Z"`, want: "2026-01-02T03:04:05.000000002Z"},
+		{name: "size min", text: `size_min:0`, want: int64(0)},
+		{name: "size max", text: `size_max:9007199254740991`, want: int64(9007199254740991)},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			compiled, err := compileQuery(t.Context(), compilerQuery(t, testCase.text), resolver)
+			require.NoError(t, err)
+			sql, args, err := compiled.Bind("")
+			require.NoError(t, err)
+			assert.Contains(t, args, testCase.want)
+			if text, ok := testCase.want.(string); ok && text != `_%.tar\_gz` {
+				assert.NotContains(t, sql, text)
+			}
+		})
+	}
+}
+
+func TestCompileQueryRetainsInheritedFieldScopeAcrossBooleanChildren(t *testing.T) {
+	compiled, err := compileQuery(t.Context(), compilerQuery(t,
+		`mime:(application/pdf OR image/png) AND NOT path:/archive`), nil)
+	require.NoError(t, err)
+	_, args, err := compiled.Bind("")
+	require.NoError(t, err)
+	assert.Contains(t, args, "application/pdf")
+	assert.Contains(t, args, "image/png")
+	assert.Contains(t, args, "/archive")
+}
+
+func TestCompiledQueryBindsFacetUnionsAndExclusions(t *testing.T) {
+	maxSize := int64(23)
+	value := compilerQuery(t, "")
+	value.Filters = query.Filters{
+		Paths: []string{"/a", "/b"}, ExcludePaths: []string{"/c"},
+		CollectionIDs: []string{compilerCollectionID}, ExcludeCollectionIDs: []string{compilerOtherCollID},
+		TagIDs: []string{compilerTagID}, ExcludeTagIDs: []string{compilerOtherTagID}, NoTags: true,
+		MediaFamilies: []string{"document", "image"}, MIMETypes: []string{"application/pdf", "image/png"},
+		Extensions: []string{"pdf", "tar_gz"}, ModifiedAfter: "2026-01-02T03:04:05Z",
+		ModifiedBefore: "2026-01-03T03:04:05Z", SizeMin: 1, SizeMax: &maxSize,
+	}
+	// no_tags cannot coexist with an inclusion list, so exercise it separately.
+	value.Filters.NoTags = false
+	compiled, err := compileQuery(t.Context(), value, compilerResolver(nil))
+	require.NoError(t, err)
+	_, args, err := compiled.Bind("")
+	require.NoError(t, err)
+	for _, expected := range []any{
+		"/a", "/b", "/c", compilerCollectionID, compilerOtherCollID,
+		compilerTagID, compilerOtherTagID, "document", "image", "application/pdf", "image/png",
+		`_%.pdf`, `_%.tar\_gz`, "2026-01-02T03:04:05.000000000Z",
+		"2026-01-03T03:04:05.000000000Z", int64(1), maxSize,
+	} {
+		assert.Contains(t, args, expected)
+	}
+
+	value.Filters.TagIDs = nil
+	value.Filters.NoTags = true
+	compiled, err = compileQuery(t.Context(), value, compilerResolver(nil))
+	require.NoError(t, err)
+	sql, _, err := compiled.Bind("")
+	require.NoError(t, err)
+	assert.Contains(t, sql, "NOT EXISTS (SELECT 1 FROM node_tags")
+}
+
+func TestCompileQueryRejectsUnsupportedFeaturesAndMalformedFieldOperands(t *testing.T) {
+	rootUnsupported := []query.Query{
+		func() query.Query { q := compilerQuery(t, ""); q.Filters.TextCoverage = []string{"complete"}; return q }(),
+		func() query.Query { q := compilerQuery(t, ""); q.Filters.HasDuplicates = true; return q }(),
+		func() query.Query { q := compilerQuery(t, ""); q.Filters.CollapseDuplicates = true; return q }(),
+		func() query.Query { q := compilerQuery(t, ""); q.Sort.Field = "relevance"; return q }(),
+		func() query.Query {
+			q := compilerQuery(t, "invalid canonical input")
+			q.Filters.Paths = []string{"relative"}
+			return q
+		}(),
+	}
+	for _, value := range rootUnsupported {
+		_, err := compileQuery(t.Context(), value, nil)
+		assertWholeExpressionError(t, value.Text, err)
+	}
+
+	for _, text := range []string{
+		`text_coverage:complete`, `has_duplicates:true`, `path:/alpha*`, `mime:not-a-mime`,
+		`extension:bad%`, `media_family:bogus`, `modified_after:not-a-time`, `size_min:-1`,
+		`size_max:9007199254740992`, `mime:""`, `alpha NEAR (beta OR gamma)`,
+		`modified_after:"2026-01-02T03:04:05+24:00"`,
+		`modified_before:"2026-01-02T03:04:05.0000000001Z"`,
+		`modified_after:"2026-01-02T03:04:05,1Z"`,
+		`size_min:9007199254740992`, `size_max:+1`, `size_min:1.5`,
+	} {
+		t.Run(text, func(t *testing.T) {
+			_, err := compileQuery(t.Context(), compilerQuery(t, text), nil)
+			var expressionErr *query.ExpressionError
+			require.ErrorAs(t, err, &expressionErr)
+			assert.GreaterOrEqual(t, expressionErr.Offset, 0)
+			assert.LessOrEqual(t, expressionErr.End, len(text))
+		})
+	}
+}
+
+func TestCompileQueryRemapsNestedSavedExpressionErrorsButPreservesBackendErrors(t *testing.T) {
+	nested := compilerQuery(t, `text_coverage:complete`)
+	text := `saved:inside`
+	_, err := compileQuery(t.Context(), compilerQuery(t, text), compilerResolver(&nested))
+	var expressionErr *query.ExpressionError
+	require.ErrorAs(t, err, &expressionErr)
+	assert.Equal(t, 6, expressionErr.Offset)
+	assert.Equal(t, len(text), expressionErr.End)
+
+	nested = compilerQuery(t, "alpha")
+	nested.Sort.Field = "relevance"
+	_, err = compileQuery(t.Context(), compilerQuery(t, text), compilerResolver(&nested))
+	require.ErrorAs(t, err, &expressionErr)
+	assert.Equal(t, 6, expressionErr.Offset)
+	assert.Equal(t, len(text), expressionErr.End)
+
+	backendErr := errors.New("resolver unavailable")
+	_, err = compileQuery(t.Context(), compilerQuery(t, `tag:urgent`), compilerResolverFunc(func(
+		context.Context, query.ReferenceKind, string, bool,
+	) (query.Reference, error) {
+		return query.Reference{}, backendErr
+	}))
+	require.ErrorIs(t, err, backendErr)
+	assert.NotErrorAs(t, err, &expressionErr)
+}
+
+func TestCompiledQueryNeverInterpolatesBoundValuesAndEnforcesLimits(t *testing.T) {
+	attack := `Robert'); DROP TABLE nodes; --`
+	compiled, err := compileQuery(t.Context(), compilerQuery(t, `name:"`+attack+`"`), nil)
+	require.NoError(t, err)
+	sql, args, err := compiled.Bind("generation-'attack")
+	require.NoError(t, err)
+	assert.NotContains(t, sql, attack)
+	assert.NotContains(t, sql, "generation-'attack")
+	assert.Contains(t, args, `"`+attack+`"`)
+
+	tooLarge := CompiledQuery{Query: compilerQuery(t, "bounded"), predicate: compiledQueryFragment{sql: strings.Repeat("x", maxCompiledQuerySQL)}}
+	_, _, err = tooLarge.Bind("")
+	assertWholeExpressionError(t, tooLarge.Query.Text, err)
+	tooMany := CompiledQuery{Query: compilerQuery(t, "bounded"), predicate: compiledQueryFragment{sql: "1", args: make([]any, maxCompiledQueryArgs+1)}}
+	_, _, err = tooMany.Bind("")
+	assertWholeExpressionError(t, tooMany.Query.Text, err)
+}
+
+func compilerResolver(saved *query.Query) compilerResolverFunc {
+	return func(_ context.Context, kind query.ReferenceKind, key string, byID bool) (query.Reference, error) {
+		ids := map[query.ReferenceKind]map[string]string{
+			query.ReferenceTag:        {"urgent": compilerTagID, compilerTagID: compilerTagID, compilerOtherTagID: compilerOtherTagID},
+			query.ReferenceCollection: {"batch": compilerCollectionID, compilerCollectionID: compilerCollectionID, compilerOtherCollID: compilerOtherCollID},
+			query.ReferenceSaved:      {"inside": compilerSavedID},
+		}
+		id := ids[kind][key]
+		if id == "" {
+			return query.Reference{}, query.ErrUnknownReference
+		}
+		ref := query.Reference{Dependency: query.Dependency{Kind: kind, ID: id, Revision: 1}}
+		if kind == query.ReferenceSaved {
+			ref.Query = saved
+		}
+		return ref, nil
+	}
+}
+
+func countArgument(args []any, value any) int {
+	count := 0
+	for _, arg := range args {
+		if arg == value {
+			count++
+		}
+	}
+	return count
+}
+
+func assertWholeExpressionError(t *testing.T, text string, err error) {
+	t.Helper()
+	var expressionErr *query.ExpressionError
+	require.ErrorAs(t, err, &expressionErr)
+	assert.Equal(t, 0, expressionErr.Offset)
+	assert.Equal(t, len(text), expressionErr.End)
+}

--- a/internal/store/query_preview.go
+++ b/internal/store/query_preview.go
@@ -1,0 +1,40 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/query"
+)
+
+// CompileQuery previews one query against a consistent definition snapshot.
+// It does not execute a search or select a lexical generation. Snapshot
+// execution uses the package compiler with its own transaction-bound resolver.
+func (s *Store) CompileQuery(ctx context.Context, value query.Query) (compiled CompiledQuery, retErr error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return CompiledQuery{}, fmt.Errorf("acquiring query preview connection: %w", err)
+	}
+	active := false
+	defer func() {
+		if active {
+			_, err := conn.ExecContext(context.Background(), "ROLLBACK")
+			retErr = errors.Join(retErr, err)
+		}
+		retErr = errors.Join(retErr, conn.Close())
+	}()
+	if _, err := conn.ExecContext(ctx, "BEGIN DEFERRED"); err != nil {
+		return CompiledQuery{}, fmt.Errorf("starting query preview: %w", err)
+	}
+	active = true
+	compiled, err = compileQuery(ctx, value, queryResolver{q: conn})
+	if err != nil {
+		return CompiledQuery{}, err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return CompiledQuery{}, fmt.Errorf("committing query preview: %w", err)
+	}
+	active = false
+	return compiled, nil
+}

--- a/internal/store/query_resolver.go
+++ b/internal/store/query_resolver.go
@@ -1,0 +1,105 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/docbank/internal/query"
+)
+
+// queryResolver uses the caller's read view. Snapshot execution must pass its
+// own transaction here rather than resolving against a second connection.
+type queryResolver struct{ q rowQuerier }
+
+func (r queryResolver) Resolve(
+	ctx context.Context, kind query.ReferenceKind, value string, byID bool,
+) (query.Reference, error) {
+	if err := ctx.Err(); err != nil {
+		return query.Reference{}, err
+	}
+	if byID {
+		if err := validateUUIDv4(value); err != nil {
+			return query.Reference{}, query.ErrUnknownReference
+		}
+	} else {
+		var err error
+		switch kind {
+		case query.ReferenceTag:
+			value, err = NormalizeTagName(value)
+		case query.ReferenceCollection:
+			value, _, err = normalizeOptionalCollectionLabel(&value)
+		case query.ReferenceSaved:
+			value, err = normalizeLabelName(value, ErrInvalidSavedQuery)
+		default:
+			return query.Reference{}, fmt.Errorf("unsupported reference kind %q", kind)
+		}
+		if err != nil {
+			return query.Reference{}, query.ErrUnknownReference
+		}
+	}
+	var ref query.Reference
+	var err error
+	switch kind {
+	case query.ReferenceTag:
+		selector := "name=?"
+		if byID {
+			selector = "id=?"
+		}
+		ref.Dependency.Kind = kind
+		err = r.q.QueryRowContext(ctx, `SELECT id, revision FROM tags WHERE `+selector, value).
+			Scan(&ref.Dependency.ID, &ref.Dependency.Revision)
+	case query.ReferenceCollection:
+		id := value
+		if !byID {
+			err = r.q.QueryRowContext(ctx, `SELECT ingest_id FROM collection_labels WHERE label=?`, value).Scan(&id)
+		}
+		if err == nil {
+			var label CollectionLabel
+			label, _, err = collectionLabelTx(ctx, r.q, id)
+			ref.Dependency = query.Dependency{Kind: kind, ID: id, Revision: label.Revision}
+		}
+	case query.ReferenceSaved:
+		ref, err = r.saved(ctx, value, byID)
+	default:
+		return query.Reference{}, fmt.Errorf("unsupported reference kind %q", kind)
+	}
+	if errors.Is(err, sql.ErrNoRows) || errors.Is(err, ErrNotFound) {
+		return query.Reference{}, query.ErrUnknownReference
+	}
+	if err != nil {
+		return query.Reference{}, fmt.Errorf("resolving %s reference: %w", kind, err)
+	}
+	return ref, nil
+}
+
+func (r queryResolver) saved(ctx context.Context, value string, byID bool) (query.Reference, error) {
+	selector := "name=?"
+	if byID {
+		selector = "id=?"
+	}
+	record, err := scanSavedQuery(r.q.QueryRowContext(ctx, `
+		SELECT id,name,description,kind,payload,fingerprint,revision,created_at,updated_at
+		FROM saved_queries WHERE `+selector+` AND kind=?`, value, SavedQueryKindQuery))
+	if err != nil {
+		return query.Reference{}, err
+	}
+	canonical, fingerprint, err := canonicalizeSavedQueryPayload(record.Kind, record.Payload)
+	if err != nil {
+		return query.Reference{}, fmt.Errorf("invalid stored query %s: %w", record.ID, err)
+	}
+	if fingerprint != record.Fingerprint {
+		return query.Reference{}, fmt.Errorf("stored query %s fingerprint mismatch", record.ID)
+	}
+	parsed, err := query.Parse(canonical)
+	if err != nil {
+		return query.Reference{}, fmt.Errorf("decoding stored query %s: %w", record.ID, err)
+	}
+	return query.Reference{
+		Dependency: query.Dependency{Kind: query.ReferenceSaved, ID: record.ID, Revision: record.Revision},
+		Query:      &parsed,
+	}, nil
+}
+
+var _ query.Resolver = queryResolver{}

--- a/internal/store/query_resolver_test.go
+++ b/internal/store/query_resolver_test.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/query"
+)
+
+// These tests fail if lookups use display text as identity, discard revisions,
+// bypass collection eligibility, or convert database failures into no matches.
+func TestQueryResolverStableReferences(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	tag, err := s.CreateTag(ctx, "Café review")
+	require.NoError(t, err)
+	run := createCollectionRun(t, s, "synthetic.txt", "a1")
+	label, err := s.SetCollectionLabel(ctx, run.ID(), 1, new("Café documents"))
+	require.NoError(t, err)
+	saved, err := s.CreateSavedQuery(ctx, "Café query", "", SavedQueryKindQuery,
+		[]byte(`{"text":"alpha OR beta","syntax":"advanced","filters":{"size_min":7}}`))
+	require.NoError(t, err)
+	r := queryResolver{q: s.db}
+	for _, test := range []struct {
+		kind     query.ReferenceKind
+		name, id string
+		revision int64
+	}{
+		{query.ReferenceTag, "Cafe\u0301 review", tag.ID, tag.Revision},
+		{query.ReferenceCollection, "Cafe\u0301 documents", run.ID(), label.Revision},
+		{query.ReferenceSaved, "Cafe\u0301 query", saved.ID, saved.Revision},
+	} {
+		byName, err := r.Resolve(ctx, test.kind, test.name, false)
+		require.NoError(t, err)
+		require.Equal(t, query.Dependency{Kind: test.kind, ID: test.id, Revision: test.revision}, byName.Dependency)
+		byID, err := r.Resolve(ctx, test.kind, test.id, true)
+		require.NoError(t, err)
+		require.Equal(t, byName, byID)
+		if test.kind == query.ReferenceSaved {
+			require.NotNil(t, byID.Query)
+			require.Equal(t, "alpha OR beta", byID.Query.Text)
+			require.Equal(t, int64(7), byID.Query.Filters.SizeMin)
+		}
+		_, err = r.Resolve(ctx, test.kind, "missing", false)
+		require.ErrorIs(t, err, query.ErrUnknownReference)
+		_, err = r.Resolve(ctx, test.kind, test.name, true)
+		require.ErrorIs(t, err, query.ErrUnknownReference)
+	}
+}
+
+func TestQueryResolverCollectionEligibilityAndSavedKind(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	r := queryResolver{q: s.db}
+	empty, err := s.BeginIngest(ctx, "cli", "Synthetic empty run")
+	require.NoError(t, err)
+	_, err = r.Resolve(ctx, query.ReferenceCollection, empty.ID(), true)
+	require.ErrorIs(t, err, query.ErrUnknownReference)
+	active := createCollectionRun(t, s, "active.txt", "b2")
+	got, err := r.Resolve(ctx, query.ReferenceCollection, active.ID(), true)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got.Dependency.Revision)
+	highlight, err := s.CreateSavedQuery(ctx, "Literal marks", "", SavedQueryKindHighlightSet, []byte(savedHighlightPayload))
+	require.NoError(t, err)
+	_, err = r.Resolve(ctx, query.ReferenceSaved, highlight.ID, true)
+	require.ErrorIs(t, err, query.ErrUnknownReference)
+}
+
+func TestQueryResolverUsesSuppliedReadSnapshotAndPreservesBackendErrors(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	saved, err := s.CreateSavedQuery(ctx, "Original", "", SavedQueryKindQuery, []byte(`{"text":"alpha"}`))
+	require.NoError(t, err)
+	conn, err := s.db.Conn(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		_ = conn.Close()
+	})
+	// Store mutations default to IMMEDIATE; match the generation reader's
+	// explicit DEFERRED transaction so a writer can advance concurrently.
+	_, err = conn.ExecContext(ctx, "BEGIN DEFERRED")
+	require.NoError(t, err)
+	r := queryResolver{q: conn}
+	first, err := r.Resolve(ctx, query.ReferenceSaved, "Original", false)
+	require.NoError(t, err)
+	_, err = s.UpdateSavedQuery(ctx, saved.ID, saved.Revision, SavedQueryPatch{Name: new("Renamed")})
+	require.NoError(t, err)
+	second, err := r.Resolve(ctx, query.ReferenceSaved, "Original", false)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	_, err = (queryResolver{q: s.db}).Resolve(ctx, query.ReferenceSaved, "Original", false)
+	require.ErrorIs(t, err, query.ErrUnknownReference)
+	_, err = conn.ExecContext(ctx, "ROLLBACK")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	_, err = r.Resolve(ctx, query.ReferenceSaved, saved.ID, true)
+	require.ErrorIs(t, err, sql.ErrConnDone)
+	require.NotErrorIs(t, err, query.ErrUnknownReference)
+}
+
+func TestQueryResolverExpansionFailsClosedAgainstRealStore(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	r := queryResolver{q: s.db}
+	deleted, err := s.CreateSavedQuery(ctx, "deleted", "", SavedQueryKindQuery, []byte(`{"text":"alpha"}`))
+	require.NoError(t, err)
+	_, err = s.DeleteSavedQuery(ctx, deleted.ID, deleted.Revision)
+	require.NoError(t, err)
+	for _, text := range []string{`NOT tag:missing`, `NOT collection:missing`, `saved:deleted`} {
+		input, err := query.Parse([]byte(`{"syntax":"advanced"}`))
+		require.NoError(t, err)
+		input.Text = text
+		_, err = query.ResolveQuery(ctx, input, r)
+		var positioned *query.ExpressionError
+		require.ErrorAs(t, err, &positioned)
+		require.GreaterOrEqual(t, positioned.Offset, 0)
+		require.LessOrEqual(t, positioned.End, len(text))
+	}
+	saved, err := s.CreateSavedQuery(ctx, "Evidence", "", SavedQueryKindQuery,
+		[]byte(`{"syntax":"advanced","text":"alpha OR beta","filters":{"size_min":7}}`))
+	require.NoError(t, err)
+	input, err := query.Parse([]byte(`{"syntax":"advanced","text":"gamma AND saved:Evidence","filters":{"size_max":20}}`))
+	require.NoError(t, err)
+	resolved, err := query.ResolveQuery(ctx, input, r)
+	require.NoError(t, err)
+	require.Equal(t, input, resolved.Query)
+	require.Equal(t, []query.Dependency{{Kind: query.ReferenceSaved, ID: saved.ID, Revision: 1}}, resolved.Dependencies)
+	reference := resolved.Expression.Children[1].Children[0]
+	require.NotNil(t, reference.Saved)
+	require.Equal(t, query.ExpressionOr, reference.Saved.Expression.Syntax.Kind)
+	require.Equal(t, int64(7), reference.Saved.Query.Filters.SizeMin)
+	require.Zero(t, resolved.Query.Filters.SizeMin)
+
+	// Corrupt persisted authority must not be mistaken for an unknown operand.
+	_, err = s.db.ExecContext(ctx, `UPDATE saved_queries SET fingerprint=? WHERE id=?`,
+		"sha256:0000000000000000000000000000000000000000000000000000000000000000", saved.ID)
+	require.NoError(t, err)
+	_, err = query.ResolveQuery(ctx, input, r)
+	require.Error(t, err)
+	var positioned *query.ExpressionError
+	require.NotErrorAs(t, err, &positioned)
+	require.NotErrorIs(t, err, query.ErrUnknownReference)
+}

--- a/internal/store/saved_query.go
+++ b/internal/store/saved_query.go
@@ -340,11 +340,7 @@ func canonicalizeSavedQueryPayload(kind string, payload []byte) ([]byte, string,
 		if err != nil {
 			return nil, "", fmt.Errorf("%w: query payload: %w", ErrInvalidSavedQuery, err)
 		}
-		canonical, err := query.Canonical(value)
-		if err != nil {
-			return nil, "", fmt.Errorf("%w: query payload: %w", ErrInvalidSavedQuery, err)
-		}
-		fingerprint, err := query.Fingerprint(value)
+		canonical, fingerprint, err := query.CanonicalWithFingerprint(value)
 		if err != nil {
 			return nil, "", fmt.Errorf("%w: query payload: %w", ErrInvalidSavedQuery, err)
 		}

--- a/sqlite/driver_contract_test.go
+++ b/sqlite/driver_contract_test.go
@@ -57,6 +57,7 @@ func TestModerncDriverContract(t *testing.T) {
 
 func exerciseDriverContract(t *testing.T, driver docsqlite.Driver) driverObservations {
 	t.Helper()
+	exerciseQueryFunctions(t, driver)
 	var observations driverObservations
 
 	observations.name = driver.Name()

--- a/sqlite/mattn/driver.go
+++ b/sqlite/mattn/driver.go
@@ -15,8 +15,20 @@ import (
 
 	sqlite3 "github.com/mattn/go-sqlite3"
 
+	"go.kenn.io/docbank/internal/query"
 	docsqlite "go.kenn.io/docbank/sqlite"
 )
+
+const driverName = "docbank-sqlite3-query-v1"
+
+func init() {
+	sql.Register(driverName, &sqlite3.SQLiteDriver{ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+		if err := conn.RegisterFunc("docbank_query_media_family_v1", query.ClassifyMedia, true); err != nil {
+			return fmt.Errorf("register query media function: %w", err)
+		}
+		return nil
+	}})
+}
 
 // Driver is Docbank's CGO-backed SQLite implementation.
 type Driver struct{}
@@ -48,7 +60,7 @@ func (Driver) Open(path string, opts docsqlite.OpenOptions) (*sql.DB, error) {
 	if opts.Access != docsqlite.ReadOnlyImmutable {
 		query.Set("_txlock", string(opts.TransactionMode))
 	}
-	return sql.Open("sqlite3", sqliteURI(path, query))
+	return sql.Open(driverName, sqliteURI(path, query))
 }
 
 func sqliteURI(path string, query url.Values) string {

--- a/sqlite/modernc/driver.go
+++ b/sqlite/modernc/driver.go
@@ -3,6 +3,7 @@ package modernc
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"net/url"
@@ -12,8 +13,21 @@ import (
 
 	modernsqlite "modernc.org/sqlite"
 
+	"go.kenn.io/docbank/internal/query"
 	docsqlite "go.kenn.io/docbank/sqlite"
 )
+
+func init() {
+	modernsqlite.MustRegisterDeterministicScalarFunction("docbank_query_media_family_v1", 2,
+		func(_ *modernsqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+			mediaType, mimeOK := args[0].(string)
+			filename, nameOK := args[1].(string)
+			if !mimeOK || !nameOK {
+				return nil, errors.New("media family requires text MIME type and filename")
+			}
+			return query.ClassifyMedia(mediaType, filename), nil
+		})
+}
 
 const (
 	sqliteBusy             = 5

--- a/sqlite/query_functions_test.go
+++ b/sqlite/query_functions_test.go
@@ -1,0 +1,50 @@
+package sqlite_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	docsqlite "go.kenn.io/docbank/sqlite"
+)
+
+// Removing registration on either adapter, or duplicating a less strict MIME
+// classifier in SQL, breaks these consumer-visible query predicate results.
+func exerciseQueryFunctions(t *testing.T, driver docsqlite.Driver) {
+	t.Helper()
+	db, err := driver.Open(filepath.Join(t.TempDir(), "query-functions.db"), docsqlite.OpenOptions{
+		Access: docsqlite.Create, TransactionMode: docsqlite.Deferred,
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	for _, test := range []struct{ mime, name, family string }{
+		{"text/plain; charset=utf-8", "message.eml", "text"},
+		{"message/rfc822", "message.txt", "email"},
+		{"application/octet-stream", "REPORT.PDF", "document"},
+		{"", "archive.zip", "archive"},
+		{"image/synthetic", "opaque.bin", "image"},
+		{"video/synthetic", "opaque.bin", "audio_video"},
+		{"application/synthetic", "report.pdf", "unknown"},
+		{"text/plain; charset=a; charset=b", "report.pdf", "unknown"},
+		{"text/plain; charset=\"unterminated", "report.pdf", "unknown"},
+	} {
+		var family string
+		require.NoError(t, db.QueryRowContext(t.Context(),
+			`SELECT docbank_query_media_family_v1(?, ?)`, test.mime, test.name).Scan(&family))
+		require.Equal(t, test.family, family, "%q / %q", test.mime, test.name)
+	}
+
+	// Force a second physical connection: the predicate must not depend on the
+	// first connection's local registration or pool reuse.
+	first, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, first.Close()) }()
+	second, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, second.Close()) }()
+	var family string
+	require.NoError(t, second.QueryRowContext(t.Context(),
+		`SELECT docbank_query_media_family_v1('application/pdf', 'report.txt')`).Scan(&family))
+	require.Equal(t, "document", family)
+}


### PR DESCRIPTION
## What changed

- Preview field-aware search expressions with phrases, Boolean groups, prefixes, and proximity matching. The response preserves the complete query and separate filters, with the identities and revisions of referenced tags, collections, and saved queries.
- Keep saved-query filters inside their own expression scope. Missing references, cycles, unsupported combinations, and oversized expressions produce explicit errors instead of silently broadening a query.
- Compile parameterized predicates over the existing name and text indexes, preserving current document versions and the selected rendition generation. Both SQLite drivers support the same predicates, including nanosecond time bounds.

## Why

Saved definitions can retain richer query intent than the existing simple-search route can execute. Clients need to validate that intent and explain errors before using it, without losing field constraints or treating a missing excluded tag as a successful query.

## Usage

Send a QueryV1 object to authenticated `POST /api/v1/queries/parse`, for example:

```json
{
  "syntax": "advanced",
  "text": "name:(budget OR forecast) AND NOT extension:tmp",
  "filters": {"size_min": 100}
}
```

The response contains `query`, `query_fingerprint`, and `dependencies`. Expression errors return `422 invalid_query` with a UTF-8 byte span; database failures remain server errors.

This is validation and compilation, not a new search executor: it returns no result rows or SQL, and the CLI and existing `/search` route keep their current behavior. Snapshot execution is separate work. Semantic/hybrid mode, relevance ordering, duplicate constraints, and text-coverage constraints are explicitly unsupported here.

Bare dotfiles such as `.pdf` have no extension in both the extension filter and media-family fallback. A declared MIME type still takes precedence; `.report.pdf` retains its extension.

Built on the saved-definition and collection APIs in #306 and #308. No schema changes or second lexical index.

Existing search interface, captured with the repository's synthetic documentation vault. Query preview is available over HTTP; this change adds no controls to this screen.

![Docbank search results with synthetic documents](https://raw.githubusercontent.com/kenn-io/docbank/c81f46b02623e9415046cd59fb481edda791bf0d/web-search-results.png)
