### PR TITLE
feat(search): discover duplicate current documents

### DIFF
--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -1,7 +1,7 @@
 ---
 title: HTTP API
 description: The agent-first HTTP API — filesystem-shaped endpoints, revision preconditions, and the daemon's error contract.
-last_edited: 2026-09-10
+last_edited: 2026-09-11
 ---
 
 # HTTP API
@@ -43,6 +43,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `POST /nodes/{id}/provenance` | append an immutable origin fact under the node revision | Implemented |
 | `GET /versions/{version_id}` · `GET /versions/{version_id}/content` | inspect or stream one immutable version by stable UUID | Implemented |
 | `GET /content-references?sha256=&limit=&offset=` | find every stable node/version pair retaining a content hash | Implemented |
+| `GET /duplicates?limit=&offset=` | list live current documents sharing content, with exact counts and bounded reference previews | Implemented |
 | `GET\|POST /tags` · `GET /tags/by-name` · `GET\|PATCH\|DELETE /tags/{tag_id}` | list, resolve, create, rename, or delete stable tag definitions | Implemented |
 | `GET /nodes/{id}/tags` · `GET /tags/{tag_id}/nodes` · `PUT\|DELETE /nodes/{id}/tags/{tag_id}` · `PUT\|DELETE /path/tags/{tag_id}` | inspect and change tag assignments | Implemented |
 | `GET\|POST /saved-queries` · `GET\|PATCH\|DELETE /saved-queries/{saved_query_id}` | list, create, inspect, edit, or delete named query and literal highlight definitions | Implemented |
@@ -405,6 +406,27 @@ loose file or pack entry alone. Each item contains the complete immutable
 version, its current node projection, whether that version is the node's
 current head, and a path only while the node is live. Results are bounded and
 deterministic: live current references, live history, then trashed references.
+
+`GET /duplicates` discovers hashes shared by at least two live current file
+nodes. Its `items`, `total`, and `total_references` describe that population;
+historical versions and trash are excluded. `limit` defaults to 50 and accepts
+1–100; `offset` is nonnegative. Groups sort by canonical SHA-256, and counts
+remain exact on an exhausted page. Counts, references, paths, and collection
+labels share one read transaction per request.
+
+Each group contains `sha256`, `size`, `reference_count`,
+`representative_node_id`, `references`, and `references_truncated`. At most
+16 references are displayed in earliest `(modified_at,node_id)` order. Each
+reference wraps the existing content-reference identity in `reference`, plus
+`collections` (up to 16 distinct eligible IDs and optional labels),
+`collection_count`, and `collections_truncated`. Collection identities sort
+by ID; multiple import memberships never multiply document counts. The read
+is available to API-key clients and browser sessions. Browser access permits
+only GET on the exact route, with optional singleton `limit` and `offset`
+parameters. There is no duplicate-deletion operation.
+
+See [duplicate discovery](../usage/searching.md#find-documents-with-identical-content)
+for pagination and historical-lookup guidance.
 
 `POST /nodes/{id}/verify` is the bounded server-side proof. It requires
 `If-Match` from a prior node response, reopens the blob through the same mixed

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-09-10
+last_edited: 2026-09-11
 title: Searching
 description: Ranked, prefix-matching search over document names and verified text content.
 ---
@@ -100,6 +100,32 @@ Search has no continuation cursor. When `truncated` is true, increase the
 limit or narrow the query. Time ranges alone cannot recover every result when
 more than 1,000 nodes share one modification timestamp, such as after a large
 restore.
+
+## Find documents with identical content
+
+Use authenticated `GET /api/v1/duplicates?limit=50&offset=0` to find live
+documents whose current versions share a SHA-256 content identity. A group
+requires at least two documents. Shared bytes do not mean the archive entries
+are interchangeable: each keeps its own node, version, path, and import
+memberships. This read does not delete or merge anything.
+
+The response reports exact group and current-reference totals. Groups sort by
+SHA-256; `limit` accepts 1–100 groups and defaults to 50. Increase `offset` to
+read the next page. Each page reflects one read snapshot, not a frozen result
+set across requests, so concurrent changes can affect later pages.
+
+Each group previews at most 16 references and reports `references_truncated`
+when more exist. References sort by earliest current modification time, then
+node ID; `representative_node_id` identifies the first. This choice does not
+assert which document was originally authored first. Each preview also shows
+up to 16 eligible collection identities and their labels, with an exact
+`collection_count` and `collections_truncated` flag.
+
+Historical versions and trash do not inflate live duplicate groups. To inspect
+all retained references for one hash, use `GET /api/v1/content-references` with
+`sha256`, `limit`, and `offset`. That lookup distinguishes current versions,
+live history, and trash. Duplicate discovery is a separate HTTP read; it does
+not change text-search results or automatically collapse them.
 
 ## Save complete query intent over HTTP
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -74,6 +74,7 @@ var storeErrCodes = []struct {
 	{store.ErrInvalidTag, http.StatusUnprocessableEntity, "invalid_tag"},
 	{store.ErrInvalidSavedQuery, http.StatusUnprocessableEntity, "invalid_saved_query"},
 	{store.ErrInvalidCollectionLabel, http.StatusUnprocessableEntity, "invalid_collection_label"},
+	{store.ErrInvalidDuplicatePage, http.StatusUnprocessableEntity, "invalid_duplicate_page"},
 	{store.ErrInvalidBatchMove, http.StatusUnprocessableEntity, "invalid_batch_move"},
 	{store.ErrNotTrashed, http.StatusUnprocessableEntity, "not_trashed"},
 	{store.ErrIsRoot, http.StatusUnprocessableEntity, "is_root"},

--- a/internal/api/routes_duplicates.go
+++ b/internal/api/routes_duplicates.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/docbank/internal/store"
+)
+
+// DuplicateCollection is a display label, not a replacement for ingest identity.
+type DuplicateCollection struct {
+	ID    string  `json:"id" format:"uuid"`
+	Label *string `json:"label"`
+}
+
+// DuplicateReference describes one current document and its bounded import memberships.
+type DuplicateReference struct {
+	Reference            ContentReference      `json:"reference"`
+	Collections          []DuplicateCollection `json:"collections" maxItems:"16"`
+	CollectionCount      int                   `json:"collection_count" minimum:"0"`
+	CollectionsTruncated bool                  `json:"collections_truncated"`
+}
+
+// DuplicateGroup groups live current document identities without deleting any of them.
+type DuplicateGroup struct {
+	SHA256               string               `json:"sha256" pattern:"^[0-9a-f]{64}$"`
+	Size                 int64                `json:"size" minimum:"0"`
+	ReferenceCount       int                  `json:"reference_count" minimum:"2"`
+	RepresentativeNodeID int64                `json:"representative_node_id" minimum:"1"`
+	References           []DuplicateReference `json:"references" maxItems:"16"`
+	ReferencesTruncated  bool                 `json:"references_truncated"`
+}
+
+// DuplicatePage keeps exact population totals separate from bounded display previews.
+type DuplicatePage struct {
+	Items           []DuplicateGroup `json:"items" maxItems:"100"`
+	Total           int              `json:"total" minimum:"0"`
+	TotalReferences int              `json:"total_references" minimum:"0"`
+	Limit           int              `json:"limit" minimum:"1" maximum:"100"`
+	Offset          int              `json:"offset" minimum:"0"`
+}
+
+func registerDuplicateRoutes(api huma.API, d Deps) {
+	huma.Register(api, huma.Operation{
+		OperationID: "listDuplicateContent", Method: http.MethodGet, Path: "/api/v1/duplicates",
+		Summary:     "Find live documents that share current content",
+		Description: "Groups are ordered by SHA-256. Counts exclude historical versions and trash; each group displays at most 16 current references. No content is deleted or merged.",
+	}, func(ctx context.Context, in *struct {
+		Limit  int `query:"limit" default:"50" minimum:"1" maximum:"100"`
+		Offset int `query:"offset" default:"0" minimum:"0"`
+	}) (*struct{ Body DuplicatePage }, error) {
+		page, err := d.Store.Duplicates(ctx, in.Limit, in.Offset)
+		if err != nil {
+			return nil, FromStoreError(err)
+		}
+		return &struct{ Body DuplicatePage }{Body: fromStoreDuplicatePage(page)}, nil
+	})
+}
+
+func fromStoreDuplicatePage(page store.DuplicatePage) DuplicatePage {
+	out := DuplicatePage{Items: []DuplicateGroup{}, Total: page.Total,
+		TotalReferences: page.TotalReferences, Limit: page.Limit, Offset: page.Offset}
+	for _, group := range page.Items {
+		item := DuplicateGroup{SHA256: group.Hash, Size: group.Size,
+			ReferenceCount: group.ReferenceCount, RepresentativeNodeID: group.RepresentativeNodeID,
+			References: []DuplicateReference{}, ReferencesTruncated: group.ReferencesTruncated}
+		for _, ref := range group.References {
+			member := DuplicateReference{Reference: fromStoreContentReference(ref.Reference),
+				Collections: []DuplicateCollection{}, CollectionCount: ref.CollectionCount,
+				CollectionsTruncated: ref.CollectionsTruncated}
+			for _, collection := range ref.Collections {
+				member.Collections = append(member.Collections, DuplicateCollection{ID: collection.ID, Label: collection.Label})
+			}
+			item.References = append(item.References, member)
+		}
+		out.Items = append(out.Items, item)
+	}
+	return out
+}

--- a/internal/api/routes_duplicates_test.go
+++ b/internal/api/routes_duplicates_test.go
@@ -1,0 +1,174 @@
+package api_test
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestDuplicatesHTTPCurrentIdentityAndHistoricalBoundary(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	first := createFileWithContent(t, ts, s, "/first.txt", "same synthetic content")
+	second := createFileWithContent(t, ts, s, "/second.txt", "same synthetic content")
+	history := createFileWithContent(t, ts, s, "/history.txt", "same synthetic content")
+	replacement := createFileWithContent(t, ts, s, "/replacement.txt", "different")
+	_, _, err := s.ReplaceContent(t.Context(), history.ID, history.Revision,
+		replacement.BlobHash, replacement.Size, replacement.MimeType)
+	require.NoError(t, err)
+	trash := createFileWithContent(t, ts, s, "/trash.txt", "same synthetic content")
+	_, _, err = s.Trash(t.Context(), trash.ID, trash.Revision)
+	require.NoError(t, err)
+
+	resp, body := get(t, ts, "/api/v1/duplicates?limit=1&offset=0", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var page struct {
+		Items []struct {
+			SHA256               string `json:"sha256"`
+			ReferenceCount       int    `json:"reference_count"`
+			RepresentativeNodeID int64  `json:"representative_node_id"`
+			References           []struct {
+				Reference api.ContentReference `json:"reference"`
+			} `json:"references"`
+			ReferencesTruncated bool `json:"references_truncated"`
+		} `json:"items"`
+		Total           int `json:"total"`
+		TotalReferences int `json:"total_references"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+	require.Equal(t, 2, page.Total)
+	require.Equal(t, 4, page.TotalReferences)
+	require.Len(t, page.Items, 1)
+	// Stable hash ordering, not creation time, determines the selected group.
+	if page.Items[0].SHA256 != first.BlobHash {
+		resp, body = get(t, ts, "/api/v1/duplicates?limit=1&offset=1", nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode, body)
+		require.NoError(t, json.Unmarshal([]byte(body), &page))
+	}
+	require.Len(t, page.Items, 1)
+	group := page.Items[0]
+	require.Equal(t, first.BlobHash, group.SHA256)
+	require.Equal(t, 2, group.ReferenceCount)
+	require.Equal(t, first.ID, group.RepresentativeNodeID)
+	require.False(t, group.ReferencesTruncated)
+	require.Len(t, group.References, 2)
+	for i, node := range []struct {
+		id            int64
+		version, path string
+	}{
+		{first.ID, first.CurrentVersionID, "/first.txt"}, {second.ID, second.CurrentVersionID, "/second.txt"},
+	} {
+		ref := group.References[i].Reference
+		require.Equal(t, node.id, ref.Node.ID)
+		require.Equal(t, node.version, ref.Version.ID)
+		require.Equal(t, first.BlobHash, ref.Version.BlobHash)
+		require.Equal(t, node.path, ref.Path)
+		require.True(t, ref.IsCurrent)
+	}
+	resp, body = get(t, ts, "/api/v1/content-references?sha256="+first.BlobHash, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var retained api.ContentReferencePage
+	require.NoError(t, json.Unmarshal([]byte(body), &retained))
+	require.Equal(t, 4, retained.Total, "historical and trash lookup remains separate and complete")
+}
+
+func TestDuplicatesHTTPPreviewBoundsAndExhaustion(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	for i := range 17 {
+		createFileWithContent(t, ts, s, fmt.Sprintf("/copy-%02d.txt", i), "shared bytes")
+	}
+	resp, body := get(t, ts, "/api/v1/duplicates", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var page struct {
+		Items []struct {
+			ReferenceCount      int                    `json:"reference_count"`
+			References          []api.ContentReference `json:"references"`
+			ReferencesTruncated bool                   `json:"references_truncated"`
+		} `json:"items"`
+		Total           int `json:"total"`
+		TotalReferences int `json:"total_references"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+	require.Equal(t, 1, page.Total)
+	require.Equal(t, 17, page.TotalReferences)
+	require.Len(t, page.Items, 1)
+	require.Equal(t, 17, page.Items[0].ReferenceCount)
+	require.Len(t, page.Items[0].References, 16)
+	require.True(t, page.Items[0].ReferencesTruncated)
+	resp, body = get(t, ts, "/api/v1/duplicates?offset=10", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+	require.NotNil(t, page.Items)
+	require.Empty(t, page.Items)
+	require.Equal(t, 1, page.Total)
+	require.Equal(t, 17, page.TotalReferences)
+}
+
+func TestDuplicatesHTTPAuthenticationAndBounds(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := get(t, ts, "/api/v1/duplicates", map[string]string{"X-Api-Key": ""})
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, body)
+	for _, query := range []string{"limit=0", "limit=101", "offset=-1", "limit=invalid"} {
+		resp, body = get(t, ts, "/api/v1/duplicates?"+query, nil)
+		require.GreaterOrEqual(t, resp.StatusCode, 400, body)
+		require.Less(t, resp.StatusCode, 500, body)
+	}
+	resp, body = do(t, ts, http.MethodPost, "/api/daemon/web-session", nil, nil)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	var issued struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &issued))
+	headers := map[string]string{"X-Api-Key": "", api.WebSessionHeader: issued.Token}
+	resp, body = get(t, ts, "/api/v1/duplicates?limit=1&offset=0", headers)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	for _, path := range []string{"/api/v1/duplicates/extra", "/api/v1/duplicates?include_trash=true", "/api/v1/duplicates?limit=1&limit=2", "/api/v1/duplicates?limit=%ZZ"} {
+		resp, body = get(t, ts, path, headers)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, body)
+	}
+	resp, body = do(t, ts, http.MethodDelete, "/api/v1/duplicates", headers, nil)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, body)
+}
+
+func TestDuplicatesHTTPCollectionLabelsKeepImportIdentity(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	label := "Synthetic review"
+	first := importCollection(t, ts.URL, ts.Client(), "alpha.txt", "shared import content", &label)
+	second := importCollection(t, ts.URL, ts.Client(), "beta.txt", "shared import content", nil)
+	resp, body := get(t, ts, "/api/v1/duplicates", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var page api.DuplicatePage
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+	require.Equal(t, 1, page.Total)
+	require.Len(t, page.Items, 1)
+	require.Len(t, page.Items[0].References, 2)
+	for i, id := range []string{first.IngestID, second.IngestID} {
+		ref := page.Items[0].References[i]
+		require.Equal(t, 1, ref.CollectionCount)
+		require.False(t, ref.CollectionsTruncated)
+		require.Len(t, ref.Collections, 1)
+		require.Equal(t, id, ref.Collections[0].ID)
+	}
+	require.NotNil(t, page.Items[0].References[0].Collections[0].Label)
+	require.Equal(t, label, *page.Items[0].References[0].Collections[0].Label)
+	require.Nil(t, page.Items[0].References[1].Collections[0].Label)
+}
+
+func TestDuplicatesHTTPEmptyPopulationAndBackendFailure(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	resp, body := get(t, ts, "/api/v1/duplicates", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var page api.DuplicatePage
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+	require.NotNil(t, page.Items)
+	require.Empty(t, page.Items)
+	require.Zero(t, page.Total)
+	require.Zero(t, page.TotalReferences)
+	require.Equal(t, 50, page.Limit)
+	require.NoError(t, s.Close())
+	resp, body = get(t, ts, "/api/v1/duplicates", nil)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode, body)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -127,6 +127,7 @@ func NewServer(d Deps) *Server {
 
 	registerReadRoutes(humaAPI, d) // Task 5 (stat-by-id lands in this task)
 	registerCollectionRoutes(humaAPI, d, g)
+	registerDuplicateRoutes(humaAPI, d)
 	registerInfoRoute(humaAPI, d)
 	registerMutateRoutes(humaAPI, d, g) // Task 6
 	registerOpsRoutes(humaAPI, d, g)    // Task 7

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -234,6 +235,18 @@ func webSessionRequestAllowed(r *http.Request) bool {
 	}
 	if method != http.MethodGet {
 		return false
+	}
+	if path == "/api/v1/duplicates" {
+		values, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			return false
+		}
+		for key, entries := range values {
+			if (key != "limit" && key != "offset") || len(entries) != 1 {
+				return false
+			}
+		}
+		return true
 	}
 	if path == "/api/v1/collections" {
 		return true

--- a/internal/store/duplicate.go
+++ b/internal/store/duplicate.go
@@ -1,0 +1,258 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+const (
+	maxDuplicatePageReferences = 16
+	maxDuplicateCollections    = 16
+)
+
+// CurrentContentMembershipCTE is the shared live-current content relation for
+// duplicate discovery and later matched-content features. It intentionally
+// omits WITH so callers can compose it with other CTEs.
+const CurrentContentMembershipCTE = `current_content_members AS (
+    SELECT n.id AS node_id, v.version_id, v.blob_hash, b.size, n.modified_at
+    FROM nodes n
+    JOIN content_versions v
+      ON v.node_id = n.id AND v.version_id = n.current_version_id
+    JOIN blobs b ON b.hash = v.blob_hash AND b.size = v.size
+    WHERE n.kind = 'file' AND n.trashed_at IS NULL
+)`
+
+// DuplicateRepresentativeOrder is the exact stable order for choosing a
+// representative from a matched population. Future matched-content callers
+// must apply it after establishing their population, not to a global
+// prefiltered winner.
+const DuplicateRepresentativeOrder = `modified_at ASC, node_id ASC`
+
+// ErrInvalidDuplicatePage reports a duplicate page outside its bounded range.
+var ErrInvalidDuplicatePage = errors.New("invalid duplicate page")
+
+// DuplicateCollection is one current operational collection containing a
+// duplicate reference.
+type DuplicateCollection struct {
+	ID    string
+	Label *string
+}
+
+// DuplicateReference binds one live current content reference to its current
+// operational collection memberships.
+type DuplicateReference struct {
+	Reference            ContentReference
+	Collections          []DuplicateCollection
+	CollectionCount      int
+	CollectionsTruncated bool
+}
+
+// DuplicateGroup describes all live current file nodes sharing one canonical
+// blob hash.
+type DuplicateGroup struct {
+	Hash                 string
+	Size                 int64
+	ReferenceCount       int
+	RepresentativeNodeID int64
+	References           []DuplicateReference
+	ReferencesTruncated  bool
+}
+
+// DuplicatePage is one hash-ordered page of duplicate groups. Totals describe
+// all matching groups and references independently of the selected page.
+type DuplicatePage struct {
+	Items           []DuplicateGroup
+	Total           int
+	TotalReferences int
+	Limit           int
+	Offset          int
+}
+
+// Duplicates lists groups of at least two distinct live files whose exact
+// current versions share canonical blob content.
+func (s *Store) Duplicates(
+	ctx context.Context, limit, offset int,
+) (DuplicatePage, error) {
+	if limit < 1 || limit > 100 {
+		return DuplicatePage{}, fmt.Errorf(
+			"%w: limit must be between 1 and 100", ErrInvalidDuplicatePage,
+		)
+	}
+	if offset < 0 {
+		return DuplicatePage{}, fmt.Errorf(
+			"%w: offset must not be negative", ErrInvalidDuplicatePage,
+		)
+	}
+
+	page := DuplicatePage{
+		Items: make([]DuplicateGroup, 0), Limit: limit, Offset: offset,
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return DuplicatePage{}, fmt.Errorf("starting duplicate snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	groupsSQL := `WITH ` + CurrentContentMembershipCTE + `,
+		duplicate_groups AS (
+			SELECT blob_hash, size, COUNT(DISTINCT node_id) AS reference_count
+			FROM current_content_members
+			GROUP BY blob_hash, size
+			HAVING COUNT(DISTINCT node_id) >= 2
+		)`
+	if err := tx.QueryRowContext(ctx, groupsSQL+`
+		SELECT COUNT(*), COALESCE(SUM(reference_count), 0)
+		FROM duplicate_groups`).Scan(&page.Total, &page.TotalReferences); err != nil {
+		return DuplicatePage{}, fmt.Errorf("counting duplicate content: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, groupsSQL+`
+		SELECT g.blob_hash, g.size, g.reference_count,
+		       (SELECT node_id FROM current_content_members
+		        WHERE blob_hash = g.blob_hash AND size = g.size
+		        ORDER BY `+DuplicateRepresentativeOrder+` LIMIT 1)
+		FROM duplicate_groups g
+		ORDER BY g.blob_hash ASC
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return DuplicatePage{}, fmt.Errorf("listing duplicate content: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var group DuplicateGroup
+		group.References = make([]DuplicateReference, 0)
+		if err := rows.Scan(
+			&group.Hash, &group.Size, &group.ReferenceCount, &group.RepresentativeNodeID,
+		); err != nil {
+			return DuplicatePage{}, fmt.Errorf("scanning duplicate group: %w", err)
+		}
+		page.Items = append(page.Items, group)
+	}
+	if err := rows.Err(); err != nil {
+		return DuplicatePage{}, fmt.Errorf("listing duplicate content: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return DuplicatePage{}, fmt.Errorf("closing duplicate groups: %w", err)
+	}
+
+	for index := range page.Items {
+		references, err := duplicateReferences(ctx, tx, page.Items[index])
+		if err != nil {
+			return DuplicatePage{}, err
+		}
+		page.Items[index].References = references
+		page.Items[index].ReferencesTruncated =
+			page.Items[index].ReferenceCount > len(references)
+	}
+	if err := tx.Commit(); err != nil {
+		return DuplicatePage{}, fmt.Errorf("closing duplicate snapshot: %w", err)
+	}
+	return page, nil
+}
+
+type duplicateReferenceIdentity struct {
+	nodeID    int64
+	versionID string
+}
+
+func duplicateReferences(
+	ctx context.Context, tx *sql.Tx, group DuplicateGroup,
+) ([]DuplicateReference, error) {
+	rows, err := tx.QueryContext(ctx, `WITH `+CurrentContentMembershipCTE+`
+		SELECT node_id, version_id
+		FROM current_content_members
+		WHERE blob_hash = ? AND size = ?
+		ORDER BY `+DuplicateRepresentativeOrder+`
+		LIMIT ?`, group.Hash, group.Size, maxDuplicatePageReferences)
+	if err != nil {
+		return nil, fmt.Errorf("listing references for duplicate %s: %w", group.Hash, err)
+	}
+	defer func() { _ = rows.Close() }()
+	identities := make([]duplicateReferenceIdentity, 0, maxDuplicatePageReferences)
+	for rows.Next() {
+		var identity duplicateReferenceIdentity
+		if err := rows.Scan(&identity.nodeID, &identity.versionID); err != nil {
+			return nil, fmt.Errorf("scanning references for duplicate %s: %w", group.Hash, err)
+		}
+		identities = append(identities, identity)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing references for duplicate %s: %w", group.Hash, err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("closing references for duplicate %s: %w", group.Hash, err)
+	}
+
+	references := make([]DuplicateReference, 0, len(identities))
+	for _, identity := range identities {
+		node, err := nodeByIDTx(tx, identity.nodeID)
+		if err != nil {
+			return nil, fmt.Errorf("reading duplicate node %d: %w", identity.nodeID, err)
+		}
+		version, err := scanContentVersion(tx.QueryRowContext(ctx,
+			`SELECT `+contentVersionCols+`
+			 FROM content_versions WHERE node_id=? AND version_id=?`,
+			identity.nodeID, identity.versionID))
+		if err != nil {
+			return nil, fmt.Errorf("reading duplicate node %d version: %w", identity.nodeID, err)
+		}
+		path, err := pathOf(ctx, tx, identity.nodeID)
+		if err != nil {
+			return nil, err
+		}
+		collections, collectionCount, err := duplicateCollections(ctx, tx, identity.nodeID)
+		if err != nil {
+			return nil, err
+		}
+		references = append(references, DuplicateReference{
+			Reference: ContentReference{
+				Version: version, Node: node, Path: path, IsCurrent: true,
+			},
+			Collections: collections, CollectionCount: collectionCount,
+			CollectionsTruncated: collectionCount > len(collections),
+		})
+	}
+	return references, nil
+}
+
+func duplicateCollections(
+	ctx context.Context, tx *sql.Tx, nodeID int64,
+) ([]DuplicateCollection, int, error) {
+	var total int
+	if err := tx.QueryRowContext(ctx, `WITH `+CollectionMembershipCTE+`
+		SELECT COUNT(*) FROM collection_members WHERE node_id=?`, nodeID).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("counting collections for duplicate node %d: %w", nodeID, err)
+	}
+	rows, err := tx.QueryContext(ctx, `WITH `+CollectionMembershipCTE+`
+		SELECT cm.ingest_id, l.label
+		FROM collection_members cm
+		LEFT JOIN collection_labels l ON l.ingest_id=cm.ingest_id
+		WHERE cm.node_id=?
+		ORDER BY cm.ingest_id ASC
+		LIMIT ?`, nodeID, maxDuplicateCollections)
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing collections for duplicate node %d: %w", nodeID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	collections := make([]DuplicateCollection, 0, min(total, maxDuplicateCollections))
+	for rows.Next() {
+		var collection DuplicateCollection
+		var label sql.NullString
+		if err := rows.Scan(&collection.ID, &label); err != nil {
+			return nil, 0, fmt.Errorf(
+				"scanning collections for duplicate node %d: %w", nodeID, err,
+			)
+		}
+		collection.Label = stringPtr(label)
+		collections = append(collections, collection)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("listing collections for duplicate node %d: %w", nodeID, err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, fmt.Errorf("closing collections for duplicate node %d: %w", nodeID, err)
+	}
+	return collections, total, nil
+}

--- a/internal/store/duplicate_test.go
+++ b/internal/store/duplicate_test.go
@@ -1,0 +1,281 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuplicatesFindsOnlyLiveCurrentContent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	duplicateHash := fakeHash("11")
+	replacementHash := fakeHash("22")
+	singleHash := fakeHash("23")
+
+	firstRun, err := s.BeginIngest(ctx, "cli", "First synthetic import")
+	require.NoError(t, err)
+	first, err := s.IngestFileExact(ctx, firstRun, s.RootID(), "first.txt",
+		duplicateHash, 12, "text/plain", "/synthetic/first.txt", "")
+	require.NoError(t, err)
+	secondRun, err := s.BeginIngest(ctx, "cli", "Second synthetic import")
+	require.NoError(t, err)
+	second, err := s.IngestFileExact(ctx, secondRun, s.RootID(), "second.txt",
+		duplicateHash, 12, "text/plain", "/synthetic/second.txt", "")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, s.RootID(), "single.txt", singleHash, 7, "text/plain")
+	require.NoError(t, err)
+
+	page, err := s.Duplicates(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, duplicateHash, page.Items[0].Hash)
+	assert.Equal(t, int64(12), page.Items[0].Size)
+	assert.Equal(t, 2, page.Items[0].ReferenceCount)
+	assert.Equal(t, 1, page.Total)
+	assert.Equal(t, 2, page.TotalReferences)
+	for _, ref := range page.Items[0].References {
+		assert.True(t, ref.Reference.IsCurrent)
+		assert.Equal(t, ref.Reference.Node.CurrentVersionID, ref.Reference.Version.ID)
+		assert.NotEmpty(t, ref.Reference.Path)
+		assert.NotNil(t, ref.Collections)
+	}
+
+	historicalVersion := second.CurrentVersionID
+	second, _, err = s.ReplaceContent(ctx, second.ID, second.Revision,
+		replacementHash, 7, "text/plain")
+	require.NoError(t, err)
+	page, err = s.Duplicates(ctx, 10, 0)
+	require.NoError(t, err)
+	assert.Empty(t, page.Items)
+	assert.Zero(t, page.Total)
+	assert.Zero(t, page.TotalReferences)
+
+	refs, total, err := s.ContentReferencesByHash(ctx, duplicateHash, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "the historical content lookup remains unchanged")
+	assert.Contains(t, duplicateReferenceVersionIDs(refs), historicalVersion)
+
+	_, _, err = s.ReplaceContent(ctx, second.ID, second.Revision,
+		duplicateHash, 12, "text/plain")
+	require.NoError(t, err)
+	page, err = s.Duplicates(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+
+	_, _, err = s.Trash(ctx, first.ID, first.Revision)
+	require.NoError(t, err)
+	page, err = s.Duplicates(ctx, 10, 0)
+	require.NoError(t, err)
+	assert.Empty(t, page.Items)
+	assert.Zero(t, page.TotalReferences)
+	refs, total, err = s.ContentReferencesByHash(ctx, duplicateHash, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Contains(t, duplicateReferenceNodeIDs(refs), first.ID)
+}
+
+func TestDuplicateReferencesExposeActiveOperationalCollections(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	hash := fakeHash("33")
+
+	primary, err := s.BeginIngestWithLabel(ctx, "cli", "Primary import", new("Primary"))
+	require.NoError(t, err)
+	first, err := s.IngestFileExact(ctx, primary, s.RootID(), "first.txt",
+		hash, 8, "text/plain", "/synthetic/first.txt", "")
+	require.NoError(t, err)
+	_, err = s.CreateFile(ctx, s.RootID(), "second.txt", hash, 8, "text/plain")
+	require.NoError(t, err)
+
+	// Repeated facts in one run and membership in another run each remain one
+	// displayed collection.
+	addCollectionMembership(t, s, primary, first.ID, "/synthetic/repeated.txt", nil)
+	secondary, err := s.BeginIngestWithLabel(ctx, "cli", "Secondary import", new("Secondary"))
+	require.NoError(t, err)
+	addCollectionMembership(t, s, secondary, first.ID, "/synthetic/secondary.txt", nil)
+
+	// A superseded operational membership disappears and its active correction
+	// replaces it. Caller-supplied embedded provenance never becomes a collection.
+	superseded, err := s.BeginIngest(ctx, "cli", "Superseded import")
+	require.NoError(t, err)
+	addCollectionMembership(t, s, superseded, first.ID, "/synthetic/old.txt", nil)
+	var prior string
+	require.NoError(t, s.db.QueryRow(`SELECT identity FROM provenance
+		WHERE ingest_id=? AND node_id=?`, superseded.ID(), first.ID).Scan(&prior))
+	correction, err := s.BeginIngestWithLabel(ctx, "cli", "Corrected import", new("Corrected"))
+	require.NoError(t, err)
+	addCollectionMembership(t, s, correction, first.ID, "/synthetic/new.txt", &prior)
+	embedded, err := s.BeginCallerSuppliedIngest(ctx, "application", "Embedded assertion")
+	require.NoError(t, err)
+	addCollectionMembership(t, s, embedded, first.ID, "opaque/item", nil)
+
+	page, err := s.Duplicates(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	var got DuplicateReference
+	for _, ref := range page.Items[0].References {
+		if ref.Reference.Node.ID == first.ID {
+			got = ref
+		}
+	}
+	require.Equal(t, first.ID, got.Reference.Node.ID)
+	assert.Equal(t, 3, got.CollectionCount)
+	assert.False(t, got.CollectionsTruncated)
+	wantIDs := []string{primary.ID(), secondary.ID(), correction.ID()}
+	sort.Strings(wantIDs)
+	assert.Equal(t, wantIDs, duplicateCollectionIDs(got.Collections))
+	wantLabels := map[string]string{
+		primary.ID(): "Primary", secondary.ID(): "Secondary", correction.ID(): "Corrected",
+	}
+	for _, collection := range got.Collections {
+		require.NotNil(t, collection.Label)
+		assert.Equal(t, wantLabels[collection.ID], *collection.Label)
+	}
+}
+
+func TestDuplicateReferencesAndCollectionsAreBounded(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	hash := fakeHash("44")
+	nodes := make([]Node, 17)
+	for index := range nodes {
+		var err error
+		nodes[index], err = s.CreateFile(ctx, s.RootID(), fmt.Sprintf("copy-%02d.txt", index),
+			hash, 5, "text/plain")
+		require.NoError(t, err)
+	}
+
+	base := time.Date(2026, time.September, 11, 12, 0, 0, 0, time.UTC)
+	early := base.Add(time.Nanosecond).Format(timestampLayout)
+	tied := base.Add(2 * time.Nanosecond).Format(timestampLayout)
+	later := base.Add(3 * time.Nanosecond).Format(timestampLayout)
+	for _, node := range nodes {
+		_, err := s.db.Exec(`UPDATE nodes SET modified_at=? WHERE id=?`, later, node.ID)
+		require.NoError(t, err)
+	}
+	_, err := s.db.Exec(`UPDATE nodes SET modified_at=? WHERE id=?`, early, nodes[2].ID)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`UPDATE nodes SET modified_at=? WHERE id IN (?,?)`,
+		tied, nodes[1].ID, nodes[3].ID)
+	require.NoError(t, err)
+
+	collectionIDs := make([]string, 17)
+	for index := range collectionIDs {
+		run, err := s.BeginIngest(ctx, "cli", fmt.Sprintf("Synthetic collection %02d", index))
+		require.NoError(t, err)
+		addCollectionMembership(t, s, run, nodes[2].ID,
+			fmt.Sprintf("/synthetic/source-%02d.txt", index), nil)
+		collectionIDs[index] = run.ID()
+	}
+	sort.Strings(collectionIDs)
+
+	page, err := s.Duplicates(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	group := page.Items[0]
+	assert.Equal(t, 17, group.ReferenceCount)
+	assert.Len(t, group.References, 16)
+	assert.True(t, group.ReferencesTruncated)
+	assert.Equal(t, nodes[2].ID, group.RepresentativeNodeID)
+	assert.Equal(t, nodes[2].ID, group.References[0].Reference.Node.ID)
+	assert.Equal(t, nodes[1].ID, group.References[1].Reference.Node.ID)
+	assert.Equal(t, nodes[3].ID, group.References[2].Reference.Node.ID,
+		"equal timestamps use node ID as the deterministic tie break")
+
+	representative := group.References[0]
+	assert.Equal(t, 17, representative.CollectionCount)
+	assert.Len(t, representative.Collections, 16)
+	assert.True(t, representative.CollectionsTruncated)
+	assert.Equal(t, collectionIDs[:16], duplicateCollectionIDs(representative.Collections))
+}
+
+func TestDuplicatesPagesGroupsByHashWithExactTotals(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	hashes := []string{fakeHash("c3"), fakeHash("a1"), fakeHash("b2")}
+	for index, hash := range hashes {
+		for copy := range 2 {
+			_, err := s.CreateFile(ctx, s.RootID(),
+				fmt.Sprintf("group-%d-copy-%d.txt", index, copy), hash, int64(index+1), "text/plain")
+			require.NoError(t, err)
+		}
+	}
+	sort.Strings(hashes)
+
+	for offset, wantHash := range hashes {
+		page, err := s.Duplicates(ctx, 1, offset)
+		require.NoError(t, err)
+		assert.Equal(t, 3, page.Total)
+		assert.Equal(t, 6, page.TotalReferences)
+		assert.Equal(t, 1, page.Limit)
+		assert.Equal(t, offset, page.Offset)
+		require.Len(t, page.Items, 1)
+		assert.Equal(t, wantHash, page.Items[0].Hash)
+	}
+	exhausted, err := s.Duplicates(ctx, 1, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 3, exhausted.Total)
+	assert.Equal(t, 6, exhausted.TotalReferences)
+	assert.Equal(t, 1, exhausted.Limit)
+	assert.Equal(t, 3, exhausted.Offset)
+	assert.NotNil(t, exhausted.Items)
+	assert.Empty(t, exhausted.Items)
+}
+
+func TestDuplicatesRejectsMalformedBounds(t *testing.T) {
+	s := newTestStore(t)
+	for _, test := range []struct {
+		limit, offset int
+	}{{0, 0}, {101, 0}, {1, -1}} {
+		page, err := s.Duplicates(t.Context(), test.limit, test.offset)
+		require.ErrorIs(t, err, ErrInvalidDuplicatePage)
+		assert.Empty(t, page)
+	}
+}
+
+func TestDuplicatesPropagatesCancellationAndBackendErrors(t *testing.T) {
+	t.Run("canceled context", func(t *testing.T) {
+		s := newTestStore(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := s.Duplicates(ctx, 10, 0)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+	t.Run("closed backend", func(t *testing.T) {
+		s := newTestStore(t)
+		require.NoError(t, s.Close())
+		_, err := s.Duplicates(t.Context(), 10, 0)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrInvalidDuplicatePage)
+	})
+}
+
+func duplicateReferenceVersionIDs(refs []ContentReference) []string {
+	ids := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		ids = append(ids, ref.Version.ID)
+	}
+	return ids
+}
+
+func duplicateReferenceNodeIDs(refs []ContentReference) []int64 {
+	ids := make([]int64, 0, len(refs))
+	for _, ref := range refs {
+		ids = append(ids, ref.Node.ID)
+	}
+	return ids
+}
+
+func duplicateCollectionIDs(collections []DuplicateCollection) []string {
+	ids := make([]string, 0, len(collections))
+	for _, collection := range collections {
+		ids = append(ids, collection.ID)
+	}
+	return ids
+}


### PR DESCRIPTION
## What changed

- Find live documents that share the same current content through `GET /api/v1/duplicates`. Each group keeps its distinct document identities and reports an exact reference count.
- Preview up to 16 references per group, including their paths, versions, and eligible import collections. Counts remain exact when the displayed lists are truncated.
- Choose a deterministic representative by earliest current modification time, then node ID. Nothing is deleted, merged, or automatically removed from search results.

## Why

Shared storage does not mean duplicate archive entries should disappear. Users need to see which current documents contain the same bytes, while keeping replaced versions and trash separate from live duplicate counts.

## Usage

Request authenticated `GET /api/v1/duplicates?limit=50&offset=0`. The limit accepts 1–100 groups; groups sort by SHA-256. The response includes `items`, `total`, and `total_references`. Advance `offset` for more groups.

Each group reports `references_truncated` when its preview stops at 16 documents. Each reference also reports the exact collection count and whether its 16-collection preview is truncated. Pages reflect individual read snapshots; concurrent edits can change subsequent pages.

Use the existing `GET /api/v1/content-references?sha256=...` lookup to inspect all retained references for a hash, including live history and trash. That lookup is unchanged. No schema changes or content deletion.
